### PR TITLE
[10X] [L1T] [DQM] Updating range for vertex histogram

### DIFF
--- a/DQMOffline/L1Trigger/interface/HistDefinition.h
+++ b/DQMOffline/L1Trigger/interface/HistDefinition.h
@@ -1,17 +1,20 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include <string>
+#include <vector>
 
 namespace dqmoffline {
 namespace l1t {
 
 class HistDefinition;
-typedef std::map<std::string, HistDefinition> HistDefinitions;
+typedef std::vector<HistDefinition> HistDefinitions;
 
 class HistDefinition {
 public:
   HistDefinition();
   HistDefinition(const edm::ParameterSet &ps);
   ~HistDefinition();
-  static HistDefinitions readHistDefinitions(const edm::ParameterSet &ps);
+  // static HistDefinitions readHistDefinitions(const edm::ParameterSet &ps,
+  // std::map<std::string, unsigned int>);
 
   std::string name;
   std::string title;
@@ -25,8 +28,9 @@ public:
   std::vector<double> binsY;
 };
 
-HistDefinitions readHistDefinitions(const edm::ParameterSet &ps);
+HistDefinitions
+readHistDefinitions(const edm::ParameterSet &ps,
+                    const std::map<std::string, unsigned int> &mapping);
 
-
-} //end l1t
-} //end dqmoffline
+} // end l1t
+} // end dqmoffline

--- a/DQMOffline/L1Trigger/interface/HistDefinition.h
+++ b/DQMOffline/L1Trigger/interface/HistDefinition.h
@@ -1,0 +1,32 @@
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+namespace dqmoffline {
+namespace l1t {
+
+class HistDefinition;
+typedef std::map<std::string, HistDefinition> HistDefinitions;
+
+class HistDefinition {
+public:
+  HistDefinition();
+  HistDefinition(const edm::ParameterSet &ps);
+  ~HistDefinition();
+  static HistDefinitions readHistDefinitions(const edm::ParameterSet &ps);
+
+  std::string name;
+  std::string title;
+  unsigned int nbinsX;
+  unsigned int nbinsY;
+  double xmin;
+  double xmax;
+  double ymin;
+  double ymax;
+  std::vector<double> binsX;
+  std::vector<double> binsY;
+};
+
+HistDefinitions readHistDefinitions(const edm::ParameterSet &ps);
+
+
+} //end l1t
+} //end dqmoffline

--- a/DQMOffline/L1Trigger/interface/HistDefinition.h
+++ b/DQMOffline/L1Trigger/interface/HistDefinition.h
@@ -1,3 +1,46 @@
+#ifndef DQMOffline_L1Trigger_HistDefinition_h
+#define DQMOffline_L1Trigger_HistDefinition_h
+
+/**
+ * \class HistDefinition
+ *
+ *
+ * Description: Class for parsing histogram definitions from a ParameterSet of
+ * ParameterSets defined in the python configuration. Acceptable parameters are
+ * all public members of the HistDefinition class.
+ *
+ * Python configuration example:
+ * https://github.com/cms-sw/cmssw/blob/master/DQMOffline/L1Trigger/python/L1THistDefinitions_cff.py
+ *
+ * Usage in CMSSW module
+ * PlotConfig enum, PlotConfigNames map:
+ * https://github.com/cms-sw/cmssw/blob/master/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
+ *
+ * enum PlotConfig {
+ *   nVertex
+ * };
+ *
+ * static const std::map<std::string, unsigned int> PlotConfigNames;
+ *
+ * https://github.com/cms-sw/cmssw/blob/master/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
+ *
+ * const std::map<std::string, unsigned int> L1TEGammaOffline::PlotConfigNames = {
+ *  {"nVertex", PlotConfig::nVertex}
+ * };
+ * Read from ParameterSet in module constructor:
+ * histDefinitions_(dqmoffline::l1t::readHistDefinitions(ps.getParameterSet("histDefinitions"), PlotConfigNames)),
+ *
+ * Use to create a histogram:
+ * dqmoffline::l1t::HistDefinition nVertexDef = histDefinitions_[PlotConfig::nVertex];
+ * h_nVertex_ = ibooker.book1D(
+ *   nVertexDef.name, nVertexDef.title, nVertexDef.nbinsX, nVertexDef.xmin, nVertexDef.xmax
+ * );
+ *
+ *
+ * \author: Luke Kreczko - kreczko@cern.ch
+ *
+ **/
+
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <string>
 #include <vector>
