### PR TITLE
Added include for Event.h to HLTMuonL2ToL1Map.h

### DIFF
--- a/HLTrigger/Muon/plugins/HLTMuonL2ToL1Map.h
+++ b/HLTrigger/Muon/plugins/HLTMuonL2ToL1Map.h
@@ -19,6 +19,8 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 
+#include "FWCore/Framework/interface/Event.h"
+
 typedef edm::AssociationMap<edm::OneToMany<std::vector<L2MuonTrajectorySeed>, std::vector<L2MuonTrajectorySeed> > > SeedMap;
 
 class HLTMuonL2ToL1Map{


### PR DESCRIPTION
We use Event in this header, so we also need to include Event.h
to make this header parsable on its own.