### PR TITLE
Make BoundarySurface.h compile

### DIFF
--- a/MagneticField/VolumeGeometry/interface/BoundarySurface.h
+++ b/MagneticField/VolumeGeometry/interface/BoundarySurface.h
@@ -1,6 +1,8 @@
 #ifndef BoundarySurface_H
 #define BoundarySurface_H
 
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+
 #include <vector>
 
 class VolumeBoundary;
@@ -10,9 +12,9 @@ public:
 
   enum Side {positive, negative};
 
-  vector<const VolumeBoundary*> volumeBoundaries( Side) const = 0;
+  virtual std::vector<const VolumeBoundary*> volumeBoundaries( Side) const = 0;
 
-  const VolumeBoundary* volumeBoundary( const LocalPoint&, Side) const = 0;
+  virtual const VolumeBoundary* volumeBoundary( const LocalPoint&, Side) const = 0;
 
 };
 


### PR DESCRIPTION
This header references LocalPoitn, so we also need include the
related header. Also the virtual functions are now correctly
marked as virtual to make clang happy.