### PR TITLE
added --ibeos command-line option for runTheMatrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixUtil.py
+++ b/Configuration/PyReleaseValidation/python/MatrixUtil.py
@@ -133,8 +133,9 @@ class InputInfo(object):
         if self.ib_blacklist:
             command += " | grep -E -v "
             command += " ".join(["-e '{0}'".format(pattern) for pattern in self.ib_blacklist])
-        command += " | sort -u"
-        return command
+        from os import getenv
+        if getenv("CMSSW_USE_IBEOS","false")=="true": return command + " | ibeos-lfn-sort"
+        return command + " | sort -u"
 
     def lumiRanges(self):
         if len(self.run) != 0:

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -244,7 +244,35 @@ if __name__ == '__main__':
                       default=False,
                       action='store_true')
     
+    parser.add_option('--ibeos',
+                      help='Use IB EOS site configuration',
+                      dest='IBEos',
+                      default=False,
+                      action='store_true')
+
     opt,args = parser.parse_args()
+    if opt.IBEos:
+      import os
+      from commands import getstatusoutput as run_cmd
+      ibeos_cache = os.path.join(os.getenv("LOCALRT"), "ibeos_cache.txt")
+      if not os.path.exists(ibeos_cache):
+        err, out = run_cmd("curl -L -s -o %s https://raw.githubusercontent.com/cms-sw/cms-sw.github.io/master/das_queries/ibeos.txt" % ibeos_cache)
+        if err:
+          run_cmd("rm -f %s" % ibeos_cache)
+          print "Error: Unable to download ibeos cache information"
+          print out
+          sys.exit(err)
+
+      for cmssw_env in [ "CMSSW_BASE", "CMSSW_RELEASE_BASE" ]:
+        cmssw_base = os.getenv(cmssw_env,None)
+        if not cmssw_base: continue
+        cmssw_base = os.path.join(cmssw_base,"src/Utilities/General/ibeos")
+        if os.path.exists(cmssw_base):
+          os.environ["PATH"]=cmssw_base+":"+os.getenv("PATH")
+          os.environ["CMS_PATH"]="/cvmfs/cms-ib.cern.ch"
+          os.environ["CMSSW_USE_IBEOS"]="true"
+          print ">> WARNING: You are using SITECONF from /cvmfs/cms-ib.cern.ch"
+          break
     if opt.restricted:
         print 'Deprecated, please use -l limited'
         if opt.testList:            opt.testList+=',limited'

