### PR TITLE
Added include for cmath to CaloRecHitResolutionProvider.h

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/CaloRecHitResolutionProvider.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/CaloRecHitResolutionProvider.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include <cmath>
 
 class CaloRecHitResolutionProvider{
  public:


### PR DESCRIPTION
This header uses `pow`, so we also need to include `cmath` to
make this header parsable on its own.