### PR TITLE
Fix HE depth access in jet code

### DIFF
--- a/DQMOffline/Trigger/src/JetMETHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/src/JetMETHLTOfflineSource.cc
@@ -210,7 +210,7 @@ JetMETHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetup&
   auto calojet_ = calojet.begin();
   for(; calojet_ != calojet.end(); ++calojet_){
     double scale = calocorrector->correction(*calojet_);	
-    jetID->calculate(iEvent, *calojet_);
+    jetID->calculate(iEvent, iSetup, *calojet_);
     
     if(scale*calojet_->pt()>CaloJetPt[0]){
       CaloJetPt[1]   = CaloJetPt[0]; 

--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -104,6 +104,9 @@ public:
   void depthBinInformation(HcalSubdetector subdet, int etaRing,
 			   int iphi, int zside, int & nDepthBins,
 			   int & startingBin) const;
+  bool mergedDepth29(HcalDetId id) const {
+    return hcons_->mergedDepthList29(id.ieta(), id.iphi(), id.depth());
+  }
   std::vector<int> mergedDepthList29(HcalDetId id) const {
     return hcons_->mergedDepthList29(id.ieta(), id.iphi());
   }

--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -104,6 +104,9 @@ public:
   void depthBinInformation(HcalSubdetector subdet, int etaRing,
 			   int iphi, int zside, int & nDepthBins,
 			   int & startingBin) const;
+  std::vector<int> mergedDepthList29(HcalDetId id) const {
+    return hcons_->mergedDepthList29(id.ieta(), id.iphi());
+  }
 
   /// how many phi segments in this ring
   int nPhiBins(int etaRing) const;

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalCalibDetId.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"

--- a/Geometry/CaloTopology/test/HcalTopologyTester.cc
+++ b/Geometry/CaloTopology/test/HcalTopologyTester.cc
@@ -145,7 +145,9 @@ void HcalTopologyTester::doTest(const HcalTopology& topology) {
 	HcalDetId cell (HcalEndcap, eta, phi, depth);
 	if (topology.valid(cell)) {
 	  std::vector<int> depths = topology.mergedDepthList29(cell);
-	  std::cout << cell << " has " << depths.size() << " merged depths:";
+	  std::cout << cell << " is with merge depth flag " 
+		    << topology.mergedDepth29(cell) << " having " << depths.size()
+		    << " merged depths:";
 	  for (unsigned int k=0; k<depths.size(); ++k) 
 	    std::cout << " [" << k << "]:" << depths[k];
 	  std::cout << std::endl;

--- a/Geometry/CaloTopology/test/HcalTopologyTester.cc
+++ b/Geometry/CaloTopology/test/HcalTopologyTester.cc
@@ -65,6 +65,8 @@ void HcalTopologyTester::analyze(edm::Event const&, edm::EventSetup const& iSetu
 void HcalTopologyTester::doTest(const HcalTopology& topology) {
 
   // First test on movements along eta/phi directions
+  std::cout << "\nTest on movements along eta/phi directions" << std::endl
+	    << "==========================================" << std::endl;
   for (int idet=0; idet<4; idet++) {
     HcalSubdetector subdet = HcalBarrel;
     if (idet == 1)      subdet = HcalOuter;
@@ -108,7 +110,8 @@ void HcalTopologyTester::doTest(const HcalTopology& topology) {
   }
 
   // Check on Dense Index
-
+  std::cout << "\nCheck on Dense Index" << std::endl
+	    << "=====================" << std::endl;
   int maxDepthHB = topology.maxDepthHB();
   int maxDepthHE = topology.maxDepthHE();
   for (int det = 1; det <= HcalForward; det++) {
@@ -128,6 +131,24 @@ void HcalTopologyTester::doTest(const HcalTopology& topology) {
 			<< " o/p " << HcalDetId(id) << " **** ERROR *****" 
 			<< std::endl;
 	  }
+	}
+      }
+    }
+  }
+
+  // Check list of depths
+  std::cout << "\nCheck list of Depths" << std::endl
+	    << "====================" << std::endl;
+  for (int eta=topology.lastHERing()-2; eta<=topology.lastHERing(); ++eta) {
+    for (int phi = 0; phi <= HcalDetId::kHcalPhiMask2; phi++) {
+      for (int depth = 1; depth <  maxDepthHE; depth++) {
+	HcalDetId cell (HcalEndcap, eta, phi, depth);
+	if (topology.valid(cell)) {
+	  std::vector<int> depths = topology.mergedDepthList29(cell);
+	  std::cout << cell << " has " << depths.size() << " merged depths:";
+	  for (unsigned int k=0; k<depths.size(); ++k) 
+	    std::cout << " [" << k << "]:" << depths[k];
+	  std::cout << std::endl;
 	}
       }
     }

--- a/Geometry/CaloTopology/test/HcalTopologyTester.cc
+++ b/Geometry/CaloTopology/test/HcalTopologyTester.cc
@@ -141,7 +141,7 @@ void HcalTopologyTester::doTest(const HcalTopology& topology) {
 	    << "====================" << std::endl;
   for (int eta=topology.lastHERing()-2; eta<=topology.lastHERing(); ++eta) {
     for (int phi = 0; phi <= HcalDetId::kHcalPhiMask2; phi++) {
-      for (int depth = 1; depth <  maxDepthHE; depth++) {
+      for (int depth = 1; depth <=  maxDepthHE; depth++) {
 	HcalDetId cell (HcalEndcap, eta, phi, depth);
 	if (topology.valid(cell)) {
 	  std::vector<int> depths = topology.mergedDepthList29(cell);

--- a/Geometry/CaloTopology/test/testHcalTopology_cfg.py
+++ b/Geometry/CaloTopology/test/testHcalTopology_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("PROD")
 process.load("SimGeneral.HepPDTESSource.pdt_cfi")
 
-process.load("Geometry.HcalCommonData.testPhase2GeometryFineXML_cfi")
+process.load("Geometry.HcalCommonData.testGeometry17bXML_cfi")
 process.load("Geometry.HcalCommonData.hcalDDConstants_cff")
 process.load("Geometry.HcalEventSetup.hcalTopologyIdeal_cfi")
 

--- a/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
@@ -114,6 +114,7 @@ public:
   bool                      isBH() const {return hcons.isBH();}
   bool                      isPlan1(const HcalDetId& id) const { return detIdSp_.find(id) != detIdSp_.end(); };
   int                       maxHFDepth(int ieta, int iphi) const {return hcons.maxHFDepth(ieta,iphi);}
+  bool                      mergedDepthList29(int ieta, int iphi, int depth) const;
   std::vector<int>          mergedDepthList29(int ieta, int iphi) const;
   unsigned int              numberOfCells(HcalSubdetector) const;
   unsigned int              nCells(HcalSubdetector) const;

--- a/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
@@ -114,6 +114,7 @@ public:
   bool                      isBH() const {return hcons.isBH();}
   bool                      isPlan1(const HcalDetId& id) const { return detIdSp_.find(id) != detIdSp_.end(); };
   int                       maxHFDepth(int ieta, int iphi) const {return hcons.maxHFDepth(ieta,iphi);}
+  std::vector<int>          mergedDepthList29(int ieta, int iphi) const;
   unsigned int              numberOfCells(HcalSubdetector) const;
   unsigned int              nCells(HcalSubdetector) const;
   unsigned int              nCells() const;

--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -614,6 +614,19 @@ HcalDDDRecConstants::HcalCellTypes(HcalSubdetector subdet) const {
   }
 }
 
+bool HcalDDDRecConstants::mergedDepthList29(int ieta, int iphi, int depth) const {
+  bool merge(false);
+  int eta   = (ieta > 0) ? ieta : -ieta;
+  int zside = (ieta > 0) ? 1 : -1;
+  int etamin= iEtaMax[1]-hcons.getDepthEta29(iphi,zside,1);
+  if ((eta >= etamin) && (eta <= iEtaMax[1])) {
+    int depthMax = getMaxDepth(1, etamin, iphi, zside);
+    int depthMin = hcons.getDepthEta29(iphi,zside,0) + 1;
+    if (depth >= depthMin && depth <= depthMax) merge = true;
+  }
+  return merge;
+}
+
 std::vector<int> HcalDDDRecConstants::mergedDepthList29(int ieta, int iphi) const {
   std::vector<int> depths;
   int eta   = (ieta > 0) ? ieta : -ieta;
@@ -622,6 +635,7 @@ std::vector<int> HcalDDDRecConstants::mergedDepthList29(int ieta, int iphi) cons
   if ((eta >= etamin) && (eta <= iEtaMax[1])) {
     int depthMax = getMaxDepth(1, etamin, iphi, zside);
     int depthMin = hcons.getDepthEta29(iphi,zside,0) + 1;
+    depths.reserve(depthMax-depthMin+1);
     for (int depth=depthMin; depth <= depthMax; ++depth)
       depths.emplace_back(depth);
   }

--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -615,21 +615,20 @@ HcalDDDRecConstants::HcalCellTypes(HcalSubdetector subdet) const {
 }
 
 bool HcalDDDRecConstants::mergedDepthList29(int ieta, int iphi, int depth) const {
-  bool merge(false);
-  int eta   = (ieta > 0) ? ieta : -ieta;
+  int eta   = std::abs(ieta);
   int zside = (ieta > 0) ? 1 : -1;
   int etamin= iEtaMax[1]-hcons.getDepthEta29(iphi,zside,1);
   if ((eta >= etamin) && (eta <= iEtaMax[1])) {
     int depthMax = getMaxDepth(1, etamin, iphi, zside);
     int depthMin = hcons.getDepthEta29(iphi,zside,0) + 1;
-    if (depth >= depthMin && depth <= depthMax) merge = true;
+    if (depth >= depthMin && depth <= depthMax) return true;
   }
-  return merge;
+  return false;
 }
 
 std::vector<int> HcalDDDRecConstants::mergedDepthList29(int ieta, int iphi) const {
   std::vector<int> depths;
-  int eta   = (ieta > 0) ? ieta : -ieta;
+  int eta   = std::abs(ieta);
   int zside = (ieta > 0) ? 1 : -1;
   int etamin= iEtaMax[1]-hcons.getDepthEta29(iphi,zside,1);
   if ((eta >= etamin) && (eta <= iEtaMax[1])) {

--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -614,6 +614,20 @@ HcalDDDRecConstants::HcalCellTypes(HcalSubdetector subdet) const {
   }
 }
 
+std::vector<int> HcalDDDRecConstants::mergedDepthList29(int ieta, int iphi) const {
+  std::vector<int> depths;
+  int eta   = (ieta > 0) ? ieta : -ieta;
+  int zside = (ieta > 0) ? 1 : -1;
+  if ((eta >= (iEtaMax[1]-hcons.getDepthEta29(iphi,zside,1))) &&
+      (eta <= iEtaMax[1])) {
+    unsigned int depthMax = (unsigned int)(hcons.getDepthEta29(iphi,zside,0));
+    for (unsigned int depth=layerGroup(eta,0); depth <= depthMax; ++depth)
+      depths.emplace_back(depth);
+  }
+  return depths;
+}
+
+
 unsigned int HcalDDDRecConstants::numberOfCells(HcalSubdetector subdet) const {
 
   if (subdet == HcalBarrel || subdet == HcalEndcap) {

--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -618,10 +618,11 @@ std::vector<int> HcalDDDRecConstants::mergedDepthList29(int ieta, int iphi) cons
   std::vector<int> depths;
   int eta   = (ieta > 0) ? ieta : -ieta;
   int zside = (ieta > 0) ? 1 : -1;
-  if ((eta >= (iEtaMax[1]-hcons.getDepthEta29(iphi,zside,1))) &&
-      (eta <= iEtaMax[1])) {
-    unsigned int depthMax = (unsigned int)(hcons.getDepthEta29(iphi,zside,0));
-    for (unsigned int depth=layerGroup(eta,0); depth <= depthMax; ++depth)
+  int etamin= iEtaMax[1]-hcons.getDepthEta29(iphi,zside,1);
+  if ((eta >= etamin) && (eta <= iEtaMax[1])) {
+    int depthMax = getMaxDepth(1, etamin, iphi, zside);
+    int depthMin = hcons.getDepthEta29(iphi,zside,0) + 1;
+    for (int depth=depthMin; depth <= depthMax; ++depth)
       depths.emplace_back(depth);
   }
   return depths;

--- a/HLTrigger/JetMET/src/HLTCaloJetIDProducer.cc
+++ b/HLTrigger/JetMET/src/HLTCaloJetIDProducer.cc
@@ -71,7 +71,7 @@ void HLTCaloJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
             pass = true;
 
         } else {
-            if (min_N90hits_ > 0)  jetIDHelper_.calculate(iEvent, j);
+	    if (min_N90hits_ > 0)  jetIDHelper_.calculate(iEvent, iSetup, j);
             if ((j.emEnergyFraction() >= min_EMF_) &&
                 (j.emEnergyFraction() <= max_EMF_) &&
                 (j.n90() >= min_N90_) &&

--- a/RecoJets/JetProducers/interface/JetIDHelper.h
+++ b/RecoJets/JetProducers/interface/JetIDHelper.h
@@ -99,7 +99,7 @@ namespace reco {
 	HFneg, HEneg, HBneg, HBpos, HEpos, HFpos };
       
       int HBHE_oddness( int iEta, int depth );
-      Region HBHE_region( int iEta, int depth );
+      Region HBHE_region( uint32_t );
       // tower-based. -1 means can't figure it out
       int HBHE_oddness( int iEta );
       Region region( int iEta );

--- a/RecoJets/JetProducers/interface/JetIDHelper.h
+++ b/RecoJets/JetProducers/interface/JetIDHelper.h
@@ -105,7 +105,6 @@ namespace reco {
       // tower-based. -1 means can't figure it out
       int HBHE_oddness( int iEta );
       Region region( int iEta );
-      std::vector<bool> computeGeom( const edm::EventSetup& setup );
 
       double fHPD_;
       double fRBX_;

--- a/RecoJets/JetProducers/interface/JetIDHelper.h
+++ b/RecoJets/JetProducers/interface/JetIDHelper.h
@@ -11,6 +11,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -32,7 +33,7 @@ namespace reco {
       void initValues ();
 
       // interface
-      void calculate( const edm::Event& event, const reco::CaloJet &jet, const int iDbg = 0 );
+      void calculate( const edm::Event& event, const edm::EventSetup& setup, const reco::CaloJet &jet, const int iDbg = 0 );
 
       // member access
       
@@ -74,7 +75,8 @@ namespace reco {
 
      
       // helper functions
-      void classifyJetComponents( const edm::Event& event, const reco::CaloJet &jet, 
+      void classifyJetComponents( const edm::Event& event, const edm::EventSetup& setup,
+				  const reco::CaloJet &jet, 
 				  std::vector< double > &energies,
 				  std::vector< double > &subdet_energies,
 				  std::vector< double > &Ecal_energies, std::vector< double > &Hcal_energies, 
@@ -103,7 +105,7 @@ namespace reco {
       // tower-based. -1 means can't figure it out
       int HBHE_oddness( int iEta );
       Region region( int iEta );
-      
+      std::vector<bool> computeGeom( const edm::EventSetup& setup );
 
       double fHPD_;
       double fRBX_;

--- a/RecoJets/JetProducers/plugins/JetIDProducer.cc
+++ b/RecoJets/JetProducers/plugins/JetIDProducer.cc
@@ -61,7 +61,7 @@ JetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	ijet != jetsEnd; ++ijet ) {
 
     // get the id from each jet
-    helper_.calculate( iEvent, *ijet );
+    helper_.calculate( iEvent, iSetup, *ijet );
 
     muHelper_.calculate( iEvent, iSetup, *ijet );
 

--- a/RecoJets/JetProducers/src/JetIDHelper.cc
+++ b/RecoJets/JetProducers/src/JetIDHelper.cc
@@ -353,9 +353,7 @@ void reco::helper::JetIDHelper::classifyJetComponents( const edm::Event& event, 
 			   <<", depth: "<<depth<<", iPhi: "<<theRecHit->id().iphi()
 			   <<" -> "<<region;
 
-	  std::vector<int> isMergedDepth = theHcalTopology->mergedDepthList29(theRecHit->id());
-	  int absIEta = TMath::Abs( theRecHit->id().ieta() );
-	  if( (absIEta == 28 || absIEta == 29) &&  std::find(isMergedDepth.begin(), isMergedDepth.end(), depth) != isMergedDepth.end() )
+	  if(theHcalTopology->mergedDepth29(theRecHit->id()))
 	    hitE /= 2;  // Depth 3 at the HE forward edge is split over tower 28 & 29, and jet reco. assigns half each
 	  
 	  int iHPD = 100 * region;

--- a/RecoJets/JetProducers/src/JetIDHelper.cc
+++ b/RecoJets/JetProducers/src/JetIDHelper.cc
@@ -11,6 +11,7 @@
 
 
 #include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 // JetIDHelper needs a much more detailed description that the one in HcalTopology, 
 // so to be consistent, all needed constants are hardwired in JetIDHelper.cc itself
 // #include "Geometry/CaloTopology/interface/HcalTopology.h"
@@ -341,7 +342,7 @@ void reco::helper::JetIDHelper::classifyJetComponents( const edm::Event& event, 
 	  hitE = theRecHit->energy();
 	  int iEta = theRecHit->id().ieta();
 	  int depth = theRecHit->id().depth();
-	  Region region = HBHE_region( iEta, depth );
+	  Region region = HBHE_region( theRecHit->id().rawId() );
 	  int hitIPhi = theRecHit->id().iphi();
 	  if( iDbg>3 ) cout<<"hit #"<<iCell<<" is HBHE, E: "<<hitE<<" iEta: "<<iEta
 			   <<", depth: "<<depth<<", iPhi: "<<theRecHit->id().iphi()
@@ -597,13 +598,16 @@ int reco::helper::JetIDHelper::HBHE_oddness( int iEta, int depth )
  return ae & 0x1;
 }
 
-reco::helper::JetIDHelper::Region reco::helper::JetIDHelper::HBHE_region( int iEta, int depth )
+reco::helper::JetIDHelper::Region reco::helper::JetIDHelper::HBHE_region( uint32_t rawid )
 {
-  // no error checking for HO indices (depth 2 & |ieta|<=14 or depth 3 & |ieta|=15)
-  if( iEta <= -17 || ( depth == 3 && iEta == -16 ) ) return HEneg;
-  if( iEta >=  17 || ( depth == 3 && iEta ==  16 ) ) return HEpos;
-  if( iEta < 0 ) return HBneg;
-  return HBpos;
+  HcalDetId id(rawid);
+  if( id.subdet() == HcalEndcap)
+    {
+      if( id.ieta() < 0 ) return HEneg;
+      else return HEpos;
+    }
+  if( id.subdet() == HcalBarrel && id.ieta() < 0) return HBneg;
+  return HBpos;  
 }
 
 int reco::helper::JetIDHelper::HBHE_oddness( int iEta )

--- a/RecoJets/JetProducers/src/JetIDHelper.cc
+++ b/RecoJets/JetProducers/src/JetIDHelper.cc
@@ -283,7 +283,6 @@ void reco::helper::JetIDHelper::classifyJetComponents( const edm::Event& event, 
 
   std::vector<bool> isMergedDepth = computeGeom(setup);
 
-
   for( int iTower = 0; iTower <nTowers ; iTower++ ) {
 
     CaloTowerPtr& tower = towers[iTower];
@@ -353,14 +352,10 @@ void reco::helper::JetIDHelper::classifyJetComponents( const edm::Event& event, 
 			   <<", depth: "<<depth<<", iPhi: "<<theRecHit->id().iphi()
 			   <<" -> "<<region;
 
-
-
-
-	  //fixme
 	  int absIEta = TMath::Abs( theRecHit->id().ieta() );
-	  if( depth == 3 && (absIEta == 28 || absIEta == 29) ) {
+	  if( (absIEta == 28 || absIEta == 29) && isMergedDepth[depth-1] )
 	    hitE /= 2; // Depth 3 at the HE forward edge is split over tower 28 & 29, and jet reco. assigns half each
-	  }
+	  
 	  int iHPD = 100 * region;
 	  int iRBX = 100 * region + ((hitIPhi + 1) % 72) / 4; // 71,72,1,2 are in the same RBX module
 	  


### PR DESCRIPTION
This PR makes use of a newly implemented function of the HcalTopology and depends on PR #21674.

This PR removes the hardcoded access to HE depths in the JetIDHelper code.
