### PR TITLE
[GT Update] HCAL Response Correction update for HE Scale change

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -48,11 +48,11 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' : '100X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '100X_upgrade2018_design_IdealBS_v5',
+    'phase1_2018_design'       : '100X_upgrade2018_design_IdealBS_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v9',
+    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v10',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v7',
+    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '100X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
# Summary of changes in Global Tags
 
## 2018_MC
 
   * **PhaseI 2018 cosmics scenario** : [100X_upgrade2018cosmics_realistic_deco_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018cosmics_realistic_deco_v8) as [100X_upgrade2018cosmics_realistic_deco_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018cosmics_realistic_deco_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018cosmics_realistic_deco_v8/100X_upgrade2018cosmics_realistic_deco_v7): 

   * **PhaseI 2018 design scenario** : [100X_upgrade2018_design_IdealBS_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018_design_IdealBS_v6) as [100X_upgrade2018_design_IdealBS_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018_design_IdealBS_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018_design_IdealBS_v6/100X_upgrade2018_design_IdealBS_v5): 

   * **PhaseI 2018 realistic scenario** : [100X_upgrade2018_realistic_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018_realistic_v10) as [100X_upgrade2018_realistic_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018_realistic_v9) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018_realistic_v10/100X_upgrade2018_realistic_v9): 

      * HCAL response correction update to take into account the energy scale change for HE. 
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3483.html
 https://indico.cern.ch/event/701241/contributions/2887035/attachments/1595810/2527619/IsoTrackN59.pdf