### PR TITLE
Added include for memory to Table.h

### DIFF
--- a/FWCore/SOA/interface/Table.h
+++ b/FWCore/SOA/interface/Table.h
@@ -114,6 +114,7 @@
 //
 
 // system include files
+#include <memory>
 #include <tuple>
 #include <array>
 


### PR DESCRIPTION
We use unique_ptr in this header, so we also need to include
`memory` to make this header parsable on its own.