### PR TITLE
Added missing includes to HLTL1TSeed.h

### DIFF
--- a/HLTrigger/HLTfilters/plugins/HLTL1TSeed.h
+++ b/HLTrigger/HLTfilters/plugins/HLTL1TSeed.h
@@ -27,6 +27,8 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMenuFwd.h"
 #include "DataFormats/L1TGlobal/interface/GlobalLogicParser.h"
+#include "DataFormats/L1TGlobal/interface/GlobalObject.h"
+#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 
 #include "FWCore/Utilities/interface/InputTag.h"
 


### PR DESCRIPTION
We use GlobalAlgBlkBxCollection and GlobalObject in this header, so
we also need to include the associated headers to make this header
parsable on its own.