### PR TITLE
Added cstdint include to DataFormats/CTPPSReco headers

### DIFF
--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -9,6 +9,8 @@
 #ifndef DataFormats_CTPPSReco_CTPPSLocalTrackLite
 #define DataFormats_CTPPSReco_CTPPSLocalTrackLite
 
+#include <cstdint>
+
 /**
  *\brief Local (=single RP) track with essential information only.
  **/

--- a/DataFormats/CTPPSReco/interface/TotemRPCluster.h
+++ b/DataFormats/CTPPSReco/interface/TotemRPCluster.h
@@ -10,6 +10,8 @@
 #ifndef DataFormats_CTPPSReco_TotemRPCluster
 #define DataFormats_CTPPSReco_TotemRPCluster
 
+#include <cstdint>
+
 /**
  *\brief Cluster of TOTEM RP strip hits.
  **/


### PR DESCRIPTION
These two headers both use uint32_t, so they also need to include
`cstdint` to make them parsable on their own.