### PR TITLE
add data processing scenarios for 2018 eras

### DIFF
--- a/Configuration/DataProcessing/python/Impl/cosmicsEra_Run2_2018.py
+++ b/Configuration/DataProcessing/python/Impl/cosmicsEra_Run2_2018.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""
+_cosmicsEra_Run2_2018_
+
+Scenario supporting cosmic data taking
+
+"""
+
+import os
+import sys
+
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+from Configuration.DataProcessing.Impl.cosmics import cosmics
+
+class cosmicsEra_Run2_2018(cosmics):
+    def __init__(self):
+        cosmics.__init__(self)
+        self.eras = Run2_2018
+    """
+    _cosmicsEra_Run2_2018_
+
+    Implement configuration building for data processing for cosmic
+    data taking in Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2018.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2018.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""
+_hcalnzsEra_Run2_2018_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Impl.hcalnzs import hcalnzs
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+
+class hcalnzsEra_Run2_2018(hcalnzs):
+    def __init__(self):
+        hcalnzs.__init__(self)
+        self.recoSeq=':reconstruction_HcalNZS'
+        self.cbSc='pp'
+        self.addEI=True
+        self.eras = Run2_2018
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+    """
+    _hcalnzsEra_Run2_2018_
+
+    Implement configuration building for data processing for proton
+    collision data taking
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2018.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2018.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2018_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run2_2018(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.addEI=True
+        self.eras=Run2_2018
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+    """
+    _ppEra_Run2_2018_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/trackingOnly.py
@@ -15,7 +15,7 @@ class trackingOnly(pp):
     def __init__(self):
         pp.__init__(self)
         # tracking only RECO is sufficient, to run high performance BS at PCL;
-        # some dedicated customization are required, though: customisePostEra_Run2_2017_trackingOnly
+        # some dedicated customization are required, though: see specific era implementations
         self.recoSeq=':reconstruction_trackingOnly'
         self.cbSc='pp'
         # don't run EI, because only tracking is done
@@ -24,7 +24,7 @@ class trackingOnly(pp):
     _trackingOnly_
 
     Implement configuration building for data processing for proton
-    collision data taking
+    collision data taking for high performance beamspot
 
     """
 
@@ -45,10 +45,4 @@ class trackingOnly(pp):
 
         return process
 
-    """
-    _ppEra_Run2_2017_trackingOnly
 
-    Implement configuration building for data processing for proton
-    collision data taking for Run2, 2017 high performance beamspot
-
-    """

--- a/Configuration/DataProcessing/python/Impl/trackingOnlyEra_Run2_2017.py
+++ b/Configuration/DataProcessing/python/Impl/trackingOnlyEra_Run2_2017.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""
+_trackingOnlyEra_Run2_2017
+
+Scenario supporting proton collisions and tracking only reconstruction for HP beamspot
+
+"""
+
+import os
+import sys
+
+from   Configuration.DataProcessing.Impl.trackingOnly import trackingOnly
+import FWCore.ParameterSet.Config as cms
+from   Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+
+from   Configuration.DataProcessing.Impl.pp import pp
+
+class trackingOnlyEra_Run2_2017(trackingOnly):
+    def __init__(self):
+        trackingOnly.__init__(self)
+        # tracking only RECO is sufficient, to run high performance BS at PCL;
+        # some dedicated customization are required, though: customisePostEra_Run2_2017_trackingOnly
+        self.recoSeq=':reconstruction_trackingOnly'
+        self.cbSc='pp'
+        self.addEI=False
+        self.eras=Run2_2017
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_express_trackingOnly' ]
+        self.alcaHarvCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_harvesting_trackingOnly' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+
+    """
+    _trackingOnlyEra_Run2_2017
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2, 2017 high performance beamspot
+
+    """

