### PR TITLE
Fixed typo in FWMuonBuilder.h

### DIFF
--- a/Fireworks/Muons/interface/FWMuonBuilder.h
+++ b/Fireworks/Muons/interface/FWMuonBuilder.h
@@ -17,7 +17,7 @@ class FWEventItem;
 class TEveElementList;
 class TEveTrackPropagator;
 class FWMagField;
-class FWPRoxyBuilderBase;
+class FWProxyBuilderBase;
 
 class FWMuonBuilder
 {


### PR DESCRIPTION
The R isn't capital, otherwise this forward decl doesn't work.