### PR TITLE
Added include to FSimTrack.h to FSimTrackEqual.h

### DIFF
--- a/FastSimulation/Event/interface/FSimTrackEqual.h
+++ b/FastSimulation/Event/interface/FSimTrackEqual.h
@@ -1,6 +1,8 @@
 #ifndef FastSimulation_Event_FSimTrackEqual_H
 #define FastSimulation_Event_FSimTrackEqual_H
 
+#include "FastSimulation/Event/interface/FSimTrack.h"
+
 class FSimTrackEqual
 {
  public: 


### PR DESCRIPTION
We use FSimTrack in this header, so we also need to include
FSimTrack.h to make this header parsable on its own.