### PR TITLE
Thread safe pileup histogram for mixing

### DIFF
--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -68,7 +68,7 @@ namespace edm {
     Source_type_(config->sourcename_),
     averageNumber_(config->averageNumber_),
     intAverage_(static_cast<int>(averageNumber_)),
-    histo_(config->histo_),
+    histo_(std::make_shared<TH1F>(*config->histo_)),
     histoDistribution_(type_ == "histo"),
     probFunctionDistribution_(type_ == "probFunction"),
     poisson_(type_ == "poisson"),


### PR DESCRIPTION
Back-port #22000 - addressing issue #21972 , implemented as suggested by @Dr15Jones .