### PR TITLE
DTTrig::createTUs: print debugs only under debug

### DIFF
--- a/L1Trigger/DTTrigger/src/DTTrig.cc
+++ b/L1Trigger/DTTrigger/src/DTTrig.cc
@@ -84,7 +84,9 @@ DTTrig::createTUs(const edm::EventSetup& iSetup ){
       DTSectCollId scid(iwh,ise);
       SC_iterator it =  _cache1.find(scid);
       if ( it != _cache1.end()) {
-	std::cout << "DTTrig::createTUs: Sector Collector unit already exists"<<std::endl;
+      	if(_debug){
+	  std::cout << "DTTrig::createTUs: Sector Collector unit already exists"<<std::endl;
+	}
 	continue;
       }    
       DTSectColl* sc;


### PR DESCRIPTION
this will remove a flood of ``` DTTrig::createTUs: Sector Collector unit already exists ``` cout messages at run transitions. 


Notably, the implementation of DTTrig::createTUs appears to be incorrect if the underlying conditions actually change: once a cache is created there is no check that conditions have changed to remake the downstream objects.