### PR TITLE
Fix ambiguity problems for Type and FunctionType

### DIFF
--- a/Utilities/StaticAnalyzers/src/ClassDumper.cpp
+++ b/Utilities/StaticAnalyzers/src/ClassDumper.cpp
@@ -86,7 +86,7 @@ void ClassDumper::checkASTDecl(const clang::CXXRecordDecl *RD,clang::ento::Analy
                                    for (unsigned J = 0, F = SD->getTemplateArgs().size(); J!=F; ++J) {
                                         if (SD->getTemplateArgs().get(J).getKind() == clang::TemplateArgument::Type) {
                                              std::string taname;
-                                             const Type * tt = SD->getTemplateArgs().get(J).getAsType().getTypePtr();
+                                             const clang::Type * tt = SD->getTemplateArgs().get(J).getAsType().getTypePtr();
                                              if ( tt->isRecordType() ) {
                                                   const clang::CXXRecordDecl * TAD = tt->getAsCXXRecordDecl();
                                                   if (TAD) taname = TAD->getQualifiedNameAsString();

--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -85,7 +85,7 @@ std::string clangcms::support::getQualifiedName(const clang::NamedDecl &d) {
     // and
     // void ANamespace::AFunction(float);
     ret += "(";
-    const FunctionType *ft = fd->getType()->castAs<FunctionType>();
+    const clang::FunctionType *ft = fd->getType()->castAs<clang::FunctionType>();
     if (const FunctionProtoType *fpt = dyn_cast_or_null<FunctionProtoType>(ft))
     {
       unsigned num_params = fd->getNumParams();


### PR DESCRIPTION
After updating to Clang 6.0.0 RC1 we end with ambiguity for Type and
FunctionType. Both are defined in llvm:: and clang:: namespaces.

Patch adds clang:: namespace to avoid ambiguity.

Build tested on:

CMSSW_10_0_DEVEL_X_2018-01-23-2300
slc6_amd64_gcc630
clang version 6.0.0

CMSSW_10_0_X_2018-01-23-2300
slc6_amd64_gcc630
clang version 5.0.0

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>