### PR TITLE
DD Compact View Producer from DB

### DIFF
--- a/CondTools/Geometry/test/geometryCTPPStest_local.py
+++ b/CondTools/Geometry/test/geometryCTPPStest_local.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.AlCa.autoCond import autoCond
+
+process = cms.Process("GeometryTest")
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.source = cms.Source("EmptyIOVSource",
+                            lastValue = cms.uint64(3),
+                            timetype = cms.string('runnumber'),
+                            firstValue = cms.uint64(1),
+                            interval = cms.uint64(1)
+                            )
+
+process.GlobalTag.toGet = cms.VPSet(
+    cms.PSet(record = cms.string('GeometryFileRcd'),
+             tag = cms.string('XMLFILE_Geometry_TagXX_Extended2017_mc'),
+             connect = cms.string("sqlite_file:myfile.db"),
+#             label = cms.string("Extended")
+             )
+    )
+
+process.MessageLogger = cms.Service("MessageLogger")
+process.demo = cms.EDAnalyzer("PrintEventSetupContent")
+
+process.GeometryTester = cms.EDAnalyzer("GeometryTester",
+                                        XMLTest = cms.untracked.bool(True),
+                                        TrackerTest = cms.untracked.bool(False),
+                                        EcalTest = cms.untracked.bool(False),
+                                        HcalTest = cms.untracked.bool(False),
+                                        HGCalTest = cms.untracked.bool(False),
+                                        CaloTowerTest = cms.untracked.bool(False),
+                                        CastorTest = cms.untracked.bool(False),
+                                        ZDCTest = cms.untracked.bool(False),
+                                        CSCTest = cms.untracked.bool(False),
+                                        DTTest = cms.untracked.bool(False),
+                                        RPCTest = cms.untracked.bool(False),
+                                        geomLabel = cms.untracked.string("")
+                                        )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.p1 = cms.Path(process.GeometryTester) #replace this with process.demo if you want to see the PrintEventSetupContent output.
+

--- a/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_writer.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("GeometryWriter")
+
+process.load('CondCore.CondDB.CondDB_cfi')
+
+# This will read all the little XML files and from
+# that fill the DDCompactView. The modules that fill
+# the reco part of the database need the DDCompactView.
+# process.load('Geometry.VeryForwardGeometry.geometryRP_cfi')
+# from Geometry.VeryForwardGeometry.geometryRP_cfi import XMLIdealGeometryESSource_CTPPS
+# process.XMLIdealGeometryESSource = XMLIdealGeometryESSource_CTPPS.clone()
+
+process.source = cms.Source("EmptyIOVSource",
+                            lastValue = cms.uint64(1),
+                            timetype = cms.string('runnumber'),
+                            firstValue = cms.uint64(1),
+                            interval = cms.uint64(1)
+                            )
+
+# This reads the big XML file and the only way to fill the
+# nonreco part of the database is to read this file.  It
+# somewhat duplicates the information read from the little
+# XML files, but there is no way to directly build the
+# DDCompactView from this.
+process.XMLGeometryWriter = cms.EDAnalyzer("XMLGeometryBuilder",
+                                           XMLFileName = cms.untracked.string("./geSingleBigFile.xml"),
+                                           ZIP = cms.untracked.bool(True)
+                                           )
+
+process.CondDB.timetype = cms.untracked.string('runnumber')
+process.CondDB.connect = cms.string('sqlite_file:myfile.db')
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          process.CondDB,
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('GeometryFileRcd'),
+                                                                     tag = cms.string('XMLFILE_Geometry_TagXX_Extended2017_mc'))
+                                                            )
+                                          )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.p1 = cms.Path(process.XMLGeometryWriter)
+

--- a/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_writer.py
@@ -4,13 +4,6 @@ process = cms.Process("GeometryWriter")
 
 process.load('CondCore.CondDB.CondDB_cfi')
 
-# This will read all the little XML files and from
-# that fill the DDCompactView. The modules that fill
-# the reco part of the database need the DDCompactView.
-# process.load('Geometry.VeryForwardGeometry.geometryRP_cfi')
-# from Geometry.VeryForwardGeometry.geometryRP_cfi import XMLIdealGeometryESSource_CTPPS
-# process.XMLIdealGeometryESSource = XMLIdealGeometryESSource_CTPPS.clone()
-
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
                             timetype = cms.string('runnumber'),
