### PR TITLE
Added missing include to CaloTowerCreatorForTauHLT.h

### DIFF
--- a/RecoTauTag/HLTProducers/interface/CaloTowerCreatorForTauHLT.h
+++ b/RecoTauTag/HLTProducers/interface/CaloTowerCreatorForTauHLT.h
@@ -20,6 +20,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/CaloTowers/interface/CaloTower.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerDefs.h"
 #include "DataFormats/L1Trigger/interface/L1JetParticle.h"
 #include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
 #include <string>


### PR DESCRIPTION
We use CaloTowerCollection, so we also need to include
CaloTowerDefs.h to make this header parsable on its own.