### PR TITLE
Switch PbPb relval wf (150) from2017 to 2018 conditions

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -755,7 +755,7 @@ U80by1={'--relval': '80,1'}
 hiAlca2011 = {'--conditions':'auto:run1_mc_hi'}
 hiAlca2015 = {'--conditions':'auto:run2_mc_hi', '--era':'Run2_HI'}
 hiAlca2017 = {'--conditions':'auto:phase1_2017_realistic', '--era':'Run2_2017_pp_on_XeXe'}
-hiAlca2018 = {'--conditions':'auto:phase1_2017_realistic', '--era':'Run2_2017'}
+hiAlca2018 = {'--conditions':'auto:phase1_2018_realistic', '--era':'Run2_2018'}
 
 
 hiDefaults2011=merge([hiAlca2011,{'--scenario':'HeavyIons','-n':2}])


### PR DESCRIPTION
This workflow is for the PbPb run in 2018.  We had been using 2017 conditions, since they were more stable.  With 2017 data-taking now behind us, it makes sense to switch for the 10XY release cycle. 
The vertex smearing remains unchanged from 2017, as it appears is the case in pp wfs.