### PR TITLE
Fix build fail in SimG4Core/CustomPhysics

### DIFF
--- a/SimG4Core/CustomPhysics/src/CMSDarkPairProduction.cc
+++ b/SimG4Core/CustomPhysics/src/CMSDarkPairProduction.cc
@@ -5,7 +5,7 @@
 //
 // -------------------------------------------------------------------
 //
-#include "SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh"
+#include "SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.h"
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PairProductionRelModel.hh"

--- a/SimG4Core/CustomPhysics/src/CMSDarkPairProductionProcess.cc
+++ b/SimG4Core/CustomPhysics/src/CMSDarkPairProductionProcess.cc
@@ -5,7 +5,7 @@
 //
 // -----------------------------------------------------------------------------
 
-#include "SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh"
+#include "SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.h"
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4BetheHeitlerModel.hh"

--- a/SimG4Core/CustomPhysics/src/HadronicProcessHelper.cc
+++ b/SimG4Core/CustomPhysics/src/HadronicProcessHelper.cc
@@ -6,7 +6,7 @@
 #include <string>
 
 #include "SimG4Core/CustomPhysics/interface/CustomPDGParser.h"
-#include "SimG4Core/CustomPhysics/interface/HadronicProcessHelper.hh"
+#include "SimG4Core/CustomPhysics/interface/HadronicProcessHelper.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"


### PR DESCRIPTION
In this PR https://github.com/cms-sw/cmssw/pull/21462 from yesterday double h has been changed to single h after renaming, but not everywhere and the build failed https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc630/CMSSW_10_0_X_2017-11-27-2300/SimG4Core/CustomPhysics 
I removed the double h's and now it builds