### PR TITLE
Add pushAndPause method to LimitedTaskQueue

### DIFF
--- a/FWCore/Concurrency/interface/LimitedTaskQueue.h
+++ b/FWCore/Concurrency/interface/LimitedTaskQueue.h
@@ -53,7 +53,7 @@ namespace edm {
        * \param[in] iAction Must be a functor that takes no arguments and return no values.
        */
       template<typename T>
-      void push(const T& iAction);
+      void push(T&& iAction);
       
       /// synchronously pushes functor iAction into queue
       /**
@@ -64,7 +64,56 @@ namespace edm {
        * \param[in] iAction Must be a functor that takes no arguments and return no values.
        */
       template<typename T>
-      void pushAndWait(const T& iAction);
+      void pushAndWait(T&& iAction);
+     
+      class Resumer {
+      public:
+         friend class LimitedTaskQueue;
+         
+         Resumer() = default;
+         ~Resumer(){
+            resume();
+         }
+
+         Resumer(Resumer&& iOther): m_queue(iOther.m_queue){
+            iOther.m_queue = nullptr;
+         }
+
+         Resumer(Resumer const& iOther): m_queue(iOther.m_queue) {
+            if(m_queue) {
+               m_queue->pause();
+            }
+         }
+
+         Resumer& operator=(Resumer const& iOther) {
+            auto t = iOther;
+            return (*this = std::move(t));
+         }
+         Resumer& operator=(Resumer&& iOther) {
+            if(m_queue) { m_queue->resume();}
+            m_queue = iOther.m_queue;
+            iOther.m_queue = nullptr;
+            return *this;
+         }
+         
+         bool resume() {
+            if(m_queue) {
+               return m_queue->resume();
+            }
+            return false;
+         }
+      private:
+         Resumer(SerialTaskQueue* iQueue): m_queue{iQueue}{}
+         SerialTaskQueue* m_queue=nullptr;
+      };
+
+      /// asynchronously pushes functor iAction into queue then pause the queue and run iAction
+      /** iAction must take as argument a copy of a LimitedTaskQueue::Resumer. To resume
+       the queue let the last copy of the Resumer go out of scope, or call Resumer::resume().
+       Using this function will decrease the allowed concurrency limit by 1.
+       */
+      template<typename T>
+      void pushAndPause(T&& iAction);
      
      unsigned int concurrencyLimit() const { return m_queues.size(); }
    private:
@@ -76,10 +125,10 @@ namespace edm {
    };
    
    template<typename T>
-   void LimitedTaskQueue::push(const T& iAction) {
+   void LimitedTaskQueue::push(T&& iAction) {
      auto set_to_run = std::make_shared<std::atomic<bool>>(false);
      for(auto& q: m_queues) {
-       q.push([set_to_run,iAction]() {
+       q.push([set_to_run,iAction]() mutable{
          bool expected = false;
          if(set_to_run->compare_exchange_strong(expected,true)) {
            iAction();
@@ -89,12 +138,12 @@ namespace edm {
    }
    
    template<typename T>
-   void LimitedTaskQueue::pushAndWait(const T& iAction) {
+   void LimitedTaskQueue::pushAndWait(T&& iAction) {
       tbb::empty_task* waitTask = new (tbb::task::allocate_root()) tbb::empty_task;
       waitTask->set_ref_count(2);
      auto set_to_run = std::make_shared<std::atomic<bool>>(false);
      for(auto& q: m_queues) {
-       q.push([set_to_run,waitTask,iAction]() {
+       q.push([set_to_run,waitTask,iAction]() mutable{
          bool expected = false;
          if(set_to_run->compare_exchange_strong(expected,true)) {
            try {
@@ -107,7 +156,21 @@ namespace edm {
      waitTask->wait_for_all();
      tbb::task::destroy(*waitTask);
    }
-   
+  
+   template<typename T>
+   void LimitedTaskQueue::pushAndPause(T&& iAction) {
+      auto set_to_run = std::make_shared<std::atomic<bool>>(false);
+      for(auto& q: m_queues) {
+         q.push([&q,set_to_run,iAction]() mutable{
+            bool expected = false;
+            if(set_to_run->compare_exchange_strong(expected,true)) {
+               q.pause();
+               iAction(Resumer(&q));
+            }
+         });
+      }
+   }
+  
 }
 
 #endif

--- a/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
@@ -19,12 +19,14 @@ class LimitedTaskQueue_test : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(LimitedTaskQueue_test);
   CPPUNIT_TEST(testPush);
   CPPUNIT_TEST(testPushAndWait);
+  CPPUNIT_TEST(testPause);
   CPPUNIT_TEST(stressTest);
   CPPUNIT_TEST_SUITE_END();
   
 public:
   void testPush();
   void testPushAndWait();
+  void testPause();
   void stressTest();
   void setUp(){}
   void tearDown(){}
@@ -174,6 +176,63 @@ void LimitedTaskQueue_test::testPushAndWait()
     }
   }
 
+}
+void LimitedTaskQueue_test::testPause()
+{
+  std::atomic<unsigned int> count{0};
+  
+  edm::LimitedTaskQueue queue{1};
+  {
+    {
+      std::shared_ptr<tbb::task> waitTask{new (tbb::task::allocate_root()) tbb::empty_task{},
+        [](tbb::task* iTask){tbb::task::destroy(*iTask);} };
+      waitTask->set_ref_count(1+3);
+      tbb::task* pWaitTask = waitTask.get();
+      edm::LimitedTaskQueue::Resumer resumer;
+      std::atomic<bool> resumerSet{false};
+      std::exception_ptr e1;
+      queue.pushAndPause([&resumer,&resumerSet,&count,&queue,pWaitTask,&e1](edm::LimitedTaskQueue::Resumer iResumer){
+        resumer = std::move(iResumer);
+        resumerSet = true;
+        try {
+          CPPUNIT_ASSERT(++count == 1);
+        } catch(...) {
+          e1 = std::current_exception();
+        }
+        pWaitTask->decrement_ref_count();
+      });
+
+      std::exception_ptr e2;
+      queue.push([&count,&queue,pWaitTask,&e2]{
+        try{
+          CPPUNIT_ASSERT(++count == 2);
+        } catch(...) {
+          e2 = std::current_exception();
+        }
+        pWaitTask->decrement_ref_count();
+      });
+      
+      std::exception_ptr e3;
+      queue.push([&count,&queue,pWaitTask,&e3]{
+        try {
+          CPPUNIT_ASSERT(++count == 3);
+        }catch(...){
+          e3 = std::current_exception();
+        }
+        pWaitTask->decrement_ref_count();
+      });
+      usleep(100);
+      //can't do == since the queue may not have processed the first task yet
+      CPPUNIT_ASSERT(2>=count);
+      while(not resumerSet) {}
+      CPPUNIT_ASSERT(resumer.resume());
+      waitTask->wait_for_all();
+      CPPUNIT_ASSERT(count==3);
+      if(e1) { std::rethrow_exception(e1);}
+      if(e2) { std::rethrow_exception(e2);}
+      if(e3) { std::rethrow_exception(e3);}
+    }
+  }
 }
 
 void LimitedTaskQueue_test::stressTest()


### PR DESCRIPTION
Add a mechanism to decrease the limit by one temporarily. This is done by calling pushAndPause.
As part, changed functor argument to be a universal reference.