### PR TITLE
Fix two bugs (out-of-bounds access) in MuonAlignment*

### DIFF
--- a/Alignment/MuonAlignment/src/MuonAlignment.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignment.cc
@@ -151,12 +151,12 @@ void MuonAlignment::copyAlignmentToSurvey(double shiftErr, double angleErr) {
    for (std::vector<AlignTransformErrorExtended>::const_iterator alignmentError = alignmentErrors.begin();
 	alignmentError != alignmentErrors.end();
 	++alignmentError) {
-      align::ErrorMatrix matrix6x6 = ROOT::Math::SMatrixIdentity();
-      CLHEP::HepSymMatrix matrix6x6new = alignmentError->matrix();
+      align::ErrorMatrix matrix6x6 = ROOT::Math::SMatrixIdentity(); // start from (0, 0)
+      CLHEP::HepSymMatrix matrix6x6new = alignmentError->matrix();  // start from (1, 1)
 
       for (int i = 0;  i < 6;  i++) {
 	 for (int j = 0;  j < 6;  j++) {
-	    matrix6x6(i, j) = matrix6x6new(i, j);
+	    matrix6x6(i, j) = matrix6x6new(i + 1, j + 1);
 	 }
       }
       //matrix6x6(3,3) = angleErr;

--- a/Alignment/MuonAlignment/src/MuonAlignmentOutputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentOutputXML.cc
@@ -348,12 +348,12 @@ void MuonAlignmentOutputXML::writeComponents(align::Alignables &alignables,
 
 	    CLHEP::HepSymMatrix err = errors[(*alignable)->id()];
 
-            outputFile <<"  <setape xx=\"" << err(0,0) << "\" xy=\"" << err(0,1) << "\" xz=\"" << err(0,2) << "\" xa=\"" << err(0,3) << "\" xb=\"" << err(0,4) << "\" xc=\"" << err(0,5)
-                       << "\" yy=\"" << err(1,1) << "\" yz=\"" << err(1,2) << "\" ya=\"" << err(1,3) << "\" yb=\"" << err(1,4) << "\" yc=\"" << err(1,5)
-                       << "\" zz=\"" << err(2,2) << "\" za=\"" << err(2,3) << "\" zb=\"" << err(2,4) << "\" zc=\"" << err(2,5)
-                       << "\" aa=\"" << err(3,3) << "\" ab=\"" << err(3,4) << "\" ac=\"" << err(3,5)
-                       << "\" bb=\"" << err(4,4) << "\" bc=\"" << err(4,5)
-                       << "\" cc=\"" << err(5,5) << "\" />" << std::endl;
+            outputFile <<"  <setape xx=\"" << err(1,1) << "\" xy=\"" << err(1,2) << "\" xz=\"" << err(1,3) << "\" xa=\"" << err(1,4) << "\" xb=\"" << err(1,5) << "\" xc=\"" << err(1,6)
+                       << "\" yy=\"" << err(2,2) << "\" yz=\"" << err(2,3) << "\" ya=\"" << err(2,4) << "\" yb=\"" << err(2,5) << "\" yc=\"" << err(2,6)
+                       << "\" zz=\"" << err(3,3) << "\" za=\"" << err(3,4) << "\" zb=\"" << err(3,5) << "\" zc=\"" << err(3,6)
+                       << "\" aa=\"" << err(4,4) << "\" ab=\"" << err(4,5) << "\" ac=\"" << err(4,6)
+                       << "\" bb=\"" << err(5,5) << "\" bc=\"" << err(5,6)
+                       << "\" cc=\"" << err(6,6) << "\" />" << std::endl;
 	 }
 
 	 outputFile << "</operation>" << std::endl << std::endl;


### PR DESCRIPTION
The patch resolves two bugs detected by ASAN and reported here:
https://github.com/cms-sw/cmssw/issues/21296

The problem comes from `CLHEP::HepSymMatrix`, which is using (1, 1) for
starting position instead of (0, 0) according to documentation.

See:
https://gitlab.cern.ch/CLHEP/CLHEP/blob/master/Matrix/Matrix/SymMatrix.h#L120

Please, verify that everything is correct.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>