### PR TITLE
L1T DQM module for BMTF zero suppression monitoring

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+# the BMTF DQM module
+from DQM.L1TMonitor.L1TStage2BMTF_cfi import *
+
+# zero suppression DQM
+l1tStage2BmtfZeroSupp = cms.EDAnalyzer(
+    "L1TMP7ZeroSupp",
+    fedIds = cms.vint32(1376, 1377),
+    rawData = cms.InputTag("rawDataCollector"),
+    # mask for inputs (pt==0 defines empty muon)
+    maskCapId1 = cms.untracked.vint32(0x01c00000,
+                                      0x01c00000,
+                                      0x01c00000,
+                                      0x01c00000,
+                                      0x00000000,
+                                      0x00000000),
+    # mask for outputs (pt==0 defines empty muon)
+    maskCapId2 = cms.untracked.vint32(0x000001FF,
+                                      0x00000000,
+                                      0x000001FF,
+                                      0x00000000,
+                                      0x000001FF,
+                                      0x00000000),
+    # no masks defined for caption IDs 0 and 3-11
+    maxFEDReadoutSize = cms.untracked.int32(7000),
+    monitorDir = cms.untracked.string("L1T/L1TStage2BMTF/zeroSuppression/AllEvts"),
+    verbose = cms.untracked.bool(False),
+)
+
+# ZS of validation events (to be used after fat event filter)
+l1tStage2BmtfZeroSuppFatEvts = l1tStage2BmtfZeroSupp.clone()
+l1tStage2BmtfZeroSuppFatEvts.monitorDir = cms.untracked.string("L1T/L1TStage2BMTF/zeroSuppression/FatEvts")
+l1tStage2BmtfZeroSuppFatEvts.maxFEDReadoutSize = cms.untracked.int32(25000)
+
+# sequences
+l1tStage2BmtfOnlineDQMSeq = cms.Sequence(
+    l1tStage2Bmtf +
+    l1tStage2BmtfZeroSupp
+)
+
+l1tStage2BmtfValidationEventOnlineDQMSeq = cms.Sequence(
+    l1tStage2BmtfZeroSuppFatEvts
+)

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -17,7 +17,7 @@ from DQM.L1TMonitor.L1TStage2CaloLayer2_cfi import *
 from DQM.L1TMonitor.L1TStage2uGTCaloLayer2Comp_cfi import *
 
 # BMTF
-from DQM.L1TMonitor.L1TStage2BMTF_cfi import *
+from DQM.L1TMonitor.L1TStage2BMTF_cff import *
 
 # OMTF
 from DQM.L1TMonitor.L1TStage2OMTF_cfi import *
@@ -38,7 +38,7 @@ from DQM.L1TMonitor.L1TStage2uGT_cff import *
 l1tStage2OnlineDQM = cms.Sequence(
     l1tStage2CaloLayer1 +
     l1tStage2CaloLayer2 +
-    l1tStage2Bmtf +
+    l1tStage2BmtfOnlineDQMSeq +
     l1tStage2Omtf +
     l1tStage2Emtf +
     l1tStage2uGMTOnlineDQMSeq +
@@ -48,6 +48,7 @@ l1tStage2OnlineDQM = cms.Sequence(
 
 # sequence to run only for validation events
 l1tStage2OnlineDQMValidationEvents = cms.Sequence(
+    l1tStage2BmtfValidationEventOnlineDQMSeq +
     l1tStage2uGMTValidationEventOnlineDQMSeq
 )
 

--- a/DQM/L1TMonitorClient/python/L1TStage2BMTFClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2BMTFClient_cff.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+# directory path shortening
+bmtfDqmDir = 'L1T/L1TStage2BMTF'
+bmtfZSDqmDir = bmtfDqmDir+'/zeroSuppression'
+errHistNumStr = 'errorSummaryNum'
+errHistDenStr = 'errorSummaryDen'
+
+# zero suppression
+l1tStage2BmtfZeroSuppRatioClient = DQMEDHarvester("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string(bmtfZSDqmDir+'/AllEvts'),
+    inputNum = cms.untracked.string(bmtfZSDqmDir+'/AllEvts/'+errHistNumStr),
+    inputDen = cms.untracked.string(bmtfZSDqmDir+'/AllEvts/'+errHistDenStr),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of bad zero suppression rates'),
+    yAxisTitle = cms.untracked.string('# fail / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+l1tStage2BmtfZeroSuppFatEvtsRatioClient = l1tStage2BmtfZeroSuppRatioClient.clone()
+l1tStage2BmtfZeroSuppFatEvtsRatioClient.monitorDir = cms.untracked.string(bmtfZSDqmDir+'/FatEvts')
+l1tStage2BmtfZeroSuppFatEvtsRatioClient.inputNum = cms.untracked.string(bmtfZSDqmDir+'/FatEvts/'+errHistNumStr)
+l1tStage2BmtfZeroSuppFatEvtsRatioClient.inputDen = cms.untracked.string(bmtfZSDqmDir+'/FatEvts/'+errHistDenStr)
+l1tStage2BmtfZeroSuppFatEvtsRatioClient.ratioTitle = cms.untracked.string('Summary of bad zero suppression rates')
+
+# sequences
+l1tStage2BmtfZeroSuppCompClient = cms.Sequence(
+    l1tStage2BmtfZeroSuppRatioClient
+  + l1tStage2BmtfZeroSuppFatEvtsRatioClient
+)
+
+l1tStage2BmtfClient = cms.Sequence(
+    l1tStage2BmtfZeroSuppCompClient
+)
+

--- a/DQM/L1TMonitorClient/python/L1TStage2MonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2MonitorClient_cff.py
@@ -22,6 +22,9 @@ from DQM.L1TMonitorClient.L1TStage2EventInfoClient_cfi import *
 # CaloLayer2 client
 from DQM.L1TMonitorClient.L1TStage2CaloLayer2Client_cff import *
 
+# BMTF client
+from DQM.L1TMonitorClient.L1TStage2BMTFClient_cff import *
+
 # uGMT client
 from DQM.L1TMonitorClient.L1TStage2uGMTClient_cff import *
 
@@ -36,6 +39,7 @@ from DQM.L1TMonitorClient.L1TStage2uGTClient_cff import *
 l1TStage2Clients = cms.Sequence(
                         l1tStage2EventInfoClient
                       + l1tStage2uGTCaloLayer2CompClient
+                      + l1tStage2BmtfClient
                       + l1tStage2uGMTClient
                       + l1tStage2uGTClient
                         )


### PR DESCRIPTION
Backport of #21900 

Adds a L1T DQM module for BMTF MP7 zero suppression monitoring.