### PR TITLE
ME3/1 ME4/1 Phase-2 upgrade TMB

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
@@ -18,7 +18,7 @@
  * \author Slava Valuev, UCLA.
  *
  * The trigger primitive emulator has been expanded with options to
- * use both ALCTs, CLCTs and GEM pads or RPC digis. The GEM-CSC integrated
+ * use both ALCTs, CLCTs and GEM pads. The GEM-CSC integrated
  * local trigger combines ALCT, CLCT and GEM information to produce integrated
  * stubs. The available stub types can be found in the class definition of
  * CSCCorrelatedLCTDigi (DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h)

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -460,6 +460,10 @@ me3141tmbSLHC = cms.PSet(
     matchEarliestClctOnly = cms.bool(False),
     tmbCrossBxAlgorithm = cms.uint32(2),
     maxLCTs = cms.uint32(2),
+
+    ## run in debug mode
+    debugLUTs = cms.bool(False),
+    debugMatching = cms.bool(False),
 )
 
 ## unganging in ME1/a

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -331,8 +331,8 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
     )
 )
 
-# Upgrade era customizations involving GEMs and RPCs
-# ==================================================
+# Upgrade era customizations involving GEMs
+# =========================================
 copadParamGE11 = cms.PSet(
      verbosity = cms.uint32(0),
      maxDeltaPad = cms.uint32(2),
@@ -442,6 +442,26 @@ me21tmbSLHCGEM = cms.PSet(
     promoteCLCTGEMquality = cms.bool(True),
 )
 
+# to be used by ME31-ME41 chambers
+me3141tmbSLHC = cms.PSet(
+    mpcBlockMe1a    = cms.uint32(0),
+    alctTrigEnable  = cms.uint32(0),
+    clctTrigEnable  = cms.uint32(0),
+    matchTrigEnable = cms.uint32(1),
+    matchTrigWindowSize = cms.uint32(3),
+    tmbL1aWindowSize = cms.uint32(7),
+    verbosity = cms.int32(0),
+    tmbEarlyTbins = cms.int32(4),
+    tmbReadoutEarliest2 = cms.bool(False),
+    tmbDropUsedAlcts = cms.bool(False),
+    clctToAlct = cms.bool(False),
+    tmbDropUsedClcts = cms.bool(False),
+    matchEarliestAlctOnly = cms.bool(False),
+    matchEarliestClctOnly = cms.bool(False),
+    tmbCrossBxAlgorithm = cms.uint32(2),
+    maxLCTs = cms.uint32(2),
+)
+
 ## unganging in ME1/a
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
 run2_common.toModify( cscTriggerPrimitiveDigis,
@@ -464,13 +484,17 @@ run3_GEM.toModify( cscTriggerPrimitiveDigis,
                    copadParamGE11 = copadParamGE11
                    )
 
-## GEM-CSC ILT in ME2/1, CSC-RPC ILT in ME3/1 and ME4/1
+## GEM-CSC ILT in ME2/1, CSC in ME3/1 and ME4/1
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( cscTriggerPrimitiveDigis,
-                      commonParam = dict(runME21ILT = cms.bool(True)),
+                      commonParam = dict(runME21ILT = cms.bool(True),
+                                         runME3141ILT = cms.bool(True)),
                       alctSLHCME21 = cscTriggerPrimitiveDigis.alctSLHC.clone(alctNplanesHitPattern = 3),
                       clctSLHCME21 = cscTriggerPrimitiveDigis.clctSLHC.clone(clctNplanesHitPattern = 3),
                       me21tmbSLHCGEM = me21tmbSLHCGEM,
+                      alctSLHCME3141 = cscTriggerPrimitiveDigis.alctSLHC.clone(alctNplanesHitPattern = 4),
+                      clctSLHCME3141 = cscTriggerPrimitiveDigis.clctSLHC.clone(clctNplanesHitPattern = 4),
+                      me3141tmbSLHC = me3141tmbSLHC,
                       copadParamGE11 = copadParamGE11,
                       copadParamGE21 = copadParamGE21
 )

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.h
@@ -15,7 +15,7 @@
  *
  * Updates for high pileup running by Vadim Khotilovich (TAMU), December 2012
  *
- * Updates for integrated local trigger with GEMs and RPCs by 
+ * Updates for integrated local trigger with GEMs by
  * Sven Dildick (TAMU) and Tao Huang (TAMU), April 2015
  *
  * Removing usage of outdated class CSCTriggerGeometry by Sven Dildick (TAMU)
@@ -152,7 +152,7 @@ class CSCAnodeLCTProcessor
   /** SLHC: delta BX time depth for ghostCancellationLogic */
   int ghost_cancellation_bx_depth;
 
-  /** SLHC: whether to consider ALCT candidates' qualities 
+  /** SLHC: whether to consider ALCT candidates' qualities
       while doing ghostCancellationLogic on +-1 wire groups */
   bool ghost_cancellation_side_quality;
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
@@ -25,7 +25,7 @@
  *
  * Updates for high pileup running by Vadim Khotilovich (TAMU), December 2012
  *
- * Updates for integrated local trigger with GEMs and RPCs by 
+ * Updates for integrated local trigger with GEMs by
  * Sven Dildick (TAMU) and Tao Huang (TAMU), April 2015
  *
  * Removing usage of outdated class CSCTriggerGeometry by Sven Dildick (TAMU)
@@ -70,7 +70,7 @@ class CSCCathodeLCTProcessor
       finding. */
   void run(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 	   const std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
- 
+
   /** Access routines to comparator digis. */
   bool getDigis(const CSCComparatorDigiCollection* compdc);
   void getDigis(const CSCComparatorDigiCollection* compdc, const CSCDetId& id);
@@ -132,14 +132,14 @@ class CSCCathodeLCTProcessor
   const unsigned theSector;
   const unsigned theSubsector;
   const unsigned theTrigChamber;
-  
+
   const CSCGeometry* csc_g;
-  
+
   // holders for easy access:
   unsigned int theRing;
   unsigned int theChamber;
   bool isME11;
-  
+
   int numStrips;
   int stagger[CSCConstants::NUM_LAYERS];
 
@@ -147,7 +147,7 @@ class CSCCathodeLCTProcessor
   std::vector<int> thePreTriggerBXs;
 
   /** Flag for "real" - not idealized - version of the algorithm. */
-  bool isMTCC; 
+  bool isMTCC;
 
   /** Flag for 2007 firmware version. */
   bool isTMB07;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -98,9 +98,12 @@ CSCMotherboard::CSCMotherboard(unsigned endcap, unsigned station,
                                            conf.getParameter<edm::ParameterSet>("me11tmbSLHCGEM"):edm::ParameterSet());
   const edm::ParameterSet me21tmbGemParams(conf.existsAs<edm::ParameterSet>("me21tmbSLHCGEM")?
                                            conf.getParameter<edm::ParameterSet>("me21tmbSLHCGEM"):edm::ParameterSet());
+  const edm::ParameterSet me3141tmbParams(conf.existsAs<edm::ParameterSet>("me3141tmbSLHC")?
+                                             conf.getParameter<edm::ParameterSet>("me3141tmbSLHC"):edm::ParameterSet());
 
   const bool runME11ILT(commonParams.existsAs<bool>("runME11ILT")?commonParams.getParameter<bool>("runME11ILT"):false);
   const bool runME21ILT(commonParams.existsAs<bool>("runME21ILT")?commonParams.getParameter<bool>("runME21ILT"):false);
+  const bool runME3141ILT(commonParams.existsAs<bool>("runME3141ILT")?commonParams.getParameter<bool>("runME3141ILT"):false);
 
   // run upgrade TMBs for all MEX/1 stations
   if (isSLHC and theRing == 1){
@@ -116,6 +119,11 @@ CSCMotherboard::CSCMotherboard(unsigned endcap, unsigned station,
       tmbParams = me21tmbGemParams;
       alctParams = conf.getParameter<edm::ParameterSet>("alctSLHCME21");
       clctParams = conf.getParameter<edm::ParameterSet>("clctSLHCME21");
+    }
+    else if ((theStation == 3 or theStation == 4) and runME3141ILT) {
+      tmbParams = me3141tmbParams;
+      alctParams = conf.getParameter<edm::ParameterSet>("alctSLHCME3141");
+      clctParams = conf.getParameter<edm::ParameterSet>("clctSLHCME3141");
     }
   }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.cc
@@ -1,0 +1,216 @@
+#include "L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.h"
+#include "DataFormats/MuonDetId/interface/CSCTriggerNumbering.h"
+
+CSCMotherboardME3141::CSCMotherboardME3141(unsigned endcap, unsigned station,
+                                     unsigned sector, unsigned subsector,
+                                     unsigned chamber,
+                                     const edm::ParameterSet& conf) :
+  CSCUpgradeMotherboard(endcap, station, sector, subsector, chamber, conf)
+  , allLCTs(match_trig_window_size)
+{
+}
+
+CSCMotherboardME3141::CSCMotherboardME3141()
+  : CSCUpgradeMotherboard()
+  , allLCTs(match_trig_window_size)
+{
+}
+
+CSCMotherboardME3141::~CSCMotherboardME3141()
+{
+}
+
+void CSCMotherboardME3141::clear()
+{
+  CSCMotherboard::clear();
+
+  for (int bx = 0; bx < MAX_LCT_BINS; bx++) {
+    for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++) {
+      for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++) {
+        allLCTs(bx,mbx,i).clear();
+      }
+    }
+  }
+}
+
+
+void
+CSCMotherboardME3141::run(const CSCWireDigiCollection* wiredc,
+                          const CSCComparatorDigiCollection* compdc)
+{
+  clear();
+
+  if (!( alct and clct))
+  {
+    if (infoV >= 0) edm::LogError("L1CSCTPEmulatorSetupError")
+      << "+++ run() called for non-existing ALCT/CLCT processor! +++ \n";
+    return;
+  }
+
+  alct->setCSCGeometry(csc_g);
+  clct->setCSCGeometry(csc_g);
+
+  alctV = alct->run(wiredc); // run anodeLCT
+  clctV = clct->run(compdc); // run cathodeLCT
+
+  // if there are no ALCTs and no CLCTs, it does not make sense to run this TMB
+  if (alctV.empty() and clctV.empty()) return;
+
+  int used_clct_mask[20];
+  for (int c=0;c<20;++c) used_clct_mask[c]=0;
+
+  // ALCT centric matching
+  for (int bx_alct = 0; bx_alct < CSCAnodeLCTProcessor::MAX_ALCT_BINS; bx_alct++)
+  {
+    if (alct->bestALCT[bx_alct].isValid())
+    {
+      const int bx_clct_start(bx_alct - match_trig_window_size/2);
+      const int bx_clct_stop(bx_alct + match_trig_window_size/2);
+
+      if (debug_matching){
+        LogTrace("CSCMotherboardME3141") << "========================================================================" << std::endl;
+        LogTrace("CSCMotherboardME3141") << "ALCT-CLCT matching in ME34/1 chamber: " << cscChamber->id() << std::endl;
+        LogTrace("CSCMotherboardME3141") << "------------------------------------------------------------------------" << std::endl;
+        LogTrace("CSCMotherboardME3141") << "+++ Best ALCT Details: ";
+        alct->bestALCT[bx_alct].print();
+        LogTrace("CSCMotherboardME3141") << "+++ Second ALCT Details: ";
+        alct->secondALCT[bx_alct].print();
+
+        LogTrace("CSCMotherboardME3141") << "------------------------------------------------------------------------" << std::endl;
+        LogTrace("CSCMotherboardME3141") << "Attempt ALCT-CLCT matching in ME34/13 in bx range: [" << bx_clct_start << "," << bx_clct_stop << "]" << std::endl;
+      }
+
+      // ALCT-to-CLCT
+      for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
+      {
+        if (bx_clct < 0 or bx_clct >= CSCCathodeLCTProcessor::MAX_CLCT_BINS) continue;
+        if (drop_used_clcts and used_clct_mask[bx_clct]) continue;
+        if (clct->bestCLCT[bx_clct].isValid())
+        {
+          if (debug_matching) LogTrace("CSCMotherboardME3141") << "++Valid ME21 CLCT: " << clct->bestCLCT[bx_clct] << std::endl;
+
+          int mbx = bx_clct-bx_clct_start;
+          CSCMotherboardME3141::correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
+                                              clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
+                                              allLCTs(bx_alct,mbx,0), allLCTs(bx_alct,mbx,1));
+          if (infoV > 1)
+            LogTrace("CSCMotherboardME3141") << "Successful ALCT-CLCT match in ME21: bx_alct = " << bx_alct
+                                             << "; match window: [" << bx_clct_start << "; " << bx_clct_stop
+                                             << "]; bx_clct = " << bx_clct << std::endl;
+          LogTrace("CSCMotherboardME3141") << "+++ Best CLCT Details: ";
+          clct->bestCLCT[bx_clct].print();
+          LogTrace("CSCMotherboardME3141") << "+++ Second CLCT Details: ";
+          clct->secondCLCT[bx_clct].print();
+          if (allLCTs(bx_alct,mbx,0).isValid()) {
+            used_clct_mask[bx_clct] += 1;
+            if (match_earliest_clct_only) break;
+          }
+        }
+      }
+    }
+  }
+
+  // reduction of nLCTs per each BX
+  for (int bx = 0; bx < MAX_LCT_BINS; bx++)
+  {
+    // counting
+    unsigned int n=0;
+    for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++)
+      for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++)
+      {
+        int cbx = bx + mbx - match_trig_window_size/2;
+        if (allLCTs(bx,mbx,i).isValid())
+        {
+          ++n;
+          if (infoV > 0) LogDebug("CSCMotherboardME3141")
+                           << "LCT"<<i+1<<" "<<bx<<"/"<<cbx<<": "<<allLCTs(bx,mbx,i)<<std::endl;
+        }
+      }
+
+    // some simple cross-bx sorting algorithms
+    if (tmb_cross_bx_algo == 1 and (n>2))
+    {
+      n=0;
+      for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++)
+        for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++)
+        {
+          if (allLCTs(bx,pref[mbx],i).isValid())
+          {
+            n++;
+            if (n>2) allLCTs(bx,pref[mbx],i).clear();
+          }
+	      }
+
+      n=0;
+      for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++)
+        for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++)
+        {
+          int cbx = bx + mbx - match_trig_window_size/2;
+          if (allLCTs(bx,mbx,i).isValid())
+          {
+            n++;
+            if (infoV > 0) LogDebug("CSCMotherboardME3141")
+                             << "LCT"<<i+1<<" "<<bx<<"/"<<cbx<<": "<<allLCTs(bx,mbx,i)<< std::endl;
+          }
+	      }
+      if (infoV > 0 and n>0) LogDebug("CSCMotherboardME3141")
+                               <<"bx "<<bx<<" nnLCT:"<<n<<" "<<n<<std::endl;
+    } // x-bx sorting
+  }
+
+  bool first = true;
+  unsigned int n=0;
+  for (const auto& p : readoutLCTs()) {
+    if (debug_matching and first){
+      LogTrace("CSCMotherboardME3141") << "========================================================================" << std::endl;
+      LogTrace("CSCMotherboardME3141") << "Counting the final LCTs" << std::endl;
+      LogTrace("CSCMotherboardME3141") << "========================================================================" << std::endl;
+      first = false;
+      LogTrace("CSCMotherboardME3141") << "tmb_cross_bx_algo: " << tmb_cross_bx_algo << std::endl;
+    }
+    n++;
+    if (debug_matching)
+      LogTrace("CSCMotherboardME3141") << "LCT "<<n<<"  " << p <<std::endl;
+  }
+}
+
+void CSCMotherboardME3141::correlateLCTs(CSCALCTDigi& bestALCT, CSCALCTDigi& secondALCT,
+                                         CSCCLCTDigi& bestCLCT, CSCCLCTDigi& secondCLCT,
+                                         CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2)
+{
+  const bool anodeBestValid     = bestALCT.isValid();
+  const bool anodeSecondValid   = secondALCT.isValid();
+  const bool cathodeBestValid   = bestCLCT.isValid();
+  const bool cathodeSecondValid = secondCLCT.isValid();
+
+  if (anodeBestValid and !anodeSecondValid)     secondALCT = bestALCT;
+  if (!anodeBestValid and anodeSecondValid)     bestALCT   = secondALCT;
+  if (cathodeBestValid and !cathodeSecondValid) secondCLCT = bestCLCT;
+  if (!cathodeBestValid and cathodeSecondValid) bestCLCT   = secondCLCT;
+
+  // ALCT-CLCT matching conditions are defined by "trig_enable" configuration
+  // parameters.
+  if ((alct_trig_enable  and bestALCT.isValid()) or
+      (clct_trig_enable  and bestCLCT.isValid()) or
+      (match_trig_enable and bestALCT.isValid() and bestCLCT.isValid())){
+    lct1 = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
+    lct1.setTrknmb(1);
+  }
+
+  if (((secondALCT != bestALCT) or (secondCLCT != bestCLCT)) and
+      ((alct_trig_enable  and secondALCT.isValid()) or
+       (clct_trig_enable  and secondCLCT.isValid()) or
+       (match_trig_enable and secondALCT.isValid() and secondCLCT.isValid()))){
+    lct2 = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
+    lct2.setTrknmb(2);
+  }
+}
+
+//readout LCTs
+std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME3141::readoutLCTs() const
+{
+  std::vector<CSCCorrelatedLCTDigi> result;
+  allLCTs.getMatched(result);
+  if (tmb_cross_bx_algo == 2) CSCUpgradeMotherboard::sortLCTs(result, CSCUpgradeMotherboard::sortLCTsByQuality);
+  return result;
+}

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.cc
@@ -24,7 +24,7 @@ void CSCMotherboardME3141::clear()
 {
   CSCMotherboard::clear();
 
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++) {
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
     for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++) {
       for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++) {
         allLCTs(bx,mbx,i).clear();
@@ -60,7 +60,7 @@ CSCMotherboardME3141::run(const CSCWireDigiCollection* wiredc,
   for (int c=0;c<20;++c) used_clct_mask[c]=0;
 
   // ALCT centric matching
-  for (int bx_alct = 0; bx_alct < CSCAnodeLCTProcessor::MAX_ALCT_BINS; bx_alct++)
+  for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++)
   {
     if (alct->bestALCT[bx_alct].isValid())
     {
@@ -83,7 +83,7 @@ CSCMotherboardME3141::run(const CSCWireDigiCollection* wiredc,
       // ALCT-to-CLCT
       for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++)
       {
-        if (bx_clct < 0 or bx_clct >= CSCCathodeLCTProcessor::MAX_CLCT_BINS) continue;
+        if (bx_clct < 0 or bx_clct >= CSCConstants::MAX_CLCT_TBINS) continue;
         if (drop_used_clcts and used_clct_mask[bx_clct]) continue;
         if (clct->bestCLCT[bx_clct].isValid())
         {
@@ -111,7 +111,7 @@ CSCMotherboardME3141::run(const CSCWireDigiCollection* wiredc,
   }
 
   // reduction of nLCTs per each BX
-  for (int bx = 0; bx < MAX_LCT_BINS; bx++)
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++)
   {
     // counting
     unsigned int n=0;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.h
@@ -1,0 +1,45 @@
+#ifndef L1Trigger_CSCTriggerPrimitives_CSCMotherboardME3141_h
+#define L1Trigger_CSCTriggerPrimitives_CSCMotherboardME3141_h
+
+#include "L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.h"
+
+class CSCMotherboardME3141 : public CSCUpgradeMotherboard
+{
+public:
+
+  enum Default_values{DEFAULT_MATCHING_VALUE = -99};
+
+  // standard constructor
+  CSCMotherboardME3141(unsigned endcap, unsigned station, unsigned sector,
+                    unsigned subsector, unsigned chamber,
+                    const edm::ParameterSet& conf);
+
+   //Default constructor for testing
+  CSCMotherboardME3141();
+
+  ~CSCMotherboardME3141() override;
+
+  // clear stored pads and copads
+  void clear();
+
+  // run TMB with GEM pad clusters as input
+  void run(const CSCWireDigiCollection* wiredc,
+           const CSCComparatorDigiCollection* compdc);
+
+  void correlateLCTs(CSCALCTDigi& bestALCT, CSCALCTDigi& secondALCT,
+                     CSCCLCTDigi& bestCLCT, CSCCLCTDigi& secondCLCT,
+                     CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2);
+
+  /* readout the two best LCTs in this CSC */
+  std::vector<CSCCorrelatedLCTDigi> readoutLCTs() const;
+
+  /* store the CLCTs found earlier */
+  std::vector<CSCCLCTDigi> clctV;
+
+ private:
+  /** for the case when more than 2 LCTs/BX are allowed;
+      maximum match window = 15 */
+  LCTContainer allLCTs;
+};
+
+#endif

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
@@ -48,6 +48,7 @@ CSCUpgradeMotherboard::CSCUpgradeMotherboard(unsigned endcap, unsigned station,
   commonParams_ = conf.getParameter<edm::ParameterSet>("commonParam");
   if (theStation==1) tmbParams_ = conf.getParameter<edm::ParameterSet>("me11tmbSLHCGEM");
   else if (theStation==2) tmbParams_ = conf.getParameter<edm::ParameterSet>("me21tmbSLHCGEM");
+  else if (theStation==3 or theStation==4) tmbParams_ = conf.getParameter<edm::ParameterSet>("me3141tmbSLHC");
 
   generator_.reset(new CSCUpgradeMotherboardLUTGenerator());
 


### PR DESCRIPTION
In the past we had ME3/1 and ME4/1 OTMBs with RPC digis. I scrapped those a while ago, since RPC digis will not be sent to the local trigger. An OTMB class for ME3/1 and ME4/1 without RPCs was constructed. Those OTMBs are based on the ME1/1 OTMB for high-pileup running, but they are a lot simpler because (1) the wiregroups are not slanted and (2) the chambers are not divided into two readout sectors for halfstrips.
