### PR TITLE
[RFC] remove dependency on afs for getPayloadData script

### DIFF
--- a/CondCore/HLTPlugins/test/test.sh
+++ b/CondCore/HLTPlugins/test/test.sh
@@ -15,7 +15,7 @@ mkdir -p $W_DIR/plots
 ####################
 # Test display 
 ####################
-/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+getPayloadData.py \
     --plugin pluginAlCaRecoTriggerBits_PayloadInspector \
     --plot plot_AlCaRecoTriggerBits_Display \
     --tag AlCaRecoHLTpaths8e29_1e31_v7_hlt \
@@ -29,7 +29,7 @@ mv *.png $W_DIR/plots/AlCaRecoTriggerBits_Display.png
 ####################
 # Test compare
 ####################
-/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+getPayloadData.py \
     --plugin pluginAlCaRecoTriggerBits_PayloadInspector \
     --plot plot_AlCaRecoTriggerBits_Compare \
     --tag AlCaRecoHLTpaths8e29_1e31_v7_hlt \

--- a/CondCore/PCLConfigPlugins/test/test.sh
+++ b/CondCore/PCLConfigPlugins/test/test.sh
@@ -13,7 +13,7 @@ cd $W_DIR;
 ####################
 # Test Gains
 ####################
-/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+getPayloadData.py \
     --plugin pluginAlignPCLThresholds_PayloadInspector \
     --plot plot_AlignPCLThresholds_Display \
     --tag SiPixelAliThresholds_offline_v0 \

--- a/CondCore/SiStripPlugins/test/test.sh
+++ b/CondCore/SiStripPlugins/test/test.sh
@@ -13,7 +13,7 @@ cd $W_DIR;
 ####################
 # Test Gains
 ####################
-/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+getPayloadData.py \
     --plugin pluginSiStripApvGain_PayloadInspector \
     --plot plot_SiStripApvGainsByRegion \
     --tag SiStripApvGain_FromParticles_GR10_v1_express \
@@ -25,7 +25,7 @@ cd $W_DIR;
 ######################
 # Test Lorentz Angle
 ######################
-/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+getPayloadData.py \
     --plugin pluginSiStripLorentzAngle_PayloadInspector \
     --plot plot_SiStripLorentzAngleByRegion \
     --tag  SiStripLorentzAngleDeco_GR10_v1_prompt \
@@ -37,7 +37,7 @@ cd $W_DIR;
 ######################
 # Test Backplane correction
 ######################
-/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+getPayloadData.py \
     --plugin pluginSiStripBackPlaneCorrection_PayloadInspector \
     --plot plot_SiStripBackPlaneCorrectionByRegion \
     --tag SiStripBackPlaneCorrection_deco_GR10_v1_express \
@@ -49,7 +49,7 @@ cd $W_DIR;
 ######################
 # Test Bad components
 ######################
-/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+getPayloadData.py \
     --plugin pluginSiStripBadStrip_PayloadInspector \
     --plot plot_SiStripBadStripQualityAnalysis \
     --tag  SiStripBadComponents_startupMC_for2017_v1_mc\

--- a/CondCore/SiStripPlugins/test/testGainsPayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testGainsPayloadInspector.sh
@@ -19,7 +19,7 @@ mkdir $W_DIR/plots
 ####################
 # Test Gains
 ####################
-/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+getPayloadData.py \
     --plugin pluginSiStripApvGain_PayloadInspector \
     --plot plot_SiStripApvGainsValuesComparator \
     --tag SiStripApvGainAfterAbortGap_PCL_v0_prompt \
@@ -30,7 +30,7 @@ mkdir $W_DIR/plots
 
 mv *.png $W_DIR/plots/G2_Value_update.png
 
-/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+getPayloadData.py \
     --plugin pluginSiStripApvGain_PayloadInspector \
     --plot plot_SiStripApvGainsMaxDeviationRatio2sigmaTrackerMap \
     --tag SiStripApvGainAfterAbortGap_PCL_v0_prompt \
@@ -41,7 +41,7 @@ mv *.png $W_DIR/plots/G2_Value_update.png
 
 mv *.png $W_DIR/plots/G2_MaxDeviatonRatio_update.png
 
