### PR TITLE
allow to set ES pointers more than once in ecalDQMonitor

### DIFF
--- a/DQM/EcalCommon/src/EcalDQMCommonUtils.cc
+++ b/DQM/EcalCommon/src/EcalDQMCommonUtils.cc
@@ -486,7 +486,6 @@ namespace ecaldqm
   setElectronicsMap(EcalElectronicsMapping const* _map)
   {
     std::lock_guard<std::mutex> lock(mapMutex);
-    if(electronicsMap) return;
     electronicsMap = _map;
   }
 
@@ -510,7 +509,6 @@ namespace ecaldqm
   setTrigTowerMap(EcalTrigTowerConstituentsMap const* _map)
   {
     std::lock_guard<std::mutex> lock(mapMutex);
-    if(trigtowerMap) return;
     trigtowerMap = _map;
   }
 
@@ -534,7 +532,6 @@ namespace ecaldqm
   setGeometry(CaloGeometry const* _geom)
   {
     std::lock_guard<std::mutex> lock(mapMutex);
-    if(geometry) return;
     geometry = _geom;
   }
 
@@ -558,7 +555,6 @@ namespace ecaldqm
   setTopology(CaloTopology const* _geom)
   {
     std::lock_guard<std::mutex> lock(mapMutex);
-    if(topology) return;
     topology = _geom;
   }
 }

--- a/DQM/EcalCommon/src/EcalDQMonitor.cc
+++ b/DQM/EcalCommon/src/EcalDQMonitor.cc
@@ -68,32 +68,26 @@ namespace ecaldqm
   void
   EcalDQMonitor::ecaldqmGetSetupObjects(edm::EventSetup const& _es)
   {
-    if(!checkElectronicsMap(false)){
-      // set up electronicsMap in EcalDQMCommonUtils
-      edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
-      _es.get<EcalMappingRcd>().get(elecMapHandle);
-      setElectronicsMap(elecMapHandle.product());
-    }
+    //NB: a more minimal solution may rely on ESWatchers
+    //    but then here the cost is rather minimal
+    // set up electronicsMap in EcalDQMCommonUtils
+    edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
+    _es.get<EcalMappingRcd>().get(elecMapHandle);
+    setElectronicsMap(elecMapHandle.product());
 
-    if(!checkTrigTowerMap(false)){
-      // set up trigTowerMap in EcalDQMCommonUtils
-      edm::ESHandle<EcalTrigTowerConstituentsMap> ttMapHandle;
-      _es.get<IdealGeometryRecord>().get(ttMapHandle);
-      setTrigTowerMap(ttMapHandle.product());
-    }
+    // set up trigTowerMap in EcalDQMCommonUtils
+    edm::ESHandle<EcalTrigTowerConstituentsMap> ttMapHandle;
+    _es.get<IdealGeometryRecord>().get(ttMapHandle);
+    setTrigTowerMap(ttMapHandle.product());
 
-    if(!checkGeometry(false)){
-      edm::ESHandle<CaloGeometry> geomHandle;
-      _es.get<CaloGeometryRecord>().get(geomHandle);
-      setGeometry(geomHandle.product());
-    }
+    edm::ESHandle<CaloGeometry> geomHandle;
+    _es.get<CaloGeometryRecord>().get(geomHandle);
+    setGeometry(geomHandle.product());
 
-    if(!checkTopology(false)){
-      // set up trigTowerMap in EcalDQMCommonUtils
-      edm::ESHandle<CaloTopology> topoHandle;
-      _es.get<CaloTopologyRecord>().get(topoHandle);
-      setTopology(topoHandle.product());
-    }
+    // set up trigTowerMap in EcalDQMCommonUtils
+    edm::ESHandle<CaloTopology> topoHandle;
+    _es.get<CaloTopologyRecord>().get(topoHandle);
+    setTopology(topoHandle.product());
   }
 
   void


### PR DESCRIPTION
this came up in tests of running on two well-separated 2017 runs (297557,305064) in one cmsRun job.
The current implementation does not allow to make a change to cached pointers to ES products.

The code is still not very safe because it's using globals to keep track of cached ES data.
@Dr15Jones I thought that this type of code was purged already (see e.g. 
https://github.com/cms-sw/cmssw/blob/master/DQM/EcalCommon/src/EcalDQMCommonUtils.cc#L454-L467
)