### PR TITLE
Adding capability to write out Ptrs in JetConstituentSelector (Backport of #22092)

### DIFF
--- a/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
@@ -42,7 +42,7 @@ public:
   JetConstituentSelector(edm::ParameterSet const& params) :
     srcToken_{consumes<edm::View<T>>(params.getParameter<edm::InputTag>("src"))},
     selector_{params.getParameter<std::string>("cut")},
-    unpackAK8_{params.existsAs<bool>("unpackAK8") ? params.getParameter<bool>("unpackAK8") : false}
+    unpackAK8_{params.getParameter<bool>("unpackAK8")}
   {
     produces<JetsOutput>();
     produces<ConstituentsOutput>("constituents");
@@ -54,7 +54,7 @@ public:
     desc.add<edm::InputTag>("src")->setComment("InputTag used for retrieving jets in event.");
     desc.add<std::string>("cut")->setComment("Cut used by which to select jets.  For example:\n"
                                              "  \"pt > 100.0 && abs(rapidity()) < 2.4\".");
-    desc.add<bool>("unpackAK8")->setComment("Assume the jets are AK8 jets from miniAOD and need to be unpacked.");
+    desc.add<bool>("unpackAK8", false)->setComment("Assume the jets are AK8 jets from miniAOD and need to be unpacked.");
 
     // addDefault must be used here instead of add unless this function is specialized
     // for different sets of template parameter types. Each specialization would need

--- a/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
@@ -20,6 +20,7 @@
 #include "DataFormats/JetReco/interface/GenJet.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -27,16 +28,21 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
+
+
+
 template <class T, typename C = std::vector<typename T::ConstituentTypeFwdPtr>>
 class JetConstituentSelector : public edm::stream::EDProducer<> {
 public:
 
   using JetsOutput = std::vector<T>;
   using ConstituentsOutput = C;
-
+  using ValueType = typename C::value_type;
+  
   JetConstituentSelector(edm::ParameterSet const& params) :
     srcToken_{consumes<edm::View<T>>(params.getParameter<edm::InputTag>("src"))},
-    selector_{params.getParameter<std::string>("cut")}
+    selector_{params.getParameter<std::string>("cut")},
+    unpackAK8_{params.existsAs<bool>("unpackAK8") ? params.getParameter<bool>("unpackAK8") : false}
   {
     produces<JetsOutput>();
     produces<ConstituentsOutput>("constituents");
@@ -48,12 +54,18 @@ public:
     desc.add<edm::InputTag>("src")->setComment("InputTag used for retrieving jets in event.");
     desc.add<std::string>("cut")->setComment("Cut used by which to select jets.  For example:\n"
                                              "  \"pt > 100.0 && abs(rapidity()) < 2.4\".");
+    desc.add<bool>("unpackAK8")->setComment("Assume the jets are AK8 jets from miniAOD and need to be unpacked.");
 
     // addDefault must be used here instead of add unless this function is specialized
     // for different sets of template parameter types. Each specialization would need
     // a different module label. Otherwise the generated cfi filenames will conflict
     // for the different plugins.
     descriptions.addDefault(desc);
+  }
+
+  // Default initialization is for edm::FwdPtr. Specialization (below) is for edm::Ptr.
+  typename  ConstituentsOutput::value_type const initptr( edm::Ptr<reco::Candidate> const & dau) const{
+    return typename ConstituentsOutput::value_type( dau, dau );
   }
 
   void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) override
@@ -64,15 +76,34 @@ public:
     edm::Handle<edm::View<T>> h_jets;
     iEvent.getByToken(srcToken_, h_jets);
 
+    
     // Now set the Ptrs with the orphan handles.
     for (auto const& jet : *h_jets) {
       // Check the selection
       if (selector_(jet)) {
-        // Add the jets that pass to the output collection
-        jets->push_back(jet);
-        for (unsigned int ida {}; ida < jet.numberOfDaughters(); ++ida) {
-          candsOut->emplace_back(jet.daughterPtr(ida), jet.daughterPtr(ida));
-        }
+	// Add the jets that pass to the output collection
+	jets->push_back(jet);
+
+	if ( !unpackAK8_) {
+	  for (unsigned int ida {}; ida < jet.numberOfDaughters(); ++ida) {
+	    candsOut->emplace_back( initptr(jet.daughterPtr(ida)) );
+	  }
+	}
+	else {
+	  // Special case for AK8 pat::Jets from miniAOD, which store the subjets in the first two
+	  // daughter links, and then the rest of the daughters that do not satisfy the jet groomer.
+	  for (unsigned int ida {}; ida < jet.numberOfDaughters(); ++ida) {
+	    auto const & dau = jet.daughterPtr(ida);
+	    if ( dau->numberOfDaughters() == 0 ) {
+	      candsOut->emplace_back( initptr(dau) );
+	    } else {
+	      auto const * dauJet = dynamic_cast<pat::Jet const *>(dau.get());
+	      for ( unsigned int jda {}; jda < dauJet->numberOfDaughters(); ++jda ) {
+		candsOut->emplace_back( initptr(dauJet->daughterPtr(jda)) );
+	      }
+	    }
+	  }
+	}
       }
     }
 
@@ -83,14 +114,35 @@ public:
 private:
   edm::EDGetTokenT<edm::View<T>> const srcToken_;
   StringCutObjectSelector<T> const selector_;
+  bool unpackAK8_;
 };
+
+template<>
+ edm::Ptr<pat::PackedCandidate> const
+JetConstituentSelector< pat::Jet,std::vector<edm::Ptr<pat::PackedCandidate>>>::initptr( edm::Ptr<reco::Candidate> const & dau) const{
+  edm::Ptr<pat::PackedCandidate> retval( dau );
+  return retval;
+}
+
+template<>
+ edm::Ptr<pat::PackedGenParticle> const
+JetConstituentSelector<reco::GenJet,std::vector<edm::Ptr<pat::PackedGenParticle>>>::initptr( edm::Ptr<reco::Candidate> const & dau) const{
+  edm::Ptr<pat::PackedGenParticle> retval( dau );
+  return retval;
+}
 
 using PFJetConstituentSelector = JetConstituentSelector<reco::PFJet>;
 using GenJetConstituentSelector = JetConstituentSelector<reco::GenJet, std::vector<edm::FwdPtr<reco::GenParticle>>>;
+using GenJetPackedConstituentSelector = JetConstituentSelector<reco::GenJet, std::vector<edm::FwdPtr<pat::PackedGenParticle>>>;
+using GenJetPackedConstituentPtrSelector = JetConstituentSelector<reco::GenJet, std::vector<edm::Ptr<pat::PackedGenParticle>>>;
 using PatJetConstituentSelector = JetConstituentSelector<pat::Jet, std::vector<edm::FwdPtr<pat::PackedCandidate>>>;
+using PatJetConstituentPtrSelector = JetConstituentSelector<pat::Jet, std::vector<edm::Ptr<pat::PackedCandidate>>>;
 using MiniAODJetConstituentSelector = JetConstituentSelector<reco::PFJet, std::vector<edm::FwdPtr<pat::PackedCandidate>>>;
+using MiniAODJetConstituentPtrSelector = JetConstituentSelector<reco::PFJet, std::vector<edm::Ptr<pat::PackedCandidate>>>;
 
 DEFINE_FWK_MODULE(PFJetConstituentSelector);
 DEFINE_FWK_MODULE(GenJetConstituentSelector);
+DEFINE_FWK_MODULE(GenJetPackedConstituentPtrSelector);
 DEFINE_FWK_MODULE(PatJetConstituentSelector);
+DEFINE_FWK_MODULE(PatJetConstituentPtrSelector);
 DEFINE_FWK_MODULE(MiniAODJetConstituentSelector);

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -413,6 +413,8 @@
   <class name="edm::Ptr<pat::MET>" />
   <class name="edm::Ptr<pat::Conversion>" />
   <class name="edm::Ptr<pat::PackedCandidate>" />
+  <class name="edm::Ptr<pat::PackedGenParticle>" />
+
 
   <class name="edm::FwdPtr<pat::PackedCandidate>" />
   <class name="std::vector<edm::FwdPtr<pat::PackedCandidate> >" />
@@ -423,6 +425,14 @@
   <class name="std::vector<edm::FwdPtr<pat::PackedGenParticle> >" />
   <class name="edm::Wrapper<edm::FwdPtr<pat::PackedGenParticle> >" />
   <class name="edm::Wrapper<std::vector<edm::FwdPtr<pat::PackedGenParticle> > >" />
+
+  <class name="std::vector<edm::Ptr<pat::PackedCandidate> >" />
+  <class name="edm::Wrapper<edm::Ptr<pat::PackedCandidate> >" />
+  <class name="edm::Wrapper<std::vector<edm::Ptr<pat::PackedCandidate> > >" />
+
+  <class name="std::vector<edm::Ptr<pat::PackedGenParticle> >" />
+  <class name="edm::Wrapper<edm::Ptr<pat::PackedGenParticle> >" />
+  <class name="edm::Wrapper<std::vector<edm::Ptr<pat::PackedGenParticle> > >" />
 
   <!-- PAT Object Collections -->
   <class name="std::vector<pat::Electron>" />

--- a/DataFormats/PatCandidates/src/classes_objects.h
+++ b/DataFormats/PatCandidates/src/classes_objects.h
@@ -169,7 +169,12 @@ namespace DataFormats_PatCandidates {
   edm::Ptr<pat::Muon> ptr_Muon;
   edm::Ptr<pat::Tau> ptr_Tau;
   edm::Ptr<pat::PackedCandidate> ptr_PackedCandidate;
+  edm::Ptr<pat::PackedGenParticle> ptr_PackedGenParticle;
+  edm::Wrapper< edm::Ptr<pat::PackedCandidate> > w_ptr_pc;
+  std::vector< edm::Ptr<pat::PackedCandidate> > v_ptr_pc;
+  edm::Wrapper< std::vector< edm::Ptr<pat::PackedCandidate> > > wv_ptr_pc;
 
+    
   edm::FwdPtr<pat::PackedCandidate> fwdptr_pc;
   edm::Wrapper< edm::FwdPtr<pat::PackedCandidate> > w_fwdptr_pc;
   std::vector< edm::FwdPtr<pat::PackedCandidate> > v_fwdptr_pc;
@@ -179,6 +184,10 @@ namespace DataFormats_PatCandidates {
   edm::Wrapper< edm::FwdPtr<pat::PackedGenParticle> > w_fwdptr_pgp;
   std::vector< edm::FwdPtr<pat::PackedGenParticle> > v_fwdptr_pgp;
   edm::Wrapper< std::vector< edm::FwdPtr<pat::PackedGenParticle> > > wv_fwdptr_pgp;
+
+  edm::Wrapper< edm::Ptr<pat::PackedGenParticle> > w_ptr_pgp;
+  std::vector< edm::Ptr<pat::PackedGenParticle> > v_ptr_pgp;
+  edm::Wrapper< std::vector< edm::Ptr<pat::PackedGenParticle> > > wv_ptr_pgp;
 
     
   edm::Wrapper<edm::Association<pat::PackedCandidateCollection > > w_asso_pc;


### PR DESCRIPTION
Backport of #22092. 


Summary there:

In order to recluster AK8 jets from MINIAOD (*), we need to write out the jet constituents in a way that can be easily read out. This adds the capability to write out Ptrs and appropriate unpacking of AK8 jets. This should not affect existing workflows. Backports incoming.

(*) This is often needed for JMAR studies. There will also be an upcoming workflow for JMAR development with nanoaod.