### PR TITLE
Added missing includes to PixelConfigList.h

### DIFF
--- a/CalibFormats/SiPixelObjects/interface/PixelConfigList.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelConfigList.h
@@ -6,7 +6,12 @@
 *   A longer explanation will be placed here later
 */
 
+#include "CalibFormats/SiPixelObjects/interface/PixelConfig.h"
+
+#include <cassert>
+#include <iostream>
 #include <stdlib.h>
+#include <string>
 
 namespace pos{
 /*! \class PixelConfigList PixelConfigList.h "interface/PixelConfigList.h"


### PR DESCRIPTION
This header references PixelConfig, assert, map and std::pair, but
it doesn't include the associated headers for these declarations.
This patch adds those missing includes to that the file can be parsed
on its own.