### PR TITLE
use named namespaces for dictionary structs to avoid symbol conflicts (L1TMuon and phase-2 TT)

### DIFF
--- a/DataFormats/L1TMuon/src/classes.h
+++ b/DataFormats/L1TMuon/src/classes.h
@@ -16,7 +16,7 @@
 
 #include <vector>
 
-namespace {
+namespace DataFormats_L1TMuon {
   struct dictionary {
     l1t::MuonCaloSumBxCollection caloSum;
     edm::Wrapper<l1t::MuonCaloSumBxCollection> caloSumWrap;

--- a/DataFormats/L1TrackTrigger/src/classes.h
+++ b/DataFormats/L1TrackTrigger/src/classes.h
@@ -16,7 +16,7 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefProd.h"
 
-namespace
+namespace DataFormats_L1TrackTrigger
 {
   struct dictionary1 {
     /// Main template type

--- a/DataFormats/Phase2TrackerCluster/src/classes.h
+++ b/DataFormats/Phase2TrackerCluster/src/classes.h
@@ -6,7 +6,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/DetSetNew.h"
 
-namespace {
+namespace DataFormats_Phase2TrackerCluster {
     struct dictionary_ph2cl {
         edm::Wrapper< Phase2TrackerCluster1D > cl0;
         edm::Wrapper< std::vector< Phase2TrackerCluster1D > > cl1;

--- a/DataFormats/Phase2TrackerDigi/src/classes.h
+++ b/DataFormats/Phase2TrackerDigi/src/classes.h
@@ -7,7 +7,7 @@
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include <vector>
 
-namespace {
+namespace DataFormats_Phase2TrackerDigi {
   struct dictionary {
     
     edm::Wrapper<Phase2TrackerDigi> zs0;
@@ -20,7 +20,7 @@ namespace {
 }
 
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerCommissioningDigi.h"
-namespace {
+namespace DataFormats_Phase2TrackerDigi {
   struct dictionary4 {
     edm::Wrapper<Phase2TrackerCommissioningDigi > pcom0;
     edm::Wrapper<edm::DetSet<Phase2TrackerCommissioningDigi> > pcom1;

--- a/EgammaAnalysis/ElectronTools/src/classes.h
+++ b/EgammaAnalysis/ElectronTools/src/classes.h
@@ -3,7 +3,7 @@
 #include "EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2.h"
 #include "EgammaAnalysis/ElectronTools/interface/PhotonEnergyCalibratorRun2.h"
 
-namespace {
+namespace EgammaAnalysis_ElectronTools {
   struct dictionaryfuffa {
     SimpleElectron fuffaElectron;
     EpCombinationTool fuffaElectronCombinator;


### PR DESCRIPTION
all objects in dictionary definitions should be unique.

this should cleanup numerous warnings when making plots with FWLite