### PR TITLE
Initialise extended variables of L1T calo objects

### DIFF
--- a/DataFormats/L1Trigger/interface/EGamma.h
+++ b/DataFormats/L1Trigger/interface/EGamma.h
@@ -21,7 +21,7 @@ namespace l1t {
   class EGamma : public L1Candidate {
 
   public:
-    EGamma(){}
+    EGamma(){ clear_extended(); }
 
     // ctor from base allowed, but note that extended variables will be set to zero:
     EGamma(const L1Candidate& rhs):L1Candidate(rhs){ clear_extended(); } 

--- a/DataFormats/L1Trigger/interface/Jet.h
+++ b/DataFormats/L1Trigger/interface/Jet.h
@@ -21,7 +21,7 @@ namespace l1t {
   class Jet : public L1Candidate {
 
   public:
-  Jet(){}
+  Jet(){ clear_extended(); }
   Jet( const LorentzVector& p4,
        int pt=0,
        int eta=0,

--- a/DataFormats/L1Trigger/interface/Tau.h
+++ b/DataFormats/L1Trigger/interface/Tau.h
@@ -21,7 +21,7 @@ namespace l1t {
   class Tau : public L1Candidate {
 
   public:
-    Tau(){}
+    Tau(){ clear_extended(); }
     Tau( const LorentzVector& p4,
 	    int pt=0,
 	    int eta=0,


### PR DESCRIPTION
This is a follow up PR for #22184 to set the uninitialised variables of the L1T calo objects to a defined value in the default constructor. Otherwise object comparisons show mismatches.