### PR TITLE
Various updates to CMSSW that are not directly related to GPU development (10.0.x)

### DIFF
--- a/CondFormats/SiPixelObjects/src/SiPixelGainCalibrationOffline.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelGainCalibrationOffline.cc
@@ -188,7 +188,7 @@ float SiPixelGainCalibrationOffline::getGain(const int& col, const int& row, con
   int maxRow = lengthOfColumnData - (lengthOfColumnData % numberOfRowsToAverageOver_) - 1;
   if (col >= nCols || row > maxRow){
     throw cms::Exception("CorruptedData")
-      << "[SiPixelGainCalibrationOffline::getPed] Pixel out of range: col " << col;
+      << "[SiPixelGainCalibrationOffline::getPed] Pixel out of range: col " << col << " row " << row;
   }  
   return decodeGain(s.datum & 0xFF);
 }

--- a/DataFormats/SiPixelDigi/interface/PixelDigi.h
+++ b/DataFormats/SiPixelDigi/interface/PixelDigi.h
@@ -17,7 +17,7 @@ public:
   typedef unsigned int PackedDigiType;
   typedef unsigned int ChannelType;
 
-  PixelDigi( int packed_value) : theData(packed_value) {}
+  explicit PixelDigi(PackedDigiType packed_value) : theData(packed_value) {}
 
   PixelDigi( int row, int col, int adc) {
     init( row, col, adc);


### PR DESCRIPTION
We are pushing to this branches the fixes and improvements to the CMSSW code that we are making during the development of the GPU algorithms, but are not GPU specific.

Various improvements to pixel-related modules
  - mark `PixelDigi` constructor as `explicit`
  - improve `SiPixelGainCalibrationOffline::getPed` exception error message

