### PR TITLE
cleanup of static ana issues (mostly) in reco. This is supposedly technical.

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
@@ -28,7 +28,7 @@ namespace cscdqm {
     }
 
     template<typename T> inline CSCCFEBTimeSlice const * const
-    timeSlice( T const & data, int nCFEB, int nSample) { return (CSCCFEBTimeSlice *)(data.cfebData(nCFEB)->timeSlice(nSample));}
+    timeSlice( T const & data, int nCFEB, int nSample) { return data.cfebData(nCFEB)->timeSlice(nSample);}
 
 
 

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
@@ -1012,7 +1012,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
   bool validKF= false; 
   reco::TrackRef myTrackRef = ele.closestCtfTrackRef();
   validKF = (myTrackRef.isAvailable());
-  validKF = (myTrackRef.isNonnull());  
+  validKF &= (myTrackRef.isNonnull());  
 
   // Pure tracking variables
   fMVAVar_fbrem           =  ele.fbrem();
@@ -1147,7 +1147,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
   bool validKF= false; 
   reco::TrackRef myTrackRef = ele.closestCtfTrackRef();
   validKF = (myTrackRef.isAvailable());
-  validKF = (myTrackRef.isNonnull());  
+  validKF &= (myTrackRef.isNonnull());  
 
   // Pure tracking variables
   fMVAVar_fbrem           =  ele.fbrem();
@@ -1252,7 +1252,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const pat::Electron& ele,
   bool validKF= false;
   reco::TrackRef myTrackRef = ele.closestCtfTrackRef();
   validKF = (myTrackRef.isAvailable());
-  validKF = (myTrackRef.isNonnull());
+  validKF &= (myTrackRef.isNonnull());
 
   // Pure tracking variables
   fMVAVar_fbrem           =  ele.fbrem();
@@ -1382,7 +1382,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const pat::Electron& ele,
   bool validKF= false; 
   reco::TrackRef myTrackRef = ele.closestCtfTrackRef();
   validKF = (myTrackRef.isAvailable());
-  validKF = (myTrackRef.isNonnull());  
+  validKF &= (myTrackRef.isNonnull());  
 
   // Pure tracking variables
   fMVAVar_fbrem           =  ele.fbrem();
@@ -1695,7 +1695,7 @@ Double_t EGammaMvaEleEstimator::IDIsoCombinedMvaValue(const reco::GsfElectron& e
   bool validKF= false; 
   reco::TrackRef myTrackRef = ele.closestCtfTrackRef();
   validKF = (myTrackRef.isAvailable());
-  validKF = (myTrackRef.isNonnull());  
+  validKF &= (myTrackRef.isNonnull());  
 
   // Pure tracking variables
   fMVAVar_fbrem           =  (ele.fbrem() < -1. ) ? -1. : ele.fbrem();

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
@@ -19,6 +19,7 @@
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h"
 #include "DataFormats/Common/interface/RefToPtr.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include <cstdio>
 #include <zlib.h>
 #endif
@@ -1030,7 +1031,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
   // Pure ECAL -> shower shapes
   fMVAVar_see             =  ele.sigmaIetaIeta();    //EleSigmaIEtaIEta
   std::vector<float> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed())) ;
-  if (!isnan(vCov[2])) fMVAVar_spp = sqrt (vCov[2]);   //EleSigmaIPhiIPhi
+  if (edm::isFinite(vCov[2])) fMVAVar_spp = sqrt (vCov[2]);   //EleSigmaIPhiIPhi
   else fMVAVar_spp = 0.;    
 
   fMVAVar_etawidth        =  ele.superCluster()->etaWidth();
@@ -1164,7 +1165,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
   // Pure ECAL -> shower shapes
   fMVAVar_see             =  ele.sigmaIetaIeta();    //EleSigmaIEtaIEta
   std::vector<float> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed())) ;
-  if (!isnan(vCov[2])) fMVAVar_spp = sqrt (vCov[2]);   //EleSigmaIPhiIPhi
+  if (edm::isFinite(vCov[2])) fMVAVar_spp = sqrt (vCov[2]);   //EleSigmaIPhiIPhi
   else fMVAVar_spp = 0.;    
 
 
@@ -1715,7 +1716,7 @@ Double_t EGammaMvaEleEstimator::IDIsoCombinedMvaValue(const reco::GsfElectron& e
   // Pure ECAL -> shower shapes
   fMVAVar_see             =  ele.sigmaIetaIeta();    //EleSigmaIEtaIEta
   std::vector<float> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed())) ;
-  if (!isnan(vCov[2])) fMVAVar_spp = sqrt (vCov[2]);   //EleSigmaIPhiIPhi
+  if (edm::isFinite(vCov[2])) fMVAVar_spp = sqrt (vCov[2]);   //EleSigmaIPhiIPhi
   else fMVAVar_spp = 0.;    
 
   fMVAVar_etawidth        =  ele.superCluster()->etaWidth();
@@ -1989,7 +1990,11 @@ void EGammaMvaEleEstimator::bindVariables() {
   
   
   // Needed for a bug in CMSSW_420, fixed in more recent CMSSW versions
+#ifndef STANDALONE
+  if(edm::isNotFinite(fMVAVar_spp))
+#else
   if(std::isnan(fMVAVar_spp))
+#endif
     fMVAVar_spp = 0.;	
   
   

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
@@ -265,7 +265,7 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const reco::GsfElectron& ele,
   bool validKF= false; 
   reco::TrackRef myTrackRef = ele.closestCtfTrackRef();
   validKF = (myTrackRef.isAvailable());
-  validKF = (myTrackRef.isNonnull());  
+  validKF &= (myTrackRef.isNonnull());  
 
   // Pure tracking variables
   fMVAVar_fbrem           =  ele.fbrem();
@@ -399,7 +399,7 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const pat::Electron& ele,
     bool validKF= false;
     reco::TrackRef myTrackRef = ele.closestCtfTrackRef();
     validKF = (myTrackRef.isAvailable());
-    validKF = (myTrackRef.isNonnull());
+    validKF &= (myTrackRef.isNonnull());
     
     // Pure tracking variables
     fMVAVar_fbrem           =  ele.fbrem();

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <zlib.h>
 #include "TMVA/MethodBase.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 
 //--------------------------------------------------------------------------------------------------
@@ -282,9 +283,9 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const reco::GsfElectron& ele,
 
   // Pure ECAL -> shower shapes
   std::vector<float> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed())) ;
-  if (!isnan(vCov[0])) fMVAVar_see = sqrt (vCov[0]); //EleSigmaIEtaIEta
+  if (edm::isFinite(vCov[0])) fMVAVar_see = sqrt (vCov[0]); //EleSigmaIEtaIEta
   else fMVAVar_see = 0.;
-  if (!isnan(vCov[2])) fMVAVar_spp = sqrt (vCov[2]);   //EleSigmaIPhiIPhi
+  if (edm::isFinite(vCov[2])) fMVAVar_spp = sqrt (vCov[2]);   //EleSigmaIPhiIPhi
   else fMVAVar_spp = 0.;    
 
   fMVAVar_etawidth        =  ele.superCluster()->etaWidth();
@@ -533,7 +534,11 @@ void EGammaMvaEleEstimatorCSA14::bindVariables() {
   
   
   // Needed for a bug in CMSSW_420, fixed in more recent CMSSW versions
+#ifndef STANDALONE
+  if(edm::isNotFinite(fMVAVar_spp))
+#else
   if(std::isnan(fMVAVar_spp))
+#endif
     fMVAVar_spp = 0.;	
   
   

--- a/EgammaAnalysis/ElectronTools/src/EnergyScaleCorrection_class.cc
+++ b/EgammaAnalysis/ElectronTools/src/EnergyScaleCorrection_class.cc
@@ -335,6 +335,7 @@ void EnergyScaleCorrection_class::ReadSmearingFromFile(TString filename)
       
     } else {
       f_in >> category >> rho >> phi;
+      err_rho = err_phi = Emean = err_Emean = 0;
       AddSmearing(category, runMin, runMax, rho,  err_rho, phi, err_phi, Emean, err_Emean);
     }
 #ifdef DEBUG

--- a/EgammaAnalysis/ElectronTools/src/EnergyScaleCorrection_class.cc
+++ b/EgammaAnalysis/ElectronTools/src/EnergyScaleCorrection_class.cc
@@ -442,10 +442,9 @@ correctionCategory_class::correctionCategory_class(TString category_)
   etmin = -1;
   etmax = 99999.;
   
-  size_t p1, p2; // boundary
+  size_t p1, p2;// boundary
   // eta region
   p1 = category.find("absEta_");
