### PR TITLE
Added missing include to MuonArbitrationMethods.h

### DIFF
--- a/RecoMuon/MuonIdentification/interface/MuonArbitrationMethods.h
+++ b/RecoMuon/MuonIdentification/interface/MuonArbitrationMethods.h
@@ -2,6 +2,7 @@
 #define MuonIdentification_MuonArbitrationMethods_h
 
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
+#include "DataFormats/MuonReco/interface/MuonChamberMatch.h"
 
 // Author: Jake Ribnik (UCSB)
 


### PR DESCRIPTION
We use MuonChamberMatch in this header, so we also need to include
the associated header to make this file parseable on its own.