### PR TITLE
Included CaloGeometry.h in eCone.h

### DIFF
--- a/Calibration/IsolatedParticles/interface/eCone.h
+++ b/Calibration/IsolatedParticles/interface/eCone.h
@@ -13,6 +13,8 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 
 namespace spr{


### PR DESCRIPTION
We use CaloGeometry in this header, so we also need to include
the associated header to make this header parsable on its own.