### PR TITLE
make use of external cms_oracleocci_abi_hack

### DIFF
--- a/OnlineDB/Oracle/test/BuildFile.xml
+++ b/OnlineDB/Oracle/test/BuildFile.xml
@@ -1,13 +1,7 @@
-<use name="oracleocci"/>
-<library name="cms_occi" file="cms_occi_hack.cc">
-</library>
 <architecture name="_amd64_">
-  <bin name="test_occi_with_cmshack" file="test.cpp">
-    <lib name="cms_occi"/>
+  <bin name="test_occi_std_length" file="test.cpp">
+    <use name="oracleocci"/>
     <flags TEST_RUNNER_ARGS="12154"/>
-  </bin>
-  <bin name="test_occi_wo_cmshack" file="test.cpp">
-      <flags TEST_RUNNER_ARGS="12154"/>
   </bin>
 </architecture>
 

--- a/OnlineDB/Oracle/test/cms_occi_hack.cc
+++ b/OnlineDB/Oracle/test/cms_occi_hack.cc
@@ -1,9 +1,0 @@
-extern "C" {
-#include <cstdio>
-#include <string.h>
-int _ZNKSs6lengthEv (char **a)
-{
-  char *s = *a;
-  return strlen (s);
-}
-}


### PR DESCRIPTION
This PR updates the unit test to make use of new cms_oracleocci_abi_hack external tool instead of local implementation of std::string