### PR TITLE
Moving off obsolete trajectory cleaner in 1st step of HI tracking

### DIFF
--- a/RecoHI/HiTracking/python/HICkfTrackCandidates_cff.py
+++ b/RecoHI/HiTracking/python/HICkfTrackCandidates_cff.py
@@ -18,7 +18,6 @@ CkfTrajectoryBuilder.alwaysUseInvalidHits = False #default is true
 ### primary track candidates
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 hiPrimTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-	TrajectoryCleaner = 'TrajectoryCleanerBySharedSeeds',
 	TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('CkfTrajectoryBuilder')), #instead of GroupedCkfTrajectoryBuilder
 	src = 'hiPixelTrackSeeds', 
 	RedundantSeedCleaner = 'none',


### PR DESCRIPTION
It was brought to my attention here that the 1st iteration of the HI tracking is using a somewhat dated version of the track trajectory cleaner:
https://hypernews.cern.ch/HyperNews/CMS/get/recoTracking/1736.html

This PR changes this iteration to pick up the current default in RecoTracker.CkfPattern.CkfTrackCandidates_cfi.py.  Testing showed basically no change to the track distributions and timing.  A small amount of tracks migrate from being found in later iterations to the 1st iteration.