### PR TITLE
Include cstdint in ConstantsForCondObjects.h

### DIFF
--- a/DataFormats/SiStripCommon/interface/ConstantsForCondObjects.h
+++ b/DataFormats/SiStripCommon/interface/ConstantsForCondObjects.h
@@ -1,6 +1,7 @@
 #ifndef DataFormats_SiStripCommon_ConstantsForCondObjects_H
 #define DataFormats_SiStripCommon_ConstantsForCondObjects_H
 
+#include <cstdint>
 
 namespace sistrip {
   static const uint32_t FirstBadStripMask_  = 0x3FF;


### PR DESCRIPTION
We use uint32_t in this header, so we also need to include `cstdint`
to make this header parsable on its own.