### PR TITLE
Added missing includes to HTLDQMHist.h

### DIFF
--- a/DQMOffline/Trigger/interface/HLTDQMHist.h
+++ b/DQMOffline/Trigger/interface/HLTDQMHist.h
@@ -23,6 +23,12 @@
 //***********************************************************************************
 
 #include "DQMOffline/Trigger/interface/FunctionDefs.h"
+#include "DQMOffline/Trigger/interface/VarRangeCutColl.h"
+
+#include "FWCore/Framework/interface/Event.h"
+
+#include <TH1.h>
+#include <TH2.h>
 
 //our base class for our histograms
 //takes an object, edm::Event,edm::EventSetup and fills the histogram


### PR DESCRIPTION
We use VarRangeCutColl, TH1, TH2 and Event in this file, so we
also need to include the associated headers to make this file
parsable on its own.