### PR TITLE
Use HCAL packer for 2019

### DIFF
--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -202,7 +202,6 @@ from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 
 run2_HCAL_2017.toModify( es_hardcode, useLayer0Weight = cms.bool(True) )
 run2_HF_2017.toModify( es_hardcode, useHFUpgrade = cms.bool(True) )
@@ -211,7 +210,7 @@ run2_HEPlan1_2017.toModify( es_hardcode, testHEPlan1 = cms.bool(True), useHEUpgr
 run3_HB.toModify( es_hardcode, useHBUpgrade = cms.bool(True), HBreCalibCutoff = cms.double(100.0) )
 
 # now that we have an emap
-phase2_hcal.toModify( es_hardcode, toGet = cms.untracked.vstring(_toGet_noEmap) )
+run3_HB.toModify( es_hardcode, toGet = cms.untracked.vstring(_toGet_noEmap) )
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify( es_hardcode, killHE = cms.bool(True) )

--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -6,7 +6,6 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
-from Configuration.Eras.Modifier_hcalSkipPacker_cff import hcalSkipPacker
 
-Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB, hcalHardcodeConditions, hcalSkipPacker)
+Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB, hcalHardcodeConditions)
 


### PR DESCRIPTION
Followup to #21395, #21442, and #20920, now that there are up-to-date 2019 GTs.