### PR TITLE
Don't include inside a namespace in Common.h

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/Common.h
+++ b/L1Trigger/L1TMuonEndCap/interface/Common.h
@@ -13,6 +13,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include <array>
 
 // Resolve namespaces
 
@@ -61,7 +62,6 @@ namespace emtf {
   constexpr int NUM_STATION_PAIRS = 6;
   
   // Fixed-size arrays
-  #include <array>
   template<typename T>
   using sector_array = std::array<T, NUM_SECTORS>;
   template<typename T>


### PR DESCRIPTION
It's not a good idea to include a STL header inside a namespace.