### PR TITLE
Include TEveVector.h in FWPFMaths.h

### DIFF
--- a/Fireworks/ParticleFlow/interface/FWPFMaths.h
+++ b/Fireworks/ParticleFlow/interface/FWPFMaths.h
@@ -1,6 +1,8 @@
 #ifndef _FWPFMATHS_H_
 #define _FWPFMATHS_H_
 
+#include "TEveVector.h"
+
 namespace FWPFMaths
 {
    TEveVector        lineCircleIntersect( const TEveVector &v1, const TEveVector &v2, float r );


### PR DESCRIPTION
We return TEveVector in this header by value from a few functions, so
we actually have to include the TEveVector.h header to get the
defintion of TEveVector and make this header parsable on its own.