### PR TITLE
Small updates and fixes for geometry comparison tool

### DIFF
--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
@@ -642,10 +642,13 @@ void TrackerGeometryCompare::compareGeometries(Alignable* refAli, Alignable* cur
 			// both local and global
 			diff = align::diffAlignables(refAli, curAli, _weightBy, _weightById, _weightByIdVector);
 			
-			CLHEP::Hep3Vector dR(-diff[0],-diff[1],-diff[2]);  // 'diffAlignables' returns 'refAli - curAli' for translations
-			CLHEP::Hep3Vector dW(diff[3],diff[4],diff[5]);  // 'diffAlignables' returns 'curAli - refAli' for rotations
-			CLHEP::Hep3Vector dRLocal(-diff[6],-diff[7],-diff[8]);  // 'diffAlignables' returns 'refAli - curAli' for translations
-			CLHEP::Hep3Vector dWLocal(diff[9],diff[10],diff[11]);  // 'diffAlignables' returns 'curAli - refAli' for rotations
+			// 'diffAlignables' returns 'refAli - curAli' for translations and 'curAli - refAli' for rotations.
+			// The plan is to unify this at some point, but a simple change of the sign for one of them was postponed
+			// to do some further checks to understand the rotations better
+			CLHEP::Hep3Vector dR(diff[0],diff[1],diff[2]);  
+			CLHEP::Hep3Vector dW(diff[3],diff[4],diff[5]);
+			CLHEP::Hep3Vector dRLocal(diff[6],diff[7],diff[8]);
+			CLHEP::Hep3Vector dWLocal(diff[9],diff[10],diff[11]);
 			
 			// Translations
 			Rtotal+=dR;

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
@@ -631,34 +631,59 @@ void TrackerGeometryCompare::compareGeometries(Alignable* refAli, Alignable* cur
 		Wtotal.set(0.,0.,0.);
 		lRtotal.set(0.,0.,0.); 
 		lWtotal.set(0.,0.,0.);
+		
+		bool converged = false;
+		
+		AlgebraicVector diff, check;
 
 		for (int i = 0; i < 100; i++){
-			AlgebraicVector diff = align::diffAlignables(refAli, curAli, _weightBy, _weightById, _weightByIdVector);
-			CLHEP::Hep3Vector dR(diff[0],diff[1],diff[2]);
-			Rtotal+=dR;
+			
+			// Get differences between alignments for rotations and translations
+			// both local and global
+			diff = align::diffAlignables(refAli, curAli, _weightBy, _weightById, _weightByIdVector);
+			
+			CLHEP::Hep3Vector dR(-diff[0],-diff[1],-diff[2]);
 			CLHEP::Hep3Vector dW(diff[3],diff[4],diff[5]);
+			CLHEP::Hep3Vector dRLocal(-diff[6],-diff[7],-diff[8]);
+			CLHEP::Hep3Vector dWLocal(diff[9],diff[10],diff[11]);
+			
+			// Translations
+			Rtotal+=dR;
+			lRtotal+=dRLocal;
+			
+			//Rotations
 			CLHEP::HepRotation rot(Wtotal.unit(),Wtotal.mag());
 			CLHEP::HepRotation drot(dW.unit(),dW.mag());
 			rot*=drot;
 			Wtotal.set(rot.axis().x()*rot.delta(), rot.axis().y()*rot.delta(), rot.axis().z()*rot.delta());
-			// local coordinates
-			lRtotal.set(diff[6],diff[7],diff[8]);
-			lWtotal.set(diff[9],diff[10],diff[11]);
 			
+			CLHEP::HepRotation rotLocal(lWtotal.unit(),lWtotal.mag());
+			CLHEP::HepRotation drotLocal(dWLocal.unit(),dWLocal.mag());
+			rotLocal*=drotLocal;
+			lWtotal.set(rotLocal.axis().x()*rotLocal.delta(), rotLocal.axis().y()*rotLocal.delta(), rotLocal.axis().z()*rotLocal.delta());
+			
+			// Move current alignable by shift and check if difference 
+			// is smaller than tolerance value
+			// if true, break the loop
 			align::moveAlignable(curAli, diff);
 			float tolerance = 1e-7;
-			AlgebraicVector check = align::diffAlignables(refAli, curAli, _weightBy, _weightById, _weightByIdVector);
+			check = align::diffAlignables(refAli, curAli, _weightBy, _weightById, _weightByIdVector);
 			align::GlobalVector checkR(check[0],check[1],check[2]);
 			align::GlobalVector checkW(check[3],check[4],check[5]);
-			if ((checkR.mag() > tolerance)||(checkW.mag() > tolerance)){
-				edm::LogInfo("TrackerGeometryCompare") << "Tolerance Exceeded!(alObjId: " << refAli->alignableObjectId()
-				<< ", rawId: " << refAli->geomDetId().rawId()
-				<< ", subdetId: "<< detid.subdetId() << "): " << diff;
-				throw cms::Exception("Tolerance in TrackerGeometryCompare exceeded");
-			}
-			else{
+			if ((checkR.mag() < tolerance)&&(checkW.mag() < tolerance))
+			{
+				converged = true;
 				break;
 			}
+		}
+		
+		// give an exception if difference has not fallen below tolerance level
+		// i.e. method has not converged 
+		if (!converged){
+			edm::LogInfo("TrackerGeometryCompare") << "Tolerance Exceeded!(alObjId: " << refAli->alignableObjectId()
+			<< ", rawId: " << refAli->geomDetId().rawId()
+			<< ", subdetId: "<< detid.subdetId() << "): " << diff << check;
+			throw cms::Exception("Tolerance in TrackerGeometryCompare exceeded");
 		}
 
 		AlgebraicVector TRtot(12);

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
@@ -642,10 +642,10 @@ void TrackerGeometryCompare::compareGeometries(Alignable* refAli, Alignable* cur
 			// both local and global
 			diff = align::diffAlignables(refAli, curAli, _weightBy, _weightById, _weightByIdVector);
 			
-			CLHEP::Hep3Vector dR(-diff[0],-diff[1],-diff[2]);
-			CLHEP::Hep3Vector dW(diff[3],diff[4],diff[5]);
-			CLHEP::Hep3Vector dRLocal(-diff[6],-diff[7],-diff[8]);
-			CLHEP::Hep3Vector dWLocal(diff[9],diff[10],diff[11]);
+			CLHEP::Hep3Vector dR(-diff[0],-diff[1],-diff[2]);  // 'diffAlignables' returns 'refAli - curAli' for translations
+			CLHEP::Hep3Vector dW(diff[3],diff[4],diff[5]);  // 'diffAlignables' returns 'curAli - refAli' for rotations
+			CLHEP::Hep3Vector dRLocal(-diff[6],-diff[7],-diff[8]);  // 'diffAlignables' returns 'refAli - curAli' for translations
+			CLHEP::Hep3Vector dWLocal(diff[9],diff[10],diff[11]);  // 'diffAlignables' returns 'curAli - refAli' for rotations
 			
 			// Translations
 			Rtotal+=dR;

--- a/Alignment/OfflineValidation/scripts/GeometryComparisonPlotter.h
+++ b/Alignment/OfflineValidation/scripts/GeometryComparisonPlotter.h
@@ -69,6 +69,7 @@ class GeometryComparisonPlotter
                           double y1,
                           double x2,  
                           double y2,
+                          int nPlottedSublevels,
                           const TString title = "");
 
 public:


### PR DESCRIPTION

![global_pixel_2_final](https://user-images.githubusercontent.com/6997559/33877772-aa699c3a-df29-11e7-8690-068f0ff014ce.png)
- Implemented a meaningful loop in TrackerGeometryCompare instead of one that either gives an exception or a 'break' at the first iteration
- Implemented comparison plots which show only the pixel (see example with quite large differences)