### PR TITLE
Fix for L1T emulator DQM client crash - PRv2

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -6,6 +6,7 @@ import FWCore.ParameterSet.Config as cms
 # Calo configuration
 from L1Trigger.L1TCalorimeter.simDigis_cff import *
 # CaloLayer1
+from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis
 valCaloStage2Layer1Digis = simCaloStage2Layer1Digis.clone()
 valCaloStage2Layer1Digis.ecalToken = cms.InputTag("caloLayer1Digis")
 valCaloStage2Layer1Digis.hcalToken = cms.InputTag("caloLayer1Digis")
@@ -13,6 +14,7 @@ valCaloStage2Layer1Digis.unpackEcalMask = cms.bool(True)
 valCaloStage2Layer1Digis.unpackHcalMask = cms.bool(True)
 
 # CaloLayer2
+from L1Trigger.L1TCalorimeter.simCaloStage2Digis_cfi import simCaloStage2Digis
 valCaloStage2Layer2Digis = simCaloStage2Digis.clone()
 valCaloStage2Layer2Digis.towerToken = cms.InputTag("caloStage2Digis", "CaloTower")
 

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -3,8 +3,9 @@ import FWCore.ParameterSet.Config as cms
 #-------------------------------------------------
 # Stage2 Emulator Modules (TODO: Move to L1Trigger.HardwareValidation.L1Stage2HardwareValidation_cff)
 
+# Calo configuration
+from L1Trigger.L1TCalorimeter.simDigis_cff import *
 # CaloLayer1
-from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis
 valCaloStage2Layer1Digis = simCaloStage2Layer1Digis.clone()
 valCaloStage2Layer1Digis.ecalToken = cms.InputTag("caloLayer1Digis")
 valCaloStage2Layer1Digis.hcalToken = cms.InputTag("caloLayer1Digis")
@@ -12,7 +13,6 @@ valCaloStage2Layer1Digis.unpackEcalMask = cms.bool(True)
 valCaloStage2Layer1Digis.unpackHcalMask = cms.bool(True)
 
 # CaloLayer2
-from L1Trigger.L1TCalorimeter.simCaloStage2Digis_cfi import simCaloStage2Digis
 valCaloStage2Layer2Digis = simCaloStage2Digis.clone()
 valCaloStage2Layer2Digis.towerToken = cms.InputTag("caloStage2Digis", "CaloTower")
 


### PR DESCRIPTION
This fixes an exception due to a missing L1TCaloParamsO2ORcd record in the L1T emulator DQM client.