### PR TITLE
TrackingTools/TrackAssociator: change ESProducer return type to unique_ptr.

### DIFF
--- a/TrackingTools/TrackAssociator/plugins/DetIdAssociatorESProducer.cc
+++ b/TrackingTools/TrackAssociator/plugins/DetIdAssociatorESProducer.cc
@@ -39,7 +39,7 @@ public:
   DetIdAssociatorESProducer(const edm::ParameterSet&);
   ~DetIdAssociatorESProducer() override;
   
-  typedef std::shared_ptr<DetIdAssociator> ReturnType;
+  typedef std::unique_ptr<DetIdAssociator> ReturnType;
   
   ReturnType produce(const DetIdAssociatorRecord&);
 private:


### PR DESCRIPTION
unique_ptr can be used when the ptr returned is created as a produce method temporary.