### PR TITLE
TTStub and TTCluster class porting to CMSSW 10

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTStub.h
+++ b/DataFormats/L1TrackTrigger/interface/TTStub.h
@@ -45,6 +45,9 @@ class TTStub
     void   setTriggerDisplacement( int aDisplacement ); /// In HALF-STRIP units!
     double getTriggerOffset() const;         /// In FULL-STRIP units! (hence, not implemented herein)
     void   setTriggerOffset( int anOffset ); /// In HALF-STRIP units!
+    double getRealTriggerOffset() const;         /// In FULL-STRIP units! (hence, not implemented herein)
+    void   setRealTriggerOffset( float anOffset ); /// In HALF-STRIP units!
+
 
     /// CBC3-style trigger information
     /// for sake of simplicity, these methods are
@@ -62,6 +65,7 @@ class TTStub
     edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > theClusterRef1;
     int theDisplacement;
     int theOffset;
+    float theRealOffset;
 
 }; /// Close class
 
@@ -80,6 +84,7 @@ TTStub< T >::TTStub()
   theDetId = 0;
   theDisplacement = 999999;
   theOffset = 0;
+  theRealOffset = 0;
 }
 
 /// Another Constructor
@@ -92,6 +97,7 @@ TTStub< T >::TTStub( DetId aDetId )
   /// Set default data members
   theDisplacement = 999999;
   theOffset = 0;
+  theRealOffset = 0;
 }
 
 /// Destructor
@@ -124,6 +130,13 @@ double TTStub< T >::getTriggerOffset() const { return 0.5*theOffset; }
 
 template< typename T >
 void TTStub< T >::setTriggerOffset( int anOffset ) { theOffset = anOffset; }
+
+template< typename T >
+double TTStub< T >::getRealTriggerOffset() const { return 0.5*theRealOffset; }
+
+template< typename T >
+void TTStub< T >::setRealTriggerOffset( float anOffset ) { theRealOffset = anOffset; }
+
 
 /// CBC3-style trigger info
 template< typename T >

--- a/DataFormats/L1TrackTrigger/interface/TTStub.h
+++ b/DataFormats/L1TrackTrigger/interface/TTStub.h
@@ -71,6 +71,7 @@ class TTStub
     float theRealOffset;
     float theHardwareBend;
 
