### PR TITLE
Fix collapsed status in HCAL topology

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -128,12 +128,16 @@ upgradeSteps['Neutron'] = {
 }
 upgradeSteps['heCollapse'] = {
     'steps' : [
+        'GenSimFull',
+        'DigiFull',
         'RecoFull',
-        'RecoFullGlobal',
+        'HARVESTFull',
+        'ALCAFull',
     ],
     'PU' : [
+        'DigiFull',
         'RecoFull',
-        'RecoFullGlobal',
+        'HARVESTFull',
     ],
     'suffix' : '_heCollapse',
     'offset' : 0.6,

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -1126,7 +1126,7 @@ double HcalRecHitsAnalyzer::dPhiWsign(double phi1, double phi2) {
 int HcalRecHitsAnalyzer::hcalSevLvl(const CaloRecHit* hit){
 
    HcalDetId id = hit->detid();
-   if (theHcalTopology->withSpecialRBXHBHE() && id.subdet() == HcalEndcap) {
+   if (theHcalTopology->getMergePositionFlag() && id.subdet() == HcalEndcap) {
      id = theHcalTopology->idFront(id);
    }
 

--- a/Geometry/CaloTopology/src/CaloTowerConstituentsMap.cc
+++ b/Geometry/CaloTopology/src/CaloTowerConstituentsMap.cc
@@ -97,7 +97,7 @@ std::vector<DetId> CaloTowerConstituentsMap::constituentsOf(const CaloTowerDetId
     if (id.ietaAbs()<=m_cttopo->lastHBRing()) {
       m_hcaltopo->depthBinInformation(HcalBarrel,hcal_ieta,id.iphi(),id.zside(),nd,sd);
       for (int i=0; i<nd; i++) {
-	if (m_hcaltopo->withSpecialRBXHBHE()) {
+	if (m_hcaltopo->getMergePositionFlag()) {
 	  HcalDetId hid = m_hcaltopo->mergedDepthDetId(HcalDetId(HcalBarrel,hcal_ieta*id.zside(),id.iphi(),i+sd));
 	  if (std::find(items.begin(),items.end(),hid) == items.end()) {
 	    items.emplace_back(hid);
@@ -131,7 +131,7 @@ std::vector<DetId> CaloTowerConstituentsMap::constituentsOf(const CaloTowerDetId
     if (id.ietaAbs()>=m_cttopo->firstHERing() && id.ietaAbs()<=m_cttopo->lastHERing()) {
       m_hcaltopo->depthBinInformation(HcalEndcap,hcal_ieta,id.iphi(),id.zside(),nd,sd);
       for (int i=0; i<nd; i++) {
-	if (m_hcaltopo->withSpecialRBXHBHE()) {
+	if (m_hcaltopo->getMergePositionFlag()) {
 	  HcalDetId hid = m_hcaltopo->mergedDepthDetId(HcalDetId(HcalEndcap,hcal_ieta*id.zside(),id.iphi(),i+sd));
 	  if (std::find(items.begin(),items.end(),hid) == items.end()) {
 	    items.emplace_back(hid);

--- a/Geometry/HcalEventSetup/python/hcalTopologyIdeal_cfi.py
+++ b/Geometry/HcalEventSetup/python/hcalTopologyIdeal_cfi.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+from Geometry.HcalEventSetup.hcalTopologyIdealBase_cfi import hcalTopologyIdealBase as hcalTopologyIdeal
+
+from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
+run2_HEPlan1_2017.toModify(hcalTopologyIdeal,
+    MergePosition = cms.untracked.bool(True)
+)
+
+from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
+run2_HECollapse_2018.toModify(hcalTopologyIdeal,
+    MergePosition = cms.untracked.bool(True)
+)

--- a/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
@@ -59,8 +59,8 @@ void HcalTopologyIdealEP::fillDescriptions( edm::ConfigurationDescriptions & des
 
   edm::ParameterSetDescription desc;
   desc.addUntracked<std::string>( "Exclude", "" );
-  desc.addUntracked<bool>("MergePosition", true);
-  descriptions.add( "hcalTopologyIdeal", desc );
+  desc.addUntracked<bool>("MergePosition", false);
+  descriptions.add( "hcalTopologyIdealBase", desc );
 }
 
 //

--- a/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
@@ -21,7 +21,7 @@ HcalGeometry::HcalGeometry(const HcalTopology& topology) :
 HcalGeometry::~HcalGeometry() {}
 
 void HcalGeometry::init() {
-  if (!m_topology.withSpecialRBXHBHE()) m_mergePosition = false;
+  if (!m_topology.getMergePositionFlag()) m_mergePosition = false;
 #ifdef EDM_ML_DEBUG
   std::cout << "HcalGeometry: " << "HcalGeometry::init() "
 			       << " HBSize " << m_topology.getHBSize() 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -32,6 +32,15 @@ def customiseFor21821(process):
 
     return process
 
+def customiseFor22001(process):
+    for producer in producers_by_type(process, "CaloTowersCreator"):
+        if hasattr(producer,'HcalCollapsed'):
+            del producer.HcalCollapsed
+    if hasattr(process,'HcalTopologyIdealEP'):
+        # should only be true for "collapsed" cases (2017, 2018)
+        process.HcalTopologyIdealEP.MergePosition = cms.untracked.bool(True)
+    return process
+
 def customiseFor21664_forMahiOn(process):
     for producer in producers_by_type(process, "HBHEPhase1Reconstructor"):
         producer.algorithm.useMahi   = cms.bool(True)
@@ -84,4 +93,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     process = customiseFor21821(process)
 
+    process = customiseFor22001(process)
+        
     return process

--- a/RecoLocalCalo/CaloTowersCreator/interface/CaloTowersCreationAlgo.h
+++ b/RecoLocalCalo/CaloTowersCreator/interface/CaloTowersCreationAlgo.h
@@ -75,8 +75,7 @@ public:
     double momHEDepth,
     double momEBDepth,
     double momEEDepth,
-	int hcalPhase=0,
-	bool hcalCollapsed=false
+	int hcalPhase=0
     );
   
   CaloTowersCreationAlgo(double EBthreshold, double EEthreshold, 
@@ -109,8 +108,7 @@ public:
     double momHEDepth,
     double momEBDepth,
     double momEEDepth,
-	int hcalPhase=0,
-	bool hcalCollapsed=false
+	int hcalPhase=0
 );
   
   void setGeometry(const CaloTowerTopology* cttopo, const CaloTowerConstituentsMap* ctmap, const HcalTopology* htopo, const CaloGeometry* geo);
@@ -249,9 +247,6 @@ private:
   /// helper method to look up the appropriate threshold & weight
   void getThresholdAndWeight(const DetId & detId, double & threshold, double & weight) const;
 
-  // wrapper for HcalTopology method
-  bool mergedDepth29(HcalDetId id) const;
-
   double theEBthreshold, theEEthreshold;
   bool theUseEtEBTresholdFlag, theUseEtEETresholdFlag;
   bool theUseSymEBTresholdFlag,theUseSymEETresholdFlag;
@@ -364,7 +359,6 @@ private:
   edm::Handle<EcalRecHitCollection> theEeHandle;
   
   int theHcalPhase;
-  bool isHcalCollapsed;
 
   std::vector<HcalDetId>          ids_;
 };

--- a/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
+++ b/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
@@ -141,9 +141,7 @@ calotowermaker = cms.EDProducer("CaloTowersCreator",
     AllowMissingInputs = cms.bool(False),
 	
 # specify hcal upgrade phase - 0, 1, 2	
-	HcalPhase = cms.int32(0),
-
-    HcalCollapsed = cms.bool(False),
+	HcalPhase = cms.int32(0)
     
 )
 
@@ -156,11 +154,10 @@ run2_HE_2018.toModify(calotowermaker,
                       HEDThreshold  = cms.double(0.2)
 )
 
-# needed to handle inner/outer and 28/29 splitting w/ collapsed rechits
+# needed to handle inner/outer assignment
 from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
 run2_HECollapse_2018.toModify(calotowermaker,
     HcalPhase = cms.int32(0),
-    HcalCollapsed = cms.bool(True),
     HESThreshold1 = cms.double(0.8),
     HESThreshold  = cms.double(0.8),
     HEDThreshold1 = cms.double(0.8),

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -494,7 +494,7 @@ void CaloTowersCreationAlgo::rescaleTowers(const CaloTowerCollection& ctc, CaloT
 void CaloTowersCreationAlgo::assignHitHcal(const CaloRecHit * recHit) {
   DetId detId = recHit->detid();
   DetId detIdF(detId);
-  if (detId.det() == DetId::Hcal && theHcalTopology->withSpecialRBXHBHE()) {
+  if (detId.det() == DetId::Hcal && theHcalTopology->getMergePositionFlag()) {
     detIdF = theHcalTopology->idFront(HcalDetId(detId));
 #ifdef EDM_ML_DEBUG
     std::cout << "AssignHitHcal DetId " << HcalDetId(detId) << " Front " 
@@ -1480,7 +1480,7 @@ GlobalPoint CaloTowersCreationAlgo::hadShwPosFromCells(DetId frontCellId, DetId 
    // to determine the axis. point set by the predefined depth.
 
   HcalDetId hid1(frontCellId), hid2(backCellId);
-  if (theHcalTopology->withSpecialRBXHBHE()) {
+  if (theHcalTopology->getMergePositionFlag()) {
     hid1 = theHcalTopology->idFront(frontCellId);
 #ifdef EDM_ML_DEBUG
     std::cout << "Front " << HcalDetId(frontCellId) << " " << hid1 << "\n";

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -86,8 +86,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo()
    theMomHEDepth(0.),
    theMomEBDepth(0.),
    theMomEEDepth(0.),
-   theHcalPhase(0),
-   isHcalCollapsed(false)
+   theHcalPhase(0)
 {
 }
 
@@ -116,8 +115,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
 					       double momHEDepth,
 					       double momEBDepth,
 					       double momEEDepth,
-                           int hcalPhase,
-                           bool hcalCollapsed)
+                           int hcalPhase)
 
   : theEBthreshold(EBthreshold),
     theEEthreshold(EEthreshold),
@@ -192,8 +190,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
     theMomHEDepth(momHEDepth),
     theMomEBDepth(momEBDepth),
     theMomEEDepth(momEEDepth),
-    theHcalPhase(hcalPhase),
-    isHcalCollapsed(hcalCollapsed)
+    theHcalPhase(hcalPhase)
 {
 }
 
@@ -229,8 +226,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
        double momHEDepth,
        double momEBDepth,
        double momEEDepth,
-       int hcalPhase,
-       bool hcalCollapsed)
+       int hcalPhase)
 
   : theEBthreshold(EBthreshold),
     theEEthreshold(EEthreshold),
@@ -305,8 +301,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
     theMomHEDepth(momHEDepth),
     theMomEBDepth(momEBDepth),
     theMomEEDepth(momEEDepth),
-    theHcalPhase(hcalPhase),
-    isHcalCollapsed(hcalCollapsed)
+    theHcalPhase(hcalPhase)
 {
   // static int N = 0;
   // std::cout << "VI Algo " << ++N << std::endl; 
@@ -526,7 +521,7 @@ void CaloTowersCreationAlgo::assignHitHcal(const CaloRecHit * recHit) {
       (theHcalPhase==0 || theHcalPhase==1) &&
       //HcalDetId(detId).depth()==3 &&
       HcalDetId(detIdF).ietaAbs()==theHcalTopology->lastHERing()-1) {
-    merge = mergedDepth29(HcalDetId(detIdF));
+    merge = theHcalTopology->mergedDepth29(HcalDetId(detIdF));
 #ifdef EDM_ML_DEBUG
     std::cout << "Merge " << HcalDetId(detIdF) << ":" << merge << std::endl;
 #endif
@@ -1304,12 +1299,6 @@ void CaloTowersCreationAlgo::getThresholdAndWeight(const DetId & detId, double &
   }
 }
 
-bool CaloTowersCreationAlgo::mergedDepth29(HcalDetId id) const {
-  //hack for collapsed case (topology only knows about real depths)
-  if(isHcalCollapsed) return id.depth()==3;
-  return theHcalTopology->mergedDepth29(id);
-}
-
 void CaloTowersCreationAlgo::setEBEScale(double scale){
   if (scale>0.00001) *&theEBEScale = scale;
   else *&theEBEScale = 50.;
@@ -1631,7 +1620,7 @@ void CaloTowersCreationAlgo::makeHcalDropChMap() {
       if (hid.subdet()==HcalEndcap &&
 	  (theHcalPhase==0 || theHcalPhase==1) &&
 	  hid.ietaAbs()==theHcalTopology->lastHERing()-1) {
-	bool merge = mergedDepth29(hid);
+	bool merge = theHcalTopology->mergedDepth29(hid);
 	if (merge) {
           CaloTowerDetId twrId29(twrId.ieta()+twrId.zside(), twrId.iphi());
           hcalDropChMap[twrId29] +=1;

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
@@ -66,8 +66,7 @@ CaloTowersCreator::CaloTowersCreator(const edm::ParameterSet& conf) :
         conf.getParameter<double>("MomHEDepth"),
         conf.getParameter<double>("MomEBDepth"),
         conf.getParameter<double>("MomEEDepth"),
-        conf.getParameter<int>("HcalPhase"),
-        conf.getParameter<bool>("HcalCollapsed")
+        conf.getParameter<int>("HcalPhase")
 	),
 
   ecalLabels_(conf.getParameter<std::vector<edm::InputTag> >("ecalInputs")),
@@ -365,7 +364,6 @@ void CaloTowersCreator::fillDescriptions(edm::ConfigurationDescriptions& descrip
 	desc.add<unsigned int>("HcalAcceptSeverityLevelForRejectedHit", 9999);
 	desc.add<std::vector<std::string> >("EcalSeveritiesToBeUsedInBadTowers", {});
 	desc.add<int>("HcalPhase", 0);
-	desc.add<bool>("HcalCollapsed", 0);
 
 	descriptions.addDefault(desc);
 }

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.cc
@@ -37,8 +37,7 @@ CaloTowersReCreator::CaloTowersReCreator(const edm::ParameterSet& conf) :
         conf.getParameter<double>("MomHEDepth"),
         conf.getParameter<double>("MomEBDepth"),
         conf.getParameter<double>("MomEEDepth"),
-        conf.getParameter<int>("HcalPhase"),
-        conf.getParameter<bool>("HcalCollapsed")
+        conf.getParameter<int>("HcalPhase")
         ),
   allowMissingInputs_(false)
 {
@@ -143,7 +142,6 @@ void CaloTowersReCreator::fillDescriptions(edm::ConfigurationDescriptions& descr
 	desc.add<edm::InputTag>("caloLabel", edm::InputTag("calotowermaker"));
 	desc.add<int>("MomConstrMethod", 1);
 	desc.add<int>("HcalPhase", 0);
-	desc.add<bool>("HcalCollapsed", 0);
 
 	descriptions.addDefault(desc);
 }

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPlan1Combiner.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPlan1Combiner.cc
@@ -104,7 +104,7 @@ HBHEPlan1Combiner::produce(edm::Event& iEvent, const edm::EventSetup& eventSetup
 
     // Are we using "Plan 1" geometry?
     const bool plan1Mode = ignorePlan1Topology_ ? usePlan1Mode_
-                                                : htopo->withSpecialRBXHBHE();
+                                                : htopo->getMergePositionFlag();
 
     // Find the input rechit collection
     Handle<HBHERecHitCollection> inputRechits;

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitSelection.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitSelection.cc
@@ -82,7 +82,7 @@ template <class CollectionType> void HcalHitSelection::skim( const edm::Handle<C
   for (;hit!=end;++hit){
     //    edm::LogError("HcalHitSelection")<<"the hit pointer is"<<&(*hit);
     HcalDetId id = hit->detid();
-    if (theHcalTopology_->withSpecialRBXHBHE() && id.subdet() == HcalEndcap) {
+    if (theHcalTopology_->getMergePositionFlag() && id.subdet() == HcalEndcap) {
       id = theHcalTopology_->idFront(id);
     }
     const uint32_t & recHitFlag = hit->flags();

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
@@ -55,7 +55,7 @@ template <typename Digi, typename Geometry,PFLayer::Layer Layer,int Detector>
 	if (esd !=Detector && Detector != HcalOther  ) 
 	  continue;
 
-        if (theHcalTopology->withSpecialRBXHBHE() && esd == HcalEndcap) {
+        if (theHcalTopology->getMergePositionFlag() && esd == HcalEndcap) {
           detid = theHcalTopology->idFront(detid);
 	}
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -147,7 +147,7 @@ protected:
 
     bool test(unsigned aDETID, double energy, int flags, bool& clean){
     HcalDetId detid = (HcalDetId)aDETID;
-    if (theHcalTopology_->withSpecialRBXHBHE() and detid.subdet() == HcalEndcap){
+    if (theHcalTopology_->getMergePositionFlag() and detid.subdet() == HcalEndcap){
       detid = theHcalTopology_->idFront(detid);
     }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.cc
@@ -187,7 +187,7 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
       if(hit.det()==DetId::Hcal) { 
 	foundHCALConstituent = true;
 	detid = hit;
-	if (theHcalTopology->withSpecialRBXHBHE() && 
+	if (theHcalTopology->getMergePositionFlag() && 
 	    detid.subdet() == HcalEndcap) {
 	  detid = theHcalTopology->idFront(detid);
 	}


### PR DESCRIPTION
#21842 unintentionally introduced some discrepancies in the 2018 "collapsed" workflow. The underlying problem is that `HcalTopology::withSpecialRBXHBHE()` is set by the underlying geometry, and since we use a geometry that allows collapsing for 2018, it is always true, even if the collapsing is not actually performed.

Instead, from now on we will use `HcalTopology::getMergePositionFlag()`, which can be set in Python. This parameter will be set by the same modifier that puts the RecHit combiner module into the HCAL local reco sequence.

This change is propagated to all necessary areas of the code. @abdoulline has confirmed that it works as expected for CaloTowers (with thresholds removed, since sometimes there can be weird threshold effects for collapsed vs uncollapsed RecHits): https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/10_0_0/10_0_0_2018C_fixNocuts_vs_10_0_0_2018UC_fixNocuts_SinglePi/

@Martin-Grunewald for HLT, the parameter `process.HcalTopologyIdealEP.MergePosition` should be false by default, except for collapsed menus (2017 and 2018). What is the best way to specify this in the customization?

This PR will be backported to 100X.

attn: @bsunanda 