### PR TITLE
Added missing vector includes EMTF

### DIFF
--- a/DataFormats/L1TMuon/interface/EMTF/ME.h
+++ b/DataFormats/L1TMuon/interface/EMTF/ME.h
@@ -5,6 +5,8 @@
 
 #include <boost/cstdint.hpp> 
 
+#include <vector>
+
 namespace l1t {
   namespace emtf {
     class ME {

--- a/DataFormats/L1TMuon/interface/EMTF/RPC.h
+++ b/DataFormats/L1TMuon/interface/EMTF/RPC.h
@@ -5,6 +5,8 @@
 
 #include <boost/cstdint.hpp> 
 
+#include <vector>
+
 namespace l1t {
   namespace emtf {
     class RPC {

--- a/DataFormats/L1TMuon/interface/EMTF/SP.h
+++ b/DataFormats/L1TMuon/interface/EMTF/SP.h
@@ -5,6 +5,8 @@
 
 #include <boost/cstdint.hpp> 
 
+#include <vector>
+
 namespace l1t {
   namespace emtf {
     class SP {


### PR DESCRIPTION
All those headers should include vector to be parsable on their
own.