### PR TITLE
Added include for CaloTowerDefs.h to EgammaHLTCaloTowerProducer.h

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTCaloTowerProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTCaloTowerProducer.h
@@ -11,6 +11,7 @@
 
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerDefs.h"
 #include "DataFormats/L1Trigger/interface/L1EmParticle.h"
 #include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
 


### PR DESCRIPTION
We use CaloTowerCollection in this header, so we also need to include
CaloTowerDefs.h to make this header parsable on its own.