### PR TITLE
Candidate Seeded option for automated doublet recovery in HLT tracking

### DIFF
--- a/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.cc
@@ -7,7 +7,6 @@
 #include "DataFormats/Math/interface/normalizedPhi.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 
-
 #include <array>
 #include <limits>
 
@@ -85,7 +84,7 @@ std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::regio
 }
 
 template <typename T>
-std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::regionImpl(const Origin& origin, const T& areas) const { 
+std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::regionImpl(const Origin& origin, const T& areas) const {
   float minEta=std::numeric_limits<float>::max(), maxEta=std::numeric_limits<float>::lowest();
   float minPhi=std::numeric_limits<float>::max(), maxPhi=std::numeric_limits<float>::lowest();
 
@@ -274,7 +273,7 @@ std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::regio
 
 		const auto x = std::cos(meanPhiTemp);
   	  	const auto y = std::sin(meanPhiTemp);
-  	  	const auto z = (x*x+y*y)/std::tan(2.f*std::atan(std::exp(-meanEtaTemp))); // simplify?
+  	  	const auto z = 1./std::tan(2.f*std::atan(std::exp(-meanEtaTemp)));
 
   		LogTrace("AreaSeededTrackingRegionsBuilder") << "Direction x,y,z " << x << "," << y << "," << z
                                                << " eta,phi " << meanEtaTemp << "," << meanPhiTemp
@@ -302,7 +301,7 @@ std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::regio
   else{
   	const auto x = std::cos(meanPhi);
   	const auto y = std::sin(meanPhi);
-  	const auto z = (x*x+y*y)/std::tan(2.f*std::atan(std::exp(-meanEta))); // simplify?
+  	const auto z = 1./std::tan(2.f*std::atan(std::exp(-meanEta))); 
 
   	LogTrace("AreaSeededTrackingRegionsBuilder") << "Direction x,y,z " << x << "," << y << "," << z
                                                << " eta,phi " << meanEta << "," << meanPhi

--- a/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.cc
@@ -181,7 +181,7 @@ std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::regio
       // rmin, but the '0.5f*' factor is omitted here to reduce
       // computations.
       const auto phi_ref = std::atan2(y_rmin_phimin + y_rmin_phimax,
-                                      x_rmin_phimin + y_rmin_phimax);
+                                      x_rmin_phimin + x_rmin_phimax);
 
       // for maximum phi we need the orthogonal vector to the left
       const auto tan_rmin_phimax = tangentVec(p_rmin_phimax, +1);

--- a/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.cc
@@ -60,7 +60,6 @@ AreaSeededTrackingRegionsBuilder::Builder AreaSeededTrackingRegionsBuilder::begi
   }
   builder.setCandidates( ( candidates_.objects(e)));
   return builder;
-
 }
 
 
@@ -86,9 +85,9 @@ std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::regio
 std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::region(const Origin& origin, const edm::VecArray<Area, 2>& areas) const {
   return regionImpl(origin, areas);
 }
+
 template <typename T>
