### PR TITLE
TrackingTools/MaterialEffects: Remove class member that is not needed.

### DIFF
--- a/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.cc
+++ b/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.cc
@@ -53,10 +53,9 @@ PropagatorWithMaterialESProducer::produce(const TrackingComponentsRecord & iReco
   if (pdir == "alongMomentum") dir = alongMomentum;
   if (pdir == "anyDirection") dir = anyDirection;
   
-  _propagator = std::make_shared<PropagatorWithMaterial>(dir, mass, &(*magfield),
-									maxDPhi,useRK,ptMin,
-									useOldAnalPropLogic);
-  return _propagator;
+  return std::make_shared<PropagatorWithMaterial>(dir, mass, &(*magfield),
+						maxDPhi,useRK,ptMin,
+						useOldAnalPropLogic);
 }
 
 

--- a/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.cc
+++ b/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.cc
@@ -23,7 +23,7 @@ PropagatorWithMaterialESProducer::PropagatorWithMaterialESProducer(const edm::Pa
 
 PropagatorWithMaterialESProducer::~PropagatorWithMaterialESProducer() {}
 
-std::shared_ptr<Propagator> 
+std::unique_ptr<Propagator> 
 PropagatorWithMaterialESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 //   if (_propagator){
 //     delete _propagator;
@@ -53,7 +53,7 @@ PropagatorWithMaterialESProducer::produce(const TrackingComponentsRecord & iReco
   if (pdir == "alongMomentum") dir = alongMomentum;
   if (pdir == "anyDirection") dir = anyDirection;
   
-  return std::make_shared<PropagatorWithMaterial>(dir, mass, &(*magfield),
+  return std::make_unique<PropagatorWithMaterial>(dir, mass, &(*magfield),
 						maxDPhi,useRK,ptMin,
 						useOldAnalPropLogic);
 }

--- a/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.h
+++ b/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.h
@@ -19,7 +19,6 @@ class  PropagatorWithMaterialESProducer: public edm::ESProducer{
   ~PropagatorWithMaterialESProducer() override; 
   std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
  private:
-  std::shared_ptr<Propagator> _propagator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.h
+++ b/TrackingTools/MaterialEffects/plugins/PropagatorWithMaterialESProducer.h
@@ -17,7 +17,7 @@ class  PropagatorWithMaterialESProducer: public edm::ESProducer{
  public:
   PropagatorWithMaterialESProducer(const edm::ParameterSet & p);
   ~PropagatorWithMaterialESProducer() override; 
-  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::unique_ptr<Propagator> produce(const TrackingComponentsRecord &);
  private:
   edm::ParameterSet pset_;
 };


### PR DESCRIPTION
Remove class member that is not needed.
Return shared_ptr directly from make_shared.