### PR TITLE
FastTimerService: add measurement of framework overhead (100x)

### DIFF
--- a/HLTrigger/Timer/interface/FastTimerService.h
+++ b/HLTrigger/Timer/interface/FastTimerService.h
@@ -82,7 +82,7 @@ Performance of std::chrono::high_resolution_clock
 class FastTimerService {
 public:
   FastTimerService(const edm::ParameterSet &, edm::ActivityRegistry & );
-  ~FastTimerService();
+  ~FastTimerService() override;
 
 private:
   double queryModuleTime_(edm::StreamID, unsigned int id) const;
@@ -101,8 +101,8 @@ public:
   double queryHighlightTime(edm::StreamID sid, std::string const& label) const;
 
 private:
-  void ignoredSignal(std::string signal) const;
-  void unsupportedSignal(std::string signal) const;
+  void ignoredSignal(const std::string& signal) const;
+  void unsupportedSignal(const std::string& signal) const;
 
   // these signal pairs are not guaranteed to happen in the same thread
 

--- a/HLTrigger/Timer/interface/FastTimerService.h
+++ b/HLTrigger/Timer/interface/FastTimerService.h
@@ -16,6 +16,7 @@
 // tbb headers
 #include <tbb/concurrent_unordered_set.h>
 #include <tbb/enumerable_thread_specific.h>
+#include <tbb/task_scheduler_observer.h>
 
 // CMSSW headers
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
@@ -79,7 +80,8 @@ Performance of std::chrono::high_resolution_clock
 */
 
 
-class FastTimerService {
+class FastTimerService : public tbb::task_scheduler_observer
+{
 public:
   FastTimerService(const edm::ParameterSet &, edm::ActivityRegistry & );
   ~FastTimerService() override;
@@ -213,6 +215,10 @@ private:
 
   void preEventReadFromSource(edm::StreamContext const&, edm::ModuleCallingContext const&);
   void postEventReadFromSource(edm::StreamContext const&, edm::ModuleCallingContext const&);
+
+  // inherited from TBB task_scheduler_observer
+  void on_scheduler_entry(bool worker) final;
+  void on_scheduler_exit(bool worker) final;
 
 public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);

--- a/HLTrigger/Timer/interface/ProcessCallGraph.h
+++ b/HLTrigger/Timer/interface/ProcessCallGraph.h
@@ -6,6 +6,7 @@
  */
 
 #include <iostream>
+#include <utility>
 #include <vector>
 #include <string>
 #include <type_traits>
@@ -56,14 +57,7 @@ public:
 
     PathType() = default;
 
-    PathType(std::string const & name, std::vector<unsigned int> const & mop, std::vector<unsigned int> const & mad, std::vector<unsigned int> const & ldom) :
-      name_(name),
-      modules_on_path_(mop),
-      modules_and_dependencies_(mad),
-      last_dependency_of_module_(ldom)
-    { }
-
-    PathType(std::string && name, std::vector<unsigned int> && mop, std::vector<unsigned int> && mad, std::vector<unsigned int> && ldom) :
+    PathType(std::string name, std::vector<unsigned int> mop, std::vector<unsigned int> mad, std::vector<unsigned int> ldom) :
       name_(std::move(name)),
       modules_on_path_(std::move(mop)),
       modules_and_dependencies_(std::move(mad)),
@@ -92,19 +86,19 @@ public:
     ProcessType() = delete;
 
     ProcessType(
-      std::string const & name,
-      GraphType const & graph,
-      std::vector<unsigned int> const & modules,
-      std::vector<PathType> const & paths,
-      std::vector<PathType> const & endPaths,
-      std::vector<unsigned int> const & subprocesses = {}
+      std::string name,
+      GraphType const& graph,
+      std::vector<unsigned int> modules,
+      std::vector<PathType> paths,
+      std::vector<PathType> endPaths,
+      std::vector<unsigned int> subprocesses = {}
     ) :
-      name_(name),
+      name_(std::move(name)),
       graph_(graph),
-      modules_(modules),
-      paths_(paths),
-      endPaths_(endPaths),
-      subprocesses_(subprocesses)
+      modules_(std::move(modules)),
+      paths_(std::move(paths)),
+      endPaths_(std::move(endPaths)),
+      subprocesses_(std::move(subprocesses))
     { }
 
     ProcessType(

--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -51,7 +51,7 @@ private:
   void fillPathSummaryPlots(    DQMStore::IBooker & booker, DQMStore::IGetter & getter, double events, std::string const & path);
   void fillPlotsVsLumi(DQMStore::IBooker & booker, DQMStore::IGetter & getter, std::string const & current_path, std::string const & suffix, MEPSet pset);
 
-  static MEPSet getHistoPSet  (edm::ParameterSet pset);
+  static MEPSet getHistoPSet(const edm::ParameterSet& pset);
 
   bool doPlotsVsScalLumi_;
   bool doPlotsVsPixelLumi_;
@@ -75,9 +75,7 @@ FastTimerServiceClient::FastTimerServiceClient(edm::ParameterSet const & config)
 {
 }
 
-FastTimerServiceClient::~FastTimerServiceClient()
-{
-}
+FastTimerServiceClient::~FastTimerServiceClient() = default;
 
 void
 FastTimerServiceClient::dqmEndJob(DQMStore::IBooker & booker, DQMStore::IGetter & getter)
@@ -372,7 +370,7 @@ FastTimerServiceClient::fillPlotsVsLumi(DQMStore::IBooker & booker, DQMStore::IG
   // get all MEs in the current_path
   getter.setCurrentFolder(current_path);
   std::vector<std::string> allmenames = getter.getMEs();
-  for ( const auto & m : allmenames ) {
+  for (auto const & m : allmenames) {
     // get only MEs vs LS
     if (boost::regex_match(m, byls))
       menames.push_back(m);
@@ -413,7 +411,7 @@ FastTimerServiceClient::fillPlotsVsLumi(DQMStore::IBooker & booker, DQMStore::IG
 
   booker.setCurrentFolder(current_path);
   getter.setCurrentFolder(current_path);
-  for ( auto m : menames ) {
+  for (auto const& m : menames) {
     std::string label = m;
     label.erase(label.find("_byls"));
 
@@ -464,7 +462,7 @@ FastTimerServiceClient::fillPUMePSetDescription(edm::ParameterSetDescription & p
 }
 
 
-MEPSet FastTimerServiceClient::getHistoPSet(edm::ParameterSet pset)
+MEPSet FastTimerServiceClient::getHistoPSet(const edm::ParameterSet& pset)
 {
   return MEPSet{
     pset.getParameter<std::string>("folder"),

--- a/HLTrigger/Timer/plugins/plugins.cc
+++ b/HLTrigger/Timer/plugins/plugins.cc
@@ -3,7 +3,7 @@
 #include "HLTrigger/Timer/interface/TimerService.h"
 #include "HLTrigger/Timer/interface/Timer.h"
 
-typedef edm::serviceregistry::AllArgsMaker<TimerService> maker_cputs;
+using maker_cputs = edm::serviceregistry::AllArgsMaker<TimerService>;
 
 DEFINE_FWK_MODULE(Timer);
 DEFINE_FWK_SERVICE_MAKER(TimerService,maker_cputs);

--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -72,16 +72,16 @@ namespace {
 FastTimerService::Resources::Resources() :
   time_thread(boost::chrono::nanoseconds::zero()),
   time_real(boost::chrono::nanoseconds::zero()),
-  allocated(0UL),
-  deallocated(0UL)
+  allocated(0ul),
+  deallocated(0ul)
 { }
 
 void
 FastTimerService::Resources::reset() {
   time_thread = boost::chrono::nanoseconds::zero();
   time_real   = boost::chrono::nanoseconds::zero();
-  allocated   = 0UL;
-  deallocated = 0UL;
+  allocated   = 0ul;
+  deallocated = 0ul;
 }
 
 FastTimerService::Resources &
@@ -106,10 +106,10 @@ FastTimerService::Resources::operator+(Resources const& other) const {
 // of results should yield the correct result.
 
 FastTimerService::AtomicResources::AtomicResources() :
-  time_thread(0UL),
-  time_real(0UL),
-  allocated(0UL),
-  deallocated(0UL)
+  time_thread(0ul),
+  time_real(0ul),
+  allocated(0ul),
+  deallocated(0ul)
 { }
 
 FastTimerService::AtomicResources::AtomicResources(AtomicResources const& other) :
@@ -121,10 +121,10 @@ FastTimerService::AtomicResources::AtomicResources(AtomicResources const& other)
 
 void
 FastTimerService::AtomicResources::reset() {
-  time_thread = 0UL;
-  time_real   = 0UL;
-  allocated   = 0UL;
-  deallocated = 0UL;
+  time_thread = 0ul;
+  time_real   = 0ul;
+  allocated   = 0ul;
+  deallocated = 0ul;
 }
 
 FastTimerService::AtomicResources &
@@ -309,8 +309,9 @@ FastTimerService::ResourcesPerJob::operator+(ResourcesPerJob const& other) const
 
 // Measurement
 
-FastTimerService::Measurement::Measurement()
-  = default;
+FastTimerService::Measurement::Measurement() {
+  measure();
+}
 
 void
 FastTimerService::Measurement::measure() {

--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -1008,13 +1008,13 @@ FastTimerService::queryHighlightTime(edm::StreamID sid, std::string const& label
 
 
 void
-FastTimerService::ignoredSignal(std::string signal) const
+FastTimerService::ignoredSignal(const std::string& signal) const
 {
   LogDebug("FastTimerService") << "The FastTimerService received is currently not monitoring the signal \"" << signal << "\".\n";
 }
 
 void
-FastTimerService::unsupportedSignal(std::string signal) const
+FastTimerService::unsupportedSignal(const std::string& signal) const
 {
   // warn about each signal only once per job
   if (unsupported_signals_.insert(signal).second)

--- a/HLTrigger/Timer/src/ProcessCallGraph.cc
+++ b/HLTrigger/Timer/src/ProcessCallGraph.cc
@@ -30,9 +30,7 @@
 #include "HLTrigger/Timer/interface/ProcessCallGraph.h"
 
 
-ProcessCallGraph::ProcessCallGraph()
-{
-}
+ProcessCallGraph::ProcessCallGraph() = default;
 
 
 // adaptor to use range-based for loops with boost::graph edges(...) and vertices(...) functions
@@ -198,8 +196,8 @@ ProcessCallGraph::depends(unsigned int module) const
   // count the visited vertices (the `black' ones) in order to properly size the
   // output vector; then fill the dependencies with the list of visited nodes
   unsigned int size = 0;
-  for (unsigned int i = 0; i < colors.size(); ++i)
-    if (boost::black_color == colors[i])
+  for (unsigned int color : colors)
+    if (boost::black_color == color)
       ++size;
   std::vector<unsigned int> dependencies(size);
   unsigned j = 0;
@@ -228,8 +226,8 @@ ProcessCallGraph::dependencies(std::vector<unsigned int> const & path)
     boost::depth_first_visit(graph_, module, visitor, colormap);
 
   unsigned int size = 0;
-  for (unsigned int i = 0; i < colors.size(); ++i)
-    if (colors[i] == 0)
+  for (unsigned int color : colors)
+    if (color == 0)
       ++size;
 
   // allocate the output vectors
@@ -239,8 +237,8 @@ ProcessCallGraph::dependencies(std::vector<unsigned int> const & path)
   indices.resize(0);
 
   // reset the color map
-  for (unsigned int i = 0; i < colors.size(); ++i)
-    colors[i] = 0;
+  for (unsigned int & color : colors)
+    color = 0;
 
   // find again all the dependencies, and record those associated to each module
   struct record_vertices : boost::default_dfs_visitor {


### PR DESCRIPTION
  - measure the time spent in the event loop, but outside any module
  - keep track of the threads joining and leaving the TBB global arena