### PR TITLE
Added missing include to SeedCreatorFromRegionHitsEDProducerT.h

### DIFF
--- a/RecoTracker/TkSeedGenerator/interface/SeedCreatorFromRegionHitsEDProducerT.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedCreatorFromRegionHitsEDProducerT.h
@@ -1,6 +1,7 @@
 #ifndef RecoTracker_TkSeedGenerator_SeedCreatorFromRegionHitsEDProducerT_H
 #define RecoTracker_TkSeedGenerator_SeedCreatorFromRegionHitsEDProducerT_H
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"


### PR DESCRIPTION
We use edm::ConsumesCollector in this header, so we also need
to include the associated header to make this file parsable on
its own.