### PR TITLE
Added missing includes to UECalibration.h

### DIFF
--- a/RecoHI/HiJetAlgos/interface/UECalibration.h
+++ b/RecoHI/HiJetAlgos/interface/UECalibration.h
@@ -5,6 +5,8 @@
 // SVD Block Predictor
 #include <fstream>
 #include <sstream>
+#include <vector>
+#include <cstring>
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 


### PR DESCRIPTION
We use vector and memset in this header, so we also need to include
the associated headers to make this file parsable on its own.