### PR TITLE
impose TMPDIR=/tmp/$USER

### DIFF
--- a/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
@@ -157,12 +157,10 @@ int Unzip(std::string infile, std::string outfile)
     /////////////////////////////////////////////
     /////////////// BUG FIX FOR MPI /////////////
     /////////////////////////////////////////////
-    std::string user = getenv("USER");
-    std::string tmpdir = "/tmp/"+user;
-    std::string command = "mkdir -p "+tmpdir;
-    system(command.c_str());
-    setenv("TMPDIR",tmpdir.c_str(), true);
-    tmpdir = getenv("TMPDIR");
+    const char *tmpdir = getenv("TMPDIR");
+    if (tmpdir && (strlen(tmpdir) > 50)) {
+        setenv("TMPDIR", "/tmp", true);
+    }
     /////////////////////////////////////////////
     /////////////////////////////////////////////
     /////////////////////////////////////////////

--- a/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
@@ -154,13 +154,18 @@ void zerr(int ret)
 /* compress or decompress from stdin to stdout */
 int Unzip(std::string infile, std::string outfile)
 {
-    std::string tmpdir = getenv("TMPDIR");
-    if (tmpdir.size() > 50 ){
-      std::string command = "ln -s $PWD "+tmpdir+"/tmp;";
-      system(command.c_str());
-      command = tmpdir+"/tmp";
-      setenv("TMPDIR",command.c_str(), true);
-    }
+    /////////////////////////////////////////////
+    /////////////// BUG FIX FOR MPI /////////////
+    /////////////////////////////////////////////
+    std::string user = getenv("USER");
+    std::string tmpdir = "/tmp/"+user;
+    std::string command = "mkdir -p "+tmpdir;
+    system(command.c_str());
+    setenv("TMPDIR",tmpdir.c_str(), true);
+    tmpdir = getenv("TMPDIR");
+    /////////////////////////////////////////////
+    /////////////////////////////////////////////
+    /////////////////////////////////////////////
     int ret;
 	FILE *in = fopen(infile.c_str(),"r");
 	if (!in) return -1;


### PR DESCRIPTION
further evolution of https://github.com/cms-sw/cmssw/pull/21419
according to
https://www.open-mpi.org/faq/?category=osx#startup-errors-with-open-mpi-2.0.x
The workaround for the Open MPI 2.0.x and v2.1.x release series is to set the TMPDIR environment variable to /tmp or other short directory name.
As far as I see from the example, the directory created in the TMPDIR path should be unique and related to the MPI session.
Most important, the written data seems to be cleaned up by MPI after use (i.e. if I point TMPDIR to any directory, it is empty after the job has either succeeded or failed)
@Dr15Jones @bbockelm