### PR TITLE
 CalibMuon/DTCalibration: Change return type of ESProducer::produce methods to unique_ptr or shared_ptr.

### DIFF
--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
@@ -46,7 +46,7 @@ DTFakeT0ESProducer::~DTFakeT0ESProducer(){
 std::unique_ptr<DTT0> DTFakeT0ESProducer::produce(const DTT0Rcd& iRecord){
   
   parseDDD(iRecord);
-  std::unique_ptr<DTT0> t0Map = std::make_unique<DTT0>();
+  auto t0Map = std::make_unique<DTT0>();
   
   //Loop on layerId-nwires map
  for(map<DTLayerId, pair <unsigned int,unsigned int> >::const_iterator lIdWire = theLayerIdWiresMap.begin();

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
@@ -60,7 +60,8 @@ std::unique_ptr<DTT0> DTFakeT0ESProducer::produce(const DTT0Rcd& iRecord){
    }
  }
 
-  return std::make_unique<DTT0>( *t0Map );
+  std::unique_ptr<DTT0> mydata( new DTT0(*t0Map) );
+  return mydata;
 }
 
 void DTFakeT0ESProducer::parseDDD(const DTT0Rcd& iRecord){

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
@@ -60,8 +60,7 @@ std::unique_ptr<DTT0> DTFakeT0ESProducer::produce(const DTT0Rcd& iRecord){
    }
  }
 
-  std::unique_ptr<DTT0> mydata( new DTT0(*t0Map) );
-  return mydata;
+  return std::make_unique<DTT0>( *t0Map );
 }
 
 void DTFakeT0ESProducer::parseDDD(const DTT0Rcd& iRecord){

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
@@ -43,7 +43,7 @@ DTFakeT0ESProducer::~DTFakeT0ESProducer(){
 
 
 // ------------ method called to produce the data  ------------
-DTT0* DTFakeT0ESProducer::produce(const DTT0Rcd& iRecord){
+std::unique_ptr<DTT0> DTFakeT0ESProducer::produce(const DTT0Rcd& iRecord){
   
   parseDDD(iRecord);
   DTT0* t0Map = new DTT0();
@@ -60,7 +60,7 @@ DTT0* DTFakeT0ESProducer::produce(const DTT0Rcd& iRecord){
    }
  }
 
-  return t0Map;
+  return std::make_unique<DTT0>( *t0Map );
 }
 
 void DTFakeT0ESProducer::parseDDD(const DTT0Rcd& iRecord){

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
@@ -46,7 +46,7 @@ DTFakeT0ESProducer::~DTFakeT0ESProducer(){
 std::unique_ptr<DTT0> DTFakeT0ESProducer::produce(const DTT0Rcd& iRecord){
   
   parseDDD(iRecord);
-  DTT0* t0Map = new DTT0();
+  std::unique_ptr<DTT0> t0Map = std::make_unique<DTT0>();
   
   //Loop on layerId-nwires map
  for(map<DTLayerId, pair <unsigned int,unsigned int> >::const_iterator lIdWire = theLayerIdWiresMap.begin();
@@ -60,8 +60,7 @@ std::unique_ptr<DTT0> DTFakeT0ESProducer::produce(const DTT0Rcd& iRecord){
    }
  }
 
-  std::unique_ptr<DTT0> mydata( new DTT0(*t0Map) );
-  return mydata;
+  return t0Map;
 }
 
 void DTFakeT0ESProducer::parseDDD(const DTT0Rcd& iRecord){

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
@@ -36,7 +36,7 @@ public:
 
   ~DTFakeT0ESProducer() override;
 
-  DTT0* produce(const DTT0Rcd& iRecord);
+  std::unique_ptr<DTT0> produce(const DTT0Rcd& iRecord);
 
 private:
 


### PR DESCRIPTION
In preparation for a move to multi IOV events in parallel, the return type of ESProducer::produce mehtods must be changed to unique_ptr or shared_ptr. These ptrs should not refer to member data. Rather they should refer to new(copied) objects.