### PR TITLE
[10X] added exception (on failed write) to reco::details::loadTMVAWeights

### DIFF
--- a/CommonTools/Utils/src/TMVAZipReader.cc
+++ b/CommonTools/Utils/src/TMVAZipReader.cc
@@ -82,7 +82,7 @@ TMVA::IMethod* reco::details::loadTMVAWeights(TMVA::Reader* reader, const std::s
     std::string weight_file_name(tmpFilename);
     weight_file_name += ".xml";
     FILE *theActualFile = fopen(weight_file_name.c_str(), "w");
-    if (theActualFile != NULL) {
+    if (theActualFile != nullptr) {
       // write xml
       fputs(c, theActualFile);
       fputs("\n", theActualFile);

--- a/CommonTools/Utils/src/TMVAZipReader.cc
+++ b/CommonTools/Utils/src/TMVAZipReader.cc
@@ -82,11 +82,16 @@ TMVA::IMethod* reco::details::loadTMVAWeights(TMVA::Reader* reader, const std::s
     std::string weight_file_name(tmpFilename);
     weight_file_name += ".xml";
     FILE *theActualFile = fopen(weight_file_name.c_str(), "w");
-    // write xml
-    fputs(c, theActualFile);
-    fputs("\n", theActualFile);
-    fclose(theActualFile);
-    close(fdToUselessFile);
+    if (theActualFile != NULL) {
+      // write xml
+      fputs(c, theActualFile);
+      fputs("\n", theActualFile);
+      fclose(theActualFile);
+      close(fdToUselessFile);
+    } else {
+      throw cms::Exception("CannotWriteFile")
+        << "Error while writing file = " << weight_file_name << " !!\n";
+    }
     if (verbose)
       std::cout << "Booking MvA" << std::endl;
     ptr = reader->BookMVA(method, weight_file_name);


### PR DESCRIPTION
Adds a `cms::Exception("CannotWriteFile")` to `reco::details::loadTMVAWeights` when the weight file cannot be written (e.g. due to missing permissions). Fixes issue #21628.