### PR TITLE
Added include to unistd to PixelConfigFile

### DIFF
--- a/CalibFormats/SiPixelObjects/interface/PixelConfigFile.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelConfigFile.h
@@ -46,6 +46,7 @@
 #include <stdexcept>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #define DEBUG_CF_ 0
 


### PR DESCRIPTION
This header is referencing ::sleep, but doesn't include the
unistd.h that provides this function. This patch adds it so that
this file can be parsed on its own.