### PR TITLE
Added header guards to ThrParameters.h

### DIFF
--- a/RecoMuon/GlobalTrackingTools/interface/ThrParameters.h
+++ b/RecoMuon/GlobalTrackingTools/interface/ThrParameters.h
@@ -1,3 +1,6 @@
+#ifndef RecoMuon_GlobalTrackingTools_ThrParameters_h
+#define RecoMuon_GlobalTrackingTools_ThrParameters_h
+
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "CondFormats/RecoMuonObjects/interface/DYTThrObject.h"
 #include "CondFormats/DataRecord/interface/DYTThrObjectRcd.h"
@@ -34,3 +37,5 @@ class ThrParameters {
   std::map<DTChamberId, GlobalError> dtApeMap;
   std::map<CSCDetId, GlobalError> cscApeMap;
 };
+
+#endif // RecoMuon_GlobalTrackingTools_ThrParameters_h


### PR DESCRIPTION
Part of the work going on regarding the C++ modules migration of CMSSW (tracked as issue https://github.com/cms-sw/cmssw/issues/15248). This PR is not meant to refactor things, but just to make these headers compile.