### PR TITLE
work around clang-tidy multi-line YAML issues (10.0.x backport)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,24 +1,22 @@
 ---
-Checks:
-  -*
-  ,boost-use-to-string
-  ,misc-string-compare
-  ,misc-uniqueptr-reset-release
-  ,modernize-deprecated-headers
-  ,modernize-make-shared
-  ,modernize-use-bool-literals
-  ,modernize-use-equals-delete
-  ,modernize-use-nullptr
-  ,modernize-use-override
-  ,performance-unnecessary-copy-initialization
-  ,readability-container-size-empty
-  ,readability-redundant-string-cstr
-  ,readability-static-definition-in-anonymous-namespace
+Checks: -*,
+  ,boost-use-to-string,
+  ,misc-string-compare,
+  ,misc-uniqueptr-reset-release,
+  ,modernize-deprecated-headers,
+  ,modernize-make-shared,
+  ,modernize-use-bool-literals,
+  ,modernize-use-equals-delete,
+  ,modernize-use-nullptr,
+  ,modernize-use-override,
+  ,performance-unnecessary-copy-initialization,
+  ,readability-container-size-empty,
+  ,readability-redundant-string-cstr,
+  ,readability-static-definition-in-anonymous-namespace,
   ,readability-uniqueptr-delete-release
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
-User:            muzaffar
 CheckOptions:    
   - key:             google-readability-braces-around-statements.ShortStatementLines
     value:           '1'


### PR DESCRIPTION
It seems that clang-tidy does not properly parse multi-line strings, leaving the newline character as part of the string.
This commit wraps all options in commas, leaving the newlines outside of the names.