### PR TITLE
Update the (pre|post)Source(Lumi|Run) signals

### DIFF
--- a/DQMServices/Core/interface/Standalone.h
+++ b/DQMServices/Core/interface/Standalone.h
@@ -8,6 +8,8 @@
 #  include "FWCore/ServiceRegistry/interface/Service.h"
 #  include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #  include "FWCore/ServiceRegistry/interface/SystemBounds.h"
+#  include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
+#  include "FWCore/Utilities/interface/RunIndex.h"
 #  include "FWCore/Version/interface/GetReleaseVersion.h"
 # else
 #  include <memory>
@@ -78,6 +80,12 @@ namespace edm
     template <typename T>
     void watchPostSourceLumi(void*, T) {}
 
+    template <typename F>
+    void watchPostSourceRun(F) {}
+
+    template <typename F>
+    void watchPostSourceLumi(F) {}
+
     template <typename T>
     void watchPostGlobalBeginRun(void*, T) {}
 
@@ -112,6 +120,13 @@ namespace edm
     JobReport(const edm::ParameterSet &) {}
     void reportAnalysisFile(const std::string &, const std::map<std::string, std::string> &) {}
   };
+
+  class LuminosityBlockIndex
+  { };
+
+  class RunIndex
+  { };
+
 }
 # endif // WITHOUT_CMS_FRAMEWORK
 #endif // DQMSERVICES_CORE_STANDALONE_H

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -536,11 +536,11 @@ DQMStore::DQMStore(const edm::ParameterSet &pset, edm::ActivityRegistry& ar)
       }
     });
   if(pset.getUntrackedParameter<bool>("forceResetOnBeginRun",false)) {
-    ar.watchPostSourceRun(this,&DQMStore::forceReset);
+    ar.watchPostSourceRun([this](edm::RunIndex){ forceReset(); });
   }
   if(pset.getUntrackedParameter<bool>("forceResetOnBeginLumi",false) && enableMultiThread_ == false) {
     forceResetOnBeginLumi_ = true;
-    ar.watchPostSourceLumi(this,&DQMStore::forceReset);
+    ar.watchPostSourceLumi([this](edm::LuminosityBlockIndex){ forceReset(); });
   }
   ar.watchPostGlobalBeginLumi(this, &DQMStore::postGlobalBeginLumi);
 }

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -47,7 +47,8 @@ Some examples of InputSource subclasses may be:
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ProcessingController.h"
-
+#include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
+#include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/Signal.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
@@ -256,19 +257,6 @@ namespace edm {
     ProcessingController::ForwardState forwardState() const;
     ProcessingController::ReverseState reverseState() const;
 
-    class SourceSentry {
-    public:
-      typedef signalslot::Signal<void()> Sig;
-      SourceSentry(Sig& pre, Sig& post);
-      ~SourceSentry();
-
-      SourceSentry(SourceSentry const&) = delete; // Disallow copying and moving
-      SourceSentry& operator=(SourceSentry const&) = delete; // Disallow copying and moving
-
-    private:
-      Sig& post_;
-    };
-
     class EventSourceSentry {
     public:
       EventSourceSentry(InputSource const& source, StreamContext & sc);
@@ -284,16 +272,28 @@ namespace edm {
 
     class LumiSourceSentry {
     public:
-      explicit LumiSourceSentry(InputSource const& source);
+      LumiSourceSentry(InputSource const& source, LuminosityBlockIndex id);
+      ~LumiSourceSentry();
+
+      LumiSourceSentry(LumiSourceSentry const&) = delete; // Disallow copying and moving
+      LumiSourceSentry& operator=(LumiSourceSentry const&) = delete; // Disallow copying and moving
+
     private:
-      SourceSentry sentry_;
+      InputSource const& source_;
+      LuminosityBlockIndex index_;
     };
 
     class RunSourceSentry {
     public:
-      explicit RunSourceSentry(InputSource const& source);
+      RunSourceSentry(InputSource const& source, RunIndex id);
+      ~RunSourceSentry();
+
+      RunSourceSentry(RunSourceSentry const&) = delete; // Disallow copying and moving
+      RunSourceSentry& operator=(RunSourceSentry const&) = delete; // Disallow copying and moving
+
     private:
-      SourceSentry sentry_;
+      InputSource const& source_;
+      RunIndex index_;
     };
 
     class FileOpenSentry {

--- a/FWCore/MessageService/src/MessageLogger.cc
+++ b/FWCore/MessageService/src/MessageLogger.cc
@@ -273,10 +273,10 @@ namespace edm {
       iRegistry.watchPreSourceEvent(this,&MessageLogger::preSourceEvent);
       iRegistry.watchPostSourceEvent(this,&MessageLogger::postSourceEvent);
       // change log 14:
-      iRegistry.watchPreSourceRun(this,&MessageLogger::preSourceRunLumi);
-      iRegistry.watchPostSourceRun(this,&MessageLogger::postSourceRunLumi);
-      iRegistry.watchPreSourceLumi(this,&MessageLogger::preSourceRunLumi);
-      iRegistry.watchPostSourceLumi(this,&MessageLogger::postSourceRunLumi);
+      iRegistry.watchPreSourceRun([this](RunIndex) { preSourceRunLumi(); });
+      iRegistry.watchPostSourceRun([this](RunIndex) { postSourceRunLumi(); });
+      iRegistry.watchPreSourceLumi([this](LuminosityBlockIndex) { preSourceRunLumi(); });
+      iRegistry.watchPostSourceLumi([this](LuminosityBlockIndex) { postSourceRunLumi(); });
       iRegistry.watchPreOpenFile(this,&MessageLogger::preFile);
       iRegistry.watchPostOpenFile(this,&MessageLogger::postFile);
       iRegistry.watchPreCloseFile(this,&MessageLogger::preFileClose);

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -30,11 +30,13 @@ unscheduled execution. The tests are in FWCore/Integration/test:
 
 // system include files
 #include <functional>
-#include "FWCore/Utilities/interface/Signal.h"
-#include "FWCore/Utilities/interface/StreamID.h"
-#include "FWCore/ServiceRegistry/interface/TerminationOrigin.h"
 
 // user include files
+#include "FWCore/ServiceRegistry/interface/TerminationOrigin.h"
+#include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
+#include "FWCore/Utilities/interface/RunIndex.h"
+#include "FWCore/Utilities/interface/Signal.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 
 #define AR_WATCH_USING_METHOD_0(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (std::bind(std::mem_fn(iMethod), iObject)); }
 #define AR_WATCH_USING_METHOD_1(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (std::bind(std::mem_fn(iMethod), iObject, std::placeholders::_1)); }
@@ -99,6 +101,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPreallocate)
 
+
       typedef signalslot::Signal<void(PathsAndConsumesOfModulesBase const&, ProcessContext const&)> PreBeginJob;
       ///signal is emitted before all modules have gotten their beginJob called
       PreBeginJob preBeginJobSignal_;
@@ -160,36 +163,36 @@ namespace edm {
       AR_WATCH_USING_METHOD_1(watchPostSourceEvent)
         
       /// signal is emitted before the source starts creating a Lumi
-      typedef signalslot::Signal<void()> PreSourceLumi;
+      typedef signalslot::Signal<void(LuminosityBlockIndex)> PreSourceLumi;
       PreSourceLumi preSourceLumiSignal_;
       void watchPreSourceLumi(PreSourceLumi::slot_type const& iSlot) {
         preSourceLumiSignal_.connect(iSlot);
       }
-      AR_WATCH_USING_METHOD_0(watchPreSourceLumi)
+      AR_WATCH_USING_METHOD_1(watchPreSourceLumi)
 
       /// signal is emitted after the source starts creating a Lumi
-      typedef signalslot::Signal<void()> PostSourceLumi;
+      typedef signalslot::Signal<void(LuminosityBlockIndex)> PostSourceLumi;
       PostSourceLumi postSourceLumiSignal_;
       void watchPostSourceLumi(PostSourceLumi::slot_type const& iSlot) {
          postSourceLumiSignal_.connect_front(iSlot);
       }
-      AR_WATCH_USING_METHOD_0(watchPostSourceLumi)
+      AR_WATCH_USING_METHOD_1(watchPostSourceLumi)
         
       /// signal is emitted before the source starts creating a Run
-      typedef signalslot::Signal<void()> PreSourceRun;
+      typedef signalslot::Signal<void(RunIndex)> PreSourceRun;
       PreSourceRun preSourceRunSignal_;
       void watchPreSourceRun(PreSourceRun::slot_type const& iSlot) {
         preSourceRunSignal_.connect(iSlot);
       }
-      AR_WATCH_USING_METHOD_0(watchPreSourceRun)
+      AR_WATCH_USING_METHOD_1(watchPreSourceRun)
 
       /// signal is emitted after the source starts creating a Run
-      typedef signalslot::Signal<void()> PostSourceRun;
+      typedef signalslot::Signal<void(RunIndex)> PostSourceRun;
       PostSourceRun postSourceRunSignal_;
       void watchPostSourceRun(PostSourceRun::slot_type const& iSlot) {
          postSourceRunSignal_.connect_front(iSlot);
       }
-      AR_WATCH_USING_METHOD_0(watchPostSourceRun)
+      AR_WATCH_USING_METHOD_1(watchPostSourceRun)
         
       /// signal is emitted before the source opens a file
       typedef signalslot::Signal<void(std::string const&, bool)> PreOpenFile;

--- a/FWCore/Services/plugins/Timing.cc
+++ b/FWCore/Services/plugins/Timing.cc
@@ -56,11 +56,11 @@ namespace edm {
       void preSourceEvent(StreamID);
       void postSourceEvent(StreamID);
       
-      void preSourceLumi();
-      void postSourceLumi();
+      void preSourceLumi(LuminosityBlockIndex);
+      void postSourceLumi(LuminosityBlockIndex);
       
-      void preSourceRun();
-      void postSourceRun();
+      void preSourceRun(RunIndex);
+      void postSourceRun(RunIndex);
      
       void preOpenFile(std::string const&, bool);
       void postOpenFile(std::string const&, bool);
@@ -423,19 +423,19 @@ namespace edm {
       postCommon();
     }
 
-    void Timing::preSourceLumi() {
+    void Timing::preSourceLumi(LuminosityBlockIndex index) {
       pushStack();
     }
  
-    void Timing::postSourceLumi() {
+    void Timing::postSourceLumi(LuminosityBlockIndex index) {
       postCommon();
     }
   
-    void Timing::preSourceRun() {
+    void Timing::preSourceRun(RunIndex index) {
       pushStack();
     }
 
-    void Timing::postSourceRun() {
+    void Timing::postSourceRun(RunIndex index) {
       postCommon();
     }
 

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -73,11 +73,11 @@ namespace edm {
       void preSourceEvent(StreamID);
       void postSourceEvent(StreamID);
       
-      void preSourceLumi();
-      void postSourceLumi();
+      void preSourceLumi(LuminosityBlockIndex);
+      void postSourceLumi(LuminosityBlockIndex);
       
-      void preSourceRun();
-      void postSourceRun();
+      void preSourceRun(RunIndex);
+      void postSourceRun(RunIndex);
       
       void preOpenFile(std::string const&, bool);
       void postOpenFile(std::string const&, bool);
@@ -475,22 +475,22 @@ Tracer::postSourceEvent(StreamID sid) {
 }
 
 void
-Tracer::preSourceLumi() {
+Tracer::preSourceLumi(LuminosityBlockIndex index) {
   LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << indention_ << " starting: source lumi";
 }
 
 void
-Tracer::postSourceLumi() {
+Tracer::postSourceLumi(LuminosityBlockIndex index) {
   LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << indention_ << " finished: source lumi";
 }
 
 void
-Tracer::preSourceRun() {
+Tracer::preSourceRun(RunIndex index) {
   LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << indention_ << " starting: source run";
 }
 
 void
-Tracer::postSourceRun() {
+Tracer::postSourceRun(RunIndex index) {
   LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << indention_ << " finished: source run";
 }
 

--- a/FWCore/Services/plugins/ZombieKillerService.cc
+++ b/FWCore/Services/plugins/ZombieKillerService.cc
@@ -78,11 +78,11 @@ m_numberChecksWhenNotAlive(0)
   iRegistry.watchPostBeginJob([this](){ startThread(); } );
   iRegistry.watchPostEndJob([this]() {stopThread(); } );
   
-  iRegistry.watchPreSourceRun([this](){notAZombieYet();});
-  iRegistry.watchPostSourceRun([this](){notAZombieYet();});
+  iRegistry.watchPreSourceRun([this](RunIndex){notAZombieYet();});
+  iRegistry.watchPostSourceRun([this](RunIndex){notAZombieYet();});
   
-  iRegistry.watchPreSourceLumi([this](){notAZombieYet();});
-  iRegistry.watchPostSourceLumi([this](){notAZombieYet();});
+  iRegistry.watchPreSourceLumi([this](LuminosityBlockIndex){notAZombieYet();});
+  iRegistry.watchPostSourceLumi([this](LuminosityBlockIndex){notAZombieYet();});
 
   iRegistry.watchPreSourceEvent([this](StreamID){notAZombieYet();});
   iRegistry.watchPostSourceEvent([this](StreamID){notAZombieYet();});

--- a/HLTrigger/Timer/interface/FastTimerService.h
+++ b/HLTrigger/Timer/interface/FastTimerService.h
@@ -127,11 +127,11 @@ private:
   void preSourceConstruction(edm::ModuleDescription const&);
   //void postSourceConstruction(edm::ModuleDescription const&);
 
-  void preSourceRun();
-  void postSourceRun();
+  void preSourceRun(edm::RunIndex);
+  void postSourceRun(edm::RunIndex);
 
-  void preSourceLumi();
-  void postSourceLumi();
+  void preSourceLumi(edm::LuminosityBlockIndex);
+  void postSourceLumi(edm::LuminosityBlockIndex);
 
   void preSourceEvent(edm::StreamID);
   void postSourceEvent(edm::StreamID);

--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -1334,25 +1334,25 @@ FastTimerService::postGlobalEndRun(edm::GlobalContext const& gc)
 }
 
 void
-FastTimerService::preSourceRun()
+FastTimerService::preSourceRun(edm::RunIndex index)
 {
   thread().measure_and_accumulate(overhead_);
 }
 
 void
-FastTimerService::postSourceRun()
+FastTimerService::postSourceRun(edm::RunIndex index)
 {
   thread().measure_and_accumulate(overhead_);
 }
 
 void
-FastTimerService::preSourceLumi()
+FastTimerService::preSourceLumi(edm::LuminosityBlockIndex index)
 {
   thread().measure_and_accumulate(overhead_);
 }
 
 void
-FastTimerService::postSourceLumi()
+FastTimerService::postSourceLumi(edm::LuminosityBlockIndex index)
 {
   thread().measure_and_accumulate(overhead_);
 }

--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -1342,7 +1342,7 @@ FastTimerService::preSourceRun(edm::RunIndex index)
 void
 FastTimerService::postSourceRun(edm::RunIndex index)
 {
-  thread().measure_and_accumulate(overhead_);
+  thread().measure_and_accumulate(run_transition_[index]);
 }
 
 void
@@ -1354,7 +1354,7 @@ FastTimerService::preSourceLumi(edm::LuminosityBlockIndex index)
 void
 FastTimerService::postSourceLumi(edm::LuminosityBlockIndex index)
 {
-  thread().measure_and_accumulate(overhead_);
+  thread().measure_and_accumulate(lumi_transition_[index]);
 }
 
 void


### PR DESCRIPTION
Update the signals to pass
  - the `LuminosityBlockIndex` to the `(pre|post)SourceLumi` signals;
  - the `RunIndex` to the `(pre|post)SourceRun` signals.

Update the FastTimerService to make use of the updated signals to account for the time spent in the Source transitions.

Update the other clients code to ignore the new parameters.