### PR TITLE
Geant4 sensitive detectors update 3

### DIFF
--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -126,26 +126,21 @@ protected:
   G4ThreeVector                   posGlobal;    
   float                           incidentEnergy;
   float                           edepositEM, edepositHAD;
-  int                             primIDSaved;    //*  ID of the last saved primary
 
   CaloHitID                       currentID, previousID; 
 
-  double                          energyCut, tmaxHit, eminHit, eminHitD;
-  int                             checkHits;
-  bool                            useMap;
+  double                          energyCut, tmaxHit, eminHit;
 
-  const SimTrackManager*          m_trackManager;
   CaloG4Hit*                      currentHit;
 
-  bool                            runInit;
-
-  bool                            corrTOFBeam, suppressHeavy;
-  double                          correctT;
+  bool                            suppressHeavy;
   double                          kmaxIon, kmaxNeutron, kmaxProton;
 
   bool                            forceSave;
 
 private:
+
+  const SimTrackManager*          m_trackManager;
 
   std::unique_ptr<CaloSlaveSD>         slave;
   std::unique_ptr<CaloMeanResponse>    meanResponse;
@@ -154,13 +149,19 @@ private:
 
   bool                            ignoreTrackID;
   bool                            isParameterized; 
+  bool                            useMap;
+  bool                            corrTOFBeam;
 
   int                             hcID;
   int                             primAncestor;
   int                             cleanIndex;
   int                             totalHits;
+  int                             primIDSaved; // ID of the last saved primary
+  int                             checkHits;
 
   float                           timeSlice;
+  double                          eminHitD;
+  double                          correctT;
 
   std::map<CaloHitID,CaloG4Hit*>  hitMap;
   std::map<int,TrackWithHistory*> tkMap;

--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -50,7 +50,7 @@ public:
   CaloSD(const std::string& aSDname, const DDCompactView & cpv,
          const SensitiveDetectorCatalog & clg,
          edm::ParameterSet const & p, const SimTrackManager*,
-	 float timeSlice=1., bool ignoreTkID=false);
+         float timeSlice=1., bool ignoreTkID=false);
   ~CaloSD() override;
 
   G4bool   ProcessHits(G4Step * step, G4TouchableHistory *) override;

--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -92,6 +92,7 @@ protected:
   virtual bool     filterHit(CaloG4Hit*, double);
 
   virtual int      getTrackID(const G4Track*); 
+  virtual int      setTrackID(const G4Step*); 
   virtual uint16_t getDepth(const G4Step*);   
   double           getResponseWt(const G4Track*);
   int              getNumberOfHits();

--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -32,7 +32,7 @@ class ECalSD : public CaloSD {
 public:    
 
   ECalSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
-	 edm::ParameterSet const & p, const SimTrackManager*);
+         edm::ParameterSet const & p, const SimTrackManager*);
   ~ECalSD() override;
   uint32_t                  setDetUnitId(const G4Step*) override;
   void                      setNumberingScheme(EcalNumberingScheme*);
@@ -47,7 +47,7 @@ private:
 
   void                      initMap(const G4String&, const DDCompactView &);
   uint16_t                  getRadiationLength(const G4StepPoint* hitPoint, 
-					       const G4LogicalVolume* lv);
+                                               const G4LogicalVolume* lv);
   uint16_t                  getLayerIDForTimeSim();
   double                    curve_LY(const G4LogicalVolume*);  
 
@@ -55,9 +55,9 @@ private:
   double                    getBirkL3(const G4Step*);
 
   std::vector<double>               getDDDArray(const std::string&,
-						const DDsvalues_type&);
+                                                const DDsvalues_type&);
   std::vector<std::string>          getStringArray(const std::string&,
-						   const DDsvalues_type&);
+                                                   const DDsvalues_type&);
 
   // initialised before run
   bool                              isEB;

--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -34,30 +34,32 @@ public:
   ECalSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	 edm::ParameterSet const & p, const SimTrackManager*);
   ~ECalSD() override;
-  double                    getEnergyDeposit(G4Step*) override;
-  virtual uint16_t          getRadiationLength(const G4Step *);
-  virtual uint16_t          getLayerIDForTimeSim(const G4Step *);
   uint32_t                  setDetUnitId(const G4Step*) override;
   void                      setNumberingScheme(EcalNumberingScheme*);
 
 protected:
 
+  double                    getEnergyDeposit(const G4Step*) override;
   int                       getTrackID(const G4Track*) override;
   uint16_t                  getDepth(const G4Step*) override;
 
 private:    
 
-  void                              initMap(const G4String&, const DDCompactView &);
-  double                            curve_LY(const G4Step*); 
-  double                            crystalLength(const G4LogicalVolume*);
-  double                            crystalDepth(const G4LogicalVolume*, const G4ThreeVector&);
-  void                              getBaseNumber(const G4Step*); 
-  double                            getBirkL3(const G4Step*);
+  void                      initMap(const G4String&, const DDCompactView &);
+  uint16_t                  getRadiationLength(const G4StepPoint* hitPoint, 
+					       const G4LogicalVolume* lv);
+  uint16_t                  getLayerIDForTimeSim();
+  double                    curve_LY(const G4LogicalVolume*);  
+
+  void                      getBaseNumber(const G4Step*); 
+  double                    getBirkL3(const G4Step*);
+
   std::vector<double>               getDDDArray(const std::string&,
 						const DDsvalues_type&);
   std::vector<std::string>          getStringArray(const std::string&,
 						   const DDsvalues_type&);
 
+  // initialised before run
   bool                              isEB;
   bool                              isEE;
   EcalNumberingScheme *             numberingScheme;
@@ -71,6 +73,13 @@ private:
   EcalBaseNumber                    theBaseNumber;
   EnergyResolutionVsLumi            ageing;
   bool                              ageingWithSlopeLY;
+
+  // run time cache
+  G4ThreeVector                     currentLocalPoint;
+  double                            crystalLength;
+  double                            crystalDepth;
+  uint16_t                          depth;
+ 
 #ifdef plotDebug
   TH2F                             *g2L_[4];
 #endif

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -14,6 +14,7 @@
 #include "SimG4CMS/Calo/interface/HFShowerPMT.h"
 #include "SimG4CMS/Calo/interface/HFShowerFibreBundle.h"
 #include "SimG4CMS/Calo/interface/HcalNumberingScheme.h"
+#include "SimG4CMS/Calo/interface/HcalTestNS.h"
 #include "CondFormats/HcalObjects/interface/HBHEDarkening.h"
 #include "SimG4CMS/Calo/interface/HFDarkening.h"
 #include "DetectorDescription/Core/interface/DDsvalues.h"
@@ -39,19 +40,24 @@ public:
 
   HCalSD(const std::string& , const DDCompactView &, const SensitiveDetectorCatalog &,
          edm::ParameterSet const &, const SimTrackManager*);
-  ~HCalSD() override;
-  bool                  ProcessHits(G4Step * , G4TouchableHistory * ) override;
-  double                getEnergyDeposit(G4Step* ) override;
+  ~HCalSD() = default;
   uint32_t              setDetUnitId(const G4Step* step) override;
   void                  setNumberingScheme(HcalNumberingScheme* );
 
 protected:
 
+  double                getEnergyDeposit(const G4Step*) override;
+  bool                  getFromLibrary(const G4Step*) override;
   void                  update(const BeginOfJob *) override;
   void                  initRun() override;
   bool                  filterHit(CaloG4Hit*, double) override;
 
 private:    
+
+  void                  fillLogVolumeVector(const std::string&, const std::string&, 
+					    const DDCompactView&,
+					    std::vector<const G4LogicalVolume*>&,
+					    std::vector<G4String>&);
 
   uint32_t                      setDetUnitId(int, const G4ThreeVector&, int, int);
   uint32_t                      setDetUnitId(HcalNumberingFromDDD::HcalID& tmp);
@@ -67,9 +73,9 @@ private:
   bool                          isItConicalBundle(const G4LogicalVolume*);
   bool                          isItScintillator(const G4Material*);
   bool                          isItinFidVolume (const G4ThreeVector&);
-  void                          getFromLibrary(G4Step * step, double weight);
-  void                          hitForFibre(const G4Step * step, double weight);
-  void                          getFromParam(G4Step * step, double weight);
+  void                          getFromHFLibrary(const G4Step * step, bool& isKilled);
+  void                          hitForFibre(const G4Step * step);
+  void                          getFromParam(const G4Step * step, bool& isKilled);
   void                          getHitPMT(const G4Step * step);
   void                          getHitFibreBundle(const G4Step * step, bool type);
   int                           setTrackID(const G4Step * step);
@@ -80,26 +86,30 @@ private:
   void                          plotHF(const G4ThreeVector& pos, bool emType);
   void                          modifyDepth(HcalNumberingFromDDD::HcalID& id);
 
+  std::unique_ptr<HcalNumberingFromDDD> numberingFromDDD;
+  std::unique_ptr<HcalNumberingScheme>  numberingScheme;
+  std::unique_ptr<HFShowerLibrary>      showerLibrary;
+  std::unique_ptr<HFShower>             hfshower;
+  std::unique_ptr<HFShowerParam>        showerParam;
+  std::unique_ptr<HFShowerPMT>          showerPMT;
+  std::unique_ptr<HFShowerFibreBundle>  showerBundle;
+
   HcalDDDSimConstants*          hcalConstants;
-  HcalNumberingFromDDD*         numberingFromDDD;
-  HcalNumberingScheme*          numberingScheme;
-  HFShowerLibrary *             showerLibrary;
-  HFShower *                    hfshower;
-  HFShowerParam *               showerParam;
-  HFShowerPMT *                 showerPMT;
-  HFShowerFibreBundle *         showerBundle;
-  bool                          agingFlagHB, agingFlagHE;
   const HBHEDarkening*          m_HBDarkening;
   const HBHEDarkening*          m_HEDarkening;
   std::unique_ptr<HFDarkening>  m_HFDarkening;
-  HcalTestNS *                  hcalTestNS_;
+  std::unique_ptr<HcalTestNS>   m_HcalTestNS;
+
+  bool                          isHF;
+  bool                          agingFlagHB, agingFlagHE;
   bool                          useBirk, useLayerWt, useFibreBundle, usePMTHit;
   bool                          testNumber, neutralDensity, testNS_;
   double                        birk1, birk2, birk3, betaThr;
   bool                          useHF, useShowerLibrary, useParam, applyFidCut;
   double                        eminHitHB, eminHitHE, eminHitHO, eminHitHF;
   double                        deliveredLumi;
-  G4int                         mumPDG, mupPDG, depth_;
+  double                        weight_;
+  int                           depth_;
   std::vector<double>           gpar;
   std::vector<int>              hfLevels;
   std::vector<G4String>         hfNames, fibreNames, matNames;

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -78,7 +78,7 @@ private:
   void                          getFromParam(const G4Step * step, bool& isKilled);
   void                          getHitPMT(const G4Step * step);
   void                          getHitFibreBundle(const G4Step * step, bool type);
-  int                           setTrackID(const G4Step * step);
+  //  int                           setTrackID(const G4Step * step);
   void                          readWeightFromFile(const std::string&);
   double                        layerWeight(int, const G4ThreeVector&, int, int);
   void                          plotProfile(const G4Step* step, const G4ThreeVector& pos, 

--- a/SimG4CMS/Calo/interface/HFFibre.h
+++ b/SimG4CMS/Calo/interface/HFFibre.h
@@ -24,9 +24,9 @@ public:
   //Constructor and Destructor
   HFFibre(const std::string & name, const DDCompactView & cpv,
 	  edm::ParameterSet const & p);
-  ~HFFibre();
+  ~HFFibre() = default;
 
-  void                initRun(HcalDDDSimConstants*);
+  void                initRun(const HcalDDDSimConstants*);
   double              attLength(double lambda);
   double              tShift(const G4ThreeVector& point, int depth, 
 			     int fromEndAbs=0);

--- a/SimG4CMS/Calo/interface/HFFibre.h
+++ b/SimG4CMS/Calo/interface/HFFibre.h
@@ -23,20 +23,20 @@ public:
   
   //Constructor and Destructor
   HFFibre(const std::string & name, const DDCompactView & cpv,
-	  edm::ParameterSet const & p);
+          edm::ParameterSet const & p);
   ~HFFibre() = default;
 
   void                initRun(const HcalDDDSimConstants*);
   double              attLength(double lambda);
   double              tShift(const G4ThreeVector& point, int depth, 
-			     int fromEndAbs=0);
+                             int fromEndAbs=0);
   double              zShift(const G4ThreeVector& point, int depth, 
-			     int fromEndAbs=0);
+                             int fromEndAbs=0);
 
 protected:
 
   std::vector<double> getDDDArray(const std::string&, 
-				  const DDsvalues_type&, int&);
+                                  const DDsvalues_type&, int&);
 
 private:
 

--- a/SimG4CMS/Calo/interface/HFGflash.h
+++ b/SimG4CMS/Calo/interface/HFGflash.h
@@ -42,7 +42,7 @@ public:
     double              pez = 0.;
   };
 
-  std::vector<Hit> gfParameterization(G4Step * aStep, bool & ok, bool onlyLong=false);
+  std::vector<Hit> gfParameterization(const G4Step * aStep, bool onlyLong=false);
 
 private:    
 

--- a/SimG4CMS/Calo/interface/HFShower.h
+++ b/SimG4CMS/Calo/interface/HFShower.h
@@ -38,7 +38,7 @@ public:
     G4ThreeVector     position;
   };
 
-  void                initRun(G4ParticleTable *, HcalDDDSimConstants*);
+  void                initRun(const HcalDDDSimConstants*);
   std::vector<Hit>    getHits(const G4Step * aStep, double weight);
   std::vector<Hit>    getHits(const G4Step * aStep, bool forLibrary);
   std::vector<Hit>    getHits(const G4Step * aStep, bool forLibraryProducer, double zoffset);

--- a/SimG4CMS/Calo/interface/HFShowerFibreBundle.h
+++ b/SimG4CMS/Calo/interface/HFShowerFibreBundle.h
@@ -26,7 +26,7 @@ public:
   virtual ~HFShowerFibreBundle();
   double                getHits(const G4Step * aStep, bool type);
   double                getRadius();
-  void                  initRun(G4ParticleTable *, HcalDDDSimConstants*);
+  void                  initRun(const HcalDDDSimConstants*);
 
 private:    
 

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -24,6 +24,7 @@
 
 class DDCompactView;    
 class G4Step;
+class G4ParticleTable;
 
 class HFShowerLibrary {
   
@@ -43,7 +44,7 @@ public:
     double                    time;
   };
 
-  void                initRun(const HcalDDDSimConstants*);
+  void                initRun(G4ParticleTable*, const HcalDDDSimConstants*);
   std::vector<Hit>    getHits(const G4Step * aStep, bool &ok, double weight, 
                               bool onlyLong=false);
   std::vector<Hit>    fillHits(const G4ThreeVector & p, const G4ThreeVector & v,
@@ -74,10 +75,6 @@ private:
   double              probMax, backProb;
   double              dphi, rMin, rMax;
   std::vector<double> gpar;
-
-  int                 emPDG, epPDG, gammaPDG;
-  int                 pi0PDG, etaPDG, nuePDG, numuPDG, nutauPDG;
-  int                 anuePDG, anumuPDG, anutauPDG, geantinoPDG;
 
   int                 npe;
   HFShowerPhotonCollection pe;

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -31,7 +31,7 @@ public:
   
   //Constructor and Destructor
   HFShowerLibrary(const std::string & name, const DDCompactView & cpv,
-		  edm::ParameterSet const & p);
+                  edm::ParameterSet const & p);
   ~HFShowerLibrary();
 
 public:
@@ -45,7 +45,7 @@ public:
 
   void                initRun(const HcalDDDSimConstants*);
   std::vector<Hit>    getHits(const G4Step * aStep, bool &ok, double weight, 
-			      bool onlyLong=false);
+                              bool onlyLong=false);
   std::vector<Hit>    fillHits(const G4ThreeVector & p, const G4ThreeVector & v,
                                int parCode, double parEnergy, bool & ok,
                                double weight, double time, bool onlyLong=false);
@@ -58,7 +58,7 @@ protected:
   void                extrapolate(int, double);
   void                storePhoton(int j);
   std::vector<double> getDDDArray(const std::string&, const DDsvalues_type&,
-				  int&);
+                                  int&);
 
 private:
 

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -12,7 +12,6 @@
 #include "SimDataFormats/CaloHit/interface/HFShowerPhoton.h"
 #include "DetectorDescription/Core/interface/DDsvalues.h"
 
-#include "G4ParticleTable.hh"
 #include "G4ThreeVector.hh"
  
 //ROOT
@@ -44,8 +43,8 @@ public:
     double                    time;
   };
 
-  void                initRun(G4ParticleTable *, HcalDDDSimConstants*);
-  std::vector<Hit>    getHits(G4Step * aStep, bool &ok, double weight, 
+  void                initRun(const HcalDDDSimConstants*);
+  std::vector<Hit>    getHits(const G4Step * aStep, bool &ok, double weight, 
 			      bool onlyLong=false);
   std::vector<Hit>    fillHits(const G4ThreeVector & p, const G4ThreeVector & v,
                                int parCode, double parEnergy, bool & ok,

--- a/SimG4CMS/Calo/interface/HFShowerPMT.h
+++ b/SimG4CMS/Calo/interface/HFShowerPMT.h
@@ -26,7 +26,7 @@ public:
   virtual ~HFShowerPMT();
   double                getHits(const G4Step * aStep);
   double                getRadius();
-  void                  initRun(G4ParticleTable *, HcalDDDSimConstants*);
+  void                  initRun(const HcalDDDSimConstants*);
 
 private:    
 

--- a/SimG4CMS/Calo/interface/HFShowerParam.h
+++ b/SimG4CMS/Calo/interface/HFShowerParam.h
@@ -13,7 +13,6 @@
 #include "SimG4CMS/Calo/interface/HFFibre.h"
 #include "SimG4CMS/Calo/interface/HFGflash.h"
 
-#include "G4ParticleTable.hh"
 #include "G4ThreeVector.hh"
 
 class DDCompactView;
@@ -42,8 +41,8 @@ public:
     double              edep;
   };
 
-  void                  initRun(G4ParticleTable *, HcalDDDSimConstants*);
-  std::vector<Hit>      getHits(G4Step * aStep, double weight);
+  void                  initRun(const HcalDDDSimConstants*);
+  std::vector<Hit>      getHits(const G4Step * aStep, double weight, bool& isKilled);
   
 private:    
 

--- a/SimG4CMS/Calo/interface/HFShowerParam.h
+++ b/SimG4CMS/Calo/interface/HFShowerParam.h
@@ -28,7 +28,7 @@ class HFShowerParam {
 public:    
 
   HFShowerParam(const std::string & name, const DDCompactView & cpv, 
-		edm::ParameterSet const & p);
+                edm::ParameterSet const & p);
   virtual ~HFShowerParam();
 
 public:    

--- a/SimG4CMS/Calo/interface/HGCSD.h
+++ b/SimG4CMS/Calo/interface/HGCSD.h
@@ -13,9 +13,9 @@
 #include "DetectorDescription/Core/interface/DDsvalues.h"
 
 #include "G4String.hh"
-#include <map>
+//#include <map>
 #include <string>
-#include <TH1F.h>
+//#include <TH1F.h>
 
 class DDCompactView;
 class DDFilteredView;
@@ -30,22 +30,22 @@ public:
   HGCSD(const std::string& , const DDCompactView &, const SensitiveDetectorCatalog &,
 	edm::ParameterSet const &, const SimTrackManager*);
   ~HGCSD() override;
-  bool                    ProcessHits(G4Step * , G4TouchableHistory * ) override;
-  double                  getEnergyDeposit(G4Step* ) override;
+
   uint32_t                setDetUnitId(const G4Step* step) override;
 
 protected:
 
+  double                  getEnergyDeposit(const G4Step* ) override;
   void                    update(const BeginOfJob *) override;
   void                    initRun() override;
   bool                    filterHit(CaloG4Hit*, double) override;
 
 private:    
 
-  uint32_t                        setDetUnitId(ForwardSubdetector&, int, int, 
-					       int, int, G4ThreeVector &);
-  bool                            isItinFidVolume (const G4ThreeVector&) {return true;}
-  int                             setTrackID(const G4Step * step);
+  uint32_t                setDetUnitId(ForwardSubdetector&, int, int, 
+				       int, int, G4ThreeVector &);
+  //bool                    isItinFidVolume (const G4ThreeVector&) {return true;}
+  //int                     setTrackID(const G4Step * step);
 
   std::string                     nameX;
 

--- a/SimG4CMS/Calo/interface/HGCSD.h
+++ b/SimG4CMS/Calo/interface/HGCSD.h
@@ -12,10 +12,7 @@
 #include "SimG4CMS/Calo/interface/HGCMouseBite.h"
 #include "DetectorDescription/Core/interface/DDsvalues.h"
 
-#include "G4String.hh"
-//#include <map>
 #include <string>
-//#include <TH1F.h>
 
 class DDCompactView;
 class DDFilteredView;
@@ -44,15 +41,12 @@ private:
 
   uint32_t                setDetUnitId(ForwardSubdetector&, int, int, 
 				       int, int, G4ThreeVector &);
-  //bool                    isItinFidVolume (const G4ThreeVector&) {return true;}
-  //int                     setTrackID(const G4Step * step);
 
   std::string                     nameX;
 
   HGCalGeometryMode::GeometryMode m_mode;
   HGCNumberingScheme*             numberingScheme;
   HGCMouseBite*                   mouseBite_;
-  G4int                           mumPDG, mupPDG; 
   double                          eminHit;
   ForwardSubdetector              myFwdSubdet_;
   double                          slopeMin_;

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -59,8 +59,8 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
       if (k < eminHitX.size()) eminHitD= eminHitX[k]*MeV;
       if (k < tmaxHits.size()) tmaxHit = tmaxHits[k]*ns;
       if (k < useResMap.size() && useResMap[k] > 0) {
-	meanResponse.reset(new CaloMeanResponse(p));
-	break;
+        meanResponse.reset(new CaloMeanResponse(p));
+        break;
       }
     }
   }
@@ -86,7 +86,7 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
                           << " ns and if energy is above " << eminHit/MeV
                           << " MeV (for depth 0) or " << eminHitD/MeV
                           << " MeV (for nonzero depths);\n"
-			  << "        Time Slice Unit " 
+                          << "        Time Slice Unit " 
                           << timeSlice << " Ignore TrackID Flag " << ignoreTrackID;
 }
 
@@ -101,10 +101,10 @@ G4bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD::" << GetName()
-			  << theTrack->GetTrackID() 
-			  << " prID= " << theTrack->GetParentID() 
-			  << " Epoststep= " << theTrack->GetKineticEnergy()
-			  << " step= " << aStep->GetStepLength() << " Edep= " << aStep->GetTotalEnergyDeposit(); 
+                          << theTrack->GetTrackID() 
+                          << " prID= " << theTrack->GetParentID() 
+                          << " Epoststep= " << theTrack->GetKineticEnergy()
+                          << " step= " << aStep->GetStepLength() << " Edep= " << aStep->GetTotalEnergyDeposit(); 
 #endif
   // apply shower library or parameterisation
   if(isParameterized) { 
@@ -115,9 +115,9 @@ G4bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
       auto tv  = aStep->GetSecondary();
       auto vol = aStep->GetPreStepPoint()->GetPhysicalVolume();
       for(auto & tk : *tv) {
-	if (tk->GetVolume() == vol) {
-	  tk->SetTrackStatus(fStopAndKill);
-	}
+        if (tk->GetVolume() == vol) {
+          tk->SetTrackStatus(fStopAndKill);
+        }
       }
       return true;
     }
@@ -149,18 +149,18 @@ G4bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
     //if(track->GetTrackID() == 8654) {
     G4TouchableHistory* touch =(G4TouchableHistory*)(track->GetTouchable());
     edm::LogInfo("CaloSim") << "CaloSD::" << GetName()
-			    << " PV:"   << touch->GetVolume(0)->GetName()
-			    << " PVid=" << touch->GetReplicaNumber(0)
-			    << " MVid=" << touch->GetReplicaNumber(1)
-			    << " Unit:" << std::hex << unitID << std::dec 
-			    << " Edep=" << edepositEM << " " << edepositHAD
-			    << " ID=" << track->GetTrackID()
-			    << " pID=" << track->GetParentID()
-			    << " E=" << track->GetKineticEnergy()
+                            << " PV:"   << touch->GetVolume(0)->GetName()
+                            << " PVid=" << touch->GetReplicaNumber(0)
+                            << " MVid=" << touch->GetReplicaNumber(1)
+                            << " Unit:" << std::hex << unitID << std::dec 
+                            << " Edep=" << edepositEM << " " << edepositHAD
+                            << " ID=" << track->GetTrackID()
+                            << " pID=" << track->GetParentID()
+                            << " E=" << track->GetKineticEnergy()
                             << " S=" << aStep->GetStepLength()
