### PR TITLE
[94X GT update][2017 MC] Hcal MCParams update

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,13 +40,13 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v7',
+    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '94X_mc2017_realistic_v10',
+    'phase1_2017_realistic'    : '94X_mc2017_realistic_v11',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v6',
+    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v7',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v6',
+    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '94X_upgrade2018_design_IdealBS_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector


### PR DESCRIPTION
CHANGES:
**phase1_2017_design**
Diff with old GT:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017_design_IdealBS_v8/94X_mc2017_design_IdealBS_v7
-> Hcal MCParams update

**phase1_2017_realistic** 
Diff with old GT:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017_realistic_v11/94X_mc2017_realistic_v10
-> Hcal MCParams update

**phase1_2017_cosmics** 
Diff with old GT:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017cosmics_realistic_deco_v7/94X_mc2017cosmics_realistic_deco_v6

**phase1_2017_cosmics_peak** 
Diff with old GT:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017cosmics_realistic_peak_v7/94X_mc2017cosmics_realistic_peak_v6
-> Hcal MCParams update

MOTIVATIONS:
Change motivated here [0], [1] to solve [2].
[0] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3190.html
[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3458.html
[2] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3456.html