### PR TITLE
Added missing includes to SUSYDQMAnalyzer.h

### DIFF
--- a/DQMOffline/JetMET/interface/SUSYDQMAnalyzer.h
+++ b/DQMOffline/JetMET/interface/SUSYDQMAnalyzer.h
@@ -16,6 +16,10 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#include "DataFormats/METReco/interface/PFMETCollection.h"
+#include "DataFormats/METReco/interface/CaloMETCollection.h"
+
 #include <string>
 
 


### PR DESCRIPTION
We use PFMETCollection, CaloJetCollection and CaloMETCollection
in this header (lines 33-37), so we also need to include the
associated files to make this header parsable on its own.