### PR TITLE
Added missing includes to SurveyPxbImageReader

### DIFF
--- a/Alignment/SurveyAnalysis/interface/SurveyPxbImageReader.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyPxbImageReader.h
@@ -1,6 +1,10 @@
 #ifndef GUARD_surveypxbimagereader_h
 #define GUARD_surveypxbimagereader_h
 
+#include "Alignment/SurveyAnalysis/interface/SurveyPxbImage.h"
+
+#include <algorithm>
+#include <iostream>
 #include <sstream>
 #include <vector>
 #include <fstream>

--- a/CalibFormats/SiPixelObjects/interface/PixelTimeFormatter.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelTimeFormatter.h
@@ -12,6 +12,8 @@
 *   A longer explanation will be placed here later
 */
 
+#include "CalibFormats/SiPixelObjects/interface/PixelConfigKey.h"
+
 #include <iostream>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
This header references std::find, std::cout and SurveyPxbImage
but doesn't include the associated headers. This patch adds
the missing includes to make this header parsable on its own.