### PR TITLE
recreate HcalDDD{Rec,Sim}Constants and HcaluLUTTPGCoder in their ESProducers

### DIFF
--- a/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
+++ b/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
@@ -128,7 +128,7 @@ HcalTPGCoderULUT::~HcalTPGCoderULUT() {
 HcalTPGCoderULUT::ReturnType
 HcalTPGCoderULUT::produce(const HcalTPGRecord& iRecord)
 {
-  if (theCoder_==nullptr) {
+  if (theCoder_==nullptr || (read_Ascii_ || read_XML_)) {// !(read_Ascii_ || read_XML_) goes via dbRecordCallback
     edm::ESHandle<HcalTopology> htopo;
     iRecord.getRecord<HcalRecNumberingRecord>().get(htopo);
     const HcalTopology* topo=&(*htopo);
@@ -146,9 +146,7 @@ void HcalTPGCoderULUT::dbRecordCallback(const HcalDbRecord& theRec) {
   theRec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  if (theCoder_==nullptr) {
-    buildCoder(topo);
-  }
+  buildCoder(topo);
 
   theCoder_->update(*conditions);
 

--- a/Geometry/HcalCommonData/plugins/HcalDDDRecConstantsESMoudle.cc
+++ b/Geometry/HcalCommonData/plugins/HcalDDDRecConstantsESMoudle.cc
@@ -46,11 +46,9 @@ public:
 
   ReturnType produce(const HcalRecNumberingRecord&);
 
-private:
-  HcalDDDRecConstants* hcalDDDConst_;
 };
 
-HcalDDDRecConstantsESModule::HcalDDDRecConstantsESModule(const edm::ParameterSet& iConfig) : hcalDDDConst_(nullptr) {
+HcalDDDRecConstantsESModule::HcalDDDRecConstantsESModule(const edm::ParameterSet& iConfig) {
 #ifdef EDM_ML_DEBUG
   std::cout <<"constructing HcalDDDRecConstantsESModule" << std::endl;
 #endif
@@ -70,14 +68,12 @@ HcalDDDRecConstantsESModule::produce(const HcalRecNumberingRecord& iRecord) {
 #ifdef EDM_ML_DEBUG
   std::cout << "in HcalDDDRecConstantsESModule::produce" << std::endl;
 #endif
-  if (hcalDDDConst_ == nullptr) {
-    edm::ESHandle<HcalParameters>         parHandle;
-    iRecord.getRecord<HcalParametersRcd>().get(parHandle);
-    edm::ESHandle<HcalDDDSimConstants>    hdc;
-    iRecord.getRecord<HcalSimNumberingRecord>().get(hdc);
-    hcalDDDConst_ = new HcalDDDRecConstants(&(*parHandle), *hdc);
-  }
-  return HcalDDDRecConstantsESModule::ReturnType(hcalDDDConst_) ;
+  edm::ESHandle<HcalParameters>         parHandle;
+  iRecord.getRecord<HcalParametersRcd>().get(parHandle);
+  edm::ESHandle<HcalDDDSimConstants>    hdc;
+  iRecord.getRecord<HcalSimNumberingRecord>().get(hdc);
+
+  return HcalDDDRecConstantsESModule::ReturnType(new HcalDDDRecConstants(&(*parHandle), *hdc)) ;
 }
 
 //define this as a plug-in

--- a/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
+++ b/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
@@ -83,9 +83,6 @@ void HcalDDDSimConstantsESModule::initializeHcalDDDSimConstants(const HcalParame
 #ifdef EDM_ML_DEBUG
   std::cout << "in HcalDDDSimConstantsESModule::initializeHcalDDDSimConstants" << std::endl;
 #endif
-  if ( hcalDDDConst_ != nullptr ) {
-    delete hcalDDDConst_;
-  }
   const HcalParameters* hpar = &(*parHandle);
 #ifdef EDM_ML_DEBUG
   std::cout << "about to make my new hcalDDDConst_ with " << hpar << std::endl;


### PR DESCRIPTION
this came up in tests of running on two well-separated 2017 runs (297557,305064) in one cmsRun.
The produced data should not be cached in ESProducers because it is not owned by the producers
and a repeated call means a new ES product is needed, while the earlier created one was destroyed by the framework.
