### PR TITLE
Actually include DQMStore in VertexMonitor.h

### DIFF
--- a/DQM/TrackingMonitor/interface/VertexMonitor.h
+++ b/DQM/TrackingMonitor/interface/VertexMonitor.h
@@ -21,13 +21,13 @@ Monitoring source for general quantities related to vertex
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 class GetLumi;
-class DQMStore;
 
 class VertexMonitor
 {


### PR DESCRIPTION
We use `DQMStore::IBooker` in this file, so we can't just use a
forward declaration of DQMStore but actually need to include the
associated header to make this file parsable on its own.