### PR TITLE
Workaround for #21749.

### DIFF
--- a/DQMServices/Core/interface/Standalone.h
+++ b/DQMServices/Core/interface/Standalone.h
@@ -88,7 +88,7 @@ namespace edm
     void watchPostGlobalEndRun(void*, T) {}
 
     template <typename T>
-    void watchPostGlobalEndLumi(void*, T) {}
+    void watchPreGlobalBeginLumi(void*, T) {}
 
     PreallocationSignal preallocateSignal_;
   };

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -543,7 +543,7 @@ DQMStore::DQMStore(const edm::ParameterSet &pset, edm::ActivityRegistry& ar)
     ar.watchPostSourceLumi(this,&DQMStore::forceReset);
   }
   ar.watchPostGlobalBeginLumi(this, &DQMStore::postGlobalBeginLumi);
-  ar.watchPostGlobalEndLumi(this,&DQMStore::deleteUnusedLumiHistogramsAfterEndLumi);
+  ar.watchPreGlobalBeginLumi(this, &DQMStore::deleteUnusedLumiHistogramsAfterEndLumi);
 }
 
 DQMStore::DQMStore(const edm::ParameterSet &pset)


### PR DESCRIPTION
> @Dr15Jones
> I have another theory as to what caused the problem. There are two
> different phases in the framework as a lumi is ending. There is the
> 'global end lumi' phase and the 'write lumi' phase. The 'write lumi'
> phase is only seen by the OutputModules and is when they "write the
> lumi to output'. So the change in #21652 deletes some histograms at
> 'end of global end lumi' which is before 'write lumi' gets called.
> Therefore if the deleted histograms were supposed to be saved to the
> file, they would be missing.

A workaround for the issue is to let the `DQMStore` delete the
no-longer-needed lumi-based histograms in the "pre global begin lumi"
transition instead of the "post global end lumi".