### PR TITLE
HBHE = Extra SOI fix

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/PedestalSub.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PedestalSub.h
@@ -13,9 +13,9 @@ class PedestalSub
   
   void init(int runCond, float threshold, float quantile);
   
-  void calculate(const std::vector<double> & inputCharge, const std::vector<double> & inputPedestal, std::vector<double> & corrCharge) const;
+  void calculate(const std::vector<double> & inputCharge, const std::vector<double> & inputPedestal, const std::vector<double> & inputNoise, std::vector<double> & corrCharge, int soi, int nSample) const;
   
-  double getCorrection(const std::vector<double> & inputCharge, const std::vector<double> & inputPedestal) const;
+  double getCorrection(const std::vector<double> & inputCharge, const std::vector<double> & inputPedestal, const std::vector<double> & inputNoise, int soi, int nSample) const;
 
   
  private:

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
@@ -99,6 +99,7 @@ void HcalDeterministicFit::phase1Apply(const HBHEChannelInfo& channelData,
   std::vector<double> corrCharge;
   std::vector<double> inputCharge;
   std::vector<double> inputPedestal;
+  std::vector<double> inputNoise;
   double gainCorr = 0;
   double respCorr = 0;
 
@@ -106,15 +107,17 @@ void HcalDeterministicFit::phase1Apply(const HBHEChannelInfo& channelData,
 
     double charge = channelData.tsRawCharge(ip);
     double ped = channelData.tsPedestal(ip); 
+    double noise = channelData.tsPedestalWidth(ip);
     double gain = channelData.tsGain(ip);
 
     gainCorr = gain;
     inputCharge.push_back(charge);
     inputPedestal.push_back(ped);
+    inputNoise.push_back(noise);
 
   }
 
-  fPedestalSubFxn_.calculate(inputCharge, inputPedestal, corrCharge);
+  fPedestalSubFxn_.calculate(inputCharge, inputPedestal, inputNoise, corrCharge, soi, channelData.nSamples());
 
   const HcalDetId& cell = channelData.id();
 

--- a/RecoLocalCalo/HcalRecAlgos/src/PedestalSub.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PedestalSub.cc
@@ -30,12 +30,12 @@ double PedestalSub::getCorrection(const std::vector<double> & inputCharge, const
   double baseline=0;
 
     for (auto i=0; i<nTS; i++) {
-      if (i==soi||i==soi+1) continue;
+      if (i==soi || i==(soi+1)) continue;
       if ( (inputCharge[i]-inputPedestal[i])<3*inputNoise[i]) {
 	baseline+=(inputCharge[i]-inputPedestal[i]);
       }
       else {
-	baseline+=fThreshold;
+	baseline+=3*inputNoise[i];
       }
     }
     baseline/=(nTS-2);

--- a/RecoLocalCalo/HcalRecAlgos/src/PedestalSub.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PedestalSub.cc
@@ -31,7 +31,7 @@ double PedestalSub::getCorrection(const std::vector<double> & inputCharge, const
 
     for (auto i=0; i<nTS; i++) {
       if (i==soi||i==soi+1) continue;
-      if ( (inputCharge[i]-inputPedestal[i])<fThreshold) {
+      if ( (inputCharge[i]-inputPedestal[i])<3*inputNoise[i]) {
 	baseline+=(inputCharge[i]-inputPedestal[i]);
       }
       else {

--- a/RecoLocalCalo/HcalRecAlgos/src/PedestalSub.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PedestalSub.cc
@@ -17,20 +17,20 @@ void PedestalSub::init(int runCond=0, float threshold=0.0, float quantile=0.0) {
   fCondition=runCond;
 }
 
-void PedestalSub::calculate(const std::vector<double> & inputCharge, const std::vector<double> & inputPedestal, std::vector<double> & corrCharge) const {
+void PedestalSub::calculate(const std::vector<double> & inputCharge, const std::vector<double> & inputPedestal, const std::vector<double> & inputNoise, std::vector<double> & corrCharge, int soi, int nTS) const {
 
-  double bseCorr=PedestalSub::getCorrection(inputCharge, inputPedestal);
-  for (auto i=0; i<10; i++) {
-      corrCharge.push_back(inputCharge[i]-inputPedestal[i]-bseCorr);
+  double bseCorr=PedestalSub::getCorrection(inputCharge, inputPedestal, inputNoise, soi, nTS);
+  for (auto i=0; i<nTS; i++) {
+    corrCharge.push_back(inputCharge[i]-inputPedestal[i]-bseCorr);
   }
 }
 
-double PedestalSub::getCorrection(const std::vector<double> & inputCharge, const std::vector<double> & inputPedestal) const {
+double PedestalSub::getCorrection(const std::vector<double> & inputCharge, const std::vector<double> & inputPedestal, const std::vector<double> & inputNoise, int soi, int nTS) const {
 
   double baseline=0;
 
-    for (auto i=0; i<10; i++) {
-      if (i==4||i==5) continue;
+    for (auto i=0; i<nTS; i++) {
+      if (i==soi||i==soi+1) continue;
       if ( (inputCharge[i]-inputPedestal[i])<fThreshold) {
 	baseline+=(inputCharge[i]-inputPedestal[i]);
       }
@@ -38,7 +38,7 @@ double PedestalSub::getCorrection(const std::vector<double> & inputCharge, const
 	baseline+=fThreshold;
       }
     }
-    baseline/=8;
+    baseline/=(nTS-2);
   return baseline;
   
 } 

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -90,7 +90,7 @@ int PulseShapeFitOOTPileupCorrection::pulseShapeFit(const double * energyArr, co
    double tsMAX=0;
    double tmpx[HcalConst::maxSamples], tmpy[HcalConst::maxSamples], tmperry[HcalConst::maxSamples],tmperry2[HcalConst::maxSamples],tmpslew[HcalConst::maxSamples];
    double tstrig = 0; // in fC
-   for(int i=0;i<HcalConst::maxSamples;++i){
+   for(unsigned int i=0;i<HcalConst::maxSamples;++i){
       tmpx[i]=i;
       tmpy[i]=energyArr[i]-pedenArr[i];
       //Add Time Slew !!! does this need to be pedestal subtracted
@@ -104,7 +104,7 @@ int PulseShapeFitOOTPileupCorrection::pulseShapeFit(const double * energyArr, co
       tmperry [i]=sqrt(tmperry2[i]);
 
       if(std::abs(energyArr[i])>tsMAX) tsMAX=std::abs(tmpy[i]);
-      if( i ==4 || i ==5 ){
+      if( i ==soi || i ==(soi+1) ){
          tstrig += chargeArr[i] - pedArr[i];
       }
    }


### PR DESCRIPTION
removed more hard coded SOI in view of the TS10->TS8
discussion triggered by #21651

commit 57507f2 take the threshold from the GT instead of of 2.7 from the python config.
https://github.com/cms-sw/cmssw/blob/master/RecoLocalCalo/HcalRecProducers/python/HBHEMethod3Parameters_cfi.py#L6

i.e. 2.7 was left over from 2015 (3*HPD noise)