### PR TITLE
Added missing include to CaloTowerFromL1TCreatorForTauHLT.h

### DIFF
--- a/RecoTauTag/HLTProducers/interface/CaloTowerFromL1TCreatorForTauHLT.h
+++ b/RecoTauTag/HLTProducers/interface/CaloTowerFromL1TCreatorForTauHLT.h
@@ -20,6 +20,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/CaloTowers/interface/CaloTower.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerDefs.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include <string>
 


### PR DESCRIPTION
We use CaloTowerCollection, so we also need to include
CaloTowerDefs.h to make this header parsable on its own.