### PR TITLE
Removed commented out dependency in DataFormats/EgammaCandidates

### DIFF
--- a/DataFormats/EgammaCandidates/BuildFile.xml
+++ b/DataFormats/EgammaCandidates/BuildFile.xml
@@ -12,7 +12,6 @@
 <use   name="DataFormats/VertexReco"/>
 <use   name="DataFormats/GsfTrackReco"/>
 <use   name="DataFormats/GeometryCommonDetAlgo"/>
-# <use   name="DataFormats/ParticleFlowCandidate"/>
 <use   name="FWCore/MessageLogger"/>
 
 <export>


### PR DESCRIPTION
It would be nice if we could remove this line. It makes this not
valid XML and makes it a bit hard for my tooling to parse the
SCRAM build files.