### PR TITLE
TrackingTools/Producers: Remove class members not needed.

### DIFF
--- a/TrackingTools/Producers/interface/AnalyticalPropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/AnalyticalPropagatorESProducer.h
@@ -13,7 +13,6 @@ class  AnalyticalPropagatorESProducer: public edm::ESProducer{
   ~AnalyticalPropagatorESProducer() override; 
   std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
  private:
-  std::shared_ptr<Propagator> _propagator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/Producers/interface/AnalyticalPropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/AnalyticalPropagatorESProducer.h
@@ -11,7 +11,7 @@ class  AnalyticalPropagatorESProducer: public edm::ESProducer{
  public:
   AnalyticalPropagatorESProducer(const edm::ParameterSet & p);
   ~AnalyticalPropagatorESProducer() override; 
-  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::unique_ptr<Propagator> produce(const TrackingComponentsRecord &);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/Producers/interface/BeamHaloPropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/BeamHaloPropagatorESProducer.h
@@ -30,7 +30,7 @@ class  BeamHaloPropagatorESProducer: public edm::ESProducer{
   ~BeamHaloPropagatorESProducer() override; 
   
   // Operations
-  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::unique_ptr<Propagator> produce(const TrackingComponentsRecord &);
   
  private:
   PropagationDirection thePropagationDirection;

--- a/TrackingTools/Producers/interface/BeamHaloPropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/BeamHaloPropagatorESProducer.h
@@ -33,7 +33,6 @@ class  BeamHaloPropagatorESProducer: public edm::ESProducer{
   std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
   
  private:
-  std::shared_ptr<Propagator> thePropagator;
   PropagationDirection thePropagationDirection;
   std::string myname;
   std::string theEndCapTrackerPropagatorName;

--- a/TrackingTools/Producers/interface/SmartPropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/SmartPropagatorESProducer.h
@@ -30,7 +30,7 @@ class  SmartPropagatorESProducer: public edm::ESProducer{
   ~SmartPropagatorESProducer() override; 
   
   // Operations
-  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::unique_ptr<Propagator> produce(const TrackingComponentsRecord &);
   
  private:
   PropagationDirection thePropagationDirection;

--- a/TrackingTools/Producers/interface/SmartPropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/SmartPropagatorESProducer.h
@@ -33,7 +33,6 @@ class  SmartPropagatorESProducer: public edm::ESProducer{
   std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
   
  private:
-  std::shared_ptr<Propagator> thePropagator;
   PropagationDirection thePropagationDirection;
   std::string theTrackerPropagatorName;
   std::string theMuonPropagatorName;

--- a/TrackingTools/Producers/interface/StraightLinePropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/StraightLinePropagatorESProducer.h
@@ -13,7 +13,6 @@ class  StraightLinePropagatorESProducer: public edm::ESProducer{
   ~StraightLinePropagatorESProducer() override; 
   std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
  private:
-  std::shared_ptr<Propagator> _propagator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/Producers/interface/StraightLinePropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/StraightLinePropagatorESProducer.h
@@ -11,7 +11,7 @@ class  StraightLinePropagatorESProducer: public edm::ESProducer{
  public:
   StraightLinePropagatorESProducer(const edm::ParameterSet & p);
   ~StraightLinePropagatorESProducer() override; 
-  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::unique_ptr<Propagator> produce(const TrackingComponentsRecord &);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/Producers/interface/TrajectoryCleanerESProducer.h
+++ b/TrackingTools/Producers/interface/TrajectoryCleanerESProducer.h
@@ -34,7 +34,7 @@ class TrajectoryCleanerESProducer : public edm::ESProducer {
       TrajectoryCleanerESProducer(const edm::ParameterSet&);
       ~TrajectoryCleanerESProducer() override;
 
-  typedef std::shared_ptr<TrajectoryCleaner> ReturnType;
+  typedef std::unique_ptr<TrajectoryCleaner> ReturnType;
 
       ReturnType produce(const  TrackingComponentsRecord&);
    private:

--- a/TrackingTools/Producers/src/AnalyticalPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/AnalyticalPropagatorESProducer.cc
@@ -45,8 +45,7 @@ AnalyticalPropagatorESProducer::produce(const TrackingComponentsRecord & iRecord
   if (pdir == "alongMomentum") dir = alongMomentum;
   if (pdir == "anyDirection") dir = anyDirection;
   
-  _propagator = std::make_shared<AnalyticalPropagator>(&(*magfield), dir,dphiCut);
-  return _propagator;
+  return std::make_shared<AnalyticalPropagator>(&(*magfield), dir,dphiCut);
 }
 
 

--- a/TrackingTools/Producers/src/AnalyticalPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/AnalyticalPropagatorESProducer.cc
@@ -22,7 +22,7 @@ AnalyticalPropagatorESProducer::AnalyticalPropagatorESProducer(const edm::Parame
 
 AnalyticalPropagatorESProducer::~AnalyticalPropagatorESProducer() {}
 
-std::shared_ptr<Propagator> 
+std::unique_ptr<Propagator> 
 AnalyticalPropagatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 //   if (_propagator){
 //     delete _propagator;
@@ -45,7 +45,7 @@ AnalyticalPropagatorESProducer::produce(const TrackingComponentsRecord & iRecord
   if (pdir == "alongMomentum") dir = alongMomentum;
   if (pdir == "anyDirection") dir = anyDirection;
   
-  return std::make_shared<AnalyticalPropagator>(&(*magfield), dir,dphiCut);
+  return std::make_unique<AnalyticalPropagator>(&(*magfield), dir,dphiCut);
 }
 
 

--- a/TrackingTools/Producers/src/BeamHaloPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/BeamHaloPropagatorESProducer.cc
@@ -44,7 +44,7 @@ BeamHaloPropagatorESProducer::BeamHaloPropagatorESProducer(const ParameterSet& p
 
 BeamHaloPropagatorESProducer::~BeamHaloPropagatorESProducer() {}
 
-std::shared_ptr<Propagator> 
+std::unique_ptr<Propagator> 
 BeamHaloPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){ 
 
   ESHandle<MagneticField> magField;
@@ -60,7 +60,7 @@ BeamHaloPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){
 				<<"\n with EndCap Propagator: "<<theEndCapTrackerPropagatorName
 				<<"\n with Crossing Propagator: "<<theCrossingTrackerPropagatorName;
 
-  return            std::make_shared<BeamHaloPropagator>(*endcapPropagator,*crossPropagator,
+  return            std::make_unique<BeamHaloPropagator>(*endcapPropagator,*crossPropagator,
 							&*magField,
 							thePropagationDirection);
 }

--- a/TrackingTools/Producers/src/BeamHaloPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/BeamHaloPropagatorESProducer.cc
@@ -60,8 +60,7 @@ BeamHaloPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){
 				<<"\n with EndCap Propagator: "<<theEndCapTrackerPropagatorName
 				<<"\n with Crossing Propagator: "<<theCrossingTrackerPropagatorName;
 
-  thePropagator = std::make_shared<BeamHaloPropagator>(*endcapPropagator,*crossPropagator,
+  return            std::make_shared<BeamHaloPropagator>(*endcapPropagator,*crossPropagator,
 							&*magField,
 							thePropagationDirection);
-  return thePropagator;
 }

--- a/TrackingTools/Producers/src/SmartPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/SmartPropagatorESProducer.cc
@@ -59,9 +59,8 @@ SmartPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){
   iRecord.get(theMuonPropagatorName,muonPropagator);
   
   
-  thePropagator = std::make_shared<SmartPropagator>(*trackerPropagator, *muonPropagator,
+  return           std::make_shared<SmartPropagator>(*trackerPropagator, *muonPropagator,
 						     &*magField,
 						     thePropagationDirection, 
 						     theEpsilon);
-  return thePropagator;
 }

--- a/TrackingTools/Producers/src/SmartPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/SmartPropagatorESProducer.cc
@@ -46,7 +46,7 @@ SmartPropagatorESProducer::SmartPropagatorESProducer(const ParameterSet& paramet
 
 SmartPropagatorESProducer::~SmartPropagatorESProducer() {}
 
-std::shared_ptr<Propagator> 
+std::unique_ptr<Propagator> 
 SmartPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){ 
 
   ESHandle<MagneticField> magField;
@@ -59,7 +59,7 @@ SmartPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){
   iRecord.get(theMuonPropagatorName,muonPropagator);
   
   
-  return           std::make_shared<SmartPropagator>(*trackerPropagator, *muonPropagator,
+  return           std::make_unique<SmartPropagator>(*trackerPropagator, *muonPropagator,
 						     &*magField,
 						     thePropagationDirection, 
 						     theEpsilon);

--- a/TrackingTools/Producers/src/StraightLinePropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/StraightLinePropagatorESProducer.cc
@@ -21,7 +21,7 @@ StraightLinePropagatorESProducer::StraightLinePropagatorESProducer(const edm::Pa
 
 StraightLinePropagatorESProducer::~StraightLinePropagatorESProducer() {}
 
-std::shared_ptr<Propagator> 
+std::unique_ptr<Propagator> 
 StraightLinePropagatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 //   if (_propagator){
 //     delete _propagator;
@@ -35,7 +35,7 @@ StraightLinePropagatorESProducer::produce(const TrackingComponentsRecord & iReco
 
   if (pdir == "oppositeToMomentum") dir = oppositeToMomentum;
   else if (pdir == "anyDirection") dir = anyDirection;
-  return  std::make_shared<StraightLinePropagator>(&(*magfield),dir);
+  return  std::make_unique<StraightLinePropagator>(&(*magfield),dir);
 }
 
 

--- a/TrackingTools/Producers/src/StraightLinePropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/StraightLinePropagatorESProducer.cc
@@ -35,8 +35,7 @@ StraightLinePropagatorESProducer::produce(const TrackingComponentsRecord & iReco
 
   if (pdir == "oppositeToMomentum") dir = oppositeToMomentum;
   else if (pdir == "anyDirection") dir = anyDirection;
-  _propagator = std::make_shared<StraightLinePropagator>(&(*magfield),dir);
-  return _propagator;
+  return  std::make_shared<StraightLinePropagator>(&(*magfield),dir);
 }
 
 

--- a/TrackingTools/Producers/src/TrajectoryCleanerESProducer.cc
+++ b/TrackingTools/Producers/src/TrajectoryCleanerESProducer.cc
@@ -19,6 +19,5 @@ TrajectoryCleanerESProducer::produce(const  TrackingComponentsRecord & iRecord)
 {
    using namespace edm::es;
    
-   ReturnType tc(TrajectoryCleanerFactory::get()->create(theComponentType, theConfig));
-   return tc;
+   return ReturnType(TrajectoryCleanerFactory::get()->create(theComponentType, theConfig));
 }


### PR DESCRIPTION
Remove class members not needed.
Return shared_ptr directly from make_shared.