### PR TITLE
move *egmGsfElectronIDsForDQM module to a cms.Task

### DIFF
--- a/DQMOffline/Trigger/python/B2GMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_cff.py
@@ -190,8 +190,10 @@ b2gHLTDQMSourceExtra = cms.Sequence(
     AK8PFJet400_TrimMass30_PromptMonitoring +
     AK8PFJet420_TrimMass30_PromptMonitoring +
 
-    B2GegmGsfElectronIDsForDQM*
     B2GegHLTDQMOfflineTnPSource*
     b2gDileptonHLTOfflineDQM*
-    b2gDimuonHLTOfflineDQM
+    b2gDimuonHLTOfflineDQM,
+
+    cms.Task(B2GegmGsfElectronIDsForDQM)
+
 )

--- a/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
@@ -3,15 +3,15 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egmGsfElectronIDsForDQM,egHLTDQMOfflineTnPSource,egmPhotonIDSequenceForDQM,egHLTElePhoDQMOfflineTnPSource,egHLTElePhoHighEtaDQMOfflineTnPSource,photonIDValueMapProducer,egmPhotonIDsForDQM,egHLTMuonPhoDQMOfflineTnPSource,egmDQMSelectedMuons,egmMuonIDSequenceForDQM,egHLTMuonEleDQMOfflineTnPSource
 
 egammaMonitorHLT = cms.Sequence(
-    egmGsfElectronIDsForDQM*
     egHLTDQMOfflineTnPSource*
     egmPhotonIDSequenceForDQM*
     egHLTElePhoDQMOfflineTnPSource*
     egHLTElePhoHighEtaDQMOfflineTnPSource*
     egmMuonIDSequenceForDQM*
     egHLTMuonEleDQMOfflineTnPSource*
-    egHLTMuonPhoDQMOfflineTnPSource
-    
+    egHLTMuonPhoDQMOfflineTnPSource,
+
+    cms.Task(egmGsfElectronIDsForDQM)
 )
 
 egmHLTDQMSourceExtra = cms.Sequence(

--- a/DQMOffline/Trigger/python/LepHTMonitor_cff.py
+++ b/DQMOffline/Trigger/python/LepHTMonitor_cff.py
@@ -187,8 +187,8 @@ DQMOffline_LepHT_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
 
 from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egmGsfElectronIDsForDQM
 
-LepHTMonitor = cms.Sequence( egmGsfElectronIDsForDQM # Use of electron VID requires this module being executed first
-                            + DQMOffline_Ele15_HT600
+LepHTMonitor = cms.Sequence( 
+                              DQMOffline_Ele15_HT600
                             + DQMOffline_Ele15_HT450
                             + DQMOffline_Ele50_HT450
                             + DQMOffline_Mu15_HT600
@@ -199,7 +199,8 @@ LepHTMonitor = cms.Sequence( egmGsfElectronIDsForDQM # Use of electron VID requi
                             + DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ
                             + DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT350
                             + DQMOffline_DoubleMu4_Mass8_PFHT350
-                            + DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350
+                            + DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350,
+                              cms.Task(egmGsfElectronIDsForDQM) # Use of electron VID requires this module being executed first
 )
 
 LepHTClient = cms.Sequence(  DQMOffline_LepHT_POSTPROCESSING )


### PR DESCRIPTION
Avoid causing an unrunnable module schedule by moving egmGsfElectronIDsForDQM
and B2GegmGsfElectronIDsForDQM to be on a cms.Task which is associated
with the cms.Sequence which previously held the module.

This fixes the release validation failure in the IBs for workflow 136.7802.