### PR TITLE
Added missing includes to BinomialProbHelper.h

### DIFF
--- a/PhysicsTools/RooStatsCms/interface/BinomialProbHelper.h
+++ b/PhysicsTools/RooStatsCms/interface/BinomialProbHelper.h
@@ -7,6 +7,10 @@
  *
  */
 
+#include "Math/PdfFuncMathCore.h"
+
+#include <cmath>
+
 class BinomialProbHelper {
 public:
   BinomialProbHelper(double rho, int x, int n)


### PR DESCRIPTION
We use ROOT::Math::binomial_pdf and pow in this header, so we
also need to include the associated includes to make this header
parsable on its own.