### PR TITLE
Added include for Candidate.h to TopProjectorAlgo.h

### DIFF
--- a/CommonTools/ParticleFlow/interface/TopProjectorAlgo.h
+++ b/CommonTools/ParticleFlow/interface/TopProjectorAlgo.h
@@ -17,6 +17,7 @@
 
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 
 


### PR DESCRIPTION
We actually require the definition of Candidate in this header,
so we include the associated header to make this header parsable
on its own.