### PR TITLE
Adding postLS2 (2019) design key and 2019 workflow updates

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -54,6 +54,8 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
+    'phase1_2019_design'       : '100X_postLS2_design_v1', # GT containing design conditions for postLS2
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_realistic'       : '100X_postLS2_realistic_v1', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
     'phase2_realistic'         : '94X_upgrade2023_realistic_v3'
@@ -85,5 +87,5 @@ autoCond['hltonline']        = ( autoCond['run1_hlt'] )
 autoCond['upgradePLS1']      = ( autoCond['run2_mc'] )
 autoCond['upgradePLS150ns']  = ( autoCond['run2_mc_50ns'] )
 autoCond['upgrade2017']      = ( autoCond['phase1_2017_design'] )
-autoCond['upgrade2019']      = ( autoCond['phase1_2019_realistic'] )
+autoCond['upgrade2019']      = ( autoCond['phase1_2019_design'] )
 autoCond['upgradePLS3']      = ( autoCond['phase2_realistic'] )

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -151,14 +151,14 @@ upgradeProperties[2017] = {
     },
     '2019' : {
         'Geom' : 'Extended2019',
-        'GT' : 'auto:phase1_2018_realistic',
+        'GT' : 'auto:phase1_2019_realistic',
         'HLTmenu': '@relval2017',
         'Era' : 'Run3',
         'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','ALCAFull','HARVESTFull'],
     },
     '2019Design' : {
         'Geom' : 'Extended2019',
-        'GT' : 'auto:phase1_2018_design',
+        'GT' : 'auto:phase1_2019_design',
         'HLTmenu': '@relval2017',
         'Era' : 'Run3',
         'BeamSpot': 'GaussSigmaZ4cm',


### PR DESCRIPTION
This PR will bring two changes : 

- adding of phase1_2019_design key with the GT containing design conditions for 2018 with HCAL electronics map update for 2019.
- update of 2019 workflows to switch them to consume 2019 GT keys

# Summary of Global Tag updates

## Upgrade

   * **PostLS2 design scenario** : [100X_postLS2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_postLS2_design_v1) as [100X_upgrade2018_design_IdealBS_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018_design_IdealBS_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_postLS2_design_v1/100X_upgrade2018_design_IdealBS_v1): 
      * first GT for postLS2 design scenario with an update of HCAL electronics map. All other conditions are same as 2018 design.

@kpedro88 @abdoulline