### PR TITLE
Test Configurations for CTPPS DB geometry

### DIFF
--- a/CondTools/Geometry/test/geometryCTPPStest_local.py
+++ b/CondTools/Geometry/test/geometryCTPPStest_local.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.AlCa.autoCond import autoCond
+
+process = cms.Process("GeometryTest")
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.source = cms.Source("EmptyIOVSource",
+                            lastValue = cms.uint64(3),
+                            timetype = cms.string('runnumber'),
+                            firstValue = cms.uint64(1),
+                            interval = cms.uint64(1)
+                            )
+
+process.GlobalTag.toGet = cms.VPSet(
+    cms.PSet(record = cms.string('GeometryFileRcd'),
+             tag = cms.string('XMLFILE_Geometry_TagXX_Extended2017_mc'),
+             connect = cms.string("sqlite_file:myfile.db"),
+#             label = cms.string("Extended")
+             )
+    )
+
+process.MessageLogger = cms.Service("MessageLogger")
+process.demo = cms.EDAnalyzer("PrintEventSetupContent")
+
+process.GeometryTester = cms.EDAnalyzer("GeometryTester",
+                                        XMLTest = cms.untracked.bool(True),
+                                        TrackerTest = cms.untracked.bool(False),
+                                        EcalTest = cms.untracked.bool(False),
+                                        HcalTest = cms.untracked.bool(False),
+                                        HGCalTest = cms.untracked.bool(False),
+                                        CaloTowerTest = cms.untracked.bool(False),
+                                        CastorTest = cms.untracked.bool(False),
+                                        ZDCTest = cms.untracked.bool(False),
+                                        CSCTest = cms.untracked.bool(False),
+                                        DTTest = cms.untracked.bool(False),
+                                        RPCTest = cms.untracked.bool(False),
+                                        geomLabel = cms.untracked.string("")
+                                        )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.p1 = cms.Path(process.GeometryTester) #replace this with process.demo if you want to see the PrintEventSetupContent output.
+

--- a/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_writer.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("GeometryWriter")
+
+process.load('CondCore.CondDB.CondDB_cfi')
+
+# This will read all the little XML files and from
+# that fill the DDCompactView. The modules that fill
+# the reco part of the database need the DDCompactView.
+# process.load('Geometry.VeryForwardGeometry.geometryRP_cfi')
+# from Geometry.VeryForwardGeometry.geometryRP_cfi import XMLIdealGeometryESSource_CTPPS
+# process.XMLIdealGeometryESSource = XMLIdealGeometryESSource_CTPPS.clone()
+
+process.source = cms.Source("EmptyIOVSource",
+                            lastValue = cms.uint64(1),
+                            timetype = cms.string('runnumber'),
+                            firstValue = cms.uint64(1),
+                            interval = cms.uint64(1)
+                            )
+
+# This reads the big XML file and the only way to fill the
+# nonreco part of the database is to read this file.  It
+# somewhat duplicates the information read from the little
+# XML files, but there is no way to directly build the
+# DDCompactView from this.
+process.XMLGeometryWriter = cms.EDAnalyzer("XMLGeometryBuilder",
+                                           XMLFileName = cms.untracked.string("./geSingleBigFile.xml"),
+                                           ZIP = cms.untracked.bool(True)
+                                           )
+
+process.CondDB.timetype = cms.untracked.string('runnumber')
+process.CondDB.connect = cms.string('sqlite_file:myfile.db')
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          process.CondDB,
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('GeometryFileRcd'),
+                                                                     tag = cms.string('XMLFILE_Geometry_TagXX_Extended2017_mc'))
+                                                            )
+                                          )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.p1 = cms.Path(process.XMLGeometryWriter)
+

--- a/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_xmlwriter.py
+++ b/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_xmlwriter.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("GeometryXMLWriter")
+
+##process.load('Configuration.Geometry.GeometryExtended2017_cff')
+process.load('Geometry.VeryForwardGeometry.geometryRP_cfi')
+from Geometry.VeryForwardGeometry.geometryRP_cfi import XMLIdealGeometryESSource_CTPPS
+process.XMLIdealGeometryESSource = XMLIdealGeometryESSource_CTPPS.clone()
+
+process.source = cms.Source("EmptyIOVSource",
+                            lastValue = cms.uint64(1),
+                            timetype = cms.string('runnumber'),
+                            firstValue = cms.uint64(1),
+                            interval = cms.uint64(1)
+                            )
+
+process.BigXMLWriter = cms.EDAnalyzer("OutputDDToDDL",
+                              rotNumSeed = cms.int32(0),
+                              fileName = cms.untracked.string("./geSingleBigFile.xml")
+                              )
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.p1 = cms.Path(process.BigXMLWriter)
+


### PR DESCRIPTION
* Add producer and test configurations for CTPPS DB geometry

To run the test:
```
cmsRun CondTools/Geometry/test/writehelpers/geometryCTPPS2017_xmlwriter.py
cmsRun CondTools/Geometry/test/writehelpers/geometryCTPPS2017_writer.py
cmsRun CondTools/Geometry/test/geometryCTPPStest_local.py
```

To check what is in the db file:
```
$ sqlite3 myfile.db 
SQLite version 3.15.1 2016-11-04 12:08:49
Enter ".help" for usage hints.
sqlite> select * from iov;
XMLFILE_Geometry_TagXX_Extended2017_mc|1|7854a2a32cf0882df0b9103c8d754c1346bf0aef|2018-01-26 14:42:16.732143
sqlite> .q

```