### PR TITLE
Redefine central CSC LCT BX in CSCCommonTrigger/CSCConstants

### DIFF
--- a/DataFormats/L1TMuon/BuildFile.xml
+++ b/DataFormats/L1TMuon/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/L1CSCTrackFinder"/>
 <use name="DataFormats/Common"/>
+<use name="L1Trigger/CSCCommonTrigger"/>
 <use name="L1Trigger/DTTrackFinder"/>
 <use name="rootrflx"/>
 <flags ADD_SUBDIR="1"/>

--- a/DataFormats/L1TMuon/src/EMTFHit.cc
+++ b/DataFormats/L1TMuon/src/EMTFHit.cc
@@ -1,4 +1,5 @@
 #include "DataFormats/L1TMuon/interface/EMTFHit.h"
+#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
 
 namespace l1t {
 
@@ -16,8 +17,8 @@ namespace l1t {
 
   CSCCorrelatedLCTDigi EMTFHit::CreateCSCCorrelatedLCTDigi() const {
     return CSCCorrelatedLCTDigi( 1, valid, quality, wire, strip,
-				 pattern, (bend == 1) ? 1 : 0,
-				 bx + 6, 0, 0, sync_err, csc_ID );
+                                 pattern, (bend == 1) ? 1 : 0,
+                                 bx + CSCConstants::LCT_CENTRAL_BX, 0, 0, sync_err, csc_ID );
     // Filling "trknmb" with 1 and "bx0" with 0 (as in MC).
     // May consider filling "trknmb" with 2 for 2nd LCT in the same chamber. - AWB 24.05.17
     // trknmb and bx0 are unused in the EMTF emulator code. mpclink = 0 (after bx) indicates unsorted.
@@ -25,7 +26,7 @@ namespace l1t {
   
   // // Not yet implemented - AWB 15.03.17
   // RPCDigi EMTFHit::CreateRPCDigi() const {
-  //   return RPCDigi( (strip_hi + strip_lo) / 2, bx + 6 );
+  //   return RPCDigi( (strip_hi + strip_lo) / 2, bx + CSCConstants::LCT_CENTRAL_BX );
   // }
   
 } // End namespace l1t

--- a/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
+++ b/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
@@ -78,7 +78,9 @@ class CSCConstants
     // Each CSC can send up to 2 LCTs to the MPC.
     MAX_LCTS_PER_CSC = 2,
     // An MPC receives up to 18 LCTs from 9 CSCs in the trigger sector
-    MAX_LCTS_PER_MPC = 18 };
+    MAX_LCTS_PER_MPC = 18,
+    // Reference BX for LCTs in simulation and firmware
+    LCT_CENTRAL_BX = 6};
 };
 
 #endif

