### PR TITLE
integration test test for EcalDAQ ( OCCI ) and RunInfo (coral)

### DIFF
--- a/CondCore/Utilities/python/popcon2dropbox.py
+++ b/CondCore/Utilities/python/popcon2dropbox.py
@@ -131,8 +131,11 @@ def copy( args ):
     if destDb.lower() in destMap.keys():
         destDb = destMap[destDb.lower()]
     else:
-        logger.error( 'Destination connection %s is not supported.' %destDb )
-        return 
+        if destDb.startswith('sqlite'):
+            destDb = destDb.split(':')[1]
+        else:
+            logger.error( 'Destination connection %s is not supported.' %destDb )
+            return 
     # run the copy
     note = '"Importing data with O2O execution"'
     commandOptions = '--force --yes --db %s copy %s %s --destdb %s --synchronize --note %s' %(dbFileName,destTag,destTag,destDb,note)

--- a/CondTools/Ecal/test/BuildFile.xml
+++ b/CondTools/Ecal/test/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="CondTools/Ecal"/>
+
+<architecture name="slc.*_amd64_.*">
+  <test name="EcalDAQ_O2O_test" command="EcalDAQ_O2O_test.sh"/>
+</architecture>

--- a/CondTools/Ecal/test/EcalDAQ_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalDAQ_O2O_test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+conddb --yes copy EcalDAQTowerStatus_online --destdb EcalDAQTowerStatus_online_O2OTEST.db --o2oTest
+popconRun ./src/CondTools/Ecal/python/EcalDAQ_popcon.py -d sqlite_file:EcalDAQTowerStatus_online_O2OTEST.db -t EcalDAQTowerStatus_online -c
+conddb --db EcalDAQTowerStatus_online_O2OTEST.db list EcalDAQTowerStatus_online

--- a/CondTools/RunInfo/test/BuildFile.xml
+++ b/CondTools/RunInfo/test/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="CondTools/RunInfo"/>
+
+<architecture name="slc.*_amd64_.*">
+  <test name="RunInfoStart_O2O_test" command="RunInfoStart_O2O_test.sh"/>
+</architecture>

--- a/CondTools/RunInfo/test/RunInfoStart_O2O_test.sh
+++ b/CondTools/RunInfo/test/RunInfoStart_O2O_test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+conddb --yes copy runinfo_start_31X_hlt --destdb runinfo_O2O_test.db --o2oTest
+lastRun=`conddb listRuns | tail -2 | awk '{print $1}'`
+echo "last run = $lastRun"
+cmsRun ./src/CondTools/RunInfo/python/RunInfoPopConAnalyzer.py runNumber=$lastRun destinationConnection=sqlite_file:runinfo_O2O_test.db tag=runinfo_start_31X_hlt
+conddb --db runinfo_O2O_test.db list runinfo_start_31X_hlt


### PR DESCRIPTION
In this PR:
- fix for the poconRun command, allowing to execute with sqlite destination db
- implementation of EcalDAQ o2o test on sqlite
- implementation of RunInfo start o2o test on sqlite