### PR TITLE
standardize implementation and offsets for special tracking workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -15,77 +15,21 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 
 #WFs to run in IB:
 #   2017 (ele guns 10, 35, 1000; pho guns 10, 35; mu guns 1, 10, 100, 1000, QCD 3TeV, QCD Flat)
-#   2017 (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
+#        (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
+#        (TTbar trackingOnly, trackingRun2, trackingOnlyRun2, trackingLowPU, pixelTrackingOnly)
 #   2018 (ele guns 10, 35, 1000; pho guns 10, 35; mu guns 1, 10, 100, 1000, QCD 3TeV, QCD Flat)
 #   2018 (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
+#        (TTbar trackingOnly, pixelTrackingOnly)
 #         he collapse: TTbar, TTbar PU, TTbar design
 #   2019 (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
 numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009.0,10059.0,10071.0,
            10042.0,10024.0,10025.0,10026.0,10023.0,10224.0,10225.0,10424.0,
+           10024.1,10024.2,10024.3,10024.4,10024.5,
            10801.0,10802.0,10803.0,10804.0,10805.0,10806.0,10807.0,10808.0,10809.0,10859.0,10871.0,
            10842.0,10824.0,10825.0,10826.0,10823.0,11024.0,11025.0,11224.0,
+           10824.1,10824.5,
            10824.6,11024.6,11224.6,
            11642.0,11624.0,11625.0,11626.0,11623.0,11824.0,11825.0,12024.0]
 for numWF in numWFIB:
     if not numWF in _upgrade_workflows: continue
     workflows[numWF] = _upgrade_workflows[numWF]
-
-# Tracking-specific special workflows
-def _trackingOnly(stepList):
-    res = []
-    for step in stepList:
-        s = step
-        if 'RecoFull' in step or 'HARVESTFull' in step:
-            s = s.replace('Full', 'Full_trackingOnly')
-        if 'ALCA' in s:
-            continue
-        res.append(s)
-    return res
-def _pixelTrackingOnly(stepList):
-    res = []
-    for step in stepList:
-        s = step
-        if 'RecoFull' in step or 'HARVESTFull' in step:
-            s = s.replace('Full', 'Full_pixelTrackingOnly')
-        if 'ALCA' in s:
-            continue
-        res.append(s)
-    return res
-def _trackingRun2(stepList):
-    res = []
-    for step in stepList:
-        s = step
-        if 'RecoFull' in step:
-            if 'trackingOnly' in step:
-                s = s.replace('Only', 'OnlyRun2')
-            else:
-                s = s.replace('Full', 'Full_trackingRun2')
-        if 'ALCA' in s:
-            continue
-        res.append(s)
-    return res
-def _trackingLowPU(stepList):
-    res = []
-    for step in stepList:
-        s = step
-        if 'RecoFull' in step:
-            if 'trackingOnly' in step:
-                s = s.replace('Only', 'OnlyLowPU')
-            else:
-                s = s.replace('Full', 'Full_trackingLowPU')
-        if 'ALCA' in s:
-            continue
-        res.append(s)
-    return res
-
-# compose and adding tracking specific workflows in the IB test. 
-# NB. those workflows are expected to be only used forIB test.
-#  if you really want to run them locally, do runTheMatrix.py --what 2017  -l workflow numbers
-workflows[10024.1] = [ workflows[10024.0][0], _trackingOnly(workflows[10024.0][1]) ]
-workflows[10024.2] = [ workflows[10024.0][0], _trackingRun2(workflows[10024.0][1]) ]
-workflows[10024.3] = [ workflows[10024.1][0], _trackingRun2(workflows[10024.1][1]) ]
-workflows[10024.4] = [ workflows[10024.0][0], _trackingLowPU(workflows[10024.0][1]) ]
-workflows[10024.5] = [ workflows[10024.0][0], _pixelTrackingOnly(workflows[10024.0][1]) ]
-# for 2018 as well, use the same numbering
-workflows[10824.1] = [ workflows[10824.0][0], _trackingOnly(workflows[10024.0][1]) ]
-workflows[10824.5] = [ workflows[10824.0][0], _pixelTrackingOnly(workflows[10024.0][1]) ]

