### PR TITLE
Include Rtypes.h for Long_t in FWEnumParameter.h

### DIFF
--- a/Fireworks/Core/interface/FWEnumParameter.h
+++ b/Fireworks/Core/interface/FWEnumParameter.h
@@ -19,6 +19,7 @@
 //
 
 // system include files
+#include "Rtypes.h"
 
 // user include files
 #include "Fireworks/Core/interface/FWLongParameter.h"


### PR DESCRIPTION
We use Long_t, so this is needed to make this header parsable on
its own.