### PR TITLE
EventProcessor refactoring

### DIFF
--- a/FWCore/Concurrency/interface/SerialTaskQueueChain.h
+++ b/FWCore/Concurrency/interface/SerialTaskQueueChain.h
@@ -58,7 +58,7 @@ namespace edm {
      * \param[in] iAction Must be a functor that takes no arguments and return no values.
      */
     template<typename T>
-    void push(const T& iAction);
+    void push(T&& iAction);
     
     /// synchronously pushes functor iAction into queue
     /**
@@ -69,7 +69,7 @@ namespace edm {
      * \param[in] iAction Must be a functor that takes no arguments and return no values.
      */
     template<typename T>
-    void pushAndWait(const T& iAction);
+    void pushAndWait(T&& iAction);
     
     unsigned long outstandingTasks() const { return m_outstandingTasks; }
     std::size_t numberOfQueues() const {return m_queues.size(); }
@@ -80,28 +80,28 @@ namespace edm {
     std::atomic<unsigned long> m_outstandingTasks{0};
     
     template<typename T>
-    void passDownChain(unsigned int iIndex, const T& iAction);
+    void passDownChain(unsigned int iIndex, T&& iAction);
     
     template<typename T>
-    void actionToRun(const T& iAction);
+    void actionToRun(T&& iAction);
 
   };
   
   template<typename T>
-  void SerialTaskQueueChain::push(const T& iAction) {
+  void SerialTaskQueueChain::push(T&& iAction) {
     ++m_outstandingTasks;
     if(m_queues.size() == 1) {
-      m_queues[0]->push( [this,iAction]() {this->actionToRun(iAction);} );
+      m_queues[0]->push( [this,iAction]() mutable {this->actionToRun(iAction);} );
     } else {
       assert(!m_queues.empty());
-      m_queues[0]->push([this, iAction]() {
+      m_queues[0]->push([this, iAction]() mutable {
         this->passDownChain(1, iAction);
       });
     }
   }
   
   template<typename T>
-  void SerialTaskQueueChain::pushAndWait(const T& iAction) {
+  void SerialTaskQueueChain::pushAndWait(T&& iAction) {
     auto destry = [](tbb::task* iTask) { tbb::task::destroy(*iTask); };
     
     std::unique_ptr<tbb::task, decltype(destry)> waitTask( new (tbb::task::allocate_root()) tbb::empty_task, destry );
@@ -129,23 +129,23 @@ namespace edm {
   }
   
   template<typename T>
-  void SerialTaskQueueChain::passDownChain(unsigned int iQueueIndex, const T& iAction) {
+  void SerialTaskQueueChain::passDownChain(unsigned int iQueueIndex, T&& iAction) {
     //Have to be sure the queue associated to this running task
     // does not attempt to start another task
     m_queues[iQueueIndex-1]->pause();
     //is this the last queue?
     if(iQueueIndex +1 == m_queues.size()) {
-      m_queues[iQueueIndex]->push([this,iAction]{ this->actionToRun(iAction); });
+      m_queues[iQueueIndex]->push([this,iAction]() mutable { this->actionToRun(iAction); });
     } else {
       auto nextQueue = iQueueIndex+1;
-      m_queues[iQueueIndex]->push([this, nextQueue, iAction]() {
+      m_queues[iQueueIndex]->push([this, nextQueue, iAction]() mutable {
         this->passDownChain(nextQueue, iAction);
       });
     }
   }
   
   template<typename T>
-  void SerialTaskQueueChain::actionToRun(const T& iAction) {
+  void SerialTaskQueueChain::actionToRun(T&& iAction) {
     //even if an exception happens we will resume the queues.
     using Queues= std::vector<std::shared_ptr<SerialTaskQueue>>;
     auto sentryAction = [](SerialTaskQueueChain* iChain) {

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -47,7 +47,6 @@ namespace edm {
   class ProcessDesc;
   class SubProcess;
   class WaitingTaskHolder;
-  class WaitingTask;
   
   namespace eventsetup {
     class EventSetupProvider;
@@ -238,7 +237,7 @@ namespace edm {
     bool readNextEventForStream(unsigned int iStreamIndex,
                                      std::atomic<bool>* finishedProcessingEvents);
 
-    void handleNextEventForStreamAsync(WaitingTask* iTask,
+    void handleNextEventForStreamAsync(WaitingTaskHolder iTask,
                                        unsigned int iStreamIndex,
                                      std::atomic<bool>* finishedProcessingEvents);
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1359,42 +1359,40 @@ namespace edm {
     return true;
   }
   
-  void EventProcessor::handleNextEventForStreamAsync(WaitingTask* iTask,
-                                                              unsigned int iStreamIndex,
-                                                              std::atomic<bool>* finishedProcessingEvents)
+  void EventProcessor::handleNextEventForStreamAsync(WaitingTaskHolder iTask,
+                                                     unsigned int iStreamIndex,
+                                                     std::atomic<bool>* finishedProcessingEvents)
   {
-    auto recursionTask = make_waiting_task(tbb::task::allocate_root(), [this,iTask,iStreamIndex,finishedProcessingEvents](std::exception_ptr const* iPtr) {
-      if(iPtr) {
-        bool expected = false;
-        if(deferredExceptionPtrIsSet_.compare_exchange_strong(expected,true)) {
-          deferredExceptionPtr_ = *iPtr;
-          {
-            WaitingTaskHolder h(iTask);
-            h.doneWaiting(*iPtr);
-          }
-        }
-        //the stream will stop now
-        iTask->decrement_ref_count();
-        return;
-      }
-
-      handleNextEventForStreamAsync(iTask, iStreamIndex,finishedProcessingEvents);
-    });
-      
-    sourceResourcesAcquirer_.serialQueueChain().push([this,finishedProcessingEvents,recursionTask,iTask,iStreamIndex]() {
+    sourceResourcesAcquirer_.serialQueueChain().push([this,finishedProcessingEvents,iTask,iStreamIndex]() mutable {
            ServiceRegistry::Operate operate(serviceToken_);
 
            try {
              if(readNextEventForStream(iStreamIndex, finishedProcessingEvents) ) {
+               auto recursionTask = make_waiting_task(tbb::task::allocate_root(), [this,iTask,iStreamIndex,finishedProcessingEvents](std::exception_ptr const* iPtr) mutable {
+                 if(iPtr) {
+                   bool expected = false;
+                   if(deferredExceptionPtrIsSet_.compare_exchange_strong(expected,true)) {
+                     deferredExceptionPtr_ = *iPtr;
+                     iTask.doneWaiting(*iPtr);
+                   }
+                   //the stream will stop now
+                   return;
+                 }
+                 handleNextEventForStreamAsync(iTask, iStreamIndex,finishedProcessingEvents);
+               });
+
                processEventAsync( WaitingTaskHolder(recursionTask), iStreamIndex);
              } else {
                //the stream will stop now
-               tbb::task::destroy(*recursionTask);
-               iTask->decrement_ref_count();
+               iTask.doneWaiting(std::exception_ptr{});
              }
            } catch(...) {
-             WaitingTaskHolder h(recursionTask);
-             h.doneWaiting(std::current_exception());
+             bool expected = false;
+             if(deferredExceptionPtrIsSet_.compare_exchange_strong(expected,true)) {
+               auto e =std::current_exception();
+               deferredExceptionPtr_ = e;
+               iTask.doneWaiting(e);
+             }
            }
     });
   }
@@ -1412,21 +1410,23 @@ namespace edm {
 
     //To wait, the ref count has to b 1+#streams
     auto eventLoopWaitTask = make_empty_waiting_task();
-    auto eventLoopWaitTaskPtr = eventLoopWaitTask.get();
     eventLoopWaitTask->increment_ref_count();
 
     const unsigned int kNumStreams = preallocations_.numberOfStreams();
     unsigned int iStreamIndex = 0;
     for(; iStreamIndex<kNumStreams-1; ++iStreamIndex) {
-      eventLoopWaitTask->increment_ref_count();
-      tbb::task::enqueue( *make_waiting_task(tbb::task::allocate_root(),[this,iStreamIndex,finishedProcessingEventsPtr,eventLoopWaitTaskPtr](std::exception_ptr const*){
-        handleNextEventForStreamAsync(eventLoopWaitTaskPtr,iStreamIndex,finishedProcessingEventsPtr);
+      tbb::task::enqueue( *make_waiting_task(tbb::task::allocate_root(),
+                                             [this,iStreamIndex,finishedProcessingEventsPtr,h=WaitingTaskHolder{eventLoopWaitTask.get()}](std::exception_ptr const*){
+        handleNextEventForStreamAsync(h,iStreamIndex,finishedProcessingEventsPtr);
       }) );
     }
-    eventLoopWaitTask->increment_ref_count();
-    eventLoopWaitTask->spawn_and_wait_for_all( *make_waiting_task(tbb::task::allocate_root(),[this,iStreamIndex,finishedProcessingEventsPtr,eventLoopWaitTaskPtr](std::exception_ptr const*){
-      handleNextEventForStreamAsync(eventLoopWaitTaskPtr,iStreamIndex,finishedProcessingEventsPtr);
-    }));
+    //need a temporary Task so that the temporary WaitingTaskHolder assigned to h will go out of scope
+    // before the call to spawn_and_wait_for_all
+    auto t = make_waiting_task(tbb::task::allocate_root(),
+                               [this,iStreamIndex,finishedProcessingEventsPtr,h=WaitingTaskHolder{eventLoopWaitTask.get()}](std::exception_ptr const*){
+      handleNextEventForStreamAsync(h,iStreamIndex,finishedProcessingEventsPtr);
+    });
+    eventLoopWaitTask->spawn_and_wait_for_all( *t);
 
     //One of the processing threads saw an exception
     if(deferredExceptionPtrIsSet_) {


### PR DESCRIPTION
Changed EventProcessor::handleNextEventForStreamAsync to take a WaitingTaskHolder instead of a
bare task pointer. This helps clean up the ownership issues and lays the ground work for better concurrency.