### PR TITLE
Update RootDelayedReader for multiple Runs and Lumis

### DIFF
--- a/IOPool/Input/src/RootDelayedReader.cc
+++ b/IOPool/Input/src/RootDelayedReader.cc
@@ -82,7 +82,8 @@ namespace edm {
     std::unique_ptr<WrapperBase> edp = getWrapperBasePtr(p, branchInfo.offsetToWrapperBase_); 
     br->SetAddress(&p);
     try{
-      tree_.getEntry(br, tree_.entryNumberForIndex(ep->transitionIndex()));
+      //Run and Lumi only have 1 entry number, which is index 0
+      tree_.getEntry(br, tree_.entryNumberForIndex(tree_.branchType()==InEvent?ep->transitionIndex(): 0));
     } catch(edm::Exception& exception) {
       exception.addContext("Rethrowing an exception that happened on a different thread.");
       lastException_ = std::current_exception();


### PR DESCRIPTION
The PoolSource only uses one cache for Runs and LuminosityBlocks because they are directly read when the source is first called and not actually read when requested by modules.