### PR TITLE
Add "pixel tracking only" workflow to 2017 matrix, and it and "tracking only" workflow to 2018 matrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -92,3 +92,6 @@ workflows[10024.2] = [ workflows[10024.0][0], _trackingRun2(workflows[10024.0][1
 workflows[10024.3] = [ workflows[10024.1][0], _trackingRun2(workflows[10024.1][1]) ]
 workflows[10024.4] = [ workflows[10024.0][0], _trackingLowPU(workflows[10024.0][1]) ]
 workflows[10024.5] = [ workflows[10024.0][0], _pixelTrackingOnly(workflows[10024.0][1]) ]
+# for 2018 as well, use the same numbering
+workflows[10824.1] = [ workflows[10824.0][0], _trackingOnly(workflows[10024.0][1]) ]
+workflows[10824.5] = [ workflows[10824.0][0], _pixelTrackingOnly(workflows[10024.0][1]) ]

--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -47,6 +47,16 @@ def _trackingOnly(stepList):
             continue
         res.append(s)
     return res
+def _pixelTrackingOnly(stepList):
+    res = []
+    for step in stepList:
+        s = step
+        if 'RecoFull' in step or 'HARVESTFull' in step:
+            s = s.replace('Full', 'Full_pixelTrackingOnly')
+        if 'ALCA' in s:
+            continue
+        res.append(s)
+    return res
 def _trackingRun2(stepList):
     res = []
     for step in stepList:
@@ -81,3 +91,4 @@ workflows[10024.1] = [ workflows[10024.0][0], _trackingOnly(workflows[10024.0][1
 workflows[10024.2] = [ workflows[10024.0][0], _trackingRun2(workflows[10024.0][1]) ]
 workflows[10024.3] = [ workflows[10024.1][0], _trackingRun2(workflows[10024.1][1]) ]
 workflows[10024.4] = [ workflows[10024.0][0], _trackingLowPU(workflows[10024.0][1]) ]
+workflows[10024.5] = [ workflows[10024.0][0], _pixelTrackingOnly(workflows[10024.0][1]) ]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1451,6 +1451,11 @@ step3_trackingOnly = {
     '--datatier':'GEN-SIM-RECO,DQMIO',
     '--eventcontent':'RECOSIM,DQM',
 }
+step3_pixelTrackingOnly = {
+    '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation',
+    '--datatier': 'GEN-SIM-RECO,DQMIO',
+    '--eventcontent': 'RECOSIM,DQM',
+}
 step3_trackingLowPU = {
     '--era': 'Run2_2016_trackingLowPU'
 }
@@ -2278,6 +2283,11 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
         stepName = step + upgradeSteps['trackingOnly']['suffix']
         if 'Reco' in step: upgradeStepDict[stepName][k] = merge([step3_trackingOnly, upgradeStepDict[step][k]])
         elif 'HARVEST' in step: upgradeStepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, upgradeStepDict[step][k]])
+
+    for step in upgradeSteps['pixelTrackingOnly']['steps']:
+        stepName = step + upgradeSteps['pixelTrackingOnly']['suffix']
+        if 'Reco' in step: upgradeStepDict[stepName][k] = merge([step3_pixelTrackingOnly, upgradeStepDict[step][k]])
+        elif 'HARVEST' in step: upgradeStepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation'}, upgradeStepDict[step][k]])
 
     for step in upgradeSteps['Timing']['steps']:
         stepName = step + upgradeSteps['Timing']['suffix']

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -94,6 +94,17 @@ upgradeSteps['trackingOnly'] = {
     'suffix' : '_trackingOnly',
     'offset' : 0.1,
 }
+upgradeSteps['pixelTrackingOnly'] = {
+    'steps' : [
+        'RecoFull',
+        'HARVESTFull',
+        'RecoFullGlobal',
+        'HARVESTFullGlobal',
+    ],
+    'PU' : [],
+    'suffix' : '_pixelTrackingOnly',
+    'offset' : 0.4,
+}
 upgradeSteps['Timing'] = {
     'steps' : upgradeSteps['baseline']['steps'],
     'PU' : upgradeSteps['baseline']['PU'],

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -64,7 +64,9 @@ RawToDigi_noTk = cms.Sequence(L1TRawToDigi
                               +scalersRawToDigi
                               +tcdsDigis
                               )
-    
+
+RawToDigi_pixelOnly = cms.Sequence(siPixelDigis)
+
 scalersRawToDigi.scalersInputTag = 'rawDataCollector'
 siPixelDigis.InputLabel = 'rawDataCollector'
 #false by default anyways ecalDigis.DoRegional = False

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -170,6 +170,12 @@ reconstruction.visit(cms.ModuleNamesFromGlobalsVisitor(globals(),_modulesInRecon
 logErrorHarvester.includeModules = cms.untracked.vstring(set(_modulesInReconstruction))
 
 reconstruction_trackingOnly = cms.Sequence(localreco*globalreco_tracking)
+reconstruction_pixelTrackingOnly = cms.Sequence(
+    pixeltrackerlocalreco*
+    offlineBeamSpot*
+    siPixelClusterShapeCachePreSplitting*
+    recopixelvertexing
+)
 
 #need a fully expanded sequence copy
 modulesToRemove = list() # copy does not work well

--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -1,5 +1,6 @@
 autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLiteTracking','validationHarvesting'],
                    'trackingOnlyValidation' : ['globalPrevalidationTrackingOnly','globalValidationTrackingOnly','postValidation_trackingOnly'],
+                   'pixelTrackingOnlyValidation' : ['globalPrevalidationPixelTrackingOnly','globalValidationPixelTrackingOnly','postValidation_trackingOnly'],
                    'trackingValidation': ['globalPrevalidationTracking','globalValidationTrackingOnly','postValidationTracking'],
                    'muonOnlyValidation' : ['globalPrevalidationMuons','globalValidationMuons','postValidation_muons'],
                    'bTagOnlyValidation' : ['prebTagSequenceMC','bTagPlotsMCbcl','bTagCollectorSequenceMCbcl'],

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -127,13 +127,14 @@ globalPrevalidationTrackingOnly = cms.Sequence(
     + tracksValidationTrackingOnly
     + vertexValidationTrackingOnly
 )
-globalValidationPixelTrackingOnly = cms.Sequence()
+globalValidationTrackingOnly = cms.Sequence()
 # Pixel tracking only validation
 globalPrevalidationPixelTrackingOnly = cms.Sequence(
       simHitTPAssocProducer
     + tracksValidationPixelTrackingOnly
     + vertexValidationPixelTrackingOnly
 )
+globalValidationPixelTrackingOnly = cms.Sequence()
 
 globalValidationJetMETonly = cms.Sequence(
                                    JetValidation 

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -127,8 +127,13 @@ globalPrevalidationTrackingOnly = cms.Sequence(
     + tracksValidationTrackingOnly
     + vertexValidationTrackingOnly
 )
-globalValidationTrackingOnly = cms.Sequence()
-
+globalValidationPixelTrackingOnly = cms.Sequence()
+# Pixel tracking only validation
+globalPrevalidationPixelTrackingOnly = cms.Sequence(
+      simHitTPAssocProducer
+    + tracksValidationPixelTrackingOnly
+    + vertexValidationPixelTrackingOnly
+)
 
 globalValidationJetMETonly = cms.Sequence(
                                    JetValidation 

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -251,9 +251,9 @@ postProcessorTrackSequence = cms.Sequence(
 )
 
 postProcessorTrackTrackingOnly = postProcessorTrack.clone()
-postProcessorTrackTrackingOnly.subDirs.extend(["Tracking/TrackSeeding/*"])
+postProcessorTrackTrackingOnly.subDirs.extend(["Tracking/TrackSeeding/*", "Tracking/PixelTrack/*"])
 postProcessorTrackSummaryTrackingOnly = postProcessorTrackSummary.clone()
-postProcessorTrackSummaryTrackingOnly.subDirs.extend(["Tracking/TrackSeeding"])
+postProcessorTrackSummaryTrackingOnly.subDirs.extend(["Tracking/TrackSeeding", "Tracking/PixelTrack"])
 
 postProcessorTrackSequenceTrackingOnly = cms.Sequence(
     postProcessorTrackTrackingOnly+

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -706,7 +706,40 @@ tracksValidationTrackingOnly = cms.Sequence(
 
 
 ### Pixel tracking only mode (placeholder for now)
-tracksValidationPixelTrackingOnly = cms.Sequence()
+tpClusterProducerPixelTrackingOnly = tpClusterProducer.clone(
+    pixelClusterSrc = "siPixelClustersPreSplitting"
+)
+quickTrackAssociatorByHitsPixelTrackingOnly = quickTrackAssociatorByHits.clone(
+    cluster2TPSrc = "tpClusterProducerPixelTrackingOnly"
+)
+trackingParticlePixelTrackAsssociation = trackingParticleRecoTrackAsssociation.clone(
+    label_tr = "pixelTracks",
+    associator = "quickTrackAssociatorByHitsPixelTrackingOnly",
+)
+PixelVertexAssociatorByPositionAndTracks = VertexAssociatorByPositionAndTracks.clone(
+    trackAssociation = "trackingParticlePixelTrackAsssociation"
+)
+
+trackValidatorPixelTrackingOnly = trackValidator.clone(
+    dirName = "Tracking/PixelTrack/",
+    label = ["pixelTracks"],
+    doResolutionPlotsForLabels = [],
+    trackCollectionForDrCalculation = "pixelTracks",
+    associators = ["trackingParticlePixelTrackAsssociation"],
+    label_vertex = "pixelVertices",
+    vertexAssociator = "PixelVertexAssociatorByPositionAndTracks",
+    dodEdxPlots = False,
+)
+
+tracksValidationTruthPixelTrackingOnly = tracksValidationTruth.copy()
+tracksValidationTruthPixelTrackingOnly.replace(tpClusterProducer, tpClusterProducerPixelTrackingOnly)
+tracksValidationTruthPixelTrackingOnly.replace(quickTrackAssociatorByHits, quickTrackAssociatorByHitsPixelTrackingOnly)
+tracksValidationTruthPixelTrackingOnly.replace(trackingParticleRecoTrackAsssociation, trackingParticlePixelTrackAsssociation)
+tracksValidationTruthPixelTrackingOnly.replace(VertexAssociatorByPositionAndTracks, PixelVertexAssociatorByPositionAndTracks)
+tracksValidationPixelTrackingOnly = cms.Sequence(
+    tracksValidationTruthPixelTrackingOnly +
+    trackValidatorPixelTrackingOnly
+)
 
 
 ### Lite mode (only generalTracks and HP)

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -705,6 +705,9 @@ tracksValidationTrackingOnly = cms.Sequence(
 )
 
 
+### Pixel tracking only mode (placeholder for now)
+tracksValidationPixelTrackingOnly = cms.Sequence()
+
 
 ### Lite mode (only generalTracks and HP)
 trackValidatorLite = trackValidator.clone(

--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -166,6 +166,7 @@ _pageNameMap = {
     "miniaod": "MiniAOD",
     "timing": "Timing",
     "hlt": "HLT",
+    "pixel": "Pixel tracks",
 }
 
 _sectionNameMapOrder = collections.OrderedDict([
@@ -190,6 +191,8 @@ _sectionNameMapOrder = collections.OrderedDict([
     ("gsf", _gsfName),
     ("bhadron", _bhadronName),
     ("bhadron_highPurity", _allToHP(_bhadronName)),
+    # Pixel tracks
+    ("pixel", "Pixel tracks"),
     # These are for vertices
     ("genvertex", "Gen vertices"),
     ("pixelVertices", "Pixel vertices"),
@@ -294,6 +297,7 @@ class PlotPurpose:
     class MiniAOD: pass
     class Timing: pass
     class HLT: pass
+    class Pixel: pass
 
 class Page(object):
     def __init__(self, title, sampleName):
@@ -672,6 +676,7 @@ class IndexSection:
         self._miniaodPage = PageSet(*params)
         self._timingPage = PageSet(*params)
         self._hltPages = PageSet(*params, dqmSubFolderTranslatedToSectionName=lambda algoQuality: algoQuality[0])
+        self._pixelPages = PageSet(*params, dqmSubFolderTranslatedToSectionName=lambda algoQuality: algoQuality[0])
         self._otherPages = PageSet(*params)
 
         self._purposePageMap = {
@@ -681,6 +686,7 @@ class IndexSection:
             PlotPurpose.MiniAOD: self._miniaodPage,
             PlotPurpose.Timing: self._timingPage,
             PlotPurpose.HLT: self._hltPages,
+            PlotPurpose.Pixel: self._pixelPages,
         }
 
     def addPlots(self, plotterFolder, dqmSubFolder, plotFiles):
@@ -702,7 +708,7 @@ class IndexSection:
             "  <ul>",
             ]
 
-        for pages in [self._summaryPage, self._iterationPages, self._vertexPage, self._miniaodPage, self._timingPage, self._hltPages, self._otherPages]:
+        for pages in [self._summaryPage, self._iterationPages, self._pixelPages, self._vertexPage, self._miniaodPage, self._timingPage, self._hltPages, self._otherPages]:
             labelFiles = pages.write(baseDir)
             for label, fname in labelFiles:
                 ret.append('   <li><a href="%s">%s</a></li>' % (fname, label))

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -934,6 +934,7 @@ class TrackingSummaryTable:
     class HighPurityPt09: pass
     class BTVLike: pass
     class AK4PFJets: pass
+    class Pixel: pass
 
     def __init__(self, section, collection=GeneralTracks):
         self._collection = collection
@@ -974,6 +975,8 @@ class TrackingSummaryTable:
                 return _getAlgoQuality(data, "btvLike", "")
             elif self._collection == TrackingSummaryTable.AK4PFJets:
                 return _getAlgoQuality(data, "ak4PFJets", "")
+            elif self._collection == TrackingSummaryTable.Pixel:
+                return _getAlgoQuality(data, "pixel", "")
             else:
                 raise Exception("Collection not recognized, %s" % str(self._collection))
         def _formatOrNone(num, func):
@@ -1330,6 +1333,13 @@ _appendTrackingPlots("TrackBuilding", "building", _seedingBuildingPlots)
 _appendTrackingPlots("TrackConversion", "conversion", _simBasedPlots+_recoBasedPlots, onlyForConversion=True, rawSummary=True, highPuritySummary=False)
 _appendTrackingPlots("TrackGsf", "gsf", _simBasedPlots+_recoBasedPlots, onlyForElectron=True, rawSummary=True, highPuritySummary=False)
 _appendTrackingPlots("TrackBHadron", "bhadron", _simBasedPlots+_recoBasedPlots, onlyForBHadron=True)
+# Pixel tracks
+_common = dict(purpose=PlotPurpose.Pixel, page="pixel")
+plotter.append("pixelTrack", _trackingFolders("PixelTrack"), TrackingPlotFolder(*(_simBasedPlots+_recoBasedPlots), **_common))
+plotterExt.append("pixelTrack", _trackingFolders("PixelTrack"), TrackingPlotFolder(*_extendedPlots, **_common))
+plotter.append("pixelTrack_summary",  _trackingFolders("PixelTrack"), PlotFolder(_summaryRaw, _summaryRawN, loopSubFolders=False, purpose=PlotPurpose.TrackingSummary, page="summary", section="pixel"))
+plotter.appendTable("pixelTrack_summary", _trackingFolders("PixelTrack"), TrackingSummaryTable(section="pixel", collection=TrackingSummaryTable.Pixel))
+
 
 # MiniAOD
 plotter.append("packedCandidate", _trackingFolders("PackedCandidate"),

--- a/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_cfi.py
+++ b/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_cfi.py
@@ -46,10 +46,14 @@ trackingPhase2PU140.toModify(vertexAnalysisTrackingOnly,
 pixelVertexAnalysisTrackingOnly = vertexAnalysis.clone(
     do_generic_sim_plots = False,
     trackAssociatorMap = "trackingParticlePixelTrackAsssociation",
+    vertexAssociator = "PixelVertexAssociatorByPositionAndTracks",
     vertexRecoCollections = [
         "pixelVertices",
         "selectedPixelVertices"
     ]
+)
+pixelVertexAnalysisPixelTrackingOnly = pixelVertexAnalysisTrackingOnly.clone(
+    do_generic_sim_plots = True,
 )
 
 ##########
@@ -75,14 +79,27 @@ from SimTracker.TrackAssociation.trackingParticleRecoTrackAsssociation_cfi impor
 trackingParticlePixelTrackAsssociation = _trackingParticleRecoTrackAsssociation.clone(
     label_tr = "pixelTracks"
 )
+from SimTracker.VertexAssociation.VertexAssociatorByPositionAndTracks_cfi import VertexAssociatorByPositionAndTracks as _VertexAssociatorByPositionAndTracks
+PixelVertexAssociatorByPositionAndTracks = _VertexAssociatorByPositionAndTracks.clone(
+    trackAssociation = "trackingParticlePixelTrackAsssociation"
+)
 
 _vertexAnalysisSequenceTrackingOnly_trackingLowPU = vertexAnalysisSequenceTrackingOnly.copy()
 _vertexAnalysisSequenceTrackingOnly_trackingLowPU += (
     trackingParticlePixelTrackAsssociation
+    + PixelVertexAssociatorByPositionAndTracks
     + selectedPixelVertices
     + pixelVertexAnalysisTrackingOnly
 )
 trackingLowPU.toReplaceWith(vertexAnalysisSequenceTrackingOnly, _vertexAnalysisSequenceTrackingOnly_trackingLowPU)
+
+vertexAnalysisSequencePixelTrackingOnly = cms.Sequence(
+    trackingParticlePixelTrackAsssociation
+    + PixelVertexAssociatorByPositionAndTracks
+    + selectedPixelVertices
+    + pixelVertexAnalysisPixelTrackingOnly
+)
+
 
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
 _vertexRecoCollectionsTiming = cms.VInputTag("offlinePrimaryVertices",

--- a/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_cfi.py
+++ b/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_cfi.py
@@ -75,28 +75,15 @@ vertexAnalysisSequenceTrackingOnly = cms.Sequence(
     + vertexAnalysisTrackingOnly
 )
 
-from SimTracker.TrackAssociation.trackingParticleRecoTrackAsssociation_cfi import trackingParticleRecoTrackAsssociation as _trackingParticleRecoTrackAsssociation
-trackingParticlePixelTrackAsssociation = _trackingParticleRecoTrackAsssociation.clone(
-    label_tr = "pixelTracks"
-)
-from SimTracker.VertexAssociation.VertexAssociatorByPositionAndTracks_cfi import VertexAssociatorByPositionAndTracks as _VertexAssociatorByPositionAndTracks
-PixelVertexAssociatorByPositionAndTracks = _VertexAssociatorByPositionAndTracks.clone(
-    trackAssociation = "trackingParticlePixelTrackAsssociation"
-)
-
 _vertexAnalysisSequenceTrackingOnly_trackingLowPU = vertexAnalysisSequenceTrackingOnly.copy()
 _vertexAnalysisSequenceTrackingOnly_trackingLowPU += (
-    trackingParticlePixelTrackAsssociation
-    + PixelVertexAssociatorByPositionAndTracks
-    + selectedPixelVertices
+    selectedPixelVertices
     + pixelVertexAnalysisTrackingOnly
 )
 trackingLowPU.toReplaceWith(vertexAnalysisSequenceTrackingOnly, _vertexAnalysisSequenceTrackingOnly_trackingLowPU)
 
 vertexAnalysisSequencePixelTrackingOnly = cms.Sequence(
-    trackingParticlePixelTrackAsssociation
-    + PixelVertexAssociatorByPositionAndTracks
-    + selectedPixelVertices
+    selectedPixelVertices
     + pixelVertexAnalysisPixelTrackingOnly
 )
 

--- a/Validation/RecoVertex/python/VertexValidation_cff.py
+++ b/Validation/RecoVertex/python/VertexValidation_cff.py
@@ -19,3 +19,8 @@ vertexValidationTrackingOnly = cms.Sequence(
     + v0Validator
     + vertexAnalysisSequenceTrackingOnly
 )
+
+vertexValidationPixelTrackingOnly = cms.Sequence(
+    tracksValidationTruth
+    + vertexAnalysisSequencePixelTrackingOnly
+)

--- a/Validation/RecoVertex/python/VertexValidation_cff.py
+++ b/Validation/RecoVertex/python/VertexValidation_cff.py
@@ -8,7 +8,7 @@ vertexValidation = cms.Sequence(v0Validator
                                 * vertexAnalysisSequence)
 
 
-from Validation.RecoTrack.TrackValidation_cff import tracksValidationTruth
+from Validation.RecoTrack.TrackValidation_cff import tracksValidationTruth, tracksValidationTruthPixelTrackingOnly
 vertexValidationStandalone = cms.Sequence(
     tracksValidationTruth
     * vertexValidation
@@ -21,6 +21,6 @@ vertexValidationTrackingOnly = cms.Sequence(
 )
 
 vertexValidationPixelTrackingOnly = cms.Sequence(
-    tracksValidationTruth
+    tracksValidationTruthPixelTrackingOnly
     + vertexAnalysisSequencePixelTrackingOnly
 )


### PR DESCRIPTION
This PR adds a "pixel tracking only" workflow aiming to have a minimal step3 configuration for producing pixel tracks and vertices (+ their validation). Such a workflow is useful e.g. for future tracking R&D.

Tested in CMSSW_10_0_X_2017-12-13-2300, no changes expected in existing workflows.

@VinInn @felicepantaleo @fwyzard 