### PR TITLE
Added include for cmath to Cluster1DCleaner.h

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/interface/Cluster1DCleaner.h
+++ b/RecoPixelVertexing/PixelVertexFinding/interface/Cluster1DCleaner.h
@@ -3,6 +3,8 @@
 
 #include "CommonTools/Clustering1D/interface/Cluster1D.h"
 
+#include <cmath>
+
 /*
  * given a vector<Cluster1D<T> >, erase Cluster1D further away than 
  * ZOffeSet from the average position, then 


### PR DESCRIPTION
This header uses `std::sqrt`, so we also need to include
`cmath` to make this header parsable on its own.