### PR TITLE
Replace swap_or_assign with move in edm::Wrapper<T> constructor

### DIFF
--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -88,9 +88,7 @@ private:
     present(ptr.get() != nullptr),
     obj() {
     if (present) {
-      // The following will call swap if T has such a function,
-      // and use assignment if T has no such function.
-      swap_or_assign(obj, *ptr);
+      obj = std::move(*ptr);
     }
   }
 
@@ -101,9 +99,7 @@ private:
   obj() {
      std::unique_ptr<T> temp(ptr);
      if (present) {
-        // The following will call swap if T has such a function,
-        // and use assignment if T has no such function.
-        swap_or_assign(obj, *ptr);
+       obj = std::move(*ptr);
      }
   }
 

--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -77,12 +77,6 @@ private:
   };
 
   template<typename T>
-  inline
-  void swap_or_assign(T& a, T& b) {
-    detail::doSwapOrAssign<T>()(a, b);
-  } 
-
-  template<typename T>
   Wrapper<T>::Wrapper(std::unique_ptr<T> ptr) :
     WrapperBase(),
     present(ptr.get() != nullptr),

--- a/DataFormats/Common/interface/WrapperDetail.h
+++ b/DataFormats/Common/interface/WrapperDetail.h
@@ -20,29 +20,6 @@ namespace edm {
     using no_tag = std::false_type; // type indicating FALSE
     using yes_tag = std::true_type; // type indicating TRUE
 
-    // void swap_or_assign(T& a, T& b) will swap if T::swap(T&) is defined and assign otherwise
-    // Definitions for the following struct and function templates are not needed; we only require the declarations.
-    template<typename T, void (T::*)(T&)> struct swap_function;
-    template<typename T> static yes_tag has_swap(swap_function<T, &T::swap>* dummy);
-    template<typename T> static no_tag has_swap(...);
-
-    template<typename T>
-    struct has_swap_function {
-      static constexpr bool value = std::is_same<decltype(has_swap<T>(nullptr)), yes_tag>::value;
-    };
-
-    template<typename T, bool = has_swap_function<T>::value> struct doSwapOrAssign;
-    template<typename T> struct doSwapOrAssign<T, true> {
-      void operator()(T& thisProduct, T& otherProduct) {
-        thisProduct.swap(otherProduct);
-      }
-    };
-    template<typename T> struct doSwapOrAssign<T, false> {
-      void operator()(T& thisProduct, T& otherProduct) {
-        thisProduct = otherProduct;
-      }
-    };
-
     // valueTypeInfo_() will return typeid(T::value_type) if T::value_type is declared and typeid(void) otherwise.
     // Definitions for the following struct and function templates are not needed; we only require the declarations.
     template<typename T> static yes_tag has_value_type(typename T::value_type*);

--- a/DataFormats/Common/test/DetSetNew_t.cpp
+++ b/DataFormats/Common/test/DetSetNew_t.cpp
@@ -119,6 +119,12 @@ void TestDetSet::default_ctor() {
   CPPUNIT_ASSERT(detsets2.dataSize()==10);
   CPPUNIT_ASSERT(!detsets2.onDemand());
 
+  // test move
+  DSTV detsets3(4);
+  detsets = std::move(detsets3);
+  CPPUNIT_ASSERT(detsets.subdetId()==4);
+  CPPUNIT_ASSERT(detsets.size()==0);
+  CPPUNIT_ASSERT(detsets.dataSize()==0);
 }
 
 void TestDetSet::inserting() {
@@ -592,6 +598,9 @@ void TestDetSet::onDemand() {
   detsets2.swap(detsets);
   CPPUNIT_ASSERT(detsets2.onDemand());
 
+  DSTV detsets3;
+  detsets3 = std::move(detsets2);
+  CPPUNIT_ASSERT(detsets3.onDemand());
 }
 
 void TestDetSet::toRangeMap() {

--- a/DataFormats/Common/test/Wrapper_t.cpp
+++ b/DataFormats/Common/test/Wrapper_t.cpp
@@ -10,32 +10,33 @@
 
 #include "DataFormats/Common/interface/Wrapper.h"
 
-class CopyNoSwappy
+class CopyNoMove
 {
  public:
-  CopyNoSwappy() {}
-  CopyNoSwappy(CopyNoSwappy const&) { /* std::cout << "copied\n"; */ }
-  CopyNoSwappy& operator=(CopyNoSwappy const&) { /*std::cout << "assigned\n";*/ return *this;}
+  CopyNoMove() {}
+  CopyNoMove(CopyNoMove const&) { /* std::cout << "copied\n"; */ }
+  CopyNoMove& operator=(CopyNoMove const&) { /*std::cout << "assigned\n";*/ return *this;}
  private:
 };
 
-class SwappyNoCopy
+class MoveNoCopy
 {
  public:
-  SwappyNoCopy() {}
-  void swap(SwappyNoCopy&) { /* std::cout << "swapped\n";*/ }
+  MoveNoCopy() {}
+  MoveNoCopy(MoveNoCopy const&) = delete;
+  MoveNoCopy& operator=(MoveNoCopy const&) = delete;
+  MoveNoCopy(MoveNoCopy&&) { /* std::cout << "moved\n";*/ }
+  MoveNoCopy& operator=(MoveNoCopy&&) { /* std::cout << "moved\n";*/ return *this; }
  private:
-  SwappyNoCopy(SwappyNoCopy const&); // not implemented
-  SwappyNoCopy& operator=(SwappyNoCopy const&); // not implemented
 };
 
 void work()
 {
-  auto thing = std::make_unique<CopyNoSwappy>();
-  edm::Wrapper<CopyNoSwappy> wrap(std::move(thing));
+  auto thing = std::make_unique<CopyNoMove>();
+  edm::Wrapper<CopyNoMove> wrap(std::move(thing));
 
-  auto thing2 = std::make_unique<SwappyNoCopy>();
-  edm::Wrapper<SwappyNoCopy> wrap2(std::move(thing2));
+  auto thing2 = std::make_unique<MoveNoCopy>();
+  edm::Wrapper<MoveNoCopy> wrap2(std::move(thing2));
 
 
   auto thing3 = std::make_unique<std::vector<double>>(10,2.2);

--- a/JetMETCorrections/JetCorrector/interface/JetCorrector.h
+++ b/JetMETCorrections/JetCorrector/interface/JetCorrector.h
@@ -39,6 +39,8 @@ namespace reco {
     JetCorrector();
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     JetCorrector(std::unique_ptr<JetCorrectorImpl const> fImpl):impl_(std::move(fImpl)) {}
+    JetCorrector(JetCorrector&&) = default;
+    JetCorrector& operator=(JetCorrector&&) = default;
     
     typedef reco::Particle::LorentzVector LorentzVector;
 
@@ -87,7 +89,6 @@ namespace reco {
     JetCorrector(const JetCorrector&) = delete; 
     
     JetCorrector& operator=(const JetCorrector&) = delete; 
-    JetCorrector& operator=(JetCorrector&&) = default;
     
     // ---------- member data --------------------------------
     std::unique_ptr<JetCorrectorImpl const> impl_;

--- a/JetMETCorrections/JetCorrector/interface/JetCorrector.h
+++ b/JetMETCorrections/JetCorrector/interface/JetCorrector.h
@@ -81,9 +81,6 @@ namespace reco {
     // ---------- static member functions --------------------
     
     // ---------- member functions ---------------------------
-    void swap(JetCorrector& iOther) {
-      std::swap(impl_,iOther.impl_);
-    }
 
   private:
     JetCorrector(const JetCorrector&) = delete; 

--- a/RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h
@@ -259,6 +259,8 @@ public:
   IntermediateHitTriplets(): seedingLayers_(nullptr) {}
   explicit IntermediateHitTriplets(const SeedingLayerSetsHits *seedingLayers): seedingLayers_(seedingLayers) {}
   IntermediateHitTriplets(const IntermediateHitTriplets& rh); // only to make ROOT dictionary generation happy
+  IntermediateHitTriplets(IntermediateHitTriplets&&) = default;
+  IntermediateHitTriplets& operator=(IntermediateHitTriplets&&) = default;
   ~IntermediateHitTriplets() = default;
 
   void swap(IntermediateHitTriplets& rh) {

--- a/RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h
@@ -263,13 +263,6 @@ public:
   IntermediateHitTriplets& operator=(IntermediateHitTriplets&&) = default;
   ~IntermediateHitTriplets() = default;
 
-  void swap(IntermediateHitTriplets& rh) {
-    std::swap(seedingLayers_, rh.seedingLayers_);
-    std::swap(regions_, rh.regions_);
-    std::swap(layerTriplets_, rh.layerTriplets_);
-    std::swap(hitTriplets_, rh.hitTriplets_);
-  }
-
   void reserve(size_t nregions, size_t nlayersets, size_t ntriplets) {
     regions_.reserve(nregions);
     layerTriplets_.reserve(nregions*nlayersets);

--- a/RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h
+++ b/RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h
@@ -41,8 +41,8 @@ public:
 
    MeasurementTrackerEvent(const MeasurementTrackerEvent & other) = delete;
    MeasurementTrackerEvent & operator=(const MeasurementTrackerEvent & other) = delete;
-   MeasurementTrackerEvent(MeasurementTrackerEvent && other) = delete;
-   MeasurementTrackerEvent & operator=(MeasurementTrackerEvent && other) = delete;
+   MeasurementTrackerEvent(MeasurementTrackerEvent && other);
+   MeasurementTrackerEvent & operator=(MeasurementTrackerEvent && other);
 
    //  for the edm wrapper...
    void swap(MeasurementTrackerEvent &other) ;

--- a/RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h
+++ b/RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h
@@ -44,9 +44,6 @@ public:
    MeasurementTrackerEvent(MeasurementTrackerEvent && other);
    MeasurementTrackerEvent & operator=(MeasurementTrackerEvent && other);
 
-   //  for the edm wrapper...
-   void swap(MeasurementTrackerEvent &other) ;
-
 
    const MeasurementTracker & measurementTracker() const { return * theTracker; }
    const StMeasurementDetSet & stripData() const { return * theStripData; }
@@ -74,7 +71,5 @@ private:
    std::vector<bool> thePixelClustersToSkip;
    std::vector<bool> thePhase2OTClustersToSkip;
 };
-
-inline void swap(MeasurementTrackerEvent &a, MeasurementTrackerEvent &b) { a.swap(b); }
 
 #endif // MeasurementTrackerEvent_H

--- a/RecoTracker/MeasurementDet/src/MeasurementTrackerEvent.cc
+++ b/RecoTracker/MeasurementDet/src/MeasurementTrackerEvent.cc
@@ -32,21 +32,6 @@ MeasurementTrackerEvent& MeasurementTrackerEvent::operator=(MeasurementTrackerEv
   return *this;
 }
 
-void
-MeasurementTrackerEvent::swap(MeasurementTrackerEvent &other)
-{
-    if (&other != this) {
-        using std::swap;
-        swap(theTracker, other.theTracker);
-        swap(theStripData, other.theStripData);
-        swap(thePixelData, other.thePixelData);
-        swap(thePhase2OTData, other.thePhase2OTData);
-        swap(theOwner, other.theOwner);
-        swap(theStripClustersToSkip, other.theStripClustersToSkip);
-        swap(thePixelClustersToSkip, other.thePixelClustersToSkip);
-    }
-}
-
 MeasurementTrackerEvent::MeasurementTrackerEvent(const MeasurementTrackerEvent &trackerEvent,
                            const edm::ContainerMask<edmNew::DetSetVector<SiStripCluster> > & stripClustersToSkip,
                            const edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > & pixelClustersToSkip) :

--- a/RecoTracker/MeasurementDet/src/MeasurementTrackerEvent.cc
+++ b/RecoTracker/MeasurementDet/src/MeasurementTrackerEvent.cc
@@ -10,6 +10,28 @@ MeasurementTrackerEvent::~MeasurementTrackerEvent() {
     }
 }
 
+MeasurementTrackerEvent::MeasurementTrackerEvent(MeasurementTrackerEvent && other) {
+  theTracker = std::move(other.theTracker);
+  theStripData = std::move(other.theStripData);
+  thePixelData = std::move(other.thePixelData);
+  thePhase2OTData = std::move(other.thePhase2OTData);
+  theOwner = other.theOwner;
+  other.theOwner = false; // make sure to fully transfer the ownership
+  theStripClustersToSkip = std::move(other.theStripClustersToSkip);
+  thePixelClustersToSkip = std::move(other.thePixelClustersToSkip);
+}
+MeasurementTrackerEvent& MeasurementTrackerEvent::operator=(MeasurementTrackerEvent && other) {
+  theTracker = std::move(other.theTracker);
+  theStripData = std::move(other.theStripData);
+  thePixelData = std::move(other.thePixelData);
+  thePhase2OTData = std::move(other.thePhase2OTData);
+  theOwner = other.theOwner;
+  other.theOwner = false; // make sure to fully transfer the ownership
+  theStripClustersToSkip = std::move(other.theStripClustersToSkip);
+  thePixelClustersToSkip = std::move(other.thePixelClustersToSkip);
+  return *this;
+}
+
 void
 MeasurementTrackerEvent::swap(MeasurementTrackerEvent &other)
 {

--- a/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
+++ b/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
@@ -200,12 +200,6 @@ public:
   IntermediateHitDoublets& operator=(IntermediateHitDoublets&&) = default;
   ~IntermediateHitDoublets() = default;
 
-  void swap(IntermediateHitDoublets& rh) {
-    std::swap(seedingLayers_, rh.seedingLayers_);
-    std::swap(regions_, rh.regions_);
-    std::swap(layerPairs_, rh.layerPairs_);
-  }
-
   void reserve(size_t nregions, size_t nlayersets) {
     regions_.reserve(nregions);
     layerPairs_.reserve(nregions*nlayersets);

--- a/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
+++ b/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
@@ -20,6 +20,8 @@ namespace ihd {
       layerSetBeginIndex_(ind),
       layerSetEndIndex_(ind)
     {}
+    RegionIndex(RegionIndex&&) = default;
+    RegionIndex& operator=(RegionIndex&&) = default;
 
     void setLayerSetsEnd(unsigned int end) { layerSetEndIndex_ = end; }
 
@@ -194,6 +196,8 @@ public:
   IntermediateHitDoublets(): seedingLayers_(nullptr) {}
   explicit IntermediateHitDoublets(const SeedingLayerSetsHits *seedingLayers): seedingLayers_(seedingLayers) {}
   IntermediateHitDoublets(const IntermediateHitDoublets& rh); // only to make ROOT dictionary generation happy
+  IntermediateHitDoublets(IntermediateHitDoublets&&) = default;
+  IntermediateHitDoublets& operator=(IntermediateHitDoublets&&) = default;
   ~IntermediateHitDoublets() = default;
 
   void swap(IntermediateHitDoublets& rh) {

--- a/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
+++ b/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
@@ -20,7 +20,10 @@ private:
     using ValueType = RecHitsSortedInPhi;
     using KeyType = int;
     SimpleCache(unsigned int initSize) : theContainer(initSize){}
-    SimpleCache(SimpleCache&& rh): theContainer(std::move(rh.theContainer)) {}
+    SimpleCache(const SimpleCache&) = delete;
+    SimpleCache& operator=(const SimpleCache&) = delete;
+    SimpleCache(SimpleCache&&) = default;
+    SimpleCache& operator=(SimpleCache&&) = default;
     ~SimpleCache() { clear(); }
     void resize(int size) { theContainer.resize(size); }
     const ValueType*  get(KeyType key) const { return theContainer[key].get();}
@@ -45,15 +48,15 @@ private:
     }
   private:
     std::vector<mayown_ptr<ValueType> > theContainer;
-  private:
-    SimpleCache(const SimpleCache &) { }
   };
 
 private:
   typedef SimpleCache Cache;
 public:
   LayerHitMapCache(unsigned int initSize=50) : theCache(initSize) { }
-  LayerHitMapCache(LayerHitMapCache&& rh): theCache(std::move(rh.theCache)) {}
+  LayerHitMapCache(LayerHitMapCache&&) = default;
+  LayerHitMapCache& operator=(LayerHitMapCache&&) = default;
+  
 
   void clear() { theCache.clear(); }
 

--- a/RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h
+++ b/RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h
@@ -45,6 +45,10 @@ public:
 
   // constructors
   RegionsSeedingHitSets() = default;
+  RegionsSeedingHitSets(const RegionsSeedingHitSets&) = delete;
+  RegionsSeedingHitSets& operator=(const RegionsSeedingHitSets&) = delete;
+  RegionsSeedingHitSets(RegionsSeedingHitSets&&) = default;
+  RegionsSeedingHitSets& operator=(RegionsSeedingHitSets&&) = default;
   ~RegionsSeedingHitSets() = default;
 
   void swap(RegionsSeedingHitSets& rh) {

--- a/RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h
+++ b/RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h
@@ -51,11 +51,6 @@ public:
   RegionsSeedingHitSets& operator=(RegionsSeedingHitSets&&) = default;
   ~RegionsSeedingHitSets() = default;
 
-  void swap(RegionsSeedingHitSets& rh) {
-    regions_.swap(rh.regions_);
-    hitSets_.swap(rh.hitSets_);
-  }
-
   void reserve(size_t nregions, size_t nhitsets) {
     regions_.reserve(nregions);
     hitSets_.reserve(nhitsets);

--- a/SimDataFormats/Associations/interface/MuonToTrackingParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/MuonToTrackingParticleAssociator.h
@@ -35,10 +35,6 @@ namespace reco {
       impl_->associateMuons(recoToSim, simToReco, muons, type, tpColl);
     }
 
-    void swap(MuonToTrackingParticleAssociator& iOther) {
-      std::swap(impl_, iOther.impl_);
-    }
-
   private:
     MuonToTrackingParticleAssociator( const MuonToTrackingParticleAssociator&) = delete;
     MuonToTrackingParticleAssociator& operator=( const MuonToTrackingParticleAssociator&) = delete;

--- a/SimDataFormats/Associations/interface/MuonToTrackingParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/MuonToTrackingParticleAssociator.h
@@ -16,11 +16,13 @@ namespace reco {
     
   public:
     
-    MuonToTrackingParticleAssociator ();
-    ~MuonToTrackingParticleAssociator ();
+    MuonToTrackingParticleAssociator () = default;
+    ~MuonToTrackingParticleAssociator () = default;
 #ifndef __GCCXML__
     MuonToTrackingParticleAssociator(std::unique_ptr<MuonToTrackingParticleAssociatorBaseImpl>);
 #endif
+    MuonToTrackingParticleAssociator(MuonToTrackingParticleAssociator&&) = default;
+    MuonToTrackingParticleAssociator& operator=(MuonToTrackingParticleAssociator&&) = default;
     
     void associateMuons(MuonToSimCollection & recoToSim, SimToMuonCollection & simToReco,
                         const edm::RefToBaseVector<reco::Muon> & muons, MuonTrackType type,
@@ -41,7 +43,7 @@ namespace reco {
     MuonToTrackingParticleAssociator( const MuonToTrackingParticleAssociator&) = delete;
     MuonToTrackingParticleAssociator& operator=( const MuonToTrackingParticleAssociator&) = delete;
 
-    MuonToTrackingParticleAssociatorBaseImpl const* impl_;
+    std::unique_ptr<MuonToTrackingParticleAssociatorBaseImpl const> impl_;
   };
 }
 

--- a/SimDataFormats/Associations/interface/TrackToGenParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/TrackToGenParticleAssociator.h
@@ -35,11 +35,13 @@ namespace reco{
     
   public:
     /// Constructor
-    TrackToGenParticleAssociator();
+    TrackToGenParticleAssociator() = default;
 #ifndef __GCCXML__
     TrackToGenParticleAssociator( std::unique_ptr<reco::TrackToGenParticleAssociatorBaseImpl>);
 #endif
-    ~TrackToGenParticleAssociator();
+    ~TrackToGenParticleAssociator() = default;
+    TrackToGenParticleAssociator(TrackToGenParticleAssociator&&) = default;
+    TrackToGenParticleAssociator& operator=(TrackToGenParticleAssociator&&) = default;
     
     /// Association Sim To Reco with Collections (Gen Particle version)
     reco::RecoToGenCollection associateRecoToGen(const edm::RefToBaseVector<reco::Track>& tracks,
@@ -74,7 +76,7 @@ namespace reco{
     
     const TrackToGenParticleAssociator& operator=(const TrackToGenParticleAssociator&) = delete; // stop default
     
-    TrackToGenParticleAssociatorBaseImpl* m_impl;
+    std::unique_ptr<TrackToGenParticleAssociatorBaseImpl> m_impl;
     
     
   };

--- a/SimDataFormats/Associations/interface/TrackToGenParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/TrackToGenParticleAssociator.h
@@ -65,10 +65,6 @@ namespace reco{
                                                  const edm::Handle<reco::GenParticleCollection>& tPCH) const {
       return m_impl->associateGenToReco(tCH,tPCH);
     }
-    
-    void swap(TrackToGenParticleAssociator& iOther) {
-      std::swap(m_impl, iOther.m_impl);
-    }
 
     
   private:

--- a/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h
@@ -55,8 +55,10 @@ namespace reco {
 #ifndef __GCCXML__
     TrackToTrackingParticleAssociator( std::unique_ptr<reco::TrackToTrackingParticleAssociatorBaseImpl>);
 #endif
-    TrackToTrackingParticleAssociator();
-    ~TrackToTrackingParticleAssociator();
+    TrackToTrackingParticleAssociator() = default;
+    TrackToTrackingParticleAssociator(TrackToTrackingParticleAssociator&&) = default;
+    TrackToTrackingParticleAssociator& operator=(TrackToTrackingParticleAssociator&&) = default;
+    ~TrackToTrackingParticleAssociator() = default;
     
     // ---------- const member functions ---------------------
     /// compare reco to sim the handle of reco::Track and TrackingParticle collections
@@ -114,7 +116,7 @@ namespace reco {
     const TrackToTrackingParticleAssociator& operator=(const TrackToTrackingParticleAssociator&) = delete; // stop default
     
     // ---------- member data --------------------------------
-    TrackToTrackingParticleAssociatorBaseImpl* m_impl;
+    std::unique_ptr<TrackToTrackingParticleAssociatorBaseImpl> m_impl;
   };
 }
 

--- a/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h
@@ -106,10 +106,6 @@ namespace reco {
                                                            const edm::Handle<TrackingParticleCollection>& tpc) const {
       return m_impl->associateSimToReco(tc,tpc);
     }
-
-    void swap(TrackToTrackingParticleAssociator& iOther) {
-      std::swap(m_impl, iOther.m_impl);
-    }
   private:
     TrackToTrackingParticleAssociator(const TrackToTrackingParticleAssociator&) = delete; // stop default
     

--- a/SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h
+++ b/SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h
@@ -29,10 +29,6 @@ namespace reco {
                                                        const edm::Handle<TrackingVertexCollection>& tVCH ) const {
       return m_impl->associateSimToReco(vCH,tVCH);
     }
-
-    void swap(VertexToTrackingVertexAssociator& iOther) {
-      std::swap(m_impl, iOther.m_impl);
-    }
   private:
     VertexToTrackingVertexAssociator(const VertexToTrackingVertexAssociator&) = delete; // stop default
     

--- a/SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h
+++ b/SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h
@@ -12,8 +12,10 @@ namespace reco {
 #ifndef __GCCXML__
     VertexToTrackingVertexAssociator( std::unique_ptr<reco::VertexToTrackingVertexAssociatorBaseImpl>);
 #endif
-    VertexToTrackingVertexAssociator();
-    ~VertexToTrackingVertexAssociator();
+    VertexToTrackingVertexAssociator() = default;
+    VertexToTrackingVertexAssociator(VertexToTrackingVertexAssociator&&) = default;
+    VertexToTrackingVertexAssociator& operator=(VertexToTrackingVertexAssociator&&) = default;
+    ~VertexToTrackingVertexAssociator() = default;
 
     // ---------- const member functions ---------------------
     /// compare reco to sim the handle of reco::Vertex and TrackingVertex collections
@@ -37,7 +39,7 @@ namespace reco {
     const VertexToTrackingVertexAssociator& operator=(const VertexToTrackingVertexAssociator&) = delete; // stop default
     
     // ---------- member data --------------------------------
-    VertexToTrackingVertexAssociatorBaseImpl* m_impl;
+    std::unique_ptr<VertexToTrackingVertexAssociatorBaseImpl> m_impl;
   };
 }
 

--- a/SimDataFormats/Associations/src/MuonToTrackingParticleAssociator.cc
+++ b/SimDataFormats/Associations/src/MuonToTrackingParticleAssociator.cc
@@ -19,18 +19,7 @@
 //
 // constructors and destructor
 //
-reco::MuonToTrackingParticleAssociator::MuonToTrackingParticleAssociator():
-  impl_(nullptr)
-{
-}
-
 reco::MuonToTrackingParticleAssociator::MuonToTrackingParticleAssociator(std::unique_ptr<MuonToTrackingParticleAssociatorBaseImpl> iImpl):
-  impl_(iImpl.release())
+  impl_(std::move(iImpl))
 {
 }
-
-reco::MuonToTrackingParticleAssociator::~MuonToTrackingParticleAssociator()
-{
-  delete impl_;
-}
-

--- a/SimDataFormats/Associations/src/TrackToGenParticleAssociator.cc
+++ b/SimDataFormats/Associations/src/TrackToGenParticleAssociator.cc
@@ -27,16 +27,6 @@
 //
 // constructors and destructor
 //
-reco::TrackToGenParticleAssociator::TrackToGenParticleAssociator()
+reco::TrackToGenParticleAssociator::TrackToGenParticleAssociator(std::unique_ptr<TrackToGenParticleAssociatorBaseImpl> impl): m_impl(std::move(impl))
 {
 }
-
-reco::TrackToGenParticleAssociator::TrackToGenParticleAssociator(std::unique_ptr<TrackToGenParticleAssociatorBaseImpl> impl): m_impl(impl.release())
-{
-}
-
-reco::TrackToGenParticleAssociator::~TrackToGenParticleAssociator()
-{
-  delete m_impl;
-}
-

--- a/SimDataFormats/Associations/src/TrackToTrackingParticleAssociator.cc
+++ b/SimDataFormats/Associations/src/TrackToTrackingParticleAssociator.cc
@@ -15,58 +15,7 @@
 // user include files
 #include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 
-
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
-reco::TrackToTrackingParticleAssociator::TrackToTrackingParticleAssociator():
-  m_impl{nullptr}
-{
-}
-
 reco::TrackToTrackingParticleAssociator::TrackToTrackingParticleAssociator(std::unique_ptr<reco::TrackToTrackingParticleAssociatorBaseImpl> iImpl):
-  m_impl{iImpl.release()}
+  m_impl{std::move(iImpl)}
 {
 }
-
-// TrackToTrackingParticleAssociator::TrackToTrackingParticleAssociator(const TrackToTrackingParticleAssociator& rhs)
-// {
-//    // do actual copying here;
-// }
-
-reco::TrackToTrackingParticleAssociator::~TrackToTrackingParticleAssociator()
-{
-  delete m_impl;
-}
-
-//
-// assignment operators
-//
-// const TrackToTrackingParticleAssociator& TrackToTrackingParticleAssociator::operator=(const TrackToTrackingParticleAssociator& rhs)
-// {
-//   //An exception safe implementation is
-//   TrackToTrackingParticleAssociator temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
-
-//
-// member functions
-//
-
-//
-// const member functions
-//
-
-//
-// static member functions
-//

--- a/SimDataFormats/Associations/src/VertexToTrackingVertexAssociator.cc
+++ b/SimDataFormats/Associations/src/VertexToTrackingVertexAssociator.cc
@@ -1,13 +1,5 @@
 #include "SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h"
 
-reco::VertexToTrackingVertexAssociator::VertexToTrackingVertexAssociator():
-  m_impl{nullptr}
-{}
-
 reco::VertexToTrackingVertexAssociator::VertexToTrackingVertexAssociator(std::unique_ptr<reco::VertexToTrackingVertexAssociatorBaseImpl> iImpl):
-  m_impl{iImpl.release()}
+  m_impl{std:move(iImpl)}
 {}
-
-reco::VertexToTrackingVertexAssociator::~VertexToTrackingVertexAssociator() {
-  delete m_impl;
-}

--- a/SimDataFormats/Associations/src/VertexToTrackingVertexAssociator.cc
+++ b/SimDataFormats/Associations/src/VertexToTrackingVertexAssociator.cc
@@ -1,5 +1,5 @@
 #include "SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h"
 
 reco::VertexToTrackingVertexAssociator::VertexToTrackingVertexAssociator(std::unique_ptr<reco::VertexToTrackingVertexAssociatorBaseImpl> iImpl):
-  m_impl{std:move(iImpl)}
+  m_impl{std::move(iImpl)}
 {}

--- a/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
@@ -24,8 +24,27 @@ class LHEEventProduct {
 	LHEEventProduct(const lhef::HEPEUP &hepeup,
 			const double originalXWGTUP) : 
 	  hepeup_(hepeup), originalXWGTUP_(originalXWGTUP) {}
-        LHEEventProduct(LHEEventProduct&&) = default;
-        LHEEventProduct& operator=(LHEEventProduct&&) = default;
+	LHEEventProduct(LHEEventProduct&& other) {
+	  hepeup_ = std::move(other.hepeup_);
+	  comments_ = std::move(other.comments_);
+	  pdf_ = other.pdf_; // auto_ptr, so copy is actually a move
+	  weights_ = std::move(other.weights_);
+	  originalXWGTUP_ = std::move(originalXWGTUP_);
+	  scales_ = std::move(scales_);
+	  npLO_ = std::move(npLO_);
+	  npNLO_ = std::move(npNLO_);
+	}
+	LHEEventProduct& operator=(LHEEventProduct&& other) {
+	  hepeup_ = std::move(other.hepeup_);
+	  comments_ = std::move(other.comments_);
+	  pdf_ = other.pdf_; // auto_ptr, so copy is actually a move
+	  weights_ = std::move(other.weights_);
+	  originalXWGTUP_ = std::move(originalXWGTUP_);
+	  scales_ = std::move(scales_);
+	  npLO_ = std::move(npLO_);
+	  npNLO_ = std::move(npNLO_);
+	  return *this;
+	}
 	~LHEEventProduct() {}
 
 	void setPDF(const PDF &pdf) { pdf_.reset(new PDF(pdf)); }

--- a/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
@@ -100,7 +100,7 @@ class LHEEventProduct {
     private:
 	lhef::HEPEUP			hepeup_;
 	std::vector<std::string>	comments_;
-	std::unique_ptr<PDF>		pdf_;
+	std::auto_ptr<PDF>		pdf_;
 	std::vector<WGT>                weights_;
 	double                          originalXWGTUP_;
         std::vector<float>              scales_; //scale value used to exclude EWK-produced partons from matching

--- a/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
@@ -24,6 +24,8 @@ class LHEEventProduct {
 	LHEEventProduct(const lhef::HEPEUP &hepeup,
 			const double originalXWGTUP) : 
 	  hepeup_(hepeup), originalXWGTUP_(originalXWGTUP) {}
+        LHEEventProduct(LHEEventProduct&&) = default;
+        LHEEventProduct& operator=(LHEEventProduct&&) = default;
 	~LHEEventProduct() {}
 
 	void setPDF(const PDF &pdf) { pdf_.reset(new PDF(pdf)); }

--- a/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
@@ -98,7 +98,7 @@ class LHEEventProduct {
     private:
 	lhef::HEPEUP			hepeup_;
 	std::vector<std::string>	comments_;
-	std::auto_ptr<PDF>		pdf_;
+	std::unique_ptr<PDF>		pdf_;
 	std::vector<WGT>                weights_;
 	double                          originalXWGTUP_;
         std::vector<float>              scales_; //scale value used to exclude EWK-produced partons from matching

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -191,11 +191,12 @@
 	<class name="LHERunInfoProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="2098560362"/>
  </class>
-	<class name="LHEEventProduct" ClassVersion="13">
+	<class name="LHEEventProduct" ClassVersion="14">
   <version ClassVersion="10" checksum="1026978494"/>
   <version ClassVersion="11" checksum="619154414"/>
   <version ClassVersion="12" checksum="259352862"/>
   <version ClassVersion="13" checksum="3927731647"/>
+  <version ClassVersion="14" checksum="905719452"/>
  </class>
  <ioread sourceClass = "LHEEventProduct" version="[-12]" targetClass="LHEEventProduct" source = "" target="npLO_">
     <![CDATA[npLO_ = -99;]]>

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -191,12 +191,11 @@
 	<class name="LHERunInfoProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="2098560362"/>
  </class>
-	<class name="LHEEventProduct" ClassVersion="14">
+	<class name="LHEEventProduct" ClassVersion="13">
   <version ClassVersion="10" checksum="1026978494"/>
   <version ClassVersion="11" checksum="619154414"/>
   <version ClassVersion="12" checksum="259352862"/>
   <version ClassVersion="13" checksum="3927731647"/>
-  <version ClassVersion="14" checksum="905719452"/>
  </class>
  <ioread sourceClass = "LHEEventProduct" version="[-12]" targetClass="LHEEventProduct" source = "" target="npLO_">
     <![CDATA[npLO_ = -99;]]>


### PR DESCRIPTION
This PR suggests to replace `swap_or_assign()` with move assignment in the constructor of `edm::Wrapper<T>` in order to benefit from compiler-generated move constructor+assignment operator for move-only products instead of having to explicitly write the `swap()` method every time (I got annoyed and after consultation with @Dr15Jones proceeded for a PR). Here the `swap()` was anyway used for a "move" before C++11.

I had to add the move constructor and assignment operators to handful of classes because they were not generated automatically by the compiler (mostly because of deleted copy constructor+assignment operator). There were a few more complex cases:
* `edmNew::DetSetVectorTrans` needed explicit move constructor+assignment operator because of atomic member variable (which are not movable), logic is as in `swap()`
* `MeasurementTrackerEvent` needed explicit move constructor+assignment operator because of the use of a boolean member variable to denote ownership of pointers
* ~~In~~ `LHEEventProduct` ~~I replaced `auto_ptr<PDF>` member with `unique_ptr<PTR>`, after which the compiler-generated move constructor+assignment operator work out of the box~~ needed explicit move constructor+assignment operator because of `auto_ptr`
   * ~~and anyway `auto_ptr` was deprecated in C++11 and removed in C++17~~

For all touched product classes I removed the `swap()` as unnecessary, except for `edmNew::DetSetVector(Trans)` where the `swap()` is used also elsewhere (and `swap()` is still part of the `std::vector` interface so for interface compatibility it makes sense to keep it).


Tested with limited matrix in 10_0_0, no changes expected.