### PR TITLE
Added missing include to SiStripPayloadInspectorHelper.h

### DIFF
--- a/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
+++ b/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
@@ -9,6 +9,7 @@
 #include "TStyle.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"   
 #include "CondFormats/SiStripObjects/interface/SiStripSummary.h"
+#include "CondFormats/SiStripObjects/interface/SiStripDetSummary.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h" 
 
 namespace SiStripPI {


### PR DESCRIPTION
We reference SiStripDetSummary::Values in this header, so
we also need to include the associated header to make this
file parsable on its own.