### PR TITLE
HCAL DQM: online config changes for 2018

### DIFF
--- a/DQM/Integration/python/clients/hcal2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal2_dqm_sourceclient-live_cfg.py
@@ -19,17 +19,13 @@ import FWCore.ParameterSet.Config as cms
 # PRocess accepts a (*list) of modifiers
 #
 from Configuration.StandardSequences.Eras import eras
-process			= cms.Process('HCALDQM', 
-    eras.run2_HCAL_2017, 
-    eras.run2_HF_2017,
-    eras.run2_HEPlan1_2017
-)
+process			= cms.Process('HCALDQM', eras.Run2_2018)
 subsystem		= 'Hcal2'
 cmssw			= os.getenv("CMSSW_VERSION").split("_")
 debugstr		= "### HcalDQM::cfg::DEBUG: "
 warnstr			= "### HcalDQM::cfg::WARN: "
 errorstr		= "### HcalDQM::cfg::ERROR:"
-useOfflineGT	= False
+useOfflineGT	= True # CHANGE BACK BEFORE COMMITTING
 useFileInput	= False
 useMap		= False
 useMapText		= False
@@ -40,7 +36,7 @@ useMapText		= False
 from DQM.Integration.config.online_customizations_cfi import *
 if useOfflineGT:
 	process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
-	process.GlobalTag.globaltag = '90X_dataRun2_HLT_v1'
+	process.GlobalTag.globaltag = '100X_dataRun2_HLT_Candidate_2018_01_31_16_04_35'
 else:
 	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
 if useFileInput:
@@ -133,7 +129,7 @@ if useMap:
 #	Settings for the Primary Modules
 #-------------------------------------
 oldsubsystem = subsystem
-process.recHitTask.tagHBHE = cms.untracked.InputTag("hbheplan1")
+process.recHitTask.tagHBHE = cms.untracked.InputTag("hbheprereco")
 process.recHitTask.tagHO = cms.untracked.InputTag("horeco")
 process.recHitTask.tagHF = cms.untracked.InputTag("hfreco")
 process.recHitTask.runkeyVal = runType
@@ -142,13 +138,6 @@ process.recHitTask.tagRaw = rawTagUntracked
 process.recHitTask.subsystem = cms.untracked.string(subsystem)
 
 process.hcalOnlineHarvesting.subsystem = cms.untracked.string(subsystem)
-
-#-------------------------------------
-#	Phase 1 upgrade modifiers
-#-------------------------------------
-from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
-run2_HF_2017.toModify(process.recHitTask, hfPreRecHitsAvailable=cms.untracked.bool(True))
-run2_HF_2017.toModify(process.recHitTask, tagPreHF=cms.untracked.InputTag("hfprereco"))
 
 #-------------------------------------
 #	Hcal DQM Tasks/Clients Sequences Definition
