### PR TITLE
[RFC] First attempt at a "global" DQM analyzer 

### DIFF
--- a/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
@@ -34,9 +34,9 @@
 #include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include "DQMServices/Core/interface/ConcurrentMonitorElement.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
 
 // helper functions
 template <typename T>
@@ -57,18 +57,91 @@ const T & get(const edm::EventSetup & setup) {
   return * handle.product();
 }
 
+namespace {
 
-class TriggerRatesMonitor : public DQMEDAnalyzer {
+  struct RunBasedHistograms {
+
+    // L1T and HLT configuration
+    L1TUtmTriggerMenu const * l1tMenu;
+
+    struct HLTIndices {
+      unsigned int index_l1_seed;
+      unsigned int index_prescale;
+
+      HLTIndices() :
+        index_l1_seed(  (unsigned int) -1),
+        index_prescale( (unsigned int) -1)
+      { }
+    };
+
+    HLTConfigProvider             hltConfig;
+    std::vector<HLTIndices>       hltIndices;
+
+    std::vector<std::vector<unsigned int>> datasets;
+    std::vector<std::vector<unsigned int>> streams;
+
+    // L1T and HLT rate plots
+
+    // per-path HLT plots
+    struct HLTRatesPlots {
+      ConcurrentMonitorElement pass_l1_seed;
+      ConcurrentMonitorElement pass_prescale;
+      ConcurrentMonitorElement accept;
+      ConcurrentMonitorElement reject;
+      ConcurrentMonitorElement error;
+    };
+
+    // overall event count and event types
+    ConcurrentMonitorElement              events_processed;
+    std::vector<ConcurrentMonitorElement> tcds_counts;
+
+    // L1T triggers
+    std::vector<ConcurrentMonitorElement> l1t_counts;
+
+    // HLT triggers
+    std::vector<std::vector<HLTRatesPlots>> hlt_by_dataset_counts;
+
+    // datasets
+    std::vector<ConcurrentMonitorElement> dataset_counts;
+
+    // streams
+    std::vector<ConcurrentMonitorElement> stream_counts;
+
+    RunBasedHistograms() :
+      // L1T and HLT configuration
+      l1tMenu(),
+      hltConfig(),
+      hltIndices(),
+      datasets(),
+      streams(),
+      // overall event count and event types
+      events_processed(),
+      tcds_counts(),
+      // L1T triggers
+      l1t_counts(),
+      // HLT triggers
+      hlt_by_dataset_counts(),
+      // datasets
+      dataset_counts(),
+      // streams
+      stream_counts()
+    {
+    }
+
+  };
+}
+
+class TriggerRatesMonitor : public DQMGlobalEDAnalyzer<RunBasedHistograms> {
 public:
   explicit TriggerRatesMonitor(edm::ParameterSet const &);
-  ~TriggerRatesMonitor() override;
+  ~TriggerRatesMonitor() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const &, edm::EventSetup const &) override;
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &, RunBasedHistograms &) const override;
+  void bookHistograms(DQMStore::ConcurrentBooker &, edm::Run const&, edm::EventSetup const&, RunBasedHistograms &) const override;
+  void dqmAnalyze(edm::Event const &, edm::EventSetup const &, RunBasedHistograms const&) const override;
 
   // TCDS trigger types
   // see https://twiki.cern.ch/twiki/bin/viewauth/CMS/TcdsEventRecord
@@ -94,56 +167,10 @@ private:
   // module configuration
   const edm::EDGetTokenT<GlobalAlgBlkBxCollection>  m_l1t_results;
   const edm::EDGetTokenT<edm::TriggerResults>       m_hlt_results;
-  std::string                                       m_dqm_path;
-  uint32_t                                          m_lumisections_range;
-
-  // L1T and HLT configuration
-
-  L1TUtmTriggerMenu const * m_l1tMenu;
-
-  struct HLTIndices {
-    unsigned int index_l1_seed;
-    unsigned int index_prescale;
-
-    HLTIndices() :
-      index_l1_seed(  (unsigned int) -1),
-      index_prescale( (unsigned int) -1)
-    { }
-  };
-
-  HLTConfigProvider             m_hltConfig;
-  std::vector<HLTIndices>       m_hltIndices;
-
-  std::vector<std::vector<unsigned int>> m_datasets;
-  std::vector<std::vector<unsigned int>> m_streams;
-
-  // L1T and HLT rate plots
-
-  struct HLTRatesPlots {
-    TH1F * pass_l1_seed;
-    TH1F * pass_prescale;
-    TH1F * accept;
-    TH1F * reject;
-    TH1F * error;
-  };
-
-  // overall event count and event types
-  TH1F *                        m_events_processed;
-  std::vector<TH1F *>           m_tcds_counts;
-
-  // L1T triggers
-  std::vector<TH1F *>           m_l1t_counts;
-
-  // HLT triggers
-  std::vector<std::vector<HLTRatesPlots> > m_hlt_by_dataset_counts;
-
-  // datasets
-  std::vector<TH1F *>           m_dataset_counts;
-
-  // streams
-  std::vector<TH1F *>           m_stream_counts;
-
+  const std::string                                 m_dqm_path;
+  const uint32_t                                    m_lumisections_range;
 };
