### PR TITLE
RecoTracker/SiTrackerMRHTools: Change return type of ESProducers.

### DIFF
--- a/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.cc
+++ b/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.cc
@@ -30,7 +30,7 @@ MultiRecHitCollectorESProducer::MultiRecHitCollectorESProducer(const edm::Parame
 
 MultiRecHitCollectorESProducer::~MultiRecHitCollectorESProducer() {}
 
-std::shared_ptr<MultiRecHitCollector> 
+std::unique_ptr<MultiRecHitCollector> 
 MultiRecHitCollectorESProducer::produce(const MultiRecHitRecord& iRecord){
   std::string mode = "Grouped";
   if (conf_.getParameter<std::string>("Mode")=="Simple") mode = "Simple"; 
@@ -57,21 +57,20 @@ MultiRecHitCollectorESProducer::produce(const MultiRecHitRecord& iRecord){
 	std::string propagatorOppositeName = conf_.getParameter<std::string>("propagatorOpposite");  
 	ESHandle<Propagator>  propagatorOppositehandle;
   	iRecord.getRecord<CkfComponentsRecord>().getRecord<TrackingComponentsRecord>().get(propagatorOppositeName, propagatorOppositehandle); 
-  	collector_ = std::make_shared<GroupedDAFHitCollector>(measurementhandle.product(),
+  	return std::make_unique<GroupedDAFHitCollector>(measurementhandle.product(),
 						         mrhuhandle.product(),
 							 estimatorhandle.product(),
 							 propagatorhandle.product(),
 							 propagatorOppositehandle.product(), debug);
   } 
   else {
-	collector_ = std::make_shared<SimpleDAFHitCollector>(trackerTopologyHandle.product(),
+	return std::make_unique<SimpleDAFHitCollector>(trackerTopologyHandle.product(),
                                                              measurementhandle.product(),
                                                              mrhuhandle.product(),
                                                              estimatorhandle.product(),
                                                              propagatorhandle.product(), debug);
   }
   	
-  return collector_;
 
 }
 

--- a/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.h
+++ b/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.h
@@ -20,13 +20,12 @@ class  MultiRecHitCollectorESProducer: public edm::ESProducer{
  public:
   MultiRecHitCollectorESProducer(const edm::ParameterSet& iConfig);
   ~MultiRecHitCollectorESProducer() override; 
-  std::shared_ptr<MultiRecHitCollector> produce(const MultiRecHitRecord &);
+  std::unique_ptr<MultiRecHitCollector> produce(const MultiRecHitRecord &);
 
   // Set parameter set
   void setConf(const edm::ParameterSet& conf){ conf_ = conf; }
  
  private:
-  std::shared_ptr<MultiRecHitCollector> collector_;
   edm::ParameterSet conf_;
 
 };

--- a/RecoTracker/SiTrackerMRHTools/plugins/SiTrackerMultiRecHitUpdatorESProducer.cc
+++ b/RecoTracker/SiTrackerMRHTools/plugins/SiTrackerMultiRecHitUpdatorESProducer.cc
@@ -21,7 +21,7 @@ SiTrackerMultiRecHitUpdatorESProducer::SiTrackerMultiRecHitUpdatorESProducer(con
 
 SiTrackerMultiRecHitUpdatorESProducer::~SiTrackerMultiRecHitUpdatorESProducer() {}
 
-std::shared_ptr<SiTrackerMultiRecHitUpdator> 
+std::unique_ptr<SiTrackerMultiRecHitUpdator> 
 SiTrackerMultiRecHitUpdatorESProducer::produce(const MultiRecHitRecord & iRecord){ 
   std::vector<double> annealingProgram = pset_.getParameter<std::vector<double> >("AnnealingProgram");
   float Chi2Cut1D = pset_.getParameter<double>("ChiSquareCut1D");
@@ -35,10 +35,9 @@ SiTrackerMultiRecHitUpdatorESProducer::produce(const MultiRecHitRecord & iRecord
   iRecord.getRecord<CkfComponentsRecord>().getRecord<TrackingComponentsRecord>().get(hitpropagator, hhitpropagator);		
 
   bool debug = pset_.getParameter<bool>("Debug");
-  //_updator  = std::make_shared<SiTrackerMultiRecHitUpdator>(pDD.product(), pp, sp, mp, annealingProgram);
-  _updator  = std::make_shared<SiTrackerMultiRecHitUpdator>(hbuilder.product(),hhitpropagator.product(), Chi2Cut1D, Chi2Cut2D, annealingProgram, debug);
-   // _updator  = std::make_shared<SiTrackerMultiRecHitUpdator>(hhitpropagator.product(),annealingProgram);
-  return _updator;
+  //_updator  = std::make_unique<SiTrackerMultiRecHitUpdator>(pDD.product(), pp, sp, mp, annealingProgram);
+  // _updator  = std::make_unique<SiTrackerMultiRecHitUpdator>(hhitpropagator.product(),annealingProgram);
+  return  std::make_unique<SiTrackerMultiRecHitUpdator>(hbuilder.product(),hhitpropagator.product(), Chi2Cut1D, Chi2Cut2D, annealingProgram, debug);
 }
 
 

--- a/RecoTracker/SiTrackerMRHTools/plugins/SiTrackerMultiRecHitUpdatorESProducer.h
+++ b/RecoTracker/SiTrackerMRHTools/plugins/SiTrackerMultiRecHitUpdatorESProducer.h
@@ -12,9 +12,8 @@ class  SiTrackerMultiRecHitUpdatorESProducer: public edm::ESProducer{
  public:
   SiTrackerMultiRecHitUpdatorESProducer(const edm::ParameterSet & p);
   ~SiTrackerMultiRecHitUpdatorESProducer() override; 
-  std::shared_ptr<SiTrackerMultiRecHitUpdator> produce(const MultiRecHitRecord &);
+  std::unique_ptr<SiTrackerMultiRecHitUpdator> produce(const MultiRecHitRecord &);
  private:
-  std::shared_ptr<SiTrackerMultiRecHitUpdator> _updator;
   edm::ParameterSet pset_;
 };
 


### PR DESCRIPTION
Remove shared_ptr class member that is not needed.