### PR TITLE
LWTNN Deep Neural Networks for track classification

### DIFF
--- a/RecoTracker/FinalTrackSelectors/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/BuildFile.xml
@@ -9,6 +9,7 @@
 <use   name="CondFormats/EgammaObjects"/>
 <use   name="TrackingTools/Records"/>
 <use   name="roottmva"/>
+<use   name="lwtnn"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
+++ b/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
@@ -34,13 +34,10 @@ protected:
 
   virtual void initEvent(const edm::EventSetup& es) = 0;
 
-  // Ideally this function should be const, but that would mean the
-  // LWTNN classifier would need to allocate map<string, double> for
-  // each track... Try to see if things could be refactored somehow.
   virtual void computeMVA(reco::TrackCollection const & tracks,
 			  reco::BeamSpot const & beamSpot,
 			  reco::VertexCollection const & vertices,
-			  MVACollection & mvas) = 0;
+			  MVACollection & mvas) const = 0;
 
 private:
   void produce(edm::Event& evt, const edm::EventSetup& es ) final;
@@ -88,7 +85,7 @@ private:
     void computeMVA(reco::TrackCollection const & tracks,
 		    reco::BeamSpot const & beamSpot,
 		    reco::VertexCollection const & vertices,
-		    MVACollection & mvas) final {
+		    MVACollection & mvas) const final {
 
       size_t current = 0;
       for (auto const & trk : tracks) {

--- a/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
+++ b/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
@@ -34,10 +34,13 @@ protected:
 
   virtual void initEvent(const edm::EventSetup& es) = 0;
 
+  // Ideally this function should be const, but that would mean the
+  // LWTNN classifier would need to allocate map<string, double> for
+  // each track... Try to see if things could be refactored somehow.
   virtual void computeMVA(reco::TrackCollection const & tracks,
 			  reco::BeamSpot const & beamSpot,
 			  reco::VertexCollection const & vertices,
-			  MVACollection & mvas) const = 0;
+			  MVACollection & mvas) = 0;
 
 private:
   void produce(edm::Event& evt, const edm::EventSetup& es ) final;
@@ -85,7 +88,7 @@ private:
     void computeMVA(reco::TrackCollection const & tracks,
 		    reco::BeamSpot const & beamSpot,
 		    reco::VertexCollection const & vertices,
-		    MVACollection & mvas) const final {
+		    MVACollection & mvas) final {
 
       size_t current = 0;
       for (auto const & trk : tracks) {

--- a/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
+++ b/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
@@ -74,7 +74,7 @@ namespace trackMVAClassifierImpl {
 
       size_t current = 0;
       for (auto const & trk : tracks) {
-	mvas[current++] = mva(trk,beamSpot,vertices,cache);
+        mvas[current++] = mva(trk,beamSpot,vertices,cache);
       }
     }
   };
@@ -91,7 +91,7 @@ namespace trackMVAClassifierImpl {
       size_t current = 0;
       for (auto const & trk : tracks) {
         //BDT outputs are considered always reliable. Hence "true"
-	std::pair<float,bool> output (mva(trk,beamSpot,vertices), true);
+        std::pair<float,bool> output (mva(trk,beamSpot,vertices), true);
         mvas[current++]= output; 
       }
     }

--- a/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
@@ -35,6 +35,7 @@
 <use   name="RecoTracker/Record"/>
 <use   name="clhep"/>
 <use   name="roottmva"/>
+<use   name="lwtnn"/>
 <library   file="*.cc" name="RecoTrackerFinalTrackSelectorsPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/RecoTracker/FinalTrackSelectors/plugins/LwtnnESProducer.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/LwtnnESProducer.cc
@@ -2,7 +2,7 @@
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
-#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 
 //from lwtnn
 #include "lwtnn/LightweightNeuralNetwork.hh"
@@ -16,12 +16,12 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  // TODO: Use of CkfComponentsRecord is as inadequate as the
+  // TODO: Use of TrackingComponentsRecord is as inadequate as the
   // placement of this ESProducer in RecoTracker/FinalTrackSelectors
   // (but it works, I tried to create a new record but for some reason
   // did not get it to work). Especially if this producer gets used
   // wider we should figure out a better record and package.
-  std::unique_ptr<lwt::LightweightNeuralNetwork> produce(const CkfComponentsRecord& iRecord);
+  std::unique_ptr<lwt::LightweightNeuralNetwork> produce(const TrackingComponentsRecord& iRecord);
 
 private:
   edm::FileInPath fileName_;
@@ -41,7 +41,7 @@ void LwtnnESProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   descriptions.add("lwtnnESProducer", desc);
 }
 
-std::unique_ptr<lwt::LightweightNeuralNetwork> LwtnnESProducer::produce(const CkfComponentsRecord& iRecord) {
+std::unique_ptr<lwt::LightweightNeuralNetwork> LwtnnESProducer::produce(const TrackingComponentsRecord& iRecord) {
   std::ifstream jsonfile(fileName_.fullPath().c_str());
   auto config = lwt::parse_json(jsonfile);
   return std::make_unique<lwt::LightweightNeuralNetwork>(config.inputs, config.layers, config.outputs);

--- a/RecoTracker/FinalTrackSelectors/plugins/LwtnnESProducer.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/LwtnnESProducer.cc
@@ -1,0 +1,52 @@
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+
+//from lwtnn
+#include "lwtnn/LightweightNeuralNetwork.hh"
+#include "lwtnn/parse_json.hh"
+#include <fstream>
+
+class LwtnnESProducer: public edm::ESProducer {
+public:
+  LwtnnESProducer(const edm::ParameterSet& iConfig);
+  ~LwtnnESProducer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  // TODO: Use of CkfComponentsRecord is as inadequate as the
+  // placement of this ESProducer in RecoTracker/FinalTrackSelectors
+  // (but it works, I tried to create a new record but for some reason
+  // did not get it to work). Especially if this producer gets used
+  // wider we should figure out a better record and package.
+  std::unique_ptr<lwt::LightweightNeuralNetwork> produce(const CkfComponentsRecord& iRecord);
+
+private:
+  edm::FileInPath fileName_;
+};
+
+LwtnnESProducer::LwtnnESProducer(const edm::ParameterSet& iConfig):
+  fileName_(iConfig.getParameter<edm::FileInPath>("fileName"))
+{
+  auto componentName = iConfig.getParameter<std::string>("ComponentName");
+  setWhatProduced(this, componentName);
+}
+
+void LwtnnESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("ComponentName", "lwtnnESProducer");
+  desc.add<edm::FileInPath>("fileName", edm::FileInPath());
+  descriptions.add("lwtnnESProducer", desc);
+}
+
+std::unique_ptr<lwt::LightweightNeuralNetwork> LwtnnESProducer::produce(const CkfComponentsRecord& iRecord) {
+  std::ifstream jsonfile(fileName_.fullPath().c_str());
+  auto config = lwt::parse_json(jsonfile);
+  return std::make_unique<lwt::LightweightNeuralNetwork>(config.inputs, config.layers, config.outputs);
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_EVENTSETUP_MODULE(LwtnnESProducer);

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCutClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCutClassifier.cc
@@ -180,7 +180,7 @@ namespace {
     
     float operator()(reco::Track const & trk,
 		     reco::BeamSpot const & beamSpot,
-		     reco::VertexCollection const & vertices) const {
+		     reco::VertexCollection const & vertices) {
       
       float ret = 1.f;
       // minimum number of hits for by-passing the other checks

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCutClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCutClassifier.cc
@@ -180,7 +180,7 @@ namespace {
     
     float operator()(reco::Track const & trk,
 		     reco::BeamSpot const & beamSpot,
-		     reco::VertexCollection const & vertices) {
+		     reco::VertexCollection const & vertices) const {
       
       float ret = 1.f;
       // minimum number of hits for by-passing the other checks

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackLwtnnClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackLwtnnClassifier.cc
@@ -1,0 +1,84 @@
+#include "RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+
+#include "getBestVertex.h"
+
+//from lwtnn
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+#include "lwtnn/LightweightNeuralNetwork.hh"
+
+namespace {
+  struct lwtnn {
+    lwtnn(const edm::ParameterSet& cfg):
+      lwtnnLabel_(cfg.getParameter<std::string>("lwtnnLabel"))
+    {}
+
+    static const char *name() { return "TrackLwtnnClassifier"; }
+
+    static void fillDescriptions(edm::ParameterSetDescription& desc) {
+      desc.add<std::string>("lwtnnLabel", "trackSelectionLwtnn");
+    }
+
+    void beginStream() {}
+    void initEvent(const edm::EventSetup& es) {
+      edm::ESHandle<lwt::LightweightNeuralNetwork> lwtnnHandle;
+      es.get<CkfComponentsRecord>().get(lwtnnLabel_, lwtnnHandle);
+      neuralNetwork_ = lwtnnHandle.product();
+    }
+
+    float operator()(reco::Track const & trk,
+                     reco::BeamSpot const & beamSpot,
+                     reco::VertexCollection const & vertices) {
+
+      Point bestVertex = getBestVertex(trk,vertices);
+
+      inputs_["trk_pt"] = trk.pt();
+      inputs_["trk_eta"] = trk.eta();
+      inputs_["trk_lambda"] = trk.lambda();
+      inputs_["trk_dxy"] = trk.dxy(beamSpot.position()); // is the training with abs() or not?
+      inputs_["trk_dz"] = trk.dz(beamSpot.position()); // is the training with abs() or not?
+      inputs_["trk_dxyClosestPV"] = trk.dxy(bestVertex); // is the training with abs() or not?
+      inputs_["trk_dzClosestPV"] = trk.dz(bestVertex); // is the training with abs() or not?
+      inputs_["trk_ptErr"] = trk.ptError();
+      inputs_["trk_etaErr"] = trk.etaError();
+      inputs_["trk_lambdaErr"] = trk.lambdaError();
+      inputs_["trk_dxyErr"] = trk.dxyError();
+      inputs_["trk_dzErr"] = trk.dzError();
+      inputs_["trk_nChi2"] = trk.normalizedChi2();
+      inputs_["trk_ndof"] = trk.ndof();
+      inputs_["trk_nInvalid"] = trk.hitPattern().numberOfLostHits(reco::HitPattern::TRACK_HITS);
+      inputs_["trk_nPixel"] = trk.hitPattern().numberOfValidPixelHits();
+      inputs_["trk_nStrip"] = trk.hitPattern().numberOfValidStripHits();
+      inputs_["trk_nPixelLay"] = trk.hitPattern().pixelLayersWithMeasurement();
+      inputs_["trk_nStripLay"] = trk.hitPattern().stripLayersWithMeasurement();
+      inputs_["trk_n3DLay"] = (trk.hitPattern().numberOfValidStripLayersWithMonoAndStereo()+trk.hitPattern().pixelLayersWithMeasurement());
+      inputs_["trk_nLostLay"] = trk.hitPattern().trackerLayersWithoutMeasurement(reco::HitPattern::TRACK_HITS);
+      inputs_["trk_algo"] = trk.algo(); // eventually move to originalAlgo
+
+      auto out = neuralNetwork_->compute(inputs_);
+      // there should only one output
+      if(out.size() != 1) throw cms::Exception("LogicError") << "Expecting exactly one output from NN, got " << out.size();
+
+
+      float output = 2.0*out.begin()->second-1.0;
+      return output;
+    }
+
+
+    std::string lwtnnLabel_;
+    const lwt::LightweightNeuralNetwork *neuralNetwork_;
+    lwt::ValueMap inputs_; //typedef of map<string, double>
+  };
+
+  using TrackLwtnnClassifier = TrackMVAClassifier<lwtnn>;
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE(TrackLwtnnClassifier);

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackLwtnnClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackLwtnnClassifier.cc
@@ -9,7 +9,7 @@
 #include "getBestVertex.h"
 
 //from lwtnn
-#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "lwtnn/LightweightNeuralNetwork.hh"
 
 namespace {
@@ -27,7 +27,7 @@ namespace {
     void beginStream() {}
     void initEvent(const edm::EventSetup& es) {
       edm::ESHandle<lwt::LightweightNeuralNetwork> lwtnnHandle;
-      es.get<CkfComponentsRecord>().get(lwtnnLabel_, lwtnnHandle);
+      es.get<TrackingComponentsRecord>().get(lwtnnLabel_, lwtnnHandle);
       neuralNetwork_ = lwtnnHandle.product();
     }
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackLwtnnClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackLwtnnClassifier.cc
@@ -33,7 +33,7 @@ namespace {
 
     float operator()(reco::Track const & trk,
                      reco::BeamSpot const & beamSpot,
-                     reco::VertexCollection const & vertices) {
+                     reco::VertexCollection const & vertices) const {
 
       Point bestVertex = getBestVertex(trk,vertices);
 
@@ -72,7 +72,12 @@ namespace {
 
     std::string lwtnnLabel_;
     const lwt::LightweightNeuralNetwork *neuralNetwork_;
-    lwt::ValueMap inputs_; //typedef of map<string, double>
+    // inputs_ is mutable in order to avoid constructing
+    // map<string,double> for each track while keeping the operator()
+    // interface const. Thread safety is in practice achieved by
+    // TrackMVAClassifierBase (and inheriting classes) being a stream
+    // module.
+    mutable lwt::ValueMap inputs_; //typedef of map<string, double>
   };
 
   using TrackLwtnnClassifier = TrackMVAClassifier<lwtnn>;

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackLwtnnClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackLwtnnClassifier.cc
@@ -77,7 +77,7 @@ namespace {
 
       bool isReliable = true;
       //T1qqqq
-      if((std::abs(inputs["trk_dxy"])>=0.1) && (inputs["trk_etaErr"]<0.003) && (inputs["trk_dxyErr"]<0.03) &&(inputs["trk_ndof"]>3)){
+      if(std::abs(inputs["trk_dxy"])>=0.1 && inputs["trk_etaErr"]<0.003 && inputs["trk_dxyErr"]<0.03 && inputs["trk_ndof"]>3){
         isReliable = false;
       }
       //T5qqqqLL

--- a/RecoTracker/FinalTrackSelectors/python/trackSelectionLwtnn_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackSelectionLwtnn_cfi.py
@@ -1,0 +1,5 @@
+from RecoTracker.FinalTrackSelectors.lwtnnESProducer_cfi import lwtnnESProducer as _lwtnnESProducer
+trackSelectionLwtnn = _lwtnnESProducer.clone(
+    ComponentName = "trackSelectionLwtnn",
+    fileName = "RecoTracker/FinalTrackSelectors/data/LWTNN_network_v1.json",
+)

--- a/RecoTracker/FinalTrackSelectors/python/trackSelectionLwtnn_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackSelectionLwtnn_cfi.py
@@ -1,5 +1,5 @@
 from RecoTracker.FinalTrackSelectors.lwtnnESProducer_cfi import lwtnnESProducer as _lwtnnESProducer
 trackSelectionLwtnn = _lwtnnESProducer.clone(
     ComponentName = "trackSelectionLwtnn",
-    fileName = "RecoTracker/FinalTrackSelectors/data/LWTNN_network_10_4_X_v2.json",
+    fileName = "RecoTracker/FinalTrackSelectors/data/LWTNN_network_10_5_X_v1.json",
 )

--- a/RecoTracker/FinalTrackSelectors/python/trackSelectionLwtnn_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackSelectionLwtnn_cfi.py
@@ -1,5 +1,5 @@
 from RecoTracker.FinalTrackSelectors.lwtnnESProducer_cfi import lwtnnESProducer as _lwtnnESProducer
 trackSelectionLwtnn = _lwtnnESProducer.clone(
     ComponentName = "trackSelectionLwtnn",
-    fileName = "RecoTracker/FinalTrackSelectors/data/LWTNN_network_v1.json",
+    fileName = "RecoTracker/FinalTrackSelectors/data/LWTNN_network_10_4_X.json",
 )

--- a/RecoTracker/FinalTrackSelectors/python/trackSelectionLwtnn_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackSelectionLwtnn_cfi.py
@@ -1,5 +1,5 @@
 from RecoTracker.FinalTrackSelectors.lwtnnESProducer_cfi import lwtnnESProducer as _lwtnnESProducer
 trackSelectionLwtnn = _lwtnnESProducer.clone(
     ComponentName = "trackSelectionLwtnn",
-    fileName = "RecoTracker/FinalTrackSelectors/data/LWTNN_network_10_4_X.json",
+    fileName = "RecoTracker/FinalTrackSelectors/data/LWTNN_network_10_4_X_v2.json",
 )

--- a/RecoTracker/FinalTrackSelectors/src/ES_Lwtnn.cc
+++ b/RecoTracker/FinalTrackSelectors/src/ES_Lwtnn.cc
@@ -1,0 +1,3 @@
+#include "lwtnn/LightweightNeuralNetwork.hh"
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(lwt::LightweightNeuralNetwork);

--- a/RecoTracker/FinalTrackSelectors/src/TrackMVAClassifierBase.cc
+++ b/RecoTracker/FinalTrackSelectors/src/TrackMVAClassifierBase.cc
@@ -54,27 +54,34 @@ void TrackMVAClassifierBase::produce(edm::Event& evt, const edm::EventSetup& es 
   initEvent(es);
 
   // products
+  auto mvaPairs = std::make_unique<MVAPairCollection>(tracks.size(),std::make_pair(-99.f,true));
   auto mvas  = std::make_unique<MVACollection>(tracks.size(),-99.f);
   auto quals = std::make_unique<QualityMaskCollection>(tracks.size(),0);
 
   if ( hVtx.isValid() && !ignoreVertices_ ) {
-    computeMVA(tracks,*hBsp,*hVtx,*mvas);
+    computeMVA(tracks,*hBsp,*hVtx,*mvaPairs);
   } else {
     if ( !ignoreVertices_ ) 
       edm::LogWarning("TrackMVAClassifierBase") << "ignoreVertices is set to False in the configuration, but the vertex collection is not valid"; 
     std::vector<reco::Vertex> vertices;
-    computeMVA(tracks,*hBsp,vertices,*mvas);
+    computeMVA(tracks,*hBsp,vertices,*mvaPairs);
   }    
-  assert((*mvas).size()==tracks.size());
+  assert((*mvaPairs).size()==tracks.size());
 
   unsigned int k=0;
-  for (auto mva : *mvas) {
+  for (auto output : *mvaPairs) {
+    if(output.second){
+      (*mvas)[k] = output.first;
+    }else{
+      // If the MVA value is known to be unreliable, force into generalTracks collection
+      (*mvas)[k] = std::max(output.first, float(qualityCuts[0]+0.001));
+    }
+    float mva = (*mvas)[k];
     (*quals)[k++]
       =  (mva>qualityCuts[0]) << reco::TrackBase::loose
       |  (mva>qualityCuts[1]) << reco::TrackBase::tight
       |  (mva>qualityCuts[2]) << reco::TrackBase::highPurity
-     ;
-
+    ;
   }
   
 

--- a/RecoTracker/FinalTrackSelectors/src/TrackMVAClassifierBase.cc
+++ b/RecoTracker/FinalTrackSelectors/src/TrackMVAClassifierBase.cc
@@ -69,7 +69,7 @@ void TrackMVAClassifierBase::produce(edm::Event& evt, const edm::EventSetup& es 
   assert((*mvaPairs).size()==tracks.size());
 
   unsigned int k=0;
-  for (auto output : *mvaPairs) {
+  for (auto const& output : *mvaPairs) {
     if(output.second){
       (*mvas)[k] = output.first;
     }else{

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -203,11 +203,11 @@ detachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduc
 fastSim.toModify(detachedQuadStepTracks,TTRHBuilder = 'WithoutRefit')
 
 # TRACK SELECTION AND QUALITY FLAG SETTING.
-from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
-detachedQuadStep = TrackMVAClassifierDetached.clone(
+from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
+detachedQuadStep = TrackLwtnnClassifier.clone(
     src = 'detachedQuadStepTracks',
-    mva = dict(GBRForestLabel = 'MVASelectorDetachedQuadStep_Phase1'),
-    qualityCuts = [-0.5,0.0,0.5],
+    qualityCuts = [-0.6,0.1,0.85],
 )
 fastSim.toModify(detachedQuadStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
 highBetaStar_2018.toModify(detachedQuadStep,qualityCuts = [-0.7,0.0,0.5])

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -207,7 +207,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 detachedQuadStep = TrackLwtnnClassifier.clone(
     src = 'detachedQuadStepTracks',
-    qualityCuts = [-0.6,0.1,0.85],
+    qualityCuts = [-0.6, 0.05, 0.7],
 )
 fastSim.toModify(detachedQuadStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
 highBetaStar_2018.toModify(detachedQuadStep,qualityCuts = [-0.7,0.0,0.5])

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -210,11 +210,19 @@ detachedQuadStep = TrackLwtnnClassifier.clone(
     qualityCuts = [-0.6, 0.05, 0.7],
 )
 fastSim.toModify(detachedQuadStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
-highBetaStar_2018.toModify(detachedQuadStep,qualityCuts = [-0.7,0.0,0.5])
-pp_on_AA_2018.toModify(detachedQuadStep, 
-        mva = dict(GBRForestLabel = 'HIMVASelectorDetachedQuadStep_Phase1'),
-        qualityCuts = [-0.2, 0.2, 0.5],
-)
+
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
+highBetaStar_2018.toReplaceWith(detachedQuadStep, TrackMVAClassifierDetached.clone(
+    src = 'detachedQuadStepTracks',
+    qualityCuts = [-0.7,0.0,0.5],
+    mva = dict(GBRForestLabel = 'MVASelectorDetachedQuadStep_Phase1')
+))
+
+pp_on_AA_2018.toReplaceWith(detachedQuadStep, TrackMVAClassifierDetached.clone(
+    src = 'detachedQuadStepTracks',
+    qualityCuts = [-0.2, 0.2, 0.5],
+    mva = dict(GBRForestLabel = 'HIMVASelectorDetachedQuadStep_Phase1')
+))
 
 # For Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -253,9 +253,12 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 detachedTripletStep = ClassifierMerger.clone()
 detachedTripletStep.inputClassifiers=['detachedTripletStepClassifier1','detachedTripletStepClassifier2']
 
-trackingPhase1.toReplaceWith(detachedTripletStep, detachedTripletStepClassifier1.clone(
-     mva = dict(GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1'),
-     qualityCuts = [-0.2,0.3,0.8],
+#LWTNN selector
+from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
+trackingPhase1.toReplaceWith(detachedTripletStep, TrackLwtnnClassifier.clone(
+     src = 'detachedTripletStepTracks',
+     qualityCuts = [-0.4,0.45,0.9],
 ))
 highBetaStar_2018.toModify(detachedTripletStep,qualityCuts = [-0.5,0.0,0.5])
 pp_on_AA_2018.toModify(detachedTripletStep, 

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -258,7 +258,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackingPhase1.toReplaceWith(detachedTripletStep, TrackLwtnnClassifier.clone(
      src = 'detachedTripletStepTracks',
-     qualityCuts = [-0.4,0.45,0.9],
+     qualityCuts = [0.0, 0.4, 0.8],
 ))
 highBetaStar_2018.toModify(detachedTripletStep,qualityCuts = [-0.5,0.0,0.5])
 pp_on_AA_2018.toModify(detachedTripletStep, 

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -112,8 +112,7 @@ _fastSim_detachedTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProduc
     hitMasks = cms.InputTag("detachedTripletStepMasks"),
     seedFinderSelector = dict( pixelTripletGeneratorFactory = _hitSetProducerToFactoryPSet(detachedTripletStepHitTriplets),
                                layerList = detachedTripletStepSeedLayers.layerList.value())
-)
-#new for phase1
+)#new for phase1
 trackingPhase1.toModify(_fastSim_detachedTripletStepSeeds, seedFinderSelector = dict(
         pixelTripletGeneratorFactory = None,
         CAHitTripletGeneratorFactory = _hitSetProducerToFactoryPSet(detachedTripletStepHitTriplets),
@@ -253,6 +252,7 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 detachedTripletStep = ClassifierMerger.clone()
 detachedTripletStep.inputClassifiers=['detachedTripletStepClassifier1','detachedTripletStepClassifier2']
 
+
 #LWTNN selector
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
@@ -260,11 +260,17 @@ trackingPhase1.toReplaceWith(detachedTripletStep, TrackLwtnnClassifier.clone(
      src = 'detachedTripletStepTracks',
      qualityCuts = [0.0, 0.4, 0.8],
 ))
-highBetaStar_2018.toModify(detachedTripletStep,qualityCuts = [-0.5,0.0,0.5])
-pp_on_AA_2018.toModify(detachedTripletStep, 
-        mva = dict(GBRForestLabel = 'HIMVASelectorDetachedTripletStep_Phase1'),
-        qualityCuts = [-0.2, 0.4, 0.85],
-)
+
+highBetaStar_2018.toReplaceWith(detachedTripletStep, detachedTripletStepClassifier1.clone(
+     qualityCuts = [-0.5,0.0,0.5],
+     mva = dict(GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1')
+))
+
+pp_on_AA_2018.toReplaceWith(detachedTripletStep, detachedTripletStepClassifier1.clone(
+     qualityCuts = [-0.2, 0.4, 0.85],
+     mva = dict(GBRForestLabel = 'HIMVASelectorDetachedTripletStep_Phase1')
+))
+
 
 # For LowPU
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -248,7 +248,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 highPtTripletStep = TrackLwtnnClassifier.clone(
     src = 'highPtTripletStepTracks',
-    qualityCuts = [0.7,0.8,0.85],
+    qualityCuts = [0.8, 0.825, 0.85],
 )
 fastSim.toModify(highPtTripletStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
 highBetaStar_2018.toModify(highPtTripletStep,qualityCuts = [-0.2,0.3,0.4])

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -248,7 +248,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 highPtTripletStep = TrackLwtnnClassifier.clone(
     src = 'highPtTripletStepTracks',
-    qualityCuts = [0.8, 0.825, 0.85],
+    qualityCuts = [0.75, 0.775, 0.8],
 )
 fastSim.toModify(highPtTripletStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
 

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -244,11 +244,11 @@ highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProdu
 fastSim.toModify(highPtTripletStepTracks,TTRHBuilder = 'WithoutRefit')
 
 # Final selection
-from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
-highPtTripletStep = TrackMVAClassifierPrompt.clone(
-    src	= 'highPtTripletStepTracks',
-    mva = dict(GBRForestLabel = 'MVASelectorHighPtTripletStep_Phase1'),
-    qualityCuts	= [0.2,0.3,0.4],
+from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
+highPtTripletStep = TrackLwtnnClassifier.clone(
+    src = 'highPtTripletStepTracks',
+    qualityCuts = [0.7,0.8,0.85],
 )
 fastSim.toModify(highPtTripletStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
 highBetaStar_2018.toModify(highPtTripletStep,qualityCuts = [-0.2,0.3,0.4])

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -251,11 +251,20 @@ highPtTripletStep = TrackLwtnnClassifier.clone(
     qualityCuts = [0.8, 0.825, 0.85],
 )
 fastSim.toModify(highPtTripletStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
-highBetaStar_2018.toModify(highPtTripletStep,qualityCuts = [-0.2,0.3,0.4])
-pp_on_AA_2018.toModify(highPtTripletStep, 
-        mva = dict(GBRForestLabel = 'HIMVASelectorHighPtTripletStep_Phase1'),
-        qualityCuts = [-0.9, -0.3, 0.85],
-)
+
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+
+highBetaStar_2018.toReplaceWith(highPtTripletStep, TrackMVAClassifierPrompt.clone(
+     qualityCuts = [-0.2,0.3,0.4],
+     src = 'highPtTripletStepTracks',
+     mva = dict(GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1') 
+))
+
+pp_on_AA_2018.toReplaceWith(highPtTripletStep, TrackMVAClassifierPrompt.clone(
+     qualityCuts = [-0.9, -0.3, 0.85],
+     src = 'highPtTripletStepTracks',
+     mva = dict(GBRForestLabel = 'HIMVASelectorHighPtTripletStep_Phase1')
+))
 
 # For Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -295,7 +295,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackingPhase1.toReplaceWith(initialStep, TrackLwtnnClassifier.clone(
 	src = 'initialStepTracks',
-	qualityCuts = [-0.2,0.2,0.4],
+	qualityCuts = [0.0, 0.3, 0.6],
 ))
 
 pp_on_AA_2018.toModify(initialStep, 

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -298,10 +298,10 @@ trackingPhase1.toReplaceWith(initialStep, TrackLwtnnClassifier.clone(
 	qualityCuts = [0.0, 0.3, 0.6],
 ))
 
-pp_on_AA_2018.toModify(initialStep, 
-        mva = dict(GBRForestLabel = 'HIMVASelectorInitialStep_Phase1'),
-        qualityCuts = [-0.9, -0.5, 0.2],
-)
+pp_on_AA_2018.toReplaceWith(initialStep, initialStepClassifier1.clone( 
+     qualityCuts = [-0.9, -0.5, 0.2],
+     mva = dict(GBRForestLabel = 'HIMVASelectorInitialStep_Phase1') 
+))
 
 # For LowPU and Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -271,7 +271,6 @@ firstStepPrimaryVertices = _sortedPrimaryVertices.clone(
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 
-
 initialStepClassifier1 = TrackMVAClassifierPrompt.clone()
 initialStepClassifier1.src = 'initialStepTracks'
 initialStepClassifier1.mva.GBRForestLabel = 'MVASelectorIter0_13TeV'
@@ -291,9 +290,12 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 initialStep = ClassifierMerger.clone()
 initialStep.inputClassifiers=['initialStepClassifier1','initialStepClassifier2','initialStepClassifier3']
 
-trackingPhase1.toReplaceWith(initialStep, initialStepClassifier1.clone(
-        mva = dict(GBRForestLabel = 'MVASelectorInitialStep_Phase1'),
-        qualityCuts = [-0.95,-0.85,-0.75],
+#LWTNN selector
+from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
+trackingPhase1.toReplaceWith(initialStep, TrackLwtnnClassifier.clone(
+	src = 'initialStepTracks',
+	qualityCuts = [-0.2,0.2,0.4],
 ))
 
 pp_on_AA_2018.toModify(initialStep, 

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -186,12 +186,16 @@ jetCoreRegionalStep.mva.maxDr = [0.3,0.2,0.1];
 jetCoreRegionalStep.vertices = 'firstStepGoodPrimaryVertices'
 
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
-trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackMVAClassifierPrompt.clone(
-     src = 'jetCoreRegionalStepTracks',
-     mva = dict(GBRForestLabel = 'MVASelectorJetCoreRegionalStep_Phase1'),
-     qualityCuts = [-0.2,0.0,0.4],
-))
+
 fastSim.toModify(jetCoreRegionalStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
+
+#LWTNN selector
+from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
+trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackLwtnnClassifier.clone(
+     src = 'jetCoreRegionalStepTracks',
+     qualityCuts = [0.7,0.85,0.95],
+))
 
 # Final sequence
 JetCoreRegionalStepTask = cms.Task(jetsForCoreTracking,                 

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -194,7 +194,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackLwtnnClassifier.clone(
      src = 'jetCoreRegionalStepTracks',
-     qualityCuts = [0.7,0.85,0.95],
+     qualityCuts = [0.6, 0.7, 0.8],
 ))
 
 # Final sequence

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -202,11 +202,20 @@ lowPtQuadStep = TrackLwtnnClassifier.clone(
     qualityCuts = [0.2, 0.425, 0.75],
 )
 fastSim.toModify(lowPtQuadStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
-highBetaStar_2018.toModify(lowPtQuadStep,qualityCuts = [-0.9,-0.35,-0.15])
-pp_on_AA_2018.toModify(lowPtQuadStep, 
-        mva = dict(GBRForestLabel = 'HIMVASelectorLowPtQuadStep_Phase1'),
-        qualityCuts = [-0.9, -0.4, 0.3],
-)
+
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+
+highBetaStar_2018.toReplaceWith(lowPtQuadStep, TrackMVAClassifierPrompt.clone(
+    src = 'lowPtQuadStepTracks',
+    qualityCuts = [-0.9,-0.35,-0.15],
+    mva = dict(GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1') 
+))
+
+pp_on_AA_2018.toReplaceWith(lowPtQuadStep, TrackMVAClassifierPrompt.clone(
+    src = 'lowPtQuadStepTracks',
+    qualityCuts = [-0.9, -0.4, 0.3],
+    mva = dict(GBRForestLabel = 'HIMVASelectorLowPtQuadStep_Phase1')
+))
 
 # For Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -199,7 +199,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 lowPtQuadStep = TrackLwtnnClassifier.clone(
     src = 'lowPtQuadStepTracks',
-    qualityCuts = [-0.2,0.2,0.4],
+    qualityCuts = [0.2, 0.425, 0.75],
 )
 fastSim.toModify(lowPtQuadStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
 highBetaStar_2018.toModify(lowPtQuadStep,qualityCuts = [-0.9,-0.35,-0.15])

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -195,11 +195,11 @@ fastSim.toModify(lowPtQuadStepTracks,TTRHBuilder = 'WithoutRefit')
 
 
 # Final selection
-from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
-lowPtQuadStep =  TrackMVAClassifierPrompt.clone(
+from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
+lowPtQuadStep = TrackLwtnnClassifier.clone(
     src = 'lowPtQuadStepTracks',
-    mva = dict(GBRForestLabel = 'MVASelectorLowPtQuadStep_Phase1'),
-    qualityCuts = [-0.7,-0.35,-0.15],
+    qualityCuts = [-0.2,0.2,0.4],
 )
 fastSim.toModify(lowPtQuadStep,vertices = "firstStepPrimaryVerticesBeforeMixing")
 highBetaStar_2018.toModify(lowPtQuadStep,qualityCuts = [-0.9,-0.35,-0.15])

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -274,23 +274,25 @@ lowPtTripletStep.src = 'lowPtTripletStepTracks'
 lowPtTripletStep.mva.GBRForestLabel = 'MVASelectorIter1_13TeV'
 lowPtTripletStep.qualityCuts = [-0.6,-0.3,-0.1]
 
-trackingPhase1.toReplaceWith(lowPtTripletStep, lowPtTripletStep.clone(
-     mva = dict(GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1'),
-     qualityCuts = [-0.4,0.0,0.3],
-))
-highBetaStar_2018.toModify(lowPtTripletStep,qualityCuts = [-0.7,-0.3,-0.1])
-fastSim.toModify(lowPtTripletStep, vertices = "firstStepPrimaryVerticesBeforeMixing")
-pp_on_AA_2018.toModify(lowPtTripletStep, 
-        mva = dict(GBRForestLabel = 'HIMVASelectorLowPtTripletStep_Phase1'),
-        qualityCuts = [-0.8, -0.4, 0.5],
-)
-
 #LWTNN selector
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackingPhase1.toReplaceWith(lowPtTripletStep, TrackLwtnnClassifier.clone(
      src = 'lowPtTripletStepTracks',
      qualityCuts = [0.2, 0.5, 0.8],
+))
+
+fastSim.toModify(lowPtTripletStep, vertices = "firstStepPrimaryVerticesBeforeMixing")
+highBetaStar_2018.toReplaceWith(lowPtTripletStep, TrackMVAClassifierPrompt.clone(
+     src = 'lowPtTripletStepTracks',
+     qualityCuts = [-0.7,-0.3,-0.1],
+     mva = dict(GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1')
+))
+
+pp_on_AA_2018.toReplaceWith(lowPtTripletStep, TrackMVAClassifierPrompt.clone( 
+     src = 'lowPtTripletStepTracks',
+     qualityCuts = [-0.8, -0.4, 0.5],
+     mva = dict(GBRForestLabel = 'HIMVASelectorLowPtTripletStep_Phase1')
 ))
 
 # For LowPU and Phase2PU140

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -290,7 +290,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackingPhase1.toReplaceWith(lowPtTripletStep, TrackLwtnnClassifier.clone(
      src = 'lowPtTripletStepTracks',
-     qualityCuts = [-0.2,0.1,0.3],
+     qualityCuts = [0.2, 0.5, 0.8],
 ))
 
 # For LowPU and Phase2PU140

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -285,6 +285,13 @@ pp_on_AA_2018.toModify(lowPtTripletStep,
         qualityCuts = [-0.8, -0.4, 0.5],
 )
 
+#LWTNN selector
+from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
+trackingPhase1.toReplaceWith(lowPtTripletStep, TrackLwtnnClassifier.clone(
+     src = 'lowPtTripletStepTracks',
+     qualityCuts = [-0.2,0.1,0.3],
+))
 
 # For LowPU and Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -342,7 +342,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackingPhase1.toReplaceWith(mixedTripletStep, TrackLwtnnClassifier.clone(
      src = 'mixedTripletStepTracks',
-     qualityCuts = [-0.8, -0.55, -0.3],
+     qualityCuts = [-0.8, -0.35, 0.1],
 ))
 
 highBetaStar_2018.toReplaceWith(mixedTripletStep, mixedTripletStepClassifier1.clone(

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -337,9 +337,12 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 mixedTripletStep = ClassifierMerger.clone()
 mixedTripletStep.inputClassifiers=['mixedTripletStepClassifier1','mixedTripletStepClassifier2']
 
-trackingPhase1.toReplaceWith(mixedTripletStep, mixedTripletStepClassifier1.clone(
-     mva = dict(GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1'),
-     qualityCuts = [-0.5,0.0,0.5],
+#LWTNN selector
+from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
+trackingPhase1.toReplaceWith(mixedTripletStep, TrackLwtnnClassifier.clone(
+     src = 'mixedTripletStepTracks',
+     qualityCuts = [-0.95,-0.9,-0.6],
 ))
 highBetaStar_2018.toModify(mixedTripletStep,qualityCuts = [-0.7,0.0,0.5])
 pp_on_AA_2018.toModify(mixedTripletStep, qualityCuts = [-0.5,0.0,0.9])

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -344,8 +344,17 @@ trackingPhase1.toReplaceWith(mixedTripletStep, TrackLwtnnClassifier.clone(
      src = 'mixedTripletStepTracks',
      qualityCuts = [-0.8, -0.55, -0.3],
 ))
-highBetaStar_2018.toModify(mixedTripletStep,qualityCuts = [-0.7,0.0,0.5])
-pp_on_AA_2018.toModify(mixedTripletStep, qualityCuts = [-0.5,0.0,0.9])
+
+highBetaStar_2018.toReplaceWith(mixedTripletStep, mixedTripletStepClassifier1.clone(
+     qualityCuts = [-0.7,0.0,0.5],
+     mva = dict(GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1')
+))
+
+pp_on_AA_2018.toReplaceWith(mixedTripletStep, mixedTripletStepClassifier1.clone(
+     qualityCuts = [-0.5,0.0,0.9],
+     mva = dict(GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1')
+))
+
 
 # For LowPU
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -342,7 +342,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackingPhase1.toReplaceWith(mixedTripletStep, TrackLwtnnClassifier.clone(
      src = 'mixedTripletStepTracks',
-     qualityCuts = [-0.95,-0.9,-0.6],
+     qualityCuts = [-0.8, -0.55, -0.3],
 ))
 highBetaStar_2018.toModify(mixedTripletStep,qualityCuts = [-0.7,0.0,0.5])
 pp_on_AA_2018.toModify(mixedTripletStep, qualityCuts = [-0.5,0.0,0.9])

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -293,7 +293,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackingPhase1.toReplaceWith(pixelLessStep, TrackLwtnnClassifier.clone(
      src = 'pixelLessStepTracks',
-     qualityCuts = [-0.6, -0.15, 0.3],
+     qualityCuts = [-0.6, -0.05, 0.5],
 ))
 
 pp_on_AA_2018.toReplaceWith(pixelLessStep, pixelLessStepClassifier1.clone(

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -295,7 +295,11 @@ trackingPhase1.toReplaceWith(pixelLessStep, TrackLwtnnClassifier.clone(
      src = 'pixelLessStepTracks',
      qualityCuts = [-0.6, -0.15, 0.3],
 ))
-pp_on_AA_2018.toModify(pixelLessStep, qualityCuts = [-0.4,0.0,0.8])
+
+pp_on_AA_2018.toReplaceWith(pixelLessStep, pixelLessStepClassifier1.clone(
+     qualityCuts = [-0.4,0.0,0.8],
+     mva = dict(GBRForestLabel = 'MVASelectorPixelLessStep_Phase1')
+))
 
 # For LowPU
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -293,7 +293,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackingPhase1.toReplaceWith(pixelLessStep, TrackLwtnnClassifier.clone(
      src = 'pixelLessStepTracks',
-     qualityCuts = [-0.4,0.0,0.4],
+     qualityCuts = [-0.6, -0.15, 0.3],
 ))
 pp_on_AA_2018.toModify(pixelLessStep, qualityCuts = [-0.4,0.0,0.8])
 

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -287,8 +287,12 @@ pixelLessStep = ClassifierMerger.clone()
 pixelLessStep.inputClassifiers=['pixelLessStepClassifier1','pixelLessStepClassifier2']
 
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-trackingPhase1.toReplaceWith(pixelLessStep, pixelLessStepClassifier1.clone(
-     mva = dict(GBRForestLabel = 'MVASelectorPixelLessStep_Phase1'),
+
+#LWTNN selector
+from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
+trackingPhase1.toReplaceWith(pixelLessStep, TrackLwtnnClassifier.clone(
+     src = 'pixelLessStepTracks',
      qualityCuts = [-0.4,0.0,0.4],
 ))
 pp_on_AA_2018.toModify(pixelLessStep, qualityCuts = [-0.4,0.0,0.8])

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -338,7 +338,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackingPhase1.toReplaceWith(pixelPairStep, TrackLwtnnClassifier.clone(
     src='pixelPairStepTracks',
-    qualityCuts=[-0.6, -0.3, -0.0],
+    qualityCuts=[-0.6, -0.1, 0.4],
 ))
 
 highBetaStar_2018.toReplaceWith(pixelPairStep, TrackMVAClassifierPrompt.clone(

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -342,7 +342,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackingPhase1.toReplaceWith(pixelPairStep, TrackLwtnnClassifier.clone(
     src='pixelPairStepTracks',
-    qualityCuts=[-0.8,-0.7,-0.4],
+    qualityCuts=[-0.6, -0.3, -0.0],
 ))
 
 

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -332,10 +332,6 @@ pixelPairStep =  TrackMVAClassifierPrompt.clone()
 pixelPairStep.src = 'pixelPairStepTracks'
 pixelPairStep.mva.GBRForestLabel = 'MVASelectorIter2_13TeV'
 pixelPairStep.qualityCuts = [-0.2,0.0,0.3]
-highBetaStar_2018.toModify(pixelPairStep,qualityCuts = [-0.95,0.0,0.3])
-
-fastSim.toModify(pixelPairStep, vertices = "firstStepPrimaryVerticesBeforeMixing")
-pp_on_AA_2018.toModify(pixelPairStep, qualityCuts = [-0.2, 0.0, 0.9])
 
 #LWTNN selector
 from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
@@ -344,6 +340,21 @@ trackingPhase1.toReplaceWith(pixelPairStep, TrackLwtnnClassifier.clone(
     src='pixelPairStepTracks',
     qualityCuts=[-0.6, -0.3, -0.0],
 ))
+
+highBetaStar_2018.toReplaceWith(pixelPairStep, TrackMVAClassifierPrompt.clone(
+    src='pixelPairStepTracks',
+    qualityCuts = [-0.95,0.0,0.3],
+    mva=dict(GBRForestLabel = 'MVASelectorPixelPairStep_Phase1')
+))
+
+pp_on_AA_2018.toReplaceWith(pixelPairStep, TrackMVAClassifierPrompt.clone( 
+    src='pixelPairStepTracks',
+    qualityCuts = [-0.2, 0.0, 0.9],
+    mva=dict(GBRForestLabel = 'MVASelectorPixelPairStep_Phase1') 
+))
+
+fastSim.toModify(pixelPairStep, vertices = "firstStepPrimaryVerticesBeforeMixing")
+
 
 
 # For LowPU and Phase2PU140

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -334,9 +334,17 @@ pixelPairStep.mva.GBRForestLabel = 'MVASelectorIter2_13TeV'
 pixelPairStep.qualityCuts = [-0.2,0.0,0.3]
 highBetaStar_2018.toModify(pixelPairStep,qualityCuts = [-0.95,0.0,0.3])
 
-trackingPhase1.toModify(pixelPairStep, mva=dict(GBRForestLabel = 'MVASelectorPixelPairStep_Phase1'))
 fastSim.toModify(pixelPairStep, vertices = "firstStepPrimaryVerticesBeforeMixing")
 pp_on_AA_2018.toModify(pixelPairStep, qualityCuts = [-0.2, 0.0, 0.9])
+
+#LWTNN selector
+from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
+trackingPhase1.toReplaceWith(pixelPairStep, TrackLwtnnClassifier.clone(
+    src='pixelPairStepTracks',
+    qualityCuts=[-0.8,-0.7,-0.4],
+))
+
 
 # For LowPU and Phase2PU140
 import RecoTracker.IterativeTracking.LowPtTripletStep_cff

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -367,9 +367,15 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackingPhase1.toReplaceWith(tobTecStep, TrackLwtnnClassifier.clone(
      src = 'tobTecStepTracks',
-     qualityCuts = [-0.4, -0.25, -0.1],
+     qualityCuts = [-0.4, -0.25, -0.1]
 ))
-pp_on_AA_2018.toModify(tobTecStep, qualityCuts = [-0.6,-0.3,0.7])
+
+pp_on_AA_2018.toReplaceWith(tobTecStep, TrackMVAClassifierDetached.clone(
+     src = 'tobTecStepTracks',
+     qualityCuts = [-0.6,-0.3,0.7],
+     mva = dict(GBRForestLabel = 'MVASelectorTobTecStep_Phase1')
+))
+
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 trackingLowPU.toReplaceWith(tobTecStep, RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -367,7 +367,7 @@ from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
 trackingPhase1.toReplaceWith(tobTecStep, TrackLwtnnClassifier.clone(
      src = 'tobTecStepTracks',
-     qualityCuts = [-0.9,-0.85,-0.8],
+     qualityCuts = [-0.4, -0.25, -0.1],
 ))
 pp_on_AA_2018.toModify(tobTecStep, qualityCuts = [-0.6,-0.3,0.7])
 

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -361,9 +361,13 @@ tobTecStep = ClassifierMerger.clone()
 tobTecStep.inputClassifiers=['tobTecStepClassifier1','tobTecStepClassifier2']
 
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-trackingPhase1.toReplaceWith(tobTecStep, tobTecStepClassifier1.clone(
-     mva = dict(GBRForestLabel = 'MVASelectorTobTecStep_Phase1'),
-     qualityCuts = [-0.6,-0.45,-0.3],
+
+#LWTNN selector
+from RecoTracker.FinalTrackSelectors.TrackLwtnnClassifier_cfi import *
+from RecoTracker.FinalTrackSelectors.trackSelectionLwtnn_cfi import *
+trackingPhase1.toReplaceWith(tobTecStep, TrackLwtnnClassifier.clone(
+     src = 'tobTecStepTracks',
+     qualityCuts = [-0.9,-0.85,-0.8],
 ))
 pp_on_AA_2018.toModify(tobTecStep, qualityCuts = [-0.6,-0.3,0.7])
 

--- a/RecoTracker/IterativeTracking/python/customise_MVAPhase1_cfi.py
+++ b/RecoTracker/IterativeTracking/python/customise_MVAPhase1_cfi.py
@@ -1,0 +1,87 @@
+import FWCore.ParameterSet.Config as cms
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
+from RecoTracker.IterativeTracking.InitialStep_cff import *
+from RecoTracker.IterativeTracking.DetachedQuadStep_cff import *
+from RecoTracker.IterativeTracking.DetachedTripletStep_cff import *
+from RecoTracker.IterativeTracking.HighPtTripletStep_cff import *
+from RecoTracker.IterativeTracking.JetCoreRegionalStep_cff import *
+from RecoTracker.IterativeTracking.LowPtQuadStep_cff import *
+from RecoTracker.IterativeTracking.LowPtTripletStep_cff import *
+from RecoTracker.IterativeTracking.MixedTripletStep_cff import *
+from RecoTracker.IterativeTracking.PixelPairStep_cff import *
+from RecoTracker.IterativeTracking.PixelLessStep_cff import *
+from RecoTracker.IterativeTracking.TobTecStep_cff import *
+
+from Configuration.StandardSequences.Eras import eras
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+
+
+def customise_MVAPhase1(process):
+	trackingPhase1.toReplaceWith(detachedQuadStep, TrackMVAClassifierDetached.clone(
+		mva = dict(GBRForestLabel = 'MVASelectorDetachedQuadStep_Phase1'),
+		src = 'detachedQuadStepTracks',
+		qualityCuts = [-0.5,0.0,0.5]
+	))
+
+        trackingPhase1.toReplaceWith(detachedTripletStep, TrackMVAClassifierDetached.clone(
+                mva = dict(GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1'),
+                src = 'detachedTripletStepTracks',
+                qualityCuts = [-0.2,0.3,0.8]
+        ))
+
+        trackingPhase1.toReplaceWith(highPtTripletStep, TrackMVAClassifierPrompt.clone(
+                mva = dict(GBRForestLabel = 'MVASelectorHighPtTripletStep_Phase1'),
+                src = 'highPtTripletStepTracks',
+                qualityCuts = [0.2,0.3,0.4]
+        ))
+
+	trackingPhase1.toReplaceWith(initialStep, TrackMVAClassifierPrompt.clone(
+		mva = dict(GBRForestLabel = 'MVASelectorInitialStep_Phase1'),
+		src = 'initialStepTracks',
+		qualityCuts = [-0.95,-0.85,-0.75]
+	))
+
+	trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackMVAClassifierPrompt.clone(
+                mva = dict(GBRForestLabel = 'MVASelectorJetCoreRegionalStep_Phase1'),
+                src = 'jetCoreRegionalStepTracks',
+                qualityCuts = [-0.2,0.0,0.4]
+        ))
+
+        trackingPhase1.toReplaceWith(lowPtQuadStep, TrackMVAClassifierPrompt.clone(
+                mva = dict(GBRForestLabel = 'MVASelectorLowPtQuadStep_Phase1'),
+                src = 'lowPtQuadStepTracks',
+                qualityCuts = [-0.7,-0.35,-0.15]
+        ))
+
+        trackingPhase1.toReplaceWith(lowPtTripletStep, TrackMVAClassifierPrompt.clone(
+                mva = dict(GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1'),
+                src = 'lowPtTripletStepTracks',
+                qualityCuts = [-0.4,0.0,0.3]
+        ))
+
+	trackingPhase1.toReplaceWith(mixedTripletStep, TrackMVAClassifierDetached.clone(
+                mva = dict(GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1'),
+                src = 'mixedTripletStepTracks',
+                qualityCuts = [-0.5,0.0,0.5]
+        ))
+
+        trackingPhase1.toReplaceWith(pixelLessStep, TrackMVAClassifierDetached.clone(
+                mva = dict(GBRForestLabel = 'MVASelectorPixelLessStep_Phase1'),
+                src = 'pixelLessStepTracks',
+                qualityCuts = [-0.4,0.0,0.4]
+        ))
+
+        trackingPhase1.toReplaceWith(pixelPairStep, TrackMVAClassifierDetached.clone(
+                mva = dict(GBRForestLabel = 'MVASelectorPixelPairStep_Phase1'),
+                src = 'pixelPairStepTracks',
+                qualityCuts = [-0.2,0.0,0.3]
+        ))
+
+        trackingPhase1.toReplaceWith(tobTecStep, TrackMVAClassifierDetached.clone(
+                mva = dict(GBRForestLabel = 'MVASelectorTobTecStep_Phase1'),
+                src = 'tobTecStepTracks',
+                qualityCuts = [-0.6,-0.45,-0.3]
+        ))
+
+	return process

--- a/RecoTracker/IterativeTracking/python/iterativeTkUtils.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkUtils.py
@@ -22,7 +22,7 @@ def getMVASelectors(postfix):
             classifiers = []
             if typeName == "ClassifierMerger":
                 classifiers = mod.inputClassifiers.value()
-            elif "TrackMVAClassifier" in typeName:
+            elif "TrackMVAClassifier" in typeName or "TrackLwtnnClassifier" in typeName:
                 classifiers = [iterName]
             if len(classifiers) > 0:
                 ret[iterName] = (iterName+"Tracks", classifiers)


### PR DESCRIPTION
This PR changes the track classifiers in iterative track reconstruction for Phase1 to use a Deep Neural Network implemented in the LWTNN library instead of Boosted Decision Trees. Uses the model .json stored in  #https://github.com/cms-data/RecoTracker-FinalTrackSelectors/pull/1

Pre-PR tests ran on CMSSW_10_0_X_2017-12-13-2300

MTV comparison plots for the current BDT and the new LWTNN implementations: http://cmsdoc.cern.ch/~jhavukai/plots_LWTNNvsBDT/

Recent talks where this work has been presented:
-CMS Fall17 Offline and Computing Week 15.11.2017
https://indico.cern.ch/event/625239/#12-track-selection-with-tf

-Tracking POG meeting 16.10.2017
https://indico.cern.ch/event/672746/#4-updates-on-mva-selection

@makortel @VinInn 