### PR TITLE
Keep HI Gen collections when pp reco is customized for XeXe

### DIFF
--- a/SimGeneral/Configuration/python/SimGeneral_EventContent_cff.py
+++ b/SimGeneral/Configuration/python/SimGeneral_EventContent_cff.py
@@ -43,3 +43,9 @@ phase2_timing.toModify( SimGeneralRAW, outputCommands = SimGeneralRAW.outputComm
 phase2_timing.toModify( SimGeneralFEVTDEBUG, outputCommands = SimGeneralFEVTDEBUG.outputCommands + _phase2_timing_extraCommands )
 phase2_timing.toModify( SimGeneralRECO, outputCommands = SimGeneralRECO.outputCommands + _phase2_timing_extraCommands )
 
+_pp_on_XeXe_extraCommands = ['keep CrossingFramePlaybackInfoNew_mix_*_*','keep *_heavyIon_*_*']
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+pp_on_XeXe_2017.toModify( SimGeneralRAW, outputCommands = SimGeneralRAW.outputCommands + _pp_on_XeXe_extraCommands )
+pp_on_XeXe_2017.toModify( SimGeneralFEVTDEBUG, outputCommands = SimGeneralFEVTDEBUG.outputCommands + _pp_on_XeXe_extraCommands )
+pp_on_XeXe_2017.toModify( SimGeneralRECO, outputCommands = SimGeneralRECO.outputCommands + _pp_on_XeXe_extraCommands )
+pp_on_XeXe_2017.toModify( SimGeneralAOD, outputCommands = SimGeneralAOD.outputCommands + _pp_on_XeXe_extraCommands )


### PR DESCRIPTION
For certain MC productions it's necessary to keep information about the geometry of colliding nuclei for centrality determination.
The heavy ion eras keep these collections, as the heavy ion event content stores them:
SimGeneral/Configuration/python/SimGeneral_HiMixing_EventContent_cff.py
However, for XeXe we use the standard pp event content. 
This PR expands that event content for the XeXe era. 
The extra collection is stored in the DIGI and RECO steps:
edm::GenHIEvent                       "heavyIon"                  ""                "HLT" 

A 94X version is also coming, which is the release needed for MC production. 