### PR TITLE
Actually include TBuffer.h in CustomStreamer.h

### DIFF
--- a/IOPool/Common/interface/CustomStreamer.h
+++ b/IOPool/Common/interface/CustomStreamer.h
@@ -6,7 +6,7 @@
 #include "TClassStreamer.h"
 #include "TClassRef.h"
 #include "FWCore/Utilities/interface/TypeID.h"
-class TBuffer;
+#include "TBuffer.h"
 
 namespace edm {
   template <typename T>


### PR DESCRIPTION
We need to actually include TBuffer.h because we call `IsReading()`
on TBuffer but only provide a forward declaration. This adds
the include to TBuffer.h to make this header parsable on its own.