--- a/Utilities/General/ibeos/das_client
+++ b/Utilities/General/ibeos/das_client
@@ -1,0 +1,82 @@
+#!/bin/sh
+#CMSSDT_DAS_CLIENT_SIGN:12345678901234567890ABCDEFABCDEF
+#Do not change the above magic line. It is signature for the cmssw ibs das_client wrapper
+function get_parent_cmds ()
+{
+  local DEPTH=$2
+  let DEPTH=$DEPTH+1
+  [ $DEPTH -gt 2 ] && return 0
+  local XPID=$(ps -p $1 -o ppid= | sed 's| ||g;')
+  [ "$XPID" = "" -o "$XPID" = "1" ] && return 0
+  cat "/proc/$XPID/cmdline"
+  echo ""
+  cat "/proc/$XPID/cmdline" >> ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.info
+  echo "" >> ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.info
+  get_parent_cmds "$XPID" "$DEPTH"
+}
+
+CMD_NAME=$(basename $0)
+LIMIT_RESULTS="NO"
+QUERY=
+FORMAT="plain"
+HELP=
+for ((i=1; i<=$#; i++)); do
+  next=$((i+1))
+  case  ${!i} in
+    --query=*  ) QUERY=$(echo ${!i} | sed 's|.*=||') ;;
+    --query    ) QUERY=${!next} ;;
+    --format=* ) FORMAT=$(echo ${!i} | sed 's|.*=||') ;;
+    --format   ) FORMAT=${!next} ;;
+    -h|--help  ) HELP=YES ;;
+  esac
+done
+
+ORIG_DAS_CLIENT=""
+for DAS_CLIENT in $(echo $PATH | tr ':' '\n' | sed "s|\$|/${CMD_NAME}|") ; do
+ [ -e ${DAS_CLIENT} ] || continue
+ if [ $(head -2 ${DAS_CLIENT} | grep 'CMSSDT_DAS_CLIENT_SIGN' | wc -l) -eq 0 ] ; then ORIG_DAS_CLIENT=${DAS_CLIENT}; break; fi
+done
+
+if [ "X${ORIG_DAS_CLIENT}" = "X" ] ; then
+  echo "${CMD_NAME}: Command not found." 1>&2
+  exit 1
+fi
+
+if [ "${QUERY}" = "" -o "${HELP}" != "" ] ; then
+  ${ORIG_DAS_CLIENT} "$@"
+  exit $?
+fi
+
+QUERY=$(echo "${QUERY}" | sed 's|^ *||;s| *$||;s|  *| |g;s| =|=|g;s|= |=|g;')
+QUERY_SHA_HASH=$(echo -n "${QUERY}" | sha256sum | sed 's| .*$||;s| *||')
+QUERY_SHA=$(echo "${QUERY_SHA_HASH}" | sed 's|^\(..\)|\1/\1|')
+QUERY_URL="https://raw.githubusercontent.com/cms-sw/cms-sw.github.io/master/das_queries/${QUERY_SHA}"
+DAS_QUERY_DIR=das_query/$$
+if [ "X${LOCALRT}" != "X" ] ; then DAS_QUERY_DIR="${LOCALRT}/${DAS_QUERY_DIR}" ; fi
+rm -rf ${DAS_QUERY_DIR}
+mkdir -p ${DAS_QUERY_DIR}
+echo "${QUERY}" > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.query
+touch ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.info
+if [ "${FORMAT}" = "json" ]  ; then
+  QUERY_RESULTS=$(curl -f -L -s "${QUERY_URL}.json" || true)
+  if [ "${QUERY_RESULTS}" = "" ] ; then
+    ${ORIG_DAS_CLIENT} "$@" > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
+  else
+    echo "${QUERY_RESULTS}" > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
+  fi
+else
+  QUERY_RESULTS=$((curl -f -L -s "${QUERY_URL}" || true) | grep /store/ | sed 's| ||g;s|"||g;s|,||g')
+  [ $((get_parent_cmds $$ 0 2>&1 || true) | grep '/cmsDriver.py' | wc -l) -gt 0 ] && LIMIT_RESULTS="YES"
+  if [ "${QUERY_RESULTS}" = "" ] ; then
+    ${ORIG_DAS_CLIENT} "$@" > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
+  else
+    echo "${QUERY_RESULTS}" > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
+  fi
+fi
+echo $LIMIT_RESULTS >> ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.info
+if [ "$LIMIT_RESULTS" = "YES" ] ; then
+  cat ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out | ibeos-lfn-sort > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.selected
+  cat ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.selected
+else
+  cat ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
+fi

--- a/Utilities/General/ibeos/dasgoclient
+++ b/Utilities/General/ibeos/dasgoclient
@@ -1,0 +1,1 @@
+das_client

--- a/Utilities/General/ibeos/ibeos-lfn-sort
+++ b/Utilities/General/ibeos/ibeos-lfn-sort
@@ -1,0 +1,24 @@
+#!/bin/bash
+IBEOS_FILES=""
+NON_IBEOS_FILES=""
+if [ -f ${LOCALRT}/ibeos_cache.txt ] ; then
+  while read LFN ; do
+    case $LFN in
+      /store/* )
+        if [ $(grep "^${LFN}$" ${LOCALRT}/ibeos_cache.txt | wc -l) -gt 0 ] ; then
+          IBEOS_FILES="$IBEOS_FILES $LFN"
+        else
+          NON_IBEOS_FILES="$NON_IBEOS_FILES $LFN"
+        fi
+        ;;
+    esac
+  done
+else
+  while read LFN ; do
+    case $LFN in
+      /store/* ) NON_IBEOS_FILES="$NON_IBEOS_FILES $LFN" ;;
+    esac
+  done
+fi
+echo $(echo $IBEOS_FILES | tr ' ' '\n' | sort -u) $(echo $NON_IBEOS_FILES | tr ' ' '\n' | sort -u) | tr ' ' '\n' | grep '/store' | head -n 20
+


### PR DESCRIPTION
This new --ibeos command-line does the following
- Use SITECONF from `/cvmfs/cms-ib.cern.ch` where we use global xrootd redirector. This is done by setting CMS_PATH to /cvmfs/cms-ib.cern.ch
- Adds das_client, dasgoclient wrapper in PATH which uses das cache from https://raw.githubusercontent.com/cms-sw/cms-sw.github.io/master/das_queries
- Make use of eos IB cache from /eos/cms/store/user/cmsbuild