### PR TITLE
Cleanup SCEnergyCorrections.h

### DIFF
--- a/ElectroWeakAnalysis/ZEE/interface/SCEnergyCorrections.h
+++ b/ElectroWeakAnalysis/ZEE/interface/SCEnergyCorrections.h
@@ -1,4 +1,11 @@
+#ifndef SCEnergyCorrections_h
+#define SCEnergyCorrections_h
+
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 reco::CaloClusterPtrVector CaloClusterVectorCopier(const reco::SuperCluster& sc);
 
@@ -112,3 +119,5 @@ reco::CaloClusterPtrVector CaloClusterVectorCopier(const reco::SuperCluster& sc)
 
 	return clusters_v;
 }
+
+#endif SCEnergyCorrections_h


### PR DESCRIPTION
This file needs header guards. It also references SuperCluster,
CaloClusterPtrVector and ParameterSet, so we also need to include
the associated headers to make this file parsable on its own.