### PR TITLE
Added missing includes to vmac.h

### DIFF
--- a/L1Trigger/CSCCommonTrigger/interface/vmac.h
+++ b/L1Trigger/CSCCommonTrigger/interface/vmac.h
@@ -7,6 +7,8 @@ Verilog++ SP.
 #ifndef _VMAC_H_FILE_
 #define _VMAC_H_FILE_
 
+#include "L1Trigger/CSCCommonTrigger/interface/vlib.h"
+
 extern globcontrol glc;
 
 #ifdef VGEN


### PR DESCRIPTION
We use globcontrol in this header, so we also need to include
vlib.h which declares globcontrol to make this header parsable
on its own.