### PR TITLE
Added include for ostream to MonitorXMLParser.h

### DIFF
--- a/DQM/EcalMonitorDbModule/interface/MonitorXMLParser.h
+++ b/DQM/EcalMonitorDbModule/interface/MonitorXMLParser.h
@@ -9,6 +9,7 @@
 #define MonitorXMLParser_h
 
 #include <string>
+#include <sstream>
 #include <vector>
 #include <map>
 #include <iostream>


### PR DESCRIPTION
We use std::ostringstream in this header, so we also need to
include the associated header to make this file parsable on its
own.