### PR TITLE
L1T object comparison producer

### DIFF
--- a/DataFormats/L1TGlobal/interface/GlobalAlgBlk.h
+++ b/DataFormats/L1TGlobal/interface/GlobalAlgBlk.h
@@ -1,5 +1,5 @@
-#ifndef L1Trigger_GlobalAlgBlk_h
-#define L1Trigger_GlobalAlgBlk_h
+#ifndef DataFormats_L1TGlobal_GlobalAlgBlk_h
+#define DataFormats_L1TGlobal_GlobalAlgBlk_h
 
 /**
 * \class GlobalAlgBlk
@@ -24,6 +24,7 @@
 #include "FWCore/Utilities/interface/typedefs.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
 //#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
+#include "DataFormats/L1Trigger/interface/L1TObjComparison.h"
 
 // forward declarations
 
@@ -31,13 +32,15 @@
 class GlobalAlgBlk;
 typedef BXVector<GlobalAlgBlk> GlobalAlgBlkBxCollection;
 
+typedef l1t::ObjectRef<GlobalAlgBlk> GlobalAlgBlkRef;
+typedef l1t::ObjectRefBxCollection<GlobalAlgBlk> GlobalAlgBlkRefBxCollection;
+typedef l1t::ObjectRefPair<GlobalAlgBlk> GlobalAlgBlkRefPair;
+typedef l1t::ObjectRefPairBxCollection<GlobalAlgBlk> GlobalAlgBlkRefPairBxCollection;
+
 // class interface
 
 class GlobalAlgBlk
 {
-
-    
-
 public:
     /// constructors
     GlobalAlgBlk(); // empty constructor, all members set to zero;
@@ -46,7 +49,6 @@ public:
 
     /// destructor
     virtual ~GlobalAlgBlk();
-
 
 public:
     static constexpr unsigned int maxPhysicsTriggers = 512;
@@ -95,9 +97,12 @@ public:
     /// reset the content of a GlobalAlgBlk
     void reset();
 
+    // compare the content of this GlobalAlgBlk with another one
+    virtual bool operator==(const GlobalAlgBlk& rhs) const;
+    virtual inline bool operator!=(const GlobalAlgBlk& rhs) const { return !(operator==(rhs)); };
+
     /// pretty print the content of a GlobalAlgBlk
     void print(std::ostream& myCout) const;
-
 
 private:
 
@@ -120,13 +125,9 @@ private:
     //Prescale Column
     int m_preScColumn;
 
-   
     std::vector<bool> m_algoDecisionInitial;
     std::vector<bool> m_algoDecisionPreScaled;   // -> Interm
     std::vector<bool> m_algoDecisionFinal;
-
-
-
 };
 
-#endif /*L1Trigger_GlobalAlgBlk_h*/
+#endif /*DataFormats_L1TGlobal_GlobalAlgBlk_h*/

--- a/DataFormats/L1TGlobal/src/GlobalAlgBlk.cc
+++ b/DataFormats/L1TGlobal/src/GlobalAlgBlk.cc
@@ -48,7 +48,6 @@ GlobalAlgBlk::GlobalAlgBlk(int orbitNr, int bxNr, int bxInEvent):
 
 }
 
-
 // empty constructor, all members set to zero;
 GlobalAlgBlk::GlobalAlgBlk( )
 {
@@ -74,15 +73,11 @@ GlobalAlgBlk::GlobalAlgBlk( )
 
 }
 
-
-
 // destructor
 GlobalAlgBlk::~GlobalAlgBlk()
 {
-
     // empty now
 }
-
 
 /// Set decision bits
 void GlobalAlgBlk::setAlgoDecisionInitial(unsigned int bit, bool val)   
@@ -97,6 +92,7 @@ void GlobalAlgBlk::setAlgoDecisionInitial(unsigned int bit, bool val)
    }
    
 }
+
 void GlobalAlgBlk::setAlgoDecisionInterm(unsigned int bit, bool val) 
 { 
 
@@ -109,6 +105,7 @@ void GlobalAlgBlk::setAlgoDecisionInterm(unsigned int bit, bool val)
    }
 
 }
+
 void GlobalAlgBlk::setAlgoDecisionFinal(unsigned int bit, bool val)     
 { 
 
@@ -127,17 +124,18 @@ bool GlobalAlgBlk::getAlgoDecisionInitial(unsigned int bit) const
    if(bit>=m_algoDecisionInitial.size()) return false;
    return m_algoDecisionInitial.at(bit); 
 }
+
 bool GlobalAlgBlk::getAlgoDecisionInterm(unsigned int bit) const
 { 
    if(bit>=m_algoDecisionPreScaled.size()) return false;
    return m_algoDecisionPreScaled.at(bit); 
 }
+
 bool GlobalAlgBlk::getAlgoDecisionFinal(unsigned int bit)  const   
 {
    if(bit>=m_algoDecisionFinal.size()) return false;
    return m_algoDecisionFinal.at(bit); 
 }
-
 
 // reset the content of a GlobalAlgBlk
 void GlobalAlgBlk::reset()
