### PR TITLE
Bugfix new CaloLayer1 unpacker

### DIFF
--- a/EventFilter/L1TRawToDigi/interface/Block.h
+++ b/EventFilter/L1TRawToDigi/interface/Block.h
@@ -57,7 +57,7 @@ namespace l1t {
          inline unsigned int getSize() const { return payload_.size() + 1; };
 
          BlockHeader header() const { return header_; };
-         std::vector<uint32_t> payload() const { return payload_; };
+         const std::vector<uint32_t>& payload() const { return payload_; };
 
          void amc(const amc::Header& h) { amc_ = h; };
          amc::Header amc() const { return amc_; };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.cc
@@ -4,6 +4,22 @@
 
 namespace l1t {
    namespace stage2 {
+      CaloLayer1Collections::CaloLayer1Collections(edm::Event& e) :
+          UnpackerCollections(e),
+          ecalDigis_(new EcalTrigPrimDigiCollection()),
+          hcalDigis_(new HcalTrigPrimDigiCollection()),
+          caloRegions_(new L1CaloRegionCollection())
+      {
+         // Pre-allocate:
+         //  72 iPhi values
+         //  28 iEta values in Ecal, 28 + 12 iEta values in Hcal + HF
+         //  2 hemispheres
+         ecalDigis_->reserve(72*28*2);
+         hcalDigis_->reserve(72*40*2);
+         // 7 regions * 18 cards * 2 hemispheres
+         caloRegions_->reserve(7*18*2);
+      }
+
       CaloLayer1Collections::~CaloLayer1Collections()
       {
          event_.put(std::move(ecalDigis_));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.h
@@ -11,13 +11,7 @@ namespace l1t {
    namespace stage2 {
      class CaloLayer1Collections : public UnpackerCollections {
          public:
-            CaloLayer1Collections(edm::Event& e) :
-               UnpackerCollections(e),
-               ecalDigis_(new EcalTrigPrimDigiCollection()),
-               hcalDigis_(new HcalTrigPrimDigiCollection()),
-               caloRegions_(new L1CaloRegionCollection())
-            {};
-
+            CaloLayer1Collections(edm::Event& e);
             ~CaloLayer1Collections() override;
 
             inline EcalTrigPrimDigiCollection* getEcalDigis() {return ecalDigis_.get();};

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Packer.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Packer.cc
@@ -25,7 +25,7 @@ namespace stage2 {
       load.resize(192, 0u);
 
       auto ctp7_phi = board();
-      uint32_t * ptr = &*load.begin();
+      uint32_t * ptr = load.data();
       UCTCTP7RawData ctp7Data(ptr);
       makeECalTPGs(ctp7_phi, ctp7Data, ecalDigis.product());
       makeHCalTPGs(ctp7_phi, ctp7Data, hcalDigis.product());

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
@@ -20,7 +20,7 @@ namespace stage2 {
       auto res = static_cast<CaloLayer1Collections*>(coll);
 
       auto ctp7_phi = block.amc().getBoardID();
-      uint32_t * ptr = &*block.payload().begin();
+      const uint32_t * ptr = block.payload().data();
 
       UCTCTP7RawData ctp7Data(ptr);
       makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
@@ -33,7 +33,6 @@ namespace stage2 {
 
    void CaloLayer1Unpacker::makeECalTPGs(uint32_t lPhi, UCTCTP7RawData& ctp7Data, EcalTrigPrimDigiCollection* ecalTPGs) {
       UCTCTP7RawData::CaloType cType = UCTCTP7RawData::EBEE;
-      ecalTPGs->reserve(4228); // # of ECAL TT
       for(uint32_t iPhi = 0; iPhi < 4; iPhi++) { // Loop over all four phi divisions on card
          int cPhi = - 1 + lPhi * 4 + iPhi; // Calorimeter phi index
          if(cPhi == 0) cPhi = 72;
@@ -77,7 +76,6 @@ namespace stage2 {
    }
 
    void CaloLayer1Unpacker::makeHCalTPGs(uint32_t lPhi, UCTCTP7RawData& ctp7Data, HcalTrigPrimDigiCollection* hcalTPGs) {
-      hcalTPGs->reserve(4608); // # of HCAL TT
       UCTCTP7RawData::CaloType cType = UCTCTP7RawData::HBHE;
       for(uint32_t iPhi = 0; iPhi < 4; iPhi++) { // Loop over all four phi divisions on card
          int cPhi = - 1 + lPhi * 4 + iPhi; // Calorimeter phi index

--- a/EventFilter/L1TRawToDigi/test/test_CaloLayer1.py
+++ b/EventFilter/L1TRawToDigi/test/test_CaloLayer1.py
@@ -86,12 +86,11 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
 # user stuff
 process.load('EventFilter.L1TRawToDigi.caloLayer1Digis_cfi')
 process.load('EventFilter.L1TRawToDigi.caloLayer1Raw_cfi')
-process.load("EventFilter.L1TXRawToDigi.caloLayer1Stage2Digis_cfi")
 
 for prod in [process.caloLayer1RawFed1354, process.caloLayer1RawFed1356, process.caloLayer1RawFed1358]:
-    prod.ecalDigis = cms.InputTag("l1tCaloLayer1Digis")
-    prod.hcalDigis = cms.InputTag("l1tCaloLayer1Digis")
-    prod.caloRegions = cms.InputTag("l1tCaloLayer1Digis")
+    prod.ecalDigis = cms.InputTag("caloLayer1Digis")
+    prod.hcalDigis = cms.InputTag("caloLayer1Digis")
+    prod.caloRegions = cms.InputTag("caloLayer1Digis")
 
 process.collectPackers = cms.EDProducer("RawDataCollectorByLabel",
     verbose = cms.untracked.int32(0),     # 0 = quiet, 1 = collection list, 2 = FED list
@@ -102,31 +101,11 @@ process.collectPackers = cms.EDProducer("RawDataCollectorByLabel",
     ),
 )
 
-process.newUnpackerNewPacked = process.caloLayer1Digis.clone()
-process.newUnpackerNewPacked.InputLabel = cms.InputTag("collectPackers")
-
-process.packMismatch = cms.EDFilter("CaloLayer1MismatchFilter",
-    ecalTPSourceSent = cms.InputTag("l1tCaloLayer1Digis"),
-    hcalTPSourceSent = cms.InputTag("l1tCaloLayer1Digis"),
-    ecalTPSourceRecd = cms.InputTag("newUnpackerNewPacked"),
-    hcalTPSourceRecd = cms.InputTag("newUnpackerNewPacked"),
-    fedRawData = cms.InputTag("rawDataCollector"),
-    filterEcalMismatch = cms.bool(True),
-    filterHcalMismatch = cms.bool(True),
-    filterEcalLinkErrors = cms.bool(False),
-    filterHcalLinkErrors = cms.bool(False),
-    printout = cms.bool(False),
-)
-
-
 # Path and EndPath definitions
 process.path = cms.Path(
-    process.l1tCaloLayer1Digis *
-    #process.caloLayer1Digis *
+    process.caloLayer1Digis *
     process.caloLayer1Raw *
-    process.collectPackers *
-    process.newUnpackerNewPacked *
-    process.packMismatch
+    process.collectPackers
 )
 
 process.out = cms.EndPath(


### PR DESCRIPTION
Fixes #21067

l1t::Block::payload() returns a copy of internal std::vector
which we grabbed a bare pointer to, but then it is destructed since it
is an rvalue, so the things we do with that pointer are rather naughty.

Fixed by returning const reference, as all access patterns are read-only
anyway.  Propagated const-ness to bare pointer in the UCTCTP7RawData
utility.

p.s. introduced in #20914, backport to 94x necessary I suppose?