### PR TITLE
treat non-pos-def covariance as if it contains a NaN

### DIFF
--- a/TrackingTools/TrackFitters/plugins/KFFittingSmoother.h
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmoother.h
@@ -166,6 +166,7 @@ bool KFFittingSmoother::checkForNans(const Trajectory & theTraj)
     if (edm::isNotFinite(tm.estimate())) return false;
     auto const & v = tm.updatedState ().localParameters ().vector();
     for (int i=0;i<5;++i) if (edm::isNotFinite(v[i])) return false;
+    if (!tm.updatedState ().curvilinearError ().posDef()) return false;//not a NaN by itself, but will lead to one
     auto const & m = tm.updatedState ().curvilinearError ().matrix();
     for (int i=0;i<5;++i)
       for (int j=0;j<(i+1);++j) if (edm::isNotFinite(m(i,j))) return false;
@@ -224,7 +225,7 @@ if (smoothed.isValid()) {
 
     bool hasNaN = false;
     if ( !smoothed.isValid() || (hasNaN = !checkForNans(smoothed)) || ( smoothed.foundHits() < theMinNumberOfHits ) )  {
-      if(hasNaN) edm::LogWarning("TrackNaN")<<"Track has NaN";
+      if(hasNaN) edm::LogWarning("TrackNaN")<<"Track has NaN or the cov is not pos-definite";
       if ( smoothed.foundHits() < theMinNumberOfHits ) LogTrace("TrackFitters") << "smoothed.foundHits()<theMinNumberOfHits";
       DPRINT("TrackFitters") << "smoothed invalid => trajectory rejected with nhits/chi2 " << smoothed.foundHits() << '/' <<  smoothed.chiSquared() << "\n";
       if (rejectTracksFlag) {

--- a/TrackingTools/TrackFitters/src/KFTrajectoryFitter.cc
+++ b/TrackingTools/TrackFitters/src/KFTrajectoryFitter.cc
@@ -129,7 +129,9 @@ Trajectory KFTrajectoryFitter::fitOne(const TrajectorySeed& aSeed,
               (std::abs(currTsos.localParameters().qbp())>100
                || std::abs(currTsos.localParameters().position().y()) > 1000
                || std::abs(currTsos.localParameters().position().x()) > 1000
-               ) ) || edm::isNotFinite(currTsos.localParameters().qbp());
+               ) ) 
+            || edm::isNotFinite(currTsos.localParameters().qbp()) 
+            || !currTsos.localError().posDef();
 	  if unlikely(badState){
 	    if (!currTsos.isValid()) {
 	      edm::LogError("FailedUpdate") <<"updating with the hit failed. Not updating the trajectory with the hit";
@@ -137,6 +139,10 @@ Trajectory KFTrajectoryFitter::fitOne(const TrajectorySeed& aSeed,
             } 
 	    else if (edm::isNotFinite(currTsos.localParameters().qbp())) {
               edm::LogError("TrajectoryNaN")<<"Trajectory has NaN";
+
+            }
+	    else if (!currTsos.localError().posDef()) {
+              edm::LogError("TrajectoryNotPosDef")<<"Trajectory covariance is not positive-definite";
 
             }
 	    else{ 


### PR DESCRIPTION
posDef check is added to checks for NaNs already present in KFFittingSmoother and KFTrajectoryFitter.
The "posDef" check is partial, but it will already capture existing cases with negative values in the track covariances diagonal elements, which have to be non-negative.

this supersedes #21816 and should also resolve the problem reported in #21780.

Tested in : 
- 4x(200 event) workflows (136.782,136.783,136.784,136.787) in 2017B data showing 
    - HLT: single track dropout (out of 250) in GSF plots in one out of 4 tested wfs (136.783)
    - RECO: no difference in saved results except for log warnings. There are fewer log warnings now: typically multiple warning about non-pos-def covariance is replaced with one about the NaN or a failing pos-def check.
        - reco DQM shows single track increase in jetCore candidates in one (136.783) of the 4 tested workflows and one pixelPairStepTrackCandidates drop out (of about 25K) in another wf (136.787)
- electron/muon/photon guns with 1K events each (10002.0,10003.0,10004.0,10005.0,10007.0,10009.0) show differences (reduction) in conversions/allConversions at 0.1% level or less.
- 3 TeV dijet 400 events (10059) has no differences in DQM plots or fwlite, but there were some single track-candidate changes in a few events based on step2 log warnings.
