### PR TITLE
Put LCT related enums in CSCConstants

### DIFF
--- a/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
+++ b/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
@@ -23,9 +23,15 @@ class CSCConstants
 
   enum Digis_Info { MAX_DIGIS_PER_ALCT = 10, MAX_DIGIS_PER_CLCT = 8 };
 
-  // Each CSC can send up to 2 LCTs to the MPC.
-  // An MPC receives up to 18 LCTs from 9 CSCs in the trigger sector
-  enum LCT_stubs{ MAX_LCTS_PER_CSC = 2, MAX_LCTS_PER_MPC = 18 };
+  enum LCT_stubs{
+    // CSC local trigger considers 4-bit BX window (16 numbers) in the readout
+    MAX_CLCT_BINS = 16,
+    MAX_ALCT_BINS = 16,
+    MAX_LCT_BINS = 16,
+    // Each CSC can send up to 2 LCTs to the MPC.
+    MAX_LCTS_PER_CSC = 2,
+    // An MPC receives up to 18 LCTs from 9 CSCs in the trigger sector
+    MAX_LCTS_PER_MPC = 18 };
 
 };
 

--- a/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
+++ b/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
@@ -11,28 +11,59 @@
 class CSCConstants
 {
  public:
-  enum WG_and_Strip { MAX_NUM_WIRES = 119, MAX_NUM_STRIPS = 80, MAX_NUM_STRIPS_7CFEBS = 112,
-                      NUM_DI_STRIPS = 40+1, // Add 1 to allow for staggering of strips
-                      NUM_HALF_STRIPS = 160+1, NUM_HALF_STRIPS_7CFEBS = 224+1};
+  enum CFEB_Info {
+    //Maximum number of cathode front-end boards
+    MAX_CFEBS = 5,
+  };
+
+  enum WG_and_Strip {
+    MAX_NUM_WIRES = 119,
+    MAX_NUM_STRIPS = 80,
+    MAX_NUM_STRIPS_7CFEBS = 112,
+    NUM_DI_STRIPS = 40+1, // Add 1 to allow for staggering of strips
+    NUM_HALF_STRIPS = 160+1,
+    NUM_HALF_STRIPS_7CFEBS = 224+1,
+    // each CFEB reads out 8 distrips, 16 strips or 32 halfstrips
+    NUM_DISTRIPS_PER_CFEB = 8,
+    NUM_STRIPS_PER_CFEB = 16,
+    NUM_HALF_STRIPS_PER_CFEB = 32};
 
   // CSCs have 6 layers. The key (refernce) layer is the third layer
-  enum Layer_Info { NUM_LAYERS = 6, KEY_CLCT_LAYER = 3, KEY_CLCT_LAYER_PRE_TMB07 = 4, KEY_ALCT_LAYER = 3 };
+  enum Layer_Info {
+    NUM_LAYERS = 6,
+    KEY_CLCT_LAYER = 3,
+    KEY_CLCT_LAYER_PRE_TMB07 = 4,
+    KEY_ALCT_LAYER = 3 };
 
   // Both ALCT and CLCTs have patterns. CLCTs have a better granularity than ALCTs, thus more patterns
-  enum Pattern_Info { NUM_ALCT_PATTERNS = 3, NUM_CLCT_PATTERNS = 11, NUM_CLCT_PATTERNS_PRE_TMB07 = 8 };
+  enum Pattern_Info {
+    NUM_ALCT_PATTERNS = 3,
+    NUM_CLCT_PATTERNS = 11,
+    NUM_CLCT_PATTERNS_PRE_TMB07 = 8,
+    // Max number of wires participating in a pattern
+    NUM_PATTERN_WIRES = 14,
+    // Max number of strips participating in a pattern
+    NUM_PATTERN_STRIPS = 26,
+    // Max number of halfstrips participating in a pattern
+    NUM_PATTERN_HALFSTRIPS = 42};
 
-  enum Digis_Info { MAX_DIGIS_PER_ALCT = 10, MAX_DIGIS_PER_CLCT = 8 };
+  enum Digis_Info {
+    MAX_DIGIS_PER_ALCT = 10,
+    MAX_DIGIS_PER_CLCT = 8 };
 
   enum LCT_stubs{
     // CSC local trigger considers 4-bit BX window (16 numbers) in the readout
     MAX_CLCT_BINS = 16,
     MAX_ALCT_BINS = 16,
     MAX_LCT_BINS = 16,
+    // Each CLCT processor can snd up to 2 CLCTs to TMB
+    MAX_CLCTS_PER_PROCESSOR = 2,
+    // Each ALCT processor can snd up to 2 ALCTs to TMB
+    MAX_ALCTS_PER_PROCESSOR = 2,
     // Each CSC can send up to 2 LCTs to the MPC.
     MAX_LCTS_PER_CSC = 2,
     // An MPC receives up to 18 LCTs from 9 CSCs in the trigger sector
     MAX_LCTS_PER_MPC = 18 };
-
 };
 
 #endif

--- a/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
+++ b/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
@@ -16,8 +16,15 @@ class CSCConstants
     MAX_CFEBS = 5,
   };
 
