### PR TITLE
RecoTracker/MeasurementDet: change return type of ESProducers.

### DIFF
--- a/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
@@ -109,10 +109,9 @@ class  Chi2ChargeMeasurementEstimatorESProducer: public edm::ESProducer{
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   Chi2ChargeMeasurementEstimatorESProducer(const edm::ParameterSet & p);
   ~Chi2ChargeMeasurementEstimatorESProducer() override; 
-  std::shared_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord &);
+  std::unique_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord &);
 
  private:
-  std::shared_ptr<Chi2MeasurementEstimatorBase> m_estimator;
   const edm::ParameterSet m_pset;
 };
 
@@ -138,7 +137,7 @@ Chi2ChargeMeasurementEstimatorESProducer::Chi2ChargeMeasurementEstimatorESProduc
 
 Chi2ChargeMeasurementEstimatorESProducer::~Chi2ChargeMeasurementEstimatorESProducer() {}
 
-std::shared_ptr<Chi2MeasurementEstimatorBase> 
+std::unique_ptr<Chi2MeasurementEstimatorBase> 
 Chi2ChargeMeasurementEstimatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 
   auto maxChi2 = m_pset.getParameter<double>("MaxChi2");
@@ -151,11 +150,10 @@ Chi2ChargeMeasurementEstimatorESProducer::produce(const TrackingComponentsRecord
   auto minGoodStripCharge  =  clusterChargeCut(m_pset);
   auto pTChargeCutThreshold=   m_pset.getParameter<double>("pTChargeCutThreshold");
 
-  m_estimator = std::make_shared<Chi2ChargeMeasurementEstimator>(
+  return std::make_unique<Chi2ChargeMeasurementEstimator>(
                                             minGoodPixelCharge, minGoodStripCharge, pTChargeCutThreshold,
                                             maxChi2,nSigma, maxDis, maxSag, minTol,minpt);
 
-  return m_estimator;
 }
 
 }

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -54,7 +54,7 @@ MeasurementTrackerESProducer::MeasurementTrackerESProducer(const edm::ParameterS
 
 MeasurementTrackerESProducer::~MeasurementTrackerESProducer() {}
 
-std::shared_ptr<MeasurementTracker> 
+std::unique_ptr<MeasurementTracker> 
 MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
 { 
 
@@ -136,9 +136,10 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
   iRecord.getRecord<TrackerDigiGeometryRecord>().get(trackerGeom);
   iRecord.getRecord<TrackerRecoGeometryRecord>().get(geometricSearchTracker);
 
+
   if(phase2TrackerCPEName != ""){
       iRecord.getRecord<TkStripCPERecord>().get(phase2TrackerCPEName,phase2TrackerCPE);
-      _measurementTracker  = std::make_shared<MeasurementTrackerImpl>(pset_,
+      return             std::make_unique<MeasurementTrackerImpl>(pset_,
 							          pixelCPE.product(),
 							          stripCPE.product(),
 							          hitMatcher.product(),
@@ -154,7 +155,7 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
                                                                   pixelQualityDebugFlags,
 							          phase2TrackerCPE.product());
   } else {
-      _measurementTracker  = std::make_shared<MeasurementTrackerImpl>(pset_,
+      return             std::make_unique<MeasurementTrackerImpl>(pset_,
 							          pixelCPE.product(),
 							          stripCPE.product(),
 							          hitMatcher.product(),
@@ -169,7 +170,6 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
                                                                   pixelQualityFlags,
                                                                   pixelQualityDebugFlags);
   }
-  return _measurementTracker;
 }
 
 

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.h
@@ -11,9 +11,8 @@ class  dso_hidden MeasurementTrackerESProducer: public edm::ESProducer{
  public:
   MeasurementTrackerESProducer(const edm::ParameterSet & p);
   ~MeasurementTrackerESProducer() override; 
-  std::shared_ptr<MeasurementTracker> produce(const CkfComponentsRecord &);
+  std::unique_ptr<MeasurementTracker> produce(const CkfComponentsRecord &);
  private:
-  std::shared_ptr<MeasurementTracker> _measurementTracker;
   edm::ParameterSet pset_;
   std::string pixelCPEName;
   std::string stripCPEName;


### PR DESCRIPTION
RecoTracker/MeasurementDet: change return type of ESProducers.
Remove shared_ptr class member not needed.