### PR TITLE
L1T object comparison producer for calo objects

### DIFF
--- a/DataFormats/L1Trigger/interface/EGamma.h
+++ b/DataFormats/L1Trigger/interface/EGamma.h
@@ -4,7 +4,7 @@
 
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
-
+#include "DataFormats/L1Trigger/interface/L1TObjComparison.h"
 
 namespace l1t {
 
@@ -13,6 +13,10 @@ namespace l1t {
   typedef edm::Ref< EGammaBxCollection > EGammaRef ;
   typedef edm::RefVector< EGammaBxCollection > EGammaRefVector ;
   typedef std::vector< EGammaRef > EGammaVectorRef ;
+
+  typedef ObjectRefBxCollection<EGamma> EGammaRefBxCollection;
+  typedef ObjectRefPair<EGamma> EGammaRefPair;
+  typedef ObjectRefPairBxCollection<EGamma> EGammaRefPairBxCollection;
 
   class EGamma : public L1Candidate {
 
@@ -55,6 +59,9 @@ namespace l1t {
     short int nTT() const;
     short int shape() const;
     short int towerHoE() const;
+
+    virtual bool operator==(const l1t::EGamma& rhs) const;
+    virtual inline bool operator!=(const l1t::EGamma& rhs) const { return !(operator==(rhs)); };
 
   private:
 

--- a/DataFormats/L1Trigger/interface/EtSum.h
+++ b/DataFormats/L1Trigger/interface/EtSum.h
@@ -4,6 +4,7 @@
 
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
+#include "DataFormats/L1Trigger/interface/L1TObjComparison.h"
 
 namespace l1t {
 
@@ -12,6 +13,10 @@ namespace l1t {
   typedef edm::Ref< EtSumBxCollection > EtSumRef ;
   typedef edm::RefVector< EtSumBxCollection > EtSumRefVector ;
   typedef std::vector< EtSumRef > EtSumVectorRef ;
+
+  typedef ObjectRefBxCollection<EtSum> EtSumRefBxCollection;
+  typedef ObjectRefPair<EtSum> EtSumRefPair;
+  typedef ObjectRefPairBxCollection<EtSum> EtSumRefPairBxCollection;
 
   class EtSum : public L1Candidate {
 
@@ -63,6 +68,9 @@ namespace l1t {
     void setType(EtSumType type);
 
     EtSumType getType() const;
+
+    virtual bool operator==(const l1t::EtSum& rhs) const;
+    virtual inline bool operator!=(const l1t::EtSum& rhs) const { return !(operator==(rhs)); };
 
   private:
 

--- a/DataFormats/L1Trigger/interface/Jet.h
+++ b/DataFormats/L1Trigger/interface/Jet.h
@@ -4,6 +4,7 @@
 
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
+#include "DataFormats/L1Trigger/interface/L1TObjComparison.h"
 
 namespace l1t {
 
@@ -12,6 +13,10 @@ namespace l1t {
   typedef edm::Ref< JetBxCollection > JetRef ;
   typedef edm::RefVector< JetBxCollection > JetRefVector ;
   typedef std::vector< JetRef > JetVectorRef ;
+
+  typedef ObjectRefBxCollection<Jet> JetRefBxCollection;
+  typedef ObjectRefPair<Jet> JetRefPair;
+  typedef ObjectRefPairBxCollection<Jet> JetRefPairBxCollection;
 
   class Jet : public L1Candidate {
 
@@ -44,6 +49,9 @@ namespace l1t {
   short int seedEt() const;
   short int puEt() const ;
   short int puDonutEt(int i) const;
+
+  virtual bool operator==(const l1t::Jet& rhs) const;
+  virtual inline bool operator!=(const l1t::Jet& rhs) const { return !(operator==(rhs)); };
 
   private:
 

--- a/DataFormats/L1Trigger/interface/Tau.h
+++ b/DataFormats/L1Trigger/interface/Tau.h
@@ -4,6 +4,7 @@
 
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
+#include "DataFormats/L1Trigger/interface/L1TObjComparison.h"
 
 namespace l1t {
 
@@ -12,6 +13,10 @@ namespace l1t {
   typedef edm::Ref< TauBxCollection > TauRef ;
   typedef edm::RefVector< TauBxCollection > TauRefVector ;
   typedef std::vector< TauRef > TauVectorRef ;
+
+  typedef ObjectRefBxCollection<Tau> TauRefBxCollection;
+  typedef ObjectRefPair<Tau> TauRefPair;
+  typedef ObjectRefPairBxCollection<Tau> TauRefPairBxCollection;
 
   class Tau : public L1Candidate {
 
@@ -48,6 +53,9 @@ namespace l1t {
     short int nTT() const;
     bool hasEM() const;
     bool isMerged() const;
+
+    virtual bool operator==(const l1t::Tau& rhs) const;
+    virtual inline bool operator!=(const l1t::Tau& rhs) const { return !(operator==(rhs)); };
 
   private:
 

--- a/DataFormats/L1Trigger/src/EGamma.cc
+++ b/DataFormats/L1Trigger/src/EGamma.cc
@@ -103,3 +103,17 @@ short int EGamma::shape() const {
 short int EGamma::towerHoE() const {
   return towerHoE_;
 }
+
+bool EGamma::operator==(const l1t::EGamma& rhs) const
+{
+  return l1t::L1Candidate::operator==(static_cast<const l1t::L1Candidate &>(rhs))
+      && towerIEta_ == rhs.towerIEta()
+      && towerIPhi_ == rhs.towerIPhi()
+      && rawEt_ == rhs.rawEt()
+      && isoEt_ == rhs.isoEt()
+      && footprintEt_ == rhs.footprintEt()
+      && nTT_ == rhs.nTT()
+      && shape_ == rhs.shape()
+      && towerHoE_ == rhs.towerHoE();
+}
+

--- a/DataFormats/L1Trigger/src/EtSum.cc
+++ b/DataFormats/L1Trigger/src/EtSum.cc
@@ -38,3 +38,10 @@ l1t::EtSum::EtSumType l1t::EtSum::getType() const
 {
   return type_;
 }
+
+bool l1t::EtSum::operator==(const l1t::EtSum& rhs) const
+{
+  return l1t::L1Candidate::operator==(static_cast<const l1t::L1Candidate &>(rhs))
+      && type_ == rhs.getType();
+}
+

--- a/DataFormats/L1Trigger/src/Jet.cc
+++ b/DataFormats/L1Trigger/src/Jet.cc
@@ -83,3 +83,18 @@ short int Jet::puDonutEt(int i) const {
   if (i>=0 && i<4) return puDonutEt_[i];
   else return 0;
 }
+
+bool Jet::operator==(const l1t::Jet& rhs) const
+{
+  return l1t::L1Candidate::operator==(static_cast<const l1t::L1Candidate &>(rhs))
+      && towerIEta_ == rhs.towerIEta()
+      && towerIPhi_ == rhs.towerIPhi()
+      && rawEt_ == rhs.rawEt()
+      && seedEt_ == rhs.seedEt()
+      && puEt_ == rhs.puEt()
+      && puDonutEt_[0] == rhs.puDonutEt(0)
+      && puDonutEt_[1] == rhs.puDonutEt(1)
+      && puDonutEt_[2] == rhs.puDonutEt(2)
+      && puDonutEt_[3] == rhs.puDonutEt(3);
+}
+

--- a/DataFormats/L1Trigger/src/Tau.cc
+++ b/DataFormats/L1Trigger/src/Tau.cc
@@ -95,3 +95,15 @@ bool Tau::isMerged() const {
   return isMerged_;
 }
 
+bool Tau::operator==(const l1t::Tau& rhs) const
+{
+  return l1t::L1Candidate::operator==(static_cast<const l1t::L1Candidate &>(rhs))
+      && towerIEta_ == rhs.towerIEta()
+      && towerIPhi_ == rhs.towerIPhi()
+      && rawEt_ == rhs.rawEt()
+      && isoEt_ == rhs.isoEt()
+      && nTT_ == rhs.nTT()
+      && hasEM_ == rhs.hasEM()
+      && isMerged_ == rhs.isMerged();
+}
+

--- a/DataFormats/L1Trigger/src/classes.h
+++ b/DataFormats/L1Trigger/src/classes.h
@@ -173,6 +173,13 @@ namespace DataFormats_L1Trigger {
     L1DataEmulRecord der;
     edm::Wrapper<L1DataEmulRecord> w_der;
 
+    l1t::EGammaRefBxCollection egrbxc;
+    edm::Wrapper<l1t::EGammaRefBxCollection> w_egrbxc;
+    l1t::EGammaRefPair egrp;
+    std::vector<l1t::EGammaRefPair> v_egrp;
+    l1t::EGammaRefPairBxCollection egrpc;
+    edm::Wrapper<l1t::EGammaRefPairBxCollection> w_egrpc;
+
     l1t::MuonRefBxCollection murbxc;
     edm::Wrapper<l1t::MuonRefBxCollection> w_murbxc;
     l1t::MuonRefPair murp;

--- a/DataFormats/L1Trigger/src/classes.h
+++ b/DataFormats/L1Trigger/src/classes.h
@@ -180,6 +180,13 @@ namespace DataFormats_L1Trigger {
     l1t::EGammaRefPairBxCollection egrpc;
     edm::Wrapper<l1t::EGammaRefPairBxCollection> w_egrpc;
 
+    l1t::TauRefBxCollection taurbxc;
+    edm::Wrapper<l1t::TauRefBxCollection> w_taurbxc;
+    l1t::TauRefPair taurp;
+    std::vector<l1t::TauRefPair> v_taurp;
+    l1t::TauRefPairBxCollection taurpc;
+    edm::Wrapper<l1t::TauRefPairBxCollection> w_taurpc;
+
     l1t::MuonRefBxCollection murbxc;
     edm::Wrapper<l1t::MuonRefBxCollection> w_murbxc;
     l1t::MuonRefPair murp;

--- a/DataFormats/L1Trigger/src/classes.h
+++ b/DataFormats/L1Trigger/src/classes.h
@@ -187,6 +187,13 @@ namespace DataFormats_L1Trigger {
     l1t::TauRefPairBxCollection taurpc;
     edm::Wrapper<l1t::TauRefPairBxCollection> w_taurpc;
 
+    l1t::JetRefBxCollection jetrbxc;
+    edm::Wrapper<l1t::JetRefBxCollection> w_jetrbxc;
+    l1t::JetRefPair jetrp;
+    std::vector<l1t::JetRefPair> v_jetrp;
+    l1t::JetRefPairBxCollection jetrpc;
+    edm::Wrapper<l1t::JetRefPairBxCollection> w_jetrpc;
+
     l1t::MuonRefBxCollection murbxc;
     edm::Wrapper<l1t::MuonRefBxCollection> w_murbxc;
     l1t::MuonRefPair murp;

--- a/DataFormats/L1Trigger/src/classes.h
+++ b/DataFormats/L1Trigger/src/classes.h
@@ -194,6 +194,13 @@ namespace DataFormats_L1Trigger {
     l1t::JetRefPairBxCollection jetrpc;
     edm::Wrapper<l1t::JetRefPairBxCollection> w_jetrpc;
 
+    l1t::EtSumRefBxCollection etsumrbxc;
+    edm::Wrapper<l1t::EtSumRefBxCollection> w_etsumrbxc;
+    l1t::EtSumRefPair etsumrp;
+    std::vector<l1t::EtSumRefPair> v_etsumrp;
+    l1t::EtSumRefPairBxCollection etsumrpc;
+    edm::Wrapper<l1t::EtSumRefPairBxCollection> w_etsumrpc;
+
     l1t::MuonRefBxCollection murbxc;
     edm::Wrapper<l1t::MuonRefBxCollection> w_murbxc;
     l1t::MuonRefPair murp;

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -220,6 +220,13 @@
   <class name="l1t::EGammaRefPairBxCollection"/>
   <class name="edm::Wrapper<l1t::EGammaRefPairBxCollection>"/>
 
+  <class name="l1t::TauRefBxCollection"/>
+  <class name="edm::Wrapper<l1t::TauRefBxCollection>"/>
+  <class name="l1t::TauRefPair"/>
+  <class name="std::vector<l1t::TauRefPair>"/>
+  <class name="l1t::TauRefPairBxCollection"/>
+  <class name="edm::Wrapper<l1t::TauRefPairBxCollection>"/>
+
   <class name="l1t::MuonRefBxCollection"/>
   <class name="edm::Wrapper<l1t::MuonRefBxCollection>"/>
   <class name="l1t::MuonRefPair"/>

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -213,6 +213,13 @@
   </class>
   <class name="edm::Wrapper<L1DataEmulRecord>"/>
 
+  <class name="l1t::EGammaRefBxCollection"/>
+  <class name="edm::Wrapper<l1t::EGammaRefBxCollection>"/>
+  <class name="l1t::EGammaRefPair"/>
+  <class name="std::vector<l1t::EGammaRefPair>"/>
+  <class name="l1t::EGammaRefPairBxCollection"/>
+  <class name="edm::Wrapper<l1t::EGammaRefPairBxCollection>"/>
+
   <class name="l1t::MuonRefBxCollection"/>
   <class name="edm::Wrapper<l1t::MuonRefBxCollection>"/>
   <class name="l1t::MuonRefPair"/>

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -227,6 +227,13 @@
   <class name="l1t::TauRefPairBxCollection"/>
   <class name="edm::Wrapper<l1t::TauRefPairBxCollection>"/>
 
+  <class name="l1t::JetRefBxCollection"/>
+  <class name="edm::Wrapper<l1t::JetRefBxCollection>"/>
+  <class name="l1t::JetRefPair"/>
+  <class name="std::vector<l1t::JetRefPair>"/>
+  <class name="l1t::JetRefPairBxCollection"/>
+  <class name="edm::Wrapper<l1t::JetRefPairBxCollection>"/>
+
   <class name="l1t::MuonRefBxCollection"/>
   <class name="edm::Wrapper<l1t::MuonRefBxCollection>"/>
   <class name="l1t::MuonRefPair"/>

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -234,6 +234,13 @@
   <class name="l1t::JetRefPairBxCollection"/>
   <class name="edm::Wrapper<l1t::JetRefPairBxCollection>"/>
 
+  <class name="l1t::EtSumRefBxCollection"/>
+  <class name="edm::Wrapper<l1t::EtSumRefBxCollection>"/>
+  <class name="l1t::EtSumRefPair"/>
+  <class name="std::vector<l1t::EtSumRefPair>"/>
+  <class name="l1t::EtSumRefPairBxCollection"/>
+  <class name="edm::Wrapper<l1t::EtSumRefPairBxCollection>"/>
+
   <class name="l1t::MuonRefBxCollection"/>
   <class name="edm::Wrapper<l1t::MuonRefBxCollection>"/>
   <class name="l1t::MuonRefPair"/>

--- a/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
@@ -156,12 +156,15 @@ L1TComparisonResultFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& d
 
 //define plugins for different L1T objects
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 typedef L1TComparisonResultFilter<GlobalAlgBlk> L1TGlobalAlgBlkComparisonResultFilter;
+typedef L1TComparisonResultFilter<l1t::EGamma> L1TEGammaComparisonResultFilter;
 typedef L1TComparisonResultFilter<l1t::Muon> L1TMuonComparisonResultFilter;
 typedef L1TComparisonResultFilter<l1t::RegionalMuonCand> L1TRegionalMuonCandComparisonResultFilter;
 DEFINE_FWK_MODULE(L1TGlobalAlgBlkComparisonResultFilter);
+DEFINE_FWK_MODULE(L1TEGammaComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TMuonComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TRegionalMuonCandComparisonResultFilter);

--- a/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
@@ -159,6 +159,7 @@ L1TComparisonResultFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& d
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
@@ -166,11 +167,13 @@ typedef L1TComparisonResultFilter<GlobalAlgBlk> L1TGlobalAlgBlkComparisonResultF
 typedef L1TComparisonResultFilter<l1t::EGamma> L1TEGammaComparisonResultFilter;
 typedef L1TComparisonResultFilter<l1t::Tau> L1TTauComparisonResultFilter;
 typedef L1TComparisonResultFilter<l1t::Jet> L1TJetComparisonResultFilter;
+typedef L1TComparisonResultFilter<l1t::EtSum> L1TEtSumComparisonResultFilter;
 typedef L1TComparisonResultFilter<l1t::Muon> L1TMuonComparisonResultFilter;
 typedef L1TComparisonResultFilter<l1t::RegionalMuonCand> L1TRegionalMuonCandComparisonResultFilter;
 DEFINE_FWK_MODULE(L1TGlobalAlgBlkComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TEGammaComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TTauComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TJetComparisonResultFilter);
+DEFINE_FWK_MODULE(L1TEtSumComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TMuonComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TRegionalMuonCandComparisonResultFilter);

--- a/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
@@ -157,14 +157,17 @@ L1TComparisonResultFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& d
 //define plugins for different L1T objects
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 typedef L1TComparisonResultFilter<GlobalAlgBlk> L1TGlobalAlgBlkComparisonResultFilter;
 typedef L1TComparisonResultFilter<l1t::EGamma> L1TEGammaComparisonResultFilter;
+typedef L1TComparisonResultFilter<l1t::Tau> L1TTauComparisonResultFilter;
 typedef L1TComparisonResultFilter<l1t::Muon> L1TMuonComparisonResultFilter;
 typedef L1TComparisonResultFilter<l1t::RegionalMuonCand> L1TRegionalMuonCandComparisonResultFilter;
 DEFINE_FWK_MODULE(L1TGlobalAlgBlkComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TEGammaComparisonResultFilter);
+DEFINE_FWK_MODULE(L1TTauComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TMuonComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TRegionalMuonCandComparisonResultFilter);

--- a/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TComparisonResultFilter.cc
@@ -158,16 +158,19 @@ L1TComparisonResultFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& d
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
+#include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 typedef L1TComparisonResultFilter<GlobalAlgBlk> L1TGlobalAlgBlkComparisonResultFilter;
 typedef L1TComparisonResultFilter<l1t::EGamma> L1TEGammaComparisonResultFilter;
 typedef L1TComparisonResultFilter<l1t::Tau> L1TTauComparisonResultFilter;
+typedef L1TComparisonResultFilter<l1t::Jet> L1TJetComparisonResultFilter;
 typedef L1TComparisonResultFilter<l1t::Muon> L1TMuonComparisonResultFilter;
 typedef L1TComparisonResultFilter<l1t::RegionalMuonCand> L1TRegionalMuonCandComparisonResultFilter;
 DEFINE_FWK_MODULE(L1TGlobalAlgBlkComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TEGammaComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TTauComparisonResultFilter);
+DEFINE_FWK_MODULE(L1TJetComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TMuonComparisonResultFilter);
 DEFINE_FWK_MODULE(L1TRegionalMuonCandComparisonResultFilter);

--- a/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
@@ -164,16 +164,19 @@ void L1TStage2ObjectComparison<T>::produce(edm::Event& e, const edm::EventSetup&
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
+#include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 typedef L1TStage2ObjectComparison<GlobalAlgBlk> L1TStage2GlobalAlgBlkComparison;
 typedef L1TStage2ObjectComparison<l1t::EGamma> L1TStage2EGammaComparison;
 typedef L1TStage2ObjectComparison<l1t::Tau> L1TStage2TauComparison;
+typedef L1TStage2ObjectComparison<l1t::Jet> L1TStage2JetComparison;
 typedef L1TStage2ObjectComparison<l1t::Muon> L1TStage2MuonComparison;
 typedef L1TStage2ObjectComparison<l1t::RegionalMuonCand> L1TStage2RegionalMuonCandComparison;
 DEFINE_FWK_MODULE(L1TStage2GlobalAlgBlkComparison);
 DEFINE_FWK_MODULE(L1TStage2EGammaComparison);
 DEFINE_FWK_MODULE(L1TStage2TauComparison);
+DEFINE_FWK_MODULE(L1TStage2JetComparison);
 DEFINE_FWK_MODULE(L1TStage2MuonComparison);
 DEFINE_FWK_MODULE(L1TStage2RegionalMuonCandComparison);

--- a/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
@@ -165,6 +165,7 @@ void L1TStage2ObjectComparison<T>::produce(edm::Event& e, const edm::EventSetup&
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
@@ -172,11 +173,13 @@ typedef L1TStage2ObjectComparison<GlobalAlgBlk> L1TStage2GlobalAlgBlkComparison;
 typedef L1TStage2ObjectComparison<l1t::EGamma> L1TStage2EGammaComparison;
 typedef L1TStage2ObjectComparison<l1t::Tau> L1TStage2TauComparison;
 typedef L1TStage2ObjectComparison<l1t::Jet> L1TStage2JetComparison;
+typedef L1TStage2ObjectComparison<l1t::EtSum> L1TStage2EtSumComparison;
 typedef L1TStage2ObjectComparison<l1t::Muon> L1TStage2MuonComparison;
 typedef L1TStage2ObjectComparison<l1t::RegionalMuonCand> L1TStage2RegionalMuonCandComparison;
 DEFINE_FWK_MODULE(L1TStage2GlobalAlgBlkComparison);
 DEFINE_FWK_MODULE(L1TStage2EGammaComparison);
 DEFINE_FWK_MODULE(L1TStage2TauComparison);
 DEFINE_FWK_MODULE(L1TStage2JetComparison);
+DEFINE_FWK_MODULE(L1TStage2EtSumComparison);
 DEFINE_FWK_MODULE(L1TStage2MuonComparison);
 DEFINE_FWK_MODULE(L1TStage2RegionalMuonCandComparison);

--- a/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
@@ -163,14 +163,17 @@ void L1TStage2ObjectComparison<T>::produce(edm::Event& e, const edm::EventSetup&
 //define plugins for different L1T objects
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 typedef L1TStage2ObjectComparison<GlobalAlgBlk> L1TStage2GlobalAlgBlkComparison;
 typedef L1TStage2ObjectComparison<l1t::EGamma> L1TStage2EGammaComparison;
+typedef L1TStage2ObjectComparison<l1t::Tau> L1TStage2TauComparison;
 typedef L1TStage2ObjectComparison<l1t::Muon> L1TStage2MuonComparison;
 typedef L1TStage2ObjectComparison<l1t::RegionalMuonCand> L1TStage2RegionalMuonCandComparison;
 DEFINE_FWK_MODULE(L1TStage2GlobalAlgBlkComparison);
 DEFINE_FWK_MODULE(L1TStage2EGammaComparison);
+DEFINE_FWK_MODULE(L1TStage2TauComparison);
 DEFINE_FWK_MODULE(L1TStage2MuonComparison);
 DEFINE_FWK_MODULE(L1TStage2RegionalMuonCandComparison);

--- a/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
+++ b/L1Trigger/L1TCommon/plugins/L1TStage2ObjectComparison.cc
@@ -162,12 +162,15 @@ void L1TStage2ObjectComparison<T>::produce(edm::Event& e, const edm::EventSetup&
 
 //define plugins for different L1T objects
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 typedef L1TStage2ObjectComparison<GlobalAlgBlk> L1TStage2GlobalAlgBlkComparison;
+typedef L1TStage2ObjectComparison<l1t::EGamma> L1TStage2EGammaComparison;
 typedef L1TStage2ObjectComparison<l1t::Muon> L1TStage2MuonComparison;
 typedef L1TStage2ObjectComparison<l1t::RegionalMuonCand> L1TStage2RegionalMuonCandComparison;
 DEFINE_FWK_MODULE(L1TStage2GlobalAlgBlkComparison);
+DEFINE_FWK_MODULE(L1TStage2EGammaComparison);
 DEFINE_FWK_MODULE(L1TStage2MuonComparison);
 DEFINE_FWK_MODULE(L1TStage2RegionalMuonCandComparison);


### PR DESCRIPTION
This completes PR #21897 by adding the remaining L1T objects from the caloL2 trigger as objects that can be compared.
Filters for the comparisons of those objects are added as well.