### PR TITLE
Added missing include to BoundaryPlane.h

### DIFF
--- a/MagneticField/VolumeGeometry/interface/BoundaryPlane.h
+++ b/MagneticField/VolumeGeometry/interface/BoundaryPlane.h
@@ -1,6 +1,9 @@
 #ifndef BoundaryPlane_H
 #define BoundaryPlane_H
 
+#include "DataFormats/GeometrySurface/interface/Plane.h"
+#include "MagneticField/VolumeGeometry/interface/BoundarySurface.h"
+
 class BoundaryPlane : public BoundarySurface, public Plane {
 public:
 


### PR DESCRIPTION
This header references BoundarySurface and Plane, so we also
need to include the related header to make it parsable on its own.