### PR TITLE
Use the CMS_THREAD_SAFE macro instead of [[cms::thread_safe]]

### DIFF
--- a/Calibration/Tools/interface/EcalRingCalibrationTools.h
+++ b/Calibration/Tools/interface/EcalRingCalibrationTools.h
@@ -49,7 +49,7 @@ class EcalRingCalibrationTools
   
   static std::atomic<bool> isInitializedFromGeometry_;
 
-  CMS_THREAD_GUARD("isInitializedFromGeometry_")
+  CMS_THREAD_GUARD(isInitializedFromGeometry_)
   static short endcapRingIndex_[EEDetId::IX_MAX][EEDetId::IY_MAX];  // array needed only for the endcaps
 
   static std::once_flag once_;

--- a/Calibration/Tools/interface/EcalRingCalibrationTools.h
+++ b/Calibration/Tools/interface/EcalRingCalibrationTools.h
@@ -15,6 +15,7 @@
 #include <atomic>
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 class DetId;
 class CaloGeometry;
@@ -48,7 +49,7 @@ class EcalRingCalibrationTools
   
   static std::atomic<bool> isInitializedFromGeometry_;
 
-  [[cms::thread_guard("isInitializedFromGeometry_")]]
+  CMS_THREAD_GUARD("isInitializedFromGeometry_")
   static short endcapRingIndex_[EEDetId::IX_MAX][EEDetId::IY_MAX];  // array needed only for the endcaps
 
   static std::once_flag once_;

--- a/CommonTools/Utils/interface/TMVAEvaluator.h
+++ b/CommonTools/Utils/interface/TMVAEvaluator.h
@@ -11,6 +11,7 @@
 #include "TMVA/IMethod.h"
 #include "CondFormats/EgammaObjects/interface/GBRForest.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 
 class TMVAEvaluator {
@@ -35,11 +36,11 @@ class TMVAEvaluator {
 
     std::string mMethod;
     mutable std::mutex m_mutex;
-    [[cms::thread_guard("m_mutex")]] std::unique_ptr<TMVA::Reader> mReader;
+    CMS_THREAD_GUARD("m_mutex") std::unique_ptr<TMVA::Reader> mReader;
     std::shared_ptr<const GBRForest> mGBRForest;
 
-    [[cms::thread_guard("m_mutex")]] mutable std::map<std::string,std::pair<size_t,float>> mVariables;
-    [[cms::thread_guard("m_mutex")]] mutable std::map<std::string,std::pair<size_t,float>> mSpectators;
+    CMS_THREAD_GUARD("m_mutex") mutable std::map<std::string,std::pair<size_t,float>> mVariables;
+    CMS_THREAD_GUARD("m_mutex") mutable std::map<std::string,std::pair<size_t,float>> mSpectators;
 };
 
 #endif // CommonTools_Utils_TMVAEvaluator_h

--- a/CommonTools/Utils/interface/TMVAEvaluator.h
+++ b/CommonTools/Utils/interface/TMVAEvaluator.h
@@ -36,11 +36,11 @@ class TMVAEvaluator {
 
     std::string mMethod;
     mutable std::mutex m_mutex;
-    CMS_THREAD_GUARD("m_mutex") std::unique_ptr<TMVA::Reader> mReader;
+    CMS_THREAD_GUARD(m_mutex) std::unique_ptr<TMVA::Reader> mReader;
     std::shared_ptr<const GBRForest> mGBRForest;
 
-    CMS_THREAD_GUARD("m_mutex") mutable std::map<std::string,std::pair<size_t,float>> mVariables;
-    CMS_THREAD_GUARD("m_mutex") mutable std::map<std::string,std::pair<size_t,float>> mSpectators;
+    CMS_THREAD_GUARD(m_mutex) mutable std::map<std::string,std::pair<size_t,float>> mVariables;
+    CMS_THREAD_GUARD(m_mutex) mutable std::map<std::string,std::pair<size_t,float>> mSpectators;
 };
 
 #endif // CommonTools_Utils_TMVAEvaluator_h

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -108,7 +108,7 @@ namespace edmNew {
 #else
         mutable int offset;
 #endif
-        CMS_THREAD_GUARD("offset") mutable size_type size;
+        CMS_THREAD_GUARD(offset) mutable size_type size;
 
         bool uninitialized() const { return (-1)==offset;}
         bool initializing() const { return (-2)==offset;}
@@ -618,7 +618,7 @@ namespace edmNew {
     // ROOT6 has a problem with this IdContainer typedef
     //IdContainer m_ids;
     std::vector<Trans::Item> m_ids;
-    CMS_THREAD_GUARD("dstvdetails::DetSetVectorTrans::m_filling") mutable DataContainer m_data;
+    CMS_THREAD_GUARD(dstvdetails::DetSetVectorTrans::m_filling) mutable DataContainer m_data;
     
   };
   

--- a/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
+++ b/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
@@ -1,18 +1,15 @@
-//
-//
-
-#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
-#include "FWCore/Common/interface/TriggerNames.h"
-
-#include <boost/algorithm/string.hpp>
 #include <tbb/concurrent_unordered_map.h>
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/PatCandidates/interface/libminifloat.h"
+#include <boost/algorithm/string.hpp>
 
 #include "DataFormats/Common/interface/TriggerResults.h"
-#include "DataFormats/Provenance/interface/ProcessHistory.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+#include "DataFormats/PatCandidates/interface/libminifloat.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
+#include "DataFormats/Provenance/interface/ProcessHistory.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 using namespace pat;
 
@@ -393,7 +390,7 @@ namespace {
           }
        };
   typedef tbb::concurrent_unordered_map<edm::ParameterSetID, std::vector<std::string>, key_hash> AllLabelsMap;
-  [[cms::thread_safe]] AllLabelsMap allLabelsMap;
+  CMS_THREAD_SAFE AllLabelsMap allLabelsMap;
 }
 
 std::vector<std::string>  const* TriggerObjectStandAlone::allLabels(edm::ParameterSetID const& psetid, const edm::EventBase &event,const edm::TriggerResults &res) const {

--- a/FWCore/Common/src/EventBase.cc
+++ b/FWCore/Common/src/EventBase.cc
@@ -20,6 +20,7 @@
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 
@@ -30,7 +31,7 @@ namespace {
       }
    };
    typedef tbb::concurrent_unordered_map<edm::ParameterSetID, edm::TriggerNames, key_hash> TriggerNamesMap;
