### PR TITLE
Make DQM headers compile with C++ modules.

### DIFF
--- a/DQM/DataScouting/interface/RazorVarProducer.h
+++ b/DQM/DataScouting/interface/RazorVarProducer.h
@@ -9,6 +9,7 @@
 
 #include "TLorentzVector.h"
 #include "DataFormats/METReco/interface/CaloMETFwd.h"
+#include "DataFormats/Math/interface/LorentzVectorFwd.h"
 #include <vector>
 
 class RazorVarProducer : public edm::EDProducer {

--- a/DQM/EcalMonitorDbModule/interface/MonitorXMLParser.h
+++ b/DQM/EcalMonitorDbModule/interface/MonitorXMLParser.h
@@ -9,6 +9,7 @@
 #define MonitorXMLParser_h
 
 #include <string>
+#include <sstream>
 #include <vector>
 #include <map>
 #include <iostream>

--- a/DQM/L1TMonitor/interface/L1TMenuHelper.h
+++ b/DQM/L1TMonitor/interface/L1TMenuHelper.h
@@ -18,6 +18,7 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"

--- a/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
+++ b/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
@@ -20,6 +20,7 @@
 #include "DQM/SiStripCommon/interface/TkHistoMap.h"
 #include "DQM/SiStripCommon/interface/APVShotFinder.h"
 #include "DQM/SiStripCommon/interface/APVShot.h"
+#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 

--- a/DQM/SiStripMonitorHardware/interface/FEDErrors.hh
+++ b/DQM/SiStripMonitorHardware/interface/FEDErrors.hh
@@ -23,6 +23,8 @@
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
+#include "DQMServices/Core/interface/MonitorElement.h"
+
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h"

--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -27,7 +27,7 @@ Monitoring source for general quantities related to tracks.
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/Scalers/interface/LumiScalers.h"
 
-class DQMStore;
+#include "DQMServices/Core/interface/DQMStore.h"
 
 class BeamSpot;
 namespace dqm {

--- a/DQM/TrackingMonitor/interface/TrackSplittingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackSplittingMonitor.h
@@ -16,6 +16,7 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -16,6 +16,7 @@ Monitoring source for general quantities related to tracks.
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -23,12 +24,16 @@ Monitoring source for general quantities related to tracks.
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h" 
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h" 
+
+#include "DataFormats/TrackReco/interface/SeedStopInfo.h"
 
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 

--- a/DQM/TrackingMonitor/interface/VertexMonitor.h
+++ b/DQM/TrackingMonitor/interface/VertexMonitor.h
@@ -21,13 +21,13 @@ Monitoring source for general quantities related to vertex
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 class GetLumi;
-class DQMStore;
 
 class VertexMonitor
 {

--- a/DQMOffline/JetMET/interface/SUSYDQMAnalyzer.h
+++ b/DQMOffline/JetMET/interface/SUSYDQMAnalyzer.h
@@ -16,6 +16,10 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#include "DataFormats/METReco/interface/PFMETCollection.h"
+#include "DataFormats/METReco/interface/CaloMETCollection.h"
+
 #include <string>
 
 

--- a/DQMOffline/JetMET/interface/SusyDQM/special_less.h
+++ b/DQMOffline/JetMET/interface/SusyDQM/special_less.h
@@ -1,6 +1,7 @@
 #ifndef SPECIAL_LESS
 #define SPECIAL_LESS
 
+#include <cmath>
 #include <functional>
 
 struct fabs_less { 

--- a/DQMOffline/RecoB/interface/IPTagPlotter_cc.h
+++ b/DQMOffline/RecoB/interface/IPTagPlotter_cc.h
@@ -1,3 +1,6 @@
+#ifndef DQMOffline_RecoB_IPTagPlotter_cc_h
+#define DQMOffline_RecoB_IPTagPlotter_cc_h
+
 #include <cstddef>
 #include <string>
 
@@ -676,3 +679,5 @@ reco::TrackBase::TrackQuality IPTagPlotter<Container, Base>::highestTrackQual(co
 
   return reco::TrackBase::undefQuality;
 }
+
+#endif // DQMOffline_RecoB_IPTagPlotter_cc_h

--- a/DQMOffline/Trigger/interface/HLTDQMFilterEffHists.h
+++ b/DQMOffline/Trigger/interface/HLTDQMFilterEffHists.h
@@ -30,6 +30,7 @@
 #include "DQMOffline/Trigger/interface/HLTDQMHist.h"
 #include "DQMOffline/Trigger/interface/VarRangeCutColl.h"
 #include "DQMOffline/Trigger/interface/FunctionDefs.h"
+#include "DQMOffline/Trigger/interface/UtilFuncs.h"
 
 template <typename ObjType> 
 class HLTDQMFilterEffHists {

--- a/DQMOffline/Trigger/interface/HLTDQMFilterTnPEffHists.h
+++ b/DQMOffline/Trigger/interface/HLTDQMFilterTnPEffHists.h
@@ -21,6 +21,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DQMOffline/Trigger/interface/HLTDQMFilterEffHists.h"
+#include "DQMOffline/Trigger/interface/UtilFuncs.h"
 
 #include <string>
 

--- a/DQMOffline/Trigger/interface/HLTDQMHist.h
+++ b/DQMOffline/Trigger/interface/HLTDQMHist.h
@@ -23,6 +23,12 @@
 //***********************************************************************************
 
 #include "DQMOffline/Trigger/interface/FunctionDefs.h"
+#include "DQMOffline/Trigger/interface/VarRangeCutColl.h"
+
+#include "FWCore/Framework/interface/Event.h"
+
+#include <TH1.h>
+#include <TH2.h>
 
 //our base class for our histograms
 //takes an object, edm::Event,edm::EventSetup and fills the histogram

--- a/DQMServices/ClientConfig/interface/ParserFunctions.h
+++ b/DQMServices/ClientConfig/interface/ParserFunctions.h
@@ -1,3 +1,11 @@
+#ifndef DQMServices_ClientConfig_ParserFunctions_h
+#define DQMServices_ClientConfig_ParserFunctions_h
+
+#include "xercesc/util/XercesDefs.hpp"
+#include "xercesc/parsers/XercesDOMParser.hpp"
+
+#include <string>
+
 namespace qtxml{
 	inline std::string _toString(const XMLCh *toTranscode){
 		std::string tmp(xercesc::XMLString::transcode(toTranscode));
@@ -10,3 +18,4 @@ namespace qtxml{
 	}
 
 }
+#endif // DQMServices_ClientConfig_ParserFunctions_h


### PR DESCRIPTION
These commits make the DQM headers either parsable on their own (which is a requirement for clang's C++ modules) and/or add header guards to them.

You can read more about this on the tracking issue for C++ modules: #15248