### PR TITLE
[10.0.X][GT update] Fix for 100X_upgrade2018_realistic GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -50,7 +50,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '100X_upgrade2018_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v3',
+    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
Fixing the 100X_upgrade2018_realistic GT in autocond.
New GT: 100X_upgrade2018_realistic_v4
Old GT: 100X_upgrade2018_realistic_v3
Difference: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018_realistic_v3/100X_upgrade2018_realistic_v4

**Explained difference:**

- HcalChannelQuality_2018_v2.0_mc  <- HcalChannelQuality_2018_v1.0_mc
(This update corresponds to the most recent 2017 version: HcalChannelQuality_2017plan1_v3.0_mc for HB+HF+HO, no dead channels in HE.)

- HcalLUTCorrs_2018_v3.0_mc <- HcalLUTCorrs_2018_v1.0_mc
(This update is important to have the HF TP scale correct. v1.0 has the infamous 0.7 factor, which can lead to 0.3 lower HF TP scale than it should.)

- HcalRespCorrs_2018_v3.0_mc <- HcalRespCorrs_2018_v2.0_mc
(This update corresponds to the most recent 2017 version: HcalRespCorrs_2017plan1_v5.0_mc for HB+HF+HO. HE part corresponds to HEP17 of 2017plan1 tag.)

- HcalZSThresholds_2018_v2.1_mc <- HcalZSThresholds_2018_v1.0_mc
(HE are set 16, as it is at p5 for HE17.)

- HcalQIEData_2017plan1_v2.0_MC2018_mc <- HcalQIEData_2018_v1.0_mc
(This update corresponds to the most recent 2017 version: DumpQIEData_2017plan1_v2.0_mc_Run1.txt for HB+HF+HO. HE is filled with mean from HEP17.)
