### PR TITLE
Added include to ostream to IOIsWritable.hh

### DIFF
--- a/Alignment/Geners/interface/IOIsWritable.hh
+++ b/Alignment/Geners/interface/IOIsWritable.hh
@@ -3,6 +3,8 @@
 
 #include "Alignment/Geners/interface/IOIsClassType.hh"
 
+#include <ostream>
+
 namespace gs {
     template <typename T>
     class IOIsWritableHelper


### PR DESCRIPTION
We use std::ostream in this header, so we also need to include
`ostream` to make this file parsable on its own.