### PR TITLE
Geant4 sensitive detectors update 3

### DIFF
--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -34,30 +34,32 @@ public:
   ECalSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	 edm::ParameterSet const & p, const SimTrackManager*);
   ~ECalSD() override;
-  double                    getEnergyDeposit(G4Step*) override;
-  virtual uint16_t          getRadiationLength(const G4Step *);
-  virtual uint16_t          getLayerIDForTimeSim(const G4Step *);
   uint32_t                  setDetUnitId(const G4Step*) override;
   void                      setNumberingScheme(EcalNumberingScheme*);
 
 protected:
 
+  double                    getEnergyDeposit(const G4Step*, bool& isKilled) override;
   int                       getTrackID(const G4Track*) override;
   uint16_t                  getDepth(const G4Step*) override;
 
 private:    
 
-  void                              initMap(const G4String&, const DDCompactView &);
-  double                            curve_LY(const G4Step*); 
-  double                            crystalLength(const G4LogicalVolume*);
-  double                            crystalDepth(const G4LogicalVolume*, const G4ThreeVector&);
-  void                              getBaseNumber(const G4Step*); 
-  double                            getBirkL3(const G4Step*);
+  void                      initMap(const G4String&, const DDCompactView &);
+  uint16_t                  getRadiationLength(const G4StepPoint* hitPoint, 
+					       const G4LogicalVolume* lv);
+  uint16_t                  getLayerIDForTimeSim();
+  double                    curve_LY(const G4LogicalVolume*);  
+
+  void                      getBaseNumber(const G4Step*); 
+  double                    getBirkL3(const G4Step*);
+
   std::vector<double>               getDDDArray(const std::string&,
 						const DDsvalues_type&);
   std::vector<std::string>          getStringArray(const std::string&,
 						   const DDsvalues_type&);
 
+  // initialised before run
   bool                              isEB;
   bool                              isEE;
   EcalNumberingScheme *             numberingScheme;
@@ -71,6 +73,13 @@ private:
   EcalBaseNumber                    theBaseNumber;
   EnergyResolutionVsLumi            ageing;
   bool                              ageingWithSlopeLY;
+
+  // run time cache
+  G4ThreeVector                     currentLocalPoint;
+  double                            crystalLength;
+  double                            crystalDepth;
+  uint16_t                          depth;
+ 
 #ifdef plotDebug
   TH2F                             *g2L_[4];
 #endif

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -41,12 +41,12 @@ public:
          edm::ParameterSet const &, const SimTrackManager*);
   ~HCalSD() override;
   bool                  ProcessHits(G4Step * , G4TouchableHistory * ) override;
-  double                getEnergyDeposit(G4Step* ) override;
   uint32_t              setDetUnitId(const G4Step* step) override;
   void                  setNumberingScheme(HcalNumberingScheme* );
 
 protected:
 
+  double                getEnergyDeposit(const G4Step*, bool& ) override;
   void                  update(const BeginOfJob *) override;
   void                  initRun() override;
   bool                  filterHit(CaloG4Hit*, double) override;
@@ -80,19 +80,21 @@ private:
   void                          plotHF(const G4ThreeVector& pos, bool emType);
   void                          modifyDepth(HcalNumberingFromDDD::HcalID& id);
 
+  std::unique_ptr<HcalNumberingFromDDD> numberingFromDDD;
+  std::unique_ptr<HcalNumberingScheme>  numberingScheme;
+  std::unique_ptr<HFShowerLibrary>      showerLibrary;
+  std::unique_ptr<HFShower>             hfshower;
+  std::unique_ptr<HFShowerParam>        showerParam;
+  std::unique_ptr<HFShowerPMT>          showerPMT;
+  std::unique_ptr<HFShowerFibreBundle>  showerBundle;
+
   HcalDDDSimConstants*          hcalConstants;
-  HcalNumberingFromDDD*         numberingFromDDD;
-  HcalNumberingScheme*          numberingScheme;
-  HFShowerLibrary *             showerLibrary;
-  HFShower *                    hfshower;
-  HFShowerParam *               showerParam;
-  HFShowerPMT *                 showerPMT;
-  HFShowerFibreBundle *         showerBundle;
-  bool                          agingFlagHB, agingFlagHE;
   const HBHEDarkening*          m_HBDarkening;
   const HBHEDarkening*          m_HEDarkening;
   std::unique_ptr<HFDarkening>  m_HFDarkening;
-  HcalTestNS *                  hcalTestNS_;
+  std::unique_ptr<HcalTestNS>   m_HcalTestNS;
+
+  bool                          agingFlagHB, agingFlagHE;
   bool                          useBirk, useLayerWt, useFibreBundle, usePMTHit;
   bool                          testNumber, neutralDensity, testNS_;
   double                        birk1, birk2, birk3, betaThr;

--- a/SimG4CMS/Calo/interface/HGCSD.h
+++ b/SimG4CMS/Calo/interface/HGCSD.h
@@ -31,7 +31,7 @@ public:
 	edm::ParameterSet const &, const SimTrackManager*);
   ~HGCSD() override;
   bool                    ProcessHits(G4Step * , G4TouchableHistory * ) override;
-  double                  getEnergyDeposit(G4Step* ) override;
+  double                  getEnergyDeposit(const G4Step*, bool& ) override;
   uint32_t                setDetUnitId(const G4Step* step) override;
 
 protected:

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -167,95 +167,63 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
 }
 
 ECalSD::~ECalSD() {
-  if (numberingScheme) delete numberingScheme;
+  delete numberingScheme;
 }
 
