### PR TITLE
Added missing include to trackHitsToClusterRefs.h

### DIFF
--- a/SimTracker/TrackAssociation/interface/trackHitsToClusterRefs.h
+++ b/SimTracker/TrackAssociation/interface/trackHitsToClusterRefs.h
@@ -1,6 +1,7 @@
 #ifndef SimTracker_TrackAssociation_trackHitsToClusterRefs_h
 #define SimTracker_TrackAssociation_trackHitsToClusterRefs_h
 
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"


### PR DESCRIPTION
We reference trackingRecHit_iterator in this header, so we also
need to include the associated header for this typedef to
make this header parsable on its own.