### PR TITLE
Switch fed error trend online client

### DIFF
--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -5,9 +5,9 @@ from Configuration.StandardSequences.Eras import eras
 process = cms.Process("SiStrpDQMLive", eras.Run2_2017)
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('siStripDigis', 
-                                         'siStripClusters', 
-                                         'siStripZeroSuppression', 
+    debugModules = cms.untracked.vstring('siStripDigis',
+                                         'siStripClusters',
+                                         'siStripZeroSuppression',
                                         'SiStripClusterizer'),
     cout = cms.untracked.PSet(threshold = cms.untracked.string('ERROR')),
     destinations = cms.untracked.vstring('cout')
@@ -15,7 +15,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 live=True
 # uncomment for running on lxplus
-#live=False
+live=False
 offlineTesting=not live
 #print "live: "+str(live)+" ==> offlineTesting: "+str(offlineTesting)
 
@@ -71,12 +71,13 @@ if (live):
 elif(offlineTesting):
     process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#you may need to set manually the GT in the line below
+    #you may need to set manually the GT in the line below
     process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 #--------------------------------------------
 ## Patch to avoid using Run Info information in reconstruction
 #
+
 process.siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
    cms.PSet( record = cms.string("SiStripDetVOffRcd"),    tag    = cms.string("") ),
    cms.PSet( record = cms.string("SiStripDetCablingRcd"), tag    = cms.string("") ),
@@ -85,7 +86,7 @@ process.siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
    cms.PSet( record = cms.string("SiStripBadModuleRcd"),  tag    = cms.string("") )
    )
 #-------------------------------------------
-                                                                                           
+
 #-----------------------
 #  Reconstruction Modules
 #-----------------------
