### PR TITLE
Include Sourcevariable.h in SourceVariableSet.h

### DIFF
--- a/PhysicsTools/MVATrainer/interface/SourceVariableSet.h
+++ b/PhysicsTools/MVATrainer/interface/SourceVariableSet.h
@@ -6,10 +6,9 @@
 #include <algorithm>
 
 #include "PhysicsTools/MVAComputer/interface/AtomicId.h"
+#include "PhysicsTools/MVATrainer/interface/SourceVariable.h"
 
 namespace PhysicsTools {
-
-class SourceVariable;
 
 class SourceVariableSet {
     public:


### PR DESCRIPTION
The existing forward decl is not enough for this header to be
parsed as we actually require the definition of SourceVariable
in this line:
```C++
  { return var.var->getName() < name; }
                  ^
```