### PR TITLE
Added missing include to CastorRawGain.h

### DIFF
--- a/CondFormats/CastorObjects/interface/CastorRawGain.h
+++ b/CondFormats/CastorObjects/interface/CastorRawGain.h
@@ -7,6 +7,7 @@
 POOL object to store raw Gain values
 */
 #include <boost/cstdint.hpp>
+#include <string>
 
 class CastorRawGain {
  public:


### PR DESCRIPTION
We use `std::string` in this header, so we also need the associated
header to make this file parsable on its own.