### PR TITLE
Add L1 ETMHF as HLT objects

### DIFF
--- a/DataFormats/HLTReco/interface/TriggerTypeDefs.h
+++ b/DataFormats/HLTReco/interface/TriggerTypeDefs.h
@@ -48,6 +48,7 @@ namespace trigger
     TriggerL1EG           = -98, // stage2
     TriggerL1Jet          = -99, // stage2
     TriggerL1Tau          =-100, // stage2
+    TriggerL1ETMHF        =-101,
 
     /// HLT
 

--- a/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
@@ -276,6 +276,21 @@ void HLTL1TSeed::dumpTriggerFilterObjectWithRefs(trigger::TriggerFilterObjectWit
     << "\t" << "phi =  " << obj->phi();  //<< "\t" << "BX = " << obj->bx();
   }
 
+  vector<l1t::EtSumRef> seedsL1EtSumETMHF;
+  filterproduct.getObjects(trigger::TriggerL1ETMHF, seedsL1EtSumETMHF);
+  const size_t sizeSeedsL1EtSumETMHF = seedsL1EtSumETMHF.size();
+  LogTrace("HLTL1TSeed") 
+  << "\n  L1EtSum ETMHF seeds:      " << sizeSeedsL1EtSumETMHF << endl << endl;
+
+  for (size_t i = 0; i != sizeSeedsL1EtSumETMHF; i++) { 
+    l1t::EtSumRef obj = l1t::EtSumRef( seedsL1EtSumETMHF[i]);
+    
+    LogTrace("HLTL1TSeed") 
+    << "\tL1EtSum  ETMHF" << "\t" << "pt = "
+    << obj->pt() << "\t" << "eta =  " << obj->eta()
+    << "\t" << "phi =  " << obj->phi();  //<< "\t" << "BX = " << obj->bx();
+  }
+
   vector<l1t::EtSumRef> seedsL1EtSumHTM;
   filterproduct.getObjects(trigger::TriggerL1HTM, seedsL1EtSumHTM);
   const size_t sizeSeedsL1EtSumHTM = seedsL1EtSumHTM.size();
@@ -319,6 +334,7 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
     std::list<int> listETT;
     std::list<int> listHTT;
     std::list<int> listHTM;
+    std::list<int> listETMHF;
 
     std::list<int> listJetCounts;
 
@@ -607,7 +623,6 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 
 
 		// THESE OBJECT CASES ARE CURRENTLY MISSING:
-		//gtETM2,
 		//gtMinBias,
 		//gtExternal,
 		//ObjNull
@@ -632,27 +647,25 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
                     break;
                     case l1t::gtETM: {
                         listETM.push_back(*itObject);
-
                     }
                     break;
                     case l1t::gtETT: {
                         listETT.push_back(*itObject);
-
                     }
-
                     break;
                     case l1t::gtHTT: {
                         listHTT.push_back(*itObject);
-
                     }
-
                     break;
                     case l1t::gtHTM: {
                         listHTM.push_back(*itObject);
-
                     }
-
                     break;
+                    case l1t::gtETMHF: {
+                        listETMHF.push_back(*itObject);
+                    }
+                    break;
+
                     //case JetCounts: {
                     //    listJetCounts.push_back(*itObject);
                     //}
@@ -705,6 +718,9 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 
     listHTM.sort();
     listHTM.unique();
+
+    listETMHF.sort();
+    listETMHF.unique();
 
     listJetCounts.sort();
     listJetCounts.unique();
@@ -865,6 +881,10 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 			    case l1t::EtSum::kMissingHt: 
             if(!listHTM.empty())
 			        filterproduct.addObject(trigger::TriggerL1HTM, myref); 
+			      break;
+			    case l1t::EtSum::kMissingEtHF: 
+            if(!listETMHF.empty())
+			        filterproduct.addObject(trigger::TriggerL1ETMHF, myref); 
 			      break;
 			    default:
 			      LogTrace("HLTL1TSeed") << "  L1EtSum seed of currently unsuported HLT TriggerType. l1t::EtSum type:      " << iter->getType() << "\n";


### PR DESCRIPTION
The new L1 objects defined with #15757 were not included in HLTL1TSeed module.
As a results, we had events passing L1_ETMHFXX but without any trigger objects.
This was an issue for study the L1/HLT trigger efficiency.

This PR fixes this issue adding L1 ETMHF as a new trigger objects format and using it in HLTL1TSeed.
Please note that the other formats (ETTHF, HTTHT, and HTMHF) added with #15757 are not present in 
/DataFormats/L1TGlobal/interface/GlobalObject.h , ie. l1t:gtHTMHF, l1t:gtHTTHF, l1t:gtETTHF are not defined.

See https://its.cern.ch/jira/browse/CMSHLT-1701