### PR TITLE
Add header guards to PhysicsTools/FWLite headers

### DIFF
--- a/PhysicsTools/FWLite/interface/EventSelectors.h
+++ b/PhysicsTools/FWLite/interface/EventSelectors.h
@@ -1,3 +1,5 @@
+#ifndef PhysicsTools_FWLite_EventSelectors_h
+#define PhysicsTools_FWLite_EventSelectors_h
 // these includes are FWLite-safe
 #include "DataFormats/FWLite/interface/Handle.h"
 #include "DataFormats/FWLite/interface/Event.h"
@@ -90,3 +92,4 @@ namespace fwlite {
             ObjectCountSelector & operator=(const fwlite::ObjectCountSelector<Collection> &other) ;
     };
 }
+#endif // PhysicsTools_FWLite_EventSelectors_h

--- a/PhysicsTools/FWLite/interface/Scanner.h
+++ b/PhysicsTools/FWLite/interface/Scanner.h
@@ -1,3 +1,5 @@
+#ifndef PhysicsTools_FWLite_Scanner_h
+#define PhysicsTools_FWLite_Scanner_h
 // these includes are FWLite-safe
 #include "DataFormats/FWLite/interface/Handle.h"
 #include "DataFormats/FWLite/interface/Event.h"
@@ -658,3 +660,4 @@ namespace fwlite {
 
     };
 }
+#endif // PhysicsTools_FWLite_Scanner_h

--- a/PhysicsTools/FWLite/interface/WSelector.h
+++ b/PhysicsTools/FWLite/interface/WSelector.h
@@ -1,3 +1,5 @@
+#ifndef PhysicsTools_FWLite_WSelector_h
+#define PhysicsTools_FWLite_WSelector_h
 #include "DataFormats/PatCandidates/interface/MET.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "PhysicsTools/SelectorUtils/interface/EventSelector.h"
@@ -81,3 +83,4 @@ protected:
   /// MET from W boson
   pat::MET const* met_;
 };
+#endif // PhysicsTools_FWLite_WSelector_h

--- a/PhysicsTools/FWLite/interface/WSelectorFast.h
+++ b/PhysicsTools/FWLite/interface/WSelectorFast.h
@@ -1,3 +1,5 @@
+#ifndef PhysicsTools_FWLite_WSelectorFast_h
+#define PhysicsTools_FWLite_WSelectorFast_h
 #include "DataFormats/PatCandidates/interface/MET.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "PhysicsTools/SelectorUtils/interface/EventSelector.h"
@@ -85,3 +87,4 @@ protected:
   /// index for MET cut
   index_type metIndex_;
 };
+#endif // PhysicsTools_FWLite_WSelectorFast_h


### PR DESCRIPTION
We use the new style header guards with the package and subsystem
in the guard symbol instead to prevent conflicts.