### PR TITLE
RecoVertex/BeamSpotProducer: Fix memory leak in ESProducer 

### DIFF
--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotFakeConditions.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotFakeConditions.cc
@@ -24,7 +24,7 @@
 
 class BeamSpotFakeConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
-	typedef std::shared_ptr<BeamSpotObjects> ReturnType;
+	typedef std::unique_ptr<BeamSpotObjects> ReturnType;
 	BeamSpotFakeConditions(const edm::ParameterSet &params);
 	~BeamSpotFakeConditions() override;
 	ReturnType produce(const BeamSpotObjectsRcd &record);
@@ -112,7 +112,7 @@ BeamSpotFakeConditions::ReturnType
 BeamSpotFakeConditions::produce(const BeamSpotObjectsRcd &record){
 
 
-	BeamSpotObjects *adummy = new BeamSpotObjects();
+	ReturnType adummy = std::make_unique<BeamSpotObjects>();
 	
 	adummy->SetPosition( x, y , z );
 	adummy->SetSigmaZ( sigmaZ);
@@ -130,7 +130,7 @@ BeamSpotFakeConditions::produce(const BeamSpotObjectsRcd &record){
 	adummy->SetEmittanceY( emittanceY );
 	adummy->SetBetaStar( betastar);
 
-	return ReturnType(adummy);
+	return adummy;
 }
 
 void BeamSpotFakeConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &key,


### PR DESCRIPTION
by removing pointer to temporary object that is never deleted.