### PR TITLE
TrackingTools/GsfTracking: update return type of ESProducer::produce

### DIFF
--- a/TrackingTools/GsfTracking/plugins/GsfMaterialEffectsESProducer.h
+++ b/TrackingTools/GsfTracking/plugins/GsfMaterialEffectsESProducer.h
@@ -5,7 +5,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/GsfTracking/interface/GsfMaterialEffectsUpdator.h"
-#include <boost/shared_ptr.hpp>
 
 /** Provides algorithms for estimating material effects (GSF compatible).
  * Multiple scattering estimates can be provided according to a single (== "KF") 
@@ -17,7 +16,7 @@ class  GsfMaterialEffectsESProducer: public edm::ESProducer{
  public:
   GsfMaterialEffectsESProducer(const edm::ParameterSet & p);
   ~GsfMaterialEffectsESProducer() override; 
-  std::shared_ptr<GsfMaterialEffectsUpdator> produce(const TrackingComponentsRecord &);
+  std::unique_ptr<GsfMaterialEffectsUpdator> produce(const TrackingComponentsRecord &);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/GsfTracking/plugins/GsfTrajectoryFitterESProducer.cc
+++ b/TrackingTools/GsfTracking/plugins/GsfTrajectoryFitterESProducer.cc
@@ -29,7 +29,7 @@ GsfTrajectoryFitterESProducer::GsfTrajectoryFitterESProducer(const edm::Paramete
 
 GsfTrajectoryFitterESProducer::~GsfTrajectoryFitterESProducer() {}
 
-std::shared_ptr<TrajectoryFitter> 
+std::unique_ptr<TrajectoryFitter> 
 GsfTrajectoryFitterESProducer::produce(const TrajectoryFitterRecord & iRecord){ 
   //
   // material effects
@@ -67,8 +67,8 @@ GsfTrajectoryFitterESProducer::produce(const TrajectoryFitterRecord & iRecord){
   //
   // create algorithm
   //
-  return std::shared_ptr<TrajectoryFitter>(new GsfTrajectoryFitter(propagator,
+  return                       std::make_unique<GsfTrajectoryFitter>(propagator,
 								     GsfMultiStateUpdator(), 
 								     estimator,merger,
-								     geo.product()));
+								     geo.product());
 }

--- a/TrackingTools/GsfTracking/plugins/GsfTrajectoryFitterESProducer.h
+++ b/TrackingTools/GsfTracking/plugins/GsfTrajectoryFitterESProducer.h
@@ -6,7 +6,6 @@
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitterRecord.h" 
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
-#include <boost/shared_ptr.hpp>
 
 /** Provides a GSF fitter algorithm */
 
@@ -14,7 +13,7 @@ class  GsfTrajectoryFitterESProducer: public edm::ESProducer{
  public:
   GsfTrajectoryFitterESProducer(const edm::ParameterSet & p);
   ~GsfTrajectoryFitterESProducer() override; 
-  std::shared_ptr<TrajectoryFitter> produce(const TrajectoryFitterRecord &);
+  std::unique_ptr<TrajectoryFitter> produce(const TrajectoryFitterRecord &);
  private:
   edm::ParameterSet pset_;
 };

--- a/TrackingTools/GsfTracking/plugins/GsfTrajectorySmootherESProducer.cc
+++ b/TrackingTools/GsfTracking/plugins/GsfTrajectorySmootherESProducer.cc
@@ -27,7 +27,7 @@ GsfTrajectorySmootherESProducer::GsfTrajectorySmootherESProducer(const edm::Para
 
 GsfTrajectorySmootherESProducer::~GsfTrajectorySmootherESProducer() {}
 
-std::shared_ptr<TrajectorySmoother> 
+std::unique_ptr<TrajectorySmoother> 
 GsfTrajectorySmootherESProducer::produce(const TrajectoryFitterRecord & iRecord){ 
   //
   // material effects
@@ -66,11 +66,11 @@ GsfTrajectorySmootherESProducer::produce(const TrajectoryFitterRecord & iRecord)
   //
   //   bool matBefUpd = pset_.getParameter<bool>("MaterialBeforeUpdate");
   double scale = pset_.getParameter<double>("ErrorRescaling");
-  return std::shared_ptr<TrajectorySmoother>(new GsfTrajectorySmoother(propagator,
+  return                         std::make_unique<GsfTrajectorySmoother>(propagator,
 									 GsfMultiStateUpdator(), 
 									 estimator,merger,
 // 									 matBefUpd,
 									 scale,
 									 true,//BM should this be taken from parameterSet?
-									 geo.product()));
+									 geo.product());
 }

--- a/TrackingTools/GsfTracking/plugins/GsfTrajectorySmootherESProducer.h
+++ b/TrackingTools/GsfTracking/plugins/GsfTrajectorySmootherESProducer.h
@@ -6,7 +6,6 @@
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitterRecord.h" 
 #include "TrackingTools/PatternTools/interface/TrajectorySmoother.h"
-#include <boost/shared_ptr.hpp>
 
 /** Provides a GSF smoother algorithm */
 
@@ -14,7 +13,7 @@ class  GsfTrajectorySmootherESProducer: public edm::ESProducer{
  public:
   GsfTrajectorySmootherESProducer(const edm::ParameterSet & p);
   ~GsfTrajectorySmootherESProducer() override; 
-  std::shared_ptr<TrajectorySmoother> produce(const TrajectoryFitterRecord &);
+  std::unique_ptr<TrajectorySmoother> produce(const TrajectoryFitterRecord &);
  private:
   edm::ParameterSet pset_;
 };


### PR DESCRIPTION
Use unique_ptr when returned ptr is create in a function temporary var.