### PR TITLE
Fix reading prescale values during miniAOD production

### DIFF
--- a/PhysicsTools/PatAlgos/python/triggerLayer1/triggerProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/triggerLayer1/triggerProducer_cfi.py
@@ -7,7 +7,7 @@ patTrigger = cms.EDProducer( "PATTriggerProducer"
 ,l1GtTriggerMenuLiteInputTag = cms.InputTag("gtDigis")
 ,l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis")
 ,l1tExtBlkInputTag = cms.InputTag("gtStage2Digis")
-,ReadPrescalesFromFile = cms.bool(True)
+,ReadPrescalesFromFile = cms.bool(False)
 
 # ## L1
 # , addL1Algos                     = cms.bool( False )                                 # default; possibly superseded by 'onlyStandAlone' = True


### PR DESCRIPTION
Fix reading prescale values during miniAOD production by setting ReadPrescalesFromFile = False, to get the proper PS column
https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3572/1/1.html

@arizzi @rekovic 