### PR TITLE
fixing bug in CaloObjFiltering for HLT when the object has no geometry

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/interface/HLTCaloObjInRegionsProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/HLTCaloObjInRegionsProducer.h
@@ -20,7 +20,8 @@
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
 #include "DataFormats/EgammaCandidates/interface/Electron.h"
 #include "DataFormats/EgammaCandidates/interface/ElectronFwd.h"
-
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "DataFormats/DetId/interface/DetId.h"
 
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
@@ -122,6 +123,7 @@ class HLTCaloObjInRegionsProducer : public edm::stream::EDProducer<> {
   makeFilteredColl(const edm::Handle<CaloObjCollType>& inputColl,
 		   const edm::ESHandle<CaloGeometry>& caloGeomHandle,
 		   const std::vector<EtaPhiRegion>& regions);
+  static bool validIDForGeom(const DetId& id);
   std::vector<std::string> outputProductNames_;
   std::vector<edm::InputTag> inputCollTags_;
   std::vector<edm::EDGetTokenT<CaloObjCollType>> inputTokens_;
@@ -228,10 +230,15 @@ makeFilteredColl(const edm::Handle<CaloObjCollType>& inputColl,
 	auto objGeom = subDetGeom->getGeometry(obj.id());
 	if(objGeom==nullptr){
 	  //wondering what to do here
-	  //something is very very wrong
-	  //given HLT should never crash or throw, decided to log an error and 
-	  edm::LogError("HLTCaloObjInRegionsProducer") << "for an object of type "<<typeid(CaloObjType).name()<<" the geometry returned null for id "<<DetId(obj.id()).rawId()<<" in HLTCaloObjsInRegion, this shouldnt be possible and something has gone wrong, auto accepting hit";
+	  //something is very very wrong  
+	  //given HLT should never crash or throw, decided to log an error 
+	  //update: so turns out HCAL can pass through calibration channels in QIE11 so for that module, its an expected behaviour	
+	  //so we check if the ID is valid
+	  if(validIDForGeom(obj.id())) {
+	    edm::LogError("HLTCaloObjInRegionsProducer") << "for an object of type "<<typeid(CaloObjType).name()<<" the geometry returned null for id "<<DetId(obj.id()).rawId()<<" with initial ID "<<DetId(inputColl->begin()->id()).rawId()<<" in HLTCaloObjsInRegion, this shouldnt be possible and something has gone wrong, auto accepting hit";
+	  }
 	  outputColl->push_back(obj);
+	  continue;
 	}
 	float eta = objGeom->getPosition().eta();
 	float phi = objGeom->getPosition().phi();
@@ -249,6 +256,22 @@ makeFilteredColl(const edm::Handle<CaloObjCollType>& inputColl,
 
 }
 
+//tells us if an ID should have a valid geometry
+//it assumes that all IDs do except those specifically mentioned
+//HCAL for example have laser calibs in the digi collection so 
+//so we have to ensure that HCAL is HB,HE or HO
+template<typename CaloObjType,typename CaloObjCollType>
+bool HLTCaloObjInRegionsProducer<CaloObjType,CaloObjCollType>::
+validIDForGeom(const DetId& id)
+{
+  if(id.det()==DetId::Hcal){
+    if(id.subdetId() == HcalSubdetector::HcalEmpty ||
+       id.subdetId() == HcalSubdetector::HcalOther){
+      return false;
+    }
+  }
+  return true;
+}
 
 
 


### PR DESCRIPTION
Dear All,

In the process of enabling filtering for phase I HCAL it was noticed by Federico that the module would crash on a handful of events. This was traced to a missing "continue" statement when checking for a null geometry which was an oversight on my part last year. This PR adds that continue statement and is a simple and necessary bug fix.

After discussing with Federico, he informed me that its QEI11 digi not having a valid geometry does happen because laser calibrations etc get mixed into the digi collection. It is harmless to pass them through as they will be killed later on by the hcal reco code. As I hate errors being sent when it is not an error, I adapted the error message not to fire if its a HCAL type which is known not to have a geometry which accounts for the other 26 lines of changes. 

We request that this simple bug fix be in the next 10_0_X release as it is necessary to control HLT timing with a fully upgraded HE detector. Expect to see a PR for the backport shortly. 