### PR TITLE
FastSimulation/*: Change return type of ESProducers to unique_ptr.

### DIFF
--- a/FastSimulation/ParticlePropagator/plugins/MagneticFieldMapESProducer.cc
+++ b/FastSimulation/ParticlePropagator/plugins/MagneticFieldMapESProducer.cc
@@ -19,7 +19,7 @@ MagneticFieldMapESProducer::MagneticFieldMapESProducer(const edm::ParameterSet &
 
 MagneticFieldMapESProducer::~MagneticFieldMapESProducer() {}
 
-std::shared_ptr<MagneticFieldMap>
+std::unique_ptr<MagneticFieldMap>
 MagneticFieldMapESProducer::produce(const MagneticFieldMapRecord & iRecord){ 
 
   edm::ESHandle<TrackerInteractionGeometry> theInteractionGeometry;
@@ -28,9 +28,7 @@ MagneticFieldMapESProducer::produce(const MagneticFieldMapRecord & iRecord){
   iRecord.getRecord<TrackerInteractionGeometryRecord>().get(_label, theInteractionGeometry );
   iRecord.getRecord<IdealMagneticFieldRecord>().get(theMagneticField );
 
-  _map = std::make_shared<MagneticFieldMap>(&(*theMagneticField),&(*theInteractionGeometry));
-
-  return _map;
+  return  std::make_unique<MagneticFieldMap>(&(*theMagneticField),&(*theInteractionGeometry));
 
 }
 

--- a/FastSimulation/ParticlePropagator/plugins/MagneticFieldMapESProducer.h
+++ b/FastSimulation/ParticlePropagator/plugins/MagneticFieldMapESProducer.h
@@ -11,9 +11,8 @@ class  MagneticFieldMapESProducer: public edm::ESProducer{
  public:
   MagneticFieldMapESProducer(const edm::ParameterSet & p);
   ~MagneticFieldMapESProducer() override; 
-  std::shared_ptr<MagneticFieldMap> produce(const MagneticFieldMapRecord &);
+  std::unique_ptr<MagneticFieldMap> produce(const MagneticFieldMapRecord &);
  private:
-  std::shared_ptr<MagneticFieldMap> _map;
   std::string _label;
 };
 

--- a/FastSimulation/TrackerSetup/plugins/TrackerInteractionGeometryESProducer.cc
+++ b/FastSimulation/TrackerSetup/plugins/TrackerInteractionGeometryESProducer.cc
@@ -17,14 +17,13 @@ TrackerInteractionGeometryESProducer::TrackerInteractionGeometryESProducer(const
 
 TrackerInteractionGeometryESProducer::~TrackerInteractionGeometryESProducer() {}
 
-std::shared_ptr<TrackerInteractionGeometry>
+std::unique_ptr<TrackerInteractionGeometry>
 TrackerInteractionGeometryESProducer::produce(const TrackerInteractionGeometryRecord & iRecord){ 
 
   edm::ESHandle<GeometricSearchTracker> theGeomSearchTracker;
   
   iRecord.getRecord<TrackerRecoGeometryRecord>().get(_label, theGeomSearchTracker );
-  _tracker = std::make_shared<TrackerInteractionGeometry>(theTrackerMaterial,&(*theGeomSearchTracker));
-  return _tracker;
+  return std::make_unique<TrackerInteractionGeometry>(theTrackerMaterial,&(*theGeomSearchTracker));
 
 }
 

--- a/FastSimulation/TrackerSetup/plugins/TrackerInteractionGeometryESProducer.h
+++ b/FastSimulation/TrackerSetup/plugins/TrackerInteractionGeometryESProducer.h
@@ -12,9 +12,8 @@ class  TrackerInteractionGeometryESProducer: public edm::ESProducer{
  public:
   TrackerInteractionGeometryESProducer(const edm::ParameterSet & p);
   ~TrackerInteractionGeometryESProducer() override; 
-  std::shared_ptr<TrackerInteractionGeometry> produce(const TrackerInteractionGeometryRecord &);
+  std::unique_ptr<TrackerInteractionGeometry> produce(const TrackerInteractionGeometryRecord &);
  private:
-  std::shared_ptr<TrackerInteractionGeometry> _tracker;
   std::string _label;
   edm::ParameterSet theTrackerMaterial;
 };


### PR DESCRIPTION
Remove shared_ptr class member that is not needed.