### PR TITLE
Added missing includes PixelAliasList.H

### DIFF
--- a/CalibFormats/SiPixelObjects/interface/PixelAliasList.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelAliasList.h
@@ -7,9 +7,13 @@
 */
 
 #include "CalibFormats/SiPixelObjects/interface/PixelConfigAlias.h"
+#include "CalibFormats/SiPixelObjects/interface/PixelConfigList.h"
 #include "CalibFormats/SiPixelObjects/interface/PixelVersionAlias.h"
 
+#include <cassert>
+#include <iostream>
 #include <stdlib.h>
+#include <map>
 
 namespace pos{
 /*! \class PixelAliasList PixelAliasList.h "interface/PixelAliasList.h"


### PR DESCRIPTION
This header is referencing cout, assert, map and PixelConfigList,
but doesn't contain the necessary includes for this to be parsed
on its own. This patch adds the missing includes for this header.