### PR TITLE
Added missing include to FEDErrors.hh

### DIFF
--- a/DQM/SiStripMonitorHardware/interface/FEDErrors.hh
+++ b/DQM/SiStripMonitorHardware/interface/FEDErrors.hh
@@ -23,6 +23,8 @@
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
+#include "DQMServices/Core/interface/MonitorElement.h"
+
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h"


### PR DESCRIPTION
This header declares a `MonitorElement *aMedianHist0`, so we also
need to include the header associated with MonitorEvent to make
this file parsable on its own.