### PR TITLE
HCALDQM: Remove all conditions access except emap (TEMPORARY PR)

### DIFF
--- a/DQM/HcalCommon/src/DQTask.cc
+++ b/DQM/HcalCommon/src/DQTask.cc
@@ -74,6 +74,7 @@ namespace hcaldqm
 		}
 
 		//	get the Channel Quality Status for all the channels
+		/*
 		edm::ESHandle<HcalChannelQuality> hcq;
 		es.get<HcalChannelQualityRcd>().get("withTopo", hcq);
 		const HcalChannelQuality *cq = hcq.product();
@@ -96,6 +97,7 @@ namespace hcaldqm
 				}
 			}
 		}
+		*/
 
 		//	book some base guys
 		_cEvsTotal.book(ib, _subsystem);

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -623,8 +623,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			rawidHEValid = did.rawId();
 
 		//double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(*it, 2.5, 0, it->size()-1);
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HBHEDataFrame>(_dbService, did, *it);
-		double sumQ = hcaldqm::utilities::sumQDB<HBHEDataFrame>(_dbService, digi_fC, did, *it, 0, it->size()-1);
+		//CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HBHEDataFrame>(_dbService, did, *it);
+		double sumQ = 0; //hcaldqm::utilities::sumQDB<HBHEDataFrame>(_dbService, digi_fC, did, *it, 0, it->size()-1);
 
 		//	filter out channels that are masked out
 		if (_xQuality.exists(did)) 