+    static constexpr float dummyBend = 999999; // Dumy value should be away from potential bends
 }; /// Close class
 
 /*! \brief   Implementation of methods
@@ -86,10 +87,10 @@ TTStub< T >::TTStub()
 {
   /// Set default data members
   theDetId = 0;
-  theDisplacement = 999999;
+  theDisplacement = dummyBend;
   theOffset = 0;
   theRealOffset = 0;
-  theHardwareBend = 999999;
+  theHardwareBend = dummyBend;
 }
 
 /// Another Constructor
@@ -100,10 +101,10 @@ TTStub< T >::TTStub( DetId aDetId )
   this->setDetId( aDetId );
 
   /// Set default data members
-  theDisplacement = 999999;
+  theDisplacement = dummyBend;
   theOffset = 0;
   theRealOffset = 0;
-  theHardwareBend = 999999;
+  theHardwareBend = dummyBend;
 }
 
 /// Destructor
@@ -157,7 +158,7 @@ double TTStub< T >::getTriggerPosition() const
 template< typename T >
 double TTStub< T >::getTriggerBend() const
 {
-  if ( theDisplacement == 999999 )
+  if ( theDisplacement == dummyBend )
     return theDisplacement;
 
   return 0.5*( theDisplacement - theOffset );
@@ -166,7 +167,7 @@ double TTStub< T >::getTriggerBend() const
 template< typename T >
 double TTStub< T >::getHardwareBend() const
 {
-  if ( theHardwareBend == 999999 )
+  if ( theHardwareBend == dummyBend )
     return this->getTriggerBend(); // If not set make it transparent
 
   return theHardwareBend;

--- a/DataFormats/L1TrackTrigger/interface/TTStub.h
+++ b/DataFormats/L1TrackTrigger/interface/TTStub.h
@@ -49,11 +49,14 @@ class TTStub
     void   setRealTriggerOffset( float anOffset ); /// In HALF-STRIP units!
 
 
+
     /// CBC3-style trigger information
     /// for sake of simplicity, these methods are
     /// slightly out of the getABC(...)/findABC(...) rule
     double getTriggerPosition() const; /// In FULL-STRIP units!
     double getTriggerBend() const;     /// In FULL-STRIP units!
+    double getHardwareBend() const; /// In FULL-STRIP units!
+    void   setHardwareBend( float aBend ); /// In HALF-STRIP units!
 
     /// Information
     std::string print( unsigned int i = 0 ) const;
@@ -66,6 +69,7 @@ class TTStub
     int theDisplacement;
     int theOffset;
     float theRealOffset;
+    float theHardwareBend;
 
 }; /// Close class
 
@@ -85,6 +89,7 @@ TTStub< T >::TTStub()
   theDisplacement = 999999;
   theOffset = 0;
   theRealOffset = 0;
+  theHardwareBend = 999999;
 }
 
 /// Another Constructor
@@ -98,6 +103,7 @@ TTStub< T >::TTStub( DetId aDetId )
   theDisplacement = 999999;
   theOffset = 0;
   theRealOffset = 0;
+  theHardwareBend = 999999;
 }
 
 /// Destructor
@@ -137,6 +143,9 @@ double TTStub< T >::getRealTriggerOffset() const { return 0.5*theRealOffset; }
 template< typename T >
 void TTStub< T >::setRealTriggerOffset( float anOffset ) { theRealOffset = anOffset; }
 
+template< typename T >
+void TTStub< T >::setHardwareBend( float aBend ) { theHardwareBend = aBend; }
+
 
 /// CBC3-style trigger info
 template< typename T >
@@ -154,6 +163,16 @@ double TTStub< T >::getTriggerBend() const
   return 0.5*( theDisplacement - theOffset );
 }
 
+template< typename T >
+double TTStub< T >::getHardwareBend() const
+{
+  if ( theHardwareBend == 999999 )
+    return this->getTriggerBend(); // If not set make it transparent
+
+  return theHardwareBend;
+}
+
+
 /// Information
 template< typename T >
 std::string TTStub< T >::print( unsigned int i ) const
@@ -169,6 +188,7 @@ std::string TTStub< T >::print( unsigned int i ) const
   padding+='\t';
   output << padding << "DetId: " << theDetId.rawId() << ", position: " << this->getTriggerPosition();
   output << ", bend: " << this->getTriggerBend() << '\n';
+  output << ", hardware bend: " << this->getHardwareBend() << '\n';
   unsigned int iClu = 0;
   output << padding << "cluster 0: address: " << theClusterRef0.get();
   output << ", cluster size: " << theClusterRef0->getHits().size() << '\n';

--- a/L1Trigger/TrackTrigger/interface/TTStubAlgorithm.h
+++ b/L1Trigger/TrackTrigger/interface/TTStubAlgorithm.h
@@ -49,6 +49,7 @@ class TTStubAlgorithm
     virtual void PatternHitCorrelation( bool &aConfirmation,
                                         int &aDisplacement,
                                         int &anOffset,
+					float &anROffset,
                                         const TTStub< T > &aTTStub ) const {}
 
     /// Algorithm name

--- a/L1Trigger/TrackTrigger/interface/TTStubAlgorithm.h
+++ b/L1Trigger/TrackTrigger/interface/TTStubAlgorithm.h
@@ -50,6 +50,7 @@ class TTStubAlgorithm
                                         int &aDisplacement,
                                         int &anOffset,
 					float &anROffset,
+					float &anHardBend,
                                         const TTStub< T > &aTTStub ) const {}
 
     /// Algorithm name

--- a/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_cbc3.h
+++ b/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_cbc3.h
@@ -51,6 +51,7 @@ class TTStubAlgorithm_cbc3 : public TTStubAlgorithm< T >
                                 int &aDisplacement,
                                 int &anOffset,
 				float &anROffset,
+				float &anHardBend,
                                 const TTStub< T > &aTTStub ) const override;
 
 }; /// Close class
@@ -68,6 +69,7 @@ void TTStubAlgorithm_cbc3< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( bool
                                                                     int &aDisplacement,
                                                                     int &anOffset,
 								    float &anROffset,
+								    float &anHardBend,
                                                                     const TTStub< Ref_Phase2TrackerDigi_ > &aTTStub ) const;
 
 /*! \class   ES_TTStubAlgorithm_cbc3

--- a/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_cbc3.h
+++ b/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_cbc3.h
@@ -50,6 +50,7 @@ class TTStubAlgorithm_cbc3 : public TTStubAlgorithm< T >
     void PatternHitCorrelation( bool &aConfirmation,
                                 int &aDisplacement,
                                 int &anOffset,
+				float &anROffset,
                                 const TTStub< T > &aTTStub ) const override;
 
 }; /// Close class
@@ -66,6 +67,7 @@ template< >
 void TTStubAlgorithm_cbc3< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( bool &aConfirmation,
                                                                     int &aDisplacement,
                                                                     int &anOffset,
+								    float &anROffset,
                                                                     const TTStub< Ref_Phase2TrackerDigi_ > &aTTStub ) const;
 
 /*! \class   ES_TTStubAlgorithm_cbc3

--- a/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_official.h
+++ b/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_official.h
@@ -79,7 +79,7 @@ class TTStubAlgorithm_official : public TTStubAlgorithm< T >
                                 const TTStub< T > &aTTStub ) const override;
 
     float degradeBend(bool psModule, int window, int bend) const;
-
+    
 }; /// Close class
 
 /*! \brief   Implementation of methods

--- a/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_official.h
+++ b/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_official.h
@@ -75,7 +75,10 @@ class TTStubAlgorithm_official : public TTStubAlgorithm< T >
                                 int &aDisplacement,
                                 int &anOffset,
 				float &anROffset,
+				float &anHardBend,
                                 const TTStub< T > &aTTStub ) const override;
+
+    float degradeBend(bool psModule, int window, int bend) const;
 
 }; /// Close class
 
@@ -92,7 +95,12 @@ void TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( 
                                                                        int &aDisplacement,
                                                                        int &anOffset,
 								       float &anROffset,
+								       float &anHardBend,
                                                                        const TTStub< Ref_Phase2TrackerDigi_ > &aTTStub ) const;
+
+template< >
+float TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::degradeBend(bool psModule, int window, int bend) const;
+
 
 /*! \class   ES_TTStubAlgorithm_official
  *  \brief   Class to declare the algorithm to the framework

--- a/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_official.h
+++ b/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_official.h
@@ -74,6 +74,7 @@ class TTStubAlgorithm_official : public TTStubAlgorithm< T >
     void PatternHitCorrelation( bool &aConfirmation,
                                 int &aDisplacement,
                                 int &anOffset,
+				float &anROffset,
                                 const TTStub< T > &aTTStub ) const override;
 
 }; /// Close class
@@ -90,6 +91,7 @@ template< >
 void TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( bool &aConfirmation,
                                                                        int &aDisplacement,
                                                                        int &anOffset,
+								       float &anROffset,
                                                                        const TTStub< Ref_Phase2TrackerDigi_ > &aTTStub ) const;
 
 /*! \class   ES_TTStubAlgorithm_official

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -162,6 +162,17 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
         /// Get the stub
         const TTStub< Ref_Phase2TrackerDigi_ >& tempTTStub = tempOutput[iTempStub];
 
+	// A temporary stub, for FE problems
+	TTStub< Ref_Phase2TrackerDigi_ > tempTTStub2( tempTTStub.getDetId() );
+	
+	tempTTStub2.addClusterRef( (tempTTStub.getClusterRef(0)) );
+	tempTTStub2.addClusterRef( (tempTTStub.getClusterRef(1)) );
+	tempTTStub2.setTriggerDisplacement( 2.*tempTTStub.getTriggerDisplacement() ); 
+	tempTTStub2.setTriggerOffset( 2.*tempTTStub.getTriggerOffset() ); 
+	tempTTStub2.setRealTriggerOffset( 2.*tempTTStub.getRealTriggerOffset() );
+	tempTTStub2.setHardwareBend( tempTTStub.getHardwareBend() );
+
+
         /// Put in the output
         if ( !applyFE ) // No dynamic inefficiencies (DEFAULT)
         {
@@ -232,15 +243,9 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
 
 	  if (FEreject) 
 	  {
-	    TTStub< Ref_Phase2TrackerDigi_ > tempTTStub2( tempTTStub.getDetId() );
-
-	    tempTTStub2.addClusterRef( (tempTTStub.getClusterRef(0)) );
-	    tempTTStub2.addClusterRef( (tempTTStub.getClusterRef(1)) );
-	    
 	    tempTTStub2.setTriggerDisplacement( 500+2.*tempTTStub.getTriggerDisplacement() ); 
 	    tempTTStub2.setTriggerOffset( 500+2.*tempTTStub.getTriggerOffset() ); 
 	    tempTTStub2.setRealTriggerOffset( 500+2.*tempTTStub.getRealTriggerOffset() );
-	    tempTTStub2.setHardwareBend( tempTTStub.getHardwareBend() );
 	    
 	    tempInner.push_back( *(tempTTStub2.getClusterRef(0)) );
 	    tempOuter.push_back( *(tempTTStub2.getClusterRef(1)) );
@@ -301,17 +306,11 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
 	      }
 
 	      if (CIC_reject) // The stub added does not pass the cut
-	      {
-		TTStub< Ref_Phase2TrackerDigi_ > tempTTStub2( tempTTStub.getDetId() );
-	      
-		tempTTStub2.addClusterRef( (tempTTStub.getClusterRef(0)) );
-		tempTTStub2.addClusterRef( (tempTTStub.getClusterRef(1)) );
-	      
+	      {	      
 		tempTTStub2.setTriggerDisplacement( 1000+2.*tempTTStub.getTriggerDisplacement() ); 
 		tempTTStub2.setTriggerOffset( 1000+2.*tempTTStub.getTriggerOffset() ); 
 	     	tempTTStub2.setRealTriggerOffset( 1000+2.*tempTTStub.getRealTriggerOffset() );
-		tempTTStub2.setHardwareBend( tempTTStub.getHardwareBend() );
-
+	
 		tempInner.push_back( *(tempTTStub2.getClusterRef(0)) );
 		tempOuter.push_back( *(tempTTStub2.getClusterRef(1)) );
 		tempAccepted.push_back( tempTTStub2 );

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -121,8 +121,9 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
         int thisDisplacement = 999999;
         int thisOffset = 0;
 	float thisROffset = 0;
+	float thisHardBend = 0;
 
-        theStubFindingAlgoHandle->PatternHitCorrelation( thisConfirmation, thisDisplacement, thisOffset, thisROffset, tempTTStub );
+        theStubFindingAlgoHandle->PatternHitCorrelation( thisConfirmation, thisDisplacement, thisOffset, thisROffset, thisHardBend, tempTTStub );
 
         /// If the Stub is above threshold
         if ( thisConfirmation )
@@ -130,6 +131,7 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
           tempTTStub.setTriggerDisplacement( thisDisplacement );
           tempTTStub.setTriggerOffset( thisOffset );
 	  tempTTStub.setRealTriggerOffset( thisROffset );
+	  tempTTStub.setHardwareBend( thisHardBend );
 	  tempOutput.push_back( tempTTStub );
         } /// Stub accepted
       } /// End of loop over outer clusters
@@ -208,6 +210,7 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
 		tempTTStub2.setTriggerDisplacement( 500+2.*tempTTStub.getTriggerDisplacement() );
 		tempTTStub2.setTriggerOffset( 500+2.*tempTTStub.getTriggerOffset() ); 
 		tempTTStub2.setRealTriggerOffset( 500+2.*tempTTStub.getRealTriggerOffset() );
+		tempTTStub2.setHardwareBend( tempTTStub.getHardwareBend() );
 
 		tempInner.push_back( *(tempTTStub2.getClusterRef(0)) );
 		tempOuter.push_back( *(tempTTStub2.getClusterRef(1)) );
@@ -239,6 +242,7 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
 		tempTTStub2.setTriggerDisplacement( 500+2.*tempTTStub.getTriggerDisplacement() ); 
 		tempTTStub2.setTriggerOffset( 500+2.*tempTTStub.getTriggerOffset() ); 
 		tempTTStub2.setRealTriggerOffset( 500+2.*tempTTStub.getRealTriggerOffset() );
+		tempTTStub2.setHardwareBend( tempTTStub.getHardwareBend() );
 
 		tempInner.push_back( *(tempTTStub2.getClusterRef(0)) );
 		tempOuter.push_back( *(tempTTStub2.getClusterRef(1)) );
@@ -316,7 +320,8 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
 		tempTTStub2.setTriggerDisplacement( 1000+2.*tempTTStub.getTriggerDisplacement() ); 
 		tempTTStub2.setTriggerOffset( 1000+2.*tempTTStub.getTriggerOffset() ); 
 	     	tempTTStub2.setRealTriggerOffset( 1000+2.*tempTTStub.getRealTriggerOffset() );
-	      
+		tempTTStub2.setHardwareBend( tempTTStub.getHardwareBend() );
+
 		tempInner.push_back( *(tempTTStub2.getClusterRef(0)) );
 		tempOuter.push_back( *(tempTTStub2.getClusterRef(1)) );
 		tempAccepted.push_back( tempTTStub2 );
@@ -438,7 +443,7 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
       tempTTStub.setTriggerDisplacement( 2.*stubIter->getTriggerDisplacement() ); /// getter is in FULL-strip units, setter is in HALF-strip units
       tempTTStub.setTriggerOffset( 2.*stubIter->getTriggerOffset() );             /// getter is in FULL-strip units, setter is in HALF-strip units
       tempTTStub.setRealTriggerOffset( 2.*stubIter->getRealTriggerOffset() );
-
+      tempTTStub.setHardwareBend( stubIter->getHardwareBend() );
 
       acceptedOutputFiller.push_back( tempTTStub );
 

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -33,18 +33,38 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
   edm::Handle< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > > > clusterHandle;
   iEvent.getByToken( clustersToken, clusterHandle );
 
-  /// Get the maximum number of stubs per ROC
-  /// (CBC3-style)
-  //  unsigned maxStubs = theStackedTracker->getCBC3MaxStubs();  
-  unsigned maxStubs = 0; // 0 is default, cut is disabled
+  int nmod=-1;
 
-  for (auto gd=theTrackerGeom->dets().begin(); gd != theTrackerGeom->dets().end(); gd++) {
-      DetId detid = (*gd)->geographicalId();
-      if(detid.subdetId()!=StripSubdetector::TOB && detid.subdetId()!=StripSubdetector::TID ) continue; // only run on OT
-      if(!tTopo->isLower(detid) ) continue; // loop on the stacks: choose the lower arbitrarily
-      DetId lowerDetid = detid;
-      DetId upperDetid = tTopo->partnerDetId(detid);
-      DetId stackDetid = tTopo->stack(detid);
+  // Loop over all the tracker elements
+
+  for (auto gd=theTrackerGeom->dets().begin(); gd != theTrackerGeom->dets().end(); gd++)
+  {
+    DetId detid = (*gd)->geographicalId();
+    if(detid.subdetId()!=StripSubdetector::TOB && detid.subdetId()!=StripSubdetector::TID ) continue; // only run on OT
+    if(!tTopo->isLower(detid) ) continue; // loop on the stacks: choose the lower arbitrarily
+    DetId lowerDetid = detid;
+    DetId upperDetid = tTopo->partnerDetId(detid);
+    DetId stackDetid = tTopo->stack(detid);
+    bool isPS        = (theTrackerGeom->getDetectorType(stackDetid)==TrackerGeometry::ModuleType::Ph2PSP);
+
+    bool is10G_PS = false;
+    
+    // Determine if this module is a 10G transmission scheme module
+
+    if (detid.subdetId()==StripSubdetector::TOB)
+    {
+      if (tTopo->layer(detid)==1) is10G_PS = true;
+    }
+    else if (detid.subdetId()==StripSubdetector::TID)
+    {
+      if (tTopo->tidWheel(detid)<=2 && tTopo->tidRing(detid)<=4) is10G_PS = true;
+    }
+
+
+    ++nmod;
+
+    unsigned int maxStubs;
+    std::vector< std::pair< unsigned int, double > > bendMap;
 
     /// Go on only if both detectors have Clusters
     if ( clusterHandle->find( lowerDetid ) == clusterHandle->end() ||
@@ -70,12 +90,13 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
     tempAccepted.clear();
 
     /// Get chip size information
-    const GeomDetUnit* det0 = theTrackerGeom->idToDetUnit( lowerDetid );
-    const PixelGeomDetUnit* pix0 = dynamic_cast< const PixelGeomDetUnit* >( det0 );
-    const PixelTopology* top0 = dynamic_cast< const PixelTopology* >( &(pix0->specificTopology()) );
-    const int chipSize = 2 * top0->rowsperroc(); /// Need to find ASIC size in half-strip units
+    //const GeomDetUnit* det0 = theTrackerGeom->idToDetUnit( lowerDetid );
+    //    const PixelGeomDetUnit* pix0 = dynamic_cast< const PixelGeomDetUnit* >( det0 );
+    //const PixelTopology* top0 = dynamic_cast< const PixelTopology* >( &(pix0->specificTopology()) );
+    //const int chipSize = 2 * top0->rowsperroc(); /// Need to find ASIC size in half-strip units
+    int chipSize = 127; /// SV 21/11/17: previous line is wrong, need to find the right numbers
 
-    std::unordered_map< int, std::vector< TTStub< Ref_Phase2TrackerDigi_ > > > moduleStubs; /// Temporary storage for stubs before max check
+    if (isPS) chipSize = 120;
 
     /// Loop over pairs of Clusters
     for ( auto lowerClusterIter = lowerClusters.begin();
@@ -85,7 +106,6 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
       /// Temporary storage to allow only one stub per inner cluster
       /// if requested in cfi
       std::vector< TTStub< Ref_Phase2TrackerDigi_ > > tempOutput;
-      // tempOutput.clear();
 
       for ( auto upperClusterIter = upperClusters.begin();
                  upperClusterIter != upperClusters.end();
@@ -100,14 +120,16 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
         bool thisConfirmation = false;
         int thisDisplacement = 999999;
         int thisOffset = 0;
+	float thisROffset = 0;
 
-        theStubFindingAlgoHandle->PatternHitCorrelation( thisConfirmation, thisDisplacement, thisOffset, tempTTStub );
+        theStubFindingAlgoHandle->PatternHitCorrelation( thisConfirmation, thisDisplacement, thisOffset, thisROffset, tempTTStub );
 
         /// If the Stub is above threshold
         if ( thisConfirmation )
         {
           tempTTStub.setTriggerDisplacement( thisDisplacement );
           tempTTStub.setTriggerOffset( thisOffset );
+	  tempTTStub.setRealTriggerOffset( thisROffset );
 	  tempOutput.push_back( tempTTStub );
         } /// Stub accepted
       } /// End of loop over outer clusters
@@ -139,7 +161,7 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
         const TTStub< Ref_Phase2TrackerDigi_ >& tempTTStub = tempOutput[iTempStub];
 
         /// Put in the output
-        if ( maxStubs == 0 )
+        if ( !applyFE ) // No dynamic inefficiencies (DEFAULT)
         {
           /// This means that ALL stubs go into the output
           tempInner.push_back( *(tempTTStub.getClusterRef(0)) );
@@ -148,65 +170,169 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
         }
         else
         {
+	  bool FEreject = false;
           /// This means that only some of them do
           /// Put in the temporary output
-          int chip = tempTTStub.getTriggerPosition() / chipSize; /// Find out which ASIC
-          if ( moduleStubs.find( chip ) == moduleStubs.end() ) /// Already a stub for this ASIC?
+          MeasurementPoint mp0 = tempTTStub.getClusterRef(0)->findAverageLocalCoordinates();
+          int seg       = static_cast<int>(mp0.y());
+	  if (isPS) seg = seg/16;
+	  int chip      = 1000*nmod+10*int(tempTTStub.getTriggerPosition()/chipSize)+seg; /// Find out which MPA/CBC ASIC
+          int CIC_chip  = 10*nmod+seg; /// Find out which CIC ASIC
+
+	  // First look is the stub is passing trough the very front end (CBC/MPA)
+	  (isPS)
+	    ? maxStubs = maxStubs_PS
+	    : maxStubs = maxStubs_2S;
+
+	  if (isPS) // MPA
+	  {
+	    if ( moduleStubs_MPA.find( chip ) == moduleStubs_MPA.end() ) /// Already a stub for this ASIC?
+	    {
+	      /// No, so new entry
+	      moduleStubs_MPA.insert( std::pair< int, int >( chip, 1 ) );
+	    }
+	    else
+	    {
+	      if ( moduleStubs_MPA[chip] < int(maxStubs) )
+	      {
+		++moduleStubs_MPA[chip];
+	      }
+	      else
+	      {
+		TTStub< Ref_Phase2TrackerDigi_ > tempTTStub2( tempTTStub.getDetId() );
+
+		tempTTStub2.addClusterRef( (tempTTStub.getClusterRef(0)) );
+		tempTTStub2.addClusterRef( (tempTTStub.getClusterRef(1)) );
+
+		// We flag the rejected stub this way, so that the bend will appear correct.
+		tempTTStub2.setTriggerDisplacement( 500+2.*tempTTStub.getTriggerDisplacement() );
+		tempTTStub2.setTriggerOffset( 500+2.*tempTTStub.getTriggerOffset() ); 
+		tempTTStub2.setRealTriggerOffset( 500+2.*tempTTStub.getRealTriggerOffset() );
+
+		tempInner.push_back( *(tempTTStub2.getClusterRef(0)) );
+		tempOuter.push_back( *(tempTTStub2.getClusterRef(1)) );
+		tempAccepted.push_back( tempTTStub2 );
+		FEreject = true;
+	      }
+	    }
+	  }
+	  else // CBC
+	  {
+	    if ( moduleStubs_CBC.find( chip ) == moduleStubs_CBC.end() ) /// Already a stub for this ASIC?
+	    {
+	      /// No, so new entry
+	      moduleStubs_CBC.insert( std::pair< int, int >( chip, 1 ) );
+	    }
+	    else
+	    {
+	      if ( moduleStubs_CBC[chip] < int(maxStubs) )
+	      {
+		++moduleStubs_CBC[chip];
+	      }
+	      else
+	      {
+		TTStub< Ref_Phase2TrackerDigi_ > tempTTStub2( tempTTStub.getDetId() );
+
+		tempTTStub2.addClusterRef( (tempTTStub.getClusterRef(0)) );
+		tempTTStub2.addClusterRef( (tempTTStub.getClusterRef(1)) );
+
+		tempTTStub2.setTriggerDisplacement( 500+2.*tempTTStub.getTriggerDisplacement() ); 
+		tempTTStub2.setTriggerOffset( 500+2.*tempTTStub.getTriggerOffset() ); 
+		tempTTStub2.setRealTriggerOffset( 500+2.*tempTTStub.getRealTriggerOffset() );
+
+		tempInner.push_back( *(tempTTStub2.getClusterRef(0)) );
+		tempOuter.push_back( *(tempTTStub2.getClusterRef(1)) );
+		tempAccepted.push_back( tempTTStub2 );
+		FEreject = true;
+	      }
+	    }
+	  }
+
+	  // End of the MPA/CBC loop
+
+	  // If the stub has been already thrown out, there is no reason to include it into the CIC stream
+	  if (FEreject) continue;
+	  
+	  (isPS)
+	    ? maxStubs = maxStubs_PS_CIC_5
+	    : maxStubs = maxStubs_2S_CIC_5;
+
+	  if (is10G_PS) maxStubs = maxStubs_PS_CIC_10;
+
+	  if ( moduleStubs_CIC.find( CIC_chip ) == moduleStubs_CIC.end() ) /// Already a stub for this ASIC?
           {
             /// No, so new entry
             std::vector< TTStub< Ref_Phase2TrackerDigi_ > > tempStubs(1,tempTTStub);
-            //tempStubs.clear();
-            //tempStubs.push_back( tempTTStub );
-            moduleStubs.insert( std::pair< int, std::vector< TTStub< Ref_Phase2TrackerDigi_ > > >( chip, tempStubs ) );
+            moduleStubs_CIC.insert( std::pair< int, std::vector< TTStub< Ref_Phase2TrackerDigi_ > > >( CIC_chip, tempStubs ) );
+
+	    tempInner.push_back( *(tempTTStub.getClusterRef(0)) );
+            tempOuter.push_back( *(tempTTStub.getClusterRef(1)) );
+            tempAccepted.push_back( tempTTStub ); // The stub is added
           }
           else
           {
-            /// Already existing entry
-            moduleStubs[chip].push_back( tempTTStub );
+	    bool CIC_reject=true;
+
+	    if ( moduleStubs_CIC[CIC_chip].size() < maxStubs )
+	    {
+	      moduleStubs_CIC[CIC_chip].push_back( tempTTStub ); //We add the new stub
+	      tempInner.push_back( *(tempTTStub.getClusterRef(0)) );
+	      tempOuter.push_back( *(tempTTStub.getClusterRef(1)) );
+	      tempAccepted.push_back( tempTTStub ); // The stub is added
+	    }
+	    else
+	    {
+	      moduleStubs_CIC[CIC_chip].push_back( tempTTStub ); //We add the new stub
+
+	      /// Sort them by |bend| and pick up only the first N.
+	      bendMap.clear();
+	      bendMap.reserve(moduleStubs_CIC[CIC_chip].size());
+	    
+	      for ( unsigned int i = 0; i < moduleStubs_CIC[CIC_chip].size(); ++i )
+	      {
+		bendMap.push_back( std::pair< unsigned int, double >( i, moduleStubs_CIC[CIC_chip].at(i).getTriggerBend() ) );
+	      }
+
+	      std::sort( bendMap.begin(), bendMap.end(), TTStubBuilder< Ref_Phase2TrackerDigi_ >::SortStubBendPairs );
+	      
+	      // bendMap contains link over all the stubs included in moduleStubs_CIC[CIC_chip]
+	      
+	      for ( unsigned int i = 0; i < maxStubs; ++i ) 
+	      {
+		// The stub we have added is among the first ones, add it
+		if (bendMap[i].first==moduleStubs_CIC[CIC_chip].size()-1)
+		{
+		  CIC_reject=false;
+		}
+	      }
+
+	      if (CIC_reject) // The stub added does not pass the cut
+	      {
+		TTStub< Ref_Phase2TrackerDigi_ > tempTTStub2( tempTTStub.getDetId() );
+	      
+		tempTTStub2.addClusterRef( (tempTTStub.getClusterRef(0)) );
+		tempTTStub2.addClusterRef( (tempTTStub.getClusterRef(1)) );
+	      
+		tempTTStub2.setTriggerDisplacement( 1000+2.*tempTTStub.getTriggerDisplacement() ); 
+		tempTTStub2.setTriggerOffset( 1000+2.*tempTTStub.getTriggerOffset() ); 
+	     	tempTTStub2.setRealTriggerOffset( 1000+2.*tempTTStub.getRealTriggerOffset() );
+	      
+		tempInner.push_back( *(tempTTStub2.getClusterRef(0)) );
+		tempOuter.push_back( *(tempTTStub2.getClusterRef(1)) );
+		tempAccepted.push_back( tempTTStub2 );
+	      }
+	      else
+	      {
+		tempInner.push_back( *(tempTTStub.getClusterRef(0)) );
+		tempOuter.push_back( *(tempTTStub.getClusterRef(1)) );
+		tempAccepted.push_back( tempTTStub ); // The stub is added
+	      }
+	    }
           }
-        } /// End of check on max number of stubs per module
+	} /// End of check on max number of stubs per module
       } /// End of nested loop
     } /// End of loop over pairs of Clusters
 
-    /// If we are working with max no. stub/ROC, then clean the temporary output
-    /// and store only the selected stubs
-    if ( moduleStubs.empty() == false )
-    {
-      /// Loop over ROC's
-      /// the ROC ID is not important
-      for ( auto const & is : moduleStubs )
-      {
-        /// Put the stubs into the output
-        if ( is.second.size() <= maxStubs )
-        {
-          for ( auto const & ts: is.second )
-          {
-            tempInner.push_back( *(ts.getClusterRef(0)) );
-            tempOuter.push_back( *(ts.getClusterRef(1)) );
-            tempAccepted.push_back( ts );
-          }
-        }
-        else
-        {
-          /// Sort them and pick up only the first N.
-          std::vector< std::pair< unsigned int, double > > bendMap;
-          bendMap.reserve(is.second.size());
-          for ( unsigned int i = 0; i < is.second.size(); ++i )
-          {
-            bendMap.push_back( std::pair< unsigned int, double >( i, is.second[i].getTriggerBend() ) );
-          }
-          std::sort( bendMap.begin(), bendMap.end(), TTStubBuilder< Ref_Phase2TrackerDigi_ >::SortStubBendPairs );
-
-          for ( unsigned int i = 0; i < maxStubs; ++i )
-          {
-            /// Put the highest momenta (lowest bend) stubs into the event
-            tempInner.push_back( *(is.second[bendMap[i].first].getClusterRef(0)) );
-            tempOuter.push_back( *(is.second[bendMap[i].first].getClusterRef(1)) );
-            tempAccepted.push_back( is.second[bendMap[i].first] );
-          }
-        }
-      } /// End of loop over temp output
-    } /// End store only the selected stubs if max no. stub/ROC is set
     /// Create the FastFillers
     if ( !tempInner.empty() )
     {
@@ -242,6 +368,8 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
     }
 
   } /// End of loop over detector elements
+
+  //  std::cout << "After DE loop" << std::endl;
 
   /// Put output in the event (1)
   /// Get also the OrphanHandle of the accepted clusters
@@ -309,6 +437,8 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
 
       tempTTStub.setTriggerDisplacement( 2.*stubIter->getTriggerDisplacement() ); /// getter is in FULL-strip units, setter is in HALF-strip units
       tempTTStub.setTriggerOffset( 2.*stubIter->getTriggerOffset() );             /// getter is in FULL-strip units, setter is in HALF-strip units
+      tempTTStub.setRealTriggerOffset( 2.*stubIter->getRealTriggerOffset() );
+
 
       acceptedOutputFiller.push_back( tempTTStub );
 
@@ -316,12 +446,18 @@ void TTStubBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const
 
     if ( acceptedOutputFiller.empty() )
       acceptedOutputFiller.abort();
-   
+
   } /// End of loop over stub DetSetVector
     
   /// Put output in the event (2)
   iEvent.put( std::move(ttStubDSVForOutputAccepted), "StubAccepted" );
   iEvent.put( std::move(ttStubDSVForOutputRejected), "StubRejected" );
+
+  ++ievt;
+  if (ievt%8==0)    moduleStubs_CIC.clear(); // Everything is cleared up after 8BX
+  if (ievt%2==0)    moduleStubs_MPA.clear(); // Everything is cleared up after 2BX
+  moduleStubs_CBC.clear(); // Everything is cleared up after everyBX
+
 }
 
 

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.h
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.h
@@ -76,6 +76,9 @@ class TTStubBuilder : public edm::EDProducer
     unsigned int  maxStubs_PS_CIC_5;  // PS 5G chip limit (in stubs/CIC/8BX)
     unsigned int  maxStubs_PS_CIC_10; // PS 10G chip limit (in stubs/CIC/8BX)
 
+    unsigned int  tedd1_maxring;  // PS 10G outermost ring in TEDD1 (default is 3)
+    unsigned int  tedd2_maxring;  // PS 10G outermost ring in TEDD2 (default is 0)
+
     int ievt;
  
     /// Temporary storage for stubs before max check
@@ -84,7 +87,17 @@ class TTStubBuilder : public edm::EDProducer
     std::unordered_map< int, int > moduleStubs_MPA; 
     std::unordered_map< int, int > moduleStubs_CBC; 
 
+    // Which disk rings are in 10G transmission scheme module
+    //
+    // sviret comment (221217): this info should be made available in conddb at some point
+    // not in TrackerTopology as some modules may switch between 10G and 5G transmission  
+    // schemes during running period
+
+    unsigned int high_rate_max_ring[5];
+
 }; /// Close class
+
+
 
 /*! \brief Implementation of methods
 * \details Here, in the header file, the methods which do not depend
@@ -105,9 +118,17 @@ TTStubBuilder< T >::TTStubBuilder( const edm::ParameterSet& iConfig )
   maxStubs_2S_CIC_5   = iConfig.getParameter< uint32_t >( "SS5GCIClimit" );
   maxStubs_PS_CIC_5   = iConfig.getParameter< uint32_t >( "PS5GCIClimit" );
   maxStubs_PS_CIC_10  = iConfig.getParameter< uint32_t >( "PS10GCIClimit" );
+  tedd1_maxring       = iConfig.getParameter< uint32_t >( "TEDD1Max10GRing" );
+  tedd2_maxring       = iConfig.getParameter< uint32_t >( "TEDD2Max10GRing" );
   produces< edmNew::DetSetVector< TTCluster< T > > >( "ClusterAccepted" );
   produces< edmNew::DetSetVector< TTStub< T > > >( "StubAccepted" );
   produces< edmNew::DetSetVector< TTStub< T > > >( "StubRejected" );
+
+  high_rate_max_ring[0] = tedd1_maxring;
+  high_rate_max_ring[1] = tedd1_maxring;
+  high_rate_max_ring[2] = tedd2_maxring;
+  high_rate_max_ring[3] = tedd2_maxring;
+  high_rate_max_ring[4] = tedd2_maxring;
 }
 
 /// Destructor

--- a/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
@@ -10,7 +10,7 @@ import FWCore.ParameterSet.Config as cms
 # https://indico.cern.ch/event/681577/#4-update-of-the-track-trigger
 #
 # This script is adapted to the very last Tilted Tracker geometry to date (tracker T5)
-# This version was tested on CMSSW 10_0_0
+# This version was tested on CMSSW 10_0_0_pre1
 # 
 
 TTStubAlgorithm_official_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_official_Phase2TrackerDigi_",

--- a/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
@@ -2,40 +2,36 @@ import FWCore.ParameterSet.Config as cms
 
 # First register all the hit matching algorithms, then specify preferred ones at end.
 
-# The stub windows used here refer to the definition provided in this link:
+# The stub windows used has been optimized for PU200
 #
-# http://sviret.web.cern.ch/sviret/docs/CMS/SLHC/L1TT_XX1215.pdf
+# Definition is presented here:
 #
-# Extension to the tilted geometry is discussed here:
-#
-# https://indico.cern.ch/event/536881/contributions/2219856/
+# https://indico.cern.ch/event/***/contributions/***/
 #
 # This script is adapted to the very last Tilted Tracker geometry to date (tracker T5)
