### PR TITLE
[10.0.X] Streamline usage of 'Alignables' + clang and static analyzer warning fixes

### DIFF
--- a/Alignment/CommonAlignment/interface/Alignable.h
+++ b/Alignment/CommonAlignment/interface/Alignable.h
@@ -65,7 +65,7 @@ public:
   virtual void addComponent( Alignable* ) = 0;
 
   /// Return vector of all direct components
-  virtual Alignables components() const = 0;
+  virtual const Alignables& components() const = 0;
 
   /// Return number of direct components
   int size() const { return components().size(); }
@@ -270,7 +270,5 @@ private:
   const SurveyDet* theSurvey; // Pointer to survey info; owned by class
 
 };
-
-typedef std::vector<Alignable*> Alignables;
 
 #endif

--- a/Alignment/CommonAlignment/interface/Alignable.h
+++ b/Alignment/CommonAlignment/interface/Alignable.h
@@ -227,6 +227,9 @@ public:
   /// Set survey info
   void setSurvey( const SurveyDet* );
 
+  /// Recenter surface object without moving possible components
+  virtual void recenterSurface();
+
 protected:
   template<class T>
   using Cache = std::map<align::RunNumber, T>;

--- a/Alignment/CommonAlignment/interface/AlignableBeamSpot.h
+++ b/Alignment/CommonAlignment/interface/AlignableBeamSpot.h
@@ -32,7 +32,7 @@ public:
   void addComponent( Alignable* component ) override {}
 
   /// Return vector of direct components
-  Alignables components() const override { return std::vector<Alignable*>(); }
+  const Alignables& components() const override { return emptyComponents_; }
 
   /// Provide all components, subcomponents etc. (cf. description in base class)
   void recursiveComponents(Alignables &result) const override { }
@@ -96,6 +96,7 @@ public:
 
 private:
 
+  static const Alignables emptyComponents_;
   AlignmentPositionError* theAlignmentPositionError;
 
   bool theInitializedFlag;

--- a/Alignment/CommonAlignment/interface/AlignableComposite.h
+++ b/Alignment/CommonAlignment/interface/AlignableComposite.h
@@ -45,10 +45,10 @@ public:
   /// Add a component and set its mother to this alignable.
   /// (Note: The component will be adopted, e.g. later deleted.)
   /// Also find average position of this composite from its modules' positions.
-  void addComponent( Alignable* component ) override;
+  void addComponent( Alignable* component ) final;
 
   /// Return vector of direct components
-  Alignables components() const override { return theComponents; }
+  const Alignables& components() const override { return theComponents; }
 
   /// Provide all components, subcomponents etc. (cf. description in base class)
   void recursiveComponents(Alignables &result) const override;

--- a/Alignment/CommonAlignment/interface/AlignableDetUnit.h
+++ b/Alignment/CommonAlignment/interface/AlignableDetUnit.h
@@ -26,10 +26,10 @@ public:
   void update(const GeomDetUnit* geomDetUnit);
 
   /// No components here => exception!
-  void addComponent( Alignable* ) override;
+  void addComponent( Alignable* ) final;
 
   /// Returns a null vector (no components here)
-  Alignables components() const override { return Alignables(); }
+  const Alignables& components() const override { return emptyComponents_; }
 
   /// Do nothing (no components here, so no subcomponents either...)
   void recursiveComponents(Alignables &result) const override {}
@@ -41,26 +41,26 @@ public:
   void rotateInGlobalFrame( const RotationType& rotation ) override;
 
   /// Set the AlignmentPositionError (no components => second argument ignored)
-  void setAlignmentPositionError(const AlignmentPositionError &ape, bool /*propDown*/) override;
+  void setAlignmentPositionError(const AlignmentPositionError &ape, bool /*propDown*/) final;
 
   /// Add (or set if it does not exist yet) the AlignmentPositionError
   /// (no components => second argument without effect)
-  void addAlignmentPositionError(const AlignmentPositionError& ape, bool /*propDown*/) override;
+  void addAlignmentPositionError(const AlignmentPositionError& ape, bool /*propDown*/) final;
 
   /// Add (or set if it does not exist yet) the AlignmentPositionError
   /// resulting from a rotation in the global reference frame
   /// (no components => second argument without effect)
-  void addAlignmentPositionErrorFromRotation(const RotationType& rot, bool /*propDown*/) override;
+  void addAlignmentPositionErrorFromRotation(const RotationType& rot, bool /*propDown*/) final;
 
   /// Add (or set if it does not exist yet) the AlignmentPositionError
   /// resulting from a rotation in the local reference frame
   /// (no components => second argument without effect)
-  void addAlignmentPositionErrorFromLocalRotation(const RotationType& rot, bool /*propDown*/) override;
+  void addAlignmentPositionErrorFromLocalRotation(const RotationType& rot, bool /*propDown*/) final;
 
   /// Set surface deformation parameters (2nd argument without effect)
-  void setSurfaceDeformation(const SurfaceDeformation *deformation, bool) override;
+  void setSurfaceDeformation(const SurfaceDeformation *deformation, bool) final;
   /// Add surface deformation parameters to the existing ones (2nd argument without effect)
-  void addSurfaceDeformation(const SurfaceDeformation *deformation, bool) override;
+  void addSurfaceDeformation(const SurfaceDeformation *deformation, bool) final;
 
   /// Return the alignable type identifier
   StructureType alignableObjectId () const override { return align::AlignableDetUnit; }
@@ -94,6 +94,7 @@ public:
 
 private:
 
+  static const Alignables emptyComponents_;
   AlignmentPositionError* theAlignmentPositionError;
   SurfaceDeformation* theSurfaceDeformation;
   SurfaceDeformation* theCachedSurfaceDeformation;

--- a/Alignment/CommonAlignment/interface/AlignableExtras.h
+++ b/Alignment/CommonAlignment/interface/AlignableExtras.h
@@ -33,7 +33,7 @@ class AlignableExtras
   /// Return beam spot alignable as a vector with one element
   Alignables& beamSpot() { return this->subStructures("BeamSpot");}
 
-  Alignables components() const { return components_; }
+  const Alignables& components() const { return components_; }
 
   /// Return alignments, sorted by DetId
   Alignments* alignments() const;

--- a/Alignment/CommonAlignment/interface/AlignableMap.h
+++ b/Alignment/CommonAlignment/interface/AlignableMap.h
@@ -22,13 +22,13 @@
 #include <map>
 #include <sstream>
 
