### PR TITLE
Added include for SuperClusterFwd.h to EgammaHLTRecoEcalCandidateProd…

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTRecoEcalCandidateProducers.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTRecoEcalCandidateProducers.h
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 
 namespace edm {


### PR DESCRIPTION
…ucers.h

We use SuperClusterCollection in this header, so we also need to include
the associated headers to make this file parsable on its own.