### PR TITLE
[10_1_X] SiStrip Gains conditions DB manipulation tools

### DIFF
--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -1107,7 +1107,7 @@ namespace {
       std::vector<std::string> parts = {"TEC","TOB","TIB","TID"};
       
       for ( const auto &part : parts){
-	ratios[part]   = std::make_shared<TH1F>(Form("hRatio_%s",part.c_str()),Form("Gains ratio IOV: %s/ IOV: %s ;New Gain (%s) / Previous Gain (%s);Number of APV",lastIOVsince.c_str(),firstIOVsince.c_str(),lastIOVsince.c_str(),firstIOVsince.c_str()),200,0.,2.);
+	ratios[part]   = std::make_shared<TH1F>(Form("hRatio_%s",part.c_str()),Form("Gains ratio IOV: %s/ IOV: %s ;Previous Gain (%s) / New Gain (%s);Number of APV",firstIOVsince.c_str(),lastIOVsince.c_str(),firstIOVsince.c_str(),lastIOVsince.c_str()),200,0.,2.);
 	scatters[part] = std::make_shared<TH2F>(Form("hScatter_%s",part.c_str()),Form("new Gain (%s) vs previous Gain (%s);Previous Gain (%s);New Gain (%s)",lastIOVsince.c_str(),firstIOVsince.c_str(),firstIOVsince.c_str(),lastIOVsince.c_str()),100,0.5,1.8,100,0.5,1.8);
       }
       
@@ -1152,6 +1152,7 @@ namespace {
 
       for (const auto &part : parts){
 	SiStripPI::makeNicePlotStyle(ratios[part].get());
+	ratios[part]->SetMinimum(1.);
 	ratios[part]->SetStats(false);
 	ratios[part]->SetLineWidth(2);
 	ratios[part]->SetLineColor(colormap[part]);
@@ -1301,8 +1302,8 @@ namespace {
       h_firstGains->SetMarkerSize(1.);
       h_lastGains->SetMarkerSize(1.);
 
-      h_firstGains->SetLineWidth(1.5);
-      h_lastGains->SetLineWidth(1.5);
+      h_firstGains->SetLineWidth(1);
+      h_lastGains->SetLineWidth(1);
 
       h_firstGains->SetMarkerStyle(20);
       h_lastGains->SetMarkerStyle(21);

--- a/CondTools/SiStrip/plugins/SiStripApvGainRescaler.cc
+++ b/CondTools/SiStrip/plugins/SiStripApvGainRescaler.cc
@@ -1,0 +1,215 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/SiStrip
+// Class:      SiStripApvGainRescaler
+// 
+/**\class SiStripApvGainRescaler SiStripApvGainRescaler.cc CondTools/SiStrip/plugins/SiStripApvGainRescaler.cc
+
+ Description: Utility class to rescale the values of SiStrip G2 by the ratio of G1_old/G1_new: this is useful in the case in which a Gain2 payload needs to recycled after a G1 update to keep the G1*G2 product constant
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Marco Musich
+//         Created:  Tue, 03 Oct 2017 12:57:34 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
+#include "CondFormats/DataRecord/interface/SiStripApvGainRcd.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
+#include "CalibTracker/Records/interface/SiStripGainRcd.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+//
+// class declaration
+//
+
+// If the analyzer does not use TFileService, please remove
+// the template argument to the base class so the class inherits
+// from  edm::one::EDAnalyzer<> and also remove the line from
+// constructor "usesResource("TFileService");"
+// This will improve performance in multithreaded jobs.
+
+class SiStripApvGainRescaler : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
+   public:
+      explicit SiStripApvGainRescaler(const edm::ParameterSet&);
+      ~SiStripApvGainRescaler();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginJob() override;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      std::unique_ptr<SiStripApvGain> getNewObject(const std::map<std::pair<uint32_t,int>,float>& theMap);
+      virtual void endJob() override;
+
+      // ----------member data ---------------------------
+      const std::string m_Record;  
+ 
+};
+
+//
+// constructors and destructor
+//
+SiStripApvGainRescaler::SiStripApvGainRescaler(const edm::ParameterSet& iConfig):
+  m_Record(iConfig.getParameter<std::string> ("Record"))
+{
+   //now do what ever initialization is needed
+   usesResource("TFileService");
+}
+
+SiStripApvGainRescaler::~SiStripApvGainRescaler()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+SiStripApvGainRescaler::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+   // take G2_old and G1_old from the regular gain handle
+   edm::ESHandle<SiStripGain> g1g2Handle_;
+   iSetup.get<SiStripGainRcd>().get(g1g2Handle_);
+
+   // take the additional G1_new from the Gain3Rcd (dirty trick)
+   edm::ESHandle<SiStripApvGain> g3Handle_;
+   iSetup.get<SiStripApvGain3Rcd>().get(g3Handle_);
+
+   std::map<std::pair<uint32_t,int>,float> theMap;
+   
+   std::vector<uint32_t> detid;
+   g1g2Handle_->getDetIds(detid);
+   for (const auto & d : detid) {
+
+     SiStripApvGain::Range rangeG1_old = g1g2Handle_->getRange(d,0);	
+     SiStripApvGain::Range rangeG2_old = g1g2Handle_->getRange(d,1);	
+     SiStripApvGain::Range rangeG1_new = g3Handle_->getRange(d);	
+	      
+     int nAPV=0;
+     for(int it=0;it<rangeG1_old.second-rangeG1_old.first;it++){
+       nAPV++;
+
+       std::pair<uint32_t,int> index = std::make_pair(d,nAPV);
+
+       float G1_old = g1g2Handle_->getApvGain(it,rangeG1_old);
+       float G2_old = g1g2Handle_->getApvGain(it,rangeG2_old);
+       float G1G2_old = G1_old*G2_old;
+       float G1_new = g3Handle_->getApvGain(it,rangeG1_new);
+
+       // this is based on G1_old*G2_old = G1_new * G2_new ==> G2_new = (G1_old*G2_old)/G1_new
+
+       float NewGain = G1G2_old/G1_new;
+
+       // DO NOT RESCALE APVs set to the default value
+       if(G2_old!=1.){
+	 theMap[index]=NewGain;
+       } else {
+	 theMap[index]=1.;
+       }
+
+     } // loop over APVs
+   } // loop over DetIds
+
+   std::unique_ptr<SiStripApvGain> theAPVGains = this->getNewObject(theMap);
+
+   // write out the APVGains record
+   edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  
+   if( poolDbService.isAvailable() )
+     poolDbService->writeOne(theAPVGains.get(),poolDbService->currentTime(),m_Record);
+   else
+     throw std::runtime_error("PoolDBService required.");
+ 
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+SiStripApvGainRescaler::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+SiStripApvGainRescaler::endJob() 
+{
+}
+
+//********************************************************************************//
+std::unique_ptr<SiStripApvGain>
+SiStripApvGainRescaler::getNewObject(const std::map<std::pair<uint32_t,int>,float>& theMap) 
+{
+  std::unique_ptr<SiStripApvGain> obj = std::unique_ptr<SiStripApvGain>(new SiStripApvGain());
+  
+  std::vector<float> theSiStripVector;
+  uint32_t PreviousDetId = 0; 
+  for(const auto &element : theMap){
+    uint32_t DetId = element.first.first;
+    if(DetId != PreviousDetId){
+      if(!theSiStripVector.empty()){
+	SiStripApvGain::Range range(theSiStripVector.begin(),theSiStripVector.end());
+	if ( !obj->put(PreviousDetId,range) )  printf("Bug to put detId = %i\n",PreviousDetId);
+      }
+      theSiStripVector.clear();
+      PreviousDetId = DetId;
+    }
+    theSiStripVector.push_back(element.second);
+    
+    edm::LogInfo("SiStripApvGainRescaler")<<" DetId: "<<DetId 
+					      <<" APV:   "<<element.first.second
+					      <<" Gain:  "<<element.second
+					      <<std::endl;
+  }
+  
+  if(!theSiStripVector.empty()){
+    SiStripApvGain::Range range(theSiStripVector.begin(),theSiStripVector.end());
+    if ( !obj->put(PreviousDetId,range) )  printf("Bug to put detId = %i\n",PreviousDetId);
+  }
+  
+  return obj;
+}
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+SiStripApvGainRescaler::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  
+  desc.setComment(" Utility class to rescale the values of SiStrip G2 by the ratio of G1_old/G1_new: this is useful in the case in which a Gain2 payload needs to recycled after a G1 update to keep the G1*G2 product constant."
+		  "PoolDBOutputService must be set up for 'SiStripApvGainRcd'.");
+  
+  desc.add<std::string>("Record","SiStripApvGainRcd");
+  descriptions.add("rescaleGain2byGain1", desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SiStripApvGainRescaler);

--- a/CondTools/SiStrip/plugins/SiStripApvGainRescaler.cc
+++ b/CondTools/SiStrip/plugins/SiStripApvGainRescaler.cc
@@ -44,13 +44,7 @@
 // class declaration
 //
 
-// If the analyzer does not use TFileService, please remove
-// the template argument to the base class so the class inherits
-// from  edm::one::EDAnalyzer<> and also remove the line from
-// constructor "usesResource("TFileService");"
-// This will improve performance in multithreaded jobs.
-
-class SiStripApvGainRescaler : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
+class SiStripApvGainRescaler : public edm::one::EDAnalyzer<>  {
    public:
       explicit SiStripApvGainRescaler(const edm::ParameterSet&);
       ~SiStripApvGainRescaler();
@@ -75,7 +69,6 @@ SiStripApvGainRescaler::SiStripApvGainRescaler(const edm::ParameterSet& iConfig)
   m_Record(iConfig.getParameter<std::string> ("Record"))
 {
    //now do what ever initialization is needed
-   usesResource("TFileService");
 }
 
 SiStripApvGainRescaler::~SiStripApvGainRescaler()

--- a/CondTools/SiStrip/plugins/SiStripChannelGainFromDBMiscalibrator.cc
+++ b/CondTools/SiStrip/plugins/SiStripChannelGainFromDBMiscalibrator.cc
@@ -1,0 +1,418 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/SiStrip
+// Class:      SiStripChannelGainFromDBMiscalibrator
+// 
+/**\class SiStripChannelGainFromDBMiscalibrator SiStripChannelGainFromDBMiscalibrator.cc CondTools/SiStrip/plugins/SiStripChannelGainFromDBMiscalibrator.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Marco Musich
+//         Created:  Tue, 03 Oct 2017 12:57:34 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
+#include "CondFormats/DataRecord/interface/SiStripApvGainRcd.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
+#include "CalibTracker/Records/interface/SiStripGainRcd.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h" 
+#include "Geometry/Records/interface/TrackerTopologyRcd.h" 
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h" 
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h" 
+#include "CondFormats/SiStripObjects/interface/SiStripSummary.h"
+
+#include "TRandom3.h"
+
+//
+// class declaration
+//
+
+namespace ApvGain {
+  struct GainSmearings{
+    GainSmearings(){
+      m_doScale = false;
+      m_doSmear = false;
+      m_scaleFactor = 1.;
+      m_smearFactor = 0.;
+    }
+    ~GainSmearings(){}
+    
+    void setSmearing(bool doScale,bool doSmear,double the_scaleFactor,double the_smearFactor){
+      m_doScale = doScale;
+      m_doSmear = doSmear;
+      m_scaleFactor = the_scaleFactor;
+      m_smearFactor = the_smearFactor;
+    }
+    
+    bool m_doScale;
+    bool m_doSmear;
+    double m_scaleFactor;
+    double m_smearFactor;
+  };
+
+}
+
+// If the analyzer does not use TFileService, please remove
+// the template argument to the base class so the class inherits
+// from  edm::one::EDAnalyzer<> and also remove the line from
+// constructor "usesResource("TFileService");"
+// This will improve performance in multithreaded jobs.
+
+class SiStripChannelGainFromDBMiscalibrator : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
+   public:
+      explicit SiStripChannelGainFromDBMiscalibrator(const edm::ParameterSet&);
+      ~SiStripChannelGainFromDBMiscalibrator();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginJob() override;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      std::unique_ptr<SiStripApvGain> getNewObject(const std::map<std::pair<uint32_t,int>,float>& theMap);
+      sistripsummary::TrackerRegion getRegionFromString(std::string region);
+      std::vector<sistripsummary::TrackerRegion> getRegionsFromDetId(const TrackerTopology* tTopo,DetId detid);
+      virtual void endJob() override;
+
+      // ----------member data ---------------------------
+      const std::string m_Record;  
+      const uint32_t m_gainType;
+      const std::vector<edm::ParameterSet> m_parameters;
+};
+
+//
+// constructors and destructor
+//
+SiStripChannelGainFromDBMiscalibrator::SiStripChannelGainFromDBMiscalibrator(const edm::ParameterSet& iConfig):
+  m_Record{iConfig.getUntrackedParameter<std::string> ("record" , "SiStripApvGainRcd")},
+  m_gainType{iConfig.getUntrackedParameter<uint32_t>("gainType",1)},
+  m_parameters{iConfig.getParameter<std::vector<edm::ParameterSet> >("params")}
+{
+   //now do what ever initialization is needed
+   usesResource("TFileService");
+}
+
+
+SiStripChannelGainFromDBMiscalibrator::~SiStripChannelGainFromDBMiscalibrator()
+{
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+SiStripChannelGainFromDBMiscalibrator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+   edm::ESHandle<TrackerTopology> tTopoHandle;
+   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+   const auto* const tTopo = tTopoHandle.product();
+
+   std::vector<std::string> partitions;
+
+   // fill the list of partitions 
+   for(auto& thePSet : m_parameters){
+     const std::string partition(thePSet.getParameter<std::string>("partition"));
+     // only if it is not yet in the list
+     if(std::find(partitions.begin(), partitions.end(), partition) == partitions.end()) {
+       partitions.push_back(partition);
+     }
+   }
+
+   std::map<sistripsummary::TrackerRegion,ApvGain::GainSmearings> mapOfSmearings;
+
+   for(auto& thePSet : m_parameters){
+     
+     const std::string partition(thePSet.getParameter<std::string>("partition"));
+     sistripsummary::TrackerRegion region = this->getRegionFromString(partition);
+     
+     bool    m_doScale(thePSet.getParameter<bool>("doScale"));
+     bool    m_doSmear(thePSet.getParameter<bool>("doSmear"));
+     double  m_scaleFactor(thePSet.getParameter<double>("scaleFactor"));
+     double  m_smearFactor(thePSet.getParameter<double>("smearFactor"));
+     
+     ApvGain::GainSmearings params = ApvGain::GainSmearings();
+     params.setSmearing(m_doScale,m_doSmear,m_scaleFactor,m_smearFactor);
+     mapOfSmearings[region]=params;
+   }
+   
+
+   edm::ESHandle<SiStripGain> SiStripApvGain_;
+   iSetup.get<SiStripGainRcd>().get(SiStripApvGain_);
+
+   std::map<std::pair<uint32_t,int>,float> theMap;
+   std::shared_ptr<TRandom3> random(new TRandom3(1));
+   
+   std::vector<uint32_t> detid;
+   SiStripApvGain_->getDetIds(detid);
+   for (const auto & d : detid) {
+     SiStripApvGain::Range range=SiStripApvGain_->getRange(d,m_gainType);
+     float nAPV=0;
+
+     auto regions = getRegionsFromDetId(tTopo,d); 
+
+     // sort by largest to smallest
+     std::sort(regions.rbegin(), regions.rend());
+     
+     ApvGain::GainSmearings params = ApvGain::GainSmearings();
+     
+     for (unsigned int j=0; j<regions.size();j++){
+       bool checkRegion = (mapOfSmearings.count(regions[j]) != 0);
+
+       if(!checkRegion) {
+	 // if the subdetector is not in the list and there's no indication for the whole tracker, just use the default 
+	 // i.e. no change
+	 continue;
+       } else {
+	 params = mapOfSmearings[regions[j]];
+	 break;
+       }
+     }
+     
+     for(int it=0;it<range.second-range.first;it++){
+       nAPV+=1;
+       float Gain=SiStripApvGain_->getApvGain(it,range);
+       std::pair<uint32_t,int> index = std::make_pair(d,nAPV);
+       
+       if(params.m_doScale){
+	 Gain*=params.m_scaleFactor;
+       }
+       
+       if(params.m_doSmear){
+	 float smearedGain = random->Gaus(Gain,params.m_smearFactor);
+	 Gain=smearedGain;
+       }
+
+       theMap[index]=Gain;
+       
+     } // loop over APVs
+   } // loop over DetIds
+
+   std::unique_ptr<SiStripApvGain> theAPVGains = this->getNewObject(theMap);
+
+   // write out the APVGains record
+   edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  
+   if( poolDbService.isAvailable() )
+     poolDbService->writeOne(theAPVGains.get(),poolDbService->currentTime(),m_Record);
+   else
+     throw std::runtime_error("PoolDBService required.");
+ 
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+SiStripChannelGainFromDBMiscalibrator::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+SiStripChannelGainFromDBMiscalibrator::endJob() 
+{
+}
+
+//********************************************************************************//
+std::unique_ptr<SiStripApvGain>
+SiStripChannelGainFromDBMiscalibrator::getNewObject(const std::map<std::pair<uint32_t,int>,float>& theMap) 
+{
+  std::unique_ptr<SiStripApvGain> obj = std::unique_ptr<SiStripApvGain>(new SiStripApvGain());
+  
+  std::vector<float> theSiStripVector;
+  uint32_t PreviousDetId = 0; 
+  for(const auto &element : theMap){
+    uint32_t DetId = element.first.first;
+    if(DetId != PreviousDetId){
+      if(!theSiStripVector.empty()){
+	SiStripApvGain::Range range(theSiStripVector.begin(),theSiStripVector.end());
+	if ( !obj->put(PreviousDetId,range) )  printf("Bug to put detId = %i\n",PreviousDetId);
+      }
+      theSiStripVector.clear();
+      PreviousDetId = DetId;
+    }
+    theSiStripVector.push_back(element.second);
+    
+    edm::LogInfo("SiStripChannelGainFromDBMiscalibrator")<<" DetId: "<<DetId 
+						 <<" APV:   "<<element.first.second
+						 <<" Gain:  "<<element.second
+						 <<std::endl;
+  }
+  
+  if(!theSiStripVector.empty()){
+    SiStripApvGain::Range range(theSiStripVector.begin(),theSiStripVector.end());
+    if ( !obj->put(PreviousDetId,range) )  printf("Bug to put detId = %i\n",PreviousDetId);
+  }
+  
+  return obj;
+}
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+SiStripChannelGainFromDBMiscalibrator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  
+  desc.setComment("Creates rescaled / smeared SiStrip Gain payload. Can be used for both G1 and G2."
+                  "PoolDBOutputService must be set up for 'SiStripApvGainRcd'.");
+  
+  edm::ParameterSetDescription descScaler;
+  descScaler.setComment("ParameterSet specifying the Strip tracker partition to be scaled / smeared "
+                        "by a given factor.");
+
+  descScaler.add<std::string>("partition", "Tracker");
+  descScaler.add<bool>("doScale",true);
+  descScaler.add<bool>("doSmear",true);
+  descScaler.add<double>("scaleFactor", 1.0);
+  descScaler.add<double>("smearFactor", 1.0);
+  desc.addVPSet("params", descScaler, std::vector<edm::ParameterSet>(1));
+
+  desc.addUntracked<std::string>("record","SiStripApvGainRcd");
+  desc.addUntracked<unsigned int>("gainType",1);
+
+  descriptions.add("scaleAndSmearSiStripGains", desc);
+
+}
+
+/*--------------------------------------------------------------------*/
+sistripsummary::TrackerRegion SiStripChannelGainFromDBMiscalibrator::getRegionFromString(std::string region)
+/*--------------------------------------------------------------------*/
+{
+  if(region.find("Tracker")!=std::string::npos){
+    return sistripsummary::TRACKER ;
+  } else if(region.find("TIB")!=std::string::npos){
+    if (region=="TIB_1") return sistripsummary::TIB_1;
+    else if (region=="TIB_2") return sistripsummary::TIB_2;
+    else if (region=="TIB_3") return sistripsummary::TIB_3;
+    else if (region=="TIB_4") return sistripsummary::TIB_4;
+    else return sistripsummary::TIB ;
+  } else if(region.find("TOB")!=std::string::npos){ 
+    if (region=="TOB_1") return sistripsummary::TOB_1;
+    else if (region=="TOB_2") return sistripsummary::TOB_2;
+    else if (region=="TOB_3") return sistripsummary::TOB_3;
+    else if (region=="TOB_4") return sistripsummary::TOB_4;
+    else if (region=="TOB_5") return sistripsummary::TOB_5;
+    else if (region=="TOB_6") return sistripsummary::TOB_6;
+    else return sistripsummary::TOB ;
+  } else if(region.find("TID")!=std::string::npos){
+    if(region.find("TIDM")!=std::string::npos){
+      if (region=="TIDM_1") return sistripsummary::TIDM_1;
+      else if (region=="TIDM_2") return sistripsummary::TIDM_2;
+      else if (region=="TIDM_3") return sistripsummary::TIDM_3;
+      else return sistripsummary::TIDM;
+    } else if(region.find("TIDP")!=std::string::npos){
+      if (region=="TIDP_1") return sistripsummary::TIDP_1;
+      else if (region=="TIDP_2") return sistripsummary::TIDP_2;
+      else if (region=="TIDP_3") return sistripsummary::TIDP_3;
+      else return sistripsummary::TIDP;
+    } else return sistripsummary::TID ;
+  } else if(region.find("TEC")!=std::string::npos) {
+    if(region.find("TECM")!=std::string::npos){
+      if (region=="TECM_1") return sistripsummary::TECM_1;
+      else if (region=="TECM_2") return sistripsummary::TECM_2;
+      else if (region=="TECM_3") return sistripsummary::TECM_3;
+      else if (region=="TECM_4") return sistripsummary::TECM_4;
+      else if (region=="TECM_5") return sistripsummary::TECM_5;
+      else if (region=="TECM_6") return sistripsummary::TECM_6;
+      else if (region=="TECM_7") return sistripsummary::TECM_7;
+      else if (region=="TECM_8") return sistripsummary::TECM_8;
+      else if (region=="TECM_9") return sistripsummary::TECM_9;
+      else return sistripsummary::TECM;
+    } else if(region.find("TECP")!=std::string::npos){
+      if (region=="TECP_1") return sistripsummary::TECP_1;
+      else if (region=="TECP_2") return sistripsummary::TECP_2;
+      else if (region=="TECP_3") return sistripsummary::TECP_3;
+      else if (region=="TECP_4") return sistripsummary::TECP_4;
+      else if (region=="TECP_5") return sistripsummary::TECP_5;
+      else if (region=="TECP_6") return sistripsummary::TECP_6;
+      else if (region=="TECP_7") return sistripsummary::TECP_7;
+      else if (region=="TECP_8") return sistripsummary::TECP_8;
+      else if (region=="TECP_9") return sistripsummary::TECP_9;
+      else return sistripsummary::TECP;
+    } else return sistripsummary::TEC ;
+  } else {
+    edm::LogError("LogicError") << "Unknown partition: " << region;
+    throw cms::Exception("Invalid Partition passed"); 
+  }  
+}
+
+/*--------------------------------------------------------------------*/
+std::vector<sistripsummary::TrackerRegion> SiStripChannelGainFromDBMiscalibrator::getRegionsFromDetId(const TrackerTopology* m_trackerTopo,DetId detid)
+/*--------------------------------------------------------------------*/      
+{
+  int layer    = 0;
+  int side     = 0;
+  int subdet   = 0;
+  int detCode  = 0;
+
+  std::vector<sistripsummary::TrackerRegion> ret;
+
+  switch (detid.subdetId()) {
+  case StripSubdetector::TIB:
+    layer = m_trackerTopo->tibLayer(detid);
+    subdet = 1;
+    break;
+  case StripSubdetector::TOB:
+    layer = m_trackerTopo->tobLayer(detid);
+    subdet = 2;
+    break;
+  case StripSubdetector::TID:
+    // is this module in TID+ or TID-?
+    layer = m_trackerTopo->tidWheel(detid);
+    side  = m_trackerTopo->tidSide(detid);
+    subdet = 3*10+side;
+    break;
+  case StripSubdetector::TEC:
+    // is this module in TEC+ or TEC-?
+    layer = m_trackerTopo->tecWheel(detid);
+    side  = m_trackerTopo->tecSide(detid);
+    subdet = 4*10+side;
+    break;
+  }
+  
+  detCode = (subdet*10)+layer;
+  
+  ret.push_back(static_cast<sistripsummary::TrackerRegion>(detCode));
+
+  if(subdet/10 > 0) {
+    ret.push_back(static_cast<sistripsummary::TrackerRegion>(subdet/10));
+  }
+
+  ret.push_back(static_cast<sistripsummary::TrackerRegion>(subdet));
+  ret.push_back(sistripsummary::TRACKER);
+
+  return ret;
+}
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SiStripChannelGainFromDBMiscalibrator);
+
+

--- a/CondTools/SiStrip/plugins/SiStripChannelGainFromDBMiscalibrator.cc
+++ b/CondTools/SiStrip/plugins/SiStripChannelGainFromDBMiscalibrator.cc
@@ -76,13 +76,7 @@ namespace ApvGain {
 
 }
 
-// If the analyzer does not use TFileService, please remove
-// the template argument to the base class so the class inherits
-// from  edm::one::EDAnalyzer<> and also remove the line from
-// constructor "usesResource("TFileService");"
-// This will improve performance in multithreaded jobs.
-
-class SiStripChannelGainFromDBMiscalibrator : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
+class SiStripChannelGainFromDBMiscalibrator : public edm::one::EDAnalyzer<>  {
    public:
       explicit SiStripChannelGainFromDBMiscalibrator(const edm::ParameterSet&);
       ~SiStripChannelGainFromDBMiscalibrator();
@@ -112,7 +106,6 @@ SiStripChannelGainFromDBMiscalibrator::SiStripChannelGainFromDBMiscalibrator(con
   m_parameters{iConfig.getParameter<std::vector<edm::ParameterSet> >("params")}
 {
    //now do what ever initialization is needed
-   usesResource("TFileService");
 }
 
 

--- a/CondTools/SiStrip/test/SiStripApvGainRescaler_cfg.py
+++ b/CondTools/SiStrip/test/SiStripApvGainRescaler_cfg.py
@@ -1,0 +1,93 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("Demo")
+
+#prepare options
+
+options = VarParsing.VarParsing("analysis")
+
+options.register ('globalTag',
+                  "92X_dataRun2_Prompt_v11",
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "GlobalTag")
+
+options.register ('runNumber',
+                  303014,
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.int,           # string, int, or float
+                  "run number")
+
+options.parseArguments()
+
+
+##
+## MessageLogger
+##
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.categories.append("SiStripGain2RescaleByGain1")  
+process.MessageLogger.destinations = cms.untracked.vstring("cout")
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    SiStripGain2RescaleByGain1  = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+    )
+process.MessageLogger.statistics.append('cout') 
+
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag,options.globalTag, '')
+process.GlobalTag.toGet = cms.VPSet(
+    ### N.B. This contains the G1_new (to be used for the rescale)
+    cms.PSet(record = cms.string("SiStripApvGain3Rcd"),
+             tag = cms.string("G1_new"),
+             connect = cms.string("sqlite_file:G1_new.db")
+             ),
+    ### N.B. This contains the G2_old (to be used for the rescale)
+    cms.PSet(record = cms.string("SiStripApvGain2Rcd"),
+             tag = cms.string("G2_old"),
+             connect = cms.string("sqlite_file:G2_old.db")
+             ),
+    ### N.B. This contains the G1_old (to be used for the rescale)
+    cms.PSet(record = cms.string("SiStripApvGainRcd"),
+             tag = cms.string("G1_old"),
+             connect = cms.string("sqlite_file:G1_old.db")
+             )
+    )
+
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(options.runNumber),
+                            numberEventsInRun = cms.untracked.uint32(1),
+                            )
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
+
+process.load("CondTools.SiStrip.rescaleGain2byGain1_cfi") 
+
+# process.demo = cms.EDAnalyzer('SiStripGain2RescaleByGain1',
+#                               Record = cms.untracked.string("SiStripApvGainRcd"),
+#                               )
+
+##
+## Database output service
+##
+process.load("CondCore.CondDB.CondDB_cfi")
+
+##
+## Output database (in this case local sqlite file)
+##
+process.CondDB.connect = 'sqlite_file:G2_new.db'
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          process.CondDB,
+                                          timetype = cms.untracked.string('runnumber'),
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('SiStripApvGainRcd'),
+                                                                     tag = cms.string('G2_new')
+                                                                     )
+                                                            )
+                                          )
+
+process.p = cms.Path(process.rescaleGain2byGain1)

