### PR TITLE
Pass const ref to ALCT and CLCT in CSCMotherboard

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
@@ -424,10 +424,7 @@ void CSCGEMMotherboardME21::correlateLCTsGEM(CSCALCTDigi& bestALCT, CSCALCTDigi&
     }
   } else {
     // run without gems - happens in less than 0.04% of the time
-    lct1 = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
-    lct1.setTrknmb(1);
-
-    lct2 = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
-    lct2.setTrknmb(2);
+    lct1 = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 1);
+    lct2 = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 2);
   }
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -549,10 +549,15 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::getLCTs() {
   return tmpV;
 }
 
-void CSCMotherboard::correlateLCTs(CSCALCTDigi bestALCT,
-                                   CSCALCTDigi secondALCT,
-                                   CSCCLCTDigi bestCLCT,
-                                   CSCCLCTDigi secondCLCT) {
+void CSCMotherboard::correlateLCTs(const CSCALCTDigi& bALCT,
+                                   const CSCALCTDigi& sALCT,
+                                   const CSCCLCTDigi& bCLCT,
+                                   const CSCCLCTDigi& sCLCT)
+{
+  CSCALCTDigi bestALCT = bALCT;
+  CSCALCTDigi secondALCT = sALCT;
+  CSCCLCTDigi bestCLCT = bCLCT;
+  CSCCLCTDigi secondCLCT = sCLCT;
 
   bool anodeBestValid     = bestALCT.isValid();
   bool anodeSecondValid   = secondALCT.isValid();
@@ -569,11 +574,10 @@ void CSCMotherboard::correlateLCTs(CSCALCTDigi bestALCT,
   if ((alct_trig_enable  && bestALCT.isValid()) ||
       (clct_trig_enable  && bestCLCT.isValid()) ||
       (match_trig_enable && bestALCT.isValid() && bestCLCT.isValid())) {
-    CSCCorrelatedLCTDigi lct = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::CLCTALCT);
+    CSCCorrelatedLCTDigi lct = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::CLCTALCT, 1);
     int bx = lct.getBX();
     if (bx >= 0 && bx < CSCConstants::MAX_LCT_TBINS) {
       firstLCT[bx] = lct;
-      firstLCT[bx].setTrknmb(1);
     }
     else {
       if (infoV > 0) edm::LogWarning("L1CSCTPEmulatorOutOfTimeLCT")
@@ -587,11 +591,10 @@ void CSCMotherboard::correlateLCTs(CSCALCTDigi bestALCT,
       ((alct_trig_enable  && secondALCT.isValid()) ||
        (clct_trig_enable  && secondCLCT.isValid()) ||
        (match_trig_enable && secondALCT.isValid() && secondCLCT.isValid()))) {
-    CSCCorrelatedLCTDigi lct = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::CLCTALCT);
+    CSCCorrelatedLCTDigi lct = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::CLCTALCT, 2);
     int bx = lct.getBX();
     if (bx >= 0 && bx < CSCConstants::MAX_LCT_TBINS) {
       secondLCT[bx] = lct;
-      secondLCT[bx].setTrknmb(2);
     }
     else {
       if (infoV > 0) edm::LogWarning("L1CSCTPEmulatorOutOfTimeLCT")
@@ -606,7 +609,8 @@ void CSCMotherboard::correlateLCTs(CSCALCTDigi bestALCT,
 // constructor of correlated LCTs.
 CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
                                                    const CSCCLCTDigi& cLCT,
-                                                   int type) const {
+                                                   int type,
+                                                   int trknmb) const {
   // CLCT pattern number
   unsigned int pattern = encodePattern(cLCT.getPattern(), cLCT.getStripType());
 
@@ -616,8 +620,7 @@ CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
   // Bunch crossing: get it from cathode LCT if anode LCT is not there.
   int bx = aLCT.isValid() ? aLCT.getBX() : cLCT.getBX();
 
-  // construct correlated LCT; temporarily assign track number of 0.
-  int trknmb = 0;
+  // construct correlated LCT
   CSCCorrelatedLCTDigi thisLCT(trknmb, 1, quality, aLCT.getKeyWG(),
                                cLCT.getKeyStrip(), pattern, cLCT.getBend(),
                                bx, 0, 0, 0, theTrigChamber);

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -142,12 +142,20 @@ class CSCMotherboard
   /** Make sure that the parameter values are within the allowed range. */
   void checkConfigParameters();
 
-  void correlateLCTs(CSCALCTDigi bestALCT, CSCALCTDigi secondALCT,
-                     CSCCLCTDigi bestCLCT, CSCCLCTDigi secondCLCT);
+  void correlateLCTs(const CSCALCTDigi& bestALCT, const CSCALCTDigi& secondALCT,
+                     const CSCCLCTDigi& bestCLCT, const CSCCLCTDigi& secondCLCT);
+
+  // This method calculates all the TMB words and then passes them to the
+  // constructor of correlated LCTs.
   CSCCorrelatedLCTDigi constructLCTs(const CSCALCTDigi& aLCT,
                                      const CSCCLCTDigi& cLCT,
-                                     int type) const;
+                                     int type, int trknmb) const;
+
+  // CLCT pattern number: encodes the pattern number itself and
+  // whether the pattern consists of half-strips or di-strips.
   unsigned int encodePattern(const int ptn, const int highPt) const;
+
+  // 4-bit LCT quality number.Made by TMB lookup tables and used for MPC sorting.
   unsigned int findQuality(const CSCALCTDigi& aLCT, const CSCCLCTDigi& cLCT) const;
 
   enum LCT_Quality{

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -388,13 +388,13 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc,
 }
 
 
-std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::readoutLCTs1a()
+std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::readoutLCTs1a() const
 {
   return readoutLCTs(ME1A);
 }
 
 
-std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::readoutLCTs1b()
+std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::readoutLCTs1b() const
 {
   return readoutLCTs(ME1B);
 }
@@ -403,7 +403,7 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::readoutLCTs1b()
 // Returns vector of read-out correlated LCTs, if any.  Starts with
 // the vector of all found LCTs and selects the ones in the read-out
 // time window.
-std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::readoutLCTs(int me1ab)
+std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::readoutLCTs(int me1ab) const
 {
   std::vector<CSCCorrelatedLCTDigi> tmpV;
 
@@ -452,7 +452,7 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::readoutLCTs(int me1ab)
 
 
 // Returns vector of found correlated LCTs, if any.
-std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::getLCTs1b()
+std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::getLCTs1b() const
 {
   std::vector<CSCCorrelatedLCTDigi> tmpV;
 
@@ -464,7 +464,7 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::getLCTs1b()
 }
 
 // Returns vector of found correlated LCTs, if any.
-std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::getLCTs1a()
+std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::getLCTs1a() const
 {
   std::vector<CSCCorrelatedLCTDigi> tmpV;
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -136,8 +136,6 @@ void CSCMotherboardME11::clear()
   if (clct1a) clct1a->clear();
   for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++)
   {
-    //firstLCT1a[bx].clear();
-    //secondLCT1a[bx].clear();
     for (unsigned int mbx = 0; mbx < match_trig_window_size; mbx++)
       for (int i=0;i<CSCConstants::MAX_LCTS_PER_CSC;i++)
       {
@@ -521,7 +519,7 @@ void CSCMotherboardME11::correlateLCTs(const CSCALCTDigi& bALCT,
                                        const CSCCLCTDigi& sCLCT,
                                        CSCCorrelatedLCTDigi& lct1,
                                        CSCCorrelatedLCTDigi& lct2,
-                                       int me)
+                                       int me) const
 {
   // assume that always anodeBestValid && cathodeBestValid
   CSCALCTDigi bestALCT = bALCT;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -480,7 +480,7 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboardME11::getLCTs1a()
 }
 
 
-bool CSCMotherboardME11::doesALCTCrossCLCT(CSCALCTDigi &a, CSCCLCTDigi &c, int me)
+bool CSCMotherboardME11::doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi &c, int me) const
 {
   if ( !c.isValid() || !a.isValid() ) return false;
   int key_hs = c.getKeyStrip();

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -515,15 +515,19 @@ bool CSCMotherboardME11::doesALCTCrossCLCT(CSCALCTDigi &a, CSCCLCTDigi &c, int m
 }
 
 
-void CSCMotherboardME11::correlateLCTs(CSCALCTDigi bestALCT,
-				   CSCALCTDigi secondALCT,
-				   CSCCLCTDigi bestCLCT,
-				   CSCCLCTDigi secondCLCT,
-				   CSCCorrelatedLCTDigi& lct1,
-				   CSCCorrelatedLCTDigi& lct2,
-                                   int me)
+void CSCMotherboardME11::correlateLCTs(const CSCALCTDigi& bALCT,
+                                       const CSCALCTDigi& sALCT,
+                                       const CSCCLCTDigi& bCLCT,
+                                       const CSCCLCTDigi& sCLCT,
+                                       CSCCorrelatedLCTDigi& lct1,
+                                       CSCCorrelatedLCTDigi& lct2,
+                                       int me)
 {
   // assume that always anodeBestValid && cathodeBestValid
+  CSCALCTDigi bestALCT = bALCT;
+  CSCALCTDigi secondALCT = sALCT;
+  CSCCLCTDigi bestCLCT = bCLCT;
+  CSCCLCTDigi secondCLCT = sCLCT;
 
   if (secondALCT == bestALCT) secondALCT.clear();
   if (secondCLCT == bestCLCT) secondCLCT.clear();
@@ -573,38 +577,34 @@ void CSCMotherboardME11::correlateLCTs(CSCALCTDigi bestALCT,
 
   switch (lut[code][0]) {
     case 11:
-      lct1 = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
+      lct1 = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 1);
       break;
     case 12:
-      lct1 = constructLCTs(bestALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
+      lct1 = constructLCTs(bestALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 1);
       break;
     case 21:
-      lct1 = constructLCTs(secondALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
+      lct1 = constructLCTs(secondALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 1);
       break;
     case 22:
-      lct1 = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
+      lct1 = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 1);
       break;
     default: return;
   }
-  lct1.setTrknmb(1);
 
   if (dbg) LogTrace("CSCMotherboardME11")<<"lct1: "<<lct1<<std::endl;
 
   switch (lut[code][1])
   {
     case 12:
-      lct2 = constructLCTs(bestALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
-      lct2.setTrknmb(2);
+      lct2 = constructLCTs(bestALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 2);
       if (dbg) LogTrace("CSCMotherboardME11")<<"lct2: "<<lct2<<std::endl;
       return;
     case 21:
-      lct2 = constructLCTs(secondALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
-      lct2.setTrknmb(2);
+      lct2 = constructLCTs(secondALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 2);
       if (dbg) LogTrace("CSCMotherboardME11")<<"lct2: "<<lct2<<std::endl;
       return;
     case 22:
-      lct2 = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
-      lct2.setTrknmb(2);
+      lct2 = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 2);
       if (dbg) LogTrace("CSCMotherboardME11")<<"lct2: "<<lct2<<std::endl;
       return;
     default: return;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
@@ -74,12 +74,6 @@ class CSCMotherboardME11 : public CSCMotherboard
 
   bool doesALCTCrossCLCT(CSCALCTDigi &a, CSCCLCTDigi &c, int me);
 
-  /** Container for first correlated LCT in ME1a. */
-  //CSCCorrelatedLCTDigi firstLCT1a[CSCConstants::MAX_LCT_TBINS];
-
-  /** Container for second correlated LCT in ME1a. */
-  //CSCCorrelatedLCTDigi secondLCT1a[CSCConstants::MAX_LCT_TBINS];
-
   /** for the case when more than 2 LCTs/BX are allowed;
       maximum match window = 15 */
   CSCCorrelatedLCTDigi allLCTs1b[CSCConstants::MAX_LCT_TBINS][15][2];
@@ -90,7 +84,7 @@ class CSCMotherboardME11 : public CSCMotherboard
                      const CSCCLCTDigi& bestCLCT,
                      const CSCCLCTDigi& secondCLCT,
                      CSCCorrelatedLCTDigi& lct1,
-                     CSCCorrelatedLCTDigi& lct2, int me);
+                     CSCCorrelatedLCTDigi& lct2, int me) const;
 
   std::vector<CSCALCTDigi> alctV;
   std::vector<CSCCLCTDigi> clctV1b;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
@@ -36,8 +36,8 @@ class CSCMotherboardME11 : public CSCMotherboard
 	   const CSCComparatorDigiCollection* compdc);
 
   /** Returns vectors of found correlated LCTs in ME1a and ME1b, if any. */
-  std::vector<CSCCorrelatedLCTDigi> getLCTs1a();
-  std::vector<CSCCorrelatedLCTDigi> getLCTs1b();
+  std::vector<CSCCorrelatedLCTDigi> getLCTs1a() const;
+  std::vector<CSCCorrelatedLCTDigi> getLCTs1b() const;
 
   /** Returns vectors of found ALCTs in ME1a and ME1b, if any. */
   std::vector<CSCALCTDigi> getALCTs1b() const {return alctV;}
@@ -56,9 +56,9 @@ class CSCMotherboardME11 : public CSCMotherboard
   /** additional Cathode LCT processor for ME1a */
   std::unique_ptr<CSCCathodeLCTProcessor> clct1a;
 
-  std::vector<CSCCorrelatedLCTDigi> readoutLCTs1a();
-  std::vector<CSCCorrelatedLCTDigi> readoutLCTs1b();
-  std::vector<CSCCorrelatedLCTDigi> readoutLCTs(int me1ab);
+  std::vector<CSCCorrelatedLCTDigi> readoutLCTs1a() const;
+  std::vector<CSCCorrelatedLCTDigi> readoutLCTs1b() const;
+  std::vector<CSCCorrelatedLCTDigi> readoutLCTs(int me1ab) const;
 
  private:
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
@@ -40,11 +40,11 @@ class CSCMotherboardME11 : public CSCMotherboard
   std::vector<CSCCorrelatedLCTDigi> getLCTs1b() const;
 
   /** Returns vectors of found ALCTs in ME1a and ME1b, if any. */
-  std::vector<CSCALCTDigi> getALCTs1b() const {return alctV;}
+  const std::vector<CSCALCTDigi>& getALCTs1b() const {return alctV;}
 
   /** Returns vectors of found CLCTs in ME1a and ME1b, if any. */
-  std::vector<CSCCLCTDigi> getCLCTs1a() const {return clctV1a;}
-  std::vector<CSCCLCTDigi> getCLCTs1b() const {return clctV1b;}
+  const std::vector<CSCCLCTDigi>& getCLCTs1a() const {return clctV1a;}
+  const std::vector<CSCCLCTDigi>& getCLCTs1b() const {return clctV1b;}
 
   /** Clears correlated LCT and passes clear signal on to cathode and anode
       LCT processors. */

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
@@ -72,7 +72,7 @@ class CSCMotherboardME11 : public CSCMotherboard
   /** SLHC: special configuration parameters for ME11 treatment. */
   bool smartME1aME1b, disableME1a, gangedME1a;
 
-  bool doesALCTCrossCLCT(CSCALCTDigi &a, CSCCLCTDigi &c, int me);
+  bool doesALCTCrossCLCT(const CSCALCTDigi &a, const CSCCLCTDigi &c, int me) const;
 
   /** for the case when more than 2 LCTs/BX are allowed;
       maximum match window = 15 */

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
@@ -85,9 +85,12 @@ class CSCMotherboardME11 : public CSCMotherboard
   CSCCorrelatedLCTDigi allLCTs1b[CSCConstants::MAX_LCT_TBINS][15][2];
   CSCCorrelatedLCTDigi allLCTs1a[CSCConstants::MAX_LCT_TBINS][15][2];
 
-  void correlateLCTs(CSCALCTDigi bestALCT, CSCALCTDigi secondALCT,
-		     CSCCLCTDigi bestCLCT, CSCCLCTDigi secondCLCT,
-		     CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2, int me);
+  void correlateLCTs(const CSCALCTDigi& bestALCT,
+                     const CSCALCTDigi& secondALCT,
+                     const CSCCLCTDigi& bestCLCT,
+                     const CSCCLCTDigi& secondCLCT,
+                     CSCCorrelatedLCTDigi& lct1,
+                     CSCCorrelatedLCTDigi& lct2, int me);
 
   std::vector<CSCALCTDigi> alctV;
   std::vector<CSCCLCTDigi> clctV1b;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.cc
@@ -174,10 +174,15 @@ CSCMotherboardME3141::run(const CSCWireDigiCollection* wiredc,
   }
 }
 
-void CSCMotherboardME3141::correlateLCTs(CSCALCTDigi& bestALCT, CSCALCTDigi& secondALCT,
-                                         CSCCLCTDigi& bestCLCT, CSCCLCTDigi& secondCLCT,
-                                         CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2)
+void CSCMotherboardME3141::correlateLCTs(const CSCALCTDigi& bALCT, const CSCALCTDigi& sALCT,
+                                         const CSCCLCTDigi& bCLCT, const CSCCLCTDigi& sCLCT,
+                                         CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2) const
 {
+  CSCALCTDigi bestALCT = bALCT;
+  CSCALCTDigi secondALCT = sALCT;
+  CSCCLCTDigi bestCLCT = bCLCT;
+  CSCCLCTDigi secondCLCT = sCLCT;
+
   const bool anodeBestValid     = bestALCT.isValid();
   const bool anodeSecondValid   = secondALCT.isValid();
   const bool cathodeBestValid   = bestCLCT.isValid();
@@ -193,16 +198,14 @@ void CSCMotherboardME3141::correlateLCTs(CSCALCTDigi& bestALCT, CSCALCTDigi& sec
   if ((alct_trig_enable  and bestALCT.isValid()) or
       (clct_trig_enable  and bestCLCT.isValid()) or
       (match_trig_enable and bestALCT.isValid() and bestCLCT.isValid())){
-    lct1 = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
-    lct1.setTrknmb(1);
+    lct1 = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 1);
   }
 
   if (((secondALCT != bestALCT) or (secondCLCT != bestCLCT)) and
       ((alct_trig_enable  and secondALCT.isValid()) or
        (clct_trig_enable  and secondCLCT.isValid()) or
        (match_trig_enable and secondALCT.isValid() and secondCLCT.isValid()))){
-    lct2 = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
-    lct2.setTrknmb(2);
+    lct2 = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT, 2);
   }
 }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME3141.h
@@ -26,9 +26,9 @@ public:
   void run(const CSCWireDigiCollection* wiredc,
            const CSCComparatorDigiCollection* compdc);
 
-  void correlateLCTs(CSCALCTDigi& bestALCT, CSCALCTDigi& secondALCT,
-                     CSCCLCTDigi& bestCLCT, CSCCLCTDigi& secondCLCT,
-                     CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2);
+  void correlateLCTs(const CSCALCTDigi& bestALCT, const CSCALCTDigi& secondALCT,
+                     const CSCCLCTDigi& bestCLCT, const CSCCLCTDigi& secondCLCT,
+                     CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2) const;
 
   /* readout the two best LCTs in this CSC */
   std::vector<CSCCorrelatedLCTDigi> readoutLCTs() const;


### PR DESCRIPTION
This pull request provides a solution for https://github.com/cms-sw/cmssw/issues/22074 in `CSCMotherboard`. A similar solution is presented for `CSCMotherboardME11`. 

Pass `const &` to object instead of a copy. A few functions in the motherboards were made `const`. Commented code was removed from `CSCMotherboardME11`

@tahuang1991 @fabiocos 