### PR TITLE
RecoTracker/TransientTrackingRecHit: change return type of ESProducers.

### DIFF
--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
@@ -90,9 +90,8 @@ TkTransientTrackingRecHitBuilderESProducer::produce(const TransientRecHitRecord 
     iRecord.getRecord<TkStripCPERecord>().get( p2OTname, p2OTe );
     p2OTp = p2OTe.product();
     return std::make_unique<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, p2OTp);
-  } else {
-    return std::make_unique<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, sp, mp, computeCoarseLocalPositionFromDisk);
-  }
+  } 
+  return std::make_unique<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, sp, mp, computeCoarseLocalPositionFromDisk);
 
 }
 

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
@@ -26,7 +26,7 @@ TkTransientTrackingRecHitBuilderESProducer::TkTransientTrackingRecHitBuilderESPr
 
 TkTransientTrackingRecHitBuilderESProducer::~TkTransientTrackingRecHitBuilderESProducer() {}
 
-std::shared_ptr<TransientTrackingRecHitBuilder> 
+std::unique_ptr<TransientTrackingRecHitBuilder> 
 TkTransientTrackingRecHitBuilderESProducer::produce(const TransientRecHitRecord & iRecord){ 
 //   if (_propagator){
 //     delete _propagator;
@@ -89,12 +89,11 @@ TkTransientTrackingRecHitBuilderESProducer::produce(const TransientRecHitRecord 
   if (p2OTname != "") {
     iRecord.getRecord<TkStripCPERecord>().get( p2OTname, p2OTe );
     p2OTp = p2OTe.product();
-    _builder  = std::make_shared<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, p2OTp);
+    return std::make_unique<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, p2OTp);
   } else {
-    _builder  = std::make_shared<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, sp, mp, computeCoarseLocalPositionFromDisk);
+    return std::make_unique<TkTransientTrackingRecHitBuilder>(pDD.product(), pp, sp, mp, computeCoarseLocalPositionFromDisk);
   }
 
-  return _builder;
 }
 
 

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.h
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.h
@@ -15,9 +15,8 @@ class  TkTransientTrackingRecHitBuilderESProducer: public edm::ESProducer{
  public:
   TkTransientTrackingRecHitBuilderESProducer(const edm::ParameterSet & p);
   ~TkTransientTrackingRecHitBuilderESProducer() override; 
-  std::shared_ptr<TransientTrackingRecHitBuilder> produce(const TransientRecHitRecord &);
+  std::unique_ptr<TransientTrackingRecHitBuilder> produce(const TransientRecHitRecord &);
  private:
-  std::shared_ptr<TransientTrackingRecHitBuilder> _builder;
   edm::ParameterSet pset_;
 };
 


### PR DESCRIPTION
Remove shared_ptr class member not needed.