### PR TITLE
Add a safety check to  L1TGlobalUtil and  L1TGlobalSummary

### DIFF
--- a/L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h
+++ b/L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h
@@ -34,10 +34,10 @@ public:
 
   // Using this constructor will require InputTags to be specified in the configuration
   L1TGlobalUtil(edm::ParameterSet const& pset,
-		edm::ConsumesCollector&& iC);
+                edm::ConsumesCollector&& iC);
 
   L1TGlobalUtil(edm::ParameterSet const& pset,
-		edm::ConsumesCollector& iC);
+                edm::ConsumesCollector& iC);
 
   // Using this constructor will cause it to look for valid InputTags in
   // the following ways in the specified order until they are found.
@@ -46,13 +46,13 @@ public:
   //   3. Search all products from any other process for the required type
   template <typename T>
   L1TGlobalUtil(edm::ParameterSet const& pset,
-		edm::ConsumesCollector&& iC,
-		T& module);
+                edm::ConsumesCollector&& iC,
+                T& module);
 
   template <typename T>
   L1TGlobalUtil(edm::ParameterSet const& pset,
-		edm::ConsumesCollector& iC,
-		T& module);
+                edm::ConsumesCollector& iC,
+                T& module);
 
   // Using this constructor will cause it to look for valid InputTags in
   // the following ways in the specified order until they are found.
@@ -62,20 +62,23 @@ public:
   //   4. Search all products from any other process for the required type
   template <typename T>
   L1TGlobalUtil(edm::ParameterSet const& pset,
-		edm::ConsumesCollector&& iC,
-		T& module,
-		edm::InputTag const& l1tAlgBlkInputTag,
-		edm::InputTag const& l1tExtBlkInputTag);
+                edm::ConsumesCollector&& iC,
+                T& module,
+                edm::InputTag const& l1tAlgBlkInputTag,
+                edm::InputTag const& l1tExtBlkInputTag);
 
   template <typename T>
   L1TGlobalUtil(edm::ParameterSet const& pset,
-		edm::ConsumesCollector& iC,
-		T& module,
-		edm::InputTag const& l1tAlgBlkInputTag,
-		edm::InputTag const& l1tExtBlkInputTag);
+                edm::ConsumesCollector& iC,
+                T& module,
+                edm::InputTag const& l1tAlgBlkInputTag,
+                edm::InputTag const& l1tExtBlkInputTag);
 
   /// destructor
   virtual ~L1TGlobalUtil();
