### PR TITLE
Actually include DQMStore in TrackAnalyzer.h

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -27,7 +27,7 @@ Monitoring source for general quantities related to tracks.
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/Scalers/interface/LumiScalers.h"
 
-class DQMStore;
+#include "DQMServices/Core/interface/DQMStore.h"
 
 class BeamSpot;
 namespace dqm {


### PR DESCRIPTION
We use `DQMStore::IBooker` in this file, so we can't just use a
forward declaration of DQMStore but actually need to include the
associated header to make this file parsable on its own.