### PR TITLE
Added include to FTLRecHit.h to FTLRecHitComparison.h

### DIFF
--- a/DataFormats/FTLRecHit/interface/FTLRecHitComparison.h
+++ b/DataFormats/FTLRecHit/interface/FTLRecHitComparison.h
@@ -1,6 +1,8 @@
 #ifndef DataFormats_FTLRecHitComparison_H
 #define DataFormats_FTLRecHitComparison_H
 
+#include "DataFormats/FTLRecHit/interface/FTLRecHit.h"
+
 //ordering capability mandatory for lazy getter framework
 // Comparison operators
 inline bool operator<( const FTLRecHit& one, const FTLRecHit& other) {


### PR DESCRIPTION
We use FTLRecHit in this header, so we also need to include the
associated header to make this file parsable on its own.