### PR TITLE
Remove unused var in SimG4Core/Geometry

### DIFF
--- a/SimG4Core/Geometry/test/Parallelepiped_.cpp
+++ b/SimG4Core/Geometry/test/Parallelepiped_.cpp
@@ -49,7 +49,6 @@ testParallelepiped::matched_g4_and_dd( void )
   cout << "\tdd volume = " << ddv << " cm3" <<  endl;
   cout << "\tDD Information: " << dds << " vol=" << ddsv << " cm3" << endl;
   
-  const double tolerance = 1e-7;
 
   CPPUNIT_ASSERT( abs(g4v - ddv) < numeric_limits<float>::epsilon());
   CPPUNIT_ASSERT( abs(g4v - ddsv) < numeric_limits<float>::epsilon());


### PR DESCRIPTION
Fix the warning listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc630/CMSSW_10_1_X_2018-02-01-1100/SimG4Core/Geometry