### PR TITLE
Include SiStripFolderOrganizer.h in SiStripMonitorDigi.h

### DIFF
--- a/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
+++ b/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
@@ -20,6 +20,7 @@
 #include "DQM/SiStripCommon/interface/TkHistoMap.h"
 #include "DQM/SiStripCommon/interface/APVShotFinder.h"
 #include "DQM/SiStripCommon/interface/APVShot.h"
+#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 


### PR DESCRIPTION
This header references SiStripFolderOrganizer, so we also need
to include the associated header to make this file parsable on
its own.