### PR TITLE
ConcurrentmonitorElement: add method to call TH1::Sumw2()

### DIFF
--- a/DQMServices/Core/interface/ConcurrentMonitorElement.h
+++ b/DQMServices/Core/interface/ConcurrentMonitorElement.h
@@ -136,6 +136,11 @@ public:
     me_->setBinLabel(bin, label, axis);
   }
 
+  void enableSumw2()
+  {
+    me_->getTH1()->Sumw2();
+  }
+
 };
 
 #endif // DQMServices_Core_ConcurrentMonitorElement_h


### PR DESCRIPTION
As requested by @makortel in #21794.