### PR TITLE
MuonDetLayerGeometryESProducer: update return type of produce method

### DIFF
--- a/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.cc
+++ b/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.cc
@@ -39,11 +39,11 @@ MuonDetLayerGeometryESProducer::MuonDetLayerGeometryESProducer(const edm::Parame
 MuonDetLayerGeometryESProducer::~MuonDetLayerGeometryESProducer(){}
 
 
-std::shared_ptr<MuonDetLayerGeometry>
+std::unique_ptr<MuonDetLayerGeometry>
 MuonDetLayerGeometryESProducer::produce(const MuonRecoGeometryRecord & record) {
 
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonDetLayerGeometryESProducer";
-  MuonDetLayerGeometry* muonDetLayerGeometry = new MuonDetLayerGeometry();
+  auto muonDetLayerGeometry = std::make_unique<MuonDetLayerGeometry>();
   
   // Build DT layers  
   edm::ESHandle<DTGeometry> dt;
@@ -95,5 +95,5 @@ MuonDetLayerGeometryESProducer::produce(const MuonRecoGeometryRecord & record) {
   // Sort layers properly
   muonDetLayerGeometry->sortLayers();
 
-  return std::shared_ptr<MuonDetLayerGeometry>(muonDetLayerGeometry);
+  return muonDetLayerGeometry;
 }

--- a/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.h
+++ b/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.h
@@ -24,7 +24,7 @@ class  MuonDetLayerGeometryESProducer: public edm::ESProducer{
   ~MuonDetLayerGeometryESProducer() override; 
 
   /// Produce MuonDeLayerGeometry.
-  std::shared_ptr<MuonDetLayerGeometry> produce(const MuonRecoGeometryRecord & record);
+  std::unique_ptr<MuonDetLayerGeometry> produce(const MuonRecoGeometryRecord & record);
 
  private:
 };


### PR DESCRIPTION
No callback methods so unique_ptr can be used.