### PR TITLE
Use of effective pedestals for HCAL Phase1/Phase2 reco

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
@@ -74,8 +74,8 @@ class HcalDbHardcode {
     const HcalHardcodeParameters& getParameters(HcalGenericDetId fId);
     const int getGainIndex(HcalGenericDetId fId);
     const bool killHE() const { return killHE_; }
-    HcalPedestal makePedestal (HcalGenericDetId fId, bool fSmear = false);
-    HcalPedestalWidth makePedestalWidth (HcalGenericDetId fId);
+    HcalPedestal makePedestal (HcalGenericDetId fId, bool fSmear, bool eff, const HcalTopology* topo, double intlumi);
+    HcalPedestalWidth makePedestalWidth (HcalGenericDetId fId, bool eff, const HcalTopology* topo, double intlumi);
     HcalGain makeGain (HcalGenericDetId fId, bool fSmear = false);
     HcalGainWidth makeGainWidth (HcalGenericDetId fId);
     HcalQIECoder makeQIECoder (HcalGenericDetId fId);

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
@@ -2044,8 +2044,11 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalTPParameters& f
 
 bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalCalibrationsSet& fObject) {
   char buffer [1024];
-  sprintf (buffer, "# %15s %15s %15s %15s %8s %8s %8s %8s %8s %8s %8s %8s %10s\n", 
-    "eta", "phi", "dep", "det", "pedcap0", "pedcap1", "pedcap2", "pedcap3", "gaincap0", "gaincap1", "gaincap2", "gaincap3", "DetId");
+  sprintf (buffer, "# %15s %15s %15s %15s %8s %8s %8s %8s %11s %11s %11s %11s %9s %9s %9s %9s %10s\n", 
+    "eta", "phi", "dep", "det",
+    "pedcap0", "pedcap1", "pedcap2", "pedcap3", 
+    "effpedcap0", "effpedcap1", "effpedcap2", "effpedcap3",
+    "gaincap0", "gaincap1", "gaincap2", "gaincap3", "DetId");
   fOutput << buffer;
 
   std::vector<DetId> channels = fObject.getAllChannels ();
@@ -2053,8 +2056,9 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalCalibrationsSet
   for (std::vector<DetId>::iterator channel = channels.begin (); channel != channels.end (); ++channel) {
     dumpId (fOutput, *channel);
     const HcalCalibrations& values = fObject.getCalibrations(*channel);
-    sprintf (buffer, " %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %10X\n",
+    sprintf (buffer, " %8.5f %8.5f %8.5f %8.5f %11.5f %11.5f %11.5f %11.5f %9.5f %9.5f %9.5f %9.5f %10X\n",
       values.pedestal(0), values.pedestal(1), values.pedestal(2), values.pedestal(3),
+      values.effpedestal(0), values.effpedestal(1), values.effpedestal(2), values.effpedestal(3),
       values.respcorrgain(0), values.respcorrgain(1), values.respcorrgain(2), values.respcorrgain(3), channel->rawId ());
     fOutput << buffer;
   }
@@ -2063,8 +2067,11 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalCalibrationsSet
 
 bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalCalibrationWidthsSet& fObject) {
   char buffer [1024];
-  sprintf (buffer, "# %15s %15s %15s %15s %8s %8s %8s %8s %9s %9s %9s %9s %10s\n", 
-    "eta", "phi", "dep", "det", "pedwcap0", "pedwcap1", "pedwcap2", "pedwcap3", "gainwcap0", "gainwcap1", "gainwcap2", "gainwcap3", "DetId");
+  sprintf (buffer, "# %15s %15s %15s %15s %9s %9s %9s %9s %12s %12s %12s %12s %10s %10s %10s %10s %10s\n", 
+    "eta", "phi", "dep", "det",
+    "pedwcap0", "pedwcap1", "pedwcap2", "pedwcap3",
+    "effpedwcap0", "effpedwcap1", "effpedwcap2", "effpedwcap3",
+    "gainwcap0", "gainwcap1", "gainwcap2", "gainwcap3", "DetId");
   fOutput << buffer;
 
   std::vector<DetId> channels = fObject.getAllChannels ();
@@ -2072,8 +2079,9 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalCalibrationWidt
   for (std::vector<DetId>::iterator channel = channels.begin (); channel != channels.end (); ++channel) {
     dumpId (fOutput, *channel);
     const HcalCalibrationWidths& values = fObject.getCalibrationWidths(*channel);
-    sprintf (buffer, " %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %10X\n",
+    sprintf (buffer, " %9.5f %9.5f %9.5f %9.5f %12.5f %12.5f %12.5f %12.5f %10.5f %10.5f %10.5f %10.5f %10X\n",
       values.pedestal(0), values.pedestal(1), values.pedestal(2), values.pedestal(3),
+      values.effpedestal(0), values.effpedestal(1), values.effpedestal(2), values.effpedestal(3),
       values.gain(0), values.gain(1), values.gain(2), values.gain(3), channel->rawId ());
     fOutput << buffer;
   }

--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -168,6 +168,8 @@ _toGet = [
     'Gains',
     'Pedestals',
     'PedestalWidths',
+    'EffectivePedestals',
+    'EffectivePedestalWidths',
     'ChannelQuality',
     'ZSThresholds',
     'TimeCorrs',

--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
@@ -166,7 +166,7 @@ void HcalDbProducer::pedestalWidthsCallback (const HcalPedestalWidthsRcd& fRecor
   const HcalTopology* topo=&(*htopo);
   mPedestalWidths->setTopo(topo);
 
-  mService->setData (mEffectivePedestalWidths.get());
+  mService->setData (mPedestalWidths.get());
   if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("PedestalWidths")) != mDumpRequest.end()) {
     *mDumpStream << "New HCAL PedestalWidths set" << std::endl;
     HcalDbASCIIIO::dumpObject (*mDumpStream, *(mPedestalWidths));

--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
@@ -66,13 +66,12 @@ HcalDbProducer::HcalDbProducer( const edm::ParameterSet& fConfig)
 			  &HcalDbProducer::TPChannelParametersCallback &
 			  &HcalDbProducer::TPParametersCallback &
 			  &HcalDbProducer::lutMetadataCallback &
-			  &HcalDbProducer::MCParamsCallback
+			  &HcalDbProducer::MCParamsCallback &
+              &HcalDbProducer::effectivePedestalsCallback &
+              &HcalDbProducer::effectivePedestalWidthsCallback
 			  )
 		   );
 
-  setWhatProduced(this, (dependsOn (&HcalDbProducer::effectivePedestalsCallback) &
-			  &HcalDbProducer::effectivePedestalWidthsCallback
-			  ), edm::es::Label("effective"));
   setWhatProduced(this, &HcalDbProducer::produceChannelQualityWithTopo, edm::es::Label("withTopo"));
   //now do what ever other initialization is needed
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.h
@@ -43,6 +43,8 @@ class HcalDbProducer : public edm::ESProducer {
   // callbacks
   void pedestalsCallback (const HcalPedestalsRcd& fRecord);
   void pedestalWidthsCallback (const HcalPedestalWidthsRcd& fRecord);
+  void effectivePedestalsCallback (const HcalPedestalsRcd& fRecord);
+  void effectivePedestalWidthsCallback (const HcalPedestalWidthsRcd& fRecord);
   void gainsCallback (const HcalGainsRcd& fRecord);
   void gainWidthsCallback (const HcalGainWidthsRcd& fRecord);
   void QIEDataCallback (const HcalQIEDataRcd& fRecord);
@@ -71,6 +73,8 @@ private:
 
   std::unique_ptr<HcalPedestals> mPedestals;
   std::unique_ptr<HcalPedestalWidths> mPedestalWidths;
+  std::unique_ptr<HcalPedestals> mEffectivePedestals;
+  std::unique_ptr<HcalPedestalWidths> mEffectivePedestalWidths;
   std::unique_ptr<HcalGains> mGains;
   std::unique_ptr<HcalGainWidths> mGainWidths;
   std::unique_ptr<HcalQIEData> mQIEData;

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -183,120 +183,120 @@ HcalHardcodeCalibrations::HcalHardcodeCalibrations ( const edm::ParameterSet& iC
   }
 
   std::vector <std::string> toGet = iConfig.getUntrackedParameter <std::vector <std::string> > ("toGet");
-  for(std::vector <std::string>::iterator objectName = toGet.begin(); objectName != toGet.end(); ++objectName ) {
-    bool all = *objectName == "all";
+  for(auto& objectName : toGet){
+    bool all = objectName == "all";
 #ifdef DebugLog
-    std::cout << "Load parameters for " << *objectName << std::endl;
+    std::cout << "Load parameters for " << objectName << std::endl;
 #endif
-    if ((*objectName == "Pedestals") || all) {
+    if ((objectName == "Pedestals") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::producePedestals);
       findingRecord <HcalPedestalsRcd> ();
     }
-    if ((*objectName == "PedestalWidths") || all) {
+    if ((objectName == "PedestalWidths") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::producePedestalWidths);
       findingRecord <HcalPedestalWidthsRcd> ();
     }
-    if ((*objectName == "Gains") || all) {
+    if ((objectName == "Gains") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceGains);
       findingRecord <HcalGainsRcd> ();
     }
-    if ((*objectName == "GainWidths") || all) {
+    if ((objectName == "GainWidths") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceGainWidths);
       findingRecord <HcalGainWidthsRcd> ();
     }
-    if ((*objectName == "QIEData") || all) {
+    if ((objectName == "QIEData") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceQIEData);
       findingRecord <HcalQIEDataRcd> ();
     }
-    if ((*objectName == "QIETypes") || all) {
+    if ((objectName == "QIETypes") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceQIETypes);
       findingRecord <HcalQIETypesRcd> ();
     }
-    if ((*objectName == "ChannelQuality") || (*objectName == "channelQuality") || all) {
+    if ((objectName == "ChannelQuality") || (objectName == "channelQuality") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceChannelQuality);
       findingRecord <HcalChannelQualityRcd> ();
     }
-    if ((*objectName == "ElectronicsMap") || (*objectName == "electronicsMap") || all) {
+    if ((objectName == "ElectronicsMap") || (objectName == "electronicsMap") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceElectronicsMap);
       findingRecord <HcalElectronicsMapRcd> ();
     }
-    if ((*objectName == "ZSThresholds") || (*objectName == "zsThresholds") || all) {
+    if ((objectName == "ZSThresholds") || (objectName == "zsThresholds") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceZSThresholds);
       findingRecord <HcalZSThresholdsRcd> ();
     }
-    if ((*objectName == "RespCorrs") || (*objectName == "ResponseCorrection") || all) {
+    if ((objectName == "RespCorrs") || (objectName == "ResponseCorrection") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceRespCorrs);
       findingRecord <HcalRespCorrsRcd> ();
     }
-    if ((*objectName == "LUTCorrs") || (*objectName == "LUTCorrection") || all) {
+    if ((objectName == "LUTCorrs") || (objectName == "LUTCorrection") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceLUTCorrs);
       findingRecord <HcalLUTCorrsRcd> ();
     }
-    if ((*objectName == "PFCorrs") || (*objectName == "PFCorrection") || all) {
+    if ((objectName == "PFCorrs") || (objectName == "PFCorrection") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::producePFCorrs);
       findingRecord <HcalPFCorrsRcd> ();
     }
-    if ((*objectName == "TimeCorrs") || (*objectName == "TimeCorrection") || all) {
+    if ((objectName == "TimeCorrs") || (objectName == "TimeCorrection") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceTimeCorrs);
       findingRecord <HcalTimeCorrsRcd> ();
     }
-    if ((*objectName == "L1TriggerObjects") || (*objectName == "L1Trigger") || all) {
+    if ((objectName == "L1TriggerObjects") || (objectName == "L1Trigger") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceL1TriggerObjects);
       findingRecord <HcalL1TriggerObjectsRcd> ();
     }
-    if ((*objectName == "ValidationCorrs") || (*objectName == "ValidationCorrection") || all) {
+    if ((objectName == "ValidationCorrs") || (objectName == "ValidationCorrection") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceValidationCorrs);
       findingRecord <HcalValidationCorrsRcd> ();
     }
-    if ((*objectName == "LutMetadata") || (*objectName == "lutMetadata") || all) {
+    if ((objectName == "LutMetadata") || (objectName == "lutMetadata") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceLutMetadata);
       findingRecord <HcalLutMetadataRcd> ();
     }
-    if ((*objectName == "DcsValues") || all) {
+    if ((objectName == "DcsValues") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceDcsValues);
       findingRecord <HcalDcsRcd> ();
     }
-    if ((*objectName == "DcsMap") || (*objectName == "dcsMap") || all) {
+    if ((objectName == "DcsMap") || (objectName == "dcsMap") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceDcsMap);
       findingRecord <HcalDcsMapRcd> ();
     }
-    if ((*objectName == "RecoParams") || all) {
+    if ((objectName == "RecoParams") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceRecoParams);
       findingRecord <HcalRecoParamsRcd> ();
     }
-    if ((*objectName == "LongRecoParams") || all) {
+    if ((objectName == "LongRecoParams") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceLongRecoParams);
       findingRecord <HcalLongRecoParamsRcd> ();
     }
-    if ((*objectName == "ZDCLowGainFractions") || all) {
+    if ((objectName == "ZDCLowGainFractions") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceZDCLowGainFractions);
       findingRecord <HcalZDCLowGainFractionsRcd> ();
     }
-    if ((*objectName == "MCParams") || all) {
+    if ((objectName == "MCParams") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceMCParams);
       findingRecord <HcalMCParamsRcd> ();
     }
-    if ((*objectName == "FlagHFDigiTimeParams") || all) {
+    if ((objectName == "FlagHFDigiTimeParams") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceFlagHFDigiTimeParams);
       findingRecord <HcalFlagHFDigiTimeParamsRcd> ();
     }
-    if ((*objectName == "FrontEndMap") || (*objectName == "frontEndMap") || all) {
+    if ((objectName == "FrontEndMap") || (objectName == "frontEndMap") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceFrontEndMap);
       findingRecord <HcalFrontEndMapRcd> ();
     }
-    if ((*objectName == "SiPMParameters") || all) {
+    if ((objectName == "SiPMParameters") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceSiPMParameters);
       findingRecord <HcalSiPMParametersRcd> ();
     }
-    if ((*objectName == "SiPMCharacteristics") || all) {
+    if ((objectName == "SiPMCharacteristics") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceSiPMCharacteristics);
       findingRecord <HcalSiPMCharacteristicsRcd> ();
     }
-    if ((*objectName == "TPChannelParameters") || all) {
+    if ((objectName == "TPChannelParameters") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceTPChannelParameters);
       findingRecord <HcalTPChannelParametersRcd> ();
     }
-    if ((*objectName == "TPParameters") || all) {
+    if ((objectName == "TPParameters") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceTPParameters);
       findingRecord <HcalTPParametersRcd> ();
     }

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -5,6 +5,8 @@
 
 #include <memory>
 #include <iostream>
+#include <string>
+#include <vector>
 
 #include "FWCore/Framework/interface/ValidityInterval.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -196,6 +198,14 @@ HcalHardcodeCalibrations::HcalHardcodeCalibrations ( const edm::ParameterSet& iC
       setWhatProduced (this, &HcalHardcodeCalibrations::producePedestalWidths);
       findingRecord <HcalPedestalWidthsRcd> ();
     }
+    if ((objectName == "EffectivePedestals") || all) {
+      setWhatProduced (this, &HcalHardcodeCalibrations::produceEffectivePedestals, edm::es::Label("effective"));
+      findingRecord <HcalPedestalsRcd> ();
+    }
+    if ((objectName == "EffectivePedestalWidths") || all) {
+      setWhatProduced (this, &HcalHardcodeCalibrations::produceEffectivePedestalWidths, edm::es::Label("effective"));
+      findingRecord <HcalPedestalWidthsRcd> ();
+    }
     if ((objectName == "Gains") || all) {
       setWhatProduced (this, &HcalHardcodeCalibrations::produceGains);
       findingRecord <HcalGainsRcd> ();
@@ -318,8 +328,9 @@ HcalHardcodeCalibrations::setIntervalFor( const edm::eventsetup::EventSetupRecor
   oInterval = edm::ValidityInterval (edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime()); //infinite
 }
 
-std::unique_ptr<HcalPedestals> HcalHardcodeCalibrations::producePedestals (const HcalPedestalsRcd& rec) {
-  edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::producePedestals-> ...";
+std::unique_ptr<HcalPedestals> HcalHardcodeCalibrations::producePedestals_ (const HcalPedestalsRcd& rec, bool eff) {
+  std::string seff = eff ? "Effective" : "";
+  edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produce" << seff << "Pedestals-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -327,14 +338,15 @@ std::unique_ptr<HcalPedestals> HcalHardcodeCalibrations::producePedestals (const
   auto result = std::make_unique<HcalPedestals>(topo,false);
   std::vector <HcalGenericDetId> cells = allCells(*topo, dbHardcode.killHE());
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
-    HcalPedestal item = dbHardcode.makePedestal (*cell, false);
+    HcalPedestal item = dbHardcode.makePedestal (*cell, false, eff, topo, iLumi);
     result->addValues(item);
   }
   return result;
 }
 
-std::unique_ptr<HcalPedestalWidths> HcalHardcodeCalibrations::producePedestalWidths (const HcalPedestalWidthsRcd& rec) {
-  edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::producePedestalWidths-> ...";
+std::unique_ptr<HcalPedestalWidths> HcalHardcodeCalibrations::producePedestalWidths_ (const HcalPedestalWidthsRcd& rec, bool eff) {
+  std::string seff = eff ? "Effective" : "";
+  edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produce" << seff << "PedestalWidths-> ...";
   edm::ESHandle<HcalTopology> htopo;
   rec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
@@ -342,10 +354,26 @@ std::unique_ptr<HcalPedestalWidths> HcalHardcodeCalibrations::producePedestalWid
   auto result = std::make_unique<HcalPedestalWidths>(topo,false);
   std::vector <HcalGenericDetId> cells = allCells(*htopo, dbHardcode.killHE());
   for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
-    HcalPedestalWidth item = dbHardcode.makePedestalWidth (*cell);
+    HcalPedestalWidth item = dbHardcode.makePedestalWidth (*cell, eff, topo, iLumi);
     result->addValues(item);
   }
   return result;
+}
+
+std::unique_ptr<HcalPedestals> HcalHardcodeCalibrations::producePedestals (const HcalPedestalsRcd& rec){
+  return producePedestals_(rec,false);
+}
+
+std::unique_ptr<HcalPedestals> HcalHardcodeCalibrations::produceEffectivePedestals (const HcalPedestalsRcd& rec){
+  return producePedestals_(rec,true);
+}
+
+std::unique_ptr<HcalPedestalWidths> HcalHardcodeCalibrations::producePedestalWidths (const HcalPedestalWidthsRcd& rec){
+  return producePedestalWidths_(rec,false);
+}
+
+std::unique_ptr<HcalPedestalWidths> HcalHardcodeCalibrations::produceEffectivePedestalWidths (const HcalPedestalWidthsRcd& rec){
+  return producePedestalWidths_(rec,true);
 }
 
 std::unique_ptr<HcalGains> HcalHardcodeCalibrations::produceGains (const HcalGainsRcd& rec) {

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
@@ -63,8 +63,12 @@ protected:
 			      const edm::IOVSyncValue& , 
 			      edm::ValidityInterval&) override ;
 
+  std::unique_ptr<HcalPedestals> producePedestals_ (const HcalPedestalsRcd& rcd, bool eff);
+  std::unique_ptr<HcalPedestalWidths> producePedestalWidths_ (const HcalPedestalWidthsRcd& rcd, bool eff);
   std::unique_ptr<HcalPedestals> producePedestals (const HcalPedestalsRcd& rcd);
   std::unique_ptr<HcalPedestalWidths> producePedestalWidths (const HcalPedestalWidthsRcd& rcd);
+  std::unique_ptr<HcalPedestals> produceEffectivePedestals (const HcalPedestalsRcd& rcd);
+  std::unique_ptr<HcalPedestalWidths> produceEffectivePedestalWidths (const HcalPedestalWidthsRcd& rcd);
   std::unique_ptr<HcalGains> produceGains (const HcalGainsRcd& rcd);
   std::unique_ptr<HcalGainWidths> produceGainWidths (const HcalGainWidthsRcd& rcd);
   std::unique_ptr<HcalQIEData> produceQIEData (const HcalQIEDataRcd& rcd);

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
@@ -43,6 +43,14 @@ HcalTextCalibrations::HcalTextCalibrations ( const edm::ParameterSet& iConfig )
       setWhatProduced (this, &HcalTextCalibrations::producePedestalWidths);
       findingRecord <HcalPedestalWidthsRcd> ();
     }
+    if (objectName == "EffectivePedestals") {
+      setWhatProduced (this, &HcalTextCalibrations::produceEffectivePedestals, edm::es::Label("effective"));
+      findingRecord <HcalPedestalsRcd> ();
+    }
+    else if (objectName == "EffectivePedestalWidths") {
+      setWhatProduced (this, &HcalTextCalibrations::produceEffectivePedestalWidths, edm::es::Label("effective"));
+      findingRecord <HcalPedestalWidthsRcd> ();
+    }
     else if (objectName == "Gains") {
       setWhatProduced (this, &HcalTextCalibrations::produceGains);
       findingRecord <HcalGainsRcd> ();
@@ -211,6 +219,21 @@ std::unique_ptr<HcalPedestalWidths> HcalTextCalibrations::producePedestalWidths 
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
   return get_impl_topo<HcalPedestalWidths> (mInputs ["PedestalWidths"],topo);
+}
+
+std::unique_ptr<HcalPedestals> HcalTextCalibrations::produceEffectivePedestals (const HcalPedestalsRcd& rcd) {
+  edm::ESHandle<HcalTopology> htopo;
+  rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
+  const HcalTopology* topo=&(*htopo);
+
+  return get_impl_topo<HcalPedestals> (mInputs ["PedestalsEffective"],topo);
+}
+
+std::unique_ptr<HcalPedestalWidths> HcalTextCalibrations::produceEffectivePedestalWidths (const HcalPedestalWidthsRcd& rcd) {
+  edm::ESHandle<HcalTopology> htopo;
+  rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
+  const HcalTopology* topo=&(*htopo);
+  return get_impl_topo<HcalPedestalWidths> (mInputs ["PedestalWidthsEffective"],topo);
 }
 
 std::unique_ptr<HcalGains> HcalTextCalibrations::produceGains (const HcalGainsRcd& rcd) {

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
@@ -90,6 +90,8 @@ protected:
 
   std::unique_ptr<HcalPedestals> producePedestals (const HcalPedestalsRcd& rcd);
   std::unique_ptr<HcalPedestalWidths> producePedestalWidths (const HcalPedestalWidthsRcd& rcd);
+  std::unique_ptr<HcalPedestals> produceEffectivePedestals (const HcalPedestalsRcd& rcd);
+  std::unique_ptr<HcalPedestalWidths> produceEffectivePedestalWidths (const HcalPedestalWidthsRcd& rcd);
   std::unique_ptr<HcalGains> produceGains (const HcalGainsRcd& rcd);
   std::unique_ptr<HcalGainWidths> produceGainWidths (const HcalGainWidthsRcd& rcd);
   std::unique_ptr<HcalQIEData> produceQIEData (const HcalQIEDataRcd& rcd);

--- a/CalibFormats/HcalObjects/interface/HcalCalibrationWidths.h
+++ b/CalibFormats/HcalObjects/interface/HcalCalibrationWidths.h
@@ -9,14 +9,16 @@
 class HcalCalibrationWidths {
  public:
   HcalCalibrationWidths () {};
-  HcalCalibrationWidths (const float fGain [4], const float fPedestal [4]);
+  HcalCalibrationWidths (const float fGain [4], const float fPedestal [4], const float fEffectivePedestal[4]);
   /// get gain width for capid=0..3
   double gain (int fCapId) const {return mGain [fCapId];}
   /// get pedestal width for capid=0..3
   double pedestal (int fCapId) const {return mPedestal [fCapId];}
+  /// get effective pedestal width for capid=0..3
+  double effpedestal (int fCapId) const {return mEffectivePedestal [fCapId];}
  private:
   double mGain [4];
   double mPedestal [4];
+  double mEffectivePedestal [4];
 };
-
 #endif

--- a/CalibFormats/HcalObjects/interface/HcalCalibrations.h
+++ b/CalibFormats/HcalObjects/interface/HcalCalibrations.h
@@ -9,7 +9,7 @@
 class HcalCalibrations {
  public:
   HcalCalibrations () {};
-  HcalCalibrations (const float fGain [4], const float fPedestal [4], const float fRespCorr, const float fTimeCorr, const float fLUTCorr);
+  HcalCalibrations (const float fGain [4], const float fPedestal [4], const float fEffectivePedestal[4], const float fRespCorr, const float fTimeCorr, const float fLUTCorr);
   /// get LUT corrected and response corrected gain for capid=0..3
   double LUTrespcorrgain (int fCapId) const {return (mLUTCorr *  mRespCorrGain [fCapId]);}
   /// get response corrected gain for capid=0..3
@@ -18,6 +18,8 @@ class HcalCalibrations {
   double rawgain (int fCapId) const {return mRespCorrGain [fCapId] / mRespCorr;}
   /// get pedestal for capid=0..3
   double pedestal (int fCapId) const {return mPedestal [fCapId];}
+  /// get effective pedestal for capid=0..3
+  double effpedestal (int fCapId) const {return mEffectivePedestal [fCapId];}
   /// get response correction factor
   double respcorr () const {return mRespCorr;}
   /// get time correction factor
@@ -25,6 +27,7 @@ class HcalCalibrations {
  private:
   double mRespCorrGain [4];
   double mPedestal [4];
+  double mEffectivePedestal [4];
   double mRespCorr;
   double mTimeCorr;
   double mLUTCorr;

--- a/CalibFormats/HcalObjects/interface/HcalDbService.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbService.h
@@ -60,8 +60,16 @@ class HcalDbService {
   const HcalTPParameters* getHcalTPParameters () const;
   const HcalMCParam* getHcalMCParam (const HcalGenericDetId& fId) const;
 
-  void setData (const HcalPedestals* fItem) {mPedestals = fItem; mCalibSet = nullptr;}
-  void setData (const HcalPedestalWidths* fItem) {mPedestalWidths = fItem; mCalibWidthSet = nullptr;}
+  void setData (const HcalPedestals* fItem, bool eff=false) {
+    if(eff) mEffectivePedestals = fItem;
+    else mPedestals = fItem;
+    mCalibSet = nullptr;
+  }
+  void setData (const HcalPedestalWidths* fItem, bool eff=false) {
+    if(eff) mEffectivePedestalWidths = fItem;
+    else mPedestalWidths = fItem;
+    mCalibWidthSet = nullptr;
+  }
   void setData (const HcalGains* fItem) {mGains = fItem; mCalibSet = nullptr; }
   void setData (const HcalGainWidths* fItem) {mGainWidths = fItem; mCalibWidthSet = nullptr; }
   void setData (const HcalQIEData* fItem) {mQIEData = fItem; mCalibSet=nullptr; mCalibWidthSet=nullptr;}
@@ -91,6 +99,8 @@ class HcalDbService {
   void buildCalibWidths() const;
   const HcalPedestals* mPedestals;
   const HcalPedestalWidths* mPedestalWidths;
+  const HcalPedestals* mEffectivePedestals;
+  const HcalPedestalWidths* mEffectivePedestalWidths;
   const HcalGains* mGains;
   const HcalGainWidths* mGainWidths;
   const HcalQIEData* mQIEData;

--- a/CalibFormats/HcalObjects/interface/HcalDbService.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbService.h
@@ -38,6 +38,8 @@ class HcalDbService {
 
   const HcalPedestal* getPedestal (const HcalGenericDetId& fId) const;
   const HcalPedestalWidth* getPedestalWidth (const HcalGenericDetId& fId) const;
+  const HcalPedestal* getEffectivePedestal (const HcalGenericDetId& fId) const;
+  const HcalPedestalWidth* getEffectivePedestalWidth (const HcalGenericDetId& fId) const;
   const HcalGain* getGain (const HcalGenericDetId& fId) const;
   const HcalGainWidth* getGainWidth (const HcalGenericDetId& fId) const;
   const HcalQIECoder* getHcalCoder (const HcalGenericDetId& fId) const;
@@ -92,11 +94,13 @@ class HcalDbService {
 
  private:
   bool makeHcalCalibration (const HcalGenericDetId& fId, HcalCalibrations* fObject, 
-			    bool pedestalInADC) const;
+			    bool pedestalInADC, bool effPedestalInADC) const;
   void buildCalibrations() const;
   bool makeHcalCalibrationWidth (const HcalGenericDetId& fId, HcalCalibrationWidths* fObject, 
-				 bool pedestalInADC) const;
+				 bool pedestalInADC, bool effPedestalInADC) const;
   void buildCalibWidths() const;
+  bool convertPedestals(const HcalGenericDetId& fId, const HcalPedestal* pedestal, float* pedTrue, bool inADC) const;
+  bool convertPedestalWidths(const HcalGenericDetId& fId, const HcalPedestalWidth* pedestalwidth, float* pedTrueWidth, bool inADC) const;
   const HcalPedestals* mPedestals;
   const HcalPedestalWidths* mPedestalWidths;
   const HcalPedestals* mEffectivePedestals;

--- a/CalibFormats/HcalObjects/src/HcalCalibrationWidths.cc
+++ b/CalibFormats/HcalObjects/src/HcalCalibrationWidths.cc
@@ -7,10 +7,11 @@
    $Author: ratnikov
 */
 
-HcalCalibrationWidths::HcalCalibrationWidths (const float fGain [4], const float fPedestal [4]) {
+HcalCalibrationWidths::HcalCalibrationWidths (const float fGain [4], const float fPedestal [4], const float fEffectivePedestal[4]) {
   for (size_t iCap = 0; iCap < 4; ++iCap)
   {
     mGain [iCap] = fGain [iCap];
     mPedestal [iCap] = fPedestal [iCap];
+    mEffectivePedestal [iCap] = fEffectivePedestal [iCap];
   }
 }

--- a/CalibFormats/HcalObjects/src/HcalCalibrations.cc
+++ b/CalibFormats/HcalObjects/src/HcalCalibrations.cc
@@ -7,12 +7,13 @@
    $Author: ratnikov
 */
 
-HcalCalibrations::HcalCalibrations (const float fGain [4], const float fPedestal [4], 
+HcalCalibrations::HcalCalibrations (const float fGain [4], const float fPedestal [4], const float fEffectivePedestal[4],
 				    const float fRespCorr, const float fTimeCorr, 
 				    const float fLUTCorr ) {
   for (size_t iCap = 0; iCap < 4; ++iCap) {
     mRespCorrGain [iCap] = fGain [iCap] * fRespCorr;
     mPedestal [iCap] = fPedestal [iCap];
+    mEffectivePedestal [iCap] = fEffectivePedestal [iCap];
   }
   mRespCorr = fRespCorr;
   mTimeCorr = fTimeCorr;

--- a/CondTools/Hcal/plugins/HcalDumpConditions.cc
+++ b/CondTools/Hcal/plugins/HcalDumpConditions.cc
@@ -52,7 +52,7 @@ namespace edmtest
     ~ HcalDumpConditions() override { }
     void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-    template<class S, class SRcd> void dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name, const HcalTopology * topo);
+    template<class S, class SRcd> void dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name, const HcalTopology * topo, std::string label="");
     template<class S, class SRcd> void dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name);
     template<class S> void writeToFile(S* myS, const edm::Event& e, std::string name);
 
@@ -63,10 +63,10 @@ namespace edmtest
   
 
   template<class S, class SRcd>
-  void HcalDumpConditions::dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name, const HcalTopology * topo)
+  void HcalDumpConditions::dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name, const HcalTopology * topo, std::string label)
   {
     edm::ESHandle<S> p;
-    if( name == "ChannelQuality") context.get<SRcd>().get("withTopo", p);
+    if(!label.empty()) context.get<SRcd>().get(label, p);
     else context.get<SRcd>().get(p);
     S* myobject = new S(*p.product());
     if( topo ) myobject->setTopo(topo);
@@ -132,12 +132,16 @@ namespace edmtest
       dumpIt(new HcalPedestals(&(*topology)), new HcalPedestalsRcd, e,context,"Pedestals", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("PedestalWidths")) != mDumpRequest.end())
       dumpIt(new HcalPedestalWidths(&(*topology)), new HcalPedestalWidthsRcd, e,context,"PedestalWidths", topo);
+    if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("EffectivePedestals")) != mDumpRequest.end())
+      dumpIt(new HcalPedestals(&(*topology)), new HcalPedestalsRcd, e,context,"EffectivePedestals", topo, "effective");
+    if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("EffectivePedestalWidths")) != mDumpRequest.end())
+      dumpIt(new HcalPedestalWidths(&(*topology)), new HcalPedestalWidthsRcd, e,context,"EffectivePedestalWidths", topo, "effective");
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("Gains")) != mDumpRequest.end())
       dumpIt(new HcalGains(&(*topology)), new HcalGainsRcd, e,context,"Gains", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("GainWidths")) != mDumpRequest.end())
       dumpIt(new HcalGainWidths(&(*topology)), new HcalGainWidthsRcd, e,context,"GainWidths", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("ChannelQuality")) != mDumpRequest.end())
-      dumpIt(new HcalChannelQuality(&(*topology)), new HcalChannelQualityRcd, e,context,"ChannelQuality", topo);
+      dumpIt(new HcalChannelQuality(&(*topology)), new HcalChannelQualityRcd, e,context,"ChannelQuality", topo, "withTopo");
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("RespCorrs")) != mDumpRequest.end())
       dumpIt(new HcalRespCorrs(&(*topology)), new HcalRespCorrsRcd, e,context,"RespCorrs", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("ZSThresholds")) != mDumpRequest.end())

