### PR TITLE
Include LorentzVectorFwd.h in RazorVarProducer.h

### DIFF
--- a/DQM/DataScouting/interface/RazorVarProducer.h
+++ b/DQM/DataScouting/interface/RazorVarProducer.h
@@ -9,6 +9,7 @@
 
 #include "TLorentzVector.h"
 #include "DataFormats/METReco/interface/CaloMETFwd.h"
+#include "DataFormats/Math/interface/LorentzVectorFwd.h"
 #include <vector>
 
 class RazorVarProducer : public edm::EDProducer {


### PR DESCRIPTION
We use XYZTLorentzVector in this header, so we also need to include
the associated header to make this file parsable on its own.