### PR TITLE
Report CPU time spent in child processes of ExternalLHEProducer [9_3]

### DIFF
--- a/FWCore/Utilities/interface/TimingServiceBase.h
+++ b/FWCore/Utilities/interface/TimingServiceBase.h
@@ -36,7 +36,7 @@ namespace edm {
     ///Extra CPU time used by a job but not seen by cmsRun
     /// The value should be in seconds.
     /// This function is safe to call from multiple threads
-    virtual void addToCPUTime(StreamID id, double iTime) = 0;
+    virtual void addToCPUTime(double iTime) = 0;
 
     ///CPU time used by this process and all its children.
     /// The value returned should be in seconds.

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -27,6 +27,9 @@ Implementation:
 #include <dirent.h>
 #include <fcntl.h>
 #include <sys/wait.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+
 
 #include "boost/bind.hpp"
 #include "boost/shared_ptr.hpp"
@@ -55,6 +58,7 @@ Implementation:
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "FWCore/Utilities/interface/TimingServiceBase.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -440,6 +444,13 @@ ExternalLHEProducer::executeScript()
       break;
     }
   } while (true);
+  edm::Service<edm::TimingServiceBase> ts;
+  if(ts.isAvailable()) {
+    struct rusage ru;
+    getrusage(RUSAGE_CHILDREN,&ru);
+    double time = static_cast<double>(ru.ru_stime.tv_sec) + (static_cast<double>(ru.ru_stime.tv_usec) * 1E-6);
+    ts->addToCPUTime(time);
+  }
   if (rc) {
     throw cms::Exception("ExternalLHEProducer") << "Child failed with exit code " << rc << ".";
   }


### PR DESCRIPTION
When accounting for CPU time used by a cmsRun job, we need to also include the CPU time of the child processes launched by ExternalLHEProducer.