### PR TITLE
CaloTowers: adding separate HES/HED depth1 cut

### DIFF
--- a/RecoLocalCalo/CaloTowersCreator/interface/CaloTowersCreationAlgo.h
+++ b/RecoLocalCalo/CaloTowersCreator/interface/CaloTowersCreationAlgo.h
@@ -59,7 +59,9 @@ public:
     bool useSymEBTreshold, bool useSymEETreshold,				    
 
     double HcalThreshold,
-    double HBthreshold, double HESthreshold, double HEDthreshold,
+    double HBthreshold, 
+    double HESthreshold, double HESthreshold1,
+    double HEDthreshold, double HEDthreshold1, 
     double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
     double HOthresholdPlus2, double HOthresholdMinus2,
     double HF1threshold, double HF2threshold, 
@@ -82,7 +84,9 @@ public:
     bool useSymEBTreshold, bool useSymEETreshold,
 
     double HcalThreshold,
-    double HBthreshold, double HESthreshold, double HEDthreshold,
+    double HBthreshold, 
+    double HESthreshold, double HESthreshold1,
+    double HEDthreshold, double HEDthreshold1,
     double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
     double HOthresholdPlus2, double HOthresholdMinus2, 
     double HF1threshold, double HF2threshold,
@@ -250,7 +254,9 @@ private:
   
   double  theHcalThreshold;
 
-  double theHBthreshold, theHESthreshold,  theHEDthreshold; 
+  double theHBthreshold;
+  double theHESthreshold, theHESthreshold1; 
+  double theHEDthreshold, theHEDthreshold1; 
   double theHOthreshold0, theHOthresholdPlus1, theHOthresholdMinus1;
   double theHOthresholdPlus2, theHOthresholdMinus2, theHF1threshold, theHF2threshold;
   std::vector<double> theEBGrid, theEBWeights;

