### PR TITLE
Revert making a copy of RefCore in RefVector calls

### DIFF
--- a/DataFormats/Common/interface/RefVector.h
+++ b/DataFormats/Common/interface/RefVector.h
@@ -77,7 +77,7 @@ namespace edm {
       key_type const& key = refVector_.keys()[idx];
       void const* memberPointer = refVector_.cachedMemberPointer(idx);
       if(memberPointer) {
-        const RefCore& newCore(core);
+        RefCore newCore(core);
         newCore.setProductPtr(memberPointer);
         return value_type(newCore, key);
       }
@@ -90,7 +90,7 @@ namespace edm {
       key_type const& key = refVector_.keys().at(idx);
       void const* memberPointer = refVector_.cachedMemberPointer(idx);
       if(memberPointer) {
-        const RefCore& newCore(core);
+        RefCore newCore(core);
         newCore.setProductPtr(memberPointer);
         return value_type(newCore, key);
       }

--- a/DataFormats/Common/interface/RefVector.h
+++ b/DataFormats/Common/interface/RefVector.h
@@ -77,7 +77,7 @@ namespace edm {
       key_type const& key = refVector_.keys()[idx];
       void const* memberPointer = refVector_.cachedMemberPointer(idx);
       if(memberPointer) {
-        RefCore newCore(core);
+        RefCore newCore(core); // NOLINT
         newCore.setProductPtr(memberPointer);
         return value_type(newCore, key);
       }
@@ -90,7 +90,7 @@ namespace edm {
       key_type const& key = refVector_.keys().at(idx);
       void const* memberPointer = refVector_.cachedMemberPointer(idx);
       if(memberPointer) {
-        RefCore newCore(core);
+        RefCore newCore(core); // NOLINT
         newCore.setProductPtr(memberPointer);
         return value_type(newCore, key);
       }


### PR DESCRIPTION
The clang check change made previously incorrectly converted a needed copy to just be a const ref. This ultimately lead to a threading race-condition when that code was called.