### PR TITLE
Added include for ParameterSet to SimpleCutsIsolator.h

### DIFF
--- a/RecoMuon/MuonIsolation/interface/SimpleCutsIsolator.h
+++ b/RecoMuon/MuonIsolation/interface/SimpleCutsIsolator.h
@@ -5,7 +5,7 @@
 #include "RecoMuon/MuonIsolation/interface/Cuts.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class SimpleCutsIsolator : public muonisolation::MuIsoBaseIsolator {
  public:


### PR DESCRIPTION
We use ParameterSet in this header, so we also need to include
the associated header to make this file parsable on its own.