--- a/CondTools/SiStrip/test/SiStripChannelGainFromDBMiscalibrator_cfg.py
+++ b/CondTools/SiStrip/test/SiStripChannelGainFromDBMiscalibrator_cfg.py
@@ -1,0 +1,162 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("Demo")
+
+#prepare options
+
+options = VarParsing.VarParsing("analysis")
+
+options.register ('globalTag',
+                  "92X_dataRun2_Prompt_v8",
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "GlobalTag")
+
+options.register ('runNumber',
+                  303014,
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.int,           # string, int, or float
+                  "run number")
+
+options.parseArguments()
+
+
+##
+## MessageLogger
+##
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.categories.append("SmearSiStripChannelGainFromDB")  
+process.MessageLogger.destinations = cms.untracked.vstring("cout")
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string("WARNING"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    SmearSiStripChannelGainFromDB  = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+    )
+process.MessageLogger.statistics.append('cout') 
+
+process.load("Configuration.Geometry.GeometryRecoDB_cff") # Ideal geometry and interface 
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag,options.globalTag, '')
+
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(options.runNumber),
+                            numberEventsInRun = cms.untracked.uint32(1),
+                            )
+
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
+
+##
+## Example smearing configurations
+##
+
+##
+## separately partition by partition
+##
+byParition = cms.VPSet(
+    cms.PSet(partition = cms.string("TIB"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(1.1),
+             smearFactor = cms.double(0.2)
+             ),
+    cms.PSet(partition = cms.string("TOB"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(1.2),
+             smearFactor = cms.double(0.15)
+             ),
+    cms.PSet(partition = cms.string("TID"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(1.3),
+             smearFactor = cms.double(0.10)
+             ),
+    cms.PSet(partition = cms.string("TEC"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(1.4),
+             smearFactor = cms.double(0.05)
+             )
+    )
+
+##
+## whole Strip tracker
+##
+
+wholeTracker = cms.VPSet(
+    cms.PSet(partition = cms.string("Tracker"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(1.15),
+             smearFactor = cms.double(0.05)
+             )
+    )
+
+
+##
+## down the hierarchy (Tracker,Subdetector,Side,Layer(Wheel)
+##
+
+subsets =  cms.VPSet(
+    cms.PSet(partition = cms.string("Tracker"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(0.65),
+             smearFactor = cms.double(0.05)
+             ),
+    cms.PSet(partition = cms.string("TEC"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(1.15),
+             smearFactor = cms.double(0.02)
+             ),
+    cms.PSet(partition = cms.string("TECP"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(1.35),
+             smearFactor = cms.double(0.02)
+             ),
+    cms.PSet(partition = cms.string("TECP_9"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(1.55),
+             smearFactor = cms.double(0.02)
+             )
+    )
+
+
+# process.demo = cms.EDAnalyzer('SiStripChannelGainFromDBMiscalibrator',
+#                               record = cms.untracked.string("SiStripApvGainRcd"),
+#                               gainType = cms.untracked.uint32(1), #0 for G1, 1 for G2
+#                               params = subsets # as a cms.VPset
+#                               )
+
+process.load("CondTools.SiStrip.scaleAndSmearSiStripGains_cfi")
+process.scaleAndSmearSiStripGains.gainType = 1        # 0 for G1, 1 for G2
+process.scaleAndSmearSiStripGains.params   = subsets  # as a cms.VPset
+
+##
+## Database output service
+##
+process.load("CondCore.CondDB.CondDB_cfi")
+
+##
+## Output database (in this case local sqlite file)
+##
+process.CondDB.connect = 'sqlite_file:modifiedGains_'+options.globalTag+'_IOV_'+str(options.runNumber)+".db"
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          process.CondDB,
+                                          timetype = cms.untracked.string('runnumber'),
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('SiStripApvGainRcd'),
+                                                                     tag = cms.string('modifiedGains')
+                                                                     )
+                                                            )
+                                          )
+
+process.p = cms.Path(process.scaleAndSmearSiStripGains)


### PR DESCRIPTION
 Greetings,
the aim of this PR is to introduce two plugins to manipulate SiStrip gain condition objects.
   * `SiStripApvGainRescaler` is designed to be used to rescale the values of the SiStrip G2 (a.k.a. particle) gains whenever there is an update of the SiStrip G1 (a.k.a. tickmark height) gains, before the cluster statistics for achieving a G2 measurement in-situ is available, according to the simple formula G2_new = (G1_old*G2_old)/G1_new. 
   * `SiStripChannelGainFromDBMiscalibrator` is designed to create mis-calibrations on top of an existing payload by smearing or setting an off scale, hierarchically, for the gain values up to the layer (wheel) level

I profit of this PR to fix a small inconsistency in the axis labeling of one of the payload inspector plots found when commissioning the tools.