### PR TITLE
treat non-pos-def covariance as if it contains a NaN

### DIFF
--- a/TrackingTools/TrackFitters/plugins/KFFittingSmoother.h
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmoother.h
@@ -166,6 +166,7 @@ bool KFFittingSmoother::checkForNans(const Trajectory & theTraj)
     if (edm::isNotFinite(tm.estimate())) return false;
     auto const & v = tm.updatedState ().localParameters ().vector();
     for (int i=0;i<5;++i) if (edm::isNotFinite(v[i])) return false;
+    if (!tm.updatedState ().curvilinearError ().posDef()) return false;//not a NaN by itself, but will lead to one
     auto const & m = tm.updatedState ().curvilinearError ().matrix();
     for (int i=0;i<5;++i)
       for (int j=0;j<(i+1);++j) if (edm::isNotFinite(m(i,j))) return false;
@@ -224,7 +225,7 @@ if (smoothed.isValid()) {
 
     bool hasNaN = false;
     if ( !smoothed.isValid() || (hasNaN = !checkForNans(smoothed)) || ( smoothed.foundHits() < theMinNumberOfHits ) )  {
-      if(hasNaN) edm::LogWarning("TrackNaN")<<"Track has NaN";
+      if(hasNaN) edm::LogWarning("TrackNaN")<<"Track has NaN or the cov is not pos-definite";
       if ( smoothed.foundHits() < theMinNumberOfHits ) LogTrace("TrackFitters") << "smoothed.foundHits()<theMinNumberOfHits";
       DPRINT("TrackFitters") << "smoothed invalid => trajectory rejected with nhits/chi2 " << smoothed.foundHits() << '/' <<  smoothed.chiSquared() << "\n";
       if (rejectTracksFlag) {

--- a/TrackingTools/TrackFitters/src/KFTrajectoryFitter.cc
+++ b/TrackingTools/TrackFitters/src/KFTrajectoryFitter.cc
@@ -129,7 +129,9 @@ Trajectory KFTrajectoryFitter::fitOne(const TrajectorySeed& aSeed,
               (std::abs(currTsos.localParameters().qbp())>100
                || std::abs(currTsos.localParameters().position().y()) > 1000
                || std::abs(currTsos.localParameters().position().x()) > 1000
-               ) ) || edm::isNotFinite(currTsos.localParameters().qbp());
+               ) ) 
+            || edm::isNotFinite(currTsos.localParameters().qbp()) 
+            || !currTsos.localError().posDef();
 	  if unlikely(badState){
 	    if (!currTsos.isValid()) {
 	      edm::LogError("FailedUpdate") <<"updating with the hit failed. Not updating the trajectory with the hit";
@@ -137,6 +139,10 @@ Trajectory KFTrajectoryFitter::fitOne(const TrajectorySeed& aSeed,
             } 
 	    else if (edm::isNotFinite(currTsos.localParameters().qbp())) {
               edm::LogError("TrajectoryNaN")<<"Trajectory has NaN";
+
+            }
+	    else if (!currTsos.localError().posDef()) {
+              edm::LogError("TrajectoryNotPosDef")<<"Trajectory covariance is not positive-definite";
 
             }
 	    else{ 


### PR DESCRIPTION
backport of #21935

posDef check is added to checks for NaNs already present in KFFittingSmoother and KFTrajectoryFitter.
The "posDef" check is partial, but it will already capture existing cases with negative values in the track covariances diagonal elements, which have to be non-negative.

this supersedes #21817  and should also resolve the problem reported in #21780.

This technically needs to wait for validation in 10X (10_1_0_pre1) and perhaps more importantly for a confirmation that data reco workflows can actually pick up this fix in 94X 
https://github.com/cms-sw/cmssw/issues/21780#issuecomment-360563259