-/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+getPayloadData.py \
     --plugin pluginSiStripApvGain_PayloadInspector \
     --plot plot_SiStripApvGainsRatioComparatorByRegion \
     --tag SiStripApvGainAfterAbortGap_PCL_v0_prompt \
@@ -52,7 +52,7 @@ mv *.png $W_DIR/plots/G2_MaxDeviatonRatio_update.png
 
 mv *.png $W_DIR/plots/G2_Ratio_update.png
 
-/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+getPayloadData.py \
     --plugin pluginSiStripApvGain_PayloadInspector \
     --plot plot_SiStripApvGainsValuesComparator \
     --tag SiStripApvGain_GR10_v1_hlt \

--- a/CondCore/SiStripPlugins/test/testNoisePayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testNoisePayloadInspector.sh
@@ -13,7 +13,7 @@ cd $W_DIR;
 ####################
 # Test Noise
 ####################
-/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+getPayloadData.py \
     --plugin pluginSiStripNoises_PayloadInspector \
     --plot plot_SiStripNoisesTest \
     --tag SiStripNoise_v2_prompt \
@@ -35,7 +35,7 @@ do
 
     #// TrackerMaps
 
-    /afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+    getPayloadData.py \
 	--plugin pluginSiStripNoises_PayloadInspector \
 	--plot plot_SiStripNoise${i}_TrackerMap \
 	--tag SiStripNoise_v2_prompt \
@@ -48,7 +48,7 @@ do
 
     #// Summaries
 
-    /afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+    getPayloadData.py \
 	--plugin pluginSiStripNoises_PayloadInspector \
 	--plot plot_SiStripNoise${i}ByRegion \
 	--tag SiStripNoise_v2_prompt \

--- a/CondCore/SiStripPlugins/test/testPedestalsPayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testPedestalsPayloadInspector.sh
@@ -13,7 +13,7 @@ cd $W_DIR;
 ####################
 # Test Pedestals
 ####################
-/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+getPayloadData.py \
     --plugin pluginSiStripPedestals_PayloadInspector \
     --plot plot_SiStripPedestalsTest \
     --tag SiStripPedestals_v2_prompt \
@@ -35,7 +35,7 @@ do
 
     #// TrackerMaps
 
-    /afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+    getPayloadData.py \
 	--plugin pluginSiStripPedestals_PayloadInspector \
 	--plot plot_SiStripPedestals${i}_TrackerMap \
 	--tag SiStripPedestals_v2_prompt \
@@ -48,7 +48,7 @@ do
     
     #// Summaries
 
-    /afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+    getPayloadData.py \
 	--plugin pluginSiStripPedestals_PayloadInspector \
 	--plot plot_SiStripPedestals${i}ByRegion \
 	--tag SiStripPedestals_v2_prompt \

