### PR TITLE
Fix unused var in L1Trigger/CSCTriggerPrimitives

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -539,7 +539,6 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
     }
   }// reduction per bx
 
-  bool first = true;
   unsigned int n1b=0, n1a=0;
   LogTrace("CSCGEMCMotherboardME11") << "========================================================================" << std::endl
                                      << "Counting the final LCTs" << std::endl


### PR DESCRIPTION
Fix unused var warning listed here https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc630/CMSSW_10_0_X_2017-12-13-2300/L1Trigger/CSCTriggerPrimitives