### PR TITLE
Fix for L1T emulator DQM client crash

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -6,7 +6,7 @@ from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 # It should be kept in synch with Express processing at Tier0: what the url
 # https://cmsweb.cern.ch/t0wmadatasvc/prod/express_config
 # would tell you.
-GlobalTag.globaltag = "92X_dataRun2_Express_v8"
+GlobalTag.globaltag = "100X_dataRun2_Express_v1"
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.
 #       This needs a valid proxy to access the cern.ch network from the .cms one.

--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
-GlobalTag.globaltag = "92X_dataRun2_HLT_v7"
+GlobalTag.globaltag = "100X_dataRun2_HLT_v1"

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -3,8 +3,9 @@ import FWCore.ParameterSet.Config as cms
 #-------------------------------------------------
 # Stage2 Emulator Modules (TODO: Move to L1Trigger.HardwareValidation.L1Stage2HardwareValidation_cff)
 
+# Calo configuration
+from L1Trigger.L1TCalorimeter.simDigis_cff import *
 # CaloLayer1
-from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis
 valCaloStage2Layer1Digis = simCaloStage2Layer1Digis.clone()
 valCaloStage2Layer1Digis.ecalToken = cms.InputTag("caloLayer1Digis")
 valCaloStage2Layer1Digis.hcalToken = cms.InputTag("caloLayer1Digis")
@@ -12,7 +13,6 @@ valCaloStage2Layer1Digis.unpackEcalMask = cms.bool(True)
 valCaloStage2Layer1Digis.unpackHcalMask = cms.bool(True)
 
 # CaloLayer2
-from L1Trigger.L1TCalorimeter.simCaloStage2Digis_cfi import simCaloStage2Digis
 valCaloStage2Layer2Digis = simCaloStage2Digis.clone()
 valCaloStage2Layer2Digis.towerToken = cms.InputTag("caloStage2Digis", "CaloTower")
 


### PR DESCRIPTION
This fixes an exception due to a missing L1TCaloParamsO2ORcd record in the L1T emulator DQM client.
The PR also contains #21907 .