### PR TITLE
Added UtilsFuncs.h include to HLTDQMFilter*.h

### DIFF
--- a/DQMOffline/Trigger/interface/HLTDQMFilterEffHists.h
+++ b/DQMOffline/Trigger/interface/HLTDQMFilterEffHists.h
@@ -30,6 +30,7 @@
 #include "DQMOffline/Trigger/interface/HLTDQMHist.h"
 #include "DQMOffline/Trigger/interface/VarRangeCutColl.h"
 #include "DQMOffline/Trigger/interface/FunctionDefs.h"
+#include "DQMOffline/Trigger/interface/UtilFuncs.h"
 
 template <typename ObjType> 
 class HLTDQMFilterEffHists {

--- a/DQMOffline/Trigger/interface/HLTDQMFilterTnPEffHists.h
+++ b/DQMOffline/Trigger/interface/HLTDQMFilterTnPEffHists.h
@@ -21,6 +21,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DQMOffline/Trigger/interface/HLTDQMFilterEffHists.h"
+#include "DQMOffline/Trigger/interface/UtilFuncs.h"
 
 #include <string>
 


### PR DESCRIPTION
Both headers reference passTrig from the UtilsFunc.h header but
dont' include this header, so we need to do this to make this
file parsable on its own.