### PR TITLE
Added missing include to TTHelpers.h

### DIFF
--- a/RecoVertex/AdaptiveVertexFinder/interface/TTHelpers.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TTHelpers.h
@@ -1,6 +1,8 @@
 #ifndef TTHelper_s
 #define TTHelper_s
 
+#include "DataFormats/Candidate/interface/Candidate.h"
+
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 


### PR DESCRIPTION
We reference Candidate in this header here:
```C++
if((*tracks)[k].bestTrack() == nullptr) return reco::TransientTrack();
               ^
```

Because of this we also need to include Candidate.h to make this
file parsable on its own.