@@ -33,7 +26,7 @@ process.CondDB.connect = cms.string('sqlite_file:myfile.db')
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDB,
                                           toPut = cms.VPSet(cms.PSet(record = cms.string('GeometryFileRcd'),
-                                                                     tag = cms.string('XMLFILE_Geometry_TagXX_Extended2017_mc'))
+                                                                     tag = cms.string('XMLFILE_CTPPS_Geometry_TagXX'))
                                                             )
                                           )
 

--- a/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_xmlwriter.py
+++ b/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_xmlwriter.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("GeometryXMLWriter")
+
+##process.load('Configuration.Geometry.GeometryExtended2017_cff')
+process.load('Geometry.VeryForwardGeometry.geometryRP_cfi')
+from Geometry.VeryForwardGeometry.geometryRP_cfi import XMLIdealGeometryESSource_CTPPS
+process.XMLIdealGeometryESSource = XMLIdealGeometryESSource_CTPPS.clone()
+
+process.source = cms.Source("EmptyIOVSource",
+                            lastValue = cms.uint64(1),
+                            timetype = cms.string('runnumber'),
+                            firstValue = cms.uint64(1),
+                            interval = cms.uint64(1)
+                            )
+
+process.BigXMLWriter = cms.EDAnalyzer("OutputDDToDDL",
+                              rotNumSeed = cms.int32(0),
+                              fileName = cms.untracked.string("./geSingleBigFile.xml")
+                              )
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.p1 = cms.Path(process.BigXMLWriter)
+

--- a/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_xmlwriter.py
+++ b/CondTools/Geometry/test/writehelpers/geometryCTPPS2017_xmlwriter.py
@@ -2,9 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("GeometryXMLWriter")
 
