### PR TITLE
Fc fix geo test100 x

### DIFF
--- a/SimG4Core/Geometry/test/Cons_.cpp
+++ b/SimG4Core/Geometry/test/Cons_.cpp
@@ -43,13 +43,14 @@ testCons::matched_g4_and_dd( void )
   double g4v = g4.GetCubicVolume()/cm3;
   double ddv = dd.volume()/cm3;
   double ddsv = dds.volume()/cm3;
+  double precision_in_digits = 1e-12;
   
   std::cout << "\tg4 volume = " << g4v <<" cm3" << std::endl;
   std::cout << "\tdd volume = " << ddv << " cm3" <<  std::endl;
   std::cout << "\tDD Information: " << dds << " vol=" << ddsv << " cm3" << std::endl;
-  
-  CPPUNIT_ASSERT( g4v == ddv );
-  CPPUNIT_ASSERT( g4v == ddsv );
+
+  CPPUNIT_ASSERT( abs(g4v - ddv) < precision_in_digits );
+  CPPUNIT_ASSERT( abs(g4v - ddsv) < precision_in_digits );
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION( testCons );

--- a/SimG4Core/Geometry/test/Cons_.cpp
+++ b/SimG4Core/Geometry/test/Cons_.cpp
@@ -49,8 +49,8 @@ testCons::matched_g4_and_dd( void )
   std::cout << "\tdd volume = " << ddv << " cm3" <<  std::endl;
   std::cout << "\tDD Information: " << dds << " vol=" << ddsv << " cm3" << std::endl;
 
-  CPPUNIT_ASSERT( abs(g4v - ddv) < precision_in_digits );
-  CPPUNIT_ASSERT( abs(g4v - ddsv) < precision_in_digits );
+  CPPUNIT_ASSERT( std::fabs(g4v - ddv) < precision_in_digits );
+  CPPUNIT_ASSERT( std::fabs(g4v - ddsv) < precision_in_digits );
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION( testCons );


### PR DESCRIPTION
Back-port of #21898 to cycle 10_0_X, move abs to std::fabs as discussed in the code review.
It will fix a unit test failure appearing after the VecGeom Geant4 geometry integration (known not to coincide up to the last digit with the other description).