### PR TITLE
Added include for MuonFwd.h to HLTrigger/Muon

### DIFF
--- a/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.h
+++ b/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.h
@@ -14,6 +14,7 @@
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"

--- a/HLTrigger/Muon/plugins/HLTMuonTrimuonL3Filter.h
+++ b/HLTrigger/Muon/plugins/HLTMuonTrimuonL3Filter.h
@@ -16,6 +16,7 @@
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 
 namespace edm {
    class ConfigurationDescriptions;


### PR DESCRIPTION
These two headers use reco::MuonTrackLinksCollection but don't
include the associated headers. This patch adds the missing
includes so that this header is parsable on its own.