### PR TITLE
Revert "DQMStore: delete unused MEs independently from the output modules"

### DIFF
--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -740,6 +740,9 @@ DQMFileSaver::globalEndLuminosityBlock(const edm::LuminosityBlock & iLS, const e
           << "Internal error, can save files"
           << " only in ROOT format.";
     }
+
+    // after saving per LS, delete the old LS global histograms.
+    dbe_->deleteUnusedLumiHistograms(enableMultiThread_ ? irun : 0, ilumi);
   }
 }
 

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -766,8 +766,6 @@ class DQMStore
                                               uint32_t moduleId);
 
   void deleteUnusedLumiHistograms(uint32_t run, uint32_t lumi);
-  void deleteUnusedLumiHistogramsAfterEndLumi(const edm::GlobalContext&);
-
  private:
 
   // ---------------- Miscellaneous -----------------------------

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -543,7 +543,6 @@ DQMStore::DQMStore(const edm::ParameterSet &pset, edm::ActivityRegistry& ar)
     ar.watchPostSourceLumi(this,&DQMStore::forceReset);
   }
   ar.watchPostGlobalBeginLumi(this, &DQMStore::postGlobalBeginLumi);
-  ar.watchPostGlobalEndLumi(this,&DQMStore::deleteUnusedLumiHistogramsAfterEndLumi);
 }
 
 DQMStore::DQMStore(const edm::ParameterSet &pset)
@@ -2222,13 +2221,6 @@ DQMStore::deleteUnusedLumiHistograms(uint32_t run, uint32_t lumi)
 
     i = data_.erase(i);
   }
-}
-
-void
-DQMStore::deleteUnusedLumiHistogramsAfterEndLumi(const edm::GlobalContext &gc)
-{
-  auto const& lumiblock = gc.luminosityBlockID();
-  deleteUnusedLumiHistograms(lumiblock.run(), lumiblock.luminosityBlock());
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/DQMServices/FileIO/plugins/DQMFileSaverBase.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverBase.cc
@@ -100,6 +100,9 @@ void DQMFileSaverBase::globalEndLuminosityBlock(const edm::LuminosityBlock &iLS,
   fp.run_ = irun;
 
   this->saveLumi(fp);
+
+  edm::Service<DQMStore> store;
+  store->deleteUnusedLumiHistograms(store->mtEnabled() ? irun : 0, ilumi);
 }
 
 void DQMFileSaverBase::globalEndRun(const edm::Run &iRun,


### PR DESCRIPTION
This reverts commit a9b77bb521310c6b5a8e46740381e2309d4300c9.