### PR TITLE
Geometry/CSCGeometryBuilder: change return type of CSCGeometryBuilder::initCSCGeometry_() 

### DIFF
--- a/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
+++ b/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.cc
@@ -90,7 +90,7 @@ CSCGeometryESModule::~CSCGeometryESModule(){}
 
 std::shared_ptr<CSCGeometry> CSCGeometryESModule::produce(const MuonGeometryRecord& record) {
 
-  initCSCGeometry_(record);
+  std::shared_ptr<CSCGeometry> cscGeometry = initCSCGeometry_(record);
 
   // Called whenever the alignments or alignment errors change
 
@@ -128,13 +128,13 @@ std::shared_ptr<CSCGeometry> CSCGeometryESModule::produce(const MuonGeometryReco
 }
 
 
-void CSCGeometryESModule::initCSCGeometry_( const MuonGeometryRecord& record )
+std::shared_ptr<CSCGeometry> CSCGeometryESModule::initCSCGeometry_( const MuonGeometryRecord& record )
 {
-  if(not recreateGeometry_) return;
+  //if(not recreateGeometry_) return;
 
   // Updates whenever a dependent Record was changed
 
-  cscGeometry = std::make_shared<CSCGeometry>( debugV, useGangedStripsInME1a, useOnlyWiresInME1a, useRealWireGeometry,
+  std::shared_ptr<CSCGeometry> cscGeometry = std::make_shared<CSCGeometry>( debugV, useGangedStripsInME1a, useOnlyWiresInME1a, useRealWireGeometry,
 								 useCentreTIOffsets );
 
   //  cscGeometry->setUseRealWireGeometry( useRealWireGeometry );
@@ -165,6 +165,7 @@ void CSCGeometryESModule::initCSCGeometry_( const MuonGeometryRecord& record )
     cscgb.build(cscGeometry, *rig, *rdp);
   }
   recreateGeometry_=false;
+  return cscGeometry;
 }
 
 void CSCGeometryESModule::muonNumberingChanged_( const MuonNumberingRecord& ) {

--- a/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.h
+++ b/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.h
@@ -34,8 +34,7 @@ private:
   void cscRecoGeometryChanged_( const CSCRecoGeometryRcd& );
   void cscRecoDigiParametersChanged_( const CSCRecoDigiParametersRcd& );
 
-  void initCSCGeometry_(const MuonGeometryRecord& );
-  std::shared_ptr<CSCGeometry> cscGeometry;
+  std::shared_ptr<CSCGeometry> initCSCGeometry_(const MuonGeometryRecord& );
   bool recreateGeometry_;
 
   // Flags for controlling geometry modelling during build of CSCGeometry


### PR DESCRIPTION
Remove class member cscGeometry which is not needed because initCSCGeometry_() creates the shared_ptr to CSCGeometry and should return it directly.

In preparation for a move to multi IOV events in parallel, the return type of ESProducer::produce mehtods must be changed to unique_ptr or shared_ptr. These ptrs should not refer to member data. Rather they should refer to new(copied) objects.