### PR TITLE
[New GT][2018 realistic and cosmic realistic] 2018 GEM,HCAL geom + ECAL thresholds for 2018

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -48,11 +48,11 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' : '100X_mc2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '100X_upgrade2018_design_IdealBS_v3',
+    'phase1_2018_design'       : '100X_upgrade2018_design_IdealBS_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v5',
+    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v4',
+    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '100X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -50,9 +50,9 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '100X_upgrade2018_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v4',
+    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v3',
+    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '100X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
CHANGES:
**2018 realistic: 100X_upgrade2018_realistic_v6**
Diff with old GT:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018_realistic_v6/100X_upgrade2018_realistic_v4
-> 2018 GEM and HCAL geom. + New ECAL thresholds

**2018 realistic cosmics: 100X_upgrade2018cosmics_realistic_deco_v5** 
Diff with old GT:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018cosmics_realistic_deco_v5/100X_upgrade2018cosmics_realistic_deco_v3
-> 2018 GEM and HCAL geom. + New ECAL thresholds + HCAL  Channel Quality, LUTCorrs. RespCorrs, ZSThresholds,  QIEData

**2018 ideal: 100X_upgrade2018_design_IdealBS_v4** 
Diff with old GT:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018_design_IdealBS_v4/100X_upgrade2018_design_IdealBS_v3
-> 2018 GEM and HCAL geom. + HCAL Channel Quality, LUTCorrs. RespCorrs, ZSThresholds, QIEData
NOTES:
. The new conditions will be signed off during the PPD meeting on Jan 18