### PR TITLE
Fix order of destructor calls

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -1069,6 +1069,10 @@ XrdAdaptor::RequestManager::OpenHandler::~OpenHandler()
 void
 XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts(XrdCl::XRootDStatus *status_ptr, XrdCl::AnyObject *, XrdCl::HostList *hostList_ptr)
 {
+  // Make sure we get rid of the strong self-reference when the callback finishes.
+  std::shared_ptr<OpenHandler> self = m_self;
+  m_self.reset();
+
   // NOTE: as in XrdCl::File (synchronous), we ignore the response object.
   // Make sure that we set m_outstanding_open to false on exit from this function.
   // NOTE: we need to pass non-nullptr to unique_ptr in order for the guard to run
@@ -1077,10 +1081,6 @@ XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts(XrdCl::XRootDSt
   std::shared_ptr<Source> source;
   std::unique_ptr<XrdCl::XRootDStatus> status(status_ptr);
   std::unique_ptr<XrdCl::HostList> hostList(hostList_ptr);
-
-    // Make sure we get rid of the strong self-reference when the callback finishes.
-  std::shared_ptr<OpenHandler> self = m_self;
-  m_self.reset();
 
   auto manager = m_manager.lock();
     // Manager object has already been deleted.  Cleanup the


### PR DESCRIPTION
The deletion of 'this' via the shared_ptr 'self' must happen after the destructor for outstanding_guard is called.