### PR TITLE
Trackingtools/TrackingFitters: ESProducers update return type to unique_ptr

### DIFF
--- a/TrackingTools/TrackFitters/plugins/KFFittingSmoother.h
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmoother.h
@@ -55,7 +55,6 @@ namespace {
   public:
     ~KFFittingSmoother() override {}
 
-  private:
     KFFittingSmoother(const TrajectoryFitter& aFitter,
 		      const TrajectorySmoother& aSmoother,
 		      const edm::ParameterSet & conf) :
@@ -64,6 +63,7 @@ namespace {
       theSmoother(aSmoother.clone())
 	{}
     
+  private:
     
     
     static void  fillDescriptions(edm::ParameterSetDescription & desc) {

--- a/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
@@ -47,7 +47,8 @@ namespace {
       iRecord.get(pset_.getParameter<std::string>("Fitter"), fit);
       iRecord.get(pset_.getParameter<std::string>("Smoother"), smooth);
       
-     return std::unique_ptr<TrajectoryFitter>(new KFFittingSmoother(*fit.product(), *smooth.product(),pset_));
+     auto kfs = std::make_unique<KFFittingSmoother>(*fit.product(), *smooth.product(),pset_);
+     return std::move(kfs);
     }
 
   private:

--- a/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
@@ -47,8 +47,7 @@ namespace {
       iRecord.get(pset_.getParameter<std::string>("Fitter"), fit);
       iRecord.get(pset_.getParameter<std::string>("Smoother"), smooth);
       
-     auto kfs = std::make_unique<KFFittingSmoother>(*fit.product(), *smooth.product(),pset_);
-     return std::move(kfs);
+     return std::make_unique<KFFittingSmoother>(*fit.product(), *smooth.product(),pset_);
     }
 
   private:

--- a/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
@@ -37,7 +37,7 @@ namespace {
     
     ~KFFittingSmootherESProducer() override {}
     
-    std::shared_ptr<TrajectoryFitter> 
+    std::unique_ptr<TrajectoryFitter> 
     produce(const TrajectoryFitterRecord & iRecord){ 
       
       
@@ -47,7 +47,7 @@ namespace {
       iRecord.get(pset_.getParameter<std::string>("Fitter"), fit);
       iRecord.get(pset_.getParameter<std::string>("Smoother"), smooth);
       
-     return std::shared_ptr<TrajectoryFitter>(new KFFittingSmoother(*fit.product(), *smooth.product(),pset_));
+     return std::unique_ptr<TrajectoryFitter>(new KFFittingSmoother(*fit.product(), *smooth.product(),pset_));
     }
 
   private:

--- a/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.h
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.h
@@ -17,9 +17,8 @@ class  KFFittingSmootherESProducer: public edm::ESProducer{
  public:
   KFFittingSmootherESProducer(const edm::ParameterSet & p);
   virtual ~KFFittingSmootherESProducer(); 
-  std::shared_ptr<TrajectoryFitter> produce(const TrajectoryFitterRecord &);
+  std::unique_ptr<TrajectoryFitter> produce(const TrajectoryFitterRecord &);
  private:
-  std::shared_ptr<TrajectoryFitter> _fitter;
   edm::ParameterSet pset_;
 };
 

--- a/TrackingTools/TrackFitters/plugins/KFTrajectoryFitterESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFTrajectoryFitterESProducer.cc
@@ -25,7 +25,7 @@ namespace {
   public:
     KFTrajectoryFitterESProducer(const edm::ParameterSet & p);
     ~KFTrajectoryFitterESProducer() override; 
-    std::shared_ptr<TrajectoryFitter> produce(const TrajectoryFitterRecord &);
+    std::unique_ptr<TrajectoryFitter> produce(const TrajectoryFitterRecord &);
     
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
@@ -52,7 +52,7 @@ namespace {
   
   KFTrajectoryFitterESProducer::~KFTrajectoryFitterESProducer() {}
   
-  std::shared_ptr<TrajectoryFitter>
+  std::unique_ptr<TrajectoryFitter>
   KFTrajectoryFitterESProducer::produce(const TrajectoryFitterRecord & iRecord){ 
     
     std::string pname = pset_.getParameter<std::string>("Propagator");
@@ -71,7 +71,7 @@ namespace {
     iRecord.getRecord<TrackingComponentsRecord>().get(ename, est);
     iRecord.getRecord<RecoGeometryRecord>().get(gname,geo);
 
-    return std::make_shared<KFTrajectoryFitter>(prop.product(),
+    return std::make_unique<KFTrajectoryFitter>(prop.product(),
 				                upd.product(),
 				                est.product(),
 				                minHits,

--- a/TrackingTools/TrackFitters/plugins/KFTrajectorySmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFTrajectorySmootherESProducer.cc
@@ -25,7 +25,7 @@ namespace {
   public:
     KFTrajectorySmootherESProducer(const edm::ParameterSet & p);
     ~KFTrajectorySmootherESProducer() override; 
-    std::shared_ptr<TrajectorySmoother> produce(const TrajectoryFitterRecord &);
+    std::unique_ptr<TrajectorySmoother> produce(const TrajectoryFitterRecord &);
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
@@ -54,7 +54,7 @@ namespace {
   
   KFTrajectorySmootherESProducer::~KFTrajectorySmootherESProducer() {}
   
-  std::shared_ptr<TrajectorySmoother> 
+  std::unique_ptr<TrajectorySmoother> 
     KFTrajectorySmootherESProducer::produce(const TrajectoryFitterRecord & iRecord){ 
     
     std::string pname = pset_.getParameter<std::string>("Propagator");
@@ -75,7 +75,7 @@ namespace {
     iRecord.getRecord<TrackingComponentsRecord>().get(ename, est);
     iRecord.getRecord<RecoGeometryRecord>().get(gname,geo);
     
-    return std::make_shared<KFTrajectorySmoother>(prop.product(),
+    return std::make_unique<KFTrajectorySmoother>(prop.product(),
 						  upd.product(),
 						  est.product(),
 						  rescaleFactor,


### PR DESCRIPTION
A shared_ptr is not needed when returning a pointer created by produce method temporary.