### PR TITLE
Change in BTagCalibration Scale Factor for eta out of bounds

### DIFF
--- a/CondTools/BTau/interface/BTagCalibrationReader.h
+++ b/CondTools/BTau/interface/BTagCalibrationReader.h
@@ -44,7 +44,6 @@ public:
   std::pair<float, float> min_max_pt(BTagEntry::JetFlavor jf,
                                      float eta,
                                      float discr=0.) const;
-
 protected:
   std::shared_ptr<BTagCalibrationReaderImpl> pimpl;
 };

--- a/CondTools/BTau/src/BTagCalibrationReader.cc
+++ b/CondTools/BTau/src/BTagCalibrationReader.cc
@@ -40,6 +40,9 @@ private:
   std::pair<float, float> min_max_pt(BTagEntry::JetFlavor jf,
                                      float eta,
                                      float discr) const;
+ 
+  std::pair<float, float> min_max_eta(BTagEntry::JetFlavor jf,
+                                     float discr) const;
 
   BTagEntry::OperatingPoint op_;
   std::string sysType_;
@@ -133,7 +136,7 @@ double BTagCalibrationReader::BTagCalibrationReaderImpl::eval(
   for (unsigned i=0; i<entries.size(); ++i) {
     const auto &e = entries.at(i);
     if (
-      e.etaMin <= eta && eta < e.etaMax                   // find eta
+      e.etaMin <= eta && eta <= e.etaMax                   // find eta
       && e.ptMin < pt && pt <= e.ptMax                    // check pt
     ){
       if (use_discr) {                                    // discr. reshaping?
@@ -156,11 +159,24 @@ double BTagCalibrationReader::BTagCalibrationReaderImpl::eval_auto_bounds(
                                              float pt,
                                              float discr) const
 {
-  auto sf_bounds = min_max_pt(jf, eta, discr);
-  float pt_for_eval = pt;
-  bool is_out_of_bounds = false;
+  auto sf_bounds_eta = min_max_eta(jf, discr);
+  bool eta_is_out_of_bounds = false;
 
-  if (pt <= sf_bounds.first) {
+  if (sf_bounds_eta.first < 0) sf_bounds_eta.first = -sf_bounds_eta.second;   
+  if (eta <= sf_bounds_eta.first || eta > sf_bounds_eta.second ) {
+    eta_is_out_of_bounds = true;
+  }
+   
+  if (eta_is_out_of_bounds) {
+    return 1.;
+  }
+
+
+   auto sf_bounds = min_max_pt(jf, eta, discr);
+   float pt_for_eval = pt;
+   bool is_out_of_bounds = false;
+
+   if (pt <= sf_bounds.first) {
     pt_for_eval = sf_bounds.first + .0001;
     is_out_of_bounds = true;
   } else if (pt > sf_bounds.second) {
@@ -204,7 +220,7 @@ std::pair<float, float> BTagCalibrationReader::BTagCalibrationReaderImpl::min_ma
   float min_pt = -1., max_pt = -1.;
   for (const auto & e: entries) {
     if (
-      e.etaMin <= eta && eta < e.etaMax                   // find eta
+      e.etaMin <= eta && eta <=e.etaMax                   // find eta
     ){
       if (min_pt < 0.) {                                  // init
         min_pt = e.ptMin;
@@ -225,6 +241,31 @@ std::pair<float, float> BTagCalibrationReader::BTagCalibrationReaderImpl::min_ma
   }
 
   return std::make_pair(min_pt, max_pt);
+}
+
+std::pair<float, float> BTagCalibrationReader::BTagCalibrationReaderImpl::min_max_eta(
+                                               BTagEntry::JetFlavor jf,
+                                               float discr) const
+{
+  bool use_discr = (op_ == BTagEntry::OP_RESHAPING);
+
+  const auto &entries = tmpData_.at(jf);
+  float min_eta = 0., max_eta = 0.;
+  for (const auto & e: entries) {
+
+      if (use_discr) {                                    // discr. reshaping?
+        if (e.discrMin <= discr && discr < e.discrMax) {  // check discr
+          min_eta = min_eta < e.etaMin ? min_eta : e.etaMin;
+          max_eta = max_eta > e.etaMax ? max_eta : e.etaMax;
+        }
+      } else {
+        min_eta = min_eta < e.etaMin ? min_eta : e.etaMin;
+        max_eta = max_eta > e.etaMax ? max_eta : e.etaMax;
+      }
+    }
+
+
+  return std::make_pair(min_eta, max_eta);
 }
 
 
@@ -263,3 +304,5 @@ std::pair<float, float> BTagCalibrationReader::min_max_pt(BTagEntry::JetFlavor j
 {
   return pimpl->min_max_pt(jf, eta, discr);
 }
+
+

--- a/CondTools/BTau/src/BTagCalibrationReader.cc
+++ b/CondTools/BTau/src/BTagCalibrationReader.cc
@@ -78,7 +78,7 @@ void BTagCalibrationReader::BTagCalibrationReaderImpl::load(
                                              BTagEntry::JetFlavor jf,
                                              std::string measurementType)
 {
-  if (tmpData_[jf].size()) {
+  if (!tmpData_[jf].empty()) {
     throw cms::Exception("BTagCalibrationReader")
           << "Data for this jet-flavor is already loaded: "
           << jf;

--- a/CondTools/BTau/test/BTagCalibrationStandalone.cpp
+++ b/CondTools/BTau/test/BTagCalibrationStandalone.cpp
@@ -404,6 +404,9 @@ private:
   std::pair<float, float> min_max_pt(BTagEntry::JetFlavor jf,
                                      float eta,
                                      float discr) const;
+ 
+  std::pair<float, float> min_max_eta(BTagEntry::JetFlavor jf,
+                                     float discr) const;
 
   BTagEntry::OperatingPoint op_;
   std::string sysType_;
@@ -499,7 +502,7 @@ double BTagCalibrationReader::BTagCalibrationReaderImpl::eval(
   for (unsigned i=0; i<entries.size(); ++i) {
     const auto &e = entries.at(i);
     if (
-      e.etaMin <= eta && eta < e.etaMax                   // find eta
+      e.etaMin <= eta && eta <= e.etaMax                   // find eta
       && e.ptMin < pt && pt <= e.ptMax                    // check pt
     ){
       if (use_discr) {                                    // discr. reshaping?
@@ -522,11 +525,24 @@ double BTagCalibrationReader::BTagCalibrationReaderImpl::eval_auto_bounds(
                                              float pt,
                                              float discr) const
 {
-  auto sf_bounds = min_max_pt(jf, eta, discr);
-  float pt_for_eval = pt;
-  bool is_out_of_bounds = false;
+  auto sf_bounds_eta = min_max_eta(jf, discr);
+  bool eta_is_out_of_bounds = false;
 
-  if (pt < sf_bounds.first) {
+  if (sf_bounds_eta.first < 0) sf_bounds_eta.first = -sf_bounds_eta.second;   
+  if (eta <= sf_bounds_eta.first || eta > sf_bounds_eta.second ) {
+    eta_is_out_of_bounds = true;
+  }
+   
+  if (eta_is_out_of_bounds) {
+    return 1.;
+  }
+
+
+   auto sf_bounds = min_max_pt(jf, eta, discr);
+   float pt_for_eval = pt;
+   bool is_out_of_bounds = false;
+
+   if (pt <= sf_bounds.first) {
     pt_for_eval = sf_bounds.first + .0001;
     is_out_of_bounds = true;
   } else if (pt > sf_bounds.second) {
@@ -571,7 +587,7 @@ std::pair<float, float> BTagCalibrationReader::BTagCalibrationReaderImpl::min_ma
   float min_pt = -1., max_pt = -1.;
   for (const auto & e: entries) {
     if (
-      e.etaMin <= eta && eta < e.etaMax                   // find eta
+      e.etaMin <= eta && eta <=e.etaMax                   // find eta
     ){
       if (min_pt < 0.) {                                  // init
         min_pt = e.ptMin;
@@ -592,6 +608,31 @@ std::pair<float, float> BTagCalibrationReader::BTagCalibrationReaderImpl::min_ma
   }
 
   return std::make_pair(min_pt, max_pt);
+}
+
+std::pair<float, float> BTagCalibrationReader::BTagCalibrationReaderImpl::min_max_eta(
+                                               BTagEntry::JetFlavor jf,
+                                               float discr) const
+{
+  bool use_discr = (op_ == BTagEntry::OP_RESHAPING);
+
+  const auto &entries = tmpData_.at(jf);
+  float min_eta = 0., max_eta = 0.;
+  for (const auto & e: entries) {
+
+      if (use_discr) {                                    // discr. reshaping?
+        if (e.discrMin <= discr && discr < e.discrMax) {  // check discr
+          min_eta = min_eta < e.etaMin ? min_eta : e.etaMin;
+          max_eta = max_eta > e.etaMax ? max_eta : e.etaMax;
+        }
+      } else {
+        min_eta = min_eta < e.etaMin ? min_eta : e.etaMin;
+        max_eta = max_eta > e.etaMax ? max_eta : e.etaMax;
+      }
+    }
+
+
+  return std::make_pair(min_eta, max_eta);
 }
 
 
@@ -630,5 +671,7 @@ std::pair<float, float> BTagCalibrationReader::min_max_pt(BTagEntry::JetFlavor j
 {
   return pimpl->min_max_pt(jf, eta, discr);
 }
+
+
 
 

--- a/CondTools/BTau/test/BTagCalibrationStandalone.h
+++ b/CondTools/BTau/test/BTagCalibrationStandalone.h
@@ -178,7 +178,6 @@ public:
   std::pair<float, float> min_max_pt(BTagEntry::JetFlavor jf,
                                      float eta,
                                      float discr=0.) const;
-
 protected:
   std::shared_ptr<BTagCalibrationReaderImpl> pimpl;
 };

--- a/CondTools/BTau/test/testBTagCalibrationReader.cpp
+++ b/CondTools/BTau/test/testBTagCalibrationReader.cpp
@@ -59,12 +59,19 @@ int main()
   assert (eq(bcr3.eval_auto_bounds("central", BTagEntry::FLAV_C, 0.5, 100.), 200., 1e-3));
   assert (eq(bcr3.eval_auto_bounds("up",      BTagEntry::FLAV_C, 0.5, 100.), 210., 1e-3));
   assert (eq(bcr3.eval_auto_bounds("down",    BTagEntry::FLAV_C, 0.5, 100.), 190., 1e-3));
-  assert (eq(bcr3.eval_auto_bounds("central", BTagEntry::FLAV_C, 0.5, 20.), 100., 1e-3));  // low
-  assert (eq(bcr3.eval_auto_bounds("up",      BTagEntry::FLAV_C, 0.5, 20.), 110., 1e-3));  // low
-  assert (eq(bcr3.eval_auto_bounds("down",    BTagEntry::FLAV_C, 0.5, 20.),  90., 1e-3));  // low
-  assert (eq(bcr3.eval_auto_bounds("central", BTagEntry::FLAV_C, 0.5, 999.), 1000., 1e-3));  // high
-  assert (eq(bcr3.eval_auto_bounds("up",      BTagEntry::FLAV_C, 0.5, 999.), 1100., 1e-3));  // high
-  assert (eq(bcr3.eval_auto_bounds("down",    BTagEntry::FLAV_C, 0.5, 999.),  900., 1e-3));  // high
+  assert (eq(bcr3.eval_auto_bounds("central", BTagEntry::FLAV_C, 0.5, 20.), 100., 1e-3));  // low pt
+  assert (eq(bcr3.eval_auto_bounds("up",      BTagEntry::FLAV_C, 0.5, 20.), 110., 1e-3));  // low pt
+  assert (eq(bcr3.eval_auto_bounds("down",    BTagEntry::FLAV_C, 0.5, 20.),  90., 1e-3));  // low pt
+  assert (eq(bcr3.eval_auto_bounds("central", BTagEntry::FLAV_C, 0.5, 999.), 1000., 1e-3));  // high pt
+  assert (eq(bcr3.eval_auto_bounds("up",      BTagEntry::FLAV_C, 0.5, 999.), 1100., 1e-3));  // high pt
+  assert (eq(bcr3.eval_auto_bounds("down",    BTagEntry::FLAV_C, 0.5, 999.),  900., 1e-3));  // high pt
+  assert (eq(bcr3.eval_auto_bounds("central", BTagEntry::FLAV_C, 2.5, 100.), 1., 1e-3));   // eta out of bounds
+  assert (eq(bcr3.eval_auto_bounds("up",      BTagEntry::FLAV_C, 2.5, 100.), 1., 1e-3));   // eta out of bounds
+  assert (eq(bcr3.eval_auto_bounds("down",    BTagEntry::FLAV_C, 2.5, 100.), 1., 1e-3));   // eta out of bounds
+  assert (eq(bcr3.eval_auto_bounds("central", BTagEntry::FLAV_C, -2.5, 100.), 1., 1e-3));   // eta out of bounds
+  assert (eq(bcr3.eval_auto_bounds("up",      BTagEntry::FLAV_C, -2.5, 100.), 1., 1e-3));   // eta out of bounds
+  assert (eq(bcr3.eval_auto_bounds("down",    BTagEntry::FLAV_C, -2.5, 100.), 1., 1e-3));   // eta out of bounds
 
-  return 0;
+ 
+ return 0.;
 }


### PR DESCRIPTION
- Implemented changes for SF = 1 at eta>2.4 by defining min_max_eta function, calling it inside eval_auto_bounds function and comparing eta with bounds returned by min_max_eta function.

- Implemented same changes for standalone version of BTagCalibration.