### PR TITLE
RecoTracker/TkNavigation: Change return type of ESProducers.

### DIFF
--- a/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
@@ -372,7 +372,6 @@ class dso_hidden SkippingLayerCosmicNavigationSchoolESProducer final : public ed
   // ----------member data ---------------------------
   edm::ParameterSet theNavigationPSet;
   std::string theNavigationSchoolName;
-  std::shared_ptr<NavigationSchool> theNavigationSchool ;
 
 
 };
@@ -380,6 +379,7 @@ class dso_hidden SkippingLayerCosmicNavigationSchoolESProducer final : public ed
 
 SkippingLayerCosmicNavigationSchoolESProducer::ReturnType SkippingLayerCosmicNavigationSchoolESProducer::produce(const NavigationSchoolRecord& iRecord){
   using namespace edm::es;
+  std::shared_ptr<NavigationSchool> theNavigationSchool ;
 
   // get the field
   edm::ESHandle<MagneticField>                field;

--- a/RecoTracker/TkNavigation/plugins/NavigationSchoolESProducer.cc
+++ b/RecoTracker/TkNavigation/plugins/NavigationSchoolESProducer.cc
@@ -20,14 +20,13 @@ public:
   NavigationSchoolESProducer(const edm::ParameterSet&);
   ~NavigationSchoolESProducer() override;
   
-  typedef std::shared_ptr<NavigationSchool> ReturnType;
+  typedef std::unique_ptr<NavigationSchool> ReturnType;
 
   virtual ReturnType produce(const NavigationSchoolRecord&);
  protected:
   // ----------member data ---------------------------
   edm::ParameterSet theNavigationPSet;
   std::string theNavigationSchoolName;
-  std::shared_ptr<NavigationSchool> theNavigationSchool ;
 };
 
 //
@@ -78,10 +77,9 @@ NavigationSchoolESProducer::produce(const NavigationSchoolRecord& iRecord)
    edm::ESHandle<GeometricSearchTracker>         geometricSearchTracker;
    iRecord.getRecord<TrackerRecoGeometryRecord>().get(geometricSearchTracker);
    
-   theNavigationSchool.reset(NavigationSchoolFactory::get()->create(theNavigationSchoolName,
+   return ReturnType(NavigationSchoolFactory::get()->create(theNavigationSchoolName,
 								    geometricSearchTracker.product(),
 								    field.product()));
-   return theNavigationSchool ;
 }
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"

--- a/RecoTracker/TkNavigation/plugins/TkMSParameterizationBuilder.cc
+++ b/RecoTracker/TkNavigation/plugins/TkMSParameterizationBuilder.cc
@@ -66,11 +66,10 @@ public:
      descriptions.add("TkMSParameterizationBuilder",desc);
   }
   
-  using ReturnType = std::shared_ptr<TkMSParameterization>;
+  using ReturnType = std::unique_ptr<TkMSParameterization>;
   ReturnType produce(TkMSParameterizationRecord const&);
 
   std::string theNavigationSchoolName;
-  ReturnType product;
 };
 
 TkMSParameterizationBuilder::TkMSParameterizationBuilder(edm::ParameterSet const& pset): 
@@ -83,7 +82,7 @@ TkMSParameterizationBuilder::produce(TkMSParameterizationRecord const& iRecord) 
 
   using namespace tkMSParameterization;
 
-  product = std::make_shared<TkMSParameterization>();  
+  ReturnType product = std::make_unique<TkMSParameterization>();  
 
   auto & msParam = *product;
 


### PR DESCRIPTION
Remove shared_ptr class member that is not needed.