### PR TITLE
Calibcalorimetry/Calomiscalibtools: Change return type of ESProducer::produce methods to unique_ptr or shared_ptr.

### DIFF
--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibTools.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibTools.h
@@ -52,7 +52,7 @@ class CaloMiscalibTools : public edm::ESProducer, public edm::EventSetupRecordIn
       CaloMiscalibTools(const edm::ParameterSet&);
       ~CaloMiscalibTools() override;
 
-      typedef const  EcalIntercalibConstants * ReturnType;
+      typedef std::unique_ptr<EcalIntercalibConstants> ReturnType;
 
       ReturnType produce(const EcalIntercalibConstantsRcd&);
    private:

--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibTools.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibTools.h
@@ -59,7 +59,6 @@ class CaloMiscalibTools : public edm::ESProducer, public edm::EventSetupRecordIn
       // ----------member data ---------------------------
     void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
     
-    CaloMiscalibMapEcal map_;
     std::string barrelfile_; 
     std::string endcapfile_; 
     std::string barrelfileinpath_; 

--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibToolsMC.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibToolsMC.h
@@ -59,7 +59,6 @@ class CaloMiscalibToolsMC : public edm::ESProducer, public edm::EventSetupRecord
       // ----------member data ---------------------------
     void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
     
-    CaloMiscalibMapEcal map_;
     std::string barrelfile_; 
     std::string endcapfile_; 
     std::string barrelfileinpath_; 

--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibToolsMC.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibToolsMC.h
@@ -52,7 +52,7 @@ class CaloMiscalibToolsMC : public edm::ESProducer, public edm::EventSetupRecord
       CaloMiscalibToolsMC(const edm::ParameterSet&);
       ~CaloMiscalibToolsMC() override;
 
