### PR TITLE
restoring premix library for UP15 workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -496,8 +496,8 @@ baseDataSetRelease=[
                                                             # THIS ABOVE IS NOT USED, AT THE MOMENT
     'CMSSW_9_2_4-91X_mcRun2_asymptotic_v3-v1',              # 3 - GEN-SIM input for 13 TeV 2016 workfows
     'CMSSW_7_3_0_pre1-PRE_LS172_V15_FastSim-v1',                   # 4 - fast sim GEN-SIM-DIGI-RAW-HLTDEBUG for id tests
-    'CMSSW_10_0_0_pre2-PU25ns_100X_mc2017_realistic_v1-v1',    # 5 - fullSim PU 25ns premix
-    'CMSSW_8_1_0_pre15-PU50ns_81X_mcRun2_startup_v12-v1',        # 6 - fullSim PU 50ns premix
+    'CMSSW_9_0_0_pre4-PU25ns_90X_mcRun2_asymptotic_v1-v1',    # 5 - fullSim PU 25ns UP15 premix
+    'CMSSW_8_1_0_pre15-PU50ns_81X_mcRun2_startup_v12-v1',        # 6 - fullSim PU 50ns UP15 premix
     'CMSSW_10_0_0_pre2-100X_mcRun2_asymptotic_v2_FastSim-v1',    # 7 - fastSim MinBias for mixing
     'CMSSW_10_0_0_pre2-PU25ns_100X_mcRun2_asymptotic_v2_FastSim-v1',# 8 - fastSim premixed MinBias
     'CMSSW_10_0_0_pre2-100X_mc2017_realistic_v1-v1',        # 9 - Run2 HI GEN-SIM for mixing


### PR DESCRIPTION
Fixing failure in recent IBs for premixing UP15 workflows after merging of #21819 (due to wrong input premix PU library call)