### PR TITLE
Extend GEM and ME0 DB dead/masked strip interface

### DIFF
--- a/CondCore/GEMPlugins/BuildFile.xml
+++ b/CondCore/GEMPlugins/BuildFile.xml
@@ -1,0 +1,9 @@
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/PluginManager"/>
+<use   name="CondCore/ESSources"/>
+<use   name="CondFormats/GEMObjects"/>
+<use   name="CondFormats/DataRecord"/>
+<use   name="root"/>
+<use   name="rootgraphics"/>
+<flags   EDM_PLUGIN="1"/>
+<flags CXXFLAGS="-ftemplate-depth=600"/>

--- a/CondCore/GEMPlugins/src/plugin.cc
+++ b/CondCore/GEMPlugins/src/plugin.cc
@@ -1,0 +1,28 @@
+/*
+ *  plugin.cc
+ *  CMSSW
+ *
+ *  Created by Sven Dildick --TAMU
+ *
+ */
+
+#include "CondCore/PluginSystem/interface/registration_macros.h"
+#include "CondFormats/GEMObjects/interface/GEMEMap.h"
+#include "CondFormats/DataRecord/interface/GEMEMapRcd.h"
+#include "CondFormats/GEMObjects/interface/GEMMaskedStrips.h"
+#include "CondFormats/DataRecord/interface/GEMMaskedStripsRcd.h"
+#include "CondFormats/GEMObjects/interface/GEMDeadStrips.h"
+#include "CondFormats/DataRecord/interface/GEMDeadStripsRcd.h"
+REGISTER_PLUGIN(GEMEMapRcd,GEMEMap);
+REGISTER_PLUGIN(GEMMaskedStripsRcd, GEMMaskedStrips);
+REGISTER_PLUGIN(GEMDeadStripsRcd, GEMDeadStrips);
+
+#include "CondFormats/GEMObjects/interface/ME0EMap.h"
+#include "CondFormats/DataRecord/interface/ME0EMapRcd.h"
+#include "CondFormats/GEMObjects/interface/ME0MaskedStrips.h"
+#include "CondFormats/DataRecord/interface/ME0MaskedStripsRcd.h"
+#include "CondFormats/GEMObjects/interface/ME0DeadStrips.h"
+#include "CondFormats/DataRecord/interface/ME0DeadStripsRcd.h"
+REGISTER_PLUGIN(ME0EMapRcd,ME0EMap);
+REGISTER_PLUGIN(ME0MaskedStripsRcd, ME0MaskedStrips);
+REGISTER_PLUGIN(ME0DeadStripsRcd, ME0DeadStrips);

--- a/CondFormats/DataRecord/interface/ME0DeadStripsRcd.h
+++ b/CondFormats/DataRecord/interface/ME0DeadStripsRcd.h
@@ -1,0 +1,8 @@
+#ifndef CondFormats_DataRecord_ME0DeadStripsRcd_h
+#define CondFormats_DataRecord_ME0DeadStripsRcd_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class ME0DeadStripsRcd : public edm::eventsetup::EventSetupRecordImplementation<ME0DeadStripsRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/interface/ME0MaskedStripsRcd.h
+++ b/CondFormats/DataRecord/interface/ME0MaskedStripsRcd.h
@@ -1,0 +1,8 @@
+#ifndef CondFormats_DataRecord_ME0MaskedStripsRcd_h
+#define CondFormats_DataRecord_ME0MaskedStripsRcd_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class ME0MaskedStripsRcd : public edm::eventsetup::EventSetupRecordImplementation<ME0MaskedStripsRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/GEMMaskedStripsRcd.cc
+++ b/CondFormats/DataRecord/src/GEMMaskedStripsRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/GEMMaskedStripsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(GEMMaskedStripsRcd);

--- a/CondFormats/DataRecord/src/ME0DeadStripsRcd.cc
+++ b/CondFormats/DataRecord/src/ME0DeadStripsRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/ME0DeadStripsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(ME0DeadStripsRcd);

--- a/CondFormats/DataRecord/src/ME0MaskedStripsRcd.cc
+++ b/CondFormats/DataRecord/src/ME0MaskedStripsRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/ME0MaskedStripsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(ME0MaskedStripsRcd);

