### PR TITLE
Added missing include to EcalUncalibRecHitRecAbsAlgo.h

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitTimeWeightsAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitTimeWeightsAlgo.h
@@ -18,7 +18,7 @@
 #include "CondFormats/EcalObjects/interface/EcalWeightSet.h"
 
 #include "RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h"
-
+#include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecAbsAlgo.h"
 
 #include "TVectorD.h"
 #include <vector>


### PR DESCRIPTION
We use EcalUncalibRechitRecAbsAlgo in this header, so we also
need to include the associated header to make this file parsable
on its own.