### PR TITLE
Avoid unnecessary exceptions in validation

### DIFF
--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -3480,29 +3480,35 @@ void PhotonValidator::analyze( const edm::Event& e, const edm::EventSetup& esup 
 
 	  if ( theConvTP_.size() < 2 )   continue;
 
-	  reco::RecoToSimCollection p1 =  trackAssociator->associateRecoToSim(tc1,theConvTP_);
-	  reco::RecoToSimCollection p2 =  trackAssociator->associateRecoToSim(tc2,theConvTP_);
+	  reco::RecoToSimCollection const& p1 =  trackAssociator->associateRecoToSim(tc1,theConvTP_);
+	  reco::RecoToSimCollection const& p2 =  trackAssociator->associateRecoToSim(tc2,theConvTP_);
 	  std::vector<std::pair<RefToBase<reco::Track>, double> > trackV1, trackV2;
-          try {
-            std::vector<std::pair<TrackingParticleRef, double> > tp1 = p1[tk1];
-            std::vector<std::pair<TrackingParticleRef, double> > tp2 = p2[tk2];
 
-            if (!tp1.empty()&&!tp2.empty()) {
-              TrackingParticleRef tpr1 = tp1.front().first;
-              TrackingParticleRef tpr2 = tp2.front().first;
+          auto itP1 = p1.find(tk1);
+          auto itP2 = p2.find(tk2);
+          bool good = (itP1 != p1.end()) and (not itP1->val.empty()) and (itP2 != p2.end()) and (not itP2->val.empty());
+          if(not good) {
+            itP1 = p1.find(tk2);
+            itP2 = p2.find(tk1);
+            good = (itP1 != p1.end()) and (not itP1->val.empty()) and (itP2 != p2.end()) and (not itP2->val.empty());
+          }
+          if(good) {
+            std::vector<std::pair<TrackingParticleRef, double> > const& tp1 = itP1->val;
+            std::vector<std::pair<TrackingParticleRef, double> > const& tp2 = itP2->val;
 
-              if (abs(tpr1->pdgId())==11&&abs(tpr2->pdgId())==11) {
-                if ( (tpr1->parentVertex()->sourceTracks_end()-tpr1->parentVertex()->sourceTracks_begin()==1) &&
-                     (tpr2->parentVertex()->sourceTracks_end()-tpr2->parentVertex()->sourceTracks_begin()==1)) {
-                  if (tpr1->parentVertex().key()==tpr2->parentVertex().key() && ((*tpr1->parentVertex()->sourceTracks_begin())->pdgId()==22)) {
-                    nAssT2 = 2;
-                    break;
-                  }
+            TrackingParticleRef tpr1 = tp1.front().first;
+            TrackingParticleRef tpr2 = tp2.front().first;
+            
+            if (abs(tpr1->pdgId())==11&&abs(tpr2->pdgId())==11) {
+              if ( (tpr1->parentVertex()->sourceTracks_end()-tpr1->parentVertex()->sourceTracks_begin()==1) &&
+                   (tpr2->parentVertex()->sourceTracks_end()-tpr2->parentVertex()->sourceTracks_begin()==1)) {
+                if (tpr1->parentVertex().key()==tpr2->parentVertex().key() && ((*tpr1->parentVertex()->sourceTracks_begin())->pdgId()==22)) {
+                  nAssT2 = 2;
+                  break;
                 }
               }
             }
 
-	  } catch (Exception event) {
 	  }
 
 	} // end loop over simulated photons

--- a/Validation/SiPixelPhase1HitsV/interface/SiPixelPhase1HitsV.h
+++ b/Validation/SiPixelPhase1HitsV/interface/SiPixelPhase1HitsV.h
@@ -46,8 +46,6 @@ class SiPixelPhase1HitsV : public SiPixelPhase1Base {
   edm::EDGetTokenT< edm::View<reco::Track> > tracksToken_;
   edm::EDGetTokenT< TrackingParticleCollection > tpToken_;
   edm::EDGetTokenT< reco::TrackToTrackingParticleAssociator > trackAssociatorByHitsToken_;
-  reco::TrackToTrackingParticleAssociator const * associatorByHits;
-  edm::SimTrackContainer const * simTC;
 
 };
 

--- a/Validation/SiPixelPhase1HitsV/src/SiPixelPhase1HitsV.cc
+++ b/Validation/SiPixelPhase1HitsV/src/SiPixelPhase1HitsV.cc
@@ -205,25 +205,18 @@ void SiPixelPhase1HitsV::analyze(const edm::Event& iEvent, const edm::EventSetup
   if ( ! theHitsAssociator.isValid() ) {
     throw cms::Exception ("NO VALID HIT ASSOCIATOR");
   }
-  associatorByHits = theHitsAssociator.product();
+  reco::TrackToTrackingParticleAssociator const *associatorByHits = theHitsAssociator.product();
 
   if ( TPCollectionH.isValid() && trackCollectionH.isValid() ) {
-    reco::RecoToSimCollection p = associatorByHits->associateRecoToSim(trackCollectionH,TPCollectionH);
+    reco::RecoToSimCollection const& p = associatorByHits->associateRecoToSim(trackCollectionH,TPCollectionH);
 
     for(edm::View<reco::Track>::size_type i=0; i<tC.size(); ++i) {
       edm::RefToBase<reco::Track> track(trackCollectionH, i);
 //      const reco::Track& t = *track;
       auto id = DetId(track->innerDetId()); // histo manager requires a det ID, use innermost ID for ease
 
-      try { 
-        std::vector<std::pair<TrackingParticleRef, double> > tp = p[track];
-//        std::cout << "Reco track matched to " << tp.size() << " MC tracks." << std::endl;
-        histo[EFFICIENCY_TRACK].fill(1, id, &iEvent);
-      } 
-      catch (edm::Exception event) {
-        histo[EFFICIENCY_TRACK].fill(0, id, &iEvent);
-//        std::cout << "Reco track has not matched to at least one sim hit" << std::endl;
-      }
+      auto iter = p.find(track);
+      histo[EFFICIENCY_TRACK].fill(iter != p.end()? 1: 0, id, &iEvent);
     }
 
   }


### PR DESCRIPTION
Switch from calling AssociationMap::operator[] which can throw an
exception if the key is missing to calling find() which will not
throw.