### PR TITLE
Added include for EvtComplex to EvtSLBaryonAmp.hh

### DIFF
--- a/GeneratorInterface/EvtGenInterface/interface/EvtGenUserModels/EvtSLBaryonAmp.hh
+++ b/GeneratorInterface/EvtGenInterface/interface/EvtGenUserModels/EvtSLBaryonAmp.hh
@@ -22,6 +22,7 @@
 #define EVTSLBARYONAMP_HH
 
 #include "EvtGenBase/EvtSemiLeptonicAmp.hh"
+#include "EvtGenBase/EvtComplex.hh"
 
 class EvtParticle;
 class EvtAmp;


### PR DESCRIPTION
This header uses EvtComplex, so it also needs to include the
associated header to be parsable on its own.