### PR TITLE
Added include for cmath to GammaZInterference.h

### DIFF
--- a/PhysicsTools/Utilities/interface/GammaZInterference.h
+++ b/PhysicsTools/Utilities/interface/GammaZInterference.h
@@ -2,6 +2,7 @@
 #define PhysicsTools_Utilities_GammaZInterference_h
 #include "PhysicsTools/Utilities/interface/Parameter.h"
 #include <boost/shared_ptr.hpp>
+#include <cmath>
 
 namespace funct {
 


### PR DESCRIPTION
We use fabs in this header, so we also need to include cmath to
make this file parsable on its own.