-#
+# This version was tested on CMSSW 10_0_0
 # 
-
-# The tuning is not yet fully validated
-# But should enable a good turn-on at 2GeV with reasonable rates at PU200
 
 # Tab2013 hit matching algorithm
 TTStubAlgorithm_official_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_official_Phase2TrackerDigi_",
-   zMatchingPS = cms.bool(True),
-   zMatching2S = cms.bool(True),
-   BarrelCut = cms.vdouble( 0, 2.0, 2.0, 3.5, 4.5, 5.5, 6.5), #Use 0 as dummy to have direct access using DetId to the correct element 
-   NTiltedRings = cms.vdouble( 0., 12., 12., 12., 0., 0., 0.), #Number of tilted rings per side in barrel layers (for tilted geom only)
+   zMatchingPS  = cms.bool(True),
+   zMatching2S  = cms.bool(True),
+   BarrelCut    = cms.vdouble( 0, 2.0, 2, 4.5, 6, 6.5, 7.0),
+   #Number of tilted rings per side in barrel layers (for tilted geom only)
+   NTiltedRings = cms.vdouble( 0., 12., 12., 12., 0., 0., 0.), 
    TiltedBarrelCutSet = cms.VPSet(
         cms.PSet( TiltedCut = cms.vdouble( 0 ) ),
-        cms.PSet( TiltedCut = cms.vdouble( 0, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2., 2., 1.5, 1.5, 1., 1.) ),
-        cms.PSet( TiltedCut = cms.vdouble( 0, 3., 3., 3., 3., 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2, 2) ),
-        cms.PSet( TiltedCut = cms.vdouble( 0, 4.5, 4.5, 4, 4, 4, 4, 3.5, 3.5, 3.5, 3, 3, 3) ),
+        cms.PSet( TiltedCut = cms.vdouble( 0, 2, 1.5, 2, 2.5, 2.5, 2, 2, 1.5, 1.5, 1, 1, 0.5) ),
+        cms.PSet( TiltedCut = cms.vdouble( 0, 3.5, 3, 3, 3, 2.5, 2.5, 2, 3, 2.5, 2.5, 2, 2) ),
+        cms.PSet( TiltedCut = cms.vdouble( 0, 5, 5, 5, 5, 5, 5, 5.5, 5, 5, 5.5, 5.5, 5) ),
 	),
    EndcapCutSet = cms.VPSet(
         cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 1.5, 1.5, 2, 2, 2.5, 3, 3, 3.5, 4, 2.5, 3, 3.5, 4.5, 5.5) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 1.5, 1.5, 2, 2, 2, 2.5, 3, 3, 3, 2, 3, 4, 5, 5.5) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 1.5, 1.5, 2, 2, 2.5, 2.5, 2.5, 3.5, 2.5, 5, 5.5, 6) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 1.0, 1.5, 1.5, 2, 2, 2, 2, 3, 3, 6, 6, 6.5) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 1.0, 1.5, 1.5, 1.5, 2, 2, 2, 3, 3, 6, 6, 6.5) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2, 3.5, 2, 3.5, 5.5, 6, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 7, 7) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3, 2, 3, 5, 6, 6.5, 6.5, 6.5, 5, 6.5, 6.5, 7, 7) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 1.5, 3, 4.5, 6, 6.5, 6.5, 7, 7, 7, 7, 7) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 2., 3.5, 5., 6.5, 6.5, 6.5, 6, 7, 7, 7) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1., 1.5, 2.5, 4., 5, 7, 5.5, 7, 7, 7, 7) ),
         )
 )
 

