### PR TITLE
Added include for vector to MyCluster.h

### DIFF
--- a/RecoJets/JetAnalyzers/interface/MyCluster.h
+++ b/RecoJets/JetAnalyzers/interface/MyCluster.h
@@ -2,6 +2,8 @@
 #define MYCLUSTER_H
 #include "CLHEP/Vector/LorentzVector.h"
 
+#include <vector>
+
 enum {ClusterEm=0,ClusterHd=1,ClusterEmHd=2,ClusterTower=3,RecHitEm=4,RecHitHd=5,CaloTowerEm=6,CaloTowerHd=7};
 
 struct MatchParam{


### PR DESCRIPTION
We use std::vector in this header, so we also need to include
vector to make this header parsable on its own.