### PR TITLE
Adding HCal depth information to PFCandidates

### DIFF
--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
@@ -10,6 +10,7 @@
 #include <atomic>
 #endif
 #include <iosfwd>
+#include <array>
 
 #include "DataFormats/Math/interface/Point3D.h"
 
@@ -423,6 +424,12 @@ namespace reco {
     /// \set the timing information
     void setTime(float time, float timeError = 0.f) { time_ = time; timeError_ = timeError; }
 
+    /// fraction of hcal energy at a given depth  (depth = 1 .. 7)
+    float hcalDepthEnergyFraction(unsigned int depth) const { return hcalDepthEnergyFractions_[depth-1]; }
+    /// fraction of hcal energy at a given depth (index 0..6 for depth 1..7)
+    const std::array<float,7> & hcalDepthEnergyFractions() const { return hcalDepthEnergyFractions_; }
+    /// set the fraction of hcal energy as function of depth (index 0..6 for depth 1..7)
+    void setHcalDepthEnergyFractions(const std::array<float,7> & fracs) { hcalDepthEnergyFractions_ = fracs; }
   private:
     /// Polymorphic overlap
     bool overlap( const Candidate & ) const override;
@@ -523,6 +530,8 @@ namespace reco {
     float time_;
     /// timing information uncertainty (<0 if timing not available)
     float timeError_;
+
+    std::array<float,7> hcalDepthEnergyFractions_;
 
   };
 

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -56,6 +56,7 @@ PFCandidate::PFCandidate() :
   
   setPdgId( translateTypeToPdgId( X ) );
   refsInfo_.reserve(3);
+  std::fill(hcalDepthEnergyFractions_.begin(), hcalDepthEnergyFractions_.end(), 0.f);
 }
 
 
@@ -63,6 +64,7 @@ PFCandidate::PFCandidate( const PFCandidatePtr& sourcePtr ):
   PFCandidate(*sourcePtr)
 {
   sourcePtr_ = sourcePtr;
+  hcalDepthEnergyFractions_ = sourcePtr->hcalDepthEnergyFractions_; // GP not sure it's needed
 }
 
 