+  enum FPGA_Latency{
+    CLCT_FPGA_LATENCY = 3,
+    ALCT_FPGA_LATENCY = 6
+  };
+
+  // Note: WIRE means actually "wiregroup" here
   enum WG_and_Strip {
     MAX_NUM_WIRES = 119,
+    MAX_NUM_WIRES_ME11 = 48,
     MAX_NUM_STRIPS = 80,
     MAX_NUM_STRIPS_7CFEBS = 112,
     NUM_DI_STRIPS = 40+1, // Add 1 to allow for staggering of strips

--- a/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
+++ b/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
@@ -17,14 +17,14 @@ class CSCConstants
   };
 
   enum FPGA_Latency{
-    CLCT_FPGA_LATENCY = 3,
-    ALCT_FPGA_LATENCY = 6
+    CLCT_EMUL_TIME_OFFSET = 3,
+    ALCT_EMUL_TIME_OFFSET = 6
   };
 
   // Note: WIRE means actually "wiregroup" here
   enum WG_and_Strip {
     MAX_NUM_WIRES = 119,
-    MAX_NUM_WIRES_ME11 = 48,
+    MAX_WIRES_ME11 = 48,
     MAX_NUM_STRIPS = 80,
     MAX_NUM_STRIPS_7CFEBS = 112,
     NUM_DI_STRIPS = 40+1, // Add 1 to allow for staggering of strips
@@ -56,11 +56,11 @@ class CSCConstants
     NUM_CLCT_PATTERNS = 11,
     NUM_CLCT_PATTERNS_PRE_TMB07 = 8,
     // Max number of wires participating in a pattern
-    NUM_PATTERN_WIRES = 14,
+    MAX_WIRES_IN_PATTERN = 14,
     // Max number of strips participating in a pattern
-    NUM_PATTERN_STRIPS = 26,
+    MAX_STRIPS_IN_PATTERN = 26,
     // Max number of halfstrips participating in a pattern
-    NUM_PATTERN_HALFSTRIPS = 42};
+    MAX_HALFSTRIPS_IN_PATTERN = 42};
 
   enum Digis_Info {
     MAX_DIGIS_PER_ALCT = 10,
@@ -68,9 +68,9 @@ class CSCConstants
 
   enum LCT_stubs{
     // CSC local trigger considers 4-bit BX window (16 numbers) in the readout
-    MAX_CLCT_BINS = 16,
-    MAX_ALCT_BINS = 16,
-    MAX_LCT_BINS = 16,
+    MAX_CLCT_TBINS = 16,
+    MAX_ALCT_TBINS = 16,
+    MAX_LCT_TBINS = 16,
     // Each CLCT processor can snd up to 2 CLCTs to TMB
     MAX_CLCTS_PER_PROCESSOR = 2,
     // Each ALCT processor can snd up to 2 ALCTs to TMB

--- a/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
+++ b/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
@@ -26,7 +26,15 @@ class CSCConstants
     // each CFEB reads out 8 distrips, 16 strips or 32 halfstrips
     NUM_DISTRIPS_PER_CFEB = 8,
     NUM_STRIPS_PER_CFEB = 16,
-    NUM_HALF_STRIPS_PER_CFEB = 32};
+    NUM_HALF_STRIPS_PER_CFEB = 32,
+    // max halfstrip number in ME1/1 chambers
+    // All ME1A readout by 1 CFEB -> 32 -1
+    MAX_HALF_STRIP_ME1A_GANGED = 31,
+    // All ME1A readout by 3 CFEBs -> 3*32 -1
+    MAX_HALF_STRIP_ME1A_UNGANGED = 95,
+    // All ME1B readout by 4 CFEBs -> 4*32 -1
+    MAX_HALF_STRIP_ME1B = 127
+  };
 
   // CSCs have 6 layers. The key (refernce) layer is the third layer
   enum Layer_Info {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -40,7 +40,7 @@
    patterns A and B.
    pattern_envelope[0][i]=layer;
    pattern_envelope[1+MEposition][i]=key_wire offset. */
-const int CSCAnodeLCTProcessor::pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES] = {
+const int CSCAnodeLCTProcessor::pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN] = {
   //Layer
   { 0,  0,  0,
         1,  1,
@@ -67,7 +67,7 @@ const int CSCAnodeLCTProcessor::pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS
 };
 
 // time averaging weights for pattern (used for SLHC version)
-const int CSCAnodeLCTProcessor::time_weights[CSCConstants::NUM_PATTERN_WIRES] =
+const int CSCAnodeLCTProcessor::time_weights[CSCConstants::MAX_WIRES_IN_PATTERN] =
   //Layer
   { 0,  1,  1,
         1,  2,
@@ -81,7 +81,7 @@ const int CSCAnodeLCTProcessor::time_weights[CSCConstants::NUM_PATTERN_WIRES] =
 // and collision patterns A and B.  These masks were meant to be the default
 // ones in early 200X, but were never implemented because of limited FPGA
 // resources.
-const int CSCAnodeLCTProcessor::pattern_mask_slim[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES] = {
+const int CSCAnodeLCTProcessor::pattern_mask_slim[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN] = {
   // Accelerator pattern
   {0,  0,  1,
        0,  1,
@@ -109,7 +109,7 @@ const int CSCAnodeLCTProcessor::pattern_mask_slim[CSCConstants::NUM_ALCT_PATTERN
 
 // Since the test beams in 2003, both collision patterns are "completely
 // open".  This is our current default.
-const int CSCAnodeLCTProcessor::pattern_mask_open[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES] = {
+const int CSCAnodeLCTProcessor::pattern_mask_open[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN] = {
   // Accelerator pattern
   {0,  0,  1,
        0,  1,
@@ -136,7 +136,7 @@ const int CSCAnodeLCTProcessor::pattern_mask_open[CSCConstants::NUM_ALCT_PATTERN
 };
 
 // Special option for narrow pattern for ring 1 stations
-const int CSCAnodeLCTProcessor::pattern_mask_r1[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES] = {
+const int CSCAnodeLCTProcessor::pattern_mask_r1[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN] = {
   // Accelerator pattern
   {0,  0,  1,
        0,  1,
@@ -224,7 +224,7 @@ CSCAnodeLCTProcessor::CSCAnodeLCTProcessor(unsigned endcap, unsigned station,
 
   // separate handle for early time bins
   early_tbins = conf.getParameter<int>("alctEarlyTbins");
-  if (early_tbins<0) early_tbins  = fifo_pretrig - CSCConstants::ALCT_FPGA_LATENCY;
+  if (early_tbins<0) early_tbins  = fifo_pretrig - CSCConstants::ALCT_EMUL_TIME_OFFSET;
 
   // delta BX time depth for ghostCancellationLogic
   ghost_cancellation_bx_depth = conf.getParameter<int>("alctGhostCancellationBxDepth");
@@ -318,7 +318,7 @@ CSCAnodeLCTProcessor::CSCAnodeLCTProcessor() :
 void CSCAnodeLCTProcessor::loadPatternMask() {
   // Load appropriate pattern mask.
   for (int i_patt = 0; i_patt < CSCConstants::NUM_ALCT_PATTERNS; i_patt++) {
-    for (int i_wire = 0; i_wire < CSCConstants::NUM_PATTERN_WIRES; i_wire++) {
+    for (int i_wire = 0; i_wire < CSCConstants::MAX_WIRES_IN_PATTERN; i_wire++) {
       if (isMTCC || isTMB07) {
         pattern_mask[i_patt][i_wire] = pattern_mask_open[i_patt][i_wire];
         if (narrow_mask_r1 && (theRing == 1 || theRing == 4))
@@ -383,7 +383,7 @@ void CSCAnodeLCTProcessor::checkConfigParameters() {
   static const unsigned int max_nplanes_hit_accel_pattern = 1 << 3;
   static const unsigned int max_trig_mode        = 1 << 2;
   static const unsigned int max_accel_mode       = 1 << 2;
-  static const unsigned int max_l1a_window_width = CSCConstants::MAX_ALCT_BINS; // 4 bits
+  static const unsigned int max_l1a_window_width = CSCConstants::MAX_ALCT_TBINS; // 4 bits
 
   // Checks.
   if (fifo_tbins >= max_fifo_tbins) {
@@ -471,7 +471,7 @@ void CSCAnodeLCTProcessor::checkConfigParameters() {
 }
 
 void CSCAnodeLCTProcessor::clear() {
-  for (int bx = 0; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_ALCT_TBINS; bx++) {
     bestALCT[bx].clear();
     secondALCT[bx].clear();
   }
@@ -830,7 +830,7 @@ bool CSCAnodeLCTProcessor::preTrigger(const int key_wire, const int start_bx) {
         hit_layer[i_layer] = false;
       layers_hit = 0;
 
-      for (int i_wire = 0; i_wire < CSCConstants::NUM_PATTERN_WIRES; i_wire++){
+      for (int i_wire = 0; i_wire < CSCConstants::MAX_WIRES_IN_PATTERN; i_wire++){
         if (pattern_mask[i_pattern][i_wire] != 0){
           this_layer = pattern_envelope[0][i_wire];
           this_wire  = pattern_envelope[1+MESelection][i_wire]+key_wire;
@@ -893,7 +893,7 @@ bool CSCAnodeLCTProcessor::patternDetection(const int key_wire) {
     std::multiset<int> mset_for_median;
     mset_for_median.clear();
 
-    for (int i_wire = 0; i_wire < CSCConstants::NUM_PATTERN_WIRES; i_wire++){
+    for (int i_wire = 0; i_wire < CSCConstants::MAX_WIRES_IN_PATTERN; i_wire++){
       if (pattern_mask[i_pattern][i_wire] != 0){
         this_layer = pattern_envelope[0][i_wire];
         delta_wire = pattern_envelope[1+MESelection][i_wire];
@@ -1277,10 +1277,10 @@ void CSCAnodeLCTProcessor::lctSearch() {
        plct != fourBest.end(); plct++) {
 
     int bx = plct->getBX();
-    if (bx >= CSCConstants::MAX_ALCT_BINS) {
+    if (bx >= CSCConstants::MAX_ALCT_TBINS) {
       if (infoV > 0) edm::LogWarning("L1CSCTPEmulatorOutOfTimeALCT")
         << "+++ Bx of ALCT candidate, " << bx << ", exceeds max allowed, "
-        << CSCConstants::MAX_ALCT_BINS-1 << "; skipping it... +++\n";
+        << CSCConstants::MAX_ALCT_TBINS-1 << "; skipping it... +++\n";
       continue;
     }
 
@@ -1297,22 +1297,22 @@ void CSCAnodeLCTProcessor::lctSearch() {
 
   if (!isTMB07) {
     // Prior to DAQ-2006 format, only ALCTs at the earliest bx were reported.
-    int first_bx = CSCConstants::MAX_ALCT_BINS;
-    for (int bx = 0; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
+    int first_bx = CSCConstants::MAX_ALCT_TBINS;
+    for (int bx = 0; bx < CSCConstants::MAX_ALCT_TBINS; bx++) {
       if (bestALCT[bx].isValid()) {
         first_bx = bx;
         break;
       }
     }
-    if (first_bx < CSCConstants::MAX_ALCT_BINS) {
-      for (int bx = first_bx + 1; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
+    if (first_bx < CSCConstants::MAX_ALCT_TBINS) {
+      for (int bx = first_bx + 1; bx < CSCConstants::MAX_ALCT_TBINS; bx++) {
         if (bestALCT[bx].isValid())   bestALCT[bx].clear();
         if (secondALCT[bx].isValid()) secondALCT[bx].clear();
       }
     }
   }
 
-  for (int bx = 0; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_ALCT_TBINS; bx++) {
     if (bestALCT[bx].isValid()) {
       bestALCT[bx].setTrknmb(1);
       if (infoV > 0) {
@@ -1344,7 +1344,7 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::bestTrackSelector(
                                  const std::vector<CSCALCTDigi>& all_alcts) {
   /* Selects two collision and two accelerator ALCTs per time bin with
      the best quality. */
-  CSCALCTDigi bestALCTs[CSCConstants::MAX_ALCT_BINS][2], secondALCTs[CSCConstants::MAX_ALCT_BINS][2];
+  CSCALCTDigi bestALCTs[CSCConstants::MAX_ALCT_TBINS][2], secondALCTs[CSCConstants::MAX_ALCT_TBINS][2];
 
   if (infoV > 1) {
     LogTrace("CSCAnodeLCTProcessor") << all_alcts.size() <<
@@ -1356,7 +1356,7 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::bestTrackSelector(
     }
   }
 
-  CSCALCTDigi tA[CSCConstants::MAX_ALCT_BINS][2], tB[CSCConstants::MAX_ALCT_BINS][2];
+  CSCALCTDigi tA[CSCConstants::MAX_ALCT_TBINS][2], tB[CSCConstants::MAX_ALCT_TBINS][2];
   for (std::vector <CSCALCTDigi>::const_iterator plct = all_alcts.begin();
        plct != all_alcts.end(); plct++) {
     if (!plct->isValid()) continue;
@@ -1386,7 +1386,7 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::bestTrackSelector(
     }
   }
 
-  for (int bx = 0; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_ALCT_TBINS; bx++) {
     for (int accel = 0; accel <= 1; accel++) {
       // Best ALCT is always tA.
       if (tA[bx][accel].isValid()) {
@@ -1423,7 +1423,7 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::bestTrackSelector(
 
   // Fill the vector with up to four best ALCTs per bx and return it.
   std::vector<CSCALCTDigi> fourBest;
-  for (int bx = 0; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_ALCT_TBINS; bx++) {
     for (int i = 0; i < 2; i++) {
       if (bestALCTs[bx][i].isValid())   fourBest.push_back(bestALCTs[bx][i]);
     }
@@ -1645,12 +1645,12 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::readoutALCTs() {
         << "; in-time ALCTs are not getting read-out!!! +++" << "\n";
     }
 
-    if (late_tbins > CSCConstants::MAX_ALCT_BINS-1) {
+    if (late_tbins > CSCConstants::MAX_ALCT_TBINS-1) {
       if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorSuspiciousParameters")
         << "+++ Allowed range of time bins, [0-" << late_tbins
-        << "] exceeds max allowed, " << CSCConstants::MAX_ALCT_BINS-1 << " +++\n"
+        << "] exceeds max allowed, " << CSCConstants::MAX_ALCT_TBINS-1 << " +++\n"
         << "+++ Set late_tbins to max allowed +++\n";
-      late_tbins = CSCConstants::MAX_ALCT_BINS-1;
+      late_tbins = CSCConstants::MAX_ALCT_TBINS-1;
     }
     ifois = 1;
   }
@@ -1689,7 +1689,7 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::readoutALCTs() {
 // Returns vector of all found ALCTs, if any.  Used in ALCT-CLCT matching.
 std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::getALCTs() {
   std::vector<CSCALCTDigi> tmpV;
-  for (int bx = 0; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_ALCT_TBINS; bx++) {
     if (bestALCT[bx].isValid())   tmpV.push_back(bestALCT[bx]);
     if (secondALCT[bx].isValid()) tmpV.push_back(secondALCT[bx]);
   }
@@ -1710,7 +1710,7 @@ void CSCAnodeLCTProcessor::showPatterns(const int key_wire) {
       strstrm_header << ((32-i)%10);
     }
     LogTrace("CSCAnodeLCTProcessor") << strstrm_header.str();
-    for (int i_wire = 0; i_wire < CSCConstants::NUM_PATTERN_WIRES; i_wire++) {
+    for (int i_wire = 0; i_wire < CSCConstants::MAX_WIRES_IN_PATTERN; i_wire++) {
       if (pattern_mask[i_pattern][i_wire] != 0) {
         std::ostringstream strstrm_pulse;
         int this_layer = pattern_envelope[0][i_wire];

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -224,8 +224,7 @@ CSCAnodeLCTProcessor::CSCAnodeLCTProcessor(unsigned endcap, unsigned station,
 
   // separate handle for early time bins
   early_tbins = conf.getParameter<int>("alctEarlyTbins");
-  int fpga_latency = 6;
-  if (early_tbins<0) early_tbins  = fifo_pretrig - fpga_latency;
+  if (early_tbins<0) early_tbins  = fifo_pretrig - CSCConstants::ALCT_FPGA_LATENCY;
 
   // delta BX time depth for ghostCancellationLogic
   ghost_cancellation_bx_depth = conf.getParameter<int>("alctGhostCancellationBxDepth");

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -384,7 +384,7 @@ void CSCAnodeLCTProcessor::checkConfigParameters() {
   static const unsigned int max_nplanes_hit_accel_pattern = 1 << 3;
   static const unsigned int max_trig_mode        = 1 << 2;
   static const unsigned int max_accel_mode       = 1 << 2;
-  static const unsigned int max_l1a_window_width = MAX_ALCT_BINS; // 4 bits
+  static const unsigned int max_l1a_window_width = CSCConstants::MAX_ALCT_BINS; // 4 bits
 
   // Checks.
   if (fifo_tbins >= max_fifo_tbins) {
@@ -472,7 +472,7 @@ void CSCAnodeLCTProcessor::checkConfigParameters() {
 }
 
 void CSCAnodeLCTProcessor::clear() {
-  for (int bx = 0; bx < MAX_ALCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
     bestALCT[bx].clear();
     secondALCT[bx].clear();
   }
@@ -1280,10 +1280,10 @@ void CSCAnodeLCTProcessor::lctSearch() {
        plct != fourBest.end(); plct++) {
 
     int bx = plct->getBX();
-    if (bx >= MAX_ALCT_BINS) {
+    if (bx >= CSCConstants::MAX_ALCT_BINS) {
       if (infoV > 0) edm::LogWarning("L1CSCTPEmulatorOutOfTimeALCT")
         << "+++ Bx of ALCT candidate, " << bx << ", exceeds max allowed, "
-        << MAX_ALCT_BINS-1 << "; skipping it... +++\n";
+        << CSCConstants::MAX_ALCT_BINS-1 << "; skipping it... +++\n";
       continue;
     }
 
@@ -1300,22 +1300,22 @@ void CSCAnodeLCTProcessor::lctSearch() {
 
   if (!isTMB07) {
     // Prior to DAQ-2006 format, only ALCTs at the earliest bx were reported.
-    int first_bx = MAX_ALCT_BINS;
-    for (int bx = 0; bx < MAX_ALCT_BINS; bx++) {
+    int first_bx = CSCConstants::MAX_ALCT_BINS;
+    for (int bx = 0; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
       if (bestALCT[bx].isValid()) {
         first_bx = bx;
         break;
       }
     }
-    if (first_bx < MAX_ALCT_BINS) {
-      for (int bx = first_bx + 1; bx < MAX_ALCT_BINS; bx++) {
+    if (first_bx < CSCConstants::MAX_ALCT_BINS) {
+      for (int bx = first_bx + 1; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
         if (bestALCT[bx].isValid())   bestALCT[bx].clear();
         if (secondALCT[bx].isValid()) secondALCT[bx].clear();
       }
     }
   }
 
-  for (int bx = 0; bx < MAX_ALCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
     if (bestALCT[bx].isValid()) {
       bestALCT[bx].setTrknmb(1);
       if (infoV > 0) {
@@ -1347,7 +1347,7 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::bestTrackSelector(
                                  const std::vector<CSCALCTDigi>& all_alcts) {
   /* Selects two collision and two accelerator ALCTs per time bin with
      the best quality. */
-  CSCALCTDigi bestALCTs[MAX_ALCT_BINS][2], secondALCTs[MAX_ALCT_BINS][2];
+  CSCALCTDigi bestALCTs[CSCConstants::MAX_ALCT_BINS][2], secondALCTs[CSCConstants::MAX_ALCT_BINS][2];
 
   if (infoV > 1) {
     LogTrace("CSCAnodeLCTProcessor") << all_alcts.size() <<
@@ -1359,7 +1359,7 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::bestTrackSelector(
     }
   }
 
-  CSCALCTDigi tA[MAX_ALCT_BINS][2], tB[MAX_ALCT_BINS][2];
+  CSCALCTDigi tA[CSCConstants::MAX_ALCT_BINS][2], tB[CSCConstants::MAX_ALCT_BINS][2];
   for (std::vector <CSCALCTDigi>::const_iterator plct = all_alcts.begin();
        plct != all_alcts.end(); plct++) {
     if (!plct->isValid()) continue;
@@ -1389,7 +1389,7 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::bestTrackSelector(
     }
   }
 
-  for (int bx = 0; bx < MAX_ALCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
     for (int accel = 0; accel <= 1; accel++) {
       // Best ALCT is always tA.
       if (tA[bx][accel].isValid()) {
@@ -1426,7 +1426,7 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::bestTrackSelector(
 
   // Fill the vector with up to four best ALCTs per bx and return it.
   std::vector<CSCALCTDigi> fourBest;
-  for (int bx = 0; bx < MAX_ALCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
     for (int i = 0; i < 2; i++) {
       if (bestALCTs[bx][i].isValid())   fourBest.push_back(bestALCTs[bx][i]);
     }
@@ -1648,12 +1648,12 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::readoutALCTs() {
         << "; in-time ALCTs are not getting read-out!!! +++" << "\n";
     }
 
-    if (late_tbins > MAX_ALCT_BINS-1) {
+    if (late_tbins > CSCConstants::MAX_ALCT_BINS-1) {
       if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorSuspiciousParameters")
         << "+++ Allowed range of time bins, [0-" << late_tbins
-        << "] exceeds max allowed, " << MAX_ALCT_BINS-1 << " +++\n"
+        << "] exceeds max allowed, " << CSCConstants::MAX_ALCT_BINS-1 << " +++\n"
         << "+++ Set late_tbins to max allowed +++\n";
-      late_tbins = MAX_ALCT_BINS-1;
+      late_tbins = CSCConstants::MAX_ALCT_BINS-1;
     }
     ifois = 1;
   }
@@ -1692,7 +1692,7 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::readoutALCTs() {
 // Returns vector of all found ALCTs, if any.  Used in ALCT-CLCT matching.
 std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::getALCTs() {
   std::vector<CSCALCTDigi> tmpV;
-  for (int bx = 0; bx < MAX_ALCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_ALCT_BINS; bx++) {
     if (bestALCT[bx].isValid())   tmpV.push_back(bestALCT[bx]);
     if (secondALCT[bx].isValid()) tmpV.push_back(secondALCT[bx]);
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -40,7 +40,7 @@
    patterns A and B.
    pattern_envelope[0][i]=layer;
    pattern_envelope[1+MEposition][i]=key_wire offset. */
-const int CSCAnodeLCTProcessor::pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS][NUM_PATTERN_WIRES] = {
+const int CSCAnodeLCTProcessor::pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES] = {
   //Layer
   { 0,  0,  0,
         1,  1,
@@ -67,7 +67,7 @@ const int CSCAnodeLCTProcessor::pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS
 };
 
 // time averaging weights for pattern (used for SLHC version)
-const int CSCAnodeLCTProcessor::time_weights[NUM_PATTERN_WIRES] =
+const int CSCAnodeLCTProcessor::time_weights[CSCConstants::NUM_PATTERN_WIRES] =
   //Layer
   { 0,  1,  1,
         1,  2,
@@ -81,7 +81,7 @@ const int CSCAnodeLCTProcessor::time_weights[NUM_PATTERN_WIRES] =
 // and collision patterns A and B.  These masks were meant to be the default
 // ones in early 200X, but were never implemented because of limited FPGA
 // resources.
-const int CSCAnodeLCTProcessor::pattern_mask_slim[CSCConstants::NUM_ALCT_PATTERNS][NUM_PATTERN_WIRES] = {
+const int CSCAnodeLCTProcessor::pattern_mask_slim[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES] = {
   // Accelerator pattern
   {0,  0,  1,
        0,  1,
@@ -109,7 +109,7 @@ const int CSCAnodeLCTProcessor::pattern_mask_slim[CSCConstants::NUM_ALCT_PATTERN
 
 // Since the test beams in 2003, both collision patterns are "completely
 // open".  This is our current default.
-const int CSCAnodeLCTProcessor::pattern_mask_open[CSCConstants::NUM_ALCT_PATTERNS][NUM_PATTERN_WIRES] = {
+const int CSCAnodeLCTProcessor::pattern_mask_open[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES] = {
   // Accelerator pattern
   {0,  0,  1,
        0,  1,
@@ -136,7 +136,7 @@ const int CSCAnodeLCTProcessor::pattern_mask_open[CSCConstants::NUM_ALCT_PATTERN
 };
 
 // Special option for narrow pattern for ring 1 stations
-const int CSCAnodeLCTProcessor::pattern_mask_r1[CSCConstants::NUM_ALCT_PATTERNS][NUM_PATTERN_WIRES] = {
+const int CSCAnodeLCTProcessor::pattern_mask_r1[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES] = {
   // Accelerator pattern
   {0,  0,  1,
        0,  1,
@@ -319,7 +319,7 @@ CSCAnodeLCTProcessor::CSCAnodeLCTProcessor() :
 void CSCAnodeLCTProcessor::loadPatternMask() {
   // Load appropriate pattern mask.
   for (int i_patt = 0; i_patt < CSCConstants::NUM_ALCT_PATTERNS; i_patt++) {
-    for (int i_wire = 0; i_wire < NUM_PATTERN_WIRES; i_wire++) {
+    for (int i_wire = 0; i_wire < CSCConstants::NUM_PATTERN_WIRES; i_wire++) {
       if (isMTCC || isTMB07) {
         pattern_mask[i_patt][i_wire] = pattern_mask_open[i_patt][i_wire];
         if (narrow_mask_r1 && (theRing == 1 || theRing == 4))
@@ -491,8 +491,6 @@ std::vector<CSCALCTDigi>
 CSCAnodeLCTProcessor::run(const CSCWireDigiCollection* wiredc) {
   // This is the main routine for normal running.  It gets wire times
   // from the wire digis and then passes them on to another run() function.
-
-  // clear(); // redundant; called by L1MuCSCMotherboard.
 
   static std::atomic<bool> config_dumped{false};
   if ((infoV > 0 || isSLHC) && !config_dumped) {
@@ -833,7 +831,7 @@ bool CSCAnodeLCTProcessor::preTrigger(const int key_wire, const int start_bx) {
         hit_layer[i_layer] = false;
       layers_hit = 0;
 
-      for (int i_wire = 0; i_wire < NUM_PATTERN_WIRES; i_wire++){
+      for (int i_wire = 0; i_wire < CSCConstants::NUM_PATTERN_WIRES; i_wire++){
         if (pattern_mask[i_pattern][i_wire] != 0){
           this_layer = pattern_envelope[0][i_wire];
           this_wire  = pattern_envelope[1+MESelection][i_wire]+key_wire;
@@ -896,7 +894,7 @@ bool CSCAnodeLCTProcessor::patternDetection(const int key_wire) {
     std::multiset<int> mset_for_median;
     mset_for_median.clear();
 
-    for (int i_wire = 0; i_wire < NUM_PATTERN_WIRES; i_wire++){
+    for (int i_wire = 0; i_wire < CSCConstants::NUM_PATTERN_WIRES; i_wire++){
       if (pattern_mask[i_pattern][i_wire] != 0){
         this_layer = pattern_envelope[0][i_wire];
         delta_wire = pattern_envelope[1+MESelection][i_wire];
@@ -1713,7 +1711,7 @@ void CSCAnodeLCTProcessor::showPatterns(const int key_wire) {
       strstrm_header << ((32-i)%10);
     }
     LogTrace("CSCAnodeLCTProcessor") << strstrm_header.str();
-    for (int i_wire = 0; i_wire < NUM_PATTERN_WIRES; i_wire++) {
+    for (int i_wire = 0; i_wire < CSCConstants::NUM_PATTERN_WIRES; i_wire++) {
       if (pattern_mask[i_pattern][i_wire] != 0) {
         std::ostringstream strstrm_pulse;
         int this_layer = pattern_envelope[0][i_wire];

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.h
@@ -68,10 +68,10 @@ class CSCAnodeLCTProcessor
       had been reported.
       In the ALCT-2006 algorithms, up to two best ALCTs PER EVERY TIME BIN in
       Level-1 accept window are reported. */
-  CSCALCTDigi bestALCT[CSCConstants::MAX_ALCT_BINS];
+  CSCALCTDigi bestALCT[CSCConstants::MAX_ALCT_TBINS];
 
   /** Second best LCTs in this chamber, as found by the processor. */
-  CSCALCTDigi secondALCT[CSCConstants::MAX_ALCT_BINS];
+  CSCALCTDigi secondALCT[CSCConstants::MAX_ALCT_TBINS];
 
   /** Returns vector of ALCTs in the read-out time window, if any. */
   std::vector<CSCALCTDigi> readoutALCTs();
@@ -83,11 +83,11 @@ class CSCAnodeLCTProcessor
   void setRing(unsigned r) {theRing = r;}
 
   /** Pre-defined patterns. */
-  static const int pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES];
-  static const int pattern_mask_slim[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES];
-  static const int pattern_mask_open[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES];
-  static const int pattern_mask_r1[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES];
-  static const int time_weights[CSCConstants::NUM_PATTERN_WIRES];
+  static const int pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
+  static const int pattern_mask_slim[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
+  static const int pattern_mask_open[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
+  static const int pattern_mask_r1[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
+  static const int time_weights[CSCConstants::MAX_WIRES_IN_PATTERN];
 
  private:
   /** Verbosity level: 0: no print (default).
@@ -177,7 +177,7 @@ class CSCAnodeLCTProcessor
   static const unsigned int def_l1a_window_width;
 
   /** Chosen pattern mask. */
-  int pattern_mask[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES];
+  int pattern_mask[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
 
   /** Load pattern mask defined by configuration into pattern_mask */
   void loadPatternMask();

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.h
@@ -15,7 +15,7 @@
  *
  * Updates for high pileup running by Vadim Khotilovich (TAMU), December 2012
  *
- * Updates for integrated local trigger with GEMs and RPCs by 
+ * Updates for integrated local trigger with GEMs and RPCs by
  * Sven Dildick (TAMU) and Tao Huang (TAMU), April 2015
  *
  * Removing usage of outdated class CSCTriggerGeometry by Sven Dildick (TAMU)
@@ -63,18 +63,15 @@ class CSCAnodeLCTProcessor
   bool getDigis(const CSCWireDigiCollection* wiredc);
   void getDigis(const CSCWireDigiCollection* wiredc, const CSCDetId& id);
 
-  /** Maximum number of time bins reported in the ALCT readout. */
-  enum {MAX_ALCT_BINS = 16};
-
   /** Best LCTs in this chamber, as found by the processor.
       In old ALCT algorithms, up to two best ALCT per Level-1 accept window
       had been reported.
       In the ALCT-2006 algorithms, up to two best ALCTs PER EVERY TIME BIN in
       Level-1 accept window are reported. */
-  CSCALCTDigi bestALCT[MAX_ALCT_BINS];
+  CSCALCTDigi bestALCT[CSCConstants::MAX_ALCT_BINS];
 
   /** Second best LCTs in this chamber, as found by the processor. */
-  CSCALCTDigi secondALCT[MAX_ALCT_BINS];
+  CSCALCTDigi secondALCT[CSCConstants::MAX_ALCT_BINS];
 
   /** Returns vector of ALCTs in the read-out time window, if any. */
   std::vector<CSCALCTDigi> readoutALCTs();
@@ -152,7 +149,7 @@ class CSCAnodeLCTProcessor
   /** SLHC: delta BX time depth for ghostCancellationLogic */
   int ghost_cancellation_bx_depth;
 
-  /** SLHC: whether to consider ALCT candidates' qualities 
+  /** SLHC: whether to consider ALCT candidates' qualities
       while doing ghostCancellationLogic on +-1 wire groups */
   bool ghost_cancellation_side_quality;
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.h
@@ -83,12 +83,11 @@ class CSCAnodeLCTProcessor
   void setRing(unsigned r) {theRing = r;}
 
   /** Pre-defined patterns. */
-  enum {NUM_PATTERN_WIRES = 14};
-  static const int pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS][NUM_PATTERN_WIRES];
-  static const int pattern_mask_slim[CSCConstants::NUM_ALCT_PATTERNS][NUM_PATTERN_WIRES];
-  static const int pattern_mask_open[CSCConstants::NUM_ALCT_PATTERNS][NUM_PATTERN_WIRES];
-  static const int pattern_mask_r1[CSCConstants::NUM_ALCT_PATTERNS][NUM_PATTERN_WIRES];
-  static const int time_weights[NUM_PATTERN_WIRES];
+  static const int pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES];
+  static const int pattern_mask_slim[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES];
+  static const int pattern_mask_open[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES];
+  static const int pattern_mask_r1[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES];
+  static const int time_weights[CSCConstants::NUM_PATTERN_WIRES];
 
  private:
   /** Verbosity level: 0: no print (default).
@@ -178,7 +177,7 @@ class CSCAnodeLCTProcessor
   static const unsigned int def_l1a_window_width;
 
   /** Chosen pattern mask. */
-  int pattern_mask[CSCConstants::NUM_ALCT_PATTERNS][NUM_PATTERN_WIRES];
+  int pattern_mask[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::NUM_PATTERN_WIRES];
 
   /** Load pattern mask defined by configuration into pattern_mask */
   void loadPatternMask();

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -41,7 +41,7 @@
 
 // This is the strip pattern that we use for pretrigger.
 // pre_hit_pattern[0][i] = layer. pre_hit_pattern[1][i] = key_strip offset.
-const int CSCCathodeLCTProcessor::pre_hit_pattern[2][NUM_PATTERN_STRIPS] = {
+const int CSCCathodeLCTProcessor::pre_hit_pattern[2][CSCConstants::NUM_PATTERN_STRIPS] = {
   { 999,  0,  0,  0,  999,
     999,  1,  1,  1,  999,
     999,  2,  2,  2,  999,
@@ -59,13 +59,13 @@ const int CSCCathodeLCTProcessor::pre_hit_pattern[2][NUM_PATTERN_STRIPS] = {
 
 // The old set of half-strip/di-strip patterns used prior to 2007.
 // For the given pattern, set the unused parts of the pattern to 999.
-// Pattern[i][NUM_PATTERN_STRIPS] contains pt bend value. JM
+// Pattern[i][CSCConstants::NUM_PATTERN_STRIPS] contains pt bend value. JM
 // bend of 0 is left/straight and bend of 1 is right bht 21 June 2001
 // note that the left/right-ness of this is exactly opposite of what one would
 // expect naively (at least it was for me). The only way to make sure you've
 // got the patterns you want is to use the printPatterns() method to dump
 // them. BHT 21 June 2001
-const int CSCCathodeLCTProcessor::pattern[CSCConstants::NUM_CLCT_PATTERNS_PRE_TMB07][NUM_PATTERN_STRIPS+1] = {
+const int CSCCathodeLCTProcessor::pattern[CSCConstants::NUM_CLCT_PATTERNS_PRE_TMB07][CSCConstants::NUM_PATTERN_STRIPS+1] = {
   { 999, 999, 999, 999, 999,
     999, 999, 999, 999, 999,
     999, 999, 999, 999, 999,
@@ -125,10 +125,10 @@ const int CSCCathodeLCTProcessor::pattern[CSCConstants::NUM_CLCT_PATTERNS_PRE_TM
 
 // New set of halfstrip patterns for 2007 version of the algorithm.
 // For the given pattern, set the unused parts of the pattern to 999.
-// Pattern[i][NUM_PATTERN_HALFSTRIPS] contains bend direction.
+// Pattern[i][CSCConstants::NUM_PATTERN_HALFSTRIPS] contains bend direction.
 // Bend of 0 is right/straight and bend of 1 is left.
-// Pattern[i][NUM_PATTERN_HALFSTRIPS+1] contains pattern maximum width
-const int CSCCathodeLCTProcessor::pattern2007_offset[NUM_PATTERN_HALFSTRIPS] =
+// Pattern[i][CSCConstants::NUM_PATTERN_HALFSTRIPS+1] contains pattern maximum width
+const int CSCCathodeLCTProcessor::pattern2007_offset[CSCConstants::NUM_PATTERN_HALFSTRIPS] =
   {  -5,  -4,  -3,  -2,  -1,   0,   1,   2,   3,   4,   5,
                     -2,  -1,   0,   1,   2,
                                0,
@@ -136,7 +136,7 @@ const int CSCCathodeLCTProcessor::pattern2007_offset[NUM_PATTERN_HALFSTRIPS] =
           -4,  -3,  -2,  -1,   0,   1,   2,   3,   4,
      -5,  -4,  -3,  -2,  -1,   0,   1,   2,   3,   4,   5 };
 
-const int CSCCathodeLCTProcessor::pattern2007[CSCConstants::NUM_CLCT_PATTERNS][NUM_PATTERN_HALFSTRIPS+2] = {
+const int CSCCathodeLCTProcessor::pattern2007[CSCConstants::NUM_CLCT_PATTERNS][CSCConstants::NUM_PATTERN_HALFSTRIPS+2] = {
   { 999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999,
                    999, 999, 999, 999, 999,
                              999,             // pid=0: no pattern found
@@ -228,7 +228,10 @@ const unsigned int CSCCathodeLCTProcessor::def_min_separation      = 10;
 const unsigned int CSCCathodeLCTProcessor::def_tmb_l1a_window_size =  7;
 
 // Number of di-strips/half-strips per CFEB.
-const int CSCCathodeLCTProcessor::cfeb_strips[2] = { 8, 32};
+const int CSCCathodeLCTProcessor::cfeb_strips[2] = {
+  CSCConstants::NUM_DISTRIPS_PER_CFEB, //8
+  CSCConstants::NUM_HALF_STRIPS_PER_CFEB//32
+};
 
 //----------------
 // Constructors --
@@ -1165,14 +1168,13 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
   int j;
   int best_strip = 0;
   int first_bx = 999;
-  const int max_lct_num = 2;
   const int adjacent_strips = 2;
   // Distrip, halfstrip pattern threshold.
   const unsigned int ptrn_thrsh[2] = {nplanes_hit_pattern, nplanes_hit_pattern};
   int highest_quality = 0;
 
   int keystrip_data[CSCConstants::NUM_HALF_STRIPS_7CFEBS][7];
-  int final_lcts[max_lct_num];
+  int final_lcts[CSCConstants::MAX_CLCTS_PER_PROCESSOR];
 
   std::vector <CSCCLCTDigi> lctList;
 
@@ -1189,7 +1191,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
     getKeyStripData(strip, keystrip_data, nStrips, first_bx, best_strip, stripType);
 
     /* Set all final_lcts to impossible key_strip numbers */
-    for (j = 0; j < max_lct_num; j++)
+    for (j = 0; j < CSCConstants::MAX_CLCTS_PER_PROCESSOR; j++)
       final_lcts[j] = -999;
 
     // Now take the keystrip with the best quality, and do a search over the
@@ -1209,7 +1211,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
       }
     }
 
-    for (j = 0; j < max_lct_num; j++){
+    for (j = 0; j < CSCConstants::MAX_CLCTS_PER_PROCESSOR; j++){
       // Only report LCTs if the number of layers hit is greater than or
       // equal to the (variable) valid pattern threshold ptrn_thrsh.
       int keystrip = final_lcts[j];
@@ -1221,9 +1223,9 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
 	int theHalfStrip = (keystrip_data[keystrip][CLCT_STRIP_TYPE] ?
 			    keystrip_data[keystrip][CLCT_STRIP] :
 			    4*keystrip_data[keystrip][CLCT_STRIP]);
-	keystrip_data[keystrip][CLCT_CFEB] = theHalfStrip/32;
+	keystrip_data[keystrip][CLCT_CFEB] = theHalfStrip/CSCConstants::NUM_HALF_STRIPS_PER_CFEB;
 	int halfstrip_in_cfeb =
-	  theHalfStrip - 32*keystrip_data[keystrip][CLCT_CFEB];
+	  theHalfStrip - CSCConstants::NUM_HALF_STRIPS_PER_CFEB*keystrip_data[keystrip][CLCT_CFEB];
 
 	CSCCLCTDigi thisLCT(1, keystrip_data[keystrip][CLCT_QUALITY],
 			    keystrip_data[keystrip][CLCT_PATTERN],
@@ -1292,7 +1294,7 @@ bool CSCCathodeLCTProcessor::preTrigger(const std::vector<int> strip[CSCConstant
       for (i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++)
 	hit_layer[i_layer] = false;
       // Loop over pattern strips and look for hits.
-      for (i_strip = 0; i_strip < NUM_PATTERN_STRIPS; i_strip++){
+      for (i_strip = 0; i_strip < CSCConstants::NUM_PATTERN_STRIPS; i_strip++){
 	this_layer = pre_hit_pattern[0][i_strip];
 	this_strip = pre_hit_pattern[1][i_strip]+key_strip;
 	if (this_strip >= 0 && this_strip < nStrips) {
@@ -1325,7 +1327,7 @@ bool CSCCathodeLCTProcessor::preTrigger(const std::vector<int> strip[CSCConstant
 void CSCCathodeLCTProcessor::getKeyStripData(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
         int keystrip_data[CSCConstants::NUM_HALF_STRIPS_7CFEBS][7],
         int nStrips, int first_bx, int& best_strip, int stripType) {
-  int lct_pattern[NUM_PATTERN_STRIPS];
+  int lct_pattern[CSCConstants::NUM_PATTERN_STRIPS];
   int key_strip, this_layer, this_strip;
   int quality, best_quality;
   int bend = 0;
@@ -1341,7 +1343,7 @@ void CSCCathodeLCTProcessor::getKeyStripData(const std::vector<int> strip[CSCCon
 
   for (key_strip = 0; key_strip < (nStrips-stripType); key_strip++){
     nullPattern = true;
-    for (int pattern_strip = 0; pattern_strip < NUM_PATTERN_STRIPS; pattern_strip++){
+    for (int pattern_strip = 0; pattern_strip < CSCConstants::NUM_PATTERN_STRIPS; pattern_strip++){
       this_layer = pre_hit_pattern[0][pattern_strip];
       this_strip = pre_hit_pattern[1][pattern_strip] + key_strip;
       // This conditional statement prevents us from looking at strips
@@ -1400,7 +1402,7 @@ void CSCCathodeLCTProcessor::getKeyStripData(const std::vector<int> strip[CSCCon
 
 // Idealized version for MC studies.
 void CSCCathodeLCTProcessor::getPattern(int pattern_num,
-       int strip_value[NUM_PATTERN_STRIPS], int bx_time,
+       int strip_value[CSCConstants::NUM_PATTERN_STRIPS], int bx_time,
        int& quality, int& bend){
   // This function takes strip values and bx_time to find out which hits fall
   // within a certain pattern.  Quality, and bend are then calculated based on
@@ -1413,7 +1415,7 @@ void CSCCathodeLCTProcessor::getPattern(int pattern_num,
     hit_layer[i_layer] = false;
 
   // Loop over all designated patterns.
-  for (int strip_num = 0; strip_num < NUM_PATTERN_STRIPS; strip_num++){
+  for (int strip_num = 0; strip_num < CSCConstants::NUM_PATTERN_STRIPS; strip_num++){
     if (hitIsGood(strip_value[strip_num], bx_time)){
       for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++){
 	// Loop over layer and see if corresponding strip is on same layer
@@ -1429,7 +1431,7 @@ void CSCCathodeLCTProcessor::getPattern(int pattern_num,
     }
   }
   // Get bend value from pattern.
-  bend = pattern[pattern_num][NUM_PATTERN_STRIPS];
+  bend = pattern[pattern_num][CSCConstants::NUM_PATTERN_STRIPS];
   quality = layers_hit;
 } // getPattern -- idealized version for MC studies.
 
@@ -1471,10 +1473,10 @@ std::vector <CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
   }
 
   // Test beam version of TMB pretrigger and LCT sorting
-  int h_keyStrip[MAX_CFEBS];       // one key per CFEB
-  unsigned int h_nhits[MAX_CFEBS]; // number of hits in envelope for each key
-  int d_keyStrip[MAX_CFEBS];       // one key per CFEB
-  unsigned int d_nhits[MAX_CFEBS]; // number of hits in envelope for each key
+  int h_keyStrip[CSCConstants::MAX_CFEBS];       // one key per CFEB
+  unsigned int h_nhits[CSCConstants::MAX_CFEBS]; // number of hits in envelope for each key
+  int d_keyStrip[CSCConstants::MAX_CFEBS];       // one key per CFEB
+  unsigned int d_nhits[CSCConstants::MAX_CFEBS]; // number of hits in envelope for each key
   int keystrip_data[2][7];    // 2 possible LCTs per CSC x 7 LCT quantities
   unsigned int h_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]; // simulate digital one-shot
   unsigned int d_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]; // simulate digital one-shot
@@ -1532,14 +1534,14 @@ std::vector <CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
       LogTrace("CSCCathodeLCTProcessor")
 	<< "...............................\n"
 	<< "Final halfstrip hits and keys (after drift delay) ...";
-      for (int icfeb = 0; icfeb < MAX_CFEBS; icfeb++) {
+      for (int icfeb = 0; icfeb < CSCConstants::MAX_CFEBS; icfeb++) {
 	LogTrace("CSCCathodeLCTProcessor")
 	  << "cfeb " << icfeb << " key: " << h_keyStrip[icfeb]
 	  << " hits " << h_nhits[icfeb];
       }
       LogTrace("CSCCathodeLCTProcessor")
 	<< "Final distrip hits and keys (after drift delay) ...";
-      for (int icfeb = 0; icfeb < MAX_CFEBS; icfeb++) {
+      for (int icfeb = 0; icfeb < CSCConstants::MAX_CFEBS; icfeb++) {
 	LogTrace("CSCCathodeLCTProcessor")
 	  << "cfeb " << icfeb << " key: " << d_keyStrip[icfeb]
 	  << " hits " << d_nhits[icfeb];
@@ -1556,10 +1558,10 @@ std::vector <CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
 	int halfstrip_in_cfeb = 0;
 	if (keystrip_data[ilct][CLCT_STRIP_TYPE] == 0)
 	  halfstrip_in_cfeb = 4*keystrip_data[ilct][CLCT_STRIP] -
-                             32*keystrip_data[ilct][CLCT_CFEB];
+                             CSCConstants::NUM_HALF_STRIPS_PER_CFEB*keystrip_data[ilct][CLCT_CFEB];
 	else
 	  halfstrip_in_cfeb = keystrip_data[ilct][CLCT_STRIP] -
-	                     32*keystrip_data[ilct][CLCT_CFEB];
+	                     CSCConstants::NUM_HALF_STRIPS_PER_CFEB*keystrip_data[ilct][CLCT_CFEB];
 
 	CSCCLCTDigi thisLCT(1, keystrip_data[ilct][CLCT_QUALITY],
 			    keystrip_data[ilct][CLCT_PATTERN],
@@ -1635,7 +1637,7 @@ bool CSCCathodeLCTProcessor::preTrigLookUp(
     return false;
   }
 
-  for (int icfeb = 0; icfeb < MAX_CFEBS; icfeb++) { // loop over cfebs
+  for (int icfeb = 0; icfeb < CSCConstants::MAX_CFEBS; icfeb++) { // loop over cfebs
     // Loop over (di-/half-)strips in CFEB.
     for (int istrip = 0; istrip < cfeb_strips[stripType]; istrip++) {
       // Calculate candidate key.
@@ -1645,7 +1647,7 @@ bool CSCCathodeLCTProcessor::preTrigLookUp(
 	hit_layer[ilayer] = false;
 
       // Loop over strips in pretrigger pattern mask and look for hits.
-      for (int pstrip = 0; pstrip < NUM_PATTERN_STRIPS; pstrip++) {
+      for (int pstrip = 0; pstrip < CSCConstants::NUM_PATTERN_STRIPS; pstrip++) {
 	this_layer = pre_hit_pattern[0][pstrip];
 	this_strip = pre_hit_pattern[1][pstrip]+key_strip;
 
@@ -1676,14 +1678,14 @@ bool CSCCathodeLCTProcessor::preTrigLookUp(
 // Pre-2007 version.
 void CSCCathodeLCTProcessor::latchLCTs(
 	   const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-	   int keyStrip[MAX_CFEBS], unsigned int n_hits[MAX_CFEBS],
+	   int keyStrip[CSCConstants::MAX_CFEBS], unsigned int n_hits[CSCConstants::MAX_CFEBS],
 	   const int stripType, const int nStrips, const int bx_time) {
 
   bool hit_layer[CSCConstants::NUM_LAYERS];
   int key_strip, this_layer, this_strip;
   int layers_hit, prev_hits;
 
-  for (int icfeb = 0; icfeb < MAX_CFEBS; icfeb++) {
+  for (int icfeb = 0; icfeb < CSCConstants::MAX_CFEBS; icfeb++) {
     keyStrip[icfeb] = -1;
     n_hits[icfeb]   =  0;
   }
@@ -1695,7 +1697,7 @@ void CSCCathodeLCTProcessor::latchLCTs(
     return;
   }
 
-  for (int icfeb = 0; icfeb < MAX_CFEBS; icfeb++) { // loop over CFEBs
+  for (int icfeb = 0; icfeb < CSCConstants::MAX_CFEBS; icfeb++) { // loop over CFEBs
     prev_hits = 0;
     // Loop over (di-/half-)strips in CFEB.
     for (int istrip = 0; istrip < cfeb_strips[stripType]; istrip++) {
@@ -1706,7 +1708,7 @@ void CSCCathodeLCTProcessor::latchLCTs(
 	hit_layer[ilayer] = false;
 
       // Loop over strips in pretrigger pattern mask and look for hits.
-      for (int pstrip = 0; pstrip < NUM_PATTERN_STRIPS; pstrip++) {
+      for (int pstrip = 0; pstrip < CSCConstants::NUM_PATTERN_STRIPS; pstrip++) {
 	this_layer = pre_hit_pattern[0][pstrip];
 	this_strip = pre_hit_pattern[1][pstrip]+key_strip;
 
@@ -1740,8 +1742,8 @@ void CSCCathodeLCTProcessor::latchLCTs(
 
 // Pre-2007 version.
 void CSCCathodeLCTProcessor::priorityEncode(
-        const int h_keyStrip[MAX_CFEBS], const unsigned int h_nhits[MAX_CFEBS],
-	const int d_keyStrip[MAX_CFEBS], const unsigned int d_nhits[MAX_CFEBS],
+        const int h_keyStrip[CSCConstants::MAX_CFEBS], const unsigned int h_nhits[CSCConstants::MAX_CFEBS],
+	const int d_keyStrip[CSCConstants::MAX_CFEBS], const unsigned int d_nhits[CSCConstants::MAX_CFEBS],
 	int keystrip_data[2][7]) {
   static const unsigned int hs_thresh = nplanes_hit_pretrig;
   //static const unsigned int ds_thresh = nplanes_hit_pretrig;
@@ -1749,7 +1751,7 @@ void CSCCathodeLCTProcessor::priorityEncode(
   int ihits[2]; // hold hits for sorting
   int cfebs[2]; // holds CFEB numbers corresponding to highest hits
   const int nlcts = 2;
-  int key_strip[MAX_CFEBS], key_phits[MAX_CFEBS], strip_type[MAX_CFEBS];
+  int key_strip[CSCConstants::MAX_CFEBS], key_phits[CSCConstants::MAX_CFEBS], strip_type[CSCConstants::MAX_CFEBS];
 
   // initialize arrays
   for (int ilct = 0; ilct < nlcts; ilct++) {
@@ -1757,7 +1759,7 @@ void CSCCathodeLCTProcessor::priorityEncode(
     ihits[ilct] = 0;
     cfebs[ilct] = -1;
   }
-  for (int icfeb = 0; icfeb < MAX_CFEBS; icfeb++) {
+  for (int icfeb = 0; icfeb < CSCConstants::MAX_CFEBS; icfeb++) {
     key_strip[icfeb]  = -1;
     key_phits[icfeb]  = -1;
     strip_type[icfeb] = -1;
@@ -1768,11 +1770,11 @@ void CSCCathodeLCTProcessor::priorityEncode(
       << ".....................PriorityEncode.......................";
     std::ostringstream strstrm;
     strstrm << "hkeys:";
-    for (int icfeb = 0; icfeb < MAX_CFEBS; icfeb++) {
+    for (int icfeb = 0; icfeb < CSCConstants::MAX_CFEBS; icfeb++) {
       strstrm << std::setw(4) << h_keyStrip[icfeb];
     }
     strstrm << "\ndkeys:";
-    for (int icfeb = 0; icfeb < MAX_CFEBS; icfeb++) {
+    for (int icfeb = 0; icfeb < CSCConstants::MAX_CFEBS; icfeb++) {
       strstrm << std::setw(4) << d_keyStrip[icfeb];
     }
     LogTrace("CSCCathodeLCTProcessor") << strstrm.str();
@@ -1780,7 +1782,7 @@ void CSCCathodeLCTProcessor::priorityEncode(
 
   // Loop over CFEBs and determine better of half- or di- strip pattern.
   // If select halfstrip, promote it by adding an extra bit to its hits.
-  for (int icfeb = 0; icfeb < MAX_CFEBS; icfeb++) {
+  for (int icfeb = 0; icfeb < CSCConstants::MAX_CFEBS; icfeb++) {
     if (h_keyStrip[icfeb] != -1 && d_keyStrip[icfeb] != -1) {
       if (h_nhits[icfeb] >= hs_thresh) {
 	key_strip[icfeb] = h_keyStrip[icfeb];
@@ -1826,16 +1828,16 @@ void CSCCathodeLCTProcessor::priorityEncode(
   // Remove duplicate LCTs at boundaries -- it is possilbe to have key[0]
   // be the higher of the two key strips, take this into account, but
   // preserve rank of lcts.
-  int key[MAX_CFEBS];
+  int key[CSCConstants::MAX_CFEBS];
   int loedge, hiedge;
 
   if (infoV > 1) LogTrace("CSCCathodeLCTProcessor")
     << "...... Remove Duplicates ......";
-  for (int icfeb = 0; icfeb < MAX_CFEBS; icfeb++) {
+  for (int icfeb = 0; icfeb < CSCConstants::MAX_CFEBS; icfeb++) {
     if(strip_type[icfeb] == 0) key[icfeb] = key_strip[icfeb]*4;
     else                       key[icfeb] = key_strip[icfeb];
   }
-  for (int icfeb = 0; icfeb < MAX_CFEBS-1; icfeb++) {
+  for (int icfeb = 0; icfeb < CSCConstants::MAX_CFEBS-1; icfeb++) {
     if (key[icfeb] >= 0 && key[icfeb+1] >= 0) {
       loedge = cfeb_strips[1]*(icfeb*8+7)/8;
       hiedge = cfeb_strips[1]*(icfeb*8+9)/8 - 1;
@@ -1865,7 +1867,7 @@ void CSCCathodeLCTProcessor::priorityEncode(
   // In case of equal quality, select the one on lower-numbered CFEBs.
   if (infoV > 1) LogTrace("CSCCathodeLCTProcessor")
     << "\n...... Select best LCTs  ......";
-  for (int icfeb = 0; icfeb < MAX_CFEBS; icfeb++) {
+  for (int icfeb = 0; icfeb < CSCConstants::MAX_CFEBS; icfeb++) {
     if (key_phits[icfeb] > ihits[0]) {
       ihits[1] = ihits[0];
       cfebs[1] = cfebs[0];
@@ -1873,7 +1875,7 @@ void CSCCathodeLCTProcessor::priorityEncode(
       cfebs[0] = icfeb;
       if (infoV > 1) {
 	std::ostringstream strstrm;
-	for (int icfeb = 0; icfeb < MAX_CFEBS; icfeb++) {
+	for (int icfeb = 0; icfeb < CSCConstants::MAX_CFEBS; icfeb++) {
 	  strstrm << std::setw(4) << strip_type[icfeb];
 	}
 	LogTrace("CSCCathodeLCTProcessor")
@@ -1915,7 +1917,7 @@ void CSCCathodeLCTProcessor::getKeyStripData(
 		const unsigned int d_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 		int keystrip_data[2][7], const int first_bx) {
 
-  int lct_pattern[NUM_PATTERN_STRIPS];
+  int lct_pattern[CSCConstants::NUM_PATTERN_STRIPS];
   int this_layer, this_strip;
   unsigned int quality = 0, bend = 0;
   unsigned int best_quality, best_pattern;
@@ -1940,7 +1942,7 @@ void CSCCathodeLCTProcessor::getKeyStripData(
 	<< "no lct at ilct " << ilct;
       continue;
     }
-    for (int pattern_strip = 0; pattern_strip < NUM_PATTERN_STRIPS;
+    for (int pattern_strip = 0; pattern_strip < CSCConstants::NUM_PATTERN_STRIPS;
 	 pattern_strip++) {
       lct_pattern[pattern_strip] = -999;
       this_layer = pre_hit_pattern[0][pattern_strip];
@@ -2019,7 +2021,7 @@ void CSCCathodeLCTProcessor::getKeyStripData(
 
 // Pre-2007 version.
 void CSCCathodeLCTProcessor::getPattern(unsigned int pattern_num,
-			 const int strip_value[NUM_PATTERN_STRIPS],
+			 const int strip_value[CSCConstants::NUM_PATTERN_STRIPS],
 			 unsigned int& quality, unsigned int& bend) {
 
   // This function takes strip "one-shots" at the correct bx to find out
@@ -2035,7 +2037,7 @@ void CSCCathodeLCTProcessor::getPattern(unsigned int pattern_num,
     hit_layer[i_layer] = false;
 
   // Loop over all designated patterns.
-  for (int strip_num = 0; strip_num < NUM_PATTERN_STRIPS; strip_num++){
+  for (int strip_num = 0; strip_num < CSCConstants::NUM_PATTERN_STRIPS; strip_num++){
     if (strip_value[strip_num] == 1){
       for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++){
 	// Loop over layer and see if corresponding strip is on same layer
@@ -2051,7 +2053,7 @@ void CSCCathodeLCTProcessor::getPattern(unsigned int pattern_num,
     }
   }
   // Get bend value from pattern.
-  bend = pattern[pattern_num][NUM_PATTERN_STRIPS];
+  bend = pattern[pattern_num][CSCConstants::NUM_PATTERN_STRIPS];
   quality = layers_hit;
 
 } // getPattern -- pre-2007 version.
@@ -2072,10 +2074,8 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
 
   if (infoV > 1) dumpDigis(halfstrip, 1, maxHalfStrips);
 
-  // Test beam version of TMB pretrigger and LCT sorting
-  enum {max_lcts = 2};
   // 2 possible LCTs per CSC x 7 LCT quantities
-  int keystrip_data[max_lcts][7] = {{0}};
+  int keystrip_data[CSCConstants::MAX_CLCTS_PER_PROCESSOR][7] = {{0}};
   unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS];
 
   // Fire half-strip one-shots for hit_persist bx's (4 bx's by default).
@@ -2123,8 +2123,8 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
 
       // Quality for sorting.
       int quality[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
-      int best_halfstrip[max_lcts], best_quality[max_lcts];
-      for (int ilct = 0; ilct < max_lcts; ilct++) {
+      int best_halfstrip[CSCConstants::MAX_CLCTS_PER_PROCESSOR], best_quality[CSCConstants::MAX_CLCTS_PER_PROCESSOR];
+      for (int ilct = 0; ilct < CSCConstants::MAX_CLCTS_PER_PROCESSOR; ilct++) {
 	best_halfstrip[ilct] = -1;
 	best_quality[ilct]   =  0;
       }
@@ -2174,13 +2174,13 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
 
 	// Pattern finder.
 	bool ptn_trig = false;
-	for (int ilct = 0; ilct < max_lcts; ilct++) {
+	for (int ilct = 0; ilct < CSCConstants::MAX_CLCTS_PER_PROCESSOR; ilct++) {
 	  int best_hs = best_halfstrip[ilct];
 	  if (best_hs >= 0 && nhits[best_hs] >= nplanes_hit_pattern) {
 	    ptn_trig = true;
 	    keystrip_data[ilct][CLCT_PATTERN]    = best_pid[best_hs];
 	    keystrip_data[ilct][CLCT_BEND]       =
-	      pattern2007[best_pid[best_hs]][NUM_PATTERN_HALFSTRIPS];
+	      pattern2007[best_pid[best_hs]][CSCConstants::NUM_PATTERN_HALFSTRIPS];
 	    // Remove stagger if any.
 	    keystrip_data[ilct][CLCT_STRIP]      =
 	      best_hs - stagger[CSCConstants::KEY_CLCT_LAYER-1];
@@ -2403,7 +2403,7 @@ bool CSCCathodeLCTProcessor::ptnFinding(
 
       // Loop over halfstrips in trigger pattern mask and calculate the
       // "absolute" halfstrip number for each.
-      for (int strip_num = 0; strip_num < NUM_PATTERN_HALFSTRIPS; strip_num++)
+      for (int strip_num = 0; strip_num < CSCConstants::NUM_PATTERN_HALFSTRIPS; strip_num++)
       {
 	int this_layer = pattern2007[pid][strip_num];
         if (this_layer >= 0 && this_layer < CSCConstants::NUM_LAYERS)
@@ -2486,7 +2486,7 @@ void CSCCathodeLCTProcessor::markBusyKeys(const int best_hstrip,
 
   // if dynamic spacing is enabled, separation is defined by pattern width
   //if (dynamic_spacing)
-  //  nspan = pspan = pattern2007[best_patid][NUM_PATTERN_HALFSTRIPS+1]-1;
+  //  nspan = pspan = pattern2007[best_patid][CSCConstants::NUM_PATTERN_HALFSTRIPS+1]-1;
 
   for (int hstrip = best_hstrip-nspan; hstrip <= best_hstrip+pspan; hstrip++) {
     if (hstrip >= 0 && hstrip < CSCConstants::NUM_HALF_STRIPS_7CFEBS) {
@@ -2510,8 +2510,6 @@ CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstan
   const int maxHalfStrips = 2 * numStrips + 1;
 
   if (infoV > 1) dumpDigis(halfstrip, 1, maxHalfStrips);
-
-  enum { max_lcts = 2 };
 
   // keeps dead-time zones around key halfstrips of triggered CLCTs
   bool busyMap[CSCConstants::NUM_HALF_STRIPS_7CFEBS][CSCConstants::MAX_CLCT_BINS];
@@ -2570,12 +2568,12 @@ CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstan
       start_bx = first_bx + 1;
 
       // 2 possible LCTs per CSC x 7 LCT quantities per BX
-      int keystrip_data[max_lcts][7] = {{0}};
+      int keystrip_data[CSCConstants::MAX_CLCTS_PER_PROCESSOR][7] = {{0}};
 
       // Quality for sorting.
       int quality[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
-      int best_halfstrip[max_lcts], best_quality[max_lcts];
-      for (int ilct = 0; ilct < max_lcts; ilct++)
+      int best_halfstrip[CSCConstants::MAX_CLCTS_PER_PROCESSOR], best_quality[CSCConstants::MAX_CLCTS_PER_PROCESSOR];
+      for (int ilct = 0; ilct < CSCConstants::MAX_CLCTS_PER_PROCESSOR; ilct++)
       {
         best_halfstrip[ilct] = -1;
         best_quality[ilct] = 0;
@@ -2656,7 +2654,7 @@ CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstan
 
         // Pattern finder.
         bool ptn_trig = false;
-        for (int ilct = 0; ilct < max_lcts; ilct++)
+        for (int ilct = 0; ilct < CSCConstants::MAX_CLCTS_PER_PROCESSOR; ilct++)
         {
           int best_hs = best_halfstrip[ilct];
           if (best_hs >= 0 && nhits[best_hs] >= nplanes_hit_pattern)
@@ -2669,7 +2667,7 @@ CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstan
             }
             ptn_trig = true;
             keystrip_data[ilct][CLCT_PATTERN] = best_pid[best_hs];
-            keystrip_data[ilct][CLCT_BEND] = pattern2007[best_pid[best_hs]][NUM_PATTERN_HALFSTRIPS];
+            keystrip_data[ilct][CLCT_BEND] = pattern2007[best_pid[best_hs]][CSCConstants::NUM_PATTERN_HALFSTRIPS];
             // Remove stagger if any.
             keystrip_data[ilct][CLCT_STRIP] = best_hs - stagger[CSCConstants::KEY_CLCT_LAYER - 1];
             keystrip_data[ilct][CLCT_BX] = bx;
@@ -2707,7 +2705,7 @@ CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstan
 
             int delta_hs = clct_state_machine_zone;
             if (dynamic_state_machine_zone)
-              delta_hs = pattern2007[lctListBX[ilct].getPattern()][NUM_PATTERN_HALFSTRIPS + 1] - 1;
+              delta_hs = pattern2007[lctListBX[ilct].getPattern()][CSCConstants::NUM_PATTERN_HALFSTRIPS + 1] - 1;
 
             int min_hstrip = key_hstrip - delta_hs;
             int max_hstrip = key_hstrip + delta_hs;
@@ -2983,8 +2981,8 @@ void CSCCathodeLCTProcessor::testLCTs() {
   // test to make sure what goes into an LCT is what comes out.
   for (int ptn = 0; ptn < 8; ptn++) {
     for (int bend = 0; bend < 2; bend++) {
-      for (int cfeb = 0; cfeb < MAX_CFEBS; cfeb++) {
-	for (int key_strip = 0; key_strip < 32; key_strip++) {
+      for (int cfeb = 0; cfeb < CSCConstants::MAX_CFEBS; cfeb++) {
+	for (int key_strip = 0; key_strip < CSCConstants::NUM_HALF_STRIPS_PER_CFEB; key_strip++) {
 	  for (int bx = 0; bx < 7; bx++) {
 	    for (int stripType = 0; stripType < 2; stripType++) {
 	      for (int quality = 3; quality < 6; quality++) {
@@ -3034,7 +3032,7 @@ void CSCCathodeLCTProcessor::printPatterns() {
   std::cout<<std::endl;
   std::cout<<" Layer ";
   for (int patternNum = 0; patternNum < CSCConstants::NUM_CLCT_PATTERNS_PRE_TMB07; patternNum++) {
-    std::cout<<"   Bend "<<(pattern[patternNum][NUM_PATTERN_STRIPS]==0 ? "L": "R")<<"  ";
+    std::cout<<"   Bend "<<(pattern[patternNum][CSCConstants::NUM_PATTERN_STRIPS]==0 ? "L": "R")<<"  ";
   }
   std::cout<<std::endl;
   for (int layer = 0; layer < CSCConstants::NUM_LAYERS; layer++) {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -535,7 +535,7 @@ void CSCCathodeLCTProcessor::checkConfigParameters() {
 
 void CSCCathodeLCTProcessor::clear() {
   thePreTriggerBXs.clear();
-  for (int bx = 0; bx < MAX_CLCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_CLCT_BINS; bx++) {
     bestCLCT[bx].clear();
     secondCLCT[bx].clear();
   }
@@ -713,10 +713,10 @@ void CSCCathodeLCTProcessor::run(
   for (std::vector<CSCCLCTDigi>::const_iterator plct = LCTlist.begin();
        plct != LCTlist.end(); plct++) {
     int bx = plct->getBX();
-    if (bx >= MAX_CLCT_BINS) {
+    if (bx >= CSCConstants::MAX_CLCT_BINS) {
       if (infoV > 0) edm::LogWarning("L1CSCTPEmulatorOutOfTimeCLCT")
 	<< "+++ Bx of CLCT candidate, " << bx << ", exceeds max allowed, "
-	<< MAX_CLCT_BINS-1 << "; skipping it... +++\n";
+	<< CSCConstants::MAX_CLCT_BINS-1 << "; skipping it... +++\n";
       continue;
     }
 
@@ -731,7 +731,7 @@ void CSCCathodeLCTProcessor::run(
     }
   }
 
-  for (int bx = 0; bx < MAX_CLCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_CLCT_BINS; bx++) {
     if (bestCLCT[bx].isValid()) {
       bestCLCT[bx].setTrknmb(1);
       if (infoV > 0) LogDebug("CSCCathodeLCTProcessor")
@@ -2514,9 +2514,9 @@ CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstan
   enum { max_lcts = 2 };
 
   // keeps dead-time zones around key halfstrips of triggered CLCTs
-  bool busyMap[CSCConstants::NUM_HALF_STRIPS_7CFEBS][MAX_CLCT_BINS];
+  bool busyMap[CSCConstants::NUM_HALF_STRIPS_7CFEBS][CSCConstants::MAX_CLCT_BINS];
   for (int i = 0; i < CSCConstants::NUM_HALF_STRIPS_7CFEBS; i++)
-    for (int j = 0; j < MAX_CLCT_BINS; j++)
+    for (int j = 0; j < CSCConstants::MAX_CLCT_BINS; j++)
       busyMap[i][j] = false;
 
   std::vector<CSCCLCTDigi> lctListBX;
@@ -2865,12 +2865,12 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::readoutCLCTs() {
 	<< "; in-time CLCTs are not getting read-out!!! +++" << "\n";
     }
 
-    if (late_tbins > MAX_CLCT_BINS-1) {
+    if (late_tbins > CSCConstants::MAX_CLCT_BINS-1) {
       if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorSuspiciousParameters")
 	<< "+++ Allowed range of time bins, [0-" << late_tbins
-	<< "] exceeds max allowed, " << MAX_CLCT_BINS-1 << " +++\n"
+	<< "] exceeds max allowed, " << CSCConstants::MAX_CLCT_BINS-1 << " +++\n"
 	<< "+++ Set late_tbins to max allowed +++\n";
-      late_tbins = MAX_CLCT_BINS-1;
+      late_tbins = CSCConstants::MAX_CLCT_BINS-1;
     }
     ifois = 1;
   }
@@ -2919,7 +2919,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::readoutCLCTs() {
 // Returns vector of all found CLCTs, if any.  Used for ALCT-CLCT matching.
 std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::getCLCTs() {
   std::vector<CSCCLCTDigi> tmpV;
-  for (int bx = 0; bx < MAX_CLCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_CLCT_BINS; bx++) {
     if (bestCLCT[bx].isValid())   tmpV.push_back(bestCLCT[bx]);
     if (secondCLCT[bx].isValid()) tmpV.push_back(secondCLCT[bx]);
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1334,7 +1334,7 @@ void CSCCathodeLCTProcessor::getKeyStripData(const std::vector<int> strip[CSCCon
   bool nullPattern;
 
   for (key_strip = 0; key_strip < nStrips; key_strip++)
-    for (int i = 0; i < CSCConstants::CLCT_NUM_QUANTITIES; i++)
+    for (int i = 0; i < CLCT_NUM_QUANTITIES; i++)
       keystrip_data[key_strip][i] = 0;
 
   // Now we need to look at all the keystrips and take the best pattern
@@ -1754,7 +1754,7 @@ void CSCCathodeLCTProcessor::priorityEncode(
 
   // initialize arrays
   for (int ilct = 0; ilct < CSCConstants::MAX_CLCTS_PER_PROCESSOR; ilct++) {
-    for (int j = 0; j < CSCConstants::CLCT_NUM_QUANTITIES; j++) keystrip_data[ilct][j] = -1;
+    for (int j = 0; j < CLCT_NUM_QUANTITIES; j++) keystrip_data[ilct][j] = -1;
     ihits[ilct] = 0;
     cfebs[ilct] = -1;
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
@@ -108,8 +108,14 @@ class CSCCathodeLCTProcessor
 
   // we use these next ones to address the various bits inside the array that's
   // used to make the cathode LCTs.
-  enum CLCT_INDICES {CLCT_PATTERN, CLCT_BEND, CLCT_STRIP, CLCT_BX,
-		     CLCT_STRIP_TYPE, CLCT_QUALITY, CLCT_CFEB};
+  enum CLCT_INDICES {CLCT_PATTERN,
+                     CLCT_BEND,
+                     CLCT_STRIP,
+                     CLCT_BX,
+                     CLCT_STRIP_TYPE,
+                     CLCT_QUALITY,
+                     CLCT_CFEB,
+                     CLCT_NUM_QUANTITIES= 7};
 
  private:
   /** Verbosity level: 0: no print (default).

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
@@ -100,16 +100,11 @@ class CSCCathodeLCTProcessor
   void setRing(unsigned r) {theRing = r;}
 
   /** Pre-defined patterns. */
-  enum {NUM_PATTERN_STRIPS = 26};
-  static const int pre_hit_pattern[2][NUM_PATTERN_STRIPS];
-  static const int pattern[CSCConstants::NUM_CLCT_PATTERNS_PRE_TMB07][NUM_PATTERN_STRIPS+1];
+  static const int pre_hit_pattern[2][CSCConstants::NUM_PATTERN_STRIPS];
+  static const int pattern[CSCConstants::NUM_CLCT_PATTERNS_PRE_TMB07][CSCConstants::NUM_PATTERN_STRIPS+1];
 
-  enum {NUM_PATTERN_HALFSTRIPS = 42};
-  static const int pattern2007_offset[NUM_PATTERN_HALFSTRIPS];
-  static const int pattern2007[CSCConstants::NUM_CLCT_PATTERNS][NUM_PATTERN_HALFSTRIPS+2];
-
-  /** Maximum number of cathode front-end boards (move to CSCConstants?). */
-  enum {MAX_CFEBS = 5};
+  static const int pattern2007_offset[CSCConstants::NUM_PATTERN_HALFSTRIPS];
+  static const int pattern2007[CSCConstants::NUM_CLCT_PATTERNS][CSCConstants::NUM_PATTERN_HALFSTRIPS+2];
 
   // we use these next ones to address the various bits inside the array that's
   // used to make the cathode LCTs.
@@ -219,7 +214,7 @@ class CSCCathodeLCTProcessor
      const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
      int keystrip_data[CSCConstants::NUM_HALF_STRIPS_7CFEBS][7],
      int nStrips, int first_bx, int& best_strip, int stripType);
-  void getPattern(int pattern_num, int strip_value[NUM_PATTERN_STRIPS],
+  void getPattern(int pattern_num, int strip_value[CSCConstants::NUM_PATTERN_STRIPS],
 		  int bx_time, int &quality, int &bend);
   bool hitIsGood(int hitTime, int BX);
 
@@ -236,18 +231,18 @@ class CSCCathodeLCTProcessor
 		     const int stripType, const int nStrips,
 		     const unsigned int bx_time);
   void latchLCTs(const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
-		 int keyStrip[MAX_CFEBS], unsigned int nhits[MAX_CFEBS],
+		 int keyStrip[CSCConstants::MAX_CFEBS], unsigned int nhits[CSCConstants::MAX_CFEBS],
 		 const int stripType, const int nStrips, const int bx_time);
-  void priorityEncode(const int h_keyStrip[MAX_CFEBS],
-		      const unsigned int h_nhits[MAX_CFEBS],
-		      const int d_keyStrip[MAX_CFEBS],
-		      const unsigned int d_nhits[MAX_CFEBS],
+  void priorityEncode(const int h_keyStrip[CSCConstants::MAX_CFEBS],
+		      const unsigned int h_nhits[CSCConstants::MAX_CFEBS],
+		      const int d_keyStrip[CSCConstants::MAX_CFEBS],
+		      const unsigned int d_nhits[CSCConstants::MAX_CFEBS],
 		      int keystrip_data[2][7]);
   void getKeyStripData(const unsigned int h_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 		       const unsigned int d_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 		       int keystrip_data[2][7], const int first_bx);
   void getPattern(unsigned int pattern_num,
-		  const int strip_value[NUM_PATTERN_STRIPS],
+		  const int strip_value[CSCConstants::NUM_PATTERN_STRIPS],
 		  unsigned int& quality, unsigned int& bend);
 
   //--------------- Functions for 2007 version of the firmware ----------------

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
@@ -25,7 +25,7 @@
  *
  * Updates for high pileup running by Vadim Khotilovich (TAMU), December 2012
  *
- * Updates for integrated local trigger with GEMs and RPCs by 
+ * Updates for integrated local trigger with GEMs and RPCs by
  * Sven Dildick (TAMU) and Tao Huang (TAMU), April 2015
  *
  * Removing usage of outdated class CSCTriggerGeometry by Sven Dildick (TAMU)
@@ -70,19 +70,16 @@ class CSCCathodeLCTProcessor
       finding. */
   void run(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 	   const std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
- 
+
   /** Access routines to comparator digis. */
   bool getDigis(const CSCComparatorDigiCollection* compdc);
   void getDigis(const CSCComparatorDigiCollection* compdc, const CSCDetId& id);
 
-  /** Maximum number of time bins. */
-  enum {MAX_CLCT_BINS = 16};
-
   /** Best LCT in this chamber, as found by the processor. */
-  CSCCLCTDigi bestCLCT[MAX_CLCT_BINS];
+  CSCCLCTDigi bestCLCT[CSCConstants::MAX_CLCT_BINS];
 
   /** Second best LCT in this chamber, as found by the processor. */
-  CSCCLCTDigi secondCLCT[MAX_CLCT_BINS];
+  CSCCLCTDigi secondCLCT[CSCConstants::MAX_CLCT_BINS];
 
   /** Returns vector of CLCTs in the read-out time window, if any. */
   std::vector<CSCCLCTDigi> readoutCLCTs();
@@ -132,14 +129,14 @@ class CSCCathodeLCTProcessor
   const unsigned theSector;
   const unsigned theSubsector;
   const unsigned theTrigChamber;
-  
+
   const CSCGeometry* csc_g;
-  
+
   // holders for easy access:
   unsigned int theRing;
   unsigned int theChamber;
   bool isME11;
-  
+
   int numStrips;
   int stagger[CSCConstants::NUM_LAYERS];
 
@@ -147,7 +144,7 @@ class CSCCathodeLCTProcessor
   std::vector<int> thePreTriggerBXs;
 
   /** Flag for "real" - not idealized - version of the algorithm. */
-  bool isMTCC; 
+  bool isMTCC;
 
   /** Flag for 2007 firmware version. */
   bool isTMB07;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
@@ -76,10 +76,10 @@ class CSCCathodeLCTProcessor
   void getDigis(const CSCComparatorDigiCollection* compdc, const CSCDetId& id);
 
   /** Best LCT in this chamber, as found by the processor. */
-  CSCCLCTDigi bestCLCT[CSCConstants::MAX_CLCT_BINS];
+  CSCCLCTDigi bestCLCT[CSCConstants::MAX_CLCT_TBINS];
 
   /** Second best LCT in this chamber, as found by the processor. */
-  CSCCLCTDigi secondCLCT[CSCConstants::MAX_CLCT_BINS];
+  CSCCLCTDigi secondCLCT[CSCConstants::MAX_CLCT_TBINS];
 
   /** Returns vector of CLCTs in the read-out time window, if any. */
   std::vector<CSCCLCTDigi> readoutCLCTs();
@@ -100,11 +100,11 @@ class CSCCathodeLCTProcessor
   void setRing(unsigned r) {theRing = r;}
 
   /** Pre-defined patterns. */
-  static const int pre_hit_pattern[2][CSCConstants::NUM_PATTERN_STRIPS];
-  static const int pattern[CSCConstants::NUM_CLCT_PATTERNS_PRE_TMB07][CSCConstants::NUM_PATTERN_STRIPS+1];
+  static const int pre_hit_pattern[2][CSCConstants::MAX_STRIPS_IN_PATTERN];
+  static const int pattern[CSCConstants::NUM_CLCT_PATTERNS_PRE_TMB07][CSCConstants::MAX_STRIPS_IN_PATTERN+1];
 
-  static const int pattern2007_offset[CSCConstants::NUM_PATTERN_HALFSTRIPS];
-  static const int pattern2007[CSCConstants::NUM_CLCT_PATTERNS][CSCConstants::NUM_PATTERN_HALFSTRIPS+2];
+  static const int pattern2007_offset[CSCConstants::MAX_HALFSTRIPS_IN_PATTERN];
+  static const int pattern2007[CSCConstants::NUM_CLCT_PATTERNS][CSCConstants::MAX_HALFSTRIPS_IN_PATTERN+2];
 
   // we use these next ones to address the various bits inside the array that's
   // used to make the cathode LCTs.
@@ -220,7 +220,7 @@ class CSCCathodeLCTProcessor
      const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
      int keystrip_data[CSCConstants::NUM_HALF_STRIPS_7CFEBS][7],
      int nStrips, int first_bx, int& best_strip, int stripType);
-  void getPattern(int pattern_num, int strip_value[CSCConstants::NUM_PATTERN_STRIPS],
+  void getPattern(int pattern_num, int strip_value[CSCConstants::MAX_STRIPS_IN_PATTERN],
 		  int bx_time, int &quality, int &bend);
   bool hitIsGood(int hitTime, int BX);
 
@@ -248,7 +248,7 @@ class CSCCathodeLCTProcessor
 		       const unsigned int d_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 		       int keystrip_data[2][7], const int first_bx);
   void getPattern(unsigned int pattern_num,
-		  const int strip_value[CSCConstants::NUM_PATTERN_STRIPS],
+		  const int strip_value[CSCConstants::MAX_STRIPS_IN_PATTERN],
 		  unsigned int& quality, unsigned int& bend);
 
   //--------------- Functions for 2007 version of the firmware ----------------

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -539,7 +539,6 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
     }
   }// reduction per bx
 
-  bool first = true;
   unsigned int n1b=0, n1a=0;
   LogTrace("CSCGEMCMotherboardME11") << "========================================================================" << std::endl
                                      << "Counting the final LCTs" << std::endl
@@ -704,14 +703,14 @@ bool CSCGEMMotherboardME11::doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLC
     if ( !gangedME1a )
     {
       // wrap around ME11 HS number for -z endcap
-      if (theEndcap==2) key_hs = 95 - key_hs;
+      if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1A_UNGANGED - key_hs;
       if ( key_hs >= (tmbLUT_->get_lut_wg_vs_hs(CSCPart::ME1A))[key_wg][0] and
 	   key_hs <= (tmbLUT_->get_lut_wg_vs_hs(CSCPart::ME1A))[key_wg][1]    ) return true;
       return false;
     }
     else
     {
-      if (theEndcap==2) key_hs = 31 - key_hs;
+      if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1A_GANGED - key_hs;
       if ( key_hs >= (tmbLUT_->get_lut_wg_vs_hs(CSCPart::ME1Ag))[key_wg][0] and
 	   key_hs <= (tmbLUT_->get_lut_wg_vs_hs(CSCPart::ME1Ag))[key_wg][1]    ) return true;
       return false;
@@ -719,7 +718,7 @@ bool CSCGEMMotherboardME11::doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLC
   }
   if ( me == ME1B)
   {
-    if (theEndcap==2) key_hs = 127 - key_hs;
+    if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1B - key_hs;
     if ( key_hs >= (tmbLUT_->get_lut_wg_vs_hs(CSCPart::ME1B))[key_wg][0] and
          key_hs <= (tmbLUT_->get_lut_wg_vs_hs(CSCPart::ME1B))[key_wg][1]      ) return true;
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -60,7 +60,7 @@ void CSCGEMMotherboardME11::clear()
   CSCGEMMotherboard::clear();
 
   if (clct1a) clct1a->clear();
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++) {
     for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++) {
       for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++) {
         allLCTs1b(bx,mbx,i).clear();
@@ -126,7 +126,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   const bool hasCoPads(hasPads and !coPads_.empty());
 
   // ALCT-centric matching
-  for (int bx_alct = 0; bx_alct < CSCAnodeLCTProcessor::MAX_ALCT_BINS; bx_alct++)
+  for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_BINS; bx_alct++)
   {
     if (alct->bestALCT[bx_alct].isValid())
     {
@@ -153,7 +153,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
       int nSuccesFulMatches = 0;
       for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
       {
-        if (bx_clct < 0 or bx_clct >= CSCCathodeLCTProcessor::MAX_CLCT_BINS) continue;
+        if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
         if (drop_used_clcts and used_clct_mask[bx_clct]) continue;
         if (clct->bestCLCT[bx_clct].isValid())
         {
@@ -273,7 +273,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
       nSuccesFulMatches = 0;
       for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
       {
-        if (bx_clct < 0 or bx_clct >= CSCCathodeLCTProcessor::MAX_CLCT_BINS) continue;
+        if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
         if (drop_used_clcts and used_clct_mask_1a[bx_clct]) continue;
         if (clct1a->bestCLCT[bx_clct].isValid())
         {
@@ -391,7 +391,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
         // matching in ME1b
         if (buildLCTfromCLCTandGEM_ME1b_) {
           for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++) {
-            if (bx_clct < 0 or bx_clct >= CSCCathodeLCTProcessor::MAX_CLCT_BINS) continue;
+            if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
             if (drop_used_clcts and used_clct_mask[bx_clct]) continue;
             if (clct->bestCLCT[bx_clct].isValid()) {
               const int quality(clct->bestCLCT[bx_clct].getQuality());
@@ -419,7 +419,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
         // matching in ME1a
         if (buildLCTfromCLCTandGEM_ME1a_) {
           for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++) {
-            if (bx_clct < 0 || bx_clct >= CSCCathodeLCTProcessor::MAX_CLCT_BINS) continue;
+            if (bx_clct < 0 || bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
             if (drop_used_clcts && used_clct_mask_1a[bx_clct]) continue;
             if (clct1a->bestCLCT[bx_clct].isValid()){
               const int quality(clct1a->bestCLCT[bx_clct].getQuality());
@@ -454,7 +454,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   }
 
   // reduction of nLCTs per each BX
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
   {
     // counting
     unsigned int n1a=0, n1b=0;
@@ -648,7 +648,7 @@ void CSCGEMMotherboardME11::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& LCTs, in
 void CSCGEMMotherboardME11::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& LCTs_final, enum CSCPart me,
                                      bool (*sorter)(const CSCCorrelatedLCTDigi&, const CSCCorrelatedLCTDigi&)) const
 {
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
     {
       // get sorted LCTs per subchamber
       std::vector<CSCCorrelatedLCTDigi> LCTs1a;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -60,7 +60,7 @@ void CSCGEMMotherboardME11::clear()
   CSCGEMMotherboard::clear();
 
   if (clct1a) clct1a->clear();
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
     for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++) {
       for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++) {
         allLCTs1b(bx,mbx,i).clear();
@@ -126,7 +126,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   const bool hasCoPads(hasPads and !coPads_.empty());
 
   // ALCT-centric matching
-  for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_BINS; bx_alct++)
+  for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++)
   {
     if (alct->bestALCT[bx_alct].isValid())
     {
@@ -153,7 +153,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
       int nSuccesFulMatches = 0;
       for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
       {
-        if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
+        if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_TBINS) continue;
         if (drop_used_clcts and used_clct_mask[bx_clct]) continue;
         if (clct->bestCLCT[bx_clct].isValid())
         {
@@ -273,7 +273,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
       nSuccesFulMatches = 0;
       for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
       {
-        if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
+        if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_TBINS) continue;
         if (drop_used_clcts and used_clct_mask_1a[bx_clct]) continue;
         if (clct1a->bestCLCT[bx_clct].isValid())
         {
@@ -391,7 +391,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
         // matching in ME1b
         if (buildLCTfromCLCTandGEM_ME1b_) {
           for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++) {
-            if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
+            if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_TBINS) continue;
             if (drop_used_clcts and used_clct_mask[bx_clct]) continue;
             if (clct->bestCLCT[bx_clct].isValid()) {
               const int quality(clct->bestCLCT[bx_clct].getQuality());
@@ -419,7 +419,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
         // matching in ME1a
         if (buildLCTfromCLCTandGEM_ME1a_) {
           for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++) {
-            if (bx_clct < 0 || bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
+            if (bx_clct < 0 || bx_clct >= CSCConstants::MAX_CLCT_TBINS) continue;
             if (drop_used_clcts && used_clct_mask_1a[bx_clct]) continue;
             if (clct1a->bestCLCT[bx_clct].isValid()){
               const int quality(clct1a->bestCLCT[bx_clct].getQuality());
@@ -454,7 +454,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   }
 
   // reduction of nLCTs per each BX
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++)
   {
     // counting
     unsigned int n1a=0, n1b=0;
@@ -647,7 +647,7 @@ void CSCGEMMotherboardME11::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& LCTs, in
 void CSCGEMMotherboardME11::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& LCTs_final, enum CSCPart me,
                                      bool (*sorter)(const CSCCorrelatedLCTDigi&, const CSCCorrelatedLCTDigi&)) const
 {
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++)
     {
       // get sorted LCTs per subchamber
       std::vector<CSCCorrelatedLCTDigi> LCTs1a;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
@@ -36,7 +36,7 @@ void CSCGEMMotherboardME21::clear()
   CSCMotherboard::clear();
   CSCGEMMotherboard::clear();
 
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
     for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++) {
       for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++) {
 	allLCTs(bx,mbx,i).clear();
@@ -96,7 +96,7 @@ CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
   const bool hasCoPads(!coPads_.empty());
 
   // ALCT centric matching
-  for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_BINS; bx_alct++)
+  for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++)
   {
     if (alct->bestALCT[bx_alct].isValid())
     {
@@ -125,7 +125,7 @@ CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
       int nSuccessFulMatches = 0;
       for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
       {
-        if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
+        if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_TBINS) continue;
         if (drop_used_clcts and used_clct_mask[bx_clct]) continue;
         if (clct->bestCLCT[bx_clct].isValid())
         {
@@ -258,7 +258,7 @@ CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
         int nSuccessFulMatches = 0;
         for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
           {
-            if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
+            if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_TBINS) continue;
             if (drop_used_clcts and used_clct_mask[bx_clct]) continue;
             if (clct->bestCLCT[bx_clct].isValid())
               {
@@ -292,7 +292,7 @@ CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
     }
   }
   // reduction of nLCTs per each BX
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++)
     {
       // counting
       unsigned int n=0;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
@@ -36,7 +36,7 @@ void CSCGEMMotherboardME21::clear()
   CSCMotherboard::clear();
   CSCGEMMotherboard::clear();
 
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++) {
     for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++) {
       for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++) {
 	allLCTs(bx,mbx,i).clear();
@@ -96,7 +96,7 @@ CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
   const bool hasCoPads(!coPads_.empty());
 
   // ALCT centric matching
-  for (int bx_alct = 0; bx_alct < CSCAnodeLCTProcessor::MAX_ALCT_BINS; bx_alct++)
+  for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_BINS; bx_alct++)
   {
     if (alct->bestALCT[bx_alct].isValid())
     {
@@ -125,7 +125,7 @@ CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
       int nSuccessFulMatches = 0;
       for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
       {
-        if (bx_clct < 0 or bx_clct >= CSCCathodeLCTProcessor::MAX_CLCT_BINS) continue;
+        if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
         if (drop_used_clcts and used_clct_mask[bx_clct]) continue;
         if (clct->bestCLCT[bx_clct].isValid())
         {
@@ -258,7 +258,7 @@ CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
         int nSuccessFulMatches = 0;
         for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
           {
-            if (bx_clct < 0 or bx_clct >= CSCCathodeLCTProcessor::MAX_CLCT_BINS) continue;
+            if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
             if (drop_used_clcts and used_clct_mask[bx_clct]) continue;
             if (clct->bestCLCT[bx_clct].isValid())
               {
@@ -292,7 +292,7 @@ CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
     }
   }
   // reduction of nLCTs per each BX
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
     {
       // counting
       unsigned int n=0;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -191,7 +191,7 @@ CSCMotherboard::CSCMotherboard() :
 void CSCMotherboard::clear() {
   if (alct) alct->clear();
   if (clct) clct->clear();
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
     firstLCT[bx].clear();
     secondLCT[bx].clear();
   }
@@ -298,7 +298,7 @@ void CSCMotherboard::run(
   clct->run(hs_times, ds_times); // run cathodeLCT
 
   int bx_alct_matched = 0;
-  for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_BINS;
+  for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_TBINS;
        bx_clct++) {
     if (clct->bestCLCT[bx_clct].isValid()) {
       bool is_matched = false;
@@ -308,7 +308,7 @@ void CSCMotherboard::run(
       if (!isSLHC) bx_alct_stop += match_trig_window_size%2;
 
       for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++) {
-        if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_BINS)
+        if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_TBINS)
           continue;
         if (alct->bestALCT[bx_alct].isValid()) {
           correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
@@ -359,7 +359,7 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
     for (int a=0;a<20;++a) used_alct_mask[a]=0;
 
     int bx_alct_matched = 0; // bx of last matched ALCT
-    for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_BINS;
+    for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_TBINS;
          bx_clct++) {
       // There should be at least one valid ALCT or CLCT for a
       // correlated LCT to be formed.  Decision on whether to reject
@@ -382,7 +382,7 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
         if (!isSLHC) bx_alct_stop += match_trig_window_size%2;
 
         for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++) {
-          if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_BINS)
+          if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_TBINS)
             continue;
           // default: do not reuse ALCTs that were used with previous CLCTs
           if (drop_used_alcts && used_alct_mask[bx_alct]) continue;
@@ -429,7 +429,7 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
     }
 
     if (infoV > 0) {
-      for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++) {
+      for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
         if (firstLCT[bx].isValid())
           LogDebug("CSCMotherboard") << firstLCT[bx];
         if (secondLCT[bx].isValid())
@@ -467,12 +467,12 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::readoutLCTs() {
         << "; in-time LCTs are not getting read-out!!! +++" << "\n";
     }
 
-    if (late_tbins > CSCConstants::MAX_LCT_BINS-1) {
+    if (late_tbins > CSCConstants::MAX_LCT_TBINS-1) {
       if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorSuspiciousParameters")
         << "+++ Allowed range of time bins, [0-" << late_tbins
-        << "] exceeds max allowed, " << CSCConstants::MAX_LCT_BINS-1 << " +++\n"
+        << "] exceeds max allowed, " << CSCConstants::MAX_LCT_TBINS-1 << " +++\n"
         << "+++ Set late_tbins to max allowed +++\n";
-      late_tbins = CSCConstants::MAX_LCT_BINS-1;
+      late_tbins = CSCConstants::MAX_LCT_TBINS-1;
     }
     ifois = 1;
   }
@@ -530,7 +530,7 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::getLCTs() {
                                                           theTrigChamber)==1);
 
   // Do not report LCTs found in ME1/A if mpc_block_me1/a is set.
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
     if (firstLCT[bx].isValid())
       if (!mpc_block_me1a || (!me11 || firstLCT[bx].getStrip() <= 127))
         tmpV.push_back(firstLCT[bx]);
@@ -563,14 +563,14 @@ void CSCMotherboard::correlateLCTs(CSCALCTDigi& bestALCT,
       (match_trig_enable && bestALCT.isValid() && bestCLCT.isValid())) {
     CSCCorrelatedLCTDigi lct = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::CLCTALCT);
     int bx = lct.getBX();
-    if (bx >= 0 && bx < CSCConstants::MAX_LCT_BINS) {
+    if (bx >= 0 && bx < CSCConstants::MAX_LCT_TBINS) {
       firstLCT[bx] = lct;
       firstLCT[bx].setTrknmb(1);
     }
     else {
       if (infoV > 0) edm::LogWarning("L1CSCTPEmulatorOutOfTimeLCT")
         << "+++ Bx of first LCT candidate, " << bx
-        << ", is not within the allowed range, [0-" << CSCConstants::MAX_LCT_BINS-1
+        << ", is not within the allowed range, [0-" << CSCConstants::MAX_LCT_TBINS-1
         << "); skipping it... +++\n";
     }
   }
@@ -581,14 +581,14 @@ void CSCMotherboard::correlateLCTs(CSCALCTDigi& bestALCT,
        (match_trig_enable && secondALCT.isValid() && secondCLCT.isValid()))) {
     CSCCorrelatedLCTDigi lct = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::CLCTALCT);
     int bx = lct.getBX();
-    if (bx >= 0 && bx < CSCConstants::MAX_LCT_BINS) {
+    if (bx >= 0 && bx < CSCConstants::MAX_LCT_TBINS) {
       secondLCT[bx] = lct;
       secondLCT[bx].setTrknmb(2);
     }
     else {
       if (infoV > 0) edm::LogWarning("L1CSCTPEmulatorOutOfTimeLCT")
         << "+++ Bx of second LCT candidate, " << bx
-        << ", is not within the allowed range, [0-" << CSCConstants::MAX_LCT_BINS-1
+        << ", is not within the allowed range, [0-" << CSCConstants::MAX_LCT_TBINS-1
         << "); skipping it... +++\n";
     }
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -191,7 +191,7 @@ CSCMotherboard::CSCMotherboard() :
 void CSCMotherboard::clear() {
   if (alct) alct->clear();
   if (clct) clct->clear();
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++) {
     firstLCT[bx].clear();
     secondLCT[bx].clear();
   }
@@ -298,7 +298,7 @@ void CSCMotherboard::run(
   clct->run(hs_times, ds_times); // run cathodeLCT
 
   int bx_alct_matched = 0;
-  for (int bx_clct = 0; bx_clct < CSCCathodeLCTProcessor::MAX_CLCT_BINS;
+  for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_BINS;
        bx_clct++) {
     if (clct->bestCLCT[bx_clct].isValid()) {
       bool is_matched = false;
@@ -308,7 +308,7 @@ void CSCMotherboard::run(
       if (!isSLHC) bx_alct_stop += match_trig_window_size%2;
 
       for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++) {
-        if (bx_alct < 0 || bx_alct >= CSCAnodeLCTProcessor::MAX_ALCT_BINS)
+        if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_BINS)
           continue;
         if (alct->bestALCT[bx_alct].isValid()) {
           correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
@@ -359,7 +359,7 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
     for (int a=0;a<20;++a) used_alct_mask[a]=0;
 
     int bx_alct_matched = 0; // bx of last matched ALCT
-    for (int bx_clct = 0; bx_clct < CSCCathodeLCTProcessor::MAX_CLCT_BINS;
+    for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_BINS;
          bx_clct++) {
       // There should be at least one valid ALCT or CLCT for a
       // correlated LCT to be formed.  Decision on whether to reject
@@ -382,7 +382,7 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
         if (!isSLHC) bx_alct_stop += match_trig_window_size%2;
 
         for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++) {
-          if (bx_alct < 0 || bx_alct >= CSCAnodeLCTProcessor::MAX_ALCT_BINS)
+          if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_BINS)
             continue;
           // default: do not reuse ALCTs that were used with previous CLCTs
           if (drop_used_alcts && used_alct_mask[bx_alct]) continue;
@@ -429,7 +429,7 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
     }
 
     if (infoV > 0) {
-      for (int bx = 0; bx < MAX_LCT_BINS; bx++) {
+      for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++) {
         if (firstLCT[bx].isValid())
           LogDebug("CSCMotherboard") << firstLCT[bx];
         if (secondLCT[bx].isValid())
@@ -467,12 +467,12 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::readoutLCTs() {
         << "; in-time LCTs are not getting read-out!!! +++" << "\n";
     }
 
-    if (late_tbins > MAX_LCT_BINS-1) {
+    if (late_tbins > CSCConstants::MAX_LCT_BINS-1) {
       if (infoV >= 0) edm::LogWarning("L1CSCTPEmulatorSuspiciousParameters")
         << "+++ Allowed range of time bins, [0-" << late_tbins
-        << "] exceeds max allowed, " << MAX_LCT_BINS-1 << " +++\n"
+        << "] exceeds max allowed, " << CSCConstants::MAX_LCT_BINS-1 << " +++\n"
         << "+++ Set late_tbins to max allowed +++\n";
-      late_tbins = MAX_LCT_BINS-1;
+      late_tbins = CSCConstants::MAX_LCT_BINS-1;
     }
     ifois = 1;
   }
@@ -530,7 +530,7 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::getLCTs() {
                                                           theTrigChamber)==1);
 
   // Do not report LCTs found in ME1/A if mpc_block_me1/a is set.
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++) {
     if (firstLCT[bx].isValid())
       if (!mpc_block_me1a || (!me11 || firstLCT[bx].getStrip() <= 127))
         tmpV.push_back(firstLCT[bx]);
@@ -541,10 +541,10 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::getLCTs() {
   return tmpV;
 }
 
-void CSCMotherboard::correlateLCTs(CSCALCTDigi bestALCT,
-                                   CSCALCTDigi secondALCT,
-                                   CSCCLCTDigi bestCLCT,
-                                   CSCCLCTDigi secondCLCT) {
+void CSCMotherboard::correlateLCTs(CSCALCTDigi& bestALCT,
+                                   CSCALCTDigi& secondALCT,
+                                   CSCCLCTDigi& bestCLCT,
+                                   CSCCLCTDigi& secondCLCT) {
 
   bool anodeBestValid     = bestALCT.isValid();
   bool anodeSecondValid   = secondALCT.isValid();
@@ -563,14 +563,14 @@ void CSCMotherboard::correlateLCTs(CSCALCTDigi bestALCT,
       (match_trig_enable && bestALCT.isValid() && bestCLCT.isValid())) {
     CSCCorrelatedLCTDigi lct = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::CLCTALCT);
     int bx = lct.getBX();
-    if (bx >= 0 && bx < MAX_LCT_BINS) {
+    if (bx >= 0 && bx < CSCConstants::MAX_LCT_BINS) {
       firstLCT[bx] = lct;
       firstLCT[bx].setTrknmb(1);
     }
     else {
       if (infoV > 0) edm::LogWarning("L1CSCTPEmulatorOutOfTimeLCT")
         << "+++ Bx of first LCT candidate, " << bx
-        << ", is not within the allowed range, [0-" << MAX_LCT_BINS-1
+        << ", is not within the allowed range, [0-" << CSCConstants::MAX_LCT_BINS-1
         << "); skipping it... +++\n";
     }
   }
@@ -581,14 +581,14 @@ void CSCMotherboard::correlateLCTs(CSCALCTDigi bestALCT,
        (match_trig_enable && secondALCT.isValid() && secondCLCT.isValid()))) {
     CSCCorrelatedLCTDigi lct = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::CLCTALCT);
     int bx = lct.getBX();
-    if (bx >= 0 && bx < MAX_LCT_BINS) {
+    if (bx >= 0 && bx < CSCConstants::MAX_LCT_BINS) {
       secondLCT[bx] = lct;
       secondLCT[bx].setTrknmb(2);
     }
     else {
       if (infoV > 0) edm::LogWarning("L1CSCTPEmulatorOutOfTimeLCT")
         << "+++ Bx of second LCT candidate, " << bx
-        << ", is not within the allowed range, [0-" << MAX_LCT_BINS-1
+        << ", is not within the allowed range, [0-" << CSCConstants::MAX_LCT_BINS-1
         << "); skipping it... +++\n";
     }
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -134,10 +134,10 @@ class CSCMotherboard
   static const unsigned int def_tmb_l1a_window_size;
 
   /** Container for first correlated LCT. */
-  CSCCorrelatedLCTDigi firstLCT[CSCConstants::MAX_LCT_BINS];
+  CSCCorrelatedLCTDigi firstLCT[CSCConstants::MAX_LCT_TBINS];
 
   /** Container for second correlated LCT. */
-  CSCCorrelatedLCTDigi secondLCT[CSCConstants::MAX_LCT_BINS];
+  CSCCorrelatedLCTDigi secondLCT[CSCConstants::MAX_LCT_TBINS];
 
   /** Make sure that the parameter values are within the allowed range. */
   void checkConfigParameters();

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -133,20 +133,17 @@ class CSCMotherboard
   static const unsigned int def_match_trig_enable, def_match_trig_window_size;
   static const unsigned int def_tmb_l1a_window_size;
 
-  /** Maximum number of time bins. */
-  enum {MAX_LCT_BINS = 16};
-
   /** Container for first correlated LCT. */
-  CSCCorrelatedLCTDigi firstLCT[MAX_LCT_BINS];
+  CSCCorrelatedLCTDigi firstLCT[CSCConstants::MAX_LCT_BINS];
 
   /** Container for second correlated LCT. */
-  CSCCorrelatedLCTDigi secondLCT[MAX_LCT_BINS];
+  CSCCorrelatedLCTDigi secondLCT[CSCConstants::MAX_LCT_BINS];
 
   /** Make sure that the parameter values are within the allowed range. */
   void checkConfigParameters();
 
-  void correlateLCTs(CSCALCTDigi bestALCT, CSCALCTDigi secondALCT,
-                     CSCCLCTDigi bestCLCT, CSCCLCTDigi secondCLCT);
+  void correlateLCTs(CSCALCTDigi& bestALCT, CSCALCTDigi& secondALCT,
+                     CSCCLCTDigi& bestCLCT, CSCCLCTDigi& secondCLCT);
   CSCCorrelatedLCTDigi constructLCTs(const CSCALCTDigi& aLCT,
                                      const CSCCLCTDigi& cLCT,
                                      int type) const;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -19,7 +19,7 @@
 // LUT for which ME1/1 wire group can cross which ME1/a halfstrip
 // 1st index: WG number
 // 2nd index: inclusive HS range
-const int CSCMotherboardME11::lut_wg_vs_hs_me1a[48][2] = {
+const int CSCMotherboardME11::lut_wg_vs_hs_me1a[CSCConstants::MAX_NUM_WIRES_ME11][2] = {
 {0, 95},{0, 95},{0, 95},{0, 95},{0, 95},
 {0, 95},{0, 95},{0, 95},{0, 95},{0, 95},
 {0, 95},{0, 95},{0, 77},{0, 61},{0, 39},
@@ -31,7 +31,7 @@ const int CSCMotherboardME11::lut_wg_vs_hs_me1a[48][2] = {
 {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
 {-1,-1},{-1,-1},{-1,-1} };
 // a modified LUT for ganged ME1a
-const int CSCMotherboardME11::lut_wg_vs_hs_me1ag[48][2] = {
+const int CSCMotherboardME11::lut_wg_vs_hs_me1ag[CSCConstants::MAX_NUM_WIRES_ME11][2] = {
 {0, 31},{0, 31},{0, 31},{0, 31},{0, 31},
 {0, 31},{0, 31},{0, 31},{0, 31},{0, 31},
 {0, 31},{0, 31},{0, 31},{0, 31},{0, 31},
@@ -46,7 +46,7 @@ const int CSCMotherboardME11::lut_wg_vs_hs_me1ag[48][2] = {
 // LUT for which ME1/1 wire group can cross which ME1/b halfstrip
 // 1st index: WG number
 // 2nd index: inclusive HS range
-const int CSCMotherboardME11::lut_wg_vs_hs_me1b[48][2] = {
+const int CSCMotherboardME11::lut_wg_vs_hs_me1b[CSCConstants::MAX_NUM_WIRES_ME11][2] = {
 {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
 {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
 {100, 127},{73, 127},{47, 127},{22, 127},{0, 127},

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -134,7 +134,7 @@ void CSCMotherboardME11::clear()
 {
   CSCMotherboard::clear();
   if (clct1a) clct1a->clear();
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
   {
     //firstLCT1a[bx].clear();
     //secondLCT1a[bx].clear();
@@ -187,7 +187,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
     used_alct_mask[b] = used_alct_mask_1a[b] = used_clct_mask[b] = used_clct_mask_1a[b] = 0;
 
   // CLCT-centric CLCT-to-ALCT matching
-  if (clct_to_alct) for (int bx_clct = 0; bx_clct < CSCCathodeLCTProcessor::MAX_CLCT_BINS; bx_clct++)
+  if (clct_to_alct) for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_BINS; bx_clct++)
   {
     // matching in ME1b
     if (clct->bestCLCT[bx_clct].isValid())
@@ -196,7 +196,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
       int bx_alct_stop  = bx_clct + match_trig_window_size/2;
       for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++)
       {
-        if (bx_alct < 0 || bx_alct >= CSCAnodeLCTProcessor::MAX_ALCT_BINS) continue;
+        if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_BINS) continue;
         if (drop_used_alcts && used_alct_mask[bx_alct]) continue;
         if (alct->bestALCT[bx_alct].isValid())
         {
@@ -224,7 +224,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
       int bx_alct_stop  = bx_clct + match_trig_window_size/2;
       for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++)
       {
-        if (bx_alct < 0 || bx_alct >= CSCAnodeLCTProcessor::MAX_ALCT_BINS) continue;
+        if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_BINS) continue;
         if (drop_used_alcts && used_alct_mask_1a[bx_alct]) continue;
         if (alct->bestALCT[bx_alct].isValid())
         {
@@ -249,7 +249,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   } // end of CLCT-centric matching
 
   // ALCT-centric ALCT-to-CLCT matching
-  else for (int bx_alct = 0; bx_alct < CSCAnodeLCTProcessor::MAX_ALCT_BINS; bx_alct++)
+  else for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_BINS; bx_alct++)
   {
     if (alct->bestALCT[bx_alct].isValid())
     {
@@ -259,7 +259,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
       // matching in ME1b
       for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
       {
-        if (bx_clct < 0 || bx_clct >= CSCCathodeLCTProcessor::MAX_CLCT_BINS) continue;
+        if (bx_clct < 0 || bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
         if (drop_used_clcts && used_clct_mask[bx_clct]) continue;
         if (clct->bestCLCT[bx_clct].isValid())
         {
@@ -282,7 +282,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
       // matching in ME1a
       for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
       {
-        if (bx_clct < 0 || bx_clct >= CSCCathodeLCTProcessor::MAX_CLCT_BINS) continue;
+        if (bx_clct < 0 || bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
         if (drop_used_clcts && used_clct_mask_1a[bx_clct]) continue;
         if (clct1a->bestCLCT[bx_clct].isValid())
         {
@@ -305,7 +305,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   } // end of ALCT-centric matching
 
   // reduction of nLCTs per each BX
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
   {
     // counting
     unsigned int n1a=0, n1b=0;
@@ -458,7 +458,7 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::getLCTs1b()
 {
   std::vector<CSCCorrelatedLCTDigi> tmpV;
 
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
     for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++)
       for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++)
         if (allLCTs1b[bx][mbx][i].isValid()) tmpV.push_back(allLCTs1b[bx][mbx][i]);
@@ -474,7 +474,7 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::getLCTs1a()
   if (mpc_block_me1a || disableME1a) return tmpV;
 
   // Report all LCTs found.
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
     for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++)
       for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++)
         if (allLCTs1a[bx][mbx][i].isValid())  tmpV.push_back(allLCTs1a[bx][mbx][i]);

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -492,14 +492,14 @@ bool CSCMotherboardME11::doesALCTCrossCLCT(CSCALCTDigi &a, CSCCLCTDigi &c, int m
     if ( !gangedME1a )
     {
       // wrap around ME11 HS number for -z endcap
-      if (theEndcap==2) key_hs = 95 - key_hs;
+      if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1A_UNGANGED - key_hs;
       if ( key_hs >= lut_wg_vs_hs_me1a[key_wg][0] &&
            key_hs <= lut_wg_vs_hs_me1a[key_wg][1]    ) return true;
       return false;
     }
     else
     {
-      if (theEndcap==2) key_hs = 31 - key_hs;
+      if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1A_GANGED - key_hs;
       if ( key_hs >= lut_wg_vs_hs_me1ag[key_wg][0] &&
            key_hs <= lut_wg_vs_hs_me1ag[key_wg][1]    ) return true;
       return false;
@@ -507,7 +507,7 @@ bool CSCMotherboardME11::doesALCTCrossCLCT(CSCALCTDigi &a, CSCCLCTDigi &c, int m
   }
   if ( me == ME1B)
   {
-    if (theEndcap==2) key_hs = 127 - key_hs;
+    if (theEndcap==2) key_hs = CSCConstants::MAX_HALF_STRIP_ME1B - key_hs;
     if ( key_hs >= lut_wg_vs_hs_me1b[key_wg][0] &&
          key_hs <= lut_wg_vs_hs_me1b[key_wg][1]      ) return true;
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -19,7 +19,7 @@
 // LUT for which ME1/1 wire group can cross which ME1/a halfstrip
 // 1st index: WG number
 // 2nd index: inclusive HS range
-const int CSCMotherboardME11::lut_wg_vs_hs_me1a[CSCConstants::MAX_NUM_WIRES_ME11][2] = {
+const int CSCMotherboardME11::lut_wg_vs_hs_me1a[CSCConstants::MAX_WIRES_ME11][2] = {
 {0, 95},{0, 95},{0, 95},{0, 95},{0, 95},
 {0, 95},{0, 95},{0, 95},{0, 95},{0, 95},
 {0, 95},{0, 95},{0, 77},{0, 61},{0, 39},
@@ -31,7 +31,7 @@ const int CSCMotherboardME11::lut_wg_vs_hs_me1a[CSCConstants::MAX_NUM_WIRES_ME11
 {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
 {-1,-1},{-1,-1},{-1,-1} };
 // a modified LUT for ganged ME1a
-const int CSCMotherboardME11::lut_wg_vs_hs_me1ag[CSCConstants::MAX_NUM_WIRES_ME11][2] = {
+const int CSCMotherboardME11::lut_wg_vs_hs_me1ag[CSCConstants::MAX_WIRES_ME11][2] = {
 {0, 31},{0, 31},{0, 31},{0, 31},{0, 31},
 {0, 31},{0, 31},{0, 31},{0, 31},{0, 31},
 {0, 31},{0, 31},{0, 31},{0, 31},{0, 31},
@@ -46,7 +46,7 @@ const int CSCMotherboardME11::lut_wg_vs_hs_me1ag[CSCConstants::MAX_NUM_WIRES_ME1
 // LUT for which ME1/1 wire group can cross which ME1/b halfstrip
 // 1st index: WG number
 // 2nd index: inclusive HS range
-const int CSCMotherboardME11::lut_wg_vs_hs_me1b[CSCConstants::MAX_NUM_WIRES_ME11][2] = {
+const int CSCMotherboardME11::lut_wg_vs_hs_me1b[CSCConstants::MAX_WIRES_ME11][2] = {
 {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
 {-1,-1},{-1,-1},{-1,-1},{-1,-1},{-1,-1},
 {100, 127},{73, 127},{47, 127},{22, 127},{0, 127},
@@ -134,7 +134,7 @@ void CSCMotherboardME11::clear()
 {
   CSCMotherboard::clear();
   if (clct1a) clct1a->clear();
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++)
   {
     //firstLCT1a[bx].clear();
     //secondLCT1a[bx].clear();
@@ -187,7 +187,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
     used_alct_mask[b] = used_alct_mask_1a[b] = used_clct_mask[b] = used_clct_mask_1a[b] = 0;
 
   // CLCT-centric CLCT-to-ALCT matching
-  if (clct_to_alct) for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_BINS; bx_clct++)
+  if (clct_to_alct) for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_TBINS; bx_clct++)
   {
     // matching in ME1b
     if (clct->bestCLCT[bx_clct].isValid())
@@ -196,7 +196,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
       int bx_alct_stop  = bx_clct + match_trig_window_size/2;
       for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++)
       {
-        if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_BINS) continue;
+        if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_TBINS) continue;
         if (drop_used_alcts && used_alct_mask[bx_alct]) continue;
         if (alct->bestALCT[bx_alct].isValid())
         {
@@ -224,7 +224,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
       int bx_alct_stop  = bx_clct + match_trig_window_size/2;
       for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++)
       {
-        if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_BINS) continue;
+        if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_TBINS) continue;
         if (drop_used_alcts && used_alct_mask_1a[bx_alct]) continue;
         if (alct->bestALCT[bx_alct].isValid())
         {
@@ -249,7 +249,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   } // end of CLCT-centric matching
 
   // ALCT-centric ALCT-to-CLCT matching
-  else for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_BINS; bx_alct++)
+  else for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++)
   {
     if (alct->bestALCT[bx_alct].isValid())
     {
@@ -259,7 +259,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
       // matching in ME1b
       for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
       {
-        if (bx_clct < 0 || bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
+        if (bx_clct < 0 || bx_clct >= CSCConstants::MAX_CLCT_TBINS) continue;
         if (drop_used_clcts && used_clct_mask[bx_clct]) continue;
         if (clct->bestCLCT[bx_clct].isValid())
         {
@@ -282,7 +282,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
       // matching in ME1a
       for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
       {
-        if (bx_clct < 0 || bx_clct >= CSCConstants::MAX_CLCT_BINS) continue;
+        if (bx_clct < 0 || bx_clct >= CSCConstants::MAX_CLCT_TBINS) continue;
         if (drop_used_clcts && used_clct_mask_1a[bx_clct]) continue;
         if (clct1a->bestCLCT[bx_clct].isValid())
         {
@@ -305,7 +305,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   } // end of ALCT-centric matching
 
   // reduction of nLCTs per each BX
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++)
   {
     // counting
     unsigned int n1a=0, n1b=0;
@@ -458,7 +458,7 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::getLCTs1b()
 {
   std::vector<CSCCorrelatedLCTDigi> tmpV;
 
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++)
     for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++)
       for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++)
         if (allLCTs1b[bx][mbx][i].isValid()) tmpV.push_back(allLCTs1b[bx][mbx][i]);
@@ -474,7 +474,7 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::getLCTs1a()
   if (mpc_block_me1a || disableME1a) return tmpV;
 
   // Report all LCTs found.
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++)
     for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++)
       for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++)
         if (allLCTs1a[bx][mbx][i].isValid())  tmpV.push_back(allLCTs1a[bx][mbx][i]);

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
@@ -75,15 +75,15 @@ class CSCMotherboardME11 : public CSCMotherboard
   bool doesALCTCrossCLCT(CSCALCTDigi &a, CSCCLCTDigi &c, int me);
 
   /** Container for first correlated LCT in ME1a. */
-  //CSCCorrelatedLCTDigi firstLCT1a[CSCConstants::MAX_LCT_BINS];
+  //CSCCorrelatedLCTDigi firstLCT1a[CSCConstants::MAX_LCT_TBINS];
 
   /** Container for second correlated LCT in ME1a. */
-  //CSCCorrelatedLCTDigi secondLCT1a[CSCConstants::MAX_LCT_BINS];
+  //CSCCorrelatedLCTDigi secondLCT1a[CSCConstants::MAX_LCT_TBINS];
 
   /** for the case when more than 2 LCTs/BX are allowed;
       maximum match window = 15 */
-  CSCCorrelatedLCTDigi allLCTs1b[CSCConstants::MAX_LCT_BINS][15][2];
-  CSCCorrelatedLCTDigi allLCTs1a[CSCConstants::MAX_LCT_BINS][15][2];
+  CSCCorrelatedLCTDigi allLCTs1b[CSCConstants::MAX_LCT_TBINS][15][2];
+  CSCCorrelatedLCTDigi allLCTs1a[CSCConstants::MAX_LCT_TBINS][15][2];
 
   void correlateLCTs(CSCALCTDigi bestALCT, CSCALCTDigi secondALCT,
 		     CSCCLCTDigi bestCLCT, CSCCLCTDigi secondCLCT,
@@ -94,7 +94,7 @@ class CSCMotherboardME11 : public CSCMotherboard
   std::vector<CSCCLCTDigi> clctV1a;
 
   /** "preferential" index array in matching window for cross-BX sorting */
-  int pref[CSCConstants::MAX_LCT_BINS];
+  int pref[CSCConstants::MAX_LCT_TBINS];
 
   bool match_earliest_alct_me11_only;
   bool match_earliest_clct_me11_only;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
@@ -75,15 +75,15 @@ class CSCMotherboardME11 : public CSCMotherboard
   bool doesALCTCrossCLCT(CSCALCTDigi &a, CSCCLCTDigi &c, int me);
 
   /** Container for first correlated LCT in ME1a. */
-  //CSCCorrelatedLCTDigi firstLCT1a[MAX_LCT_BINS];
+  //CSCCorrelatedLCTDigi firstLCT1a[CSCConstants::MAX_LCT_BINS];
 
   /** Container for second correlated LCT in ME1a. */
-  //CSCCorrelatedLCTDigi secondLCT1a[MAX_LCT_BINS];
+  //CSCCorrelatedLCTDigi secondLCT1a[CSCConstants::MAX_LCT_BINS];
 
   /** for the case when more than 2 LCTs/BX are allowed;
       maximum match window = 15 */
-  CSCCorrelatedLCTDigi allLCTs1b[MAX_LCT_BINS][15][2];
-  CSCCorrelatedLCTDigi allLCTs1a[MAX_LCT_BINS][15][2];
+  CSCCorrelatedLCTDigi allLCTs1b[CSCConstants::MAX_LCT_BINS][15][2];
+  CSCCorrelatedLCTDigi allLCTs1a[CSCConstants::MAX_LCT_BINS][15][2];
 
   void correlateLCTs(CSCALCTDigi bestALCT, CSCALCTDigi secondALCT,
 		     CSCCLCTDigi bestCLCT, CSCCLCTDigi secondCLCT,
@@ -94,7 +94,7 @@ class CSCMotherboardME11 : public CSCMotherboard
   std::vector<CSCCLCTDigi> clctV1a;
 
   /** "preferential" index array in matching window for cross-BX sorting */
-  int pref[MAX_LCT_BINS];
+  int pref[CSCConstants::MAX_LCT_BINS];
 
   bool match_earliest_alct_me11_only;
   bool match_earliest_clct_me11_only;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
@@ -25,7 +25,7 @@ CSCUpgradeMotherboard::LCTContainer::getTimeMatched(const int bx,
 void
 CSCUpgradeMotherboard::LCTContainer::getMatched(std::vector<CSCCorrelatedLCTDigi>& lcts) const
 {
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++){
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++){
     std::vector<CSCCorrelatedLCTDigi> temp_lcts;
     CSCUpgradeMotherboard::LCTContainer::getTimeMatched(bx,temp_lcts);
     lcts.insert(std::end(lcts), std::begin(temp_lcts), std::end(temp_lcts));

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
@@ -25,7 +25,7 @@ CSCUpgradeMotherboard::LCTContainer::getTimeMatched(const int bx,
 void
 CSCUpgradeMotherboard::LCTContainer::getMatched(std::vector<CSCCorrelatedLCTDigi>& lcts) const
 {
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_BINS; bx++){
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++){
     std::vector<CSCCorrelatedLCTDigi> temp_lcts;
     CSCUpgradeMotherboard::LCTContainer::getTimeMatched(bx,temp_lcts);
     lcts.insert(std::end(lcts), std::begin(temp_lcts), std::end(temp_lcts));

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.h
@@ -57,7 +57,7 @@ public:
     void getMatched(std::vector<CSCCorrelatedLCTDigi>&) const;
 
     // array with stored LCTs
-    CSCCorrelatedLCTDigi data[CSCConstants::MAX_LCT_BINS][15][2];
+    CSCCorrelatedLCTDigi data[CSCConstants::MAX_LCT_TBINS][15][2];
 
     // matching trigger window
     const unsigned int match_trig_window_size;
@@ -117,7 +117,7 @@ public:
   std::unique_ptr<CSCUpgradeMotherboardLUTGenerator> generator_;
 
   /** "preferential" index array in matching window for cross-BX sorting */
-  int pref[CSCConstants::MAX_LCT_BINS];
+  int pref[CSCConstants::MAX_LCT_TBINS];
 
   bool match_earliest_alct_only;
   bool match_earliest_clct_only;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.h
@@ -57,7 +57,7 @@ public:
     void getMatched(std::vector<CSCCorrelatedLCTDigi>&) const;
 
     // array with stored LCTs
-    CSCCorrelatedLCTDigi data[CSCMotherboard::MAX_LCT_BINS][15][2];
+    CSCCorrelatedLCTDigi data[CSCConstants::MAX_LCT_BINS][15][2];
 
     // matching trigger window
     const unsigned int match_trig_window_size;
@@ -117,7 +117,7 @@ public:
   std::unique_ptr<CSCUpgradeMotherboardLUTGenerator> generator_;
 
   /** "preferential" index array in matching window for cross-BX sorting */
-  int pref[MAX_LCT_BINS];
+  int pref[CSCConstants::MAX_LCT_BINS];
 
   bool match_earliest_alct_only;
   bool match_earliest_clct_only;

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCAnodeLCTAnalyzer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCAnodeLCTAnalyzer.cc
@@ -113,7 +113,7 @@ vector<CSCAnodeLayerInfo> CSCAnodeLCTAnalyzer::lctDigis(
 
     // Loop over all the wires in a pattern.
     int mask;
-    for (int i_wire = 0; i_wire < CSCConstants::NUM_PATTERN_WIRES;
+    for (int i_wire = 0; i_wire < CSCConstants::MAX_WIRES_IN_PATTERN;
 	 i_wire++) {
       if (CSCAnodeLCTProcessor::pattern_envelope[0][i_wire] == i_layer) {
 	if (!isMTCCMask) {

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCAnodeLCTAnalyzer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCAnodeLCTAnalyzer.cc
@@ -113,7 +113,7 @@ vector<CSCAnodeLayerInfo> CSCAnodeLCTAnalyzer::lctDigis(
 
     // Loop over all the wires in a pattern.
     int mask;
-    for (int i_wire = 0; i_wire < CSCAnodeLCTProcessor::NUM_PATTERN_WIRES;
+    for (int i_wire = 0; i_wire < CSCConstants::NUM_PATTERN_WIRES;
 	 i_wire++) {
       if (CSCAnodeLCTProcessor::pattern_envelope[0][i_wire] == i_layer) {
 	if (!isMTCCMask) {

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCCathodeLCTAnalyzer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCCathodeLCTAnalyzer.cc
@@ -147,10 +147,10 @@ vector<CSCCathodeLayerInfo> CSCCathodeLCTAnalyzer::lctDigis(
     // Loop over all the strips in a pattern.
     int max_pattern_strips, layer, strip;
     if (!isTMB07) {
-      max_pattern_strips = CSCConstants::NUM_PATTERN_STRIPS;
+      max_pattern_strips = CSCConstants::MAX_STRIPS_IN_PATTERN;
     }
     else {
-      max_pattern_strips = CSCConstants::NUM_PATTERN_HALFSTRIPS;
+      max_pattern_strips = CSCConstants::MAX_HALFSTRIPS_IN_PATTERN;
     }
     for (int i_strip = 0; i_strip < max_pattern_strips; i_strip++) {
       if (!isTMB07) {

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCCathodeLCTAnalyzer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCCathodeLCTAnalyzer.cc
@@ -147,10 +147,10 @@ vector<CSCCathodeLayerInfo> CSCCathodeLCTAnalyzer::lctDigis(
     // Loop over all the strips in a pattern.
     int max_pattern_strips, layer, strip;
     if (!isTMB07) {
-      max_pattern_strips = CSCCathodeLCTProcessor::NUM_PATTERN_STRIPS;
+      max_pattern_strips = CSCConstants::NUM_PATTERN_STRIPS;
     }
     else {
-      max_pattern_strips = CSCCathodeLCTProcessor::NUM_PATTERN_HALFSTRIPS;
+      max_pattern_strips = CSCConstants::NUM_PATTERN_HALFSTRIPS;
     }
     for (int i_strip = 0; i_strip < max_pattern_strips; i_strip++) {
       if (!isTMB07) {
@@ -249,7 +249,7 @@ int CSCCathodeLCTAnalyzer::preselectDigis(const int clct_bx,
 	}
 
 	if (time[i_strip] <= 0 || time[i_strip] > bx_time) {
- 
+
 	  // @ Switch to maps; check for match in time.
 	  int i_hfstrip = 2*i_strip + (*digiIt).getComparator() + stagger;
 	  hfstripDigis[i_hfstrip] = digi_num;


### PR DESCRIPTION
Enums `MAX_CLCT_BINS`, `MAX_ALCT_BINS` and `MAX_LCT_BINS` were defined in 3 different places. This PR puts all three in the common class `CSCConstants`. 

Additional enums were created in `CSCConstants`: 
* `MAX_CFEBS`
* `NUM_DISTRIPS_PER_CFEB`, `NUM_STRIPS_PER_CFEB`, `NUM_HALF_STRIPS_PER_CFEB`
* `NUM_PATTERN_WIRES`, `NUM_PATTERN_STRIPS`, `NUM_PATTERN_HALFSTRIPS`
* `MAX_CLCTS_PER_PROCESSOR`, `MAX_ALCTS_PER_PROCESSOR`
* `MAX_HALF_STRIP_ME1A_GANGED`, `MAX_HALF_STRIP_ME1A_UNGANGED`, `MAX_HALF_STRIP_ME1B`
* `CLCT_FPGA_LATENCY`, `ALCT_FPGA_LATENCY`
* `MAX_NUM_WIRES_ME11`.

EDIT:

<PRE>
MAX_CLCT_BINS -> MAX_CLCT_TBINS
MAX_ALCT_BINS -> MAX_ALCT_TBINS
MAX_LCT_BINS -> MAX_LCT_TBINS
NUM_PATTERN_WIRES -> MAX_WIRES_IN_PATTERN
NUM_PATTERN_STRIPS -> MAX_STRIPS_IN_PATTERN
NUM_PATTERN_HALFSTRIPS -> MAX_HALFSTRIPS_IN_PATTERN
MAX_NUM_WIRES_ME11 -> MAX_WIRES_ME11
_LATENCY -> _EMUL_TIME_OFFSET
</PRE>

This PR is part of an effort to document the "magic" numbers in the CSC local trigger. There should be no change in performance.

@tahuang1991 