--- a/CondTools/Hcal/test/runDumpHcalCond_cfg.py
+++ b/CondTools/Hcal/test/runDumpHcalCond_cfg.py
@@ -179,7 +179,7 @@ if options.usehardcode:
     process.es_hardcode.toGet.append('GainWidths')
 
 if options.command:
-    cmds = options.command.split('\n')
+    cmds = options.command.split('\\n')
     for cmd in cmds:
         exec(cmd)
 

--- a/CondTools/Hcal/test/runDumpHcalCond_cfg.py
+++ b/CondTools/Hcal/test/runDumpHcalCond_cfg.py
@@ -23,6 +23,8 @@ options.parseArguments()
 allconds = [
     'Pedestals',
     'PedestalWidths',
+    'EffectivePedestals',
+    'EffectivePedestalWidths',
     'Gains',
     'QIEData',
     'QIETypes',

--- a/CondTools/Hcal/test/runDumpHcalCond_cfg.py
+++ b/CondTools/Hcal/test/runDumpHcalCond_cfg.py
@@ -61,7 +61,7 @@ if options.info:
     print allconds
     print "dbfile format: sqlite_file:foo.db"
     print "frontierloc possibilities: frontier://FrontierProd/CMS_CONDITIONS (default), frontier://FrontierDev/CMS_COND_HCAL, etc."
-    print "dblist/frontierlist entry format: HcalPedestalsRcd:hcal_pedestals_fC_v6_mc"
+    print "dblist/frontierlist entry format: HcalPedestalsRcd:hcal_pedestals_fC_v6_mc or HcalPedestalsRcd:effective:HcalPedestals_2018_v2.0_mc_effective for labeled records"
     print "asciilist entry format: Pedestals:CondFormats/HcalObjects/data/hcal_pedestals_fC_v5.txt"
     print "command can be used to execute extra settings, newline separated, e.g.: process.es_hardcode.useHEUpgrade=cms.bool(True)\\nprocess.es_hardcode.useHFUpgrade=cms.bool(True)"
     print "dump will do the equivalent of edmConfigDump: use with python instead of cmsRun"
@@ -144,8 +144,8 @@ if options.dbfile and options.dblist:
     )
     for rcd in options.dblist:
         rcds = rcd.split(':')
