### PR TITLE
Added include for string to HcalRawGain.h

### DIFF
--- a/CondFormats/HcalObjects/interface/HcalRawGain.h
+++ b/CondFormats/HcalObjects/interface/HcalRawGain.h
@@ -10,6 +10,7 @@ $Date: 2007/12/10 18:38:20 $
 $Revision: 1.4 $
 */
 #include <boost/cstdint.hpp>
+#include <string>
 
 class HcalRawGain {
  public:


### PR DESCRIPTION
We use std::string in this file, so we also need to include
`string` to make this file parsable on its own.