### PR TITLE
Added include for Point3D.h to Cluster1DMerger.h

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/interface/Cluster1DMerger.h
+++ b/RecoPixelVertexing/PixelVertexFinding/interface/Cluster1DMerger.h
@@ -4,6 +4,8 @@
 #include "CommonTools/Clustering1D/interface/Cluster1D.h"
 #include "CommonTools/Clustering1D/interface/WeightEstimator.h"
 
+#include "DataFormats/Math/interface/Point3D.h"
+
 /**
  *  The class that should always be used to merge
  *  two Cluster1D into a single Cluster1D.


### PR DESCRIPTION
We use XYZPoint in this header, so we also need to include Point3D.h
to make this file parsable on its own.