### PR TITLE
Improve theano tests

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -17,11 +17,11 @@
 <test name="testNumba" command="testNumba.py"/>
 <test name="testTables" command="testTables.py"/>
 
-<test name="testDownhill" command="testDownhill.py"/>
+<test name="testDownhill" command="testDownhill.sh"/>
 <test name="testXGBoost_and_sklearn" command="testXGBoost_and_sklearn.py"/>
 #<test name="testTheanets" command="testTheanets.py"/>
 
-<test name="testhep_ml" command="testhep_ml.py"/>
+<test name="testhep_ml" command="testhep_ml.sh"/>
 <test name="testUncertainties" command="testUncertainties.py"/>
-<test name="testImports" command="imports.py"/>
-<test name="testTheano" command="testTheano.py"/>
+<test name="testImports" command="imports.sh"/>
+<test name="testTheano" command="testTheano.sh"/>

--- a/PhysicsTools/PythonAnalysis/test/imports.sh
+++ b/PhysicsTools/PythonAnalysis/test/imports.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -x
+set -e
+
+echo ">>> Create temporary directory for cache"
+TEST_TMPDIR=$(mktemp -d /tmp/cmssw_theano.XXXXXXX)
+
+echo ">>> Change default behaviour for Theano"
+export THEANO_FLAGS="device=cpu,force_device=True,base_compiledir=$TEST_TMPDIR"
+
+echo ">>> Theano configuration for testing:"
+python -c 'import theano; print(theano.config)'
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+python ${CMSSW_BASE}/src/PhysicsTools/PythonAnalysis/test/imports.py
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+rm -rf "$TEST_TMPDIR"

--- a/PhysicsTools/PythonAnalysis/test/testDownhill.sh
+++ b/PhysicsTools/PythonAnalysis/test/testDownhill.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -x
+set -e
+
+echo ">>> Create temporary directory for cache"
+TEST_TMPDIR=$(mktemp -d /tmp/cmssw_theano.XXXXXXX)
+
+echo ">>> Change default behaviour for Theano"
+export THEANO_FLAGS="device=cpu,force_device=True,base_compiledir=$TEST_TMPDIR"
+
+echo ">>> Theano configuration for testing:"
+python -c 'import theano; print(theano.config)'
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+python ${CMSSW_BASE}/src/PhysicsTools/PythonAnalysis/test/testDownhill.py
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+rm -rf "$TEST_TMPDIR"

--- a/PhysicsTools/PythonAnalysis/test/testTheano.sh
+++ b/PhysicsTools/PythonAnalysis/test/testTheano.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -x
+set -e
+
+echo ">>> Create temporary directory for cache"
+TEST_TMPDIR=$(mktemp -d /tmp/cmssw_theano.XXXXXXX)
+
+echo ">>> Change default behaviour for Theano"
+export THEANO_FLAGS="device=cpu,force_device=True,base_compiledir=$TEST_TMPDIR"
+
+echo ">>> Theano configuration for testing:"
+python -c 'import theano; print(theano.config)'
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+python ${CMSSW_BASE}/src/PhysicsTools/PythonAnalysis/test/testTheano.py
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+rm -rf "$TEST_TMPDIR"

--- a/PhysicsTools/PythonAnalysis/test/testhep_ml.sh
+++ b/PhysicsTools/PythonAnalysis/test/testhep_ml.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -x
+set -e
+
+echo ">>> Create temporary directory for cache"
+TEST_TMPDIR=$(mktemp -d /tmp/cmssw_theano.XXXXXXX)
+
+echo ">>> Change default behaviour for Theano"
+export THEANO_FLAGS="device=cpu,force_device=True,base_compiledir=$TEST_TMPDIR"
+
+echo ">>> Theano configuration for testing:"
+python -c 'import theano; print(theano.config)'
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+python ${CMSSW_BASE}/src/PhysicsTools/PythonAnalysis/test/testhep_ml.py
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+rm -rf "$TEST_TMPDIR"


### PR DESCRIPTION
CMSSW has now CUDA compiler enabled by default. Theano finds it and
attemps to use it.

By default force theano to use only CPU backend. Note, that by default
OpenMP is also disabled thus not disabled explicitly.

Also theano has a compilation cache, which by default is in your home
directory. This avoid writing directly and create a temporary directory
for the cache. It is constantly deleted.

This might solve random failures in IBs.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>