### PR TITLE
more DQM-related developments, fixes and improvements

### DIFF
--- a/DQMServices/Core/interface/ConcurrentMonitorElement.h
+++ b/DQMServices/Core/interface/ConcurrentMonitorElement.h
@@ -31,7 +31,7 @@ public:
   // movable
   ConcurrentMonitorElement(ConcurrentMonitorElement && other)
   {
-    std::lock_guard<std::mutex>(other.lock_);
+    std::lock_guard<std::mutex> guard(other.lock_);
     me_ = other.me_;
     other.me_ = nullptr;
   }

--- a/DQMServices/Core/interface/ConcurrentMonitorElement.h
+++ b/DQMServices/Core/interface/ConcurrentMonitorElement.h
@@ -7,6 +7,7 @@
  */
 
 #include <mutex>
+#include <tbb/spin_mutex.h>
 
 #include "DQMServices/Core/interface/MonitorElement.h"
 
@@ -14,7 +15,7 @@ class ConcurrentMonitorElement
 {
 private:
   mutable MonitorElement* me_;
-  mutable std::mutex lock_;
+  mutable tbb::spin_mutex lock_;
 
 public:
   ConcurrentMonitorElement(void) :
@@ -31,7 +32,7 @@ public:
   // movable
   ConcurrentMonitorElement(ConcurrentMonitorElement && other)
   {
-    std::lock_guard<std::mutex> guard(other.lock_);
+    std::lock_guard<tbb::spin_mutex> guard(other.lock_);
     me_ = other.me_;
     other.me_ = nullptr;
   }
@@ -44,8 +45,8 @@ public:
   {
     // FIXME replace with std::scoped_lock once C++17 is available
     std::lock(lock_, other.lock_);
-    std::lock_guard<std::mutex> ours(lock_, std::adopt_lock);
-    std::lock_guard<std::mutex> others(other.lock_, std::adopt_lock);
+    std::lock_guard<tbb::spin_mutex> ours(lock_, std::adopt_lock);
+    std::lock_guard<tbb::spin_mutex> others(other.lock_, std::adopt_lock);
     me_ = other.me_;
     other.me_ = nullptr;
     return *this;
@@ -58,27 +59,27 @@ public:
   template <typename... Args>
   void fill(Args && ... args) const
   {
-    std::lock_guard<std::mutex> guard(lock_);
+    std::lock_guard<tbb::spin_mutex> guard(lock_);
     me_->Fill(std::forward<Args>(args)...);
   }
 
   // expose as a const method to mean that it is concurrent-safe
   void shiftFillLast(double y, double ye = 0., int32_t xscale = 1) const
   {
-    std::lock_guard<std::mutex> guard(lock_);
+    std::lock_guard<tbb::spin_mutex> guard(lock_);
     me_->ShiftFillLast(y, ye, xscale);
   }
 
   // reset the internal pointer
   void reset()
   {
-    std::lock_guard<std::mutex> guard(lock_);
+    std::lock_guard<tbb::spin_mutex> guard(lock_);
     me_ = nullptr;
   }
 
   operator bool() const
   {
-    std::lock_guard<std::mutex> guard(lock_);
+    std::lock_guard<tbb::spin_mutex> guard(lock_);
     return (me_ != nullptr);
   }
 

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -779,26 +779,27 @@ class DQMStore
 
   // ---------------------- Booking ------------------------------------
   MonitorElement *              initialise(MonitorElement *me, const std::string &path);
-  MonitorElement *              book(const std::string &dir,
-                                     const std::string &name,
-                                     const char *context);
+  MonitorElement *              book_(const std::string &dir,
+                                      const std::string &name,
+                                      const char *context);
   template <class HISTO, class COLLATE>
-  MonitorElement *              book(const std::string &dir, const std::string &name,
-                                     const char *context, int kind,
-                                     HISTO *h, COLLATE collate);
+  MonitorElement *              book_(const std::string &dir,
+                                      const std::string &name,
+                                      const char *context,
+                                      int kind, HISTO *h, COLLATE collate);
 
-  MonitorElement *              bookInt(const std::string &dir, const std::string &name);
-  MonitorElement *              bookFloat(const std::string &dir, const std::string &name);
-  MonitorElement *              bookString(const std::string &dir, const std::string &name, const std::string &value);
-  MonitorElement *              book1D(const std::string &dir, const std::string &name, TH1F *h);
-  MonitorElement *              book1S(const std::string &dir, const std::string &name, TH1S *h);
-  MonitorElement *              book1DD(const std::string &dir, const std::string &name, TH1D *h);
-  MonitorElement *              book2D(const std::string &dir, const std::string &name, TH2F *h);
-  MonitorElement *              book2S(const std::string &dir, const std::string &name, TH2S *h);
-  MonitorElement *              book2DD(const std::string &dir, const std::string &name, TH2D *h);
-  MonitorElement *              book3D(const std::string &dir, const std::string &name, TH3F *h);
-  MonitorElement *              bookProfile(const std::string &dir, const std::string &name, TProfile *h);
-  MonitorElement *              bookProfile2D(const std::string &folder, const std::string &name, TProfile2D *h);
+  MonitorElement *              bookInt_(const std::string &dir, const std::string &name);
+  MonitorElement *              bookFloat_(const std::string &dir, const std::string &name);
+  MonitorElement *              bookString_(const std::string &dir, const std::string &name, const std::string &value);
+  MonitorElement *              book1D_(const std::string &dir, const std::string &name, TH1F *h);
+  MonitorElement *              book1S_(const std::string &dir, const std::string &name, TH1S *h);
+  MonitorElement *              book1DD_(const std::string &dir, const std::string &name, TH1D *h);
+  MonitorElement *              book2D_(const std::string &dir, const std::string &name, TH2F *h);
+  MonitorElement *              book2S_(const std::string &dir, const std::string &name, TH2S *h);
+  MonitorElement *              book2DD_(const std::string &dir, const std::string &name, TH2D *h);
+  MonitorElement *              book3D_(const std::string &dir, const std::string &name, TH3F *h);
+  MonitorElement *              bookProfile_(const std::string &dir, const std::string &name, TProfile *h);
+  MonitorElement *              bookProfile2D_(const std::string &dir, const std::string &name, TProfile2D *h);
 
   static bool                   checkBinningMatches(MonitorElement *me, TH1 *h, unsigned verbose);
 

--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -63,8 +63,6 @@ public:
     DQM_KIND_TPROFILE2D = DQMNet::DQM_PROP_TYPE_TPROF2D
   };
 
-  using QReportIterator = std::vector<QReport>::const_iterator;
-
 private:
   DQMNet::CoreObject    data_;       //< Core object information.
   Scalar                scalar_;     //< Current scalar value.

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -816,9 +816,9 @@ DQMStore::dirExists(const std::string &path) const
 //////////////////////////////////////////////////////////////////////
 template <class HISTO, class COLLATE>
 MonitorElement *
-DQMStore::book(const std::string &dir, const std::string &name,
-               const char *context, int kind,
-               HISTO *h, COLLATE collate)
+DQMStore::book_(const std::string &dir, const std::string &name,
+                const char *context, int kind,
+                HISTO *h, COLLATE collate)
 {
   assert(name.find('/') == std::string::npos);
   if (verbose_ > 3)
@@ -892,9 +892,9 @@ DQMStore::book(const std::string &dir, const std::string &name,
 }
 
 MonitorElement *
-DQMStore::book(const std::string &dir,
-               const std::string &name,
-               const char *context)
+DQMStore::book_(const std::string &dir,
+                const std::string &name,
+                const char *context)
 {
   assert(name.find('/') == std::string::npos);
   if (verbose_ > 3)
@@ -927,7 +927,7 @@ DQMStore::book(const std::string &dir,
 // -------------------------------------------------------------------
 /// Book int.
 MonitorElement *
-DQMStore::bookInt(const std::string &dir, const std::string &name)
+DQMStore::bookInt_(const std::string &dir, const std::string &name)
 {
   if (collateHistograms_)
   {
@@ -938,26 +938,26 @@ DQMStore::bookInt(const std::string &dir, const std::string &name)
     }
   }
 
-  return book(dir, name, "bookInt")
+  return book_(dir, name, "bookInt")
     ->initialise(MonitorElement::DQM_KIND_INT);
 }
 
 /// Book int.
 MonitorElement *
 DQMStore::bookInt(const char *name)
-{ return bookInt(pwd_, name); }
+{ return bookInt_(pwd_, name); }
 
 /// Book int.
 MonitorElement *
 DQMStore::bookInt(const std::string &name)
 {
-  return bookInt(pwd_, name);
+  return bookInt_(pwd_, name);
 }
 
 // -------------------------------------------------------------------
 /// Book float.
 MonitorElement *
-DQMStore::bookFloat(const std::string &dir, const std::string &name)
+DQMStore::bookFloat_(const std::string &dir, const std::string &name)
 {
   if (collateHistograms_)
   {
@@ -968,28 +968,28 @@ DQMStore::bookFloat(const std::string &dir, const std::string &name)
     }
   }
 
-  return book(dir, name, "bookFloat")
+  return book_(dir, name, "bookFloat")
     ->initialise(MonitorElement::DQM_KIND_REAL);
 }
 
 /// Book float.
 MonitorElement *
 DQMStore::bookFloat(const char *name)
-{ return bookFloat(pwd_, name); }
+{ return bookFloat_(pwd_, name); }
 
 /// Book float.
 MonitorElement *
 DQMStore::bookFloat(const std::string &name)
 {
-  return bookFloat(pwd_, name);
+  return bookFloat_(pwd_, name);
 }
 
 // -------------------------------------------------------------------
 /// Book string.
 MonitorElement *
-DQMStore::bookString(const std::string &dir,
-                     const std::string &name,
-                     const std::string &value)
+DQMStore::bookString_(const std::string &dir,
+                      const std::string &name,
+                      const std::string &value)
 {
   if (collateHistograms_)
   {
@@ -997,42 +997,42 @@ DQMStore::bookString(const std::string &dir,
       return me;
   }
 
-  return book(dir, name, "bookString")
+  return book_(dir, name, "bookString")
     ->initialise(MonitorElement::DQM_KIND_STRING, value);
 }
 
 /// Book string.
 MonitorElement *
 DQMStore::bookString(const char *name, const char *value)
-{ return bookString(pwd_, name, value); }
+{ return bookString_(pwd_, name, value); }
 
 /// Book string.
 MonitorElement *
 DQMStore::bookString(const std::string &name, const std::string &value)
 {
-  return bookString(pwd_, name, value);
+  return bookString_(pwd_, name, value);
 }
 
 // -------------------------------------------------------------------
 /// Book 1D histogram based on TH1F.
 MonitorElement *
-DQMStore::book1D(const std::string &dir, const std::string &name, TH1F *h)
+DQMStore::book1D_(const std::string &dir, const std::string &name, TH1F *h)
 {
-  return book(dir, name, "book1D", MonitorElement::DQM_KIND_TH1F, h, collate1D);
+  return book_(dir, name, "book1D", MonitorElement::DQM_KIND_TH1F, h, collate1D);
 }
 
 /// Book 1D histogram based on TH1S.
 MonitorElement *
-DQMStore::book1S(const std::string &dir, const std::string &name, TH1S *h)
+DQMStore::book1S_(const std::string &dir, const std::string &name, TH1S *h)
 {
-  return book(dir, name, "book1S", MonitorElement::DQM_KIND_TH1S, h, collate1S);
+  return book_(dir, name, "book1S", MonitorElement::DQM_KIND_TH1S, h, collate1S);
 }
 
 /// Book 1D histogram based on TH1D.
 MonitorElement *
-DQMStore::book1DD(const std::string &dir, const std::string &name, TH1D *h)
+DQMStore::book1DD_(const std::string &dir, const std::string &name, TH1D *h)
 {
-  return book(dir, name, "book1DD", MonitorElement::DQM_KIND_TH1D, h, collate1DD);
+  return book_(dir, name, "book1DD", MonitorElement::DQM_KIND_TH1D, h, collate1DD);
 }
 
 /// Book 1D histogram.
@@ -1040,7 +1040,7 @@ MonitorElement *
 DQMStore::book1D(const char *name, const char *title,
                  int nchX, double lowX, double highX)
 {
-  return book1D(pwd_, name, new TH1F(name, title, nchX, lowX, highX));
+  return book1D_(pwd_, name, new TH1F(name, title, nchX, lowX, highX));
 }
 
 /// Book 1D histogram.
@@ -1048,7 +1048,7 @@ MonitorElement *
 DQMStore::book1D(const std::string &name, const std::string &title,
                  int nchX, double lowX, double highX)
 {
-  return book1D(pwd_, name, new TH1F(name.c_str(), title.c_str(), nchX, lowX, highX));
+  return book1D_(pwd_, name, new TH1F(name.c_str(), title.c_str(), nchX, lowX, highX));
 }
 
 /// Book 1S histogram.
@@ -1056,7 +1056,7 @@ MonitorElement *
 DQMStore::book1S(const char *name, const char *title,
                  int nchX, double lowX, double highX)
 {
-  return book1S(pwd_, name, new TH1S(name, title, nchX, lowX, highX));
+  return book1S_(pwd_, name, new TH1S(name, title, nchX, lowX, highX));
 }
 
 /// Book 1S histogram.
@@ -1064,7 +1064,7 @@ MonitorElement *
 DQMStore::book1S(const std::string &name, const std::string &title,
                  int nchX, double lowX, double highX)
 {
-  return book1S(pwd_, name, new TH1S(name.c_str(), title.c_str(), nchX, lowX, highX));
+  return book1S_(pwd_, name, new TH1S(name.c_str(), title.c_str(), nchX, lowX, highX));
 }
 
 /// Book 1S histogram.
@@ -1072,7 +1072,7 @@ MonitorElement *
 DQMStore::book1DD(const char *name, const char *title,
                   int nchX, double lowX, double highX)
 {
-  return book1DD(pwd_, name, new TH1D(name, title, nchX, lowX, highX));
+  return book1DD_(pwd_, name, new TH1D(name, title, nchX, lowX, highX));
 }
 
 /// Book 1S histogram.
@@ -1080,7 +1080,7 @@ MonitorElement *
 DQMStore::book1DD(const std::string &name, const std::string &title,
                   int nchX, double lowX, double highX)
 {
-  return book1DD(pwd_, name, new TH1D(name.c_str(), title.c_str(), nchX, lowX, highX));
+  return book1DD_(pwd_, name, new TH1D(name.c_str(), title.c_str(), nchX, lowX, highX));
 }
 
 /// Book 1D variable bin histogram.
@@ -1088,7 +1088,7 @@ MonitorElement *
 DQMStore::book1D(const char *name, const char *title,
                  int nchX, const float *xbinsize)
 {
-  return book1D(pwd_, name, new TH1F(name, title, nchX, xbinsize));
+  return book1D_(pwd_, name, new TH1F(name, title, nchX, xbinsize));
 }
 
 /// Book 1D variable bin histogram.
@@ -1096,71 +1096,71 @@ MonitorElement *
 DQMStore::book1D(const std::string &name, const std::string &title,
                  int nchX, const float *xbinsize)
 {
-  return book1D(pwd_, name, new TH1F(name.c_str(), title.c_str(), nchX, xbinsize));
+  return book1D_(pwd_, name, new TH1F(name.c_str(), title.c_str(), nchX, xbinsize));
 }
 
 /// Book 1D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1D(const char *name, TH1F *source)
 {
-  return book1D(pwd_, name, static_cast<TH1F *>(source->Clone(name)));
+  return book1D_(pwd_, name, static_cast<TH1F *>(source->Clone(name)));
 }
 
 /// Book 1D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1D(const std::string &name, TH1F *source)
 {
-  return book1D(pwd_, name, static_cast<TH1F *>(source->Clone(name.c_str())));
+  return book1D_(pwd_, name, static_cast<TH1F *>(source->Clone(name.c_str())));
 }
 
 /// Book 1S histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1S(const char *name, TH1S *source)
 {
-  return book1S(pwd_, name, static_cast<TH1S *>(source->Clone(name)));
+  return book1S_(pwd_, name, static_cast<TH1S *>(source->Clone(name)));
 }
 
 /// Book 1S histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1S(const std::string &name, TH1S *source)
 {
-  return book1S(pwd_, name, static_cast<TH1S *>(source->Clone(name.c_str())));
+  return book1S_(pwd_, name, static_cast<TH1S *>(source->Clone(name.c_str())));
 }
 
 /// Book 1D double histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1DD(const char *name, TH1D *source)
 {
-  return book1DD(pwd_, name, static_cast<TH1D *>(source->Clone(name)));
+  return book1DD_(pwd_, name, static_cast<TH1D *>(source->Clone(name)));
 }
 
 /// Book 1D double histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1DD(const std::string &name, TH1D *source)
 {
-  return book1DD(pwd_, name, static_cast<TH1D *>(source->Clone(name.c_str())));
+  return book1DD_(pwd_, name, static_cast<TH1D *>(source->Clone(name.c_str())));
 }
 
 // -------------------------------------------------------------------
 /// Book 2D histogram based on TH2F.
 MonitorElement *
-DQMStore::book2D(const std::string &dir, const std::string &name, TH2F *h)
+DQMStore::book2D_(const std::string &dir, const std::string &name, TH2F *h)
 {
-  return book(dir, name, "book2D", MonitorElement::DQM_KIND_TH2F, h, collate2D);
+  return book_(dir, name, "book2D", MonitorElement::DQM_KIND_TH2F, h, collate2D);
 }
 
 /// Book 2D histogram based on TH2S.
 MonitorElement *
-DQMStore::book2S(const std::string &dir, const std::string &name, TH2S *h)
+DQMStore::book2S_(const std::string &dir, const std::string &name, TH2S *h)
 {
-  return book(dir, name, "book2S", MonitorElement::DQM_KIND_TH2S, h, collate2S);
+  return book_(dir, name, "book2S", MonitorElement::DQM_KIND_TH2S, h, collate2S);
 }
 
 /// Book 2D histogram based on TH2D.
 MonitorElement *
-DQMStore::book2DD(const std::string &dir, const std::string &name, TH2D *h)
+DQMStore::book2DD_(const std::string &dir, const std::string &name, TH2D *h)
 {
-  return book(dir, name, "book2DD", MonitorElement::DQM_KIND_TH2D, h, collate2DD);
+  return book_(dir, name, "book2DD", MonitorElement::DQM_KIND_TH2D, h, collate2DD);
 }
 
 /// Book 2D histogram.
@@ -1169,7 +1169,7 @@ DQMStore::book2D(const char *name, const char *title,
                  int nchX, double lowX, double highX,
                  int nchY, double lowY, double highY)
 {
-  return book2D(pwd_, name, new TH2F(name, title,
+  return book2D_(pwd_, name, new TH2F(name, title,
                                      nchX, lowX, highX,
                                      nchY, lowY, highY));
 }
@@ -1180,7 +1180,7 @@ DQMStore::book2D(const std::string &name, const std::string &title,
                  int nchX, double lowX, double highX,
                  int nchY, double lowY, double highY)
 {
-  return book2D(pwd_, name, new TH2F(name.c_str(), title.c_str(),
+  return book2D_(pwd_, name, new TH2F(name.c_str(), title.c_str(),
                                      nchX, lowX, highX,
                                      nchY, lowY, highY));
 }
@@ -1191,7 +1191,7 @@ DQMStore::book2S(const char *name, const char *title,
                  int nchX, double lowX, double highX,
                  int nchY, double lowY, double highY)
 {
-  return book2S(pwd_, name, new TH2S(name, title,
+  return book2S_(pwd_, name, new TH2S(name, title,
                                      nchX, lowX, highX,
                                      nchY, lowY, highY));
 }
@@ -1202,7 +1202,7 @@ DQMStore::book2S(const std::string &name, const std::string &title,
                  int nchX, double lowX, double highX,
                  int nchY, double lowY, double highY)
 {
-  return book2S(pwd_, name, new TH2S(name.c_str(), title.c_str(),
+  return book2S_(pwd_, name, new TH2S(name.c_str(), title.c_str(),
                                      nchX, lowX, highX,
                                      nchY, lowY, highY));
 }
@@ -1213,7 +1213,7 @@ DQMStore::book2DD(const char *name, const char *title,
                   int nchX, double lowX, double highX,
                   int nchY, double lowY, double highY)
 {
-  return book2DD(pwd_, name, new TH2D(name, title,
+  return book2DD_(pwd_, name, new TH2D(name, title,
                                       nchX, lowX, highX,
                                       nchY, lowY, highY));
 }
@@ -1224,7 +1224,7 @@ DQMStore::book2DD(const std::string &name, const std::string &title,
                   int nchX, double lowX, double highX,
                   int nchY, double lowY, double highY)
 {
-  return book2DD(pwd_, name, new TH2D(name.c_str(), title.c_str(),
+  return book2DD_(pwd_, name, new TH2D(name.c_str(), title.c_str(),
                                       nchX, lowX, highX,
                                       nchY, lowY, highY));
 }
@@ -1234,7 +1234,7 @@ MonitorElement *
 DQMStore::book2D(const char *name, const char *title,
                  int nchX, const float *xbinsize, int nchY, const float *ybinsize)
 {
-  return book2D(pwd_, name, new TH2F(name, title,
+  return book2D_(pwd_, name, new TH2F(name, title,
                                      nchX, xbinsize, nchY, ybinsize));
 }
 
@@ -1243,7 +1243,7 @@ MonitorElement *
 DQMStore::book2D(const std::string &name, const std::string &title,
                  int nchX, const float *xbinsize, int nchY, const float *ybinsize)
 {
-  return book2D(pwd_, name, new TH2F(name.c_str(), title.c_str(),
+  return book2D_(pwd_, name, new TH2F(name.c_str(), title.c_str(),
                                      nchX, xbinsize, nchY, ybinsize));
 }
 
@@ -1252,7 +1252,7 @@ MonitorElement *
 DQMStore::book2S(const char *name, const char *title,
                  int nchX, const float *xbinsize, int nchY, const float *ybinsize)
 {
-  return book2S(pwd_, name, new TH2S(name, title,
+  return book2S_(pwd_, name, new TH2S(name, title,
                                      nchX, xbinsize, nchY, ybinsize));
 }
 
@@ -1261,7 +1261,7 @@ MonitorElement *
 DQMStore::book2S(const std::string &name, const std::string &title,
                  int nchX, const float *xbinsize, int nchY, const float *ybinsize)
 {
-  return book2S(pwd_, name, new TH2S(name.c_str(), title.c_str(),
+  return book2S_(pwd_, name, new TH2S(name.c_str(), title.c_str(),
                                      nchX, xbinsize, nchY, ybinsize));
 }
 
@@ -1269,50 +1269,50 @@ DQMStore::book2S(const std::string &name, const std::string &title,
 MonitorElement *
 DQMStore::book2D(const char *name, TH2F *source)
 {
-  return book2D(pwd_, name, static_cast<TH2F *>(source->Clone(name)));
+  return book2D_(pwd_, name, static_cast<TH2F *>(source->Clone(name)));
 }
 
 /// Book 2D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2D(const std::string &name, TH2F *source)
 {
-  return book2D(pwd_, name, static_cast<TH2F *>(source->Clone(name.c_str())));
+  return book2D_(pwd_, name, static_cast<TH2F *>(source->Clone(name.c_str())));
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2S(const char *name, TH2S *source)
 {
-  return book2S(pwd_, name, static_cast<TH2S *>(source->Clone(name)));
+  return book2S_(pwd_, name, static_cast<TH2S *>(source->Clone(name)));
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2S(const std::string &name, TH2S *source)
 {
-  return book2S(pwd_, name, static_cast<TH2S *>(source->Clone(name.c_str())));
+  return book2S_(pwd_, name, static_cast<TH2S *>(source->Clone(name.c_str())));
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2DD(const char *name, TH2D *source)
 {
-  return book2DD(pwd_, name, static_cast<TH2D *>(source->Clone(name)));
+  return book2DD_(pwd_, name, static_cast<TH2D *>(source->Clone(name)));
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2DD(const std::string &name, TH2D *source)
 {
-  return book2DD(pwd_, name, static_cast<TH2D *>(source->Clone(name.c_str())));
+  return book2DD_(pwd_, name, static_cast<TH2D *>(source->Clone(name.c_str())));
 }
 
 // -------------------------------------------------------------------
 /// Book 3D histogram based on TH3F.
 MonitorElement *
-DQMStore::book3D(const std::string &dir, const std::string &name, TH3F *h)
+DQMStore::book3D_(const std::string &dir, const std::string &name, TH3F *h)
 {
-  return book(dir, name, "book3D", MonitorElement::DQM_KIND_TH3F, h, collate3D);
+  return book_(dir, name, "book3D", MonitorElement::DQM_KIND_TH3F, h, collate3D);
 }
 
 /// Book 3D histogram.
@@ -1322,7 +1322,7 @@ DQMStore::book3D(const char *name, const char *title,
                  int nchY, double lowY, double highY,
                  int nchZ, double lowZ, double highZ)
 {
-  return book3D(pwd_, name, new TH3F(name, title,
+  return book3D_(pwd_, name, new TH3F(name, title,
                                      nchX, lowX, highX,
                                      nchY, lowY, highY,
                                      nchZ, lowZ, highZ));
@@ -1335,7 +1335,7 @@ DQMStore::book3D(const std::string &name, const std::string &title,
                  int nchY, double lowY, double highY,
                  int nchZ, double lowZ, double highZ)
 {
-  return book3D(pwd_, name, new TH3F(name.c_str(), title.c_str(),
+  return book3D_(pwd_, name, new TH3F(name.c_str(), title.c_str(),
                                      nchX, lowX, highX,
                                      nchY, lowY, highY,
                                      nchZ, lowZ, highZ));
@@ -1345,24 +1345,24 @@ DQMStore::book3D(const std::string &name, const std::string &title,
 MonitorElement *
 DQMStore::book3D(const char *name, TH3F *source)
 {
-  return book3D(pwd_, name, static_cast<TH3F *>(source->Clone(name)));
+  return book3D_(pwd_, name, static_cast<TH3F *>(source->Clone(name)));
 }
 
 /// Book 3D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book3D(const std::string &name, TH3F *source)
 {
-  return book3D(pwd_, name, static_cast<TH3F *>(source->Clone(name.c_str())));
+  return book3D_(pwd_, name, static_cast<TH3F *>(source->Clone(name.c_str())));
 }
 
 // -------------------------------------------------------------------
 /// Book profile histogram based on TProfile.
 MonitorElement *
-DQMStore::bookProfile(const std::string &dir, const std::string &name, TProfile *h)
+DQMStore::bookProfile_(const std::string &dir, const std::string &name, TProfile *h)
 {
-  return book(dir, name, "bookProfile",
-              MonitorElement::DQM_KIND_TPROFILE,
-              h, collateProfile);
+  return book_(dir, name, "bookProfile",
+               MonitorElement::DQM_KIND_TPROFILE,
+               h, collateProfile);
 }
 
 /// Book profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1374,7 +1374,7 @@ DQMStore::bookProfile(const char *name, const char *title,
                       int /* nchY */, double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name, title,
+  return bookProfile_(pwd_, name, new TProfile(name, title,
                                               nchX, lowX, highX,
                                               lowY, highY,
                                               option));
@@ -1389,7 +1389,7 @@ DQMStore::bookProfile(const std::string &name, const std::string &title,
                       int /* nchY */, double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name.c_str(), title.c_str(),
+  return bookProfile_(pwd_, name, new TProfile(name.c_str(), title.c_str(),
                                               nchX, lowX, highX,
                                               lowY, highY,
                                               option));
@@ -1404,7 +1404,7 @@ DQMStore::bookProfile(const char *name, const char *title,
                       double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name, title,
+  return bookProfile_(pwd_, name, new TProfile(name, title,
                                               nchX, lowX, highX,
                                               lowY, highY,
                                               option));
@@ -1419,7 +1419,7 @@ DQMStore::bookProfile(const std::string &name, const std::string &title,
                       double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name.c_str(), title.c_str(),
+  return bookProfile_(pwd_, name, new TProfile(name.c_str(), title.c_str(),
                                               nchX, lowX, highX,
                                               lowY, highY,
                                               option));
@@ -1434,7 +1434,7 @@ DQMStore::bookProfile(const char *name, const char *title,
                       int /* nchY */, double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name, title,
+  return bookProfile_(pwd_, name, new TProfile(name, title,
                                               nchX, xbinsize,
                                               lowY, highY,
                                               option));
@@ -1449,7 +1449,7 @@ DQMStore::bookProfile(const std::string &name, const std::string &title,
                       int /* nchY */, double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name.c_str(), title.c_str(),
+  return bookProfile_(pwd_, name, new TProfile(name.c_str(), title.c_str(),
                                               nchX, xbinsize,
                                               lowY, highY,
                                               option));
@@ -1464,7 +1464,7 @@ DQMStore::bookProfile(const char *name, const char *title,
                       double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name, title,
+  return bookProfile_(pwd_, name, new TProfile(name, title,
                                               nchX, xbinsize,
                                               lowY, highY,
                                               option));
@@ -1479,7 +1479,7 @@ DQMStore::bookProfile(const std::string &name, const std::string &title,
                       double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name.c_str(), title.c_str(),
+  return bookProfile_(pwd_, name, new TProfile(name.c_str(), title.c_str(),
                                               nchX, xbinsize,
                                               lowY, highY,
                                               option));
@@ -1489,24 +1489,24 @@ DQMStore::bookProfile(const std::string &name, const std::string &title,
 MonitorElement *
 DQMStore::bookProfile(const char *name, TProfile *source)
 {
-  return bookProfile(pwd_, name, static_cast<TProfile *>(source->Clone(name)));
+  return bookProfile_(pwd_, name, static_cast<TProfile *>(source->Clone(name)));
 }
 
 /// Book TProfile by cloning an existing profile.
 MonitorElement *
 DQMStore::bookProfile(const std::string &name, TProfile *source)
 {
-  return bookProfile(pwd_, name, static_cast<TProfile *>(source->Clone(name.c_str())));
+  return bookProfile_(pwd_, name, static_cast<TProfile *>(source->Clone(name.c_str())));
 }
 
 // -------------------------------------------------------------------
 /// Book 2D profile histogram based on TProfile2D.
 MonitorElement *
-DQMStore::bookProfile2D(const std::string &dir, const std::string &name, TProfile2D *h)
+DQMStore::bookProfile2D_(const std::string &dir, const std::string &name, TProfile2D *h)
 {
-  return book(dir, name, "bookProfile2D",
-              MonitorElement::DQM_KIND_TPROFILE2D,
-              h, collateProfile2D);
+  return book_(dir, name, "bookProfile2D",
+               MonitorElement::DQM_KIND_TPROFILE2D,
+               h, collateProfile2D);
 }
 
 /// Book 2-D profile.  Option is one of: " ", "s" (default), "i", "G"
@@ -1519,7 +1519,7 @@ DQMStore::bookProfile2D(const char *name, const char *title,
                         int /* nchZ */, double lowZ, double highZ,
                         const char *option /* = "s" */)
 {
-  return bookProfile2D(pwd_, name, new TProfile2D(name, title,
+  return bookProfile2D_(pwd_, name, new TProfile2D(name, title,
                                                   nchX, lowX, highX,
                                                   nchY, lowY, highY,
                                                   lowZ, highZ,
@@ -1536,7 +1536,7 @@ DQMStore::bookProfile2D(const std::string &name, const std::string &title,
                         int /* nchZ */, double lowZ, double highZ,
                         const char *option /* = "s" */)
 {
-  return bookProfile2D(pwd_, name, new TProfile2D(name.c_str(), title.c_str(),
+  return bookProfile2D_(pwd_, name, new TProfile2D(name.c_str(), title.c_str(),
                                                   nchX, lowX, highX,
                                                   nchY, lowY, highY,
                                                   lowZ, highZ,
@@ -1553,7 +1553,7 @@ DQMStore::bookProfile2D(const char *name, const char *title,
                         double lowZ, double highZ,
                         const char *option /* = "s" */)
 {
-  return bookProfile2D(pwd_, name, new TProfile2D(name, title,
+  return bookProfile2D_(pwd_, name, new TProfile2D(name, title,
                                                   nchX, lowX, highX,
                                                   nchY, lowY, highY,
                                                   lowZ, highZ,
@@ -1570,7 +1570,7 @@ DQMStore::bookProfile2D(const std::string &name, const std::string &title,
                         double lowZ, double highZ,
                         const char *option /* = "s" */)
 {
-  return bookProfile2D(pwd_, name, new TProfile2D(name.c_str(), title.c_str(),
+  return bookProfile2D_(pwd_, name, new TProfile2D(name.c_str(), title.c_str(),
                                                   nchX, lowX, highX,
                                                   nchY, lowY, highY,
                                                   lowZ, highZ,
@@ -1581,14 +1581,14 @@ DQMStore::bookProfile2D(const std::string &name, const std::string &title,
 MonitorElement *
 DQMStore::bookProfile2D(const char *name, TProfile2D *source)
 {
-  return bookProfile2D(pwd_, name, static_cast<TProfile2D *>(source->Clone(name)));
+  return bookProfile2D_(pwd_, name, static_cast<TProfile2D *>(source->Clone(name)));
 }
 
 /// Book TProfile2D by cloning an existing profile.
 MonitorElement *
 DQMStore::bookProfile2D(const std::string &name, TProfile2D *source)
 {
-  return bookProfile2D(pwd_, name, static_cast<TProfile2D *>(source->Clone(name.c_str())));
+  return bookProfile2D_(pwd_, name, static_cast<TProfile2D *>(source->Clone(name.c_str())));
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -2238,7 +2238,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = bookProfile(dir, h->GetName(), (TProfile *) h->Clone());
+      me = bookProfile_(dir, h->GetName(), (TProfile *) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2249,7 +2249,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = bookProfile2D(dir, h->GetName(), (TProfile2D *) h->Clone());
+      me = bookProfile2D_(dir, h->GetName(), (TProfile2D *) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2260,7 +2260,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book1D(dir, h->GetName(), (TH1F *) h->Clone());
+      me = book1D_(dir, h->GetName(), (TH1F *) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2271,7 +2271,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book1S(dir, h->GetName(), (TH1S *) h->Clone());
+      me = book1S_(dir, h->GetName(), (TH1S *) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2282,7 +2282,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book1DD(dir, h->GetName(), (TH1D *) h->Clone());
+      me = book1DD_(dir, h->GetName(), (TH1D *) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2293,7 +2293,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book2D(dir, h->GetName(), (TH2F *) h->Clone());
+      me = book2D_(dir, h->GetName(), (TH2F *) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2304,7 +2304,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book2S(dir, h->GetName(), (TH2S *) h->Clone());
+      me = book2S_(dir, h->GetName(), (TH2S *) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2315,7 +2315,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book2DD(dir, h->GetName(), (TH2D *) h->Clone());
+      me = book2DD_(dir, h->GetName(), (TH2D *) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2326,7 +2326,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book3D(dir, h->GetName(), (TH3F *) h->Clone());
+      me = book3D_(dir, h->GetName(), (TH3F *) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2368,7 +2368,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
       MonitorElement *me = findObject(dir, label);
       if (! me || overwrite)
       {
-        if (! me) me = bookInt(dir, label);
+        if (! me) me = bookInt_(dir, label);
         me->Fill(atoll(value.c_str()));
       }
     }
@@ -2377,7 +2377,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
       MonitorElement *me = findObject(dir, label);
       if (! me || overwrite)
       {
-        if (! me) me = bookFloat(dir, label);
+        if (! me) me = bookFloat_(dir, label);
         me->Fill(atof(value.c_str()));
       }
     }
@@ -2385,7 +2385,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
     {
       MonitorElement *me = findObject(dir, label);
       if (! me)
-        me = bookString(dir, label, value);
+        me = bookString_(dir, label, value);
       else if (overwrite)
         me->Fill(value);
     }


### PR DESCRIPTION
Follow up of the work in #21652 .

Rename private `book...` methods to `book..._` to reduce the ambiguity of the public vs private interface.

Update the `ConcurrentMonitorElement` class:
  - fix the `lock_guard` used in the move constructor
  - use a `tbb:spin_mutex` in place of a `std::mutex`

On a microbenchmark, when guarding a small code section `tbb:spin_mutex` is twice as fast as `std::mutex` if there is no contention, and even faster as the number of threads increase.