### PR TITLE
Make binning consistent and remove several plots in Offline DQM

### DIFF
--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -39,7 +39,7 @@ PerModule = cms.PSet(enabled = cms.bool(True)) # normal histos per module
 PerLadder = cms.PSet(enabled = cms.bool(True)) # histos per ladder, profiles
 PerLayer2D = cms.PSet(enabled = cms.bool(True)) # 2D maps/profiles of layers
 PerLayer1D = cms.PSet(enabled = cms.bool(True)) # normal histos per layer
-PerReadout = cms.PSet(enabled = cms.bool(True)) # "Readout view", also for initial timing
+PerReadout = cms.PSet(enabled = cms.bool(False)) # "Readout view", also for initial timing
 OverlayCurvesForTiming= cms.PSet(enabled = cms.bool(False)) #switch to overlay digi/clusters curves for timing scan
 IsOffline = cms.PSet(enabled = cms.bool(True)) # should be switch off for Online
 

--- a/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
@@ -400,7 +400,7 @@ SiPixelPhase1ClustersChargeVsSizeOnTrack = DefaultHistoTrack.clone(
 SiPixelPhase1TrackClustersOnTrackChargeOuter = DefaultHistoTrack.clone(
   name = "chargeOuter",
   title = "Corrected Cluster Charge (OnTrack) outer ladders",
-  range_min = 0, range_max = 150e3, range_nbins = 150,
+  range_min = 0, range_max = 80e3, range_nbins = 100,
   xlabel = "Charge (electrons)",
 
   specs = VPSet(


### PR DESCRIPTION
This PR make the binning of on track cluster charge histograms consistent and remove several plots in Offline DQM