### PR TITLE
Added include for cstdint to ESCrcKchipFast.h

### DIFF
--- a/EventFilter/ESRawToDigi/interface/ESCrcKchipFast.h
+++ b/EventFilter/ESRawToDigi/interface/ESCrcKchipFast.h
@@ -1,6 +1,8 @@
 #ifndef ESCrcKchipFast_H
 #define ESCrcKchipFast_H
 
+#include <cstdint>
+
 class ESCrcKchipFast {
 
    private :


### PR DESCRIPTION
We use uint32_t in this file, so we also need to include `cstdint`
to make this header parsable on its own.