### PR TITLE
[10.1.X] [GT Updates] for HCAL Bug fixes and Jet Probability calibration for btagging

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,19 +40,19 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '100X_dataRun2_HLTHI_frozen_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '100X_mc2017_design_IdealBS_v2',
+    'phase1_2017_design'       :  '100X_mc2017_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '100X_mc2017_realistic_v2',
+    'phase1_2017_realistic'    : '100X_mc2017_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '100X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'      : '100X_mc2017cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '100X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak' : '100X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '100X_upgrade2018_design_IdealBS_v4',
+    'phase1_2018_design'       : '100X_upgrade2018_design_IdealBS_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v7',
+    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v8',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v5',
+    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '100X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -50,9 +50,9 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '100X_upgrade2018_design_IdealBS_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v8',
+    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v9',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v6',
+    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '100X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## 2018_MC
 
   * **PhaseI 2018 cosmics scenario** : [100X_upgrade2018cosmics_realistic_deco_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018cosmics_realistic_deco_v7) as [100X_upgrade2018cosmics_realistic_deco_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018cosmics_realistic_deco_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018cosmics_realistic_deco_v7/100X_upgrade2018cosmics_realistic_deco_v5): 
      * update of jet probability calibrations for b-tagging : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3464.html
      * HCAL bug fixes : https://indico.cern.ch/event/691337/contributions/2866494/attachments/1586921/2509518/ConditionUpdateProposal20180122.pdf
      * update of leftover ECAL TPG threshold tags
      * update of ECAL and CSC bad channel status

   * **PhaseI 2018 design scenario** : [100X_upgrade2018_design_IdealBS_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018_design_IdealBS_v5) as [100X_upgrade2018_design_IdealBS_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018_design_IdealBS_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018_design_IdealBS_v5/100X_upgrade2018_design_IdealBS_v4): 
      * update of jet probability calibrations for b-tagging : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3464.html
      * HCAL bug fixes : https://indico.cern.ch/event/691337/contributions/2866494/attachments/1586921/2509518/ConditionUpdateProposal20180122.pdf

   * **PhaseI 2018 realistic scenario** : [100X_upgrade2018_realistic_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018_realistic_v9) as [100X_upgrade2018_realistic_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018_realistic_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018_realistic_v9/100X_upgrade2018_realistic_v7): 
      * update of jet probability calibrations for b-tagging : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3464.html
      * HCAL bug fixes : https://indico.cern.ch/event/691337/contributions/2866494/attachments/1586921/2509518/ConditionUpdateProposal20180122.pdf
      * update of ECAL and CSC bad channel status

## 2017_MC 
 
   * **PhaseI 2017 cosmics peak scenario** : [100X_mc2017cosmics_realistic_peak_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017cosmics_realistic_peak_v3) as [100X_mc2017cosmics_realistic_peak_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017cosmics_realistic_peak_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mc2017cosmics_realistic_peak_v3/100X_mc2017cosmics_realistic_peak_v2): 
      * update of jet probability calibrations for b-tagging : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3464.html

   * **PhaseI 2017 cosmics scenario** : [100X_mc2017cosmics_realistic_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017cosmics_realistic_deco_v3) as [100X_mc2017cosmics_realistic_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017cosmics_realistic_deco_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mc2017cosmics_realistic_deco_v3/100X_mc2017cosmics_realistic_deco_v2): 
      * update of jet probability calibrations for b-tagging : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3464.html

   * **PhaseI 2017 design scenario** : [100X_mc2017_design_IdealBS_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017_design_IdealBS_v3) as [100X_mc2017_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017_design_IdealBS_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mc2017_design_IdealBS_v3/100X_mc2017_design_IdealBS_v2): 
      * update of jet probability calibrations for b-tagging : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3464.html

   * **PhaseI 2017 realistic scenario** : [100X_mc2017_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017_realistic_v3) as [100X_mc2017_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mc2017_realistic_v3/100X_mc2017_realistic_v2): 
      * update of jet probability calibrations for b-tagging : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3464.html