-        if len(rcds) != 2: continue
-        process.es_dbfile.toGet.append(cms.PSet(record = cms.string(rcds[0]), tag = cms.string(rcds[1])))
+        if len(rcds) == 2: process.es_dbfile.toGet.append(cms.PSet(record = cms.string(rcds[0]), tag = cms.string(rcds[1])))
+        elif len(rcds) == 3: process.es_dbfile.toGet.append(cms.PSet(record = cms.string(rcds[0]), label = cms.untracked.string(rcds[1]), tag = cms.string(rcds[2])))
     process.es_prefer_dbfile = cms.ESPrefer('PoolDBESSource','es_dbfile')
 
 if options.frontierloc and options.frontierlist:
@@ -158,8 +158,8 @@ if options.frontierloc and options.frontierlist:
     )
     for rcd in options.frontierlist:
         rcds = rcd.split(':')
-        if len(rcds) != 2: continue
-        process.es_frontier.toGet.append(cms.PSet(record = cms.string(rcds[0]), tag = cms.string(rcds[1])))
+        if len(rcds) == 2: process.es_frontier.toGet.append(cms.PSet(record = cms.string(rcds[0]), tag = cms.string(rcds[1])))
+        elif len(rcds) == 3: process.es_frontier.toGet.append(cms.PSet(record = cms.string(rcds[0]), label = cms.untracked.string(rcds[1]), tag = cms.string(rcds[2])))
     process.es_prefer_frontier = cms.ESPrefer('PoolDBESSource','es_frontier')
 
 if options.asciilist:

