### PR TITLE
Added missing fftjet includes to ScaleCalculators.h

### DIFF
--- a/RecoJets/FFTJetAlgorithms/interface/ScaleCalculators.h
+++ b/RecoJets/FFTJetAlgorithms/interface/ScaleCalculators.h
@@ -6,6 +6,8 @@
 
 #include "fftjet/SimpleFunctors.hh"
 #include "fftjet/RecombinedJet.hh"
+#include "fftjet/LinearInterpolator2d.hh"
+#include "fftjet/JetMagnitudeMapper2d.hh"
 
 #include "RecoJets/FFTJetAlgorithms/interface/fftjetTypedefs.h"
 


### PR DESCRIPTION
We use LinearInterpolator2d and JetMagnitudeMapper2d in this header,
so we also need to include the associated headers to make this file
parsable on its own.