### PR TITLE
Changed a static to be atomic to fix a thread-safety issue

### DIFF
--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -10,6 +10,8 @@
 //#include "HiggsTemplateCrossSections.h"
 #include "SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h"
 
+#include <atomic>
+
 namespace Rivet {
   
   /// @class HiggsTemplateCrossSections 
@@ -87,7 +89,7 @@ namespace Rivet {
       ++m_errorCount[err];
 
       // Print warning message to the screen/log
-      static int Nwarnings = 0;
+      static std::atomic<int> Nwarnings{0};
       if ( msg!="" && ++Nwarnings < NmaxWarnings )
 	  MSG_WARNING(msg);
 


### PR DESCRIPTION
This was found by the clang static analyzer.