### PR TITLE
bug fix for g6 and g1 handling

### DIFF
--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
@@ -154,7 +154,7 @@ void ECALpedestalPCLHarvester::endRun(edm::Run const& run, edm::EventSetup const
 
     edm::ESHandle<EcalPedestals> g6g1peds;
     isetup.get<EcalPedestalsRcd>().get(labelG6G1_,g6g1peds);
-    g6g1Pedestals_=peds.product();
+    g6g1Pedestals_=g6g1peds.product();
 
 }
 


### PR DESCRIPTION
in the ECAL pedestal PCL, G6 and G1 are not handled correctly because of this bug