### PR TITLE
Added include for vector to MuonArbitrationMethods.h

### DIFF
--- a/RecoMuon/MuonIdentification/interface/MuonArbitrationMethods.h
+++ b/RecoMuon/MuonIdentification/interface/MuonArbitrationMethods.h
@@ -3,6 +3,8 @@
 
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 
+#include <utility>
+
 // Author: Jake Ribnik (UCSB)
 
 /// functor predicate for standard library sort algorithm


### PR DESCRIPTION
We use std::vector in this file, so we also need to include
the associated header to make this file parsable on its own.