### PR TITLE
activate 2018 PU workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2034,7 +2034,7 @@ from  Configuration.PyReleaseValidation.upgradeWorkflowComponents import *
 defaultDataSets={}
 defaultDataSets['2017']='CMSSW_9_4_0_pre3-94X_mc2017_realistic_v4-v'
 defaultDataSets['2017Design']='CMSSW_9_4_0_pre3-94X_mc2017_design_IdealBS_v4-v'
-#defaultDataSets['2018']='CMSSW_9_4_0_pre3-94X_upgrade2018_realistic_v4-v'
+defaultDataSets['2018']='CMSSW_10_0_0_pre1-94X_upgrade2018_realistic_v5-v'
 #defaultDataSets['2018Design']='CMSSW_8_1_0_pre16-81X_upgrade2017_design_IdealBS_v6-v'
 #defaultDataSets['2019']=''
 #defaultDataSets['2019Design']=''

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -10,7 +10,7 @@ upgradeKeys[2017] = [
     '2017Design',
     '2017DesignPU',
     '2018',
-#    '2018PU',
+    '2018PU',
     '2018Design',
 #    '2018DesignPU',
     '2019',
@@ -37,7 +37,7 @@ numWFStart={
 }
 numWFSkip=200
 # temporary measure to keep other WF numbers the same
-numWFConflict = [[11000,11200],[11400,11600],[11800,12000],[12200,12400],[25000,26000],[50000,51000]]
+numWFConflict = [[11400,11600],[11800,12000],[12200,12400],[25000,26000],[50000,51000]]
 numWFAll={
     2017: [],
     2023: []


### PR DESCRIPTION
In preparation for next year, activate the PU workflows for the 2018 scenario.

The design workflow is left inactive until an appropriate minbias sample is generated.