### PR TITLE
Updated list of magnetic field steppers and EM physlists for Geant4 10.4

### DIFF
--- a/SimG4Core/Application/src/ParametrisedEMPhysics.cc
+++ b/SimG4Core/Application/src/ParametrisedEMPhysics.cc
@@ -221,9 +221,8 @@ void ParametrisedEMPhysics::ConstructProcess() {
   }
   // enable fluorescence
   bool fluo = theParSet.getParameter<bool>("FlagFluo");
-  if(fluo) {
+  if(fluo && !G4LossTableManager::Instance()->AtomDeexcitation()) {
     G4VAtomDeexcitation* de = new G4UAtomicDeexcitation();
     G4LossTableManager::Instance()->SetAtomDeexcitation(de);
-    de->SetFluo(true);
   }
 }

--- a/SimG4Core/MagneticField/src/FieldStepper.cc
+++ b/SimG4Core/MagneticField/src/FieldStepper.cc
@@ -6,8 +6,9 @@
 #include "G4SimpleRunge.hh"
 #include "G4SimpleHeum.hh"
 #include "G4CashKarpRKF45.hh"
-#include "G4RKG3_Stepper.hh"
-#include "G4ExplicitEuler.hh"
+#include "G4DormandPrince745.hh"
+#include "G4BogackiShampine45.hh"
+#include "G4TsitourasRK45.hh"
 #include "G4ImplicitEuler.hh"
 #include "G4HelixExplicitEuler.hh"
 #include "G4HelixImplicitEuler.hh"
@@ -38,8 +39,9 @@ G4MagIntegratorStepper * FieldStepper::select(const std::string & ss)
     else if (ss == "G4SimpleRunge")        theStepper = new G4SimpleRunge(theEquation);
     else if (ss == "G4SimpleHeum")         theStepper = new G4SimpleHeum(theEquation);
     else if (ss == "G4CashKarpRKF45")      theStepper = new G4CashKarpRKF45(theEquation);
-    else if (ss == "G4RKG3_Stepper")       theStepper = new G4RKG3_Stepper(theEquation);
-    else if (ss == "G4ExplicitEuler")      theStepper = new G4ExplicitEuler(theEquation);
+    else if (ss == "G4DormandPrince745")   theStepper = new G4DormandPrince745(theEquation);
+    else if (ss == "G4BogackiShampine45")  theStepper = new G4BogackiShampine45(theEquation);
+    else if (ss == "G4TsitourasRK45")      theStepper = new G4TsitourasRK45(theEquation);
     else if (ss == "G4ImplicitEuler")      theStepper = new G4ImplicitEuler(theEquation);
     else if (ss == "G4HelixExplicitEuler") theStepper = new G4HelixExplicitEuler(theEquation);
     else if (ss == "G4HelixImplicitEuler") theStepper = new G4HelixImplicitEuler(theEquation);
@@ -51,5 +53,7 @@ G4MagIntegratorStepper * FieldStepper::select(const std::string & ss)
         << " FieldStepper invalid choice, defaulting to G4ClassicalRK4 ";
       theStepper = new G4ClassicalRK4(theEquation);
     }
+    edm::LogWarning("SimG4CoreMagneticField") 
+      << "### FieldStepper <" << ss << ">";
     return theStepper;
 }

--- a/SimG4Core/MagneticField/src/FieldStepper.cc
+++ b/SimG4Core/MagneticField/src/FieldStepper.cc
@@ -50,10 +50,10 @@ G4MagIntegratorStepper * FieldStepper::select(const std::string & ss)
     else
     {
       edm::LogWarning("SimG4CoreMagneticField") 
-        << " FieldStepper invalid choice, defaulting to G4ClassicalRK4 ";
+        << " FieldStepper <" << ss << "> is not known, defaulting to G4ClassicalRK4 ";
       theStepper = new G4ClassicalRK4(theEquation);
     }
-    edm::LogWarning("SimG4CoreMagneticField") 
-      << "### FieldStepper <" << ss << ">";
+    edm::LogInfo("SimG4CoreMagneticField") 
+      << "### FieldStepper: <" << ss << ">";
     return theStepper;
 }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
