### PR TITLE
TrackPropagation: Update ESProducer return type to unique_ptr.

### DIFF
--- a/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.cc
+++ b/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.cc
@@ -22,7 +22,7 @@ GeantPropagatorESProducer::GeantPropagatorESProducer(const edm::ParameterSet & p
 
 GeantPropagatorESProducer::~GeantPropagatorESProducer() {}
 
-std::shared_ptr<Propagator> 
+std::unique_ptr<Propagator> 
 GeantPropagatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 
   ESHandle<MagneticField> magfield;
@@ -37,8 +37,7 @@ GeantPropagatorESProducer::produce(const TrackingComponentsRecord & iRecord){
   if (pdir == "alongMomentum") dir = alongMomentum;
   if (pdir == "anyDirection") dir = anyDirection;
   
-  _propagator  = std::make_shared<Geant4ePropagator>(&(*magfield),particleName,dir);
-  return _propagator;
+  return std::make_unique<Geant4ePropagator>(&(*magfield),particleName,dir);
 }
 
 

--- a/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.h
+++ b/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.h
@@ -19,10 +19,9 @@ class GeantPropagatorESProducer: public edm::ESProducer{
   GeantPropagatorESProducer(const edm::ParameterSet & p);
   ~GeantPropagatorESProducer() override; 
 
-  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::unique_ptr<Propagator> produce(const TrackingComponentsRecord &);
 
  private:
-  std::shared_ptr<Propagator> _propagator;
   edm::ParameterSet pset_;
 };
 

--- a/TrackPropagation/SteppingHelixPropagator/plugins/SteppingHelixPropagatorESProducer.cc
+++ b/TrackPropagation/SteppingHelixPropagator/plugins/SteppingHelixPropagatorESProducer.cc
@@ -20,9 +20,8 @@ class  SteppingHelixPropagatorESProducer: public edm::ESProducer{
  public:
   SteppingHelixPropagatorESProducer(const edm::ParameterSet & p);
   ~SteppingHelixPropagatorESProducer() override;
-  std::shared_ptr<Propagator> produce(const TrackingComponentsRecord &);
+  std::unique_ptr<Propagator> produce(const TrackingComponentsRecord &);
  private:
-  std::shared_ptr<Propagator> _propagator;
   edm::ParameterSet pset_;
 };
 
@@ -39,7 +38,7 @@ SteppingHelixPropagatorESProducer::SteppingHelixPropagatorESProducer(const edm::
 
 SteppingHelixPropagatorESProducer::~SteppingHelixPropagatorESProducer() {}
 
-std::shared_ptr<Propagator> 
+std::unique_ptr<Propagator> 
 SteppingHelixPropagatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
 //   if (_propagator){
 //     delete _propagator;
@@ -56,7 +55,8 @@ SteppingHelixPropagatorESProducer::produce(const TrackingComponentsRecord & iRec
   if (pdir == "alongMomentum") dir = alongMomentum;
   if (pdir == "anyDirection") dir = anyDirection;
   
-  SteppingHelixPropagator* shProp = new SteppingHelixPropagator(&(*magfield), dir);
+  std::unique_ptr<SteppingHelixPropagator> shProp;
+  shProp.reset( new SteppingHelixPropagator(&(*magfield), dir));
 
   bool useInTeslaFromMagField = pset_.getParameter<bool>("useInTeslaFromMagField");
   bool setVBFPointer = pset_.getParameter<bool>("SetVBFPointer");
@@ -121,8 +121,7 @@ SteppingHelixPropagatorESProducer::produce(const TrackingComponentsRecord & iRec
     shProp->setEndcapShiftsInZPosNeg(valPos, valNeg);
   }
 
-  _propagator  = std::shared_ptr<Propagator>(shProp);
-  return _propagator;
+  return shProp;
 }
 
 #include "FWCore/Utilities/interface/typelookup.h"


### PR DESCRIPTION
A shared_ptr class member is only need when the ESProducer has callbacks.
The shared_ptr class member is removed and a unique_ptr to the
prt created in the produce method is returned.