### PR TITLE
TrackingTools/RecoGeometry: change return type of ESProducers

### DIFF
--- a/TrackingTools/RecoGeometry/plugins/DetLayerGeometryESProducer.cc
+++ b/TrackingTools/RecoGeometry/plugins/DetLayerGeometryESProducer.cc
@@ -19,12 +19,11 @@ DetLayerGeometryESProducer::DetLayerGeometryESProducer(const edm::ParameterSet &
  
 DetLayerGeometryESProducer::~DetLayerGeometryESProducer() {}
 
-std::shared_ptr<DetLayerGeometry> 
+std::unique_ptr<DetLayerGeometry> 
 DetLayerGeometryESProducer::produce(const RecoGeometryRecord & iRecord){ 
 
 
-  geometry_ = std::make_shared<DetLayerGeometry>();
-  return geometry_;
+  return std::make_unique<DetLayerGeometry>();
 }
 
 

--- a/TrackingTools/RecoGeometry/plugins/DetLayerGeometryESProducer.h
+++ b/TrackingTools/RecoGeometry/plugins/DetLayerGeometryESProducer.h
@@ -11,9 +11,7 @@ class  DetLayerGeometryESProducer: public edm::ESProducer{
  public:
   DetLayerGeometryESProducer(const edm::ParameterSet & p);
   ~DetLayerGeometryESProducer() override; 
-  std::shared_ptr<DetLayerGeometry> produce(const RecoGeometryRecord &);
- private:
-  std::shared_ptr<DetLayerGeometry> geometry_;
+  std::unique_ptr<DetLayerGeometry> produce(const RecoGeometryRecord &);
 };
 
 

--- a/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.cc
+++ b/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.cc
@@ -18,7 +18,7 @@ GlobalDetLayerGeometryESProducer::GlobalDetLayerGeometryESProducer(const edm::Pa
  
 GlobalDetLayerGeometryESProducer::~GlobalDetLayerGeometryESProducer() {}
 
-std::shared_ptr<DetLayerGeometry> 
+std::unique_ptr<DetLayerGeometry> 
 GlobalDetLayerGeometryESProducer::produce(const RecoGeometryRecord & iRecord){ 
   
   edm::ESHandle<GeometricSearchTracker> tracker;  
@@ -27,8 +27,7 @@ GlobalDetLayerGeometryESProducer::produce(const RecoGeometryRecord & iRecord){
   iRecord.getRecord<TrackerRecoGeometryRecord>().get(tracker);
   iRecord.getRecord<MuonRecoGeometryRecord>().get(muon);
 
-  geometry_ = std::make_shared<GlobalDetLayerGeometry>(tracker.product(), muon.product());
-  return geometry_;
+  return std::make_unique<GlobalDetLayerGeometry>(tracker.product(), muon.product());
 }
 
 

--- a/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.h
+++ b/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.h
@@ -11,9 +11,7 @@ class  GlobalDetLayerGeometryESProducer: public edm::ESProducer{
  public:
   GlobalDetLayerGeometryESProducer(const edm::ParameterSet & p);
   ~GlobalDetLayerGeometryESProducer() override; 
-  std::shared_ptr<DetLayerGeometry> produce(const RecoGeometryRecord &);
- private:
-  std::shared_ptr<DetLayerGeometry> geometry_;
+  std::unique_ptr<DetLayerGeometry> produce(const RecoGeometryRecord &);
 };
 
 


### PR DESCRIPTION
Remove class member that is not needed.
Change return type to unique_ptr and return directly from make_unique.