### PR TITLE
[HCAL] Make sure that trigger towers with abs(ieta)=16 are processed with QIE8 settings in 2018.

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -85,6 +85,7 @@ public:
 
   bool validUpgradeFG(const HcalTrigTowerDetId& id, int depth) const;
   bool validChannel(const QIE10DataFrame& digi, int ts) const;
+  bool needLegacyFG(const HcalTrigTowerDetId& id) const;
 
   /// adds the actual RecHits
   void analyze(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result);

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -741,13 +741,30 @@ HcalTriggerPrimitiveAlgo::validUpgradeFG(const HcalTrigTowerDetId& id, int depth
       return false;
    if (id.ietaAbs() > LAST_FINEGRAIN_TOWER)
       return false;
+   if (id.ietaAbs() == HBHE_OVERLAP_TOWER and not upgrade_hb_)
+      return false;
    return true;
+}
+
+bool
+HcalTriggerPrimitiveAlgo::needLegacyFG(const HcalTrigTowerDetId& id) const
+{
+   // This tower (ietaAbs == 16) does not accept upgraded FG bits,
+   // but needs pseudo legacy ones to ensure that the tower is processed
+   // even when the QIE8 depths in front of it do not have energy deposits.
+   if (id.ietaAbs() == HBHE_OVERLAP_TOWER and not upgrade_hb_)
+      return true;
+   return false;
 }
 
 void
 HcalTriggerPrimitiveAlgo::addUpgradeFG(const HcalTrigTowerDetId& id, int depth, const std::vector<std::bitset<2>>& bits)
 {
    if (not validUpgradeFG(id, depth)) {
+      if (needLegacyFG(id)) {
+         std::vector<bool> pseudo(bits.size(), false);
+         addFG(id, pseudo);
+      }
       return;
    }
 


### PR DESCRIPTION
Fixes a crash when only the last depth of tower 16 is present.