--- a/DataFormats/HcalRecHit/interface/HBHEChannelInfo.h
+++ b/DataFormats/HcalRecHit/interface/HBHEChannelInfo.h
@@ -21,12 +21,13 @@ public:
     inline HBHEChannelInfo()
       : rawCharge_{0.}, pedestal_{0.}, pedestalWidth_{0.},
         gain_{0.}, gainWidth_{0.}, riseTime_{0.f}, adc_{0},
-        dFcPerADC_{0.f}, hasTimeInfo_(false) {clear();}
+        dFcPerADC_{0.f}, hasTimeInfo_(false), hasEffectivePedestals_(false) {clear();}
 
-    inline explicit HBHEChannelInfo(const bool hasTimeFromTDC)
+    inline explicit HBHEChannelInfo(const bool hasTimeFromTDC, const bool hasEffectivePed)
       : rawCharge_{0.}, pedestal_{0.}, pedestalWidth_{0.},
         gain_{0.}, gainWidth_{0.}, riseTime_{0.f}, adc_{0},
-        dFcPerADC_{0.f}, hasTimeInfo_(hasTimeFromTDC) {clear();}
+        dFcPerADC_{0.f}, hasTimeInfo_(hasTimeFromTDC), 
+        hasEffectivePedestals_(hasEffectivePed) {clear();}
 
     inline void clear()
     {
@@ -92,6 +93,7 @@ public:
     inline unsigned soi() const {return soi_;}
     inline int capid() const {return capid_;}
     inline bool hasTimeInfo() const {return hasTimeInfo_;}
+    inline bool hasEffectivePedestals() const {return hasEffectivePedestals_;}
     inline double darkCurrent() const {return darkCurrent_;}
     inline double fcByPE() const {return fcByPE_;}
     inline double lambda() const {return lambda_;}
@@ -246,6 +248,9 @@ private:
 
     // Flag indicating presence of the time info from TDC (QIE11)
     bool hasTimeInfo_;
+
+    // Flag indicating use of effective pedestals
+    bool hasEffectivePedestals_;
 
     // Flag indicating that this channel should be dropped
     // (typically, tagged bad from DB or zero-suppressed)

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -20,7 +20,8 @@
    <class name="HFPreRecHit" ClassVersion="3">
     <version ClassVersion="3" checksum="224636588"/>
    </class>
-   <class name="HBHEChannelInfo" ClassVersion="6">
+   <class name="HBHEChannelInfo" ClassVersion="7">
+    <version ClassVersion="7" checksum="530224705"/>
     <version ClassVersion="3" checksum="184305963"/>
     <version ClassVersion="4" checksum="1052948187"/>
     <version ClassVersion="5" checksum="2422402317"/>

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -42,15 +42,6 @@ def customiseFor19989(process):
         process.GlobalParameters = GlobalParameters
     return process
 
-# new parameter for HCAL method 2 reconstruction
-def customiseFor20422(process):
-    from RecoLocalCalo.HcalRecProducers.HBHEMethod2Parameters_cfi import m2Parameters
-    for producer in producers_by_type(process, "HBHEPhase1Reconstructor"):
-        producer.algorithm.applyDCConstraint = m2Parameters.applyDCConstraint
-    for producer in producers_by_type(process, "HcalHitReconstructor"):
-        producer.applyDCConstraint = m2Parameters.applyDCConstraint
-    return process
-
 # Refactor track MVA classifiers
 def customiseFor20429(process):
     for producer in producers_by_type(process, "TrackMVAClassifierDetached", "TrackMVAClassifierPrompt"):
@@ -72,7 +63,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     process = customiseFor19029(process)
     process = customiseFor20269(process)
     process = customiseFor19989(process)
-    process = customiseFor20422(process)
     process = customiseFor20429(process)
 
     return process

--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
@@ -39,7 +39,7 @@ public:
 		     double iTMin, double iTMax,
 		     const std::vector<double> & its4Chi2, HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes);
 
