### PR TITLE
Fix cmsDriver exception message when --conditions is not given

### DIFF
--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -50,7 +50,7 @@ def OptionsFromItems(items):
         from Configuration.AlCa import autoCond
         possible=""
         for k in autoCond.autoCond:
-            possible+="\nauto:"+k+" -> "+autoCond.autoCond[k]
+            possible+="\nauto:"+k+" -> "+str(autoCond.autoCond[k])
         raise Exception("the --conditions option is mandatory. Possibilities are: "+possible)
 
 


### PR DESCRIPTION
Minimal fix to resolve #12708. The `autoCond.autoCond[k]` can be a tuple, so easiest was just to convert it to a string for concatenation.

Tested in 10_0_0_pre1, no changes expected.