### PR TITLE
Compare cone volumes up to 11th digit of fp

### DIFF
--- a/SimG4Core/Geometry/test/Cons_.cpp
+++ b/SimG4Core/Geometry/test/Cons_.cpp
@@ -43,13 +43,14 @@ testCons::matched_g4_and_dd( void )
   double g4v = g4.GetCubicVolume()/cm3;
   double ddv = dd.volume()/cm3;
   double ddsv = dds.volume()/cm3;
+  double precision_in_digits = 1e-12;
   
   std::cout << "\tg4 volume = " << g4v <<" cm3" << std::endl;
   std::cout << "\tdd volume = " << ddv << " cm3" <<  std::endl;
   std::cout << "\tDD Information: " << dds << " vol=" << ddsv << " cm3" << std::endl;
-  
-  CPPUNIT_ASSERT( g4v == ddv );
-  CPPUNIT_ASSERT( g4v == ddsv );
+
+  CPPUNIT_ASSERT( abs(g4v - ddv) < precision_in_digits );
+  CPPUNIT_ASSERT( abs(g4v - ddsv) < precision_in_digits );
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION( testCons );


### PR DESCRIPTION
After introducing VecGeom into ROOT IBs a unit test started failing:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc630/CMSSW_10_0_ROOT6_X_2018-01-18-2300/unitTestLogs/SimG4Core/Geometry
with explanation given here:
https://github.com/cms-sw/cmssw/issues/21887
This PR fixes the test, as in the issue above is explained that the difference is explicable and introducing a tolerance instead of strict comparison is acceptable.