### PR TITLE
CTPPS: Improved Diamond data formats

### DIFF
--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
@@ -27,14 +27,14 @@ class CTPPSDiamondLocalTrack
       t_( t ), t_sigma_( t_sigma ), ts_index_( oot_idx ), mh_( mult_hits ) {}
     virtual ~CTPPSDiamondLocalTrack() {}
 
-    inline static bool containsHit( const CTPPSDiamondLocalTrack& localTrack, const CTPPSDiamondRecHit& recHit, float tolerance = 0.1 ) {
-      return ( recHit.getOOTIndex() == localTrack.getOOTIndex()
-        && ( ( recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
-            && recHit.getX() + 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
-          || ( recHit.getX() - 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
-            && recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
-          || ( recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() - localTrack.getX0Sigma() - tolerance
-            && recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() + localTrack.getX0Sigma() + tolerance ) ) );
+    inline bool containsHit( const CTPPSDiamondRecHit& recHit, float tolerance = 0.1 ) const {
+      const float x_low  = pos0_.x() - pos0_sigma_.x() - tolerance;
+      const float x_high = pos0_.x() + pos0_sigma_.x() + tolerance;
+      return ( recHit.getOOTIndex() == ts_index_
+        && ( recHit.getZ() * pos0_.z() > 0. )
+        && ( ( recHit.getX() + 0.5 * recHit.getXWidth() > x_low && recHit.getX() + 0.5 * recHit.getXWidth() < x_high )
+          || ( recHit.getX() - 0.5 * recHit.getXWidth() > x_low && recHit.getX() - 0.5 * recHit.getXWidth() < x_high )
+          || ( recHit.getX() - 0.5 * recHit.getXWidth() < x_low && recHit.getX() + 0.5 * recHit.getXWidth() > x_high ) ) );
     }
 
     //--- spatial get'ters

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
@@ -21,7 +21,7 @@ class CTPPSDiamondLocalTrack
     CTPPSDiamondLocalTrack() :
       num_hits_( 0 ), num_planes_( 0 ), valid_( true ),
       t_( 0. ), t_sigma_( 0. ), ts_index_( 0 ), mh_( 0 ) {}
-    CTPPSDiamondLocalTrack( const math::XYZPoint& pos0, const math::XYZPoint& pos0_sigma, float chisq, float t, float t_sigma, int oot_idx, int mult_hits ) :
+    CTPPSDiamondLocalTrack( const math::XYZPoint& pos0, const math::XYZPoint& pos0_sigma, float t, float t_sigma, int oot_idx, int mult_hits ) :
       pos0_( pos0 ), pos0_sigma_( pos0_sigma ),
       num_hits_( 0 ), num_planes_( 0 ), valid_( false ),
       t_( t ), t_sigma_( t_sigma ), ts_index_( oot_idx ), mh_( mult_hits ) {}

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
@@ -27,6 +27,16 @@ class CTPPSDiamondLocalTrack
       t_( t ), t_sigma_( t_sigma ), ts_index_( oot_idx ), mh_( mult_hits ) {}
     virtual ~CTPPSDiamondLocalTrack() {}
 
+    inline static bool containsHit( const CTPPSDiamondLocalTrack& localTrack, const CTPPSDiamondRecHit& recHit, float tolerance = 0.1 ) {
+      return ( recHit.getOOTIndex() == localTrack.getOOTIndex()
+        && ( ( recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
+            && recHit.getX() + 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
+          || ( recHit.getX() - 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
+            && recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
+          || ( recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() - localTrack.getX0Sigma() - tolerance
+            && recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() + localTrack.getX0Sigma() + tolerance ) ) );
+    }
+
     //--- spatial get'ters
 
     inline float getX0() const { return pos0_.x(); }
@@ -103,18 +113,6 @@ inline bool operator<( const CTPPSDiamondLocalTrack& lhs, const CTPPSDiamondLoca
   // then sort by x-position
   return ( lhs.getX0() < rhs.getX0() );
 }
-
-inline bool
-CTPPSHitBelongsToTrack( const CTPPSDiamondLocalTrack& localTrack, const CTPPSDiamondRecHit& recHit, float tolerance = 0.1 )
-{
-  return ( recHit.getOOTIndex() == localTrack.getOOTIndex()
-        && ( ( recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
-            && recHit.getX() + 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
-          || ( recHit.getX() - 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
-            && recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
-          || ( recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() - localTrack.getX0Sigma() - tolerance
-            && recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() + localTrack.getX0Sigma() + tolerance ) ) );
-};
 
 #endif
 

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
@@ -19,10 +19,11 @@ class CTPPSDiamondLocalTrack
 {
   public:
     CTPPSDiamondLocalTrack() :
-      numOfHits_( 0 ), valid_( true ), t_( 0. ), t_sigma_( 0. ), ts_index_( 0 ), mh_( 0 ) {}
+      num_hits_( 0 ), num_planes_( 0 ), valid_( true ),
+      t_( 0. ), t_sigma_( 0. ), ts_index_( 0 ), mh_( 0 ) {}
     CTPPSDiamondLocalTrack( const math::XYZPoint& pos0, const math::XYZPoint& pos0_sigma, float chisq, float t, float t_sigma, int oot_idx, int mult_hits ) :
       pos0_( pos0 ), pos0_sigma_( pos0_sigma ),
-      numOfHits_( 0 ), valid_( false ),
+      num_hits_( 0 ), num_planes_( 0 ), valid_( false ),
       t_( t ), t_sigma_( t_sigma ), ts_index_( oot_idx ), mh_( mult_hits ) {}
     virtual ~CTPPSDiamondLocalTrack() {}
 
@@ -37,16 +38,16 @@ class CTPPSDiamondLocalTrack
     inline float getZ0() const { return pos0_.z(); }
     inline float getZ0Sigma() const { return pos0_sigma_.z(); }
     
-    inline int getNumOfHits() const { return numOfHits_; }
-    inline int getNumOfPlanes() const { return numOfPlanes_; }
+    inline int getNumOfHits() const { return num_hits_; }
+    inline int getNumOfPlanes() const { return num_planes_; }
     
     //--- spatial set'ters
 
     inline void setPosition( const math::XYZPoint& pos0 ) { pos0_ = pos0; }
     inline void setPositionSigma( const math::XYZPoint& pos0_sigma ) { pos0_sigma_ = pos0_sigma; }
 
-    inline void setNumOfHits( const int numOfHits ) { numOfHits_ = numOfHits; }
-    inline void setNumOfPlanes( const int numOfPlanes ) { numOfPlanes_ = numOfPlanes; }
+    inline void setNumOfHits( const int num_hits ) { num_hits_ = num_hits; }
+    inline void setNumOfPlanes( const int num_planes ) { num_planes_ = num_planes; }
 
     inline bool isValid() const { return valid_; }
     inline void setValid( bool valid ) { valid_ = valid; }
@@ -76,10 +77,10 @@ class CTPPSDiamondLocalTrack
     math::XYZPoint pos0_sigma_;
 
     /// number of hits participating in the track
-    int numOfHits_;
-    
+    int num_hits_;
+
     /// number of planes participating in the track
-    int numOfPlanes_;
+    int num_planes_;
 
     /// fit valid?
     bool valid_;
@@ -116,3 +117,4 @@ CTPPSHitBelongsToTrack( const CTPPSDiamondLocalTrack& localTrack, const CTPPSDia
 };
 
 #endif
+

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
@@ -30,8 +30,8 @@ class CTPPSDiamondLocalTrack
     inline bool containsHit( const CTPPSDiamondRecHit& recHit, float tolerance = 0.1 ) const {
       const float x_low  = pos0_.x() - pos0_sigma_.x() - tolerance;
       const float x_high = pos0_.x() + pos0_sigma_.x() + tolerance;
-      return ( recHit.getOOTIndex() == ts_index_
-        && ( recHit.getZ() * pos0_.z() > 0. )
+      return ( ( recHit.getZ() * pos0_.z() > 0. )
+        && ( recHit.getOOTIndex() == ts_index_ || recHit.getOOTIndex() == ts_index_ + CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING )
         && ( ( recHit.getX() + 0.5 * recHit.getXWidth() > x_low && recHit.getX() + 0.5 * recHit.getXWidth() < x_high )
           || ( recHit.getX() - 0.5 * recHit.getXWidth() > x_low && recHit.getX() - 0.5 * recHit.getXWidth() < x_high )
           || ( recHit.getX() - 0.5 * recHit.getXWidth() < x_low && recHit.getX() + 0.5 * recHit.getXWidth() > x_high ) ) );

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
@@ -38,6 +38,7 @@ class CTPPSDiamondLocalTrack
     inline float getZ0Sigma() const { return pos0_sigma_.z(); }
     
     inline int getNumOfHits() const { return numOfHits_; }
+    inline int getNumOfPlanes() const { return numOfPlanes_; }
     
     //--- spatial set'ters
 
@@ -45,6 +46,7 @@ class CTPPSDiamondLocalTrack
     inline void setPositionSigma( const math::XYZPoint& pos0_sigma ) { pos0_sigma_ = pos0_sigma; }
 
     inline void setNumOfHits( const int numOfHits ) { numOfHits_ = numOfHits; }
+    inline void setNumOfPlanes( const int numOfPlanes ) { numOfPlanes_ = numOfPlanes; }
 
     inline bool isValid() const { return valid_; }
     inline void setValid( bool valid ) { valid_ = valid; }
@@ -75,6 +77,9 @@ class CTPPSDiamondLocalTrack
 
     /// number of hits participating in the track
     int numOfHits_;
+    
+    /// number of planes participating in the track
+    int numOfPlanes_;
 
     /// fit valid?
     bool valid_;
@@ -98,5 +103,18 @@ inline bool operator<( const CTPPSDiamondLocalTrack& lhs, const CTPPSDiamondLoca
   // then sort by x-position
   return ( lhs.getX0() < rhs.getX0() );
 }
+
+inline bool
+CTPPSHitBelongsToTrack( const CTPPSDiamondLocalTrack& localTrack, const CTPPSDiamondRecHit& recHit, float tolerance=0.1 )
+{
+  return
+  ( recHit.getOOTIndex() == localTrack.getOOTIndex() &&
+               ( ( recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
+                && recHit.getX() + 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
+              || ( recHit.getX() - 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
+                && recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
+              || ( recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() - localTrack.getX0Sigma() - tolerance
+                && recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() + localTrack.getX0Sigma() + tolerance ) ) );
+};
 
 #endif

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
@@ -92,7 +92,6 @@ class CTPPSDiamondLocalTrack
     int ts_index_;
     /// Multiple hits counter
     int mh_;
-
 };
 
 inline bool operator<( const CTPPSDiamondLocalTrack& lhs, const CTPPSDiamondLocalTrack& rhs )
@@ -105,16 +104,15 @@ inline bool operator<( const CTPPSDiamondLocalTrack& lhs, const CTPPSDiamondLoca
 }
 
 inline bool
-CTPPSHitBelongsToTrack( const CTPPSDiamondLocalTrack& localTrack, const CTPPSDiamondRecHit& recHit, float tolerance=0.1 )
+CTPPSHitBelongsToTrack( const CTPPSDiamondLocalTrack& localTrack, const CTPPSDiamondRecHit& recHit, float tolerance = 0.1 )
 {
-  return
-  ( recHit.getOOTIndex() == localTrack.getOOTIndex() &&
-               ( ( recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
-                && recHit.getX() + 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
-              || ( recHit.getX() - 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
-                && recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
-              || ( recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() - localTrack.getX0Sigma() - tolerance
-                && recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() + localTrack.getX0Sigma() + tolerance ) ) );
+  return ( recHit.getOOTIndex() == localTrack.getOOTIndex()
+        && ( ( recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
+            && recHit.getX() + 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
+          || ( recHit.getX() - 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
+            && recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
+          || ( recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() - localTrack.getX0Sigma() - tolerance
+            && recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() + localTrack.getX0Sigma() + tolerance ) ) );
 };
 
 #endif

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
@@ -19,10 +19,10 @@ class CTPPSDiamondLocalTrack
 {
   public:
     CTPPSDiamondLocalTrack() :
-      chi_squared_( 0. ), valid_( true ), t_( 0. ), t_sigma_( 0. ), ts_index_( 0 ), mh_( 0 ) {}
+      numOfHits_( 0 ), valid_( true ), t_( 0. ), t_sigma_( 0. ), ts_index_( 0 ), mh_( 0 ) {}
     CTPPSDiamondLocalTrack( const math::XYZPoint& pos0, const math::XYZPoint& pos0_sigma, float chisq, float t, float t_sigma, int oot_idx, int mult_hits ) :
       pos0_( pos0 ), pos0_sigma_( pos0_sigma ),
-      chi_squared_( chisq ), valid_( false ),
+      numOfHits_( 0 ), valid_( false ),
       t_( t ), t_sigma_( t_sigma ), ts_index_( oot_idx ), mh_( mult_hits ) {}
     virtual ~CTPPSDiamondLocalTrack() {}
 
@@ -35,15 +35,16 @@ class CTPPSDiamondLocalTrack
     inline float getY0Sigma() const { return pos0_sigma_.y(); }
 
     inline float getZ0() const { return pos0_.z(); }
-
-    inline float getChiSquared() const { return chi_squared_; }
+    inline float getZ0Sigma() const { return pos0_sigma_.z(); }
+    
+    inline int getNumOfHits() const { return numOfHits_; }
     
     //--- spatial set'ters
 
     inline void setPosition( const math::XYZPoint& pos0 ) { pos0_ = pos0; }
     inline void setPositionSigma( const math::XYZPoint& pos0_sigma ) { pos0_sigma_ = pos0_sigma; }
 
-    inline void setChiSquared( const float chisq ) { chi_squared_ = chisq; }
+    inline void setNumOfHits( const int numOfHits ) { numOfHits_ = numOfHits; }
 
     inline bool isValid() const { return valid_; }
     inline void setValid( bool valid ) { valid_ = valid; }
@@ -72,8 +73,8 @@ class CTPPSDiamondLocalTrack
     /// error on the initial track position
     math::XYZPoint pos0_sigma_;
 
-    /// fit chi^2
-    float chi_squared_;
+    /// number of hits participating in the track
+    int numOfHits_;
 
     /// fit valid?
     bool valid_;

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
@@ -37,10 +37,10 @@ class CTPPSDiamondLocalTrack
 
     inline float getZ0() const { return pos0_.z(); }
     inline float getZ0Sigma() const { return pos0_sigma_.z(); }
-    
+
     inline int getNumOfHits() const { return num_hits_; }
     inline int getNumOfPlanes() const { return num_planes_; }
-    
+
     //--- spatial set'ters
 
     inline void setPosition( const math::XYZPoint& pos0 ) { pos0_ = pos0; }
@@ -56,15 +56,15 @@ class CTPPSDiamondLocalTrack
 
     inline float getT() const { return t_; }
     inline float getTSigma() const { return t_sigma_; }
-    
+ 
     //--- temporal set'ters
 
     inline void setT( const float t ) { t_ = t; }
     inline void setTSigma( const float t_sigma ) { t_sigma_ = t_sigma; }
-    
+
     inline void setOOTIndex( const int i ) { ts_index_ = i; }
     inline int getOOTIndex() const { return ts_index_; }
-    
+
     inline void setMultipleHits( const int i ) { mh_ = i; }
     inline int getMultipleHits() const { return mh_; }
 

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
@@ -64,7 +64,6 @@ class CTPPSDiamondRecHit
 
     inline void setHPTDCErrorFlags( const HPTDCErrorFlags& err ) { hptdc_err_ = err; }
     inline HPTDCErrorFlags getHPTDCErrorFlags() const { return hptdc_err_; }
-    
 
   private:
     float x_, x_width_;
@@ -86,3 +85,4 @@ inline bool operator<( const CTPPSDiamondRecHit& l, const CTPPSDiamondRecHit& r 
 }
 
 #endif
+

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
@@ -21,9 +21,9 @@ class CTPPSDiamondRecHit
       t_( 0. ), tot_( 0. ), t_precision_(0.),
       ts_index_( 0 ), hptdc_err_( 0 ), mh_( false )
     {}
-    CTPPSDiamondRecHit( float x, float x_width, float y, float y_width, float t, float tot, int oot_idx, const HPTDCErrorFlags& hptdc_err, const bool mh ) :
-      x_( x ), x_width_( x_width ), y_( y ), y_width_( y_width ),
-      t_( t ), tot_( tot ),
+    CTPPSDiamondRecHit( float x, float x_width, float y, float y_width, float z, float z_width, float t, float tot, float t_precision, int oot_idx, const HPTDCErrorFlags& hptdc_err, const bool mh ) :
+      x_( x ), x_width_( x_width ), y_( y ), y_width_( y_width ), z_( z ), z_width_( z_width ),
+      t_( t ), tot_( tot ), t_precision_(t_precision),
       ts_index_( oot_idx ), hptdc_err_( hptdc_err ), mh_( mh )
     {}
 

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
@@ -12,6 +12,8 @@
 
 #include "DataFormats/CTPPSDigi/interface/HPTDCErrorFlags.h"
 
+enum {CTPPSDIAMONDRECHIT_WITHOUT_LEADING_TIMESLICE = -10};
+
 /// Reconstructed hit in diamond detectors.
 class CTPPSDiamondRecHit
 {
@@ -26,6 +28,7 @@ class CTPPSDiamondRecHit
       t_( t ), tot_( tot ), t_precision_(t_precision),
       ts_index_( oot_idx ), hptdc_err_( hptdc_err ), mh_( mh )
     {}
+    
 
     inline void setX( const float& x ) { x_ = x; }
     inline float getX() const { return x_; }
@@ -62,6 +65,7 @@ class CTPPSDiamondRecHit
 
     inline void setHPTDCErrorFlags( const HPTDCErrorFlags& err ) { hptdc_err_ = err; }
     inline HPTDCErrorFlags getHPTDCErrorFlags() const { return hptdc_err_; }
+    
 
   private:
     float x_, x_width_;

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
@@ -17,8 +17,8 @@ class CTPPSDiamondRecHit
 {
   public:
     CTPPSDiamondRecHit() :
-      x_( 0. ), x_width_( 0. ), y_( 0. ), y_width_( 0. ),
-      t_( 0. ), tot_( 0. ),
+      x_( 0. ), x_width_( 0. ), y_( 0. ), y_width_( 0. ), z_( 0. ), z_width_( 0. ),
+      t_( 0. ), tot_( 0. ), t_precision_(0.),
       ts_index_( 0 ), hptdc_err_( 0 ), mh_( false )
     {}
     CTPPSDiamondRecHit( float x, float x_width, float y, float y_width, float t, float tot, int oot_idx, const HPTDCErrorFlags& hptdc_err, const bool mh ) :
@@ -32,18 +32,27 @@ class CTPPSDiamondRecHit
 
     inline void setY( const float& y ) { y_ = y; }
     inline float getY() const { return y_; }
+    
+    inline void setZ( const float& z ) { z_ = z; }
+    inline float getZ() const { return z_; }
 
     inline void setXWidth( const float& xwidth ) { x_width_ = xwidth; }
     inline float getXWidth() const { return x_width_; }
 
     inline void setYWidth( const float& ywidth ) { y_width_ = ywidth; }
     inline float getYWidth() const { return y_width_; }
+    
+    inline void setZWidth( const float& zwidth ) { z_width_ = zwidth; }
+    inline float getZWidth() const { return z_width_; }
 
     inline void setT( const float& t ) { t_ = t; }
     inline float getT() const { return t_; }
 
     inline void setToT( const float& tot ) { tot_ = tot;  }
     inline float getToT() const { return tot_; }
+    
+    inline void setTPrecision( const float& t_precision ) { t_precision_ = t_precision;  }
+    inline float getTPrecision() const { return t_precision_; }
 
     inline void setOOTIndex( const int& i ) { ts_index_ = i; }
     inline int getOOTIndex() const { return ts_index_; }
@@ -57,7 +66,8 @@ class CTPPSDiamondRecHit
   private:
     float x_, x_width_;
     float y_, y_width_;
-    float t_, tot_;
+    float z_, z_width_;
+    float t_, tot_, t_precision_;
     /// Time slice index
     int ts_index_;
     HPTDCErrorFlags hptdc_err_;

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
@@ -34,7 +34,7 @@ class CTPPSDiamondRecHit
 
     inline void setY( const float& y ) { y_ = y; }
     inline float getY() const { return y_; }
-    
+
     inline void setZ( const float& z ) { z_ = z; }
     inline float getZ() const { return z_; }
 
@@ -43,7 +43,7 @@ class CTPPSDiamondRecHit
 
     inline void setYWidth( const float& ywidth ) { y_width_ = ywidth; }
     inline float getYWidth() const { return y_width_; }
-    
+
     inline void setZWidth( const float& zwidth ) { z_width_ = zwidth; }
     inline float getZWidth() const { return z_width_; }
 
@@ -52,13 +52,13 @@ class CTPPSDiamondRecHit
 
     inline void setToT( const float& tot ) { tot_ = tot;  }
     inline float getToT() const { return tot_; }
-    
+
     inline void setTPrecision( const float& t_precision ) { t_precision_ = t_precision;  }
     inline float getTPrecision() const { return t_precision_; }
 
     inline void setOOTIndex( const int& i ) { ts_index_ = i; }
     inline int getOOTIndex() const { return ts_index_; }
-    
+
     inline void setMultipleHits( const bool mh ) { mh_ = mh; }
     inline bool getMultipleHits() const { return mh_; }
 

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
@@ -12,23 +12,22 @@
 
 #include "DataFormats/CTPPSDigi/interface/HPTDCErrorFlags.h"
 
-enum {CTPPSDIAMONDRECHIT_WITHOUT_LEADING_TIMESLICE = -10};
-
 /// Reconstructed hit in diamond detectors.
 class CTPPSDiamondRecHit
 {
   public:
     CTPPSDiamondRecHit() :
       x_( 0. ), x_width_( 0. ), y_( 0. ), y_width_( 0. ), z_( 0. ), z_width_( 0. ),
-      t_( 0. ), tot_( 0. ), t_precision_(0.),
+      t_( 0. ), tot_( 0. ), t_precision_( 0. ),
       ts_index_( 0 ), hptdc_err_( 0 ), mh_( false )
     {}
     CTPPSDiamondRecHit( float x, float x_width, float y, float y_width, float z, float z_width, float t, float tot, float t_precision, int oot_idx, const HPTDCErrorFlags& hptdc_err, const bool mh ) :
       x_( x ), x_width_( x_width ), y_( y ), y_width_( y_width ), z_( z ), z_width_( z_width ),
-      t_( t ), tot_( tot ), t_precision_(t_precision),
+      t_( t ), tot_( tot ), t_precision_( t_precision ),
       ts_index_( oot_idx ), hptdc_err_( hptdc_err ), mh_( mh )
     {}
-    
+
+    static constexpr int TIMESLICE_WITHOUT_LEADING = -10;
 
     inline void setX( const float& x ) { x_ = x; }
     inline float getX() const { return x_; }

--- a/DataFormats/CTPPSReco/src/classes.h
+++ b/DataFormats/CTPPSReco/src/classes.h
@@ -57,19 +57,19 @@ namespace DataFormats_CTPPSReco {
     edm::Ptr<CTPPSDiamondRecHit> ptr_ctd_rh;
     edm::Wrapper<CTPPSDiamondRecHit> wrp_ctd_rh;
     std::vector<CTPPSDiamondRecHit> vec_ctd_rh;
-    std::vector< edm::DetSet<CTPPSDiamondRecHit> > vec_ds_ctd_rh;
+    std::vector<edm::DetSet<CTPPSDiamondRecHit> > vec_ds_ctd_rh;
     edm::DetSet<CTPPSDiamondRecHit> ds_ctd_rh;
     edm::DetSetVector<CTPPSDiamondRecHit> dsv_ctd_rh;
-    edm::Wrapper< edm::DetSetVector<CTPPSDiamondRecHit> > wrp_dsv_ctd_rh;
-    edm::Wrapper< std::vector<CTPPSDiamondRecHit> > wrp_vec_ctd_rh;
+    edm::Wrapper<edm::DetSetVector<CTPPSDiamondRecHit> > wrp_dsv_ctd_rh;
+    edm::Wrapper<std::vector<CTPPSDiamondRecHit> > wrp_vec_ctd_rh;
 
     CTPPSDiamondLocalTrack ctd_lt;
     edm::Ptr<CTPPSDiamondLocalTrack> ptr_ctd_lt;
     edm::Wrapper<CTPPSDiamondLocalTrack> wrp_ctd_lt;
     std::vector<CTPPSDiamondLocalTrack> vec_ctd_lt;
     edm::DetSet<CTPPSDiamondLocalTrack> ds_ctd_lt;
-    std::vector< edm::DetSet<CTPPSDiamondLocalTrack> > vec_ds_ctd_lt;
-    edm::Wrapper< std::vector<CTPPSDiamondLocalTrack> > wrp_vec_ctd_lt;
+    std::vector<edm::DetSet<CTPPSDiamondLocalTrack> > vec_ds_ctd_lt;
+    edm::Wrapper<std::vector<CTPPSDiamondLocalTrack> > wrp_vec_ctd_lt;
     edm::DetSetVector<CTPPSDiamondLocalTrack> dsv_ctd_lt;
     edm::Wrapper<edm::DetSetVector<CTPPSDiamondLocalTrack> > wrp_dsv_ctd_lt;
 

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -61,7 +61,7 @@
 
   <class name="CTPPSDiamondLocalTrack" ClassVersion="4">
     <version ClassVersion="3" checksum="2739193553"/>
-    <version ClassVersion="4" checksum="4125286609"/>
+    <version ClassVersion="4" checksum="1269161307"/>
   </class>
   <class name="edm::Ptr<CTPPSDiamondLocalTrack>"/>
   <class name="edm::Wrapper<CTPPSDiamondLocalTrack>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -45,9 +45,10 @@
 
 <!-- diamonds objects -->
 
-  <class name="CTPPSDiamondRecHit" ClassVersion="4">
+  <class name="CTPPSDiamondRecHit" ClassVersion="5">
     <version ClassVersion="3" checksum="2377257106"/>
     <version ClassVersion="4" checksum="2150979176"/>
+    <version ClassVersion="5" checksum="2528095961"/>
   </class>
   <class name="edm::Ptr<CTPPSDiamondRecHit>"/>
   <class name="edm::Wrapper<CTPPSDiamondRecHit>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -61,7 +61,7 @@
 
   <class name="CTPPSDiamondLocalTrack" ClassVersion="4">
     <version ClassVersion="3" checksum="2739193553"/>
-    <version ClassVersion="4" checksum="1269161307"/>
+    <version ClassVersion="4" checksum="3974505177"/>
   </class>
   <class name="edm::Ptr<CTPPSDiamondLocalTrack>"/>
   <class name="edm::Wrapper<CTPPSDiamondLocalTrack>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -53,11 +53,11 @@
   <class name="edm::Ptr<CTPPSDiamondRecHit>"/>
   <class name="edm::Wrapper<CTPPSDiamondRecHit>"/>
   <class name="std::vector<CTPPSDiamondRecHit>"/>
-  <class name="std::vector< edm::DetSet<CTPPSDiamondRecHit> >"/>
+  <class name="std::vector<edm::DetSet<CTPPSDiamondRecHit> >"/>
   <class name="edm::DetSet<CTPPSDiamondRecHit>"/>
   <class name="edm::DetSetVector<CTPPSDiamondRecHit>"/>
-  <class name="edm::Wrapper< edm::DetSetVector<CTPPSDiamondRecHit> >"/>
-  <class name="edm::Wrapper< std::vector<CTPPSDiamondRecHit> >"/>
+  <class name="edm::Wrapper<edm::DetSetVector<CTPPSDiamondRecHit> >"/>
+  <class name="edm::Wrapper<std::vector<CTPPSDiamondRecHit> >"/>
 
   <class name="CTPPSDiamondLocalTrack" ClassVersion="4">
     <version ClassVersion="3" checksum="2739193553"/>
@@ -67,10 +67,10 @@
   <class name="edm::Wrapper<CTPPSDiamondLocalTrack>"/>
   <class name="std::vector<CTPPSDiamondLocalTrack>"/>
   <class name="edm::DetSet<CTPPSDiamondLocalTrack>"/>
-  <class name="std::vector< edm::DetSet<CTPPSDiamondLocalTrack> >"/>
-  <class name="edm::Wrapper< std::vector<CTPPSDiamondLocalTrack> >"/>
+  <class name="std::vector<edm::DetSet<CTPPSDiamondLocalTrack> >"/>
+  <class name="edm::Wrapper<std::vector<CTPPSDiamondLocalTrack> >"/>
   <class name="edm::DetSetVector<CTPPSDiamondLocalTrack>"/>
-  <class name="edm::Wrapper< edm::DetSetVector<CTPPSDiamondLocalTrack> >"/>
+  <class name="edm::Wrapper<edm::DetSetVector<CTPPSDiamondLocalTrack> >"/>
 
 <!-- pixel objects -->
 

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -59,8 +59,9 @@
   <class name="edm::Wrapper< edm::DetSetVector<CTPPSDiamondRecHit> >"/>
   <class name="edm::Wrapper< std::vector<CTPPSDiamondRecHit> >"/>
 
-  <class name="CTPPSDiamondLocalTrack" ClassVersion="3">
+  <class name="CTPPSDiamondLocalTrack" ClassVersion="4">
     <version ClassVersion="3" checksum="2739193553"/>
+    <version ClassVersion="4" checksum="4125286609"/>
   </class>
   <class name="edm::Ptr<CTPPSDiamondLocalTrack>"/>
   <class name="edm::Wrapper<CTPPSDiamondLocalTrack>"/>

--- a/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondRecHitProducerAlgorithm.h
+++ b/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondRecHitProducerAlgorithm.h
@@ -30,7 +30,6 @@ class CTPPSDiamondRecHitProducerAlgorithm
   private:
     /// Conversion constant between HPTDC time slice and absolute time (in ns)
     double ts_to_ns_;
-    int t_shift_;
 };
 
 #endif

--- a/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondRecHitProducerAlgorithm.h
+++ b/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondRecHitProducerAlgorithm.h
@@ -26,8 +26,6 @@ class CTPPSDiamondRecHitProducerAlgorithm
     CTPPSDiamondRecHitProducerAlgorithm( const edm::ParameterSet& conf );
 
     void build( const CTPPSGeometry*, const edm::DetSetVector<CTPPSDiamondDigi>&, edm::DetSetVector<CTPPSDiamondRecHit>& );
-    
-    enum {NO_LEADING_EDGE_TIMESLICE = -10};
 
   private:
     /// Conversion constant between HPTDC time slice and absolute time (in ns)

--- a/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondRecHitProducerAlgorithm.h
+++ b/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondRecHitProducerAlgorithm.h
@@ -26,6 +26,8 @@ class CTPPSDiamondRecHitProducerAlgorithm
     CTPPSDiamondRecHitProducerAlgorithm( const edm::ParameterSet& conf );
 
     void build( const CTPPSGeometry*, const edm::DetSetVector<CTPPSDiamondDigi>&, edm::DetSetVector<CTPPSDiamondRecHit>& );
+    
+    enum {NO_LEADING_EDGE_TIMESLICE = -10};
 
   private:
     /// Conversion constant between HPTDC time slice and absolute time (in ns)

--- a/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondTrackRecognition.h
+++ b/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondTrackRecognition.h
@@ -43,7 +43,7 @@ class CTPPSDiamondTrackRecognition
 
   private:
     struct HitParameters {
-      HitParameters( const float center, const float width) :
+      HitParameters( const float center, const float width ) :
         center( center ), width( width ) {}
       float center;
       float width;

--- a/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondTrackRecognition.h
+++ b/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondTrackRecognition.h
@@ -43,7 +43,7 @@ class CTPPSDiamondTrackRecognition
 
   private:
     struct HitParameters {
-      HitParameters( const float center, const float width ) :
+      HitParameters( const float center, const float width) :
         center( center ), width( width ) {}
       float center;
       float width;
@@ -65,6 +65,10 @@ class CTPPSDiamondTrackRecognition
     float yWidth_;
     float yPositionInitial_;
     float yWidthInitial_;
+    float zPosition_;
+    float zWidth_;
+    float zPositionInitial_;
+    float zWidthInitial_;
 
     /// Function for pad efficiency
     TF1 hit_f_;

--- a/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondTrackRecognition.h
+++ b/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondTrackRecognition.h
@@ -43,7 +43,7 @@ class CTPPSDiamondTrackRecognition
 
   private:
     struct HitParameters {
-      HitParameters( const float center, const float width ) :
+      HitParameters( const float center, const float width) :
         center( center ), width( width ) {}
       float center;
       float width;

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -69,17 +69,21 @@ CTPPSDiamondLocalTrackFitter::produce( edm::Event& iEvent, const edm::EventSetup
 
   // workaround to retrieve the detset for 4-5 without losing the reference
   edm::DetSet<CTPPSDiamondLocalTrack>& tracks45 = pOut->operator[]( id_45 );
+  
+  
+  // Create vector to simplify code for both arms
+  std::vector< edm::DetSet<CTPPSDiamondLocalTrack>* > tracksPair( 2 );
+  tracksPair[0] = &tracks45;
+  tracksPair[1] = &tracks56;
+  
+  std::vector< CTPPSDiamondTrackRecognition* > trackRecoPair( 2 );
+  trackRecoPair[0] = &trk_algo_45_;
+  trackRecoPair[1] = &trk_algo_56_;
 
   // feed hits to the track producers
   for ( const auto& vec : *recHits ) {
     const CTPPSDiamondDetId detid( vec.detId() );
-
-    if ( detid.arm() == 0 ) {
-      for ( const auto& hit : vec ) trk_algo_45_.addHit( hit );
-    }
-    else if ( detid.arm() == 1 ) {
-      for ( const auto& hit : vec ) trk_algo_56_.addHit( hit );
-    }
+    for ( const auto& hit : vec ) trackRecoPair.at( detid.arm() )->addHit( hit );
   }
 
   // retrieve the tracks for both arms
@@ -96,10 +100,17 @@ CTPPSDiamondLocalTrackFitter::produce( edm::Event& iEvent, const edm::EventSetup
 bool
 CTPPSDiamondLocalTrackFitter::hitBelongsToTrack( const CTPPSDiamondLocalTrack& localTrack, const CTPPSDiamondRecHit& recHit ) const
 {
-  return ( recHit.getX() + recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma()
-        && recHit.getX() + recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() )
-      || ( recHit.getX() - recHit.getXWidth() > localTrack.getX0() + localTrack.getX0Sigma()
-        && recHit.getX() - recHit.getXWidth() < localTrack.getX0() - localTrack.getX0Sigma() );
+  bool inside =  ( recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - 0.1
+                && recHit.getX() + 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + 0.1 )
+              || ( recHit.getX() - 0.5 * recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() - 0.1
+                && recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() + 0.1 )
+              || ( recHit.getX() - 0.5 * recHit.getXWidth() < localTrack.getX0() - localTrack.getX0Sigma() - 0.1
+                && recHit.getX() + 0.5 * recHit.getXWidth() > localTrack.getX0() + localTrack.getX0Sigma() + 0.1 );
+      
+//   std::cout << "##### Track: " << localTrack.getX0() - localTrack.getX0Sigma() << "  to  " << localTrack.getX0() + localTrack.getX0Sigma() << "\t\tHit: " << recHit.getX() - 0.5 * recHit.getXWidth() << "  to  " << recHit.getX() + 0.5 * recHit.getXWidth();
+//   if ( inside ) std::cout << " Inside! ";
+//   std::cout << std::endl;
+  return inside;
 };
 
 void
@@ -112,7 +123,7 @@ CTPPSDiamondLocalTrackFitter::fillDescriptions( edm::ConfigurationDescriptions& 
     ->setComment( "general verbosity of this module" );
 
   edm::ParameterSetDescription trackingAlgoParams;
-  trackingAlgoParams.add<double>( "threshold", 1.5 )
+  trackingAlgoParams.add<double>( "threshold", 1.9 )
     ->setComment( "minimal number of rechits to be observed before launching the track recognition algorithm" );
   trackingAlgoParams.add<double>( "thresholdFromMaximum", 0.5 );
   trackingAlgoParams.add<double>( "resolution", 0.01 /* mm */ )

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -75,10 +75,13 @@ CTPPSDiamondLocalTrackFitter::produce( edm::Event& iEvent, const edm::EventSetup
       // skip hits without a leading edge
       if ( hit.getOOTIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING ) continue;
 
-      if ( detid.arm() == 0 )
-        trk_algo_45_.addHit( hit );
-      if ( detid.arm() == 1 )
-        trk_algo_56_.addHit( hit );
+      switch ( detid.arm() ) {
+        case 0: { trk_algo_45_.addHit( hit ); } break;
+        case 1: { trk_algo_56_.addHit( hit ); } break;
+        default:
+          edm::LogWarning("CTPPSDiamondLocalTrackFitter") << "Invalid arm for rechit: " << detid.arm();
+          break;
+      }
     }
   }
 

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -34,7 +34,7 @@ class CTPPSDiamondLocalTrackFitter : public edm::stream::EDProducer<>
     static void fillDescriptions( edm::ConfigurationDescriptions& );
 
   private:
-    virtual void produce( edm::Event&, const edm::EventSetup& ) override;
+    void produce( edm::Event&, const edm::EventSetup& ) override;
 
     edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondRecHit> > recHitsToken_;
     CTPPSDiamondTrackRecognition trk_algo_45_;

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -34,20 +34,13 @@ class CTPPSDiamondLocalTrackFitter : public edm::stream::EDProducer<>
     static void fillDescriptions( edm::ConfigurationDescriptions& );
 
   private:
-    void produce( edm::Event&, const edm::EventSetup& ) override;
+    virtual void produce( edm::Event&, const edm::EventSetup& ) override;
+    /// Check if one of the edges of the recHit is within the local track
+    bool hitBelongsToTrack( const CTPPSDiamondLocalTrack& localTrack, const CTPPSDiamondRecHit& recHit ) const;
 
     edm::EDGetTokenT< edm::DetSetVector<CTPPSDiamondRecHit> > recHitsToken_;
     CTPPSDiamondTrackRecognition trk_algo_45_;
     CTPPSDiamondTrackRecognition trk_algo_56_;
-};
-
-inline bool hitBelongsToTrack( const CTPPSDiamondLocalTrack& localTrack, const CTPPSDiamondRecHit& recHit )
-{
-  // Check if one of the edges of the recHit is within the 
-  return ( recHit.getX() + recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma()
-        && recHit.getX() + recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() )
-      || ( recHit.getX() - recHit.getXWidth() > localTrack.getX0() + localTrack.getX0Sigma()
-        && recHit.getX() - recHit.getXWidth() < localTrack.getX0() - localTrack.getX0Sigma() );
 };
 
 CTPPSDiamondLocalTrackFitter::CTPPSDiamondLocalTrackFitter( const edm::ParameterSet& iConfig ) :
@@ -99,6 +92,15 @@ CTPPSDiamondLocalTrackFitter::produce( edm::Event& iEvent, const edm::EventSetup
   trk_algo_45_.clear();
   trk_algo_56_.clear();
 }
+
+bool
+CTPPSDiamondLocalTrackFitter::hitBelongsToTrack( const CTPPSDiamondLocalTrack& localTrack, const CTPPSDiamondRecHit& recHit ) const
+{
+  return ( recHit.getX() + recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma()
+        && recHit.getX() + recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() )
+      || ( recHit.getX() - recHit.getXWidth() > localTrack.getX0() + localTrack.getX0Sigma()
+        && recHit.getX() - recHit.getXWidth() < localTrack.getX0() - localTrack.getX0Sigma() );
+};
 
 void
 CTPPSDiamondLocalTrackFitter::fillDescriptions( edm::ConfigurationDescriptions& descr )

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -25,7 +25,6 @@
 
 #include "RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondTrackRecognition.h"
 
-
 class CTPPSDiamondLocalTrackFitter : public edm::stream::EDProducer<>
 {
   public:
@@ -83,7 +82,7 @@ CTPPSDiamondLocalTrackFitter::produce( edm::Event& iEvent, const edm::EventSetup
   for ( const auto& vec : *recHits ) {
     const CTPPSDiamondDetId detid( vec.detId() );
     for ( const auto& hit : vec ) {
-      if ( hit.getOOTIndex() != CTPPSDIAMONDRECHIT_WITHOUT_LEADING_TIMESLICE )
+      if ( hit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING )
         trackRecoPair.at( detid.arm() )->addHit( hit );
     }
   }

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -67,23 +67,18 @@ CTPPSDiamondLocalTrackFitter::produce( edm::Event& iEvent, const edm::EventSetup
 
   // workaround to retrieve the detset for 4-5 without losing the reference
   edm::DetSet<CTPPSDiamondLocalTrack>& tracks45 = pOut->operator[]( id_45 );
-  
-  
-  // Create vector to simplify code for both arms
-  std::vector< edm::DetSet<CTPPSDiamondLocalTrack>* > tracksPair( 2 );
-  tracksPair[0] = &tracks45;
-  tracksPair[1] = &tracks56;
-  
-  std::vector< CTPPSDiamondTrackRecognition* > trackRecoPair( 2 );
-  trackRecoPair[0] = &trk_algo_45_;
-  trackRecoPair[1] = &trk_algo_56_;
 
   // feed hits to the track producers
   for ( const auto& vec : *recHits ) {
     const CTPPSDiamondDetId detid( vec.detId() );
     for ( const auto& hit : vec ) {
-      if ( hit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING )
-        trackRecoPair.at( detid.arm() )->addHit( hit );
+      // skip hits without a leading edge
+      if ( hit.getOOTIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING ) continue;
+
+      if ( detid.arm() == 0 )
+        trk_algo_45_.addHit( hit );
+      if ( detid.arm() == 1 )
+        trk_algo_56_.addHit( hit );
     }
   }
 

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -106,12 +106,12 @@ CTPPSDiamondLocalTrackFitter::fillDescriptions( edm::ConfigurationDescriptions& 
     ->setComment( "general verbosity of this module" );
 
   edm::ParameterSetDescription trackingAlgoParams;
-  trackingAlgoParams.add<double>( "threshold", 1.9 )
+  trackingAlgoParams.add<double>( "threshold", 1.5 )
     ->setComment( "minimal number of rechits to be observed before launching the track recognition algorithm" );
   trackingAlgoParams.add<double>( "thresholdFromMaximum", 0.5 );
-  trackingAlgoParams.add<double>( "resolution", 0.005 /* mm */ )
+  trackingAlgoParams.add<double>( "resolution", 0.01 /* mm */ )
     ->setComment( "spatial resolution on the horizontal coordinate (in mm)" );
-  trackingAlgoParams.add<double>( "sigma", 0 );
+  trackingAlgoParams.add<double>( "sigma", 0.1 );
   trackingAlgoParams.add<double>( "startFromX", -0.5 /* mm */ )
     ->setComment( "starting horizontal coordinate of rechits for the track recognition" );
   trackingAlgoParams.add<double>( "stopAtX", 19.5 /* mm */ )

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -80,22 +80,14 @@ CTPPSDiamondLocalTrackFitter::produce( edm::Event& iEvent, const edm::EventSetup
   edm::DetSet<CTPPSDiamondLocalTrack>& tracks45 = pOut->operator[]( id_45 );
 
   // feed hits to the track producers
-  for ( edm::DetSetVector<CTPPSDiamondRecHit>::const_iterator vec = recHits->begin(); vec != recHits->end(); ++vec )
-  {
-    const CTPPSDiamondDetId detid( vec->detId() );
+  for ( const auto& vec : *recHits ) {
+    const CTPPSDiamondDetId detid( vec.detId() );
 
-    if (detid.arm()==0)
-    {
-      for ( edm::DetSet<CTPPSDiamondRecHit>::const_iterator hit = vec->begin(); hit != vec->end(); ++hit )
-      {
-        trk_algo_45_.addHit( *hit );
-      }
-    } else
-    {
-      for ( edm::DetSet<CTPPSDiamondRecHit>::const_iterator hit = vec->begin(); hit != vec->end(); ++hit )
-      {
-        trk_algo_56_.addHit( *hit );
-      }
+    if ( detid.arm() == 0 ) {
+      for ( const auto& hit : vec ) trk_algo_45_.addHit( hit );
+    }
+    else if ( detid.arm() == 1 ) {
+      for ( const auto& hit : vec ) trk_algo_56_.addHit( hit );
     }
   }
 

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -41,6 +41,17 @@ class CTPPSDiamondLocalTrackFitter : public edm::stream::EDProducer<>
     CTPPSDiamondTrackRecognition trk_algo_56_;
 };
 
+inline bool hitBelongsToTrack( const CTPPSDiamondLocalTrack& localTrack, const CTPPSDiamondRecHit& recHit )
+{
+  // Check if one of the edges of the recHit is within the 
+  return ( 
+            ( ( recHit.getX() + recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() ) &&
+              ( recHit.getX() + recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() )  ) ||
+            ( ( recHit.getX() - recHit.getXWidth() > localTrack.getX0() + localTrack.getX0Sigma() ) &&
+              ( recHit.getX() - recHit.getXWidth() < localTrack.getX0() - localTrack.getX0Sigma() )  )
+         );
+};
+
 CTPPSDiamondLocalTrackFitter::CTPPSDiamondLocalTrackFitter( const edm::ParameterSet& iConfig ) :
   recHitsToken_( consumes< edm::DetSetVector<CTPPSDiamondRecHit> >( iConfig.getParameter<edm::InputTag>( "recHitsTag" ) ) ),
   trk_algo_45_ ( iConfig.getParameter<edm::ParameterSet>( "trackingAlgorithmParams" ) ),
@@ -77,13 +88,13 @@ CTPPSDiamondLocalTrackFitter::produce( edm::Event& iEvent, const edm::EventSetup
     {
       for ( edm::DetSet<CTPPSDiamondRecHit>::const_iterator hit = vec->begin(); hit != vec->end(); ++hit )
       {
-	trk_algo_45_.addHit( *hit );
+        trk_algo_45_.addHit( *hit );
       }
     } else
     {
       for ( edm::DetSet<CTPPSDiamondRecHit>::const_iterator hit = vec->begin(); hit != vec->end(); ++hit )
       {
-	trk_algo_56_.addHit( *hit );
+        trk_algo_56_.addHit( *hit );
       }
     }
   }

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -44,12 +44,10 @@ class CTPPSDiamondLocalTrackFitter : public edm::stream::EDProducer<>
 inline bool hitBelongsToTrack( const CTPPSDiamondLocalTrack& localTrack, const CTPPSDiamondRecHit& recHit )
 {
   // Check if one of the edges of the recHit is within the 
-  return ( 
-            ( ( recHit.getX() + recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma() ) &&
-              ( recHit.getX() + recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() )  ) ||
-            ( ( recHit.getX() - recHit.getXWidth() > localTrack.getX0() + localTrack.getX0Sigma() ) &&
-              ( recHit.getX() - recHit.getXWidth() < localTrack.getX0() - localTrack.getX0Sigma() )  )
-         );
+  return ( recHit.getX() + recHit.getXWidth() > localTrack.getX0() - localTrack.getX0Sigma()
+        && recHit.getX() + recHit.getXWidth() < localTrack.getX0() + localTrack.getX0Sigma() )
+      || ( recHit.getX() - recHit.getXWidth() > localTrack.getX0() + localTrack.getX0Sigma()
+        && recHit.getX() - recHit.getXWidth() < localTrack.getX0() - localTrack.getX0Sigma() );
 };
 
 CTPPSDiamondLocalTrackFitter::CTPPSDiamondLocalTrackFitter( const edm::ParameterSet& iConfig ) :

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -36,17 +36,17 @@ class CTPPSDiamondLocalTrackFitter : public edm::stream::EDProducer<>
   private:
     virtual void produce( edm::Event&, const edm::EventSetup& ) override;
 
-    edm::EDGetTokenT< edm::DetSetVector<CTPPSDiamondRecHit> > recHitsToken_;
+    edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondRecHit> > recHitsToken_;
     CTPPSDiamondTrackRecognition trk_algo_45_;
     CTPPSDiamondTrackRecognition trk_algo_56_;
 };
 
 CTPPSDiamondLocalTrackFitter::CTPPSDiamondLocalTrackFitter( const edm::ParameterSet& iConfig ) :
-  recHitsToken_( consumes< edm::DetSetVector<CTPPSDiamondRecHit> >( iConfig.getParameter<edm::InputTag>( "recHitsTag" ) ) ),
+  recHitsToken_( consumes<edm::DetSetVector<CTPPSDiamondRecHit> >( iConfig.getParameter<edm::InputTag>( "recHitsTag" ) ) ),
   trk_algo_45_ ( iConfig.getParameter<edm::ParameterSet>( "trackingAlgorithmParams" ) ),
   trk_algo_56_ ( iConfig.getParameter<edm::ParameterSet>( "trackingAlgorithmParams" ) )
 {
-  produces< edm::DetSetVector<CTPPSDiamondLocalTrack> >();
+  produces<edm::DetSetVector<CTPPSDiamondLocalTrack> >();
 }
 
 CTPPSDiamondLocalTrackFitter::~CTPPSDiamondLocalTrackFitter()
@@ -55,9 +55,9 @@ CTPPSDiamondLocalTrackFitter::~CTPPSDiamondLocalTrackFitter()
 void
 CTPPSDiamondLocalTrackFitter::produce( edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
-  std::unique_ptr< edm::DetSetVector<CTPPSDiamondLocalTrack> > pOut( new edm::DetSetVector<CTPPSDiamondLocalTrack> );
+  std::unique_ptr<edm::DetSetVector<CTPPSDiamondLocalTrack> > pOut( new edm::DetSetVector<CTPPSDiamondLocalTrack> );
 
-  edm::Handle< edm::DetSetVector<CTPPSDiamondRecHit> > recHits;
+  edm::Handle<edm::DetSetVector<CTPPSDiamondRecHit> > recHits;
   iEvent.getByToken( recHitsToken_, recHits );
 
   const CTPPSDiamondDetId id_45( 0, 1, 6, 0, 0 ), id_56( 1, 1, 6, 0, 0 );

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
@@ -41,7 +41,7 @@ class CTPPSDiamondRecHitProducer : public edm::stream::EDProducer<>
   private:
     void produce( edm::Event&, const edm::EventSetup& ) override;
 
-    edm::EDGetTokenT< edm::DetSetVector<CTPPSDiamondDigi> > digiToken_;
+    edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondDigi> > digiToken_;
 
     /// A watcher to detect geometry changes.
     //edm::ESWatcher<VeryForwardRealGeometryRecord> geometryWatcher_;
@@ -50,10 +50,10 @@ class CTPPSDiamondRecHitProducer : public edm::stream::EDProducer<>
 };
 
 CTPPSDiamondRecHitProducer::CTPPSDiamondRecHitProducer( const edm::ParameterSet& iConfig ) :
-  digiToken_( consumes< edm::DetSetVector<CTPPSDiamondDigi> >( iConfig.getParameter<edm::InputTag>( "digiTag" ) ) ),
+  digiToken_( consumes<edm::DetSetVector<CTPPSDiamondDigi> >( iConfig.getParameter<edm::InputTag>( "digiTag" ) ) ),
   algo_( iConfig )
 {
-  produces< edm::DetSetVector<CTPPSDiamondRecHit> >();
+  produces<edm::DetSetVector<CTPPSDiamondRecHit> >();
 }
 
 CTPPSDiamondRecHitProducer::~CTPPSDiamondRecHitProducer()
@@ -62,10 +62,10 @@ CTPPSDiamondRecHitProducer::~CTPPSDiamondRecHitProducer()
 void
 CTPPSDiamondRecHitProducer::produce( edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
-  std::unique_ptr< edm::DetSetVector<CTPPSDiamondRecHit> > pOut( new edm::DetSetVector<CTPPSDiamondRecHit> );
+  std::unique_ptr<edm::DetSetVector<CTPPSDiamondRecHit> > pOut( new edm::DetSetVector<CTPPSDiamondRecHit> );
 
   // get the digi collection
-  edm::Handle< edm::DetSetVector<CTPPSDiamondDigi> > digis;
+  edm::Handle<edm::DetSetVector<CTPPSDiamondDigi> > digis;
   iEvent.getByToken( digiToken_, digis );
 
   // get the geometry

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
@@ -89,7 +89,6 @@ CTPPSDiamondRecHitProducer::fillDescriptions( edm::ConfigurationDescriptions& de
     ->setComment( "conversion constant between HPTDC timing bin size and nanoseconds" );
   desc.add<int>( "timeShift", 0 ) // to be determined at calibration level, will be replaced by a map channel id -> time shift
     ->setComment( "overall time offset to apply on all hits in all channels" );
-
   descr.add( "ctppsDiamondRecHits", desc );
 }
 

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
@@ -89,6 +89,7 @@ CTPPSDiamondRecHitProducer::fillDescriptions( edm::ConfigurationDescriptions& de
     ->setComment( "conversion constant between HPTDC timing bin size and nanoseconds" );
   desc.add<int>( "timeShift", 0 ) // to be determined at calibration level, will be replaced by a map channel id -> time shift
     ->setComment( "overall time offset to apply on all hits in all channels" );
+
   descr.add( "ctppsDiamondRecHits", desc );
 }
 

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -11,8 +11,7 @@
 //----------------------------------------------------------------------------------------------------
 
 CTPPSDiamondRecHitProducerAlgorithm::CTPPSDiamondRecHitProducerAlgorithm( const edm::ParameterSet& iConfig ) :
-  ts_to_ns_( iConfig.getParameter<double>( "timeSliceNs" ) ),
-  t_shift_( iConfig.getParameter<int>( "timeShift" ) )
+  ts_to_ns_( iConfig.getParameter<double>( "timeSliceNs" ) )
 {}
 
 void
@@ -36,10 +35,10 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm
 
     for ( edm::DetSet<CTPPSDiamondDigi>::const_iterator digi = vec->begin(); digi != vec->end(); ++digi ) {
       if ( digi->getLeadingEdge()==0 and digi->getTrailingEdge()==0 ) { continue; }
-
+      
       const int t = digi->getLeadingEdge();
-      const int t0 = ( t-t_shift_ ) % 1024;
-      int time_slice = ( t-t_shift_ ) / 1024;
+      const int t0 = t % 1024;
+      int time_slice = t / 1024;
       
       if ( t==0 ) time_slice= CTPPSDIAMONDRECHIT_WITHOUT_LEADING_TIMESLICE;
 

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -33,7 +33,7 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm
                 y_pos = det->translation().y(),
                 y_width = 2.0 * det->params().at( 1 ),
                 z_pos = det->parents()[det->parents().size()-1].absTranslation().z(), // retrieve the plane position
-                z_width = 2.0 * det->params().at( 2 );  // TODO ?
+                z_width = 2.0 * det->params().at( 2 );
 
     edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert( detid );
 

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -49,6 +49,7 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm
                                               ( t0 * ts_to_ns_ ),
                                               ( tot * ts_to_ns_),
                                               time_slice,
+                                              0., // time precision
                                               digi->getHPTDCErrorFlags(),
                                               digi->getMultipleHit() ) );
     }

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -17,8 +17,8 @@ CTPPSDiamondRecHitProducerAlgorithm::CTPPSDiamondRecHitProducerAlgorithm( const 
 void
 CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm::DetSetVector<CTPPSDiamondDigi>& input, edm::DetSetVector<CTPPSDiamondRecHit>& output )
 {
-  for ( edm::DetSetVector<CTPPSDiamondDigi>::const_iterator vec = input.begin(); vec != input.end(); ++vec ) {
-    const CTPPSDiamondDetId detid( vec->detId() );
+  for ( const auto& vec : input ) {
+    const CTPPSDiamondDetId detid( vec.detId() );
 
     if ( detid.channel() > 20 ) continue;              // VFAT-like information, to be ignored by CTPPSDiamondRecHitProducer
 
@@ -29,29 +29,28 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm
                 y_width = 2.0 * det->params().at( 1 ),
                 z_pos = det->translation().z(),
                 z_width = 2.0 * det->params().at( 2 );  // TODO ?
-                
 
     edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert( detid );
 
-    for ( edm::DetSet<CTPPSDiamondDigi>::const_iterator digi = vec->begin(); digi != vec->end(); ++digi ) {
-      if ( digi->getLeadingEdge()==0 and digi->getTrailingEdge()==0 ) { continue; }
-      
-      const int t = digi->getLeadingEdge();
+    for ( const auto& digi : vec ) {
+      if ( digi.getLeadingEdge() == 0 && digi.getTrailingEdge() == 0 ) continue;
+
+      const int t = digi.getLeadingEdge();
       const int t0 = t % 1024;
       int time_slice = t / 1024;
       
-      if ( t==0 ) time_slice= CTPPSDIAMONDRECHIT_WITHOUT_LEADING_TIMESLICE;
+      if ( t == 0 ) time_slice = CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING;
 
       int tot = 0;
-      if ( t!=0 && digi->getTrailingEdge()!=0 ) tot = ( (int) digi->getTrailingEdge() ) - t;
+      if ( t != 0 && digi.getTrailingEdge() != 0 ) tot = ( (int)digi.getTrailingEdge() ) - t;
 
       rec_hits.push_back( CTPPSDiamondRecHit( x_pos, x_width, y_pos, y_width, z_pos, z_width, // spatial information
                                               ( t0 * ts_to_ns_ ),
                                               ( tot * ts_to_ns_),
                                               time_slice,
                                               0., // time precision
-                                              digi->getHPTDCErrorFlags(),
-                                              digi->getMultipleHit() ) );
+                                              digi.getHPTDCErrorFlags(),
+                                              digi.getMultipleHit() ) );
     }
   }
 }

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -25,14 +25,16 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm
     // retrieve the geometry element associated to this DetID
     const DetGeomDesc* det = geom->getSensor( detid );
 
+    const float x_pos = det->translation().x(),
+                y_pos = det->translation().y();
+    float z_pos = 0.;
     if ( det->parents().empty() )
       edm::LogWarning("CTPPSDiamondRecHitProducerAlgorithm") << "The geometry element for " << detid << " has no parents. Check the geometry hierarchy!";
+    else
+      z_pos = det->parents()[det->parents().size()-1].absTranslation().z(); // retrieve the plane position;
 
-    const float x_pos = det->translation().x(),
-                x_width = 2.0 * det->params().at( 0 ), // parameters stand for half the size
-                y_pos = det->translation().y(),
+    const float x_width = 2.0 * det->params().at( 0 ), // parameters stand for half the size
                 y_width = 2.0 * det->params().at( 1 ),
-                z_pos = det->parents()[det->parents().size()-1].absTranslation().z(), // retrieve the plane position
                 z_width = 2.0 * det->params().at( 2 );
 
     edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert( detid );

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -44,9 +44,7 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm
 
       const int t = digi.getLeadingEdge();
       const int t0 = t % 1024;
-      int time_slice = t / 1024;
-      
-      if ( t == 0 ) time_slice = CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING;
+      const int time_slice = ( t != 0 ) ? t / 1024 : CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING;
 
       int tot = 0;
       if ( t != 0 && digi.getTrailingEdge() != 0 ) tot = ( (int)digi.getTrailingEdge() ) - t;

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -27,7 +27,10 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm
     const float x_pos = det->translation().x(),
                 x_width = 2.0 * det->params().at( 0 ), // parameters stand for half the size
                 y_pos = det->translation().y(),
-                y_width = 2.0 * det->params().at( 1 );
+                y_width = 2.0 * det->params().at( 1 ),
+                z_pos = det->translation().z(),
+                z_width = 2.0 * det->params().at( 2 );  // TODO ?
+                
 
     edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert( detid );
 
@@ -36,12 +39,14 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm
 
       const int t = digi->getLeadingEdge();
       const int t0 = ( t-t_shift_ ) % 1024;
-      const int time_slice = ( t-t_shift_ ) / 1024;
+      int time_slice = ( t-t_shift_ ) / 1024;
+      
+      if ( t==0 ) time_slice= NO_LEADING_EDGE_TIMESLICE;
 
       int tot = 0;
       if ( t!=0 && digi->getTrailingEdge()!=0 ) tot = ( (int) digi->getTrailingEdge() ) - t;
 
-      rec_hits.push_back( CTPPSDiamondRecHit( x_pos, x_width, y_pos, y_width, // spatial information
+      rec_hits.push_back( CTPPSDiamondRecHit( x_pos, x_width, y_pos, y_width, z_pos, z_width, // spatial information
                                               ( t0 * ts_to_ns_ ),
                                               ( tot * ts_to_ns_),
                                               time_slice,

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -41,7 +41,7 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm
       const int t0 = ( t-t_shift_ ) % 1024;
       int time_slice = ( t-t_shift_ ) / 1024;
       
-      if ( t==0 ) time_slice= NO_LEADING_EDGE_TIMESLICE;
+      if ( t==0 ) time_slice= CTPPSDIAMONDRECHIT_WITHOUT_LEADING_TIMESLICE;
 
       int tot = 0;
       if ( t!=0 && digi->getTrailingEdge()!=0 ) tot = ( (int) digi->getTrailingEdge() ) - t;

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -20,14 +20,19 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm
   for ( const auto& vec : input ) {
     const CTPPSDiamondDetId detid( vec.detId() );
 
-    if ( detid.channel() > 20 ) continue;              // VFAT-like information, to be ignored by CTPPSDiamondRecHitProducer
+    if ( detid.channel() > 20 ) continue; // VFAT-like information, to be ignored
 
+    // retrieve the geometry element associated to this DetID
     const DetGeomDesc* det = geom->getSensor( detid );
+
+    if ( det->parents().empty() )
+      edm::LogWarning("CTPPSDiamondRecHitProducerAlgorithm") << "The geometry element for " << detid << " has no parents. Check the geometry hierarchy!";
+
     const float x_pos = det->translation().x(),
                 x_width = 2.0 * det->params().at( 0 ), // parameters stand for half the size
                 y_pos = det->translation().y(),
                 y_width = 2.0 * det->params().at( 1 ),
-                z_pos = det->translation().z(),
+                z_pos = det->parents()[det->parents().size()-1].absTranslation().z(), // retrieve the plane position
                 z_width = 2.0 * det->params().at( 2 );  // TODO ?
 
     edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert( detid );

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
@@ -58,7 +58,7 @@ CTPPSDiamondTrackRecognition::addHit( const CTPPSDiamondRecHit& recHit )
 {
   // store hit parameters
   hitParametersVectorMap_[recHit.getOOTIndex()].emplace_back( recHit.getX(), recHit.getXWidth() );
-
+  
   // Check y
   if ( yPosition_ == yPositionInitial_ and yWidth_ == yWidthInitial_ ) {
     yPosition_ = recHit.getY();
@@ -121,7 +121,8 @@ CTPPSDiamondTrackRecognition::produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>
               if ( mhMap_.find( oot.first ) != mhMap_.end() ) mult_hits = mhMap_[oot.first];
 
               CTPPSDiamondLocalTrack track( pos0, pos0_sigma, 0., 0., 0., oot.first, mult_hits );
-              track.setValid( true );
+              track.setValid( true );              
+              
               tracks.push_back( track );
               ++number_of_tracks;
             }
@@ -133,3 +134,4 @@ CTPPSDiamondTrackRecognition::produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>
 
   return number_of_tracks;
 }
+

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
@@ -78,8 +78,10 @@ int
 CTPPSDiamondTrackRecognition::produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>& tracks )
 {
   int number_of_tracks = 0;
+  const double inv_resolution = 1./resolution_;
+
   for ( auto const& oot : hitParametersVectorMap_ ) {
-    std::vector<float> hit_profile( ( stopAtX_-startFromX_ )/resolution_, 0. );
+    std::vector<float> hit_profile( ( stopAtX_-startFromX_ ) * inv_resolution, 0. );
     for ( auto const& param : oot.second ) {
       hit_f_.SetParameters( param.center, param.width, sigma_ );
       for ( unsigned int i = 0; i < hit_profile.size(); ++i ) {
@@ -94,7 +96,7 @@ CTPPSDiamondTrackRecognition::produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>
     for ( unsigned int i = 0; i < hit_profile.size(); ++i ) {
       if ( below && hit_profile[i] >= threshold_ ) { // going above the threshold
         track_start_n = i;
-        maximum=0;
+        maximum = 0;
         below = false;
       }
       if ( !below ) {

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
@@ -117,8 +117,8 @@ CTPPSDiamondTrackRecognition::produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>
               below = true;
 
               //store track
-              math::XYZPoint pos0_sigma( ( j-track_start_n )*resolution_*0.5, yWidth_ * 0.5, 0. );
-              math::XYZPoint pos0( startFromX_ + track_start_n*resolution_ + pos0_sigma.X(), yPosition_, 0. );
+              math::XYZPoint pos0_sigma( ( j-track_start_n )*resolution_*0.5, yWidth_ * 0.5, zWidth_ * 0.5 );
+              math::XYZPoint pos0( startFromX_ + track_start_n*resolution_ + pos0_sigma.X(), yPosition_, zPosition_ );
               int mult_hits = 0;
               if ( mhMap_.find( oot.first ) != mhMap_.end() ) mult_hits = mhMap_[oot.first];
 

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
@@ -28,7 +28,7 @@ CTPPSDiamondTrackRecognition::CTPPSDiamondTrackRecognition( const edm::Parameter
   yWidthInitial_       ( iConfig.getParameter<double>( "yWidth" ) ),
   hit_f_( "hit_TF1_CTPPS", iConfig.getParameter<std::string>( "pixelEfficiencyFunction" ).c_str(), startFromX_, stopAtX_ )
 {
-  if (sigma_==0.0) {
+  if ( sigma_ == 0. ) {
     hit_f_ = TF1( "hit_TF1_CTPPS", pixelEfficiencyDefaultFunction_.c_str(), startFromX_, stopAtX_ ); // simple step function
   }
 }
@@ -58,15 +58,15 @@ CTPPSDiamondTrackRecognition::addHit( const CTPPSDiamondRecHit& recHit )
 {
   // store hit parameters
   hitParametersVectorMap_[recHit.getOOTIndex()].emplace_back( recHit.getX(), recHit.getXWidth() );
-  
-  // Check y
-  if ( yPosition_ == yPositionInitial_ and yWidth_ == yWidthInitial_ ) {
+
+  // check y
+  if ( yPosition_ == yPositionInitial_ && yWidth_ == yWidthInitial_ ) {
     yPosition_ = recHit.getY();
     yWidth_ = recHit.getYWidth();
   }
-  
-  // Check z
-  if ( zPosition_ == zPositionInitial_ and zWidth_ == zWidthInitial_ ) {
+
+  // check z
+  if ( zPosition_ == zPositionInitial_ && zWidth_ == zWidthInitial_ ) {
     zPosition_ = recHit.getZ();
     zWidth_ = recHit.getZWidth();
   }
@@ -82,7 +82,7 @@ CTPPSDiamondTrackRecognition::produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>
     std::vector<float> hit_profile( ( stopAtX_-startFromX_ )/resolution_, 0. );
     for ( auto const& param : oot.second ) {
       hit_f_.SetParameters( param.center, param.width, sigma_ );
-      for ( unsigned int i=0; i<hit_profile.size(); ++i ) {
+      for ( unsigned int i = 0; i < hit_profile.size(); ++i ) {
         hit_profile[i] += hit_f_.Eval( startFromX_ + i*resolution_ );
       }
     }
@@ -91,7 +91,7 @@ CTPPSDiamondTrackRecognition::produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>
     bool below = true; // start below the threshold
     int track_start_n = 0;
 
-    for ( unsigned int i=0; i<hit_profile.size(); ++i ) {
+    for ( unsigned int i = 0; i < hit_profile.size(); ++i ) {
       if ( below && hit_profile[i] >= threshold_ ) { // going above the threshold
         track_start_n = i;
         maximum=0;
@@ -106,7 +106,7 @@ CTPPSDiamondTrackRecognition::produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>
 
           // go back and use new threshold
           const float threshold = maximum - thresholdFromMaximum_;
-          for ( unsigned int j=track_start_n; j<=i; ++j ) {
+          for ( unsigned int j = track_start_n; j <= i; ++j ) {
             if ( below && hit_profile[j] >= threshold ) { // going above the threshold
               track_start_n = j;
               below = false;
@@ -121,8 +121,7 @@ CTPPSDiamondTrackRecognition::produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>
               if ( mhMap_.find( oot.first ) != mhMap_.end() ) mult_hits = mhMap_[oot.first];
 
               CTPPSDiamondLocalTrack track( pos0, pos0_sigma, 0., 0., 0., oot.first, mult_hits );
-              track.setValid( true );              
-              
+              track.setValid( true );
               tracks.push_back( track );
               ++number_of_tracks;
             }

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
@@ -58,7 +58,7 @@ CTPPSDiamondTrackRecognition::addHit( const CTPPSDiamondRecHit& recHit )
 {
   // store hit parameters
   hitParametersVectorMap_[recHit.getOOTIndex()].emplace_back( recHit.getX(), recHit.getXWidth() );
-  
+
   // Check y
   if ( yPosition_ == yPositionInitial_ and yWidth_ == yWidthInitial_ ) {
     yPosition_ = recHit.getY();
@@ -121,8 +121,7 @@ CTPPSDiamondTrackRecognition::produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>
               if ( mhMap_.find( oot.first ) != mhMap_.end() ) mult_hits = mhMap_[oot.first];
 
               CTPPSDiamondLocalTrack track( pos0, pos0_sigma, 0., 0., 0., oot.first, mult_hits );
-              track.setValid( true );              
-              
+              track.setValid( true );
               tracks.push_back( track );
               ++number_of_tracks;
             }

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
@@ -122,7 +122,7 @@ CTPPSDiamondTrackRecognition::produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>
               int mult_hits = 0;
               if ( mhMap_.find( oot.first ) != mhMap_.end() ) mult_hits = mhMap_[oot.first];
 
-              CTPPSDiamondLocalTrack track( pos0, pos0_sigma, 0., 0., 0., oot.first, mult_hits );
+              CTPPSDiamondLocalTrack track( pos0, pos0_sigma, 0., 0., oot.first, mult_hits );
               track.setValid( true );
               tracks.push_back( track );
               ++number_of_tracks;

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
@@ -47,6 +47,8 @@ CTPPSDiamondTrackRecognition::clear()
   mhMap_.clear();
   yPosition_ = yPositionInitial_;
   yWidth_ = yWidthInitial_;
+  zPosition_ = zPositionInitial_;
+  zWidth_ = zWidthInitial_;
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -56,21 +58,17 @@ CTPPSDiamondTrackRecognition::addHit( const CTPPSDiamondRecHit& recHit )
 {
   // store hit parameters
   hitParametersVectorMap_[recHit.getOOTIndex()].emplace_back( recHit.getX(), recHit.getXWidth() );
-
-  // Check vertical coordinates
+  
+  // Check y
   if ( yPosition_ == yPositionInitial_ and yWidth_ == yWidthInitial_ ) {
     yPosition_ = recHit.getY();
     yWidth_ = recHit.getYWidth();
   }
-
-  //Multiple hits in the RP
-  if ( recHit.getMultipleHits() ) {
-    if ( mhMap_.find( recHit.getOOTIndex() ) == mhMap_.end() ) {
-      mhMap_[recHit.getOOTIndex()] = 1;
-    }
-    else {
-      ++( mhMap_[recHit.getOOTIndex()] );
-    }
+  
+  // Check z
+  if ( zPosition_ == zPositionInitial_ and zWidth_ == zWidthInitial_ ) {
+    zPosition_ = recHit.getZ();
+    zWidth_ = recHit.getZWidth();
   }
 }
 
@@ -123,7 +121,8 @@ CTPPSDiamondTrackRecognition::produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>
               if ( mhMap_.find( oot.first ) != mhMap_.end() ) mult_hits = mhMap_[oot.first];
 
               CTPPSDiamondLocalTrack track( pos0, pos0_sigma, 0., 0., 0., oot.first, mult_hits );
-              track.setValid( true );
+              track.setValid( true );              
+              
               tracks.push_back( track );
               ++number_of_tracks;
             }

--- a/RecoCTPPS/TotemRPLocal/test/diamonds_reco_cfg.py
+++ b/RecoCTPPS/TotemRPLocal/test/diamonds_reco_cfg.py
@@ -27,7 +27,7 @@ process.source = cms.Source('NewEventStreamFileReader',
 )
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10)
+    input = cms.untracked.int32(-1)
 )
 
 # raw-to-digi conversion

--- a/RecoCTPPS/TotemRPLocal/test/diamonds_reco_cfg.py
+++ b/RecoCTPPS/TotemRPLocal/test/diamonds_reco_cfg.py
@@ -1,9 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-process = cms.Process("CTPPS")
 
-from Configuration.StandardSequences.Eras import eras
-
-process = cms.Process('RECODQM')
+process = cms.Process('CTPPS')
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -18,31 +15,17 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_hlt_relval', '')
 #process.source = cms.Source("NewEventStreamFileReader",
 #    fileNames = cms.untracked.vstring(
 #        '/store/t0streamer/Data/Physics/000/286/591/run286591_ls0521_streamPhysics_StorageManager.dat',
+#        '/store/t0streamer/Minidaq/A/000/303/982/run303982_ls0001_streamA_StorageManager.dat',
 #    )
 #)
 process.source = cms.Source('PoolSource',
     fileNames = cms.untracked.vstring(
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/001C958C-7FA9-E711-858F-02163E011A5F.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/00BA3B56-80A9-E711-8E7B-02163E01430D.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0219EE0A-C7A9-E711-9994-02163E0145B7.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/02362D0E-C7A9-E711-B61A-02163E014457.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/02412D74-83A9-E711-904C-02163E01A3F1.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/024405B7-74A9-E711-BC80-02163E019D96.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0417FFB5-79A9-E711-AEB4-02163E019D61.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/043E5522-C7A9-E711-96B9-02163E014360.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0653EC19-C7A9-E711-AF8F-02163E011918.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/08204734-6FA9-E711-8320-02163E01A2DD.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0A58360C-82A9-E711-A233-02163E013689.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0AA7DF3B-78A9-E711-A5EE-02163E019E85.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0C14A314-C7A9-E711-95BF-02163E013772.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0C61967B-89A9-E711-90E4-02163E0145A4.root',
-'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0C9104CF-8DA9-E711-B9E3-02163E019D0B.root',
-#/store/t0streamer/Minidaq/A/000/303/982/run303982_ls0001_streamA_StorageManager.dat',
-),
+        '/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/001C958C-7FA9-E711-858F-02163E011A5F.root',
+    ),
 )
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10000)
+    input = cms.untracked.int32(1000)
 )
 
 # raw-to-digi conversion
@@ -58,11 +41,6 @@ process.load('RecoCTPPS.TotemRPLocal.ctppsDiamondRecHits_cfi')
 # local tracks fitter
 process.load('RecoCTPPS.TotemRPLocal.ctppsDiamondLocalTracks_cfi')
 
-#process.ctppsDiamondLocalTracks.trackingAlgorithmParams.threshold = cms.double(1.5)
-#process.ctppsDiamondLocalTracks.trackingAlgorithmParams.sigma = cms.double(0)
-#process.ctppsDiamondLocalTracks.trackingAlgorithmParams.resolution = cms.double(0.025) # in mm
-#process.ctppsDiamondLocalTracks.trackingAlgorithmParams.pixel_efficiency_function = cms.string("(TMath::Erf((x-[0]+0.5*[1])/([2]/4)+2)+1)*TMath::Erfc((x-[0]-0.5*[1])/([2]/4)-2)/4")
-
 process.output = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string("file:AOD.root"),
     outputCommands = cms.untracked.vstring(
@@ -77,4 +55,5 @@ process.p = cms.Path(
     process.ctppsDiamondLocalReconstruction
 )
 
-process.outpath = cms.EndPath(process.output) 
+process.outpath = cms.EndPath(process.output)
+

--- a/RecoCTPPS/TotemRPLocal/test/diamonds_reco_cfg.py
+++ b/RecoCTPPS/TotemRPLocal/test/diamonds_reco_cfg.py
@@ -20,14 +20,29 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_hlt_relval', '')
 #        '/store/t0streamer/Data/Physics/000/286/591/run286591_ls0521_streamPhysics_StorageManager.dat',
 #    )
 #)
-process.source = cms.Source('NewEventStreamFileReader',
+process.source = cms.Source('PoolSource',
     fileNames = cms.untracked.vstring(
-'/store/t0streamer/Minidaq/A/000/303/982/run303982_ls0001_streamA_StorageManager.dat',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/001C958C-7FA9-E711-858F-02163E011A5F.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/00BA3B56-80A9-E711-8E7B-02163E01430D.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0219EE0A-C7A9-E711-9994-02163E0145B7.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/02362D0E-C7A9-E711-B61A-02163E014457.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/02412D74-83A9-E711-904C-02163E01A3F1.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/024405B7-74A9-E711-BC80-02163E019D96.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0417FFB5-79A9-E711-AEB4-02163E019D61.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/043E5522-C7A9-E711-96B9-02163E014360.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0653EC19-C7A9-E711-AF8F-02163E011918.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/08204734-6FA9-E711-8320-02163E01A2DD.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0A58360C-82A9-E711-A233-02163E013689.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0AA7DF3B-78A9-E711-A5EE-02163E019E85.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0C14A314-C7A9-E711-95BF-02163E013772.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0C61967B-89A9-E711-90E4-02163E0145A4.root',
+'/store/data/Run2017E/ZeroBias/RAW/v1/000/304/447/00000/0C9104CF-8DA9-E711-B9E3-02163E019D0B.root',
+#/store/t0streamer/Minidaq/A/000/303/982/run303982_ls0001_streamA_StorageManager.dat',
 ),
 )
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
+    input = cms.untracked.int32(10000)
 )
 
 # raw-to-digi conversion

--- a/RecoCTPPS/TotemRPLocal/test/diamonds_reco_cfg.py
+++ b/RecoCTPPS/TotemRPLocal/test/diamonds_reco_cfg.py
@@ -1,14 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 process = cms.Process("CTPPS")
 
-# minimum of logs
-#process.MessageLogger = cms.Service("MessageLogger",
-#    statistics = cms.untracked.vstring(),
-#    destinations = cms.untracked.vstring('cerr'),
-#    cerr = cms.untracked.PSet(
-#        threshold = cms.untracked.string('WARNING')
-#    )
-#)
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process('RECODQM')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_hlt_relval', '')
 
 # raw data source
 #process.source = cms.Source("NewEventStreamFileReader",
@@ -16,22 +20,29 @@ process = cms.Process("CTPPS")
 #        '/store/t0streamer/Data/Physics/000/286/591/run286591_ls0521_streamPhysics_StorageManager.dat',
 #    )
 #)
-process.source = cms.Source('PoolSource',
+process.source = cms.Source('NewEventStreamFileReader',
     fileNames = cms.untracked.vstring(
-        'root://eoscms.cern.ch:1094//eos/totem/data/ctpps/run284036.root',
-    ),
+'/store/t0streamer/Minidaq/A/000/303/982/run303982_ls0001_streamA_StorageManager.dat',
+),
 )
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1000)
+    input = cms.untracked.int32(10)
 )
 
 # raw-to-digi conversion
-process.load('EventFilter.CTPPSRawToDigi.ctppsDiamondRawToDigi_cfi')
+process.load("EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff")
 
+# local RP reconstruction chain with standard settings
+process.load("RecoCTPPS.Configuration.recoCTPPS_cff")
+
+# rechits production
 process.load('Geometry.VeryForwardGeometry.geometryRP_cfi')
+process.load('RecoCTPPS.TotemRPLocal.ctppsDiamondRecHits_cfi')
 
-process.load('RecoCTPPS.TotemRPLocal.ctppsDiamondLocalReconstruction_cff')
+# local tracks fitter
+process.load('RecoCTPPS.TotemRPLocal.ctppsDiamondLocalTracks_cfi')
+
 #process.ctppsDiamondLocalTracks.trackingAlgorithmParams.threshold = cms.double(1.5)
 #process.ctppsDiamondLocalTracks.trackingAlgorithmParams.sigma = cms.double(0)
 #process.ctppsDiamondLocalTracks.trackingAlgorithmParams.resolution = cms.double(0.025) # in mm


### PR DESCRIPTION
This PR amends the Diamond detector's rechits and local tracks data formats definition (and associated producers) to include the z-coordinate and a time precision container for future calibration developments.
Additionally, an extra check on a leading/trailing edges association is performed on hits collection before building the local tracks, reflecting DAQ-level optimisations performed during 2017 data-taking.
Finally, a helper public method is added to the `CTPPSDiamondLocalTrack` object to retrieve the association between a track and rechits.