### PR TITLE
Added include for cmath to special_less.h

### DIFF
--- a/DQMOffline/JetMET/interface/SusyDQM/special_less.h
+++ b/DQMOffline/JetMET/interface/SusyDQM/special_less.h
@@ -1,6 +1,7 @@
 #ifndef SPECIAL_LESS
 #define SPECIAL_LESS
 
+#include <cmath>
 #include <functional>
 
 struct fabs_less { 


### PR DESCRIPTION
We use fabs in this header, so we also need to include the
associtated header to make this file parsable on its own.