### PR TITLE
only print "failed to propagate to ECAL entrance" message for eta<3 (from PFRecoTauChargedHadronFromTrackPlugin)

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromTrackPlugin.cc
@@ -202,7 +202,7 @@ PFRecoTauChargedHadronFromTrackPlugin::return_type PFRecoTauChargedHadronFromTra
     if ( trackPropagator.getSuccess() != 0 ) { 
       chargedHadron->positionAtECALEntrance_ = trackPropagator.vertex();
     } else {
-      if ( chargedPionP4.pt() > 2. ) {
+      if ( chargedPionP4.pt() > 2. and std::abs(chargedPionP4.eta()) < 3. ) {
 	edm::LogWarning("PFRecoTauChargedHadronFromTrackPlugin::operator()") 
 	  << "Failed to propagate track: Pt = " << track->pt() << ", eta = " << track->eta() << ", phi = " << track->phi() << " to ECAL entrance !!" << std::endl;
       }


### PR DESCRIPTION
This message was showing up frequently in Phase2 workflows. Since there is no ECAL beyond eta=3, it is pointless to print the message for tracks with eta>3.