### PR TITLE
Oracle occi unittest

### DIFF
--- a/OnlineDB/Oracle/test/BuildFile.xml
+++ b/OnlineDB/Oracle/test/BuildFile.xml
@@ -1,0 +1,19 @@
+
+<use name="oracleocci"/>
+<library name="cms_occi" file="cms_occi_hack.cc">
+</library>
+<architecture name="_amd64_">
+  <bin name="test_occi_with_cmshack" file="test.cpp">
+    <lib name="cms_occi"/>
+    <flags TEST_RUNNER_ARGS="12154"/>
+  </bin>
+  <bin name="test_occi_wo_cmshack" file="test.cpp">
+    <architecture name="_gcc7">
+      <flags TEST_RUNNER_ARGS="12154"/>
+    </architecture>
+    <architecture name="_gcc6">
+      <flags TEST_RUNNER_ARGS="24960"/>
+    </architecture>  
+  </bin>
+</architecture>
+

--- a/OnlineDB/Oracle/test/BuildFile.xml
+++ b/OnlineDB/Oracle/test/BuildFile.xml
@@ -1,4 +1,3 @@
-
 <use name="oracleocci"/>
 <library name="cms_occi" file="cms_occi_hack.cc">
 </library>

--- a/OnlineDB/Oracle/test/cms_occi_hack.cc
+++ b/OnlineDB/Oracle/test/cms_occi_hack.cc
@@ -1,0 +1,9 @@
+extern "C" {
+#include <cstdio>
+#include <string.h>
+int _ZNKSs6lengthEv (char **a)
+{
+  char *s = *a;
+  return strlen (s);
+}
+}

--- a/OnlineDB/Oracle/test/test.cpp
+++ b/OnlineDB/Oracle/test/test.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <string>
+#include <sstream>
+
+#include "occi.h"
+
+using namespace oracle::occi;
+using namespace std;
+
+int main(int argc, char *argv[]){
+  int errCode = 0;
+  if (argc==2){errCode = stoi(argv[1]);}
+  if (errCode==24960){
+    cout <<"Tesing: 'ORA-24960: the attribute  OCI_ATTR_USERNAME is greater than the maximum allowable length of 255'"<<endl;    
+  }
+  else if (errCode==12154){
+    cout <<"Tesing: 'ORA-12154: TNS:could not resolve the connect identifier specified'"<<endl;    
+  }
+  else{
+    cout<<"Testing exception error code:"<<errCode<<endl;
+  }
+  try
+  {
+    auto env = Environment::createEnvironment(Environment::OBJECT);
+    auto conn = env->createConnection("a", "b", "c");
+    env->terminateConnection(conn);
+    Environment::terminateEnvironment(env);
+  }catch(oracle::occi::SQLException &e)
+  {
+    cout <<"Caught oracle::occi::SQLException exception with error code: "<<e.getErrorCode()<<endl;
+    if (e.getErrorCode()==errCode){
+      cout << "OK: Expected exception found:" << errCode << endl;
+    }
+    else{
+      throw;
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
Basic unit test added for oracle occi.
- **test_occi_wo_cmshack** uses occi directly , so it should generate
   - for gcc630 (i.e new ABI): exception 24960 i.e `ORA-24960: the attribute  OCI_ATTR_USERNAME is greater than the maximum allowable length of 255`
   - for gcc7 (i.e old ABI): exception 12154 i.e. `ORA-12154: TNS:could not resolve the connect identifier specified`

- **test_occi_with_cmshack** uses cms_occi (linked against occi) + overrides _ZNKSs6lengthEv. This should generate exception 12154 for both gcc630 and gcc700

these tests do not build/run on non-amd64 archs