### PR TITLE
Added missing includes to PixelConfig.h

### DIFF
--- a/CalibFormats/SiPixelObjects/interface/PixelConfig.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelConfig.h
@@ -6,6 +6,11 @@
 *   A longer explanation will be placed here later
 */
 
+#include <fstream>
+#include <string>
+#include <vector>
+#include <utility>
+
 namespace pos{
 /*! \class PixelConfig PixelConfig.h "interface/PixelConfig.h"
 *   \brief This class implements..


### PR DESCRIPTION
This header is referencing std::vector, std::pair, std::ofstream
and std::string but doesn't include any header that provides
these declarations. This patch adds the missing includes
to make this file parsable on its own.