-##process.load('Configuration.Geometry.GeometryExtended2017_cff')
-process.load('Geometry.VeryForwardGeometry.geometryRP_cfi')
-from Geometry.VeryForwardGeometry.geometryRP_cfi import XMLIdealGeometryESSource_CTPPS
+process.load('Geometry.VeryForwardGeometry.geometryRPFromDD_cfi')
+from Geometry.VeryForwardGeometry.geometryRPFromDD_cfi import XMLIdealGeometryESSource_CTPPS
 process.XMLIdealGeometryESSource = XMLIdealGeometryESSource_CTPPS.clone()
 
 process.source = cms.Source("EmptyIOVSource",
@@ -15,9 +14,9 @@ process.source = cms.Source("EmptyIOVSource",
                             )
 
 process.BigXMLWriter = cms.EDAnalyzer("OutputDDToDDL",
-                              rotNumSeed = cms.int32(0),
-                              fileName = cms.untracked.string("./geSingleBigFile.xml")
-                              )
+                                      rotNumSeed = cms.int32(0),
+                                      fileName = cms.untracked.string("./geSingleBigFile.xml")
+                                      )
 
 
 process.maxEvents = cms.untracked.PSet(

--- a/Geometry/VeryForwardGeometry/python/geometryRPFromDB_cfi.py
+++ b/Geometry/VeryForwardGeometry/python/geometryRPFromDB_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+XMLIdealGeometryESSource_CTPPS = cms.ESProducer("XMLIdealCTPPSGeometryESProducer",
+                                                rootDDName = cms.string('cms:CMSE'),
+                                                label = cms.string(''),
+                                                appendToDataLabel = cms.string('XMLIdealGeometryESSource_CTPPS')
+                                                )
+
+ctppsGeometryESModule = cms.ESProducer("CTPPSGeometryESModule",
+    verbosity = cms.untracked.uint32(1),
+    compactViewTag = cms.string('XMLIdealGeometryESSource_CTPPS')
+)

--- a/Geometry/VeryForwardGeometry/python/geometryRPFromDD_cfi.py
+++ b/Geometry/VeryForwardGeometry/python/geometryRPFromDD_cfi.py
@@ -1,0 +1,148 @@
+import FWCore.ParameterSet.Config as cms
+
+# common and strip files
+totemGeomXMLFiles = cms.vstring(
+    'Geometry/CMSCommonData/data/materials.xml',
+    'Geometry/CMSCommonData/data/rotations.xml',
+    'Geometry/CMSCommonData/data/extend/cmsextent.xml',
+    'Geometry/CMSCommonData/data/cms/2017/v1/cms.xml',
+    'Geometry/CMSCommonData/data/beampipe/2017/v1/beampipe.xml',
+    'Geometry/CMSCommonData/data/cmsBeam.xml',
+    'Geometry/CMSCommonData/data/cmsMother.xml',
+    'Geometry/CMSCommonData/data/mgnt.xml',
+    'Geometry/ForwardCommonData/data/forward.xml',
+    'Geometry/ForwardCommonData/data/totemRotations.xml',
+    'Geometry/ForwardCommonData/data/totemMaterials.xml',
+    'Geometry/ForwardCommonData/data/totemt1.xml',
+    'Geometry/ForwardCommonData/data/totemt2.xml',
+    'Geometry/ForwardCommonData/data/ionpump.xml',
+    'Geometry/VeryForwardData/data/RP_Box.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_000.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_001.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_002.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_003.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_004.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_005.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_020.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_021.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_022.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_023.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_024.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_025.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_100.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_101.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_102.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_103.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_104.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_105.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_120.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_121.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_122.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_123.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_124.xml',
+    'Geometry/VeryForwardData/data/RP_Box/RP_Box_125.xml',
+    'Geometry/VeryForwardData/data/RP_Hybrid.xml',
+    'Geometry/VeryForwardData/data/RP_Materials.xml',
+    'Geometry/VeryForwardData/data/RP_Transformations.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_000.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_001.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_002.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_003.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_004.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_005.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_020.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_021.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_022.xml',
+    #'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_023.xml', # this RP is now equipped with pixels
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_024.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_025.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_100.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_101.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_102.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_103.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_104.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_105.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_120.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_121.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_122.xml',
+    #'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_123.xml', # this RP is now equipped with pixels
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_124.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_125.xml',
+    'Geometry/VeryForwardData/data/RP_Device.xml',
+    'Geometry/VeryForwardData/data/RP_Vertical_Device.xml',
+    'Geometry/VeryForwardData/data/RP_Horizontal_Device.xml',
+    'Geometry/VeryForwardData/data/RP_220_Right_Station.xml',
+    'Geometry/VeryForwardData/data/RP_220_Left_Station.xml',
+    'Geometry/VeryForwardData/data/RP_147_Right_Station.xml',
+    'Geometry/VeryForwardData/data/RP_147_Left_Station.xml',
+    'Geometry/VeryForwardData/data/RP_Stations_Assembly.xml',
+    'Geometry/VeryForwardData/data/RP_Sensitive_Dets.xml',
+    'Geometry/VeryForwardData/data/RP_Cuts_Per_Region.xml',
+    'Geometry/VeryForwardData/data/RP_Param_Beam_Region.xml'
+)
+
+# diamond files
+ctppsDiamondGeomXMLFiles = cms.vstring(
+    # diamond detectors
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Materials.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Transformations.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_X_Distance.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Parameters.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Station_Parameters.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Horizontal_Pot.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Positive_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Negative_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Stations_Assembly.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern1_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern2_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern2_Segment2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment4.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment4.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment5.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane3.xml',
+    #'Geometry/VeryForwardData/data/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane4.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Detector_Assembly.xml'
+)
+
+# UFSD files
+ctppsUFSDGeomXMLFiles = cms.vstring(
+    # UFSDetectors
+    'Geometry/VeryForwardData/data/CTPPS_UFSD_Segments/CTPPS_UFSD_Pattern1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_UFSD_Segments/CTPPS_UFSD_Pattern2_SegmentA.xml',
+    'Geometry/VeryForwardData/data/CTPPS_UFSD_Segments/CTPPS_UFSD_Pattern2_SegmentB.xml',
+    'Geometry/VeryForwardData/data/CTPPS_UFSD_Planes/CTPPS_UFSD_Plane4.xml',
+    'Geometry/VeryForwardData/data/CTPPS_UFSD_Parameters.xml',
+    #'Geometry/VeryForwardData/data/CTPPS_UFSD_Detector_Assembly.xml',
+)
+
+# pixel files
+ctppsPixelGeomXMLFiles = cms.vstring(
+    'Geometry/VeryForwardData/data/ppstrackerMaterials.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_Module.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_Module_2x2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_Assembly_Box_Real_023.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_Assembly_Box_Real_123.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_Sens.xml'
+)
+
+XMLIdealGeometryESSource_CTPPS = cms.ESSource("XMLIdealGeometryESSource",
+    geomXMLFiles = totemGeomXMLFiles + ctppsDiamondGeomXMLFiles + ctppsUFSDGeomXMLFiles + ctppsPixelGeomXMLFiles,
+    rootNodeName = cms.string('cms:CMSE')
+)
+
+# position of RPs
+XMLIdealGeometryESSource_CTPPS.geomXMLFiles.append("Geometry/VeryForwardData/data/2016_ctpps_15sigma_margin0/RP_Dist_Beam_Cent.xml")
+
+ctppsGeometryESModule = cms.ESProducer("CTPPSGeometryESModule",
+    verbosity = cms.untracked.uint32(1),
+    compactViewTag = cms.string('XMLIdealGeometryESSource_CTPPS')
+)

--- a/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESProducer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESProducer.cc
@@ -1,31 +1,7 @@
-// -*- C++ -*-
-//
-// Package:    XMLIdealGeometryESProducer
-// Class:      XMLIdealGeometryESProducer
-// 
-/**\class XMLIdealGeometryESProducer XMLIdealGeometryESProducer.h GeometryReaders/XMLIdealGeometryESProducer/src/XMLIdealGeometryESProducer.cc
-
- Description: <one line class summary>
-
- Implementation:
-     <Notes on implementation>
-*/
-//
-// Original Author:  Mike Case
-//         Created:  Fri Jan 16 01:45:49 CET 2009
-
-
-
-// system include files
-#include <memory>
-
-// user include files
-#include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
-
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
-
+#include "FWCore/Framework/interface/ModuleFactory.h"
 #include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "DetectorDescription/Core/interface/DDRoot.h"
 #include "DetectorDescription/Parser/interface/DDLParser.h"
@@ -33,110 +9,52 @@
 #include "Geometry/Records/interface/GeometryFileRcd.h"
 #include "CondFormats/Common/interface/FileBlob.h"
 
-#include "DetectorDescription/Core/interface/DDMaterial.h"
-#include "DetectorDescription/Core/interface/DDSolid.h"
-#include "DetectorDescription/Core/interface/DDSpecifics.h"
-#include "DetectorDescription/Core/interface/DDRotationMatrix.h"
+#include <memory>
 
-#include "DetectorDescription/Core/src/Material.h"
-#include "DetectorDescription/Core/src/Solid.h"
-#include "DetectorDescription/Core/src/LogicalPart.h"
-#include "DetectorDescription/Core/src/Specific.h"
-
-//
-// class decleration
-//
-
-class XMLIdealGeometryESProducer : public edm::ESProducer {
+class XMLIdealGeometryESProducer : public edm::ESProducer
+{
 public:
   XMLIdealGeometryESProducer(const edm::ParameterSet&);
-  ~XMLIdealGeometryESProducer() override;
   
-  typedef std::unique_ptr<DDCompactView> ReturnType;
+  using ReturnType = std::unique_ptr<DDCompactView>;
   
   ReturnType produce(const IdealGeometryRecord&);
+
 private:
-  // ----------member data ---------------------------
+
   std::string rootDDName_; // this must be the form namespace:name
   std::string label_;
-    // 2009-07-09 memory patch
-    // for copying and protecting DD Store's after parsing is complete.
-    DDI::Store<DDName, DDI::Material*> matStore_;
-    DDI::Store<DDName, DDI::Solid*> solidStore_;
-    DDI::Store<DDName, DDI::LogicalPart*> lpStore_;
-    DDI::Store<DDName, DDI::Specific*> specStore_;
-    DDI::Store<DDName, DDRotationMatrix*> rotStore_;    
+  std::string compactViewTag_;
 };
 
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
-XMLIdealGeometryESProducer::XMLIdealGeometryESProducer(const edm::ParameterSet& iConfig)
-  :   rootDDName_(iConfig.getParameter<std::string>("rootDDName")),
-      label_(iConfig.getParameter<std::string>("label"))
+XMLIdealGeometryESProducer::XMLIdealGeometryESProducer( const edm::ParameterSet& iConfig )
+  : rootDDName_( iConfig.getParameter<std::string>( "rootDDName" )),
+    label_( iConfig.getParameter<std::string>( "label" )),
+    compactViewTag_( iConfig.getUntrackedParameter<std::string>( "compactViewTag", "" ))
 {
-   //the following line is needed to tell the framework what
-   // data is being produced
-   setWhatProduced(this);
-   //now do what ever other initialization is needed
+  setWhatProduced( this, compactViewTag_ );
 }
 
-
-XMLIdealGeometryESProducer::~XMLIdealGeometryESProducer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
-}
-
-
-//
-// member functions
-//
-
-// ------------ method called to produce the data  ------------
 XMLIdealGeometryESProducer::ReturnType
-XMLIdealGeometryESProducer::produce(const IdealGeometryRecord& iRecord)
+XMLIdealGeometryESProducer::produce( const IdealGeometryRecord& iRecord )
 {
-   using namespace edm::es;
-
-   edm::ESTransientHandle<FileBlob> gdd;
-   iRecord.getRecord<GeometryFileRcd>().get( label_, gdd );
-//    if ( gdd.isValid() ) {
-//      std::cout << "gdd.isValid()" << std::endl; 
-//      if (gdd.product() != 0) {
-//        std::cout << "object address is not zero" << std::endl;
-//      } else {
-//        std::cout << "object address is zero" << std::endl;
-//      }
-//    } else {
-//      std::cout << "gdd is NOT valid" << std::endl;
-//    }
-   DDName ddName(rootDDName_);
-   DDLogicalPart rootNode(ddName);
-   DDRootDef::instance().set(rootNode);
-   ReturnType returnValue(new DDCompactView(rootNode));
-   DDLParser parser(*returnValue);
-   parser.getDDLSAX2FileHandler()->setUserNS(true);
-   parser.clearFiles();
-
-   std::unique_ptr<std::vector<unsigned char> > tb = (*gdd).getUncompressedBlob();
-
-   parser.parse(*tb, tb->size());
-
-   //std::cout << "In XMLIdealGeometryESProducer::produce" << std::endl;
-   returnValue->lockdown();
-
-   return returnValue ;
+  edm::ESTransientHandle<FileBlob> gdd;
+  iRecord.getRecord<GeometryFileRcd>().get( label_, gdd );
+  DDName ddName( rootDDName_ );
+  DDLogicalPart rootNode( ddName );
+  DDRootDef::instance().set( rootNode );
+  auto cpv = std::make_unique<DDCompactView>( rootNode );
+  DDLParser parser( *cpv );
+  parser.getDDLSAX2FileHandler()->setUserNS( true );
+  parser.clearFiles();
+  
+  std::unique_ptr<std::vector<unsigned char> > tb = (*gdd).getUncompressedBlob();
+  
+  parser.parse( *tb, tb->size());
+  
+  cpv->lockdown();
+  
+  return cpv;
 }
 
 //define this as a plug-in

--- a/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESProducer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESProducer.cc
@@ -24,15 +24,13 @@ private:
 
   std::string rootDDName_; // this must be the form namespace:name
   std::string label_;
-  std::string compactViewTag_;
 };
 
 XMLIdealGeometryESProducer::XMLIdealGeometryESProducer( const edm::ParameterSet& iConfig )
   : rootDDName_( iConfig.getParameter<std::string>( "rootDDName" )),