--- a/CondCore/Utilities/scripts/getPayloadData.py
+++ b/CondCore/Utilities/scripts/getPayloadData.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python
+
+
+import shutil
+import glob
+import json
+import sys
+import sys
+import os
+
+from importlib  import import_module
+from argparse   import ArgumentParser, RawTextHelpFormatter
+
+
+import pluginCondDBV2PyInterface
+pluginCondDBV2PyInterface.CMSSWInit()
+
+
+
+def supress_output( f ):
+    '''
+    Temporarily disables stdout and stderr so that printouts from the plot
+    plugin does not compromise the purity of our ssh stream if 
+    args.suppress_output is true
+    '''
+    def decorated( *fargs, **fkwargs ):
+
+        suppress = args.suppress_output
+        if suppress:
+            
+            # Get rid of what is already there ( should be nothing for this script )
+            sys.stdout.flush()
+
+            # Save file descriptors so it can be reactivated later 
+            saved_stdout = os.dup( 1 )
+            saved_stderr = os.dup( 2 )
+
+            # /dev/null is used just to discard what is being printed
+            devnull = os.open( '/dev/null', os.O_WRONLY )
+
+            # Duplicate the file descriptor for /dev/null
+            # and overwrite the value for stdout (file descriptor 1)
+            os.dup2( devnull, 1 )
+            os.dup2( devnull, 2 )
+
+        result = f( *fargs, **fkwargs )
+
+        if suppress:
+
+            # Close devnull after duplication (no longer needed)
+            os.close( devnull )
+
+            # Reenable stdout and stderr
+            os.dup2( saved_stdout, 1 )
+            os.dup2( saved_stderr, 2 )
+
+        return result
+
+    return decorated
+
+
+@supress_output
+def deserialize_iovs(db, plugin_name, plot_name, tag, time_type, iovs):
+    ''' Deserializes given iovs data and returns plot coordinates '''
+    
+    output('Starting to deserialize iovs: ', '')
+    output('db: ', db)
+    output('plugin name: ', plugin_name)
+    output('plot name: ', plot_name)
+    output('tag name: ', tag)
+    output('tag time type: ', time_type)
+    output('iovs: ', iovs)
+  
+    plugin_base = import_module('pluginModule_PayloadInspector')
+    output('PI plugin base: ', plugin_base)
+
+    plugin_obj = import_module(plugin_name)
+    output('PI plugin object: ', plugin_obj)
+
+    # get plot method and execute it with given iovs
+    plot = getattr(plugin_obj, plot_name)()
+    output('plot object: ', plot)
+
+    if db == "Prod":
+        db_name = 'oracle://cms_orcon_adg/CMS_CONDITIONS'
+    elif db == 'Prep' :
+        db_name = 'oracle://cms_orcoff_prep/CMS_CONDITIONS'
+    else:
+        db_name = db
+    output('full DB name: ', db_name)
+    
+
+    success = plot.process(db_name, tag, time_type, int(iovs['start_iov']), int(iovs['end_iov']))
+    output('plot processed data successfully: ', success)
+    if not success:
+        return False
+
+
+    result = plot.data()
+    output('deserialized data: ', result)
+    return result
+
+def discover_plugins():
+    ''' Returns a list of Payload Inspector plugin names
+        Example:
+        ['pluginBasicPayload_PayloadInspector', 'pluginBeamSpot_PayloadInspector', 'pluginSiStrip_PayloadInspector']
+    '''
+    architecture = os.environ.get('SCRAM_ARCH', None)
+    output('architecture: ', architecture)
+
+    plugins = []
+    releases = [
+        os.environ.get('CMSSW_BASE', None),
+        os.environ.get('CMSSW_RELEASE_BASE', None)
+    ]
+
+    for r in releases:
+        if not r: continue # skip if release base is not specified
+        output('* release: ', r)
+
+        path = os.path.join(r, 'lib', architecture)
+        output('* full release path: ', path)
+
+        plugins += glob.glob(path + '/plugin*_PayloadInspector.so' )
+        output('found plugins: ', plugins) 
+        
+        if r: break # break loop if CMSSW_BASE is specified        
+  
+    # extracts the object name from plugin path:
+    # /afs/cern.ch/cms/slc6_amd64_gcc493/cms/cmssw/CMSSW_8_0_6/lib/slc6_amd64_gcc493/pluginBasicPayload_PayloadInspector.so
+    # becomes pluginBasicPayload_PayloadInspector
+    result = []
+    for p in plugins:
+         result.append(p.split('/')[-1].replace('.so', ''))
+
+    output('discovered plugins: ', result)
+    return result
+
+def discover():
+    ''' Discovers object types and plots for a given cmssw release
+        Example:
+        {
+            "BasicPayload": [
+                {"plot": "plot_BeamSpot_x", "plot_type": "History", 
+                 "single_iov": false, "plugin_name": "pluginBeamSpot_PayloadInspector",
+                 "title": "x vs run number"},
+                ...
+            ],
+           ...
+        }
+    '''
+    plugin_base = import_module('pluginModule_PayloadInspector') 
+    result = {}
+    for plugin_name in discover_plugins():
+        output(' - plugin name: ', plugin_name)
+        plugin_obj = import_module(plugin_name)
+        output('*** PI plugin object: ', plugin_obj)
+        for plot in dir(plugin_obj):
+            if 'plot_' not in plot: continue # skip if method doesn't start with 'plot_' prefix
+            output(' - plot name: ', plot)
+            plot_method= getattr(plugin_obj, plot)()
+            output(' - plot object: ', plot_method)
+            payload_type = plot_method.payloadType()
+            output(' - payload type: ', payload_type)
+            plot_title = plot_method.title()
+            output(' - plot title: ', plot_title)
+            plot_type = plot_method.type()
+            output(' - plot type: ', plot_type)
+            single_iov = plot_method.isSingleIov()
+            output(' - is single iov: ', single_iov)
+            result.setdefault(payload_type, []).append({'plot': plot, 'plugin_name': plugin_name, 'title': plot_title, 'plot_type': plot_type, 'single_iov': single_iov})
+            output('currently discovered info: ', result)
+    output('*** final output:', '')
+    return json.dumps(result)
+
+def output(description, param):
+    if args.verbose:
+        print ''
+        print description, param
+
+if __name__ == '__main__':
+
+    description = '''
+    Payload Inspector - data visualisation tool which is integrated into the cmsDbBrowser.
+    It allows to display plots and monitor the calibration and alignment data.
+
+    You can access Payload Inspector with a link below:
+    https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod
+
+    This script is a part of the Payload Inspector service and is responsible for:
+    a) discovering PI objects that are available in a given cmssw release
+    b) deserializing payload data which is later used as plot coordinates
+    c) testing new PI objects which are under development
+
+    To test new PI objects please do the following:
+    a) run ./getPayloadData.py --discover
+    to check if your newly created object is found by the script.
+    Please note that we strongly rely on naming conventions so if you don't
+    see your object listed you probably misnamed it in objectType() method.
+    Also all plot methods should start with "plot_" prefix.
+
+    b) second step is to test if it returns data correctly:
+    run ./getPayloadData.py --plugin YourPIPluginName --plot YourObjectPlot --tag tagName --time_type Run --iovs '{"start_iov": "201", "end_iov": "801"}' --db Prod --test 
+  
+    Here is an example for BasicPayload object:
+    run ./getPayloadData.py --plugin pluginBasicPayload_PayloadInspector --plot plot_BasicPayload_data0 --tag BasicPayload_v2 --time_type Run --iovs '{"start_iov": "201", "end_iov": "801"}' --db Prod --test
+
+    c) if it works correctly please make a pull request and once it's accepted
+    go to cmsDbBrowser and wait for the next IB to test it.
+    '''
+
+    parser = ArgumentParser(description=description, formatter_class=RawTextHelpFormatter)
+    parser.add_argument("-d", "--discover",   help="discovers object types and plots \nfor a given cmssw release", action="store_true")
+    parser.add_argument("-i", "--iovs",       help="deserializes given iovs data encoded in base64 and returns plot coordinates also encoded in base64")
+    parser.add_argument("-o", "--plugin",     help="Payload Inspector plugin name needed for iovs deserialization")
+    parser.add_argument("-p", "--plot",       help="plot name needed for iovs deserialization")
+    parser.add_argument("-t", "--tag",        help="tag name needed for iovs deserialization")
+    parser.add_argument("-tt", "--time_type", help="tag time type name needed for iovs deserialization")
+    parser.add_argument("-b", "--db",         help="db (Prod or Prep) needed for iovs deserialization")
+    parser.add_argument("-test", "--test",    help="add this flag if you want to test the deserialization function and want to see a readable output", action="store_true")
+    parser.add_argument("-v", "--verbose",    help="verbose mode. Shows more information", action="store_true")
+    parser.add_argument("-ip","--image_plot", help="Switch telling the script that this plot type is of type Image", action="store_true")
+    parser.add_argument("-s", "--suppress-output", help="Supresses output from so that stdout and stderr can be kept pure for the ssh transmission", action="store_true")
+
+    # shows help if no arguments are provided
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
+    args = parser.parse_args()
+    
+    # Return discover of plot if requested
+    if args.discover:
+        os.write( 1, discover() )
+
+    # Return a plot if iovs are provided
+    if args.iovs:
+
+        # Run plugin with arguments
+        result = deserialize_iovs(args.db, args.plugin, args.plot, args.tag, args.time_type, json.loads(args.iovs))
+        
+        # If test -> output the result as formatted json
+        if args.test:
+            os.write( 1, json.dumps( json.loads( result ), indent=4 ))
+
+        # If image plot -> get image file from result, open it and output bytes 
+        elif args.image_plot:
+
+            filename = None
+            
+            try:
+                filename = json.loads( result )['file']
+            except ValueError, e:
+                os.write( 2, 'Value error when getting image name: %s\n' % str( e ))
+            except KeyError, e:
+                os.write( 2, 'Key error when getting image name: %s\n' % str( e ))
+
+            if not filename or not os.path.isfile( filename ):
+                os.write( 2, 'Error: Generated image file (%s) not found\n' % filename )
+
+            try:
+                with open( filename, 'r' ) as f:
+                    shutil.copyfileobj( f, sys.stdout )
+            except IOError, e:
+                os.write( 2, 'IO error when streaming image: %s' % str( e ))
+            finally:
+                os.remove( filename )
+
+                        
+        # Else -> output result json string with base 64 encoding
+        else: 
+            os.write( 1, result.encode( 'base64' ))
+

