### PR TITLE
Added include for Event/Parameter set ot CommonTools/ParticleFlow

### DIFF
--- a/CommonTools/ParticleFlow/interface/ElectronIDPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/ElectronIDPFCandidateSelectorDefinition.h
@@ -9,7 +9,9 @@
    \version  $Id: ElectronIDPFCandidateSelectorDefinition.h,v 1.1 2011/01/28 20:56:44 srappocc Exp $
 */
 
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/Common/interface/ValueMap.h"

--- a/CommonTools/ParticleFlow/interface/GenericPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/GenericPFCandidateSelectorDefinition.h
@@ -9,7 +9,9 @@
    \version  $Id: GenericPFCandidateSelectorDefinition.h,v 1.1 2011/01/28 20:56:44 srappocc Exp $
 */
 
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "CommonTools/ParticleFlow/interface/PFCandidateSelectorDefinition.h"

--- a/CommonTools/ParticleFlow/interface/GenericPFJetSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/GenericPFJetSelectorDefinition.h
@@ -2,7 +2,9 @@
 #define CommonTools_ParticleFlow_GenericPFJetSelectorDefinition
 
 
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "CommonTools/ParticleFlow/interface/PFJetSelectorDefinition.h"

--- a/CommonTools/ParticleFlow/interface/IPCutPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/IPCutPFCandidateSelectorDefinition.h
@@ -9,7 +9,9 @@
    \version  $Id: IPCutPFCandidateSelectorDefinition.h,v 1.2 2011/04/06 12:12:38 rwolf Exp $
 */
 
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "CommonTools/ParticleFlow/interface/PFCandidateSelectorDefinition.h"

--- a/CommonTools/ParticleFlow/interface/IsolatedPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/IsolatedPFCandidateSelectorDefinition.h
@@ -1,7 +1,9 @@
 #ifndef CommonTools_ParticleFlow_IsolatedPFCandidateSelectorDefinition
 #define CommonTools_ParticleFlow_IsolatedPFCandidateSelectorDefinition
 
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "CommonTools/ParticleFlow/interface/PFCandidateSelectorDefinition.h"

--- a/CommonTools/ParticleFlow/interface/MuonIDPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/MuonIDPFCandidateSelectorDefinition.h
@@ -9,7 +9,10 @@
    \version  $Id: MuonIDPFCandidateSelectorDefinition.h,v 1.1 2011/01/28 20:56:44 srappocc Exp $
 */
 
+
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/Common/interface/ValueMap.h"

--- a/CommonTools/ParticleFlow/interface/PtMinPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/PtMinPFCandidateSelectorDefinition.h
@@ -1,7 +1,9 @@
 #ifndef CommonTools_ParticleFlow_PtMinPFCandidateSelectorDefinition
 #define CommonTools_ParticleFlow_PtMinPFCandidateSelectorDefinition
 
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "CommonTools/ParticleFlow/interface/PFCandidateSelectorDefinition.h"


### PR DESCRIPTION
All the headers in this subsystem have the same copy pasted includes
and all seem to miss the include for Event/ParameterSet that they
reference in their source. This patch adds all these includes
to make these headers parsable on their own.