-double ECalSD::getEnergyDeposit(G4Step * aStep) {
-  
-  if (aStep == nullptr) {
-    return 0;
-  } else {
-    preStepPoint = aStep->GetPreStepPoint();
-    theTrack     = aStep->GetTrack();
-    double wt2   = theTrack->GetWeight();
-    const G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
+double ECalSD::getEnergyDeposit(const G4Step * aStep, bool&) {
 
-    // take into account light collection curve for crystals
-    double weight = 1.;
-    if (suppressHeavy) {
-      TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
-      if (trkInfo) {
-        int pdg = theTrack->GetDefinition()->GetPDGEncoding();
-        if (!(trkInfo->isPrimary())) { // Only secondary particles
-          double ke = theTrack->GetKineticEnergy()/MeV;
-          if (((pdg/1000000000 == 1 && ((pdg/10000)%100) > 0 &&
-                ((pdg/10)%100) > 0)) && (ke<kmaxIon)) weight = 0;
-          if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
-          if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
+  const G4Track* theTrack = aStep->GetTrack();
+  double edep = aStep->GetTotalEnergyDeposit();
+
+  // take into account light collection curve for crystals
+  double weight = 1.;
+  if (suppressHeavy) {
+    TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
+    if (trkInfo) {
+      int pdg = theTrack->GetDefinition()->GetPDGEncoding();
+      if (!(trkInfo->isPrimary())) { // Only secondary particles
+	double ke = theTrack->GetKineticEnergy()/MeV;
+	if (((pdg/1000000000 == 1 && ((pdg/10000)%100) > 0 &&
+	      ((pdg/10)%100) > 0)) && (ke<kmaxIon)) weight = 0;
+	if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
+	if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
 #ifdef EDM_ML_DEBUG
-          if (weight == 0) 
-            edm::LogInfo("EcalSim") << "Ignore Track " << theTrack->GetTrackID()
-                                    << " Type " << theTrack->GetDefinition()->GetParticleName()
-                                    << " Kinetic Energy " << ke << " MeV";
+	if (weight == 0) 
+	  edm::LogInfo("EcalSim") << "Ignore Track " << theTrack->GetTrackID()
+				  << " Type " << theTrack->GetDefinition()->GetParticleName()
+				  << " Kinetic Energy " << ke << " MeV";
 #endif
-        }
       }
     }
-    const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-    if (useWeight && !any(noWeight,lv)) {
-      weight *= curve_LY(aStep);
-      if (useBirk) {
-        if (useBirkL3) weight *= getBirkL3(aStep);
-        else           weight *= getAttenuation(aStep, birk1, birk2, birk3);
-      }
+  }
+  const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+  double wt1 = 1.0;
+  if (useWeight && !any(noWeight,lv)) {
+    weight *= curve_LY(lv);
+    if (useBirk) {
+      if (useBirkL3) weight *= getBirkL3(aStep);
+      else           weight *= getAttenuation(aStep, birk1, birk2, birk3);
     }
-    double wt1  = getResponseWt(theTrack);
-    double edep = aStep->GetTotalEnergyDeposit()*weight*wt1;
-    /*
-    if(wt2 != 1.0) { 
-      edm::LogInfo("EcalSim") << "ECalSD:: " << nameVolume
-                              <<" LightWeight= " <<weight << " wt1= " <<wt1
-                              << "  wt2= " << wt2 << "  "
-                              << " Weighted Energy Deposit " << edep/MeV
-                              << " MeV";
-      const G4VProcess* pr = theTrack->GetCreatorProcess();
-      if (pr) 
-        edm::LogInfo("EcalSim") << theTrack->GetDefinition()->GetParticleName()
-                                << " " << theTrack->GetKineticEnergy()
-                                << " Id=" << theTrack->GetTrackID()
-                                << " IdP=" << theTrack->GetParentID()
-                                << " from  " << pr->GetProcessName();
-      else
-        edm::LogInfo("EcalSim") << theTrack->GetDefinition()->GetParticleName()
-                                << " " << theTrack->GetKineticEnergy()
-                                << " Id=" << theTrack->GetTrackID()
-                                << " IdP=" << theTrack->GetParentID();
-    }
-    */
-    if(wt2 > 0.0) { edep *= wt2; }
+    wt1 = getResponseWt(theTrack);
+  }
+  edep *= weight*wt1;
+  // Russian Roulette
+  double wt2 = theTrack->GetWeight();
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("EcalSim") << "ECalSD:: " << nameVolume
-                            << " Light Collection Efficiency " << weight << ":"
-                            << wt1 << " Weighted Energy Deposit " << edep/MeV 
-                            << " MeV";
+  edm::LogInfo("EcalSim") << lv->GetName()
+			  << " Light Collection Efficiency " << weight << ":"
+			  << wt1 << " wt2= " << wt2
+			  << " Weighted Energy Deposit " << edep/MeV << " MeV";
 #endif
-    return edep;
-  } 
+  if(wt2 > 0.0) { edep *= wt2; }
+  return edep; 
 }
 
 int ECalSD::getTrackID(const G4Track* aTrack) {
 
   int  primaryID(0);
-  bool flag(false);
-  if (storeTrack) {
-    const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-    if (any(useDepth1,lv)) {
-      flag = true;
-    } else if (any(useDepth2,lv)) {
-      flag = true;
-    }
-  }
-  if (flag) {
+  if (storeTrack && depth > 0) {
     forceSave = true;
     primaryID = aTrack->GetTrackID();
   } else {
@@ -265,17 +233,25 @@ int ECalSD::getTrackID(const G4Track* aTrack) {
 }
 
 uint16_t ECalSD::getDepth(const G4Step * aStep) {
+
+  // this method should be called first at a step
   const G4StepPoint* hitPoint = aStep->GetPreStepPoint();
+  currentLocalPoint = setToLocal(hitPoint->GetPosition(), hitPoint->GetTouchable());
   const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-  uint16_t depth  = any(useDepth1,lv) ? 1 : (any(useDepth2,lv) ? 2 : 0);
+
+  auto ite = xtalLMap.find(lv);
+  crystalLength = (ite == xtalLMap.end()) ? 230.0 : std::abs(ite->second);
+  crystalDepth = (ite == xtalLMap.end()) 
+    ? 0.0 : (std::abs(0.5*(ite->second)+currentLocalPoint.z()));
+  depth = any(useDepth1,lv) ? 1 : (any(useDepth2,lv) ? 2 : 0);
+
   if (storeRL) {
-    auto ite        = xtalLMap.find(lv);
     uint16_t depth1 = (ite == xtalLMap.end()) ? 0 : (((ite->second) >= 0) ? 0 :
                                                      PCaloHit::kEcalDepthRefz);
-    uint16_t depth2 = getRadiationLength(aStep);
+    uint16_t depth2 = getRadiationLength(hitPoint, lv);
     depth          |= (((depth2&PCaloHit::kEcalDepthMask) << PCaloHit::kEcalDepthOffset) | depth1);
   } else if (storeLayerTimeSim) {
-    uint16_t depth2 = getLayerIDForTimeSim(aStep);
+    uint16_t depth2 = getLayerIDForTimeSim();
     depth          |= ((depth2&PCaloHit::kEcalDepthMask) << PCaloHit::kEcalDepthOffset);
   }
 #ifdef EDM_ML_DEBUG
@@ -286,63 +262,41 @@ uint16_t ECalSD::getDepth(const G4Step * aStep) {
   return depth;
 }
 
-uint16_t ECalSD::getRadiationLength(const G4Step * aStep) {
+uint16_t ECalSD::getRadiationLength(const G4StepPoint* hitPoint, const G4LogicalVolume* lv) {
   
   uint16_t thisX0 = 0;
-  if (aStep != nullptr) {
-    const G4StepPoint* hitPoint = aStep->GetPreStepPoint();
-    const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-#ifdef EDM_ML_DEBUG
-    edm::LogInfo("EcalSim") << lv->GetName() << " useWight " << useWeight;
-#endif
-    if (useWeight) {
-      const G4ThreeVector  localPoint = setToLocal(hitPoint->GetPosition(),
-                                                   hitPoint->GetTouchable());
-      double radl     = preStepPoint->GetMaterial()->GetRadlen();
-      double depth    = crystalDepth(lv,localPoint);
-      thisX0 = (uint16_t)floor(scaleRL*depth/radl);
+  if (useWeight) {
+    double radl = hitPoint->GetMaterial()->GetRadlen();
+    thisX0 = (uint16_t)floor(scaleRL*crystalDepth/radl);
 #ifdef plotDebug
-      std::string lvname = lv->GetName();
-      int k1 = (lvname.find("EFRY")!=std::string::npos) ? 2 : 0;
-      int k2 = (lvname.find("refl")!=std::string::npos) ? 1 : 0;
-      int kk = k1+k2;
-      double rz = (k1 == 0) ? (hitPoint->GetPosition()).rho() : 
-        std::abs((hitPoint->GetPosition()).z());
-      edm::LogVerbatim("EcalSim") << lvname << " # " << k1 << ":" << k2 << ":" 
-                                  << kk << " rz " << rz << " D " << thisX0;
-      g2L_[kk]->Fill(rz,thisX0);
+    const std::string& lvname = lv->GetName();
+    int k1 = (lvname.find("EFRY")!=std::string::npos) ? 2 : 0;
+    int k2 = (lvname.find("refl")!=std::string::npos) ? 1 : 0;
+    int kk = k1+k2;
+    double rz = (k1 == 0) ? (hitPoint->GetPosition()).rho() : 
+      std::abs((hitPoint->GetPosition()).z());
+    edm::LogVerbatim("EcalSim") << lvname << " # " << k1 << ":" << k2 << ":" 
+				<< kk << " rz " << rz << " D " << thisX0;
+    g2L_[kk]->Fill(rz,thisX0);
 #endif
 #ifdef EDM_ML_DEBUG
-      double crlength = crystalLength(lv);
-      edm::LogVerbatim("EcalSim") << lv->GetName() << " Global " 
-                                  << hitPoint->GetPosition() << ":" 
-                                  << (hitPoint->GetPosition()).rho() 
-                                  << " Local " << localPoint 
-                                  << " Crystal Length " << crlength 
-                                  << " Radl " << radl << " DetZ " << detz 
-                                  << " Index " << thisX0 
-                                  << " : " << getLayerIDForTimeSim(aStep);
+    edm::LogVerbatim("EcalSim") << lv->GetName() << " Global " 
+				<< hitPoint->GetPosition() << ":" 
+				<< (hitPoint->GetPosition()).rho() 
+				<< " Local " << localPoint 
+				<< " Crystal Length " << crlength 
+				<< " Radl " << radl << " DetZ " << detz 
+				<< " Index " << thisX0 
+				<< " : " << getLayerIDForTimeSim();
 #endif
-    } 
-  }
+  } 
   return thisX0;
 }
 
-uint16_t ECalSD::getLayerIDForTimeSim(const G4Step * aStep) 
+uint16_t ECalSD::getLayerIDForTimeSim() 
 {
-  float    layerSize = 1*cm; //layer size in cm
-  if (!isEB && !isEE)  return 0;
-
-  if (aStep != nullptr ) {
-    const G4StepPoint* hitPoint = aStep->GetPreStepPoint();
-    const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-    const G4ThreeVector  localPoint = setToLocal(hitPoint->GetPosition(),
-                                                 hitPoint->GetTouchable());
-    double detz     = crystalDepth(lv,localPoint);
-    if (detz<0) detz= 0;
-    return (int)detz/layerSize;
-  }
-  return 0;
+  const double layerSize = 10.; //layer size in mm
+  return (int)crystalDepth/layerSize;
 }
 
 uint32_t ECalSD::setDetUnitId(const G4Step * aStep) { 
@@ -482,37 +436,30 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
 #endif
 }
 
-double ECalSD::curve_LY(const G4Step* aStep) {
-
-  const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+double ECalSD::curve_LY(const G4LogicalVolume* lv) {
 
   double weight = 1.;
-  const G4ThreeVector localPoint = setToLocal(preStepPoint->GetPosition(),
-                                              preStepPoint->GetTouchable());
-
-  double crlength = crystalLength(lv);
-  double depth    = crystalDepth(lv,localPoint);
-
   if (ageingWithSlopeLY) {
     //position along the crystal in mm from 0 to 230 (in EB)
-    if (depth >= -0.1 || depth <= crlength+0.1)
-      weight = ageing.calcLightCollectionEfficiencyWeighted(currentID.unitID(), depth/crlength);
+    if (crystalDepth >= -0.1 || crystalDepth <= crystalLength+0.1)
+      weight = ageing.calcLightCollectionEfficiencyWeighted(currentID.unitID(), 
+							    crystalDepth/crystalLength);
   } else {
-    double dapd = crlength - depth;
-    if (dapd >= -0.1 || dapd <= crlength+0.1) {
+    double dapd = crystalLength - crystalDepth;
+    if (dapd >= -0.1 || dapd <= crystalLength+0.1) {
       if (dapd <= 100.)
         weight = 1.0 + slopeLY - dapd * 0.01 * slopeLY;
     } else {
       edm::LogWarning("EcalSim") << "ECalSD: light coll curve : wrong distance "
                                  << "to APD " << dapd << " crlength = " 
-                                 << crlength <<" crystal name = " <<lv->GetName()
-                                 << " z of localPoint = " << localPoint.z() 
+                                 << crystalLength <<" crystal name = " <<lv->GetName()
+                                 << " z of localPoint = " << currentLocalPoint.z() 
                                  << " take weight = " << weight;
     }
   }
   return weight;
 }
-
+/*
 double ECalSD::crystalLength(const G4LogicalVolume* lv) {
 
   auto ite = xtalLMap.find(lv);
@@ -529,11 +476,11 @@ double ECalSD::crystalDepth(const G4LogicalVolume* lv,
 //  (0.5*std::abs(ite->second)+localPoint.z());
   return depth;
 }
-
+*/
 void ECalSD::getBaseNumber(const G4Step* aStep) {
 
   theBaseNumber.reset();
-  const G4VTouchable* touch = preStepPoint->GetTouchable();
+  const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   int theSize = touch->GetHistoryDepth()+1;
   if ( theBaseNumber.getCapacity() < theSize ) theBaseNumber.setSize(theSize);
   //Get name and copy numbers
@@ -552,6 +499,7 @@ void ECalSD::getBaseNumber(const G4Step* aStep) {
 double ECalSD::getBirkL3(const G4Step* aStep) {
 
   double weight = 1.;
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
   double charge = preStepPoint->GetCharge();
 
   if (charge != 0. && aStep->GetStepLength() > 0.) {
@@ -572,7 +520,6 @@ double ECalSD::getBirkL3(const G4Step* aStep) {
 #endif
   }
   return weight;
-
 }
 
 std::vector<double> ECalSD::getDDDArray(const std::string & str,

--- a/SimG4CMS/Calo/src/HGCSD.cc
+++ b/SimG4CMS/Calo/src/HGCSD.cc
@@ -114,16 +114,17 @@ bool HGCSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 #endif
     // Apply fiducial cuts
     if (r/z >= slopeMin_) {
-      if (getStepInfo(aStep)) {
-	if ((storeAllG4Hits_ || (hitExists() == false)) && 
-	    (edepositEM+edepositHAD>0.)) currentHit = createNewHit();
+      bool isKilled(false);
+      if (getStepInfo(aStep, isKilled)) {
+	if ((storeAllG4Hits_ || (hitExists(aStep) == false)) && 
+	    (edepositEM+edepositHAD>0.)) currentHit = createNewHit(aStep);
       }
     }
     return true;
   }
 } 
 
-double HGCSD::getEnergyDeposit(G4Step* aStep) {
+double HGCSD::getEnergyDeposit(const G4Step* aStep, bool&) {
   double wt1    = getResponseWt(aStep->GetTrack());
   double wt2    = aStep->GetTrack()->GetWeight();
   double destep = wt1*(aStep->GetTotalEnergyDeposit());
@@ -244,9 +245,7 @@ uint32_t HGCSD::setDetUnitId (ForwardSubdetector &subdet, int layer, int module,
 }
 
 int HGCSD::setTrackID (const G4Step* aStep) {
-  const G4Track* theTrack    = aStep->GetTrack();
-
-  double etrack = preStepPoint->GetKineticEnergy();
+  const G4Track* theTrack = aStep->GetTrack();
   TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
   int      primaryID = trkInfo->getIDonCaloSurface();
   if (primaryID == 0) {
@@ -257,8 +256,8 @@ int HGCSD::setTrackID (const G4Step* aStep) {
     primaryID = theTrack->GetTrackID();
   }
 
-  if (primaryID != previousID.trackID())
-    resetForNewPrimary(preStepPoint->GetPosition(), etrack);
-
+  if (primaryID != previousID.trackID()) {
+    resetForNewPrimary(aStep);
+  }
   return primaryID;
 }

--- a/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
+++ b/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
@@ -28,7 +28,7 @@ public:
 
 protected:
 
-  G4bool getStepInfo(G4Step* aStep) override;
+  G4bool getStepInfo(const G4Step* aStep, bool&) override;
   void   initRun() override;
 
 private:    

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -82,14 +82,15 @@ bool DreamSD::ProcessHits(G4Step * aStep, G4TouchableHistory *) {
     return true;
   } else {
     side = 1;
-    if (getStepInfo(aStep)) {
-      if (hitExists() == false && edepositEM+edepositHAD>0.)
-        currentHit = createNewHit();
+    bool isKilled(false);
+    if (getStepInfo(aStep, isKilled)) {
+      if (hitExists(aStep) == false && edepositEM+edepositHAD>0.)
+        currentHit = createNewHit(aStep);
       if (readBothSide_) {
 	side = -1;
-	getStepInfo(aStep);
-	if (hitExists() == false && edepositEM+edepositHAD>0.)
-	  currentHit = createNewHit();
+	getStepInfo(aStep, isKilled);
+	if (hitExists(aStep) == false && edepositEM+edepositHAD>0.)
+	  currentHit = createNewHit(aStep);
       }
     }
   }
@@ -98,10 +99,10 @@ bool DreamSD::ProcessHits(G4Step * aStep, G4TouchableHistory *) {
 
 
 //________________________________________________________________________________________
-bool DreamSD::getStepInfo(G4Step* aStep) {
+bool DreamSD::getStepInfo(const G4Step* aStep, bool&) {
 
-  preStepPoint = aStep->GetPreStepPoint();
-  theTrack     = aStep->GetTrack();
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
+  const G4Track* theTrack     = aStep->GetTrack();
   G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
 
   // take into account light collection curve for crystals

--- a/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
+++ b/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
@@ -24,9 +24,12 @@ public:
   EcalTBH4BeamSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 		 edm::ParameterSet const &, const SimTrackManager*);
   ~EcalTBH4BeamSD() override;
-  double getEnergyDeposit(G4Step*) override;
   uint32_t setDetUnitId(const G4Step* step) override;
   void setNumberingScheme(EcalNumberingScheme* scheme);
+
+protected:    
+
+  double getEnergyDeposit(const G4Step*, bool&) override;
 
 private:    
 

--- a/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
+++ b/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
@@ -50,12 +50,12 @@ EcalTBH4BeamSD::~EcalTBH4BeamSD() {
   if (numberingScheme) delete numberingScheme;
 }
 
-double EcalTBH4BeamSD::getEnergyDeposit(G4Step * aStep) {
+double EcalTBH4BeamSD::getEnergyDeposit(const G4Step * aStep, bool&) {
   
   if (aStep == nullptr) {
     return 0;
   } else {
-    preStepPoint        = aStep->GetPreStepPoint();
+    const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
     G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
 
     // take into account light collection curve for crystals

--- a/SimG4CMS/Forward/interface/CastorSD.h
+++ b/SimG4CMS/Forward/interface/CastorSD.h
@@ -34,15 +34,15 @@ public:
   CastorSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog & clg,
 	   edm::ParameterSet const &, const SimTrackManager*);
   ~CastorSD() override;
-  double   getEnergyDeposit(G4Step* ) override;
+  double   getEnergyDeposit(const G4Step*, bool& ) override;
   uint32_t setDetUnitId(const G4Step* step) override;
   void     setNumberingScheme(CastorNumberingScheme* scheme);
 
 private:
 
-  void                    getFromLibrary(G4Step*);
-  int                     setTrackID(G4Step*);
-  uint32_t                rotateUnitID(uint32_t, G4Track*, const CastorShowerEvent&);
+  void                    getFromLibrary(const G4Step*, bool&);
+  int                     setTrackID(const G4Step*);
+  uint32_t                rotateUnitID(uint32_t, const G4Track*, const CastorShowerEvent&);
   CastorNumberingScheme * numberingScheme;
   CastorShowerLibrary *   showerLibrary;
   G4LogicalVolume         *lvC3EF, *lvC3HF, *lvC4EF, *lvC4HF;

--- a/SimG4CMS/Forward/interface/CastorShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/CastorShowerLibrary.h
@@ -40,7 +40,7 @@ public:
 public:
 
   void                initParticleTable(G4ParticleTable *);
-  CastorShowerEvent   getShowerHits(G4Step*, bool&);
+  CastorShowerEvent   getShowerHits(const G4Step*, bool&);
   int                 FindEnergyBin(double);
   int                 FindEtaBin(double);
   int                 FindPhiBin(double);

--- a/SimG4CMS/Forward/interface/ZdcSD.h
+++ b/SimG4CMS/Forward/interface/ZdcSD.h
@@ -9,7 +9,6 @@
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 #include "SimG4CMS/Forward/interface/ZdcShowerLibrary.h"
 #include "SimG4CMS/Forward/interface/ZdcNumberingScheme.h"
-#undef debug
 
 class ZdcSD : public CaloSD {
 
@@ -17,10 +16,10 @@ public:
   ZdcSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	edm::ParameterSet const &,const SimTrackManager*);
  
-  ~ZdcSD() override;
-  bool ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
+  ~ZdcSD() = default;
+  G4bool ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
   uint32_t setDetUnitId(const G4Step* step) override;
-  double getEnergyDeposit(const G4Step*, edm::ParameterSet const &);
+  double getEnergyDeposit(const G4Step*, bool&);
  
   void setNumberingScheme(ZdcNumberingScheme* scheme);
   void getFromLibrary(G4Step * step);
@@ -31,12 +30,12 @@ private:
 
   int verbosity;
   bool  useShowerLibrary,useShowerHits; 
-  int   setTrackID(G4Step * step);
+  int   setTrackID(const G4Step * step);
   double thFibDir;
   double zdcHitEnergyCut;
-  ZdcShowerLibrary *    showerLibrary;
-  ZdcNumberingScheme * numberingScheme;
 
+  std::unique_ptr<ZdcShowerLibrary>   showerLibrary;
+  std::unique_ptr<ZdcNumberingScheme> numberingScheme;
   std::vector<ZdcShowerLibrary::Hit> hits;
 
 };

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -41,8 +41,10 @@ CastorSD::CastorSD(const std::string& name, const DDCompactView & cpv,
 	  
   non_compensation_factor = m_CastorSD.getParameter<double>("nonCompensationFactor");
   
-  if (useShowerLibrary) showerLibrary = new CastorShowerLibrary(name, p);
-  
+  if (useShowerLibrary) {
+    showerLibrary = new CastorShowerLibrary(name, p);
+    setParameterized(true);
+  }
   setNumberingScheme(new CastorNumberingScheme());
   
   edm::LogInfo("ForwardSim") 
@@ -91,7 +93,7 @@ void CastorSD::initRun(){
 
 //=============================================================================================
 
-double CastorSD::getEnergyDeposit(G4Step * aStep) {
+double CastorSD::getEnergyDeposit(const G4Step * aStep, bool& isKilled) {
   
   double NCherPhot = 0.;
 
@@ -100,13 +102,13 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
 
   // preStepPoint information *********************************************
   
-  G4StepPoint*       preStepPoint = aStep->GetPreStepPoint();
-  G4VPhysicalVolume* currentPV    = preStepPoint->GetPhysicalVolume();
-  G4LogicalVolume*   currentLV    = currentPV->GetLogicalVolume();
+  const G4StepPoint*       preStepPoint = aStep->GetPreStepPoint();
+  const G4VPhysicalVolume* currentPV    = preStepPoint->GetPhysicalVolume();
+  const G4LogicalVolume*   currentLV    = currentPV->GetLogicalVolume();
 
 #ifdef debugLog
-  G4String           name   = currentPV->GetName();
-  std::string        nameVolume;
+  auto const & name   = currentPV->GetName();
+  std::string nameVolume;
   nameVolume.assign(name,0,4);
 
   G4SteppingControl  stepControlFlag = aStep->GetControlFlag();
@@ -205,7 +207,7 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   if (useShowerLibrary && particleWithinShowerLibrary) {
     // Use Castor shower library if energy is above threshold, is not a muon 
     // and is not moving backward 
-    getFromLibrary(aStep);
+    getFromLibrary(aStep, isKilled);
     
 #ifdef debugLog
     LogDebug("ForwardSim") << " Current logical volume is " << nameVolume ;
@@ -252,8 +254,8 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   
 #ifdef debugLog
   // postStepPoint information *********************************************
-  G4StepPoint* postStepPoint= aStep->GetPostStepPoint();   
-  G4VPhysicalVolume* postPV= postStepPoint->GetPhysicalVolume();
+  const G4StepPoint* postStepPoint= aStep->GetPostStepPoint();   
+  const G4VPhysicalVolume* postPV= postStepPoint->GetPhysicalVolume();
   
   G4String           postname   = postPV->GetName();
   std::string        postnameVolume;
@@ -544,9 +546,9 @@ void CastorSD::setNumberingScheme(CastorNumberingScheme* scheme) {
 
 //=======================================================================================
 
-int CastorSD::setTrackID (G4Step* aStep) {
+int CastorSD::setTrackID (const G4Step* aStep) {
 
-  theTrack     = aStep->GetTrack();
+  const G4Track* theTrack = aStep->GetTrack();
 
   TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
   int      primaryID = trkInfo->getIDonCaloSurface();
@@ -559,8 +561,7 @@ int CastorSD::setTrackID (G4Step* aStep) {
   }
 
   if (primaryID != previousID.trackID()) {
-    double etrack = preStepPoint->GetKineticEnergy();
-    resetForNewPrimary(preStepPoint->GetPosition(), etrack);
+    resetForNewPrimary(aStep);
   }
 
   return primaryID;
@@ -568,7 +569,7 @@ int CastorSD::setTrackID (G4Step* aStep) {
 
 //=======================================================================================
 
-uint32_t CastorSD::rotateUnitID(uint32_t unitID, G4Track* track, const CastorShowerEvent& shower) {
+uint32_t CastorSD::rotateUnitID(uint32_t unitID, const G4Track* track, const CastorShowerEvent& shower) {
 // ==============================================================
 //
 //   o   Exploit Castor phi symmetry to return newUnitID for  
@@ -633,7 +634,7 @@ uint32_t CastorSD::rotateUnitID(uint32_t unitID, G4Track* track, const CastorSho
 
 //=======================================================================================
 
-void CastorSD::getFromLibrary (G4Step* aStep) {
+void CastorSD::getFromLibrary (const G4Step* aStep, bool& isKilled) {
 
 /////////////////////////////////////////////////////////////////////
 //
@@ -646,20 +647,16 @@ void CastorSD::getFromLibrary (G4Step* aStep) {
 //
 /////////////////////////////////////////////////////////////////////
 
-  preStepPoint  = aStep->GetPreStepPoint(); 
-  theTrack      = aStep->GetTrack();   
-  bool ok;
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
+  const G4Track* theTrack = aStep->GetTrack();   
   
   // ****    Call method to retrieve hits from the ShowerLibrary   ****
-  CastorShowerEvent hits = showerLibrary->getShowerHits(aStep, ok);
+  CastorShowerEvent hits = showerLibrary->getShowerHits(aStep, isKilled);
 
-  double etrack    = preStepPoint->GetKineticEnergy();
   int    primaryID = setTrackID(aStep);
-  // int    primaryID = theTrack->GetTrackID();
 
   // Reset entry point for new primary
-  posGlobal = preStepPoint->GetPosition();
-  resetForNewPrimary(posGlobal, etrack);
+  resetForNewPrimary(aStep);
 
   // Check whether track is EM or HAD
   G4int particleCode = theTrack->GetDefinition()->GetPDGEncoding();
@@ -743,35 +740,8 @@ void CastorSD::getFromLibrary (G4Step* aStep) {
     if (currentID == previousID) {
       updateHit(currentHit);
     } else {
-      if (!checkHit()) currentHit = createNewHit();
+      if (!checkHit()) currentHit = createNewHit(aStep);
     }
   }  //  End of loop over hits
-
-  //Now kill the current track
-  if (ok) {
-    theTrack->SetTrackStatus(fStopAndKill);
-#ifdef debugLog
-    LogDebug("ForwardSim") << "CastorSD::getFromLibrary:"
-			   << "\n \"theTrack\" with TrackID() = " 
-			   << theTrack->GetTrackID() 
-			   << " and with energy " 
-			   << theTrack->GetTotalEnergy()
-			   << " has been set to be killed" ;
-#endif
-    G4TrackVector tv = *(aStep->GetSecondary());
-    for (unsigned int kk=0; kk<tv.size(); kk++) {
-      if (tv[kk]->GetVolume() == preStepPoint->GetPhysicalVolume()) {
-	tv[kk]->SetTrackStatus(fStopAndKill);
-#ifdef debugLog
-	LogDebug("ForwardSim") << "CastorSD::getFromLibrary:"
-			       << "\n tv[" << kk << "]->GetTrackID() = " 
-			       << tv[kk]->GetTrackID() 
-			       << " with energy " 
-			       << tv[kk]->GetTotalEnergy()
-			       << " has been set to be killed" ;
-#endif
-      }
-    }
-  }
 }
 

--- a/SimG4CMS/Forward/src/CastorShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/CastorShowerLibrary.cc
@@ -209,10 +209,10 @@ void CastorShowerLibrary::initParticleTable(G4ParticleTable * theParticleTable) 
 
 //=============================================================================================
 
-CastorShowerEvent CastorShowerLibrary::getShowerHits(G4Step * aStep, bool & ok) {
+CastorShowerEvent CastorShowerLibrary::getShowerHits(const G4Step * aStep, bool & ok) {
 
-  G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
-  G4Track *     track         = aStep->GetTrack();
+  const G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
+  const G4Track *     track         = aStep->GetTrack();
 
   const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
   G4String      partType = track->GetDefinition()->GetParticleName();
@@ -221,7 +221,6 @@ CastorShowerEvent CastorShowerLibrary::getShowerHits(G4Step * aStep, bool & ok) 
   CastorShowerEvent hit;
   hit.Clear();
   
-  ok = false;
   if (parCode == pi0PDG   || parCode == etaPDG    || parCode == nuePDG  ||
       parCode == numuPDG  || parCode == nutauPDG  || parCode == anuePDG ||
       parCode == anumuPDG || parCode == anutauPDG || parCode == geantinoPDG) 

--- a/SimG4CMS/Forward/src/ZdcSD.cc
+++ b/SimG4CMS/Forward/src/ZdcSD.cc
@@ -23,17 +23,16 @@
 ZdcSD::ZdcSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg,
 	     edm::ParameterSet const & p,const SimTrackManager* manager) : 
-  CaloSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
+  CaloSD(name, cpv, clg, p, manager){
   edm::ParameterSet m_ZdcSD = p.getParameter<edm::ParameterSet>("ZdcSD");
   useShowerLibrary = m_ZdcSD.getParameter<bool>("UseShowerLibrary");
   useShowerHits    = m_ZdcSD.getParameter<bool>("UseShowerHits");
   zdcHitEnergyCut  = m_ZdcSD.getParameter<double>("ZdcHitEnergyCut")*GeV;
+  thFibDir   = m_ZdcSD.getParameter<double>("FiberDirection");
   verbosity  = m_ZdcSD.getParameter<int>("Verbosity");
   int verbn  = verbosity/10;
   verbosity %= 10;
-  ZdcNumberingScheme* scheme;
-  scheme = new ZdcNumberingScheme(verbn);
-  setNumberingScheme(scheme);
+  setNumberingScheme(new ZdcNumberingScheme(verbn));
   
   edm::LogInfo("ForwardSim")
     << "***************************************************\n"
@@ -54,28 +53,22 @@ ZdcSD::ZdcSD(const std::string& name, const DDCompactView & cpv,
      <<" (GeV)";
   
   if(useShowerLibrary){
-    showerLibrary = new ZdcShowerLibrary(name, cpv, p);
+    showerLibrary.reset(new ZdcShowerLibrary(name, cpv, p));
+    setParameterized(true);
+  } else {
+    showerLibrary.reset(nullptr);
   }
-}
-
-ZdcSD::~ZdcSD() {
-  
-  if(numberingScheme) delete numberingScheme;
-  if(showerLibrary)delete showerLibrary;
-
-  edm::LogInfo("ForwardSim") 
-    <<"end of ZdcSD\n";
 }
 
 void ZdcSD::initRun(){
   if(useShowerLibrary){
     G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
-    showerLibrary->initRun(theParticleTable); 
+    showerLibrary.get()->initRun(theParticleTable); 
   }
   hits.clear();  
 }
 
-bool ZdcSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
+G4bool ZdcSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
   NaNTrap( aStep ) ;
 
@@ -86,9 +79,10 @@ bool ZdcSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
       getFromLibrary(aStep);
     }
     if(useShowerHits){
-      if (getStepInfo(aStep)) {
-	if (hitExists() == false && edepositEM+edepositHAD>0.)
-	  currentHit = CaloSD::createNewHit();
+      bool yes(false);
+      if (getStepInfo(aStep, yes)) {
+	if (hitExists(aStep) == false && edepositEM+edepositHAD>0.)
+	  currentHit = CaloSD::createNewHit(aStep);
       }
     }
   }
@@ -98,26 +92,16 @@ bool ZdcSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 void ZdcSD::getFromLibrary (G4Step* aStep) {
   bool ok = true;
 
-  preStepPoint  = aStep->GetPreStepPoint(); 
-  theTrack      = aStep->GetTrack();   
+  auto const preStepPoint  = aStep->GetPreStepPoint(); 
+  G4Track* theTrack = aStep->GetTrack();   
 
-  double etrack    = preStepPoint->GetKineticEnergy();
-  int primaryID = setTrackID(aStep);  
+  double etrack = preStepPoint->GetKineticEnergy();
+  int primaryID = getTrackID(theTrack);  
 
   hits.clear();
-
-  /*
-    if (etrack >= zdcHitEnergyCut) {
-    primaryID    = theTrack->GetTrackID();
-    } else {
-    primaryID    = theTrack->GetParentID();
-    if (primaryID == 0) primaryID = theTrack->GetTrackID();
-    }
-  */
     
   // Reset entry point for new primary
-  posGlobal = preStepPoint->GetPosition();
-  resetForNewPrimary(posGlobal, etrack);
+  resetForNewPrimary(aStep);
 
   if (etrack >= zdcHitEnergyCut){
     // create hits only if above threshold
@@ -130,9 +114,9 @@ void ZdcSD::getFromLibrary (G4Step* aStep) {
       << "ZdcSD::getFromLibrary " <<hits.size() <<" hits for "
       << GetName() << " of " << primaryID << " with " 
       << theTrack->GetDefinition()->GetParticleName() << " of " 
-      << preStepPoint->GetKineticEnergy()<< " MeV\n"; 
+      << etrack<< " MeV\n"; 
     
-    hits.swap(showerLibrary->getHits(aStep, ok));    
+    hits.swap(showerLibrary.get()->getHits(aStep, ok));    
   }
  
   entrancePoint = preStepPoint->GetPosition();
@@ -149,7 +133,7 @@ void ZdcSD::getFromLibrary (G4Step* aStep) {
     if (currentID == previousID) {
       updateHit(currentHit);	
     } else {
-      currentHit = createNewHit();
+      currentHit = createNewHit(aStep);
     }
       
     //  currentHit->setPosition(hitPoint.x(),hitPoint.y(),hitPoint.z());
@@ -179,7 +163,7 @@ void ZdcSD::getFromLibrary (G4Step* aStep) {
   }
 }
 
-double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p ) {
+double ZdcSD::getEnergyDeposit(const G4Step * aStep, bool&) {
 
   float NCherPhot = 0.;
   //std::cout<<"I go through here"<<std::endl;
@@ -199,12 +183,6 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p
     G4double           stepL = aStep->GetStepLength()/cm;
     G4double           beta     = preStepPoint->GetBeta();
     G4double           charge   = preStepPoint->GetCharge();
-
-    // G4VProcess*        curprocess   = preStepPoint->GetProcessDefinedStep();
-    // G4String           namePr   = preStepPoint->GetProcessDefinedStep()->GetProcessName();
-    // G4LogicalVolume*   lv    = currentPV->GetLogicalVolume();
-    // G4Material*        mat   = lv->GetMaterial();
-    // G4double           rad   = mat->GetRadlen();
 
     // postStepPoint information
     G4StepPoint* postStepPoint = aStep->GetPostStepPoint();   
@@ -260,9 +238,6 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p
       float thFullRefl = 23.;
       float thFullReflRad = thFullRefl*pi/180.;
 
-      edm::ParameterSet m_ZdcSD = p.getParameter<edm::ParameterSet>("ZdcSD");
-      thFibDir  = m_ZdcSD.getParameter<double>("FiberDirection");
-      //float thFibDir = 90.;
       float thFibDirRad = thFibDir*pi/180.;
 
       // at which theta the point is located:
@@ -409,21 +384,19 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p
 }
 
 uint32_t ZdcSD::setDetUnitId(const G4Step* aStep) {
-  return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
+  return (numberingScheme.get() == nullptr ? 0 : numberingScheme.get()->getUnitID(aStep));
 }
 
 void ZdcSD::setNumberingScheme(ZdcNumberingScheme* scheme) {
   if (scheme != nullptr) {
     edm::LogInfo("ForwardSim") << "ZdcSD: updates numbering scheme for " 
 			       << GetName();
-    if (numberingScheme) delete numberingScheme;
-    numberingScheme = scheme;
+    numberingScheme.reset(scheme);
   }
 }
 
-int ZdcSD::setTrackID (G4Step* aStep) {
-  theTrack     = aStep->GetTrack();
-  double etrack = preStepPoint->GetKineticEnergy();
+int ZdcSD::setTrackID (const G4Step* aStep) {
+  const G4Track* theTrack = aStep->GetTrack();
   TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
   int primaryID = trkInfo->getIDonCaloSurface();
   if (primaryID == 0) {
@@ -433,7 +406,8 @@ int ZdcSD::setTrackID (G4Step* aStep) {
 #endif
     primaryID = theTrack->GetTrackID();
     }
-  if (primaryID != previousID.trackID())
-      resetForNewPrimary(preStepPoint->GetPosition(), etrack); 
+  if (primaryID != previousID.trackID()) {
+      resetForNewPrimary(aStep); 
+  }
   return primaryID;
 }

--- a/SimG4CMS/HGCalTestBeam/interface/AHCalSD.h
+++ b/SimG4CMS/HGCalTestBeam/interface/AHCalSD.h
@@ -3,7 +3,6 @@
 
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 
-#include "G4String.hh"
 #include <map>
 #include <string>
 
@@ -15,13 +14,13 @@ public:
 
   AHCalSD(const std::string& , const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
-  ~AHCalSD() override;
-  double                getEnergyDeposit(G4Step* ) override;
+  ~AHCalSD() = default;
   uint32_t              setDetUnitId(const G4Step* step) override;
   bool                  unpackIndex(const uint32_t & idx, int & row, 
 				    int& col, int& depth);
 protected:
 
+  double                getEnergyDeposit(const G4Step*, bool& ) override;
   bool                  filterHit(CaloG4Hit*, double) override;
 
 private:    

--- a/SimG4CMS/HGCalTestBeam/interface/HGCalTB16SD01.h
+++ b/SimG4CMS/HGCalTestBeam/interface/HGCalTB16SD01.h
@@ -8,8 +8,6 @@
 
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 
-#include "G4String.hh"
-
 #include <string>
 
 class DDCompactView;
@@ -23,12 +21,15 @@ public:
   HGCalTB16SD01(const std::string& , const DDCompactView &, 
 		const SensitiveDetectorCatalog &, edm::ParameterSet const &, 
 		const SimTrackManager*);
-  ~HGCalTB16SD01() override;
-  double   getEnergyDeposit(G4Step* ) override;
+  ~HGCalTB16SD01() = default;
   uint32_t setDetUnitId(const G4Step* step) override;
   static uint32_t  packIndex(int det, int lay, int x, int y);
   static void      unpackIndex(const uint32_t & idx, int& det, int& lay,
 			       int& x, int& y);
+
+protected:
+
+  double           getEnergyDeposit(const G4Step*, bool& ) override;
 
 private:    
   void             initialize(const G4StepPoint* point);

--- a/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
@@ -38,9 +38,7 @@ AHCalSD::AHCalSD(const std::string& name, const DDCompactView & cpv,
                           << eminHit << std::endl;
 }
 
-AHCalSD::~AHCalSD() { }
-
-double AHCalSD::getEnergyDeposit(G4Step* aStep) {
+double AHCalSD::getEnergyDeposit(const G4Step* aStep, bool&) {
 
   double destep = aStep->GetTotalEnergyDeposit();
   double wt2    = aStep->GetTrack()->GetWeight();
@@ -59,7 +57,7 @@ double AHCalSD::getEnergyDeposit(G4Step* aStep) {
 
 uint32_t AHCalSD::setDetUnitId(const G4Step * aStep) { 
 
-  G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
 
   int depth = (touch->GetReplicaNumber(1));

--- a/SimG4CMS/HGCalTestBeam/src/HGCalTB16SD01.cc
+++ b/SimG4CMS/HGCalTestBeam/src/HGCalTB16SD01.cc
@@ -42,11 +42,9 @@ HGCalTB16SD01::HGCalTB16SD01(const std::string& name, const DDCompactView & cpv,
 			 << ", C1 = " << birk2_ << ", C2 = " << birk3_;
 }
 
-HGCalTB16SD01::~HGCalTB16SD01() {}
+double HGCalTB16SD01::getEnergyDeposit(const G4Step* aStep, bool&) {
 
-double HGCalTB16SD01::getEnergyDeposit(G4Step* aStep) {
-
-  G4StepPoint* point = aStep->GetPreStepPoint();
+  auto const point = aStep->GetPreStepPoint();
   if (initialize_) initialize(point);
   double destep = aStep->GetTotalEnergyDeposit();
   double wt2    = aStep->GetTrack()->GetWeight();
@@ -65,9 +63,8 @@ double HGCalTB16SD01::getEnergyDeposit(G4Step* aStep) {
 
 uint32_t HGCalTB16SD01::setDetUnitId(const G4Step * aStep) { 
 
-  G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
-  G4String name             = preStepPoint->GetPhysicalVolume()->GetName();
 
   int det(1), x(0), y(0);
   int lay = (touch->GetReplicaNumber(0));

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
@@ -32,15 +32,18 @@ public:
   HcalTB02SD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	     edm::ParameterSet const &, const SimTrackManager*);
   ~HcalTB02SD() override;
-  double getEnergyDeposit(G4Step*) override;
   uint32_t setDetUnitId(const G4Step* step) override;
   void setNumberingScheme(HcalTB02NumberingScheme* scheme);
+
+protected:
+
+  double getEnergyDeposit(const G4Step*, bool&) override;
 
 private:    
 
   void   initMap(const std::string&, const DDCompactView &);
-  double curve_LY(G4String& , G4StepPoint* ); 
-  double crystalLength(G4String);
+  double curve_LY(const G4String& , const G4StepPoint* ); 
+  double crystalLength(const G4String&);
 
 private:    
 

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
@@ -25,8 +25,11 @@ public:
                  const SensitiveDetectorCatalog &,
 		 edm::ParameterSet const &, const SimTrackManager*);
   ~HcalTB06BeamSD() override;
-  double getEnergyDeposit(G4Step* ) override;
   uint32_t setDetUnitId(const G4Step* step) override;
+
+protected:
+
+  double getEnergyDeposit(const G4Step*, bool& ) override;
 
 private:    
 

--- a/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
@@ -84,13 +84,13 @@ HcalTB02SD::~HcalTB02SD() {
 // member functions
 //
  
-double HcalTB02SD::getEnergyDeposit(G4Step * aStep) {
+double HcalTB02SD::getEnergyDeposit(const G4Step * aStep, bool&) {
   
   if (aStep == nullptr) {
     return 0;
   } else {
-    preStepPoint        = aStep->GetPreStepPoint();
-    G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
+    auto const preStepPoint = aStep->GetPreStepPoint();
+    auto const & nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
 
     // take into account light collection curve for crystals
     double weight = 1.;
@@ -148,7 +148,7 @@ void HcalTB02SD::initMap(const std::string& sd, const DDCompactView & cpv) {
   }
 }
 
-double HcalTB02SD::curve_LY(G4String& nameVolume, G4StepPoint* stepPoint) {
+double HcalTB02SD::curve_LY(const G4String& nameVolume, const G4StepPoint* stepPoint) {
 
   double weight = 1.;
   G4ThreeVector  localPoint = setToLocal(stepPoint->GetPosition(),
@@ -173,7 +173,7 @@ double HcalTB02SD::curve_LY(G4String& nameVolume, G4StepPoint* stepPoint) {
   return weight;
 }
 
-double HcalTB02SD::crystalLength(G4String name) {
+double HcalTB02SD::crystalLength(const G4String& name) {
 
   double length = 230.;
   std::map<G4String,double>::const_iterator it = lengthMap.find(name);

--- a/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
@@ -93,7 +93,7 @@ HcalTB06BeamSD::HcalTB06BeamSD(const std::string& name, const DDCompactView & cp
 
 HcalTB06BeamSD::~HcalTB06BeamSD() {}
 
-double HcalTB06BeamSD::getEnergyDeposit(G4Step* aStep) {
+double HcalTB06BeamSD::getEnergyDeposit(const G4Step* aStep, bool&) {
 
   double destep = aStep->GetTotalEnergyDeposit();
   double weight = 1;

--- a/SimG4Core/Notification/interface/G4TrackToParticleID.h
+++ b/SimG4Core/Notification/interface/G4TrackToParticleID.h
@@ -4,14 +4,17 @@
 class G4Track;
 
 /**
- * Converts G4Track to particle ID. For PDG Particles it is the obvious number; for alpha, triton and deuteron 
- * the CMS convention is used
+ * Converts G4Track to particle ID. For PDG Particles it is the obvious number; 
+ * for alpha, triton and deuteron the CMS convention is used
  */
 
 class G4TrackToParticleID
 {
 public:
-  static int particleID(const G4Track *);
+  static int  particleID(const G4Track *);
+  static bool isGammaElectronPositron(const G4Track *);
+  static bool isMuon(const G4Track *);
+  static bool isStableHadron(const G4Track *);
 };
 
 #endif

--- a/SimG4Core/Notification/src/G4TrackToParticleID.cc
+++ b/SimG4Core/Notification/src/G4TrackToParticleID.cc
@@ -9,8 +9,26 @@ int G4TrackToParticleID::particleID(const G4Track * g4trk)
     int particleID_ = g4trk->GetDefinition()->GetPDGEncoding();
     if (0 == particleID_) {
       edm::LogWarning("SimG4CoreNotification") 
-	<< "G4TrackToParticleID: unknown code for track Id = " << g4trk->GetTrackID();
+	<< "G4TrackToParticleID: unknown code 0 for track Id = " << g4trk->GetTrackID();
       particleID_ = -99;
     }
     return particleID_;
+}
+
+bool G4TrackToParticleID::isGammaElectronPositron(const G4Track * g4trk)
+{
+  int pdg = std::abs(g4trk->GetDefinition()->GetPDGEncoding());
+  return (pdg == 11 || pdg == 22);
+}
+
+bool G4TrackToParticleID::isMuon(const G4Track * g4trk)
+{
+  return (std::abs(g4trk->GetDefinition()->GetPDGEncoding()) == 13);
+}
+
+bool G4TrackToParticleID::isStableHadron(const G4Track * g4trk)
+{
+  // is pi+-, p, pbar, n, nbar, KL, K+-, 
+  int pdg = std::abs(g4trk->GetDefinition()->GetPDGEncoding());
+  return (pdg == 211 || pdg == 2212 || pdg == 2112 || pdg == 130 || pdg == 321);
 }


### PR DESCRIPTION
This PR is made instead of #21767 Geant4 calorimeter sensitive detectors are updated:
1) use const G4Step* pointer in protected and private interfaces where possible
2) use std::unique_ptr in several places
3) optimized ECalSD run time methods - perform one search over map of logical volumes instead of 3
4) use const pointers and references 
5) removed old commented lines

Results should be unchanged. Clean-up is not yet completed, an extra iteration is needed.  