### PR TITLE
[10.0.x] remove memory leak in PVValidation and fix ini file

### DIFF
--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -814,11 +814,10 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	      int L1BPixHitCount = 0;
 
 	      for (trackingRecHit_iterator iHit = theTrack.recHitsBegin(); iHit != theTrack.recHitsEnd(); ++iHit) {
-		TrackingRecHit* hit = (*iHit)->clone();
-		const DetId& detId = hit->geographicalId();
+		const DetId& detId = (*iHit)->geographicalId();
 		unsigned int subid = detId.subdetId();
 		
-		if(hit->isValid() && ( subid == PixelSubdetector::PixelBarrel ) ) {
+		if((*iHit)->isValid() && ( subid == PixelSubdetector::PixelBarrel ) ) {
 		  int layer = tTopo->pxbLayer(detId);
 		  if(layer==1){
 		    L1BPixHitCount+=1;
@@ -826,7 +825,6 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 		    module_num = tTopo->pxbModule(detId);
 		  }
 		}
-		delete hit;
 	      }
 
 	      h_probeL1Ladder_->Fill(ladder_num);

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -824,6 +824,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 		    module_num = tTopo->pxbModule(detId);
 		  }
 		}
+		delete hit;
 	      }
 
 	      h_probeL1Ladder_->Fill(ladder_num);

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -186,6 +186,8 @@ PrimaryVertexValidation::~PrimaryVertexValidation()
 {
    // do anything here that needs to be done at desctruction time
    // (e.g. close files, deallocate resources etc.)
+  if (theTrackFilter_) delete theTrackFilter_;
+  if (theTrackClusterizer_) delete theTrackClusterizer_;
 }
 
 

--- a/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
+++ b/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
@@ -12,31 +12,31 @@ datadir = /afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/data/commonValidation/r
 ###############################################################################
 # configuration of several alignments
 
-[alignment:2016_mc]
+[alignment:mc_2016]
 title= 2016 MC
 globaltag = auto:run2_mc
 color = kBlack
 style = kOpenCircle
 
-[alignment:2016_data]
+[alignment:data_2016]
 title= 2016 data
 globaltag = auto:run2_data
 color = kRed
 style = kFullSquare
 
-[alignment:2017_mc]
+[alignment:mc_2017]
 title= 2017 MC
 globaltag = auto:phase1_2017_realistic
 color = kBlue
 style = kFullTriangleDown
 
-[alignment:2017_mc_bpixonly]
+[alignment:mc_2017_bpixonly]
 title= 2017 MC BPix
 globaltag = auto:phase1_2017_realistic
 color = kMagenta
 style = kOpenTriangleDown
 
-[alignment:2017_mc_Ideal]
+[alignment:mc_2017_Ideal]
 title= 2017 MC Ideal
 globaltag = auto:phase1_2017_design
 condition TrackerAlignmentRcd = frontier://FrontierProd/CMS_CONDITIONS,TrackerAlignment_Upgrade2017_design_v4
@@ -45,7 +45,7 @@ condition BeamSpotObjectsRcd  = frontier://FrontierProd/CMS_CONDITIONS,BeamSpotO
 color = kCyan
 style = kOpenSquare
 
-[alignment:2017_data]
+[alignment:data_2017]
 title= 2017 Data
 globaltag = auto:run2_data_promptlike
 color = kBlack
@@ -160,11 +160,11 @@ runControl = True
 # configure which validation to run on which alignment
 
 [validation]
-primaryvertex phase0MC    : 2016_mc 
-primaryvertex run2016data : 2016_data
-primaryvertex phaseIMC    : 2017_mc
-primaryvertex run2017data : 2017_data
-primaryvertex phaseIMC_BPixOnly : 2017_mc_bpixonly
-primaryvertex phaseIMC    : 2017_mc_Ideal
+primaryvertex phase0MC    : mc_2016 
+primaryvertex run2016data : data_2016
+primaryvertex phaseIMC    : mc_2016
+primaryvertex run2017data : data_2017
+primaryvertex phaseIMC_BPixOnly : mc_2017_bpixonly
+primaryvertex phaseIMC    : mc_2017_Ideal
 
 


### PR DESCRIPTION
The purpose of this PR is to remove the large memory leak introduced in https://github.com/cms-sw/cmssw/commit/c3db41b36a71506952bcb7792e74b1c4a2beeba7.
As the cloned recHit was not destroyed after being used, running over a large sample of data was resulting in jobs killed because of memory exhaustion. 
For comparison here is the RSS performance measured by running over 10k events of run 305967 of `/HLTPhysics/Run2017F-TkAlMinBias-PromptReco-v1/ALCARECO`

![alltrends_vs_cmssw_10_0_0_pre1_vs_this_fix](https://user-images.githubusercontent.com/5082376/33127311-422969ee-cf88-11e7-907a-ebb8d302301f.png)

I profit of this PR also to clean-up two other (relatively minor) memory leaks as well as to change the nomenclature in the example ini file, which is now broken due to https://github.com/cms-sw/cmssw/pull/21160/commits/fb077407e1e23fcb62a5dc8e30e0f61e339d4028.