@@ -129,7 +130,7 @@ process.TrackMon_ckf.AlgoName = 'CKFTk'
 #--------------------------
 process.stripQTester = cms.EDAnalyzer("QualityTester",
     qtList = cms.untracked.FileInPath('DQM/SiStripMonitorClient/data/sistrip_qualitytest_config.xml'),
-    prescaleFactor = cms.untracked.int32(3),                               
+    prescaleFactor = cms.untracked.int32(3),
     getQualityTestsFromFile = cms.untracked.bool(True),
     qtestOnEndLumi = cms.untracked.bool(True),
     qtestOnEndRun = cms.untracked.bool(True)
@@ -137,7 +138,7 @@ process.stripQTester = cms.EDAnalyzer("QualityTester",
 
 process.trackingQTester = cms.EDAnalyzer("QualityTester",
     qtList = cms.untracked.FileInPath('DQM/TrackingMonitorClient/data/tracking_qualitytest_config.xml'),
-    prescaleFactor = cms.untracked.int32(3),                               
+    prescaleFactor = cms.untracked.int32(3),
     getQualityTestsFromFile = cms.untracked.bool(True),
     qtestOnEndLumi = cms.untracked.bool(True),
     qtestOnEndRun = cms.untracked.bool(True)
@@ -193,6 +194,11 @@ process.SiStripSources_LocalReco = cms.Sequence(process.siStripFEDMonitor*proces
 process.DQMCommon                = cms.Sequence(process.stripQTester*process.trackingQTester*process.dqmEnv*process.dqmEnvTr*process.dqmSaver)
 process.RecoForDQM_LocalReco     = cms.Sequence(process.siPixelDigis*process.siStripDigis*process.gtDigis*process.trackerlocalreco)
 
+#------------------------------------------------------
+# Switch for channel errors per FED ID trend plots.
+#------------------------------------------------------
+process.siStripFEDMonitor.fedErrorsVsIdVsLumiHistogramConfig.globalswitchon = cms.untracked.bool(True)
+
 #--------------------------
 # Global Plot Switches
 #--------------------------
@@ -215,7 +221,7 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
     process.SiStripAnalyserCosmic.StaticUpdateFrequency = 5
     process.SiStripAnalyserCosmic.MonitorSiStripBackPlaneCorrection = cms.bool(False)
     process.SiStripClients           = cms.Sequence(process.SiStripAnalyserCosmic)
-    ### TRACKING 
+    ### TRACKING
     process.load("DQM.TrackingMonitorClient.TrackingClientConfigP5_Cosmic_cff")
     process.TrackingAnalyserCosmic.RawDataTag           = cms.untracked.InputTag("rawDataCollector")
     process.TrackingAnalyserCosmic.ShiftReportFrequency = -1
@@ -239,7 +245,7 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
     process.trackingQTester.prescaleFactor          = cms.untracked.int32(1)
     process.trackingQTester.getQualityTestsFromFile = cms.untracked.bool(True)
     process.trackingQTester.qtestOnEndLumi          = cms.untracked.bool(True)
-    process.trackingQTester.qtestOnEndRun           = cms.untracked.bool(True)                                                                    
+    process.trackingQTester.qtestOnEndRun           = cms.untracked.bool(True)
 
     process.p = cms.Path(process.scalersRawToDigi*
                          process.APVPhases*
@@ -277,7 +283,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
 
     process.SiStripMonitorDigi.UseDCSFiltering = cms.bool(False)
     process.SiStripMonitorClusterReal.UseDCSFiltering = cms.bool(False)
-    
+
     process.MonitorTrackResiduals_gentk.Tracks                 = 'initialStepTracksPreSplitting'
     process.MonitorTrackResiduals_gentk.trajectoryInput        = 'initialStepTracksPreSplitting'
     process.MonitorTrackResiduals_gentk.TrackProducer          = cms.string('initialStepTracksPreSplitting')
@@ -298,7 +304,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.SiStripClients           = cms.Sequence(process.SiStripAnalyser)
 
     process.SiStripMonitorDigi.TotalNumberOfDigisFailure.integrateNLumisections = cms.int32(25)
-    ### TRACKING 
+    ### TRACKING
     process.load("DQM.TrackingMonitorClient.TrackingClientConfigP5_cff")
     process.TrackingAnalyser.ShiftReportFrequency = -1
     process.TrackingAnalyser.StaticUpdateFrequency = 5
@@ -306,24 +312,32 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     if offlineTesting :
         process.TrackingAnalyser.verbose = cms.untracked.bool(True)
     process.TrackingClient = cms.Sequence( process.TrackingAnalyser )
-    
+
     process.trackingQTester.qtList                  = cms.untracked.FileInPath('DQM/TrackingMonitorClient/data/tracking_qualitytest_config.xml')
     process.trackingQTester.prescaleFactor          = cms.untracked.int32(1)
     process.trackingQTester.getQualityTestsFromFile = cms.untracked.bool(True)
     process.trackingQTester.qtestOnEndLumi          = cms.untracked.bool(True)
-    process.trackingQTester.qtestOnEndRun           = cms.untracked.bool(True)                                                                    
+    process.trackingQTester.qtestOnEndRun           = cms.untracked.bool(True)
 
     # Reco for pp collisions
 
     process.load('RecoTracker.IterativeTracking.InitialStepPreSplitting_cff')
-    process.InitialStepPreSplitting.remove(process.initialStepTrackRefsForJetsPreSplitting)
+    '''process.InitialStepPreSplitting.remove(process.initialStepTrackRefsForJetsPreSplitting)
     process.InitialStepPreSplitting.remove(process.caloTowerForTrkPreSplitting)
     process.InitialStepPreSplitting.remove(process.ak4CaloJetsForTrkPreSplitting)
     process.InitialStepPreSplitting.remove(process.jetsForCoreTrackingPreSplitting)
     process.InitialStepPreSplitting.remove(process.siPixelClusters)
     process.InitialStepPreSplitting.remove(process.siPixelRecHits)
     process.InitialStepPreSplitting.remove(process.MeasurementTrackerEvent)
-    process.InitialStepPreSplitting.remove(process.siPixelClusterShapeCache)
+    process.InitialStepPreSplitting.remove(process.siPixelClusterShapeCache)'''
+
+    process.InitialStepPreSplittingTask.remove(process.initialStepTrackRefsForJetsPreSplitting)
+    process.InitialStepPreSplittingTask.remove(process.caloTowerForTrkPreSplitting)
+    process.InitialStepPreSplittingTask.remove(process.ak4CaloJetsForTrkPreSplitting)
+    process.InitialStepPreSplittingTask.remove(process.jetsForCoreTrackingPreSplitting)
+    process.InitialStepPreSplittingTask.remove(process.siPixelClusters)
+    process.InitialStepPreSplittingTask.remove(process.siPixelRecHits)
+    process.InitialStepPreSplittingTask.remove(process.MeasurementTrackerEvent)
 
     # Redefinition of siPixelClusters: has to be after RecoTracker.IterativeTracking.InitialStepPreSplitting_cff
     process.load("RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi")
@@ -366,7 +380,7 @@ if (process.runType.getRunType() == process.runType.hpu_run):
     # => PRESCALE = 50
     # but try firstly w/ 30, maybe it is enough
     process.eventFilter.EventsToSkip = cms.untracked.int32(30)
-    
+
     # change the HLT trigger path selection
     # it should already be ok, but the name could be changed
     process.hltHighLevel.HLTPaths = cms.vstring( 'HLT_ZeroBias*' )
@@ -377,7 +391,7 @@ if (process.runType.getRunType() == process.runType.hpu_run):
 
     process.SiStripMonitorDigi.UseDCSFiltering = cms.bool(False)
     process.SiStripMonitorClusterReal.UseDCSFiltering = cms.bool(False)
-    
+
     process.MonitorTrackResiduals_gentk.Tracks                 = 'earlyGeneralTracks'
     process.MonitorTrackResiduals_gentk.trajectoryInput        = 'earlyGeneralTracks'
     process.MonitorTrackResiduals_gentk.TrackProducer          = cms.string('earlyGeneralTracks')
@@ -404,18 +418,18 @@ if (process.runType.getRunType() == process.runType.hpu_run):
     # Reco for pp collisions
 
     process.load('RecoTracker.Configuration.RecoTracker_cff')
-    
+
     #process.newCombinedSeeds.seedCollections = cms.VInputTag(
     #    cms.InputTag('initialStepSeeds'),
     #    )
-    
+
     process.load('RecoTracker.FinalTrackSelectors.MergeTrackCollections_cff')
     import RecoTracker.FinalTrackSelectors.earlyGeneralTracks_cfi
     process.load('RecoTracker.FinalTrackSelectors.earlyGeneralTracks_cfi')
     process.earlyGeneralTracks.TrackProducers = (
         cms.InputTag('initialStepTracks'),
         )
-    
+
     process.earlyGeneralTracks.hasSelector=cms.vint32(1)
     process.earlyGeneralTracks.selectedTrackQuals = cms.VInputTag(
 #        cms.InputTag("initialStepSelector","initialStep"),
@@ -497,7 +511,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
 #    process.DQMEventStreamerReader.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('HLT_HIJet*','HLT_HICentralityVeto*','HLT_HIFullTrack*','HLT_HIMinBias*'))
 #
     process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/sistrip_reference_hi.root'
-    # Quality test for HI                                                                                                                  
+    # Quality test for HI
     process.stripQTester = cms.EDAnalyzer("QualityTester",
                                      qtList = cms.untracked.FileInPath('DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_heavyion.xml'),
                                      prescaleFactor = cms.untracked.int32(3),
@@ -512,7 +526,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.trackingQTester.qtestOnEndLumi          = cms.untracked.bool(True)
     process.trackingQTester.qtestOnEndRun           = cms.untracked.bool(True)
 
-    # Sources for HI 
+    # Sources for HI
     process.load("Configuration.StandardSequences.RawToDigi_Repacked_cff")
     process.SiStripBaselineValidator.srcProcessedRawDigi =  cms.InputTag('siStripVRDigis','VirginRaw')
     process.SiStripMonitorTrack_hi.TrackProducer = "hiSelectedTracks"
@@ -553,7 +567,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.SiStripMonitorTrack_hi.TrackProducer = cms.string('hiSelectedTracks')
     process.RecoForDQM_LocalReco = cms.Sequence(process.siPixelDigis*process.siStripDigis*process.siStripVRDigis*process.gtDigis*process.trackerlocalreco*process.pixeltrackerlocalreco)
     process.RecoForDQM_TrkReco = cms.Sequence(process.offlineBeamSpot*process.MeasurementTrackerEventPreSplitting*process.siPixelClusterShapeCachePreSplitting*process.hiBasicTracking*process.hiSelectedTracks)
-    
+
     process.p = cms.Path(process.scalersRawToDigi*
                          process.APVPhases*
                          process.consecutiveHEs*
@@ -569,7 +583,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
                          process.SiStripBaselineValidator*
                          process.TrackingClient
                          )
-    
+
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -15,7 +15,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 live=True
 # uncomment for running on lxplus
-live=False
+#live=False
 offlineTesting=not live
 #print "live: "+str(live)+" ==> offlineTesting: "+str(offlineTesting)
 


### PR DESCRIPTION
…of channel errors per FED ID. Removed modules from 'process.InitialStepPreSplittingTask' so online client doesnt crash due to trying to override definition of siPixelClusters while it is used by the task InitialStepPreSplittingTask. Added global switch to online clients to enable trend plots of channel errors per FED ID.