### PR TITLE
Fix mismatched calo signals warning and make accessors consistent

### DIFF
--- a/CalibFormats/CaloObjects/interface/CaloSamples.h
+++ b/CalibFormats/CaloObjects/interface/CaloSamples.h
@@ -52,7 +52,9 @@ public:
 
   void setDetId( DetId detId ) { id_ = detId ; }
 
-  void setSize( unsigned int size ) { size_ = size ; }
+  void setSize( unsigned int size ) { size_ = size ; data_.resize(size,0.); }
+
+  void setPreciseSize( unsigned int size ) { preciseSize_ = size ; preciseData_.resize(preciseSize_,0.); }
 
   bool isBlank() const ; // are the samples blank (zero?)
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
@@ -67,6 +67,11 @@ void HcalSiPMHitResponse::finalizeHits(CLHEP::HepRandomEngine* engine) {
 
     LogDebug("HcalSiPMHitResponse") << HcalDetId(signal.id()) << ' ' << signal;
 
+    //if we don't want to keep precise info at the end
+    if (!HighFidelityPreMix){
+      signal.setPreciseSize(0);
+    }
+
     if (keep) CaloHitResponse::add(signal);
   }
 }

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
@@ -174,7 +174,6 @@ namespace {
         unsigned int sizenew = (hitSample).size();
         unsigned int sizeold = resultSample.size();
         if (sizenew > sizeold) { // extend sample
-          for (unsigned int isamp = sizeold; isamp < sizenew; ++isamp) resultSample[isamp] = 0;
           resultSample.setSize (sizenew);
         }
         for(unsigned int isamp = 0; isamp<sizenew; isamp++) { // add new values


### PR DESCRIPTION
It was noticed (by @fwyzard in https://hypernews.cern.ch/HyperNews/CMS/get/simDevelopment/1835.html) that the warning "Mismatched calo signals" occasionally appeared in premixing workflows in 94X.

I eventually determined this was an unintended side effect of #17920. Before that PR, `CaloHitResponse::add()` didn't use the built-in `+=` operator for `CaloSamples`, but a separate, simpler algorithm that didn't check the precise size. We don't bother to do high-fidelity premixing for HO, so the warning started to appear in the (fairly rare) occurrence of premixing pileup hits in HO. It has no effect on physics, but is slightly irritating.

To fix this, I made a `setPreciseSize()` accessor for `CaloSamples` that resizes the associated vector. I also made `setSize()` resize the data vector (and appropriately modified the one place where `setSize()` was already used). The `HcalSiPMHitResponse` class uses this when high fidelity premixing is not enabled, and that suppresses the warning as intended.

attn: @abdoulline