-#include "Alignment/CommonAlignment/interface/Alignable.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 
 
 
 class AlignableMap
 {
-  typedef typename std::map<std::string, Alignables> Container;
+  using Container = std::map<std::string, align::Alignables>;
 
 public:
 
@@ -37,11 +37,11 @@ public:
 
   /// Get an object from map using its name.
   /// A new object is default-constructed if the name does not exist.
-  Alignables& get( const std::string& name = "" );
+  align::Alignables& get( const std::string& name = "" );
 
   /// Find and return an object from map using its name.
   /// Throw an exception if the name does not exist.
-  Alignables& find( const std::string& name = "" );
+  align::Alignables& find( const std::string& name = "" );
 
   /// Print the name of all stored data
   void dump( void ) const;

--- a/Alignment/CommonAlignment/interface/AlignableNavigator.h
+++ b/Alignment/CommonAlignment/interface/AlignableNavigator.h
@@ -11,6 +11,7 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 #include "Alignment/CommonAlignment/interface/AlignableDetOrUnitPtr.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 
 class Alignable;
 class AlignableDet;
@@ -34,7 +35,7 @@ public:
   explicit AlignableNavigator(AlignableExtras* extras, Alignable* tracker, Alignable* muon = nullptr);
 
   /// Constructor from list of Alignbable
-  explicit AlignableNavigator( const std::vector<Alignable*>& alignables );
+  explicit AlignableNavigator(const align::Alignables&);
 
   typedef std::map<DetId, AlignableDetOrUnitPtr> MapType;
   typedef MapType::value_type PairType;

--- a/Alignment/CommonAlignment/interface/MisalignmentScenarioBuilder.h
+++ b/Alignment/CommonAlignment/interface/MisalignmentScenarioBuilder.h
@@ -15,6 +15,7 @@
 
 #include "Alignment/CommonAlignment/interface/AlignableModifier.h"
 #include "Alignment/CommonAlignment/interface/AlignableObjectId.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 
 /// Base class to build a scenario from configuration and apply to either tracker or muon.
 
@@ -35,10 +36,10 @@ public:
 protected: // Methods
 
   /// Decode movements defined in given parameter set for given set of alignables
-  void decodeMovements_(const edm::ParameterSet &pSet, const std::vector<Alignable*> &alignables);
+  void decodeMovements_(const edm::ParameterSet&, const align::Alignables&);
   
   /// Decode movements defined in given parameter set for given set of alignables tagged by given name
-  void decodeMovements_(const edm::ParameterSet& pSet, const std::vector<Alignable*> &alignables,
+  void decodeMovements_(const edm::ParameterSet&, const align::Alignables&,
 			const std::string &levelName);
 
   /// Apply movements given by parameter set to given alignable

--- a/Alignment/CommonAlignment/interface/Utilities.h
+++ b/Alignment/CommonAlignment/interface/Utilities.h
@@ -12,6 +12,7 @@
 
 #include <map>
 #include <memory>
+#include <vector>
 
 #include "CondCore/CondDB/interface/Time.h"
 #include "CondFormats/Alignment/interface/Definitions.h"

--- a/Alignment/CommonAlignment/src/AlignTools.cc
+++ b/Alignment/CommonAlignment/src/AlignTools.cc
@@ -94,7 +94,7 @@ void align::createPoints(align::GlobalVectors* Vs, Alignable* ali, const std::st
 	std::string copy=weightBy; 	 
 	std::transform(copy.begin(), copy.end(), copy.begin(),  (int(*)(int)) toupper); 	 
 	if(copy != "SELF"){
-		const align::Alignables& comp = ali->components();
+		const auto& comp = ali->components();
 		unsigned int nComp = comp.size();
 		for (unsigned int i = 0; i < nComp; ++i) align::createPoints(Vs, comp[i], weightBy, weightById, weightByIdVector);
 		// double the weight for SS modules if weight by Det

--- a/Alignment/CommonAlignment/src/Alignable.cc
+++ b/Alignment/CommonAlignment/src/Alignable.cc
@@ -370,3 +370,12 @@ void Alignable::updateMother(const GlobalVector& shift) {
     break;
   }
 }
+
+//______________________________________________________________________________
+void Alignable::recenterSurface()
+{
+  const auto& currentPosition = this->globalPosition();
+  theSurface.move(align::GlobalVector{-currentPosition.x(),
+                                      -currentPosition.y(),
+                                      -currentPosition.z()});
+}

--- a/Alignment/CommonAlignment/src/Alignable.cc
+++ b/Alignment/CommonAlignment/src/Alignable.cc
@@ -71,16 +71,15 @@ bool Alignable::firstCompsWithParams(Alignables &paramComps) const
   bool isConsistent = true;
   bool hasAliComp = false; // whether there are any (grand-) daughters with parameters
   bool first = true;
-  const Alignables comps(this->components());
-  for (Alignables::const_iterator iComp = comps.begin(), iCompEnd = comps.end();
-       iComp != iCompEnd; ++iComp) {
-    if ((*iComp)->alignmentParameters()) { // component has parameters itself
-      paramComps.push_back(*iComp);
+  const auto& comps = this->components();
+  for (const auto& iComp: comps) {
+    if (iComp->alignmentParameters()) { // component has parameters itself
+      paramComps.push_back(iComp);
       if (!first && !hasAliComp) isConsistent = false;
       hasAliComp = true;
     } else {
       const unsigned int nCompBefore = paramComps.size();
-      if (!(*iComp)->firstCompsWithParams(paramComps)) {
+      if (!(iComp->firstCompsWithParams(paramComps))) {
         isConsistent = false; // problem down in hierarchy
       }
       if (paramComps.size() != nCompBefore) {
@@ -102,7 +101,7 @@ bool Alignable::lastCompsWithParams(Alignables& paramComps) const
   bool isConsistent = true;
   bool hasAliComp = false;
   bool first = true;
-  const Alignables comps(this->components());
+  const auto& comps = this->components();
   for (const auto& iComp: comps) {
     const auto nCompsBefore = paramComps.size();
     isConsistent = iComp->lastCompsWithParams(paramComps);
@@ -297,12 +296,7 @@ void Alignable::cacheTransformation()
   theCachedRotation = theRotation;
 
   // now treat components (a clean design would move that to AlignableComposite...)
-  const Alignables comps(this->components());
-
-  for (auto it = comps.begin(); it != comps.end(); ++it) {
-    (*it)->cacheTransformation();
-  }
-
+  for (const auto& it: this->components()) it->cacheTransformation();
 }
 
 void Alignable::cacheTransformation(const align::RunNumber& run)
@@ -313,8 +307,7 @@ void Alignable::cacheTransformation(const align::RunNumber& run)
   rotationsCache_[run] = theRotation;
 
   // now treat components (a clean design would move that to AlignableComposite...)
-  const Alignables comps(this->components());
-  for (auto& it: comps) it->cacheTransformation(run);
+  for (const auto& it: this->components()) it->cacheTransformation(run);
 }
 
 void Alignable::restoreCachedTransformation()
@@ -325,12 +318,7 @@ void Alignable::restoreCachedTransformation()
   theRotation = theCachedRotation;
 
   // now treat components (a clean design would move that to AlignableComposite...)
-  const auto comps = this->components();
-
-  for (auto it = comps.begin(); it != comps.end(); ++it) {
-    (*it)->restoreCachedTransformation();
-  }
- 
+  for (const auto& it: this->components()) it->restoreCachedTransformation();
 }
 
 void Alignable::restoreCachedTransformation(const align::RunNumber& run)
@@ -347,8 +335,7 @@ void Alignable::restoreCachedTransformation(const align::RunNumber& run)
     theRotation = rotationsCache_[run];
 
     // now treat components (a clean design would move that to AlignableComposite...)
-    const auto comps = this->components();
-    for (auto it: comps) it->restoreCachedTransformation();
+    for (const auto& it: this->components()) it->restoreCachedTransformation();
   }
 }
 

--- a/Alignment/CommonAlignment/src/AlignableBeamSpot.cc
+++ b/Alignment/CommonAlignment/src/AlignableBeamSpot.cc
@@ -184,3 +184,6 @@ void AlignableBeamSpot::reset()
   theAlignmentPositionError = nullptr;
   theInitializedFlag = false;
 }
+
+//______________________________________________________________________________
+const align::Alignables AlignableBeamSpot::emptyComponents_{};

--- a/Alignment/CommonAlignment/src/AlignableComposite.cc
+++ b/Alignment/CommonAlignment/src/AlignableComposite.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 // Framework
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -63,7 +65,7 @@ void AlignableComposite::update(align::ID id,
 //__________________________________________________________________________________________________
 void AlignableComposite::addComponent(Alignable* ali)
 {
-  const Alignables& newComps = ali->deepComponents();
+  const auto& newComps = ali->deepComponents();
 
   theDeepComponents.insert( theDeepComponents.end(), newComps.begin(), newComps.end() );
 
@@ -79,15 +81,14 @@ void AlignableComposite::addComponent(Alignable* ali)
 void AlignableComposite::recursiveComponents(Alignables &result) const
 {
 
-  Alignables components = this->components();
+  const auto& components = this->components();
   if (this->alignableObjectId() == align::AlignableDet 
       && components.size() <= 1) { // Non-glued AlignableDets (still) contain themselves
     return; // (would be better to implement AlignableDet::recursiveComponents!)
   }
-  for (Alignables::const_iterator iter = components.begin();
-       iter != components.end(); ++iter) {
-    result.push_back(*iter); // could use std::copy(..), but here we build a real hierarchy
-    (*iter)->recursiveComponents(result);
+  for (const auto& iter: components) {
+    result.push_back(iter); // could use std::copy(..), but here we build a real hierarchy
+    iter->recursiveComponents(result);
   }
 }
 
@@ -96,9 +97,7 @@ void AlignableComposite::move( const GlobalVector& displacement )
 {
   
   // Move components
-  Alignables comp = this->components();
-  for ( Alignables::iterator i=comp.begin(); i!=comp.end(); ++i )
-    (**i).move( displacement);
+  for (const auto& i: this->components()) i->move(displacement);
 
   // Move surface
   this->addDisplacement( displacement );
@@ -123,7 +122,7 @@ void AlignableComposite::moveComponentLocal( const int i, const LocalVector& loc
     throw cms::Exception("LogicError")
       << "AlignableComposite index (" << i << ") out of range";
 
-  Alignables comp = this->components();
+  const auto& comp = this->components();
   comp[i]->move( this->surface().toGlobal( localDisplacement ) );
 
 }
@@ -137,11 +136,11 @@ void AlignableComposite::moveComponentLocal( const int i, const LocalVector& loc
 void AlignableComposite::rotateInGlobalFrame( const RotationType& rotation )
 {
   
-  Alignables comp = this->components();
+  const auto& comp = this->components();
   
   PositionType myPosition = this->globalPosition();
   
-  for ( Alignables::iterator i=comp.begin(); i!=comp.end(); ++i )
+  for (const auto& i: comp)
     {
       
       // It is much simpler to calculate the local position given in coordinates 
@@ -159,7 +158,7 @@ void AlignableComposite::rotateInGlobalFrame( const RotationType& rotation )
     
     
       // Local Position given in coordinates of the GLOBAL Frame
-      const GlobalVector localPositionVector = (**i).globalPosition() - myPosition;
+      const GlobalVector localPositionVector = i->globalPosition() - myPosition;
       const GlobalVector::BasicVectorType& lpvgf = localPositionVector.basicVector();
 
       // rotate with GLOBAL rotation matrix  and subtract => moveVector in 
@@ -169,8 +168,8 @@ void AlignableComposite::rotateInGlobalFrame( const RotationType& rotation )
       GlobalVector moveVector( rotation.multiplyInverse(lpvgf) - lpvgf );
     
     
-      (**i).move( moveVector );
-      (**i).rotateInGlobalFrame( rotation );
+      i->move(moveVector);
+      i->rotateInGlobalFrame(rotation);
 
     }
 
@@ -190,9 +189,8 @@ void AlignableComposite::setAlignmentPositionError( const AlignmentPositionError
   // The APE is, therefore, just propagated down
   if (!propagateDown) return;
 
-  Alignables comp = this->components();
-  for (Alignables::const_iterator i = comp.begin(); i != comp.end(); ++i) {
-    (*i)->setAlignmentPositionError(ape, propagateDown);
+  for (const auto& i: this->components()) {
+    i->setAlignmentPositionError(ape, propagateDown);
   }
 }
 
@@ -207,11 +205,9 @@ AlignableComposite::addAlignmentPositionError( const AlignmentPositionError& ape
   // The APE is, therefore, just propagated down
   if (!propagateDown) return;
 
-  Alignables comp = this->components();
-  for (Alignables::const_iterator i = comp.begin(); i != comp.end(); ++i) {
-    (*i)->addAlignmentPositionError(ape, propagateDown);
+  for (const auto& i: this->components()) {
+    i->addAlignmentPositionError(ape, propagateDown);
   }
-  
 }
 
 
@@ -222,19 +218,15 @@ AlignableComposite::addAlignmentPositionError( const AlignmentPositionError& ape
 void AlignableComposite::addAlignmentPositionErrorFromRotation( const RotationType& rotation,
 								bool propagateDown )
 {
-
   if (!propagateDown) return;
 
-  Alignables comp = this->components();
   PositionType myPosition=this->globalPosition();
 
-  for ( Alignables::const_iterator i=comp.begin(); i!=comp.end(); ++i )
-    {
-
+  for (const auto& i: this->components()) {
       // It is just similar to to the "movement" that results to the components
       // when the composite is rotated. 
       // Local Position given in coordinates of the GLOBAL Frame
-      const GlobalVector localPositionVector = (**i).globalPosition()-myPosition;
+      const GlobalVector localPositionVector = i->globalPosition()-myPosition;
       const GlobalVector::BasicVectorType& lpvgf = localPositionVector.basicVector();
 
       // rotate with GLOBAL rotation matrix  and subtract => moveVector in global coordinates
@@ -243,11 +235,9 @@ void AlignableComposite::addAlignmentPositionErrorFromRotation( const RotationTy
       GlobalVector moveVector( rotation.multiplyInverse(lpvgf) - lpvgf );    
       
       AlignmentPositionError ape( moveVector.x(), moveVector.y(), moveVector.z() );
-      (*i)->addAlignmentPositionError( ape, propagateDown );
-      (*i)->addAlignmentPositionErrorFromRotation( rotation, propagateDown );
-	  
+      i->addAlignmentPositionError( ape, propagateDown );
+      i->addAlignmentPositionErrorFromRotation( rotation, propagateDown );
     }
-
 }
 
 
@@ -275,9 +265,8 @@ void AlignableComposite::setSurfaceDeformation(const SurfaceDeformation *deforma
   // The parameters are, therefore, just propagated down.
   if (!propagateDown) return;
 
-  Alignables comp(this->components());
-  for (Alignables::const_iterator i = comp.begin(); i != comp.end(); ++i) {
-    (*i)->setSurfaceDeformation(deformation, propagateDown);
+  for (const auto& i: this->components()) {
+    i->setSurfaceDeformation(deformation, propagateDown);
   }
 }
 
@@ -289,9 +278,8 @@ void AlignableComposite::addSurfaceDeformation(const SurfaceDeformation *deforma
   // The parameters are, therefore, just propagated down.
   if (!propagateDown) return;
 
-  Alignables comp(this->components());
-  for (Alignables::const_iterator i = comp.begin(); i != comp.end(); ++i) {
-    (*i)->addSurfaceDeformation(deformation, propagateDown);
+  for (const auto& i: this->components()) {
+    i->addSurfaceDeformation(deformation, propagateDown);
   }
 }
 
@@ -301,7 +289,7 @@ void AlignableComposite::dump( void ) const
 
   // A simple printout method. Could be specialized in the implementation classes.
 
-  Alignables comp = this->components();
+  const auto& comp = this->components();
 
   // Dump this
   edm::LogInfo("AlignableDump") 
@@ -311,9 +299,7 @@ void AlignableComposite::dump( void ) const
     << this->globalRotation();
 
   // Dump components
-  for ( Alignables::iterator i=comp.begin(); i!=comp.end(); ++i )
-    (*i)->dump();
-
+  for (const auto& i: comp) i->dump();
 }
 
 
@@ -321,64 +307,48 @@ void AlignableComposite::dump( void ) const
 //__________________________________________________________________________________________________
 Alignments* AlignableComposite::alignments( void ) const
 {
-
   // Recursively call alignments, until we get to an AlignableDetUnit
-  Alignables comp = this->components();
 
   Alignments* m_alignments = new Alignments();
 
   // Add components recursively
-  for ( Alignables::iterator i=comp.begin(); i!=comp.end(); ++i )
-    {
-      Alignments* tmpAlignments = (*i)->alignments();
-      std::copy( tmpAlignments->m_align.begin(), tmpAlignments->m_align.end(), 
-		 std::back_inserter(m_alignments->m_align) );
-	  delete tmpAlignments;
-    }
-
+  for (const auto& i: this->components()) {
+    std::unique_ptr<Alignments> tmpAlignments{i->alignments()};
+    std::copy(tmpAlignments->m_align.begin(), tmpAlignments->m_align.end(), 
+              std::back_inserter(m_alignments->m_align));
+  }
   
   return m_alignments;
-
 }
 
 
 //__________________________________________________________________________________________________
 AlignmentErrorsExtended* AlignableComposite::alignmentErrors( void ) const
 {
-
   // Recursively call alignmentsErrors, until we get to an AlignableDetUnit
-  Alignables comp = this->components();
 
   AlignmentErrorsExtended* m_alignmentErrors = new AlignmentErrorsExtended();
 
   // Add components recursively
-  for ( Alignables::iterator i=comp.begin(); i!=comp.end(); ++i )
-    {
-      AlignmentErrorsExtended* tmpAlignmentErrorsExtended = (*i)->alignmentErrors();
-      std::copy( tmpAlignmentErrorsExtended->m_alignError.begin(), tmpAlignmentErrorsExtended->m_alignError.end(), 
-		 std::back_inserter(m_alignmentErrors->m_alignError) );
-	  delete tmpAlignmentErrorsExtended;
+  for (const auto& i: this->components()) {
+    std::unique_ptr<AlignmentErrorsExtended> tmpAlignmentErrorsExtended{i->alignmentErrors()};
+    std::copy(tmpAlignmentErrorsExtended->m_alignError.begin(), tmpAlignmentErrorsExtended->m_alignError.end(), 
+               std::back_inserter(m_alignmentErrors->m_alignError));
     }
 
-  
   return m_alignmentErrors;
-
 }
 
 
 //__________________________________________________________________________________________________
 int AlignableComposite::surfaceDeformationIdPairs(std::vector<std::pair<int,SurfaceDeformation*> > & result) const
 {
-
-  Alignables comp = this->components();
-
   int count = 0;
 
   // Add components recursively
-  for ( Alignables::iterator i=comp.begin(); i!=comp.end(); ++i) {
-    count += (*i)->surfaceDeformationIdPairs(result);
+  for (const auto& i: this->components()) {
+    count += i->surfaceDeformationIdPairs(result);
   }
   
   return count;
-
 }

--- a/Alignment/CommonAlignment/src/AlignableCompositeBuilder.cc
+++ b/Alignment/CommonAlignment/src/AlignableCompositeBuilder.cc
@@ -87,7 +87,7 @@ unsigned int AlignableCompositeBuilder
   // This vector is used indicate if a parent already exists. It is initialized
   // with 'naked' Alignables-pointers; if the pointer is not naked (!= nullptr)
   // for one of the child-IDs, its parent was already built before.
-  Alignables tmpParents(maxNumParents, nullptr);
+  align::Alignables tmpParents(maxNumParents, nullptr);
 
   for (auto* child: children) {
     // get the number of the child-Alignable ...

--- a/Alignment/CommonAlignment/src/AlignableDetUnit.cc
+++ b/Alignment/CommonAlignment/src/AlignableDetUnit.cc
@@ -326,3 +326,6 @@ void AlignableDetUnit::restoreCachedTransformation(const align::RunNumber& run)
     }
   }
 }
+
+//______________________________________________________________________________
+const align::Alignables AlignableDetUnit::emptyComponents_{};

--- a/Alignment/CommonAlignment/src/AlignableMap.cc
+++ b/Alignment/CommonAlignment/src/AlignableMap.cc
@@ -6,13 +6,13 @@
 
 
 //_____________________________________________________________________________
-Alignables& AlignableMap::get(const std::string& name)
+align::Alignables& AlignableMap::get(const std::string& name)
 {
   return theStore[name];
 }
 
 //_____________________________________________________________________________
-Alignables& AlignableMap::find(const std::string& name)
+align::Alignables& AlignableMap::find(const std::string& name)
 {
   typename Container::iterator o = theStore.find(name);
 

--- a/Alignment/CommonAlignment/src/AlignableNavigator.cc
+++ b/Alignment/CommonAlignment/src/AlignableNavigator.cc
@@ -43,9 +43,8 @@ AlignableNavigator::AlignableNavigator(AlignableExtras* extras, Alignable* track
   unsigned int numNonDets = this->recursiveGetId(tracker) + this->recursiveGetId(muon);
 
   if (extras) {
-    align::Alignables allExtras = extras->components();
-    for ( std::vector<Alignable*>::iterator it = allExtras.begin(); it != allExtras.end(); ++it ) {
-      numNonDets += this->recursiveGetId(*it);
+    for (const auto& it: extras->components()) {
+      numNonDets += this->recursiveGetId(it);
     }
   }
 
@@ -64,13 +63,13 @@ AlignableNavigator::AlignableNavigator(AlignableExtras* extras, Alignable* track
 }
 
 //_____________________________________________________________________________
-AlignableNavigator::AlignableNavigator( const std::vector<Alignable*>& alignables )
+AlignableNavigator::AlignableNavigator(const align::Alignables& alignables )
 {
   theMap.clear();
 
   unsigned int numNonDets = 0;
-  for ( std::vector<Alignable*>::const_iterator it = alignables.begin(); it != alignables.end(); ++it ) {
-    numNonDets += this->recursiveGetId(*it);
+  for (const auto& it: alignables) {
+    numNonDets += this->recursiveGetId(it);
   }
   if (numNonDets) {
     edm::LogWarning("Alignment") <<"@SUB=AlignableNavigator" << "Created with map of size "
@@ -149,11 +148,11 @@ unsigned int AlignableNavigator::recursiveGetId( Alignable* alignable )
       theDetAndSubdet.push_back(std::pair<int, int>( detId.det(), detId.subdetId() ));
     }
   }
-  std::vector<Alignable*> comp = alignable->components();
+  const auto& comp = alignable->components();
   if ( alignable->alignableObjectId() != align::AlignableDet
        || comp.size() > 1 ) { // Non-glued AlignableDets contain themselves
-    for ( std::vector<Alignable*>::iterator it = comp.begin(); it != comp.end(); ++it ) {
-      nProblem += this->recursiveGetId(*it);
+    for (const auto& it: comp) {
+      nProblem += this->recursiveGetId(it);
     }
   }
   return nProblem;

--- a/Alignment/CommonAlignment/src/AlignmentParameters.cc
+++ b/Alignment/CommonAlignment/src/AlignmentParameters.cc
@@ -157,14 +157,13 @@ unsigned int AlignmentParameters::hierarchyLevel() const
     return 0;
   }
 
-  std::vector<Alignable*> comps;
+  align::Alignables comps;
   theAlignable->firstCompsWithParams(comps);
   if (comps.empty()) return 0;
 
   unsigned int maxLevelOfComp = 0;
-  for (std::vector<Alignable*>::const_iterator iAli = comps.begin(), iAliEnd = comps.end();
-       iAli != iAliEnd; ++iAli) {// firstCompsWithParams guaranties that alignmentParameters() != 0:
-    const unsigned int compResult = (*iAli)->alignmentParameters()->hierarchyLevel();
+  for (const auto& iAli: comps) {// firstCompsWithParams guaranties that alignmentParameters() != 0:
+    const unsigned int compResult = iAli->alignmentParameters()->hierarchyLevel();
     // levels might be different for components, get largest:
     if (maxLevelOfComp < compResult) maxLevelOfComp = compResult;
   }

--- a/Alignment/CommonAlignment/src/MisalignmentScenarioBuilder.cc
+++ b/Alignment/CommonAlignment/src/MisalignmentScenarioBuilder.cc
@@ -30,13 +30,13 @@ MisalignmentScenarioBuilder::MisalignmentScenarioBuilder(AlignableObjectId::Geom
 //__________________________________________________________________________________________________
 // Call for each alignable the more general version with its appropriate level name. 
 void MisalignmentScenarioBuilder::decodeMovements_(const edm::ParameterSet &pSet, 
-                                                   const std::vector<Alignable*> &alignables)
+                                                   const align::Alignables &alignables)
 {
 
-  // first create a map with one std::vector<Alignable*> per type (=levelName)
-  typedef std::map<std::string, std::vector<Alignable*> > AlignablesMap;
+  // first create a map with one align::Alignables per type (=levelName)
+  using AlignablesMap = std::map<std::string, align::Alignables>;
   AlignablesMap alisMap;
-  for (std::vector<Alignable*>::const_iterator iA = alignables.begin(); iA != alignables.end(); ++iA) {
+  for (align::Alignables::const_iterator iA = alignables.begin(); iA != alignables.end(); ++iA) {
     const std::string &levelName = alignableObjectId_.idToString((*iA)->alignableObjectId());
     alisMap[levelName].push_back(*iA); // either first entry of new level or add to an old one
   }
@@ -60,7 +60,7 @@ void MisalignmentScenarioBuilder::decodeMovements_(const edm::ParameterSet &pSet
 //__________________________________________________________________________________________________
 // Decode nested parameter sets: this is the tricky part... Recursively called on components
 void MisalignmentScenarioBuilder::decodeMovements_(const edm::ParameterSet &pSet, 
-                                                   const std::vector<Alignable*> &alignables,
+                                                   const align::Alignables &alignables,
 						   const std::string &levelName)
 {
 
@@ -83,7 +83,7 @@ void MisalignmentScenarioBuilder::decodeMovements_(const edm::ParameterSet &pSet
 
   // Loop on alignables
   int iComponent = 0; // physical numbering starts at 1...
-  for (std::vector<Alignable*>::const_iterator iter = alignables.begin();
+  for (align::Alignables::const_iterator iter = alignables.begin();
        iter != alignables.end(); ++iter) {
     iComponent++;
 

--- a/Alignment/CommonAlignment/src/SurveyResidual.cc
+++ b/Alignment/CommonAlignment/src/SurveyResidual.cc
@@ -149,7 +149,7 @@ void SurveyResidual::findSisters(const Alignable* ali,
   theSisters.clear();
   theSisters.reserve(1000);
 
-  const std::vector<Alignable*>& comp = ali->mother()->components();
+  const auto& comp = ali->mother()->components();
 
   unsigned int nComp = comp.size();
 

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterStore.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterStore.h
@@ -41,8 +41,7 @@ public:
   CompositeAlignmentParameters
     selectParameters( const std::vector <AlignableDetOrUnitPtr>& alignabledets ) const;
   /// select parameters 
-  CompositeAlignmentParameters
-    selectParameters( const std::vector <Alignable*>& alignables ) const;
+  CompositeAlignmentParameters selectParameters(const align::Alignables&) const;
 
   /// update parameters 
   void updateParameters(const CompositeAlignmentParameters& aap, bool updateCorrelations = true);

--- a/Alignment/CommonAlignmentAlgorithm/src/TkModuleGroupSelector.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/TkModuleGroupSelector.cc
@@ -176,17 +176,16 @@ void TkModuleGroupSelector::createModuleGroups(AlignableTracker *aliTracker,
     selector.clear();
     selector.addSelections((*pset).getParameter<edm::ParameterSet> ("levels"));
 
-    const std::vector<Alignable*> &alis = selector.selectedAlignables();
+    const auto& alis = selector.selectedAlignables();
     std::list<Alignable*> selected_alis;
-    for(std::vector<Alignable*>::const_iterator it = alis.begin(); it != alis.end(); ++it) {
-      const std::vector<Alignable*> &aliDaughts = (*it)->deepComponents();
-      for (std::vector<Alignable*>::const_iterator iD = aliDaughts.begin();
-           iD != aliDaughts.end(); ++iD) {
-        if((*iD)->alignableObjectId() == align::AlignableDetUnit || (*iD)->alignableObjectId() == align::AlignableDet) {
+    for(const auto& it: alis) {
+      const auto& aliDaughts = it->deepComponents();
+      for (const auto& iD: aliDaughts) {
+        if(iD->alignableObjectId() == align::AlignableDetUnit || iD->alignableObjectId() == align::AlignableDet) {
           if(split) {
-            modules_selected = this->createGroup(Id, range, std::list<Alignable*>(1,(*iD)), refrun);
+            modules_selected = this->createGroup(Id, range, std::list<Alignable*>(1,iD), refrun);
           } else {
-            selected_alis.push_back((*iD));
+            selected_alis.push_back(iD);
           }
         }
       }

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
@@ -34,7 +34,7 @@
 #include "Alignment/CommonAlignmentMonitor/interface/AlignmentMonitorPluginFactory.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterStore.h"
-#include "Alignment/CommonAlignment/interface/Alignable.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h"
@@ -187,7 +187,7 @@ AlignmentMonitorAsAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
 					    align::DetectorGlobalPosition(*globalPositionRcd, DetId(DetId::Muon)) );
       
       // within an analyzer, modules can't expect to see any selected alignables!
-      std::vector<Alignable*> empty_alignables;
+      align::Alignables empty_alignables;
       
       m_alignableTracker = new AlignableTracker( &(*theTracker), tTopo );
       m_alignableMuon = new AlignableMuon( &(*theMuonDT), &(*theMuonCSC) );

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorGeneric.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorGeneric.cc
@@ -26,7 +26,7 @@ void AlignmentMonitorGeneric::book()
   auto alignableObjectId =
     AlignableObjectId::commonObjectIdProvider(pTracker(), pMuon());
 
-  const std::vector<Alignable*>& alignables = pStore()->alignables();
+  const auto& alignables = pStore()->alignables();
 
   unsigned int nAlignable = alignables.size();
   unsigned int nResidName = residNames.size();

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonResiduals.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonResiduals.cc
@@ -198,14 +198,12 @@ void AlignmentMonitorMuonResiduals::book() {
    m_y_wy.clear();
    m_y_wyy.clear();
 
-   std::vector<Alignable*> chambers;
-   std::vector<Alignable*> tmp1 = pMuon()->DTChambers();
-   for (std::vector<Alignable*>::const_iterator iter = tmp1.begin();  iter != tmp1.end();  ++iter) chambers.push_back(*iter);
-   std::vector<Alignable*> tmp2 = pMuon()->CSCChambers();
-   for (std::vector<Alignable*>::const_iterator iter = tmp2.begin();  iter != tmp2.end();  ++iter) chambers.push_back(*iter);
+   align::Alignables chambers;
+   for (const auto& iter: pMuon()->DTChambers()) chambers.push_back(iter);
+   for (const auto& iter: pMuon()->CSCChambers()) chambers.push_back(iter);
 
-   for (std::vector<Alignable*>::const_iterator chamber = chambers.begin();  chamber != chambers.end();  ++chamber) {
-      int id = (*chamber)->geomDetId().rawId();
+   for (const auto& chamber: chambers) {
+      int id = chamber->geomDetId().rawId();
       m_numx[id] = 0;
       m_x_w[id] = 0;
       m_x_ww[id] = 0;
@@ -821,15 +819,13 @@ void AlignmentMonitorMuonResiduals::event(const edm::Event &iEvent, const edm::E
 }
 
 void AlignmentMonitorMuonResiduals::afterAlignment() {
-   std::vector<Alignable*> chambers;
-   std::vector<Alignable*> tmp1 = pMuon()->DTChambers();
-   for (std::vector<Alignable*>::const_iterator iter = tmp1.begin();  iter != tmp1.end();  ++iter) chambers.push_back(*iter);
-   std::vector<Alignable*> tmp2 = pMuon()->CSCChambers();
-   for (std::vector<Alignable*>::const_iterator iter = tmp2.begin();  iter != tmp2.end();  ++iter) chambers.push_back(*iter);
+   align::Alignables chambers;
+   for (const auto& iter: pMuon()->DTChambers()) chambers.push_back(iter);
+   for (const auto& iter: pMuon()->CSCChambers()) chambers.push_back(iter);
 
    int index = 0;
-   for (std::vector<Alignable*>::const_iterator chamber = chambers.begin();  chamber != chambers.end();  ++chamber) {
-      const int id = (*chamber)->geomDetId().rawId();
+   for (const auto& chamber: chambers) {
+      const int id = chamber->geomDetId().rawId();
       
       m_chambers_rawid = id;
       m_chambers_numx = m_numx[id];
@@ -848,8 +844,8 @@ void AlignmentMonitorMuonResiduals::afterAlignment() {
       m_sumnumy->SetBinContent(index, m_numy[id]);
 
       std::ostringstream name;
-      if ((*chamber)->geomDetId().subdetId() == MuonSubdetId::DT) {
-	 DTChamberId dtId((*chamber)->geomDetId());
+      if (chamber->geomDetId().subdetId() == MuonSubdetId::DT) {
+	 DTChamberId dtId(chamber->geomDetId());
 	 name << "MB" << dtId.wheel() << "/" << dtId.station() << " (" << dtId.sector() << ")";
 	 m_chambers_endcap = 0;
 	 m_chambers_wheel = dtId.wheel();
@@ -859,7 +855,7 @@ void AlignmentMonitorMuonResiduals::afterAlignment() {
 	 m_chambers_chamber = 0;
       }
       else {
-	 CSCDetId cscId((*chamber)->geomDetId());
+	 CSCDetId cscId(chamber->geomDetId());
 	 name << "ME" << (cscId.endcap() == 1? "+": "-") << cscId.station() << "/" << cscId.ring() << " (" << cscId.chamber() << ")";
 	 m_chambers_endcap = cscId.endcap();
 	 m_chambers_wheel = 0;
@@ -884,9 +880,9 @@ void AlignmentMonitorMuonResiduals::afterAlignment() {
 	 m_xsummary->SetBinError(index, xerronmean);
 
 	 m_xmean->Fill(xmean);  m_xstdev->Fill(xstdev);  m_xerronmean->Fill(xerronmean);
-	 if ((*chamber)->geomDetId().subdetId() == MuonSubdetId::DT) {
+	 if (chamber->geomDetId().subdetId() == MuonSubdetId::DT) {
 	    m_xmean_mb->Fill(xmean);  m_xstdev_mb->Fill(xstdev);  m_xerronmean_mb->Fill(xerronmean);
-	    DTChamberId id((*chamber)->geomDetId().rawId());
+	    DTChamberId id(chamber->geomDetId().rawId());
 	    if (id.station() == 1) {
 	       m_xmean_mb1->Fill(xmean);  m_xstdev_mb1->Fill(xstdev);  m_xerronmean_mb1->Fill(xerronmean);
 	    }
@@ -919,7 +915,7 @@ void AlignmentMonitorMuonResiduals::afterAlignment() {
 	 else {
 	    m_xmean_me->Fill(xmean);  m_xstdev_me->Fill(xstdev);  m_xerronmean_me->Fill(xerronmean);
 
-	    CSCDetId id((*chamber)->geomDetId().rawId());
+	    CSCDetId id(chamber->geomDetId().rawId());
 
 	    if ((id.endcap() == 1? 1: -1)*id.station() == 1  &&  id.ring() == 1) {
 	       m_xmean_mep11->Fill(xmean);  m_xstdev_mep11->Fill(xstdev);  m_xerronmean_mep11->Fill(xerronmean);
@@ -1005,9 +1001,9 @@ void AlignmentMonitorMuonResiduals::afterAlignment() {
 	 m_ysummary->SetBinError(index, yerronmean);
 
 	 m_ymean->Fill(ymean);  m_ystdev->Fill(ystdev);  m_yerronmean->Fill(yerronmean);
-	 if ((*chamber)->geomDetId().subdetId() == MuonSubdetId::DT) {
+	 if (chamber->geomDetId().subdetId() == MuonSubdetId::DT) {
 	    m_ymean_mb->Fill(ymean);  m_ystdev_mb->Fill(ystdev);  m_yerronmean_mb->Fill(yerronmean);
-	    DTChamberId id((*chamber)->geomDetId().rawId());
+	    DTChamberId id(chamber->geomDetId().rawId());
 	    if (id.station() == 1) {
 	       m_ymean_mb1->Fill(ymean);  m_ystdev_mb1->Fill(ystdev);  m_yerronmean_mb1->Fill(yerronmean);
 	    }
@@ -1040,7 +1036,7 @@ void AlignmentMonitorMuonResiduals::afterAlignment() {
 	 else {
 	    m_ymean_me->Fill(ymean);  m_ystdev_me->Fill(ystdev);  m_yerronmean_me->Fill(yerronmean);
 
-	    CSCDetId id((*chamber)->geomDetId().rawId());
+	    CSCDetId id(chamber->geomDetId().rawId());
 
 	    if ((id.endcap() == 1? 1: -1)*id.station() == 1  &&  id.ring() == 1) {
 	       m_ymean_mep11->Fill(ymean);  m_ystdev_mep11->Fill(ystdev);  m_yerronmean_mep11->Fill(yerronmean);

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorTemplate.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorTemplate.cc
@@ -62,13 +62,13 @@ void AlignmentMonitorTemplate::book() {
    // This is a procedure that makes one histogram for each selected alignable, and puts them in the iterN directory.
    // This is not a constant-time lookup.  If you need something faster, see AlignmentMonitorMuonHIP, which has a
    // dynamically-allocated array of TH1F*s.
-   std::vector<Alignable*> alignables = pStore()->alignables();
-   for (std::vector<Alignable*>::const_iterator it = alignables.begin();  it != alignables.end();  ++it) {
+   const auto& alignables = pStore()->alignables();
+   for (const auto& it: alignables) {
       char name[256], title[256];
-      snprintf(name, sizeof(name), "xresid%d", (*it)->geomDetId().rawId());
-      snprintf(title, sizeof(title), "x track-hit for DetId %d", (*it)->geomDetId().rawId());
+      snprintf(name, sizeof(name), "xresid%d", it->geomDetId().rawId());
+      snprintf(title, sizeof(title), "x track-hit for DetId %d", it->geomDetId().rawId());
 
-      m_residuals[*it] = book1D("/iterN/", name, title, 100, -5., 5.);
+      m_residuals[it] = book1D("/iterN/", name, title, 100, -5., 5.);
    }
 
    // Important: you create TObject pointers with the "new" operator, but YOU don't delete them.  They're deleted by the

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
@@ -314,7 +314,7 @@ void AlignmentStats::endJob(){
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
   AlignableTracker* theAliTracker=new AlignableTracker(&(*trackerGeometry_), tTopo);
-  const std::vector<Alignable*>& Detunitslist=theAliTracker->deepComponents();
+  const auto& Detunitslist = theAliTracker->deepComponents();
   int ndetunits=Detunitslist.size();
   edm::LogInfo("AlignmentStats")<<"Number of DetUnits in the AlignableTracker: "<< ndetunits<<std::endl;
 

--- a/Alignment/CommonAlignmentParametrization/interface/CompositeAlignmentDerivativesExtractor.h
+++ b/Alignment/CommonAlignmentParametrization/interface/CompositeAlignmentDerivativesExtractor.h
@@ -2,6 +2,7 @@
 #define Alignment_CommonAlignmentParametrization_CompositeAlignmentDerivativesExtractor_H
 
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 
 /// \class CompositeAlignmentDerivativesExtractor
 ///
@@ -22,11 +23,11 @@ class CompositeAlignmentDerivativesExtractor
 public:
   
   /// deprecated  constructor for backward compatibility (use mor general AlignableDetOrUnitPtr)
-  CompositeAlignmentDerivativesExtractor( const std::vector< Alignable* > & alignables,
+  CompositeAlignmentDerivativesExtractor( const align::Alignables & alignables,
 					  const std::vector< AlignableDet* > & alignableDets,
 					  const std::vector< TrajectoryStateOnSurface > & tsos );
   /// constructor
-  CompositeAlignmentDerivativesExtractor( const std::vector< Alignable* > & alignables,
+  CompositeAlignmentDerivativesExtractor( const align::Alignables & alignables,
 					  const std::vector< AlignableDetOrUnitPtr > & alignableDets,
 					  const std::vector< TrajectoryStateOnSurface > & tsos );
 
@@ -38,7 +39,7 @@ public:
   
 private:
   
-  void extractCurrentAlignment( const std::vector< Alignable* > & alignables,
+  void extractCurrentAlignment( const align::Alignables & alignables,
 				const std::vector< AlignableDetOrUnitPtr > & alignableDets,
 				const std::vector< TrajectoryStateOnSurface > & tsos );
   
@@ -47,7 +48,7 @@ private:
   
   void extractWithMultipleHits( const std::vector< AlgebraicVector > & subCorrectionTerm,
 				const std::vector< AlgebraicMatrix > & subDerivatives,
-				const std::vector< Alignable* > & alignables );
+				const align::Alignables & alignables );
   
   AlgebraicMatrix theDerivatives;
   AlgebraicVector theCorrectionTerm;

--- a/Alignment/CommonAlignmentParametrization/interface/CompositeAlignmentParameters.h
+++ b/Alignment/CommonAlignmentParametrization/interface/CompositeAlignmentParameters.h
@@ -4,6 +4,7 @@
 
 #include "Alignment/CommonAlignment/interface/AlignmentParametersData.h"
 #include "Alignment/CommonAlignment/interface/AlignableDetOrUnitPtr.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
 #include <map>
@@ -30,7 +31,7 @@ class CompositeAlignmentParameters
 public:
 
   /// vector of alignable components 
-  typedef std::vector<Alignable*> Components;
+  typedef align::Alignables Components;
 
   typedef std::map<AlignableDetOrUnitPtr,Alignable*> AlignableDetToAlignableMap;
   typedef std::map<Alignable*,int> Aliposmap;
@@ -112,14 +113,14 @@ public:
 
 
   /// Extract parameters for subset of alignables
-  AlgebraicVector parameterSubset ( const std::vector<Alignable*>& vec ) const;
+  AlgebraicVector parameterSubset (const align::Alignables&) const;
 
   /// Extract covariance matrix for subset of alignables
-  AlgebraicSymMatrix covarianceSubset( const std::vector<Alignable*>& vec ) const;
+  AlgebraicSymMatrix covarianceSubset(const align::Alignables&) const;
 
   /// Extract covariance matrix elements between two subsets of alignables
-  AlgebraicMatrix covarianceSubset ( const std::vector<Alignable*>& veci,
-                                     const std::vector<Alignable*>& vecj ) const;
+  AlgebraicMatrix covarianceSubset (const align::Alignables&,
+                                    const align::Alignables&) const;
 
 protected:
   DataContainer theData;
@@ -127,13 +128,13 @@ protected:
 private:
 
   /// Extract position and length of parameters for a subset of Alignables.
-  bool extractPositionAndLength( const std::vector<Alignable*>& alignables,
+  bool extractPositionAndLength( const align::Alignables& alignables,
 				 std::vector<int>& posvec,
 				 std::vector<int>& lenvec,
 				 int& length ) const;
 
   /// Return vector of alignables without multiple occurences.
-  std::vector< Alignable* > extractAlignables( const std::vector< Alignable* >& alignables ) const;
+  align::Alignables extractAlignables(const align::Alignables&) const;
 
   /// backward compatibility method to convert vectors from specific AlignableDet
   /// to more general AlignableDetOrUnitPtr

--- a/Alignment/CommonAlignmentParametrization/src/CompositeAlignmentDerivativesExtractor.cc
+++ b/Alignment/CommonAlignmentParametrization/src/CompositeAlignmentDerivativesExtractor.cc
@@ -9,7 +9,7 @@
 
 //--------------------------------------------------------------------------------------
 CompositeAlignmentDerivativesExtractor::
-CompositeAlignmentDerivativesExtractor( const std::vector< Alignable* > & alignables,
+CompositeAlignmentDerivativesExtractor( const align::Alignables & alignables,
                                         const std::vector< AlignableDet* > & alignableDets,
                                         const std::vector< TrajectoryStateOnSurface > & tsos )
 {
@@ -25,7 +25,7 @@ CompositeAlignmentDerivativesExtractor( const std::vector< Alignable* > & aligna
 
 //--------------------------------------------------------------------------------------
 CompositeAlignmentDerivativesExtractor::
-CompositeAlignmentDerivativesExtractor( const std::vector< Alignable* > & alignables,
+CompositeAlignmentDerivativesExtractor( const align::Alignables & alignables,
                                         const std::vector< AlignableDetOrUnitPtr > & alignableDets,
                                         const std::vector< TrajectoryStateOnSurface > & tsos )
 {
@@ -35,7 +35,7 @@ CompositeAlignmentDerivativesExtractor( const std::vector< Alignable* > & aligna
 //--------------------------------------------------------------------------------------
 
 void CompositeAlignmentDerivativesExtractor::
-extractCurrentAlignment( const std::vector< Alignable* > & alignables,
+extractCurrentAlignment( const align::Alignables & alignables,
                          const std::vector< AlignableDetOrUnitPtr > & alignableDets,
                          const std::vector< TrajectoryStateOnSurface > & tsos )
 {
@@ -57,7 +57,7 @@ extractCurrentAlignment( const std::vector< Alignable* > & alignables,
 	  return;
 	}
 
-  std::vector< Alignable* >::const_iterator itAlignable = alignables.begin();
+  align::Alignables::const_iterator itAlignable = alignables.begin();
   std::vector< AlignableDetOrUnitPtr >::const_iterator itAlignableDet = alignableDets.begin();
   std::vector< TrajectoryStateOnSurface >::const_iterator itTsos = tsos.begin();
 
@@ -143,16 +143,16 @@ extractWithoutMultipleHits( const std::vector< AlgebraicVector > & subCorrection
 //--------------------------------------------------------------------------------------
 
 void CompositeAlignmentDerivativesExtractor::
-extractWithMultipleHits( const std::vector< AlgebraicVector > & subCorrectionTerm,
-						 const std::vector< AlgebraicMatrix > & subDerivatives,
-						 const std::vector< Alignable* > & alignables )
+extractWithMultipleHits(const std::vector<AlgebraicVector>& subCorrectionTerm,
+                        const std::vector<AlgebraicMatrix>& subDerivatives,
+                        const align::Alignables& alignables)
 {
 
   std::vector< AlgebraicVector >::const_iterator itSubCorrectionTerm = subCorrectionTerm.begin();
   std::vector< AlgebraicMatrix >::const_iterator itSubDerivatives = subDerivatives.begin();
-  std::vector< Alignable* >::const_iterator itAlignables = alignables.begin();
-  std::vector< Alignable* >::const_iterator itPosition;
-  std::vector< Alignable* >::const_iterator itLastPosition;
+  align::Alignables::const_iterator itAlignables = alignables.begin();
+  align::Alignables::const_iterator itPosition;
+  align::Alignables::const_iterator itLastPosition;
 
   int iRow = 1;
 

--- a/Alignment/CommonAlignmentParametrization/src/CompositeAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/CompositeAlignmentParameters.cc
@@ -103,7 +103,7 @@ AlgebraicMatrix
 CompositeAlignmentParameters::derivatives( const std::vector<TrajectoryStateOnSurface>& tsosvec,
 					   const std::vector<AlignableDetOrUnitPtr>& alidetvec ) const
 {
-  std::vector<Alignable*> alivec;
+  align::Alignables alivec;
   for (std::vector<AlignableDetOrUnitPtr>::const_iterator it=alidetvec.begin(); it!=alidetvec.end(); ++it)
     alivec.push_back(alignableFromAlignableDet(*it));
   
@@ -127,7 +127,7 @@ AlgebraicVector
 CompositeAlignmentParameters::correctionTerm( const std::vector<TrajectoryStateOnSurface>& tsosvec,
 					      const std::vector<AlignableDetOrUnitPtr>& alidetvec) const
 {
-  std::vector<Alignable*> alivec;
+  align::Alignables alivec;
   for (std::vector<AlignableDetOrUnitPtr>::const_iterator it=alidetvec.begin(); it!=alidetvec.end(); ++it )
     alivec.push_back(alignableFromAlignableDet(*it));
   
@@ -271,9 +271,9 @@ CompositeAlignmentParameters::alignableFromAlignableDet(const AlignableDetOrUnit
 
 //__________________________________________________________________________________________________
 AlgebraicVector
-CompositeAlignmentParameters::parameterSubset( const std::vector<Alignable*>& vec ) const
+CompositeAlignmentParameters::parameterSubset( const align::Alignables& vec ) const
 {
-  const std::vector< Alignable* > sel = extractAlignables( vec );
+  const auto& sel = extractAlignables(vec);
 
   const unsigned int nali = sel.size();
   int ndim = 0;
@@ -309,9 +309,9 @@ CompositeAlignmentParameters::parameterSubset( const std::vector<Alignable*>& ve
 //__________________________________________________________________________________________________
 // extract covariance matrix for a subset of alignables
 AlgebraicSymMatrix 
-CompositeAlignmentParameters::covarianceSubset( const std::vector<Alignable*>& vec ) const
+CompositeAlignmentParameters::covarianceSubset( const align::Alignables& vec ) const
 {
-  const std::vector< Alignable* > sel = extractAlignables( vec );
+  const auto& sel = extractAlignables(vec);
 
   const unsigned int nali = sel.size();
   int ndim = 0;
@@ -357,11 +357,11 @@ CompositeAlignmentParameters::covarianceSubset( const std::vector<Alignable*>& v
 //__________________________________________________________________________________________________
 // extract covariance matrix elements between two subsets of alignables
 AlgebraicMatrix 
-CompositeAlignmentParameters::covarianceSubset( const std::vector<Alignable*>& veci, 
-						const std::vector<Alignable*>& vecj ) const
+CompositeAlignmentParameters::covarianceSubset( const align::Alignables& veci, 
+						const align::Alignables& vecj ) const
 {
-  const std::vector< Alignable* > seli = extractAlignables( veci );
-  const std::vector< Alignable* > selj = extractAlignables( vecj );
+  const auto& seli = extractAlignables( veci );
+  const auto& selj = extractAlignables( vecj );
 
   int ndimi=0;
   int ndimj=0;
@@ -413,17 +413,16 @@ CompositeAlignmentParameters::covarianceSubset( const std::vector<Alignable*>& v
 //__________________________________________________________________________________________________
 // Extract position and length of parameters for a subset of Alignables.
 bool
-CompositeAlignmentParameters::extractPositionAndLength( const std::vector<Alignable*>& alignables,
+CompositeAlignmentParameters::extractPositionAndLength( const align::Alignables& alignables,
 							std::vector<int>& posvec,
 							std::vector<int>& lenvec,
 							int& length ) const
 {
   length = 0;
 
-  for ( std::vector<Alignable*>::const_iterator it = alignables.begin(); it != alignables.end(); ++it ) 
-  {
+  for (const auto& it: alignables) {
     // check if in components 
-    if ( std::find( theComponents.begin(), theComponents.end(), *it ) == theComponents.end() ) 
+    if ( std::find( theComponents.begin(), theComponents.end(), it ) == theComponents.end() ) 
     {
       edm::LogError( "NotFound" ) << "@SUB=CompositeAlignmentParameters::extractPositionAndLength"
 				  << "Alignable not found in components!";
@@ -431,8 +430,8 @@ CompositeAlignmentParameters::extractPositionAndLength( const std::vector<Aligna
     }
 
     // get pos/length
-    Aliposmap::const_iterator iposmap = theAliposmap.find( *it );
-    Alilenmap::const_iterator ilenmap = theAlilenmap.find( *it );
+    Aliposmap::const_iterator iposmap = theAliposmap.find(it);
+    Alilenmap::const_iterator ilenmap = theAlilenmap.find(it);
     if ( iposmap == theAliposmap.end() || ilenmap == theAlilenmap.end() ) 
     {
       edm::LogError( "NotFound" ) << "@SUB=CompositeAlignmentParameters::extractPositionAndLength"
@@ -449,15 +448,13 @@ CompositeAlignmentParameters::extractPositionAndLength( const std::vector<Aligna
 
 
 //__________________________________________________________________________________________________
-std::vector< Alignable* >
-CompositeAlignmentParameters::extractAlignables( const std::vector< Alignable* >& alignables ) const
+align::Alignables
+CompositeAlignmentParameters::extractAlignables(const align::Alignables& alignables) const
 {
-  std::vector< Alignable* > result;
+  align::Alignables result;
 
-  std::vector< Alignable* >::const_iterator itA, itEnd;
-  for ( itA = alignables.begin(), itEnd = alignables.end(); itA != itEnd; ++itA )
-  {
-    if ( std::find( result.begin(), result.end(), *itA ) == result.end() ) result.push_back( *itA );
+  for (const auto& itA: alignables) {
+    if (std::find( result.begin(), result.end(), itA ) == result.end()) result.push_back(itA);
   }
 
   return result;

--- a/Alignment/HIPAlignmentAlgorithm/interface/HIPAlignmentAlgorithm.h
+++ b/Alignment/HIPAlignmentAlgorithm/interface/HIPAlignmentAlgorithm.h
@@ -89,7 +89,7 @@ private:
 
   std::unique_ptr<AlignableObjectId> alignableObjectId_;
   AlignmentParameterStore* theAlignmentParameterStore;
-  std::vector<Alignable*> theAlignables;
+  align::Alignables theAlignables;
   std::unique_ptr<AlignableNavigator> theAlignableDetAccessor;
 
   AlignmentIORoot theIO;
@@ -113,7 +113,7 @@ private:
   // alignment position error parameters
   bool theApplyAPE;
   std::vector<edm::ParameterSet> theAPEParameterSet;
-  std::vector<std::pair<std::vector<Alignable*>, std::vector<double> > > theAPEParameters;
+  std::vector<std::pair<align::Alignables, std::vector<double> > > theAPEParameters;
 
   // Default alignment specifications
   // - min number of hits on alignable to calc parameters

--- a/Alignment/HIPAlignmentAlgorithm/interface/HIPUserVariablesIORoot.h
+++ b/Alignment/HIPAlignmentAlgorithm/interface/HIPUserVariablesIORoot.h
@@ -1,6 +1,7 @@
 #ifndef HIPUserVariablesIORoot_H
 #define HIPUserVariablesIORoot_H
 
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORootBase.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentUserVariablesIO.h"
 
@@ -8,7 +9,7 @@
 
 class HIPUserVariablesIORoot : public AlignmentIORootBase, public AlignmentUserVariablesIO{
 public:
-  typedef std::vector<Alignable*> Alignables;
+  using Alignables = align::Alignables;
 
   /** constructor */
   HIPUserVariablesIORoot();

--- a/Alignment/LaserAlignment/src/LASGeometryUpdater.cc
+++ b/Alignment/LaserAlignment/src/LASGeometryUpdater.cc
@@ -1,5 +1,6 @@
 
 #include "Alignment/LaserAlignment/interface/LASGeometryUpdater.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 
 
 ///
@@ -129,7 +130,7 @@ void LASGeometryUpdater::TrackerUpdate( LASEndcapAlignmentParameterSet& endcapPa
 
   // re-arrange to match the structure in LASBarrelAlignmentParameterSet and simplify the loop
   // 2 (TIB+), 3 (TIB-), 4 (TOB+), 5 (TOB-)
-  std::vector<Alignable*> theHalfBarrels( 6 );
+  align::Alignables theHalfBarrels( 6 );
   theHalfBarrels.at( 0 ) = theEndcaps.at( 0 ); // TEC+
   theHalfBarrels.at( 1 ) = theEndcaps.at( 1 ); // TEC-
   theHalfBarrels.at( 2 ) = theInnerHalfBarrels.at( 1 ); // TIB+

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeVariablesIORoot.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeVariablesIORoot.h
@@ -12,6 +12,7 @@
 ///  (last update by $Author: flucke $)
 
 
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORootBase.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentUserVariablesIO.h"
 
@@ -34,12 +35,12 @@ class MillePedeVariablesIORoot : public AlignmentIORootBase, public AlignmentUse
   ~MillePedeVariablesIORoot() override {}
 
   /** write user variables */
-  void writeMillePedeVariables(const std::vector<Alignable*> &alivec, const char *filename,
+  void writeMillePedeVariables(const align::Alignables &alivec, const char *filename,
 			       int iter, bool validCheck, int &ierr);
 
   /** read user variables (not that their memory is owned by this class!) */
   std::vector<AlignmentUserVariables*> readMillePedeVariables
-    (const std::vector<Alignable*> &alivec, const char *filename, int iter, int &ierr);
+    (const align::Alignables &alivec, const char *filename, int iter, int &ierr);
 
  protected:
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -1064,7 +1064,7 @@ bool MillePedeAlignmentAlgorithm::readFromPede(const edm::ParameterSet &mprespse
   bool allEmpty = this->areEmptyParams(theAlignables);
 
   PedeReader reader(mprespset, *thePedeSteer, *thePedeLabels, runrange);
-  std::vector<Alignable*> alis;
+  align::Alignables alis;
   bool okRead = reader.read(alis, setUserVars); // also may set params of IntegratedCalibration's
   bool numMatch = true;
 
@@ -1095,12 +1095,11 @@ bool MillePedeAlignmentAlgorithm::readFromPede(const edm::ParameterSet &mprespse
 }
 
 //__________________________________________________________________________________________________
-bool MillePedeAlignmentAlgorithm::areEmptyParams(const std::vector<Alignable*> &alignables) const
+bool MillePedeAlignmentAlgorithm::areEmptyParams(const align::Alignables& alignables) const
 {
 
-  for (std::vector<Alignable*>::const_iterator iAli = alignables.begin();
-       iAli != alignables.end(); ++iAli) {
-    const AlignmentParameters *params = (*iAli)->alignmentParameters();
+  for (const auto& iAli: alignables) {
+    const AlignmentParameters *params = iAli->alignmentParameters();
     if (params) {
       const auto& parVec(params->parameters());
       const auto& parCov(params->covariance());
@@ -1177,7 +1176,7 @@ unsigned int MillePedeAlignmentAlgorithm::doIO(int loop) const
 }
 
 //__________________________________________________________________________________________________
-void MillePedeAlignmentAlgorithm::buildUserVariables(const std::vector<Alignable*> &alis) const
+void MillePedeAlignmentAlgorithm::buildUserVariables(const align::Alignables& alis) const
 {
   for (const auto& iAli: alis) {
     AlignmentParameters *params = iAli->alignmentParameters();
@@ -1254,13 +1253,12 @@ bool MillePedeAlignmentAlgorithm::addHitStatistics(int fromIov, const std::strin
 }
 
 //__________________________________________________________________________________________________
-bool MillePedeAlignmentAlgorithm::addHits(const std::vector<Alignable*> &alis,
+bool MillePedeAlignmentAlgorithm::addHits(const align::Alignables& alis,
                                           const std::vector<AlignmentUserVariables*> &mpVars) const
 {
   bool allOk = (mpVars.size() == alis.size());
   std::vector<AlignmentUserVariables*>::const_iterator iUser = mpVars.begin();
-  for (std::vector<Alignable*>::const_iterator iAli = alis.begin();
-       iAli != alis.end() && iUser != mpVars.end(); ++iAli, ++iUser) {
+  for (auto iAli = alis.cbegin(); iAli != alis.cend() && iUser != mpVars.end(); ++iAli, ++iUser) {
     MillePedeVariables *mpVarNew = dynamic_cast<MillePedeVariables*>(*iUser);
     AlignmentParameters *ps = (*iAli)->alignmentParameters();
     MillePedeVariables *mpVarOld = (ps ? dynamic_cast<MillePedeVariables*>(ps->userVariables()) : nullptr);

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -234,10 +234,10 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   /// read pede input defined by 'psetName', flag to create/not create MillePedeVariables
   bool readFromPede(const edm::ParameterSet &mprespset, bool setUserVars,
                     const RunRange &runrange);
-  bool areEmptyParams(const std::vector<Alignable*> &alignables) const;
+  bool areEmptyParams(const align::Alignables& alignables) const;
   unsigned int doIO(int loop) const;
   /// add MillePedeVariables for each AlignmentParameters (exception if no parameters...)
-  void buildUserVariables(const std::vector<Alignable*> &alignables) const;
+  void buildUserVariables(const align::Alignables& alignables) const;
 
   /// Generates list of files to read, given the list and dir from the configuration.
   /// This will automatically expand formatting directives, if they appear.
@@ -265,14 +265,14 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   bool isMode(unsigned int testMode) const {return (theMode & testMode);}
   bool addHitStatistics(int fromLoop, const std::string &outFile,
                         const std::vector<std::string> &inFiles) const;
-  bool addHits(const std::vector<Alignable*> &alis,
+  bool addHits(const align::Alignables& alis,
                const std::vector<AlignmentUserVariables*> &mpVars) const;
 
   edm::ParameterSet         theConfig;
   unsigned int              theMode;
   std::string               theDir; /// directory for all kind of files
   AlignmentParameterStore  *theAlignmentParameterStore;
-  std::vector<Alignable*>   theAlignables;
+  align::Alignables         theAlignables;
   std::unique_ptr<AlignableNavigator>    theAlignableNavigator;
   std::unique_ptr<MillePedeMonitor>      theMonitor;
   std::unique_ptr<Mille>                 theMille;

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MomentumDependentPedeLabeler.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MomentumDependentPedeLabeler.cc
@@ -30,7 +30,7 @@ MomentumDependentPedeLabeler::MomentumDependentPedeLabeler(const PedeLabelerBase
     theOpenMomentumRange(std::pair<float,float>(0.0, 10000.0)),
     theMaxNumberOfParameterInstances(0)
 {
-  std::vector<Alignable*> alis;
+  align::Alignables alis;
   alis.push_back(alignables.aliTracker_);
   alis.push_back(alignables.aliMuon_);
   
@@ -354,7 +354,7 @@ unsigned int MomentumDependentPedeLabeler::buildMomentumDependencyMap(AlignableT
       selector.clear();
       selector.addSelection(decompSel[0], paramSelDumthe);
 
-      const std::vector<Alignable*> &alis = selector.selectedAlignables();
+      const auto& alis = selector.selectedAlignables();
       for (const auto& iAli: alis) {
 
         if(iAli->alignmentParameters() == nullptr) {
@@ -396,11 +396,11 @@ unsigned int MomentumDependentPedeLabeler::buildMomentumDependencyMap(AlignableT
 }
 
 //_________________________________________________________________________
-unsigned int MomentumDependentPedeLabeler::buildMap(const std::vector<Alignable*> &alis)
+unsigned int MomentumDependentPedeLabeler::buildMap(const align::Alignables& alis)
 {
   theAlignableToIdMap.clear(); // just in case of re-use...
 
-  std::vector<Alignable*> allComps;
+  align::Alignables allComps;
   
   for (const auto& iAli: alis) {
     if (iAli) {

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MomentumDependentPedeLabeler.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MomentumDependentPedeLabeler.h
@@ -18,6 +18,7 @@
 
 #include <Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h>
 
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 /***************************************
@@ -86,7 +87,7 @@ class MomentumDependentPedeLabeler : public PedeLabelerBase
 					  const edm::ParameterSet &config);
 
   /// returns size of map
-  unsigned int buildMap(const std::vector<Alignable*> &alis);
+  unsigned int buildMap(const align::Alignables&);
   /// returns size of map
   unsigned int buildReverseMap();
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/PedeLabeler.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/PedeLabeler.cc
@@ -23,7 +23,7 @@ PedeLabeler::PedeLabeler(const PedeLabelerBase::TopLevelAlignables& alignables,
 			 const edm::ParameterSet& config)
   :PedeLabelerBase(alignables, config)
 {
-  std::vector<Alignable*> alis;
+  align::Alignables alis;
   alis.push_back(alignables.aliTracker_);
   alis.push_back(alignables.aliMuon_);
 
@@ -150,11 +150,11 @@ unsigned int PedeLabeler::lasBeamIdFromLabel(unsigned int label) const
 }
 
 //_________________________________________________________________________
-unsigned int PedeLabeler::buildMap(const std::vector<Alignable*> &alis)
+unsigned int PedeLabeler::buildMap(const align::Alignables& alis)
 {
   theAlignableToIdMap.clear(); // just in case of re-use...
 
-  std::vector<Alignable*> allComps;
+  align::Alignables allComps;
 
   for (const auto& iAli: alis) {
     if (iAli) {

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/PedeLabeler.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/PedeLabeler.h
@@ -18,6 +18,7 @@
 
 #include <Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h>
 
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 /***************************************
@@ -69,7 +70,7 @@ class PedeLabeler : public PedeLabelerBase
   typedef std::map <unsigned int, unsigned int> UintUintMap;
 
   /// returns size of map
-  unsigned int buildMap(const std::vector<Alignable*> &alis);
+  unsigned int buildMap(const align::Alignables&);
   /// returns size of map
   unsigned int buildReverseMap();
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/RunRangeDependentPedeLabeler.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/RunRangeDependentPedeLabeler.cc
@@ -30,7 +30,7 @@ RunRangeDependentPedeLabeler::RunRangeDependentPedeLabeler(const PedeLabelerBase
   : PedeLabelerBase(alignables, config),
     theMaxNumberOfParameterInstances(0)
 {
-  std::vector<Alignable*> alis;
+  align::Alignables alis;
   alis.push_back(alignables.aliTracker_);
   alis.push_back(alignables.aliMuon_);
 
@@ -410,7 +410,7 @@ unsigned int RunRangeDependentPedeLabeler::buildRunRangeDependencyMap(AlignableT
       selector.clear();
       selector.addSelection(decompSel[0], paramSelDummy);
 
-      const std::vector<Alignable*> &alis = selector.selectedAlignables();
+      const auto& alis = selector.selectedAlignables();
        
       for (const auto& iAli: alis) {
         
@@ -453,11 +453,11 @@ unsigned int RunRangeDependentPedeLabeler::buildRunRangeDependencyMap(AlignableT
 }
 
 //_________________________________________________________________________
-unsigned int RunRangeDependentPedeLabeler::buildMap(const std::vector<Alignable*> &alis)
+unsigned int RunRangeDependentPedeLabeler::buildMap(const align::Alignables& alis)
 {
   theAlignableToIdMap.clear(); // just in case of re-use...
 
-  std::vector<Alignable*> allComps;
+  align::Alignables allComps;
   
   for (const auto& iAli: alis) {
     if (iAli) {

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/RunRangeDependentPedeLabeler.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/RunRangeDependentPedeLabeler.h
@@ -20,6 +20,7 @@
 
 #include "CondFormats/Common/interface/Time.h"
 
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace edm {
@@ -95,7 +96,7 @@ class RunRangeDependentPedeLabeler : public PedeLabelerBase
 				     const edm::ParameterSet &config);
 
   /// returns size of map
-  unsigned int buildMap(const std::vector<Alignable*> &alis);
+  unsigned int buildMap(const align::Alignables&);
   /// returns size of map
   unsigned int buildReverseMap();
 

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeVariablesIORoot.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeVariablesIORoot.cc
@@ -35,7 +35,7 @@ MillePedeVariablesIORoot::MillePedeVariablesIORoot() :
 
 // -------------------------------------------------------------------------------------------------
 void MillePedeVariablesIORoot::writeMillePedeVariables
-(const std::vector<Alignable*> &alivec, const char *filename, int iter, bool validCheck, int &ierr)
+(const align::Alignables& alivec, const char *filename, int iter, bool validCheck, int &ierr)
 {
   ierr = 0;
 
@@ -60,7 +60,7 @@ void MillePedeVariablesIORoot::writeMillePedeVariables
 
 // -------------------------------------------------------------------------------------------------
 std::vector<AlignmentUserVariables*> MillePedeVariablesIORoot::readMillePedeVariables
-(const std::vector<Alignable*> &alivec, const char *filename, int iter, int &ierr)
+(const align::Alignables& alivec, const char *filename, int iter, int &ierr)
 {
   std::vector<AlignmentUserVariables*> result;
   ierr = 0;

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeReader.cc
@@ -51,7 +51,7 @@ PedeReader::PedeReader(const edm::ParameterSet &config, const PedeSteerer &steer
 }
 
 //__________________________________________________________________________________________________
-bool PedeReader::read(std::vector<Alignable*> &alignables, bool setUserVars)
+bool PedeReader::read(align::Alignables& alignables, bool setUserVars)
 {
   alignables.clear();
   myPedeResult.seekg(0, std::ios::beg); // back to start

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeReader.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include <Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h>
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 
 class PedeSteerer;
 class PedeLabelerBase;
@@ -45,7 +46,7 @@ class PedeReader
   /// (if they fit to the run range). If (setUserVars == true) also care about
   /// MillePedeVariables.
   /// Also treats parameters belonging to a IntegratedCalibrationBase.
-  bool read(std::vector<Alignable*> &alignables, bool setUserVars);
+  bool read(align::Alignables& alignables, bool setUserVars);
   /// true if 'outValue' could be read via operator >> from the current line (!) of aStream,
   /// false otherwise
   template<class T>

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
@@ -91,8 +91,8 @@ PedeSteerer::PedeSteerer(AlignableTracker *aliTracker, AlignableMuon *aliMuon, A
     // - but the addComponent(..) method is so cute that it calculates position from 
     //   daughters' deepComponents()
     // - so we want to move it back to (0,0,0), but ali->move(..) would move daughters as well
-    //   => cheat with a const_cast and move only the surface back
-    // - this hacked master object does not have a label for its parameters
+    //   => move only the surface back
+    // - this master object does not have a label for its parameters
     //   => some warnings if debug output selected in pedeSteer files
     // - we must not delete our new master (little mem. leak...) since that would delete
     //   the daughters as well!
@@ -112,9 +112,7 @@ PedeSteerer::PedeSteerer(AlignableTracker *aliTracker, AlignableMuon *aliMuon, A
       for (const auto& it: allExtras ) theCoordMaster->addComponent(it);
     }
 
-    const Alignable::PositionType &tmpPos = theCoordMaster->globalPosition();
-    AlignableSurface & masterSurf = const_cast<AlignableSurface&>(theCoordMaster->surface());
-    masterSurf.move(align::GlobalVector(-tmpPos.x(),-tmpPos.y(),-tmpPos.z()));
+    theCoordMaster->recenterSurface();
 
     if (this->isCorrectToRefSystem(theCoordDefiners)) { // defined by 's' (MC): 'correct' misalignment
       this->correctToReferenceSystem(); // really before 'defineCoordinates'?

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
@@ -78,7 +78,7 @@ PedeSteerer::PedeSteerer(AlignableTracker *aliTracker, AlignableMuon *aliMuon, A
     myDirectory += '/'; // directory may need '/'
   }
 
-  const std::vector<Alignable*> &alis = myParameterStore->alignables();
+  const auto& alis = myParameterStore->alignables();
   if (!this->checkParameterChoices(alis)) {} // anyway thrown exception
 
   // Coordinate system selection and correction before everything
@@ -109,9 +109,7 @@ PedeSteerer::PedeSteerer(AlignableTracker *aliTracker, AlignableMuon *aliMuon, A
     if (aliMuon) theCoordMaster->addComponent(aliMuon); // tracker is already added if existing
     if (aliExtras) { // tracker and/or muon are already added if existing
       align::Alignables allExtras = aliExtras->components();
-      for ( std::vector<Alignable*>::iterator it = allExtras.begin(); it != allExtras.end(); ++it ) {
-	theCoordMaster->addComponent(*it);
-      }
+      for (const auto& it: allExtras ) theCoordMaster->addComponent(it);
     }
 
     const Alignable::PositionType &tmpPos = theCoordMaster->globalPosition();
@@ -159,12 +157,12 @@ double PedeSteerer::cmsToPedeFactor(unsigned int parNum) const
 }
 
 //_________________________________________________________________________
-unsigned int PedeSteerer::buildNoHierarchyCollection(const std::vector<Alignable*> &alis)
+unsigned int PedeSteerer::buildNoHierarchyCollection(const align::Alignables& alis)
 {
   myNoHieraCollection.clear();  // just in case of re-use...
 
-  for (std::vector<Alignable*>::const_iterator iAli = alis.begin() ; iAli != alis.end(); ++iAli) {
-    AlignmentParameters *params = (*iAli)->alignmentParameters();
+  for (const auto& iAli: alis) {
+    AlignmentParameters *params = iAli->alignmentParameters();
     SelectionUserVariables *selVar = dynamic_cast<SelectionUserVariables*>(params->userVariables());
     if (!selVar) continue;
     // Now check whether taking out of hierarchy is selected - must be consistent!
@@ -186,12 +184,12 @@ unsigned int PedeSteerer::buildNoHierarchyCollection(const std::vector<Alignable
 	  << " taken out of the hierarchy must be marked with capital letters 'C', 'F' or 'H'!";
       }
       bool isInHiera = false; // Check whether Alignable is really part of hierarchy:
-      Alignable *mother = *iAli;
+      auto mother = iAli;
       while ((mother = mother->mother())) {
 	if (mother->alignmentParameters()) isInHiera = true; // could 'break;', but loop is short
       }
       // Complain, but keep collection short if not in hierarchy:
-      if (isInHiera) myNoHieraCollection.insert(*iAli);
+      if (isInHiera) myNoHieraCollection.insert(iAli);
       else edm::LogWarning("Alignment") << "@SUB=PedeSteerer::buildNoHierarchyCollection"
 					<< "Alignable not in hierarchy, no need to remove it!";
     }
@@ -201,10 +199,10 @@ unsigned int PedeSteerer::buildNoHierarchyCollection(const std::vector<Alignable
 }
 
 //_________________________________________________________________________
-bool PedeSteerer::checkParameterChoices(const std::vector<Alignable*> &alis) const
+bool PedeSteerer::checkParameterChoices(const align::Alignables& alis) const
 {
-  for (std::vector<Alignable*>::const_iterator iAli = alis.begin() ; iAli != alis.end(); ++iAli) {
-    AlignmentParameters *paras = (*iAli)->alignmentParameters();
+  for (const auto& iAli: alis) {
+    AlignmentParameters *paras = iAli->alignmentParameters();
     SelectionUserVariables *selVar = dynamic_cast<SelectionUserVariables*>(paras->userVariables());
     if (!selVar) continue;
     for (unsigned int iParam = 0; static_cast<int>(iParam) < paras->size(); ++iParam) {
@@ -229,23 +227,23 @@ bool PedeSteerer::checkParameterChoices(const std::vector<Alignable*> &alis) con
 
 //_________________________________________________________________________
 std::pair<unsigned int, unsigned int>
-PedeSteerer::fixParameters(const std::vector<Alignable*> &alis, const std::string &fileName)
+PedeSteerer::fixParameters(const align::Alignables& alis, const std::string &fileName)
 {
   // return number of parameters fixed at 0. and fixed at original position 
   std::pair<unsigned int, unsigned int> numFixNumFixCor(0, 0);
 
   std::ofstream *filePtr = nullptr;
 
-  for (std::vector<Alignable*>::const_iterator iAli = alis.begin() ; iAli != alis.end(); ++iAli) {
+  for (const auto& iAli: alis) {
 
-    AlignmentParameters *params = (*iAli)->alignmentParameters();
+    AlignmentParameters *params = iAli->alignmentParameters();
     SelectionUserVariables *selVar = dynamic_cast<SelectionUserVariables*>(params->userVariables());
     if (!selVar) continue;
     
     for (unsigned int iParam = 0; static_cast<int>(iParam) < params->size(); ++iParam) {
-      const unsigned int nInstances = myLabels->numberOfParameterInstances(*iAli, iParam);
+      const unsigned int nInstances = myLabels->numberOfParameterInstances(iAli, iParam);
       for (unsigned int iInstance=0;iInstance<nInstances;++iInstance) {
-	int whichFix = this->fixParameter(*iAli, iInstance, iParam,
+	int whichFix = this->fixParameter(iAli, iInstance, iParam,
 					  selVar->fullSelection()[iParam], filePtr,
 					  fileName);
 	if (whichFix == 1) {
@@ -302,12 +300,12 @@ int PedeSteerer::fixParameter(Alignable *ali, unsigned int iInstance,
 }
 
 //_________________________________________________________________________
-std::vector<Alignable*> PedeSteerer::selectCoordinateAlis(const std::vector<Alignable*> &alis) const
+align::Alignables PedeSteerer::selectCoordinateAlis(const align::Alignables& alis) const
 {
-  std::vector<Alignable*> coordAlis;
+  align::Alignables coordAlis;
 
-  for (std::vector<Alignable*>::const_iterator iAli = alis.begin() ; iAli != alis.end(); ++iAli) {
-    AlignmentParameters *params = (*iAli)->alignmentParameters();
+  for (const auto& iAli: alis) {
+    AlignmentParameters *params = iAli->alignmentParameters();
     SelectionUserVariables *selVar = dynamic_cast<SelectionUserVariables*>(params->userVariables());
     if (!selVar) continue;
     unsigned int refParam = 0;
@@ -327,7 +325,7 @@ std::vector<Alignable*> PedeSteerer::selectCoordinateAlis(const std::vector<Alig
 	  << "[PedeSteerer::selectCoordinateAlis] All active parameters of alignables defining "
 	  << "the coordinate system must be marked with 'r/s' (or fixed, 'f')!";
       } else {
-	Alignable *mother = *iAli;
+	auto mother = iAli;
 	while ((mother = mother->mother())) {
 	  if (mother->alignmentParameters()) {
 	    throw cms::Exception("BadConfig") << "[PedeSteerer::selectCoordinateAlis] "
@@ -335,7 +333,7 @@ std::vector<Alignable*> PedeSteerer::selectCoordinateAlis(const std::vector<Alig
 					      << "be highest level!";
 	  }
 	}
-	coordAlis.push_back(*iAli);
+	coordAlis.push_back(iAli);
       }
     }
   } // end loop on alignables
@@ -345,7 +343,7 @@ std::vector<Alignable*> PedeSteerer::selectCoordinateAlis(const std::vector<Alig
 
 
 //_________________________________________________________________________
-void PedeSteerer::defineCoordinates(const std::vector<Alignable*> &alis, Alignable *aliMaster,
+void PedeSteerer::defineCoordinates(const align::Alignables& alis, Alignable *aliMaster,
 				    const std::string &fileName)
 {
   std::ofstream *filePtr = this->createSteerFile(fileName, true);
@@ -367,15 +365,14 @@ void PedeSteerer::defineCoordinates(const std::vector<Alignable*> &alis, Alignab
 }
 
 //_________________________________________________________________________
-bool PedeSteerer::isCorrectToRefSystem(const std::vector<Alignable*> &coordDefiners) const
+bool PedeSteerer::isCorrectToRefSystem(const align::Alignables& coordDefiners) const
 {
   bool doCorrect = false;
   bool doNotCorrect = false;
-  for (std::vector<Alignable*>::const_iterator it = coordDefiners.begin(), iE=coordDefiners.end();
-       it != iE; ++it) {
+  for (const auto& it: coordDefiners) {
     SelectionUserVariables *selVar = 
-      ((*it)->alignmentParameters() ? 
-       dynamic_cast<SelectionUserVariables*>((*it)->alignmentParameters()->userVariables()) : nullptr);
+      (it->alignmentParameters() ? 
+       dynamic_cast<SelectionUserVariables*>(it->alignmentParameters()->userVariables()) : nullptr);
     if (!selVar) continue;  // is an error!?
 
     for (unsigned int i = 0; i < selVar->fullSelection().size(); ++i) {
@@ -398,18 +395,16 @@ void PedeSteerer::correctToReferenceSystem()
   typedef RigidBodyAlignmentParameters RbPars;
   if (!theCoordMaster || theCoordDefiners.empty()) return; // nothing was defined
 
-  std::vector<Alignable*> definerDets; // or ...DetUnits
-  for (std::vector<Alignable*>::iterator it = theCoordDefiners.begin(), iE = theCoordDefiners.end();
-       it != iE; ++it) {// find lowest level objects of alignables that define the coordinate system
-    const std::vector<Alignable*> &comp = (*it)->deepComponents();
+  align::Alignables definerDets; // or ...DetUnits
+  for (const auto& it: theCoordDefiners) {// find lowest level objects of alignables that define the coordinate system
+    const auto& comp = it->deepComponents();
     definerDets.insert(definerDets.end(), comp.begin(), comp.end());
   }
 
   for (unsigned int iLoop = 0; ; ++iLoop) { // iterate: shifts and rotations are not independent
     AlgebraicVector meanPars(RbPars::N_PARAM);
-    for (std::vector<Alignable*>::iterator it = definerDets.begin(), iE = definerDets.end();
-	 it != iE; ++it) { // sum up mean displacements/misrotations:
-      meanPars += RbPars(*it, true).globalParameters();// requires theCoordMaster has global frame
+    for (const auto& it: definerDets) { // sum up mean displacements/misrotations:
+      meanPars += RbPars(it, true).globalParameters();// requires theCoordMaster has global frame
     }
     meanPars /= definerDets.size();
     const align::Scalar squareSum = meanPars.normsq();
@@ -441,20 +436,19 @@ void PedeSteerer::correctToReferenceSystem()
 }
 
 //_________________________________________________________________________
-unsigned int PedeSteerer::hierarchyConstraints(const std::vector<Alignable*> &alis,
+unsigned int PedeSteerer::hierarchyConstraints(const align::Alignables& alis,
 					       const std::string &fileName)
 {
   std::ofstream *filePtr = nullptr;
 
   unsigned int nConstraints = 0;
-  std::vector<Alignable*> aliDaughts;
-  for (std::vector<Alignable*>::const_iterator iA = alis.begin(), iEnd = alis.end();
-       iA != iEnd; ++iA) {
+  align::Alignables aliDaughts;
+  for (const auto& iA: alis) {
     aliDaughts.clear();
-    if (!(*iA)->firstCompsWithParams(aliDaughts)) {
+    if (!(iA->firstCompsWithParams(aliDaughts))) {
       edm::LogWarning("Alignment") << "@SUB=PedeSteerer::hierarchyConstraints"
 				   << "Some but not all daughters of "
-				   << alignableObjectId_.idToString((*iA)->alignableObjectId())
+				   << alignableObjectId_.idToString(iA->alignableObjectId())
 				   << " with params!";
     }
     //     edm::LogInfo("Alignment") << "@SUB=PedeSteerer::hierarchyConstraints"
@@ -462,14 +456,14 @@ unsigned int PedeSteerer::hierarchyConstraints(const std::vector<Alignable*> &al
     if (aliDaughts.empty()) continue;
     //     edm::LogInfo("Alignment") << "@SUB=PedeSteerer::hierarchyConstraints"
     // 			      << aliDaughts.size() << " alignable components ("
-    // 			      << (*iA)->size() << " in total) for " 
-    // 			      << aliId.alignableTypeName(*iA) 
-    // 			      << ", layer " << aliId.typeAndLayerFromAlignable(*iA).second
-    // 			      << ", position " << (*iA)->globalPosition()
-    // 			      << ", r = " << (*iA)->globalPosition().perp();
+    // 			      << iA->size() << " in total) for " 
+    // 			      << aliId.alignableTypeName(iA) 
+    // 			      << ", layer " << aliId.typeAndLayerFromAlignable(iA).second
+    // 			      << ", position " << (iA)->globalPosition()
+    // 			      << ", r = " << (iA)->globalPosition().perp();
     if (!filePtr) filePtr = this->createSteerFile(fileName, true);
     ++nConstraints;
-    this->hierarchyConstraint(*iA, aliDaughts, *filePtr);
+    this->hierarchyConstraint(iA, aliDaughts, *filePtr);
   }
 
   delete filePtr; // automatically flushes, no problem if NULL ptr.   
@@ -478,7 +472,7 @@ unsigned int PedeSteerer::hierarchyConstraints(const std::vector<Alignable*> &al
 }
 //_________________________________________________________________________
 void PedeSteerer::hierarchyConstraint(const Alignable *ali,
-                                      const std::vector<Alignable*> &components,
+                                      const align::Alignables& components,
 				      std::ofstream &file) const
 {
   typedef AlignmentParameterStore::ParameterId ParameterId;
@@ -549,7 +543,7 @@ void PedeSteerer::hierarchyConstraint(const Alignable *ali,
 //_________________________________________________________________________
 unsigned int PedeSteerer::presigmas(const std::vector<edm::ParameterSet> &cffPresi,
                                     const std::string &fileName,
-                                    const std::vector<Alignable*> &alis,
+                                    const align::Alignables& alis,
                                     AlignableTracker *aliTracker, AlignableMuon *aliMuon, AlignableExtras *aliExtras)
 {
   // We loop on given PSet's, each containing a parameter selection and the presigma value
@@ -562,7 +556,7 @@ unsigned int PedeSteerer::presigmas(const std::vector<edm::ParameterSet> &cffPre
        iSet != iE; ++iSet) { // loop on individual PSets defining ali-params with their presigma
     selector.clear();
     selector.addSelections((*iSet).getParameter<edm::ParameterSet>("Selector"));
-    const std::vector<Alignable*> &alis = selector.selectedAlignables();
+    const auto& alis = selector.selectedAlignables();
     const std::vector<std::vector<char> > &sels =  selector.selectedParameters();
     const float presigma = (*iSet).getParameter<double>("presigma");
     if (presigma <= 0.) { // given presigma > 0., 0. later used if not (yet) chosen for parameter
@@ -593,7 +587,7 @@ unsigned int PedeSteerer::presigmas(const std::vector<edm::ParameterSet> &cffPre
 
 //_________________________________________________________________________
 unsigned int PedeSteerer::presigmasFile(const std::string &fileName,
-                                        const std::vector<Alignable*> &alis,
+                                        const align::Alignables& alis,
                                         const AlignablePresigmasMap &aliPresiMap)
 {
   // Check if 'alis' are in aliPresiMap, 
@@ -601,10 +595,9 @@ unsigned int PedeSteerer::presigmasFile(const std::string &fileName,
   std::ofstream *filePtr = nullptr;
 
   unsigned int nPresiParam = 0;
-  for (std::vector<Alignable*>::const_iterator iAli = alis.begin(), iAliE = alis.end();
-       iAli != iAliE; ++iAli) {
+  for (const auto& iAli: alis) {
     // Any presigma chosen for alignable?
-    AlignablePresigmasMap::const_iterator presigmasIt = aliPresiMap.find(*iAli);
+    AlignablePresigmasMap::const_iterator presigmasIt = aliPresiMap.find(iAli);
     if (presigmasIt == aliPresiMap.end()) continue; // no presigma chosen for alignable
 
     // Why does the following not work? It does with CMSSW_1_3_X on SLC3...
@@ -614,9 +607,9 @@ unsigned int PedeSteerer::presigmasFile(const std::string &fileName,
       // Now check whether a presigma value > 0. chosen: 
       if (presigmas[iParam] <= 0.) continue; // must be positive, '<' checked above
       // Do not apply presigma to inactive or fixed values.
-      if (!(*iAli)->alignmentParameters()->selector()[iParam]) continue;
+      if (!(iAli->alignmentParameters()->selector()[iParam])) continue;
       SelectionUserVariables *selVar 
-        = dynamic_cast<SelectionUserVariables*>((*iAli)->alignmentParameters()->userVariables());
+        = dynamic_cast<SelectionUserVariables*>(iAli->alignmentParameters()->userVariables());
       const char selChar = (selVar ? selVar->fullSelection()[iParam] : '1');
       if (selChar == 'f' || selChar == 'F' || selChar == 'c' || selChar == 'C') continue;
       // Finally create and write steering file:
@@ -624,11 +617,11 @@ unsigned int PedeSteerer::presigmasFile(const std::string &fileName,
         filePtr = this->createSteerFile(fileName, true);
         (*filePtr) << "* Presigma values for active parameters: \nParameter\n";
       }
-      const unsigned int aliLabel = myLabels->alignableLabel(*iAli);
+      const unsigned int aliLabel = myLabels->alignableLabel(iAli);
       (*filePtr) << myLabels->parameterLabel(aliLabel, iParam) << "   0.   " 
                  << presigmas[iParam] * fabs(this->cmsToPedeFactor(iParam));
       if (myIsSteerFileDebug) {
-	(*filePtr) << "  ! for a " << alignableObjectId_.idToString((*iAli)->alignableObjectId());
+	(*filePtr) << "  ! for a " << alignableObjectId_.idToString((iAli)->alignableObjectId());
       }
       (*filePtr) << '\n';
 
@@ -674,7 +667,7 @@ std::string PedeSteerer::fileName(const std::string &addendum) const
 //___________________________________________________________________________
 void PedeSteerer::buildSubSteer(AlignableTracker *aliTracker, AlignableMuon *aliMuon, AlignableExtras *aliExtras)
 {
-  const std::vector<Alignable*> &alis = myParameterStore->alignables();
+  const auto& alis = myParameterStore->alignables();
 
   if (theCoordMaster && !theCoordDefiners.empty()) {
     const std::string nameCoordFile(this->fileName("Coord"));

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.h
@@ -21,6 +21,7 @@
 #include <iosfwd> 
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignment/interface/AlignableObjectId.h"
 
 class Alignable;
@@ -57,7 +58,7 @@ class PedeSteerer
   /// If reference alignables have been configured, shift everything such that mean
   /// position and orientation of dets in these alignables are zero.
   void correctToReferenceSystem();
-  bool isCorrectToRefSystem(const std::vector<Alignable*> &coordDefiners) const;
+  bool isCorrectToRefSystem(const align::Alignables& coordDefiners) const;
 
 
   double cmsToPedeFactor(unsigned int parNum) const;
@@ -71,15 +72,15 @@ class PedeSteerer
 
   /// Checks whether SelectionUserVariables that might be attached to alis' AlignmentParameters
   /// (these must exist) are all known.
-  bool checkParameterChoices(const std::vector<Alignable*> &alis) const;
+  bool checkParameterChoices(const align::Alignables&) const;
   /// Store Alignables that have SelectionUserVariables attached to their AlignmentParameters
   /// (these must exist) that indicate removal from hierarchy, i.e. make it 'top level'.
-  unsigned int buildNoHierarchyCollection(const std::vector<Alignable*> &alis);
+  unsigned int buildNoHierarchyCollection(const align::Alignables&);
   /// Checks whether 'alignables' have SelectionUserVariables attached to their AlignmentParameters
   /// (these must exist) that indicate fixation of a parameter, a steering 'file'
   /// is created accordingly.
   /// Returns number of parameters fixed at 0 and at 'nominal truth'.
-  std::pair<unsigned int, unsigned int> fixParameters(const std::vector<Alignable*> &alignables,
+  std::pair<unsigned int, unsigned int> fixParameters(const align::Alignables&,
 						      const std::string &file);
   /// If 'selector' means fixing, create corresponding steering file line in file pointed to
   /// by 'filePtr'. If 'filePtr == 0' create file with name 'fileName'
@@ -90,22 +91,22 @@ class PedeSteerer
   /// Return 'alignables' that have SelectionUserVariables attached to their AlignmentParameters
   /// (these must exist) that indicate a definition of a coordinate system.
   /// Throws if ill defined reference objects.
-  std::vector<Alignable*> selectCoordinateAlis(const std::vector<Alignable*> &alignables) const;
+  align::Alignables selectCoordinateAlis(const align::Alignables&) const;
   /// Create steering file with constraints defining coordinate system via hierarchy constraints
   /// between 'aliMaster' and 'alis'; 'aliMaster' must not have parameters: would not make sense!
-  void defineCoordinates(const std::vector<Alignable*> &alis, Alignable *aliMaster,
+  void defineCoordinates(const align::Alignables&, Alignable *aliMaster,
 			 const std::string &fileName);
 
-  unsigned int hierarchyConstraints(const std::vector<Alignable*> &alis, const std::string &file);
-  void hierarchyConstraint(const Alignable *ali, const std::vector<Alignable*> &components,
+  unsigned int hierarchyConstraints(const align::Alignables&, const std::string &file);
+  void hierarchyConstraint(const Alignable *ali, const align::Alignables& components,
 			   std::ofstream &file) const;
 
   /// interprete content of presigma VPSet 'cffPresi' and call presigmasFile
   unsigned int presigmas(const std::vector<edm::ParameterSet> &cffPresi,
-			 const std::string &fileName, const std::vector<Alignable*> &alis,
+			 const std::string &fileName, const align::Alignables&,
 			 AlignableTracker *aliTracker, AlignableMuon *aliMuon, AlignableExtras *aliExtras);
   /// look for active 'alis' in map of presigma values and create steering file 
-  unsigned int presigmasFile(const std::string &fileName, const std::vector<Alignable*> &alis,
+  unsigned int presigmasFile(const std::string &fileName, const align::Alignables&,
 			     const AlignablePresigmasMap &aliPresisMap); 
   /// full name with directory and 'idenitfier'
   std::string fileName(const std::string &addendum) const;
@@ -130,7 +131,7 @@ class PedeSteerer
 
   std::set<const Alignable*> myNoHieraCollection; /// Alignables deselected for hierarchy constr.
   Alignable *theCoordMaster;                      /// master coordinates, must (?) be global frame
-  std::vector<Alignable*> theCoordDefiners;      /// Alignables selected to define coordinates
+  align::Alignables theCoordDefiners;             /// Alignables selected to define coordinates
 };
 
 #endif

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
@@ -58,7 +58,7 @@ GeometryConstraintConfigData::GeometryConstraintConfigData(const std::vector<dou
                                                            const std::string& c,
                                                            const std::vector<std::pair<Alignable*,std::string> >& alisFile,
                                                            const int sd,
-                                                           const std::vector<Alignable*>& ex,
+                                                           const align::Alignables& ex,
                                                            const int instance,
 							   const bool downToLowestLevel
                                                            ) :
@@ -190,7 +190,7 @@ PedeSteererWeakModeConstraints::createAlignablesDataStructure()
     //loop over all HLS for which the constraint is to be determined
     for(const auto& iHLS: iC.levelsFilenames_) {
       //determine next active sub-alignables for iHLS
-      std::vector<Alignable*> aliDaughts;
+      align::Alignables aliDaughts;
       if (iC.downToLowestLevel_) {
 	if (!iHLS.first->lastCompsWithParams(aliDaughts)) {
 	  edm::LogWarning("Alignment")
@@ -565,7 +565,7 @@ PedeSteererWeakModeConstraints::getX0(const std::pair<Alignable*, std::list<Alig
 
 //_________________________________________________________________________
 unsigned int
-PedeSteererWeakModeConstraints::constructConstraints(const std::vector<Alignable*> &alis)
+PedeSteererWeakModeConstraints::constructConstraints(const align::Alignables& alis)
 {
   //FIXME: split the code of the method into smaller pieces/submethods
 
@@ -731,7 +731,7 @@ PedeSteererWeakModeConstraints::verifyParameterNames(const edm::ParameterSet &ps
 //_________________________________________________________________________
 const std::vector<std::pair<Alignable*, std::string> >
 PedeSteererWeakModeConstraints::makeLevelsFilenames(std::set<std::string> &steerFilePrefixContainer,
-                                                    const std::vector<Alignable*> &alis,
+                                                    const align::Alignables& alis,
                                                     const std::string &steerFilePrefix) const
 {
   //check whether the prefix is unique

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.h
@@ -19,6 +19,7 @@
 #include <iosfwd>
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.h"
 
 #include <DataFormats/GeometryVector/interface/GlobalPoint.h>
@@ -37,14 +38,14 @@ class GeometryConstraintConfigData {
                                const std::string& c,
                                const std::vector<std::pair<Alignable*,std::string> >& alisFile,
                                const int sd,
-                               const std::vector<Alignable*>& ex,
+                               const align::Alignables& ex,
                                const int instance,
 			       const bool downToLowestLevel
                                );
   const std::vector<double> coefficients_;
   const std::string constraintName_;
   const std::vector<std::pair<Alignable*, std::string> > levelsFilenames_;
-  const std::vector<Alignable*> excludedAlignables_;
+  const align::Alignables excludedAlignables_;
   std::map<std::string, std::ofstream*> mapFileName_;
   std::list<std::pair<Alignable*, std::list<Alignable*> > > HLSsubdets_; //first pointer to HLS object, second list is the list of pointers to the lowest components
   const int sysdeformation_;
@@ -63,7 +64,7 @@ class PedeSteererWeakModeConstraints {
 
   //FIXME: split the code of the method into smaller pieces/submethods
   // Main method that configures everything and calculates also the constraints
-  unsigned int constructConstraints(const std::vector<Alignable*> &alis);
+  unsigned int constructConstraints(const align::Alignables&);
 
   // Returns a references to the container in which the configuration is stored
   std::list<GeometryConstraintConfigData>& getConfigData() { return ConstraintsConfigContainer_; }
@@ -115,7 +116,7 @@ class PedeSteererWeakModeConstraints {
   // Method which creates the associative map between levels and coefficient file names
   const std::vector<std::pair<Alignable*, std::string> > makeLevelsFilenames(
                                                                              std::set<std::string> &steerFilePrefixContainer,
-                                                                             const std::vector<Alignable*> &alis,
+                                                                             const align::Alignables& alis,
                                                                              const std::string &steerFilePrefix
                                                                              ) const;
 

--- a/Alignment/MuonAlignment/interface/AlignableCSCEndcap.h
+++ b/Alignment/MuonAlignment/interface/AlignableCSCEndcap.h
@@ -10,7 +10,7 @@
  */
 
 
-#include "Alignment/CommonAlignment/interface/Alignable.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignment/interface/AlignableComposite.h"
 #include "Alignment/CommonAlignment/interface/AlignableSurface.h"
 
@@ -33,17 +33,6 @@ class AlignableCSCEndcap : public AlignableComposite
  public:
 
   AlignableCSCEndcap( const std::vector<AlignableCSCStation*>& cscStations );
-
-  ~AlignableCSCEndcap() override;
-  
-  std::vector<Alignable*> components() const override 
-  {
-
-        std::vector<Alignable*> result;
-        result.insert( result.end(), theCSCStations.begin(), theCSCStations.end() );
-        return result;
-
-  }
   
   // gets the global position as the average over all positions of the layers
   PositionType computePosition() ;

--- a/Alignment/MuonAlignment/interface/AlignableCSCRing.h
+++ b/Alignment/MuonAlignment/interface/AlignableCSCRing.h
@@ -10,7 +10,7 @@
  */
 
 
-#include "Alignment/CommonAlignment/interface/Alignable.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignment/interface/AlignableComposite.h"
 #include "Alignment/CommonAlignment/interface/AlignableSurface.h"
 
@@ -33,17 +33,6 @@ class AlignableCSCRing : public AlignableComposite
  public:
 
   AlignableCSCRing( const std::vector<AlignableCSCChamber*>& cscChambers );
-
-  ~AlignableCSCRing() override;
-  
-  std::vector<Alignable*> components() const override 
-  {
-
-        std::vector<Alignable*> result;
-        result.insert( result.end(), theCSCChambers.begin(), theCSCChambers.end() );
-        return result;
-
-  }
   
   // gets the global position as the average over all positions of the layers
   PositionType computePosition() ;

--- a/Alignment/MuonAlignment/interface/AlignableCSCStation.h
+++ b/Alignment/MuonAlignment/interface/AlignableCSCStation.h
@@ -10,7 +10,7 @@
  */
 
 
-#include "Alignment/CommonAlignment/interface/Alignable.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignment/interface/AlignableComposite.h"
 #include "Alignment/CommonAlignment/interface/AlignableSurface.h"
 
@@ -33,17 +33,6 @@ class AlignableCSCStation : public AlignableComposite
  public:
 
   AlignableCSCStation( const std::vector<AlignableCSCRing*>& cscRings );
-
-  ~AlignableCSCStation() override;
-  
-  std::vector<Alignable*> components() const override 
-  {
-
-        std::vector<Alignable*> result;
-        result.insert( result.end(), theCSCRings.begin(), theCSCRings.end() );
-        return result;
-
-  }
   
   // gets the global position as the average over all positions of the layers
   PositionType computePosition() ;

--- a/Alignment/MuonAlignment/interface/AlignableDTBarrel.h
+++ b/Alignment/MuonAlignment/interface/AlignableDTBarrel.h
@@ -10,7 +10,7 @@
  */
 
 
-#include "Alignment/CommonAlignment/interface/Alignable.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignment/interface/AlignableComposite.h"
 #include "Alignment/CommonAlignment/interface/AlignableSurface.h"
 
@@ -33,17 +33,6 @@ class AlignableDTBarrel : public AlignableComposite
  public:
 
   AlignableDTBarrel( const std::vector<AlignableDTWheel*>& dtWheels );
-
-  ~AlignableDTBarrel() override;
-  
-  std::vector<Alignable*> components() const override 
-  {
-
-        std::vector<Alignable*> result;
-        result.insert( result.end(), theDTWheels.begin(), theDTWheels.end() );
-        return result;
-
-  }
   
   // gets the global position as the average over all positions of the layers
   PositionType computePosition() ;

--- a/Alignment/MuonAlignment/interface/AlignableDTStation.h
+++ b/Alignment/MuonAlignment/interface/AlignableDTStation.h
@@ -10,7 +10,7 @@
  */
 
 
-#include "Alignment/CommonAlignment/interface/Alignable.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignment/interface/AlignableComposite.h"
 #include "Alignment/CommonAlignment/interface/AlignableSurface.h"
 
@@ -32,17 +32,6 @@ class AlignableDTStation : public AlignableComposite
  public:
 
   AlignableDTStation( const std::vector<AlignableDTChamber*>& dtChambers );
-
-  ~AlignableDTStation() override;
-  
-  std::vector<Alignable*> components() const override 
-  {
-
-        std::vector<Alignable*> result;
-        result.insert( result.end(), theDTChambers.begin(), theDTChambers.end() );
-        return result;
-
-  }
   
   // gets the global position as the average over all positions of the layers
   PositionType computePosition() ;

--- a/Alignment/MuonAlignment/interface/AlignableDTWheel.h
+++ b/Alignment/MuonAlignment/interface/AlignableDTWheel.h
@@ -10,7 +10,7 @@
  */
 
 
-#include "Alignment/CommonAlignment/interface/Alignable.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignment/interface/AlignableComposite.h"
 #include "Alignment/CommonAlignment/interface/AlignableSurface.h"
 
@@ -32,17 +32,6 @@ class AlignableDTWheel : public AlignableComposite
  public:
 
   AlignableDTWheel( const std::vector<AlignableDTStation*>& dtStations );
-
-  ~AlignableDTWheel() override;
-  
-  std::vector<Alignable*> components() const override 
-  {
-
-        std::vector<Alignable*> result;
-        result.insert( result.end(), theDTStations.begin(), theDTStations.end() );
-        return result;
-
-  }
   
   // gets the global position as the average over all positions of the layers
   PositionType computePosition() ;

--- a/Alignment/MuonAlignment/interface/AlignableMuon.h
+++ b/Alignment/MuonAlignment/interface/AlignableMuon.h
@@ -50,7 +50,7 @@ public:
   void update(const DTGeometry* , const CSCGeometry*);
 
   /// Return all components
-  align::Alignables components() const override { return theMuonComponents; }
+  const align::Alignables& components() const final { return theMuonComponents; }
 
   /// Alignable tracker has no mother
   virtual Alignable* mother() { return nullptr; }

--- a/Alignment/MuonAlignment/plugins/MuonGeometryArrange.cc
+++ b/Alignment/MuonAlignment/plugins/MuonGeometryArrange.cc
@@ -492,9 +492,9 @@ void MuonGeometryArrange::compare(Alignable* refAli, Alignable* curAli,
   if(refAli==nullptr){return;}	
   if(curAli==nullptr){return;}
   
-  const std::vector<Alignable*>& refComp = refAli->components();
-  const std::vector<Alignable*>& curComp = curAli->components();
-  const std::vector<Alignable*>& curComp2 = curAliCopy2->components();
+  const auto& refComp = refAli->components();
+  const auto& curComp = curAli->components();
+  const auto& curComp2 = curAliCopy2->components();
   compareGeometries(refAli, curAli, curAliCopy2);
 
   int nComp=refComp.size();
@@ -517,8 +517,8 @@ void MuonGeometryArrange::compareGeometries(Alignable* refAli,
  // the layers of the chambers.  So, if the mother of this is also an approved
  // mother, bail.
   if(isMother(refAli->mother() )) return;
-  const std::vector<Alignable*>& refComp = refAli->components();
-  const std::vector<Alignable*>& curComp = curCopy->components();
+  const auto& refComp = refAli->components();
+  const auto& curComp = curCopy->components();
   if(refComp.size()!=curComp.size()){
      return;
   }
@@ -667,7 +667,7 @@ void MuonGeometryArrange::compareGeometries(Alignable* refAli,
    align::moveAlignable(curAli, change);	// move as a chunk
 
   // Now get the components again.  They should be in new locations
-   const std::vector<Alignable*>& curComp2 = curAli->components();
+   const auto& curComp2 = curAli->components();
 
   for(int ich=0; ich<nComp; ich++){
      CLHEP::Hep3Vector Rtotal, Wtotal;
@@ -877,7 +877,7 @@ void MuonGeometryArrange::fillTree(Alignable *refAli, const AlgebraicVector& dif
 bool MuonGeometryArrange::isMother(Alignable* ali){
   // Is this the mother ring?
  if(ali==nullptr) return false;	// elementary sanity
- const std::vector<Alignable*>& aliComp = ali->components();
+ const auto& aliComp = ali->components();
 
  int size=aliComp.size();
  if(size<=0) return false;	// no subcomponents
@@ -931,7 +931,7 @@ bool MuonGeometryArrange::passChosen( Alignable* ali ){
  if(ali==nullptr) return false;
  if(checkChosen(ali)) return true;	// If this is one of the desired
  					// CSC chambers, accept it
- const std::vector<Alignable*>& aliComp = ali->components();
+ const auto& aliComp = ali->components();
 
  int size=aliComp.size();
  if(size<=0) return false;	// no subcomponents

--- a/Alignment/MuonAlignment/plugins/MuonGeometryArrange.h
+++ b/Alignment/MuonAlignment/plugins/MuonGeometryArrange.h
@@ -41,7 +41,6 @@ public edm::EDAnalyzer
 public:
 	typedef AlignTransform SurveyValue;
 	typedef Alignments SurveyValues;
-	typedef std::vector<Alignable*> Alignables;
 		
   /// Do nothing. Required by framework.
   MuonGeometryArrange(

--- a/Alignment/MuonAlignment/src/AlignableCSCChamber.cc
+++ b/Alignment/MuonAlignment/src/AlignableCSCChamber.cc
@@ -27,7 +27,7 @@ void AlignableCSCChamber::update(const GeomDet* geomDet)
 
 /// Printout the DetUnits in the CSC chamber
 std::ostream& operator<< (std::ostream &os, const AlignableCSCChamber & r) {
-   std::vector<Alignable*> theDets = r.components();
+   const auto& theDets = r.components();
 
    os << "    This CSCChamber contains " << theDets.size() << " units" << std::endl ;
    os << "    position = " << r.globalPosition() << std::endl;
@@ -37,8 +37,8 @@ std::ostream& operator<< (std::ostream &os, const AlignableCSCChamber & r) {
    os << "    total displacement and rotation: " << r.displacement() << std::endl;
    os << r.rotation() << std::endl;
  
-   for (std::vector<Alignable*>::const_iterator idet = theDets.begin();  idet != theDets.end();  ++idet) {
-      const align::Alignables& comp = (*idet)->components();
+   for (const auto& idet: theDets) {
+      const auto& comp = idet->components();
 
       for (unsigned int i = 0; i < comp.size(); ++i) {
 	 os << "     Det position, phi, r: " 

--- a/Alignment/MuonAlignment/src/AlignableCSCRing.cc
+++ b/Alignment/MuonAlignment/src/AlignableCSCRing.cc
@@ -18,19 +18,17 @@ AlignableCSCRing::AlignableCSCRing( const std::vector<AlignableCSCChamber*>& csc
 
   theCSCChambers.insert( theCSCChambers.end(), cscChambers.begin(), cscChambers.end() );
 
+  // maintain also list of components
+  for (const auto& chamber: cscChambers) {
+    const auto mother = chamber->mother();
+    this->addComponent(chamber); // components will be deleted by dtor of AlignableComposite
+    chamber->setMother(mother); // restore previous behaviour where mother is not set
+  }
+
   setSurface( computeSurface() );
   compConstraintType_ = Alignable::CompConstraintType::POSITION_Z;
 }
-      
 
-/// Clean delete of the vector and its elements
-AlignableCSCRing::~AlignableCSCRing() 
-{
-  for ( std::vector<AlignableCSCChamber*>::iterator iter = theCSCChambers.begin(); 
-	iter != theCSCChambers.end(); iter++)
-    delete *iter;
-
-}
 
 /// Return Alignable CSC Chamber at given index
 AlignableCSCChamber &AlignableCSCRing::chamber(int i) 

--- a/Alignment/MuonAlignment/src/AlignableCSCStation.cc
+++ b/Alignment/MuonAlignment/src/AlignableCSCStation.cc
@@ -18,19 +18,17 @@ AlignableCSCStation::AlignableCSCStation( const std::vector<AlignableCSCRing*>& 
 
   theCSCRings.insert( theCSCRings.end(), cscRings.begin(), cscRings.end() );
 
+  // maintain also list of components
+  for (const auto& ring: cscRings) {
+    const auto mother = ring->mother();
+    this->addComponent(ring); // components will be deleted by dtor of AlignableComposite
+    ring->setMother(mother); // restore previous behaviour where mother is not set
+  }
+
   setSurface( computeSurface() );
   compConstraintType_ = Alignable::CompConstraintType::POSITION_Z;
 }
-      
 
-/// Clean delete of the vector and its elements
-AlignableCSCStation::~AlignableCSCStation() 
-{
-  for ( std::vector<AlignableCSCRing*>::iterator iter = theCSCRings.begin(); 
-	iter != theCSCRings.end(); iter++)
-    delete *iter;
-
-}
 
 /// Return Alignable CSC Ring at given index
 AlignableCSCRing &AlignableCSCStation::ring(int i) 

--- a/Alignment/MuonAlignment/src/AlignableDTChamber.cc
+++ b/Alignment/MuonAlignment/src/AlignableDTChamber.cc
@@ -4,7 +4,7 @@
  *  $Revision: 1.10 $
  *  \author Andre Sznajder - UERJ(Brazil)
  */
- 
+
 #include "Alignment/MuonAlignment/interface/AlignableDTChamber.h"
 #include "Alignment/MuonAlignment/interface/AlignableDTSuperLayer.h"
 
@@ -28,7 +28,7 @@ AlignableDTChamber::AlignableDTChamber(const GeomDet *geomDet)
 
 /// Printout the DetUnits in the DT chamber
 std::ostream& operator<< (std::ostream &os, const AlignableDTChamber & r) {
-   std::vector<Alignable*> theDets = r.components();
+   const auto& theDets = r.components();
 
    os << "    This DTChamber contains " << theDets.size() << " units" << std::endl ;
    os << "    position = " << r.globalPosition() << std::endl;
@@ -38,8 +38,8 @@ std::ostream& operator<< (std::ostream &os, const AlignableDTChamber & r) {
    os << "    total displacement and rotation: " << r.displacement() << std::endl;
    os << r.rotation() << std::endl;
  
-   for (std::vector<Alignable*>::const_iterator idet = theDets.begin();  idet != theDets.end();  ++idet) {
-      const align::Alignables& comp = (*idet)->components();
+   for (const auto& idet: theDets) {
+      const auto& comp = idet->components();
 
       for (unsigned int i = 0; i < comp.size(); ++i) {
 	 os << "     Det position, phi, r: " 

--- a/Alignment/MuonAlignment/src/AlignableDTStation.cc
+++ b/Alignment/MuonAlignment/src/AlignableDTStation.cc
@@ -18,19 +18,17 @@ AlignableDTStation::AlignableDTStation( const std::vector<AlignableDTChamber*>& 
 
   theDTChambers.insert( theDTChambers.end(), dtChambers.begin(), dtChambers.end() );
 
+  // maintain also list of components
+  for (const auto& chamber: dtChambers) {
+    const auto mother = chamber->mother();
+    this->addComponent(chamber); // components will be deleted by dtor of AlignableComposite
+    chamber->setMother(mother); // restore previous behaviour where mother is not set
+  }
+
   setSurface( computeSurface() );
   compConstraintType_ = Alignable::CompConstraintType::POSITION_Z;
 }
-      
 
-/// Clean delete of the vector and its elements
-AlignableDTStation::~AlignableDTStation() 
-{
-  for ( std::vector<AlignableDTChamber*>::iterator iter = theDTChambers.begin(); 
-	iter != theDTChambers.end(); iter++)
-    delete *iter;
-
-}
 
 /// Return Alignable DT Chamber at given index
 AlignableDTChamber &AlignableDTStation::chamber(int i) 

--- a/Alignment/MuonAlignment/src/AlignableDTSuperLayer.cc
+++ b/Alignment/MuonAlignment/src/AlignableDTSuperLayer.cc
@@ -16,7 +16,7 @@ AlignableDTSuperLayer::AlignableDTSuperLayer(const GeomDet *geomDet): AlignableD
 
 /// Printout the DetUnits in the CSC chamber
 std::ostream& operator<< (std::ostream &os, const AlignableDTSuperLayer & r) {
-   std::vector<Alignable*> theDets = r.components();
+   const auto& theDets = r.components();
 
    os << "    This DTSuperLayer contains " << theDets.size() << " units" << std::endl ;
    os << "    position = " << r.globalPosition() << std::endl;
@@ -26,8 +26,8 @@ std::ostream& operator<< (std::ostream &os, const AlignableDTSuperLayer & r) {
    os << "    total displacement and rotation: " << r.displacement() << std::endl;
    os << r.rotation() << std::endl;
  
-   for (std::vector<Alignable*>::const_iterator idet = theDets.begin();  idet != theDets.end();  ++idet) {
-      const align::Alignables& comp = (*idet)->components();
+   for (const auto& idet: theDets) {
+      const auto& comp = idet->components();
 
       for (unsigned int i = 0; i < comp.size(); ++i) {
 	 os << "     Det position, phi, r: " 

--- a/Alignment/MuonAlignment/src/AlignableDTWheel.cc
+++ b/Alignment/MuonAlignment/src/AlignableDTWheel.cc
@@ -18,18 +18,15 @@ AlignableDTWheel::AlignableDTWheel( const std::vector<AlignableDTStation*>& dtSt
 
   theDTStations.insert( theDTStations.end(), dtStations.begin(), dtStations.end() );
 
+  // maintain also list of components
+  for (const auto& station: dtStations) {
+    const auto mother = station->mother();
+    this->addComponent(station); // components will be deleted by dtor of AlignableComposite
+    station->setMother(mother); // restore previous behaviour where mother is not set
+  }
+
   setSurface( computeSurface() );
   compConstraintType_ = Alignable::CompConstraintType::POSITION_Z;
-}
-      
-
-/// Clean delete of the vector and its elements
-AlignableDTWheel::~AlignableDTWheel() 
-{
-  for ( std::vector<AlignableDTStation*>::iterator iter = theDTStations.begin(); 
-	iter != theDTStations.end(); iter++)
-    delete *iter;
-
 }
 
 /// Return Alignable DT Station at given index

--- a/Alignment/MuonAlignment/src/AlignableMuon.cc
+++ b/Alignment/MuonAlignment/src/AlignableMuon.cc
@@ -425,16 +425,13 @@ align::Alignables AlignableMuon::CSCEndcaps()
 //__________________________________________________________________________________________________
 void AlignableMuon::recursiveSetMothers( Alignable* alignable )
 {
-  
-  align::Alignables components = alignable->components();
-  for ( align::Alignables::iterator iter = components.begin();
-		iter != components.end(); iter++ )
-	{
-	  (*iter)->setMother( alignable );
-	  recursiveSetMothers( *iter );
-	}
-
+  for (const auto& iter: alignable->components()) {
+    iter->setMother(alignable);
+    recursiveSetMothers(iter);
+  }
 }
+
+
 //__________________________________________________________________________________________________
 Alignments* AlignableMuon::alignments( void ) const
 {

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputSurveyDB.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputSurveyDB.cc
@@ -80,17 +80,17 @@ AlignableMuon *MuonAlignmentInputSurveyDB::newAlignableMuon(const edm::EventSetu
    unsigned int theSurveyIndex  = 0;
    const Alignments *theSurveyValues = &*dtSurvey;
    const SurveyErrors *theSurveyErrors = &*dtSurveyError;
-   std::vector<Alignable*> barrels = output->DTBarrel();
-   for (std::vector<Alignable*>::const_iterator iter = barrels.begin();  iter != barrels.end();  ++iter) {
-      addSurveyInfo_(*iter, &theSurveyIndex, theSurveyValues, theSurveyErrors);
+   const auto& barrels = output->DTBarrel();
+   for (const auto& iter: barrels) {
+      addSurveyInfo_(iter, &theSurveyIndex, theSurveyValues, theSurveyErrors);
    }
 
    theSurveyIndex  = 0;
    theSurveyValues = &*cscSurvey;
    theSurveyErrors = &*cscSurveyError;
-   std::vector<Alignable*> endcaps = output->CSCEndcaps();
-   for (std::vector<Alignable*>::const_iterator iter = endcaps.begin();  iter != endcaps.end();  ++iter) {
-      addSurveyInfo_(*iter, &theSurveyIndex, theSurveyValues, theSurveyErrors);
+   const auto& endcaps = output->CSCEndcaps();
+   for (const auto& iter: endcaps) {
+      addSurveyInfo_(iter, &theSurveyIndex, theSurveyValues, theSurveyErrors);
    }
 
    return output;
@@ -104,7 +104,7 @@ void MuonAlignmentInputSurveyDB::addSurveyInfo_(Alignable* ali,
 						unsigned int *theSurveyIndex,
 						const Alignments* theSurveyValues,
 						const SurveyErrors* theSurveyErrors) const {
-  const std::vector<Alignable*>& comp = ali->components();
+  const auto& comp = ali->components();
 
   unsigned int nComp = comp.size();
 

--- a/Alignment/MuonAlignment/src/MuonScenarioBuilder.cc
+++ b/Alignment/MuonAlignment/src/MuonScenarioBuilder.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <iostream>
 #include <sstream>
+#include <algorithm>
 
 // Framework
 #include "FWCore/Utilities/interface/Exception.h"
@@ -127,6 +128,7 @@ void MuonScenarioBuilder::moveDTSectors(const edm::ParameterSet& pSet)
   errorRotation.push_back(errorphix); errorRotation.push_back(errorphiy); errorRotation.push_back(errorphiz);
  
   int index[5][4][14];
+  std::fill_n(index[0][0], 5*4*14, -1); // initialize to -1
   int counter = 0;
   //Create and index for the chambers in the Alignable vector
   for(const auto& iter: DTchambers) {
@@ -190,6 +192,8 @@ void MuonScenarioBuilder::moveCSCSectors(const edm::ParameterSet& pSet)
   
   int index[2][4][4][36];
   int sector_index[2][4][4][36];
+  std::fill_n(index[0][0][0],        2*4*4*36, -1); // initialize to -1
+  std::fill_n(sector_index[0][0][0], 2*4*4*36, -1); // initialize to -1
   int counter = 0;
   //Create an index for the chambers in the alignable vector
   for(const auto& iter: CSCchambers) {

--- a/Alignment/MuonAlignment/src/MuonScenarioBuilder.cc
+++ b/Alignment/MuonAlignment/src/MuonScenarioBuilder.cc
@@ -51,10 +51,10 @@ void MuonScenarioBuilder::applyScenario( const edm::ParameterSet& scenario )
 
 
   // DT Barrel
-  std::vector<Alignable*> dtBarrel = theAlignableMuon->DTBarrel();
+  const auto& dtBarrel = theAlignableMuon->DTBarrel();
   this->decodeMovements_( theScenario, dtBarrel, "DTBarrel" );
   // CSC Endcap
-  std::vector<Alignable*> cscEndcaps = theAlignableMuon->CSCEndcaps();
+  const auto& cscEndcaps = theAlignableMuon->CSCEndcaps();
   this->decodeMovements_( theScenario, cscEndcaps, "CSCEndcap" );
 
   this->moveDTSectors(theScenario);
@@ -109,7 +109,7 @@ align::Scalars MuonScenarioBuilder::extractParameters(const edm::ParameterSet& p
 //_____________________________________________________________________________________________________
 void MuonScenarioBuilder::moveDTSectors(const edm::ParameterSet& pSet)
 {
-  std::vector<Alignable *> DTchambers = theAlignableMuon->DTChambers();
+  const auto& DTchambers = theAlignableMuon->DTChambers();
   //Take parameters
   align::Scalars param = this->extractParameters(pSet, "DTSectors");
   double scale_ = param[0]; double scaleError_ = param[1];
@@ -129,8 +129,8 @@ void MuonScenarioBuilder::moveDTSectors(const edm::ParameterSet& pSet)
   int index[5][4][14];
   int counter = 0;
   //Create and index for the chambers in the Alignable vector
-  for(std::vector<Alignable *>::iterator iter = DTchambers.begin(); iter != DTchambers.end(); ++iter) {
-    DTChamberId myId((*iter)->geomDetId().rawId());
+  for(const auto& iter: DTchambers) {
+    DTChamberId myId(iter->geomDetId().rawId());
     index[myId.wheel()+2][myId.station()-1][myId.sector()-1] = counter;
     counter++;
   }
@@ -171,7 +171,7 @@ void MuonScenarioBuilder::moveDTSectors(const edm::ParameterSet& pSet)
 //______________________________________________________________________________________________________
 void MuonScenarioBuilder::moveCSCSectors(const edm::ParameterSet& pSet)
 {
-  std::vector<Alignable *> CSCchambers = theAlignableMuon->CSCChambers();
+  const auto& CSCchambers = theAlignableMuon->CSCChambers();
   //Take Parameters
   align::Scalars param = this->extractParameters(pSet, "CSCSectors");
   double scale_ = param[0]; double scaleError_ = param[1];
@@ -192,8 +192,8 @@ void MuonScenarioBuilder::moveCSCSectors(const edm::ParameterSet& pSet)
   int sector_index[2][4][4][36];
   int counter = 0;
   //Create an index for the chambers in the alignable vector
-  for(std::vector<Alignable *>::iterator iter = CSCchambers.begin(); iter != CSCchambers.end(); ++iter) {
-    CSCDetId myId((*iter)->geomDetId().rawId());
+  for(const auto& iter: CSCchambers) {
+    CSCDetId myId(iter->geomDetId().rawId());
     index[myId.endcap()-1][myId.station()-1][myId.ring()-1][myId.chamber()-1] = counter;
     sector_index[myId.endcap()-1][myId.station()-1][myId.ring()-1][myId.chamber()-1] = CSCTriggerNumbering::sectorFromTriggerLabels(CSCTriggerNumbering::triggerSectorFromLabels(myId),CSCTriggerNumbering::triggerSubSectorFromLabels(myId) , myId.station());
     counter++;
@@ -255,8 +255,8 @@ void MuonScenarioBuilder::moveCSCSectors(const edm::ParameterSet& pSet)
 //______________________________________________________________________________________________________
 void MuonScenarioBuilder::moveMuon(const edm::ParameterSet& pSet)
 {
-  std::vector<Alignable *> DTbarrel = theAlignableMuon->DTBarrel();	
-  std::vector<Alignable *> CSCendcaps = theAlignableMuon->CSCEndcaps();  
+  const auto& DTbarrel = theAlignableMuon->DTBarrel();	
+  const auto& CSCendcaps = theAlignableMuon->CSCEndcaps();  
   //Take Parameters
   align::Scalars param = this->extractParameters(pSet, "Muon");
   double scale_ = param[0]; double scaleError_ = param[1];
@@ -284,17 +284,17 @@ void MuonScenarioBuilder::moveMuon(const edm::ParameterSet& pSet)
     disp.push_back(dx); disp.push_back(dy); disp.push_back(dz);
     rotation.push_back(phix); rotation.push_back(phiy); rotation.push_back(phiz);
   }
-  for(std::vector<Alignable *>::iterator iter = DTbarrel.begin(); iter != DTbarrel.end(); ++iter) {
-    theMuonModifier.moveAlignable( *iter, false, true, disp[0], disp[1], disp[2] );
-    theMuonModifier.rotateAlignable( *iter, false, true, rotation[0],  rotation[1], rotation[2] );
-    theMuonModifier.addAlignmentPositionError( *iter, errorx, errory, errorz );
-    theMuonModifier.addAlignmentPositionErrorFromRotation( *iter,  errorphix, errorphiy, errorphiz ); 
+  for(const auto& iter: DTbarrel) {
+    theMuonModifier.moveAlignable(iter, false, true, disp[0], disp[1], disp[2]);
+    theMuonModifier.rotateAlignable(iter, false, true, rotation[0],  rotation[1], rotation[2]);
+    theMuonModifier.addAlignmentPositionError(iter, errorx, errory, errorz);
+    theMuonModifier.addAlignmentPositionErrorFromRotation(iter,  errorphix, errorphiy, errorphiz); 
   }
-  for(std::vector<Alignable *>::iterator iter = CSCendcaps.begin(); iter != CSCendcaps.end(); ++iter) {
-    theMuonModifier.moveAlignable( *iter, false, true, disp[0], disp[1], disp[2] );
-    theMuonModifier.rotateAlignable( *iter, false, true, rotation[0],  rotation[1], rotation[2] );
-    theMuonModifier.addAlignmentPositionError( *iter, errorx, errory, errorz );
-    theMuonModifier.addAlignmentPositionErrorFromRotation( *iter,  errorphix, errorphiy, errorphiz ); 
+  for(const auto& iter: CSCendcaps) {
+    theMuonModifier.moveAlignable(iter, false, true, disp[0], disp[1], disp[2]);
+    theMuonModifier.rotateAlignable(iter, false, true, rotation[0],  rotation[1], rotation[2]);
+    theMuonModifier.addAlignmentPositionError(iter, errorx, errory, errorz);
+    theMuonModifier.addAlignmentPositionErrorFromRotation(iter,  errorphix, errorphiy, errorphiz); 
   }
 }
 

--- a/Alignment/MuonAlignment/test/TestAlign.cpp
+++ b/Alignment/MuonAlignment/test/TestAlign.cpp
@@ -85,32 +85,28 @@ TestAlign::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
   rotation.push_back(1.64);
 
   // Loop over DT chamber to apply alignment corrections
-  std::vector<Alignable*> theDTAlignables = theAlignableMuon->DTChambers();
-  for ( std::vector<Alignable*>::iterator iter = theDTAlignables.begin();
-		                          iter != theDTAlignables.end(); iter++ ){ 
+  for (const auto& iter: theAlignableMuon->DTChambers()) { 
 
     // Print inital position/orientation
-    align::GlobalPoint  pos_i  = (*iter)->globalPosition();
-    align::RotationType dir_i  = (*iter)->globalRotation();
+    align::GlobalPoint  pos_i = iter->globalPosition();
+    align::RotationType dir_i = iter->globalRotation();
 
     std::cout << "Initial pos: x=" << pos_i.x() << ",  y=" << pos_i.y() << ",  z=" << pos_i.z() << std::endl;
     std::cout << "Initial ori: x=" << dir_i.xx() << ",  y=" << dir_i.yy() << ",  z=" << dir_i.zz() << std::endl;
 
     // Move DT chamber
-    DetId detid = (*iter)->geomDetId();
+    DetId detid = iter->geomDetId();
     align.moveAlignableGlobalCoord( detid , displacement , rotation );
 
     // Print final position/orientation
-    align::GlobalPoint  pos_f  = (*iter)->globalPosition();
-    align::RotationType dir_f = (*iter)->globalRotation();
+    align::GlobalPoint  pos_f = iter->globalPosition();
+    align::RotationType dir_f = iter->globalRotation();
 
     std::cout << "Final pos: x=" << pos_f.x() << ",  y=" << pos_f.y() << ",  z=" << pos_f.z()  << std::endl ;
     std::cout << "Final ori: x=" << dir_f.xx() << ",  y=" << dir_f.yy() << ",  z=" << dir_f.zz() << std::endl;
     std::cout << "------------------------" << std::endl;
  
   }
-
-  theDTAlignables.clear();
 
 
   // Saves to DB

--- a/Alignment/MuonAlignment/test/TestRotation.cpp
+++ b/Alignment/MuonAlignment/test/TestRotation.cpp
@@ -122,37 +122,36 @@ TestRotation::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 
   // Apply alignment
  
-  std::vector<Alignable*> theDTWheels = theAlignableMuon->DTWheels();
+  const auto& theDTWheels = theAlignableMuon->DTWheels();
   std::cout << "Number of wheels=" << theDTWheels.size() << std::endl;
 
-  for ( std::vector<Alignable*>::iterator iter = theDTWheels.begin();
-		iter != theDTWheels.end(); iter++ )
+  for (const auto& iter: theDTWheels)
   {
     std::cout << "------------------------" << std::endl
               << " BEFORE ROTATION " << std::endl;
 
-    align::GlobalPoint  pos_i  = (*iter)->globalPosition() ;
-    align::RotationType dir_i  = (*iter)->globalRotation();
+    align::GlobalPoint  pos_i  = iter->globalPosition() ;
+    align::RotationType dir_i  = iter->globalRotation();
 
     std::cout << "x=" << pos_i.x() << ",  y=" << pos_i.y() << ",  z=" << pos_i.z() << std::endl;
     std::cout << "xx=" << dir_i.xx() << ",  yx=" << dir_i.yx() << ",  zx=" << dir_i.zx()  << std::endl;
     std::cout << "xy=" << dir_i.xy() << ",  yy=" << dir_i.yy() << ",  zy=" << dir_i.zy()  << std::endl;
     std::cout << "xz=" << dir_i.xz() << ",  yz=" << dir_i.yz() << ",  zz=" << dir_i.zz()  << std::endl;
 
-    // x      = (*iter)->surface().position().x();
-    // y      = (*iter)->surface().position().y();
-    // z      = (*iter)->surface().position().z();
+    // x      = iter->surface().position().x();
+    // y      = iter->surface().position().y();
+    // z      = iter->surface().position().z();
     // std::cout << "X=" << x << ", Y= " <<  y << ", Z=" << z  << std::endl ;
 
     double deltaPhi = 3.1415926/180*45;
 
-    (*iter)->rotateAroundGlobalZ( deltaPhi );
+    iter->rotateAroundGlobalZ( deltaPhi );
 
     std::cout << "------------------------" << std::endl
 	      << " AFTER ROTATION " << std::endl;
 
-    align::GlobalPoint  pos_f  = (*iter)->globalPosition() ;
-    align::RotationType dir_f = (*iter)->globalRotation();
+    align::GlobalPoint  pos_f = iter->globalPosition() ;
+    align::RotationType dir_f = iter->globalRotation();
 
     std::cout << "x=" << pos_f.x() << ",  y=" << pos_f.y() << ",  z=" << pos_f.z()  << std::endl ;
     std::cout << "xx=" << dir_f.xx() << ",  yx=" << dir_f.yx() << ",  zx=" << dir_f.zx()   << std::endl ;

--- a/Alignment/MuonAlignment/test/TestTranslation.cpp
+++ b/Alignment/MuonAlignment/test/TestTranslation.cpp
@@ -129,31 +129,11 @@ TestTranslation::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetu
 
   AlignableMuon* theAlignableMuon = new AlignableMuon( &(*dtGeometry), &(*cscGeometry) );
 
-
-
   // Apply  alignment
+  for (const auto& iter: theAlignableMuon->DTChambers()) apply(iter); 
+  for (const auto& iter: theAlignableMuon->CSCEndcaps()) apply(iter); 
 
-  std::vector<Alignable*> theDTAlignables = theAlignableMuon->DTChambers();
-  std::vector<Alignable*> theCSCAlignables = theAlignableMuon->CSCEndcaps();
-
-
-  for ( std::vector<Alignable*>::iterator iter = theDTAlignables.begin();
-		                          iter != theDTAlignables.end(); iter++ ){ 
-    apply( *iter ); 
-  }
-
-  theDTAlignables.clear();
-
-  for ( std::vector<Alignable*>::iterator iter = theCSCAlignables.begin();
-		                          iter != theCSCAlignables.end(); iter++ ){ 
-    apply( *iter ); 
-  }
-
-  theCSCAlignables.clear();
-
-
-edm::LogInfo("MuonAlignment") << "Done!";
-
+  edm::LogInfo("MuonAlignment") << "Done!";
 }
 
 

--- a/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsAlignmentAlgorithm.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsAlignmentAlgorithm.cc
@@ -190,13 +190,13 @@ void CSCOverlapsAlignmentAlgorithm::initialize(const edm::EventSetup& iSetup, Al
   if (alignableTracker == nullptr) m_alignableNavigator = new AlignableNavigator(alignableMuon);
   else m_alignableNavigator = new AlignableNavigator(alignableTracker, alignableMuon);
 
-  for (std::vector<Alignable*>::const_iterator alignable = m_alignables.begin();  alignable != m_alignables.end();  ++alignable) {
-    DetId id = (*alignable)->geomDetId();
+  for (const auto& alignable: m_alignables) {
+    DetId id = alignable->geomDetId();
     if (id.det() != DetId::Muon  ||  id.subdetId() != MuonSubdetId::CSC  ||  CSCDetId(id.rawId()).layer() != 0) {
       throw cms::Exception("BadConfig") << "Only CSC chambers may be alignable" << std::endl;
     }
 
-    std::vector<bool> selector = (*alignable)->alignmentParameters()->selector();
+    std::vector<bool> selector = alignable->alignmentParameters()->selector();
     for (std::vector<bool>::const_iterator i = selector.begin();  i != selector.end();  ++i) {
       if (!(*i)) throw cms::Exception("BadConfig") << "All selector strings should be \"111111\"" << std::endl;
     }

--- a/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsAlignmentAlgorithm.h
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsAlignmentAlgorithm.h
@@ -139,7 +139,7 @@ private:
   bool m_doAlignment;
 
   AlignmentParameterStore* m_alignmentParameterStore;
-  std::vector<Alignable*> m_alignables;
+  align::Alignables m_alignables;
   AlignableNavigator *m_alignableNavigator;
   std::vector<CSCChamberFitter> m_fitters;
   std::vector<CSCPairResidualsConstraint*> m_residualsConstraints;

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
@@ -97,9 +97,9 @@ class MuonAlignmentFromReference : public AlignmentAlgorithmBase
         int number(std::string s);
         std::string chamberPrettyNameFromId(unsigned int idx);
 
-        void parseReference(std::vector<Alignable*> &reference, 
-                std::vector<Alignable*> &all_DT_chambers, 
-                std::vector<Alignable*> &all_CSC_chambers);
+        void parseReference(align::Alignables& reference,
+                            const align::Alignables& all_DT_chambers,
+                            const align::Alignables& all_CSC_chambers);
 
         void fitAndAlign();
         void readTmpFiles();
@@ -148,7 +148,7 @@ class MuonAlignmentFromReference : public AlignmentAlgorithmBase
         // utility objects
         AlignableNavigator *m_alignableNavigator;
         AlignmentParameterStore *m_alignmentParameterStore;
-        std::vector<Alignable*> m_alignables;
+        align::Alignables m_alignables;
         std::map<Alignable*,Alignable*> m_me11map;
         std::map<Alignable*,MuonResidualsTwoBin*> m_fitters;
         std::vector<unsigned int> m_indexes;
@@ -346,25 +346,25 @@ void MuonAlignmentFromReference::initialize(const edm::EventSetup& iSetup,
     m_indexes.clear();
     m_fitterOrder.clear();
 
-    for (std::vector<Alignable*>::const_iterator ali = m_alignables.begin();  ali != m_alignables.end();  ++ali)
+    for (const auto& ali: m_alignables)
     {
         bool made_fitter = false;
 
         // fitters for DT
-        if ((*ali)->alignableObjectId() == align::AlignableDTChamber)
+        if (ali->alignableObjectId() == align::AlignableDTChamber)
         {
-            DTChamberId id( (*ali)->geomDetId().rawId() );
+            DTChamberId id(ali->geomDetId().rawId());
 
             if (id.station() == 4)
             {
-                m_fitters[*ali] =
+                m_fitters[ali] =
                     new MuonResidualsTwoBin(m_twoBin, new MuonResiduals5DOFFitter(residualsModel, m_minAlignmentHits, useResiduals, m_weightAlignment),
                             new MuonResiduals5DOFFitter(residualsModel, m_minAlignmentHits, useResiduals, m_weightAlignment));
                 made_fitter = true;
             }
             else
             {
-                m_fitters[*ali] =
+                m_fitters[ali] =
                     new MuonResidualsTwoBin(m_twoBin, new MuonResiduals6DOFFitter(residualsModel, m_minAlignmentHits, useResiduals, m_weightAlignment),
                             new MuonResiduals6DOFFitter(residualsModel, m_minAlignmentHits, useResiduals, m_weightAlignment));
                 made_fitter = true;
@@ -372,30 +372,30 @@ void MuonAlignmentFromReference::initialize(const edm::EventSetup& iSetup,
         }
 
         // fitters for CSC
-        else if ((*ali)->alignableObjectId() == align::AlignableCSCChamber)
+        else if (ali->alignableObjectId() == align::AlignableCSCChamber)
         {
-            Alignable *thisali = *ali;
-            CSCDetId id( (*ali)->geomDetId().rawId() );
+            auto thisali = ali;
+            CSCDetId id(ali->geomDetId().rawId());
 
             // take care of ME1/1a
             if (m_combineME11  &&  id.station() == 1  &&  id.ring() == 4)
             {
                 CSCDetId pairid(id.endcap(), 1, 1, id.chamber());
 
-                for (std::vector<Alignable*>::const_iterator ali2 = m_alignables.begin();  ali2 != m_alignables.end();  ++ali2)
+                for (const auto& ali2: m_alignables)
                 {
-                    if ((*ali2)->alignableObjectId() == align::AlignableCSCChamber  &&  (*ali2)->geomDetId().rawId() == pairid.rawId())
+                    if (ali2->alignableObjectId() == align::AlignableCSCChamber  &&  ali2->geomDetId().rawId() == pairid.rawId())
                     {
-                        thisali = *ali2;
+                        thisali = ali2;
                         break;
                     }
                 }
-                m_me11map[*ali] = thisali;  // points from each ME1/4 chamber to the corresponding ME1/1 chamber
+                m_me11map[ali] = thisali;  // points from each ME1/4 chamber to the corresponding ME1/1 chamber
             }
 
-            if (thisali == *ali)   // don't make fitters for ME1/4; they get taken care of in ME1/1
+            if (thisali == ali)   // don't make fitters for ME1/4; they get taken care of in ME1/1
             {
-                m_fitters[*ali] =
+                m_fitters[ali] =
                     new MuonResidualsTwoBin(m_twoBin, new MuonResiduals6DOFrphiFitter(residualsModel, m_minAlignmentHits, useResiduals, &(*cscGeometry), m_weightAlignment),
                             new MuonResiduals6DOFrphiFitter(residualsModel, m_minAlignmentHits, useResiduals, &(*cscGeometry), m_weightAlignment));
                 made_fitter = true;
@@ -407,11 +407,11 @@ void MuonAlignmentFromReference::initialize(const edm::EventSetup& iSetup,
         }
 
         if (made_fitter) {
-            m_fitters[*ali]->setStrategy(m_strategy);
+            m_fitters[ali]->setStrategy(m_strategy);
 
-            int index = (*ali)->geomDetId().rawId();
+            int index = ali->geomDetId().rawId();
             m_indexes.push_back(index);
-            m_fitterOrder[index] = m_fitters[*ali];
+            m_fitterOrder[index] = m_fitters[ali];
         }
     } // end loop over chambers chosen for alignment
 
@@ -419,9 +419,9 @@ void MuonAlignmentFromReference::initialize(const edm::EventSetup& iSetup,
     std::sort(m_indexes.begin(), m_indexes.end());
 
     // de-weight all chambers but the reference
-    std::vector<Alignable*> all_DT_chambers = alignableMuon->DTChambers();
-    std::vector<Alignable*> all_CSC_chambers = alignableMuon->CSCChambers();
-    std::vector<Alignable*> reference;
+    const auto& all_DT_chambers = alignableMuon->DTChambers();
+    const auto& all_CSC_chambers = alignableMuon->CSCChambers();
+    align::Alignables reference;
     if (!m_reference.empty()) parseReference(reference, all_DT_chambers, all_CSC_chambers);
 
     alignmentParameterStore->setAlignmentPositionError(all_DT_chambers, 100000000., 0.);
@@ -862,11 +862,11 @@ void MuonAlignmentFromReference::fitAndAlign()
 
     if (m_debug) std::cout << "***** just after report.open" << std::endl;
 
-    for (std::vector<Alignable*>::const_iterator ali = m_alignables.begin(); ali != m_alignables.end(); ++ali)
+    for (const auto& ali: m_alignables)
     {
         if (m_debug) std::cout << "***** Start loop over alignables" << std::endl;
 
-        std::vector<bool> selector = (*ali)->alignmentParameters()->selector();
+        std::vector<bool> selector = ali->alignmentParameters()->selector();
         bool align_x = selector[0];
         bool align_y = selector[1];
         bool align_z = selector[2];
@@ -891,13 +891,13 @@ void MuonAlignmentFromReference::fitAndAlign()
         if (align_phiz) paramIndex_counter++;
         paramIndex.push_back(paramIndex_counter);
 
-        DetId id = (*ali)->geomDetId();
+        DetId id = ali->geomDetId();
 
-        Alignable *thisali = *ali;
+        auto thisali = ali;
         if (m_combineME11 && id.subdetId() == MuonSubdetId::CSC)
         {
             CSCDetId cscid(id.rawId());
-            if (cscid.station() == 1 && cscid.ring() == 4)   thisali = m_me11map[*ali];
+            if (cscid.station() == 1 && cscid.ring() == 4)   thisali = m_me11map[ali];
         }
 
         if (m_debug) std::cout << "***** loop over alignables 1" << std::endl;
@@ -1379,9 +1379,9 @@ void MuonAlignmentFromReference::fitAndAlign()
 
                 if (successful_fit)
                 {
-                    std::vector<Alignable*> oneortwo;
-                    oneortwo.push_back(*ali);
-                    if (thisali != *ali) oneortwo.push_back(thisali);
+                    align::Alignables oneortwo;
+                    oneortwo.push_back(ali);
+                    if (thisali != ali) oneortwo.push_back(thisali);
                     m_alignmentParameterStore->setAlignmentPositionError(oneortwo, 0., 0.);
                 }
                 else
@@ -1394,9 +1394,9 @@ void MuonAlignmentFromReference::fitAndAlign()
 
                     for (int i = 0; i < numParams; i++)  cov[i][i] = 1000.;
 
-                    std::vector<Alignable*> oneortwo;
-                    oneortwo.push_back(*ali);
-                    if (thisali != *ali) oneortwo.push_back(thisali);
+                    align::Alignables oneortwo;
+                    oneortwo.push_back(ali);
+                    if (thisali != ali) oneortwo.push_back(thisali);
                     m_alignmentParameterStore->setAlignmentPositionError(oneortwo, 1000., 0.);
                 }
             }
@@ -1410,16 +1410,16 @@ void MuonAlignmentFromReference::fitAndAlign()
 
                 for (int i = 0; i < numParams; i++)  cov[i][i] = 1000.;
 
-                std::vector<Alignable*> oneortwo;
-                oneortwo.push_back(*ali);
-                if (thisali != *ali) oneortwo.push_back(thisali);
+                align::Alignables oneortwo;
+                oneortwo.push_back(ali);
+                if (thisali != ali) oneortwo.push_back(thisali);
                 m_alignmentParameterStore->setAlignmentPositionError(oneortwo, 1000., 0.);
             }
 
-            AlignmentParameters *parnew = (*ali)->alignmentParameters()->cloneFromSelected(params, cov);
-            (*ali)->setAlignmentParameters(parnew);
-            m_alignmentParameterStore->applyParameters(*ali);
-            (*ali)->alignmentParameters()->setValid(true);
+            AlignmentParameters *parnew = ali->alignmentParameters()->cloneFromSelected(params, cov);
+            ali->setAlignmentParameters(parnew);
+            m_alignmentParameterStore->applyParameters(ali);
+            ali->alignmentParameters()->setValid(true);
 
             if (m_debug) std::cout << cname<<" fittime= "<< stop_watch.CpuTime() << " sec" << std::endl;
         } // end we have a fitter for this alignable
@@ -1687,10 +1687,9 @@ void MuonAlignmentFromReference::fillNtuple()
     }
 }
 
-void MuonAlignmentFromReference::parseReference(
-        std::vector<Alignable*> &reference, 
-        std::vector<Alignable*> &all_DT_chambers, 
-        std::vector<Alignable*> &all_CSC_chambers)
+void MuonAlignmentFromReference::parseReference(align::Alignables& reference,
+                                                const align::Alignables& all_DT_chambers,
+                                                const align::Alignables& all_CSC_chambers)
 {
     std::map<Alignable*,bool> already_seen;
 
@@ -1774,15 +1773,15 @@ void MuonAlignmentFromReference::parseReference(
                     throw cms::Exception("MuonAlignmentFromReference") << "reference chamber doesn't exist: " << (*name) << std::endl;
 
                 DTChamberId id(wheel, station, sector);
-                for (std::vector<Alignable*>::const_iterator ali = all_DT_chambers.begin();  ali != all_DT_chambers.end();  ++ali)
+                for (const auto& ali: all_DT_chambers)
                 {
-                    if ((*ali)->geomDetId().rawId() == id.rawId())
+                    if (ali->geomDetId().rawId() == id.rawId())
                     {
-                        std::map<Alignable*,bool>::const_iterator trial = already_seen.find(*ali);
+                        std::map<Alignable*,bool>::const_iterator trial = already_seen.find(ali);
                         if (trial == already_seen.end())
                         {
-                            reference.push_back(*ali);
-                            already_seen[*ali] = true;
+                            reference.push_back(ali);
+                            already_seen[ali] = true;
                         }
                     }
                 }
@@ -1865,15 +1864,15 @@ void MuonAlignmentFromReference::parseReference(
                     throw cms::Exception("MuonAlignmentFromReference") << "reference chamber doesn't exist: " << (*name) << std::endl;
 
                 CSCDetId id(endcap, station, ring, chamber);
-                for (std::vector<Alignable*>::const_iterator ali = all_CSC_chambers.begin();  ali != all_CSC_chambers.end();  ++ali)
+                for (const auto& ali: all_CSC_chambers)
                 {
-                    if ((*ali)->geomDetId().rawId() == id.rawId())
+                    if (ali->geomDetId().rawId() == id.rawId())
                     {
-                        std::map<Alignable*,bool>::const_iterator trial = already_seen.find(*ali);
+                        std::map<Alignable*,bool>::const_iterator trial = already_seen.find(ali);
                         if (trial == already_seen.end()) 
                         {
-                            reference.push_back(*ali);
-                            already_seen[*ali] = true;
+                            reference.push_back(ali);
+                            already_seen[ali] = true;
                         }
                     }
                 }

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonDTLocalMillepedeAlgorithm.h
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonDTLocalMillepedeAlgorithm.h
@@ -125,7 +125,7 @@ class MuonDTLocalMillepedeAlgorithm : public AlignmentAlgorithmBase
 
 
   AlignmentParameterStore* theAlignmentParameterStore;
-  std::vector<Alignable*> theAlignables;
+  align::Alignables theAlignables;
   AlignableNavigator* theAlignableDetAccessor;
   
   //Service for histograms

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonMillepedeAlgorithm.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonMillepedeAlgorithm.cc
@@ -176,9 +176,7 @@
 	  edm::LogWarning("Alignment") << "[MuonMillepedeAlgorithm] Terminating";
 
 	  // iterate over alignment parameters
-	  for(std::vector<Alignable*>::const_iterator
-	    it=theAlignables.begin(); it!=theAlignables.end(); it++) {
-	    Alignable* ali=(*it);
+	  for(const auto& ali: theAlignables) {
 	    // Alignment parameters
 	    // AlignmentParameters* par = ali->alignmentParameters();
 	    edm::LogInfo("Alignment") << "now apply params";

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonMillepedeAlgorithm.h
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonMillepedeAlgorithm.h
@@ -55,7 +55,7 @@ class MuonMillepedeAlgorithm : public AlignmentAlgorithmBase
   void printM(const AlgebraicMatrix& ); 
   
   AlignmentParameterStore* theAlignmentParameterStore;
-  std::vector<Alignable*> theAlignables;
+  align::Alignables theAlignables;
   AlignableNavigator* theAlignableDetAccessor;
 
   // verbosity flag

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
@@ -400,7 +400,7 @@ void TrackerGeometryCompare::createROOTGeometry(const edm::EventSetup& iSetup){
 	std::vector<double>* p_inputDpar1 = &inputDpar1; 
 	std::vector<double>* p_inputDpar2 = &inputDpar2; 
 
-	const std::vector<Alignable*> comp1 = referenceTracker->deepComponents(); 
+	const auto& comp1 = referenceTracker->deepComponents(); 
 
 	SurfaceDeformation * surfDef1; 
 	if (_inputFilename1 != "IDEAL"){
@@ -432,7 +432,7 @@ void TrackerGeometryCompare::createROOTGeometry(const edm::EventSetup& iSetup){
 	}
 	currentTracker = new AlignableTracker(&(*theCurTracker), tTopo);
 	
-	const std::vector<Alignable*> comp2 = currentTracker->deepComponents(); 
+	const auto& comp2 = currentTracker->deepComponents(); 
 
 	SurfaceDeformation * surfDef2 ; 
 	if (_inputFilename2 != "IDEAL"){ 
@@ -609,8 +609,8 @@ void TrackerGeometryCompare::compareGeometries(Alignable* refAli, Alignable* cur
 
 	using namespace align ; 
 	
-	const std::vector<Alignable*>& refComp = refAli->components();
-	const std::vector<Alignable*>& curComp = curAli->components();
+	const auto& refComp = refAli->components();
+	const auto& curComp = curAli->components();
 	
 	unsigned int nComp = refComp.size();
 	//only perform for designate levels
@@ -718,8 +718,8 @@ void TrackerGeometryCompare::setCommonTrackerSystem(){
 
 void TrackerGeometryCompare::diffCommonTrackerSystem(Alignable *refAli, Alignable *curAli){
 	
-	const std::vector<Alignable*>& refComp = refAli->components();
-	const std::vector<Alignable*>& curComp = curAli->components();
+	const auto& refComp = refAli->components();
+	const auto& curComp = curAli->components();
 	
 	unsigned int nComp = refComp.size();
 	//only perform for designate levels
@@ -887,14 +887,14 @@ void TrackerGeometryCompare::fillTree(Alignable *refAli, const AlgebraicVector& 
 void TrackerGeometryCompare::surveyToTracker(AlignableTracker* ali, Alignments* alignVals, AlignmentErrorsExtended* alignErrors){
 	
 	//getting the right alignables for the alignment record
-	std::vector<Alignable*> detPB = ali->pixelHalfBarrelGeomDets();
-	std::vector<Alignable*> detPEC = ali->pixelEndcapGeomDets();
-	std::vector<Alignable*> detTIB = ali->innerBarrelGeomDets();
-	std::vector<Alignable*> detTID = ali->TIDGeomDets();
-	std::vector<Alignable*> detTOB = ali->outerBarrelGeomDets();
-	std::vector<Alignable*> detTEC = ali->endcapGeomDets();
+	auto detPB = ali->pixelHalfBarrelGeomDets();
+	auto detPEC = ali->pixelEndcapGeomDets();
+	auto detTIB = ali->innerBarrelGeomDets();
+	auto detTID = ali->TIDGeomDets();
+	auto detTOB = ali->outerBarrelGeomDets();
+	auto detTEC = ali->endcapGeomDets();
 	
-	std::vector<Alignable*> allGeomDets;
+	align::Alignables allGeomDets;
 	std::copy(detPB.begin(), detPB.end(), std::back_inserter(allGeomDets));
 	std::copy(detPEC.begin(), detPEC.end(), std::back_inserter(allGeomDets));
 	std::copy(detTIB.begin(), detTIB.end(), std::back_inserter(allGeomDets));
@@ -902,30 +902,27 @@ void TrackerGeometryCompare::surveyToTracker(AlignableTracker* ali, Alignments* 
 	std::copy(detTOB.begin(), detTOB.end(), std::back_inserter(allGeomDets));
 	std::copy(detTEC.begin(), detTEC.end(), std::back_inserter(allGeomDets));
 	
-	std::vector<Alignable*> rcdAlis;
-	for (std::vector<Alignable*>::iterator i = allGeomDets.begin(); i!= allGeomDets.end(); i++){
-		if ((*i)->components().size() == 1){
-			rcdAlis.push_back((*i));
+	align::Alignables rcdAlis;
+	for (const auto& i: allGeomDets){
+		if (i->components().size() == 1){
+			rcdAlis.push_back(i);
 		}
-		else if ((*i)->components().size() > 1){
-			rcdAlis.push_back((*i));
-			std::vector<Alignable*> comp = (*i)->components();
-			for (std::vector<Alignable*>::iterator j = comp.begin(); j != comp.end(); j++){
-				rcdAlis.push_back((*j));
-			}
+		else if (i->components().size() > 1){
+			rcdAlis.push_back(i);
+			const auto& comp = i->components();
+			for (const auto& j: comp) rcdAlis.push_back(j);
 		}
 	}
 	
 	//turning them into alignments
-	for(std::vector<Alignable*>::iterator k = rcdAlis.begin(); k != rcdAlis.end(); k++){
-		
-		const SurveyDet* surveyInfo = (*k)->survey();
+	for(const auto& k: rcdAlis) {
+		const SurveyDet* surveyInfo = k->survey();
 		const align::PositionType& pos(surveyInfo->position());
 		align::RotationType rot(surveyInfo->rotation());
 		CLHEP::Hep3Vector clhepVector(pos.x(),pos.y(),pos.z());
 		CLHEP::HepRotation clhepRotation( CLHEP::HepRep3x3(rot.xx(),rot.xy(),rot.xz(),rot.yx(),rot.yy(),rot.yz(),rot.zx(),rot.zy(),rot.zz()));
-		AlignTransform transform(clhepVector, clhepRotation, (*k)->id());
-		AlignTransformErrorExtended transformError(CLHEP::HepSymMatrix(3,1), (*k)->id());
+		AlignTransform transform(clhepVector, clhepRotation, k->id());
+		AlignTransformErrorExtended transformError(CLHEP::HepSymMatrix(3,1), k->id());
 		alignVals->m_align.push_back(transform);
 		alignErrors->m_alignError.push_back(transformError);
 	}
@@ -938,7 +935,7 @@ void TrackerGeometryCompare::surveyToTracker(AlignableTracker* ali, Alignments* 
 
 void TrackerGeometryCompare::addSurveyInfo(Alignable* ali){
 	
-	const std::vector<Alignable*>& comp = ali->components();
+	const auto& comp = ali->components();
 	
 	unsigned int nComp = comp.size();
 	

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.h
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.h
@@ -50,7 +50,6 @@ class TrackerGeometryCompare: public edm::EDAnalyzer {
 public:
 	typedef AlignTransform SurveyValue;
 	typedef Alignments SurveyValues;
-	typedef std::vector<Alignable*> Alignables;
 		
   /// Do nothing. Required by framework.
   TrackerGeometryCompare(

--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -636,7 +636,7 @@ TrackerOfflineValidation::bookGlobalHists(DirectoryWrapper& tfd )
 void
 TrackerOfflineValidation::bookDirHists(DirectoryWrapper& tfd, const Alignable& ali, const TrackerTopology* tTopo)
 {
-  std::vector<Alignable*> alivec(ali.components());
+  const auto& alivec = ali.components();
   for(int i=0, iEnd = ali.components().size();i < iEnd; ++i) {
     std::string structurename  = alignableTracker_->objectIdProvider().idToString((alivec)[i]->alignableObjectId());
     LogDebug("TrackerOfflineValidation") << "StructureName = " << structurename;
@@ -1286,7 +1286,7 @@ void
 TrackerOfflineValidation::prepareSummaryHists( DirectoryWrapper& tfd, const Alignable& ali,
 					       std::vector<TrackerOfflineValidation::SummaryContainer>& vLevelProfiles)
 {
-  std::vector<Alignable*> alivec(ali.components());
+  const auto& alivec = ali.components();
   if( this->isDetOrDetUnit((alivec)[0]->alignableObjectId()) ) return;
   
   for(int iComp=0, iCompEnd = ali.components().size();iComp < iCompEnd; ++iComp) {

--- a/Alignment/SurveyAnalysis/interface/SurveyOutput.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyOutput.h
@@ -14,14 +14,15 @@
 
 #include "TFile.h"
 
+#include "Alignment/CommonAlignment/interface/Utilities.h"
+
 class Alignable;
 
 class SurveyOutput
 {
   public:
 
-  SurveyOutput(
-	       const std::vector<Alignable*>&,
+  SurveyOutput(const align::Alignables&,
 	       const std::string& fileName
 	       );
 
@@ -32,7 +33,7 @@ class SurveyOutput
 
   private:
 
-  const std::vector<Alignable*>& theAlignables;
+  const align::Alignables& theAlignables;
 
   TFile theFile;
 };

--- a/Alignment/SurveyAnalysis/plugins/SurveyDBUploader.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDBUploader.cc
@@ -43,7 +43,7 @@ void SurveyDBUploader::endJob()
 
 void SurveyDBUploader::getSurveyInfo(const Alignable* ali)
 {
-  const std::vector<Alignable*>& comp = ali->components();
+  const auto& comp = ali->components();
 
   unsigned int nComp = comp.size();
 

--- a/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.h
@@ -40,7 +40,7 @@ private:
 
   static const int NFILES = 2;
   
-  // void applyAllSurveyInfo( std::vector<Alignable*> alignables, 
+  // void applyAllSurveyInfo( align::Alignables alignables,
   //			   const MapType map );
   
   void applyCoarseSurveyInfo(TrackerAlignment& tr_align);

--- a/Alignment/SurveyAnalysis/plugins/SurveyInputCSCfromPins.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyInputCSCfromPins.cc
@@ -150,13 +150,12 @@ void SurveyInputCSCfromPins::analyze(const edm::Event&, const edm::EventSetup& i
  
  	AlignableMuon* theAlignableMuon = new AlignableMuon( &(*dtGeometry) , &(*cscGeometry) );
  	AlignableNavigator* theAlignableNavigator = new AlignableNavigator( theAlignableMuon );
- 
-  	std::vector<Alignable*> theEndcaps = theAlignableMuon->CSCEndcaps();
- 
-	for (std::vector<Alignable*>::const_iterator aliiter = theEndcaps.begin();  aliiter != theEndcaps.end();  ++aliiter) {
-     
- 		addComponent(*aliiter);
-    	}
+
+        const auto& theEndcaps = theAlignableMuon->CSCEndcaps();
+
+        for (const auto& aliiter: theEndcaps) {
+                addComponent(aliiter);
+        }
     
 	
 	while (in.good())
@@ -264,10 +263,9 @@ void SurveyInputCSCfromPins::analyze(const edm::Event&, const edm::EventSetup& i
 
 	file1->Close();
    
-	for (std::vector<Alignable*>::const_iterator aliiter = theEndcaps.begin();  aliiter != theEndcaps.end();  ++aliiter) {
-     
- 		fillAllRecords(*aliiter);
-    	} 
+        for (const auto& aliiter: theEndcaps) {
+                fillAllRecords(aliiter);
+        }
 
 	delete theAlignableMuon;
 	delete theAlignableNavigator;
@@ -343,11 +341,9 @@ void SurveyInputCSCfromPins::fillAllRecords(Alignable *ali) {
 	   }
    	}
 
-   	std::vector<Alignable*> components = ali->components();
-   	for (std::vector<Alignable*>::const_iterator iter = components.begin();  iter != components.end();  ++iter) {
-	
-      		fillAllRecords(*iter);
-   	}
+        for (const auto& iter: ali->components()) {
+                fillAllRecords(iter);
+        }
 }
 
 

--- a/Alignment/SurveyAnalysis/src/SurveyOutput.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyOutput.cc
@@ -7,7 +7,7 @@
 
 #include "Alignment/SurveyAnalysis/interface/SurveyOutput.h"
 
-SurveyOutput::SurveyOutput(const std::vector<Alignable*>& alignables,
+SurveyOutput::SurveyOutput(const align::Alignables& alignables,
 			   const std::string& fileName):
   theAlignables(alignables),
   theFile(fileName.c_str(), "RECREATE")

--- a/Alignment/SurveyAnalysis/test/SurveyTest.cc
+++ b/Alignment/SurveyAnalysis/test/SurveyTest.cc
@@ -32,7 +32,7 @@ void SurveyTest::beginJob()
 {
   Alignable* det = SurveyInputBase::detector();
 
-  std::vector<Alignable*> sensors;
+  align::Alignables sensors;
 
   getTerminals(sensors, det);
 
@@ -47,10 +47,10 @@ void SurveyTest::beginJob()
        i != algos.end(); ++i) delete i->second;
 }
 
-void SurveyTest::getTerminals(std::vector<Alignable*>& terminals,
+void SurveyTest::getTerminals(align::Alignables& terminals,
 			      Alignable* ali)
 {
-  const std::vector<Alignable*>& comp = ali->components();
+  const auto& comp = ali->components();
 
   unsigned int nComp = comp.size();
 

--- a/Alignment/TrackerAlignment/interface/AlignableTrackerBuilder.h
+++ b/Alignment/TrackerAlignment/interface/AlignableTrackerBuilder.h
@@ -10,12 +10,14 @@
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 
 // alignment
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 #include "Alignment/TrackerAlignment/interface/TrackerAlignmentLevelBuilder.h"
 
 
 
 class AlignableTrackerBuilder {
+  using Alignables = align::Alignables;
 
   //========================== PUBLIC METHODS =================================
   public: //===================================================================

--- a/Alignment/TrackerAlignment/test/ApeAdder.cpp
+++ b/Alignment/TrackerAlignment/test/ApeAdder.cpp
@@ -45,7 +45,7 @@ public:
 
 private:
     // methods
-    void addApe( std::vector<Alignable*> alignables );
+  void addApe(const align::Alignables& alignables);
     
 private:
     // members
@@ -109,14 +109,13 @@ void ApeAdder::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
 
 }
 
-void ApeAdder::addApe( std::vector<Alignable*> alignables )
+void ApeAdder::addApe(const align::Alignables& alignables)
 {
   
   AlignmentPositionError ape( theApe[0], theApe[1], theApe[2] );
-  for ( std::vector<Alignable*>::iterator iDet = alignables.begin();
-		iDet != alignables.end(); ++iDet )
-    (*iDet)->setAlignmentPositionError( ape, true ); // true: propagate to components
-    
+  for (const auto& iDet: alignables) {
+    iDet->setAlignmentPositionError(ape, true); // true: propagate to components
+  }
 }
 
 //define this as a plug-in


### PR DESCRIPTION
The typedef `Alignables` is (re-)defined in multiple places.
This PR streamlines their usage together with turning copies of these vectors to const references when a copy is not needed.
It is also one step towards better ownership handling of the composite alignables.

Also fixes a few warnings noticed in previous PRs.

Purely technical modifications with no changes in behaviour expected.

attn.: @lpernie as I am modifying classes in MuonAlignment