### PR TITLE
EventSetup no longer holds a IOVSyncValue

### DIFF
--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -100,8 +100,6 @@ namespace edm {
            rec.get(iTag,iHolder);
         }
    
-      const IOVSyncValue& iovSyncValue() const { return syncValue_;}
-
       const eventsetup::EventSetupRecord* find(const eventsetup::EventSetupRecordKey&) const;
       
       ///clears the oToFill vector and then fills it with the keys for all available records
@@ -120,7 +118,6 @@ namespace edm {
          }
     protected:
       //Only called by EventSetupProvider
-      void setIOVSyncValue(const IOVSyncValue&);
       void setKnownRecordsSupplier(eventsetup::EventSetupKnownRecordsSupplier const* iSupplier) {
         knownRecords_ = iSupplier;
       }
@@ -140,8 +137,7 @@ namespace edm {
                   const eventsetup::EventSetupRecord*);
 
       // ---------- member data --------------------------------
-      IOVSyncValue syncValue_;
-      
+    
       //NOTE: the records are not owned
       std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecord const *> recordMap_;
       eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;

--- a/FWCore/Framework/interface/NoRecordException.h
+++ b/FWCore/Framework/interface/NoRecordException.h
@@ -39,8 +39,7 @@ namespace edm {
    class EventSetup;
    namespace eventsetup {
       class EventSetupRecordKey;
-      void no_record_exception_message_builder(cms::Exception&,const char*, IOVSyncValue const&, bool iKnownRecord);
-      IOVSyncValue const& iovSyncValueFrom( edm::EventSetup const& );
+      void no_record_exception_message_builder(cms::Exception&,const char*, bool iKnownRecord);
      bool recordDoesExist( edm::EventSetup const& , edm::eventsetup::EventSetupRecordKey const&);
 
 //NOTE: when EDM gets own exception hierarchy, will need to change inheritance
@@ -49,10 +48,10 @@ class NoRecordException : public cms::Exception
 {
  public:
   // ---------- Constructors and destructor ----------------
-  explicit NoRecordException(IOVSyncValue const& iValue, bool iKnownRecord )
+  explicit NoRecordException(bool iKnownRecord )
   :cms::Exception("NoRecord")
   {
-    no_record_exception_message_builder(*this,heterocontainer::className<T>(), iValue, iKnownRecord);
+    no_record_exception_message_builder(*this,heterocontainer::className<T>(), iKnownRecord);
   }
 
       ~NoRecordException() noexcept override {}

--- a/FWCore/Framework/interface/eventSetupGetImplementation.h
+++ b/FWCore/Framework/interface/eventSetupGetImplementation.h
@@ -32,7 +32,7 @@ namespace edm {
       inline void eventSetupGetImplementation(EventSetup const& iEventSetup, T const*& iValue) {
          T const* temp = heterocontainer::find<EventSetupRecordKey, T const>(iEventSetup);
          if(nullptr == temp) {
-            throw NoRecordException<T>(iovSyncValueFrom(iEventSetup), recordDoesExist(iEventSetup, EventSetupRecordKey::makeKey<T>()));
+            throw NoRecordException<T>(recordDoesExist(iEventSetup, EventSetupRecordKey::makeKey<T>()));
          }
          iValue = temp;
       }

--- a/FWCore/Framework/src/EventSetup.cc
+++ b/FWCore/Framework/src/EventSetup.cc
@@ -31,7 +31,7 @@ namespace edm {
 //
 // constructors and destructor
 //
-   EventSetup::EventSetup() : syncValue_(IOVSyncValue::invalidIOVSyncValue()), recordMap_()
+   EventSetup::EventSetup() : recordMap_()
 {
 }
 
@@ -60,12 +60,6 @@ EventSetup::~EventSetup()
 // member functions
 //
 void
-EventSetup::setIOVSyncValue(const IOVSyncValue& iTime) {
-   //will ultimately build our list of records
-   syncValue_ = iTime;
-}
-
-void 
 EventSetup::insert(const eventsetup::EventSetupRecordKey& iKey,
                 const eventsetup::EventSetupRecord* iRecord)
 {

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -743,8 +743,6 @@ EventSetupProvider::addRecordToEventSetup(EventSetupRecord& iRecord) {
 EventSetup const&
 EventSetupProvider::eventSetupForInstance(const IOVSyncValue& iValue)
 {
-   eventSetup_.setIOVSyncValue(iValue);
-
    eventSetup_.clear();
 
    // In a cmsRun job this does nothing because the EventSetupsController

--- a/FWCore/Framework/src/NoRecordException.cc
+++ b/FWCore/Framework/src/NoRecordException.cc
@@ -19,11 +19,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-edm::IOVSyncValue const&
-edm::eventsetup::iovSyncValueFrom( EventSetup const& iES) {
-    return iES.iovSyncValue();
-}
-
 bool
 edm::eventsetup::recordDoesExist( EventSetup const& iES, EventSetupRecordKey const& iKey) {
   return iES.recordIsProvidedByAModule(iKey);
@@ -31,15 +26,11 @@ edm::eventsetup::recordDoesExist( EventSetup const& iES, EventSetupRecordKey con
 
 
 void
-edm::eventsetup::no_record_exception_message_builder(cms::Exception& oException,const char* iName, IOVSyncValue const& iValue, bool iKnownRecord) {
+edm::eventsetup::no_record_exception_message_builder(cms::Exception& oException, const char* iName, bool iKnownRecord) {
    oException
    << "No \"" 
    << iName
-   << "\" record found in the EventSetup for synchronization value\n"
-   << "Run: "<<iValue.eventID().run()
-   <<" LuminosityBlock: "<<iValue.luminosityBlockNumber()
-   <<" Event: "<<iValue.eventID().event()
-   <<" Time: "<<iValue.time().value();
+   << "\" record found in the EventSetup.n";
   if(iKnownRecord) {
    oException<<"\n The Record is delivered by an ESSource or ESProducer but there is no valid IOV for the synchronizatio value.\n"
     " Please check \n"

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -108,7 +108,6 @@ void testEventsetup::constructTest()
    const IOVSyncValue timestamp(time);
    EventSetup const& eventSetup = provider.eventSetupForInstance(timestamp);
    CPPUNIT_ASSERT(non_null(&eventSetup));
-   CPPUNIT_ASSERT(eventSetup.iovSyncValue() == timestamp);
 }
 
 void testEventsetup::getTest()


### PR DESCRIPTION
In order to allow one EventSetup to be used across multiple concurrent LuminosityBlocks/Runs, it no longer holds onto an IOVSyncValue.