-    const HcalPulseShapes::Shape* currentPulseShape_=NULL;
+    const HcalPulseShapes::Shape* currentPulseShape_=nullptr;
     void setChi2Term( bool isHPD );
 
     void setPulseShapeTemplate  (const HcalPulseShapes::Shape& ps, bool isHPD, unsigned nSamples);

--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
@@ -37,9 +37,9 @@ public:
 		     double iTimeMean, double iTimeSigHPD, double iTimeSigSiPM,
 		     double iPedMean,
 		     double iTMin, double iTMax,
-		     const std::vector<double> & its4Chi2, HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes, bool iDCConstraint=false);
+		     const std::vector<double> & its4Chi2, HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes);
 
-    const HcalPulseShapes::Shape* currentPulseShape_=nullptr;
+    const HcalPulseShapes::Shape* currentPulseShape_=NULL;
     void setChi2Term( bool isHPD );
 
     void setPulseShapeTemplate  (const HcalPulseShapes::Shape& ps, bool isHPD, unsigned nSamples);
@@ -88,8 +88,7 @@ private:
     double noise_;    
     double noiseHPD_;
     double noiseSiPM_;
-    HcalTimeSlew::BiasSetting slewFlavor_;
-    bool dcConstraint_;
+    HcalTimeSlew::BiasSetting slewFlavor_;    
 
     bool isCurrentChannelHPD_;
 

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -268,9 +268,9 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
     // quantization noise from the ADC (QIE8 or QIE10/11)
     noiseADCArr[ip] = (1./sqrt(12))*channelData.tsDFcPerADC(ip);
 
