### PR TITLE
RecoTracker/GeometryESProducer: Update produce return type to unique_ptr.

### DIFF
--- a/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.cc
+++ b/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.cc
@@ -31,7 +31,7 @@ TrackerRecoGeometryESProducer::TrackerRecoGeometryESProducer(const edm::Paramete
 
 TrackerRecoGeometryESProducer::~TrackerRecoGeometryESProducer() {}
 
-std::shared_ptr<GeometricSearchTracker> 
+std::unique_ptr<GeometricSearchTracker> 
 TrackerRecoGeometryESProducer::produce(const TrackerRecoGeometryRecord & iRecord){ 
 
 
@@ -43,8 +43,7 @@ TrackerRecoGeometryESProducer::produce(const TrackerRecoGeometryRecord & iRecord
   const TrackerTopology *tTopo=tTopoHand.product();
 
   GeometricSearchTrackerBuilder builder;
-  _tracker  = std::shared_ptr<GeometricSearchTracker>(builder.build( tG->trackerDet(), &(*tG), tTopo ));
-  return _tracker;
+  return std::unique_ptr<GeometricSearchTracker>(builder.build( tG->trackerDet(), &(*tG), tTopo ));
 }
 
 

--- a/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.h
+++ b/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.h
@@ -12,9 +12,8 @@ class  TrackerRecoGeometryESProducer: public edm::ESProducer{
  public:
   TrackerRecoGeometryESProducer(const edm::ParameterSet & p);
   ~TrackerRecoGeometryESProducer() override; 
-  std::shared_ptr<GeometricSearchTracker> produce(const TrackerRecoGeometryRecord &);
+  std::unique_ptr<GeometricSearchTracker> produce(const TrackerRecoGeometryRecord &);
  private:
- std::shared_ptr<GeometricSearchTracker> _tracker;
  std::string geoLabel;
 };
 


### PR DESCRIPTION
Since no callbacks are used the shared_ptr class member is not needed
and a unique_ptr can be returned instead.