-  p2 = p1 + 1;
   if(category.find("absEta_0_1") != std::string::npos) {
     etamin = 0;
     etamax = 1;
@@ -490,7 +489,7 @@ correctionCategory_class::correctionCategory_class(TString category_)
   
   // Et region
   p1 = category.find("-Et_");
-  p2 = p1 + 1;
+  //  p2 = p1 + 1;//this is needed only for the printouts
   //    std::cout << "p1 = " << p1 << "\t" << std::string::npos << "\t" << category.size() << std::endl;
   //std::cout << etmin << "\t" << etmax << "\t" << category.substr(p1+1, p2-p1-1) << "\t" << p1 << "\t" << p2 << std::endl;
   if(p1 != std::string::npos) {

--- a/EgammaAnalysis/ElectronTools/src/SuperClusterHelper.cc
+++ b/EgammaAnalysis/ElectronTools/src/SuperClusterHelper.cc
@@ -1,6 +1,6 @@
 #include "EgammaAnalysis/ElectronTools/interface/SuperClusterHelper.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
-
+#include "FWCore/Utilities/interface/isFinite.h"
 
 
 
@@ -103,7 +103,7 @@ void SuperClusterHelper::computeLocalCovariances() {
     covComputed_ = true;
     
     spp_ = 0;
-    if (!isnan(vCov_[2])) spp_ = sqrt (vCov_[2]);
+    if (edm::isFinite(vCov_[2])) spp_ = sqrt (vCov_[2]);
     
     if (theElectron_->sigmaIetaIeta()*spp_ > 0) {
       sep_ = vCov_[1] / (theElectron_->sigmaIetaIeta() * spp_);

--- a/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
@@ -46,6 +46,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 #include <cmath>
 #include <vector>
@@ -513,7 +514,7 @@ void ElectronTestAnalyzer::myVar(const reco::GsfElectron& ele,
 
   myMVAVar_see             =  ele.sigmaIetaIeta();    //EleSigmaIEtaIEta
   std::vector<float> vCov = myEcalCluster.localCovariances(*(ele.superCluster()->seed())) ;
-  if (!isnan(vCov[2])) myMVAVar_spp = sqrt (vCov[2]);   //EleSigmaIPhiIPhi
+  if (edm::isFinite(vCov[2])) myMVAVar_spp = sqrt (vCov[2]);   //EleSigmaIPhiIPhi
   else myMVAVar_spp = 0.;
   myMVAVar_etawidth        =  ele.superCluster()->etaWidth();
   myMVAVar_phiwidth        =  ele.superCluster()->phiWidth();
@@ -648,7 +649,7 @@ void ElectronTestAnalyzer::myBindVariables() {
 
 
   // Needed for a bug in CMSSW_420, fixed in more recent CMSSW versions
-  if(isnan(myMVAVar_spp))
+  if(edm::isNotFinite(myMVAVar_spp))
     myMVAVar_spp = 0.;
 
 

--- a/EventFilter/CSCRawToDigi/interface/CSCBadCFEBTimeSlice.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCBadCFEBTimeSlice.h
@@ -13,7 +13,7 @@ class CSCBadCFEBTimeSlice {
 public:
   unsigned sizeInWords() const {return 4;}
   /// count from zero
-  CSCBadCFEBWord & word(int i);
+  const CSCBadCFEBWord & word(int i) const;
 
   bool check() const;
 

--- a/EventFilter/CSCRawToDigi/interface/CSCCFEBData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCCFEBData.h
@@ -14,7 +14,7 @@ class CSCCFEBStatusDigi;
 class CSCCFEBData {
  public:
  /// read from an existing data stream. 
-  CSCCFEBData(unsigned boardNumber, unsigned short * buf, uint16_t theFormatVersion = 2005, bool fDCFEB = false);
+  CSCCFEBData(unsigned boardNumber, const uint16_t * buf, uint16_t theFormatVersion = 2005, bool fDCFEB = false);
   /// create, 
   CSCCFEBData(unsigned boardNumber, bool sixteenSamples, uint16_t theFormatVersion = 2005, bool fDCFEB = false);
   

--- a/EventFilter/CSCRawToDigi/interface/CSCCFEBData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCCFEBData.h
@@ -34,16 +34,16 @@ class CSCCFEBData {
   /// WARNING: these digis have no comparator information.
 
   ///faster way to get to digis
-  void digis(uint32_t idlayer,  std::vector<CSCStripDigi> & result);
+  void digis(uint32_t idlayer,  std::vector<CSCStripDigi> & result) const;
 
-  std::vector<CSCStripDigi> digis(unsigned idlayer);
+  std::vector<CSCStripDigi> digis(unsigned idlayer) const;
   /// deprecated.  Use the above method.
   std::vector<std::vector<CSCStripDigi> > stripDigis();
  
   /// returns one status digi per cfeb
   CSCCFEBStatusDigi statusDigi() const;
 
-  unsigned short * data() {return theData;}
+  uint16_t * data() {return theData;}
   unsigned sizeInWords() const {return theSize;} 
   unsigned boardNumber() const {return boardNumber_;}
   void setBoardNumber(int cfeb) {boardNumber_=cfeb;}
@@ -60,7 +60,9 @@ class CSCCFEBData {
  
  
  private:
-  unsigned short theData[1600];
+  CSCCFEBTimeSlice * timeSlice(unsigned i);
+
+  uint16_t theData[1600];
   /// Shows where in theData the words start.  A bad slice will 
   /// be tagged with a false
   std::vector<std::pair<int,bool> > theSliceStarts;

--- a/EventFilter/CSCRawToDigi/interface/CSCCFEBTimeSlice.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCCFEBTimeSlice.h
@@ -70,7 +70,7 @@ class CSCCFEBTimeSlice {
   CSCCFEBDataWord * timeSample(int layer, int channel, bool isDCFEB=false) const;
 
   /// whether we keep 8 or 16 time samples
-  bool sixteenSamples() {/*return scaControllerWord(1).ts_flag;i*/
+  bool sixteenSamples() const {/*return scaControllerWord(1).ts_flag;i*/
     return timeSample(95)->controllerData;}
   unsigned sizeInWords() const {return 100;}
 

--- a/EventFilter/CSCRawToDigi/interface/CSCDCCEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDCCEventData.h
@@ -15,7 +15,7 @@ public:
   CSCDCCEventData(int sourceId, int nDDUs, int bx, int l1a);
   /// buf may need to stay pinned in memory as long
   /// as this data is used.  Not sure
-  explicit CSCDCCEventData(unsigned short *buf, CSCDCCExaminer* examiner=nullptr);
+  explicit CSCDCCEventData(const uint16_t *buf, CSCDCCExaminer* examiner=nullptr);
 
   ~CSCDCCEventData();
 
@@ -51,7 +51,7 @@ public:
 
 
 protected:
-  void unpack_data(unsigned short * buf, CSCDCCExaminer* examiner=nullptr);
+  void unpack_data(const uint16_t * buf, CSCDCCExaminer* examiner=nullptr);
   CSCDCCHeader theDCCHeader;
   // DDUData is unpacked and stored in this vector
   std::vector<CSCDDUEventData> theDDUData;

--- a/EventFilter/CSCRawToDigi/interface/CSCDDUEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDDUEventData.h
@@ -23,7 +23,7 @@ public:
 
   // buf may need to stay pinned in memory as long
   // as this data is used.  Not sure
-  explicit CSCDDUEventData(unsigned short *buf, CSCDCCExaminer* examiner=nullptr);
+  explicit CSCDDUEventData(const uint16_t *buf, CSCDCCExaminer* examiner=nullptr);
 
   ~CSCDDUEventData();
 
@@ -69,7 +69,7 @@ public:
 
   /// a good test routine would be to unpack data, then pack it again.
 protected:
-  void unpack_data(unsigned short * buf, CSCDCCExaminer* examiner=nullptr);
+  void unpack_data(const uint16_t * buf, CSCDCCExaminer* examiner=nullptr);
   CSCDCCHeader theDCCHeader;
   CSCDDUHeader theDDUHeader;
   // CSCData is unpacked and stored in this vector

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
@@ -9,8 +9,8 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBHeaderFormat.h"
 #include <boost/shared_ptr.hpp>
 
-class CSCDMBHeader2005;
-class CSCDMBHeader2013;
+struct CSCDMBHeader2005;
+struct CSCDMBHeader2013;
 
 class CSCDMBHeader  {
 public:

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
@@ -17,7 +17,7 @@ public:
   
   CSCDMBHeader(uint16_t firmware_version = 2005);
   
-  CSCDMBHeader(unsigned short * buf, uint16_t firmware_version = 2005);
+  CSCDMBHeader(const uint16_t * buf, uint16_t firmware_version = 2005);
 
   CSCDMBHeader(const CSCDMBStatusDigi & digi)
     {

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBHeader2005.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBHeader2005.h
@@ -12,7 +12,7 @@ struct CSCDMBHeader2005: public CSCVDMBHeaderFormat  {
   
   CSCDMBHeader2005();
   
-  CSCDMBHeader2005(unsigned short * buf);
+  CSCDMBHeader2005(const uint16_t * buf);
 /*
   CSCDMBHeader2005(const CSCDMBStatusDigi & digi)
     {

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBHeader2013.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBHeader2013.h
@@ -46,7 +46,7 @@ struct CSCDMBHeader2013: public CSCVDMBHeaderFormat  {
   
   CSCDMBHeader2013();
   
-  CSCDMBHeader2013(unsigned short * buf);
+  CSCDMBHeader2013(const uint16_t * buf);
 /*
   CSCDMBHeader2013(const CSCDMBStatusDigi & digi)
     {

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer.h
@@ -20,7 +20,7 @@ public:
 
   CSCDMBTrailer(uint16_t firmware_version = 2005);
 
-  CSCDMBTrailer(unsigned short * buf, uint16_t firmware_version = 2005);
+  CSCDMBTrailer(const uint16_t * buf, uint16_t firmware_version = 2005);
   
   CSCDMBTrailer(const CSCDMBStatusDigi & digi) 
     {

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer.h
@@ -12,8 +12,8 @@
 
 
 // class CSCDMBHeader;
-class CSCDMBTrailer2005;
-class CSCDMBTrailer2013;
+struct CSCDMBTrailer2005;
+struct CSCDMBTrailer2013;
 
 class CSCDMBTrailer {
 public:

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2005.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2005.h
@@ -14,7 +14,7 @@ struct CSCDMBTrailer2005: public CSCVDMBTrailerFormat {
       bits.ddu_code_5 = bits.ddu_code_6 = bits.ddu_code_7 = bits.ddu_code_8 = 0xE;
     }
 
-  CSCDMBTrailer2005(unsigned short * buf)
+  CSCDMBTrailer2005(const uint16_t * buf)
     {
       memcpy(data(), buf, sizeInWords()*2);
     };

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2013.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2013.h
@@ -48,7 +48,7 @@ struct CSCDMBTrailer2013: public CSCVDMBTrailerFormat {
       bits.ddu_code_5 = bits.ddu_code_6 = bits.ddu_code_7 = bits.ddu_code_8 = 0xE;
     }
  
-  CSCDMBTrailer2013(unsigned short * buf)
+  CSCDMBTrailer2013(const uint16_t * buf)
     {
       memcpy(data(), buf, sizeInWords()*2);
     }

--- a/EventFilter/CSCRawToDigi/interface/CSCEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCEventData.h
@@ -43,7 +43,7 @@ class CSCEventData {
  public:
   explicit CSCEventData(int chamberType, uint16_t format_version = 2005);
   /// should make const input soon
-  CSCEventData(unsigned short * buf, uint16_t format_version = 2005);
+  CSCEventData(const uint16_t * buf, uint16_t format_version = 2005);
   CSCEventData(){}
   /// since we need deep copies, need the Big Three
   /// (destructor, copy ctor, op=)
@@ -59,10 +59,10 @@ class CSCEventData {
 
 
   ///if dealing with ALCT data
-  bool isALCT(const short unsigned int * buf);
+  bool isALCT(const uint16_t * buf);
 
   ///if dealing with TMB data
-  bool isTMB(const short unsigned int * buf);
+  bool isTMB(const uint16_t * buf);
 
 
   
@@ -157,7 +157,7 @@ private:
   /// helpers for ctors, dtor, and op=
   /// zeroes all pointers
   void init();
-  void unpack_data(unsigned short * buf);
+  void unpack_data(const uint16_t * buf);
   void copy(const CSCEventData &);
   void destroy();
 

--- a/EventFilter/CSCRawToDigi/interface/CSCEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCEventData.h
@@ -68,7 +68,7 @@ class CSCEventData {
   
 
   /// unpacked in long mode: has overflow and error bits decoded
-  CSCCFEBData * cfebData(unsigned icfeb) const;
+  const CSCCFEBData * cfebData(unsigned icfeb) const;
 
   /// returns all the strip digis in the chamber, with the comparator information.
   std::vector<CSCStripDigi> stripDigis(const CSCDetId & idlayer) const;

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBBlockedCFEB.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBBlockedCFEB.h
@@ -8,13 +8,14 @@
 #ifndef CSCTMBBlockedCFEB_h
 #define CSCTMBBlockedCFEB_h
 #include <vector>
+#include <cstdint>
 
 class CSCTMBBlockedCFEB {
 
 public:
 
   CSCTMBBlockedCFEB() {size_ = 0;}  //default constructor
-  CSCTMBBlockedCFEB(unsigned short *buf,int Line6BCB,int Line6ECB);
+  CSCTMBBlockedCFEB(const uint16_t *buf,int Line6BCB,int Line6ECB);
   int getSize() const {return size_;}
   std::vector<int> getData() const {return BlockedCFEBdata;}
   std::vector< std::vector<int> > getSingleCFEBList(int CFEBn) const;
@@ -23,7 +24,7 @@ public:
   
 private:
 
-  int UnpackBlockedCFEB(unsigned short *buf,int Line6BCB,int Line6ECB);
+  int UnpackBlockedCFEB(const uint16_t *buf,int Line6BCB,int Line6ECB);
 
   std::vector<int> BlockedCFEBdata;     /// stores all mini scope data
   unsigned size_;

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBData.h
@@ -29,9 +29,9 @@ class CSCTMBData {
   CSCTMBData();
   CSCTMBData(int firmwareVersion, int firmwareRevision, int ncfebs=5);
   ~CSCTMBData();
-  CSCTMBData(unsigned short *buf);
+  CSCTMBData(const uint16_t *buf);
   CSCTMBData(const CSCTMBData& data);
-  int UnpackTMB(unsigned short *buf);
+  int UnpackTMB(const uint16_t *buf);
   /// sees if the size adds up to the word count
   bool checkSize() const;
   static void setDebug(const bool value) {debug = value;}
@@ -72,7 +72,7 @@ class CSCTMBData {
 
   ///@@ not sure what this means for simulation.  I keep this
   /// around so we can calculate CRCs
-  unsigned short * theOriginalBuffer;
+  const uint16_t * theOriginalBuffer;
   /// CRC calc needs to know where 0x6B0C and 0x6E0F lines were
   /// we want to put off CRC calc until needed
   unsigned theB0CLine;

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBMiniScope.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBMiniScope.h
@@ -15,7 +15,7 @@ class CSCTMBMiniScope {
 public:
 
   CSCTMBMiniScope() {size_ = 0;}  //default constructor
-  CSCTMBMiniScope(unsigned short *buf,int Line6b07,int Line6E07);
+  CSCTMBMiniScope(const uint16_t *buf,int Line6b07,int Line6E07);
   int getSize() const {return size_;}
   int getTbinCount() const {return miniScopeTbinCount;}
   int getTbinPreTrigger() const {return miniScopeTbinPreTrigger;}
@@ -27,7 +27,7 @@ public:
   
 private:
 
-  int UnpackMiniScope(unsigned short *buf,int Line6b07,int Line6E07);
+  int UnpackMiniScope(const uint16_t *buf,int Line6b07,int Line6E07);
 
   std::vector <int> miniScopeAdress;                /// stores all mini scope adresses
   std::vector <int> miniScopeData;                  /// stores all mini scope data

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBScope.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBScope.h
@@ -17,7 +17,7 @@ class CSCTMBScope {
 public:
 
   CSCTMBScope() {size_ = 0;}  //default constructor
-  CSCTMBScope(unsigned short *buf,int b05Line,int e05Line);
+  CSCTMBScope(const uint16_t *buf,int b05Line,int e05Line);
   static unsigned short sizeInWords() {return 1538;}
   static void setDebug(const bool value) {debug = value;};
 
@@ -25,7 +25,7 @@ public:
                                     //public for now -- better way?
 private:
 
-  int UnpackScope(unsigned short *buf,int b05Line,int e05Line);
+  int UnpackScope(const uint16_t *buf,int b05Line,int e05Line);
   int GetPretrig(int ich);
 
   unsigned int scope_ram[256][6];   //stores all scope data

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBTrailer.h
@@ -32,7 +32,7 @@ public:
   /// don't forget to pass in the size of the tmb header + clct data
   CSCTMBTrailer(int wordCount, int firmwareVersion);
 
-  CSCTMBTrailer(unsigned short * buf, unsigned short int firmwareVersion);
+  CSCTMBTrailer(const uint16_t * buf, unsigned short int firmwareVersion);
 
   CSCTMBTrailer(const CSCTMBStatusDigi & digi)
     {

--- a/EventFilter/CSCRawToDigi/src/CSCAnodeData2007.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCAnodeData2007.cc
@@ -29,8 +29,8 @@ void CSCAnodeData2007::init(const CSCALCTHeader & header) {
   ///the sizes of raw words vary depending on type of the ALCT board
   ///                         number of layer parts for various
   ///                         alct board types:     1  2  3     5  6
-  static unsigned short int layerParts[7]    = { 3, 3, 4, 6, 6, 8,10};
-  static unsigned short int wireGroups[7]    = {32,32,48,64,64,96,112};
+  static const unsigned short int layerParts[7]    = { 3, 3, 4, 6, 6, 8,10};
+  static const unsigned short int wireGroups[7]    = {32,32,48,64,64,96,112};
   //header.ALCTDigis();
   sizeInWords2007_=(1-header.alctHeader2007().rawOverflow)*6*
   header.alctHeader2007().rawBins*layerParts[header.alctHeader2007().boardType];

--- a/EventFilter/CSCRawToDigi/src/CSCBadCFEBTimeSlice.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCBadCFEBTimeSlice.cc
@@ -1,7 +1,7 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCBadCFEBTimeSlice.h"
 #include<cassert>
 
-CSCBadCFEBWord & CSCBadCFEBTimeSlice::word(int i) 
+const CSCBadCFEBWord & CSCBadCFEBTimeSlice::word(int i) const
 {
   assert(i>=0 && i<4);
   return theWords[i];

--- a/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
@@ -90,31 +90,29 @@ void CSCCFEBData::add(const CSCStripDigi & digi, int layer)
       unsigned channel = (digi.getStrip()-1) % 16 + 1;
       unsigned value = scaCounts[itime] & 0xFFF; // 12-bit
       // assume it's good, since we're working with simulation
-      const CSCCFEBTimeSlice * slice = timeSlice(itime);
+      CSCCFEBTimeSlice * slice = timeSlice(itime);
       assert(slice != nullptr);
       slice->timeSample(layer, channel,fDCFEB)->adcCounts = value;
       /// =VB= Set CRC value for simulated data
-      ((CSCCFEBTimeSlice *)slice)->setCRC();
+      slice->setCRC();
     }
 }
 
 const CSCCFEBTimeSlice * CSCCFEBData::timeSlice(unsigned i) const 
 {
-  const CSCCFEBTimeSlice * result;
   assert(i < theNumberOfSamples);
   std::pair<int,bool> start = theSliceStarts[i];
   // give a NULL pointer if this is a bad slice
-  if(!start.second) 
-    {
-      result = nullptr;
-    } 
-  else 
-    {
-      result = reinterpret_cast<const CSCCFEBTimeSlice *>(theData+start.first);
-    }
-  return result;
+  return start.second ? reinterpret_cast<const CSCCFEBTimeSlice *>(theData+start.first) : nullptr;
 }
 
+CSCCFEBTimeSlice * CSCCFEBData::timeSlice(unsigned i)
+{
+  assert(i < theNumberOfSamples);
+  std::pair<int,bool> start = theSliceStarts[i];
+  // give a NULL pointer if this is a bad slice
+  return start.second ? reinterpret_cast<CSCCFEBTimeSlice *>(theData+start.first) : nullptr;
+}
 
 unsigned CSCCFEBData::adcCounts(unsigned layer, unsigned channel, unsigned timeBin) const 
 {
@@ -220,7 +218,7 @@ CSCCFEBStatusDigi CSCCFEBData::statusDigi() const
 
 
 
-void CSCCFEBData::digis(uint32_t idlayer, std::vector<CSCStripDigi> & result )
+void CSCCFEBData::digis(uint32_t idlayer, std::vector<CSCStripDigi> & result ) const
 {
   
   // assert(layer>0 && layer <= 6);
@@ -307,7 +305,7 @@ void CSCCFEBData::digis(uint32_t idlayer, std::vector<CSCStripDigi> & result )
 
 
 
-std::vector<CSCStripDigi> CSCCFEBData::digis(unsigned idlayer)
+std::vector<CSCStripDigi> CSCCFEBData::digis(unsigned idlayer) const
 {
   //assert(layer>0 && layer <= 6);
   std::vector<CSCStripDigi> result;

--- a/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
@@ -8,7 +8,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <cassert>
 
-CSCCFEBData::CSCCFEBData(unsigned number, unsigned short * buf, uint16_t format_version, bool f_dcfeb) 
+CSCCFEBData::CSCCFEBData(unsigned number, const uint16_t * buf, uint16_t format_version, bool f_dcfeb) 
   : theSize(0), boardNumber_(number), theNumberOfSamples(0), theFormatVersion(format_version), fDCFEB(f_dcfeb) {
   // I may be grabbing too many words, but that's OK
   // parse for time slices
@@ -18,8 +18,8 @@ CSCCFEBData::CSCCFEBData(unsigned number, unsigned short * buf, uint16_t format_
   theSliceStarts.reserve(8);
   while(theNumberOfSamples < maxSamples) {
     // first see if it's a bad slice
-    CSCBadCFEBTimeSlice * badSlice
-      = reinterpret_cast<CSCBadCFEBTimeSlice *>(buf+pos);
+    const CSCBadCFEBTimeSlice * badSlice
+      = reinterpret_cast<const CSCBadCFEBTimeSlice *>(buf+pos);
     if(badSlice->check()) {
       //show that a bad slice starts here
       theSliceStarts.push_back(std::pair<int, bool>(pos, false));
@@ -29,8 +29,8 @@ CSCCFEBData::CSCCFEBData(unsigned number, unsigned short * buf, uint16_t format_
     } 
     else {
       // OK.  Maybe it's good.
-      CSCCFEBTimeSlice * goodSlice 
-	= reinterpret_cast<CSCCFEBTimeSlice *>(buf+pos);
+      const CSCCFEBTimeSlice * goodSlice 
+	= reinterpret_cast<const CSCCFEBTimeSlice *>(buf+pos);
       if(goodSlice->check()) {
 	// show that a good slice starts here
 	theSliceStarts.push_back(std::pair<int, bool>(pos, true));

--- a/EventFilter/CSCRawToDigi/src/CSCChamberDataItr.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCChamberDataItr.cc
@@ -10,7 +10,7 @@ CSCChamberDataItr::CSCChamberDataItr(const char * buf) :
     = reinterpret_cast<const CSCDCCHeader *>(buf);
   if(dccHeader->check())
     {
-      theDCCData = new CSCDCCEventData((unsigned short *)buf);
+      theDCCData = new CSCDCCEventData((const uint16_t *)buf);
       theNumberOfDDUs = theDCCData->dduData().size();
       theDDUItr = new CSCDDUDataItr( &(theDCCData->dduData()[theCurrentDDU]) );
     }

--- a/EventFilter/CSCRawToDigi/src/CSCDCCEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDCCEventData.cc
@@ -25,7 +25,7 @@ CSCDCCEventData::CSCDCCEventData(int sourceId, int nDDUs, int bx, int l1a)
   theDDUData.reserve(nDDUs);
 } 
 
-CSCDCCEventData::CSCDCCEventData(unsigned short *buf, CSCDCCExaminer* examiner)
+CSCDCCEventData::CSCDCCEventData(const uint16_t *buf, CSCDCCExaminer* examiner)
 {
   unpack_data(buf, examiner);
 }
@@ -35,7 +35,7 @@ CSCDCCEventData::~CSCDCCEventData()
 }
 
 
-void CSCDCCEventData::unpack_data(unsigned short *buf, CSCDCCExaminer* examiner) 
+void CSCDCCEventData::unpack_data(const uint16_t *buf, CSCDCCExaminer* examiner) 
 {
  
 /*

--- a/EventFilter/CSCRawToDigi/src/CSCDDUDataItr.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUDataItr.cc
@@ -23,7 +23,7 @@ CSCDDUDataItr::CSCDDUDataItr(const char * buf) :
   const CSCDDUHeader * dduHeader
     = reinterpret_cast<const CSCDDUHeader *>(buf);
   if(dduHeader->check()){
-    theDDUData = new CSCDDUEventData((unsigned short *)buf);
+    theDDUData = new CSCDDUEventData((const uint16_t *)buf);
     theNumberOfCSCs = theDDUData->cscData().size();
   } else {
     LogTrace ("CSCDDUDataItr|CSCRawToDigi") << "Failed DDU header check.";
@@ -67,7 +67,7 @@ CSCDDUDataItr::CSCDDUDataItr(const CSCDDUDataItr & i) :
 
 void CSCDDUDataItr::operator=(const CSCDDUDataItr & i) 
 {
-  if(theDataIsOwnedByMe) 
+  if(theDataIsOwnedByMe && theDDUData != i.theDDUData) 
     {
       delete theDDUData;
       if(i.theDDUData != nullptr) 

--- a/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
@@ -215,7 +215,7 @@ void CSCDDUEventData::unpack_data(const uint16_t *buf, CSCDCCExaminer* examiner)
 	
     std::map<DDUIdType,std::map<CSCIdType,const uint16_t*> > ddus = examiner->DMB_block();
     std::map<DDUIdType,std::map<CSCIdType,const uint16_t*> >::iterator ddu_itr = ddus.find(dduID);
-    uint16_t* dduBlock = (uint16_t*)((examiner->DDU_block())[dduID]);
+    const uint16_t* dduBlock = (const uint16_t*)((examiner->DDU_block())[dduID]);
     uint32_t dduBufSize = (examiner->DDU_size())[dduID];
 		
     if (ddu_itr != ddus.end() && dduBufSize!=0 && dduBlock==inputBuf) {
@@ -227,7 +227,7 @@ void CSCDDUEventData::unpack_data(const uint16_t *buf, CSCDCCExaminer* examiner)
 
         if(cscid != -1)
         {
-	  uint16_t* pos = (uint16_t*)csc_itr->second;
+	  const uint16_t* pos = (const uint16_t*)csc_itr->second;
 	
 	
           ExaminerStatusType errors = examiner->errorsForChamber(cscid);

--- a/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
@@ -29,7 +29,7 @@ CSCDDUEventData::CSCDDUEventData(const CSCDDUHeader & header)
 }
 
   
-CSCDDUEventData::CSCDDUEventData(uint16_t *buf, CSCDCCExaminer* examiner) 
+CSCDDUEventData::CSCDDUEventData(const uint16_t *buf, CSCDCCExaminer* examiner) 
 {
   unpack_data(buf, examiner);
 }
@@ -157,11 +157,11 @@ void CSCDDUEventData::decodeStatus(int code) const
     }
 }
 
-void CSCDDUEventData::unpack_data(uint16_t *buf, CSCDCCExaminer* examiner) 
+void CSCDDUEventData::unpack_data(const uint16_t *buf, CSCDCCExaminer* examiner) 
 {
   // just to calculate length
-  uint16_t * inputBuf = buf;
-  uint16_t * inputBuf0 = buf; /// To pack trailer 0 
+  const uint16_t * inputBuf = buf;
+  const uint16_t * inputBuf0 = buf; /// To pack trailer 0 
   theData.clear();
   if (debug) LogTrace ("CSCDDUEventData|CSCRawToDigi") << "CSCDDUEventData::unpack_data() is called";
   if (debug) 

--- a/EventFilter/CSCRawToDigi/src/CSCDMBHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDMBHeader.cc
@@ -17,7 +17,7 @@ CSCDMBHeader::CSCDMBHeader(uint16_t firmware_version)
 
 }
 
-CSCDMBHeader::CSCDMBHeader(unsigned short * buf, uint16_t firmware_version)
+CSCDMBHeader::CSCDMBHeader(const uint16_t * buf, uint16_t firmware_version)
 : theHeaderFormat(), theFirmwareVersion(firmware_version) 
 {
   if (theFirmwareVersion == 2013) {

--- a/EventFilter/CSCRawToDigi/src/CSCDMBHeader2005.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDMBHeader2005.cc
@@ -9,7 +9,7 @@ CSCDMBHeader2005::CSCDMBHeader2005()
   bits.newddu_code_1 = bits.newddu_code_2 = bits.newddu_code_3 = bits.newddu_code_4 = 0x9;
 }
 
-CSCDMBHeader2005::CSCDMBHeader2005(unsigned short * buf) 
+CSCDMBHeader2005::CSCDMBHeader2005(const uint16_t * buf) 
 {
   memcpy(data(), buf, sizeInWords()*2);
 }

--- a/EventFilter/CSCRawToDigi/src/CSCDMBHeader2013.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDMBHeader2013.cc
@@ -9,7 +9,7 @@ CSCDMBHeader2013::CSCDMBHeader2013()
   bits.newddu_code_1 = bits.newddu_code_2 = bits.newddu_code_3 = bits.newddu_code_4 = 0x9;
 }
 
-CSCDMBHeader2013::CSCDMBHeader2013(unsigned short * buf) 
+CSCDMBHeader2013::CSCDMBHeader2013(const uint16_t * buf) 
 {
   memcpy(data(), buf, sizeInWords()*2);
 }

--- a/EventFilter/CSCRawToDigi/src/CSCDMBTrailer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDMBTrailer.cc
@@ -17,7 +17,7 @@ CSCDMBTrailer::CSCDMBTrailer(uint16_t firmware_version)
 
 }
 
-CSCDMBTrailer::CSCDMBTrailer(unsigned short * buf, uint16_t firmware_version)
+CSCDMBTrailer::CSCDMBTrailer(const uint16_t * buf, uint16_t firmware_version)
 : theTrailerFormat(), theFirmwareVersion(firmware_version) 
 {
   if (theFirmwareVersion == 2013) {

--- a/EventFilter/CSCRawToDigi/src/CSCEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCEventData.cc
@@ -35,18 +35,18 @@ CSCEventData::CSCEventData(int chamberType, uint16_t format_version) :
 }
 
 
-CSCEventData::CSCEventData(unsigned short * buf, uint16_t format_version): theFormatVersion(format_version)
+CSCEventData::CSCEventData(const uint16_t * buf, uint16_t format_version): theFormatVersion(format_version)
 {
   theFormatVersion = format_version;
   unpack_data(buf);
 }
 
 
-void CSCEventData::unpack_data(unsigned short * buf)
+void CSCEventData::unpack_data(const uint16_t * buf)
 {
   // zero everything
   init();
-  unsigned short * pos = buf;
+  const uint16_t * pos = buf;
   if (debug)
     {
       LogTrace ("CSCEventData|CSCRawToDigi") << "The event data ";
@@ -130,7 +130,7 @@ void CSCEventData::unpack_data(unsigned short * buf)
                   /// Calculate the number of words in the layer
                   int nWG_round_up   = int(nWGs_per_layer/12)+(nWGs_per_layer%3?1:0);
                   //std::cout << " Words per layer: " << nWG_round_up << std::endl; ///to_rm
-                  unsigned short * posZSE = pos;
+                  const uint16_t * posZSE = pos;
                   std::vector<unsigned short> alctZSErecoveredVector;
                   alctZSErecoveredVector.clear();
 

--- a/EventFilter/CSCRawToDigi/src/CSCEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCEventData.cc
@@ -448,7 +448,7 @@ std::vector < std::vector<CSCWireDigi> > CSCEventData::wireDigis() const
 }
 
 
-CSCCFEBData* CSCEventData::cfebData(unsigned icfeb) const
+const CSCCFEBData* CSCEventData::cfebData(unsigned icfeb) const
 {
   return theCFEBData[icfeb];
 }

--- a/EventFilter/CSCRawToDigi/src/CSCTMBBlockedCFEB.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBBlockedCFEB.cc
@@ -8,7 +8,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
-CSCTMBBlockedCFEB::CSCTMBBlockedCFEB(unsigned short *buf,int Line6BCB,int Line6ECB)
+CSCTMBBlockedCFEB::CSCTMBBlockedCFEB(const uint16_t *buf,int Line6BCB,int Line6ECB)
 {
 
   size_ = UnpackBlockedCFEB(buf,Line6BCB,Line6ECB);
@@ -16,7 +16,7 @@ CSCTMBBlockedCFEB::CSCTMBBlockedCFEB(unsigned short *buf,int Line6BCB,int Line6E
 } ///CSCTMBMiniScope
 
 
-int CSCTMBBlockedCFEB::UnpackBlockedCFEB(unsigned short *buf,int Line6BCB,int Line6ECB)
+int CSCTMBBlockedCFEB::UnpackBlockedCFEB(const uint16_t *buf,int Line6BCB,int Line6ECB)
 {
 
   if ((Line6ECB-Line6BCB) != 0)

--- a/EventFilter/CSCRawToDigi/src/CSCTMBData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBData.cc
@@ -64,7 +64,7 @@ CSCTMBData::CSCTMBData(int firmwareVersion, int firmwareRevision, int cfebs)
 
 }
 
-CSCTMBData::CSCTMBData(unsigned short *buf) 
+CSCTMBData::CSCTMBData(const uint16_t *buf) 
   : theOriginalBuffer(buf), 
     theTMBHeader(2007, 0x50c3),
     theCLCTData(&theTMBHeader),
@@ -135,7 +135,7 @@ CSCTMBData::~CSCTMBData(){
 
 /// returns -1 if not found
 /// obsolete
-int findLine(unsigned short *buf, unsigned short marker,int first,  int maxToDo) {
+int findLine(const uint16_t *buf, uint16_t marker,int first,  int maxToDo) {
   for(int i = first; i < maxToDo; ++i) { 
     if(buf[i] == marker) {
       return i;
@@ -162,7 +162,7 @@ int CSCTMBData::TMBCRCcalc() {
   }
 }
 
-int CSCTMBData::UnpackTMB(unsigned short *buf) {
+int CSCTMBData::UnpackTMB(const uint16_t *buf) {
   ///determine 2007 or 2006 version
   unsigned short int firmwareVersion=0;
   int Ntbins = 0 ;

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
@@ -201,7 +201,7 @@ CSCTMBHeader2006 CSCTMBHeader::tmbHeader2006()   const
 
 void CSCTMBHeader::selfTest()
 {
-  static bool debug = false;
+  constexpr bool debug = false;
 
   // tests packing and unpacking
   for(int station = 1; station <= 4; ++station)

--- a/EventFilter/CSCRawToDigi/src/CSCTMBMiniScope.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBMiniScope.cc
@@ -10,14 +10,14 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
-CSCTMBMiniScope::CSCTMBMiniScope(unsigned short *buf,int Line6b07,int Line6E07) {
+CSCTMBMiniScope::CSCTMBMiniScope(const uint16_t *buf,int Line6b07,int Line6E07) {
 
   size_ = UnpackMiniScope(buf,Line6b07,Line6E07);
 
 } ///CSCTMBMiniScope
 
 
-int CSCTMBMiniScope::UnpackMiniScope(unsigned short *buf,int Line6b07,int Line6E07) {
+int CSCTMBMiniScope::UnpackMiniScope(const uint16_t *buf,int Line6b07,int Line6E07) {
 
 
   if((Line6E07-Line6b07) != 0) {

--- a/EventFilter/CSCRawToDigi/src/CSCTMBScope.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBScope.cc
@@ -14,14 +14,14 @@ bool CSCTMBScope::debug = false;
 std::atomic<bool> CSCTMBScope::debug{false};
 #endif
 
-CSCTMBScope::CSCTMBScope(unsigned short *buf,int b05Line,int e05Line) {
+CSCTMBScope::CSCTMBScope(const uint16_t *buf,int b05Line,int e05Line) {
 
   size_ = UnpackScope(buf,b05Line,e05Line);
 
 } //CSCTMBScope
 
 
-int CSCTMBScope::UnpackScope(unsigned short *buf,int b05Line,int e05Line) {
+int CSCTMBScope::UnpackScope(const uint16_t *buf,int b05Line,int e05Line) {
 
   int pretrig_chan[4]={0,0,0,0};
   unsigned int tbin_strt,tbin_stop;

--- a/EventFilter/CSCRawToDigi/src/CSCTMBTrailer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBTrailer.cc
@@ -31,7 +31,7 @@ CSCTMBTrailer::CSCTMBTrailer(int wordCount, int firmwareVersion)
 }
 
 
-CSCTMBTrailer::CSCTMBTrailer(unsigned short * buf, unsigned short int firmwareVersion) 
+CSCTMBTrailer::CSCTMBTrailer(const uint16_t * buf, unsigned short int firmwareVersion) 
 : theFirmwareVersion(firmwareVersion)
 {
   // take a little too much, maybe

--- a/EventFilter/CSCRawToDigi/src/bitset_append.cc
+++ b/EventFilter/CSCRawToDigi/src/bitset_append.cc
@@ -55,10 +55,11 @@ namespace bitset_utilities {
 
   void printWords(const boost::dynamic_bitset<> & bs) 
   {
-    unsigned char words[60000];
+    constexpr unsigned int nShorts = 30000;
+    unsigned char words[nShorts*2];
     bitsetToChar(bs, words);
     unsigned short * buf= (unsigned short *) words;
-    for (int unsigned i=0;i<bs.size()/16;++i) {
+    for (int unsigned i=0;i<bs.size()/16 && i+3 < nShorts;++i) {
       printf("%04x %04x %04x %04x\n",buf[i+3],buf[i+2],buf[i+1],buf[i]);
       i+=3;
     }

--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
@@ -66,7 +66,7 @@ public:
 
 private:
 
-  mutable int theWordCounter;
+  int theWordCounter;
 
   RPixErrorChecker errorcheck;
 

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -280,7 +280,7 @@ void RawToDigiConverter::Run(const VFATFrameCollection &coll, const TotemDAQMapp
     if (record.status.isOK())
     {
       const VFATFrame *fr = record.frame;
-      const DiamondVFATFrame *diamondframe = dynamic_cast<const DiamondVFATFrame*>(fr);
+      const DiamondVFATFrame *diamondframe = static_cast<const DiamondVFATFrame*>(fr);
 
       // update Event Counter in status
       record.status.setEC(record.frame->getEC() & 0xFF);

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -95,7 +95,7 @@ void RawToDigiConverter::RunCommon(const VFATFrameCollection &input, const Totem
       if (verbosity > 0)
         fes << "    invalid footprint" << endl;
 
-      if ((testFootprint == tfErr))
+      if (testFootprint == tfErr)
       {
         record.status.setFootprintError();
         stopProcessing = true;

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -280,7 +280,7 @@ void RawToDigiConverter::Run(const VFATFrameCollection &coll, const TotemDAQMapp
     if (record.status.isOK())
     {
       const VFATFrame *fr = record.frame;
-      DiamondVFATFrame *diamondframe = (DiamondVFATFrame*) fr;
+      const DiamondVFATFrame *diamondframe = dynamic_cast<const DiamondVFATFrame*>(fr);
 
       // update Event Counter in status
       record.status.setEC(record.frame->getEC() & 0xFF);

--- a/EventFilter/CastorRawToDigi/src/CastorCTDCHeader.cc
+++ b/EventFilter/CastorRawToDigi/src/CastorCTDCHeader.cc
@@ -20,13 +20,13 @@ unsigned int CastorCTDCHeader::getTotalLengthBytes() const {
 }  
 
 int CastorCTDCHeader::getSpigotData(int nspigot, CastorCORData& decodeTool, int validSize) const {
-  const unsigned short* base=((unsigned short*)this)+sizeof(CastorCTDCHeader)/sizeof(unsigned short);
+  const uint16_t* base=((const uint16_t*)this)+sizeof(CastorCTDCHeader)/sizeof(uint16_t);
   int offset=0,i,len=0;
   for (i=0; i<=nspigot; i++) {
     offset+=len;
     len=(spigotInfo[i]&0x3FF)*2;
   }
-  if ((offset+len+sizeof(CastorCTDCHeader)/sizeof(unsigned short))<(validSize/sizeof(unsigned short))) {
+  if ((offset+len+sizeof(CastorCTDCHeader)/sizeof(uint16_t))<(validSize/sizeof(uint16_t))) {
     decodeTool.adoptData(base+offset,len);
     return 0;
   } else { return -1; }

--- a/EventFilter/EcalRawToDigi/plugins/MatacqProducer.cc
+++ b/EventFilter/EcalRawToDigi/plugins/MatacqProducer.cc
@@ -545,9 +545,9 @@ MatacqProducer::getMatacqFile(uint32_t runNumber, uint32_t orbitId,
   if(openedFileRunNumber_ != 0
      && openedFileRunNumber_ == runNumber){
     uint32_t firstOrb, lastOrb;
-    getOrbitRange(firstOrb, lastOrb);
+    bool goodRange = getOrbitRange(firstOrb, lastOrb);
     //    if(orbitId < firstOrb || orbitId > lastOrb) continue;
-    if(firstOrb <= orbitId && orbitId <= lastOrb){
+    if(goodRange && firstOrb <= orbitId && orbitId <= lastOrb){
       if(fileChange!=nullptr) *fileChange = false;
       return misOpened();
     }
@@ -600,7 +600,7 @@ MatacqProducer::getMatacqFile(uint32_t runNumber, uint32_t orbitId,
       for(unsigned iglob = 0; iglob < g.gl_pathc; ++iglob){
 	char* thePath = g.gl_pathv[iglob];
 	//FIXME: add sanity check on the path
-	static int nOpenErrors = 0;
+	static std::atomic<int> nOpenErrors {0};
 	const int maxOpenErrors = 50;
 	if(!mopen(thePath) && nOpenErrors < maxOpenErrors){
 	  std::cout << "[Matacq " << now() << "] Failed to open file " << thePath;
@@ -614,9 +614,9 @@ MatacqProducer::getMatacqFile(uint32_t runNumber, uint32_t orbitId,
 	}
 	uint32_t firstOrb;
 	uint32_t lastOrb;
-	getOrbitRange(firstOrb, lastOrb);
-	if(lastOrb > maxOrb) maxOrb = lastOrb;
-	if(firstOrb <= orbitId && orbitId <= lastOrb){
+	bool goodRange = getOrbitRange(firstOrb, lastOrb);
+	if(goodRange && lastOrb > maxOrb) maxOrb = lastOrb;
+	if(goodRange && firstOrb <= orbitId && orbitId <= lastOrb){
 	  found = true;
 	  //continue;
 	  fname = thePath;

--- a/EventFilter/EcalRawToDigi/src/DCCEETCCBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCEETCCBlock.cc
@@ -67,7 +67,8 @@ void DCCEETCCBlock::addTriggerPrimitivesToCollection(){
             break;
           }
           // adding trigger primitive digi to the collection
-          (*tps_)->push_back(*pTP_);
+          if (pTP_) (*tps_)->push_back(*pTP_);
+          else edm::LogError("IncorrectBlock")<<"trigger primitive digi was not aquired";
         }
         
         
@@ -138,7 +139,8 @@ void DCCEETCCBlock::addTriggerPrimitivesToCollection(){
             break;
           }
           // adding trigger primitive digi to the collection
-          (*tps_)->push_back(*pTP_);
+          if (pTP_) (*tps_)->push_back(*pTP_);
+          else edm::LogError("IncorrectBlock")<<"trigger primitive digi was not aquired";
         }
         
         if(processTPG2){

--- a/EventFilter/EcalRawToDigi/src/DCCTowerBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCTowerBlock.cc
@@ -48,15 +48,16 @@ int DCCTowerBlock::unpackXtalData(unsigned int expStripID, unsigned int expXtalI
     pDetId_ = (EBDetId*) mapper_->getDetIdPointer(towerId_,expStripID,expXtalID);
     (*invalidChIds_)->push_back(*pDetId_);
     
-    stripId    = expStripID;
-    xtalId     = expXtalID;
-    errorOnXtal= true;
-    
     // return here, so to skip all following checks
     lastXtalId_++;
     if (lastXtalId_ > NUMB_XTAL)         {lastXtalId_=1; lastStripId_++;}
     data_ += numbDWInXtalBlock_;
     return BLOCK_UNPACKED;
+
+    //keep these here in case the return is to be dropped
+    stripId    = expStripID;
+    xtalId     = expXtalID;
+    errorOnXtal= true;    
   }
 
 
@@ -85,14 +86,13 @@ int DCCTowerBlock::unpackXtalData(unsigned int expStripID, unsigned int expXtalI
       //(*invalidChIds_)->push_back(*pDetId_);
       fillEcalElectronicsError(invalidZSXtalIds_); 
 
-      errorOnXtal = true;
 
       lastStripId_ = st;
       lastXtalId_  = ch;
       
       // return here, so to skip all following checks
       return SKIP_BLOCK_UNPACKING;
-      
+      errorOnXtal = true; //keep it here in case the return is to be dropped      
     }else{
 
       // Check for zs valid Ids 2) if channel-in-strip has increased wrt previous xtal
@@ -120,13 +120,12 @@ int DCCTowerBlock::unpackXtalData(unsigned int expStripID, unsigned int expXtalI
           //(*invalidChIds_)->push_back(*pDetId_);
           fillEcalElectronicsError(invalidZSXtalIds_); 
           
-          errorOnXtal = true;
           lastStripId_ = st;
           lastXtalId_  = ch;
 
           // return here, so to skip all following checks
           return SKIP_BLOCK_UNPACKING;
-          
+          errorOnXtal = true; //keep it here in case the return is to be dropped
         }
       
       // if channel id not proven wrong, update lastStripId_ and lastXtalId_
@@ -203,13 +202,13 @@ int DCCTowerBlock::unpackXtalData(unsigned int expStripID, unsigned int expXtalI
       {
         (*invalidGains_)->push_back(*pDetId_);
         (*digis_)->pop_back(); 
-        errorOnXtal = true; 
         
         //Point to begin of next xtal Block
         data_ += numbDWInXtalBlock_;
         //return here, so to skip all the rest
         //make special collection for gain0 data frames when due to saturation
         return BLOCK_UNPACKED;
+        errorOnXtal = true; //keep it here in case the return is to be dropped
       }//end isSaturation 
     else {
         data_ += numbDWInXtalBlock_;

--- a/EventFilter/EcalRawToDigi/src/MatacqRawEvent.cc
+++ b/EventFilter/EcalRawToDigi/src/MatacqRawEvent.cc
@@ -160,7 +160,7 @@ void MatacqRawEvent::setRawData(const unsigned char* pData, size_t maxSize){
   if((size_t)(pData16-begin16)>maxSize){
     throwExcept(string("Corrupted or truncated data"));
   }
-  uint32le_t* trailer32 = (uint32le_t*)(pData16);
+  const uint32le_t* trailer32 = (const uint32le_t*)(pData16);
   fragLen = trailer32[1]&0xFFFFFF;
   
   //cout << "Event fragment length including headers: " << fragLen

--- a/EventFilter/EcalTBRawToDigi/src/DCCBlockPrototype.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCBlockPrototype.cc
@@ -7,7 +7,7 @@
 #include <sstream>
 
 
-DCCTBBlockPrototype::DCCTBBlockPrototype(DCCTBDataParser * parser, std::string name, uint32_t * buffer, uint32_t numbBytes, uint32_t wordsToEndOfEvent,  uint32_t wordEventOffset ){
+DCCTBBlockPrototype::DCCTBBlockPrototype(DCCTBDataParser * parser, std::string name, const uint32_t * buffer, uint32_t numbBytes, uint32_t wordsToEndOfEvent,  uint32_t wordEventOffset ){
 			
 	blockError_        = false;
 	parser_            = parser;

--- a/EventFilter/EcalTBRawToDigi/src/DCCBlockPrototype.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCBlockPrototype.h
@@ -27,7 +27,7 @@ class DCCTBBlockPrototype{
 		DCCTBBlockPrototype(
 			DCCTBDataParser * parser, 
 			std::string name, 
-			uint32_t* buffer,
+			const uint32_t* buffer,
 			uint32_t numbBytes, 
 			uint32_t wordsToEndOfEvent, 
 			uint32_t wordEventOffset = 0 
@@ -70,8 +70,8 @@ class DCCTBBlockPrototype{
 		
 		std::string formatString(std::string myString,uint32_t minPositions);
 		
-		uint32_t * dataP_;
-		uint32_t * beginOfBuffer_;
+		const uint32_t * dataP_;
+		const uint32_t * beginOfBuffer_;
 		
 		uint32_t blockSize_;
 		uint32_t wordCounter_;

--- a/EventFilter/EcalTBRawToDigi/src/DCCDataParser.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCDataParser.cc
@@ -111,7 +111,7 @@ void DCCTBDataParser::parseFile(std::string fileName, bool singleEvent){
 /* DCCTBDataParser::parseBuffer                               */
 /* parse data from a buffer                                 */
 /*----------------------------------------------------------*/
-void DCCTBDataParser::parseBuffer(uint32_t * buffer, uint32_t bufferSize, bool singleEvent){
+void DCCTBDataParser::parseBuffer(const uint32_t * buffer, uint32_t bufferSize, bool singleEvent){
 	
   resetErrorCounters();                           //reset error counters
 	
@@ -147,7 +147,7 @@ void DCCTBDataParser::parseBuffer(uint32_t * buffer, uint32_t bufferSize, bool s
     throw ECALTBParserException(fatalError);
   }
 
-  uint32_t *myPointer =  buffer_;                        
+  const uint32_t *myPointer =  buffer_;                        
   
   //  uint32_t processedBytes(0), wordIndex(0), lastEvIndex(0),eventSize(0), eventLength(0), errorMask(0);
   uint32_t processedBytes(0), wordIndex(0), eventLength(0), errorMask(0);
@@ -189,8 +189,8 @@ void DCCTBDataParser::parseBuffer(uint32_t * buffer, uint32_t bufferSize, bool s
     }
     
     //build the event pointer with error mask and add it to the events vector
-    std::pair<uint32_t *, uint32_t> eventPointer(myPointer,eventLength);
-    std::pair<uint32_t, std::pair<uint32_t*, uint32_t> > eventPointerWithErrorMask(errorMask,eventPointer);
+    std::pair<const uint32_t *, uint32_t> eventPointer(myPointer,eventLength);
+    std::pair<uint32_t, std::pair<const uint32_t*, uint32_t> > eventPointerWithErrorMask(errorMask,eventPointer);
     events_.push_back(eventPointerWithErrorMask);
     		
     //update processed buffer size 
@@ -215,21 +215,21 @@ void DCCTBDataParser::parseBuffer(uint32_t * buffer, uint32_t bufferSize, bool s
 /*   bit 3 - EOE Error                         */
 /* and the event length                        */
 /*---------------------------------------------*/
-std::pair<uint32_t,uint32_t> DCCTBDataParser::checkEventLength(uint32_t *pointerToEvent, uint32_t bytesToEnd, bool singleEvent){
+std::pair<uint32_t,uint32_t> DCCTBDataParser::checkEventLength(const uint32_t *pointerToEvent, uint32_t bytesToEnd, bool singleEvent){
 	
   std::pair<uint32_t,uint32_t> result;    //returns error mask and event length 
   uint32_t errorMask(0);          //error mask to return
 
   //check begin of event (BOE bits field) 
   //(Note: we have to add one to read the 2nd 32 bit word where BOE is written)
-  uint32_t *boePointer = pointerToEvent + 1;
+  const uint32_t *boePointer = pointerToEvent + 1;
   if( (  ((*boePointer)>>BOEBEGIN)& BOEMASK  )  != BOE ) { 
     (errors_["DCC::BOE"])++; errorMask = 1; 
   }
 	
 	
   //get Event Length from buffer (Note: we have to add two to read the 3rd 32 bit word where EVENT LENGTH is written)
-  uint32_t * myPointer = pointerToEvent + 2; 
+  const uint32_t * myPointer = pointerToEvent + 2; 
   uint32_t eventLength = (*myPointer)&EVENTLENGTHMASK;
 
   // std::cout << " Event Length(from decoding) = " << dec << eventLength << "... bytes to end... " << bytesToEnd << ", event numb : " << processedEvent_ << std::endl;
@@ -265,7 +265,7 @@ std::pair<uint32_t,uint32_t> DCCTBDataParser::checkEventLength(uint32_t *pointer
 
   //check end of event (EOE bits field) 
   //(Note: event length is multiplied by 2 because its written as 32 bit words and not 64 bit words)
-  uint32_t *endOfEventPointer = pointerToEvent + eventLength*2 -1;
+  const uint32_t *endOfEventPointer = pointerToEvent + eventLength*2 -1;
   if ( (  ((*endOfEventPointer) >> EOEBEGIN & EOEMASK )  != EOEMASK) && !eoeError ){ 
     (errors_["DCC::EOE"])++; 
     errorMask = errorMask | (1<<2); 

--- a/EventFilter/EcalTBRawToDigi/src/DCCDataParser.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCDataParser.cc
@@ -85,7 +85,7 @@ void DCCTBDataParser::parseFile(std::string fileName, bool singleEvent){
     if( buffer_ ){ delete [] buffer_; }           //delete current vector if any
     buffer_ = new uint32_t[dataVector.size()];       //allocate memory for new data buffer
 
-    uint32_t *myData_ = (uint32_t *) buffer_;         
+    const uint32_t *myData_ = (const uint32_t *) buffer_;         
     
     //fill buffer data with data from file lines
     for(uint32_t i = 1; i <= dataVector.size() ; i++, myData_++ ){

--- a/EventFilter/EcalTBRawToDigi/src/DCCDataParser.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCDataParser.cc
@@ -82,23 +82,21 @@ void DCCTBDataParser::parseFile(std::string fileName, bool singleEvent){
     }
     
     bufferSize_ = (dataVector.size() ) * 4 ;      //buffer size in bytes (note:each char is an hex number)
-    if( buffer_ ){ delete [] buffer_; }           //delete current vector if any
-    buffer_ = new uint32_t[dataVector.size()];       //allocate memory for new data buffer
 
-    const uint32_t *myData_ = (const uint32_t *) buffer_;         
+    uint32_t *myData = new uint32_t[dataVector.size()];       //allocate memory for a new data buffer
     
     //fill buffer data with data from file lines
-    for(uint32_t i = 1; i <= dataVector.size() ; i++, myData_++ ){
-      sscanf((dataVector[i-1]).c_str(),"%x",(unsigned int *)myData_);
+    for(uint32_t i = 1; i <= dataVector.size() ; i++, myData++ ){
+      sscanf((dataVector[i-1]).c_str(),"%x",myData);
       
       //for debug purposes
-      //std::cout << std::endl << "Data position: " << dec << i << " val = " << getHexString(*myData_);
+      //std::cout << std::endl << "Data position: " << dec << i << " val = " << getHexString(*myData);
     }
     
     inputFile.close();                              //close file
     
-    parseBuffer( buffer_,bufferSize_,singleEvent);  //parse data from buffer
-    
+    parseBuffer( myData,bufferSize_,singleEvent);  //parse data from the newly filled myData
+    delete [] myData;
   }
   else{ 
     std::string errorMessage = std::string(" Error::Unable to open file :") + fileName;

--- a/EventFilter/EcalTBRawToDigi/src/DCCDataParser.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCDataParser.h
@@ -49,7 +49,7 @@ public :
   /**
      Parse data from a buffer
   */
-  void parseBuffer( uint32_t * buffer, uint32_t bufferSize, bool singleEvent = false);
+  void parseBuffer( const uint32_t * buffer, uint32_t bufferSize, bool singleEvent = false);
 
   /**
      Get method for DCCTBDataMapper
@@ -60,7 +60,7 @@ public :
      Check if EVENT LENGTH is coeherent and if BOE/EOE are correctly written
      returns 3 bits code with the error found + event length
   */
-  std::pair<uint32_t,uint32_t> checkEventLength(uint32_t * pointerToEvent, uint32_t bytesToEnd, bool singleEvent = false);
+  std::pair<uint32_t,uint32_t> checkEventLength(const uint32_t * pointerToEvent, uint32_t bytesToEnd, bool singleEvent = false);
   
   /**
      Get methods for parser parameters;
@@ -108,7 +108,7 @@ public :
   /**
    * Get method for events
    */
-  std::vector< std::pair< uint32_t, std::pair<uint32_t *, uint32_t> > > events();
+  std::vector< std::pair< uint32_t, std::pair<const uint32_t *, uint32_t> > > events();
 
 
   /**
@@ -128,7 +128,7 @@ public :
   /**
    * Retrieves a pointer to the data buffer
    */
-  uint32_t *getBuffer() { return buffer_;}
+  const uint32_t *getBuffer() { return buffer_;}
   
   /**
      Class destructor
@@ -142,7 +142,7 @@ public :
 protected :
   void computeBlockSizes();
 
-  uint32_t *buffer_;                //data buffer
+  const uint32_t *buffer_;                //data buffer
   uint32_t bufferSize_;             //buffer size
 
   uint32_t srpBlockSize_;           //SR block size
@@ -155,7 +155,7 @@ protected :
   std::vector<DCCTBEventBlock *> dccEvents_;
   
   // std::pair< errorMask, std::pair< pointer to event, event size (number of DW)> >
-  std::vector< std::pair< uint32_t, std::pair<uint32_t *, uint32_t> > > events_;
+  std::vector< std::pair< uint32_t, std::pair<const uint32_t *, uint32_t> > > events_;
   
   bool parseInternalData_;          //parse internal data flag
   bool debug_;                      //debug flag
@@ -198,7 +198,7 @@ inline uint32_t DCCTBDataParser::tccBlockSize()        { return tccBlockSize_; }
 inline bool DCCTBDataParser::debug()                          { return debug_;     }
 inline std::vector<DCCTBEventBlock *> &DCCTBDataParser::dccEvents()  { return dccEvents_;    }
 inline std::map<std::string,uint32_t> &DCCTBDataParser::errorCounters()    { return errors_;       }
-inline std::vector< std::pair< uint32_t, std::pair<uint32_t *, uint32_t> > > DCCTBDataParser::events() { return events_;   }
+inline std::vector< std::pair< uint32_t, std::pair<const uint32_t *, uint32_t> > > DCCTBDataParser::events() { return events_;   }
 
 
 #endif

--- a/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.cc
@@ -14,7 +14,7 @@
 
 DCCTBEventBlock::DCCTBEventBlock(
 	DCCTBDataParser * parser, 
-	uint32_t * buffer, 
+	const uint32_t * buffer, 
 	uint32_t numbBytes, 
 	uint32_t wordsToEnd, 
 	uint32_t wordBufferOffset , 

--- a/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.h
@@ -20,7 +20,7 @@ class DCCTBEventBlock : public DCCTBBlockPrototype {
 		
 		DCCTBEventBlock(
 			DCCTBDataParser * parser, 
-			uint32_t * buffer, 
+			const uint32_t * buffer, 
 			uint32_t numbBytes, 
 			uint32_t wordsToEnd, 
 			uint32_t wordBufferOffset = 0 , 

--- a/EventFilter/EcalTBRawToDigi/src/DCCSRPBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCSRPBlock.cc
@@ -6,7 +6,7 @@
 DCCTBSRPBlock::DCCTBSRPBlock(
 	DCCTBEventBlock * dccBlock,
 	DCCTBDataParser * parser, 
-	uint32_t * buffer, 
+	const uint32_t * buffer, 
 	uint32_t numbBytes,
 	uint32_t wordsToEnd,
 	uint32_t wordEventOffset

--- a/EventFilter/EcalTBRawToDigi/src/DCCSRPBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCSRPBlock.h
@@ -25,7 +25,7 @@ class DCCTBSRPBlock : public DCCTBBlockPrototype {
 		DCCTBSRPBlock(
 			DCCTBEventBlock * dccBlock,
 			DCCTBDataParser * parser, 
-			uint32_t * buffer, 
+			const uint32_t * buffer, 
 			uint32_t numbBytes,
 			uint32_t wordsToEnd, 
 			uint32_t wordEventOffset

--- a/EventFilter/EcalTBRawToDigi/src/DCCTCCBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTCCBlock.cc
@@ -13,7 +13,7 @@
 DCCTBTCCBlock::DCCTBTCCBlock(
 	DCCTBEventBlock * dccBlock,
 	DCCTBDataParser * parser, 
-	uint32_t * buffer, 
+	const uint32_t * buffer, 
 	uint32_t numbBytes,  
 	uint32_t wordsToEnd,
 	uint32_t wordEventOffset,

--- a/EventFilter/EcalTBRawToDigi/src/DCCTCCBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTCCBlock.h
@@ -29,7 +29,7 @@ public :
   */
   DCCTBTCCBlock(DCCTBEventBlock * dccBlock,
 	      DCCTBDataParser * parser, 
-	      uint32_t * buffer, 
+              const uint32_t * buffer, 
 	      uint32_t numbBytes, 
 	      uint32_t wordsToEnd,
 	      uint32_t wordEventOffset,

--- a/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.cc
@@ -11,7 +11,7 @@
 DCCTBTowerBlock::DCCTBTowerBlock(
  	DCCTBEventBlock * dccBlock, 
 	DCCTBDataParser * parser, 
-	uint32_t * buffer, 
+	const uint32_t * buffer, 
 	uint32_t numbBytes,
 	uint32_t wordsToEnd,
 	uint32_t wordEventOffset,

--- a/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.h
@@ -25,7 +25,7 @@ class DCCTBTowerBlock : public DCCTBBlockPrototype {
 		DCCTBTowerBlock(
 			DCCTBEventBlock * dccBlock,
 			DCCTBDataParser * parser, 
-			uint32_t * buffer, 
+			const uint32_t * buffer, 
 			uint32_t numbBytes, 
 			uint32_t wordsToEnd,
 			uint32_t wordEventOffset,

--- a/EventFilter/EcalTBRawToDigi/src/DCCTrailerBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTrailerBlock.cc
@@ -3,7 +3,7 @@
 #include "DCCDataMapper.h"
 DCCTBTrailerBlock::DCCTBTrailerBlock(
 	DCCTBDataParser * parser, 
-	uint32_t * buffer, 
+	const uint32_t * buffer, 
 	uint32_t numbBytes,  
 	uint32_t wToEnd,
 	uint32_t wordEventOffset,

--- a/EventFilter/EcalTBRawToDigi/src/DCCTrailerBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTrailerBlock.h
@@ -14,7 +14,7 @@ class DCCTBTrailerBlock : public DCCTBBlockPrototype {
 		
 		DCCTBTrailerBlock(
 			DCCTBDataParser * parser, 
-			uint32_t * buffer, 
+			const uint32_t * buffer, 
 			uint32_t numbBytes,
 			uint32_t wToEnd, 
 			uint32_t wordEventOffset,

--- a/EventFilter/EcalTBRawToDigi/src/DCCXtalBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCXtalBlock.cc
@@ -5,7 +5,7 @@
 
 DCCTBXtalBlock::DCCTBXtalBlock(
 	DCCTBDataParser * parser, 
-	uint32_t * buffer, 
+	const uint32_t * buffer, 
 	uint32_t numbBytes,  
 	uint32_t wordsToEnd,
 	uint32_t wordEventOffset,

--- a/EventFilter/EcalTBRawToDigi/src/DCCXtalBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCXtalBlock.h
@@ -13,7 +13,7 @@ class DCCTBXtalBlock : public DCCTBBlockPrototype {
 		
 		DCCTBXtalBlock(
 			DCCTBDataParser * parser, 
-			uint32_t * buffer,
+			const uint32_t * buffer,
 			uint32_t numbBytes,
 			uint32_t wordsToEnd,  
 			uint32_t wordEventOffset,

--- a/EventFilter/EcalTBRawToDigi/src/EcalSupervisorDataFormatter.cc
+++ b/EventFilter/EcalTBRawToDigi/src/EcalSupervisorDataFormatter.cc
@@ -9,7 +9,7 @@ EcalSupervisorTBDataFormatter::EcalSupervisorTBDataFormatter () {
 void EcalSupervisorTBDataFormatter::interpretRawData( const FEDRawData & fedData, 
 					   EcalTBEventHeader& tbEventHeader)
 {
-  const unsigned long * buffer = ( reinterpret_cast<unsigned long*>(const_cast<unsigned char*> ( fedData.data())));
+  const unsigned long * buffer = reinterpret_cast<const unsigned long*>(fedData.data());
   int fedLenght                        = fedData.size(); // in Bytes
   
   // check ultimate fed size and strip off fed-header and -trailer

--- a/EventFilter/EcalTBRawToDigi/src/EcalTB07DaqFormatter.cc
+++ b/EventFilter/EcalTBRawToDigi/src/EcalTB07DaqFormatter.cc
@@ -103,7 +103,7 @@ void EcalTB07DaqFormatter::interpretRawData(const FEDRawData & fedData ,
   pnAllocated = false;
   
 
-  theParser_->parseBuffer( reinterpret_cast<uint32_t*>(const_cast<unsigned char*>(pData)), static_cast<uint32_t>(length), shit );
+  theParser_->parseBuffer( reinterpret_cast<const uint32_t*>(pData), static_cast<uint32_t>(length), shit );
   
   std::vector< DCCTBEventBlock * > &   dccEventBlocks = theParser_->dccEvents();
 

--- a/EventFilter/EcalTBRawToDigi/src/EcalTBDaqFormatter.cc
+++ b/EventFilter/EcalTBRawToDigi/src/EcalTBDaqFormatter.cc
@@ -76,7 +76,7 @@ void EcalTBDaqFormatter::interpretRawData(const FEDRawData & fedData ,
   pnAllocated = false;
   
 
-  theParser_->parseBuffer( reinterpret_cast<uint32_t*>(const_cast<unsigned char*>(pData)), static_cast<uint32_t>(length), shit );
+  theParser_->parseBuffer( reinterpret_cast<const uint32_t*>(pData), static_cast<uint32_t>(length), shit );
   
   std::vector< DCCTBEventBlock * > &   dccEventBlocks = theParser_->dccEvents();
 

--- a/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.cc
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.cc
@@ -64,7 +64,7 @@ void MatacqTBRawEvent::setRawData(const unsigned char* pData, size_t maxSize){
   int padding = (4-(pData16-begin16))%4;
   if(padding<0) padding+=4;
   pData16 += padding;
-  uint32le_t* trailer32 = (uint32le_t*)(pData16);
+  const uint32le_t* trailer32 = (const uint32le_t*)(pData16);
   fragLen = trailer32[1]&0xFFFFFF;
   
   //std::cout << "Event fragment length including headers: " << fragLen

--- a/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.cc
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.cc
@@ -33,9 +33,9 @@ const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::h1Marker32        = {3, 
 
 void MatacqTBRawEvent::setRawData(const unsigned char* pData, size_t maxSize){
   error = 0;
-  int16le_t* begin16 = (int16le_t*) pData;
-  int16le_t* pData16 = begin16;
-  daqHeader = (uint32le_t*) pData16;
+  const int16le_t* begin16 = (const int16le_t*) pData;
+  const int16le_t* pData16 = begin16;
+  daqHeader = (const uint32le_t*) pData16;
   const int daqHeaderLen = 16; //in bytes 
   pData16 += daqHeaderLen/sizeof(pData16[0]);
   matacqHeader = (matacqHeader_t*) pData16;
@@ -100,7 +100,7 @@ void MatacqTBRawEvent::setRawData(const unsigned char* pData, size_t maxSize){
   }
 }
 
-int MatacqTBRawEvent::read32(uint32le_t* pData, field32spec_t spec32) const{
+int MatacqTBRawEvent::read32(const uint32le_t* pData, field32spec_t spec32) const{
   int result =  pData[spec32.offset] & spec32.mask;
   int mask = spec32.mask;
   while((mask&0x1) == 0){

--- a/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.cc
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.cc
@@ -38,10 +38,10 @@ void MatacqTBRawEvent::setRawData(const unsigned char* pData, size_t maxSize){
   daqHeader = (const uint32le_t*) pData16;
   const int daqHeaderLen = 16; //in bytes 
   pData16 += daqHeaderLen/sizeof(pData16[0]);
-  matacqHeader = (matacqHeader_t*) pData16;
+  matacqHeader = (const matacqHeader_t*) pData16;
   pData16 += sizeof(matacqHeader_t)/sizeof(pData16[0]);
   if(getMatacqDataFormatVersion()>=2){//trigger position present
-    tTrigPs = *((int32_t*) pData16);
+    tTrigPs = *((const int32_t*)pData16);
     pData16 += 2;
   } else{
     tTrigPs = std::numeric_limits<int>::max();    

--- a/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
@@ -311,7 +311,7 @@ private:
 
   /**Matacq header:
    */
-  matacqHeader_t* matacqHeader;
+  const matacqHeader_t* matacqHeader;
   
   /** MATACQ data format internal version
    */

--- a/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
@@ -240,7 +240,7 @@ private:
    * @param spec specification of the data field to read
    * @return content of data field specified by 'spec'
    */
-  int read32(uint32le_t* pData, field32spec_t spec) const;
+  int read32(const uint32le_t* pData, field32spec_t spec) const;
   
   /** Changes the raw data pointer and updates accordingly this object. 
    * @param buffer new pointer to the data buffer. Must be aligned at least
@@ -271,7 +271,7 @@ private:
 
   /** Pointer to the standard CMS DAQ header
    */
-  uint32le_t* daqHeader;
+  const uint32le_t* daqHeader;
 
   /** DCC error field content.
    */

--- a/EventFilter/EcalTBRawToDigi/src/TableDataFormatter.cc
+++ b/EventFilter/EcalTBRawToDigi/src/TableDataFormatter.cc
@@ -9,7 +9,7 @@ TableDataFormatter::TableDataFormatter () {
 void TableDataFormatter::interpretRawData( const FEDRawData & fedData, 
 					   EcalTBEventHeader& tbEventHeader)
 {
-  const unsigned long * buffer = ( reinterpret_cast<unsigned long*>(const_cast<unsigned char*> ( fedData.data())));
+  const unsigned long * buffer = reinterpret_cast<const unsigned long*>(fedData.data());
   int fedLenght                        = fedData.size(); // in Bytes
   
   // check ultimate fed size and strip off fed-header and -trailer

--- a/EventFilter/HcalRawToDigi/src/HcalDCCHeader.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalDCCHeader.cc
@@ -25,13 +25,13 @@ void HcalDCCHeader::getSpigotData(int nspigot, HcalHTRData& decodeTool) const {
   
 
 int HcalDCCHeader::getSpigotData(int nspigot, HcalHTRData& decodeTool, int validSize) const {
-  const unsigned short* base=((unsigned short*)this)+sizeof(HcalDCCHeader)/sizeof(unsigned short);
+  const uint16_t* base=((const uint16_t*)this)+sizeof(HcalDCCHeader)/sizeof(uint16_t);
   int offset=0,i,len=0;
   for (i=0; i<=nspigot; i++) {
     offset+=len;
     len=(spigotInfo[i]&0x3FF)*2;
   }
-  if ((offset+len+sizeof(HcalDCCHeader)/sizeof(unsigned short))<(validSize/sizeof(unsigned short))) {
+  if ((offset+len+sizeof(HcalDCCHeader)/sizeof(uint16_t))<(validSize/sizeof(uint16_t))) {
     decodeTool.adoptData(base+offset,len);
     return 0;
   } else { return -1; }

--- a/EventFilter/HcalRawToDigi/src/HcalDTCHeader.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalDTCHeader.cc
@@ -20,13 +20,13 @@ unsigned int HcalDTCHeader::getTotalLengthBytes() const {
 }
 
 int HcalDTCHeader::getSlotData(int nslot, HcalHTRData& decodeTool, int validSize) const {
-  const unsigned short* base=((unsigned short*)this)+sizeof(HcalDTCHeader)/sizeof(unsigned short);
+  const uint16_t* base=((const uint16_t*)this)+sizeof(HcalDTCHeader)/sizeof(uint16_t);
   int offset=0,i,len=0;
   for (i=1; i<=nslot; i++) {
     offset+=len;
     len=(slotInfo[i-1]&0xFFF);
   }
-  if ((offset+len+sizeof(HcalDTCHeader)/sizeof(unsigned short))<(validSize/sizeof(unsigned short))) {
+  if ((offset+len+sizeof(HcalDTCHeader)/sizeof(uint16_t))<(validSize/sizeof(uint16_t))) {
     decodeTool.adoptData(base+offset,len);
     return 0;
   } else { return -1; }

--- a/EventFilter/HcalRawToDigi/src/HcalHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalHTRData.cc
@@ -132,6 +132,7 @@ void HcalHTRData::determineSectionLengths(int& tpWords, int& daqWords, int& head
     tpWords=m_rawConst[5]>>8;
     if (m_rawLength>4) 
       daqWords=m_rawConst[m_rawLength-4]&0x7FF; // zero suppression supported
+    else daqWords = 0;//should there be a warning as well?
     headerWords=8;
     trailerWords=4; // minimum, may be more...
   }

--- a/PhysicsTools/SelectorUtils/bin/calculateIdMD5.cc
+++ b/PhysicsTools/SelectorUtils/bin/calculateIdMD5.cc
@@ -45,7 +45,7 @@ int main ( int argc, char ** argv )
   // now setup the md5 and cute accessor functions
   unsigned char id_md5_[MD5_DIGEST_LENGTH];
   memset(id_md5_,0,MD5_DIGEST_LENGTH*sizeof(unsigned char));
-  MD5((unsigned char*)tracked.c_str(), tracked.size(), id_md5_);
+  MD5((const unsigned char*)tracked.c_str(), tracked.size(), id_md5_);
   printf("%s : ",argv[2]);
   for( unsigned i=0; i<MD5_DIGEST_LENGTH; ++i ){
     printf("%02x", id_md5_[i]);   

--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -531,9 +531,9 @@ buildSuperCluster(CalibClusterPtr& seed,
       for( auto i_ps = clustops.first; i_ps != clustops.second; ++i_ps) {
 	edm::Ptr<reco::PFCluster> psclus(i_ps->second);
 #ifdef EDM_ML_DEBUG
-	auto found_pscluster = std::find(new_sc.preshowerClustersBegin(),
+	auto found_pscluster = std::find_if(new_sc.preshowerClustersBegin(),
 					 new_sc.preshowerClustersEnd(),
-					 i_ps->second);
+					 [&i_ps](const auto& i) { return i.key() == i_ps->first;});
 	if( found_pscluster == new_sc.preshowerClustersEnd() ) {
 #endif	  
 	  new_sc.addPreshowerCluster(psclus);	  	  

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.cc
@@ -124,7 +124,7 @@ reco::IsoDeposit EgammaRecHitExtractor::deposit(const edm::Event & iEvent,
   const CaloSubdetectorGeometry* barrelgeom = caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalBarrel);
   const CaloSubdetectorGeometry* endcapgeom = caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalEndcap);
 
-  static std::string metname = "EgammaIsolationAlgos|EgammaRecHitExtractor";
+  static const std::string metname = "EgammaIsolationAlgos|EgammaRecHitExtractor";
 
   //Get barrel ECAL RecHits
   edm::Handle<EcalRecHitCollection> barrelEcalRecHitsH;

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.cc
@@ -222,21 +222,21 @@ void EgammaRecHitExtractor::collect(reco::IsoDeposit &deposit,
       std::vector<int>::const_iterator vit;
       if (barrel) {
 	// new rechit flag checks
-	//vit = std::find(flagsexclEB_.begin(), flagsexclEB_.end(), ((EcalRecHit*)(&*j))->recoFlag());
+	//vit = std::find(flagsexclEB_.begin(), flagsexclEB_.end(), j->recoFlag());
 	//if (vit != flagsexclEB_.end())
 	//  continue;
-	if (!((EcalRecHit*)(&*j))->checkFlag(EcalRecHit::kGood)) {
-	  if (((EcalRecHit*)(&*j))->checkFlags(flagsexclEB_)) {
+	if (!j->checkFlag(EcalRecHit::kGood)) {
+	  if (j->checkFlags(flagsexclEB_)) {
 	    continue;
 	  }
 	}
       } else {
 	// new rechit flag checks
-	//vit = std::find(flagsexclEE_.begin(), flagsexclEE_.end(), ((EcalRecHit*)(&*j))->recoFlag());
+	//vit = std::find(flagsexclEE_.begin(), flagsexclEE_.end(), j->recoFlag());
 	//if (vit != flagsexclEE_.end())
 	//  continue;
-	if (!((EcalRecHit*)(&*j))->checkFlag(EcalRecHit::kGood)) {
-	  if (((EcalRecHit*)(&*j))->checkFlags(flagsexclEE_)) {
+	if (!j->checkFlag(EcalRecHit::kGood)) {
+	  if (j->checkFlags(flagsexclEE_)) {
 	    continue;
 	  }
 	}

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTrackExtractor.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTrackExtractor.cc
@@ -65,7 +65,7 @@ reco::IsoDeposit::Veto EgammaTrackExtractor::veto(const reco::IsoDeposit::Direct
 
 IsoDeposit EgammaTrackExtractor::deposit(const Event & event, const EventSetup & eventSetup, const Candidate & candTk) const
 {
-    static std::string metname = "EgammaIsolationAlgos|EgammaTrackExtractor";
+    static const std::string metname = "EgammaIsolationAlgos|EgammaTrackExtractor";
 
     reco::isodeposit::Direction candDir;
     double dzCut=0;

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.cc
@@ -146,21 +146,21 @@ GamIsoDetIdCollectionProducer::produce (edm::Event& iEvent,
                 std::vector<int>::const_iterator vit;
                 if (isBarrel) {
                   // new rechit flag checks
-                  //vit = std::find(flagsexclEB_.begin(), flagsexclEB_.end(), ((EcalRecHit*)(&*recIt))->recoFlag());
+                  //vit = std::find(flagsexclEB_.begin(), flagsexclEB_.end(), recIt->recoFlag());
                   //if (vit != flagsexclEB_.end())
                   //  continue;
-                  if (!((EcalRecHit*)(&*recIt))->checkFlag(EcalRecHit::kGood)) {
-                    if (((EcalRecHit*)(&*recIt))->checkFlags(flagsexclEB_)) {                
+                  if (!recIt->checkFlag(EcalRecHit::kGood)) {
+                    if (recIt->checkFlags(flagsexclEB_)) {                
                       return;
                     }
                   }
                 } else {
                   // new rechit flag checks
-                  //vit = std::find(flagsexclEE_.begin(), flagsexclEE_.end(), ((EcalRecHit*)(&*recIt))->recoFlag());
+                  //vit = std::find(flagsexclEE_.begin(), flagsexclEE_.end(), recIt->recoFlag());
                   //if (vit != flagsexclEE_.end())
                   //  continue;
-                  if (!((EcalRecHit*)(&*recIt))->checkFlag(EcalRecHit::kGood)) {
-                    if (((EcalRecHit*)(&*recIt))->checkFlags(flagsexclEE_)) {                
+                  if (!recIt->checkFlag(EcalRecHit::kGood)) {
+                    if (recIt->checkFlags(flagsexclEE_)) {                
                       return;
                     }
                   }

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaRecHitIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaRecHitIsolation.cc
@@ -144,8 +144,8 @@ double EgammaRecHitIsolation::getSum_(const reco::Candidate* emObject,bool retur
 	  
 	  
 	  
-	  //std::cout << "detid " << ((EcalRecHit*)(&*j))->detid() << std::endl;
-	  int severityFlag = ecalBarHits_ == nullptr ? -1 : sevLevel_->severityLevel(((const EcalRecHit*)(&*j))->detid(), *ecalBarHits_);
+	  //std::cout << "detid " << j->detid() << std::endl;
+	  int severityFlag = ecalBarHits_ == nullptr ? -1 : sevLevel_->severityLevel(j->detid(), *ecalBarHits_);
 	  std::vector<int>::const_iterator sit = std::find(severitiesexcl_.begin(), 
 							   severitiesexcl_.end(), 
 							   severityFlag);
@@ -156,11 +156,11 @@ double EgammaRecHitIsolation::getSum_(const reco::Candidate* emObject,bool retur
 	  // new rechit flag checks
 	  //std::vector<int>::const_iterator vit = std::find(flags_.begin(), 
 	  //						   flags_.end(),
-	  //						   ((const EcalRecHit*)(&*j))->recoFlag());
+	  //						   j->recoFlag());
 	  //if (vit != flags_.end()) 
 	  //  continue;
-	  if (!((EcalRecHit*)(&*j))->checkFlag(EcalRecHit::kGood)) {
-	    if (((EcalRecHit*)(&*j))->checkFlags(flags_)) {                
+	  if (!j->checkFlag(EcalRecHit::kGood)) {
+	    if (j->checkFlags(flags_)) {                
 	      continue;
 	    }
 	  }
@@ -258,11 +258,11 @@ double EgammaRecHitIsolation::getSum_(const reco::SuperCluster* sc, bool returnE
 	  // new rechit flag checks
 	  //std::vector<int>::const_iterator vit = std::find(flags_.begin(), 
 	  //						   flags_.end(),
-	  //						   ((EcalRecHit*)(&*j))->recoFlag());
+	  //						   j->recoFlag());
 	  //if (vit != flags_.end()) 
 	  //  continue;
-	  if (!((EcalRecHit*)(&*j))->checkFlag(EcalRecHit::kGood)) {
-	    if (((EcalRecHit*)(&*j))->checkFlags(flags_)) {                
+	  if (!j->checkFlag(EcalRecHit::kGood)) {
+	    if (j->checkFlags(flags_)) {                
 	      continue;
 	    }
 	  }

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaTrackSelector.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaTrackSelector.cc
@@ -7,7 +7,7 @@ using namespace reco;
 
 EgammaTrackSelector::result_type EgammaTrackSelector::operator()(const EgammaTrackSelector::input_type & tracks) const
 {
-  static std::string metname = "EgammaIsolationAlgos|EgammaTrackSelector";
+  static const std::string metname = "EgammaIsolationAlgos|EgammaTrackSelector";
   result_type result;
   for (input_type::const_iterator it = tracks.begin(); it != tracks.end(); it++) {
 

--- a/RecoEgamma/EgammaPhotonAlgos/interface/ConversionSeedFinder.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/ConversionSeedFinder.h
@@ -60,12 +60,12 @@ class ConversionSeedFinder {
   virtual ~ConversionSeedFinder(){}
 
   
-  virtual void makeSeeds(const edm::Handle<edm::View<reco::CaloCluster> > & allBc ) const  =0 ;
+  virtual void makeSeeds(const edm::Handle<edm::View<reco::CaloCluster> > & allBc ) =0 ;
  
 
 
   TrajectorySeedCollection & seeds() {  return theSeeds_;}
-  virtual void setCandidate( float e, GlobalPoint pos ) const {  theSCenergy_=e; theSCPosition_= pos; }			       
+  virtual void setCandidate( float e, GlobalPoint pos ) {  theSCenergy_=e; theSCPosition_= pos; }			       
   std::vector<const DetLayer*> const & layerList() const { return theLayerList_;}
  
   
@@ -85,8 +85,8 @@ class ConversionSeedFinder {
 
 
   //edm::ParameterSet conf_; found this to be completely unused
-  void findLayers() const ;
-  void findLayers(const FreeTrajectoryState & fts) const  ; 
+  void findLayers();
+  void findLayers(const FreeTrajectoryState & fts); 
 
   FreeTrajectoryState trackStateFromClusters ( int aCharge,
 					       const GlobalPoint & gpOrigine, 
@@ -97,8 +97,8 @@ class ConversionSeedFinder {
   void printLayer(int i) const ;
 
   
-  mutable TrajectorySeedCollection theSeeds_;
-  mutable GlobalPoint theSCPosition_;
+  TrajectorySeedCollection theSeeds_;
+  GlobalPoint theSCPosition_;
     
 
   std::string theMeasurementTrackerName_;
@@ -116,14 +116,14 @@ class ConversionSeedFinder {
 
   KFUpdator                  theUpdator_;
   PropagationDirection       dir_; 
-  mutable reco::CaloCluster*  theSC_;
-  mutable float theSCenergy_;  
+  reco::CaloCluster*  theSC_;
+  float theSCenergy_;  
 
   
-  mutable std::vector<const DetLayer *> theLayerList_ ;    
+  std::vector<const DetLayer *> theLayerList_ ;    
     
-  mutable GlobalPoint theBCPosition_;
-  mutable float       theBCEnergy_; 
+  GlobalPoint theBCPosition_;
+  float       theBCEnergy_; 
 
   const Propagator*  thePropagatorAlongMomentum_;
   const Propagator*  thePropagatorOppositeToMomentum_;

--- a/RecoEgamma/EgammaPhotonAlgos/interface/ConversionTrackEcalImpactPoint.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/ConversionTrackEcalImpactPoint.h
@@ -61,7 +61,7 @@ private:
 
   TrajectoryStateOnSurface  stateAtECAL_;
 
-  mutable PropagatorWithMaterial*    forwardPropagator_ ;
+  PropagatorWithMaterial*    forwardPropagator_ ;
   PropagationDirection       dir_;
   std::vector<reco::CaloClusterPtr> matchingBC_;
 

--- a/RecoEgamma/EgammaPhotonAlgos/interface/InOutConversionSeedFinder.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/InOutConversionSeedFinder.h
@@ -53,7 +53,7 @@ class InOutConversionSeedFinder : public ConversionSeedFinder {
   ~InOutConversionSeedFinder() override;
   
   
-  void  makeSeeds(  const edm::Handle<edm::View<reco::CaloCluster> > & allBc) const override;
+  void  makeSeeds(  const edm::Handle<edm::View<reco::CaloCluster> > & allBc) override;
   
   
   
@@ -63,34 +63,34 @@ class InOutConversionSeedFinder : public ConversionSeedFinder {
   private :
 
   edm::ParameterSet conf_;
-  virtual void fillClusterSeeds(  ) const ;
-  void startSeed(const FreeTrajectoryState * fts, const TrajectoryStateOnSurface & stateAtPreviousLayer, int charge, int layer) const ;
+  virtual void fillClusterSeeds();
+  void startSeed(const FreeTrajectoryState * fts, const TrajectoryStateOnSurface & stateAtPreviousLayer, int charge, int layer);
   virtual void findSeeds(const TrajectoryStateOnSurface & startingState,
-			 float signedpt, unsigned int startingLayer) const ;
+			 float signedpt, unsigned int startingLayer);
   
   std::vector<const reco::CaloCluster*> getSecondCaloClusters(const GlobalPoint & conversionPosition, float charge) const;
-  void completeSeed(const TrajectoryMeasurement & m1,FreeTrajectoryState & fts, const Propagator* propagator, int ilayer) const;
-  void createSeed(const TrajectoryMeasurement & m1,  const TrajectoryMeasurement & m2) const ;
+  void completeSeed(const TrajectoryMeasurement & m1, const FreeTrajectoryState & fts, const Propagator* propagator, int ilayer);
+  void createSeed(const TrajectoryMeasurement & m1,  const TrajectoryMeasurement & m2);
 
 
  private:
   float  the2ndHitdphi_;
   float  the2ndHitdzConst_;    
   float  the2ndHitdznSigma_;
-  mutable int track2Charge_;
-  mutable GlobalVector track2InitialMomentum_; 
-  mutable int nSeedsPerInputTrack_;
+  int track2Charge_;
+  GlobalVector track2InitialMomentum_; 
+  int nSeedsPerInputTrack_;
   int maxNumberOfInOutSeedsPerInputTrack_;
      
 
-  mutable TrajectoryMeasurement* myPointer;
+  TrajectoryMeasurement* myPointer;
 
-  mutable std::vector<Trajectory> inputTracks_;
-  mutable std::vector<Trajectory> theOutInTracks_;
-  mutable std::vector<TrajectoryMeasurement> theFirstMeasurements_;
+  std::vector<Trajectory> inputTracks_;
+  std::vector<Trajectory> theOutInTracks_;
+  std::vector<TrajectoryMeasurement> theFirstMeasurements_;
 
-  mutable reco::CaloCluster theSecondBC_;
-  mutable edm::Handle<edm::View<reco::CaloCluster> >  bcCollection_;
+  reco::CaloCluster theSecondBC_;
+  edm::Handle<edm::View<reco::CaloCluster> >  bcCollection_;
 
   
 };

--- a/RecoEgamma/EgammaPhotonAlgos/interface/OutInConversionSeedFinder.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/OutInConversionSeedFinder.h
@@ -46,22 +46,22 @@ class OutInConversionSeedFinder : public ConversionSeedFinder {
   
   
   
-  void  makeSeeds( const edm::Handle<edm::View<reco::CaloCluster> > & allBc) const override  ;
-  virtual void  makeSeeds( const reco::CaloClusterPtr&  aBC ) const  ;  
+  void  makeSeeds( const edm::Handle<edm::View<reco::CaloCluster> > & allBc) override  ;
+  virtual void  makeSeeds( const reco::CaloClusterPtr&  aBC ) ;  
   
  private:
   
   edm::ParameterSet conf_;
   std::pair<FreeTrajectoryState,bool> makeTrackState(int charge) const ;
   
-  void fillClusterSeeds(const reco::CaloClusterPtr& bc) const ;
+  void fillClusterSeeds(const reco::CaloClusterPtr& bc);
   
-  void startSeed(const FreeTrajectoryState &) const;
+  void startSeed(const FreeTrajectoryState &);
   void completeSeed(const TrajectoryMeasurement & m1,
-			    FreeTrajectoryState & fts, 
+			    const FreeTrajectoryState & fts, 
 			    const Propagator *, 
-			    int layer) const  ;
-  void createSeed(const TrajectoryMeasurement & m1,const TrajectoryMeasurement & m2) const;
+			    int layer);
+  void createSeed(const TrajectoryMeasurement & m1,const TrajectoryMeasurement & m2);
   FreeTrajectoryState createSeedFTS(const TrajectoryMeasurement & m1, const TrajectoryMeasurement & m2) const;  
   GlobalPoint fixPointRadius(const TrajectoryMeasurement &) const;
 
@@ -75,8 +75,8 @@ class OutInConversionSeedFinder : public ConversionSeedFinder {
   float  the2ndHitdphi_;
   float   the2ndHitdzConst_;    
   float  the2ndHitdznSigma_; 
-  mutable std::vector<TrajectoryMeasurement> theFirstMeasurements_;
-  mutable int nSeedsPerBC_;
+  std::vector<TrajectoryMeasurement> theFirstMeasurements_;
+  int nSeedsPerBC_;
   int maxNumberOfOutInSeedsPerBC_;
   float bcEtcut_;
   float bcEcut_;

--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionSeedFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionSeedFinder.cc
@@ -65,7 +65,7 @@ void ConversionSeedFinder::setEventSetup(const edm::EventSetup& es  )  {
 }
 
 
-void ConversionSeedFinder::findLayers() const {
+void ConversionSeedFinder::findLayers() {
   
 
   int charge;
@@ -124,7 +124,7 @@ FreeTrajectoryState ConversionSeedFinder::trackStateFromClusters( int charge, co
 
 }
 
-void ConversionSeedFinder::findLayers(const FreeTrajectoryState & traj) const {
+void ConversionSeedFinder::findLayers(const FreeTrajectoryState & traj) {
 
 
 

--- a/RecoEgamma/EgammaPhotonAlgos/src/InOutConversionSeedFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/InOutConversionSeedFinder.cc
@@ -42,7 +42,7 @@ InOutConversionSeedFinder::~InOutConversionSeedFinder() {
 
 
 
-void InOutConversionSeedFinder::makeSeeds( const edm::Handle<edm::View<reco::CaloCluster> > &  allBC )  const  {
+void InOutConversionSeedFinder::makeSeeds( const edm::Handle<edm::View<reco::CaloCluster> > &  allBC ) {
   
 
   //std::cout << "  InOutConversionSeedFinder::makeSeeds() " << "\n";
@@ -65,7 +65,7 @@ void InOutConversionSeedFinder::makeSeeds( const edm::Handle<edm::View<reco::Cal
 }
 
 
-void InOutConversionSeedFinder::fillClusterSeeds() const {
+void InOutConversionSeedFinder::fillClusterSeeds() {
   
   std::vector<Trajectory>::const_iterator outInTrackItr;
   
@@ -311,7 +311,7 @@ void InOutConversionSeedFinder::fillClusterSeeds() const {
 
 
 
-void InOutConversionSeedFinder::startSeed( const FreeTrajectoryState * fts, const TrajectoryStateOnSurface & stateAtPreviousLayer, int charge, int ilayer  )  const {
+void InOutConversionSeedFinder::startSeed( const FreeTrajectoryState * fts, const TrajectoryStateOnSurface & stateAtPreviousLayer, int charge, int ilayer  ) {
   
   //std::cout << "InOutConversionSeedFinder::startSeed ilayer " << ilayer <<  "\n";
   // Get a list of basic clusters that are consistent with a track 
@@ -410,7 +410,7 @@ std::vector<const reco::CaloCluster*> InOutConversionSeedFinder::getSecondCaloCl
 
 void InOutConversionSeedFinder::findSeeds(const TrajectoryStateOnSurface & startingState,
 					  float transverseCurvature, 
-					  unsigned int startingLayer) const {
+					  unsigned int startingLayer) {
   
   
   std::vector<const DetLayer*> allLayers=layerList();
@@ -592,7 +592,7 @@ void InOutConversionSeedFinder::findSeeds(const TrajectoryStateOnSurface & start
 
 
 void InOutConversionSeedFinder::completeSeed(const TrajectoryMeasurement & m1,
-					     FreeTrajectoryState & fts, const Propagator* propagator, int ilayer) const {
+					     const FreeTrajectoryState & fts, const Propagator* propagator, int ilayer) {
   
  //std::cout<<  "InOutConversionSeedFinder::completeSeed ilayer " << ilayer <<  "\n";
   // A seed is made from 2 Trajectory Measuremennts.  The 1st is the input
@@ -665,7 +665,7 @@ void InOutConversionSeedFinder::completeSeed(const TrajectoryMeasurement & m1,
 
 
 
-void InOutConversionSeedFinder::createSeed(const TrajectoryMeasurement & m1,  const TrajectoryMeasurement & m2) const {
+void InOutConversionSeedFinder::createSeed(const TrajectoryMeasurement & m1,  const TrajectoryMeasurement & m2) {
   
  //std::cout << "InOutConversionSeedFinder::createSeed " << "\n";
 

--- a/RecoEgamma/EgammaPhotonAlgos/src/OutInConversionSeedFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/OutInConversionSeedFinder.cc
@@ -62,7 +62,7 @@ OutInConversionSeedFinder::~OutInConversionSeedFinder() {
 
 
 
-void OutInConversionSeedFinder::makeSeeds( const edm::Handle<edm::View<reco::CaloCluster> > &  allBC )  const  {
+void OutInConversionSeedFinder::makeSeeds( const edm::Handle<edm::View<reco::CaloCluster> > &  allBC ) {
 
   theSeeds_.clear();
   
@@ -163,7 +163,7 @@ void OutInConversionSeedFinder::makeSeeds( const edm::Handle<edm::View<reco::Cal
 
 
 
-void OutInConversionSeedFinder::makeSeeds( const reco::CaloClusterPtr&  aBC )  const  {
+void OutInConversionSeedFinder::makeSeeds( const reco::CaloClusterPtr&  aBC ) {
 
   theSeeds_.clear();
 
@@ -193,7 +193,7 @@ void OutInConversionSeedFinder::makeSeeds( const reco::CaloClusterPtr&  aBC )  c
  
 
 
-void OutInConversionSeedFinder::fillClusterSeeds(const reco::CaloClusterPtr& bc) const {
+void OutInConversionSeedFinder::fillClusterSeeds(const reco::CaloClusterPtr& bc) {
 
   
   theFirstMeasurements_.clear();
@@ -287,7 +287,7 @@ std::pair<FreeTrajectoryState,bool>  OutInConversionSeedFinder::makeTrackState(i
 }
 
 
-void OutInConversionSeedFinder::startSeed(const FreeTrajectoryState & fts) const {
+void OutInConversionSeedFinder::startSeed(const FreeTrajectoryState & fts) {
 
 
   //  std::cout << "OutInConversionSeedFinder::startSeed layer list " << this->layerList().size() <<  "\n";
@@ -400,8 +400,8 @@ MeasurementEstimator * OutInConversionSeedFinder::makeEstimator(const DetLayer *
 
 
 void OutInConversionSeedFinder::completeSeed(const TrajectoryMeasurement & m1, 
-					     FreeTrajectoryState & fts, 
-					     const Propagator* propagator, int ilayer) const {
+					     const FreeTrajectoryState & fts, 
+					     const Propagator* propagator, int ilayer) {
 
   //std::cout <<  "OutInConversionSeedFinder::completeSeed ilayer " << ilayer << "\n";
 
@@ -455,7 +455,7 @@ void OutInConversionSeedFinder::completeSeed(const TrajectoryMeasurement & m1,
 
 
 void OutInConversionSeedFinder::createSeed(const TrajectoryMeasurement & m1, 
-					   const TrajectoryMeasurement & m2) const {
+					   const TrajectoryMeasurement & m2) {
 
   //std::cout  << "OutInConversionSeedFinder::createSeed  from hit1 " << m1.recHit()->globalPosition() << " r1 " << m1.recHit()->globalPosition().perp() << " and hit2 " << m2.recHit()->globalPosition() << " r2 " << m2.recHit()->globalPosition().perp() << "\n";
   

--- a/RecoEgamma/EgammaTools/plugins/HGCalElectronFilter.cc
+++ b/RecoEgamma/EgammaTools/plugins/HGCalElectronFilter.cc
@@ -86,7 +86,6 @@ HGCalElectronFilter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
     for(const auto& electron1 : *electronsH) {
         bool isBest = true;
         if (!cleanBarrel_ && electron1.isEB()) { // keep all barrel electrons
-            isBest = true;
             gsfElectrons_p->push_back(electron1);
             continue;
         } else {

--- a/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
+++ b/RecoEgamma/EgammaTools/src/EcalRegressionData.cc
@@ -10,6 +10,7 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 float EcalRegressionData::seedLeftRightAsym()const
 {
@@ -76,8 +77,8 @@ void EcalRegressionData::fill(const reco::SuperCluster& superClus,
   eLeft_ = EcalClusterTools::eLeft(*superClus.seed(),recHits,topology);
   eRight_ = EcalClusterTools::eRight(*superClus.seed(),recHits,topology);
   std::vector<float> localCovs = EcalClusterTools::localCovariances(*superClus.seed(),recHits,topology);
-  sigmaIEtaIEta_ = std::isnan(localCovs[0]) ? 0. : std::sqrt(localCovs[0]);
-  sigmaIPhiIPhi_ = std::isnan(localCovs[2]) ? 0. : std::sqrt(localCovs[2]);
+  sigmaIEtaIEta_ = edm::isNotFinite(localCovs[0]) ? 0. : std::sqrt(localCovs[0]);
+  sigmaIPhiIPhi_ = edm::isNotFinite(localCovs[2]) ? 0. : std::sqrt(localCovs[2]);
   
   if(sigmaIEtaIEta_*sigmaIPhiIPhi_>0) sigmaIEtaIPhi_ = localCovs[1]/(sigmaIEtaIEta_*sigmaIPhiIPhi_);
   else if(localCovs[1]>0) sigmaIEtaIPhi_ = 1.;

--- a/RecoLocalMuon/CSCValidation/src/CSCValidation.cc
+++ b/RecoLocalMuon/CSCValidation/src/CSCValidation.cc
@@ -2195,7 +2195,6 @@ int CSCValidation::getWidth(const CSCStripDigiCollection& stripdigis, CSCDetId i
 void CSCValidation::doGasGain(const CSCWireDigiCollection& wirecltn, 
                               const CSCStripDigiCollection&   strpcltn,
                               const CSCRecHit2DCollection& rechitcltn) {
-     float y;
      int channel=0,mult,wire,layer,idlayer,idchamber,ring;
      int wire_strip_rechit_present;
      std::string name,title,endcapstr;
@@ -2395,7 +2394,6 @@ void CSCValidation::doGasGain(const CSCWireDigiCollection& wirecltn,
                  int hvsgmtnmb=m_wire_hvsegm[chambertype][wire];
                  int nmbofhvsegm=nmbhvsegm[chambertype-1];
                  int location= (layer-1)*nmbofhvsegm+hvsgmtnmb;
-                 float x=location;
                 
                  ss<<"gas_gain_rechit_adc_3_3_sum_location_ME_"<<idchamber;
                  name=ss.str(); ss.str("");
@@ -2406,8 +2404,8 @@ void CSCValidation::doGasGain(const CSCWireDigiCollection& wirecltn,
                  ss<<"Gas Gain Rechit ADC3X3 Sum ME"<<endcapstr<<
                    id.station()<<"/"<<ring<<"/"<<id.chamber();
                  title=ss.str(); ss.str("");
-                 x=location;
-                 y=adc_3_3_sum;
+                 float x=location;
+                 float y=adc_3_3_sum;
                  histos->fill2DHist(x,y,name,title,30,1.0,31.0,50,0.0,2000.0,"GasGain");
 
                  /*

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegAlgoRR.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegAlgoRR.cc
@@ -305,7 +305,7 @@ std::vector<GEMCSCSegment> GEMCSCSegAlgoRR::buildSegments(const CSCSegment* cscs
   // Extract the GEMRecHits from the TrackingRecHit vector
   for(std::vector<const TrackingRecHit*>::const_iterator trhIt = rechits.begin(); trhIt!=rechits.end(); ++trhIt) 
     {
-      if (DetId((*trhIt)->rawId()).subdetId() == MuonSubdetId::GEM) { gemrechits.push_back( ((GEMRecHit*)*trhIt) ); }
+      if (DetId((*trhIt)->rawId()).subdetId() == MuonSubdetId::GEM) { gemrechits.push_back( ((const GEMRecHit*)*trhIt) ); }
     }
 
   // The actual fit on all hits of the vector of the selected Tracking RecHits:

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.cc
@@ -51,12 +51,13 @@ ME0SegmentAlgorithm::~ME0SegmentAlgorithm() {
 std::vector<ME0Segment> ME0SegmentAlgorithm::run(const ME0Chamber * chamber, const HitAndPositionContainer& rechits) {
 
   #ifdef EDM_ML_DEBUG // have lines below only compiled when in debug mode
-  ME0DetId chId((ensemble.first)->id());
+  ME0DetId chId(chamber->id());
   edm::LogVerbatim("ME0SegAlgoMM") << "[ME0SegmentAlgorithm::run] build segments in chamber " << chId << " which contains "<<rechits.size()<<" rechits";
   for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
-    auto me0id = (*rh)->rh->me0Id();
-    auto rhLP = (*rh)->lp;
-    edm::LogVerbatim("ME0SegmentAlgorithm") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rhLP.x()<<" Loc y = "<<std::showpos<<std::setw(9)<<rhLP.y()<<" Time = "<<std::showpos<<(*rh)->rh->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]";
+    auto me0id = rh->rh->me0Id();
+    auto rhLP = rh->lp;
+    edm::LogVerbatim("ME0SegmentAlgorithm") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rhLP.x()<<" Loc y = "<<std::showpos<<std::setw(9)<<rhLP.y()
+                                            <<" Time = "<<std::showpos<<rh->rh->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]";
   }
   #endif
 

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilder.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilder.cc
@@ -50,7 +50,7 @@ void ME0SegmentBuilder::build(const ME0RecHitCollection* recHits, ME0SegmentColl
           hitAndPositions.emplace_back(&(*it2),nLoc,glb,hitAndPositions.size());
 	  }
 
-      LogDebug("ME0Segment|ME0") << "found " << hitAndPositions.size() << " rechits in chamber " << *chIt;
+      LogDebug("ME0Segment|ME0") << "found " << hitAndPositions.size() << " rechits in chamber " << chId;
       //sort by layer
         auto getLayer =[&](int iL) ->const ME0Layer* { //function is broken in the geo currently
       	  for (auto layer : chamber->layers()){
@@ -69,7 +69,7 @@ void ME0SegmentBuilder::build(const ME0RecHitCollection* recHits, ME0SegmentColl
       // given the chamber select the appropriate algo... and run it
       std::vector<ME0Segment> segv = algo->run(chamber, hitAndPositions);
 
-      LogDebug("ME0Segment|ME0") << "found " << segv.size() << " segments in chamber " << *chIt;
+      LogDebug("ME0Segment|ME0") << "found " << segv.size() << " segments in chamber " << chId;
 
       // Add the segments to master collection
       if(!segv.empty())

--- a/RecoMuon/MeasurementDet/src/MuonDetLayerMeasurements.cc
+++ b/RecoMuon/MeasurementDet/src/MuonDetLayerMeasurements.cc
@@ -56,7 +56,7 @@ MuonDetLayerMeasurements::MuonDetLayerMeasurements(edm::InputTag dtlabel,
   gemToken_ = iC.consumes<GEMRecHitCollection>(gemlabel);
   me0Token_ = iC.consumes<ME0SegmentCollection>(me0label);
 
-  static int procInstance(0);
+  static std::atomic<int> procInstance{0};
   std::ostringstream sDT;
   sDT<<"MuonDetLayerMeasurements::checkDTRecHits::" << procInstance;
   //  theDTCheckName = sDT.str();

--- a/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.cc
+++ b/RecoMuon/MuonIsolationProducers/plugins/MuIsoDepositProducer.cc
@@ -38,7 +38,8 @@ MuIsoDepositProducer::MuIsoDepositProducer(const ParameterSet& par) :
   theDepositNames(std::vector<std::string>(1,std::string())),
   theExtractor(nullptr)
 {
-  LogDebug("RecoMuon|MuonIsolation")<<" MuIsoDepositProducer CTOR";
+  static const std::string metname = "RecoMuon|MuonIsolationProducers|MuIsoDepositProducer";
+  LogDebug(metname)<<" MuIsoDepositProducer CTOR";
 
   edm::ParameterSet ioPSet = par.getParameter<edm::ParameterSet>("IOPSet");
 
@@ -92,7 +93,7 @@ MuIsoDepositProducer::~MuIsoDepositProducer(){
 
 //! build deposits
 void MuIsoDepositProducer::produce(Event& event, const EventSetup& eventSetup){
-  std::string metname = "RecoMuon|MuonIsolationProducers|MuIsoDepositProducer";
+  static const std::string metname = "RecoMuon|MuonIsolationProducers|MuIsoDepositProducer";
 
   LogDebug(metname)<<" Muon Deposit producing..."
 		   <<" BEGINING OF EVENT " <<"================================";
@@ -102,7 +103,7 @@ void MuIsoDepositProducer::produce(Event& event, const EventSetup& eventSetup){
 
 
   // Take the muon container
-  LogTrace(metname)<<" Taking the muons: "<<theMuonCollectionTag;
+  LogTrace(metname)<<" Taking the muons: "<<theMuonCollectionTag.index();//a more friendly print would use "inputMuonCollection"
   Handle<View<Track> > tracks;
   //! read them as RecoCandidates: need to have track() standAloneMuon() etc in the interface
   Handle<View<RecoCandidate> > muons;//! get rid of this at some point and use the cands

--- a/RecoMuon/MuonSeedGenerator/src/MuonDTSeedFromRecHits.cc
+++ b/RecoMuon/MuonSeedGenerator/src/MuonDTSeedFromRecHits.cc
@@ -327,10 +327,10 @@ void MuonDTSeedFromRecHits::computeMean(const double* pt, const double * weights
   double wtTmp[8];
   assert(sz<=8);
 
-  for (int i=0; i<sz; ++i) {
+  for (int i=0; i<8; ++i) {
     ptTmp[i] = 0.;
     wtTmp[i] = 0;
-    if (pt[i]!=0) {
+    if (i < sz && pt[i]!=0) {
       ptTmp[n]=pt[i];
       wtTmp[n]=weights[i];
       ++n;

--- a/RecoMuon/MuonSeedGenerator/src/MuonSeedCreator.cc
+++ b/RecoMuon/MuonSeedGenerator/src/MuonSeedCreator.cc
@@ -455,22 +455,18 @@ void MuonSeedCreator::estimatePtCSC(const SegmentContainer& seg, const std::vect
       if ( layer0 == 2 && temp_dphi > 0.0001 ) {
 
         // ME4 is outer-most
-        bool ME4av =false;
         if ( layer1 == 4 )  {
           temp_dphi = scaledPhi(temp_dphi, CSC24_1[3]);
           pt  = getPt( CSC24, eta , temp_dphi )[0];
           spt = getPt( CSC24, eta , temp_dphi )[1];
-          ME4av = true;
         }
         // ME3 is outer-most
         else {
           // if ME2-4 is availabe , discard ME2-3 
-          if ( !ME4av ) {
-            if ( eta <= 1.7 )  {   temp_dphi = scaledPhi(temp_dphi, CSC23_1[3]); }
-            if ( eta >  1.7 )  {   temp_dphi = scaledPhi(temp_dphi, CSC23_2[3]); }
-            pt  = getPt( CSC23, eta , temp_dphi )[0];
-            spt = getPt( CSC23, eta , temp_dphi )[1];
-          }
+          if ( eta <= 1.7 )  {   temp_dphi = scaledPhi(temp_dphi, CSC23_1[3]); }
+          if ( eta >  1.7 )  {   temp_dphi = scaledPhi(temp_dphi, CSC23_2[3]); }
+          pt  = getPt( CSC23, eta , temp_dphi )[0];
+          spt = getPt( CSC23, eta , temp_dphi )[1];
         }
         ptEstimate.push_back( pt*sign );   
         sptEstimate.push_back( spt );
@@ -555,7 +551,6 @@ void MuonSeedCreator::estimatePtDT(const SegmentContainer& seg, const std::vecto
       }
 
       // MB1 is inner-most
-      bool MB23av = false;
       if (layer0 == -1 && temp_dphi > 0.0001 ) {
         // MB2 is outer-most
         if (layer1 == -2) {
@@ -564,7 +559,6 @@ void MuonSeedCreator::estimatePtDT(const SegmentContainer& seg, const std::vecto
           if ( eta >  0.7 )  {   temp_dphi = scaledPhi(temp_dphi, DT12_2[3]); }
           pt  = getPt( DT12, eta , temp_dphi )[0];
           spt = getPt( DT12, eta , temp_dphi )[1];
-          MB23av = true;
         }
         // MB3 is outer-most
         else if (layer1 == -3) {
@@ -573,16 +567,13 @@ void MuonSeedCreator::estimatePtDT(const SegmentContainer& seg, const std::vecto
           if ( eta >  0.6 )  {   temp_dphi = scaledPhi(temp_dphi, DT13_2[3]); }
           pt  = getPt( DT13, eta , temp_dphi )[0];
           spt = getPt( DT13, eta , temp_dphi )[1];
-          MB23av = true;
         }
         // MB4 is outer-most
         else {
-          if ( !MB23av ) {
-             if ( eta <= 0.52 )  {   temp_dphi = scaledPhi(temp_dphi, DT14_1[3]); }
-	     if ( eta >  0.52 )  {   temp_dphi = scaledPhi(temp_dphi, DT14_2[3]); }
-	     pt  = getPt( DT14, eta , temp_dphi )[0];
-	     spt = getPt( DT14, eta , temp_dphi )[1];
-          }
+          if ( eta <= 0.52 )  {   temp_dphi = scaledPhi(temp_dphi, DT14_1[3]); }
+          if ( eta >  0.52 )  {   temp_dphi = scaledPhi(temp_dphi, DT14_2[3]); }
+          pt  = getPt( DT14, eta , temp_dphi )[0];
+          spt = getPt( DT14, eta , temp_dphi )[1];
         }
         ptEstimate.push_back( pt*sign );
         sptEstimate.push_back( spt );

--- a/RecoMuon/MuonSeedGenerator/src/RPCSeedPattern.cc
+++ b/RecoMuon/MuonSeedGenerator/src/RPCSeedPattern.cc
@@ -993,7 +993,6 @@ double RPCSeedPattern::extropolateStep(const GlobalPoint& startPosition, const G
     cout << "Start side : " << startSide;
 
     GlobalPoint currentPosition = startPosition;
-    double currentSide = RPCSurface.localZ(currentPosition);
     GlobalVector currentMomentum = startMomentum;
     GlobalVector ZDirection(0, 0, 1);
 
@@ -1046,7 +1045,7 @@ double RPCSeedPattern::extropolateStep(const GlobalPoint& startPosition, const G
         tracklength += stepLength * currentMomentum.perp() / currentMomentum.mag();
 
         // Get the next step distance
-        currentSide = RPCSurface.localZ(currentPosition);
+        double currentSide = RPCSurface.localZ(currentPosition);
         cout << "Stepping current side : " << currentSide << endl;
         cout << "Stepping current position is: " << currentPosition << endl;
         cout << "Stepping current Momentum is: " << currentMomentum.mag() << ", in vector: " << currentMomentum << endl;

--- a/RecoMuon/MuonSeedGenerator/src/SETFilter.cc
+++ b/RecoMuon/MuonSeedGenerator/src/SETFilter.cc
@@ -613,16 +613,20 @@ find3MoreStartingPoints(CLHEP::Hep3Vector &key_foot,
     std::pair <double,double> result_phi =
       findParabolaMinimum(phi_init, chi2_init);
     // should we use that?
+    /* not used, keep it in case some interest comes back
     double newPhi = result_phi.first;
     if(fabs(newPhi - phi)<0.02){// too close?
       newPhi = phi + 0.02;
     }
+    */
     CLHEP::Hep3Vector foot2(invP, theta, result_phi.first);
     CLHEP::Hep3Vector foot3(invP, result_theta.first , phi);
+    /* not used, keep it in case some interest comes back
     double newInvP = result_pInv.first;
     if(fabs(newInvP - invP)<0.001){//too close
       newInvP = invP + 0.001;
     }
+    */
     CLHEP::Hep3Vector foot4(result_pInv.first, theta, phi);
     morePoints.push_back(foot2);
     morePoints.push_back(foot3);

--- a/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
@@ -72,7 +72,7 @@ class InitialClusteringStepBase {
 			     const std::vector<bool>& seeds, // seed flags
 			     reco::PFClusterCollection&) = 0; //output
 
-  std::ostream& operator<<(std::ostream& o) {
+  std::ostream& operator<<(std::ostream& o) const {
     o << "InitialClusteringStep with algo \"" << _algoName 
       << "\" located " << _nSeeds << " seeds and built " 
       << _nClustersFound << " clusters from those seeds. ";
@@ -95,6 +95,8 @@ class InitialClusteringStepBase {
   const std::string _algoName;
   
 };
+
+std::ostream& operator<<(std::ostream& o, const InitialClusteringStepBase& a);
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 typedef edmplugin::PluginFactory< InitialClusteringStepBase* (const edm::ParameterSet&, edm::ConsumesCollector&) > InitialClusteringStepFactory;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
@@ -64,6 +64,8 @@ class PFClusterBuilderBase {
   
 };
 
+std::ostream& operator<<(std::ostream& o, const PFClusterBuilderBase& a);
+
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 typedef edmplugin::PluginFactory< PFClusterBuilderBase* (const edm::ParameterSet&) > PFClusterBuilderFactory;
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
@@ -111,17 +111,11 @@ class PFHFRecHitCreator final :  public  PFRecHitCreatorBase {
 
       /////////////////////HF DUAL READOUT/////////////////////////
       
-      double lONG=0.;
-      double sHORT=0.;
-
       for (auto& hit : tmpOut) {
-	lONG=0.0;
-	sHORT=0.0;
-
 	reco::PFRecHit newHit = hit;
 	const HcalDetId& detid = (HcalDetId)hit.detId();
 	if (detid.depth()==1) {
-	  lONG=hit.energy();
+	  double lONG=hit.energy();
 	  //find the short hit
 	  HcalDetId shortID (HcalForward, detid.ieta(), detid.iphi(), 2);
 	  auto found_hit = std::lower_bound(tmpOut.begin(),tmpOut.end(),
@@ -131,7 +125,7 @@ class PFHFRecHitCreator final :  public  PFRecHitCreatorBase {
 					     return  a.detId() < b.rawId();
 					    });
 	if( found_hit != tmpOut.end() && found_hit->detId() == shortID.rawId() ) {
-	  sHORT = found_hit->energy();
+	  double sHORT = found_hit->energy();
 	    //Ask for fraction
 	    double energy = lONG-sHORT;
 
@@ -158,7 +152,7 @@ class PFHFRecHitCreator final :  public  PFRecHitCreatorBase {
 
 	}
 	else {
-	  sHORT=hit.energy();
+	  double sHORT=hit.energy();
 	  HcalDetId longID (HcalForward, detid.ieta(), detid.iphi(), 1);
 	  auto found_hit = std::lower_bound(tmpOut.begin(),tmpOut.end(),
 					    longID,
@@ -168,7 +162,7 @@ class PFHFRecHitCreator final :  public  PFRecHitCreatorBase {
 					    });
 	  double energy = 2*sHORT;
 	  if( found_hit != tmpOut.end() && found_hit->detId() == longID.rawId() ) {
-	    lONG = found_hit->energy();
+	    double lONG = found_hit->energy();
 	    //Ask for fraction
 
 	    //If in this case lONG-sHORT<0 add the energy to the sHORT

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
@@ -158,7 +158,7 @@ growPFClusters(const reco::PFCluster& topo,
   }
   // loop over topo cluster and grow current PFCluster hypothesis 
   std::vector<double> dist2, frac;
-  double fractot = 0, fraction = 0;
+  double fractot = 0;
   for( const reco::PFRecHitFraction& rhf : topo.recHitFractions() ) {
     const reco::PFRecHitRef& refhit = rhf.recHitRef();
     int cell_layer = (int)refhit->layer();
@@ -173,7 +173,6 @@ growPFClusters(const reco::PFCluster& topo,
     // add rechits to clusters, calculating fraction based on distance
     for( auto& cluster : clusters ) {      
       const math::XYZPoint& clusterpos_xyz = cluster.position();
-      fraction = 0.0;
       const math::XYZVector deltav = clusterpos_xyz - topocellpos_xyz;
       const double d2 = deltav.Mag2()/_showerSigma2;
       dist2.emplace_back( d2 );
@@ -183,6 +182,7 @@ growPFClusters(const reco::PFCluster& topo,
 	  << d2;
       }
       // fraction assignment logic
+      double fraction;
       if( refhit->detId() == cluster.seed() && _excludeOtherSeeds ) {
 	fraction = 1.0;	
       } else if ( seedable[refhit.key()] && _excludeOtherSeeds ) {

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
@@ -196,7 +196,7 @@ growPFClusters(const reco::PFCluster& topo,
   std::vector<double> clus_chi2;
   std::vector<size_t> clus_chi2_nhits;
 
-  double fractot = 0, fraction = 0;
+  double fractot = 0;
   for( const reco::PFRecHitFraction& rhf : topo.recHitFractions() ) {
     const reco::PFRecHitRef& refhit = rhf.recHitRef();
     int cell_layer = (int)refhit->layer();
@@ -214,7 +214,6 @@ growPFClusters(const reco::PFCluster& topo,
     for (size_t iCluster = 0; iCluster < clusters.size(); ++iCluster) {
       reco::PFCluster& cluster = clusters[iCluster];
       const math::XYZPoint& clusterpos_xyz = cluster.position();
-      fraction = 0.0;
       const math::XYZVector deltav = clusterpos_xyz - topocellpos_xyz;
       double d2 = deltav.Mag2()/_showerSigma2;
 
@@ -234,6 +233,7 @@ growPFClusters(const reco::PFCluster& topo,
 	  << d2;
       }
       // fraction assignment logic
+      double fraction;
       if( refhit->detId() == cluster.seed() && _excludeOtherSeeds ) {
 	fraction = 1.0;	
       } else if ( seedable[refhit.key()] && _excludeOtherSeeds ) {

--- a/RecoParticleFlow/PFClusterProducer/src/InitialClusteringStepBase.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/InitialClusteringStepBase.cc
@@ -1,4 +1,6 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
 
+std::ostream& operator<<(std::ostream& o, const InitialClusteringStepBase& a){return a<<o;}
+
 EDM_REGISTER_PLUGINFACTORY(InitialClusteringStepFactory,
 			   "InitialClusteringStepFactory");

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterBuilderBase.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterBuilderBase.cc
@@ -1,4 +1,6 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h"
 
+std::ostream& operator<<(std::ostream& o, const PFClusterBuilderBase& a){return a<<o;}
+
 EDM_REGISTER_PLUGINFACTORY(PFClusterBuilderFactory,
 			   "PFClusterBuilderFactory");

--- a/RecoPixelVertexing/PixelLowPtUtilities/bin/PixelClusterShapeExtractor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/bin/PixelClusterShapeExtractor.cc
@@ -67,11 +67,11 @@ class PixelClusterShapeExtractor final : public edm::global::EDAnalyzer<>
 
    // Sim
    void processSim(const SiPixelRecHit &   recHit, ClusterShapeHitFilter const & theClusterFilter,
-                   const PSimHit & simHit, const SiPixelClusterShapeCache& clusterShapeCache, vector<TH2F *> & histo) const;
+                   const PSimHit & simHit, const SiPixelClusterShapeCache& clusterShapeCache, const vector<TH2F *> & histo) const;
 
    // Rec
    void processRec(const SiPixelRecHit &   recHit, ClusterShapeHitFilter const & theFilter,
-                   LocalVector ldir, const SiPixelClusterShapeCache& clusterShapeCache, vector<TH2F *> & histo) const;
+                   LocalVector ldir, const SiPixelClusterShapeCache& clusterShapeCache, const vector<TH2F *> & histo) const;
 
    bool checkSimHits
     (const TrackingRecHit & recHit, TrackerHitAssociator const & theAssociator,
@@ -100,9 +100,9 @@ class PixelClusterShapeExtractor final : public edm::global::EDAnalyzer<>
    const    TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 
    using Lock = std::unique_lock<std::mutex>;
-   mutable std::unique_ptr<std::mutex[]> theMutex;
-   mutable std::vector<TH2F *> hspc; // simulated pixel cluster
-   mutable std::vector<TH2F *> hrpc; // reconstructed pixel cluster
+   std::unique_ptr<std::mutex[]> theMutex;
+   std::vector<TH2F *> hspc; // simulated pixel cluster
+   std::vector<TH2F *> hrpc; // reconstructed pixel cluster
 };
 
 /*****************************************************************************/
@@ -194,7 +194,7 @@ bool PixelClusterShapeExtractor::isSuitable(const PSimHit & simHit, const GeomDe
 
 /*****************************************************************************/
 void PixelClusterShapeExtractor::processRec(const SiPixelRecHit & recHit, ClusterShapeHitFilter const & theClusterShape,
-    LocalVector ldir, const SiPixelClusterShapeCache& clusterShapeCache, vector<TH2F *> & histo) const
+    LocalVector ldir, const SiPixelClusterShapeCache& clusterShapeCache, const vector<TH2F *> & histo) const
 {
   int part;
   ClusterData::ArrayType meas;
@@ -224,7 +224,7 @@ void PixelClusterShapeExtractor::processRec(const SiPixelRecHit & recHit, Cluste
 
 /*****************************************************************************/
 void PixelClusterShapeExtractor::processSim(const SiPixelRecHit & recHit, ClusterShapeHitFilter const & theClusterFilter,
-     const PSimHit & simHit, const SiPixelClusterShapeCache& clusterShapeCache, vector<TH2F *> & histo) const
+     const PSimHit & simHit, const SiPixelClusterShapeCache& clusterShapeCache, const vector<TH2F *> & histo) const
 {
   LocalVector ldir = simHit.exitPoint() - simHit.entryPoint(); 
   processRec(recHit, theClusterFilter, ldir, clusterShapeCache, histo);

--- a/RecoPixelVertexing/PixelTrackFitting/src/ParabolaFit.h
+++ b/RecoPixelVertexing/PixelTrackFitting/src/ParabolaFit.h
@@ -46,7 +46,7 @@ private:
 
 private:
   struct Point { double x; double y; mutable double w; }; 
-  mutable std::vector<Point> points;
+  std::vector<Point> points;
   bool doErr, hasFixedParC;
   mutable bool hasValues, hasErrors;
   bool hasWeights;

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvLine.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvLine.cc
@@ -30,7 +30,6 @@ ThirdHitPredictionFromInvLine::ThirdHitPredictionFromInvLine(
 
   add(P1, errorRPhiP1);
   add(P2, errorRPhiP2);
-
 }
 
 GlobalPoint ThirdHitPredictionFromInvLine::crossing(double radius) const
@@ -62,6 +61,7 @@ void ThirdHitPredictionFromInvLine::add(const ThirdHitPredictionFromInvLine::Poi
   theSumV += point.v()*weigth;
   theSumUV +=  point.u()*point.v()*weigth; 
   theSumVV += sqr(point.v())*weigth;
+  check();
 }
 
 void ThirdHitPredictionFromInvLine::remove(const GlobalPoint &p, double errorRPhi)
@@ -76,6 +76,7 @@ void ThirdHitPredictionFromInvLine::remove(const GlobalPoint &p, double errorRPh
   theSumV -= point.v()*weigth;
   theSumUV -=  point.u()*point.v()*weigth;
   theSumVV -= sqr(point.v())*weigth;
+  check();
 }
 
 void ThirdHitPredictionFromInvLine::print() const
@@ -84,7 +85,7 @@ void ThirdHitPredictionFromInvLine::print() const
                                       <<" theSumV: "<< theSumV <<" theSumUV: "<<theSumUV<<std::endl;
 }
 
-void ThirdHitPredictionFromInvLine::check() const
+void ThirdHitPredictionFromInvLine::check()
 {
   if (hasParameters) return;
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvLine.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvLine.h
@@ -14,6 +14,8 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoRange.h"
 
+#include <cassert>
+
 class ThirdHitPredictionFromInvLine {
 
 public:
@@ -31,11 +33,11 @@ public:
 
   GlobalPoint crossing(double radius) const;
 
-  double curvature() const { check(); return theCurvatureValue; }
+  double curvature() const { assert(hasParameters); return theCurvatureValue; }
 
-  double errorCurvature() const { check(); return theCurvatureError; }
+  double errorCurvature() const { assert(hasParameters); return theCurvatureError; }
 
-  double chi2() const {  check(); return theChi2; }
+  double chi2() const {  assert(hasParameters); return theChi2; }
 
   void print() const;
 private:
@@ -68,14 +70,14 @@ private:
 private:
   typedef MappedPoint<double> PointUV;
   void add(const ThirdHitPredictionFromInvLine::PointUV & point, double weight);
-  void check() const;
+  void check();
 
 private:
   Rotation theRotation;
   int    nPoints;
   long double theSum, theSumU, theSumUU, theSumV, theSumUV, theSumVV;
-  mutable bool hasParameters;
-  mutable double theCurvatureValue, theCurvatureError, theChi2; 
+  bool hasParameters;
+  double theCurvatureValue, theCurvatureError, theChi2; 
 };
 
 

--- a/RecoTauTag/HLTProducers/interface/L1TJetsMatching.h
+++ b/RecoTauTag/HLTProducers/interface/L1TJetsMatching.h
@@ -70,12 +70,6 @@ class L1TJetsMatching: public edm::global::EDProducer<> {
     //
     // class decleration
     //
-    using namespace reco   ;
-    using namespace std    ;
-    using namespace edm    ;
-    using namespace trigger;
-    
-    
     template< typename T>
     std::pair<std::vector<T>,std::vector<T>> categorise(const std::vector<T>& pfMatchedJets, double pt1, double pt2, double Mjj)
     {
@@ -133,8 +127,8 @@ class L1TJetsMatching: public edm::global::EDProducer<> {
     }
     template< typename T>
     L1TJetsMatching<T>::L1TJetsMatching(const edm::ParameterSet& iConfig):
-    jetSrc_    ( consumes<std::vector<T>>                     (iConfig.getParameter<InputTag>("JetSrc"      ) ) ),
-    jetTrigger_( consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<InputTag>("L1JetTrigger") ) ),
+    jetSrc_    ( consumes<std::vector<T>>                     (iConfig.getParameter<edm::InputTag>("JetSrc"      ) ) ),
+    jetTrigger_( consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<edm::InputTag>("L1JetTrigger") ) ),
     pt1Min_   ( iConfig.getParameter<double>("pt1Min")),
     pt2Min_   ( iConfig.getParameter<double>("pt2Min")),
     mjjMin_   ( iConfig.getParameter<double>("mjjMin")),

--- a/RecoTauTag/ImpactParameter/interface/TauA1NuConstrainedFitter.h
+++ b/RecoTauTag/ImpactParameter/interface/TauA1NuConstrainedFitter.h
@@ -56,8 +56,6 @@ class TauA1NuConstrainedFitter : public MultiProngTauSolver{
   std::vector<LorentzVectorParticle> particles_;
   unsigned int ambiguity_;
 
-  static  unsigned int static_amb;
-
 };
 }
 #endif

--- a/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstCaloMuon.cc
+++ b/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstCaloMuon.cc
@@ -270,7 +270,7 @@ double TauDiscriminationAgainstCaloMuon<TauType, TauDiscriminator>::discriminate
 
   const CaloSubdetectorGeometry* ebGeometry = caloGeometry_->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
   const CaloSubdetectorGeometry* eeGeometry = caloGeometry_->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-  const HcalGeometry* hcGeometry = (HcalGeometry*)(caloGeometry_->getSubdetectorGeometry(DetId::Hcal, HcalBarrel));
+  const HcalGeometry* hcGeometry = (const HcalGeometry*)(caloGeometry_->getSubdetectorGeometry(DetId::Hcal, HcalBarrel));
 
   TrackRef leadTrackRef = leadTrackExtractor_.getLeadTrack(*tau);
 

--- a/RecoTauTag/RecoTau/src/AntiElectronIDCut2.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDCut2.cc
@@ -137,11 +137,8 @@ AntiElectronIDCut2::Discriminator(float TauPt,
 {
 
   double sumPt  = 0.;
-  double dEta   = 0.;
   double dEta2  = 0.;
-  double dPhi   = 0.;
   double dPhi2  = 0.;
-  double sumPt2 = 0.;
   for ( unsigned int i = 0 ; i < GammasPt.size() ; ++i ) {
     double pt_i  = GammasPt[i];
     double phi_i = GammasdPhi[i];
@@ -149,18 +146,13 @@ AntiElectronIDCut2::Discriminator(float TauPt,
     else if ( GammasdPhi[i] < -TMath::Pi() ) phi_i = GammasdPhi[i] + 2*TMath::Pi();
     double eta_i = GammasdEta[i];
     sumPt  +=  pt_i;
-    sumPt2 += (pt_i*pt_i);
-    dEta   += (pt_i*eta_i);
     dEta2  += (pt_i*eta_i*eta_i);
-    dPhi   += (pt_i*phi_i);
     dPhi2  += (pt_i*phi_i*phi_i);
   }
 
   float TauGammaEnFrac = sumPt/TauPt;
 
   if ( sumPt > 0. ) {
-    dEta  /= sumPt;
-    dPhi  /= sumPt;
     dEta2 /= sumPt;
     dPhi2 /= sumPt;
   }

--- a/RecoTauTag/RecoTau/src/AntiElectronIDMVA5.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDMVA5.cc
@@ -226,11 +226,8 @@ double AntiElectronIDMVA5::MVAValue(Float_t TauEtaAtEcalEntrance,
 				    Float_t ElecGSFTrackEta)
 {
   double sumPt  = 0.;
-  double dEta   = 0.;
   double dEta2  = 0.;
-  double dPhi   = 0.;
   double dPhi2  = 0.;
-  double sumPt2 = 0.;
   for ( unsigned int i = 0 ; i < GammasPt.size() ; ++i ) {
     double pt_i  = GammasPt[i];
     double phi_i = GammasdPhi[i];
@@ -238,18 +235,13 @@ double AntiElectronIDMVA5::MVAValue(Float_t TauEtaAtEcalEntrance,
     else if ( GammasdPhi[i] < -M_PI ) phi_i = GammasdPhi[i] + 2*M_PI;
     double eta_i = GammasdEta[i];
     sumPt  +=  pt_i;
-    sumPt2 += (pt_i*pt_i);
-    dEta   += (pt_i*eta_i);
     dEta2  += (pt_i*eta_i*eta_i);
-    dPhi   += (pt_i*phi_i);
     dPhi2  += (pt_i*phi_i*phi_i);
   }
 
   Float_t TauGammaEnFrac = sumPt/TauPt;
 
   if ( sumPt > 0. ) {
-    dEta  /= sumPt;
-    dPhi  /= sumPt;
     dEta2 /= sumPt;
     dPhi2 /= sumPt;
   }

--- a/RecoTauTag/TauTagTools/interface/PFCandCommonVertexFitter.h
+++ b/RecoTauTag/TauTagTools/interface/PFCandCommonVertexFitter.h
@@ -36,12 +36,6 @@ protected:
 	    reco::Candidate &) const;
   virtual bool fit(TransientVertex &, 
 		   const std::vector<reco::TransientTrack> &) const = 0;
-  /// chi-sqared
-  mutable double chi2_;
-  /// number of degrees of freedom
-  mutable double ndof_;
-  /// covariance matrix (3x3)
-  mutable CovarianceMatrix cov_;
 };
 
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"

--- a/RecoTauTag/TauTagTools/src/PFCandCommonVertexFitter.cc
+++ b/RecoTauTag/TauTagTools/src/PFCandCommonVertexFitter.cc
@@ -46,12 +46,11 @@ void PFCandCommonVertexFitterBase::set(VertexCompositeCandidate & c) const {
     }
     c.setP4(mp4);
     Vertex v = vertex;
-    c.setChi2AndNdof(chi2_ = v.chi2(), ndof_ = v.ndof());
-    v.fill(cov_);
-    c.setCovariance(cov_);
+    c.setChi2AndNdof(v.chi2(), v.ndof());
+    c.setCovariance(v.covariance());
   } else {
-    c.setChi2AndNdof(chi2_ = -1, ndof_ = 0);
-    c.setCovariance(cov_ = CovarianceMatrix(ROOT::Math::SMatrixIdentity())); 
+    c.setChi2AndNdof(-1, 0);
+    c.setCovariance(CovarianceMatrix(ROOT::Math::SMatrixIdentity())); 
   }
 }
 

--- a/RecoTauTag/TauTagTools/src/PFTauElementsOperators.cc
+++ b/RecoTauTag/TauTagTools/src/PFTauElementsOperators.cc
@@ -340,7 +340,6 @@ PFTauElementsOperators::computeInsideOutContents(const std::vector<reco::PFCandi
    double totalEnergySoFar                                    = (**signalObjectCandidate).energy();
    double totalEtSoFar                                        = (**signalObjectCandidate).et();
    math::XYZVector axisVectorSoFar                            = leadTrackVector;
-   double currentDelToCenter = ptrToMetricFunction(leadTrackVector, axisVectorSoFar);
    //advance to next object
    ++signalObjectCandidate;
    bool doneBuilding = false;
@@ -350,7 +349,7 @@ PFTauElementsOperators::computeInsideOutContents(const std::vector<reco::PFCandi
       math::XYZVector testAxis       = axisVectorSoFar;
       if (useScanningAxis)
          testAxis           += (**signalObjectCandidate).momentum();
-      currentDelToCenter    = ptrToMetricFunction((**signalObjectCandidate).momentum(), testAxis);
+      double currentDelToCenter    = ptrToMetricFunction((**signalObjectCandidate).momentum(), testAxis);
       double testEnergy     = totalEnergySoFar + (**signalObjectCandidate).energy();
       double testEt         = totalEtSoFar     + (**signalObjectCandidate).et();
       bool isCharged        = (**signalObjectCandidate).charge();

--- a/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversion1Leg.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversion1Leg.cc
@@ -151,7 +151,7 @@ const TrajectorySeed * SeedForPhotonConversion1Leg::buildSeed(
   edm::ESHandle<TransientTrackingRecHitBuilder> builderH;
   es.get<TransientRecHitRecord>().get(TTRHBuilder, builderH);
   auto builder = (TkTransientTrackingRecHitBuilder const *)(builderH.product());
-  cloner = (*builder).cloner();
+  auto cloner = (*builder).cloner();
 
   // get updator
   KFUpdator  updator;
@@ -173,7 +173,7 @@ const TrajectorySeed * SeedForPhotonConversion1Leg::buildSeed(
     
     SeedingHitSet::ConstRecHitPointer tth = hits[iHit]; 
     
-    std::unique_ptr<BaseTrackerRecHit> newtth(refitHit( tth, state));
+    std::unique_ptr<BaseTrackerRecHit> newtth(refitHit( tth, state, cloner));
 
     
     if (!checkHit(state,&*newtth,es)) return nullptr;
@@ -202,7 +202,7 @@ const TrajectorySeed * SeedForPhotonConversion1Leg::buildSeed(
 
 SeedingHitSet::RecHitPointer SeedForPhotonConversion1Leg::refitHit(
       SeedingHitSet::ConstRecHitPointer hit, 
-      const TrajectoryStateOnSurface &state) const
+      const TrajectoryStateOnSurface &state, const TkClonerImpl& cloner) const
 {
   //const TransientTrackingRecHit* a= hit.get();
   //return const_cast<TransientTrackingRecHit*> (a);

--- a/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversion1Leg.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversion1Leg.h
@@ -67,15 +67,12 @@ public:
 					   const edm::EventSetup& es) const;
 
   SeedingHitSet::RecHitPointer refitHit( SeedingHitSet::ConstRecHitPointer hit, 
-					 const TrajectoryStateOnSurface &state) const;
+					 const TrajectoryStateOnSurface &state, const TkClonerImpl& cloner) const;
   
 protected:
   std::string thePropagatorLabel;
   double theBOFFMomentum;
   std::string TTRHBuilder;
-
-  // FIXME (well the whole class needs to be fixed!)      
-  mutable  TkClonerImpl cloner;
 
   std::stringstream * pss;
   PrintRecoObjects po;

--- a/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversionFromQuadruplets.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversionFromQuadruplets.cc
@@ -582,7 +582,13 @@ if(DeltaPhiManualM1P1>DeltaPhiMaxM1P1+tol_DeltaPhiMaxM1P1 || DeltaPhiManualM1P1<
 #endif
 
     
-
+    // get cloner (FIXME: add to config)
+    auto TTRHBuilder = "WithTrackAngle"; 
+    edm::ESHandle<TransientTrackingRecHitBuilder> builderH;
+    es.get<TransientRecHitRecord>().get(TTRHBuilder, builderH);
+    auto builder = (TkTransientTrackingRecHitBuilder const *)(builderH.product());
+    cloner = (*builder).cloner(); 
+    
     bool buildSeedBoolPos = buildSeedBool(seedCollection,phits,ftsPlus,es,applydzCAcut,region, dzcut);
     bool buildSeedBoolNeg = buildSeedBool(seedCollection,mhits,ftsMinus,es,applydzCAcut,region, dzcut);
 
@@ -765,13 +771,6 @@ bool SeedForPhotonConversionFromQuadruplets::buildSeedBool(
   edm::ESHandle<Propagator>  propagatorHandle;
   es.get<TrackingComponentsRecord>().get(thePropagatorLabel, propagatorHandle);
   const Propagator*  propagator = &(*propagatorHandle);
-
-   // get cloner (FIXME: add to config)
-  auto TTRHBuilder = "WithTrackAngle"; 
-  edm::ESHandle<TransientTrackingRecHitBuilder> builderH;
-  es.get<TransientRecHitRecord>().get(TTRHBuilder, builderH);
-  auto builder = (TkTransientTrackingRecHitBuilder const *)(builderH.product());
-  cloner = (*builder).cloner(); 
 
   // get updator
   KFUpdator  updator;

--- a/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversionFromQuadruplets.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversionFromQuadruplets.h
@@ -107,7 +107,7 @@ protected:
   double  kPI_;
 
   // FIXME (well the whole class needs to be fixed!)
-  mutable TkClonerImpl cloner;
+  TkClonerImpl cloner;
 
   std::stringstream * pss;
   PrintRecoObjects po;

--- a/RecoTracker/SiTrackerMRHTools/src/SimpleDAFHitCollector.cc
+++ b/RecoTracker/SiTrackerMRHTools/src/SimpleDAFHitCollector.cc
@@ -167,7 +167,7 @@ void SimpleDAFHitCollector::Debug( const std::vector<TrajectoryMeasurement> TM )
       DetId hitId = itrajmeas->recHit()->geographicalId();
 
       if(hitId.det() == DetId::Tracker) {
-        switch (hitId.subdetid()) {
+        switch (hitId.subdetId()) {
           case StripSubdetector::TIB:
             LogTrace("MultiRecHitCollector") << "  I am TIB " << theTopology->tibLayer(hitId); break;
           case StripSubdetector::TOB:

--- a/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
@@ -444,7 +444,7 @@ bool SimpleCosmicBONSeeder::seeds(TrajectorySeedCollection &output, const edm::E
     typedef TrajectoryStateOnSurface TSOS;
     
     for (size_t it=0;it<hitTriplets.size();it++){
-      OrderedHitTriplet &trip = const_cast<OrderedHitTriplet &>(hitTriplets[it]);
+      OrderedHitTriplet &trip = hitTriplets.at(it);
       
       GlobalPoint inner = tracker->idToDet((*(trip.inner())).geographicalId())->surface().
 	toGlobal((*(trip.inner())).localPosition());

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -276,7 +276,7 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region, OrderedMul
             auto angle = layer3.phi(i);
 	    auto myz = layer3.v[i];
 #ifdef EDM_ML_DEBUG
-             IfLogTrace(layer3.hit(i)->rawId()==debug_Id2, "MultiHitGeneratorFromChi2") << "filling KDTree with hit in id=" << debug_Id2
+             IfLogTrace(hi->hit()->rawId()==debug_Id2, "MultiHitGeneratorFromChi2") << "filling KDTree with hit in id=" << debug_Id2
                                                                                    << " with pos: " << hi->hit()->globalPosition()
                                                                                    << " phi=" << hi->hit()->globalPosition().phi()
                                                                                    << " z=" << hi->hit()->globalPosition().z()

--- a/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaFinder.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaFinder.cc
@@ -445,7 +445,7 @@ PixelInactiveAreaFinder::PixelInactiveAreaFinder(const edm::ParameterSet& iConfi
 {
 #ifdef EDM_ML_DEBUG
   for(const auto& layer: seedingLayers) {
-    LogTrace("PixelInactiveAreaFinder") << "Input layer subdet " << std::get<0>(layer) << " side " << std::get<1>(layer) << " layer " << std::get<2>(layer);
+    LogTrace("PixelInactiveAreaFinder") << "Input layer subdet " << std::get<0>(layer) << " side " << static_cast<unsigned int>(std::get<1>(layer)) << " layer " << std::get<2>(layer);
   }
 #endif
 

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableAdaptiveFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableAdaptiveFitter.cc
@@ -91,5 +91,5 @@ edm::ParameterSet ConfigurableAdaptiveFitter::defaults() const
 #include "RecoVertex/ConfigurableVertexReco/interface/ConfFitterBuilder.h"
 
 namespace {
-  ConfFitterBuilder < ConfigurableAdaptiveFitter > t ( "avf", "AdaptiveVertexFitter" );
+  const ConfFitterBuilder < ConfigurableAdaptiveFitter > t ( "avf", "AdaptiveVertexFitter" );
 }

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableAdaptiveReconstructor.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableAdaptiveReconstructor.cc
@@ -80,7 +80,7 @@ edm::ParameterSet ConfigurableAdaptiveReconstructor::defaults() const
 #include "RecoVertex/ConfigurableVertexReco/interface/ConfRecoBuilder.h"
 
 namespace {
-  ConfRecoBuilder < ConfigurableAdaptiveReconstructor > t
+  const ConfRecoBuilder < ConfigurableAdaptiveReconstructor > t
     ( "avr", "Adaptive Vertex Reconstructor [ = Iterative avf]" );
   // ConfRecoBuilder < ConfigurableAdaptiveReconstructor > s ( "default", "Adaptive Vertex Reconstructor [ = Iterative avf]" );
 }

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableKalmanFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableKalmanFitter.cc
@@ -48,6 +48,6 @@ edm::ParameterSet ConfigurableKalmanFitter::defaults() const
 #include "RecoVertex/ConfigurableVertexReco/interface/ConfFitterBuilder.h"
 
 namespace {
-  ConfFitterBuilder < ConfigurableKalmanFitter > t ( "kalman", "Standard Kalman Filter" );
-  ConfFitterBuilder < ConfigurableKalmanFitter > s ( "default", "Standard Kalman Filter" );
+  const ConfFitterBuilder < ConfigurableKalmanFitter > t ( "kalman", "Standard Kalman Filter" );
+  const ConfFitterBuilder < ConfigurableKalmanFitter > s ( "default", "Standard Kalman Filter" );
 }

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableMultiVertexFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableMultiVertexFitter.cc
@@ -99,5 +99,5 @@ edm::ParameterSet ConfigurableMultiVertexFitter::defaults() const
 #include "RecoVertex/ConfigurableVertexReco/interface/ConfRecoBuilder.h"
 
 namespace {
-  ConfRecoBuilder < ConfigurableMultiVertexFitter > t ( "mvf", "Multi Vertex Fitter" );
+  const ConfRecoBuilder < ConfigurableMultiVertexFitter > t ( "mvf", "Multi Vertex Fitter" );
 }

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableTrimmedKalmanFinder.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableTrimmedKalmanFinder.cc
@@ -76,5 +76,5 @@ edm::ParameterSet ConfigurableTrimmedKalmanFinder::defaults() const
 #include "RecoVertex/ConfigurableVertexReco/interface/ConfRecoBuilder.h"
 
 namespace {
-  ConfRecoBuilder < ConfigurableTrimmedKalmanFinder > t ( "tkf", "Trimmed Kalman Vertex Finder" );
+  const ConfRecoBuilder < ConfigurableTrimmedKalmanFinder > t ( "tkf", "Trimmed Kalman Vertex Finder" );
 }

--- a/RecoVertex/ConfigurableVertexReco/src/ReconstructorFromFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ReconstructorFromFitter.cc
@@ -54,6 +54,7 @@ edm::ParameterSet ReconstructorFromFitter::defaults() const
 
 void ReconstructorFromFitter::configure ( const edm::ParameterSet & s )
 {
+  //this looks better than changing the data member to be non-const ptr and allow changes in all calls
   const_cast < AbstractConfFitter *> (theFitter)->configure (s );
 }
 

--- a/RecoVertex/MultiVertexFit/interface/MultiVertexFitter.h
+++ b/RecoVertex/MultiVertexFit/interface/MultiVertexFitter.h
@@ -115,7 +115,7 @@ private:
   std::set < reco::TransientTrack > thePrimaries;
   AnnealingSchedule * theAssComp;
   LinearizationPointFinder * theSeeder;
-  mutable TrackAndSeedToWeightMap theWeights;
+  TrackAndSeedToWeightMap theWeights;
   LinTrackCache theCache;
 };
 

--- a/RecoVertex/MultiVertexFit/src/MultiVertexFitter.cc
+++ b/RecoVertex/MultiVertexFit/src/MultiVertexFitter.cc
@@ -617,8 +617,14 @@ void MultiVertexFitter::printWeights ( const reco::TransientTrack & t ) const
     for ( vector < pair < int, CachingVertex<5> > >::const_iterator seed=theVertexStates.begin();
           seed!=theVertexStates.end(); ++seed )
     {
+      double val = 0;
+      auto a = theWeights.find(t);
+      if ( a != theWeights.end()){
+        auto b = a->second.find(seed->first);
+        if (b != a->second.end()) val = b->second;
+      }
       cout << "  -- Vertex[" << seed->first << "] with " << setw(12)
-           << setprecision(3) << theWeights[t][seed->first];
+           << setprecision(3) << val;
     };
     cout << endl;
 }

--- a/TrackingTools/GsfTracking/interface/GsfBetheHeitlerUpdator.h
+++ b/TrackingTools/GsfTracking/interface/GsfBetheHeitlerUpdator.h
@@ -75,7 +75,7 @@ private:
   /// Read parametrization from file
   void readParameters (const std::string);
   /// Read coefficients of one polynomial from file
-  Polynomial readPolynomial (std::ifstream&,const int);
+  Polynomial readPolynomial (std::ifstream&,const unsigned int);
 
  
   /// Filling of mixture (in terms of z=E/E0)

--- a/TrackingTools/GsfTracking/src/GsfBetheHeitlerUpdator.cc
+++ b/TrackingTools/GsfTracking/src/GsfBetheHeitlerUpdator.cc
@@ -97,9 +97,9 @@ void GsfBetheHeitlerUpdator::readParameters (const std::string fileName)
 
 GsfBetheHeitlerUpdator::Polynomial
 GsfBetheHeitlerUpdator::readPolynomial (std::ifstream& aStream, 
-					const int order) {
+					const unsigned int order) {
   float coeffs[order+1];
-  for ( int i=0; i<(order+1); ++i ) aStream >> coeffs[i];
+  for ( unsigned int i=0; i<(order+1); ++i ) aStream >> coeffs[i];
   return Polynomial(coeffs,order+1);
 }
 

--- a/TrackingTools/PatternTools/interface/TrajectoryMeasurement.h
+++ b/TrackingTools/PatternTools/interface/TrajectoryMeasurement.h
@@ -204,7 +204,7 @@ private:
   TrajectoryStateOnSurface theBwdPredictedState;
   TrajectoryStateOnSurface theUpdatedState;
   ConstRecHitPointer       theRecHit;
-  mutable DetLayer const * theLayer;
+  DetLayer const * theLayer;
   float theEstimate;
 };
 

--- a/TrackingTools/PatternTools/interface/TwoTrackMinimumDistance.h
+++ b/TrackingTools/PatternTools/interface/TwoTrackMinimumDistance.h
@@ -63,11 +63,11 @@ public:
 private:
   enum Charge { hh, hl, ll };
   Mode theModus;
-  mutable Charge theCharge;
+  Charge theCharge;
   ClosestApproachInRPhi theIniAlgo;
-  mutable TwoTrackMinimumDistanceHelixHelix theTTMDhh;
-  mutable TwoTrackMinimumDistanceLineLine theTTMDll;
-  mutable TwoTrackMinimumDistanceHelixLine theTTMDhl;
+  TwoTrackMinimumDistanceHelixHelix theTTMDhh;
+  TwoTrackMinimumDistanceLineLine theTTMDll;
+  TwoTrackMinimumDistanceHelixLine theTTMDhl;
   bool status_;
   std::pair<GlobalPoint, GlobalPoint> points_;
 

--- a/TrackingTools/PatternTools/interface/TwoTrackMinimumDistanceHelixHelix.h
+++ b/TrackingTools/PatternTools/interface/TwoTrackMinimumDistanceHelixHelix.h
@@ -26,26 +26,22 @@ public:
       const float qual=.001 ); // retval=true? error occured.
 
   std::pair <GlobalPoint, GlobalPoint> points() const {
-    if (!pointsUpdated) finalPoints();
     return std::pair<GlobalPoint, GlobalPoint> (pointG, pointH);
   }
 
   std::pair <double, double> pathLength() const {
-    if (!pointsUpdated) finalPoints();
     return std::pair <double, double> ( pathG, pathH);
   }
-
-
 
   double firstAngle() const {return thepG;}
   double secondAngle() const {return thepH;}
 
 private:
   bool updateCoeffs( const GlobalPoint & , const GlobalPoint & );
-  bool oneIteration ( double &, double & ) const;
+  bool oneIteration ( double &, double & ) ;
 
 // bool parallelTracks () const;
-  void finalPoints() const;
+  void finalPoints();
 
 private:
   GlobalTrajectoryParameters const *theH, *theG;
@@ -59,12 +55,12 @@ private:
 
   // the variable stuff
   // = the point we are currently looking at.
-  mutable double thepG, thepH;
-  mutable double thesinpG, thesinpH;
-  mutable double thecospG, thecospH;
-  mutable GlobalPoint pointG, pointH;
-  mutable double pathG, pathH;
-  mutable bool pointsUpdated;
+  double thepG, thepH;
+  double thesinpG, thesinpH;
+  double thecospG, thecospH;
+  GlobalPoint pointG, pointH;
+  double pathG, pathH;
+  bool pointsUpdated;
 
   double themaxjump, thesingjacI;
   int themaxiter;

--- a/TrackingTools/PatternTools/interface/TwoTrackMinimumDistanceHelixLine.h
+++ b/TrackingTools/PatternTools/interface/TwoTrackMinimumDistanceHelixLine.h
@@ -45,7 +45,7 @@ public:
   double secondAngle() const;
 
 private:
-  GlobalTrajectoryParameters *theH, *theL, *firstGTP, *secondGTP;
+  const GlobalTrajectoryParameters *theH, *theL, *firstGTP, *secondGTP;
   GlobalVector posDiff;
   GlobalVector theLp;
   double X, Y, Z, px, py, pz, px2, py2, pz2, baseFct, baseDer;

--- a/TrackingTools/PatternTools/interface/TwoTrackMinimumDistanceHelixLine.h
+++ b/TrackingTools/PatternTools/interface/TwoTrackMinimumDistanceHelixLine.h
@@ -56,11 +56,11 @@ private:
 
   int themaxiter;
   bool updateCoeffs();
-  void finalPoints() const;
+  void finalPoints();
   bool oneIteration(double & thePhiH, double & fct, double & derivative ) const;
-  mutable GlobalPoint helixPoint, linePoint;
-  mutable double tL, linePath, helixPath;
-  mutable bool pointsUpdated;
+  GlobalPoint helixPoint, linePoint;
+  double tL, linePath, helixPath;
+  bool pointsUpdated;
 
 };
 #endif

--- a/TrackingTools/PatternTools/interface/bqueue.h
+++ b/TrackingTools/PatternTools/interface/bqueue.h
@@ -82,12 +82,12 @@ namespace cmsutils {
     bool operator==(const _bqueue_itr<T> &t2) const  { return t2.it == it; }
     bool operator!=(const _bqueue_itr<T> &t2) const { return t2.it != it; }
     // so that I can assign a const_iterator to a const_iterator
-    const _bqueue_itr<T> & operator=(const _bqueue_itr<T> &t2) const { it = t2.it; return *this; }
+    const _bqueue_itr<T> & operator=(const _bqueue_itr<T> &t2) { it = t2.it; return *this; }
     friend class bqueue<T>;
   private:
     // _bqueue_itr(_bqueue_item<T> *t) : it(t) { }
     _bqueue_itr(const _bqueue_item<T> *t) : it(t) { }
-    mutable _bqueue_item<T> const * it;
+    _bqueue_item<T> const * it;
   };
   
   template<class T>

--- a/TrackingTools/PatternTools/src/TwoTrackMinimumDistanceHelixHelix.cc
+++ b/TrackingTools/PatternTools/src/TwoTrackMinimumDistanceHelixHelix.cc
@@ -99,7 +99,7 @@ bool TwoTrackMinimumDistanceHelixHelix::updateCoeffs(
   return false;
 }
 
-bool TwoTrackMinimumDistanceHelixHelix::oneIteration(double & dH, double & dG ) const {
+bool TwoTrackMinimumDistanceHelixHelix::oneIteration(double & dH, double & dG ) {
   thesinpH=sin(thepH);
   thecospH=cos(thepH);
   thesinpG=sin(thepG);
@@ -148,7 +148,10 @@ bool TwoTrackMinimumDistanceHelixHelix::calculate(
   theH= &H;
   bool retval=false;
   
-  if ( updateCoeffs ( theG->position(), theH->position() ) ) return true;
+  if ( updateCoeffs ( theG->position(), theH->position() ) ){
+    finalPoints();
+    return true;
+  }
   
   thepG = thepG0;
   thepH = thepH0;
@@ -162,11 +165,15 @@ bool TwoTrackMinimumDistanceHelixHelix::calculate(
   } while ( (!retval) && ( fabs(pG) > qual || fabs(pH) > qual ));
   if ( fabs ( theg * ( thepG - thepG0 ) ) > themaxjump ) retval=true;
   if ( fabs ( theh * ( thepH - thepH0 ) ) > themaxjump ) retval=true;
+
+  finalPoints();
+
   return retval;
 }
 
 
-void TwoTrackMinimumDistanceHelixHelix::finalPoints() const {
+void TwoTrackMinimumDistanceHelixHelix::finalPoints() {
+  if (pointsUpdated) return;
   GlobalVector tmpG( sin(thepG) - thesinpG0,
 		   - cos(thepG) + thecospG0,
 		   thetanlambdaG * ( thepG- thepG0 ) 

--- a/TrackingTools/PatternTools/src/TwoTrackMinimumDistanceHelixLine.cc
+++ b/TrackingTools/PatternTools/src/TwoTrackMinimumDistanceHelixLine.cc
@@ -115,8 +115,8 @@ bool TwoTrackMinimumDistanceHelixLine::calculate(
     const GlobalTrajectoryParameters & theSecondGTP, const float qual )
 {
   pointsUpdated = false;
-  firstGTP  = (GlobalTrajectoryParameters *) &theFirstGTP;
-  secondGTP = (GlobalTrajectoryParameters *) &theSecondGTP;
+  firstGTP  = &theFirstGTP;
+  secondGTP = &theSecondGTP;
 
   if ( updateCoeffs () )
   {

--- a/TrackingTools/PatternTools/src/TwoTrackMinimumDistanceHelixLine.cc
+++ b/TrackingTools/PatternTools/src/TwoTrackMinimumDistanceHelixLine.cc
@@ -120,6 +120,7 @@ bool TwoTrackMinimumDistanceHelixLine::calculate(
 
   if ( updateCoeffs () )
   {
+    finalPoints();
     return true;
   };
 
@@ -136,10 +137,14 @@ bool TwoTrackMinimumDistanceHelixLine::calculate(
         << "Jumped out of brackets in root finding. Will be moved closer.";
       thePhiH += (dPhiH*0.8);
     }
-    if (fabs(dPhiH) < qual) {return false;}
+    if (fabs(dPhiH) < qual) {
+      finalPoints();
+      return false;
+    }
   }
   LogDebug ("TwoTrackMinimumDistanceHelixLine")
     <<"Number of steps exceeded. Has not converged.";
+  finalPoints();
   return true;
 }
 
@@ -155,10 +160,8 @@ double TwoTrackMinimumDistanceHelixLine::secondAngle() const
   else return thePhiH;
 }
 
-pair <GlobalPoint, GlobalPoint> TwoTrackMinimumDistanceHelixLine::points()
-    const 
+pair <GlobalPoint, GlobalPoint> TwoTrackMinimumDistanceHelixLine::points() const 
 {
-  if (!pointsUpdated)finalPoints();
   if (firstGTP==theL) 
     return pair<GlobalPoint, GlobalPoint> (linePoint, helixPoint);
   else return pair<GlobalPoint, GlobalPoint> (helixPoint, linePoint);
@@ -166,14 +169,14 @@ pair <GlobalPoint, GlobalPoint> TwoTrackMinimumDistanceHelixLine::points()
 
 pair <double, double> TwoTrackMinimumDistanceHelixLine::pathLength() const
 {
-  if (!pointsUpdated)finalPoints();
   if (firstGTP==theL) 
     return pair<double, double> (linePath, helixPath);
   else return pair<double, double> (helixPath, linePath);
 }
 
-void TwoTrackMinimumDistanceHelixLine::finalPoints() const
+void TwoTrackMinimumDistanceHelixLine::finalPoints()
 {
+  if (pointsUpdated) return;
   helixPoint = GlobalPoint (
       theH->position().x() + theh * ( sin ( thePhiH) - thesinPhiH0 ),
       theH->position().y() + theh * ( - cos ( thePhiH) + thecosPhiH0 ),

--- a/TrackingTools/TrackFitters/interface/DebugHelpers.h
+++ b/TrackingTools/TrackFitters/interface/DebugHelpers.h
@@ -1,5 +1,7 @@
 #ifdef EDM_ML_DEBUG
 
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"


### PR DESCRIPTION
- make reco (and some AT) related files compile with EDM_ML_DEBUG (required in static ana checks)
- unpackers use const ptr to input data buffers
- RecoEgamma/EgammaPhotonAlgos/interface/ConversionSeedFinder and related are made less const to the logic that modifying methods are not const
-  RecoPixelVertexing/PixelTriplets/plugins/ThirdHitPredictionFromInvLine consolidate all actually non-const operations in non-const qualified methods (and avoid mutables)
-  RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversion1Leg and SeedForPhotonConversionFromQuadruplets: make TkClonerImpl in place instead of a repeatedly remade mutable data member
-  TrackingTools/PatternTools/interface/TwoTrackMinimumDistance*: drop mutables and move all modifying calls to declared non-const methods
- detection of uninitialized cases :  EventFilter/EcalRawToDigi/plugins/MatacqProducer,  EventFilter/EcalRawToDigi/src/DCCEETCCBlock
- the rest is of simpler kind:
    - a few non-cost statics made const or atomic where appropriate
    - move away or drop unused initializations
    - remove unneeded mutables and const_casts
    - is{,Not}Finite use instead of isnan


Tested in CMSSW_10_0_0_pre3 with a short matrix and comparisons showed no differences.