### PR TITLE
DAQ output module file locking thread safety fix

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -104,8 +104,6 @@ namespace evf{
       FileStatus updateFuLock(unsigned int& ls, std::string& nextFile, uint32_t& fsize, uint64_t& lockWaitTime);
       void tryInitializeFuLockFile();
       unsigned int getRunNumber() const { return run_; }
-      FILE * maybeCreateAndLockFileHeadForStream(unsigned int ls, std::string &stream);
-      void unlockAndCloseMergeStream();
       void lockInitLock();
       void unlockInitLock();
       void setFMS(evf::FastMonitoringService* fms) {fms_=fms;}
@@ -164,7 +162,6 @@ namespace evf{
       int bu_readlock_fd_;
       int bu_writelock_fd_;
       int fu_readwritelock_fd_;
-      int data_readwrite_fd_;
       int fulocal_rwlock_fd_;
       int fulocal_rwlock_fd2_;
 
@@ -173,7 +170,6 @@ namespace evf{
       FILE * fu_rw_lock_stream;
       FILE * bu_w_monitor_stream;
       FILE * bu_t_monitor_stream;
-      FILE * data_rw_stream;
 
       DirManager dirManager_;
 
@@ -185,8 +181,6 @@ namespace evf{
       struct flock bu_r_fulk;
       struct flock fu_rw_flk;
       struct flock fu_rw_fulk;
-      struct flock data_rw_flk;
-      struct flock data_rw_fulk;
       //struct flock fulocal_rw_flk;
       //struct flock fulocal_rw_fulk;
       //struct flock fulocal_rw_flk2;

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -18,8 +18,8 @@
 #include <mutex>
 
 //system headers
-//#include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/file.h>
 #include <fcntl.h>
 #include <cerrno>
 #include <cstring>
@@ -125,7 +125,7 @@ namespace evf{
       std::string getStreamMergeType(std::string const& stream, MergeType defaultType);
       bool emptyLumisectionMode() const {return emptyLumisectionMode_;}
       bool microMergeDisabled() const {return microMergeDisabled_;}
-
+      static struct flock make_flock(short type, short whence, off_t start, off_t len, pid_t pid);
 
     private:
       //bool bulock();
@@ -181,10 +181,6 @@ namespace evf{
       struct flock bu_r_fulk;
       struct flock fu_rw_flk;
       struct flock fu_rw_fulk;
-      //struct flock fulocal_rw_flk;
-      //struct flock fulocal_rw_fulk;
-      //struct flock fulocal_rw_flk2;
-      //struct flock fulocal_rw_fulk2;
 
       evf::FastMonitoringService * fms_ = nullptr;
 

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -21,17 +21,6 @@
 
 namespace evf {
 
-  namespace {
-    struct flock make_flock(short type, short whence, off_t start, off_t len, pid_t pid)
-    {
-#ifdef __APPLE__
-      return {start, len, pid, type, whence};
-#else
-      return {type, whence, start, len, pid};
-#endif
-    }
-  }
-
   template<typename Consumer>
   class RecoEventOutputModuleForFU : public edm::StreamerOutputModuleBase {
     
@@ -103,8 +92,8 @@ namespace evf {
     mergeType_(),
     hltErrorEvents_(0),
     outBuf_(new unsigned char[1024*1024]),
-    data_rw_flk( evf::make_flock( F_WRLCK, SEEK_SET, 0, 0, getpid() )),
-    data_rw_fulk( evf:: make_flock( F_UNLCK, SEEK_SET, 0, 0, getpid() ))
+    data_rw_flk( evf::EvFDaqDirector::make_flock( F_WRLCK, SEEK_SET, 0, 0, getpid() )),
+    data_rw_fulk( evf::EvFDaqDirector::make_flock( F_UNLCK, SEEK_SET, 0, 0, getpid() ))
  
   {
     //replace hltOutoputA with stream if the HLT menu uses this convention
@@ -167,7 +156,7 @@ namespace evf {
     std::string outJsonDefName = ss.str();
 
     edm::Service<evf::EvFDaqDirector>()->lockInitLock();
-    struct stat   fstat;
+    struct stat fstat;
     if (stat (outJsonDefName.c_str(), &fstat) != 0) { //file does not exist
       LogDebug("RecoEventOutputModuleForFU") << "writing output definition file -: " << outJsonDefName;
       std::string content;

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -50,7 +50,7 @@ namespace evf {
 
   private:
     std::auto_ptr<Consumer> c_;
-    std::string stream_label_;
+    std::string streamLabel_;
     boost::filesystem::path openDatFilePath_;
     boost::filesystem::path openDatChecksumFilePath_;
     jsoncollector::IntJ processed_;
@@ -69,8 +69,8 @@ namespace evf {
     jsoncollector::DataPointDefinition outJsonDef_;
     unsigned char* outBuf_=nullptr;
     bool readAdler32Check_=false;
-    struct flock data_rw_flk;
-    struct flock data_rw_fulk;
+    struct flock dataRwFlk_;
+    struct flock dataRwFulk_;
 
   }; //end-of-class-def
 
@@ -79,7 +79,7 @@ namespace evf {
     edm::one::OutputModuleBase::OutputModuleBase(ps),
     edm::StreamerOutputModuleBase(ps),
     c_(new Consumer(ps)),
-    stream_label_(ps.getParameter<std::string>("@module_label")),
+    streamLabel_(ps.getParameter<std::string>("@module_label")),
     processed_(0),
     accepted_(0),
     errorEvents_(0),
@@ -92,23 +92,23 @@ namespace evf {
     mergeType_(),
     hltErrorEvents_(0),
     outBuf_(new unsigned char[1024*1024]),
-    data_rw_flk( evf::EvFDaqDirector::make_flock( F_WRLCK, SEEK_SET, 0, 0, getpid() )),
-    data_rw_fulk( evf::EvFDaqDirector::make_flock( F_UNLCK, SEEK_SET, 0, 0, getpid() ))
+    dataRwFlk_( evf::EvFDaqDirector::make_flock( F_WRLCK, SEEK_SET, 0, 0, getpid() )),
+    dataRwFulk_( evf::EvFDaqDirector::make_flock( F_UNLCK, SEEK_SET, 0, 0, getpid() ))
  
   {
     //replace hltOutoputA with stream if the HLT menu uses this convention
     std::string testPrefix="hltOutput";
-    if (stream_label_.find(testPrefix)==0) 
-      stream_label_=std::string("stream")+stream_label_.substr(testPrefix.size());
+    if (streamLabel_.find(testPrefix)==0) 
+      streamLabel_=std::string("stream")+streamLabel_.substr(testPrefix.size());
 
-    if (stream_label_.find("_")!=std::string::npos) {
+    if (streamLabel_.find("_")!=std::string::npos) {
       throw cms::Exception("RecoEventOutputModuleForFU")
-        << "Underscore character is reserved can not be used for stream names in FFF, but was detected in stream name -: " << stream_label_;
+        << "Underscore character is reserved can not be used for stream names in FFF, but was detected in stream name -: " << streamLabel_;
     }
 
-    std::string stream_label_lo = stream_label_;
-    boost::algorithm::to_lower(stream_label_lo);
-    auto streampos = stream_label_lo.rfind("stream");
+    std::string streamLabelLow = streamLabel_;
+    boost::algorithm::to_lower(streamLabelLow);
+    auto streampos = streamLabelLow.rfind("stream");
     if (streampos !=0 && streampos!=std::string::npos)
       throw cms::Exception("RecoEventOutputModuleForFU")
         << "stream (case-insensitive) sequence was found in stream suffix. This is reserved and can not be used for names in FFF based HLT, but was detected in stream name";
@@ -191,7 +191,7 @@ namespace evf {
   RecoEventOutputModuleForFU<Consumer>::start()
   {
     initRun();
-    const std::string openInitFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(stream_label_);
+    const std::string openInitFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(streamLabel_);
     edm::LogInfo("RecoEventOutputModuleForFU") << "start() method, initializing streams. init stream -: "  
 	                                       << openInitFileName;
     c_->setInitMessageFile(openInitFileName);
@@ -212,7 +212,7 @@ namespace evf {
   {
     c_->doOutputHeader(init_message);
 
-    const std::string openIniFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(stream_label_);
+    const std::string openIniFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(streamLabel_);
     struct stat istat;
     stat(openIniFileName.c_str(), &istat);
     //read back file to check integrity of what was written
@@ -238,8 +238,8 @@ namespace evf {
                            << " expected:" << c_->get_adler32_ini() << " obtained:" << adler32c;
     }
     else {
-      edm::LogWarning("RecoEventOutputModuleForFU") << "Ini file checksum -: "<< stream_label_ << " " << adler32c;
-      boost::filesystem::rename(openIniFileName,edm::Service<evf::EvFDaqDirector>()->getInitFilePath(stream_label_));
+      edm::LogWarning("RecoEventOutputModuleForFU") << "Ini file checksum -: "<< streamLabel_ << " " << adler32c;
+      boost::filesystem::rename(openIniFileName,edm::Service<evf::EvFDaqDirector>()->getInitFilePath(streamLabel_));
     }
   }
    
@@ -274,8 +274,8 @@ namespace evf {
   void RecoEventOutputModuleForFU<Consumer>::beginJob()
   {
     //get stream transfer destination
-    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(stream_label_);
-    mergeType_ = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType(stream_label_,evf::MergeTypeDAT);
+    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(streamLabel_);
+    mergeType_ = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType(streamLabel_,evf::MergeTypeDAT);
   }
 
 
@@ -283,8 +283,8 @@ namespace evf {
   void RecoEventOutputModuleForFU<Consumer>::beginLuminosityBlock(edm::LuminosityBlockForOutput const& ls)
   {
     //edm::LogInfo("RecoEventOutputModuleForFU") << "begin lumi";
-    openDatFilePath_ = edm::Service<evf::EvFDaqDirector>()->getOpenDatFilePath(ls.luminosityBlock(),stream_label_);
-    openDatChecksumFilePath_ = edm::Service<evf::EvFDaqDirector>()->getOpenDatFilePath(ls.luminosityBlock(),stream_label_);
+    openDatFilePath_ = edm::Service<evf::EvFDaqDirector>()->getOpenDatFilePath(ls.luminosityBlock(),streamLabel_);
+    openDatChecksumFilePath_ = edm::Service<evf::EvFDaqDirector>()->getOpenDatFilePath(ls.luminosityBlock(),streamLabel_);
     c_->setOutputFile(openDatFilePath_.string());
     filelist_ = openDatFilePath_.filename().string();
   }
@@ -311,15 +311,15 @@ namespace evf {
       if (!edm::Service<evf::EvFDaqDirector>()->microMergeDisabled()) {
 
         //create if does not exist then lock the merge destination file
-        FILE *des = fopen(edm::Service<evf::EvFDaqDirector>()->getMergedDatFilePath(ls.luminosityBlock(),stream_label_).c_str(), "a"); //open stream for appending
-        int data_readwrite_fd_ = fileno(des);
-        if (data_readwrite_fd_ == -1)
+        FILE *des = fopen(edm::Service<evf::EvFDaqDirector>()->getMergedDatFilePath(ls.luminosityBlock(),streamLabel_).c_str(), "a"); //open stream for appending
+        int data_readwrite_fd = fileno(des);
+        if (data_readwrite_fd == -1)
           edm::LogError("RecoEventOutputModuleForFU") << "problem with creating filedesc for datamerge " << strerror(errno);
         else
-          LogDebug("RecoEventOutputModuleForFU") << "creating filedesc for datamerge -: " << data_readwrite_fd_;
-        fcntl(data_readwrite_fd_, F_SETLKW, &data_rw_flk);
+          LogDebug("RecoEventOutputModuleForFU") << "creating filedesc for datamerge -: " << data_readwrite_fd;
+        fcntl(data_readwrite_fd, F_SETLKW, &dataRwFlk_);
 
-        std::string deschecksum = edm::Service<evf::EvFDaqDirector>()->getMergedDatChecksumFilePath(ls.luminosityBlock(), stream_label_);
+        std::string deschecksum = edm::Service<evf::EvFDaqDirector>()->getMergedDatChecksumFilePath(ls.luminosityBlock(), streamLabel_);
 
         struct stat istat;
         FILE * cf = nullptr;
@@ -363,7 +363,7 @@ namespace evf {
 
         //unlock and close output file
         fflush(des);
-        fcntl(data_readwrite_fd_, F_SETLKW, &data_rw_fulk);
+        fcntl(data_readwrite_fd, F_SETLKW, &dataRwFulk_);
         fclose(des);
 
         fclose(src);
@@ -377,7 +377,7 @@ namespace evf {
       else  { //no micromerge by HLT
         stat(openDatFilePath_.string().c_str(), &istat);
         filesize = istat.st_size;
-        boost::filesystem::rename(openDatFilePath_.string().c_str(), edm::Service<evf::EvFDaqDirector>()->getDatFilePath(ls.luminosityBlock(),stream_label_));
+        boost::filesystem::rename(openDatFilePath_.string().c_str(), edm::Service<evf::EvFDaqDirector>()->getDatFilePath(ls.luminosityBlock(),streamLabel_));
       }
     } else {
       //return if not in empty lumisection mode
@@ -395,7 +395,7 @@ namespace evf {
 
     jsonMonitor_->snap(ls.luminosityBlock());
     const std::string outputJsonNameStream =
-      edm::Service<evf::EvFDaqDirector>()->getOutputJsonFilePath(ls.luminosityBlock(),stream_label_);
+      edm::Service<evf::EvFDaqDirector>()->getOutputJsonFilePath(ls.luminosityBlock(),streamLabel_);
     jsonMonitor_->outputFullJSON(outputJsonNameStream,ls.luminosityBlock());
 
     // reset monitoring params

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -19,7 +19,6 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <cstdio>
-#include <sys/file.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/filesystem/fstream.hpp>
 
@@ -32,17 +31,6 @@ namespace evf {
 
   //for enum MergeType
   const std::vector<std::string> EvFDaqDirector::MergeTypeNames_ = {"","DAT","PB","JSNDATA"};
-
-  namespace {
-    struct flock make_flock(short type, short whence, off_t start, off_t len, pid_t pid)
-    {
-#ifdef __APPLE__
-      return {start, len, pid, type, whence};
-#else
-      return {type, whence, start, len, pid};
-#endif
-    }
-  }
 
   EvFDaqDirector::EvFDaqDirector(const edm::ParameterSet &pset,
 				 edm::ActivityRegistry& reg) :
@@ -81,10 +69,6 @@ namespace evf {
     bu_r_fulk( make_flock( F_UNLCK, SEEK_SET, 0, 0, 0 )),
     fu_rw_flk( make_flock ( F_WRLCK, SEEK_SET, 0, 0, getpid() )),
     fu_rw_fulk( make_flock( F_UNLCK, SEEK_SET, 0, 0, getpid() ))
-    //fulocal_rw_flk( make_flock( F_WRLCK, SEEK_SET, 0, 0, getpid() )),
-    //fulocal_rw_fulk( make_flock( F_UNLCK, SEEK_SET, 0, 0, getpid() )),
-    //fulocal_rw_flk2( make_flock( F_WRLCK, SEEK_SET, 0, 0, getpid() )),
-    //fulocal_rw_fulk2( make_flock( F_UNLCK, SEEK_SET, 0, 0, getpid() ))
   {
 
     reg.watchPreallocate(this, &EvFDaqDirector::preallocate);
@@ -1011,4 +995,14 @@ namespace evf {
     close(proc_flag_fd);
   }
 
+  struct flock EvFDaqDirector::make_flock(short type, short whence, off_t start, off_t len, pid_t pid)
+  {
+#ifdef __APPLE__
+      return {start, len, pid, type, whence};
+#else
+      return {type, whence, start, len, pid};
+#endif
+  }
+
 }
+

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -62,7 +62,6 @@ namespace evf {
     bu_readlock_fd_(-1),
     bu_writelock_fd_(-1),
     fu_readwritelock_fd_(-1),
-    data_readwrite_fd_(-1),
     fulocal_rwlock_fd_(-1),
     fulocal_rwlock_fd2_(-1),
 
@@ -71,7 +70,6 @@ namespace evf {
     fu_rw_lock_stream(nullptr),
     //bu_w_monitor_stream(0),
     //bu_t_monitor_stream(0),
-    data_rw_stream(nullptr),
 
     dirManager_(base_dir_),
 
@@ -82,9 +80,7 @@ namespace evf {
     bu_w_fulk( make_flock( F_UNLCK, SEEK_SET, 0, 0, 0 )),
     bu_r_fulk( make_flock( F_UNLCK, SEEK_SET, 0, 0, 0 )),
     fu_rw_flk( make_flock ( F_WRLCK, SEEK_SET, 0, 0, getpid() )),
-    fu_rw_fulk( make_flock( F_UNLCK, SEEK_SET, 0, 0, getpid() )),
-    data_rw_flk( make_flock ( F_WRLCK, SEEK_SET, 0, 0, getpid() )),
-    data_rw_fulk( make_flock( F_UNLCK, SEEK_SET, 0, 0, getpid() ))
+    fu_rw_fulk( make_flock( F_UNLCK, SEEK_SET, 0, 0, getpid() ))
     //fulocal_rw_flk( make_flock( F_WRLCK, SEEK_SET, 0, 0, getpid() )),
     //fulocal_rw_fulk( make_flock( F_UNLCK, SEEK_SET, 0, 0, getpid() )),
     //fulocal_rw_flk2( make_flock( F_WRLCK, SEEK_SET, 0, 0, getpid() )),
@@ -818,27 +814,6 @@ namespace evf {
 		<< fu_readwritelock_fd_;
 
     fu_rw_lock_stream = fdopen(fu_readwritelock_fd_, "r+");
-  }
-
-  //create if does not exist then lock the merge destination file
-  FILE *EvFDaqDirector::maybeCreateAndLockFileHeadForStream(unsigned int ls, std::string &stream) {
-    data_rw_stream = fopen(getMergedDatFilePath(ls,stream).c_str(), "a"); //open stream for appending
-    data_readwrite_fd_ = fileno(data_rw_stream);
-    if (data_readwrite_fd_ == -1)
-      edm::LogError("EvFDaqDirector") << "problem with creating filedesc for datamerge "
-		<< strerror(errno);
-    else
-      LogDebug("EvFDaqDirector") << "creating filedesc for datamerge -: "
-		<< data_readwrite_fd_;
-    fcntl(data_readwrite_fd_, F_SETLKW, &data_rw_flk);
-
-    return data_rw_stream;
-  }
-
-  void EvFDaqDirector::unlockAndCloseMergeStream() {
-    fflush(data_rw_stream);
-    fcntl(data_readwrite_fd_, F_SETLKW, &data_rw_fulk);
-    fclose(data_rw_stream);
   }
 
   void EvFDaqDirector::lockInitLock() {


### PR DESCRIPTION
Fixes thread safety issue caused by calling the EvFDaqDirector Service function where variable was getting shared by multiple otuput module instances (running possibly in paralel in 9_4_X release).
Note however that this mechanism is deprecated (hlt daemon defaults to external micro-merging scheme, instead of doing it as part of CMSSW output module EoL) and will be removed in the future.