### PR TITLE
CalibTracker-SiStripESProducers: Remove class members and return function temporaries instead.

### DIFF
--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.cc
@@ -34,7 +34,7 @@ SiStripBackPlaneCorrectionDepESProducer::SiStripBackPlaneCorrectionDepESProducer
 
 std::shared_ptr<SiStripBackPlaneCorrection> SiStripBackPlaneCorrectionDepESProducer::produce(const SiStripBackPlaneCorrectionDepRcd& iRecord)
 {
-  std::shared_ptr<SiStripBackPlaneCorrection> siStripBPC_;
+  std::shared_ptr<SiStripBackPlaneCorrection> siStripBPC;
   edm::LogInfo("SiStripBackPlaneCorrectionDepESProducer") << "Producer called" << std::endl;
   
   std::string latencyRecordName = getLatency.getParameter<std::string>("record");
@@ -61,11 +61,11 @@ std::shared_ptr<SiStripBackPlaneCorrection> SiStripBackPlaneCorrectionDepESProdu
   if ( backPlaneCorrectionRecordName == "SiStripBackPlaneCorrectionRcd"){
     edm::ESHandle<SiStripBackPlaneCorrection> siStripBackPlaneCorrection;
     iRecord.getRecord<SiStripBackPlaneCorrectionRcd>().get(backPlaneCorrectionLabel, siStripBackPlaneCorrection);
-    siStripBPC_.reset(new SiStripBackPlaneCorrection(*(siStripBackPlaneCorrection.product())));
+    siStripBPC.reset(new SiStripBackPlaneCorrection(*(siStripBackPlaneCorrection.product())));
   } else edm::LogError("SiStripBackPlaneCorrectionDepESProducer") << "[SiStripBackPlaneCorrectionDepESProducer::produce] No Lorentz Angle Record found " << std::endl;
 	 
 
-   return siStripBPC_;
+   return siStripBPC;
 
   
 }

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.cc
@@ -34,7 +34,7 @@ SiStripBackPlaneCorrectionDepESProducer::SiStripBackPlaneCorrectionDepESProducer
 
 std::shared_ptr<SiStripBackPlaneCorrection> SiStripBackPlaneCorrectionDepESProducer::produce(const SiStripBackPlaneCorrectionDepRcd& iRecord)
 {
-
+  std::shared_ptr<SiStripBackPlaneCorrection> siStripBPC_;
   edm::LogInfo("SiStripBackPlaneCorrectionDepESProducer") << "Producer called" << std::endl;
   
   std::string latencyRecordName = getLatency.getParameter<std::string>("record");

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.cc
@@ -61,7 +61,7 @@ std::shared_ptr<SiStripBackPlaneCorrection> SiStripBackPlaneCorrectionDepESProdu
   if ( backPlaneCorrectionRecordName == "SiStripBackPlaneCorrectionRcd"){
     edm::ESHandle<SiStripBackPlaneCorrection> siStripBackPlaneCorrection;
     iRecord.getRecord<SiStripBackPlaneCorrectionRcd>().get(backPlaneCorrectionLabel, siStripBackPlaneCorrection);
-    siStripBPC.reset(new SiStripBackPlaneCorrection(*(siStripBackPlaneCorrection.product())));
+    siStripBPC = std::make_shared<SiStripBackPlaneCorrection>(*(siStripBackPlaneCorrection.product()));
   } else edm::LogError("SiStripBackPlaneCorrectionDepESProducer") << "[SiStripBackPlaneCorrectionDepESProducer::produce] No Lorentz Angle Record found " << std::endl;
 	 
 

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.h
@@ -36,7 +36,6 @@ class SiStripBackPlaneCorrectionDepESProducer : public edm::ESProducer {
   edm::ParameterSet getPeak;
   edm::ParameterSet getDeconv;
 
-  std::shared_ptr<SiStripBackPlaneCorrection> siStripBPC_;
 
 };
 

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.cc
@@ -36,7 +36,7 @@ SiStripDelayESProducer::SiStripDelayESProducer(const edm::ParameterSet& iConfig)
 std::shared_ptr<SiStripDelay> SiStripDelayESProducer::produce(const SiStripDelayRcd& iRecord)
 {
   edm::LogInfo("SiStripDelayESProducer") << "produce called" << std::endl;
-  std::shared_ptr<SiStripDelay> delay{new SiStripDelay};
+  std::shared_ptr<SiStripDelay> delay = std::make_shared<SiStripDelay>();
   delay->clear();
 
   edm::ESHandle<SiStripBaseDelay> baseDelay;

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.cc
@@ -30,14 +30,13 @@ SiStripDelayESProducer::SiStripDelayESProducer(const edm::ParameterSet& iConfig)
   
   edm::LogInfo("SiStripDelayESProducer") << "ctor" << std::endl;
 
-  delay.reset(new SiStripDelay());
 }
 
 
 std::shared_ptr<SiStripDelay> SiStripDelayESProducer::produce(const SiStripDelayRcd& iRecord)
 {
   edm::LogInfo("SiStripDelayESProducer") << "produce called" << std::endl;
-
+  std::shared_ptr<SiStripDelay> delay{new SiStripDelay};
   delay->clear();
 
   edm::ESHandle<SiStripBaseDelay> baseDelay;

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.cc
@@ -36,7 +36,7 @@ SiStripDelayESProducer::SiStripDelayESProducer(const edm::ParameterSet& iConfig)
 std::shared_ptr<SiStripDelay> SiStripDelayESProducer::produce(const SiStripDelayRcd& iRecord)
 {
   edm::LogInfo("SiStripDelayESProducer") << "produce called" << std::endl;
-  std::shared_ptr<SiStripDelay> delay = std::make_shared<SiStripDelay>();
+  auto delay = std::make_shared<SiStripDelay>();
   delay->clear();
 
   edm::ESHandle<SiStripBaseDelay> baseDelay;

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.h
@@ -33,7 +33,6 @@ class SiStripDelayESProducer : public edm::ESProducer {
   typedef std::vector< edm::ParameterSet > Parameters;
   Parameters toGet;
 
-  std::shared_ptr<SiStripDelay> delay;
 };
 
 #endif

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.cc
@@ -36,7 +36,7 @@ SiStripLorentzAngleDepESProducer::SiStripLorentzAngleDepESProducer(const edm::Pa
 
 std::shared_ptr<SiStripLorentzAngle> SiStripLorentzAngleDepESProducer::produce(const SiStripLorentzAngleDepRcd& iRecord)
 {
-  std::shared_ptr<SiStripLorentzAngle> siStripLA_;
+  std::shared_ptr<SiStripLorentzAngle> siStripLA;
   edm::LogInfo("SiStripLorentzAngleDepESProducer") << "Producer called" << std::endl;
   
   std::string latencyRecordName = getLatency.getParameter<std::string>("record");
@@ -63,11 +63,11 @@ std::shared_ptr<SiStripLorentzAngle> SiStripLorentzAngleDepESProducer::produce(c
   if ( lorentzAngleRecordName == "SiStripLorentzAngleRcd"){
     edm::ESHandle<SiStripLorentzAngle> siStripLorentzAngle;
     iRecord.getRecord<SiStripLorentzAngleRcd>().get(lorentzAngleLabel, siStripLorentzAngle);
-    siStripLA_.reset(new SiStripLorentzAngle(*(siStripLorentzAngle.product())));
+    siStripLA.reset(new SiStripLorentzAngle(*(siStripLorentzAngle.product())));
   } else edm::LogError("SiStripLorentzAngleDepESProducer") << "[SiStripLorentzAngleDepESProducer::produce] No Lorentz Angle Record found " << std::endl;
 	 
 
-   return siStripLA_;
+   return siStripLA;
 
   
 }

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.cc
@@ -36,7 +36,7 @@ SiStripLorentzAngleDepESProducer::SiStripLorentzAngleDepESProducer(const edm::Pa
 
 std::shared_ptr<SiStripLorentzAngle> SiStripLorentzAngleDepESProducer::produce(const SiStripLorentzAngleDepRcd& iRecord)
 {
-
+  std::shared_ptr<SiStripLorentzAngle> siStripLA_;
   edm::LogInfo("SiStripLorentzAngleDepESProducer") << "Producer called" << std::endl;
   
   std::string latencyRecordName = getLatency.getParameter<std::string>("record");

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.h
@@ -36,7 +36,6 @@ class SiStripLorentzAngleDepESProducer : public edm::ESProducer {
   edm::ParameterSet getPeak;
   edm::ParameterSet getDeconv;
 
-  std::shared_ptr<SiStripLorentzAngle> siStripLA_;
 
 };
 

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
@@ -36,7 +36,7 @@ SiStripQualityESProducer::SiStripQualityESProducer(const edm::ParameterSet& iCon
 
 std::shared_ptr<SiStripQuality> SiStripQualityESProducer::produce(const SiStripQualityRcd& iRecord)
 {
-  std::shared_ptr<SiStripQuality>  quality = std::make_shared<SiStripQuality>();  
+  auto quality = std::make_shared<SiStripQuality>();  
   edm::LogInfo("SiStripQualityESProducer") << "produce called" << std::endl;
 
   quality->clear();

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
@@ -36,7 +36,7 @@ SiStripQualityESProducer::SiStripQualityESProducer(const edm::ParameterSet& iCon
 
 std::shared_ptr<SiStripQuality> SiStripQualityESProducer::produce(const SiStripQualityRcd& iRecord)
 {
-  std::shared_ptr<SiStripQuality>  quality{new SiStripQuality};  
+  std::shared_ptr<SiStripQuality>  quality = std::make_shared<SiStripQuality>();  
   edm::LogInfo("SiStripQualityESProducer") << "produce called" << std::endl;
 
   quality->clear();

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
@@ -31,13 +31,12 @@ SiStripQualityESProducer::SiStripQualityESProducer(const edm::ParameterSet& iCon
   
   edm::LogInfo("SiStripQualityESProducer") << "ctor" << std::endl;
 
-  quality.reset(new SiStripQuality());
 }
 
 
 std::shared_ptr<SiStripQuality> SiStripQualityESProducer::produce(const SiStripQualityRcd& iRecord)
 {
-  
+  std::shared_ptr<SiStripQuality>  quality{new SiStripQuality};  
   edm::LogInfo("SiStripQualityESProducer") << "produce called" << std::endl;
 
   quality->clear();

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.h
@@ -33,7 +33,6 @@ class SiStripQualityESProducer : public edm::ESProducer {
   typedef std::vector< edm::ParameterSet > Parameters;
   Parameters toGet;
 
-  std::shared_ptr<SiStripQuality>  quality;
 };
 
 #endif


### PR DESCRIPTION
Change class members to funtion temporaries.
Return type is unchanged.