### PR TITLE
Fix order in sequence of LepHTMonitor_cff, minor addition

### DIFF
--- a/DQMOffline/Trigger/python/LepHTMonitor_cff.py
+++ b/DQMOffline/Trigger/python/LepHTMonitor_cff.py
@@ -187,8 +187,7 @@ DQMOffline_LepHT_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
 
 from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egmGsfElectronIDsForDQM
 
-LepHTMonitor = cms.Sequence( egmGsfElectronIDsForDQM # Use of electron VID requires this module being executed first
-                            + DQMOffline_Ele15_HT600
+LepHTMonitor = cms.Sequence( DQMOffline_Ele15_HT600
                             + DQMOffline_Ele15_HT450
                             + DQMOffline_Ele50_HT450
                             + DQMOffline_Mu15_HT600
@@ -199,7 +198,8 @@ LepHTMonitor = cms.Sequence( egmGsfElectronIDsForDQM # Use of electron VID requi
                             + DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ
                             + DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT350
                             + DQMOffline_DoubleMu4_Mass8_PFHT350
-                            + DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350
+                            + DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350,
+                            cms.Task(egmGsfElectronIDsForDQM) # Use of electron VID requires this module being executed first
 )
 
 LepHTClient = cms.Sequence(  DQMOffline_LepHT_POSTPROCESSING )


### PR DESCRIPTION
Fix for a wrong order in the sequence in DQMOffline/Trigger/python/LepHTMonitor_cff.py
Causing wf 136.7802 not to run (as in #21859 for 10_0_X, although the sequence there is different)