--- a/Configuration/DataProcessing/python/Impl/trackingOnlyEra_Run2_2018.py
+++ b/Configuration/DataProcessing/python/Impl/trackingOnlyEra_Run2_2018.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""
+_trackingOnlyEra_Run2_2018
+
+Scenario supporting proton collisions and tracking only reconstruction for HP beamspot
+
+"""
+
+import os
+import sys
+
+from   Configuration.DataProcessing.Impl.trackingOnly import trackingOnly
+import FWCore.ParameterSet.Config as cms
+from   Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+
+from   Configuration.DataProcessing.Impl.pp import pp
+
+class trackingOnlyEra_Run2_2018(trackingOnly):
+    def __init__(self):
+        trackingOnly.__init__(self)
+        # tracking only RECO is sufficient, to run high performance BS at PCL;
+        # some dedicated customization are required, though: customisePostEra_Run2_2018_trackingOnly
+        self.recoSeq=':reconstruction_trackingOnly'
+        self.cbSc='pp'
+        self.addEI=False
+        self.eras=Run2_2018
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018_express_trackingOnly' ]
+        self.alcaHarvCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018_harvesting_trackingOnly' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+
+    """
+    _trackingOnlyEra_Run2_2018
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2, 2018 high performance beamspot
+
+    """

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -68,6 +68,23 @@ def customisePostEra_Run2_2017_ppRef(process):
     customisePostEra_Run2_2017(process)
     return process
 
+# 2018 equivalents
+def customisePostEra_Run2_2018(process):
+    #start with a repeat of 2017
+    customisePostEra_Run2_2017(process)
+    return process
+
+def customisePostEra_Run2_2018_express_trackingOnly(process):
+    #start with a repeat of 2017
+    customisePostEra_Run2_2017_express_trackingOnly(process)
+    return process
+
+def customisePostEra_Run2_2018_harvesting_trackingOnly(process):
+    #start with a repeat of 2017
+    customisePostEra_Run2_2017_harvesting_trackingOnly(process)
+    return process
+
+
 ##############################################################################
 def customisePPData(process):
     #deprecated process= customiseCommon(process)

--- a/Configuration/DataProcessing/test/cosmicsEra_Run2_2018_t.py
+++ b/Configuration/DataProcessing/test/cosmicsEra_Run2_2018_t.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+_cosmicsEra_Run2_2018_
+
+Test for CosmicsRun2 Scenario implementation
+
+"""
+
+
+import unittest
+import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.GetScenario import getScenario
+
+
+
+def writePSetFile(name, process):
+    """
+    _writePSetFile_
+
+    Util to dump the process to a file
+
+    """
+    handle = open(name, 'w')
+    handle.write(process.dumpPython())
+    handle.close()
+
+
+class cosmicsEra_Run2_2018ScenarioTest(unittest.TestCase):
+    """
+    unittest for cosmicsEra_Run2_2018 scenario
+
+    """
+
+    def testA(self):
+        """get the scenario"""
+        try:
+            scenario = getScenario("cosmicsEra_Run2_2018")
+        except Exception as ex:
+            msg = "Failed to get cosmicsEra_Run2_2018 scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testPromptReco(self):
+        """test promptReco method"""
+        scenario = getScenario("cosmicsEra_Run2_2018")
+        try:
+            process = scenario.promptReco("GLOBALTAG::ALL")
+            writePSetFile("testPromptReco.py", process)
+        except Exception as ex:
+            msg = "Failed to create Prompt Reco configuration\n"
+            msg += "for cosmicsEra_Run2_2018 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testExpressProcessing(self):
+        """ test expressProcessing method"""
+        scenario = getScenario("cosmicsEra_Run2_2018")
+        try:
+            process = scenario.expressProcessing("GLOBALTAG::ALL")
+            writePSetFile("testExpressProcessing.py", process)
+        except Exception as ex:
+            msg = "Failed to create Express Processing configuration\n"
+            msg += "for cosmicsEra_Run2_2018 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testAlcaSkim(self):
+        """ test alcaSkim method"""
+        scenario = getScenario("cosmicsEra_Run2_2018")
+        try:
+            process = scenario.alcaSkim(["MuAlCalIsolatedMu"])
+            writePSetFile("testAlcaReco.py", process)
+        except Exception as ex:
+           msg = "Failed to create Alca Skimming configuration\n"
+           msg += "for cosmicsEra_Run2_2018 Scenario\n"
+           msg += str(ex)
+           self.fail(msg)
+
+
+    def testDQMHarvesting(self):
+        """test dqmHarvesting  method"""
+        scenario = getScenario("cosmicsEra_Run2_2018")
+        try:
+            process = scenario.dqmHarvesting("dataset", 123456,
+                                             "GLOBALTAG::ALL")
+            writePSetFile("testDQMHarvesting.py", process)
+        except Exception as ex:
+            msg = "Failed to create DQM Harvesting configuration "
+            msg += "for cosmicsEra_Run2_2018 scenario:\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Configuration/DataProcessing/test/ppEra_Run2_2018_t.py
+++ b/Configuration/DataProcessing/test/ppEra_Run2_2018_t.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2018_
+
+Test for Collision Scenario implementation
+
+"""
+
+
+import unittest
+import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.GetScenario import getScenario
+
+
+
+def writePSetFile(name, process):
+    """
+    _writePSetFile_
+
+    Util to dump the process to a file
+
+    """
+    handle = open(name, 'w')
+    handle.write(process.dumpPython())
+    handle.close()
+
+
+class ppEra_Run2_2018ScenarioTest(unittest.TestCase):
+    """
+    unittest for ppEra_Run2_2018 collisions scenario
+
+    """
+
+    def testA(self):
+        """get the scenario"""
+        try:
+            scenario = getScenario("ppEra_Run2_2018")
+        except Exception as ex:
+            msg = "Failed to get ppEra_Run2_2018 scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testPromptReco(self):
+        """test promptReco method"""
+        scenario = getScenario("ppEra_Run2_2018")
+        try:
+            process = scenario.promptReco("GLOBALTAG::ALL")
+            writePSetFile("testPromptReco.py", process)
+        except Exception as ex:
+            msg = "Failed to create Prompt Reco configuration\n"
+            msg += "for ppEra_Run2_2018 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testExpressProcessing(self):
+        """ test expressProcessing method"""
+        scenario = getScenario("ppEra_Run2_2018")
+        try:
+            process = scenario.expressProcessing("GLOBALTAG::ALL")
+            writePSetFile("testExpressProcessing.py", process)
+        except Exception as ex:
+            msg = "Failed to create Express Processing configuration\n"
+            msg += "for ppEra_Run2_2018 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testAlcaSkim(self):
+        """ test alcaSkim method"""
+        scenario = getScenario("ppEra_Run2_2018")
+        try:
+            process = scenario.alcaSkim(["MuAlCalIsolatedMu"])
+            writePSetFile("testAlcaReco.py", process)
+        except Exception as ex:
+           msg = "Failed to create Alca Skimming configuration\n"
+           msg += "for ppEra_Run2_2018 Scenario\n"
+           msg += str(ex)
+           self.fail(msg)
+
+
+    def testDQMHarvesting(self):
+        """test dqmHarvesting  method"""
+        scenario = getScenario("ppEra_Run2_2018")
+        try:
+            process = scenario.dqmHarvesting("dataset", 123456,
+                                             "GLOBALTAG::ALL")
+            writePSetFile("testDQMHarvesting.py", process)
+        except Exception as ex:
+            msg = "Failed to create DQM Harvesting configuration "
+            msg += "for ppEra_Run2_2018 scenario:\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef")
+declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "cosmicsEra_Run2_2018" "ppEra_Run2_2018")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
@@ -22,7 +22,7 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "cosmicsEra_Run2_2017" "hcalnzsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017")
+declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "cosmicsEra_Run2_2017" "hcalnzsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
@@ -36,14 +36,14 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "HeavyIons" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017")
+declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "HeavyIons" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "ppEra_Run2_2018")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
      runTest "${LOCAL_TEST_DIR}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
 done
 
-declare -a arr=("ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef")
+declare -a arr=("ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2018")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
@@ -54,6 +54,10 @@ runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario AlCaTestEnable --g
 runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario AlCaTestEnable --lfn=/store/whatever --global-tag GLOBALTAG --skims PromptCalibProdEcalPedestals"
 runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario AlCaTestEnable --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --workflows=EcalPedestals"
 
-runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario trackingOnlyEra_Run2_2017 --global-tag GLOBALTAG  --lfn /store/whatever  --alcarecos=TkAlMinBias"
-runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario trackingOnlyEra_Run2_2017 --lfn /store/whatever --global-tag GLOBALTAG --skims TkAlMinBias"
-runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario trackingOnlyEra_Run2_2017 --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG"
+declare -a arr=("trackingOnlyEra_Run2_2017" "trackingOnlyEra_Run2_2018")
+for scenario in "${arr[@]}"
+do
+    runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG  --lfn /store/whatever  --alcarecos=TkAlMinBias"
+    runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn /store/whatever --global-tag GLOBALTAG --skims TkAlMinBias"
+    runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario $scenario --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG"
+done

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "cosmicsEra_Run2_2018" "ppEra_Run2_2018")
+declare -a arr=("cosmicsEra_Run2_2016" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "cosmicsEra_Run2_2018" "ppEra_Run2_2018")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
@@ -22,28 +22,20 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "cosmicsEra_Run2_2017" "hcalnzsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018")
+declare -a arr=("cosmicsEra_Run2_2016" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzsEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "cosmicsEra_Run2_2017" "hcalnzsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
 done
 
-declare -a arr=("HeavyIonsEra_Run2_HI")
-for scenario in "${arr[@]}"
-do
-     runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBiasHI+SiStripCalMinBias "
-     runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBiasHI+SiStripCalMinBias"
-done
-
-
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "HeavyIons" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "ppEra_Run2_2018")
+declare -a arr=("cosmicsEra_Run2_2016" "AlCaLumiPixels" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "ppEra_Run2_2018")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
      runTest "${LOCAL_TEST_DIR}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
 done
 
-declare -a arr=("ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2018")
+declare -a arr=("ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2018")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -54,6 +54,6 @@ runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario AlCaTestEnable --g
 runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario AlCaTestEnable --lfn=/store/whatever --global-tag GLOBALTAG --skims PromptCalibProdEcalPedestals"
 runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario AlCaTestEnable --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --workflows=EcalPedestals"
 
-runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario ppEra_Run2_2017_trackingOnly --global-tag GLOBALTAG  --lfn /store/whatever  --alcarecos=TkAlMinBias"
-runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario ppEra_Run2_2017_trackingOnly --lfn /store/whatever --global-tag GLOBALTAG --skims TkAlMinBias"
-runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario ppEra_Run2_2017_trackingOnly --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG"
+runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario trackingOnlyEra_Run2_2017 --global-tag GLOBALTAG  --lfn /store/whatever  --alcarecos=TkAlMinBias"
+runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario trackingOnlyEra_Run2_2017 --lfn /store/whatever --global-tag GLOBALTAG --skims TkAlMinBias"
+runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario trackingOnlyEra_Run2_2017 --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG"


### PR DESCRIPTION
- added: cosmicsEra_Run2_2018 hcalnzsEra_Run2_2018 ppEra_Run2_2018 trackingOnlyEra_Run2_2018
- also, the baseline ppEra_Run2_2017_trackingOnly is renamed to trackingOnlyEra_Run2_2017 in order to match the style of what is the scenario category (prefix) and what is the era (suffix).
- run_CfgTest.sh is updated to have 2018. Is is also cleaned up a bit to drop pre-2016 scenarios. 
    - Some more extensive cleanup and perhaps some refactoring is needed for this file at some point to get the unit tests to complete in a more reasonable time.
