### PR TITLE
TrackingTools/TransientTrack: change return type of ESProducer

### DIFF
--- a/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.cc
+++ b/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.cc
@@ -20,7 +20,7 @@ TransientTrackBuilderESProducer::TransientTrackBuilderESProducer(const edm::Para
 
 TransientTrackBuilderESProducer::~TransientTrackBuilderESProducer() {}
 
-std::shared_ptr<TransientTrackBuilder> 
+std::unique_ptr<TransientTrackBuilder> 
 TransientTrackBuilderESProducer::produce(const TransientTrackRecord & iRecord){ 
 
   edm::ESHandle<MagneticField> magfield;
@@ -28,8 +28,7 @@ TransientTrackBuilderESProducer::produce(const TransientTrackRecord & iRecord){
   edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
   iRecord.getRecord<GlobalTrackingGeometryRecord>().get(theTrackingGeometry); 
 
-  _builder  = std::make_shared<TransientTrackBuilder>(magfield.product(), theTrackingGeometry);
-  return _builder;
+  return std::make_unique<TransientTrackBuilder>(magfield.product(), theTrackingGeometry);
 
 }
 

--- a/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.h
+++ b/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.h
@@ -14,9 +14,8 @@ class  TransientTrackBuilderESProducer: public edm::ESProducer{
  public:
   TransientTrackBuilderESProducer(const edm::ParameterSet & p);
   ~TransientTrackBuilderESProducer() override; 
-  std::shared_ptr<TransientTrackBuilder> produce(const TransientTrackRecord &);
+  std::unique_ptr<TransientTrackBuilder> produce(const TransientTrackRecord &);
  private:
-  std::shared_ptr<TransientTrackBuilder> _builder;
   edm::ParameterSet pset_;
 };
 


### PR DESCRIPTION
Remove class member not needed.
Change return type to unique_ptr.