### PR TITLE
Added include for PixelMaskOverrideBase to PixelMaskOverride

### DIFF
--- a/CalibFormats/SiPixelObjects/interface/PixelMaskOverride.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelMaskOverride.h
@@ -10,6 +10,7 @@
 
 #include <string>
 #include "PixelROCMaskBits.h"
+#include "CalibFormats/SiPixelObjects/interface/PixelMaskOverrideBase.h"
 
 namespace pos{
 /*!  \ingroup ConfigurationObjects "Configuration Objects"


### PR DESCRIPTION
We inhertif from PixelMaskOverrideBase in this header, so
we need the defintition of this class to make this header
parsable on its own.