@@ -158,7 +156,21 @@ void GlobalAlgBlk::reset()
     m_algoDecisionPreScaled.assign(maxPhysicsTriggers,false);
     m_algoDecisionFinal.assign(maxPhysicsTriggers,false);
 
+}
 
+// compare the content of this GlobalAlgBlk with another one
+bool GlobalAlgBlk::operator==(const GlobalAlgBlk& rhs) const
+{
+    return m_orbitNr == rhs.getL1MenuUUID()
+        && m_bxNr == rhs.getL1FirmwareUUID()
+        && m_bxInEvent == rhs.getbxInEventNr()
+        && m_finalOR == rhs.getFinalOR()
+        && m_finalORPreVeto == rhs.getFinalORPreVeto()
+        && m_finalORVeto == rhs.getFinalORVeto()
+        && m_preScColumn == rhs.getPreScColumn()
+        && m_algoDecisionInitial == rhs.getAlgoDecisionInitial()
+        && m_algoDecisionPreScaled == rhs.getAlgoDecisionInterm()
+        && m_algoDecisionFinal == rhs.getAlgoDecisionFinal();
 }
 
 // pretty print the content of a GlobalAlgBlk
@@ -187,8 +199,8 @@ void GlobalAlgBlk::print(std::ostream& myCout) const
       if(m_algoDecisionInitial.at(i)) digit |= (1 << (i%4));
       if((i%4) == 0){
          myCout << std::hex << std::setw(1) << digit;
-	 digit = 0; 
-	 if(i%32 == 0 && i<lengthWd-1) myCout << " ";
+         digit = 0; 
+         if(i%32 == 0 && i<lengthWd-1) myCout << " ";
       }  
     } //end loop over algorithm bits
     myCout << std::endl;
@@ -201,8 +213,8 @@ void GlobalAlgBlk::print(std::ostream& myCout) const
       if(m_algoDecisionPreScaled.at(i)) digit |= (1 << (i%4));
       if((i%4) == 0){
          myCout << std::hex << std::setw(1) << digit;
-	 digit = 0; 
-	 if(i%32 == 0 && i<lengthWd-1) myCout << " ";
+         digit = 0; 
+         if(i%32 == 0 && i<lengthWd-1) myCout << " ";
       }  
     } //end loop over algorithm bits
     myCout << std::endl;
@@ -216,12 +228,11 @@ void GlobalAlgBlk::print(std::ostream& myCout) const
       if(m_algoDecisionFinal.at(i)) digit |= (1 << (i%4));
       if((i%4) == 0){
          myCout << std::hex << std::setw(1) << digit;
-	 digit = 0; 
-	 if(i%32 == 0 && i<lengthWd-1) myCout << " ";
+         digit = 0; 
+         if(i%32 == 0 && i<lengthWd-1) myCout << " ";
       }  
     } //end loop over algorithm bits
     myCout << std::endl;
 
 }
-
 

--- a/DataFormats/L1TGlobal/src/classes.h
+++ b/DataFormats/L1TGlobal/src/classes.h
@@ -37,5 +37,14 @@ namespace DataFormats_L1TGlobal {
 
     std::vector<GlobalAlgBlk> v_uGtAlgBx;
     std::vector<GlobalExtBlk> v_uGtExtBx;
+
+    GlobalAlgBlkRef                               gabr;
+    std::vector<GlobalAlgBlkRef>                  v_gabr;
+    GlobalAlgBlkRefBxCollection                   gabrbxc;
+    edm::Wrapper<GlobalAlgBlkRefBxCollection>     w_gabrbxc;
+    GlobalAlgBlkRefPair                           gabrp;
+    std::vector<GlobalAlgBlkRefPair>              v_gabrp;
+    GlobalAlgBlkRefPairBxCollection               gabrpc;
+    edm::Wrapper<GlobalAlgBlkRefPairBxCollection> w_gabrpc;
   };
 }

--- a/DataFormats/L1TGlobal/src/classes_def.xml
+++ b/DataFormats/L1TGlobal/src/classes_def.xml
@@ -46,6 +46,15 @@
   </class>
   <class name="std::vector<GlobalLogicParser::TokenRPN>"/>
   
+  <class name="GlobalAlgBlkRef"/>
+  <class name="std::vector<GlobalAlgBlkRef>"/>
+  <class name="GlobalAlgBlkRefBxCollection"/>
+  <class name="edm::Wrapper<GlobalAlgBlkRefBxCollection>"/>
+  <class name="GlobalAlgBlkRefPair"/>
+  <class name="std::vector<GlobalAlgBlkRefPair>"/>
+  <class name="GlobalAlgBlkRefPairBxCollection"/>
+  <class name="edm::Wrapper<GlobalAlgBlkRefPairBxCollection>"/>
+
 </lcgdict>
 
 

--- a/DataFormats/L1TMuon/interface/RegionalMuonCand.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonCand.h
@@ -141,6 +141,8 @@ class RegionalMuonCand {
         return m_trackAddress.at(subAddress);
     }
 
