### PR TITLE
EMTF patch for DQM quality test time-out issue

### DIFF
--- a/DQMServices/Core/interface/QTest.h
+++ b/DQMServices/Core/interface/QTest.h
@@ -369,7 +369,7 @@ protected:
   /// get average for bin under consideration
   /// (see description of method setNumNeighbors)
   double getAverage(int bin, const TH1 *h) const;
-  double getAverage2D(int binX, int binY, const TH1 *h) const;
+  double getAverage2D(int binX, int binY, const TH2 *h) const;
 
   float tolerance_;        /*< tolerance for considering a channel noisy */
   unsigned numNeighbors_;  /*< # of neighboring channels for calculating average to be used


### PR DESCRIPTION
Follow up to PR #21812 

Fix for Noisy Channel test causing time-out issues, described here:
https://github.com/cms-sw/cmssw/issues/22008

"runTheMatrix.py -l 4.28 -i all" now takes 12 minutes on lxplus, single-threaded.

Replaces GetBinContents with integrals and adds TH2 passing to class.  Based off branch from @chadfreer here:
https://github.com/chadfreer/cmssw/tree/Noisy_fix/

@fabiocos , @smuzaffar , @davidlange6 , @thomreis please take a look and test.