### PR TITLE
Added include for SiStripApvGain to SiStripGainsPCLHarvester.h

### DIFF
--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLHarvester.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLHarvester.h
@@ -18,6 +18,7 @@
 //
 
 // CMSSW includes
+#include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"


### PR DESCRIPTION
We reference SiStripApvGain but in this header, so we also
need to include the associated header to make this file
parsable on its own.