### PR TITLE
Include string in Pythia6Declarations.h

### DIFF
--- a/GeneratorInterface/Pythia6Interface/interface/Pythia6Declarations.h
+++ b/GeneratorInterface/Pythia6Interface/interface/Pythia6Declarations.h
@@ -4,6 +4,8 @@
 
 #include "HepMC/PythiaWrapper6_4.h"
 
+#include <string>
+
 namespace gen
 {
 


### PR DESCRIPTION
We use std::string in this header, so we also need to include
`string` to make this file parsable on its own.