--- a/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
@@ -2,37 +2,55 @@ import FWCore.ParameterSet.Config as cms
 
 # First register all the hit matching algorithms, then specify preferred ones at end.
 
-# The stub windows used has been optimized for PU200
+# The stub windows used has been optimized for for PU200 events
+# We use by default the tight tuning
 #
 # Definition is presented here:
 #
-# https://indico.cern.ch/event/***/contributions/***/
+# https://indico.cern.ch/event/681577/#4-update-of-the-track-trigger
 #
 # This script is adapted to the very last Tilted Tracker geometry to date (tracker T5)
 # This version was tested on CMSSW 10_0_0
 # 
 
-# Tab2013 hit matching algorithm
 TTStubAlgorithm_official_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_official_Phase2TrackerDigi_",
    zMatchingPS  = cms.bool(True),
    zMatching2S  = cms.bool(True),
-   BarrelCut    = cms.vdouble( 0, 2.0, 2, 4.5, 6, 6.5, 7.0),
    #Number of tilted rings per side in barrel layers (for tilted geom only)
    NTiltedRings = cms.vdouble( 0., 12., 12., 12., 0., 0., 0.), 
+   # PU200 tight tuning, optimized for muons
+   BarrelCut    = cms.vdouble( 0, 2, 2.5, 3.5, 4.5, 5.5, 7),
    TiltedBarrelCutSet = cms.VPSet(
         cms.PSet( TiltedCut = cms.vdouble( 0 ) ),
-        cms.PSet( TiltedCut = cms.vdouble( 0, 2, 1.5, 2, 2.5, 2.5, 2, 2, 1.5, 1.5, 1, 1, 0.5) ),
-        cms.PSet( TiltedCut = cms.vdouble( 0, 3.5, 3, 3, 3, 2.5, 2.5, 2, 3, 2.5, 2.5, 2, 2) ),
-        cms.PSet( TiltedCut = cms.vdouble( 0, 5, 5, 5, 5, 5, 5, 5.5, 5, 5, 5.5, 5.5, 5) ),
+        cms.PSet( TiltedCut = cms.vdouble( 0, 3, 3, 2.5, 3, 3, 2.5, 2.5, 2, 1.5, 1.5, 1, 1) ),
+        cms.PSet( TiltedCut = cms.vdouble( 0, 3.5, 3, 3, 3, 3, 2.5, 2.5, 3, 3, 2.5, 2.5, 2.5) ),
+        cms.PSet( TiltedCut = cms.vdouble( 0, 4, 4, 4, 3.5, 3.5, 3.5, 3.5, 3, 3, 3, 3, 3) ),
 	),
    EndcapCutSet = cms.VPSet(
         cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2, 3.5, 2, 3.5, 5.5, 6, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 7, 7) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3, 2, 3, 5, 6, 6.5, 6.5, 6.5, 5, 6.5, 6.5, 7, 7) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 1.5, 3, 4.5, 6, 6.5, 6.5, 7, 7, 7, 7, 7) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 2., 3.5, 5., 6.5, 6.5, 6.5, 6, 7, 7, 7) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1., 1.5, 2.5, 4., 5, 7, 5.5, 7, 7, 7, 7) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 2.5, 3, 2.5, 3, 3.5, 4, 4, 4.5, 3.5, 4, 4.5, 5, 5.5) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2.5, 2.5, 3, 2.5, 3, 3, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5, 5) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 3, 3, 2.5, 3.5, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 3, 2.5, 3.5, 3, 3, 3.5, 3.5, 3.5, 4, 4) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3, 2.5, 3.5, 3, 3, 3.5, 4, 3.5, 4, 3.5) ),
         )