-    // dark current noise relevant for siPM
+    // dark current noise relevant for siPM (only if effective pedestal not used)
     noiseDCArr[ip] = 0;
-    if(channelData.hasTimeInfo() && (charge-ped)>channelData.tsPedestalWidth(ip)) {
+    if(channelData.hasTimeInfo() && !channelData.hasEffectivePedestals() && (charge-ped)>channelData.tsPedestalWidth(ip)) {
       noiseDCArr[ip] = psfPtr_->getSiPMDarkCurrent(channelData.darkCurrent(),channelData.fcByPE(),channelData.lambda());
     }
 

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -6,8 +6,8 @@
 
 PulseShapeFitOOTPileupCorrection::PulseShapeFitOOTPileupCorrection() : cntsetPulseShape(0),
 								       psfPtr_(nullptr), spfunctor_(nullptr), dpfunctor_(nullptr), tpfunctor_(nullptr),
-								       TSMin_(0), TSMax_(0), vts4Chi2_(0), pedestalConstraint_(0),
-								       timeConstraint_(0), addPulseJitter_(0), applyTimeSlew_(0),
+								       TSMin_(0), TSMax_(0), vts4Chi2_(0), pedestalConstraint_(false),
+								       timeConstraint_(false), addPulseJitter_(false), applyTimeSlew_(false),
 								       ts4Min_(0), vts4Max_(0), pulseJitter_(0), timeMean_(0), timeSig_(0), pedMean_(0), pedSig_(0),
 								       noise_(0) {
    hybridfitter = new PSFitter::HybridMinimizer(PSFitter::HybridMinimizer::kMigrad);
@@ -192,7 +192,7 @@ void PulseShapeFitOOTPileupCorrection::fit(int iFit,float &timevalfit,float &cha
    //a special number to label the initial condition
    chi2=-1;
    //3 fits why?!
-   const double *results = 0;
+   const double *results = nullptr;
    for(int tries=0; tries<=3;++tries){
      if( fitTimes_ != 2 || tries !=1 ){
         hybridfitter->SetMinimizerType(PSFitter::HybridMinimizer::kMigrad);

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -271,7 +271,7 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
     // dark current noise relevant for siPM (only if effective pedestal not used)
     noiseDCArr[ip] = 0;
     if(channelData.hasTimeInfo() && !channelData.hasEffectivePedestals() && (charge-ped)>channelData.tsPedestalWidth(ip)) {
-      noiseDCArr[ip] = psfPtr_->getSiPMDarkCurrent(channelData.darkCurrent(),channelData.fcByPE(),channelData.lambda());
+      noiseDCArr[ip] = getSiPMDarkCurrent(channelData.darkCurrent(),channelData.fcByPE(),channelData.lambda());
     }
 
     // Photo statistics uncertainties

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -6,10 +6,10 @@
 
 PulseShapeFitOOTPileupCorrection::PulseShapeFitOOTPileupCorrection() : cntsetPulseShape(0),
 								       psfPtr_(nullptr), spfunctor_(nullptr), dpfunctor_(nullptr), tpfunctor_(nullptr),
-								       TSMin_(0), TSMax_(0), vts4Chi2_(0), pedestalConstraint_(false),
-								       timeConstraint_(false), addPulseJitter_(false), applyTimeSlew_(false),
+								       TSMin_(0), TSMax_(0), vts4Chi2_(0), pedestalConstraint_(0),
+								       timeConstraint_(0), addPulseJitter_(0), applyTimeSlew_(0),
 								       ts4Min_(0), vts4Max_(0), pulseJitter_(0), timeMean_(0), timeSig_(0), pedMean_(0), pedSig_(0),
-								       noise_(0), dcConstraint_(false) {
+								       noise_(0) {
    hybridfitter = new PSFitter::HybridMinimizer(PSFitter::HybridMinimizer::kMigrad);
    iniTimesArr = { {-100,-75,-50,-25,0,25,50,75,100,125} };
 }
@@ -38,7 +38,7 @@ void PulseShapeFitOOTPileupCorrection::setPUParams(bool   iPedestalConstraint, b
 						   double iPedMean,
 						   double iTMin,double iTMax,
 						   const std::vector<double> & its4Chi2,
-						   HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes, bool iDCConstraint) {
+						   HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes) {
 
   TSMin_ = iTMin;
   TSMax_ = iTMax;
@@ -59,7 +59,6 @@ void PulseShapeFitOOTPileupCorrection::setPUParams(bool   iPedestalConstraint, b
   pedMean_            = iPedMean;
   slewFlavor_         = slewFlavor;
   fitTimes_           = iFitTimes;
-  dcConstraint_       = iDCConstraint;
 
 }
 
@@ -193,7 +192,7 @@ void PulseShapeFitOOTPileupCorrection::fit(int iFit,float &timevalfit,float &cha
    //a special number to label the initial condition
    chi2=-1;
    //3 fits why?!
-   const double *results = nullptr;
+   const double *results = 0;
    for(int tries=0; tries<=3;++tries){
      if( fitTimes_ != 2 || tries !=1 ){
         hybridfitter->SetMinimizerType(PSFitter::HybridMinimizer::kMigrad);
@@ -250,7 +249,6 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
   double noisePHArr[HcalConst::maxSamples]={};
   double tsTOT = 0, tstrig = 0; // in fC
   double tsTOTen = 0; // in GeV
-  double sipmDarkCurrentWidth = getSiPMDarkCurrent(channelData.darkCurrent(),channelData.fcByPE(),channelData.lambda());
 
   // go over the time slices
   for(unsigned int ip=0; ip<cssize; ++ip){
@@ -273,7 +271,7 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
     // dark current noise relevant for siPM
     noiseDCArr[ip] = 0;
     if(channelData.hasTimeInfo() && (charge-ped)>channelData.tsPedestalWidth(ip)) {
-      noiseDCArr[ip] = sipmDarkCurrentWidth;
+      noiseDCArr[ip] = psfPtr_->getSiPMDarkCurrent(channelData.darkCurrent(),channelData.fcByPE(),channelData.lambda());
     }
 
     // Photo statistics uncertainties
@@ -295,12 +293,10 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
     }
   }
 
-  double sipmDarkCurrentWidth2 = 0.;
-  if(dcConstraint_) sipmDarkCurrentWidth2 = sipmDarkCurrentWidth*sipmDarkCurrentWidth;
-  double averagePedSig2GeV=0.25*((channelData.tsPedestalWidth(0)*channelData.tsPedestalWidth(0)+sipmDarkCurrentWidth2)*channelData.tsGain(0)*channelData.tsGain(0) +
-				 (channelData.tsPedestalWidth(1)*channelData.tsPedestalWidth(1)+sipmDarkCurrentWidth2)*channelData.tsGain(1)*channelData.tsGain(1) +
-				 (channelData.tsPedestalWidth(2)*channelData.tsPedestalWidth(2)+sipmDarkCurrentWidth2)*channelData.tsGain(2)*channelData.tsGain(2) +
-				 (channelData.tsPedestalWidth(3)*channelData.tsPedestalWidth(3)+sipmDarkCurrentWidth2)*channelData.tsGain(3)*channelData.tsGain(3));
+  double averagePedSig2GeV=0.25*(channelData.tsPedestalWidth(0)*channelData.tsPedestalWidth(0)*channelData.tsGain(0)*channelData.tsGain(0) +
+				 channelData.tsPedestalWidth(1)*channelData.tsPedestalWidth(1)*channelData.tsGain(1)*channelData.tsGain(1) +
+				 channelData.tsPedestalWidth(2)*channelData.tsPedestalWidth(2)*channelData.tsGain(2)*channelData.tsGain(2) +
+				 channelData.tsPedestalWidth(3)*channelData.tsPedestalWidth(3)*channelData.tsGain(3)*channelData.tsGain(3));
 
   // redefine the invertpedSig2
   psfPtr_->setinvertpedSig2(1./(averagePedSig2GeV));

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
@@ -14,7 +14,6 @@ static std::unique_ptr<PulseShapeFitOOTPileupCorrection>
 parseHBHEMethod2Description(const edm::ParameterSet& conf)
 {
     const bool iPedestalConstraint = conf.getParameter<bool>  ("applyPedConstraint");
-    const bool iDCConstraint = conf.getParameter<bool>  ("applyDCConstraint");
     const bool iTimeConstraint =     conf.getParameter<bool>  ("applyTimeConstraint");
     const bool iAddPulseJitter =     conf.getParameter<bool>  ("applyPulseJitter");
     const bool iApplyTimeSlew =      conf.getParameter<bool>  ("applyTimeSlew");
@@ -41,7 +40,7 @@ parseHBHEMethod2Description(const edm::ParameterSet& conf)
                       iPulseJitter,
 		      iTimeMean,iTimeSigHPD, iTimeSigSiPM, iPedMean,
 		      iTMin, iTMax, its4Chi2,
-                      HcalTimeSlew::Medium, iFitTimes, iDCConstraint);
+                      HcalTimeSlew::Medium, iFitTimes);
 
     return corr;
 }

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEMethod2Parameters_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEMethod2Parameters_cfi.py
@@ -19,9 +19,6 @@ m2Parameters = cms.PSet(
     timeMin               = cms.double(-12.5),#ns
     timeMax               = cms.double(12.5), #ns
     ts4chi2               = cms.vdouble(15.,15.),  #chi2 for triple pulse
-    fitTimes              = cms.int32(1),      # -1 means no constraint on number of fits per channel
-    applyDCConstraint     = cms.bool(False),
-)
+    fitTimes              = cms.int32(1)      # -1 means no constraint on number of fits per channel
 
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toModify(m2Parameters, applyDCConstraint = True)
+)

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
@@ -26,7 +26,7 @@ hbheprereco = cms.EDProducer(
     # the reconstruction algorithm?
     recoParamsFromDB = cms.bool(True),
 
-    # include SiPM dark current contribution in pedestal mean
+    # store "effective" pedestal including SiPM dark current contribution
     saveEffectivePedestal = cms.bool(False),
 
     # Drop zero-suppressed channels?
@@ -100,5 +100,5 @@ hbheprereco = cms.EDProducer(
 # Disable the "triangle peak fit" and the corresponding HBHETriangleNoise flag
 hbheprereco.pulseShapeParametersQIE8.TrianglePeakTS = cms.uint32(10000)
 
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toModify(hbheprereco, saveEffectivePedestal = cms.bool(True))
+from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
+run2_HE_2017.toModify(hbheprereco, saveEffectivePedestal = cms.bool(True))

--- a/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cc
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cc
@@ -196,8 +196,8 @@ void HcalDigitizerTest::analyze(const edm::Event& iEvent,
   HcalGainWidths gainWidths(&topology);
   // make a calibration service by hand
   for (auto detItr = allDetIds.begin(); detItr != allDetIds.end(); ++detItr) {
-    pedestals.addValues(dbHardcode.makePedestal(*detItr, false));
-    pedestalWidths.addValues(dbHardcode.makePedestalWidth(*detItr));
+    pedestals.addValues(dbHardcode.makePedestal(*detItr, false, false, NULL, 0.0));
+    pedestalWidths.addValues(dbHardcode.makePedestalWidth(*detItr, false, NULL, 0.0));
     gains.addValues(dbHardcode.makeGain(*detItr));
     gainWidths.addValues(dbHardcode.makeGainWidth(*detItr));
   }


### PR DESCRIPTION
After the GT updates in #21395, this long-planned update can finally be submitted.

With SiPMs, there are two independent contributions to the electronics noise:
1. Usual Gaussian pedestal (from QIE, etc.)
2. Dark current + crosstalk (from SiPM)

Previously, the dark current contribution had been included in Method 2 reconstruction in a somewhat haphazard/inconsistent way. Instead, we prefer to measure the pedestals twice (with and without bias voltage), so we do not induce any dependence in the data reconstruction on the *modeling* of SiPM noise. The simulation will still use the (unlabeled) bias voltage off measurement (QIE-only), while the reconstruction uses the "effective" bias voltage on measurement, so the dark current is included naturally in both the pedestal means and widths.

The terms in the Method 2 reconstruction are changed automatically depending on whether the effective pedestal is stored in the channel info or not (so the old way is still supported). A boolean member is added to the channel info class to keep track of which type of pedestals are stored.

*Also*, this PR fixes a bug for Phase2 where the dark current was subtracted before calculating the nonlinearity correction for SiPMs. The dark current should be kept when calculating the nonlinearity correction, because it results in pixels firing, the same as signal. This results in a few % change in the pion energy scale for Phase2. (The effective pedestals in hardcode conditions are computed using the model-dependent equations, since this is MC-only usage.)

More details in a talk co-written by myself and @abdoulline: https://indico.cern.ch/event/680480/contributions/2787885/attachments/1556785/2448593/Dual_peds_S.A._Nov13_2017.pdf
(including single pion scans for [2018](https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/Dual_peds/940pre3_2018_Dual_peds_v2_effective_vs_94X_2018_SinglePi/) and [2023](https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/Dual_peds/940pre3_2023D17_dual_vs_940pre3_2023D17_default_SinglePi/), showing expected results)

attn: @abdoulline, @mariadalfonso, @igv4321, @bsunanda, @hatakeyamak, @deguio 