### PR TITLE
[HCAL] Bug fix and default configuration change for Mahi reconstruction

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -184,7 +184,7 @@ void MahiFit::doFit(std::array<float,3> &correctedOutput, int nbx) const {
     nnlsWork_.pulseCovArray[iBX]   = FullSampleMatrix::Constant(0);
 
     if (offset==pedestalBX_) {
-      nnlsWork_.ampVec.coeffRef(iBX) = 0;
+      nnlsWork_.ampVec.coeffRef(iBX) = sqrt(nnlsWork_.pedConstraint.coeff(0));
     }
     else {
 

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -184,7 +184,7 @@ void MahiFit::doFit(std::array<float,3> &correctedOutput, int nbx) const {
     nnlsWork_.pulseCovArray[iBX]   = FullSampleMatrix::Constant(0);
 
     if (offset==pedestalBX_) {
-      nnlsWork_.ampVec.coeffRef(iBX) = sqrt(nnlsWork_.pedConstraint.coeff(0));
+      nnlsWork_.ampVec.coeffRef(iBX) = 0;
     }
     else {
 
@@ -292,8 +292,9 @@ void MahiFit::updatePulseShape(double itQ, FullSampleVector &pulseShape, FullSam
   (*pfunctor_)(&xxp[0]);
   psfPtr_->getPulseShape(nnlsWork_.pulseP);
 
-  //in the 8 TS case for 2018+, add an extra offset to align with 10 TS returned from psfPtr_->getPulseShape()
-  int delta =nnlsWork_. tsSize == 8 ? 1 : 0;
+  //in the 2018+ case where the sample of interest (SOI) is in TS3, add an extra offset to align with previous SOI=TS4 case
+  //assumed by psfPtr_->getPulseShape()
+  int delta =nnlsWork_. tsSize == 3 ? 1 : 0;
 
   for (unsigned int iTS=nnlsWork_.fullTSOffset; iTS<nnlsWork_.fullTSOffset + nnlsWork_.tsSize; iTS++) {
 

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -184,7 +184,7 @@ void MahiFit::doFit(std::array<float,3> &correctedOutput, int nbx) const {
     nnlsWork_.pulseCovArray[iBX]   = FullSampleMatrix::Constant(0);
 
     if (offset==pedestalBX_) {
-      nnlsWork_.ampVec.coeffRef(iBX) = sqrt(nnlsWork_.pedConstraint.coeff(0));
+      nnlsWork_.ampVec.coeffRef(iBX) = 0;
     }
     else {
 
@@ -292,9 +292,9 @@ void MahiFit::updatePulseShape(double itQ, FullSampleVector &pulseShape, FullSam
   (*pfunctor_)(&xxp[0]);
   psfPtr_->getPulseShape(nnlsWork_.pulseP);
 
-  //in the 2018+ case where the sample of interest (SOI) is in TS3, add an extra offset to align with previous SOI=TS4 case
-  //assumed by psfPtr_->getPulseShape()
-  int delta =nnlsWork_. tsSize == 3 ? 1 : 0;
+  //in the 2018+ case where the sample of interest (SOI) is in TS3, add an extra offset to align 
+  //with previous SOI=TS4 case assumed by psfPtr_->getPulseShape()
+  int delta =nnlsWork_. tsOffset == 3 ? 1 : 0;
 
   for (unsigned int iTS=nnlsWork_.fullTSOffset; iTS<nnlsWork_.fullTSOffset + nnlsWork_.tsSize; iTS++) {
 

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEMahiParameters_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEMahiParameters_cfi.py
@@ -5,7 +5,7 @@ mahiParameters = cms.PSet(
 
     dynamicPed        = cms.bool(True),
     ts4Thresh         = cms.double(0.0),
-    chiSqSwitch       = cms.double(-10.0),
+    chiSqSwitch       = cms.double(15.0),
     activeBXs         = cms.vint32(-1, 0, 1),
     nMaxItersMin      = cms.int32(500),
     nMaxItersNNLS     = cms.int32(500),


### PR DESCRIPTION
After some internal discussion, this PR makes the following changes to Mahi reconstruction:
- Initialize floating pedestal at 0, not sqrt(pedestal Width)
- Activate chiSquare-based 1 vs 3 pulse switch for Mahi so that:
     (1)Start with 1 pulse + pedestal fit
     (2)If chiSq>chiSqThresh[15], do 3 pulse + pedestal fit
- Offset pulse shape template based on sample of interest (TS3 vs TS4) instead of number of samples (8 vs 10)

In pre3 configuration, observe that the relative energy response between Method 2 and Mahi has energy dependent variation of ~20%
Attached
[mahi_config_change.pdf](https://github.com/cms-sw/cmssw/files/1630071/mahi_config_change.pdf)
 slides show this PR reduces this variation as well as improving overall resolution between Method 2 and Mahi.

~~This is one small bugfix and one config change for Mahi reconstruction:~~

~~(1) The 1 TS offset for the pulse shape arrays in Mahi should be based on the sample of interest, not the number of samples.~~

~~(2) The fit is initialized with pedestal at 0 instead of the average pedestal width.~~

~~These are expected to have very little impact on the overall performance, mostly at low energy. Point (1) should have no impact at all.~~