+    bool operator==(const RegionalMuonCand& rhs) const;
+    inline bool operator!=(const RegionalMuonCand& rhs) const { return !(operator==(rhs)); };
 
   private:
     int m_hwPt;

--- a/DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h
@@ -2,13 +2,19 @@
 #define __l1t_regional_muon_candidatefwd_h__
 
 #include "DataFormats/L1Trigger/interface/BXVector.h"
+#include "DataFormats/L1Trigger/interface/L1TObjComparison.h"
 
 namespace l1t {
-	enum tftype {
-  	bmtf, omtf_neg, omtf_pos, emtf_neg, emtf_pos
-	};
-	class RegionalMuonCand;
-	typedef BXVector<RegionalMuonCand> RegionalMuonCandBxCollection;
+  enum tftype {
+    bmtf, omtf_neg, omtf_pos, emtf_neg, emtf_pos
+  };
+  class RegionalMuonCand;
+  typedef BXVector<RegionalMuonCand> RegionalMuonCandBxCollection;
+
+  typedef ObjectRef<RegionalMuonCand> RegionalMuonCandRef;
+  typedef ObjectRefBxCollection<RegionalMuonCand> RegionalMuonCandRefBxCollection;
+  typedef ObjectRefPair<RegionalMuonCand> RegionalMuonCandRefPair;
+  typedef ObjectRefPairBxCollection<RegionalMuonCand> RegionalMuonCandRefPairBxCollection;
 }
 
 #endif /* define __l1t_regional_muon_candidatefwd_h__ */

--- a/DataFormats/L1TMuon/src/RegionalMuonCand.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonCand.cc
@@ -25,4 +25,19 @@ RegionalMuonCand::setTFIdentifiers(int processor, tftype trackFinder) {
   }
 }
 
+bool RegionalMuonCand::operator==(const RegionalMuonCand& rhs) const
+{
+  return m_hwPt == rhs.hwPt()
+      && m_hwPhi == rhs.hwPhi()
+      && m_hwEta == rhs.hwEta()
+      && m_hwHF == (bool)rhs.hwHF()
+      && m_hwSign == rhs.hwSign()
+      && m_hwSignValid == rhs.hwSignValid()
+      && m_hwQuality == rhs.hwQual()
+      && m_link == rhs.link()
+      && m_processor == rhs.processor()
+      && m_trackFinder == rhs.trackFinderType()
+      && m_trackAddress == rhs.trackAddress();
+}
+
 } // namespace l1t

--- a/DataFormats/L1TMuon/src/classes.h
+++ b/DataFormats/L1TMuon/src/classes.h
@@ -57,3 +57,17 @@ namespace L1Trigger_L1TMuonBarrel {
     edm::Wrapper<L1MuBMTrackSegEtaCollection> l1mu_trk_th_W;
   };
 }
+
+namespace DataFormats_L1TMuon {
+  struct dictionary {
+    l1t::RegionalMuonCandRef rmcr;
+    std::vector<l1t::RegionalMuonCandRef> v_rmcr;
+    l1t::RegionalMuonCandRefBxCollection rmcrbxc;
+    edm::Wrapper<l1t::RegionalMuonCandRefBxCollection> w_rmcrbxc;
+    l1t::RegionalMuonCandRefPair rmcrp;
+    std::vector<l1t::RegionalMuonCandRefPair> v_rmcrp;
+    l1t::RegionalMuonCandRefPairBxCollection rmcrpc;
+    edm::Wrapper<l1t::RegionalMuonCandRefPairBxCollection> w_rmcrpc;
+  };
+}
+

--- a/DataFormats/L1TMuon/src/classes.h
+++ b/DataFormats/L1TMuon/src/classes.h
@@ -35,6 +35,15 @@ namespace {
 
     l1t::EMTFTrackCollection emtfTrack;
     edm::Wrapper<l1t::EMTFTrackCollection> emtfTrackWrap;
+
+    l1t::RegionalMuonCandRef rmcr;
+    std::vector<l1t::RegionalMuonCandRef> v_rmcr;
+    l1t::RegionalMuonCandRefBxCollection rmcrbxc;
+    edm::Wrapper<l1t::RegionalMuonCandRefBxCollection> w_rmcrbxc;
+    l1t::RegionalMuonCandRefPair rmcrp;
+    std::vector<l1t::RegionalMuonCandRefPair> v_rmcrp;
+    l1t::RegionalMuonCandRefPairBxCollection rmcrpc;
+    edm::Wrapper<l1t::RegionalMuonCandRefPairBxCollection> w_rmcrpc;
   };
 }
 
