### PR TITLE
[GT Updates] for mcRunI and mcRunII for HCAL effective Pedestals to fix PR 21438

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,27 +2,27 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '100X_mcRun1_design_v1',
+    'run1_design'       :   '100X_mcRun1_design_v2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '100X_mcRun1_realistic_v1',
+    'run1_mc'           :   '100X_mcRun1_realistic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '100X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '100X_mcRun1_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '100X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '100X_mcRun1_pA_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '100X_mcRun2_design_v1',
+    'run2_design'       :   '100X_mcRun2_design_v2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '100X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '100X_mcRun2_startup_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '100X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '100X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '100X_mcRun2cosmics_startup_deco_v1',
+    'run2_mc_cosmics'   :   '100X_mcRun2cosmics_startup_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '100X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'        :   '100X_mcRun2_HeavyIon_v3',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '100X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '100X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '100X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,7 +16,7 @@ autoCond = {
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '100X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v1',
+    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '100X_mcRun2cosmics_startup_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2


### PR DESCRIPTION
This PR updates the global tags for mcRunI and mcRunII to fix the problem mentioned here : https://github.com/cms-sw/cmssw/pull/21438#issuecomment-346743645

GT changes description with links will follow...

@abdoulline @kpedro88 