### PR TITLE
Fixing lack of virtualness for some GsfElectron methods : 94X 

### DIFF
--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -187,7 +187,7 @@ class GsfElectron : public RecoCandidate
     float ctfGsfOverlap() const { return core()->ctfGsfOverlap() ; }
     bool ecalDrivenSeed() const { return core()->ecalDrivenSeed() ; }
     bool trackerDrivenSeed() const { return core()->trackerDrivenSeed() ; }
-    SuperClusterRef parentSuperCluster() const { return core()->parentSuperCluster() ; }
+    virtual SuperClusterRef parentSuperCluster() const { return core()->parentSuperCluster() ; }
 
     // backward compatibility
     struct ClosestCtfTrack
@@ -198,8 +198,8 @@ class GsfElectron : public RecoCandidate
       ClosestCtfTrack( TrackRef track, float sh ) : ctfTrack(track), shFracInnerHits(sh) {}
      } ;
     float shFracInnerHits() const { return core()->ctfGsfOverlap() ; }
-    TrackRef closestCtfTrackRef() const { return core()->ctfTrack() ; }
-    ClosestCtfTrack closestCtfTrack() const { return ClosestCtfTrack(core()->ctfTrack(),core()->ctfGsfOverlap()) ; }
+    virtual TrackRef closestCtfTrackRef() const { return core()->ctfTrack() ; }
+    virtual ClosestCtfTrack closestCtfTrack() const { return ClosestCtfTrack(core()->ctfTrack(),core()->ctfGsfOverlap()) ; }
 
   private:
 

--- a/DataFormats/PatCandidates/interface/Electron.h
+++ b/DataFormats/PatCandidates/interface/Electron.h
@@ -77,11 +77,11 @@ namespace pat {
       /// override the reco::GsfElectron::superCluster method, to access the internal storage of the supercluster
       reco::SuperClusterRef superCluster() const;
       /// override the reco::GsfElectron::pflowSuperCluster method, to access the internal storage of the pflowSuperCluster
-      reco::SuperClusterRef parentSuperCluster() const;
+      reco::SuperClusterRef parentSuperCluster() const override;
       /// returns nothing. Use either gsfTrack or closestCtfTrack
       reco::TrackRef track() const;
       /// override the reco::GsfElectron::closestCtfTrackRef method, to access the internal storage of the track
-      reco::TrackRef closestCtfTrackRef() const;
+      reco::TrackRef closestCtfTrackRef() const override;
       /// direct access to the seed cluster
       reco::CaloClusterPtr seed() const; 
 


### PR DESCRIPTION
This is a bug fix backport https://github.com/cms-sw/cmssw/pull/21708

which would be nice so we can update our code to take advantage of this in 94X and 10X code. 