### PR TITLE
Include set in TrackUtils.h

### DIFF
--- a/Fireworks/Tracks/interface/TrackUtils.h
+++ b/Fireworks/Tracks/interface/TrackUtils.h
@@ -8,6 +8,7 @@
 
 // system include files
 #include "TEveVSDStructs.h"
+#include <set>
 
 // forward declarations
 namespace reco 


### PR DESCRIPTION
We use std::set in this header, so we also need to include `set`
to make this header parsable on its own.