### PR TITLE
Geant4 Sensitive Detectors update 4: revised selection of particle type for shower libraries

### DIFF
--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -22,9 +22,6 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-// To be replaced by something else 
-/* #include "Utilities/Notification/interface/TimerProxy.h" */
- 
 #include "G4VPhysicalVolume.hh"
 #include "G4Track.hh"
 #include "G4VGFlashSensitiveDetector.hh"
@@ -134,7 +131,6 @@ protected:
   double                          correctT;
   double                          kmaxIon, kmaxNeutron, kmaxProton;
 
-  G4int                           emPDG, epPDG, gammaPDG;
   bool                            forceSave;
 
 private:

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -97,9 +97,10 @@ private:
   bool                          testNumber, neutralDensity, testNS_;
   double                        birk1, birk2, birk3, betaThr;
   bool                          useHF, useShowerLibrary, useParam, applyFidCut;
+  bool                          isEM;
   double                        eminHitHB, eminHitHE, eminHitHO, eminHitHF;
   double                        deliveredLumi;
-  G4int                         mumPDG, mupPDG, depth_;
+  G4int                         depth_;
   std::vector<double>           gpar;
   std::vector<int>              hfLevels;
   std::vector<G4String>         hfNames, fibreNames, matNames;

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -76,10 +76,6 @@ private:
   double              dphi, rMin, rMax;
   std::vector<double> gpar;
 
-  int                 emPDG, epPDG, gammaPDG;
-  int                 pi0PDG, etaPDG, nuePDG, numuPDG, nutauPDG;
-  int                 anuePDG, anumuPDG, anutauPDG, geantinoPDG;
-
   int                 npe;
   HFShowerPhotonCollection pe;
   HFShowerPhotonCollection* photo;

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -6,6 +6,7 @@
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 #include "SimDataFormats/SimHitMaker/interface/CaloSlaveSD.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
+#include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
 #include "SimG4Core/Application/interface/EventAction.h"
 
 #include "G4EventManager.hh"
