### PR TITLE
fix packing of 2x32 in 64 bits (10.0.x)

### DIFF
--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -339,7 +339,7 @@ void PixelDataFormatter::formatRawData(unsigned int lvl1_ID, RawData & fedRawDat
     // write data
     unsigned int nWord32InFed = words.find(fedId)->second.size();
     for (unsigned int i=0; i < nWord32InFed; i+=2) {
-      *word = (Word64(words.find(fedId)->second[i]) << 32 ) | words.find(fedId)->second[i+1];
+      *word = (Word64(words.find(fedId)->second[i+1]) << 32 ) | words.find(fedId)->second[i];
       LogDebug("PixelDataFormatter")  << print(*word);
       word++;
     }


### PR DESCRIPTION
backport #21982:

@VinInn wrote:
> the title says all.
> We noticed that in MC (and never in Data) often the last word of a Det comes after the first word of the successive det....
> 
> Purely technical affecting only digitization.
> 
> no regression expected.