### PR TITLE
Include cstdint in TotemFEDInfo.H

### DIFF
--- a/DataFormats/CTPPSDigi/interface/TotemFEDInfo.h
+++ b/DataFormats/CTPPSDigi/interface/TotemFEDInfo.h
@@ -9,6 +9,8 @@
 #ifndef DataFormats_CTPPSDigi_TotemFEDInfo
 #define DataFormats_CTPPSDigi_TotemFEDInfo
 
+#include <cstdint>
+
 /**
  * \brief OptoRx headers and footers.
  **/


### PR DESCRIPTION
We use uint32_t in this header, so we also need to include `cstdint`
to make this file parsable on its own.