### PR TITLE
PFRecHit PFClusters = generalize to accept HCAL thresholds separately for each depth

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -27,6 +27,69 @@ def customiseFor21810(process):
         producer.HEDThreshold  = cms.double(0.8)
     return process
 
+def customiseFor21845(process):
+
+    for producer in producers_by_type(process, "PFClusterProducer"):
+        if producer.seedFinder.thresholdsByDetector[0].detector.value()=='HCAL_BARREL1':
+            producer.seedFinder.thresholdsByDetector[0].depths = cms.vint32(1, 2, 3, 4)
+            producer.seedFinder.thresholdsByDetector[0].seedingThreshold = cms.vdouble(1.0, 1.0, 1.0, 1.0)
+            producer.seedFinder.thresholdsByDetector[0].seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
+
+        if producer.seedFinder.thresholdsByDetector[1].detector.value()=='HCAL_ENDCAP':
+            producer.seedFinder.thresholdsByDetector[1].depths = cms.vint32(1, 2, 3, 4, 5, 6, 7)
+            producer.seedFinder.thresholdsByDetector[1].seedingThreshold = cms.vdouble(1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1)
+            producer.seedFinder.thresholdsByDetector[1].seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+            #############
+
+        if producer.initialClusteringStep.thresholdsByDetector[0].detector.value()=='HCAL_BARREL1':
+            producer.initialClusteringStep.thresholdsByDetector[0].depths = cms.vint32(1, 2, 3, 4)
+            producer.initialClusteringStep.thresholdsByDetector[0].gatheringThreshold = cms.vdouble(0.8, 0.8, 0.8, 0.8)
+            producer.initialClusteringStep.thresholdsByDetector[0].gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
+
+        if producer.initialClusteringStep.thresholdsByDetector[1].detector.value()=='HCAL_ENDCAP':
+            producer.initialClusteringStep.thresholdsByDetector[1].depths = cms.vint32(1, 2, 3, 4, 5, 6, 7)
+            producer.initialClusteringStep.thresholdsByDetector[1].gatheringThreshold = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
+            producer.initialClusteringStep.thresholdsByDetector[1].gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+            #############
+
+        if producer.pfClusterBuilder.recHitEnergyNorms[0].detector.value()=='HCAL_BARREL1':
+            producer.pfClusterBuilder.recHitEnergyNorms[0].depths = cms.vint32(1, 2, 3, 4)
+            producer.pfClusterBuilder.recHitEnergyNorms[0].recHitEnergyNorm = cms.vdouble(0.8, 0.8, 0.8, 0.8)
+
+        if producer.pfClusterBuilder.recHitEnergyNorms[1].detector.value()=='HCAL_ENDCAP':
+            producer.pfClusterBuilder.recHitEnergyNorms[1].depths = cms.vint32(1, 2, 3, 4, 5, 6, 7)
+            producer.pfClusterBuilder.recHitEnergyNorms[1].recHitEnergyNorm = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
+
+            #############
+
+    for producer in producers_by_type(process, "PFRecHitProducer"):
+        if producer.producers[0].name.value()=='PFHBHERecHitCreator':
+            producer.producers[0].qualityTests[0].cuts = cms.VPSet(
+                cms.PSet(),
+                cms.PSet()
+                )
+            producer.producers[0].qualityTests[0].cuts[0].depth = cms.vint32(1, 2, 3, 4)
+            producer.producers[0].qualityTests[0].cuts[0].threshold = cms.vdouble(0.8, 0.8, 0.8, 0.8)
+            producer.producers[0].qualityTests[0].cuts[0].detectorEnum = cms.int32(1)
+
+            producer.producers[0].qualityTests[0].cuts[1].depth = cms.vint32(1, 2, 3, 4, 5, 6, 7)
+            producer.producers[0].qualityTests[0].cuts[1].threshold = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
+            producer.producers[0].qualityTests[0].cuts[1].detectorEnum = cms.int32(2)
+
+    for producer in producers_by_type(process, "PFRecHitProducer"):
+        if producer.producers[0].name.value()=='PFHFRecHitCreator':
+            producer.producers[0].qualityTests[1].cuts = cms.VPSet(
+                cms.PSet()
+                )
+            producer.producers[0].qualityTests[1].cuts[0].depth = cms.vint32(1,2)
+            producer.producers[0].qualityTests[1].cuts[0].threshold = cms.vdouble(1.2,1.8)
+            producer.producers[0].qualityTests[1].cuts[0].detectorEnum = cms.int32(4)
+
+    return process
+
+
 def customiseFor21664_forMahiOn(process):
     for producer in producers_by_type(process, "HBHEPhase1Reconstructor"):
         producer.algorithm.useMahi   = cms.bool(True)
@@ -56,5 +119,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     process = customiseFor21733(process)
 
     process = customiseFor21810(process)
+
+    process = customiseFor21845(process)
 
     return process

--- a/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <iostream>
 #include <unordered_map>
