### PR TITLE
Fix compile warnings in FastSimulation/SimplifiedGeometryPropagator pkg

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/interface/SimplifiedGeometry.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/SimplifiedGeometry.h
@@ -48,7 +48,7 @@ namespace fastsim
         SimplifiedGeometry(double geomProperty);
 
         //! Default destructor.
-        ~SimplifiedGeometry();
+        virtual ~SimplifiedGeometry();
 
         ////////
         // HACK

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/Trajectory.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/Trajectory.h
@@ -83,6 +83,7 @@ namespace fastsim
             \param deltaTimeC Time in units of t*c..
         */
         virtual void move(double deltaTimeC) = 0;
+	virtual ~Trajectory();
 
         protected:
         //! Constructor of base class.

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Trajectory.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Trajectory.cc
@@ -7,6 +7,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FastSimulation/SimplifiedGeometryPropagator/interface/Constants.h"
 
+fastsim::Trajectory::~Trajectory(){}
 
 fastsim::Trajectory::Trajectory(const fastsim::Particle & particle)
 {


### PR DESCRIPTION
Fix for most of these warnings : 
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_10_1_X_2018-02-11-0000/FastSimulation/SimplifiedGeometryPropagator
introduced by this PR https://github.com/cms-sw/cmssw/pull/20666