### PR TITLE
Only HCAL HT versions 0 and 1 should be considered valid

### DIFF
--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -217,12 +217,16 @@ bool HcalTopology::validHT(const HcalTrigTowerDetId& id) const {
        if ((id.iphi() % 4) != 1)                               return false;
        if (id.ietaAbs() > 32)                                  return false;
     }
-  } else {
+  } else if (id.version()==1) {
     if (triggerMode_==HcalTopologyMode::TriggerMode_2009) return false;
     if (id.ietaAbs()<30 || id.ietaAbs()>41)         return false;
     if (id.ietaAbs()>29 && ((id.iphi()%2)==0))      return false;
     if (id.ietaAbs()>39 && ((id.iphi()%4)!=3))      return false;
+  } else if (id.version()>1) {
+    // only versions 0 and 1 are supported
+    return false;
   }
+
   return true;
 }
 


### PR DESCRIPTION
Only HCAL HT trigger channel versions 0 and 1 should be considered valid. Currently versions 1 to 7 are considered equivalent, which could lead to problems if a version 2 is ever introduced.

This PR should have no effect on any standard workflow. The only effect expected is that the hardcoded conditions, which are also used to generate database input files (i.e. with [1]), will now be generated with the correct version number for HT channels corresponding to HF (version 1 rather than 7). The correct behavior of this PR has been verified for with [1].

[1] cmsRun $CMSSW_RELEASE_BASE/src/CondTools/Hcal/test/runDumpHcalCond_cfg.py dumplist="LutMetadata" usehardcode=True run=999999 geometry=Extended2018