### PR TITLE
Added missing include to EcalTrigPrimFunctionalAlgo.h

### DIFF
--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalTrigPrimFunctionalAlgo.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalTrigPrimFunctionalAlgo.h
@@ -29,6 +29,7 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <map>
 #include <utility>


### PR DESCRIPTION
We use LogWarning in this file, so we also need to include
MessageLogger.h to make this file parsable on its own.