### PR TITLE
Fix CaloTower outer energy for HE 2018

### DIFF
--- a/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
+++ b/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
@@ -142,3 +142,6 @@ calotowermaker = cms.EDProducer("CaloTowersCreator",
 	HcalPhase = cms.int32(0)
     
 )
+
+from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
+run2_HE_2018.toModify(calotowermaker, HcalPhase = cms.int32(1))

--- a/RecoLocalCalo/CaloTowersCreator/python/calotowerremaker_cfi.py
+++ b/RecoLocalCalo/CaloTowersCreator/python/calotowerremaker_cfi.py
@@ -63,4 +63,6 @@ ct2ct = cms.EDProducer("CaloTowersReCreator",
 	HcalPhase = cms.int32(0)
 )
 
+from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
+run2_HE_2018.toModify(ct2ct, HcalPhase = cms.int32(1))
 

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -768,11 +768,22 @@ void CaloTowersCreationAlgo::assignHitHcal(const CaloRecHit * recHit) {
         // store energy in highest depth for towers 18-27 (for electron,photon ID in endcap)
         // also, store energy in HE part of tower 16 (for JetMET cleanup)
         HcalDetId hcalDetId(detId);
-        if (hcalDetId.subdet()==HcalEndcap && theHcalPhase==0) {
-          if ( (hcalDetId.depth()==2 && hcalDetId.ietaAbs()>=18 && hcalDetId.ietaAbs()<27) ||
-               (hcalDetId.depth()==3 && hcalDetId.ietaAbs()==27) ||
-               (hcalDetId.depth()==3 && hcalDetId.ietaAbs()==16) ) {
-            tower.E_outer += e;
+        if (hcalDetId.subdet()==HcalEndcap){
+          if(theHcalPhase==0) {
+            if ( (hcalDetId.depth()==2 && hcalDetId.ietaAbs()>=18 && hcalDetId.ietaAbs()<27) ||
+                 (hcalDetId.depth()==3 && hcalDetId.ietaAbs()==27) ||
+                 (hcalDetId.depth()==3 && hcalDetId.ietaAbs()==16) ) {
+              tower.E_outer += e;
+            }
+          }
+          //combine depths in phase0-like way
+          else if(theHcalPhase==1) {
+            if ( (hcalDetId.depth()>=3 && hcalDetId.ietaAbs()>=18 && hcalDetId.ietaAbs()<26) ||
+                 (hcalDetId.depth()>=4 && (hcalDetId.ietaAbs()==26 || hcalDetId.ietaAbs()==27)) ||
+                 (hcalDetId.depth()==3 && hcalDetId.ietaAbs()==17) ||
+                 (hcalDetId.depth()==4 && hcalDetId.ietaAbs()==16) ) {
+              tower.E_outer += e;
+            }
           }
         }
 


### PR DESCRIPTION
For the full HE upgrade in 2018, we will not combine RecHits to resemble the old (phase 0) depth segmentation scheme.

However, egamma would like to retain (as much as possible) the definitions of "outer energy" and "inner energy" for CaloTowers in HE. This PR implements that, using the existing `HcalPhase` parameter (held over from 62XSLHC, so far unused in modern releases).

I also added a case for tower 17, which now has 2 depths and can be treated similarly to the other towers.

These diagrams show phase 0, phase 1, and "HEP17" = phase 1 combined to be as close to phase 0 as possible (though NB above caveat about tower 17 in this PR):

<img src="http://kjplanet.com/pr/HCAL-Depth-Segmentation-Legacy-View-HE-v201706A.png" alt="phase 0 depths" width=198 height=209> <img src="http://kjplanet.com/pr/HCAL-Depth-Segmentation-Phase1-HBHE-View-HE-v201706A.png" alt="phase 1 depths" width=198 height=209> <img src="http://kjplanet.com/pr/HCAL-Depth-Segmentation-Phase1-HBHE-View-HE-Label-HEP17-v201706A.png" alt="phase 1 depths" width=200 height=209>

attn: @abdoulline @igv4321 @bsunanda @Sam-Harper 
