### PR TITLE
Implement ability to run external work

### DIFF
--- a/FWCore/Concurrency/interface/WaitingTask.h
+++ b/FWCore/Concurrency/interface/WaitingTask.h
@@ -31,13 +31,15 @@
 namespace edm {
   class WaitingTaskList;
   class WaitingTaskHolder;
-  
+  class WaitingTaskWithArenaHolder;
+
   class WaitingTask : public tbb::task {
       
    public:
     friend class WaitingTaskList;
     friend class WaitingTaskHolder;
-    
+    friend class WaitingTaskWithArenaHolder;
+
     ///Constructor
     WaitingTask() : m_ptr{nullptr} {}
     ~WaitingTask() override {

--- a/FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h
+++ b/FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h
@@ -22,9 +22,7 @@
 #include <exception>
 #include <memory>
 
-namespace tbb {
-  class task_arena;
-}
+#include "tbb/task_arena.h"
 
 namespace edm {
 

--- a/FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h
+++ b/FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h
@@ -1,0 +1,118 @@
+#ifndef FWCore_Concurrency_WaitingTaskWithArenaHolder_h
+#define FWCore_Concurrency_WaitingTaskWithArenaHolder_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Concurrency
+// Class  :     WaitingTaskWithArenaHolder
+//
+/**\class edm::WaitingTaskWithArenaHolder
+
+ Description: This holds a WaitingTask and can be passed to something
+ the WaitingTask is waiting for. That allows that something to call
+ doneWaiting to let the WaitingTask know it can run. The use of the
+ arena allows one to call doneWaiting from a thread external to arena
+ where the task should run. The external thread might be a non-TBB
+ thread.
+
+ Usage:
+
+*/
+//
+// Original Author:  W. David Dagenhart
+//         Created:  9 November 2017
+//
+
+#include <memory>
+
+#include "tbb/task_arena.h"
+
+#include "FWCore/Concurrency/interface/WaitingTask.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+
+namespace edm {
+
+  class WaitingTaskWithArenaHolder {
+  public:
+
+    WaitingTaskWithArenaHolder() : m_task(nullptr) {}
+
+    // Note that the arena is to be the one containing the thread
+    // that runs this constructor. This is the arena where you
+    // eventually intend for the task to be spawned.
+    explicit WaitingTaskWithArenaHolder(edm::WaitingTask* iTask) :
+      m_task(iTask),
+      m_arena(std::make_shared<tbb::task_arena>(tbb::task_arena::attach())) {
+
+      m_task->increment_ref_count();
+    }
+
+    ~WaitingTaskWithArenaHolder() {
+      if(m_task) {
+        doneWaiting(std::exception_ptr{});
+      }
+    }
+
+    WaitingTaskWithArenaHolder(WaitingTaskWithArenaHolder const& iHolder) :
+      m_task(iHolder.m_task),
+      m_arena(iHolder.m_arena) {
+
+      m_task->increment_ref_count();
+    }
+
+    WaitingTaskWithArenaHolder(WaitingTaskWithArenaHolder&& iOther) :
+      m_task(iOther.m_task),
+      m_arena(std::move(iOther.m_arena)) {
+
+      iOther.m_task = nullptr;
+    }
+
+    WaitingTaskWithArenaHolder& operator=(const WaitingTaskWithArenaHolder& iRHS) {
+      WaitingTaskWithArenaHolder tmp(iRHS);
+      std::swap(m_task, tmp.m_task);
+      std::swap(m_arena, tmp.m_arena);
+      return *this;
+    }
+
+    // This spawns the task. The arena is needed to get the task spawned
+    // into the correct arena of threads. Use of the arena allows doneWaiting
+    // to be called from a thread outside the arena of threads that will manage
+    // the task. doneWaiting can be called from a non-TBB thread.
+    void doneWaiting(std::exception_ptr iExcept) {
+      if(iExcept) {
+        m_task->dependentTaskFailed(iExcept);
+      }
+      if(0 == m_task->decrement_ref_count()) {
+        // The enqueue call will cause a worker thread to be created in
+        // the arena if there is not one already.
+        m_arena->enqueue( [m_task = m_task](){ tbb::task::spawn(*m_task); });
+      }
+      m_task = nullptr;
+    }
+
+    // This next function is useful if you know from the context that
+    // m_arena (which is set when the  constructor was executes) is the
+    // same arena in which you want to execute the doneWaiting function.
+    // It allows an optimization which avoids the enqueue step in the
+    // doneWaiting function.
+    //
+    // Be warned though that in general this function cannot be used.
+    // Spawning a task outside the correct arena could create a new separate
+    // arena with its own extra TBB worker threads if this function is used
+    // in an inappropriate context (and silently such that you might not notice
+    // the problem quickly).
+
+    WaitingTaskHolder makeWaitingTaskHolderAndRelease() {
+      WaitingTaskHolder holder(m_task);
+      m_task->decrement_ref_count();
+      m_task = nullptr;
+      return holder;
+    }
+
+  private:
+
+    // ---------- member data --------------------------------
+    WaitingTask* m_task;
+    std::shared_ptr<tbb::task_arena> m_arena;
+  };
+}
+#endif

--- a/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
+++ b/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
@@ -1,0 +1,98 @@
+// -*- C++ -*-
+//
+// Package:     Concurrency
+// Class  :     WaitingTaskWithArenaHolder
+//
+// Original Author:  W. David Dagenhart
+//         Created:  6 December 2017
+
+#include "tbb/task_arena.h"
+
+#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
+#include "FWCore/Concurrency/interface/WaitingTask.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+
+namespace edm {
+
+  WaitingTaskWithArenaHolder::WaitingTaskWithArenaHolder() : m_task(nullptr) {
+  }
+
+  // Note that the arena will be the one containing the thread
+  // that runs this constructor. This is the arena where you
+  // eventually intend for the task to be spawned.
+  WaitingTaskWithArenaHolder::WaitingTaskWithArenaHolder(WaitingTask* iTask) :
+    m_task(iTask),
+    m_arena(std::make_shared<tbb::task_arena>(tbb::task_arena::attach())) {
+
+    m_task->increment_ref_count();
+  }
+
+  WaitingTaskWithArenaHolder::~WaitingTaskWithArenaHolder() {
+    if (m_task) {
+      doneWaiting(std::exception_ptr{});
+    }
+  }
+
+  WaitingTaskWithArenaHolder::WaitingTaskWithArenaHolder(WaitingTaskWithArenaHolder const& iHolder) :
+    m_task(iHolder.m_task),
+    m_arena(iHolder.m_arena) {
+
+    m_task->increment_ref_count();
+  }
+
+  WaitingTaskWithArenaHolder::WaitingTaskWithArenaHolder(WaitingTaskWithArenaHolder&& iOther) :
+    m_task(iOther.m_task),
+    m_arena(std::move(iOther.m_arena)) {
+
+    iOther.m_task = nullptr;
+  }
+
+  WaitingTaskWithArenaHolder& WaitingTaskWithArenaHolder::operator=(const WaitingTaskWithArenaHolder& iRHS) {
+    WaitingTaskWithArenaHolder tmp(iRHS);
+    std::swap(m_task, tmp.m_task);
+    std::swap(m_arena, tmp.m_arena);
+    return *this;
+  }
+
+  WaitingTaskWithArenaHolder& WaitingTaskWithArenaHolder::operator=(WaitingTaskWithArenaHolder&& iRHS) {
+    WaitingTaskWithArenaHolder tmp(std::move(iRHS));
+    std::swap(m_task, tmp.m_task);
+    std::swap(m_arena, tmp.m_arena);
+    return *this;
+  }
+
+  // This spawns the task. The arena is needed to get the task spawned
+  // into the correct arena of threads. Use of the arena allows doneWaiting
+  // to be called from a thread outside the arena of threads that will manage
+  // the task. doneWaiting can be called from a non-TBB thread.
+  void WaitingTaskWithArenaHolder::doneWaiting(std::exception_ptr iExcept) {
+    if (iExcept) {
+      m_task->dependentTaskFailed(iExcept);
+    }
+    if (0 == m_task->decrement_ref_count()) {
+      // The enqueue call will cause a worker thread to be created in
+      // the arena if there is not one already.
+      m_arena->enqueue( [m_task = m_task](){ tbb::task::spawn(*m_task); });
+    }
+    m_task = nullptr;
+  }
+
+  // This next function is useful if you know from the context that
+  // m_arena (which is set when the  constructor was executes) is the
+  // same arena in which you want to execute the doneWaiting function.
+  // It allows an optimization which avoids the enqueue step in the
+  // doneWaiting function.
+  //
+  // Be warned though that in general this function cannot be used.
+  // Spawning a task outside the correct arena could create a new separate
+  // arena with its own extra TBB worker threads if this function is used
+  // in an inappropriate context (and silently such that you might not notice
+  // the problem quickly).
+
+  WaitingTaskHolder WaitingTaskWithArenaHolder::makeWaitingTaskHolderAndRelease() {
+    WaitingTaskHolder holder(m_task);
+    m_task->decrement_ref_count();
+    m_task = nullptr;
+    return holder;
+  }
+}

--- a/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
+++ b/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
@@ -6,8 +6,6 @@
 // Original Author:  W. David Dagenhart
 //         Created:  6 December 2017
 
-#include "tbb/task_arena.h"
-
 #include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
 #include "FWCore/Concurrency/interface/WaitingTask.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"

--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -88,6 +88,8 @@ namespace edm {
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
 
+    bool hasAcquire() const { return false; }
+
     void setModuleDescription(ModuleDescription const& md) {
       moduleDescription_ = md;
     }

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -100,7 +100,9 @@ namespace edm {
     virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&){}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
-     
+
+    bool hasAcquire() const { return false; }
+
     void setModuleDescription(ModuleDescription const& md) {
       moduleDescription_ = md;
     }

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -96,6 +96,8 @@ namespace edm {
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
 
+    bool hasAcquire() const { return false; }
+
     void setModuleDescription(ModuleDescription const& md) {
       moduleDescription_ = md;
     }

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -77,7 +77,9 @@ namespace edm {
 
     void setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer);
     
-    void setProducer( ProducerBase const* iProd, std::vector<BranchID>* previousParentage );
+    void setProducer(ProducerBase const* iProd,
+                     std::vector<BranchID>* previousParentage,
+                     std::vector<BranchID>* gotBranchIDsFromAcquire = nullptr);
 
     // AUX functions are defined in EventBase
     EventAuxiliary const& eventAuxiliary() const override {return aux_;}
@@ -313,8 +315,10 @@ namespace edm {
     mutable BranchIDSet gotBranchIDs_;
     mutable std::vector<bool> gotBranchIDsFromPrevious_;
     std::vector<BranchID>* previousBranchIDs_ = nullptr;
-    
+    std::vector<BranchID>* gotBranchIDsFromAcquire_ = nullptr;
+
     void addToGotBranchIDs(Provenance const& prov) const;
+    void addToGotBranchIDs(BranchID const& branchID) const;
 
     // We own the retrieved Views, and have to destroy them.
     mutable std::vector<std::shared_ptr<ViewBase> > gotViews_;

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -76,10 +76,17 @@ namespace edm {
     void setConsumer(EDConsumerBase const* iConsumer);
 
     void setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer);
-    
+
+    void setProducerCommon(ProducerBase const* iProd,
+                           std::vector<BranchID>* previousParentage);
+
     void setProducer(ProducerBase const* iProd,
                      std::vector<BranchID>* previousParentage,
                      std::vector<BranchID>* gotBranchIDsFromAcquire = nullptr);
+
+    void setProducerForAcquire(ProducerBase const* iProd,
+                               std::vector<BranchID>* previousParentage,
+                               std::vector<BranchID>& gotBranchIDsFromAcquire);
 
     // AUX functions are defined in EventBase
     EventAuxiliary const& eventAuxiliary() const override {return aux_;}

--- a/FWCore/Framework/interface/OccurrenceTraits.h
+++ b/FWCore/Framework/interface/OccurrenceTraits.h
@@ -34,9 +34,9 @@ namespace edm {
   public:
     typedef EventPrincipal MyPrincipal;
     typedef StreamContext Context;
-    static BranchType const branchType_ = InEvent;
-    static bool const begin_ = true;
-    static bool const isEvent_ = true;
+    static BranchType constexpr branchType_ = InEvent;
+    static bool constexpr begin_ = true;
+    static bool constexpr isEvent_ = true;
 
     static void setStreamContext(StreamContext& streamContext, MyPrincipal const& principal) {
       streamContext.setTransition(StreamContext::Transition::kEvent);
@@ -67,9 +67,9 @@ namespace edm {
   public:
     typedef RunPrincipal MyPrincipal;
     typedef GlobalContext Context;
-    static BranchType const branchType_ = InRun;
-    static bool const begin_ = true;
-    static bool const isEvent_ = false;
+    static BranchType constexpr branchType_ = InRun;
+    static bool constexpr begin_ = true;
+    static bool constexpr isEvent_ = false;
 
     static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
       return GlobalContext(GlobalContext::Transition::kBeginRun,
@@ -106,9 +106,9 @@ namespace edm {
   public:
     typedef RunPrincipal MyPrincipal;
     typedef StreamContext Context;
-    static BranchType const branchType_ = InRun;
-    static bool const begin_ = true;
-    static bool const isEvent_ = false;
+    static BranchType constexpr branchType_ = InRun;
+    static bool constexpr begin_ = true;
+    static bool constexpr isEvent_ = false;
 
     static void setStreamContext(StreamContext& streamContext, MyPrincipal const& principal) {
       streamContext.setTransition(StreamContext::Transition::kBeginRun);
@@ -144,9 +144,9 @@ namespace edm {
   public:
     typedef RunPrincipal MyPrincipal;
     typedef StreamContext Context;
-    static BranchType const branchType_ = InRun;
-    static bool const begin_ = false;
-    static bool const isEvent_ = false;
+    static BranchType constexpr branchType_ = InRun;
+    static bool constexpr begin_ = false;
+    static bool constexpr isEvent_ = false;
 
     static void setStreamContext(StreamContext& streamContext, MyPrincipal const& principal) {
       streamContext.setTransition(StreamContext::Transition::kEndRun);
@@ -182,9 +182,9 @@ namespace edm {
   public:
     typedef RunPrincipal MyPrincipal;
     typedef GlobalContext Context;
-    static BranchType const branchType_ = InRun;
-    static bool const begin_ = false;
-    static bool const isEvent_ = false;
+    static BranchType constexpr branchType_ = InRun;
+    static bool constexpr begin_ = false;
+    static bool constexpr isEvent_ = false;
 
     static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
       return GlobalContext(GlobalContext::Transition::kEndRun,
@@ -221,9 +221,9 @@ namespace edm {
   public:
     typedef LuminosityBlockPrincipal MyPrincipal;
     typedef GlobalContext Context;
-    static BranchType const branchType_ = InLumi;
-    static bool const begin_ = true;
-    static bool const isEvent_ = false;
+    static BranchType constexpr branchType_ = InLumi;
+    static bool constexpr begin_ = true;
+    static bool constexpr isEvent_ = false;
 
     static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
       return GlobalContext(GlobalContext::Transition::kBeginLuminosityBlock,
@@ -260,9 +260,9 @@ namespace edm {
   public:
     typedef LuminosityBlockPrincipal MyPrincipal;
     typedef StreamContext Context;
-    static BranchType const branchType_ = InLumi;
-    static bool const begin_ = true;
-    static bool const isEvent_ = false;
+    static BranchType constexpr branchType_ = InLumi;
+    static bool constexpr begin_ = true;
+    static bool constexpr isEvent_ = false;
 
     static void setStreamContext(StreamContext& streamContext, MyPrincipal const& principal) {
       streamContext.setTransition(StreamContext::Transition::kBeginLuminosityBlock);
@@ -298,9 +298,9 @@ namespace edm {
   public:
     typedef LuminosityBlockPrincipal MyPrincipal;
     typedef StreamContext Context;
-    static BranchType const branchType_ = InLumi;
-    static bool const begin_ = false;
-    static bool const isEvent_ = false;
+    static BranchType constexpr branchType_ = InLumi;
+    static bool constexpr begin_ = false;
+    static bool constexpr isEvent_ = false;
 
     static StreamContext const* context(StreamContext const* s, GlobalContext const*) { return s; }
 
@@ -338,9 +338,9 @@ namespace edm {
   public:
     typedef LuminosityBlockPrincipal MyPrincipal;
     typedef GlobalContext Context;
-    static BranchType const branchType_ = InLumi;
-    static bool const begin_ = false;
-    static bool const isEvent_ = false;
+    static BranchType constexpr branchType_ = InLumi;
+    static bool constexpr begin_ = false;
+    static bool constexpr isEvent_ = false;
 
     static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
       return GlobalContext(GlobalContext::Transition::kEndLuminosityBlock,

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -226,6 +226,8 @@ namespace edm {
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
 
+    bool hasAcquire() const { return false; }
+
     virtual bool isFileOpen() const { return true; }
 
     void keepThisBranch(BranchDescription const& desc,

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -138,7 +138,9 @@ namespace edm {
       virtual void doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c);
       virtual void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c);
       virtual void doEndLuminosityBlock_(LuminosityBlock const& lb, EventSetup const& c);
-      
+
+      bool hasAcquire() const { return false; }
+
       void setModuleDescription(ModuleDescription const& md) {
         moduleDescription_ = md;
       }

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -120,8 +120,8 @@ namespace edm {
       virtual void endJob(){}
       
 
-      virtual void preallocStreams(unsigned int);
-      virtual void preallocate(unsigned int);
+      virtual void preallocStreams(PreallocationConfiguration const&);
+      virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);
       virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -121,6 +121,7 @@ namespace edm {
       
 
       virtual void preallocStreams(unsigned int);
+      virtual void preallocate(unsigned int);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);
       virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -120,7 +120,7 @@ namespace edm {
       virtual void endJob(){}
       
 
-      virtual void preallocStreams(PreallocationConfiguration const&);
+      virtual void preallocStreams(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -38,6 +38,7 @@ namespace edm {
   class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
+  class WaitingTaskWithArenaHolder;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -69,9 +70,13 @@ namespace edm {
       virtual bool wantsStreamLuminosityBlocks() const =0;
 
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const&, EventSetup const&,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
+      void doAcquire(EventPrincipal const&, EventSetup const&,
+                     ActivityRegistry*,
+                     ModuleCallingContext const*,
+                     WaitingTaskWithArenaHolder&);
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
 
@@ -146,16 +151,19 @@ namespace edm {
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
-      
-      
+
+      virtual bool hasAcquire() const { return false; }
+
+      virtual void doAcquire_(StreamID, Event const&, edm::EventSetup const&, WaitingTaskWithArenaHolder&);
+
       void setModuleDescription(ModuleDescription const& md) {
         moduleDescription_ = md;
       }
       ModuleDescription moduleDescription_;
       std::unique_ptr<std::vector<BranchID>[]> previousParentages_; //Per stream in the future?
+      std::unique_ptr<std::vector<BranchID>[]> gotBranchIDsFromAcquire_;
       std::unique_ptr<ParentageID[]> previousParentageIds_;
     };
-
   }
 }
 

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -128,8 +128,8 @@ namespace edm {
       virtual void beginJob() {}
       virtual void endJob(){}
 
-      virtual void preallocStreams(unsigned int);
-      virtual void preallocate(unsigned int);
+      virtual void preallocStreams(PreallocationConfiguration const&);
+      virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);
       virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -129,6 +129,7 @@ namespace edm {
       virtual void endJob(){}
 
       virtual void preallocStreams(unsigned int);
+      virtual void preallocate(unsigned int);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);
       virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -128,7 +128,7 @@ namespace edm {
       virtual void beginJob() {}
       virtual void endJob(){}
 
-      virtual void preallocStreams(PreallocationConfiguration const&);
+      virtual void preallocStreams(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -131,7 +131,7 @@ namespace edm {
       virtual void beginJob() {}
       virtual void endJob(){}
 
-      virtual void preallocStreams(PreallocationConfiguration const&);
+      virtual void preallocStreams(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -39,6 +39,7 @@ namespace edm {
   class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
+  class WaitingTaskWithArenaHolder;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -72,9 +73,13 @@ namespace edm {
       virtual bool wantsStreamLuminosityBlocks() const =0;
 
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+      bool doEvent(EventPrincipal const&, EventSetup const&,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
+      void doAcquire(EventPrincipal const&, EventSetup const&,
+                     ActivityRegistry*,
+                     ModuleCallingContext const*,
+                     WaitingTaskWithArenaHolder&);
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
       void doEndJob();
@@ -149,13 +154,17 @@ namespace edm {
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
-      
-      
+
+      virtual bool hasAcquire() const { return false; }
+
+      virtual void doAcquire_(StreamID, Event const&, edm::EventSetup const&, WaitingTaskWithArenaHolder&);
+
       void setModuleDescription(ModuleDescription const& md) {
         moduleDescription_ = md;
       }
       ModuleDescription moduleDescription_;
       std::unique_ptr<std::vector<BranchID>[]> previousParentages_;
+      std::unique_ptr<std::vector<BranchID>[]> gotBranchIDsFromAcquire_;
       std::unique_ptr<ParentageID[]> previousParentageIds_;
     };
 

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -132,6 +132,7 @@ namespace edm {
       virtual void endJob(){}
 
       virtual void preallocStreams(unsigned int);
+      virtual void preallocate(unsigned int);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);
       virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -131,8 +131,8 @@ namespace edm {
       virtual void beginJob() {}
       virtual void endJob(){}
 
-      virtual void preallocStreams(unsigned int);
-      virtual void preallocate(unsigned int);
+      virtual void preallocStreams(PreallocationConfiguration const&);
+      virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);
       virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -245,8 +245,8 @@ namespace edm {
       virtual void openFile(FileBlock const&) {}
       virtual bool isFileOpen() const { return true; }
       
-      virtual void preallocStreams(unsigned int){}
-      virtual void preallocate(unsigned int){}
+      virtual void preallocStreams(PreallocationConfiguration const&){}
+      virtual void preallocate(PreallocationConfiguration const&){}
       virtual void doBeginStream_(StreamID){}
       virtual void doEndStream_(StreamID){}
       virtual void doStreamBeginRun_(StreamID, RunForOutput const&, EventSetup const&){}

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -246,6 +246,7 @@ namespace edm {
       virtual bool isFileOpen() const { return true; }
       
       virtual void preallocStreams(unsigned int){}
+      virtual void preallocate(unsigned int){}
       virtual void doBeginStream_(StreamID){}
       virtual void doEndStream_(StreamID){}
       virtual void doStreamBeginRun_(StreamID, RunForOutput const&, EventSetup const&){}

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -245,7 +245,7 @@ namespace edm {
       virtual void openFile(FileBlock const&) {}
       virtual bool isFileOpen() const { return true; }
       
-      virtual void preallocStreams(PreallocationConfiguration const&){}
+      virtual void preallocStreams(unsigned int){}
       virtual void preallocate(PreallocationConfiguration const&){}
       virtual void doBeginStream_(StreamID){}
       virtual void doEndStream_(StreamID){}

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -265,7 +265,9 @@ namespace edm {
       virtual void doEndLuminosityBlockSummary_(LuminosityBlockForOutput const&, EventSetup const&){}
       virtual void doRespondToOpenInputFile_(FileBlock const&) {}
       virtual void doRespondToCloseInputFile_(FileBlock const&) {}
-      
+
+      bool hasAcquire() const { return false; }
+
       void keepThisBranch(BranchDescription const& desc,
                           std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
                           std::set<BranchID>& keptProductsInEvent);

--- a/FWCore/Framework/interface/global/filterAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/filterAbilityToImplementor.h
@@ -75,7 +75,11 @@ namespace edm {
       struct AbilityToImplementor<edm::EndLuminosityBlockProducer> {
         typedef edm::global::impl::EndLuminosityBlockProducer<edm::global::EDFilterBase> Type;
       };
-      
+      template<>
+      struct AbilityToImplementor<edm::ExternalWork> {
+        typedef edm::global::impl::ExternalWork<edm::global::EDFilterBase> Type;
+      };
+
       template<bool,bool,typename T> struct SpecializeAbilityToImplementor {
         typedef typename AbilityToImplementor<T>::Type Type;
       };

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -302,7 +302,7 @@ namespace edm {
         ExternalWork() = default;
         ExternalWork(ExternalWork const&) = delete;
         ExternalWork& operator=(ExternalWork const&) = delete;
-        ~ExternalWork() noexcept(false) {};
+        ~ExternalWork() noexcept(false) override {};
 
       private:
 
@@ -311,7 +311,7 @@ namespace edm {
         void doAcquire_(StreamID,
                         Event const&,
                         edm::EventSetup const&,
-                        WaitingTaskWithArenaHolder&) override final;
+                        WaitingTaskWithArenaHolder&) final;
 
         virtual void acquire(StreamID,
                              Event const&,

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -55,9 +55,7 @@ namespace edm {
       private:
         void preallocStreams(unsigned int iNStreams) final {
           caches_.resize(iNStreams,static_cast<C*>(nullptr));
-          preallocStreamsExtend(iNStreams);
         }
-        virtual void preallocStreamsExtend(unsigned int iNStreams) {}
         void doBeginStream_(StreamID id) final {
           caches_[id.value()] = beginStream(id).release();
         }

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -24,6 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
@@ -53,8 +54,8 @@ namespace edm {
       protected:
         C * streamCache(edm::StreamID iID) const { return caches_[iID.value()]; }
       private:
-        void preallocStreams(unsigned int iNStreams) final {
-          caches_.resize(iNStreams,static_cast<C*>(nullptr));
+        void preallocStreams(PreallocationConfiguration const& iPrealloc) final {
+          caches_.resize(iPrealloc.numberOfStreams(),static_cast<C*>(nullptr));
         }
         void doBeginStream_(StreamID id) final {
           caches_[id.value()] = beginStream(id).release();

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -24,7 +24,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
@@ -54,8 +53,8 @@ namespace edm {
       protected:
         C * streamCache(edm::StreamID iID) const { return caches_[iID.value()]; }
       private:
-        void preallocStreams(PreallocationConfiguration const& iPrealloc) final {
-          caches_.resize(iPrealloc.numberOfStreams(),static_cast<C*>(nullptr));
+        void preallocStreams(unsigned int iNStreams) final {
+          caches_.resize(iNStreams,static_cast<C*>(nullptr));
         }
         void doBeginStream_(StreamID id) final {
           caches_[id.value()] = beginStream(id).release();

--- a/FWCore/Framework/interface/global/producerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/producerAbilityToImplementor.h
@@ -76,6 +76,11 @@ namespace edm {
         typedef edm::global::impl::EndLuminosityBlockProducer<edm::global::EDProducerBase> Type;
       };
       
+      template<>
+      struct AbilityToImplementor<edm::ExternalWork> {
+        typedef edm::global::impl::ExternalWork<edm::global::EDProducerBase> Type;
+      };
+
       template<bool,bool,typename T> struct SpecializeAbilityToImplementor {
         typedef typename AbilityToImplementor<T>::Type Type;
       };

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -144,7 +144,9 @@ namespace edm {
       virtual void doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c);
       virtual void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c);
       virtual void doEndLuminosityBlock_(LuminosityBlock const& lb, EventSetup const& c);
-      
+
+      bool hasAcquire() const { return false; }
+
       void setModuleDescription(ModuleDescription const& md) {
         moduleDescription_ = md;
       }

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -127,6 +127,7 @@ namespace edm {
       
 
       virtual void preallocStreams(unsigned int);
+      virtual void preallocate(unsigned int);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);
       virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -126,7 +126,7 @@ namespace edm {
       virtual void endJob(){}
       
 
-      virtual void preallocStreams(PreallocationConfiguration const&);
+      virtual void preallocStreams(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -126,8 +126,8 @@ namespace edm {
       virtual void endJob(){}
       
 
-      virtual void preallocStreams(unsigned int);
-      virtual void preallocate(unsigned int);
+      virtual void preallocStreams(PreallocationConfiguration const&);
+      virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);
       virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -130,6 +130,7 @@ namespace edm {
       virtual void endJob(){}
 
       virtual void preallocStreams(unsigned int);
+      virtual void preallocate(unsigned int);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);
       virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -129,7 +129,7 @@ namespace edm {
       virtual void beginJob() {}
       virtual void endJob(){}
 
-      virtual void preallocStreams(PreallocationConfiguration const&);
+      virtual void preallocStreams(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -129,8 +129,8 @@ namespace edm {
       virtual void beginJob() {}
       virtual void endJob(){}
 
-      virtual void preallocStreams(unsigned int);
-      virtual void preallocate(unsigned int);
+      virtual void preallocStreams(PreallocationConfiguration const&);
+      virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);
       virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -152,8 +152,9 @@ namespace edm {
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
-      
-      
+
+      bool hasAcquire() const { return false; }
+
       void setModuleDescription(ModuleDescription const& md) {
         moduleDescription_ = md;
       }

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -132,8 +132,8 @@ namespace edm {
       virtual void beginJob() {}
       virtual void endJob(){}
 
-      virtual void preallocStreams(unsigned int);
-      virtual void preallocate(unsigned int);
+      virtual void preallocStreams(PreallocationConfiguration const&);
+      virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);
       virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -155,8 +155,9 @@ namespace edm {
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
-      
-      
+
+      bool hasAcquire() const { return false; }
+
       void setModuleDescription(ModuleDescription const& md) {
         moduleDescription_ = md;
       }

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -133,6 +133,7 @@ namespace edm {
       virtual void endJob(){}
 
       virtual void preallocStreams(unsigned int);
+      virtual void preallocate(unsigned int);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);
       virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -132,7 +132,7 @@ namespace edm {
       virtual void beginJob() {}
       virtual void endJob(){}
 
-      virtual void preallocStreams(PreallocationConfiguration const&);
+      virtual void preallocStreams(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -252,6 +252,7 @@ namespace edm {
       virtual bool isFileOpen() const { return true; }
       
       virtual void preallocStreams(unsigned int){}
+      virtual void preallocate(unsigned int){}
       virtual void doBeginStream_(StreamID){}
       virtual void doEndStream_(StreamID){}
       virtual void doStreamBeginRun_(StreamID, RunForOutput const&, EventSetup const&){}

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -271,7 +271,9 @@ namespace edm {
       virtual void doEndLuminosityBlockSummary_(LuminosityBlockForOutput const&, EventSetup const&){}
       virtual void doRespondToOpenInputFile_(FileBlock const&) {}
       virtual void doRespondToCloseInputFile_(FileBlock const&) {}
-      
+
+      bool hasAcquire() const { return false; }
+
       void keepThisBranch(BranchDescription const& desc,
                           std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
                           std::set<BranchID>& keptProductsInEvent);

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -251,8 +251,8 @@ namespace edm {
       virtual void openFile(FileBlock const&) const {}
       virtual bool isFileOpen() const { return true; }
       
-      virtual void preallocStreams(unsigned int){}
-      virtual void preallocate(unsigned int){}
+      virtual void preallocStreams(PreallocationConfiguration const&){}
+      virtual void preallocate(PreallocationConfiguration const&){}
       virtual void doBeginStream_(StreamID){}
       virtual void doEndStream_(StreamID){}
       virtual void doStreamBeginRun_(StreamID, RunForOutput const&, EventSetup const&){}

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -251,7 +251,7 @@ namespace edm {
       virtual void openFile(FileBlock const&) const {}
       virtual bool isFileOpen() const { return true; }
       
-      virtual void preallocStreams(PreallocationConfiguration const&){}
+      virtual void preallocStreams(unsigned int){}
       virtual void preallocate(PreallocationConfiguration const&){}
       virtual void doBeginStream_(StreamID){}
       virtual void doEndStream_(StreamID){}

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -24,6 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
@@ -54,8 +55,8 @@ namespace edm {
       protected:
         C * streamCache(edm::StreamID iID) const { return caches_[iID.value()]; }
       private:
-        void preallocStreams(unsigned int iNStreams) final {
-          caches_.resize(iNStreams,static_cast<C*>(nullptr));
+        void preallocStreams(PreallocationConfiguration const& iPrealloc) final {
+          caches_.resize(iPrealloc.numberOfStreams(),static_cast<C*>(nullptr));
         }
         void doBeginStream_(StreamID id) final {
           caches_[id.value()] = beginStream(id).release();

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -56,7 +56,9 @@ namespace edm {
       private:
         void preallocStreams(unsigned int iNStreams) final {
           caches_.resize(iNStreams,static_cast<C*>(nullptr));
+          preallocStreamsExtend(iNStreams);
         }
+        virtual void preallocStreamsExtend(unsigned int iNStreams) {}
         void doBeginStream_(StreamID id) final {
           caches_[id.value()] = beginStream(id).release();
         }

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -24,7 +24,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
@@ -55,8 +54,8 @@ namespace edm {
       protected:
         C * streamCache(edm::StreamID iID) const { return caches_[iID.value()]; }
       private:
-        void preallocStreams(PreallocationConfiguration const& iPrealloc) final {
-          caches_.resize(iPrealloc.numberOfStreams(),static_cast<C*>(nullptr));
+        void preallocStreams(unsigned int iNStreams) final {
+          caches_.resize(iNStreams,static_cast<C*>(nullptr));
         }
         void doBeginStream_(StreamID id) final {
           caches_[id.value()] = beginStream(id).release();

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -56,9 +56,7 @@ namespace edm {
       private:
         void preallocStreams(unsigned int iNStreams) final {
           caches_.resize(iNStreams,static_cast<C*>(nullptr));
-          preallocStreamsExtend(iNStreams);
         }
-        virtual void preallocStreamsExtend(unsigned int iNStreams) {}
         void doBeginStream_(StreamID id) final {
           caches_[id.value()] = beginStream(id).release();
         }

--- a/FWCore/Framework/interface/moduleAbilities.h
+++ b/FWCore/Framework/interface/moduleAbilities.h
@@ -93,6 +93,11 @@ namespace edm {
     typedef module::Empty Type;
   };
 
+  struct ExternalWork {
+    static constexpr module::Abilities kAbilities=module::Abilities::kExternalWork;
+    typedef module::Empty Type;
+  };
+
   //Recursively checks VArgs template arguments looking for the ABILITY
   template<module::Abilities ABILITY, typename... VArgs> struct CheckAbility;
 

--- a/FWCore/Framework/interface/moduleAbilityEnums.h
+++ b/FWCore/Framework/interface/moduleAbilityEnums.h
@@ -41,7 +41,8 @@ namespace edm {
       kOneSharedResources,
       kOneWatchRuns,
       kOneWatchLuminosityBlocks,
-      kWatchInputFiles
+      kWatchInputFiles,
+      kExternalWork
     };
     
     namespace AbilityBits {

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -112,6 +112,8 @@ namespace edm {
       virtual void doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c);
 
+      bool hasAcquire() const { return false; }
+
       virtual SharedResourcesAcquirer createAcquirer();
 
       void setModuleDescription(ModuleDescription const& md) {

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -118,7 +118,9 @@ namespace edm {
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
-      
+
+      bool hasAcquire() const { return false; }
+
       virtual SharedResourcesAcquirer createAcquirer();
 
       void setModuleDescription(ModuleDescription const& md) {

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -119,6 +119,8 @@ namespace edm {
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
 
+      bool hasAcquire() const { return false; }
+
       virtual SharedResourcesAcquirer createAcquirer();
       
       void setModuleDescription(ModuleDescription const& md) {

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -245,7 +245,9 @@ namespace edm {
       virtual void doEndLuminosityBlock_(LuminosityBlockForOutput const&){}
       virtual void doRespondToOpenInputFile_(FileBlock const&) {}
       virtual void doRespondToCloseInputFile_(FileBlock const&) {}
-      
+
+      bool hasAcquire() const { return false; }
+
       void keepThisBranch(BranchDescription const& desc,
                           std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
                           std::set<BranchID>& keptProductsInEvent);

--- a/FWCore/Framework/interface/stream/AbilityChecker.h
+++ b/FWCore/Framework/interface/stream/AbilityChecker.h
@@ -77,6 +77,11 @@ namespace edm {
         static constexpr bool kEndLuminosityBlockProducer = true;
       };
       
+      template<typename... U>
+      struct HasAbility<edm::ExternalWork, U...> :public HasAbility<U...> {
+        static constexpr bool kExternalWork = true;
+      };
+
       template<>
       struct HasAbility<LastCheck> {
         static constexpr bool kGlobalCache = false;
@@ -88,6 +93,7 @@ namespace edm {
         static constexpr bool kEndRunProducer = false;
         static constexpr bool kBeginLuminosityBlockProducer = false;
         static constexpr bool kEndLuminosityBlockProducer = false;
+        static constexpr bool kExternalWork = false;
       };
     }
     template<typename... T>

--- a/FWCore/Framework/interface/stream/AbilityToImplementor.h
+++ b/FWCore/Framework/interface/stream/AbilityToImplementor.h
@@ -73,6 +73,11 @@ namespace edm {
     struct AbilityToImplementor<edm::EndLuminosityBlockProducer> {
       typedef edm::stream::impl::EndLuminosityBlockProducer Type;
     };
+
+    template<>
+    struct AbilityToImplementor<edm::ExternalWork> {
+      typedef edm::stream::impl::ExternalWork Type;
+    };
   }
 }
 

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -164,6 +164,8 @@ namespace edm {
       void doRegisterThinnedAssociations(ProductRegistry const&,
                                          ThinnedAssociationsHelper&) { }
 
+      bool hasAcquire() const { return false; }
+
       // ---------- member data --------------------------------
       void setModuleDescriptionPtr(EDAnalyzerBase* m);
       void setModuleDescription(ModuleDescription const& md) {

--- a/FWCore/Framework/interface/stream/EDFilter.h
+++ b/FWCore/Framework/interface/stream/EDFilter.h
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/stream/Contexts.h"
 #include "FWCore/Framework/interface/stream/AbilityChecker.h"
 #include "FWCore/Framework/interface/stream/EDFilterBase.h"
+#include "FWCore/Framework/interface/stream/ProducingModuleHelper.h"
 // forward declarations
 namespace edm {
 
@@ -72,19 +73,6 @@ namespace edm {
                       EventSetup const& es,
                       WaitingTaskWithArenaHolder& holder) override final {
         doAcquireIfNeeded(this, ev, es, holder);
-      }
-
-      void doAcquireIfNeeded(impl::ExternalWork* base,
-                             Event const& ev,
-                             EventSetup const& es,
-                             WaitingTaskWithArenaHolder& holder) {
-        base->acquire(ev, es, holder);
-      }
-
-      void doAcquireIfNeeded(void*,
-                             Event const&,
-                             EventSetup const&,
-                             WaitingTaskWithArenaHolder&) {
       }
 
       // ---------- member data --------------------------------

--- a/FWCore/Framework/interface/stream/EDFilter.h
+++ b/FWCore/Framework/interface/stream/EDFilter.h
@@ -21,6 +21,7 @@
 // system include files
 
 // user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/AbilityToImplementor.h"
 #include "FWCore/Framework/interface/stream/CacheContexts.h"
 #include "FWCore/Framework/interface/stream/Contexts.h"
@@ -28,6 +29,9 @@
 #include "FWCore/Framework/interface/stream/EDFilterBase.h"
 // forward declarations
 namespace edm {
+
+  class WaitingTaskWithArenaHolder;
+
   namespace stream {
     template< typename... T>
     class EDFilter : public AbilityToImplementor<T>::Type...,
@@ -63,7 +67,26 @@ namespace edm {
       EDFilter(const EDFilter&) = delete; // stop default
       
       const EDFilter& operator=(const EDFilter&) = delete; // stop default
-      
+
+      void doAcquire_(Event const& ev,
+                      EventSetup const& es,
+                      WaitingTaskWithArenaHolder& holder) override final {
+        doAcquireIfNeeded(this, ev, es, holder);
+      }
+
+      void doAcquireIfNeeded(impl::ExternalWork* base,
+                             Event const& ev,
+                             EventSetup const& es,
+                             WaitingTaskWithArenaHolder& holder) {
+        base->acquire(ev, es, holder);
+      }
+
+      void doAcquireIfNeeded(void*,
+                             Event const&,
+                             EventSetup const&,
+                             WaitingTaskWithArenaHolder&) {
+      }
+
       // ---------- member data --------------------------------
       
     };

--- a/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
@@ -37,7 +37,8 @@ namespace edm {
   class ModuleCallingContext;
   class ActivityRegistry;
   class WaitingTask;
-  
+  class WaitingTaskWithArenaHolder;
+
   namespace maker {
     template<typename T> class ModuleHolderT;
   }
@@ -67,10 +68,16 @@ namespace edm {
       EDFilterAdaptorBase(const EDFilterAdaptorBase&) =delete; // stop default
       
       const EDFilterAdaptorBase& operator=(const EDFilterAdaptorBase&) =delete; // stop default
-      
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+
+      bool doEvent(EventPrincipal const&, EventSetup const&,
                    ActivityRegistry*,
-                   ModuleCallingContext const*) ;
+                   ModuleCallingContext const*);
+
+      void doAcquire(EventPrincipal const&, EventSetup const&,
+                     ActivityRegistry*,
+                     ModuleCallingContext const*,
+                     WaitingTaskWithArenaHolder&);
+
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
 

--- a/FWCore/Framework/interface/stream/EDFilterBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterBase.h
@@ -30,8 +30,10 @@
 
 // forward declarations
 namespace edm {
+
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTaskWithArenaHolder;
 
   namespace stream {
     class EDFilterAdaptorBase;
@@ -74,12 +76,17 @@ namespace edm {
       virtual void registerThinnedAssociations(ProductRegistry const&,
                                                ThinnedAssociationsHelper&) { }
 
+      virtual void doAcquire_(Event const&,
+                              EventSetup const&,
+                              WaitingTaskWithArenaHolder&) = 0;
+
       void setModuleDescriptionPtr(ModuleDescription const* iDesc) {
         moduleDescriptionPtr_ = iDesc;
       }
       // ---------- member data --------------------------------
 
       std::vector<BranchID> previousParentage_;
+      std::vector<BranchID> gotBranchIDsFromAcquire_;
       ParentageID previousParentageId_;
       ModuleDescription const* moduleDescriptionPtr_;
     };

--- a/FWCore/Framework/interface/stream/EDProducer.h
+++ b/FWCore/Framework/interface/stream/EDProducer.h
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/stream/Contexts.h"
 #include "FWCore/Framework/interface/stream/AbilityChecker.h"
 #include "FWCore/Framework/interface/stream/EDProducerBase.h"
+#include "FWCore/Framework/interface/stream/ProducingModuleHelper.h"
 // forward declarations
 namespace edm {
 
@@ -72,19 +73,6 @@ namespace edm {
                       EventSetup const& es,
                       WaitingTaskWithArenaHolder& holder) override final {
         doAcquireIfNeeded(this, ev, es, holder);
-      }
-
-      void doAcquireIfNeeded(impl::ExternalWork* base,
-                             Event const& ev,
-                             EventSetup const& es,
-                             WaitingTaskWithArenaHolder& holder) {
-        base->acquire(ev, es, holder);
-      }
-
-      void doAcquireIfNeeded(void*,
-                             Event const&,
-                             EventSetup const&,
-                             WaitingTaskWithArenaHolder&) {
       }
 
       // ---------- member data --------------------------------

--- a/FWCore/Framework/interface/stream/EDProducer.h
+++ b/FWCore/Framework/interface/stream/EDProducer.h
@@ -21,6 +21,7 @@
 // system include files
 
 // user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/AbilityToImplementor.h"
 #include "FWCore/Framework/interface/stream/CacheContexts.h"
 #include "FWCore/Framework/interface/stream/Contexts.h"
@@ -28,6 +29,9 @@
 #include "FWCore/Framework/interface/stream/EDProducerBase.h"
 // forward declarations
 namespace edm {
+
+  class WaitingTaskWithArenaHolder;
+
   namespace stream {
     template< typename... T>
     class EDProducer : public AbilityToImplementor<T>::Type...,
@@ -63,7 +67,26 @@ namespace edm {
       EDProducer(const EDProducer&) = delete; // stop default
       
       const EDProducer& operator=(const EDProducer&) = delete; // stop default
-      
+
+      void doAcquire_(Event const& ev,
+                      EventSetup const& es,
+                      WaitingTaskWithArenaHolder& holder) override final {
+        doAcquireIfNeeded(this, ev, es, holder);
+      }
+
+      void doAcquireIfNeeded(impl::ExternalWork* base,
+                             Event const& ev,
+                             EventSetup const& es,
+                             WaitingTaskWithArenaHolder& holder) {
+        base->acquire(ev, es, holder);
+      }
+
+      void doAcquireIfNeeded(void*,
+                             Event const&,
+                             EventSetup const&,
+                             WaitingTaskWithArenaHolder&) {
+      }
+
       // ---------- member data --------------------------------
       
     };

--- a/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
@@ -37,7 +37,8 @@ namespace edm {
   class ModuleCallingContext;
   class ActivityRegistry;
   class WaitingTask;
-  
+  class WaitingTaskWithArenaHolder;
+
   namespace maker {
     template<typename T> class ModuleHolderT;
   }
@@ -67,10 +68,16 @@ namespace edm {
       EDProducerAdaptorBase(const EDProducerAdaptorBase&) =delete; // stop default
       
       const EDProducerAdaptorBase& operator=(const EDProducerAdaptorBase&) =delete; // stop default
-      
-      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+
+      bool doEvent(EventPrincipal const&, EventSetup const&,
                    ActivityRegistry*,
-                   ModuleCallingContext const*) ;
+                   ModuleCallingContext const*);
+
+      void doAcquire(EventPrincipal const&, EventSetup const&,
+                     ActivityRegistry*,
+                     ModuleCallingContext const*,
+                     WaitingTaskWithArenaHolder&);
+
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
 

--- a/FWCore/Framework/interface/stream/EDProducerBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerBase.h
@@ -33,6 +33,7 @@ namespace edm {
   template<typename T> class WorkerT;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTaskWithArenaHolder;
 
   namespace stream {
     class EDProducerAdaptorBase;
@@ -74,11 +75,16 @@ namespace edm {
       virtual void registerThinnedAssociations(ProductRegistry const&,
                                                ThinnedAssociationsHelper&) { }
 
+      virtual void doAcquire_(Event const&,
+                              EventSetup const&,
+                              WaitingTaskWithArenaHolder&) = 0;
+
       void setModuleDescriptionPtr(ModuleDescription const* iDesc) {
         moduleDescriptionPtr_ = iDesc;
       }
       // ---------- member data --------------------------------
       std::vector<BranchID> previousParentage_;
+      std::vector<BranchID> gotBranchIDsFromAcquire_;
       ParentageID previousParentageId_;
       ModuleDescription const* moduleDescriptionPtr_;
     };

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -69,7 +69,10 @@ namespace edm {
         T::HasAbility::kBeginLuminosityBlockProducer or
         T::HasAbility::kEndLuminosityBlockProducer;}
 
-      
+      bool hasAcquire() const final {
+        return T::HasAbility::kExternalWork;
+      }
+
     private:
       typedef CallGlobal<T> MyGlobal;
       typedef CallGlobalRun<T> MyGlobalRun;

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -75,6 +75,7 @@ namespace edm {
       
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
+      virtual bool hasAcquire() const = 0;
       bool wantsStreamRuns() const {return true;}
       bool wantsStreamLuminosityBlocks() const {return true;}
 

--- a/FWCore/Framework/interface/stream/ProducingModuleHelper.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleHelper.h
@@ -1,0 +1,36 @@
+#ifndef FWCore_Framework_stream_ProducingModuleHelper_h
+#define FWCore_Framework_stream_ProducingModuleHelper_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+//
+// Original Author:  W. David Dagenhart
+//         Created:  1 December 2017
+
+namespace edm {
+
+  class Event;
+  class EventSetup;
+  class WaitingTaskWithArenaHolder;
+
+  namespace stream {
+
+    namespace impl {
+      class ExternalWork;
+    }
+
+    // Two overloaded functions, the first is called by doAcquire_
+    // when the module inherits from ExternalWork. The first function
+    // calls acquire, while the second function does nothing.
+    void doAcquireIfNeeded(impl::ExternalWork*,
+                           Event const&,
+                           EventSetup const&,
+                           WaitingTaskWithArenaHolder&);
+
+    void doAcquireIfNeeded(void*,
+                           Event const&,
+                           EventSetup const&,
+                           WaitingTaskWithArenaHolder&);
+  }
+}
+#endif

--- a/FWCore/Framework/interface/stream/implementors.h
+++ b/FWCore/Framework/interface/stream/implementors.h
@@ -29,6 +29,8 @@
 
 // forward declarations
 namespace edm {
+
+  class WaitingTaskWithArenaHolder;
   
   namespace stream {
     namespace impl {
@@ -143,6 +145,18 @@ namespace edm {
       private:
         ///requires the following be defined in the inheriting class
         ///static void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&, LuminosityBlockContext const*)
+      };
+
+      class ExternalWork {
+      public:
+        ExternalWork() = default;
+        ExternalWork(ExternalWork const&) = delete;
+        ExternalWork& operator=(ExternalWork const&) = delete;
+        ~ExternalWork() noexcept(false) {};
+
+        virtual void acquire(Event const&,
+                             edm::EventSetup const&,
+                             WaitingTaskWithArenaHolder) = 0;
       };
     }
   }

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -77,6 +77,12 @@ namespace edm {
         }
       }
     } else if (gotBranchIDsFromAcquire) {
+      // If we get to this point, we are preparing an Event for
+      // a module that is special because it runs external work
+      // and has an acquire function. At this point we are just
+      // before calling the acquire function. We need to tell
+      // the event where to store BranchIDs for any products we
+      // get and clear out any that are in there from a prior event.
       gotBranchIDsFromAcquire_ = gotBranchIDsFromAcquire;
       gotBranchIDsFromAcquire_->clear();
     }

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -52,14 +52,21 @@ namespace edm {
   }
 
   void
-  Event::setProducer(ProducerBase const* iProd,
-                     std::vector<BranchID>* previousParentage,
-                     std::vector<BranchID>* gotBranchIDsFromAcquire) {
+  Event::setProducerCommon(ProducerBase const* iProd,
+                           std::vector<BranchID>* previousParentage) {
+
     provRecorder_.setProducer(iProd);
     //set appropriate size
     putProducts_.resize(
                         provRecorder_.putTokenIndexToProductResolverIndex().size());
     previousBranchIDs_ =previousParentage;
+  }
+
+  void
+  Event::setProducer(ProducerBase const* iProd,
+                     std::vector<BranchID>* previousParentage,
+                     std::vector<BranchID>* gotBranchIDsFromAcquire) {
+    setProducerCommon(iProd, previousParentage);
     if(previousParentage) {
       //are we supposed to record parentage for at least one item?
       bool record_parents = false;
@@ -76,16 +83,16 @@ namespace edm {
           addToGotBranchIDs(branchID);
         }
       }
-    } else if (gotBranchIDsFromAcquire) {
-      // If we get to this point, we are preparing an Event for
-      // a module that is special because it runs external work
-      // and has an acquire function. At this point we are just
-      // before calling the acquire function. We need to tell
-      // the event where to store BranchIDs for any products we
-      // get and clear out any that are in there from a prior event.
-      gotBranchIDsFromAcquire_ = gotBranchIDsFromAcquire;
-      gotBranchIDsFromAcquire_->clear();
     }
+  }
+
+  void
+  Event::setProducerForAcquire(ProducerBase const* iProd,
+                               std::vector<BranchID>* previousParentage,
+                               std::vector<BranchID>& gotBranchIDsFromAcquire) {
+    setProducerCommon(iProd, previousParentage);
+    gotBranchIDsFromAcquire_ = &gotBranchIDsFromAcquire;
+    gotBranchIDsFromAcquire_->clear();
   }
 
   EventPrincipal const&

--- a/FWCore/Framework/src/EventAcquireSignalsSentry.h
+++ b/FWCore/Framework/src/EventAcquireSignalsSentry.h
@@ -1,0 +1,49 @@
+#ifndef FWCore_Framework_EventAcquireSignalsSentry_h
+#define FWCore_Framework_EventAcquireSignalsSentry_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     EventAcquireSignalsSentry
+//
+/**\class edm::EventAcquireSignalsSentry EventAcquireSignalsSentry.h "EventAcquireSignalsSentry.h"
+
+ Description: Guarantees that the pre/post module EventAcquire signals are sent
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  W. David Dagenhart
+//         Created:  Mon, 20 October 2017
+//
+
+// system include files
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+
+// user include files
+
+// forward declarations
+namespace edm {
+  class EventAcquireSignalsSentry {
+
+  public:
+    EventAcquireSignalsSentry(ActivityRegistry* iReg,
+                       ModuleCallingContext const * iContext) :
+      m_reg(iReg),
+      m_context(iContext)
+    { iReg->preModuleEventAcquireSignal_( *(iContext->getStreamContext()), *iContext);}
+
+    ~EventAcquireSignalsSentry() {
+      m_reg->postModuleEventAcquireSignal_( *(m_context->getStreamContext()), *m_context);
+    }
+
+  private:
+    // ---------- member data --------------------------------
+    ActivityRegistry* m_reg; // We do not use propagate_const because the registry itself is mutable.
+    ModuleCallingContext const* m_context;
+  };
+}
+
+#endif

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -614,6 +614,8 @@ namespace edm {
 
       areg->watchPreModuleEvent(timeKeeperPtr, &SystemTimeKeeper::startModuleEvent);
       areg->watchPostModuleEvent(timeKeeperPtr, &SystemTimeKeeper::stopModuleEvent);
+      areg->watchPreModuleEventAcquire(timeKeeperPtr, &SystemTimeKeeper::restartModuleEvent);
+      areg->watchPostModuleEventAcquire(timeKeeperPtr, &SystemTimeKeeper::stopModuleEvent);
       areg->watchPreModuleEventDelayedGet(timeKeeperPtr, &SystemTimeKeeper::pauseModuleEvent);
       areg->watchPostModuleEventDelayedGet(timeKeeperPtr,&SystemTimeKeeper::restartModuleEvent);
 

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -421,14 +421,12 @@ namespace edm {
 
         if( not excptr) {
           if(auto queue = m_worker->serializeRunModule()) {
-            Worker* worker = m_worker;
             auto const & principal = m_principal;
             auto& es = m_es;
-            auto streamID = m_streamID;
-            auto parentContext = m_parentContext;
-            auto serviceToken = m_serviceToken;
-            auto sContext = m_context;
-            queue.push( [worker, &principal, &es, streamID,parentContext,sContext, serviceToken]()
+            queue.push( [worker = m_worker, &principal,
+                         &es, streamID = m_streamID,
+                         parentContext = m_parentContext,
+                         sContext = m_context, serviceToken = m_serviceToken]()
             {
               //Need to make the services available
               ServiceRegistry::Operate guard(serviceToken);
@@ -514,12 +512,11 @@ namespace edm {
 
         if( not excptr) {
           if(auto queue = m_worker->serializeRunModule()) {
-            Worker* worker = m_worker;
             auto const & principal = m_principal;
             auto& es = m_es;
-            auto parentContext = m_parentContext;
-            auto serviceToken = m_serviceToken;
-            queue.push( [worker, &principal, &es, parentContext, serviceToken, holder = m_holder]()
+            queue.push( [worker = m_worker, &principal,
+                         &es, parentContext = m_parentContext,
+                         serviceToken = m_serviceToken, holder = m_holder]()
             {
               //Need to make the services available
               ServiceRegistry::Operate guard(serviceToken);

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -432,7 +432,7 @@ namespace edm {
               ServiceRegistry::Operate guard(serviceToken);
 
               std::exception_ptr* ptr = nullptr;
-              worker->runModuleAfterAsyncPrefetch<T>(ptr,
+              worker->template runModuleAfterAsyncPrefetch<T>(ptr,
                                                     principal,
                                                     es,
                                                     streamID,

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -158,6 +158,50 @@ namespace edm{
 
   template<typename T>
   inline
+  void
+  WorkerT<T>::implDoAcquire(EventPrincipal const&, EventSetup const&,
+                            ModuleCallingContext const*,
+                            WaitingTaskWithArenaHolder&) {
+  }
+
+  template<>
+  inline
+  void
+  WorkerT<global::EDProducerBase>::implDoAcquire(EventPrincipal const& ep, EventSetup const& c,
+                                                 ModuleCallingContext const* mcc,
+                                                 WaitingTaskWithArenaHolder& holder) {
+    module_->doAcquire(ep, c, activityRegistry(), mcc, holder);
+  }
+
+  template<>
+  inline
+  void
+  WorkerT<global::EDFilterBase>::implDoAcquire(EventPrincipal const& ep, EventSetup const& c,
+                                               ModuleCallingContext const* mcc,
+                                               WaitingTaskWithArenaHolder& holder) {
+    module_->doAcquire(ep, c, activityRegistry(), mcc, holder);
+  }
+
+  template<>
+  inline
+  void
+  WorkerT<stream::EDProducerAdaptorBase>::implDoAcquire(EventPrincipal const& ep, EventSetup const& c,
+                                                        ModuleCallingContext const* mcc,
+                                                        WaitingTaskWithArenaHolder& holder) {
+    module_->doAcquire(ep, c, activityRegistry(), mcc, holder);
+  }
+
+  template<>
+  inline
+  void
+  WorkerT<stream::EDFilterAdaptorBase>::implDoAcquire(EventPrincipal const& ep, EventSetup const& c,
+                                                      ModuleCallingContext const* mcc,
+                                                      WaitingTaskWithArenaHolder& holder) {
+    module_->doAcquire(ep, c, activityRegistry(), mcc, holder);
+  }
+
+  template<typename T>
+  inline
   bool
   WorkerT<T>::implNeedToRunSelection() const { return false;}
 

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -90,7 +90,7 @@ namespace edm {
 
     void implDoAcquire(EventPrincipal const& ep, EventSetup const& c,
                        ModuleCallingContext const* mcc,
-                       WaitingTaskWithArenaHolder& holder) override final;
+                       WaitingTaskWithArenaHolder& holder) final;
 
     bool implDoPrePrefetchSelection(StreamID id,
                                             EventPrincipal const& ep,

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -25,6 +25,7 @@ namespace edm {
   class ProductResolverIndexAndSkipBit;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTaskWithArenaHolder;
 
   template<typename T>
   class WorkerT : public Worker {
@@ -83,8 +84,14 @@ namespace edm {
   private:
     bool implDo(EventPrincipal const& ep, EventSetup const& c,
                         ModuleCallingContext const* mcc) override;
+
     void itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>&) const final;
     bool implNeedToRunSelection() const final;
+
+    void implDoAcquire(EventPrincipal const& ep, EventSetup const& c,
+                       ModuleCallingContext const* mcc,
+                       WaitingTaskWithArenaHolder& holder) override;
+
     bool implDoPrePrefetchSelection(StreamID id,
                                             EventPrincipal const& ep,
                                             ModuleCallingContext const* mcc) override;
@@ -145,7 +152,10 @@ namespace edm {
       module_->preActionBeforeRunEventAsync(iTask,iModuleCallingContext,iPrincipal);
     }
 
-    
+    bool hasAcquire() const override {
+      return module_->hasAcquire();
+    }
+
     edm::propagate_const<std::shared_ptr<T>> module_;
   };
 

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -90,7 +90,7 @@ namespace edm {
 
     void implDoAcquire(EventPrincipal const& ep, EventSetup const& c,
                        ModuleCallingContext const* mcc,
-                       WaitingTaskWithArenaHolder& holder) override;
+                       WaitingTaskWithArenaHolder& holder) override final;
 
     bool implDoPrePrefetchSelection(StreamID id,
                                             EventPrincipal const& ep,

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -64,6 +64,7 @@ namespace edm {
     void
     EDAnalyzerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       preallocStreams(iPrealloc.numberOfStreams());
+      preallocate(iPrealloc.numberOfStreams());
     }
 
     void
@@ -179,6 +180,7 @@ namespace edm {
     }
     
     void EDAnalyzerBase::preallocStreams(unsigned int) {}
+    void EDAnalyzerBase::preallocate(unsigned int) {}
     void EDAnalyzerBase::doBeginStream_(StreamID id){}
     void EDAnalyzerBase::doEndStream_(StreamID id) {}
     void EDAnalyzerBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -63,8 +63,8 @@ namespace edm {
     
     void
     EDAnalyzerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
-      preallocStreams(iPrealloc.numberOfStreams());
-      preallocate(iPrealloc.numberOfStreams());
+      preallocStreams(iPrealloc);
+      preallocate(iPrealloc);
     }
 
     void
@@ -179,8 +179,8 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
     
-    void EDAnalyzerBase::preallocStreams(unsigned int) {}
-    void EDAnalyzerBase::preallocate(unsigned int) {}
+    void EDAnalyzerBase::preallocStreams(PreallocationConfiguration const&) {}
+    void EDAnalyzerBase::preallocate(PreallocationConfiguration const&) {}
     void EDAnalyzerBase::doBeginStream_(StreamID id){}
     void EDAnalyzerBase::doEndStream_(StreamID id) {}
     void EDAnalyzerBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -63,7 +63,7 @@ namespace edm {
     
     void
     EDAnalyzerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
-      preallocStreams(iPrealloc);
+      preallocStreams(iPrealloc.numberOfStreams());
       preallocate(iPrealloc);
     }
 
@@ -179,7 +179,7 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
     
-    void EDAnalyzerBase::preallocStreams(PreallocationConfiguration const&) {}
+    void EDAnalyzerBase::preallocStreams(unsigned int) {}
     void EDAnalyzerBase::preallocate(PreallocationConfiguration const&) {}
     void EDAnalyzerBase::doBeginStream_(StreamID id){}
     void EDAnalyzerBase::doEndStream_(StreamID id) {}

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -91,6 +91,7 @@ namespace edm {
       }
       previousParentageIds_.reset(new ParentageID[nStreams]);
       preallocStreams(nStreams);
+      preallocate(nStreams);
     }
 
     void
@@ -217,6 +218,7 @@ namespace edm {
     }
     
     void EDFilterBase::preallocStreams(unsigned int) {}
+    void EDFilterBase::preallocate(unsigned int) {}
     void EDFilterBase::doBeginStream_(StreamID id){}
     void EDFilterBase::doEndStream_(StreamID id) {}
     void EDFilterBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -75,9 +75,9 @@ namespace edm {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       const auto streamIndex = e.streamID().value();
-      e.setProducer(this,
-                    nullptr,
-                    &gotBranchIDsFromAcquire_[streamIndex]);
+      e.setProducerForAcquire(this,
+                              nullptr,
+                              gotBranchIDsFromAcquire_[streamIndex]);
       EventAcquireSignalsSentry sentry(act,mcc);
       this->doAcquire_(e.streamID(), e, c, holder);
     }

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -90,8 +90,8 @@ namespace edm {
         gotBranchIDsFromAcquire_.reset(new std::vector<BranchID>[nStreams]);
       }
       previousParentageIds_.reset(new ParentageID[nStreams]);
-      preallocStreams(nStreams);
-      preallocate(nStreams);
+      preallocStreams(iPrealloc);
+      preallocate(iPrealloc);
     }
 
     void
@@ -217,8 +217,8 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
     
-    void EDFilterBase::preallocStreams(unsigned int) {}
-    void EDFilterBase::preallocate(unsigned int) {}
+    void EDFilterBase::preallocStreams(PreallocationConfiguration const&) {}
+    void EDFilterBase::preallocate(PreallocationConfiguration const&) {}
     void EDFilterBase::doBeginStream_(StreamID id){}
     void EDFilterBase::doEndStream_(StreamID id) {}
     void EDFilterBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -90,7 +90,7 @@ namespace edm {
         gotBranchIDsFromAcquire_.reset(new std::vector<BranchID>[nStreams]);
       }
       previousParentageIds_.reset(new ParentageID[nStreams]);
-      preallocStreams(iPrealloc);
+      preallocStreams(nStreams);
       preallocate(iPrealloc);
     }
 
@@ -217,7 +217,7 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
     
-    void EDFilterBase::preallocStreams(PreallocationConfiguration const&) {}
+    void EDFilterBase::preallocStreams(unsigned int) {}
     void EDFilterBase::preallocate(PreallocationConfiguration const&) {}
     void EDFilterBase::doBeginStream_(StreamID id){}
     void EDFilterBase::doEndStream_(StreamID id) {}

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/src/EventAcquireSignalsSentry.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -29,6 +30,9 @@
 // constants, enums and typedefs
 //
 namespace edm {
+
+  class WaitingTaskWithArenaHolder;
+
   namespace global {
     //
     // static data member definitions
@@ -54,7 +58,9 @@ namespace edm {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       const auto streamIndex =e.streamID().value();
-      e.setProducer(this, &previousParentages_[streamIndex]);
+      e.setProducer(this,
+                    &previousParentages_[streamIndex],
+                    hasAcquire() ? &gotBranchIDsFromAcquire_[streamIndex] : nullptr);
       EventSignalsSentry sentry(act,mcc);
       bool returnValue = this->filter(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
@@ -62,9 +68,27 @@ namespace edm {
     }
     
     void
+    EDFilterBase::doAcquire(EventPrincipal const& ep, EventSetup const& c,
+                            ActivityRegistry* act,
+                            ModuleCallingContext const* mcc,
+                            WaitingTaskWithArenaHolder& holder) {
+      Event e(ep, moduleDescription_, mcc);
+      e.setConsumer(this);
+      const auto streamIndex = e.streamID().value();
+      e.setProducer(this,
+                    nullptr,
+                    &gotBranchIDsFromAcquire_[streamIndex]);
+      EventAcquireSignalsSentry sentry(act,mcc);
+      this->doAcquire_(e.streamID(), e, c, holder);
+    }
+
+    void
     EDFilterBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       const auto nStreams =iPrealloc.numberOfStreams();
       previousParentages_.reset(new std::vector<BranchID>[nStreams]);
+      if (hasAcquire()) {
+        gotBranchIDsFromAcquire_.reset(new std::vector<BranchID>[nStreams]);
+      }
       previousParentageIds_.reset(new ParentageID[nStreams]);
       preallocStreams(nStreams);
     }
@@ -217,7 +241,9 @@ namespace edm {
     void EDFilterBase::doEndRunProduce_(Run& rp, EventSetup const& c) {}
     void EDFilterBase::doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}
     void EDFilterBase::doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}
-    
+
+    void EDFilterBase::doAcquire_(StreamID, Event const&, EventSetup const&, WaitingTaskWithArenaHolder&) {}
+
     void
     EDFilterBase::fillDescriptions(ConfigurationDescriptions& descriptions) {
       ParameterSetDescription desc;

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -91,8 +91,8 @@ namespace edm {
         gotBranchIDsFromAcquire_.reset(new std::vector<BranchID>[nStreams]);
       }
       previousParentageIds_.reset( new ParentageID[nStreams]);
-      preallocStreams(nStreams);
-      preallocate(nStreams);
+      preallocStreams(iPrealloc);
+      preallocate(iPrealloc);
     }
     
     void
@@ -218,8 +218,8 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
     
-    void EDProducerBase::preallocStreams(unsigned int) {}
-    void EDProducerBase::preallocate(unsigned int) {}
+    void EDProducerBase::preallocStreams(PreallocationConfiguration const&) {}
+    void EDProducerBase::preallocate(PreallocationConfiguration const&) {}
     void EDProducerBase::doBeginStream_(StreamID id){}
     void EDProducerBase::doEndStream_(StreamID id) {}
     void EDProducerBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -76,9 +76,9 @@ namespace edm {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       const auto streamIndex = e.streamID().value();
-      e.setProducer(this,
-                    nullptr,
-                    &gotBranchIDsFromAcquire_[streamIndex]);
+      e.setProducerForAcquire(this,
+                              nullptr,
+                              gotBranchIDsFromAcquire_[streamIndex]);
       EventAcquireSignalsSentry sentry(act,mcc);
       this->doAcquire_(e.streamID(), e, c, holder);
     }

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -92,6 +92,7 @@ namespace edm {
       }
       previousParentageIds_.reset( new ParentageID[nStreams]);
       preallocStreams(nStreams);
+      preallocate(nStreams);
     }
     
     void
@@ -218,6 +219,7 @@ namespace edm {
     }
     
     void EDProducerBase::preallocStreams(unsigned int) {}
+    void EDProducerBase::preallocate(unsigned int) {}
     void EDProducerBase::doBeginStream_(StreamID id){}
     void EDProducerBase::doEndStream_(StreamID id) {}
     void EDProducerBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/src/EventAcquireSignalsSentry.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -29,6 +30,9 @@
 // constants, enums and typedefs
 //
 namespace edm {
+
+  class WaitingTaskWithArenaHolder;
+
   namespace global {
     //
     // static data member definitions
@@ -41,6 +45,7 @@ namespace edm {
     ProducerBase(),
     moduleDescription_(),
     previousParentages_(),
+    gotBranchIDsFromAcquire_(),
     previousParentageIds_() { }
     
     EDProducerBase::~EDProducerBase()
@@ -54,7 +59,9 @@ namespace edm {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       const auto streamIndex = e.streamID().value();
-      e.setProducer(this, &previousParentages_[streamIndex]);
+      e.setProducer(this,
+                    &previousParentages_[streamIndex],
+                    hasAcquire() ? &gotBranchIDsFromAcquire_[streamIndex] : nullptr);
       EventSignalsSentry sentry(act,mcc);
       this->produce(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
@@ -62,9 +69,27 @@ namespace edm {
     }
 
     void
+    EDProducerBase::doAcquire(EventPrincipal const& ep, EventSetup const& c,
+                              ActivityRegistry* act,
+                              ModuleCallingContext const* mcc,
+                              WaitingTaskWithArenaHolder& holder) {
+      Event e(ep, moduleDescription_, mcc);
+      e.setConsumer(this);
+      const auto streamIndex = e.streamID().value();
+      e.setProducer(this,
+                    nullptr,
+                    &gotBranchIDsFromAcquire_[streamIndex]);
+      EventAcquireSignalsSentry sentry(act,mcc);
+      this->doAcquire_(e.streamID(), e, c, holder);
+    }
+
+    void
     EDProducerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       auto const nStreams = iPrealloc.numberOfStreams();
       previousParentages_.reset(new std::vector<BranchID>[nStreams]);
+      if (hasAcquire()) {
+        gotBranchIDsFromAcquire_.reset(new std::vector<BranchID>[nStreams]);
+      }
       previousParentageIds_.reset( new ParentageID[nStreams]);
       preallocStreams(nStreams);
     }
@@ -217,7 +242,9 @@ namespace edm {
     void EDProducerBase::doEndRunProduce_(Run& rp, EventSetup const& c) {}
     void EDProducerBase::doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}
     void EDProducerBase::doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}
-    
+
+    void EDProducerBase::doAcquire_(StreamID, Event const&, EventSetup const&, WaitingTaskWithArenaHolder&) {}
+
     void
     EDProducerBase::fillDescriptions(ConfigurationDescriptions& descriptions) {
       ParameterSetDescription desc;

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -91,7 +91,7 @@ namespace edm {
         gotBranchIDsFromAcquire_.reset(new std::vector<BranchID>[nStreams]);
       }
       previousParentageIds_.reset( new ParentageID[nStreams]);
-      preallocStreams(iPrealloc);
+      preallocStreams(nStreams);
       preallocate(iPrealloc);
     }
     
@@ -218,7 +218,7 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
     
-    void EDProducerBase::preallocStreams(PreallocationConfiguration const&) {}
+    void EDProducerBase::preallocStreams(unsigned int) {}
     void EDProducerBase::preallocate(PreallocationConfiguration const&) {}
     void EDProducerBase::doBeginStream_(StreamID id){}
     void EDProducerBase::doEndStream_(StreamID id) {}

--- a/FWCore/Framework/src/global/OutputModuleBase.cc
+++ b/FWCore/Framework/src/global/OutputModuleBase.cc
@@ -197,7 +197,7 @@ namespace edm {
           seenFirst = true;
         }
       }
-      preallocStreams(iPC);
+      preallocStreams(nstreams);
       preallocate(iPC);
     }
 

--- a/FWCore/Framework/src/global/OutputModuleBase.cc
+++ b/FWCore/Framework/src/global/OutputModuleBase.cc
@@ -197,6 +197,8 @@ namespace edm {
           seenFirst = true;
         }
       }
+      preallocStreams(nstreams);
+      preallocate(nstreams);
     }
 
     void OutputModuleBase::doBeginJob() {

--- a/FWCore/Framework/src/global/OutputModuleBase.cc
+++ b/FWCore/Framework/src/global/OutputModuleBase.cc
@@ -197,8 +197,8 @@ namespace edm {
           seenFirst = true;
         }
       }
-      preallocStreams(nstreams);
-      preallocate(nstreams);
+      preallocStreams(iPC);
+      preallocate(iPC);
     }
 
     void OutputModuleBase::doBeginJob() {

--- a/FWCore/Framework/src/global/filterImplementors.cc
+++ b/FWCore/Framework/src/global/filterImplementors.cc
@@ -23,6 +23,7 @@ namespace edm {
       template class EndRunProducer<edm::global::EDFilterBase>;
       template class BeginLuminosityBlockProducer<edm::global::EDFilterBase>;
       template class EndLuminosityBlockProducer<edm::global::EDFilterBase>;
+      template class ExternalWork<edm::global::EDFilterBase>;
     }
   }
 }

--- a/FWCore/Framework/src/global/implementorsMethods.h
+++ b/FWCore/Framework/src/global/implementorsMethods.h
@@ -22,6 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/global/implementors.h"
+#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
 
 // forward declarations
 
@@ -46,6 +47,11 @@ namespace edm {
       template< typename T>
       void EndLuminosityBlockProducer<T>::doEndLuminosityBlockProduce_(LuminosityBlock& rp, EventSetup const& c) {
         this->globalEndLuminosityBlockProduce(rp,c);
+      }
+
+      template< typename T>
+      void ExternalWork<T>::doAcquire_(StreamID s, Event const& ev, edm::EventSetup const& es, WaitingTaskWithArenaHolder& holder) {
+        this->acquire(s, ev, es, holder);
       }
     }
   }

--- a/FWCore/Framework/src/global/producerImplementors.cc
+++ b/FWCore/Framework/src/global/producerImplementors.cc
@@ -23,6 +23,7 @@ namespace edm {
       template class EndRunProducer<edm::global::EDProducerBase>;
       template class BeginLuminosityBlockProducer<edm::global::EDProducerBase>;
       template class EndLuminosityBlockProducer<edm::global::EDProducerBase>;
+      template class ExternalWork<edm::global::EDProducerBase>;
     }
   }
 }

--- a/FWCore/Framework/src/limited/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/limited/EDAnalyzerBase.cc
@@ -65,6 +65,7 @@ namespace edm {
     void
     EDAnalyzerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       preallocStreams(iPrealloc.numberOfStreams());
+      preallocate(iPrealloc.numberOfStreams());
     }
 
     void
@@ -180,6 +181,7 @@ namespace edm {
     }
     
     void EDAnalyzerBase::preallocStreams(unsigned int) {}
+    void EDAnalyzerBase::preallocate(unsigned int) {}
     void EDAnalyzerBase::doBeginStream_(StreamID id){}
     void EDAnalyzerBase::doEndStream_(StreamID id) {}
     void EDAnalyzerBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/limited/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/limited/EDAnalyzerBase.cc
@@ -64,8 +64,8 @@ namespace edm {
     
     void
     EDAnalyzerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
-      preallocStreams(iPrealloc.numberOfStreams());
-      preallocate(iPrealloc.numberOfStreams());
+      preallocStreams(iPrealloc);
+      preallocate(iPrealloc);
     }
 
     void
@@ -180,8 +180,8 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
     
-    void EDAnalyzerBase::preallocStreams(unsigned int) {}
-    void EDAnalyzerBase::preallocate(unsigned int) {}
+    void EDAnalyzerBase::preallocStreams(PreallocationConfiguration const&) {}
+    void EDAnalyzerBase::preallocate(PreallocationConfiguration const&) {}
     void EDAnalyzerBase::doBeginStream_(StreamID id){}
     void EDAnalyzerBase::doEndStream_(StreamID id) {}
     void EDAnalyzerBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/limited/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/limited/EDAnalyzerBase.cc
@@ -64,7 +64,7 @@ namespace edm {
     
     void
     EDAnalyzerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
-      preallocStreams(iPrealloc);
+      preallocStreams(iPrealloc.numberOfStreams());
       preallocate(iPrealloc);
     }
 
@@ -180,7 +180,7 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
     
-    void EDAnalyzerBase::preallocStreams(PreallocationConfiguration const&) {}
+    void EDAnalyzerBase::preallocStreams(unsigned int) {}
     void EDAnalyzerBase::preallocate(PreallocationConfiguration const&) {}
     void EDAnalyzerBase::doBeginStream_(StreamID id){}
     void EDAnalyzerBase::doEndStream_(StreamID id) {}

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -67,7 +67,7 @@ namespace edm {
       const auto nStreams =iPrealloc.numberOfStreams();
       previousParentages_.reset(new std::vector<BranchID>[nStreams]);
       previousParentageIds_.reset(new ParentageID[nStreams]);
-      preallocStreams(iPrealloc);
+      preallocStreams(nStreams);
       preallocate(iPrealloc);
     }
 
@@ -194,7 +194,7 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
     
-    void EDFilterBase::preallocStreams(PreallocationConfiguration const&) {}
+    void EDFilterBase::preallocStreams(unsigned int) {}
     void EDFilterBase::preallocate(PreallocationConfiguration const&) {}
     void EDFilterBase::doBeginStream_(StreamID id){}
     void EDFilterBase::doEndStream_(StreamID id) {}

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -68,6 +68,7 @@ namespace edm {
       previousParentages_.reset(new std::vector<BranchID>[nStreams]);
       previousParentageIds_.reset(new ParentageID[nStreams]);
       preallocStreams(nStreams);
+      preallocate(nStreams);
     }
 
     void
@@ -194,6 +195,7 @@ namespace edm {
     }
     
     void EDFilterBase::preallocStreams(unsigned int) {}
+    void EDFilterBase::preallocate(unsigned int) {}
     void EDFilterBase::doBeginStream_(StreamID id){}
     void EDFilterBase::doEndStream_(StreamID id) {}
     void EDFilterBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -67,8 +67,8 @@ namespace edm {
       const auto nStreams =iPrealloc.numberOfStreams();
       previousParentages_.reset(new std::vector<BranchID>[nStreams]);
       previousParentageIds_.reset(new ParentageID[nStreams]);
-      preallocStreams(nStreams);
-      preallocate(nStreams);
+      preallocStreams(iPrealloc);
+      preallocate(iPrealloc);
     }
 
     void
@@ -194,8 +194,8 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
     
-    void EDFilterBase::preallocStreams(unsigned int) {}
-    void EDFilterBase::preallocate(unsigned int) {}
+    void EDFilterBase::preallocStreams(PreallocationConfiguration const&) {}
+    void EDFilterBase::preallocate(PreallocationConfiguration const&) {}
     void EDFilterBase::doBeginStream_(StreamID id){}
     void EDFilterBase::doEndStream_(StreamID id) {}
     void EDFilterBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -68,6 +68,7 @@ namespace edm {
       previousParentages_.reset(new std::vector<BranchID>[nStreams]);
       previousParentageIds_.reset( new ParentageID[nStreams]);
       preallocStreams(nStreams);
+      preallocate(nStreams);
     }
     
     void
@@ -194,6 +195,7 @@ namespace edm {
     }
     
     void EDProducerBase::preallocStreams(unsigned int) {}
+    void EDProducerBase::preallocate(unsigned int) {}
     void EDProducerBase::doBeginStream_(StreamID id){}
     void EDProducerBase::doEndStream_(StreamID id) {}
     void EDProducerBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -67,7 +67,7 @@ namespace edm {
       auto const nStreams = iPrealloc.numberOfStreams();
       previousParentages_.reset(new std::vector<BranchID>[nStreams]);
       previousParentageIds_.reset( new ParentageID[nStreams]);
-      preallocStreams(iPrealloc);
+      preallocStreams(nStreams);
       preallocate(iPrealloc);
     }
     
@@ -194,7 +194,7 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
     
-    void EDProducerBase::preallocStreams(PreallocationConfiguration const&) {}
+    void EDProducerBase::preallocStreams(unsigned int) {}
     void EDProducerBase::preallocate(PreallocationConfiguration const&) {}
     void EDProducerBase::doBeginStream_(StreamID id){}
     void EDProducerBase::doEndStream_(StreamID id) {}

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -67,8 +67,8 @@ namespace edm {
       auto const nStreams = iPrealloc.numberOfStreams();
       previousParentages_.reset(new std::vector<BranchID>[nStreams]);
       previousParentageIds_.reset( new ParentageID[nStreams]);
-      preallocStreams(nStreams);
-      preallocate(nStreams);
+      preallocStreams(iPrealloc);
+      preallocate(iPrealloc);
     }
     
     void
@@ -194,8 +194,8 @@ namespace edm {
       //respondToCloseInputFile(fb);
     }
     
-    void EDProducerBase::preallocStreams(unsigned int) {}
-    void EDProducerBase::preallocate(unsigned int) {}
+    void EDProducerBase::preallocStreams(PreallocationConfiguration const&) {}
+    void EDProducerBase::preallocate(PreallocationConfiguration const&) {}
     void EDProducerBase::doBeginStream_(StreamID id){}
     void EDProducerBase::doEndStream_(StreamID id) {}
     void EDProducerBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}

--- a/FWCore/Framework/src/limited/OutputModuleBase.cc
+++ b/FWCore/Framework/src/limited/OutputModuleBase.cc
@@ -198,7 +198,7 @@ namespace edm {
           seenFirst = true;
         }
       }
-      preallocStreams(iPC);
+      preallocStreams(nstreams);
       preallocate(iPC);
     }
 

--- a/FWCore/Framework/src/limited/OutputModuleBase.cc
+++ b/FWCore/Framework/src/limited/OutputModuleBase.cc
@@ -198,6 +198,8 @@ namespace edm {
           seenFirst = true;
         }
       }
+      preallocStreams(nstreams);
+      preallocate(nstreams);
     }
 
     void OutputModuleBase::doBeginJob() {

--- a/FWCore/Framework/src/limited/OutputModuleBase.cc
+++ b/FWCore/Framework/src/limited/OutputModuleBase.cc
@@ -198,8 +198,8 @@ namespace edm {
           seenFirst = true;
         }
       }
-      preallocStreams(nstreams);
-      preallocate(nstreams);
+      preallocStreams(iPC);
+      preallocate(iPC);
     }
 
     void OutputModuleBase::doBeginJob() {

--- a/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
@@ -56,7 +56,7 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducer(mod,
                     &mod->previousParentage_,
-                    hasAcquire() ? &mod->gotBranchIDsFromAcquire_ : nullptr);
+                    &mod->gotBranchIDsFromAcquire_);
       EventSignalsSentry sentry(act,mcc);
       bool result = mod->filter(e, c);
       commit(e, &mod->previousParentageId_);

--- a/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
@@ -72,9 +72,9 @@ namespace edm {
       auto mod = m_streamModules[ep.streamID()];
       Event e(ep, moduleDescription(), mcc);
       e.setConsumer(mod);
-      e.setProducer(mod,
-                    nullptr,
-                    &mod->gotBranchIDsFromAcquire_);
+      e.setProducerForAcquire(mod,
+                              nullptr,
+                              mod->gotBranchIDsFromAcquire_);
       EventAcquireSignalsSentry sentry(act,mcc);
       mod->doAcquire_(e, c, holder);
     }

--- a/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Framework/src/EventAcquireSignalsSentry.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc"
 
@@ -53,13 +54,31 @@ namespace edm {
       auto mod = m_streamModules[ep.streamID()];
       Event e(ep, moduleDescription(), mcc);
       e.setConsumer(mod);
-      e.setProducer(mod,&mod->previousParentage_);
+      e.setProducer(mod,
+                    &mod->previousParentage_,
+                    hasAcquire() ? &mod->gotBranchIDsFromAcquire_ : nullptr);
       EventSignalsSentry sentry(act,mcc);
       bool result = mod->filter(e, c);
       commit(e, &mod->previousParentageId_);
       return result;
     }
     
+    void
+    EDFilterAdaptorBase::doAcquire(EventPrincipal const& ep, EventSetup const& c,
+                                   ActivityRegistry* act,
+                                   ModuleCallingContext const* mcc,
+                                   WaitingTaskWithArenaHolder& holder) {
+      assert(ep.streamID()<m_streamModules.size());
+      auto mod = m_streamModules[ep.streamID()];
+      Event e(ep, moduleDescription(), mcc);
+      e.setConsumer(mod);
+      e.setProducer(mod,
+                    nullptr,
+                    &mod->gotBranchIDsFromAcquire_);
+      EventAcquireSignalsSentry sentry(act,mcc);
+      mod->doAcquire_(e, c, holder);
+    }
+
     template class edm::stream::ProducingModuleAdaptorBase<edm::stream::EDFilterBase>;
   }
 }

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -56,7 +56,7 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducer(mod,
                     &mod->previousParentage_,
-                    hasAcquire() ? &mod->gotBranchIDsFromAcquire_ : nullptr);
+                    &mod->gotBranchIDsFromAcquire_);
       EventSignalsSentry sentry(act,mcc);
       mod->produce(e, c);
       commit(e, &mod->previousParentageId_);

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -72,9 +72,9 @@ namespace edm {
       auto mod = m_streamModules[ep.streamID()];
       Event e(ep, moduleDescription(), mcc);
       e.setConsumer(mod);
-      e.setProducer(mod,
-                    nullptr,
-                    &mod->gotBranchIDsFromAcquire_);
+      e.setProducerForAcquire(mod,
+                              nullptr,
+                              mod->gotBranchIDsFromAcquire_);
       EventAcquireSignalsSentry sentry(act,mcc);
       mod->doAcquire_(e, c, holder);
     }

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Framework/src/EventAcquireSignalsSentry.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc"
 
@@ -53,13 +54,31 @@ namespace edm {
       auto mod = m_streamModules[ep.streamID()];
       Event e(ep, moduleDescription(), mcc);
       e.setConsumer(mod);
-      e.setProducer(mod,&mod->previousParentage_);
+      e.setProducer(mod,
+                    &mod->previousParentage_,
+                    hasAcquire() ? &mod->gotBranchIDsFromAcquire_ : nullptr);
       EventSignalsSentry sentry(act,mcc);
       mod->produce(e, c);
       commit(e, &mod->previousParentageId_);
       return true;
     }
-    
+
+    void
+    EDProducerAdaptorBase::doAcquire(EventPrincipal const& ep, EventSetup const& c,
+                                     ActivityRegistry* act,
+                                     ModuleCallingContext const* mcc,
+                                     WaitingTaskWithArenaHolder& holder) {
+      assert(ep.streamID()<m_streamModules.size());
+      auto mod = m_streamModules[ep.streamID()];
+      Event e(ep, moduleDescription(), mcc);
+      e.setConsumer(mod);
+      e.setProducer(mod,
+                    nullptr,
+                    &mod->gotBranchIDsFromAcquire_);
+      EventAcquireSignalsSentry sentry(act,mcc);
+      mod->doAcquire_(e, c, holder);
+    }
+
     template class edm::stream::ProducingModuleAdaptorBase<edm::stream::EDProducerBase>;
   }
 }

--- a/FWCore/Framework/src/stream/ProducingModuleHelper.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleHelper.cc
@@ -1,0 +1,28 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+//
+// Original Author:  W. David Dagenhart
+//         Created:  1 December 2017
+
+#include "FWCore/Framework/interface/stream/ProducingModuleHelper.h"
+#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
+#include "FWCore/Framework/interface/stream/implementors.h"
+
+namespace edm {
+  namespace stream {
+
+    void doAcquireIfNeeded(impl::ExternalWork* base,
+                           Event const& ev,
+                           EventSetup const& es,
+                           WaitingTaskWithArenaHolder& holder) {
+      base->acquire(ev, es, holder);
+    }
+
+    void doAcquireIfNeeded(void*,
+                           Event const&,
+                           EventSetup const&,
+                           WaitingTaskWithArenaHolder&) {
+    }
+  }
+}

--- a/FWCore/Integration/test/AcquireIntFilter.cc
+++ b/FWCore/Integration/test/AcquireIntFilter.cc
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Integration/test/WaitingServer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
@@ -36,7 +37,7 @@ namespace edmtest {
 
   private:
 
-    void preallocate(unsigned int) override;
+    void preallocate(edm::PreallocationConfiguration const&) override;
 
     std::vector<edm::EDGetTokenT<IntProduct>> m_tokens;
     edm::EDGetTokenT<IntProduct> m_tokenForProduce;
@@ -62,9 +63,9 @@ namespace edmtest {
     }
   }
 
-  void AcquireIntFilter::preallocate(unsigned int iNStreams) {
+  void AcquireIntFilter::preallocate(edm::PreallocationConfiguration const& iPrealloc) {
 
-    m_server = std::make_unique<test_acquire::WaitingServer>(iNStreams,
+    m_server = std::make_unique<test_acquire::WaitingServer>(iPrealloc.numberOfStreams(),
                                                              m_numberOfStreamsToAccumulate,
                                                              m_secondsToWaitForWork);
     m_server->start();

--- a/FWCore/Integration/test/AcquireIntFilter.cc
+++ b/FWCore/Integration/test/AcquireIntFilter.cc
@@ -1,0 +1,121 @@
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Integration/test/WaitingServer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include <memory>
+#include <vector>
+
+namespace edm {
+  class EventSetup;
+}
+
+namespace edmtest {
+
+  class AcquireIntFilter : public edm::global::EDFilter<edm::ExternalWork,
+                                                        edm::StreamCache<test_acquire::Cache>> {
+  public:
+
+    explicit AcquireIntFilter(edm::ParameterSet const& pset);
+    ~AcquireIntFilter() override;
+
+    std::unique_ptr<test_acquire::Cache> beginStream(edm::StreamID) const override;
+
+    void acquire(edm::StreamID, edm::Event const&, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder) const override;
+
+    bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+
+    void endJob() override;
+
+  private:
+
+    void preallocStreamsExtend(unsigned int) override;
+
+    std::vector<edm::EDGetTokenT<IntProduct>> m_tokens;
+    edm::EDGetTokenT<IntProduct> m_tokenForProduce;
+    std::unique_ptr<test_acquire::WaitingServer> m_server;
+    const unsigned int m_numberOfStreamsToAccumulate;
+    const unsigned int m_secondsToWaitForWork;
+  };
+
+  AcquireIntFilter::AcquireIntFilter(edm::ParameterSet const& pset) :
+    m_numberOfStreamsToAccumulate(pset.getUntrackedParameter<unsigned int>("streamsToAccumulate", 8)),
+    m_secondsToWaitForWork(pset.getUntrackedParameter<unsigned int>("secondsToWaitForWork",1))
+ {
+    for (auto const& tag : pset.getParameter<std::vector<edm::InputTag>>("tags")) {
+      m_tokens.emplace_back(consumes<IntProduct>(tag));
+    }
+    m_tokenForProduce = consumes<IntProduct>(pset.getParameter<edm::InputTag>("produceTag"));
+    produces<IntProduct>();
+  }
+
+  AcquireIntFilter::~AcquireIntFilter() {
+    if(m_server) {
+      m_server->stop();
+    }
+  }
+
+  void AcquireIntFilter::preallocStreamsExtend(unsigned int iNStreams) {
+
+    m_server = std::make_unique<test_acquire::WaitingServer>(iNStreams,
+                                                             m_numberOfStreamsToAccumulate,
+                                                             m_secondsToWaitForWork);
+    m_server->start();
+  }
+
+  std::unique_ptr<test_acquire::Cache> AcquireIntFilter::beginStream(edm::StreamID) const {
+    return std::make_unique<test_acquire::Cache>();
+  }
+
+  void AcquireIntFilter::acquire(edm::StreamID streamID,
+                                 edm::Event const& event,
+                                 edm::EventSetup const&,
+                                 edm::WaitingTaskWithArenaHolder holder) const {
+
+    test_acquire::Cache* streamCacheData = streamCache(streamID);
+    streamCacheData->retrieved().clear();
+    streamCacheData->processed().clear();
+
+    for(auto const& token: m_tokens) {
+      edm::Handle<IntProduct> handle;
+      event.getByToken(token, handle);
+      streamCacheData->retrieved().push_back(handle->value);
+    }
+
+    m_server->requestValuesAsync(streamID, &streamCacheData->retrieved(), &streamCacheData->processed(), holder);
+  }
+
+  bool AcquireIntFilter::filter(edm::StreamID streamID,
+                                edm::Event& event,
+                                edm::EventSetup const&) const {
+    int sum = 0;
+    for (auto v : streamCache(streamID)->processed()) {
+      sum += v;
+    }
+    event.put(std::make_unique<IntProduct>(sum));
+
+    // This part is here only for the Parentage test.
+    edm::Handle<IntProduct> handle;
+    event.getByToken(m_tokenForProduce, handle);
+    *handle;
+
+    return true;
+  }
+
+  void AcquireIntFilter::endJob() {
+    if(m_server) {
+      m_server->stop();
+    }
+    m_server.reset();
+  }
+}
+
+using edmtest::AcquireIntFilter;
+DEFINE_FWK_MODULE(AcquireIntFilter);

--- a/FWCore/Integration/test/AcquireIntFilter.cc
+++ b/FWCore/Integration/test/AcquireIntFilter.cc
@@ -36,7 +36,7 @@ namespace edmtest {
 
   private:
 
-    void preallocStreamsExtend(unsigned int) override;
+    void preallocate(unsigned int) override;
 
     std::vector<edm::EDGetTokenT<IntProduct>> m_tokens;
     edm::EDGetTokenT<IntProduct> m_tokenForProduce;
@@ -62,7 +62,7 @@ namespace edmtest {
     }
   }
 
-  void AcquireIntFilter::preallocStreamsExtend(unsigned int iNStreams) {
+  void AcquireIntFilter::preallocate(unsigned int iNStreams) {
 
     m_server = std::make_unique<test_acquire::WaitingServer>(iNStreams,
                                                              m_numberOfStreamsToAccumulate,

--- a/FWCore/Integration/test/AcquireIntProducer.cc
+++ b/FWCore/Integration/test/AcquireIntProducer.cc
@@ -1,0 +1,122 @@
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Integration/test/WaitingServer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include <memory>
+#include <vector>
+
+namespace edm {
+  class EventSetup;
+}
+
+namespace edmtest {
+
+  class AcquireIntProducer : public edm::global::EDProducer<edm::ExternalWork,
+                                                            edm::StreamCache<test_acquire::Cache>> {
+  public:
+
+    explicit AcquireIntProducer(edm::ParameterSet const& pset);
+    ~AcquireIntProducer() override;
+
+    std::unique_ptr<test_acquire::Cache> beginStream(edm::StreamID) const override;
+
+    void acquire(edm::StreamID, edm::Event const&, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder) const override;
+
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+
+    void endJob() override;
+
+  private:
+
+    void preallocStreamsExtend(unsigned int) override;
+
+    std::vector<edm::EDGetTokenT<IntProduct>> m_tokens;
+    edm::EDGetTokenT<IntProduct> m_tokenForProduce;
+    std::unique_ptr<test_acquire::WaitingServer> m_server;
+    const unsigned int m_numberOfStreamsToAccumulate;
+    const unsigned int m_secondsToWaitForWork;
+  };
+
+  AcquireIntProducer::AcquireIntProducer(edm::ParameterSet const& pset) :
+    m_numberOfStreamsToAccumulate(pset.getUntrackedParameter<unsigned int>("streamsToAccumulate", 8)),
+    m_secondsToWaitForWork(pset.getUntrackedParameter<unsigned int>("secondsToWaitForWork",1))
+ {
+    for (auto const& tag : pset.getParameter<std::vector<edm::InputTag>>("tags")) {
+      m_tokens.emplace_back(consumes<IntProduct>(tag));
+    }
+    m_tokenForProduce = consumes<IntProduct>(pset.getParameter<edm::InputTag>("produceTag"));
+    produces<IntProduct>();
+  }
+
+  AcquireIntProducer::~AcquireIntProducer() {
+    if(m_server) {
+      m_server->stop();
+    }
+  }
+
+  void AcquireIntProducer::preallocStreamsExtend(unsigned int iNStreams) {
+
+    m_server = std::make_unique<test_acquire::WaitingServer>(iNStreams,
+                                                             m_numberOfStreamsToAccumulate,
+                                                             m_secondsToWaitForWork);
+    m_server->start();
+  }
+
+  std::unique_ptr<test_acquire::Cache> AcquireIntProducer::beginStream(edm::StreamID) const {
+    return std::make_unique<test_acquire::Cache>();
+  }
+
+  void AcquireIntProducer::acquire(edm::StreamID streamID,
+                                   edm::Event const& event,
+                                   edm::EventSetup const&,
+                                   edm::WaitingTaskWithArenaHolder holder) const {
+
+    test_acquire::Cache* streamCacheData = streamCache(streamID);
+    streamCacheData->retrieved().clear();
+    streamCacheData->processed().clear();
+
+    for(auto const& token: m_tokens) {
+      edm::Handle<IntProduct> handle;
+      event.getByToken(token, handle);
+      streamCacheData->retrieved().push_back(handle->value);
+    }
+    m_server->requestValuesAsync(streamID.value(),
+                                 &streamCacheData->retrieved(),
+                                 &streamCacheData->processed(),
+                                 holder);
+  }
+
+  void AcquireIntProducer::produce(edm::StreamID streamID,
+                                   edm::Event& event,
+                                   edm::EventSetup const&) const {
+
+    int sum = 0;
+    for (auto v : streamCache(streamID)->processed()) {
+      sum += v;
+    }
+    event.put(std::make_unique<IntProduct>(sum));
+
+    // This part is here only for the Parentage test.
+    edm::Handle<IntProduct> handle;
+    event.getByToken(m_tokenForProduce, handle);
+    *handle;
+  }
+
+  void AcquireIntProducer::endJob() {
+    if(m_server) {
+      m_server->stop();
+    }
+    m_server.reset();
+  }
+}
+
+using edmtest::AcquireIntProducer;
+DEFINE_FWK_MODULE(AcquireIntProducer);

--- a/FWCore/Integration/test/AcquireIntProducer.cc
+++ b/FWCore/Integration/test/AcquireIntProducer.cc
@@ -36,7 +36,7 @@ namespace edmtest {
 
   private:
 
-    void preallocStreamsExtend(unsigned int) override;
+    void preallocate(unsigned int) override;
 
     std::vector<edm::EDGetTokenT<IntProduct>> m_tokens;
     edm::EDGetTokenT<IntProduct> m_tokenForProduce;
@@ -62,7 +62,7 @@ namespace edmtest {
     }
   }
 
-  void AcquireIntProducer::preallocStreamsExtend(unsigned int iNStreams) {
+  void AcquireIntProducer::preallocate(unsigned int iNStreams) {
 
     m_server = std::make_unique<test_acquire::WaitingServer>(iNStreams,
                                                              m_numberOfStreamsToAccumulate,

--- a/FWCore/Integration/test/AcquireIntProducer.cc
+++ b/FWCore/Integration/test/AcquireIntProducer.cc
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Integration/test/WaitingServer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
@@ -36,7 +37,7 @@ namespace edmtest {
 
   private:
 
-    void preallocate(unsigned int) override;
+    void preallocate(edm::PreallocationConfiguration const&) override;
 
     std::vector<edm::EDGetTokenT<IntProduct>> m_tokens;
     edm::EDGetTokenT<IntProduct> m_tokenForProduce;
@@ -62,9 +63,9 @@ namespace edmtest {
     }
   }
 
-  void AcquireIntProducer::preallocate(unsigned int iNStreams) {
+  void AcquireIntProducer::preallocate(edm::PreallocationConfiguration const& iPrealloc) {
 
-    m_server = std::make_unique<test_acquire::WaitingServer>(iNStreams,
+    m_server = std::make_unique<test_acquire::WaitingServer>(iPrealloc.numberOfStreams(),
                                                              m_numberOfStreamsToAccumulate,
                                                              m_secondsToWaitForWork);
     m_server->start();

--- a/FWCore/Integration/test/AcquireIntStreamFilter.cc
+++ b/FWCore/Integration/test/AcquireIntStreamFilter.cc
@@ -1,0 +1,87 @@
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Integration/test/WaitingService.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include <memory>
+#include <vector>
+
+namespace edm {
+  class EventSetup;
+}
+
+namespace edmtest {
+
+  class AcquireIntStreamFilter : public edm::stream::EDFilter<edm::ExternalWork> {
+  public:
+
+    explicit AcquireIntStreamFilter(edm::ParameterSet const& pset);
+    ~AcquireIntStreamFilter() override;
+    void acquire(edm::Event const&, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder) override;
+    bool filter(edm::Event&, edm::EventSetup const&) override;
+
+  private:
+
+    std::vector<edm::EDGetTokenT<IntProduct>> m_getTokens;
+    edm::EDGetTokenT<IntProduct> m_tokenForProduce;
+    test_acquire::Token m_token;
+  };
+
+  AcquireIntStreamFilter::AcquireIntStreamFilter(edm::ParameterSet const& pset) :
+    m_token{edm::Service<test_acquire::WaitingService>{}->getToken()}
+  {
+    for (auto const& tag : pset.getParameter<std::vector<edm::InputTag>>("tags")) {
+      m_getTokens.emplace_back(consumes<IntProduct>(tag));
+    }
+    m_tokenForProduce = consumes<IntProduct>(pset.getParameter<edm::InputTag>("produceTag"));
+    produces<IntProduct>();
+  }
+
+  AcquireIntStreamFilter::~AcquireIntStreamFilter() { }
+
+  void AcquireIntStreamFilter::acquire(edm::Event const& event,
+                                       edm::EventSetup const&,
+                                       edm::WaitingTaskWithArenaHolder holder) {
+
+    test_acquire::Cache* cache = edm::Service<test_acquire::WaitingService>()->getCache(m_token);
+    cache->retrieved().clear();
+    cache->processed().clear();
+
+    for(auto const& token: m_getTokens) {
+      edm::Handle<IntProduct> handle;
+      event.getByToken(token, handle);
+      cache->retrieved().push_back(handle->value);
+    }
+
+    edm::Service<test_acquire::WaitingService>()->requestValuesAsync(m_token,
+                                                                     &cache->retrieved(),
+                                                                     &cache->processed(),
+                                                                     holder);
+  }
+
+  bool AcquireIntStreamFilter::filter(edm::Event& event,
+                                      edm::EventSetup const&) {
+    int sum = 0;
+    test_acquire::Cache* cache = edm::Service<test_acquire::WaitingService>()->getCache(m_token);
+    for (auto v : cache->processed()) {
+      sum += v;
+    }
+    event.put(std::make_unique<IntProduct>(sum));
+
+    // This part is here only for the Parentage test.
+    edm::Handle<IntProduct> handle;
+    event.getByToken(m_tokenForProduce, handle);
+    *handle;
+
+    return true;
+  }
+}
+using edmtest::AcquireIntStreamFilter;
+DEFINE_FWK_MODULE(AcquireIntStreamFilter);

--- a/FWCore/Integration/test/AcquireIntStreamProducer.cc
+++ b/FWCore/Integration/test/AcquireIntStreamProducer.cc
@@ -1,0 +1,85 @@
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Integration/test/WaitingService.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include <memory>
+#include <vector>
+
+namespace edm {
+  class EventSetup;
+}
+
+namespace edmtest {
+
+  class AcquireIntStreamProducer : public edm::stream::EDProducer<edm::ExternalWork> {
+  public:
+
+    explicit AcquireIntStreamProducer(edm::ParameterSet const& pset);
+    ~AcquireIntStreamProducer() override;
+    void acquire(edm::Event const&, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder) override;
+    void produce(edm::Event&, edm::EventSetup const&) override;
+
+  private:
+
+    std::vector<edm::EDGetTokenT<IntProduct>> m_getTokens;
+    edm::EDGetTokenT<IntProduct> m_tokenForProduce;
+    test_acquire::Token m_token;
+  };
+
+  AcquireIntStreamProducer::AcquireIntStreamProducer(edm::ParameterSet const& pset) :
+    m_token{edm::Service<test_acquire::WaitingService>{}->getToken()}
+  {
+    for (auto const& tag : pset.getParameter<std::vector<edm::InputTag>>("tags")) {
+      m_getTokens.emplace_back(consumes<IntProduct>(tag));
+    }
+    m_tokenForProduce = consumes<IntProduct>(pset.getParameter<edm::InputTag>("produceTag"));
+    produces<IntProduct>();
+  }
+
+  AcquireIntStreamProducer::~AcquireIntStreamProducer() { }
+
+  void AcquireIntStreamProducer::acquire(edm::Event const& event,
+                                         edm::EventSetup const&,
+                                         edm::WaitingTaskWithArenaHolder holder) {
+
+    test_acquire::Cache* cache = edm::Service<test_acquire::WaitingService>()->getCache(m_token);
+    cache->retrieved().clear();
+    cache->processed().clear();
+
+    for(auto const& token: m_getTokens) {
+      edm::Handle<IntProduct> handle;
+      event.getByToken(token, handle);
+      cache->retrieved().push_back(handle->value);
+    }
+
+    edm::Service<test_acquire::WaitingService>()->requestValuesAsync(m_token,
+                                                                     &cache->retrieved(),
+                                                                     &cache->processed(),
+                                                                     holder);
+  }
+
+  void AcquireIntStreamProducer::produce(edm::Event& event,
+                                         edm::EventSetup const&) {
+    int sum = 0;
+    test_acquire::Cache* cache = edm::Service<test_acquire::WaitingService>()->getCache(m_token);
+    for (auto v : cache->processed()) {
+      sum += v;
+    }
+    event.put(std::make_unique<IntProduct>(sum));
+
+    // This part is here only for the Parentage test.
+    edm::Handle<IntProduct> handle;
+    event.getByToken(m_tokenForProduce, handle);
+    *handle;
+  }
+}
+using edmtest::AcquireIntStreamProducer;
+DEFINE_FWK_MODULE(AcquireIntStreamProducer);

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -125,8 +125,9 @@
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/Framework"/>
   </library>
-  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc, WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc" name="SomeTestModules">
+  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc, WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc" name="SomeTestModules">
     <flags   EDM_PLUGIN="1"/>
+    <lib   name="FWCoreIntegrationWaitingServer"/>
     <use   name="FWCore/Framework"/>
     <use   name="DataFormats/TestObjects"/>
   </library>
@@ -191,6 +192,15 @@
     <flags   EDM_PLUGIN="1"/>
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/Framework"/>
+  </library>
+  <library   file="WaitingServer.cc" name="FWCoreIntegrationWaitingServer">
+    <use   name="FWCore/Concurrency"/>
+  </library>
+  <library   file="WaitingService.cc" name="FWCoreIntegrationWaitingService">
+    <flags   EDM_PLUGIN="1"/>
+    <lib   name="FWCoreIntegrationWaitingServer"/>
+    <use   name="FWCore/ParameterSet"/>
+    <use   name="FWCore/ServiceRegistry"/>
   </library>
   <library   file="OtherThingAnalyzer.cc,OtherThingRefComparer.cc" name="TestOtherThingAnalyzer">
     <flags   EDM_PLUGIN="1"/>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -199,6 +199,7 @@
   <library   file="WaitingService.cc" name="FWCoreIntegrationWaitingService">
     <flags   EDM_PLUGIN="1"/>
     <lib   name="FWCoreIntegrationWaitingServer"/>
+    <use   name="FWCore/Concurrency"/>
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/ServiceRegistry"/>
   </library>

--- a/FWCore/Integration/test/WaitingServer.cc
+++ b/FWCore/Integration/test/WaitingServer.cc
@@ -1,0 +1,81 @@
+
+#include "FWCore/Integration/test/WaitingServer.h"
+
+#include <exception>
+
+namespace edmtest {
+  namespace test_acquire {
+
+    void
+    WaitingServer::requestValuesAsync(unsigned int dataID,
+                                      std::vector<int> const* iIn,
+                                      std::vector<int>* iOut,
+                                      edm::WaitingTaskWithArenaHolder holder) {
+
+      auto& streamData = m_perStream.at(dataID);
+
+      streamData.in_ = iIn;
+      streamData.out_ = iOut;
+      streamData.holder_ = std::move(holder);
+      {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        m_waitingStreams.push_back(dataID);
+      }
+      m_cond.notify_one(); //wakes up the server thread
+    }
+
+    void WaitingServer::start() {
+      m_thread = std::make_unique<std::thread>([this]() { serverDoWork(); } );
+    }
+
+    void WaitingServer::stop() {
+      m_shouldStop = true;
+      if (m_thread) {
+        m_thread->join();
+        m_thread.reset();
+      }
+    }
+
+    bool WaitingServer::readyForWork() const {
+      return m_waitingStreams.size() >= m_minNumStreamsBeforeDoingWork;
+    }
+
+    void WaitingServer::serverDoWork() {
+      while (not m_shouldStop) {
+        std::vector<unsigned int> streamsToUse;
+        {
+          std::unique_lock<std::mutex> lk(m_mutex);
+
+          m_cond.wait_for(lk,
+                          std::chrono::seconds(m_secondsToWait),
+                          [this] ()->bool
+          {
+            return readyForWork();
+          });
+
+          // Once we know which streams have given us data
+          // we can release the lock and let other streams
+          // set their data
+          streamsToUse.swap(m_waitingStreams);
+          lk.unlock();
+        }
+
+        // Here is the work that the server does for the modules
+        // it will just add 1 to each value it has been given
+        for(auto index: streamsToUse){
+          auto & streamData = m_perStream.at(index);
+
+          std::exception_ptr exceptionPtr;
+          try {
+            for (auto v: *streamData.in_) {
+              streamData.out_->push_back(v+1);
+            }
+          } catch(...) {
+            exceptionPtr = std::current_exception();
+          }
+          streamData.holder_.doneWaiting(exceptionPtr);
+        }
+      }
+    }
+  }
+}

--- a/FWCore/Integration/test/WaitingServer.h
+++ b/FWCore/Integration/test/WaitingServer.h
@@ -1,0 +1,75 @@
+#ifndef FWCore_Integration_WaitingServer_h
+#define FWCore_Integration_WaitingServer_h
+
+#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace edmtest {
+  namespace test_acquire {
+
+    struct StreamData {
+      StreamData() : in_(nullptr), out_(nullptr) {}
+
+      std::vector<int> const* in_;
+      std::vector<int>* out_;
+      edm::WaitingTaskWithArenaHolder holder_;
+    };
+
+    class WaitingServer {
+    public:
+      WaitingServer(unsigned int iNumberOfStreams,
+                    unsigned int iMinNumberOfStreamsBeforeDoingWork,
+                    unsigned int iSecondsToWait):
+        m_perStream(iNumberOfStreams),
+        m_minNumStreamsBeforeDoingWork(iMinNumberOfStreamsBeforeDoingWork),
+        m_secondsToWait(iSecondsToWait),
+        m_shouldStop(false) {
+      }
+
+      void start();
+      void stop();
+
+      void requestValuesAsync(unsigned int dataID,
+                              std::vector<int> const* iIn,
+                              std::vector<int>* iOut,
+                              edm::WaitingTaskWithArenaHolder holder);
+
+    private:
+
+      void serverDoWork();
+
+      bool readyForWork() const;
+
+      std::mutex m_mutex; //needed by m_cond
+      std::condition_variable m_cond;
+      std::unique_ptr<std::thread> m_thread;
+      std::vector<StreamData> m_perStream;
+      std::vector<unsigned int> m_waitingStreams;
+      const unsigned int m_minNumStreamsBeforeDoingWork;
+      const unsigned int m_secondsToWait;
+      std::atomic<bool> m_shouldStop;
+    };
+
+    class Cache {
+    public:
+
+      std::vector<int> const& retrieved() const { return m_retrieved; }
+      std::vector<int> & retrieved() { return m_retrieved; }
+
+      std::vector<int> const& processed() const { return m_processed; }
+      std::vector<int> & processed() { return m_processed; }
+
+    private:
+
+      std::vector<int> m_retrieved;
+      std::vector<int> m_processed;
+    };
+  }
+}
+#endif

--- a/FWCore/Integration/test/WaitingService.cc
+++ b/FWCore/Integration/test/WaitingService.cc
@@ -1,0 +1,42 @@
+#include "FWCore/Integration/test/WaitingService.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+
+namespace edmtest {
+  namespace test_acquire {
+
+    WaitingService::WaitingService(edm::ParameterSet const& pset, edm::ActivityRegistry&iRegistry) :
+      count_(0),
+      numberOfStreamsToAccumulate_(pset.getUntrackedParameter<unsigned int>("streamsToAccumulate", 8)),
+      secondsToWaitForWork_(pset.getUntrackedParameter<unsigned int>("secondsToWaitForWork",1))
+    {
+      iRegistry.watchPreallocate(this, &WaitingService::preallocate);
+      iRegistry.watchPostEndJob(this, &WaitingService::postEndJob);
+    }
+
+    WaitingService::~WaitingService() {
+      if (server_) {
+        server_->stop();
+      }
+    }
+
+    void WaitingService::preallocate(edm::service::SystemBounds const&) {
+      caches_.resize(count_.load());
+      server_ = std::make_unique<test_acquire::WaitingServer>(count_.load(),
+                                                              numberOfStreamsToAccumulate_,
+                                                              secondsToWaitForWork_);
+      server_->start();
+    }
+
+    void  WaitingService::postEndJob() {
+      if(server_) {
+        server_->stop();
+      }
+      server_.reset();
+    }
+  }
+}
+
+using edmtest::test_acquire::WaitingService;
+DEFINE_FWK_SERVICE(WaitingService);

--- a/FWCore/Integration/test/WaitingService.h
+++ b/FWCore/Integration/test/WaitingService.h
@@ -1,0 +1,59 @@
+#ifndef FWCore_Integration_WaitingService_h
+#define FWCore_Integration_WaitingService_h
+
+#include "FWCore/Integration/test/WaitingServer.h"
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+namespace edm {
+  class ActivityRegistry;
+  class ParameterSet;
+  namespace service {
+    class SystemBounds;
+  }
+}
+
+namespace edmtest {
+  namespace test_acquire {
+
+    class Token {
+    public:
+      Token(unsigned int v) : value_(v) { }
+      unsigned int value() const { return value_; }
+    private:
+      unsigned int value_;
+    };
+
+    class WaitingService {
+    public:
+
+      WaitingService(edm::ParameterSet const& pset, edm::ActivityRegistry&iRegistry);
+      ~WaitingService();
+
+      Token getToken() { return Token(count_.fetch_add(1)); }
+
+      void preallocate(edm::service::SystemBounds const&);
+
+      Cache* getCache(Token const& token) { return &caches_[token.value()]; }
+
+      void requestValuesAsync(Token const& token,
+                              std::vector<int> const* iIn,
+                              std::vector<int>* iOut,
+                              edm::WaitingTaskWithArenaHolder& holder) {
+        server_->requestValuesAsync(token.value(), iIn, iOut, holder);
+      }
+
+      void postEndJob();
+
+    private:
+      std::atomic<unsigned int> count_;
+      std::vector<Cache> caches_;
+      std::unique_ptr<WaitingServer> server_;
+      const unsigned int numberOfStreamsToAccumulate_;
+      const unsigned int secondsToWaitForWork_;
+    };
+  }
+}
+#endif

--- a/FWCore/Integration/test/WaitingThreadIntProducer.cc
+++ b/FWCore/Integration/test/WaitingThreadIntProducer.cc
@@ -2,6 +2,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
@@ -190,7 +191,7 @@ namespace edmtest {
     virtual void endJob() override;
     
   private:
-    virtual void preallocStreams(unsigned int) override;
+    virtual void preallocate(edm::PreallocationConfiguration const&) override;
 
     std::vector<edm::EDGetTokenT<IntProduct>> m_tokens;
     std::unique_ptr<WaitingServer> m_server;
@@ -215,7 +216,8 @@ namespace edmtest {
     }
   }
 
-  void WaitingThreadIntProducer::preallocStreams(unsigned int iNStreams) {
+  void WaitingThreadIntProducer::preallocate(edm::PreallocationConfiguration const& iPrealloc) {
+    unsigned int iNStreams = iPrealloc.numberOfStreams();
     m_server = std::make_unique<WaitingServer>(iNStreams,
                                                m_numberOfStreamsToAccumulate <=iNStreams? m_numberOfStreamsToAccumulate : iNStreams,
                                                m_secondsToWaitForWork);

--- a/FWCore/Integration/test/acquireTest_cfg.py
+++ b/FWCore/Integration/test/acquireTest_cfg.py
@@ -1,0 +1,87 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Test")
+
+process.WaitingService = cms.Service("WaitingService")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(2),
+    numberOfStreams = cms.untracked.uint32(0)
+)
+
+process.waiter = cms.EDProducer("AcquireIntProducer",
+                                streamsToAccumulate = cms.untracked.uint32(3),
+                                tags = cms.VInputTag("busy1", "busy2"),
+                                produceTag = cms.InputTag("busy3")
+)
+
+process.filterwaiter = cms.EDFilter("AcquireIntFilter",
+                                    streamsToAccumulate = cms.untracked.uint32(3),
+                                    tags = cms.VInputTag("busy1", "busy2"),
+                                    produceTag = cms.InputTag("busy3")
+)
+
+process.streamwaiter = cms.EDProducer("AcquireIntStreamProducer",
+                                      streamsToAccumulate = cms.untracked.uint32(3),
+                                      tags = cms.VInputTag("busy1", "busy2"),
+                                      produceTag = cms.InputTag("busy3")
+)
+
+process.streamfilterwaiter = cms.EDFilter("AcquireIntStreamFilter",
+                                          streamsToAccumulate = cms.untracked.uint32(3),
+                                          tags = cms.VInputTag("busy1", "busy2"),
+                                          produceTag = cms.InputTag("busy3")
+)
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(10*1000*1000))
+process.busy2 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(2), iterations = cms.uint32(10*1000*1000))
+process.busy3 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(2), iterations = cms.uint32(10*1000*1000))
+
+process.tester = cms.EDAnalyzer("IntTestAnalyzer",
+                                moduleLabel = cms.untracked.string("waiter"),
+                                valueMustMatch = cms.untracked.int32(5))
+
+process.filtertester = cms.EDAnalyzer("IntTestAnalyzer",
+                                      moduleLabel = cms.untracked.string("filterwaiter"),
+                                      valueMustMatch = cms.untracked.int32(5))
+
+process.streamtester = cms.EDAnalyzer("IntTestAnalyzer",
+                                      moduleLabel = cms.untracked.string("streamwaiter"),
+                                      valueMustMatch = cms.untracked.int32(5))
+
+process.streamfiltertester = cms.EDAnalyzer("IntTestAnalyzer",
+                                            moduleLabel = cms.untracked.string("streamfilterwaiter"),
+                                            valueMustMatch = cms.untracked.int32(5))
+
+process.task = cms.Task(process.busy1, process.busy2, process.busy3,
+                        process.waiter, process.filterwaiter,
+                        process.streamwaiter, process.streamfilterwaiter)
+
+process.testParentage1 = cms.EDAnalyzer("TestParentage",
+                                        inputTag = cms.InputTag("waiter"),
+                                        expectedAncestors = cms.vstring("busy1", "busy2", "busy3")
+)
+
+process.testParentage2 = cms.EDAnalyzer("TestParentage",
+                                        inputTag = cms.InputTag("filterwaiter"),
+                                        expectedAncestors = cms.vstring("busy1", "busy2", "busy3")
+)
+
+process.testParentage3 = cms.EDAnalyzer("TestParentage",
+                                        inputTag = cms.InputTag("streamwaiter"),
+                                        expectedAncestors = cms.vstring("busy1", "busy2", "busy3")
+)
+
+process.testParentage4 = cms.EDAnalyzer("TestParentage",
+                                        inputTag = cms.InputTag("streamfilterwaiter"),
+                                        expectedAncestors = cms.vstring("busy1", "busy2", "busy3")
+)
+
+process.p1 = cms.Path(process.tester + process.testParentage1, process.task)
+process.p2 = cms.Path(process.filtertester + process.testParentage2, process.task)
+process.p3 = cms.Path(process.streamtester + process.testParentage3, process.task)
+process.p4 = cms.Path(process.streamfiltertester + process.testParentage4, process.task)

--- a/FWCore/Integration/test/waiting_thread_test.sh
+++ b/FWCore/Integration/test/waiting_thread_test.sh
@@ -2,4 +2,12 @@
 
 function die { echo $1: status $2 ;  exit $2; }
 
+pushd ${LOCAL_TMP_DIR}
+
+echo "cmsRun waiting_thread_cfg.py"
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/waiting_thread_cfg.py || die 'Failed in waiting_thread_cfg.py' $?
+
+echo "cmsRun acquireTest_cfg.py"
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/acquireTest_cfg.py || die 'Failed in acquireTest_cfg.py' $?
+
+popd

--- a/FWCore/MessageService/interface/MessageLogger.h
+++ b/FWCore/MessageService/interface/MessageLogger.h
@@ -82,6 +82,9 @@ private:
   void  preModuleEvent ( StreamContext const&, ModuleCallingContext const& );
   void  postModuleEvent( StreamContext const&, ModuleCallingContext const& );
   
+  void  preModuleEventAcquire ( StreamContext const&, ModuleCallingContext const& );
+  void  postModuleEventAcquire( StreamContext const&, ModuleCallingContext const& );
+
   void  preModuleBeginJob  ( ModuleDescription const & );
   void  postModuleBeginJob ( ModuleDescription const & );
   void  preModuleEndJob  ( ModuleDescription const & );

--- a/FWCore/MessageService/src/MessageLogger.cc
+++ b/FWCore/MessageService/src/MessageLogger.cc
@@ -266,7 +266,10 @@ namespace edm {
       
       iRegistry.watchPreModuleEvent(this,&MessageLogger::preModuleEvent);
       iRegistry.watchPostModuleEvent(this,&MessageLogger::postModuleEvent);
-      
+
+      iRegistry.watchPreModuleEventAcquire(this,&MessageLogger::preModuleEventAcquire);
+      iRegistry.watchPostModuleEventAcquire(this,&MessageLogger::postModuleEventAcquire);
+
       iRegistry.watchPreSourceEvent(this,&MessageLogger::preSourceEvent);
       iRegistry.watchPostSourceEvent(this,&MessageLogger::postSourceEvent);
       // change log 14:
@@ -604,7 +607,19 @@ namespace edm {
     {
       unEstablishModule(mod,"PostModuleEvent");
     }
-    
+
+    void
+    MessageLogger::preModuleEventAcquire(StreamContext const& stream, ModuleCallingContext const& mod)
+    {
+      establishModule (stream.streamID().value(),mod,
+                       s_streamTransitionNames[static_cast<int>(StreamContext::Transition::kEvent)]);
+    }
+
+    void MessageLogger::postModuleEventAcquire(StreamContext const& stream, ModuleCallingContext const& mod)
+    {
+      unEstablishModule(mod,"PostModuleEventAcquire");
+    }
+
     void
     MessageLogger::preModuleStreamEndLumi(StreamContext const& stream, ModuleCallingContext const& mod)
     {

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -700,6 +700,22 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_2(watchPostModuleEvent)
 
+      /// signal is emitted before the module starts the acquire method for the Event
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleEventAcquire;
+      PreModuleEventAcquire preModuleEventAcquireSignal_;
+      void watchPreModuleEventAcquire(PreModuleEventAcquire::slot_type const& iSlot) {
+         preModuleEventAcquireSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreModuleEventAcquire)
+
+      /// signal is emitted after the module finishes the acquire method for the Event
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostModuleEventAcquire;
+      PostModuleEventAcquire postModuleEventAcquireSignal_;
+      void watchPostModuleEventAcquire(PostModuleEventAcquire::slot_type const& iSlot) {
+         postModuleEventAcquireSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostModuleEventAcquire)
+
       /// signal is emitted after the module starts processing the Event and before a delayed get has started
       typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleEventDelayedGet;
       PreModuleEventDelayedGet preModuleEventDelayedGetSignal_;

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -210,7 +210,10 @@ namespace edm {
 
     preModuleEventSignal_.connect(std::cref(iOther.preModuleEventSignal_));
      postModuleEventSignal_.connect(std::cref(iOther.postModuleEventSignal_));
-    
+
+     preModuleEventAcquireSignal_.connect(std::cref(iOther.preModuleEventAcquireSignal_));
+     postModuleEventAcquireSignal_.connect(std::cref(iOther.postModuleEventAcquireSignal_));
+
      preModuleEventDelayedGetSignal_.connect(std::cref(iOther.preModuleEventDelayedGetSignal_));
      postModuleEventDelayedGetSignal_.connect(std::cref(iOther.postModuleEventDelayedGetSignal_));
 
@@ -379,6 +382,9 @@ namespace edm {
     
     copySlotsToFrom(preModuleEventSignal_, iOther.preModuleEventSignal_);
     copySlotsToFromReverse(postModuleEventSignal_, iOther.postModuleEventSignal_);
+
+    copySlotsToFrom(preModuleEventAcquireSignal_, iOther.preModuleEventAcquireSignal_);
+    copySlotsToFromReverse(postModuleEventAcquireSignal_, iOther.postModuleEventAcquireSignal_);
 
     copySlotsToFrom(preModuleEventDelayedGetSignal_, iOther.preModuleEventDelayedGetSignal_);
     copySlotsToFromReverse(postModuleEventDelayedGetSignal_, iOther.postModuleEventDelayedGetSignal_);

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -134,6 +134,8 @@ namespace edm {
       void postModuleEventPrefetching(StreamContext const&, ModuleCallingContext const&);
       void preModuleEvent(StreamContext const&, ModuleCallingContext const&);
       void postModuleEvent(StreamContext const&, ModuleCallingContext const&);
+      void preModuleEventAcquire(StreamContext const&, ModuleCallingContext const&);
+      void postModuleEventAcquire(StreamContext const&, ModuleCallingContext const&);
       void preModuleEventDelayedGet(StreamContext const&, ModuleCallingContext const&);
       void postModuleEventDelayedGet(StreamContext const&, ModuleCallingContext const&);
       void preEventReadFromSource(StreamContext const&, ModuleCallingContext const&);
@@ -275,6 +277,8 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry&iRegistry) :
   iRegistry.watchPostModuleEventPrefetching(this, &Tracer::postModuleEventPrefetching);
   iRegistry.watchPreModuleEvent(this, &Tracer::preModuleEvent);
   iRegistry.watchPostModuleEvent(this, &Tracer::postModuleEvent);
+  iRegistry.watchPreModuleEventAcquire(this, &Tracer::preModuleEventAcquire);
+  iRegistry.watchPostModuleEventAcquire(this, &Tracer::postModuleEventAcquire);
   iRegistry.watchPreModuleEventDelayedGet(this, &Tracer::preModuleEventDelayedGet);
   iRegistry.watchPostModuleEventDelayedGet(this, &Tracer::postModuleEventDelayedGet);
   iRegistry.watchPreEventReadFromSource(this, &Tracer::preEventReadFromSource);
@@ -914,6 +918,27 @@ Tracer::postModuleEvent(StreamContext const& sc, ModuleCallingContext const& mcc
   }
 }
 
+void
+Tracer::preModuleEventAcquire(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 4;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " starting: processing event acquire for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
+}
+
+void
+Tracer::postModuleEventAcquire(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 4;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " finished: processing event acquire for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
+}
 
 void
 Tracer::preModuleEventDelayedGet(StreamContext const& sc, ModuleCallingContext const& mcc) {


### PR DESCRIPTION
Implements Framework level support for modules that run in new ways. For example, they might be used to run GPUs, FPGAs, or GEANT V. Initially we expect these modules to be used in prototypes and tests that will direct the path of future development.

These new modules are declared as EDFilters or EDProducers in the global or stream namespace with a template parameter of type ExternalWork. These special modules will have a new acquire method in which they are expected to get products from the event and pass that data to an external worker. The external worker is also passed a WaitingTaskWithArenaHolder that it uses to signal the Framework when it is done and also to pass exceptions back to the Framework.  After the external work is complete, the produce or filter method is called as before. A critically important point is that the acquire method returns and is removed from the stack without waiting for the external work to complete. 

Except for the unit tests included in this PR, no modules currently use this new External Work feature so it should not have any effect on any pre-existing tests.  

(As a separate PR that will follow this one, I am working on the stall grapher code so that stall grapher will properly account for the new signals related to the acquire method)
 