@@ -96,6 +98,7 @@ PFCandidate::PFCandidate( Charge charge,
   refsInfo_.reserve(3);
   blocksStorage_.reserve(10);
   elementsStorage_.reserve(10);
+  std::fill(hcalDepthEnergyFractions_.begin(), hcalDepthEnergyFractions_.end(), 0.f);
 
   muonTrackType_ = reco::Muon::None;
 
@@ -155,7 +158,8 @@ PFCandidate::PFCandidate( PFCandidate const& iOther) :
   storedRefsBitPattern_(iOther.storedRefsBitPattern_),
   refsInfo_(iOther.refsInfo_),
   refsCollectionCache_(iOther.refsCollectionCache_),
-  time_(iOther.time_),timeError_(iOther.timeError_)
+  time_(iOther.time_),timeError_(iOther.timeError_),
+  hcalDepthEnergyFractions_(iOther.hcalDepthEnergyFractions_)
 {
   auto tmp = iOther.elementsInBlocks_.load(std::memory_order_acquire);
   if(nullptr != tmp) {
@@ -200,7 +204,7 @@ PFCandidate& PFCandidate::operator=(PFCandidate const& iOther) {
   refsCollectionCache_=iOther.refsCollectionCache_;
   time_=iOther.time_;
   timeError_=iOther.timeError_;
-
+  hcalDepthEnergyFractions_=iOther.hcalDepthEnergyFractions_;
   return *this;
 }
 

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 
-   <class name="reco::PFCandidate" ClassVersion="18">
+   <class name="reco::PFCandidate" ClassVersion="19">
+    <version ClassVersion="19" checksum="2990582232"/>
     <version ClassVersion="18" checksum="910857761"/>
     <version ClassVersion="17" checksum="3126170233"/>
     <version ClassVersion="16" checksum="3060382005"/>
@@ -51,7 +52,8 @@
   <class name="edm::PtrVector<reco::PFCandidate> "/>
   <class name="edm::Wrapper<edm::PtrVector<reco::PFCandidate> >"/>
 
-  <class name="reco::IsolatedPFCandidate"  ClassVersion="14">
+  <class name="reco::IsolatedPFCandidate"  ClassVersion="15">
+   <version ClassVersion="15" checksum="3042264953"/>
    <version ClassVersion="14" checksum="207328514"/>
    <version ClassVersion="13" checksum="1855164250"/>
    <version ClassVersion="12" checksum="2650360086"/>
@@ -65,7 +67,8 @@
   <class name="reco::IsolatedPFCandidateRefVector"/>
   <class name="reco::IsolatedPFCandidatePtr"/>
 
-  <class name="reco::PileUpPFCandidate"  ClassVersion="14">
+  <class name="reco::PileUpPFCandidate"  ClassVersion="15">
+   <version ClassVersion="15" checksum="953549166"/>
    <version ClassVersion="14" checksum="4065938015"/>
    <version ClassVersion="13" checksum="1734488695"/>
    <version ClassVersion="12" checksum="2377890195"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -285,7 +285,8 @@
    <version ClassVersion="11" checksum="3492108938"/>
    <version ClassVersion="10" checksum="417284221"/>
   </class>
-  <class name="pat::PFParticle"  ClassVersion="14">
+  <class name="pat::PFParticle"  ClassVersion="15">
+   <version ClassVersion="15" checksum="1485536104"/>
    <version ClassVersion="14" checksum="2795911745"/>
    <version ClassVersion="13" checksum="223824921"/>
    <version ClassVersion="12" checksum="4118931093"/>

--- a/RecoParticleFlow/PFProducer/interface/PFAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFAlgo.h
@@ -263,6 +263,7 @@ class PFAlgo {
 			       double particleY=0.,
 			       double particleZ=0.);
 
+  void setHcalDepthInfo(reco::PFCandidate & cand, const reco::PFCluster& cluster) const ;
 
   /// \return calibrated energy of a photon
   // double gammaCalibratedEnergy( double clusterEnergy ) const;

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -1882,6 +1882,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	} else {
 	  (*pfCandidates_)[tmpi].setHcalEnergy(totalHcal, muonHcal);
 	}
+        setHcalDepthInfo((*pfCandidates_)[tmpi], *hclusterref);
 
 	if(letMuonEatCaloEnergy){
 	  muonHCALEnergy += totalHcal;
@@ -2221,6 +2222,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	    (*pfCandidates_)[tmpi].setHcalEnergy(max(totalHcal-totalHO,0.0),muonHcal);
 	    (*pfCandidates_)[tmpi].setHoEnergy(hoclusterref->energy(),muonHO);
 	  }
+          setHcalDepthInfo((*pfCandidates_)[tmpi], *hclusterref);
 	  // Remove it from the block
 	  const ::math::XYZPointF& chargedPosition = 
 	    dynamic_cast<const reco::PFBlockElementTrack*>(&elements[it->second.first])->positionAtECALEntrance();	  
@@ -2392,6 +2394,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 
       (*pfCandidates_)[tmpi].addElementInBlock( blockref, iTrack );
       (*pfCandidates_)[tmpi].addElementInBlock( blockref, iHcal );
+      setHcalDepthInfo((*pfCandidates_)[tmpi], *hclusterref);
       std::pair<II,II> myEcals = associatedEcals.equal_range(iTrack);
       for (II ii=myEcals.first; ii!=myEcals.second; ++ii ) { 
 	unsigned iEcal = ii->second.second;
@@ -3314,13 +3317,14 @@ PFAlgo::setHcalDepthInfo(reco::PFCandidate & cand, const reco::PFCluster& cluste
         }
     }
     double sum = std::accumulate(energyPerDepth.begin(), energyPerDepth.end(), 0.);
+    std::array<float,7> depthFractions;
+    std::fill(depthFractions.begin(), depthFractions.end(), 0.f);
     if (sum > 0) {
-        std::array<float,7> depthFractions;
         for (unsigned int i = 0; i < depthFractions.size(); ++i) {
             depthFractions[i] = energyPerDepth[i]/sum;
         }
-        cand.setHcalDepthEnergyFractions(depthFractions);
     }
+    cand.setHcalDepthEnergyFractions(depthFractions);
 }
 
 //GMA need the followign two for HO also

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -3318,11 +3318,12 @@ PFAlgo::setHcalDepthInfo(reco::PFCandidate & cand, const reco::PFCluster& cluste
     }
     double sum = std::accumulate(energyPerDepth.begin(), energyPerDepth.end(), 0.);
     std::array<float,7> depthFractions;
-    std::fill(depthFractions.begin(), depthFractions.end(), 0.f);
     if (sum > 0) {
         for (unsigned int i = 0; i < depthFractions.size(); ++i) {
             depthFractions[i] = energyPerDepth[i]/sum;
         }
+    } else {
+        std::fill(depthFractions.begin(), depthFractions.end(), 0.f);
     }
     cand.setHcalDepthEnergyFractions(depthFractions);
 }


### PR DESCRIPTION
Energy fractions at different depths stored,  as `std::array<float,7>`.

Disk size cost on AODSIM for ttbar with PU is ~1% or less (http://gpetrucc.web.cern.ch/gpetrucc/micro/reco.html#recoPFCandidates_particleFlow__RECO vs http://gpetrucc.web.cern.ch/gpetrucc/micro/reco.0.html#recoPFCandidates_particleFlow__RECO)

Checked some ttbar events from `10_0_0_pre3` and output looks reasonable. 

Note that the depth information is from the PFCluster, and one PFCluster can correspond to multiple PFCandidates (e.g within a jet), so the information is to be interpreted with some grain of salt.

@mariadalfonso @deguio @bachtis @arizzi 