@@ -55,19 +64,6 @@ namespace L1Trigger_L1TMuonBarrel {
 
     L1MuBMTrackSegEtaCollection l1mu_trk_th_V;
     edm::Wrapper<L1MuBMTrackSegEtaCollection> l1mu_trk_th_W;
-  };
-}
-
-namespace DataFormats_L1TMuon {
-  struct dictionary {
-    l1t::RegionalMuonCandRef rmcr;
-    std::vector<l1t::RegionalMuonCandRef> v_rmcr;
-    l1t::RegionalMuonCandRefBxCollection rmcrbxc;
-    edm::Wrapper<l1t::RegionalMuonCandRefBxCollection> w_rmcrbxc;
-    l1t::RegionalMuonCandRefPair rmcrp;
-    std::vector<l1t::RegionalMuonCandRefPair> v_rmcrp;
-    l1t::RegionalMuonCandRefPairBxCollection rmcrpc;
-    edm::Wrapper<l1t::RegionalMuonCandRefPairBxCollection> w_rmcrpc;
   };
 }
 

--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -71,5 +71,14 @@
   <class name="edm::Wrapper<L1MuBMTrackSegPhiCollection >"/>
   <class name="edm::Wrapper<L1MuBMTrackSegEtaCollection >"/>
 
+  <class name="l1t::RegionalMuonCandRef"/>
+  <class name="std::vector<l1t::RegionalMuonCandRef>"/>
+  <class name="l1t::RegionalMuonCandRefBxCollection"/>
+  <class name="edm::Wrapper<l1t::RegionalMuonCandRefBxCollection>"/>
+  <class name="l1t::RegionalMuonCandRefPair"/>
+  <class name="std::vector<l1t::RegionalMuonCandRefPair>"/>
+  <class name="l1t::RegionalMuonCandRefPairBxCollection"/>
+  <class name="edm::Wrapper<l1t::RegionalMuonCandRefPairBxCollection>"/>
+
  </selection>
 </lcgdict>

