### PR TITLE
Add include for string to JetSelection.h

### DIFF
--- a/PhysicsTools/PatUtils/interface/JetSelection.h
+++ b/PhysicsTools/PatUtils/interface/JetSelection.h
@@ -1,6 +1,8 @@
 #ifndef PhysicsTools_PatUtils_JetSelection_h
 #define PhysicsTools_PatUtils_JetSelection_h
 
+#include <string>
+
 namespace pat {
 
   /// Structure defining the jet selection.


### PR DESCRIPTION
We use `std::string` in this header, so we also need to include
`string` to make this file parsable on its own.