### PR TITLE
Fix typo in setting pixel AddNoisyPixels in premixing

### DIFF
--- a/SimGeneral/MixingModule/python/digi_noNoise_cfi.py
+++ b/SimGeneral/MixingModule/python/digi_noNoise_cfi.py
@@ -19,7 +19,7 @@ theDigitizersNoNoise.hcal.HcalPreMixStage1 = cms.bool(True)
 # no pixel in fastsim era
 if hasattr(theDigitizersNoNoise,"pixel"):
     theDigitizersNoNoise.pixel.AddNoise = cms.bool(True)
-    theDigitizersNoNoise.pixel.addNoisyPixels = cms.bool(False)
+    theDigitizersNoNoise.pixel.AddNoisyPixels = False
     theDigitizersNoNoise.pixel.AddPixelInefficiency = cms.bool(False) #done in second step
     theDigitizersNoNoise.pixel.makeDigiSimLinks = cms.untracked.bool(False)
 # no strip in fastsim era


### PR DESCRIPTION
This PR fixes a typo in premixing stage1 configuration that left the pixel digitizer `AddNoisyPixels=True` while it should have been set to `False`. 

To test the effect I ran 100 TTbar+PU35 events with the following workflows
* classical mixing (10224.0; black)
* premixing as in IB (250199.17+250202.17; blue)
* premixing with IB+PR (250199.17+250202.17; orange)

(keeping the same order for both TTbar and MinBias GEN-SIM files in all cases), results can be found from my DQM GUI
http://127.0.0.1:8081/dqm/relval/start?runnr=1;dataset=/RelValTTbar_13/CMSSW_10_1_X_2018-02-08-1100-PU35_2017_classical_mixing-v1/DQMIO;sampletype=offline_relval;filter=all;referencepos=ratiooverlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A%3A/RelValTTbar_13/CMSSW_10_1_X_2018-02-08-1100-PU35_2017_premixing-v1/DQMIO%3A;referenceobj2=other%3A%3A/RelValTTbar_13/CMSSW_10_1_X_2018-02-08-1100-PU35_2017_premixing_fixed-v1/DQMIO%3A;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=;focus=;zoom=no;
(with the ssh tunnel recipe `ssh -L8081:mkdev.cern.ch:8081 lxplus.cern.ch`)

This was the largest effect I noticed
![image](https://user-images.githubusercontent.com/33993/36029375-3ccf8204-0da3-11e8-94e7-94544ad26a7f.png)
so the effects of the bug/fix are quite small (on the other hand 100 events is not much).

Tested in CMSSW_10_1_X_2018-02-08-1100. Differences are expected in pixel digitization in premixing workflows.

@mdhildreth @kpedro88 
Also FYI @veszpv @boudoul 