### PR TITLE
L1T DQM fix for correct histogram summing when running multithreaded

### DIFF
--- a/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
+++ b/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
@@ -128,6 +128,10 @@ void L1TMP7ZeroSupp::bookCapIdHistograms(DQMStore::IBooker& ibooker, const unsig
   errorSummaryDenMap_[id]->setBinLabel(RBXBLKS+1, "# BX blocks", 1);
   errorSummaryDenMap_[id]->setBinLabel(RBXBLKSFALSEPOS+1, "# BX blocks", 1);
   errorSummaryDenMap_[id]->setBinLabel(RBXBLKSFALSENEG+1, "# BX blocks", 1);
+  // Setting canExtend to false is needed to get the correct behaviour when running multithreaded.
+  // Otherwise, when merging the histgrams of the threads, TH1::Merge sums bins that have the same label in one bin.
+  // This needs to come after the calls to setBinLabel.
+  errorSummaryDenMap_[id]->getTH1F()->GetXaxis()->SetCanExtend(false);
 
   readoutSizeNoZSMap_[id] = ibooker.book1D("readoutSize", sizeTitleText + "size", 100, 0, maxFedReadoutSize_);
   readoutSizeNoZSMap_[id]->setAxisTitle("size (byte)", 1);

--- a/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
@@ -86,21 +86,19 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
       errorSummaryNum->setBinLabel(i, "Ignored", 1);
     }
   }
+  // Setting canExtend to false is needed to get the correct behaviour when running multithreaded.
+  // Otherwise, when merging the histgrams of the threads, TH1::Merge sums bins that have the same label in one bin.
+  // This needs to come after the calls to setBinLabel.
+  errorSummaryNum->getTH1F()->GetXaxis()->SetCanExtend(false);
 
   errorSummaryDen = ibooker.book1D("errorSummaryDen", "denominators", 13, 1, 14); // range to match bin numbering
   errorSummaryDen->setBinLabel(RBXRANGE, "# events", 1);
   errorSummaryDen->setBinLabel(RNMUON, "# muon collections", 1);
-  errorSummaryDen->setBinLabel(RMUON, "# muons", 1);
-  errorSummaryDen->setBinLabel(RPT, "# muons", 1);
-  errorSummaryDen->setBinLabel(RETA, "# muons", 1);
-  errorSummaryDen->setBinLabel(RPHI, "# muons", 1);
-  errorSummaryDen->setBinLabel(RETAATVTX, "# muons", 1);
-  errorSummaryDen->setBinLabel(RPHIATVTX, "# muons", 1);
-  errorSummaryDen->setBinLabel(RCHARGE, "# muons", 1);
-  errorSummaryDen->setBinLabel(RCHARGEVAL, "# muons", 1);
-  errorSummaryDen->setBinLabel(RQUAL, "# muons", 1);
-  errorSummaryDen->setBinLabel(RISO, "# muons", 1);
-  errorSummaryDen->setBinLabel(RIDX, "# muons", 1);
+  for (int i = RMUON; i <= RIDX; ++i) {
+    errorSummaryDen->setBinLabel(i, "# muons", 1);
+  }
+  // Needed for correct histogram summing in multithreaded running.
+  errorSummaryDen->getTH1F()->GetXaxis()->SetCanExtend(false);
 
   muColl1BxRange = ibooker.book1D("muBxRangeColl1", (muonColl1Title+" mismatching BX range").c_str(), 5, -2.5, 2.5);
   muColl1BxRange->setAxisTitle("BX range", 1);

--- a/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
@@ -95,22 +95,19 @@ void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker, c
       errorSummaryNum->setBinLabel(i, "Ignored", 1);
     }
   }
+  // Setting canExtend to false is needed to get the correct behaviour when running multithreaded.
+  // Otherwise, when merging the histgrams of the threads, TH1::Merge sums bins that have the same label in one bin.
+  // This needs to come after the calls to setBinLabel.
+  errorSummaryNum->getTH1F()->GetXaxis()->SetCanExtend(false);
 
   errorSummaryDen = ibooker.book1D("errorSummaryDen", "denominators", 14, 1, 15); // range to match bin numbering
   errorSummaryDen->setBinLabel(RBXRANGE, "# events", 1);
   errorSummaryDen->setBinLabel(RNMUON, "# muon collections", 1);
-  errorSummaryDen->setBinLabel(RMUON, "# muons", 1);
-  errorSummaryDen->setBinLabel(RPT, "# muons", 1);
-  errorSummaryDen->setBinLabel(RETA, "# muons", 1);
-  errorSummaryDen->setBinLabel(RLOCALPHI, "# muons", 1);
-  errorSummaryDen->setBinLabel(RSIGN, "# muons", 1);
-  errorSummaryDen->setBinLabel(RSIGNVAL, "# muons", 1);
-  errorSummaryDen->setBinLabel(RQUAL, "# muons", 1);
-  errorSummaryDen->setBinLabel(RHF, "# muons", 1);
-  errorSummaryDen->setBinLabel(RLINK, "# muons", 1);
-  errorSummaryDen->setBinLabel(RPROC, "# muons", 1);
-  errorSummaryDen->setBinLabel(RTF, "# muons", 1);
-  errorSummaryDen->setBinLabel(RTRACKADDR, "# muons", 1);
+  for (int i = RMUON; i <= RTRACKADDR; ++i) {
+    errorSummaryDen->setBinLabel(i, "# muons", 1);
+  }
+  // Needed for correct histogram summing in multithreaded running.
+  errorSummaryDen->getTH1F()->GetXaxis()->SetCanExtend(false);
 
   muColl1BxRange = ibooker.book1D("muBxRangeColl1", (muonColl1Title+" mismatching BX range").c_str(), 11, -5.5, 5.5);
   muColl1BxRange->setAxisTitle("BX range", 1);

--- a/DQM/L1TMonitor/src/L1TStage2uGTCaloLayer2Comp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGTCaloLayer2Comp.cc
@@ -76,6 +76,10 @@ void L1TStage2uGTCaloLayer2Comp::bookHistograms(
   comparisonDenum->setBinLabel(TAUS2, "# taus");
   comparisonDenum->setBinLabel(TAUS3, "# taus");
   comparisonDenum->setBinLabel(SUMS, "# sums");
+  // Setting canExtend to false is needed to get the correct behaviour when running multithreaded.
+  // Otherwise, when merging the histgrams of the threads, TH1::Merge sums bins that have the same label in one bin.
+  // This needs to come after the calls to setBinLabel.
+  comparisonDenum->getTH1F()->GetXaxis()->SetCanExtend(false);
 }
 void L1TStage2uGTCaloLayer2Comp::analyze (
   const edm::Event& e,


### PR DESCRIPTION
When running multithreaded, DQM histograms with several bins having the same bin label are summed in a wrong way (https://hypernews.cern.ch/HyperNews/CMS/get/swDevelopment/3441.html, https://its.cern.ch/jira/browse/CMSLITDPG-350).

This PR fixes this by setting the axis behaviour to be non-extendable. In this setting the summing is done as expected.