### PR TITLE
Forward declared Wrapperbase in InternalDataKey.h

### DIFF
--- a/DataFormats/FWLite/interface/InternalDataKey.h
+++ b/DataFormats/FWLite/interface/InternalDataKey.h
@@ -27,6 +27,8 @@
 
 #include <cstring>
 
+namespace edm { class WrapperBase; }
+
 namespace fwlite {
    namespace internal {
       class DataKey {


### PR DESCRIPTION
We use it as a member in this header, so we also should forward
delcare it to make this header parseable on its own.

(No need to include the header here, we only store a pointer).