### PR TITLE
Added missing includes to TrackerDetectorStruct.h

### DIFF
--- a/Alignment/APEEstimation/interface/TrackerDetectorStruct.h
+++ b/Alignment/APEEstimation/interface/TrackerDetectorStruct.h
@@ -2,7 +2,9 @@
 #define Alignment_APEEstimation_TrackerDetectorStruct_h
 
 
-//#include "TH1.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TProfile.h"
 
 struct TrackerDetectorStruct{
   


### PR DESCRIPTION
This header references TH1, TH2 and TProfile, so we also
need to include the associated ROOT headers to make this
header parsable on its own.