--- a/DataFormats/L1Trigger/interface/L1Candidate.h
+++ b/DataFormats/L1Trigger/interface/L1Candidate.h
@@ -51,6 +51,9 @@ namespace l1t {
     int hwQual() const {return hwQual_;}
     int hwIso() const {return hwIso_;}
 
+    virtual bool operator==(const l1t::L1Candidate & rhs) const;
+    virtual inline bool operator!=(const l1t::L1Candidate & rhs) const { return !(operator==(rhs)); };
+
   private:
 
     // integer "hardware" values

--- a/DataFormats/L1Trigger/interface/L1TObjComparison.h
+++ b/DataFormats/L1Trigger/interface/L1TObjComparison.h
@@ -1,0 +1,19 @@
+#ifndef DataFormats_L1Trigger_L1TObjComparison_h
+#define DataFormats_L1Trigger_L1TObjComparison_h
+
+#include <utility>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/L1Trigger/interface/BXVector.h"
+
+namespace l1t {
+  template <typename T>
+  using ObjectRef = edm::Ref<BXVector<T>>;
+  template <typename T>
+  using ObjectRefBxCollection = BXVector<ObjectRef<T>>;
+  template <typename T>
+  using ObjectRefPair = std::pair<edm::Ref<BXVector<T>>, edm::Ref<BXVector<T>>>;
+  template <typename T>
+  using ObjectRefPairBxCollection = BXVector<ObjectRefPair<T>>;
+}
+
+#endif

--- a/DataFormats/L1Trigger/interface/Muon.h
+++ b/DataFormats/L1Trigger/interface/Muon.h
@@ -4,6 +4,7 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
+#include "DataFormats/L1Trigger/interface/L1TObjComparison.h"
 
 namespace l1t {
 
@@ -12,6 +13,10 @@ namespace l1t {
   typedef edm::Ref< MuonBxCollection > MuonRef ;
   typedef edm::RefVector< MuonBxCollection > MuonRefVector ;
   typedef std::vector< MuonRef > MuonVectorRef ;
+
+  typedef ObjectRefBxCollection<Muon> MuonRefBxCollection;
+  typedef ObjectRefPair<Muon> MuonRefPair;
+  typedef ObjectRefPairBxCollection<Muon> MuonRefPairBxCollection;
 
   class Muon : public L1Candidate {
     
@@ -95,7 +100,10 @@ namespace l1t {
     inline int hwRank() const { return hwRank_; };
 
     inline bool debug() const { return debug_; };
-    
+
+    virtual bool operator==(const l1t::Muon& rhs) const;
+    virtual inline bool operator!=(const l1t::Muon& rhs) const { return !(operator==(rhs)); };
+ 
   private:
     
     // additional hardware quantities common to L1 global jet

--- a/DataFormats/L1Trigger/src/L1Candidate.cc
+++ b/DataFormats/L1Trigger/src/L1Candidate.cc
@@ -41,6 +41,12 @@ l1t::L1Candidate::~L1Candidate()
 
 }
 
-
-
+bool l1t::L1Candidate::operator==(const l1t::L1Candidate& rhs) const
+{
+  return hwPt_ == rhs.hwPt()
+      && hwEta_ == rhs.hwEta()
+      && hwPhi_ == rhs.hwPhi()
+      && hwQual_ == rhs.hwQual()
+      && hwIso_ == rhs.hwIso();
+}
 

--- a/DataFormats/L1Trigger/src/Muon.cc
+++ b/DataFormats/L1Trigger/src/Muon.cc
@@ -98,3 +98,13 @@ l1t::Muon::~Muon()
 
 }
 
+bool l1t::Muon::operator==(const l1t::Muon& rhs) const
+{
+  return l1t::L1Candidate::operator==(static_cast<const l1t::L1Candidate &>(rhs))
+      && hwCharge_ == rhs.hwCharge()
+      && hwChargeValid_ == rhs.hwChargeValid()
+      && tfMuonIndex_ == rhs.tfMuonIndex()
+      && hwEtaAtVtx_ == rhs.hwEtaAtVtx()
+      && hwPhiAtVtx_ == rhs.hwPhiAtVtx();
+}
+

--- a/DataFormats/L1Trigger/src/classes.h
+++ b/DataFormats/L1Trigger/src/classes.h
@@ -5,7 +5,6 @@
 #include "Math/CylindricalEta3D.h"
 #include "Math/PxPyPzE4D.h"
 #include <boost/cstdint.hpp>
-#include <utility>
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctCand.h"
 #include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
 #include "DataFormats/L1Trigger/interface/L1JetParticle.h"
@@ -21,7 +20,6 @@
 #include "DataFormats/L1Trigger/interface/L1HFRingsFwd.h"
 #include "DataFormats/L1Trigger/interface/L1TriggerError.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefProd.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"

--- a/DataFormats/L1Trigger/src/classes.h
+++ b/DataFormats/L1Trigger/src/classes.h
@@ -5,6 +5,7 @@
 #include "Math/CylindricalEta3D.h"
 #include "Math/PxPyPzE4D.h"
 #include <boost/cstdint.hpp>
+#include <utility>
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctCand.h"
 #include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
 #include "DataFormats/L1Trigger/interface/L1JetParticle.h"
@@ -20,6 +21,7 @@
 #include "DataFormats/L1Trigger/interface/L1HFRingsFwd.h"
 #include "DataFormats/L1Trigger/interface/L1TriggerError.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefProd.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
@@ -172,6 +174,13 @@ namespace DataFormats_L1Trigger {
 
     L1DataEmulRecord der;
     edm::Wrapper<L1DataEmulRecord> w_der;
+
+    l1t::MuonRefBxCollection murbxc;
+    edm::Wrapper<l1t::MuonRefBxCollection> w_murbxc;
+    l1t::MuonRefPair murp;
+    std::vector<l1t::MuonRefPair> v_murp;
+    l1t::MuonRefPairBxCollection murpc;
+    edm::Wrapper<l1t::MuonRefPairBxCollection> w_murpc;
 
     L1TriggerError l1tErr;
     L1TriggerErrorCollection l1tErrColl;

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -213,6 +213,13 @@
   </class>
   <class name="edm::Wrapper<L1DataEmulRecord>"/>
 
+  <class name="l1t::MuonRefBxCollection"/>
+  <class name="edm::Wrapper<l1t::MuonRefBxCollection>"/>
+  <class name="l1t::MuonRefPair"/>
+  <class name="std::vector<l1t::MuonRefPair>"/>
+  <class name="l1t::MuonRefPairBxCollection"/>
+  <class name="edm::Wrapper<l1t::MuonRefPairBxCollection>"/>
+
   <class name="L1TriggerError" ClassVersion="10">
    <version ClassVersion="10" checksum="3499325937"/>
   </class>
@@ -225,6 +232,5 @@
   <class name="l1t::L1DataEmulResultBxCollection"/>
   <class name="std::vector<l1t::L1DataEmulResult>"/>
   <class name="edm::Wrapper<l1t::L1DataEmulResultBxCollection>"/>
-
 
 </lcgdict>

--- a/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
@@ -1,0 +1,167 @@
+// -*- C++ -*-
+//
+// Package:    L1Trigger/L1TCommon
+// Class:      L1TComparisonResultFilter
+// 
+/**\class L1TComparisonResultFilter L1TComparisonResultFilter.cc L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
+
+ Description: Filters on result of L1T object comparison. Events where the collections match are passing.
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Thomas Reis
+//         Created:  Fri, 19 Jan 2018 14:08:35 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <algorithm>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/L1Trigger/interface/L1TObjComparison.h"
+
+//
+// class declaration
+//
+
+template <typename T>
+class L1TComparisonResultFilter : public edm::stream::EDFilter<> {
+   public:
+      explicit L1TComparisonResultFilter(const edm::ParameterSet&);
+      ~L1TComparisonResultFilter() override = default;
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginStream(edm::StreamID) override { };
+      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+      virtual void endStream() override { };
+
+      // ----------member data ---------------------------
+      edm::InputTag inputTag_;
+
+      edm::EDGetTokenT<l1t::ObjectRefPairBxCollection<T>> pairCollToken_;
+      edm::EDGetTokenT<l1t::ObjectRefBxCollection<T>> coll1Token_;
+      edm::EDGetTokenT<l1t::ObjectRefBxCollection<T>> coll2Token_;
+
+      // Maximal mismatch sizes
+      // Only analyse the corresponding property if max is not negative
+      const int maxBxRangeDiff_;
+      const int maxExcess_;
+      const int maxSize_;
+
+      // Invert the final result
+      const bool invert_;
+};
+
+//
+// constructors and destructor
+//
+template <typename T>
+L1TComparisonResultFilter<T>::L1TComparisonResultFilter(const edm::ParameterSet& iConfig)
+ : inputTag_(iConfig.getParameter<edm::InputTag>("objComparisonColl")),
+   maxBxRangeDiff_(iConfig.getParameter<int>("maxBxRangeDiff")),
+   maxExcess_(iConfig.getParameter<int>("maxExcess")),
+   maxSize_(iConfig.getParameter<int>("maxSize")),
+   invert_(iConfig.getParameter<bool>("invert"))
+{
+   if (maxBxRangeDiff_ > -1 || maxExcess_ > -1) {
+      // Take all input tags needed from the same module
+      edm::InputTag coll1Tag(inputTag_.label(), "collection1ExcessObjects");
+      edm::InputTag coll2Tag(inputTag_.label(), "collection2ExcessObjects");
+      coll1Token_ = consumes<l1t::ObjectRefBxCollection<T>>(coll1Tag);
+      coll2Token_ = consumes<l1t::ObjectRefBxCollection<T>>(coll2Tag);
+   }
+   if (maxSize_ > -1) {
+      pairCollToken_ = consumes<l1t::ObjectRefPairBxCollection<T>>(inputTag_);
+   }
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called on each new Event  ------------
+template <typename T>
+bool
+L1TComparisonResultFilter<T>::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   bool pass = true;
+
+   if (maxBxRangeDiff_ > -1 || maxExcess_ > -1) {
+      edm::Handle<l1t::ObjectRefBxCollection<T>> bxColl1;
+      edm::Handle<l1t::ObjectRefBxCollection<T>> bxColl2;
+      iEvent.getByToken(coll1Token_, bxColl1);
+      iEvent.getByToken(coll2Token_, bxColl2);
+
+      // Check if BX ranges match
+      if (maxBxRangeDiff_ > -1) {
+         const auto bxRange1 = bxColl1->getLastBX() - bxColl1->getFirstBX() + 1;
+         const auto bxRange2 = bxColl2->getLastBX() - bxColl2->getFirstBX() + 1;
+         pass &= (std::abs(bxRange1 - bxRange2) <= maxBxRangeDiff_);
+      }
+
+      // If the BX range check passed check if number of objects per BX matches
+      if (pass && maxExcess_ > -1) {
+         const auto firstCommonBx = std::max(bxColl1->getFirstBX(), bxColl2->getFirstBX());
+         const auto lastCommonBx = std::min(bxColl1->getLastBX(), bxColl2->getLastBX());
+         for (auto iBx = firstCommonBx; iBx <= lastCommonBx; ++iBx) {
+            pass &= (bxColl1->size(iBx) <= static_cast<unsigned>(maxExcess_));
+            pass &= (bxColl2->size(iBx) <= static_cast<unsigned>(maxExcess_));
+            if (!pass) break;
+         }
+      }
+   }
+
+   // If the previous checks passed check if there are mismatching objects
+   if (pass && maxSize_ > -1) {
+      edm::Handle<l1t::ObjectRefPairBxCollection<T>> bxPairColl;
+      iEvent.getByToken(pairCollToken_, bxPairColl);
+
+      pass &= (bxPairColl->size() <= static_cast<unsigned>(maxSize_));
+   }
+
+   if (invert_) {
+      return !pass;
+   }
+   return pass;
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+template <typename T>
+void
+L1TComparisonResultFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("objComparisonColl")->setComment("Object comparison collection");
+  desc.add<int>("maxBxRangeDiff", -1)->setComment("Maximal BX range difference");
+  desc.add<int>("maxExcess", -1)->setComment("Maximal allowed excess objects per BX");
+  desc.add<int>("maxSize", -1)->setComment("Maximal allowed mismatches");
+  desc.add<bool>("invert", false)->setComment("Invert final result");
+  descriptions.addDefault(desc);
+}
+
+//define plugins for different L1T objects
+#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
+typedef L1TComparisonResultFilter<GlobalAlgBlk> L1TGlobalAlgBlkComparisonResultFilter;
+typedef L1TComparisonResultFilter<l1t::Muon> L1TMuonComparisonResultFilter;
+typedef L1TComparisonResultFilter<l1t::RegionalMuonCand> L1TRegionalMuonCandComparisonResultFilter;
+DEFINE_FWK_MODULE(L1TGlobalAlgBlkComparisonResultFilter);
+DEFINE_FWK_MODULE(L1TMuonComparisonResultFilter);
+DEFINE_FWK_MODULE(L1TRegionalMuonCandComparisonResultFilter);

--- a/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
@@ -162,5 +162,9 @@ void L1TStage2ObjectComparison<T>::produce(edm::Event& e, const edm::EventSetup&
 
 //define plugins for different L1T objects
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 typedef L1TStage2ObjectComparison<l1t::Muon> L1TStage2MuonComparison;
+typedef L1TStage2ObjectComparison<l1t::RegionalMuonCand> L1TStage2RegionalMuonCandComparison;
 DEFINE_FWK_MODULE(L1TStage2MuonComparison);
+DEFINE_FWK_MODULE(L1TStage2RegionalMuonCandComparison);

--- a/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
@@ -1,0 +1,163 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/L1Trigger/interface/BXVector.h"
+#include "DataFormats/L1Trigger/interface/L1TObjComparison.h"
+
+#include <algorithm>
+
+template <typename T>
+class L1TStage2ObjectComparison : public edm::stream::EDProducer<> {
+
+ public:
+
+  L1TStage2ObjectComparison(const edm::ParameterSet& ps);
+  ~L1TStage2ObjectComparison() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+ protected:
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+ private:  
+
+  edm::EDGetTokenT<BXVector<T>> token1_;
+  edm::EDGetTokenT<BXVector<T>> token2_;
+  const bool checkBxRange_;
+  const bool checkCollSizePerBx_;
+  const bool checkObject_;
+
+};
+
+template <typename T>
+L1TStage2ObjectComparison<T>::L1TStage2ObjectComparison(const edm::ParameterSet& ps)
+    : token1_(consumes<BXVector<T>>(ps.getParameter<edm::InputTag>("collection1"))),
+      token2_(consumes<BXVector<T>>(ps.getParameter<edm::InputTag>("collection2"))),
+      checkBxRange_(ps.getParameter<bool>("checkBxRange")),
+      checkCollSizePerBx_(ps.getParameter<bool>("checkCollSizePerBx")),
+      checkObject_(ps.getParameter<bool>("checkObject"))
+{
+  if (checkBxRange_ || checkCollSizePerBx_) {
+    produces<l1t::ObjectRefBxCollection<T>>("collection1ExcessObjects");
+    produces<l1t::ObjectRefBxCollection<T>>("collection2ExcessObjects");
+  }
+  if (checkObject_) {
+    produces<l1t::ObjectRefPairBxCollection<T>>("objectMatches");
+    produces<l1t::ObjectRefPairBxCollection<T>>("objectMismatches");
+  }
+}
+
+template <typename T>
+void L1TStage2ObjectComparison<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("collection1")->setComment("L1T object collection 1");
+  desc.add<edm::InputTag>("collection2")->setComment("L1T object collection 2");
+  desc.add<bool>("checkBxRange")->setComment("Check if BX ranges match");
+  desc.add<bool>("checkCollSizePerBx")->setComment("Check if collection sizes within one BX match");
+  desc.add<bool>("checkObject")->setComment("Check if objects match");
+  descriptions.addDefault(desc);
+}
+
+template <typename T>
+void L1TStage2ObjectComparison<T>::produce(edm::Event& e, const edm::EventSetup& c)
+{
+  auto excessObjRefsColl1 = std::make_unique<l1t::ObjectRefBxCollection<T>>();
+  auto excessObjRefsColl2 = std::make_unique<l1t::ObjectRefBxCollection<T>>();
+  auto matchRefPairs = std::make_unique<l1t::ObjectRefPairBxCollection<T>>();
+  auto mismatchRefPairs = std::make_unique<l1t::ObjectRefPairBxCollection<T>>();
+
+  edm::Handle<BXVector<T>> bxColl1;
+  edm::Handle<BXVector<T>> bxColl2;
+  e.getByToken(token1_, bxColl1);
+  e.getByToken(token2_, bxColl2);
+
+  // Set the BX ranges like the input collection BX ranges
+  excessObjRefsColl1->setBXRange(bxColl1->getFirstBX(), bxColl1->getLastBX());
+  excessObjRefsColl2->setBXRange(bxColl2->getFirstBX(), bxColl2->getLastBX());
+  // Set the BX range to the intersection of the two input collection BX ranges
+  matchRefPairs->setBXRange(std::max(bxColl1->getFirstBX(), bxColl2->getFirstBX()), std::min(bxColl1->getLastBX(), bxColl2->getLastBX()));
+  mismatchRefPairs->setBXRange(std::max(bxColl1->getFirstBX(), bxColl2->getFirstBX()), std::min(bxColl1->getLastBX(), bxColl2->getLastBX()));
+
+  if (checkBxRange_) {
+    // Store references to objects in BX that do not exist in the other collection
+    typename BXVector<T>::const_iterator it;
+    // BX range of collection 1 > collection 2
+    for (auto iBx = bxColl1->getFirstBX(); iBx < bxColl2->getFirstBX(); ++iBx) {
+      for (it = bxColl1->begin(iBx); it != bxColl1->end(iBx); ++it) {
+        edm::Ref<BXVector<T>> ref{bxColl1, bxColl1->key(it)};
+        excessObjRefsColl1->push_back(iBx, ref);
+      }
+    }
+    for (auto iBx = bxColl1->getLastBX(); iBx > bxColl2->getLastBX(); --iBx) {
+      for (it = bxColl1->begin(iBx); it != bxColl1->end(iBx); ++it) {
+        edm::Ref<BXVector<T>> ref{bxColl1, bxColl1->key(it)};
+        excessObjRefsColl1->push_back(iBx, ref);
+      }
+    }
+    // BX range of collection 2 > collection 1
+    for (auto iBx = bxColl2->getFirstBX(); iBx < bxColl1->getFirstBX(); ++iBx) {
+      for (it = bxColl2->begin(iBx); it != bxColl2->end(iBx); ++it) {
+        edm::Ref<BXVector<T>> ref{bxColl2, bxColl2->key(it)};
+        excessObjRefsColl2->push_back(iBx, ref);
+      }
+    }
+    for (auto iBx = bxColl2->getLastBX(); iBx > bxColl1->getLastBX(); --iBx) {
+      for (it = bxColl2->begin(iBx); it != bxColl2->end(iBx); ++it) {
+        edm::Ref<BXVector<T>> ref{bxColl2, bxColl2->key(it)};
+        excessObjRefsColl2->push_back(iBx, ref);
+      }
+    }
+  }
+
+  // Loop over all BX that exist in both collections
+  for (int iBx = matchRefPairs->getFirstBX(); iBx <= matchRefPairs->getLastBX(); ++iBx) {
+    auto it1 = bxColl1->begin(iBx);
+    auto it2 = bxColl2->begin(iBx);
+    while (it1 != bxColl1->end(iBx) && it2 != bxColl2->end(iBx)) {
+      if (checkObject_) {
+        // Store reference pairs for matching and mismatching objects
+        edm::Ref<BXVector<T>> ref1{bxColl1, bxColl1->key(it1)};
+        edm::Ref<BXVector<T>> ref2{bxColl2, bxColl2->key(it2)};
+        if (*it1 == *it2) {
+          matchRefPairs->push_back(iBx, std::make_pair(ref1, ref2));
+        } else {
+          mismatchRefPairs->push_back(iBx, std::make_pair(ref1, ref2));
+        }
+      }
+      ++it1;
+      ++it2;
+    }
+    if (checkCollSizePerBx_) {
+      // Store references to excess objects if there are more objects in one collection (per BX)
+      while (it1 != bxColl1->end(iBx)) {
+        edm::Ref<BXVector<T>> ref{bxColl1, bxColl1->key(it1)};
+        excessObjRefsColl1->push_back(iBx, ref);
+        ++it1;
+      }
+      while (it2 != bxColl2->end(iBx)) {
+        edm::Ref<BXVector<T>> ref{bxColl2, bxColl2->key(it2)};
+        excessObjRefsColl2->push_back(iBx, ref);
+        ++it2;
+      }
+    }
+  }
+
+  // Put data in the event
+  if (checkBxRange_ || checkCollSizePerBx_) {
+    e.put(std::move(excessObjRefsColl1), "collection1ExcessObjects");
+    e.put(std::move(excessObjRefsColl2), "collection2ExcessObjects");
+  }
+  if (checkObject_) {
+    e.put(std::move(matchRefPairs), "objectMatches");
+    e.put(std::move(mismatchRefPairs), "objectMismatches");
+  }
+}
+
+

--- a/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
@@ -160,4 +160,7 @@ void L1TStage2ObjectComparison<T>::produce(edm::Event& e, const edm::EventSetup&
   }
 }
 
-
+//define plugins for different L1T objects
+#include "DataFormats/L1Trigger/interface/Muon.h"
+typedef L1TStage2ObjectComparison<l1t::Muon> L1TStage2MuonComparison;
+DEFINE_FWK_MODULE(L1TStage2MuonComparison);

--- a/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
@@ -161,10 +161,13 @@ void L1TStage2ObjectComparison<T>::produce(edm::Event& e, const edm::EventSetup&
 }
 
 //define plugins for different L1T objects
+#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
+typedef L1TStage2ObjectComparison<GlobalAlgBlk> L1TStage2GlobalAlgBlkComparison;
 typedef L1TStage2ObjectComparison<l1t::Muon> L1TStage2MuonComparison;
 typedef L1TStage2ObjectComparison<l1t::RegionalMuonCand> L1TStage2RegionalMuonCandComparison;
+DEFINE_FWK_MODULE(L1TStage2GlobalAlgBlkComparison);
 DEFINE_FWK_MODULE(L1TStage2MuonComparison);
 DEFINE_FWK_MODULE(L1TStage2RegionalMuonCandComparison);


### PR DESCRIPTION
This adds a templated EDProducer to compare L1T objects stored in two BXVectors.
The result could then be used in a filter to select events for where objects mismatch.
In addition, DQM modules can use the products to generate histograms, e.g. for data to emulator comparisons.

Three tests can be activated in the configuration.
The BXVectors BX ranges are compared and references to objects in the larger BX range collection are stored.
The number of objects per BX is compared between the two collections and references to excess objects are put in the events.
The third comparison is between objects. pairs of matching and pairs of mismatching objects are put in 
the event. For this the `operator==` was overloaded for the objects that can be compared.

Objects that are handled so far are GlobalAlgBlk, l1t::Muon, l1t::RegionalMuonCand but additional objects can be added.