+#include <tuple>
 
 namespace edm {
   class Event;
@@ -43,11 +44,26 @@ class InitialClusteringStepBase {
     conf.getParameterSetVector("thresholdsByDetector");
     for( const auto& pset : thresholds ) {
       const std::string& det = pset.getParameter<std::string>("detector");
-      const double& thresh_E = 
-	pset.getParameter<double>("gatheringThreshold");
-      const double& thresh_pT = 
-	pset.getParameter<double>("gatheringThresholdPt");
-      const double thresh_pT2 = thresh_pT*thresh_pT;
+
+      std::vector<int> depths;
+      std::vector<double> thresh_E;
+      std::vector<double> thresh_pT ;
+      std::vector<double> thresh_pT2;
+
+      if (det==std::string("HCAL_BARREL1") || det==std::string("HCAL_ENDCAP")) {
+	depths = pset.getParameter<std::vector<int> >("depths");
+	thresh_E = pset.getParameter<std::vector<double> >("gatheringThreshold");
+	thresh_pT = pset.getParameter<std::vector<double> >("gatheringThresholdPt");
+      } else {
+	depths.push_back(0);
+	thresh_E.push_back(pset.getParameter<double>("gatheringThreshold"));
+	thresh_pT.push_back(pset.getParameter<double>("gatheringThresholdPt"));
+      }
+
+      for(unsigned int i=0;i < thresh_pT.size();++i){
+	thresh_pT2.push_back(thresh_pT[i]*thresh_pT[i]);
+      }
+
       auto entry = _layerMap.find(det);
       if( entry == _layerMap.end() ) {
 	throw cms::Exception("InvalidDetectorLayer")
@@ -55,7 +71,7 @@ class InitialClusteringStepBase {
 	  << " detector layers!";
       }
       _thresholds.emplace(_layerMap.find(det)->second, 
-			  std::make_pair(thresh_E,thresh_pT2));
+			  std::make_tuple(depths,thresh_E,thresh_pT2));
   }
   }
   virtual ~InitialClusteringStepBase() = default;
@@ -88,8 +104,9 @@ class InitialClusteringStepBase {
   }
   unsigned _nSeeds, _nClustersFound; // basic performance information
   const std::unordered_map<std::string,int> _layerMap;
-  std::unordered_map<int,std::pair<double,double> > 
-    _thresholds;
+
+  typedef std::tuple<std::vector<int> ,std::vector<double> , std::vector<double> > _i3tuple;
+  std::unordered_map<int,_i3tuple > _thresholds;
  
  private:
   const std::string _algoName;

--- a/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
@@ -54,6 +54,10 @@ class InitialClusteringStepBase {
 	depths = pset.getParameter<std::vector<int> >("depths");
 	thresh_E = pset.getParameter<std::vector<double> >("gatheringThreshold");
 	thresh_pT = pset.getParameter<std::vector<double> >("gatheringThresholdPt");
+	if(thresh_E.size()!=depths.size() || thresh_pT.size()!=depths.size()) {
+	  throw cms::Exception("InvalidGatheringThreshold")
+	    << "gatheringThresholds mismatch with the numbers of depths";
+	}
       } else {
 	depths.push_back(0);
 	thresh_E.push_back(pset.getParameter<double>("gatheringThreshold"));

--- a/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
@@ -109,8 +109,8 @@ class InitialClusteringStepBase {
   unsigned _nSeeds, _nClustersFound; // basic performance information
   const std::unordered_map<std::string,int> _layerMap;
 
-  typedef std::tuple<std::vector<int> ,std::vector<double> , std::vector<double> > _i3tuple;
-  std::unordered_map<int,_i3tuple > _thresholds;
+  typedef std::tuple<std::vector<int> ,std::vector<double> , std::vector<double> > I3tuple;
+  std::unordered_map<int,I3tuple > _thresholds;
  
  private:
   const std::string _algoName;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -262,6 +262,10 @@ public:
         depths_=pset.getParameter<std::vector<int> >("depth");
         thresholds_=pset.getParameter<std::vector<double> >("threshold");
 	detector_=pset.getParameter<int>("detectorEnum");
+        if(thresholds_.size()!=depths_.size()) {
+          throw cms::Exception("InvalidPFRecHitThreshold")
+            << "PFRecHitThreshold mismatch with the numbers of depths";
+        }
       }
     }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -259,8 +259,9 @@ public:
     {
       std::vector<edm::ParameterSet> psets = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
       for (auto & pset : psets) {
-        depths_.push_back(pset.getParameter<int>("depth"));
-        thresholds_.push_back(pset.getParameter<double>("threshold"));
+        depths_=pset.getParameter<std::vector<int> >("depth");
+        thresholds_=pset.getParameter<std::vector<double> >("threshold");
+	detector_=pset.getParameter<int>("detectorEnum");
       }
     }
 
@@ -292,11 +293,13 @@ public:
 protected:
     std::vector<int> depths_;
     std::vector<double> thresholds_;
+    int detector_;
 
     bool test(unsigned aDETID, double energy, double time, bool& clean){
       HcalDetId detid(aDETID);
-      for (unsigned int i=0;i<depths_.size();++i) {
-        if (detid.depth() == depths_[i]) {
+
+      for (unsigned int i=0;i<thresholds_.size();++i) {
+	if (detid.depth() == depths_[i] && detid.subdet() == detector_ ) {
           if (  energy<thresholds_[i])
             {
               clean=false;

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
@@ -184,11 +184,18 @@ growPFClusters(const reco::PFCluster& topo,
 
     std::pair<std::vector<int>,std::vector<double> > recHitEnergyNormDepthPair = _recHitEnergyNorms.find(cell_layer)->second;
 
-    const std::vector<double> recHitEnergyNormV = recHitEnergyNormDepthPair.second;
-    const std::vector<int> recHitDepthV = recHitEnergyNormDepthPair.first;
+    const std::vector<double>& recHitEnergyNormV = recHitEnergyNormDepthPair.second;
+    const std::vector<int>& recHitDepthV = recHitEnergyNormDepthPair.first;
 
     math::XYZPoint topocellpos_xyz(refhit->position());
     dist2.clear(); frac.clear(); fractot = 0;
+
+    double recHitEnergyNorm=0.;
+    for (unsigned int j=0; j<recHitEnergyNormV.size(); ++j) {
+      if((cell_layer == PFLayer::HCAL_BARREL1 || cell_layer == PFLayer::HCAL_ENDCAP) && refhit->depth()!=recHitDepthV[j]) continue;
+      recHitEnergyNorm = recHitEnergyNormV[j];
+    }
+
     // add rechits to clusters, calculating fraction based on distance
     for( auto& cluster : clusters ) {      
       const math::XYZPoint& clusterpos_xyz = cluster.position();
@@ -200,14 +207,6 @@ growPFClusters(const reco::PFCluster& topo,
 	  << "Warning! :: pfcluster-topocell distance is too large! d= "
 	  << d2;
       }
-
-      double recHitEnergyNorm=0.;
-
-      for (unsigned int j=0; j<recHitEnergyNormV.size(); ++j) {
-	if((cell_layer == PFLayer::HCAL_BARREL1 || cell_layer == PFLayer::HCAL_ENDCAP) && refhit->depth()!=recHitDepthV[j]) continue;
-	recHitEnergyNorm = recHitEnergyNormV[j];
-      }
-
 
       // fraction assignment logic
       double fraction;

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
@@ -68,7 +68,7 @@ Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf) :
 	<< "Detector layer : " << det << " is not in the list of recognized"
 	<< " detector layers!";
     }
-    _recHitEnergyNorms.emplace(_layerMap.find(det)->second,std::make_tuple(depths,depths,rhE_norm));
+    _recHitEnergyNorms.emplace(_layerMap.find(det)->second,std::make_pair(depths,rhE_norm));
   }
   
   _allCellsPosCalc.reset(nullptr);
@@ -188,15 +188,15 @@ growPFClusters(const reco::PFCluster& topo,
     dist2.clear(); frac.clear(); fractot = 0;
 
     double recHitEnergyNorm=0.;
-    std::tuple<std::vector<int> ,std::vector<int> , std::vector<double> > _recHitEnergyNormsT = _recHitEnergyNorms.find(cell_layer)->second;
+    auto const& recHitEnergyNormDepthPair = _recHitEnergyNorms.find(cell_layer)->second;
 
-    for (unsigned int j=0; j<(std::get<2>(_recHitEnergyNormsT)).size(); ++j) {
-      int depth=std::get<1>(_recHitEnergyNormsT)[j];
+    for (unsigned int j=0; j<recHitEnergyNormDepthPair.second.size(); ++j) {
+      int depth=recHitEnergyNormDepthPair.first[j];
 
       if( ( cell_layer == PFLayer::HCAL_BARREL1 && refhit->depth()== depth)
 	  || ( cell_layer == PFLayer::HCAL_ENDCAP && refhit->depth()== depth)
 	  || ( cell_layer != PFLayer::HCAL_ENDCAP && cell_layer != PFLayer::HCAL_BARREL1)
-	  ) recHitEnergyNorm=std::get<2>(_recHitEnergyNormsT)[j];
+	  ) recHitEnergyNorm = recHitEnergyNormDepthPair.second[j];
     }
 
     // add rechits to clusters, calculating fraction based on distance

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.h
@@ -32,7 +32,7 @@ class Basic2DGenericPFlowClusterizer : public PFClusterBuilderBase {
   const bool _excludeOtherSeeds;
   const double _minFracTot;
   const std::unordered_map<std::string,int> _layerMap;
-  std::unordered_map<int,double> _recHitEnergyNorms;
+  std::unordered_map<int,std::pair<std::vector<int>,std::vector<double> > > _recHitEnergyNorms;
   std::unique_ptr<PFCPositionCalculatorBase> _allCellsPosCalc;
   std::unique_ptr<PFCPositionCalculatorBase> _convergencePosCalc;
   

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.h
@@ -5,7 +5,6 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
 
 #include <unordered_map>
-#include <tuple>
 
 class Basic2DGenericPFlowClusterizer : public PFClusterBuilderBase {
   typedef Basic2DGenericPFlowClusterizer B2DGPF;
@@ -34,9 +33,7 @@ class Basic2DGenericPFlowClusterizer : public PFClusterBuilderBase {
   const double _minFracTot;
   const std::unordered_map<std::string,int> _layerMap;
 
-  typedef std::tuple<std::vector<int> ,std::vector<int> , std::vector<double> > _i3tuple;
-
-  std::unordered_map<int,_i3tuple > _recHitEnergyNorms;
+  std::unordered_map<int,std::pair<std::vector<int>,std::vector<double> > > _recHitEnergyNorms;
   std::unique_ptr<PFCPositionCalculatorBase> _allCellsPosCalc;
   std::unique_ptr<PFCPositionCalculatorBase> _convergencePosCalc;
   

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.h
@@ -5,6 +5,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
 
 #include <unordered_map>
+#include <tuple>
 
 class Basic2DGenericPFlowClusterizer : public PFClusterBuilderBase {
   typedef Basic2DGenericPFlowClusterizer B2DGPF;
@@ -32,7 +33,10 @@ class Basic2DGenericPFlowClusterizer : public PFClusterBuilderBase {
   const bool _excludeOtherSeeds;
   const double _minFracTot;
   const std::unordered_map<std::string,int> _layerMap;
-  std::unordered_map<int,std::pair<std::vector<int>,std::vector<double> > > _recHitEnergyNorms;
+
+  typedef std::tuple<std::vector<int> ,std::vector<int> , std::vector<double> > _i3tuple;
+
+  std::unordered_map<int,_i3tuple > _recHitEnergyNorms;
   std::unique_ptr<PFCPositionCalculatorBase> _allCellsPosCalc;
   std::unique_ptr<PFCPositionCalculatorBase> _convergencePosCalc;
   

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.h
@@ -8,16 +8,58 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "RecoParticleFlow/PFClusterProducer/interface/CaloRecHitResolutionProvider.h"
+#include <tuple>
 
 class Basic2DGenericPFlowPositionCalc : public PFCPositionCalculatorBase {
  public:
   Basic2DGenericPFlowPositionCalc(const edm::ParameterSet& conf) :
     PFCPositionCalculatorBase(conf),    
     _posCalcNCrystals(conf.getParameter<int>("posCalcNCrystals")),
-    _logWeightDenom(1./conf.getParameter<double>("logWeightDenominator")),
     _minAllowedNorm(conf.getParameter<double>("minAllowedNormalization"))
-
   {  
+
+    std::vector<int> detectorEnum;
+    std::vector<int> depths;
+    std::vector<double> logWeightDenom;
+    std::vector<float> logWeightDenomInv;
+
+    if(conf.exists("logWeightDenominatorByDetector")) {
+
+      const std::vector<edm::ParameterSet>& logWeightDenominatorByDetectorPSet = conf.getParameterSetVector("logWeightDenominatorByDetector");
+
+      for( const auto& pset : logWeightDenominatorByDetectorPSet ) {
+
+	if(!pset.exists("detector")) continue;
+	const std::string& det = pset.getParameter<std::string>("detector");
+
+	if (det==std::string("HCAL_BARREL1") || det==std::string("HCAL_ENDCAP")) {
+	  std::vector<int> depthsT=pset.getParameter<std::vector<int> >("depths");
+	  std::vector<double> logWeightDenomT=pset.getParameter<std::vector<double> >("logWeightDenominator");
+	  if(logWeightDenomT.size()!=depthsT.size()) {
+	    throw cms::Exception("logWeightDenominator")
+	      << "logWeightDenominator mismatch with the numbers of depths";
+	  }
+	  for(unsigned int i=0;i < depthsT.size();++i){
+	    if(det==std::string("HCAL_BARREL1")) detectorEnum.push_back(1);
+	    if(det==std::string("HCAL_ENDCAP")) detectorEnum.push_back(2);
+	    depths.push_back(depthsT[i]);
+	    logWeightDenom.push_back(logWeightDenomT[i]);
+	  }
+	}
+      }
+    } else {
+      detectorEnum.push_back(0);
+      depths.push_back(0);
+      logWeightDenom.push_back(conf.getParameter<double>("logWeightDenominator"));
+    }
+
+    for(unsigned int i=0;i < depths.size();++i){
+      logWeightDenomInv.push_back(1./logWeightDenom[i]);
+    }
+
+    //    _logWeightDenom = std::make_pair(depths,logWeightDenomInv);
+    _logWeightDenom = std::make_tuple(detectorEnum,depths,logWeightDenomInv);
+
     _timeResolutionCalcBarrel.reset(nullptr);
     if( conf.exists("timeResolutionCalcBarrel") ) {
       const edm::ParameterSet& timeResConf = 
@@ -52,7 +94,7 @@ class Basic2DGenericPFlowPositionCalc : public PFCPositionCalculatorBase {
 
  private:
   const int _posCalcNCrystals;
-  const float _logWeightDenom;
+  std::tuple<std::vector<int> ,std::vector<int> , std::vector<float> > _logWeightDenom;
   const float _minAllowedNorm;
   
   std::unique_ptr<CaloRecHitResolutionProvider> _timeResolutionCalcBarrel;

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.h
@@ -28,8 +28,11 @@ class Basic2DGenericPFlowPositionCalc : public PFCPositionCalculatorBase {
       const std::vector<edm::ParameterSet>& logWeightDenominatorByDetectorPSet = conf.getParameterSetVector("logWeightDenominatorByDetector");
 
       for( const auto& pset : logWeightDenominatorByDetectorPSet ) {
+	if(!pset.exists("detector")) {
+	  throw cms::Exception("logWeightDenominatorByDetectorPSet")
+	    << "logWeightDenominator : detector not specified";
+	}
 
-	if(!pset.exists("detector")) continue;
 	const std::string& det = pset.getParameter<std::string>("detector");
 
 	if (det==std::string("HCAL_BARREL1") || det==std::string("HCAL_ENDCAP")) {

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
@@ -53,15 +53,23 @@ buildTopoCluster(const edm::Handle<reco::PFRecHitCollection>& input,
       std::abs(cell.positionREP().eta()) > 0.34 ) {
       cell_layer *= 100;
     }    
-  const std::pair<double,double>& thresholds =
-      _thresholds.find(cell_layer)->second;
-  if( cell.energy() < thresholds.first || 
-      cell.pt2() < thresholds.second ) {
-    LOGDRESSED("GenericTopoCluster::buildTopoCluster()")
-      << "RecHit " << cell.detId() << " with enegy " 
-      << cell.energy() << " GeV was rejected!." << std::endl;
-    return;
+
+  std::tuple<std::vector<int> ,std::vector<double> , std::vector<double> > thresholds = _thresholds.find(cell_layer)->second;
+
+  for (unsigned int j=0; j<(std::get<1>(thresholds)).size(); ++j) {
+    if((cell_layer == PFLayer::HCAL_BARREL1 || cell_layer == PFLayer::HCAL_ENDCAP) && (cell.depth()!=std::get<0>(thresholds)[j])) continue;
+
+    if( cell.energy() < std::get<1>(thresholds)[j] ||
+	cell.pt2() < std::get<2>(thresholds)[j]  ) {
+      LOGDRESSED("GenericTopoCluster::buildTopoCluster()")
+	<< "RecHit " << cell.detId() << " with enegy "
+	<< cell.energy() << " GeV was rejected!." << std::endl;
+      return;
+    }
+
   }
+
+
   auto k = kcell;
   used[k] = true;
   auto ref = makeRefhit(input,k);

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
@@ -54,9 +54,7 @@ buildTopoCluster(const edm::Handle<reco::PFRecHitCollection>& input,
       cell_layer *= 100;
     }    
 
-  std::tuple<std::vector<int> ,std::vector<double> , std::vector<double> > thresholds = _thresholds.find(cell_layer)->second;
-
-
+  auto const& thresholds = _thresholds.find(cell_layer)->second;
   double thresholdE=0.;
   double thresholdPT2=0.;
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
@@ -56,17 +56,26 @@ buildTopoCluster(const edm::Handle<reco::PFRecHitCollection>& input,
 
   std::tuple<std::vector<int> ,std::vector<double> , std::vector<double> > thresholds = _thresholds.find(cell_layer)->second;
 
+
+  double thresholdE=0.;
+  double thresholdPT2=0.;
+
   for (unsigned int j=0; j<(std::get<1>(thresholds)).size(); ++j) {
-    if((cell_layer == PFLayer::HCAL_BARREL1 || cell_layer == PFLayer::HCAL_ENDCAP) && (cell.depth()!=std::get<0>(thresholds)[j])) continue;
+    int depth=std::get<0>(thresholds)[j];
 
-    if( cell.energy() < std::get<1>(thresholds)[j] ||
-	cell.pt2() < std::get<2>(thresholds)[j]  ) {
-      LOGDRESSED("GenericTopoCluster::buildTopoCluster()")
-	<< "RecHit " << cell.detId() << " with enegy "
-	<< cell.energy() << " GeV was rejected!." << std::endl;
-      return;
-    }
+    if( ( cell_layer == PFLayer::HCAL_BARREL1 && cell.depth()== depth)
+	|| ( cell_layer == PFLayer::HCAL_ENDCAP && cell.depth()== depth)
+	|| ( cell_layer != PFLayer::HCAL_BARREL1 && cell_layer != PFLayer::HCAL_ENDCAP )
+	) { thresholdE=std::get<1>(thresholds)[j]; thresholdPT2=std::get<2>(thresholds)[j]; }
 
+  }
+
+  if( cell.energy() < thresholdE ||
+      cell.pt2() < thresholdPT2  ) {
+    LOGDRESSED("GenericTopoCluster::buildTopoCluster()")
+      << "RecHit " << cell.detId() << " with enegy "
+      << cell.energy() << " GeV was rejected!." << std::endl;
+    return;
   }
 
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
@@ -62,7 +62,7 @@ LocalMaximumSeedFinder(const edm::ParameterSet& conf) :
     }
 
     _thresholds[entry->second+layerOffset]= 
-                       std::make_tuple(depths,thresh_E,thresh_pT2);
+      std::make_tuple(depths,thresh_E,thresh_pT2);
   }
 }
 
@@ -91,15 +91,25 @@ findSeeds( const edm::Handle<reco::PFRecHitCollection>& input,
     }
     auto const & thresholds = _thresholds[seedlayer+layerOffset];
 
-    for (unsigned int j=0; j<(std::get<1>(thresholds)).size(); ++j) {
-      if((seedlayer == PFLayer::HCAL_BARREL1 || seedlayer == PFLayer::HCAL_ENDCAP) && (maybeseed.depth()!=std::get<0>(thresholds)[j])) continue;
 
-	if( maybeseed.energy() < std::get<1>(thresholds)[j] ||
-	    maybeseed.pt2() < std::get<2>(thresholds)[j]   ) usable[i] = false;
-	if( !usable[i] ) continue;
-	ordered_hits.push(i);
+    double thresholdE=0.;
+    double thresholdPT2=0.;
+
+    for (unsigned int j=0; j<(std::get<2>(thresholds)).size(); ++j) {
+
+      int depth=std::get<0>(thresholds)[j];
+      if( ( seedlayer == PFLayer::HCAL_BARREL1 && maybeseed.depth()== depth)
+	  || ( seedlayer == PFLayer::HCAL_ENDCAP && maybeseed.depth()== depth)
+	  || ( seedlayer != PFLayer::HCAL_BARREL1 && seedlayer != PFLayer::HCAL_ENDCAP)
+	  ) { thresholdE=std::get<1>(thresholds)[j]; thresholdPT2=std::get<2>(thresholds)[j]; }
 
     }
+
+    if( maybeseed.energy() < thresholdE ||
+	maybeseed.pt2() < thresholdPT2   ) usable[i] = false;
+    if( !usable[i] ) continue;
+    ordered_hits.push(i);
+
   }
 
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
@@ -40,6 +40,10 @@ LocalMaximumSeedFinder(const edm::ParameterSet& conf) :
       depths = pset.getParameter<std::vector<int> >("depths");
       thresh_E = pset.getParameter<std::vector<double> >("seedingThreshold");
       thresh_pT = pset.getParameter<std::vector<double> >("seedingThresholdPt");
+      if(thresh_E.size()!=depths.size() || thresh_pT.size()!=depths.size()) {
+	throw cms::Exception("InvalidGatheringThreshold")
+	  << "gatheringThresholds mismatch with the numbers of depths";
+      }
     } else {
       depths.push_back(0);
       thresh_E.push_back(pset.getParameter<double>("seedingThreshold"));

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.h
@@ -4,6 +4,7 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h"
 
 #include <unordered_map>
+#include <tuple>
 
 class LocalMaximumSeedFinder final : public SeedFinderBase {
  public:
@@ -19,7 +20,10 @@ class LocalMaximumSeedFinder final : public SeedFinderBase {
   const int _nNeighbours;
 
   const std::unordered_map<std::string,int> _layerMap;
-  std::array<std::pair<double,double>, 35> _thresholds;
+
+  typedef std::tuple<std::vector<int> ,std::vector<double> , std::vector<double> > _i3tuple;
+
+  std::array<_i3tuple, 35> _thresholds;
   static constexpr int layerOffset = 15;
 };
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.h
@@ -21,7 +21,7 @@ class LocalMaximumSeedFinder final : public SeedFinderBase {
 
   const std::unordered_map<std::string,int> _layerMap;
 
-  typedef std::tuple<std::vector<int> ,std::vector<double> , std::vector<double> > _i3tuple;
+  typedef std::tuple<std::vector<int>, std::vector<double> , std::vector<double> > _i3tuple;
 
   std::array<_i3tuple, 35> _thresholds;
   static constexpr int layerOffset = 15;

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.h
@@ -21,9 +21,9 @@ class LocalMaximumSeedFinder final : public SeedFinderBase {
 
   const std::unordered_map<std::string,int> _layerMap;
 
-  typedef std::tuple<std::vector<int>, std::vector<double> , std::vector<double> > _i3tuple;
+  typedef std::tuple<std::vector<int>, std::vector<double> , std::vector<double> > I3tuple;
 
-  std::array<_i3tuple, 35> _thresholds;
+  std::array<I3tuple, 35> _thresholds;
   static constexpr int layerOffset = 15;
 };
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -231,31 +231,31 @@ recHitEnergyNormsPhase2 = cms.VPSet(
 
 # offline 2018 -- uncollapsed
 from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
-run2_HCAL_2018.toModify(particleFlowClusterHBHE, recHitEnergyNorms = recHitEnergyNorms2018)
+run2_HCAL_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNorms2018)
 run2_HCAL_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2018)
 run2_HCAL_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2018)
 
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
-run2_HE_2018.toModify(particleFlowClusterHBHE, recHitEnergyNorms = recHitEnergyNorms2018)
+run2_HE_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNorms2018)
 run2_HE_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2018)
 run2_HE_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2018)
 
 """
 # offline 2018 -- collapsed (this need PR 21842)
 from Configuration.Eras.Modifier_run2_HECollapse_2018_cff import run2_HECollapse_2018
-run2_HECollapse_2018.toModify(particleFlowClusterHBHE, recHitEnergyNorms = recHitEnergyNorms2017)
+run2_HECollapse_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNorms2017)
 run2_HCAL_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2017)
 run2_HCAL_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2017)
 """
 
 # offline 2019
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
-run3_HB.toModify(particleFlowClusterHBHE, recHitEnergyNorms = recHitEnergyNorms2019)
+run3_HB.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNorms2019)
 run3_HB.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2019)
 run3_HB.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2019)
 
 # offline phase2 restore what has been studied in the TDR
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toModify(particleFlowClusterHBHE, recHitEnergyNorms = recHitEnergyNormsPhase2)
+phase2_hcal.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNormsPhase2)
 phase2_hcal.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetectorPhase2)
 phase2_hcal.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetectorPhase2)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -10,12 +10,14 @@ particleFlowClusterHBHE = cms.EDProducer(
         algoName = cms.string("LocalMaximumSeedFinder"),
         thresholdsByDetector = cms.VPSet(
               cms.PSet( detector = cms.string("HCAL_BARREL1"),
-                        seedingThreshold = cms.double(1.0),
-                        seedingThresholdPt = cms.double(0.0)
+                        depths = cms.vint32(1, 2, 3, 4),
+                        seedingThreshold = cms.vdouble(1.0, 1.0, 1.0, 1.0),
+                        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
                         ),
               cms.PSet( detector = cms.string("HCAL_ENDCAP"),
-                        seedingThreshold = cms.double(1.1),
-                        seedingThresholdPt = cms.double(0.0)
+                        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+                        seedingThreshold = cms.vdouble(1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1),
+                        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
                         )
               ),
         nNeighbours = cms.int32(4)
@@ -24,12 +26,14 @@ particleFlowClusterHBHE = cms.EDProducer(
         algoName = cms.string("Basic2DGenericTopoClusterizer"),    
         thresholdsByDetector = cms.VPSet(
         cms.PSet( detector = cms.string("HCAL_BARREL1"),
-                  gatheringThreshold = cms.double(0.8),
-                  gatheringThresholdPt = cms.double(0.0)
+                  depths = cms.vint32(1, 2, 3, 4),
+                  gatheringThreshold = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+                  gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
                   ),
         cms.PSet( detector = cms.string("HCAL_ENDCAP"),
-                  gatheringThreshold = cms.double(0.8),
-                  gatheringThresholdPt = cms.double(0.0)
+                  depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+                  gatheringThreshold = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8),
+                  gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
                   )
         ),
         useCornerCells = cms.bool(True)
@@ -68,13 +72,15 @@ particleFlowClusterHBHE = cms.EDProducer(
            excludeOtherSeeds = cms.bool(True),
            minFracTot = cms.double(1e-20), ## numerical stabilization
            recHitEnergyNorms = cms.VPSet(
-           cms.PSet( detector = cms.string("HCAL_BARREL1"),
-                     recHitEnergyNorm = cms.double(0.8)
-                     ),
-           cms.PSet( detector = cms.string("HCAL_ENDCAP"),
-                     recHitEnergyNorm = cms.double(0.8)
-                     )
-           )
+            cms.PSet( detector = cms.string("HCAL_BARREL1"),
+                      depths = cms.vint32(1, 2, 3, 4),
+                      recHitEnergyNorm = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+                      ),
+            cms.PSet( detector = cms.string("HCAL_ENDCAP"),
+                      depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+                      recHitEnergyNorm = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8),
+                      )
+            )
     ),
     positionReCalc = cms.PSet(),
     energyCorrector = cms.PSet()

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -90,7 +90,6 @@ particleFlowClusterHBHE = cms.EDProducer(
 
 seedFinderThresholdsByDetector2017 = particleFlowClusterHBHE.seedFinder.thresholdsByDetector
 
-seedFinderThresholdsByDetector2018 = particleFlowClusterHBHE.seedFinder.thresholdsByDetector
 seedFinderThresholdsByDetector2018 = cms.VPSet(
     cms.PSet(
         detector = cms.string("HCAL_BARREL1"),
@@ -106,7 +105,6 @@ seedFinderThresholdsByDetector2018 = cms.VPSet(
         )
 )
 
-seedFinderThresholdsByDetector2019 = particleFlowClusterHBHE.seedFinder.thresholdsByDetector
 seedFinderThresholdsByDetector2019 = cms.VPSet(
     cms.PSet(
         detector = cms.string("HCAL_BARREL1"),
@@ -126,8 +124,14 @@ seedFinderThresholdsByDetectorPhase2 = cms.VPSet(
     cms.PSet(
         detector = cms.string("HCAL_BARREL1"),
         depths = cms.vint32(1, 2, 3, 4),
-        seedingThreshold = cms.vdouble(0.125, 0.25, 0.25, 0.25),
-        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
+        seedingThreshold = cms.vdouble(1.0, 1.0, 1.0, 1.0),
+        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
+        ),
+    cms.PSet(
+        detector = cms.string("HCAL_ENDCAP"),
+        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+        seedingThreshold = cms.vdouble(1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1),
+        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
         )
     )
 
@@ -135,7 +139,6 @@ seedFinderThresholdsByDetectorPhase2 = cms.VPSet(
 
 initialClusteringStepThresholdsByDetector2017 = particleFlowClusterHBHE.initialClusteringStep.thresholdsByDetector
 
-initialClusteringStepThresholdsByDetector2018 = particleFlowClusterHBHE.initialClusteringStep.thresholdsByDetector
 initialClusteringStepThresholdsByDetector2018 = cms.VPSet(
     cms.PSet(
         detector = cms.string("HCAL_BARREL1"),
@@ -151,7 +154,6 @@ initialClusteringStepThresholdsByDetector2018 = cms.VPSet(
         )
 )
 
-initialClusteringStepThresholdsByDetector2019 = particleFlowClusterHBHE.initialClusteringStep.thresholdsByDetector
 initialClusteringStepThresholdsByDetector2019 = cms.VPSet(
     cms.PSet(
         detector = cms.string("HCAL_BARREL1"),
@@ -171,8 +173,14 @@ initialClusteringStepThresholdsByDetectorPhase2 = cms.VPSet(
     cms.PSet(
         detector = cms.string("HCAL_BARREL1"),
         depths = cms.vint32(1, 2, 3, 4),
-        gatheringThreshold = cms.vdouble(0.1, 0.2, 0.3, 0.3),
+        gatheringThreshold = cms.vdouble(0.8, 0.8, 0.8, 0.8),
         gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
+        ),
+    cms.PSet(
+        detector = cms.string("HCAL_ENDCAP"),
+        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+        gatheringThreshold = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8),
+        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
         )
     )
 
@@ -211,6 +219,11 @@ recHitEnergyNormsPhase2 = cms.VPSet(
         detector = cms.string("HCAL_BARREL1"),
         depths = cms.vint32(1, 2, 3, 4),
         recHitEnergyNorm = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+        ),
+    cms.PSet(
+        detector = cms.string("HCAL_ENDCAP"),
+        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+        recHitEnergyNorm = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8),
         )
     )
 
@@ -222,6 +235,10 @@ run2_HCAL_2018.toModify(particleFlowClusterHBHE, recHitEnergyNorms = recHitEnerg
 run2_HCAL_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2018)
 run2_HCAL_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2018)
 
+from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
+run2_HE_2018.toModify(particleFlowClusterHBHE, recHitEnergyNorms = recHitEnergyNorms2018)
+run2_HE_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2018)
+run2_HE_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2018)
 
 """
 # offline 2018 -- collapsed (this need PR 21842)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -1,6 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 from RecoParticleFlow.PFClusterProducer.particleFlowCaloResolution_cfi import _timeResolutionHCALMaxSample
 
+_thresholdsHB = cms.vdouble(0.8, 0.8, 0.8, 0.8)
+_thresholdsHE = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
+_thresholdsHBphase1 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
+_thresholdsHEphase1 = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2)
+
 #### PF CLUSTER HCAL ####
 particleFlowClusterHBHE = cms.EDProducer(
     "PFClusterProducer",
@@ -27,12 +32,12 @@ particleFlowClusterHBHE = cms.EDProducer(
         thresholdsByDetector = cms.VPSet(
         cms.PSet( detector = cms.string("HCAL_BARREL1"),
                   depths = cms.vint32(1, 2, 3, 4),
-                  gatheringThreshold = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+                  gatheringThreshold = _thresholdsHB,
                   gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
                   ),
         cms.PSet( detector = cms.string("HCAL_ENDCAP"),
                   depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-                  gatheringThreshold = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8),
+                  gatheringThreshold = _thresholdsHE,
                   gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
                   )
         ),
@@ -47,14 +52,34 @@ particleFlowClusterHBHE = cms.EDProducer(
                  algoName = cms.string("Basic2DGenericPFlowPositionCalc"),
                  minFractionInCalc = cms.double(1e-9),    
                  posCalcNCrystals = cms.int32(5),
-                 logWeightDenominator = cms.double(0.8),#same as gathering threshold
+#                 logWeightDenominator = cms.double(0.8),#same as gathering threshold
+                 logWeightDenominatorByDetector = cms.VPSet(
+                       cms.PSet( detector = cms.string("HCAL_BARREL1"),
+                                 depths = cms.vint32(1, 2, 3, 4),
+                                 logWeightDenominator = _thresholdsHB,
+                                 ),
+                       cms.PSet( detector = cms.string("HCAL_ENDCAP"),
+                                 depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+                                 logWeightDenominator = _thresholdsHE,
+                                 )
+                       ),
                  minAllowedNormalization = cms.double(1e-9)
            ),
            allCellsPositionCalc =cms.PSet(
                  algoName = cms.string("Basic2DGenericPFlowPositionCalc"),
                  minFractionInCalc = cms.double(1e-9),    
                  posCalcNCrystals = cms.int32(-1),
-                 logWeightDenominator = cms.double(0.8),#same as gathering threshold
+##                 logWeightDenominator = cms.double(0.8),#same as gathering threshold
+                 logWeightDenominatorByDetector = cms.VPSet(
+                       cms.PSet( detector = cms.string("HCAL_BARREL1"),
+                                 depths = cms.vint32(1, 2, 3, 4),
+                                 logWeightDenominator = _thresholdsHB,
+                                 ),
+                       cms.PSet( detector = cms.string("HCAL_ENDCAP"),
+                                 depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+                                 logWeightDenominator = _thresholdsHE,
+                                 )
+                       ),
                  minAllowedNormalization = cms.double(1e-9)
            ),
            
@@ -74,11 +99,11 @@ particleFlowClusterHBHE = cms.EDProducer(
            recHitEnergyNorms = cms.VPSet(
             cms.PSet( detector = cms.string("HCAL_BARREL1"),
                       depths = cms.vint32(1, 2, 3, 4),
-                      recHitEnergyNorm = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+                      recHitEnergyNorm = _thresholdsHB,
                       ),
             cms.PSet( detector = cms.string("HCAL_ENDCAP"),
                       depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-                      recHitEnergyNorm = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8),
+                      recHitEnergyNorm = _thresholdsHE,
                       )
             )
     ),
@@ -143,13 +168,13 @@ initialClusteringStepThresholdsByDetector2018 = cms.VPSet(
     cms.PSet(
         detector = cms.string("HCAL_BARREL1"),
         depths = cms.vint32(1, 2, 3, 4),
-        gatheringThreshold = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+        gatheringThreshold = _thresholdsHB,
         gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
         ),
     cms.PSet(
         detector = cms.string("HCAL_ENDCAP"),
         depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        gatheringThreshold = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2),
+        gatheringThreshold = _thresholdsHEphase1,
         gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
         )
 )
@@ -158,13 +183,13 @@ initialClusteringStepThresholdsByDetector2019 = cms.VPSet(
     cms.PSet(
         detector = cms.string("HCAL_BARREL1"),
         depths = cms.vint32(1, 2, 3, 4),
-        gatheringThreshold = cms.vdouble(0.1, 0.2, 0.3, 0.3),
+        gatheringThreshold = _thresholdsHBphase1,
         gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
         ),
     cms.PSet(
         detector = cms.string("HCAL_ENDCAP"),
         depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        gatheringThreshold = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2),
+        gatheringThreshold = _thresholdsHEphase1,
         gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
         )
 )
@@ -173,13 +198,13 @@ initialClusteringStepThresholdsByDetectorPhase2 = cms.VPSet(
     cms.PSet(
         detector = cms.string("HCAL_BARREL1"),
         depths = cms.vint32(1, 2, 3, 4),
-        gatheringThreshold = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+        gatheringThreshold = _thresholdsHB,
         gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
         ),
     cms.PSet(
         detector = cms.string("HCAL_ENDCAP"),
         depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        gatheringThreshold = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8),
+        gatheringThreshold = _thresholdsHE,
         gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
         )
     )
@@ -192,12 +217,12 @@ recHitEnergyNorms2018 = cms.VPSet(
     cms.PSet(
         detector = cms.string("HCAL_BARREL1"),
         depths = cms.vint32(1, 2, 3, 4),
-        recHitEnergyNorm = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+        recHitEnergyNorm = _thresholdsHB,
         ),
     cms.PSet(
         detector = cms.string("HCAL_ENDCAP"),
         depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        recHitEnergyNorm = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2),
+        recHitEnergyNorm = _thresholdsHEphase1,
         )
 )
 
@@ -205,12 +230,12 @@ recHitEnergyNorms2019 = cms.VPSet(
     cms.PSet(
         detector = cms.string("HCAL_BARREL1"),
         depths = cms.vint32(1, 2, 3, 4),
-        recHitEnergyNorm = cms.vdouble(0.1, 0.2, 0.3, 0.3),
+        recHitEnergyNorm = _thresholdsHBphase1,
         ),
     cms.PSet(
         detector = cms.string("HCAL_ENDCAP"),
         depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        recHitEnergyNorm = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2),
+        recHitEnergyNorm = _thresholdsHEphase1,
         )
     )
 
@@ -218,13 +243,50 @@ recHitEnergyNormsPhase2 = cms.VPSet(
     cms.PSet(
         detector = cms.string("HCAL_BARREL1"),
         depths = cms.vint32(1, 2, 3, 4),
-        recHitEnergyNorm = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+        recHitEnergyNorm = _thresholdsHB,
         ),
     cms.PSet(
         detector = cms.string("HCAL_ENDCAP"),
         depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        recHitEnergyNorm = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8),
+        recHitEnergyNorm = _thresholdsHE,
         )
+    )
+
+#######################
+
+logWeightDenominatorByDetector2017= particleFlowClusterHBHE.pfClusterBuilder.positionCalc.logWeightDenominatorByDetector
+
+logWeightDenominatorByDetector2018 = cms.VPSet(
+    cms.PSet( detector = cms.string("HCAL_BARREL1"),
+              depths = cms.vint32(1, 2, 3, 4),
+              logWeightDenominator = _thresholdsHB
+              ),
+    cms.PSet( detector = cms.string("HCAL_ENDCAP"),
+              depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+              logWeightDenominator = _thresholdsHEphase1,
+              )
+    )
+
+logWeightDenominatorByDetector2019 = cms.VPSet(
+    cms.PSet( detector = cms.string("HCAL_BARREL1"),
+              depths = cms.vint32(1, 2, 3, 4),
+              logWeightDenominator = _thresholdsHBphase1,
+              ),
+    cms.PSet( detector = cms.string("HCAL_ENDCAP"),
+              depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+              logWeightDenominator = _thresholdsHEphase1,
+              )
+    )
+
+logWeightDenominatorByDetectorPhase2 = cms.VPSet(
+    cms.PSet( detector = cms.string("HCAL_BARREL1"),
+              depths = cms.vint32(1, 2, 3, 4),
+              logWeightDenominator = _thresholdsHB,
+              ),
+    cms.PSet( detector = cms.string("HCAL_ENDCAP"),
+              depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+              logWeightDenominator = _thresholdsHE,
+              )
     )
 
 #######################
@@ -234,28 +296,38 @@ from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
 run2_HCAL_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNorms2018)
 run2_HCAL_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2018)
 run2_HCAL_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2018)
+run2_HCAL_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder.positionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2018)
+run2_HCAL_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2018)
+
 
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
 run2_HE_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNorms2018)
 run2_HE_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2018)
 run2_HE_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2018)
+run2_HE_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder.positionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2018)
+run2_HE_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2018)
 
-"""
-# offline 2018 -- collapsed (this need PR 21842)
-from Configuration.Eras.Modifier_run2_HECollapse_2018_cff import run2_HECollapse_2018
+# offline 2018 -- collapsed
+run2_HECollapse_2018 =  cms.Modifier()
 run2_HECollapse_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNorms2017)
-run2_HCAL_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2017)
-run2_HCAL_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2017)
-"""
+run2_HECollapse_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2017)
+run2_HECollapse_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2017)
+run2_HECollapse_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder.positionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2017)
+run2_HECollapse_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2017)
+
 
 # offline 2019
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 run3_HB.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNorms2019)
 run3_HB.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2019)
 run3_HB.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2019)
+run3_HB.toModify(particleFlowClusterHBHE.pfClusterBuilder.positionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2019)
+run3_HB.toModify(particleFlowClusterHBHE.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2019)
 
 # offline phase2 restore what has been studied in the TDR
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 phase2_hcal.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNormsPhase2)
 phase2_hcal.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetectorPhase2)
 phase2_hcal.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetectorPhase2)
+phase2_hcal.toModify(particleFlowClusterHBHE.pfClusterBuilder.positionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetectorPhase2)
+phase2_hcal.toModify(particleFlowClusterHBHE.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetectorPhase2)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -86,3 +86,159 @@ particleFlowClusterHBHE = cms.EDProducer(
     energyCorrector = cms.PSet()
 )
 
+#####
+
+seedFinderThresholdsByDetector2017 = particleFlowClusterHBHE.seedFinder.thresholdsByDetector
+
+seedFinderThresholdsByDetector2018 = particleFlowClusterHBHE.seedFinder.thresholdsByDetector
+seedFinderThresholdsByDetector2018 = cms.VPSet(
+    cms.PSet(
+        detector = cms.string("HCAL_BARREL1"),
+        depths = cms.vint32(1, 2, 3, 4),
+        seedingThreshold = cms.vdouble(1.0, 1.0, 1.0, 1.0),
+        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
+        ),
+    cms.PSet(
+        detector = cms.string("HCAL_ENDCAP"),
+        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+        seedingThreshold = cms.vdouble(0.1375, 0.275, 0.275, 0.275, 0.275, 0.275, 0.275),
+        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        )
+)
+
+seedFinderThresholdsByDetector2019 = particleFlowClusterHBHE.seedFinder.thresholdsByDetector
+seedFinderThresholdsByDetector2019 = cms.VPSet(
+    cms.PSet(
+        detector = cms.string("HCAL_BARREL1"),
+        depths = cms.vint32(1, 2, 3, 4),
+        seedingThreshold = cms.vdouble(0.125, 0.25, 0.25, 0.25),
+        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
+        ),
+    cms.PSet(
+        detector = cms.string("HCAL_ENDCAP"),
+        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+        seedingThreshold = cms.vdouble(0.1375, 0.275, 0.275, 0.275, 0.275, 0.275, 0.275),
+        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        )
+)
+
+seedFinderThresholdsByDetectorPhase2 = cms.VPSet(
+    cms.PSet(
+        detector = cms.string("HCAL_BARREL1"),
+        depths = cms.vint32(1, 2, 3, 4),
+        seedingThreshold = cms.vdouble(0.125, 0.25, 0.25, 0.25),
+        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
+        )
+    )
+
+#######################
+
+initialClusteringStepThresholdsByDetector2017 = particleFlowClusterHBHE.initialClusteringStep.thresholdsByDetector
+
+initialClusteringStepThresholdsByDetector2018 = particleFlowClusterHBHE.initialClusteringStep.thresholdsByDetector
+initialClusteringStepThresholdsByDetector2018 = cms.VPSet(
+    cms.PSet(
+        detector = cms.string("HCAL_BARREL1"),
+        depths = cms.vint32(1, 2, 3, 4),
+        gatheringThreshold = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
+        ),
+    cms.PSet(
+        detector = cms.string("HCAL_ENDCAP"),
+        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+        gatheringThreshold = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2),
+        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        )
+)
+
+initialClusteringStepThresholdsByDetector2019 = particleFlowClusterHBHE.initialClusteringStep.thresholdsByDetector
+initialClusteringStepThresholdsByDetector2019 = cms.VPSet(
+    cms.PSet(
+        detector = cms.string("HCAL_BARREL1"),
+        depths = cms.vint32(1, 2, 3, 4),
+        gatheringThreshold = cms.vdouble(0.1, 0.2, 0.3, 0.3),
+        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
+        ),
+    cms.PSet(
+        detector = cms.string("HCAL_ENDCAP"),
+        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+        gatheringThreshold = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2),
+        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        )
+)
+
+initialClusteringStepThresholdsByDetectorPhase2 = cms.VPSet(
+    cms.PSet(
+        detector = cms.string("HCAL_BARREL1"),
+        depths = cms.vint32(1, 2, 3, 4),
+        gatheringThreshold = cms.vdouble(0.1, 0.2, 0.3, 0.3),
+        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
+        )
+    )
+
+#######################
+
+recHitEnergyNorms2017 = particleFlowClusterHBHE.pfClusterBuilder.recHitEnergyNorms
+
+recHitEnergyNorms2018 = cms.VPSet(
+    cms.PSet(
+        detector = cms.string("HCAL_BARREL1"),
+        depths = cms.vint32(1, 2, 3, 4),
+        recHitEnergyNorm = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+        ),
+    cms.PSet(
+        detector = cms.string("HCAL_ENDCAP"),
+        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+        recHitEnergyNorm = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2),
+        )
+)
+
+recHitEnergyNorms2019 = cms.VPSet(
+    cms.PSet(
+        detector = cms.string("HCAL_BARREL1"),
+        depths = cms.vint32(1, 2, 3, 4),
+        recHitEnergyNorm = cms.vdouble(0.1, 0.2, 0.3, 0.3),
+        ),
+    cms.PSet(
+        detector = cms.string("HCAL_ENDCAP"),
+        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+        recHitEnergyNorm = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2),
+        )
+    )
+
+recHitEnergyNormsPhase2 = cms.VPSet(
+    cms.PSet(
+        detector = cms.string("HCAL_BARREL1"),
+        depths = cms.vint32(1, 2, 3, 4),
+        recHitEnergyNorm = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+        )
+    )
+
+#######################
+
+# offline 2018 -- uncollapsed
+from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+run2_HCAL_2018.toModify(particleFlowClusterHBHE, recHitEnergyNorms = recHitEnergyNorms2018)
+run2_HCAL_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2018)
+run2_HCAL_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2018)
+
+
+"""
+# offline 2018 -- collapsed (this need PR 21842)
+from Configuration.Eras.Modifier_run2_HECollapse_2018_cff import run2_HECollapse_2018
+run2_HECollapse_2018.toModify(particleFlowClusterHBHE, recHitEnergyNorms = recHitEnergyNorms2017)
+run2_HCAL_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2017)
+run2_HCAL_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2017)
+"""
+
+# offline 2019
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toModify(particleFlowClusterHBHE, recHitEnergyNorms = recHitEnergyNorms2019)
+run3_HB.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2019)
+run3_HB.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2019)
+
+# offline phase2 restore what has been studied in the TDR
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+phase2_hcal.toModify(particleFlowClusterHBHE, recHitEnergyNorms = recHitEnergyNormsPhase2)
+phase2_hcal.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetectorPhase2)
+phase2_hcal.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetectorPhase2)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+_thresholdsHB = cms.vdouble(0.8, 0.8, 0.8, 0.8)
+_thresholdsHE = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
+_thresholdsHBphase1 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
+_thresholdsHEphase1 = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0., 0.2)
+
 particleFlowClusterHCAL = cms.EDProducer('PFMultiDepthClusterProducer',
        clustersSource = cms.InputTag("particleFlowClusterHBHE"),
        pfClusterBuilder =cms.PSet(
@@ -12,10 +17,74 @@ particleFlowClusterHCAL = cms.EDProducer('PFMultiDepthClusterProducer',
                algoName = cms.string("Basic2DGenericPFlowPositionCalc"),
                minFractionInCalc = cms.double(1e-9),    
                posCalcNCrystals = cms.int32(-1),
-               logWeightDenominator = cms.double(0.8),#same as gathering threshold
+               logWeightDenominatorByDetector = cms.VPSet(
+                cms.PSet( detector = cms.string("HCAL_BARREL1"),
+                          depths = cms.vint32(1, 2, 3, 4),
+                          logWeightDenominator = _thresholdsHB,
+                          ),
+                cms.PSet( detector = cms.string("HCAL_ENDCAP"),
+                          depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+                          logWeightDenominator = _thresholdsHE,
+                          )
+                ),
                minAllowedNormalization = cms.double(1e-9)
            )
        ),
        positionReCalc = cms.PSet(),
        energyCorrector = cms.PSet()
 )
+
+
+logWeightDenominatorByDetector2017= particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc.logWeightDenominatorByDetector
+
+logWeightDenominatorByDetector2018 = cms.VPSet(
+    cms.PSet( detector = cms.string("HCAL_BARREL1"),
+              depths = cms.vint32(1, 2, 3, 4),
+              logWeightDenominator = _thresholdsHB
+              ),
+    cms.PSet( detector = cms.string("HCAL_ENDCAP"),
+              depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+              logWeightDenominator = _thresholdsHEphase1,
+              )
+    )
+
+logWeightDenominatorByDetector2019 = cms.VPSet(
+    cms.PSet( detector = cms.string("HCAL_BARREL1"),
+              depths = cms.vint32(1, 2, 3, 4),
+              logWeightDenominator = _thresholdsHBphase1,
+              ),
+    cms.PSet( detector = cms.string("HCAL_ENDCAP"),
+              depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+              logWeightDenominator = _thresholdsHEphase1,
+              )
+    )
+
+logWeightDenominatorByDetectorPhase2 = cms.VPSet(
+    cms.PSet( detector = cms.string("HCAL_BARREL1"),
+              depths = cms.vint32(1, 2, 3, 4),
+              logWeightDenominator = _thresholdsHB,
+              ),
+    cms.PSet( detector = cms.string("HCAL_ENDCAP"),
+              depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+              logWeightDenominator = _thresholdsHE,
+              )
+    )
+
+# offline 2018 -- uncollapsed
+from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+run2_HCAL_2018.toModify(particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2018)
+
+from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
+run2_HE_2018.toModify(particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2018)
+
+# offline 2018 -- collapsed
+run2_HECollapse_2018 =  cms.Modifier()
+run2_HECollapse_2018.toModify(particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2017)
+
+# offline 2019
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toModify(particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2019)
+
+# offline phase2 restore what has been studied in the TDR
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+phase2_hcal.toModify(particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetectorPhase2)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 _thresholdsHB = cms.vdouble(0.8, 0.8, 0.8, 0.8)
 _thresholdsHE = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
 _thresholdsHBphase1 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
-_thresholdsHEphase1 = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0., 0.2)
+_thresholdsHEphase1 = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2)
 
 particleFlowClusterHCAL = cms.EDProducer('PFMultiDepthClusterProducer',
        clustersSource = cms.InputTag("particleFlowClusterHBHE"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -85,21 +85,21 @@ cutsPhase2 = cms.VPSet(
 
 # offline 2018 -- uncollapsed
 from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
-run2_HCAL_2018.toModify(particleFlowRecHitHBHE, cuts = cuts2018)
+run2_HCAL_2018.toModify(particleFlowRecHitHBHE.producers[0].qualityTests[0], cuts = cuts2018)
 
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
-run2_HE_2018.toModify(particleFlowRecHitHBHE, cuts = cuts2018)
+run2_HE_2018.toModify(particleFlowRecHitHBHE.producers[0].qualityTests[0], cuts = cuts2018)
 
 """
 # offline 2018 -- collapsed (this need PR 21842)
 from Configuration.Eras.Modifier_run2_HECollapse_2018_cff import run2_HECollapse_2018
-run2_HECollapse_2018.toModify(particleFlowRecHitHBHE, cuts = cuts2017)
+run2_HECollapse_2018.toModify(particleFlowRecHitHBHE.producers[0].qualityTests[0], cuts = cuts2017)
 """
 
 # offline 2019
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
-run3_HB.toModify(particleFlowRecHitHBHE, cuts = cuts2019)
+run3_HB.toModify(particleFlowRecHitHBHE.producers[0].qualityTests[0], cuts = cuts2019)
 
 # offline phase2 restore what has been studied in the TDR
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toModify(particleFlowRecHitHBHE, cuts = cutsPhase2)
+phase2_hcal.toModify(particleFlowRecHitHBHE.producers[0].qualityTests[0], cuts = cutsPhase2)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -1,6 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 from RecoParticleFlow.PFClusterProducer.particleFlowCaloResolution_cfi import _timeResolutionHCAL
 
+_thresholdsHB = cms.vdouble(0.8, 0.8, 0.8, 0.8)
+_thresholdsHE = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
+_thresholdsHBphase1 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
+_thresholdsHEphase1 = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2)
+
+
 particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
     navigator = cms.PSet(
             name = cms.string("PFRecHitHCALNavigator"),
@@ -17,12 +23,12 @@ particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
                   cuts = cms.VPSet(
                         cms.PSet(
                             depth=cms.vint32(1, 2, 3, 4),
-                            threshold = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+                            threshold = _thresholdsHB,
                             detectorEnum = cms.int32(1)
                             ),
                         cms.PSet(
                             depth=cms.vint32(1, 2, 3, 4, 5, 6, 7),
-                            threshold = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8),
+                            threshold = _thresholdsHE,
                             detectorEnum = cms.int32(2)
                             )
                         )
@@ -47,12 +53,12 @@ cuts2017 = particleFlowRecHitHBHE.producers[0].qualityTests[0].cuts
 cuts2018 = cms.VPSet(
     cms.PSet(
         depth=cms.vint32(1, 2, 3, 4),
-        threshold = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+        threshold = _thresholdsHB,
         detectorEnum = cms.int32(1)
         ),
     cms.PSet(
         depth=cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        threshold = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2),
+        threshold = _thresholdsHEphase1,
         detectorEnum = cms.int32(2)
         )
     )
@@ -60,12 +66,12 @@ cuts2018 = cms.VPSet(
 cuts2019 = cms.VPSet(
     cms.PSet(
         depth=cms.vint32(1, 2, 3, 4),
-        threshold = cms.vdouble(0.1, 0.2, 0.3, 0.3),
+        threshold = _thresholdsHBphase1,
         detectorEnum = cms.int32(1)
         ),
     cms.PSet(
         depth=cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        threshold = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2),
+        threshold = _thresholdsHEphase1,
         detectorEnum = cms.int32(2)
         )
     )
@@ -73,12 +79,12 @@ cuts2019 = cms.VPSet(
 cutsPhase2 = cms.VPSet(
     cms.PSet(
         depth=cms.vint32(1, 2, 3, 4),
-        threshold = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+        threshold = _thresholdsHB,
         detectorEnum = cms.int32(1)
         ),
     cms.PSet(
         depth=cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        threshold = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8),
+        threshold = _thresholdsHE,
         detectorEnum = cms.int32(2)
         )
     )
@@ -90,11 +96,9 @@ run2_HCAL_2018.toModify(particleFlowRecHitHBHE.producers[0].qualityTests[0], cut
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
 run2_HE_2018.toModify(particleFlowRecHitHBHE.producers[0].qualityTests[0], cuts = cuts2018)
 
-"""
-# offline 2018 -- collapsed (this need PR 21842)
-from Configuration.Eras.Modifier_run2_HECollapse_2018_cff import run2_HECollapse_2018
+# offline 2018 -- collapsed
+run2_HECollapse_2018 =  cms.Modifier()
 run2_HECollapse_2018.toModify(particleFlowRecHitHBHE.producers[0].qualityTests[0], cuts = cuts2017)
-"""
 
 # offline 2019
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -75,13 +75,20 @@ cutsPhase2 = cms.VPSet(
         depth=cms.vint32(1, 2, 3, 4),
         threshold = cms.vdouble(0.8, 0.8, 0.8, 0.8),
         detectorEnum = cms.int32(1)
+        ),
+    cms.PSet(
+        depth=cms.vint32(1, 2, 3, 4, 5, 6, 7),
+        threshold = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8),
+        detectorEnum = cms.int32(2)
         )
     )
-
 
 # offline 2018 -- uncollapsed
 from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
 run2_HCAL_2018.toModify(particleFlowRecHitHBHE, cuts = cuts2018)
+
+from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
+run2_HE_2018.toModify(particleFlowRecHitHBHE, cuts = cuts2018)
 
 """
 # offline 2018 -- collapsed (this need PR 21842)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -13,8 +13,19 @@ particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
              src  = cms.InputTag("hbhereco",""),
              qualityTests = cms.VPSet(
                   cms.PSet(
-                  name = cms.string("PFRecHitQTestThreshold"),
-                  threshold = cms.double(0.8)
+                  name = cms.string("PFRecHitQTestHCALThresholdVsDepth"),
+                  cuts = cms.VPSet(
+                        cms.PSet(
+                            depth=cms.vint32(1, 2, 3, 4),
+                            threshold = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+                            detectorEnum = cms.int32(1)
+                            ),
+                        cms.PSet(
+                            depth=cms.vint32(1, 2, 3, 4, 5, 6, 7),
+                            threshold = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8),
+                            detectorEnum = cms.int32(2)
+                            )
+                        )
                   ),
                   cms.PSet(
                       name = cms.string("PFRecHitQTestHCALChannel"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -42,3 +42,57 @@ particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
 
 )
 
+cuts2017 = particleFlowRecHitHBHE.producers[0].qualityTests[0].cuts
+
+cuts2018 = cms.VPSet(
+    cms.PSet(
+        depth=cms.vint32(1, 2, 3, 4),
+        threshold = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+        detectorEnum = cms.int32(1)
+        ),
+    cms.PSet(
+        depth=cms.vint32(1, 2, 3, 4, 5, 6, 7),
+        threshold = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2),
+        detectorEnum = cms.int32(2)
+        )
+    )
+
+cuts2019 = cms.VPSet(
+    cms.PSet(
+        depth=cms.vint32(1, 2, 3, 4),
+        threshold = cms.vdouble(0.1, 0.2, 0.3, 0.3),
+        detectorEnum = cms.int32(1)
+        ),
+    cms.PSet(
+        depth=cms.vint32(1, 2, 3, 4, 5, 6, 7),
+        threshold = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2),
+        detectorEnum = cms.int32(2)
+        )
+    )
+
+cutsPhase2 = cms.VPSet(
+    cms.PSet(
+        depth=cms.vint32(1, 2, 3, 4),
+        threshold = cms.vdouble(0.8, 0.8, 0.8, 0.8),
+        detectorEnum = cms.int32(1)
+        )
+    )
+
+
+# offline 2018 -- uncollapsed
+from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+run2_HCAL_2018.toModify(particleFlowRecHitHBHE, cuts = cuts2018)
+
+"""
+# offline 2018 -- collapsed (this need PR 21842)
+from Configuration.Eras.Modifier_run2_HECollapse_2018_cff import run2_HECollapse_2018
+run2_HECollapse_2018.toModify(particleFlowRecHitHBHE, cuts = cuts2017)
+"""
+
+# offline 2019
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toModify(particleFlowRecHitHBHE, cuts = cuts2019)
+
+# offline phase2 restore what has been studied in the TDR
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+phase2_hcal.toModify(particleFlowRecHitHBHE, cuts = cutsPhase2)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHF_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHF_cfi.py
@@ -1,4 +1,3 @@
-
 import FWCore.ParameterSet.Config as cms
 
 #HB HE HO rec hits
@@ -33,13 +32,11 @@ particleFlowRecHitHF = cms.EDProducer("PFRecHitProducer",
                       name = cms.string("PFRecHitQTestHCALThresholdVsDepth"),
                       cuts = cms.VPSet(
                              cms.PSet(
-                                 depth = cms.int32(1),
-                                 threshold = cms.double(1.2)),
-                             cms.PSet(
-                                 depth = cms.int32(2),
-                                 threshold = cms.double(1.8))
+                                 depth = cms.vint32(1,2),
+                                 threshold = cms.vdouble(1.2,1.8),
+                                 detectorEnum = cms.int32(4))
                       )
-                  )   
+                  )
                       
           )
     )             


### PR DESCRIPTION
PFRecHit PFClusters take different thresholds for HCAL for each depth

Customized the siPM PF threshold for the phase 2018 (siPM in HE) and 2019 (siPM in HB/HE)

Offline:
Expected minor changes in the 2018,2019 scenario.
No Change at all in the Run1/Run2 including the 2017 and neither in the Phase2 
Online: 
No changes expected for HLT  since the preferred scenario is the collapsing

Reference for the thresholds 
https://indico.cern.ch/event/689725/contributions/2832041/attachments/1581339/2499023/20180111_-_HE_upgrade_-_DPG_report.pdf

@gpetruc @deguio