-std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::regionImpl(const Origin& origin, const T& areas) const {
-  
+std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::regionImpl(const Origin& origin, const T& areas) const { 
   float minEta=std::numeric_limits<float>::max(), maxEta=std::numeric_limits<float>::lowest();
   float minPhi=std::numeric_limits<float>::max(), maxPhi=std::numeric_limits<float>::lowest();
 

--- a/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.cc
@@ -86,7 +86,6 @@ std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::regio
 std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::region(const Origin& origin, const edm::VecArray<Area, 2>& areas) const {
   return regionImpl(origin, areas);
 }
- 
 template <typename T>
 std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::regionImpl(const Origin& origin, const T& areas) const {
   
@@ -250,7 +249,7 @@ std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::regio
 		float dEta_Cand = candidates.second.first;
 		float dPhi_Cand = candidates.second.second;
 	       	float eta_Cand = object.eta();
-                float phi_Cand = object.phi();
+		float phi_Cand = object.phi();
           	float dEta_Cand_Point = std::abs(eta_Cand-meanEta);
           	float dPhi_Cand_Point = std::abs(deltaPhi(phi_Cand,meanPhi));
 
@@ -268,18 +267,13 @@ std::unique_ptr<TrackingRegion> AreaSeededTrackingRegionsBuilder::Builder::regio
 		float phiMax_RoI = deltaPhi(phi_Cand_plus,phi_Point_plus)<0. ? phi_Cand_plus : phi_Point_plus;
 
 
-
 		const auto meanEtaTemp = (etaMin_RoI+etaMax_RoI)/2.f;
-                auto meanPhiTemp = (phiMin_RoI+phiMax_RoI)/2.f;
+		auto meanPhiTemp = (phiMin_RoI+phiMax_RoI)/2.f;
 		if( phiMax_RoI < phiMin_RoI ) meanPhiTemp-=M_PI;
 	        meanPhiTemp = normalizedPhi(meanPhiTemp);
 	        
 		const auto dPhiTemp = deltaPhi(phiMax_RoI,meanPhiTemp);
-                const auto dEtaTemp = etaMax_RoI-meanEtaTemp;
-
-
-
-
+		const auto dEtaTemp = etaMax_RoI-meanEtaTemp;
 
 		const auto x = std::cos(meanPhiTemp);
   	  	const auto y = std::sin(meanPhiTemp);

--- a/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.cc
@@ -4,11 +4,9 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Math/interface/PtEtaPhiMass.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/Math/interface/normalizedPhi.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 
-#include "DataFormats/Candidate/interface/Candidate.h"
-#include "DataFormats/Math/interface/deltaPhi.h"
-#include "DataFormats/Math/interface/normalizedPhi.h"
 
 #include <array>
 #include <limits>

--- a/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.h
+++ b/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.h
@@ -97,21 +97,19 @@ public:
   AreaSeededTrackingRegionsBuilder(const edm::ParameterSet& regPSet, edm::ConsumesCollector&& iC): AreaSeededTrackingRegionsBuilder(regPSet, iC) {}
   AreaSeededTrackingRegionsBuilder(const edm::ParameterSet& regPSet, edm::ConsumesCollector& iC);
   ~AreaSeededTrackingRegionsBuilder() = default;
-  
   static void fillDescriptions(edm::ParameterSetDescription& desc);
 
   Builder beginEvent(const edm::Event& e) const;
 
-  private:
-   std::vector<Area> m_areas;
-   TrackingSeedCandidates candidates_;
+ private:
+  std::vector<Area> m_areas;
+  TrackingSeedCandidates candidates_;
   float m_extraPhi;
   float m_extraEta;
   float m_ptMin;
   float m_originRadius;
   bool m_precise;
   edm::EDGetTokenT<MeasurementTrackerEvent> token_measurementTracker;
-  edm::EDGetTokenT<TrackingSeedCandidates> token_candidates;
   RectangularEtaPhiTrackingRegion::UseMeasurementTracker m_whereToUseMeasurementTracker;
   bool m_searchOpt;
 };

--- a/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.h
+++ b/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.h
@@ -7,11 +7,11 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Utilities/interface/VecArray.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
+#include "TrackingSeedCandidates.h"
 class AreaSeededTrackingRegionsBuilder {
 public:
   using Origin = std::pair<GlobalPoint, float>; // (origin, half-length in z)
@@ -19,12 +19,10 @@ public:
 
   class Area {
   public:
-    Area() {}
-
     // phimin and phimax, and hence xmin+xmax and ymin+ymax are
     // ordered by which way one goes around the unit circle, so it may
     // happen that actually phimax < phimin
-    Area(float rmin, float rmax, float phimin, float phimax, float zmin, float zmax):
+    Area(double rmin, double rmax, double phimin, double phimax, double zmin, double zmax):
       m_zmin(zmin), m_zmax(zmax)
     {
       auto cosphimin = std::cos(phimin);
@@ -78,36 +76,35 @@ public:
     ~Builder() = default;
 
     void setMeasurementTracker(const MeasurementTrackerEvent *mte) { m_measurementTracker = mte; }
+    void setCandidates(const TrackingSeedCandidates::Objects cands) { candidates = cands; }
 
     std::vector<std::unique_ptr<TrackingRegion> > regions(const Origins& origins, const std::vector<Area>& areas) const;
     std::unique_ptr<TrackingRegion> region(const Origin& origin, const std::vector<Area>& areas) const;
-    std::unique_ptr<TrackingRegion> region(const Origin& origin, const edm::VecArray<Area, 2>& areas) const;
 
   private:
-    template <typename T>
-    std::unique_ptr<TrackingRegion> regionImpl(const Origin& origin, const T& areas) const;
-
     const AreaSeededTrackingRegionsBuilder *m_conf = nullptr;
     const MeasurementTrackerEvent *m_measurementTracker = nullptr;
+    TrackingSeedCandidates::Objects candidates;
   };
 
   AreaSeededTrackingRegionsBuilder(const edm::ParameterSet& regPSet, edm::ConsumesCollector&& iC): AreaSeededTrackingRegionsBuilder(regPSet, iC) {}
   AreaSeededTrackingRegionsBuilder(const edm::ParameterSet& regPSet, edm::ConsumesCollector& iC);
   ~AreaSeededTrackingRegionsBuilder() = default;
+  
+	  static void fillDescriptions(edm::ParameterSetDescription& desc);
 
-  static void fillDescriptions(edm::ParameterSetDescription& desc);
+	  Builder beginEvent(const edm::Event& e) const;
 
-  Builder beginEvent(const edm::Event& e) const;
-
-private:
-  std::vector<Area> m_areas;
-
+	private:
+	  std::vector<Area> m_areas;
+	  TrackingSeedCandidates candidates_;
   float m_extraPhi;
   float m_extraEta;
   float m_ptMin;
   float m_originRadius;
   bool m_precise;
   edm::EDGetTokenT<MeasurementTrackerEvent> token_measurementTracker;
+  edm::EDGetTokenT<TrackingSeedCandidates> token_candidates;
   RectangularEtaPhiTrackingRegion::UseMeasurementTracker m_whereToUseMeasurementTracker;
   bool m_searchOpt;
 };

--- a/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.h
+++ b/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.h
@@ -97,11 +97,12 @@ public:
   AreaSeededTrackingRegionsBuilder(const edm::ParameterSet& regPSet, edm::ConsumesCollector&& iC): AreaSeededTrackingRegionsBuilder(regPSet, iC) {}
   AreaSeededTrackingRegionsBuilder(const edm::ParameterSet& regPSet, edm::ConsumesCollector& iC);
   ~AreaSeededTrackingRegionsBuilder() = default;
+
   static void fillDescriptions(edm::ParameterSetDescription& desc);
 
   Builder beginEvent(const edm::Event& e) const;
 
- private:
+private:
   std::vector<Area> m_areas;
   TrackingSeedCandidates candidates_;
   float m_extraPhi;

--- a/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.h
+++ b/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.h
@@ -20,10 +20,12 @@ public:
 
   class Area {
   public:
+    Area() {}
+
     // phimin and phimax, and hence xmin+xmax and ymin+ymax are
     // ordered by which way one goes around the unit circle, so it may
     // happen that actually phimax < phimin
-    Area(double rmin, double rmax, double phimin, double phimax, double zmin, double zmax):
+    Area(float rmin, float rmax, float phimin, float phimax, float zmin, float zmax):
       m_zmin(zmin), m_zmax(zmax)
     {
       auto cosphimin = std::cos(phimin);
@@ -81,8 +83,12 @@ public:
 
     std::vector<std::unique_ptr<TrackingRegion> > regions(const Origins& origins, const std::vector<Area>& areas) const;
     std::unique_ptr<TrackingRegion> region(const Origin& origin, const std::vector<Area>& areas) const;
+    std::unique_ptr<TrackingRegion> region(const Origin& origin, const edm::VecArray<Area, 2>& areas) const;
 
   private:
+    template <typename T>
+    std::unique_ptr<TrackingRegion> regionImpl(const Origin& origin, const T& areas) const;
+
     const AreaSeededTrackingRegionsBuilder *m_conf = nullptr;
     const MeasurementTrackerEvent *m_measurementTracker = nullptr;
     TrackingSeedCandidates::Objects candidates;
@@ -92,13 +98,13 @@ public:
   AreaSeededTrackingRegionsBuilder(const edm::ParameterSet& regPSet, edm::ConsumesCollector& iC);
   ~AreaSeededTrackingRegionsBuilder() = default;
   
-	  static void fillDescriptions(edm::ParameterSetDescription& desc);
+  static void fillDescriptions(edm::ParameterSetDescription& desc);
 
-	  Builder beginEvent(const edm::Event& e) const;
+  Builder beginEvent(const edm::Event& e) const;
 
-	private:
-	  std::vector<Area> m_areas;
-	  TrackingSeedCandidates candidates_;
+  private:
+   std::vector<Area> m_areas;
+   TrackingSeedCandidates candidates_;
   float m_extraPhi;
   float m_extraEta;
   float m_ptMin;

--- a/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.h
+++ b/RecoTracker/TkTrackingRegions/plugins/AreaSeededTrackingRegionsBuilder.h
@@ -7,6 +7,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/VecArray.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"

--- a/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaTrackingRegionsSeedingLayersProducer.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaTrackingRegionsSeedingLayersProducer.cc
@@ -75,6 +75,7 @@ void PixelInactiveAreaTrackingRegionsSeedingLayersProducer::produce(edm::Event& 
     LogTrace("PixelInactiveAreaTrackingRegionsSeedingLayersProducer") << "Origin " << origin.first.x() << "," << origin.first.y() << "," << origin.first.z() << " z half lengh " << origin.second;
     for(auto& areasLayerSet: areasLayerSets) {
       auto region = builder.region(origin, areasLayerSet.first);
+      if(!region) continue;
 #ifdef EDM_ML_DEBUG
       auto etaPhiRegion = dynamic_cast<const RectangularEtaPhiTrackingRegion *>(region.get());
       std::stringstream ss;

--- a/RecoTracker/TkTrackingRegions/plugins/TrackingSeedCandidates.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/TrackingSeedCandidates.cc
@@ -23,19 +23,16 @@ void TrackingSeedCandidates::fillDescriptions(edm::ParameterSetDescription& desc
   desc.add<edm::InputTag>("input",edm::InputTag());
   desc.add<double>("deltaEta_Cand", -1.);
   desc.add<double>("deltaPhi_Cand", -1.);
- 
 }
 
 TrackingSeedCandidates::Objects TrackingSeedCandidates::objects(const edm::Event& iEvent) const {
  
  Objects result;
-
  std::pair <float,float> dimensions = std::make_pair(m_deltaEta_Cand,m_deltaPhi_Cand);
  edm::Handle< reco::CandidateView > objects;
   
  if(m_seedingMode == SeedingMode::CANDIDATE_SEEDED){
       iEvent.getByToken( m_token_input, objects ); 
-
       result = std::make_pair(objects.product(),dimensions); 
   }
   else result = std::make_pair(nullptr,dimensions); 

--- a/RecoTracker/TkTrackingRegions/plugins/TrackingSeedCandidates.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/TrackingSeedCandidates.cc
@@ -1,0 +1,43 @@
+#include "TrackingSeedCandidates.h"
+
+TrackingSeedCandidates::TrackingSeedCandidates(const edm::ParameterSet& regPSet, edm::ConsumesCollector& iC) {
+  // operation mode
+  //
+    std::string seedingModeString = regPSet.getParameter<std::string>("seedingMode");
+    if      (seedingModeString == "Candidate")      m_seedingMode = SeedingMode::CANDIDATE_SEEDED;
+    else if (seedingModeString == "Global")          m_seedingMode = SeedingMode::GLOBAL;
+    else throw edm::Exception(edm::errors::Configuration) << "Unknown seeding mode string: "<<seedingModeString;
+
+    m_deltaEta_Cand = regPSet.getParameter<double>("deltaEta_Cand"); 
+    m_deltaPhi_Cand = regPSet.getParameter<double>("deltaPhi_Cand");
+ 
+    // basic inputs
+    if(m_seedingMode == SeedingMode::CANDIDATE_SEEDED)
+      m_token_input        = iC.consumes<reco::CandidateView>(regPSet.getParameter<edm::InputTag>("input"));
+
+}
+
+void TrackingSeedCandidates::fillDescriptions(edm::ParameterSetDescription& desc) {
+  desc.add<std::string>("seedingMode", "Global");
+  const std::string defaultInput = ""; 
+  desc.add<edm::InputTag>("input",defaultInput);
+  desc.add<double>("deltaEta_Cand", -1.);
+  desc.add<double>("deltaPhi_Cand", -1.);
+ 
+}
+
+TrackingSeedCandidates::Objects TrackingSeedCandidates::objects(const edm::Event& iEvent) const {
+ 
+ Objects result;
+
+ std::pair <float,float> dimensions = std::make_pair(m_deltaEta_Cand,m_deltaPhi_Cand);
+ edm::Handle< reco::CandidateView > objects;
+  
+ if(m_seedingMode == SeedingMode::CANDIDATE_SEEDED){
+      iEvent.getByToken( m_token_input, objects ); 
+
+      result = std::make_pair(objects.product(),dimensions); 
+  }
+  else result = std::make_pair(nullptr,dimensions); 
+  return result;
+}

--- a/RecoTracker/TkTrackingRegions/plugins/TrackingSeedCandidates.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/TrackingSeedCandidates.cc
@@ -12,15 +12,15 @@ TrackingSeedCandidates::TrackingSeedCandidates(const edm::ParameterSet& regPSet,
     m_deltaPhi_Cand = regPSet.getParameter<double>("deltaPhi_Cand");
  
     // basic inputs
-    if(m_seedingMode == SeedingMode::CANDIDATE_SEEDED)
+    if(m_seedingMode == SeedingMode::CANDIDATE_SEEDED){
       m_token_input        = iC.consumes<reco::CandidateView>(regPSet.getParameter<edm::InputTag>("input"));
-
+      if (m_deltaEta_Cand<0 || m_deltaPhi_Cand<0) throw edm::Exception(edm::errors::Configuration) << "Delta eta and phi parameters must be set for candidates in candidate seeding mode"; 
+    }
 }
 
 void TrackingSeedCandidates::fillDescriptions(edm::ParameterSetDescription& desc) {
   desc.add<std::string>("seedingMode", "Global");
-  const std::string defaultInput = ""; 
-  desc.add<edm::InputTag>("input",defaultInput);
+  desc.add<edm::InputTag>("input",edm::InputTag());
   desc.add<double>("deltaEta_Cand", -1.);
   desc.add<double>("deltaPhi_Cand", -1.);
  

--- a/RecoTracker/TkTrackingRegions/plugins/TrackingSeedCandidates.h
+++ b/RecoTracker/TkTrackingRegions/plugins/TrackingSeedCandidates.h
@@ -1,0 +1,38 @@
+#ifndef RecoTracker_TkTrackingRegions_TrackingSeedCandidates_h
+#define RecoTracker_TkTrackingRegions_TrackingSeedCandidates_h
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include <vector>
+#include <utility>
+
+class TrackingSeedCandidates {
+public:
+
+  enum class SeedingMode {CANDIDATE_SEEDED, GLOBAL};
+  //using Objects = std::pair< edm::Handle< reco::CandidateView > , std::pair < float, float > > ; // (origin, half-length in z)
+  using Objects = std::pair< const reco::CandidateView* , std::pair < float, float > > ; // (origin, half-length in z)
+  TrackingSeedCandidates(const edm::ParameterSet& regPSet, edm::ConsumesCollector&& iC): TrackingSeedCandidates(regPSet, iC) {}
+  TrackingSeedCandidates(const edm::ParameterSet& regPSet, edm::ConsumesCollector& iC);
+  ~TrackingSeedCandidates() = default;
+
+  static void fillDescriptions(edm::ParameterSetDescription& desc);
+
+  Objects objects(const edm::Event& iEvent) const;
+
+private:
+  SeedingMode m_seedingMode;
+  float m_deltaEta_Cand;
+  float m_deltaPhi_Cand;
+ 
+  edm::EDGetTokenT<reco::CandidateView> m_token_input;
+
+};
+
+
+#endif


### PR DESCRIPTION
Automated doublet recovery running in a global tracking region in the full pixel volume is too time consuming at HLT. This PR implements the combination of this automated recovery with the usual candidate seeded tracking regions used at HLT by finding the intersection between the regions found by the recovery procedure and using those for HLT tracking. This will allow us to make HLT tracking robust against current and future problems with the pixel detector. 

Some performances notes can be found here https://cernbox.cern.ch/index.php/s/AuCleNY9dq9k8gh, 
together with plots showing that the new code does not impact the current functionality. 