### PR TITLE
Switch uROS in DT Online DQM

### DIFF
--- a/DQM/DTMonitorModule/python/dt_dqm_sourceclient_common_cff.py
+++ b/DQM/DTMonitorModule/python/dt_dqm_sourceclient_common_cff.py
@@ -28,13 +28,16 @@ scalersRawToDigi.scalersInputTag = 'rawDataCollector'
 from EventFilter.L1TXRawToDigi.twinMuxStage2Digis_cfi import *
 twinMuxStage2Digis.DTTM7_FED_Source = 'rawDataCollector'
 
-from EventFilter.DTRawToDigi.dtunpackerDDUGlobal_cfi import *
+#from EventFilter.DTRawToDigi.dtunpackerDDUGlobal_cfi import *
 #from EventFilter.DTRawToDigi.dtunpackerDDULocal_cfi import *
-dtunpacker.readOutParameters.performDataIntegrityMonitor = True
-dtunpacker.readOutParameters.rosParameters.performDataIntegrityMonitor = True
-dtunpacker.readOutParameters.debug = False
-dtunpacker.readOutParameters.rosParameters.debug = False
-dtunpacker.inputLabel = 'rawDataCollector'
+#dtunpacker.readOutParameters.performDataIntegrityMonitor = True
+#dtunpacker.readOutParameters.rosParameters.performDataIntegrityMonitor = True
+#dtunpacker.readOutParameters.debug = False
+#dtunpacker.readOutParameters.rosParameters.debug = False
+#dtunpacker.inputLabel = 'rawDataCollector'
+
+import EventFilter.DTRawToDigi.dturosunpacker_cfi
+dtunpacker = EventFilter.DTRawToDigi.dturosunpacker_cfi.dturosunpacker.clone()
 
 from RecoLocalMuon.Configuration.RecoLocalMuon_cff import *
 dt1DRecHits.dtDigiLabel = 'dtunpacker'
@@ -49,6 +52,7 @@ DTDataIntegrityTask.processingMode = 'Online'
 DTDataIntegrityTask.dtDDULabel     = 'dtunpacker'
 DTDataIntegrityTask.dtROS25Label   = 'dtunpacker'
 DTDataIntegrityTask.dtFEDlabel     = 'dtunpacker'
+DTDataIntegrityTask.checkUros      = True
 
 # Digi task
 from DQM.DTMonitorModule.dtDigiTask_cfi import *


### PR DESCRIPTION
Change to switch Online DQM in order to read DT uROS data. 

It will be default from 2018 MWGR1 onwards. Legacy ROS currently disabled.

The change only affects Online DQM