### PR TITLE
Include cmath in PI.h

### DIFF
--- a/GeneratorInterface/ExhumeInterface/interface/PI.h
+++ b/GeneratorInterface/ExhumeInterface/interface/PI.h
@@ -1,4 +1,5 @@
 #ifndef PI
+#include <cmath>
 const double dont_even_think_about_using = 4*atan(1.0);
 #define PI dont_even_think_about_using
 #endif


### PR DESCRIPTION
Beside the questionable idea to use the header guard for passing
values around, this header also uses atan but doesn't include
cmath. Let's fix that by actually including it.