### PR TITLE
CSC DQM CSCMonitorModule fix for missing histo text labels

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Collection.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Collection.cc
@@ -156,8 +156,7 @@ namespace cscdqm {
       const XMLCh *content = element->getTextContent();
       XERCES_CPP_NAMESPACE_QUALIFIER TranscodeToStr tc(content, "UTF-8");
       std::istringstream buffer((const char*)tc.str());
-      std::string value;
-      buffer >> value;
+      std::string value = buffer.str();
       
       DOMNamedNodeMap* attributes = node->getAttributes();
       if (attributes) {


### PR DESCRIPTION
CSC DQM CSCMonitorModule fix for missing histo labels in recent CMSSW/DQM releases
- Fixes issue with parsing of histograms booking configuration file with 'xml strings with spaces', which caused missing text labels on DQM histograms/plots