### PR TITLE
revert stream::producer to simple producer to avoid crashes in HTXSRivetProducer

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -28,7 +28,7 @@ using namespace Rivet;
 using namespace edm;
 using namespace std;
 
-class HTXSRivetProducer : public edm::one::Producer<> {
+class HTXSRivetProducer : public edm::one::EDProducer<> {
 public:
     
     explicit HTXSRivetProducer(const edm::ParameterSet& cfg) : 

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Run.h"

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -28,7 +28,7 @@ using namespace Rivet;
 using namespace edm;
 using namespace std;
 
-class HTXSRivetProducer : public edm::Producer<> {
+class HTXSRivetProducer : public edm::one::Producer<> {
 public:
     
     explicit HTXSRivetProducer(const edm::ParameterSet& cfg) : 

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -28,7 +28,7 @@ using namespace Rivet;
 using namespace edm;
 using namespace std;
 
-class HTXSRivetProducer : public edm::stream::EDProducer<> {
+class HTXSRivetProducer : public edm::one::EDProducer<edm::one::WatchRuns> {
 public:
     
     explicit HTXSRivetProducer(const edm::ParameterSet& cfg) : 
@@ -48,12 +48,10 @@ public:
     
 private:
     
-  void beginStream(edm::StreamID) override;
     void produce( edm::Event&, const edm::EventSetup&) ;
-    void endStream() override;
     
-    void beginRun(edm::Run const& iRun, edm::EventSetup const& es) ;
-    void endRun(edm::Run const& iRun, edm::EventSetup const& es) ;
+    void beginRun(edm::Run const& iRun, edm::EventSetup const& es) override ;
+    void endRun(edm::Run const& iRun, edm::EventSetup const& es) override ;
     
     edm::EDGetTokenT<edm::HepMCProduct> _hepmcCollection;
     edm::EDGetTokenT<LHERunInfoProduct> _lheRunInfo;
@@ -70,10 +68,6 @@ private:
 };
 
 HTXSRivetProducer::~HTXSRivetProducer(){
-}
-
-void HTXSRivetProducer::beginStream(edm::StreamID) {
-  //  _analysisHandler.addAnalysis(_HTXS);
 }
 
 void HTXSRivetProducer::produce( edm::Event & iEvent, const edm::EventSetup & ) {
@@ -171,12 +165,9 @@ void HTXSRivetProducer::produce( edm::Event & iEvent, const edm::EventSetup & ) 
     }
 }
 
-void HTXSRivetProducer::endStream(){
-    _HTXS->printClassificationSummary();
-}
-
 void HTXSRivetProducer::endRun(edm::Run const& iRun, edm::EventSetup const& es) 
 {
+  _HTXS->printClassificationSummary();
 }
 
 void HTXSRivetProducer::beginRun(edm::Run const& iRun, edm::EventSetup const& es) {

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -28,7 +28,7 @@ using namespace Rivet;
 using namespace edm;
 using namespace std;
 
-class HTXSRivetProducer : public edm::one::EDProducer<> {
+class HTXSRivetProducer : public edm::stream::EDProducer<> {
 public:
     
     explicit HTXSRivetProducer(const edm::ParameterSet& cfg) : 
@@ -48,9 +48,9 @@ public:
     
 private:
     
-    void beginJob();
+  void beginStream(edm::StreamID) override;
     void produce( edm::Event&, const edm::EventSetup&) ;
-    void endJob();
+    void endStream() override;
     
     void beginRun(edm::Run const& iRun, edm::EventSetup const& es) ;
     void endRun(edm::Run const& iRun, edm::EventSetup const& es) ;
@@ -72,8 +72,8 @@ private:
 HTXSRivetProducer::~HTXSRivetProducer(){
 }
 
-void HTXSRivetProducer::beginJob(){
-    _analysisHandler.addAnalysis(_HTXS);
+void HTXSRivetProducer::beginStream(edm::StreamID) {
+  //  _analysisHandler.addAnalysis(_HTXS);
 }
 
 void HTXSRivetProducer::produce( edm::Event & iEvent, const edm::EventSetup & ) {
@@ -130,6 +130,8 @@ void HTXSRivetProducer::produce( edm::Event & iEvent, const edm::EventSetup & ) 
 
       if (_isFirstEvent){
 
+	_analysisHandler.addAnalysis(_HTXS);
+
           // set the production mode if not done already
           if      ( _prodMode == "GGF"   ) m_HiggsProdMode = HTXS::GGF;
           else if ( _prodMode == "VBF"   ) m_HiggsProdMode = HTXS::VBF;
@@ -150,7 +152,7 @@ void HTXSRivetProducer::produce( edm::Event & iEvent, const edm::EventSetup & ) 
 
           // at this point the production mode must be known
           if (m_HiggsProdMode == HTXS::UNKNOWN) {
-              edm::LogInfo   ("HTXSRivetProducer")  << "HTXSRivetProducer WARNING: HiggsProduction mode is UNKNOWN" << endl;
+              edm::LogInfo ("HTXSRivetProducer") << "HTXSRivetProducer WARNING: HiggsProduction mode is UNKNOWN" << endl;
           }            
 
           // initialize rivet analysis
@@ -169,7 +171,7 @@ void HTXSRivetProducer::produce( edm::Event & iEvent, const edm::EventSetup & ) 
     }
 }
 
-void HTXSRivetProducer::endJob(){
+void HTXSRivetProducer::endStream(){
     _HTXS->printClassificationSummary();
 }
 

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -41,7 +41,7 @@ public:
         _prodMode = cfg.getParameter<string>("ProductionMode");
         m_HiggsProdMode = HTXS::UNKNOWN;
         
-        produce<HTXS::HiggsClassification>("HiggsClassification").setBranchAlias("HiggsClassification");
+        produces<HTXS::HiggsClassification>("HiggsClassification").setBranchAlias("HiggsClassification");
 
     }
     ~HTXSRivetProducer() ;

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -28,7 +28,7 @@ using namespace Rivet;
 using namespace edm;
 using namespace std;
 
-class HTXSRivetProducer : public edm::stream::EDProducer<> {
+class HTXSRivetProducer : public edm::Producer<> {
 public:
     
     explicit HTXSRivetProducer(const edm::ParameterSet& cfg) : 

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -41,19 +41,19 @@ public:
         _prodMode = cfg.getParameter<string>("ProductionMode");
         m_HiggsProdMode = HTXS::UNKNOWN;
         
-        produces<HTXS::HiggsClassification>("HiggsClassification").setBranchAlias("HiggsClassification");
+        produce<HTXS::HiggsClassification>("HiggsClassification").setBranchAlias("HiggsClassification");
 
     }
-    ~HTXSRivetProducer() override;
+    ~HTXSRivetProducer() ;
     
 private:
     
     void beginJob();
-    void produce( edm::Event&, const edm::EventSetup&) override;
+    void produce( edm::Event&, const edm::EventSetup&) ;
     void endJob();
     
-    void beginRun(edm::Run const& iRun, edm::EventSetup const& es) override;
-    void endRun(edm::Run const& iRun, edm::EventSetup const& es) override;
+    void beginRun(edm::Run const& iRun, edm::EventSetup const& es) ;
+    void endRun(edm::Run const& iRun, edm::EventSetup const& es) ;
     
     edm::EDGetTokenT<edm::HepMCProduct> _hepmcCollection;
     edm::EDGetTokenT<LHERunInfoProduct> _lheRunInfo;


### PR DESCRIPTION
It has been observed that the use of `stream::EDProducer` causes a crash in the Higgs Template Cross Section Rivet producer. The change had not been captured by the validation as no dedicated relval workflow is setup.
Reverted to simple `EDProducer`
@dsperka @sethzenz 