### PR TITLE
Fix bug when an exception happens near lumi end

### DIFF
--- a/FWCore/Framework/test/test_earlyTerminationSignal.sh
+++ b/FWCore/Framework/test/test_earlyTerminationSignal.sh
@@ -4,14 +4,24 @@
 
 function die { echo $1: status $2 ;  exit $2; }
 
+function test_failure { 
+    if [ "$2" != "90" ]
+     then
+       echo $1: status $2; exit $2;
+    fi
+}
+
 echo "running cmsRun testEarlyTerminationSignal_cfg.py"
 (cmsRun ${LOCAL_TEST_DIR}/testEarlyTerminationSignal_cfg.py 2>&1 | grep -q 'early termination of event: stream = 0 run = 1 lumi = 1 event = 10 : time = 50000001') || die "Early termination signal failed" $?
 
-echo "runnig cmsRun test_dependentPathsAndExceptions_cfg.py"
+echo "running cmsRun test_dependentPathsAndExceptions_cfg.py"
 (cmsRun ${LOCAL_TEST_DIR}/test_dependentPathsAndExceptions_cfg.py 2>&1 | grep -q "Intentional 'NotFound' exception for testing purposes") || die "dependent Paths and Exceptions failed" $?
 
-echo "runnig cmsRun test_dependentRunDataAndException_cfg.py"
+echo "running cmsRun test_dependentRunDataAndException_cfg.py"
 (cmsRun ${LOCAL_TEST_DIR}/test_dependentRunDataAndException_cfg.py 2>&1 | grep -q "Intentional 'NotFound' exception for testing purposes") || die "dependent Run data and Exceptions failed" $?
 
-echo "runnig cmsRun test_exceptionAtGlobalBeginRun_cfg.py"
+echo "running cmsRun test_exceptionAtGlobalBeginRun_cfg.py"
 (cmsRun ${LOCAL_TEST_DIR}/test_exceptionAtGlobalBeginRun_cfg.py 2>&1 | grep -q -v "An exception of category 'transitions' occurred") || die "exception at globalBeginRun failed" $?
+
+echo "running cmsRun  test_exceptionInShortLumi_cfg.py"
+cmsRun ${LOCAL_TEST_DIR}/test_exceptionInShortLumi_cfg.py; test_failure "test_exceptionInShortLumi_cfg.py failed" $?

--- a/FWCore/Framework/test/test_exceptionInShortLumi_cfg.py
+++ b/FWCore/Framework/test/test_exceptionInShortLumi_cfg.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(2),
+    numberOfStreams = cms.untracked.uint32(0)
+)
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(2) )
+
+process.filter = cms.EDFilter("ModuloStreamIDFilter",
+                              modulo = cms.uint32(2),
+                              offset = cms.uint32(1))
+
+process.fail = cms.EDProducer("FailingProducer")
+
+process.p = cms.Path(process.filter+process.fail)
+
+#process.add_(cms.Service("Tracer"))


### PR DESCRIPTION
Fixed a bug where an exception happens during event processing near
a lumi end boundary such that some streams see the exception while
others exited normally.