+
+  /// check that the L1TGlobalUtil has been properly initialised
+  bool valid() const;
 
   static void fillDescription(edm::ParameterSetDescription & desc) {
     L1TGlobalUtilHelper::fillDescription(desc);
@@ -95,7 +98,7 @@ public:
     void retrieveL1Event(const edm::Event& iEvent, const edm::EventSetup& evSetup); // using helper
     void retrieveL1Event(const edm::Event& iEvent, const edm::EventSetup& evSetup, edm::EDGetToken gtAlgToken);
 
-    inline void setUnprescaledUnmasked(const bool unprescale, const bool unmask) {
+    inline void setUnprescaledUnmasked(bool unprescale, bool unmask) {
       m_algorithmTriggersUnprescaled = unprescale;
       m_algorithmTriggersUnmasked = unmask;
     }
@@ -137,7 +140,7 @@ public:
     const bool getPrescaleByName(const std::string& algName,           int& prescale) const;
 
     // Access Masks (see note) above
-    const bool getMaskByName(const std::string& algName,              std::vector<int>&     mask) const;
+    const bool getMaskByName(const std::string& algName,              std::vector<int>& mask) const;
 
     // Some inline commands to return the full vectors
     inline const std::vector<std::pair<std::string, bool> >& decisionsInitial()   { return m_decisionsInitial; }
@@ -226,41 +229,41 @@ private:
 
 template <typename T>
 L1TGlobalUtil::L1TGlobalUtil(edm::ParameterSet const& pset,
-			     edm::ConsumesCollector&& iC,
-			     T& module) :
+                             edm::ConsumesCollector&& iC,
+                             T& module) :
  L1TGlobalUtil(pset, iC, module) { }
 
 template <typename T>
 L1TGlobalUtil::L1TGlobalUtil(edm::ParameterSet const& pset,
-			     edm::ConsumesCollector& iC,
-			     T& module) :
+                             edm::ConsumesCollector& iC,
+                             T& module) :
  L1TGlobalUtil() {
    m_l1tGlobalUtilHelper.reset(new L1TGlobalUtilHelper(pset,
-						       iC,
-						       module));
+                                                       iC,
+                                                       module));
    m_readPrescalesFromFile=m_l1tGlobalUtilHelper->readPrescalesFromFile();
  }
 
 template <typename T>
 L1TGlobalUtil::L1TGlobalUtil(edm::ParameterSet const& pset,
-			     edm::ConsumesCollector&& iC,
-			     T& module,
-			     edm::InputTag const& l1tAlgBlkInputTag,
-			     edm::InputTag const& l1tExtBlkInputTag) :
+                             edm::ConsumesCollector&& iC,
+                             T& module,
+                             edm::InputTag const& l1tAlgBlkInputTag,
+                             edm::InputTag const& l1tExtBlkInputTag) :
  L1TGlobalUtil(pset, iC, module, l1tAlgBlkInputTag, l1tExtBlkInputTag) { }
 
 template <typename T>
 L1TGlobalUtil::L1TGlobalUtil(edm::ParameterSet const& pset,
-			     edm::ConsumesCollector& iC,
-			     T& module,
-			     edm::InputTag const& l1tAlgBlkInputTag,
-			     edm::InputTag const& l1tExtBlkInputTag) :
+                             edm::ConsumesCollector& iC,
+                             T& module,
+                             edm::InputTag const& l1tAlgBlkInputTag,
+                             edm::InputTag const& l1tExtBlkInputTag) :
  L1TGlobalUtil() {
    m_l1tGlobalUtilHelper.reset(new L1TGlobalUtilHelper(pset,
-						       iC,
-						       module,
-						       l1tAlgBlkInputTag,
-						       l1tExtBlkInputTag));
+                                                       iC,
+                                                       module,
+                                                       l1tAlgBlkInputTag,
+                                                       l1tExtBlkInputTag));
    m_readPrescalesFromFile=m_l1tGlobalUtilHelper->readPrescalesFromFile();
  }
 }

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalSummary.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalSummary.cc
@@ -106,48 +106,47 @@ void L1TGlobalSummary::beginRun(Run const&, EventSetup const& evSetup){
   gtUtil_->retrieveL1Setup(evSetup);
 
   int size = gtUtil_->decisionsInitial().size();
-  decisionCount_  .resize(size);
-  intermCount_ .resize(size);
-  finalCount_     .resize(size);
-  std::fill(decisionCount_.begin(),  decisionCount_.end(),  0);
-  std::fill(intermCount_.begin(), intermCount_.end(), 0);
-  std::fill(finalCount_.begin(),     finalCount_.end(),     0);
-
+  decisionCount_.resize(size);
+  intermCount_  .resize(size);
+  finalCount_   .resize(size);
+  std::fill(decisionCount_.begin(), decisionCount_.end(), 0);
+  std::fill(intermCount_.begin(),   intermCount_.end(),   0);
+  std::fill(finalCount_.begin(),    finalCount_.end(),    0);
 }
 
 void L1TGlobalSummary::endRun(Run const&, EventSetup const&){
 
-  if(dumpTriggerSummary_) {
+  if (dumpTriggerSummary_) {
+    LogVerbatim out("L1TGlobalSummary");
+    if (gtUtil_->valid()) {
+      out << "==================  L1 Trigger Report  =====================================================================\n";
+      out << '\n';
+      out << " L1T menu Name   : " << gtUtil_->gtTriggerMenuName() << '\n';
+      out << " L1T menu Version: " << gtUtil_->gtTriggerMenuVersion() << '\n';
+      out << " L1T menu Comment: " << gtUtil_->gtTriggerMenuComment() << '\n';
+      out << '\n';
+      out << "    Bit                  Algorithm Name                  Init    PScd  Final   PS Factor     Num Bx Masked\n";
+      out << "============================================================================================================\n";
+      auto const& prescales = gtUtil_->prescales();
+      auto const& masks = gtUtil_->masks();
+      for (unsigned int i = 0; i < prescales.size(); i++) {
+        // get the prescale and mask (needs some error checking here)
+        int resultInit = decisionCount_[i];
+        int resultPre = intermCount_[i];
+        int resultFin = finalCount_[i];
 
-    const std::vector<std::pair<std::string, int> >  prescales = gtUtil_->prescales();
-    const std::vector<std::pair<std::string, std::vector<int> > > masks = gtUtil_->masks();
-
-    // Dump the results
-    LogVerbatim("L1TGlobalSummary") << " " << "\n\n";
-    LogVerbatim("L1TGlobalSummary") << " =================  L1 Trigger Report  =====================================================================" << endl;
-    LogVerbatim("L1TGlobalSummary") << " " << endl;
-    LogVerbatim("L1TGlobalSummary") << " L1T menu Name   : " << gtUtil_->gtTriggerMenuName() << endl;
-    LogVerbatim("L1TGlobalSummary") << " L1T menu Version: " << gtUtil_->gtTriggerMenuVersion() << endl;
-    LogVerbatim("L1TGlobalSummary") << " L1T menu Comment: " << gtUtil_->gtTriggerMenuComment() << endl;
-    LogVerbatim("L1TGlobalSummary") << " " << endl;
-    LogVerbatim("L1TGlobalSummary") << "    Bit                  Algorithm Name                  Init    PScd  Final   PS Factor     Num Bx Masked" << endl;
-    LogVerbatim("L1TGlobalSummary") << "============================================================================================================" << endl;
-    for(unsigned int i=0; i<prescales.size(); i++) {
-
-
-      // get the prescale and mask (needs some error checking here)
-      int resultInit = decisionCount_[i];
-      int resultPre = intermCount_[i];
-      int resultFin = finalCount_[i];
-
-      std::string name = (prescales.at(i)).first;
-      int prescale = (prescales.at(i)).second;
-      std::vector<int> mask    = (masks.at(i)).second;
-
-      if(name != "NULL") LogVerbatim("L1TGlobalSummary") << std::dec << setfill(' ') << "   " << setw(5) << i << "   " << setw(40) << name.c_str() << "   " << setw(7) << resultInit << setw(7) << resultPre << setw(7) << resultFin << setw(10) << prescale << setw(11) << mask.size() << setw(9) << endl;
+        auto const& name = prescales.at(i).first;
+        if (name != "NULL") {
+          int prescale = prescales.at(i).second;
+          auto const& mask = masks.at(i).second;
+          out << std::dec << setfill(' ') << "   " << setw(5) << i << "   " << setw(40) << name << "   " << setw(7) << resultInit << setw(7) << resultPre << setw(7) << resultFin << setw(10) << prescale << setw(11) << mask.size() << '\n';
+        }
+      }
+      out << "                                                      Final OR Count = " << finalOrCount << '\n';
+      out << "============================================================================================================\n";
+    } else {
+      out << "==================  No Level-1 Trigger menu  ===============================================================\n";
     }
-    LogVerbatim("L1TGlobalSummary") << "                                                      Final OR Count = " << finalOrCount <<endl;
-    LogVerbatim("L1TGlobalSummary") << "===========================================================================================================" << endl;
   }
 
 }

--- a/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
+++ b/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
@@ -27,7 +27,9 @@
 
 
 // constructor
-l1t::L1TGlobalUtil::L1TGlobalUtil(){
+l1t::L1TGlobalUtil::L1TGlobalUtil() : 
+    m_l1GtMenu(nullptr)
+{
     // initialize cached IDs
     m_l1GtMenuCacheID = 0ULL;
     m_l1GtPfAlgoCacheID = 0ULL;
@@ -59,9 +61,12 @@ l1t::L1TGlobalUtil::L1TGlobalUtil(edm::ParameterSet const& pset,
 
 // destructor
 l1t::L1TGlobalUtil::~L1TGlobalUtil() {
-
   // empty
+}
 
+/// check that the L1TGlobalUtil has been properly initialised
+bool l1t::L1TGlobalUtil::valid() const {
+  return m_l1GtMenuCacheID != 0ULL and m_l1GtMenu != nullptr;
 }
 
 void l1t::L1TGlobalUtil::OverridePrescalesAndMasks(std::string filename, unsigned int psColumn){


### PR DESCRIPTION
This fixes the segmentation fault that happens if an unrelated error prevents the `L1TGlobalSummary` from analysing any events.
When that happens, the `L1TGlobalUtil` never reads the `EventSetup` and is left partly unconfigured, leading to a crash when `L1TGlobalSummary` attempts to print the summary.
The fix is to check the validity of the `L1TGlobalUtil` before reading its contents.
