### PR TITLE
Added include for cmath to BionamialProbability.h

### DIFF
--- a/CommonTools/Statistics/interface/BinomialProbability.h
+++ b/CommonTools/Statistics/interface/BinomialProbability.h
@@ -1,6 +1,8 @@
 #ifndef BinomialProbability_H
 #define BinomialProbability_H
 
+#include <cmath>
+
 /** A simple class for accumulating binomial "events",
  *  i.e. events that have a yes/no outcome,
  *  and for computing the binomial error on the


### PR DESCRIPTION
This header uses `sqrt`, so we also need to include cmath to
make this header parsable on its own.