@@ -109,11 +110,8 @@ bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) {
 
   if (aSpot != nullptr) {   
     theTrack = const_cast<G4Track *>(aSpot->GetOriginatorTrack()->GetPrimaryTrack());
-    G4int particleCode = theTrack->GetDefinition()->GetPDGEncoding();
     
-    if (particleCode == emPDG ||
-        particleCode == epPDG ||
-        particleCode == gammaPDG ) {
+    if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
       edepositEM  = aSpot->GetEnergySpot()->GetEnergy();
       edepositHAD = 0.;
     } else {
@@ -253,10 +251,7 @@ bool CaloSD::getStepInfo(G4Step* aStep) {
 #endif
   }
   
-  G4int particleCode = theTrack->GetDefinition()->GetPDGEncoding();
-  if (particleCode == emPDG ||
-      particleCode == epPDG ||
-      particleCode == gammaPDG ) {
+  if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
     edepositEM  = getEnergyDeposit(aStep);
     edepositHAD = 0.;
   } else {
@@ -459,15 +454,6 @@ double CaloSD::getAttenuation(const G4Step* aStep, double birk1, double birk2, d
 }
 
 void CaloSD::update(const BeginOfRun *) {
-  G4ParticleTable * theParticleTable = G4ParticleTable::GetParticleTable();
-  G4String particleName;
-  emPDG = theParticleTable->FindParticle(particleName="e-")->GetPDGEncoding();
-  epPDG = theParticleTable->FindParticle(particleName="e+")->GetPDGEncoding();
-  gammaPDG = theParticleTable->FindParticle(particleName="gamma")->GetPDGEncoding();
-#ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD: Particle code for e- = " << emPDG
-			  << " for e+ = " << epPDG << " for gamma = " << gammaPDG;
-#endif
   initRun();
   runInit = true;
 } 

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -8,6 +8,7 @@
 #include "SimG4CMS/Calo/interface/HFFibreFiducial.h"
 #include "SimG4CMS/Calo/interface/HcalTestNS.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
+#include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DetectorDescription/Core/interface/DDFilter.h"
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
@@ -296,7 +297,7 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
     edm::LogInfo("HcalSim") << "HCalSD: (" << i << ") " << matNames[i]
                             << " pointer " << materials[i];
 
-  mumPDG = mupPDG = 0;
+  isEM = false;
   
   if (useLayerWt) readWeightFromFile(file);
 
@@ -365,20 +366,20 @@ bool HCalSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
     depth_ = (aStep->GetPreStepPoint()->GetTouchable()->GetReplicaNumber(0))%10;
     const G4LogicalVolume* lv =
       aStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume();
+    isEM = (G4TrackToParticleID::isGammaElectronPositron(aStep->GetTrack())) ? true : false;
     G4String nameVolume = lv->GetName();
     if (isItHF(aStep)) {
-      G4int parCode = aStep->GetTrack()->GetDefinition()->GetPDGEncoding();
       double weight(1.0);
       if (m_HFDarkening) {
 	G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
 	double r = hitPoint.perp()/CLHEP::cm;
 	double z = std::abs(hitPoint.z())/CLHEP::cm;
 	double dose_acquired = 0.;
-  if (z>=HFDarkening::lowZLimit && z <= HFDarkening::upperZLimit) {
-    unsigned int hfZLayer = (int)((z - HFDarkening::lowZLimit)/5);
-    if (hfZLayer >= HFDarkening::upperZLimit) hfZLayer = (HFDarkening::upperZLimit-1);
+	if (z>=HFDarkening::lowZLimit && z <= HFDarkening::upperZLimit) {
+	  unsigned int hfZLayer = (int)((z - HFDarkening::lowZLimit)/5);
+	  if (hfZLayer >= HFDarkening::upperZLimit) hfZLayer = (HFDarkening::upperZLimit-1);
 	  float normalized_lumi = m_HFDarkening->int_lumi(deliveredLumi);
-    for (int i = hfZLayer; i != HFDarkening::numberOfZLayers; ++i) {
+	  for (int i = hfZLayer; i != HFDarkening::numberOfZLayers; ++i) {
 	    dose_acquired = m_HFDarkening->dose(i,r);
 	    weight *= m_HFDarkening->degradation(normalized_lumi*dose_acquired);
 	  }
@@ -403,9 +404,8 @@ bool HCalSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 			    << " hits afterParamS*";
 #endif 
       } else {
-        bool notaMuon = true;
-        if (parCode == mupPDG || parCode == mumPDG ) notaMuon = false;
-        if (useShowerLibrary && notaMuon) {
+	// shower library is applied only for gamma, e+- or stable hadrons
+        if (useShowerLibrary && (isEM || G4TrackToParticleID::isStableHadronIon(aStep->GetTrack()))) {
 #ifdef EDM_ML_DEBUG
           LogDebug("HcalSim") << "HCalSD: Starts shower library from " 
                               << nameVolume << " for Track " 
@@ -608,13 +608,6 @@ void HCalSD::update(const BeginOfJob * job) {
 
 void HCalSD::initRun() {
   G4ParticleTable * theParticleTable = G4ParticleTable::GetParticleTable();
-  G4String          particleName;
-  mumPDG = theParticleTable->FindParticle(particleName="mu-")->GetPDGEncoding();
-  mupPDG = theParticleTable->FindParticle(particleName="mu+")->GetPDGEncoding();
-#ifdef EDM_ML_DEBUG
-  LogDebug("HcalSim") << "HCalSD: Particle code for mu- = " << mumPDG
-		      << " for mu+ = " << mupPDG;
-#endif
   if (showerLibrary) showerLibrary->initRun(theParticleTable,hcalConstants);
   if (showerParam)   showerParam->initRun(theParticleTable,hcalConstants);
   if (hfshower)      hfshower->initRun(theParticleTable,hcalConstants);
@@ -797,8 +790,7 @@ void HCalSD::getFromLibrary (G4Step* aStep, double weight) {
   posGlobal = preStepPoint->GetPosition();
   resetForNewPrimary(posGlobal, etrack);
 
-  G4int particleCode = theTrack->GetDefinition()->GetPDGEncoding();
-  if (particleCode==emPDG || particleCode==epPDG || particleCode==gammaPDG) {
+  if (isEM) {
     edepositEM  = 1.*GeV;
     edepositHAD = 0.;
   } else {
@@ -820,10 +812,7 @@ void HCalSD::getFromLibrary (G4Step* aStep, double weight) {
       currentID.setID(unitID, time, primaryID, 0);
 #ifdef plotDebug
       plotProfile(aStep, hitPoint, 1.0*GeV, time, depth);
-      bool emType = false;
-      if (particleCode==emPDG || particleCode==epPDG || particleCode==gammaPDG)
-	emType = true;
-      plotHF(hitPoint,emType);
+      plotHF(hitPoint,isEM);
 #endif
    
       // check if it is in the same unit and timeslice as the previous one
@@ -848,14 +837,12 @@ void HCalSD::getFromLibrary (G4Step* aStep, double weight) {
 void HCalSD::hitForFibre (const G4Step* aStep, double weight) { // if not ParamShower
 
   const G4StepPoint* preStepPoint  = aStep->GetPreStepPoint();
-  const G4Track*     theTrack      = aStep->GetTrack();
   int primaryID = setTrackID(aStep);
 
   int det   = 5;
   std::vector<HFShower::Hit> hits = hfshower->getHits(aStep, weight);
 
-  G4int particleCode = theTrack->GetDefinition()->GetPDGEncoding();
-  if (particleCode==emPDG || particleCode==epPDG || particleCode==gammaPDG) {
+  if (isEM) {
     edepositEM  = 1.*GeV;
     edepositHAD = 0.;
   } else {
@@ -880,10 +867,7 @@ void HCalSD::hitForFibre (const G4Step* aStep, double weight) { // if not ParamS
 	currentID.setID(unitID, time, primaryID, 0);
 #ifdef plotDebug
 	plotProfile(aStep, hitPoint, edepositEM, time, depth);
-	bool emType = false;
-	if (particleCode==emPDG || particleCode==epPDG || particleCode==gammaPDG)
-	  emType = true;
-	plotHF(hitPoint,emType);
+	plotHF(hitPoint,isEM);
 #endif
 	// check if it is in the same unit and timeslice as the previous one
 	if (currentID == previousID) {

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -193,7 +193,10 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(G4Step * aStep,
 #endif
 
   double tSlice = (postStepPoint->GetGlobalTime())/nanosecond;
-  double pin    = preStepPoint->GetTotalEnergy();
+
+  // use kinetic energy for protons and ions
+  double pin = (track->GetDefinition()->GetBaryonNumber() > 0) 
+    ? preStepPoint->GetKineticEnergy() : preStepPoint->GetTotalEnergy();
 
   return fillHits(hitPoint,momDir,parCode,pin,ok,weight,tSlice,onlyLong);
 }
@@ -211,6 +214,10 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
     return hit;
   }
   ok = true;
+
+  // remove low-energy component
+  const double threshold = 50*MeV;
+  if(pin < threshold) { return hit; }
 
   double pz     = momDir.z(); 
   double zint   = hitPoint.z(); 

--- a/SimG4CMS/Forward/interface/CastorShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/CastorShowerLibrary.h
@@ -70,10 +70,6 @@ private:
   
   std::vector<double> pmom;
 
-  int                 emPDG, epPDG, gammaPDG;
-  int                 pi0PDG, etaPDG, nuePDG, numuPDG, nutauPDG;
-  int                 anuePDG, anumuPDG, anutauPDG, geantinoPDG;
-  int                 mumPDG, mupPDG;
 // new variables (bins in eta and phi)
   unsigned int        nBinsE, nBinsEta, nBinsPhi;
   unsigned int        nEvtPerBinE, nEvtPerBinEta, nEvtPerBinPhi;

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -177,7 +177,8 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   if(theTrack->GetKineticEnergy() > energyThresholdSL) aboveThreshold = true;
     
   // Check if theTrack is a muon (if so, DO NOT use Shower Library) 
-  bool notaMuon = !G4TrackToParticleID::isMuon(theTrack);
+  G4int parCode = theTrack->GetDefinition()->GetPDGEncoding();
+  bool notaMuon = !G4TrackToParticleID::isMuon(parCode);
   
   // angle condition
   double theta_max = M_PI - 3.1305; // angle in radians corresponding to -5.2 eta
@@ -222,7 +223,7 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   TrackInformationExtractor TIextractor;
   TrackInformation& trkInfo = TIextractor(theTrack);
   if (!trkInfo.hasCastorHit()) {
-    trkInfo.setCastorHitPID(theTrack->GetDefinition()->GetPDGEncoding());
+    trkInfo.setCastorHitPID(parCode);
   }
   int castorHitPID = trkInfo.getCastorHitPID();
   
@@ -230,20 +231,9 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   bool isHad = !(G4TrackToParticleID::isGammaElectronPositron(castorHitPID)
 		 || G4TrackToParticleID::isMuon(castorHitPID));
   
-  // Usual calculations
-  // G4ThreeVector      hitPoint = preStepPoint->GetPosition();	
-  // G4ThreeVector      hit_mom = preStepPoint->GetMomentumDirection();
   G4double           stepl    = aStep->GetStepLength()/cm;
   G4double           beta     = preStepPoint->GetBeta();
   G4double           charge   = preStepPoint->GetCharge();
-  //        G4VProcess*        curprocess   = preStepPoint->GetProcessDefinedStep();
-  //        G4String           namePr   = preStepPoint->GetProcessDefinedStep()->GetProcessName();
-  //        std::string nameProcess;
-  //        nameProcess.assign(namePr,0,4);
-  
-  //        G4LogicalVolume*   lv    = currentPV->GetLogicalVolume();
-  //        G4Material*        mat   = lv->GetMaterial();
-  //        G4double           rad   = mat->GetRadlen();
   
   
 #ifdef debugLog

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -233,7 +233,6 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   if (!trkInfo.hasCastorHit()) {
     trkInfo.setCastorHitPID(parCode);
   }
-  int castorHitPID = trkInfo.getCastorHitPID();
   
   G4double           stepl    = aStep->GetStepLength()/cm;
   

--- a/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
+++ b/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
@@ -23,7 +23,6 @@ class TrackingSlaveSD;
 class FrameRotation;
 class UpdatablePSimHit;
 class G4ProcessTypeEnumerator;
-class G4TrackToParticleID;
 class TrackerG4SimHitNumberingScheme;
 
 class TkAccumulatingSensitiveDetector : 
@@ -65,7 +64,6 @@ private:
     std::unique_ptr<TrackingSlaveSD> slaveHighTof;
     std::unique_ptr<FrameRotation>   theRotation;
     std::unique_ptr<const G4ProcessTypeEnumerator> theG4ProcTypeEnumerator;
-    std::unique_ptr<const G4TrackToParticleID> theG4TrackToParticleID;
     std::unique_ptr<TrackerG4SimHitNumberingScheme> theNumberingScheme;
     bool allowZeroEnergyLoss;
     bool printHits;

--- a/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
+++ b/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
@@ -93,7 +93,6 @@ TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(const std::stri
   setNames(temp);  
 
   theG4ProcTypeEnumerator.reset(new G4ProcessTypeEnumerator);
-  theG4TrackToParticleID.reset(new G4TrackToParticleID);
   theNumberingScheme.reset(nullptr);
 }
 
@@ -232,7 +231,7 @@ void TkAccumulatingSensitiveDetector::createHit(const G4Step * aStep)
     float thePabs             = preStepPoint->GetMomentum().mag()/GeV;
     float theTof              = preStepPoint->GetGlobalTime()/nanosecond;
     float theEnergyLoss       = aStep->GetTotalEnergyDeposit()/GeV;
-    int theParticleType       = theG4TrackToParticleID.get()->particleID(theTrack);
+    int theParticleType       = G4TrackToParticleID::particleID(theTrack);
     uint32_t theDetUnitId     = setDetUnitId(aStep);
     int theTrackID            = theTrack->GetTrackID();
     if (theDetUnitId == 0)

--- a/SimG4Core/Notification/interface/G4TrackToParticleID.h
+++ b/SimG4Core/Notification/interface/G4TrackToParticleID.h
@@ -3,15 +3,23 @@
 
 class G4Track;
 
-/**
- * Converts G4Track to particle ID. For PDG Particles it is the obvious number; for alpha, triton and deuteron 
- * the CMS convention is used
- */
-
 class G4TrackToParticleID
 {
 public:
-  static int particleID(const G4Track *);
+  // CMS convention (different from ordinary PDG code)
+  static int  particleID(const G4Track *);
+
+  static bool isGammaElectronPositron(int pdgCode);
+  static bool isGammaElectronPositron(const G4Track *);
+
+  static bool isMuon(int pdgCode);
+  static bool isMuon(const G4Track *);
+
+  // pi+-, p, pbar, n, nbar, KL, K+-, light ion and anti-ion, generic ion
+  static bool isStableHadron(int pdgCode);
+
+  // pi+-, p, pbar, n, nbar, KL, K+-, light ions and anti-ions 
+  static bool isStableHadronIon(const G4Track *);
 };
 
 #endif

--- a/SimG4Core/Notification/src/G4TrackToParticleID.cc
+++ b/SimG4Core/Notification/src/G4TrackToParticleID.cc
@@ -42,7 +42,8 @@ bool G4TrackToParticleID::isStableHadron(int pdgCode)
   // pi+-, p, pbar, n, nbar, KL, K+-, light ions and anti-ions 
   int pdg = std::abs(pdgCode);
   return (pdg == 211 || pdg == 2212 || pdg == 2112 || pdg == 130 || pdg == 321
-	  || pdg == 1000010020 || pdg == 1000010030 || 1000020040);
+	  || pdg == 1000010020 || pdg == 1000010030 
+	  || pdg == 1000020030 || pdg == 1000020040);
 }
 
 bool G4TrackToParticleID::isStableHadronIon(const G4Track * g4trk)
@@ -50,7 +51,8 @@ bool G4TrackToParticleID::isStableHadronIon(const G4Track * g4trk)
   // pi+-, p, pbar, n, nbar, KL, K+-, light ion and anti-ion, generic ion
   int pdg = std::abs(g4trk->GetDefinition()->GetPDGEncoding());
   return (pdg == 211 || pdg == 2212 || pdg == 2112 || pdg == 130 || pdg == 321
-	  || pdg == 1000010020 || pdg == 1000010030 || 1000020040
+	  || pdg == 1000010020 || pdg == 1000010030 
+	  || pdg == 1000020030 || pdg == 1000020040
 	  || g4trk->GetDefinition()->IsGeneralIon());
 }
 

--- a/SimG4Core/Notification/src/G4TrackToParticleID.cc
+++ b/SimG4Core/Notification/src/G4TrackToParticleID.cc
@@ -9,8 +9,48 @@ int G4TrackToParticleID::particleID(const G4Track * g4trk)
     int particleID_ = g4trk->GetDefinition()->GetPDGEncoding();
     if (0 == particleID_) {
       edm::LogWarning("SimG4CoreNotification") 
-	<< "G4TrackToParticleID: unknown code for track Id = " << g4trk->GetTrackID();
+	<< "G4TrackToParticleID: unknown code 0 for track Id = " << g4trk->GetTrackID();
       particleID_ = -99;
     }
     return particleID_;
 }
+
+bool G4TrackToParticleID::isGammaElectronPositron(int pdgCode)
+{
+  int pdg = std::abs(pdgCode);
+  return (pdg == 11 || pdg == 22);
+}
+
+bool G4TrackToParticleID::isGammaElectronPositron(const G4Track * g4trk)
+{
+  int pdg = std::abs(g4trk->GetDefinition()->GetPDGEncoding());
+  return (pdg == 11 || pdg == 22);
+}
+
+bool G4TrackToParticleID::isMuon(int pdgCode)
+{
+  return (std::abs(pdgCode) == 13);
+}
+
+bool G4TrackToParticleID::isMuon(const G4Track * g4trk)
+{
+  return (std::abs(g4trk->GetDefinition()->GetPDGEncoding()) == 13);
+}
+
+bool G4TrackToParticleID::isStableHadron(int pdgCode)
+{
+  // pi+-, p, pbar, n, nbar, KL, K+-, light ions and anti-ions 
+  int pdg = std::abs(pdgCode);
+  return (pdg == 211 || pdg == 2212 || pdg == 2112 || pdg == 130 || pdg == 321
+	  || pdg == 1000010020 || pdg == 1000010030 || 1000020040);
+}
+
+bool G4TrackToParticleID::isStableHadronIon(const G4Track * g4trk)
+{
+  // pi+-, p, pbar, n, nbar, KL, K+-, light ion and anti-ion, generic ion
+  int pdg = std::abs(g4trk->GetDefinition()->GetPDGEncoding());
+  return (pdg == 211 || pdg == 2212 || pdg == 2112 || pdg == 130 || pdg == 321
+	  || pdg == 1000010020 || pdg == 1000010030 || 1000020040
+	  || g4trk->GetDefinition()->IsGeneralIon());
+}
+


### PR DESCRIPTION
This PR was discussed at the SIM meeting: 
https://indico.cern.ch/event/702324/contributions/2885360/attachments/1596130/2528121/VI20180206.pdf 

Several static methods are added to identify Geant4 particle type. These methods are used to select shower library branches with EM or hadronic hits. Hyperons and exotic particles will not any more treated as "hadrons", they should decay and only decay products will provide showers. Due to that, in many workflows one can expect different simulation histories and only statistical comparison of results is possible.

HF hits are sampled differently:
1) for e+-, gamma and stable hadrons SL is called, if kinetic energy of a particle is below 50 MeV the particle is killed 2) Hyperons are ignored - no hits are created, allowing them to decay first
3) If baryon number of a particle is above 0 then kinetic energy is used for SL interpolation and not total energy. DUe to these modifications low-energy ions does not produce any more extra hits

CastorSD class was changed more in order to use this opportunity when results are not identical:
1) many commented lines removed; 2) fabs -> std::abs 3) early check of primary particle type and do not perform computations if a particle is not for shower library and cannot produce Cerenkov light.

Additionally some commented lines and unused variables are removed in other classes.
