### PR TITLE
Added missing includes to JetAlgoHelper.h

### DIFF
--- a/RecoJets/JetAlgorithms/interface/JetAlgoHelper.h
+++ b/RecoJets/JetAlgorithms/interface/JetAlgoHelper.h
@@ -4,9 +4,11 @@
 // Various simple tools
 // F.Ratnikov, UMd
 
-#include<limits>
+#include <algorithm>
+#include <limits>
 #include <iostream>
 #include <cmath>
+#include <vector>
 
 #include "CommonTools/Utils/interface/PtComparator.h"
 #include "CommonTools/Utils/interface/EtComparator.h"


### PR DESCRIPTION
This header used std::sort and std::vector, so we also need to
include the relevant headers to make this header parsable on its
own.