### PR TITLE
New thresholds for gathering and seeding in PF in EE, and deactivation of SR@PF

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
@@ -38,8 +38,8 @@ _localMaxSeeds_ECAL = cms.PSet(
     algoName = cms.string("LocalMaximumSeedFinder"),
     thresholdsByDetector = cms.VPSet(
     cms.PSet( detector = cms.string("ECAL_ENDCAP"),
-              seedingThreshold = cms.double(0.6),
-              seedingThresholdPt = cms.double(0.15)
+              seedingThreshold = cms.double(0.50),
+              seedingThresholdPt = cms.double(0.50)
               ),
     cms.PSet( detector = cms.string("ECAL_BARREL"),
               seedingThreshold = cms.double(0.23),
@@ -58,8 +58,8 @@ _topoClusterizer_ECAL = cms.PSet(
               gatheringThresholdPt = cms.double(0.0)
               ),
     cms.PSet( detector = cms.string("ECAL_ENDCAP"),
-              gatheringThreshold = cms.double(0.3),
-              gatheringThresholdPt = cms.double(0.0)
+              gatheringThreshold = cms.double(0.50),
+              gatheringThresholdPt = cms.double(0.50)
               )
     ),
     useCornerCells = cms.bool(True)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
@@ -38,8 +38,8 @@ _localMaxSeeds_ECAL = cms.PSet(
     algoName = cms.string("LocalMaximumSeedFinder"),
     thresholdsByDetector = cms.VPSet(
     cms.PSet( detector = cms.string("ECAL_ENDCAP"),
-              seedingThreshold = cms.double(0.50),
-              seedingThresholdPt = cms.double(0.50)
+              seedingThreshold = cms.double(0.60),
+              seedingThresholdPt = cms.double(0.15)
               ),
     cms.PSet( detector = cms.string("ECAL_BARREL"),
               seedingThreshold = cms.double(0.23),
@@ -58,8 +58,8 @@ _topoClusterizer_ECAL = cms.PSet(
               gatheringThresholdPt = cms.double(0.0)
               ),
     cms.PSet( detector = cms.string("ECAL_ENDCAP"),
-              gatheringThreshold = cms.double(0.50),
-              gatheringThresholdPt = cms.double(0.50)
+              gatheringThreshold = cms.double(0.3),
+              gatheringThresholdPt = cms.double(0.0)
               )
     ),
     useCornerCells = cms.bool(True)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -19,8 +19,8 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
              srFlags = cms.InputTag("ecalDigis"),
              qualityTests = cms.VPSet(
                   cms.PSet(
-                  name = cms.string("PFRecHitQTestECALMultiThreshold"),
-                  thresholds = particle_flow_zero_suppression_ECAL.thresholds
+                  name = cms.string("PFRecHitQTestThreshold"),
+                  threshold = cms.double(0.08)
                   ),
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECAL"),
@@ -37,8 +37,8 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
             srFlags = cms.InputTag("ecalDigis"),
             qualityTests = cms.VPSet(
                  cms.PSet(
-                 name = cms.string("PFRecHitQTestECALMultiThreshold"),
-                 thresholds = particle_flow_zero_suppression_ECAL.thresholds
+                 name = cms.string("PFRecHitQTestThreshold"),
+                 threshold = cms.double(0.3)
                  ),
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECAL"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -16,11 +16,11 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
            cms.PSet(
              name = cms.string("PFEBRecHitCreator"),
              src  = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
-             srFlags = cms.InputTag("ecalDigis"),
+             srFlags = cms.InputTag(""),
              qualityTests = cms.VPSet(
                   cms.PSet(
-                  name = cms.string("PFRecHitQTestThreshold"),
-                  threshold = cms.double(0.08)
+                  name = cms.string("PFRecHitQTestECALMultiThreshold"),
+                  thresholds = particle_flow_zero_suppression_ECAL.thresholds
                   ),
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECAL"),
@@ -34,11 +34,11 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
           cms.PSet(
             name = cms.string("PFEERecHitCreator"),
             src  = cms.InputTag("ecalRecHit","EcalRecHitsEE"),
-            srFlags = cms.InputTag("ecalDigis"),
+            srFlags = cms.InputTag(""),
             qualityTests = cms.VPSet(
                  cms.PSet(
-                 name = cms.string("PFRecHitQTestThreshold"),
-                 threshold = cms.double(0.3)
+                 name = cms.string("PFRecHitQTestECALMultiThreshold"),
+                 thresholds = particle_flow_zero_suppression_ECAL.thresholds
                  ),
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECAL"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
@@ -23,8 +23,8 @@ _particle_flow_zero_suppression_ECAL_2017 = cms.PSet(
         )
     )
 
-from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
-run2_ECAL_2017.toReplaceWith(particle_flow_zero_suppression_ECAL, _particle_flow_zero_suppression_ECAL_2017)
+#from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
+#run2_ECAL_2017.toReplaceWith(particle_flow_zero_suppression_ECAL, _particle_flow_zero_suppression_ECAL_2017)
 
-from Configuration.Eras.Modifier_phase2_ecal_cff import phase2_ecal
-phase2_ecal.toReplaceWith(particle_flow_zero_suppression_ECAL, _particle_flow_zero_suppression_ECAL_2017)
+#from Configuration.Eras.Modifier_phase2_ecal_cff import phase2_ecal
+#phase2_ecal.toReplaceWith(particle_flow_zero_suppression_ECAL, _particle_flow_zero_suppression_ECAL_2017)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
@@ -23,6 +23,16 @@ _particle_flow_zero_suppression_ECAL_2017 = cms.PSet(
         )
     )
 
+# 
+# The following commented lines were used in 2017 to set SR@PF eta dependent thresholds
+# as defined in _particle_flow_zero_suppression_ECAL_2017
+#
+# For 2018 the thresholds have been temporarily removed (lowered to 80 MeV in EB and 300 MeV in EE,
+# then overseeded by the gathering and seeding PF cluster thresholds)
+# Later, we may need to reintroduce eta dependent thresholds
+# to mitigate the effect of the noise
+#
+
 #from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
 #run2_ECAL_2017.toReplaceWith(particle_flow_zero_suppression_ECAL, _particle_flow_zero_suppression_ECAL_2017)
 


### PR DESCRIPTION
Deactivation of SR@PF for 2018.
80 MeV in EB and 300 MeV in EE in ZS regions is applied (negligible given the seeding and gathering thresholds, see below).

Update of PF ECAL cluster thresholds: seeding (500 MeV in E_T) and gathering (500 MeV in E_T) in EE.
EB thresholds for PF ECAL cluster are left untouched.

See the minutes of Fri 12th Jan meeting for details: https://indico.cern.ch/event/662757/attachments/1582189/2500613/EGM-ECAL_Minutes_120118.pdf

@argiro @crovelli 