--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -13,9 +13,9 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #just define all of them
 
 #2023 WFs to run in IB (TTbar, TTbar+Timing)
-numWFIB = [20034.0,20034.1,20034.2] #2023D17 w/ special tracking and timing workflows
+numWFIB = [20034.0,20034.1,20034.11] #2023D17 w/ special tracking and timing workflows
 numWFIB.extend([20434.0]) #2023D19 (already has timing)
-numWFIB.extend([20834.0,20834.2]) #2023D20
-numWFIB.extend([21234.0,21234.2]) #2023D21  
+numWFIB.extend([20834.0,20834.11]) #2023D20
+numWFIB.extend([21234.0,21234.11]) #2023D21  
 for numWF in numWFIB:
     workflows[numWF] = _upgrade_workflows[numWF]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2365,6 +2365,22 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
         if 'Reco' in step: upgradeStepDict[stepName][k] = merge([step3_pixelTrackingOnly, upgradeStepDict[step][k]])
         elif 'HARVEST' in step: upgradeStepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation'}, upgradeStepDict[step][k]])
 
+    for step in upgradeSteps['trackingRun2']['steps']:
+        stepName = step + upgradeSteps['trackingRun2']['suffix']
+        if 'Reco' in step and upgradeStepDict[step][k]['--era']=='Run2_2017':
+            upgradeStepDict[stepName][k] = merge([{'--era': 'Run2_2017_trackingRun2'}, upgradeStepDict[step][k]])
+
+    for step in upgradeSteps['trackingOnlyRun2']['steps']:
+        stepName = step + upgradeSteps['trackingOnlyRun2']['suffix']
+        if 'Reco' in step and upgradeStepDict[step][k]['--era']=='Run2_2017':
+            upgradeStepDict[stepName][k] = merge([{'--era': 'Run2_2017_trackingRun2'}, step3_trackingOnly, upgradeStepDict[step][k]])
+        elif 'HARVEST' in step: upgradeStepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, upgradeStepDict[step][k]])
+
+    for step in upgradeSteps['trackingLowPU']['steps']:
+        stepName = step + upgradeSteps['trackingLowPU']['suffix']
+        if 'Reco' in step and upgradeStepDict[step][k]['--era']=='Run2_2017':
+            upgradeStepDict[stepName][k] = merge([{'--era': 'Run2_2017_trackingLowPU'}, upgradeStepDict[step][k]])
+
     for step in upgradeSteps['Timing']['steps']:
         stepName = step + upgradeSteps['Timing']['suffix']
         upgradeStepDict[stepName][k] = deepcopy(upgradeStepDict[step][k])
@@ -2416,8 +2432,3 @@ for step in upgradeStepDict.keys():
             k=step+'_'+key
             if step in upgradeStepDict and key in upgradeStepDict[step]:
                 steps[k]=merge([upgradeStepDict[step][key]])
-
-# 2017 tracking specific eras
-steps['RecoFull_trackingRun2_2017'] = merge([{'--era': 'Run2_2017_trackingRun2'}, steps['RecoFull_2017']])
-steps['RecoFull_trackingOnlyRun2_2017'] = merge([{'--era': 'Run2_2017_trackingRun2'}, steps['RecoFull_trackingOnly_2017']])
-steps['RecoFull_trackingLowPU_2017'] = merge([{'--era': 'Run2_2017_trackingLowPU'}, steps['RecoFull_2017']])

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -56,7 +56,16 @@ for year in upgradeKeys:
 
             # special workflows for tracker
             if (upgradeDatasetFromFragment[frag]=="TTbar_13" or upgradeDatasetFromFragment[frag]=="TTbar_14TeV") and not 'PU' in key and hasHarvest:
+                # skip ALCA
+                trackingVariations = ['trackingOnly','trackingRun2','trackingOnlyRun2','trackingLowPU','pixelTrackingOnly']
+                for tv in trackingVariations:
+                    stepList[tv] = filter(lambda s : "ALCA" not in s, stepList[tv])
                 workflows[numWF+upgradeSteps['trackingOnly']['offset']] = [ upgradeDatasetFromFragment[frag], stepList['trackingOnly']]
+                if '2017' in key:
+                    for tv in trackingVariations[1:]:
+                        workflows[numWF+upgradeSteps[tv]['offset']] = [ upgradeDatasetFromFragment[frag], stepList[tv]]
+                elif '2018' in key:
+                    workflows[numWF+upgradeSteps['pixelTrackingOnly']['offset']] = [ upgradeDatasetFromFragment[frag], stepList['pixelTrackingOnly']]
 
             # special workflows for HE
             if upgradeDatasetFromFragment[frag]=="TTbar_13" and '2018' in key:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -94,6 +94,31 @@ upgradeSteps['trackingOnly'] = {
     'suffix' : '_trackingOnly',
     'offset' : 0.1,
 }
+upgradeSteps['trackingRun2'] = {
+    'steps' : [
+        'RecoFull',
+    ],
+    'PU' : [],
+    'suffix' : '_trackingRun2',
+    'offset' : 0.2,
+}
+upgradeSteps['trackingOnlyRun2'] = {
+    'steps' : [
+        'RecoFull',
+        'HARVESTFull',
+    ],
+    'PU' : [],
+    'suffix' : '_trackingOnlyRun2',
+    'offset' : 0.3,
+}
+upgradeSteps['trackingLowPU'] = {
+    'steps' : [
+        'RecoFull',
+    ],
+    'PU' : [],
+    'suffix' : '_trackingLowPU',
+    'offset' : 0.4,
+}
 upgradeSteps['pixelTrackingOnly'] = {
     'steps' : [
         'RecoFull',
@@ -103,13 +128,13 @@ upgradeSteps['pixelTrackingOnly'] = {
     ],
     'PU' : [],
     'suffix' : '_pixelTrackingOnly',
-    'offset' : 0.4,
+    'offset' : 0.5,
 }
 upgradeSteps['Timing'] = {
     'steps' : upgradeSteps['baseline']['steps'],
     'PU' : upgradeSteps['baseline']['PU'],
     'suffix' : '_Timing',
-    'offset' : 0.2,
+    'offset' : 0.11,
 }
 upgradeSteps['Neutron'] = {
     'steps' : [
@@ -124,7 +149,7 @@ upgradeSteps['Neutron'] = {
         'DigiFullTrigger',
     ],
     'suffix' : '_Neutron',
-    'offset' : 0.3,
+    'offset' : 0.12,
 }
 upgradeSteps['heCollapse'] = {
     'steps' : [


### PR DESCRIPTION
In #18503 I tried to standardize the implementation of "special" workflows, but only propagated this to Phase2, ignoring Phase1.

This led to some offset numbers being used inconsistently between Phase1 and Phase2, as well as novel code in relval_2017 (which I would prefer to keep as a strict forwarding file to pass workflow numbers between the upgrade matrix and regular matrix).

I've moved all the special tracking workflows from relval_2017 into the new approach (all definitions/conditions in `upgradeWorkflowComponents`, `relval_steps`, and `relval_upgrade`). I checked the `cmsDriver` commands before and after the change using `runTheMatrix.py --dryRun` to make sure nothing was unintentionally altered.

In the process, I fixed a bug that the 2018 tracking workflows were actually using 2017 steps. I also changed the offset numbers for the Phase 2 timing and neutron workflows to be separate from the tracking workflows.