--- a/CondCore/Utilities/scripts/getPayloadData.py
+++ b/CondCore/Utilities/scripts/getPayloadData.py
@@ -82,9 +82,9 @@ def deserialize_iovs(db, plugin_name, plot_name, tag, time_type, iovs):
     output('plot object: ', plot)
 
     if db == "Prod":
-        db_name = 'oracle://cms_orcon_adg/CMS_CONDITIONS'
+        db_name = 'frontier://FrontierProd/CMS_CONDITIONS'
     elif db == 'Prep' :
-        db_name = 'oracle://cms_orcoff_prep/CMS_CONDITIONS'
+        db_name = 'frontier://FrontierPrep/CMS_CONDITIONS'
     else:
         db_name = db
     output('full DB name: ', db_name)

--- a/CondCore/Utilities/src/PayloadInspector.cc
+++ b/CondCore/Utilities/src/PayloadInspector.cc
@@ -1,5 +1,7 @@
 #include "CondCore/Utilities/interface/PayloadInspector.h"
 #include "CondCore/CondDB/interface/ConnectionPool.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 
 #include <sstream>
 #include <iostream>
@@ -45,6 +47,14 @@ namespace cond {
 
     bool PlotBase::process( const std::string& connectionString,  const std::string& tag, const std::string& timeType, cond::Time_t begin, cond::Time_t end ){
       init();
+
+      std::vector<edm::ParameterSet> psets;
+      edm::ParameterSet pSet;
+      pSet.addParameter("@service_type",std::string("SiteLocalConfigService"));
+      psets.push_back(pSet);
+      static const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
+      static const edm::ServiceRegistry::Operate operate(services);
+
       m_tagTimeType = cond::time::timeTypeFromName(timeType);
       cond::persistency::ConnectionPool connection;
       m_dbSession = connection.createSession( connectionString );


### PR DESCRIPTION
As requested in https://github.com/cms-sw/cmssw/pull/21417#discussion_r153776820 and https://github.com/cms-sw/cmssw/pull/21266#discussion_r152192952, this PR is meant to distribute the `getPayloadData` script with the release rather than calling it from an afs location. It's a request for comments as I am not completely sure how having the script callable without local checkout is going to affect the client code in `cmsDbBrowser`. 
The script is almost the same as in `/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py`, the only modification I made is to provide the functionality to inspect also other DB types other than oracle (e.g. local sqlite files):

```diff
diff --git a/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py b/getPayloadData.py
index 96aad99dab8..1ef9ed6fcb5 100755
--- a/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py
+++ b/getPayloadData.py
@@ -81,9 +81,14 @@ def deserialize_iovs(db, plugin_name, plot_name, tag, time_type, iovs):
     plot = getattr(plugin_obj, plot_name)()
     output('plot object: ', plot)
 
-    db_name = 'oracle://cms_orcon_adg/CMS_CONDITIONS' if db == 'Prod' else 'oracle://cms_orcoff_prep/CMS_CONDITIONS'
+    if db == "Prod":
+        db_name = 'oracle://cms_orcon_adg/CMS_CONDITIONS'
+    elif db == 'Prep' :
+        db_name = 'oracle://cms_orcoff_prep/CMS_CONDITIONS'
+    else:
+        db_name = db
     output('full DB name: ', db_name)
```
Attn: @ggovi, if you are working on some more sophisticated solution, just let me know and I'll close this PR. 
Thanks 