### PR TITLE
Added include for SuperClusterFwd.h to ConversionTrackCandidateProduc…

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackCandidateProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackCandidateProducer.h
@@ -24,6 +24,7 @@
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h"


### PR DESCRIPTION
…er.h

We use SuperClusterCollection in this header, so we also need to include
SuperClusterFwd to get the definition of this typedef and to make this
header parsable on its own.