### PR TITLE
Added include for cmath to TopQuarkAnalysis/TopObjectResolutions

### DIFF
--- a/TopQuarkAnalysis/TopObjectResolutions/interface/Electron.h
+++ b/TopQuarkAnalysis/TopObjectResolutions/interface/Electron.h
@@ -1,6 +1,8 @@
 #ifndef TopObjetcResolutionsElectron_h
 #define TopObjetcResolutionsElectron_h
 
+#include <cmath>
+
 namespace res{
   class HelperElectron {
 

--- a/TopQuarkAnalysis/TopObjectResolutions/interface/Jet.h
+++ b/TopQuarkAnalysis/TopObjectResolutions/interface/Jet.h
@@ -1,6 +1,8 @@
 #ifndef TopObjetcResolutionsJet_h
 #define TopObjetcResolutionsJet_h
 
+#include <cmath>
+
 namespace res{
   class HelperJet {
 

--- a/TopQuarkAnalysis/TopObjectResolutions/interface/MET.h
+++ b/TopQuarkAnalysis/TopObjectResolutions/interface/MET.h
@@ -1,6 +1,8 @@
 #ifndef TopObjetcResolutionsMET_h
 #define TopObjetcResolutionsMET_h
 
+#include <cmath>
+
 namespace res{
   class HelperMET {
     

--- a/TopQuarkAnalysis/TopObjectResolutions/interface/Muon.h
+++ b/TopQuarkAnalysis/TopObjectResolutions/interface/Muon.h
@@ -1,6 +1,8 @@
 #ifndef TopObjetcResolutionsMuon_h
 #define TopObjetcResolutionsMuon_h
 
+#include <cmath>
+
 namespace res{
   class HelperMuon {
 


### PR DESCRIPTION
We use fabs and other functions from cmath in these headers, but
we don't actually include cmath. This patch adds this include
so that these headers are parsable on their own.