### PR TITLE
temporarily disable 8TS for HBHE

### DIFF
--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -132,20 +132,21 @@ run2_HF_2017.toModify( hcalSimParameters,
               )
 )
 
-from Configuration.Eras.Modifier_run2_HB_2018_cff import run2_HB_2018
-run2_HB_2018.toModify( hcalSimParameters,
-    hb = dict(
-               readoutFrameSize = cms.int32(8), 
-               binOfMaximum     = cms.int32(4)
-              )
-)
-from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
-run2_HE_2018.toModify( hcalSimParameters,
-    he = dict(
-               readoutFrameSize = cms.int32(8), 
-               binOfMaximum     = cms.int32(4)
-              )
-)
+# temporarily disabled
+#from Configuration.Eras.Modifier_run2_HB_2018_cff import run2_HB_2018
+#run2_HB_2018.toModify( hcalSimParameters,
+#    hb = dict(
+#               readoutFrameSize = cms.int32(8), 
+#               binOfMaximum     = cms.int32(4)
+#              )
+#)
+#from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
+#run2_HE_2018.toModify( hcalSimParameters,
+#    he = dict(
+#               readoutFrameSize = cms.int32(8), 
+#               binOfMaximum     = cms.int32(4)
+#              )
+#)
 
 
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB

--- a/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
@@ -32,13 +32,14 @@ run2_HF_2017.toModify( simHcalDigis,
                              HFregion = cms.vint32(1,2)
 )
 
-from Configuration.Eras.Modifier_run2_HB_2018_cff import run2_HB_2018
-run2_HB_2018.toModify( simHcalDigis,
-                             HBregion = cms.vint32(2,5)
-)
-
-from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
-run2_HE_2018.toModify( simHcalDigis,
-                             HEregion = cms.vint32(2,5)
-)
+# temporarily disabled
+#from Configuration.Eras.Modifier_run2_HB_2018_cff import run2_HB_2018
+#run2_HB_2018.toModify( simHcalDigis,
+#                             HBregion = cms.vint32(2,5)
+#)
+#
+#from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
+#run2_HE_2018.toModify( simHcalDigis,
+#                             HEregion = cms.vint32(2,5)
+#)
 


### PR DESCRIPTION
Temporarily disables the change from 10TS to 8TS introduced in #21651, due to issues observed with Method 3 reconstruction results (https://github.com/cms-sw/cmssw/pull/21651#issuecomment-351731950). Should be reverted once the underlying problem is addressed.

attn: @abdoulline @mariadalfonso @slava77 