### PR TITLE
Have TTreeCache work with EmbeddedRootSource

### DIFF
--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -202,7 +202,7 @@ namespace edm {
     bool skipEntries(unsigned int& offset) {return eventTree_.skipEntries(offset);}
     bool skipEvents(int& offset);
     bool goToEvent(EventID const& eventID);
-    bool nextEventEntry() {return eventTree_.next();}
+    bool nextEventEntry() {return eventTree_.nextWithCache();}
     IndexIntoFile::EntryType getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
     std::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return get_underlying_safe(branchIDListHelper_);}
     std::shared_ptr<BranchIDListHelper>& branchIDListHelper() {return get_underlying_safe(branchIDListHelper_);}

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -93,6 +93,7 @@ namespace edm {
                    std::string const& oldBranchName);
 
     bool next() {return ++entryNumber_ < entries_;}
+    bool nextWithCache();
     bool previous() {return --entryNumber_ >= 0;}
     bool current() const {return entryNumber_ < entries_ && entryNumber_ >= 0;}
     bool current(EntryNumber entry) const {return entry < entries_ && entry >= 0;}


### PR DESCRIPTION
The EmbeddedRootSource calls different functions of RootFile and
RootTree. This was causing it to not properly use the TTreeCache.
Now we will use the TTreeCache in that case and properly handle
the case where we start reading near the end of the file and then
jump back to the beginning before training has completed.