+
+   # PU200 loose tuning, optimized for robustness (uncomment if you want to use it)
+   #BarrelCut    = cms.vdouble( 0, 2.0, 3, 4.5, 6, 6.5, 7.0),
+   #TiltedBarrelCutSet = cms.VPSet(
+   #     cms.PSet( TiltedCut = cms.vdouble( 0 ) ),
+   #     cms.PSet( TiltedCut = cms.vdouble( 0, 3, 3., 2.5, 3., 3., 2.5, 2.5, 2., 1.5, 1.5, 1, 1) ),
+   #     cms.PSet( TiltedCut = cms.vdouble( 0, 4., 4, 4, 4, 4., 4., 4.5, 5, 4., 3.5, 3.5, 3) ),
+   #     cms.PSet( TiltedCut = cms.vdouble( 0, 5, 5, 5, 5, 5, 5, 5.5, 5, 5, 5.5, 5.5, 5.5) ),
+   #	),
+   #EndcapCutSet = cms.VPSet(
+   #     cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
+   #     cms.PSet( EndcapCut = cms.vdouble( 0, 1., 2.5, 2.5, 3.5, 5.5, 5.5, 6, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 7, 7) ),
+   #     cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2.5, 2.5, 3, 5, 6, 6, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 7, 7) ),
+   #     cms.PSet( EndcapCut = cms.vdouble( 0, 1, 3., 4.5, 6., 6.5, 6.5, 6.5, 7, 7, 7, 7, 7) ),
+   #     cms.PSet( EndcapCut = cms.vdouble( 0, 1., 2.5, 3.5, 6., 6.5, 6.5, 6.5, 6.5, 7, 7, 7, 7) ),
+   #     cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3., 4.5, 6.5, 6.5, 7, 7, 7, 7, 7, 7) ),
+   #     )
 )
 
 # CBC3 hit matching algorithm

--- a/L1Trigger/TrackTrigger/python/TTStub_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStub_cfi.py
@@ -8,7 +8,9 @@ TTStubsFromPhase2TrackerDigis = cms.EDProducer("TTStubBuilder_Phase2TrackerDigi_
     MPAlimit      = cms.uint32(5),   # MPA chip limit (in stubs/chip/2BX)
     SS5GCIClimit  = cms.uint32(16),  # 2S 5G chip limit (in stubs/CIC/8BX)
     PS5GCIClimit  = cms.uint32(17),  # PS 5G chip limit (in stubs/CIC/8BX)
-    PS10GCIClimit = cms.uint32(35)   # PS 10G chip limit (in stubs/CIC/8BX)
+    PS10GCIClimit = cms.uint32(35),  # PS 10G chip limit (in stubs/CIC/8BX)
+    TEDD1Max10GRing = cms.uint32(3), # How many rings are PS10G in TEDD1 disks (1/2)? 
+    TEDD2Max10GRing = cms.uint32(0)  # How many rings are PS10G in TEDD2 disks (3/4/5)? 
 )
 
 

--- a/L1Trigger/TrackTrigger/python/TTStub_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStub_cfi.py
@@ -2,7 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 TTStubsFromPhase2TrackerDigis = cms.EDProducer("TTStubBuilder_Phase2TrackerDigi_",
     TTClusters = cms.InputTag("TTClustersFromPhase2TrackerDigis", "ClusterInclusive"),
-    OnlyOnePerInputCluster = cms.bool(True)
+    OnlyOnePerInputCluster = cms.bool(True), 
+    FEineffs      = cms.bool(False), # Turn ON (true) or OFF (false) the dynamic FE inefficiency accounting
+    CBClimit      = cms.uint32(3),   # CBC chip limit (in stubs/chip/BX)
+    MPAlimit      = cms.uint32(5),   # MPA chip limit (in stubs/chip/2BX)
+    SS5GCIClimit  = cms.uint32(16),  # 2S 5G chip limit (in stubs/CIC/8BX)
+    PS5GCIClimit  = cms.uint32(17),  # PS 5G chip limit (in stubs/CIC/8BX)
+    PS10GCIClimit = cms.uint32(35)   # PS 10G chip limit (in stubs/CIC/8BX)
 )
 
 