-   [[cms::thread_safe]] TriggerNamesMap triggerNamesMap;
+   CMS_THREAD_SAFE TriggerNamesMap triggerNamesMap;
 }
 
 namespace edm

--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -23,6 +23,7 @@
 #include <atomic>
 
 // user include files
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // forward declarations
 namespace edm {
@@ -88,7 +89,7 @@ namespace edm {
          DataProxy const& operator=(DataProxy const&) = delete; // stop default
 
          // ---------- member data --------------------------------
-         [[cms::thread_safe]] mutable void const* cache_; //protected by a global mutex
+         CMS_THREAD_SAFE mutable void const* cache_; //protected by a global mutex
          mutable std::atomic<bool> cacheIsValid_;
          mutable std::atomic<bool> nonTransientAccessRequested_;
          ComponentDescription const* description_;

--- a/FWCore/MessageLogger/interface/MessageLoggerQ.h
+++ b/FWCore/MessageLogger/interface/MessageLoggerQ.h
@@ -2,6 +2,7 @@
 #define FWCore_MessageLogger_MessageLoggerQ_h
 
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <memory>
 
@@ -81,9 +82,9 @@ private:
   void  operator = ( MessageLoggerQ const & ) = delete;
 
   // --- data:
-  [[cms::thread_safe]] static  std::shared_ptr<edm::service::AbstractMLscribe> mlscribe_ptr;
-  [[cms::thread_safe]] static  edm::ELseverityLevel threshold;
-  [[cms::thread_safe]] static  std::set<std::string> squelchSet;
+  CMS_THREAD_SAFE static  std::shared_ptr<edm::service::AbstractMLscribe> mlscribe_ptr;
+  CMS_THREAD_SAFE static  edm::ELseverityLevel threshold;
+  CMS_THREAD_SAFE static  std::set<std::string> squelchSet;
   
 };  // MessageLoggerQ
 

--- a/FWCore/MessageLogger/src/ErrorObj.cc
+++ b/FWCore/MessageLogger/src/ErrorObj.cc
@@ -42,6 +42,7 @@
 #include <atomic>
 
 #include "FWCore/MessageLogger/interface/ErrorObj.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #ifndef IOSTREAM_INCLUDED
 #endif
@@ -69,7 +70,7 @@ namespace edm
 
   // ---  class-wide serial number stamper:
   //
-[[cms::thread_safe]] static std::atomic<int>  ourSerial(  0 );
+CMS_THREAD_SAFE static std::atomic<int>  ourSerial(  0 );
 const unsigned int  maxIDlength( 200 );		// changed 4/28/06 from 20
 
 

--- a/FWCore/MessageLogger/src/MessageLoggerQ.cc
+++ b/FWCore/MessageLogger/src/MessageLoggerQ.cc
@@ -1,7 +1,8 @@
-#include "FWCore/MessageLogger/interface/MessageLoggerQ.h"
 #include "FWCore/MessageLogger/interface/AbstractMLscribe.h"
-#include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/MessageLogger/interface/ErrorObj.h"
+#include "FWCore/MessageLogger/interface/MessageLoggerQ.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <cstring>
 #include <iostream>
@@ -130,7 +131,7 @@ MessageLoggerQ::~MessageLoggerQ()
 MessageLoggerQ *
   MessageLoggerQ::instance()
 {
-  [[cms::thread_safe]] static MessageLoggerQ queue;
+  CMS_THREAD_SAFE static MessageLoggerQ queue;
   return &queue;
 }  // MessageLoggerQ::instance()
 

--- a/FWCore/MessageLogger/src/MessageSender.cc
+++ b/FWCore/MessageLogger/src/MessageSender.cc
@@ -1,8 +1,8 @@
+#include "FWCore/MessageLogger/interface/ErrorSummaryEntry.h"
 #include "FWCore/MessageLogger/interface/MessageSender.h"
 #include "FWCore/MessageLogger/interface/MessageLoggerQ.h"
 #include "FWCore/MessageLogger/interface/MessageDrop.h"
-
-#include "FWCore/MessageLogger/interface/ErrorSummaryEntry.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <algorithm>
 #include <cassert>
@@ -80,9 +80,9 @@ namespace  {
 
 }
 
-[[cms::thread_safe]] static std::atomic<bool> errorSummaryIsBeingKept{false};
+CMS_THREAD_SAFE static std::atomic<bool> errorSummaryIsBeingKept{false};
 //Each item in the vector is reserved for a different Stream
-[[cms::thread_safe]] static std::vector<tbb::concurrent_unordered_map<ErrorSummaryMapKey, AtomicUnsignedInt,ErrorSummaryMapKey::key_hash>> errorSummaryMaps;
+CMS_THREAD_SAFE static std::vector<tbb::concurrent_unordered_map<ErrorSummaryMapKey, AtomicUnsignedInt,ErrorSummaryMapKey::key_hash>> errorSummaryMaps;
 
 MessageSender::MessageSender( ELseverityLevel const & sev, 
 			      ELstring const & id,

--- a/FWCore/MessageService/interface/ELstatistics.h
+++ b/FWCore/MessageService/interface/ELstatistics.h
@@ -26,11 +26,11 @@
 //
 // ----------------------------------------------------------------------
 
-#include "FWCore/MessageService/interface/ELdestination.h"
-
 #include "FWCore/MessageLogger/interface/ELextendedID.h"
 #include "FWCore/MessageLogger/interface/ELmap.h"
 #include "FWCore/MessageLogger/interface/ELstring.h"
+#include "FWCore/MessageService/interface/ELdestination.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <set>
 
@@ -107,7 +107,7 @@ protected:
 
   bool           printAtTermination;
 
-  [[cms::thread_safe]] static std::set<std::string> groupedCategories;		// 8/16/07 mf 
+  CMS_THREAD_SAFE static std::set<std::string> groupedCategories;		// 8/16/07 mf 
   static ELstring formSummary(ELmap_stats & stats);		// 8/16/07 mf 
 
   // ----  Helper methods specific to MessageLogger applicaton

--- a/FWCore/MessageService/interface/MessageLogger.h
+++ b/FWCore/MessageService/interface/MessageLogger.h
@@ -31,11 +31,11 @@
 
 // user include files
 
-#include "FWCore/MessageLogger/interface/ErrorObj.h"
-
-#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"
+#include "FWCore/MessageLogger/interface/ErrorObj.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // forward declarations
 
@@ -160,10 +160,10 @@ private:
   std::set<std::string> debugEnabledModules_;
   std::map<std::string,ELseverityLevel> suppression_levels_;
   bool debugEnabled_;
-  [[cms::thread_safe]] static bool   anyDebugEnabled_;
-  [[cms::thread_safe]] static bool everyDebugEnabled_;
+  CMS_THREAD_SAFE static bool   anyDebugEnabled_;
+  CMS_THREAD_SAFE static bool everyDebugEnabled_;
 
-  [[cms::thread_safe]] static bool fjrSummaryRequested_;
+  CMS_THREAD_SAFE static bool fjrSummaryRequested_;
   bool messageServicePSetHasBeenValidated_;
   std::string  messageServicePSetValidatationResults_;
 

--- a/FWCore/ParameterSet/src/Registry.cc
+++ b/FWCore/ParameterSet/src/Registry.cc
@@ -4,13 +4,14 @@
 #include <ostream>
 
 #include "FWCore/ParameterSet/interface/Registry.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace edm {
   namespace pset {
 
     Registry*
     Registry::instance() {
-      [[cms::thread_safe]] static Registry s_reg;
+      CMS_THREAD_SAFE static Registry s_reg;
       return &s_reg;
     }
     

--- a/FWCore/PluginManager/interface/PluginFactory.h
+++ b/FWCore/PluginManager/interface/PluginFactory.h
@@ -25,6 +25,7 @@
 // user include files
 #include "FWCore/PluginManager/interface/PluginFactoryBase.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 // forward declarations
 
 namespace edmplugin {
@@ -89,7 +90,7 @@ class PluginFactory<R*(Args...)> : public PluginFactoryBase
 #define CONCATENATE(a,b) CONCATENATE_HIDDEN(a,b)
 #define EDM_REGISTER_PLUGINFACTORY(_factory_,_category_) \
 namespace edmplugin {\
-  template<> edmplugin::PluginFactory<_factory_::TemplateArgType>* edmplugin::PluginFactory<_factory_::TemplateArgType>::get() { [[cms::thread_safe]] static edmplugin::PluginFactory<_factory_::TemplateArgType> s_instance; return &s_instance;}\
+  template<> edmplugin::PluginFactory<_factory_::TemplateArgType>* edmplugin::PluginFactory<_factory_::TemplateArgType>::get() { CMS_THREAD_SAFE static edmplugin::PluginFactory<_factory_::TemplateArgType> s_instance; return &s_instance;}\
   template<> const std::string& edmplugin::PluginFactory<_factory_::TemplateArgType>::category() const { static const std::string s_cat(_category_);  return s_cat;}\
   } enum {CONCATENATE(dummy_edm_register_pluginfactory_, __LINE__)}
 

--- a/FWCore/PluginManager/src/PluginCapabilities.cc
+++ b/FWCore/PluginManager/src/PluginCapabilities.cc
@@ -17,6 +17,7 @@
 #include "FWCore/PluginManager/interface/SharedLibrary.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace edmplugin {
 //
@@ -163,7 +164,7 @@ PluginCapabilities::category() const
 //
 PluginCapabilities*
 PluginCapabilities::get() {
-  [[cms::thread_safe]] static PluginCapabilities s_instance;
+  CMS_THREAD_SAFE static PluginCapabilities s_instance;
   return &s_instance;
 }
 

--- a/FWCore/PluginManager/src/PluginFactoryManager.cc
+++ b/FWCore/PluginManager/src/PluginFactoryManager.cc
@@ -14,6 +14,7 @@
 
 // user include files
 #include "FWCore/PluginManager/interface/PluginFactoryManager.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace edmplugin{
 //
@@ -83,7 +84,7 @@ PluginFactoryManager::end() const
 PluginFactoryManager*
 PluginFactoryManager::get()
 {
-   [[cms::thread_safe]] static PluginFactoryManager s_instance;
+   CMS_THREAD_SAFE static PluginFactoryManager s_instance;
    return &s_instance;
 }
 }

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -22,13 +22,13 @@
 #include "TVirtualMutex.h"
 
 // user include files
-#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/CacheParser.h"
 #include "FWCore/PluginManager/interface/PluginFactoryBase.h"
 #include "FWCore/PluginManager/interface/PluginFactoryManager.h"
-#include "FWCore/PluginManager/interface/CacheParser.h"
-#include "FWCore/Utilities/interface/Exception.h"
-
+#include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace edmplugin {
 //
@@ -360,13 +360,13 @@ PluginManager::loadingLibraryNamed_()
 {
   //NOTE: pluginLoadMutex() indirectly guards this since this value
   // is only accessible via the Sentry call which us guarded by the mutex
-  [[cms::thread_safe]] static std::string s_name(staticallyLinkedLoadingFileName());
+  CMS_THREAD_SAFE static std::string s_name(staticallyLinkedLoadingFileName());
   return s_name;
 }
 
 PluginManager*& PluginManager::singleton()
 {
-  [[cms::thread_safe]] static PluginManager* s_singleton=nullptr;
+  CMS_THREAD_SAFE static PluginManager* s_singleton=nullptr;
   return s_singleton;
 }
 

--- a/FWCore/PluginManager/src/PresenceFactory.cc
+++ b/FWCore/PluginManager/src/PresenceFactory.cc
@@ -1,6 +1,7 @@
 #include "FWCore/PluginManager/interface/PresenceFactory.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/DebugMacros.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <iostream>
 
@@ -16,7 +17,7 @@ namespace edm {
 
 
   PresenceFactory* PresenceFactory::get() {
-    [[cms::thread_safe]] static PresenceFactory singleInstance_;
+    CMS_THREAD_SAFE static PresenceFactory singleInstance_;
     return &singleInstance_;
   }
 

--- a/FWCore/Utilities/interface/DebugMacros.h
+++ b/FWCore/Utilities/interface/DebugMacros.h
@@ -1,6 +1,8 @@
 #ifndef Utilities_DebugMacros_h
 #define Utilities_DebugMacros_h
 
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+
 namespace edm {
   struct debugvalue {
 
@@ -12,7 +14,7 @@ namespace edm {
     int value_;
   };
 
-[[cms::thread_safe]] extern debugvalue debugit;
+CMS_THREAD_SAFE extern debugvalue debugit;
 }
 
 #define FDEBUG(lev) if(lev <= debugit()) std::cerr

--- a/FWCore/Utilities/interface/thread_safety_macros.h
+++ b/FWCore/Utilities/interface/thread_safety_macros.h
@@ -1,6 +1,6 @@
 #ifndef FWCore_Utilites_thread_safe_macros_h 
 #define FWCore_Utilites_thread_safe_macros_h 
-#ifndef __ROOTCLING__
+#if ! defined __ROOTCLING__ && ! defined __INTEL_COMPILER
 #define CMS_THREAD_SAFE [[cms::thread_safe]]
 #define CMS_THREAD_GUARD(_var_) [[cms::thread_guard("#_var_")]]
 #else 

--- a/FWCore/Utilities/interface/thread_safety_macros.h
+++ b/FWCore/Utilities/interface/thread_safety_macros.h
@@ -2,7 +2,7 @@
 #define FWCore_Utilites_thread_safe_macros_h 
 #if ! defined __ROOTCLING__ && ! defined __INTEL_COMPILER
 #define CMS_THREAD_SAFE [[cms::thread_safe]]
-#define CMS_THREAD_GUARD(_var_) [[cms::thread_guard("#_var_")]]
+#define CMS_THREAD_GUARD(_var_) [[cms::thread_guard(#_var_)]]
 #else 
 #define CMS_THREAD_SAFE
 #define CMS_THREAD_GUARD(_var_)

--- a/FastSimulation/MaterialEffects/src/NuclearInteractionFTFSimulator.cc
+++ b/FastSimulation/MaterialEffects/src/NuclearInteractionFTFSimulator.cc
@@ -67,8 +67,8 @@
 #include "G4SystemOfUnits.hh"
 
 static std::once_flag initializeOnce;
-CMS_THREAD_GUARD("initializeOnce") const G4ParticleDefinition* NuclearInteractionFTFSimulator::theG4Hadron[] = {nullptr};
-CMS_THREAD_GUARD("initializeOnce") int NuclearInteractionFTFSimulator::theId[] = {0};
+CMS_THREAD_GUARD(initializeOnce) const G4ParticleDefinition* NuclearInteractionFTFSimulator::theG4Hadron[] = {nullptr};
+CMS_THREAD_GUARD(initializeOnce) int NuclearInteractionFTFSimulator::theId[] = {0};
 
 const double fact = 1.0/CLHEP::GeV;
 

--- a/FastSimulation/MaterialEffects/src/NuclearInteractionFTFSimulator.cc
+++ b/FastSimulation/MaterialEffects/src/NuclearInteractionFTFSimulator.cc
@@ -3,6 +3,7 @@
 
 // Framework Headers
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // Fast Sim headers
 #include "FastSimulation/MaterialEffects/interface/NuclearInteractionFTFSimulator.h"
@@ -66,8 +67,8 @@
 #include "G4SystemOfUnits.hh"
 
 static std::once_flag initializeOnce;
-[[cms::thread_guard("initializeOnce")]] const G4ParticleDefinition* NuclearInteractionFTFSimulator::theG4Hadron[] = {nullptr};
-[[cms::thread_guard("initializeOnce")]] int NuclearInteractionFTFSimulator::theId[] = {0};
+CMS_THREAD_GUARD("initializeOnce") const G4ParticleDefinition* NuclearInteractionFTFSimulator::theG4Hadron[] = {nullptr};
+CMS_THREAD_GUARD("initializeOnce") int NuclearInteractionFTFSimulator::theId[] = {0};
 
 const double fact = 1.0/CLHEP::GeV;
 

--- a/MagneticField/Engine/interface/MagneticField.h
+++ b/MagneticField/Engine/interface/MagneticField.h
@@ -8,11 +8,13 @@
  *  \author N. Amapane - CERN
  */
 
+#include <atomic>
+
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "FWCore/Utilities/interface/Visibility.h"
 #include "FWCore/Utilities/interface/Likely.h"
-#include <atomic>
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 class MagneticField
 {
@@ -62,9 +64,9 @@ private:
   //nominal field value 
   virtual int computeNominalValue() const;
   mutable std::atomic<char> nominalValueCompiuted;
-//  [[cms::thread_guard("nominalValueCompiuted")]] mutable int theNominalValue;
+//  CMS_THREAD_GUARD("nominalValueCompiuted") mutable int theNominalValue;
 //  PG temporary fix for clang 3.4 which is not parsing thread_guard correctly
-  [[cms::thread_safe]] mutable int theNominalValue;
+  CMS_THREAD_SAFE mutable int theNominalValue;
   enum FooStates {kUnset, kSetting, kSet};
 };
 

--- a/MagneticField/Engine/interface/MagneticField.h
+++ b/MagneticField/Engine/interface/MagneticField.h
@@ -64,7 +64,7 @@ private:
   //nominal field value 
   virtual int computeNominalValue() const;
   mutable std::atomic<char> nominalValueCompiuted;
-//  CMS_THREAD_GUARD("nominalValueCompiuted") mutable int theNominalValue;
+//  CMS_THREAD_GUARD(nominalValueCompiuted) mutable int theNominalValue;
 //  PG temporary fix for clang 3.4 which is not parsing thread_guard correctly
   CMS_THREAD_SAFE mutable int theNominalValue;
   enum FooStates {kUnset, kSetting, kSet};

--- a/PhysicsTools/MVAComputer/interface/ProcessRegistry.icc
+++ b/PhysicsTools/MVAComputer/interface/ProcessRegistry.icc
@@ -14,6 +14,7 @@
 #include <string>
 #include <map>
 
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "PhysicsTools/MVAComputer/interface/ProcessRegistry.h"
 
 namespace PhysicsTools {
@@ -27,7 +28,7 @@ template<class Base_t, class CalibBase_t, class Parent_t>
 tbb::concurrent_unordered_map<std::string, const ProcessRegistry<Base_t, CalibBase_t, Parent_t>*>
 	*ProcessRegistry<Base_t, CalibBase_t, Parent_t>::getRegistry()
 {
-	[[cms::thread_safe]] static struct Sentinel {
+	CMS_THREAD_SAFE static struct Sentinel {
 		Sentinel() : instance(new RegistryMap) {}
 		~Sentinel() { delete instance; instance = 0; }
 

--- a/PhysicsTools/MVAComputer/src/AtomicId.cc
+++ b/PhysicsTools/MVAComputer/src/AtomicId.cc
@@ -1,11 +1,11 @@
 #include <algorithm>
-#include <cstdlib>
 #include <cstddef>
+#include <cstdlib>
 #include <cstring>
+#include <mutex>
 #include <set>
 
-#include <mutex>
-
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "PhysicsTools/MVAComputer/interface/AtomicId.h"
 
 namespace { // anonymous
@@ -58,7 +58,7 @@ namespace PhysicsTools {
 
 static IdCache &getAtomicIdCache()
 {
-	[[cms::thread_safe]] static IdCache atomicIdCache;
+	CMS_THREAD_SAFE static IdCache atomicIdCache;
 	return atomicIdCache;
 }
 

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -1,6 +1,8 @@
+#include <algorithm>
+#include <array>
+
 #include "GroupedCkfTrajectoryBuilder.h"
 #include "TrajectorySegmentBuilder.h"
-
 
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 #include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
@@ -27,16 +29,15 @@
 #include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
 #include "TrackingTools/TrajectoryState/interface/BasicSingleTrajectoryState.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "TrackingTools/PatternTools/interface/TransverseImpactPointExtrapolator.h"
 
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
-
 
 // only included for RecHit comparison operator:
 #include "TrackingTools/TrajectoryCleaning/interface/TrajectoryCleanerBySharedHits.h"
 
 #include "TrackingTools/TrajectoryCleaning/interface/FastTrajectoryCleaner.h"
-
 
 // for looper reconstruction
 #include "TrackingTools/GeomPropagators/interface/HelixBarrelCylinderCrossing.h"
@@ -44,9 +45,6 @@
 #include "TrackingTools/GeomPropagators/interface/HelixArbitraryPlaneCrossing.h"
 
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
-
-#include <algorithm>
-#include <array>
 
 // #define STAT_TSB
 
@@ -85,7 +83,7 @@ namespace {
     void rebuilt(long long) {}
     void invalid() {}
   };
-  [[cms::thread_safe]] StatCount statCount;
+  CMS_THREAD_SAFE StatCount statCount;
 #endif
 
 

--- a/RecoTracker/CkfPattern/plugins/TrajectorySegmentBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/TrajectorySegmentBuilder.cc
@@ -1,3 +1,4 @@
+#include <algorithm> 
 
 #include "TrajectorySegmentBuilder.h"
 
@@ -19,8 +20,7 @@
 #include "TrackingTools/MeasurementDet/interface/MeasurementDet.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include <algorithm> 
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // #define DBG_TSB
 // #define STAT_TSB
@@ -59,7 +59,7 @@ namespace {
     void truncated() {}
     void invalid() {}
   };
-  [[cms::thread_safe]] StatCount statCount;
+  CMS_THREAD_SAFE StatCount statCount;
 #endif
 
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -9,25 +9,24 @@
 //
 //
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackBase.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
-#include "TrackingTools/PatternTools/interface/Trajectory.h"
-#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
-#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/Common/interface/ValueMap.h"
-
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "RecoTracker/FinalTrackSelectors/interface/TrackAlgoPriorityOrder.h"
 #include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
 
 class dso_hidden TrackListMerger : public edm::stream::EDProducer<>
   {
@@ -190,7 +189,7 @@ inline volatile unsigned long long rdtsc() {
 
 
   };
-  [[cms::thread_safe]] StatCount statCount;
+  CMS_THREAD_SAFE StatCount statCount;
 #endif
 
 

--- a/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
@@ -1,34 +1,30 @@
-#include "RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h"
+#include <sstream>
 
 #include "DataFormats/Common/interface/OrphanHandle.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
-
-#include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
+#include "DataFormats/TrackReco/interface/TrackBase.h"
+#include "DataFormats/TrackerRecHit2D/interface/TrackingRecHitLessFromGlobalPosition.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
-
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TRecHit1DMomConstraint.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TRecHit2DPosConstraint.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
+#include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
+#include "TrackingTools/PatternTools/interface/TSCBLBuilderWithPropagator.h"
+#include "TrackingTools/PatternTools/interface/TransverseImpactPointExtrapolator.h"
+#include "TrackingTools/TrackFitters/interface/RecHitSorter.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
-#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
-#include "TrackingTools/PatternTools/interface/TransverseImpactPointExtrapolator.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-
-#include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
-#include "TrackingTools/PatternTools/interface/TSCBLBuilderWithPropagator.h"
-#include "FWCore/Utilities/interface/Exception.h"
-
-#include "RecoTracker/TransientTrackingRecHit/interface/TRecHit2DPosConstraint.h"
-#include "RecoTracker/TransientTrackingRecHit/interface/TRecHit1DMomConstraint.h"
-#include "DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h"
-#include "TrackingTools/TrackFitters/interface/RecHitSorter.h"
-#include "DataFormats/TrackReco/interface/TrackBase.h"
-
-#include<sstream>
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 
 // #define VI_DEBUG
 // #define STAT_TSB
@@ -75,7 +71,7 @@ namespace {
     void gsf(){}
     void algo(int){}
   };
-  [[cms::thread_safe]] StatCount statCount;
+  CMS_THREAD_SAFE StatCount statCount;
 #endif
 
 

--- a/RecoVertex/ConfigurableVertexReco/src/VertexFitterManager.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/VertexFitterManager.cc
@@ -1,3 +1,4 @@
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "RecoVertex/ConfigurableVertexReco/interface/VertexFitterManager.h"
 #include "RecoVertex/ConfigurableVertexReco/interface/VertexRecoManager.h"
 #include "RecoVertex/ConfigurableVertexReco/interface/ReconstructorFromFitter.h"
@@ -56,7 +57,7 @@ VertexFitterManager & VertexFitterManager::Instance()
   //The singleton's internal structure only changes while
   // this library is being loaded. All other methods are const.
   
-  [[cms::thread_safe]] static VertexFitterManager singleton;
+  CMS_THREAD_SAFE static VertexFitterManager singleton;
   return singleton;
 }
 

--- a/RecoVertex/ConfigurableVertexReco/src/VertexRecoManager.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/VertexRecoManager.cc
@@ -1,3 +1,4 @@
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "RecoVertex/ConfigurableVertexReco/interface/VertexRecoManager.h"
 
 using namespace std;
@@ -46,7 +47,7 @@ VertexRecoManager & VertexRecoManager::Instance()
 {
   //The singleton's internal structure only changes while
   // this library is being loaded. All other methods are const.
-  [[cms::thread_safe]] static VertexRecoManager singleton;
+  CMS_THREAD_SAFE static VertexRecoManager singleton;
   return singleton;
 }
 

--- a/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
+++ b/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
@@ -1,13 +1,16 @@
 #ifndef KinematicConstrainedVertexUpdatorT_H
 #define KinematicConstrainedVertexUpdatorT_H
 
+#include <atomic>
+#include <cassert>
+#include <iostream>
+
+#include "DataFormats/Math/interface/invertPosDefMatrix.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "RecoVertex/KinematicFitPrimitives/interface/MultiTrackKinematicConstraintT.h"
 #include "RecoVertex/KinematicFitPrimitives/interface/KinematicVertexFactory.h"
 #include "RecoVertex/KinematicFit/interface/VertexKinematicConstraintT.h"
-#include "DataFormats/Math/interface/invertPosDefMatrix.h"
-#include<cassert>
-#include<iostream>
-#include <atomic>
+
 // the usual stupid counter
 namespace KineDebug3 {
   struct Count {
@@ -18,7 +21,7 @@ namespace KineDebug3 {
 
   };
   inline void count() {
-    [[cms::thread_safe]] static Count c;
+    CMS_THREAD_SAFE static Count c;
     ++c.n;
   }
 

--- a/TrackingTools/DetLayers/src/GeomDetCompatibilityChecker.cc
+++ b/TrackingTools/DetLayers/src/GeomDetCompatibilityChecker.cc
@@ -1,14 +1,14 @@
-#include "TrackingTools/DetLayers/interface/GeomDetCompatibilityChecker.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h" 
-
-#include "TrackingTools/GeomPropagators/interface/StraightLinePlaneCrossing.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 // #define STAT_TSB
 
 #ifdef STAT_TSB
-#include<iostream>
+#include <iostream>
 #endif
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+#include "TrackingTools/DetLayers/interface/GeomDetCompatibilityChecker.h"
+#include "TrackingTools/GeomPropagators/interface/StraightLinePlaneCrossing.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h" 
 
 namespace{
 
@@ -45,7 +45,7 @@ namespace{
 #endif
   };
 
-  [[cms::thread_safe]] Stat stat; // for production purpose it is thread safe
+  CMS_THREAD_SAFE Stat stat; // for production purpose it is thread safe
 
 }
 

--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -18,18 +18,20 @@
 #include <fstream>
 #include <iterator>
 #include <string>
+
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+
 // PGartung needed for bloom filter loading
 #include "dablooms.h"
 #define CAPACITY 5000
 #define ERROR_RATE .0002
-
 
 using namespace clang;
 using namespace llvm;
 bool clangcms::support::isCmsLocalFile(const char* file)
 {
   static const char* LocalDir= std::getenv("LOCALRT");
-  [[cms::thread_safe]] static int DirLen=-1;
+  CMS_THREAD_SAFE static int DirLen=-1;
   if (DirLen==-1)
   {
     DirLen=0;
@@ -147,7 +149,7 @@ bool clangcms::support::isSafeClassName(const std::string &cname) {
 }
 
 bool clangcms::support::isDataClass(const std::string & name) {
-     [[cms::thread_safe]] static std::string iname("");
+     CMS_THREAD_SAFE static std::string iname("");
      if ( iname == "") {
           clang::FileSystemOptions FSO;
           clang::FileManager FM(FSO);
@@ -172,7 +174,7 @@ bool clangcms::support::isDataClass(const std::string & name) {
                iname = fname2;
      }
 
-     [[cms::thread_safe]] static scaling_bloom_t * blmflt = new_scaling_bloom_from_file( CAPACITY, ERROR_RATE, iname.c_str() );
+     CMS_THREAD_SAFE static scaling_bloom_t * blmflt = new_scaling_bloom_from_file( CAPACITY, ERROR_RATE, iname.c_str() );
 
      if ( scaling_bloom_check( blmflt, name.c_str(), name.length() ) == 1 ) return true;
 

--- a/Utilities/StaticAnalyzers/test/class_checker.cpp
+++ b/Utilities/StaticAnalyzers/test/class_checker.cpp
@@ -1,3 +1,4 @@
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // is ok, because const-qualified
 const static int g_staticConst = 23;
@@ -6,7 +7,7 @@ static int const* g_ptr_staticConst = &g_staticConst;
 
 
 // results in a warning by GlobalStaticChecker
-[[cms::thread_safe]] static int g_static;
+CMS_THREAD_SAFE static int g_static;
 static int * g_ptr_static = &g_static;
 
 class ClassTest {
@@ -86,7 +87,7 @@ Thing * getThing() { return T_p; }
 
 class Bar
 {
-[[cms::thread_safe]] static int si_;
+CMS_THREAD_SAFE static int si_;
 static void const modifyStatic(int &x) {si_=x;}
 private:
 Bar(): ci_{0},ipc_{&i_},icp_{&i_},ir_{i_},icr_{ci_} {}
@@ -169,7 +170,7 @@ void method3() const
 // must not produce a warning
 	int const& ira = (int const&)(icr_);
 // will produce a warning by StaticLocalChecker
-        [[cms::thread_safe]] static int evilStaticLocal = 0;
+        CMS_THREAD_SAFE static int evilStaticLocal = 0;
 	static int & intRef = evilStaticLocal;
 	static int * intPtr = & evilStaticLocal;
 // no warnings here

--- a/Utilities/StaticAnalyzers/test/func_checker.cpp
+++ b/Utilities/StaticAnalyzers/test/func_checker.cpp
@@ -1,11 +1,13 @@
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "func_checker.h"
-[[cms::thread_guard("dummy")]] static int global_static = 23;
+
+CMS_THREAD_GUARD("dummy") static int global_static = 23;
 class Bar {
 public:
 Bar() {}
-[[cms::thread_guard("dummy2")]] static int member_static;
+CMS_THREAD_GUARD("dummy2") static int member_static;
 void  bar()  {
-	/*[[cms::thread_safe]]*/ static int local_static;
+	/*CMS_THREAD_SAFE*/ static int local_static;
 	member_static = global_static;
 	local_static = global_static; 
 	member_static = external_int;

--- a/Utilities/StaticAnalyzers/test/func_checker.cpp
+++ b/Utilities/StaticAnalyzers/test/func_checker.cpp
@@ -1,11 +1,11 @@
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "func_checker.h"
 
-CMS_THREAD_GUARD("dummy") static int global_static = 23;
+CMS_THREAD_GUARD(dummy) static int global_static = 23;
 class Bar {
 public:
 Bar() {}
-CMS_THREAD_GUARD("dummy2") static int member_static;
+CMS_THREAD_GUARD(dummy2) static int member_static;
 void  bar()  {
 	/*CMS_THREAD_SAFE*/ static int local_static;
 	member_static = global_static;

--- a/Utilities/StaticAnalyzers/test/func_checker.h
+++ b/Utilities/StaticAnalyzers/test/func_checker.h
@@ -1,1 +1,3 @@
-[[cms::thread_safe]] extern int external_int;
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+
+CMS_THREAD_SAFE extern int external_int;

--- a/Utilities/StaticAnalyzers/test/static_local.cpp
+++ b/Utilities/StaticAnalyzers/test/static_local.cpp
@@ -1,3 +1,4 @@
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 class Foo
 {
@@ -5,7 +6,7 @@ public:
     void bar()
     {
         // will produce a warning by StaticLocalChecker
-        	[[cms::thread_safe]] static int evilStaticLocal = 0;
+        	CMS_THREAD_SAFE static int evilStaticLocal = 0;
 		static int & intRef = evilStaticLocal;
 		static int * intPtr = & evilStaticLocal;
 

--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include "Utilities/StorageFactory/interface/StorageMaker.h"
 #include "Utilities/StorageFactory/interface/StorageMakerFactory.h"
@@ -188,7 +189,7 @@ public:
   }
 
 private:
-  [[cms::thread_safe]] mutable MakerResponseHandler m_null_handler;
+  CMS_THREAD_SAFE mutable MakerResponseHandler m_null_handler;
   mutable std::mutex m_envMutex;
   mutable std::atomic<unsigned int> m_lastDebugLevel;
   mutable std::atomic<unsigned int> m_lastTimeout;

--- a/Utilities/XrdAdaptor/src/QualityMetric.cc
+++ b/Utilities/XrdAdaptor/src/QualityMetric.cc
@@ -2,6 +2,7 @@
 #include <iostream>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include "QualityMetric.h"
 
@@ -153,7 +154,7 @@ QualityMetric::get()
 }
 
 
-[[cms::thread_safe]] QualityMetricFactory QualityMetricFactory::m_instance;
+CMS_THREAD_SAFE QualityMetricFactory QualityMetricFactory::m_instance;
 
 
 std::unique_ptr<QualityMetricSource>

--- a/Utilities/XrdAdaptor/src/QualityMetric.h
+++ b/Utilities/XrdAdaptor/src/QualityMetric.h
@@ -10,6 +10,7 @@
 #include <boost/utility.hpp>
 
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace XrdAdaptor {
 
@@ -66,7 +67,7 @@ private:
     static
     std::unique_ptr<QualityMetricSource> get(timespec now, const std::string &id);
 
-    [[cms::thread_safe]] static QualityMetricFactory m_instance;
+    CMS_THREAD_SAFE static QualityMetricFactory m_instance;
 
     typedef tbb::concurrent_unordered_map<std::string, QualityMetricUniqueSource*> MetricMap;
     MetricMap m_sources;

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -12,6 +12,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "Utilities/StorageFactory/interface/StatisticsSenderService.h"
 
 #include "XrdStatistics.h"
@@ -84,7 +85,7 @@ class SendMonitoringInfoHandler : boost::noncopyable, public XrdCl::ResponseHand
     }
 };
 
-[[cms::thread_safe]] SendMonitoringInfoHandler nullHandler;
+CMS_THREAD_SAFE SendMonitoringInfoHandler nullHandler;
 
 
 static void


### PR DESCRIPTION
The Intel Compiler does not seem to support attributes with a namespace:

> warning #3924: attribute namespace "cms" is unrecognized