### PR TITLE
Added missing includes to CandMapTrait.h

### DIFF
--- a/CommonTools/CandUtils/interface/CandMapTrait.h
+++ b/CommonTools/CandUtils/interface/CandMapTrait.h
@@ -1,5 +1,9 @@
 #ifndef CommonTools_CandUtils_CandMapTrait_h
 #define CommonTools_CandUtils_CandMapTrait_h
+
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
 /* \class reco::helper::CandMapTrait<T>
  *
  * \author Luca Lista, INFN 


### PR DESCRIPTION
We use AssociationMap and CandidateView in this header, so we
also need to include the associated headers to make this file
parsable on its own.