### PR TITLE
Bugfix duplicate ALCT/CLCT in Run-2 configuration

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -541,10 +541,10 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::getLCTs() {
   return tmpV;
 }
 
-void CSCMotherboard::correlateLCTs(CSCALCTDigi& bestALCT,
-                                   CSCALCTDigi& secondALCT,
-                                   CSCCLCTDigi& bestCLCT,
-                                   CSCCLCTDigi& secondCLCT) {
+void CSCMotherboard::correlateLCTs(CSCALCTDigi bestALCT,
+                                   CSCALCTDigi secondALCT,
+                                   CSCCLCTDigi bestCLCT,
+                                   CSCCLCTDigi secondCLCT) {
 
   bool anodeBestValid     = bestALCT.isValid();
   bool anodeSecondValid   = secondALCT.isValid();

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -142,8 +142,8 @@ class CSCMotherboard
   /** Make sure that the parameter values are within the allowed range. */
   void checkConfigParameters();
 
-  void correlateLCTs(CSCALCTDigi& bestALCT, CSCALCTDigi& secondALCT,
-                     CSCCLCTDigi& bestCLCT, CSCCLCTDigi& secondCLCT);
+  void correlateLCTs(CSCALCTDigi bestALCT, CSCALCTDigi secondALCT,
+                     CSCCLCTDigi bestCLCT, CSCCLCTDigi secondCLCT);
   CSCCorrelatedLCTDigi constructLCTs(const CSCALCTDigi& aLCT,
                                      const CSCCLCTDigi& cLCT,
                                      int type) const;


### PR DESCRIPTION
PR #21650 introduced a bug in the CSCMotherboard. By using references in the argument list, ALCTs and CLCTs that were invalid became copies of valid ones. This duplicated the ALCTs and CLCTs in the event. The bug is fixed by reverting to sending copies of objects. This is not ideal (should send const reference). I will look at some options to modernize the code.

@tahuang1991 