@@ -686,7 +686,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		if (sumQ>_cutSumQ_HBHE)
 		{
 			//double timing = hcaldqm::utilities::aveTS<HBHEDataFrame>(*it, 2.5, 0, it->size()-1);
-			double timing = hcaldqm::utilities::aveTSDB<HBHEDataFrame>(_dbService, digi_fC, did, *it, 0, it->size()-1);
+			double timing = 0; //hcaldqm::utilities::aveTSDB<HBHEDataFrame>(_dbService, digi_fC, did, *it, 0, it->size()-1);
 			_cTimingCut_SubdetPM.fill(did, timing);
 			_cTimingCut_depth.fill(did, timing);
 			_cOccupancyCut_depth.fill(did);
@@ -751,8 +751,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			rawidHEValid = did.rawId();
 
 		//double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(digi, 2.5, 0, digi.samples()-1);
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
-		double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
+		//CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
+		double sumQ = 0; //hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
 
 		//	filter out channels that are masked out
 		if (_xQuality.exists(did)) 
@@ -808,7 +808,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		if (sumQ>_cutSumQ_HEP17)
 		{
 			//double timing = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
-			double timing = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
+			double timing = 0; //hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
 
 			_cOccupancyCut_depth.fill(did);
 			_cTimingCut_depth.fill(did, timing);
@@ -877,8 +877,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			rawidValid = did.rawId();
 
 		//double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(*it, 8.5, 0, it->size()-1);
-		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HODataFrame>(_dbService, did, *it);
-		double sumQ = hcaldqm::utilities::sumQDB<HODataFrame>(_dbService, digi_fC, did, *it, 0, it->size()-1);
+		//CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HODataFrame>(_dbService, did, *it);
+		double sumQ = 0; //hcaldqm::utilities::sumQDB<HODataFrame>(_dbService, digi_fC, did, *it, 0, it->size()-1);
 
 		//	filter out channels that are masked out
 		if (_xQuality.exists(did)) 
@@ -936,7 +936,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		if (sumQ>_cutSumQ_HO)
 		{
 			//double timing = hcaldqm::utilities::aveTS<HODataFrame>(*it, 8.5, 0,it->size()-1);
-			double timing = hcaldqm::utilities::aveTSDB<HODataFrame>(_dbService, digi_fC, did, *it, 0, it->size()-1);
+			double timing = 0; //hcaldqm::utilities::aveTSDB<HODataFrame>(_dbService, digi_fC, did, *it, 0, it->size()-1);
 			_cSumQ_depth.fill(did, sumQ);
 			_cSumQvsLS_SubdetPM.fill(did, _currentLS, sumQ);
 			_cOccupancyCut_depth.fill(did);
@@ -1017,8 +1017,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			if (did.subdet()==HcalForward)
 				rawidValid = did.rawId();
 
-			CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, digi);
-			double sumQ = hcaldqm::utilities::sumQDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
+			//CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, digi);
+			double sumQ = 0; //hcaldqm::utilities::sumQDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
 			//double sumQ = hcaldqm::utilities::sumQ_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
 
 
@@ -1067,7 +1067,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 
 			for (int i=0; i<digi.samples(); i++)
 			{
-				double q = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i);
+				double q = 0; //hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i);
 				if (!_filter_HF.filter(did)) {
 					_cADC_SubdetPM_HF.fill(did, digi[i].adc());
 					_cfC_SubdetPM_HF.fill(did, q);
@@ -1097,11 +1097,10 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 
 			if (sumQ>_cutSumQ_HF)
 			{
-				double timing = hcaldqm::utilities::aveTS_v10<QIE10DataFrame>(digi, 2.5, 0,
-					digi.samples()-1);
-				double q1 = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, 1);
-				double q2 = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, 2);
-				double q2q12 = q2/(q1+q2);
+				double timing = 0; //hcaldqm::utilities::aveTS_v10<QIE10DataFrame>(digi, 2.5, 0,digi.samples()-1);
+				//double q1 = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, 1);
+				//double q2 = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, 2);
+				double q2q12 = 0.; //q2/(q1+q2);
 				_cSumQ_depth.fill(did, sumQ);
 				if (!_filter_HF.filter(did)) {
 					_cSumQvsLS_SubdetPM_HF.fill(did, _currentLS, sumQ);

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -24,7 +24,7 @@ useMap		= False
 
 # 2018 MWGR preparation: use text emap and a local run test file
 MWGR1_hacks = True
-useLocalFileInput = True
+useLocalFileInput = False
 
 #-------------------------------------
 #	Central DQM Stuff imports

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -51,7 +51,7 @@ referenceFileName = '/dqmdata/dqm/reference/hcal_reference.root'
 process.DQMStore.referenceFileName = referenceFileName
 process = customise(process)
 process.DQMStore.verbose = 0
-#process.source.minEventsPerLumi=100
+process.source.minEventsPerLumi=100
 
 
 #-------------------------------------

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -203,12 +203,12 @@ if MWGR1_hacks:
 #-------------------------------------
 #process.hcalDigiTask.moduleParameters.debug = 10
 
-process.tbunpacker = cms.EDProducer(
-	"HcalTBObjectUnpacker",
-	IncludeUnmatchedHits	= cms.untracked.bool(False),
-	HcalTriggerFED			= cms.untracked.int32(1)
-)
-process.tbunpacker.fedRawDataCollectionTag = rawTag
+#process.tbunpacker = cms.EDProducer(
+#	"HcalTBObjectUnpacker",
+#	IncludeUnmatchedHits	= cms.untracked.bool(False),
+#	HcalTriggerFED			= cms.untracked.int32(1)
+#)
+#process.tbunpacker.fedRawDataCollectionTag = rawTag
 
 #-------------------------------------
 #	Some Settings before Finishing up
@@ -252,8 +252,8 @@ process.harvestingPath = cms.Path(
 #	Paths/Sequences Definitions
 #-------------------------------------
 process.preRecoPath = cms.Path(
-		process.tbunpacker
-		*process.hcalDigis
+		#process.tbunpacker
+		process.hcalDigis
 		#*process.castorDigis
 		#*process.emulTPDigis
 )

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -12,31 +12,32 @@ import os, sys, socket, string
 #-------------------------------------
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
-process			= cms.Process('HCALDQM', 
-    eras.run2_HCAL_2017, 
-    eras.run2_HF_2017,
-    eras.run2_HEPlan1_2017
-)
+process			= cms.Process('HCALDQM', eras.Run2_2018)
 subsystem		= 'Hcal'
 cmssw			= os.getenv("CMSSW_VERSION").split("_")
 debugstr		= "### HcalDQM::cfg::DEBUG: "
 warnstr			= "### HcalDQM::cfg::WARN: "
 errorstr		= "### HcalDQM::cfg::ERROR:"
-useOfflineGT	= False
+useOfflineGT	= True
 useFileInput	= False
 useMap		= False
+
+# 2018 MWGR preparation: use text emap and a local run test file
+MWGR1_hacks = True
+useLocalFileInput = True
 
 #-------------------------------------
 #	Central DQM Stuff imports
 #-------------------------------------
 from DQM.Integration.config.online_customizations_cfi import *
-if useOfflineGT:
-	process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
-	process.GlobalTag.globaltag = '90X_dataRun2_HLT_v1'
-else:
-	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
 if useFileInput:
 	process.load("DQM.Integration.config.fileinputsource_cfi")
+elif useLocalFileInput:
+	process.source = cms.Source("HcalTBSource",
+		fileNames = cms.untracked.vstring("file:/build/dryu/DQM/local_emulator/data/USC_308175.root"),
+		maxEvents = cms.untracked.int32(1000),
+		minEventsPerLumi = cms.untracked.int32(100),
+	)
 else:
 	process.load('DQM.Integration.config.inputsource_cfi')
 process.load('DQM.Integration.config.environment_cfi')
@@ -50,17 +51,24 @@ referenceFileName = '/dqmdata/dqm/reference/hcal_reference.root'
 process.DQMStore.referenceFileName = referenceFileName
 process = customise(process)
 process.DQMStore.verbose = 0
-process.source.minEventsPerLumi=100
+#process.source.minEventsPerLumi=100
 
 
 #-------------------------------------
 #	CMSSW/Hcal non-DQM Related Module import
 #-------------------------------------
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load('FWCore.MessageLogger.MessageLogger_cfi')
 process.load("EventFilter.HcalRawToDigi.HcalRawToDigi_cfi")
 process.load('EventFilter.CastorRawToDigi.CastorRawToDigi_cff')
 process.load("SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff")
+process.load('CondCore.CondDB.CondDB_cfi')
+if useOfflineGT:
+	#process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
+	process.GlobalTag.globaltag = '100X_dataRun2_HLT_v1' # '90X_dataRun2_HLT_v1'
+else:
+	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
 
 #-------------------------------------
 #	CMSSW/Hcal non-DQM Related Module Settings
@@ -73,17 +81,28 @@ process.load("SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff")
 #	-> L1 GT setting
 #	-> Rename the hbheprereco to hbhereco
 #-------------------------------------
-runType			= process.runType.getRunType()
-runTypeName		= process.runType.getRunTypeName()
-isCosmicRun		= runTypeName=="cosmic_run" or runTypeName=="cosmic_run_stage1"
-isHeavyIon		= runTypeName=="hi_run"
+if useLocalFileInput:
+	isCosmicRun		= False
+	isHeavyIon		= False
+	runType = cms.untracked.int32(0)
+	runTypeName = "pp"
+else:
+	runType			= process.runType.getRunType()
+	runTypeName		= process.runType.getRunTypeName()
+	isCosmicRun		= runTypeName=="cosmic_run" or runTypeName=="cosmic_run_stage1"
+	isHeavyIon		= runTypeName=="hi_run"
 cmssw			= os.getenv("CMSSW_VERSION").split("_")
-rawTag			= cms.InputTag("rawDataCollector")
-rawTagUntracked = cms.untracked.InputTag("rawDataCollector")
-if isHeavyIon:
+if useLocalFileInput:
+	rawTag = cms.InputTag("source")
+	rawTagUntracked = cms.untracked.InputTag("source")
+elif isHeavyIon:
 	rawTag = cms.InputTag("rawDataRepacker")
 	rawTagUntracked = cms.untracked.InputTag("rawDataRepacker")
 	process.castorDigis.InputLabel = rawTag
+else:
+	rawTag			= cms.InputTag("rawDataCollector")
+	rawTagUntracked = cms.untracked.InputTag("rawDataCollector")
+
 
 process.emulTPDigis = \
 		process.simHcalTriggerPrimitiveDigis.clone()
@@ -104,8 +123,8 @@ process.emulTPDigis.ZS_threshold = cms.uint32(0)
 process.hcalDigis.InputLabel = rawTag
 
 # Exclude the laser FEDs. They contaminate the QIE10/11 digi collections. 
-from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
-run2_HCAL_2017.toModify(process.hcalDigis, FEDs=cms.untracked.vint32(724,725,726,727,728,729,730,731,1100,1101,1102,1103,1104,1105,1106,1107,1108,1109,1110,1111,1112,1113,1114,1115,1116,1117,1118,1119,1120,1121,1122,1123))
+#from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
+#run2_HCAL_2017.toModify(process.hcalDigis, FEDs=cms.untracked.vint32(724,725,726,727,728,729,730,731,1100,1101,1102,1103,1104,1105,1106,1107,1108,1109,1110,1111,1112,1113,1114,1115,1116,1117,1118,1119,1120,1121,1122,1123))
 
 #-------------------------------------
 #	Hcal DQM Tasks and Harvesters import
@@ -124,16 +143,72 @@ process.load('DQM.HcalTasks.HcalOnlineHarvesting')
 #	Will not be here for Online DQM
 #-------------------------------------
 if useMap:
-    process.GlobalTag.toGet.append(cms.PSet(
+	process.GlobalTag.toGet.append(cms.PSet(
 		record = cms.string("HcalElectronicsMapRcd"),
-        tag = cms.string("HcalElectronicsMap_v7.05_hlt"),
-        )
-    )
+		tag = cms.string("HcalElectronicsMap_v7.05_hlt"),
+		)
+	)
+if MWGR1_hacks:
+	#process.GlobalTag.toGet.append(cms.PSet(
+	#	record = cms.string("PHcalRcd"),
+	#	tag = cms.string("HCALRECO_Geometry_10YV4"),
+	#	)
+	#)
+	#process.GlobalTag.toGet.append(cms.PSet(
+	#	record = cms.string("HcalParametersRcd"),
+	#	tag = cms.string("HCALParameters_Geometry_10YV4"),
+	#	)
+	#)
+	process.es_pool = cms.ESSource("PoolDBESSource",
+			DBParameters=process.CondDB,
+			connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+			timetype = cms.string('runnumber'),
+			toGet = cms.VPSet(
+				cms.PSet(
+					record = cms.string("HcalParametersRcd"),
+					tag = cms.string("HCALParameters_Geometry_10YV4")
+				),
+				cms.PSet(
+					record = cms.string("PHcalRcd"),
+					tag = cms.string("HCALRECO_Geometry_10YV4")
+				),
+				cms.PSet(
+					record = cms.string("HcalElectronicsMapRcd"),
+					tag = cms.string("HcalElectronicsMap_all_2018")
+				)
+			),
+			authenticationMethod = cms.untracked.uint32(0)
+	)	
+	process.es_prefer_es_pool = cms.ESPrefer('PoolDBESSource', 'es_pool')
+
+	#process.es_ascii = cms.ESSource(
+	#	'HcalTextCalibrations',
+	#	input = cms.VPSet(
+	#		cms.PSet(
+	#			object = cms.string('ElectronicsMap'),
+	#			#file = cms.FileInPath("HCALemap_all_J.txt")
+	#			file = cms.FileInPath("emap_2018MWGR1.txt")
+	#			#file = cms.FileInPath("emap_ngHF20170206_plus_HBHEP17_CRF.txt")
+	#			#file = cms.FileInPath("emap_ngHF20170206_plus_HBHEP17_template.txt")
+#	#			file = cms.FileInPath(settings.emapfileInPath)
+	#			#file = cms.FileInPath('ngHF2017EMap_20170125_pre04.txt')
+	#			#file = cms.FileInPath('ngHF2017EMap_20170206_pre05.txt')
+	#		)
+	#	)
+	#)
+	#process.es_prefer = cms.ESPrefer('HcalTextCalibrations', 'es_ascii')
 
 #-------------------------------------
-#	For Debugginb
+#	For Debugging
 #-------------------------------------
 #process.hcalDigiTask.moduleParameters.debug = 10
+
+process.tbunpacker = cms.EDProducer(
+	"HcalTBObjectUnpacker",
+	IncludeUnmatchedHits	= cms.untracked.bool(False),
+	HcalTriggerFED			= cms.untracked.int32(1)
+)
+process.tbunpacker.fedRawDataCollectionTag = rawTag
 
 #-------------------------------------
 #	Some Settings before Finishing up
@@ -162,7 +237,7 @@ process.qie11Task.tagQIE11 = cms.untracked.InputTag("hcalDigis")
 process.tasksPath = cms.Path(
 		process.rawTask
 		+process.digiTask
-		+process.tpTask
+		#+process.tpTask
 		+process.nocqTask
 		+process.qie11Task
 		#ZDC to be removed for 2017 pp running
@@ -177,9 +252,10 @@ process.harvestingPath = cms.Path(
 #	Paths/Sequences Definitions
 #-------------------------------------
 process.preRecoPath = cms.Path(
-		process.hcalDigis
-		*process.castorDigis
-		*process.emulTPDigis
+		process.tbunpacker
+		*process.hcalDigis
+		#*process.castorDigis
+		#*process.emulTPDigis
 )
 
 process.dqmPath = cms.EndPath(
@@ -191,7 +267,7 @@ process.dqmPath1 = cms.EndPath(
 process.schedule = cms.Schedule(
 	process.preRecoPath,
 	process.tasksPath,
-	process.harvestingPath,
+	#process.harvestingPath,
 	process.dqmPath,
 	process.dqmPath1
 )


### PR DESCRIPTION
For MWGR1, HCAL conditions are not yet ready. This is a *temporary PR for online DQM* which removes all calls to conditions except for the emap, for which a tag has specially been prepared [1]. Note that only the "hcal" application will work, not "hcal2," which uses reco. 


[1]
-File: /afs/cern.ch/user/c/cawest/public/HCALemap_all_2018.txt
-Tag: HcalElectronicsMap_all_2018
-Payload: bf8532b2e18d42712a5b995da11a1edfd2bd779b