-    label_( iConfig.getParameter<std::string>( "label" )),
-    compactViewTag_( iConfig.getUntrackedParameter<std::string>( "compactViewTag", "" ))
+    label_( iConfig.getParameter<std::string>( "label" ))
 {
-  setWhatProduced( this, compactViewTag_ );
+  setWhatProduced( this );
 }
 
 XMLIdealGeometryESProducer::ReturnType


### PR DESCRIPTION
*  Cleanup a DDCompactView producer from DB XML

This allows to pick up CTPPS geometry from DB with the following modifications to Geometry/VeryForwardGeometry/python/geometryRP_cfi.py:

```
import FWCore.ParameterSet.Config as cms

XMLIdealGeometryESSource_CTPPS = cms.ESProducer("XMLIdealGeometryESProducer",
                                                rootDDName = cms.string('cms:CMSE'),
                                                label = cms.string(''),
                                                appendToDataLabel = cms.untracked.string('XMLIdealGeometryESSource_CTPPS')
                                                )

ctppsGeometryESModule = cms.ESProducer("CTPPSGeometryESModule",
    verbosity = cms.untracked.uint32(1),
    compactViewTag = cms.string('XMLIdealGeometryESSource_CTPPS')
)

```

Note, the following addition to a job configuration is needed to pick up the record from a local DB:

```
$ diff testTracks-fromDB.py testTracks.py 
42,48d41
< process.GlobalTag.toGet = cms.VPSet(
<     cms.PSet(record = cms.string('GeometryFileRcd'),
<              tag = cms.string('XMLFILE_Geometry_TagXX_Extended2017_mc'),
<              connect = cms.string("sqlite_file:myfile.db"),
< #             label = cms.string("Extended")
<              )
<     )
52d44
<
```
See https://github.com/cms-sw/cmssw/pull/21974