### PR TITLE
use explicit clang:: namespace to fix llvm 6.0.0 error

### DIFF
--- a/Utilities/StaticAnalyzers/src/ClassDumper.cpp
+++ b/Utilities/StaticAnalyzers/src/ClassDumper.cpp
@@ -86,7 +86,7 @@ void ClassDumper::checkASTDecl(const clang::CXXRecordDecl *RD,clang::ento::Analy
                                    for (unsigned J = 0, F = SD->getTemplateArgs().size(); J!=F; ++J) {
                                         if (SD->getTemplateArgs().get(J).getKind() == clang::TemplateArgument::Type) {
                                              std::string taname;
-                                             const Type * tt = SD->getTemplateArgs().get(J).getAsType().getTypePtr();
+                                             const clang::Type * tt = SD->getTemplateArgs().get(J).getAsType().getTypePtr();
                                              if ( tt->isRecordType() ) {
                                                   const clang::CXXRecordDecl * TAD = tt->getAsCXXRecordDecl();
                                                   if (TAD) taname = TAD->getQualifiedNameAsString();

--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -85,7 +85,7 @@ std::string clangcms::support::getQualifiedName(const clang::NamedDecl &d) {
     // and
     // void ANamespace::AFunction(float);
     ret += "(";
-    const FunctionType *ft = fd->getType()->castAs<FunctionType>();
+    const clang::FunctionType *ft = fd->getType()->castAs<clang::FunctionType>();
     if (const FunctionProtoType *fpt = dyn_cast_or_null<FunctionProtoType>(ft))
     {
       unsigned num_params = fd->getNumParams();


### PR DESCRIPTION
This should fix build errors in DEVEL IBs
```
  Utilities/StaticAnalyzers/src/ClassDumper.cpp:89:52: error: reference to 'Type' is ambiguous
       const Type * tt = SD->getTemplateArgs().get(J).getAsType().getTypePtr();
```