### PR TITLE
L1T muon unpacker fix for crash with corrupt uGT RO record - 94x

### DIFF
--- a/DataFormats/L1Trigger/interface/BxBlock.h
+++ b/DataFormats/L1Trigger/interface/BxBlock.h
@@ -17,7 +17,7 @@ namespace l1t {
 
          bool operator<(const BxBlockHeader& o) const { return getBx() < o.getBx(); };
 
-         inline int getBx() const { return (int)id_ - (int)std::floor(totalBx_/2.); };
+         inline int getBx() const { return (int)id_ + std::min(0, 1 - (int)totalBx_%2 - (int)std::floor(totalBx_/2.)); }; // In case of an even totalBx_ the BX range should be like, e.g. -3 to +4
          inline unsigned int getId() const { return id_; };
          inline unsigned int getTotalBx() const { return totalBx_; };
          inline unsigned int getFlags() const { return flags_; };

--- a/DataFormats/L1Trigger/interface/BxBlock.h
+++ b/DataFormats/L1Trigger/interface/BxBlock.h
@@ -1,6 +1,7 @@
 #ifndef DataFormats_L1Trigger_BxBlock_h
 #define DataFormats_L1Trigger_BxBlock_h
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 #include <cmath>

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -1,5 +1,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include "EventFilter/L1TRawToDigi/plugins/UnpackerFactory.h"
+
 
 #include "L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h"
 
@@ -43,11 +45,10 @@ namespace l1t {
          // Get the BX blocks and unpack them
          auto bxBlocks = block.getBxBlocks(nWords_, bxZsEnabled);
          for (const auto& bxBlock : bxBlocks) {
-            // Protect against corrupted BX headers with out of range BX numbers
+            // Throw an exception if finding a corrupt BX header with out of range BX numbers
             const auto bx = bxBlock.header().getBx();
             if (bx < firstBX || bx > lastBX) {
-               edm::LogError("L1T") << "Corrupt RAW data from FED " << fed_ << ", AMC " << block.amc().getAMCNumber() << ". BX number " << bx << " in BX header is outside of the BX range [" << firstBX << "," << lastBX << "] defined in the block header. Skip unpacking of this BX block.";
-               continue;
+               throw cms::Exception("CorruptData") << "Corrupt RAW data from FED " << fed_ << ", AMC " << block.amc().getAMCNumber() << ". BX number " << bx << " in BX header is outside of the BX range [" << firstBX << "," << lastBX << "] defined in the block header.";
             }
             unpackBx(bx, bxBlock.payload());
          }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -43,7 +43,13 @@ namespace l1t {
          // Get the BX blocks and unpack them
          auto bxBlocks = block.getBxBlocks(nWords_, bxZsEnabled);
          for (const auto& bxBlock : bxBlocks) {
-            unpackBx(bxBlock.header().getBx(), bxBlock.payload());
+            // Protect against corrupted BX headers with out of range BX numbers
+            const auto bx = bxBlock.header().getBx();
+            if (bx < firstBX || bx > lastBX) {
+               edm::LogError("L1T") << "Corrupt RAW data from FED " << fed_ << ", AMC " << block.amc().getAMCNumber() << ". BX number " << bx << " in BX header is outside of the BX range [" << firstBX << "," << lastBX << "] defined in the block header. Skip unpacking of this BX block.";
+               continue;
+            }
+            unpackBx(bx, bxBlock.payload());
          }
          return true;
       }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -1,4 +1,5 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include "EventFilter/L1TRawToDigi/plugins/UnpackerFactory.h"
 
 #include "L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h"
@@ -69,11 +70,10 @@ namespace l1t {
          // Get the BX blocks and unpack them
          auto bxBlocks = block.getBxBlocks(nWords_, bxZsEnabled);
          for (const auto& bxBlock : bxBlocks) {
-            // Protect against corrupted BX headers with out of range BX numbers
+            // Throw an exception if finding a corrupt BX header with out of range BX numbers
             const auto bx = bxBlock.header().getBx();
             if (bx < firstBX || bx > lastBX) {
-               edm::LogError("L1T") << "Corrupt RAW data from AMC " << block.amc().getAMCNumber() << ". BX number " << bx << " in BX header is outside of the BX range [" << firstBX << "," << lastBX << "] defined in the block header. Skip unpacking of this BX block.";
-               continue;
+               throw cms::Exception("CorruptData") << "Corrupt RAW data from AMC " << block.amc().getAMCNumber() << ". BX number " << bx << " in BX header is outside of the BX range [" << firstBX << "," << lastBX << "] defined in the block header.";
             }
             // Check if there are enough words left in the BX block payload
             auto bxPayload = bxBlock.payload();

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -69,6 +69,12 @@ namespace l1t {
          // Get the BX blocks and unpack them
          auto bxBlocks = block.getBxBlocks(nWords_, bxZsEnabled);
          for (const auto& bxBlock : bxBlocks) {
+            // Protect against corrupted BX headers with out of range BX numbers
+            const auto bx = bxBlock.header().getBx();
+            if (bx < firstBX || bx > lastBX) {
+               edm::LogError("L1T") << "Corrupt RAW data from AMC " << block.amc().getAMCNumber() << ". BX number " << bx << " in BX header is outside of the BX range [" << firstBX << "," << lastBX << "] defined in the block header. Skip unpacking of this BX block.";
+               continue;
+            }
             // Check if there are enough words left in the BX block payload
             auto bxPayload = bxBlock.payload();
             if (nWords_ <= bxPayload.size()) {
@@ -83,7 +89,7 @@ namespace l1t {
                   }
                   // Detect and ignore comma events
                   if (raw_data_00_31 == 0x505050bc || raw_data_32_63 == 0x505050bc) {
-                     edm::LogWarning("L1T") << "Comma detected in raw data stream. Orbit number: " << block.amc().getOrbitNumber() << ", BX ID: " << block.amc().getBX() << ", BX: " << bxBlock.header().getBx() << ", linkId: " << linkId << ", Raw data: 0x" << hex << setw(8) << setfill('0') << raw_data_32_63 << setw(8) << setfill('0') << raw_data_00_31 << dec << ". Skip.";
+                     edm::LogWarning("L1T") << "Comma detected in raw data stream. Orbit number: " << block.amc().getOrbitNumber() << ", BX ID: " << block.amc().getBX() << ", BX: " << bx << ", linkId: " << linkId << ", Raw data: 0x" << hex << setw(8) << setfill('0') << raw_data_32_63 << setw(8) << setfill('0') << raw_data_00_31 << dec << ". Skip.";
                      continue;
                   }
  
@@ -93,11 +99,11 @@ namespace l1t {
 
                   LogDebug("L1T") << "Mu" << nWord/2 << ": eta " << mu.hwEta() << " phi " << mu.hwPhi() << " pT " << mu.hwPt() << " qual " << mu.hwQual() << " sign " << mu.hwSign() << " sign valid " << mu.hwSignValid();
 
-                  res->push_back(bxBlock.header().getBx(), mu);
+                  res->push_back(bx, mu);
                }
             } else {
                unsigned int nWords = nWords_; // This seems unnecessary but it prevents an 'undefined reference' linker error that occurs when using nWords_ directly with LogWarning.
-               edm::LogWarning("L1T") << "Only " << bxPayload.size() << " 32 bit words in this BX but " << nWords << " are required. Not unpacking the data for BX " << bxBlock.header().getBx() << ".";
+               edm::LogWarning("L1T") << "Only " << bxPayload.size() << " 32 bit words in this BX but " << nWords << " are required. Not unpacking the data for BX " << bx << ".";
             }
          }
          return true;


### PR DESCRIPTION
backport of #21665 

This addresses the issue https://github.com/cms-l1t-offline/cmssw/issues/642 
The L1T muon unpacker was crashing when encountering an event with a corrupt uGT readout record.
Throwing an exception if a corrupt RO record is encountered since this data should not be used.