### PR TITLE
Add ability to measure time in the EventSetup

### DIFF
--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -27,6 +27,8 @@
 
 // forward declarations
 namespace edm {
+   class ActivityRegistry;
+
    namespace eventsetup {
       struct ComponentDescription;
       class DataKey;
@@ -41,8 +43,8 @@ namespace edm {
          // ---------- const member functions ---------------------
          bool cacheIsValid() const { return cacheIsValid_.load(std::memory_order_acquire); }
 
-         void doGet(EventSetupRecord const& iRecord, DataKey const& iKey, bool iTransiently) const;
-         void const* get(EventSetupRecord const&, DataKey const& iKey, bool iTransiently) const;
+         void doGet(EventSetupRecord const& iRecord, DataKey const& iKey, bool iTransiently, ActivityRegistry*) const;
+         void const* get(EventSetupRecord const&, DataKey const& iKey, bool iTransiently, ActivityRegistry*) const;
 
          ///returns the description of the DataProxyProvider which owns this Proxy
          ComponentDescription const* providerDescription() const {

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -35,6 +35,7 @@
 // forward declarations
 
 namespace edm {
+   class ActivityRegistry;
    class ESInputTag;
    
    namespace eventsetup {
@@ -116,6 +117,9 @@ namespace edm {
          getAvoidCompilerBug(const T*& iValue) const {
             iValue = &(get<T>());
          }
+
+      friend class eventsetup::EventSetupRecord;
+
     protected:
       //Only called by EventSetupProvider
       void setKnownRecordsSupplier(eventsetup::EventSetupKnownRecordsSupplier const* iSupplier) {
@@ -127,11 +131,13 @@ namespace edm {
       void clear();
       
     private:
-      EventSetup();
+      EventSetup(ActivityRegistry*);
       
       EventSetup(EventSetup const&) = delete; // stop default
 
       EventSetup const& operator=(EventSetup const&) = delete; // stop default
+
+      ActivityRegistry* activityRegistry() const { return activityRegistry_; }
 
       void insert(const eventsetup::EventSetupRecordKey&,
                   const eventsetup::EventSetupRecord*);
@@ -141,6 +147,7 @@ namespace edm {
       //NOTE: the records are not owned
       std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecord const *> recordMap_;
       eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;
+      ActivityRegistry* activityRegistry_;
   };
 
   // Free functions to retrieve an object from the EventSetup.

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -33,6 +33,7 @@
 
 // forward declarations
 namespace edm {
+   class ActivityRegistry;
    class EventSetupRecordIntervalFinder;
    class IOVSyncValue;
    class ParameterSet;
@@ -57,7 +58,7 @@ class EventSetupProvider {
       typedef std::multimap<RecordName, DataKeyInfo> RecordToDataMap;
       typedef std::map<ComponentDescription, RecordToDataMap> PreferredProviderInfo;
 
-      EventSetupProvider(unsigned subProcessIndex = 0U, PreferredProviderInfo const* iInfo = nullptr);
+      EventSetupProvider(ActivityRegistry*, unsigned subProcessIndex = 0U, PreferredProviderInfo const* iInfo = nullptr);
       virtual ~EventSetupProvider();
 
       // ---------- const member functions ---------------------

--- a/FWCore/Framework/interface/EventSetupProviderMaker.h
+++ b/FWCore/Framework/interface/EventSetupProviderMaker.h
@@ -6,13 +6,14 @@
 
 // forward declarations
 namespace edm {
+  class ActivityRegistry;
   class ParameterSet;
   namespace eventsetup {
     class EventSetupProvider;
     class EventSetupsController;
 
     std::unique_ptr<EventSetupProvider>
-    makeEventSetupProvider(ParameterSet const& params, unsigned subProcessIndex);
+    makeEventSetupProvider(ParameterSet const& params, unsigned subProcessIndex, ActivityRegistry*);
 
     void
     fillEventSetupProvider(EventSetupsController& esController,

--- a/FWCore/Framework/src/DataProxy.cc
+++ b/FWCore/Framework/src/DataProxy.cc
@@ -18,7 +18,7 @@
 #include "FWCore/Framework/interface/ComponentDescription.h"
 #include "FWCore/Framework/interface/MakeDataException.h"
 #include "FWCore/Framework/interface/EventSetupRecord.h"
-
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
 //
 // constants, enums and typedefs
@@ -97,14 +97,47 @@ namespace  {
                            const DataKey& iKey)  {
       throw MakeDataException(iRecord.key(),iKey);
    }
+
+   class ESSignalSentry {
+   public:
+      ESSignalSentry(const EventSetupRecord& iRecord,
+                     const DataKey& iKey,
+                     ComponentDescription const* componentDescription,
+                     ActivityRegistry* activityRegistry) :
+         eventSetupRecord_(iRecord),
+         dataKey_(iKey),
+         componentDescription_(componentDescription),
+         calledPostLock_(false),
+         activityRegistry_(activityRegistry) {
+
+         activityRegistry->preLockEventSetupGetSignal_(componentDescription_, eventSetupRecord_.key(), dataKey_);
+      }
+      void sendPostLockSignal() {
+         calledPostLock_ = true;
+         activityRegistry_->postLockEventSetupGetSignal_(componentDescription_, eventSetupRecord_.key(), dataKey_);
+      }
+      ~ESSignalSentry() noexcept(false) {
+         if (!calledPostLock_) {
+            activityRegistry_->postLockEventSetupGetSignal_(componentDescription_, eventSetupRecord_.key(), dataKey_);
+         }
+         activityRegistry_->postEventSetupGetSignal_(componentDescription_, eventSetupRecord_.key(), dataKey_);
+      }
+   private:
+      EventSetupRecord const& eventSetupRecord_;
+      DataKey const& dataKey_;
+      ComponentDescription const* componentDescription_;
+      bool calledPostLock_;
+      ActivityRegistry* activityRegistry_;
+   };
 }
-      
-      
+
 const void* 
-DataProxy::get(const EventSetupRecord& iRecord, const DataKey& iKey, bool iTransiently) const
+DataProxy::get(const EventSetupRecord& iRecord, const DataKey& iKey, bool iTransiently, ActivityRegistry* activityRegistry) const
 {
    if(!cacheIsValid()) {
+      ESSignalSentry signalSentry(iRecord, iKey, providerDescription(), activityRegistry);
       std::lock_guard<std::recursive_mutex> guard(s_esGlobalMutex);
+      signalSentry.sendPostLockSignal();
       if(!cacheIsValid()) {
          cache_ = const_cast<DataProxy*>(this)->getImpl(iRecord, iKey);
          cacheIsValid_.store(true,std::memory_order_release);
@@ -123,8 +156,8 @@ DataProxy::get(const EventSetupRecord& iRecord, const DataKey& iKey, bool iTrans
    return cache_;
 }
 
-void DataProxy::doGet(const EventSetupRecord& iRecord, const DataKey& iKey, bool iTransiently) const {
-   get(iRecord, iKey, iTransiently);
+void DataProxy::doGet(const EventSetupRecord& iRecord, const DataKey& iKey, bool iTransiently, ActivityRegistry* activityRegistry) const {
+   get(iRecord, iKey, iTransiently, activityRegistry);
 }
       
       

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -475,7 +475,7 @@ namespace edm {
     std::shared_ptr<CommonParams> common(items.initMisc(*parameterSet));
 
     // intialize the event setup provider
-    esp_ = espController_->makeProvider(*parameterSet);
+    esp_ = espController_->makeProvider(*parameterSet, items.actReg_.get());
 
     // initialize the looper, if any
     looper_ = fillLooper(*espController_, *esp_, *parameterSet);

--- a/FWCore/Framework/src/EventSetup.cc
+++ b/FWCore/Framework/src/EventSetup.cc
@@ -31,7 +31,10 @@ namespace edm {
 //
 // constructors and destructor
 //
-   EventSetup::EventSetup() : recordMap_()
+EventSetup::EventSetup(ActivityRegistry* activityRegistry) :
+   recordMap_(),
+   activityRegistry_(activityRegistry)
+
 {
 }
 

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -61,8 +61,10 @@ namespace edm {
 //
 // constructors and destructor
 //
-EventSetupProvider::EventSetupProvider(unsigned subProcessIndex, const PreferredProviderInfo* iInfo) :
-eventSetup_(),
+EventSetupProvider::EventSetupProvider(ActivityRegistry* activityRegistry,
+                                       unsigned subProcessIndex,
+                                       const PreferredProviderInfo* iInfo) :
+eventSetup_(activityRegistry),
 providers_(),
 knownRecordsSupplier_( std::make_unique<KnownRecordsSupplierImpl>(providers_)),
 mustFinishConfiguration_(true),

--- a/FWCore/Framework/src/EventSetupProviderMaker.cc
+++ b/FWCore/Framework/src/EventSetupProviderMaker.cc
@@ -23,12 +23,12 @@ namespace edm {
   namespace eventsetup {
   // ---------------------------------------------------------------
     std::unique_ptr<EventSetupProvider>
-    makeEventSetupProvider(ParameterSet const& params, unsigned subProcessIndex) {
+    makeEventSetupProvider(ParameterSet const& params, unsigned subProcessIndex, ActivityRegistry* activityRegistry) {
       std::vector<std::string> prefers =
         params.getParameter<std::vector<std::string> >("@all_esprefers");
 
       if(prefers.empty()) {
-        return std::make_unique<EventSetupProvider>(subProcessIndex);
+        return std::make_unique<EventSetupProvider>(activityRegistry, subProcessIndex);
       }
 
       EventSetupProvider::PreferredProviderInfo preferInfo;
@@ -96,7 +96,7 @@ namespace edm {
                                         preferPSet.getParameter<std::string>("@module_label"),
                                         false)] = recordToData;
       }
-      return std::make_unique<EventSetupProvider>(subProcessIndex, &preferInfo);
+      return std::make_unique<EventSetupProvider>(activityRegistry, subProcessIndex, &preferInfo);
     }
 
     // ---------------------------------------------------------------

--- a/FWCore/Framework/src/EventSetupRecord.cc
+++ b/FWCore/Framework/src/EventSetupRecord.cc
@@ -17,6 +17,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/DataProxy.h"
 #include "FWCore/Framework/interface/ComponentDescription.h"
@@ -181,7 +182,7 @@ EventSetupRecord::getFromProxy(DataKey const & iKey ,
    if(nullptr!=proxy) {
       try {
         convertException::wrap([&]() {
-            hold = proxy->get(*this, iKey,iTransientAccessOnly);
+            hold = proxy->get(*this, iKey,iTransientAccessOnly, eventSetup_->activityRegistry());
             iDesc = proxy->providerDescription(); 
         });
       }
@@ -211,7 +212,7 @@ EventSetupRecord::doGet(const DataKey& aKey, bool aGetTransiently) const {
    if(nullptr != proxy) {
       try {
          convertException::wrap([&]() {
-            proxy->doGet(*this, aKey, aGetTransiently);
+            proxy->doGet(*this, aKey, aGetTransiently, eventSetup_->activityRegistry());
          });
       }
       catch( cms::Exception& e) {

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -29,12 +29,12 @@ namespace edm {
     }
 
     std::shared_ptr<EventSetupProvider>
-    EventSetupsController::makeProvider(ParameterSet& iPSet) {
+    EventSetupsController::makeProvider(ParameterSet& iPSet, ActivityRegistry* activityRegistry) {
 
       // Makes an EventSetupProvider
       // Also parses the prefer information from ParameterSets and puts
       // it in a map that is stored in the EventSetupProvider
-      std::shared_ptr<EventSetupProvider> returnValue(makeEventSetupProvider(iPSet, providers_.size()) );
+      std::shared_ptr<EventSetupProvider> returnValue(makeEventSetupProvider(iPSet, providers_.size(), activityRegistry) );
 
       // Construct the ESProducers and ESSources
       // shared_ptrs to them are temporarily stored in this

--- a/FWCore/Framework/src/EventSetupsController.h
+++ b/FWCore/Framework/src/EventSetupsController.h
@@ -26,6 +26,7 @@
 
 namespace edm {
 
+   class ActivityRegistry;
    class EventSetupRecordIntervalFinder;
    class ParameterSet;
    class IOVSyncValue;
@@ -74,7 +75,7 @@ namespace edm {
       public:
          EventSetupsController();
 
-         std::shared_ptr<EventSetupProvider> makeProvider(ParameterSet&);
+         std::shared_ptr<EventSetupProvider> makeProvider(ParameterSet&, ActivityRegistry*);
 
          void eventSetupForInstance(IOVSyncValue const& syncValue);
 

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -145,7 +145,7 @@ namespace edm {
     items.initMisc(*processParameterSet_);
 
     // intialize the event setup provider
-    esp_ = esController.makeProvider(*processParameterSet_);
+    esp_ = esController.makeProvider(*processParameterSet_, actReg_.get());
 
     branchIDListHelper_ = items.branchIDListHelper();
     updateBranchIDListHelper(parentBranchIDListHelper->branchIDLists());

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/EventSetupRecordProvider.h"
 #include "FWCore/Framework/interface/NoRecordException.h"
 #include "FWCore/Framework/interface/print_eventsetup_record_dependencies.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
 #include "cppunit/extensions/HelperMacros.h"
 #include <cstring>
@@ -76,6 +77,9 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testdependentrecord);
  */
 
 namespace {
+
+edm::ActivityRegistry activityRegistry;
+
 class DummyProxyProvider : public edm::eventsetup::DataProxyProvider {
 public:
    DummyProxyProvider() {
@@ -508,7 +512,7 @@ void testdependentrecord::timeAndRunTest()
 
    {
      //check that going all the way through EventSetup works properly
-     edm::eventsetup::EventSetupProvider provider;
+     edm::eventsetup::EventSetupProvider provider(&activityRegistry);
      std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
      provider.add(dummyProv);
      
@@ -556,7 +560,7 @@ void testdependentrecord::timeAndRunTest()
    {
       //check that going all the way through EventSetup works properly
       // using two records with open ended IOVs
-      edm::eventsetup::EventSetupProvider provider;
+      edm::eventsetup::EventSetupProvider provider(&activityRegistry);
       std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
       provider.add(dummyProv);
       
@@ -626,7 +630,7 @@ void testdependentrecord::dependentSetproviderTest()
 
 void testdependentrecord::getTest()
 {
-   edm::eventsetup::EventSetupProvider provider;
+   edm::eventsetup::EventSetupProvider provider(&activityRegistry);
    std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
    provider.add(dummyProv);
 
@@ -652,7 +656,7 @@ void testdependentrecord::getTest()
 
 void testdependentrecord::oneOfTwoRecordTest()
 {
-  edm::eventsetup::EventSetupProvider provider;
+  edm::eventsetup::EventSetupProvider provider(&activityRegistry);
   std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
   provider.add(dummyProv);
   
@@ -682,7 +686,7 @@ void testdependentrecord::oneOfTwoRecordTest()
 }
 void testdependentrecord::resetTest()
 {
-  edm::eventsetup::EventSetupProvider provider;
+  edm::eventsetup::EventSetupProvider provider(&activityRegistry);
   std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
   provider.add(dummyProv);
   
@@ -830,7 +834,7 @@ void testdependentrecord::invalidRecordTest()
 
 void testdependentrecord::extendIOVTest()
 {
-   edm::eventsetup::EventSetupProvider provider;
+   edm::eventsetup::EventSetupProvider provider(&activityRegistry);
    std::shared_ptr<edm::eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
    provider.add(dummyProv);
    

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -14,6 +14,7 @@
 #include "FWCore/Framework/interface/EventSetupProvider.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESProducts.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "cppunit/extensions/HelperMacros.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
@@ -21,6 +22,10 @@ using edm::eventsetup::test::DummyData;
 using namespace edm::eventsetup;
 using edm::ESProducer;
 using edm::EventSetupRecordIntervalFinder;
+
+namespace {
+edm::ActivityRegistry activityRegistry;
+}
 
 class testEsproducer: public CppUnit::TestFixture 
 {
@@ -157,7 +162,7 @@ void testEsproducer::registerTest()
 
 void testEsproducer::getFromTest()
 {
-   EventSetupProvider provider;
+  EventSetupProvider provider(&activityRegistry);
    
    std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<Test1Producer>();
    provider.add(pProxyProv);
@@ -178,7 +183,7 @@ void testEsproducer::getFromTest()
 
 void testEsproducer::getfromShareTest()
 {
-   EventSetupProvider provider;
+  EventSetupProvider provider(&activityRegistry);
    
    std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<ShareProducer>();
    provider.add(pProxyProv);
@@ -199,7 +204,7 @@ void testEsproducer::getfromShareTest()
 
 void testEsproducer::getfromUniqueTest()
 {
-   EventSetupProvider provider;
+   EventSetupProvider provider(&activityRegistry);
    
    std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<UniqueProducer>();
    provider.add(pProxyProv);
@@ -221,7 +226,7 @@ void testEsproducer::getfromUniqueTest()
 void testEsproducer::labelTest()
 {
    try {
-   EventSetupProvider provider;
+   EventSetupProvider provider(&activityRegistry);
    
    std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<LabelledProducer>();
    provider.add(pProxyProv);
@@ -284,7 +289,7 @@ private:
 
 void testEsproducer::decoratorTest()
 {
-   EventSetupProvider provider;
+   EventSetupProvider provider(&activityRegistry);
    
    std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<DecoratorProducer>();
    provider.add(pProxyProv);
@@ -335,7 +340,7 @@ private:
 
 void testEsproducer::dependsOnTest()
 {
-   EventSetupProvider provider;
+   EventSetupProvider provider(&activityRegistry);
    
    std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<DepProducer>();
    provider.add(pProxyProv);
@@ -362,7 +367,7 @@ void testEsproducer::failMultipleRegistration()
 
 void testEsproducer::forceCacheClearTest()
 {
-   EventSetupProvider provider;
+   EventSetupProvider provider(&activityRegistry);
    
    std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<Test1Producer>();
    provider.add(pProxyProv);

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -34,6 +34,7 @@
 #include "FWCore/Framework/interface/DataProxyProvider.h"
 #include "FWCore/Framework/interface/EventSetupRecordProviderFactoryTemplate.h"
 #include "FWCore/Framework/test/DummyEventSetupRecordRetriever.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
 using namespace edm;
 namespace {
@@ -100,10 +101,13 @@ public:
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testEventsetup);
 
+namespace {
+  edm::ActivityRegistry activityRegistry;
+}
 
 void testEventsetup::constructTest()
 {
-   eventsetup::EventSetupProvider provider;
+   eventsetup::EventSetupProvider provider(&activityRegistry);
    const Timestamp time(1);
    const IOVSyncValue timestamp(time);
    EventSetup const& eventSetup = provider.eventSetupForInstance(timestamp);
@@ -112,7 +116,7 @@ void testEventsetup::constructTest()
 
 void testEventsetup::getTest()
 {
-   eventsetup::EventSetupProvider provider;
+   eventsetup::EventSetupProvider provider(&activityRegistry);
    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
    CPPUNIT_ASSERT(non_null(&eventSetup));
    //eventSetup.get<DummyRecord>();
@@ -127,7 +131,7 @@ void testEventsetup::getTest()
 
 void testEventsetup::tryToGetTest()
 {
-  eventsetup::EventSetupProvider provider;
+  eventsetup::EventSetupProvider provider(&activityRegistry);
   EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
   CPPUNIT_ASSERT(non_null(&eventSetup));
   //eventSetup.get<DummyRecord>();
@@ -142,7 +146,7 @@ void testEventsetup::tryToGetTest()
 
 void testEventsetup::getExcTest()
 {
-   eventsetup::EventSetupProvider provider;
+   eventsetup::EventSetupProvider provider(&activityRegistry);
    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
    CPPUNIT_ASSERT(non_null(&eventSetup));
    eventSetup.get<DummyRecord>();
@@ -152,6 +156,9 @@ void testEventsetup::getExcTest()
 
 class DummyEventSetupProvider : public edm::eventsetup::EventSetupProvider {
 public:
+
+   DummyEventSetupProvider(ActivityRegistry* activityRegistry) : EventSetupProvider(activityRegistry) { }
+
    template<class T>
    void insert(std::unique_ptr<T> iRecord) {
       edm::eventsetup::EventSetupProvider::insert(std::move(iRecord));
@@ -160,7 +167,7 @@ public:
 
 void testEventsetup::recordProviderTest()
 {
-   DummyEventSetupProvider provider;
+   DummyEventSetupProvider provider(&activityRegistry);
    typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
    auto dummyRecordProvider = std::make_unique<DummyRecordProvider>();
    
@@ -203,7 +210,7 @@ private:
 
 void testEventsetup::recordValidityTest()
 {
-   DummyEventSetupProvider provider;
+   DummyEventSetupProvider provider(&activityRegistry);
    typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
    auto dummyRecordProvider = std::make_unique<DummyRecordProvider>();
 
@@ -240,7 +247,7 @@ void testEventsetup::recordValidityTest()
 
 void testEventsetup::recordValidityExcTest()
 {
-   DummyEventSetupProvider provider;
+   DummyEventSetupProvider provider(&activityRegistry);
    typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
    auto dummyRecordProvider = std::make_unique<DummyRecordProvider>();
 
@@ -277,7 +284,7 @@ static eventsetup::EventSetupRecordProviderFactoryTemplate<DummyRecord> s_factor
 
 void testEventsetup::proxyProviderTest()
 {
-   eventsetup::EventSetupProvider provider;
+   eventsetup::EventSetupProvider provider(&activityRegistry);
    std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
    provider.add(dummyProv);
    
@@ -290,7 +297,7 @@ void testEventsetup::producerConflictTest()
 {
    edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
    using edm::eventsetup::test::DummyProxyProvider;
-   eventsetup::EventSetupProvider provider;
+   eventsetup::EventSetupProvider provider(&activityRegistry);
    {
       std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
       dummyProv->setDescription(description);
@@ -309,7 +316,7 @@ void testEventsetup::sourceConflictTest()
 {
    edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
    using edm::eventsetup::test::DummyProxyProvider;
-   eventsetup::EventSetupProvider provider;
+   eventsetup::EventSetupProvider provider(&activityRegistry);
    {
       std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
       dummyProv->setDescription(description);
@@ -330,7 +337,7 @@ void testEventsetup::twoSourceTest()
 {
   edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
   using edm::eventsetup::test::DummyProxyProvider;
-  eventsetup::EventSetupProvider provider;
+  eventsetup::EventSetupProvider provider(&activityRegistry);
   {
     std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>();
     dummyProv->setDescription(description);
@@ -356,7 +363,7 @@ void testEventsetup::provenanceTest()
    DummyData kGood; kGood.value_ = 1;
    DummyData kBad; kBad.value_=0;
 
-   eventsetup::EventSetupProvider provider;
+   eventsetup::EventSetupProvider provider(&activityRegistry);
    try {
       {
          edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
@@ -397,7 +404,7 @@ void testEventsetup::getDataWithLabelTest()
    DummyData kGood; kGood.value_ = 1;
    DummyData kBad; kBad.value_=0;
    
-   eventsetup::EventSetupProvider provider;
+   eventsetup::EventSetupProvider provider(&activityRegistry);
    try {
       {
          edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
@@ -440,7 +447,7 @@ void testEventsetup::getDataWithESInputTagTest()
    DummyData kGood; kGood.value_ = 1;
    DummyData kBad; kBad.value_=0;
    
-   eventsetup::EventSetupProvider provider;
+   eventsetup::EventSetupProvider provider(&activityRegistry);
    try {
       {
          edm::eventsetup::ComponentDescription description("DummyProxyProvider","testOne",true);
@@ -515,7 +522,7 @@ void testEventsetup::sourceProducerResolutionTest()
    DummyData kBad; kBad.value_=0;
 
    {
-      eventsetup::EventSetupProvider provider;
+      eventsetup::EventSetupProvider provider(&activityRegistry);
       {
          edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
          std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
@@ -541,7 +548,7 @@ void testEventsetup::sourceProducerResolutionTest()
 
    //reverse order
    {
-      eventsetup::EventSetupProvider provider;
+      eventsetup::EventSetupProvider provider(&activityRegistry);
       {
          edm::eventsetup::ComponentDescription description("DummyProxyProvider","",false);
          std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
@@ -583,7 +590,7 @@ void testEventsetup::preferTest()
          //default means use all proxies
          preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
          
-         eventsetup::EventSetupProvider provider(0U, &preferInfo);
+         eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","bad",false);
             std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kBad);
@@ -614,7 +621,7 @@ void testEventsetup::preferTest()
          EventSetupProvider::RecordToDataMap recordToData;
          //default means use all proxies
          preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
-         eventsetup::EventSetupProvider provider(0U, &preferInfo);
+         eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
             std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
@@ -646,7 +653,7 @@ void testEventsetup::preferTest()
          recordToData.insert(std::make_pair(std::string("DummyRecord"),
                                             std::make_pair(std::string("DummyData"),std::string())));
          preferInfo[ComponentDescription("DummyProxyProvider","",false)]=recordToData;
-         eventsetup::EventSetupProvider provider(0U, &preferInfo);
+         eventsetup::EventSetupProvider provider(&activityRegistry, 0U, &preferInfo);
          {
             edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
             std::shared_ptr<eventsetup::DataProxyProvider> dummyProv = std::make_shared<DummyProxyProvider>(kGood);
@@ -683,7 +690,7 @@ void testEventsetup::introspectionTest()
   DummyData kGood; kGood.value_ = 1;
   DummyData kBad; kBad.value_=0;
   
-  eventsetup::EventSetupProvider provider;
+  eventsetup::EventSetupProvider provider(&activityRegistry);
   try {
   {
     edm::eventsetup::ComponentDescription description("DummyProxyProvider","",true);
@@ -721,7 +728,7 @@ void testEventsetup::introspectionTest()
 
 void testEventsetup::iovExtentionTest()
 {
-  DummyEventSetupProvider provider;
+  DummyEventSetupProvider provider(&activityRegistry);
   typedef eventsetup::EventSetupRecordProviderTemplate<DummyRecord> DummyRecordProvider;
   auto dummyRecordProvider = std::make_unique<DummyRecordProvider>();
   

--- a/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
@@ -22,8 +22,13 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/EventSetupProvider.h"
 #include "FWCore/Framework/src/EventSetupsController.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
 using namespace edm::eventsetup;
+
+namespace {
+  edm::ActivityRegistry activityRegistry;
+}
 
 class testEventsetupplugin: public CppUnit::TestFixture
 {
@@ -57,7 +62,7 @@ void testEventsetupplugin::finderTest()
 {
    doInit();
    EventSetupsController esController;
-   EventSetupProvider provider;
+   EventSetupProvider provider(&activityRegistry);
    
    edm::ParameterSet dummyFinderPSet;
    dummyFinderPSet.addParameter("@module_type", std::string("LoadableDummyFinder"));

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -8,6 +8,7 @@
 
 #include "cppunit/extensions/HelperMacros.h"
 
+#include "FWCore/Framework/interface/EventSetupProvider.h"
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/EventSetupRecordProviderTemplate.h"
 #include "FWCore/Framework/interface/EventSetupRecordProviderFactoryManager.h"
@@ -22,6 +23,12 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
+
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+
+namespace {
+  edm::ActivityRegistry activityRegistry;
+}
 
 using namespace edm;
 using namespace edm::eventsetup;
@@ -190,7 +197,10 @@ void testEventsetupRecord::proxyTest()
 
 void testEventsetupRecord::getTest()
 {
+   eventsetup::EventSetupProvider provider(&activityRegistry);
    DummyRecord dummyRecord;
+   provider.addRecordToEventSetup(dummyRecord);
+
    FailingDummyProxy dummyProxy;
 
    const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),
@@ -269,7 +279,9 @@ void testEventsetupRecord::getNodataExpTest()
 
 void testEventsetupRecord::getExepTest()
 {
+   eventsetup::EventSetupProvider provider(&activityRegistry);
    DummyRecord dummyRecord;
+   provider.addRecordToEventSetup(dummyRecord);
    FailingDummyProxy dummyProxy;
 
    const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),"");
@@ -284,7 +296,10 @@ void testEventsetupRecord::getExepTest()
 
 void testEventsetupRecord::doGetTest()
 {
+   eventsetup::EventSetupProvider provider(&activityRegistry);
    DummyRecord dummyRecord;
+   provider.addRecordToEventSetup(dummyRecord);
+
    FailingDummyProxy dummyProxy;
    
    const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),
@@ -432,7 +447,9 @@ void testEventsetupRecord::introspectionTest()
 
 void testEventsetupRecord::doGetExepTest()
 {
+   eventsetup::EventSetupProvider provider(&activityRegistry);
    DummyRecord dummyRecord;
+   provider.addRecordToEventSetup(dummyRecord);
    FailingDummyProxy dummyProxy;
    
    const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(),
@@ -459,7 +476,10 @@ void testEventsetupRecord::proxyResetTest()
   CPPUNIT_ASSERT(0 !=prov);
   if(prov == 0) return; // To silence Coverity
   const EventSetupRecordProviderTemplate<DummyRecord>* constProv = prov;
-   
+
+  eventsetup::EventSetupProvider provider(&activityRegistry);
+  prov->addRecordTo(provider);
+
   const EventSetupRecord& dummyRecord = constProv->record();
 
   unsigned long long cacheID = dummyRecord.cacheIdentifier();
@@ -508,7 +528,10 @@ void testEventsetupRecord::transientTest()
    
    EventSetupRecordProviderTemplate<DummyRecord>* prov= dynamic_cast<EventSetupRecordProviderTemplate<DummyRecord>*>(&(*dummyProvider)); 
    CPPUNIT_ASSERT(0 !=prov);
-  if(prov == 0) return; // To silence Coverity
+   if(prov == 0) return; // To silence Coverity
+
+   eventsetup::EventSetupProvider provider(&activityRegistry);
+   prov->addRecordTo(provider);
    
    const EventSetupRecordProviderTemplate<DummyRecord>* constProv = prov;
    const EventSetupRecord& dummyRecord = constProv->record();

--- a/FWCore/Framework/test/eventsetupscontroller_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetupscontroller_t.cppunit.cc
@@ -10,11 +10,16 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/test/DummyFinder.h"
 #include "FWCore/Framework/test/DummyProxyProvider.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include <memory>
 #include <string>
 #include <vector>
+
+namespace {
+edm::ActivityRegistry activityRegistry;
+}
 
 class TestEventSetupsController: public CppUnit::TestFixture
 {
@@ -52,9 +57,9 @@ void TestEventSetupsController::constructorTest() {
   pset.addParameter<std::vector<std::string> >("@all_essources", emptyVStrings);
   pset.addParameter<std::vector<std::string> >("@all_esmodules", emptyVStrings);
 
-  esController.makeProvider(pset);
-  esController.makeProvider(pset);
-  esController.makeProvider(pset);
+  esController.makeProvider(pset, &activityRegistry);
+  esController.makeProvider(pset, &activityRegistry);
+  esController.makeProvider(pset, &activityRegistry);
 
   CPPUNIT_ASSERT(esController.providers().size() == 3);
   CPPUNIT_ASSERT(esController.providers()[0]->subProcessIndex() == 0);

--- a/FWCore/Framework/test/fullchain_t.cppunit.cc
+++ b/FWCore/Framework/test/fullchain_t.cppunit.cc
@@ -16,11 +16,16 @@
 #include "FWCore/Framework/test/DummyData.h"
 #include "FWCore/Framework/test/DummyFinder.h"
 #include "FWCore/Framework/test/DummyProxyProvider.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "cppunit/extensions/HelperMacros.h"
 
 using namespace edm;
 using namespace edm::eventsetup;
 using namespace edm::eventsetup::test;
+
+namespace {
+edm::ActivityRegistry activityRegistry;
+}
 
 class testfullChain: public CppUnit::TestFixture
 {
@@ -41,7 +46,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testfullChain);
 
 void testfullChain::getfromDataproxyproviderTest()
 {
-   eventsetup::EventSetupProvider provider;
+   eventsetup::EventSetupProvider provider(&activityRegistry);
 
    std::shared_ptr<DataProxyProvider> pProxyProv = std::make_shared<DummyProxyProvider>();
    provider.add(pProxyProv);

--- a/FWCore/Integration/test/testSubProcess_cfg.py
+++ b/FWCore/Integration/test/testSubProcess_cfg.py
@@ -1,7 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 process = cms.Process("FIRST")
 
-process.Tracer = cms.Service('Tracer')
+process.Tracer = cms.Service('Tracer',
+  dumpEventSetupInfo = cms.untracked.bool(True)
+)
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep.txt
@@ -1,6 +1,12 @@
 Sharing ESSource: class=DoodadESSource label=''
 Sharing ESSource: class=DoodadESSource label=''
 Sharing ESSource: class=DoodadESSource label=''
+preLockEventSetupGet    GadgetRcd  edmtest::Doodad  abcd
+postLockEventSetupGet    GadgetRcd  edmtest::Doodad  abcd
+postEventSetupGet    GadgetRcd  edmtest::Doodad  abcd
 got data of type "edmtest::Doodad" with name "abcd" in record GadgetRcd
+preLockEventSetupGet    GadgetRcd  edmtest::Doodad  abc
+postLockEventSetupGet    GadgetRcd  edmtest::Doodad  abc
+postEventSetupGet    GadgetRcd  edmtest::Doodad  abc
 got data of type "edmtest::Doodad" with name "abc" in record GadgetRcd
 got data of type "edmtest::Doodad" with name "abc" in record GadgetRcd

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -258,6 +258,10 @@ namespace edm {
 
     //preModuleEndLumiSignal_.connect(std::cref(iOther.preModuleEndLumiSignal_));
     //postModuleEndLumiSignal_.connect(std::cref(iOther.postModuleEndLumiSignal_));
+
+     preLockEventSetupGetSignal_.connect(std::cref(iOther.preLockEventSetupGetSignal_));
+     postLockEventSetupGetSignal_.connect(std::cref(iOther.postLockEventSetupGetSignal_));
+     postEventSetupGetSignal_.connect(std::cref(iOther.postEventSetupGetSignal_));
   }
 
   void
@@ -435,6 +439,9 @@ namespace edm {
     copySlotsToFrom(preSourceConstructionSignal_, iOther.preSourceConstructionSignal_);
     copySlotsToFromReverse(postSourceConstructionSignal_, iOther.postSourceConstructionSignal_);
 
+    copySlotsToFrom(preLockEventSetupGetSignal_, iOther.preLockEventSetupGetSignal_);
+    copySlotsToFromReverse(postLockEventSetupGetSignal_, iOther.postLockEventSetupGetSignal_);
+    copySlotsToFromReverse(postEventSetupGetSignal_, iOther.postEventSetupGetSignal_);
   }
 
   //

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -9,6 +9,11 @@
 // Original Author:  Chris Jones
 //         Created:  Thu Sep  8 14:17:58 EDT 2005
 //
+
+#include "FWCore/Framework/interface/ComponentDescription.h"
+#include "FWCore/Framework/interface/DataKey.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
+
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -163,13 +168,26 @@ namespace edm {
       
       void preSourceConstruction(ModuleDescription const& md);
       void postSourceConstruction(ModuleDescription const& md);
-      
+
+      void preLockEventSetupGet(eventsetup::ComponentDescription const*,
+                                eventsetup::EventSetupRecordKey const&,
+                                eventsetup::DataKey const&);
+
+      void postLockEventSetupGet(eventsetup::ComponentDescription const*,
+                                 eventsetup::EventSetupRecordKey const&,
+                                 eventsetup::DataKey const&);
+
+      void postEventSetupGet(eventsetup::ComponentDescription const*,
+                             eventsetup::EventSetupRecordKey const&,
+                             eventsetup::DataKey const&);
+
     private:
       std::string indention_;
       std::set<std::string> dumpContextForLabels_;
       bool dumpNonModuleContext_;
       bool dumpPathsAndConsumes_;
       bool printTimestamps_;
+      bool dumpEventSetupInfo_;
     };
   }
 }
@@ -202,7 +220,8 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry&iRegistry) :
   dumpContextForLabels_(),
   dumpNonModuleContext_(iPS.getUntrackedParameter<bool>("dumpNonModuleContext")),
   dumpPathsAndConsumes_(iPS.getUntrackedParameter<bool>("dumpPathsAndConsumes")),
-  printTimestamps_(iPS.getUntrackedParameter<bool>("printTimestamps"))
+  printTimestamps_(iPS.getUntrackedParameter<bool>("printTimestamps")),
+  dumpEventSetupInfo_(iPS.getUntrackedParameter<bool>("dumpEventSetupInfo"))
 {
   for (std::string & label: iPS.getUntrackedParameter<std::vector<std::string>>("dumpContextForLabels"))
     dumpContextForLabels_.insert(std::move(label));
@@ -306,7 +325,13 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry&iRegistry) :
 
   iRegistry.watchPreSourceConstruction(this, &Tracer::preSourceConstruction);
   iRegistry.watchPostSourceConstruction(this, &Tracer::postSourceConstruction);
-  
+
+  if (dumpEventSetupInfo_) {
+    iRegistry.watchPreLockEventSetupGet(this, &Tracer::preLockEventSetupGet);
+    iRegistry.watchPostLockEventSetupGet(this, &Tracer::postLockEventSetupGet);
+    iRegistry.watchPostEventSetupGet(this, &Tracer::postEventSetupGet);
+  }
+
   iRegistry.preSourceEarlyTerminationSignal_.connect([this](edm::TerminationOrigin iOrigin) {
     LogAbsolute out("Tracer");
     out << TimeStamper(printTimestamps_);
@@ -356,6 +381,7 @@ Tracer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
   desc.addUntracked<bool>("dumpNonModuleContext", false)->setComment("Prints context information to cout for the transitions not associated with any module label");
   desc.addUntracked<bool>("dumpPathsAndConsumes", false)->setComment("Prints information to cout about paths, endpaths, products consumed by modules and the dependencies between modules created by the products they consume");
   desc.addUntracked<bool>("printTimestamps", false)->setComment("Prints a time stamp for every transition");
+  desc.addUntracked<bool>("dumpEventSetupInfo", false)->setComment("Prints info 3 times when an event setup cache is filled, before the lock, after the lock, and after filling");
   descriptions.add("Tracer", desc);
   descriptions.setComment("This service prints each phase the framework is processing, e.g. constructing a module,running a module, etc.");
 }
@@ -1255,7 +1281,41 @@ Tracer::postSourceConstruction(ModuleDescription const& desc) {
   }
 }
 
+void
+Tracer::preLockEventSetupGet(eventsetup::ComponentDescription const* desc,
+                             eventsetup::EventSetupRecordKey const& recordKey,
+                             eventsetup::DataKey const& dataKey) {
+  LogAbsolute out("Tracer");
+  out << "preLockEventSetupGet  ";
+  out << desc->label_ << "  ";
+  out << recordKey.name() << "  ";
+  out << dataKey.type().name() << "  ";
+  out << dataKey.name().value();
+}
+
+void
+Tracer::postLockEventSetupGet(eventsetup::ComponentDescription const* desc,
+                              eventsetup::EventSetupRecordKey const& recordKey,
+                              eventsetup::DataKey const& dataKey) {
+  LogAbsolute out("Tracer");
+  out << "postLockEventSetupGet  ";
+  out << desc->label_ << "  ";
+  out << recordKey.name() << "  ";
+  out << dataKey.type().name() << "  ";
+  out << dataKey.name().value();
+}
+
+void
+Tracer::postEventSetupGet(eventsetup::ComponentDescription const* desc,
+                          eventsetup::EventSetupRecordKey const& recordKey,
+                          eventsetup::DataKey const& dataKey) {
+  LogAbsolute out("Tracer");
+  out << "postEventSetupGet  ";
+  out << desc->label_ << "  ";
+  out << recordKey.name() << "  ";
+  out << dataKey.type().name() << "  ";
+  out << dataKey.name().value();
+}
+
 using edm::service::Tracer;
 DEFINE_FWK_SERVICE(Tracer);
-
-


### PR DESCRIPTION
Uses the Timing Service to measure to two time totals.
First, the time while threads are blocked by the mutex in
DataProxy::get. Second, the time to run the getImpl function
to fill the data cache after the mutex lock has been obtained.