### PR TITLE
Added include to Eigen to ReferenceTrajectoryBase.h

### DIFF
--- a/Alignment/ReferenceTrajectories/interface/ReferenceTrajectoryBase.h
+++ b/Alignment/ReferenceTrajectories/interface/ReferenceTrajectoryBase.h
@@ -98,6 +98,8 @@
 
 #include <vector>
 
+#include <Eigen/Dense>
+
 #include "GblTrajectory.h"
 
 


### PR DESCRIPTION
We use Eigen::MatrixXd in this header, so we also need
to include the relevant Eigen header.