### PR TITLE
Added include for boost access to ScalingExponential.h

### DIFF
--- a/CondFormats/HcalObjects/interface/ScalingExponential.h
+++ b/CondFormats/HcalObjects/interface/ScalingExponential.h
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "boost/cstdint.hpp"
+#include "boost/serialization/access.hpp"
 #include "boost/serialization/version.hpp"
 
 class ScalingExponential


### PR DESCRIPTION
We declare the access class as a friend, so we also need to
include the associated header to make this header parsable on
its own.