### PR TITLE
Added include for Exception.h to InputSource.h/OutputFiles.h

### DIFF
--- a/DataFormats/FWLite/interface/InputSource.h
+++ b/DataFormats/FWLite/interface/InputSource.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 /**
   \class    InputSource InputSource.h "DataFormats/FWLite/interface/InputSource.h"

--- a/DataFormats/FWLite/interface/OutputFiles.h
+++ b/DataFormats/FWLite/interface/OutputFiles.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 /**
   \class    OutputFiles OutputFiles.h "DataFormats/FWLite/interface/OutputFiles.h"


### PR DESCRIPTION
Both headers reference cms::Exception, so we also need to include
the associated headers to make this header parsable on its own.