--- a/CondFormats/GEMObjects/interface/ME0DeadStrips.h
+++ b/CondFormats/GEMObjects/interface/ME0DeadStrips.h
@@ -1,0 +1,27 @@
+#ifndef CondFormats_ME0Objects_ME0DeadStrips_h
+#define CondFormats_ME0Objects_ME0DeadStrips_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include <vector>
+
+class ME0DeadStrips
+{
+ public:
+  struct DeadItem {
+    int rawId;
+    int strip;
+    COND_SERIALIZABLE;
+  };
+
+  ME0DeadStrips(){}
+  ~ME0DeadStrips(){}
+
+  std::vector<DeadItem> const & getDeadVec() const {return deadVec_;}
+
+ private:
+  std::vector<DeadItem> deadVec_;
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/GEMObjects/interface/ME0MaskedStrips.h
+++ b/CondFormats/GEMObjects/interface/ME0MaskedStrips.h
@@ -1,0 +1,27 @@
+#ifndef CondFormats_GEMObjects_ME0MaskedStrips_h
+#define CondFormats_GEMObjects_ME0MaskedStrips_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include <vector>
+
+class ME0MaskedStrips
+{
+ public:
+  struct MaskItem {
+    int rawId;
+    int strip;
+    COND_SERIALIZABLE;
+  };
+
+  ME0MaskedStrips(){}
+  ~ME0MaskedStrips(){}
+
+  std::vector<MaskItem> const & getMaskVec() const {return maskVec_;}
+
+ private:
+  std::vector<MaskItem> maskVec_;
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/GEMObjects/src/ME0DeadStrips.cc
+++ b/CondFormats/GEMObjects/src/ME0DeadStrips.cc
@@ -1,0 +1,2 @@
+#include "CondFormats/GEMObjects/interface/ME0DeadStrips.h"
+#include "FWCore/Utilities/interface/Exception.h"

--- a/CondFormats/GEMObjects/src/ME0MaskedStrips.cc
+++ b/CondFormats/GEMObjects/src/ME0MaskedStrips.cc
@@ -1,0 +1,2 @@
+#include "CondFormats/GEMObjects/interface/ME0MaskedStrips.h"
+#include "FWCore/Utilities/interface/Exception.h"

--- a/CondFormats/GEMObjects/src/T_EventSetup_GEMDeadStrips.cc
+++ b/CondFormats/GEMObjects/src/T_EventSetup_GEMDeadStrips.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/GEMObjects/interface/GEMDeadStrips.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(GEMDeadStrips);

--- a/CondFormats/GEMObjects/src/T_EventSetup_GEMMaskedStrips.cc
+++ b/CondFormats/GEMObjects/src/T_EventSetup_GEMMaskedStrips.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/GEMObjects/interface/GEMMaskedStrips.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(GEMMaskedStrips);

--- a/CondFormats/GEMObjects/src/T_EventSetup_ME0DeadStrips.cc
+++ b/CondFormats/GEMObjects/src/T_EventSetup_ME0DeadStrips.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/GEMObjects/interface/ME0DeadStrips.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(ME0DeadStrips);

--- a/CondFormats/GEMObjects/src/T_EventSetup_ME0MaskedStrips.cc
+++ b/CondFormats/GEMObjects/src/T_EventSetup_ME0MaskedStrips.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/GEMObjects/interface/ME0MaskedStrips.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(ME0MaskedStrips);

--- a/CondFormats/GEMObjects/src/classes_def.xml
+++ b/CondFormats/GEMObjects/src/classes_def.xml
@@ -10,5 +10,14 @@
   <class name="GEMEMap::GEMVFatMapInPos"/>
   <class name="std::vector<GEMEMap::GEMVFatMapInPos>"/>
 
+  <class name="GEMDeadStrips"/>
+  <class name="GEMDeadStrips::DeadItem"/>
+  <class name="GEMMaskedStrips"/>
+  <class name="GEMMaskedStrips::MaskItem"/>
+
+  <class name="ME0DeadStrips"/>
+  <class name="ME0DeadStrips::DeadItem"/>
+  <class name="ME0MaskedStrips"/>
+  <class name="ME0MaskedStrips::MaskItem"/>
 
 </lcgdict>

--- a/CondFormats/GEMObjects/src/headers.h
+++ b/CondFormats/GEMObjects/src/headers.h
@@ -1,2 +1,8 @@
 #include "CondFormats/GEMObjects/interface/GEMEMap.h"
 #include "CondFormats/GEMObjects/interface/ME0EMap.h"
+
+#include "CondFormats/GEMObjects/interface/GEMDeadStrips.h"
+#include "CondFormats/GEMObjects/interface/GEMMaskedStrips.h"
+
+#include "CondFormats/GEMObjects/interface/ME0DeadStrips.h"
+#include "CondFormats/GEMObjects/interface/ME0MaskedStrips.h"


### PR DESCRIPTION
The additions allow to mask certain GEM/ME0 strips in the local RECO step. This will be needed when unpacked GEM/ME0 data will be reconstructed.

@jshlee @archiesharma @mmaggi 