### PR TITLE
Added include for IsolationProducer.h to CalIsolationExtrapolate.h

### DIFF
--- a/PhysicsTools/IsolationAlgos/interface/CalIsolationExtrapolate.h
+++ b/PhysicsTools/IsolationAlgos/interface/CalIsolationExtrapolate.h
@@ -4,6 +4,7 @@
  *
  */
 #include "PhysicsTools/IsolationAlgos/interface/CalIsolationAlgo.h"
+#include "PhysicsTools/IsolationAlgos/interface/IsolationProducer.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"


### PR DESCRIPTION
We specialize IsolationAlgorithmSetup in this header, so we also need to
include the associated header to make this file parsable on its own.