### PR TITLE
[10.0.x] fix tk map scale in SiStrip PI, in case there is a sigle value to be displayed

### DIFF
--- a/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
+++ b/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
@@ -145,8 +145,11 @@ namespace SiStripPI {
     
     float stdev = sqrt(accum / (values.size()-1)); 
     
-    return std::make_pair(m-nsigma*stdev,m+nsigma*stdev);
-    
+    if(stdev!=0.){
+      return std::make_pair(m-nsigma*stdev,m+nsigma*stdev);
+    } else {
+      return std::make_pair(m>0.? 0.95*m : 1.05*m, m>0? 1.05*m : 0.95*m);
+    }
   }
   
   /*--------------------------------------------------------------------*/

--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -745,14 +745,22 @@ namespace {
 	    theMaxGain=currentGain;
 	  }
 	} // loop over APVs
-	// fill the tracker map taking the average gain on a single DetId
+	// fill the tracker map taking the maximum gain on a single DetId
 	tmap->fill(d,theMaxGain);
       } // loop over detIds
 
       //=========================
       
+      std::pair<float,float> extrema = tmap->getAutomaticRange(); 	
+
       std::string fileName(m_imageFileName);
-      tmap->save(true,0,0,fileName);
+
+      // protect against uniform values (gains are defined positive)
+      if (extrema.first!=extrema.second){
+	tmap->save(true,0,0,fileName);
+      } else {
+	tmap->save(true,extrema.first*0.95,extrema.first*1.05,fileName);
+      }
 
       return true;
     }
@@ -789,14 +797,22 @@ namespace {
 	    theMinGain=currentGain;
 	  }
 	} // loop over APVs
-	// fill the tracker map taking the average gain on a single DetId
+	// fill the tracker map taking the minimum gain on a single DetId
 	tmap->fill(d,theMinGain);
       } // loop over detIds
 
       //=========================
       
+      std::pair<float,float> extrema = tmap->getAutomaticRange(); 	
+
       std::string fileName(m_imageFileName);
-      tmap->save(true,0,0,fileName);
+
+      // protect against uniform values (gains are defined positive)
+      if (extrema.first!=extrema.second){
+	tmap->save(true,0,0,fileName);
+      } else {
+	tmap->save(true,extrema.first*0.95,extrema.first*1.05,fileName);
+      }
 
       return true;
     }

--- a/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
@@ -86,8 +86,16 @@ namespace {
 	tmap->fill(element.first,element.second);
       } // loop over the BP MAP
       
+      std::pair<float,float> extrema = tmap->getAutomaticRange(); 	
+
       std::string fileName(m_imageFileName);
-      tmap->save(true,0,0,fileName);
+
+      // protect against uniform values across the map (BP corrections are defined positive)
+      if (extrema.first!=extrema.second){
+	tmap->save(true,0,0,fileName);
+      } else {
+	tmap->save(true,extrema.first*0.95,extrema.first*1.05,fileName);
+      }
 
       return true;
     }

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -114,13 +114,13 @@ namespace {
       payload->getDetIds(detid);
       
       for (const auto & d : detid) {
-	tmap->fill(d,1);
+	tmap->fill(d,1.);
       } // loop over detIds
       
       //=========================
       
       std::string fileName(m_imageFileName);
-      tmap->save(true,0,0,fileName);
+      tmap->save(true,0,1.,fileName);
 
       return true;
     }
@@ -165,8 +165,16 @@ namespace {
       
       //=========================
       
+      std::pair<float,float> extrema = tmap->getAutomaticRange(); 	
+
       std::string fileName(m_imageFileName);
-      tmap->save(true,0,0,fileName);
+
+      // protect against uniform values across the map (bad components fractions are defined positive)
+      if (extrema.first!=extrema.second){
+	tmap->save(true,0,0,fileName);
+      } else {
+	tmap->save(true,extrema.first*0.95,extrema.first*1.05,fileName);
+      }
 
       delete reader;
       return true;

--- a/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
@@ -70,12 +70,12 @@ namespace {
 
       for (const auto & d : detid) {
 	if(payload->IsModuleVOff(d)){
-	  tmap->fill(d,1);
+	  tmap->fill(d,1.);
 	}
       } // loop over detIds
       
       std::string fileName(m_imageFileName);
-      tmap->save(true,0,0,fileName);
+      tmap->save(true,0.99,1.01,fileName);
 
       return true;
     }
@@ -104,12 +104,12 @@ namespace {
 
       for (const auto & d : detid) {
 	if(payload->IsModuleHVOff(d)){
-	  tmap->fill(d,1);
+	  tmap->fill(d,1.);
 	}
       } // loop over detIds
       
       std::string fileName(m_imageFileName);
-      tmap->save(true,0,0,fileName);
+      tmap->save(true,0.99,1.01,fileName);
 
       return true;
     }
@@ -138,12 +138,12 @@ namespace {
 
       for (const auto & d : detid) {
 	if(payload->IsModuleLVOff(d)){
-	  tmap->fill(d,1);
+	  tmap->fill(d,1.);
 	}
       } // loop over detIds
       
       std::string fileName(m_imageFileName);
-      tmap->save(true,0,0,fileName);
+      tmap->save(true,0.99,1.01,fileName);
 
       return true;
     }

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -86,8 +86,16 @@ namespace {
 	tmap->fill(element.first,element.second);
       } // loop over the LA MAP
       
+      std::pair<float,float> extrema = tmap->getAutomaticRange(); 	
+
       std::string fileName(m_imageFileName);
-      tmap->save(true,0,0,fileName);
+
+      // protect against uniform values (LA values are defined positive)
+      if (extrema.first!=extrema.second){
+	tmap->save(true,0,0,fileName);
+      } else {
+	tmap->save(true,extrema.first*0.95,extrema.first*1.05,fileName);
+      }
 
       return true;
     }


### PR DESCRIPTION
 Greetings,
this fixes the cases in which there is a uniform value to be displayed all over the tk map, avoid to generate default images (with irrelevant legend) as in: [here](https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/image_plot/Prod/CMSSW_10_0_X_2017-11-28-2300/eyJ0YWciOiJTaVN0cmlwRGV0Vk9mZl92N19wcm9tcHQiLCJwbG90IjoicGxvdF9TaVN0cmlwRGV0Vk9mZl9Jc01vZHVsZUhWT2ZmX1RyYWNrZXJNYXAiLCJwbHVnaW4iOiJwbHVnaW5TaVN0cmlwRGV0Vk9mZl9QYXlsb2FkSW5zcGVjdG9yIiwidHlwZSI6IkltYWdlIiwiaW92cyI6eyJzdGFydF9pb3YiOiI2NDkyNjY4NTYwOTcyMjkxMjAwIiwiZW5kX2lvdiI6IjY0OTI2Njg1NjA5NzIyOTEyMDAifX0%3D) 