### PR TITLE
Backport updated python AI pkgs tests

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -17,11 +17,11 @@
 <test name="testNumba" command="testNumba.py"/>
 <test name="testTables" command="testTables.py"/>
 
-<test name="testDownhill" command="testDownhill.py"/>
+<test name="testDownhill" command="testDownhill.sh"/>
 <test name="testXGBoost_and_sklearn" command="testXGBoost_and_sklearn.py"/>
 #<test name="testTheanets" command="testTheanets.py"/>
 
-<test name="testhep_ml" command="testhep_ml.py"/>
+<test name="testhep_ml" command="testhep_ml.sh"/>
 <test name="testUncertainties" command="testUncertainties.py"/>
-<test name="testImports" command="imports.py"/>
-<test name="testTheano" command="testTheano.py"/>
+<test name="testImports" command="imports.sh"/>
+<test name="testTheano" command="testTheano.sh"/>

--- a/PhysicsTools/PythonAnalysis/test/imports.sh
+++ b/PhysicsTools/PythonAnalysis/test/imports.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -x
+set -e
+
+echo ">>> Create temporary directory for cache"
+TEST_TMPDIR=$(mktemp -d /tmp/cmssw_theano.XXXXXXX)
+
+echo ">>> Change default behaviour for Theano"
+export THEANO_FLAGS="device=cpu,force_device=True,base_compiledir=$TEST_TMPDIR"
+
+echo ">>> Theano configuration for testing:"
+python -c 'import theano; print(theano.config)'
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+python ${CMSSW_BASE}/src/PhysicsTools/PythonAnalysis/test/imports.py
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+rm -rf "$TEST_TMPDIR"

--- a/PhysicsTools/PythonAnalysis/test/testDownhill.sh
+++ b/PhysicsTools/PythonAnalysis/test/testDownhill.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -x
+set -e
+
+echo ">>> Create temporary directory for cache"
+TEST_TMPDIR=$(mktemp -d /tmp/cmssw_theano.XXXXXXX)
+
+echo ">>> Change default behaviour for Theano"
+export THEANO_FLAGS="device=cpu,force_device=True,base_compiledir=$TEST_TMPDIR"
+
+echo ">>> Theano configuration for testing:"
+python -c 'import theano; print(theano.config)'
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+python ${CMSSW_BASE}/src/PhysicsTools/PythonAnalysis/test/testDownhill.py
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+rm -rf "$TEST_TMPDIR"

--- a/PhysicsTools/PythonAnalysis/test/testTheano.py
+++ b/PhysicsTools/PythonAnalysis/test/testTheano.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 import keras
 import theano
+
 from keras.models import Sequential
-from keras.layers import MaxPooling2D, Conv2D
+from keras.layers import Dense
 
 print keras.__version__
 print theano.__version__
 
 model = Sequential()
-model.add(Conv2D(32, 10, 10,border_mode='valid',input_shape = (1,100,100)))
-model.add(MaxPooling2D(pool_size=(2, 2)))
+model.add(Dense(units=64, activation='relu', input_dim=100))
+model.add(Dense(units=10, activation='softmax'))

--- a/PhysicsTools/PythonAnalysis/test/testTheano.sh
+++ b/PhysicsTools/PythonAnalysis/test/testTheano.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -x
+set -e
+
+echo ">>> Create temporary directory for cache"
+TEST_TMPDIR=$(mktemp -d /tmp/cmssw_theano.XXXXXXX)
+
+echo ">>> Change default behaviour for Theano"
+export THEANO_FLAGS="device=cpu,force_device=True,base_compiledir=$TEST_TMPDIR"
+
+echo ">>> Theano configuration for testing:"
+python -c 'import theano; print(theano.config)'
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+python ${CMSSW_BASE}/src/PhysicsTools/PythonAnalysis/test/testTheano.py
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+rm -rf "$TEST_TMPDIR"

--- a/PhysicsTools/PythonAnalysis/test/testhep_ml.sh
+++ b/PhysicsTools/PythonAnalysis/test/testhep_ml.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -x
+set -e
+
+echo ">>> Create temporary directory for cache"
+TEST_TMPDIR=$(mktemp -d /tmp/cmssw_theano.XXXXXXX)
+
+echo ">>> Change default behaviour for Theano"
+export THEANO_FLAGS="device=cpu,force_device=True,base_compiledir=$TEST_TMPDIR"
+
+echo ">>> Theano configuration for testing:"
+python -c 'import theano; print(theano.config)'
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+python ${CMSSW_BASE}/src/PhysicsTools/PythonAnalysis/test/testhep_ml.py
+
+echo ">>> Cleaning compile cache"
+theano-cache clear
+
+rm -rf "$TEST_TMPDIR"


### PR DESCRIPTION
Backport tests changes that fixes 
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc630/CMSSW_9_4_X_2018-01-21-0000/unitTestLogs/PhysicsTools/PythonAnalysis
and eventually backport it to 9_3_X