--- a/L1Trigger/CSCTrackFinder/src/CSCTFDTReceiver.cc
+++ b/L1Trigger/CSCTrackFinder/src/CSCTFDTReceiver.cc
@@ -28,7 +28,7 @@ CSCTriggerContainer<csctf::TrackStub> CSCTFDTReceiver::process(const L1MuDTChamb
 	{
 	  int wheel = (e == 1) ? 2 : -2;
 	  int sector = 2*s - 1;
-	  int csc_bx = bx + 6;//Delay DT stubs by 6 bx.
+         int csc_bx = bx + CSCConstants::LCT_CENTRAL_BX;//Delay DT stubs by the central LCT bx.
 
 	  // combine two 30 degree DT sectors into a 60 degree CSC
 	  // sector.

--- a/L1Trigger/CSCTrackFinder/src/CSCTFMuonSorter.cc
+++ b/L1Trigger/CSCTrackFinder/src/CSCTFMuonSorter.cc
@@ -1,5 +1,5 @@
 #include <L1Trigger/CSCTrackFinder/interface/CSCTFMuonSorter.h>
-
+#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 
 CSCTFMuonSorter::CSCTFMuonSorter(const edm::ParameterSet& pset)
@@ -13,7 +13,8 @@ std::vector<L1MuRegionalCand> CSCTFMuonSorter::run(const CSCTriggerContainer<csc
   std::vector<L1MuRegionalCand> result;
 
   // First we sort and crop the incoming tracks based on their rank.
-  for(int bx = m_minBX - 6; bx <= m_maxBX - 6; ++bx) // switch back into signed BX
+  for(int bx = m_minBX - CSCConstants::LCT_CENTRAL_BX;
+      bx <= m_maxBX - CSCConstants::LCT_CENTRAL_BX; ++bx) // switch back into signed BX
     {
       std::vector<csc::L1Track> tks = tracks.get(bx);
       std::sort(tks.begin(),tks.end(),std::greater<csc::L1Track>());

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -61,7 +61,7 @@ void CSCGEMMotherboard::retrieveGEMPads(const GEMPadDigiCollection* gemPads, uns
       GEMDetId roll_id(roll->id());
       auto pads_in_det = gemPads->get(roll_id);
       for (auto pad = pads_in_det.first; pad != pads_in_det.second; ++pad) {
-        const int bx_shifted(lct_central_bx + pad->bx());
+        const int bx_shifted(CSCConstants::LCT_CENTRAL_BX + pad->bx());
         // consider matches with BX difference +1/0/-1
         for (int bx = bx_shifted - maxDeltaBXPad_;bx <= bx_shifted + maxDeltaBXPad_; ++bx) {
           pads_[bx].emplace_back(roll_id.rawId(), *pad);
@@ -77,7 +77,7 @@ void CSCGEMMotherboard::retrieveGEMCoPads()
   for (const auto& copad: gemCoPadV){
     GEMDetId detId(theRegion, 1, theStation, 0, theChamber, 0);
     // only consider matches with same BX
-    coPads_[lct_central_bx + copad.bx(1)].emplace_back(detId.rawId(), copad);
+    coPads_[CSCConstants::LCT_CENTRAL_BX + copad.bx(1)].emplace_back(detId.rawId(), copad);
   }
 }
 
@@ -170,7 +170,7 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
     const auto& mymap2 = getLUT()->get_gem_roll_to_csc_wg(par, p);
     pattern = encodePattern(clct.getPattern(), clct.getStripType());
     quality = promoteCLCTGEMquality_ ? 15 : 11;
-    bx = gem2.bx(1) + lct_central_bx;
+    bx = gem2.bx(1) + CSCConstants::LCT_CENTRAL_BX;
     keyStrip = clct.getKeyStrip();
     // choose the corresponding wire-group in the middle of the partition
     keyWG = mymap2[gem2.roll()];

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.h
@@ -275,7 +275,7 @@ void CSCGEMMotherboard::matchingPads(const CSCALCTDigi& alct,
     if (part==CSCPart::ME1A and !isPadInOverlap(padRoll)) continue;
 
     // pad bx needs to match to ALCT bx
-    int pad_bx = getBX(p.second)+lct_central_bx;
+    int pad_bx = getBX(p.second)+CSCConstants::LCT_CENTRAL_BX;
     if (std::abs(alct.getBX()-pad_bx)>getMaxDeltaBX<T>()) continue;
 
     // gem roll number if invalid
@@ -318,7 +318,7 @@ void CSCGEMMotherboard::matchingPads(const CSCCLCTDigi& clct,
   for (const auto& p: lut.at(clct.getBX())){
 
     // pad bx needs to match to CLCT bx
-    int pad_bx = getBX(p.second)+lct_central_bx;
+    int pad_bx = getBX(p.second)+CSCConstants::LCT_CENTRAL_BX;
     if (std::abs(clct.getBX()-pad_bx)>getMaxDeltaBX<T>()) continue;
 
     // pad number must match

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
@@ -269,7 +269,7 @@ CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
 	     ++nSuccessFulMatches;
 
 	     int mbx = std::abs(clct->bestCLCT[bx_clct].getBX()-bx_alct);
-	     int bx_gem = (coPads[0].second).bx(1)+lct_central_bx;
+	     int bx_gem = (coPads[0].second).bx(1)+CSCConstants::LCT_CENTRAL_BX;
 	     CSCGEMMotherboard::correlateLCTsGEM(clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct], coPads,
 						 allLCTs(bx_gem,mbx,0), allLCTs(bx_gem,mbx,1), CSCPart::ME21);
 	     if (debug_matching) {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -136,8 +136,6 @@ CSCMotherboard::CSCMotherboard(unsigned endcap, unsigned station,
   tmb_l1a_window_size = // Common to CLCT and TMB
     tmbParams.getParameter<unsigned int>("tmbL1aWindowSize");
 
-  lct_central_bx = 6;
-
   // configuration handle for number of early time bins
   early_tbins = tmbParams.getParameter<int>("tmbEarlyTbins");
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -116,7 +116,7 @@ class CSCMotherboard
   unsigned int match_trig_window_size, tmb_l1a_window_size;
 
   /** Central BX */
-  int lct_central_bx;
+  int lct_central_bx = CSCConstants::LCT_CENTRAL_BX;
 
   /** SLHC: whether to not reuse ALCTs that were used by previous matching CLCTs */
   bool drop_used_alcts;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -115,9 +115,6 @@ class CSCMotherboard
   unsigned int alct_trig_enable, clct_trig_enable, match_trig_enable;
   unsigned int match_trig_window_size, tmb_l1a_window_size;
 
-  /** Central BX */
-  int lct_central_bx = CSCConstants::LCT_CENTRAL_BX;
-
   /** SLHC: whether to not reuse ALCTs that were used by previous matching CLCTs */
   bool drop_used_alcts;
 

--- a/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
@@ -12,7 +12,7 @@
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFinput.h"
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFConfiguration.h"
 #include "L1Trigger/L1TMuonOverlap/interface/AngleConverter.h"
-
+#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -274,10 +274,9 @@ OMTFinput OMTFinputMaker::processCSC(const CSCCorrelatedLCTDigiCollection *cscDi
     auto dend = (*chamber).second.second;    
     for( ; digi != dend; ++digi ) {
 
-      ///Check Trigger primitive quality.
-      ///CSC central BX is 6 for some reason.
-      if (abs(digi->getBX()- 6)>0) continue;
-      
+      ///Check if LCT trigger primitive has the right BX.
+      if (abs(digi->getBX()- CSCConstants::LCT_CENTRAL_BX)>0) continue;
+
       unsigned int hwNumber = myOmtfConfig->getLayerNumber(rawid);
       if(myOmtfConfig->getHwToLogicLayer().find(hwNumber)==myOmtfConfig->getHwToLogicLayer().end()) continue;
 


### PR DESCRIPTION
The CSC trigger, CSC track-finder, EMTF and OMTF all use the magic number `6` somewhere in the code, which historically has been the central LCT BX in the simulation. However, in the hardware, LCTs are always centered at BX8. CSC DPG has asked to shift the central BX in simulation, so it agrees in hardware. 

This pull request is the first step to make that happen. A constant `LCT_CENTRAL_BX` (with current value 6) is defined in `L1Trigger/CommonTrigger/interface/CSCConstants.h` so that it can be used in other packages. 

The redefinition of BX6 should not introduce any changes to the L1 trigger performance in any workflow.

The actual shift BX6->BX8 will follow later after rigorous testing.

@tahuang1991 @ptcox @abrinke1 