### PR TITLE
Fixed forward decls in AlignmentGlobalTrackSelector.h

### DIFF
--- a/Alignment/CommonAlignmentProducer/interface/AlignmentGlobalTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentGlobalTrackSelector.h
@@ -11,8 +11,8 @@
 //STL
 #include <vector>
 
-namespace edm {class Track;}
-namespace reco {class Event;}
+namespace reco {class Track;}
+namespace edm {class Event; class EventSetup;}
 
 class AlignmentGlobalTrackSelector
 {


### PR DESCRIPTION
The Event forward decl goes into the edm namespace and the Track
forward decl in the reco namespace. Also added the missing
forward decl to EventSetup to make this header parsable on its own.