+
 
 // definition
 constexpr const char * const TriggerRatesMonitor::s_tcds_trigger_types[];
@@ -165,42 +192,21 @@ TriggerRatesMonitor::TriggerRatesMonitor(edm::ParameterSet const & config) :
   m_l1t_results(consumes<GlobalAlgBlkBxCollection>( config.getUntrackedParameter<edm::InputTag>( "l1tResults" ) )),
   m_hlt_results(consumes<edm::TriggerResults>(      config.getUntrackedParameter<edm::InputTag>( "hltResults" ) )),
   m_dqm_path(                                       config.getUntrackedParameter<std::string>(   "dqmPath" ) ),
-  m_lumisections_range(                             config.getUntrackedParameter<uint32_t>(      "lumisectionRange" ) ),
-  // L1T and HLT configuration
-  m_l1tMenu(nullptr),
-  m_hltConfig(),
-  m_hltIndices(),
-  m_datasets(),
-  m_streams(),
-  // overall event count and event types
-  m_events_processed(nullptr),
-  m_tcds_counts(),
-  // L1T triggers
-  m_l1t_counts(),
-  // HLT triggers
-  m_hlt_by_dataset_counts(),
-  // datasets
-  m_dataset_counts(),
-  // streams
-  m_stream_counts()
+  m_lumisections_range(                             config.getUntrackedParameter<uint32_t>(      "lumisectionRange" ) )
 {
 }
 
