### PR TITLE
Added missing includes to HLTMuonL2ToL1TMap.h

### DIFF
--- a/HLTrigger/Muon/plugins/HLTMuonL2ToL1TMap.h
+++ b/HLTrigger/Muon/plugins/HLTMuonL2ToL1TMap.h
@@ -19,6 +19,9 @@
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
 typedef edm::AssociationMap<edm::OneToMany<std::vector<L2MuonTrajectorySeed>, std::vector<L2MuonTrajectorySeed> > > SeedMap;
 
 class HLTMuonL2ToL1TMap{


### PR DESCRIPTION
We use Event and edm::EDGetTokenT in this header, so we also need
to include the associated headers to make this file parsable on its
own.