### PR TITLE
Geant4 sensitive detectors cleanup 1

### DIFF
--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -49,15 +49,16 @@ class CaloSD : public SensitiveCaloDetector,
 
 public:    
   
-  CaloSD(G4String  aSDname, const DDCompactView & cpv,
+  CaloSD(const std::string& aSDname, const DDCompactView & cpv,
          const SensitiveDetectorCatalog & clg,
          edm::ParameterSet const & p, const SimTrackManager*,
 	 float timeSlice=1., bool ignoreTkID=false);
   ~CaloSD() override;
   bool     ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
   bool     ProcessHits(G4GFlashSpot*aSpot,G4TouchableHistory*) override;
-  virtual double   getEnergyDeposit(G4Step* step); 
-  uint32_t setDetUnitId(G4Step* step) override =0;
+
+  virtual double getEnergyDeposit(G4Step* step); 
+  uint32_t setDetUnitId(const G4Step* step) override =0;
   
   void     Initialize(G4HCofThisEvent * HCE) override;
   void     EndOfEvent(G4HCofThisEvent * eventHC) override;
@@ -65,7 +66,8 @@ public:
   void     DrawAll() override;
   void     PrintAll() override;
 
-  void             fillHits(edm::PCaloHitContainer&,std::string n) override;
+  void     clearHits() override;
+  void     fillHits(edm::PCaloHitContainer&, const std::string&) override;
 
 protected:
 
@@ -77,7 +79,7 @@ protected:
   CaloG4Hit*       createNewHit();
   void             updateHit(CaloG4Hit*);
   void             resetForNewPrimary(const G4ThreeVector&, double);
-  double           getAttenuation(G4Step* aStep, double birk1, double birk2,
+  double           getAttenuation(const G4Step* aStep, double birk1, double birk2,
                                   double birk3);
 
   void     update(const BeginOfRun *) override;
@@ -85,13 +87,12 @@ protected:
   void     update(const BeginOfTrack * trk) override;
   void     update(const EndOfTrack * trk) override;
   void     update(const ::EndOfEvent *) override;
-  void     clearHits() override;
   virtual void     initRun();
   virtual bool     filterHit(CaloG4Hit*, double);
 
-  virtual int      getTrackID(G4Track*);
-  virtual uint16_t getDepth(G4Step*);   
-  double           getResponseWt(G4Track*);
+  virtual int      getTrackID(const G4Track*);
+  virtual uint16_t getDepth(const G4Step*);   
+  double           getResponseWt(const G4Track*);
   int              getNumberOfHits();
 
 private:
@@ -126,7 +127,7 @@ protected:
 
   const SimTrackManager*          m_trackManager;
   CaloG4Hit*                      currentHit;
-//  TimerProxy                    theHitTimer;
+
   bool                            runInit;
 
   bool                            corrTOFBeam, suppressHeavy;

--- a/SimG4CMS/Calo/interface/CaloTrkProcessing.h
+++ b/SimG4CMS/Calo/interface/CaloTrkProcessing.h
@@ -25,7 +25,7 @@ class CaloTrkProcessing : public SensitiveCaloDetector,
 
 public:
 
-  CaloTrkProcessing(G4String aSDname, const DDCompactView & cpv,
+  CaloTrkProcessing(const std::string& aSDname, const DDCompactView & cpv,
 		    const SensitiveDetectorCatalog & clg,
 		    edm::ParameterSet const & p, const SimTrackManager*);
   ~CaloTrkProcessing() override;
@@ -34,9 +34,9 @@ public:
   bool             ProcessHits(G4Step * , G4TouchableHistory * ) override {
     return true;
   }
-  uint32_t         setDetUnitId(G4Step * step) override {return 0;}
+  uint32_t         setDetUnitId(const G4Step * step) override {return 0;}
   void             EndOfEvent(G4HCofThisEvent * ) override {}
-  void                     fillHits(edm::PCaloHitContainer&, std::string ) override {}
+  void             fillHits(edm::PCaloHitContainer&, const std::string& ) override {}
 
 private:
 

--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -31,28 +31,33 @@ class ECalSD : public CaloSD {
 
 public:    
 
-  ECalSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  ECalSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	 edm::ParameterSet const & p, const SimTrackManager*);
   ~ECalSD() override;
   double                    getEnergyDeposit(G4Step*) override;
-  virtual uint16_t                  getRadiationLength(G4Step *);
-  virtual uint16_t                  getLayerIDForTimeSim(G4Step *);
-  uint32_t                  setDetUnitId(G4Step*) override;
-  void                              setNumberingScheme(EcalNumberingScheme*);
-  int                       getTrackID(G4Track*) override;
-  uint16_t                  getDepth(G4Step*) override;
+  virtual uint16_t          getRadiationLength(const G4Step *);
+  virtual uint16_t          getLayerIDForTimeSim(const G4Step *);
+  uint32_t                  setDetUnitId(const G4Step*) override;
+  void                      setNumberingScheme(EcalNumberingScheme*);
+
+protected:
+
+  int                       getTrackID(const G4Track*) override;
+  uint16_t                  getDepth(const G4Step*) override;
 
 private:    
-  void                              initMap(G4String, const DDCompactView &);
-  double                            curve_LY(G4Step*); 
-  double                            crystalLength(G4LogicalVolume*);
-  double                            crystalDepth(G4LogicalVolume*, const G4ThreeVector&);
+
+  void                              initMap(const G4String&, const DDCompactView &);
+  double                            curve_LY(const G4Step*); 
+  double                            crystalLength(const G4LogicalVolume*);
+  double                            crystalDepth(const G4LogicalVolume*, const G4ThreeVector&);
   void                              getBaseNumber(const G4Step*); 
-  double                            getBirkL3(G4Step*);
+  double                            getBirkL3(const G4Step*);
   std::vector<double>               getDDDArray(const std::string&,
 						const DDsvalues_type&);
   std::vector<std::string>          getStringArray(const std::string&,
 						   const DDsvalues_type&);
+
   bool                              isEB;
   bool                              isEE;
   EcalNumberingScheme *             numberingScheme;
@@ -61,8 +66,8 @@ private:
   double                            birk1, birk2, birk3, birkSlope, birkCut;
   double                            slopeLY, scaleRL;
   std::string                       crystalMat, depth1Name, depth2Name;
-  std::map<G4LogicalVolume*,double> xtalLMap;
-  std::vector<G4LogicalVolume*>     useDepth1, useDepth2, noWeight;
+  std::map<const G4LogicalVolume*,double> xtalLMap;
+  std::vector<const G4LogicalVolume*>     useDepth1, useDepth2, noWeight;
   EcalBaseNumber                    theBaseNumber;
   EnergyResolutionVsLumi            ageing;
   bool                              ageingWithSlopeLY;

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -37,13 +37,13 @@ class HCalSD : public CaloSD, public Observer<const BeginOfJob *> {
 
 public:    
 
-  HCalSD(G4String , const DDCompactView &, const SensitiveDetectorCatalog &,
+  HCalSD(const std::string& , const DDCompactView &, const SensitiveDetectorCatalog &,
          edm::ParameterSet const &, const SimTrackManager*);
   ~HCalSD() override;
   bool                  ProcessHits(G4Step * , G4TouchableHistory * ) override;
   double                getEnergyDeposit(G4Step* ) override;
-  uint32_t              setDetUnitId(G4Step* step) override;
-  void                          setNumberingScheme(HcalNumberingScheme* );
+  uint32_t              setDetUnitId(const G4Step* step) override;
+  void                  setNumberingScheme(HcalNumberingScheme* );
 
 protected:
 
@@ -58,26 +58,26 @@ private:
   std::vector<double>           getDDDArray(const std::string&, 
                                             const DDsvalues_type&);
   std::vector<G4String>         getNames(DDFilteredView&);
-  bool                          isItHF(G4Step *);
-  bool                          isItHF(G4String);
-  bool                          isItFibre(G4LogicalVolume*);
-  bool                          isItFibre(G4String);
-  bool                          isItPMT(G4LogicalVolume*);
-  bool                          isItStraightBundle(G4LogicalVolume*);
-  bool                          isItConicalBundle(G4LogicalVolume*);
-  bool                          isItScintillator(G4Material*);
-  bool                          isItinFidVolume (G4ThreeVector&);
+  bool                          isItHF(const G4Step *);
+  bool                          isItHF(const G4String&);
+  bool                          isItFibre(const G4LogicalVolume*);
+  bool                          isItFibre(const G4String&);
+  bool                          isItPMT(const G4LogicalVolume*);
+  bool                          isItStraightBundle(const G4LogicalVolume*);
+  bool                          isItConicalBundle(const G4LogicalVolume*);
+  bool                          isItScintillator(const G4Material*);
+  bool                          isItinFidVolume (const G4ThreeVector&);
   void                          getFromLibrary(G4Step * step, double weight);
-  void                          hitForFibre(G4Step * step, double weight);
+  void                          hitForFibre(const G4Step * step, double weight);
   void                          getFromParam(G4Step * step, double weight);
-  void                          getHitPMT(G4Step * step);
-  void                          getHitFibreBundle(G4Step * step, bool type);
-  int                           setTrackID(G4Step * step);
-  void                          readWeightFromFile(std::string);
+  void                          getHitPMT(const G4Step * step);
+  void                          getHitFibreBundle(const G4Step * step, bool type);
+  int                           setTrackID(const G4Step * step);
+  void                          readWeightFromFile(const std::string&);
   double                        layerWeight(int, const G4ThreeVector&, int, int);
-  void                          plotProfile(G4Step* step, const G4ThreeVector& pos, 
+  void                          plotProfile(const G4Step* step, const G4ThreeVector& pos, 
                                             double edep, double time, int id);
-  void                          plotHF(G4ThreeVector& pos, bool emType);
+  void                          plotHF(const G4ThreeVector& pos, bool emType);
   void                          modifyDepth(HcalNumberingFromDDD::HcalID& id);
 
   HcalDDDSimConstants*          hcalConstants;
@@ -103,8 +103,8 @@ private:
   std::vector<double>           gpar;
   std::vector<int>              hfLevels;
   std::vector<G4String>         hfNames, fibreNames, matNames;
-  std::vector<G4Material*>      materials;
-  std::vector<G4LogicalVolume*> hfLV, fibreLV, pmtLV, fibre1LV, fibre2LV;
+  std::vector<const G4Material*>      materials;
+  std::vector<const G4LogicalVolume*> hfLV, fibreLV, pmtLV, fibre1LV, fibre2LV;
   std::map<uint32_t,double>     layerWeights;
   TH1F                          *hit_[9], *time_[9], *dist_[9], *hzvem, *hzvhad;
 

--- a/SimG4CMS/Calo/interface/HFCherenkov.h
+++ b/SimG4CMS/Calo/interface/HFCherenkov.h
@@ -23,12 +23,12 @@ public:
    HFCherenkov(edm::ParameterSet const & p);
    virtual ~HFCherenkov();
   
-   int                 computeNPE(G4Step* step, G4ParticleDefinition* pDef,
+   int                 computeNPE(const G4Step* step, const G4ParticleDefinition* pDef,
 				  double pBeta, double u, double v, double w, 
 				  double step_length, double zFiber, 
 				  double Dose, int Npe_Dose);
    
-   int                 computeNPEinPMT(G4ParticleDefinition* pDef,double pBeta,
+   int                 computeNPEinPMT(const G4ParticleDefinition* pDef,double pBeta,
                                        double u, double v, double w, 
                                        double step_length);
 

--- a/SimG4CMS/Calo/interface/HFFibre.h
+++ b/SimG4CMS/Calo/interface/HFFibre.h
@@ -22,7 +22,7 @@ class HFFibre {
 public:
   
   //Constructor and Destructor
-  HFFibre(std::string & name, const DDCompactView & cpv,
+  HFFibre(const std::string & name, const DDCompactView & cpv,
 	  edm::ParameterSet const & p);
   ~HFFibre();
 

--- a/SimG4CMS/Calo/interface/HFShower.h
+++ b/SimG4CMS/Calo/interface/HFShower.h
@@ -23,7 +23,7 @@ class HFShower {
 
 public:    
 
-  HFShower(std::string & name, const DDCompactView & cpv, 
+  HFShower(const std::string & name, const DDCompactView & cpv, 
 	   edm::ParameterSet const & p, int chk=0);
   virtual ~HFShower();
 
@@ -39,9 +39,9 @@ public:
   };
 
   void                initRun(G4ParticleTable *, HcalDDDSimConstants*);
-  std::vector<Hit>    getHits(G4Step * aStep, double weight);
-  std::vector<Hit>    getHits(G4Step * aStep, bool forLibrary);
-  std::vector<Hit>    getHits(G4Step * aStep, bool forLibraryProducer, double zoffset);
+  std::vector<Hit>    getHits(const G4Step * aStep, double weight);
+  std::vector<Hit>    getHits(const G4Step * aStep, bool forLibrary);
+  std::vector<Hit>    getHits(const G4Step * aStep, bool forLibraryProducer, double zoffset);
 
 
 private:    

--- a/SimG4CMS/Calo/interface/HFShowerFibreBundle.h
+++ b/SimG4CMS/Calo/interface/HFShowerFibreBundle.h
@@ -21,10 +21,10 @@ class HFShowerFibreBundle {
 
 public:    
 
-  HFShowerFibreBundle(std::string & name, const DDCompactView & cpv, 
+  HFShowerFibreBundle(const std::string & name, const DDCompactView & cpv, 
 		      edm::ParameterSet const & p);
   virtual ~HFShowerFibreBundle();
-  double                getHits(G4Step * aStep, bool type);
+  double                getHits(const G4Step * aStep, bool type);
   double                getRadius();
   void                  initRun(G4ParticleTable *, HcalDDDSimConstants*);
 

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -31,7 +31,7 @@ class HFShowerLibrary {
 public:
   
   //Constructor and Destructor
-  HFShowerLibrary(std::string & name, const DDCompactView & cpv,
+  HFShowerLibrary(const std::string & name, const DDCompactView & cpv,
 		  edm::ParameterSet const & p);
   ~HFShowerLibrary();
 

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -47,7 +47,7 @@ public:
   void                initRun(G4ParticleTable *, HcalDDDSimConstants*);
   std::vector<Hit>    getHits(G4Step * aStep, bool &ok, double weight, 
 			      bool onlyLong=false);
-  std::vector<Hit>    fillHits(G4ThreeVector & p, G4ThreeVector & v,
+  std::vector<Hit>    fillHits(const G4ThreeVector & p, const G4ThreeVector & v,
                                int parCode, double parEnergy, bool & ok,
                                double weight, double time, bool onlyLong=false);
 protected:

--- a/SimG4CMS/Calo/interface/HFShowerPMT.h
+++ b/SimG4CMS/Calo/interface/HFShowerPMT.h
@@ -21,10 +21,10 @@ class HFShowerPMT {
 
 public:    
 
-  HFShowerPMT(std::string & name, const DDCompactView & cpv, 
+  HFShowerPMT(const std::string & name, const DDCompactView & cpv, 
 	      edm::ParameterSet const & p);
   virtual ~HFShowerPMT();
-  double                getHits(G4Step * aStep);
+  double                getHits(const G4Step * aStep);
   double                getRadius();
   void                  initRun(G4ParticleTable *, HcalDDDSimConstants*);
 

--- a/SimG4CMS/Calo/interface/HFShowerParam.h
+++ b/SimG4CMS/Calo/interface/HFShowerParam.h
@@ -28,7 +28,7 @@ class HFShowerParam {
 
 public:    
 
-  HFShowerParam(std::string & name, const DDCompactView & cpv, 
+  HFShowerParam(const std::string & name, const DDCompactView & cpv, 
 		edm::ParameterSet const & p);
   virtual ~HFShowerParam();
 

--- a/SimG4CMS/Calo/interface/HGCSD.h
+++ b/SimG4CMS/Calo/interface/HGCSD.h
@@ -27,12 +27,12 @@ class HGCSD : public CaloSD, public Observer<const BeginOfJob *> {
 
 public:    
 
-  HGCSD(G4String , const DDCompactView &, const SensitiveDetectorCatalog &,
+  HGCSD(const std::string& , const DDCompactView &, const SensitiveDetectorCatalog &,
 	edm::ParameterSet const &, const SimTrackManager*);
   ~HGCSD() override;
   bool                    ProcessHits(G4Step * , G4TouchableHistory * ) override;
   double                  getEnergyDeposit(G4Step* ) override;
-  uint32_t                setDetUnitId(G4Step* step) override;
+  uint32_t                setDetUnitId(const G4Step* step) override;
 
 protected:
 
@@ -44,8 +44,8 @@ private:
 
   uint32_t                        setDetUnitId(ForwardSubdetector&, int, int, 
 					       int, int, G4ThreeVector &);
-  bool                            isItinFidVolume (G4ThreeVector&) {return true;}
-  int                             setTrackID(G4Step * step);
+  bool                            isItinFidVolume (const G4ThreeVector&) {return true;}
+  int                             setTrackID(const G4Step * step);
 
   std::string                     nameX;
 

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -30,9 +30,6 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
   eminHitD(0), m_trackManager(manager), currentHit(nullptr), runInit(false),
   timeSlice(timeSliceUnit), ignoreTrackID(ignoreTkID), hcID(-1), theHC(nullptr), 
   meanResponse(nullptr) {
-  //Add Hcal Sentitive Detector Names
-
-  collectionName.insert(name);
 
   //Parameters
   edm::ParameterSet m_CaloSD = p.getParameter<edm::ParameterSet>("CaloSD");
@@ -64,17 +61,6 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
       break;
     }
   }
-#ifdef DebugLog
-  LogDebug("CaloSim") << "***************************************************" 
-                      << "\n"
-                      << "*                                                 *" 
-                      << "\n"
-                      << "* Constructing a CaloSD  with name " << GetName()
-                      << "\n"
-                      << "*                                                 *" 
-                      << "\n"
-                      << "***************************************************";
-#endif
   slave      = new CaloSlaveSD(name);
   currentID  = CaloHitID(timeSlice, ignoreTrackID);
   previousID = CaloHitID(timeSlice, ignoreTrackID);
@@ -83,18 +69,6 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
   cleanIndex = 0;
   totalHits = 0;
   forceSave = false;
-
-  //
-  // Now attach the right detectors (LogicalVolumes) to me
-  //
-  const std::vector<std::string>& lvNames = clg.logicalNames(name);
-  this->Register();
-  for (std::vector<std::string>::const_iterator it=lvNames.begin(); it !=lvNames.end(); ++it) {
-    this->AssignSD(*it);
-#ifdef DebugLog
-    LogDebug("CaloSim") << "CaloSD : Assigns SD to LV " << (*it);
-#endif
-  }
 
   edm::LogInfo("CaloSim") << "CaloSD: Minimum energy of track for saving it " 
                           << energyCut/GeV  << " GeV" << "\n"
@@ -111,9 +85,9 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
 }
 
 CaloSD::~CaloSD() { 
-  if (slave)           delete slave; 
-  if (theHC)           delete theHC;
-  if (meanResponse)    delete meanResponse;
+  delete slave; 
+  delete theHC;
+  delete meanResponse;
 }
 
 bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -21,7 +21,7 @@
 
 //#define DebugLog
 
-CaloSD::CaloSD(G4String name, const DDCompactView & cpv,
+CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
         const SensitiveDetectorCatalog & clg,
         edm::ParameterSet const & p, const SimTrackManager* manager,
         float timeSliceUnit, bool ignoreTkID) : 
@@ -242,8 +242,8 @@ void CaloSD::PrintAll() {
   theHC->PrintAllHits();
 } 
 
-void CaloSD::fillHits(edm::PCaloHitContainer& c, std::string n) {
-  if (slave->name() == n) c=slave->hits();
+void CaloSD::fillHits(edm::PCaloHitContainer& cc, const std::string& hname) {
+  if (slave->name() == hname) { cc=slave->hits(); }
   slave->Clean();
 }
 
@@ -322,9 +322,9 @@ G4bool CaloSD::hitExists() {
   
   // Reset entry point for new primary
   posGlobal = preStepPoint->GetPosition();
-  if (currentID.trackID() != previousID.trackID()) 
-    resetForNewPrimary(preStepPoint->GetPosition(), preStepPoint->GetKineticEnergy());
-  
+  if (currentID.trackID() != previousID.trackID()) { 
+    resetForNewPrimary(posGlobal, preStepPoint->GetKineticEnergy());
+  }
   return checkHit();
 }
 
@@ -462,7 +462,7 @@ void CaloSD::resetForNewPrimary(const G4ThreeVector& point, double energy) {
 #endif
 }
 
-double CaloSD::getAttenuation(G4Step* aStep, double birk1, double birk2, double birk3) {
+double CaloSD::getAttenuation(const G4Step* aStep, double birk1, double birk2, double birk3) {
   double weight = 1.;
   double charge = aStep->GetPreStepPoint()->GetCharge();
 
@@ -571,7 +571,7 @@ void CaloSD::clearHits() {
 
 void CaloSD::initRun() {}
 
-int CaloSD::getTrackID(G4Track* aTrack) {
+int CaloSD::getTrackID(const G4Track* aTrack) {
   int primaryID = 0;
   forceSave = false;
   TrackInformation* trkInfo=(TrackInformation *)(aTrack->GetUserInformation());
@@ -592,7 +592,7 @@ int CaloSD::getTrackID(G4Track* aTrack) {
   return primaryID;
 }
 
-uint16_t CaloSD::getDepth(G4Step*) { return 0; }
+uint16_t CaloSD::getDepth(const G4Step*) { return 0; }
 
 bool CaloSD::filterHit(CaloG4Hit* hit, double time) {
   double emin(eminHit);
@@ -604,7 +604,7 @@ bool CaloSD::filterHit(CaloG4Hit* hit, double time) {
   return ((time <= tmaxHit) && (hit->getEnergyDeposit() > emin));
 }
 
-double CaloSD::getResponseWt(G4Track* aTrack) {
+double CaloSD::getResponseWt(const G4Track* aTrack) {
   if (meanResponse) {
     TrackInformation * trkInfo = (TrackInformation *)(aTrack->GetUserInformation());
     return meanResponse->getWeight(trkInfo->genParticlePID(), trkInfo->genParticleP());

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -23,7 +23,7 @@
 
 //#define DebugLog
 
-CaloTrkProcessing::CaloTrkProcessing(G4String name, 
+CaloTrkProcessing::CaloTrkProcessing(const std::string& name, 
 				     const DDCompactView & cpv,
 				     const SensitiveDetectorCatalog & clg,
 				     edm::ParameterSet const & p,

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -39,11 +39,11 @@ bool any(const std::vector<T> & v, const T &what) {
 }
 
 ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
-	       const SensitiveDetectorCatalog & clg,
-	       edm::ParameterSet const & p, const SimTrackManager* manager) : 
+               const SensitiveDetectorCatalog & clg,
+               edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager, 
-	 (float)(p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit")),
-	 p.getParameter<edm::ParameterSet>("ECalSD").getParameter<bool>("IgnoreTrackID")), 
+         (float)(p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit")),
+         p.getParameter<edm::ParameterSet>("ECalSD").getParameter<bool>("IgnoreTrackID")), 
   numberingScheme(nullptr){
 
   //   static SimpleConfigurable<bool>   on1(false,  "ECalSD:UseBirkLaw");
@@ -76,7 +76,7 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
   
   ageingWithSlopeLY   = m_EC.getUntrackedParameter<bool>("AgeingWithSlopeLY", false);
   if(ageingWithSlopeLY) ageing.setLumies(p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("DelivLuminosity"),
-					 p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("InstLuminosity"));
+                                         p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("InstLuminosity"));
 
   //Material list for HB/HE/HO sensitive detectors
   std::string attribute = "ReadOutName";
@@ -90,7 +90,7 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
   if (!tempD.empty()) { if (tempD[0] < 0.1) useWeight = false; }
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("EcalSim") << "ECalSD:: useWeight " << tempD.size() << ":" 
-			  << useWeight << std::endl;
+                          << useWeight << std::endl;
 #endif
   std::vector<std::string> tempS = getStringArray("Depth1Name",sv);
   if (!tempS.empty()) depth1Name = tempS[0];
@@ -100,7 +100,7 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
   else                  depth2Name = " ";
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("EcalSim") << "Names (Depth 1):" << depth1Name << " (Depth 2):" 
-			  << depth2Name << std::endl;
+                          << depth2Name << std::endl;
 #endif
   EcalNumberingScheme* scheme=nullptr;
   if (nullNS) {
@@ -125,27 +125,27 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
 #endif
   if (useWeight) {
     edm::LogInfo("EcalSim")  << "ECalSD:: Use of Birks law is set to      " 
-			     << useBirk << "        with three constants kB = "
-			     << birk1 << ", C1 = " << birk2 << ", C2 = " 
-			     << birk3 <<"\n         Use of L3 parametrization "
-			     << useBirkL3 << " with slope " << birkSlope
-			     << " and cut off " << birkCut << "\n"
-			     << "         Slope for Light yield is set to "
-			     << slopeLY;
+                             << useBirk << "        with three constants kB = "
+                             << birk1 << ", C1 = " << birk2 << ", C2 = " 
+                             << birk3 <<"\n         Use of L3 parametrization "
+                             << useBirkL3 << " with slope " << birkSlope
+                             << " and cut off " << birkCut << "\n"
+                             << "         Slope for Light yield is set to "
+                             << slopeLY;
   } else {
     edm::LogInfo("EcalSim")  << "ECalSD:: energy deposit is not corrected "
-			     << " by Birk or light yield curve";
+                             << " by Birk or light yield curve";
   }
 
   edm::LogInfo("EcalSim") << "ECalSD:: Suppression Flag " << suppressHeavy
-			  << "\tprotons below " << kmaxProton << " MeV,"
-			  << "\tneutrons below " << kmaxNeutron << " MeV"
-			  << "\tions below " << kmaxIon << " MeV"
-			  << "\n\tDepth1 Name = " << depth1Name
-			  << "\tDepth2 Name = " << depth2Name
-			  << "\n\tstoreRL" << storeRL << ":" << scaleRL
-			  << "\tstoreLayerTimeSim " << storeLayerTimeSim
-			  << "\n\ttime Granularity " << p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit") << " ns"; 
+                          << "\tprotons below " << kmaxProton << " MeV,"
+                          << "\tneutrons below " << kmaxNeutron << " MeV"
+                          << "\tions below " << kmaxIon << " MeV"
+                          << "\n\tDepth1 Name = " << depth1Name
+                          << "\tDepth2 Name = " << depth2Name
+                          << "\n\tstoreRL" << storeRL << ":" << scaleRL
+                          << "\tstoreLayerTimeSim " << storeLayerTimeSim
+                          << "\n\ttime Granularity " << p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit") << " ns"; 
   if (useWeight) initMap(name,cpv);
 #ifdef plotDebug
   edm::Service<TFileService> tfile;
@@ -157,7 +157,7 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
       std::string title= "Local vs Global for "+ctype[k];
       double xmin = (k > 1) ? 3000.0 : 1000.0;
       g2L_[k] = ecDir.make<TH2F>(name.c_str(),title.c_str(),100,xmin,
-				 xmin+1000.,100,0.0,3000.);
+                                 xmin+1000.,100,0.0,3000.);
     }
   } else {
     for (int k=0; k<4; ++k) g2L_[k] = 0;
@@ -175,9 +175,9 @@ double ECalSD::getEnergyDeposit(G4Step * aStep) {
   if (aStep == nullptr) {
     return 0;
   } else {
-    const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
-    const G4Track* theTrack   = aStep->GetTrack();
-    double wt2  = theTrack->GetWeight();
+    preStepPoint = aStep->GetPreStepPoint();
+    theTrack     = aStep->GetTrack();
+    double wt2   = theTrack->GetWeight();
     const G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
 
     // take into account light collection curve for crystals
@@ -185,28 +185,28 @@ double ECalSD::getEnergyDeposit(G4Step * aStep) {
     if (suppressHeavy) {
       TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
       if (trkInfo) {
-	int pdg = theTrack->GetDefinition()->GetPDGEncoding();
-	if (!(trkInfo->isPrimary())) { // Only secondary particles
-	  double ke = theTrack->GetKineticEnergy()/MeV;
-	  if (((pdg/1000000000 == 1 && ((pdg/10000)%100) > 0 &&
-		((pdg/10)%100) > 0)) && (ke<kmaxIon)) weight = 0;
-	  if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
-	  if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
+        int pdg = theTrack->GetDefinition()->GetPDGEncoding();
+        if (!(trkInfo->isPrimary())) { // Only secondary particles
+          double ke = theTrack->GetKineticEnergy()/MeV;
+          if (((pdg/1000000000 == 1 && ((pdg/10000)%100) > 0 &&
+                ((pdg/10)%100) > 0)) && (ke<kmaxIon)) weight = 0;
+          if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
+          if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
 #ifdef EDM_ML_DEBUG
-	  if (weight == 0) 
-	    edm::LogInfo("EcalSim") << "Ignore Track " << theTrack->GetTrackID()
-				    << " Type " << theTrack->GetDefinition()->GetParticleName()
-				    << " Kinetic Energy " << ke << " MeV";
+          if (weight == 0) 
+            edm::LogInfo("EcalSim") << "Ignore Track " << theTrack->GetTrackID()
+                                    << " Type " << theTrack->GetDefinition()->GetParticleName()
+                                    << " Kinetic Energy " << ke << " MeV";
 #endif
-	}
+        }
       }
     }
     const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
     if (useWeight && !any(noWeight,lv)) {
       weight *= curve_LY(aStep);
       if (useBirk) {
-	if (useBirkL3) weight *= getBirkL3(aStep);
-	else           weight *= getAttenuation(aStep, birk1, birk2, birk3);
+        if (useBirkL3) weight *= getBirkL3(aStep);
+        else           weight *= getAttenuation(aStep, birk1, birk2, birk3);
       }
     }
     double wt1  = getResponseWt(theTrack);
@@ -214,30 +214,30 @@ double ECalSD::getEnergyDeposit(G4Step * aStep) {
     /*
     if(wt2 != 1.0) { 
       edm::LogInfo("EcalSim") << "ECalSD:: " << nameVolume
-			      <<" LightWeight= " <<weight << " wt1= " <<wt1
-			      << "  wt2= " << wt2 << "  "
-			      << " Weighted Energy Deposit " << edep/MeV
-			      << " MeV";
+                              <<" LightWeight= " <<weight << " wt1= " <<wt1
+                              << "  wt2= " << wt2 << "  "
+                              << " Weighted Energy Deposit " << edep/MeV
+                              << " MeV";
       const G4VProcess* pr = theTrack->GetCreatorProcess();
       if (pr) 
-	edm::LogInfo("EcalSim") << theTrack->GetDefinition()->GetParticleName()
-				<< " " << theTrack->GetKineticEnergy()
-				<< " Id=" << theTrack->GetTrackID()
-				<< " IdP=" << theTrack->GetParentID()
-				<< " from  " << pr->GetProcessName();
+        edm::LogInfo("EcalSim") << theTrack->GetDefinition()->GetParticleName()
+                                << " " << theTrack->GetKineticEnergy()
+                                << " Id=" << theTrack->GetTrackID()
+                                << " IdP=" << theTrack->GetParentID()
+                                << " from  " << pr->GetProcessName();
       else
-	edm::LogInfo("EcalSim") << theTrack->GetDefinition()->GetParticleName()
-				<< " " << theTrack->GetKineticEnergy()
-				<< " Id=" << theTrack->GetTrackID()
-				<< " IdP=" << theTrack->GetParentID();
+        edm::LogInfo("EcalSim") << theTrack->GetDefinition()->GetParticleName()
+                                << " " << theTrack->GetKineticEnergy()
+                                << " Id=" << theTrack->GetTrackID()
+                                << " IdP=" << theTrack->GetParentID();
     }
     */
     if(wt2 > 0.0) { edep *= wt2; }
 #ifdef EDM_ML_DEBUG
     edm::LogInfo("EcalSim") << "ECalSD:: " << nameVolume
-			    << " Light Collection Efficiency " << weight << ":"
-			    << wt1 << " Weighted Energy Deposit " << edep/MeV 
-			    << " MeV";
+                            << " Light Collection Efficiency " << weight << ":"
+                            << wt1 << " Weighted Energy Deposit " << edep/MeV 
+                            << " MeV";
 #endif
     return edep;
   } 
@@ -248,7 +248,6 @@ int ECalSD::getTrackID(const G4Track* aTrack) {
   int  primaryID(0);
   bool flag(false);
   if (storeTrack) {
-    const G4StepPoint* preStepPoint = aTrack->GetStep()->GetPreStepPoint();
     const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
     if (any(useDepth1,lv)) {
       flag = true;
@@ -266,12 +265,13 @@ int ECalSD::getTrackID(const G4Track* aTrack) {
 }
 
 uint16_t ECalSD::getDepth(const G4Step * aStep) {
-  const G4LogicalVolume* lv = aStep->GetPreStepPoint()->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+  const G4StepPoint* hitPoint = aStep->GetPreStepPoint();
+  const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
   uint16_t depth  = any(useDepth1,lv) ? 1 : (any(useDepth2,lv) ? 2 : 0);
   if (storeRL) {
     auto ite        = xtalLMap.find(lv);
     uint16_t depth1 = (ite == xtalLMap.end()) ? 0 : (((ite->second) >= 0) ? 0 :
-						     PCaloHit::kEcalDepthRefz);
+                                                     PCaloHit::kEcalDepthRefz);
     uint16_t depth2 = getRadiationLength(aStep);
     depth          |= (((depth2&PCaloHit::kEcalDepthMask) << PCaloHit::kEcalDepthOffset) | depth1);
   } else if (storeLayerTimeSim) {
@@ -280,8 +280,8 @@ uint16_t ECalSD::getDepth(const G4Step * aStep) {
   }
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("EcalSim") << "ECalSD::Depth " << std::hex << depth1 << ":"
-			      << depth2 << ":" << depth << std::dec << " L "
-			      << (ite == xtalLMap.end()) << ":" <<ite->second;
+                              << depth2 << ":" << depth << std::dec << " L "
+                              << (ite == xtalLMap.end()) << ":" <<ite->second;
 #endif
   return depth;
 }
@@ -291,14 +291,14 @@ uint16_t ECalSD::getRadiationLength(const G4Step * aStep) {
   uint16_t thisX0 = 0;
   if (aStep != nullptr) {
     const G4StepPoint* hitPoint = aStep->GetPreStepPoint();
-    const G4LogicalVolume* lv   = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+    const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
 #ifdef EDM_ML_DEBUG
     edm::LogInfo("EcalSim") << lv->GetName() << " useWight " << useWeight;
 #endif
     if (useWeight) {
       const G4ThreeVector  localPoint = setToLocal(hitPoint->GetPosition(),
-					     hitPoint->GetTouchable());
-      double radl     = hitPoint->GetMaterial()->GetRadlen();
+                                                   hitPoint->GetTouchable());
+      double radl     = preStepPoint->GetMaterial()->GetRadlen();
       double depth    = crystalDepth(lv,localPoint);
       thisX0 = (uint16_t)floor(scaleRL*depth/radl);
 #ifdef plotDebug
@@ -307,21 +307,21 @@ uint16_t ECalSD::getRadiationLength(const G4Step * aStep) {
       int k2 = (lvname.find("refl")!=std::string::npos) ? 1 : 0;
       int kk = k1+k2;
       double rz = (k1 == 0) ? (hitPoint->GetPosition()).rho() : 
-	std::abs((hitPoint->GetPosition()).z());
+        std::abs((hitPoint->GetPosition()).z());
       edm::LogVerbatim("EcalSim") << lvname << " # " << k1 << ":" << k2 << ":" 
-				  << kk << " rz " << rz << " D " << thisX0;
+                                  << kk << " rz " << rz << " D " << thisX0;
       g2L_[kk]->Fill(rz,thisX0);
 #endif
 #ifdef EDM_ML_DEBUG
       double crlength = crystalLength(lv);
       edm::LogVerbatim("EcalSim") << lv->GetName() << " Global " 
-				  << hitPoint->GetPosition() << ":" 
-				  << (hitPoint->GetPosition()).rho() 
-				  << " Local " << localPoint 
-				  << " Crystal Length " << crlength 
-				  << " Radl " << radl << " DetZ " << detz 
-				  << " Index " << thisX0 
-				  << " : " << getLayerIDForTimeSim(aStep);
+                                  << hitPoint->GetPosition() << ":" 
+                                  << (hitPoint->GetPosition()).rho() 
+                                  << " Local " << localPoint 
+                                  << " Crystal Length " << crlength 
+                                  << " Radl " << radl << " DetZ " << detz 
+                                  << " Index " << thisX0 
+                                  << " : " << getLayerIDForTimeSim(aStep);
 #endif
     } 
   }
@@ -335,9 +335,9 @@ uint16_t ECalSD::getLayerIDForTimeSim(const G4Step * aStep)
 
   if (aStep != nullptr ) {
     const G4StepPoint* hitPoint = aStep->GetPreStepPoint();
-    const G4LogicalVolume* lv   = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+    const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
     const G4ThreeVector  localPoint = setToLocal(hitPoint->GetPosition(),
-					   hitPoint->GetTouchable());
+                                                 hitPoint->GetTouchable());
     double detz     = crystalDepth(lv,localPoint);
     if (detz<0) detz= 0;
     return (int)detz/layerSize;
@@ -357,7 +357,7 @@ uint32_t ECalSD::setDetUnitId(const G4Step * aStep) {
 void ECalSD::setNumberingScheme(EcalNumberingScheme* scheme) {
   if (scheme != nullptr) {
     edm::LogInfo("EcalSim") << "EcalSD: updates numbering scheme for " 
-			    << GetName();
+                            << GetName();
     if (numberingScheme) delete numberingScheme;
     numberingScheme = scheme;
   }
@@ -387,96 +387,96 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
     int type = (ibec+iref == 1) ? 1 : -1;
     if (depth1Name != " ") {
       if (strncmp(lvname.c_str(), depth1Name.c_str(), 4) == 0) {
-	if (!any(useDepth1, lv)) {
- 	  useDepth1.push_back(lv);
+        if (!any(useDepth1, lv)) {
+           useDepth1.push_back(lv);
 #ifdef EDM_ML_DEBUG
-	  edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
-				  << lvname <<" in Depth 1 volume list";
+          edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
+                                  << lvname <<" in Depth 1 volume list";
 #endif
-	}
-	const G4LogicalVolume* lvr = nameMap[lvname + "_refl"];
-	if (lvr != nullptr && !any(useDepth1, lvr)) {
-	  useDepth1.push_back(lvr);
+        }
+        const G4LogicalVolume* lvr = nameMap[lvname + "_refl"];
+        if (lvr != nullptr && !any(useDepth1, lvr)) {
+          useDepth1.push_back(lvr);
 #ifdef EDM_ML_DEBUG
-	  edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
-				  << lvname << "_refl"
-				  <<" in Depth 1 volume list";
+          edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
+                                  << lvname << "_refl"
+                                  <<" in Depth 1 volume list";
 #endif
-	}
+        }
       }
     }
     if (depth2Name != " ") {
       if (strncmp(lvname.c_str(), depth2Name.c_str(), 4) == 0) {
-	if (!any(useDepth2, lv)) {
-	  useDepth2.push_back(lv);
+        if (!any(useDepth2, lv)) {
+          useDepth2.push_back(lv);
 #ifdef EDM_ML_DEBUG
-	  edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
-				  << lvname <<" in Depth 2 volume list";
+          edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
+                                  << lvname <<" in Depth 2 volume list";
 #endif
-	}
-	const G4LogicalVolume* lvr = nameMap[lvname + "_refl"];
-	if (lvr != nullptr && !any(useDepth2,lvr)) {
-	  useDepth2.push_back(lvr);
+        }
+        const G4LogicalVolume* lvr = nameMap[lvname + "_refl"];
+        if (lvr != nullptr && !any(useDepth2,lvr)) {
+          useDepth2.push_back(lvr);
 #ifdef EDM_ML_DEBUG
-	  edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
-				  << lvname << "_refl"
-				  <<" in Depth 2 volume list";
+          edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
+                                  << lvname << "_refl"
+                                  <<" in Depth 2 volume list";
 #endif
-	}
+        }
       }
     }
     if (lv != nullptr) {
       if (crystalMat.size() == matname.size() && !strcmp(crystalMat.c_str(), matname.c_str())) {
-	if (!any(lvused,lv)) {
-	  lvused.push_back(lv);
-	  const DDSolid & sol  = fv.logicalPart().solid();
-	  const std::vector<double> & paras = sol.parameters();
+        if (!any(lvused,lv)) {
+          lvused.push_back(lv);
+          const DDSolid & sol  = fv.logicalPart().solid();
+          const std::vector<double> & paras = sol.parameters();
 #ifdef EDM_ML_DEBUG
-	  edm::LogInfo("EcalSim") << "ECalSD::initMap (for " << sd 
-				  << "): Solid " << lvname << " Shape " 
-				  << sol.shape() << " Parameter 0 = "
-				  << paras[0] << " Logical Volume " << lv;
+          edm::LogInfo("EcalSim") << "ECalSD::initMap (for " << sd 
+                                  << "): Solid " << lvname << " Shape " 
+                                  << sol.shape() << " Parameter 0 = "
+                                  << paras[0] << " Logical Volume " << lv;
 #endif
-	  if (sol.shape() == ddtrap) {
-	    double dz = 2*paras[0];
-	    xtalLMap.insert(std::pair<const G4LogicalVolume*,double>(lv,dz*type));
-	    lv = nameMap[lvname + "_refl"];
-	    if (lv != nullptr) {
-	      xtalLMap.insert(std::pair<const G4LogicalVolume*,double>(lv,-dz*type));
-	    }
-	  }
-	}
+          if (sol.shape() == ddtrap) {
+            double dz = 2*paras[0];
+            xtalLMap.insert(std::pair<const G4LogicalVolume*,double>(lv,dz*type));
+            lv = nameMap[lvname + "_refl"];
+            if (lv != nullptr) {
+              xtalLMap.insert(std::pair<const G4LogicalVolume*,double>(lv,-dz*type));
+            }
+          }
+        }
       } else {
-	if (!any(noWeight,lv)) {
-	  noWeight.push_back(lv);
+        if (!any(noWeight,lv)) {
+          noWeight.push_back(lv);
 #ifdef EDM_ML_DEBUG
-	  edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume "
-				  << lvname << " Material " << matname 
-				  << " in noWeight list";
+          edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume "
+                                  << lvname << " Material " << matname 
+                                  << " in noWeight list";
 #endif
-	}
-	lv = nameMap[lvname];
-	if (lv != nullptr && !any(noWeight,lv)) {
-	  noWeight.push_back(lv);
+        }
+        lv = nameMap[lvname];
+        if (lv != nullptr && !any(noWeight,lv)) {
+          noWeight.push_back(lv);
 #ifdef EDM_ML_DEBUG
-	  edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
-				  << lvname << " Material " << matname 
-				  << " in noWeight list";
+          edm::LogInfo("EcalSim") << "ECalSD::initMap Logical Volume " 
+                                  << lvname << " Material " << matname 
+                                  << " in noWeight list";
 #endif
-	}
+        }
       }
     }
     dodet = fv.next();
   }
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("EcalSim") << "ECalSD: Length Table for " << attribute << " = " 
-			  << sd << ":";   
+                          << sd << ":";   
   int i=0;
   for (auto ite : xtalLMap) {
     G4String name("Unknown");
     if (ite.first != 0) name = (ite.first)->GetName();
     edm::LogInfo("EcalSim") << " " << i << " " << ite.first << " " << name 
-			    << " L = " << ite.second;
+                            << " L = " << ite.second;
     ++i;
   }
 #endif
@@ -484,12 +484,11 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
 
 double ECalSD::curve_LY(const G4Step* aStep) {
 
-  const G4StepPoint*     stepPoint = aStep->GetPreStepPoint();
-  const G4LogicalVolume* lv        = stepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+  const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
 
   double weight = 1.;
-  const G4ThreeVector  localPoint = setToLocal(stepPoint->GetPosition(),
-					 stepPoint->GetTouchable());
+  const G4ThreeVector localPoint = setToLocal(preStepPoint->GetPosition(),
+                                              preStepPoint->GetTouchable());
 
   double crlength = crystalLength(lv);
   double depth    = crystalDepth(lv,localPoint);
@@ -502,13 +501,13 @@ double ECalSD::curve_LY(const G4Step* aStep) {
     double dapd = crlength - depth;
     if (dapd >= -0.1 || dapd <= crlength+0.1) {
       if (dapd <= 100.)
-	weight = 1.0 + slopeLY - dapd * 0.01 * slopeLY;
+        weight = 1.0 + slopeLY - dapd * 0.01 * slopeLY;
     } else {
       edm::LogWarning("EcalSim") << "ECalSD: light coll curve : wrong distance "
-				 << "to APD " << dapd << " crlength = " 
-				 << crlength <<" crystal name = " <<lv->GetName()
-				 << " z of localPoint = " << localPoint.z() 
-				 << " take weight = " << weight;
+                                 << "to APD " << dapd << " crlength = " 
+                                 << crlength <<" crystal name = " <<lv->GetName()
+                                 << " z of localPoint = " << localPoint.z() 
+                                 << " take weight = " << weight;
     }
   }
   return weight;
@@ -522,7 +521,7 @@ double ECalSD::crystalLength(const G4LogicalVolume* lv) {
 }
 
 double ECalSD::crystalDepth(const G4LogicalVolume* lv, 
-			    const G4ThreeVector& localPoint) {
+                            const G4ThreeVector& localPoint) {
 
   auto ite = xtalLMap.find(lv);
   double depth = (ite == xtalLMap.end()) ? 0 :
@@ -534,7 +533,7 @@ double ECalSD::crystalDepth(const G4LogicalVolume* lv,
 void ECalSD::getBaseNumber(const G4Step* aStep) {
 
   theBaseNumber.reset();
-  const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
+  const G4VTouchable* touch = preStepPoint->GetTouchable();
   int theSize = touch->GetHistoryDepth()+1;
   if ( theBaseNumber.getCapacity() < theSize ) theBaseNumber.setSize(theSize);
   //Get name and copy numbers
@@ -543,8 +542,8 @@ void ECalSD::getBaseNumber(const G4Step* aStep) {
       theBaseNumber.addLevel(touch->GetVolume(ii)->GetName(),touch->GetReplicaNumber(ii));
 #ifdef EDM_ML_DEBUG
       edm::LogInfo("EcalSim") << "ECalSD::getBaseNumber(): Adding level " << ii
-			      << ": " << touch->GetVolume(ii)->GetName() << "["
-			      << touch->GetReplicaNumber(ii) << "]";
+                              << ": " << touch->GetVolume(ii)->GetName() << "["
+                              << touch->GetReplicaNumber(ii) << "]";
 #endif
     }
   }
@@ -553,10 +552,10 @@ void ECalSD::getBaseNumber(const G4Step* aStep) {
 double ECalSD::getBirkL3(const G4Step* aStep) {
 
   double weight = 1.;
-  double charge = aStep->GetPreStepPoint()->GetCharge();
+  double charge = preStepPoint->GetCharge();
 
-  if (charge != 0. && aStep->GetStepLength() > 0) {
-    const G4Material* mat = aStep->GetPreStepPoint()->GetMaterial();
+  if (charge != 0. && aStep->GetStepLength() > 0.) {
+    const G4Material* mat = preStepPoint->GetMaterial();
     double density = mat->GetDensity();
     double dedx    = aStep->GetTotalEnergyDeposit()/aStep->GetStepLength();
     double rkb     = birk1/density;
@@ -567,9 +566,9 @@ double ECalSD::getBirkL3(const G4Step* aStep) {
     }
 #ifdef EDM_ML_DEBUG
     edm::LogInfo("EcalSim") << "ECalSD::getBirkL3 in " << mat->GetName()
-			    << " Charge " << charge << " dE/dx " << dedx
-			    << " Birk Const " << rkb << " Weight = " << weight 
-			    << " dE " << aStep->GetTotalEnergyDeposit();
+                            << " Charge " << charge << " dE/dx " << dedx
+                            << " Birk Const " << rkb << " Weight = " << weight 
+                            << " dE " << aStep->GetTotalEnergyDeposit();
 #endif
   }
   return weight;
@@ -577,7 +576,7 @@ double ECalSD::getBirkL3(const G4Step* aStep) {
 }
 
 std::vector<double> ECalSD::getDDDArray(const std::string & str,
-					const DDsvalues_type & sv) {
+                                        const DDsvalues_type & sv) {
 
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("EcalSim") << "ECalSD:getDDDArray called for " << str;
@@ -596,7 +595,7 @@ std::vector<double> ECalSD::getDDDArray(const std::string & str,
 }
 
 std::vector<std::string> ECalSD::getStringArray(const std::string & str,
-						const DDsvalues_type & sv) {
+                                                const DDsvalues_type & sv) {
 
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("EcalSim") << "ECalSD:getStringArray called for " << str;

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -41,14 +41,15 @@
 //#define EDM_ML_DEBUG
 //#define plotDebug
 
-HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
+HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
                const SensitiveDetectorCatalog & clg,
                edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager,
          (float)(p.getParameter<edm::ParameterSet>("HCalSD").getParameter<double>("TimeSliceUnit")),
          p.getParameter<edm::ParameterSet>("HCalSD").getParameter<bool>("IgnoreTrackID")), 
-  hcalConstants(nullptr), numberingFromDDD(nullptr), numberingScheme(nullptr), showerLibrary(nullptr), 
-  hfshower(nullptr), showerParam(nullptr), showerPMT(nullptr), showerBundle(nullptr), m_HBDarkening(nullptr), m_HEDarkening(nullptr),
+  hcalConstants(nullptr), numberingFromDDD(nullptr), numberingScheme(nullptr), 
+  showerLibrary(nullptr), hfshower(nullptr), showerParam(nullptr), showerPMT(nullptr), 
+  showerBundle(nullptr), m_HBDarkening(nullptr), m_HEDarkening(nullptr),
   m_HFDarkening(nullptr), hcalTestNS_(nullptr), depth_(1) {
 
   //static SimpleConfigurable<double> bk1(0.013, "HCalSD:BirkC1");
@@ -127,7 +128,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
 
   const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
   std::vector<G4LogicalVolume *>::const_iterator lvcite;
-  G4LogicalVolume* lv;
+  const G4LogicalVolume* lv;
   std::string attribute, value;
   if (useHF) {
     if (useParam) {
@@ -276,7 +277,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
       if (notIn) {
         namx = log.material().name().name();
         matNames.push_back(namx);
-        G4Material* mat = nullptr;
+        const G4Material* mat = nullptr;
         for (matite = matTab->begin(); matite != matTab->end(); ++matite) {
           if ((*matite)->GetName() == namx) {
             mat = (*matite);
@@ -362,7 +363,7 @@ bool HCalSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
     return true;
   } else {
     depth_ = (aStep->GetPreStepPoint()->GetTouchable()->GetReplicaNumber(0))%10;
-    G4LogicalVolume* lv =
+    const G4LogicalVolume* lv =
       aStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume();
     G4String nameVolume = lv->GetName();
     if (isItHF(aStep)) {
@@ -462,7 +463,7 @@ bool HCalSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 double HCalSD::getEnergyDeposit(G4Step* aStep) {
   double destep = aStep->GetTotalEnergyDeposit();
   double weight = 1;
-  G4Track* theTrack = aStep->GetTrack();
+  const G4Track* theTrack = aStep->GetTrack();
 
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   uint32_t detid = setDetUnitId(aStep);
@@ -532,7 +533,7 @@ double HCalSD::getEnergyDeposit(G4Step* aStep) {
   double weight0 = weight;
 #endif
   if (useBirk) {
-    G4Material* mat = aStep->GetPreStepPoint()->GetMaterial();
+    const G4Material* mat = aStep->GetPreStepPoint()->GetMaterial();
     if (isItScintillator(mat)) weight *= getAttenuation(aStep, birk1, birk2, birk3);
   }
   double wt1 = getResponseWt(theTrack);
@@ -547,9 +548,9 @@ double HCalSD::getEnergyDeposit(G4Step* aStep) {
   return edep;
 }
 
-uint32_t HCalSD::setDetUnitId(G4Step * aStep) { 
+uint32_t HCalSD::setDetUnitId(const G4Step * aStep) { 
 
-  G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
   const G4ThreeVector& hitPoint    = preStepPoint->GetPosition();
 
@@ -710,61 +711,61 @@ std::vector<G4String> HCalSD::getNames(DDFilteredView& fv) {
   return tmp;
 }
 
-bool HCalSD::isItHF(G4Step * aStep) {
+bool HCalSD::isItHF(const G4Step * aStep) {
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   int levels = (touch->GetHistoryDepth()) + 1;
   for (unsigned int it=0; it < hfNames.size(); ++it) {
     if (levels >= hfLevels[it]) {
-      G4LogicalVolume* lv = touch->GetVolume(levels-hfLevels[it])->GetLogicalVolume();
+      const G4LogicalVolume* lv = touch->GetVolume(levels-hfLevels[it])->GetLogicalVolume();
       if (lv == hfLV[it]) return true;
     }
   }
   return false;
 }
 
-bool HCalSD::isItHF (G4String name) {
+bool HCalSD::isItHF (const G4String& name) {
   std::vector<G4String>::const_iterator it = hfNames.begin();
   for (; it != hfNames.end(); ++it) if (name == *it) return true;
   return false;
 }
 
-bool HCalSD::isItFibre (G4LogicalVolume* lv) {
-  std::vector<G4LogicalVolume*>::const_iterator ite = fibreLV.begin();
+bool HCalSD::isItFibre (const G4LogicalVolume* lv) {
+  std::vector<const G4LogicalVolume*>::const_iterator ite = fibreLV.begin();
   for (; ite != fibreLV.end(); ++ite) if (lv == *ite) return true;
   return false;
 }
 
-bool HCalSD::isItFibre (G4String name) {
+bool HCalSD::isItFibre (const G4String& name) {
   std::vector<G4String>::const_iterator it = fibreNames.begin();
   for (; it != fibreNames.end(); ++it) if (name == *it) return true;
   return false;
 }
 
-bool HCalSD::isItPMT (G4LogicalVolume* lv) {
-  std::vector<G4LogicalVolume*>::const_iterator ite = pmtLV.begin();
+bool HCalSD::isItPMT (const G4LogicalVolume* lv) {
+  std::vector<const G4LogicalVolume*>::const_iterator ite = pmtLV.begin();
   for (; ite != pmtLV.end(); ++ite) if (lv == *ite) return true;
   return false;
 }
 
-bool HCalSD::isItStraightBundle (G4LogicalVolume* lv) {
-  std::vector<G4LogicalVolume*>::const_iterator ite = fibre1LV.begin();
+bool HCalSD::isItStraightBundle (const G4LogicalVolume* lv) {
+  std::vector<const G4LogicalVolume*>::const_iterator ite = fibre1LV.begin();
   for (; ite != fibre1LV.end(); ++ite) if (lv == *ite) return true;
   return false;
 }
 
-bool HCalSD::isItConicalBundle (G4LogicalVolume* lv) {
-  std::vector<G4LogicalVolume*>::const_iterator ite = fibre2LV.begin();
+bool HCalSD::isItConicalBundle (const G4LogicalVolume* lv) {
+  std::vector<const G4LogicalVolume*>::const_iterator ite = fibre2LV.begin();
   for (; ite != fibre2LV.end(); ++ite) if (lv == *ite) return true;
   return false;
 }
 
-bool HCalSD::isItScintillator (G4Material* mat) {
-  std::vector<G4Material*>::const_iterator ite = materials.begin();
+bool HCalSD::isItScintillator (const G4Material* mat) {
+  std::vector<const G4Material*>::const_iterator ite = materials.begin();
   for (; ite != materials.end(); ++ite) if (mat == *ite) return true;
   return false;
 }
 
-bool HCalSD::isItinFidVolume (G4ThreeVector& hitPoint) {
+bool HCalSD::isItinFidVolume (const G4ThreeVector& hitPoint) {
   bool flag = true;
   if (applyFidCut) {
     int npmt = HFFibreFiducial:: PMTNumber(hitPoint);
@@ -783,7 +784,7 @@ bool HCalSD::isItinFidVolume (G4ThreeVector& hitPoint) {
 
 void HCalSD::getFromLibrary (G4Step* aStep, double weight) {
   preStepPoint  = aStep->GetPreStepPoint(); 
-  theTrack      = aStep->GetTrack();   
+  theTrack = aStep->GetTrack();   
   int det       = 5;
   bool ok;
 
@@ -844,10 +845,10 @@ void HCalSD::getFromLibrary (G4Step* aStep, double weight) {
   }
 }
 
-void HCalSD::hitForFibre (G4Step* aStep, double weight) { // if not ParamShower
+void HCalSD::hitForFibre (const G4Step* aStep, double weight) { // if not ParamShower
 
-  preStepPoint  = aStep->GetPreStepPoint();
-  theTrack      = aStep->GetTrack();
+  const G4StepPoint* preStepPoint  = aStep->GetPreStepPoint();
+  const G4Track*     theTrack      = aStep->GetTrack();
   int primaryID = setTrackID(aStep);
 
   int det   = 5;
@@ -901,7 +902,7 @@ void HCalSD::getFromParam (G4Step* aStep, double weight) {
   int nHit = static_cast<int>(hits.size());
 
   if (nHit > 0) {
-    preStepPoint  = aStep->GetPreStepPoint();
+    const G4StepPoint* preStepPoint  = aStep->GetPreStepPoint();
     int primaryID = setTrackID(aStep);
    
     int det   = 5;
@@ -935,10 +936,10 @@ void HCalSD::getFromParam (G4Step* aStep, double weight) {
   }
 }
 
-void HCalSD::getHitPMT (G4Step * aStep) {
+void HCalSD::getHitPMT (const G4Step * aStep) {
 
-  preStepPoint = aStep->GetPreStepPoint();
-  theTrack     = aStep->GetTrack();
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
+  const G4Track*     theTrack     = aStep->GetTrack();
   double edep  = showerPMT->getHits(aStep);
 
   if (edep >= 0) {
@@ -1002,9 +1003,9 @@ void HCalSD::getHitPMT (G4Step * aStep) {
   }
 }
 
-void HCalSD::getHitFibreBundle (G4Step* aStep, bool type) {
-  preStepPoint = aStep->GetPreStepPoint();
-  theTrack     = aStep->GetTrack();
+void HCalSD::getHitFibreBundle (const G4Step* aStep, bool type) {
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
+  const G4Track*     theTrack     = aStep->GetTrack();
   double edep  = showerBundle->getHits(aStep, type);
 
   if (edep >= 0) {
@@ -1065,8 +1066,9 @@ void HCalSD::getHitFibreBundle (G4Step* aStep, bool type) {
   } // non-zero energy deposit
 }
 
-int HCalSD::setTrackID (G4Step* aStep) {
-  theTrack     = aStep->GetTrack();
+int HCalSD::setTrackID (const G4Step* aStep) {
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
+  const G4Track* theTrack         = aStep->GetTrack();
 
   double etrack = preStepPoint->GetKineticEnergy();
   TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
@@ -1085,7 +1087,7 @@ int HCalSD::setTrackID (G4Step* aStep) {
   return primaryID;
 }
 
-void HCalSD::readWeightFromFile(std::string fName) {
+void HCalSD::readWeightFromFile(const std::string& fName) {
 
   std::ifstream infile;
   int entry=0;
@@ -1133,7 +1135,7 @@ double HCalSD::layerWeight(int det, const G4ThreeVector& pos, int depth, int lay
   return wt;
 }
 
-void HCalSD::plotProfile(G4Step* aStep,const G4ThreeVector& global, double edep,
+void HCalSD::plotProfile(const G4Step* aStep,const G4ThreeVector& global, double edep,
                          double time, int id) { 
 
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
@@ -1180,7 +1182,7 @@ void HCalSD::plotProfile(G4Step* aStep,const G4ThreeVector& global, double edep,
   }
 }
 
-void HCalSD::plotHF(G4ThreeVector& hitPoint, bool emType) {
+void HCalSD::plotHF(const G4ThreeVector& hitPoint, bool emType) {
   double zv  = std::abs(hitPoint.z()) - gpar[4];
   if (emType) {
     if (hzvem  != nullptr) hzvem->Fill(zv);

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -463,7 +463,7 @@ bool HCalSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 double HCalSD::getEnergyDeposit(G4Step* aStep) {
   double destep = aStep->GetTotalEnergyDeposit();
   double weight = 1;
-  const G4Track* theTrack = aStep->GetTrack();
+  theTrack = aStep->GetTrack();
 
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   uint32_t detid = setDetUnitId(aStep);
@@ -550,9 +550,9 @@ double HCalSD::getEnergyDeposit(G4Step* aStep) {
 
 uint32_t HCalSD::setDetUnitId(const G4Step * aStep) { 
 
-  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
-  const G4VTouchable* touch = preStepPoint->GetTouchable();
-  const G4ThreeVector& hitPoint    = preStepPoint->GetPosition();
+  const G4StepPoint* prePoint   = aStep->GetPreStepPoint(); 
+  const G4VTouchable* touch     = prePoint->GetTouchable();
+  const G4ThreeVector& hitPoint = prePoint->GetPosition();
 
   int depth = (touch->GetReplicaNumber(0))%10 + 1;
   int lay   = (touch->GetReplicaNumber(0)/10)%100 + 1;

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -957,7 +957,7 @@ void HCalSD::getHitPMT (const G4Step * aStep) {
 
     //
     int    det      = static_cast<int>(HcalForward);
-    G4ThreeVector hitPoint = preStepPoint->GetPosition();   
+    const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
     double rr       = (hitPoint.x()*hitPoint.x() + hitPoint.y()*hitPoint.y());
     double phi      = (rr == 0. ? 0. :atan2(hitPoint.y(),hitPoint.x()));
     double etaR     = showerPMT->getRadius();
@@ -1023,7 +1023,7 @@ void HCalSD::getHitFibreBundle (const G4Step* aStep, bool type) {
 
     //
     int    det      = static_cast<int>(HcalForward);
-    G4ThreeVector hitPoint = preStepPoint->GetPosition();   
+    const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
     double rr       = (hitPoint.x()*hitPoint.x() + hitPoint.y()*hitPoint.y());
     double phi      = (rr == 0. ? 0. :atan2(hitPoint.y(),hitPoint.x()));
     double etaR     = showerBundle->getRadius();

--- a/SimG4CMS/Calo/src/HFCherenkov.cc
+++ b/SimG4CMS/Calo/src/HFCherenkov.cc
@@ -79,7 +79,7 @@ int HFCherenkov::computeNPhTrapped(double pBeta,
   return n_photons;
 }
 
-int HFCherenkov::computeNPE(G4Step * aStep, G4ParticleDefinition* pDef,
+int HFCherenkov::computeNPE(const G4Step * aStep, const G4ParticleDefinition* pDef,
 			    double pBeta, double u, double v, double w,
 			    double step_length, double zFiber,
 			    double dose, int npe_Dose) {
@@ -226,7 +226,7 @@ int HFCherenkov::computeNPE(G4Step * aStep, G4ParticleDefinition* pDef,
   return npe;
 }
 
-int HFCherenkov::computeNPEinPMT(G4ParticleDefinition* pDef, double pBeta, 
+int HFCherenkov::computeNPEinPMT(const G4ParticleDefinition* pDef, double pBeta, 
                                  double u, double v, double w, 
                                  double step_length){
   clearVectors();

--- a/SimG4CMS/Calo/src/HFFibre.cc
+++ b/SimG4CMS/Calo/src/HFFibre.cc
@@ -16,7 +16,7 @@
 
 //#define DebugLog
 
-HFFibre::HFFibre(std::string & name, const DDCompactView & cpv, 
+HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv, 
 		 edm::ParameterSet const & p) {
 
   edm::ParameterSet m_HF = p.getParameter<edm::ParameterSet>("HFShower");

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -23,7 +23,7 @@
 
 #include<iostream>
 
-HFShower::HFShower(std::string & name, const DDCompactView & cpv, 
+HFShower::HFShower(const std::string & name, const DDCompactView & cpv, 
 		   edm::ParameterSet const & p, int chk) : cherenkov(nullptr),
                                                            fibre(nullptr),
                                                            chkFibre(chk) {
@@ -44,7 +44,7 @@ HFShower::~HFShower() {
   if (fibre)     delete fibre;
 }
 
-std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep, double weight) {
+std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight) {
 
   std::vector<HFShower::Hit> hits;
   int    nHit    = 0;
@@ -63,7 +63,7 @@ std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep, double weight) {
 #endif
     return hits;
   }
-  G4Track *aTrack = aStep->GetTrack();
+  const G4Track *aTrack = aStep->GetTrack();
   const G4DynamicParticle *aParticle = aTrack->GetDynamicParticle();
  
   HFShower::Hit hit;
@@ -74,9 +74,9 @@ std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep, double weight) {
   int    npeDose  = 0;
 
   const G4ThreeVector& momentumDir = aParticle->GetMomentumDirection();
-  G4ParticleDefinition *particleDef = aTrack->GetDefinition();
+  const G4ParticleDefinition *particleDef = aTrack->GetDefinition();
      
-  G4StepPoint * preStepPoint = aStep->GetPreStepPoint();
+  const G4StepPoint * preStepPoint = aStep->GetPreStepPoint();
   const G4ThreeVector& globalPos    = preStepPoint->GetPosition();
   G4String      name         = preStepPoint->GetTouchable()->GetSolid(0)->GetName();
   //double        zv           = std::abs(globalPos.z()) - gpar[4] - 0.5*gpar[1];
@@ -179,7 +179,7 @@ std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep, double weight) {
 
 } 
 
-std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep,
+std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
 					     bool forLibraryProducer,
 					     double zoffset) {
 
@@ -197,7 +197,7 @@ std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep,
 #endif
     return hits;
   }
-  G4Track *aTrack = aStep->GetTrack();
+  const G4Track *aTrack = aStep->GetTrack();
   const G4DynamicParticle *aParticle = aTrack->GetDynamicParticle();
  
   HFShower::Hit hit;
@@ -314,7 +314,7 @@ std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep,
 
 } 
 
-std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep, bool forLibrary) {
+std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, bool forLibrary) {
   std::vector<HFShower::Hit> hits;
   int    nHit    = 0;
 
@@ -330,7 +330,7 @@ std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep, bool forLibrary) {
     return hits;
   }
 
-  G4Track *aTrack = aStep->GetTrack();
+  const G4Track *aTrack = aStep->GetTrack();
   const G4DynamicParticle *aParticle = aTrack->GetDynamicParticle();
 
   HFShower::Hit hit;
@@ -343,7 +343,7 @@ std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep, bool forLibrary) {
   const G4ThreeVector& momentumDir = aParticle->GetMomentumDirection();
   G4ParticleDefinition *particleDef = aTrack->GetDefinition();
 
-  G4StepPoint * preStepPoint = aStep->GetPreStepPoint();
+  const G4StepPoint * preStepPoint = aStep->GetPreStepPoint();
   const G4ThreeVector& globalPos    = preStepPoint->GetPosition();
   G4String      name         = preStepPoint->GetTouchable()->GetSolid(0)->GetName();
   double        zv           = std::abs(globalPos.z()) - gpar[4] - 0.5*gpar[1];

--- a/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
+++ b/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
@@ -19,7 +19,7 @@
 
 //#define DebugLog
 
-HFShowerFibreBundle::HFShowerFibreBundle(std::string & name, 
+HFShowerFibreBundle::HFShowerFibreBundle(const std::string & name, 
 					 const DDCompactView & cpv,
 					 edm::ParameterSet const & p) {
 
@@ -93,11 +93,11 @@ void HFShowerFibreBundle::initRun(G4ParticleTable *, HcalDDDSimConstants* hcons)
                              << rTable[ig]/cm << " cm";
 }
 
-double HFShowerFibreBundle::getHits(G4Step * aStep, bool type) {
+double HFShowerFibreBundle::getHits(const G4Step * aStep, bool type) {
 
   indexR = indexF = -1;
 
-  G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
+  const G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch   = preStepPoint->GetTouchable();
   int                 boxNo   = touch->GetReplicaNumber(1);
   int                 pmtNo   = touch->GetReplicaNumber(0);
@@ -118,8 +118,8 @@ double HFShowerFibreBundle::getHits(G4Step * aStep, bool type) {
 
   double photons = 0;
   if (indexR >= 0 && indexF > 0) {
-    G4Track *aTrack = aStep->GetTrack();
-    G4ParticleDefinition *particleDef = aTrack->GetDefinition();
+    const G4Track *aTrack = aStep->GetTrack();
+    const G4ParticleDefinition *particleDef = aTrack->GetDefinition();
     double stepl = aStep->GetStepLength();
     double beta  = preStepPoint->GetBeta();
     G4ThreeVector pDir = aTrack->GetDynamicParticle()->GetMomentumDirection();

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -21,7 +21,7 @@
 
 //#define DebugLog
 
-HFShowerLibrary::HFShowerLibrary(std::string & name, const DDCompactView & cpv,
+HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView & cpv,
 				 edm::ParameterSet const & p) : fibre(nullptr),hf(nullptr),
 								emBranch(nullptr),
 								hadBranch(nullptr),
@@ -187,9 +187,9 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(G4Step * aStep,
 							   double weight,
 							   bool onlyLong) {
 
-  G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
-  G4StepPoint * postStepPoint = aStep->GetPostStepPoint(); 
-  G4Track *     track    = aStep->GetTrack();
+  const G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
+  const G4StepPoint * postStepPoint = aStep->GetPostStepPoint(); 
+  const G4Track *     track    = aStep->GetTrack();
   // Get Z-direction 
   const G4DynamicParticle *aParticle = track->GetDynamicParticle();
   G4ThreeVector momDir = aParticle->GetMomentumDirection();

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -192,10 +192,9 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(G4Step * aStep,
   const G4Track *     track    = aStep->GetTrack();
   // Get Z-direction 
   const G4DynamicParticle *aParticle = track->GetDynamicParticle();
-  G4ThreeVector momDir = aParticle->GetMomentumDirection();
-  //  double mom = aParticle->GetTotalMomentum();
+  const G4ThreeVector& momDir = aParticle->GetMomentumDirection();
 
-  G4ThreeVector hitPoint = preStepPoint->GetPosition();   
+  const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
   G4String      partType = track->GetDefinition()->GetParticleName();
   int           parCode  = track->GetDefinition()->GetPDGEncoding();
 
@@ -220,8 +219,8 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(G4Step * aStep,
   return fillHits(hitPoint,momDir,parCode,pin,ok,weight,tSlice,onlyLong);
 }
 
-std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(G4ThreeVector & hitPoint,
-                               G4ThreeVector & momDir,
+std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector & hitPoint,
+                               const G4ThreeVector & momDir,
                                int parCode, double pin, bool & ok,
                                double weight, double tSlice,bool onlyLong) {
 

--- a/SimG4CMS/Calo/src/HFShowerPMT.cc
+++ b/SimG4CMS/Calo/src/HFShowerPMT.cc
@@ -19,7 +19,7 @@
 
 //#define DebugLog
 
-HFShowerPMT::HFShowerPMT(std::string & name, const DDCompactView & cpv,
+HFShowerPMT::HFShowerPMT(const std::string & name, const DDCompactView & cpv,
 			 edm::ParameterSet const & p) : cherenkov(nullptr) {
 
   edm::ParameterSet m_HF  = p.getParameter<edm::ParameterSet>("HFShowerPMT");
@@ -85,7 +85,7 @@ void HFShowerPMT::initRun(G4ParticleTable *, HcalDDDSimConstants* hcons) {
                              << rTable[ig]/cm << " cm";
 }
 
-double HFShowerPMT::getHits(G4Step * aStep) {
+double HFShowerPMT::getHits(const G4Step * aStep) {
 
   indexR = indexF = -1;
 

--- a/SimG4CMS/Calo/src/HFShowerParam.cc
+++ b/SimG4CMS/Calo/src/HFShowerParam.cc
@@ -27,7 +27,7 @@
 //#define plotDebug
 //#define mkdebug
 
-HFShowerParam::HFShowerParam(std::string & name, const DDCompactView & cpv,
+HFShowerParam::HFShowerParam(const std::string & name, const DDCompactView & cpv,
                              edm::ParameterSet const & p) : showerLibrary(nullptr), 
                                                             fibre(nullptr), gflash(nullptr),
                                                             fillHisto(false) { 
@@ -116,7 +116,7 @@ void HFShowerParam::initRun(G4ParticleTable * theParticleTable,
 
 std::vector<HFShowerParam::Hit> HFShowerParam::getHits(G4Step * aStep, 
 						       double weight) {
-  G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
+  const G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
   G4Track *     track    = aStep->GetTrack();   
   const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
   G4int         particleCode = track->GetDefinition()->GetPDGEncoding();

--- a/SimG4CMS/Calo/src/HGCSD.cc
+++ b/SimG4CMS/Calo/src/HGCSD.cc
@@ -33,7 +33,7 @@
 
 //#define EDM_ML_DEBUG
 
-HGCSD::HGCSD(G4String name, const DDCompactView & cpv,
+HGCSD::HGCSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg, 
 	     edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager,
@@ -52,7 +52,7 @@ HGCSD::HGCSD(G4String name, const DDCompactView & cpv,
   mouseBiteCut_    = waferSize*tan(30.0*CLHEP::deg) - mouseBite;
 
   //this is defined in the hgcsens.xml
-  G4String myName(this->nameOfSD());
+  G4String myName = name;
   myFwdSubdet_= ForwardSubdetector::ForwardEmpty;
   nameX = "HGCal";
   if (myName.find("HitsEE")!=std::string::npos) {
@@ -131,9 +131,9 @@ double HGCSD::getEnergyDeposit(G4Step* aStep) {
   return destep;
 }
 
-uint32_t HGCSD::setDetUnitId(G4Step * aStep) { 
+uint32_t HGCSD::setDetUnitId(const G4Step * aStep) { 
 
-  G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
 
   //determine the exact position in global coordinates in the mass geometry 
@@ -243,8 +243,8 @@ uint32_t HGCSD::setDetUnitId (ForwardSubdetector &subdet, int layer, int module,
   return id;
 }
 
-int HGCSD::setTrackID (G4Step* aStep) {
-  theTrack     = aStep->GetTrack();
+int HGCSD::setTrackID (const G4Step* aStep) {
+  const G4Track* theTrack    = aStep->GetTrack();
 
   double etrack = preStepPoint->GetKineticEnergy();
   TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());

--- a/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
+++ b/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
@@ -20,11 +20,11 @@ class DreamSD : public CaloSD {
 
 public:    
 
-  DreamSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  DreamSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
   ~DreamSD() override {}
   bool   ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
-  uint32_t setDetUnitId(G4Step*) override;
+  uint32_t setDetUnitId(const G4Step*) override;
 
 protected:
 
@@ -36,24 +36,24 @@ private:
   typedef std::pair<double,double> Doubles;
   typedef std::map<G4LogicalVolume*,Doubles> DimensionMap;
 
-  void           initMap(G4String, const DDCompactView &);
-  double         curve_LY(G4Step*, int); 
+  void           initMap(const std::string&, const DDCompactView &);
+  double         curve_LY(const G4Step*, int); 
   const double   crystalLength(G4LogicalVolume*) const;
   const double   crystalWidth(G4LogicalVolume*) const;
 
   /// Returns the total energy due to Cherenkov radiation
-  double         cherenkovDeposit_( G4Step* aStep );
+  double         cherenkovDeposit_(const G4Step* aStep );
   /// Returns average number of photons created by track
   double getAverageNumberOfPhotons_(const double charge,
 				    const double beta,
 				    const G4Material* aMaterial,
-				    G4MaterialPropertyVector* rIndex );
+				    const G4MaterialPropertyVector* rIndex );
   /// Returns energy deposit for a given photon
   double getPhotonEnergyDeposit_( const G4ParticleMomentum& p, 
 				  const G4ThreeVector& x,
 				  const G4Step* aStep );
   /// Sets material properties at run-time...
-  bool setPbWO2MaterialProperties_( G4Material* aMaterial );
+  bool setPbWO2MaterialProperties_(G4Material* aMaterial );
 
   bool         useBirk, doCherenkov_, readBothSide_;
   double       birk1, birk2, birk3;
@@ -63,8 +63,8 @@ private:
   int          side;
 
   /// Table of Cherenkov angle integrals vs photon momentum
-  std::auto_ptr<G4PhysicsOrderedFreeVector> chAngleIntegrals_;
-  G4MaterialPropertiesTable*                materialPropertiesTable;
+  std::unique_ptr<G4PhysicsOrderedFreeVector> chAngleIntegrals_;
+  G4MaterialPropertiesTable* materialPropertiesTable;
   // Histogramming
   TTree* ntuple_;
   int nphotons_;

--- a/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
+++ b/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
@@ -21,11 +21,11 @@ class EcalTBH4BeamSD : public CaloSD {
 
 public:    
 
-  EcalTBH4BeamSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  EcalTBH4BeamSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 		 edm::ParameterSet const &, const SimTrackManager*);
   ~EcalTBH4BeamSD() override;
   double getEnergyDeposit(G4Step*) override;
-  uint32_t setDetUnitId(G4Step* step) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
   void setNumberingScheme(EcalNumberingScheme* scheme);
 
 private:    

--- a/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
+++ b/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
@@ -19,7 +19,7 @@
 
 #include "G4SystemOfUnits.hh"
 
-EcalTBH4BeamSD::EcalTBH4BeamSD(G4String name, const DDCompactView & cpv,
+EcalTBH4BeamSD::EcalTBH4BeamSD(const std::string& name, const DDCompactView & cpv,
 			       const SensitiveDetectorCatalog & clg,
 			       edm::ParameterSet const & p, 
 			       const SimTrackManager* manager) : 
@@ -69,7 +69,7 @@ double EcalTBH4BeamSD::getEnergyDeposit(G4Step * aStep) {
   } 
 }
 
-uint32_t EcalTBH4BeamSD::setDetUnitId(G4Step * aStep) { 
+uint32_t EcalTBH4BeamSD::setDetUnitId(const G4Step * aStep) { 
   getBaseNumber(aStep);
   return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(theBaseNumber));
 }

--- a/SimG4CMS/FP420/interface/FP420SD.h
+++ b/SimG4CMS/FP420/interface/FP420SD.h
@@ -12,35 +12,22 @@
 
 #include "SimG4Core/Notification/interface/BeginOfTrack.h"
 #include "SimG4Core/Notification/interface/BeginOfJob.h"
-// last
-//#include "SimG4Core/Application/interface/SimTrackManager.h"
-//#include "SimG4CMS/Calo/interface/CaloSD.h"
 
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
-//#include "SimG4Core/Notification/interface/TrackWithHistory.h"
-//#include "SimG4Core/Notification/interface/TrackContainer.h"
 
 #include "SimG4CMS/FP420/interface/FP420G4Hit.h"
 #include "SimG4CMS/FP420/interface/FP420G4HitCollection.h"
 #include "SimG4CMS/FP420/interface/FP420NumberingScheme.h"
-
   
 #include "G4Step.hh"
 #include "G4StepPoint.hh"
 #include "G4Track.hh"
 #include "G4VPhysicalVolume.hh"
 
-//#include <iostream>
-//#include <fstream>
-//#include <vector>
-//#include <map>
 #include <string>
  
-
-
 class TrackingSlaveSD;
 //AZ:
-class FP420SD;
 class FrameRotation;
 class TrackInformation;
 class SimTrackManager;
@@ -59,25 +46,13 @@ class FP420SD : public SensitiveTkDetector,
 
 public:
   
-  FP420SD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &,
+  FP420SD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
   	  edm::ParameterSet const &, const SimTrackManager* );
-
-//-------------------------------------------------------------------
-/*
-class FP420SD : public CaloSD {
-
-public:    
-  FP420SD(G4String, const DDCompactView &, edm::ParameterSet const &,const SimTrackManager*);
-*/
-//-------------------------------------------------------------------
-
-
-
 
   ~FP420SD() override;
   
   bool ProcessHits(G4Step *,G4TouchableHistory *) override;
-  uint32_t  setDetUnitId(G4Step*) override;
+  uint32_t  setDetUnitId(const G4Step*) override;
 
   void Initialize(G4HCofThisEvent * HCE) override;
   void EndOfEvent(G4HCofThisEvent * eventHC) override;
@@ -86,24 +61,13 @@ public:
   void PrintAll() override;
 
   virtual double getEnergyDeposit(G4Step* step);
-  //protected:
-  //    Collection       hits_;
-    void fillHits(edm::PSimHitContainer&, std::string use) override;
-  
-  std::vector<std::string> getNames() override;
+  void fillHits(edm::PSimHitContainer&, const std::string&) override;
+  void clearHits() override;
   
  private:
   void           update(const BeginOfRun *) override;
   void           update(const BeginOfEvent *) override;
   void           update(const ::EndOfEvent *) override;
-  void   clearHits() override;
-  
-  //void SetNumberingScheme(FP420NumberingScheme* scheme);
-  
-  
-  
-  //  int eventno;
- private:
   
   G4ThreeVector SetToLocal(const G4ThreeVector& global);
   G4ThreeVector SetToLocalExit(const G4ThreeVector& globalPoint);
@@ -114,27 +78,19 @@ public:
   void          StoreHit(FP420G4Hit*);
   void          ResetForNewPrimary();
   void          Summarize();
-  
-  
+    
  private:
   
   //AZ:
   TrackingSlaveSD* slave;
   FP420NumberingScheme * numberingScheme;
   
-    G4ThreeVector entrancePoint, exitPoint;
-    G4ThreeVector theEntryPoint ;
-    G4ThreeVector theExitPoint  ;
+  G4ThreeVector entrancePoint, exitPoint;
+  G4ThreeVector theEntryPoint ;
+  G4ThreeVector theExitPoint  ;
 
-    //  Local3DPoint  entrancePoint, exitPoint, theEntryPoint, theExitPoint;
-
-
-
-  
   float                incidentEnergy;
   
-  //  G4String             name;
-  std::string             name;
   G4int                    hcID;
   FP420G4HitCollection*       theHC; 
   const SimTrackManager*      theManager;
@@ -155,7 +111,6 @@ public:
   float                edeposit;
   
   G4ThreeVector        hitPoint;
-  //  G4ThreeVector    Position;
   G4ThreeVector        hitPointExit;
   G4ThreeVector        hitPointLocal;
   G4ThreeVector        hitPointLocalExit;

--- a/SimG4CMS/FP420/plugins/FP420SD.cc
+++ b/SimG4CMS/FP420/plugins/FP420SD.cc
@@ -5,9 +5,6 @@
 // Modifications: 
 ///////////////////////////////////////////////////////////////////////////////
  
-//#include "Geometry/Vector/interface/LocalPoint.h"
-//#include "Geometry/Vector/interface/LocalVector.h"
-
 #include "SimG4Core/SensitiveDetector/interface/FrameRotation.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
@@ -43,35 +40,16 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#ifdef DUMPPROCESSES
-#include "G4VProcess.hh"
-#endif
-
-using std::cout;
-using std::endl;
-using std::vector;
-using std::string;
 
 //#define debug
 //-------------------------------------------------------------------
-FP420SD::FP420SD(std::string name, const DDCompactView & cpv,
+FP420SD::FP420SD(const std::string& name, const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg,
 		 edm::ParameterSet const & p, const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr), name(name),
+  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr), 
   hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
   currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
   postStepPoint(nullptr), eventno(0){
-//-------------------------------------------------------------------
-/*
-FP420SD::FP420SD(G4String name, const DDCompactView & cpv,
-		 edm::ParameterSet const & p, const SimTrackManager* manager) :
-  CaloSD(name, cpv, p, manager), numberingScheme(0), name(name),hcID(-1),
-  theHC(0), currentHit(0), theTrack(0), currentPV(0), 
-  unitID(0),  previousUnitID(0), preStepPoint(0), postStepPoint(0), eventno(0){
-*/
-//-------------------------------------------------------------------
-
-
     
     //Add FP420 Sentitive Detector Name
     collectionName.insert(name);
@@ -108,21 +86,15 @@ FP420SD::FP420SD(G4String name, const DDCompactView & cpv,
     
     if      (name == "FP420SI") {
       if (verbn > 0) {
-      edm::LogInfo("FP420Sim") << "name = FP420SI and  new FP420NumberingSchem";
-    std::cout << "name = FP420SI and  new FP420NumberingSchem"<< std::endl;
+	edm::LogInfo("FP420Sim") << "name = FP420SI and  new FP420NumberingSchem";
       }
       numberingScheme = new FP420NumberingScheme() ;
     } else {
       edm::LogWarning("FP420Sim") << "FP420SD: ReadoutName not supported\n";
-    std::cout << "FP420SD: ReadoutName not supported"<< std::endl;
     }
     
     edm::LogInfo("FP420Sim") << "FP420SD: Instantiation completed";
-    std::cout << "FP420SD: Instantiation completed"<< std::endl;
   }
-
-
-
 
 FP420SD::~FP420SD() { 
   //AZ:
@@ -142,7 +114,7 @@ void FP420SD::Initialize(G4HCofThisEvent * HCE) {
     LogDebug("FP420Sim") << "FP420SD : Initialize called for " << name << std::endl;
 #endif
 
-  theHC = new FP420G4HitCollection(name, collectionName[0]);
+    theHC = new FP420G4HitCollection(GetName(), collectionName[0]);
   if (hcID<0) 
     hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
   HCE->AddHitsCollection(hcID, theHC);
@@ -223,11 +195,10 @@ void FP420SD::GetStepInfo(G4Step* aStep) {
   Z  = hitPoint.z();
 }
 
-uint32_t FP420SD::setDetUnitId(G4Step * aStep) { 
+uint32_t FP420SD::setDetUnitId(const G4Step * aStep) { 
 
   return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
 }
-
 
 G4bool FP420SD::HitExists() {
   if (primaryID<1) {
@@ -506,11 +477,8 @@ void FP420SD::PrintAll() {
 //
 //}
 
-void FP420SD::fillHits(edm::PSimHitContainer& c, std::string n) {
-  if (slave->name() == n) {
-    c=slave->hits();
-    std::cout << "FP420SD: fillHits to PSimHitContainer for name= " <<  name << std::endl;
-  }
+void FP420SD::fillHits(edm::PSimHitContainer& cc, const std::string& hname) {
+  if (slave->name() == hname) { cc=slave->hits(); }
 }
 
 void FP420SD::update (const BeginOfEvent * i) {
@@ -536,11 +504,5 @@ void FP420SD::update (const ::EndOfEvent*) {
 void FP420SD::clearHits(){
   //AZ:
     slave->Initialize();
-}
-
-std::vector<std::string> FP420SD::getNames(){
-  std::vector<std::string> temp;
-  temp.push_back(slave->name());
-  return temp;
 }
 

--- a/SimG4CMS/FP420/plugins/FP420SD.cc
+++ b/SimG4CMS/FP420/plugins/FP420SD.cc
@@ -51,39 +51,15 @@ FP420SD::FP420SD(const std::string& name, const DDCompactView & cpv,
   currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
   postStepPoint(nullptr), eventno(0){
     
-    //Add FP420 Sentitive Detector Name
-    collectionName.insert(name);
-    
-    
     //Parameters
       edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("FP420SD");
        int verbn = m_p.getUntrackedParameter<int>("Verbosity");
     //int verbn = 1;
     
     SetVerboseLevel(verbn);
-    LogDebug("FP420Sim") 
-      << "*******************************************************\n"
-      << "*                                                     *\n"
-      << "* Constructing a FP420SD  with name " << name << "\n"
-      << "*                                                     *\n"
-      << "*******************************************************";
-    
     
     slave  = new TrackingSlaveSD(name);
-    
-    //
-    // attach detectors (LogicalVolumes)
-    //
-    const std::vector<std::string>& lvNames = clg.logicalNames(name);
-
-    this->Register();
-
-    for (std::vector<std::string>::const_iterator it=lvNames.begin();
-	 it !=lvNames.end(); it++) {
-      this->AssignSD(*it);
-      edm::LogInfo("FP420Sim") << "FP420SD : Assigns SD to LV " << (*it);
-    }
-    
+        
     if      (name == "FP420SI") {
       if (verbn > 0) {
 	edm::LogInfo("FP420Sim") << "name = FP420SI and  new FP420NumberingSchem";
@@ -92,17 +68,11 @@ FP420SD::FP420SD(const std::string& name, const DDCompactView & cpv,
     } else {
       edm::LogWarning("FP420Sim") << "FP420SD: ReadoutName not supported\n";
     }
-    
-    edm::LogInfo("FP420Sim") << "FP420SD: Instantiation completed";
-  }
+}
 
 FP420SD::~FP420SD() { 
-  //AZ:
-  if (slave) delete slave; 
-
-  if (numberingScheme)
-    delete numberingScheme;
-
+  delete slave; 
+  delete numberingScheme;
 }
 
 double FP420SD::getEnergyDeposit(G4Step* aStep) {

--- a/SimG4CMS/Forward/interface/BHMSD.h
+++ b/SimG4CMS/Forward/interface/BHMSD.h
@@ -39,14 +39,14 @@ class BHMSD : public SensitiveTkDetector,
 
 public:
   
-  BHMSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &, 
+  BHMSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &, 
 	edm::ParameterSet const &, const SimTrackManager* );
 
 
   ~BHMSD() override;
   
   bool ProcessHits(G4Step *,G4TouchableHistory *) override;
-  uint32_t  setDetUnitId(G4Step*) override;
+  uint32_t  setDetUnitId(const G4Step*) override;
 
   void Initialize(G4HCofThisEvent * HCE) override;
   void EndOfEvent(G4HCofThisEvent * eventHC) override;
@@ -54,19 +54,16 @@ public:
   void DrawAll() override;
   void PrintAll() override;
 
-  virtual double getEnergyDeposit(G4Step* step);
-  void           fillHits(edm::PSimHitContainer&, std::string use) override;
-  
-  std::vector<std::string> getNames() override;
-  
+  double getEnergyDeposit(const G4Step* step);
+  void   fillHits(edm::PSimHitContainer&, const std::string&) override;
+  void   clearHits() override;
+    
 private:
+
   void           update(const BeginOfRun *) override;
   void           update(const BeginOfEvent *) override;
   void           update(const ::EndOfEvent *) override;
-  void   clearHits() override;
 
-private:
-  
   G4ThreeVector SetToLocal(const G4ThreeVector& global);
   G4ThreeVector SetToLocalExit(const G4ThreeVector& globalPoint);
   void          GetStepInfo(G4Step* aStep);
@@ -76,8 +73,7 @@ private:
   void          StoreHit(BscG4Hit*);
   void          ResetForNewPrimary();
   void          Summarize();
-  
-  
+    
 private:
   
   TrackingSlaveSD       *slave;
@@ -89,7 +85,6 @@ private:
   float                  incidentEnergy;
   G4int                  primID  ; 
   
-  std::string            name;
   G4int                  hcID;
   BscG4HitCollection*    theHC; 
   const SimTrackManager* theManager;

--- a/SimG4CMS/Forward/interface/Bcm1fSD.h
+++ b/SimG4CMS/Forward/interface/Bcm1fSD.h
@@ -34,16 +34,17 @@ class Bcm1fSD : public SensitiveTkDetector,
 
 public:
 
-  Bcm1fSD(std::string, const DDCompactView &, 
-		       const SensitiveDetectorCatalog &,
-		       edm::ParameterSet const &, const SimTrackManager*);
+  Bcm1fSD(const std::string&, const DDCompactView &, 
+	  const SensitiveDetectorCatalog &,
+	  edm::ParameterSet const &, const SimTrackManager*);
   ~Bcm1fSD() override;
 
   bool     ProcessHits(G4Step *,G4TouchableHistory *) override;
-  uint32_t setDetUnitId(G4Step*) override;
+  uint32_t setDetUnitId(const G4Step*) override;
   void EndOfEvent(G4HCofThisEvent*) override;
 
-  void fillHits (edm::PSimHitContainer&, std::string use) override;
+  void fillHits(edm::PSimHitContainer&, const std::string&) override;
+  void clearHits() override;
 
 private:
 
@@ -55,7 +56,6 @@ private:
   void           update(const BeginOfEvent *) override;
   void           update(const BeginOfTrack *) override;
   void           update(const BeginOfJob *) override;
-  void   clearHits() override;
   TrackInformation* getOrCreateTrackInformation(const G4Track *);
 
 private:
@@ -63,7 +63,6 @@ private:
   TrackingSlaveSD*            slave;
   G4ProcessTypeEnumerator * theG4ProcessTypeEnumerator;
   G4TrackToParticleID * myG4TrackToParticleID;
-  std::string        myName;
   UpdatablePSimHit * mySimHit;
   float energyCut;
   float energyHistoryCut;

--- a/SimG4CMS/Forward/interface/BscSD.h
+++ b/SimG4CMS/Forward/interface/BscSD.h
@@ -10,37 +10,18 @@
 #include "SimG4Core/Notification/interface/BeginOfEvent.h"
 #include "SimG4Core/Notification/interface/EndOfEvent.h"
 
-// last
-//#include "SimG4Core/Application/interface/SimTrackManager.h"
-//#include "SimG4CMS/Calo/interface/CaloSD.h"
-
-
-//#include "SimG4Core/Notification/interface/TrackWithHistory.h"
-//#include "SimG4Core/Notification/interface/TrackContainer.h"
-
 #include "SimG4CMS/Forward/interface/BscG4Hit.h"
 #include "SimG4CMS/Forward/interface/BscG4HitCollection.h"
 #include "SimG4CMS/Forward/interface/BscNumberingScheme.h"
-
   
 #include "G4Step.hh"
 #include "G4StepPoint.hh"
 #include "G4Track.hh"
 #include "G4VPhysicalVolume.hh"
 
-//#include <CLHEP/Vector/ThreeVector.h>
-//#include <iostream>
-//#include <fstream>
-//#include <vector>
-//#include <map>
 #include <string>
- 
-
 
 class TrackingSlaveSD;
-//AZ:
-class BscSD;
-
 class TrackInformation;
 class SimTrackManager;
 class TrackingSlaveSD;
@@ -58,14 +39,13 @@ class BscSD : public SensitiveTkDetector,
 
 public:
   
-  BscSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &,
-  	  edm::ParameterSet const &, const SimTrackManager* );
-
+  BscSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
+	edm::ParameterSet const &, const SimTrackManager* );
 
   ~BscSD() override;
   
   bool ProcessHits(G4Step *,G4TouchableHistory *) override;
-  uint32_t  setDetUnitId(G4Step*) override;
+  uint32_t  setDetUnitId(const G4Step*) override;
 
   void Initialize(G4HCofThisEvent * HCE) override;
   void EndOfEvent(G4HCofThisEvent * eventHC) override;
@@ -73,25 +53,14 @@ public:
   void DrawAll() override;
   void PrintAll() override;
 
-  virtual double getEnergyDeposit(G4Step* step);
-  //protected:
-  //    Collection       hits_;
-    void fillHits(edm::PSimHitContainer&, std::string use) override;
-  
-  std::vector<std::string> getNames() override;
+  double getEnergyDeposit(const G4Step* step);
+  void fillHits(edm::PSimHitContainer&, const std::string&) override;
+  void clearHits() override;
   
  private:
   void           update(const BeginOfRun *) override;
   void           update(const BeginOfEvent *) override;
   void           update(const ::EndOfEvent *) override;
-  void   clearHits() override;
-  
-  //void SetNumberingScheme(BscNumberingScheme* scheme);
-  
-  
-  
-  //  int eventno;
- private:
   
   G4ThreeVector SetToLocal(const G4ThreeVector& global);
   G4ThreeVector SetToLocalExit(const G4ThreeVector& globalPoint);
@@ -102,7 +71,6 @@ public:
   void          StoreHit(BscG4Hit*);
   void          ResetForNewPrimary();
   void          Summarize();
-  
   
  private:
   
@@ -116,9 +84,7 @@ public:
   
   float                incidentEnergy;
   G4int                primID  ; 
-  
-  //  G4String             name;
-  std::string             name;
+
   G4int                    hcID;
   BscG4HitCollection*       theHC; 
   const SimTrackManager*      theManager;
@@ -127,7 +93,6 @@ public:
   BscG4Hit*               currentHit;
   G4Track*                 theTrack;
   G4VPhysicalVolume*         currentPV;
-  // unsigned int         unitID, previousUnitID;
   uint32_t             unitID, previousUnitID;
   G4int                primaryID, tSliceID;  
   G4double             tSlice;
@@ -137,7 +102,6 @@ public:
   float                edeposit;
   
   G4ThreeVector        hitPoint;
-  //  G4ThreeVector    Position;
   G4ThreeVector        hitPointExit;
   G4ThreeVector        hitPointLocal;
   G4ThreeVector        hitPointLocalExit;
@@ -152,8 +116,6 @@ public:
   int ParentId;
   float Vx,Vy,Vz;
   float X,Y,Z;
-  
-  
   //
   // Hist
   //
@@ -161,7 +123,7 @@ public:
   
  protected:
   
-  float                edepositEM, edepositHAD;
+  float edepositEM, edepositHAD;
   G4int emPDG;
   G4int epPDG;
   G4int gammaPDG;

--- a/SimG4CMS/Forward/interface/CastorSD.h
+++ b/SimG4CMS/Forward/interface/CastorSD.h
@@ -31,12 +31,12 @@ class CastorSD : public CaloSD {
 
 public:    
 
-  CastorSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog & clg,
+  CastorSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog & clg,
 	   edm::ParameterSet const &, const SimTrackManager*);
   ~CastorSD() override;
   double   getEnergyDeposit(G4Step* ) override;
-  uint32_t setDetUnitId(G4Step* step) override;
-  void             setNumberingScheme(CastorNumberingScheme* scheme);
+  uint32_t setDetUnitId(const G4Step* step) override;
+  void     setNumberingScheme(CastorNumberingScheme* scheme);
 
 private:
 

--- a/SimG4CMS/Forward/interface/CastorShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/CastorShowerLibrary.h
@@ -34,7 +34,7 @@ class CastorShowerLibrary {
 public:
   
   //Constructor and Destructor
-  CastorShowerLibrary(std::string & name, edm::ParameterSet const & p);
+  CastorShowerLibrary(const std::string & name, edm::ParameterSet const & p);
   ~CastorShowerLibrary();
 
 public:

--- a/SimG4CMS/Forward/interface/FastTimerSD.h
+++ b/SimG4CMS/Forward/interface/FastTimerSD.h
@@ -39,14 +39,13 @@ class FastTimerSD : public SensitiveTkDetector,
 
 public:
   
-  FastTimerSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &, 
+  FastTimerSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &, 
 	      edm::ParameterSet const &, const SimTrackManager* );
-
 
   ~FastTimerSD() override;
   
   bool     ProcessHits(G4Step *,G4TouchableHistory *) override;
-  uint32_t setDetUnitId(G4Step*) override;
+  uint32_t setDetUnitId(const G4Step*) override;
 
   void     Initialize(G4HCofThisEvent * HCE) override;
   void     EndOfEvent(G4HCofThisEvent * eventHC) override;
@@ -54,20 +53,16 @@ public:
   void     DrawAll() override;
   void     PrintAll() override;
 
-  virtual double   getEnergyDeposit(G4Step* step);
-  void             fillHits(edm::PSimHitContainer&, std::string use) override;
-  
-  std::vector<std::string> getNames() override;
+  double   getEnergyDeposit(const G4Step* step);
+  void     fillHits(edm::PSimHitContainer&, const std::string&) override;
+  void     clearHits() override;
   
 private:
   void     update(const BeginOfJob *) override;
   void     update(const BeginOfRun *) override;
   void     update(const BeginOfEvent *) override;
   void     update(const ::EndOfEvent *) override;
-  void     clearHits() override;
 
-private:
-  
   G4ThreeVector    SetToLocal(const G4ThreeVector& global);
   G4ThreeVector    SetToLocalExit(const G4ThreeVector& globalPoint);
   void             GetStepInfo(G4Step* aStep);

--- a/SimG4CMS/Forward/interface/PltSD.h
+++ b/SimG4CMS/Forward/interface/PltSD.h
@@ -34,16 +34,17 @@ class PltSD : public SensitiveTkDetector,
 
 public:
 
-  PltSD(std::string, const DDCompactView &, 
-		       const SensitiveDetectorCatalog &,
-		       edm::ParameterSet const &, const SimTrackManager*);
+  PltSD(const std::string&, const DDCompactView &, 
+	const SensitiveDetectorCatalog &,
+	edm::ParameterSet const &, const SimTrackManager*);
   ~PltSD() override;
 
   bool     ProcessHits(G4Step *,G4TouchableHistory *) override;
-  uint32_t setDetUnitId(G4Step*) override;
+  uint32_t setDetUnitId(const G4Step*) override;
   void EndOfEvent(G4HCofThisEvent*) override;
 
-  void fillHits (edm::PSimHitContainer&, std::string use) override;
+  void fillHits (edm::PSimHitContainer&, const std::string&) override;
+  void clearHits() override;
 
 private:
 
@@ -55,7 +56,6 @@ private:
   void           update(const BeginOfEvent *) override;
   void           update(const BeginOfTrack *) override;
   void           update(const BeginOfJob *) override;
-  void   clearHits() override;
   TrackInformation* getOrCreateTrackInformation(const G4Track *);
 
 private:
@@ -63,7 +63,6 @@ private:
   TrackingSlaveSD*            slave;
   G4ProcessTypeEnumerator * theG4ProcessTypeEnumerator;
   G4TrackToParticleID * myG4TrackToParticleID;
-  std::string        myName;
   UpdatablePSimHit * mySimHit;
   float energyCut;
   float energyHistoryCut;

--- a/SimG4CMS/Forward/interface/TotemSD.h
+++ b/SimG4CMS/Forward/interface/TotemSD.h
@@ -46,12 +46,12 @@ class TotemSD : public SensitiveTkDetector,
 
 public:
 
-  TotemSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &,
+  TotemSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
   ~TotemSD() override;
 
   bool   ProcessHits(G4Step *,G4TouchableHistory *) override;
-  uint32_t setDetUnitId(G4Step*) override;
+  uint32_t setDetUnitId(const G4Step*) override;
 
   void   Initialize(G4HCofThisEvent * HCE) override;
   void   EndOfEvent(G4HCofThisEvent * eventHC) override;
@@ -59,15 +59,13 @@ public:
   void   DrawAll() override;
   void   PrintAll() override;
 
-  void fillHits(edm::PSimHitContainer&, std::string use) override;
-
-private:
-
-  void           update(const BeginOfEvent *) override;
-  void           update(const ::EndOfEvent *) override;
+  void   fillHits(edm::PSimHitContainer&, const std::string&) override;
   void   clearHits() override;
 
 private:
+
+  void   update(const BeginOfEvent *) override;
+  void   update(const ::EndOfEvent *) override;
 
   G4ThreeVector  SetToLocal(const G4ThreeVector& globalPoint);
   void           GetStepInfo(G4Step* aStep);
@@ -94,7 +92,6 @@ private:
   float                       incidentEnergy;
   G4int                       primID  ; //@@ ID of the primary particle.
 
-  std::string                 name;
   G4int                       hcID;
   TotemG4HitCollection*       theHC; 
   const SimTrackManager*      theManager;

--- a/SimG4CMS/Forward/interface/ZdcSD.h
+++ b/SimG4CMS/Forward/interface/ZdcSD.h
@@ -14,18 +14,17 @@
 class ZdcSD : public CaloSD {
 
 public:    
-  ZdcSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  ZdcSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	edm::ParameterSet const &,const SimTrackManager*);
  
   ~ZdcSD() override;
   bool ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
-  uint32_t setDetUnitId(G4Step* step) override;
-  virtual double getEnergyDeposit(G4Step*, edm::ParameterSet const &);
+  uint32_t setDetUnitId(const G4Step* step) override;
+  double getEnergyDeposit(const G4Step*, edm::ParameterSet const &);
  
   void setNumberingScheme(ZdcNumberingScheme* scheme);
   void getFromLibrary(G4Step * step);
  
-
 protected:
   void initRun() override;
 private:    

--- a/SimG4CMS/Forward/interface/ZdcShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/ZdcShowerLibrary.h
@@ -25,7 +25,7 @@ class ZdcShowerLibrary {
 public:
   
   //Constructor and Destructor
-  ZdcShowerLibrary(std::string & name, const DDCompactView & cpv, edm::ParameterSet const & p);
+  ZdcShowerLibrary(const std::string & name, const DDCompactView & cpv, edm::ParameterSet const & p);
   ~ZdcShowerLibrary();
   
  public:

--- a/SimG4CMS/Forward/src/BHMSD.cc
+++ b/SimG4CMS/Forward/src/BHMSD.cc
@@ -25,12 +25,12 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#define debug
+//#define debug
 //-------------------------------------------------------------------
-BHMSD::BHMSD(std::string name, const DDCompactView & cpv,
+BHMSD::BHMSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg, 
 	     edm::ParameterSet const & p, const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr), name(name),
+  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr), 
   hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
   currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
   postStepPoint(nullptr), eventno(0){
@@ -76,23 +76,22 @@ BHMSD::BHMSD(std::string name, const DDCompactView & cpv,
   edm::LogInfo("BHMSim") << "BHMSD: Instantiation completed";
 }
 
-
 BHMSD::~BHMSD() { 
 
   if (slave)           delete slave; 
   if (numberingScheme) delete numberingScheme;
 }
 
-double BHMSD::getEnergyDeposit(G4Step* aStep) {
+double BHMSD::getEnergyDeposit(const G4Step* aStep) {
   return aStep->GetTotalEnergyDeposit();
 }
 
 void BHMSD::Initialize(G4HCofThisEvent * HCE) { 
 #ifdef debug
-  LogDebug("BHMSim") << "BHMSD : Initialize called for " << name << std::endl;
+  LogDebug("BHMSim") << "BHMSD : Initialize called for " << GetName();
 #endif
 
-  theHC = new BscG4HitCollection(name, collectionName[0]);
+  theHC = new BscG4HitCollection(GetName(), collectionName[0]);
   if (hcID<0) 
     hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
   HCE->AddHitsCollection(hcID, theHC);
@@ -166,10 +165,9 @@ void BHMSD::GetStepInfo(G4Step* aStep) {
   Z  = hitPoint.z();
 }
 
-uint32_t BHMSD::setDetUnitId(G4Step * aStep) { 
+uint32_t BHMSD::setDetUnitId(const G4Step * aStep) { 
   return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
 }
-
 
 G4bool BHMSD::HitExists() {
   if (primaryID<1) {
@@ -210,14 +208,12 @@ G4bool BHMSD::HitExists() {
   }    
 }
 
-
 void BHMSD::ResetForNewPrimary() {
   
   entrancePoint  = SetToLocal(hitPoint);
   exitPoint      = SetToLocalExit(hitPointExit);
   incidentEnergy = preStepPoint->GetKineticEnergy();
 }
-
 
 void BHMSD::StoreHit(BscG4Hit* hit){
 
@@ -229,7 +225,6 @@ void BHMSD::StoreHit(BscG4Hit* hit){
 
   theHC->insert( hit );
 }
-
 
 void BHMSD::CreateNewHit() {
 
@@ -289,7 +284,6 @@ void BHMSD::CreateNewHit() {
   StoreHit(currentHit);
 }	 
  
-
 void BHMSD::UpdateHit() {
 
   if (Eloss > 0.) {
@@ -309,7 +303,6 @@ void BHMSD::UpdateHit() {
   previousUnitID = unitID;
 }
 
-
 G4ThreeVector BHMSD::SetToLocal(const G4ThreeVector& global) {
 
   const G4VTouchable* touch= preStepPoint->GetTouchable();
@@ -317,7 +310,6 @@ G4ThreeVector BHMSD::SetToLocal(const G4ThreeVector& global) {
   return theEntryPoint;  
 }
      
-
 G4ThreeVector BHMSD::SetToLocalExit(const G4ThreeVector& globalPoint) {
 
   const G4VTouchable* touch= postStepPoint->GetTouchable();
@@ -325,7 +317,6 @@ G4ThreeVector BHMSD::SetToLocalExit(const G4ThreeVector& globalPoint) {
   return theExitPoint;  
 }
      
-
 void BHMSD::EndOfEvent(G4HCofThisEvent* ) {
 
   // here we loop over transient hits and make them persistent
@@ -352,27 +343,22 @@ void BHMSD::EndOfEvent(G4HCofThisEvent* ) {
   Summarize();
 }
      
-
 void BHMSD::Summarize() {
 }
-
 
 void BHMSD::clear() {
 } 
 
-
 void BHMSD::DrawAll() {
 } 
-
 
 void BHMSD::PrintAll() {
   LogDebug("BHMSim") << "BHMSD: Collection " << theHC->GetName() << "\n";
   theHC->PrintAllHits();
 } 
 
-
-void BHMSD::fillHits(edm::PSimHitContainer& c, std::string n) {
-  if (slave->name() == n) c=slave->hits();
+void BHMSD::fillHits(edm::PSimHitContainer& cc, const std::string& hname) {
+  if (slave->name() == hname) { cc=slave->hits(); }
 }
 
 void BHMSD::update (const BeginOfEvent * i) {
@@ -397,10 +383,4 @@ void BHMSD::update (const ::EndOfEvent*) {
 
 void BHMSD::clearHits(){
   slave->Initialize();
-}
-
-std::vector<std::string> BHMSD::getNames(){
-  std::vector<std::string> temp;
-  temp.push_back(slave->name());
-  return temp;
 }

--- a/SimG4CMS/Forward/src/BHMSD.cc
+++ b/SimG4CMS/Forward/src/BHMSD.cc
@@ -35,45 +35,19 @@ BHMSD::BHMSD(const std::string& name, const DDCompactView & cpv,
   currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
   postStepPoint(nullptr), eventno(0){
     
-  //Add BHM Sentitive Detector Name
-  collectionName.insert(name);
-    
-    
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("BHMSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");
   //int verbn = 1;
     
   SetVerboseLevel(verbn);
-  LogDebug("BHMSim") 
-    << "*******************************************************\n"
-    << "*                                                     *\n"
-    << "* Constructing a BHMSD  with name " << name << "\n"
-    << "*                                                     *\n"
-    << "*******************************************************";
-    
     
   slave  = new TrackingSlaveSD(name);
-    
-  //
-  // attach detectors (LogicalVolumes)
-  //
-  std::vector<std::string> lvNames = clg.logicalNames(name);
-
-  this->Register();
-
-  for (std::vector<std::string>::iterator it=lvNames.begin();  
-       it !=lvNames.end(); it++) {
-    this->AssignSD(*it);
-    edm::LogInfo("BHMSim") << "BHMSD : Assigns SD to LV " << (*it);
-  }
     
   if (verbn > 0) {
     edm::LogInfo("BHMSim") << "name = " <<name <<" and new BHMNumberingScheme";
   }
   numberingScheme = new BHMNumberingScheme() ;
-  
-  edm::LogInfo("BHMSim") << "BHMSD: Instantiation completed";
 }
 
 BHMSD::~BHMSD() { 

--- a/SimG4CMS/Forward/src/Bcm1fSD.cc
+++ b/SimG4CMS/Forward/src/Bcm1fSD.cc
@@ -30,12 +30,11 @@
 
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-Bcm1fSD::Bcm1fSD(std::string name, 
-					   const DDCompactView & cpv,
-					   const SensitiveDetectorCatalog & clg,
-					   edm::ParameterSet const & p,
-					   const SimTrackManager* manager) : 
-  SensitiveTkDetector(name, cpv, clg, p), myName(name), mySimHit(nullptr),
+Bcm1fSD::Bcm1fSD(const std::string& name, const DDCompactView & cpv,
+		 const SensitiveDetectorCatalog & clg,
+		 edm::ParameterSet const & p,
+		 const SimTrackManager* manager) : 
+  SensitiveTkDetector(name, cpv, clg, p), mySimHit(nullptr),
   oldVolume(nullptr), lastId(0), lastTrack(0), eventno(0) {
   
   edm::ParameterSet m_TrackerSD = p.getParameter<edm::ParameterSet>("Bcm1fSD");
@@ -98,7 +97,7 @@ bool Bcm1fSD::ProcessHits(G4Step * aStep,  G4TouchableHistory *) {
   return false;
 }
 
-uint32_t Bcm1fSD::setDetUnitId(G4Step * aStep ) {
+uint32_t Bcm1fSD::setDetUnitId(const G4Step * aStep ) {
  
   unsigned int detId = 0;
 
@@ -152,14 +151,14 @@ uint32_t Bcm1fSD::setDetUnitId(G4Step * aStep ) {
 
 void Bcm1fSD::EndOfEvent(G4HCofThisEvent *) {
   
-  LogDebug("Bcm1fSD")<< " Saving the last hit in a ROU " << myName;
+  LogDebug("Bcm1fSD")<< " Saving the last hit in a ROU " << GetName();
 
   if (mySimHit == nullptr) return;
   sendHit();
 }
 
-void Bcm1fSD::fillHits(edm::PSimHitContainer& c, std::string n){
-  if (slave->name() == n)  c=slave->hits();
+void Bcm1fSD::fillHits(edm::PSimHitContainer& cc, const std::string& hname){
+  if (slave->name() == hname) { cc=slave->hits(); }
 }
 
 void Bcm1fSD::sendHit() {  
@@ -294,7 +293,6 @@ TrackInformation* Bcm1fSD::getOrCreateTrackInformation( const G4Track* gTrack) {
     TrackInformation* info = dynamic_cast<TrackInformation*>(temp);
     if (info == nullptr){
       edm::LogError("Bcm1fSD") <<" ERROR: TkSimTrackSelection: the UserInformation does not appear to be a TrackInformation";
-      abort();
     }
     return info;
   }

--- a/SimG4CMS/Forward/src/Bcm1fSD.cc
+++ b/SimG4CMS/Forward/src/Bcm1fSD.cc
@@ -41,21 +41,12 @@ Bcm1fSD::Bcm1fSD(const std::string& name, const DDCompactView & cpv,
   energyCut           = m_TrackerSD.getParameter<double>("EnergyThresholdForPersistencyInGeV")*GeV; //default must be 0.5 (?)
   energyHistoryCut    = m_TrackerSD.getParameter<double>("EnergyThresholdForHistoryInGeV")*GeV;//default must be 0.05 (?)
 
-  edm::LogInfo("Bcm1fSD") <<"Criteria for Saving Tracker SimTracks: \n "
-				       <<" History: "<<energyHistoryCut<< " MeV ; Persistency: "<< energyCut<<" MeV\n"
-				       <<" Constructing a Bcm1fSD with ";
+  edm::LogInfo("Bcm1fSD") <<" Criteria for Saving Tracker SimTracks: \n "
+			  <<" History: "<<energyHistoryCut<< " MeV ; Persistency: "
+			  << energyCut<<" MeV\n" <<" Constructing a Bcm1fSD";
 
   slave  = new TrackingSlaveSD(name);
   
-  // Now attach the right detectors (LogicalVolumes) to me
-  std::vector<std::string>  lvNames = clg.logicalNames(name);
-  this->Register();
-  for (std::vector<std::string>::iterator it = lvNames.begin(); it != lvNames.end(); it++)
-  {
-     edm::LogInfo("Bcm1fSD")<< name << " attaching LV " << *it;
-     this->AssignSD(*it);
-  }
-
   theG4ProcessTypeEnumerator = new G4ProcessTypeEnumerator;
   myG4TrackToParticleID = new G4TrackToParticleID;
 }

--- a/SimG4CMS/Forward/src/BscSD.cc
+++ b/SimG4CMS/Forward/src/BscSD.cc
@@ -5,9 +5,6 @@
 // Modifications: 
 ///////////////////////////////////////////////////////////////////////////////
  
-//#include "Geometry/Vector/interface/LocalPoint.h"
-//#include "Geometry/Vector/interface/LocalVector.h"
-
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
 #include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
@@ -45,17 +42,16 @@
 
 #define debug
 //-------------------------------------------------------------------
-BscSD::BscSD(std::string name, const DDCompactView & cpv,
+BscSD::BscSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg,
 	     edm::ParameterSet const & p, const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr), name(name),
+  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr),
   hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
   currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
   postStepPoint(nullptr), eventno(0){
     
   //Add Bsc Sentitive Detector Name
   collectionName.insert(name);
-    
     
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("BscSD");
@@ -69,7 +65,6 @@ BscSD::BscSD(std::string name, const DDCompactView & cpv,
     << "* Constructing a BscSD  with name " << name << "\n"
     << "*                                                     *\n"
     << "*******************************************************";
-    
     
   slave  = new TrackingSlaveSD(name);
     
@@ -98,9 +93,6 @@ BscSD::BscSD(std::string name, const DDCompactView & cpv,
   edm::LogInfo("BscSim") << "BscSD: Instantiation completed";
 }
 
-
-
-
 BscSD::~BscSD() { 
   //AZ:
   if (slave) delete slave; 
@@ -110,16 +102,16 @@ BscSD::~BscSD() {
 
 }
 
-double BscSD::getEnergyDeposit(G4Step* aStep) {
+double BscSD::getEnergyDeposit(const G4Step* aStep) {
   return aStep->GetTotalEnergyDeposit();
 }
 
 void BscSD::Initialize(G4HCofThisEvent * HCE) { 
 #ifdef debug
-  LogDebug("BscSim") << "BscSD : Initialize called for " << name << std::endl;
+  LogDebug("BscSim") << "BscSD : Initialize called for " << GetName();
 #endif
 
-  theHC = new BscG4HitCollection(name, collectionName[0]);
+  theHC = new BscG4HitCollection(GetName(), collectionName[0]);
   if (hcID<0) 
     hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
   HCE->AddHitsCollection(hcID, theHC);
@@ -129,7 +121,6 @@ void BscSD::Initialize(G4HCofThisEvent * HCE) {
 
   ////    slave->Initialize();
 }
-
 
 bool BscSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
@@ -199,11 +190,9 @@ void BscSD::GetStepInfo(G4Step* aStep) {
   Z  = hitPoint.z();
 }
 
-uint32_t BscSD::setDetUnitId(G4Step * aStep) { 
-
+uint32_t BscSD::setDetUnitId(const G4Step * aStep) { 
   return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
 }
-
 
 G4bool BscSD::HitExists() {
   if (primaryID<1) {
@@ -250,7 +239,6 @@ G4bool BscSD::HitExists() {
   }    
 }
 
-
 void BscSD::ResetForNewPrimary() {
   
   entrancePoint  = SetToLocal(hitPoint);
@@ -258,7 +246,6 @@ void BscSD::ResetForNewPrimary() {
   incidentEnergy = preStepPoint->GetKineticEnergy();
 
 }
-
 
 void BscSD::StoreHit(BscG4Hit* hit){
 
@@ -270,7 +257,6 @@ void BscSD::StoreHit(BscG4Hit* hit){
 
   theHC->insert( hit );
 }
-
 
 void BscSD::CreateNewHit() {
 
@@ -330,7 +316,6 @@ void BscSD::CreateNewHit() {
   StoreHit(currentHit);
 }	 
  
-
 void BscSD::UpdateHit() {
 
   if (Eloss > 0.) {
@@ -351,7 +336,6 @@ void BscSD::UpdateHit() {
   previousUnitID = unitID;
 }
 
-
 G4ThreeVector BscSD::SetToLocal(const G4ThreeVector& global){
 
   const G4VTouchable* touch= preStepPoint->GetTouchable();
@@ -359,7 +343,6 @@ G4ThreeVector BscSD::SetToLocal(const G4ThreeVector& global){
   return theEntryPoint;  
 }
      
-
 G4ThreeVector BscSD::SetToLocalExit(const G4ThreeVector& globalPoint){
 
   const G4VTouchable* touch= postStepPoint->GetTouchable();
@@ -395,27 +378,22 @@ void BscSD::EndOfEvent(G4HCofThisEvent* ) {
   Summarize();
 }
      
-
 void BscSD::Summarize() {
 }
-
 
 void BscSD::clear() {
 } 
 
-
 void BscSD::DrawAll() {
 } 
-
 
 void BscSD::PrintAll() {
   LogDebug("BscSim") << "BscSD: Collection " << theHC->GetName() << "\n";
   theHC->PrintAllHits();
 } 
 
-
-void BscSD::fillHits(edm::PSimHitContainer& c, std::string n) {
-  if (slave->name() == n) c=slave->hits();
+void BscSD::fillHits(edm::PSimHitContainer& cc, const std::string& hname) {
+  if (slave->name() == hname) { cc=slave->hits(); }
 }
 
 void BscSD::update (const BeginOfEvent * i) {
@@ -441,11 +419,5 @@ void BscSD::update (const ::EndOfEvent*) {
 void BscSD::clearHits(){
   //AZ:
   slave->Initialize();
-}
-
-std::vector<std::string> BscSD::getNames(){
-  std::vector<std::string> temp;
-  temp.push_back(slave->name());
-  return temp;
 }
 

--- a/SimG4CMS/Forward/src/BscSD.cc
+++ b/SimG4CMS/Forward/src/BscSD.cc
@@ -50,37 +50,15 @@ BscSD::BscSD(const std::string& name, const DDCompactView & cpv,
   currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
   postStepPoint(nullptr), eventno(0){
     
-  //Add Bsc Sentitive Detector Name
-  collectionName.insert(name);
-    
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("BscSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");
   //int verbn = 1;
     
   SetVerboseLevel(verbn);
-  LogDebug("BscSim") 
-    << "*******************************************************\n"
-    << "*                                                     *\n"
-    << "* Constructing a BscSD  with name " << name << "\n"
-    << "*                                                     *\n"
-    << "*******************************************************";
     
   slave  = new TrackingSlaveSD(name);
-    
-  //
-  // attach detectors (LogicalVolumes)
-  //
-  const std::vector<std::string>& lvNames = clg.logicalNames(name);
-
-  this->Register();
-
-  for (std::vector<std::string>::const_iterator it=lvNames.begin();
-       it !=lvNames.end(); it++) {
-    this->AssignSD(*it);
-    edm::LogInfo("BscSim") << "BscSD : Assigns SD to LV " << (*it);
-  }
-    
+        
   if      (name == "BSCHits") {
     if (verbn > 0) {
       edm::LogInfo("BscSim") << "name = BSCHits and  new BscNumberingSchem";
@@ -89,8 +67,6 @@ BscSD::BscSD(const std::string& name, const DDCompactView & cpv,
   } else {
     edm::LogWarning("BscSim") << "BscSD: ReadoutName "<<name<<" not supported";
   }
-  
-  edm::LogInfo("BscSim") << "BscSD: Instantiation completed";
 }
 
 BscSD::~BscSD() { 

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -9,7 +9,6 @@
 #include "SimG4Core/Notification/interface/TrackInformationExtractor.h"
 
 #include "SimG4CMS/Forward/interface/CastorSD.h"
-//#include "SimDataFormats/CaloHit/interface/CastorShowerEvent.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4SDManager.hh"
@@ -28,7 +27,7 @@
 
 //#define debugLog
 
-CastorSD::CastorSD(G4String name, const DDCompactView & cpv,
+CastorSD::CastorSD(const std::string& name, const DDCompactView & cpv,
 		   const SensitiveDetectorCatalog & clg,
 		   edm::ParameterSet const & p, 
 		   const SimTrackManager* manager) : 
@@ -96,11 +95,8 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   
   double NCherPhot = 0.;
 
-  if (aStep == nullptr) 
-    return 0;
-
   // Get theTrack 
-  G4Track*        theTrack = aStep->GetTrack();
+  G4Track* theTrack = aStep->GetTrack();
 
   // preStepPoint information *********************************************
   
@@ -530,7 +526,7 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
 
 //=======================================================================================
 
-uint32_t CastorSD::setDetUnitId(G4Step* aStep) {
+uint32_t CastorSD::setDetUnitId(const G4Step* aStep) {
   return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
 }
 

--- a/SimG4CMS/Forward/src/CastorShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/CastorShowerLibrary.cc
@@ -20,12 +20,12 @@
 
 //#define DebugLog
 
-CastorShowerLibrary::CastorShowerLibrary(std::string & name, edm::ParameterSet const & p) 
-                                          : hf(nullptr), evtInfo(nullptr), emBranch(nullptr), hadBranch(nullptr),
-                                            nMomBin(0), totEvents(0), evtPerBin(0),
-                                            nBinsE(0),nBinsEta(0),nBinsPhi(0),
-                                            nEvtPerBinE(0),nEvtPerBinEta(0),nEvtPerBinPhi(0),
-                                            SLenergies(),SLetas(),SLphis() {
+CastorShowerLibrary::CastorShowerLibrary(const std::string & name, edm::ParameterSet const & p) 
+  : hf(nullptr), evtInfo(nullptr), emBranch(nullptr), hadBranch(nullptr),
+    nMomBin(0), totEvents(0), evtPerBin(0),
+    nBinsE(0),nBinsEta(0),nBinsPhi(0),
+    nEvtPerBinE(0),nEvtPerBinEta(0),nEvtPerBinPhi(0),
+    SLenergies(),SLetas(),SLphis() {
   
   initFile(p);
   

--- a/SimG4CMS/Forward/src/FastTimerSD.cc
+++ b/SimG4CMS/Forward/src/FastTimerSD.cc
@@ -37,11 +37,11 @@
 
 //#define EDM_ML_DEBUG
 //-------------------------------------------------------------------
-FastTimerSD::FastTimerSD(std::string name, const DDCompactView & cpv,
+FastTimerSD::FastTimerSD(const std::string& name, const DDCompactView & cpv,
 			 const SensitiveDetectorCatalog & clg, 
 			 edm::ParameterSet const & p, 
 			 const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), ftcons(nullptr), name(name),
+  SensitiveTkDetector(name, cpv, clg, p), ftcons(nullptr),
   hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
   currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
   postStepPoint(nullptr), eventno(0) {
@@ -90,12 +90,11 @@ FastTimerSD::FastTimerSD(std::string name, const DDCompactView & cpv,
 			       << name << " of type " << type_;
 }
 
-
 FastTimerSD::~FastTimerSD() { 
   if (slave)  delete slave; 
 }
 
-double FastTimerSD::getEnergyDeposit(G4Step* aStep) {
+double FastTimerSD::getEnergyDeposit(const G4Step* aStep) {
   return aStep->GetTotalEnergyDeposit();
 }
 
@@ -112,7 +111,6 @@ void FastTimerSD::Initialize(G4HCofThisEvent * HCE) {
   tsID   = -2;
   primID = -2;
 }
-
 
 bool FastTimerSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
@@ -181,7 +179,7 @@ void FastTimerSD::GetStepInfo(G4Step* aStep) {
   Z  = hitPoint.z();
 }
 
-uint32_t FastTimerSD::setDetUnitId(G4Step * aStep) { 
+uint32_t FastTimerSD::setDetUnitId(const G4Step * aStep) { 
 
   //Find the depth segment
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
@@ -394,8 +392,8 @@ void FastTimerSD::PrintAll() {
   theHC->PrintAllHits();
 } 
 
-void FastTimerSD::fillHits(edm::PSimHitContainer& c, std::string n) {
-  if (slave->name() == n) c=slave->hits();
+void FastTimerSD::fillHits(edm::PSimHitContainer& cc, const std::string& hname) {
+  if (slave->name() == hname) { cc=slave->hits(); }
 }
 
 void FastTimerSD::update(const BeginOfJob * job) {
@@ -436,12 +434,6 @@ void FastTimerSD::update (const ::EndOfEvent*) {}
 
 void FastTimerSD::clearHits(){
   slave->Initialize();
-}
-
-std::vector<std::string> FastTimerSD::getNames(){
-  std::vector<std::string> temp;
-  temp.push_back(slave->name());
-  return temp;
 }
 
 std::vector<double> FastTimerSD::getDDDArray(const std::string & str, 

--- a/SimG4CMS/Forward/src/FastTimerSD.cc
+++ b/SimG4CMS/Forward/src/FastTimerSD.cc
@@ -46,38 +46,14 @@ FastTimerSD::FastTimerSD(const std::string& name, const DDCompactView & cpv,
   currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
   postStepPoint(nullptr), eventno(0) {
     
-  //Add FastTimer Sentitive Detector Name
-  collectionName.insert(name);
-    
-    
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("FastTimerSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");
     
   SetVerboseLevel(verbn);
-#ifdef EDM_ML_DEBUG
-  std::cout << "*******************************************************\n"
-	    << "*                                                     *\n"
-	    << "* Constructing a FastTimerSD  with name " << name << "\n"
-	    << "*                                                     *\n"
-	    << "*******************************************************\n";
-#endif    
     
   slave  = new TrackingSlaveSD(name);
-    
-  //
-  // attach detectors (LogicalVolumes)
-  //
-  std::vector<std::string> lvNames = clg.logicalNames(name);
-
-  this->Register();
-
-  for (std::vector<std::string>::iterator it=lvNames.begin();  
-       it !=lvNames.end(); it++) {
-    this->AssignSD(*it);
-    edm::LogInfo("FastTimerSim") << "FastTimerSD : Assigns SD to LV " << (*it);
-  }
-    
+        
   std::string attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute,name,0)};
   DDFilteredView fv(cpv,filter);

--- a/SimG4CMS/Forward/src/PltSD.cc
+++ b/SimG4CMS/Forward/src/PltSD.cc
@@ -46,19 +46,10 @@ oldVolume(nullptr), lastId(0), lastTrack(0), eventno(0) {
     
     edm::LogInfo("PltSD") <<"Criteria for Saving Tracker SimTracks: \n "
     <<" History: "<<energyHistoryCut<< " MeV ; Persistency: "<< energyCut<<" MeV\n"
-    <<" Constructing a PltSD with ";
+    <<" Constructing a PltSD";
     
     slave  = new TrackingSlaveSD(name);
-    
-    // Now attach the right detectors (LogicalVolumes) to me
-    const std::vector<std::string>&  lvNames = clg.logicalNames(name);
-    this->Register();
-    for (std::vector<std::string>::const_iterator it = lvNames.begin();
-         it != lvNames.end(); it++)  {
-        edm::LogInfo("PltSD")<< name << " attaching LV " << *it;
-        this->AssignSD(*it);
-    }
-    
+        
     theG4ProcessTypeEnumerator = new G4ProcessTypeEnumerator;
     myG4TrackToParticleID = new G4TrackToParticleID;
 }

--- a/SimG4CMS/Forward/src/PltSD.cc
+++ b/SimG4CMS/Forward/src/PltSD.cc
@@ -32,12 +32,12 @@
 #include <iostream>
 
 
-PltSD::PltSD(std::string name,
+PltSD::PltSD(const std::string& name,
              const DDCompactView & cpv,
              const SensitiveDetectorCatalog & clg,
              edm::ParameterSet const & p,
              const SimTrackManager* manager) :
-SensitiveTkDetector(name, cpv, clg, p), myName(name), mySimHit(nullptr),
+SensitiveTkDetector(name, cpv, clg, p), mySimHit(nullptr),
 oldVolume(nullptr), lastId(0), lastTrack(0), eventno(0) {
     
     edm::ParameterSet m_TrackerSD = p.getParameter<edm::ParameterSet>("PltSD");
@@ -100,7 +100,7 @@ bool PltSD::ProcessHits(G4Step * aStep,  G4TouchableHistory *) {
     return false;
 }
 
-uint32_t PltSD::setDetUnitId(G4Step * aStep ) {
+uint32_t PltSD::setDetUnitId(const G4Step * aStep ) {
     
     unsigned int detId = 0;
     
@@ -196,14 +196,14 @@ uint32_t PltSD::setDetUnitId(G4Step * aStep ) {
 
 void PltSD::EndOfEvent(G4HCofThisEvent *) {
     
-    LogDebug("PltSD")<< " Saving the last hit in a ROU " << myName;
+    LogDebug("PltSD")<< " Saving the last hit in a ROU " << GetName();
     
     if (mySimHit == nullptr) return;
     sendHit();
 }
 
-void PltSD::fillHits(edm::PSimHitContainer& c, std::string n){
-    if (slave->name() == n)  c=slave->hits();
+void PltSD::fillHits(edm::PSimHitContainer& cc, const std::string& hname){
+  if (slave->name() == hname) { cc=slave->hits(); }
 }
 
 void PltSD::sendHit() {

--- a/SimG4CMS/Forward/src/TotemSD.cc
+++ b/SimG4CMS/Forward/src/TotemSD.cc
@@ -53,33 +53,13 @@ TotemSD::TotemSD(const std::string& name, const DDCompactView & cpv,
   currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
   postStepPoint(nullptr), eventno(0){
 
-  //Add Totem Sentitive Detector Names
-  collectionName.insert(name);
-
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("TotemSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");
  
   SetVerboseLevel(verbn);
-  LogDebug("ForwardSim") 
-    << "*******************************************************\n"
-    << "*                                                     *\n"
-    << "* Constructing a TotemSD  with name " << name << "\n"
-    << "*                                                     *\n"
-    << "*******************************************************";
 
   slave  = new TrackingSlaveSD(name);
-
-  //
-  // Now attach the right detectors (LogicalVolumes) to me
-  //
-  const std::vector<std::string>& lvNames = clg.logicalNames(name);
-  this->Register();
-  for (std::vector<std::string>::const_iterator it=lvNames.begin();
-       it !=lvNames.end(); it++) {
-    this->AssignSD(*it);
-    edm::LogInfo("ForwardSim") << "TotemSD : Assigns SD to LV " << (*it);
-  }
 
   if      (name == "TotemHitsT1") {
     numberingScheme = dynamic_cast<TotemVDetectorOrganization*>(new TotemT1NumberingScheme(1));
@@ -92,13 +72,11 @@ TotemSD::TotemSD(const std::string& name, const DDCompactView & cpv,
   } else {
     edm::LogWarning("ForwardSim") << "TotemSD: ReadoutName not supported\n";
   }
-  
-  edm::LogInfo("ForwardSim") << "TotemSD: Instantiation completed";
 } 
 
 TotemSD::~TotemSD() { 
-  if (slave)           delete slave; 
-  if (numberingScheme) delete numberingScheme;
+  delete slave; 
+  delete numberingScheme;
 }
 
 bool TotemSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {

--- a/SimG4CMS/Forward/src/TotemSD.cc
+++ b/SimG4CMS/Forward/src/TotemSD.cc
@@ -45,10 +45,10 @@
 //
 // constructors and destructor
 //
-TotemSD::TotemSD(std::string name, const DDCompactView & cpv,
+TotemSD::TotemSD(const std::string& name, const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg,
 		 edm::ParameterSet const & p, const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr), name(name),
+  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr), 
   hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
   currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
   postStepPoint(nullptr), eventno(0){
@@ -120,16 +120,16 @@ bool TotemSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
   return true;
 }
 
-uint32_t TotemSD::setDetUnitId(G4Step * aStep) { 
+uint32_t TotemSD::setDetUnitId(const G4Step * aStep) { 
 
   return (numberingScheme == nullptr ? 0 : numberingScheme->GetUnitID(aStep));
 }
 
 void TotemSD::Initialize(G4HCofThisEvent * HCE) { 
 
-  LogDebug("ForwardSim") << "TotemSD : Initialize called for " << name;
+  LogDebug("ForwardSim") << "TotemSD : Initialize called for " << GetName();
 
-  theHC = new TotemG4HitCollection(name, collectionName[0]);
+  theHC = new TotemG4HitCollection(GetName(), collectionName[0]);
   if (hcID<0) 
     hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
   HCE->AddHitsCollection(hcID, theHC);
@@ -176,8 +176,8 @@ void TotemSD::PrintAll() {
   theHC->PrintAllHits();
 } 
 
-void TotemSD::fillHits(edm::PSimHitContainer& c, std::string n) {
-  if (slave->name() == n) c=slave->hits();
+void TotemSD::fillHits(edm::PSimHitContainer& cc, const std::string& hname) {
+  if (slave->name() == hname) { cc=slave->hits(); }
 }
 
 void TotemSD::update (const BeginOfEvent * i) {

--- a/SimG4CMS/Forward/src/ZdcSD.cc
+++ b/SimG4CMS/Forward/src/ZdcSD.cc
@@ -20,7 +20,7 @@
 #include "Randomize.hh"
 #include "G4Poisson.hh"
 
-ZdcSD::ZdcSD(G4String name, const DDCompactView & cpv,
+ZdcSD::ZdcSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg,
 	     edm::ParameterSet const & p,const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
@@ -179,7 +179,7 @@ void ZdcSD::getFromLibrary (G4Step* aStep) {
   }
 }
 
-double ZdcSD::getEnergyDeposit(G4Step * aStep, edm::ParameterSet const & p ) {
+double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p ) {
 
   float NCherPhot = 0.;
   //std::cout<<"I go through here"<<std::endl;
@@ -408,11 +408,8 @@ double ZdcSD::getEnergyDeposit(G4Step * aStep, edm::ParameterSet const & p ) {
   } 
 }
 
-uint32_t ZdcSD::setDetUnitId(G4Step* aStep) {
-  uint32_t returnNumber = 0;
-  if(numberingScheme != nullptr)returnNumber = numberingScheme->getUnitID(aStep);
-  // edm: return (numberingScheme == 0 ? 0 : numberingScheme->getUnitID(aStep));
-  return returnNumber;
+uint32_t ZdcSD::setDetUnitId(const G4Step* aStep) {
+  return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
 }
 
 void ZdcSD::setNumberingScheme(ZdcNumberingScheme* scheme) {

--- a/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
@@ -16,7 +16,7 @@
 #include "Randomize.hh"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-ZdcShowerLibrary::ZdcShowerLibrary(std::string & name, const DDCompactView & cpv,
+ZdcShowerLibrary::ZdcShowerLibrary(const std::string & name, const DDCompactView & cpv,
 				 edm::ParameterSet const & p) {
   edm::ParameterSet m_HS   = p.getParameter<edm::ParameterSet>("ZdcShowerLibrary");
   verbose                  = m_HS.getUntrackedParameter<int>("Verbosity",0);

--- a/SimG4CMS/HGCalTestBeam/interface/AHCalSD.h
+++ b/SimG4CMS/HGCalTestBeam/interface/AHCalSD.h
@@ -13,13 +13,13 @@ class AHCalSD : public CaloSD {
 
 public:    
 
-  AHCalSD(G4String , const DDCompactView &, const SensitiveDetectorCatalog &,
+  AHCalSD(const std::string& , const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
   ~AHCalSD() override;
   double                getEnergyDeposit(G4Step* ) override;
-  uint32_t              setDetUnitId(G4Step* step) override;
-  bool                          unpackIndex(const uint32_t & idx, int & row, 
-					    int& col, int& depth);
+  uint32_t              setDetUnitId(const G4Step* step) override;
+  bool                  unpackIndex(const uint32_t & idx, int & row, 
+				    int& col, int& depth);
 protected:
 
   bool                  filterHit(CaloG4Hit*, double) override;

--- a/SimG4CMS/HGCalTestBeam/interface/HGCalTB16SD01.h
+++ b/SimG4CMS/HGCalTestBeam/interface/HGCalTB16SD01.h
@@ -20,18 +20,18 @@ class HGCalTB16SD01 : public CaloSD {
 
 public:    
 
-  HGCalTB16SD01(G4String , const DDCompactView &, 
+  HGCalTB16SD01(const std::string& , const DDCompactView &, 
 		const SensitiveDetectorCatalog &, edm::ParameterSet const &, 
 		const SimTrackManager*);
   ~HGCalTB16SD01() override;
   double   getEnergyDeposit(G4Step* ) override;
-  uint32_t setDetUnitId(G4Step* step) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
   static uint32_t  packIndex(int det, int lay, int x, int y);
   static void      unpackIndex(const uint32_t & idx, int& det, int& lay,
 			       int& x, int& y);
 
 private:    
-  void             initialize(G4StepPoint* point);
+  void             initialize(const G4StepPoint* point);
 
   std::string      matName_;
   bool             useBirk_;

--- a/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
@@ -17,7 +17,7 @@
 #include <iomanip>
 //#define EDM_ML_DEBUG
 
-AHCalSD::AHCalSD(G4String name, const DDCompactView & cpv,
+AHCalSD::AHCalSD(const std::string& name, const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg,
 		 edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager,
@@ -57,7 +57,7 @@ double AHCalSD::getEnergyDeposit(G4Step* aStep) {
   return edep;
 }
 
-uint32_t AHCalSD::setDetUnitId(G4Step * aStep) { 
+uint32_t AHCalSD::setDetUnitId(const G4Step * aStep) { 
 
   G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();

--- a/SimG4CMS/HGCalTestBeam/src/HGCalTB16SD01.cc
+++ b/SimG4CMS/HGCalTestBeam/src/HGCalTB16SD01.cc
@@ -21,7 +21,7 @@
 
 //#define EDM_ML_DEBUG
 
-HGCalTB16SD01::HGCalTB16SD01(G4String name, const DDCompactView & cpv,
+HGCalTB16SD01::HGCalTB16SD01(const std::string& name, const DDCompactView & cpv,
 			     const SensitiveDetectorCatalog & clg,
 			     edm::ParameterSet const & p, 
 			     const SimTrackManager* manager) : 
@@ -63,7 +63,7 @@ double HGCalTB16SD01::getEnergyDeposit(G4Step* aStep) {
   return weight*destep;
 }
 
-uint32_t HGCalTB16SD01::setDetUnitId(G4Step * aStep) { 
+uint32_t HGCalTB16SD01::setDetUnitId(const G4Step * aStep) { 
 
   G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
@@ -106,7 +106,7 @@ void HGCalTB16SD01::unpackIndex(const uint32_t & idx, int& det, int& lay,
 
 }
 
-void HGCalTB16SD01::initialize(G4StepPoint* point) {
+void HGCalTB16SD01::initialize(const G4StepPoint* point) {
   if (matName_ == point->GetMaterial()->GetName()) {
     matScin_    =  point->GetMaterial();
     initialize_ = false;

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
@@ -29,16 +29,16 @@
 class HcalTB02SD : public CaloSD {
 
 public:
-  HcalTB02SD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  HcalTB02SD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	     edm::ParameterSet const &, const SimTrackManager*);
   ~HcalTB02SD() override;
   double getEnergyDeposit(G4Step*) override;
-  uint32_t setDetUnitId(G4Step* step) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
   void setNumberingScheme(HcalTB02NumberingScheme* scheme);
 
 private:    
 
-  void   initMap(G4String, const DDCompactView &);
+  void   initMap(const std::string&, const DDCompactView &);
   double curve_LY(G4String& , G4StepPoint* ); 
   double crystalLength(G4String);
 

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
@@ -21,17 +21,17 @@ class HcalTB06BeamSD : public CaloSD {
 
 public:    
 
-  HcalTB06BeamSD(const G4String&, const DDCompactView &, 
+  HcalTB06BeamSD(const std::string&, const DDCompactView &, 
                  const SensitiveDetectorCatalog &,
 		 edm::ParameterSet const &, const SimTrackManager*);
   ~HcalTB06BeamSD() override;
   double getEnergyDeposit(G4Step* ) override;
-  uint32_t setDetUnitId(G4Step* step) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
 
 private:    
 
   std::vector<G4String> getNames(DDFilteredView&);
-  bool                  isItWireChamber(G4String);
+  bool                  isItWireChamber(const G4String&);
 
   bool                  useBirk;
   double                birk1, birk2, birk3;

--- a/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
@@ -33,7 +33,7 @@
 // constructors and destructor
 //
 
-HcalTB02SD::HcalTB02SD(G4String name, const DDCompactView & cpv,
+HcalTB02SD::HcalTB02SD(const std::string& name, const DDCompactView & cpv,
 		       const SensitiveDetectorCatalog & clg,
 		       edm::ParameterSet const & p, 
 		       const SimTrackManager* manager) : 
@@ -104,7 +104,7 @@ double HcalTB02SD::getEnergyDeposit(G4Step * aStep) {
   } 
 }
 
-uint32_t HcalTB02SD::setDetUnitId(G4Step * aStep) { 
+uint32_t HcalTB02SD::setDetUnitId(const G4Step * aStep) { 
   return (numberingScheme == nullptr ? 0 : (uint32_t)(numberingScheme->getUnitID(aStep)));
 }
 
@@ -117,7 +117,7 @@ void HcalTB02SD::setNumberingScheme(HcalTB02NumberingScheme* scheme) {
   }
 }
 
-void HcalTB02SD::initMap(G4String sd, const DDCompactView & cpv) {
+void HcalTB02SD::initMap(const std::string& sd, const DDCompactView & cpv) {
 
   G4String attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute,sd,0)};

--- a/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
@@ -20,7 +20,7 @@
 #include "G4Material.hh"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-HcalTB06BeamSD::HcalTB06BeamSD(const G4String& name, const DDCompactView & cpv,
+HcalTB06BeamSD::HcalTB06BeamSD(const std::string& name, const DDCompactView & cpv,
 			       const SensitiveDetectorCatalog & clg,
 			       edm::ParameterSet const & p, 
 			       const SimTrackManager* manager) : 
@@ -107,9 +107,9 @@ double HcalTB06BeamSD::getEnergyDeposit(G4Step* aStep) {
   return weight*destep;
 }
 
-uint32_t HcalTB06BeamSD::setDetUnitId(G4Step * aStep) { 
+uint32_t HcalTB06BeamSD::setDetUnitId(const G4Step * aStep) { 
 
-  G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
   G4String name             = preStepPoint->GetPhysicalVolume()->GetName();
 
@@ -144,7 +144,7 @@ std::vector<G4String> HcalTB06BeamSD::getNames(DDFilteredView& fv) {
   return tmp;
 }
  
-bool HcalTB06BeamSD::isItWireChamber (G4String name) {
+bool HcalTB06BeamSD::isItWireChamber (const G4String& name) {
  
   std::vector<G4String>::const_iterator it = wcNames.begin();
   for (; it != wcNames.end(); it++)

--- a/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
+++ b/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
@@ -49,16 +49,17 @@ public Observer<const EndOfEvent*>
  {
 
  public:    
-  MuonSensitiveDetector(std::string, const DDCompactView &,
+  MuonSensitiveDetector(const std::string&, const DDCompactView &,
 			const SensitiveDetectorCatalog &, edm::ParameterSet const &,
 			const SimTrackManager*);
   ~MuonSensitiveDetector() override;
   G4bool ProcessHits(G4Step *,G4TouchableHistory *) override;
-  uint32_t setDetUnitId(G4Step *) override;
+  uint32_t setDetUnitId(const G4Step *) override;
   void EndOfEvent(G4HCofThisEvent*) override;
 
-  void fillHits(edm::PSimHitContainer&, std::string use) override;
-  std::vector<std::string> getNames() override;
+  void fillHits(edm::PSimHitContainer&, const std::string&) override;
+  void clearHits() override;
+
   std::string type();
 
   const MuonSlaveSD* GetSlaveMuon() const {
@@ -67,11 +68,10 @@ public Observer<const EndOfEvent*>
  private:
   void update(const BeginOfEvent *) override;
   void update(const ::EndOfEvent *) override;
-  void clearHits() override;
 
-  Local3DPoint toOrcaRef(Local3DPoint in ,G4Step * s);
-  Local3DPoint toOrcaUnits(Local3DPoint);
-  Global3DPoint toOrcaUnits(Global3DPoint);
+  Local3DPoint toOrcaRef(Local3DPoint in ,G4Step *);
+  Local3DPoint toOrcaUnits(const Local3DPoint&);
+  Global3DPoint toOrcaUnits(const Global3DPoint&);
 
   TrackInformation* getOrCreateTrackInformation( const G4Track* theTrack );
 
@@ -82,7 +82,7 @@ public Observer<const EndOfEvent*>
   MuonFrameRotation* theRotation;
   MuonG4Numbering* g4numbering;
 
-  void storeVolumeAndTrack(G4Step *);
+  void storeVolumeAndTrack(const G4Step *);
   bool newHit(G4Step *);
   void createHit(G4Step *);
   void updateHit(G4Step *);

--- a/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
@@ -29,7 +29,7 @@
 
 #include <iostream>
 
-MuonSensitiveDetector::MuonSensitiveDetector(std::string name, 
+MuonSensitiveDetector::MuonSensitiveDetector(const std::string& name, 
 					     const DDCompactView & cpv,
 					     const SensitiveDetectorCatalog & clg,
 					     edm::ParameterSet const & p,
@@ -121,10 +121,8 @@ void MuonSensitiveDetector::update(const BeginOfEvent * i){
 
 }
 
-void MuonSensitiveDetector::update(const  ::EndOfEvent * ev)
-{
-  //slaveMuon->renumbering(theManager);
-}
+void MuonSensitiveDetector::update(const  ::EndOfEvent *)
+{}
 
 
 void MuonSensitiveDetector::clearHits()
@@ -158,7 +156,7 @@ bool MuonSensitiveDetector::ProcessHits(G4Step * aStep, G4TouchableHistory * ROh
   return false;
 }
 
-uint32_t MuonSensitiveDetector::setDetUnitId(G4Step * aStep)
+uint32_t MuonSensitiveDetector::setDetUnitId(const G4Step * aStep)
 { 
   //  G4VPhysicalVolume * pv = aStep->GetPreStepPoint()->GetPhysicalVolume();
   MuonBaseNumber num = g4numbering->PhysicalVolumeToBaseNumber(aStep);
@@ -179,22 +177,22 @@ uint32_t MuonSensitiveDetector::setDetUnitId(G4Step * aStep)
 }
 
 
-Local3DPoint MuonSensitiveDetector::toOrcaRef(Local3DPoint in ,G4Step * s){
+Local3DPoint MuonSensitiveDetector::toOrcaRef(Local3DPoint in ,G4Step * step){
   if (theRotation !=nullptr ) {
-    return theRotation->transformPoint(in,s);
+    return theRotation->transformPoint(in,step);
   }
   return (in);
 }
 
-Local3DPoint MuonSensitiveDetector::toOrcaUnits(Local3DPoint in){
+Local3DPoint MuonSensitiveDetector::toOrcaUnits(const Local3DPoint& in){
   return Local3DPoint(in.x()/cm,in.y()/cm,in.z()/cm);
 }
 
-Global3DPoint MuonSensitiveDetector::toOrcaUnits(Global3DPoint in){
+Global3DPoint MuonSensitiveDetector::toOrcaUnits(const Global3DPoint& in){
   return Global3DPoint(in.x()/cm,in.y()/cm,in.z()/cm);
 }
 
-void MuonSensitiveDetector::storeVolumeAndTrack(G4Step * aStep) {
+void MuonSensitiveDetector::storeVolumeAndTrack(const G4Step * aStep) {
   G4VPhysicalVolume* pv = aStep->GetPreStepPoint()->GetPhysicalVolume();
   G4Track * t  = aStep->GetTrack();
   thePV=pv;
@@ -409,19 +407,8 @@ void MuonSensitiveDetector::EndOfEvent(G4HCofThisEvent*)
 }
 
 
-void MuonSensitiveDetector::fillHits(edm::PSimHitContainer& c, std::string n){
-  //
-  // do it once for low, once for High
-  //
-
-  if (slaveMuon->name() == n) c=slaveMuon->hits();
-
-}
-
-std::vector<std::string> MuonSensitiveDetector::getNames(){
-  std::vector<std::string> temp;
-  temp.push_back(slaveMuon->name());
-  return temp;
+void MuonSensitiveDetector::fillHits(edm::PSimHitContainer& cc, const std::string& hname){
+  if (slaveMuon->name() == hname) { cc=slaveMuon->hits(); }
 }
 
 Local3DPoint MuonSensitiveDetector::InitialStepPositionVsParent(G4Step * currentStep, G4int levelsUp) {

--- a/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
@@ -75,29 +75,18 @@ MuonSensitiveDetector::MuonSensitiveDetector(const std::string& name,
   numbering  = new MuonSimHitNumberingScheme(detector, constants);
   g4numbering = new MuonG4Numbering(constants);
   
-
-  //
-  // Now attach the right detectors (LogicalVolumes) to me
-  //
-  const std::vector<std::string>&  lvNames = clg.logicalNames(name);
-  this->Register();
-  for (std::vector<std::string>::const_iterator it = lvNames.begin();  it != lvNames.end(); it++){
-    LogDebug("MuonSimDebug") << name << " MuonSensitiveDetector:: attaching SD to LV " << *it << std::endl;
-    this->AssignSD(*it);
-  }
-
   if (printHits) {
     thePrinter = new SimHitPrinter("HitPositionOSCAR.dat");
   }
 
 
-    LogDebug("MuonSimDebug") << "  EnergyThresholdForPersistency " << STenergyPersistentCut << " AllMuonsPersistent " <<  STallMuonsPersistent << std::endl;
+  edm::LogInfo("MuonSimDebug") << "  EnergyThresholdForPersistency " 
+			       << STenergyPersistentCut << " AllMuonsPersistent " 
+			       <<  STallMuonsPersistent;
     
-    theG4ProcessTypeEnumerator = new G4ProcessTypeEnumerator;
-    myG4TrackToParticleID = new G4TrackToParticleID;
-
+  theG4ProcessTypeEnumerator = new G4ProcessTypeEnumerator;
+  myG4TrackToParticleID = new G4TrackToParticleID;
 }
-
 
 MuonSensitiveDetector::~MuonSensitiveDetector() { 
   delete g4numbering;

--- a/SimG4CMS/ShowerLibraryProducer/interface/FiberSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/FiberSD.h
@@ -31,8 +31,9 @@ class FiberSD : public SensitiveCaloDetector,
 
 public:
 
-  FiberSD(std::string, const DDCompactView&, const SensitiveDetectorCatalog&,
-	  edm::ParameterSet const &, const SimTrackManager*);
+  explicit FiberSD(const std::string&, const DDCompactView&, 
+		   const SensitiveDetectorCatalog&,
+		   edm::ParameterSet const &, const SimTrackManager*);
   ~FiberSD() override;
 
   void     Initialize(G4HCofThisEvent*HCE) override;
@@ -42,11 +43,11 @@ public:
   void     DrawAll() override;
   void     PrintAll() override;
 
-protected:
-
   void     clearHits() override;
-  uint32_t setDetUnitId(G4Step*) override;
-  void     fillHits(edm::PCaloHitContainer&, std::string) override;
+  uint32_t setDetUnitId(const G4Step*) override;
+  void     fillHits(edm::PCaloHitContainer&, const std::string&) override;
+
+protected:
 
   void     update(const BeginOfJob *) override;
   void     update(const BeginOfRun *) override;
@@ -55,7 +56,6 @@ protected:
 
 private:
 
-  std::string            theName;
   const SimTrackManager* m_trackManager;
   HFShower*              theShower;
 

--- a/SimG4CMS/ShowerLibraryProducer/interface/HFChamberSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HFChamberSD.h
@@ -20,8 +20,9 @@ class HFChamberSD : public SensitiveCaloDetector {
 
 public:
 
-  HFChamberSD(std::string, const DDCompactView&, const SensitiveDetectorCatalog&,
-	  edm::ParameterSet const &, const SimTrackManager*);
+  explicit HFChamberSD(const std::string&, const DDCompactView&, 
+		       const SensitiveDetectorCatalog&,
+		       const edm::ParameterSet&, const SimTrackManager*);
   ~HFChamberSD() override;
 
   void     Initialize(G4HCofThisEvent*HCE) override;
@@ -31,15 +32,12 @@ public:
   void     DrawAll() override;
   void     PrintAll() override;
 
-protected:
-
   void     clearHits() override;
-  uint32_t setDetUnitId(G4Step*) override;
-  void     fillHits(edm::PCaloHitContainer&, std::string) override;
+  uint32_t setDetUnitId(const G4Step*) override;
+  void     fillHits(edm::PCaloHitContainer&, const std::string&) override;
 
 private:
 
-  std::string               theName;
   const SimTrackManager*    m_trackManager;
 
   G4int                     theHCID;

--- a/SimG4CMS/ShowerLibraryProducer/interface/HFWedgeSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HFWedgeSD.h
@@ -11,9 +11,6 @@
 #include "G4VPhysicalVolume.hh"
 #include "G4Track.hh"
 
-#include <iostream>
-#include <fstream>
-#include <vector>
 #include <map>
 
 class G4Step;
@@ -23,9 +20,9 @@ class HFWedgeSD : public SensitiveCaloDetector {
 
 public:    
   
-  HFWedgeSD(std::string name, const DDCompactView & cpv,
-	    const SensitiveDetectorCatalog & clg,
-	    edm::ParameterSet const & p, const SimTrackManager*);
+  explicit HFWedgeSD(const std::string&, const DDCompactView & cpv,
+		     const SensitiveDetectorCatalog & clg,
+		     edm::ParameterSet const &p, const SimTrackManager*);
   ~HFWedgeSD() override;
   
   void     Initialize(G4HCofThisEvent * HCE) override;
@@ -35,20 +32,18 @@ public:
   void     DrawAll() override;
   void     PrintAll() override;
 
+  void     clearHits() override;
+  uint32_t setDetUnitId(const G4Step*) override;
+  void     fillHits(edm::PCaloHitContainer&, const std::string&) override;
+
 protected:
 
   G4bool           hitExists();
   HFShowerG4Hit*   createNewHit();
   void             updateHit(HFShowerG4Hit*);
 
-  void     clearHits() override;
-  uint32_t setDetUnitId(G4Step*) override;
-  void     fillHits(edm::PCaloHitContainer&, std::string) override;
-
-
 private:
 
-  std::string                  theName;
   const SimTrackManager*       m_trackManager;
 
   int                          hcID;

--- a/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
@@ -18,13 +18,13 @@
 #include "G4SDManager.hh"
 #include "G4ios.hh"
 
-FiberSD::FiberSD(std::string name, const DDCompactView & cpv, 
+FiberSD::FiberSD(const std::string& iname, const DDCompactView & cpv, 
 		 const SensitiveDetectorCatalog & clg, edm::ParameterSet const & p,
 		 const SimTrackManager* manager) :
-  SensitiveCaloDetector(name, cpv, clg, p), theName(name),
+  SensitiveCaloDetector(iname, cpv, clg, p),
   m_trackManager(manager), theHCID(-1), theHC(nullptr) {
 
-  collectionName.insert(name);
+  collectionName.insert(iname);
   LogDebug("FiberSim") << "***************************************************"
 		       << "\n"
 		       << "*                                                 *"
@@ -34,12 +34,12 @@ FiberSD::FiberSD(std::string name, const DDCompactView & cpv,
 		       << "*                                                 *"
 		       << "\n"
 		       << "***************************************************";
-  theShower = new HFShower(name, cpv, p, 1);
+  theShower = new HFShower(iname, cpv, p, 1);
 
   //
   // Now attach the right detectors (LogicalVolumes) to me
   //
-  const std::vector<std::string>& lvNames = clg.logicalNames(name);
+  const std::vector<std::string>& lvNames = clg.logicalNames(iname);
   this->Register();
   for (std::vector<std::string>::const_iterator it=lvNames.begin();
        it !=lvNames.end(); it++){
@@ -151,7 +151,7 @@ void FiberSD::update(const ::EndOfEvent *) {}
 
 void FiberSD::clearHits() {}
 
-uint32_t FiberSD::setDetUnitId(G4Step* aStep) {
+uint32_t FiberSD::setDetUnitId(const G4Step* aStep) {
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   int fibre = (touch->GetReplicaNumber(1))%10;
   int cell  = (touch->GetReplicaNumber(2));
@@ -159,4 +159,4 @@ uint32_t FiberSD::setDetUnitId(G4Step* aStep) {
   return ((tower*1000+cell)*10+fibre);
 }
 
-void FiberSD::fillHits(edm::PCaloHitContainer&, std::string) {}
+void FiberSD::fillHits(edm::PCaloHitContainer&, const std::string&) {}

--- a/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
@@ -24,34 +24,14 @@ FiberSD::FiberSD(const std::string& iname, const DDCompactView & cpv,
   SensitiveCaloDetector(iname, cpv, clg, p),
   m_trackManager(manager), theHCID(-1), theHC(nullptr) {
 
-  collectionName.insert(iname);
-  LogDebug("FiberSim") << "***************************************************"
-		       << "\n"
-		       << "*                                                 *"
-		       << "\n"
-		       << "* Constructing a FiberSD  with name " << GetName()
-		       << "\n"
-		       << "*                                                 *"
-		       << "\n"
-		       << "***************************************************";
   theShower = new HFShower(iname, cpv, p, 1);
 
-  //
-  // Now attach the right detectors (LogicalVolumes) to me
-  //
-  const std::vector<std::string>& lvNames = clg.logicalNames(iname);
-  this->Register();
-  for (std::vector<std::string>::const_iterator it=lvNames.begin();
-       it !=lvNames.end(); it++){
-    this->AssignSD(*it);
-    LogDebug("FiberSim") << "FiberSD : Assigns SD to LV " << (*it);
-  }
 }
 
 FiberSD::~FiberSD() {
  
-  if (theShower) delete theShower;
-  if (theHC)     delete theHC;
+  delete theShower;
+  delete theHC;
 }
 
 void FiberSD::Initialize(G4HCofThisEvent * HCE) {

--- a/SimG4CMS/ShowerLibraryProducer/src/HFChamberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HFChamberSD.cc
@@ -16,10 +16,10 @@
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
 
-HFChamberSD::HFChamberSD(std::string name, const DDCompactView & cpv,
+HFChamberSD::HFChamberSD(const std::string& name, const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg, edm::ParameterSet const & p,
 		 const SimTrackManager* manager) :
-  SensitiveCaloDetector(name, cpv, clg, p), theName(name),
+  SensitiveCaloDetector(name, cpv, clg, p), 
   m_trackManager(manager), theHCID(-1), theHC(nullptr), theNSteps(0) {
 
   collectionName.insert(name);
@@ -111,9 +111,9 @@ void HFChamberSD::PrintAll() {}
 
 void HFChamberSD::clearHits() {}
 
-uint32_t HFChamberSD::setDetUnitId(G4Step* aStep) {
+uint32_t HFChamberSD::setDetUnitId(const G4Step* aStep) {
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   return (touch->GetReplicaNumber(0));
 }
 
-void HFChamberSD::fillHits(edm::PCaloHitContainer&, std::string) {}
+void HFChamberSD::fillHits(edm::PCaloHitContainer&, const std::string&) {}

--- a/SimG4CMS/ShowerLibraryProducer/src/HFChamberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HFChamberSD.cc
@@ -22,30 +22,10 @@ HFChamberSD::HFChamberSD(const std::string& name, const DDCompactView & cpv,
   SensitiveCaloDetector(name, cpv, clg, p), 
   m_trackManager(manager), theHCID(-1), theHC(nullptr), theNSteps(0) {
 
-  collectionName.insert(name);
-  LogDebug("FiberSim") << "***************************************************"
-		       << "\n"
-		       << "*                                                 *"
-		       << "\n"
-		       << "* Constructing a HFChamberSD  with name " << GetName()
-		       << "\n"
-		       << "*                                                 *"
-		       << "\n"
-		       << "***************************************************";
-  //
-  // Now attach the right detectors (LogicalVolumes) to me
-  //
-  const std::vector<std::string>& lvNames = clg.logicalNames(name);
-  this->Register();
-  for (std::vector<std::string>::const_iterator it=lvNames.begin();
-       it !=lvNames.end(); it++){
-    this->AssignSD(*it);
-    LogDebug("FiberSim") << "HFChamberSD : Assigns SD to LV " << (*it);
-  }
 }
 
 HFChamberSD::~HFChamberSD() {
-  if (theHC)    delete theHC;
+  delete theHC;
 }
 
 void HFChamberSD::Initialize(G4HCofThisEvent * HCE) {

--- a/SimG4CMS/ShowerLibraryProducer/src/HFWedgeSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HFWedgeSD.cc
@@ -16,13 +16,13 @@
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
 
-HFWedgeSD::HFWedgeSD(std::string name, const DDCompactView & cpv, 
-		 const SensitiveDetectorCatalog & clg, edm::ParameterSet const & p,
-		 const SimTrackManager* manager) :
-  SensitiveCaloDetector(name, cpv, clg, p), theName(name),
+HFWedgeSD::HFWedgeSD(const std::string& iname, const DDCompactView & cpv, 
+		     const SensitiveDetectorCatalog & clg, edm::ParameterSet const & p,
+		     const SimTrackManager* manager) :
+  SensitiveCaloDetector(iname, cpv, clg, p),
   m_trackManager(manager), hcID(-1), theHC(nullptr), currentHit(nullptr) {
 
-  collectionName.insert(name);
+  collectionName.insert(iname);
   LogDebug("FiberSim") << "***************************************************"
 		       << "\n"
 		       << "*                                                 *"
@@ -35,7 +35,7 @@ HFWedgeSD::HFWedgeSD(std::string name, const DDCompactView & cpv,
   //
   // Now attach the right detectors (LogicalVolumes) to me
   //
-  const std::vector<std::string>& lvNames = clg.logicalNames(name);
+  const std::vector<std::string>& lvNames = clg.logicalNames(iname);
   this->Register();
   for (std::vector<std::string>::const_iterator it=lvNames.begin();
        it !=lvNames.end(); it++){
@@ -145,9 +145,9 @@ void HFWedgeSD::clearHits() {
   previousID = -1;
 }
 
-uint32_t HFWedgeSD::setDetUnitId(G4Step* aStep) {
+uint32_t HFWedgeSD::setDetUnitId(const G4Step* aStep) {
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   return (touch->GetReplicaNumber(0));
 }
 
-void HFWedgeSD::fillHits(edm::PCaloHitContainer&, std::string) {}
+void HFWedgeSD::fillHits(edm::PCaloHitContainer&, const std::string&) {}

--- a/SimG4CMS/ShowerLibraryProducer/src/HFWedgeSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HFWedgeSD.cc
@@ -22,30 +22,10 @@ HFWedgeSD::HFWedgeSD(const std::string& iname, const DDCompactView & cpv,
   SensitiveCaloDetector(iname, cpv, clg, p),
   m_trackManager(manager), hcID(-1), theHC(nullptr), currentHit(nullptr) {
 
-  collectionName.insert(iname);
-  LogDebug("FiberSim") << "***************************************************"
-		       << "\n"
-		       << "*                                                 *"
-		       << "\n"
-		       << "* Constructing a HFWedgeSD  with name " << GetName()
-		       << "\n"
-		       << "*                                                 *"
-		       << "\n"
-		       << "***************************************************";
-  //
-  // Now attach the right detectors (LogicalVolumes) to me
-  //
-  const std::vector<std::string>& lvNames = clg.logicalNames(iname);
-  this->Register();
-  for (std::vector<std::string>::const_iterator it=lvNames.begin();
-       it !=lvNames.end(); it++){
-    this->AssignSD(*it);
-    LogDebug("FiberSim") << "HFWedgeSD : Assigns SD to LV " << (*it);
-  }
 }
 
 HFWedgeSD::~HFWedgeSD() {
-  if (theHC)    delete theHC;
+  delete theHC;
 }
 
 void HFWedgeSD::Initialize(G4HCofThisEvent * HCE) {

--- a/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
+++ b/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
@@ -34,17 +34,18 @@ public Observer<const BeginOfTrack*>,
 public Observer<const BeginOfJob*>
 { 
 public:    
-    TkAccumulatingSensitiveDetector(std::string, const DDCompactView &,
+    TkAccumulatingSensitiveDetector(const std::string&, const DDCompactView &,
 				    const SensitiveDetectorCatalog &,
 				    edm::ParameterSet const &,
 				    const SimTrackManager*);
     ~TkAccumulatingSensitiveDetector() override;
     bool ProcessHits(G4Step *,G4TouchableHistory *) override;
-    uint32_t setDetUnitId(G4Step*) override;
+    uint32_t setDetUnitId(const G4Step*) override;
     void EndOfEvent(G4HCofThisEvent*) override;
 
-    void fillHits(edm::PSimHitContainer&, std::string use) override;
-    std::vector<std::string> getNames() override;
+    void fillHits(edm::PSimHitContainer&, const std::string&) override;
+    void clearHits() override;
+
     std::string type();
 
 private:
@@ -57,10 +58,9 @@ private:
     void update(const BeginOfEvent *) override;
     void update(const BeginOfTrack *) override;
     void update(const BeginOfJob *) override;
-    void clearHits() override;
     Local3DPoint toOrcaRef(Local3DPoint ,G4VPhysicalVolume *);
     int tofBin(float);
-    std::string myName; 
+
     TrackingSlaveSD * slaveLowTof;
     TrackingSlaveSD * slaveHighTof;
     FrameRotation * myRotation;

--- a/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
+++ b/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
@@ -66,9 +66,10 @@ TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(const std::stri
   energyCut           = m_TrackerSD.getParameter<double>("EnergyThresholdForPersistencyInGeV")*GeV; //default must be 0.5
   energyHistoryCut    = m_TrackerSD.getParameter<double>("EnergyThresholdForHistoryInGeV")*GeV;//default must be 0.05
 
-  edm::LogInfo("TrackerSimInfo") <<"Criteria for Saving Tracker SimTracks:  ";
-  edm::LogInfo("TrackerSimInfo")<<" History: "<<energyHistoryCut<< " MeV ; Persistency: "<< energyCut<<" MeV ";
-  edm::LogInfo("TrackerSimInfo")<<" Constructing a TkAccumulatingSensitiveDetector with ";
+  edm::LogInfo("TrackerSimInfo")<<" TkAccumulatingSensitiveDetector: " 
+                                <<" Criteria for Saving Tracker SimTracks: \n"
+                                <<" History: "<<energyHistoryCut<< " MeV ; Persistency: "
+                                << energyCut<<" MeV ";
 
 #ifndef FAKEFRAMEROTATION
   // No Rotation given in input, automagically choose one based upon the name
@@ -97,15 +98,6 @@ TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(const std::stri
   temp.push_back(slaveLowTof->name());
   temp.push_back(slaveHighTof->name());
   setNames(temp);  
-
-  // Now attach the right detectors (LogicalVolumes) to me
-  const std::vector<std::string>&  lvNames = clg.logicalNames(name);
-  this->Register();
-  for (auto & lvnam : lvNames)
-    {
-      edm::LogInfo("TrackerSimInfo")<< name << " attaching LV " << lvnam;
-      this->AssignSD(lvnam);
-    }
 
   theG4ProcessTypeEnumerator = new G4ProcessTypeEnumerator;
   myG4TrackToParticleID = new G4TrackToParticleID;

--- a/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
+++ b/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
@@ -33,24 +33,12 @@
 
 #include "G4SystemOfUnits.hh"
 
-
-#include <string>
 #include <vector>
 #include <iostream>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //#define FAKEFRAMEROTATION
-//#define DUMPPROCESSES
-
-#ifdef DUMPPROCESSES
-#include "G4VProcess.hh"
-#endif
-
-using std::cout;
-using std::endl;
-using std::vector;
-using std::string;
 
 static 
 TrackerG4SimHitNumberingScheme&
@@ -60,13 +48,12 @@ numberingScheme(const DDCompactView& cpv, const GeometricDet& det)
    return s_scheme;
 }
 
-
-TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(string name, 
+TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(const std::string& name, 
 								 const DDCompactView & cpv,
 								 const SensitiveDetectorCatalog & clg,
 								 edm::ParameterSet const & p,
 								 const SimTrackManager* manager) : 
-  SensitiveTkDetector(name, cpv, clg, p), myName(name), myRotation(nullptr),  mySimHit(nullptr),theManager(manager),
+  SensitiveTkDetector(name, cpv, clg, p), myRotation(nullptr),  mySimHit(nullptr),theManager(manager),
    oldVolume(nullptr), lastId(0), lastTrack(0), eventno(0) ,rTracker(1200.*mm),zTracker(3000.*mm),
    numberingScheme_(nullptr)
 {
@@ -85,15 +72,17 @@ TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(string name,
 
 #ifndef FAKEFRAMEROTATION
   // No Rotation given in input, automagically choose one based upon the name
-  if (name.find("TrackerHits") != string::npos) 
+  if (name.find("TrackerHits") != std::string::npos) 
     {
-      edm::LogInfo("TrackerSimInfo")<<" TkAccumulatingSensitiveDetector: using TrackerFrameRotation for "<<myName;
+      edm::LogInfo("TrackerSimInfo")
+	<<" TkAccumulatingSensitiveDetector: using TrackerFrameRotation for "<<name;
       myRotation = new TrackerFrameRotation;
     }
   // Just in case (test beam etc)
   if (myRotation == nullptr) 
     {
-      edm::LogInfo("TrackerSimInfo")<<" TkAccumulatingSensitiveDetector: using StandardFrameRotation for "<<myName;
+      edm::LogInfo("TrackerSimInfo")
+	<<" TkAccumulatingSensitiveDetector: using StandardFrameRotation for "<<name;
       myRotation = new StandardFrameRotation;
     }
 #else
@@ -101,20 +90,25 @@ TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(string name,
   edm::LogWarning("TrackerSimInfo")<< " WARNING - Using FakeFrameRotation in TkAccumulatingSensitiveDetector;";  
 #endif
 
-    slaveLowTof  = new TrackingSlaveSD(name+"LowTof");
-    slaveHighTof = new TrackingSlaveSD(name+"HighTof");
+  slaveLowTof  = new TrackingSlaveSD(name+"LowTof");
+  slaveHighTof = new TrackingSlaveSD(name+"HighTof");
   
-    // Now attach the right detectors (LogicalVolumes) to me
-    const vector<string>&  lvNames = clg.logicalNames(name);
-    this->Register();
-    for (vector<string>::const_iterator it = lvNames.begin();  it != lvNames.end(); it++)
+  std::vector<std::string> temp;
+  temp.push_back(slaveLowTof->name());
+  temp.push_back(slaveHighTof->name());
+  setNames(temp);  
+
+  // Now attach the right detectors (LogicalVolumes) to me
+  const std::vector<std::string>&  lvNames = clg.logicalNames(name);
+  this->Register();
+  for (auto & lvnam : lvNames)
     {
-      edm::LogInfo("TrackerSimInfo")<< name << " attaching LV " << *it;
-	this->AssignSD(*it);
+      edm::LogInfo("TrackerSimInfo")<< name << " attaching LV " << lvnam;
+      this->AssignSD(lvnam);
     }
 
-    theG4ProcessTypeEnumerator = new G4ProcessTypeEnumerator;
-    myG4TrackToParticleID = new G4TrackToParticleID;
+  theG4ProcessTypeEnumerator = new G4ProcessTypeEnumerator;
+  myG4TrackToParticleID = new G4TrackToParticleID;
 }
 
 TkAccumulatingSensitiveDetector::~TkAccumulatingSensitiveDetector() 
@@ -149,19 +143,14 @@ bool TkAccumulatingSensitiveDetector::ProcessHits(G4Step * aStep, G4TouchableHis
     return false;
 }
 
-uint32_t TkAccumulatingSensitiveDetector::setDetUnitId(G4Step * s)
+uint32_t TkAccumulatingSensitiveDetector::setDetUnitId(const G4Step * step)
 { 
- unsigned int detId = numberingScheme_->g4ToNumberingScheme(s->GetPreStepPoint()->GetTouchable());
-
- LogDebug("TrackerSimDebug")<< " DetID = "<<detId; 
-
- return detId;
+  return numberingScheme_->g4ToNumberingScheme(step->GetPreStepPoint()->GetTouchable());
 }
 
 
 int TkAccumulatingSensitiveDetector::tofBin(float tof)
 {
-
     float threshold = 3. * theSigma;
     if (tof < threshold) return 1;
     return 2;
@@ -217,12 +206,9 @@ void TkAccumulatingSensitiveDetector::update(const BeginOfTrack *bot){
       //LogDebug("TrackerSimDebug")<<" POINTER "<<info;
       //LogDebug("TrackerSimDebug")<<" track inside the tracker selected for HISTORY";
       //LogDebug("TrackerSimDebug")<<"Track ID (history track) = "<<gTrack->GetTrackID();
-    }
-    
+    }    
   }
 }
-
-
 
 void TkAccumulatingSensitiveDetector::sendHit()
 {  
@@ -233,7 +219,7 @@ void TkAccumulatingSensitiveDetector::sendHit()
     if (printHits)
     {
 	TkSimHitPrinter thePrinter("TkHitPositionOSCAR.dat");
-	thePrinter.startNewSimHit(myName,oldVolume->GetLogicalVolume()->GetName(),
+	thePrinter.startNewSimHit(GetName(),oldVolume->GetLogicalVolume()->GetName(),
 				  mySimHit->detUnitId(),mySimHit->trackId(),eventno);
 	thePrinter.printLocal(mySimHit->entryPoint(),mySimHit->exitPoint());
 	thePrinter.printGlobal(globalEntryPoint,globalExitPoint);
@@ -413,10 +399,9 @@ bool TkAccumulatingSensitiveDetector::closeHit(G4Step * aStep)
 void TkAccumulatingSensitiveDetector::EndOfEvent(G4HCofThisEvent *)
 {
 
-  LogDebug("TrackerSimDebug")<< " Saving the last hit in a ROU " << myName;
+  LogDebug("TrackerSimDebug")<< " Saving the last hit in a ROU " << GetName();
 
-    if (mySimHit == nullptr) return;
-      sendHit();
+  if (mySimHit != nullptr) sendHit();
 }
 
 void TkAccumulatingSensitiveDetector::update(const BeginOfEvent * i)
@@ -474,19 +459,8 @@ TrackInformation* TkAccumulatingSensitiveDetector::getOrCreateTrackInformation( 
   }
 }
 
-void TkAccumulatingSensitiveDetector::fillHits(edm::PSimHitContainer& c, std::string n){
-  //
-  // do it once for low, once for High
-  //
+void TkAccumulatingSensitiveDetector::fillHits(edm::PSimHitContainer& cc, const std::string& hname){
 
-  if (slaveLowTof->name() == n)  c=slaveLowTof->hits();
-  if (slaveHighTof->name() == n) c=slaveHighTof->hits();
-
-}
-
-std::vector<string> TkAccumulatingSensitiveDetector::getNames(){
-  std::vector<string> temp;
-  temp.push_back(slaveLowTof->name());
-  temp.push_back(slaveHighTof->name());
-  return temp;
+  if (slaveLowTof->name()  == hname)      { cc=slaveLowTof->hits(); }
+  else if (slaveHighTof->name() == hname) { cc=slaveHighTof->hits();}
 }

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -198,7 +198,7 @@ void OscarMTProducer::produce(edm::Event & e, const edm::EventSetup & es)
 
   for (auto & tracker : sTk) {
 
-    std::vector<std::string> v = tracker->getNames();
+    const std::vector<std::string>& v = tracker->getNames();
     for (auto & name : v) {
 
       std::unique_ptr<edm::PSimHitContainer>
@@ -209,7 +209,7 @@ void OscarMTProducer::produce(edm::Event & e, const edm::EventSetup & es)
   }
   for (auto & calo : sCalo) {
 
-    std::vector<std::string> v = calo->getNames();
+    const std::vector<std::string>& v = calo->getNames();
 
     for (auto & name : v) {
 

--- a/SimG4Core/Application/plugins/OscarProducer.cc
+++ b/SimG4Core/Application/plugins/OscarProducer.cc
@@ -187,7 +187,7 @@ void OscarProducer::produce(edm::Event & e, const edm::EventSetup & es)
   
   for (auto & tracker : sTk) {
 
-    std::vector<std::string> v = tracker->getNames();
+    const std::vector<std::string>& v = tracker->getNames();
     for (auto & name : v) {
 
       std::unique_ptr<edm::PSimHitContainer>
@@ -198,7 +198,7 @@ void OscarProducer::produce(edm::Event & e, const edm::EventSetup & es)
   }
   for (auto & calo : sCalo) {
 
-    std::vector<std::string> v = calo->getNames();
+    const std::vector<std::string>& v = calo->getNames();
 
     for (auto & name : v) {
 

--- a/SimG4Core/Geometry/src/DDDWorld.cc
+++ b/SimG4Core/Geometry/src/DDDWorld.cc
@@ -15,7 +15,7 @@ DDDWorld::DDDWorld(const DDCompactView* cpv,
 		   SensitiveDetectorCatalog & catalog,
 		   bool check) {
 
-  std::auto_ptr<DDG4Builder> theBuilder(new DDG4Builder(cpv, check));
+  std::unique_ptr<DDG4Builder> theBuilder(new DDG4Builder(cpv, check));
 
   DDGeometryReturnType ret = theBuilder->BuildGeometry();
   G4LogicalVolume *    world = ret.logicalVolume();

--- a/SimG4Core/GeometryProducer/interface/GeometryProducer.h
+++ b/SimG4Core/GeometryProducer/interface/GeometryProducer.h
@@ -53,8 +53,8 @@ private:
     SimActivityRegistry m_registry;
     std::vector<std::shared_ptr<SimWatcher> > m_watchers;
     std::vector<std::shared_ptr<SimProducer> > m_producers;
-    std::auto_ptr<sim::FieldBuilder> m_fieldBuilder;
-    std::auto_ptr<SimTrackManager> m_trackManager;
+    std::unique_ptr<sim::FieldBuilder> m_fieldBuilder;
+    std::unique_ptr<SimTrackManager> m_trackManager;
     AttachSD * m_attach;
     std::vector<SensitiveTkDetector*> m_sensTkDets;
     std::vector<SensitiveCaloDetector*> m_sensCaloDets;

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -134,7 +134,7 @@ void GeometryProducer::produce(edm::Event & e, const edm::EventSetup & es)
     {
        edm::LogInfo("GeometryProducer") << " instantiating sensitive detectors ";
        // instantiate and attach the sensitive detectors
-       m_trackManager = std::auto_ptr<SimTrackManager>(new SimTrackManager);
+       m_trackManager = std::unique_ptr<SimTrackManager>(new SimTrackManager);
        if (m_attach==nullptr) m_attach = new AttachSD;
        {
            std::pair< std::vector<SensitiveTkDetector*>,

--- a/SimG4Core/SensitiveDetector/interface/AttachSD.h
+++ b/SimG4Core/SensitiveDetector/interface/AttachSD.h
@@ -16,15 +16,16 @@ class SimTrackManager;
 class AttachSD
 {
 public:
-    AttachSD();
-    ~AttachSD();
-    std::pair< std::vector<SensitiveTkDetector*>,
-      std::vector<SensitiveCaloDetector*> > create(const DDDWorld & w, 
-						   const DDCompactView & cpv,
-						   const SensitiveDetectorCatalog & clg,
-						   edm::ParameterSet const & p,
-						   const SimTrackManager* m,
-						   SimActivityRegistry& reg ) const;
+  AttachSD();
+  ~AttachSD();
+
+  std::pair< std::vector<SensitiveTkDetector*>,
+    std::vector<SensitiveCaloDetector*> > 
+    create(const DDDWorld &, const DDCompactView &,
+	   const SensitiveDetectorCatalog &,
+	   edm::ParameterSet const &,
+	   const SimTrackManager*,
+	   SimActivityRegistry& reg ) const;
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/AttachSD.h
+++ b/SimG4Core/SensitiveDetector/interface/AttachSD.h
@@ -1,5 +1,5 @@
-#ifndef SimG4Core_AttachSD_h
-#define SimG4Core_AttachSD_h
+#ifndef SimG4Core_SensitiveDetector_AttachSD_h
+#define SimG4Core_SensitiveDetector_AttachSD_h
 
 
 #include "SimG4Core/Geometry/interface/DDDWorld.h"

--- a/SimG4Core/SensitiveDetector/interface/FrameRotation.h
+++ b/SimG4Core/SensitiveDetector/interface/FrameRotation.h
@@ -1,5 +1,5 @@
-#ifndef SimG4Core_FrameRotation_H
-#define SimG4Core_FrameRotation_H
+#ifndef SimG4Core_SensitiveDetector_FrameRotation_H
+#define SimG4Core_SensitiveDetector_FrameRotation_H
 
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"

--- a/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
@@ -1,5 +1,5 @@
-#ifndef SimG4Core_SensitiveCaloDetector_H
-#define SimG4Core_SensitiveCaloDetector_H
+#ifndef SimG4Core_SensitiveDetector_SensitiveCaloDetector_H
+#define SimG4Core_SensitiveDetector_SensitiveCaloDetector_H
 
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
@@ -10,13 +10,12 @@
 class SensitiveCaloDetector : public SensitiveDetector
 {
 public:
-    SensitiveCaloDetector(std::string & iname, const DDCompactView & cpv,
-			  const SensitiveDetectorCatalog & clg,
-			  edm::ParameterSet const & p) :
-      SensitiveDetector(iname,cpv,clg,p) {}
-    virtual void fillHits(edm::PCaloHitContainer &, std::string name = nullptr) = 0;
+  explicit SensitiveCaloDetector(const std::string & iname, const DDCompactView & cpv,
+				 const SensitiveDetectorCatalog & clg,
+				 edm::ParameterSet const & p) :
+  SensitiveDetector(iname,cpv,clg,p) {}
+
+  virtual void fillHits(edm::PCaloHitContainer &, const std::string& hname) = 0;
 };
 
 #endif
-
-

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -27,13 +27,11 @@ public:
   ~SensitiveDetector() override;
 
   void Initialize(G4HCofThisEvent * eventHC) override;
-  virtual void clearHits() = 0;
   G4bool ProcessHits(G4Step * step ,G4TouchableHistory * tHistory) override = 0;
-  virtual uint32_t setDetUnitId(const G4Step * step) = 0;
   void EndOfEvent(G4HCofThisEvent * eventHC) override;
 
-  void Register();
-  virtual void AssignSD(const std::string & vname);
+  virtual uint32_t setDetUnitId(const G4Step * step) = 0;
+  virtual void clearHits() = 0;
  
   enum coordinates {WorldCoordinates, LocalCoordinates};
   Local3DPoint InitialStepPosition(const G4Step * step, coordinates) const;
@@ -51,6 +49,9 @@ public:
   void NaNTrap(const G4Step* step ) const;
     
 private:
+
+  void AssignSD(const std::string & vname);
+
   std::vector<std::string> namesOfSD;
 };
 

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -9,7 +9,6 @@
 
 #include "G4VSensitiveDetector.hh"
 
-//#include <boost/cstdint.hpp>
 #include <string>
 
 class G4Step;
@@ -21,7 +20,8 @@ class DDCompactView;
 class SensitiveDetector : public G4VSensitiveDetector
 {
 public:
-  explicit SensitiveDetector(const std::string & iname, const DDCompactView & cpv,
+  explicit SensitiveDetector(const std::string & iname, 
+                             const DDCompactView & cpv,
 			     const SensitiveDetectorCatalog & ,
 			     edm::ParameterSet const & p);
   ~SensitiveDetector() override;
@@ -32,7 +32,11 @@ public:
 
   virtual uint32_t setDetUnitId(const G4Step * step) = 0;
   virtual void clearHits() = 0;
+
+  inline const std::vector<std::string>& getNames() const { return namesOfSD; }
  
+protected:
+
   enum coordinates {WorldCoordinates, LocalCoordinates};
   Local3DPoint InitialStepPosition(const G4Step * step, coordinates) const;
   Local3DPoint FinalStepPosition(const G4Step * step, coordinates) const;
@@ -42,10 +46,8 @@ public:
 
   inline Local3DPoint ConvertToLocal3DPoint(const G4ThreeVector& point) const
   { return Local3DPoint(point.x(),point.y(),point.z()); }
-
-  inline const std::vector<std::string>& getNames() const { return namesOfSD; }
   
-  void setNames(std::vector<std::string>&);
+  void setNames(const std::vector<std::string>&);
   void NaNTrap(const G4Step* step ) const;
     
 private:

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -5,12 +5,11 @@
 
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
-#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
 
 #include "G4VSensitiveDetector.hh"
 
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <string>
 
 class G4Step;
@@ -22,34 +21,37 @@ class DDCompactView;
 class SensitiveDetector : public G4VSensitiveDetector
 {
 public:
-  explicit SensitiveDetector(std::string & iname, const DDCompactView & cpv,
+  explicit SensitiveDetector(const std::string & iname, const DDCompactView & cpv,
 			     const SensitiveDetectorCatalog & ,
 			     edm::ParameterSet const & p);
   ~SensitiveDetector() override;
+
   void Initialize(G4HCofThisEvent * eventHC) override;
   virtual void clearHits() = 0;
   G4bool ProcessHits(G4Step * step ,G4TouchableHistory * tHistory) override = 0;
-  virtual uint32_t setDetUnitId(G4Step * step) = 0;
+  virtual uint32_t setDetUnitId(const G4Step * step) = 0;
+  void EndOfEvent(G4HCofThisEvent * eventHC) override;
+
   void Register();
   virtual void AssignSD(const std::string & vname);
-  void EndOfEvent(G4HCofThisEvent * eventHC) override; 
+ 
   enum coordinates {WorldCoordinates, LocalCoordinates};
-  Local3DPoint InitialStepPosition(G4Step * s, coordinates);
-  Local3DPoint FinalStepPosition(G4Step * s, coordinates);
-  Local3DPoint ConvertToLocal3DPoint(const G4ThreeVector& point);    
-  std::string nameOfSD() { return name; }
-  virtual std::vector<std::string> getNames() 
-  {
-    std::vector<std::string> temp;
-    temp.push_back(nameOfSD());
-    return temp;
-  }
+  Local3DPoint InitialStepPosition(const G4Step * step, coordinates) const;
+  Local3DPoint FinalStepPosition(const G4Step * step, coordinates) const;
+
+  Local3DPoint LocalPreStepPosition(const G4Step * step) const;
+  Local3DPoint LocalPostStepPosition(const G4Step * step) const;
+
+  inline Local3DPoint ConvertToLocal3DPoint(const G4ThreeVector& point) const
+  { return Local3DPoint(point.x(),point.y(),point.z()); }
+
+  inline const std::vector<std::string>& getNames() const { return namesOfSD; }
   
-  void NaNTrap( G4Step* step ) ;
+  void setNames(std::vector<std::string>&);
+  void NaNTrap(const G4Step* step ) const;
     
 private:
-  std::string name;
-  G4Step * currentStep;
+  std::vector<std::string> namesOfSD;
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
@@ -1,18 +1,10 @@
-#ifndef SensitiveDetector_SensitiveDetectorMaker_h
-#define SensitiveDetector_SensitiveDetectorMaker_h
+#ifndef SimG4Core_SensitiveDetector_SensitiveDetectorMaker_h
+#define SimG4Core_SensitiveDetector_SensitiveDetectorMaker_h
 // -*- C++ -*-
 //
 // Package:     SensitiveDetector
 // Class  :     SensitiveDetectorMaker
 // 
-/**\class SensitiveDetectorMaker SensitiveDetectorMaker.h SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
-
- Description: <one line class summary>
-
- Usage:
-    <usage>
-
-*/
 //
 // Original Author:  
 //         Created:  Mon Nov 14 11:56:05 EST 2005
@@ -42,10 +34,10 @@ class SensitiveDetectorMaker : public SensitiveDetectorMakerBase
 			const edm::ParameterSet& p,
 			const SimTrackManager* m,
 			SimActivityRegistry& reg,
-			std::auto_ptr<SensitiveTkDetector>& oTK,
-			std::auto_ptr<SensitiveCaloDetector>& oCalo) const override
+			std::unique_ptr<SensitiveTkDetector>& oTK,
+			std::unique_ptr<SensitiveCaloDetector>& oCalo) const override
       {
-	std::auto_ptr<T> returnValue(new T(iname, cpv, clg, p, m));
+	std::unique_ptr<T> returnValue(new T(iname, cpv, clg, p, m));
 	SimActivityRegistryEnroller::enroll(reg, returnValue.get());
 
 	this->convertTo(returnValue.get(), oTK,oCalo);
@@ -53,16 +45,10 @@ class SensitiveDetectorMaker : public SensitiveDetectorMakerBase
 	returnValue.release();
       }
 
-      // ---------- static member functions --------------------
-
-      // ---------- member functions ---------------------------
-
    private:
       SensitiveDetectorMaker(const SensitiveDetectorMaker&) = delete; // stop default
 
       const SensitiveDetectorMaker& operator=(const SensitiveDetectorMaker&) = delete; // stop default
-
-      // ---------- member data --------------------------------
 
 };
 

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
@@ -22,35 +22,30 @@
 template<class T>
 class SensitiveDetectorMaker : public SensitiveDetectorMakerBase
 {
+public:
+  SensitiveDetectorMaker(){}
 
-   public:
-     SensitiveDetectorMaker(){}
-     //virtual ~SensitiveDetectorMaker();
+  // ---------- const member functions ---------------------
+  void make(const std::string& iname,
+	    const DDCompactView& cpv,
+	    const SensitiveDetectorCatalog& clg,
+	    const edm::ParameterSet& p,
+	    const SimTrackManager* man,
+	    SimActivityRegistry& reg,
+	    SensitiveTkDetector* oTK,
+	    SensitiveCaloDetector* oCalo) const override
+  {
+    std::unique_ptr<T> returnValue(new T(iname, cpv, clg, p, man));
+    SimActivityRegistryEnroller::enroll(reg, returnValue.get());
 
-      // ---------- const member functions ---------------------
-      void make(const std::string& iname,
-			const DDCompactView& cpv,
-			const SensitiveDetectorCatalog& clg,
-			const edm::ParameterSet& p,
-			const SimTrackManager* m,
-			SimActivityRegistry& reg,
-			std::unique_ptr<SensitiveTkDetector>& oTK,
-			std::unique_ptr<SensitiveCaloDetector>& oCalo) const override
-      {
-	std::unique_ptr<T> returnValue(new T(iname, cpv, clg, p, m));
-	SimActivityRegistryEnroller::enroll(reg, returnValue.get());
+    convertTo(returnValue.get(), oTK, oCalo);
+    //ownership was passed in the previous function
+    returnValue.release();
+  }
 
-	this->convertTo(returnValue.get(), oTK,oCalo);
-	//ownership was passed in the previous function
-	returnValue.release();
-      }
-
-   private:
-      SensitiveDetectorMaker(const SensitiveDetectorMaker&) = delete; // stop default
-
-      const SensitiveDetectorMaker& operator=(const SensitiveDetectorMaker&) = delete; // stop default
-
+private:
+  SensitiveDetectorMaker(const SensitiveDetectorMaker&) = delete;
+  const SensitiveDetectorMaker& operator=(const SensitiveDetectorMaker&) = delete;
 };
-
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
@@ -32,10 +32,10 @@ public:
 	    const edm::ParameterSet& p,
 	    const SimTrackManager* man,
 	    SimActivityRegistry& reg,
-	    SensitiveTkDetector* oTK,
-	    SensitiveCaloDetector* oCalo) const override
+	    std::auto_ptr<SensitiveTkDetector>& oTK,
+	    std::auto_ptr<SensitiveCaloDetector>& oCalo) const override
   {
-    std::unique_ptr<T> returnValue(new T(iname, cpv, clg, p, man));
+    std::auto_ptr<T> returnValue(new T(iname, cpv, clg, p, man));
     SimActivityRegistryEnroller::enroll(reg, returnValue.get());
 
     convertTo(returnValue.get(), oTK, oCalo);

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
@@ -1,19 +1,10 @@
-#ifndef SensitiveDetector_SensitiveDetectorMakerBase_h
-#define SensitiveDetector_SensitiveDetectorMakerBase_h
+#ifndef SimG4Core_SensitiveDetector_SensitiveDetectorMakerBase_h
+#define SimG4Core_SensitiveDetector_SensitiveDetectorMakerBase_h
 // -*- C++ -*-
 //
 // Package:     SensitiveDetector
 // Class  :     SensitiveDetectorMakerBase
 // 
-/**\class SensitiveDetectorMakerBase SensitiveDetectorMakerBase.h SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
-
- Description: <one line class summary>
-
- Usage:
-    <usage>
-
-*/
-//
 // Original Author:  
 //         Created:  Mon Nov 14 11:50:24 EST 2005
 //
@@ -47,8 +38,8 @@ class SensitiveDetectorMakerBase
 			const edm::ParameterSet& p,
 			const SimTrackManager* m,
 			SimActivityRegistry& reg,
-			std::auto_ptr<SensitiveTkDetector>& oTK,
-			std::auto_ptr<SensitiveCaloDetector>& oCalo) const =0;
+			std::unique_ptr<SensitiveTkDetector>& oTK,
+			std::unique_ptr<SensitiveCaloDetector>& oCalo) const =0;
       
       // ---------- static member functions --------------------
 
@@ -57,14 +48,14 @@ class SensitiveDetectorMakerBase
    protected:
       //used to identify which type of Sensitive Detector we have
       void convertTo( SensitiveTkDetector* iFrom, 
-		      std::auto_ptr<SensitiveTkDetector>& oTo,
-		      std::auto_ptr<SensitiveCaloDetector>&) const{
-	oTo= std::auto_ptr<SensitiveTkDetector>(iFrom);
+		      std::unique_ptr<SensitiveTkDetector>& oTo,
+		      std::unique_ptr<SensitiveCaloDetector>&) const{
+	oTo= std::unique_ptr<SensitiveTkDetector>(iFrom);
       }
       void convertTo( SensitiveCaloDetector* iFrom,
-		      std::auto_ptr<SensitiveTkDetector>&,
-		      std::auto_ptr<SensitiveCaloDetector>& oTo) const{
-	oTo=std::auto_ptr<SensitiveCaloDetector>(iFrom);
+		      std::unique_ptr<SensitiveTkDetector>&,
+		      std::unique_ptr<SensitiveCaloDetector>& oTo) const{
+	oTo=std::unique_ptr<SensitiveCaloDetector>(iFrom);
       }
 
    private:

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
@@ -27,44 +27,37 @@ namespace edm{
 class SensitiveDetectorMakerBase
 {
 
-   public:
-      SensitiveDetectorMakerBase(){}
-      virtual ~SensitiveDetectorMakerBase(){}
+public:
+  SensitiveDetectorMakerBase(){}
+  virtual ~SensitiveDetectorMakerBase(){}
 
-      // ---------- const member functions ---------------------
-      virtual void make(const std::string& iname,
-			const DDCompactView& cpv,
-			const SensitiveDetectorCatalog& clg,
-			const edm::ParameterSet& p,
-			const SimTrackManager* m,
-			SimActivityRegistry& reg,
-			std::unique_ptr<SensitiveTkDetector>& oTK,
-			std::unique_ptr<SensitiveCaloDetector>& oCalo) const =0;
+  // ---------- const member functions ---------------------
+  virtual void make(const std::string& iname,
+		    const DDCompactView& cpv,
+		    const SensitiveDetectorCatalog& clg,
+		    const edm::ParameterSet& p,
+		    const SimTrackManager* man,
+		    SimActivityRegistry& reg,
+		    SensitiveTkDetector* oTK,
+		    SensitiveCaloDetector* oCalo) const =0;
       
-      // ---------- static member functions --------------------
+protected:
+  //used to identify which type of Sensitive Detector we have
+  void convertTo( SensitiveTkDetector* iFrom, 
+		  SensitiveTkDetector* oTo,
+		  SensitiveCaloDetector*) const{
+    oTo = iFrom;
+  }
 
-      // ---------- member functions ---------------------------
+  void convertTo( SensitiveCaloDetector* iFrom,
+		  SensitiveTkDetector*,
+		  SensitiveCaloDetector* oTo) const{
+    oTo = iFrom;
+  }
 
-   protected:
-      //used to identify which type of Sensitive Detector we have
-      void convertTo( SensitiveTkDetector* iFrom, 
-		      std::unique_ptr<SensitiveTkDetector>& oTo,
-		      std::unique_ptr<SensitiveCaloDetector>&) const{
-	oTo= std::unique_ptr<SensitiveTkDetector>(iFrom);
-      }
-      void convertTo( SensitiveCaloDetector* iFrom,
-		      std::unique_ptr<SensitiveTkDetector>&,
-		      std::unique_ptr<SensitiveCaloDetector>& oTo) const{
-	oTo=std::unique_ptr<SensitiveCaloDetector>(iFrom);
-      }
-
-   private:
-      SensitiveDetectorMakerBase(const SensitiveDetectorMakerBase&) = delete; // stop default
-
-      const SensitiveDetectorMakerBase& operator=(const SensitiveDetectorMakerBase&) = delete; // stop default
-
-      // ---------- member data --------------------------------
-
+private:
+  SensitiveDetectorMakerBase(const SensitiveDetectorMakerBase&) = delete;
+  const SensitiveDetectorMakerBase& operator=(const SensitiveDetectorMakerBase&) = delete;
 };
 
 

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
@@ -11,6 +11,7 @@
 
 // system include files
 #include <string>
+#include <memory>
 
 // user include files
 #include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
@@ -38,21 +39,21 @@ public:
 		    const edm::ParameterSet& p,
 		    const SimTrackManager* man,
 		    SimActivityRegistry& reg,
-		    SensitiveTkDetector* oTK,
-		    SensitiveCaloDetector* oCalo) const =0;
+		    std::auto_ptr<SensitiveTkDetector>& oTK,
+		    std::auto_ptr<SensitiveCaloDetector>& oCalo) const =0;
       
 protected:
   //used to identify which type of Sensitive Detector we have
   void convertTo( SensitiveTkDetector* iFrom, 
-		  SensitiveTkDetector* oTo,
-		  SensitiveCaloDetector*) const{
-    oTo = iFrom;
+		  std::auto_ptr<SensitiveTkDetector>& oTo,
+		  std::auto_ptr<SensitiveCaloDetector>) const{
+    oTo = std::auto_ptr<SensitiveTkDetector>(iFrom);
   }
 
   void convertTo( SensitiveCaloDetector* iFrom,
-		  SensitiveTkDetector*,
-		  SensitiveCaloDetector* oTo) const{
-    oTo = iFrom;
+		  std::auto_ptr<SensitiveTkDetector>,
+		  std::auto_ptr<SensitiveCaloDetector>& oTo) const{
+    oTo = std::auto_ptr<SensitiveCaloDetector>(iFrom);
   }
 
 private:

--- a/SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h
@@ -1,5 +1,5 @@
-#ifndef SimG4Core_SensitiveTkDetector_H
-#define SimG4Core_SensitiveTkDetector_H
+#ifndef SimG4Core_SensitiveDetector_SensitiveTkDetector_H
+#define SimG4Core_SensitiveDetector_SensitiveTkDetector_H
 
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
@@ -10,11 +10,11 @@
 class SensitiveTkDetector : public SensitiveDetector
 {
 public:
-    SensitiveTkDetector(std::string & iname, const DDCompactView & cpv,
-			const SensitiveDetectorCatalog & clg,
-			edm::ParameterSet const & p) : 
-      SensitiveDetector(iname, cpv, clg, p) {}
-    virtual void fillHits(edm::PSimHitContainer &, std::string name = nullptr) = 0;
+  explicit SensitiveTkDetector(const std::string & iname, const DDCompactView & cpv,
+			       const SensitiveDetectorCatalog & clg,
+			       edm::ParameterSet const & p) : 
+  SensitiveDetector(iname, cpv, clg, p) {}
+  virtual void fillHits(edm::PSimHitContainer &, const std::string& hname) = 0;
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -1,4 +1,3 @@
-//#include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorFactoryByName.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
 #include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
@@ -6,13 +5,6 @@
 #include <vector>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-using std::vector;
-using std::string;
-using std::cout;
-using std::endl;
-
-// #define DEBUG
 
 AttachSD::AttachSD() {}
 
@@ -27,23 +19,18 @@ AttachSD::create(const DDDWorld & w,
 		 const SimTrackManager* m,
 		 SimActivityRegistry& reg) const
 {
-  std::pair< std::vector<SensitiveTkDetector *>,
-    std::vector<SensitiveCaloDetector*> > detList;
-//#ifdef DEBUG
-  //cout << " Initializing AttachSD " << endl;
+  std::pair< std::vector<SensitiveTkDetector *>,std::vector<SensitiveCaloDetector*> > detList;
   LogDebug("SimG4CoreSensitiveDetector") << " AttachSD: Initializing" ;
-//#endif
   const std::vector<std::string>& rouNames = clg.readoutNames();
-  for (std::vector<std::string>::const_iterator it = rouNames.begin();
-       it != rouNames.end(); it++) {
-    std::string className = clg.className(*it);
-    //std::cout<<" trying to find something for "<<className<<" " <<*it<<std::endl;
-    edm::LogInfo("SimG4CoreSensitiveDetector") << " AttachSD: trying to find something for " << className << " "  << *it ;
-    std::auto_ptr<SensitiveDetectorMakerBase> temp(
-						   SensitiveDetectorPluginFactory::get()->create(className) );
-    std::auto_ptr<SensitiveTkDetector> tkDet;
-    std::auto_ptr<SensitiveCaloDetector> caloDet;
-    temp->make(*it,cpv,clg,p,m,reg,tkDet,caloDet);
+  for (auto & rname : rouNames) {
+    std::string className = clg.className(rname);
+    edm::LogInfo("SimG4CoreSensitiveDetector") << " AttachSD: trying to find something for " 
+					       << className << " "  << rname;
+    std::unique_ptr<SensitiveDetectorMakerBase> 
+      temp(SensitiveDetectorPluginFactory::get()->create(className));
+    std::unique_ptr<SensitiveTkDetector> tkDet;
+    std::unique_ptr<SensitiveCaloDetector> caloDet;
+    temp->make(rname,cpv,clg,p,m,reg,tkDet,caloDet);
     if(tkDet.get()){
       detList.first.push_back(tkDet.get());
       tkDet.release();
@@ -52,10 +39,8 @@ AttachSD::create(const DDDWorld & w,
       detList.second.push_back(caloDet.get());
       caloDet.release();
     }
-//#ifdef DEBUG
-    // cout << " AttachSD: created a " << className << " with name " << *it << endl;
-    LogDebug("SimG4CoreSensitiveDetector") << " AttachSD: created a " << className << " with name " << *it ;
-    //#endif
+    LogDebug("SimG4CoreSensitiveDetector") 
+      << " AttachSD: created a " << className << " with name " << rname;
   }      
   return detList;
 }

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -16,7 +16,7 @@ AttachSD::create(const DDDWorld & w,
 		 const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg,
 		 edm::ParameterSet const & p,
-		 const SimTrackManager* m,
+		 const SimTrackManager* man,
 		 SimActivityRegistry& reg) const
 {
   std::pair< std::vector<SensitiveTkDetector *>,std::vector<SensitiveCaloDetector*> > detList;
@@ -28,16 +28,14 @@ AttachSD::create(const DDDWorld & w,
 					       << className << " "  << rname;
     std::unique_ptr<SensitiveDetectorMakerBase> 
       temp(SensitiveDetectorPluginFactory::get()->create(className));
-    std::unique_ptr<SensitiveTkDetector> tkDet;
-    std::unique_ptr<SensitiveCaloDetector> caloDet;
-    temp->make(rname,cpv,clg,p,m,reg,tkDet,caloDet);
-    if(tkDet.get()){
-      detList.first.push_back(tkDet.get());
-      tkDet.release();
+    SensitiveTkDetector* tkDet = nullptr;
+    SensitiveCaloDetector* caloDet = nullptr;
+    temp.get()->make(rname,cpv,clg,p,man,reg,tkDet,caloDet);
+    if(tkDet){
+      detList.first.push_back(tkDet);
     }
-    if(caloDet.get()){
-      detList.second.push_back(caloDet.get());
-      caloDet.release();
+    if(caloDet){
+      detList.second.push_back(caloDet);
     }
     LogDebug("SimG4CoreSensitiveDetector") 
       << " AttachSD: created a " << className << " with name " << rname;

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -20,25 +20,28 @@ AttachSD::create(const DDDWorld & w,
 		 SimActivityRegistry& reg) const
 {
   std::pair< std::vector<SensitiveTkDetector *>,std::vector<SensitiveCaloDetector*> > detList;
-  LogDebug("SimG4CoreSensitiveDetector") << " AttachSD: Initializing" ;
   const std::vector<std::string>& rouNames = clg.readoutNames();
+  edm::LogInfo("SimG4CoreSensitiveDetector") << " AttachSD: Initializing " 
+					     << rouNames.size() << " SDs";
+  std::unique_ptr<SensitiveDetectorMakerBase> temp; 
   for (auto & rname : rouNames) {
     std::string className = clg.className(rname);
-    edm::LogInfo("SimG4CoreSensitiveDetector") << " AttachSD: trying to find something for " 
-					       << className << " "  << rname;
-    std::unique_ptr<SensitiveDetectorMakerBase> 
-      temp(SensitiveDetectorPluginFactory::get()->create(className));
-    SensitiveTkDetector* tkDet = nullptr;
-    SensitiveCaloDetector* caloDet = nullptr;
+    temp.reset(SensitiveDetectorPluginFactory::get()->create(className));
+    std::auto_ptr<SensitiveTkDetector> tkDet;
+    std::auto_ptr<SensitiveCaloDetector> caloDet;
     temp.get()->make(rname,cpv,clg,p,man,reg,tkDet,caloDet);
-    if(tkDet){
-      detList.first.push_back(tkDet);
+    edm::LogInfo("SimG4CoreSensitiveDetector") 
+      << " AttachSD: created a " << className << " with name " << rname 
+      << " TkDet <" << tkDet.get() << "> caloDet<" << caloDet.get() << ">"
+      << " temp= <" << temp.get() << ">";
+    if(tkDet.get()){
+      detList.first.push_back(tkDet.get());
+      tkDet.release();
     }
-    if(caloDet){
-      detList.second.push_back(caloDet);
+    if(caloDet.get()){
+      detList.second.push_back(caloDet.get());
+      caloDet.release();
     }
-    LogDebug("SimG4CoreSensitiveDetector") 
-      << " AttachSD: created a " << className << " with name " << rname;
   }      
   return detList;
 }

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -98,7 +98,7 @@ void SensitiveDetector::NaNTrap(const G4Step* aStep) const
   if( edm::isNotFinite(xyz) != 0 ) {
 
     const G4VPhysicalVolume* pCurrentVol = aStep->GetPreStepPoint()->GetPhysicalVolume();
-    const G4String NameOfVol = pCurrentVol->GetName();
+    const G4String& NameOfVol = pCurrentVol->GetName();
     throw SimG4Exception( "SimG4CoreSensitiveDetector: Corrupted Event - NaN detected in volume "
 			  + NameOfVol);
   }

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -51,7 +51,7 @@ void SensitiveDetector::AssignSD(const std::string & vname)
   G4LogicalVolumeStore * theStore = G4LogicalVolumeStore::GetInstance();
   for (auto & lv : *theStore)
     {
-      if (vname==lv->GetName()) { 
+      if (vname == lv->GetName()) { 
 	lv->SetSensitiveDetector(this); 
         break;
       }
@@ -99,7 +99,7 @@ Local3DPoint SensitiveDetector::LocalPostStepPosition(const G4Step * step) const
   return ConvertToLocal3DPoint(localCoordinates); 
 }
 
-void SensitiveDetector::setNames(std::vector<std::string>& hnames)
+void SensitiveDetector::setNames(const std::vector<std::string>& hnames)
 {
   namesOfSD.clear();
   namesOfSD = hnames;

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -53,7 +53,6 @@ void SensitiveDetector::AssignSD(const std::string & vname)
     {
       if (vname == lv->GetName()) { 
 	lv->SetSensitiveDetector(this); 
-        break;
       }
     }
 }

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -1,21 +1,23 @@
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
 
+#include "SimG4Core/Notification/interface/SimG4Exception.h"
+#include "FWCore/Utilities/interface/isFinite.h"
+
 #include "G4SDManager.hh"
 #include "G4Step.hh"
 #include "G4StepPoint.hh"
 #include "G4Transform3D.hh"
 #include "G4LogicalVolumeStore.hh"
+#include "G4TouchableHistory.hh"
 
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
-#include "FWCore/Utilities/interface/isFinite.h"
-
-using std::string;
-
-SensitiveDetector::SensitiveDetector(std::string & iname, 
+SensitiveDetector::SensitiveDetector(const std::string & iname, 
 				     const DDCompactView & cpv,
 				     const SensitiveDetectorCatalog & clg,
 				     edm::ParameterSet const & p) :
-  G4VSensitiveDetector(iname), name(iname) {}
+  G4VSensitiveDetector(iname) 
+{
+  namesOfSD.push_back(iname);
+}
 
 SensitiveDetector::~SensitiveDetector() {}
 
@@ -30,97 +32,74 @@ void SensitiveDetector::Register()
 void SensitiveDetector::AssignSD(const std::string & vname)
 {
   G4LogicalVolumeStore * theStore = G4LogicalVolumeStore::GetInstance();
-  G4LogicalVolumeStore::const_iterator it;
-  for (it = theStore->begin(); it != theStore->end(); it++)
+  for (auto & lv : *theStore)
     {
-      G4LogicalVolume * v = *it;
-      if (vname==v->GetName()) { v->SetSensitiveDetector(this); }
+      if (vname==lv->GetName()) { lv->SetSensitiveDetector(this); }
     }
 }
 
 void SensitiveDetector::EndOfEvent(G4HCofThisEvent * eventHC) {}
 
-#include "G4TouchableHistory.hh"
-
-Local3DPoint SensitiveDetector::InitialStepPosition(G4Step * s, coordinates c)
+Local3DPoint SensitiveDetector::InitialStepPosition(const G4Step * step, coordinates cd) const
 {
-    currentStep = s;
-    G4StepPoint * preStepPoint = currentStep->GetPreStepPoint();
-    const G4ThreeVector& globalCoordinates = preStepPoint->GetPosition();
-    if (c == WorldCoordinates) return ConvertToLocal3DPoint(globalCoordinates);
-    G4TouchableHistory * theTouchable=(G4TouchableHistory *)
-                                      (preStepPoint->GetTouchable());
-    G4ThreeVector localCoordinates = theTouchable->GetHistory()
+  const G4StepPoint * preStepPoint = step->GetPreStepPoint();
+  const G4ThreeVector& globalCoordinates = preStepPoint->GetPosition();
+  if (cd == WorldCoordinates) { return ConvertToLocal3DPoint(globalCoordinates); }
+  G4TouchableHistory * theTouchable=(G4TouchableHistory *)(preStepPoint->GetTouchable());
+  const G4ThreeVector localCoordinates = theTouchable->GetHistory()
                   ->GetTopTransform().TransformPoint(globalCoordinates);
-    return ConvertToLocal3DPoint(localCoordinates); 
+  return ConvertToLocal3DPoint(localCoordinates); 
 }
 
-Local3DPoint SensitiveDetector::FinalStepPosition(G4Step * s, coordinates c)
+Local3DPoint SensitiveDetector::FinalStepPosition(const G4Step * step, coordinates cd) const
 {
-    currentStep = s;
-    G4StepPoint * postStepPoint = currentStep->GetPostStepPoint();
-    G4StepPoint * preStepPoint  = currentStep->GetPreStepPoint();
-    const G4ThreeVector& globalCoordinates = postStepPoint->GetPosition();
-    if (c == WorldCoordinates) return ConvertToLocal3DPoint(globalCoordinates);
-    G4TouchableHistory * theTouchable = (G4TouchableHistory *)
-                                        (preStepPoint->GetTouchable());
-    G4ThreeVector localCoordinates = theTouchable->GetHistory()
+  const G4StepPoint * postStepPoint = step->GetPostStepPoint();
+  const G4ThreeVector& globalCoordinates = postStepPoint->GetPosition();
+  if (cd == WorldCoordinates) { return ConvertToLocal3DPoint(globalCoordinates); }
+  const G4StepPoint * preStepPoint  = step->GetPreStepPoint();
+  G4TouchableHistory * theTouchable = (G4TouchableHistory *)(preStepPoint->GetTouchable());
+  const G4ThreeVector localCoordinates = theTouchable->GetHistory()
                   ->GetTopTransform().TransformPoint(globalCoordinates);
-    return ConvertToLocal3DPoint(localCoordinates); 
+  return ConvertToLocal3DPoint(localCoordinates); 
 }
 
-Local3DPoint SensitiveDetector::ConvertToLocal3DPoint(const G4ThreeVector& p)
+Local3DPoint SensitiveDetector::LocalPreStepPosition(const G4Step * step) const
 {
-    return Local3DPoint(p.x(),p.y(),p.z());
+  const G4StepPoint * preStepPoint = step->GetPreStepPoint();
+  G4TouchableHistory * theTouchable=(G4TouchableHistory *)(preStepPoint->GetTouchable());
+  G4ThreeVector localCoordinates = theTouchable->GetHistory()
+    ->GetTopTransform().TransformPoint(preStepPoint->GetPosition());
+  return ConvertToLocal3DPoint(localCoordinates); 
 }
 
-void SensitiveDetector::NaNTrap( G4Step* aStep )
+Local3DPoint SensitiveDetector::LocalPostStepPosition(const G4Step * step) const
 {
+  const G4ThreeVector& globalCoordinates = step->GetPostStepPoint()->GetPosition();
+  G4TouchableHistory * theTouchable = (G4TouchableHistory *)(step->GetPreStepPoint()->GetTouchable());
+  G4ThreeVector localCoordinates = theTouchable->GetHistory()
+    ->GetTopTransform().TransformPoint(globalCoordinates);
+  return ConvertToLocal3DPoint(localCoordinates); 
+}
 
-    if ( aStep == nullptr ) return ;
-    
-    G4Track* CurrentTrk = aStep->GetTrack() ;
-    const G4ThreeVector& CurrentPos = CurrentTrk->GetPosition() ;
-    G4ThreeVector CurrentMom = CurrentTrk->GetMomentum() ;
-    G4VPhysicalVolume* pCurrentVol = CurrentTrk->GetVolume() ;
-    G4String NameOfVol ;
-    if ( pCurrentVol != nullptr )
-    {
-       NameOfVol = pCurrentVol->GetName() ;
-    }
-    else
-    {
-       NameOfVol = "CorruptedVolumeInfo" ;
-    }
-    
-    // for simplicity... maybe edm::isNotFinite() will work on the 
-    // 3-vector directly...
+void SensitiveDetector::setNames(std::vector<std::string>& hnames)
+{
+  namesOfSD.clear();
+  namesOfSD = hnames;
+}
 
-    double xyz[3] ;
-    xyz[0] = CurrentPos.x() ;
-    xyz[1] = CurrentPos.y() ;
-    xyz[2] = CurrentPos.z() ;
-    
-    //
-    // this is another trick to check on a NaN, maybe it's even CPU-faster...
-    // but ler's stick to system function edm::isNotFinite(...) for now
-    //
-    // if ( !(xyz[0]==xyz[0]) || !(xyz[1]==xyz[1]) || !(xyz[2]==xyz[2]) )
-    if( edm::isNotFinite(xyz[0]+xyz[1]+xyz[2]) != 0 )
-    {
-      throw SimG4Exception( "SimG4CoreSensitiveDetector: Corrupted Event - NaN detected (position) in volume " + NameOfVol);
-    }
+void SensitiveDetector::NaNTrap(const G4Step* aStep) const
+{
+  const G4Track* CurrentTrk = aStep->GetTrack();
+  const G4ThreeVector& CurrentPos = CurrentTrk->GetPosition();
+  double xyz = CurrentPos.x() + CurrentPos.y() + CurrentPos.z();
+  const G4ThreeVector& CurrentMom = CurrentTrk->GetMomentum();
+  xyz += CurrentMom.x() + CurrentMom.y() + CurrentMom.z();
 
-    xyz[0] = CurrentMom.x() ;
-    xyz[1] = CurrentMom.y() ;
-    xyz[2] = CurrentMom.z() ;
-    if ( !(xyz[0]==xyz[0]) || !(xyz[1]==xyz[1]) || !(xyz[2]==xyz[2]) ||
-         edm::isNotFinite(xyz[0]) != 0 || edm::isNotFinite(xyz[1]) != 0 || 
-	 edm::isNotFinite(xyz[2]) != 0 )
-    {
-      throw SimG4Exception( "SimG4CoreSensitiveDetector: Corrupted Event - NaN detected (3-momentum) in volume " + NameOfVol);
-    }
+  if( edm::isNotFinite(xyz) != 0 ) {
 
-   return;
-
+    const G4VPhysicalVolume* pCurrentVol = aStep->GetPreStepPoint()->GetPhysicalVolume();
+    const G4String NameOfVol = pCurrentVol->GetName();
+    throw SimG4Exception( "SimG4CoreSensitiveDetector: Corrupted Event - NaN detected in volume "
+			  + NameOfVol);
+  }
 }


### PR DESCRIPTION
Geant4 sensitive detectors were developed at different time by different developers, it turn out that there are a lot of duplicated code, variable shadowing, many protected members in base and derived classes. There is a possibility to make code faster and be more clean but any such change requires editions in many files. This is a first clean-up, which includes:
  1) use of const pointers and references were possible
  2) removal of all protected members from the base class
  3) implement common intialisation in the base class
  4) substitute remaining auto_ptr by std::unique_ptr
No change of algorithms, so expected unchanged results.