-TriggerRatesMonitor::~TriggerRatesMonitor()
+void TriggerRatesMonitor::dqmBeginRun(edm::Run const& run, edm::EventSetup const& setup, RunBasedHistograms& histograms) const
 {
-}
-
-void TriggerRatesMonitor::dqmBeginRun(edm::Run const & run, edm::EventSetup const & setup)
-{
-  m_events_processed = nullptr;
-  m_tcds_counts.clear();
-  m_tcds_counts.resize(sizeof(s_tcds_trigger_types)/sizeof(const char *), nullptr);
+  histograms.events_processed.reset();
+  histograms.tcds_counts.clear();
+  histograms.tcds_counts.resize(sizeof(s_tcds_trigger_types)/sizeof(const char *));
 
   // cache the L1 trigger menu
-  m_l1tMenu = & get<L1TUtmTriggerMenuRcd, L1TUtmTriggerMenu>(setup);
-  if (m_l1tMenu) {
-    m_l1t_counts.clear();
-    m_l1t_counts.resize(GlobalAlgBlk::maxPhysicsTriggers, nullptr);
+  histograms.l1tMenu = & get<L1TUtmTriggerMenuRcd, L1TUtmTriggerMenu>(setup);
+  if (histograms.l1tMenu) {
+    histograms.l1t_counts.clear();
+    histograms.l1t_counts.resize(GlobalAlgBlk::maxPhysicsTriggers);
   } else {
     edm::LogError("TriggerRatesMonitor") << "failed to read the L1 menu from the EventSetup, the L1 trigger rates will not be monitored";
   }
@@ -209,104 +215,104 @@ void TriggerRatesMonitor::dqmBeginRun(edm::Run const & run, edm::EventSetup cons
   bool changed = true;
   edm::EDConsumerBase::Labels labels;
   labelsForToken(m_hlt_results, labels);
-  if (m_hltConfig.init(run, setup, labels.process, changed)) {
-    m_hltIndices.resize( m_hltConfig.size(), HLTIndices() );
+  if (histograms.hltConfig.init(run, setup, labels.process, changed)) {
+    histograms.hltIndices.resize(histograms.hltConfig.size());
 
-    unsigned int datasets = m_hltConfig.datasetNames().size();
-    m_hlt_by_dataset_counts.clear();
-    m_hlt_by_dataset_counts.resize( datasets, {} );
+    unsigned int datasets = histograms.hltConfig.datasetNames().size();
+    histograms.hlt_by_dataset_counts.clear();
+    histograms.hlt_by_dataset_counts.resize(datasets);
     
-    m_datasets.clear();
-    m_datasets.resize( datasets, {} );
+    histograms.datasets.clear();
+    histograms.datasets.resize(datasets);
     for (unsigned int i = 0; i < datasets; ++i) {
-      auto const & paths = m_hltConfig.datasetContent(i);
-      m_hlt_by_dataset_counts[i].resize( paths.size(), HLTRatesPlots() );
-      m_datasets[i].reserve(paths.size());
+      auto const & paths = histograms.hltConfig.datasetContent(i);
+      histograms.hlt_by_dataset_counts[i].resize(paths.size());
+      histograms.datasets[i].reserve(paths.size());
       for (auto const & path: paths) {
-        m_datasets[i].push_back(m_hltConfig.triggerIndex(path));
+        histograms.datasets[i].push_back(histograms.hltConfig.triggerIndex(path));
       }
     }
-    m_dataset_counts.clear();
-    m_dataset_counts.resize( datasets, nullptr );
+    histograms.dataset_counts.clear();
+    histograms.dataset_counts.resize(datasets);
 
-    unsigned int streams = m_hltConfig.streamNames().size();
-    m_streams.clear();
-    m_streams.resize( streams, {} );
+    unsigned int streams = histograms.hltConfig.streamNames().size();
+    histograms.streams.clear();
+    histograms.streams.resize(streams);
     for (unsigned int i = 0; i < streams; ++i) {
-      for (auto const & dataset : m_hltConfig.streamContent(i)) {
-        for (auto const & path : m_hltConfig.datasetContent(dataset))
-          m_streams[i].push_back(m_hltConfig.triggerIndex(path));
+      for (auto const & dataset : histograms.hltConfig.streamContent(i)) {
+        for (auto const & path : histograms.hltConfig.datasetContent(dataset))
+          histograms.streams[i].push_back(histograms.hltConfig.triggerIndex(path));
       }
-      std::sort(m_streams[i].begin(), m_streams[i].end());
-      auto unique_end = std::unique(m_streams[i].begin(), m_streams[i].end());
-      m_streams[i].resize(unique_end - m_streams[i].begin());
-      m_streams[i].shrink_to_fit();
+      std::sort(histograms.streams[i].begin(), histograms.streams[i].end());
+      auto unique_end = std::unique(histograms.streams[i].begin(), histograms.streams[i].end());
+      histograms.streams[i].resize(unique_end - histograms.streams[i].begin());
+      histograms.streams[i].shrink_to_fit();
     }
-    m_stream_counts.clear();
-    m_stream_counts.resize( streams, nullptr );
+    histograms.stream_counts.clear();
+    histograms.stream_counts.resize(streams);
   } else {
     // HLTConfigProvider not initialised, skip the the HLT monitoring
     edm::LogError("TriggerRatesMonitor") << "failed to initialise HLTConfigProvider, the HLT trigger and datasets rates will not be monitored";
   }
 }
 
-void TriggerRatesMonitor::bookHistograms(DQMStore::IBooker & booker, edm::Run const & run, edm::EventSetup const & setup)
+void TriggerRatesMonitor::bookHistograms(DQMStore::ConcurrentBooker & booker, edm::Run const& run, edm::EventSetup const& setup, RunBasedHistograms & histograms) const
 {
   // book the overall event count and event types histograms
   booker.setCurrentFolder( m_dqm_path );
-  m_events_processed = booker.book1D("events", "Processed events vs. lumisection", m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5)->getTH1F();
+  histograms.events_processed = booker.book1D("events", "Processed events vs. lumisection", m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
   booker.setCurrentFolder( m_dqm_path + "/TCDS" );
   for (unsigned int i = 0; i < sizeof(s_tcds_trigger_types)/sizeof(const char *); ++i)
     if (s_tcds_trigger_types[i]) {
       std::string const & title = (boost::format("%s events vs. lumisection") % s_tcds_trigger_types[i]).str();
-      m_tcds_counts[i] = booker.book1D(s_tcds_trigger_types[i], title, m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5)->getTH1F();
+      histograms.tcds_counts[i] = booker.book1D(s_tcds_trigger_types[i], title, m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
     }
 
-  if (m_l1tMenu) {
+  if (histograms.l1tMenu) {
     // book the rate histograms for the L1 triggers that are included in the L1 menu
     booker.setCurrentFolder( m_dqm_path + "/L1T" );
-    for (auto const & keyval: m_l1tMenu->getAlgorithmMap()) {
+    for (auto const & keyval: histograms.l1tMenu->getAlgorithmMap()) {
       unsigned int bit = keyval.second.getIndex();
       bool masked = false;      // FIXME read L1 masks once they will be avaiable in the EventSetup
       std::string const & name  = (boost::format("%s (bit %d)") % keyval.first % bit).str();
       std::string const & title = (boost::format("%s (bit %d)%s vs. lumisection") % keyval.first % bit % (masked ? " (masked)" : "")).str();
-      m_l1t_counts.at(bit) = booker.book1D(name, title, m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5)->getTH1F();
+      histograms.l1t_counts.at(bit) = booker.book1D(name, title, m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
     }
   }
 
-  if (m_hltConfig.inited()) {
+  if (histograms.hltConfig.inited()) {
 
-    auto const & datasets = m_hltConfig.datasetNames();
+    auto const & datasets = histograms.hltConfig.datasetNames();
 
     // book the rate histograms for the HLT triggers
     for (unsigned int d = 0; d < datasets.size(); ++d) {
       booker.setCurrentFolder( m_dqm_path + "/HLT/" + datasets[d]);
-      for (unsigned int i = 0; i < m_datasets[d].size(); ++i) {
-	unsigned int index = m_datasets[d][i];
-	std::string const & name = m_hltConfig.triggerName(index);
-	m_hlt_by_dataset_counts[d][i].pass_l1_seed  = booker.book1D(name + "_pass_L1_seed",     name + " pass L1 seed, vs. lumisection",     m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
-	m_hlt_by_dataset_counts[d][i].pass_prescale = booker.book1D(name + "_pass_prescaler",   name + " pass prescaler, vs. lumisection",   m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
-	m_hlt_by_dataset_counts[d][i].accept        = booker.book1D(name + "_accept",           name + " accept, vs. lumisection",           m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
-	m_hlt_by_dataset_counts[d][i].reject        = booker.book1D(name + "_reject",           name + " reject, vs. lumisection",           m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
-	m_hlt_by_dataset_counts[d][i].error         = booker.book1D(name + "_error",            name + " error, vs. lumisection",            m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
+      for (unsigned int i = 0; i < histograms.datasets[d].size(); ++i) {
+	unsigned int index = histograms.datasets[d][i];
+	std::string const & name = histograms.hltConfig.triggerName(index);
+	histograms.hlt_by_dataset_counts[d][i].pass_l1_seed  = booker.book1D(name + "_pass_L1_seed",     name + " pass L1 seed, vs. lumisection",     m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5);
+	histograms.hlt_by_dataset_counts[d][i].pass_prescale = booker.book1D(name + "_pass_prescaler",   name + " pass prescaler, vs. lumisection",   m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5);
+	histograms.hlt_by_dataset_counts[d][i].accept        = booker.book1D(name + "_accept",           name + " accept, vs. lumisection",           m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5);
+	histograms.hlt_by_dataset_counts[d][i].reject        = booker.book1D(name + "_reject",           name + " reject, vs. lumisection",           m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5);
+	histograms.hlt_by_dataset_counts[d][i].error         = booker.book1D(name + "_error",            name + " error, vs. lumisection",            m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5);
       }
 
       //      booker.setCurrentFolder( m_dqm_path + "/HLT/" + datasets[d]);
-      for (unsigned int i: m_datasets[d]) {
+      for (unsigned int i: histograms.datasets[d]) {
 
 	// look for the index of the (last) L1 seed and prescale module in each path
-	m_hltIndices[i].index_l1_seed  = m_hltConfig.size(i);
-	m_hltIndices[i].index_prescale = m_hltConfig.size(i);
-	for (unsigned int j = 0; j < m_hltConfig.size(i); ++j) {
-	  std::string const & label = m_hltConfig.moduleLabel(i, j);
-	  std::string const & type  = m_hltConfig.moduleType(label);
+	histograms.hltIndices[i].index_l1_seed  = histograms.hltConfig.size(i);
+	histograms.hltIndices[i].index_prescale = histograms.hltConfig.size(i);
+	for (unsigned int j = 0; j < histograms.hltConfig.size(i); ++j) {
+	  std::string const & label = histograms.hltConfig.moduleLabel(i, j);
+	  std::string const & type  = histograms.hltConfig.moduleType(label);
 	  if (type == "HLTL1TSeed" or type == "HLTLevel1GTSeed" or type == "HLTLevel1Activity" or type == "HLTLevel1Pattern") {
 	    // there might be more L1 seed filters in sequence
 	    // keep looking and store the index of the last one
-	    m_hltIndices[i].index_l1_seed  = j;
+	    histograms.hltIndices[i].index_l1_seed  = j;
 	  } else if (type == "HLTPrescaler") {
 	    // there should be only one prescaler in a path, and it should follow all L1 seed filters
-	    m_hltIndices[i].index_prescale = j;
+	    histograms.hltIndices[i].index_prescale = j;
 	    break;
 	  }
 	}
@@ -316,75 +322,75 @@ void TriggerRatesMonitor::bookHistograms(DQMStore::IBooker & booker, edm::Run co
     // book the HLT datasets rate histograms
     booker.setCurrentFolder( m_dqm_path + "/Datasets" );
     for (unsigned int i = 0; i < datasets.size(); ++i)
-      m_dataset_counts[i] = booker.book1D(datasets[i], datasets[i], m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5)->getTH1F();
+      histograms.dataset_counts[i] = booker.book1D(datasets[i], datasets[i], m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
    
     // book the HLT streams rate histograms
     booker.setCurrentFolder( m_dqm_path + "/Streams" );
-    auto const & streams = m_hltConfig.streamNames();
+    auto const & streams = histograms.hltConfig.streamNames();
     for (unsigned int i = 0; i < streams.size(); ++i)
-      m_stream_counts[i]  = booker.book1D(streams[i],  streams[i],  m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5)->getTH1F();
+      histograms.stream_counts[i] = booker.book1D(streams[i],  streams[i],  m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
   }
 
 }
 
 
-void TriggerRatesMonitor::analyze(edm::Event const & event, edm::EventSetup const & setup)
+void TriggerRatesMonitor::dqmAnalyze(edm::Event const & event, edm::EventSetup const & setup, RunBasedHistograms const& histograms) const
 {
   unsigned int lumisection = event.luminosityBlock();
 
   // monitor the overall event count and event types rates
-  m_events_processed->Fill(lumisection);
-  if (m_tcds_counts[event.experimentType()])
-    m_tcds_counts[event.experimentType()]->Fill(lumisection);
+  histograms.events_processed.fill(lumisection);
+  if (histograms.tcds_counts[event.experimentType()])
+    histograms.tcds_counts[event.experimentType()].fill(lumisection);
 
   // monitor the L1 triggers rates
-  if (m_l1tMenu) {
+  if (histograms.l1tMenu) {
     auto const & bxvector = get<GlobalAlgBlkBxCollection>(event, m_l1t_results);
     if (not bxvector.isEmpty(0)) {
       auto const & results = bxvector.at(0, 0);
       for (unsigned int i = 0; i < GlobalAlgBlk::maxPhysicsTriggers; ++i)
         if (results.getAlgoDecisionFinal(i))
-          if (m_l1t_counts[i])
-            m_l1t_counts[i]->Fill(lumisection);
+          if (histograms.l1t_counts[i])
+            histograms.l1t_counts[i].fill(lumisection);
     }
   }
 
   // monitor the HLT triggers and datsets rates
-  if (m_hltConfig.inited()) {
+  if (histograms.hltConfig.inited()) {
     edm::TriggerResults const & hltResults = get<edm::TriggerResults>(event, m_hlt_results);
-    if (hltResults.size() == m_hltIndices.size()) {
+    if (hltResults.size() == histograms.hltIndices.size()) {
     } else {
       edm::LogWarning("TriggerRatesMonitor") << "This should never happen: the number of HLT paths has changed since the beginning of the run";
     }
 
-    for (unsigned int d = 0; d < m_datasets.size(); ++d) {
-      for (unsigned int i: m_datasets[d])
+    for (unsigned int d = 0; d < histograms.datasets.size(); ++d) {
+      for (unsigned int i: histograms.datasets[d])
         if (hltResults.at(i).accept()) {
-          m_dataset_counts[d]->Fill(lumisection);
+          histograms.dataset_counts[d].fill(lumisection);
           // ensure each dataset is incremented only once per event
           break;
         }
-      for (unsigned int i = 0; i < m_datasets[d].size(); ++i) {
-	unsigned int index = m_datasets[d][i];
+      for (unsigned int i = 0; i < histograms.datasets[d].size(); ++i) {
+	unsigned int index = histograms.datasets[d][i];
 	edm::HLTPathStatus const & path = hltResults.at(index);
 
-        if (path.index() > m_hltIndices[index].index_l1_seed)
-          m_hlt_by_dataset_counts[d][i].pass_l1_seed->Fill(lumisection);
-        if  (path.index() > m_hltIndices[index].index_prescale)
-          m_hlt_by_dataset_counts[d][i].pass_prescale->Fill(lumisection);
+        if (path.index() > histograms.hltIndices[index].index_l1_seed)
+          histograms.hlt_by_dataset_counts[d][i].pass_l1_seed.fill(lumisection);
+        if (path.index() > histograms.hltIndices[index].index_prescale)
+          histograms.hlt_by_dataset_counts[d][i].pass_prescale.fill(lumisection);
         if (path.accept())
-          m_hlt_by_dataset_counts[d][i].accept->Fill(lumisection);
+          histograms.hlt_by_dataset_counts[d][i].accept.fill(lumisection);
         else if (path.error())
-          m_hlt_by_dataset_counts[d][i].error ->Fill(lumisection);
+          histograms.hlt_by_dataset_counts[d][i].error .fill(lumisection);
         else
-          m_hlt_by_dataset_counts[d][i].reject->Fill(lumisection);
+          histograms.hlt_by_dataset_counts[d][i].reject.fill(lumisection);
       }
     }
 
-    for (unsigned int i = 0; i < m_streams.size(); ++i)
-      for (unsigned int j: m_streams[i])
+    for (unsigned int i = 0; i < histograms.streams.size(); ++i)
+      for (unsigned int j: histograms.streams[i])
         if (hltResults.at(j).accept()) {
-          m_stream_counts[i]->Fill(lumisection);
+          histograms.stream_counts[i].fill(lumisection);
           // ensure each stream is incremented only once per event
           break;
         }

--- a/DQMServices/Core/interface/ConcurrentMonitorElement.h
+++ b/DQMServices/Core/interface/ConcurrentMonitorElement.h
@@ -1,0 +1,86 @@
+#ifndef DQMServices_Core_ConcurrentMonitorElement_h
+#define DQMServices_Core_ConcurrentMonitorElement_h
+
+/* Encapsulate of MonitorElement to expose *limited* support for concurrency.
+ *
+ * ...
+ */
+
+#include <mutex>
+
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+class ConcurrentMonitorElement : protected MonitorElement
+{
+private:
+  mutable MonitorElement* me_;
+  mutable std::mutex lock_;
+
+public:
+  ConcurrentMonitorElement(void) :
+    me_(nullptr)
+  { }
+
+  explicit ConcurrentMonitorElement(MonitorElement* me) :
+    me_(me)
+  { }
+
+  // non-copiable
+  ConcurrentMonitorElement(ConcurrentMonitorElement const&) = delete;
+
+  // movable
+  ConcurrentMonitorElement(ConcurrentMonitorElement && other)
+  {
+    std::lock_guard<std::mutex>(other.lock_);
+    me_ = other.me_;
+    other.me_ = nullptr;
+  }
+
+  // not copy-assignable
+  ConcurrentMonitorElement& operator=(ConcurrentMonitorElement const&) = delete;
+
+  // move-assignable
+  ConcurrentMonitorElement& operator=(ConcurrentMonitorElement && other)
+  {
+    // FIXME replace with std::scoped_lock once C++17 is available
+    std::lock(lock_, other.lock_);
+    std::lock_guard<std::mutex> ours(lock_, std::adopt_lock);
+    std::lock_guard<std::mutex> others(other.lock_, std::adopt_lock);
+    me_ = other.me_;
+    other.me_ = nullptr;
+    return *this;
+  }
+
+  // nothing to do, we do not own the MonitorElement
+  ~ConcurrentMonitorElement(void) = default;
+
+  // expose as a const method to mean that it is concurrent-safe
+  template <typename... Args>
+  void fill(Args && ... args) const
+  {
+    std::lock_guard<std::mutex> guard(lock_);
+    me_->Fill(std::forward<Args>(args)...);
+  }
+
+  // expose as a const method to mean that it is concurrent-safe
+  void shiftFillLast(double y, double ye = 0., int32_t xscale = 1) const
+  {
+    std::lock_guard<std::mutex> guard(lock_);
+    me_->ShiftFillLast(y, ye, xscale);
+  }
+
+  // reset the internal pointer
+  void reset()
+  {
+    std::lock_guard<std::mutex> guard(lock_);
+    me_ = nullptr;
+  }
+
+  operator bool() const
+  {
+    std::lock_guard<std::mutex> guard(lock_);
+    return (me_ != nullptr);
+  } 
+};
+
+#endif // DQMServices_Core_ConcurrentMonitorElement_h

--- a/DQMServices/Core/interface/DQMGlobalEDAnalyzer.h
+++ b/DQMServices/Core/interface/DQMGlobalEDAnalyzer.h
@@ -1,0 +1,64 @@
+#ifndef DQMServices_Core_DQMGlobalEDAnalyzer_h
+#define DQMServices_Core_DQMGlobalEDAnalyzer_h
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+template <typename H>
+class DQMGlobalEDAnalyzer : public edm::global::EDAnalyzer<edm::RunCache<H>>
+{
+private:
+  std::shared_ptr<H>
+  globalBeginRun(edm::Run const&, edm::EventSetup const&) const final;
+
+  void
+  globalEndRun(edm::Run const&, edm::EventSetup const&) const final;
+
+  virtual void
+  dqmBeginRun(edm::Run const&, edm::EventSetup const&, H &) const { }
+
+  // this will run while holding the DQMStore lock
+  virtual void
+  bookHistograms(DQMStore::ConcurrentBooker &, edm::Run const&, edm::EventSetup const&, H &) const = 0;
+
+  void
+  analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const final;
+
+  virtual void
+  dqmAnalyze(edm::Event const&, edm::EventSetup const&, H const&) const = 0;
+};
+
+template <typename H>
+std::shared_ptr<H>
+DQMGlobalEDAnalyzer<H>::globalBeginRun(edm::Run const& run, edm::EventSetup const& setup) const
+{
+  auto h = std::make_shared<H>();
+  dqmBeginRun(run, setup, *h);
+  edm::Service<DQMStore>()->bookConcurrentTransaction([&, this](DQMStore::ConcurrentBooker &b) {
+      // this runs while holding the DQMStore lock
+      b.cd();
+      bookHistograms(b, run, setup, *h);
+    },
+    run.run() );
+  return h;
+}
+
+template <typename H>
+void
+DQMGlobalEDAnalyzer<H>::globalEndRun(edm::Run const&, edm::EventSetup const&) const
+{
+}
+
+template <typename H>
+void
+DQMGlobalEDAnalyzer<H>::analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const
+{
+  //auto& h = const_cast<H&>(* this->runCache(event.getRun().index()));
+  auto const& h = * this->runCache(event.getRun().index());
+  dqmAnalyze(event, setup, h);
+}
+
+#endif // DQMServices_Core_DQMGlobalEDAnalyzer_h

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -1,25 +1,28 @@
-#ifndef DQMSERVICES_CORE_DQM_STORE_H
-# define DQMSERVICES_CORE_DQM_STORE_H
+#ifndef DQMServices_Core_DQMStore_h
+#define DQMServices_Core_DQMStore_h
 
-# if __GNUC__ && ! defined DQM_DEPRECATED
-#  define DQM_DEPRECATED __attribute__((deprecated))
-# endif
+#if __GNUC__ && ! defined DQM_DEPRECATED
+#define DQM_DEPRECATED __attribute__((deprecated))
+#endif
 
-# include "DQMServices/Core/interface/DQMDefinitions.h"
-# include "classlib/utils/Regexp.h"
-# include <vector>
-# include <string>
-# include <list>
-# include <map>
-# include <set>
-# include <cassert>
-# include <mutex>
-# include <thread>
-# include <execinfo.h>
-# include <cstdio>
-# include <cstdlib>
-# include <cxxabi.h>
-# include <iosfwd>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <iosfwd>
+#include <list>
+#include <map>
+#include <mutex>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+#include <cxxabi.h>
+#include <execinfo.h>
+
+#include <classlib/utils/Regexp.h>
+
+#include "DQMServices/Core/interface/DQMDefinitions.h"
+#include "DQMServices/Core/interface/ConcurrentMonitorElement.h"
 
 namespace edm { class DQMHttpSource; class ParameterSet; class ActivityRegistry;}
 namespace lat { class Regexp; }
@@ -187,6 +190,109 @@ class DQMStore
     DQMStore * owner_;
   };  // IBooker
 
+  class ConcurrentBooker : public IBooker
+  {
+  public:
+    friend class DQMStore;
+
+    // for the supported syntaxes, see the declarations of DQMStore::bookString
+    template <typename... Args>
+    ConcurrentMonitorElement bookString(Args && ... args) {
+      MonitorElement* me = IBooker::bookString(std::forward<Args>(args)...);
+      return ConcurrentMonitorElement(me);
+    }
+
+    // for the supported syntaxes, see the declarations of DQMStore::bookInt
+    template <typename... Args>
+    ConcurrentMonitorElement bookInt(Args && ... args) {
+      MonitorElement* me = IBooker::bookInt(std::forward<Args>(args)...);
+      return ConcurrentMonitorElement(me);
+    }
+
+    // for the supported syntaxes, see the declarations of DQMStore::bookFloat
+    template <typename... Args>
+    ConcurrentMonitorElement bookFloat(Args && ... args) {
+      MonitorElement* me = IBooker::bookFloat(std::forward<Args>(args)...);
+      return ConcurrentMonitorElement(me);
+    }
+
+    // for the supported syntaxes, see the declarations of DQMStore::book1D
+    template <typename... Args>
+    ConcurrentMonitorElement book1D(Args && ... args) {
+      MonitorElement* me = IBooker::book1D(std::forward<Args>(args)...);
+      return ConcurrentMonitorElement(me);
+    }
+
+    // for the supported syntaxes, see the declarations of DQMStore::book1S
+    template <typename... Args>
+    ConcurrentMonitorElement book1S(Args && ... args) {
+      MonitorElement* me = IBooker::book1S(std::forward<Args>(args)...);
+      return ConcurrentMonitorElement(me);
+    }
+
+    // for the supported syntaxes, see the declarations of DQMStore::book1DD
+    template <typename... Args>
+    ConcurrentMonitorElement book1DD(Args && ... args) {
+      MonitorElement* me = IBooker::book1DD(std::forward<Args>(args)...);
+      return ConcurrentMonitorElement(me);
+    }
+
+    // for the supported syntaxes, see the declarations of DQMStore::book2D
+    template <typename... Args>
+    ConcurrentMonitorElement book2D(Args && ... args) {
+      MonitorElement* me = IBooker::book2D(std::forward<Args>(args)...);
+      return ConcurrentMonitorElement(me);
+    }
+
+    // for the supported syntaxes, see the declarations of DQMStore::book2S
+    template <typename... Args>
+    ConcurrentMonitorElement book2S(Args && ... args) {
+      MonitorElement* me = IBooker::book2S(std::forward<Args>(args)...);
+      return ConcurrentMonitorElement(me);
+    }
+
+    // for the supported syntaxes, see the declarations of DQMStore::book2DD
+    template <typename... Args>
+    ConcurrentMonitorElement book2DD(Args && ... args) {
+      MonitorElement* me = IBooker::book2DD(std::forward<Args>(args)...);
+      return ConcurrentMonitorElement(me);
+    }
+
+    // for the supported syntaxes, see the declarations of DQMStore::book3D
+    template <typename... Args>
+    ConcurrentMonitorElement book3D(Args && ... args) {
+      MonitorElement* me = IBooker::book3D(std::forward<Args>(args)...);
+      return ConcurrentMonitorElement(me);
+    }
+
+    // for the supported syntaxes, see the declarations of DQMStore::bookProfile
+    template <typename... Args>
+    ConcurrentMonitorElement bookProfile(Args && ... args) {
+      MonitorElement* me = IBooker::bookProfile(std::forward<Args>(args)...);
+      return ConcurrentMonitorElement(me);
+    }
+
+    // for the supported syntaxes, see the declarations of DQMStore::bookProfile2D
+    template <typename... Args>
+    ConcurrentMonitorElement bookProfile2D(Args && ... args) {
+      MonitorElement* me = IBooker::bookProfile2D(std::forward<Args>(args)...);
+      return ConcurrentMonitorElement(me);
+    }
+
+  private:
+    explicit ConcurrentBooker(DQMStore * store) :
+      IBooker(store)
+    { }
+
+    ConcurrentBooker() = delete;
+    ConcurrentBooker(ConcurrentBooker const&) = delete;
+    ConcurrentBooker(ConcurrentBooker &&) = delete;
+    ConcurrentBooker& operator= (ConcurrentBooker const&) = delete;
+    ConcurrentBooker& operator= (ConcurrentBooker &&) = delete;
+
+    ~ConcurrentBooker() = default;
+  };
+
   class IGetter
   {
    public:
@@ -240,7 +346,7 @@ class DQMStore
   // is passed the instance of the IBooker class (owned by the *only*
   // DQMStore instance), that is capable of booking MonitorElements
   // into the DQMStore via a public API. The central mutex is acquired
-  // *before* invoking fand automatically released upon returns.
+  // *before* invoking and automatically released upon returns.
   template <typename iFunc>
   void bookTransaction(iFunc f,
 		       uint32_t run,
@@ -266,6 +372,27 @@ class DQMStore
       moduleId_ = 0;
     }
   }
+
+  // Similar function used to book "global" histograms via the
+  // ConcurrentMonitorElement interface.
+  template <typename iFunc>
+  void bookConcurrentTransaction(iFunc f, uint32_t run) {
+    std::lock_guard<std::mutex> guard(book_mutex_);
+    /* Even if enableMultiThread_ is enabled, keep the streamId_
+       and moduleId_ to 0, since we want to book global histograms. */
+    if (enableMultiThread_) {
+      run_ = run;
+    }
+    ConcurrentBooker booker(this);
+    f(booker);
+
+    /* Set back to 0 the run_ in case we run in mixed conditions
+       with DQMEDAnalyzers and legacy modules */
+    if (enableMultiThread_) {
+      run_ = 0;
+    }
+  }
+
   // Signature needed in the harvesting where the booking is done
   // in the endJob. No handles to the run there. Two arguments ensure
   // the capability of booking and getting. The method relies on the
@@ -275,6 +402,7 @@ class DQMStore
   void meBookerGetter(iFunc f) {
     f(*ibooker_, *igetter_);
   }
+
   // Signature needed in the harvesting where it might be needed to get
   // the LS based histograms. Handle to the Lumi and to the iSetup are available.
   // No need to book anything there. The method relies on the
@@ -640,7 +768,7 @@ class DQMStore
   void        initializeFrom(const edm::ParameterSet&);
   void        reset(void);
   void        forceReset(void);
-  
+
   bool        extract(TObject *obj, const std::string &dir, bool overwrite, bool collateHistograms);
   TObject *   extractNextObject(TBufferFile&) const;
 
@@ -690,7 +818,7 @@ class DQMStore
 
   //-------------------------------------------------------------------------------
   //-------------------------------------------------------------------------------
-  typedef std::pair<fastmatch *, QCriterion *>                  QTestSpec;
+  typedef std::pair<fastmatch *, QCriterion *>                          QTestSpec;
   typedef std::list<QTestSpec>                                          QTestSpecs;
   typedef std::set<MonitorElement>                                      MEMap;
   typedef std::map<std::string, QCriterion *>                           QCMap;
@@ -733,4 +861,4 @@ class DQMStore
   friend class MEtoEDMConverter;
 };
 
-#endif // DQMSERVICES_CORE_DQM_STORE_H
+#endif // DQMServices_Core_DQMStore_h


### PR DESCRIPTION
Use a wrapper around `MonitorElement` to handle concurrent filling via the `fill(...) const` and `shiftFillLast(...) const` methods.

All configuration of the underlying ROOT objects should to be done before booking the `MonitorElement` (e.g. via `book1D (const std::string &name, TH1F *h);`.
Or, we can add the non-`const` methods that are already avalable in the `MonitorElement` interface, though they are only a subset of the `TH1` methods.
In any case, no access to the underlying ROOT object pointer is provided.

Add a `ConcurrentBooker` class that inherits from `IBooker` and replace its `book...` methods to return `ConcurrentMonitorElements`; and a `DQMStore::bookConcurrentTransaction(...)` method that uses the `ConcurrentBooker` in place of the `IBooker`.

Add a new `DQMGlobalEDAnalyzer` inheriting from `edm::global::EDAnalyzer` instead of `edm::stream::EDAnalyzer`, and books "global" `MonitorElement`s (with stream id = 0 and module id = 0).
The user will need to provide a `class` or `struct` that can book and fill the histograms. Filling must be a `const` method, so one should make use of the `ConcurrentMonitorElement` just introduced.