### PR TITLE
Added include for ESHandle.h to TrackSplittingMonitor.h

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackSplittingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackSplittingMonitor.h
@@ -16,6 +16,7 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
We use ESHandle in this header, so we also need to include
the associated header to make this file parsable on its own.