@@ -77,6 +77,7 @@ CMSEmStandardPhysics95::CMSEmStandardPhysics95(const G4String& name, G4int ver,
   param->SetDefaults();
   param->SetVerbose(verbose);
   param->SetApplyCuts(true);
+  param->SetStepFunction(0.8, 1*CLHEP::mm);
   param->SetMscRangeFactor(0.2);
   param->SetMscStepLimitType(fMinimal);
   SetPhysicsType(bElectromagnetic);
@@ -132,11 +133,12 @@ void CMSEmStandardPhysics95::ConstructParticle() {
 
 void CMSEmStandardPhysics95::ConstructProcess() 
 {
-  // This EM builder takes default models of Geant4 10 EMV.
+  // This EM builder takes default models of Geant4 EMV.
   // Multiple scattering by Urban for all particles
 
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
+  // muon & hadron bremsstrahlung and pair production
   G4MuBremsstrahlung* mub = nullptr;
   G4MuPairProduction* mup = nullptr;
   G4hBremsstrahlung* pib = nullptr;
@@ -146,7 +148,12 @@ void CMSEmStandardPhysics95::ConstructProcess()
   G4hBremsstrahlung* pb = nullptr;
   G4hPairProduction* pp = nullptr;
 
-  G4hMultipleScattering* hmsc = nullptr;
+  // muon & hadron multiple scattering
+  G4MuMultipleScattering* mumsc = nullptr;
+  G4hMultipleScattering*  pimsc = nullptr;
+  G4hMultipleScattering*  kmsc = nullptr;
+  G4hMultipleScattering*  pmsc = nullptr;
+  G4hMultipleScattering*  hmsc = nullptr;
 
   // Add standard EM Processes
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
@@ -166,10 +173,7 @@ void CMSEmStandardPhysics95::ConstructProcess()
     } else if (particleName == "e-") {
 
       G4eIonisation* eioni = new G4eIonisation();
-      eioni->SetStepFunction(0.8, 1.0*mm);
       G4eMultipleScattering* msc = new G4eMultipleScattering();
-      msc->SetStepLimitType(fMinimal);
-
       G4eBremsstrahlung* ebrem = new G4eBremsstrahlung();
 
       ph->RegisterProcess(msc, particle);
@@ -179,10 +183,7 @@ void CMSEmStandardPhysics95::ConstructProcess()
     } else if (particleName == "e+") {
 
       G4eIonisation* eioni = new G4eIonisation();
-      eioni->SetStepFunction(0.8, 1.0*mm);
       G4eMultipleScattering* msc = new G4eMultipleScattering();
-      msc->SetStepLimitType(fMinimal);
-
       G4eBremsstrahlung* ebrem = new G4eBremsstrahlung();
 
       ph->RegisterProcess(msc, particle);
@@ -191,14 +192,14 @@ void CMSEmStandardPhysics95::ConstructProcess()
       ph->RegisterProcess(new G4eplusAnnihilation(), particle);
 
     } else if (particleName == "mu+" ||
-               particleName == "mu-"    ) {
+               particleName == "mu-" ) {
 
       if(nullptr == mub) {
 	mub = new G4MuBremsstrahlung();
 	mup = new G4MuPairProduction();
+	mumsc = new G4MuMultipleScattering();
       }
-      G4MuMultipleScattering* msc = new G4MuMultipleScattering();
-      ph->RegisterProcess(msc, particle);
+      ph->RegisterProcess(mumsc, particle);
       ph->RegisterProcess(new G4MuIonisation(), particle);
       ph->RegisterProcess(mub, particle);
       ph->RegisterProcess(mup, particle);
@@ -223,8 +224,9 @@ void CMSEmStandardPhysics95::ConstructProcess()
       if(nullptr == pib) {
 	pib = new G4hBremsstrahlung();
 	pip = new G4hPairProduction();
+	pimsc = new G4hMultipleScattering();
       }
-      ph->RegisterProcess(new G4hMultipleScattering(), particle);
+      ph->RegisterProcess(pimsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pib, particle);
       ph->RegisterProcess(pip, particle);
@@ -234,21 +236,23 @@ void CMSEmStandardPhysics95::ConstructProcess()
 
       if(nullptr == kb) {
 	kb = new G4hBremsstrahlung();
-	kp = new G4hPairProduction();
+        kp = new G4hPairProduction();
+	kmsc = new G4hMultipleScattering();
       }
-      ph->RegisterProcess(new G4hMultipleScattering(), particle);
+      ph->RegisterProcess(kmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(kb, particle);
       ph->RegisterProcess(kp, particle);
 
-    } else if (particleName == "proton" || 
+    } else if (particleName == "proton" ||
 	       particleName == "anti_proton") {
 
       if(nullptr == pb) {
 	pb = new G4hBremsstrahlung();
 	pp = new G4hPairProduction();
+	pmsc = new G4hMultipleScattering();
       }
-      ph->RegisterProcess(new G4hMultipleScattering(), particle);
+      ph->RegisterProcess(pmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pb, particle);
       ph->RegisterProcess(pp, particle);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
@@ -250,8 +250,8 @@ void CMSEmStandardPhysics95::ConstructProcess()
       if(nullptr == pb) {
 	pb = new G4hBremsstrahlung();
 	pp = new G4hPairProduction();
-	pmsc = new G4hMultipleScattering();
       }
+      pmsc = new G4hMultipleScattering();
       ph->RegisterProcess(pmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pb, particle);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
@@ -257,8 +257,9 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
       if(nullptr == pb) {
 	pb = new G4hBremsstrahlung();
 	pp = new G4hPairProduction();
-	pmsc = new G4hMultipleScattering();
       }
+      pmsc = new G4hMultipleScattering();
+
       ph->RegisterProcess(pmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pb, particle);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -80,6 +80,7 @@ CMSEmStandardPhysicsLPM::CMSEmStandardPhysicsLPM(G4int ver) :
   param->SetDefaults();
   param->SetVerbose(verbose);
   param->SetApplyCuts(true);
+  param->SetStepFunction(0.8, 1*CLHEP::mm);
   param->SetMscRangeFactor(0.2);
   param->SetMscStepLimitType(fMinimal);
   SetPhysicsType(bElectromagnetic);
@@ -162,6 +163,12 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
   G4hMultipleScattering*  pmsc = nullptr;
   G4hMultipleScattering*  hmsc = nullptr;
 
+  // muon and hadron single scattering
+  G4CoulombScattering* muss = nullptr;
+  G4CoulombScattering* piss = nullptr;
+  G4CoulombScattering* kss = nullptr;
+  G4CoulombScattering* pss = nullptr;
+
   // high energy limit for e+- scattering models and bremsstrahlung
   G4double highEnergyLimit = 100*MeV;
 
@@ -184,10 +191,8 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
     } else if (particleName == "e-") {
 
       G4eIonisation* eioni = new G4eIonisation();
-      eioni->SetStepFunction(0.8, 1.0*mm);
 
       G4eMultipleScattering* msc = new G4eMultipleScattering;
-      msc->SetStepLimitType(fMinimal);
       G4UrbanMscModel* msc1 = new G4UrbanMscModel();
       G4WentzelVIModel* msc2 = new G4WentzelVIModel();
       G4UrbanMscModel* msc3 = new G4UrbanMscModel();
@@ -195,8 +200,8 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       msc1->SetHighEnergyLimit(highEnergyLimit);
       msc2->SetLowEnergyLimit(highEnergyLimit);
       msc3->SetHighEnergyLimit(highEnergyLimit);
-      msc->AddEmModel(0, msc1);
-      msc->AddEmModel(0, msc2);
+      msc->SetEmModel(msc1);
+      msc->SetEmModel(msc2);
       msc->AddEmModel(-1, msc3, aRegion);
       if (bRegion) msc->AddEmModel(-1, msc3, bRegion);
 
@@ -215,10 +220,8 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
     } else if (particleName == "e+") {
 
       G4eIonisation* eioni = new G4eIonisation();
-      eioni->SetStepFunction(0.8, 1.0*mm);
 
       G4eMultipleScattering* msc = new G4eMultipleScattering;
-      msc->SetStepLimitType(fMinimal);
       G4UrbanMscModel* msc1 = new G4UrbanMscModel();
       G4WentzelVIModel* msc2 = new G4WentzelVIModel();
       G4UrbanMscModel* msc3 = new G4UrbanMscModel();
@@ -226,8 +229,8 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       msc2->SetLowEnergyLimit(highEnergyLimit);
       msc3->SetHighEnergyLimit(highEnergyLimit);
       msc3->SetLocked(true);
-      msc->AddEmModel(0, msc1);
-      msc->AddEmModel(0, msc2);
+      msc->SetEmModel(msc1);
+      msc->SetEmModel(msc2);
       msc->AddEmModel(-1, msc3, aRegion);
       if (bRegion) msc->AddEmModel(-1, msc3, bRegion);
 
@@ -251,13 +254,14 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
 	mub = new G4MuBremsstrahlung();
 	mup = new G4MuPairProduction();
 	mumsc = new G4MuMultipleScattering();
-	mumsc->AddEmModel(0, new G4WentzelVIModel());
+	mumsc->SetEmModel(new G4WentzelVIModel());
+        muss = new G4CoulombScattering();
       }
       ph->RegisterProcess(mumsc, particle);
       ph->RegisterProcess(new G4MuIonisation(), particle);
       ph->RegisterProcess(mub, particle);
       ph->RegisterProcess(mup, particle);
-      ph->RegisterProcess(new G4CoulombScattering(), particle);
+      ph->RegisterProcess(muss, particle);
 
     } else if (particleName == "alpha" || 
 	       particleName == "He3" ) {
@@ -280,13 +284,14 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
 	pib = new G4hBremsstrahlung();
 	pip = new G4hPairProduction();
 	pimsc = new G4hMultipleScattering();
-	pimsc->AddEmModel(0, new G4WentzelVIModel());
+	pimsc->SetEmModel(new G4WentzelVIModel());
+        piss = new G4CoulombScattering();
       }
       ph->RegisterProcess(pimsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pib, particle);
       ph->RegisterProcess(pip, particle);
-      ph->RegisterProcess(new G4CoulombScattering(), particle);
+      ph->RegisterProcess(piss, particle);
 
     } else if (particleName == "kaon+" ||
                particleName == "kaon-" ) {
@@ -295,13 +300,14 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
 	kb = new G4hBremsstrahlung();
         kp = new G4hPairProduction();
 	kmsc = new G4hMultipleScattering();
-	kmsc->AddEmModel(0, new G4WentzelVIModel());
+	kmsc->SetEmModel(new G4WentzelVIModel());
+        kss = new G4CoulombScattering();
       }
       ph->RegisterProcess(kmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(kb, particle);
       ph->RegisterProcess(kp, particle);
-      ph->RegisterProcess(new G4CoulombScattering(), particle);
+      ph->RegisterProcess(kss, particle);
 
     } else if (particleName == "proton" ||
 	       particleName == "anti_proton") {
@@ -310,13 +316,14 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
 	pb = new G4hBremsstrahlung();
 	pp = new G4hPairProduction();
 	pmsc = new G4hMultipleScattering();
-	pmsc->AddEmModel(0, new G4WentzelVIModel());
+	pmsc->SetEmModel(new G4WentzelVIModel());
+        pss = new G4CoulombScattering();
       }
       ph->RegisterProcess(pmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pb, particle);
       ph->RegisterProcess(pp, particle);
-      ph->RegisterProcess(new G4CoulombScattering(), particle);
+      ph->RegisterProcess(pss, particle);
 
     } else if (particleName == "B+" ||
 	       particleName == "B-" ||
@@ -356,6 +363,4 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       ph->RegisterProcess(new G4hIonisation(), particle);
     }
   }
