### PR TITLE
Make destructor virtual

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/interface/SimplifiedGeometry.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/SimplifiedGeometry.h
@@ -48,7 +48,7 @@ namespace fastsim
         SimplifiedGeometry(double geomProperty);
 
         //! Default destructor.
-        ~SimplifiedGeometry();
+        virtual ~SimplifiedGeometry();
 
         ////////
         // HACK

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/Trajectory.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/Trajectory.h
@@ -29,6 +29,8 @@ namespace fastsim
     class Trajectory
     {
         public:
+        virtual ~Trajectory() = default;
+
         //! Calls constructor of derived classes.
         /*!
             Decides whether a straight (uncharged particle or very high pT charged particle) or a helix trajectory (generic charged particle) is constructed.


### PR DESCRIPTION
The base classes have virtual functions but accessible non-virtual
destructors. This problem was found by the address sanitizer.