@@ -34,3 +77,5 @@ readHistDefinitions(const edm::ParameterSet &ps,
 
 } // end l1t
 } // end dqmoffline
+
+#endif

--- a/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
@@ -42,6 +42,12 @@ public:
   L1TEGammaOffline(const edm::ParameterSet& ps);
   ~L1TEGammaOffline() override;
 
+  enum PlotConfig {
+    nVertex
+  };
+
+  static const std::map<std::string, unsigned int> PlotConfigNames;
+
 protected:
 
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;

--- a/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
@@ -14,6 +14,7 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMOffline/L1Trigger/interface/HistDefinition.h"
 
 //Candidate handling
 #include "DataFormats/Candidate/interface/Candidate.h"
@@ -92,6 +93,8 @@ private:
   reco::GsfElectron tagElectron_;
   reco::GsfElectron probeElectron_;
   double tagAndProbleInvariantMass_;
+
+  dqmoffline::l1t::HistDefinitions histDefinitions_;
 
   // TODO: add turn-on cuts (vectors of doubles)
   // Histograms

--- a/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
@@ -52,6 +52,9 @@
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
 
+#include "DQMOffline/L1Trigger/interface/HistDefinition.h"
+
+
 class L1TStage2CaloLayer2Offline: public DQMEDAnalyzer {
 
 public:
@@ -128,6 +131,8 @@ private:
 
   double recoHTTMaxEta_;
   double recoMHTMaxEta_;
+
+  dqmoffline::l1t::HistDefinitions histDefinitions_;
 
   // TODO: add turn-on cuts (vectors of doubles)
   // Histograms

--- a/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
@@ -80,6 +80,12 @@ public:
 
   typedef std::map<L1TStage2CaloLayer2Offline::ControlPlots, MonitorElement*> ControlPlotMap;
 
+  enum PlotConfig {
+    nVertex
+  };
+
+  static const std::map<std::string, unsigned int> PlotConfigNames;
+
 protected:
 
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;

--- a/DQMOffline/L1Trigger/interface/L1TTauOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TTauOffline.h
@@ -86,6 +86,12 @@ public:
   L1TTauOffline(const edm::ParameterSet& ps);
   ~L1TTauOffline() override;
 
+  enum PlotConfig {
+    nVertex
+  };
+
+  static const std::map<std::string, unsigned int> PlotConfigNames;
+
 protected:
 
   void dqmBeginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;

--- a/DQMOffline/L1Trigger/interface/L1TTauOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TTauOffline.h
@@ -2,7 +2,7 @@
 #define DQMOFFLINE_L1TRIGGER_L1TTAUOFFLINE_H
 
 //DataFormats
-#include "DataFormats/L1Trigger/interface/BXVector.h"	
+#include "DataFormats/L1Trigger/interface/BXVector.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
 #include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
@@ -34,6 +34,8 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
+#include "DQMOffline/L1Trigger/interface/HistDefinition.h"
+
 //MagneticField
 #include "MagneticField/Engine/interface/MagneticField.h"
 
@@ -49,9 +51,9 @@ class TauL1TPair {
 
  public :
 
-  TauL1TPair(const reco::PFTau *tau, const l1t::Tau *regTau) : 				
+  TauL1TPair(const reco::PFTau *tau, const l1t::Tau *regTau) :
   m_tau(tau), m_regTau(regTau), m_eta(999.), m_phi_bar(999.), m_phi_end(999.) { };
-    
+
   TauL1TPair(const TauL1TPair& tauL1tPair);
 
   ~TauL1TPair() { };
@@ -61,15 +63,15 @@ class TauL1TPair {
   double phi() const { return m_tau->phi(); };
   double pt()  const { return m_tau->pt(); };
 
-  double l1tPt() const { return m_regTau ? m_regTau->pt() : -1.; };					
+  double l1tPt() const { return m_regTau ? m_regTau->pt() : -1.; };
   double l1tIso() const { return m_regTau ? m_regTau->hwIso() : -1.; };
-  double l1tPhi() const { return m_regTau ? m_regTau->phi() : -5.; };					
-  double l1tEta() const { return m_regTau ? m_regTau->eta() : -5.; };					
+  double l1tPhi() const { return m_regTau ? m_regTau->phi() : -5.; };
+  double l1tEta() const { return m_regTau ? m_regTau->eta() : -5.; };
 
 private :
 
   const reco::PFTau *m_tau;
-  const l1t::Tau *m_regTau;					
+  const l1t::Tau *m_regTau;
 
   double m_eta;
   double m_phi_bar;
@@ -98,7 +100,7 @@ protected:
   bool matchHlt(edm::Handle<trigger::TriggerEvent> const& triggerEvent, const reco::Muon * muon);
 
   // Cut and Matching
-  void getTauL1tPairs(edm::Handle<l1t::TauBxCollection> const& l1tCands);	
+  void getTauL1tPairs(edm::Handle<l1t::TauBxCollection> const& l1tCands);
   void getTightMuons(edm::Handle<reco::MuonCollection> const& muons, edm::Handle<reco::PFMETCollection> const& mets, const reco::Vertex & vertex, edm::Handle<trigger::TriggerEvent> const& trigEvent);
   void getProbeTaus(const edm::Event& e, edm::Handle<reco::PFTauCollection> const& taus, edm::Handle<reco::MuonCollection> const& muons, const reco::Vertex & vertex);
 
@@ -136,18 +138,19 @@ private:
   std::string efficiencyFolder_;
   edm::EDGetTokenT<l1t::TauBxCollection> stage2CaloLayer2TauToken_;
   std::vector<int> tauEfficiencyThresholds_;
-  std::vector<double> tauEfficiencyBins_; 
+  std::vector<double> tauEfficiencyBins_;
+  dqmoffline::l1t::HistDefinitions histDefinitions_;
 
   std::vector<const reco::Muon*>  m_TightMuons;
   std::vector<const reco::PFTau*>  m_ProbeTaus;
   std::vector<TauL1TPair>  m_TauL1tPairs;
 
 
-  std::vector<reco::PFTauCollection>  m_RecoTaus;		
-  std::vector<l1t::TauBxCollection>  m_L1tTaus;		  
-  std::vector<reco::PFTau>  m_RecoRecoTaus;		
-  BXVector<l1t::Tau>  m_L1tL1tTaus;		  
-  
+  std::vector<reco::PFTauCollection>  m_RecoTaus;
+  std::vector<l1t::TauBxCollection>  m_L1tTaus;
+  std::vector<reco::PFTau>  m_RecoRecoTaus;
+  BXVector<l1t::Tau>  m_L1tL1tTaus;
+
   // config params
   std::vector<int> m_L1tPtCuts;
 

--- a/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from DQMOffline.L1Trigger.L1THistDefinitions_cff import histDefinitions
 
 electronEfficiencyThresholds = [34, 36, 38, 40, 42]
 
@@ -48,6 +49,10 @@ l1tEGammaOfflineDQM = cms.EDAnalyzer(
 
     photonEfficiencyThresholds=cms.vdouble(photonEfficiencyThresholds),
     photonEfficiencyBins=cms.vdouble(photonEfficiencyBins),
+
+    histDefinitions=cms.PSet(
+        nVertex = histDefinitions.nVertex.clone(),
+    ),
 )
 
 # modifications for the pp reference run
@@ -66,7 +71,8 @@ photonEfficiencyThresholds_HI = electronEfficiencyThresholds_HI
 photonEfficiencyBins_HI = electronEfficiencyBins_HI
 
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
-ppRef_2017.toModify(l1tEGammaOfflineDQM,
+ppRef_2017.toModify(
+    l1tEGammaOfflineDQM,
     TriggerFilter=cms.InputTag('hltEle20WPLoose1GsfTrackIsoFilter', '', 'HLT'),
     TriggerPath=cms.string('HLT_Ele20_WPLoose_Gsf_v4'),
     electronEfficiencyThresholds=cms.vdouble(electronEfficiencyThresholds_HI),
@@ -82,4 +88,3 @@ l1tEGammaOfflineDQMEmu = l1tEGammaOfflineDQM.clone(
 
     histFolder=cms.string('L1TEMU/L1TEGamma'),
 )
-

--- a/DQMOffline/L1Trigger/python/L1THistDefinitions_cff.py
+++ b/DQMOffline/L1Trigger/python/L1THistDefinitions_cff.py
@@ -1,0 +1,12 @@
+
+import FWCore.ParameterSet.Config as cms
+
+histDefinitions = cms.PSet(
+    nVertex=cms.PSet(
+        name=cms.untracked.string('nVertex'),
+        title=cms.untracked.string('Number of event vertices in collection'),
+        nbins=cms.untracked.int32(100),
+        xmin=cms.untracked.double(-0.5),
+        xmax=cms.untracked.double(99.5),
+    ),
+)

--- a/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Offline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Offline_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from DQMOffline.L1Trigger.L1THistDefinitions_cff import histDefinitions
 
 jetEfficiencyThresholds = [36, 68, 128, 176]
 metEfficiencyThresholds = [40, 60, 80, 100, 120]
@@ -76,6 +77,10 @@ l1tStage2CaloLayer2OfflineDQM = cms.EDAnalyzer(
 
     recoHTTMaxEta=cms.double(2.5),
     recoMHTMaxEta=cms.double(2.5),
+
+    histDefinitions=cms.PSet(
+        nVertex = histDefinitions.nVertex.clone(),
+    ),
 )
 
 # modifications for the pp reference run
@@ -89,7 +94,8 @@ jetEfficiencyBins_HI.extend(list(xrange(180, 300, 40)))
 jetEfficiencyBins_HI.extend(list(xrange(300, 401, 100)))
 
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
-ppRef_2017.toModify(l1tStage2CaloLayer2OfflineDQM,
+ppRef_2017.toModify(
+    l1tStage2CaloLayer2OfflineDQM,
     TriggerFilter=cms.InputTag('hltEle20WPLoose1GsfTrackIsoFilter', '', 'HLT'),
     TriggerPath=cms.string('HLT_Ele20_WPLoose_Gsf_v4'),
     jetEfficiencyThresholds=cms.vdouble(jetEfficiencyThresholds_HI),

--- a/DQMOffline/L1Trigger/python/L1TTauOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TTauOffline_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from DQMOffline.L1Trigger.L1THistDefinitions_cff import histDefinitions
 
 tauEfficiencyThresholds = [28, 30, 32, 128, 176]
 
@@ -35,6 +36,10 @@ l1tTauOfflineDQM = cms.EDAnalyzer(
 
     tauEfficiencyThresholds=cms.vint32(tauEfficiencyThresholds),
     tauEfficiencyBins=cms.vdouble(tauEfficiencyBins),
+
+    histDefinitions=cms.PSet(
+        nVertex = histDefinitions.nVertex.clone(),
+    ),
 
 )
 

--- a/DQMOffline/L1Trigger/src/HistDefinition.cc
+++ b/DQMOffline/L1Trigger/src/HistDefinition.cc
@@ -1,0 +1,52 @@
+#include "DQMOffline/L1Trigger/interface/HistDefinition.h"
+
+namespace dqmoffline {
+namespace l1t {
+
+typedef std::vector<double> vdouble;
+
+HistDefinition::HistDefinition():
+  name("name"),
+  title("title"),
+  nbinsX(0),
+  nbinsY(0),
+  xmin(0),
+  xmax(0),
+  ymin(0),
+  ymax(0),
+  binsX(),
+  binsY() {
+
+}
+
+
+HistDefinition::HistDefinition(const edm::ParameterSet &ps):
+  name(ps.getUntrackedParameter<std::string>("name")),
+  title(ps.getUntrackedParameter<std::string>("title")),
+  nbinsX(ps.getUntrackedParameter<unsigned int>("nbinsX", 0)),
+  nbinsY(ps.getUntrackedParameter<unsigned int>("nbinsY", 0)),
+  xmin(ps.getUntrackedParameter<double>("xmin", 0)),
+  xmax(ps.getUntrackedParameter<double>("xmax", 0)),
+  ymin(ps.getUntrackedParameter<double>("ymin", 0)),
+  ymax(ps.getUntrackedParameter<double>("ymax", 0)),
+  binsX(ps.getUntrackedParameter<vdouble>("binsX", vdouble())),
+  binsY(ps.getUntrackedParameter<vdouble>("binsY", vdouble())) {
+
+}
+
+HistDefinition::~HistDefinition(){
+
+}
+
+HistDefinitions readHistDefinitions(const edm::ParameterSet &ps) {
+  HistDefinitions definitions;
+  std::vector<std::string> names = ps.getParameterNames();
+  for(auto name: names){
+    const edm::ParameterSet &hd(ps.getParameter<edm::ParameterSet>(name));
+    definitions[name] = HistDefinition(hd);
+  }
+  return definitions;
+}
+
+}
+}

--- a/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
@@ -17,6 +17,11 @@
 #include <cmath>
 #include <algorithm>
 
+
+const std::map<std::string, unsigned int> L1TEGammaOffline::PlotConfigNames = {
+  {"nVertex", PlotConfig::nVertex}
+};
+
 //
 // -------------------------------------- Constructor --------------------------------------------
 //
@@ -44,7 +49,7 @@ L1TEGammaOffline::L1TEGammaOffline(const edm::ParameterSet& ps) :
         tagElectron_(),
         probeElectron_(),
         tagAndProbleInvariantMass_(-1.),
-        histDefinitions_(dqmoffline::l1t::readHistDefinitions(ps.getParameterSet("histDefinitions")))
+        histDefinitions_(dqmoffline::l1t::readHistDefinitions(ps.getParameterSet("histDefinitions"), PlotConfigNames))
 {
   edm::LogInfo("L1TEGammaOffline") << "Constructor " << "L1TEGammaOffline::L1TEGammaOffline " << std::endl;
 }
@@ -512,7 +517,7 @@ void L1TEGammaOffline::bookElectronHistos(DQMStore::IBooker & ibooker)
   ibooker.cd();
   ibooker.setCurrentFolder(histFolder_);
 
-  dqmoffline::l1t::HistDefinition nVertexDef = histDefinitions_["nVertex"];
+  dqmoffline::l1t::HistDefinition nVertexDef = histDefinitions_[PlotConfig::nVertex];
   h_nVertex_ = ibooker.book1D(
     nVertexDef.name, nVertexDef.title, nVertexDef.nbinsX, nVertexDef.xmin, nVertexDef.xmax
   );

--- a/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
@@ -43,7 +43,8 @@ L1TEGammaOffline::L1TEGammaOffline(const edm::ParameterSet& ps) :
         photonEfficiencyBins_(ps.getParameter < std::vector<double> > ("photonEfficiencyBins")),
         tagElectron_(),
         probeElectron_(),
-        tagAndProbleInvariantMass_(-1.)
+        tagAndProbleInvariantMass_(-1.),
+        histDefinitions_(dqmoffline::l1t::readHistDefinitions(ps.getParameterSet("histDefinitions")))
 {
   edm::LogInfo("L1TEGammaOffline") << "Constructor " << "L1TEGammaOffline::L1TEGammaOffline " << std::endl;
 }
@@ -510,7 +511,11 @@ void L1TEGammaOffline::bookElectronHistos(DQMStore::IBooker & ibooker)
 {
   ibooker.cd();
   ibooker.setCurrentFolder(histFolder_);
-  h_nVertex_ = ibooker.book1D("nVertex", "Number of event vertices in collection", 40, -0.5, 39.5);
+
+  dqmoffline::l1t::HistDefinition nVertexDef = histDefinitions_["nVertex"];
+  h_nVertex_ = ibooker.book1D(
+    nVertexDef.name, nVertexDef.title, nVertexDef.nbinsX, nVertexDef.xmin, nVertexDef.xmax
+  );
   h_tagAndProbeMass_ = ibooker.book1D("tagAndProbeMass", "Invariant mass of tag & probe pair", 100, 40, 140);
   // electron reco vs L1
   h_L1EGammaETvsElectronET_EB_ = ibooker.book2D("L1EGammaETvsElectronET_EB",

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -43,6 +43,7 @@ L1TStage2CaloLayer2Offline::L1TStage2CaloLayer2Offline(const edm::ParameterSet& 
         httEfficiencyBins_(ps.getParameter < std::vector<double> > ("httEfficiencyBins")),
         recoHTTMaxEta_(ps.getParameter <double>("recoHTTMaxEta")),
         recoMHTMaxEta_(ps.getParameter <double>("recoMHTMaxEta")),
+        histDefinitions_(dqmoffline::l1t::readHistDefinitions(ps.getParameterSet("histDefinitions"))),
         h_controlPlots_()
 {
   edm::LogInfo("L1TStage2CaloLayer2Offline") << "Constructor "
@@ -454,7 +455,10 @@ void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker
   ibooker.cd();
   ibooker.setCurrentFolder(histFolder_);
 
-  h_nVertex_ = ibooker.book1D("nVertex", "Number of event vertices in collection", 40, -0.5, 39.5);
+  dqmoffline::l1t::HistDefinition nVertexDef = histDefinitions_["nVertex"];
+  h_nVertex_ = ibooker.book1D(
+    nVertexDef.name, nVertexDef.title, nVertexDef.nbinsX, nVertexDef.xmin, nVertexDef.xmax
+  );
 
   // energy sums control plots (monitor beyond the limits of the 2D histograms)
   h_controlPlots_[ControlPlots::L1MET] = ibooker.book1D("L1MET", "L1 E_{T}^{miss}; L1 E_{T}^{miss} (GeV); events", 500,

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -9,6 +9,11 @@
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "TLorentzVector.h"
 
+
+const std::map<std::string, unsigned int> L1TStage2CaloLayer2Offline::PlotConfigNames = {
+  {"nVertex", PlotConfig::nVertex}
+};
+
 //
 // -------------------------------------- Constructor --------------------------------------------
 //
@@ -43,7 +48,7 @@ L1TStage2CaloLayer2Offline::L1TStage2CaloLayer2Offline(const edm::ParameterSet& 
         httEfficiencyBins_(ps.getParameter < std::vector<double> > ("httEfficiencyBins")),
         recoHTTMaxEta_(ps.getParameter <double>("recoHTTMaxEta")),
         recoMHTMaxEta_(ps.getParameter <double>("recoMHTMaxEta")),
-        histDefinitions_(dqmoffline::l1t::readHistDefinitions(ps.getParameterSet("histDefinitions"))),
+        histDefinitions_(dqmoffline::l1t::readHistDefinitions(ps.getParameterSet("histDefinitions"), PlotConfigNames)),
         h_controlPlots_()
 {
   edm::LogInfo("L1TStage2CaloLayer2Offline") << "Constructor "
@@ -455,7 +460,7 @@ void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker
   ibooker.cd();
   ibooker.setCurrentFolder(histFolder_);
 
-  dqmoffline::l1t::HistDefinition nVertexDef = histDefinitions_["nVertex"];
+  dqmoffline::l1t::HistDefinition nVertexDef = histDefinitions_[PlotConfig::nVertex];
   h_nVertex_ = ibooker.book1D(
     nVertexDef.name, nVertexDef.title, nVertexDef.nbinsX, nVertexDef.xmin, nVertexDef.xmax
   );

--- a/DQMOffline/L1Trigger/src/L1TTauOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TTauOffline.cc
@@ -63,7 +63,8 @@ L1TTauOffline::L1TTauOffline(const edm::ParameterSet& ps) :
         efficiencyFolder_(histFolder_ + "/efficiency_raw"),
         stage2CaloLayer2TauToken_(consumes < l1t::TauBxCollection > (ps.getUntrackedParameter < edm::InputTag > ("l1tInputTag"))),
         tauEfficiencyThresholds_(ps.getParameter < std::vector<int> > ("tauEfficiencyThresholds")),
-        tauEfficiencyBins_(ps.getParameter < std::vector<double> > ("tauEfficiencyBins"))
+        tauEfficiencyBins_(ps.getParameter < std::vector<double> > ("tauEfficiencyBins")),
+  histDefinitions_(dqmoffline::l1t::readHistDefinitions(ps.getParameterSet("histDefinitions")))
 {
   edm::LogInfo("L1TTauOffline") << "Constructor " << "L1TTauOffline::L1TTauOffline " << std::endl;
 }
@@ -315,7 +316,10 @@ void L1TTauOffline::bookTauHistos(DQMStore::IBooker & ibooker)
 {
   ibooker.cd();
   ibooker.setCurrentFolder(histFolder_);
-  h_nVertex_ = ibooker.book1D("nVertex", "Number of event vertices in collection", 40, -0.5, 39.5);
+  dqmoffline::l1t::HistDefinition nVertexDef = histDefinitions_["nVertex"];
+  h_nVertex_ = ibooker.book1D(
+    nVertexDef.name, nVertexDef.title, nVertexDef.nbinsX, nVertexDef.xmin, nVertexDef.xmax
+  );
   h_tagAndProbeMass_ = ibooker.book1D("tagAndProbeMass", "Invariant mass of tag & probe pair", 100, 40, 140);
 
   h_L1TauETvsTauET_EB_ = ibooker.book2D("L1TauETvsTauET_EB",

--- a/DQMOffline/L1Trigger/src/L1TTauOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TTauOffline.cc
@@ -41,6 +41,9 @@ double TauL1TPair::dR() {
   return deltaR(m_regTau->eta(),m_regTau->phi(),eta(),phi());
 }
 
+const std::map<std::string, unsigned int> L1TTauOffline::PlotConfigNames = {
+  {"nVertex", PlotConfig::nVertex}
+};
 
 //
 // -------------------------------------- Constructor --------------------------------------------
@@ -64,7 +67,7 @@ L1TTauOffline::L1TTauOffline(const edm::ParameterSet& ps) :
         stage2CaloLayer2TauToken_(consumes < l1t::TauBxCollection > (ps.getUntrackedParameter < edm::InputTag > ("l1tInputTag"))),
         tauEfficiencyThresholds_(ps.getParameter < std::vector<int> > ("tauEfficiencyThresholds")),
         tauEfficiencyBins_(ps.getParameter < std::vector<double> > ("tauEfficiencyBins")),
-  histDefinitions_(dqmoffline::l1t::readHistDefinitions(ps.getParameterSet("histDefinitions")))
+  histDefinitions_(dqmoffline::l1t::readHistDefinitions(ps.getParameterSet("histDefinitions"), PlotConfigNames))
 {
   edm::LogInfo("L1TTauOffline") << "Constructor " << "L1TTauOffline::L1TTauOffline " << std::endl;
 }
@@ -316,7 +319,7 @@ void L1TTauOffline::bookTauHistos(DQMStore::IBooker & ibooker)
 {
   ibooker.cd();
   ibooker.setCurrentFolder(histFolder_);
-  dqmoffline::l1t::HistDefinition nVertexDef = histDefinitions_["nVertex"];
+  dqmoffline::l1t::HistDefinition nVertexDef = histDefinitions_[PlotConfig::nVertex];
   h_nVertex_ = ibooker.book1D(
     nVertexDef.name, nVertexDef.title, nVertexDef.nbinsX, nVertexDef.xmin, nVertexDef.xmax
   );


### PR DESCRIPTION
Fixes issue https://its.cern.ch/jira/browse/CMSLITDPG-328:
increased the max nVertex value from 40 to 100.

Since 3 modules use the same definition, I've added the functionality, `dqmoffline::l1t::HistDefinition`, to define such limits in python. The `L1TEGammaOffline`, `L1TStage2CaloLayer2Offline`, and `L1TTauOffline` modules are now using the same `nVertex` histogram definition.

Of course, `dqmoffline::l1t::HistDefinition` would technically allow for all definitions to come from the python file, which could be shared across modules. This might be addressed in a later PR.
