### PR TITLE
Added include for vector to TimeMeasurementSequence.h

### DIFF
--- a/RecoMuon/MuonIdentification/interface/TimeMeasurementSequence.h
+++ b/RecoMuon/MuonIdentification/interface/TimeMeasurementSequence.h
@@ -10,6 +10,8 @@
  *
  */
 
+#include <vector>
+
 class TimeMeasurementSequence {
 
     public:


### PR DESCRIPTION
We use std::vector in this file, so we also need to include
the associated header to make this file parsable on its own.