### PR TITLE
Added include for ESHandle.h to L1TMenuHelper.h

### DIFF
--- a/DQM/L1TMonitor/interface/L1TMenuHelper.h
+++ b/DQM/L1TMonitor/interface/L1TMenuHelper.h
@@ -18,6 +18,7 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"


### PR DESCRIPTION
We use ESHandle in this header, so we also need to include
the associated header to make this file parsable on its own.