### PR TITLE
Implement an edm::get() free function.

### DIFF
--- a/DQM/HLTEvF/plugins/TriggerBxMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerBxMonitor.cc
@@ -33,26 +33,6 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
-// helper functions
-template <typename T>
-static
-const T & get(const edm::Event & event, const edm::EDGetTokenT<T> & token) {
-  edm::Handle<T> handle;
-  event.getByToken(token, handle);
-  if (not handle.isValid())
-    throw * handle.whyFailed();
-  return * handle.product();
-}
-
-template <typename R, typename T>
-static
-const T & get(const edm::EventSetup & setup) {
-  edm::ESHandle<T> handle;
-  setup.get<R>().get(handle);
-  return * handle.product();
-}
-
-
 class TriggerBxMonitor : public DQMEDAnalyzer {
 public:
   explicit TriggerBxMonitor(edm::ParameterSet const &);
@@ -171,7 +151,7 @@ void TriggerBxMonitor::dqmBeginRun(edm::Run const & run, edm::EventSetup const &
   }
 
   // cache the L1 trigger menu
-  m_l1tMenu = & get<L1TUtmTriggerMenuRcd, L1TUtmTriggerMenu>(setup);
+  m_l1tMenu = & edm::get<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>(setup);
   if (m_l1tMenu) {
     if (m_make_1d_plots) {
       m_l1t_bx.clear();
@@ -295,7 +275,7 @@ void TriggerBxMonitor::analyze(edm::Event const & event, edm::EventSetup const &
 
   // monitor the bx distribution for the L1 triggers
   if (m_l1tMenu) {
-    auto const & bxvector = get<GlobalAlgBlkBxCollection>(event, m_l1t_results);
+    auto const & bxvector = edm::get(event, m_l1t_results);
     if (not bxvector.isEmpty(0)) {
       auto const & results = bxvector.at(0, 0);
       for (unsigned int i = 0; i < GlobalAlgBlk::maxPhysicsTriggers; ++i)
@@ -311,7 +291,7 @@ void TriggerBxMonitor::analyze(edm::Event const & event, edm::EventSetup const &
 
   // monitor the bx distribution for the HLT triggers
   if (m_hltConfig.inited()) {
-    auto const & hltResults = get<edm::TriggerResults>(event, m_hlt_results);
+    auto const & hltResults = edm::get(event, m_hlt_results);
     for (unsigned int i = 0; i < hltResults.size(); ++i) {
       if (hltResults.at(i).accept()) {
         if (m_make_1d_plots and m_hlt_bx.at(i))

--- a/DQM/HLTEvF/plugins/TriggerBxVsOrbitMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerBxVsOrbitMonitor.cc
@@ -2,11 +2,6 @@
 #include <string>
 #include <cstring>
 
-// boost headers
-#include <boost/regex.hpp>
-#include <boost/format.hpp>
-#include <boost/lexical_cast.hpp>
-
 // Root headers
 #include <TH1F.h>
 
@@ -33,26 +28,6 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
-
-// helper functions
-template <typename T>
-static
-const T & get(const edm::Event & event, const edm::EDGetTokenT<T> & token) {
-  edm::Handle<T> handle;
-  event.getByToken(token, handle);
-  if (not handle.isValid())
-    throw * handle.whyFailed();
-  return * handle.product();
-}
-
-template <typename R, typename T>
-static
-const T & get(const edm::EventSetup & setup) {
-  edm::ESHandle<T> handle;
-  setup.get<R>().get(handle);
-  return * handle.product();
-}
-
 
 class TriggerBxVsOrbitMonitor : public DQMEDAnalyzer {
 public:
@@ -202,7 +177,6 @@ void TriggerBxVsOrbitMonitor::analyze(edm::Event const & event, edm::EventSetup 
   int iLS = ls-m_minLS;
   if (iLS >= 0 && iLS < int(m_orbit_bx_all_byLS.size()))
     m_orbit_bx_all_byLS.at(iLS)->Fill(bx,orbit_in_ls);
- 
 
   // monitor the bx distribution for the TCDS trigger types
   size_t size = sizeof(s_tcds_trigger_types) / sizeof(const char *);

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -611,5 +611,34 @@ namespace edm {
     Handle<View<ELEMENT> > h(&*newview, bh.provenance());
     result.swap(h);
   }
+
+  // Free functions to retrieve a collection from the Event.
+  // Will throw an exception if the collection is not available.
+
+  template <typename T>
+  T const& get(Event const& event, InputTag const& tag) {
+    Handle<T> handle;
+    event.getByLabel(tag, handle);
+    // throw if the handle is not valid
+    return * handle.product();
+  }
+
+  template <typename T>
+  T const& get(Event const& event, EDGetToken const& token) {
+    Handle<T> handle;
+    event.getByToken(token, handle);
+    // throw if the handle is not valid
+    return * handle.product();
+  }
+
+  template <typename T>
+  T const& get(Event const& event, EDGetTokenT<T> const& token) {
+    Handle<T> handle;
+    event.getByToken(token, handle);
+    // throw if the handle is not valid
+    return * handle.product();
+  }
+
 }
-#endif
+
+#endif // FWCore_Framework_Event_h

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -19,15 +19,17 @@
 //
 
 // system include files
+#include <cassert>
 #include <map>
 #include <string>
-#include <vector>
-#include <cassert>
 #include <type_traits>
+#include <vector>
+
 // user include files
-#include "FWCore/Framework/interface/IOVSyncValue.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/HCMethods.h"
+#include "FWCore/Framework/interface/IOVSyncValue.h"
 #include "FWCore/Framework/interface/eventSetupGetImplementation.h"
 
 // forward declarations
@@ -41,11 +43,12 @@ namespace edm {
       template<class T> struct data_default_record_trait;
       class EventSetupKnownRecordsSupplier;
    }
-class EventSetup
-{
-   ///Only EventSetupProvider allowed to create a EventSetup
-   friend class eventsetup::EventSetupProvider;
-   public:
+
+  class EventSetup
+  {
+    ///Only EventSetupProvider allowed to create a EventSetup
+    friend class eventsetup::EventSetupProvider;
+    public:
       virtual ~EventSetup();
 
       // ---------- const member functions ---------------------
@@ -115,7 +118,7 @@ class EventSetup
          getAvoidCompilerBug(const T*& iValue) const {
             iValue = &(get<T>());
          }
-   protected:
+    protected:
       //Only called by EventSetupProvider
       void setIOVSyncValue(const IOVSyncValue&);
       void setKnownRecordsSupplier(eventsetup::EventSetupKnownRecordsSupplier const* iSupplier) {
@@ -126,7 +129,7 @@ class EventSetup
       
       void clear();
       
-   private:
+    private:
       EventSetup();
       
       EventSetup(EventSetup const&) = delete; // stop default
@@ -142,7 +145,47 @@ class EventSetup
       //NOTE: the records are not owned
       std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecord const *> recordMap_;
       eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;
-};
+  };
+
+  // Free functions to retrieve an object from the EventSetup.
+  // Will throw an exception if the record or  object are not found.
+
+  template <typename R, typename T>
+  T const& get(EventSetup const& setup) {
+    ESHandle<T> handle;
+    // throw if the record is not available
+    setup.get<R>().get(handle);
+    // throw if the handle is not valid
+    return * handle.product();
+  }
+
+  template <typename R, typename T>
+  T const& get(EventSetup const& setup, const char* label) {
+    ESHandle<T> handle;
+    // throw if the record is not available
+    setup.get<R>().get(label, handle);
+    // throw if the handle is not valid
+    return * handle.product();
+  }
+
+  template <typename R, typename T>
+  T const& get(EventSetup const& setup, std::string const& label) {
+    ESHandle<T> handle;
+    // throw if the record is not available
+    setup.get<R>().get(label, handle);
+    // throw if the handle is not valid
+    return * handle.product();
+  }
+
+  template <typename R, typename T>
+  T const& get(EventSetup const& setup, ESInputTag const& tag) {
+    ESHandle<T> handle;
+    // throw if the record is not available
+    setup.get<R>().get(tag, handle);
+    // throw if the handle is not valid
+    return * handle.product();
+  }
 
 }
-#endif
+
+#endif // FWCore_Framework_EventSetup_h

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -159,29 +159,11 @@ namespace edm {
     return * handle.product();
   }
 
-  template <typename R, typename T>
-  T const& get(EventSetup const& setup, const char* label) {
+  template <typename R, typename T, typename L>
+  T const& get(EventSetup const& setup, L && label) {
     ESHandle<T> handle;
     // throw if the record is not available
-    setup.get<R>().get(label, handle);
-    // throw if the handle is not valid
-    return * handle.product();
-  }
-
-  template <typename R, typename T>
-  T const& get(EventSetup const& setup, std::string const& label) {
-    ESHandle<T> handle;
-    // throw if the record is not available
-    setup.get<R>().get(label, handle);
-    // throw if the handle is not valid
-    return * handle.product();
-  }
-
-  template <typename R, typename T>
-  T const& get(EventSetup const& setup, ESInputTag const& tag) {
-    ESHandle<T> handle;
-    // throw if the record is not available
-    setup.get<R>().get(tag, handle);
+    setup.get<R>().get(std::forward(label), handle);
     // throw if the handle is not valid
     return * handle.product();
   }

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -150,7 +150,7 @@ namespace edm {
   // Free functions to retrieve an object from the EventSetup.
   // Will throw an exception if the record or  object are not found.
 
-  template <typename R, typename T>
+  template <typename T, typename R = typename eventsetup::data_default_record_trait<typename T::value_type>::type>
   T const& get(EventSetup const& setup) {
     ESHandle<T> handle;
     // throw if the record is not available
@@ -159,7 +159,7 @@ namespace edm {
     return * handle.product();
   }
 
-  template <typename R, typename T, typename L>
+  template <typename T, typename R = typename eventsetup::data_default_record_trait<typename T::value_type>::type, typename L>
   T const& get(EventSetup const& setup, L && label) {
     ESHandle<T> handle;
     // throw if the record is not available

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -311,5 +311,33 @@ namespace edm {
     return provRecorder_.getManyByType(results, moduleCallingContext_);
   }
 
+  // Free functions to retrieve a collection from the LuminosityBlock.
+  // Will throw an exception if the collection is not available.
+
+  template <typename T>
+  T const& get(LuminosityBlock const& event, InputTag const& tag) {
+    Handle<T> handle;
+    event.getByLabel(tag, handle);
+    // throw if the handle is not valid
+    return * handle.product();
+  }
+
+  template <typename T>
+  T const& get(LuminosityBlock const& event, EDGetToken const& token) {
+    Handle<T> handle;
+    event.getByToken(token, handle);
+    // throw if the handle is not valid
+    return * handle.product();
+  }
+
+  template <typename T>
+  T const& get(LuminosityBlock const& event, EDGetTokenT<T> const& token) {
+    Handle<T> handle;
+    event.getByToken(token, handle);
+    // throw if the handle is not valid
+    return * handle.product();
+  }
+
 }
-#endif
+
+#endif // FWCore_Framework_LuminosityBlock_h

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -321,5 +321,33 @@ namespace edm {
     return provRecorder_.getManyByType(results, moduleCallingContext_);
   }
 
+  // Free functions to retrieve a collection from the Run.
+  // Will throw an exception if the collection is not available.
+
+  template <typename T>
+  T const& get(Run const& event, InputTag const& tag) {
+    Handle<T> handle;
+    event.getByLabel(tag, handle);
+    // throw if the handle is not valid
+    return * handle.product();
+  }
+
+  template <typename T>
+  T const& get(Run const& event, EDGetToken const& token) {
+    Handle<T> handle;
+    event.getByToken(token, handle);
+    // throw if the handle is not valid
+    return * handle.product();
+  }
+
+  template <typename T>
+  T const& get(Run const& event, EDGetTokenT<T> const& token) {
+    Handle<T> handle;
+    event.getByToken(token, handle);
+    // throw if the handle is not valid
+    return * handle.product();
+  }
+
 }
-#endif
+
+#endif // FWCore_Framework_Run_h

--- a/HLTrigger/HLTcore/src/TriggerExpressionData.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionData.cc
@@ -15,28 +15,6 @@
 
 namespace triggerExpression {
 
-template <typename T>
-static 
-const T * get(const edm::Event & event, const edm::EDGetTokenT<T> & token) {
-  edm::Handle<T> handle;
-  event.getByToken(token, handle);
-  if (not handle.isValid()) {
-    auto const & error = handle.whyFailed();
-    edm::LogWarning(error->category()) << error->what();
-    return nullptr;
-  } else {
-    return handle.product();
-  }
-}
-
-template <typename R, typename T>
-static
-const T * get(const edm::EventSetup & setup) {
-  edm::ESHandle<T> handle;
-  setup.get<R>().get(handle);
-  return handle.product();
-}
-
 bool Data::setEvent(const edm::Event & event, const edm::EventSetup & setup) {
 
   // cache the event number
@@ -45,22 +23,22 @@ bool Data::setEvent(const edm::Event & event, const edm::EventSetup & setup) {
   // access L1 objects only if L1 is used
   if (hasL1T()) {
     // cache the L1 GT results objects
-    auto l1t = get<GlobalAlgBlkBxCollection>(event, m_l1tResultsToken);
-    if (not l1t or l1t->size() == 0 or l1t->isEmpty(0)) {
+    auto const& l1t = edm::get(event, m_l1tResultsToken);
+    if (l1t.size() == 0 or l1t.isEmpty(0)) {
       m_l1tResults = nullptr;
       return false;
     }
     if (m_l1tIgnoreMaskAndPrescale)
-      m_l1tResults = & l1t->at(0, 0).getAlgoDecisionInitial();
+      m_l1tResults = & l1t.at(0, 0).getAlgoDecisionInitial();
     else
-      m_l1tResults = & l1t->at(0, 0).getAlgoDecisionFinal();
+      m_l1tResults = & l1t.at(0, 0).getAlgoDecisionFinal();
 
     // cache the L1 trigger menu
     unsigned long long l1tCacheID = setup.get<L1TUtmTriggerMenuRcd>().cacheIdentifier();
     if (m_l1tCacheID == l1tCacheID) {
       m_l1tUpdated = false;
     } else {
-      m_l1tMenu = get<L1TUtmTriggerMenuRcd, L1TUtmTriggerMenu>(setup);
+      m_l1tMenu = & edm::get<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>(setup);
       m_l1tCacheID = l1tCacheID;
       m_l1tUpdated = true;
     }
@@ -69,7 +47,7 @@ bool Data::setEvent(const edm::Event & event, const edm::EventSetup & setup) {
   // access HLT objects only if HLT is used
   if (hasHLT()) {
     // cache the HLT TriggerResults
-    m_hltResults = get<edm::TriggerResults>(event, m_hltResultsToken);
+    m_hltResults = & edm::get(event, m_hltResultsToken);
     if (not m_hltResults)
       return false;
 


### PR DESCRIPTION
Implement a free function `edm::get<...>()` to retrieve an object from the `EventSetup`, `Event`, `LumiSection` or `Run`, and return it by reference, or throws an exception if the object is not present.