### PR TITLE
Migrated HGCFETriggerDigiFwd.h to HGCFETriggerDigiDefs.h

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCFETriggerDigiDefs.h
+++ b/DataFormats/L1THGCal/interface/HGCFETriggerDigiDefs.h
@@ -8,10 +8,9 @@
 
 #include "DataFormats/Common/interface/SortedCollection.h"
 
-namespace l1t {
-  //fwd decl. of FETriggerDigi
-  class HGCFETriggerDigi;
+#include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
 
+namespace l1t {
   // main collection type
   typedef edm::SortedCollection<HGCFETriggerDigi> HGCFETriggerDigiCollection;
 

--- a/DataFormats/L1THGCal/src/classes.h
+++ b/DataFormats/L1THGCal/src/classes.h
@@ -1,5 +1,5 @@
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
-#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiFwd.h"
+#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiDefs.h"
 
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/PtrVector.h"

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerBackendAlgorithmBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerBackendAlgorithmBase.h
@@ -6,7 +6,7 @@
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
-#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiFwd.h"
+#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiDefs.h"
 
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerBackendProcessor.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerBackendProcessor.h
@@ -6,7 +6,7 @@
 #include "FWCore/Framework/interface/Event.h"
 
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
-#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiFwd.h"
+#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiDefs.h"
 
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiFEReproducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiFEReproducer.cc
@@ -6,7 +6,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
-#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiFwd.h"
+#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiDefs.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 
 #include "Geometry/Records/interface/CaloGeometryRecord.h"

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
@@ -6,7 +6,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
-#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiFwd.h"
+#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiDefs.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 
 #include "Geometry/Records/interface/CaloGeometryRecord.h"

--- a/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTester.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTester.cc
@@ -16,7 +16,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
-#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiFwd.h"
+#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiDefs.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 

--- a/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTriggerCellTester.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerBestChoiceTriggerCellTester.cc
@@ -16,7 +16,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
-#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiFwd.h"
+#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiDefs.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 

--- a/L1Trigger/L1THGCal/test/HGCalTriggerThresholdTriggerCellTester.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerThresholdTriggerCellTester.cc
@@ -16,7 +16,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
-#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiFwd.h"
+#include "DataFormats/L1THGCal/interface/HGCFETriggerDigiDefs.h"
 #include "DataFormats/L1THGCal/interface/HGCalCluster.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 


### PR DESCRIPTION
As discussed in PR #18805, the Fwd.h headers need a definition of
the specific class they wrap. We do the same as we did for this PR
by renaming th efile to *Defs.h and actually including
HGCFETriggerDigi.