### PR TITLE
Fix creation of 2D efficiency histograms in TagProbeFitter

### DIFF
--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -747,7 +747,7 @@ void TagProbeFitter::saveEfficiencyPlots(RooDataSet& eff, const TString& effName
           TString catName = t->GetName();
           if(catName.Contains("NotMapped")) continue;
           catName.ReplaceAll("{","").ReplaceAll("}","").ReplaceAll(";","_&_");
-          makeEfficiencyPlot2D(myEff, *v1, *v2, TString::Format("%s_%s_PLOT_%s",v1->GetName(), v2->GetName(), catName.Data()), catName, effName, "allCats1D", t->getVal());
+          makeEfficiencyPlot2D(myEff, *v1, *v2, TString::Format("%s_%s_PLOT_%s",v1->GetName(), v2->GetName(), catName.Data()), catName, effName, "allCats2D", t->getVal());
         }        
       }
     }


### PR DESCRIPTION
Currently makeEfficiencyPlot2D is called with "allCats1D" as catName argument. This leads to empty 2D efficiency histograms, since the passed catIndex and the one obtained from the passed RooDataSet never match (TagProbFitter.cc:L815).
Since the RooMultiCategory used as column in the RooDataSet myEff is created with the name "allCats2D", this issue can be fixed by calling makeEfficiencyPlot2D with the appropriate argument.