### PR TITLE
replacing string "generatorSmeared" (deprecated)  by InputTag (recommended) 

### DIFF
--- a/Configuration/StandardSequences/python/SimNOBEAM_cff.py
+++ b/Configuration/StandardSequences/python/SimNOBEAM_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from SimG4Core.Configuration.SimG4Core_cff import *
 
 g4SimHits.NonBeamEvent = cms.bool(True)
-g4SimHits.Generator.HepMCProductLabel = cms.string('generatorSmeared')
+g4SimHits.Generator.HepMCProductLabel = cms.InputTag('generatorSmeared')
 g4SimHits.Generator.ApplyEtaCuts = cms.bool(False)
 
 psim = cms.Sequence(cms.SequencePlaceholder("randomEngineStateProducer")*g4SimHits)


### PR DESCRIPTION
Greetings
While generating some Cosmics, I noticed a comment in the log  (see * ) which I tracked down to come from the file changed in this PR. 
Therefore I'm updating it following the recommendation of the message .
I'm not at all epxert of this, so sim or gen peole may want to comment and agree with the changes of this PR
The cosmic workflow (for example 7.2) is not more showing this message after this change .

(*)
%MSG-w Configuration:  OscarMTProducer:g4SimHits@ctor 30-Jan-2018 14:48:10 CET  pre-events
Warning:
	string HepMCProductLabel = "generatorSmeared"
is deprecated, please update your config file to use
	InputTag HepMCProductLabel = generatorSmeared
%MSG
