### PR TITLE
CalibTracker/SiPixelConnectivity: update ESProducer to return unique_ptr.

### DIFF
--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.cc
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.cc
@@ -16,10 +16,9 @@ PixelToFEDAssociateFromAsciiESProducer::
     ~PixelToFEDAssociateFromAsciiESProducer()
 { }
 
-std::shared_ptr<PixelToFEDAssociate> PixelToFEDAssociateFromAsciiESProducer::
+std::unique_ptr<PixelToFEDAssociate> PixelToFEDAssociateFromAsciiESProducer::
     produce(const TrackerDigiGeometryRecord & r)
 {
-  theAssociator = std::make_shared<PixelToFEDAssociateFromAscii>(theConfig.getParameter<std::string>("fileName"));
-  return theAssociator;
+  return std::make_unique<PixelToFEDAssociateFromAscii>(theConfig.getParameter<std::string>("fileName"));
 }
 

--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.h
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.h
@@ -12,9 +12,8 @@ class PixelToFEDAssociateFromAsciiESProducer : public edm::ESProducer {
 public:
   PixelToFEDAssociateFromAsciiESProducer(const edm::ParameterSet & p);
   ~PixelToFEDAssociateFromAsciiESProducer() override;
-  std::shared_ptr<PixelToFEDAssociate> produce(const TrackerDigiGeometryRecord&);
+  std::unique_ptr<PixelToFEDAssociate> produce(const TrackerDigiGeometryRecord&);
 private:
-  std::shared_ptr<PixelToFEDAssociate> theAssociator;
   edm::ParameterSet theConfig;
 };
 

--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.cc
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.cc
@@ -16,10 +16,9 @@ PixelToLNKAssociateFromAsciiESProducer::
     ~PixelToLNKAssociateFromAsciiESProducer()
 { }
 
-std::shared_ptr<PixelToFEDAssociate> PixelToLNKAssociateFromAsciiESProducer::
+std::unique_ptr<PixelToFEDAssociate> PixelToLNKAssociateFromAsciiESProducer::
     produce(const TrackerDigiGeometryRecord & r)
 {
-  theAssociator = std::make_shared<PixelToLNKAssociateFromAscii>(theConfig.getParameter<std::string>("fileName"));
-  return theAssociator;
+  return std::make_unique<PixelToLNKAssociateFromAscii>(theConfig.getParameter<std::string>("fileName"));
 }
 

--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.h
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.h
@@ -12,9 +12,8 @@ class PixelToLNKAssociateFromAsciiESProducer : public edm::ESProducer {
 public:
   PixelToLNKAssociateFromAsciiESProducer(const edm::ParameterSet & p);
   ~PixelToLNKAssociateFromAsciiESProducer() override;
-  std::shared_ptr<PixelToFEDAssociate> produce(const TrackerDigiGeometryRecord&);
+  std::unique_ptr<PixelToFEDAssociate> produce(const TrackerDigiGeometryRecord&);
 private:
-  std::shared_ptr<PixelToFEDAssociate> theAssociator;
   edm::ParameterSet theConfig;
 };
 


### PR DESCRIPTION
Remove shared_ptr member since no callbacks are defined.