### PR TITLE
Added missing includes to PrintoutHelper.h

### DIFF
--- a/RecoTracker/CkfPattern/interface/PrintoutHelper.h
+++ b/RecoTracker/CkfPattern/interface/PrintoutHelper.h
@@ -1,6 +1,9 @@
 #ifndef RecoTracker_CkfPattern_PrintoutHelper_h
 #define RecoTracker_CkfPattern_PrintoutHelper_h
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 #include "TrackingTools/PatternTools/interface/bqueue.h"
 


### PR DESCRIPTION
We use LogDebug and Trajectory in this header, so we also need
to include the associated headers to make this header
parsable on its own.