### PR TITLE
Add duplicate rate vs. sim PV z, and update plotting

### DIFF
--- a/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
+++ b/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
@@ -227,7 +227,7 @@ class MTVHistoProducerAlgoForTracker {
 
   std::vector<MonitorElement*> h_reco_dzpvcut_pt, h_assoc_dzpvcut_pt, h_assoc2_dzpvcut_pt, h_simul_dzpvcut_pt, h_simul2_dzpvcut_pt, h_pileup_dzpvcut_pt;
   std::vector<MonitorElement*> h_reco_dzpvsigcut_pt, h_assoc_dzpvsigcut_pt, h_assoc2_dzpvsigcut_pt, h_simul_dzpvsigcut_pt, h_simul2_dzpvsigcut_pt, h_pileup_dzpvsigcut_pt;
-  std::vector<MonitorElement*> h_reco_simpvz, h_assoc_simpvz, h_assoc2_simpvz, h_simul_simpvz, h_pileup_simpvz;
+  std::vector<MonitorElement*> h_reco_simpvz, h_assoc_simpvz, h_assoc2_simpvz, h_simul_simpvz, h_looper_simpvz, h_pileup_simpvz;
 
   std::vector<MonitorElement*> h_reco_seedingLayerSet, h_assoc2_seedingLayerSet, h_looper_seedingLayerSet, h_pileup_seedingLayerSet;
 

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -129,6 +129,7 @@ postProcessorTrack = DQMEDHarvester("DQMGenericClient",
 
     "effic_vs_simpvz 'Efficiency vs. sim PV z' num_assoc(simToReco)_simpvz num_simul_simpvz",
     "fakerate_vs_simpvz 'Fake rate vs. sim PV z' num_assoc(recoToSim)_simpvz num_reco_simpvz fake",
+    "duplicatesRate_simpvz 'Duplicates Rate vs sim PV z' num_duplicate_simpvz num_reco_simpvz",
     "pileuprate_simpvz 'Pileup rate vs. sim PV z' num_pileup_simpvz num_reco_simpvz",
 
     "fakerate_vs_mva1 'Fake rate vs. MVA1' num_assoc(recoToSim)_mva1 num_reco_mva1 fake",

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -32,6 +32,8 @@ _maxLayers = [5, 10, 25]
 _maxPixelLayers = 8
 _min3DLayers = [0, 5, 10]
 _max3DLayers = [5, 10, 20]
+_minZ = [-60, -40, -20, -10, -5]
+_maxZ = [5, 10, 20, 40, 60]
 _minPU = [0, 10, 20, 50, 100, 150]
 _maxPU = [20, 50, 65, 80, 100, 150, 200, 250]
 _minMaxTracks = [0, 200, 500, 1000, 1500, 2000]
@@ -204,13 +206,18 @@ _effandfakeHitsLayers = PlotGroup("effandfakeHitsLayers",
                                   legendDy=_legendDy_4rows
 )
 _common = {"ymin": 0, "ymax": _maxEff}
-_effandfakePosDeltaRPU = PlotGroup("effandfakePosDeltaRPU",
-                                   _makeEffFakeDupPlots("vertpos", "vert r", "cm", fakeopts=dict(xtitle="track ref. point r (cm)", ytitle="fake+duplicates vs. r"), common=dict(xlog=True)) +
-                                   _makeEffFakeDupPlots("zpos"   , "vert z", "cm", fakeopts=dict(xtitle="track ref. point z (cm)", ytitle="fake+duplicates vs. z")) +
-                                   _makeEffFakeDupPlots("dr"     , "#DeltaR", effopts=dict(xtitle="TP min #DeltaR"), fakeopts=dict(xtitle="track min #DeltaR"), common=dict(xlog=True)) +
-                                   _makeEffFakeDupPlots("pu"     , "PU"     , common=dict(xtitle="Pileup", xmin=_minPU, xmax=_maxPU)),
-                                   legendDy=_legendDy_4rows
+_effandfakePos = PlotGroup("effandfakePos",
+                           _makeEffFakeDupPlots("vertpos", "vert r", "cm", fakeopts=dict(xtitle="track ref. point r (cm)", ytitle="fake+duplicates vs. r"), common=dict(xlog=True)) +
+                           _makeEffFakeDupPlots("zpos"   , "vert z", "cm", fakeopts=dict(xtitle="track ref. point z (cm)", ytitle="fake+duplicates vs. z")) +
+                           _makeEffFakeDupPlots("simpvz" , "Sim. PV z", "cm", common=dict(xtitle="Sim. PV z (cm)", xmin=_minZ, xmax=_maxZ))
 )
+_effandfakeDeltaRPU = PlotGroup("effandfakeDeltaRPU",
+                                _makeEffFakeDupPlots("dr"     , "#DeltaR", effopts=dict(xtitle="TP min #DeltaR"), fakeopts=dict(xtitle="track min #DeltaR"), common=dict(xlog=True)) +
+                                _makeEffFakeDupPlots("pu"     , "PU"     , common=dict(xtitle="Pileup", xmin=_minPU, xmax=_maxPU)),
+                                legendDy=_legendDy_2rows
+)
+
+
 _algos_common = dict(removeEmptyBins=True, xbinlabelsize=10, xbinlabeloption="d")
 _duplicateAlgo = PlotOnSideGroup("duplicateAlgo", Plot("duplicates_oriAlgo_vs_oriAlgo", drawStyle="COLZ", adjustMarginLeft=0.1, adjustMarginRight=0.1, **_algos_common))
 
@@ -243,12 +250,16 @@ _dupandfakeHitsLayers = PlotGroup("dupandfakeHitsLayers",
                                   _makeFakeDupPileupPlots("3Dlayer"   , "3D layers"   , common=dict(xmin=_min3DLayers, xmax=_max3DLayers)),
                                   ncols=3, legendDy=_legendDy_4rows
 )
-_dupandfakePosDeltaRPU = PlotGroup("dupandfakePosDeltaRPU",
-                                   _makeFakeDupPileupPlots("vertpos", "r", "cm", xquantity="ref. point r (cm)", common=dict(xlog=True)) +
-                                   _makeFakeDupPileupPlots("zpos"   , "z", "cm", xquantity="ref. point z (cm)") +
-                                   _makeFakeDupPileupPlots("dr"     , "#DeltaR", xquantity="min #DeltaR", common=dict(xlog=True)) +
-                                   _makeFakeDupPileupPlots("pu"     , "PU"     , xtitle="Pileup", common=dict(xmin=_minPU, xmax=_maxPU)),
-                                   ncols=3, legendDy=_legendDy_4rows
+_dupandfakePos = PlotGroup("dupandfakePos",
+                           _makeFakeDupPileupPlots("vertpos", "r", "cm", xquantity="ref. point r (cm)", common=dict(xlog=True)) +
+                           _makeFakeDupPileupPlots("zpos"   , "z", "cm", xquantity="ref. point z (cm)") +
+                           _makeFakeDupPileupPlots("simpvz" , "Sim. PV z", xtitle="Sim. PV z (cm)", common=dict(xmin=_minZ, xmax=_maxZ)),
+                           ncols=3,
+)
+_dupandfakeDeltaRPU = PlotGroup("dupandfakeDeltaRPU",
+                                _makeFakeDupPileupPlots("dr"     , "#DeltaR", xquantity="min #DeltaR", common=dict(xlog=True)) +
+                                _makeFakeDupPileupPlots("pu"     , "PU"     , xtitle="Pileup", common=dict(xmin=_minPU, xmax=_maxPU)),
+                                ncols=3, legendDy=_legendDy_2rows_3cols
 )
 _seedingLayerSet_common = dict(removeEmptyBins=True, xbinlabelsize=8, xbinlabeloption="d", adjustMarginRight=0.1)
 _dupandfakeSeedingPlots = _makeFakeDupPileupPlots("seedingLayerSet", "seeding layers", xtitle="", common=_seedingLayerSet_common)
@@ -411,8 +422,9 @@ _extDistHitsLayers = PlotGroup("distHitsLayers",
 _extDistPosDeltaR = PlotGroup("distPosDeltaR",
                               _makeDistPlots("vertpos", "ref. point r (cm)", common=dict(xlog=True)) +
                               _makeDistPlots("zpos"   , "ref. point z (cm)") +
+                              _makeDistPlots("simpvz" , "Sim. PV z (cm)", common=dict(xmin=_minZ, xmax=_maxZ)) +
                               _makeDistPlots("dr"     , "min #DeltaR", common=dict(xlog=True)),
-                              ncols=4
+                              ncols=4, legendDy=_legendDy_4rows,
 )
 _extDistSeedingPlots = _makeDistPlots("seedingLayerSet", "seeding layers", common=dict(xtitle="", **_seedingLayerSet_common))
 _extDistChi2Seeding = PlotGroup("distChi2Seeding",
@@ -477,8 +489,9 @@ _extDistSimHitsLayers = PlotGroup("distsimHitsLayers",
 _extDistSimPosDeltaR = PlotGroup("distsimPosDeltaR",
                                  _makeDistSimPlots("vertpos", "vert r (cm)", common=dict(xlog=True)) +
                                  _makeDistSimPlots("zpos"   , "vert z (cm)") +
+                                 _makeDistSimPlots("simpvz" , "Sim. PV z (cm)", common=dict(xmin=_minZ, xmax=_maxZ)) +
                                  _makeDistSimPlots("dr"     , "min #DeltaR", common=dict(xlog=True)),
-                                 ncols=2
+                                 ncols=2, legendDy=_legendDy_4rows,
 )
 
 ########################################
@@ -1166,7 +1179,8 @@ _simBasedPlots = [
     _effandfakeDxyDzBS,
     _effandfakeDxyDzPV,
     _effandfakeHitsLayers,
-    _effandfakePosDeltaRPU,
+    _effandfakePos,
+    _effandfakeDeltaRPU,
     _duplicateAlgo,
 ]
 _recoBasedPlots = [
@@ -1174,7 +1188,8 @@ _recoBasedPlots = [
     _dupandfakeDxyDzBS,
     _dupandfakeDxyDzPV,
     _dupandfakeHitsLayers,
-    _dupandfakePosDeltaRPU,
+    _dupandfakePos,
+    _dupandfakeDeltaRPU,
     _dupandfakeChi2Seeding,
     _dupandfakeSeedingTable,
     _pvassociation1,
@@ -1193,7 +1208,8 @@ _seedingBuildingPlots = _simBasedPlots + [
     _dupandfakeDxyDzBS,
     _dupandfakeDxyDzPV,
     _dupandfakeHitsLayers,
-    _dupandfakePosDeltaRPU,
+    _dupandfakePos,
+    _dupandfakeDeltaRPU,
     _dupandfakeChi2Seeding,
     _dupandfakeSeedingTable,
     _hitsAndPt,

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -308,6 +308,10 @@ _globalTags = {
     "CMSSW_9_4_0_pre3_phase1": {"default": "94X_mc2017_realistic_v4",
                                 "fullsim_25ns_PU50": "94X_mc2017_realistic_v4_highPU_AVE50",
                                 "Design": "94X_mc2017_design_IdealBS_v4"},
+    "CMSSW_9_4_0": {"default": "94X_mcRun2_asymptotic_v0"},
+    "CMSSW_9_4_0_phase1": {"default": "94X_mc2017_realistic_v10",
+                           "fullsim_25ns_PU50": "94X_mc2017_realistic_v10_highPU_AVE50",
+                           "Design": "94X_mc2017_design_IdealBS_v5"},
 }
 
 _releasePostfixes = ["_AlcaCSA14", "_PHYS14", "_TEST", "_v2", "_v3", "_pmx", "_Fall14DR", "_FIXGT", "_PU", "_PXbest", "_PXworst", "_hcal", "_tec", "_71XGENSIM", "_73XGENSIM", "_BS", "_GenSim_7113", "_extended",

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -571,6 +571,7 @@ void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::IBooker& ibook, bo
 
   h_reco_simpvz.push_back( ibook.book1D("num_reco_simpvz", "N of reco track vs. sim PV z", nintPVz, minPVz, maxPVz) );
   h_assoc2_simpvz.push_back( ibook.book1D("num_assoc(recoToSim)_simpvz", "N of associated tracks (recoToSim) vs. sim PV z", nintPVz, minPVz, maxPVz) );
+  h_looper_simpvz.push_back( ibook.book1D("num_duplicate_simpvz", "N of associated (recoToSim) looper tracks vs. sim PV z", nintPVz, minPVz, maxPVz) );
   h_pileup_simpvz.push_back( ibook.book1D("num_pileup_simpvz", "N of associated (recoToSim) pileup tracks vs. sim PV z", nintPVz, minPVz, maxPVz) );
 
   h_recochi2.push_back( ibook.book1D("num_reco_chi2","N of reco track vs normalized #chi^{2}",nintChi2,minChi2,maxChi2) );
@@ -1242,6 +1243,9 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
           fillPlotNoFlow(h_looperdzpv[count], dzpv);
           fillPlotNoFlow(h_looperdxypvzoomed[count], dxypv);
           fillPlotNoFlow(h_looperdzpvzoomed[count], dzpv);
+        }
+        if(simPVPosition) {
+          h_looper_simpvz[count]->Fill(simpvz);
         }
       }
       fillPlotNoFlow(h_looperhit[count], nhits);

--- a/Validation/RecoTrack/test/trackingPerformanceValidation.py
+++ b/Validation/RecoTrack/test/trackingPerformanceValidation.py
@@ -9,10 +9,10 @@ import Validation.RecoVertex.plotting.vertexPlots as vertexPlots
 ########### User Defined Variables (BEGIN) ##############
 
 ### Reference release
-RefRelease='CMSSW_9_4_0_pre2_phase1'
+RefRelease='CMSSW_9_4_0_pre3_phase1'
 
 ### Relval release (set if different from $CMSSW_VERSION)
-NewRelease='CMSSW_9_4_0_pre3_phase1'
+NewRelease='CMSSW_9_4_0_phase1'
 
 ### This is the list of IDEAL-conditions relvals 
 startupsamples_run1 = [


### PR DESCRIPTION
This PR adds the "plots vs. sim PV z" (added in #16212) the the plotting infrastructure, and also adds the duplicates vs. sim PV z for completeness (was intentionally omitted in #16212).

Tested in 10_0_0_pre1, no changes expected in existing histograms.

@VinInn @hajohajo