### PR TITLE
Added missing includes to EgammaHLTPixelMatchParamObjects.h

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchParamObjects.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchParamObjects.h
@@ -29,6 +29,9 @@
 //    with this
 
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "TF1.h"
 #include "TF2.h"


### PR DESCRIPTION
We use SuperClusterCollection and dereference its contents, so we
need to include SuperCluster.h and SuperClusterFwd.h. We also
use ParameterSet so we need ParameterSet.h to make this header
parsable on its own.