### PR TITLE
Also fwd declare TGLCheckButton in CmsShowModelPopuph

### DIFF
--- a/Fireworks/Core/interface/CmsShowModelPopup.h
+++ b/Fireworks/Core/interface/CmsShowModelPopup.h
@@ -38,6 +38,7 @@ class FWSelectionManager;
 class FWColorManager;
 //class FWModelId;
 class FWColorSelect;
+class TGCheckButton;
 class TGLabel;
 class TGTextButton;
 class TGTextButton;


### PR DESCRIPTION
We use this class in this header, so we should forward declare
it to make this header parsable on its own.