-			    << " " << track->GetDefinition()->GetParticleName()
-			    << " currentID= " << currentID 
-			    << " previousID= " << previousID;
+                            << " " << track->GetDefinition()->GetParticleName()
+                            << " currentID= " << currentID 
+                            << " previousID= " << previousID;
     //}
 #endif
     if(!hitExists(aStep)) {
@@ -198,9 +198,9 @@ bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory * ) {
     currentID.setID(unitID, time, primaryID, depth);
 #ifdef DebugLog
     edm::LogInfo("CaloSim") << "CaloSD:: GetSpotInfo for"
-			    << " Unit 0x" << std::hex << currentID.unitID() 
-			    << std::dec << " Edeposit = " << edepositEM << " " 
-			    << edepositHAD;
+                            << " Unit 0x" << std::hex << currentID.unitID() 
+                            << std::dec << " Edeposit = " << edepositEM << " " 
+                            << edepositHAD;
 #endif
     // Update if in the same detector, time-slice and for same track   
     if (currentID == previousID) {
@@ -209,15 +209,15 @@ bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory * ) {
       posGlobal = aSpot->GetEnergySpot()->GetPosition();
       // Reset entry point for new primary
       if (currentID.trackID() != previousID.trackID()) {
-	entrancePoint = aSpot->GetPosition();
-	entranceLocal = aSpot->GetTouchableHandle()->GetHistory()->
-	  GetTopTransform().TransformPoint(entrancePoint);
-	incidentEnergy = track->GetKineticEnergy();
+        entrancePoint = aSpot->GetPosition();
+        entranceLocal = aSpot->GetTouchableHandle()->GetHistory()->
+          GetTopTransform().TransformPoint(entrancePoint);
+        incidentEnergy = track->GetKineticEnergy();
 #ifdef DebugLog
-	LogDebug("CaloSim") << "CaloSD: Incident energy " 
-			    << incidentEnergy/GeV << " GeV and" 
-			    << " entrance point " << entrancePoint 
-			    << " (Global) " << entranceLocal << " (Local)";
+        LogDebug("CaloSim") << "CaloSD: Incident energy " 
+                            << incidentEnergy/GeV << " GeV and" 
+                            << " entrance point " << entrancePoint 
+                            << " (Global) " << entranceLocal << " (Local)";
 #endif
       }
       if (!checkHit()) { currentHit = createNewHit(&fFakeStep); }
@@ -339,16 +339,16 @@ CaloG4Hit* CaloSD::createNewHit(const G4Step* aStep) {
   auto const theTrack = aStep->GetTrack();
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD::CreateNewHit " << getNumberOfHits()
-			  << " for " << GetName()
-			  << " Unit:" << currentID.unitID() 
-			  << " " << currentID.depth()
-			  << " Edep= " << edepositEM << " " << edepositHAD
-			  << " primaryID= "    << currentID.trackID()
-			  << " timeSlice= " << currentID.timeSliceID()
-			  << " ID= " << theTrack->GetTrackID()
-			  << " " <<theTrack->GetDefinition()->GetParticleName()
-			  << " E(GeV)= "  << theTrack->GetKineticEnergy()/GeV
-			  << " parentID= " << theTrack->GetParentID();
+                          << " for " << GetName()
+                          << " Unit:" << currentID.unitID() 
+                          << " " << currentID.depth()
+                          << " Edep= " << edepositEM << " " << edepositHAD
+                          << " primaryID= "    << currentID.trackID()
+                          << " timeSlice= " << currentID.timeSliceID()
+                          << " ID= " << theTrack->GetTrackID()
+                          << " " <<theTrack->GetDefinition()->GetParticleName()
+                          << " E(GeV)= "  << theTrack->GetKineticEnergy()/GeV
+                          << " parentID= " << theTrack->GetParentID();
 #endif  
   
   CaloG4Hit* aHit;
@@ -375,9 +375,9 @@ CaloG4Hit* CaloSD::createNewHit(const G4Step* aStep) {
     etrack= theTrack->GetKineticEnergy();
 #ifdef DebugLog
     edm::LogInfo("CaloSim") << "CaloSD: set save the track " << currentID.trackID()
-			    << " etrack " << etrack << " eCut " << energyCut 
-			    << " force: " << forceSave 
-			    << " save: " << (etrack >= energyCut || forceSave);
+                            << " etrack " << etrack << " eCut " << energyCut 
+                            << " force: " << forceSave 
+                            << " save: " << (etrack >= energyCut || forceSave);
 #endif
     if (etrack >= energyCut || forceSave) {
       TrackInformation* trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
@@ -388,15 +388,15 @@ CaloG4Hit* CaloSD::createNewHit(const G4Step* aStep) {
     TrackWithHistory * trkh = tkMap[currentID.trackID()];
 #ifdef DebugLog
     edm::LogInfo("CaloSim") << "CaloSD : TrackwithHistory pointer for " 
-			    << currentID.trackID() << " is " << trkh;
+                            << currentID.trackID() << " is " << trkh;
 #endif
     if (trkh != nullptr) {
       etrack = sqrt(trkh->momentum().Mag2());
       if (etrack >= energyCut) {
         trkh->save();
 #ifdef DebugLog
-	edm::LogInfo("CaloSim") << "CaloSD: set save the track " 
-				<< currentID.trackID() << " with Hit";
+        edm::LogInfo("CaloSim") << "CaloSD: set save the track " 
+                                << currentID.trackID() << " with Hit";
 #endif
       }
     }
@@ -411,8 +411,8 @@ void CaloSD::updateHit(CaloG4Hit* aHit) {
   aHit->addEnergyDeposit(edepositEM,edepositHAD);
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: Add energy deposit in " << currentID 
-			  << " em " << edepositEM/MeV << " hadronic " 
-			  << edepositHAD/MeV << " MeV"; 
+                          << " em " << edepositEM/MeV << " hadronic " 
+                          << edepositHAD/MeV << " MeV"; 
 #endif
 
   // buffer for next steps:
@@ -426,8 +426,8 @@ void CaloSD::resetForNewPrimary(const G4Step* aStep) {
   incidentEnergy = preStepPoint->GetKineticEnergy();
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: Incident energy " << incidentEnergy/GeV 
-			  << " GeV and" << " entrance point " << entrancePoint 
-			  << " (Global) " << entranceLocal << " (Local)";
+                          << " GeV and" << " entrance point " << entrancePoint 
+                          << " (Global) " << entranceLocal << " (Local)";
 #endif
 }
 
@@ -445,9 +445,9 @@ double CaloSD::getAttenuation(const G4Step* aStep, double birk1, double birk2, d
     weight = 1./(1.+rkb*dedx+c*dedx*dedx);
 #ifdef DebugLog
     edm::LogInfo("CaloSim") << "CaloSD::getAttenuation in " << mat->GetName() 
-			    << " Charge " << charge << " dE/dx " << dedx 
-			    << " Birk Const " << rkb << ", " << c << " Weight = " 
-			    << weight << " dE " << aStep->GetTotalEnergyDeposit();
+                            << " Charge " << charge << " dE/dx " << dedx 
+                            << " Birk Const " << rkb << ", " << c << " Weight = " 
+                            << weight << " dE " << aStep->GetTotalEnergyDeposit();
 #endif
   }
   return weight;
@@ -461,7 +461,7 @@ void CaloSD::update(const BeginOfRun *) {
 void CaloSD::update(const BeginOfEvent *) {
 #ifdef DebugLog
   edm::LogInfo("CaloSim")  << "CaloSD: Dispatched BeginOfEvent for " 
-			   << GetName() << " !" ;
+                           << GetName() << " !" ;
 #endif
   clearHits();
 }
@@ -479,13 +479,13 @@ void CaloSD::update(const EndOfTrack * trk) {
         TrackWithHistory * trkH = (*trksForThisEvent)[it];
         if (trkH->trackID() == (unsigned int)(id)) tkMap[id] = trkH;
 #ifdef DebugLog
-	edm::LogInfo("CaloSim") << "CaloSD: get track " << it << " from "
-				<< "Container of size " << trksForThisEvent->size()
-				<< " with ID " << trkH->trackID();
+        edm::LogInfo("CaloSim") << "CaloSD: get track " << it << " from "
+                                << "Container of size " << trksForThisEvent->size()
+                                << " with ID " << trkH->trackID();
       } else {
-	edm::LogInfo("CaloSim") << "CaloSD: get track " << it << " from "
-				<< "Container of size " << trksForThisEvent->size()
-				<< " with no ID";
+        edm::LogInfo("CaloSim") << "CaloSD: get track " << it << " from "
+                                << "Container of size " << trksForThisEvent->size()
+                                << " with no ID";
 #endif
       }
     }
@@ -522,7 +522,7 @@ void CaloSD::clearHits() {
   primIDSaved = -99;
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: Clears hit vector for " << GetName() 
-			  << " and initialise slave: " << slave;
+                          << " and initialise slave: " << slave;
 #endif
   slave.get()->Initialize();
 }
@@ -542,7 +542,7 @@ int CaloSD::getTrackID(const G4Track* aTrack) {
   }
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD::" << GetName() << " trackID= " << aTrack->GetTrackID()
-			  << " primaryID= " << primaryID;
+                          << " primaryID= " << primaryID;
 #endif
   return primaryID;
 }
@@ -554,7 +554,7 @@ bool CaloSD::filterHit(CaloG4Hit* hit, double time) {
   if (hit->getDepth() > 0) emin = eminHitD;
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "Depth " << hit->getDepth() << " Emin = " << emin 
-			  << " (" << eminHit << ", " << eminHitD << ")";
+                          << " (" << eminHit << ", " << eminHitD << ")";
 #endif   
   return ((time <= tmaxHit) && (hit->getEnergyDeposit() > emin));
 }
@@ -587,7 +587,7 @@ bool CaloSD::saveHit(CaloG4Hit* aHit) {
     if (tkID == 0) {
       if (m_trackManager->trackExists(aHit->getTrackID())) tkID = (aHit->getTrackID());
       else {
-	ok = false;
+        ok = false;
       }
     }
   } else {
@@ -596,20 +596,20 @@ bool CaloSD::saveHit(CaloG4Hit* aHit) {
   }
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CalosD: Track ID " << aHit->getTrackID() 
-			  << " changed to " << tkID << " by SimTrackManager"
-			  << " Status " << ok;
+                          << " changed to " << tkID << " by SimTrackManager"
+                          << " Status " << ok;
 #endif
   double time = aHit->getTimeSlice();
   if (corrTOFBeam) time += correctT;
   slave.get()->processHits(aHit->getUnitID(), aHit->getEM()/GeV, 
-			   aHit->getHadr()/GeV, time, tkID, aHit->getDepth());
+                           aHit->getHadr()/GeV, time, tkID, aHit->getDepth());
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: Store Hit at " << std::hex 
-			  << aHit->getUnitID() << std::dec << " " 
-			  << aHit->getDepth() << " due to " << tkID 
-			  << " in time " << time << " of energy " 
-			  << aHit->getEM()/GeV << " GeV (EM) and " 
-			  << aHit->getHadr()/GeV << " GeV (Hadr)";
+                          << aHit->getUnitID() << std::dec << " " 
+                          << aHit->getDepth() << " due to " << tkID 
+                          << " in time " << time << " of energy " 
+                          << aHit->getEM()/GeV << " GeV (EM) and " 
+                          << aHit->getHadr()/GeV << " GeV (Hadr)";
 #endif
   return ok;
 }
@@ -623,8 +623,8 @@ void CaloSD::update(const BeginOfTrack * trk) {
   
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "New track: isPrimary " << trkInfo->isPrimary() 
-			  << " primary ID = " << primary 
-			  << " primary ancestor ID " << primAncestor;
+                          << " primary ID = " << primary 
+                          << " primary ancestor ID " << primAncestor;
 #endif
   
   // update the information if a different primary track ID 
@@ -644,7 +644,7 @@ void CaloSD::cleanHitCollection() {
 
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: collection before merging, size = " 
-			  << theHC->entries();
+                          << theHC->entries();
 #endif
   
   selIndex.reserve(theHC->entries()-cleanIndex);
@@ -656,7 +656,7 @@ void CaloSD::cleanHitCollection() {
     sort((hitvec.begin()+cleanIndex), hitvec.end(), CaloG4HitLess());
 #ifdef DebugLog
     edm::LogInfo("CaloSim") << "CaloSD::cleanHitCollection: sort hits in buffer "
-			    << "starting from element = " << cleanIndex;
+                            << "starting from element = " << cleanIndex;
     for (unsigned int i = 0; i<hitvec.size(); ++i) 
       edm::LogInfo("CaloSim") << i << " " << *hitvec[i];
 #endif
@@ -686,7 +686,7 @@ void CaloSD::cleanHitCollection() {
     hitvec.resize(cleanIndex+selIndex.size());
 #ifdef DebugLog
     edm::LogInfo("CaloSim") << "CaloSD::cleanHitCollection: remove the merged hits in buffer,"
-			    << " new size = " << hitvec.size();
+                            << " new size = " << hitvec.size();
     for (unsigned int i = 0; i<hitvec.size(); ++i) 
       edm::LogInfo("CaloSim") << i << " " << *hitvec[i];
 #endif
@@ -698,8 +698,8 @@ void CaloSD::cleanHitCollection() {
 
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: collection after merging, size= " << theHC->entries()
-			  << " Size of reusehit= " << reusehit.size()
-			  << "\n      starting hit selection from index = " << cleanIndex;
+                          << " Size of reusehit= " << reusehit.size()
+                          << "\n      starting hit selection from index = " << cleanIndex;
 #endif
   
   int addhit = 0;
@@ -727,8 +727,8 @@ void CaloSD::cleanHitCollection() {
 
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: Size of reusehit after selection = " 
-			  << reusehit.size() << " Number of added hit = " 
-			  << addhit;
+                          << reusehit.size() << " Number of added hit = " 
+                          << addhit;
 #endif
   if (useMap) {
     if ( addhit>0 ) {
@@ -748,7 +748,7 @@ void CaloSD::cleanHitCollection() {
 
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: hit collection after selection, size = "
-			  << theHC->entries();
+                          << theHC->entries();
   theHC->PrintAllHits();
 #endif
     

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -538,7 +538,26 @@ int CaloSD::getTrackID(const G4Track* aTrack) {
     primaryID = aTrack->GetTrackID();
   }
 #ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD::" << GetName() << " trackID= " << aTrack->GetTrackID()
+  edm::LogInfo("CaloSim") << "CaloSD::getTrackID for " << GetName() 
+                          << " trackID= " << aTrack->GetTrackID()
+                          << " primaryID= " << primaryID;
+#endif
+  return primaryID;
+}
+
+int CaloSD::setTrackID(const G4Step* aStep) {
+
+  int primaryID = getTrackID(aStep->GetTrack());
+  if (primaryID == 0) {
+    primaryID = aStep->GetTrack()->GetTrackID();
+  }
+
+  if (primaryID != previousID.trackID()) {
+    resetForNewPrimary(aStep);
+  }
+#ifdef DebugLog
+  edm::LogInfo("CaloSim") << "CaloSD::setTrackID for " << GetName() 
+                          << " trackID= " << aStep->GetTrack()->GetTrackID()
                           << " primaryID= " << primaryID;
 #endif
   return primaryID;
@@ -550,7 +569,8 @@ bool CaloSD::filterHit(CaloG4Hit* hit, double time) {
   double emin(eminHit);
   if (hit->getDepth() > 0) emin = eminHitD;
 #ifdef DebugLog
-  edm::LogInfo("CaloSim") << "Depth " << hit->getDepth() << " Emin = " << emin 
+  edm::LogInfo("CaloSim") << "CaloSD::filterHit(..) Depth " << hit->getDepth() 
+                          << " Emin = " << emin 
                           << " (" << eminHit << ", " << eminHitD << ")";
 #endif   
   return ((time <= tmaxHit) && (hit->getEnergyDeposit() > emin));

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -27,9 +27,9 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
         edm::ParameterSet const & p, const SimTrackManager* manager,
         float timeSliceUnit, bool ignoreTkID) : 
   SensitiveCaloDetector(name, cpv, clg, p),
-  G4VGFlashSensitiveDetector(), eminHit(0), 
-  eminHitD(0), m_trackManager(manager), currentHit(nullptr), runInit(false),
-  theHC(nullptr), ignoreTrackID(ignoreTkID), hcID(-1), timeSlice(timeSliceUnit) {
+  G4VGFlashSensitiveDetector(), eminHit(0.),currentHit(nullptr), 
+  m_trackManager(manager), theHC(nullptr), ignoreTrackID(ignoreTkID), hcID(-1), 
+  timeSlice(timeSliceUnit), eminHitD(0.) {
 
   //Parameters
   edm::ParameterSet m_CaloSD = p.getParameter<edm::ParameterSet>("CaloSD");
@@ -70,9 +70,7 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
   previousID = CaloHitID(timeSlice, ignoreTrackID);
   isParameterized = false;
   
-  primAncestor = 0;
-  cleanIndex = 0;
-  totalHits = 0;
+  primAncestor = cleanIndex = totalHits = primIDSaved = 0;
   forceSave = false;
 
   edm::LogInfo("CaloSim") << "CaloSD: Minimum energy of track for saving it " 
@@ -455,7 +453,6 @@ double CaloSD::getAttenuation(const G4Step* aStep, double birk1, double birk2, d
 
 void CaloSD::update(const BeginOfRun *) {
   initRun();
-  runInit = true;
 } 
 
 void CaloSD::update(const BeginOfEvent *) {

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -6,6 +6,7 @@
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 #include "SimDataFormats/SimHitMaker/interface/CaloSlaveSD.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
+#include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
 #include "SimG4Core/Application/interface/EventAction.h"
 
 #include "G4EventManager.hh"
@@ -26,10 +27,9 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
         edm::ParameterSet const & p, const SimTrackManager* manager,
         float timeSliceUnit, bool ignoreTkID) : 
   SensitiveCaloDetector(name, cpv, clg, p),
-  G4VGFlashSensitiveDetector(), theTrack(nullptr), preStepPoint(nullptr), eminHit(0), 
+  G4VGFlashSensitiveDetector(), eminHit(0), 
   eminHitD(0), m_trackManager(manager), currentHit(nullptr), runInit(false),
-  timeSlice(timeSliceUnit), ignoreTrackID(ignoreTkID), hcID(-1), theHC(nullptr), 
-  meanResponse(nullptr) {
+  theHC(nullptr), ignoreTrackID(ignoreTkID), hcID(-1), timeSlice(timeSliceUnit) {
 
   //Parameters
   edm::ParameterSet m_CaloSD = p.getParameter<edm::ParameterSet>("CaloSD");
@@ -52,18 +52,23 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
   correctT     = beamZ/c_light/nanosecond;
 
   SetVerboseLevel(verbn);
+  meanResponse.reset(nullptr);
   for (unsigned int k=0; k<hcn.size(); ++k) {
-    if (name == (G4String)(hcn[k])) {
+    if (name == hcn[k]) {
       if (k < eminHits.size()) eminHit = eminHits[k]*MeV;
       if (k < eminHitX.size()) eminHitD= eminHitX[k]*MeV;
       if (k < tmaxHits.size()) tmaxHit = tmaxHits[k]*ns;
-      if (k < useResMap.size() && useResMap[k] > 0) meanResponse = new CaloMeanResponse(p);
-      break;
+      if (k < useResMap.size() && useResMap[k] > 0) {
+	meanResponse.reset(new CaloMeanResponse(p));
+	break;
+      }
     }
   }
-  slave      = new CaloSlaveSD(name);
+  slave.reset(new CaloSlaveSD(name));
+
   currentID  = CaloHitID(timeSlice, ignoreTrackID);
   previousID = CaloHitID(timeSlice, ignoreTrackID);
+  isParameterized = false;
   
   primAncestor = 0;
   cleanIndex = 0;
@@ -80,102 +85,154 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
                           << "        Save hits recorded before " << tmaxHit
                           << " ns and if energy is above " << eminHit/MeV
                           << " MeV (for depth 0) or " << eminHitD/MeV
-                          << " MeV (for nonzero depths); Time Slice Unit " 
+                          << " MeV (for nonzero depths);\n"
+			  << "        Time Slice Unit " 
                           << timeSlice << " Ignore TrackID Flag " << ignoreTrackID;
 }
 
-CaloSD::~CaloSD() { 
-  delete slave; 
+CaloSD::~CaloSD()
+{
   delete theHC;
-  delete meanResponse;
 }
 
-bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
+G4bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
   
-  NaNTrap( aStep ) ;
-  
-  if (aStep == nullptr) {
-    return true;
-  } else {
-    if (getStepInfo(aStep)) {
-      if (hitExists() == false && edepositEM+edepositHAD>0.) 
-        currentHit = createNewHit();
+  NaNTrap( aStep );
+
+#ifdef DebugLog
+  edm::LogInfo("CaloSim") << "CaloSD::" << GetName()
+			  << theTrack->GetTrackID() 
+			  << " prID= " << theTrack->GetParentID() 
+			  << " Epoststep= " << theTrack->GetKineticEnergy()
+			  << " step= " << aStep->GetStepLength() << " Edep= " << aStep->GetTotalEnergyDeposit(); 
+#endif
+  // apply shower library or parameterisation
+  if(isParameterized) { 
+    if(getFromLibrary(aStep)) {
+
+      // for parameterized showers the primary track should be killed
+      aStep->GetTrack()->SetTrackStatus(fStopAndKill); 
+      auto tv  = aStep->GetSecondary();
+      auto vol = aStep->GetPreStepPoint()->GetPhysicalVolume();
+      for(auto & tk : *tv) {
+	if (tk->GetVolume() == vol) {
+	  tk->SetTrackStatus(fStopAndKill);
+	}
+      }
+      return true;
     }
   }
-  return true;
-} 
 
-bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) { 
+  // ignore steps without energy deposit
+  if(aStep->GetTotalEnergyDeposit() == 0.0) 
+    { return false; }
 
-  if (aSpot != nullptr) {   
-    theTrack = const_cast<G4Track *>(aSpot->GetOriginatorTrack()->GetPrimaryTrack());
-    G4int particleCode = theTrack->GetDefinition()->GetPDGEncoding();
+  unsigned int unitID = setDetUnitId(aStep);
+  auto const track = aStep->GetTrack();   
+  uint16_t depth = getDepth(aStep);
     
-    if (particleCode == emPDG ||
-        particleCode == epPDG ||
-        particleCode == gammaPDG ) {
-      edepositEM  = aSpot->GetEnergySpot()->GetEnergy();
-      edepositHAD = 0.;
+  double   time  = track->GetGlobalTime()/nanosecond;
+  int      primaryID = getTrackID(track);
+  currentID.setID(unitID, time, primaryID, depth);
+
+  edepositEM = edepositHAD = 0.f;
+  double energy = getEnergyDeposit(aStep);
+  if(energy > 0.0) {
+    if(G4TrackToParticleID::isGammaElectronPositron(track)) {
+      edepositEM  = energy;
+      edepositHAD = 0.f;
     } else {
-      edepositEM  = 0.;
-      edepositHAD = 0.;
+      edepositEM  = 0.f;
+      edepositHAD = energy;
     }
- 
-    if (edepositEM>0.) {
-      G4Step *      fFakeStep          = new G4Step();
-      preStepPoint                     = fFakeStep->GetPreStepPoint();
-      G4StepPoint * fFakePostStepPoint = fFakeStep->GetPostStepPoint();
-      preStepPoint->SetPosition(aSpot->GetPosition());
-      fFakePostStepPoint->SetPosition(aSpot->GetPosition());
-      
-      G4TouchableHandle fTouchableHandle   = aSpot->GetTouchableHandle();
-      preStepPoint->SetTouchableHandle(fTouchableHandle);
-      fFakeStep->SetTotalEnergyDeposit(aSpot->GetEnergySpot()->GetEnergy());
-      
-      double       time   = 0;
-      unsigned int unitID = setDetUnitId(fFakeStep);
-      int          primaryID = getTrackID(theTrack);
-      uint16_t     depth = getDepth(fFakeStep);
-
-      if (unitID > 0) {
-        currentID.setID(unitID, time, primaryID, depth);
 #ifdef DebugLog
-        LogDebug("CaloSim") << "CaloSD:: GetSpotInfo for"
-                            << " Unit 0x" << std::hex << currentID.unitID() 
-                            << std::dec << " Edeposit = " << edepositEM << " " 
-                            << edepositHAD;
+    //if(track->GetTrackID() == 8654) {
+    G4TouchableHistory* touch =(G4TouchableHistory*)(track->GetTouchable());
+    edm::LogInfo("CaloSim") << "CaloSD::" << GetName()
+			    << " PV:"   << touch->GetVolume(0)->GetName()
+			    << " PVid=" << touch->GetReplicaNumber(0)
+			    << " MVid=" << touch->GetReplicaNumber(1)
+			    << " Unit:" << std::hex << unitID << std::dec 
+			    << " Edep=" << edepositEM << " " << edepositHAD
+			    << " ID=" << track->GetTrackID()
+			    << " pID=" << track->GetParentID()
+			    << " E=" << track->GetKineticEnergy()
+                            << " S=" << aStep->GetStepLength()
+			    << " " << track->GetDefinition()->GetParticleName()
+			    << " currentID= " << currentID 
+			    << " previousID= " << previousID;
+    //}
 #endif
-        // Update if in the same detector, time-slice and for same track   
-        if (currentID == previousID) {
-	  updateHit(currentHit);
-        } else {
-          posGlobal = aSpot->GetEnergySpot()->GetPosition();
-          // Reset entry point for new primary
-          if (currentID.trackID() != previousID.trackID()) {
-            entrancePoint  = aSpot->GetPosition();
-            entranceLocal  = aSpot->GetTouchableHandle()->GetHistory()->
-                                      GetTopTransform().TransformPoint(entrancePoint);
-            incidentEnergy = theTrack->GetKineticEnergy();
-#ifdef DebugLog
-            LogDebug("CaloSim") << "CaloSD: Incident energy " 
-                                << incidentEnergy/GeV << " GeV and" 
-                                << " entrance point " << entrancePoint 
-                                << " (Global) " << entranceLocal << " (Local)";
-#endif
-          }
-
-          if (checkHit() == false) currentHit = createNewHit();
-        }
-      }
-      delete  fFakeStep;
+    if(!hitExists(aStep)) {
+      currentHit = createNewHit(aStep);
     }
     return true;
-  } 
+  }
+  return false;
+} 
+
+bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory * ) { 
+
+  edepositEM = edepositHAD = 0.f;
+  const G4Track* track = aSpot->GetOriginatorTrack()->GetPrimaryTrack();
+  if(!G4TrackToParticleID::isGammaElectronPositron(track)) { return false; }
+  double edep = aSpot->GetEnergySpot()->GetEnergy();
+  if (edep <= 0.0) { return false; }
+  edepositEM = edep;
+  G4Step fFakeStep;
+  G4StepPoint * fFakePreStepPoint  = fFakeStep.GetPreStepPoint();
+  G4StepPoint * fFakePostStepPoint = fFakeStep.GetPostStepPoint();
+  fFakePreStepPoint->SetPosition(aSpot->GetPosition());
+  fFakePostStepPoint->SetPosition(aSpot->GetPosition());
+      
+  G4TouchableHandle fTouchableHandle = aSpot->GetTouchableHandle();
+  fFakePreStepPoint->SetTouchableHandle(fTouchableHandle);
+  fFakeStep.SetTotalEnergyDeposit(edep);
+      
+  unsigned int unitID = setDetUnitId(&fFakeStep);
+
+  if (unitID > 0) {
+    double time   = 0;
+    int primaryID = getTrackID(track);
+    uint16_t depth = getDepth(&fFakeStep);
+    currentID.setID(unitID, time, primaryID, depth);
+#ifdef DebugLog
+    edm::LogInfo("CaloSim") << "CaloSD:: GetSpotInfo for"
+			    << " Unit 0x" << std::hex << currentID.unitID() 
+			    << std::dec << " Edeposit = " << edepositEM << " " 
+			    << edepositHAD;
+#endif
+    // Update if in the same detector, time-slice and for same track   
+    if (currentID == previousID) {
+      updateHit(currentHit);
+    } else {
+      posGlobal = aSpot->GetEnergySpot()->GetPosition();
+      // Reset entry point for new primary
+      if (currentID.trackID() != previousID.trackID()) {
+	entrancePoint = aSpot->GetPosition();
+	entranceLocal = aSpot->GetTouchableHandle()->GetHistory()->
+	  GetTopTransform().TransformPoint(entrancePoint);
+	incidentEnergy = track->GetKineticEnergy();
+#ifdef DebugLog
+	LogDebug("CaloSim") << "CaloSD: Incident energy " 
+			    << incidentEnergy/GeV << " GeV and" 
+			    << " entrance point " << entrancePoint 
+			    << " (Global) " << entranceLocal << " (Local)";
+#endif
+      }
+      if (!checkHit()) { currentHit = createNewHit(&fFakeStep); }
+    }
+    return true;
+  }
   return false;
 }                                   
 
-double CaloSD::getEnergyDeposit(G4Step* aStep) {
+double CaloSD::getEnergyDeposit(const G4Step* aStep) {
   return aStep->GetTotalEnergyDeposit();
+}
+
+bool CaloSD::getFromLibrary(const G4Step*) {
+  return false;
 }
 
 void CaloSD::Initialize(G4HCofThisEvent * HCE) { 
@@ -189,7 +246,9 @@ void CaloSD::Initialize(G4HCofThisEvent * HCE) {
   //------------------------------------------------------------
   theHC = new CaloG4HitCollection(GetName(), collectionName[0]);
   
-  if (hcID<0) hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
+  if (hcID<0) { 
+    hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]); 
+  }
   HCE->AddHitsCollection(hcID, theHC);
 }
 
@@ -202,7 +261,6 @@ void CaloSD::EndOfEvent(G4HCofThisEvent* ) {
   edm::LogInfo("CaloSim") << "CaloSD: EndofEvent entered with " << theHC->entries()
                           << " entries";
 #endif
-  //  TimeMe("CaloSD:sortAndMergeHits",false);
 }
 
 void CaloSD::clear() {} 
@@ -217,77 +275,19 @@ void CaloSD::PrintAll() {
 } 
 
 void CaloSD::fillHits(edm::PCaloHitContainer& cc, const std::string& hname) {
-  if (slave->name() == hname) { cc=slave->hits(); }
-  slave->Clean();
+  if (slave.get()->name() == hname) { cc=slave.get()->hits(); }
+  slave.get()->Clean();
 }
 
-bool CaloSD::getStepInfo(G4Step* aStep) {  
-
-  preStepPoint = aStep->GetPreStepPoint(); 
-  theTrack     = aStep->GetTrack();   
-  
-  double       time  = (aStep->GetPostStepPoint()->GetGlobalTime())/nanosecond;
-  unsigned int unitID= setDetUnitId(aStep);
-  uint16_t     depth = getDepth(aStep);
-  int          primaryID = getTrackID(theTrack);
-  
-  bool flag = (unitID > 0);
-  if (flag) {
-    currentID.setID(unitID, time, primaryID, depth);
-#ifdef DebugLog
-    G4TouchableHistory* touch =(G4TouchableHistory*)(theTrack->GetTouchable());
-    edm::LogInfo("CaloSim") << "CaloSD:: GetStepInfo for"
-			    << " PV "     << touch->GetVolume(0)->GetName()
-			    << " PVid = " << touch->GetReplicaNumber(0)
-			    << " MVid = " << touch->GetReplicaNumber(1)
-			    << " Unit   " << currentID.unitID() 
-			    << " Edeposit = " << edepositEM << " " << edepositHAD;
-  } else {
-    G4TouchableHistory* touch =(G4TouchableHistory*)(theTrack->GetTouchable());
-    edm::LogInfo("CaloSim") << "CaloSD:: GetStepInfo for"
-			    << " PV "     << touch->GetVolume(0)->GetName()
-			    << " PVid = " << touch->GetReplicaNumber(0)
-			    << " MVid = " << touch->GetReplicaNumber(1)
-			    << " Unit   " << std::hex << unitID << std::dec 
-			    << " Edeposit = " << edepositEM << " " << edepositHAD;
-#endif
-  }
-  
-  G4int particleCode = theTrack->GetDefinition()->GetPDGEncoding();
-  if (particleCode == emPDG ||
-      particleCode == epPDG ||
-      particleCode == gammaPDG ) {
-    edepositEM  = getEnergyDeposit(aStep);
-    edepositHAD = 0.;
-  } else {
-    edepositEM  = 0.;
-    edepositHAD = getEnergyDeposit(aStep);
-  }
-
-  return flag;
+G4ThreeVector CaloSD::setToLocal(const G4ThreeVector& global, const G4VTouchable* touch) const {
+  return touch->GetHistory()->GetTopTransform().TransformPoint(global);
 }
 
-G4ThreeVector CaloSD::setToLocal(const G4ThreeVector& global, const G4VTouchable* touch) {
-
-  G4ThreeVector localPoint = touch->GetHistory()->GetTopTransform().TransformPoint(global);
-  
-  return localPoint;  
+G4ThreeVector CaloSD::setToGlobal(const G4ThreeVector& local, const G4VTouchable* touch) const {
+  return touch->GetHistory()->GetTopTransform().Inverse().TransformPoint(local);
 }
 
-G4ThreeVector CaloSD::setToGlobal(const G4ThreeVector& local, const G4VTouchable* touch) {
-
-  G4ThreeVector globalPoint = touch->GetHistory()->GetTopTransform().Inverse().TransformPoint(local);
-  
-  return globalPoint;  
-}
-
-G4bool CaloSD::hitExists() {
-#ifdef DebugLog
-  if (currentID.trackID()<1)
-    edm::LogWarning("CaloSim") << "***** CaloSD error: primaryID = " 
-                               << currentID.trackID()
-                               << " maybe detector name changed";
-#endif  
+bool CaloSD::hitExists(const G4Step* aStep) {
   // Update if in the same detector, time-slice and for same track   
   if (currentID == previousID) {
     updateHit(currentHit);
@@ -295,14 +295,13 @@ G4bool CaloSD::hitExists() {
   }
   
   // Reset entry point for new primary
-  posGlobal = preStepPoint->GetPosition();
   if (currentID.trackID() != previousID.trackID()) { 
-    resetForNewPrimary(posGlobal, preStepPoint->GetKineticEnergy());
+    resetForNewPrimary(aStep);
   }
   return checkHit();
 }
 
-G4bool CaloSD::checkHit() {  
+bool CaloSD::checkHit() {  
   //look in the HitContainer whether a hit with the same ID already exists:
   bool       found = false;
   if (useMap) {
@@ -316,10 +315,11 @@ G4bool CaloSD::checkHit() {
     int  minhit= (theHC->entries()>checkHits ? theHC->entries()-checkHits : 0);
     int  maxhit= theHC->entries()-1;
     
-    for (int j=maxhit; j>minhit&&!found; --j) {
+    for (int j=maxhit; j>minhit; --j) {
       if ((*theHC)[j]->getID() == currentID) {
         currentHit = (*theHC)[j];
         found      = true;
+        break;
       }
     }          
   }
@@ -334,32 +334,28 @@ G4bool CaloSD::checkHit() {
 
 int CaloSD::getNumberOfHits() { return theHC->entries(); }
 
-CaloG4Hit* CaloSD::createNewHit() {
+CaloG4Hit* CaloSD::createNewHit(const G4Step* aStep) {
+
+  auto const theTrack = aStep->GetTrack();
 #ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD::CreateNewHit for"
-			  << " Unit " << currentID.unitID() 
+  edm::LogInfo("CaloSim") << "CaloSD::CreateNewHit " << getNumberOfHits()
+			  << " for " << GetName()
+			  << " Unit:" << currentID.unitID() 
 			  << " " << currentID.depth()
-			  << " Edeposit = " << edepositEM << " " << edepositHAD;
-  edm::LogInfo("CaloSim") << " primary "    << currentID.trackID()
-			  << " time slice " << currentID.timeSliceID()
-			  << " For Track  " << theTrack->GetTrackID()
-			  << " which is a " <<theTrack->GetDefinition()->GetParticleName()
-			  << " of energy "  << theTrack->GetKineticEnergy()/GeV
-			  << " " << theTrack->GetMomentum().mag()/GeV
-			  << " daughter of part. " << theTrack->GetParentID()
-			  << " and created by " ;
-  
-  if (theTrack->GetCreatorProcess()!=NULL)
-    edm::LogInfo("CaloSim") << theTrack->GetCreatorProcess()->GetProcessName();
-  else 
-    edm::LogInfo("CaloSim") << "NO process";
+			  << " Edep= " << edepositEM << " " << edepositHAD
+			  << " primaryID= "    << currentID.trackID()
+			  << " timeSlice= " << currentID.timeSliceID()
+			  << " ID= " << theTrack->GetTrackID()
+			  << " " <<theTrack->GetDefinition()->GetParticleName()
+			  << " E(GeV)= "  << theTrack->GetKineticEnergy()/GeV
+			  << " parentID= " << theTrack->GetParentID();
 #endif  
   
   CaloG4Hit* aHit;
   if (!reusehit.empty()) {
     aHit = reusehit[0];
-    aHit->setEM(0.);
-    aHit->setHadr(0.);
+    aHit->setEM(0.f);
+    aHit->setHadr(0.f);
     reusehit.erase(reusehit.begin());
   } else {
     aHit = new CaloG4Hit;
@@ -377,17 +373,16 @@ CaloG4Hit* CaloSD::createNewHit() {
   if (currentID.trackID() == primIDSaved) { // The track is saved; nothing to be done
   } else if (currentID.trackID() == theTrack->GetTrackID()) {
     etrack= theTrack->GetKineticEnergy();
-    //edm::LogInfo("CaloSim") << "CaloSD: set save the track " << currentID.trackID()
-    //      << " etrack " << etrack << " eCut " << energyCut << " flag " << forceSave;
+#ifdef DebugLog
+    edm::LogInfo("CaloSim") << "CaloSD: set save the track " << currentID.trackID()
+			    << " etrack " << etrack << " eCut " << energyCut 
+			    << " force: " << forceSave 
+			    << " save: " << (etrack >= energyCut || forceSave);
+#endif
     if (etrack >= energyCut || forceSave) {
       TrackInformation* trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
       trkInfo->storeTrack(true);
       trkInfo->putInHistory();
-      //      trkInfo->setAncestor();
-#ifdef DebugLog
-      edm::LogInfo("CaloSim") << "CaloSD: set save the track " 
-			      << currentID.trackID() << " with Hit";
-#endif
     }
   } else {
     TrackWithHistory * trkh = tkMap[currentID.trackID()];
@@ -407,28 +402,28 @@ CaloG4Hit* CaloSD::createNewHit() {
     }
   }
   primIDSaved = currentID.trackID();
-  if (useMap) totalHits++;
+  if (useMap) ++totalHits;
   return aHit;
 }  
 
 void CaloSD::updateHit(CaloG4Hit* aHit) {
-  if (edepositEM+edepositHAD != 0) {
-    aHit->addEnergyDeposit(edepositEM,edepositHAD);
+
+  aHit->addEnergyDeposit(edepositEM,edepositHAD);
 #ifdef DebugLog
-    edm::LogInfo("CaloSim") << "CaloSD: Add energy deposit in " << currentID 
-			    << " em " << edepositEM/MeV << " hadronic " 
-			    << edepositHAD/MeV << " MeV"; 
+  edm::LogInfo("CaloSim") << "CaloSD: Add energy deposit in " << currentID 
+			  << " em " << edepositEM/MeV << " hadronic " 
+			  << edepositHAD/MeV << " MeV"; 
 #endif
-  }
 
   // buffer for next steps:
   previousID = currentID;
 }
 
-void CaloSD::resetForNewPrimary(const G4ThreeVector& point, double energy) { 
-  entrancePoint  = point;
+void CaloSD::resetForNewPrimary(const G4Step* aStep) { 
+  auto const preStepPoint = aStep->GetPreStepPoint();
+  entrancePoint  = preStepPoint->GetPosition();
   entranceLocal  = setToLocal(entrancePoint, preStepPoint->GetTouchable());
-  incidentEnergy = energy;
+  incidentEnergy = preStepPoint->GetKineticEnergy();
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: Incident energy " << incidentEnergy/GeV 
 			  << " GeV and" << " entrance point " << entrancePoint 
@@ -436,14 +431,14 @@ void CaloSD::resetForNewPrimary(const G4ThreeVector& point, double energy) {
 #endif
 }
 
-double CaloSD::getAttenuation(const G4Step* aStep, double birk1, double birk2, double birk3) {
+double CaloSD::getAttenuation(const G4Step* aStep, double birk1, double birk2, double birk3) const {
   double weight = 1.;
   double charge = aStep->GetPreStepPoint()->GetCharge();
+  double length = aStep->GetStepLength();
 
-  if (charge != 0. && aStep->GetStepLength() > 0) {
-    G4Material* mat = aStep->GetPreStepPoint()->GetMaterial();
-    double density = mat->GetDensity();
-    double dedx    = aStep->GetTotalEnergyDeposit()/aStep->GetStepLength();
+  if (charge != 0. && length > 0.) {
+    double density = aStep->GetPreStepPoint()->GetMaterial()->GetDensity();
+    double dedx    = aStep->GetTotalEnergyDeposit()/length;
     double rkb     = birk1/density;
     double c       = birk2*rkb*rkb;
     if (std::abs(charge) >= 2.) rkb /= birk3; // based on alpha particle data
@@ -459,15 +454,6 @@ double CaloSD::getAttenuation(const G4Step* aStep, double birk1, double birk2, d
 }
 
 void CaloSD::update(const BeginOfRun *) {
-  G4ParticleTable * theParticleTable = G4ParticleTable::GetParticleTable();
-  G4String particleName;
-  emPDG = theParticleTable->FindParticle(particleName="e-")->GetPDGEncoding();
-  epPDG = theParticleTable->FindParticle(particleName="e+")->GetPDGEncoding();
-  gammaPDG = theParticleTable->FindParticle(particleName="gamma")->GetPDGEncoding();
-#ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD: Particle code for e- = " << emPDG
-			  << " for e+ = " << epPDG << " for gamma = " << gammaPDG;
-#endif
   initRun();
   runInit = true;
 } 
@@ -510,7 +496,7 @@ void CaloSD::update(const ::EndOfEvent * ) {
   int count = 0, wrong = 0;
   bool ok;
   
-  slave->ReserveMemory(theHC->entries());
+  slave.get()->ReserveMemory(theHC->entries());
 
   for (int i=0; i<theHC->entries(); ++i) {
     ok = saveHit((*theHC)[i]);
@@ -535,34 +521,29 @@ void CaloSD::clearHits() {
   previousID.reset();
   primIDSaved = -99;
 #ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD: Clears hit vector for " << GetName() << " " << slave;
+  edm::LogInfo("CaloSim") << "CaloSD: Clears hit vector for " << GetName() 
+			  << " and initialise slave: " << slave;
 #endif
-  slave->Initialize();
-#ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD: Initialises slave SD for " << GetName();
-#endif
+  slave.get()->Initialize();
 }
 
 void CaloSD::initRun() {}
 
 int CaloSD::getTrackID(const G4Track* aTrack) {
+
   int primaryID = 0;
   forceSave = false;
   TrackInformation* trkInfo=(TrackInformation *)(aTrack->GetUserInformation());
   if (trkInfo) {
-    primaryID = trkInfo->getIDonCaloSurface(); 
-#ifdef DebugLog
-    edm::LogInfo("CaloSim") << "CaloSD: hit update from track Id on Calo Surface " 
-			    << trkInfo->getIDonCaloSurface();
-#endif   
+    int id = trkInfo->getIDonCaloSurface();
+    if(id > 0) { primaryID = id; } 
   } else {
     primaryID = aTrack->GetTrackID();
-#ifdef DebugLog
-    edm::LogWarning("CaloSim") << "CaloSD: Problem with primaryID **** set by "
-                               << "force to TkID **** " << primaryID << " in "
-                               << preStepPoint->GetTouchable()->GetVolume(0)->GetName();
-#endif
   }
+#ifdef DebugLog
+  edm::LogInfo("CaloSim") << "CaloSD::" << GetName() << " trackID= " << aTrack->GetTrackID()
+			  << " primaryID= " << primaryID;
+#endif
   return primaryID;
 }
 
@@ -579,12 +560,12 @@ bool CaloSD::filterHit(CaloG4Hit* hit, double time) {
 }
 
 double CaloSD::getResponseWt(const G4Track* aTrack) {
-  if (meanResponse) {
+  double wt = 1.0;
+  if (meanResponse.get()) {
     TrackInformation * trkInfo = (TrackInformation *)(aTrack->GetUserInformation());
-    return meanResponse->getWeight(trkInfo->genParticlePID(), trkInfo->genParticleP());
-  } else {
-    return 1;
+    wt = meanResponse.get()->getWeight(trkInfo->genParticlePID(), trkInfo->genParticleP());
   }
+  return wt;
 }
 
 void CaloSD::storeHit(CaloG4Hit* hit) {
@@ -613,7 +594,6 @@ bool CaloSD::saveHit(CaloG4Hit* aHit) {
     tkID = aHit->getTrackID();
     ok = false;
   }
-  //  edm::LogInfo("CaloSim") << "CalosD: Track ID " << aHit->getTrackID() << " changed to " << tkID << " by SimTrackManager" << " Status " << ok;
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CalosD: Track ID " << aHit->getTrackID() 
 			  << " changed to " << tkID << " by SimTrackManager"
@@ -621,8 +601,8 @@ bool CaloSD::saveHit(CaloG4Hit* aHit) {
 #endif
   double time = aHit->getTimeSlice();
   if (corrTOFBeam) time += correctT;
-  slave->processHits(aHit->getUnitID(), aHit->getEM()/GeV, 
-                     aHit->getHadr()/GeV, time, tkID, aHit->getDepth());
+  slave.get()->processHits(aHit->getUnitID(), aHit->getEM()/GeV, 
+			   aHit->getHadr()/GeV, time, tkID, aHit->getDepth());
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: Store Hit at " << std::hex 
 			  << aHit->getUnitID() << std::dec << " " 
@@ -663,7 +643,8 @@ void CaloSD::cleanHitCollection() {
   std::vector<CaloG4Hit*>* theCollection = theHC->GetVector();
 
 #ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD: collection before merging, size = " << theHC->entries();
+  edm::LogInfo("CaloSim") << "CaloSD: collection before merging, size = " 
+			  << theHC->entries();
 #endif
   
   selIndex.reserve(theHC->entries()-cleanIndex);
@@ -716,16 +697,12 @@ void CaloSD::cleanHitCollection() {
   }
 
 #ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD: collection after merging, size = " << theHC->entries();
-#endif
-
-  int addhit = 0;
-
-#ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD: Size of reusehit after merge = " << reusehit.size();
-  edm::LogInfo("CaloSim") << "CaloSD: Starting hit selection from index = " << cleanIndex;
+  edm::LogInfo("CaloSim") << "CaloSD: collection after merging, size= " << theHC->entries()
+			  << " Size of reusehit= " << reusehit.size()
+			  << "\n      starting hit selection from index = " << cleanIndex;
 #endif
   
+  int addhit = 0;
   selIndex.reserve(theCollection->size()-cleanIndex);
   for (unsigned int i = cleanIndex; i<theCollection->size(); ++i) {   
     CaloG4Hit* aHit((*theCollection)[i]);

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -547,9 +547,11 @@ int CaloSD::getTrackID(const G4Track* aTrack) {
 
 int CaloSD::setTrackID(const G4Step* aStep) {
 
-  int primaryID = getTrackID(aStep->GetTrack());
+  auto const theTrack = aStep->GetTrack();
+  TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
+  int primaryID = trkInfo->getIDonCaloSurface();
   if (primaryID == 0) {
-    primaryID = aStep->GetTrack()->GetTrackID();
+    primaryID = theTrack->GetTrackID();
   }
 
   if (primaryID != previousID.trackID()) {

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -72,7 +72,7 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
   
   primAncestor = cleanIndex = totalHits = primIDSaved = 0;
   forceSave = false;
-
+  
   edm::LogInfo("CaloSim") << "CaloSD: Minimum energy of track for saving it " 
                           << energyCut/GeV  << " GeV" << "\n"
                           << "        Use of HitID Map " << useMap << "\n"
@@ -338,7 +338,7 @@ CaloG4Hit* CaloSD::createNewHit(const G4Step* aStep) {
 
   auto const theTrack = aStep->GetTrack();
 #ifdef DebugLog
-  if(GetName() == "EcalHitsES")
+  if(GetName() == "CastorFI")
   edm::LogInfo("CaloSim") << "CaloSD::CreateNewHit " << getNumberOfHits()
                           << " for " << GetName()
                           << " Unit:" << currentID.unitID() 
@@ -412,8 +412,8 @@ void CaloSD::updateHit(CaloG4Hit* aHit) {
   aHit->addEnergyDeposit(edepositEM,edepositHAD);
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD:" << GetName() << " Add energy deposit in " 
-			  << currentID << " Edep_em(MeV)= " 
-			  << edepositEM << " Edep_had(MeV)= " << edepositHAD; 
+                          << currentID << " Edep_em(MeV)= " 
+                          << edepositEM << " Edep_had(MeV)= " << edepositHAD; 
 #endif
 
   // buffer for next steps:

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -206,14 +206,13 @@ double ECalSD::getEnergyDeposit(const G4Step * aStep) {
   edep *= weight*wt1;
   // Russian Roulette
   double wt2 = theTrack->GetWeight();
-#ifdef EDM_ML_DEBUG
-  if(theTrack->GetTrackID() == 37 || theTrack->GetTrackID() == 8654) {
+  //#ifdef EDM_ML_DEBUG
+  if(theTrack->GetTrackID() == 82946)
   edm::LogInfo("EcalSim") << lv->GetName()
                           << " Light Collection Efficiency " << weight << ":"
                           << wt1 << " wt2= " << wt2
                           << " Weighted Energy Deposit " << edep/MeV << " MeV";
-  }
-#endif
+  //#endif
   if(wt2 > 0.0) { edep *= wt2; }
   return edep; 
 }

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -167,95 +167,59 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
 }
 
 ECalSD::~ECalSD() {
-  if (numberingScheme) delete numberingScheme;
+  delete numberingScheme;
 }
 
-double ECalSD::getEnergyDeposit(G4Step * aStep) {
-  
-  if (aStep == nullptr) {
-    return 0;
-  } else {
-    preStepPoint = aStep->GetPreStepPoint();
-    theTrack     = aStep->GetTrack();
-    double wt2   = theTrack->GetWeight();
-    const G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
+double ECalSD::getEnergyDeposit(const G4Step * aStep) {
 
-    // take into account light collection curve for crystals
-    double weight = 1.;
-    if (suppressHeavy) {
-      TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
-      if (trkInfo) {
-        int pdg = theTrack->GetDefinition()->GetPDGEncoding();
-        if (!(trkInfo->isPrimary())) { // Only secondary particles
-          double ke = theTrack->GetKineticEnergy()/MeV;
-          if (((pdg/1000000000 == 1 && ((pdg/10000)%100) > 0 &&
-                ((pdg/10)%100) > 0)) && (ke<kmaxIon)) weight = 0;
-          if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
-          if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
-#ifdef EDM_ML_DEBUG
-          if (weight == 0) 
-            edm::LogInfo("EcalSim") << "Ignore Track " << theTrack->GetTrackID()
-                                    << " Type " << theTrack->GetDefinition()->GetParticleName()
-                                    << " Kinetic Energy " << ke << " MeV";
-#endif
-        }
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
+  const G4Track* theTrack = aStep->GetTrack();
+  double edep = aStep->GetTotalEnergyDeposit();
+
+  // take into account light collection curve for crystals
+  double weight = 1.;
+  if (suppressHeavy) {
+    TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
+    if (trkInfo) {
+      int pdg = theTrack->GetDefinition()->GetPDGEncoding();
+      if (!(trkInfo->isPrimary())) { // Only secondary particles
+	double ke = theTrack->GetKineticEnergy();
+	if (((pdg/1000000000 == 1 && ((pdg/10000)%100) > 0 &&
+	      ((pdg/10)%100) > 0)) && (ke<kmaxIon)) weight = 0;
+	if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
+	if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
       }
     }
-    const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-    if (useWeight && !any(noWeight,lv)) {
-      weight *= curve_LY(aStep);
-      if (useBirk) {
-        if (useBirkL3) weight *= getBirkL3(aStep);
-        else           weight *= getAttenuation(aStep, birk1, birk2, birk3);
-      }
+  }
+  const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+  double wt1 = 1.0;
+  if (useWeight && !any(noWeight,lv)) {
+    weight *= curve_LY(lv);
+    if (useBirk) {
+      if (useBirkL3) weight *= getBirkL3(aStep);
+      else           weight *= getAttenuation(aStep, birk1, birk2, birk3);
     }
-    double wt1  = getResponseWt(theTrack);
-    double edep = aStep->GetTotalEnergyDeposit()*weight*wt1;
-    /*
-    if(wt2 != 1.0) { 
-      edm::LogInfo("EcalSim") << "ECalSD:: " << nameVolume
-                              <<" LightWeight= " <<weight << " wt1= " <<wt1
-                              << "  wt2= " << wt2 << "  "
-                              << " Weighted Energy Deposit " << edep/MeV
-                              << " MeV";
-      const G4VProcess* pr = theTrack->GetCreatorProcess();
-      if (pr) 
-        edm::LogInfo("EcalSim") << theTrack->GetDefinition()->GetParticleName()
-                                << " " << theTrack->GetKineticEnergy()
-                                << " Id=" << theTrack->GetTrackID()
-                                << " IdP=" << theTrack->GetParentID()
-                                << " from  " << pr->GetProcessName();
-      else
-        edm::LogInfo("EcalSim") << theTrack->GetDefinition()->GetParticleName()
-                                << " " << theTrack->GetKineticEnergy()
-                                << " Id=" << theTrack->GetTrackID()
-                                << " IdP=" << theTrack->GetParentID();
-    }
-    */
-    if(wt2 > 0.0) { edep *= wt2; }
+    wt1 = getResponseWt(theTrack);
+  }
+  edep *= weight*wt1;
+  // Russian Roulette
+  double wt2 = theTrack->GetWeight();
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("EcalSim") << "ECalSD:: " << nameVolume
-                            << " Light Collection Efficiency " << weight << ":"
-                            << wt1 << " Weighted Energy Deposit " << edep/MeV 
-                            << " MeV";
+  if(theTrack->GetTrackID() == 37 || theTrack->GetTrackID() == 8654) {
+  edm::LogInfo("EcalSim") << lv->GetName()
+			  << " Light Collection Efficiency " << weight << ":"
+			  << wt1 << " wt2= " << wt2
+			  << " Weighted Energy Deposit " << edep/MeV << " MeV";
+  }
 #endif
-    return edep;
-  } 
+  if(wt2 > 0.0) { edep *= wt2; }
+  return edep; 
 }
 
 int ECalSD::getTrackID(const G4Track* aTrack) {
 
   int  primaryID(0);
-  bool flag(false);
-  if (storeTrack) {
-    const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-    if (any(useDepth1,lv)) {
-      flag = true;
-    } else if (any(useDepth2,lv)) {
-      flag = true;
-    }
-  }
-  if (flag) {
+  if (storeTrack && depth > 0) {
     forceSave = true;
     primaryID = aTrack->GetTrackID();
   } else {
@@ -265,17 +229,25 @@ int ECalSD::getTrackID(const G4Track* aTrack) {
 }
 
 uint16_t ECalSD::getDepth(const G4Step * aStep) {
+
+  // this method should be called first at a step
   const G4StepPoint* hitPoint = aStep->GetPreStepPoint();
+  currentLocalPoint = setToLocal(hitPoint->GetPosition(), hitPoint->GetTouchable());
   const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-  uint16_t depth  = any(useDepth1,lv) ? 1 : (any(useDepth2,lv) ? 2 : 0);
+
+  auto ite = xtalLMap.find(lv);
+  crystalLength = (ite == xtalLMap.end()) ? 230.0 : std::abs(ite->second);
+  crystalDepth = (ite == xtalLMap.end()) 
+    ? 0.0 : (std::abs(0.5*(ite->second)+currentLocalPoint.z()));
+  depth = any(useDepth1,lv) ? 1 : (any(useDepth2,lv) ? 2 : 0);
+
   if (storeRL) {
-    auto ite        = xtalLMap.find(lv);
     uint16_t depth1 = (ite == xtalLMap.end()) ? 0 : (((ite->second) >= 0) ? 0 :
                                                      PCaloHit::kEcalDepthRefz);
-    uint16_t depth2 = getRadiationLength(aStep);
+    uint16_t depth2 = getRadiationLength(hitPoint, lv);
     depth          |= (((depth2&PCaloHit::kEcalDepthMask) << PCaloHit::kEcalDepthOffset) | depth1);
   } else if (storeLayerTimeSim) {
-    uint16_t depth2 = getLayerIDForTimeSim(aStep);
+    uint16_t depth2 = getLayerIDForTimeSim();
     depth          |= ((depth2&PCaloHit::kEcalDepthMask) << PCaloHit::kEcalDepthOffset);
   }
 #ifdef EDM_ML_DEBUG
@@ -286,63 +258,41 @@ uint16_t ECalSD::getDepth(const G4Step * aStep) {
   return depth;
 }
 
-uint16_t ECalSD::getRadiationLength(const G4Step * aStep) {
+uint16_t ECalSD::getRadiationLength(const G4StepPoint* hitPoint, const G4LogicalVolume* lv) {
   
   uint16_t thisX0 = 0;
-  if (aStep != nullptr) {
-    const G4StepPoint* hitPoint = aStep->GetPreStepPoint();
-    const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-#ifdef EDM_ML_DEBUG
-    edm::LogInfo("EcalSim") << lv->GetName() << " useWight " << useWeight;
-#endif
-    if (useWeight) {
-      const G4ThreeVector  localPoint = setToLocal(hitPoint->GetPosition(),
-                                                   hitPoint->GetTouchable());
-      double radl     = preStepPoint->GetMaterial()->GetRadlen();
-      double depth    = crystalDepth(lv,localPoint);
-      thisX0 = (uint16_t)floor(scaleRL*depth/radl);
+  if (useWeight) {
+    double radl = hitPoint->GetMaterial()->GetRadlen();
+    thisX0 = (uint16_t)floor(scaleRL*crystalDepth/radl);
 #ifdef plotDebug
-      std::string lvname = lv->GetName();
-      int k1 = (lvname.find("EFRY")!=std::string::npos) ? 2 : 0;
-      int k2 = (lvname.find("refl")!=std::string::npos) ? 1 : 0;
-      int kk = k1+k2;
-      double rz = (k1 == 0) ? (hitPoint->GetPosition()).rho() : 
-        std::abs((hitPoint->GetPosition()).z());
-      edm::LogVerbatim("EcalSim") << lvname << " # " << k1 << ":" << k2 << ":" 
-                                  << kk << " rz " << rz << " D " << thisX0;
-      g2L_[kk]->Fill(rz,thisX0);
+    const std::string& lvname = lv->GetName();
+    int k1 = (lvname.find("EFRY")!=std::string::npos) ? 2 : 0;
+    int k2 = (lvname.find("refl")!=std::string::npos) ? 1 : 0;
+    int kk = k1+k2;
+    double rz = (k1 == 0) ? (hitPoint->GetPosition()).rho() : 
+      std::abs((hitPoint->GetPosition()).z());
+    edm::LogVerbatim("EcalSim") << lvname << " # " << k1 << ":" << k2 << ":" 
+				<< kk << " rz " << rz << " D " << thisX0;
+    g2L_[kk]->Fill(rz,thisX0);
 #endif
 #ifdef EDM_ML_DEBUG
-      double crlength = crystalLength(lv);
-      edm::LogVerbatim("EcalSim") << lv->GetName() << " Global " 
-                                  << hitPoint->GetPosition() << ":" 
-                                  << (hitPoint->GetPosition()).rho() 
-                                  << " Local " << localPoint 
-                                  << " Crystal Length " << crlength 
-                                  << " Radl " << radl << " DetZ " << detz 
-                                  << " Index " << thisX0 
-                                  << " : " << getLayerIDForTimeSim(aStep);
+    edm::LogVerbatim("EcalSim") << lv->GetName() << " Global " 
+				<< hitPoint->GetPosition() << ":" 
+				<< (hitPoint->GetPosition()).rho() 
+				<< " Local " << localPoint 
+				<< " Crystal Length " << crlength 
+				<< " Radl " << radl << " DetZ " << detz 
+				<< " Index " << thisX0 
+				<< " : " << getLayerIDForTimeSim();
 #endif
-    } 
-  }
+  } 
   return thisX0;
 }
 
-uint16_t ECalSD::getLayerIDForTimeSim(const G4Step * aStep) 
+uint16_t ECalSD::getLayerIDForTimeSim() 
 {
-  float    layerSize = 1*cm; //layer size in cm
-  if (!isEB && !isEE)  return 0;
-
-  if (aStep != nullptr ) {
-    const G4StepPoint* hitPoint = aStep->GetPreStepPoint();
-    const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-    const G4ThreeVector  localPoint = setToLocal(hitPoint->GetPosition(),
-                                                 hitPoint->GetTouchable());
-    double detz     = crystalDepth(lv,localPoint);
-    if (detz<0) detz= 0;
-    return (int)detz/layerSize;
-  }
-  return 0;
+  const double invLayerSize = 0.1; //layer size in 1/mm
+  return (int)crystalDepth*invLayerSize;
 }
 
 uint32_t ECalSD::setDetUnitId(const G4Step * aStep) { 
@@ -482,58 +432,34 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
 #endif
 }
 
-double ECalSD::curve_LY(const G4Step* aStep) {
-
-  const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+double ECalSD::curve_LY(const G4LogicalVolume* lv) {
 
   double weight = 1.;
-  const G4ThreeVector localPoint = setToLocal(preStepPoint->GetPosition(),
-                                              preStepPoint->GetTouchable());
-
-  double crlength = crystalLength(lv);
-  double depth    = crystalDepth(lv,localPoint);
-
   if (ageingWithSlopeLY) {
     //position along the crystal in mm from 0 to 230 (in EB)
-    if (depth >= -0.1 || depth <= crlength+0.1)
-      weight = ageing.calcLightCollectionEfficiencyWeighted(currentID.unitID(), depth/crlength);
+    if (crystalDepth >= -0.1 || crystalDepth <= crystalLength+0.1)
+      weight = ageing.calcLightCollectionEfficiencyWeighted(currentID.unitID(), 
+							    crystalDepth/crystalLength);
   } else {
-    double dapd = crlength - depth;
-    if (dapd >= -0.1 || dapd <= crlength+0.1) {
+    double dapd = crystalLength - crystalDepth;
+    if (dapd >= -0.1 || dapd <= crystalLength+0.1) {
       if (dapd <= 100.)
         weight = 1.0 + slopeLY - dapd * 0.01 * slopeLY;
     } else {
       edm::LogWarning("EcalSim") << "ECalSD: light coll curve : wrong distance "
                                  << "to APD " << dapd << " crlength = " 
-                                 << crlength <<" crystal name = " <<lv->GetName()
-                                 << " z of localPoint = " << localPoint.z() 
+                                 << crystalLength <<" crystal name = " <<lv->GetName()
+                                 << " z of localPoint = " << currentLocalPoint.z() 
                                  << " take weight = " << weight;
     }
   }
   return weight;
 }
 
-double ECalSD::crystalLength(const G4LogicalVolume* lv) {
-
-  auto ite = xtalLMap.find(lv);
-  double length = (ite == xtalLMap.end()) ? 230.0 : std::abs(ite->second);
-  return length;
-}
-
-double ECalSD::crystalDepth(const G4LogicalVolume* lv, 
-                            const G4ThreeVector& localPoint) {
-
-  auto ite = xtalLMap.find(lv);
-  double depth = (ite == xtalLMap.end()) ? 0 :
-    (std::abs(0.5*(ite->second)+localPoint.z()));
-//  (0.5*std::abs(ite->second)+localPoint.z());
-  return depth;
-}
-
 void ECalSD::getBaseNumber(const G4Step* aStep) {
 
   theBaseNumber.reset();
-  const G4VTouchable* touch = preStepPoint->GetTouchable();
+  const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   int theSize = touch->GetHistoryDepth()+1;
   if ( theBaseNumber.getCapacity() < theSize ) theBaseNumber.setSize(theSize);
   //Get name and copy numbers
@@ -552,6 +478,7 @@ void ECalSD::getBaseNumber(const G4Step* aStep) {
 double ECalSD::getBirkL3(const G4Step* aStep) {
 
   double weight = 1.;
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
   double charge = preStepPoint->GetCharge();
 
   if (charge != 0. && aStep->GetStepLength() > 0.) {
@@ -572,7 +499,6 @@ double ECalSD::getBirkL3(const G4Step* aStep) {
 #endif
   }
   return weight;
-
 }
 
 std::vector<double> ECalSD::getDDDArray(const std::string & str,

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -145,7 +145,9 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
                           << "\tDepth2 Name = " << depth2Name
                           << "\n\tstoreRL" << storeRL << ":" << scaleRL
                           << "\tstoreLayerTimeSim " << storeLayerTimeSim
-                          << "\n\ttime Granularity " << p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit") << " ns"; 
+                          << "\n\ttime Granularity " 
+                          << p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit") 
+                          << " ns"; 
   if (useWeight) initMap(name,cpv);
 #ifdef plotDebug
   edm::Service<TFileService> tfile;
@@ -183,11 +185,11 @@ double ECalSD::getEnergyDeposit(const G4Step * aStep) {
     if (trkInfo) {
       int pdg = theTrack->GetDefinition()->GetPDGEncoding();
       if (!(trkInfo->isPrimary())) { // Only secondary particles
-	double ke = theTrack->GetKineticEnergy();
-	if (((pdg/1000000000 == 1 && ((pdg/10000)%100) > 0 &&
-	      ((pdg/10)%100) > 0)) && (ke<kmaxIon)) weight = 0;
-	if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
-	if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
+        double ke = theTrack->GetKineticEnergy();
+        if (((pdg/1000000000 == 1 && ((pdg/10000)%100) > 0 &&
+              ((pdg/10)%100) > 0)) && (ke<kmaxIon)) weight = 0;
+        if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
+        if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
       }
     }
   }
@@ -207,9 +209,9 @@ double ECalSD::getEnergyDeposit(const G4Step * aStep) {
 #ifdef EDM_ML_DEBUG
   if(theTrack->GetTrackID() == 37 || theTrack->GetTrackID() == 8654) {
   edm::LogInfo("EcalSim") << lv->GetName()
-			  << " Light Collection Efficiency " << weight << ":"
-			  << wt1 << " wt2= " << wt2
-			  << " Weighted Energy Deposit " << edep/MeV << " MeV";
+                          << " Light Collection Efficiency " << weight << ":"
+                          << wt1 << " wt2= " << wt2
+                          << " Weighted Energy Deposit " << edep/MeV << " MeV";
   }
 #endif
   if(wt2 > 0.0) { edep *= wt2; }
@@ -272,18 +274,18 @@ uint16_t ECalSD::getRadiationLength(const G4StepPoint* hitPoint, const G4Logical
     double rz = (k1 == 0) ? (hitPoint->GetPosition()).rho() : 
       std::abs((hitPoint->GetPosition()).z());
     edm::LogVerbatim("EcalSim") << lvname << " # " << k1 << ":" << k2 << ":" 
-				<< kk << " rz " << rz << " D " << thisX0;
+                                << kk << " rz " << rz << " D " << thisX0;
     g2L_[kk]->Fill(rz,thisX0);
 #endif
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("EcalSim") << lv->GetName() << " Global " 
-				<< hitPoint->GetPosition() << ":" 
-				<< (hitPoint->GetPosition()).rho() 
-				<< " Local " << localPoint 
-				<< " Crystal Length " << crlength 
-				<< " Radl " << radl << " DetZ " << detz 
-				<< " Index " << thisX0 
-				<< " : " << getLayerIDForTimeSim();
+                                << hitPoint->GetPosition() << ":" 
+                                << (hitPoint->GetPosition()).rho() 
+                                << " Local " << localPoint 
+                                << " Crystal Length " << crlength 
+                                << " Radl " << radl << " DetZ " << detz 
+                                << " Index " << thisX0 
+                                << " : " << getLayerIDForTimeSim();
 #endif
   } 
   return thisX0;
@@ -439,7 +441,7 @@ double ECalSD::curve_LY(const G4LogicalVolume* lv) {
     //position along the crystal in mm from 0 to 230 (in EB)
     if (crystalDepth >= -0.1 || crystalDepth <= crystalLength+0.1)
       weight = ageing.calcLightCollectionEfficiencyWeighted(currentID.unitID(), 
-							    crystalDepth/crystalLength);
+                                                            crystalDepth/crystalLength);
   } else {
     double dapd = crystalLength - crystalDepth;
     if (dapd >= -0.1 || dapd <= crystalLength+0.1) {

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -6,8 +6,8 @@
 #include "SimG4CMS/Calo/interface/HCalSD.h"
 #include "SimG4CMS/Calo/interface/HcalTestNumberingScheme.h"
 #include "SimG4CMS/Calo/interface/HFFibreFiducial.h"
-#include "SimG4CMS/Calo/interface/HcalTestNS.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
+#include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DetectorDescription/Core/interface/DDFilter.h"
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
@@ -28,15 +28,15 @@
 #include "G4LogicalVolume.hh"
 #include "G4Step.hh"
 #include "G4Track.hh"
-#include "G4ParticleTable.hh"
-#include "G4VProcess.hh"
 
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
+#include "Randomize.hh"
 
 #include <iostream>
 #include <fstream>
 #include <iomanip>
+#include <sstream>
 
 //#define EDM_ML_DEBUG
 //#define plotDebug
@@ -47,10 +47,18 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
   CaloSD(name, cpv, clg, p, manager,
          (float)(p.getParameter<edm::ParameterSet>("HCalSD").getParameter<double>("TimeSliceUnit")),
          p.getParameter<edm::ParameterSet>("HCalSD").getParameter<bool>("IgnoreTrackID")), 
-  hcalConstants(nullptr), numberingFromDDD(nullptr), numberingScheme(nullptr), 
-  showerLibrary(nullptr), hfshower(nullptr), showerParam(nullptr), showerPMT(nullptr), 
-  showerBundle(nullptr), m_HBDarkening(nullptr), m_HEDarkening(nullptr),
-  m_HFDarkening(nullptr), hcalTestNS_(nullptr), depth_(1) {
+  hcalConstants(nullptr), m_HBDarkening(nullptr), m_HEDarkening(nullptr), isHF(false), 
+  weight_(1.0), depth_(1) {
+
+  numberingFromDDD.reset(nullptr); 
+  numberingScheme.reset(nullptr); 
+  showerLibrary.reset(nullptr); 
+  hfshower.reset(nullptr); 
+  showerParam.reset(nullptr);
+  showerPMT.reset(nullptr); 
+  showerBundle.reset(nullptr);
+  m_HFDarkening.reset(nullptr);
+  m_HcalTestNS.reset(nullptr);
 
   //static SimpleConfigurable<double> bk1(0.013, "HCalSD:BirkC1");
   //static SimpleConfigurable<double> bk2(0.0568,"HCalSD:BirkC2");
@@ -88,10 +96,7 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
 #ifdef EDM_ML_DEBUG
   LogDebug("HcalSim") << "***************************************************" 
                       << "\n"
-                      << "*                                                 *"
-                      << "\n"
                       << "* Constructing a HCalSD  with name " << name << "\n"
-                      << "*                                                 *"
                       << "\n"
                       << "***************************************************";
 #endif
@@ -113,29 +118,34 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
                           << eminHitHO << " HF: " << eminHitHF << "\n"
 			  << "Delivered luminosity for Darkening " 
 			  << deliveredLumi << " Flag (HE) " << agingFlagHE
-              << " Flag (HB) " << agingFlagHB
+			  << " Flag (HB) " << agingFlagHB
 			  << " Flag (HF) " << agingFlagHF << "\n"
 			  << "Application of Fiducial Cut " << applyFidCut
 			  << "Flag for test number|neutral density filter "
 			  << testNumber << " " << neutralDensity;
 
   HcalNumberingScheme* scheme;
-  if (testNumber || forTBH2) 
+  if (testNumber || forTBH2) {
     scheme = dynamic_cast<HcalNumberingScheme*>(new HcalTestNumberingScheme(forTBH2));
-  else 
+  } else { 
     scheme = new HcalNumberingScheme();
+  }
   setNumberingScheme(scheme);
 
+  // always call getFromLibrary() method to identify HF region
+  setParameterized(true);
+
   const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
-  std::vector<G4LogicalVolume *>::const_iterator lvcite;
+  //  std::vector<G4LogicalVolume *>::const_iterator lvcite;
   const G4LogicalVolume* lv;
   std::string attribute, value;
+
   if (useHF) {
     if (useParam) {
-      showerParam = new HFShowerParam(name, cpv, p);
+      showerParam.reset(new HFShowerParam(name, cpv, p));
     }  else {
-      if (useShowerLibrary) showerLibrary = new HFShowerLibrary(name, cpv, p);
-      hfshower  = new HFShower(name, cpv, p, 0);
+      if (useShowerLibrary) { showerLibrary.reset(new HFShowerLibrary(name, cpv, p)); }
+      hfshower.reset(new HFShower(name, cpv, p, 0));
     }
 
     // HF volume names
@@ -147,111 +157,34 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
     fv0.firstChild();
     DDsvalues_type sv0(fv0.mergedSpecifics());
     std::vector<double> temp =  getDDDArray("Levels",sv0);
-    edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute 
-                            << " = " << value << " has " << hfNames.size() 
-			    << " elements";
-    for (unsigned int i=0; i < hfNames.size(); ++i) {
+
+    unsigned int nhf = hfNames.size();
+    std::stringstream ss;
+    ss << "HCalSD: Names to be tested for " << attribute 
+       << " = " << value << " has " << nhf << " elements";
+    for (unsigned int i=0; i < nhf; ++i) {
       G4String namv = hfNames[i];
       lv            = nullptr;
-      for(lvcite=lvs->begin(); lvcite!=lvs->end(); lvcite++) 
-	if((*lvcite)->GetName()==namv) {
-	  lv = (*lvcite);
+      for(auto lvol : *lvs) {
+	if(lvol->GetName() == namv) {
+	  lv = lvol;
 	  break;
 	}
+      }
       hfLV.push_back(lv);
       int level = static_cast<int>(temp[i]);
       hfLevels.push_back(level);
-      edm::LogInfo("HcalSim") << "HCalSD:  HF[" << i << "] = " << hfNames[i]
-                              << " LV " << hfLV[i] << " at level " 
-			      << hfLevels[i];
+      ss << "\n        HF[" << i << "] = " << namv
+	 << " LV " << hfLV[i] << " at level " << hfLevels[i];
     }
+    edm::LogInfo("HcalSim") << ss.str();
   
     // HF Fibre volume names
-    value     = "HFFibre";
-    DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
-    DDFilteredView fv1(cpv,filter1);
-    fibreNames = getNames(fv1);
-    edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute 
-                            << " = " << value << ":";
-    for (unsigned int i=0; i<fibreNames.size(); ++i) {
-      G4String namv = fibreNames[i];
-      lv            = nullptr;
-      for (lvcite = lvs->begin(); lvcite != lvs->end(); ++lvcite) {
-        if ((*lvcite)->GetName() == namv) {
-          lv = (*lvcite);
-          break;
-        }
-      }
-      fibreLV.push_back(lv);
-      edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << fibreNames[i]
-                              << " LV " << fibreLV[i];
-    }
-  
-    // HF PMT volume names
-    value     = "HFPMT";
-    DDSpecificsMatchesValueFilter filter3{DDValue(attribute,value,0)};
-    DDFilteredView fv3(cpv,filter3);
-    std::vector<G4String> pmtNames = getNames(fv3);
-    edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute 
-			    << " = " << value << " have " << pmtNames.size() 
-			    << " entries";
-    for (unsigned int i=0; i<pmtNames.size(); ++i)  {
-      G4String namv = pmtNames[i];
-      lv            = nullptr;
-      for (lvcite = lvs->begin(); lvcite != lvs->end(); ++lvcite) 
-        if ((*lvcite)->GetName() == namv) {
-	  lv = (*lvcite);
-	  break;
-	}
-      pmtLV.push_back(lv);
-      edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << pmtNames[i]
-                              << " LV " << pmtLV[i];
-    }
-    if (!pmtNames.empty()) showerPMT = new HFShowerPMT (name, cpv, p);
-  
-    // HF Fibre bundles
-    value     = "HFFibreBundleStraight";
-    DDSpecificsMatchesValueFilter filter4{DDValue(attribute,value,0)};
-    DDFilteredView fv4(cpv,filter4);
-    std::vector<G4String> fibreNames = getNames(fv4);
-    edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute
-                            << " = " << value << " have " << fibreNames.size()
-                            << " entries";
-    for (unsigned int i=0; i<fibreNames.size(); ++i) {
-      G4String namv = fibreNames[i];
-      lv            = nullptr;
-      for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) 
-        if ((*lvcite)->GetName() == namv) {
-	  lv = (*lvcite);
-	  break;
-	}
-      fibre1LV.push_back(lv);
-      edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << fibreNames[i]
-                              << " LV " << fibre1LV[i];
-    }
-
-    // Geometry parameters for HF
-    value     = "HFFibreBundleConical";
-    DDSpecificsMatchesValueFilter filter5{DDValue(attribute,value,0)};
-    DDFilteredView fv5(cpv,filter5);
-    fibreNames = getNames(fv5);
-    edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute
-			    << " = " << value << " have " << fibreNames.size() 
-			    << " entries";
-    for (unsigned int i=0; i<fibreNames.size(); ++i) {
-      G4String namv = fibreNames[i];
-      lv            = nullptr;
-      for (lvcite = lvs->begin(); lvcite != lvs->end(); ++lvcite) 
-	if ((*lvcite)->GetName() == namv) {
-	  lv = (*lvcite);
-	  break;
-	}
-      fibre2LV.push_back(lv);
-      edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << fibreNames[i]
-                              << " LV " << fibre2LV[i];
-    }
-    if (!fibre1LV.empty() || !fibre2LV.empty()) 
-      showerBundle = new HFShowerFibreBundle (name, cpv, p);
+    fillLogVolumeVector(attribute, "HFFibre", cpv, fibreLV, fibreNames);
+    std::vector<G4String> tempNames;
+    fillLogVolumeVector(attribute, "HFPMT", cpv, pmtLV, tempNames);
+    fillLogVolumeVector(attribute, "HFFibreBundleStraight", cpv, fibre1LV, tempNames);
+    fillLogVolumeVector(attribute, "HFFibreBundleConical", cpv, fibre2LV, tempNames);
   }
 
   //Material list for HB/HE/HO sensitive detectors
@@ -290,20 +223,22 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
     dodet = fv2.next();
   }
 
+  std::stringstream sss;
+  for (unsigned int i=0; i<matNames.size(); ++i) {
+    if(i/10*10 == i) { sss << "\n"; }
+    sss << "  "  << matNames[i];
+  }
   edm::LogInfo("HcalSim") << "HCalSD: Material names for " << attribute 
-                          << " = " << name << ":";
-  for (unsigned int i=0; i<matNames.size(); ++i)
-    edm::LogInfo("HcalSim") << "HCalSD: (" << i << ") " << matNames[i]
-                            << " pointer " << materials[i];
+                          << " = " << name << ":" << sss.str();
 
-  mumPDG = mupPDG = 0;
-  
-  if (useLayerWt) readWeightFromFile(file);
+  if (useLayerWt) { readWeightFromFile(file); }
 
-  for (int i=0;  i<9; ++i) hit_[i] = time_[i]= dist_[i] = nullptr;
+  for (int i=0;  i<9; ++i) { hit_[i] = time_[i]= dist_[i] = nullptr; }
   hzvem = hzvhad = nullptr;
 
-  if (agingFlagHF) m_HFDarkening.reset(new HFDarkening(m_HC.getParameter<edm::ParameterSet>("HFDarkeningParameterBlock")));
+  if (agingFlagHF) {
+    m_HFDarkening.reset(new HFDarkening(m_HC.getParameter<edm::ParameterSet>("HFDarkeningParameterBlock")));
+  }
 #ifdef plotDebug
   edm::Service<TFileService> tfile;
 
@@ -341,136 +276,156 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
     }
   }
 #endif
-}
+  }
 
-HCalSD::~HCalSD() { 
+void HCalSD::fillLogVolumeVector(const std::string& attribute, const std::string& value, 
+				 const DDCompactView& cpv,
+				 std::vector<const G4LogicalVolume*>& lvvec,
+				 std::vector<G4String>& lvnames) {
 
-  if (numberingFromDDD) delete numberingFromDDD;
-  if (numberingScheme)  delete numberingScheme;
-  if (showerLibrary)    delete showerLibrary;
-  if (hfshower)         delete hfshower;
-  if (showerParam)      delete showerParam;
-  if (showerPMT)        delete showerPMT;
-  if (showerBundle)     delete showerBundle;
-  if (hcalTestNS_)      delete hcalTestNS_;
-}
+  const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
+  const G4LogicalVolume* lv;
 
-bool HCalSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute,value,0)};
+  DDFilteredView fv(cpv,filter);
+  lvnames = getNames(fv);
 
-  NaNTrap( aStep ) ;
-  
-  if (aStep == nullptr) {
-    return true;
-  } else {
-    depth_ = (aStep->GetPreStepPoint()->GetTouchable()->GetReplicaNumber(0))%10;
-    const G4LogicalVolume* lv =
-      aStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume();
-    G4String nameVolume = lv->GetName();
-    if (isItHF(aStep)) {
-      G4int parCode = aStep->GetTrack()->GetDefinition()->GetPDGEncoding();
-      double weight(1.0);
-      if (m_HFDarkening) {
-	G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
-	double r = hitPoint.perp()/CLHEP::cm;
-	double z = std::abs(hitPoint.z())/CLHEP::cm;
-	double dose_acquired = 0.;
-  if (z>=HFDarkening::lowZLimit && z <= HFDarkening::upperZLimit) {
-    unsigned int hfZLayer = (int)((z - HFDarkening::lowZLimit)/5);
-    if (hfZLayer >= HFDarkening::upperZLimit) hfZLayer = (HFDarkening::upperZLimit-1);
-	  float normalized_lumi = m_HFDarkening->int_lumi(deliveredLumi);
-    for (int i = hfZLayer; i != HFDarkening::numberOfZLayers; ++i) {
-	    dose_acquired = m_HFDarkening->dose(i,r);
-	    weight *= m_HFDarkening->degradation(normalized_lumi*dose_acquired);
-	  }
-	}
-#ifdef EDM_ML_DEBUG
-	LogDebug("HcalSim") << "HCalSD: HFLumiDarkening at r = " << r 
-			    << ", z = " << z << " Dose " << dose_acquired 
-			    << " weight " << weight;
-#endif
-      }
-      if (useParam) {
-#ifdef EDM_ML_DEBUG
-        LogDebug("HcalSim") << "HCalSD: " << getNumberOfHits()
-			    << " hits from parametrization in " << nameVolume 
-			    << " for Track " << aStep->GetTrack()->GetTrackID()
-			    <<" (" << aStep->GetTrack()->GetDefinition()->GetParticleName() 
-			    <<")";
-#endif
-        getFromParam(aStep, weight);
-#ifdef EDM_ML_DEBUG
-        LogDebug("HcalSim") << "HCalSD: " << getNumberOfHits() 
-			    << " hits afterParamS*";
-#endif 
-      } else {
-        bool notaMuon = true;
-        if (parCode == mupPDG || parCode == mumPDG ) notaMuon = false;
-        if (useShowerLibrary && notaMuon) {
-#ifdef EDM_ML_DEBUG
-          LogDebug("HcalSim") << "HCalSD: Starts shower library from " 
-                              << nameVolume << " for Track " 
-                              << aStep->GetTrack()->GetTrackID() << " ("
-                              << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-          getFromLibrary(aStep, weight);
-        } else if (isItFibre(lv)) {
-#ifdef EDM_ML_DEBUG
-          LogDebug("HcalSim") << "HCalSD: Hit at Fibre in " << nameVolume 
-                              << " for Track " 
-                              << aStep->GetTrack()->GetTrackID() <<" ("
-                              << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-          hitForFibre(aStep, weight);
-        }
-      }
-    } else if (isItPMT(lv)) {
-#ifdef EDM_ML_DEBUG
-      LogDebug("HcalSim") << "HCalSD: Hit from PMT parametrization from " 
-                          <<  nameVolume << " for Track " 
-                          << aStep->GetTrack()->GetTrackID() << " ("
-                          << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-      if (usePMTHit && showerPMT) getHitPMT(aStep);
-    } else if (isItStraightBundle(lv) || isItConicalBundle(lv)) {
-#ifdef EDM_ML_DEBUG
-      LogDebug("HcalSim") << "HCalSD: Hit from FibreBundle from "
-                          << nameVolume << " for Track " 
-                          << aStep->GetTrack()->GetTrackID() << " ("
-                          << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-      if (useFibreBundle && showerBundle) 
-	getHitFibreBundle(aStep, isItConicalBundle(lv));
-    } else {
-#ifdef EDM_ML_DEBUG
-      LogDebug("HcalSim") << "HCalSD: Hit from standard path from " 
-                          <<  nameVolume << " for Track " 
-                          << aStep->GetTrack()->GetTrackID() << " ("
-                          << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-      if (getStepInfo(aStep)) {
-#ifdef plotDebug
-        if (edepositEM+edepositHAD > 0)
-          plotProfile(aStep, aStep->GetPreStepPoint()->GetPosition(),
-                      edepositEM+edepositHAD,aStep->GetPostStepPoint()->GetGlobalTime(),0);
-#endif
-        if (hitExists() == false && edepositEM+edepositHAD>0.) currentHit = createNewHit();
+  unsigned int nvol = lvnames.size();
+  std::stringstream ss;
+  ss << "HCalSD: " << nvol << " names to be tested for " << attribute << " <" << value << ">:";
+  for (unsigned int i=0; i<nvol; ++i) {
+    G4String namv = lvnames[i];
+    lv = nullptr;
+    for (auto lvol : *lvs) {
+      if (lvol->GetName() == namv) {
+	lv = lvol;
+	break;
       }
     }
-    return true;
+    lvvec.push_back(lv);
+    if(i/10*10 == i) { ss << "\n"; }
+    ss << "  " << namv;
   }
+  edm::LogInfo("HcalSim") << ss.str();
+}
+
+bool HCalSD::getFromLibrary(const G4Step * aStep) {
+
+  depth_ = (aStep->GetPreStepPoint()->GetTouchable()->GetReplicaNumber(0))%10;
+  weight_= 1.0;
+  bool kill(false);
+  isHF = isItHF(aStep);
+
+  if(isHF) { 
+    if (m_HFDarkening) {
+      G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
+      const double invcm = 1./CLHEP::cm;
+      double r = hitPoint.perp()*invcm;
+      double z = std::abs(hitPoint.z())*invcm;
+      double dose_acquired = 0.;
+      if (z>=HFDarkening::lowZLimit && z <= HFDarkening::upperZLimit) {
+	unsigned int hfZLayer = (unsigned int)((z - HFDarkening::lowZLimit)/5);
+	if (hfZLayer >= HFDarkening::upperZLimit) hfZLayer = (HFDarkening::upperZLimit-1);
+	float normalized_lumi = m_HFDarkening->int_lumi(deliveredLumi);
+	for (int i = hfZLayer; i != HFDarkening::numberOfZLayers; ++i) {
+	  dose_acquired = m_HFDarkening->dose(i,r);
+	  weight_ *= m_HFDarkening->degradation(normalized_lumi*dose_acquired);
+	}
+      }
+#ifdef EDM_ML_DEBUG
+      edm::LogInfo("HcalSim") << "HCalSD::getFromLibrary: HFLumiDarkening at r= " 
+			      << r << ", z= " << z << " Dose= " << dose_acquired 
+			      << " weight= " << weight_;
+#endif
+    }
+
+    if (useParam) {
+      getFromParam(aStep, kill);
+#ifdef EDM_ML_DEBUG
+      G4String nameVolume = lv->GetName();
+      LogDebug("HcalSim") << "HCalSD: " << getNumberOfHits()
+			  << " hits from parametrization in " << nameVolume 
+			  << " for Track " << aStep->GetTrack()->GetTrackID()
+			  <<" (" << aStep->GetTrack()->GetDefinition()->GetParticleName() 
+			  <<")";
+#endif
+    } else if (useShowerLibrary && !G4TrackToParticleID::isMuon(aStep->GetTrack())) {
+#ifdef EDM_ML_DEBUG
+      LogDebug("HcalSim") << "HCalSD: Starts shower library from " 
+			  << nameVolume << " for Track " 
+			  << aStep->GetTrack()->GetTrackID() << " ("
+			  << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+#endif
+      getFromHFLibrary(aStep, kill);
+    }
+  }
+#ifdef EDM_ML_DEBUG
+  edm::LogInfo("HcalSim") << "HCalSD::getFromLibrary ID= " 
+			  << aStep->GetTrack()->GetTrackID() << " ("
+			  << aStep->GetTrack()->GetDefinition()->GetParticleName() 
+			  << ") kill= " << kill << " weight= " << weight_ 
+			  << " depth= " << depth_ << " isHF: " << isHF;
+#endif
+  return kill;
 } 
 
-double HCalSD::getEnergyDeposit(G4Step* aStep) {
-  double destep = aStep->GetTotalEnergyDeposit();
-  double weight = 1;
-  theTrack = aStep->GetTrack();
+double HCalSD::getEnergyDeposit(const G4Step* aStep) {
+  double destep(0.0);
+  auto const lv = aStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume();
+
+  if(isHF) {
+    if (isItFibre(lv)) {
+#ifdef EDM_ML_DEBUG
+      edm::LogInfo("HcalSim") << "HCalSD: Hit at Fibre in LV " << lv->GetName() 
+			      << " for track " << aStep->GetTrack()->GetTrackID() <<" ("
+			      << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+#endif
+      hitForFibre(aStep);
+    }
+    return destep;
+  }
+
+  if (usePMTHit && showerPMT && isItPMT(lv)) {
+    getHitPMT(aStep);
+#ifdef EDM_ML_DEBUG
+    edm::LogInfo("HcalSim") << "HCalSD: Hit from PMT parametrization in LV " 
+			    <<  lv->GetName() << " for Track " 
+			    << aStep->GetTrack()->GetTrackID() << " ("
+			    << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+#endif
+    return destep;
+
+  } else if (isItStraightBundle(lv)) {
+    if (useFibreBundle && showerBundle) { getHitFibreBundle(aStep, false); }
+#ifdef EDM_ML_DEBUG
+    edm::LogDebug("HcalSim") << "HCalSD: Hit from straight FibreBundle in LV: "
+			     << lv->GetName() << " for track " 
+			     << aStep->GetTrack()->GetTrackID() << " ("
+			     << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+#endif
+    return destep;
+
+  } else if(isItConicalBundle(lv)) {
+    if (useFibreBundle && showerBundle) { getHitFibreBundle(aStep, true); }
+#ifdef EDM_ML_DEBUG
+    LogDebug("HcalSim") << "HCalSD: Hit from conical FibreBundle PV: "
+			<< lv->GetName() << " for track " 
+			<< aStep->GetTrack()->GetTrackID() << " ("
+			<< aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+#endif
+    return destep;
+  }
+
+  // normal hit
+  destep = aStep->GetTotalEnergyDeposit();
+  auto const theTrack = aStep->GetTrack();
 
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   uint32_t detid = setDetUnitId(aStep);
   int det(0), ieta(0), phi(0), z(0), lay, depth(-1);
   if (testNumber) {
     HcalTestNumbering::unpackHcalIndex(detid,det,z,depth,ieta,phi,lay);
-    if (z==0) z = -1;
+    if (z==0) { z = -1; }
   } else {
     HcalDetId hcid(detid);
     det  = hcid.subdetId();
@@ -485,27 +440,27 @@ double HCalSD::getEnergyDeposit(G4Step* aStep) {
 			  << lay-2;
 #endif 
   if (depth_==0 && (det==1 || det==2) && ((!testNumber) || neutralDensity))
-    weight = hcalConstants->getLayer0Wt(det,phi,z);
+    weight_ = hcalConstants->getLayer0Wt(det,phi,z);
   if (useLayerWt) {
     G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
-    weight = layerWeight(det+2, hitPoint, depth_, lay);
+    weight_ = layerWeight(det+2, hitPoint, depth_, lay);
   }
 
   if (m_HBDarkening && det == 1) {
-    float dweight = m_HBDarkening->degradation(deliveredLumi,ieta,lay);
-    weight *= dweight;
+    double dweight = m_HBDarkening->degradation(deliveredLumi,ieta,lay);
+    weight_ *= dweight;
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD:         >>> HB Lumi: " << deliveredLumi
-			    << "    coefficient = " << dweight;
+    edm::LogInfo("HcalSim") << "HCalSD: HB Lumi: " << deliveredLumi
+			    << " coefficient = " << dweight << " Weight= " << weight_;
 #endif  
   }
 
   if (m_HEDarkening && det == 2) {
-    float dweight = m_HEDarkening->degradation(deliveredLumi,ieta,lay);
-    weight *= dweight;
+    double dweight = m_HEDarkening->degradation(deliveredLumi,ieta,lay);
+    weight_ *= dweight;
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD:         >>> HE Lumi: " << deliveredLumi
-			    << "    coefficient = " << dweight;
+    edm::LogInfo("HcalSim") << "HCalSD: HB Lumi: " << deliveredLumi
+			    << " coefficient = " << dweight << " Weight= " << weight_;
 #endif  
   }
 
@@ -514,44 +469,33 @@ double HCalSD::getEnergyDeposit(G4Step* aStep) {
     if (trkInfo) {
       int pdg = theTrack->GetDefinition()->GetPDGEncoding();
       if (!(trkInfo->isPrimary())) {         // Only secondary particles
-        double ke = theTrack->GetKineticEnergy()/MeV;
+        double ke = theTrack->GetKineticEnergy();
         if ( pdg/1000000000 == 1 && (pdg/10000)%100 > 0 &&
-	     (pdg/10)%100 > 0    && ke <kmaxIon   ) weight = 0;
-        if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
-        if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
-#ifdef EDM_ML_DEBUG
-        if (weight == 0) 
-          edm::LogInfo("HcalSim") << "HCalSD:Ignore Track " 
-                                  << theTrack->GetTrackID() << " Type " 
-                                  << theTrack->GetDefinition()->GetParticleName()
-                                  << " Kinetic Energy " << ke << " MeV";
-#endif
+	     (pdg/10)%100 > 0    && ke <kmaxIon   ) weight_ = 0;
+        if ((pdg == 2212) && (ke < kmaxProton))     weight_ = 0;
+        if ((pdg == 2112) && (ke < kmaxNeutron))    weight_ = 0;
       }
     }
   }
-#ifdef EDM_ML_DEBUG
-  double weight0 = weight;
-#endif
   if (useBirk) {
     const G4Material* mat = aStep->GetPreStepPoint()->GetMaterial();
-    if (isItScintillator(mat)) weight *= getAttenuation(aStep, birk1, birk2, birk3);
+    if (isItScintillator(mat)) weight_ *= getAttenuation(aStep, birk1, birk2, birk3);
   }
   double wt1 = getResponseWt(theTrack);
   double wt2 = theTrack->GetWeight();
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("HcalSim") << "HCalSD: Detector " << det+2 << " Depth " << depth_
-                          << " weight " << weight0 << " " << weight << " " << wt1 
-			  << " " << wt2; 
+  edm::LogInfo("HcalSim") << "HCalSD: Detector " << det+2 << " depth= " << depth_
+                          << " weight= " << weight_ << " wt1= " << wt1 << " wt2= " << wt2; 
 #endif
-  double edep = weight*wt1*destep;
+  double edep = weight_*wt1*destep;
   if (wt2 > 0.0) { edep *= wt2; }
   return edep;
 }
 
 uint32_t HCalSD::setDetUnitId(const G4Step * aStep) { 
 
-  const G4StepPoint* prePoint   = aStep->GetPreStepPoint(); 
-  const G4VTouchable* touch     = prePoint->GetTouchable();
+  auto const prePoint  = aStep->GetPreStepPoint(); 
+  auto const touch     = prePoint->GetTouchable();
   const G4ThreeVector& hitPoint = prePoint->GetPosition();
 
   int depth = (touch->GetReplicaNumber(0))%10 + 1;
@@ -564,8 +508,7 @@ uint32_t HCalSD::setDetUnitId(const G4Step * aStep) {
 void HCalSD::setNumberingScheme(HcalNumberingScheme * scheme) {
   if (scheme != nullptr) {
     edm::LogInfo("HcalSim") << "HCalSD: updates numbering scheme for " << GetName();
-    if (numberingScheme) delete numberingScheme;
-    numberingScheme = scheme;
+    numberingScheme.reset(scheme);
   }
 }
 
@@ -581,18 +524,18 @@ void HCalSD::update(const BeginOfJob * job) {
     throw cms::Exception("Unknown", "HCalSD") << "Cannot find HcalDDDSimConstant" << "\n";
   }
 
-  numberingFromDDD = new HcalNumberingFromDDD(hcalConstants);
-
-  edm::LogInfo("HcalSim") << "Maximum depth for HF " << hcalConstants->getMaxDepth(2);
+  numberingFromDDD.reset(new HcalNumberingFromDDD(hcalConstants));
 
   //Special Geometry parameters
-  gpar      = hcalConstants->getGparHF();
-  edm::LogInfo("HcalSim") << "HCalSD: " << gpar.size()<< " gpar (cm)";
-  for (unsigned int ig=0; ig<gpar.size(); ig++)
-    edm::LogInfo("HcalSim") << "HCalSD: gpar[" << ig << "] = "
-			    << gpar[ig]/cm << " cm";
+  gpar = hcalConstants->getGparHF();
+  std::stringstream sss;
+  for (unsigned int ig=0; ig<gpar.size(); ig++) {
+    sss << "\n         gpar[" << ig << "] = " << gpar[ig]/cm << " cm";
+  }
+  edm::LogInfo("HcalSim") << "Maximum depth for HF " << hcalConstants->getMaxDepth(2)
+			  << gpar.size()<< " gpar (cm)" << sss.str();
   //Test Hcal Numbering Scheme
-  if (testNS_) hcalTestNS_ = new HcalTestNS(es);
+  if (testNS_) m_HcalTestNS.reset(new HcalTestNS(es));
 
   if (agingFlagHB) {
     edm::ESHandle<HBHEDarkening> hdark;
@@ -607,19 +550,12 @@ void HCalSD::update(const BeginOfJob * job) {
 }
 
 void HCalSD::initRun() {
-  G4ParticleTable * theParticleTable = G4ParticleTable::GetParticleTable();
-  G4String          particleName;
-  mumPDG = theParticleTable->FindParticle(particleName="mu-")->GetPDGEncoding();
-  mupPDG = theParticleTable->FindParticle(particleName="mu+")->GetPDGEncoding();
-#ifdef EDM_ML_DEBUG
-  LogDebug("HcalSim") << "HCalSD: Particle code for mu- = " << mumPDG
-		      << " for mu+ = " << mupPDG;
-#endif
-  if (showerLibrary) showerLibrary->initRun(theParticleTable,hcalConstants);
-  if (showerParam)   showerParam->initRun(theParticleTable,hcalConstants);
-  if (hfshower)      hfshower->initRun(theParticleTable,hcalConstants);
-  if (showerPMT)     showerPMT->initRun(theParticleTable,hcalConstants);
-  if (showerBundle)  showerBundle->initRun(theParticleTable,hcalConstants);
+  edm::LogWarning("HcalSim") << "InitRun for HFFFFF ";
+  if (showerLibrary.get()) showerLibrary.get()->initRun(hcalConstants);
+  if (showerParam.get())   showerParam.get()->initRun(hcalConstants);
+  if (hfshower.get())      hfshower.get()->initRun(hcalConstants);
+  if (showerPMT.get())     showerPMT.get()->initRun(hcalConstants);
+  if (showerBundle.get())  showerBundle.get()->initRun(hcalConstants);
 }
 
 bool HCalSD::filterHit(CaloG4Hit* aHit, double time) {
@@ -642,9 +578,9 @@ bool HCalSD::filterHit(CaloG4Hit* aHit, double time) {
 
 uint32_t HCalSD::setDetUnitId (int det, const G4ThreeVector& pos, int depth, int lay=1) { 
   uint32_t id = 0;
-  if (numberingFromDDD) {
+  if (numberingFromDDD.get()) {
     //get the ID's as eta, phi, depth, ... indices
-    HcalNumberingFromDDD::HcalID tmp = numberingFromDDD->unitID(det, pos, depth, lay);
+    HcalNumberingFromDDD::HcalID tmp = numberingFromDDD.get()->unitID(det, pos, depth, lay);
     id = setDetUnitId(tmp);
   }
   return id;
@@ -652,9 +588,9 @@ uint32_t HCalSD::setDetUnitId (int det, const G4ThreeVector& pos, int depth, int
 
 uint32_t HCalSD::setDetUnitId (HcalNumberingFromDDD::HcalID& tmp) { 
   modifyDepth(tmp);
-  uint32_t id = (numberingScheme) ? numberingScheme->getUnitID(tmp) : 0;
-  if ((!testNumber) && hcalTestNS_) {
-    bool ok = hcalTestNS_->compare(tmp,id);
+  uint32_t id = (numberingScheme.get()) ? numberingScheme.get()->getUnitID(tmp) : 0;
+  if ((!testNumber) && m_HcalTestNS.get()) {
+    bool ok = m_HcalTestNS.get()->compare(tmp,id);
     if (!ok)
       edm::LogWarning("HcalSim") << "Det ID from HCalSD " << HcalDetId(id) 
 				 << " " << std::hex << id << std::dec 
@@ -724,51 +660,44 @@ bool HCalSD::isItHF(const G4Step * aStep) {
 }
 
 bool HCalSD::isItHF (const G4String& name) {
-  std::vector<G4String>::const_iterator it = hfNames.begin();
-  for (; it != hfNames.end(); ++it) if (name == *it) return true;
+  for (auto nam : hfNames) if (name == nam) { return true; }
   return false;
 }
 
 bool HCalSD::isItFibre (const G4LogicalVolume* lv) {
-  std::vector<const G4LogicalVolume*>::const_iterator ite = fibreLV.begin();
-  for (; ite != fibreLV.end(); ++ite) if (lv == *ite) return true;
+  for (auto lvol : fibreLV) if (lv == lvol) { return true; }
   return false;
 }
 
 bool HCalSD::isItFibre (const G4String& name) {
-  std::vector<G4String>::const_iterator it = fibreNames.begin();
-  for (; it != fibreNames.end(); ++it) if (name == *it) return true;
+  for (auto nam : fibreNames) if (name == nam) { return true; }
   return false;
 }
 
 bool HCalSD::isItPMT (const G4LogicalVolume* lv) {
-  std::vector<const G4LogicalVolume*>::const_iterator ite = pmtLV.begin();
-  for (; ite != pmtLV.end(); ++ite) if (lv == *ite) return true;
+  for (auto lvol : pmtLV) if (lv == lvol) { return true; }
   return false;
 }
 
 bool HCalSD::isItStraightBundle (const G4LogicalVolume* lv) {
-  std::vector<const G4LogicalVolume*>::const_iterator ite = fibre1LV.begin();
-  for (; ite != fibre1LV.end(); ++ite) if (lv == *ite) return true;
+  for (auto lvol : fibre1LV) if (lv == lvol) { return true; }
   return false;
 }
 
 bool HCalSD::isItConicalBundle (const G4LogicalVolume* lv) {
-  std::vector<const G4LogicalVolume*>::const_iterator ite = fibre2LV.begin();
-  for (; ite != fibre2LV.end(); ++ite) if (lv == *ite) return true;
+  for (auto lvol : fibre2LV) if (lv == lvol) { return true; }
   return false;
 }
 
 bool HCalSD::isItScintillator (const G4Material* mat) {
-  std::vector<const G4Material*>::const_iterator ite = materials.begin();
-  for (; ite != materials.end(); ++ite) if (mat == *ite) return true;
+  for (auto amat : materials) if (amat == mat) { return true; }
   return false;
 }
 
 bool HCalSD::isItinFidVolume (const G4ThreeVector& hitPoint) {
   bool flag = true;
   if (applyFidCut) {
-    int npmt = HFFibreFiducial:: PMTNumber(hitPoint);
+    int npmt = HFFibreFiducial::PMTNumber(hitPoint);
 #ifdef EDM_ML_DEBUG
     edm::LogInfo("HcalSim") << "HCalSD::isItinFidVolume:#PMT= " << npmt 
 			    << " for hit point " << hitPoint;
@@ -782,23 +711,20 @@ bool HCalSD::isItinFidVolume (const G4ThreeVector& hitPoint) {
   return flag;
 }
 
-void HCalSD::getFromLibrary (G4Step* aStep, double weight) {
-  preStepPoint  = aStep->GetPreStepPoint(); 
-  theTrack = aStep->GetTrack();   
-  int det       = 5;
-  bool ok;
+void HCalSD::getFromHFLibrary (const G4Step* aStep, bool& isKilled) {
 
-  std::vector<HFShowerLibrary::Hit> hits = showerLibrary->getHits(aStep, ok, weight, false);
+  std::vector<HFShowerLibrary::Hit> hits = showerLibrary.get()->getHits(aStep, isKilled, weight_, false);
+  if(!isKilled) { return; } 
 
-  double etrack    = preStepPoint->GetKineticEnergy();
   int    primaryID = setTrackID(aStep);
 
   // Reset entry point for new primary
-  posGlobal = preStepPoint->GetPosition();
-  resetForNewPrimary(posGlobal, etrack);
+  resetForNewPrimary(aStep);
 
-  G4int particleCode = theTrack->GetDefinition()->GetPDGEncoding();
-  if (particleCode==emPDG || particleCode==epPDG || particleCode==gammaPDG) {
+  auto const theTrack = aStep->GetTrack();   
+  int det = 5;
+
+  if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
     edepositEM  = 1.*GeV;
     edepositHAD = 0.;
   } else {
@@ -809,7 +735,7 @@ void HCalSD::getFromLibrary (G4Step* aStep, double weight) {
   edm::LogInfo("HcalSim") << "HCalSD::getFromLibrary " <<hits.size() 
                           << " hits for " << GetName() << " of " << primaryID 
                           << " with " << theTrack->GetDefinition()->GetParticleName() 
-                          << " of " << preStepPoint->GetKineticEnergy()/GeV << " GeV";
+                          << " of " << aStep->GetPreStepPoint()->GetKineticEnergy()/GeV << " GeV";
 #endif
   for (unsigned int i=0; i<hits.size(); ++i) {
     G4ThreeVector hitPoint = hits[i].position;
@@ -820,42 +746,23 @@ void HCalSD::getFromLibrary (G4Step* aStep, double weight) {
       currentID.setID(unitID, time, primaryID, 0);
 #ifdef plotDebug
       plotProfile(aStep, hitPoint, 1.0*GeV, time, depth);
-      bool emType = false;
-      if (particleCode==emPDG || particleCode==epPDG || particleCode==gammaPDG)
-	emType = true;
+      bool emType = G4TrackToParticleID::isGammaElectronPositron(parCode);
       plotHF(hitPoint,emType);
 #endif
-   
-      // check if it is in the same unit and timeslice as the previous one
-      if (currentID == previousID) {
-	updateHit(currentHit);
-      } else {
-	if (!checkHit()) currentHit = createNewHit();
-      }
+      processHit(aStep);
     }
-  }
-
-  //Now kill the current track
-  if (ok) {
-    theTrack->SetTrackStatus(fStopAndKill);
-    G4TrackVector tv = *(aStep->GetSecondary());
-    for (unsigned int kk=0; kk<tv.size(); ++kk)
-      if (tv[kk]->GetVolume() == preStepPoint->GetPhysicalVolume())
-        tv[kk]->SetTrackStatus(fStopAndKill);
   }
 }
 
-void HCalSD::hitForFibre (const G4Step* aStep, double weight) { // if not ParamShower
+void HCalSD::hitForFibre (const G4Step* aStep) { // if not ParamShower
 
-  const G4StepPoint* preStepPoint  = aStep->GetPreStepPoint();
-  const G4Track*     theTrack      = aStep->GetTrack();
+  const G4Track* theTrack = aStep->GetTrack();
   int primaryID = setTrackID(aStep);
 
   int det   = 5;
-  std::vector<HFShower::Hit> hits = hfshower->getHits(aStep, weight);
+  std::vector<HFShower::Hit> hits = hfshower.get()->getHits(aStep, weight_);
 
-  G4int particleCode = theTrack->GetDefinition()->GetPDGEncoding();
-  if (particleCode==emPDG || particleCode==epPDG || particleCode==gammaPDG) {
+  if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
     edepositEM  = 1.*GeV;
     edepositHAD = 0.;
   } else {
@@ -885,24 +792,20 @@ void HCalSD::hitForFibre (const G4Step* aStep, double weight) { // if not ParamS
 	  emType = true;
 	plotHF(hitPoint,emType);
 #endif
-	// check if it is in the same unit and timeslice as the previous one
-	if (currentID == previousID) {
-	  updateHit(currentHit);
-	} else {
-	  posGlobal = preStepPoint->GetPosition();
-	  if (!checkHit()) currentHit = createNewHit();
-	}
+        processHit(aStep);
       }
     }
   }
 }
 
-void HCalSD::getFromParam (G4Step* aStep, double weight) {
-  std::vector<HFShowerParam::Hit> hits = showerParam->getHits(aStep, weight);
+void HCalSD::getFromParam (const G4Step* aStep, bool& isKilled) {
+
+  std::vector<HFShowerParam::Hit> hits = showerParam.get()->getHits(aStep, weight_, isKilled);
+  if(!isKilled) { return; }
+
   int nHit = static_cast<int>(hits.size());
 
   if (nHit > 0) {
-    const G4StepPoint* preStepPoint  = aStep->GetPreStepPoint();
     int primaryID = setTrackID(aStep);
    
     int det   = 5;
@@ -924,14 +827,7 @@ void HCalSD::getFromParam (G4Step* aStep, double weight) {
 #ifdef plotDebug
       plotProfile(aStep, hitPoint, edepositEM, time, depth);
 #endif
-
-      // check if it is in the same unit and timeslice as the previous one
-      if (currentID == previousID) {
-	updateHit(currentHit);
-      } else {
-        posGlobal = preStepPoint->GetPosition();
-        if (!checkHit()) currentHit = createNewHit();
-      }
+      processHit(aStep);
     }
   }
 }
@@ -943,6 +839,7 @@ void HCalSD::getHitPMT (const G4Step * aStep) {
   double edep  = showerPMT->getHits(aStep);
 
   if (edep >= 0) {
+    edep *= GeV;
     double etrack    = preStepPoint->GetKineticEnergy();
     int    primaryID = 0;
     if (etrack >= energyCut) {
@@ -952,9 +849,7 @@ void HCalSD::getHitPMT (const G4Step * aStep) {
       if (primaryID == 0) primaryID = theTrack->GetTrackID();
     }
     // Reset entry point for new primary
-    posGlobal = preStepPoint->GetPosition();
-    resetForNewPrimary(posGlobal, etrack);
-
+    resetForNewPrimary(aStep);
     //
     int    det      = static_cast<int>(HcalForward);
     const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
@@ -974,16 +869,16 @@ void HCalSD::getHitPMT (const G4Step * aStep) {
     double time = (aStep->GetPostStepPoint()->GetGlobalTime());
     uint32_t unitID = 0;
     if (numberingFromDDD) {
-      HcalNumberingFromDDD::HcalID tmp = numberingFromDDD->unitID(det,etaR,phi,
+      HcalNumberingFromDDD::HcalID tmp = numberingFromDDD.get()->unitID(det,etaR,phi,
 								  depth,1);
       unitID = setDetUnitId(tmp);
     }
     currentID.setID(unitID, time, primaryID, 1);
 
     edepositHAD = aStep->GetTotalEnergyDeposit();
-    edepositEM  =-edepositHAD + (edep*GeV);
+    edepositEM  =-edepositHAD + edep;
 #ifdef plotDebug
-    plotProfile(aStep, hitPoint, edep*GeV, time, depth);
+    plotProfile(aStep, hitPoint, edep, time, depth);
 #endif
 #ifdef EDM_ML_DEBUG
     double beta = preStepPoint->GetBeta();
@@ -994,21 +889,17 @@ void HCalSD::getHitPMT (const G4Step * aStep) {
                         << " GeV with velocity " << beta << " UnitID "
                         << std::hex << unitID << std::dec;
 #endif
-    // check if it is in the same unit and timeslice as the previous one
-    if      (currentID == previousID) {
-      updateHit(currentHit);
-    } else {
-      if (!checkHit()) currentHit = createNewHit();
-    }
+    processHit(aStep);
   }
 }
 
 void HCalSD::getHitFibreBundle (const G4Step* aStep, bool type) {
   const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
   const G4Track*     theTrack     = aStep->GetTrack();
-  double edep  = showerBundle->getHits(aStep, type);
+  double edep  = showerBundle.get()->getHits(aStep, type);
 
-  if (edep >= 0) {
+  if (edep >= 0.0) {
+    edep *= GeV;
     double etrack    = preStepPoint->GetKineticEnergy();
     int    primaryID = 0;
     if (etrack >= energyCut) {
@@ -1018,14 +909,12 @@ void HCalSD::getHitFibreBundle (const G4Step* aStep, bool type) {
       if (primaryID == 0) primaryID = theTrack->GetTrackID();
     }
     // Reset entry point for new primary
-    posGlobal = preStepPoint->GetPosition();
-    resetForNewPrimary(posGlobal, etrack);
-
+    resetForNewPrimary(aStep);
     //
     int    det      = static_cast<int>(HcalForward);
     const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
-    double rr       = (hitPoint.x()*hitPoint.x() + hitPoint.y()*hitPoint.y());
-    double phi      = (rr == 0. ? 0. :atan2(hitPoint.y(),hitPoint.x()));
+    double rr       = hitPoint.x()*hitPoint.x() + hitPoint.y()*hitPoint.y();
+    double phi      = rr == 0. ? 0. :atan2(hitPoint.y(),hitPoint.x());
     double etaR     = showerBundle->getRadius();
     int depth       = 1;
     if (etaR < 0) {
@@ -1040,16 +929,16 @@ void HCalSD::getHitFibreBundle (const G4Step* aStep, bool type) {
     double time = (aStep->GetPostStepPoint()->GetGlobalTime());
     uint32_t unitID = 0;
     if (numberingFromDDD) {
-      HcalNumberingFromDDD::HcalID tmp = numberingFromDDD->unitID(det,etaR,phi,depth,1);
+      HcalNumberingFromDDD::HcalID tmp = numberingFromDDD.get()->unitID(det,etaR,phi,depth,1);
       unitID = setDetUnitId(tmp);
     }
     if (type) currentID.setID(unitID, time, primaryID, 3);
     else      currentID.setID(unitID, time, primaryID, 2);
 
     edepositHAD = aStep->GetTotalEnergyDeposit();
-    edepositEM  =-edepositHAD + (edep*GeV);
+    edepositEM  =-edepositHAD + edep;
 #ifdef plotDebug
-    plotProfile(aStep, hitPoint, edep*GeV, time, depth);
+    plotProfile(aStep, hitPoint, edep, time, depth);
 #endif
 #ifdef EDM_ML_DEBUG
     double beta = preStepPoint->GetBeta();
@@ -1060,30 +949,16 @@ void HCalSD::getHitFibreBundle (const G4Step* aStep, bool type) {
                         << " GeV with velocity " << beta << " UnitID "
                         << std::hex << unitID << std::dec;
 #endif
-    // check if it is in the same unit and timeslice as the previous one
-    if (currentID == previousID) updateHit(currentHit);
-    else if (!checkHit()) currentHit = createNewHit();
+    processHit(aStep);
   } // non-zero energy deposit
 }
 
 int HCalSD::setTrackID (const G4Step* aStep) {
-  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
-  const G4Track* theTrack         = aStep->GetTrack();
 
-  double etrack = preStepPoint->GetKineticEnergy();
-  TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
-  int      primaryID = trkInfo->getIDonCaloSurface();
-  if (primaryID == 0) {
-#ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD: Problem with primaryID **** set by "
-			    << "force to TkID **** " <<theTrack->GetTrackID();
-#endif
-    primaryID = theTrack->GetTrackID();
+  int primaryID = getTrackID(aStep->GetTrack());
+  if (primaryID != previousID.trackID()) {
+    resetForNewPrimary(aStep);
   }
-
-  if (primaryID != previousID.trackID())
-    resetForNewPrimary(preStepPoint->GetPosition(), etrack);
-
   return primaryID;
 }
 
@@ -1118,7 +993,7 @@ double HCalSD::layerWeight(int det, const G4ThreeVector& pos, int depth, int lay
   double wt = 1.;
   if (numberingFromDDD) {
     //get the ID's as eta, phi, depth, ... indices
-    HcalNumberingFromDDD::HcalID tmp = numberingFromDDD->unitID(det, pos, 
+    HcalNumberingFromDDD::HcalID tmp = numberingFromDDD.get()->unitID(det, pos, 
 								depth, lay);
     modifyDepth(tmp);
     uint32_t id = HcalTestNumbering::packHcalIndex(tmp.subdet, tmp.zside, 1,
@@ -1200,7 +1075,6 @@ void HCalSD::modifyDepth(HcalNumberingFromDDD::HcalID& id) {
       }
     }
   } else if ((id.subdet == 1 || id.subdet ==2) && testNumber) {
-    if (depth_ == 0) id.depth = 1;
-    else             id.depth = 2;
+    id.depth = (depth_ == 0) ? 1 : 2;
   }
 }

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -551,7 +551,7 @@ void HCalSD::update(const BeginOfJob * job) {
 
 void HCalSD::initRun() {
   edm::LogWarning("HcalSim") << "InitRun for HFFFFF ";
-  if (showerLibrary.get()) showerLibrary.get()->initRun(hcalConstants);
+  if (showerLibrary.get()) showerLibrary.get()->initRun(nullptr, hcalConstants);
   if (showerParam.get())   showerParam.get()->initRun(hcalConstants);
   if (hfshower.get())      hfshower.get()->initRun(hcalConstants);
   if (showerPMT.get())     showerPMT.get()->initRun(hcalConstants);
@@ -952,7 +952,7 @@ void HCalSD::getHitFibreBundle (const G4Step* aStep, bool type) {
     processHit(aStep);
   } // non-zero energy deposit
 }
-
+/*
 int HCalSD::setTrackID (const G4Step* aStep) {
 
   int primaryID = getTrackID(aStep->GetTrack());
@@ -961,7 +961,7 @@ int HCalSD::setTrackID (const G4Step* aStep) {
   }
   return primaryID;
 }
-
+*/
 void HCalSD::readWeightFromFile(const std::string& fName) {
 
   std::ifstream infile;

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -116,13 +116,13 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
                           << "         Threshold for storing hits in HB: "
                           << eminHitHB << " HE: " << eminHitHE << " HO: "
                           << eminHitHO << " HF: " << eminHitHF << "\n"
-			  << "Delivered luminosity for Darkening " 
-			  << deliveredLumi << " Flag (HE) " << agingFlagHE
-			  << " Flag (HB) " << agingFlagHB
-			  << " Flag (HF) " << agingFlagHF << "\n"
-			  << "Application of Fiducial Cut " << applyFidCut
-			  << "Flag for test number|neutral density filter "
-			  << testNumber << " " << neutralDensity;
+                          << "Delivered luminosity for Darkening " 
+                          << deliveredLumi << " Flag (HE) " << agingFlagHE
+                          << " Flag (HB) " << agingFlagHB
+                          << " Flag (HF) " << agingFlagHF << "\n"
+                          << "Application of Fiducial Cut " << applyFidCut
+                          << "Flag for test number|neutral density filter "
+                          << testNumber << " " << neutralDensity;
 
   HcalNumberingScheme* scheme;
   if (testNumber || forTBH2) {
@@ -166,16 +166,16 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
       G4String namv = hfNames[i];
       lv            = nullptr;
       for(auto lvol : *lvs) {
-	if(lvol->GetName() == namv) {
-	  lv = lvol;
-	  break;
-	}
+        if(lvol->GetName() == namv) {
+          lv = lvol;
+          break;
+        }
       }
       hfLV.push_back(lv);
       int level = static_cast<int>(temp[i]);
       hfLevels.push_back(level);
       ss << "\n        HF[" << i << "] = " << namv
-	 << " LV " << hfLV[i] << " at level " << hfLevels[i];
+         << " LV " << hfLV[i] << " at level " << hfLevels[i];
     }
     edm::LogInfo("HcalSim") << ss.str();
   
@@ -279,9 +279,9 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
   }
 
 void HCalSD::fillLogVolumeVector(const std::string& attribute, const std::string& value, 
-				 const DDCompactView& cpv,
-				 std::vector<const G4LogicalVolume*>& lvvec,
-				 std::vector<G4String>& lvnames) {
+                                 const DDCompactView& cpv,
+                                 std::vector<const G4LogicalVolume*>& lvvec,
+                                 std::vector<G4String>& lvnames) {
 
   const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
   const G4LogicalVolume* lv;
@@ -298,8 +298,8 @@ void HCalSD::fillLogVolumeVector(const std::string& attribute, const std::string
     lv = nullptr;
     for (auto lvol : *lvs) {
       if (lvol->GetName() == namv) {
-	lv = lvol;
-	break;
+        lv = lvol;
+        break;
       }
     }
     lvvec.push_back(lv);
@@ -324,18 +324,18 @@ bool HCalSD::getFromLibrary(const G4Step * aStep) {
       double z = std::abs(hitPoint.z())*invcm;
       double dose_acquired = 0.;
       if (z>=HFDarkening::lowZLimit && z <= HFDarkening::upperZLimit) {
-	unsigned int hfZLayer = (unsigned int)((z - HFDarkening::lowZLimit)/5);
-	if (hfZLayer >= HFDarkening::upperZLimit) hfZLayer = (HFDarkening::upperZLimit-1);
-	float normalized_lumi = m_HFDarkening->int_lumi(deliveredLumi);
-	for (int i = hfZLayer; i != HFDarkening::numberOfZLayers; ++i) {
-	  dose_acquired = m_HFDarkening->dose(i,r);
-	  weight_ *= m_HFDarkening->degradation(normalized_lumi*dose_acquired);
-	}
+        unsigned int hfZLayer = (unsigned int)((z - HFDarkening::lowZLimit)/5);
+        if (hfZLayer >= HFDarkening::upperZLimit) hfZLayer = (HFDarkening::upperZLimit-1);
+        float normalized_lumi = m_HFDarkening->int_lumi(deliveredLumi);
+        for (int i = hfZLayer; i != HFDarkening::numberOfZLayers; ++i) {
+          dose_acquired = m_HFDarkening->dose(i,r);
+          weight_ *= m_HFDarkening->degradation(normalized_lumi*dose_acquired);
+        }
       }
 #ifdef EDM_ML_DEBUG
       edm::LogInfo("HcalSim") << "HCalSD::getFromLibrary: HFLumiDarkening at r= " 
-			      << r << ", z= " << z << " Dose= " << dose_acquired 
-			      << " weight= " << weight_;
+                              << r << ", z= " << z << " Dose= " << dose_acquired 
+                              << " weight= " << weight_;
 #endif
     }
 
@@ -344,27 +344,27 @@ bool HCalSD::getFromLibrary(const G4Step * aStep) {
 #ifdef EDM_ML_DEBUG
       G4String nameVolume = lv->GetName();
       LogDebug("HcalSim") << "HCalSD: " << getNumberOfHits()
-			  << " hits from parametrization in " << nameVolume 
-			  << " for Track " << aStep->GetTrack()->GetTrackID()
-			  <<" (" << aStep->GetTrack()->GetDefinition()->GetParticleName() 
-			  <<")";
+                          << " hits from parametrization in " << nameVolume 
+                          << " for Track " << aStep->GetTrack()->GetTrackID()
+                          <<" (" << aStep->GetTrack()->GetDefinition()->GetParticleName() 
+                          <<")";
 #endif
     } else if (useShowerLibrary && !G4TrackToParticleID::isMuon(aStep->GetTrack())) {
 #ifdef EDM_ML_DEBUG
       LogDebug("HcalSim") << "HCalSD: Starts shower library from " 
-			  << nameVolume << " for Track " 
-			  << aStep->GetTrack()->GetTrackID() << " ("
-			  << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+                          << nameVolume << " for Track " 
+                          << aStep->GetTrack()->GetTrackID() << " ("
+                          << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
 #endif
       getFromHFLibrary(aStep, kill);
     }
   }
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("HcalSim") << "HCalSD::getFromLibrary ID= " 
-			  << aStep->GetTrack()->GetTrackID() << " ("
-			  << aStep->GetTrack()->GetDefinition()->GetParticleName() 
-			  << ") kill= " << kill << " weight= " << weight_ 
-			  << " depth= " << depth_ << " isHF: " << isHF;
+                          << aStep->GetTrack()->GetTrackID() << " ("
+                          << aStep->GetTrack()->GetDefinition()->GetParticleName() 
+                          << ") kill= " << kill << " weight= " << weight_ 
+                          << " depth= " << depth_ << " isHF: " << isHF;
 #endif
   return kill;
 } 
@@ -377,8 +377,8 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
     if (isItFibre(lv)) {
 #ifdef EDM_ML_DEBUG
       edm::LogInfo("HcalSim") << "HCalSD: Hit at Fibre in LV " << lv->GetName() 
-			      << " for track " << aStep->GetTrack()->GetTrackID() <<" ("
-			      << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+                              << " for track " << aStep->GetTrack()->GetTrackID() <<" ("
+                              << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
 #endif
       hitForFibre(aStep);
     }
@@ -389,9 +389,9 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
     getHitPMT(aStep);
 #ifdef EDM_ML_DEBUG
     edm::LogInfo("HcalSim") << "HCalSD: Hit from PMT parametrization in LV " 
-			    <<  lv->GetName() << " for Track " 
-			    << aStep->GetTrack()->GetTrackID() << " ("
-			    << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+                            <<  lv->GetName() << " for Track " 
+                            << aStep->GetTrack()->GetTrackID() << " ("
+                            << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
 #endif
     return destep;
 
@@ -399,9 +399,9 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
     if (useFibreBundle && showerBundle) { getHitFibreBundle(aStep, false); }
 #ifdef EDM_ML_DEBUG
     edm::LogDebug("HcalSim") << "HCalSD: Hit from straight FibreBundle in LV: "
-			     << lv->GetName() << " for track " 
-			     << aStep->GetTrack()->GetTrackID() << " ("
-			     << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+                             << lv->GetName() << " for track " 
+                             << aStep->GetTrack()->GetTrackID() << " ("
+                             << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
 #endif
     return destep;
 
@@ -409,9 +409,9 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
     if (useFibreBundle && showerBundle) { getHitFibreBundle(aStep, true); }
 #ifdef EDM_ML_DEBUG
     LogDebug("HcalSim") << "HCalSD: Hit from conical FibreBundle PV: "
-			<< lv->GetName() << " for track " 
-			<< aStep->GetTrack()->GetTrackID() << " ("
-			<< aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+                        << lv->GetName() << " for track " 
+                        << aStep->GetTrack()->GetTrackID() << " ("
+                        << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
 #endif
     return destep;
   }
@@ -436,8 +436,8 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
   lay   = (touch->GetReplicaNumber(0)/10)%100 + 1;
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("HcalSim") << "HCalSD: det: " << det << " ieta: "<< ieta 
-			  << " iphi: " << phi << " zside " << z << "  lay: " 
-			  << lay-2;
+                          << " iphi: " << phi << " zside " << z << "  lay: " 
+                          << lay-2;
 #endif 
   if (depth_==0 && (det==1 || det==2) && ((!testNumber) || neutralDensity))
     weight_ = hcalConstants->getLayer0Wt(det,phi,z);
@@ -451,7 +451,7 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
     weight_ *= dweight;
 #ifdef EDM_ML_DEBUG
     edm::LogInfo("HcalSim") << "HCalSD: HB Lumi: " << deliveredLumi
-			    << " coefficient = " << dweight << " Weight= " << weight_;
+                            << " coefficient = " << dweight << " Weight= " << weight_;
 #endif  
   }
 
@@ -460,7 +460,7 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
     weight_ *= dweight;
 #ifdef EDM_ML_DEBUG
     edm::LogInfo("HcalSim") << "HCalSD: HB Lumi: " << deliveredLumi
-			    << " coefficient = " << dweight << " Weight= " << weight_;
+                            << " coefficient = " << dweight << " Weight= " << weight_;
 #endif  
   }
 
@@ -471,7 +471,7 @@ double HCalSD::getEnergyDeposit(const G4Step* aStep) {
       if (!(trkInfo->isPrimary())) {         // Only secondary particles
         double ke = theTrack->GetKineticEnergy();
         if ( pdg/1000000000 == 1 && (pdg/10000)%100 > 0 &&
-	     (pdg/10)%100 > 0    && ke <kmaxIon   ) weight_ = 0;
+             (pdg/10)%100 > 0    && ke <kmaxIon   ) weight_ = 0;
         if ((pdg == 2212) && (ke < kmaxProton))     weight_ = 0;
         if ((pdg == 2112) && (ke < kmaxNeutron))    weight_ = 0;
       }
@@ -533,7 +533,7 @@ void HCalSD::update(const BeginOfJob * job) {
     sss << "\n         gpar[" << ig << "] = " << gpar[ig]/cm << " cm";
   }
   edm::LogInfo("HcalSim") << "Maximum depth for HF " << hcalConstants->getMaxDepth(2)
-			  << gpar.size()<< " gpar (cm)" << sss.str();
+                          << gpar.size()<< " gpar (cm)" << sss.str();
   //Test Hcal Numbering Scheme
   if (testNS_) m_HcalTestNS.reset(new HcalTestNS(es));
 
@@ -593,11 +593,11 @@ uint32_t HCalSD::setDetUnitId (HcalNumberingFromDDD::HcalID& tmp) {
     bool ok = m_HcalTestNS.get()->compare(tmp,id);
     if (!ok)
       edm::LogWarning("HcalSim") << "Det ID from HCalSD " << HcalDetId(id) 
-				 << " " << std::hex << id << std::dec 
-				 << " does not match one from relabller for " 
-				 << tmp.subdet << ":" << tmp.etaR << ":"
-				 << tmp.phi << ":" << tmp.phis << ":" 
-				 << tmp.depth << ":" << tmp.lay << std::endl;
+                                 << " " << std::hex << id << std::dec 
+                                 << " does not match one from relabller for " 
+                                 << tmp.subdet << ":" << tmp.etaR << ":"
+                                 << tmp.phi << ":" << tmp.phis << ":" 
+                                 << tmp.depth << ":" << tmp.lay << std::endl;
   }
   return id;
 }
@@ -700,13 +700,13 @@ bool HCalSD::isItinFidVolume (const G4ThreeVector& hitPoint) {
     int npmt = HFFibreFiducial::PMTNumber(hitPoint);
 #ifdef EDM_ML_DEBUG
     edm::LogInfo("HcalSim") << "HCalSD::isItinFidVolume:#PMT= " << npmt 
-			    << " for hit point " << hitPoint;
+                            << " for hit point " << hitPoint;
 #endif
     if (npmt <= 0) flag = false;
   }
 #ifdef EDM_ML_DEBUG
     edm::LogInfo("HcalSim") << "HCalSD::isItinFidVolume: point " << hitPoint
-			    << " return flag " << flag;
+                            << " return flag " << flag;
 #endif
   return flag;
 }
@@ -772,25 +772,25 @@ void HCalSD::hitForFibre (const G4Step* aStep) { // if not ParamShower
  
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("HcalSim") << "HCalSD::hitForFibre " << hits.size() 
-			  << " hits for " << GetName() << " of " << primaryID 
-			  << " with " << theTrack->GetDefinition()->GetParticleName() 
-			  << " of " << preStepPoint->GetKineticEnergy()/GeV 
-			  << " GeV in detector type " << det;
+                          << " hits for " << GetName() << " of " << primaryID 
+                          << " with " << theTrack->GetDefinition()->GetParticleName() 
+                          << " of " << preStepPoint->GetKineticEnergy()/GeV 
+                          << " GeV in detector type " << det;
 #endif
   if (!hits.empty()) {
     for (unsigned int i=0; i<hits.size(); ++i) {
       G4ThreeVector hitPoint = hits[i].position;
       if (isItinFidVolume (hitPoint)) {
-	int depth              = hits[i].depth;
-	double time            = hits[i].time;
-	unsigned int unitID = setDetUnitId(det, hitPoint, depth);
-	currentID.setID(unitID, time, primaryID, 0);
+        int depth              = hits[i].depth;
+        double time            = hits[i].time;
+        unsigned int unitID = setDetUnitId(det, hitPoint, depth);
+        currentID.setID(unitID, time, primaryID, 0);
 #ifdef plotDebug
-	plotProfile(aStep, hitPoint, edepositEM, time, depth);
-	bool emType = false;
-	if (particleCode==emPDG || particleCode==epPDG || particleCode==gammaPDG)
-	  emType = true;
-	plotHF(hitPoint,emType);
+        plotProfile(aStep, hitPoint, edepositEM, time, depth);
+        bool emType = false;
+        if (particleCode==emPDG || particleCode==epPDG || particleCode==gammaPDG)
+          emType = true;
+        plotHF(hitPoint,emType);
 #endif
         processHit(aStep);
       }
@@ -870,7 +870,7 @@ void HCalSD::getHitPMT (const G4Step * aStep) {
     uint32_t unitID = 0;
     if (numberingFromDDD) {
       HcalNumberingFromDDD::HcalID tmp = numberingFromDDD.get()->unitID(det,etaR,phi,
-								  depth,1);
+                                                                  depth,1);
       unitID = setDetUnitId(tmp);
     }
     currentID.setID(unitID, time, primaryID, 1);
@@ -924,7 +924,7 @@ void HCalSD::getHitFibreBundle (const G4Step* aStep, bool type) {
     if (hitPoint.z() < 0) etaR =-etaR;
 #ifdef EDM_ML_DEBUG
     LogDebug("HcalSim") << "HCalSD::Hit for Detector " << det << " etaR "
-			<< etaR << " phi " << phi/deg << " depth " <<depth;
+                        << etaR << " phi " << phi/deg << " depth " <<depth;
 #endif
     double time = (aStep->GetPostStepPoint()->GetGlobalTime());
     uint32_t unitID = 0;
@@ -994,7 +994,7 @@ double HCalSD::layerWeight(int det, const G4ThreeVector& pos, int depth, int lay
   if (numberingFromDDD) {
     //get the ID's as eta, phi, depth, ... indices
     HcalNumberingFromDDD::HcalID tmp = numberingFromDDD.get()->unitID(det, pos, 
-								depth, lay);
+                                                                depth, lay);
     modifyDepth(tmp);
     uint32_t id = HcalTestNumbering::packHcalIndex(tmp.subdet, tmp.zside, 1,
                                                    tmp.etaR, tmp.phis,tmp.lay);
@@ -1015,7 +1015,7 @@ void HCalSD::plotProfile(const G4Step* aStep,const G4ThreeVector& global, double
 
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   static const G4String modName[8] = {"HEModule", "HVQF" , "HBModule", "MBAT",
-				      "MBBT"    , "MBBTC", "MBBT_R1P", "MBBT_R1M"};
+                                      "MBBT"    , "MBBTC", "MBBT_R1P", "MBBT_R1M"};
   G4ThreeVector local;
   bool found=false;
   double depth=-2000;
@@ -1027,14 +1027,14 @@ void HCalSD::plotProfile(const G4Step* aStep,const G4ThreeVector& global, double
 #endif
     for (unsigned int ii=0; ii<8; ++ii) {
       if (name == modName[ii]) {
-	found = true;
-	int dn = touch->GetHistoryDepth() - n;
-	local = touch->GetHistory()->GetTransform(dn).TransformPoint(global);
-	if      (ii == 0) {depth = local.z() - 4006.5; idx = 1;}
-	else if (ii == 1) {depth = local.z() + 825.0;  idx = 3;}
-	else if (ii == 2) {depth = local.x() - 1775.;  idx = 0;}
-	else              {depth = local.y() + 15.;    idx = 2;}
-	break;
+        found = true;
+        int dn = touch->GetHistoryDepth() - n;
+        local = touch->GetHistory()->GetTransform(dn).TransformPoint(global);
+        if      (ii == 0) {depth = local.z() - 4006.5; idx = 1;}
+        else if (ii == 1) {depth = local.z() + 825.0;  idx = 3;}
+        else if (ii == 2) {depth = local.x() - 1775.;  idx = 0;}
+        else              {depth = local.y() + 15.;    idx = 2;}
+        break;
       }
     }
     if (found) break;
@@ -1043,7 +1043,7 @@ void HCalSD::plotProfile(const G4Step* aStep,const G4ThreeVector& global, double
 #ifdef EDM_ML_DEBUG
   LogDebug("HcalSim") << "plotProfile Found " << found << " Global " << global
                       << " Local " << local << " depth " << depth << " ID " 
-		      << id << " EDEP " << edep << " Time " << time;
+                      << id << " EDEP " << edep << " Time " << time;
 #endif
   if (hit_[idx]  != nullptr) hit_[idx]->Fill(edep);
   if (time_[idx] != nullptr) time_[idx]->Fill(time,edep);
@@ -1071,7 +1071,7 @@ void HCalSD::modifyDepth(HcalNumberingFromDDD::HcalID& id) {
     int ieta = (id.zside == 0) ? -id.etaR : id.etaR;
     if (hcalConstants->maxHFDepth(ieta,id.phis) > 2) {
       if (id.depth <= 2) {
-	if (G4UniformRand() > 0.5) id.depth += 2;
+        if (G4UniformRand() > 0.5) id.depth += 2;
       }
     }
   } else if ((id.subdet == 1 || id.subdet ==2) && testNumber) {

--- a/SimG4CMS/Calo/src/HFFibre.cc
+++ b/SimG4CMS/Calo/src/HFFibre.cc
@@ -13,6 +13,7 @@
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include <iostream>
+#include <sstream>
 
 //#define DebugLog
 
@@ -37,10 +38,12 @@ HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv,
     // Attenuation length
     nBinAtt      = -1;
     attL         = getDDDArray("attl",sv,nBinAtt);
-    edm::LogInfo("HFShower") << "HFFibre: " << nBinAtt << " attL ";
-    for (int it=0; it<nBinAtt; it++) 
-      edm::LogInfo("HFShower") << "HFFibre: attL[" << it << "] = " 
-			       << attL[it]*cm << "(1/cm)";
+    std::stringstream ss1;
+    for (int it=0; it<nBinAtt; it++) {
+      if(it/10*10 == it) { ss1 << "\n"; }
+      ss1 << "  " << attL[it]*cm;
+    }
+    edm::LogInfo("HFShower") << "HFFibre: " << nBinAtt << " attL(1/cm): " << ss1.str();
 
     // Limits on Lambda
     int nb   = 2;
@@ -53,16 +56,20 @@ HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv,
     // Fibre Lengths
     nb       = 0;
     longFL   = getDDDArray("LongFL",sv,nb);
-    edm::LogInfo("HFShower") << "HFFibre: " << nb << " Long Fibre Length";
-    for (int it=0; it<nb; it++) 
-      edm::LogInfo("HFShower") << "HFFibre: longFL[" << it << "] = " 
-			       << longFL[it]/cm << " cm";
-    nb       = 0;
+    std::stringstream ss2;
+    for (int it=0; it<nb; it++) {
+      if(it/10*10 == it) { ss2 << "\n"; }
+      ss2 << "  " << longFL[it]/cm;
+    }
+    edm::LogInfo("HFShower") << "HFFibre: " << nb << " Long Fibre Length(cm):" << ss2.str();
+    nb = 0;
     shortFL   = getDDDArray("ShortFL",sv,nb);
-    edm::LogInfo("HFShower") << "HFFibre: " << nb << " Short Fibre Length";
-    for (int it=0; it<nb; it++) 
-      edm::LogInfo("HFShower") << "HFFibre: shortFL[" << it << "] = " 
-			       << shortFL[it]/cm << " cm";
+    std::stringstream ss3;
+    for (int it=0; it<nb; it++) {
+      if(it/10*10 == it) { ss3 << "\n"; }
+      ss3 << "  " << shortFL[it]/cm;
+    } 
+    edm::LogInfo("HFShower") << "HFFibre: " << nb << " Short Fibre Length(cm):" << ss3.str();
   } else {
     edm::LogError("HFShower") << "HFFibre: cannot get filtered "
 			      << " view for " << attribute << " matching "
@@ -72,23 +79,19 @@ HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv,
   }
 }
 
-HFFibre::~HFFibre() {}
-
-void HFFibre::initRun(HcalDDDSimConstants* hcons) {
+void HFFibre::initRun(const HcalDDDSimConstants* hcons) {
 
   // Now geometry parameters
   gpar      = hcons->getGparHF();
-  edm::LogInfo("HFShower") << "HFFibre: " << gpar.size() <<" gpar (cm)";
-  for (unsigned int i=0; i<gpar.size(); i++)
-    edm::LogInfo("HFShower") << "HFFibre: gpar[" << i << "] = "
-                             << gpar[i]/cm << " cm";
-
   radius    = hcons->getRTableHF();
+
   nBinR     = (int)(radius.size());
-  edm::LogInfo("HFShower") << "HFFibre: " << radius.size() <<" rTable (cm)";
-  for (unsigned int i=0; i<radius.size(); i++)
-    edm::LogInfo("HFShower") << "HFFibre: radius[" << i << "] = "
-                             << radius[i]/cm << " cm";
+  std::stringstream sss;
+  for (int i=0; i<nBinR; ++i) {
+    if(i/10*10 == i) { sss << "\n"; }
+    sss << "  " << radius[i]/cm;
+  }
+  edm::LogInfo("HFShower") << "HFFibre: " << radius.size() <<" rTable(cm):" << sss.str();
 }
 
 double HFFibre::attLength(double lambda) {

--- a/SimG4CMS/Calo/src/HFFibre.cc
+++ b/SimG4CMS/Calo/src/HFFibre.cc
@@ -18,13 +18,13 @@
 //#define DebugLog
 
 HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv, 
-		 edm::ParameterSet const & p) {
+                 edm::ParameterSet const & p) {
 
   edm::ParameterSet m_HF = p.getParameter<edm::ParameterSet>("HFShower");
   cFibre           = c_light*(m_HF.getParameter<double>("CFibre"));
   
   edm::LogInfo("HFShower") << "HFFibre:: Speed of light in fibre " << cFibre
-			   << " m/ns";
+                           << " m/ns";
 
   std::string attribute = "Volume"; 
   std::string value     = "HF";
@@ -51,7 +51,7 @@ HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv,
     lambLim[0] = static_cast<int>(nvec[0]);
     lambLim[1] = static_cast<int>(nvec[1]);
     edm::LogInfo("HFShower") << "HFFibre: Limits on lambda " << lambLim[0]
-			     << " and " << lambLim[1];
+                             << " and " << lambLim[1];
 
     // Fibre Lengths
     nb       = 0;
@@ -72,8 +72,8 @@ HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv,
     edm::LogInfo("HFShower") << "HFFibre: " << nb << " Short Fibre Length(cm):" << ss3.str();
   } else {
     edm::LogError("HFShower") << "HFFibre: cannot get filtered "
-			      << " view for " << attribute << " matching "
-			      << name;
+                              << " view for " << attribute << " matching "
+                              << name;
     throw cms::Exception("Unknown", "HFFibre")
       << "cannot match " << attribute << " to " << name <<"\n";
   }
@@ -106,8 +106,8 @@ double HFFibre::attLength(double lambda) {
   double att = attL[j];
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFFibre::attLength for Lambda " << lambda
-			   << " index " << i  << " " << j << " Att. Length " 
-			   << att;
+                           << " index " << i  << " " << j << " Att. Length " 
+                           << att;
 #endif
   return att;
 }
@@ -118,8 +118,8 @@ double HFFibre::tShift(const G4ThreeVector& point, int depth, int fromEndAbs) {
   double time   = zFibre/cFibre;
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFFibre::tShift for point " << point
-			   << " ( depth = " << depth <<", traversed length = " 
-			   << zFibre/cm  << " cm) = " << time/ns << " ns";
+                           << " ( depth = " << depth <<", traversed length = " 
+                           << zFibre/cm  << " cm) = " << time/ns << " ns";
 #endif
   return time;
 }
@@ -153,21 +153,21 @@ double HFFibre::zShift(const G4ThreeVector& point, int depth, int fromEndAbs) { 
 
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFFibre::zShift for point " << point
-			   << " (R = " << hR/cm << " cm, Index = " << ieta 
-			   << ", depth = " << depth << ", Fibre Length = " 
-			   << length/cm       << " cm = " << zFibre/cm  
-			   << " cm)";
+                           << " (R = " << hR/cm << " cm, Index = " << ieta 
+                           << ", depth = " << depth << ", Fibre Length = " 
+                           << length/cm       << " cm = " << zFibre/cm  
+                           << " cm)";
 #endif
   return zFibre;
 }
 
 std::vector<double> HFFibre::getDDDArray(const std::string & str, 
-					 const DDsvalues_type & sv, 
-					 int & nmin) {
+                                         const DDsvalues_type & sv, 
+                                         int & nmin) {
 
 #ifdef DebugLog
   LogDebug("HFShower") << "HFFibre:getDDDArray called for " << str 
-		       << " with nMin " << nmin;
+                       << " with nMin " << nmin;
 #endif
   DDValue value(str);
   if (DDfetch(&sv,value)) {
@@ -178,18 +178,18 @@ std::vector<double> HFFibre::getDDDArray(const std::string & str,
     int nval = fvec.size();
     if (nmin > 0) {
       if (nval < nmin) {
-	edm::LogError("HFShower") << "HFFibre : # of " << str << " bins " 
-				  << nval << " < " << nmin << " ==> illegal";
-	throw cms::Exception("Unknown", "HFFibre")
-	  << "nval < nmin for array " << str <<"\n";
+        edm::LogError("HFShower") << "HFFibre : # of " << str << " bins " 
+                                  << nval << " < " << nmin << " ==> illegal";
+        throw cms::Exception("Unknown", "HFFibre")
+          << "nval < nmin for array " << str <<"\n";
       }
     } else {
       if (nval < 1 && nmin != 0) {
-	edm::LogError("HFShower") << "HFFibre : # of " << str << " bins " 
-				  << nval << " < 1 ==> illegal (nmin=" 
-				  << nmin << ")";
-	throw cms::Exception("Unknown", "HFFibre")
-	  << "nval < 1 for array " << str <<"\n";
+        edm::LogError("HFShower") << "HFFibre : # of " << str << " bins " 
+                                  << nval << " < 1 ==> illegal (nmin=" 
+                                  << nmin << ")";
+        throw cms::Exception("Unknown", "HFFibre")
+          << "nval < 1 for array " << str <<"\n";
       }
     }
     nmin = nval;
@@ -198,7 +198,7 @@ std::vector<double> HFFibre::getDDDArray(const std::string & str,
     if (nmin != 0) {
       edm::LogError("HFShower") << "HFFibre : cannot get array " << str;
       throw cms::Exception("Unknown", "HFFibre")
-	<< "cannot get array " << str <<"\n";
+        << "cannot get array " << str <<"\n";
     } else {
       std::vector<double> fvec;
       return fvec;

--- a/SimG4CMS/Calo/src/HFFibreFiducial.cc
+++ b/SimG4CMS/Calo/src/HFFibreFiducial.cc
@@ -6,18 +6,21 @@
 
 #include<iostream>
 
+//#define DebugLog
+
 int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
 {
   double xv  = pe_effect.x();          // X in global system
   double yv  = pe_effect.y();          // Y in global system
-  double zv  = pe_effect.z();          // Z in global system
   double phi = atan2(yv, xv);          // In global system
   if (phi < 0.) phi+=CLHEP::pi;        // Just for security
   double dph = CLHEP::pi/18;           // 10 deg = a half sector width
   double sph = dph+dph;                // 20 deg = a sector width
   int   nphi = phi/dph;                // 10 deg sector #
+#ifdef DebugLog
   edm::LogInfo("HFShower") <<"HFFibreFiducial:***> P = " << pe_effect 
                            << ", phi = " << phi/CLHEP::deg;
+#endif
   if (nphi > 35) nphi=35;              // Just for security
   double xl=0.;                        // local sector coordinates (left/right)
   double yl=0.;                        // local sector coordinates (down/up)
@@ -46,12 +49,16 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
     double sinr= sin(phir);
     yl= xv*cosr+yv*sinr;
     xl= yv*cosr-xv*sinr;
+#ifdef DebugLog
     edm::LogInfo("HFShower") << "HFFibreFiducial: nr " << nr << " phi " << phir/CLHEP::deg;
+#endif
   }
   if (yl < 0) yl =-yl;
+#ifdef DebugLog
   edm::LogInfo("HFShower") << "HFFibreFiducial: Global Point " << pe_effect
                            << " nphi " << nphi << " Local Sector Coordinates (" 
                            << xl << ", " << yl << "), widget # " << nwid;
+#endif
   // Provides a PMT # for the (x,y) hit in the widget # nwid (M. Kosov, 11.2010)
   // Send comments/questions to Mikhail.Kossov@cern.ch
   // nwid = 1-18 for Forward HF, 19-36 for Backward HF (all equal now)
@@ -1517,7 +1524,9 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
     return 0;
   }
   int nx=static_cast<int>(fx);           // Cell number (starting from 0)
+#ifdef DebugLog
   double phis=atan2(xl, yl)/CLHEP::deg;
+  double zv  = pe_effect.z();          // Z in global system
   edm::LogInfo("HFShower") << "HFFibreFiducial::PMTNumber:X = " << xv 
       << ", Y = " << yv << ", Z = " << zv << ", fX = "
       << fx << "-> nX = " << nx << ", nY = " << ny 
@@ -1526,9 +1535,10 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
       << nwid << ", phi = " << phi/CLHEP::deg 
       << ", phis = " << phis << ", phir = "
       << phir/CLHEP::deg;
+#endif
   if (nx >= nSL[ny])
   {
-    edm::LogInfo("HFShower") << "-Warning-HFFibreFiducial::nx/ny (" << nx 
+    edm::LogInfo("HFShower") << "HFFibreFiducial::nx/ny (" << nx 
                              << "," << ny <<") " << " above limit " << nSL[ny];
     return 0;                           // ===> out of the acceptance
   }
@@ -1538,16 +1548,21 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
   int flag= code%10;
   int npmt= code/10;
   bool src= false;                       // by default: not a source-tube
+#ifdef DebugLog
   edm::LogInfo("HFShower") << "HFFibreFiducial::nx/ny (" << nx << ","
                            << ny << ") code/flag/npmt " <<  code << "/" << flag
                            << "/" << npmt;
+#endif
+
   if (!flag) return 0;                   // ===> no fiber in the cell
   else if (flag==1) npmt += 24;
   else if (flag==3 || flag==4) {
     src=true;
   }
+#ifdef DebugLog
   edm::LogInfo("HFShower") << "HFFibreFiducial::PMTNumber: src = " << src 
                            << ", npmt =" << npmt;
+#endif
   if (src) return -npmt;   // return the negative number for the source
   return npmt;
 } // End of PMTNumber

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -24,7 +24,7 @@
 #include<iostream>
 
 HFShower::HFShower(const std::string & name, const DDCompactView & cpv, 
-		   edm::ParameterSet const & p, int chk) : cherenkov(nullptr),
+                   edm::ParameterSet const & p, int chk) : cherenkov(nullptr),
                                                            fibre(nullptr),
                                                            chkFibre(chk) {
 
@@ -97,7 +97,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
       ok = false;
     } else if (npmt > 24) { // a short fibre
       if (zv > gpar[0]) {
-	depth = 2; 
+        depth = 2; 
       } else {
         ok = false;
       }
@@ -124,10 +124,10 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
 
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFShower::getHits: in " << name << " Z " 
-			   << zCoor << "(" << globalPos.z() << ") " << zFibre 
-			   << " Trans " << translation << " Time " << tSlice  
-			   << " " << time << "\n                  Direction " 
-			   << momentumDir << " Local " << localMom;
+                           << zCoor << "(" << globalPos.z() << ") " << zFibre 
+                           << " Trans " << translation << " Time " << tSlice  
+                           << " " << time << "\n                  Direction " 
+                           << momentumDir << " Local " << localMom;
 #endif 
   // Here npe should be 0 if there is no fiber (@@ M.K.)
   int npe = 1;
@@ -146,23 +146,23 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
       double r2  = G4UniformRand();
 #ifdef DebugLog
       edm::LogInfo("HFShower") << "HFShower::getHits: " << i << " attenuation "
-			       << r1 <<":" << exp(-p*zFibre) << " r2 " << r2 
-			       << ":" << probMax << " Survive: " 
-			       << (r1 <= exp(-p*zFibre) && r2 <= probMax);
+                               << r1 <<":" << exp(-p*zFibre) << " r2 " << r2 
+                               << ":" << probMax << " Survive: " 
+                               << (r1 <= exp(-p*zFibre) && r2 <= probMax);
 #endif
       if (applyFidCut || chkFibre < 0 || (r1 <= exp(-p*zFibre) && r2 <= probMax)) {
-	hit.depth      = depth;
-	hit.time       = tSlice+time;
-	if (!applyFidCut) {
-	  hit.wavelength = wavelength[i]; // Tmp
-	  hit.momentum   = momz[i]; // Tmp
-	} else {
-	  hit.wavelength = 300.; // Tmp
-	  hit.momentum   = 1.; // Tmp
-	}
-	hit.position   = globalPos;
-	hits.push_back(hit);
-	nHit++;
+        hit.depth      = depth;
+        hit.time       = tSlice+time;
+        if (!applyFidCut) {
+          hit.wavelength = wavelength[i]; // Tmp
+          hit.momentum   = momz[i]; // Tmp
+        } else {
+          hit.wavelength = 300.; // Tmp
+          hit.momentum   = 1.; // Tmp
+        }
+        hit.position   = globalPos;
+        hits.push_back(hit);
+        nHit++;
       }
     }
   }
@@ -171,17 +171,17 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
   edm::LogInfo("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
   for (int i=0; i<nHit; ++i)
     edm::LogInfo("HFShower") << "HFShower::Hit " << i << " WaveLength " 
-			     << hits[i].wavelength << " Time " << hits[i].time
-			     << " Momentum " << hits[i].momentum <<" Position "
-			     << hits[i].position;
+                             << hits[i].wavelength << " Time " << hits[i].time
+                             << " Momentum " << hits[i].momentum <<" Position "
+                             << hits[i].position;
 #endif
   return hits;
 
 } 
 
 std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
-					     bool forLibraryProducer,
-					     double zoffset) {
+                                             bool forLibraryProducer,
+                                             double zoffset) {
 
   std::vector<HFShower::Hit> hits;
   int    nHit    = 0;
@@ -232,7 +232,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
       ok = false;
     } else if (npmt > 24) { // a short fibre
       if (zv > gpar[0]) {
-	depth = 2; 
+        depth = 2; 
       } else {
         ok = false;
       }
@@ -259,10 +259,10 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
 
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFShower::getHits: in " << name << " Z " <<zCoor
-			   << "(" << globalPos.z() <<") " << zFibre <<" Trans "
-			   << translation << " Time " << tSlice  << " " << time
-			   << "\n                  Direction " << momentumDir 
-			   << " Local " << localMom;
+                           << "(" << globalPos.z() <<") " << zFibre <<" Trans "
+                           << translation << " Time " << tSlice  << " " << time
+                           << "\n                  Direction " << momentumDir 
+                           << " Local " << localMom;
 #endif 
   // Here npe should be 0 if there is no fiber (@@ M.K.)
   int npe = 1;
@@ -281,23 +281,23 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
       double r2  = G4UniformRand();
 #ifdef DebugLog
       edm::LogInfo("HFShower") << "HFShower::getHits: " << i << " attenuation "
-			       << r1 << ":" << exp(-p*zFibre) << " r2 " << r2 
-			       << ":" << probMax << " Survive: " 
-			       << (r1 <= exp(-p*zFibre) && r2 <= probMax);
+                               << r1 << ":" << exp(-p*zFibre) << " r2 " << r2 
+                               << ":" << probMax << " Survive: " 
+                               << (r1 <= exp(-p*zFibre) && r2 <= probMax);
 #endif
       if (applyFidCut || chkFibre < 0 || (r1 <= exp(-p*zFibre) && r2 <= probMax)) {
-	hit.depth      = depth;
-	hit.time       = tSlice+time;
-	if (!applyFidCut) {
-	  hit.wavelength = wavelength[i]; // Tmp
-	  hit.momentum   = momz[i]; // Tmp
-	} else {
-	  hit.wavelength = 300.; // Tmp
-	  hit.momentum   = 1.; // Tmp
-	}
-	hit.position   = globalPos;
-	hits.push_back(hit);
-	nHit++;
+        hit.depth      = depth;
+        hit.time       = tSlice+time;
+        if (!applyFidCut) {
+          hit.wavelength = wavelength[i]; // Tmp
+          hit.momentum   = momz[i]; // Tmp
+        } else {
+          hit.wavelength = 300.; // Tmp
+          hit.momentum   = 1.; // Tmp
+        }
+        hit.position   = globalPos;
+        hits.push_back(hit);
+        nHit++;
       }
     }
   }
@@ -306,9 +306,9 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
   edm::LogInfo("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
   for (int i=0; i<nHit; ++i)
     edm::LogInfo("HFShower") << "HFShower::Hit " << i << " WaveLength " 
-			     << hits[i].wavelength << " Time " << hits[i].time
-			     << " Momentum " << hits[i].momentum <<" Position "
-			     << hits[i].position;
+                             << hits[i].wavelength << " Time " << hits[i].time
+                             << " Momentum " << hits[i].momentum <<" Position "
+                             << hits[i].position;
 #endif
   return hits;
 
@@ -363,7 +363,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, bool forLibra
       ok = false;
     } else if (npmt > 24) { // a short fibre
       if (zv > gpar[0]) {
-	depth = 2; 
+        depth = 2; 
       } else {
         ok = false;
       }
@@ -390,10 +390,10 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, bool forLibra
 
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFShower::getHits(SL): in " << name << " Z " 
-			   << zCoor << "(" << globalPos.z() << ") " << zFibre 
-			   << " Trans " << translation << " Time " << tSlice  
-			   << " " << time << "\n                  Direction " 
-			   << momentumDir << " Local " << localMom;
+                           << zCoor << "(" << globalPos.z() << ") " << zFibre 
+                           << " Trans " << translation << " Time " << tSlice  
+                           << " " << time << "\n                  Direction " 
+                           << momentumDir << " Local " << localMom;
 #endif
   // npe should be 0
   int npe = 0;
@@ -415,7 +415,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, bool forLibra
 
 std::vector<double> HFShower::getDDDArray(const std::string & str, 
                                           const DDsvalues_type & sv, 
-					  int & nmin) {
+                                          int & nmin) {
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShower:getDDDArray called for " << str 
                        << " with nMin " << nmin;
@@ -438,8 +438,7 @@ std::vector<double> HFShower::getDDDArray(const std::string & str,
       if (nval < 2) {
         edm::LogError("HFShower") << "HFShower : # of " << str << " bins " << nval
                                   << " < 2 ==> illegal" << " (nmin=" << nmin << ")";
-        throw cms::Exception("Unknown", "HFShower")
-	  << "nval < 2 for array " << str << "\n";
+        throw cms::Exception("Unknown", "HFShower") << "nval < 2 for array " << str;
       }
     }
     nmin = nval;

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -451,14 +451,9 @@ std::vector<double> HFShower::getDDDArray(const std::string & str,
   }
 }
 
-void HFShower::initRun(G4ParticleTable *, HcalDDDSimConstants* hcons) {
+void HFShower::initRun(const HcalDDDSimConstants* hcons) {
 
   //Special Geometry parameters
-  gpar      = hcons->getGparHF();
-  edm::LogInfo("HFShower") << "HFShower: " << gpar.size() << " gpar (cm)";
-  for (unsigned int ig=0; ig<gpar.size(); ig++)
-    edm::LogInfo("HFShower") << "HFShower: gpar[" << ig << "] = "
-                             << gpar[ig]/cm << " cm";
-
-  if (fibre) fibre->initRun(hcons);
+  gpar = hcons->getGparHF();
+  if (fibre) { fibre->initRun(hcons); }
 }

--- a/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
+++ b/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
@@ -16,6 +16,7 @@
 #include "G4Track.hh"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include <sstream>
 
 //#define DebugLog
 
@@ -82,15 +83,17 @@ HFShowerFibreBundle::~HFShowerFibreBundle() {
   delete cherenkov2;
 }
 
-void HFShowerFibreBundle::initRun(G4ParticleTable *, HcalDDDSimConstants* hcons) {
+void HFShowerFibreBundle::initRun(const HcalDDDSimConstants* hcons) {
 
   // Special Geometry parameters
   rTable   = hcons->getRTableHF();
+  std::stringstream sss;
+  for (unsigned int ig=0; ig<rTable.size(); ig++) {
+    if(ig/10*10 == ig) { sss << "\n"; }
+    sss << "  " << rTable[ig]/cm;
+  }
   edm::LogInfo("HFShower") << "HFShowerFibreBundle: " << rTable.size() 
-                           << " rTable (cm)";
-  for (unsigned int ig=0; ig<rTable.size(); ig++)
-    edm::LogInfo("HFShower") << "HFShowerFibreBundle: rTable[" << ig << "] = "
-                             << rTable[ig]/cm << " cm";
+                           << " rTable(cm):" << sss.str();
 }
 
 double HFShowerFibreBundle::getHits(const G4Step * aStep, bool type) {

--- a/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
+++ b/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
@@ -21,8 +21,8 @@
 //#define DebugLog
 
 HFShowerFibreBundle::HFShowerFibreBundle(const std::string & name, 
-					 const DDCompactView & cpv,
-					 edm::ParameterSet const & p) {
+                                         const DDCompactView & cpv,
+                                         edm::ParameterSet const & p) {
 
   edm::ParameterSet m_HF1 = p.getParameter<edm::ParameterSet>("HFShowerStraightBundle");
   facTube                 = m_HF1.getParameter<double>("FactorBundle");
@@ -31,8 +31,8 @@ HFShowerFibreBundle::HFShowerFibreBundle(const std::string & name,
   facCone                 = m_HF2.getParameter<double>("FactorBundle");
   cherenkov2              = new HFCherenkov(m_HF2);
   edm::LogInfo("HFShower") << "HFShowerFibreBundle intialized with factors: "
-			   << facTube << " for the straight portion and "
-			   << facCone << " for the curved portion";
+                           << facTube << " for the straight portion and "
+                           << facCone << " for the curved portion";
 
   //Special Geometry parameters
   std::string attribute = "Volume";
@@ -47,7 +47,7 @@ HFShowerFibreBundle::HFShowerFibreBundle(const std::string & name,
       int index = static_cast<int>(neta[ii]);
       int ir=-1, ifib=-1;
       if (index >= 0) {
-	ir   = index/10; ifib = index%10;
+        ir   = index/10; ifib = index%10;
       }
       pmtR1.push_back(ir);
       pmtFib1.push_back(ifib);
@@ -57,23 +57,23 @@ HFShowerFibreBundle::HFShowerFibreBundle(const std::string & name,
       int index = static_cast<int>(neta[ii]);
       int ir=-1, ifib=-1;
       if (index >= 0) {
-	ir   = index/10; ifib = index%10;
+        ir   = index/10; ifib = index%10;
       }
       pmtR2.push_back(ir);
       pmtFib2.push_back(ifib);
     }
     edm::LogInfo("HFShower") << "HFShowerFibreBundle: gets the Index matches "
-			     << "for " << neta.size() << " PMTs";
+                             << "for " << neta.size() << " PMTs";
     for (unsigned int ii=0; ii<neta.size(); ii++) 
       edm::LogInfo("HFShower") << "HFShowerFibreBundle: rIndexR[" << ii 
-			       << "] = " << pmtR1[ii] << " fibreR[" << ii 
-			       << "] = " << pmtFib1[ii] << " rIndexL[" << ii 
-			       << "] = " << pmtR2[ii] << " fibreL[" << ii 
-			       << "] = " << pmtFib2[ii];
+                               << "] = " << pmtR1[ii] << " fibreR[" << ii 
+                               << "] = " << pmtFib1[ii] << " rIndexL[" << ii 
+                               << "] = " << pmtR2[ii] << " fibreL[" << ii 
+                               << "] = " << pmtFib2[ii];
   } else {
     edm::LogWarning("HFShower") << "HFShowerFibreBundle: cannot get filtered "
-				<< " view for " << attribute << " matching "
-				<< value;
+                                << " view for " << attribute << " matching "
+                                << value;
   }
   
 }
@@ -115,8 +115,8 @@ double HFShowerFibreBundle::getHits(const G4Step * aStep, bool type) {
 #ifdef DebugLog
   double edep = aStep->GetTotalEnergyDeposit();
   LogDebug("HFShower") << "HFShowerFibreBundle: Box " << boxNo << " PMT "
-		       << pmtNo << " Mapped Indices " << indexR << ", "
-		       << indexF << " Edeposit " << edep/MeV << " MeV";
+                       << pmtNo << " Mapped Indices " << indexR << ", "
+                       << indexF << " Edeposit " << edep/MeV << " MeV";
 #endif
 
   double photons = 0;
@@ -130,18 +130,18 @@ double HFShowerFibreBundle::getHits(const G4Step * aStep, bool type) {
       GetTopTransform().TransformAxis(pDir);
     if (type) {
       photons = facCone*cherenkov2->computeNPEinPMT(particleDef, beta,
-						    localMom.x(), localMom.y(),
-						    localMom.z(), stepl);
+                                                    localMom.x(), localMom.y(),
+                                                    localMom.z(), stepl);
     } else {
       photons = facTube*cherenkov1->computeNPEinPMT(particleDef, beta,
-						    localMom.x(), localMom.y(),
-						    localMom.z(), stepl);
+                                                    localMom.x(), localMom.y(),
+                                                    localMom.z(), stepl);
     }
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerFibreBundle::getHits: for particle " 
-		       << particleDef->GetParticleName() << " Step " << stepl
-		       << " Beta " << beta << " Direction " << pDir
-		       << " Local " << localMom << " p.e. " << photons;
+                       << particleDef->GetParticleName() << " Step " << stepl
+                       << " Beta " << beta << " Direction " << pDir
+                       << " Local " << localMom << " p.e. " << photons;
 #endif 
 
   }
@@ -156,18 +156,18 @@ double HFShowerFibreBundle::getRadius() {
 #ifdef DebugLog
   else
     LogDebug("HFShower") << "HFShowerFibreBundle::getRadius: R " << indexR
-			 << " F " << indexF;
+                         << " F " << indexF;
 #endif
   if (indexF == 2)  r =-r;
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerFibreBundle: Radius (" << indexR << "/" 
-		       << indexF << ") " << r;
+                       << indexF << ") " << r;
 #endif
   return r;
 }
 
 std::vector<double> HFShowerFibreBundle::getDDDArray(const std::string & str, 
-						     const DDsvalues_type& sv){
+                                                     const DDsvalues_type& sv){
 
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerFibreBundle:getDDDArray called for " << str;
@@ -181,9 +181,9 @@ std::vector<double> HFShowerFibreBundle::getDDDArray(const std::string & str,
     int nval = fvec.size();
     if (nval < 2) {
       edm::LogError("HFShower") << "HFShowerFibreBundle: # of " << str 
-				<< " bins " << nval << " < 2 ==> illegal";
+                                << " bins " << nval << " < 2 ==> illegal";
       throw cms::Exception("Unknown", "HFShowerFibreBundle")
-	<< "nval < 2 for array " << str << "\n";
+        << "nval < 2 for array " << str << "\n";
     }
 
     return fvec;

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -23,10 +23,10 @@
 //#define DebugLog
 
 HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView & cpv,
-				 edm::ParameterSet const & p) : fibre(nullptr),hf(nullptr),
-								emBranch(nullptr),
-								hadBranch(nullptr),
-								npe(0) {
+                                 edm::ParameterSet const & p) : fibre(nullptr),hf(nullptr),
+                                                                emBranch(nullptr),
+                                                                hadBranch(nullptr),
+                                                                npe(0) {
   
 
   edm::ParameterSet m_HF  = p.getParameter<edm::ParameterSet>("HFShower");
@@ -50,12 +50,12 @@ HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView &
 
   if (!hf->IsOpen()) { 
     edm::LogError("HFShower") << "HFShowerLibrary: opening " << nTree 
-			      << " failed";
+                              << " failed";
     throw cms::Exception("Unknown", "HFShowerLibrary") 
       << "Opening of " << pTreeName << " fails\n";
   } else {
     edm::LogInfo("HFShower") << "HFShowerLibrary: opening " << nTree 
-			     << " successfully"; 
+                             << " successfully"; 
   }
 
   newForm = (branchEvInfo == "");
@@ -72,26 +72,26 @@ HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView &
       loadEventInfo(evtInfo);
     } else {
       edm::LogError("HFShower") << "HFShowerLibrary: HFShowerLibrayEventInfo"
-				<< " Branch does not exist in Event";
+                                << " Branch does not exist in Event";
       throw cms::Exception("Unknown", "HFShowerLibrary")
-	<< "Event information absent\n";
+        << "Event information absent\n";
     }
   } else {
     edm::LogError("HFShower") << "HFShowerLibrary: Events Tree does not "
-			      << "exist";
+                              << "exist";
     throw cms::Exception("Unknown", "HFShowerLibrary")
       << "Events tree absent\n";
   }
   
   edm::LogInfo("HFShower") << "HFShowerLibrary: Library " << libVers 
-			   << " ListVersion "	<< listVersion 
-			   << " Events Total " << totEvents << " and "
-			   << evtPerBin << " per bin";
+                           << " ListVersion "        << listVersion 
+                           << " Events Total " << totEvents << " and "
+                           << evtPerBin << " per bin";
   edm::LogInfo("HFShower") << "HFShowerLibrary: Energies (GeV) with " 
-			   << nMomBin	<< " bins";
+                           << nMomBin        << " bins";
   for (int i=0; i<nMomBin; i++)
     edm::LogInfo("HFShower") << "HFShowerLibrary: pmom[" << i << "] = "
-			     << pmom[i]/GeV << " GeV";
+                             << pmom[i]/GeV << " GeV";
 
   std::string nameBr = branchPre + emName + branchPost;
   emBranch         = event->GetBranch(nameBr.c_str());
@@ -106,14 +106,14 @@ HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView &
   }
   
   edm::LogInfo("HFShower") << " HFShowerLibrary:Branch " << emName 
-			   << " has " << emBranch->GetEntries() 
-			   << " entries and Branch " << hadName 
-			   << " has " << hadBranch->GetEntries() 
-			   << " entries"
+                           << " has " << emBranch->GetEntries() 
+                           << " entries and Branch " << hadName 
+                           << " has " << hadBranch->GetEntries() 
+                           << " entries"
                            << "\n HFShowerLibrary::No packing information -"
-			   << " Assume x, y, z are not in packed form"
-			   << "\n Maximum probability cut off " 
-			   << probMax << "  Back propagation of light prob. "
+                           << " Assume x, y, z are not in packed form"
+                           << "\n Maximum probability cut off " 
+                           << probMax << "  Back propagation of light prob. "
                            << backProb;
   
   fibre = new HFFibre(name, cpv, p);
@@ -149,13 +149,13 @@ void HFShowerLibrary::initRun(const HcalDDDSimConstants* hcons) {
   geantinoPDG= theParticleTable->FindParticle(parName="geantino")->GetPDGEncoding();
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFShowerLibrary: Particle codes for e- = " 
-			   << emPDG << ", e+ = " << epPDG << ", gamma = " 
-			   << gammaPDG << ", pi0 = " << pi0PDG << ", eta = " 
-			   << etaPDG << ", geantino = " << geantinoPDG 
-			   << "\n        nu_e = " << nuePDG << ", nu_mu = " 
-			   << numuPDG << ", nu_tau = " << nutauPDG 
-			   << ", anti_nu_e = " << anuePDG << ", anti_nu_mu = " 
-			   << anumuPDG << ", anti_nu_tau = " << anutauPDG;
+                           << emPDG << ", e+ = " << epPDG << ", gamma = " 
+                           << gammaPDG << ", pi0 = " << pi0PDG << ", eta = " 
+                           << etaPDG << ", geantino = " << geantinoPDG 
+                           << "\n        nu_e = " << nuePDG << ", nu_mu = " 
+                           << numuPDG << ", nu_tau = " << nutauPDG 
+                           << ", anti_nu_e = " << anuePDG << ", anti_nu_mu = " 
+                           << anumuPDG << ", anti_nu_tau = " << anutauPDG;
 #endif
   
   //Radius (minimum and maximum)
@@ -176,9 +176,9 @@ void HFShowerLibrary::initRun(const HcalDDDSimConstants* hcons) {
 }
 
 std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(const G4Step * aStep,
-							   bool & isKilled,
-							   double weight,
-							   bool onlyLong) {
+                                                           bool & isKilled,
+                                                           double weight,
+                                                           bool onlyLong) {
 
   auto const preStepPoint  = aStep->GetPreStepPoint(); 
   auto const postStepPoint = aStep->GetPostStepPoint(); 
@@ -199,7 +199,7 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(const G4Step * aStep,
 
   edm::LogInfo("HFShower") << "HFShowerLibrary::getHits " << partType
                            << " of energy " << pin/GeV << " GeV"
-			   << " weight= " << weight << " onlyLong: " << onlyLong
+                           << " weight= " << weight << " onlyLong: " << onlyLong
                            << "  dir.orts " << momDir.x() << ", " <<momDir.y()
                            << ", " << momDir.z() << "  Pos x,y,z = "
                            << hitPoint.x() << "," << hitPoint.y() << ","
@@ -258,13 +258,13 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
     edm::LogInfo("HFShower") << "HFShowerLibrary: Hit " << i << " " << pe[i] << " zv " << zv;
 #endif
     if (zv <= gpar[1] && pe[i].lambda() > 0 && 
-	(pe[i].z() >= 0 || (zv > gpar[0] && (!onlyLong)))) {
+        (pe[i].z() >= 0 || (zv > gpar[0] && (!onlyLong)))) {
       int depth = 1;
       if (onlyLong) {
       } else if (backward == 0) {    // fully valid only for "front" particles
-	if (pe[i].z() < 0) depth = 2;// with "front"-simulated shower lib.
+        if (pe[i].z() < 0) depth = 2;// with "front"-simulated shower lib.
       } else {                       // for "backward" particles - almost equal
-	double r = G4UniformRand();  // share between L and S fibers
+        double r = G4UniformRand();  // share between L and S fibers
         if (r > 0.5) depth = 2;
       } 
       
@@ -295,9 +295,9 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
       double dfir  = r * sin(dfi);
 #ifdef DebugLog
       edm::LogInfo("HFShower") << "HFShowerLibrary: Position shift " << xx 
-			       << ", " << yy << ", "  << zz << ": " << pos 
-			       << " R " << r << " Phi " << fi << " Section " 
-			       << isect << " R*Dfi " << dfir << " Dist " << zv;
+                               << ", " << yy << ", "  << zz << ": " << pos 
+                               << " R " << r << " Phi " << fi << " Section " 
+                               << isect << " R*Dfi " << dfir << " Dist " << zv;
 #endif
       zz           = std::abs(pos.z());
       double r1    = G4UniformRand();
@@ -308,69 +308,69 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
 
 #ifdef DebugLog
       edm::LogInfo("HFShower") << "HFShowerLibrary: rLimits " << rInside(r)
-			       << " attenuation " << r1 <<":" << exp(-p*zv) 
-			       << " r2 " << r2 << " r3 " << r3 << " rDfi "  
-			       << gpar[5] << " zz " 
-			       << zz << " zLim " << gpar[4] << ":" 
-			       << gpar[4]+gpar[1] << "\n"
-			       << "  rInside(r) :" << rInside(r) 
-			       << "  r1 <= exp(-p*zv) :" <<  (r1 <= exp(-p*zv))
-			       << "  r2 <= probMax :"    <<  (r2 <= probMax*weight)
-			       << "  r3 <= backProb :"   <<  (r3 <= backProb) 
-			       << "  dfir > gpar[5] :"   <<  (dfir > gpar[5])
-			       << "  zz >= gpar[4] :"    <<  (zz >= gpar[4])
-			       << "  zz <= gpar[4]+gpar[1] :" 
-			       << (zz <= gpar[4]+gpar[1]);   
+                               << " attenuation " << r1 <<":" << exp(-p*zv) 
+                               << " r2 " << r2 << " r3 " << r3 << " rDfi "  
+                               << gpar[5] << " zz " 
+                               << zz << " zLim " << gpar[4] << ":" 
+                               << gpar[4]+gpar[1] << "\n"
+                               << "  rInside(r) :" << rInside(r) 
+                               << "  r1 <= exp(-p*zv) :" <<  (r1 <= exp(-p*zv))
+                               << "  r2 <= probMax :"    <<  (r2 <= probMax*weight)
+                               << "  r3 <= backProb :"   <<  (r3 <= backProb) 
+                               << "  dfir > gpar[5] :"   <<  (dfir > gpar[5])
+                               << "  zz >= gpar[4] :"    <<  (zz >= gpar[4])
+                               << "  zz <= gpar[4]+gpar[1] :" 
+                               << (zz <= gpar[4]+gpar[1]);   
 #endif
       if (rInside(r) && r1 <= exp(-p*zv) && r2 <= probMax*weight && 
-	  dfir > gpar[5] && zz >= gpar[4] && zz <= gpar[4]+gpar[1] && 
-	  r3 <= backProb && (depth != 2 || zz >= gpar[4]+gpar[0])) {
-	oneHit.position = pos;
-	oneHit.depth    = depth;
-	oneHit.time     = (tSlice+(pe[i].t())+(fibre->tShift(lpos,depth,1)));
-	hit.push_back(oneHit);
+          dfir > gpar[5] && zz >= gpar[4] && zz <= gpar[4]+gpar[1] && 
+          r3 <= backProb && (depth != 2 || zz >= gpar[4]+gpar[0])) {
+        oneHit.position = pos;
+        oneHit.depth    = depth;
+        oneHit.time     = (tSlice+(pe[i].t())+(fibre->tShift(lpos,depth,1)));
+        hit.push_back(oneHit);
 #ifdef DebugLog
-	edm::LogInfo("HFShower") << "HFShowerLibrary: Final Hit " << nHit 
-				 <<" position " << (hit[nHit].position) 
-				 << " Depth " << (hit[nHit].depth) <<" Time " 
-				 << tSlice << ":" << pe[i].t() << ":" 
-				 << fibre->tShift(lpos,depth,1) << ":" 
-				 << (hit[nHit].time);
+        edm::LogInfo("HFShower") << "HFShowerLibrary: Final Hit " << nHit 
+                                 <<" position " << (hit[nHit].position) 
+                                 << " Depth " << (hit[nHit].depth) <<" Time " 
+                                 << tSlice << ":" << pe[i].t() << ":" 
+                                 << fibre->tShift(lpos,depth,1) << ":" 
+                                 << (hit[nHit].time);
 #endif
-	nHit++;
+        nHit++;
       }
 #ifdef DebugLog
       else  LogDebug("HFShower") << "HFShowerLibrary: REJECTED !!!";
 #endif
       if (onlyLong && zz >= gpar[4]+gpar[0] && zz <= gpar[4]+gpar[1]) {
-	r1    = G4UniformRand();
-	r2    = G4UniformRand();
-	if (rInside(r) && r1 <= exp(-p*zv) && r2 <= probMax && dfir > gpar[5]){
-	  oneHit.position = pos;
-	  oneHit.depth    = 2;
-	  oneHit.time     = (tSlice+(pe[i].t())+(fibre->tShift(lpos,2,1)));
-	  hit.push_back(oneHit);
+        r1    = G4UniformRand();
+        r2    = G4UniformRand();
+        if (rInside(r) && r1 <= exp(-p*zv) && r2 <= probMax && dfir > gpar[5]){
+          oneHit.position = pos;
+          oneHit.depth    = 2;
+          oneHit.time     = (tSlice+(pe[i].t())+(fibre->tShift(lpos,2,1)));
+          hit.push_back(oneHit);
 #ifdef DebugLog
-	  edm::LogInfo("HFShower") << "HFShowerLibrary: Final Hit " << nHit 
-				   << " position " << (hit[nHit].position) 
-				   << " Depth " << (hit[nHit].depth) <<" Time "
-				   << tSlice << ":" << pe[i].t() << ":" 
-				   << fibre->tShift(lpos,2,1) << ":" 
-				   << (hit[nHit].time);
+          edm::LogInfo("HFShower") << "HFShowerLibrary: Final Hit " << nHit 
+                                   << " position " << (hit[nHit].position) 
+                                   << " Depth " << (hit[nHit].depth) <<" Time "
+                                   << tSlice << ":" << pe[i].t() << ":" 
+                                   << fibre->tShift(lpos,2,1) << ":" 
+                                   << (hit[nHit].time);
 #endif
-	  nHit++;
-	}
+          nHit++;
+        }
       }
     }
   }
 
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFShowerLibrary: Total Hits " << nHit
-			   << " out of " << npe << " PE";
+                           << " out of " << npe << " PE";
 #endif
   if (nHit > npe && !onlyLong)
     edm::LogWarning("HFShower") << "HFShowerLibrary: Hit buffer " << npe 
-				<< " smaller than " << nHit << " Hits";
+                                << " smaller than " << nHit << " Hits";
  return hit;
 
 }
@@ -388,19 +388,19 @@ void HFShowerLibrary::getRecord(int type, int record) {
   if (type > 0) {
     if (newForm) {
       if ( !v3version ) {
-	hadBranch->SetAddress(&photo);
-	hadBranch->GetEntry(nrc+totEvents);
+        hadBranch->SetAddress(&photo);
+        hadBranch->GetEntry(nrc+totEvents);
       }
       else{
-	std::vector<float> t;
-	std::vector<float> *tp=&t;
-	hadBranch->SetAddress(&tp);
-	hadBranch->GetEntry(nrc+totEvents);
-	unsigned int tSize=t.size()/5;
-	photo->reserve(tSize);
-	for ( unsigned int i=0; i<tSize; i++ ) {
-	  photo->push_back( HFShowerPhoton( t[i], t[1*tSize+i], t[2*tSize+i], t[3*tSize+i], t[4*tSize+i] ) );
-	}
+        std::vector<float> t;
+        std::vector<float> *tp=&t;
+        hadBranch->SetAddress(&tp);
+        hadBranch->GetEntry(nrc+totEvents);
+        unsigned int tSize=t.size()/5;
+        photo->reserve(tSize);
+        for ( unsigned int i=0; i<tSize; i++ ) {
+          photo->push_back( HFShowerPhoton( t[i], t[1*tSize+i], t[2*tSize+i], t[3*tSize+i], t[4*tSize+i] ) );
+        }
       }
     } else {
       hadBranch->SetAddress(&photon);
@@ -409,19 +409,19 @@ void HFShowerLibrary::getRecord(int type, int record) {
   } else {
     if (newForm) {
       if (!v3version) {
-	emBranch->SetAddress(&photo);
-	emBranch->GetEntry(nrc);
+        emBranch->SetAddress(&photo);
+        emBranch->GetEntry(nrc);
       }
       else{
-	std::vector<float> t;
-	std::vector<float> *tp=&t;
-	emBranch->SetAddress(&tp);
-	emBranch->GetEntry(nrc);
-	unsigned int tSize=t.size()/5;
-	photo->reserve(tSize);
-	for ( unsigned int i=0; i<tSize; i++ ) {
-	  photo->push_back( HFShowerPhoton( t[i], t[1*tSize+i], t[2*tSize+i], t[3*tSize+i], t[4*tSize+i] ) );
-	}
+        std::vector<float> t;
+        std::vector<float> *tp=&t;
+        emBranch->SetAddress(&tp);
+        emBranch->GetEntry(nrc);
+        unsigned int tSize=t.size()/5;
+        photo->reserve(tSize);
+        for ( unsigned int i=0; i<tSize; i++ ) {
+          photo->push_back( HFShowerPhoton( t[i], t[1*tSize+i], t[2*tSize+i], t[3*tSize+i], t[4*tSize+i] ) );
+        }
       }
     } else {
       emBranch->SetAddress(&photon);
@@ -431,8 +431,8 @@ void HFShowerLibrary::getRecord(int type, int record) {
 #ifdef DebugLog
   int nPhoton = (newForm) ? photo->size() : photon.size();
   LogDebug("HFShower") << "HFShowerLibrary::getRecord: Record " << record
-		       << " of type " << type << " with " << nPhoton 
-		       << " photons";
+                       << " of type " << type << " with " << nPhoton 
+                       << " photons";
   for (int j = 0; j < nPhoton; j++) 
     if (newForm) LogDebug("HFShower") << "Photon " << j << " " << photo->at(j);
     else         LogDebug("HFShower") << "Photon " << j << " " << photon[j];
@@ -446,8 +446,8 @@ void HFShowerLibrary::loadEventInfo(TBranch* branch) {
     branch->SetAddress(&eventInfoCollection);
     branch->GetEntry(0);
     edm::LogInfo("HFShower") << "HFShowerLibrary::loadEventInfo loads "
-			     << " EventInfo Collection of size "
-			     << eventInfoCollection.size() << " records";
+                             << " EventInfo Collection of size "
+                             << eventInfoCollection.size() << " records";
     totEvents   = eventInfoCollection[0].totalEvents();
     nMomBin     = eventInfoCollection[0].numberOfBins();
     evtPerBin   = eventInfoCollection[0].eventsPerBin();
@@ -456,7 +456,7 @@ void HFShowerLibrary::loadEventInfo(TBranch* branch) {
     pmom        = eventInfoCollection[0].energyBins();
   } else {
     edm::LogInfo("HFShower") << "HFShowerLibrary::loadEventInfo loads "
-			     << " EventInfo from hardwired numbers";
+                             << " EventInfo from hardwired numbers";
     nMomBin     = 16;
     evtPerBin   = 5000;
     totEvents   = nMomBin*evtPerBin;
@@ -472,8 +472,8 @@ void HFShowerLibrary::interpolate(int type, double pin) {
 
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerLibrary:: Interpolate for Energy " <<pin/GeV
-		       << " GeV with " << nMomBin << " momentum bins and " 
-		       << evtPerBin << " entries/bin -- total " << totEvents;
+                       << " GeV with " << nMomBin << " momentum bins and " 
+                       << evtPerBin << " entries/bin -- total " << totEvents;
 #endif
   int irc[2]={0,0};
   double w = 0.;
@@ -486,41 +486,41 @@ void HFShowerLibrary::interpolate(int type, double pin) {
   } else {
     for (int j=0; j<nMomBin-1; j++) {
       if (pin >= pmom[j] && pin < pmom[j+1]) {
-	w = (pin-pmom[j])/(pmom[j+1]-pmom[j]);
-	if (j == nMomBin-2) { 
-	  irc[1] = int(evtPerBin*0.5*r);
-	} else {
-	  irc[1] = int(evtPerBin*r);
-	}
-	irc[1] += (j+1)*evtPerBin + 1;
-	r = G4UniformRand();
-	irc[0] = int(evtPerBin*r) + 1 + j*evtPerBin;
-	if (irc[0]<0) {
-	  edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[0] = "
-				      << irc[0] << " now set to 0";
-	  irc[0] = 0;
-	} else if (irc[0] > totEvents) {
-	  edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[0] = "
-				      << irc[0] << " now set to "<< totEvents;
-	  irc[0] = totEvents;
-	}
+        w = (pin-pmom[j])/(pmom[j+1]-pmom[j]);
+        if (j == nMomBin-2) { 
+          irc[1] = int(evtPerBin*0.5*r);
+        } else {
+          irc[1] = int(evtPerBin*r);
+        }
+        irc[1] += (j+1)*evtPerBin + 1;
+        r = G4UniformRand();
+        irc[0] = int(evtPerBin*r) + 1 + j*evtPerBin;
+        if (irc[0]<0) {
+          edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[0] = "
+                                      << irc[0] << " now set to 0";
+          irc[0] = 0;
+        } else if (irc[0] > totEvents) {
+          edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[0] = "
+                                      << irc[0] << " now set to "<< totEvents;
+          irc[0] = totEvents;
+        }
       }
     }
   }
   if (irc[1]<1) {
     edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[1] = " 
-				<< irc[1] << " now set to 1";
+                                << irc[1] << " now set to 1";
     irc[1] = 1;
   } else if (irc[1] > totEvents) {
     edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[1] = " 
-				<< irc[1] << " now set to "<< totEvents;
+                                << irc[1] << " now set to "<< totEvents;
     irc[1] = totEvents;
   }
 
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerLibrary:: Select records " << irc[0] 
-		       << " and " << irc[1] << " with weights " << 1-w 
-		       << " and " << w;
+                       << " and " << irc[1] << " with weights " << 1-w 
+                       << " and " << w;
 #endif
   pe.clear(); 
   npe       = 0;
@@ -531,25 +531,25 @@ void HFShowerLibrary::interpolate(int type, double pin) {
       int nPhoton = (newForm) ? photo->size() : photon.size();
       npold      += nPhoton;
       for (int j=0; j<nPhoton; j++) {
-	r = G4UniformRand();
-	if ((ir==0 && r > w) || (ir > 0 && r < w)) {
-	  storePhoton (j);
-	}
+        r = G4UniformRand();
+        if ((ir==0 && r > w) || (ir > 0 && r < w)) {
+          storePhoton (j);
+        }
       }
     }
   }
 
   if ((npe > npold || (npold == 0 && irc[0] > 0)) && !(npe == 0 && npold == 0))
     edm::LogWarning("HFShower") << "HFShowerLibrary: Interpolation Warning =="
-				<< " records " << irc[0] << " and " << irc[1]
-				<< " gives a buffer of " << npold 
-				<< " photons and fills " << npe << " *****";
+                                << " records " << irc[0] << " and " << irc[1]
+                                << " gives a buffer of " << npold 
+                                << " photons and fills " << npe << " *****";
 #ifdef DebugLog
   else
     LogDebug("HFShower") << "HFShowerLibrary: Interpolation == records " 
-			 << irc[0] << " and " << irc[1] << " gives a "
-			 << "buffer of " << npold << " photons and fills "
-			 << npe << " PE";
+                         << irc[0] << " and " << irc[1] << " gives a "
+                         << "buffer of " << npold << " photons and fills "
+                         << npe << " PE";
   for (int j=0; j<npe; j++)
     LogDebug("HFShower") << "Photon " << j << " " << pe[j];
 #endif
@@ -562,9 +562,9 @@ void HFShowerLibrary::extrapolate(int type, double pin) {
   nrec++;
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerLibrary:: Extrapolate for Energy " << pin 
-		       << " GeV with " << nMomBin << " momentum bins and " 
-		       << evtPerBin << " entries/bin -- total " << totEvents 
-		       << " using " << nrec << " records";
+                       << " GeV with " << nMomBin << " momentum bins and " 
+                       << evtPerBin << " entries/bin -- total " << totEvents 
+                       << " using " << nrec << " records";
 #endif
   std::vector<int> irc(nrec);
 
@@ -573,17 +573,17 @@ void HFShowerLibrary::extrapolate(int type, double pin) {
     irc[ir] = int(evtPerBin*0.5*r) +(nMomBin-1)*evtPerBin + 1;
     if (irc[ir]<1) {
       edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[" << ir 
-				  << "] = " << irc[ir] << " now set to 1";
+                                  << "] = " << irc[ir] << " now set to 1";
       irc[ir] = 1;
     } else if (irc[ir] > totEvents) {
       edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[" << ir 
-				  << "] = " << irc[ir] << " now set to "
-				  << totEvents;
+                                  << "] = " << irc[ir] << " now set to "
+                                  << totEvents;
       irc[ir] = totEvents;
 #ifdef DebugLog
     } else {
       LogDebug("HFShower") << "HFShowerLibrary::Extrapolation use irc[" 
-			   << ir  << "] = " << irc[ir];
+                           << ir  << "] = " << irc[ir];
 #endif
     }
   }
@@ -597,14 +597,14 @@ void HFShowerLibrary::extrapolate(int type, double pin) {
       int nPhoton = (newForm) ? photo->size() : photon.size();
       npold      += nPhoton;
       for (int j=0; j<nPhoton; j++) {
-	double r = G4UniformRand();
-	if (ir != nrec-1 || r < w) {
-	  storePhoton (j);
-	}
+        double r = G4UniformRand();
+        if (ir != nrec-1 || r < w) {
+          storePhoton (j);
+        }
       }
 #ifdef DebugLog
       LogDebug("HFShower") << "HFShowerLibrary: Record [" << ir << "] = " 
-			   << irc[ir] << " npold = " << npold;
+                           << irc[ir] << " npold = " << npold;
 #endif
     }
   }
@@ -614,16 +614,16 @@ void HFShowerLibrary::extrapolate(int type, double pin) {
 
   if (npe > npold || npold == 0)
     edm::LogWarning("HFShower") << "HFShowerLibrary: Extrapolation Warning == "
-				<< nrec << " records " << irc[0] << ", " 
-				<< irc[1] << ", ... gives a buffer of " <<npold
-				<< " photons and fills " << npe 
-				<< " *****";
+                                << nrec << " records " << irc[0] << ", " 
+                                << irc[1] << ", ... gives a buffer of " <<npold
+                                << " photons and fills " << npe 
+                                << " *****";
 #ifdef DebugLog
   else
     LogDebug("HFShower") << "HFShowerLibrary: Extrapolation == " << nrec
-			 << " records " << irc[0] << ", " << irc[1] 
-			 << ", ... gives a buffer of " << npold 
-			 << " photons and fills " << npe << " PE";
+                         << " records " << irc[0] << ", " << irc[1] 
+                         << ", ... gives a buffer of " << npold 
+                         << " photons and fills " << npe << " PE";
   for (int j=0; j<npe; j++)
     LogDebug("HFShower") << "Photon " << j << " " << pe[j];
 #endif
@@ -635,18 +635,18 @@ void HFShowerLibrary::storePhoton(int j) {
   else         pe.push_back(photon[j]);
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerLibrary: storePhoton " << j << " npe " 
-		       << npe << " " << pe[npe];
+                       << npe << " " << pe[npe];
 #endif
   npe++;
 }
 
 std::vector<double> HFShowerLibrary::getDDDArray(const std::string & str, 
-						 const DDsvalues_type & sv, 
-						 int & nmin) {
+                                                 const DDsvalues_type & sv, 
+                                                 int & nmin) {
 
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerLibrary:getDDDArray called for " << str 
-		       << " with nMin " << nmin;
+                       << " with nMin " << nmin;
 #endif
   DDValue value(str);
   if (DDfetch(&sv,value)) {
@@ -657,19 +657,19 @@ std::vector<double> HFShowerLibrary::getDDDArray(const std::string & str,
     int nval = fvec.size();
     if (nmin > 0) {
       if (nval < nmin) {
-	edm::LogError("HFShower") << "HFShowerLibrary : # of " << str 
-				  << " bins " << nval << " < " << nmin 
-				  << " ==> illegal";
-	throw cms::Exception("Unknown", "HFShowerLibrary")
-	  << "nval < nmin for array " << str << "\n";
+        edm::LogError("HFShower") << "HFShowerLibrary : # of " << str 
+                                  << " bins " << nval << " < " << nmin 
+                                  << " ==> illegal";
+        throw cms::Exception("Unknown", "HFShowerLibrary")
+          << "nval < nmin for array " << str << "\n";
       }
     } else {
       if (nval < 2) {
-	edm::LogError("HFShower") << "HFShowerLibrary : # of " << str 
-				  << " bins " << nval << " < 2 ==> illegal"
-				  << " (nmin=" << nmin << ")";
-	throw cms::Exception("Unknown", "HFShowerLibrary")
-	  << "nval < 2 for array " << str << "\n";
+        edm::LogError("HFShower") << "HFShowerLibrary : # of " << str 
+                                  << " bins " << nval << " < 2 ==> illegal"
+                                  << " (nmin=" << nmin << ")";
+        throw cms::Exception("Unknown", "HFShowerLibrary")
+          << "nval < 2 for array " << str << "\n";
       }
     }
     nmin = nval;

--- a/SimG4CMS/Calo/src/HFShowerPMT.cc
+++ b/SimG4CMS/Calo/src/HFShowerPMT.cc
@@ -21,7 +21,7 @@
 //#define DebugLog
 
 HFShowerPMT::HFShowerPMT(const std::string & name, const DDCompactView & cpv,
-			 edm::ParameterSet const & p) : cherenkov(nullptr) {
+                         edm::ParameterSet const & p) : cherenkov(nullptr) {
 
   edm::ParameterSet m_HF  = p.getParameter<edm::ParameterSet>("HFShowerPMT");
   pePerGeV                = m_HF.getParameter<double>("PEPerGeVPMT");
@@ -39,7 +39,7 @@ HFShowerPMT::HFShowerPMT(const std::string & name, const DDCompactView & cpv,
       int index = static_cast<int>(neta[ii]);
       int ir=-1, ifib=-1;
       if (index >= 0) {
-	ir   = index/10; ifib = index%10;
+        ir   = index/10; ifib = index%10;
       }
       pmtR1.push_back(ir);
       pmtFib1.push_back(ifib);
@@ -49,26 +49,26 @@ HFShowerPMT::HFShowerPMT(const std::string & name, const DDCompactView & cpv,
       int index = static_cast<int>(neta[ii]);
       int ir=-1, ifib=-1;
       if (index >= 0) {
-	ir   = index/10; ifib = index%10;
+        ir   = index/10; ifib = index%10;
       }
       pmtR2.push_back(ir);
       pmtFib2.push_back(ifib);
     }
 #ifdef DebugLog
     edm::LogInfo("HFShower") << "HFShowerPMT: gets the Index matches for "
-			     << neta.size() << " PMTs";
+                             << neta.size() << " PMTs";
     for (unsigned int ii=0; ii<neta.size(); ii++) {
       edm::LogInfo("HFShower") << "HFShowerPMT: rIndexR[" << ii << "] = "
-			       << pmtR1[ii] << " fibreR[" << ii << "] = "
-			       << pmtFib1[ii] << " rIndexL[" << ii << "] = "
-			       << pmtR2[ii] << " fibreL[" << ii << "] = "
-			       << pmtFib2[ii];
+                               << pmtR1[ii] << " fibreR[" << ii << "] = "
+                               << pmtFib1[ii] << " rIndexL[" << ii << "] = "
+                               << pmtR2[ii] << " fibreL[" << ii << "] = "
+                               << pmtFib2[ii];
     }
 #endif
   } else {
     edm::LogWarning("HFShower") << "HFShowerPMT: cannot get filtered "
-				<< " view for " << attribute << " matching "
-				<< value;
+                                << " view for " << attribute << " matching "
+                                << value;
   }
 
   cherenkov = new HFCherenkov(m_HF);
@@ -88,7 +88,7 @@ void HFShowerPMT::initRun(const HcalDDDSimConstants* hcons) {
     sss << "  " << rTable[ig]/cm;
   }
   edm::LogInfo("HFShowerPMT") << "HFShowerPMT: " << rTable.size() 
-			      << " rTable(cm):" << sss.str();
+                              << " rTable(cm):" << sss.str();
 }
 
 double HFShowerPMT::getHits(const G4Step * aStep) {
@@ -110,9 +110,9 @@ double HFShowerPMT::getHits(const G4Step * aStep) {
 #ifdef DebugLog
   double edep = aStep->GetTotalEnergyDeposit();
   LogDebug("HFShower") << "HFShowerPMT: Box " << boxNo << " PMT "
-		       << pmtNo << " Mapped Indices " << indexR << ", "
-		       << indexF << " Edeposit " << edep/MeV << " MeV; PE "
-		       << edep*pePerGeV/GeV;
+                       << pmtNo << " Mapped Indices " << indexR << ", "
+                       << indexF << " Edeposit " << edep/MeV << " MeV; PE "
+                       << edep*pePerGeV/GeV;
 #endif
 
   double photons = 0;
@@ -125,12 +125,12 @@ double HFShowerPMT::getHits(const G4Step * aStep) {
     G4ThreeVector localMom = preStepPoint->GetTouchable()->GetHistory()->
       GetTopTransform().TransformAxis(pDir);
     photons = cherenkov->computeNPEinPMT(particleDef, beta, localMom.x(),
-					 localMom.y(), localMom.z(), stepl);
+                                         localMom.y(), localMom.z(), stepl);
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerPMT::getHits: for particle " 
-		       << particleDef->GetParticleName() << " Step " << stepl
-		       << " Beta " << beta << " Direction " << pDir
-		       << " Local " << localMom << " p.e. " << photons;
+                       << particleDef->GetParticleName() << " Step " << stepl
+                       << " Beta " << beta << " Direction " << pDir
+                       << " Local " << localMom << " p.e. " << photons;
 #endif 
 
   }
@@ -145,18 +145,18 @@ double HFShowerPMT::getRadius() {
 #ifdef DebugLog
   else
     LogDebug("HFShower") << "HFShowerPMT::getRadius: R " << indexR
-			 << " F " << indexF;
+                         << " F " << indexF;
 #endif
   if (indexF == 2)  r =-r;
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerPMT: Radius (" << indexR << "/" << indexF 
-		       << ") " << r;
+                       << ") " << r;
 #endif
   return r;
 }
 
 std::vector<double> HFShowerPMT::getDDDArray(const std::string & str, 
-					     const DDsvalues_type & sv) {
+                                             const DDsvalues_type & sv) {
 
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerPMT:getDDDArray called for " << str;
@@ -170,9 +170,9 @@ std::vector<double> HFShowerPMT::getDDDArray(const std::string & str,
     int nval = fvec.size();
     if (nval < 2) {
       edm::LogError("HFShower") << "HFShowerPMT: # of " << str 
-				<< " bins " << nval << " < 2 ==> illegal";
+                                << " bins " << nval << " < 2 ==> illegal";
       throw cms::Exception("Unknown", "HFShowerPMT")
-	<< "nval < 2 for array " << str << "\n";
+        << "nval < 2 for array " << str << "\n";
     }
 
     return fvec;

--- a/SimG4CMS/Calo/src/HFShowerPMT.cc
+++ b/SimG4CMS/Calo/src/HFShowerPMT.cc
@@ -16,6 +16,7 @@
 #include "G4Track.hh"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include <sstream>
 
 //#define DebugLog
 
@@ -53,14 +54,17 @@ HFShowerPMT::HFShowerPMT(const std::string & name, const DDCompactView & cpv,
       pmtR2.push_back(ir);
       pmtFib2.push_back(ifib);
     }
+#ifdef DebugLog
     edm::LogInfo("HFShower") << "HFShowerPMT: gets the Index matches for "
 			     << neta.size() << " PMTs";
-    for (unsigned int ii=0; ii<neta.size(); ii++) 
+    for (unsigned int ii=0; ii<neta.size(); ii++) {
       edm::LogInfo("HFShower") << "HFShowerPMT: rIndexR[" << ii << "] = "
 			       << pmtR1[ii] << " fibreR[" << ii << "] = "
 			       << pmtFib1[ii] << " rIndexL[" << ii << "] = "
 			       << pmtR2[ii] << " fibreL[" << ii << "] = "
 			       << pmtFib2[ii];
+    }
+#endif
   } else {
     edm::LogWarning("HFShower") << "HFShowerPMT: cannot get filtered "
 				<< " view for " << attribute << " matching "
@@ -74,15 +78,17 @@ HFShowerPMT::~HFShowerPMT() {
   if (cherenkov) delete cherenkov;
 }
 
-void HFShowerPMT::initRun(G4ParticleTable *, HcalDDDSimConstants* hcons) {
+void HFShowerPMT::initRun(const HcalDDDSimConstants* hcons) {
 
   // Special Geometry parameters
-  rTable   = hcons->getRTableHF();
-  edm::LogInfo("HFShower") << "HFShowerPMT: " << rTable.size() 
-                           << " rTable (cm)";
-  for (unsigned int ig=0; ig<rTable.size(); ig++)
-    edm::LogInfo("HFShower") << "HFShowerPMT: rTable[" << ig << "] = "
-                             << rTable[ig]/cm << " cm";
+  rTable = hcons->getRTableHF();
+  std::stringstream sss;
+  for (unsigned int ig=0; ig<rTable.size(); ++ig) {
+    if(ig/10*10 == ig) { sss << "\n"; }
+    sss << "  " << rTable[ig]/cm;
+  }
+  edm::LogInfo("HFShowerPMT") << "HFShowerPMT: " << rTable.size() 
+			      << " rTable(cm):" << sss.str();
 }
 
 double HFShowerPMT::getHits(const G4Step * aStep) {

--- a/SimG4CMS/Calo/src/HFShowerParam.cc
+++ b/SimG4CMS/Calo/src/HFShowerParam.cc
@@ -96,7 +96,7 @@ HFShowerParam::~HFShowerParam() {
 }
 
 void HFShowerParam::initRun(const HcalDDDSimConstants* hcons) {
-  if (showerLibrary) showerLibrary->initRun(hcons);
+  if (showerLibrary) showerLibrary->initRun(nullptr, hcons);
   if (fibre)         fibre->initRun(hcons);
 }
 

--- a/SimG4CMS/Calo/src/HFShowerParam.cc
+++ b/SimG4CMS/Calo/src/HFShowerParam.cc
@@ -53,7 +53,7 @@ HFShowerParam::HFShowerParam(const std::string & name, const DDCompactView & cpv
                            << " shower library set to " << !(onlyLong)
                            << ", use of parametrization for last part set to "
                            << parametrizeLast << ", Mean lambda " << lambdaMean
-			   << ", aperture (cutoff) " << aperture
+                           << ", aperture (cutoff) " << aperture
                            << ", Application of Fiducial Cut " << applyFidCut;
 
 #ifdef plotDebug
@@ -61,7 +61,7 @@ HFShowerParam::HFShowerParam(const std::string & name, const DDCompactView & cpv
   if (tfile.isAvailable()) {
     fillHisto = true;
     LogDebug("HFShower") << "HFShowerParam::Save histos in directory "
-			 << "ProfileFromParam";
+                         << "ProfileFromParam";
     TFileDirectory showerDir = tfile->mkdir("ProfileFromParam");
     hzvem           = showerDir.make<TH1F>("hzvem", "Longitudinal Profile (EM Part);Number of PE",330,0.0,1650.0);
     hzvhad          = showerDir.make<TH1F>("hzvhad","Longitudinal Profile (Had Part);Number of PE",330,0.0,1650.0);
@@ -77,7 +77,7 @@ HFShowerParam::HFShowerParam(const std::string & name, const DDCompactView & cpv
   } else {
     fillHisto = false;
     edm::LogInfo("HFShower") << "HFShowerParam::No file is available for "
-			     << "saving histos so the flag is set to false";
+                             << "saving histos so the flag is set to false";
   }
 #endif
   
@@ -101,8 +101,8 @@ void HFShowerParam::initRun(const HcalDDDSimConstants* hcons) {
 }
 
 std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep, 
-						       double weight, 
-						       bool& isKilled) {
+                                                       double weight, 
+                                                       bool& isKilled) {
   auto const preStepPoint  = aStep->GetPreStepPoint(); 
   auto const track    = aStep->GetTrack();
   bool isEM = G4TrackToParticleID::isGammaElectronPositron(track);
@@ -135,8 +135,8 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
   if (hitPoint.z() < 0) dirz *= -1.;
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFShowerParam: getHits Momentum " 
-			   <<track->GetDynamicParticle()->GetMomentumDirection()
-			   << " HitPoint " << hitPoint << " dirz " << dirz;
+                           <<track->GetDynamicParticle()->GetMomentumDirection()
+                           << " HitPoint " << hitPoint << " dirz " << dirz;
 #endif  
   if (!isEM && track->GetDefinition()->GetPDGCharge() != 0 && pBeta > (1/ref_index) &&
       aStep->GetTotalEnergyDeposit() > 0.) { other = true; }
@@ -149,13 +149,13 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
       edep = pin;
       isKilled = true;
     } else if ((track->GetDefinition()->GetPDGCharge() != 0) && 
-	       (pBeta > (1/ref_index)) && (dirz > aperture)) {
+               (pBeta > (1/ref_index)) && (dirz > aperture)) {
       edep = (aStep->GetTotalEnergyDeposit())/GeV;
     }
     std::string path = "ShowerLibrary";
 #ifdef DebugLog
     edm::LogInfo("HFShower") << "HFShowerParam: getHits edep = " << edep
-			     << " weight " << weight << " final " <<edep*weight
+                             << " weight " << weight << " final " <<edep*weight
                              << ", Kill = " << kill << ", pin = " << pin 
                              << ", edMin = " << edMin << " Other " << other;
 #endif
@@ -181,7 +181,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
               hits.push_back(hit);
 #ifdef plotDebug
               if (fillHisto) {
-		double zv  = std::abs(hit.position.z()) - gpar[4];
+                double zv  = std::abs(hit.position.z()) - gpar[4];
                 hzvem->Fill(zv);
                 em_long_sl->Fill(hit.position.z()/cm);
                 double sq = sqrt(pow(hit.position.x()/cm,2)+pow(hit.position.y()/cm,2));
@@ -229,16 +229,16 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
               if (npmt <= 0) {
 #ifdef DebugLog
                 edm::LogInfo("HFShower") << "-#PMT=0 cut-HFShowerParam::"
-					 << "getHits: npmt = " << npmt;
+                                         << "getHits: npmt = " << npmt;
 #endif
                 ok = false;
               } else if (npmt > 24) { // a short fibre
                 if    (zv > gpar[0]) {
-		  depth = 2; 
+                  depth = 2; 
                 } else {
 #ifdef DebugLog
                   edm::LogInfo("HFShower") << "-SHORT cut-HFShowerParam::"
-					   << "getHits:zMin=" << gpar[0];
+                                           << "getHits:zMin=" << gpar[0];
 #endif
                   ok = false;
                 }
@@ -248,7 +248,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
                                        << " zv " << std::abs(pe_effect.z()) 
                                        << ":" << gpar[4] << ":" << zv << ":" 
                                        << gpar[0] << " ok " << ok << " depth "
-				       << depth;
+                                       << depth;
 #endif
             } else {
               if (G4UniformRand() > 0.5) depth = 2;
@@ -264,43 +264,43 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
 #endif
             if (r1 > exp(-attLMeanInv*dist)) ok = false;
             if (ok) {
-	      double r2   = G4UniformRand();
+              double r2   = G4UniformRand();
 #ifdef DebugLog
-	      edm::LogInfo("HFShower") << "HFShowerParam:Extra exclusion "
-				       << r2 << ">" << weight << " "
-				       << (r2 > weight);
+              edm::LogInfo("HFShower") << "HFShowerParam:Extra exclusion "
+                                       << r2 << ">" << weight << " "
+                                       << (r2 > weight);
 #endif
-	      if (r2 < weight) {
-		double time = fibre->tShift(localPoint,depth,0);
+              if (r2 < weight) {
+                double time = fibre->tShift(localPoint,depth,0);
 
-		hit.position = hitSL[i].position;
-		hit.depth    = depth;
-		hit.time     = time + hitSL[i].time;
-		hit.edep     = 1;
-		hits.push_back(hit);
+                hit.position = hitSL[i].position;
+                hit.depth    = depth;
+                hit.time     = time + hitSL[i].time;
+                hit.edep     = 1;
+                hits.push_back(hit);
 #ifdef plotDebug
-		if (fillHisto) {
-		  em_long_gflash->Fill(pe_effect.z()/cm, hitSL[i].edep);
-		  hzvem->Fill(zv);
-		  double sq = sqrt(pow(hit.position.x()/cm,2)+pow(hit.position.y()/cm,2));
-		  double zp = hit.position.z()/cm;
-		  if (hit.depth == 1) {
-		    em_2d_1->Fill(zp, sq);
-		    em_lateral_1->Fill(s);
-		    em_long_1->Fill(zp);
-		  } else if (hit.depth == 2) {
-		    em_2d_2->Fill(zp, sq);
-		    em_lateral_2->Fill(sq);
-		    em_long_2->Fill(zp);
-		  }
-		}
+                if (fillHisto) {
+                  em_long_gflash->Fill(pe_effect.z()/cm, hitSL[i].edep);
+                  hzvem->Fill(zv);
+                  double sq = sqrt(pow(hit.position.x()/cm,2)+pow(hit.position.y()/cm,2));
+                  double zp = hit.position.z()/cm;
+                  if (hit.depth == 1) {
+                    em_2d_1->Fill(zp, sq);
+                    em_lateral_1->Fill(s);
+                    em_long_1->Fill(zp);
+                  } else if (hit.depth == 2) {
+                    em_2d_2->Fill(zp, sq);
+                    em_lateral_2->Fill(sq);
+                    em_long_2->Fill(zp);
+                  }
+                }
 #endif
 #ifdef DebugLog
-		edm::LogInfo("HFShower") << "HFShowerParam: Hit at depth " 
-					 << hit.depth << " with edep " 
-					 << hit.edep << " Time "  << hit.time;
+                edm::LogInfo("HFShower") << "HFShowerParam: Hit at depth " 
+                                         << hit.depth << " with edep " 
+                                         << hit.edep << " Time "  << hit.time;
 #endif
-	      }
+              }
             }
           }
         }
@@ -309,54 +309,54 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep,
         edep         *= pePerGeV;
         double tSlice = (aStep->GetPostStepPoint()->GetGlobalTime());
         double time   = fibre->tShift(localPoint,1,0); // remaining part
-	bool ok = true;
-	if (applyFidCut) { // @@ For showerlibrary no z-cut for Short (no z)
-	  int npmt = HFFibreFiducial:: PMTNumber(hitPoint);
-	  if (npmt <= 0) ok = false;
-	} 
+        bool ok = true;
+        if (applyFidCut) { // @@ For showerlibrary no z-cut for Short (no z)
+          int npmt = HFFibreFiducial:: PMTNumber(hitPoint);
+          if (npmt <= 0) ok = false;
+        } 
 #ifdef DebugLog
-	edm::LogInfo("HFShower") << "HFShowerParam: getHits hitPoint " << hitPoint << " flag " << ok;
+        edm::LogInfo("HFShower") << "HFShowerParam: getHits hitPoint " << hitPoint << " flag " << ok;
 #endif
-	if (ok) {
-	  hit.depth     = 1;
-	  hit.time      = tSlice+time;
-	  hit.edep      = edep;
-	  hits.push_back(hit);
+        if (ok) {
+          hit.depth     = 1;
+          hit.time      = tSlice+time;
+          hit.edep      = edep;
+          hits.push_back(hit);
 #ifdef DebugLog
-	  edm::LogInfo("HFShower") << "HFShowerParam: Hit at depth 1 with edep "
-				   << edep << " Time " << tSlice << ":" << time
-				   << ":" << hit.time;
+          edm::LogInfo("HFShower") << "HFShowerParam: Hit at depth 1 with edep "
+                                   << edep << " Time " << tSlice << ":" << time
+                                   << ":" << hit.time;
 #endif
 #ifdef plotDebug
-	  double zv = std::abs(hitPoint.z()) - gpar[4];
-	  if (fillHisto) {
-	    hzvhad->Fill(zv);
-	  }
+          double zv = std::abs(hitPoint.z()) - gpar[4];
+          if (fillHisto) {
+            hzvhad->Fill(zv);
+          }
 #endif
-	  if (zz >= gpar[0]) {
-	    time      = fibre->tShift(localPoint,2,0);
-	    hit.depth = 2;
-	    hit.time  = tSlice+time;
-	    hits.push_back(hit);
+          if (zz >= gpar[0]) {
+            time      = fibre->tShift(localPoint,2,0);
+            hit.depth = 2;
+            hit.time  = tSlice+time;
+            hits.push_back(hit);
 #ifdef DebugLog
-	    edm::LogInfo("HFShower") <<"HFShowerParam: Hit at depth 2 with edep "
-				     << edep << " Time " << tSlice << ":" << time
-				     << hit.time;
+            edm::LogInfo("HFShower") <<"HFShowerParam: Hit at depth 2 with edep "
+                                     << edep << " Time " << tSlice << ":" << time
+                                     << hit.time;
 #endif
 #ifdef plotDebug
-	    if (fillHisto) {
-	      hzvhad->Fill(zv);
-	    }
+            if (fillHisto) {
+              hzvhad->Fill(zv);
+            }
 #endif
-	  }
-	}
+          }
+        }
       }
 #ifdef DebugLog
       for (unsigned int ii=0; ii<hits.size(); ++ii) {
         double zv = std::abs(hits[ii].position.z());
         if (zv > 12790) edm::LogInfo("HFShower")<< "HFShowerParam: Abnormal hit along " 
                                                 << path << " in " 
-						<< preStepPoint->GetPhysicalVolume()->GetLogicalVolume()->GetName()
+                                                << preStepPoint->GetPhysicalVolume()->GetLogicalVolume()->GetName()
                                                 << " at " << hits[ii].position << " zz " 
                                                 << zv << " Edep " << edep << " due to " 
                                                 <<track->GetDefinition()->GetParticleName()

--- a/SimG4CMS/Calo/src/HGCSD.cc
+++ b/SimG4CMS/Calo/src/HGCSD.cc
@@ -90,39 +90,7 @@ HGCSD::~HGCSD() {
   delete numberingScheme;
   delete mouseBite_;
 }
-/*
-bool HGCSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
-  NaNTrap( aStep ) ;
-  
-  if (aStep == nullptr) {
-    return true;
-  } else {
-    double r = aStep->GetPreStepPoint()->GetPosition().perp();
-    double z = std::abs(aStep->GetPreStepPoint()->GetPosition().z());
-#ifdef EDM_ML_DEBUG
-    G4int parCode = aStep->GetTrack()->GetDefinition()->GetPDGEncoding();
-    bool notaMuon = (parCode == mupPDG || parCode == mumPDG ) ? false : true;
-    G4LogicalVolume* lv =
-      aStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume();
-    edm::LogInfo("HGCSim") << "HGCSD: Hit from standard path from "
-			   << lv->GetName() << " for Track " 
-			   << aStep->GetTrack()->GetTrackID() << " ("
-			   << aStep->GetTrack()->GetDefinition()->GetParticleName() 
-			   << ":" << notaMuon << ") R = " << r << " Z = " << z
-			   << " slope = " << r/z << ":" << slopeMin_;
-#endif
-    // Apply fiducial cuts
-    if (r/z >= slopeMin_) {
-      if (getStepInfo(aStep)) {
-	if ((storeAllG4Hits_ || (hitExists() == false)) && 
-	    (edepositEM+edepositHAD>0.)) currentHit = createNewHit();
-      }
-    }
-    return true;
-  }
-} 
-*/
 double HGCSD::getEnergyDeposit(const G4Step* aStep) {
   double destep(0.0);
   double r = aStep->GetPreStepPoint()->GetPosition().perp();
@@ -224,14 +192,6 @@ void HGCSD::update(const BeginOfJob * job) {
 }
 
 void HGCSD::initRun() {
-  G4ParticleTable * theParticleTable = G4ParticleTable::GetParticleTable();
-  G4String          particleName;
-  mumPDG = theParticleTable->FindParticle(particleName="mu-")->GetPDGEncoding();
-  mupPDG = theParticleTable->FindParticle(particleName="mu+")->GetPDGEncoding();
-#ifdef EDM_ML_DEBUG
-  edm::LogInfo("HGCSim") << "HGCSD: Particle code for mu- = " << mumPDG
-			 << " for mu+ = " << mupPDG;
-#endif
 }
 
 bool HGCSD::filterHit(CaloG4Hit* aHit, double time) {
@@ -244,24 +204,4 @@ uint32_t HGCSD::setDetUnitId (ForwardSubdetector &subdet, int layer, int module,
     numberingScheme->getUnitID(subdet, layer, module, cell, iz, pos) : 0;
   return id;
 }
-/*
-int HGCSD::setTrackID (const G4Step* aStep) {
-  const G4Track* theTrack    = aStep->GetTrack();
 
-  double etrack = preStepPoint->GetKineticEnergy();
-  TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
-  int      primaryID = trkInfo->getIDonCaloSurface();
-  if (primaryID == 0) {
-#ifdef EDM_ML_DEBUG
-    edm::LogInfo("HGCSim") << "HGCSD: Problem with primaryID **** set by "
-			   << "force to TkID **** " <<theTrack->GetTrackID();
-#endif
-    primaryID = theTrack->GetTrackID();
-  }
-
-  if (primaryID != previousID.trackID())
-    resetForNewPrimary(preStepPoint->GetPosition(), etrack);
-
-  return primaryID;
-}
-*/

--- a/SimG4CMS/Calo/src/HGCSD.cc
+++ b/SimG4CMS/Calo/src/HGCSD.cc
@@ -87,10 +87,10 @@ HGCSD::HGCSD(const std::string& name, const DDCompactView & cpv,
 }
 
 HGCSD::~HGCSD() { 
-  if (numberingScheme)  delete numberingScheme;
-  if (mouseBite_)       delete mouseBite_;
+  delete numberingScheme;
+  delete mouseBite_;
 }
-
+/*
 bool HGCSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
   NaNTrap( aStep ) ;
@@ -122,12 +122,19 @@ bool HGCSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
     return true;
   }
 } 
+*/
+double HGCSD::getEnergyDeposit(const G4Step* aStep) {
+  double destep(0.0);
+  double r = aStep->GetPreStepPoint()->GetPosition().perp();
+  double z = std::abs(aStep->GetPreStepPoint()->GetPosition().z());
 
-double HGCSD::getEnergyDeposit(G4Step* aStep) {
-  double wt1    = getResponseWt(aStep->GetTrack());
-  double wt2    = aStep->GetTrack()->GetWeight();
-  double destep = wt1*(aStep->GetTotalEnergyDeposit());
-  if (wt2 > 0) destep *= wt2;
+  // check fiductial volume
+  if (r >= z*slopeMin_) {
+    double wt1    = getResponseWt(aStep->GetTrack());
+    destep *= wt1*aStep->GetTotalEnergyDeposit();
+    double wt2    = aStep->GetTrack()->GetWeight();
+    if (wt2 > 0) { destep *= wt2; }
+  }
   return destep;
 }
 
@@ -237,7 +244,7 @@ uint32_t HGCSD::setDetUnitId (ForwardSubdetector &subdet, int layer, int module,
     numberingScheme->getUnitID(subdet, layer, module, cell, iz, pos) : 0;
   return id;
 }
-
+/*
 int HGCSD::setTrackID (const G4Step* aStep) {
   const G4Track* theTrack    = aStep->GetTrack();
 
@@ -257,3 +264,4 @@ int HGCSD::setTrackID (const G4Step* aStep) {
 
   return primaryID;
 }
+*/

--- a/SimG4CMS/Calo/src/HGCSD.cc
+++ b/SimG4CMS/Calo/src/HGCSD.cc
@@ -99,7 +99,7 @@ double HGCSD::getEnergyDeposit(const G4Step* aStep) {
   // check fiductial volume
   if (r >= z*slopeMin_) {
     double wt1    = getResponseWt(aStep->GetTrack());
-    destep *= wt1*aStep->GetTotalEnergyDeposit();
+    destep = wt1*aStep->GetTotalEnergyDeposit();
     double wt2    = aStep->GetTrack()->GetWeight();
     if (wt2 > 0) { destep *= wt2; }
   }

--- a/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
+++ b/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
@@ -23,12 +23,13 @@ public:
   DreamSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
   ~DreamSD() override {}
-  bool   ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
+  //  bool   ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
   uint32_t setDetUnitId(const G4Step*) override;
 
 protected:
 
-  G4bool getStepInfo(G4Step* aStep) override;
+  // G4bool getStepInfo(G4Step* aStep) override;
+  double getEnergyDeposit(const G4Step* ) override;
   void   initRun() override;
 
 private:    

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -27,8 +27,8 @@
 
 //________________________________________________________________________________________
 DreamSD::DreamSD(const std::string& name, const DDCompactView & cpv,
-		 const SensitiveDetectorCatalog & clg,
-		 edm::ParameterSet const & p, const SimTrackManager* manager) : 
+                 const SensitiveDetectorCatalog & clg,
+                 edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager) {
 
   edm::ParameterSet m_EC = p.getParameter<edm::ParameterSet>("ECalSD");
@@ -43,15 +43,15 @@ DreamSD::DreamSD(const std::string& name, const DDCompactView & cpv,
   chAngleIntegrals_.reset(nullptr);
   
   edm::LogInfo("EcalSim")  << "Constructing a DreamSD  with name " << GetName() << "\n"
-			   << "DreamSD:: Use of Birks law is set to      " 
-			   << useBirk << "  with three constants kB = "
-			   << birk1 << ", C1 = " << birk2 << ", C2 = " 
-			   << birk3 << "\n"
-			   << "          Slope for Light yield is set to "
-			   << slopeLY << "\n"
+                           << "DreamSD:: Use of Birks law is set to      " 
+                           << useBirk << "  with three constants kB = "
+                           << birk1 << ", C1 = " << birk2 << ", C2 = " 
+                           << birk3 << "\n"
+                           << "          Slope for Light yield is set to "
+                           << slopeLY << "\n"
                            << "          Parameterization of Cherenkov is set to " 
                            << doCherenkov_ << " and readout both sides is "
-			   << readBothSide_;
+                           << readBothSide_;
 
   initMap(name,cpv);
 
@@ -76,97 +76,7 @@ DreamSD::DreamSD(const std::string& name, const DDCompactView & cpv,
 }
 
 //________________________________________________________________________________________
-/*
-bool DreamSD::ProcessHits(G4Step * aStep, G4TouchableHistory *) {
-
-  if (aStep == nullptr) {
-    return true;
-  } else {
-    side = 1;
-    if (getStepInfo(aStep)) {
-      if (hitExists() == false && edepositEM+edepositHAD>0.)
-        currentHit = createNewHit();
-      if (readBothSide_) {
-	side = -1;
-	getStepInfo(aStep);
-	if (hitExists() == false && edepositEM+edepositHAD>0.)
-	  currentHit = createNewHit();
-      }
-    }
-  }
-  return true;
-}
-
-
-//________________________________________________________________________________________
-bool DreamSD::getStepInfo(G4Step* aStep) {
-
-  preStepPoint = aStep->GetPreStepPoint();
-  theTrack     = aStep->GetTrack();
-  G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
-
-  // take into account light collection curve for crystals
-  double weight = 1.;
-  weight *= curve_LY(aStep, side);
-  if (useBirk)   weight *= getAttenuation(aStep, birk1, birk2, birk3);
-  edepositEM  = aStep->GetTotalEnergyDeposit() * weight;
-  LogDebug("EcalSim") << "DreamSD:: " << nameVolume << " Side " << side
-		      <<" Light Collection Efficiency " << weight 
-		      << " Weighted Energy Deposit " << edepositEM/MeV 
-		      << " MeV";
-  // Get cherenkov contribution
-  if ( doCherenkov_ ) {
-    edepositHAD = cherenkovDeposit_( aStep );
-  } else {
-    edepositHAD = 0;
-  }
-
-  double       time  = (aStep->GetPostStepPoint()->GetGlobalTime())/nanosecond;
-  unsigned int unitID= setDetUnitId(aStep);
-  if (side < 0) unitID++;
-  TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
-  int      primaryID;
-
-  if (trkInfo)
-    primaryID = trkInfo->getIDonCaloSurface();
-  else
-    primaryID = 0;
-
-  if (primaryID == 0) {
-    edm::LogWarning("EcalSim") << "CaloSD: Problem with primaryID **** set by "
-                               << "force to TkID **** "
-                               << theTrack->GetTrackID() << " in Volume "
-                               << preStepPoint->GetTouchable()->GetVolume(0)->GetName();
-    primaryID = theTrack->GetTrackID();
-  }
-
-  bool flag = (unitID > 0);
-  G4TouchableHistory* touch =(G4TouchableHistory*)(theTrack->GetTouchable());
-  if (flag) {
-    currentID.setID(unitID, time, primaryID, 0);
-
-    LogDebug("EcalSim") << "CaloSD:: GetStepInfo for"
-                        << " PV "     << touch->GetVolume(0)->GetName()
-                        << " PVid = " << touch->GetReplicaNumber(0)
-                        << " MVid = " << touch->GetReplicaNumber(1)
-                        << " Unit   " << currentID.unitID()
-                        << " Edeposit = " << edepositEM << " " << edepositHAD;
-  } else {
-    LogDebug("EcalSim") << "CaloSD:: GetStepInfo for"
-                        << " PV "     << touch->GetVolume(0)->GetName()
-                        << " PVid = " << touch->GetReplicaNumber(0)
-                        << " MVid = " << touch->GetReplicaNumber(1)
-                        << " Unit   " << std::hex << unitID << std::dec
-                        << " Edeposit = " << edepositEM << " " << edepositHAD;
-  }
-  return flag;
-
-}
-*/
-//________________________________________________________________________________________
 double DreamSD::getEnergyDeposit(const G4Step* aStep) {
-
-  auto const preStepPoint = aStep->GetPreStepPoint();
 
   // take into account light collection curve for crystals
   double weight = curve_LY(aStep, side);
@@ -175,11 +85,11 @@ double DreamSD::getEnergyDeposit(const G4Step* aStep) {
 
   // Get Cerenkov contribution
   if ( doCherenkov_ ) { edep += cherenkovDeposit_( aStep ); }
-  LogDebug("EcalSim") << "DreamSD:: " << preStepPoint->GetPhysicalVolume()->GetName() 
-		      << " Side " << side
-		      <<" Light Collection Efficiency " << weight 
-		      << " Weighted Energy Deposit " << edep/MeV 
-		      << " MeV";
+  LogDebug("EcalSim") << "DreamSD:: " << aStep->GetPreStepPoint()->GetPhysicalVolume()->GetName() 
+                      << " Side " << side
+                      <<" Light Collection Efficiency " << weight 
+                      << " Weighted Energy Deposit " << edep/MeV 
+                      << " MeV";
 
   return edep;
 }
@@ -192,7 +102,7 @@ void DreamSD::initRun() {
   const G4LogicalVolume* lv = (ite->first);
   G4Material* material = lv->GetMaterial();
   edm::LogInfo("EcalSim") << "DreamSD::initRun: Initializes for material " 
-			  << material->GetName() << " in " << lv->GetName();
+                          << material->GetName() << " in " << lv->GetName();
   materialPropertiesTable = material->GetMaterialPropertiesTable();
   if ( !materialPropertiesTable ) {
     if ( !setPbWO2MaterialProperties_( material ) ) {
@@ -233,12 +143,12 @@ void DreamSD::initMap(const std::string& sd, const DDCompactView & cpv) {
     G4LogicalVolume* lv=nullptr;
     for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) 
       if ((*lvcite)->GetName() == name) {
-	lv = (*lvcite);
-	break;
+        lv = (*lvcite);
+        break;
       }
     LogDebug("EcalSim") << "DreamSD::initMap (for " << sd << "): Solid " 
-			<< name	<< " Shape " << sol.shape() <<" Parameter 0 = "
-			<< paras[0] << " Logical Volume " << lv;
+                        << name        << " Shape " << sol.shape() <<" Parameter 0 = "
+                        << paras[0] << " Logical Volume " << lv;
     double length = 0, width = 0;
     // Set length to be the largest size, width the smallest
     std::sort( paras.begin(), paras.end() );
@@ -248,14 +158,14 @@ void DreamSD::initMap(const std::string& sd, const DDCompactView & cpv) {
     dodet = fv.next();
   }
   LogDebug("EcalSim") << "DreamSD: Length Table for " << attribute << " = " 
-		      << sd << ":";   
+                      << sd << ":";   
   DimensionMap::const_iterator ite = xtalLMap.begin();
   int i=0;
   for (; ite != xtalLMap.end(); ite++, i++) {
     G4String name = "Unknown";
     if (ite->first != nullptr) name = (ite->first)->GetName();
     LogDebug("EcalSim") << " " << i << " " << ite->first << " " << name 
-			<< " L = " << ite->second.first
+                        << " L = " << ite->second.first
                         << " W = " << ite->second.second;
   }
 }
@@ -269,7 +179,7 @@ double DreamSD::curve_LY(const G4Step* aStep, int flag) {
 
   double weight = 1.;
   G4ThreeVector  localPoint = setToLocal(stepPoint->GetPosition(),
-					 stepPoint->GetTouchable());
+                                         stepPoint->GetTouchable());
   double crlength = crystalLength(lv);
   double localz   = localPoint.x();
   double dapd = 0.5 * crlength - flag*localz; // Distance from closest APD
@@ -278,16 +188,16 @@ double DreamSD::curve_LY(const G4Step* aStep, int flag) {
       weight = 1.0 + slopeLY - dapd * 0.01 * slopeLY;
   } else {
     edm::LogWarning("EcalSim") << "DreamSD: light coll curve : wrong distance "
-			       << "to APD " << dapd << " crlength = " 
-			       << crlength << " crystal name = " << nameVolume 
-			       << " z of localPoint = " << localz
-			       << " take weight = " << weight;
+                               << "to APD " << dapd << " crlength = " 
+                               << crlength << " crystal name = " << nameVolume 
+                               << " z of localPoint = " << localz
+                               << " take weight = " << weight;
   }
   LogDebug("EcalSim") << "DreamSD, light coll curve : " << dapd 
-		      << " crlength = " << crlength
-		      << " crystal name = " << nameVolume 
-		      << " z of localPoint = " << localz
-		      << " take weight = " << weight;
+                      << " crlength = " << crlength
+                      << " crystal name = " << nameVolume 
+                      << " z of localPoint = " << localz
+                      << " take weight = " << weight;
   return weight;
 }
 
@@ -387,13 +297,13 @@ double DreamSD::cherenkovDeposit_(const G4Step* aStep ) {
 
     // sample a momentum (not sure why this is needed!)
     do {
-      randomNumber = G4UniformRand();	
+      randomNumber = G4UniformRand();        
       sampledMomentum = Pmin + randomNumber * dp; 
       sampledRI = Rindex->Value(sampledMomentum);
       cosTheta = BetaInverse / sampledRI;  
       
       sin2Theta = (1.0 - cosTheta)*(1.0 + cosTheta);
-      randomNumber = G4UniformRand();	
+      randomNumber = G4UniformRand();        
       
     } while (randomNumber*maxSin2 > sin2Theta);
 
@@ -448,9 +358,9 @@ double DreamSD::cherenkovDeposit_(const G4Step* aStep ) {
 // Returns number of photons produced per GEANT-unit (millimeter) in the current medium. 
 // From G4Cerenkov.cc
 double DreamSD::getAverageNumberOfPhotons_( const double charge,
-					    const double beta,
-					    const G4Material* aMaterial,
-					    const G4MaterialPropertyVector* Rindex )
+                                            const double beta,
+                                            const G4Material* aMaterial,
+                                            const G4MaterialPropertyVector* Rindex )
 {
   const G4double rFact = 369.81/(eV * cm);
 
@@ -459,8 +369,8 @@ double DreamSD::getAverageNumberOfPhotons_( const double charge,
   double BetaInverse = 1./beta;
 
   // Vectors used in computation of Cerenkov Angle Integral:
-  // 	- Refraction Indices for the current material
-  //	- new G4PhysicsOrderedFreeVector allocated to hold CAI's
+  //         - Refraction Indices for the current material
+  //        - new G4PhysicsOrderedFreeVector allocated to hold CAI's
  
   // Min and Max photon momenta 
   int Rlength = Rindex->GetVectorLength() - 1; 
@@ -468,7 +378,7 @@ double DreamSD::getAverageNumberOfPhotons_( const double charge,
   double Pmax = Rindex->Energy(Rlength);
 
   // Min and Max Refraction Indices 
-  double nMin = (*Rindex)[0];	
+  double nMin = (*Rindex)[0];        
   double nMax = (*Rindex)[Rlength];
 
   // Max Cerenkov Angle Integral 
@@ -481,7 +391,7 @@ double DreamSD::getAverageNumberOfPhotons_( const double charge,
 
   // otherwise if n(Pmin) >= 1/Beta -- photons generated  
   else if (nMin > BetaInverse) {
-    dp = Pmax - Pmin;	
+    dp = Pmax - Pmin;        
     ge = CAImax; 
   } 
   // If n(Pmin) < 1/Beta, and n(Pmax) >= 1/Beta, then
@@ -582,8 +492,8 @@ bool DreamSD::setPbWO2MaterialProperties_( G4Material* aMaterial ) {
 // - configurable reflection probability if not straight to APD;
 // - APD response function
 double DreamSD::getPhotonEnergyDeposit_( const G4ThreeVector& p, 
-					 const G4ThreeVector& x,
-					 const G4Step* aStep )
+                                         const G4ThreeVector& x,
+                                         const G4Step* aStep )
 {
 
   double energy = 0;

--- a/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
+++ b/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
@@ -12,7 +12,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "G4String.hh"
+//#include "G4String.hh"
 #include <map>
 
 class EcalBaseNumber;
@@ -24,9 +24,11 @@ public:
   EcalTBH4BeamSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 		 edm::ParameterSet const &, const SimTrackManager*);
   ~EcalTBH4BeamSD() override;
-  double getEnergyDeposit(G4Step*) override;
   uint32_t setDetUnitId(const G4Step* step) override;
   void setNumberingScheme(EcalNumberingScheme* scheme);
+
+ protected:
+  double getEnergyDeposit(const G4Step*) override;
 
 private:    
 

--- a/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
+++ b/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
@@ -50,23 +50,17 @@ EcalTBH4BeamSD::~EcalTBH4BeamSD() {
   if (numberingScheme) delete numberingScheme;
 }
 
-double EcalTBH4BeamSD::getEnergyDeposit(G4Step * aStep) {
+double EcalTBH4BeamSD::getEnergyDeposit(const G4Step * aStep) {
   
-  if (aStep == nullptr) {
-    return 0;
-  } else {
-    preStepPoint        = aStep->GetPreStepPoint();
-    G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
-
-    // take into account light collection curve for crystals
-    double weight = 1.;
-    if (useBirk)   weight *= getAttenuation(aStep, birk1, birk2, birk3);
-    double edep   = aStep->GetTotalEnergyDeposit() * weight;
-    LogDebug("EcalTBSim") << "EcalTBH4BeamSD:: " << nameVolume
+  // take into account light collection curve for crystals
+  double weight = 1.;
+  if (useBirk)   weight *= getAttenuation(aStep, birk1, birk2, birk3);
+  double edep   = aStep->GetTotalEnergyDeposit() * weight;
+  LogDebug("EcalTBSim") << "EcalTBH4BeamSD:: " 
+			<< aStep->GetPreStepPoint()->GetPhysicalVolume()->GetName()
 			<<" Light Collection Efficiency " << weight 
 			<< " Weighted Energy Deposit " << edep/MeV << " MeV";
-    return edep;
-  } 
+  return edep;
 }
 
 uint32_t EcalTBH4BeamSD::setDetUnitId(const G4Step * aStep) { 

--- a/SimG4CMS/Forward/interface/CastorSD.h
+++ b/SimG4CMS/Forward/interface/CastorSD.h
@@ -32,7 +32,7 @@ class CastorSD : public CaloSD {
 public:    
 
   CastorSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog & clg,
-	   edm::ParameterSet const &, const SimTrackManager*);
+           edm::ParameterSet const &, const SimTrackManager*);
   ~CastorSD() override;
   uint32_t setDetUnitId(const G4Step* step) override;
   void     setNumberingScheme(CastorNumberingScheme* scheme);
@@ -53,7 +53,7 @@ private:
   
   bool                    useShowerLibrary;
   double                  energyThresholdSL; 
-  double		  non_compensation_factor;
+  double                  non_compensation_factor;
 };
 
 #endif // CastorSD_h

--- a/SimG4CMS/Forward/interface/CastorSD.h
+++ b/SimG4CMS/Forward/interface/CastorSD.h
@@ -34,15 +34,18 @@ public:
   CastorSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog & clg,
 	   edm::ParameterSet const &, const SimTrackManager*);
   ~CastorSD() override;
-  double   getEnergyDeposit(G4Step* ) override;
   uint32_t setDetUnitId(const G4Step* step) override;
   void     setNumberingScheme(CastorNumberingScheme* scheme);
 
+protected:
+
+  double   getEnergyDeposit(const G4Step*) override;
+  bool     getFromLibrary(const G4Step*) override;
+  void     initRun() override;
+
 private:
 
-  void                    getFromLibrary(G4Step*);
-  int                     setTrackID(G4Step*);
-  uint32_t                rotateUnitID(uint32_t, G4Track*, const CastorShowerEvent&);
+  uint32_t                rotateUnitID(uint32_t, const G4Track*, const CastorShowerEvent&);
   CastorNumberingScheme * numberingScheme;
   CastorShowerLibrary *   showerLibrary;
   G4LogicalVolume         *lvC3EF, *lvC3HF, *lvC4EF, *lvC4HF;
@@ -51,11 +54,6 @@ private:
   bool                    useShowerLibrary;
   double                  energyThresholdSL; 
   double		  non_compensation_factor;
-
-protected:
-
-  void            initRun() override;
-
 };
 
 #endif // CastorSD_h

--- a/SimG4CMS/Forward/interface/CastorShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/CastorShowerLibrary.h
@@ -40,7 +40,7 @@ public:
 public:
 
   void                initParticleTable(G4ParticleTable *);
-  CastorShowerEvent   getShowerHits(G4Step*, bool&);
+  CastorShowerEvent   getShowerHits(const G4Step*, bool&);
   int                 FindEnergyBin(double);
   int                 FindEtaBin(double);
   int                 FindPhiBin(double);

--- a/SimG4CMS/Forward/interface/ZdcSD.h
+++ b/SimG4CMS/Forward/interface/ZdcSD.h
@@ -9,7 +9,6 @@
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 #include "SimG4CMS/Forward/interface/ZdcShowerLibrary.h"
 #include "SimG4CMS/Forward/interface/ZdcNumberingScheme.h"
-#undef debug
 
 class ZdcSD : public CaloSD {
 
@@ -17,26 +16,29 @@ public:
   ZdcSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	edm::ParameterSet const &,const SimTrackManager*);
  
-  ~ZdcSD() override;
-  bool ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
+  ~ZdcSD() = default;
+
+  //G4bool ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
   uint32_t setDetUnitId(const G4Step* step) override;
-  double getEnergyDeposit(const G4Step*, edm::ParameterSet const &);
  
   void setNumberingScheme(ZdcNumberingScheme* scheme);
-  void getFromLibrary(G4Step * step);
  
 protected:
+
+  double getEnergyDeposit(const G4Step*) override;
+  bool   getFromLibrary(const G4Step*) override;
   void initRun() override;
+
 private:    
 
   int verbosity;
   bool  useShowerLibrary,useShowerHits; 
-  int   setTrackID(G4Step * step);
+  //int   setTrackID(const G4Step * step);
   double thFibDir;
   double zdcHitEnergyCut;
-  ZdcShowerLibrary *    showerLibrary;
-  ZdcNumberingScheme * numberingScheme;
 
+  std::unique_ptr<ZdcShowerLibrary>   showerLibrary;
+  std::unique_ptr<ZdcNumberingScheme> numberingScheme;
   std::vector<ZdcShowerLibrary::Hit> hits;
 
 };

--- a/SimG4CMS/Forward/interface/ZdcSD.h
+++ b/SimG4CMS/Forward/interface/ZdcSD.h
@@ -14,7 +14,7 @@ class ZdcSD : public CaloSD {
 
 public:    
   ZdcSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
-	edm::ParameterSet const &,const SimTrackManager*);
+        edm::ParameterSet const &,const SimTrackManager*);
  
   ~ZdcSD() = default;
 
@@ -27,13 +27,14 @@ protected:
 
   double getEnergyDeposit(const G4Step*) override;
   bool   getFromLibrary(const G4Step*) override;
-  void initRun() override;
+  void   initRun() override;
 
 private:    
 
+  int   setTrackID(const G4Step * step);
+
   int verbosity;
   bool  useShowerLibrary,useShowerHits; 
-  //int   setTrackID(const G4Step * step);
   double thFibDir;
   double zdcHitEnergyCut;
 

--- a/SimG4CMS/Forward/interface/ZdcSD.h
+++ b/SimG4CMS/Forward/interface/ZdcSD.h
@@ -18,7 +18,6 @@ public:
  
   ~ZdcSD() = default;
 
-  //G4bool ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
   uint32_t setDetUnitId(const G4Step* step) override;
  
   void setNumberingScheme(ZdcNumberingScheme* scheme);
@@ -30,8 +29,6 @@ protected:
   void   initRun() override;
 
 private:    
-
-  int   setTrackID(const G4Step * step);
 
   int verbosity;
   bool  useShowerLibrary,useShowerHits; 

--- a/SimG4CMS/Forward/interface/ZdcShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/ZdcShowerLibrary.h
@@ -43,7 +43,7 @@ public:
 
 
   void                        initRun(G4ParticleTable * theParticleTable);
-  std::vector<Hit>&           getHits(G4Step * aStep, bool & ok);
+  std::vector<Hit>&           getHits(const G4Step * aStep, bool & ok);
   int                         getEnergyFromLibrary(const G4ThreeVector& posHit, const G4ThreeVector& momDir, double energy,
                                                    G4int parCode,HcalZDCDetId::Section section, bool side, int channel);
   int                         photonFluctuation(double eav, double esig,double edis);

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -29,9 +29,9 @@
 //#define debugLog
 
 CastorSD::CastorSD(const std::string& name, const DDCompactView & cpv,
-		   const SensitiveDetectorCatalog & clg,
-		   edm::ParameterSet const & p, 
-		   const SimTrackManager* manager) : 
+                   const SensitiveDetectorCatalog & clg,
+                   edm::ParameterSet const & p, 
+                   const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager), numberingScheme(nullptr), lvC3EF(nullptr),
   lvC3HF(nullptr), lvC4EF(nullptr), lvC4HF(nullptr), lvCAST(nullptr) {
   
@@ -39,7 +39,7 @@ CastorSD::CastorSD(const std::string& name, const DDCompactView & cpv,
   useShowerLibrary  = m_CastorSD.getParameter<bool>("useShowerLibrary");
   energyThresholdSL = m_CastorSD.getParameter<double>("minEnergyInGeVforUsingSLibrary");
   energyThresholdSL = energyThresholdSL*GeV;   //  Convert GeV => MeV 
-	  
+          
   non_compensation_factor = m_CastorSD.getParameter<double>("nonCompensationFactor");
   
   if (useShowerLibrary) {
@@ -62,13 +62,13 @@ CastorSD::CastorSD(const std::string& name, const DDCompactView & cpv,
     if (strcmp((lv->GetName()).c_str(),"C4HF") == 0) { lvC4HF = lv; }
     if (strcmp((lv->GetName()).c_str(),"CAST") == 0) { lvCAST = lv; }
     if (lvC3EF != nullptr && lvC3HF != nullptr && lvC4EF != nullptr && 
-	lvC4HF != nullptr && lvCAST != nullptr) { break; }
+        lvC4HF != nullptr && lvCAST != nullptr) { break; }
   }
   edm::LogInfo("ForwardSim") << "CastorSD:: LogicalVolume pointers\n"
-			     << lvC3EF << " for C3EF; " << lvC3HF 
-			     << " for C3HF; " << lvC4EF << " for C4EF; " 
-			     << lvC4HF << " for C4HF; " 
-			     << lvCAST << " for CAST. ";
+                             << lvC3EF << " for C3EF; " << lvC3HF 
+                             << " for C3HF; " << lvC4EF << " for C4EF; " 
+                             << lvC4HF << " for C4HF; " 
+                             << lvCAST << " for CAST. ";
 }
 
 //=============================================================================================
@@ -103,29 +103,29 @@ double CastorSD::getEnergyDeposit(const G4Step * aStep) {
   auto const currentLV    = currentPV->GetLogicalVolume();
 
   const G4ThreeVector&  hit_mom  = preStepPoint->GetMomentumDirection();
-  const G4ThreeVector&  hitPoint = preStepPoint->GetPosition();	
+  const G4ThreeVector&  hitPoint = preStepPoint->GetPosition();        
   double zint = hitPoint.z();
 
 #ifdef debugLog
   edm::LogInfo("ForwardSim") << "CastorSD::getEnergyDeposit:"
-			     << "\n CurrentStepNumber , TrackID , ParentID, Particle , VertexPosition ,"
-			     << " LogicalVolumeAtVertex , PV, Time"
-			     << "\n  TRACKINFO: " 
-			     << theTrack->GetCurrentStepNumber() 
-			     << " , " 
-			     << theTrack->GetTrackID() 
-			     << " , " 
-			     << theTrack->GetParentID() 
-			     << " , "
-			     << theTrack->GetDefinition()->GetParticleName() 
-			     << " , "
-			     << theTrack->GetVertexPosition() 
-			     << " , "
-			     << theTrack->GetLogicalVolumeAtVertex()->GetName() 
-			     << " , "
-			     << currentPV->GetName()
-			     << " , " 
-			     << theTrack->GetGlobalTime();
+                             << "\n CurrentStepNumber , TrackID , ParentID, Particle , VertexPosition ,"
+                             << " LogicalVolumeAtVertex , PV, Time"
+                             << "\n  TRACKINFO: " 
+                             << theTrack->GetCurrentStepNumber() 
+                             << " , " 
+                             << theTrack->GetTrackID() 
+                             << " , " 
+                             << theTrack->GetParentID() 
+                             << " , "
+                             << theTrack->GetDefinition()->GetParticleName() 
+                             << " , "
+                             << theTrack->GetVertexPosition() 
+                             << " , "
+                             << theTrack->GetLogicalVolumeAtVertex()->GetName() 
+                             << " , "
+                             << currentPV->GetName()
+                             << " , " 
+                             << theTrack->GetGlobalTime();
   }
 #endif
 
@@ -158,19 +158,19 @@ double CastorSD::getEnergyDeposit(const G4Step * aStep) {
   
   // *************************************************
   /*    comments for sensitive volumes:      
-	C001 ...-... CP06,CBU1 ...-...CALM --- > fibres and bundle 
-	for first release of CASTOR
-	CASF  --- > quartz plate  for first and second releases of CASTOR  
-	GF2Q, GFNQ, GR2Q, GRNQ 
-	for tests with my own test geometry of HF (on ask of Gavrilov)
-	C3TF, C4TF - for third release of CASTOR
+        C001 ...-... CP06,CBU1 ...-...CALM --- > fibres and bundle 
+        for first release of CASTOR
+        CASF  --- > quartz plate  for first and second releases of CASTOR  
+        GF2Q, GFNQ, GR2Q, GRNQ 
+        for tests with my own test geometry of HF (on ask of Gavrilov)
+        C3TF, C4TF - for third release of CASTOR
   */  
 #ifdef debugLog
   if(theTrack->GetTrackID() == 8654) 
   edm::LogInfo("ForwardSim") << "CastorSD::getEnergyDeposit: for ID=" 
-  			     << theTrack->GetTrackID() << " LV: " << currentLV->GetName() 
-			     << " isHad: " << isHad << " pdg= " << castorHitPID
-			     << " sl= " << stepl << " Edep= " << aStep->GetTotalEnergyDeposit(); 
+                               << theTrack->GetTrackID() << " LV: " << currentLV->GetName() 
+                             << " isHad: " << isHad << " pdg= " << castorHitPID
+                             << " sl= " << stepl << " Edep= " << aStep->GetTotalEnergyDeposit(); 
 #endif
   if (currentLV == lvC3EF || currentLV == lvC4EF || currentLV == lvC3HF ||
       currentLV == lvC4HF) {
@@ -206,8 +206,8 @@ double CastorSD::getEnergyDeposit(const G4Step * aStep) {
     
     // theta of charged particle in LabRF(hit momentum direction):
     double costh =hit_mom.z()/sqrt(hit_mom.x()*hit_mom.x()+
-				   hit_mom.y()*hit_mom.y()+
-				   hit_mom.z()*hit_mom.z());
+                                   hit_mom.y()*hit_mom.y()+
+                                   hit_mom.z()*hit_mom.z());
     if (zint < 0) costh = -costh;
     double th = acos(std::min(std::max(costh,double(-1.)),double(1.)));
     
@@ -242,40 +242,40 @@ double CastorSD::getEnergyDeposit(const G4Step * aStep) {
     // if(d > (r+a) ) {d_qz = 0.; variant=0.;}
     else {
       if((th + thcher) < (thFibDirRad+thFullReflRad) && 
-	 (th - thcher) > (thFibDirRad-thFullReflRad)) {
-	d_qz = 1.; 
+         (th - thcher) > (thFibDirRad-thFullReflRad)) {
+        d_qz = 1.; 
 #ifdef debugLog
-	variant=1.;
+        variant=1.;
 #endif
       }
       // if((DelFibPart + thcher) < thFullReflRad ) {d_qz = 1.; variant=1.;}
       // if((d+r) < a ) {d_qz = 1.; variant=1.;}
       else {
-	if((thFibDirRad + thFullReflRad) < (th + thcher) && 
-	   (thFibDirRad - thFullReflRad) > (th - thcher) ) {
-	  // if((thcher - DelFibPart ) > thFullReflRad ) 
-	  // if((r-d ) > a ) 
-	  d_qz = 0.; 
+        if((thFibDirRad + thFullReflRad) < (th + thcher) && 
+           (thFibDirRad - thFullReflRad) > (th - thcher) ) {
+          // if((thcher - DelFibPart ) > thFullReflRad ) 
+          // if((r-d ) > a ) 
+          d_qz = 0.; 
 #ifdef debugLog
-	  variant=2.;
+          variant=2.;
 #endif
-	} else {
-	  // if((thcher + DelFibPart ) > thFullReflRad && 
-	  //    thcher < (DelFibPart+thFullReflRad) ) 
-	  //      {
+        } else {
+          // if((thcher + DelFibPart ) > thFullReflRad && 
+          //    thcher < (DelFibPart+thFullReflRad) ) 
+          //      {
 #ifdef debugLog
-	  variant=3.;
+          variant=3.;
 #endif
-	  
-	  // use crossed length of circles(cone projection)
-	  // dC1/dC2 : 
-	  double arg_arcos = 0.;
-	  double tan_arcos = 2.*a*d;
-	  if(tan_arcos != 0.) arg_arcos =(r*r-a*a-d*d)/tan_arcos; 
-	  arg_arcos = fabs(arg_arcos);
-	  double th_arcos = acos(std::min(std::max(arg_arcos,double(-1.)),double(1.)));
-	  d_qz = fabs(th_arcos/pi/2.);
-	}
+          
+          // use crossed length of circles(cone projection)
+          // dC1/dC2 : 
+          double arg_arcos = 0.;
+          double tan_arcos = 2.*a*d;
+          if(tan_arcos != 0.) arg_arcos =(r*r-a*a-d*d)/tan_arcos; 
+          arg_arcos = fabs(arg_arcos);
+          double th_arcos = acos(std::min(std::max(arg_arcos,double(-1.)),double(1.)));
+          d_qz = fabs(th_arcos/pi/2.);
+        }
       }
     }
         
@@ -284,8 +284,8 @@ double CastorSD::getEnergyDeposit(const G4Step * aStep) {
     if(charge != 0. && beta > bThreshold )  {
       
       meanNCherPhot = 370.*charge*charge*
-	( 1. - 1./(nMedium*nMedium*beta*beta) )*
-	photEnSpectrDE*stepl;
+        ( 1. - 1./(nMedium*nMedium*beta*beta) )*
+        photEnSpectrDE*stepl;
       
       const double scale = isHad ? non_compensation_factor : 1.0;
       G4int poissNCherPhot = (G4int) G4Poisson(meanNCherPhot * scale);
@@ -299,11 +299,11 @@ double CastorSD::getEnergyDeposit(const G4Step * aStep) {
 #ifdef debugLog
       if(theTrack->GetTrackID() == 8654)       
       edm::LogInfo("ForwardSim") << " Nph= " << NCherPhot << " Np= " << poissNCherPhot
-				 << " eff= " << effPMTandTransport << " pb= " << proba
-				 << " Nmean= " << meanNCherPhot
-				 << " q=" << charge << " beta=" << beta 
-				 << " nMedium= " << nMedium << " sl= " << stepl
-				 << " Nde=" << photEnSpectrDE;
+                                 << " eff= " << effPMTandTransport << " pb= " << proba
+                                 << " Nmean= " << meanNCherPhot
+                                 << " q=" << charge << " beta=" << beta 
+                                 << " nMedium= " << nMedium << " sl= " << stepl
+                                 << " Nde=" << photEnSpectrDE;
 #endif
     }
   }
@@ -322,7 +322,7 @@ void CastorSD::setNumberingScheme(CastorNumberingScheme* scheme) {
 
   if (scheme != nullptr) {
     edm::LogInfo("ForwardSim") << "CastorSD: updates numbering scheme for " 
-			       << GetName();
+                               << GetName();
     delete numberingScheme;
     numberingScheme = scheme;
   }
@@ -384,8 +384,8 @@ uint32_t CastorSD::rotateUnitID(uint32_t unitID, const G4Track* track, const Cas
 #ifdef debugLog
   if(newUnitID != unitID) {
     LogDebug("ForwardSim") << "\n CastorSD::rotateUnitID:  " 
-			   << "\n     unitID = " << unitID 
-			   << "\n  newUnitID = " << newUnitID ; 
+                           << "\n     unitID = " << unitID 
+                           << "\n  newUnitID = " << newUnitID ; 
   }
 #endif
   
@@ -421,20 +421,20 @@ bool CastorSD::getFromLibrary(const G4Step* aStep) {
 #ifdef debugLog
   if(theTrack->GetTrackID() == 2358) 
     edm::LogInfo("ForwardSim") << "CastorSD::getFromLibrary: for ID=" << theTrack->GetTrackID() 
-			       << " parentID= " << theTrack->GetParentID() << " " 
-			       << theTrack->GetDefinition()->GetParticleName() 
-			       << " LV: " << currentLV->GetName() << " PV: " << currentPV->GetName()
-			       << "\n eta= " << theTrack->GetPosition().eta() 
-			       << " phi= " << theTrack->GetPosition().phi()
-			       << " z(cm)= " << theTrack->GetPosition().z()/cm 
-			       << " time(ns)= " << theTrack->GetGlobalTime() 
-			       << " E(GeV)= " << theTrack->GetTotalEnergy()/GeV;
+                               << " parentID= " << theTrack->GetParentID() << " " 
+                               << theTrack->GetDefinition()->GetParticleName() 
+                               << " LV: " << currentLV->GetName() << " PV: " << currentPV->GetName()
+                               << "\n eta= " << theTrack->GetPosition().eta() 
+                               << " phi= " << theTrack->GetPosition().phi()
+                               << " z(cm)= " << theTrack->GetPosition().z()/cm 
+                               << " time(ns)= " << theTrack->GetGlobalTime() 
+                               << " E(GeV)= " << theTrack->GetTotalEnergy()/GeV;
   } // end of if(useShowerLibrary)
 #endif
   
   // if particle moves from interaction point or "backwards (halo)
   bool backward = false;
-  const G4ThreeVector&  hitPoint = preStepPoint->GetPosition();	
+  const G4ThreeVector&  hitPoint = preStepPoint->GetPosition();        
   const G4ThreeVector&  hit_mom  = preStepPoint->GetMomentumDirection();
   double zint = hitPoint.z();
   double pz   = hit_mom.z();
@@ -472,11 +472,11 @@ bool CastorSD::getFromLibrary(const G4Step* aStep) {
 
 #ifdef debugLog
   edm::LogInfo("ForwardSim") << "CastorSD::getFromLibrary: ID= " << theTrack->GetTrackID()
-			     << " E>E0 " << aboveThreshold
-			     << " nMuon " << notaMuon << " backword " << backward
-			     << " Ok " << OkToUse << " angle " << angleok << " LV: " 
-			     << currentLV->GetName() << "  " << (currentLV == lvCAST) 
-			     << " " << particleWithinShowerLibrary;
+                             << " E>E0 " << aboveThreshold
+                             << " nMuon " << notaMuon << " backword " << backward
+                             << " Ok " << OkToUse << " angle " << angleok << " LV: " 
+                             << currentLV->GetName() << "  " << (currentLV == lvCAST) 
+                             << " " << particleWithinShowerLibrary;
 #endif
   
   // Use Castor shower library if energy is above threshold, is not a muon 
@@ -484,7 +484,7 @@ bool CastorSD::getFromLibrary(const G4Step* aStep) {
   if (!particleWithinShowerLibrary) {
     
     if (currentLV == lvC3EF || currentLV == lvC4EF || currentLV == lvC3HF ||
-	currentLV == lvC4HF) {
+        currentLV == lvC4HF) {
       G4double edep     = aStep->GetTotalEnergyDeposit();
       G4double beta     = preStepPoint->GetBeta();
       G4double charge   = preStepPoint->GetCharge();
@@ -515,10 +515,10 @@ bool CastorSD::getFromLibrary(const G4Step* aStep) {
 #ifdef debugLog
   if(theTrack->GetTrackID() == 2358) {
   edm::LogInfo("ForwardSim") << "\n CastorSD::getFromLibrary:  " 
-			     << hits.getNhit() << " hits for " << GetName() << " from " 
-			     << theTrack->GetDefinition()->GetParticleName() << " of "
-			     << preStepPoint->GetKineticEnergy()/GeV << " GeV and trackID " 
-			     << theTrack->GetTrackID() << " isHAD: " << isHAD;
+                             << hits.getNhit() << " hits for " << GetName() << " from " 
+                             << theTrack->GetDefinition()->GetParticleName() << " of "
+                             << preStepPoint->GetKineticEnergy()/GeV << " GeV and trackID " 
+                             << theTrack->GetTrackID() << " isHAD: " << isHAD;
   }
 #endif
 
@@ -526,12 +526,10 @@ bool CastorSD::getFromLibrary(const G4Step* aStep) {
   double E_track = preStepPoint->GetTotalEnergy() ;
   double E_SLhit = hits.getPrimE() * GeV ;
   double scale = E_track/E_SLhit ;
-	
+
   //Non compensation 
   if (isHAD){
-    scale=scale*non_compensation_factor; // if hadronic extend the scale with the non-compensation factor
-  } else {
-    scale=scale; // if electromagnetic, don't do anything
+    scale *= non_compensation_factor; // if hadronic extend the scale with the non-compensation factor
   }
   //  Loop over hits retrieved from the library
   for (unsigned int i=0; i<hits.getNhit(); ++i) {

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -164,9 +164,9 @@ double CastorSD::getEnergyDeposit(const G4Step * aStep) {
 #ifdef debugLog
   if(theTrack->GetTrackID() == 40420) 
   edm::LogInfo("ForwardSim") << "CastorSD::getEnergyDeposit: for ID=" 
-			     << theTrack->GetTrackID() << " LV: " << currentLV->GetName() 
+                             << theTrack->GetTrackID() << " LV: " << currentLV->GetName() 
                              << " isHad:" << isHad << " pdg=" << parCode 
-			     << " castorPID=" << castorHitPID
+                             << " castorPID=" << castorHitPID
                              << " sl= " << stepl << " Edep= " << aStep->GetTotalEnergyDeposit(); 
 #endif
   if (currentLV == lvC3EF || currentLV == lvC4EF || currentLV == lvC3HF ||
@@ -285,7 +285,7 @@ double CastorSD::getEnergyDeposit(const G4Step * aStep) {
                                  << " Nmean= " << meanNCherPhot
                                  << " q=" << charge << " beta=" << beta 
                                  << " nMedium= " << nMedium << " sl= " << stepl
-				 << " var=" << variant
+                                 << " var=" << variant
                                  << " Nde=" << photEnSpectrDE;
 #endif
     }
@@ -470,6 +470,7 @@ bool CastorSD::getFromLibrary(const G4Step* aStep) {
   // Use Castor shower library if energy is above threshold, is not a muon 
   // and is not moving backward 
   if (!particleWithinShowerLibrary) {
+    //--- This code is for backward compatibility and should be removed 
     if (currentLV == lvC3EF || currentLV == lvC4EF || currentLV == lvC3HF ||
         currentLV == lvC4HF) {
       G4double edep     = aStep->GetTotalEnergyDeposit();
@@ -477,9 +478,10 @@ bool CastorSD::getFromLibrary(const G4Step* aStep) {
       G4double charge   = preStepPoint->GetCharge();
       double bThreshold = 0.67;
       if(edep == 0.0 && charge != 0.0 && beta > bThreshold) { 
-	G4Poisson(0.0); 
+        G4Poisson(0.0); 
       }
     }
+    //---
     return false;
   }
   

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -279,13 +279,12 @@ double CastorSD::getEnergyDeposit(const G4Step * aStep) {
       double proba = d_qz + (1-d_qz)*ReflPower;
       NCherPhot = poissNCherPhot*effPMTandTransport*proba*0.307;
 #ifdef debugLog
-      if(theTrack->GetTrackID() == 8654)       
+      //if(theTrack->GetTrackID() == 8654)       
       edm::LogInfo("ForwardSim") << " Nph= " << NCherPhot << " Np= " << poissNCherPhot
                                  << " eff= " << effPMTandTransport << " pb= " << proba
                                  << " Nmean= " << meanNCherPhot
                                  << " q=" << charge << " beta=" << beta 
                                  << " nMedium= " << nMedium << " sl= " << stepl
-                                 << " var=" << variant
                                  << " Nde=" << photEnSpectrDE;
 #endif
     }
@@ -407,7 +406,7 @@ bool CastorSD::getFromLibrary(const G4Step* aStep) {
   auto const currentLV    = currentPV->GetLogicalVolume();
 
 #ifdef debugLog
-  if(theTrack->GetTrackID() == 2358) 
+    if(theTrack->GetTrackID() == 2358) 
     edm::LogInfo("ForwardSim") << "CastorSD::getFromLibrary: for ID=" << theTrack->GetTrackID() 
                                << " parentID= " << theTrack->GetParentID() << " " 
                                << theTrack->GetDefinition()->GetParticleName() 
@@ -466,7 +465,7 @@ bool CastorSD::getFromLibrary(const G4Step* aStep) {
                              << " " << particleWithinShowerLibrary 
                              << " Edep= " << aStep->GetTotalEnergyDeposit();
 #endif
-  
+
   // Use Castor shower library if energy is above threshold, is not a muon 
   // and is not moving backward 
   if (!particleWithinShowerLibrary) {
@@ -490,7 +489,7 @@ bool CastorSD::getFromLibrary(const G4Step* aStep) {
   bool isKilled(true);
   CastorShowerEvent hits = showerLibrary->getShowerHits(aStep, isKilled);
   
-  int primaryID = getTrackID(theTrack);
+  int primaryID = setTrackID(aStep);
 
   // Reset entry point for new primary
   resetForNewPrimary(aStep);
@@ -504,13 +503,11 @@ bool CastorSD::getFromLibrary(const G4Step* aStep) {
   }
 
 #ifdef debugLog
-  if(theTrack->GetTrackID() == 2358) {
-  edm::LogInfo("ForwardSim") << "\n CastorSD::getFromLibrary:  " 
-                             << hits.getNhit() << " hits for " << GetName() << " from " 
+  //if(theTrack->GetTrackID() == 2358) 
+  edm::LogInfo("ForwardSim") << "\n CastorSD::getFromLibrary:  " << GetName() << " from " 
                              << theTrack->GetDefinition()->GetParticleName() << " of "
                              << preStepPoint->GetKineticEnergy()/GeV << " GeV and trackID " 
                              << theTrack->GetTrackID() << " isHAD: " << isHAD;
-  }
 #endif
 
   // Scale to correct energy

--- a/SimG4CMS/Forward/src/CastorShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/CastorShowerLibrary.cc
@@ -209,7 +209,7 @@ void CastorShowerLibrary::initParticleTable(G4ParticleTable * theParticleTable) 
 
 //=============================================================================================
 
-CastorShowerEvent CastorShowerLibrary::getShowerHits(G4Step * aStep, bool & ok) {
+CastorShowerEvent CastorShowerLibrary::getShowerHits(const G4Step * aStep, bool & ok) {
 
   G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
   G4Track *     track         = aStep->GetTrack();

--- a/SimG4CMS/Forward/src/ZdcSD.cc
+++ b/SimG4CMS/Forward/src/ZdcSD.cc
@@ -337,21 +337,3 @@ void ZdcSD::setNumberingScheme(ZdcNumberingScheme* scheme) {
     numberingScheme.reset(scheme);
   }
 }
-
-int ZdcSD::setTrackID (const G4Step* aStep) {
-  const G4Track* theTrack = aStep->GetTrack();
-  TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
-  int primaryID = trkInfo->getIDonCaloSurface();
-  if (primaryID == 0) {
-#ifdef DebugLog
-    LogDebug("ZdcSD") << "ZdcSD: Problem with primaryID **** set by force "
-                        << "to TkID **** " << theTrack->GetTrackID();
-#endif
-    primaryID = theTrack->GetTrackID();
-  }
-  if (primaryID != previousID.trackID()) {
-      resetForNewPrimary(aStep); 
-  }
-  return primaryID;
-}
-

--- a/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
@@ -53,7 +53,7 @@ void ZdcShowerLibrary::initRun(G4ParticleTable *theParticleTable){
 		       << anutauPDG;
 }
 
-std::vector<ZdcShowerLibrary::Hit> & ZdcShowerLibrary::getHits(G4Step * aStep, bool & ok) {
+std::vector<ZdcShowerLibrary::Hit> & ZdcShowerLibrary::getHits(const G4Step * aStep, bool & ok) {
 
   G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
   G4StepPoint * postStepPoint = aStep->GetPostStepPoint(); 

--- a/SimG4CMS/HGCalTestBeam/interface/AHCalSD.h
+++ b/SimG4CMS/HGCalTestBeam/interface/AHCalSD.h
@@ -3,7 +3,6 @@
 
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 
-#include "G4String.hh"
 #include <map>
 #include <string>
 
@@ -15,13 +14,13 @@ public:
 
   AHCalSD(const std::string& , const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
-  ~AHCalSD() override;
-  double                getEnergyDeposit(G4Step* ) override;
+  ~AHCalSD() = default;
   uint32_t              setDetUnitId(const G4Step* step) override;
   bool                  unpackIndex(const uint32_t & idx, int & row, 
 				    int& col, int& depth);
 protected:
 
+  double                getEnergyDeposit(const G4Step*) override;
   bool                  filterHit(CaloG4Hit*, double) override;
 
 private:    

--- a/SimG4CMS/HGCalTestBeam/interface/HGCalTB16SD01.h
+++ b/SimG4CMS/HGCalTestBeam/interface/HGCalTB16SD01.h
@@ -8,8 +8,6 @@
 
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 
-#include "G4String.hh"
-
 #include <string>
 
 class DDCompactView;
@@ -23,12 +21,15 @@ public:
   HGCalTB16SD01(const std::string& , const DDCompactView &, 
 		const SensitiveDetectorCatalog &, edm::ParameterSet const &, 
 		const SimTrackManager*);
-  ~HGCalTB16SD01() override;
-  double   getEnergyDeposit(G4Step* ) override;
+  ~HGCalTB16SD01() = default;
   uint32_t setDetUnitId(const G4Step* step) override;
   static uint32_t  packIndex(int det, int lay, int x, int y);
   static void      unpackIndex(const uint32_t & idx, int& det, int& lay,
 			       int& x, int& y);
+
+protected:
+
+  double           getEnergyDeposit(const G4Step*) override;
 
 private:    
   void             initialize(const G4StepPoint* point);

--- a/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
@@ -38,9 +38,7 @@ AHCalSD::AHCalSD(const std::string& name, const DDCompactView & cpv,
                           << eminHit << std::endl;
 }
 
-AHCalSD::~AHCalSD() { }
-
-double AHCalSD::getEnergyDeposit(G4Step* aStep) {
+double AHCalSD::getEnergyDeposit(const G4Step* aStep) {
 
   double destep = aStep->GetTotalEnergyDeposit();
   double wt2    = aStep->GetTrack()->GetWeight();
@@ -59,7 +57,7 @@ double AHCalSD::getEnergyDeposit(G4Step* aStep) {
 
 uint32_t AHCalSD::setDetUnitId(const G4Step * aStep) { 
 
-  G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
 
   int depth = (touch->GetReplicaNumber(1));

--- a/SimG4CMS/HGCalTestBeam/src/HGCalTB16SD01.cc
+++ b/SimG4CMS/HGCalTestBeam/src/HGCalTB16SD01.cc
@@ -42,11 +42,9 @@ HGCalTB16SD01::HGCalTB16SD01(const std::string& name, const DDCompactView & cpv,
 			 << ", C1 = " << birk2_ << ", C2 = " << birk3_;
 }
 
-HGCalTB16SD01::~HGCalTB16SD01() {}
+double HGCalTB16SD01::getEnergyDeposit(const G4Step* aStep) {
 
-double HGCalTB16SD01::getEnergyDeposit(G4Step* aStep) {
-
-  G4StepPoint* point = aStep->GetPreStepPoint();
+  auto const point = aStep->GetPreStepPoint();
   if (initialize_) initialize(point);
   double destep = aStep->GetTotalEnergyDeposit();
   double wt2    = aStep->GetTrack()->GetWeight();
@@ -65,9 +63,8 @@ double HGCalTB16SD01::getEnergyDeposit(G4Step* aStep) {
 
 uint32_t HGCalTB16SD01::setDetUnitId(const G4Step * aStep) { 
 
-  G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
-  G4String name             = preStepPoint->GetPhysicalVolume()->GetName();
 
   int det(1), x(0), y(0);
   int lay = (touch->GetReplicaNumber(0));

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
@@ -32,15 +32,18 @@ public:
   HcalTB02SD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	     edm::ParameterSet const &, const SimTrackManager*);
   ~HcalTB02SD() override;
-  double getEnergyDeposit(G4Step*) override;
   uint32_t setDetUnitId(const G4Step* step) override;
   void setNumberingScheme(HcalTB02NumberingScheme* scheme);
+
+protected:
+
+  double getEnergyDeposit(const G4Step*) override;
 
 private:    
 
   void   initMap(const std::string&, const DDCompactView &);
-  double curve_LY(G4String& , G4StepPoint* ); 
-  double crystalLength(G4String);
+  double curve_LY(const G4String& , const G4StepPoint* ); 
+  double crystalLength(const G4String&);
 
 private:    
 

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
@@ -25,8 +25,11 @@ public:
                  const SensitiveDetectorCatalog &,
 		 edm::ParameterSet const &, const SimTrackManager*);
   ~HcalTB06BeamSD() override;
-  double getEnergyDeposit(G4Step* ) override;
   uint32_t setDetUnitId(const G4Step* step) override;
+
+protected:
+
+  double getEnergyDeposit(const G4Step*) override;
 
 private:    
 

--- a/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
@@ -84,13 +84,13 @@ HcalTB02SD::~HcalTB02SD() {
 // member functions
 //
  
-double HcalTB02SD::getEnergyDeposit(G4Step * aStep) {
+double HcalTB02SD::getEnergyDeposit(const G4Step * aStep) {
   
   if (aStep == nullptr) {
     return 0;
   } else {
-    preStepPoint        = aStep->GetPreStepPoint();
-    G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
+    auto const preStepPoint = aStep->GetPreStepPoint();
+    auto const & nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
 
     // take into account light collection curve for crystals
     double weight = 1.;
@@ -148,7 +148,7 @@ void HcalTB02SD::initMap(const std::string& sd, const DDCompactView & cpv) {
   }
 }
 
-double HcalTB02SD::curve_LY(G4String& nameVolume, G4StepPoint* stepPoint) {
+double HcalTB02SD::curve_LY(const G4String& nameVolume, const G4StepPoint* stepPoint) {
 
   double weight = 1.;
   G4ThreeVector  localPoint = setToLocal(stepPoint->GetPosition(),
@@ -173,7 +173,7 @@ double HcalTB02SD::curve_LY(G4String& nameVolume, G4StepPoint* stepPoint) {
   return weight;
 }
 
-double HcalTB02SD::crystalLength(G4String name) {
+double HcalTB02SD::crystalLength(const G4String& name) {
 
   double length = 230.;
   std::map<G4String,double>::const_iterator it = lengthMap.find(name);

--- a/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
@@ -93,7 +93,7 @@ HcalTB06BeamSD::HcalTB06BeamSD(const std::string& name, const DDCompactView & cp
 
 HcalTB06BeamSD::~HcalTB06BeamSD() {}
 
-double HcalTB06BeamSD::getEnergyDeposit(G4Step* aStep) {
+double HcalTB06BeamSD::getEnergyDeposit(const G4Step* aStep) {
 
   double destep = aStep->GetTotalEnergyDeposit();
   double weight = 1;

--- a/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
@@ -115,7 +115,7 @@ void FiberSD::update(const BeginOfJob * job) {
   es->get<HcalSimNumberingRecord>().get(hdc);
   if (hdc.isValid()) {
     HcalDDDSimConstants *hcalConstants = (HcalDDDSimConstants*)(&(*hdc));
-    theShower->initRun(nullptr, hcalConstants);
+    theShower->initRun(hcalConstants);
   } else {
     edm::LogError("HcalSim") << "HCalSD : Cannot find HcalDDDSimConstant";
     throw cms::Exception("Unknown", "HCalSD") << "Cannot find HcalDDDSimConstant" << "\n";

--- a/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
+++ b/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
@@ -23,7 +23,6 @@ class TrackingSlaveSD;
 class FrameRotation;
 class UpdatablePSimHit;
 class G4ProcessTypeEnumerator;
-class G4TrackToParticleID;
 class TrackerG4SimHitNumberingScheme;
 
 class TkAccumulatingSensitiveDetector : 
@@ -65,7 +64,6 @@ private:
     std::unique_ptr<TrackingSlaveSD> slaveHighTof;
     std::unique_ptr<FrameRotation>   theRotation;
     std::unique_ptr<const G4ProcessTypeEnumerator> theG4ProcTypeEnumerator;
-    std::unique_ptr<const G4TrackToParticleID> theG4TrackToParticleID;
     std::unique_ptr<TrackerG4SimHitNumberingScheme> theNumberingScheme;
     bool allowZeroEnergyLoss;
     bool printHits;

--- a/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
+++ b/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
@@ -93,7 +93,7 @@ TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(const std::stri
   setNames(temp);  
 
   theG4ProcTypeEnumerator.reset(new G4ProcessTypeEnumerator);
-  theG4TrackToParticleID.reset(new G4TrackToParticleID);
+  //theG4TrackToParticleID.reset(new G4TrackToParticleID);
   theNumberingScheme.reset(nullptr);
 }
 
@@ -232,7 +232,7 @@ void TkAccumulatingSensitiveDetector::createHit(const G4Step * aStep)
     float thePabs             = preStepPoint->GetMomentum().mag()/GeV;
     float theTof              = preStepPoint->GetGlobalTime()/nanosecond;
     float theEnergyLoss       = aStep->GetTotalEnergyDeposit()/GeV;
-    int theParticleType       = theG4TrackToParticleID.get()->particleID(theTrack);
+    int theParticleType       = G4TrackToParticleID::particleID(theTrack);
     uint32_t theDetUnitId     = setDetUnitId(aStep);
     int theTrackID            = theTrack->GetTrackID();
     if (theDetUnitId == 0)

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -103,7 +103,7 @@ RunManagerMT::~RunManagerMT()
 }
 
 void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF, 
-			  const HepPDT::ParticleDataTable *fPDGTable)
+                          const HepPDT::ParticleDataTable *fPDGTable)
 {
   if (m_managerInitialized) return;
 
@@ -125,7 +125,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
       sim::FieldBuilder fieldBuilder(pMF, m_pField);
       CMSFieldManager* fieldManager = new CMSFieldManager();
       G4TransportationManager * tM =
-	G4TransportationManager::GetTransportationManager();
+        G4TransportationManager::GetTransportationManager();
       tM->SetFieldManager(fieldManager);
       fieldBuilder.build( fieldManager, tM->GetPropagatorInField());
       DumpMagneticField(tM->GetFieldManager()->GetDetectorField());
@@ -148,7 +148,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   PhysicsList* phys = m_physicsList.get(); 
   if (phys==nullptr) { 
     throw edm::Exception( edm::errors::Configuration,
-			  "Physics list construction failed!"); 
+                          "Physics list construction failed!"); 
   }
 
   // adding GFlash, Russian Roulette for eletrons and gamma, 
@@ -166,14 +166,14 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
     << "RunManagerMT: start initialisation of PhysicsList for master";
 
   int verb = std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity",0),
-		      m_p.getParameter<int>("SteppingVerbosity"));
+                      m_p.getParameter<int>("SteppingVerbosity"));
   m_kernel->SetVerboseLevel(verb);
 
   m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue")*CLHEP::cm);
   m_physicsList->SetCutsWithDefault();
 
   if(m_pPhysics.getParameter<bool>("CutsPerRegion")) {
-    m_prodCuts.reset(new DDG4ProductionCuts(map_, verb, m_pPhysics));	
+    m_prodCuts.reset(new DDG4ProductionCuts(map_, verb, m_pPhysics));        
     m_prodCuts->update();
   }
   
@@ -192,7 +192,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   if (m_kernel->RunInitialization()) { m_managerInitialized = true; }
   else { 
     throw edm::Exception( edm::errors::LogicError, 
-			  "G4RunManagerKernel initialization failed!"); 
+                          "G4RunManagerKernel initialization failed!"); 
   }
 
   if (m_StorePhysicsTables) {
@@ -305,15 +305,15 @@ void RunManagerMT::DumpMagneticField(const G4Field* field) const
       z = z0;
       for(int j=0; j<=nz; ++j) {
         point[0] = r*cosf;
-	point[1] = r*sinf;
-	point[2] = z;
+        point[1] = r*sinf;
+        point[2] = z;
         field->GetFieldValue(point, bfield);
         fout << "R(mm)= " << r/mm << " phi(deg)= " << phi/degree
-	     << " Z(mm)= " << z/mm << "   Bz(tesla)= " << bfield[2]/tesla
-	     << " Br(tesla)= " << (bfield[0]*cosf + bfield[1]*sinf)/tesla
-	     << " Bphi(tesla)= " << (bfield[0]*sinf - bfield[1]*cosf)/tesla
-	     << G4endl;
-	z += dz;
+             << " Z(mm)= " << z/mm << "   Bz(tesla)= " << bfield[2]/tesla
+             << " Br(tesla)= " << (bfield[0]*cosf + bfield[1]*sinf)/tesla
+             << " Bphi(tesla)= " << (bfield[0]*sinf - bfield[1]*cosf)/tesla
+             << G4endl;
+        z += dz;
       }
       r += dr;
     }

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -40,6 +40,7 @@
 #include "G4ApplicationState.hh"
 #include "G4MTRunManagerKernel.hh"
 #include "G4UImanager.hh"
+#include "G4StateManager.hh"
 
 #include "G4EventManager.hh"
 #include "G4Run.hh"
@@ -153,6 +154,9 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   // adding GFlash, Russian Roulette for eletrons and gamma, 
   // step limiters on top of any Physics Lists
   phys->RegisterPhysics(new ParametrisedEMPhysics("EMoptions",m_pPhysics));
+
+  m_kernel->SetPhysics(phys);
+  G4StateManager::GetStateManager()->SetNewState(G4State_Init);
 
   m_physicsList->ResetStoredInAscii();
   if (m_RestorePhysicsTables) {

--- a/SimG4Core/Notification/interface/G4TrackToParticleID.h
+++ b/SimG4Core/Notification/interface/G4TrackToParticleID.h
@@ -4,14 +4,17 @@
 class G4Track;
 
 /**
- * Converts G4Track to particle ID. For PDG Particles it is the obvious number; for alpha, triton and deuteron 
- * the CMS convention is used
+ * Converts G4Track to particle ID. For PDG Particles it is the obvious number; 
+ * for alpha, triton and deuteron the CMS convention is used
  */
 
 class G4TrackToParticleID
 {
 public:
-  static int particleID(const G4Track *);
+  static int  particleID(const G4Track *);
+  static bool isGammaElectronPositron(const G4Track *);
+  static bool isMuon(const G4Track *);
+  static bool isStableHadron(const G4Track *);
 };
 
 #endif

--- a/SimG4Core/Notification/interface/G4TrackToParticleID.h
+++ b/SimG4Core/Notification/interface/G4TrackToParticleID.h
@@ -12,9 +12,11 @@ class G4TrackToParticleID
 {
 public:
   static int  particleID(const G4Track *);
+  static bool isGammaElectronPositron(int pdgCode);
   static bool isGammaElectronPositron(const G4Track *);
   static bool isMuon(const G4Track *);
   static bool isStableHadron(const G4Track *);
+  static bool isNeutrinoOrUnstable(int pdgCode);
 };
 
 #endif

--- a/SimG4Core/Notification/src/G4TrackToParticleID.cc
+++ b/SimG4Core/Notification/src/G4TrackToParticleID.cc
@@ -9,8 +9,26 @@ int G4TrackToParticleID::particleID(const G4Track * g4trk)
     int particleID_ = g4trk->GetDefinition()->GetPDGEncoding();
     if (0 == particleID_) {
       edm::LogWarning("SimG4CoreNotification") 
-	<< "G4TrackToParticleID: unknown code for track Id = " << g4trk->GetTrackID();
+	<< "G4TrackToParticleID: unknown code 0 for track Id = " << g4trk->GetTrackID();
       particleID_ = -99;
     }
     return particleID_;
+}
+
+bool G4TrackToParticleID::isGammaElectronPositron(const G4Track * g4trk)
+{
+  int pdg = std::abs(g4trk->GetDefinition()->GetPDGEncoding());
+  return (pdg == 11 || pdg == 22);
+}
+
+bool G4TrackToParticleID::isMuon(const G4Track * g4trk)
+{
+  return (std::abs(g4trk->GetDefinition()->GetPDGEncoding()) == 13);
+}
+
+bool G4TrackToParticleID::isStableHadron(const G4Track * g4trk)
+{
+  // is pi+-, p, pbar, n, nbar, KL, K+-, 
+  int pdg = std::abs(g4trk->GetDefinition()->GetPDGEncoding());
+  return (pdg == 211 || pdg == 2212 || pdg == 2112 || pdg == 130 || pdg == 321);
 }

--- a/SimG4Core/Notification/src/G4TrackToParticleID.cc
+++ b/SimG4Core/Notification/src/G4TrackToParticleID.cc
@@ -15,6 +15,12 @@ int G4TrackToParticleID::particleID(const G4Track * g4trk)
     return particleID_;
 }
 
+bool G4TrackToParticleID::isGammaElectronPositron(int pdgCode)
+{
+  int pdg = std::abs(pdgCode);
+  return (pdg == 11 || pdg == 22);
+}
+
 bool G4TrackToParticleID::isGammaElectronPositron(const G4Track * g4trk)
 {
   int pdg = std::abs(g4trk->GetDefinition()->GetPDGEncoding());
@@ -31,4 +37,10 @@ bool G4TrackToParticleID::isStableHadron(const G4Track * g4trk)
   // is pi+-, p, pbar, n, nbar, KL, K+-, 
   int pdg = std::abs(g4trk->GetDefinition()->GetPDGEncoding());
   return (pdg == 211 || pdg == 2212 || pdg == 2112 || pdg == 130 || pdg == 321);
+}
+
+bool G4TrackToParticleID::isNeutrinoOrUnstable(int pdgCode)
+{
+  int pdg = std::abs(pdgCode);
+  return (pdg == 0 || pdg == 12|| pdg == 14 || pdg == 16 || pdg == 111 || pdg == 221);
 }


### PR DESCRIPTION
This PR is made instead of #21767 and #21797 
Geant4 calorimeter sensitive detectors are updated:
1) use const G4Step* pointer in protected and private interfaces where possible
2) Two main methods for sub-detectors : getFromLibrary(..) amd getEnergyDeposit(.. )
3) use std::unique_ptr, auto, and other C++11 features in several places
4) reduce number of protected class members
5) reduced number of type conversions
6) optimized ECalSD run time methods - perform one search over map of logical volumes instead of 3,
use const pointers and references
7) remove usage of G4ParticleTable at initialisation use instead static utility
8) removed duplicate codes 
9) optimised LogInfo and LogDebug - verbose output is substantially smaller but keep similar information
10) removed old commented lines
11) applied corrections suggested by @kpedro88 and @VinInn 

Correctness of this PR means identical results for all WFs.