### PR TITLE
Fix dE/dx hit association index (94X)

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
@@ -385,7 +385,7 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
             const auto &dedxRef = (*gt2dedxHitInfo)[tkref];
             if (saveDeDxHitInfoCut_(outPtrP->back()) && dedxRef.isNonnull()) {
                 outDeDxC->push_back( *dedxRef );
-                dEdXass.push_back(outDeDxC->size());
+                dEdXass.push_back(outDeDxC->size()-1);
             } else {
                 dEdXass.push_back(-1);
             }


### PR DESCRIPTION
Fix issue in dE/dx hit association, as reported in https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3586/1/1/1.html

backport of #22124

for MiniAODv2 (will be added to the list in #21864)