### PR TITLE
Made ParserFunctions.h standalone

### DIFF
--- a/DQMServices/ClientConfig/interface/ParserFunctions.h
+++ b/DQMServices/ClientConfig/interface/ParserFunctions.h
@@ -1,3 +1,11 @@
+#ifndef ParserFunctions_h
+#define ParserFunctions_h
+
+#include "xercesc/util/XercesDefs.hpp"
+#include "xercesc/parsers/XercesDOMParser.hpp"
+
+#include <string>
+
 namespace qtxml{
 	inline std::string _toString(const XMLCh *toTranscode){
 		std::string tmp(xercesc::XMLString::transcode(toTranscode));
@@ -10,3 +18,4 @@ namespace qtxml{
 	}
 
 }
+#endif // ParserFunctions_h


### PR DESCRIPTION
This patch adds header guards and the relevant includes for the
used Xerces and STL classes to make this file parsable on its own.