### PR TITLE
Added include for string to PixelVersionAlias.h

### DIFF
--- a/CalibFormats/SiPixelObjects/interface/PixelVersionAlias.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelVersionAlias.h
@@ -1,6 +1,8 @@
 #ifndef PixelVersionAlias_h
 #define PixelVersionAlias_h
 
+#include <string>
+
 namespace pos{
   class PixelVersionAlias {
 


### PR DESCRIPTION
This file references std::string but doesn't include `string`,
so we just include it to make this header parsable on its own.