### PR TITLE
TrackingTools/PatternTools: ESProducers updated to return unique_ptr.

### DIFF
--- a/TrackingTools/PatternTools/plugins/TSCBLBuilderNoMaterialESProducer.cc
+++ b/TrackingTools/PatternTools/plugins/TSCBLBuilderNoMaterialESProducer.cc
@@ -77,7 +77,7 @@ TSCBLBuilderNoMaterialESProducer::produce(const TrackingComponentsRecord& iRecor
    auto pTSCBLBuilderNoMaterial = std::make_unique<TSCBLBuilderNoMaterial>() ;
 
 
-   return std::move(pTSCBLBuilderNoMaterial) ;
+   return pTSCBLBuilderNoMaterial ;
 }
 
 //define this as a plug-in

--- a/TrackingTools/PatternTools/plugins/TSCBLBuilderNoMaterialESProducer.cc
+++ b/TrackingTools/PatternTools/plugins/TSCBLBuilderNoMaterialESProducer.cc
@@ -27,7 +27,7 @@ class TSCBLBuilderNoMaterialESProducer : public edm::ESProducer {
       TSCBLBuilderNoMaterialESProducer(const edm::ParameterSet&);
       ~TSCBLBuilderNoMaterialESProducer() override;
 
-      typedef std::shared_ptr<TrajectoryStateClosestToBeamLineBuilder> ReturnType;
+      typedef std::unique_ptr<TrajectoryStateClosestToBeamLineBuilder> ReturnType;
 
       ReturnType produce(const TrackingComponentsRecord&);
    private:
@@ -74,10 +74,10 @@ TSCBLBuilderNoMaterialESProducer::ReturnType
 TSCBLBuilderNoMaterialESProducer::produce(const TrackingComponentsRecord& iRecord)
 {
    using namespace edm::es;
-   TSCBLBuilderNoMaterialESProducer::ReturnType pTSCBLBuilderNoMaterial(new TSCBLBuilderNoMaterial()) ;
+   auto pTSCBLBuilderNoMaterial = std::make_unique<TSCBLBuilderNoMaterial>() ;
 
 
-   return pTSCBLBuilderNoMaterial ;
+   return std::move(pTSCBLBuilderNoMaterial) ;
 }
 
 //define this as a plug-in

--- a/TrackingTools/PatternTools/plugins/TSCBLBuilderWithPropagatorESProducer.cc
+++ b/TrackingTools/PatternTools/plugins/TSCBLBuilderWithPropagatorESProducer.cc
@@ -27,7 +27,7 @@ class TSCBLBuilderWithPropagatorESProducer : public edm::ESProducer {
       TSCBLBuilderWithPropagatorESProducer(const edm::ParameterSet&);
       ~TSCBLBuilderWithPropagatorESProducer() override;
 
-      typedef std::shared_ptr<TrajectoryStateClosestToBeamLineBuilder> ReturnType;
+      typedef std::unique_ptr<TrajectoryStateClosestToBeamLineBuilder> ReturnType;
 
       ReturnType produce(const TrackingComponentsRecord&);
    private:
@@ -83,10 +83,10 @@ TSCBLBuilderWithPropagatorESProducer::produce(const TrackingComponentsRecord& iR
 
    const Propagator * pro = theProp.product();
 
-   TSCBLBuilderWithPropagatorESProducer::ReturnType pTSCBLBuilderWithPropagator(new TSCBLBuilderWithPropagator(*pro)) ;
+   auto pTSCBLBuilderWithPropagator = std::make_unique<TSCBLBuilderWithPropagator>(*pro) ;
 
 
-   return pTSCBLBuilderWithPropagator ;
+   return std::move(pTSCBLBuilderWithPropagator) ;
 }
 
 //define this as a plug-in

--- a/TrackingTools/PatternTools/plugins/TSCBLBuilderWithPropagatorESProducer.cc
+++ b/TrackingTools/PatternTools/plugins/TSCBLBuilderWithPropagatorESProducer.cc
@@ -86,7 +86,7 @@ TSCBLBuilderWithPropagatorESProducer::produce(const TrackingComponentsRecord& iR
    auto pTSCBLBuilderWithPropagator = std::make_unique<TSCBLBuilderWithPropagator>(*pro) ;
 
 
-   return std::move(pTSCBLBuilderWithPropagator) ;
+   return pTSCBLBuilderWithPropagator ;
 }
 
 //define this as a plug-in


### PR DESCRIPTION
Use std::move to pass pointer ownership from constructed ptr type to return ptr type.