### PR TITLE
Corrected include in EcalWeightSetXMLTranslator.h

### DIFF
--- a/CondTools/Ecal/interface/EcalWeightSetXMLTranslator.h
+++ b/CondTools/Ecal/interface/EcalWeightSetXMLTranslator.h
@@ -12,7 +12,7 @@
 
 #include "CondFormats/EcalObjects/interface/EcalWeightSet.h"
 #include "CondTools/Ecal/interface/EcalCondHeader.h"
-#include <xercesc/dom/DOMNode.hpp>
+#include <xercesc/dom/DOMElement.hpp>
 #include <string>
 
 class EcalWeightSetXMLTranslator {


### PR DESCRIPTION
We use DOMElement and not DOMNode in this header, so we also need
to include the DOMElement header to make this file parsable on its
own.