### PR TITLE
Explicitly pass run number to SiStrip DQM classes

### DIFF
--- a/DQM/SiStripMonitorClient/src/SiStripAnalyser.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripAnalyser.cc
@@ -141,7 +141,7 @@ void SiStripAnalyser::beginRun(edm::Run const& run, edm::EventSetup const& eSetu
     eSetup.get<SiStripFedCablingRcd>().get(fedCabling_);
     eSetup.get<SiStripDetCablingRcd>().get(detCabling_);
   } 
-  if (condDataMon_) condDataMon_->beginRun(eSetup);
+  if (condDataMon_) condDataMon_->beginRun(run.run(),eSetup);
   if (globalStatusFilling_) actionExecutor_->createStatus(dqmStore_);
 }
 //

--- a/DQM/SiStripMonitorSummary/interface/SiStripApvGainsDQM.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripApvGainsDQM.h
@@ -15,6 +15,7 @@ class SiStripApvGainsDQM : public SiStripBaseCondObjDQM{
   public:
   
   SiStripApvGainsDQM(const edm::EventSetup & eSetup,
+                     edm::RunNumber_t iRun,
                      edm::ParameterSet const& hPSet,
                      edm::ParameterSet const& fPSet);
   

--- a/DQM/SiStripMonitorSummary/interface/SiStripBackPlaneCorrectionDQM.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripBackPlaneCorrectionDQM.h
@@ -13,8 +13,9 @@ class SiStripBackPlaneCorrectionDQM : public SiStripBaseCondObjDQM{
   public:
   
   SiStripBackPlaneCorrectionDQM(const edm::EventSetup & eSetup,
-                             edm::ParameterSet const& hPSet,
-                             edm::ParameterSet const& fPSet);
+                                edm::RunNumber_t iRun,
+                                edm::ParameterSet const& hPSet,
+                                edm::ParameterSet const& fPSet);
   
   ~SiStripBackPlaneCorrectionDQM() override;
   

--- a/DQM/SiStripMonitorSummary/interface/SiStripBaseCondObjDQM.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripBaseCondObjDQM.h
@@ -46,6 +46,7 @@ class SiStripBaseCondObjDQM {
 		 
 
   SiStripBaseCondObjDQM(const edm::EventSetup & eSetup,
+                        edm::RunNumber_t iRun,
 			edm::ParameterSet const& hPSet,
 			edm::ParameterSet const& fPSet );
   
@@ -158,6 +159,7 @@ class SiStripBaseCondObjDQM {
     SiStripHistoId hidmanager;                        
     SiStripFolderOrganizer folder_organizer;         
     DQMStore* dqmStore_;
+    edm::RunNumber_t runNumber_;
 
 };
 

--- a/DQM/SiStripMonitorSummary/interface/SiStripCablingDQM.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripCablingDQM.h
@@ -17,6 +17,7 @@ class SiStripCablingDQM: public SiStripBaseCondObjDQM{
   public:
 
   SiStripCablingDQM(const edm::EventSetup & eSetup,
+                    edm::RunNumber_t iRun,
 		    edm::ParameterSet const& hPSet,
 		    edm::ParameterSet const& fPSet);
   

--- a/DQM/SiStripMonitorSummary/interface/SiStripClassToMonitorCondData.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripClassToMonitorCondData.h
@@ -47,7 +47,7 @@ class SiStripClassToMonitorCondData{
    ~SiStripClassToMonitorCondData();
    
    void beginJob() ;  
-   void beginRun(edm::EventSetup const& eSetup);
+   void beginRun(edm::RunNumber_t iRun, edm::EventSetup const& eSetup);
    void analyseCondData(const edm::EventSetup&);
    void endRun(edm::EventSetup const& eSetup);
    void endJob() ;

--- a/DQM/SiStripMonitorSummary/interface/SiStripLorentzAngleDQM.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripLorentzAngleDQM.h
@@ -13,8 +13,9 @@ class SiStripLorentzAngleDQM : public SiStripBaseCondObjDQM{
   public:
   
   SiStripLorentzAngleDQM(const edm::EventSetup & eSetup,
-                             edm::ParameterSet const& hPSet,
-                             edm::ParameterSet const& fPSet);
+                         edm::RunNumber_t iRun,
+                         edm::ParameterSet const& hPSet,
+                         edm::ParameterSet const& fPSet);
   
   ~SiStripLorentzAngleDQM() override;
   

--- a/DQM/SiStripMonitorSummary/interface/SiStripNoisesDQM.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripNoisesDQM.h
@@ -14,6 +14,7 @@ class SiStripNoisesDQM : public SiStripBaseCondObjDQM{
   public:
   
   SiStripNoisesDQM(const edm::EventSetup & eSetup,
+                   edm::RunNumber_t iRun,
                    edm::ParameterSet const& hPSet,
                    edm::ParameterSet const& fPSet);
   

--- a/DQM/SiStripMonitorSummary/interface/SiStripPedestalsDQM.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripPedestalsDQM.h
@@ -13,6 +13,7 @@ class SiStripPedestalsDQM : public SiStripBaseCondObjDQM{
   public:
   
   SiStripPedestalsDQM(const edm::EventSetup & eSetup,
+                      edm::RunNumber_t iRun,
                       edm::ParameterSet const& hPSet,
                       edm::ParameterSet const& fPSet);
   

--- a/DQM/SiStripMonitorSummary/interface/SiStripQualityDQM.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripQualityDQM.h
@@ -30,8 +30,9 @@ class SiStripQualityDQM : public SiStripBaseCondObjDQM{
   public:
   
   SiStripQualityDQM(const edm::EventSetup & eSetup,
-                      edm::ParameterSet const& hPSet,
-                      edm::ParameterSet const& fPSet);
+                    edm::RunNumber_t iRun,
+                    edm::ParameterSet const& hPSet,
+                    edm::ParameterSet const& fPSet);
   
   ~SiStripQualityDQM() override;
   

--- a/DQM/SiStripMonitorSummary/interface/SiStripThresholdDQM.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripThresholdDQM.h
@@ -13,6 +13,7 @@ class SiStripThresholdDQM : public SiStripBaseCondObjDQM{
   public:
   
   SiStripThresholdDQM(const edm::EventSetup & eSetup,
+                      edm::RunNumber_t iRun,
                       edm::ParameterSet const& hPSet,
                       edm::ParameterSet const& fPSet);
   

--- a/DQM/SiStripMonitorSummary/src/SiStripApvGainsDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripApvGainsDQM.cc
@@ -6,8 +6,9 @@
 
 // -----
 SiStripApvGainsDQM::SiStripApvGainsDQM(const edm::EventSetup & eSetup,
+                                       edm::RunNumber_t iRun,
                                        edm::ParameterSet const& hPSet,
-                                       edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup,hPSet, fPSet){
+                                       edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup,iRun,hPSet, fPSet){
 
   // Build the Histo_TkMap:
   if ( HistoMaps_On_ ) {

--- a/DQM/SiStripMonitorSummary/src/SiStripBackPlaneCorrectionDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripBackPlaneCorrectionDQM.cc
@@ -6,8 +6,9 @@
 
 // -----
 SiStripBackPlaneCorrectionDQM::SiStripBackPlaneCorrectionDQM(const edm::EventSetup & eSetup,
-					       edm::ParameterSet const& hPSet,
-					       edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, hPSet, fPSet){
+                                                             edm::RunNumber_t iRun,
+                                                             edm::ParameterSet const& hPSet,
+                                                             edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, iRun, hPSet, fPSet){
 
   // Build the Histo_TkMap:
   if ( HistoMaps_On_ ) {

--- a/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
@@ -9,13 +9,15 @@
 
 
 SiStripBaseCondObjDQM::SiStripBaseCondObjDQM(const edm::EventSetup & eSetup,
+                                             edm::RunNumber_t iRun,
                                              edm::ParameterSet const& hPSet,
                                              edm::ParameterSet const& fPSet ):
   eSetup_(eSetup),
   hPSet_(hPSet),
   fPSet_(fPSet),
   cacheID_memory(0),
-  dqmStore_(edm::Service<DQMStore>().operator->()){
+  dqmStore_(edm::Service<DQMStore>().operator->()),
+  runNumber_(iRun) {
 
   reader = new SiStripDetInfoFileReader(edm::FileInPath(std::string("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat") ).fullPath());
   
@@ -76,8 +78,9 @@ void SiStripBaseCondObjDQM::analysis(const edm::EventSetup & eSetup_){
   if(fPSet_.getParameter<bool>("TkMap_On") || hPSet_.getParameter<bool>("TkMap_On")) {
     std::string filename = hPSet_.getParameter<std::string>("TkMapName");
     if (filename!=""){
-      char sRun[128];
-      sprintf(sRun,"_Run_%d",eSetup_.iovSyncValue().eventID().run());
+      constexpr unsigned int kSLen = 128;
+      char sRun[kSLen];
+      snprintf(sRun,kSLen, "_Run_%d",runNumber_);
       filename.insert(filename.find("."),sRun);
       
       saveTkMap(filename, minValue, maxValue);

--- a/DQM/SiStripMonitorSummary/src/SiStripCablingDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripCablingDQM.cc
@@ -6,8 +6,9 @@ using namespace std;
 // -----
 
 SiStripCablingDQM::SiStripCablingDQM(const edm::EventSetup & eSetup,
+                                     edm::RunNumber_t iRun,
 				     edm::ParameterSet const& hPSet,
-				     edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, hPSet, fPSet){
+				     edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, iRun, hPSet, fPSet){
 
   // Build the Histo_TkMap:
   if ( HistoMaps_On_ ) {

--- a/DQM/SiStripMonitorSummary/src/SiStripClassToMonitorCondData.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripClassToMonitorCondData.cc
@@ -103,10 +103,11 @@ SiStripClassToMonitorCondData::~SiStripClassToMonitorCondData(){
 //
 // ----- beginRun
 //    
-void SiStripClassToMonitorCondData::beginRun(edm::EventSetup const& eSetup) {
+void SiStripClassToMonitorCondData::beginRun(edm::RunNumber_t iRun, edm::EventSetup const& eSetup) {
   
   if(monitorPedestals_){
     pedestalsDQM_ = new SiStripPedestalsDQM(eSetup,
+                                            iRun,
                                             conf_.getParameter<edm::ParameterSet>("SiStripPedestalsDQM_PSet"),
                                             conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
@@ -114,6 +115,7 @@ void SiStripClassToMonitorCondData::beginRun(edm::EventSetup const& eSetup) {
   
   if(monitorNoises_){
     noisesDQM_ = new SiStripNoisesDQM(eSetup,
+                                      iRun,
                                       conf_.getParameter<edm::ParameterSet>("SiStripNoisesDQM_PSet"),
                                       conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
@@ -121,6 +123,7 @@ void SiStripClassToMonitorCondData::beginRun(edm::EventSetup const& eSetup) {
   
   if(monitorQuality_){
     qualityDQM_ = new SiStripQualityDQM(eSetup,
+                                        iRun,
                                         conf_.getParameter<edm::ParameterSet>("SiStripQualityDQM_PSet"),
                                         conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   } 
@@ -128,36 +131,42 @@ void SiStripClassToMonitorCondData::beginRun(edm::EventSetup const& eSetup) {
  
   if(monitorApvGains_){
     apvgainsDQM_ = new SiStripApvGainsDQM(eSetup,
+                                          iRun,
                                           conf_.getParameter<edm::ParameterSet>("SiStripApvGainsDQM_PSet"),
                                           conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
   
   if(monitorLorentzAngle_){
     lorentzangleDQM_ = new SiStripLorentzAngleDQM(eSetup,
+                                                  iRun,
                                                   conf_.getParameter<edm::ParameterSet>("SiStripLorentzAngleDQM_PSet"),
                                                   conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if(monitorBackPlaneCorrection_){
     bpcorrectionDQM_ = new SiStripBackPlaneCorrectionDQM(eSetup,
+                                                         iRun,
                                                   conf_.getParameter<edm::ParameterSet>("SiStripBackPlaneCorrectionDQM_PSet"),
                                                   conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
   
   if(monitorLowThreshold_){
     lowthresholdDQM_ = new SiStripThresholdDQM(eSetup,
+                                               iRun,
                                                conf_.getParameter<edm::ParameterSet>("SiStripLowThresholdDQM_PSet"),
                                                conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if(monitorHighThreshold_){
     highthresholdDQM_ = new SiStripThresholdDQM(eSetup,
+                                                iRun,
                                                 conf_.getParameter<edm::ParameterSet>("SiStripHighThresholdDQM_PSet"),
                                                 conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if(monitorCabling_){
     cablingDQM_ = new SiStripCablingDQM(eSetup,
+                                        iRun,
                                         conf_.getParameter<edm::ParameterSet>("SiStripCablingDQM_PSet"),
                                         conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }

--- a/DQM/SiStripMonitorSummary/src/SiStripLorentzAngleDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripLorentzAngleDQM.cc
@@ -6,8 +6,9 @@
 
 // -----
 SiStripLorentzAngleDQM::SiStripLorentzAngleDQM(const edm::EventSetup & eSetup,
+                                               edm::RunNumber_t iRun,
 					       edm::ParameterSet const& hPSet,
-					       edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, hPSet, fPSet){
+					       edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, iRun, hPSet, fPSet){
 
   // Build the Histo_TkMap:
   if ( HistoMaps_On_ ) {

--- a/DQM/SiStripMonitorSummary/src/SiStripMonitorCondData.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripMonitorCondData.cc
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -93,57 +94,66 @@ void SiStripMonitorCondData::beginRun(edm::Run const& run, edm::EventSetup const
 
   if(monitorPedestals_){
     pedestalsDQM_ = new SiStripPedestalsDQM(eSetup,
-                                           conf_.getParameter<edm::ParameterSet>("SiStripPedestalsDQM_PSet"),
-                                           conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+                                            run.run(),
+                                            conf_.getParameter<edm::ParameterSet>("SiStripPedestalsDQM_PSet"),
+                                            conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
   
   
   if(monitorNoises_){
     noisesDQM_ = new SiStripNoisesDQM(eSetup,
-                                     conf_.getParameter<edm::ParameterSet>("SiStripNoisesDQM_PSet"),
-                                     conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+                                      run.run(),
+                                      conf_.getParameter<edm::ParameterSet>("SiStripNoisesDQM_PSet"),
+                                      conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
   
   
   if(monitorLowThreshold_){
     lowthresholdDQM_ = new SiStripThresholdDQM(eSetup,
-                                           conf_.getParameter<edm::ParameterSet>("SiStripLowThresholdDQM_PSet"),
-                                           conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+                                               run.run(),
+                                               conf_.getParameter<edm::ParameterSet>("SiStripLowThresholdDQM_PSet"),
+                                               conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if(monitorHighThreshold_){
     highthresholdDQM_ = new SiStripThresholdDQM(eSetup,
-                                           conf_.getParameter<edm::ParameterSet>("SiStripHighThresholdDQM_PSet"),
-                                           conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+                                                run.run(),
+                                                conf_.getParameter<edm::ParameterSet>("SiStripHighThresholdDQM_PSet"),
+                                                conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if(monitorQuality_){
     qualityDQM_ = new SiStripQualityDQM(eSetup,
-                                       conf_.getParameter<edm::ParameterSet>("SiStripQualityDQM_PSet"),
-                                       conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+                                        run.run(),
+                                        conf_.getParameter<edm::ParameterSet>("SiStripQualityDQM_PSet"),
+                                        conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   } 
   
  
   if(monitorApvGains_){
     apvgainsDQM_ = new SiStripApvGainsDQM(eSetup,
-                                         conf_.getParameter<edm::ParameterSet>("SiStripApvGainsDQM_PSet"),
-                                         conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+                                          run.run(),
+                                          conf_.getParameter<edm::ParameterSet>("SiStripApvGainsDQM_PSet"),
+                                          conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
   
   
   if(monitorLorentzAngle_){
     lorentzangleDQM_ = new SiStripLorentzAngleDQM(eSetup,
+                                                  run.run(),
                                                  conf_.getParameter<edm::ParameterSet>("SiStripLorentzAngleDQM_PSet"),
                                                  conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if(monitorBackPlaneCorrection_){
     bpcorrectionDQM_ = new SiStripBackPlaneCorrectionDQM(eSetup,
+                                                         run.run(),
                                                  conf_.getParameter<edm::ParameterSet>("SiStripBackPlaneCorrectionDQM_PSet"),
                                                  conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
   if(monitorCabling_){
     cablingDQM_ = new SiStripCablingDQM(eSetup,
+                                        run.run(),
 					conf_.getParameter<edm::ParameterSet>("SiStripCablingDQM_PSet"),
 					conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }

--- a/DQM/SiStripMonitorSummary/src/SiStripMonitorCondDataOnDemandExample.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripMonitorCondDataOnDemandExample.cc
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -52,7 +53,7 @@ SiStripMonitorCondDataOnDemandExample::~SiStripMonitorCondDataOnDemandExample(){
 void SiStripMonitorCondDataOnDemandExample::beginRun(edm::Run const& run, edm::EventSetup const& eSetup) {  
   eventCounter_=0;
   condDataMonitoring_ = new SiStripClassToMonitorCondData(conf_);
-  condDataMonitoring_->beginRun(eSetup);
+  condDataMonitoring_->beginRun(run.run(),eSetup);
   
   
 

--- a/DQM/SiStripMonitorSummary/src/SiStripNoisesDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripNoisesDQM.cc
@@ -7,8 +7,9 @@
 
 // -----
 SiStripNoisesDQM::SiStripNoisesDQM(const edm::EventSetup & eSetup,
+                                   edm::RunNumber_t iRun,
                                    edm::ParameterSet const& hPSet,
-                                   edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, hPSet, fPSet){  
+                                   edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, iRun, hPSet, fPSet){  
   gainRenormalisation_ = hPSet_.getParameter<bool>("GainRenormalisation");
   simGainRenormalisation_ = hPSet_.getParameter<bool>("SimGainRenormalisation");
   if( gainRenormalisation_ && !simGainRenormalisation_){ eSetup.get<SiStripApvGainRcd>().get(gainHandle_);}

--- a/DQM/SiStripMonitorSummary/src/SiStripPedestalsDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripPedestalsDQM.cc
@@ -5,8 +5,9 @@
 
 // -----
 SiStripPedestalsDQM::SiStripPedestalsDQM(const edm::EventSetup & eSetup,
+                                         edm::RunNumber_t iRun,
                                          edm::ParameterSet const& hPSet,
-                                         edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, hPSet, fPSet){
+                                         edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, iRun, hPSet, fPSet){
 
   // Build the Histo_TkMap:
   if ( HistoMaps_On_ ) {

--- a/DQM/SiStripMonitorSummary/src/SiStripQualityDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripQualityDQM.cc
@@ -5,8 +5,9 @@
 
 // -----
 SiStripQualityDQM::SiStripQualityDQM(const edm::EventSetup & eSetup,
-                                         edm::ParameterSet const& hPSet,
-                                         edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, hPSet, fPSet){
+                                     edm::RunNumber_t iRun,
+                                     edm::ParameterSet const& hPSet,
+                                     edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, iRun, hPSet, fPSet){
   qualityLabel_ = fPSet.getParameter<std::string>("StripQualityLabel");
 
   // Build the Histo_TkMap:

--- a/DQM/SiStripMonitorSummary/src/SiStripThresholdDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripThresholdDQM.cc
@@ -6,8 +6,9 @@
 
 // -----
 SiStripThresholdDQM::SiStripThresholdDQM(const edm::EventSetup & eSetup,
+                                         edm::RunNumber_t iRun,
                                          edm::ParameterSet const& hPSet,
-                                         edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, hPSet, fPSet){
+                                         edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, iRun, hPSet, fPSet){
   WhichThreshold=hPSet.getParameter<std::string>("WhichThreshold");
 
   // Build the Histo_TkMap:


### PR DESCRIPTION
The EventSetup::iovSyncValue method is being removed. The run number
is now explicitly passed to the DQM classes instead of being pulled
from the EventSetup.