-      typedef const  EcalIntercalibConstantsMC * ReturnType;
+      typedef std::unique_ptr<EcalIntercalibConstantsMC> ReturnType;
 
       ReturnType produce(const EcalIntercalibConstantsMCRcd&);
    private:

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
@@ -37,7 +37,6 @@ CaloMiscalibTools::CaloMiscalibTools(const edm::ParameterSet& iConfig)
 {
    //the following line is needed to tell the framework what
    // data is being produced
-  map_.prefillMap();
 
   barrelfileinpath_=iConfig.getUntrackedParameter<std::string> ("fileNameBarrel","");
   endcapfileinpath_=iConfig.getUntrackedParameter<std::string> ("fileNameEndcap","");
@@ -77,6 +76,7 @@ CaloMiscalibTools::~CaloMiscalibTools()
 CaloMiscalibTools::ReturnType
 CaloMiscalibTools::produce(const EcalIntercalibConstantsRcd& iRecord)
 {
+    CaloMiscalibMapEcal map_;
     map_.prefillMap();
     MiscalibReaderFromXMLEcalBarrel barrelreader_(map_);
     MiscalibReaderFromXMLEcalEndcap endcapreader_(map_);

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
@@ -85,7 +85,7 @@ CaloMiscalibTools::produce(const EcalIntercalibConstantsRcd& iRecord)
     map_.print();
     // Added by Zhen, need a new object so to not be deleted at exit
     //    std::cout<<"about to copy"<<std::endl;
-    std::unique_ptr<EcalIntercalibConstants> mydata(new EcalIntercalibConstants(map_.get()));
+    CaloMiscalibTools::ReturnType mydata = std::make_unique<EcalIntercalibConstants>(map_.get());
     //    std::cout<<"mydata "<<mydata<<std::endl;
     return mydata;
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
@@ -85,7 +85,7 @@ CaloMiscalibTools::produce(const EcalIntercalibConstantsRcd& iRecord)
     map_.print();
     // Added by Zhen, need a new object so to not be deleted at exit
     //    std::cout<<"about to copy"<<std::endl;
-    std::unique_ptr<EcalIntercalibConstants> mydata(new EcalIntercalibConstants(map_.get()));
+    auto mydata = std::make_unique<EcalIntercalibConstants>(map_.get());
     //    std::cout<<"mydata "<<mydata<<std::endl;
     return mydata;
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
@@ -76,16 +76,16 @@ CaloMiscalibTools::~CaloMiscalibTools()
 CaloMiscalibTools::ReturnType
 CaloMiscalibTools::produce(const EcalIntercalibConstantsRcd& iRecord)
 {
-    CaloMiscalibMapEcal map_;
-    map_.prefillMap();
-    MiscalibReaderFromXMLEcalBarrel barrelreader_(map_);
-    MiscalibReaderFromXMLEcalEndcap endcapreader_(map_);
+    CaloMiscalibMapEcal map;
+    map.prefillMap();
+    MiscalibReaderFromXMLEcalBarrel barrelreader_(map);
+    MiscalibReaderFromXMLEcalEndcap endcapreader_(map);
     if(!barrelfile_.empty()) barrelreader_.parseXMLMiscalibFile(barrelfile_);
     if(!endcapfile_.empty())endcapreader_.parseXMLMiscalibFile(endcapfile_);
-    map_.print();
+    map.print();
     // Added by Zhen, need a new object so to not be deleted at exit
     //    std::cout<<"about to copy"<<std::endl;
-    CaloMiscalibTools::ReturnType mydata = std::make_unique<EcalIntercalibConstants>(map_.get());
+    CaloMiscalibTools::ReturnType mydata = std::make_unique<EcalIntercalibConstants>(map.get());
     //    std::cout<<"mydata "<<mydata<<std::endl;
     return mydata;
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
@@ -85,7 +85,7 @@ CaloMiscalibTools::produce(const EcalIntercalibConstantsRcd& iRecord)
     map_.print();
     // Added by Zhen, need a new object so to not be deleted at exit
     //    std::cout<<"about to copy"<<std::endl;
-    auto mydata = std::make_unique<EcalIntercalibConstants>(map_.get());
+    std::unique_ptr<EcalIntercalibConstants> mydata(new EcalIntercalibConstants(map_.get()));
     //    std::cout<<"mydata "<<mydata<<std::endl;
     return mydata;
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
@@ -85,7 +85,7 @@ CaloMiscalibTools::produce(const EcalIntercalibConstantsRcd& iRecord)
     map_.print();
     // Added by Zhen, need a new object so to not be deleted at exit
     //    std::cout<<"about to copy"<<std::endl;
-    EcalIntercalibConstants* mydata=new EcalIntercalibConstants(map_.get());
+    std::unique_ptr<EcalIntercalibConstants> mydata(new EcalIntercalibConstants(map_.get()));
     //    std::cout<<"mydata "<<mydata<<std::endl;
     return mydata;
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
@@ -85,7 +85,7 @@ CaloMiscalibToolsMC::produce(const EcalIntercalibConstantsMCRcd& iRecord)
     map_.print();
     // Added by Zhen, need a new object so to not be deleted at exit
     //    std::cout<<"about to copy"<<std::endl;
-    CaloMiscalibToolsMC::ReturnType mydata(new EcalIntercalibConstantsMC(map_.get()));
+    CaloMiscalibToolsMC::ReturnType mydata = std::make_unique<EcalIntercalibConstantsMC>(map_.get());
     //    std::cout<<"mydata "<<mydata<<std::endl;
     return mydata;
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
@@ -85,7 +85,7 @@ CaloMiscalibToolsMC::produce(const EcalIntercalibConstantsMCRcd& iRecord)
     map_.print();
     // Added by Zhen, need a new object so to not be deleted at exit
     //    std::cout<<"about to copy"<<std::endl;
-    auto mydata = std::make_unique<EcalIntercalibConstantsMC>(map_.get());
+    CaloMiscalibToolsMC::ReturnType mydata(new EcalIntercalibConstantsMC(map_.get()));
     //    std::cout<<"mydata "<<mydata<<std::endl;
     return mydata;
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
@@ -37,7 +37,6 @@ CaloMiscalibToolsMC::CaloMiscalibToolsMC(const edm::ParameterSet& iConfig)
 {
    //the following line is needed to tell the framework what
    // data is being produced
-  map_.prefillMap();
 
   barrelfileinpath_=iConfig.getUntrackedParameter<std::string> ("fileNameBarrel","");
   endcapfileinpath_=iConfig.getUntrackedParameter<std::string> ("fileNameEndcap","");
@@ -77,6 +76,7 @@ CaloMiscalibToolsMC::~CaloMiscalibToolsMC()
 CaloMiscalibToolsMC::ReturnType
 CaloMiscalibToolsMC::produce(const EcalIntercalibConstantsMCRcd& iRecord)
 {
+    CaloMiscalibMapEcal map_;
     map_.prefillMap();
     MiscalibReaderFromXMLEcalBarrel barrelreader_(map_);
     MiscalibReaderFromXMLEcalEndcap endcapreader_(map_);

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
@@ -85,7 +85,7 @@ CaloMiscalibToolsMC::produce(const EcalIntercalibConstantsMCRcd& iRecord)
     map_.print();
     // Added by Zhen, need a new object so to not be deleted at exit
     //    std::cout<<"about to copy"<<std::endl;
-    CaloMiscalibToolsMC::ReturnType mydata(new EcalIntercalibConstantsMC(map_.get()));
+    auto mydata = std::make_unique<EcalIntercalibConstantsMC>(map_.get());
     //    std::cout<<"mydata "<<mydata<<std::endl;
     return mydata;
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
@@ -85,7 +85,7 @@ CaloMiscalibToolsMC::produce(const EcalIntercalibConstantsMCRcd& iRecord)
     map_.print();
     // Added by Zhen, need a new object so to not be deleted at exit
     //    std::cout<<"about to copy"<<std::endl;
-    EcalIntercalibConstantsMC* mydata=new EcalIntercalibConstantsMC(map_.get());
+    CaloMiscalibToolsMC::ReturnType mydata(new EcalIntercalibConstantsMC(map_.get()));
     //    std::cout<<"mydata "<<mydata<<std::endl;
     return mydata;
 }

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
@@ -76,16 +76,16 @@ CaloMiscalibToolsMC::~CaloMiscalibToolsMC()
 CaloMiscalibToolsMC::ReturnType
 CaloMiscalibToolsMC::produce(const EcalIntercalibConstantsMCRcd& iRecord)
 {
-    CaloMiscalibMapEcal map_;
-    map_.prefillMap();
-    MiscalibReaderFromXMLEcalBarrel barrelreader_(map_);
-    MiscalibReaderFromXMLEcalEndcap endcapreader_(map_);
+    CaloMiscalibMapEcal map;
+    map.prefillMap();
+    MiscalibReaderFromXMLEcalBarrel barrelreader_(map);
+    MiscalibReaderFromXMLEcalEndcap endcapreader_(map);
     if(!barrelfile_.empty()) barrelreader_.parseXMLMiscalibFile(barrelfile_);
     if(!endcapfile_.empty())endcapreader_.parseXMLMiscalibFile(endcapfile_);
-    map_.print();
+    map.print();
     // Added by Zhen, need a new object so to not be deleted at exit
     //    std::cout<<"about to copy"<<std::endl;
-    CaloMiscalibToolsMC::ReturnType mydata = std::make_unique<EcalIntercalibConstantsMC>(map_.get());
+    CaloMiscalibToolsMC::ReturnType mydata = std::make_unique<EcalIntercalibConstantsMC>(map.get());
     //    std::cout<<"mydata "<<mydata<<std::endl;
     return mydata;
 }


### PR DESCRIPTION
In preparation for a move to multi IOV events in parallel, the return type of ESProducer::produce mehtods must be changed to unique_ptr or shared_ptr. These ptrs should not refer to member data. Rather they should refer to new(copied) objects.