--- a/L1Trigger/TrackTrigger/src/TTStubAlgorithm_cbc3.cc
+++ b/L1Trigger/TrackTrigger/src/TTStubAlgorithm_cbc3.cc
@@ -12,11 +12,11 @@
 /// Matching operations
 template< >
 void TTStubAlgorithm_cbc3< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( bool &aConfirmation,
-                                                                    int &aDisplacement, 
-                                                                    int &anOffset, 
-								    float &anROffset,
-								    float &anHardBend,
-                                                                    const TTStub< Ref_Phase2TrackerDigi_ > &aTTStub ) const
+									    int &aDisplacement, 
+									    int &anOffset, 
+									    float &anROffset,
+									    float &anHardBend,
+									    const TTStub< Ref_Phase2TrackerDigi_ > &aTTStub ) const
 {
   /*
   /// Calculate average coordinates col/row for inner/outer Cluster

--- a/L1Trigger/TrackTrigger/src/TTStubAlgorithm_cbc3.cc
+++ b/L1Trigger/TrackTrigger/src/TTStubAlgorithm_cbc3.cc
@@ -14,6 +14,7 @@ template< >
 void TTStubAlgorithm_cbc3< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( bool &aConfirmation,
                                                                     int &aDisplacement, 
                                                                     int &anOffset, 
+								    float &anROffset,
                                                                     const TTStub< Ref_Phase2TrackerDigi_ > &aTTStub ) const
 {
   /*

--- a/L1Trigger/TrackTrigger/src/TTStubAlgorithm_cbc3.cc
+++ b/L1Trigger/TrackTrigger/src/TTStubAlgorithm_cbc3.cc
@@ -15,6 +15,7 @@ void TTStubAlgorithm_cbc3< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( bool
                                                                     int &aDisplacement, 
                                                                     int &anOffset, 
 								    float &anROffset,
+								    float &anHardBend,
                                                                     const TTStub< Ref_Phase2TrackerDigi_ > &aTTStub ) const
 {
   /*

--- a/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
@@ -13,11 +13,11 @@
 /// Matching operations
 template< >
 void TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( bool &aConfirmation,
-                                                                       int &aDisplacement, 
-                                                                       int &anOffset, 
-								       float &anROffset,
-								       float &anHardBend,
-                                                                       const TTStub< Ref_Phase2TrackerDigi_ > &aTTStub ) const
+										int &aDisplacement, 
+										int &anOffset, 
+										float &anROffset,
+										float &anHardBend,
+										const TTStub< Ref_Phase2TrackerDigi_ > &aTTStub ) const
 { 
   /// Calculate average coordinates col/row for inner/outer Cluster
   // These are already corrected for being at the center of each pixel
@@ -135,10 +135,8 @@ void TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( 
 
 
 //--- Does the actual work of degrading the bend. (based on I.Tomalin's code)
-
 template< >   
-float TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::degradeBend(bool psModule, int window, int bend) const {
- 
+ float TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::degradeBend(bool psModule, int window, int bend) const {
 
   // Number of bits used to encoded bend output by FE electronics.
   const unsigned int bitsPS_ = 3;
@@ -158,7 +156,7 @@ float TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::degradeBend(bool psMod
   unsigned int numAllowed = (psModule)  ?  pow(2, bitsPS_)  :  pow(2, bits2S_);
 
   // Existance of bend = 0 means can only use an odd number of groups.
-  numAllowed -= 1; // 7 or 15
+  numAllowed -= 1; // NumAllowed can be only based on 3 or 4 bits encoded bends, so 7 or 15 possible values
   if (numBends <= numAllowed) 
   { 
     // Can output uncompressed bend info. (So if window is lower or equal than 1.5 in PS, and 3.5 in 2S
@@ -213,7 +211,7 @@ float TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::degradeBend(bool psMod
 	degradedB = 0.5*(iUp + iDown); 
       }
     }
-    if (degradedB == 999) throw cms::Exception("DegradeResolution: Logic error in loop over groups");
+    if (degradedB == 999) throw cms::Exception("DegradeStubResolution: error in the group creation, method has been called with wrong inputs");
   }
 
   // This is degraded bend in full strip units (neglecting bend sign).

--- a/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
@@ -16,6 +16,7 @@ void TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( 
                                                                        int &aDisplacement, 
                                                                        int &anOffset, 
 								       float &anROffset,
+								       float &anHardBend,
                                                                        const TTStub< Ref_Phase2TrackerDigi_ > &aTTStub ) const
 { 
   /// Calculate average coordinates col/row for inner/outer Cluster
@@ -127,6 +128,98 @@ void TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( 
     aDisplacement = dispI; /// In HALF-STRIP units!
     anOffset      = offsetI; /// In HALF-STRIP units!
     anROffset     = static_cast<float>(offsetD); /// In HALF-STRIP units!
+    anHardBend    = this->degradeBend(isPS, window, (aDisplacement - anOffset)); // In strips units
   } /// End of stub is accepted
 
 }
+
+
+//--- Does the actual work of degrading the bend. (based on I.Tomalin's code
+)
+template< >   
+float TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::degradeBend(bool psModule, int window, int bend) const {
+ 
+
+  // Number of bits used to encoded bend output by FE electronics.
+  const unsigned int bitsPS_ = 3;
+  const unsigned int bits2S_ = 4;
+
+  // Number of degraded bend values should correspond to 3 bits (PS modules) or 4 bits (2S modules),
+  // so measuring everything in half-strip units, max integer "window" size that can be encoded without
+  // compression given by 2*window+1 <= pow(2,B), where B is number of bits.
+  // Hence no compression required if window cut is abs(b) <= 3 (PS) or 7 (2S). Must introduce one merge for
+  // each 1 unit increase in "window" beyond this.
+
+  // Bend is measured with granularity of 0.5 strips.
+  // Convert it to integer measured in half-strip units for this calculation!
+
+  float degradedB;
+  unsigned int numBends = 2*window + 1;
+  unsigned int numAllowed = (psModule)  ?  pow(2, bitsPS_)  :  pow(2, bits2S_);
+
+  // Existance of bend = 0 means can only use an odd number of groups.
+  numAllowed -= 1; // 7 or 15
+  if (numBends <= numAllowed) 
+  { 
+    // Can output uncompressed bend info. (So if window is lower or equal than 1.5 in PS, and 3.5 in 2S
+    degradedB = static_cast<double>(bend);
+  } 
+  else // all other cases, need to compress
+  {
+    unsigned int inSmallGroup   = numBends/numAllowed;
+    unsigned int numLargeGroups = numBends%numAllowed;
+    unsigned int inLargeGroup   = inSmallGroup + 1;
+    unsigned int numSmallGroups = numAllowed - numLargeGroups;
+
+    std::vector<unsigned int> groups;
+
+    // At the end we have
+    //
+    // numBends=inSmallGroup*numSmallGroups+inLargeGroup*numLargeGroups
+    // and
+    // numAllowed= numSmallGroups+numLargeGroups;
+    //
+    // Then you alternate large-small-large-small....large. In the middle, you
+    // put either large or small, depending if group size is odd or not
+
+
+    for (unsigned int i = 0; i < numLargeGroups/2; i++) groups.push_back(inLargeGroup);
+    for (unsigned int i = 0; i < numSmallGroups/2; i++) groups.push_back(inSmallGroup);
+
+    // Only one of numLargeGroups & numSmallGroups can be odd, since numAllowed is odd.
+    // And whichever one is odd is associated to a group with an odd number of elements since numBends is odd,
+    if (numLargeGroups%2 == 1 && inLargeGroup%2 == 1) 
+    {
+      groups.push_back(inLargeGroup);
+    } else if (numSmallGroups%2 == 1 && inSmallGroup%2 == 1) {
+      groups.push_back(inSmallGroup);
+    } else {
+      throw cms::Exception("DegradeBend: logic error with odd numbers");
+    }
+
+    for (unsigned int i = 0; i < numSmallGroups/2; i++) groups.push_back(inSmallGroup);
+    for (unsigned int i = 0; i < numLargeGroups/2; i++) groups.push_back(inLargeGroup);	  
+
+    degradedB = 999;
+    int iUp = -static_cast<int>(window) - 1; // Start with the minimal possible bend -1
+    int iDown;
+
+    for (unsigned int& inGroup: groups) 
+    {
+      iUp   += inGroup;
+      iDown = iUp - inGroup + 1;
+      if (bend <= iUp && bend >= iDown) 
+      {
+	degradedB = 0.5*(iUp + iDown); 
+      }
+    }
+    if (degradedB == 999) throw cms::Exception("DegradeResolution: Logic error in loop over groups");
+  }
+
+  // This is degraded bend in full strip units (neglecting bend sign).
+  return static_cast<float>(degradedB)/2.;
+      
+  
+}
+
+//--- Check for mistakes.

--- a/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
@@ -15,6 +15,7 @@ template< >
 void TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( bool &aConfirmation,
                                                                        int &aDisplacement, 
                                                                        int &anOffset, 
+								       float &anROffset,
                                                                        const TTStub< Ref_Phase2TrackerDigi_ > &aTTStub ) const
 { 
   /// Calculate average coordinates col/row for inner/outer Cluster
@@ -124,7 +125,8 @@ void TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( 
   {
     aConfirmation = true;
     aDisplacement = dispI; /// In HALF-STRIP units!
-    anOffset = offsetI; /// In HALF-STRIP units!
+    anOffset      = offsetI; /// In HALF-STRIP units!
+    anROffset     = static_cast<float>(offsetD); /// In HALF-STRIP units!
   } /// End of stub is accepted
 
 }

--- a/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
@@ -134,8 +134,8 @@ void TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::PatternHitCorrelation( 
 }
 
 
-//--- Does the actual work of degrading the bend. (based on I.Tomalin's code
-)
+//--- Does the actual work of degrading the bend. (based on I.Tomalin's code)
+
 template< >   
 float TTStubAlgorithm_official< Ref_Phase2TrackerDigi_ >::degradeBend(bool psModule, int window, int bend) const {
  

--- a/L1Trigger/TrackTrigger/test/SLHC_MBIAS_TkOnly.py
+++ b/L1Trigger/TrackTrigger/test/SLHC_MBIAS_TkOnly.py
@@ -3,14 +3,14 @@
 # Configuration file for simple MBias events
 # production in tracker only
 # Produces 100 minbias events, to be used as an input in
-# SLHC_PU_TkOnly_90X.py (of course with the same geometry)
+# SLHC_PU_TkOnly.py (of course with the same geometry)
 #
 # UE tuning is UE_P8M1
 #
 # Author: S.Viret (viret@in2p3.fr)
 # Date        : 16/02/2017
 #
-# Script tested with release CMSSW_9_0_0_pre4
+# Script tested with release CMSSW_10_0_0_pre1
 #
 #########################
 #
@@ -30,10 +30,9 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
-process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load('Configuration.StandardSequences.SimIdeal_cff')
-process.load('L1Trigger.TrackTrigger.TkOnlyFlatGeom_cff') # Special config file for TkOnly geometry
 process.load('IOMC.EventVertexGenerators.VtxSmearedGauss_cfi')
 process.load('GeneratorInterface.Core.genFilterSummary_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
@@ -62,7 +61,7 @@ process.source = cms.Source("EmptySource")
 # Global tag for PromptReco
 process.genstepfilter.triggerConditions=cms.vstring("generation_step")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
 
 # Random seeds
 process.RandomNumberGeneratorService.generator.initialSeed      = 1

--- a/L1Trigger/TrackTrigger/test/SLHC_MBIAS_TkOnly.py
+++ b/L1Trigger/TrackTrigger/test/SLHC_MBIAS_TkOnly.py
@@ -61,7 +61,7 @@ process.source = cms.Source("EmptySource")
 # Global tag for PromptReco
 process.genstepfilter.triggerConditions=cms.vstring("generation_step")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 # Random seeds
 process.RandomNumberGeneratorService.generator.initialSeed      = 1

--- a/L1Trigger/TrackTrigger/test/SLHC_PGUN_TkOnly.py
+++ b/L1Trigger/TrackTrigger/test/SLHC_PGUN_TkOnly.py
@@ -1,12 +1,12 @@
 #########################
 #
-# Configuration file for PileUp events
-# production in tracker only
+# Configuration file for simple PGUN events
+# production in Tracker-Only geometry
 #
 # Author: S.Viret (viret@in2p3.fr)
-# Date        : 16/02/2017
+# Date  : 16/02/2017
 #
-# Script tested with release CMSSW_9_0_0_pre4
+# Script tested with release CMSSW_10_0_0_pre1
 #
 #########################
 #
@@ -26,15 +26,14 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
-process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load('Configuration.StandardSequences.SimIdeal_cff')
 process.load('Configuration.StandardSequences.Digi_cff')
-process.load('SimGeneral.MixingModule.mix_POISSON_average_cfi')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 process.load('IOMC.EventVertexGenerators.VtxSmearedGauss_cfi')
 process.load('GeneratorInterface.Core.genFilterSummary_cff')
 process.load('L1Trigger.TrackTrigger.TrackTrigger_cff')
-process.load('L1Trigger.TrackTrigger.TkOnlyFlatGeom_cff') # Special config file for TkOnly geometry
 process.load('SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
@@ -42,41 +41,56 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 if flat:
 	print 'You choose the flat geometry'
 	process.load('L1Trigger.TrackTrigger.TkOnlyFlatGeom_cff') # Special config file for TkOnly geometry
+	process.TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = cms.bool(False) 
+	process.TTStubAlgorithm_official_Phase2TrackerDigi_.EndcapCutSet = cms.VPSet(
+		cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
+		cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2, 3.5, 2, 3.5, 5.5, 6, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 7, 7) ),
+		cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3, 2, 3, 5, 6, 6.5, 6.5, 6.5, 5, 6.5, 6.5, 7, 7) ),
+		cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 1, 1.5, 3, 4.5, 6, 6.5, 6.5, 7, 7, 7, 7, 7) ),
+		cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 1.5, 2., 3.5, 5., 6.5, 6.5, 6.5, 6, 7, 7, 7) ),
+		cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 1., 1.5, 2.5, 4., 5, 7, 5.5, 7, 7, 7, 7) ),
+		)
 else:
 	print 'You choose the tilted geometry'
 	process.load('L1Trigger.TrackTrigger.TkOnlyTiltedGeom_cff') # Special config file for TkOnly geometry
 
+
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(20)
+    input = cms.untracked.int32(100)
 )
 
 # Input source
 process.source = cms.Source("EmptySource")
 
-process.mix.minBunch = cms.int32(-12)
-process.mix.bunchspace=cms.int32(25)
-process.mix.input.nbPileupEvents.averageNumber = cms.double(20.0)  # The average number of pileup events you want  
-process.mix.input.fileNames     = cms.untracked.vstring('file:MBias_100_TkOnly.root') # The file where to pick them up
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('PGun_example_TkOnly.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW-FEVT')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
 
 # Additional output definition
-
 # Other statements
-# Global tag for PromptReco
-#
-# To find where upgradePLS3 is pointing, look here:
-#
-# https://github.com/cms-sw/cmssw/blob/CMSSW_6_2_X_SLHC_2014-06-16-0200/Configuration/AlCa/python/autoCond.py
-
 process.genstepfilter.triggerConditions=cms.vstring("generation_step")
-
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
 
-process.RandomNumberGeneratorService.generator.initialSeed      = 20
+
+# Random seeds
+process.RandomNumberGeneratorService.generator.initialSeed      = 1
 process.RandomNumberGeneratorService.VtxSmeared.initialSeed     = 2
-process.RandomNumberGeneratorService.g4SimHits.initialSeed      = 178
-process.RandomNumberGeneratorService.mix.initialSeed            = 210
-
+process.RandomNumberGeneratorService.g4SimHits.initialSeed      = 3
+process.RandomNumberGeneratorService.mix.initialSeed            = 4
 
 # Generate particle gun events
 process.generator = cms.EDFilter("Pythia8PtGun",
@@ -99,30 +113,15 @@ process.generator = cms.EDFilter("Pythia8PtGun",
 )
 
 
-# Output definition
-
-process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
-    splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
-    outputCommands = process.RAWSIMEventContent.outputCommands,
-    fileName = cms.untracked.string('PU_20_sample_TkOnly_FLAT.root'),
-    dataset = cms.untracked.PSet(
-        filterName = cms.untracked.string(''),
-        dataTier = cms.untracked.string('GEN-SIM')
-    ),
-    SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('generation_step')
-    )
-)
+# This line is necessary to keep track of the Tracking Particles
 
 process.RAWSIMoutput.outputCommands.append('keep  *_*_*_*')
 process.RAWSIMoutput.outputCommands.append('drop  *_mix_*_STUBS')
 process.RAWSIMoutput.outputCommands.append('drop  PCaloHits_*_*_*')
 process.RAWSIMoutput.outputCommands.append('drop  *_ak*_*_*')
-process.RAWSIMoutput.outputCommands.append('drop  *_simSi*_*_*')
+process.RAWSIMoutput.outputCommands.append('drop  *_simSiPixelDigis_*_*')
 process.RAWSIMoutput.outputCommands.append('keep  *_*_MergedTrackTruth_*')
 process.RAWSIMoutput.outputCommands.append('keep  *_mix_Tracker_*')
-
 
 # Path and EndPath definitions
 process.generation_step         = cms.Path(process.pgen)
@@ -140,12 +139,12 @@ process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary
 # filter all path with the production filter sequence
 for path in process.paths:
 	getattr(process,path)._seq = process.generator * getattr(process,path)._seq
+	
+# Automatic addition of the customisation function 
 
-
-# Automatic addition of the customisation function
 from L1Trigger.TrackTrigger.TkOnlyDigi_cff import TkOnlyDigi
-process = TkOnlyDigi(process)
-# End of customisation functions
 
+process = TkOnlyDigi(process) # TkOnly digitization
 
+# End of customisation functions	
 

--- a/L1Trigger/TrackTrigger/test/SLHC_PGUN_TkOnly.py
+++ b/L1Trigger/TrackTrigger/test/SLHC_PGUN_TkOnly.py
@@ -83,7 +83,7 @@ process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
 # Other statements
 process.genstepfilter.triggerConditions=cms.vstring("generation_step")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 
 # Random seeds

--- a/L1Trigger/TrackTrigger/test/SLHC_PU_TkOnly.py
+++ b/L1Trigger/TrackTrigger/test/SLHC_PU_TkOnly.py
@@ -71,7 +71,7 @@ process.mix.input.fileNames     = cms.untracked.vstring('file:MBias_100_TkOnly.r
 process.genstepfilter.triggerConditions=cms.vstring("generation_step")
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 process.RandomNumberGeneratorService.generator.initialSeed      = 20
 process.RandomNumberGeneratorService.VtxSmeared.initialSeed     = 2

--- a/L1Trigger/TrackTrigger/test/SLHC_PU_TkOnly.py
+++ b/L1Trigger/TrackTrigger/test/SLHC_PU_TkOnly.py
@@ -1,12 +1,12 @@
 #########################
 #
-# Configuration file for simple PGUN events
-# production in Tracker-Only geometry
+# Configuration file for PileUp events
+# production in tracker only
 #
 # Author: S.Viret (viret@in2p3.fr)
 # Date        : 16/02/2017
 #
-# Script tested with release CMSSW_9_0_0_pre4
+# Script tested with release CMSSW_10_0_0_pre1
 #
 #########################
 #
@@ -26,15 +26,14 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
-process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load('Configuration.StandardSequences.SimIdeal_cff')
 process.load('Configuration.StandardSequences.Digi_cff')
-process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('SimGeneral.MixingModule.mix_POISSON_average_cfi')
 process.load('IOMC.EventVertexGenerators.VtxSmearedGauss_cfi')
 process.load('GeneratorInterface.Core.genFilterSummary_cff')
 process.load('L1Trigger.TrackTrigger.TrackTrigger_cff')
-process.load('L1Trigger.TrackTrigger.TkOnlyFlatGeom_cff') # Special config file for TkOnly geometry
 process.load('SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
@@ -42,47 +41,43 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 if flat:
 	print 'You choose the flat geometry'
 	process.load('L1Trigger.TrackTrigger.TkOnlyFlatGeom_cff') # Special config file for TkOnly geometry
+	process.TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = cms.bool(False) # Tilted is the new default
+	process.TTStubAlgorithm_official_Phase2TrackerDigi_.EndcapCutSet = cms.VPSet(
+		cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
+		cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2, 3.5, 2, 3.5, 5.5, 6, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 7, 7) ),
+		cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3, 2, 3, 5, 6, 6.5, 6.5, 6.5, 5, 6.5, 6.5, 7, 7) ),
+		cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 1, 1.5, 3, 4.5, 6, 6.5, 6.5, 7, 7, 7, 7, 7) ),
+		cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 1.5, 2., 3.5, 5., 6.5, 6.5, 6.5, 6, 7, 7, 7) ),
+		cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 1., 1.5, 2.5, 4., 5, 7, 5.5, 7, 7, 7, 7) ),
+		)
 else:
 	print 'You choose the tilted geometry'
 	process.load('L1Trigger.TrackTrigger.TkOnlyTiltedGeom_cff') # Special config file for TkOnly geometry
 
-
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(100)
+    input = cms.untracked.int32(5)
 )
 
 # Input source
 process.source = cms.Source("EmptySource")
 
-
-# Output definition
-
-process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
-    splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
-    outputCommands = process.RAWSIMEventContent.outputCommands,
-    fileName = cms.untracked.string('PGun_example_TkOnly.root'),
-    dataset = cms.untracked.PSet(
-        filterName = cms.untracked.string(''),
-        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW-FEVT')
-    ),
-    SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('generation_step')
-    )
-)
+process.mix.minBunch = cms.int32(-12)
+process.mix.bunchspace=cms.int32(25)
+process.mix.input.nbPileupEvents.averageNumber = cms.double(20.0)  # The average number of pileup events you want  
+process.mix.input.fileNames     = cms.untracked.vstring('file:MBias_100_TkOnly.root') # The file where to pick them up
 
 # Additional output definition
-# Other statements
+
 process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
 
-
-# Random seeds
-process.RandomNumberGeneratorService.generator.initialSeed      = 1
+process.RandomNumberGeneratorService.generator.initialSeed      = 20
 process.RandomNumberGeneratorService.VtxSmeared.initialSeed     = 2
-process.RandomNumberGeneratorService.g4SimHits.initialSeed      = 3
-process.RandomNumberGeneratorService.mix.initialSeed            = 4
+process.RandomNumberGeneratorService.g4SimHits.initialSeed      = 178
+process.RandomNumberGeneratorService.mix.initialSeed            = 210
+
 
 # Generate particle gun events
 process.generator = cms.EDFilter("Pythia8PtGun",
@@ -105,15 +100,30 @@ process.generator = cms.EDFilter("Pythia8PtGun",
 )
 
 
-# This line is necessary to keep track of the Tracking Particles
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('PU_20_sample_TkOnly.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN-SIM')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
 
 process.RAWSIMoutput.outputCommands.append('keep  *_*_*_*')
 process.RAWSIMoutput.outputCommands.append('drop  *_mix_*_STUBS')
 process.RAWSIMoutput.outputCommands.append('drop  PCaloHits_*_*_*')
 process.RAWSIMoutput.outputCommands.append('drop  *_ak*_*_*')
-process.RAWSIMoutput.outputCommands.append('drop  *_simSiPixelDigis_*_*')
+process.RAWSIMoutput.outputCommands.append('drop  *_simSi*_*_*')
 process.RAWSIMoutput.outputCommands.append('keep  *_*_MergedTrackTruth_*')
 process.RAWSIMoutput.outputCommands.append('keep  *_mix_Tracker_*')
+
 
 # Path and EndPath definitions
 process.generation_step         = cms.Path(process.pgen)
@@ -131,12 +141,12 @@ process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary
 # filter all path with the production filter sequence
 for path in process.paths:
 	getattr(process,path)._seq = process.generator * getattr(process,path)._seq
-	
-# Automatic addition of the customisation function 
 
+
+# Automatic addition of the customisation function
 from L1Trigger.TrackTrigger.TkOnlyDigi_cff import TkOnlyDigi
+process = TkOnlyDigi(process)
+# End of customisation functions
 
-process = TkOnlyDigi(process) # TkOnly digitization
 
-# End of customisation functions	
 

--- a/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
@@ -165,15 +165,13 @@ bool TTClusterAssociationMap< T >::isGenuine( edm::Ref< edmNew::DetSetVector< TT
 
   std::vector<float> tp_mom;
 
-  tp_mom.clear();
-
   float tp_tot=0;
 
   /// Loop over the TrackingParticles
-  for ( unsigned int itp = 0; itp < theseTrackingParticles.size(); itp++ )
+  for ( const auto& tp : theseTrackingParticles )
   {
     /// Get the TrackingParticle
-    edm::Ptr< TrackingParticle > curTP = theseTrackingParticles.at(itp);
+    edm::Ptr< TrackingParticle > curTP = tp;
 
     /// Count the NULL TrackingParticles
     if ( curTP.isNull() )
@@ -213,17 +211,7 @@ bool TTClusterAssociationMap< T >::isGenuine( edm::Ref< edmNew::DetSetVector< TT
   std::sort( tpAddressVector.begin(), tpAddressVector.end() );
   tpAddressVector.erase( std::unique( tpAddressVector.begin(), tpAddressVector.end() ), tpAddressVector.end() );
   goodDifferentTPs = tpAddressVector.size();
-  /*
-  bool isGenuine=( nullTPs == 0 && goodDifferentTPs == 1 );
 
-  if (!isGenuine)
-  {
-    std::cout << "Into IsGenuineCluster " << theseTrackingParticles.size() << std::endl;
-    std::cout << nullTPs << " / " << goodDifferentTPs << " / " << ( nullTPs == 0 && goodDifferentTPs == 1 ) << std::endl;
-  }
-  */
-  /// GENUINE means no NULLs and only one good TP
-  //return ( nullTPs == 0 && goodDifferentTPs == 1 );
   return ( goodDifferentTPs == 1 );
 }
 