-  G4VAtomDeexcitation* de = new G4UAtomicDeexcitation();
-  G4LossTableManager::Instance()->SetAtomDeexcitation(de);
 }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -167,7 +167,6 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
   G4CoulombScattering* muss = nullptr;
   G4CoulombScattering* piss = nullptr;
   G4CoulombScattering* kss = nullptr;
-  G4CoulombScattering* pss = nullptr;
 
   // high energy limit for e+- scattering models and bremsstrahlung
   G4double highEnergyLimit = 100*MeV;
@@ -315,15 +314,17 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       if(nullptr == pb) {
 	pb = new G4hBremsstrahlung();
 	pp = new G4hPairProduction();
+	//--- VI: these lines should be moved out of the brackets
 	pmsc = new G4hMultipleScattering();
 	pmsc->SetEmModel(new G4WentzelVIModel());
-        pss = new G4CoulombScattering();
+	//---
       }
+
       ph->RegisterProcess(pmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pb, particle);
       ph->RegisterProcess(pp, particle);
-      ph->RegisterProcess(pss, particle);
+      ph->RegisterProcess(new G4CoulombScattering(), particle);
 
     } else if (particleName == "B+" ||
 	       particleName == "B-" ||

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
@@ -325,9 +325,10 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
 	pb = new G4hBremsstrahlung();
 	pp = new G4hPairProduction();
 	pmsc = new G4hMultipleScattering();
-	pmsc->SetEmModel(new G4WentzelVIModel());
-        pss = new G4CoulombScattering();
       }
+      pmsc->SetEmModel(new G4WentzelVIModel());
+      pss = new G4CoulombScattering();
+
       ph->RegisterProcess(pmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pb, particle);


### PR DESCRIPTION
These modifications are recommended by Geant4 experts for the version 10.4. None of those should affect current results, because the default configuration is not changed. This PR includes:

1) addition of optional magnetic field steppers provided by Geant4 team. If enabled this may allow speed-up of FullSim. Two old obsolete steppers are removed from the list.
2) More optimal configuration of CMS custom EM physics constructors, may be result as a tiny optimisation of CPU/memory 