### PR TITLE
Enbale TrackTriggerAssociatorClustersStubs in L1TrackTrigger sequence. 

### DIFF
--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.TrackTrigger.TrackTrigger_cff import *
-##from SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff import *
+from SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff import *
 
 #L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackTriggerTTTracks*TrackTriggerAssociatorTracks)
-L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs)
+L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs)
 
 TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = cms.bool(True)

--- a/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
+++ b/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
@@ -13,7 +13,10 @@ SimTrackerFEVTDEBUG = cms.PSet(
         'keep *_assoc2thStepTk_*_*', 
         'keep *_assoc2GsfTracks_*_*', 
         'keep *_assocOutInConversionTracks_*_*', 
-        'keep *_assocInOutConversionTracks_*_*')
+        'keep *_assocInOutConversionTracks_*_*',
+        'keep *_TTClusterAssociatorFromPixelDigis_*_*',
+        'keep *_TTStubAssociatorFromPixelDigis_*_*')
+
 )
 
 SimTrackerDEBUG = cms.PSet(

--- a/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
+++ b/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
@@ -13,10 +13,7 @@ SimTrackerFEVTDEBUG = cms.PSet(
         'keep *_assoc2thStepTk_*_*', 
         'keep *_assoc2GsfTracks_*_*', 
         'keep *_assocOutInConversionTracks_*_*', 
-        'keep *_assocInOutConversionTracks_*_*',
-        'keep *_TTClusterAssociatorFromPixelDigis_*_*',
-        'keep *_TTStubAssociatorFromPixelDigis_*_*')
-
+        'keep *_assocInOutConversionTracks_*_*')
 )
 
 SimTrackerDEBUG = cms.PSet(


### PR DESCRIPTION
PR 93x.  
Add `TrackTriggerAssociatorClustersStubs` in `L1TrackTrigger` sequence, as done in 
master branch (#22261)

Use:
Needed for L1Trigger studies
With PU 200 it takes ~20sec/ev.  
Too long, prefer not to run offline in post-production,

Note:
*Not* adding products to the EventContent (additional total of 1MB/ev at PU 200).

```

'keep *_TTClusterAssociatorFromPixelDigis_*_*',
'keep *_TTStubAssociatorFromPixelDigis_*_*' 
```


