### PR TITLE
Added missing include to EcalCondHandler.h

### DIFF
--- a/CondTools/Ecal/interface/EcalCondHandler.h
+++ b/CondTools/Ecal/interface/EcalCondHandler.h
@@ -3,6 +3,7 @@
 
 #include "CondCore/PopCon/interface/PopConSourceHandler.h"
 #include "CondTools/Ecal/interface/EcalCondHeader.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <string>
 
 


### PR DESCRIPTION
We use ParameterSet in this header, so we also need to include
the associated header to make this file parsable on its own.