### PR TITLE
migrate PrimaryVertexMonitor to concurrent DQM

### DIFF
--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.h
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.h
@@ -11,8 +11,9 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/Association.h"
 
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
+#include "DQMServices/Core/interface/ConcurrentMonitorElement.h"
 
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -24,25 +25,22 @@
  *
  */
 
-class PrimaryVertexMonitor : public DQMEDAnalyzer {
+class PrimaryVertexMonitorSlave {
    public:
-      explicit PrimaryVertexMonitor(const edm::ParameterSet& pSet);
+      PrimaryVertexMonitorSlave();
+      void init(const edm::ParameterSet& pSet);
 
-      ~PrimaryVertexMonitor() override;
+      void bookHistograms(DQMStore::ConcurrentBooker & ibooker, edm::Run const &, edm::EventSetup const &);
+      void analyze(const edm::Event &, const edm::EventSetup &) const;
 
-      void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-      void analyze(const edm::Event &, const edm::EventSetup &) override;
 
-   private:
-
-  void pvTracksPlots(const reco::Vertex & v);
-  void vertexPlots(const reco::Vertex & v, const reco::BeamSpot& beamSpot, int i);
+  void pvTracksPlots(const reco::Vertex & v) const;
+  void vertexPlots(const reco::Vertex & v, const reco::BeamSpot& beamSpot, int i) const;
 
   edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
   edm::EDGetTokenT<reco::BeamSpot>         beamspotToken_;
   using VertexScore = edm::ValueMap<float>;
   edm::EDGetTokenT<VertexScore>        scoreToken_;
-  
   edm::InputTag vertexInputTag_, beamSpotInputTag_;
 
   edm::ParameterSet conf_;
@@ -52,24 +50,24 @@ class PrimaryVertexMonitor : public DQMEDAnalyzer {
   std::string TopFolderName_;
   std::string AlignmentLabel_;
   int ndof_;
-  bool errorPrinted_;
+  mutable std::atomic<bool> errorPrinted_;
   
   // the histos
-  MonitorElement *nbvtx, *nbgvtx, *nbtksinvtx[2], *trksWeight[2], *score[2];
-  MonitorElement *tt[2];
-  MonitorElement *xrec[2] , *yrec[2], *zrec[2], *xDiff[2] , *yDiff[2], *xerr[2] , *yerr[2], *zerr[2] ;
-  MonitorElement *xerrVsTrks[2] , *yerrVsTrks[2], *zerrVsTrks[2] ;
-  MonitorElement * ntracksVsZ[2];
-  MonitorElement *vtxchi2[2] , *vtxndf[2], *vtxprob[2] , *nans[2];
-  MonitorElement *type[2];
-  MonitorElement *bsX, *bsY, *bsZ, *bsSigmaZ, *bsDxdz, *bsDydz, *bsBeamWidthX, *bsBeamWidthY, *bsType;
+  ConcurrentMonitorElement nbvtx, nbgvtx, nbtksinvtx[2], trksWeight[2], score[2];
+  ConcurrentMonitorElement tt[2];
+  ConcurrentMonitorElement xrec[2] , yrec[2], zrec[2], xDiff[2] , yDiff[2], xerr[2] , yerr[2], zerr[2] ;
+  ConcurrentMonitorElement xerrVsTrks[2] , yerrVsTrks[2], zerrVsTrks[2];
+  ConcurrentMonitorElement ntracksVsZ[2];
+  ConcurrentMonitorElement vtxchi2[2] , vtxndf[2], vtxprob[2] , nans[2];
+  ConcurrentMonitorElement type[2];
+  ConcurrentMonitorElement bsX, bsY, bsZ, bsSigmaZ, bsDxdz, bsDydz, bsBeamWidthX, bsBeamWidthY, bsType;
 
-  MonitorElement *sumpt, *ntracks, *weight, *chi2ndf, *chi2prob;
-  MonitorElement *dxy, *dxy2, *dz, *dxyErr, *dzErr;
-  MonitorElement *dxyVsPhi_pt1, *dzVsPhi_pt1;
-  MonitorElement *dxyVsEta_pt1, *dzVsEta_pt1;
-  MonitorElement *dxyVsPhi_pt10, *dzVsPhi_pt10;
-  MonitorElement *dxyVsEta_pt10, *dzVsEta_pt10;
+  ConcurrentMonitorElement sumpt, ntracks, weight, chi2ndf, chi2prob;
+  ConcurrentMonitorElement dxy, dxy2, dz, dxyErr, dzErr;
+  ConcurrentMonitorElement dxyVsPhi_pt1, dzVsPhi_pt1;
+  ConcurrentMonitorElement dxyVsEta_pt1, dzVsEta_pt1;
+  ConcurrentMonitorElement dxyVsPhi_pt10, dzVsPhi_pt10;
+  ConcurrentMonitorElement dxyVsEta_pt10, dzVsEta_pt10;
 
 
 };


### PR DESCRIPTION
An exercise to see how complex it is.
Complex is, impossible not.
Having the "slave class" available in the constructor would save some copying around of config, tags and tokens.
Making stateless all DQM analyzers will be a challenge  