--- a/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
@@ -68,6 +68,8 @@ class TTClusterAssociationMap
     std::map< edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > >, std::vector< edm::Ptr< TrackingParticle > > > clusterToTrackingParticleVectorMap;
     std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > > > trackingParticleToClusterVectorMap;
 
+    int nclus;
+
 }; /// Close class
 
 /*! \brief   Implementation of methods
@@ -85,6 +87,7 @@ TTClusterAssociationMap< T >::TTClusterAssociationMap()
   /// Set default data members
   clusterToTrackingParticleVectorMap.clear();
   trackingParticleToClusterVectorMap.clear();
+  nclus=0;
 }
 
 /// Destructor
@@ -131,11 +134,25 @@ std::vector< edm::Ptr< TrackingParticle > > TTClusterAssociationMap< T >::findTr
 /// ----------------------
 /// >0       | U | C | C
 ///
+
+/// NEW SV 060617
+///
+/// N / D--> | 0 | 1 | >1 (with 1 TP getting >99 of the total pT) | >1
+/// -------------------------------------------------------------------
+/// 0        | U | G | G                                          | C
+/// -------------------------------------------------------------------
+/// >0       | U | G | G                                          | C
+///
+
 template< typename T >
 bool TTClusterAssociationMap< T >::isGenuine( edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > aCluster ) const
 {
+
+
   /// Get the TrackingParticles
   std::vector< edm::Ptr< TrackingParticle > > theseTrackingParticles = this->findTrackingParticlePtrs( aCluster );
+
+
 
   /// If the vector is empty, then the cluster is UNKNOWN
   if ( theseTrackingParticles.empty() )
@@ -146,6 +163,12 @@ bool TTClusterAssociationMap< T >::isGenuine( edm::Ref< edmNew::DetSetVector< TT
   unsigned int goodDifferentTPs = 0;
   std::vector< const TrackingParticle* > tpAddressVector;
 
+  std::vector<float> tp_mom;
+
+  tp_mom.clear();
+
+  float tp_tot=0;
+
   /// Loop over the TrackingParticles
   for ( unsigned int itp = 0; itp < theseTrackingParticles.size(); itp++ )
   {
@@ -154,6 +177,26 @@ bool TTClusterAssociationMap< T >::isGenuine( edm::Ref< edmNew::DetSetVector< TT
 
     /// Count the NULL TrackingParticles
     if ( curTP.isNull() )
+    {
+      //      nullTPs++;
+      tp_mom.push_back(0);
+    }
+    else
+    {
+      tp_mom.push_back(curTP.get()->p4().pt());
+      tp_tot+=curTP.get()->p4().pt();
+    }
+  }
+
+  if (tp_tot==0) return false;
+  
+  for ( unsigned int itp = 0; itp < theseTrackingParticles.size(); itp++ )
+  {
+    /// Get the TrackingParticle
+    edm::Ptr< TrackingParticle > curTP = theseTrackingParticles.at(itp);
+
+    /// Count the NULL TrackingParticles
+    if ( tp_mom.at(itp) <= 0.01*tp_tot)
     {
       nullTPs++;
     }
@@ -164,14 +207,24 @@ bool TTClusterAssociationMap< T >::isGenuine( edm::Ref< edmNew::DetSetVector< TT
       tpAddressVector.push_back( curTP.get() );
     }
   }
+  
 
   /// Count how many different TrackingParticle there are
   std::sort( tpAddressVector.begin(), tpAddressVector.end() );
   tpAddressVector.erase( std::unique( tpAddressVector.begin(), tpAddressVector.end() ), tpAddressVector.end() );
   goodDifferentTPs = tpAddressVector.size();
+  /*
+  bool isGenuine=( nullTPs == 0 && goodDifferentTPs == 1 );
 
+  if (!isGenuine)
+  {
+    std::cout << "Into IsGenuineCluster " << theseTrackingParticles.size() << std::endl;
+    std::cout << nullTPs << " / " << goodDifferentTPs << " / " << ( nullTPs == 0 && goodDifferentTPs == 1 ) << std::endl;
+  }
+  */
   /// GENUINE means no NULLs and only one good TP
