### PR TITLE
Fix compression level in NANOAOD production (10_0_X)

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -10,6 +10,7 @@ standard processing
 
 from FWCore.ParameterSet.Config import Process, EndPath
 from FWCore.ParameterSet.Modules import OutputModule, Source, Service
+from Configuration.EventContent.EventContent_cff import NANOAODEventContent
 import FWCore.ParameterSet.Types as CfgTypes
 
 
@@ -64,7 +65,7 @@ def mergeProcess(*inputFiles, **options):
     if newDQMIO:
         outMod = OutputModule("DQMRootOutputModule")
     elif mergeNANO:
-        outMod = OutputModule("NanoAODOutputModule")
+        outMod = OutputModule("NanoAODOutputModule",NANOAODEventContent.clone())
     else:
         outMod = OutputModule("PoolOutputModule")
 


### PR DESCRIPTION
This forces Merge.py to read the eventcontent definition (for NanoAOD) so that the correct compression settings are set.

This is needed because merging for nanoaod is NOT simply a fastmerge.

The event content is set in the OutputModule in the same way as in cmsDriver
https://github.com/cms-sw/cmssw/blob/master/Configuration/Applications/python/ConfigBuilder.py#L557-L558

As there is no test of Merge.py I simply did the following in interactive python (and seem to give the expected result)
<pre>
>>> import Merge
>>> p=Merge.mergeProcess(["afile.root"],mergeNANO=True)
>>> print p.dumpPython()
import FWCore.ParameterSet.Config as cms

process = cms.Process("Merge")

process.source = cms.Source("PoolSource",
    fileNames = cms.untracked.vstring("[\'afile.root\']")
)
process.Merged = cms.OutputModule("NanoAODOutputModule",
    compressionAlgorithm = cms.untracked.string('LZMA'),
    compressionLevel = cms.untracked.int32(9),
    fileName = cms.untracked.string('Merged.root'),
    outputCommands = cms.untracked.vstring('drop *', 
        'keep nanoaodFlatTable_*Table_*_*', 
        'keep edmTriggerResults_*_*_*', 
        'keep nanoaodMergeableCounterTable_*Table_*_*', 
        'keep nanoaodUniqueString_nanoMetadata_*_*')
)


process.outputPath = cms.EndPath(process.Merged)

</pre> 

same as #21873