@@ -171,7 +160,6 @@ process.recoPath = cms.Path(
     *process.hfprereco
     *process.hfreco
     *process.hbheprereco
-    *process.hbheplan1
 )
 
 process.dqmPath = cms.Path(

--- a/DQM/Integration/python/clients/hcal2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal2_dqm_sourceclient-live_cfg.py
@@ -19,16 +19,16 @@ import FWCore.ParameterSet.Config as cms
 # PRocess accepts a (*list) of modifiers
 #
 from Configuration.StandardSequences.Eras import eras
-process			= cms.Process('HCALDQM', eras.Run2_2018)
-subsystem		= 'Hcal2'
-cmssw			= os.getenv("CMSSW_VERSION").split("_")
-debugstr		= "### HcalDQM::cfg::DEBUG: "
-warnstr			= "### HcalDQM::cfg::WARN: "
-errorstr		= "### HcalDQM::cfg::ERROR:"
-useOfflineGT	= True # CHANGE BACK BEFORE COMMITTING
-useFileInput	= False
-useMap		= False
-useMapText		= False
+process      = cms.Process('HCALDQM', eras.Run2_2018)
+subsystem    = 'Hcal2'
+cmssw        = os.getenv("CMSSW_VERSION").split("_")
+debugstr     = "### HcalDQM::cfg::DEBUG: "
+warnstr      = "### HcalDQM::cfg::WARN: "
+errorstr     = "### HcalDQM::cfg::ERROR:"
+useOfflineGT = False
+useFileInput = False
+useMap       = False
+useMapText   = False
 
 #-------------------------------------
 #	Central DQM Stuff imports
@@ -36,7 +36,8 @@ useMapText		= False
 from DQM.Integration.config.online_customizations_cfi import *
 if useOfflineGT:
 	process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
-	process.GlobalTag.globaltag = '100X_dataRun2_HLT_Candidate_2018_01_31_16_04_35'
+	#process.GlobalTag.globaltag = '100X_dataRun2_HLT_Candidate_2018_01_31_16_04_35'
+	process.GlobalTag.globaltag = '100X_dataRun2_HLT_v1'
 else:
 	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
 if useFileInput:
@@ -69,12 +70,6 @@ process.load('FWCore.MessageLogger.MessageLogger_cfi')
 process.load("EventFilter.HcalRawToDigi.HcalRawToDigi_cfi")
 process.load("SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff")
 process.load("RecoLocalCalo.Configuration.hcalLocalReco_cff")
-#process.load("RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi")
-#process.load("RecoLocalCalo.HcalRecProducers.hbheplan1_cfi")
-#process.load("RecoLocalCalo.HcalRecProducers.HcalHitReconstructor_ho_cfi")
-#process.load("RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi")
-#from RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi import hfreco as _phase1_hfreco
-#from RecoLocalCalo.HcalRecProducers.hbheplan1_cfi import hbheplan1
 process.load('CondCore.CondDB.CondDB_cfi')
 
 #-------------------------------------

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -12,15 +12,15 @@ import os, sys, socket, string
 #-------------------------------------
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
-process			= cms.Process('HCALDQM', eras.Run2_2018)
-subsystem		= 'Hcal'
-cmssw			= os.getenv("CMSSW_VERSION").split("_")
-debugstr		= "### HcalDQM::cfg::DEBUG: "
-warnstr			= "### HcalDQM::cfg::WARN: "
-errorstr		= "### HcalDQM::cfg::ERROR:"
-useOfflineGT	= True # CHANGE BACK TO FALSE BEFORE COMMITTING
-useFileInput	= False
-useMap		= False
+process      = cms.Process('HCALDQM', eras.Run2_2018)
+subsystem    = 'Hcal'
+cmssw        = os.getenv("CMSSW_VERSION").split("_")
+debugstr     = "### HcalDQM::cfg::DEBUG: "
+warnstr      = "### HcalDQM::cfg::WARN: "
+errorstr     = "### HcalDQM::cfg::ERROR:"
+useOfflineGT = False
+useFileInput = False
+useMap       = False
 
 #-------------------------------------
 #	Central DQM Stuff imports
@@ -28,7 +28,8 @@ useMap		= False
 from DQM.Integration.config.online_customizations_cfi import *
 if useOfflineGT:
 	process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
-	process.GlobalTag.globaltag = '100X_dataRun2_HLT_Candidate_2018_01_31_16_04_35'
+	process.GlobalTag.globaltag = '100X_dataRun2_HLT_v1'
+	#process.GlobalTag.globaltag = '100X_dataRun2_HLT_Candidate_2018_01_31_16_04_35'
 else:
 	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
 if useFileInput:

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -12,17 +12,13 @@ import os, sys, socket, string
 #-------------------------------------
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
-process			= cms.Process('HCALDQM', 
-    eras.run2_HCAL_2017, 
-    eras.run2_HF_2017,
-    eras.run2_HEPlan1_2017
-)
+process			= cms.Process('HCALDQM', eras.Run2_2018)
 subsystem		= 'Hcal'
 cmssw			= os.getenv("CMSSW_VERSION").split("_")
 debugstr		= "### HcalDQM::cfg::DEBUG: "
 warnstr			= "### HcalDQM::cfg::WARN: "
 errorstr		= "### HcalDQM::cfg::ERROR:"
-useOfflineGT	= False
+useOfflineGT	= True # CHANGE BACK TO FALSE BEFORE COMMITTING
 useFileInput	= False
 useMap		= False
 
@@ -32,7 +28,7 @@ useMap		= False
 from DQM.Integration.config.online_customizations_cfi import *
 if useOfflineGT:
 	process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
-	process.GlobalTag.globaltag = '90X_dataRun2_HLT_v1'
+	process.GlobalTag.globaltag = '100X_dataRun2_HLT_Candidate_2018_01_31_16_04_35'
 else:
 	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
 if useFileInput:
@@ -104,8 +100,8 @@ process.emulTPDigis.ZS_threshold = cms.uint32(0)
 process.hcalDigis.InputLabel = rawTag
 
 # Exclude the laser FEDs. They contaminate the QIE10/11 digi collections. 
-from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
-run2_HCAL_2017.toModify(process.hcalDigis, FEDs=cms.untracked.vint32(724,725,726,727,728,729,730,731,1100,1101,1102,1103,1104,1105,1106,1107,1108,1109,1110,1111,1112,1113,1114,1115,1116,1117,1118,1119,1120,1121,1122,1123))
+#from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
+#run2_HCAL_2017.toModify(process.hcalDigis, FEDs=cms.untracked.vint32(724,725,726,727,728,729,730,731,1100,1101,1102,1103,1104,1105,1106,1107,1108,1109,1110,1111,1112,1113,1114,1115,1116,1117,1118,1119,1120,1121,1122,1123))
 
 #-------------------------------------
 #	Hcal DQM Tasks and Harvesters import

--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -12,15 +12,15 @@ import os, sys, socket, string
 #-------------------------------------
 from Configuration.StandardSequences.Eras import eras
 import FWCore.ParameterSet.Config as cms
-process			= cms.Process('HCALDQM')
-subsystem		= 'HcalCalib'
-cmssw			= os.getenv("CMSSW_VERSION").split("_")
-debugstr		= "### HcalDQM::cfg::DEBUG: "
-warnstr			= "### HcalDQM::cfg::WARN: "
-errorstr		= "### HcalDQM::cfg::ERROR:"
-useOfflineGT	= False
-useFileInput	= False
-useMap		= False
+process      = cms.Process('HCALDQM')
+subsystem    = 'HcalCalib'
+cmssw        = os.getenv("CMSSW_VERSION").split("_")
+debugstr     = "### HcalDQM::cfg::DEBUG: "
+warnstr      = "### HcalDQM::cfg::WARN: "
+errorstr     = "### HcalDQM::cfg::ERROR:"
+useOfflineGT = False
+useFileInput = False
+useMap       = False
 
 #-------------------------------------
 #	Central DQM Stuff imports
@@ -28,7 +28,7 @@ useMap		= False
 from DQM.Integration.config.online_customizations_cfi import *
 if useOfflineGT:
 	process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
-	process.GlobalTag.globaltag = '90X_dataRun2_HLT_v1'
+	process.GlobalTag.globaltag = '100X_dataRun2_HLT_v1'
 else:
 	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
 if useFileInput:


### PR DESCRIPTION
Some basic changes to the configurations for HCAL online DQM: change eras to 2018, remove plan-1-specific things. 