### PR TITLE
Added missing includes to HLTRechitInRegionsProducer.h

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/interface/HLTRechitInRegionsProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/HLTRechitInRegionsProducer.h
@@ -16,6 +16,9 @@
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 
+#include "RecoEcal/EgammaCoreTools/interface/EcalEtaPhiRegion.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+
 // Geometry and topology
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"


### PR DESCRIPTION
We use EcalEtaPhiRegion and EcalRecHitCollection in this header,
so we also need to include EcalEtaPhiRegion.h and EcalRecHitCollections.h
to make this file parsable on its own.