### PR TITLE
Change initial value of Ratio from 1 to 0 in the HFPET algorithm

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/HcalHF_PETalgorithm.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalHF_PETalgorithm.cc
@@ -120,7 +120,7 @@ void HcalHF_PETalgorithm::HFSetFlagFromPET(HFRecHit& hf,
     }
 
   // Step 3:  Compute ratio
-  double Ratio=1;
+  double Ratio=0;
   HFRecHitCollection::const_iterator part=rec.find(partner);
   if (part!=rec.end())
     {


### PR DESCRIPTION
The HFPET algorithm is applied to all short fiber channels and long fiber channels in |ieta|=29. It looks for the partner long or short fiber channel and calculates the energy asymmetry, Ratio=(E_L-E_S)/(E_S+E_L). If the value of Ratio is larger than 0.8, the channel gets the HFPET flag turned on.

After introducing the TDC cut, it was observed that when the rechit for a long fiber channel is not made due to failing the TDC cut, the short fiber channel always gets the HFPET flag on. What happens is the following. 

(1) Once the long fiber channel is killed by TDC cut, Ratio can’t be calculated by definition, so this channel should pass HFPET. This needs to be done by Step 2 in https://github.com/cms-sw/cmssw/blob/2b5e96f3e6a6184d72a624812467ca62594db987/RecoLocalCalo/HcalRecAlgos/src/HcalHF_PETalgorithm.cc#L109-L120 that checks the status of the partner channel, i.e., long fiber channel. But, it is based on the channel status https://github.com/cms-sw/cmssw/blob/2b5e96f3e6a6184d72a624812467ca62594db987/RecoLocalCalo/HcalRecAlgos/src/HcalHF_PETalgorithm.cc#L112 that does not know whether the rechit was dropped due to TDC cut.

(2) Then, it goes to Step 3 where Ratio is calculated and the decision is made. The part where Ratio is calculated is https://github.com/cms-sw/cmssw/blob/2b5e96f3e6a6184d72a624812467ca62594db987/RecoLocalCalo/HcalRecAlgos/src/HcalHF_PETalgorithm.cc#L122-L135. Since the partner long fiber channel does not exist, L122-L135 is not run. The problem is that the default value of Ratio is 1, which is badly chosen in this case because HFPET is set when Ratio is larger than 0.8. 

The simplest solution is to change the initial value of Ratio from 1 to 0 so that the Ratio is smaller than the cut value even though L122-L135 is not run. The impact of this change was studied with the events in MET and SingleMuon datasets [1]. There is no impact on the SingleMuon events which is a noise-free sample concerning the HF noise, and about 10% change (increase) in the number of events in the MET dataset. Since HF noise is not simulated in MC, negligible change in MC is expected. 

[1] p19-20 (right plots) in https://indico.cern.ch/event/678759/contributions/2788324/attachments/1570480/2477214/20171205_Jae_HCALDPG_Noise.pdf