### PR TITLE
Adding an accessor for groomed jet mass in 10.0.x

### DIFF
--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -47,6 +47,8 @@
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/Common/interface/AtomicPtrCache.h"
 
+#include <numeric>
+
 
 // Define typedefs for convenience
 namespace pat {
@@ -498,13 +500,13 @@ namespace pat {
 
 
       /// String access to subjet list
-      pat::JetPtrCollection const & subjets( std::string label ) const ;
+      pat::JetPtrCollection const & subjets( std::string const & label ) const ;
 
       /// Add new set of subjets
-      void addSubjets( pat::JetPtrCollection const & pieces, std::string label = ""  );
+      void addSubjets( pat::JetPtrCollection const & pieces, std::string const & label = ""  );
 
       /// Check to see if the subjet collection exists
-      bool hasSubjets( std::string label ) const { return find( subjetLabels_.begin(), subjetLabels_.end(), label) != subjetLabels_.end(); }
+      bool hasSubjets( std::string const & label ) const { return find( subjetLabels_.begin(), subjetLabels_.end(), label) != subjetLabels_.end(); }
       
       /// Number of subjet collections
       unsigned int nSubjetCollections(  ) const { return  subjetCollections_.size(); }
@@ -512,7 +514,19 @@ namespace pat {
       /// Subjet collection names
       std::vector<std::string> const & subjetCollectionNames() const { return subjetLabels_; }
 
-
+      /// Access to mass of subjets
+      double groomedMass(unsigned int index = 0) const{
+	return nSubjetCollections() > 0 && !subjets(index).empty() ?
+	  std::accumulate( subjets(index).begin(), subjets(index).end(),
+			   reco::Candidate::LorentzVector(), [] (reco::Candidate::LorentzVector a, reco::CandidatePtr const & b){return a + b->p4();}).mass() :
+	  -1.0;
+      }
+      double groomedMass(std::string const & label) const{
+	return hasSubjets(label) && !subjets(label).empty() ?
+	  std::accumulate( subjets(label).begin(), subjets(label).end(),
+			   reco::Candidate::LorentzVector(), [] (reco::Candidate::LorentzVector a, reco::CandidatePtr const & b){return a + b->p4();}).mass() :
+	  -1.0;
+      }
 
     protected:
 

--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -516,15 +516,19 @@ namespace pat {
 
       /// Access to mass of subjets
       double groomedMass(unsigned int index = 0) const{
-	return nSubjetCollections() > 0 && !subjets(index).empty() ?
-	  std::accumulate( subjets(index).begin(), subjets(index).end(),
-			   reco::Candidate::LorentzVector(), [] (reco::Candidate::LorentzVector a, reco::CandidatePtr const & b){return a + b->p4();}).mass() :
+	auto const& sub = subjets(index);
+	return nSubjetCollections() > index && !sub.empty() ?
+	  std::accumulate( sub.begin(), sub.end(),
+			   reco::Candidate::LorentzVector(),
+			   [] (reco::Candidate::LorentzVector const & a, reco::CandidatePtr const & b){return a + b->p4();}).mass() :
 	  -1.0;
       }
       double groomedMass(std::string const & label) const{
-	return hasSubjets(label) && !subjets(label).empty() ?
-	  std::accumulate( subjets(label).begin(), subjets(label).end(),
-			   reco::Candidate::LorentzVector(), [] (reco::Candidate::LorentzVector a, reco::CandidatePtr const & b){return a + b->p4();}).mass() :
+	auto const& sub = subjets(label);
+	return hasSubjets(label) && !sub.empty() ?
+	  std::accumulate( sub.begin(), sub.end(),
+			   reco::Candidate::LorentzVector(),
+			   [] (reco::Candidate::LorentzVector const & a, reco::CandidatePtr const & b){return a + b->p4();}).mass() :
 	  -1.0;
       }
 

--- a/DataFormats/PatCandidates/src/Jet.cc
+++ b/DataFormats/PatCandidates/src/Jet.cc
@@ -599,7 +599,7 @@ pat::JetPtrCollection const & Jet::subjets( unsigned int index) const {
 
 
 /// String access to subjet list
-pat::JetPtrCollection const & Jet::subjets( std::string label ) const { 
+pat::JetPtrCollection const & Jet::subjets( std::string const & label ) const { 
   auto found = find( subjetLabels_.begin(), subjetLabels_.end(), label );
   if ( found != subjetLabels_.end() ){
     auto index = std::distance( subjetLabels_.begin(), found );
@@ -611,7 +611,7 @@ pat::JetPtrCollection const & Jet::subjets( std::string label ) const {
 }
 
 /// Add new set of subjets
-void Jet::addSubjets( pat::JetPtrCollection const & pieces, std::string label  ) {
+void Jet::addSubjets( pat::JetPtrCollection const & pieces, std::string const & label  ) {
   subjetCollections_.push_back( pieces );
   subjetLabels_.push_back( label );
 }


### PR DESCRIPTION
The JME recommendations for groomed masses changed since we implemented miniaod, so this adds some accessors to take the invariant mass of all groomed subjets, which gives the groomed jet mass.

This is also planned to be implemented in nanoaod. @rappoccio @gpetruc

Same as:
#21901 #21902 