### PR TITLE
Added missing include to EgammaHLTTimeCleanedRechitProducer.h

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTTimeCleanedRechitProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTTimeCleanedRechitProducer.h
@@ -3,6 +3,8 @@
 
 #include <memory>
 
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"


### PR DESCRIPTION
We use EcalRecHitCollection in this header, so we also need to
include EcalRecHitCollections.h to make this file parsable on
its own.