--- a/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
+++ b/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
@@ -65,7 +65,8 @@ calotowermaker = cms.EDProducer("CaloTowersCreator",
     HF2Threshold = cms.double(0.85),
 
     # Energy threshold for 5-degree (phi) HE cell inclusion [GeV]
-    HESThreshold = cms.double(0.8),
+    HESThreshold1 = cms.double(0.8), # depth  1    
+    HESThreshold  = cms.double(0.8), # depths 2-7
     HF1Weights = cms.vdouble(1.0, 1.0, 1.0, 1.0, 1.0),
     # Label of HORecHitCollection to use
     hoInput = cms.InputTag("horeco"),
@@ -73,7 +74,8 @@ calotowermaker = cms.EDProducer("CaloTowersCreator",
     #
     HESWeights = cms.vdouble(1.0, 1.0, 1.0, 1.0, 1.0),
     # Energy threshold for 10-degree (phi) HE cel inclusion [GeV]
-    HEDThreshold = cms.double(0.8),
+    HEDThreshold1 = cms.double(0.8), # depth  1  
+    HEDThreshold  = cms.double(0.8), # depths 2-7
     # Global energy threshold on tower [GeV]
     EcutTower = cms.double(-1000.0),
     HEDGrid = cms.vdouble(-1.0, 1.0, 10.0, 100.0, 1000.0),
@@ -144,4 +146,10 @@ calotowermaker = cms.EDProducer("CaloTowersCreator",
 )
 
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
-run2_HE_2018.toModify(calotowermaker, HcalPhase = cms.int32(1))
+run2_HE_2018.toModify(calotowermaker, 
+                      HcalPhase = cms.int32(1),
+                      HESThreshold1 = cms.double(0.1),
+                      HESThreshold  = cms.double(0.2),
+                      HEDThreshold1 = cms.double(0.1),
+                      HEDThreshold  = cms.double(0.2)
+)

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -24,7 +24,9 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo()
    theHcalThreshold(-1000.),
    theHBthreshold(-1000.),
    theHESthreshold(-1000.),
+   theHESthreshold1(-1000.),
    theHEDthreshold(-1000.),
+   theHEDthreshold1(-1000.),
    theHOthreshold0(-1000.),  
    theHOthresholdPlus1(-1000.),   
    theHOthresholdMinus1(-1000.),  
@@ -96,7 +98,9 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
 					       bool useSymEETreshold,				    
 
 					       double HcalThreshold,
-					       double HBthreshold, double HESthreshold, double  HEDthreshold,
+					       double HBthreshold, 
+                                               double HESthreshold, double HESthreshold1, 
+                                               double HEDthreshold, double HEDthreshold1,
 					       double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
 					       double HOthresholdPlus2, double HOthresholdMinus2, 
 					       double HF1threshold, double HF2threshold,
@@ -124,7 +128,9 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
     theHcalThreshold(HcalThreshold),
     theHBthreshold(HBthreshold),
     theHESthreshold(HESthreshold),
+    theHESthreshold1(HESthreshold1),
     theHEDthreshold(HEDthreshold),
+    theHEDthreshold1(HEDthreshold1),
     theHOthreshold0(HOthreshold0), 
     theHOthresholdPlus1(HOthresholdPlus1),
     theHOthresholdMinus1(HOthresholdMinus1),
@@ -195,7 +201,9 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
        bool useSymEETreshold,
 
        double HcalThreshold,
-       double HBthreshold, double HESthreshold, double  HEDthreshold,
+       double HBthreshold, 
+       double HESthreshold, double HESthreshold1, 
+       double HEDthreshold, double HEDthreshold1,
        double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
        double HOthresholdPlus2, double HOthresholdMinus2,  
        double HF1threshold, double HF2threshold,
@@ -231,7 +239,9 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
     theHcalThreshold(HcalThreshold),
     theHBthreshold(HBthreshold),
     theHESthreshold(HESthreshold),
+    theHESthreshold1(HESthreshold1),
     theHEDthreshold(HEDthreshold),
+    theHEDthreshold1(HEDthreshold1),
     theHOthreshold0(HOthreshold0), 
     theHOthresholdPlus1(HOthresholdPlus1),
     theHOthresholdMinus1(HOthresholdMinus1),
@@ -1218,7 +1228,8 @@ void CaloTowersCreationAlgo::getThresholdAndWeight(const DetId & detId, double &
   else if(det == DetId::Hcal) {
     HcalDetId hcalDetId(detId);
     HcalSubdetector subdet = hcalDetId.subdet();
-    
+    int depth =  hcalDetId.depth();   
+
     if(subdet == HcalBarrel) {
       threshold = theHBthreshold;
       weight = theHBweight;
@@ -1231,15 +1242,15 @@ void CaloTowersCreationAlgo::getThresholdAndWeight(const DetId & detId, double &
     else if(subdet == HcalEndcap) {
       // check if it's single or double tower
       if(hcalDetId.ietaAbs() < theHcalTopology->firstHEDoublePhiRing()) {
-        threshold = theHESthreshold;
+        threshold = (depth == 1) ? theHESthreshold1 : theHESthreshold;
         weight = theHESweight;
         if (weight <= 0.) {
           ROOT::Math::Interpolator my(theHESGrid,theHESWeights,ROOT::Math::Interpolation::kAKIMA);
           weight = my.Eval(theHESEScale);
         }
       }
-      else {
-        threshold = theHEDthreshold;
+      else {        
+        threshold = (depth == 1) ? theHEDthreshold1 : theHEDthreshold;
         weight = theHEDweight;
         if (weight <= 0.) {
           ROOT::Math::Interpolator my(theHEDGrid,theHEDWeights,ROOT::Math::Interpolation::kAKIMA);

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
@@ -22,7 +22,9 @@ CaloTowersCreator::CaloTowersCreator(const edm::ParameterSet& conf) :
 	conf.getParameter<double>("HcalThreshold"),
 	conf.getParameter<double>("HBThreshold"),
 	conf.getParameter<double>("HESThreshold"),
+	conf.getParameter<double>("HESThreshold1"),
 	conf.getParameter<double>("HEDThreshold"),
+	conf.getParameter<double>("HEDThreshold1"),
 	conf.getParameter<double>("HOThreshold0"),
 	conf.getParameter<double>("HOThresholdPlus1"),
 	conf.getParameter<double>("HOThresholdMinus1"),
@@ -316,7 +318,9 @@ void CaloTowersCreator::fillDescriptions(edm::ConfigurationDescriptions& descrip
 	desc.add<double>("HcalThreshold", -1000.0);
 	desc.add<double>("HF2Threshold", 0.85);
 	desc.add<double>("HESThreshold", 0.8);
+	desc.add<double>("HESThreshold1", 0.8);
 	desc.add<double>("HEDThreshold", 0.8);
+	desc.add<double>("HEDThreshold1", 0.8);
 	desc.add<double>("EcutTower", -1000.0);
 	desc.add<double>("HBWeight", 1.0);
 	desc.add<double>("MomHBDepth", 0.2);

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.cc
@@ -4,7 +4,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 CaloTowersReCreator::CaloTowersReCreator(const edm::ParameterSet& conf) : 
-  algo_(0.,0., false, false, false, false, 0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0., // thresholds cannot be reapplied
+  algo_(0.,0., false, false, false, false, 0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,// thresholds cannot be reapplied
         conf.getParameter<std::vector<double> >("EBGrid"),
         conf.getParameter<std::vector<double> >("EBWeights"),
         conf.getParameter<std::vector<double> >("EEGrid"),


### PR DESCRIPTION
No changes expected for eras <= 2017 (cuts kept unchanged).
Some increase of HE N_towers and small addition to energy sums (CaloJets, SumET) expected for >= 2018 due to lowering of HE RecHit cut (both for depth1 and depths2-7) on CaloTowers constituents.

2018  single-pion HE N_towers (vs default reference):
https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/100X_2018_CT_HEd1_vs_100X_2018_SinglePi/N_calotowers_HE.gif
  
HB N_towers is just minimally affected, as there are (more) HE RecHits with |ieta|=16 depth=3 
which are included in HB CaloTower |ieta|=16 
https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/100X_2018_CT_HEd1_vs_100X_2018_SinglePi/N_calotowers_HB.gif

NB: 
HES stands for 5-deg phi-segmentation rings (|ieta|<21)
HED - for 10-deg rings (|ieta|>= 21)  
  
  
  