### PR TITLE
Actually cindelu CSCDMBHeader.h in CSCDMBTrailer2005/2013.h

### DIFF
--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2005.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2005.h
@@ -2,9 +2,8 @@
 #define CSCDMBTrailer2005_h
 
 #include "DataFormats/CSCDigi/interface/CSCDMBStatusDigi.h"
+#include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBTrailerFormat.h"
-
-class CSCDMBHeader;
 
 struct CSCDMBTrailer2005: public CSCVDMBTrailerFormat {
 // public:

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2013.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2013.h
@@ -36,9 +36,8 @@
 
 #include <iostream>
 #include "DataFormats/CSCDigi/interface/CSCDMBStatusDigi.h"
+#include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBTrailerFormat.h"
-
-class CSCDMBHeader;
 
 struct CSCDMBTrailer2013: public CSCVDMBTrailerFormat {
 // public:


### PR DESCRIPTION
We require the definition of this class in this piece of code:
```C++
      bits.dmb_id = dmbHeader.dmbID();
                             ^
```

So we actually have to include the header to make this file
parsable on its own.