### PR TITLE
Added missing includes to EventHypothesisLooper.h

### DIFF
--- a/DataFormats/PatCandidates/interface/EventHypothesisLooper.h
+++ b/DataFormats/PatCandidates/interface/EventHypothesisLooper.h
@@ -1,7 +1,8 @@
 #ifndef DataFormats_EventHypothesis_interface_EventHypothesisLooper_h
 #define DataFormats_EventHypothesis_interface_EventHypothesisLooper_h
 
-#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/PatCandidates/interface/EventHypothesis.h"
 #include <algorithm>
 
 namespace pat { namespace eventhypothesis {


### PR DESCRIPTION
We actually dereference a pointer to reco::Candidate in this header,
so we can't just include the Fwd.h header but need the full
Candidate header. We also need to include the EventHypothesis.h
because we reference EventHypothesis in this header. This patch
adds these includes to make this header parsable on its own.