### PR TITLE
Added missing forward decls to AlignmentTwoBodyDecayTrackSelector.h

### DIFF
--- a/Alignment/CommonAlignmentProducer/interface/AlignmentTwoBodyDecayTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentTwoBodyDecayTrackSelector.h
@@ -12,6 +12,8 @@
 #include <DataFormats/TrackReco/interface/TrackFwd.h>
 #include <DataFormats/METReco/interface/CaloMETFwd.h>
 
+namespace edm { class Event; class EventSetup; }
+
 class AlignmentTwoBodyDecayTrackSelector
 {
  public:


### PR DESCRIPTION
We reference Event and EventSetup in this header but don't include
the associated headers for those declarations. This patch forward
declares those two classes to make this header parsable on its own.