-  return ( nullTPs == 0 && goodDifferentTPs == 1 );
+  //return ( nullTPs == 0 && goodDifferentTPs == 1 );
+  return ( goodDifferentTPs == 1 );
 }
 
 template< typename T >
@@ -219,8 +272,16 @@ bool TTClusterAssociationMap< T >::isCombinatoric( edm::Ref< edmNew::DetSetVecto
   std::vector< edm::Ptr< TrackingParticle > > theseTrackingParticles = this->findTrackingParticlePtrs( aCluster );
 
   /// If the vector is empty, then the cluster is UNKNOWN
-  if ( theseTrackingParticles.empty() )
+  if ( theseTrackingParticles.empty())
     return false;
+
+
+  bool genuineClu = this->isGenuine( aCluster );
+  bool unknownClu = this->isUnknown( aCluster );
+
+  if (genuineClu || unknownClu) return false;
+
+  return true;
 
   /// If we are here, it means there are some TrackingParticles
   unsigned int nullTPs = 0;
@@ -253,7 +314,8 @@ bool TTClusterAssociationMap< T >::isCombinatoric( edm::Ref< edmNew::DetSetVecto
 
   /// COMBINATORIC means no NULLs and more than one good TP
   /// OR, in alternative, only one good TP but non-zero NULLS
-  return ( ( nullTPs == 0 && goodDifferentTPs > 1 ) || ( nullTPs > 0 && goodDifferentTPs > 0 ) );
+  //return ( ( nullTPs == 0 && goodDifferentTPs > 1 ) || ( nullTPs > 0 && goodDifferentTPs > 0 ) );
+  return (goodDifferentTPs > 1);
 }
 
 template< typename T >


### PR DESCRIPTION
This branch contains significant updates of the TTStub building algorithm, and a TTCluster association update:

1. **FE inefficiencies**: if this option is turned on (default is off), the MPA/CBC and CIC inefficiencies are accounted for based on the event sequence over which stubs are reconstructed. CIC inefficiency is only partially accounted, MPA and CBC are exact.

2. **Hardware bend degradation**: bend is encoded on a limited number of bits. Therefore for given stub window tuning all the values cannot be encoded independently and they must be grouped. This process is now done during the Stub building, and the degraded bend can be obtained using the getHardwareBend() method, which is added to the TTStub class. Of course nominal bend is still accessible.

3. **Full parallax correction**: within the FE asics, parallax is corrected in half-strips units. However, the exact parallax value can always be retrieved at the backend using the stub position and module radius, and can subsequently be used to improve the bend resolution. This parameter is therefore computed during stub building, and can be retrieved via the method getRealTriggerOffset()

4. **New stub window tuning**: stub are built using the new tuning optimized for PU200 events. The default tuning is PU200 TIGHT. For stub tuning documentation, information is available here: [https://www.dropbox.com/s/sc1ifhfbcv5pts3/Stub%20windows%20tuning-%20a%20tutorial.pdf?dl=0](https://www.dropbox.com/s/sc1ifhfbcv5pts3/Stub%20windows%20tuning-%20a%20tutorial.pdf?dl=0)

5. **Updated TTCluster association scheme**: 
```
/// OLD ASSOCIATION SCHEME
/// MC truth
/// Table to define Genuine, Combinatoric and Unknown
///
/// N = number of NULL TP pointers
/// D = number of GOOD TP pointers different from each other
///
/// N / D--> | 0 | 1 | >1
/// ----------------------
/// 0        | U | G | C
/// ----------------------
/// >0       | U | C | C
```
is replaced by his
```
/// MC truth
/// Table to define Genuine, Combinatoric and Unknown
///
/// N = number of NULL TP pointers
/// D = number of GOOD TP pointers different from each other
///
/// N / D--> | 0 | 1 | >1 (with 1 TP w/more than 99% of total cluster pT) | >1 (other)
/// -------------------------------------------------------------------
/// 0        | U | G | G                                                  | C
/// -------------------------------------------------------------------
/// >0       | U | G | G                                                  | C
///
```
With this new association scheme, a cluster made from more than 1 digis, with one digi associated to a low-pt secondary and the other one associated to the primary will be flagged as genuine and associated to the primary TP. Was flagged as combinatoric with the previous association.

**IMPORTANT NOTE**: This PR does not include any modification of the TTTrack class, as Track Trigger algorithm using it are still in development phase within CMSSW