### PR TITLE
Phase2 era from run3

### DIFF
--- a/Configuration/Eras/python/Era_Phase2_cff.py
+++ b/Configuration/Eras/python/Era_Phase2_cff.py
@@ -1,23 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Modifier_run2_common_cff import run2_common
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
+from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 from Configuration.Eras.Modifier_phase2_ecal_cff import phase2_ecal
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
-from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
-from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
-from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
-from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
 
-Phase2 = cms.ModifierChain(run2_common, run3_common, phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal,
-    run2_HE_2017, run2_HF_2017, run2_HCAL_2017, run3_HB, phase2_hcal, phase2_hgcal, phase2_muon, run3_GEM, stage2L1Trigger,
-    hcalHardcodeConditions,
-)
+Phase2 = cms.ModifierChain(Run3, phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon)

--- a/Configuration/Eras/python/Era_Phase2_cff.py
+++ b/Configuration/Eras/python/Era_Phase2_cff.py
@@ -8,5 +8,7 @@ from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 
-Phase2 = cms.ModifierChain(Run3, phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon)
+Phase2 = cms.ModifierChain(Run3.copyAndExclude([phase1Pixel,trackingPhase1]), phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon)


### PR DESCRIPTION
Now that 2018 and 2019/Run3 scenarios are actively being developed, the Phase2 Era should inherit from Run3 in order to stay consistent with the latest changes.

However, to avoid potential confusion, I excluded the Phase1 pixel & tracking eras from Phase2. @boudoul @makortel @VinInn can you confirm that this is the right thing?

Some changes are expected in Phase2 workflows due to the 10TS->8TS change in HB.
  