### PR TITLE
[RFC] Another prototype of fillDescriptions for generic selectors

### DIFF
--- a/CommonTools/RecoAlgos/plugins/PtMinMuonCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/PtMinMuonCountFilter.cc
@@ -16,5 +16,14 @@ typedef ObjectCountFilter<
           reco::MuonCollection, 
           PtMinSelector
         >::type PtMinMuonCountFilter;
+template <>
+struct SelectorFillDescriptions<PtMinMuonCountFilter> {
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("src", edm::InputTag("muons"));
+    desc.add<double>("ptMin", 0.);
+    descriptions.add("ptMinMuonCountFilter", desc);
+  }
+};
 
 DEFINE_FWK_MODULE( PtMinMuonCountFilter );


### PR DESCRIPTION
Following the discussion in #21241 I cooked up another prototype of an fillDescriptions implementation for generic selectors (wrt. #21430).

Idea is to provide a hook for user providing the full `fillDescriptions(edm::ConfigurationDescriptions&)` implementation. In this PR the hook is implemented as a "traits" class template that is specialized for each selector EDModule a `fillDescriptions` is wanted. I wanted to leave also a possibility of not specifying the `fillDescriptions` (which is the default) so that I wouldn't have to implement it for the gazillion selectors that are defined but not used (within CMSSW at least).

Compared to #21430:
* Pros
   * Simpler to implement (probably also to understand and maintain)
   * Implementation of per-module fillDescriptions closer to the standard way (in cases where #21430 the defaults need to be changed)
   * Allows generation of multiple cfi files (e.g. with different defaults)
* Cons
  * Need to provide the specialization explicitly for each selector template instantiation
  * Can lead to copy-paste between instantiations that have same components
     * Copy-paste can be mitigated with e.g. another hierarchy of functions that add the common parameters (leading to further mess?)
  * Can go out of synch wrt. parameters that are actually used
     * Probably not a problem for simple selectors, but I'm thinking cases like this
       * https://github.com/cms-sw/cmssw/blob/master/CommonTools/RecoAlgos/plugins/RecoTrackSelector.cc
       * https://github.com/cms-sw/cmssw/blob/master/CommonTools/RecoAlgos/interface/RecoTrackSelector.h
       * https://github.com/cms-sw/cmssw/blob/master/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h


I've tested in 10_0_0_pre1 that the PR compiles and wf 10024.0 runs. No changes are expected in monitored quantities.