### PR TITLE
Require vertex to have time to use timing cuts in displaced track seeding

### DIFF
--- a/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitration.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitration.h
@@ -271,7 +271,7 @@ std::vector<VTX> TrackVertexArbitration<VTX>::trackVertexArbitrator(
              	 singleFitVertex = theAdaptiveFitter.vertex(selTracks,ssv);
 		 
               	if(singleFitVertex.isValid())  { 
-		  svhelper::updateVertexTime(singleFitVertex);
+		  if( pv.covariance(3,3) > 0. ) svhelper::updateVertexTime(singleFitVertex);
 		  recoVertices.push_back(VTX(singleFitVertex));
 		  
 

--- a/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
@@ -255,8 +255,10 @@ void TemplatedInclusiveVertexFinder<InputContainer,VTX>::produce(edm::Event &eve
 		}
 		
 		// for each transient vertex state determine if a time can be measured and fill covariance
-		for(auto& vtx : vertices) {
-		  svhelper::updateVertexTime(vtx);
+		if( pv.covariance(3,3) > 0. ) {
+		  for(auto& vtx : vertices) {		  
+		    svhelper::updateVertexTime(vtx);
+		  }
 		}
 
 		for(std::vector<TransientVertex>::const_iterator v = vertices.begin();

--- a/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc
+++ b/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc
@@ -42,7 +42,9 @@ std::pair<std::vector<reco::TransientTrack>,GlobalPoint> TracksClusteringFromDis
                  GlobalPoint cp(dist.crossingPoint()); 
 
 		 double timeSig = 0.;
-		 if( edm::isFinite(seed.timeExt()) && edm::isFinite(tt->timeExt()) ) { // apply only if time available
+		 if( primaryVertex.covariance(3,3) > 0. && 
+		     edm::isFinite(seed.timeExt()) && edm::isFinite(tt->timeExt()) ) { 
+		   // apply only if time available and being used in vertexing
 		   const double tError = std::sqrt( std::pow(seed.dtErrorExt(),2) + std::pow(tt->dtErrorExt(),2) );
 		   timeSig = std::abs( seed.timeExt() - tt->timeExt() ) / tError;
 		 }


### PR DESCRIPTION
Since  #20640 was merged, this is needed to bring master in line with #21193.

Add the requirement that the primary vertex has timing information to use the track time cuts.