### PR TITLE
Better handling of TFormula in PerformancePayloadFromTFormula

### DIFF
--- a/CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h
+++ b/CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <iostream>
 #include "TFormula.h"
 #include "CondFormats/PhysicsToolsObjects/interface/BinningPointByMap.h"
@@ -86,7 +86,7 @@ class PerformancePayloadFromTFormula : public PerformancePayload {
   //
   // the transient part
   //
-  std::vector< boost::shared_ptr<TFormula> > compiledFormulas_ COND_TRANSIENT;
+  std::vector< std::shared_ptr<const TFormula> > compiledFormulas_ COND_TRANSIENT;
 
  COND_SERIALIZABLE;
 };

--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
@@ -17,9 +17,10 @@ void PerformancePayloadFromTFormula::initialize() {
   for( std::vector<std::string>::const_iterator formula = pl.formulas().begin(); formula != pl.formulas().end(); ++formula ) {
     boost::uuids::uuid uniqueFormulaId = gen();
     const auto formulaUniqueName = boost::lexical_cast<std::string>(uniqueFormulaId);
-    boost::shared_ptr<TFormula> temp(new TFormula(formulaUniqueName.c_str(),formula->c_str()));
+    //be sure not to add TFormula to ROOT's global list
+    auto temp = std::make_shared<TFormula>(formulaUniqueName.c_str(),formula->c_str(),false);
     temp->Compile();
-    compiledFormulas_.push_back(temp);
+    compiledFormulas_.emplace_back(std::move(temp));
   }
 }
 
@@ -33,8 +34,8 @@ float PerformancePayloadFromTFormula::getResult(PerformanceResult::ResultType r 
     edm::LogError("PerformancePayloadFromTFormula") <<"Missing formula in conditions. Maybe code/conditions are inconsistent" << std::endl;
     assert(false);
   }
-  // nice, what to do here???
-  const boost::shared_ptr<TFormula>& formula = compiledFormulas_[resultPos(r)];
+  
+  const TFormula* formula = compiledFormulas_[resultPos(r)].get();
   //
   // prepare the vector to pass, order counts!!!
   //
@@ -47,11 +48,6 @@ float PerformancePayloadFromTFormula::getResult(PerformanceResult::ResultType r 
     values[i] = p.value(*it);
   }
   //
-  // i need a non const version #$%^
-  // Note, in current implementation of TFormula EvalPar should be
-  // thread safe as it does nothing more than call a function
-  // through a function pointer which is stateless. In spite of the
-  // fact that it is not const.
   return formula->EvalPar(values);
 }
 
@@ -86,9 +82,9 @@ void PerformancePayloadFromTFormula::printFormula(PerformanceResult::ResultType 
     return;
   }
 
-  // nice, what to do here???
-  const boost::shared_ptr<TFormula>& formula =
-    compiledFormulas_[resultPos(res)];
+
+  const TFormula* formula =
+    compiledFormulas_[resultPos(res)].get();
   cout << "-- Formula: " << formula->GetExpFormula("p") << endl;
   // prepare the vector to pass, order counts!!!
   //


### PR DESCRIPTION
The new TFormula interface is 'const' so PerformancePayloadFromTFormula
can now hold const TFormula. In addition, the TFormula are explicitly
not added to ROOT's global list of TFormula.