### PR TITLE
Made SaturationFcn.h parsable on its own

### DIFF
--- a/OnlineDB/CSCCondDB/interface/SaturationFcn.h
+++ b/OnlineDB/CSCCondDB/interface/SaturationFcn.h
@@ -2,7 +2,11 @@
 #define SaturationFcn_h
                                                                
 #include "Minuit2/FCNBase.h"  
+#include <cmath>
 #include <vector>
+
+
+using namespace ROOT::Minuit2;
 
 class SaturationFcn : public FCNBase{ 
 


### PR DESCRIPTION
This header assumed that we have the contents of namespace ROOT::Minuit2
in the global namespace. Easiest way to fix this is by just importing
the contents of ROOT::Minuit2 with a `using` declaration.

It also uses `pow`, so we need to include `cmath` to make this header
parsable on its own.