### PR TITLE
Added missing includes to APDSimParameters.h

### DIFF
--- a/SimCalorimetry/EcalSimAlgos/interface/APDSimParameters.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/APDSimParameters.h
@@ -1,6 +1,9 @@
 #ifndef EcalSimAlgos_APDSimParameters_h
 #define EcalSimAlgos_APDSimParameters_h
 
+#include <cmath>
+#include <string>
+#include <vector>
 
 class APDSimParameters
 {


### PR DESCRIPTION
We use fabs, std::string and std::vector in this header, so we
also need to include the associated headers to make this header
parsable on its own.