### PR TITLE
Added missing includes to L1CSCStatusDigiCollection.h

### DIFF
--- a/DataFormats/L1CSCTrackFinder/interface/L1CSCStatusDigiCollection.h
+++ b/DataFormats/L1CSCTrackFinder/interface/L1CSCStatusDigiCollection.h
@@ -1,6 +1,9 @@
 #ifndef L1CSCSPStatusDigiCollection_h
 #define L1CSCSPStatusDigiCollection_h
 
+#include <utility>
+#include <vector>
+
 #include <DataFormats/L1CSCTrackFinder/interface/L1CSCSPStatusDigi.h>
 
 typedef std::pair< int, std::vector<L1CSCSPStatusDigi> > L1CSCStatusDigiCollection;


### PR DESCRIPTION
We use std::pair and std::vector in this header, so we also need
to include `utility` and `vector` to make this header parseable
on its own.