### PR TITLE
Fix clang warnings about unneeded lambda captures

### DIFF
--- a/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
@@ -191,7 +191,7 @@ void LimitedTaskQueue_test::testPause()
       edm::LimitedTaskQueue::Resumer resumer;
       std::atomic<bool> resumerSet{false};
       std::exception_ptr e1;
-      queue.pushAndPause([&resumer,&resumerSet,&count,&queue,pWaitTask,&e1](edm::LimitedTaskQueue::Resumer iResumer){
+      queue.pushAndPause([&resumer,&resumerSet,&count,pWaitTask,&e1](edm::LimitedTaskQueue::Resumer iResumer){
         resumer = std::move(iResumer);
         resumerSet = true;
         try {
@@ -203,7 +203,7 @@ void LimitedTaskQueue_test::testPause()
       });
 
       std::exception_ptr e2;
-      queue.push([&count,&queue,pWaitTask,&e2]{
+      queue.push([&count,pWaitTask,&e2]{
         try{
           CPPUNIT_ASSERT(++count == 2);
         } catch(...) {
@@ -213,7 +213,7 @@ void LimitedTaskQueue_test::testPause()
       });
       
       std::exception_ptr e3;
-      queue.push([&count,&queue,pWaitTask,&e3]{
+      queue.push([&count,pWaitTask,&e3]{
         try {
           CPPUNIT_ASSERT(++count == 3);
         }catch(...){
@@ -260,7 +260,7 @@ void LimitedTaskQueue_test::stressTest()
                    iTask->decrement_ref_count();}};
                   for(unsigned int i = 0; i<nTasks;++i) {
                      pWaitTask->increment_ref_count();
-                     queue.push([i,&count,pWaitTask,&nRunningTasks] {
+                     queue.push([&count,pWaitTask,&nRunningTasks] {
                        std::shared_ptr<tbb::task> guard{pWaitTask,[](tbb::task*iTask) {
                          iTask->decrement_ref_count();}};
                        auto nrt = nRunningTasks++;
@@ -278,7 +278,7 @@ void LimitedTaskQueue_test::stressTest()
          waitToStart=false;
          for(unsigned int i=0; i<nTasks;++i) {
             pWaitTask->increment_ref_count();
-            queue.push([i,&count,pWaitTask,&nRunningTasks] {
+            queue.push([&count,pWaitTask,&nRunningTasks] {
               std::shared_ptr<tbb::task> guard{pWaitTask,[](tbb::task*iTask) {
                 iTask->decrement_ref_count();}};
               auto nrt = nRunningTasks++;

--- a/FWCore/Concurrency/test/serialtaskqueue_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/serialtaskqueue_t.cppunit.cpp
@@ -129,11 +129,11 @@ void SerialTaskQueue_test::testPause()
             CPPUNIT_ASSERT(count++ == 1);
             pWaitTask->decrement_ref_count();
          });
-         queue.push([&count,&queue,pWaitTask]{
+         queue.push([&count,pWaitTask]{
             CPPUNIT_ASSERT(count++ == 2);
             pWaitTask->decrement_ref_count();
          });
-         queue.push([&count,&queue,pWaitTask]{
+         queue.push([&count,pWaitTask]{
             CPPUNIT_ASSERT(count++ == 3);
             pWaitTask->decrement_ref_count();
          });
@@ -169,7 +169,7 @@ void SerialTaskQueue_test::stressTest()
 	    while(waitToStart.load()) {__sync_synchronize();};
             for(unsigned int i = 0; i<nTasks;++i) {
                pWaitTask->increment_ref_count();
-               queue.push([i,&count,pWaitTask] {
+               queue.push([&count,pWaitTask] {
                   ++count;
                   pWaitTask->decrement_ref_count();
                });
@@ -182,7 +182,7 @@ void SerialTaskQueue_test::stressTest()
          waitToStart=false;
          for(unsigned int i=0; i<nTasks;++i) {
             pWaitTask->increment_ref_count();
-            queue.push([i,&count,pWaitTask] {
+            queue.push([&count,pWaitTask] {
                ++count;
                pWaitTask->decrement_ref_count();
             });

--- a/FWCore/Concurrency/test/serialtaskqueuechain_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/serialtaskqueuechain_t.cppunit.cpp
@@ -197,7 +197,7 @@ void SerialTaskQueueChain_test::stressTest()
 	    while(waitToStart.load()) {};
             for(unsigned int i = 0; i<nTasks;++i) {
                pWaitTask->increment_ref_count();
-               chain.push([i,&count,pWaitTask] {
+               chain.push([&count,pWaitTask] {
                   ++count;
                   pWaitTask->decrement_ref_count();
                });
@@ -209,7 +209,7 @@ void SerialTaskQueueChain_test::stressTest()
          waitToStart=false;
          for(unsigned int i=0; i<nTasks;++i) {
             pWaitTask->increment_ref_count();
-            chain.push([i,&count,pWaitTask] {
+            chain.push([&count,pWaitTask] {
                ++count;
                pWaitTask->decrement_ref_count();
             });

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -374,7 +374,7 @@ namespace edm {
       //Have to create a new task which will make sure the state for UnscheduledProductResolver
       // is properly set after the module has run
       auto t = make_waiting_task(tbb::task::allocate_root(),
-                                 [this,&principal, skipCurrentProcess,sra,mcc](std::exception_ptr const* iPtr)
+                                 [this](std::exception_ptr const* iPtr)
       {
         //The exception is being rethrown because resolveProductImpl sets the ProductResolver to a failed
         // state for the case where an exception occurs during the call to the function.

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -266,7 +266,7 @@ namespace edm {
     unsigned int nUniqueBranchesToDelete=branchToReadingWorker.size();
     
     //talk with output modules first
-    modReg.forAllModuleHolders([this, &branchToReadingWorker,&nUniqueBranchesToDelete](maker::ModuleHolder* iHolder){
+    modReg.forAllModuleHolders([&branchToReadingWorker,&nUniqueBranchesToDelete](maker::ModuleHolder* iHolder){
       auto comm = iHolder->createOutputModuleCommunicator();
       if (comm) {
         if(!branchToReadingWorker.empty()) {

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -426,7 +426,7 @@ namespace edm {
       
     });
     
-    auto task = make_functor_task(tbb::task::allocate_root(), [this,doneTask,&ep,&es,cleaningUpAfterException,token] () mutable {
+    auto task = make_functor_task(tbb::task::allocate_root(), [this,doneTask,&ep,&es,token] () mutable {
       ServiceRegistry::Operate op(token);
       T::preScheduleSignal(actReg_.get(), &streamContext_);
       WaitingTaskHolder h(doneTask);

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -374,7 +374,7 @@ namespace edm {
     propagateProducts(InEvent, principal, ep);
     
     WaitingTaskHolder finalizeEventTask( make_waiting_task(tbb::task::allocate_root(),
-                                                           [this,&ep,iHolder](std::exception_ptr const* iPtr) mutable
+                                                           [&ep,iHolder](std::exception_ptr const* iPtr) mutable
       {
         ep.clearEventPrincipal();
         if(iPtr) {

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -373,7 +373,7 @@ m_ep()
 
 
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kBeginStream] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kBeginStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
     iBase->beginStream(s_streamID0, streamContext); };
 
@@ -421,7 +421,7 @@ m_ep()
     edm::ParentContext nullParentContext;
     iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
 
-  m_transToFunc[Trans::kEndStream] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kEndStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
     iBase->endStream(s_streamID0, streamContext); };
 

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -188,7 +188,7 @@ m_ep()
   m_actReg.reset(new edm::ActivityRegistry);
 
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kGlobalOpenInputFile] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
+  m_transToFunc[Trans::kGlobalOpenInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     edm::FileBlock fb;
     iBase->respondToOpenInputFile(fb);
   };
@@ -225,7 +225,7 @@ m_ep()
     iComm->writeRun(*m_rp, nullptr);
   };
   
-  m_transToFunc[Trans::kGlobalCloseInputFile] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
+  m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     edm::FileBlock fb;
     iBase->respondToCloseInputFile(fb);
   };

--- a/FWCore/Framework/test/limited_module_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_module_t.cppunit.cc
@@ -400,7 +400,7 @@ m_ep()
 
 
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kBeginStream] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kBeginStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
     iBase->beginStream(s_streamID0, streamContext); };
 
@@ -448,7 +448,7 @@ m_ep()
     edm::ParentContext nullParentContext;
     iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
 
-  m_transToFunc[Trans::kEndStream] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kEndStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
     iBase->endStream(s_streamID0, streamContext); };
 

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -188,7 +188,7 @@ m_ep()
   m_actReg.reset(new edm::ActivityRegistry);
 
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kGlobalOpenInputFile] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
+  m_transToFunc[Trans::kGlobalOpenInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     edm::FileBlock fb;
     iBase->respondToOpenInputFile(fb);
   };
@@ -225,7 +225,7 @@ m_ep()
     iComm->writeRun(*m_rp, nullptr);
   };
   
-  m_transToFunc[Trans::kGlobalCloseInputFile] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
+  m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     edm::FileBlock fb;
     iBase->respondToCloseInputFile(fb);
   };

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -266,7 +266,7 @@ m_ep()
   m_actReg.reset(new edm::ActivityRegistry);
 
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kGlobalOpenInputFile] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
+  m_transToFunc[Trans::kGlobalOpenInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     edm::FileBlock fb;
     iBase->respondToOpenInputFile(fb);
   };
@@ -303,7 +303,7 @@ m_ep()
     iComm->writeRun(*m_rp, nullptr);
   };
   
-  m_transToFunc[Trans::kGlobalCloseInputFile] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
+  m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     edm::FileBlock fb;
     iBase->respondToCloseInputFile(fb);
   };

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -402,7 +402,7 @@ m_ep()
 
 
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kBeginStream] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kBeginStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
     iBase->beginStream(s_streamID0, streamContext); };
   
@@ -449,7 +449,7 @@ m_ep()
     edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, parentContext, nullptr); };
 
-  m_transToFunc[Trans::kEndStream] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kEndStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
     iBase->endStream(s_streamID0, streamContext); };
 

--- a/FWCore/ROOTTests/test/tclass_methods_threaded_t.cc
+++ b/FWCore/ROOTTests/test/tclass_methods_threaded_t.cc
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
   
   
   for(int i=0; i<kNThreads; ++i) {
-    threads.emplace_back([i,&canStart,&classWasGotten,&firstMethodGotten]() {
+    threads.emplace_back([&canStart,&classWasGotten,&firstMethodGotten]() {
         static thread_local TThread guard;
         ++classWasGotten;
         ++firstMethodGotten;

--- a/FWCore/ROOTTests/test/tformula_threaded_t.cc
+++ b/FWCore/ROOTTests/test/tformula_threaded_t.cc
@@ -51,7 +51,7 @@ int main(int argc, char** argv)
   
   
   for(int i=0; i<kNThreads; ++i) {
-    threads.emplace_back([i,&canStart]() {
+    threads.emplace_back([&canStart]() {
         static thread_local TThread guard;
         --canStart;
         while( canStart > 0 ) {}

--- a/FWCore/ROOTTests/test/tprofile_threaded_t.cc
+++ b/FWCore/ROOTTests/test/tprofile_threaded_t.cc
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
     profiles.push_back(std::make_unique<TProfile>(s.str().c_str(),s.str().c_str(), 100,10,11,0,10));
     profiles.back()->SetCanExtend(TH1::kAllAxes);
     auto profile = profiles.back().get();
-    threads.emplace_back([i,profile,&canStart]() {
+    threads.emplace_back([profile,&canStart]() {
         static thread_local TThread guard;
         while(not canStart) {}
         for(int x=10; x>0; --x) {

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -795,7 +795,7 @@ namespace edm {
         });
       }
 
-      iReg.watchPreallocate([this](edm::service::SystemBounds const& iBounds){
+      iReg.watchPreallocate([](edm::service::SystemBounds const& iBounds){
         if (iBounds.maxNumberOfThreads() > moduleListBuffers_.size()) {
           moduleListBuffers_.resize(iBounds.maxNumberOfThreads());
         }


### PR DESCRIPTION
Removed unused variables captured in a lambda expression. These
were caught by a clang warning.