### PR TITLE
Fixing lack of virtualness for some GsfElectron methods

### DIFF
--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -187,7 +187,7 @@ class GsfElectron : public RecoCandidate
     float ctfGsfOverlap() const { return core()->ctfGsfOverlap() ; }
     bool ecalDrivenSeed() const { return core()->ecalDrivenSeed() ; }
     bool trackerDrivenSeed() const { return core()->trackerDrivenSeed() ; }
-    SuperClusterRef parentSuperCluster() const { return core()->parentSuperCluster() ; }
+    virtual SuperClusterRef parentSuperCluster() const { return core()->parentSuperCluster() ; }
 
     // backward compatibility
     struct ClosestCtfTrack
@@ -198,8 +198,8 @@ class GsfElectron : public RecoCandidate
       ClosestCtfTrack( TrackRef track, float sh ) : ctfTrack(track), shFracInnerHits(sh) {}
      } ;
     float shFracInnerHits() const { return core()->ctfGsfOverlap() ; }
-    TrackRef closestCtfTrackRef() const { return core()->ctfTrack() ; }
-    ClosestCtfTrack closestCtfTrack() const { return ClosestCtfTrack(core()->ctfTrack(),core()->ctfGsfOverlap()) ; }
+    virtual TrackRef closestCtfTrackRef() const { return core()->ctfTrack() ; }
+    virtual ClosestCtfTrack closestCtfTrack() const { return ClosestCtfTrack(core()->ctfTrack(),core()->ctfGsfOverlap()) ; }
 
   private:
 

--- a/DataFormats/PatCandidates/interface/Electron.h
+++ b/DataFormats/PatCandidates/interface/Electron.h
@@ -77,11 +77,11 @@ namespace pat {
       /// override the reco::GsfElectron::superCluster method, to access the internal storage of the supercluster
       reco::SuperClusterRef superCluster() const override;
       /// override the reco::GsfElectron::pflowSuperCluster method, to access the internal storage of the pflowSuperCluster
-      reco::SuperClusterRef parentSuperCluster() const;
+      reco::SuperClusterRef parentSuperCluster() const override;
       /// returns nothing. Use either gsfTrack or closestCtfTrack
       reco::TrackRef track() const override;
       /// override the reco::GsfElectron::closestCtfTrackRef method, to access the internal storage of the track
-      reco::TrackRef closestCtfTrackRef() const;
+      reco::TrackRef closestCtfTrackRef() const override;
       /// direct access to the seed cluster
       reco::CaloClusterPtr seed() const; 
 


### PR DESCRIPTION
This is bug fix that makes the methods that really should be virtual in GsfElectron virtual while also ensuring overrides in the pat::Electron.

The pat::Electron embeds its tracks therefore it needs to override its methods. Because its not virtual you get gems like this in the code: https://github.com/cms-sw/cmssw/blob/CMSSW_10_0_0_pre2/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2Spring16GeneralPurpose.cc#L301-L306

which is not great. So I've fixed it here and then once its merged, we can fix it in our MVA code. We also would this this backported to 94X if possible, opinons? 

