### PR TITLE
TrackingTools/KalmanUpdators: Remove class member that are not needed.

### DIFF
--- a/TrackingTools/KalmanUpdators/interface/KFSwitching1DUpdatorESProducer.h
+++ b/TrackingTools/KalmanUpdators/interface/KFSwitching1DUpdatorESProducer.h
@@ -19,7 +19,6 @@ class  KFSwitching1DUpdatorESProducer: public edm::ESProducer{
   ~KFSwitching1DUpdatorESProducer() override; 
   std::shared_ptr<TrajectoryStateUpdator> produce(const TrackingComponentsRecord &);
  private:
-  std::shared_ptr<TrajectoryStateUpdator> _updator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/KalmanUpdators/interface/KFSwitching1DUpdatorESProducer.h
+++ b/TrackingTools/KalmanUpdators/interface/KFSwitching1DUpdatorESProducer.h
@@ -17,7 +17,7 @@ class  KFSwitching1DUpdatorESProducer: public edm::ESProducer{
  public:
   KFSwitching1DUpdatorESProducer(const edm::ParameterSet & p);
   ~KFSwitching1DUpdatorESProducer() override; 
-  std::shared_ptr<TrajectoryStateUpdator> produce(const TrackingComponentsRecord &);
+  std::unique_ptr<TrajectoryStateUpdator> produce(const TrackingComponentsRecord &);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/KalmanUpdators/interface/KFUpdatorESProducer.h
+++ b/TrackingTools/KalmanUpdators/interface/KFUpdatorESProducer.h
@@ -19,7 +19,6 @@ class  KFUpdatorESProducer: public edm::ESProducer{
   ~KFUpdatorESProducer() override; 
   std::shared_ptr<TrajectoryStateUpdator> produce(const TrackingComponentsRecord &);
  private:
-  std::shared_ptr<TrajectoryStateUpdator> _updator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/KalmanUpdators/interface/KFUpdatorESProducer.h
+++ b/TrackingTools/KalmanUpdators/interface/KFUpdatorESProducer.h
@@ -17,7 +17,7 @@ class  KFUpdatorESProducer: public edm::ESProducer{
  public:
   KFUpdatorESProducer(const edm::ParameterSet & p);
   ~KFUpdatorESProducer() override; 
-  std::shared_ptr<TrajectoryStateUpdator> produce(const TrackingComponentsRecord &);
+  std::unique_ptr<TrajectoryStateUpdator> produce(const TrackingComponentsRecord &);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/KalmanUpdators/interface/TrackingRecHitPropagatorESProducer.h
+++ b/TrackingTools/KalmanUpdators/interface/TrackingRecHitPropagatorESProducer.h
@@ -14,7 +14,6 @@ class  TrackingRecHitPropagatorESProducer: public edm::ESProducer{
   ~TrackingRecHitPropagatorESProducer() override; 
   std::shared_ptr<TrackingRecHitPropagator> produce(const TrackingComponentsRecord&);
  private:
-  std::shared_ptr<TrackingRecHitPropagator> theHitPropagator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/KalmanUpdators/interface/TrackingRecHitPropagatorESProducer.h
+++ b/TrackingTools/KalmanUpdators/interface/TrackingRecHitPropagatorESProducer.h
@@ -12,7 +12,7 @@ class  TrackingRecHitPropagatorESProducer: public edm::ESProducer{
  public:
   TrackingRecHitPropagatorESProducer(const edm::ParameterSet & p);
   ~TrackingRecHitPropagatorESProducer() override; 
-  std::shared_ptr<TrackingRecHitPropagator> produce(const TrackingComponentsRecord&);
+  std::unique_ptr<TrackingRecHitPropagator> produce(const TrackingComponentsRecord&);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/KalmanUpdators/plugins/Chi2MeasurementEstimatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/Chi2MeasurementEstimatorESProducer.cc
@@ -22,7 +22,6 @@ class  Chi2MeasurementEstimatorESProducer: public edm::ESProducer{
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
  private:
-  std::shared_ptr<Chi2MeasurementEstimatorBase> m_estimator;
   edm::ParameterSet const m_pset;
 };
 
@@ -43,8 +42,7 @@ Chi2MeasurementEstimatorESProducer::produce(const TrackingComponentsRecord & iRe
   auto minTol = m_pset.getParameter<double>("MinimalTolerance");
   auto minpt = m_pset.getParameter<double>("MinPtForHitRecoveryInGluedDet");
    
-  m_estimator = std::make_shared<Chi2MeasurementEstimator>(maxChi2,nSigma, maxDis, maxSag, minTol,minpt);
-  return m_estimator;
+  return std::make_shared<Chi2MeasurementEstimator>(maxChi2,nSigma, maxDis, maxSag, minTol,minpt);
 }
 
 

--- a/TrackingTools/KalmanUpdators/plugins/Chi2MeasurementEstimatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/Chi2MeasurementEstimatorESProducer.cc
@@ -17,7 +17,7 @@ class  Chi2MeasurementEstimatorESProducer: public edm::ESProducer{
  public:
   Chi2MeasurementEstimatorESProducer(const edm::ParameterSet & p);
   ~Chi2MeasurementEstimatorESProducer() override;
-  std::shared_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord &);
+  std::unique_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord &);
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -33,7 +33,7 @@ Chi2MeasurementEstimatorESProducer::Chi2MeasurementEstimatorESProducer(const edm
 
 Chi2MeasurementEstimatorESProducer::~Chi2MeasurementEstimatorESProducer() {}
 
-std::shared_ptr<Chi2MeasurementEstimatorBase> 
+std::unique_ptr<Chi2MeasurementEstimatorBase> 
 Chi2MeasurementEstimatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
   auto maxChi2 = m_pset.getParameter<double>("MaxChi2");
   auto nSigma  = m_pset.getParameter<double>("nSigma");
@@ -42,7 +42,7 @@ Chi2MeasurementEstimatorESProducer::produce(const TrackingComponentsRecord & iRe
   auto minTol = m_pset.getParameter<double>("MinimalTolerance");
   auto minpt = m_pset.getParameter<double>("MinPtForHitRecoveryInGluedDet");
    
-  return std::make_shared<Chi2MeasurementEstimator>(maxChi2,nSigma, maxDis, maxSag, minTol,minpt);
+  return std::make_unique<Chi2MeasurementEstimator>(maxChi2,nSigma, maxDis, maxSag, minTol,minpt);
 }
 
 

--- a/TrackingTools/KalmanUpdators/plugins/KFSwitching1DUpdatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/KFSwitching1DUpdatorESProducer.cc
@@ -28,8 +28,7 @@ KFSwitching1DUpdatorESProducer::produce(const TrackingComponentsRecord & iRecord
 //     _updator = 0;
 //   }
   
-  _updator  = std::make_shared<KFSwitching1DUpdator>(&pset_);
-  return _updator;
+  return std::make_shared<KFSwitching1DUpdator>(&pset_);
 }
 
 

--- a/TrackingTools/KalmanUpdators/plugins/KFSwitching1DUpdatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/KFSwitching1DUpdatorESProducer.cc
@@ -21,14 +21,14 @@ KFSwitching1DUpdatorESProducer::KFSwitching1DUpdatorESProducer(const edm::Parame
 
 KFSwitching1DUpdatorESProducer::~KFSwitching1DUpdatorESProducer() {}
 
-std::shared_ptr<TrajectoryStateUpdator> 
+std::unique_ptr<TrajectoryStateUpdator> 
 KFSwitching1DUpdatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 //   if (_updator){
 //     delete _updator;
 //     _updator = 0;
 //   }
   
-  return std::make_shared<KFSwitching1DUpdator>(&pset_);
+  return std::make_unique<KFSwitching1DUpdator>(&pset_);
 }
 
 

--- a/TrackingTools/KalmanUpdators/plugins/KFUpdatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/KFUpdatorESProducer.cc
@@ -27,9 +27,7 @@ KFUpdatorESProducer::produce(const TrackingComponentsRecord & iRecord){
 //     delete _updator;
 //     _updator = 0;
 //   }
-  
-  _updator = std::make_shared<KFUpdator>();
-  return _updator;
+  return std::make_shared<KFUpdator>();
 }
 
 

--- a/TrackingTools/KalmanUpdators/plugins/KFUpdatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/KFUpdatorESProducer.cc
@@ -21,13 +21,13 @@ KFUpdatorESProducer::KFUpdatorESProducer(const edm::ParameterSet & p)
 
 KFUpdatorESProducer::~KFUpdatorESProducer() {}
 
-std::shared_ptr<TrajectoryStateUpdator> 
+std::unique_ptr<TrajectoryStateUpdator> 
 KFUpdatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 //   if (_updator){
 //     delete _updator;
 //     _updator = 0;
 //   }
-  return std::make_shared<KFUpdator>();
+  return std::make_unique<KFUpdator>();
 }
 
 

--- a/TrackingTools/KalmanUpdators/plugins/MRHChi2MeasurementEstimatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/MRHChi2MeasurementEstimatorESProducer.cc
@@ -13,7 +13,7 @@ class  MRHChi2MeasurementEstimatorESProducer: public edm::ESProducer{
  public:
   MRHChi2MeasurementEstimatorESProducer(const edm::ParameterSet & p);
   ~MRHChi2MeasurementEstimatorESProducer() override;
-  std::shared_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord&);
+  std::unique_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord&);
  private:
   edm::ParameterSet pset_;
 };
@@ -27,11 +27,11 @@ MRHChi2MeasurementEstimatorESProducer::MRHChi2MeasurementEstimatorESProducer(con
 
 MRHChi2MeasurementEstimatorESProducer::~MRHChi2MeasurementEstimatorESProducer() {}
 
-std::shared_ptr<Chi2MeasurementEstimatorBase> 
+std::unique_ptr<Chi2MeasurementEstimatorBase> 
 MRHChi2MeasurementEstimatorESProducer::produce(const TrackingComponentsRecord& iRecord){ 
   double maxChi2 = pset_.getParameter<double>("MaxChi2");
   double nSigma = pset_.getParameter<double>("nSigma");
-  return std::make_shared<MRHChi2MeasurementEstimator>(maxChi2,nSigma);
+  return std::make_unique<MRHChi2MeasurementEstimator>(maxChi2,nSigma);
 }
 
 }

--- a/TrackingTools/KalmanUpdators/plugins/MRHChi2MeasurementEstimatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/MRHChi2MeasurementEstimatorESProducer.cc
@@ -15,7 +15,6 @@ class  MRHChi2MeasurementEstimatorESProducer: public edm::ESProducer{
   ~MRHChi2MeasurementEstimatorESProducer() override;
   std::shared_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord&);
  private:
-  std::shared_ptr<Chi2MeasurementEstimatorBase> _estimator;
   edm::ParameterSet pset_;
 };
 
@@ -30,11 +29,9 @@ MRHChi2MeasurementEstimatorESProducer::~MRHChi2MeasurementEstimatorESProducer() 
 
 std::shared_ptr<Chi2MeasurementEstimatorBase> 
 MRHChi2MeasurementEstimatorESProducer::produce(const TrackingComponentsRecord& iRecord){ 
-  
   double maxChi2 = pset_.getParameter<double>("MaxChi2");
   double nSigma = pset_.getParameter<double>("nSigma");
-  _estimator = std::make_shared<MRHChi2MeasurementEstimator>(maxChi2,nSigma);
-  return _estimator;
+  return std::make_shared<MRHChi2MeasurementEstimator>(maxChi2,nSigma);
 }
 
 }

--- a/TrackingTools/KalmanUpdators/plugins/TrackingRecHitPropagatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/TrackingRecHitPropagatorESProducer.cc
@@ -29,8 +29,7 @@ TrackingRecHitPropagatorESProducer::produce(const TrackingComponentsRecord& iRec
    iRecord.getRecord<IdealMagneticFieldRecord>().get(mfName,magfield);
    //   edm::ESInputTag mfESInputTag(mfName);
    //   iRecord.getRecord<IdealMagneticFieldRecord>().get(mfESInputTag,magfield);
-   theHitPropagator = std::make_shared<TrackingRecHitPropagator>(magfield.product());
-   return theHitPropagator;
+   return std::make_shared<TrackingRecHitPropagator>(magfield.product());
 }
 
 

--- a/TrackingTools/KalmanUpdators/plugins/TrackingRecHitPropagatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/TrackingRecHitPropagatorESProducer.cc
@@ -20,7 +20,7 @@ TrackingRecHitPropagatorESProducer::TrackingRecHitPropagatorESProducer(const edm
 
 TrackingRecHitPropagatorESProducer::~TrackingRecHitPropagatorESProducer() {}
 
-std::shared_ptr<TrackingRecHitPropagator> 
+std::unique_ptr<TrackingRecHitPropagator> 
 TrackingRecHitPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){ 
    ESHandle<MagneticField> magfield;
    std::string mfName = "";
@@ -29,7 +29,7 @@ TrackingRecHitPropagatorESProducer::produce(const TrackingComponentsRecord& iRec
    iRecord.getRecord<IdealMagneticFieldRecord>().get(mfName,magfield);
    //   edm::ESInputTag mfESInputTag(mfName);
    //   iRecord.getRecord<IdealMagneticFieldRecord>().get(mfESInputTag,magfield);
-   return std::make_shared<TrackingRecHitPropagator>(magfield.product());
+   return std::make_unique<TrackingRecHitPropagator>(magfield.product());
 }
 
 


### PR DESCRIPTION
Remove class member that are not needed.
Return shared_ptr from make_shared directly.