### PR TITLE
Added include for cstdint to liblogintpack.h

### DIFF
--- a/DataFormats/PatCandidates/interface/liblogintpack.h
+++ b/DataFormats/PatCandidates/interface/liblogintpack.h
@@ -2,6 +2,7 @@
 #define liblogintpack_h
 
 #include <cmath>
+#include <cstdint>
 
 namespace logintpack
 {


### PR DESCRIPTION
We use uint16_t in this header, so we also need to include
cstdint to make this header parsable on its own.