### PR TITLE
clear valgrind warning in VirtualJetProducers not using HEPTopTagger

### DIFF
--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -220,7 +220,7 @@ protected:
   unsigned int                    minSeed_;              // minimum seed to use, useful for MC generation
 
   int                   verbosity_;                 // flag to enable/disable debug output
-  bool                  fromHTTTopJetProducer_;   // for running the v2.0 HEPTopTagger
+  bool                  fromHTTTopJetProducer_ = false;   // for running the v2.0 HEPTopTagger
 
 private:
   std::auto_ptr<AnomalousTower>   anomalousTowerDef_;  // anomalous tower definition


### PR DESCRIPTION
addHTTTopJetTagInfoCollection is a no-op, but it's execution or not depends on fromHTTTopJetProducer_, which is uninitialized in the baseline. This triggers a warning in valgrind even though there is no effect.
This PR initializes this parameter.