### PR TITLE
Added include for vector to FindPeakFastPV.h

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/interface/FindPeakFastPV.h
+++ b/RecoPixelVertexing/PixelVertexFinding/interface/FindPeakFastPV.h
@@ -8,6 +8,7 @@
  *  \author Silvio Donato (SNS)
  */
 
+#include <vector>
 
 float FindPeakFastPV(const std::vector<float> &zProjections, const std::vector<float> &zWeights, const float oldVertex, const float m_zClusterWidth, const float m_zClusterSearchArea, const float m_weightCut) {
 float centerWMax = oldVertex;


### PR DESCRIPTION
We use std::vector in this header, so we also need to include
`vector` to make this header parsable on its own.