### PR TITLE
DD4Hep Migration: Parse CMS XML Files

### DIFF
--- a/DetectorDescription/DDCMS/BuildFile.xml
+++ b/DetectorDescription/DDCMS/BuildFile.xml
@@ -1,0 +1,2 @@
+<use   name="FWCore/PluginManager"/>
+<use   name="dd4hep"/>

--- a/DetectorDescription/DDCMS/data/cms-tracker.xml
+++ b/DetectorDescription/DDCMS/data/cms-tracker.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  <debug>
+<!-- 
+    <debug_rotations/>
+    <debug_materials/>
+
+    <debug_shapes/>
+    <debug_volumes/>
+    <debug_constants/>
+    <debug_includes/>
+    <debug_namespaces/>
+    <debug_placements/>
+    <debug_algorithms/>
+    <debug_visattr/>
+-->
+  </debug>
+  <open_geometry/>
+  <close_geometry/>
+
+  <ConstantsSection label="" eval="true">
+    <Constant name="world_x" value="5*m"/>
+    <Constant name="world_y" value="5*m"/>
+    <Constant name="world_z" value="5*m"/>
+    <Constant name="fm"      value="1e-12*m"/>
+    <Constant name="Air"     value="materials_Air"     type="string"/>
+    <Constant name="Vacuum"  value="materials_Vacuum"  type="string"/>
+  </ConstantsSection>
+  <ConstantsSection label="servicescylinderb.xml" eval="true">
+	<Constant name="zero" value="0.0*fm"/>
+  </ConstantsSection>
+  <ConstantsSection label="servicescylinderf.xml" eval="true">
+	<Constant name="zero" value="0.0*fm"/>
+  </ConstantsSection>
+
+  <DisabledAlgo  name="track:DDTOBRadCableAlgo"/>
+  <ConstantsSection label="pixfwd" eval="true">
+        <Constant name="AnchorZ" value="0.*mm"/>
+        <Constant name="ZPixelForward" value="325.*mm"/>
+  </ConstantsSection>
+  <ConstantsSection label="tracker.xml" eval="true">
+	<Constant name="BackPlaneDz" value="0.015*mm"/>
+  </ConstantsSection>
+
+  <IncludeSection>
+    <Include ref="materials.xml"/>
+    <Include ref="trackermaterial.xml"/>
+    <Include ref="tibtidcommonmaterial.xml"/>
+
+    <Include ref="vacuum.xml"/>
+    <Include ref="cmsextent.xml"/>
+    <Include ref="cms.xml"/>
+
+    <Include ref="pixfwdMaterials.xml"/>
+    <Include ref="pixbarmaterial.xml"/>
+    <Include ref="pixbarladder.xml"/>
+    <Include ref="pixbarladderfull.xml"/>
+    <Include ref="pixbarladderhalf.xml"/>
+    <Include ref="pixbarlayer.xml"/>
+    <Include ref="pixbarlayer0.xml"/>
+    <Include ref="pixbarlayer1.xml"/>
+    <Include ref="pixbarlayer2.xml"/>
+    <Include ref="pixbar.xml"/>
+
+    <Include ref="tecmaterial.xml"/>
+
+    <Include ref="tecpetpar.xml"/>
+    <Include ref="tecpetalb.xml"/>
+    <Include ref="tecpetalf.xml"/>
+    <Include ref="tecpetal0.xml"/>
+    <Include ref="tecpetal0b.xml"/>
+    <Include ref="tecpetal0f.xml"/>
+    <Include ref="tecpetal3.xml"/>
+    <Include ref="tecpetal3b.xml"/>
+    <Include ref="tecpetal3f.xml"/>
+    <Include ref="tecpetal6b.xml"/>
+    <Include ref="tecpetal6f.xml"/>
+    <Include ref="tecpetal8b.xml"/>
+    <Include ref="tecpetal8f.xml"/>
+
+    <Include ref="tecmodpar.xml"/>
+    <Include ref="tecmodule0.xml"/>
+    <Include ref="tecmodule0s.xml"/>
+    <Include ref="tecmodule1.xml"/>
+    <Include ref="tecmodule1r.xml"/>
+    <Include ref="tecmodule1s.xml"/>
+    <Include ref="tecmodule2.xml"/>
+    <Include ref="tecmodule3.xml"/>
+    <Include ref="tecmodule4.xml"/>
+    <Include ref="tecmodule4r.xml"/>
+    <Include ref="tecmodule4s.xml"/>
+    <Include ref="tecmodule5.xml"/>
+    <Include ref="tecmodule6.xml"/>
+    <Include ref="tecmodule0r.xml"/>
+
+    <Include ref="tecring0.xml"/>
+    <Include ref="tecring0b.xml"/>
+    <Include ref="tecring0f.xml"/>
+    <Include ref="tecring1.xml"/>
+    <Include ref="tecring1b.xml"/>
+    <Include ref="tecring1f.xml"/>
+    <Include ref="tecring2.xml"/>
+    <Include ref="tecring2b.xml"/>
+    <Include ref="tecring2f.xml"/>
+    <Include ref="tecring3.xml"/>
+    <Include ref="tecring3b.xml"/>
+    <Include ref="tecring3f.xml"/>
+    <Include ref="tecring4.xml"/>
+    <Include ref="tecring4b.xml"/>
+    <Include ref="tecring4f.xml"/>
+    <Include ref="tecring5.xml"/>
+    <Include ref="tecring5b.xml"/>
+    <Include ref="tecring5f.xml"/>
+    <Include ref="tecring6.xml"/>
+    <Include ref="tecring6b.xml"/>
+    <Include ref="tecring6f.xml"/>
+
+    <Include ref="tecwheel.xml"/>
+    <Include ref="tecwheel6.xml"/>
+    <Include ref="tecwheela.xml"/>
+    <Include ref="tecwheelb.xml"/>
+    <Include ref="tecwheelc.xml"/>
+    <Include ref="tecwheeld.xml"/>
+
+    <Include ref="tecbackplate.xml"/>
+    <Include ref="tec.xml"/>
+    <Include ref="tecservices.xml"/>
+
+    <Include ref="tibmaterial.xml"/>
+
+    <Include ref="tibmodpar.xml"/>
+    <Include ref="tibmodule0.xml"/>
+    <Include ref="tibmodule0a.xml"/>
+    <Include ref="tibmodule0b.xml"/>
+    <Include ref="tibmodule2.xml"/>
+
+    <Include ref="tiblayerpar.xml"/>
+    <Include ref="tiblayer0.xml"/>
+    <Include ref="tiblayer1.xml"/>
+    <Include ref="tiblayer2.xml"/>
+    <Include ref="tiblayer3.xml"/>
+
+    <Include ref="tibstringpar.xml"/>
+    <Include ref="tibstring0.xml"/>
+    <Include ref="tibstring0ll.xml"/>
+    <Include ref="tibstring0lr.xml"/>
+    <Include ref="tibstring0ul.xml"/>
+    <Include ref="tibstring0ur.xml"/>
+    <Include ref="tibstring1.xml"/>
+    <Include ref="tibstring1ll.xml"/>
+    <Include ref="tibstring1lr.xml"/>
+    <Include ref="tibstring1ul.xml"/>
+    <Include ref="tibstring1ur.xml"/>
+    <Include ref="tibstring2.xml"/>
+    <Include ref="tibstring2ll.xml"/>
+    <Include ref="tibstring2lr.xml"/>
+    <Include ref="tibstring2ul.xml"/>
+    <Include ref="tibstring2ur.xml"/>
+    <Include ref="tibstring3.xml"/>
+    <Include ref="tibstring3ll.xml"/>
+    <Include ref="tibstring3lr.xml"/>
+    <Include ref="tibstring3ul.xml"/>
+    <Include ref="tibstring3ur.xml"/>
+
+    <Include ref="tib.xml"/>
+
+    <Include ref="tidmaterial.xml"/>
+    <Include ref="tidmodpar.xml"/>
+    <Include ref="tidringpar.xml"/>
+
+    <Include ref="tidb.xml"/>
+    <Include ref="tidf.xml"/>
+    <Include ref="tidmodule0.xml"/>
+    <Include ref="tidmodule0l.xml"/>
+    <Include ref="tidmodule0r.xml"/>
+    <Include ref="tidmodule1.xml"/>
+    <Include ref="tidmodule1l.xml"/>
+    <Include ref="tidmodule1r.xml"/>
+    <Include ref="tidmodule2.xml"/>
+    <Include ref="tidring0.xml"/>
+    <Include ref="tidring0b.xml"/>
+    <Include ref="tidring0f.xml"/>
+    <Include ref="tidring1.xml"/>
+    <Include ref="tidring1b.xml"/>
+    <Include ref="tidring1f.xml"/>
+    <Include ref="tidring2.xml"/>
+    <Include ref="tid.xml"/>
+
+    <Include ref="tibtidservices.xml"/>
+    <Include ref="tibtidservicesb.xml"/>
+    <Include ref="tibtidservicesf.xml"/>
+
+    <Include ref="tobmaterial.xml"/>
+    <Include ref="tobmodpar.xml"/>
+    <Include ref="tobrodpar.xml"/>
+    <Include ref="tobmodule0.xml"/>
+    <Include ref="tobmodule2.xml"/>
+    <Include ref="tobmodule4.xml"/>
+
+    <Include ref="tobrod0.xml"/>
+    <Include ref="tobrod0c.xml"/>
+    <Include ref="tobrod0h.xml"/>
+    <Include ref="tobrod0l.xml"/>
+
+    <Include ref="tobrod1.xml"/>
+    <Include ref="tobrod1h.xml"/>
+    <Include ref="tobrod1l.xml"/>
+
+    <Include ref="tobrod2.xml"/>
+    <Include ref="tobrod2c.xml"/>
+    <Include ref="tobrod2h.xml"/>
+    <Include ref="tobrod2l.xml"/>
+
+    <Include ref="tobrod3.xml"/>
+    <Include ref="tobrod3h.xml"/>
+    <Include ref="tobrod3l.xml"/>
+
+    <Include ref="tobrod4.xml"/>
+    <Include ref="tobrod4c.xml"/>
+    <Include ref="tobrod4h.xml"/>
+    <Include ref="tobrod4l.xml"/>
+
+    <Include ref="tobrod5.xml"/>
+    <Include ref="tobrod5h.xml"/>
+    <Include ref="tobrod5l.xml"/>
+    <Include ref="tob.xml"/>
+
+    <Include ref="pixfwdCommon.xml"/>
+
+<!--
+
+    PixbarFWD IS THE HORROR.
+    CANNOT GET IT GOING. Ignore it.
+
+    <Include ref="pixfwdBlade.xml"/>
+    <Include ref="pixfwdPanel.xml"/>
+    <Include ref="pixfwdPanelBase.xml"/>
+    <Include ref="pixfwdDisk.xml"/>
+    <Include ref="pixfwdCylinder.xml"/>
+    <Include ref="pixfwdNipple.xml"/>
+
+    <Include ref="pixfwdPlaq.xml"/>
+    <Include ref="pixfwdPlaq1x2.xml"/>
+    <Include ref="pixfwdPlaq1x5.xml"/>
+    <Include ref="pixfwdPlaq2x3.xml"/>
+    <Include ref="pixfwdPlaq2x4.xml"/>
+    <Include ref="pixfwdPlaq2x5.xml"/>
+
+    <Include ref="pixfwd.xml"/>
+
+    TEC sucks in Geant4. Ignored.
+
+    <Include ref="trackertec.xml"/>
+-->
+    <Include ref="trackerbulkhead.xml"/>
+
+    <Include ref="trackertib.xml"/>
+    <Include ref="trackertid.xml"/>
+
+    <Include ref="trackerother.xml"/>
+    <Include ref="trackerpixbar.xml"/>
+
+    <Include ref="tracker.xml"/>
+    <Include ref="trackertob.xml"/>
+
+  </IncludeSection>
+
+  <PosPartSection label="">
+    <PosPart copyNumber="2">
+	<rParent name="world_volume"/>
+	<rChild name="tracker:Tracker"/>
+   </PosPart>
+  </PosPartSection>
+
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/cms.xml
+++ b/DetectorDescription/DDCMS/data/cms.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="cms.xml" eval="true">
+		<Constant name="Rmin" value="[cmsextent:Rmin]"/>
+		<Constant name="Zmin" value="[cmsextent:Zmin]"/>
+		<Constant name="HallZ" value="[cmsextent:HallZ]"/>
+		<Constant name="HallR" value="[cmsextent:HallR]"/>
+		<Constant name="HallRMax" value="[cmsextent:HallRMax]"/>
+		<Constant name="CMSR1" value="[cmsextent:CMSR1]"/>
+		<Constant name="CMSR2" value="[cmsextent:CMSR2]"/>
+		<Constant name="CMSZ1" value="[cmsextent:CMSZ1]"/>
+		<Constant name="CMSZ2" value="[cmsextent:CMSZ2]"/>
+		<Constant name="TrackCalorR" value="1.233*m"/>
+		<Constant name="CalorMuonR"  value="2.950*m"/>
+		<Constant name="CalorMuonR2" value="2.810*m"/>
+		<Constant name="TrackBeamZ1" value="1.948*m"/>
+		<Constant name="TrackBeamZ2" value="2.935*m"/>
+		<Constant name="TrackBeamR1" value="3.15*cm"/>
+		<Constant name="TrackBeamR2" value="7.40*cm"/>
+		<Constant name="TrackLumiR1" value="7.70*cm"/>
+                <Constant name="TrackLumiR2Min"  value="3.3*cm"/>
+		<Constant name="TrackLumiZ1" value="1.722*m"/>
+		<Constant name="TrackLumiZ2" value="1.800*m"/>
+		<Constant name="CalorBeamZ1" value="3.180*m"/>
+		<Constant name="CalorBeamZ2" value="5.541*m"/>
+		<Constant name="CalorBeamZ3" value="5.245*m"/>
+		<Constant name="CalorBeamR1" value="8.00*cm"/>
+		<Constant name="CalorBeamR2" value="8.93*cm"/>
+		<Constant name="MuonBeamZ0" value="6.50*m"/>
+		<Constant name="MuonBeamZ1" value="7.499*m"/>
+		<Constant name="MuonBeamZ2" value="10.86*m"/>
+		<Constant name="MuonBeamR0" value="10.50*cm"/>
+		<Constant name="MuonBeamR1" value="11.785*cm"/>
+		<Constant name="MuonBeamR2" value="76.80*cm"/>
+		<Constant name="TotemMuonZ1" value="10.165*m"/>
+		<Constant name="TotemMuonZ2" value="10.50*m"/>
+		<Constant name="TotemMuonR1" value="1.0411*m"/>
+		<Constant name="TotemMuonR2" value="1.1300*m"/>
+		<Constant name="TotemBeamZ1" value="7.9500*m"/>
+		<Constant name="TotemBeamZ2" value="13.381*m"/>
+		<Constant name="TotemBeamZ3" value="13.439*m"/>
+		<Constant name="TotemBeamZ4" value="13.465*m"/>
+		<Constant name="TotemBeamR1" value="[MuonBeamR1]"/>
+		<Constant name="TotemBeamR2" value="12.15*cm"/>
+		<Constant name="TotemBeamR3" value="12.20*cm"/>
+		<Constant name="TotemBeamR4" value="3.675*cm"/>
+		<Constant name="TotemBeamR5" value="3.575*cm"/>
+		<Constant name="ForwdBeamZ1" value="10.539*m"/>
+		<Constant name="ForwdBeamZ2" value="13.109*m"/>
+		<Constant name="ForwdBeamZ3" value="13.290*m"/>
+		<Constant name="ForwdBeamZ4" value="16.0305*m"/>
+		<Constant name="ForwdBeamZ5" value="16.424*m"/>
+		<Constant name="ForwdBeamZ6" value="17.058*m"/>
+		<Constant name="ForwdBeamZ7" value="17.920*m"/>
+		<Constant name="ForwdBeamZ8" value="18.562*m"/>
+		<Constant name="ForwdBeamZ9" value="18.905*m"/>
+		<Constant name="ForwdBeamR0" value="15.95*cm"/>
+		<Constant name="ForwdBeamR1" value="12.495*cm"/>
+		<Constant name="ForwdBeamR2" value="12.50*cm"/>
+		<Constant name="ForwdBeamR3" value="25.0*cm"/>
+		<Constant name="ForwdBeamR4" value="2.85*cm"/>
+		<Constant name="ForwdBeamR5" value="7.50*cm"/>
+		<Constant name="ForwdBeamR6" value="20.5*cm"/>
+		<Constant name="ForwdBeamR7" value="4.00*cm"/>
+		<Constant name="ForwdBeamR8" value="2.15*cm"/>
+		<Constant name="ForwdVcalZ1" value="11.1495*m"/>
+		<Constant name="ForwdVcalZ2" value="12.8005*m"/>
+		<Constant name="ForwdVcalR1" value="1.595*m"/>
+		<Constant name="ForwdDetsZ1" value="16.0065*m"/>
+		<Constant name="ForwdDetsR1" value="33.00*cm"/>
+		<Constant name="MBarRmin" value="3.80*m"/>
+		<Constant name="MBarRmax" value="8.05*m"/>
+		<Constant name="MBarZ" value="6.61*m"/>
+		<Constant name="MBRingZ" value="1.268*m"/>
+		<Constant name="MBRing1Zpos" value="2.686*m"/>
+		<Constant name="MBRing2Zpos" value="5.342*m"/>
+		<Constant name="MEndcapZ0" value="6.59*m"/>
+		<Constant name="MEndcapZ1" value="6.835*m"/>
+		<Constant name="MERmin0" value="66.569*cm"/>
+		<Constant name="MERmin1" value="67.50*cm"/>
+		<Constant name="MERmin2" value="70.00*cm"/>
+		<Constant name="MERmin3" value="108.60*cm"/>
+	</ConstantsSection>
+	<SolidSection label="cms.xml">
+		<Polycone name="OCMS" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="-[CMSZ1]" rMin="[Rmin]" rMax="[CMSR2]"/>
+			<ZSection z="-[HallZ]" rMin="[Rmin]" rMax="[CMSR2]"/>
+			<ZSection z="-[HallZ]" rMin="[Rmin]" rMax="[HallRMax]"/>
+			<ZSection z="[HallZ]" rMin="[Rmin]" rMax="[HallRMax]"/>
+			<ZSection z="[HallZ]" rMin="[Rmin]" rMax="[CMSR2]"/>
+			<ZSection z="[CMSZ1]" rMin="[Rmin]" rMax="[CMSR2]"/>
+		</Polycone>
+		<Polycone name="CMSE" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="-[CMSZ1]" rMin="[Rmin]" rMax="[CMSR2]"/>
+			<ZSection z="-[CMSZ2]" rMin="[Rmin]" rMax="[CMSR2]"/>
+			<ZSection z="-[CMSZ2]" rMin="[Rmin]" rMax="[CMSR1]"/>
+			<ZSection z="[CMSZ2]" rMin="[Rmin]" rMax="[CMSR1]"/>
+			<ZSection z="[CMSZ2]" rMin="[Rmin]" rMax="[CMSR2]"/>
+			<ZSection z="[CMSZ1]" rMin="[Rmin]" rMax="[CMSR2]"/>
+		</Polycone>
+	</SolidSection>
+	<LogicalPartSection label="cms.xml">
+		<LogicalPart name="World" category="unspecified">
+			<rSolid name="OCMS"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="OCMS" category="unspecified">
+			<rSolid name="OCMS"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="MCMS" category="unspecified">
+			<rSolid name="OCMS"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="CMSE" category="unspecified">
+			<rSolid name="CMSE"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/cms_tracker.xml
+++ b/DetectorDescription/DDCMS/data/cms_tracker.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  <debug>
+<!-- 
+    <debug_rotations/>
+    <debug_materials/>
+
+    <debug_shapes/>
+    <debug_volumes/>
+    <debug_constants/>
+    <debug_includes/>
+    <debug_namespaces/>
+    <debug_placements/>
+    <debug_algorithms/>
+    <debug_visattr/>
+-->
+  </debug>
+  <open_geometry/>
+  <close_geometry/>
+
+  <ConstantsSection label="" eval="true">
+    <Constant name="world_x" value="5*m"/>
+    <Constant name="world_y" value="5*m"/>
+    <Constant name="world_z" value="5*m"/>
+    <Constant name="fm"      value="1e-12*m"/>
+    <Constant name="Air"     value="materials_Air"     type="string"/>
+    <Constant name="Vacuum"  value="materials_Vacuum"  type="string"/>
+  </ConstantsSection>
+  <ConstantsSection label="servicescylinderb.xml" eval="true">
+	<Constant name="zero" value="0.0*fm"/>
+  </ConstantsSection>
+  <ConstantsSection label="servicescylinderf.xml" eval="true">
+	<Constant name="zero" value="0.0*fm"/>
+  </ConstantsSection>
+
+  <DisabledAlgo  name="track:DDTOBRadCableAlgo"/>
+  <ConstantsSection label="pixfwd" eval="true">
+        <Constant name="AnchorZ" value="0.*mm"/>
+        <Constant name="ZPixelForward" value="325.*mm"/>
+  </ConstantsSection>
+  <ConstantsSection label="tracker.xml" eval="true">
+	<Constant name="BackPlaneDz" value="0.015*mm"/>
+  </ConstantsSection>
+
+  <IncludeSection>
+    <Include ref="materials.xml"/>
+    <Include ref="trackermaterial.xml"/>
+    <Include ref="tibtidcommonmaterial.xml"/>
+
+    <Include ref="vacuum.xml"/>
+    <Include ref="cmsextent.xml"/>
+    <Include ref="cms.xml"/>
+
+    <Include ref="pixfwdMaterials.xml"/>
+    <Include ref="pixbarmaterial.xml"/>
+    <Include ref="pixbarladder.xml"/>
+    <Include ref="pixbarladderfull.xml"/>
+    <Include ref="pixbarladderhalf.xml"/>
+    <Include ref="pixbarlayer.xml"/>
+    <Include ref="pixbarlayer0.xml"/>
+    <Include ref="pixbarlayer1.xml"/>
+    <Include ref="pixbarlayer2.xml"/>
+    <Include ref="pixbar.xml"/>
+
+    <Include ref="tecmaterial.xml"/>
+
+    <Include ref="tecpetpar.xml"/>
+    <Include ref="tecpetalb.xml"/>
+    <Include ref="tecpetalf.xml"/>
+    <Include ref="tecpetal0.xml"/>
+    <Include ref="tecpetal0b.xml"/>
+    <Include ref="tecpetal0f.xml"/>
+    <Include ref="tecpetal3.xml"/>
+    <Include ref="tecpetal3b.xml"/>
+    <Include ref="tecpetal3f.xml"/>
+    <Include ref="tecpetal6b.xml"/>
+    <Include ref="tecpetal6f.xml"/>
+    <Include ref="tecpetal8b.xml"/>
+    <Include ref="tecpetal8f.xml"/>
+
+    <Include ref="tecmodpar.xml"/>
+    <Include ref="tecmodule0.xml"/>
+    <Include ref="tecmodule0s.xml"/>
+    <Include ref="tecmodule1.xml"/>
+    <Include ref="tecmodule1r.xml"/>
+    <Include ref="tecmodule1s.xml"/>
+    <Include ref="tecmodule2.xml"/>
+    <Include ref="tecmodule3.xml"/>
+    <Include ref="tecmodule4.xml"/>
+    <Include ref="tecmodule4r.xml"/>
+    <Include ref="tecmodule4s.xml"/>
+    <Include ref="tecmodule5.xml"/>
+    <Include ref="tecmodule6.xml"/>
+    <Include ref="tecmodule0r.xml"/>
+
+    <Include ref="tecring0.xml"/>
+    <Include ref="tecring0b.xml"/>
+    <Include ref="tecring0f.xml"/>
+    <Include ref="tecring1.xml"/>
+    <Include ref="tecring1b.xml"/>
+    <Include ref="tecring1f.xml"/>
+    <Include ref="tecring2.xml"/>
+    <Include ref="tecring2b.xml"/>
+    <Include ref="tecring2f.xml"/>
+    <Include ref="tecring3.xml"/>
+    <Include ref="tecring3b.xml"/>
+    <Include ref="tecring3f.xml"/>
+    <Include ref="tecring4.xml"/>
+    <Include ref="tecring4b.xml"/>
+    <Include ref="tecring4f.xml"/>
+    <Include ref="tecring5.xml"/>
+    <Include ref="tecring5b.xml"/>
+    <Include ref="tecring5f.xml"/>
+    <Include ref="tecring6.xml"/>
+    <Include ref="tecring6b.xml"/>
+    <Include ref="tecring6f.xml"/>
+
+    <Include ref="tecwheel.xml"/>
+    <Include ref="tecwheel6.xml"/>
+    <Include ref="tecwheela.xml"/>
+    <Include ref="tecwheelb.xml"/>
+    <Include ref="tecwheelc.xml"/>
+    <Include ref="tecwheeld.xml"/>
+
+    <Include ref="tecbackplate.xml"/>
+    <Include ref="tec.xml"/>
+    <Include ref="tecservices.xml"/>
+
+    <Include ref="tibmaterial.xml"/>
+
+    <Include ref="tibmodpar.xml"/>
+    <Include ref="tibmodule0.xml"/>
+    <Include ref="tibmodule0a.xml"/>
+    <Include ref="tibmodule0b.xml"/>
+    <Include ref="tibmodule2.xml"/>
+
+    <Include ref="tiblayerpar.xml"/>
+    <Include ref="tiblayer0.xml"/>
+    <Include ref="tiblayer1.xml"/>
+    <Include ref="tiblayer2.xml"/>
+    <Include ref="tiblayer3.xml"/>
+
+    <Include ref="tibstringpar.xml"/>
+    <Include ref="tibstring0.xml"/>
+    <Include ref="tibstring0ll.xml"/>
+    <Include ref="tibstring0lr.xml"/>
+    <Include ref="tibstring0ul.xml"/>
+    <Include ref="tibstring0ur.xml"/>
+    <Include ref="tibstring1.xml"/>
+    <Include ref="tibstring1ll.xml"/>
+    <Include ref="tibstring1lr.xml"/>
+    <Include ref="tibstring1ul.xml"/>
+    <Include ref="tibstring1ur.xml"/>
+    <Include ref="tibstring2.xml"/>
+    <Include ref="tibstring2ll.xml"/>
+    <Include ref="tibstring2lr.xml"/>
+    <Include ref="tibstring2ul.xml"/>
+    <Include ref="tibstring2ur.xml"/>
+    <Include ref="tibstring3.xml"/>
+    <Include ref="tibstring3ll.xml"/>
+    <Include ref="tibstring3lr.xml"/>
+    <Include ref="tibstring3ul.xml"/>
+    <Include ref="tibstring3ur.xml"/>
+
+    <Include ref="tib.xml"/>
+
+    <Include ref="tidmaterial.xml"/>
+    <Include ref="tidmodpar.xml"/>
+    <Include ref="tidringpar.xml"/>
+
+    <Include ref="tidb.xml"/>
+    <Include ref="tidf.xml"/>
+    <Include ref="tidmodule0.xml"/>
+    <Include ref="tidmodule0l.xml"/>
+    <Include ref="tidmodule0r.xml"/>
+    <Include ref="tidmodule1.xml"/>
+    <Include ref="tidmodule1l.xml"/>
+    <Include ref="tidmodule1r.xml"/>
+    <Include ref="tidmodule2.xml"/>
+    <Include ref="tidring0.xml"/>
+    <Include ref="tidring0b.xml"/>
+    <Include ref="tidring0f.xml"/>
+    <Include ref="tidring1.xml"/>
+    <Include ref="tidring1b.xml"/>
+    <Include ref="tidring1f.xml"/>
+    <Include ref="tidring2.xml"/>
+    <Include ref="tid.xml"/>
+
+    <Include ref="tibtidservices.xml"/>
+    <Include ref="tibtidservicesb.xml"/>
+    <Include ref="tibtidservicesf.xml"/>
+
+    <Include ref="tobmaterial.xml"/>
+    <Include ref="tobmodpar.xml"/>
+    <Include ref="tobrodpar.xml"/>
+    <Include ref="tobmodule0.xml"/>
+    <Include ref="tobmodule2.xml"/>
+    <Include ref="tobmodule4.xml"/>
+
+    <Include ref="tobrod0.xml"/>
+    <Include ref="tobrod0c.xml"/>
+    <Include ref="tobrod0h.xml"/>
+    <Include ref="tobrod0l.xml"/>
+
+    <Include ref="tobrod1.xml"/>
+    <Include ref="tobrod1h.xml"/>
+    <Include ref="tobrod1l.xml"/>
+
+    <Include ref="tobrod2.xml"/>
+    <Include ref="tobrod2c.xml"/>
+    <Include ref="tobrod2h.xml"/>
+    <Include ref="tobrod2l.xml"/>
+
+    <Include ref="tobrod3.xml"/>
+    <Include ref="tobrod3h.xml"/>
+    <Include ref="tobrod3l.xml"/>
+
+    <Include ref="tobrod4.xml"/>
+    <Include ref="tobrod4c.xml"/>
+    <Include ref="tobrod4h.xml"/>
+    <Include ref="tobrod4l.xml"/>
+
+    <Include ref="tobrod5.xml"/>
+    <Include ref="tobrod5h.xml"/>
+    <Include ref="tobrod5l.xml"/>
+    <Include ref="tob.xml"/>
+
+    <Include ref="pixfwdCommon.xml"/>
+
+<!--
+
+    PixbarFWD IS THE HORROR.
+    CANNOT GET IT GOING. Ignore it.
+
+    <Include ref="pixfwdBlade.xml"/>
+    <Include ref="pixfwdPanel.xml"/>
+    <Include ref="pixfwdPanelBase.xml"/>
+    <Include ref="pixfwdDisk.xml"/>
+    <Include ref="pixfwdCylinder.xml"/>
+    <Include ref="pixfwdNipple.xml"/>
+
+    <Include ref="pixfwdPlaq.xml"/>
+    <Include ref="pixfwdPlaq1x2.xml"/>
+    <Include ref="pixfwdPlaq1x5.xml"/>
+    <Include ref="pixfwdPlaq2x3.xml"/>
+    <Include ref="pixfwdPlaq2x4.xml"/>
+    <Include ref="pixfwdPlaq2x5.xml"/>
+
+    <Include ref="pixfwd.xml"/>
+
+    TEC sucks in Geant4. Ignored.
+
+    <Include ref="trackertec.xml"/>
+-->
+    <Include ref="trackerbulkhead.xml"/>
+
+    <Include ref="trackertib.xml"/>
+    <Include ref="trackertid.xml"/>
+
+    <Include ref="trackerother.xml"/>
+    <Include ref="trackerpixbar.xml"/>
+
+    <Include ref="tracker.xml"/>
+    <Include ref="trackertob.xml"/>
+
+  </IncludeSection>
+
+  <PosPartSection label="">
+    <PosPart copyNumber="2">
+	<rParent name="world_volume"/>
+	<rChild name="tracker:Tracker"/>
+   </PosPart>
+  </PosPartSection>
+
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/cmsextent.xml
+++ b/DetectorDescription/DDCMS/data/cmsextent.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="cmsextent.xml" eval="true">
+		<Constant name="Rmin" value="0*fm"/>
+		<Constant name="Zmin" value="0*fm"/>
+		<Constant name="HallZ" value="27.0*m"/>
+		<Constant name="HallR" value="13.0*m"/>
+		<Constant name="HallRMax" value="[HallR]"/>
+		<Constant name="CMSR1" value="8.30*m"/>
+		<Constant name="CMSR2" value="1.00*m"/>
+		<Constant name="CMSZ1" value="27.1*m"/>
+		<Constant name="CMSZ2" value="26.0*m"/>
+	</ConstantsSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/dd4hep-config.xml
+++ b/DetectorDescription/DDCMS/data/dd4hep-config.xml
@@ -1,0 +1,341 @@
+<plugins>
+<!--
+
+   # Configuration file top load the CMS geometry
+
+   This XML script extends the raw geometry defintiion from CMS (see cms_tracker.xml for details).
+   * We load the primary geometry entities and instantiate them.
+     Note: TEC, and PixbarFWD do not work and cannot be converted;
+   * Here the DetElement structure and the readout structures are defined to run Geant4
+     Note: TEC, and PixbarFWD do not work and cannot be used for Geant4. To be investigated.
+   * Here we also define the visualization attributes to get nicer pictures.
+
+                         M.Frank CERN EP/LBC  October 2017
+
+-->
+
+  <display>
+<!--   Unused stuff:
+    <vis name="Layer_pixbarlayer0_PixelBarrelLayer0"         alpha="1.0" r="1"    g="0"  b="1" showDaughters="true" visible="true"/>
+
+    <vis name="pixbarladderhalf_PixelBarrelModuleHalfMinus"         alpha="0.3" r="0.3"    g="0.3"  b="0.3" showDaughters="true" visible="true"/>
+    <vis name="pixbarladderhalf_PixelBarrelModuleHalfPlus"         alpha="0.3" r="0.3"    g="0.3"  b="0.3" showDaughters="true" visible="true"/>
+
+    <vis name="pixbarladderhalf_PixelBarrelROChipHalf"         alpha="0.5" r="0.3"    g="0.3"  b="0.3" showDaughters="true" visible="true"/>
+    <vis name="pixbarladderhalf_PixelBarrelSensorHalf"         alpha="1.0" r="0.9"    g="0.9"  b="0" showDaughters="true" visible="true"/>
+    <vis name="pixbarladderhalf_PixelBarrelActiveHalf"         alpha="1.0" r="0.9"    g="0.9"  b="0" showDaughters="true" visible="true"/>
+
+    <vis name="pixbarladderfull_PixelBarrelCFStripHoleFull"    alpha="0.3" r="0.3"  g="0.3"  b="0.3" showDaughters="true" visible="true"/>
+    <vis name="pixbarladderfull_PixelBarrelModuleFullMinus"         alpha="0.3" r="0.3"    g="0.3"  b="0.3" showDaughters="true" visible="true"/>
+    <vis name="pixbarladderfull_PixelBarrelModuleFullPlus"         alpha="0.3" r="0.3"    g="0.3"  b="0.3" showDaughters="true" visible="true"/>
+
+    <vis name="pixbarladderfull_PixelBarrelROChipFull"         alpha="1" r="0.1"    g="0.1"  b="0.1" showDaughters="true" visible="true"/>
+    <vis name="pixbarladderfull_PixelBarrelSensorFull"         alpha="1" r="0.9"    g="0.9"  b="0" showDaughters="true" visible="true"/>
+    <vis name="pixbarladderfull_PixelBarrelActiveFull"         alpha="1" r="0.9"    g="0.9"  b="0" showDaughters="true" visible="true"/>
+-->      
+
+ <!--  DO NOT REFORMAT PLEASE!!!!  Vis attributes represent volume hierarchy!  -->
+          <vis name="pixbarladderhalf_PixelBarrelCable1Half"     alpha="1.0"   r="0"    g="1"    b="1"   showDaughters="true" visible="true"/>
+          <vis name="pixbarladderhalf_PixelBarrelCable2Half"     alpha="1.0"   r="0"    g="1"    b="1"   showDaughters="true" visible="true"/>
+          <vis name="pixbarladderhalf_PixelBarrelCable3Half"     alpha="1.0"   r="0"    g="1"    b="1"   showDaughters="true" visible="true"/>
+          <vis name="pixbarladderhalf_PixelBarrelCable4Half"     alpha="1.0"   r="0"    g="1"    b="1"   showDaughters="true" visible="true"/>
+        <vis name="pixbarladderhalf_PixelBarrelCableBoxHalf"     alpha="0.4"   r="0.4"  g="0.2"  b="0.2" showDaughters="true" visible="true"/>
+        <vis name="pixbarladderhalf_PixelBarrelModuleBoxHalf"    alpha="0.6"   r="0.2"  g="0.2"  b="0.2" showDaughters="true" visible="true"/>
+        <vis name="pixbarladderhalf_PixelBarrelCFStripHalf"      alpha="1"     r="1"    g="0.1"  b="0.1" showDaughters="true" visible="true"/>
+      <vis name="pixbarladderhalf_PixelBarrelLadderHalf"         alpha="0.8"   r="0.6"  g="0.6"  b="0.0" showDaughters="true" visible="true"/>
+
+          <vis name="pixbarladderfull_PixelBarrelCable1Full"     alpha="1.0"   r="0"    g="1"    b="1"   showDaughters="true"  visible="true"/>
+          <vis name="pixbarladderfull_PixelBarrelCable2Full"     alpha="1.0"   r="0"    g="1"    b="1"   showDaughters="true"  visible="true"/>
+          <vis name="pixbarladderfull_PixelBarrelCable3Full"     alpha="1.0"   r="0"    g="1"    b="1"   showDaughters="true"  visible="true"/>
+          <vis name="pixbarladderfull_PixelBarrelCable4Full"     alpha="1.0"   r="0"    g="1"    b="1"   showDaughters="true"  visible="true"/>
+        <vis name="pixbarladderfull_PixelBarrelCableBoxFull"     alpha="0.4"   r="0.4"  g="0.2"  b="0.2" showDaughters="true"  visible="true"/>
+        <vis name="pixbarladderfull_PixelBarrelModuleBoxFull"    alpha="0.6"   r="0.2"  g="0.2"  b="0.2" showDaughters="true"  visible="true"/>
+        <vis name="pixbarladderfull_PixelBarrelCFStripFull"      alpha="1"     r="1"    g="0.1"  b="0.1" showDaughters="true"  visible="true"/>
+      <vis name="pixbarladderfull_PixelBarrelLadderFull"         alpha="0.8"   r="0.6"  g="0.6"  b="0.0" showDaughters="true"  visible="true"/>
+
+        <vis name="pixbarlayer0_PixelBarrelLayer0Coolant"        alpha="0.5"   r="0"    g="0.4"  b="0.6" showDaughters="true"  visible="false"/>
+      <vis name="pixbarlayer0_PixelBarrelLayer0CoolTube"         alpha="1.0"   r="0"    g="0.2"  b="0.8" showDaughters="true"  visible="true"/>
+    <vis name="pixbarlayer0_PixelBarrelLayer0"                   alpha="0.5"   r="0.6"  g="0.6"  b="0.6" showDaughters="true"  visible="true"/>
+
+        <vis name="pixbarlayer1_PixelBarrelLayer1Coolant"        alpha="0.5"   r="0"    g="0.4"  b="0.6" showDaughters="true"  visible="false"/>
+      <vis name="pixbarlayer1_PixelBarrelLayer1CoolTube"         alpha="1.0"   r="0"    g="0.2"  b="0.8" showDaughters="true"  visible="true"/>
+    <vis name="pixbarlayer1_PixelBarrelLayer1"                   alpha="0.5"   r="0.6"  g="0.6"  b="0.6" showDaughters="true"  visible="true"/>
+
+        <vis name="pixbarlayer2_PixelBarrelLayer2Coolant"        alpha="0.5"   r="0"    g="0.4"  b="0.6" showDaughters="true"  visible="false"/>
+      <vis name="pixbarlayer2_PixelBarrelLayer2CoolTube"         alpha="1.0"   r="0"    g="0.2"  b="0.8" showDaughters="true"  visible="true"/>
+    <vis name="pixbarlayer2_PixelBarrelLayer2"                   alpha="0.5"   r="0.6"  g="0.6"  b="0.6" showDaughters="true"  visible="true"/> 
+    <vis name="pixbar_PixelBarrelSuppBox"                        alpha="0.5"   r="0.6"  g="0.6"  b="0.6" showDaughters="true"  visible="false"/> 
+    <vis name="pixbar_PixelBarrelShield4"                        alpha="0.5"   r="0.6"  g="0.6"  b="0.6" showDaughters="true"  visible="false"/> 
+    <vis name="pixbar_PixelBarrelRadialCooling"                  alpha="0.5"   r="0.6"  g="0.6"  b="0.6" showDaughters="true"  visible="false"/> 
+
+<!--
+    <vis name="tobmodule0_TOBActiveRphi0"                        alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tobmodule0_TOBWaferSter0"                         alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tobmodule2_TOBActiveRphi2"                        alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tobmodule4_TOBActiveRphi4"                        alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tobmodule4_TOBWaferRphi4"                         alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tobmodpar_TOBInactive"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+
+    <vis name="tibmodule0_TIBActiveRphi0"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tibmodule0_TIBActiveSter0"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tibmodule2_TIBActiveRphi2"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tibmodule0_TIBWaferRphi0"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tibmodule0_TIBWaferSter0"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tibmodule2_TIBWaferRphi2"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+
+
+    <vis name="vis-tob"                                          alpha="0.4"   r="0.0"  g="0.0"  b="0.4" showDaughters="true"  visible="true"/>
+    <vis name="tracker_Tracker"                                  alpha="0.5"   r="0.9"  g="0.9"  b="0.9"   showDaughters="true"  visible="false"/>
+-->
+
+    <vis name="solid-light-grey"                                 alpha="0.5"   r="0.5"  g="0.5"  b="0.5" showDaughters="true"  visible="false"/>
+    <vis name="solid-verylight-grey"                             alpha="0.6"   r="0.5"  g="0.5"  b="0.5" showDaughters="true"  visible="true"/>
+    <vis name="solid-red"                                        alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="solid-verylight-red"                              alpha="0.6"   r="1.0"  g="0.8"  b="0.8" showDaughters="true"  visible="true"/>
+    <vis name="solid-green"                                      alpha="1.0"   r="0.0"  g="0.9"  b="0.2" showDaughters="true"  visible="true"/>
+    <vis name="solid-light-green"                                alpha="0.4"   r="0.0"  g="0.4"  b="0.0" showDaughters="true"  visible="false"/>
+    <vis name="solid-verylight-green"                            alpha="0.6"   r="0.8"  g="1.0"  b="0.8" showDaughters="true"  visible="true"/>
+    <vis name="solid-blue"                                       alpha="1.0"   r="0.0"  g="0.0"  b="1.0" showDaughters="true"  visible="true"/>
+    <vis name="solid-light-blue"                                 alpha="1.0"   r="0.0"  g="0.0"  b="1.0" showDaughters="true"  visible="true"/>
+    <vis name="solid-verylight-blue"                             alpha="0.6"   r="0.8"  g="0.8"  b="1.0" showDaughters="true"  visible="true"/>
+    <vis name="solid-verylight-yellow"                           alpha="0.3"   r="1.0"  g="1.0"  b="0.2" showDaughters="true"  visible="true"/>
+    <vis name="CMS_Invisible"                                    alpha="0.5"   r="0.9"  g="0.9"  b="0.9" showDaughters="true"  visible="false"/>
+
+    <vis name="vis-active-material"                              alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="vis-invisible-daughters"                          alpha="1.0"   r="0.1"  g="0.1"  b="0.8" showDaughters="true"  visible="false"/>
+  </display>
+
+  <plugin name="DD4hep_XMLLoader">
+    <arg value="file:${DD4hepINSTALL}/examples/DDCMS/data/cms_tracker.xml"/>
+  </plugin>
+
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-recursive"/>
+    <arg value="-processor"/>
+    <arg value="DDCMS_DetElementCreator"/>
+  </plugin>
+  <plugin name="DD4hep_VolumeManager"/>
+  <plugin name="DD4hep_InteractiveUI"/>
+
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-recursive"/>
+    <arg value="-detector"/>
+    <arg value="Tracker_2"/>
+
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisMaterialProcessor"/>
+    <arg value="-name"/>
+    <arg value="AL_Vis"/>
+    <arg value="-vis-active"/>
+    <arg value="CMS_Invisible"/>
+    <arg value="-elt-active"/>
+    <arg value="AL"/>
+    <arg value="-fraction"/>
+    <arg value="0.7"/>
+    <arg value="-show"/>
+  </plugin>
+
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-recursive"/>
+    <arg value="-detector"/>
+    <arg value="Tracker_2/TrackerOuterCylinder_1"/>
+
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisMaterialProcessor"/>
+    <arg value="-name"/>
+    <arg value="OuterCylinder_1_Vis"/>
+    <arg value="-vis-inactive"/>
+    <arg value="CMS_Invisible"/>
+    <arg value="-show"/>
+  </plugin>
+
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-recursive"/>
+    <arg value="-detector"/>
+    <arg value="Tracker_2/TrackerBulkhead_1"/>
+
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisMaterialProcessor"/>
+    <arg value="-name"/>
+    <arg value="TrackerBulkhead_1_Vis"/>
+    <arg value="-vis-inactive"/>
+    <arg value="CMS_Invisible"/>
+    <arg value="-show"/>
+  </plugin>
+
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-recursive"/>
+    <arg value="-detector"/>
+    <arg value="Tracker_2/TrackerBulkhead_2"/>
+
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisMaterialProcessor"/>
+    <arg value="-name"/>
+    <arg value="TrackerBulkhead_2_Vis"/>
+    <arg value="-vis-inactive"/>
+    <arg value="CMS_Invisible"/>
+    <arg value="-show"/>
+  </plugin>
+
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-recursive"/>
+    <arg value="-detector"/>
+    <arg value="Tracker_2/PixelBarrel_1"/>
+
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisMaterialProcessor"/>
+    <arg value="-name"/>
+    <arg value="PixelBarrel_1_Vis"/>
+    <arg value="-vis-inactive"/>
+    <arg value="solid-verylight-yellow"/>
+    <arg value="-show"/>
+  </plugin>
+<!--
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-recursive"/>
+    <arg value="-detector"/>
+    <arg value="Tracker_2/TEC_1"/>
+
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisMaterialProcessor"/>
+    <arg value="-name"/>
+    <arg value="Invisible_Vis"/>
+    <arg value="-vis-active"/>
+    <arg value="solid-green"/>
+
+    <arg value="-vis-inactive"/>
+    <arg value="solid-verylight-green"/>
+
+    <arg value="-elt-active"/>
+    <arg value="SI"/>
+    <arg value="-fraction"/>
+    <arg value="0.7"/>
+    <arg value="-show"/>
+  </plugin>
+
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-recursive"/>
+    <arg value="-detector"/>
+    <arg value="Tracker_2/TEC_2"/>
+
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisMaterialProcessor"/>
+    <arg value="-name"/>
+    <arg value="Invisible_Vis"/>
+    <arg value="-vis-active"/>
+    <arg value="solid-green"/>
+
+    <arg value="-vis-inactive"/>
+    <arg value="solid-verylight-green"/>
+
+    <arg value="-elt-active"/>
+    <arg value="SI"/>
+    <arg value="-fraction"/>
+    <arg value="0.7"/>
+    <arg value="-show"/>
+  </plugin>
+-->
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-recursive"/>
+    <arg value="-detector"/>
+    <arg value="Tracker_2/TIB_1"/>
+
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisMaterialProcessor"/>
+    <arg value="-name"/>
+    <arg value="Tracker_2/TIB_1"/>
+    <arg value="-vis-active"/>
+    <arg value="solid-blue"/>
+
+    <arg value="-vis-inactive"/>
+    <arg value="solid-verylight-blue"/>
+
+    <arg value="-elt-active"/>
+    <arg value="SI"/>
+    <arg value="-fraction"/>
+    <arg value="0.7"/>
+    <arg value="-show"/>
+  </plugin>
+
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-recursive"/>
+    <arg value="-detector"/>
+    <arg value="Tracker_2/TIDF_1"/>
+
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisMaterialProcessor"/>
+    <arg value="-name"/>
+    <arg value="Tracker_2/TIDF_1"/>
+    <arg value="-vis-active"/>
+    <arg value="solid-light-blue"/>
+
+    <arg value="-vis-inactive"/>
+    <arg value="solid-verylight-blue"/>
+
+    <arg value="-elt-active"/>
+    <arg value="SI"/>
+    <arg value="-fraction"/>
+    <arg value="0.7"/>
+    <arg value="-show"/>
+  </plugin>
+
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-recursive"/>
+    <arg value="-detector"/>
+    <arg value="Tracker_2/TOB_1"/>
+
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisMaterialProcessor"/>
+    <arg value="-name"/>
+    <arg value="TOB_1_Vis"/>
+    <arg value="-vis-active"/>
+    <arg value="solid-red"/>
+
+    <arg value="-vis-inactive"/>
+    <arg value="solid-verylight-red"/>
+
+    <arg value="-elt-active"/>
+    <arg value="SI"/>
+    <arg value="-fraction"/>
+    <arg value="0.33"/>
+    <arg value="-show"/>
+  </plugin>
+
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-recursive"/>
+    <arg value="-detector"/>
+    <arg value="Tracker_2"/>
+
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisDensityProcessor"/>
+    <arg value="-name"/>
+    <arg value="Density_Vis"/>
+    <arg value="-min-density"/>
+    <arg value="5.0"/>
+    <arg value="-vis"/>
+    <arg value="vis-invisible-daughters"/>
+    <arg value="-show"/>
+  </plugin>
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-recursive"/>
+    <arg value="-detector"/>
+    <arg value="Tracker_2"/>
+
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisVolNameProcessor"/>
+    <arg value="-name"/>
+    <arg value="VolName_Vis"/>
+    <arg value="-show"/>
+  </plugin>
+<!--
+  <plugin name="DD4hep_DetectorDump">
+    <arg value="-sensitive"/>
+  </plugin>
+  <plugin name="DD4hep_GeometryDisplay"/>
+
+  <plugin name="DD4hep_VolumeDump">
+    <arg value="-sensitive"/>
+    <arg value="-volids"/>
+  </plugin>
+-->
+</plugins>

--- a/DetectorDescription/DDCMS/data/materials.xml
+++ b/DetectorDescription/DDCMS/data/materials.xml
@@ -1,0 +1,4680 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <MaterialSection label="materials.xml">
+  <ElementaryMaterial name="Aluminium" density="2.7*g/cm3" symbol=" " atomicWeight="26.98*g/mole" atomicNumber="13"/>
+ <ElementaryMaterial name="TD_Aluminium" density="8.1*g/cm3" symbol=" " atomicWeight="26.98*g/mole" atomicNumber="13"/>
+  <ElementaryMaterial name="Antimony" density="6.679*g/cm3" symbol=" " atomicWeight="121.75*g/mole" atomicNumber="51"/>
+  <ElementaryMaterial name="Argon" density="1.639*mg/cm3" symbol=" " atomicWeight="39.948*g/mole" atomicNumber="18"/>
+  <ElementaryMaterial name="Arsenic" density="5.72*g/cm3" symbol=" " atomicWeight="74.922*g/mole" atomicNumber="33"/>
+  <ElementaryMaterial name="Barium" density="3.5*g/cm3" symbol=" " atomicWeight="137.33*g/mole" atomicNumber="56"/>
+  <ElementaryMaterial name="Beryllium" density="1.848*g/cm3" symbol=" " atomicWeight="9.0122*g/mole" atomicNumber="4"/>
+  <ElementaryMaterial name="Bismuth" density="9.37*g/cm3" symbol=" " atomicWeight="208.98*g/mole" atomicNumber="83"/>
+  <ElementaryMaterial name="Bor 10" density="2.34*g/cm3" symbol=" " atomicWeight="10*g/mole" atomicNumber="5"/>
+  <ElementaryMaterial name="Bor 11" density="2.34*g/cm3" symbol=" " atomicWeight="11*g/mole" atomicNumber="5"/>
+  <ElementaryMaterial name="Bromine" density="3.11*g/cm3" symbol=" " atomicWeight="79.904*g/mole" atomicNumber="35"/>
+  <ElementaryMaterial name="Cadmium" density="8.63*g/cm3" symbol=" " atomicWeight="112.41*g/mole" atomicNumber="48"/>
+  <ElementaryMaterial name="Calcium" density="1.55*g/cm3" symbol=" " atomicWeight="40.078*g/mole" atomicNumber="20"/>
+  <ElementaryMaterial name="Carbon" density="2.265*g/cm3" symbol=" " atomicWeight="12.011*g/mole" atomicNumber="6"/>
+  <ElementaryMaterial name="Cerium" density="6.637*g/cm3" symbol=" " atomicWeight="140.12*g/mole" atomicNumber="58"/>
+  <ElementaryMaterial name="Cesium" density="1.87*g/cm3" symbol=" " atomicWeight="132.9054*g/mole" atomicNumber="55"/>
+  <ElementaryMaterial name="Chlorine" density="1.56*g/cm3" symbol=" " atomicWeight="35.45*g/mole" atomicNumber="17"/>
+  <ElementaryMaterial name="Chromium" density="7.18*g/cm3" symbol=" " atomicWeight="51.996*g/mole" atomicNumber="24"/>
+  <ElementaryMaterial name="Cobalt" density="8.9*g/cm3" symbol=" " atomicWeight="58.933*g/mole" atomicNumber="27"/>
+  <ElementaryMaterial name="Copper" density="8.96*g/cm3" symbol=" " atomicWeight="63.546*g/mole" atomicNumber="29"/>
+  <ElementaryMaterial name="Deuterium" density="162*mg/cm3" symbol=" " atomicWeight="2.01*g/mole" atomicNumber="1"/>
+  <ElementaryMaterial name="Fluorine" density="1.108*g/cm3" symbol=" " atomicWeight="18.998*g/mole" atomicNumber="9"/>
+  <ElementaryMaterial name="Gallium" density="5.877*g/cm3" symbol=" " atomicWeight="69.723*g/mole" atomicNumber="31"/>
+  <ElementaryMaterial name="Germanium" density="5.323*g/cm3" symbol=" " atomicWeight="72.61*g/mole" atomicNumber="32"/>
+  <ElementaryMaterial name="Gold" density="18.85*g/cm3" symbol=" " atomicWeight="196.97*g/mole" atomicNumber="79"/>
+  <ElementaryMaterial name="Helium" density="125*mg/cm3" symbol=" " atomicWeight="4.0026*g/mole" atomicNumber="2"/>
+  <ElementaryMaterial name="Hydrogen" density="70.8*mg/cm3" symbol=" " atomicWeight="1.00794*g/mole" atomicNumber="1"/>
+  <ElementaryMaterial name="Indium" density="7.3*g/cm3" symbol=" " atomicWeight="114.82*g/mole" atomicNumber="49"/>
+  <ElementaryMaterial name="Iodine" density="7.3*g/cm3" symbol=" " atomicWeight="114.82*g/mole" atomicNumber="53"/>
+  <ElementaryMaterial name="Iron" density="7.87*g/cm3" symbol=" " atomicWeight="55.85*g/mole" atomicNumber="26"/>
+  <ElementaryMaterial name="Krypton" density="2.6*g/cm3" symbol=" " atomicWeight="83.8*g/mole" atomicNumber="36"/>
+  <ElementaryMaterial name="Lanthanum" density="6.127*g/cm3" symbol=" " atomicWeight="138.9055*g/mole" atomicNumber="57"/>
+  <ElementaryMaterial name="Lead" density="11.35*g/cm3" symbol=" " atomicWeight="207.19*g/mole" atomicNumber="82"/>
+  <ElementaryMaterial name="Lithium" density="534*mg/cm3" symbol=" " atomicWeight="6.941*g/mole" atomicNumber="3"/>
+   <ElementaryMaterial name="Lutecium" density="9.841*g/cm3" symbol=" " atomicWeight="174.96*g/mole" atomicNumber="71"/>
+  <ElementaryMaterial name="Magnesium" density="1.735*g/cm3" symbol=" " atomicWeight="24.305*g/mole" atomicNumber="12"/>
+  <ElementaryMaterial name="Manganese" density="7.43*g/cm3" symbol=" " atomicWeight="54.938*g/mole" atomicNumber="25"/>
+  <ElementaryMaterial name="Molybdenum" density="10.2*g/cm3" symbol=" " atomicWeight="95.94*g/mole" atomicNumber="42"/>
+  <ElementaryMaterial name="Neodymium" density="1e-22*mg/cm3" symbol=" " atomicWeight="144.24*g/mole" atomicNumber="60"/>
+  <ElementaryMaterial name="Neon" density="1.207*g/cm3" symbol=" " atomicWeight="20.18*g/mole" atomicNumber="10"/>
+  <ElementaryMaterial name="Nickel" density="8.876*g/cm3" symbol=" " atomicWeight="58.693*g/mole" atomicNumber="28"/>
+  <ElementaryMaterial name="Niobium" density="8.55*g/cm3" symbol=" " atomicWeight="92.906*g/mole" atomicNumber="41"/>
+  <ElementaryMaterial name="Nitrogen" density="808*mg/cm3" symbol=" " atomicWeight="14.007*g/mole" atomicNumber="7"/>
+  <ElementaryMaterial name="Oxygen" density="1.43*mg/cm3" symbol=" " atomicWeight="15.999*g/mole" atomicNumber="8"/>
+  <ElementaryMaterial name="Palladium" density="12*g/cm3" symbol=" " atomicWeight="106.42*g/mole" atomicNumber="46"/>
+  <ElementaryMaterial name="Phosphor" density="1.82*g/cm3" symbol=" " atomicWeight="30.974*g/mole" atomicNumber="15"/>
+  <ElementaryMaterial name="Potassium" density="860*mg/cm3" symbol=" " atomicWeight="39.098*g/mole" atomicNumber="19"/>
+  <ElementaryMaterial name="Praseodymium" density="1e-22*mg/cm3" symbol=" " atomicWeight="140.9077*g/mole" atomicNumber="59"/>
+  <ElementaryMaterial name="Rhodium" density="12.39*g/cm3" symbol=" " atomicWeight="102.9055*g/mole" atomicNumber="45"/>
+  <ElementaryMaterial name="Rubidium" density="1.529*g/cm3" symbol=" " atomicWeight="85.4678*g/mole" atomicNumber="37"/>
+  <ElementaryMaterial name="Ruthenium" density="12.39*g/cm3" symbol=" " atomicWeight="101.07*g/mole" atomicNumber="44"/>
+  <ElementaryMaterial name="Scandium" density="2.98*g/cm3" symbol=" " atomicWeight="44.956*g/mole" atomicNumber="21"/>
+  <ElementaryMaterial name="Selenium" density="4.78*g/cm3" symbol=" " atomicWeight="78.96*g/mole" atomicNumber="34"/>
+  <ElementaryMaterial name="Silicon" density="2.33*g/cm3" symbol=" " atomicWeight="28.09*g/mole" atomicNumber="14"/>
+  <ElementaryMaterial name="Silver" density="10.48*g/cm3" symbol=" " atomicWeight="107.87*g/mole" atomicNumber="47"/>
+  <ElementaryMaterial name="Sodium" density="969*mg/cm3" symbol=" " atomicWeight="22.99*g/mole" atomicNumber="11"/>
+  <ElementaryMaterial name="Strontium" density="2.54*g/cm3" symbol=" " atomicWeight="87.62*g/mole" atomicNumber="38"/>
+  <ElementaryMaterial name="Sulfur" density="2.07*g/cm3" symbol=" " atomicWeight="32.066*g/mole" atomicNumber="16"/>
+  <ElementaryMaterial name="Tantalum" density="16.65*g/cm3" symbol=" " atomicWeight="180.9479*g/mole" atomicNumber="73"/>
+  <ElementaryMaterial name="Technetium" density="11.48*g/cm3" symbol=" " atomicWeight="98*g/mole" atomicNumber="43"/>
+  <ElementaryMaterial name="Tellurium" density="6.23*g/cm3" symbol=" " atomicWeight="127.6*g/mole" atomicNumber="52"/>
+  <ElementaryMaterial name="Tin" density="7.31*g/cm3" symbol=" " atomicWeight="118.69*g/mole" atomicNumber="50"/>
+  <ElementaryMaterial name="Titanium" density="4.53*g/cm3" symbol=" " atomicWeight="47.88*g/mole" atomicNumber="22"/>
+  <ElementaryMaterial name="Tungsten" density="19.3*g/cm3" symbol=" " atomicWeight="183.85*g/mole" atomicNumber="74"/>
+  <ElementaryMaterial name="Uranium" density="18.95*g/cm3" symbol=" " atomicWeight="238.03*g/mole" atomicNumber="92"/>
+  <ElementaryMaterial name="Vacuum" density="1e-13*mg/cm3" symbol=" " atomicWeight="1*g/mole" atomicNumber="1"/>
+  <ElementaryMaterial name="Vanadium" density="6.1*g/cm3" symbol=" " atomicWeight="50.941*g/mole" atomicNumber="23"/>
+  <ElementaryMaterial name="Xenon" density="3.057*g/cm3" symbol=" " atomicWeight="131.29*g/mole" atomicNumber="54"/>
+  <ElementaryMaterial name="Yttrium" density="4.456*g/cm3" symbol=" " atomicWeight="88.9059*g/mole" atomicNumber="39"/>
+  <ElementaryMaterial name="Zinc" density="7.112*g/cm3" symbol=" " atomicWeight="65.39*g/mole" atomicNumber="30"/>
+  <ElementaryMaterial name="Zirconium" density="6.494*g/cm3" symbol=" " atomicWeight="91.22*g/mole" atomicNumber="40"/>
+  <CompositeMaterial name="FPix_Thermflow" density="0.7625*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.3787448">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.21575329">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3239468">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.08155498">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_TPG" density="2.47*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin" density="3.43511*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_OuterOuterRing" density="2.2677*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_OuterInnerRing" density="1.000035*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_InnerOuterRing" density="1.77*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_InnerInnerRing" density="1.1744*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_OuterOuterRing" density="1.612*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_OuterInnerRing" density="1.745*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_InnerOuterRing" density="1.944*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_InnerInnerRing" density="1.566*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="80pct Argon plus 20pct CO_2" density="1.675*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.78405896">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.058934941">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1570061">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AISI-1006-Steel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0045">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9938">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AISI-1018-Steel" density="7.83*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0018">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0001">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0025">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9854">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Steel_Upgrade" density="0.4915*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:AISI-1018-Steel"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  <CompositeMaterial name="AISI-1045-Steel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.005">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.009">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9851">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bpix_Pipe_Steel" density="8.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.7195">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  <CompositeMaterial name="AQBB borated concre" density="2.135*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.032142361">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47563465">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20400656">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.051371319">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20008524">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0048537181">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02135636">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010549802">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001119">
+    <rMaterial name="materials:Water"/>
+   </MaterialFraction>   
+  </CompositeMaterial>
+  <CompositeMaterial name="Heavy Boron concrete" density="3.574*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5203954">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34702">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0080099">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0296094">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0684299">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.006620977">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.008010562">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004774732">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004804022">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.000555229">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001653212">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.000118189">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>   
+  </CompositeMaterial>
+  <CompositeMaterial name="Air" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al support" density="254*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al-MMC" density="1.84*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al-silicate plus Zi" density="3.3196*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.34196227">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11867705">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43936068">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al_2 O_3" density="3.91*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.52924272">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47075728">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium 2219" density="2.84*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9168">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.068">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.003">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.002">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Vanadium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0025">
+    <rMaterial name="materials:Zirconium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium 2219 light" density="1.42*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Aluminium 2219"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium 2219 very light" density="0.067558*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.065">
+    <rMaterial name="materials:Aluminium 2219"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.935">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Alumina" density="3.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.52924272">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47075728">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium Pix_b" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium honeycomb" density="0.0511415*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.97670111">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017460186">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0055195064">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00030055565">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.863911e-05">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium silicate" density="3.156*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.37995808">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13186339">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.48817853">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminized Mylar" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45014471">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.030220222">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.23984232">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27979275">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar 50pct plus CO_2 50pct" density="1.729*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.475815">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14306133">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38112367">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar 40pct plus Ethane 60pct " density="1.4692*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46968659">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.42365618">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10665723">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Cu mixt. for Cors" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.032220584">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.93514796">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.018242877">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0021475706">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0056206649">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0048079473">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010151454">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00079724857">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Cu mixture for EM" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.30224783">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.4919464">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17112881">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0020145463">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012041684">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017214762">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.002658102">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00074786557">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Cu mixture for HD" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.032220584">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.93514796">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.018242877">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0021475706">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0056206649">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0048079473">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010151454">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00079724857">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Pb mixture for EM" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.26749417">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.54605374">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15145173">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017829057">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010657083">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015235339">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0023524628">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.000661873">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0043106974">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="WCu" density="14.979*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.75">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/W Catcher section" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="9.6146597e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99990385">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/W Hadron section" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="9.6146597e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99990385">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/W mixt. for E.M." density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="9.6146597e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99990385">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Argon 50pct CF_4 CO_2" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.39336475">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11827135">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29931485">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18904904">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Argon CF_4 CO_2" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="BET2a concrete plus Poly" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.75468049">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.070780535">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0095602944">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.079376542">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035227691">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040083658">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0057520693">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00084050447">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0036982197">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="BET2b concrete plus Poly" density="1.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.86250534">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080265403">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0031685162">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.026156529">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011497209">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013100008">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017629095">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00028594245">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0012581468">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="B_2 O_3" density="2.34*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.057473742">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25288446">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68964179">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ba O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.89565575">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10434425">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bakelite" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.074565894">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77748634">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14794776">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Barite" density="3.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.003866475">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31286387">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0055278003">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0036870588">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042359836">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017690768">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00036536456">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.49076686">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11459208">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015333135">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0067465796">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Barium sulfate" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5884092">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13739117">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27419963">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Beryllia" density="2.63*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.36032657">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.63967343">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bi_4 Ge_3 O_12" density="7.1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.67102392">
+    <rMaterial name="materials:Bismuth"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1748602">
+    <rMaterial name="materials:Germanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15411587">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Borated Polyethyl." density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.116">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.612">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.222">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron" density="2.34*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18518519">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.81481481">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron-Barite" density="3.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0067292668">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34051688">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013925946">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0080541549">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013576194">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.044652146">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0011660794">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00088239182">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.8572377e-05">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0023924499">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01052678">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.45198295">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10553619">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron_frits-Lumnite" density="3.1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.006189139">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33104107">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054553968">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016633648">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.029078398">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020734192">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00052224672">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00060798896">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00045402481">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015404679">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0067780588">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012029137">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.46123883">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1076974">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C F_4" density="3.7037*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.13648398">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.86351602">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C O_2" density="1.8182*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27292145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.72707855">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C6F14" density="1.76*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.21318905">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.78681095">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CF_4 CO_2 50:50" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18196831">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.57564464">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24238706">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CO2Ar Freon" density="2.04*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017209441">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25354028">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.030543441">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016368527">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68233831">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CSC Electronics" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00046948789">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00014841431">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="8.081657e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.0118803e-07">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32063924">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.39047805">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28825623">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CT Al cable" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.67273024">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31187538">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015319366">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.5010078e-05">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CT Cu cable" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.87214714">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12183881">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0059847409">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="2.9303816e-05">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_New Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ca C O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.40043563">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47955758">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12000679">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ca O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.71469586">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28530414">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_0" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.47272949">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16266859">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041785423">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.23271447">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.143868e-05">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.039129523">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.050901068">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_MSGC_2" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.3625772">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12348903">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.036468221">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30679798">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="3.0189302e-05">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.074162202">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.096475172">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_MSGC_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.37934415">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12285748">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035749337">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29734771">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="2.9095785e-05">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.071569642">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.093102596">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_Si_1" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.61618264">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.082694045">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.044364552">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2563757">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00037658981">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="6.4825308e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Carbon fib.str." density="1.45*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6470534">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3529466">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Carbon fibre str." density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Carbon_fibre_str_Upgrade2" density="0.845*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  <CompositeMaterial name="Carbon fibre st_b" density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Carbon fibre str."/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Phase1 BPIX CFStrip material as defined by W. Bertl-->
+  <CompositeMaterial name="CFK" density="1.575*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Phase1 BPIX micro-twisted pairs signal cables material as defined by W. Bertl -->
+  <CompositeMaterial name="micro_twisted_signal_cable" density="4.09*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.476683">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.274139">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1494102">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02006116">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.07960754">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Phase1 BPIX micro-twisted pairs power cables material as defined by W. Bertl -->
+  <CompositeMaterial name="micro_twisted_power_cable" density="3.42*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.751011">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138483">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066287">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0089008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0353182">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+  <!--OUTDATED Phase1 BPIX micro-twisted pairs boundle material as defined by W. Bertl, effective density defined to matcht the measured weigth (0.0071+0.0208 g/cm) in a single 1.5mm diam. boundle-->
+  <CompositeMaterial name="micro_twisted_boundle" density="1.585*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7455">
+    <rMaterial name="materials:micro_twisted_power_cable"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2545">
+    <rMaterial name="materials:micro_twisted_signal_cable"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+  <!--Phase1 BPIX micro-twisted pairs boundle material as defined by L. Caminada-->
+  <CompositeMaterial name="micro_twisted_power_cable" density="3.639*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.36933">
+      <rMaterial name="trackermaterial:T_Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.63067">
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="micro_twisted_boundle_1" density="2.93382*g/cm3" symbol=" " method="mixture by weight"> <!--for L1-->
+   <MaterialFraction fraction="0.04631">
+    <rMaterial name="trackermaterial:T_Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.95369">
+    <rMaterial name="materials:micro_twisted_power_cable"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="micro_twisted_boundle_2" density="2.91735*g/cm3" symbol=" " method="mixture by weight"> <!--for L2,3,4-->
+   <MaterialFraction fraction="0.04964">
+    <rMaterial name="trackermaterial:T_Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.95036">
+    <rMaterial name="materials:micro_twisted_power_cable"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Carbon_fibre_str_Upgrade" density="0.293*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Carbon fibre str."/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ce F_3" density="6.16*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.71085768">
+    <rMaterial name="materials:Cerium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28914232">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ceramic" density="3.96525*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.52924272">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47075728">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Coil average" density="5.10794*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98933034">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010669663">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Colmanite Barite" density="3.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0033244208">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32054568">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.019644903">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00631619">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.021681066">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.024762714">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00091831559">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0071874954">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00057930956">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="8.1400861e-05">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0019024847">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0083709328">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47400649">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1106786">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Connector" density="1.119*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.12175975">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.029972928">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.075860931">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77184835">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00054859821">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.4434439e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Coolant" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012092387">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063980691">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24016253">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68376439">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Thick_Copper" density="8.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Crack average" density="1.85*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.1922">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0242">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2836">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cu/Quartz" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0081131524">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0092418886">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0011862487">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00011002641">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.98134868">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cu/Sci spaghetti mix" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012637483">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017671321">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00040177288">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00010044322">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0022298395">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.98286333">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cu/Scintillator/PolB" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.013621137">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0018577191">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.98179207">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00040133497">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00010033374">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0022274091">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DTBX gas" density="1.695*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.049996061">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25927645">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.69072749">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Dead_Argon CF_4 CO_2" density="2.14154*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Doped Quartz" density="2.5*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.28638718">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32623058">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38738224">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Double-sided MSGC el" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.15487536">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0062815446">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.062222733">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30743601">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12068891">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30724234">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041253098">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Double-sided MSGCsub" density="2.207*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.20936607">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36666251">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01999014">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36881246">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035168818">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Double-sided Si elec" density="2.392*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.25534309">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013472574">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.058711815">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1751292">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.023514409">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24970935">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22411956">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DropsPolyethylene" density="450*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="EAPD_Silicon" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Aluminium" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP1" density="1.6*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP2" density="700*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP3" density="400*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP4" density="300*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Cables" density="2.68*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DD_E_Cables" density="5.36*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+   <CompositeMaterial name="E_Carbon Fibre" density="1.45*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.65">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Copper" density="8.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Epoxy" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.53539691">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13179314">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33280996">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_G10" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.2198829">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.41718655">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26819334">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066018389">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028718811">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Iron" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Lead" density="11.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_PbWO4" density="8.28*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45532661">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.40403397">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14063942">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Polythene" density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Rohacell" density="71*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Silicon" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Water" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.11190083">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.88809917">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ec_Cable_1" density="2.12*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="EE_Aveolar" density="0.94*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.65">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Epoxy" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.53539691">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13179314">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33280996">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ethane" density="1.356*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.79887887">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20112113">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Fe_2 O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.69944958">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30055042">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Fibre_connector" density="1.05917*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.33154227">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38182349">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.064261825">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16677931">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.052722204">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028709009">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Flushing gas" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0010671918">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00033736021">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.8370396e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.1392493e-06">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99857594">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Foam" density="100*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Freon-12" density="4.93*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.099340816">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.58640112">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31425807">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FrontEnd Electronics" density="1.03441*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00065963049">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002085221">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.1354728e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.0416919e-07">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.45049813">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.54862165">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="G10" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.13232243">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032572448">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.48316123">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35194389">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="G_conntr" density="2.007*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.36065118">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38351407">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.051494019">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20434074">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Gas" density="1.9573*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.49078595">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.50287777">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0063362788">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Glass" density="2.23*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.36611059">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53173295">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.007820091">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0344084">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.059927964">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Graph.Epoxy Sup." density="138.3*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.80947966">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.073636829">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11688351">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Graphite Epoxy suprt" density="1.383*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.80947966">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.073636829">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11688351">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HFE" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012092387">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063980691">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24016253">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68376439">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HV Light Guides" density="1.32*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46726616">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53238309">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00034445206">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.9293189e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="3.677097e-07">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Aluminium" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Brass" density="8.53*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Iron" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Polystyrene" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Scintillator" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hcal average" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98854345">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="2.2305277e-06">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.0511343e-07">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="3.8395793e-08">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00034716943">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011106403">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hcal sci" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.92257895">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.07742105">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hexel for CSC" density="165*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0002303291">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.046295939">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35049864">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47901437">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11791403">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0060466926">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="High Tension cables" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45726783">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.44778783">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.070543148">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.024401185">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Honeycomb" density="280*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hybrids" density="1.785*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6459597">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.21237145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028514885">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11315397">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="ICB" density="2.309*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.26383847">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.097410682">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.023978583">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35568471">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25908755">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Insulation" density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.008091404">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043705226">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0029341267">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.023286651">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10908214">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.81290046">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Isobutane" density="2.67*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.82658619">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17341381">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="K_2 O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.83015022">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16984978">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kapton" density="1.11*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kr/Cu mixture for HD" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.054145746">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017829582">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0020989171">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054933281">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0046990226">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00099214713">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0007791868">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.91396207">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kr/Pb mixture for EM" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.38570939">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.45792903">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12700974">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001495172">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0089371927">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012776589">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0019728114">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00055505683">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0036150168">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kr/Pb mixture for HD" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.043537564">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.93041049">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014336428">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0016876993">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0044170805">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0037783947">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00079776662">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00062652927">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00040805081">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="LeadBPolymer" density="3.53*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.023">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0037037037">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016296296">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.114">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.102">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.088">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.022">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.618">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="LeadLoadedPolymerCon" density="3.53*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.023512713">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041643122">
+    <rMaterial name="materials:Lithium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11416406">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10198306">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.087818747">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01869691">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028328615">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013031207">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.59631732">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Limonite" density="2.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0097839501">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36018046">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012566469">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.008172324">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.57297034">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035392035">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00093441511">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Limonite Iron" density="4.16*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0077950891">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25025334">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035888928">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020743458">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.61983399">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.062339683">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0020806726">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010648449">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Limonite magetite" density="3.41*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0046317534">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33176807">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010582504">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.006612936">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.61641603">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.029106142">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00088255997">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Ar Detector" density="1.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Argon" density="1.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Kr Detector" density="2.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Krypton" density="2.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Lithium Polyethyl." density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.113">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.596">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.075">
+    <rMaterial name="materials:Lithium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.216">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron Polyethyl." density="1.02*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.81347018">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1365297">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0092592584">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040740732">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AntiLead" density="11.16*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.96">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04">
+    <rMaterial name="materials:Antimony"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Low Tension cables" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98029046">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016876977">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028325668">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Lucite" density="1.16*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="ME_free_space" density="0.254467*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.003218">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.157312">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.5388547e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020068">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.249899">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013999">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.555499">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MSGC cooling pipe" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.30132877">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.053356059">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.42345953">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22185565">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MSGC-Average" density="7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0016109746">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11608918">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.87746662">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004833228">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Al36" density="1.403*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.379586">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27524785">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26823734">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.045019923">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03190889">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Al48" density="1.373*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.40684004">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25552552">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26144891">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043880579">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032304952">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Al60" density="971*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.43940244">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22781143">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25517545">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042827665">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.034783015">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Al_cable" density="1.95062*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.69471035">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2614148">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043874854">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Cu_cable" density="9.4537*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91351941">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.074051989">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012428601">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_cntr" density="2.049*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27792206">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36612478">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.21351888">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028668949">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11376533">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Aluminium" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Argon 50pct CF_4 CO_2" density="2.1057*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.39336475">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11827135">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29931485">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18904904">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Argon CF_4 CO_2" density="2.1416*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_B_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Cables" density="2.68*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="NEMA G10 plate" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.2198829">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.41718655">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26819334">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066018389">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028718811">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Copper" density="8.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Thick_Steel-008" density="7.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00089992039">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015987127">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042943177">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017903506">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012830888">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5139401e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00029757275">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069973892">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99180725">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_DTBX Gas" density="1.695*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.049996061">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25927645">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.69072749">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Electronics averag" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.074565894">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77748634">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14794776">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_F_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_NEMA FR4 plate" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18077359">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.4056325">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27804208">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.068442752">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.067109079">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_RPC_Bakelite" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.074565894">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77748634">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14794776">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_RPC_Gas" density="1.87685*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017572792">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2588934">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.031188319">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016714124">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.67563137">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Steel-008" density="7.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00089992039">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015987127">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042943177">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017903506">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012830888">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5139401e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00029757275">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069973892">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99180725">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_YokeSteel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9825">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_honeycomb" density=" 0.0511415*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.97670111">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017460186">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0055195064">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00030055565">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.863911e-05">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cables" density="2.68*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Magetite" density="3.12*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0068217712">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34582528">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011586696">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0079728988">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.59461377">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032281783">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00089780071">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Magnet Conductor" density="3.157*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.097336411">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014292995">
+    <rMaterial name="materials:Niobium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017134031">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054482651">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.75894659">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10684171">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MagnetiteBoron" density="3.637*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.007">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0026">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0104">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.027">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.55">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MagnetiteConc" density="3.65*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0035">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0026">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0104">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3512">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0131">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0271">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5519">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Thick_MagnetiteConc" density="3.65*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0035">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0026">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0104">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3512">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0131">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0271">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5519">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Marble" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46021905">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53804265">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017382968">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Methane" density="0.717*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.74868663">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25131337">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mg O" density="3.58*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.60304188">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.39695812">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mg-MMC" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mn O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.77446185">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22553815">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Muon Al" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Muon average" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0012744281">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001149531">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002893993">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99728664">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mylar" density="1.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.62502108">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041960452">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33301847">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="NEMA FR4 plate" density="1.025*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18077359">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.4056325">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27804208">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.068442752">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.067109079">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_NEMA G10 plate" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.2198829">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.41718655">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26819334">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066018389">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028718811">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Na_2 O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.74186418">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25813582">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ne30_DME70" density="1.7*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.15805943">
+    <rMaterial name="materials:Neon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43902091">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29239429">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11052537">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ni_2 O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.70978275">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29021725">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Nomex" density="32*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.027815941">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31653768">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00047881724">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.077581544">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.57758601">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Nomex for CSC" density="28.9*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Noryl" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="O_Hybrid" density="2.838*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.17862818">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0038859926">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012801535">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11166264">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13680825">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.096505544">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.238333">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.027828501">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17363266">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.019913693">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Optical fibre" density="1.05*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Outer_pipes" density="2.533*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.49604605">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.006094006">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032243322">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12103086">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34458577">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="P_pipes" density="2.3285*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.32927494">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0007222183">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0019399576">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="8.087907e-05">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.7963526e-05">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="4.2979215e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00013442846">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00031610699">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.44804883">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.044156804">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17522489">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pb W O_4" density="8.28*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45532661">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.40403397">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14063942">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pb/Sci spaghetti mix" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.018845478">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017479474">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.97940657">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Peek" density="1.32*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.53539691">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13179314">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33280996">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="PhotoCathode" density="1.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Cesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pigtails" density="3.145*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.65753522">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20542786">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.027582577">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10945434">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pipe with Water" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.092022289">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.082576264">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29261257">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53278887">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pipe with gas" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18514234">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13149061">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24084727">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24888489">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1936349">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Plexiglas" density="1.18*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polycarbonate" density="7*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polyethylene" density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DD_Polyethylene" density="2*950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polymer Concrete" density="450*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.23789097">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43443755">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26294502">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.064726463">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polystyrene" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polyvinylchloride" density="1.38*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.38437771">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.048384356">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.56723794">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Px_cool_pipe" density="2.72629*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.54838378">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054611179">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028894718">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1084613">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30879909">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Quartz" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Quartz support" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="QuartzBundle" density="1.30515*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.41130114">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.46868914">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.056403482">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0052320714">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.057839878">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00052523876">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.0413398e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="QuartzFibers" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="RPC Gas" density="1.87685*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017572792">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2588934">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.031188319">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016714124">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.67563137">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Rohacell" density="0.052*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.60">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.08">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="SITRA-Average" density="7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="SMD_metal" density="10.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.045444306">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.80484958">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14970612">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="S_2 O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.57194838">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.42805162">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Scintillator" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Serpentine - Iron" density="3.765*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0089840293">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31549151">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11229814">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017986016">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0023751734">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.40725359">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.049064913">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.085014416">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015322121">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Serpentine 2" density="2.01*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017056138">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.52511018">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22286408">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028434767">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.055055747">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.048338182">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.095947828">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010639801">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042627075">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0018663973">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Si O_2" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Si cooling pipe" density="1.921*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.56814774">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19928206">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.026024798">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2065454">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Silica" density="2.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Silicon Detector" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Siliecal" density="1.0859*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.87264263">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12735737">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Single-sided MSGC el" density="2.44*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.30413689">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0014717137">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.058467105">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36931633">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15011919">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10269944">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013789342">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Single-sided MSGCsub" density="2.3258*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.33240081">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43382861">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017726182">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19998078">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016063621">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Single-sided Si elec" density="2.392*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.31484492">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014476209">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.050561611">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.114528">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015377551">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2652606">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22495111">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="StainlessSteel" density="8.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6996">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Stand.Concrete" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.006">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Thick_Stand.Concrete" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.006">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Standard Serpentine" density="2.302*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0096577278">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.52863475">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32556232">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.054746312">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.022623255">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028372381">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0012881659">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00095487516">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01557902">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012581187">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Steel-008" density="7.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00089992039">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015987127">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042943177">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017903506">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012830888">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5139401e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00029757275">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069973892">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99180725">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Steel-light" density="520*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6996">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Super Conductor" density="4.94*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.81579799">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.077846795">
+    <rMaterial name="materials:Niobium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.096238669">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010116543">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Brass" density="8.5*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.63">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.37">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="BGA" density="8.82*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.62">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Air" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Argon CF_4 CO_2" density="2.1416*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Bronze" density="8.89*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.94059406">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.059405941">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Carbon fibre str." density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Foam" density="100*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Kapton" density="1.4*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_MSGC-Average" density="230*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.8">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_OPC" density="1.05917*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.33154227">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38182349">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.064261825">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16677931">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.052722204">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028709009">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_OP_cable" density="601.463*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0086851733">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10083068">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.51167977">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.086185453">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28766708">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0049518353">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Bar_Det" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Bar_Hybrid" density="3.918*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.12227401">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020384302">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.23710889">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24417229">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17802235">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19803815">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Bar_Readout" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Fwd_Det" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Fwd_Readout" density="2.17525*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84842968">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063360581">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015596821">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.039385794">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.033227128">
+    <rMaterial name="materials:Indium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Silicon" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Silicon Detector" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Teflon" density="2.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.24018637">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.75981363">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ti_2 O_3" density="4.6*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.66612408">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33387592">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_Cable_1" density="942.8*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.4364364">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19550706">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.031331664">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.060965631">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043156039">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041667015">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15813109">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032805106">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_square_bundles" density="971*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45591441">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20422984">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032729696">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063679098">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.045081214">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043521896">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12057473">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03426911">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_support" density="5.25617*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="V_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="V_Iron" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="V_Quartz" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Vcal C4H10" density="2.67*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.82658619">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17341381">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Vcal CO2" density="1.98*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27292145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.72707855">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Vcal average" density="7.55*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0012701968">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015979957">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042923919">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017895477">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012825134">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5096736e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002974393">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069942512">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99136248">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.7766882e-05">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="W/Sci spaghetti mix" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0059212984">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00082799058">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00018825087">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="4.7062717e-05">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010447923">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99197061">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Water" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.11190083">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.88809917">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Wood" density="500*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.11684213">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.88315787">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="YokeSteel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9825">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="active_screen" density="11.197*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.025418913">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.085235146">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.50483588">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38451007">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="c_Peek" density="1.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45427914">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11182521">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36306779">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.070827858">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HV_Cu/QFib_mx." density="7.30515*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0247913">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00471238  ">
+    <rMaterial name="materials:Polystyrene"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04296 ">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.927536">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Borosilicate_Glass" density="2.51*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.303594">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0452533">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0556199">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0449903">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0222285">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0245335">
+    <rMaterial name="materials:Boron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0239803">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00459437">
+    <rMaterial name="materials:Antimony"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00001">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.475195">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Silicone_Gel" density="0.965*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.3866">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0973">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3616">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1545">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Barium_Titanate" density="6.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5889">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2053">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2058">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_PolyGrains" density="589*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CuNi" density="8.94*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Acrylate" density="1170*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.55814">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.06977">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.37209">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Inconel600" density="8.47*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7200">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0285">
+    <rMaterial name="materials:Cobalt"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1500">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0800">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0100">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0050">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0050">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kevlar" density="1.44*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.71180785">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11852895">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12699531">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04266788">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Tracker Cooling Fluids INIT -->
+  <!-- 3M type is the old one used for Thermal Screen only -->
+  <CompositeMaterial name="C6F14_3M_-15C" density="1.80340*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- F2 type is the new one used for subdetectors and preshower -->
+  <CompositeMaterial name="C6F14_F2_-30C" density="1.87917*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C6F14_F2_-20C" density="1.84675*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C6F14_F2_-10C" density="1.82033*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CO2_Upgrade" density="0.2033*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Vcal CO2"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bpix_CO2_-20C" density="1.0327*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27292145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.72707855">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  <!-- Tracker Cooling Fluids END -->
+  <!-- CASTOR materials -->
+  <CompositeMaterial name="Castor_QuartzFibers/Air_mx" density="2.1743080*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9999233027749">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0000766972251">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle6_QF/Air_mx" density="0.4808336*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99800842127">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00199157873">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle5_QF/Air_mx" density="0.5726188*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99841066074">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00158933926">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle4_QF/Air_mx" density="0.7092276*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99881654262">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00118345738">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle3_QF/Air_mx" density="1.1048788*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99942577695">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00057422305">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle2_QF/Air_mx" density="1.5612536*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99974500842">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00025499158">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle1_QF/Air_mx" density="2.2522530*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99998212349">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00001787651">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_LMixer_QF/Air_mx" density="2.2834241*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99998943692">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00001056308">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Electronics averag" density="1.4881*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.000560">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.999440">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Paper" density="1.55*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.448">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.056">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.496">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Coolant" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012092387">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063980691">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24016253">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68376439">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AlBeMet" density="2.071*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.380">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.615">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0045">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Rdout_Brd" density="1.79*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98667">
+    <rMaterial name="materials:G10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01333">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Kapton_Cu" density="1.24*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9836">
+    <rMaterial name="materials:Kapton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0164">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_GEM_Gas" density="1.8*mg/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.60">
+    <rMaterial name="materials:Argon"/>
+    </MaterialFraction>
+   <MaterialFraction fraction="0.083">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.145">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.172">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_GEM_Foil" density="1.74*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6565">
+    <rMaterial name="materials:Kapton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1013">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2422">
+    <rMaterial name="materials:M_GEM_Gas"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Diamond" density="3.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>   
+  <!--Materials added for BHM-->
+    <CompositeMaterial name="BorosilicateGlass" density="2.23*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.377220">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028191">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.003321">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.539562">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011644">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040064">
+    <rMaterial name="materials:Boron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bialkali" density="4.28*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.133">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.452">
+    <rMaterial name="materials:Cesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.415">
+    <rMaterial name="materials:Antimony"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="RTV" density="1.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0811">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3790">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3241">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2158">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="LYSO" density="7.11*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7145">
+    <rMaterial name="materials:Lutecium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0403">
+    <rMaterial name="materials:Yttrium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0637">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1815">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+ </MaterialSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixbar.xml
+++ b/DetectorDescription/DDCMS/data/pixbar.xml
@@ -1,0 +1,495 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="pixbar.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="Rin1" value="[cms:TrackBeamR1]"/>
+		<Constant name="Rin2" value="18.00*cm"/>
+		<Constant name="Rin3" value="18.50*cm"/>
+		<Constant name="RinSupTubCab" value="15.00*cm"/>
+		<Constant name="Rout1" value="21.80*cm"/>
+		<Constant name="Rout2" value="21.00*cm"/>
+		<Constant name="Zv1" value="30.00*cm"/>
+		<Constant name="Zv2" value="56.00*cm"/>
+		<Constant name="Zv3" value="110.5*cm"/>
+		<Constant name="Zv4" value="282.0*cm"/>
+		<Constant name="ZvSupTubCab" value="248.0*cm"/>
+		<Constant name="SupportL" value="221.0*cm"/>
+		<Constant name="SupportRin" value="21.65*cm"/>
+		<Constant name="SupportW" value="20.00*cm"/>
+		<Constant name="SupportT" value="0.350*cm"/>
+		<Constant name="SupportY" value="19.00*cm"/>
+		<Constant name="ShieldL" value="55.40*cm"/>
+		<Constant name="Shield1Rin" value="3.700*cm"/>
+		<Constant name="Shield1Rout" value="3.705*cm"/>
+		<Constant name="Shield2Rout" value="3.730*cm"/>
+		<Constant name="Shield3Rin" value="18.470*cm"/>
+		<Constant name="Shield3Rout" value="18.475*cm"/>
+		<Constant name="FlangeRin" value="10.600*cm"/>
+		<Constant name="FlangeT" value="0.600*cm"/>
+		<Constant name="FlangeZ" value="28.00*cm"/>
+		<Constant name="FlangeHCT" value="0.528*cm"/>
+		<Constant name="Cable1Rin" value="4.500*cm"/>
+		<Constant name="Cable1T1" value="0.0127*cm"/>
+		<Constant name="Cable1T2" value="0.0479*cm"/>
+		<Constant name="Cable2Rin" value="7.500*cm"/>
+		<Constant name="Cable2T1" value="0.0207*cm"/>
+		<Constant name="Cable2T2" value="0.0469*cm"/>
+		<Constant name="Cable3Rin" value="11.00*cm"/>
+		<Constant name="Cable3T1" value="0.0410*cm"/>
+		<Constant name="Cable3T2" value="0.06336*cm"/>
+		<Constant name="CableRout" value="17.0*cm"/>
+		<Constant name="Conn1T" value="0.190*cm"/>
+		<Constant name="Cable3Z1" value="[FlangeZ]-[FlangeT]/2-[Conn1T]"/>
+		<Constant name="Cable3Z2" value="[Cable3Z1]-[Cable3T1]"/>
+		<Constant name="Cable3Z3" value="[Cable3Z1]-[Cable3T2]"/>
+		<Constant name="Cable2Z1" value="[FlangeZ]+[FlangeT]/2+[Conn1T]"/>
+		<Constant name="Cable2Z2" value="[Cable2Z1]+[Cable2T1]"/>
+		<Constant name="Cable2Z3" value="[Cable2Z1]+[Cable2T2]"/>
+		<Constant name="Cable1Z1" value="[Cable2Z3]"/>
+		<Constant name="Cable1Z2" value="[Cable1Z1]+[Cable1T1]"/>
+		<Constant name="Cable1Z3" value="[Cable1Z1]+[Cable2T2]"/>
+		<!--
+		     <Constant name="Cable3Z1"          value="[FlangeZ]+[FlangeT]/2"/>
+		     <Constant name="Cable3Z2"          value="[Cable3Z1]+[Cable3T]"/>
+		     <Constant name="Cable2Z1"          value="[Cable3Z1]+[CableT]"/>
+		     <Constant name="Cable2Z2"          value="[Cable2Z1]+[Cable2T]"/>
+		     <Constant name="Cable1Z1"          value="[Cable2Z1]+[CableT]"/>
+		     <Constant name="Cable1Z2"          value="[Cable1Z1]+[Cable1T]"/>
+		     <Constant name="Cable0Z1"          value="[Cable1Z1]+[CableT]"/>
+		     -->
+		<Constant name="Cool1Rin" value="4.00*cm"/>
+		<Constant name="Cool2Rin" value="6.90*cm"/>
+		<Constant name="Cool3Rin" value="9.70*cm"/>
+		<Constant name="CoolDR" value="0.88*cm"/>
+		<Constant name="CoolT" value="0.50*cm"/>
+		<Constant name="CoolZ" value="[FlangeZ]"/>
+		<Constant name="Cool1Rout" value="[Cool1Rin]+[CoolDR]"/>
+		<Constant name="Cool2Rout" value="[Cool2Rin]+[CoolDR]"/>
+		<Constant name="Cool3Rout" value="[Cool3Rin]+[CoolDR]"/>
+		<Constant name="Conn1Rin" value="12.00*cm"/>
+		<Constant name="Conn2Rin" value="11.00*cm"/>
+		<Constant name="Conn1Z" value="[FlangeZ]-[FlangeT]/2-[Conn1T]/2"/>
+		<Constant name="Conn2Z" value="[FlangeZ]+[FlangeT]/2+[Conn1T]/2"/>
+		<Constant name="Conn3Rout" value="19.0*cm"/>
+		<Constant name="Conn3Rin" value="18.0*cm"/>
+		<Constant name="Conn4Rin" value="18.0*cm"/>
+		<Constant name="ConnToSTT" value="3.00*cm"/>
+		<Constant name="ConnToSTRin" value="18.0*cm"/>
+		<Constant name="ConnToSTRout" value="18.8*cm"/>
+		<Constant name="Conn3T" value="49.3*cm"/>
+		<Constant name="Conn4T" value="120.00*cm"/>
+		<Constant name="ConnToSTZ" value="30.50*cm"/>
+		<Constant name="Conn3Z" value="56.65*cm"/>
+		<Constant name="Conn4Z" value="[Conn3Z]+                                            ([Conn3T]+[Conn4T])/2"/>
+		<Constant name="ServiceRout" value="21.0*cm"/>
+		<Constant name="ServiceRin" value="18.0*cm"/>
+		<Constant name="ServT" value="48.5*cm"/>
+		<Constant name="ServZ" value="[Conn4Z]+                                            ([Conn4T]+[ServT])/2"/>
+		<Constant name="ServCablT" value="32.2*cm"/>
+		<Constant name="ServCablZ" value="[ServZ]+[ServT]/2+[ServCablT]/2"/>
+		<Constant name="RadialCoolZ" value="29.5*cm"/>
+		<Constant name="RadialCoolDZ" value="1.0*cm"/>
+		<Constant name="RadialCoolRin" value="4.0*cm"/>
+	</ConstantsSection>
+	<RotationSection label="pixbar.xml">
+		<Rotation name="180D" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="90*deg" thetaZ="180*deg" phiZ="0*deg"/>
+	</RotationSection>
+	<SolidSection label="pixbar.xml">
+		<Polycone name="PixelBarrel" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="-[Zv4]" rMin="[RinSupTubCab]" rMax="[Rout2]"/>
+			<ZSection z="-[ZvSupTubCab]" rMin="[RinSupTubCab]" rMax="[Rout2]"/>
+			<ZSection z="-[ZvSupTubCab]" rMin="[Rin2]" rMax="[Rout2]"/>
+			<ZSection z="-[Zv3]" rMin="[Rin2]" rMax="[Rout2]"/>
+			<ZSection z="-[Zv3]" rMin="[Rin2]" rMax="[Rout1]"/>
+			<ZSection z="-[Zv1]" rMin="[Rin2]" rMax="[Rout1]"/>
+			<ZSection z="-[Zv1]" rMin="[Rin1]" rMax="[Rout1]"/>
+			<ZSection z="[Zv1]" rMin="[Rin1]" rMax="[Rout1]"/>
+			<ZSection z="[Zv1]" rMin="[Rin2]" rMax="[Rout1]"/>
+			<ZSection z="[Zv3]" rMin="[Rin2]" rMax="[Rout1]"/>
+			<ZSection z="[Zv3]" rMin="[Rin2]" rMax="[Rout2]"/>
+			<ZSection z="[ZvSupTubCab]" rMin="[Rin2]" rMax="[Rout2]"/>
+			<ZSection z="[ZvSupTubCab]" rMin="[RinSupTubCab]" rMax="[Rout2]"/>
+			<ZSection z="[Zv4]" rMin="[RinSupTubCab]" rMax="[Rout2]"/>
+		</Polycone>
+		<Tubs name="PixelBarrelSuppTub" rMin="[SupportRin]" rMax="[Rout1]" dz="[SupportL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Box name="PixelBarrelSuppBox" dx="[SupportW]/2" dy="[SupportT]/2" dz="[SupportL]/2"/>
+		<Tubs name="PixelBarrelShield1" rMin="[Shield1Rin]" rMax="[Shield1Rout]" dz="[ShieldL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="PixelBarrelShield2" rMin="[Shield1Rout]" rMax="[Shield2Rout]" dz="[ShieldL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="PixelBarrelShield3" rMin="[Shield3Rin]" rMax="[Shield3Rout]" dz="[ShieldL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="PixelBarrelShield4" rMin="[Shield3Rout]" rMax="[Rin3]" dz="[ShieldL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="PixelBarrelFlange" rMin="[FlangeRin]" rMax="[Rin2]" dz="[FlangeT]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<!-- <Tubs name="PixelBarrelFlangIn" rMin="[FlangeRin]"      rMax="[Rin2]"
+		     dz="[FlangeHCT]/2"        startPhi="0*deg"        deltaPhi="360*deg"/> -->
+		<Tubs name="PixelBarrelRadialCooling" rMin="[RadialCoolRin]" rMax="[Rin2]" dz="[RadialCoolDZ]/2" startPhi="290*deg" deltaPhi="140*deg"/>
+		<Polycone name="PixelBarrelCable1" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="[Cable1Z1]" rMin="[Cable1Rin]" rMax="[CableRout]"/>
+			<ZSection z="[Cable1Z2]" rMin="[Cable1Rin]" rMax="[CableRout]"/>
+			<ZSection z="[Cable1Z3]" rMin="[Cable1Rin]" rMax="[Cable1Rin]"/>
+		</Polycone>
+		<Polycone name="PixelBarrelCable2" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="[Cable2Z1]" rMin="[Cable2Rin]" rMax="[CableRout]"/>
+			<ZSection z="[Cable2Z2]" rMin="[Cable2Rin]" rMax="[CableRout]"/>
+			<ZSection z="[Cable2Z3]" rMin="[Cable2Rin]" rMax="[Cable2Rin]"/>
+		</Polycone>
+		<Polycone name="PixelBarrelCable3" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="[Cable3Z1]" rMin="[Cable3Rin]" rMax="[CableRout]"/>
+			<ZSection z="[Cable3Z2]" rMin="[Cable3Rin]" rMax="[CableRout]"/>
+			<ZSection z="[Cable3Z3]" rMin="[Cable3Rin]" rMax="[Cable3Rin]"/>
+		</Polycone>
+		<Tubs name="PixelBarrelCool1" rMin="[Cool1Rin]" rMax="[Cool1Rout]" dz="[CoolT]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="PixelBarrelCool2" rMin="[Cool2Rin]" rMax="[Cool2Rout]" dz="[CoolT]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="PixelBarrelCool3" rMin="[Cool3Rin]" rMax="[Cool3Rout]" dz="[CoolT]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="PixelBarrelConn1" rMin="[Conn1Rin]" rMax="[Shield3Rin]" dz="[Conn1T]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="PixelBarrelConn2" rMin="[Conn2Rin]" rMax="[Shield3Rin]" dz="[Conn1T]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="PixelBarrelConnToST" rMin="[ConnToSTRin]" rMax="[ConnToSTRout]" dz="[ConnToSTT]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="PixelBarrelConn3" rMin="[Conn3Rin]" rMax="[Conn3Rout]" dz="[Conn3T]/2" startPhi="285*deg" deltaPhi="150*deg"/>
+		<Tubs name="PixelBarrelConn4" rMin="[Conn4Rin]" rMax="[Conn3Rout]" dz="[Conn4T]/2" startPhi="285*deg" deltaPhi="150*deg"/>
+		<Tubs name="PixelBarrelService" rMin="[ServiceRin]" rMax="[ServiceRout]" dz="[ServT]/2" startPhi="293*deg" deltaPhi="134*deg"/>
+		<Tubs name="PixelBarrelSupTubCables" rMin="[RinSupTubCab]" rMax="[Conn3Rout]" dz="[ServCablT]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+	</SolidSection>
+	<LogicalPartSection label="pixbar.xml">
+		<LogicalPart name="PixelBarrel" category="unspecified">
+			<rSolid name="PixelBarrel"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelSuppTub" category="unspecified">
+			<rSolid name="PixelBarrelSuppTub"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelSuppBox" category="unspecified">
+			<rSolid name="PixelBarrelSuppBox"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelShield1" category="unspecified">
+			<rSolid name="PixelBarrelShield1"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelShield2" category="unspecified">
+			<rSolid name="PixelBarrelShield2"/>
+			<rMaterial name="trackermaterial:T_Kevlar"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelShield3" category="unspecified">
+			<rSolid name="PixelBarrelShield3"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelShield4" category="unspecified">
+			<rSolid name="PixelBarrelShield4"/>
+			<rMaterial name="trackermaterial:T_Kevlar"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelFlange" category="unspecified">
+			<rSolid name="PixelBarrelFlange"/>
+			<rMaterial name="pixbarmaterial:FlangeOuter_Layer3"/>
+		</LogicalPart>
+		<!-- <LogicalPart name="PixelBarrelFlangIn" category="unspecified">
+		     <rSolid name="PixelBarrelFlangIn"/>
+		     <rMaterial name="pixbarmaterial:Pix_Bar_Ring_HC"/>
+		</LogicalPart> -->
+		<LogicalPart name="PixelBarrelRadialCooling" category="unspecified">
+			<rSolid name="PixelBarrelRadialCooling"/>
+			<rMaterial name="pixbarmaterial:silicone_pipes_plus_coolant"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCable1" category="unspecified">
+			<rSolid name="PixelBarrelCable1"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Cable"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCable2" category="unspecified">
+			<rSolid name="PixelBarrelCable2"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Cable"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCable3" category="unspecified">
+			<rSolid name="PixelBarrelCable3"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Cable"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCool1" category="unspecified">
+			<rSolid name="PixelBarrelCool1"/>
+			<rMaterial name="pixbarmaterial:Flange_with_Manifold_Layer1"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCool2" category="unspecified">
+			<rSolid name="PixelBarrelCool2"/>
+			<rMaterial name="pixbarmaterial:Flange_with_Manifold_Layer2"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCool3" category="unspecified">
+			<rSolid name="PixelBarrelCool3"/>
+			<rMaterial name="pixbarmaterial:FlangeInner_with_Manifold_Layer3"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelConn1" category="unspecified">
+			<rSolid name="PixelBarrelConn1"/>
+			<rMaterial name="pixbarmaterial:Layer3_EndringPrints"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelConn2" category="unspecified">
+			<rSolid name="PixelBarrelConn2"/>
+			<rMaterial name="pixbarmaterial:Layer1_2_EndringPrints"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelConnToST" category="unspecified">
+			<rSolid name="PixelBarrelConnToST"/>
+			<rMaterial name="pixbarmaterial:cable_endring_to_tube"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelConn3" category="unspecified">
+			<rSolid name="PixelBarrelConn3"/>
+			<rMaterial name="pixbarmaterial:SectorC"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelConn4" category="unspecified">
+			<rSolid name="PixelBarrelConn4"/>
+			<rMaterial name="pixbarmaterial:SectorB"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelService" category="unspecified">
+			<rSolid name="PixelBarrelService"/>
+			<rMaterial name="pixbarmaterial:SectorA"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelSupTubCables" category="unspecified">
+			<rSolid name="PixelBarrelSupTubCables"/>
+			<rMaterial name="pixbarmaterial:PixelBarrelSupTubCables2"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="pixbar.xml">
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelSuppTub"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelSuppBox"/>
+			<Translation x="[zero]" y="[SupportY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelSuppBox"/>
+			<Translation x="[zero]" y="-[SupportY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelShield1"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelShield2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelShield3"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelShield4"/>
+		</PosPart>
+		<!-- <PosPart copyNumber="1">
+		     <rParent name="pixbar:PixelBarrelFlange"/>
+		     <rChild name="pixbar:PixelBarrelFlangIn"/>
+		</PosPart> -->
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelFlange"/>
+			<Translation x="[zero]" y="[zero]" z="[FlangeZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelFlange"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[FlangeZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelRadialCooling"/>
+			<Translation x="[zero]" y="[zero]" z="[RadialCoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelRadialCooling"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="[RadialCoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelRadialCooling"/>
+			<Translation x="[zero]" y="[zero]" z="-[RadialCoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelRadialCooling"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[RadialCoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelCable1"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelCable1"/>
+			<rRotation name="pixbar:180D"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelCable2"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelCable2"/>
+			<rRotation name="pixbar:180D"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelCable3"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelCable3"/>
+			<rRotation name="pixbar:180D"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelCool1"/>
+			<Translation x="[zero]" y="[zero]" z="[CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelCool1"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelCool2"/>
+			<Translation x="[zero]" y="[zero]" z="[CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelCool2"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelCool3"/>
+			<Translation x="[zero]" y="[zero]" z="[CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelCool3"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConn1"/>
+			<Translation x="[zero]" y="[zero]" z="[Conn1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConn1"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[Conn1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConn2"/>
+			<Translation x="[zero]" y="[zero]" z="[Conn2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConn2"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[Conn2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConnToST"/>
+			<Translation x="[zero]" y="[zero]" z="[ConnToSTZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConnToST"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[ConnToSTZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConn3"/>
+			<Translation x="[zero]" y="[zero]" z="[Conn3Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConn3"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="[Conn3Z]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConn3"/>
+			<Translation x="[zero]" y="[zero]" z="-[Conn3Z]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConn3"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[Conn3Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConn4"/>
+			<Translation x="[zero]" y="[zero]" z="[Conn4Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConn4"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="[Conn4Z]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConn4"/>
+			<Translation x="[zero]" y="[zero]" z="-[Conn4Z]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelConn4"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[Conn4Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelService"/>
+			<Translation x="[zero]" y="[zero]" z="[ServZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelService"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="[ServZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelService"/>
+			<Translation x="[zero]" y="[zero]" z="-[ServZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelService"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[ServZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelSupTubCables"/>
+			<Translation x="[zero]" y="[zero]" z="[ServCablZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbar:PixelBarrelSupTubCables"/>
+			<rRotation name="pixbar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[ServCablZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbarlayer0:PixelBarrelLayer0"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbarlayer1:PixelBarrelLayer1"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbar:PixelBarrel"/>
+			<rChild name="pixbarlayer2:PixelBarrelLayer2"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixbarladder.xml
+++ b/DetectorDescription/DDCMS/data/pixbarladder.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="pixbarladder.xml" eval="true">
+		<Constant name="Length" value="53.6*cm"/>
+		<Constant name="ExternalLength" value="55.4*cm"/>
+		<Constant name="Modules" value="8"/>
+		<Constant name="ModulesPerSide" value="[Modules]/2"/>
+		<Constant name="BaseThick" value="0.30*mm"/>
+		<Constant name="ROChipThick" value="0.18*mm"/>
+		<Constant name="SensorThick" value="0.285*mm"/>
+		<Constant name="SensorDz" value="6.66*cm"/>
+		<Constant name="SensorEdge" value="1.20*mm"/>
+		<Constant name="ActiveDz" value="6.48*cm"/>
+		<Constant name="HybridThick" value="0.044*mm"/>
+		<Constant name="HybridDz" value="6.50*cm"/>
+		<Constant name="CableThick" value="0.300*mm"/>
+		<Constant name="Cable1Length" value="21.02*cm"/>
+		<Constant name="Cable2Length" value="14.32*cm"/>
+		<Constant name="Cable3Length" value="7.62*cm"/>
+		<Constant name="Cable4Length" value="0.92*cm"/>
+		<Constant name="CableDzOverModule" value="1.93*cm"/>
+		<Constant name="Cable1Dz" value="[Cable1Length]+[CableDzOverModule]"/>
+		<Constant name="Cable2Dz" value="[Cable2Length]+[CableDzOverModule]"/>
+		<Constant name="Cable3Dz" value="[Cable3Length]+[CableDzOverModule]"/>
+		<Constant name="Cable4Dz" value="[Cable4Length]+[CableDzOverModule]"/>
+		<Constant name="CableBoxThick" value="[CableThick]*4"/>
+		<Constant name="CapacitorZ" value="2.80*cm"/>
+		<Constant name="CapacitorThick" value="1.50*mm"/>
+		<Constant name="CapacitorDx" value="3.20*mm"/>
+		<Constant name="CapacitorDz" value="2.50*mm"/>
+		<Constant name="CapacitorStripThick" value="0.50*mm"/>
+		<Constant name="CapacitorStripDx" value="0.50*mm"/>
+		<Constant name="CapacitorStripDz" value="([HybridDz])"/>
+		<Constant name="TBMchipThick" value="0.30*mm"/>
+		<Constant name="TBMchipDx" value="3.20*mm"/>
+		<Constant name="TBMchipDz" value="4.80*mm"/>
+		<!-- Module thick uses CapacitorThick since it is the highest object on the Hybrid surface -->
+		<Constant name="ModuleThick" value="([BaseThick]+[ROChipThick]+            [SensorThick]+[HybridThick]+[CapacitorThick])"/>
+		<Constant name="ModuleDz" value="[Length]/[Modules]"/>
+		<Constant name="ModuleZ" value="-([Length]-[ModuleDz])/2"/>
+		<Constant name="Cable1Y" value="([CableBoxThick]-[CableThick])/2"/>
+		<Constant name="Cable1Z" value="([ExternalLength]-[Cable1Dz])/2"/>
+		<Constant name="Cable2Y" value="[Cable1Y]-[CableThick]"/>
+		<Constant name="Cable2Z" value="([ExternalLength]-[Cable2Dz])/2"/>
+		<Constant name="Cable3Y" value="[Cable2Y]-[CableThick]"/>
+		<Constant name="Cable3Z" value="([ExternalLength]-[Cable3Dz])/2"/>
+		<Constant name="Cable4Y" value="[Cable3Y]-[CableThick]"/>
+		<Constant name="Cable4Z" value="([ExternalLength]-[Cable4Dz])/2"/>
+	</ConstantsSection>
+	<RotationSection label="pixbarladder.xml">
+		<Rotation name="Z2XY" thetaX="90*deg" phiX="0*deg" thetaY="180*deg" phiY="0*deg" thetaZ="90*deg" phiZ="90*deg"/>
+	</RotationSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixbarladderfull.xml
+++ b/DetectorDescription/DDCMS/data/pixbarladderfull.xml
@@ -1,0 +1,320 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="pixbarladderfull.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="CFStripThick" value="0.25*mm"/>
+		<Constant name="CFStripWidth" value="26.00*mm"/>
+		<Constant name="CFHoleWidth" value="11.00*mm"/>
+		<Constant name="CFHoleDz" value="22.00*mm"/>
+		<Constant name="CFHoles" value="16"/>
+		<Constant name="CFHoleStep" value="33.00*mm"/>
+		<Constant name="VirtualBaseWidth" value="21.76*mm"/>
+		<Constant name="BaseWidth" value="4.48*mm"/>
+		<Constant name="BaseX" value="[VirtualBaseWidth]/2-[BaseWidth]/2"/>
+		<Constant name="ROChipWidth" value="19.955*mm"/>
+		<Constant name="SensorWidth" value="18.60*mm"/>
+		<Constant name="CableWidth" value="6.70*mm"/>
+		<Constant name="HybridWidth" value="18.80*mm"/>
+		<Constant name="CapacitorStripX" value="8.25*mm"/>
+		<Constant name="ActiveWidth" value="[SensorWidth]-            2*[pixbarladder:SensorEdge]"/>
+		<Constant name="LadderWidth" value="[CFStripWidth]"/>
+		<Constant name="LadderThick" value="[CFStripThick]+            [pixbarladder:ModuleThick]+[pixbarladder:CableBoxThick]"/>
+		<Constant name="CableBoxY" value="([LadderThick]-            [pixbarladder:CableBoxThick])/2"/>
+		<Constant name="ModuleBoxY" value="[CableBoxY]-            ([pixbarladder:CableBoxThick]+[pixbarladder:ModuleThick])/2"/>
+		<Constant name="CFStripY" value="[ModuleBoxY]-            ([pixbarladder:ModuleThick]+[CFStripThick])/2"/>
+		<Constant name="BaseY" value="-([pixbarladder:ModuleThick]-            [pixbarladder:BaseThick])/2"/>
+		<Constant name="ROChipY" value="[BaseY]+            ([pixbarladder:BaseThick]+[pixbarladder:ROChipThick])/2"/>
+		<Constant name="SensorY" value="[ROChipY]+            ([pixbarladder:ROChipThick]+[pixbarladder:SensorThick])/2"/>
+		<Constant name="HybridY" value="[SensorY]+            ([pixbarladder:SensorThick]+[pixbarladder:HybridThick])/2"/>
+		<Constant name="CapacitorY" value="[HybridY]+            ([pixbarladder:HybridThick]+[pixbarladder:CapacitorThick])/2"/>
+		<Constant name="CapacitorStripY" value="[HybridY]+            ([pixbarladder:HybridThick]+[pixbarladder:CapacitorStripThick])/2"/>
+		<Constant name="TBMchipY" value="[HybridY]+            ([pixbarladder:HybridThick]+[pixbarladder:TBMchipThick])/2"/>
+		<Constant name="CFHoleZ" value="-([CFHoles]-1)*[CFHoleStep]/2"/>
+	</ConstantsSection>
+	<SolidSection label="pixbarladderfull.xml">
+		<Box name="PixelBarrelLadderFull" dx="[pixbarladderfull:LadderWidth]/2" dy="[pixbarladderfull:LadderThick]/2" dz="[pixbarladder:ExternalLength]/2"/>
+		<Box name="PixelBarrelModuleBoxFull" dx="[pixbarladderfull:LadderWidth]/2" dy="[pixbarladder:ModuleThick]/2" dz="[pixbarladder:Length]/2"/>
+		<Box name="PixelBarrelCFStripFull" dx="[pixbarladderfull:CFStripWidth]/2" dy="[pixbarladderfull:CFStripThick]/2" dz="[pixbarladder:Length]/2"/>
+		<Box name="PixelBarrelCableBoxFull" dx="[pixbarladderfull:LadderWidth]/2" dy="[pixbarladder:CableBoxThick]/2" dz="[pixbarladder:ExternalLength]/2"/>
+		<Box name="PixelBarrelModuleFull" dx="[pixbarladderfull:LadderWidth]/2" dy="[pixbarladder:ModuleThick]/2" dz="[pixbarladder:ModuleDz]/2"/>
+		<Box name="PixelBarrelBaseFull" dx="[pixbarladderfull:BaseWidth]/2" dy="[pixbarladder:BaseThick]/2" dz="[pixbarladder:SensorDz]/2"/>
+		<Box name="PixelBarrelROChipFull" dx="[pixbarladderfull:ROChipWidth]/2" dy="[pixbarladder:ROChipThick]/2" dz="[pixbarladder:ActiveDz]/2"/>
+		<Box name="PixelBarrelSensorFull" dx="[pixbarladderfull:SensorWidth]/2" dy="[pixbarladder:SensorThick]/2" dz="[pixbarladder:SensorDz]/2"/>
+		<Box name="PixelBarrelActiveFull" dx="[pixbarladderfull:ActiveWidth]/2" dy="[pixbarladder:ActiveDz]/2" dz="[pixbarladder:SensorThick]/2"/>
+		<Box name="PixelBarrelHybridFull" dx="[pixbarladderfull:HybridWidth]/2" dy="[pixbarladder:HybridThick]/2" dz="[pixbarladder:HybridDz]/2"/>
+		<Box name="PixelBarrelCable1Full" dx="[pixbarladderfull:CableWidth]/2" dy="[pixbarladder:CableThick]/2" dz="[pixbarladder:Cable1Dz]/2"/>
+		<Box name="PixelBarrelCable2Full" dx="[pixbarladderfull:CableWidth]/2" dy="[pixbarladder:CableThick]/2" dz="[pixbarladder:Cable2Dz]/2"/>
+		<Box name="PixelBarrelCable3Full" dx="[pixbarladderfull:CableWidth]/2" dy="[pixbarladder:CableThick]/2" dz="[pixbarladder:Cable3Dz]/2"/>
+		<Box name="PixelBarrelCable4Full" dx="[pixbarladderfull:CableWidth]/2" dy="[pixbarladder:CableThick]/2" dz="[pixbarladder:Cable4Dz]/2"/>
+		<Box name="PixelBarrelCFStripHoleFull" dx="[pixbarladderfull:CFHoleWidth]/2" dy="[pixbarladderfull:CFStripThick]/2" dz="[pixbarladderfull:CFHoleDz]/2"/>
+		<Box name="PixelBarrelCapacitorFull" dx="[pixbarladder:CapacitorDx]/2" dy="[pixbarladder:CapacitorThick]/2" dz="[pixbarladder:CapacitorDz]/2"/>
+		<Box name="PixelBarrelCapacitorStripFull" dx="[pixbarladder:CapacitorStripDx]/2" dy="[pixbarladder:CapacitorStripThick]/2" dz="[pixbarladder:CapacitorStripDz]/2"/>
+		<Box name="PixelBarrelTBMFull" dx="[pixbarladder:TBMchipDx]/2" dy="[pixbarladder:TBMchipThick]/2" dz="[pixbarladder:TBMchipDz]/2"/>
+	</SolidSection>
+	<LogicalPartSection label="pixbarladderfull.xml">
+		<LogicalPart name="PixelBarrelLadderFull" category="unspecified">
+			<rSolid name="PixelBarrelLadderFull"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelModuleBoxFull" category="unspecified">
+			<rSolid name="PixelBarrelModuleBoxFull"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCFStripFull" category="unspecified">
+			<rSolid name="PixelBarrelCFStripFull"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCableBoxFull" category="unspecified">
+			<rSolid name="PixelBarrelCableBoxFull"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelModuleFullMinus" category="unspecified">
+			<rSolid name="PixelBarrelModuleFull"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelModuleFullPlus" category="unspecified">
+			<rSolid name="PixelBarrelModuleFull"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelBaseFull" category="unspecified">
+			<rSolid name="PixelBarrelBaseFull"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Baseplate_Full"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelROChipFull" category="unspecified">
+			<rSolid name="PixelBarrelROChipFull"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelSensorFull" category="unspecified">
+			<rSolid name="PixelBarrelSensorFull"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelActiveFull" category="unspecified">
+			<rSolid name="PixelBarrelActiveFull"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelHybridFull" category="unspecified">
+			<rSolid name="PixelBarrelHybridFull"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Hybrid_Full"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCable1Full" category="unspecified">
+			<rSolid name="PixelBarrelCable1Full"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Cable"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCable2Full" category="unspecified">
+			<rSolid name="PixelBarrelCable2Full"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Cable"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCable3Full" category="unspecified">
+			<rSolid name="PixelBarrelCable3Full"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Cable"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCable4Full" category="unspecified">
+			<rSolid name="PixelBarrelCable4Full"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Cable"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCFStripHoleFull" category="unspecified">
+			<rSolid name="PixelBarrelCFStripHoleFull"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCapacitorFull" category="unspecified">
+			<rSolid name="PixelBarrelCapacitorFull"/>
+			<rMaterial name="trackermaterial:T_Barium_Titanate"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCapacitorStripFull" category="unspecified">
+			<rSolid name="PixelBarrelCapacitorStripFull"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Capacitor"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelTBMFull" category="unspecified">
+			<rSolid name="PixelBarrelTBMFull"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="pixbarladderfull.xml">
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelLadderFull"/>
+			<rChild name="pixbarladderfull:PixelBarrelCableBoxFull"/>
+			<Translation x="[zero]" y="[CableBoxY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelLadderFull"/>
+			<rChild name="pixbarladderfull:PixelBarrelModuleBoxFull"/>
+			<Translation x="[zero]" y="[ModuleBoxY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelLadderFull"/>
+			<rChild name="pixbarladderfull:PixelBarrelCFStripFull"/>
+			<Translation x="[zero]" y="[CFStripY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelSensorFull"/>
+			<rChild name="pixbarladderfull:PixelBarrelActiveFull"/>
+			<rRotation name="pixbarladder:Z2XY"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullMinus"/>
+			<rChild name="pixbarladderfull:PixelBarrelBaseFull"/>
+			<Translation x="[BaseX]" y="[BaseY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullMinus"/>
+			<rChild name="pixbarladderfull:PixelBarrelBaseFull"/>
+			<Translation x="-[BaseX]" y="[BaseY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullMinus"/>
+			<rChild name="pixbarladderfull:PixelBarrelROChipFull"/>
+			<Translation x="[zero]" y="[ROChipY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullMinus"/>
+			<rChild name="pixbarladderfull:PixelBarrelSensorFull"/>
+			<Translation x="[zero]" y="[SensorY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullMinus"/>
+			<rChild name="pixbarladderfull:PixelBarrelHybridFull"/>
+			<Translation x="[zero]" y="[HybridY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullPlus"/>
+			<rChild name="pixbarladderfull:PixelBarrelBaseFull"/>
+			<Translation x="[BaseX]" y="[BaseY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullPlus"/>
+			<rChild name="pixbarladderfull:PixelBarrelBaseFull"/>
+			<Translation x="-[BaseX]" y="[BaseY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullPlus"/>
+			<rChild name="pixbarladderfull:PixelBarrelROChipFull"/>
+			<Translation x="[zero]" y="[ROChipY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullPlus"/>
+			<rChild name="pixbarladderfull:PixelBarrelSensorFull"/>
+			<Translation x="[zero]" y="[SensorY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullPlus"/>
+			<rChild name="pixbarladderfull:PixelBarrelHybridFull"/>
+			<Translation x="[zero]" y="[HybridY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelCableBoxFull"/>
+			<rChild name="pixbarladderfull:PixelBarrelCable1Full"/>
+			<Translation x="[zero]" y="[pixbarladder:Cable1Y]" z="[pixbarladder:Cable1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbarladderfull:PixelBarrelCableBoxFull"/>
+			<rChild name="pixbarladderfull:PixelBarrelCable1Full"/>
+			<Translation x="[zero]" y="[pixbarladder:Cable1Y]" z="-[pixbarladder:Cable1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelCableBoxFull"/>
+			<rChild name="pixbarladderfull:PixelBarrelCable2Full"/>
+			<Translation x="[zero]" y="[pixbarladder:Cable2Y]" z="[pixbarladder:Cable2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbarladderfull:PixelBarrelCableBoxFull"/>
+			<rChild name="pixbarladderfull:PixelBarrelCable2Full"/>
+			<Translation x="[zero]" y="[pixbarladder:Cable2Y]" z="-[pixbarladder:Cable2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelCableBoxFull"/>
+			<rChild name="pixbarladderfull:PixelBarrelCable3Full"/>
+			<Translation x="[zero]" y="[pixbarladder:Cable3Y]" z="[pixbarladder:Cable3Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbarladderfull:PixelBarrelCableBoxFull"/>
+			<rChild name="pixbarladderfull:PixelBarrelCable3Full"/>
+			<Translation x="[zero]" y="[pixbarladder:Cable3Y]" z="-[pixbarladder:Cable3Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelCableBoxFull"/>
+			<rChild name="pixbarladderfull:PixelBarrelCable4Full"/>
+			<Translation x="[zero]" y="[pixbarladder:Cable4Y]" z="[pixbarladder:Cable4Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbarladderfull:PixelBarrelCableBoxFull"/>
+			<rChild name="pixbarladderfull:PixelBarrelCable4Full"/>
+			<Translation x="[zero]" y="[pixbarladder:Cable4Y]" z="-[pixbarladder:Cable4Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullPlus"/>
+			<rChild name="pixbarladderfull:PixelBarrelCapacitorFull"/>
+			<Translation x="[zero]" y="[pixbarladderfull:CapacitorY]" z="[pixbarladder:CapacitorZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullPlus"/>
+			<rChild name="pixbarladderfull:PixelBarrelCapacitorStripFull"/>
+			<Translation x="[pixbarladderfull:CapacitorStripX]" y="[pixbarladderfull:CapacitorStripY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullPlus"/>
+			<rChild name="pixbarladderfull:PixelBarrelCapacitorStripFull"/>
+			<Translation x="-[pixbarladderfull:CapacitorStripX]" y="[pixbarladderfull:CapacitorStripY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullMinus"/>
+			<rChild name="pixbarladderfull:PixelBarrelCapacitorFull"/>
+			<Translation x="[zero]" y="[pixbarladderfull:CapacitorY]" z="-[pixbarladder:CapacitorZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullMinus"/>
+			<rChild name="pixbarladderfull:PixelBarrelCapacitorStripFull"/>
+			<Translation x="[pixbarladderfull:CapacitorStripX]" y="[pixbarladderfull:CapacitorStripY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullMinus"/>
+			<rChild name="pixbarladderfull:PixelBarrelCapacitorStripFull"/>
+			<Translation x="-[pixbarladderfull:CapacitorStripX]" y="[pixbarladderfull:CapacitorStripY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullMinus"/>
+			<rChild name="pixbarladderfull:PixelBarrelTBMFull"/>
+			<Translation x="[zero]" y="[pixbarladderfull:TBMchipY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderfull:PixelBarrelModuleFullPlus"/>
+			<rChild name="pixbarladderfull:PixelBarrelTBMFull"/>
+			<Translation x="[zero]" y="[pixbarladderfull:TBMchipY]" z="[zero]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerLinear">
+		<rParent name="pixbarladderfull:PixelBarrelModuleBoxFull"/>
+		<String name="ChildName" value="pixbarladderfull:PixelBarrelModuleFullMinus"/>
+		<Numeric name="Number" value="[pixbarladder:ModulesPerSide]"/>
+		<Numeric name="Theta" value="0*deg"/>
+		<Numeric name="Phi" value="0*deg"/>
+		<Numeric name="Offset" value="[pixbarladder:ModuleZ]"/>
+		<Numeric name="Delta" value="[pixbarladder:ModuleDz]"/>
+		<String name="Rotation" value="pixbarladder:NULL"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			[zero], [zero], [zero] </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerLinear">
+		<rParent name="pixbarladderfull:PixelBarrelModuleBoxFull"/>
+		<String name="ChildName" value="pixbarladderfull:PixelBarrelModuleFullPlus"/>
+		<Numeric name="Number" value="[pixbarladder:ModulesPerSide]"/>
+		<Numeric name="Theta" value="0*deg"/>
+		<Numeric name="Phi" value="0*deg"/>
+		<Numeric name="Offset" value="[pixbarladder:ModuleZ]+[pixbarladder:ModuleDz]*[pixbarladder:ModulesPerSide]"/>
+		<Numeric name="Delta" value="[pixbarladder:ModuleDz]"/>
+		<String name="Rotation" value="pixbarladder:NULL"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			[zero], [zero], [zero] </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerLinear">
+		<rParent name="pixbarladderfull:PixelBarrelCFStripFull"/>
+		<String name="ChildName" value="pixbarladderfull:PixelBarrelCFStripHoleFull"/>
+		<Numeric name="Number" value="[pixbarladderfull:CFHoles]"/>
+		<Numeric name="Theta" value="0*deg"/>
+		<Numeric name="Phi" value="0*deg"/>
+		<Numeric name="Offset" value="[pixbarladderfull:CFHoleZ]"/>
+		<Numeric name="Delta" value="[pixbarladderfull:CFHoleStep]"/>
+		<String name="Rotation" value="pixbarladder:NULL"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			[zero], [zero], [zero] </Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixbarladderhalf.xml
+++ b/DetectorDescription/DDCMS/data/pixbarladderhalf.xml
@@ -1,0 +1,288 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="pixbarladderhalf.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="CFStripThick" value="0.25*mm"/>
+		<Constant name="CFStripWidth" value="13.00*mm"/>
+		<Constant name="BaseWidth" value="12.9*mm"/>
+		<Constant name="ROChipWidth" value="9.935*mm"/>
+		<Constant name="SensorWidth" value="10.20*mm"/>
+		<Constant name="HybridWidth" value="10.30*mm"/>
+		<Constant name="SensorEdge" value="0.90*mm"/>
+		<Constant name="CableWidth" value="6.70*mm"/>
+		<Constant name="CapacitorStripDistToEdge" value="1.15*mm"/>
+		<Constant name="ActiveWidth" value="[SensorWidth]-[SensorEdge]-            [pixbarladder:SensorEdge]"/>
+		<Constant name="LadderWidth" value="[CFStripWidth]+[SensorEdge]"/>
+		<Constant name="LadderThick" value="[CFStripThick]+            [pixbarladder:ModuleThick]+[pixbarladder:CableBoxThick]"/>
+		<Constant name="CableBoxY" value="([LadderThick]-            [pixbarladder:CableBoxThick])/2"/>
+		<Constant name="ModuleBoxY" value="[CableBoxY]-            ([pixbarladder:CableBoxThick]+[pixbarladder:ModuleThick])/2"/>
+		<Constant name="CFStripX" value="[SensorEdge]-            ([LadderWidth]-[CFStripWidth])/2"/>
+		<Constant name="CFStripY" value="[ModuleBoxY]-            ([pixbarladder:ModuleThick]+[CFStripThick])/2"/>
+		<Constant name="ActiveX" value="[SensorEdge]-            ([SensorWidth]-[ActiveWidth])/2"/>
+		<Constant name="BaseX" value="[SensorEdge]-            ([LadderWidth]-[BaseWidth])/2"/>
+		<Constant name="BaseY" value="-([pixbarladder:ModuleThick]-            [pixbarladder:BaseThick])/2"/>
+		<Constant name="ROChipX" value="[SensorEdge]-            ([LadderWidth]-[ROChipWidth])/2"/>
+		<Constant name="ROChipY" value="[BaseY]+            ([pixbarladder:BaseThick]+[pixbarladder:ROChipThick])/2"/>
+		<Constant name="SensorX" value="-([LadderWidth]-[SensorWidth])/2"/>
+		<Constant name="SensorY" value="[ROChipY]+            ([pixbarladder:ROChipThick]+[pixbarladder:SensorThick])/2"/>
+		<Constant name="HybridX" value="([HybridWidth]-[LadderWidth])/2"/>
+		<Constant name="HybridY" value="[SensorY]+            ([pixbarladder:SensorThick]+[pixbarladder:HybridThick])/2"/>
+		<Constant name="CapacitorX" value="[HybridX]"/>
+		<Constant name="CapacitorStripX" value="[HybridX]+[HybridWidth]/2-[CapacitorStripDistToEdge]-[pixbarladder:CapacitorStripDx]/2"/>
+		<Constant name="TBMchipX" value="[HybridX]-[HybridWidth]/2+[pixbarladder:TBMchipDx]/2"/>
+		<Constant name="CapacitorY" value="[HybridY]+            ([pixbarladder:HybridThick]+[pixbarladder:CapacitorThick])/2"/>
+		<Constant name="CapacitorStripY" value="[HybridY]+            ([pixbarladder:HybridThick]+[pixbarladder:CapacitorStripThick])/2"/>
+		<Constant name="TBMchipY" value="[HybridY]+            ([pixbarladder:HybridThick]+[pixbarladder:TBMchipThick])/2"/>
+		<Constant name="CableX" value="[SensorEdge]-            ([LadderWidth]-[CableWidth])/2"/>
+	</ConstantsSection>
+	<SolidSection label="pixbarladderhalf.xml">
+		<Box name="PixelBarrelLadderHalf" dx="[pixbarladderhalf:LadderWidth]/2" dy="[pixbarladderhalf:LadderThick]/2" dz="[pixbarladder:ExternalLength]/2"/>
+		<Box name="PixelBarrelModuleBoxHalf" dx="[pixbarladderhalf:LadderWidth]/2" dy="[pixbarladder:ModuleThick]/2" dz="[pixbarladder:Length]/2"/>
+		<Box name="PixelBarrelCFStripHalf" dx="[pixbarladderhalf:CFStripWidth]/2" dy="[pixbarladderhalf:CFStripThick]/2" dz="[pixbarladder:Length]/2"/>
+		<Box name="PixelBarrelCableBoxHalf" dx="[pixbarladderhalf:LadderWidth]/2" dy="[pixbarladder:CableBoxThick]/2" dz="[pixbarladder:ExternalLength]/2"/>
+		<Box name="PixelBarrelModuleHalf" dx="[pixbarladderhalf:LadderWidth]/2" dy="[pixbarladder:ModuleThick]/2" dz="[pixbarladder:ModuleDz]/2"/>
+		<Box name="PixelBarrelBaseHalf" dx="[pixbarladderhalf:BaseWidth]/2" dy="[pixbarladder:BaseThick]/2" dz="[pixbarladder:SensorDz]/2"/>
+		<Box name="PixelBarrelROChipHalf" dx="[pixbarladderhalf:ROChipWidth]/2" dy="[pixbarladder:ROChipThick]/2" dz="[pixbarladder:ActiveDz]/2"/>
+		<Box name="PixelBarrelSensorHalf" dx="[pixbarladderhalf:SensorWidth]/2" dy="[pixbarladder:SensorThick]/2" dz="[pixbarladder:SensorDz]/2"/>
+		<Box name="PixelBarrelActiveHalf" dx="[pixbarladderhalf:ActiveWidth]/2" dy="[pixbarladder:ActiveDz]/2" dz="[pixbarladder:SensorThick]/2"/>
+		<Box name="PixelBarrelHybridHalf" dx="[pixbarladderhalf:HybridWidth]/2" dy="[pixbarladder:HybridThick]/2" dz="[pixbarladder:HybridDz]/2"/>
+		<Box name="PixelBarrelCable1Half" dx="[pixbarladderhalf:CableWidth]/2" dy="[pixbarladder:CableThick]/2" dz="[pixbarladder:Cable1Dz]/2"/>
+		<Box name="PixelBarrelCable2Half" dx="[pixbarladderhalf:CableWidth]/2" dy="[pixbarladder:CableThick]/2" dz="[pixbarladder:Cable2Dz]/2"/>
+		<Box name="PixelBarrelCable3Half" dx="[pixbarladderhalf:CableWidth]/2" dy="[pixbarladder:CableThick]/2" dz="[pixbarladder:Cable3Dz]/2"/>
+		<Box name="PixelBarrelCable4Half" dx="[pixbarladderhalf:CableWidth]/2" dy="[pixbarladder:CableThick]/2" dz="[pixbarladder:Cable4Dz]/2"/>
+		<Box name="PixelBarrelCapacitorHalf" dx="[pixbarladder:CapacitorDx]/2" dy="[pixbarladder:CapacitorThick]/2" dz="[pixbarladder:CapacitorDz]/2"/>
+		<Box name="PixelBarrelCapacitorStripHalf" dx="[pixbarladder:CapacitorStripDx]/2" dy="[pixbarladder:CapacitorStripThick]/2" dz="[pixbarladder:CapacitorStripDz]/2"/>
+		<Box name="PixelBarrelTBMHalf" dx="[pixbarladder:TBMchipDx]/2" dy="[pixbarladder:TBMchipThick]/2" dz="[pixbarladder:TBMchipDz]/2"/>
+	</SolidSection>
+	<LogicalPartSection label="pixbarladderhalf.xml">
+		<LogicalPart name="PixelBarrelLadderHalf" category="unspecified">
+			<rSolid name="PixelBarrelLadderHalf"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelModuleBoxHalf" category="unspecified">
+			<rSolid name="PixelBarrelModuleBoxHalf"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCFStripHalf" category="unspecified">
+			<rSolid name="PixelBarrelCFStripHalf"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCableBoxHalf" category="unspecified">
+			<rSolid name="PixelBarrelCableBoxHalf"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelModuleHalfMinus" category="unspecified">
+			<rSolid name="PixelBarrelModuleHalf"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelModuleHalfPlus" category="unspecified">
+			<rSolid name="PixelBarrelModuleHalf"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelBaseHalf" category="unspecified">
+			<rSolid name="PixelBarrelBaseHalf"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Baseplate_Half"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelROChipHalf" category="unspecified">
+			<rSolid name="PixelBarrelROChipHalf"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelSensorHalf" category="unspecified">
+			<rSolid name="PixelBarrelSensorHalf"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelActiveHalf" category="unspecified">
+			<rSolid name="PixelBarrelActiveHalf"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelHybridHalf" category="unspecified">
+			<rSolid name="PixelBarrelHybridHalf"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Hybrid_Half"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCable1Half" category="unspecified">
+			<rSolid name="PixelBarrelCable1Half"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Cable"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCable2Half" category="unspecified">
+			<rSolid name="PixelBarrelCable2Half"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Cable"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCable3Half" category="unspecified">
+			<rSolid name="PixelBarrelCable3Half"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Cable"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCable4Half" category="unspecified">
+			<rSolid name="PixelBarrelCable4Half"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Cable"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCapacitorHalf" category="unspecified">
+			<rSolid name="PixelBarrelCapacitorHalf"/>
+			<rMaterial name="trackermaterial:T_Barium_Titanate"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelCapacitorStripHalf" category="unspecified">
+			<rSolid name="PixelBarrelCapacitorStripHalf"/>
+			<rMaterial name="pixbarmaterial:Pix_Bar_Capacitor"/>
+		</LogicalPart>
+		<LogicalPart name="PixelBarrelTBMHalf" category="unspecified">
+			<rSolid name="PixelBarrelTBMHalf"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="pixbarladderhalf.xml">
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelLadderHalf"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCableBoxHalf"/>
+			<Translation x="[zero]" y="[CableBoxY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelLadderHalf"/>
+			<rChild name="pixbarladderhalf:PixelBarrelModuleBoxHalf"/>
+			<Translation x="[zero]" y="[ModuleBoxY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelLadderHalf"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCFStripHalf"/>
+			<Translation x="[CFStripX]" y="[CFStripY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelSensorHalf"/>
+			<rChild name="pixbarladderhalf:PixelBarrelActiveHalf"/>
+			<rRotation name="pixbarladder:Z2XY"/>
+			<Translation x="[ActiveX]" y="[zero]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfMinus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelBaseHalf"/>
+			<Translation x="[BaseX]" y="[BaseY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfMinus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelROChipHalf"/>
+			<Translation x="[ROChipX]" y="[ROChipY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfMinus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelSensorHalf"/>
+			<Translation x="[SensorX]" y="[SensorY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfMinus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelHybridHalf"/>
+			<Translation x="[HybridX]" y="[HybridY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfPlus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelBaseHalf"/>
+			<Translation x="[BaseX]" y="[BaseY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfPlus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelROChipHalf"/>
+			<Translation x="[ROChipX]" y="[ROChipY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfPlus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelSensorHalf"/>
+			<Translation x="[SensorX]" y="[SensorY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfPlus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelHybridHalf"/>
+			<Translation x="[HybridX]" y="[HybridY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelCableBoxHalf"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCable1Half"/>
+			<Translation x="[CableX]" y="[pixbarladder:Cable1Y]" z="[pixbarladder:Cable1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbarladderhalf:PixelBarrelCableBoxHalf"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCable1Half"/>
+			<Translation x="[CableX]" y="[pixbarladder:Cable1Y]" z="-[pixbarladder:Cable1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelCableBoxHalf"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCable2Half"/>
+			<Translation x="[CableX]" y="[pixbarladder:Cable2Y]" z="[pixbarladder:Cable2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbarladderhalf:PixelBarrelCableBoxHalf"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCable2Half"/>
+			<Translation x="[CableX]" y="[pixbarladder:Cable2Y]" z="-[pixbarladder:Cable2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelCableBoxHalf"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCable3Half"/>
+			<Translation x="[CableX]" y="[pixbarladder:Cable3Y]" z="[pixbarladder:Cable3Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbarladderhalf:PixelBarrelCableBoxHalf"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCable3Half"/>
+			<Translation x="[CableX]" y="[pixbarladder:Cable3Y]" z="-[pixbarladder:Cable3Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelCableBoxHalf"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCable4Half"/>
+			<Translation x="[CableX]" y="[pixbarladder:Cable4Y]" z="[pixbarladder:Cable4Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="pixbarladderhalf:PixelBarrelCableBoxHalf"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCable4Half"/>
+			<Translation x="[CableX]" y="[pixbarladder:Cable4Y]" z="-[pixbarladder:Cable4Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfPlus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCapacitorHalf"/>
+			<Translation x="[pixbarladderhalf:CapacitorX]" y="[pixbarladderhalf:CapacitorY]" z="[pixbarladder:CapacitorZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfPlus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCapacitorStripHalf"/>
+			<Translation x="[pixbarladderhalf:CapacitorStripX]" y="[pixbarladderhalf:CapacitorStripY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfMinus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCapacitorHalf"/>
+			<Translation x="[pixbarladderhalf:CapacitorX]" y="[pixbarladderhalf:CapacitorY]" z="-[pixbarladder:CapacitorZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfMinus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelCapacitorStripHalf"/>
+			<Translation x="[pixbarladderhalf:CapacitorStripX]" y="[pixbarladderhalf:CapacitorStripY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfMinus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelTBMHalf"/>
+			<Translation x="[pixbarladderhalf:TBMchipX]" y="[pixbarladderhalf:TBMchipY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="pixbarladderhalf:PixelBarrelModuleHalfPlus"/>
+			<rChild name="pixbarladderhalf:PixelBarrelTBMHalf"/>
+			<Translation x="[pixbarladderhalf:TBMchipX]" y="[pixbarladderhalf:TBMchipY]" z="[zero]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerLinear">
+		<rParent name="pixbarladderhalf:PixelBarrelModuleBoxHalf"/>
+		<String name="ChildName" value="pixbarladderhalf:PixelBarrelModuleHalfMinus"/>
+		<Numeric name="Number" value="[pixbarladder:ModulesPerSide]"/>
+		<Numeric name="Theta" value="0*deg"/>
+		<Numeric name="Phi" value="0*deg"/>
+		<Numeric name="Offset" value="[pixbarladder:ModuleZ]"/>
+		<Numeric name="Delta" value="[pixbarladder:ModuleDz]"/>
+		<String name="Rotation" value="pixbarladder:NULL"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero] </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerLinear">
+		<rParent name="pixbarladderhalf:PixelBarrelModuleBoxHalf"/>
+		<String name="ChildName" value="pixbarladderhalf:PixelBarrelModuleHalfPlus"/>
+		<Numeric name="Number" value="[pixbarladder:ModulesPerSide]"/>
+		<Numeric name="Theta" value="0*deg"/>
+		<Numeric name="Phi" value="0*deg"/>
+		<Numeric name="Offset" value="[pixbarladder:ModuleZ]+[pixbarladder:ModuleDz]*[pixbarladder:ModulesPerSide]"/>
+		<Numeric name="Delta" value="[pixbarladder:ModuleDz]"/>
+		<String name="Rotation" value="pixbarladder:NULL"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero] </Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixbarlayer.xml
+++ b/DetectorDescription/DDCMS/data/pixbarlayer.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="pixbarlayer.xml" eval="true">
+		<Constant name="LayerDz" value="55.40*cm"/>
+		<Constant name="CoolDz" value="55.40*cm"/>
+		<Constant name="CoolSide" value="0.40*cm"/>
+		<Constant name="CoolThick" value="0.03*cm"/>
+	</ConstantsSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixbarlayer0.xml
+++ b/DetectorDescription/DDCMS/data/pixbarlayer0.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="pixbarlayer0.xml" eval="true">
+		<Constant name="Ladders" value="18"/>
+		<Constant name="CoolDist" value="4.4429*cm"/>
+		<Constant name="CoolWidth" value="0.3747*cm"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDPixBarLayerAlgo">
+		<rParent name="pixbarlayer0:PixelBarrelLayer0"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="Ladders" value="[pixbarlayer0:Ladders]"/>
+		<Numeric name="LayerDz" value="[pixbarlayer:LayerDz]"/>
+		<Numeric name="SensorEdge" value="[pixbarladderhalf:SensorEdge]"/>
+		<Numeric name="CoolDz" value="[pixbarlayer:CoolDz]"/>
+		<Numeric name="CoolWidth" value="[pixbarlayer0:CoolWidth]"/>
+		<Numeric name="CoolSide" value="[pixbarlayer:CoolSide]"/>
+		<Numeric name="CoolThick" value="[pixbarlayer:CoolThick]"/>
+		<Numeric name="CoolDist" value="[pixbarlayer0:CoolDist]"/>
+		<String name="CoolMaterial" value="trackermaterial:T_C6F14_F2_-20C"/>
+		<String name="CoolTubeMaterial" value="trackermaterial:T_Aluminium"/>
+		<Vector name="LadderName" type="string" nEntries="2">
+			pixbarladderfull:PixelBarrelLadderFull, 
+			pixbarladderhalf:PixelBarrelLadderHalf</Vector>
+		<Vector name="LadderWidth" type="numeric" nEntries="2">
+			[pixbarladderfull:LadderWidth], [pixbarladderhalf:LadderWidth]
+		</Vector>
+		<Vector name="LadderThick" type="numeric" nEntries="2">
+			[pixbarladderfull:LadderThick], [pixbarladderhalf:LadderThick]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixbarlayer1.xml
+++ b/DetectorDescription/DDCMS/data/pixbarlayer1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="pixbarlayer1.xml" eval="true">
+		<Constant name="Ladders" value="30"/>
+		<Constant name="CoolDist" value="7.32575*cm"/>
+		<Constant name="CoolWidth" value="0.3432*cm"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDPixBarLayerAlgo">
+		<rParent name="pixbarlayer1:PixelBarrelLayer1"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="Ladders" value="[pixbarlayer1:Ladders]"/>
+		<Numeric name="LayerDz" value="[pixbarlayer:LayerDz]"/>
+		<Numeric name="SensorEdge" value="[pixbarladderhalf:SensorEdge]"/>
+		<Numeric name="CoolDz" value="[pixbarlayer:CoolDz]"/>
+		<Numeric name="CoolWidth" value="[pixbarlayer1:CoolWidth]"/>
+		<Numeric name="CoolSide" value="[pixbarlayer:CoolSide]"/>
+		<Numeric name="CoolThick" value="[pixbarlayer:CoolThick]"/>
+		<Numeric name="CoolDist" value="[pixbarlayer1:CoolDist]"/>
+		<String name="CoolMaterial" value="trackermaterial:T_C6F14_F2_-20C"/>
+		<String name="CoolTubeMaterial" value="trackermaterial:T_Aluminium"/>
+		<Vector name="LadderName" type="string" nEntries="2">
+			pixbarladderfull:PixelBarrelLadderFull, 
+			pixbarladderhalf:PixelBarrelLadderHalf</Vector>
+		<Vector name="LadderWidth" type="numeric" nEntries="2">
+			[pixbarladderfull:LadderWidth], [pixbarladderhalf:LadderWidth]
+		</Vector>
+		<Vector name="LadderThick" type="numeric" nEntries="2">
+			[pixbarladderfull:LadderThick], [pixbarladderhalf:LadderThick]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixbarlayer2.xml
+++ b/DetectorDescription/DDCMS/data/pixbarlayer2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="pixbarlayer2.xml" eval="true">
+		<Constant name="Ladders" value="42"/>
+		<Constant name="CoolDist" value="10.1853*cm"/>
+		<Constant name="CoolWidth" value="0.3283*cm"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDPixBarLayerAlgo">
+		<rParent name="pixbarlayer2:PixelBarrelLayer2"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="Ladders" value="[pixbarlayer2:Ladders]"/>
+		<Numeric name="LayerDz" value="[pixbarlayer:LayerDz]"/>
+		<Numeric name="SensorEdge" value="[pixbarladderhalf:SensorEdge]"/>
+		<Numeric name="CoolDz" value="[pixbarlayer:CoolDz]"/>
+		<Numeric name="CoolWidth" value="[pixbarlayer2:CoolWidth]"/>
+		<Numeric name="CoolSide" value="[pixbarlayer:CoolSide]"/>
+		<Numeric name="CoolThick" value="[pixbarlayer:CoolThick]"/>
+		<Numeric name="CoolDist" value="[pixbarlayer2:CoolDist]"/>
+		<String name="CoolMaterial" value="trackermaterial:T_C6F14_F2_-20C"/>
+		<String name="CoolTubeMaterial" value="trackermaterial:T_Aluminium"/>
+		<Vector name="LadderName" type="string" nEntries="2">
+			pixbarladderfull:PixelBarrelLadderFull, 
+			pixbarladderhalf:PixelBarrelLadderHalf</Vector>
+		<Vector name="LadderWidth" type="numeric" nEntries="2">
+			[pixbarladderfull:LadderWidth], [pixbarladderhalf:LadderWidth]
+		</Vector>
+		<Vector name="LadderThick" type="numeric" nEntries="2">
+			[pixbarladderfull:LadderThick], [pixbarladderhalf:LadderThick]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixbarmaterial.xml
+++ b/DetectorDescription/DDCMS/data/pixbarmaterial.xml
@@ -1,0 +1,455 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <MaterialSection label="pixbarmaterial.xml">
+    <CompositeMaterial name="Polyoxymethylene" density="1.4*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.4">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06667">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.5333">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="BPix_Silicone" density="1.3*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.3787448">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.21575329">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.3239468">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08155498">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="LCP_Glass_Enforced" density="2.0*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.08">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.52">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.39">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Silicon_Nitride" density="3.4*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.6006">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.3994">
+        <rMaterial name="materials:Nitrogen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Bar_Baseplate_Full" density="3.67256*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.75244">
+        <rMaterial name="pixbarmaterial:Silicon_Nitride" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.15186">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04271">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05299">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Bar_Baseplate_Half" density="3.18369*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.86861">
+        <rMaterial name="pixbarmaterial:Silicon_Nitride" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06085">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04931">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02123">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Bar_Hybrid_Full" density="4.41590*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.0063">
+        <rMaterial name="materials:Indium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09358">
+        <rMaterial name="materials:Lead" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05034">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.3217">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02405">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04379">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1596">
+        <rMaterial name="materials:Tin" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.23875">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00379">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00741">
+        <rMaterial name="materials:Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0507">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Bar_Hybrid_Half" density="5.70663*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00443">
+        <rMaterial name="materials:Indium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1322">
+        <rMaterial name="materials:Lead" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03912">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.24865">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0185">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06187">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22547">
+        <rMaterial name="materials:Tin" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00267">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.185">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01047">
+        <rMaterial name="materials:Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07162">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Bar_Capacitor" density="2.22277*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_Pix_Bar_Cool" density="1.95447*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.61432">
+        <rMaterial name="materials:C6F14_F2_-10C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.38568">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Bar_Cable" density="1.67629*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.43796">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02339">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.19088">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.34777">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Flange_with_Manifold_Layer1" density="6.001116*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.1636">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.25809">
+        <rMaterial name="materials:C6F14_F2_-10C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.23898">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12917">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.19713">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01304">
+        <rMaterial name="trackermaterial:T_Nomex" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Flange_with_Manifold_Layer2" density="6.415752*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.14778">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.28678">
+        <rMaterial name="materials:C6F14_F2_-10C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20276">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.15657">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.18269">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02342">
+        <rMaterial name="trackermaterial:T_Nomex" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FlangeInner_with_Manifold_Layer3" density="5.8872*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.10879">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.35422">
+        <rMaterial name="materials:C6F14_F2_-10C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.36829">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16871">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FlangeOuter_Layer3" density="0.517704*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.11657">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.87067">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00339">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00938">
+        <rMaterial name="materials:Air" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="cable_endring_to_tube" density="2.331588*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.10301">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.15922">
+        <rMaterial name="pixfwdMaterials:FPix_Silicone" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06696">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04431">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Noryl" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02972">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.40314">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.19365">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Layer1_2_EndringPrints" density="1.402032*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.01765">
+        <rMaterial name="materials:Lead" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.23843">
+        <rMaterial name="pixbarmaterial:LCP_Glass_Enforced" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.3061">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00657">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01658">
+        <rMaterial name="materials:Tin" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.41468">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Layer3_EndringPrints" density="1.303776*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.01766">
+        <rMaterial name="materials:Lead" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.238">
+        <rMaterial name="pixbarmaterial:LCP_Glass_Enforced" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.30544">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00789">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01706">
+        <rMaterial name="materials:Tin" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.41396">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="silicone_pipes_plus_coolant" density="0.31236*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.53007">
+        <rMaterial name="materials:C6F14_F2_-10C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.46993">
+        <rMaterial name="pixbarmaterial:BPix_Silicone" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="SectorA" density="0.47813*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.10443">
+        <rMaterial name="materials:C6F14_F2_-10C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00283">
+        <rMaterial name="pixbarmaterial:Polyoxymethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20588">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08188">
+        <rMaterial name="materials:Acrylate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11064">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0145">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10724">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00283">
+        <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01613">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.19232">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1272">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.009">
+        <rMaterial name="materials:Polyvinylchloride" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02513">
+        <rMaterial name="trackermaterial:T_Nomex" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="SectorB" density="1.049454*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.19011">
+        <rMaterial name="materials:C6F14_F2_-10C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00494">
+        <rMaterial name="pixbarmaterial:Polyoxymethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1187">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14233">
+        <rMaterial name="materials:Acrylate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0512">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.18915">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06486">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.17137">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05152">
+        <rMaterial name="materials:Polyvinylchloride" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01581">
+        <rMaterial name="trackermaterial:T_Nomex" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="SectorC" density="1.375654*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.14778">
+        <rMaterial name="materials:C6F14_F2_-10C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0139">
+        <rMaterial name="pixbarmaterial:Polyoxymethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22693">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11069">
+        <rMaterial name="materials:Acrylate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03989">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14938">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01005">
+        <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06396">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20077">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02082">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00319">
+        <rMaterial name="materials:Polyvinylchloride" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01264">
+        <rMaterial name="trackermaterial:T_Nomex" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="PixelBarrelSupTubCables" density="2.25064*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.09162">
+        <rMaterial name="materials:C6F14_F2_-10C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14907">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.28441">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.4749">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="PixelBarrelSupTubCables2" density="0.61235*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.09162">
+        <rMaterial name="materials:C6F14_F2_-10C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14907">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.28441">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.4749">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+  </MaterialSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwd.xml
+++ b/DetectorDescription/DDCMS/data/pixfwd.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Dmitry Onoprienko
+         @modified Xingtao Huang to implement the simplified fpix service cylinder
+         
+         == Subsystem or component described by the file ==
+         
+         Forward pixels endcap (contains two disks inside a service cylinder).
+         
+         == Root volume and its reference frame ==
+         
+         Two root volumes are defined:
+         
+         PixelForwardZPlus  : +Z half of the detector
+         PixelForwardZMinus : -Z half of the detector
+         
+         X horizontal
+         Y vertical
+         Z along the beam line, pointing away from IP
+         
+         == Positioning ==
+         
+         Anchor point of this component is at the IP-side edge of the service cylider, on 
+         the axis of the detector (see annotated drawings).
+         The file defines [AnchorZ] constant that corresponds to the Z coordinate
+         of the anchor point in the forward pixels endcap reference frame, and the
+         [ZPixelForward] constant equal to the distance from CMS IP to the 
+         anchor point. 
+         
+         Therefore, in the CMS global reference frame,
+         PixelForwardZPlus has to be positioned at 
+         (0., 0., 0.) with no rotation, and 
+         PixelForwardZMinus has to be positioned at
+         (0., 0., 0.) 
+         with pixfwdCommon:Y180 rotation (180 degrees around Y axis).
+         
+         -->
+    <!-- Root volumes -->
+    <ConstantsSection label="Root" eval="true">
+        <Constant name="RootRadius" value="[pixfwdCylinder:CylindersOuterRmax]"/>
+        <Constant name="RootHalfLength" value="[pixfwdCylinder:CylindersOuterLength]/2.+ [pixfwdCylinder:CylindersEndFlangeLength]/2."/>
+        <Constant name="AnchorZ" value="0.*mm"/>
+        <Constant name="ZPixelForward" value="325.*mm"/>
+        <Constant name="RootStartZ" value="-2*mm"/>
+        <Constant name="RootMidZ3" value="[cms:TrackBeamZ1]-[ZPixelForward]"/>
+        <Constant name="RootEndZ" value="2*[RootHalfLength]"/>
+    </ConstantsSection>
+    <SolidSection label="Root">
+        <Polycone name="PixelForward" startPhi="0*deg" deltaPhi="360*deg">
+            <ZSection z="[RootStartZ]" rMin="[cms:TrackBeamR1]" rMax="[RootRadius]"/>
+            <ZSection z="[RootMidZ3]" rMin="[cms:TrackBeamR1]" rMax="[RootRadius]"/>
+            <ZSection z="[RootEndZ]" rMin="[cms:TrackBeamR2]" rMax="[RootRadius]"/>
+        </Polycone>
+    </SolidSection>
+    <LogicalPartSection label="Root">
+        <LogicalPart name="PixelForwardZPlus" category="envelope">
+            <rSolid name="PixelForward"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardZMinus" category="envelope">
+            <rSolid name="PixelForward"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <!-- Position disks inside root -->
+    <ConstantsSection label="Disks" eval="true">
+        <!-- Distances from IP-side edge of PixelForwardRoot to disk centers -->
+        <Constant name="Disk1Z" value="30*mm"/>
+        <Constant name="Disk2Z" value="160*mm"/>
+        <Constant name="Disk3Z" value="290*mm"/>
+    </ConstantsSection>
+    <PosPartSection label="Disks">
+        <!-- +Z endcap -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardZPlus"/>
+            <rChild name="pixfwdDisk:PixelForwardDiskZPlus"/>
+            <Translation x="0." y="0." z="[AnchorZ]+[Disk1Z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardZPlus"/>
+            <rChild name="pixfwdDisk:PixelForwardDiskZPlus"/>
+            <Translation x="0." y="0." z="[AnchorZ]+[Disk2Z]"/>
+        </PosPart>
+        <!-- UNCOMMENT TO SIMULATE THE THIRD DISK -->
+        <!--  <PosPart copyNumber="3">-->
+        <!--    <rParent name="PixelForwardZPlus"/>-->
+        <!--    <rChild name="pixfwdDisk:PixelForwardDiskZPlus"/>-->
+        <!--    <Translation x="0." y="0." z="[AnchorZ]+ [Disk3Z]" />-->
+        <!--  </PosPart>-->
+        <!-- -Z endcap -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardZMinus"/>
+            <rChild name="pixfwdDisk:PixelForwardDiskZMinus"/>
+            <Translation x="0." y="0." z="[AnchorZ]+[Disk1Z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardZMinus"/>
+            <rChild name="pixfwdDisk:PixelForwardDiskZMinus"/>
+            <Translation x="0." y="0." z="[AnchorZ]+[Disk2Z]"/>
+        </PosPart>
+        <!-- UNCOMMENT TO SIMULATE THE THIRD DISK -->
+        <!--  <PosPart copyNumber="3">-->
+        <!--    <rParent name="PixelForwardZMinus"/>-->
+        <!--    <rChild name="pixfwdDisk:PixelForwardDiskZMinus"/>-->
+        <!--    <Translation x="0." y="0." z="[AnchorZ]+[Disk3Z]" />-->
+        <!--  </PosPart>-->
+    </PosPartSection>
+    <!-- Position service cylinders inside root.
+         Since shapeless volumes are not useable at the moment, 
+         PixelForwardCylinder.xml does the actual positioning, we just tell it where to place the
+         cylinders by defining Z position of IP-side edge of service cylinder in PixelForward frame:
+         -->
+    <ConstantsSection label="ServiceCylinder" eval="true">
+        <Constant name="ZCylinder" value="[AnchorZ]"/>
+    </ConstantsSection>
+    <PosPartSection label="Cylinders">
+        <!-- +Z endcap -->
+        <PosPart copyNumber="1">
+            <rParent name="pixfwd:PixelForwardZPlus"/>
+            <rChild name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <Translation x="0." y="0." z="0."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="pixfwd:PixelForwardZPlus"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderEndFlange"/>
+            <Translation x="0." y="0." z="[pixfwd:ZCylinder]+[pixfwdCylinder:CylindersOuterLength]+[pixfwdCylinder:CylindersEndFlangeLength]/2."/>
+            <rRotation name="pixfwdCylinder:EndFlangeRot1"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="pixfwd:PixelForwardZPlus"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderEndFlange"/>
+            <Translation x="0." y="0." z="[pixfwd:ZCylinder]+[pixfwdCylinder:CylindersOuterLength]+[pixfwdCylinder:CylindersEndFlangeLength]/2."/>
+            <rRotation name="pixfwdCylinder:EndFlangeRot2"/>
+            <!-- xt rRotation name="pixfwdCommon:Z180" / xt-->
+        </PosPart>
+        <!-- xt PosPart copyNumber="1">
+             <rParent name="pixfwd:PixelForwardZPlus"/>
+             <rChild name="pixfwdCylinder:PixelForwardCylinderBackCyl"/>
+             <Translation x="0." y="0." z="[pixfwd:ZCylinder]+[pixfwdCylinder:CylindersFrontLength]+[pixfwdCylinder:CylinderBackLength]/2." />
+        </PosPart xt -->
+        <!-- -Z endcap -->
+        <PosPart copyNumber="1">
+            <rParent name="pixfwd:PixelForwardZMinus"/>
+            <rChild name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <Translation x="0." y="0." z="0."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="pixfwd:PixelForwardZMinus"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderEndFlange"/>
+            <Translation x="0." y="0." z="[pixfwd:ZCylinder]+[pixfwdCylinder:CylindersOuterLength]+[pixfwdCylinder:CylindersEndFlangeLength]/2."/>
+            <rRotation name="pixfwdCylinder:EndFlangeRot1"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="pixfwd:PixelForwardZMinus"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderEndFlange"/>
+            <Translation x="0." y="0." z="[pixfwd:ZCylinder]+[pixfwdCylinder:CylindersOuterLength]+[pixfwdCylinder:CylindersEndFlangeLength]/2."/>
+            <rRotation name="pixfwdCylinder:EndFlangeRot2"/>
+        </PosPart>
+        <!-- xt PosPart copyNumber="1">
+             <rParent name="pixfwd:PixelForwardZMinus"/>
+             <rChild name="pixfwdCylinder:PixelForwardCylinderBackCyl"/>
+             <Translation x="0." y="0." z="[pixfwd:ZCylinder]+[pixfwdCylinder:CylindersFrontLength]+[pixfwdCylinder:CylinderBackLength]/2." />
+        </PosPart xt -->
+    </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdBlade.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdBlade.xml
@@ -1,0 +1,551 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Dmitry Onoprienko
+         @modified Vesna Cuplov (fix overlaps 05.02.07)
+         
+         == Subsystem or component described by the file ==
+         
+         Aluminum base of a blade with a cooling channel (no nipples, no panels). 
+         
+         == Root volume and its reference frame ==
+         
+         "PixelForwardBlade"
+         
+         Y is along the axis of the blade, from narrow to wider end. Once the blade 
+         is positioned, its Y axis will be pointing away from the beam line.
+         Z is perpendicular to the plane of the blade, pointing from "body" (narrow) to "cover" (wide) side.
+         
+         == Positioning ==
+         
+         The file defines AnchorX, AnchorY, and AnchorZ 
+         constants that describe the coordinates of the anchor point in the blade 
+         root volume (PixelForwardBlade) reference frame.
+         Currently, [AnchorX] = [AnchorZ] = 0.
+         
+         Since the origin of the "blade frame" with respect to which DDPixFwdBlades
+         algorithm positions all one-per-blade items coincides with the blade anchor point,
+         the "child translation" vector passed to the algorithm should be
+         (-[pixfwdBlade:AnchorX], -[pixfwdBlade:AnchorY], -[pixfwdBlade:AnchorZ]).
+         
+         == Additional comments ==
+         
+         Blade is implemented so that it consists of 
+         "body" (narrow aluminum side), "cover" (wide aluminum side), and
+         "tip" (part close to inner ring, common to both sides. 
+         Cooling channel then goes into both "body" and "cover".
+         
+         Multiple boolean operations are used in describing the tip of the blade and
+         the crossbar. As a result, IguanaCMS sometimes fails to visualize it properly.
+         This seems to be a problem for visualization only, not for tracking at simulation time.
+         
+         -->
+    <!-- Blade geometry parameters: Input from drawings -->
+    <ConstantsSection label="Common" eval="true">
+        <Constant name="T01" value="0.5*mm"/>
+        <!-- Blade01.gif -->
+        <Constant name="T02" value="3.0*mm"/>
+        <!-- Blade01.gif -->
+        <Constant name="T03" value="0.5*mm"/>
+        <!-- Blade01.gif -->
+        <Constant name="T04" value="2.5*mm"/>
+        <!-- Blade01.gif -->
+        <Constant name="W01" value="6.5*mm"/>
+        <!-- Blade01.gif -->
+        <Constant name="W02" value="7.5*mm"/>
+        <!-- Blade01.gif -->
+        <Constant name="W03" value="11.5*mm"/>
+        <!-- Blade01.gif -->
+        <Constant name="R01" value="8.57*mm"/>
+        <!-- Blade02.gif -->
+        <Constant name="L01" value="57.1*mm"/>
+        <!-- Blade02.gif -->
+        <Constant name="L02" value="32.38*mm"/>
+        <!-- Blade02.gif -->
+        <Constant name="L03" value="32.42*mm"/>
+        <!-- Blade02.gif -->
+        <Constant name="L09" value="48.80*mm"/>
+        <!-- Blade02.gif -->
+        <Constant name="A01" value="16.625*deg"/>
+        <!-- Blade03.gif -->
+        <Constant name="W04" value="1.0*mm"/>
+        <!-- Blade03.gif -->
+        <Constant name="W05" value="4.0*mm"/>
+        <!-- Blade03.gif -->
+        <Constant name="R02" value="2.0*mm"/>
+        <!-- Blade03.gif -->
+        <Constant name="R03" value="2.0*mm"/>
+        <!-- Blade03.gif -->
+        <Constant name="L04" value="9.79*mm"/>
+        <!-- Blade03.gif -->
+        <Constant name="L05" value="1.83*mm"/>
+        <!-- Blade03.gif -->
+        <Constant name="L10" value="3.47*mm"/>
+        <!-- Blade03.gif -->
+        <Constant name="W06" value="5.6*mm"/>
+        <!-- Blade04.gif -->
+        <Constant name="R04" value="2.0*mm"/>
+        <!-- Blade04.gif -->
+        <Constant name="L06" value="3.77*mm"/>
+        <!-- Blade04.gif -->
+        <Constant name="L07" value="3.0*mm"/>
+        <!-- Blade04.gif -->
+        <Constant name="L08" value="5.79*mm"/>
+        <!-- Blade04.gif -->
+    </ConstantsSection>
+    <!-- Calculating parameters that will be needed by multiple components : -->
+    <ConstantsSection label="Common" eval="true">
+        <!-- Root volume dimensions (may need to be changed later) -->
+        <Constant name="RootHalfLength" value="([L04]+[L03]+[L01]+[W03]/2.)/2."/>
+        <Constant name="RootHalfWidth" value="([L02]+[W03])/2."/>
+        <Constant name="RootHalfThickness" value="[BladeHalfThickness]+0.1*mm"/>
+        <!-- Coordinates of ancor point  -->
+        <Constant name="AnchorX" value="0."/>
+        <Constant name="AnchorY" value="-[RootHalfLength]+[L10]"/>
+        <Constant name="AnchorZ" value="0."/>
+        <!-- Coordinate of point 0 on Blade02.gif. All other Y-coordinates are relative to it. -->
+        <Constant name="y00" value="[AnchorY]-[L10]+[L04]+[L03]"/>
+        <!-- Others -->
+        <Constant name="zCover" value="([T02]-[T03])/2."/>
+        <Constant name="zBody" value="-([T01]+[T03])/2."/>
+        <Constant name="BladeHalfThickness" value="([T01]+[T02])/2."/>
+        <Constant name="BodyHalfThickness" value="([T02]-[T03])/2."/>
+        <Constant name="CoverHalfThickness" value="([T01]+[T03])/2."/>
+    </ConstantsSection>
+    <!-- Root volume for the blade. This volume is positioned by pixfwdDisk.xml -->
+    <!-- Previous description from D. Onoprienko
+         <SolidSection label="Root">
+         <Box name="PixelForwardBlade" dx="[RootHalfWidth]" dy="[RootHalfLength]" dz="[RootHalfThickness]" />
+    </SolidSection>
+         -->
+    <!-- New Description (05/02/07): Two overlaps were fixed. The overlap with the Nipples was fixed by removing 0.1*mm in the mother volume thickness. The second overlap was: The corners of the box describing the mother volume were going outside the DiskOuterRing, so we remove these corners with a little box for simplicity. -->
+    <SolidSection label="Root">
+        <Box name="PixelForwardBlade_main" dx="[RootHalfWidth]" dy="[RootHalfLength]" dz="[RootHalfThickness]-0.1*mm"/>
+        <Box name="PixelForwardBlade_box" dx="1.5*mm" dy="1.5*mm" dz="[RootHalfThickness]"/>
+        <SubtractionSolid name="PixelForwardBlade_Left_subtraction">
+            <rSolid name="PixelForwardBlade_main"/>
+            <rSolid name="PixelForwardBlade_box"/>
+            <Translation x="-[RootHalfWidth]" y="[RootHalfLength]" z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="PixelForwardBlade">
+            <rSolid name="PixelForwardBlade_Left_subtraction"/>
+            <rSolid name="PixelForwardBlade_box"/>
+            <Translation x="[RootHalfWidth]" y="[RootHalfLength]" z="0."/>
+        </SubtractionSolid>
+    </SolidSection>
+    <LogicalPartSection label="Root">
+        <LogicalPart name="PixelForwardBlade" category="envelope">
+            <rSolid name="PixelForwardBlade"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <!-- Constants for Body and Cover -->
+    <ConstantsSection label="BodyCover" eval="true">
+        <Constant name="e01" value="[L02]/2."/>
+        <Constant name="e02" value="sqrt([e01]*[e01]+[L01]*[L01]-[R01]*[R01])"/>
+        <!-- length of straight part of cooling channel -->
+        <Constant name="a01" value="atan([e01]/[L01])-atan([R01]/[e02])"/>
+        <!-- angle between blade axis and straight part of cooling channel -->
+        <Constant name="sin01" value="sin([a01])"/>
+        <Constant name="cos01" value="cos([a01])"/>
+        <Constant name="x04" value="[L02]/2."/>
+        <Constant name="y05" value="[y00]+[L01]"/>
+        <Constant name="x03" value="([R01]*[cos01]+[x04])/2."/>
+        <Constant name="y04" value="[y00]+(-[R01]*[sin01]+[L01])/2."/>
+        <Constant name="e03" value="([L03]*cos([A01]))/2."/>
+        <Constant name="r01" value="([R01]+[W02]/2.-[W04]/2.)"/>
+        <Constant name="y02" value="-[r01]*sin([A01])-[e03]*cos([A01])"/>
+        <Constant name="x01" value="[r01]*cos([A01])-[e03]*sin([A01])"/>
+        <Constant name="x06" value="[L07]/2.+[R04]+[L06]/2."/>
+    </ConstantsSection>
+    <!-- Body -->
+    <SolidSection label="Body">
+        <Box name="PixelForwardBladeBody01" dx="[W02]/2." dy="[e02]/2." dz="[BodyHalfThickness]"/>
+        <Tubs name="PixelForwardBladeBody02_01" rMin="[R01]-[W02]/2." rMax="[R01]+[W02]/2." dz="[BodyHalfThickness]" startPhi="-180.*deg+[a01]" deltaPhi="180.*deg-2.*[a01]"/>
+        <Box name="PixelForwardBladeBody02_02" dx="[W04]/2." dy="[e03]" dz="[BodyHalfThickness]"/>
+        <Box name="PixelForwardBladeBody02_03" dx="[W04]/2." dy="[e03]" dz="[BodyHalfThickness]"/>
+        <UnionSolid name="PixelForwardBladeBody02_int01">
+            <rSolid name="PixelForwardBladeBody02_01"/>
+            <rSolid name="PixelForwardBladeBody02_02"/>
+            <Translation x="-[x01]" y="[y02]" z="0."/>
+            <rRotation name="LeftArm02"/>
+        </UnionSolid>
+        <UnionSolid name="PixelForwardBladeBody02">
+            <rSolid name="PixelForwardBladeBody02_int01"/>
+            <rSolid name="PixelForwardBladeBody02_03"/>
+            <Translation x="[x01]" y="[y02]" z="0."/>
+            <rRotation name="RightArm02"/>
+        </UnionSolid>
+        <Tubs name="PixelForwardBladeBody03" rMin="0." rMax="[W02]/2." dz="[BodyHalfThickness]" startPhi="0*deg" deltaPhi="180*deg"/>
+        <!-- Crossbar -->
+        <Trapezoid name="PixelForwardBladeBody04" dz="[BodyHalfThickness]" bl1="([R01]-[W02]/2.)/[cos01]+([L09]-[W06]/2.)*tan([a01])" bl2="([R01]-[W02]/2.)/[cos01]+([L09]-[W06]/2.)*tan([a01])" tl1="([R01]-[W02]/2.)/[cos01]+([L09]+[W06]/2.)*tan([a01])" tl2="([R01]-[W02]/2.)/[cos01]+([L09]+[W06]/2.)*tan([a01])" h1="[W06]/2." h2="[W06]/2." alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <Box name="PixelForwardBladeBody05_01" dx="[L08]/2." dy="[R04]" dz="[BodyHalfThickness]"/>
+        <Tubs name="PixelForwardBladeBody05_02" rMin="0." rMax="[R04]" dz="[BodyHalfThickness]" startPhi="0." deltaPhi="360*deg"/>
+        <Tubs name="PixelForwardBladeBody05_03" rMin="0." rMax="[R04]" dz="[BodyHalfThickness]" startPhi="0." deltaPhi="360*deg"/>
+        <UnionSolid name="PixelForwardBladeBody05_int01">
+            <rSolid name="PixelForwardBladeBody05_01"/>
+            <rSolid name="PixelForwardBladeBody05_02"/>
+            <Translation x="[L08]/2." y="0." z="0."/>
+        </UnionSolid>
+        <UnionSolid name="PixelForwardBladeBody05">
+            <rSolid name="PixelForwardBladeBody05_int01"/>
+            <rSolid name="PixelForwardBladeBody05_03"/>
+            <Translation x="-[L08]/2." y="0." z="0."/>
+        </UnionSolid>
+    </SolidSection>
+    <LogicalPartSection label="Body">
+        <LogicalPart name="PixelForwardBladeBody01_Left" category="support">
+            <rSolid name="PixelForwardBladeBody01"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeBody01_Right" category="support">
+            <rSolid name="PixelForwardBladeBody01"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeBody02" category="support">
+            <rSolid name="PixelForwardBladeBody02"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeBody03_Left" category="support">
+            <rSolid name="PixelForwardBladeBody03"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeBody03_Right" category="support">
+            <rSolid name="PixelForwardBladeBody03"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeBody04" category="support">
+            <rSolid name="PixelForwardBladeBody04"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeBody05" category="support">
+            <rSolid name="PixelForwardBladeBody05"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="Body">
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBlade"/>
+            <rChild name="PixelForwardBladeBody01_Left"/>
+            <Translation x="-[x03]" y="[y04]" z="[zBody]"/>
+            <rRotation name="LeftArm01"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBlade"/>
+            <rChild name="PixelForwardBladeBody01_Right"/>
+            <Translation x="[x03]" y="[y04]" z="[zBody]"/>
+            <rRotation name="RightArm01"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBlade"/>
+            <rChild name="PixelForwardBladeBody02"/>
+            <Translation x="0." y="[y00]" z="[zBody]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBlade"/>
+            <rChild name="PixelForwardBladeBody03_Left"/>
+            <Translation x="-[x04]" y="[y05]" z="[zBody]"/>
+            <rRotation name="LeftArm01"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBlade"/>
+            <rChild name="PixelForwardBladeBody03_Right"/>
+            <Translation x="[x04]" y="[y05]" z="[zBody]"/>
+            <rRotation name="RightArm01"/>
+        </PosPart>
+        <!-- Crossbar -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBlade"/>
+            <rChild name="PixelForwardBladeBody04"/>
+            <Translation x="0." y="[y00]+[L09]" z="[zBody]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBladeBody04"/>
+            <rChild name="PixelForwardBladeBody05"/>
+            <Translation x="[x06]" y="0." z="0."/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardBladeBody04"/>
+            <rChild name="PixelForwardBladeBody05"/>
+            <Translation x="-[x06]" y="0." z="0."/>
+        </PosPart>
+    </PosPartSection>
+    <!-- Cover -->
+    <SolidSection label="Cover">
+        <Box name="PixelForwardBladeCover01" dx="[W03]/2." dy="[e02]/2." dz="[CoverHalfThickness]"/>
+        <Tubs name="PixelForwardBladeCover02_01" rMin="[R01]-[W03]/2." rMax="[R01]+[W03]/2." dz="[CoverHalfThickness]" startPhi="-180.*deg+[a01]" deltaPhi="180.*deg-2.*[a01]"/>
+        <Box name="PixelForwardBladeCover02_02" dx="[W04]/2." dy="[e03]" dz="[CoverHalfThickness]"/>
+        <Box name="PixelForwardBladeCover02_03" dx="[W04]/2." dy="[e03]" dz="[CoverHalfThickness]"/>
+        <UnionSolid name="PixelForwardBladeCover02_int01">
+            <rSolid name="PixelForwardBladeCover02_01"/>
+            <rSolid name="PixelForwardBladeCover02_02"/>
+            <Translation x="-[x01]" y="[y02]" z="0."/>
+            <rRotation name="LeftArm02"/>
+        </UnionSolid>
+        <UnionSolid name="PixelForwardBladeCover02">
+            <rSolid name="PixelForwardBladeCover02_int01"/>
+            <rSolid name="PixelForwardBladeCover02_03"/>
+            <Translation x="[x01]" y="[y02]" z="0."/>
+            <rRotation name="RightArm02"/>
+        </UnionSolid>
+        <Tubs name="PixelForwardBladeCover03" rMin="0." rMax="[W03]/2." dz="[CoverHalfThickness]" startPhi="0*deg" deltaPhi="180*deg"/>
+        <!-- Crossbar -->
+        <Trapezoid name="PixelForwardBladeCover04_01" dz="[CoverHalfThickness]" bl1="([R01]-[W03]/2.)/[cos01]+([L09]-[W06]/2.)*tan([a01])" bl2="([R01]-[W03]/2.)/[cos01]+([L09]-[W06]/2.)*tan([a01])" tl1="([R01]-[W03]/2.)/[cos01]+([L09]+[W06]/2.)*tan([a01])" tl2="([R01]-[W03]/2.)/[cos01]+([L09]+[W06]/2.)*tan([a01])" h1="[W06]/2." h2="[W06]/2." alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <Box name="PixelForwardBladeCover04_02" dx="[L06]/2." dy="[CoverHalfThickness]+[pixfwdCommon:SmallBool]" dz="[R04]"/>
+        <Box name="PixelForwardBladeCover04_03" dx="[L06]/2." dy="[CoverHalfThickness]+[pixfwdCommon:SmallBool]" dz="[R04]"/>
+        <Tubs name="PixelForwardBladeCover04_04" rMin="0." rMax="[R04]" dz="[CoverHalfThickness]+[pixfwdCommon:SmallBool]" startPhi="0." deltaPhi="360*deg"/>
+        <Tubs name="PixelForwardBladeCover04_05" rMin="0." rMax="[R04]" dz="[CoverHalfThickness]+[pixfwdCommon:SmallBool]" startPhi="0." deltaPhi="360*deg"/>
+        <Tubs name="PixelForwardBladeCover04_06" rMin="0." rMax="[R04]" dz="[CoverHalfThickness]+[pixfwdCommon:SmallBool]" startPhi="0." deltaPhi="360*deg"/>
+        <Tubs name="PixelForwardBladeCover04_07" rMin="0." rMax="[R04]" dz="[CoverHalfThickness]+[pixfwdCommon:SmallBool]" startPhi="0." deltaPhi="360*deg"/>
+        <SubtractionSolid name="PixelForwardBladeCover04_int01">
+            <rSolid name="PixelForwardBladeCover04_01"/>
+            <rSolid name="PixelForwardBladeCover04_02"/>
+            <Translation x="[L07]/2.+[R04]+[L06]/2." y="0." z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="PixelForwardBladeCover04_int02">
+            <rSolid name="PixelForwardBladeCover04_int01"/>
+            <rSolid name="PixelForwardBladeCover04_03"/>
+            <Translation x="-[L07]/2.-[R04]-[L06]/2." y="0." z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="PixelForwardBladeCover04_int03">
+            <rSolid name="PixelForwardBladeCover04_int02"/>
+            <rSolid name="PixelForwardBladeCover04_04"/>
+            <Translation x="-[L07]/2.-[R04]" y="0." z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="PixelForwardBladeCover04_int04">
+            <rSolid name="PixelForwardBladeCover04_int03"/>
+            <rSolid name="PixelForwardBladeCover04_05"/>
+            <Translation x="-[L07]/2.-[R04]-[L06]" y="0." z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="PixelForwardBladeCover04_int05">
+            <rSolid name="PixelForwardBladeCover04_int04"/>
+            <rSolid name="PixelForwardBladeCover04_06"/>
+            <Translation x="[L07]/2.+[R04]" y="0." z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="PixelForwardBladeCover04">
+            <rSolid name="PixelForwardBladeCover04_int05"/>
+            <rSolid name="PixelForwardBladeCover04_07"/>
+            <Translation x="[L07]/2.+[R04]+[L06]" y="0." z="0."/>
+        </SubtractionSolid>
+    </SolidSection>
+    <LogicalPartSection label="Cover">
+        <LogicalPart name="PixelForwardBladeCover01_Left" category="support">
+            <rSolid name="PixelForwardBladeCover01"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeCover01_Right" category="support">
+            <rSolid name="PixelForwardBladeCover01"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeCover02" category="support">
+            <rSolid name="PixelForwardBladeCover02"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeCover03_Left" category="support">
+            <rSolid name="PixelForwardBladeCover03"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeCover03_Right" category="support">
+            <rSolid name="PixelForwardBladeCover03"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeCover04" category="support">
+            <rSolid name="PixelForwardBladeCover04"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="Cover">
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBlade"/>
+            <rChild name="PixelForwardBladeCover01_Left"/>
+            <Translation x="-[x03]" y="[y04]" z="[zCover]"/>
+            <rRotation name="LeftArm01"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBlade"/>
+            <rChild name="PixelForwardBladeCover01_Right"/>
+            <Translation x="[x03]" y="[y04]" z="[zCover]"/>
+            <rRotation name="RightArm01"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBlade"/>
+            <rChild name="PixelForwardBladeCover02"/>
+            <Translation x="0." y="[y00]" z="[zCover]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBlade"/>
+            <rChild name="PixelForwardBladeCover03_Left"/>
+            <Translation x="-[x04]" y="[y05]" z="[zCover]"/>
+            <rRotation name="LeftArm01"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBlade"/>
+            <rChild name="PixelForwardBladeCover03_Right"/>
+            <Translation x="[x04]" y="[y05]" z="[zCover]"/>
+            <rRotation name="RightArm01"/>
+        </PosPart>
+        <!-- Crossbar -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBlade"/>
+            <rChild name="PixelForwardBladeCover04"/>
+            <Translation x="0." y="[y00]+[L09]" z="[zCover]"/>
+        </PosPart>
+    </PosPartSection>
+    <!-- Tip -->
+    <ConstantsSection label="Tip" eval="true">
+        <Constant name="r02" value="[R01]+[W02]/2.-[L03]*sin([A01])"/>
+        <Constant name="r03" value="[r02]-[W04]"/>
+        <Constant name="e04" value="([L04]-[r03])/2."/>
+        <Constant name="e05" value="(([r02]*cos([A01])-[W05]/2.)/sin([A01]))/2."/>
+        <Constant name="y03" value="-([r02]-[W04]/2.)*sin([A01])-[e05]*cos([A01])"/>
+        <Constant name="x02" value="([r02]-[W04]/2.)*cos([A01])-[e05]*sin([A01])"/>
+    </ConstantsSection>
+    <SolidSection label="Tip">
+        <Tubs name="PixelForwardBladeTip01_01" rMin="[r03]" rMax="[r02]" dz="[BladeHalfThickness]" startPhi="180.*deg+[A01]" deltaPhi="180.*deg-2.*[A01]"/>
+        <Box name="PixelForwardBladeTip01_02" dx="[W05]/2." dy="[e04]-[pixfwdCommon:SmallBool]" dz="[BladeHalfThickness]"/>
+        <Tubs name="PixelForwardBladeTip01_03" rMin="[R02]" rMax="[R02]*sqrt(2.)" dz="[BladeHalfThickness]+[pixfwdCommon:SmallBool]" startPhi="180.*deg" deltaPhi="180.*deg"/>
+        <Box name="PixelForwardBladeTip01_04" dx="[W04]/2." dy="[e05]" dz="[BladeHalfThickness]"/>
+        <Box name="PixelForwardBladeTip01_05" dx="[W04]/2." dy="[e05]" dz="[BladeHalfThickness]"/>
+        <UnionSolid name="PixelForwardBladeTip01_int01">
+            <rSolid name="PixelForwardBladeTip01_01"/>
+            <rSolid name="PixelForwardBladeTip01_04"/>
+            <Translation x="-[x02]" y="[y03]" z="0."/>
+            <rRotation name="LeftArm02"/>
+        </UnionSolid>
+        <UnionSolid name="PixelForwardBladeTip01_int02">
+            <rSolid name="PixelForwardBladeTip01_int01"/>
+            <rSolid name="PixelForwardBladeTip01_05"/>
+            <Translation x="[x02]" y="[y03]" z="0."/>
+            <rRotation name="RightArm02"/>
+        </UnionSolid>
+        <UnionSolid name="PixelForwardBladeTip01_int03">
+            <rSolid name="PixelForwardBladeTip01_int02"/>
+            <rSolid name="PixelForwardBladeTip01_02"/>
+            <Translation x="0." y="-[r03]-[e04]-[pixfwdCommon:SmallBool]" z="0."/>
+        </UnionSolid>
+        <SubtractionSolid name="PixelForwardBladeTip01">
+            <rSolid name="PixelForwardBladeTip01_int03"/>
+            <rSolid name="PixelForwardBladeTip01_03"/>
+            <Translation x="0." y="-[L04]+[L05]" z="0."/>
+        </SubtractionSolid>
+    </SolidSection>
+    <LogicalPartSection label="Tip">
+        <LogicalPart name="PixelForwardBladeTip01" category="support">
+            <rSolid name="PixelForwardBladeTip01"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="Tip">
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBlade"/>
+            <rChild name="PixelForwardBladeTip01"/>
+            <Translation x="0." y="[y00]-[L03]" z="0."/>
+        </PosPart>
+    </PosPartSection>
+    <!-- Cooling channel -->
+    <ConstantsSection label="Channel" eval="true">
+        <Constant name="ChanBodyHalfThickness" value="([T04]-[T03])/2."/>
+        <Constant name="ChanCoverHalfThickness" value="[T03]/2."/>
+        <Constant name="z03" value="[BodyHalfThickness]-[ChanBodyHalfThickness]"/>
+        <!-- Channel central plane inside body -->
+        <Constant name="z04" value="-[CoverHalfThickness]+[ChanCoverHalfThickness]"/>
+        <!-- Channel central plane inside cover -->
+    </ConstantsSection>
+    <SolidSection label="Channel">
+        <Box name="PixelForwardBladeChan01_Body" dx="[W01]/2." dy="[e02]/2." dz="[ChanBodyHalfThickness]"/>
+        <Box name="PixelForwardBladeChan01_Cover" dx="[W01]/2." dy="[e02]/2." dz="[ChanCoverHalfThickness]"/>
+        <Tubs name="PixelForwardBladeChan02_Body" rMin="[R01]-[W01]/2." rMax="[R01]+[W01]/2." dz="[ChanBodyHalfThickness]" startPhi="180.*deg+[a01]" deltaPhi="180.*deg-2.*[a01]"/>
+        <Tubs name="PixelForwardBladeChan02_Cover" rMin="[R01]-[W01]/2." rMax="[R01]+[W01]/2." dz="[ChanCoverHalfThickness]" startPhi="180.*deg+[a01]" deltaPhi="180.*deg-2.*[a01]"/>
+        <Tubs name="PixelForwardBladeChan03_Body" rMin="0." rMax="[W01]/2." dz="[ChanBodyHalfThickness]" startPhi="0*deg" deltaPhi="180*deg"/>
+        <Tubs name="PixelForwardBladeChan03_Cover" rMin="0." rMax="[W01]/2." dz="[ChanCoverHalfThickness]" startPhi="0*deg" deltaPhi="180*deg"/>
+    </SolidSection>
+    <LogicalPartSection label="Channel">
+        <LogicalPart name="PixelForwardBladeChan01_Body" category="cooling">
+            <rSolid name="PixelForwardBladeChan01_Body"/>
+            <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeChan01_Cover" category="cooling">
+            <rSolid name="PixelForwardBladeChan01_Cover"/>
+            <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeChan02_Body" category="cooling">
+            <rSolid name="PixelForwardBladeChan02_Body"/>
+            <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeChan02_Cover" category="cooling">
+            <rSolid name="PixelForwardBladeChan02_Cover"/>
+            <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeChan03_Body" category="cooling">
+            <rSolid name="PixelForwardBladeChan03_Body"/>
+            <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBladeChan03_Cover" category="cooling">
+            <rSolid name="PixelForwardBladeChan03_Cover"/>
+            <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="Channel">
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBladeBody01_Left"/>
+            <rChild name="PixelForwardBladeChan01_Body"/>
+            <Translation x="0." y="0." z="[z03]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardBladeBody01_Right"/>
+            <rChild name="PixelForwardBladeChan01_Body"/>
+            <Translation x="0." y="0." z="[z03]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBladeCover01_Left"/>
+            <rChild name="PixelForwardBladeChan01_Cover"/>
+            <Translation x="0." y="0." z="[z04]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardBladeCover01_Right"/>
+            <rChild name="PixelForwardBladeChan01_Cover"/>
+            <Translation x="0." y="0." z="[z04]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBladeBody02"/>
+            <rChild name="PixelForwardBladeChan02_Body"/>
+            <Translation x="0." y="0." z="[z03]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBladeCover02"/>
+            <rChild name="PixelForwardBladeChan02_Cover"/>
+            <Translation x="0." y="0." z="[z04]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBladeBody03_Left"/>
+            <rChild name="PixelForwardBladeChan03_Body"/>
+            <Translation x="0." y="0." z="[z03]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardBladeBody03_Right"/>
+            <rChild name="PixelForwardBladeChan03_Body"/>
+            <Translation x="0." y="0." z="[z03]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBladeCover03_Left"/>
+            <rChild name="PixelForwardBladeChan03_Cover"/>
+            <Translation x="0." y="0." z="[z04]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardBladeCover03_Right"/>
+            <rChild name="PixelForwardBladeChan03_Cover"/>
+            <Translation x="0." y="0." z="[z04]"/>
+        </PosPart>
+    </PosPartSection>
+    <!-- All rotations -->
+    <RotationSection label="Blade">
+        <Rotation name="LeftArm01" phiX="[a01]" thetaX="90.*deg" phiY="90.*deg + [a01]" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="RightArm01" phiX="-[a01]" thetaX="90.*deg" phiY="90.*deg - [a01]" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="LeftArm02" phiX="[A01]" thetaX="90.*deg" phiY="90.*deg + [A01]" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="RightArm02" phiX="-[A01]" thetaX="90.*deg" phiY="90.*deg - [A01]" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+    </RotationSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdCommon.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdCommon.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Dmitry Onoprienko
+         
+         == COMPONENT DEFINED BY THIS FILE: ==
+         
+         Constants and rotations required by multiple components.
+         
+         -->
+    <ConstantsSection label="Common" eval="true">
+        <Constant name="SmallBool" value="0.01*mm"/>
+        <!-- Small value used to make boolean-subtracted volumes
+             slightly larger then their mothers, so that Iguana 
+             can visualize them properly -->
+    </ConstantsSection>
+    <RotationSection label="Root">
+        <Rotation name="Y180" phiX="180.*deg" thetaX="90.*deg" phiY="90.*deg" thetaY="90.*deg" phiZ="0.*deg" thetaZ="180.*deg"/>
+        <Rotation name="Z180" phiX="180.*deg" thetaX="90.*deg" phiY="270.*deg" thetaY="90.*deg" phiZ="0.*deg" thetaZ="0.*deg"/>
+        <ReflectionRotation name="ReflectionX" phiX="180.*deg" thetaX="90.*deg" phiY="90.*deg" thetaY="90.*deg" phiZ="0.*deg" thetaZ="0.*deg"/>
+    </RotationSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdCylinder.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdCylinder.xml
@@ -1,0 +1,343 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Dmitry Onoprienko
+         @modified Xingtao Huang to implement the fpix service cylinder
+         @modified Vesna Cuplov to fix the Electronics boards positions (august 2008).
+         
+         
+         == COMPONENT DEFINED BY THIS FILE: ==
+         
+         Service cylinders.
+         
+         == Comments : ==
+         
+         Currently, only three graphite cylinders are described. No ribs, cables, coolant pipes, circuit boards, etc. 
+         And unlike files for all other subsystems, this file does not define a root volume, but instead positions 
+         new volumes directly into pixfwd:PixelForwardZPlus and pixfwd:PixelForwardZMinus, using 
+         the pixfwd:ZCylinder constant defined in pixfwd.xml.
+         
+         The reason is that many components that should go into service cylinders have not been designed yet, 
+         and it's not clear what shape the root volume will eventually have to have, what symmetry 
+         between Z+ and Z- endcaps we will be able to use, and so on. Once the exact geometry is known, 
+         the file will need to be modified to follow the standard scheme for forward pixels geometry - 
+         root volume plus an anchor point for positioning. 
+         
+         -->
+    <ConstantsSection label="Cylinders" eval="true">
+        <Constant name="CylindersOuterRmin" value="160.00*mm"/>
+        <Constant name="CylindersOuterRmax" value="168.50*mm"/>
+        <Constant name="CylindersOuterLength" value="2101.09*mm"/>
+        <Constant name="CylindersEndFlangeRmin" value="132.50*mm"/>
+        <Constant name="CylindersEndFlangeRmax" value="160.50*mm"/>
+        <Constant name="CylindersEndFlangeLength" value="41.30*mm"/>
+        <Constant name="CylindersElectronicsRmin" value="117.20*mm"/>
+        <Constant name="CylindersElectronicsRmax" value="160.00*mm"/>
+        <Constant name="CylindersElectronicsLength" value="132.08*mm"/>
+        <Constant name="CylindersCoilFiberWidth" value="98.48*mm"/>
+        <Constant name="CylindersCoilFiberLength" value="582.97*mm"/>
+        <Constant name="CylindersCoilFiberThickness" value="12.70*mm"/>
+        <Constant name="CylinderPipeRmax" value="15.0/2.0*mm"/>
+        <Constant name="CylinderPipeRmin" value="9.02/2.0*mm"/>
+        <Constant name="CylinderPipeLength1" value="(1177.16-239.58)*mm"/>
+        <Constant name="CylinderPipeLength2" value="823.60*mm"/>
+        <Constant name="CylindersPortCardsWidth" value="60.0*mm"/>
+        <Constant name="CylindersPortCardsLength1" value="223.52*mm"/>
+        <Constant name="CylindersPortCardsLength2" value="355.60*mm"/>
+        <Constant name="CylindersPortCardsThickness" value="5.40*mm"/>
+        <Constant name="CylindersServiceZoff" value="320.0*mm"/>
+        <Constant name="CylindersServiceRmin" value="100*mm"/>
+        <Constant name="CylindersServiceZ0" value="0*mm"/>
+        <Constant name="CylindersServiceZMin" value="[CylindersServiceZoff]"/>
+        <Constant name="CylindersServiceZMax" value="[CylindersOuterLength]"/>
+    </ConstantsSection>
+    <RotationSection label="Cylinders">
+        <Rotation name="EndFlangeRot1" phiX="290.*deg" thetaX="90.*deg" phiY="20.*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="EndFlangeRot2" phiX="110.*deg" thetaX="90.*deg" phiY="200.*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="ElectronicsRot1" phiX="39.31*deg" thetaX="90.*deg" phiY="129.31*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="ElectronicsRot2" phiX="39.31*deg" thetaX="90.*deg" phiY="129.31*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="CoilFiberRot1" phiX="317.19*deg" thetaX="90.*deg" phiY="47.19*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="CoilFiberRot2" phiX="222.81*deg" thetaX="90.*deg" phiY="312.81*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="CoilFiberRot3" phiX="42.81*deg" thetaX="90.*deg" phiY="132.81*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="CoilFiberRot4" phiX="137.19*deg" thetaX="90.*deg" phiY="227.19*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="PortCardsRot1" phiX="337.5*deg" thetaX="90.*deg" phiY="67.5*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="PortCardsRot2" phiX="292.5*deg" thetaX="90.*deg" phiY="22.5*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="PortCardsRot3" phiX="247.5*deg" thetaX="90.*deg" phiY="337.5*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="PortCardsRot4" phiX="202.5*deg" thetaX="90.*deg" phiY="292.5*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="PortCardsRot5" phiX="22.5*deg" thetaX="90.*deg" phiY="112.5*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="PortCardsRot6" phiX="67.5*deg" thetaX="90.*deg" phiY="157.5*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="PortCardsRot7" phiX="112.5*deg" thetaX="90.*deg" phiY="202.5*deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+        <Rotation name="PortCardsRot8" phiX="157.5*deg" thetaX="90.*deg" phiY="247.5* deg" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+    </RotationSection>
+    <SolidSection label="Cylinders">
+        <Polycone name="PixelForwardServiceCylinder" startPhi="0*deg" deltaPhi="360*deg">
+            <ZSection z="[CylindersServiceZ0]" rMin="[CylindersOuterRmin]" rMax="[CylindersOuterRmax]"/>
+            <ZSection z="[CylindersServiceZMin]" rMin="[CylindersOuterRmin]" rMax="[CylindersOuterRmax]"/>
+            <ZSection z="[CylindersServiceZMin]" rMin="[CylindersServiceRmin]" rMax="[CylindersOuterRmax]"/>
+            <ZSection z="[CylindersServiceZMax]" rMin="[CylindersServiceRmin]" rMax="[CylindersOuterRmax]"/>
+        </Polycone>
+        <Tubs name="PixelForwardCylinderOuterCyl" rMin="[CylindersOuterRmin]" rMax="[CylindersOuterRmax]" dz="[CylindersOuterLength]/2." startPhi="0." deltaPhi="360*deg"/>
+        <Tubs name="PixelForwardCylinderEndFlange" rMin="[CylindersEndFlangeRmin]" rMax="[CylindersEndFlangeRmax]" dz="[CylindersEndFlangeLength]/2." startPhi="0.*deg" deltaPhi="140.*deg"/>
+        <Tubs name="PixelForwardCylinderElectronics1" rMin="[CylindersElectronicsRmin]" rMax="[CylindersElectronicsRmax]" dz="[CylindersElectronicsLength]/2." startPhi="19.79*deg" deltaPhi="33.57*deg"/>
+        <Tubs name="PixelForwardCylinderElectronics2" rMin="[CylindersElectronicsRmin]" rMax="[CylindersElectronicsRmax]" dz="[CylindersElectronicsLength]/2." startPhi="121.17*deg" deltaPhi="39.04*deg"/>
+        <Tubs name="PixelForwardCylinderElectronics3" rMin="[CylindersElectronicsRmin]" rMax="[CylindersElectronicsRmax]" dz="[CylindersElectronicsLength]/2." startPhi="302.75*deg" deltaPhi="39.04*deg"/>
+        <Tubs name="PixelForwardCylinderElectronics4" rMin="[CylindersElectronicsRmin]" rMax="[CylindersElectronicsRmax]" dz="[CylindersElectronicsLength]/2." startPhi="203.675*deg" deltaPhi="33.57*deg"/>
+        <Box name="PixelForwardCylindersCoilFiber" dx="[CylindersCoilFiberWidth]/2." dy="[CylindersCoilFiberThickness]/2." dz="[CylindersCoilFiberLength]/2."/>
+        <Tubs name="PixelForwardCylinderPipe1" rMin="[CylinderPipeRmin]" rMax="[CylinderPipeRmax]" dz="[CylinderPipeLength1]/2." startPhi="0." deltaPhi="360*deg"/>
+        <Tubs name="PixelForwardCylinderPipe2" rMin="[CylinderPipeRmin]" rMax="[CylinderPipeRmax]" dz="[CylinderPipeLength2]/2." startPhi="0." deltaPhi="360*deg"/>
+        <Box name="PixelForwardCylindersPortCards1" dx="[CylindersPortCardsWidth]/2." dy="[CylindersPortCardsThickness]/2." dz="[CylindersPortCardsLength1]/2."/>
+        <Box name="PixelForwardCylindersPortCards2" dx="[CylindersPortCardsWidth]/2." dy="[CylindersPortCardsThickness]/2." dz="[CylindersPortCardsLength2]/2."/>
+    </SolidSection>
+    <LogicalPartSection label="Cylinders">
+        <LogicalPart name="PixelForwardServiceCylinder" category="support">
+            <rSolid name="PixelForwardServiceCylinder"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardCylinderOuterCyl" category="support">
+            <rSolid name="PixelForwardCylinderOuterCyl"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_Servi_Cylind"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardCylinderEndFlange" category="support">
+            <rSolid name="PixelForwardCylinderEndFlange"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_End_Flange"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardCylinderElectronics1" category="support">
+            <rSolid name="PixelForwardCylinderElectronics1"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_End_Electro_2"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardCylinderElectronics2" category="support">
+            <rSolid name="PixelForwardCylinderElectronics2"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_End_Electro_1"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardCylinderElectronics3" category="support">
+            <rSolid name="PixelForwardCylinderElectronics3"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_End_Electro_1"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardCylinderElectronics4" category="support">
+            <rSolid name="PixelForwardCylinderElectronics4"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_End_Electro_2"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardCylindersCoilFiber" category="support">
+            <rSolid name="PixelForwardCylindersCoilFiber"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_End_Coil_Fiber"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardCylinderPipe1" category="support">
+            <rSolid name="PixelForwardCylinderPipe1"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_End_Pipe_1"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardCylinderPipe2" category="support">
+            <rSolid name="PixelForwardCylinderPipe2"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_End_Pipe_2"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardCylindersPortCards1" category="support">
+            <rSolid name="PixelForwardCylindersPortCards1"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_Port_Cards"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardCylindersPortCards2" category="support">
+            <rSolid name="PixelForwardCylindersPortCards2"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_Port_Cards"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <ConstantsSection label="CylindersPosition" eval="true">
+        <Constant name="ZOuterCylinder" value="([pixfwd:AnchorZ]+[CylindersOuterLength]/2.0)"/>
+        <Constant name="CoilFiblerToIP" value="1538.97*mm"/>
+        <Constant name="CoilFilberToBeam" value="114.7*mm"/>
+        <Constant name="CoilFilberAngle" value="47.19*deg"/>
+        <!--Constant name="FractionForPipe" value="0.9499"/-->
+        <Constant name="FractionForPipe" value="0.99"/>
+        <Constant name="PipeX1" value="19.9*mm"/>
+        <Constant name="PipeX2" value="151.7*mm"/>
+        <Constant name="PipeY1" value="150.4*mm"/>
+        <Constant name="PipeY2" value="16.9*mm"/>
+        <Constant name="PipeToIP1" value="([pixfwd:ZPixelForward]+[CylindersServiceZMin]+[CylinderPipeLength1]/2)"/>
+        <Constant name="PipeToIP2" value="1994.38*mm"/>
+        <Constant name="PortCardsToBeam" value="143.1*mm"/>
+        <Constant name="PortCardsAngle1" value="(22.5+1)*deg"/>
+        <Constant name="PortCardsAngle2" value="(67.5-1)*deg"/>
+        <Constant name="PortCardsToIP" value="952.75*mm"/>
+        <Constant name="ZOffCylinder" value="-[pixfwd:ZPixelForward]"/>
+    </ConstantsSection>
+    <PosPartSection label="Cylinders">
+        <PosPart copyNumber="1">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderOuterCyl"/>
+            <Translation x="0." y="0." z="[ZOuterCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderElectronics1"/>
+            <Translation x="0." y="0." z="[CylindersServiceZMax]-[CylindersElectronicsLength]/2."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderElectronics2"/>
+            <Translation x="0." y="0." z="[CylindersServiceZMax]-[CylindersElectronicsLength]/2."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderElectronics3"/>
+            <Translation x="0." y="0." z="[CylindersServiceZMax]-[CylindersElectronicsLength]/2."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderElectronics4"/>
+            <Translation x="0." y="0." z="[CylindersServiceZMax]-[CylindersElectronicsLength]/2."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylindersCoilFiber"/>
+            <Translation x="[CoilFilberToBeam]*cos([CoilFilberAngle])" y="[CoilFilberToBeam]*sin([CoilFilberAngle])" z="[CoilFiblerToIP]+[ZOffCylinder]"/>
+            <rRotation name="pixfwdCylinder:CoilFiberRot1"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylindersCoilFiber"/>
+            <Translation x="[CoilFilberToBeam]*cos([CoilFilberAngle])" y="-[CoilFilberToBeam]*sin([CoilFilberAngle])" z="[CoilFiblerToIP]+[ZOffCylinder]"/>
+            <rRotation name="pixfwdCylinder:CoilFiberRot2"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylindersCoilFiber"/>
+            <Translation x="-[CoilFilberToBeam]*cos([CoilFilberAngle])" y="[CoilFilberToBeam]*sin([CoilFilberAngle])" z="[CoilFiblerToIP]+[ZOffCylinder]"/>
+            <rRotation name="pixfwdCylinder:CoilFiberRot3"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylindersCoilFiber"/>
+            <Translation x="-[CoilFilberToBeam]*cos([CoilFilberAngle])" y="-[CoilFilberToBeam]*sin([CoilFilberAngle])" z="[CoilFiblerToIP]+[ZOffCylinder]"/>
+            <rRotation name="pixfwdCylinder:CoilFiberRot4"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe1"/>
+            <Translation x="[PipeX1]*[FractionForPipe]" y="[PipeY1]*[FractionForPipe]" z="[PipeToIP1]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe1"/>
+            <Translation x="[PipeX2]*[FractionForPipe]" y="[PipeY2]*[FractionForPipe]" z="[PipeToIP1]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe1"/>
+            <Translation x="[PipeX2]*[FractionForPipe]" y="-[PipeY2]*[FractionForPipe]" z="[PipeToIP1]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe1"/>
+            <Translation x="[PipeX1]*[FractionForPipe]" y="-[PipeY1]*[FractionForPipe]" z="[PipeToIP1]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe1"/>
+            <Translation x="-[PipeX1]*[FractionForPipe]" y="[PipeY1]*[FractionForPipe]" z="[PipeToIP1]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe1"/>
+            <Translation x="-[PipeX2]*[FractionForPipe]" y="[PipeY2]*[FractionForPipe]" z="[PipeToIP1]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe1"/>
+            <Translation x="-[PipeX2]*[FractionForPipe]" y="-[PipeY2]*[FractionForPipe]" z="[PipeToIP1]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe1"/>
+            <Translation x="-[PipeX1]*[FractionForPipe]" y="-[PipeY1]*[FractionForPipe]" z="[PipeToIP1]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe2"/>
+            <Translation x="[PipeX1]*[FractionForPipe]" y="[PipeY1]*[FractionForPipe]" z="[PipeToIP2]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe2"/>
+            <Translation x="[PipeX2]*[FractionForPipe]" y="[PipeY2]*[FractionForPipe]" z="[PipeToIP2]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe2"/>
+            <Translation x="[PipeX2]*[FractionForPipe]" y="-[PipeY2]*[FractionForPipe]" z="[PipeToIP2]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe2"/>
+            <Translation x="[PipeX1]*[FractionForPipe]" y="-[PipeY1]*[FractionForPipe]" z="[PipeToIP2]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe2"/>
+            <Translation x="-[PipeX1]*[FractionForPipe]" y="[PipeY1]*[FractionForPipe]" z="[PipeToIP2]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe2"/>
+            <Translation x="-[PipeX2]*[FractionForPipe]" y="[PipeY2]*[FractionForPipe]" z="[PipeToIP2]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe2"/>
+            <Translation x="-[PipeX2]*[FractionForPipe]" y="-[PipeY2]*[FractionForPipe]" z="[PipeToIP2]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="8">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylinderPipe2"/>
+            <Translation x="-[PipeX1]*[FractionForPipe]" y="-[PipeY1]*[FractionForPipe]" z="[PipeToIP2]+[ZOffCylinder]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
+            <Translation x="[PortCardsToBeam]*cos([PortCardsAngle2])" y="[PortCardsToBeam]*sin([PortCardsAngle2])" z="[PortCardsToIP]+[ZOffCylinder]"/>
+            <rRotation name="pixfwdCylinder:PortCardsRot1"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards2"/>
+            <Translation x="[PortCardsToBeam]*cos([PortCardsAngle1])" y="[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]+[ZOffCylinder]"/>
+            <rRotation name="pixfwdCylinder:PortCardsRot2"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
+            <Translation x="[PortCardsToBeam]*cos([PortCardsAngle1])" y="-[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]+[ZOffCylinder]"/>
+            <rRotation name="pixfwdCylinder:PortCardsRot3"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
+            <Translation x="[PortCardsToBeam]*cos([PortCardsAngle2])" y="-[PortCardsToBeam]*sin([PortCardsAngle2])" z="[PortCardsToIP]+[ZOffCylinder]"/>
+            <rRotation name="pixfwdCylinder:PortCardsRot4"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
+            <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle2])" y="[PortCardsToBeam]*sin([PortCardsAngle2])" z="[PortCardsToIP]+[ZOffCylinder]"/>
+            <rRotation name="pixfwdCylinder:PortCardsRot5"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards2"/>
+            <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle1])" y="[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]+[ZOffCylinder]"/>
+            <rRotation name="pixfwdCylinder:PortCardsRot6"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
+            <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle1])" y="-[PortCardsToBeam]*sin([PortCardsAngle1])" z="[PortCardsToIP]+[ZOffCylinder]"/>
+            <rRotation name="pixfwdCylinder:PortCardsRot7"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="pixfwdCylinder:PixelForwardServiceCylinder"/>
+            <rChild name="pixfwdCylinder:PixelForwardCylindersPortCards1"/>
+            <Translation x="-[PortCardsToBeam]*cos([PortCardsAngle2])" y="-[PortCardsToBeam]*sin([PortCardsAngle2])" z="[PortCardsToIP]+[ZOffCylinder]"/>
+            <rRotation name="pixfwdCylinder:PortCardsRot8"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdDisk.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdDisk.xml
@@ -1,0 +1,278 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Dmitry Onoprienko
+         @modified Vesna Cuplov 04.17.07
+         @modified august 2008: Aluminium_OuterRing material with appropriate density (lighter than aluminium density)   in order to comprensate the in-existing holes in the outer-ring simulation.
+         @modified Vesna Cuplov (august 2008): Inner and Outer Rings have 2 different aluminium densities.
+         
+         
+         == Subsystem or component described by the file ==
+         
+         Forward Pixels disk.
+         
+         == Root volume and its reference frame ==
+         
+         Two root volumes are defined: 
+         
+         PixelForwardDiskZPlus   (Disks for Z+ endcap)
+         PixelForwardDiskZMinus  (Disks for Z- endcap)
+         
+         X horizontal<br>
+         Y vertical pointing up<br>
+         Z along the beam line perpendicular to the disk plane, points away from IP<br>
+         
+         Origin at the center of the disk.<br>
+         
+         == Positioning ==
+         
+         Anchor point coincides with the root reference frame origin.
+         Disks are positioned into endcaps without any rotations.
+         
+         -->
+    <ConstantsSection label="Input" eval="true">
+        <Constant name="InnerRingREdge" value="49.16*mm"/>
+        <Constant name="InnerRingRMin" value="50.16*mm"/>
+        <Constant name="InnerRingRMax" value="51.16*mm"/>
+        <Constant name="InnerRingEdge" value="1.00*mm"/>
+        <Constant name="InnerRingHalfWidth" value="29.50*mm"/>
+        <Constant name="OuterRingRMin" value="157.5*mm"/>
+        <Constant name="OuterRingRMax" value="158.5*mm"/>
+        <Constant name="OuterRingREdge" value="159.5*mm"/>
+        <Constant name="OuterRingEdge" value="1.00*mm"/>
+        <Constant name="OuterRingHalfWidth" value="29.50*mm"/>
+        <!-- Layout of panels in disks (left or right). Blades are numbered in 
+             increasing phi order in the disk frame. Therefore, in the global
+             frame they are numbered in increasing phi order for the Z Plus disks,
+             in decreasing phi order, starting with blade 12, for the Z Minus disks. -->
+        <!--   "L" - left, "R" - right, "-" - no panel : 000000000111111111122222   -->
+        <!--                                                 123456789012345678901234   -->
+        <!--  <Constant name="PanelLayoutZPlus3"      value="RLLLLRLLLLLRRLLLLRLLLLLR" />-->
+        <!--  <Constant name="PanelLayoutZPlus4"      value="LLLLLLRLLLLRLLLLLLRLLLLR" />-->
+        <!--  <Constant name="PanelLayoutZMinus3"     value="LRRRRRLRRRRLLRRRRRLRRRRL" />-->
+        <!--  <Constant name="PanelLayoutZMinus4"     value="LRRRRLRRRRRRLRRRRLRRRRRR" />-->
+        <!-- Oops! DDL does not support string constants... Cut-and-paste to algorithm calls below. -->
+    </ConstantsSection>
+    <!-- Disk root -->
+    <ConstantsSection label="Root" eval="true">
+        <Constant name="DiskRmin" value="[InnerRingREdge]"/>
+        <Constant name="DiskRmax" value="[OuterRingREdge]"/>
+        <Constant name="DiskHalfWidth" value="[OuterRingHalfWidth]"/>
+    </ConstantsSection>
+    <!-- New description (modification) 04/17/07 : Panel3R, 4R and 4L were going through the Disk, so 2mm were added to the Width of the mother volume of the Disk -->
+    <SolidSection label="Root">
+        <Tubs name="PixelForwardDisk" rMin="[DiskRmin]" rMax="[DiskRmax]" dz="[DiskHalfWidth]+2.0*mm" startPhi="0." deltaPhi="360*deg"/>
+    </SolidSection>
+    <LogicalPartSection label="Root">
+        <LogicalPart name="PixelForwardDiskZPlus" category="envelope">
+            <rSolid name="PixelForwardDisk"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardDiskZMinus" category="envelope">
+            <rSolid name="PixelForwardDisk"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <!-- Support rings -->
+    <SolidSection label="Rings">
+        <Tubs name="PixelForwardDiskInnerRing" rMin="[InnerRingRMin]" rMax="[InnerRingRMax]" dz="[InnerRingHalfWidth]" startPhi="0." deltaPhi="360*deg"/>
+        <Tubs name="PixelForwardDiskInnerRingEdge" rMin="[InnerRingREdge]" rMax="[InnerRingRMin]" dz="[InnerRingEdge]/2." startPhi="0." deltaPhi="360*deg"/>
+        <Tubs name="PixelForwardDiskOuterRing" rMin="[OuterRingRMin]" rMax="[OuterRingRMax]" dz="[OuterRingHalfWidth]" startPhi="0." deltaPhi="360*deg"/>
+        <Tubs name="PixelForwardDiskOuterRingEdge" rMin="[OuterRingRMax]" rMax="[OuterRingREdge]" dz="[OuterRingEdge]/2." startPhi="0." deltaPhi="360*deg"/>
+    </SolidSection>
+    <LogicalPartSection label="Rings">
+        <LogicalPart name="PixelForwardDiskInnerRing" category="support">
+            <rSolid name="PixelForwardDiskInnerRing"/>
+            <rMaterial name="pixfwdMaterials:Aluminium_InnerRing"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardDiskInnerRingEdge" category="support">
+            <rSolid name="PixelForwardDiskInnerRingEdge"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardDiskOuterRing" category="support">
+            <rSolid name="PixelForwardDiskOuterRing"/>
+            <rMaterial name="pixfwdMaterials:Aluminium_OuterRing"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardDiskOuterRingEdge" category="support">
+            <rSolid name="PixelForwardDiskOuterRingEdge"/>
+            <rMaterial name="trackermaterial:T_Aluminium"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="Rings">
+        <!-- Z Plus Disk -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardDiskZPlus"/>
+            <rChild name="PixelForwardDiskInnerRing"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardDiskZPlus"/>
+            <rChild name="PixelForwardDiskInnerRingEdge"/>
+            <Translation x="0." y="0." z="-[InnerRingHalfWidth]-[InnerRingEdge]/2."/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardDiskZPlus"/>
+            <rChild name="PixelForwardDiskInnerRingEdge"/>
+            <Translation x="0." y="0." z="[InnerRingHalfWidth]+[InnerRingEdge]/2."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardDiskZPlus"/>
+            <rChild name="PixelForwardDiskOuterRing"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardDiskZPlus"/>
+            <rChild name="PixelForwardDiskOuterRingEdge"/>
+            <Translation x="0." y="0." z="-[OuterRingHalfWidth]-[OuterRingEdge]/2."/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardDiskZPlus"/>
+            <rChild name="PixelForwardDiskOuterRingEdge"/>
+            <Translation x="0." y="0." z="[OuterRingHalfWidth]+[OuterRingEdge]/2."/>
+        </PosPart>
+        <!-- Z Minus Disk -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardDiskZMinus"/>
+            <rChild name="PixelForwardDiskInnerRing"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardDiskZMinus"/>
+            <rChild name="PixelForwardDiskInnerRingEdge"/>
+            <Translation x="0." y="0." z="-[InnerRingHalfWidth]-[InnerRingEdge]/2."/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardDiskZMinus"/>
+            <rChild name="PixelForwardDiskInnerRingEdge"/>
+            <Translation x="0." y="0." z="[InnerRingHalfWidth]+[InnerRingEdge]/2."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardDiskZMinus"/>
+            <rChild name="PixelForwardDiskOuterRing"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardDiskZMinus"/>
+            <rChild name="PixelForwardDiskOuterRingEdge"/>
+            <Translation x="0." y="0." z="-[OuterRingHalfWidth]-[OuterRingEdge]/2."/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardDiskZMinus"/>
+            <rChild name="PixelForwardDiskOuterRingEdge"/>
+            <Translation x="0." y="0." z="[OuterRingHalfWidth]+[OuterRingEdge]/2."/>
+        </PosPart>
+    </PosPartSection>
+    <!-- Blades -->
+    <!-- Z Plus Disk -->
+    <Algorithm name="track:DDPixFwdBlades">
+        <rParent name="pixfwdDisk:PixelForwardDiskZPlus"/>
+        <Numeric name="Endcap" value="1."/>
+        <String name="Child" value="pixfwdBlade:PixelForwardBlade"/>
+        <Vector name="ChildTranslation" type="numeric" nEntries="3"> 0., -[pixfwdBlade:AnchorY], 0. </Vector>
+    </Algorithm>
+    <!-- Z Minus Disk -->
+    <Algorithm name="track:DDPixFwdBlades">
+        <rParent name="pixfwdDisk:PixelForwardDiskZMinus"/>
+        <Numeric name="Endcap" value="-1."/>
+        <String name="Child" value="pixfwdBlade:PixelForwardBlade"/>
+        <Vector name="ChildTranslation" type="numeric" nEntries="3"> 0., -[pixfwdBlade:AnchorY], 0. </Vector>
+        <String name="ChildRotation" value="pixfwdCommon:ReflectionX"/>
+    </Algorithm>
+    <!-- Panels -->
+    <ConstantsSection label="Panels" eval="true">
+        <Constant name="zPanel" value="[pixfwdBlade:RootHalfThickness]+[pixfwdPanel:RootHalfThickness]"/>
+    </ConstantsSection>
+    <!-- Z Plus Disk -->
+    <Algorithm name="track:DDPixFwdBlades">
+        <rParent name="pixfwdDisk:PixelForwardDiskZPlus"/>
+        <Numeric name="Endcap" value="1."/>
+        <String name="Child" value="pixfwdPanel:PixelForwardPanel3Right"/>
+        <Vector name="ChildTranslation" type="numeric" nEntries="3"> 0., -[pixfwdPanel:AnchorY], [zPanel] </Vector>
+        <String name="FlagString" value="RLLLLRLLLLLRRLLLLRLLLLLR"/>
+        <!-- Panel Layout ZPlus 3  -->
+        <String name="FlagSelector" value="R"/>
+    </Algorithm>
+    <Algorithm name="track:DDPixFwdBlades">
+        <rParent name="pixfwdDisk:PixelForwardDiskZPlus"/>
+        <Numeric name="Endcap" value="1."/>
+        <String name="Child" value="pixfwdPanel:PixelForwardPanel3Left"/>
+        <Vector name="ChildTranslation" type="numeric" nEntries="3"> 0., -[pixfwdPanel:AnchorY], [zPanel] </Vector>
+        <String name="FlagString" value="RLLLLRLLLLLRRLLLLRLLLLLR"/>
+        <!-- Panel Layout ZPlus 3  -->
+        <String name="FlagSelector" value="L"/>
+    </Algorithm>
+    <Algorithm name="track:DDPixFwdBlades">
+        <rParent name="pixfwdDisk:PixelForwardDiskZPlus"/>
+        <Numeric name="Endcap" value="1."/>
+        <String name="Child" value="pixfwdPanel:PixelForwardPanel4Right"/>
+        <Vector name="ChildTranslation" type="numeric" nEntries="3"> 0., -[pixfwdPanel:AnchorY], -[zPanel] </Vector>
+        <String name="ChildRotation" value="pixfwdCommon:Y180"/>
+        <String name="FlagString" value="LLLLLLRLLLLRLLLLLLRLLLLR"/>
+        <!-- Panel Layout ZPlus 4  -->
+        <String name="FlagSelector" value="R"/>
+    </Algorithm>
+    <Algorithm name="track:DDPixFwdBlades">
+        <rParent name="pixfwdDisk:PixelForwardDiskZPlus"/>
+        <Numeric name="Endcap" value="1."/>
+        <String name="Child" value="pixfwdPanel:PixelForwardPanel4Left"/>
+        <Vector name="ChildTranslation" type="numeric" nEntries="3"> 0., -[pixfwdPanel:AnchorY], -[zPanel] </Vector>
+        <String name="ChildRotation" value="pixfwdCommon:Y180"/>
+        <String name="FlagString" value="LLLLLLRLLLLRLLLLLLRLLLLR"/>
+        <!-- Panel Layout ZPlus 4  -->
+        <String name="FlagSelector" value="L"/>
+    </Algorithm>
+    <!-- Z Minus Disk -->
+    <Algorithm name="track:DDPixFwdBlades">
+        <rParent name="pixfwdDisk:PixelForwardDiskZMinus"/>
+        <Numeric name="Endcap" value="-1."/>
+        <String name="Child" value="pixfwdPanel:PixelForwardPanel3Right"/>
+        <Vector name="ChildTranslation" type="numeric" nEntries="3"> 0., -[pixfwdPanel:AnchorY], [zPanel] </Vector>
+        <String name="FlagString" value="LRRRRRLRRRRLLRRRRRLRRRRL"/>
+        <!-- Panel Layout ZMinus 3  -->
+        <String name="FlagSelector" value="R"/>
+    </Algorithm>
+    <Algorithm name="track:DDPixFwdBlades">
+        <rParent name="pixfwdDisk:PixelForwardDiskZMinus"/>
+        <Numeric name="Endcap" value="-1."/>
+        <String name="Child" value="pixfwdPanel:PixelForwardPanel3Left"/>
+        <Vector name="ChildTranslation" type="numeric" nEntries="3"> 0., -[pixfwdPanel:AnchorY], [zPanel] </Vector>
+        <String name="FlagString" value="LRRRRRLRRRRLLRRRRRLRRRRL"/>
+        <!-- Panel Layout ZMinus 3  -->
+        <String name="FlagSelector" value="L"/>
+    </Algorithm>
+    <Algorithm name="track:DDPixFwdBlades">
+        <rParent name="pixfwdDisk:PixelForwardDiskZMinus"/>
+        <Numeric name="Endcap" value="-1."/>
+        <String name="Child" value="pixfwdPanel:PixelForwardPanel4Right"/>
+        <Vector name="ChildTranslation" type="numeric" nEntries="3"> 0., -[pixfwdPanel:AnchorY], -[zPanel] </Vector>
+        <String name="ChildRotation" value="pixfwdCommon:Y180"/>
+        <String name="FlagString" value="LRRRRLRRRRRRLRRRRLRRRRRR"/>
+        <!-- Panel Layout ZMinus 4  -->
+        <String name="FlagSelector" value="R"/>
+    </Algorithm>
+    <Algorithm name="track:DDPixFwdBlades">
+        <rParent name="pixfwdDisk:PixelForwardDiskZMinus"/>
+        <Numeric name="Endcap" value="-1."/>
+        <String name="Child" value="pixfwdPanel:PixelForwardPanel4Left"/>
+        <Vector name="ChildTranslation" type="numeric" nEntries="3"> 0., -[pixfwdPanel:AnchorY], -[zPanel] </Vector>
+        <String name="ChildRotation" value="pixfwdCommon:Y180"/>
+        <String name="FlagString" value="LRRRRLRRRRRRLRRRRLRRRRRR"/>
+        <!-- Panel Layout ZMinus 4  -->
+        <String name="FlagSelector" value="L"/>
+    </Algorithm>
+    <!-- Nipples -->
+    <Algorithm name="track:DDPixFwdBlades">
+        <rParent name="pixfwdDisk:PixelForwardDiskZPlus"/>
+        <Numeric name="Endcap" value="1."/>
+        <String name="Child" value="pixfwdNipple:PixelForwardNippleZPlus"/>
+        <String name="FlagString" value="YYYYYNYYYYYNYYYYYNYYYYYN"/>
+        <String name="FlagSelector" value="Y"/>
+    </Algorithm>
+    <Algorithm name="track:DDPixFwdBlades">
+        <rParent name="pixfwdDisk:PixelForwardDiskZMinus"/>
+        <Numeric name="Endcap" value="-1."/>
+        <String name="Child" value="pixfwdNipple:PixelForwardNippleZMinus"/>
+        <String name="FlagString" value="NYYYYYNYYYYYNYYYYYNYYYYY"/>
+        <String name="FlagSelector" value="Y"/>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdMaterials.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdMaterials.xml
@@ -1,0 +1,380 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <MaterialSection label="PixelForwardMaterial.xml">
+    <CompositeMaterial name="FPix_Alumina" density="3.96*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.52924272">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.47075728">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FPix_TinLeadSolder" density="8.8*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.49377422">
+        <rMaterial name="materials:Tin" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.50622577">
+        <rMaterial name="materials:Lead" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FPix_Epoxy" density="1.1*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.7367217">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0529922">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.21028601">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FPix_BNPowder" density="3.5*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.4356165">
+        <rMaterial name="materials:Bor 11" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.564383">
+        <rMaterial name="materials:Nitrogen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FPix_Silicone" density="1.3*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.3787448">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.21575329">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.3239468">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08155498">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FPix_Kapton" density="1.4*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.6911352">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.026363">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20923002">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0732717">
+        <rMaterial name="materials:Nitrogen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FPix_Cylind_CF" density="1.495*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.7498836">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05034303">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1997733">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FPix_Cylind_G10" density="1.7*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.58320025">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04194946">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.27744272">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09740755">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FPix_Cylind_SnCu" density="8.86*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.08950548">
+        <rMaterial name="materials:Tin" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.91049451">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FPix_Cylind_POLIAX" density="1.27*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.74992040">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04082067">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16198633">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04727259">
+        <rMaterial name="materials:Nitrogen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FPix_Cylind_Polyester" density="1.4*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.492">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.065">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.263">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.091">
+        <rMaterial name="materials:Chlorine" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.089">
+        <rMaterial name="materials:Antimony" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FPix_Cylind_Noryl" density="1.08*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.7997302">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06711181">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1331579">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="FPix_Cylind_PMMA" density="1.2*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.59985105">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.080541353">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.31960759">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_Bump" density="0.41391*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00">
+        <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_AgEpoxy" density="1.60005*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.09823">
+        <rMaterial name="pixfwdMaterials:FPix_Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.31254">
+        <rMaterial name="pixfwdMaterials:FPix_BNPowder" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.46422">
+        <rMaterial name="pixfwdMaterials:FPix_Silicone" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12502">
+        <rMaterial name="pixfwdMaterials:FPix_Kapton" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_AdhFilm" density="1.57984*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.55706">
+        <rMaterial name="pixfwdMaterials:FPix_Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.44294">
+        <rMaterial name="pixfwdMaterials:FPix_BNPowder" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_VHDI" density="3.10741*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.34454">
+        <rMaterial name="pixfwdMaterials:FPix_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.58810">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04589">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02147">
+        <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_ROChip" density="2.33*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_HDI" density="2.23694*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.3718">
+        <rMaterial name="pixfwdMaterials:FPix_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13869">
+        <rMaterial name="pixfwdMaterials:FPix_Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.42221">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00315">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00240">
+        <rMaterial name="pixfwdMaterials:FPix_Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04968">
+        <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01206">
+        <rMaterial name="materials:Indium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="PixelForwardCoolant" density="1.79*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.213189">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.7868109">
+        <rMaterial name="materials:Fluorine" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Aluminium_OuterRing" density="1.82*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Aluminium_InnerRing" density="1.92*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_Servi_Cylind" density="0.20113*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+      <MaterialFraction fraction="0.96427">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_CF" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02453">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00899">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00220">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_End_Flange" density="1.66566*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.75148">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14202">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_SnCu" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06477">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_POLIAX" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04173">
+        <rMaterial name="pixfwdMaterials:PixelForwardCoolant" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_End_Electro_1" density="0.29369*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.34432">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_SnCu" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.33033">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14807">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_POLIAX" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10279">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_CF" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05357">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02093">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_End_Electro_2" density="0.27714*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.35884">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_SnCu" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.338">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14496">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_POLIAX" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10459">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_CF" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03299">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02062">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_End_Coil_Fiber" density="0.19983*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+      <MaterialFraction fraction="0.55642">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.27369">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_POLIAX" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09910">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04960">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Noryl" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02120">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_PMMA" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_End_Pipe_1" density="2.87036*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.47886">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_SnCu" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.27978">
+        <rMaterial name="pixfwdMaterials:PixelForwardCoolant" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.15973">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08163">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_POLIAX" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_End_Pipe_2" density="3.05434*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.48346">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_SnCu" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.25159">
+        <rMaterial name="pixfwdMaterials:PixelForwardCoolant" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.18305">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08190">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_POLIAX" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_Port_Cards" density="1.2278*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+      <MaterialFraction fraction="0.54216">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.24179">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11334">
+        <rMaterial name="pixfwdMaterials:FPix_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04121">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02159">
+        <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01943">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01477">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00572">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+  </MaterialSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdNipple.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdNipple.xml
@@ -1,0 +1,377 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <!-- 
+       
+       == CMS Forward Pixels Geometry ==
+       
+       @version 3.02.01 May 30, 2006
+       @created Dmitry Onoprienko
+       @modified Vesna Cuplov april 2007
+       
+       == Subsystem or component described by the file ==
+       
+       "Nipple" connecting cooling channels in two adjacent blades.
+       
+       == Root volume and its reference frame ==
+       
+       Two root volumes are defined:
+       
+       PixelForwardNippleZPlus  (nipple for +Z disk)
+       PixelForwardNippleZMinus (nipple for -Z disk)
+       
+       Z along the nipple axis, pointing from J to K.
+       
+       Origin at the middle of a segment connecting points J and K on the drawing
+       
+       == Positioning ==
+       
+       Positioned automatically by the <code>DDPixFwdBlades</code> algorithm, which recognizes
+       this component by its volume name, and applies appropriate rotations and translations.
+       
+       == Additional comments ==
+       
+       +Z and -Z versions of a nipple are, in fact, reflections of each other, but they are defined
+       separately to make Iguana happy: G4 visualization cannot handle polycone reflection at the moment.
+       
+       The call to DDPixFwdBlades algorithm calculates parameters needed for constructing
+       the nipple: rotations pixfwdNipple:NippleToCoverZPlus, pixfwdNipple:NippleToCoverZMinus,
+       pixfwdNipple:NippleToBodyZPlus, pixfwdNipple:NippleToBodyZMinus 
+       and constants pixfwdNipple:JK, pixfwdNipple:AngleBody, pixfwdNipple:AngleCover.
+       
+       Currently, there is a problem with passing constants from algorithms to DDL files, so these constants
+       are defined manually (by copy-and-paste from the algorithm output). To make sure the resulting 
+       numerical error does not cause volumes to overlap, nipples are described to be slightly shorter
+       than they are on the drawings.
+       
+       -->
+  <!-- Input geometry parameters -->
+  <ConstantsSection label="Input" eval="true">
+    <Constant name="R01" value="2.00*mm"/>
+    <Constant name="R02" value="2.50*mm"/>
+    <Constant name="R03" value="2.00*mm"/>
+    <Constant name="R04" value="2.50*mm"/>
+    <Constant name="R05" value="3.00*mm"/>
+    <Constant name="R06" value="3.00*mm"/>
+    <Constant name="R07" value="3.50*mm"/>
+    <Constant name="R08" value="4.50*mm"/>
+    <Constant name="R09" value="3.25*mm"/>
+    <Constant name="R10" value="3.75*mm"/>
+    <Constant name="R11" value="3.50*mm"/>
+    <Constant name="L01" value="8.23*mm"/>
+    <Constant name="L02" value="8.23*mm"/>
+    <Constant name="L03" value="6.73*mm"/>
+    <Constant name="L04" value="9.50*mm"/>
+    <Constant name="L05" value="4.00*mm"/>
+    <Constant name="L06" value="4.00*mm"/>
+    <Constant name="L07" value="1.00*mm"/>
+    <Constant name="L08" value="1.00*mm"/>
+    <Constant name="A01" value="60*deg"/>
+    <Constant name="RootHalfThickness" value="[pixfwdPanelBase:RootHalfThickness]"/>
+  </ConstantsSection>
+  <!-- THIS ALGORITHM DEFINES A FEW ROTATIONS (LIKE  pixfwdNipple:NippleToCover) AND
+       ATTEMPTS TO DEFINE A CONSTANT pixfwdNipple: JK, AngleBody, AngleCover -->
+  <Algorithm name="track:DDPixFwdBlades">
+    <rParent name="pixfwdNipple:PixelForwardNippleZPlus"/>
+  </Algorithm>
+  <!-- Nipple root and a solid for boolean subtraction -->
+  <ConstantsSection label="Root" eval="true">
+    <Constant name="JK" value="16.9*mm"/>
+    <!-- 16.9523 as printed by algorithm, made slightly smaller
+         to avoid overlaps due to numerical errors. Can be made
+         more precise once DDL is able to use constants defined 
+         in algorithms directly. -->
+    <Constant name="AngleBody" value="0.172941*rad"/>
+    <Constant name="AngleCover" value="0.172941*rad"/>
+    <Constant name="Dsub" value="2.0*mm"/>
+    <Constant name="Rsub" value="[R08]/cos([AngleBody]) + ([Dsub]/2)*tan([AngleBody]) + [pixfwdCommon:SmallBool]"/>
+    <Constant name="DeltaBody" value="([Dsub]/2 - 0.5*mm) / cos([AngleBody])"/>
+    <Constant name="DeltaCover" value="([Dsub]/2 - 0.5*mm) / cos([AngleCover])"/>
+  </ConstantsSection>
+  <SolidSection label="Root">
+    <!-- Previous description (D. Onoprienko)    
+         <Tubs name="PixelForwardNipple_01" rMin="0.*mm" rMax="[R08]" dz="[JK]/2." startPhi="0." deltaPhi="360*deg" />
+         <Tubs name="PixelForwardNippleSubtract" rMin="0.*mm" rMax="[Rsub]" dz="[Dsub]/2." startPhi="0." deltaPhi="360*deg" /> 
+         <SubtractionSolid name="PixelForwardNipple_int01">
+         <rSolid name="PixelForwardNipple_01" />
+         <rSolid name="PixelForwardNippleSubtract" />
+         <Translation x="0." y="0." z="-[JK]/2.-[DeltaCover]" />
+         <rRotation name="NippleToCoverZPlus" />
+    </SubtractionSolid>
+         <SubtractionSolid name="PixelForwardNippleZPlus">
+         <rSolid name="PixelForwardNipple_int01" />
+         <rSolid name="PixelForwardNippleSubtract" />
+         <Translation x="0." y="0." z="[JK]/2.+[DeltaBody]" />
+         <rRotation name="NippleToBodyZPlus" />
+    </SubtractionSolid>
+         -->
+    <!-- New description (I used the description of D. Onoprienko as a basement) to fix overlaps of panels with nipples: Previously there was only one shape as a Tub with special angles for the extremities, but this shape was overlaping with panels. I had to split into 2 shapes: the first shape is like the previous Tub with special angles for extremities but with a smaller rMax and the second shape that I add is a basic Tub (no angles for the extremities) that covers the largest part of the nipple. -->
+    <Tubs name="PixelForwardNipple_01" rMin="0.*mm" rMax="[R08]-0.9*mm" dz="[L04]/2+3.7*mm" startPhi="0." deltaPhi="360*deg"/>
+    <Tubs name="PixelForwardNippleSubtract" rMin="0.*mm" rMax="[Rsub]-0.9*mm" dz="[Dsub]/2." startPhi="0." deltaPhi="360*deg"/>
+    <Tubs name="PixelForwardNippleMiddle" rMin="0.*mm" rMax="[R08]" dz="[L04]/2.+0.4*mm" startPhi="0." deltaPhi="360*deg"/>
+    <SubtractionSolid name="PixelForwardNipple_int01">
+      <rSolid name="PixelForwardNipple_01"/>
+      <rSolid name="PixelForwardNippleSubtract"/>
+      <Translation x="0." y="0." z="-[L04]/2.-3.7*mm-[DeltaCover]"/>
+      <rRotation name="NippleToCoverZPlus"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="PixelForwardNippleZPlus_01">
+      <rSolid name="PixelForwardNipple_int01"/>
+      <rSolid name="PixelForwardNippleSubtract"/>
+      <Translation x="0." y="0." z="[L04]/2.+3.7*mm+[DeltaBody]"/>
+      <rRotation name="NippleToBodyZPlus"/>
+    </SubtractionSolid>
+    <UnionSolid name="PixelForwardNippleZPlus">
+      <rSolid name="PixelForwardNippleZPlus_01"/>
+      <rSolid name="PixelForwardNippleMiddle"/>
+      <Translation x="0." y="0." z="0."/>
+    </UnionSolid>
+    <SubtractionSolid name="PixelForwardNipple_int02">
+      <rSolid name="PixelForwardNipple_01"/>
+      <rSolid name="PixelForwardNippleSubtract"/>
+      <Translation x="0." y="0." z="-[L04]/2.-3.7*mm-[DeltaCover]"/>
+      <rRotation name="NippleToCoverZMinus"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="PixelForwardNippleZMinus_01">
+      <rSolid name="PixelForwardNipple_int02"/>
+      <rSolid name="PixelForwardNippleSubtract"/>
+      <Translation x="0." y="0." z="[L04]/2.+3.7*mm+[DeltaBody]"/>
+      <rRotation name="NippleToBodyZMinus"/>
+    </SubtractionSolid>
+    <UnionSolid name="PixelForwardNippleZMinus">
+      <rSolid name="PixelForwardNippleZMinus_01"/>
+      <rSolid name="PixelForwardNippleMiddle"/>
+      <Translation x="0." y="0." z="0."/>
+    </UnionSolid>
+  </SolidSection>
+  <LogicalPartSection label="Root">
+    <LogicalPart name="PixelForwardNippleZPlus" category="envelope">
+      <rSolid name="PixelForwardNippleZPlus"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="PixelForwardNippleZMinus" category="envelope">
+      <rSolid name="PixelForwardNippleZMinus"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+  </LogicalPartSection>
+  <!-- Sleeve and pipes inside it -->
+  <ConstantsSection label="Sleeve" eval="true">
+    <Constant name="e01" value="[JK]-[L01]-[L02]"/>
+  </ConstantsSection>
+  <SolidSection label="Sleeve">
+    <Polycone name="PixelForwardNippleSleeve" startPhi="0.*deg" deltaPhi="360*deg">
+      <ZSection z="-[L04]/2" rMin="0." rMax="[R08]"/>
+      <ZSection z="[L04]/2-([R08]-[R07])*tan([A01])" rMin="0." rMax="[R08]"/>
+      <ZSection z="[L04]/2" rMin="0." rMax="[R07]"/>
+    </Polycone>
+    <Polycone name="PixelForwardNippleEpoxyCover" startPhi="0.*deg" deltaPhi="360*deg">
+      <ZSection z="-[L06]/2" rMin="[R05]" rMax="[R11]"/>
+      <ZSection z="[L06]/2-[L07]-([R10]-[R11])" rMin="[R05]" rMax="[R11]"/>
+      <ZSection z="[L06]/2-[L07]" rMin="[R05]" rMax="[R10]"/>
+      <ZSection z="[L06]/2" rMin="[R05]" rMax="[R10]"/>
+    </Polycone>
+    <Polycone name="PixelForwardNippleEpoxyBody" startPhi="0.*deg" deltaPhi="360*deg">
+      <ZSection z="-[L05]/2" rMin="[R02]" rMax="[R09]"/>
+      <ZSection z="-[L05]/2+[L08]" rMin="[R02]" rMax="[R09]"/>
+      <ZSection z="-[L05]/2+[L08]+([R09]-[R06])" rMin="[R02]" rMax="[R06]"/>
+      <ZSection z="[L05]/2" rMin="[R02]" rMax="[R06]"/>
+    </Polycone>
+    <Polycone name="PixelForwardNippleSleeveCoolant" startPhi="0.*deg" deltaPhi="360*deg">
+      <ZSection z="-[L04]/2" rMin="0.0" rMax="[R04]"/>
+      <ZSection z="-[L04]/2+[L06]-([L02]-[L03])" rMin="0.0" rMax="[R04]"/>
+      <ZSection z="-[L04]/2+[L06]-([L02]-[L03])+([R04]-[R03])" rMin="0.0" rMax="[R03]"/>
+      <ZSection z="-[L04]/2+[L06]" rMin="0.0" rMax="[R03]"/>
+      <ZSection z="-[L04]/2+[L06]" rMin="0.0" rMax="[R02]"/>
+      <ZSection z="-[L04]/2+[L06]+[e01]" rMin="0.0" rMax="[R02]"/>
+      <ZSection z="-[L04]/2+[L06]+[e01]" rMin="0.0" rMax="[R01]"/>
+      <ZSection z="[L04]/2" rMin="0.0" rMax="[R01]"/>
+    </Polycone>
+  </SolidSection>
+  <LogicalPartSection label="Sleeve">
+    <LogicalPart name="PixelForwardNippleSleeve" category="cooling">
+      <rSolid name="PixelForwardNippleSleeve"/>
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </LogicalPart>
+    <LogicalPart name="PixelForwardNippleEpoxyCover" category="cooling">
+      <rSolid name="PixelForwardNippleEpoxyCover"/>
+      <rMaterial name="pixfwdMaterials:Pix_Fwd_AgEpoxy"/>
+    </LogicalPart>
+    <LogicalPart name="PixelForwardNippleEpoxyBody" category="cooling">
+      <rSolid name="PixelForwardNippleEpoxyBody"/>
+      <rMaterial name="pixfwdMaterials:Pix_Fwd_AgEpoxy"/>
+    </LogicalPart>
+    <LogicalPart name="PixelForwardNippleSleeveCoolant" category="cooling">
+      <rSolid name="PixelForwardNippleSleeveCoolant"/>
+      <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+    </LogicalPart>
+  </LogicalPartSection>
+  <PosPartSection label="Sleeve">
+    <PosPart copyNumber="1">
+      <rParent name="PixelForwardNippleZPlus"/>
+      <rChild name="PixelForwardNippleSleeve"/>
+      <Translation x="0." y="0." z="-[JK]/2 + [L02] - [L06] + [L04]/2"/>
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="PixelForwardNippleZMinus"/>
+      <rChild name="PixelForwardNippleSleeve"/>
+      <Translation x="0." y="0." z="-[JK]/2 + [L02] - [L06] + [L04]/2"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="PixelForwardNippleSleeve"/>
+      <rChild name="PixelForwardNippleEpoxyCover"/>
+      <Translation x="0." y="0." z="-[L04]/2 + [L06]/2"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="PixelForwardNippleSleeve"/>
+      <rChild name="PixelForwardNippleEpoxyBody"/>
+      <Translation x="0." y="0." z="[L04]/2 - [L05]/2"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="PixelForwardNippleSleeve"/>
+      <rChild name="PixelForwardNippleSleeveCoolant"/>
+    </PosPart>
+  </PosPartSection>
+  <!-- Cover side : -->
+  <ConstantsSection label="Cover" eval="true">
+    <Constant name="e02" value="([L02]-[L06])/2"/>
+    <!-- Half length of cover side -->
+  </ConstantsSection>
+  <SolidSection label="Cover">
+    <Tubs name="PixelForwardNippleCover_01" rMin="0.*mm" rMax="[R05]" dz="[e02]" startPhi="0." deltaPhi="360*deg"/>
+    <Tubs name="PixelForwardNippleCoverCoolant_01" rMin="0.*mm" rMax="[R04]" dz="[e02]" startPhi="0." deltaPhi="360*deg"/>
+    <SubtractionSolid name="PixelForwardNippleCoverZPlus">
+      <rSolid name="PixelForwardNippleCover_01"/>
+      <rSolid name="PixelForwardNippleSubtract"/>
+      <Translation x="0." y="0." z="-[e02]-[DeltaCover]"/>
+      <rRotation name="NippleToCoverZPlus"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="PixelForwardNippleCoverCoolantZPlus">
+      <rSolid name="PixelForwardNippleCoverCoolant_01"/>
+      <rSolid name="PixelForwardNippleSubtract"/>
+      <Translation x="0." y="0." z="-[e02]-[DeltaCover]"/>
+      <rRotation name="NippleToCoverZPlus"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="PixelForwardNippleCoverZMinus">
+      <rSolid name="PixelForwardNippleCover_01"/>
+      <rSolid name="PixelForwardNippleSubtract"/>
+      <Translation x="0." y="0." z="-[e02]-[DeltaCover]"/>
+      <rRotation name="NippleToCoverZMinus"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="PixelForwardNippleCoverCoolantZMinus">
+      <rSolid name="PixelForwardNippleCoverCoolant_01"/>
+      <rSolid name="PixelForwardNippleSubtract"/>
+      <Translation x="0." y="0." z="-[e02]-[DeltaCover]"/>
+      <rRotation name="NippleToCoverZMinus"/>
+    </SubtractionSolid>
+  </SolidSection>
+  <LogicalPartSection label="Cover">
+    <LogicalPart name="PixelForwardNippleCoverZPlus" category="cooling">
+      <rSolid name="PixelForwardNippleCoverZPlus"/>
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </LogicalPart>
+    <LogicalPart name="PixelForwardNippleCoverCoolantZPlus" category="cooling">
+      <rSolid name="PixelForwardNippleCoverCoolantZPlus"/>
+      <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+    </LogicalPart>
+    <LogicalPart name="PixelForwardNippleCoverZMinus" category="cooling">
+      <rSolid name="PixelForwardNippleCoverZMinus"/>
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </LogicalPart>
+    <LogicalPart name="PixelForwardNippleCoverCoolantZMinus" category="cooling">
+      <rSolid name="PixelForwardNippleCoverCoolantZMinus"/>
+      <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+    </LogicalPart>
+  </LogicalPartSection>
+  <PosPartSection label="Cover">
+    <PosPart copyNumber="1">
+      <rParent name="PixelForwardNippleZPlus"/>
+      <rChild name="PixelForwardNippleCoverZPlus"/>
+      <Translation x="0." y="0." z="-[JK]/2 + [e02]"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="PixelForwardNippleCoverZPlus"/>
+      <rChild name="PixelForwardNippleCoverCoolantZPlus"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="PixelForwardNippleZMinus"/>
+      <rChild name="PixelForwardNippleCoverZMinus"/>
+      <Translation x="0." y="0." z="-[JK]/2 + [e02]"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="PixelForwardNippleCoverZMinus"/>
+      <rChild name="PixelForwardNippleCoverCoolantZMinus"/>
+    </PosPart>
+  </PosPartSection>
+  <!-- Body side : -->
+  <ConstantsSection label="Body" eval="true">
+    <Constant name="e03" value="([JK]-[e02]*2-[L04])/2"/>
+    <!--Half length of body side -->
+  </ConstantsSection>
+  <SolidSection label="Body">
+    <Tubs name="PixelForwardNippleBody_01" rMin="0.*mm" rMax="[R02]" dz="[e03]" startPhi="0." deltaPhi="360*deg"/>
+    <Tubs name="PixelForwardNippleBodyCoolant_01" rMin="0.*mm" rMax="[R01]" dz="[e03]" startPhi="0." deltaPhi="360*deg"/>
+    <SubtractionSolid name="PixelForwardNippleBodyZPlus">
+      <rSolid name="PixelForwardNippleBody_01"/>
+      <rSolid name="PixelForwardNippleSubtract"/>
+      <Translation x="0." y="0." z="[e03]+[DeltaBody]"/>
+      <rRotation name="NippleToBodyZPlus"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="PixelForwardNippleBodyCoolantZPlus">
+      <rSolid name="PixelForwardNippleBodyCoolant_01"/>
+      <rSolid name="PixelForwardNippleSubtract"/>
+      <Translation x="0." y="0." z="[e03]+[DeltaBody]"/>
+      <rRotation name="NippleToBodyZPlus"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="PixelForwardNippleBodyZMinus">
+      <rSolid name="PixelForwardNippleBody_01"/>
+      <rSolid name="PixelForwardNippleSubtract"/>
+      <Translation x="0." y="0." z="[e03]+[DeltaBody]"/>
+      <rRotation name="NippleToBodyZMinus"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="PixelForwardNippleBodyCoolantZMinus">
+      <rSolid name="PixelForwardNippleBodyCoolant_01"/>
+      <rSolid name="PixelForwardNippleSubtract"/>
+      <Translation x="0." y="0." z="[e03]+[DeltaBody]"/>
+      <rRotation name="NippleToBodyZMinus"/>
+    </SubtractionSolid>
+  </SolidSection>
+  <LogicalPartSection label="Body">
+    <LogicalPart name="PixelForwardNippleBodyZPlus" category="cooling">
+      <rSolid name="PixelForwardNippleBodyZPlus"/>
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </LogicalPart>
+    <LogicalPart name="PixelForwardNippleBodyCoolantZPlus" category="cooling">
+      <rSolid name="PixelForwardNippleBodyCoolantZPlus"/>
+      <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+    </LogicalPart>
+    <LogicalPart name="PixelForwardNippleBodyZMinus" category="cooling">
+      <rSolid name="PixelForwardNippleBodyZMinus"/>
+      <rMaterial name="trackermaterial:T_Aluminium"/>
+    </LogicalPart>
+    <LogicalPart name="PixelForwardNippleBodyCoolantZMinus" category="cooling">
+      <rSolid name="PixelForwardNippleBodyCoolantZMinus"/>
+      <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+    </LogicalPart>
+  </LogicalPartSection>
+  <PosPartSection label="BodyPlus">
+    <PosPart copyNumber="1">
+      <rParent name="PixelForwardNippleZPlus"/>
+      <rChild name="PixelForwardNippleBodyZPlus"/>
+      <Translation x="0." y="0." z="[JK]/2 - [e03]"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="PixelForwardNippleBodyZPlus"/>
+      <rChild name="PixelForwardNippleBodyCoolantZPlus"/>
+    </PosPart>
+  </PosPartSection>
+  <PosPartSection label="BodyMinus">
+    <PosPart copyNumber="1">
+      <rParent name="PixelForwardNippleZMinus"/>
+      <rChild name="PixelForwardNippleBodyZMinus"/>
+      <Translation x="0." y="0." z="[JK]/2 - [e03]"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="PixelForwardNippleBodyZMinus"/>
+      <rChild name="PixelForwardNippleBodyCoolantZMinus"/>
+    </PosPart>
+  </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdPanel.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdPanel.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Dmitry Onoprienko
+         @modified Vesna Cuplov (to Fix overlaps 04.17.07)
+         
+         == Subsystem or component described by the file ==
+         
+         A panel that includes a base and three or four sensor plaquettes mounted on it.
+         Every blade will have two such panels, one on each side.
+         
+         == Root volume and its reference frame ==
+         
+         Four types of panels are defined :
+         
+         PixelForwardPanel3Right - right 3-plaquette panel (3RX on the drawings)
+         PixelForwardPanel3Left  - left 3-plaquette panel (3LX on the drawings)
+         PixelForwardPanel4Right - right 4-plaquette panel (4RX on the drawings)
+         PixelForwardPanel4Left  - left 3-plaquette panel (4LX on the drawings)
+         
+         Y is along the axis of the panel, points from narrow to wide end.
+         X is in the plane of the panel, ear is on X-positive side for "right" panels.
+         Z is perpendicular to the plane of the panel, points to plaquettes side.
+         
+         == Positioning ==
+         
+         The file defines AnchorX, AnchorY, and AnchorZ 
+         constants that describe the coordinates of the anchor point in the panel 
+         root volume (PixelForwardPanelXXX) reference frame.
+         Currently, [AnchorX] = [AnchorZ] = 0.
+         
+         -->
+    <ConstantsSection label="Input" eval="true">
+        <!-- Y-coordinates of active centers of sensors with respect to ancor point ((0.,0.) on the drawing) -->
+        <Constant name="ACp3y1" value="19.469*mm"/>
+        <Constant name="ACp3y2" value="48.777*mm"/>
+        <Constant name="ACp3y3" value="78.091*mm"/>
+        <Constant name="ACp4y1" value="7.664*mm"/>
+        <Constant name="ACp4y2" value="32.394*mm"/>
+        <Constant name="ACp4y3" value="61.128*mm"/>
+        <Constant name="ACp4y4" value="85.869*mm"/>
+    </ConstantsSection>
+    <ConstantsSection label="Common" eval="true">
+        <Constant name="RootHalfWidth" value="[pixfwdPanelBase:RootHalfWidth]"/>
+        <Constant name="RootHalfLength" value="[pixfwdPanelBase:RootHalfLength]"/>
+        <Constant name="RootHalfThickness" value="[pixfwdPlaq:PlaquetteT]/2.+[pixfwdPanelBase:RootHalfThickness]"/>
+        <Constant name="zPanel" value="-[pixfwdPlaq:PlaquetteT]/2."/>
+        <Constant name="zPlaquette" value="[pixfwdPanelBase:RootHalfThickness]"/>
+        <!-- Coordinates of the ancor point ((0.,0.) on the drawing) in the Root (PixelForwardPanel<ХХХ>) frame -->
+        <Constant name="AnchorX" value="0.*mm"/>
+        <Constant name="AnchorY" value="[pixfwdPanelBase:AnchorY]"/>
+        <Constant name="AnchorZ" value="0.*mm"/>
+        <Constant name="EarWidth" value="[pixfwdPanelBase:EarWidth]"/>
+        <Constant name="EarLength" value="[pixfwdPanelBase:EarLength]"/>
+        <Constant name="MainHalfWidthBottom" value="[pixfwdPanelBase:MainHalfWidthBottom]"/>
+        <Constant name="MainHalfWidthTop" value="[pixfwdPanelBase:MainHalfWidthTop]"/>
+        <Constant name="PanelAngle" value="[pixfwdPanelBase:PanelAngle]"/>
+        <Constant name="MainLength" value="[pixfwdPanelBase:]MainLength"/>
+        <Constant name="NoseLength" value="[pixfwdPanelBase:]NoseLength"/>
+    </ConstantsSection>
+    <!-- Root volumes for 4 types panels -->
+    <!-- previous description (D. Onoprienko)
+         <SolidSection label="Root">
+         <Box name="PixelForwardPanel" dx="[RootHalfWidth]" dy="[RootHalfLength]" dz="[RootHalfThickness]" />
+    </SolidSection>
+         -->
+    <!-- New description (april 2007): As for the PanelBase, I used a trapezoid for the main panel volume and a second trapezoid for the part made of the ear -->
+    <SolidSection label="Root">
+        <Trapezoid name="PixelForwardPanelMain" dz="[RootHalfThickness]" bl1="[MainHalfWidthBottom]+4.0*mm" bl2="[MainHalfWidthBottom]+4.0*mm" tl1="[MainHalfWidthTop]+4.0*mm" tl2="[MainHalfWidthTop]+4.0*mm" h1="[MainLength]/2.+[NoseLength]/2." h2="[MainLength]/2.+[NoseLength]/2." alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelEar" dz="[RootHalfThickness]" bl1="[MainHalfWidthBottom]+[EarWidth]/2.+12.0*mm" bl2="[MainHalfWidthBottom]+[EarWidth]/2.+12.0*mm" tl1="[MainHalfWidthTop]+[EarWidth]/2.+4.0*mm" tl2="[MainHalfWidthTop]+[EarWidth]/2.+4.0*mm" h1="[EarLength]/2.+3.0*mm" h2="[EarLength]/2.+3.0*mm" alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <UnionSolid name="PixelForwardPanel">
+            <rSolid name="PixelForwardPanelMain"/>
+            <rSolid name="PixelForwardPanelEar"/>
+            <Translation x="0." y="29.0" z="0."/>
+        </UnionSolid>
+    </SolidSection>
+    <LogicalPartSection label="Root">
+        <LogicalPart name="PixelForwardPanel3Right" category="envelope">
+            <rSolid name="PixelForwardPanel"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPanel3Left" category="envelope">
+            <rSolid name="PixelForwardPanel"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPanel4Right" category="envelope">
+            <rSolid name="PixelForwardPanel"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPanel4Left" category="envelope">
+            <rSolid name="PixelForwardPanel"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="Root">
+        <!-- Panel 3 Right -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanel3Right"/>
+            <rChild name="pixfwdPanelBase:PixelForwardPanelBase"/>
+            <Translation x="0." y="0." z="[zPanel]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanel3Right"/>
+            <rChild name="pixfwdPlaq2x3:PixelForwardPlaquette2x3Up"/>
+            <Translation x="[AnchorX]-[pixfwdPlaq2x3:AnchorX]" y="[AnchorY]+[ACp3y1]-[pixfwdPlaq2x3:AnchorY]" z="[zPlaquette]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanel3Right"/>
+            <rChild name="pixfwdPlaq2x4:PixelForwardPlaquette2x4Up"/>
+            <Translation x="[AnchorX]-[pixfwdPlaq2x4:AnchorX]" y="[AnchorY]+[ACp3y2]-[pixfwdPlaq2x4:AnchorY]" z="[zPlaquette]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanel3Right"/>
+            <rChild name="pixfwdPlaq2x5:PixelForwardPlaquette2x5Up"/>
+            <Translation x="[AnchorX]-[pixfwdPlaq2x5:AnchorX]" y="[AnchorY]+[ACp3y3]-[pixfwdPlaq2x5:AnchorY]" z="[zPlaquette]"/>
+        </PosPart>
+        <!-- Panel 3 Left -->
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPanel3Left"/>
+            <rChild name="pixfwdPanelBase:PixelForwardPanelBase"/>
+            <Translation x="0." y="0." z="[zPanel]"/>
+            <rReflectionRotation name="pixfwdCommon:ReflectionX"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanel3Left"/>
+            <rChild name="pixfwdPlaq2x3:PixelForwardPlaquette2x3Down"/>
+            <Translation x="[AnchorX]+[pixfwdPlaq2x3:AnchorX]" y="[AnchorY]+[ACp3y1]+[pixfwdPlaq2x3:AnchorY]" z="[zPlaquette]"/>
+            <rRotation name="pixfwdCommon:Z180"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanel3Left"/>
+            <rChild name="pixfwdPlaq2x4:PixelForwardPlaquette2x4Down"/>
+            <Translation x="[AnchorX]+[pixfwdPlaq2x4:AnchorX]" y="[AnchorY]+[ACp3y2]+[pixfwdPlaq2x4:AnchorY]" z="[zPlaquette]"/>
+            <rRotation name="pixfwdCommon:Z180"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanel3Left"/>
+            <rChild name="pixfwdPlaq2x5:PixelForwardPlaquette2x5Down"/>
+            <Translation x="[AnchorX]+[pixfwdPlaq2x5:AnchorX]" y="[AnchorY]+[ACp3y3]+[pixfwdPlaq2x5:AnchorY]" z="[zPlaquette]"/>
+            <rRotation name="pixfwdCommon:Z180"/>
+        </PosPart>
+        <!-- Panel 4 Right -->
+        <PosPart copyNumber="3">
+            <rParent name="PixelForwardPanel4Right"/>
+            <rChild name="pixfwdPanelBase:PixelForwardPanelBase"/>
+            <Translation x="0." y="0." z="[zPanel]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanel4Right"/>
+            <rChild name="pixfwdPlaq1x2:PixelForwardPlaquette1x2Right"/>
+            <Translation x="[AnchorX]-[pixfwdPlaq1x2:AnchorXRight]" y="[AnchorY]+[ACp4y1]-[pixfwdPlaq1x2:AnchorY]" z="[zPlaquette]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPanel4Right"/>
+            <rChild name="pixfwdPlaq2x3:PixelForwardPlaquette2x3Down"/>
+            <Translation x="[AnchorX]-[pixfwdPlaq2x3:AnchorX]" y="[AnchorY]+[ACp4y2]-[pixfwdPlaq2x3:AnchorY]" z="[zPlaquette]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPanel4Right"/>
+            <rChild name="pixfwdPlaq2x4:PixelForwardPlaquette2x4Down"/>
+            <Translation x="[AnchorX]-[pixfwdPlaq2x4:AnchorX]" y="[AnchorY]+[ACp4y3]-[pixfwdPlaq2x4:AnchorY]" z="[zPlaquette]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanel4Right"/>
+            <rChild name="pixfwdPlaq1x5:PixelForwardPlaquette1x5Left"/>
+            <Translation x="[AnchorX]-[pixfwdPlaq1x5:AnchorXLeft]" y="[AnchorY]+[ACp4y4]-[pixfwdPlaq1x5:AnchorY]" z="[zPlaquette]"/>
+        </PosPart>
+        <!-- Panel 4 Left -->
+        <PosPart copyNumber="4">
+            <rParent name="PixelForwardPanel4Left"/>
+            <rChild name="pixfwdPanelBase:PixelForwardPanelBase"/>
+            <Translation x="0." y="0." z="[zPanel]"/>
+            <rReflectionRotation name="pixfwdCommon:ReflectionX"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanel4Left"/>
+            <rChild name="pixfwdPlaq1x2:PixelForwardPlaquette1x2Left"/>
+            <Translation x="[AnchorX]-[pixfwdPlaq1x2:AnchorXLeft]" y="[AnchorY]+[ACp4y1]-[pixfwdPlaq1x2:AnchorY]" z="[zPlaquette]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPanel4Left"/>
+            <rChild name="pixfwdPlaq2x3:PixelForwardPlaquette2x3Up"/>
+            <Translation x="[AnchorX]+[pixfwdPlaq2x3:AnchorX]" y="[AnchorY]+[ACp4y2]+[pixfwdPlaq2x3:AnchorY]" z="[zPlaquette]"/>
+            <rRotation name="pixfwdCommon:Z180"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPanel4Left"/>
+            <rChild name="pixfwdPlaq2x4:PixelForwardPlaquette2x4Up"/>
+            <Translation x="[AnchorX]+[pixfwdPlaq2x4:AnchorX]" y="[AnchorY]+[ACp4y3]+[pixfwdPlaq2x4:AnchorY]" z="[zPlaquette]"/>
+            <rRotation name="pixfwdCommon:Z180"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanel4Left"/>
+            <rChild name="pixfwdPlaq1x5:PixelForwardPlaquette1x5Right"/>
+            <Translation x="[AnchorX]-[pixfwdPlaq1x5:AnchorXRight]" y="[AnchorY]+[ACp4y4]-[pixfwdPlaq1x5:AnchorY]" z="[zPlaquette]"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdPanelBase.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdPanelBase.xml
@@ -1,0 +1,301 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Victoria Martin
+         @modified Dmitry Onoprienko
+         @modified Vesna Cuplov (fixing overlaps in panels 04.17.07)
+         
+         == Subsystem or component described by the file ==
+         
+         Beryllium panel with HDI (no plaquettes).
+         
+         == Root volume and its reference frame ==
+         
+         Root volume : PixelForwardPanelBase
+         
+         Y is along the axis of the panel, points from narrow to wide end
+         X is in the plane of the panel, ear is on X-positive side
+         Z is perpendicular to the panel, points to VHDI side.
+         
+         == Positioning ==
+         
+         The file defines AnchorX, AnchorY, and AnchorZ
+         constants that describe the coordinates of the anchor point in the panel base
+         root volume (PixelForwardPanelBase) reference frame.
+         Currently, [AnchorX] = [AnchorZ] = 0.
+         
+         -->
+    <ConstantsSection label="Input" eval="true">
+        <!-- These constants are taken from the design drawings of 3-R Panel dated 14 Oct 05
+             X and Y here correspond to Y and -X on the drawing -->
+        <Constant name="Y1" value="-1.500*mm"/>
+        <Constant name="Y2" value="3.071*mm"/>
+        <Constant name="Y3" value="4.196*mm"/>
+        <Constant name="Y4" value="55.452*mm"/>
+        <Constant name="Y5" value="62.390*mm"/>
+        <Constant name="Y6" value="62.420*mm"/>
+        <Constant name="Y7" value="87.440*mm"/>
+        <Constant name="Y8" value="86.713*mm"/>
+        <Constant name="Y9" value="92.417*mm"/>
+        <Constant name="Y10" value="94.500*mm"/>
+        <Constant name="Y11" value="96.250*mm"/>
+        <Constant name="Y12" value="102.000*mm"/>
+        <Constant name="X1" value="-26.293*mm"/>
+        <Constant name="X2" value="-23.000*mm"/>
+        <Constant name="X3" value="-15.059*mm"/>
+        <Constant name="X4" value="2.500*mm"/>
+        <Constant name="X5" value="7.500*mm"/>
+        <Constant name="X6" value="10.095*mm"/>
+        <Constant name="X7" value="10.895*mm"/>
+        <Constant name="X8" value="18.150*mm"/>
+        <Constant name="X9" value="26.100*mm"/>
+        <Constant name="X10" value="34.376*mm"/>
+        <Constant name="BeThickness" value="0.508*mm"/>
+        <Constant name="HDIThickness" value="0.191*mm"/>
+        <Constant name="FilmThickness" value="0.051*mm"/>
+        <Constant name="TanPanelAngle" value="([X3]-[X1])/([Y8]-[Y2])"/>
+        <Constant name="PanelAngle" value="atan([TanPanelAngle])"/>
+    </ConstantsSection>
+    <ConstantsSection label="Common" eval="true">
+        <Constant name="RootHalfThickness" value="([BeThickness]+[HDIThickness]+[FilmThickness])/2."/>
+        <Constant name="RootHalfLength" value="([Y9]-[Y1])/2."/>
+        <Constant name="RootHalfWidth" value="[X10]"/>
+        <!-- Coordinates of the anchor point ((0.,0.) on the drawing) in the Root (PixelForwardPanelBase) frame -->
+        <Constant name="AnchorX" value="0.*mm"/>
+        <Constant name="AnchorY" value="-[RootHalfLength]-[Y1]"/>
+        <Constant name="AnchorZ" value="0.*mm"/>
+        <!-- Z-positions of layers -->
+        <Constant name="zBe" value="-([HDIThickness]+[FilmThickness])/2."/>
+        <Constant name="zFilm" value="([BeThickness]-[HDIThickness])/2."/>
+        <Constant name="zHDI" value="([BeThickness]+[FilmThickness])/2."/>
+        <Constant name="EarWidth" value="[X10]+[X3]-([Y7]-[Y2])*[TanPanelAngle]"/>
+        <Constant name="EarLength" value="[Y7]-[Y6]"/>
+    </ConstantsSection>
+    <!-- Root volume for the panel and its layers (Be, Film, HDI) -->
+    <!--previous description (D. Onoprienko)
+         <SolidSection label="Root">
+         <Box name="PixelForwardPanelBase" dx="[RootHalfWidth]" dy="[RootHalfLength]" dz="[RootHalfThickness]" />
+         <Box name="PixelForwardPanelBaseBe"   dx="[RootHalfWidth]" dy="[RootHalfLength]" dz="[BeThickness]/2." />
+         <Box name="PixelForwardPanelBaseFilm" dx="[RootHalfWidth]" dy="[RootHalfLength]" dz="[FilmThickness]/2." />
+         <Box name="PixelForwardPanelBaseHDI"  dx="[RootHalfWidth]" dy="[RootHalfLength]" dz="[HDIThickness]/2." />
+    </SolidSection>
+         -->
+    <!-- New Description (april 2007): I used a Trapezoid for the main part of the panel and added a trapezoid for the part made of the panel ear -->
+    <SolidSection label="Root">
+        <Trapezoid name="PixelForwardPanelBaseMain" dz="[RootHalfThickness]" bl1="[MainHalfWidthBottom]+4.0*mm" bl2="[MainHalfWidthBottom]+4.0*mm" tl1="[MainHalfWidthTop]+4.0*mm" tl2="[MainHalfWidthTop]+4.0*mm" h1="[MainLength]/2.+[NoseLength]/2." h2="[MainLength]/2.+[NoseLength]/2." alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelBaseEar" dz="[RootHalfThickness]" bl1="[MainHalfWidthBottom]+[EarWidth]/2.+12.0*mm" bl2="[MainHalfWidthBottom]+[EarWidth]/2.+12.0*mm" tl1="[MainHalfWidthTop]+[EarWidth]/2.+4.0*mm" tl2="[MainHalfWidthTop]+[EarWidth]/2.+4.0*mm" h1="[EarLength]/2.+3.0*mm" h2="[EarLength]/2.+3.0*mm" alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <UnionSolid name="PixelForwardPanelBase">
+            <rSolid name="PixelForwardPanelBaseMain"/>
+            <rSolid name="PixelForwardPanelBaseEar"/>
+            <Translation x="0." y="29.0" z="0."/>
+        </UnionSolid>
+        <Trapezoid name="PixelForwardPanelBaseBeMain" dz="[BeThickness]/2." bl1="[MainHalfWidthBottom]+4.0*mm" bl2="[MainHalfWidthBottom]+4.0*mm" tl1="[MainHalfWidthTop]+4.0*mm" tl2="[MainHalfWidthTop]+4.0*mm" h1="[MainLength]/2.+[NoseLength]/2." h2="[MainLength]/2.+[NoseLength]/2." alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelBaseBeEar" dz="[BeThickness]/2." bl1="[MainHalfWidthBottom]+[EarWidth]/2.+12.0*mm" bl2="[MainHalfWidthBottom]+[EarWidth]/2.+12.0*mm" tl1="[MainHalfWidthTop]+[EarWidth]/2.+4.0*mm" tl2="[MainHalfWidthTop]+[EarWidth]/2.+4.0*mm" h1="[EarLength]/2.+3.0*mm" h2="[EarLength]/2.+3.0*mm" alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <UnionSolid name="PixelForwardPanelBaseBe">
+            <rSolid name="PixelForwardPanelBaseBeMain"/>
+            <rSolid name="PixelForwardPanelBaseBeEar"/>
+            <Translation x="0." y="29.0" z="0."/>
+        </UnionSolid>
+        <Trapezoid name="PixelForwardPanelBaseFilmMain" dz="[FilmThickness]/2." bl1="[MainHalfWidthBottom]+4.0*mm" bl2="[MainHalfWidthBottom]+4.0*mm" tl1="[MainHalfWidthTop]+4.0*mm" tl2="[MainHalfWidthTop]+4.0*mm" h1="[MainLength]/2.+[NoseLength]/2." h2="[MainLength]/2.+[NoseLength]/2." alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelBaseFilmEar" dz="[FilmThickness]/2." bl1="[MainHalfWidthBottom]+[EarWidth]/2.+12.0*mm" bl2="[MainHalfWidthBottom]+[EarWidth]/2.+12.0*mm" tl1="[MainHalfWidthTop]+[EarWidth]/2.+4.0*mm" tl2="[MainHalfWidthTop]+[EarWidth]/2.+4.0*mm" h1="[EarLength]/2.+3.0*mm" h2="[EarLength]/2.+3.0*mm" alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <UnionSolid name="PixelForwardPanelBaseFilm">
+            <rSolid name="PixelForwardPanelBaseFilmMain"/>
+            <rSolid name="PixelForwardPanelBaseFilmEar"/>
+            <Translation x="0." y="29.0" z="0."/>
+        </UnionSolid>
+        <Trapezoid name="PixelForwardPanelBaseHDIMain" dz="[HDIThickness]/2." bl1="[MainHalfWidthBottom]+4.0*mm" bl2="[MainHalfWidthBottom]+4.0*mm" tl1="[MainHalfWidthTop]+4.0*mm" tl2="[MainHalfWidthTop]+4.0*mm" h1="[MainLength]/2.+[NoseLength]/2." h2="[MainLength]/2.+[NoseLength]/2." alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelBaseHDIEar" dz="[HDIThickness]/2." bl1="[MainHalfWidthBottom]+[EarWidth]/2.+12.0*mm" bl2="[MainHalfWidthBottom]+[EarWidth]/2.+12.0*mm" tl1="[MainHalfWidthTop]+[EarWidth]/2.+4.0*mm" tl2="[MainHalfWidthTop]+[EarWidth]/2.+4.0*mm" h1="[EarLength]/2.+3.0*mm" h2="[EarLength]/2.+3.0*mm" alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <UnionSolid name="PixelForwardPanelBaseHDI">
+            <rSolid name="PixelForwardPanelBaseHDIMain"/>
+            <rSolid name="PixelForwardPanelBaseHDIEar"/>
+            <Translation x="0." y="29.0" z="0."/>
+        </UnionSolid>
+    </SolidSection>
+    <LogicalPartSection label="Root">
+        <LogicalPart name="PixelForwardPanelBase" category="envelope">
+            <rSolid name="PixelForwardPanelBase"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPanelBaseBe" category="envelope">
+            <rSolid name="PixelForwardPanelBaseBe"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPanelBaseFilm" category="envelope">
+            <rSolid name="PixelForwardPanelBaseFilm"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPanelBaseHDI" category="envelope">
+            <rSolid name="PixelForwardPanelBaseHDI"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="Root">
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanelBase"/>
+            <rChild name="PixelForwardPanelBaseBe"/>
+            <Translation x="0." y="0." z="[zBe]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanelBase"/>
+            <rChild name="PixelForwardPanelBaseFilm"/>
+            <Translation x="0." y="0." z="[zFilm]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanelBase"/>
+            <rChild name="PixelForwardPanelBaseHDI"/>
+            <Translation x="0." y="0." z="[zHDI]"/>
+        </PosPart>
+    </PosPartSection>
+    <ConstantsSection label="Parts" eval="true">
+        <!-- Shapes -->
+        <Constant name="TanNoseAngle" value="([Y3]-[Y1])/([X8]-[X4])"/>
+        <Constant name="NoseAngle" value="atan([TanNoseAngle])"/>
+        <Constant name="MainLength" value="([Y9]-[Y2])"/>
+        <Constant name="MainHalfWidthBottom" value="-[X3]"/>
+        <Constant name="MainHalfWidthTop" value="-[X3]+[MainLength]*[TanPanelAngle]"/>
+        <Constant name="NoseLength" value="([Y2]-[Y1])"/>
+        <Constant name="NoseHalfWidthBottom" value="[X4]"/>
+        <Constant name="NoseHalfWidthTop" value="-[X3]"/>
+        <Constant name="ExtentionWidth" value="[X8]+[X3]-([Y3]-[Y2])*[TanPanelAngle]"/>
+        <Constant name="ExtentionHeight" value="[ExtentionWidth]*cos([PanelAngle])"/>
+        <Constant name="ExtentionSide" value="([Y6]-[Y2])/cos([PanelAngle])"/>
+        <!-- Positioning -->
+        <Constant name="earY" value="[Y6]+[EarLength]/2."/>
+        <Constant name="earX" value="-[X3]+([earY]-[Y2])*[TanPanelAngle]+[EarWidth]/2."/>
+        <Constant name="extentionX" value="(-[EarWidth]-([Y7]-[Y2])*[TanPanelAngle]+([X8]+[X3]))/2."/>
+        <Constant name="extentionY" value="(-[Y7]+[Y3])/2."/>
+    </ConstantsSection>
+    <RotationSection label="Parts">
+        <Rotation name="ExtentionRot" phiX="90.*deg-[PanelAngle]" thetaX="90.*deg" phiY="180.*deg-[PanelAngle]" thetaY="90.*deg" phiZ="0." thetaZ="0."/>
+    </RotationSection>
+    <SolidSection label="Parts">
+        <!-- Beryllium -->
+        <Trapezoid name="PixelForwardPanelBaseMainBe" dz="[BeThickness]/2." bl1="[MainHalfWidthBottom]" bl2="[MainHalfWidthBottom]" tl1="[MainHalfWidthTop]" tl2="[MainHalfWidthTop]" h1="[MainLength]/2." h2="[MainLength]/2." alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelBaseNoseBe" dz="[BeThickness]/2." bl1="[NoseHalfWidthBottom]" bl2="[NoseHalfWidthBottom]" tl1="[NoseHalfWidthTop]" tl2="[NoseHalfWidthTop]" h1="[NoseLength]/2." h2="[NoseLength]/2." alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelBaseEarBe_01" dz="[BeThickness]/2." bl1="[EarWidth]/2." bl2="[EarWidth]/2." tl1="[EarWidth]/2." tl2="[EarWidth]/2." h1="[EarLength]/2." h2="[EarLength]/2." alp1="[PanelAngle]" alp2="[PanelAngle]" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelBaseExtentionBe" dz="[BeThickness]/2." bl1="[ExtentionSide]/2." bl2="[ExtentionSide]/2." tl1="[ExtentionSide]/2." tl2="[ExtentionSide]/2." h1="[ExtentionHeight]/2." h2="[ExtentionHeight]/2." alp1="-[NoseAngle]" alp2="-[NoseAngle]" phi="90*deg"/>
+        <UnionSolid name="PixelForwardPanelBaseEarBe">
+            <rSolid name="PixelForwardPanelBaseEarBe_01"/>
+            <rSolid name="PixelForwardPanelBaseExtentionBe"/>
+            <Translation x="[extentionX]" y="[extentionY]" z="0."/>
+            <rRotation name="ExtentionRot"/>
+        </UnionSolid>
+        <!-- Film -->
+        <Trapezoid name="PixelForwardPanelBaseMainFilm" dz="[FilmThickness]/2." bl1="[MainHalfWidthBottom]" bl2="[MainHalfWidthBottom]" tl1="[MainHalfWidthTop]" tl2="[MainHalfWidthTop]" h1="[MainLength]/2." h2="[MainLength]/2." alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelBaseNoseFilm" dz="[FilmThickness]/2." bl1="[NoseHalfWidthBottom]" bl2="[NoseHalfWidthBottom]" tl1="[NoseHalfWidthTop]" tl2="[NoseHalfWidthTop]" h1="[NoseLength]/2." h2="[NoseLength]/2." alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelBaseEarFilm_01" dz="[FilmThickness]/2." bl1="[EarWidth]/2." bl2="[EarWidth]/2." tl1="[EarWidth]/2." tl2="[EarWidth]/2." h1="[EarLength]/2." h2="[EarLength]/2." alp1="[PanelAngle]" alp2="[PanelAngle]" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelBaseExtentionFilm" dz="[FilmThickness]/2." bl1="[ExtentionSide]/2." bl2="[ExtentionSide]/2." tl1="[ExtentionSide]/2." tl2="[ExtentionSide]/2." h1="[ExtentionHeight]/2." h2="[ExtentionHeight]/2." alp1="-[NoseAngle]" alp2="-[NoseAngle]" phi="90*deg"/>
+        <UnionSolid name="PixelForwardPanelBaseEarFilm">
+            <rSolid name="PixelForwardPanelBaseEarFilm_01"/>
+            <rSolid name="PixelForwardPanelBaseExtentionFilm"/>
+            <Translation x="[extentionX]" y="[extentionY]" z="0."/>
+            <rRotation name="ExtentionRot"/>
+        </UnionSolid>
+        <!-- HDI -->
+        <Trapezoid name="PixelForwardPanelBaseMainHDI" dz="[HDIThickness]/2." bl1="[MainHalfWidthBottom]" bl2="[MainHalfWidthBottom]" tl1="[MainHalfWidthTop]" tl2="[MainHalfWidthTop]" h1="[MainLength]/2." h2="[MainLength]/2." alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelBaseNoseHDI" dz="[HDIThickness]/2." bl1="[NoseHalfWidthBottom]" bl2="[NoseHalfWidthBottom]" tl1="[NoseHalfWidthTop]" tl2="[NoseHalfWidthTop]" h1="[NoseLength]/2." h2="[NoseLength]/2." alp1="0.0" alp2="0.0" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelBaseEarHDI_01" dz="[HDIThickness]/2." bl1="[EarWidth]/2." bl2="[EarWidth]/2." tl1="[EarWidth]/2." tl2="[EarWidth]/2." h1="[EarLength]/2." h2="[EarLength]/2." alp1="[PanelAngle]" alp2="[PanelAngle]" phi="90*deg"/>
+        <Trapezoid name="PixelForwardPanelBaseExtentionHDI" dz="[HDIThickness]/2." bl1="[ExtentionSide]/2." bl2="[ExtentionSide]/2." tl1="[ExtentionSide]/2." tl2="[ExtentionSide]/2." h1="[ExtentionHeight]/2." h2="[ExtentionHeight]/2." alp1="-[NoseAngle]" alp2="-[NoseAngle]" phi="90*deg"/>
+        <UnionSolid name="PixelForwardPanelBaseEarHDI">
+            <rSolid name="PixelForwardPanelBaseEarHDI_01"/>
+            <rSolid name="PixelForwardPanelBaseExtentionHDI"/>
+            <Translation x="[extentionX]" y="[extentionY]" z="0."/>
+            <rRotation name="ExtentionRot"/>
+        </UnionSolid>
+    </SolidSection>
+    <LogicalPartSection label="Parts">
+        <!-- Beryllium -->
+        <LogicalPart name="PixelForwardPanelBaseMainBe" category="support">
+            <rSolid name="PixelForwardPanelBaseMainBe"/>
+            <rMaterial name="trackermaterial:T_Beryllium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPanelBaseNoseBe" category="support">
+            <rSolid name="PixelForwardPanelBaseNoseBe"/>
+            <rMaterial name="trackermaterial:T_Beryllium"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPanelBaseEarBe" category="support">
+            <rSolid name="PixelForwardPanelBaseEarBe"/>
+            <rMaterial name="trackermaterial:T_Beryllium"/>
+        </LogicalPart>
+        <!-- Film -->
+        <LogicalPart name="PixelForwardPanelBaseMainFilm" category="support">
+            <rSolid name="PixelForwardPanelBaseMainFilm"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AdhFilm"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPanelBaseNoseFilm" category="support">
+            <rSolid name="PixelForwardPanelBaseNoseFilm"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AdhFilm"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPanelBaseEarFilm" category="support">
+            <rSolid name="PixelForwardPanelBaseEarFilm"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AdhFilm"/>
+        </LogicalPart>
+        <!-- HDI -->
+        <LogicalPart name="PixelForwardPanelBaseMainHDI" category="support">
+            <rSolid name="PixelForwardPanelBaseMainHDI"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_VHDI"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPanelBaseNoseHDI" category="support">
+            <rSolid name="PixelForwardPanelBaseNoseHDI"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_VHDI"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPanelBaseEarHDI" category="support">
+            <rSolid name="PixelForwardPanelBaseEarHDI"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_VHDI"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="Parts">
+        <!-- Beryllium -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanelBaseBe"/>
+            <rChild name="PixelForwardPanelBaseMainBe"/>
+            <Translation x="[AnchorX]" y="[AnchorY]+[Y2]+[MainLength]/2." z="0."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanelBaseBe"/>
+            <rChild name="PixelForwardPanelBaseNoseBe"/>
+            <Translation x="[AnchorX]" y="[AnchorY]+[Y2]-[NoseLength]/2." z="0."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanelBaseBe"/>
+            <rChild name="PixelForwardPanelBaseEarBe"/>
+            <Translation x="[AnchorX]+[earX]" y="[AnchorY]+[earY]" z="0."/>
+        </PosPart>
+        <!-- Film -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanelBaseFilm"/>
+            <rChild name="PixelForwardPanelBaseMainFilm"/>
+            <Translation x="[AnchorX]" y="[AnchorY]+[Y2]+[MainLength]/2." z="0."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanelBaseFilm"/>
+            <rChild name="PixelForwardPanelBaseNoseFilm"/>
+            <Translation x="[AnchorX]" y="[AnchorY]+[Y2]-[NoseLength]/2." z="0."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanelBaseFilm"/>
+            <rChild name="PixelForwardPanelBaseEarFilm"/>
+            <Translation x="[AnchorX]+[earX]" y="[AnchorY]+[earY]" z="0."/>
+        </PosPart>
+        <!-- HDI -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanelBaseHDI"/>
+            <rChild name="PixelForwardPanelBaseMainHDI"/>
+            <Translation x="[AnchorX]" y="[AnchorY]+[Y2]+[MainLength]/2." z="0."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanelBaseHDI"/>
+            <rChild name="PixelForwardPanelBaseNoseHDI"/>
+            <Translation x="[AnchorX]" y="[AnchorY]+[Y2]-[NoseLength]/2." z="0."/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPanelBaseHDI"/>
+            <rChild name="PixelForwardPanelBaseEarHDI"/>
+            <Translation x="[AnchorX]+[earX]" y="[AnchorY]+[earY]" z="0."/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdPlaq.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdPlaq.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Sunanda Banjeree
+         @modified Dmitry Onoprienko
+         
+         == COMPONENT DEFINED BY THIS FILE: ==
+         
+         Common parts for all types of plaquettes.
+         
+         -->
+    <!-- Rotations for placing sensors -->
+    <RotationSection label="PlaquetteCommon">
+        <Rotation name="Z90" phiX="90.*deg" thetaX="90.*deg" phiY="180.*deg" thetaY="90.*deg" phiZ="0.*deg" thetaZ="0.*deg"/>
+        <Rotation name="Z270" phiX="-90.*deg" thetaX="90.*deg" phiY="0.*deg" thetaY="90.*deg" phiZ="0.*deg" thetaZ="0.*deg"/>
+    </RotationSection>
+    <ConstantsSection label="Input" eval="true">
+        <Constant name="SensorT" value="0.270*mm"/>
+        <Constant name="BumpT" value="0.025*mm"/>
+        <Constant name="ROChipT" value="0.200*mm"/>
+        <Constant name="EpoxyT" value="0.178*mm"/>
+        <Constant name="FlexCircuitT" value="0.125*mm"/>
+        <Constant name="AdhFilmT" value="0.051*mm"/>
+        <Constant name="BackingT" value="0.300*mm"/>
+        <Constant name="ChoThermT" value="0.178*mm"/>
+        <Constant name="ROChipW" value="8.005*mm"/>
+        <!-- Readout chip width -->
+        <Constant name="ROChipH" value="9.935*mm"/>
+        <!-- Readout chip height -->
+        <Constant name="ROChipSpaceW" value="8.100*mm"/>
+        <!-- Distance (along width) between centers of adjacent chips -->
+    </ConstantsSection>
+    <ConstantsSection label="Calculated">
+        <!-- Thicknesses of superlayers -->
+        <Constant name="BumpROChipEpoxyT" value="[BumpT]+[ROChipT]+[EpoxyT]"/>
+        <Constant name="PassiveT" value="[BumpROChipEpoxyT]+[FlexCircuitT]+[AdhFilmT]+[BackingT]+[ChoThermT]"/>
+        <Constant name="PlaquetteT" value="[SensorT]+[PassiveT]"/>
+        <!-- Z-positions of superlayers to be positioned into plaquette root volume -->
+        <Constant name="SensorZ" value="([PlaquetteT]-[SensorT])/2."/>
+        <Constant name="PassiveZ" value="(-[PlaquetteT]+[PassiveT])/2."/>
+        <!-- Z-positions of layers to be positioned into "Passive" layer -->
+        <Constant name="BumpROChipEpoxyZ" value="([PassiveT]-[BumpROChipEpoxyT])/2."/>
+        <Constant name="FlexCircuitZ" value="[PassiveT]/2.-[BumpROChipEpoxyT]-[FlexCircuitT]/2."/>
+        <Constant name="AdhFilmZ" value="[PassiveT]/2.-[BumpROChipEpoxyT]-[FlexCircuitT]-[AdhFilmT]/2."/>
+        <Constant name="BackingZ" value="[PassiveT]/2.-[BumpROChipEpoxyT]-[FlexCircuitT]-[AdhFilmT]-[BackingT]/2."/>
+        <Constant name="ChoThermZ" value="(-[PassiveT]+[ChoThermT])/2."/>
+    </ConstantsSection>
+    <!-- Readout chip with epoxy and bump bond -->
+    <ConstantsSection label="BumpROChipCalculated">
+        <Constant name="BumpZ" value="([BumpROChipEpoxyT]-[BumpT])/2."/>
+        <Constant name="EpoxyZ" value="(-[BumpROChipEpoxyT]+[EpoxyT])/2."/>
+    </ConstantsSection>
+    <SolidSection label="BumpROChipEpoxy">
+        <Box name="PixelForwardBumpROChipEpoxy" dx="[ROChipW]/2." dy="[ROChipH]/2" dz="[BumpROChipEpoxyT]/2."/>
+        <Box name="PixelForwardBump" dx="[ROChipW]/2." dy="[ROChipH]/2" dz="[BumpT]/2."/>
+        <Box name="PixelForwardEpoxy" dx="[ROChipW]/2." dy="[ROChipH]/2" dz="[EpoxyT]/2."/>
+    </SolidSection>
+    <LogicalPartSection label="BumpROChipEpoxy">
+        <LogicalPart name="PixelForwardBumpROChipEpoxy" category="unspecified">
+            <rSolid name="PixelForwardBumpROChipEpoxy"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBump" category="unspecified">
+            <rSolid name="PixelForwardBump"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_Bump"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardEpoxy" category="unspecified">
+            <rSolid name="PixelForwardEpoxy"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AgEpoxy"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="BumpROChipEpoxy">
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBumpROChipEpoxy"/>
+            <rChild name="PixelForwardBump"/>
+            <Translation x="0.*mm" y="0.*mm" z="[BumpZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardBumpROChipEpoxy"/>
+            <rChild name="PixelForwardEpoxy"/>
+            <Translation x="0.*mm" y="0.*mm" z="[EpoxyZ]"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdPlaq1x2.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdPlaq1x2.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Victoria Martin
+         @modified Dmitry Onoprienko
+         
+         == Subsystem or component described by the file ==
+         
+         1x2 Plaquette (Left and Right versions).
+         
+         == Root volume and its reference frame ==
+         
+         Root volume : PixelForwardPlaquette1x2Left and PixelForwardPlaquette1x2Right
+         
+         Y is in the plane of the plaquette, pointing away from the beam line
+         Z is perpendicular to the plaquette, pointing to the sensor side
+         
+         == Positioning ==
+         
+         The file defines AnchorXLeft(AnchorXRight) and AnchorY constants that 
+         correspond to the anchor point (aka active center) coordinates in the plaquette
+         root volume PixelForwardPlaquette1x2Left(PixelForwardPlaquette1x2Right).
+         
+         The two root volumes defined by this file contain ...........
+         
+         PixelForwardPlaquette1x2Right should be positioned unrotated into "PixelForwardPanel3Right" panel,
+         and PixelForwardPlaquette1x2Left should be positioned unrotated into "PixelForwardPanel4Left" panel.
+         
+         == Additional comments ==
+         
+         The volume representing the active part of the sensor is placed with 90 degrees 
+         rotation around Z axis to make its local reference frame Y go along the longer side.
+         
+         -->
+    <ConstantsSection label="Input" eval="true">
+        <Constant name="PlaquetteW" value="21.358*mm"/>
+        <Constant name="PlaquetteH" value="15.048*mm"/>
+        <Constant name="SensorW" value="18.494*mm"/>
+        <Constant name="SensorH" value="10.394*mm"/>
+        <Constant name="ActiveW" value="16.200*mm"/>
+        <Constant name="ActiveH" value="8.100*mm"/>
+        <Constant name="ROChipX_TopRight" value="3.074*mm"/>
+        <Constant name="ROChipY_TopRight" value="3.905*mm"/>
+        <Constant name="ActiveCenterXRight" value="11.137*mm"/>
+        <Constant name="ActiveCenterXLeft" value="11.116*mm"/>
+        <Constant name="ActiveCenterY" value="9.833*mm"/>
+    </ConstantsSection>
+    <ConstantsSection label="Common" eval="true">
+        <Constant name="AnchorXRight" value=" [PlaquetteW]/2.-[ActiveCenterXRight]"/>
+        <Constant name="AnchorXLeft" value="-[PlaquetteW]/2.+[ActiveCenterXLeft]"/>
+        <Constant name="AnchorY" value="[PlaquetteH]/2.-[ActiveCenterY]"/>
+    </ConstantsSection>
+    <SolidSection label="All">
+        <!-- Root volume -->
+        <Box name="PixelForwardPlaquette1x2" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:PlaquetteT]/2."/>
+        <!-- Sensor -->
+        <Box name="PixelForwardSensor1x2" dx="[SensorH]/2." dy="[SensorW]/2" dz="[pixfwdPlaq:SensorT]/2."/>
+        <Box name="PixelForwardActive1x2" dx="[ActiveH]/2." dy="[ActiveW]/2" dz="[pixfwdPlaq:SensorT]/2."/>
+        <!-- Passive part -->
+        <Box name="PixelForwardPassive1x2" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:PassiveT]/2."/>
+        <Box name="PixelForwardFlexCircuit1x2" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:FlexCircuitT]/2."/>
+        <Box name="PixelForwardAdhFilm1x2" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:AdhFilmT]/2."/>
+        <Box name="PixelForwardBacking1x2" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:BackingT]/2."/>
+        <Box name="PixelForwardChoTherm1x2" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:ChoThermT]/2."/>
+    </SolidSection>
+    <LogicalPartSection label="All">
+        <!-- Root volumes -->
+        <LogicalPart name="PixelForwardPlaquette1x2Right" category="envelope">
+            <rSolid name="PixelForwardPlaquette1x2"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPlaquette1x2Left" category="envelope">
+            <rSolid name="PixelForwardPlaquette1x2"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <!-- Sensor -->
+        <LogicalPart name="PixelForwardSensor1x2" category="unspecified">
+            <rSolid name="PixelForwardSensor1x2"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardActive1x2" category="sensitive">
+            <rSolid name="PixelForwardActive1x2"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <!-- Passive part -->
+        <LogicalPart name="PixelForwardPassive1x2" category="envelope">
+            <rSolid name="PixelForwardPassive1x2"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardFlexCircuit1x2" category="unspecified">
+            <rSolid name="PixelForwardFlexCircuit1x2"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_VHDI"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardAdhFilm1x2" category="unspecified">
+            <rSolid name="PixelForwardAdhFilm1x2"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AdhFilm"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBacking1x2" category="unspecified">
+            <rSolid name="PixelForwardBacking1x2"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardChoTherm1x2" category="unspecified">
+            <rSolid name="PixelForwardChoTherm1x2"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AgEpoxy"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="All">
+        <!-- Sensor -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardSensor1x2"/>
+            <rChild name="PixelForwardActive1x2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPlaquette1x2Right"/>
+            <rChild name="PixelForwardSensor1x2"/>
+            <Translation x="[AnchorXRight]" y="[AnchorY]" z="[pixfwdPlaq:SensorZ]"/>
+            <rRotation name="pixfwdPlaq:Z270"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPlaquette1x2Left"/>
+            <rChild name="PixelForwardSensor1x2"/>
+            <Translation x="[AnchorXLeft]" y="[AnchorY]" z="[pixfwdPlaq:SensorZ]"/>
+            <rRotation name="pixfwdPlaq:Z270"/>
+        </PosPart>
+        <!-- Passive part -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPlaquette1x2Right"/>
+            <rChild name="PixelForwardPassive1x2"/>
+            <Translation x="0.*mm" y="0.*mm" z="[pixfwdPlaq:PassiveZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPlaquette1x2Left"/>
+            <rChild name="PixelForwardPassive1x2"/>
+            <Translation x="0.*mm" y="0.*mm" z="[pixfwdPlaq:PassiveZ]"/>
+            <rReflectionRotation name="pixfwdCommon:ReflectionX"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive1x2"/>
+            <rChild name="PixelForwardFlexCircuit1x2"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:FlexCircuitZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive1x2"/>
+            <rChild name="PixelForwardAdhFilm1x2"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:AdhFilmZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive1x2"/>
+            <rChild name="PixelForwardBacking1x2"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:BackingZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive1x2"/>
+            <rChild name="PixelForwardChoTherm1x2"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:ChoThermZ]"/>
+        </PosPart>
+        <!-- Readout chips in the passive part -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive1x2"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPassive1x2"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-[pixfwdPlaq:ROChipSpaceW]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdPlaq1x5.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdPlaq1x5.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Victoria Martin
+         @modified Dmitry Onoprienko
+         
+         == Subsystem or component described by the file ==
+         
+         1x5 Plaquette (Left and Right versions).
+         
+         == Root volume and its reference frame ==
+         
+         Root volume : PixelForwardPlaquette1x5Left and PixelForwardPlaquette1x5Right
+         
+         Y is in the plane of the plaquette, pointing away from the beam line
+         Z is perpendicular to the plaquette, pointing to the sensor side
+         
+         == Positioning ==
+         
+         The file defines AnchorXLeft(AnchorXRight) and AnchorY constants that 
+         correspond to the anchor point (aka active center) coordinates in the plaquette
+         root volume PixelForwardPlaquette1x5Left(PixelForwardPlaquette1x5Right).
+         
+         The two root volumes defined by this file contain ...........
+         
+         PixelForwardPlaquette1x5Right should be positioned unrotated into "PixelForwardPanel4Left" panel,
+         and PixelForwardPlaquette1x5Left should be positioned unrotated into "PixelForwardPanel4Right" panel.
+         (Not a typo - a follow notation from the drawings).
+         
+         == Additional comments ==
+         
+         The volume representing the active part of the sensor is placed with 90 degrees 
+         rotation around Z axis to make its local reference frame Y go along the longer side.
+         
+         -->
+    <ConstantsSection label="Input" eval="true">
+        <Constant name="PlaquetteW" value="45.658*mm"/>
+        <Constant name="PlaquetteH" value="15.048*mm"/>
+        <Constant name="SensorW" value="42.794*mm"/>
+        <Constant name="SensorH" value="10.394*mm"/>
+        <Constant name="ActiveW" value="40.500*mm"/>
+        <Constant name="ActiveH" value="8.100*mm"/>
+        <Constant name="ROChipX_BottomLeft" value="42.584*mm"/>
+        <Constant name="ROChipY_BottomLeft" value="11.143*mm"/>
+        <Constant name="ActiveCenterXRight" value="22.371*mm"/>
+        <Constant name="ActiveCenterXLeft" value="23.266*mm"/>
+        <Constant name="ActiveCenterY" value="9.833*mm"/>
+    </ConstantsSection>
+    <ConstantsSection label="Common" eval="true">
+        <Constant name="AnchorXRight" value=" [PlaquetteW]/2.-[ActiveCenterXRight]"/>
+        <Constant name="AnchorXLeft" value=" [PlaquetteW]/2.-[ActiveCenterXLeft]"/>
+        <Constant name="AnchorY" value="-[PlaquetteH]/2.+[ActiveCenterY]"/>
+    </ConstantsSection>
+    <SolidSection label="All">
+        <!-- Root volume -->
+        <Box name="PixelForwardPlaquette1x5" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:PlaquetteT]/2."/>
+        <!-- Sensor -->
+        <Box name="PixelForwardSensor1x5" dx="[SensorH]/2." dy="[SensorW]/2" dz="[pixfwdPlaq:SensorT]/2."/>
+        <Box name="PixelForwardActive1x5" dx="[ActiveH]/2." dy="[ActiveW]/2" dz="[pixfwdPlaq:SensorT]/2."/>
+        <!-- Passive part -->
+        <Box name="PixelForwardPassive1x5" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:PassiveT]/2."/>
+        <Box name="PixelForwardFlexCircuit1x5" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:FlexCircuitT]/2."/>
+        <Box name="PixelForwardAdhFilm1x5" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:AdhFilmT]/2."/>
+        <Box name="PixelForwardBacking1x5" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:BackingT]/2."/>
+        <Box name="PixelForwardChoTherm1x5" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:ChoThermT]/2."/>
+    </SolidSection>
+    <LogicalPartSection label="All">
+        <!-- Root volumes -->
+        <LogicalPart name="PixelForwardPlaquette1x5Right" category="envelope">
+            <rSolid name="PixelForwardPlaquette1x5"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPlaquette1x5Left" category="envelope">
+            <rSolid name="PixelForwardPlaquette1x5"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <!-- Sensor -->
+        <LogicalPart name="PixelForwardSensor1x5" category="unspecified">
+            <rSolid name="PixelForwardSensor1x5"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardActive1x5" category="sensitive">
+            <rSolid name="PixelForwardActive1x5"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <!-- Passive part -->
+        <LogicalPart name="PixelForwardPassive1x5" category="envelope">
+            <rSolid name="PixelForwardPassive1x5"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardFlexCircuit1x5" category="unspecified">
+            <rSolid name="PixelForwardFlexCircuit1x5"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_VHDI"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardAdhFilm1x5" category="unspecified">
+            <rSolid name="PixelForwardAdhFilm1x5"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AdhFilm"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBacking1x5" category="unspecified">
+            <rSolid name="PixelForwardBacking1x5"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardChoTherm1x5" category="unspecified">
+            <rSolid name="PixelForwardChoTherm1x5"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AgEpoxy"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="All">
+        <!-- Sensor -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardSensor1x5"/>
+            <rChild name="PixelForwardActive1x5"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPlaquette1x5Right"/>
+            <rChild name="PixelForwardSensor1x5"/>
+            <Translation x="[AnchorXRight]" y="[AnchorY]" z="[pixfwdPlaq:SensorZ]"/>
+            <rRotation name="pixfwdPlaq:Z270"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPlaquette1x5Left"/>
+            <rChild name="PixelForwardSensor1x5"/>
+            <Translation x="[AnchorXLeft]" y="[AnchorY]" z="[pixfwdPlaq:SensorZ]"/>
+            <rRotation name="pixfwdPlaq:Z270"/>
+        </PosPart>
+        <!-- Passive part -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPlaquette1x5Right"/>
+            <rChild name="PixelForwardPassive1x5"/>
+            <Translation x="0.*mm" y="0.*mm" z="[pixfwdPlaq:PassiveZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPlaquette1x5Left"/>
+            <rChild name="PixelForwardPassive1x5"/>
+            <Translation x="0.*mm" y="0.*mm" z="[pixfwdPlaq:PassiveZ]"/>
+            <rReflectionRotation name="pixfwdCommon:ReflectionX"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive1x5"/>
+            <rChild name="PixelForwardFlexCircuit1x5"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:FlexCircuitZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive1x5"/>
+            <rChild name="PixelForwardAdhFilm1x5"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:AdhFilmZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive1x5"/>
+            <rChild name="PixelForwardBacking1x5"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:BackingZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive1x5"/>
+            <rChild name="PixelForwardChoTherm1x5"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:ChoThermZ]"/>
+        </PosPart>
+        <!-- Readout chips in the passive part -->
+        <PosPart copyNumber="3">
+            <rParent name="PixelForwardPassive1x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="PixelForwardPassive1x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+[pixfwdPlaq:ROChipSpaceW]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="PixelForwardPassive1x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+2.*[pixfwdPlaq:ROChipSpaceW]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="6">
+            <rParent name="PixelForwardPassive1x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+3.*[pixfwdPlaq:ROChipSpaceW]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="7">
+            <rParent name="PixelForwardPassive1x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+4.*[pixfwdPlaq:ROChipSpaceW]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdPlaq2x3.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdPlaq2x3.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Victoria Martin
+         @modified Dmitry Onoprienko
+         
+         == Subsystem or component described by the file ==
+         
+         2x3 Plaquette.
+         
+         == Root volume and its reference frame ==
+         
+         Root volume : PixelForwardPlaquette2x3Up and PixelForwardPlaquette2x3Down
+         
+         Y is in the plane of the plaquette, pointing away from the beam line
+         Z is perpendicular to the plaquette, pointing to the sensor side
+         
+         == Positioning ==
+         
+         The file defines AnchorX and AnchorY constants that 
+         correspond to the anchor point (aka active center) coordinates in the plaquette
+         root volume.
+         
+         The two root volumes defined by this file contain identical geometry, but differ
+         in the directions of X and Y axes of the sensitive volume.
+         
+         PixelForwardPlaquette2x3Up should be positioned unrotated into "PixelForwardPanel3Right" panel,
+         and rotated by 180 deg around Z into "PixelForwardPanel4Left" panel.
+         
+         PixelForwardPlaquette2x3Down should be positioned unrotated into "PixelForwardPanel4Right" panel,
+         and rotated by 180 deg around Z into "PixelForwardPanel3Left" panel.
+         
+         == Additional comments ==
+         
+         The volume representing the active part of the sensor is placed with 90 degrees 
+         rotation around Z axis to make its local reference frame Y go along the longer side.
+         
+         -->
+    <ConstantsSection label="Input" eval="true">
+        <Constant name="PlaquetteW" value="29.458*mm"/>
+        <Constant name="PlaquetteH" value="27.766*mm"/>
+        <Constant name="SensorW" value="26.594*mm"/>
+        <Constant name="SensorH" value="18.494*mm"/>
+        <Constant name="ActiveW" value="24.300*mm"/>
+        <Constant name="ActiveH" value="16.200*mm"/>
+        <Constant name="ROChipX_TopRight" value="3.074*mm"/>
+        <Constant name="ROChipY_TopRight" value="3.905*mm"/>
+        <Constant name="ROChipX_BottomLeft" value="27.300*mm"/>
+        <Constant name="ROChipY_BottomLeft" value="23.860*mm"/>
+        <Constant name="ActiveCenterX" value="15.187*mm"/>
+        <Constant name="ActiveCenterY" value="13.883*mm"/>
+    </ConstantsSection>
+    <ConstantsSection label="Common" eval="true">
+        <Constant name="AnchorX" value=" [PlaquetteW]/2.-[ActiveCenterX]"/>
+        <Constant name="AnchorY" value="0.*mm"/>
+    </ConstantsSection>
+    <SolidSection label="All">
+        <!-- Root volume -->
+        <Box name="PixelForwardPlaquette2x3" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:PlaquetteT]/2."/>
+        <!-- Sensor -->
+        <Box name="PixelForwardSensor2x3" dx="[SensorH]/2." dy="[SensorW]/2" dz="[pixfwdPlaq:SensorT]/2."/>
+        <Box name="PixelForwardActive2x3" dx="[ActiveH]/2." dy="[ActiveW]/2" dz="[pixfwdPlaq:SensorT]/2."/>
+        <!-- Passive part -->
+        <Box name="PixelForwardPassive2x3" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:PassiveT]/2."/>
+        <Box name="PixelForwardFlexCircuit2x3" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:FlexCircuitT]/2."/>
+        <Box name="PixelForwardAdhFilm2x3" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:AdhFilmT]/2."/>
+        <Box name="PixelForwardBacking2x3" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:BackingT]/2."/>
+        <Box name="PixelForwardChoTherm2x3" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:ChoThermT]/2."/>
+    </SolidSection>
+    <LogicalPartSection label="All">
+        <!-- Root volumes -->
+        <LogicalPart name="PixelForwardPlaquette2x3Up" category="envelope">
+            <rSolid name="PixelForwardPlaquette2x3"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPlaquette2x3Down" category="envelope">
+            <rSolid name="PixelForwardPlaquette2x3"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <!-- Sensor -->
+        <LogicalPart name="PixelForwardSensor2x3" category="unspecified">
+            <rSolid name="PixelForwardSensor2x3"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardActive2x3" category="sensitive">
+            <rSolid name="PixelForwardActive2x3"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <!-- Passive part -->
+        <LogicalPart name="PixelForwardPassive2x3" category="envelope">
+            <rSolid name="PixelForwardPassive2x3"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardFlexCircuit2x3" category="unspecified">
+            <rSolid name="PixelForwardFlexCircuit2x3"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_VHDI"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardAdhFilm2x3" category="unspecified">
+            <rSolid name="PixelForwardAdhFilm2x3"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AdhFilm"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBacking2x3" category="unspecified">
+            <rSolid name="PixelForwardBacking2x3"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardChoTherm2x3" category="unspecified">
+            <rSolid name="PixelForwardChoTherm2x3"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AgEpoxy"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="All">
+        <!-- Sensor -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardSensor2x3"/>
+            <rChild name="PixelForwardActive2x3"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPlaquette2x3Up"/>
+            <rChild name="PixelForwardSensor2x3"/>
+            <Translation x="[AnchorX]" y="[AnchorY]" z="[pixfwdPlaq:SensorZ]"/>
+            <rRotation name="pixfwdPlaq:Z90"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPlaquette2x3Down"/>
+            <rChild name="PixelForwardSensor2x3"/>
+            <Translation x="[AnchorX]" y="[AnchorY]" z="[pixfwdPlaq:SensorZ]"/>
+            <rRotation name="pixfwdPlaq:Z270"/>
+        </PosPart>
+        <!-- Passive part -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPlaquette2x3Up"/>
+            <rChild name="PixelForwardPassive2x3"/>
+            <Translation x="0.*mm" y="0.*mm" z="[pixfwdPlaq:PassiveZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPlaquette2x3Down"/>
+            <rChild name="PixelForwardPassive2x3"/>
+            <Translation x="0.*mm" y="0.*mm" z="[pixfwdPlaq:PassiveZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive2x3"/>
+            <rChild name="PixelForwardFlexCircuit2x3"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:FlexCircuitZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive2x3"/>
+            <rChild name="PixelForwardAdhFilm2x3"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:AdhFilmZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive2x3"/>
+            <rChild name="PixelForwardBacking2x3"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:BackingZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive2x3"/>
+            <rChild name="PixelForwardChoTherm2x3"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:ChoThermZ]"/>
+        </PosPart>
+        <!-- Readout chips in the passive part -->
+        <PosPart copyNumber="8">
+            <rParent name="PixelForwardPassive2x3"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="9">
+            <rParent name="PixelForwardPassive2x3"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-[pixfwdPlaq:ROChipSpaceW]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="10">
+            <rParent name="PixelForwardPassive2x3"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-2.*[pixfwdPlaq:ROChipSpaceW]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="11">
+            <rParent name="PixelForwardPassive2x3"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="12">
+            <rParent name="PixelForwardPassive2x3"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+[pixfwdPlaq:ROChipSpaceW]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="13">
+            <rParent name="PixelForwardPassive2x3"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+2.*[pixfwdPlaq:ROChipSpaceW]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdPlaq2x4.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdPlaq2x4.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Victoria Martin
+         @modified Dmitry Onoprienko
+         
+         == Subsystem or component described by the file ==
+         
+         2x4 Plaquette.
+         
+         == Root volume and its reference frame ==
+         
+         Root volume : PixelForwardPlaquette2x4Up and PixelForwardPlaquette2x4Down
+         
+         Y is in the plane of the plaquette, pointing away from the beam line
+         Z is perpendicular to the plaquette, pointing to the sensor side
+         
+         == Positioning ==
+         
+         The file defines AnchorX and AnchorY constants that 
+         correspond to the anchor point (aka active center) coordinates in the plaquette
+         root volume.
+         
+         The two root volumes defined by this file contain identical geometry, but differ
+         in the directions of X and Y axes of the sensitive volume.
+         
+         PixelForwardPlaquette2x4Up should be positioned unrotated into "PixelForwardPanel3Right" panel,
+         and rotated by 180 deg around Z into "PixelForwardPanel4Left" panel.
+         
+         PixelForwardPlaquette2x4Down should be positioned unrotated into "PixelForwardPanel4Right" panel,
+         and rotated by 180 deg around Z into "PixelForwardPanel3Left" panel.
+         
+         == Additional comments ==
+         
+         The volume representing the active part of the sensor is placed with 90 degrees 
+         rotation around Z axis to make its local reference frame Y go along the longer side.
+         
+         -->
+    <ConstantsSection label="Input" eval="true">
+        <Constant name="PlaquetteW" value="37.558*mm"/>
+        <Constant name="PlaquetteH" value="27.766*mm"/>
+        <Constant name="SensorW" value="34.694*mm"/>
+        <Constant name="SensorH" value="18.494*mm"/>
+        <Constant name="ActiveW" value="32.400*mm"/>
+        <Constant name="ActiveH" value="16.200*mm"/>
+        <Constant name="ROChipX_TopRight" value="3.074*mm"/>
+        <Constant name="ROChipY_TopRight" value="3.905*mm"/>
+        <Constant name="ROChipX_BottomLeft" value="35.400*mm"/>
+        <Constant name="ROChipY_BottomLeft" value="23.860*mm"/>
+        <Constant name="ActiveCenterX" value="19.237*mm"/>
+        <Constant name="ActiveCenterY" value="13.883*mm"/>
+    </ConstantsSection>
+    <ConstantsSection label="Common" eval="true">
+        <Constant name="AnchorX" value=" [PlaquetteW]/2.-[ActiveCenterX]"/>
+        <Constant name="AnchorY" value="0.*mm"/>
+    </ConstantsSection>
+    <SolidSection label="All">
+        <!-- Root volume -->
+        <Box name="PixelForwardPlaquette2x4" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:PlaquetteT]/2."/>
+        <!-- Sensor -->
+        <Box name="PixelForwardSensor2x4" dx="[SensorH]/2." dy="[SensorW]/2" dz="[pixfwdPlaq:SensorT]/2."/>
+        <Box name="PixelForwardActive2x4" dx="[ActiveH]/2." dy="[ActiveW]/2" dz="[pixfwdPlaq:SensorT]/2."/>
+        <!-- Passive part -->
+        <Box name="PixelForwardPassive2x4" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:PassiveT]/2."/>
+        <Box name="PixelForwardFlexCircuit2x4" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:FlexCircuitT]/2."/>
+        <Box name="PixelForwardAdhFilm2x4" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:AdhFilmT]/2."/>
+        <Box name="PixelForwardBacking2x4" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:BackingT]/2."/>
+        <Box name="PixelForwardChoTherm2x4" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:ChoThermT]/2."/>
+    </SolidSection>
+    <LogicalPartSection label="All">
+        <!-- Root volumes -->
+        <LogicalPart name="PixelForwardPlaquette2x4Up" category="envelope">
+            <rSolid name="PixelForwardPlaquette2x4"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPlaquette2x4Down" category="envelope">
+            <rSolid name="PixelForwardPlaquette2x4"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <!-- Sensor -->
+        <LogicalPart name="PixelForwardSensor2x4" category="unspecified">
+            <rSolid name="PixelForwardSensor2x4"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardActive2x4" category="sensitive">
+            <rSolid name="PixelForwardActive2x4"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <!-- Passive part -->
+        <LogicalPart name="PixelForwardPassive2x4" category="envelope">
+            <rSolid name="PixelForwardPassive2x4"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardFlexCircuit2x4" category="unspecified">
+            <rSolid name="PixelForwardFlexCircuit2x4"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_VHDI"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardAdhFilm2x4" category="unspecified">
+            <rSolid name="PixelForwardAdhFilm2x4"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AdhFilm"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBacking2x4" category="unspecified">
+            <rSolid name="PixelForwardBacking2x4"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardChoTherm2x4" category="unspecified">
+            <rSolid name="PixelForwardChoTherm2x4"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AgEpoxy"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="All">
+        <!-- Sensor -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardSensor2x4"/>
+            <rChild name="PixelForwardActive2x4"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPlaquette2x4Up"/>
+            <rChild name="PixelForwardSensor2x4"/>
+            <Translation x="[AnchorX]" y="[AnchorY]" z="[pixfwdPlaq:SensorZ]"/>
+            <rRotation name="pixfwdPlaq:Z90"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPlaquette2x4Down"/>
+            <rChild name="PixelForwardSensor2x4"/>
+            <Translation x="[AnchorX]" y="[AnchorY]" z="[pixfwdPlaq:SensorZ]"/>
+            <rRotation name="pixfwdPlaq:Z270"/>
+        </PosPart>
+        <!-- Passive part -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPlaquette2x4Up"/>
+            <rChild name="PixelForwardPassive2x4"/>
+            <Translation x="0.*mm" y="0.*mm" z="[pixfwdPlaq:PassiveZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPlaquette2x4Down"/>
+            <rChild name="PixelForwardPassive2x4"/>
+            <Translation x="0.*mm" y="0.*mm" z="[pixfwdPlaq:PassiveZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive2x4"/>
+            <rChild name="PixelForwardFlexCircuit2x4"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:FlexCircuitZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive2x4"/>
+            <rChild name="PixelForwardAdhFilm2x4"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:AdhFilmZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive2x4"/>
+            <rChild name="PixelForwardBacking2x4"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:BackingZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive2x4"/>
+            <rChild name="PixelForwardChoTherm2x4"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:ChoThermZ]"/>
+        </PosPart>
+        <!-- Readout chips in the passive part -->
+        <PosPart copyNumber="14">
+            <rParent name="PixelForwardPassive2x4"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="15">
+            <rParent name="PixelForwardPassive2x4"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-[pixfwdPlaq:ROChipSpaceW]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="16">
+            <rParent name="PixelForwardPassive2x4"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-2.*[pixfwdPlaq:ROChipSpaceW]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="17">
+            <rParent name="PixelForwardPassive2x4"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-3.*[pixfwdPlaq:ROChipSpaceW]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="18">
+            <rParent name="PixelForwardPassive2x4"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="19">
+            <rParent name="PixelForwardPassive2x4"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+[pixfwdPlaq:ROChipSpaceW]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="20">
+            <rParent name="PixelForwardPassive2x4"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+2.*[pixfwdPlaq:ROChipSpaceW]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="21">
+            <rParent name="PixelForwardPassive2x4"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+3.*[pixfwdPlaq:ROChipSpaceW]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdPlaq2x5.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdPlaq2x5.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Victoria Martin
+         @modified Dmitry Onoprienko
+         
+         == Subsystem or component described by the file ==
+         
+         2x5 Plaquette.
+         
+         == Root volume and its reference frame ==
+         
+         Root volume : PixelForwardPlaquette2x5Up and PixelForwardPlaquette2x5Down
+         
+         Y is in the plane of the plaquette, pointing away from the beam line
+         Z is perpendicular to the plaquette, pointing to the sensor side
+         
+         == Positioning ==
+         
+         The file defines AnchorX and AnchorY constants that 
+         correspond to the anchor point (aka active center) coordinates in the plaquette
+         root volume.
+         
+         The two root volumes defined by this file contain identical geometry, but differ
+         in the directions of X and Y axes of the sensitive volume.
+         
+         PixelForwardPlaquette2x5Up should be positioned unrotated into "PixelForwardPanel3Right" panel.
+         PixelForwardPlaquette2x5Down should be positioned rotated by 180 deg around Z into "PixelForwardPanel3Left" panel.
+         
+         == Additional comments ==
+         
+         The volume representing the active part of the sensor is placed with 90 degrees 
+         rotation around Z axis to make its local reference frame Y go along the longer side.
+         
+         -->
+    <ConstantsSection label="Input" eval="true">
+        <Constant name="PlaquetteW" value="45.658*mm"/>
+        <Constant name="PlaquetteH" value="27.766*mm"/>
+        <Constant name="SensorW" value="42.794*mm"/>
+        <Constant name="SensorH" value="18.494*mm"/>
+        <Constant name="ActiveW" value="40.500*mm"/>
+        <Constant name="ActiveH" value="16.200*mm"/>
+        <Constant name="ROChipX_TopRight" value="3.074*mm"/>
+        <Constant name="ROChipY_TopRight" value="3.905*mm"/>
+        <Constant name="ROChipX_BottomLeft" value="43.500*mm"/>
+        <Constant name="ROChipY_BottomLeft" value="23.860*mm"/>
+        <Constant name="ActiveCenterX" value="23.287*mm"/>
+        <Constant name="ActiveCenterY" value="13.883*mm"/>
+    </ConstantsSection>
+    <ConstantsSection label="Common" eval="true">
+        <Constant name="AnchorX" value=" [PlaquetteW]/2.-[ActiveCenterX]"/>
+        <Constant name="AnchorY" value="0.*mm"/>
+    </ConstantsSection>
+    <SolidSection label="All">
+        <!-- Root volume -->
+        <Box name="PixelForwardPlaquette2x5" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:PlaquetteT]/2."/>
+        <!-- Sensor -->
+        <Box name="PixelForwardSensor2x5" dx="[SensorH]/2." dy="[SensorW]/2" dz="[pixfwdPlaq:SensorT]/2."/>
+        <Box name="PixelForwardActive2x5" dx="[ActiveH]/2." dy="[ActiveW]/2" dz="[pixfwdPlaq:SensorT]/2."/>
+        <!-- Passive part -->
+        <Box name="PixelForwardPassive2x5" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:PassiveT]/2."/>
+        <Box name="PixelForwardFlexCircuit2x5" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:FlexCircuitT]/2."/>
+        <Box name="PixelForwardAdhFilm2x5" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:AdhFilmT]/2."/>
+        <Box name="PixelForwardBacking2x5" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:BackingT]/2."/>
+        <Box name="PixelForwardChoTherm2x5" dx="[PlaquetteW]/2." dy="[PlaquetteH]/2." dz="[pixfwdPlaq:ChoThermT]/2."/>
+    </SolidSection>
+    <LogicalPartSection label="All">
+        <!-- Root volumes -->
+        <LogicalPart name="PixelForwardPlaquette2x5Up" category="envelope">
+            <rSolid name="PixelForwardPlaquette2x5"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardPlaquette2x5Down" category="envelope">
+            <rSolid name="PixelForwardPlaquette2x5"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <!-- Sensor -->
+        <LogicalPart name="PixelForwardSensor2x5" category="unspecified">
+            <rSolid name="PixelForwardSensor2x5"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardActive2x5" category="sensitive">
+            <rSolid name="PixelForwardActive2x5"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <!-- Passive part -->
+        <LogicalPart name="PixelForwardPassive2x5" category="envelope">
+            <rSolid name="PixelForwardPassive2x5"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardFlexCircuit2x5" category="unspecified">
+            <rSolid name="PixelForwardFlexCircuit2x5"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_VHDI"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardAdhFilm2x5" category="unspecified">
+            <rSolid name="PixelForwardAdhFilm2x5"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AdhFilm"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardBacking2x5" category="unspecified">
+            <rSolid name="PixelForwardBacking2x5"/>
+            <rMaterial name="materials:Silicon"/>
+        </LogicalPart>
+        <LogicalPart name="PixelForwardChoTherm2x5" category="unspecified">
+            <rSolid name="PixelForwardChoTherm2x5"/>
+            <rMaterial name="pixfwdMaterials:Pix_Fwd_AgEpoxy"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="All">
+        <!-- Sensor -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardSensor2x5"/>
+            <rChild name="PixelForwardActive2x5"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPlaquette2x5Up"/>
+            <rChild name="PixelForwardSensor2x5"/>
+            <Translation x="[AnchorX]" y="[AnchorY]" z="[pixfwdPlaq:SensorZ]"/>
+            <rRotation name="pixfwdPlaq:Z90"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPlaquette2x5Down"/>
+            <rChild name="PixelForwardSensor2x5"/>
+            <Translation x="[AnchorX]" y="[AnchorY]" z="[pixfwdPlaq:SensorZ]"/>
+            <rRotation name="pixfwdPlaq:Z270"/>
+        </PosPart>
+        <!-- Passive part -->
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPlaquette2x5Up"/>
+            <rChild name="PixelForwardPassive2x5"/>
+            <Translation x="0.*mm" y="0.*mm" z="[pixfwdPlaq:PassiveZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="PixelForwardPlaquette2x5Down"/>
+            <rChild name="PixelForwardPassive2x5"/>
+            <Translation x="0.*mm" y="0.*mm" z="[pixfwdPlaq:PassiveZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="PixelForwardFlexCircuit2x5"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:FlexCircuitZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="PixelForwardAdhFilm2x5"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:AdhFilmZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="PixelForwardBacking2x5"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:BackingZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="PixelForwardChoTherm2x5"/>
+            <Translation x="0." y="0." z="[pixfwdPlaq:ChoThermZ]"/>
+        </PosPart>
+        <!-- Readout chips in the passive part -->
+        <PosPart copyNumber="22">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="23">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-[pixfwdPlaq:ROChipSpaceW]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="24">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-2.*[pixfwdPlaq:ROChipSpaceW]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="25">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-3.*[pixfwdPlaq:ROChipSpaceW]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="26">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_TopRight]-4.*[pixfwdPlaq:ROChipSpaceW]-[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_TopRight]-[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="27">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="28">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+[pixfwdPlaq:ROChipSpaceW]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="29">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+2.*[pixfwdPlaq:ROChipSpaceW]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="30">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+3.*[pixfwdPlaq:ROChipSpaceW]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+        <PosPart copyNumber="31">
+            <rParent name="PixelForwardPassive2x5"/>
+            <rChild name="pixfwdPlaq:PixelForwardBumpROChipEpoxy"/>
+            <Translation x="[PlaquetteW]/2.-[ROChipX_BottomLeft]+4.*[pixfwdPlaq:ROChipSpaceW]+[pixfwdPlaq:ROChipW]/2." y="[PlaquetteH]/2.-[ROChipY_BottomLeft]+[pixfwdPlaq:ROChipH]/2." z="[pixfwdPlaq:BumpROChipEpoxyZ]"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/pixfwdTest.xml
+++ b/DetectorDescription/DDCMS/data/pixfwdTest.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- 
+         
+         == CMS Forward Pixels Geometry ==
+         
+         @version 3.02.01 May 30, 2006
+         @created Dmitry Onoprienko
+         
+         == COMPONENT DEFINED BY THIS FILE: ==
+         
+         Root volume for testing forward pixels geometry.
+         
+         -->
+    <ConstantsSection label="Root" eval="true">
+        <Constant name="RootRadius" value="[pixfwd:RootRadius] + 5.*mm"/>
+        <Constant name="RootHalfLength" value="[pixfwd:ZPixelForward] + [pixfwd:RootHalfLength]*2. + 5.*mm"/>
+    </ConstantsSection>
+    <!-- Test root volume -->
+    <SolidSection label="Root">
+        <Tubs name="TestRoot" rMin="0." rMax="[RootRadius]" dz="[RootHalfLength]" startPhi="0." deltaPhi="360*deg"/>
+    </SolidSection>
+    <LogicalPartSection label="Root">
+        <LogicalPart name="TestRoot" category="envelope">
+            <rSolid name="TestRoot"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <!-- Position forward pixels endcaps inside Test root volume -->
+    <PosPartSection label="PixelForwardRootPlacement">
+        <PosPart copyNumber="1">
+            <rParent name="TestRoot"/>
+            <rChild name="pixfwd:PixelForwardZPlus"/>
+            <Translation x="0." y="0." z="[pixfwd:ZPixelForward]-[pixfwd:AnchorZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="TestRoot"/>
+            <rChild name="pixfwd:PixelForwardZMinus"/>
+            <Translation x="0." y="0." z="-[pixfwd:ZPixelForward]+[pixfwd:AnchorZ]"/>
+            <rRotation name="pixfwdCommon:Y180"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tec.xml
+++ b/DetectorDescription/DDCMS/data/tec.xml
@@ -1,0 +1,389 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tec.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="Rin" value="22.30*cm"/>
+		<Constant name="Rout" value="113.51*cm"/>
+		<Constant name="ZStart" value="124.00*cm"/>
+		<Constant name="ZEnd" value="281.27*cm+0.34*mm"/>
+		<Constant name="WheelR" value="110.30*cm"/>
+		<Constant name="OuterSkinRin" value="113.46*cm"/>
+		<Constant name="FrontPlateRin" value="22.90*cm"/>
+		<Constant name="FrontPlateZ1" value="124.00*cm"/>
+		<Constant name="FrontPlateZ2" value="124.54*cm"/>
+		<Constant name="FixFrameDR" value="2.30*cm"/>
+		<Constant name="FixServiceRin" value="108.80*cm"/>
+		<Constant name="BeamSupportRin" value="30.00*cm"/>
+		<Constant name="BeamSupportRout" value="30.10*cm"/>
+		<Constant name="BeamSupportZ1" value="173.10*cm"/>
+		<Constant name="InTubeRin1" value="22.30*cm"/>
+		<Constant name="InTubeRin2" value="30.50*cm"/>
+		<Constant name="InTubeRout1" value="22.60*cm"/>
+		<Constant name="InTubeRout2" value="30.80*cm"/>
+		<Constant name="InTubeZ1" value="166.36*cm"/>
+		<Constant name="InTubeZ2" value="172.03*cm"/>
+		<Constant name="ServiceRin" value="110.60*cm"/>
+		<Constant name="ServiceRout" value="[OuterSkinRin]"/>
+		<Constant name="ServiceZ1" value="124.00*cm"/>
+		<Constant name="TECRailsADz" value="15.30*cm"/>
+		<Constant name="TECRailsAZ" value="160.25*cm"/>
+		<Constant name="TECRailsBDz" value="26.65*cm"/>
+		<Constant name="TECRailsBZ" value="250.10*cm"/>
+		<Constant name="RailsPhi" value="-0.664*deg"/>
+		<Constant name="RailsDeltaPhi" value="7.409*deg"/>
+		<Constant name="RailsRin" value="112.70*cm"/>
+		<Constant name="Wheel0Z" value="132.25*cm"/>
+		<Constant name="Wheel1Z" value="146.25*cm"/>
+		<Constant name="Wheel2Z" value="160.25*cm"/>
+		<Constant name="Wheel3Z" value="174.25*cm"/>
+		<Constant name="Wheel4Z" value="188.25*cm"/>
+		<Constant name="Wheel5Z" value="205.75*cm"/>
+		<Constant name="Wheel6Z" value="224.75*cm"/>
+		<Constant name="Wheel7Z" value="245.25*cm"/>
+		<Constant name="Wheel8Z" value="266.75*cm"/>
+		<Constant name="BackplateZ" value="[Wheel8Z]+87.4*mm-0.5*[tecwheel:DiskT]+0.5*[tecbackplate:Thick]"/>
+		<Constant name="AxialCableW" value="2.0*deg"/>
+		<Constant name="AxialCableT" value="0.21*cm"/>
+		<Constant name="CableFi1" value="-11.25*deg"/>
+		<Constant name="CableFi2" value="11.25*deg"/>
+		<Constant name="TECDz" value="([ZEnd]-[ZStart])/2"/>
+		<Constant name="ZPos" value="([ZEnd]+[ZStart])/2"/>
+		<Constant name="FrontFixRout" value="[FrontPlateRin]+[FixFrameDR]"/>
+		<Constant name="FrontPlateDz" value="([FrontPlateZ2]-[FrontPlateZ1])/2"/>
+		<Constant name="DPhi" value="[AxialCableW]+0.05*deg"/>
+		<Constant name="AxialCableDz" value="[tecpetpar:PetalThick]+                                          [tecpetpar:ICCThick]"/>
+		<Constant name="RailsInsARin" value="0.3*cm"/>
+		<Constant name="RailsInsARout" value="0.95*cm"/>
+		<Constant name="RailsInsADz" value="([ServiceRout]-[ServiceRin])/2-2"/>
+		<Constant name="RailsInsBRin" value="0.75*cm"/>
+		<Constant name="RailsInsBRout" value="0.95*cm"/>
+		<Constant name="RailsInsBDz" value="([ServiceRout]-[ServiceRin])/2-2"/>
+		<Constant name="RailsInsXup" value="([ServiceRout]+[ServiceRin])/2-1"/>
+		<Constant name="RailsInsXmid" value="([ServiceRout]+[ServiceRin])/2-2"/>
+		<Constant name="RailsInsXdown" value="([ServiceRout]+[ServiceRin])/2-4"/>
+	</ConstantsSection>
+	<RotationSection label="tec.xml">
+		<Rotation name="90Y" thetaX="180*deg" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="90*deg" phiZ="0*deg"/>
+	</RotationSection>
+	<SolidSection label="tec.xml">
+		<Tubs name="TEC" rMin="[Rin]" rMax="[Rout]" dz="[TECDz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TECWheels" rMin="[Rin]" rMax="[WheelR]" dz="[TECDz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TECOuterSkin" rMin="[OuterSkinRin]" rMax="[Rout]" dz="[TECDz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TECFrontPlate" rMin="[FrontPlateRin]" rMax="[WheelR]" dz="[FrontPlateDz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TECFrontPlateFixB" rMin="[FrontPlateRin]" rMax="[FrontFixRout]" dz="[FrontPlateDz]" startPhi="-7.60*deg" deltaPhi="15.20*deg"/>
+		<Tubs name="TECFrontPlateFixT" rMin="[FixServiceRin]" rMax="[WheelR]" dz="[FrontPlateDz]" startPhi="-2.50*deg" deltaPhi="5.00*deg"/>
+		<Tubs name="TECBeamSupport" rMin="[BeamSupportRin]" rMax="[BeamSupportRout]" dz="([ZEnd]-[BeamSupportZ1])/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Polycone name="TECInnerTube" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="-[TECDz]" rMin="[InTubeRin1]" rMax="[InTubeRout1]"/>
+			<ZSection z="([InTubeZ1]-[ZPos])" rMin="[InTubeRin1]" rMax="[InTubeRout1]"/>
+			<ZSection z="([InTubeZ2]-[ZPos])" rMin="[InTubeRin2]" rMax="[InTubeRout2]"/>
+			<ZSection z="[TECDz]-2.97" rMin="[InTubeRin2]" rMax="[InTubeRout2]"/>
+		</Polycone>
+		<Tubs name="RailsA" rMin="[ServiceRin]" rMax="[tecservices:GasPipeRpos]+[tecservices:GasPipeRout]" dz="[TECRailsADz]" startPhi="[RailsDeltaPhi]/2" deltaPhi="[RailsDeltaPhi]"/>
+		<Tubs name="RailsB" rMin="[ServiceRin]" rMax="[tecservices:GasPipeRpos]+[tecservices:GasPipeRout]" dz="[TECRailsBDz]" startPhi="[RailsDeltaPhi]/2" deltaPhi="[RailsDeltaPhi]"/>
+		<Tubs name="TECRailsInsertA" rMin="[RailsInsARin]" rMax="[RailsInsARout]" dz="[RailsInsADz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TECRailsInsertB" rMin="[RailsInsBRin]" rMax="[RailsInsBRout]" dz="[RailsInsBDz]" startPhi="0*deg" deltaPhi="360*deg"/>
+	</SolidSection>
+	<LogicalPartSection label="tec.xml">
+		<LogicalPart name="TEC" category="unspecified">
+			<rSolid name="tec:TEC"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECWheels" category="unspecified">
+			<rSolid name="tec:TECWheels"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECOuterSkin" category="unspecified">
+			<rSolid name="tec:TECOuterSkin"/>
+			<rMaterial name="tecmaterial:TEC_Skin"/>
+		</LogicalPart>
+		<LogicalPart name="TECFrontPlate" category="unspecified">
+			<rSolid name="tec:TECFrontPlate"/>
+			<rMaterial name="tecmaterial:Tk_SO_FC_C"/>
+		</LogicalPart>
+		<LogicalPart name="TECFrontPlateFixB" category="unspecified">
+			<rSolid name="tec:TECFrontPlateFixB"/>
+			<rMaterial name="tecmaterial:TEC_Fixframe"/>
+		</LogicalPart>
+		<LogicalPart name="TECFrontPlateFixT" category="unspecified">
+			<rSolid name="tec:TECFrontPlateFixT"/>
+			<rMaterial name="tecmaterial:TEC_FixServ"/>
+		</LogicalPart>
+		<LogicalPart name="TECBeamSupport" category="unspecified">
+			<rSolid name="tec:TECBeamSupport"/>
+			<rMaterial name="tecmaterial:Tk_SO_FC_D"/>
+		</LogicalPart>
+		<LogicalPart name="TECInnerTube" category="unspecified">
+			<rSolid name="tec:TECInnerTube"/>
+			<rMaterial name="tecmaterial:Tk_SO_FC_E"/>
+		</LogicalPart>
+		<LogicalPart name="RailsA" category="unspecified">
+			<rSolid name="tec:RailsA"/>
+			<rMaterial name="tecmaterial:TEC_Rails"/>
+		</LogicalPart>
+		<LogicalPart name="RailsB" category="unspecified">
+			<rSolid name="tec:RailsB"/>
+			<rMaterial name="tecmaterial:TEC_Rails"/>
+		</LogicalPart>
+		<LogicalPart name="TECRailsInsertA" category="unspecified">
+			<rSolid name="tec:TECRailsInsertA"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="TECRailsInsertB" category="unspecified">
+			<rSolid name="tec:TECRailsInsertB"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tec.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tec:TEC"/>
+			<rChild name="tec:TECWheels"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tec:TEC"/>
+			<rChild name="tec:TECOuterSkin"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tec:TECWheels"/>
+			<rChild name="tecbackplate:TECBackPlate"/>
+			<Translation x="[zero]" y="[zero]" z="[BackplateZ]-[ZPos]"/>
+			<!--Translation x="[zero]" y="[zero]" z="[TECDz]-0.5*[tecbackplate:Thick]"/-->
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tec:TECWheels"/>
+			<rChild name="tec:TECFrontPlate"/>
+			<Translation x="[zero]" y="[zero]" z="([FrontPlateZ2]+[FrontPlateZ1])/2-[ZPos]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tec:TECWheels"/>
+			<rChild name="tec:TECBeamSupport"/>
+			<Translation x="[zero]" y="[zero]" z="([BeamSupportZ1]-[ZStart])/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tec:TECWheels"/>
+			<rChild name="tec:TECInnerTube"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tec:TEC"/>
+			<rChild name="tecservices:TECServices"/>
+		</PosPart>
+		<PosPart copyNumber="0">
+			<rParent name="tec:TECWheels"/>
+			<rChild name="tecwheela:TECWheelA"/>
+			<Translation x="[zero]" y="[zero]" z="[Wheel0Z]-[ZPos]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tec:TECWheels"/>
+			<rChild name="tecwheela:TECWheelA"/>
+			<Translation x="[zero]" y="[zero]" z="[Wheel1Z]-[ZPos]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tec:TECWheels"/>
+			<rChild name="tecwheela:TECWheelA"/>
+			<Translation x="[zero]" y="[zero]" z="[Wheel2Z]-[ZPos]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tec:TECWheels"/>
+			<rChild name="tecwheelb:TECWheelB"/>
+			<Translation x="[zero]" y="[zero]" z="[Wheel3Z]-[ZPos]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tec:TECWheels"/>
+			<rChild name="tecwheelb:TECWheelB"/>
+			<Translation x="[zero]" y="[zero]" z="[Wheel4Z]-[ZPos]"/>
+		</PosPart>
+		<PosPart copyNumber="5">
+			<rParent name="tec:TECWheels"/>
+			<rChild name="tecwheel6:TECWheel6"/>
+			<Translation x="[zero]" y="[zero]" z="[Wheel5Z]-[ZPos]"/>
+		</PosPart>
+		<PosPart copyNumber="6">
+			<rParent name="tec:TECWheels"/>
+			<rChild name="tecwheelc:TECWheelC"/>
+			<Translation x="[zero]" y="[zero]" z="[Wheel6Z]-[ZPos]"/>
+		</PosPart>
+		<PosPart copyNumber="7">
+			<rParent name="tec:TECWheels"/>
+			<rChild name="tecwheelc:TECWheelC"/>
+			<Translation x="[zero]" y="[zero]" z="[Wheel7Z]-[ZPos]"/>
+		</PosPart>
+		<PosPart copyNumber="8">
+			<rParent name="tec:TECWheels"/>
+			<rChild name="tecwheeld:TECWheelD"/>
+			<Translation x="[zero]" y="[zero]" z="[Wheel8Z]-[ZPos]"/>
+		</PosPart>
+		<!-- TECRailsInsert-->
+		<!--PosPart copyNumber="1">
+		     <rParent name="tec:RailsA"/>
+		     <rChild name="tec:TECRailsInsertA"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXmid]" y="5.69*cm" z="-14.0*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="2">
+		     <rParent name="tec:RailsA"/>
+		     <rChild name="tec:TECRailsInsertA"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXmid]" y="5.69*cm" z="0*fm"/>	
+		</PosPart>
+		     <PosPart copyNumber="3">
+		     <rParent name="tec:RailsA"/>
+		     <rChild name="tec:TECRailsInsertA"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXmid]" y="5.69*cm" z="14.0*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="1">
+		     <rParent name="tec:RailsA"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXup]" y="1.69*cm" z="-14.0*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="2">
+		     <rParent name="tec:RailsA"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXup]" y="1.69*cm" z="0*fm"/>	
+		</PosPart>
+		     <PosPart copyNumber="3">
+		     <rParent name="tec:RailsA"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXup]" y="1.69*cm" z="14.0*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="4">
+		     <rParent name="tec:RailsA"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXdown]" y="9.69*cm" z="-14.0*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="5">
+		     <rParent name="tec:RailsA"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXdown]" y="9.69*cm" z="0*fm"/>	
+		</PosPart>
+		     <PosPart copyNumber="6">
+		     <rParent name="tec:RailsA"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXdown]" y="9.69*cm" z="14.0*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="1">
+		     <rParent name="tec:RailsB"/>
+		     <rChild name="tec:TECRailsInsertA"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXmid]" y="5.69*cm" z="-25.35*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="2">
+		     <rParent name="tec:RailsB"/>
+		     <rChild name="tec:TECRailsInsertA"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXmid]" y="5.69*cm" z="-4.85*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="3">
+		     <rParent name="tec:RailsB"/>
+		     <rChild name="tec:TECRailsInsertA"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXmid]" y="5.69*cm" z="16.65*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="4">
+		     <rParent name="tec:RailsB"/>
+		     <rChild name="tec:TECRailsInsertA"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXmid]" y="5.69*cm" z="25.39*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="1">
+		     <rParent name="tec:RailsB"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXup]" y="1.69*cm" z="-25.35*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="2">
+		     <rParent name="tec:RailsB"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXup]" y="1.69*cm" z="-4.85*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="3">
+		     <rParent name="tec:RailsB"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXup]" y="1.69*cm" z="16.65*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="4">
+		     <rParent name="tec:RailsB"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXup]" y="1.69*cm" z="25.39*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="5">
+		     <rParent name="tec:RailsB"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXdown]" y="9.69*cm" z="-25.35*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="6">
+		     <rParent name="tec:RailsB"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXdown]" y="9.69*cm" z="-4.85*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="7">
+		     <rParent name="tec:RailsB"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXdown]" y="9.69*cm" z="16.65*cm"/>	
+		</PosPart>
+		     <PosPart copyNumber="8">
+		     <rParent name="tec:RailsB"/>
+		     <rChild name="tec:TECRailsInsertB"/>
+		     <rRotation name="90Y"/>
+		     <Translation x="[RailsInsXdown]" y="9.69*cm" z="25.35*cm"/>	
+		</PosPart-->
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tec:TECFrontPlate"/>
+		<String name="ChildName" value="tec:TECFrontPlateFixB"/>
+		<Numeric name="N" value="4"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="67.5*deg"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0 </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tec:TECFrontPlate"/>
+		<String name="ChildName" value="tec:TECFrontPlateFixT"/>
+		<Numeric name="N" value="8"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="11.25*deg"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0 </Vector>
+	</Algorithm>
+	<!--Algorithm name="track:DDTrackerAngular">
+	     <rParent name="tecservices:TECServices"/>
+	     <String  name="ChildName"   value="tec:RailsA"/>
+	     <Numeric name="N"           value="2" />
+	     <Numeric name="StartCopyNo" value="1" />
+	     <Numeric name="IncrCopyNo"  value="1" />
+	     <Numeric name="RangeAngle"  value="360*deg"/>
+	     <Numeric name="StartAngle"  value="[RailsPhi]"/>
+	     <Numeric name="Radius"      value="[zero]"/>
+	     <Vector name="Center" type="numeric" nEntries="3">
+	     0, 0, [TECRailsAZ]-[ZPos] </Vector>
+	</Algorithm>
+	     <Algorithm name="track:DDTrackerAngular">
+	     <rParent name="tecservices:TECServices"/>
+	     <String  name="ChildName"   value="tec:RailsB"/>
+	     <Numeric name="N"           value="2" />
+	     <Numeric name="StartCopyNo" value="1" />
+	     <Numeric name="IncrCopyNo"  value="1" />
+	     <Numeric name="RangeAngle"  value="360*deg"/>
+	     <Numeric name="StartAngle"  value="[RailsPhi]"/>
+	     <Numeric name="Radius"      value="[zero]"/>
+	     <Vector name="Center" type="numeric" nEntries="3">
+	     0, 0, [TECRailsBZ]-[ZPos] </Vector>
+	</Algorithm-->
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecbackplate.xml
+++ b/DetectorDescription/DDCMS/data/tecbackplate.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <ConstantsSection label="tecbackplate.xml" eval="true">
+  <Constant name="zero" value="0.0*fm"/>
+  <Constant name="Rin" value="[tecpetal3:PetalContRmin]"/>
+  <!--  drawings show Rin =302*mm-->
+  <Constant name="Rout" value="[tec:WheelR]"/>
+  <Constant name="Thick" value="[tecwheel:DiskT] + [ThermalShieldThick]"/>
+  <Constant name="ThermalShieldRout" value="1053*mm"/>
+  <Constant name="ThermalShieldThick" value="49.7*mm"/>
+  <Constant name="CircPipeRin" value="[ThermalShieldRout]"/>
+  <Constant name="CircPipeRout" value="[Rout]"/>
+  <Constant name="CircPipeThick" value="[ThermalShieldThick]"/>
+  <Constant name="TiltmeterDist" value="792*mm"/>
+  <Constant name="TiltmeterDxy" value="42*mm"/>
+  <Constant name="TiltmeterDz" value="[ThermalShieldThick]/2."/>
+ </ConstantsSection>
+ <SolidSection label="tecbackplate.xml">
+  <Tubs name="TECBackPlate" rMin="[Rin]" rMax="[Rout]" dz="0.5*[Thick]" startPhi="0*deg" deltaPhi="360*deg"/>
+  <Tubs name="TECThermalShield" rMin="[Rin]" rMax="[ThermalShieldRout]" dz="0.5*[ThermalShieldThick]" startPhi="0*deg" deltaPhi="360*deg"/>
+  <Tubs name="TECCircPipe" rMin="[CircPipeRin]" rMax="[CircPipeRout]" dz="0.5*[CircPipeThick]" startPhi="0*deg" deltaPhi="360*deg"/>
+  <Box name="TECTiltmeter" dx="[TiltmeterDxy]" dy="[TiltmeterDxy]" dz="[TiltmeterDz]"/>
+ </SolidSection>
+ <LogicalPartSection label="tecbackplate.xml">
+  <LogicalPart name="TECBackPlate" category="unspecified">
+   <rSolid name="tecbackplate:TECBackPlate"/>
+   <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="TECBackDisk" category="unspecified">
+   <rSolid name="tecwheeld:TECWheelDiskD"/>
+   <rMaterial name="tecmaterial:TEC_BackDiskCF"/>
+  </LogicalPart>
+  <LogicalPart name="TECBackDiskNomex" category="unspecified">
+   <rSolid name="tecwheeld:TECWheelNomexD"/>
+   <rMaterial name="tecmaterial:TEC_Nomex"/>
+  </LogicalPart>
+  <LogicalPart name="TECBackDiskGroundingRing" category="unspecified">
+   <rSolid name="tecwheel:TECGroundingRing"/>
+   <rMaterial name="trackermaterial:T_Copper"/>
+  </LogicalPart>
+  <LogicalPart name="TECThermalShield" category="unspecified">
+   <rSolid name="tecbackplate:TECThermalShield"/>
+   <rMaterial name="tecmaterial:TEC_ThermalShield"/>
+  </LogicalPart>
+  <LogicalPart name="TECCircPipe" category="unspecified">
+   <rSolid name="tecbackplate:TECCircPipe"/>
+   <rMaterial name="tecmaterial:TEC_CircPipe"/>
+  </LogicalPart>
+  <LogicalPart name="TECTiltmeter" category="unspecified">
+   <rSolid name="tecbackplate:TECTiltmeter"/>
+   <rMaterial name="tecmaterial:TEC_Tiltmeter"/>
+  </LogicalPart>
+ </LogicalPartSection>
+ <PosPartSection label="tecbackplate.xml">
+  <PosPart copyNumber="1">
+   <rParent name="tecbackplate:TECBackPlate"/>
+   <rChild name="tecbackplate:TECBackDisk"/>
+   <Translation x="[zero]" y="[zero]" z="(-0.5*[Thick]+0.5*[tecwheel:DiskT])"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="tecbackplate:TECBackDisk"/>
+   <rChild name="tecbackplate:TECBackDiskNomex"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="tecbackplate:TECBackDisk"/>
+   <rChild name="tecbackplate:TECBackDiskGroundingRing"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="tecbackplate:TECBackPlate"/>
+   <rChild name="tecbackplate:TECThermalShield"/>
+   <Translation x="[zero]" y="[zero]" z="(-0.5*[Thick]+[tecwheel:DiskT]+0.5*[ThermalShieldThick])"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="tecbackplate:TECBackPlate"/>
+   <rChild name="tecbackplate:TECCircPipe"/>
+   <Translation x="[zero]" y="[zero]" z="(-0.5*[Thick]+[tecwheel:DiskT]+0.5*[CircPipeThick])"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="tecbackplate:TECThermalShield"/>
+   <rChild name="tecbackplate:TECTiltmeter"/>
+   <Translation x="[zero]" y="[TiltmeterDist]" z="[zero]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+   <rParent name="tecbackplate:TECThermalShield"/>
+   <rChild name="tecbackplate:TECTiltmeter"/>
+   <Translation x="[TiltmeterDist]" y="[zero]" z="[zero]"/>
+  </PosPart>
+  <PosPart copyNumber="3">
+   <rParent name="tecbackplate:TECThermalShield"/>
+   <rChild name="tecbackplate:TECTiltmeter"/>
+   <Translation x="[zero]" y="-[TiltmeterDist]" z="[zero]"/>
+  </PosPart>
+  <PosPart copyNumber="4">
+   <rParent name="tecbackplate:TECThermalShield"/>
+   <rChild name="tecbackplate:TECTiltmeter"/>
+   <Translation x="-[TiltmeterDist]" y="[zero]" z="[zero]"/>
+  </PosPart>
+ </PosPartSection>
+ <Algorithm name="track:DDTrackerAngular">
+  <rParent name="tecbackplate:TECBackDiskNomex"/>
+  <String name="ChildName" value="tecwheeld:TECFixSupportD"/>
+  <Numeric name="N" value="[tecwheel:FixSuppN]"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="RangeAngle" value="360*deg"/>
+  <Numeric name="StartAngle" value="[tecwheel:FixSuppFi]"/>
+  <Numeric name="Radius" value="[zero]"/>
+  <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+ </Algorithm>
+ <Algorithm name="track:DDTrackerAngular">
+  <rParent name="tecbackplate:TECBackDiskNomex"/>
+  <String name="ChildName" value="tecwheel:TECFixService"/>
+  <Numeric name="N" value="[tecwheel:FixServN]"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="RangeAngle" value="360*deg"/>
+  <Numeric name="StartAngle" value="[tecwheel:FixServFi]"/>
+  <Numeric name="Radius" value="[zero]"/>
+  <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+ </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmaterial.xml
+++ b/DetectorDescription/DDCMS/data/tecmaterial.xml
@@ -1,0 +1,1093 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <MaterialSection label="tecmaterial.xml">
+    <CompositeMaterial name="Tk_SO_FC_D" density="1.69*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.84491305">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.042542086">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11254487">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Tk_SO_FC_E" density="1.69*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.84491305">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.042542086">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11254487">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_Nomex" density="29*mg/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.">
+        <rMaterial name="trackermaterial:T_Nomex" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_SideFrameSuppliesBox" density="1.42*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.4">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.6">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_Hybrid4APV" density="4.853*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.01244">
+        <rMaterial name="materials:Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03101">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01097">
+        <rMaterial name="materials:SMD_metal" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00116">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.58835">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04057">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.2722">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04114">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00215">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_Hybrid6APV" density="4.853*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.01293">
+        <rMaterial name="materials:Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03041">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01203">
+        <rMaterial name="materials:SMD_metal" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0017">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.57692">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05642">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.26691">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04034">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00234">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_PitchAdapter" density="2.285*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.01964">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00405">
+        <rMaterial name="materials:Antimony" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02119">
+        <rMaterial name="materials:Titanium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11635">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.2683">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04916">
+        <rMaterial name="materials:Potassium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02169">
+        <rMaterial name="materials:Bor 11" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03975">
+        <rMaterial name="materials:Zinc" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03986">
+        <rMaterial name="materials:Sodium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.42001">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="1e-05">
+        <rMaterial name="materials:Chromium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_frame_top" density="1.931*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_frame_side_1_4" density="2.990*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.0001">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01928">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16527">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.81353">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00182">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_frame_side_5_7" density="1.835*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="9e-05">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.2644">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0219">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00139">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.71223">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_SideFrSupBox" density="1.420*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00108">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.46347">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16343">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01545">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.35657">
+        <rMaterial name="materials:Silver" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_SiReenforcment" density="3.731*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_petal" density="0.325*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.0047">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0889">
+        <rMaterial name="materials:Titanium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06686">
+        <rMaterial name="tecmaterial:TEC_Nomex" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00444">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1168">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00328">
+        <rMaterial name="materials:Peek" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03366">
+        <rMaterial name="trackermaterial:Optical_Fiber" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.68137">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_OptoH" density="4.200*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00692">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00084">
+        <rMaterial name="materials:Air" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.24416">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22453">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.24707">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11266">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1401">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02371">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_DOHM" density="2.969*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.40226">
+        <rMaterial name="tobmaterial:TOB_DOH" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01487">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13519">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0768">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0183">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.31357">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03901">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_petalinsert" density="4.739*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.20957">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0385">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00797">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.74097">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00298">
+        <rMaterial name="materials:Peek" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ICC01LF" density="1.218*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.04545">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03276">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00011">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06699">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.26301">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03844">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04788">
+        <rMaterial name="materials:Peek" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.23006">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.23995">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03322">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00214">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ICC2F" density="3.355*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.04734">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.026">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00012">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04602">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.2773">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03051">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04987">
+        <rMaterial name="materials:Peek" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1657">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.3328">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02211">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00222">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ICC35F" density="3.200*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.01212">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00749">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="3e-05">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0182">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.26402">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00425">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00879">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01277">
+        <rMaterial name="materials:Peek" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10676">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.55519">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00983">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00057">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ICC1SF" density="2.183*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.03717">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02297">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="9e-05">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0271">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.27509">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02695">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03916">
+        <rMaterial name="materials:Peek" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09757">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.45429">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01787">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00175">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ICC0F" density="3.343*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.05789">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02385">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00014">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04343">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.25615">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02798">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06098">
+        <rMaterial name="materials:Peek" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.19929">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.30564">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02194">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00272">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ICC46F" density="2.865*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.04776">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00874">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00012">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03324">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.2646">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01026">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05032">
+        <rMaterial name="materials:Peek" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14008">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.42377">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01886">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00224">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ICC1B" density="2.115*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.02528">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02524">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="8e-05">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03771">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.2752">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02962">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16436">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.42028">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02079">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00144">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ICC35B" density="3.157*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.01025">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00704">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="3e-05">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01871">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.26067">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00428">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00826">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0108">
+        <rMaterial name="materials:Peek" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11119">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.55824">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01005">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00048">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ICC0LB" density="2.916*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.04027">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03318">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0001">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04808">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.2504">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03892">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04242">
+        <rMaterial name="materials:Peek" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.17716">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.3454">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02218">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00189">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ICC2B" density="2.868*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.03474">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02862">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="9e-05">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04148">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.23894">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03358">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03659">
+        <rMaterial name="materials:Peek" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.15283">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.41232">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01918">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00163">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ICC46B" density="3.096*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.04246">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01272">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0001">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03072">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.238">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01492">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04473">
+        <rMaterial name="materials:Peek" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12221">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.47552">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01664">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.002">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_InnerManifold" density="3.698*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.16543">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.83457">
+        <rMaterial name="materials:Titanium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_CCUM" density="4.762*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.27951">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0881">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.55723">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07516">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ServChan" density="3.182*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.01852">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.88755">
+        <rMaterial name="trackermaterial:Fibre_Ribbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09393">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ServChanIns" density="0.943*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_AxGrounding" density="2.127*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.20529">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.79471">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_CoolPipe" density="9.274*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_AxCable" density="0.957*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.03995">
+        <rMaterial name="trackermaterial:MS_cntrl_cable" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.32482">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.34061">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.29462">
+        <rMaterial name="trackermaterial:CAB_Al60" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_GasPipe" density="2.937*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.04053">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.95947">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_PhiCableL" density="0.453*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.19421">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06174">
+        <rMaterial name="trackermaterial:MS_cntrl_cable" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20367">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.19221">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06638">
+        <rMaterial name="materials:Tin" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.17603">
+        <rMaterial name="trackermaterial:CAB_Al60" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10576">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_PhiCableU" density="0.755*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.1898">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06692">
+        <rMaterial name="trackermaterial:MS_cntrl_cable" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1852">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20844">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07162">
+        <rMaterial name="materials:Tin" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20623">
+        <rMaterial name="trackermaterial:CAB_Al60" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07178">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_GroundingRing" density="23.139*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.2285">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.7715">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_Skin" density="1.352*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.18681">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.81319">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_OptoCon" density="0.321*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.50304">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.48126">
+        <rMaterial name="trackermaterial:T_Ribbon12xMUConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00623">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00948">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_Rails" density="2.211*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_BackDiskCF" density="2.984*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_ThermalShield" density="0.166*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00385">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0037">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22782">
+        <rMaterial name="tecmaterial:TEC_Nomex" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01799">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.74664">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_CircPipe" density="0.763*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.13141">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.15522">
+        <rMaterial name="trackermaterial:MS_cntrl_cable" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13783">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.41593">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11923">
+        <rMaterial name="trackermaterial:CAB_Al60" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04038">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_BHDisk" density="1.556*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00661">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00467">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01234">
+        <rMaterial name="trackermaterial:T_Nomex" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03247">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.94391">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_BHCovers" density="1.834*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.05206">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11002">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.83792">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial density="2.669*0.79*g/cm3" method="mixture by weight" name="TEC_PatchpanelBox" symbol=" ">
+      <MaterialFraction fraction="0.01151">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.19806">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01207">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.7577">
+        <rMaterial name="trackermaterial:MS_Cu60" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00372">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01044">
+        <rMaterial name="trackermaterial:CAB_Al60" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0065">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_Connectors" density="2.669*1.21*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.01151">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.19806">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01207">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.7577">
+        <rMaterial name="trackermaterial:MS_Cu60" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00372">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01044">
+        <rMaterial name="trackermaterial:CAB_Al60" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0065">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_PatchCtrlBox" density="1.382*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00445">
+        <rMaterial name="trackermaterial:MS_cntrl_cable" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.8749">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12065">
+        <rMaterial name="trackermaterial:Fibre_Ribbon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_AlignRing" density="0.534*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.16497">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0189">
+        <rMaterial name="materials:Titanium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00284">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04474">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00378">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.76478">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Tk_SO_FC_C" density="0.178*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.13847">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00404">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.15144">
+        <rMaterial name="tecmaterial:TEC_Nomex" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.70605">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_wheel_Nomex" density="0.038*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="trackermaterial:T_Nomex" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_wheel_CF" density="1.269*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_wheel6_Nomex" density="0.024*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="trackermaterial:T_Nomex" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_wheel6_CF" density="1.627*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_wheelinsert" density="1.353*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_Fixframe" density="1.372*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_FixServ" density="3.050*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.14267">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.85733">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_AlignHolder" density="0.559*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_CraneBracket" density="2.021*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.0">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_Beamsplitter" density="1.207*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.04703">
+        <rMaterial name="materials:Silica" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.87717">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0758">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_RailsConnector" density="6.305*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.10736">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.89264">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_RailsSupport" density="2.843*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00641">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08031">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00221">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.91107">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TEC_Tiltmeter" density="0.659*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.24222">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00433">
+        <rMaterial name="materials:Titanium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00433">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.61421">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00433">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0519">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07869">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+  </MaterialSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodpar.xml
+++ b/DetectorDescription/DDCMS/data/tecmodpar.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecmodpar.xml" eval="true">
+		<Constant name="ModuleThick" value="1.55*mm"/>
+		<Constant name="DetTilt" value="0.100*rad"/>
+		<Constant name="FrameWidth" value="1.200*cm"/>
+		<Constant name="FrameOver" value="0.300*cm"/>
+		<!-- the TopFrameHeight -Parameter should be replaced by local values!!!
+		     It is used to POSITION(!) the wafer the name is missleading and kept for
+		     compatibility-->
+		<Constant name="TopFrameHeight" value="3.720*cm"/>
+		<Constant name="TopFrameThick" value="0.764*mm"/>
+		<Constant name="TopFrameZ" value="0.275*mm"/>
+		<Constant name="SideFrameThick" value="0.764*mm"/>
+		<Constant name="SideFrameZ" value="0.025*mm"/>
+		<Constant name="WaferThick1" value="0.320*mm"/>
+		<Constant name="WaferThick2" value="0.500*mm"/>
+		<Constant name="ActiveZ1" value="-0.606*mm"/>
+		<Constant name="ActiveZ2" value="-0.525*mm"/>
+		<Constant name="HybridHeight" value="2.526*cm"/>
+		<Constant name="HybridWidth" value="6.520*cm"/>
+		<Constant name="HybridThick" value="0.680*mm"/>
+		<Constant name="HybridZ" value="-0.525*mm"/>
+		<Constant name="PitchHeight" value="13.0*mm"/>
+		<Constant name="PitchStereoHeight" value="14.35*mm"/>
+		<Constant name="PitchThick" value="0.6650*mm"/>
+		<Constant name="PitchZ" value="-1.1075*mm"/>
+		<Constant name="GapModule" value="0.500*mm"/>
+		<Constant name="ModuleThickSS" value="[ModuleThick]+[SideFrameThick]"/>
+		<Constant name="ModuleThickDS" value="(2*[ModuleThick]+[GapModule])"/>
+		<Constant name="SiFrSuppBoxThick" value="0.258*mm"/>
+		<Constant name="SiReenforcementThick" value="0.387*mm"/>
+		<Constant name="NoOverlapShift" value="0.0*mm"/>
+		<Constant name="InactiveDy" value="1.50*mm"/>
+	</ConstantsSection>
+	<RotationSection label="tecmodpar.xml">
+		<Rotation name="90ZD" thetaX="-90*deg" phiX="0*deg" thetaY="0*deg" phiY="0*deg" thetaZ="90*deg" phiZ="90*deg"/>
+		<Rotation name="9NYX" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="-90*deg" phiZ="0*deg"/>
+		<Rotation name="G100" thetaX="84.2704*deg" phiX="180*deg" thetaY="90*deg" phiY="-90*deg" thetaZ="5.7296*deg" phiZ="0*deg"/>
+		<Rotation name="R180" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="-90*deg" thetaZ="0*deg" phiZ="0*deg"/>
+		<Rotation name="AR05" thetaX="-90*deg" phiX="0*deg" thetaY="180*deg" phiY="180*deg" thetaZ="90*deg" phiZ="270*deg"/>
+		<Rotation name="ART6" thetaX="90*deg" phiX="0*deg" thetaY="0*deg" phiY="0*deg" thetaZ="90*deg" phiZ="270*deg"/>
+		<Rotation name="RPHI" thetaX="90*deg" phiX="90*deg" thetaY="0*deg" phiY="0*deg" thetaZ="90*deg" phiZ="0*deg"/>
+		<Rotation name="STER" thetaX="90*deg" phiX="-84.2704*deg" thetaY="180*deg" phiY="0*deg" thetaZ="90*deg" phiZ="5.7296*deg"/>
+		<Rotation name="RFI2" thetaX="90*deg" phiX="-90*deg" thetaY="180*deg" phiY="0*deg" thetaZ="90*deg" phiZ="0*deg"/>
+		<Rotation name="PITC" thetaX="90*deg" phiX="0*deg" thetaY="0*deg" phiY="0*deg" thetaZ="90*deg" phiZ="-90*deg"/>
+	</RotationSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodule0.xml
+++ b/DetectorDescription/DDCMS/data/tecmodule0.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecmodule0.xml" eval="true">
+		<Constant name="Rin" value="23.08*cm"/>
+		<Constant name="Rout" value="36.65*cm"/>
+		<Constant name="FullHeight" value="8.7236000*cm"/>
+		<Constant name="ActiveHeight" value="8.5160000*cm"/>
+		<Constant name="DlTop" value="8.7914000*cm"/>
+		<Constant name="DlBottom" value="6.4610000*cm"/>
+		<Constant name="SideWidthTop" value="0.1093380*cm"/>
+		<Constant name="SideWidthBottom" value="0.0839200*cm"/>
+		<Constant name="ActiveZ" value="([tecmodpar:ActiveZ1]+[ShiftZ])"/>
+		<Constant name="DlHybrid" value="9.749*cm"/>
+		<Constant name="BridgeWidth" value="2.350*cm"/>
+		<Constant name="BridgeThick" value="0.194*cm"/>
+		<Constant name="BridgeHeight" value="1.3*cm"/>
+		<Constant name="BridgeSeparation" value="4.856*cm"/>
+		<Constant name="ModuleThick" value="[tecmodpar:ModuleThickDS]"/>
+		<Constant name="ShiftZ" value="-([tecmodpar:ModuleThick]+[tecmodpar:GapModule])/2"/>
+		<Constant name="HybridZ" value="[ActiveZ]+ 0.5*(-[tecmodpar:WaferThick1] + [tecmodpar:HybridThick])"/>
+		<Constant name="TopFrameZ" value="[HybridZ]+ 0.5*([tecmodpar:HybridThick]+[tecmodpar:TopFrameThick])"/>
+		<Constant name="SideFrameZ" value="[TopFrameZ]+0.5*(-[tecmodpar:TopFrameThick]+[tecmodpar:SideFrameThick])"/>
+		<Constant name="PitchZ" value="[TopFrameZ] - 0.5*([tecmodpar:TopFrameThick] + [tecmodpar:PitchThick])"/>
+		<Constant name="PitchWidth" value="87.8*mm"/>
+		<Constant name="TopFrameBotWidth" value="109.0*mm"/>
+		<Constant name="dPhi" value="2.2*asin(0.5*[TopFrameBotWidth]/([Rin]+[FullHeight]))"/>
+	</ConstantsSection>
+	<SolidSection label="tecmodule0.xml">
+		<Tubs name="TECModule0" rMin="[Rin]" rMax="[Rout]" dz="0.5*[tecmodpar:ModuleThickDS]" startPhi="-[dPhi]/2" deltaPhi="[dPhi]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecmodule0.xml">
+		<LogicalPart name="TECModule0" category="unspecified">
+			<rSolid name="tecmodule0:TECModule0"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodule0r.xml
+++ b/DetectorDescription/DDCMS/data/tecmodule0r.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <ConstantsSection label="tecmodule0r.xml" eval="true">
+  <Constant name="isStereo" value="0"/>
+  <Constant name="TopFrameTopWidth" value="84.6*mm"/>
+  <Constant name="TopFrameBotWidth" value="[tecmodule0:TopFrameBotWidth]"/>
+  <Constant name="TopFrameHeight" value="35.7*mm"/>
+  <Constant name="SideFrameRtheta" value=" 0.133*rad"/>
+  <Constant name="SideFrameRHeight" value="93.1*mm"/>
+  <Constant name="SideFrameRWidth" value="14.2*mm"/>
+  <Constant name="SideFrameLtheta" value="-.134*rad"/>
+  <Constant name="SideFrameLHeight" value="97.6*mm"/>
+  <Constant name="SideFrameLWidth" value="15.4*mm"/>
+  <Constant name="PosCorrectionR" value="-2.388*mm"/>
+ </ConstantsSection>
+ <Algorithm name="track:DDTECModuleAlgo">
+  <rParent name="tecmodule0:TECModule0"/>
+  <Numeric name="RingNo" value="0"/>
+  <Numeric name="isStereo" value="[isStereo]"/>
+  <String name="GeneralMaterial" value="materials:Air"/>
+  <Numeric name="ModuleThick" value="[tecmodpar:ModuleThick]"/>
+  <Numeric name="DetTilt" value="[tecmodpar:DetTilt]"/>
+  <Numeric name="FullHeight" value="[tecmodule0:FullHeight]"/>
+  <Numeric name="DlTop" value="[tecmodule0:DlTop]"/>
+  <Numeric name="DlBottom" value="[tecmodule0:DlBottom]"/>
+  <Numeric name="DlHybrid" value="[tecmodule0:DlHybrid]"/>
+  <String name="ActiveRotation" value="tecmodpar:AR05"/>
+  <Numeric name="FrameWidth" value="[tecmodpar:FrameWidth]"/>
+  <Numeric name="FrameThick" value="[tecmodule0:ModuleThick]"/>
+  <Numeric name="FrameOver" value="[tecmodpar:FrameOver]"/>
+  <String name="TopFrameMaterial" value="tecmaterial:TEC_frame_top"/>
+  <Numeric name="TopFrameTopWidth" value="[TopFrameTopWidth]"/>
+  <Numeric name="TopFrameBotWidth" value="[TopFrameBotWidth]"/>
+  <Numeric name="TopFrameHeight" value="[TopFrameHeight]"/>
+  <Numeric name="TopFrameThick" value="[tecmodpar:TopFrameThick]"/>
+  <Numeric name="TopFrameZ" value="[tecmodule0:TopFrameZ]"/>
+  <String name="SideFrameMaterial" value="tecmaterial:TEC_frame_side_1_4"/>
+  <Numeric name="SideFrameThick" value="[tecmodpar:SideFrameThick]"/>
+  <String name="SiFrSuppBoxMaterial" value="tecmaterial:TEC_SideFrSupBox"/>
+  <Numeric name="SideFrameRtheta" value="[SideFrameRtheta]"/>
+  <Numeric name="SideFrameRHeight" value="[SideFrameRHeight]"/>
+  <Numeric name="SideFrameRWidth" value="[SideFrameRWidth]"/>
+  <Numeric name="SideFrameLtheta" value="[SideFrameLtheta]"/>
+  <Numeric name="SideFrameLHeight" value="[SideFrameLHeight]"/>
+  <Numeric name="SideFrameLWidth" value="[SideFrameLWidth]"/>
+  <Numeric name="SiFrSuppBoxThick" value="[tecmodpar:SiFrSuppBoxThick]"/>
+  <Vector name="SiFrSuppBoxYPos" type="numeric" nEntries="1">
+   43.6*mm  </Vector>
+  <Vector name="SiFrSuppBoxHeight" type="numeric" nEntries="1">
+   30.1*mm  </Vector>
+  <Vector name="SiFrSuppBoxWidth" type="numeric" nEntries="1">
+   15.8*mm  </Vector>
+  <Numeric name="SideFrameZ" value="[tecmodule0:SideFrameZ]"/>
+  <String name="WaferMaterial" value="materials:Silicon"/>
+  <Numeric name="SideWidthTop" value="[tecmodule0:SideWidthTop]"/>
+  <Numeric name="SideWidthBottom" value="[tecmodule0:SideWidthBottom]"/>
+  <String name="WaferRotation" value="tecmodpar:RPHI"/>
+  <String name="ActiveMaterial" value="materials:Silicon"/>
+  <Numeric name="ActiveHeight" value="[tecmodule0:ActiveHeight]"/>
+  <Numeric name="WaferThick" value="[tecmodpar:WaferThick1]"/>
+  <String name="ActiveRotation" value="tecmodpar:AR05"/>
+  <Numeric name="ActiveZ" value="[tecmodule0:ActiveZ]"/>
+  <Numeric name="BackPlaneThick" value="2*[tracker:BackPlaneDz]"/>
+  <String name="HybridMaterial" value="tecmaterial:TEC_Hybrid6APV"/>
+  <Numeric name="HybridHeight" value="[tecmodpar:HybridHeight]"/>
+  <Numeric name="HybridWidth" value="[tecmodpar:HybridWidth]"/>
+  <Numeric name="HybridThick" value="[tecmodpar:HybridThick]"/>
+  <Numeric name="HybridZ" value="[tecmodule0:HybridZ]"/>
+  <String name="PitchMaterial" value="tecmaterial:TEC_PitchAdapter"/>
+  <Numeric name="PitchHeight" value="[tecmodpar:PitchHeight]"/>
+  <Numeric name="PitchThick" value="[tecmodpar:PitchThick]"/>
+  <Numeric name="PitchWidth" value="[tecmodule0:PitchWidth]"/>
+  <Numeric name="PitchZ" value="[tecmodule0:PitchZ]"/>
+  <String name="PitchRotation" value="tecmodpar:PITC"/>
+  <Numeric name="BridgeWidth" value="[tecmodule0:BridgeWidth]"/>
+  <Numeric name="BridgeThick" value="[tecmodule0:BridgeThick]"/>
+  <Numeric name="BridgeHeight" value="[tecmodule0:BridgeHeight]"/>
+  <Numeric name="BridgeSeparation" value="[tecmodule0:BridgeSeparation]"/>
+  <String name="BridgeMaterial" value="trackermaterial:T_Aluminium"/>
+  <Numeric name="WaferPosition" value="[tecmodpar:TopFrameHeight]"/>
+  <Vector name="SiReenforcementHeight" type="numeric" nEntries="1">
+   4.5*mm  </Vector>
+  <Vector name="SiReenforcementWidth" type="numeric" nEntries="1">
+   74.0*mm  </Vector>
+  <Vector name="SiReenforcementPosY" type="numeric" nEntries="1">
+   0.0001*mm  </Vector>
+  <String name="SiReenforcementMaterial" value="tecmaterial:TEC_SiReenforcment"/>
+  <Numeric name="SiReenforcementThick" value="[tecmodpar:SiReenforcementThick]"/>
+  <Numeric name="NoOverlapShift" value="[tecmodpar:NoOverlapShift]"/>
+  <Numeric name="RPos" value="0.5*([tecmodule0:Rin]+[tecmodule0:Rout])+[PosCorrectionR]"/>
+  <String name="StandardRotation" value="tecmodpar:RPHI"/>
+ </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodule0s.xml
+++ b/DetectorDescription/DDCMS/data/tecmodule0s.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecmodule0s.xml" eval="true">
+		<Constant name="isStereo" value="1"/>
+		<Constant name="TopFrameTopWidth" value="76.8*mm"/>
+		<Constant name="TopFrameBotWidth" value="111.0*mm"/>
+		<Constant name="TopFrameHeight" value="29.1*mm"/>
+		<Constant name="TopFrame2Width" value="111.0*mm"/>
+		<Constant name="TopFrame2LHeight" value="12.8*mm"/>
+		<Constant name="TopFrame2RHeight" value="1.8*mm"/>
+		<Constant name="SideFrameRtheta" value="0.172*rad"/>
+		<Constant name="SideFrameRHeight" value="92.8*mm"/>
+		<Constant name="SideFrameRWidthLow" value="10.1*mm"/>
+		<Constant name="SideFrameRWidth" value="21.5*mm"/>
+		<Constant name="SideFrameLtheta" value="-0.089*rad"/>
+		<Constant name="SideFrameLHeight" value="95.8*mm"/>
+		<Constant name="SideFrameLWidthLow" value="21.3*mm"/>
+		<Constant name="SideFrameLWidth" value="11.5*mm"/>
+		<Constant name="PosCorrectionR" value="-2.3878*mm"/>
+		<Constant name="PosCorrectionPhi" value="0.0000345*rad"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDTECModuleAlgo">
+		<rParent name="tecmodule0:TECModule0"/>
+		<Numeric name="RingNo" value="0"/>
+		<Numeric name="isStereo" value="[isStereo]"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="ModuleThick" value="[tecmodpar:ModuleThick]"/>
+		<Numeric name="DetTilt" value="[tecmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[tecmodule0:FullHeight]"/>
+		<Numeric name="DlTop" value="[tecmodule0:DlTop]"/>
+		<Numeric name="DlBottom" value="[tecmodule0:DlBottom]"/>
+		<Numeric name="DlHybrid" value="[tecmodule0:DlHybrid]"/>
+		<Numeric name="FrameWidth" value="[tecmodpar:FrameWidth]"/>
+		<Numeric name="FrameThick" value="[tecmodule0:ModuleThick]"/>
+		<Numeric name="FrameOver" value="[tecmodpar:FrameOver]"/>
+		<String name="TopFrameMaterial" value="tecmaterial:TEC_frame_top"/>
+		<Numeric name="TopFrameTopWidth" value="[TopFrameTopWidth]"/>
+		<Numeric name="TopFrameBotWidth" value="[TopFrameBotWidth]"/>
+		<Numeric name="TopFrameHeight" value="[TopFrameHeight]"/>
+		<Numeric name="TopFrame2Width" value="[TopFrame2Width]"/>
+		<Numeric name="TopFrame2LHeight" value="[TopFrame2LHeight]"/>
+		<Numeric name="TopFrame2RHeight" value="[TopFrame2RHeight]"/>
+		<Numeric name="TopFrameThick" value="[tecmodpar:TopFrameThick]"/>
+		<Numeric name="TopFrameZ" value="-[tecmodule0:TopFrameZ]"/>
+		<String name="SideFrameMaterial" value="tecmaterial:TEC_frame_side_1_4"/>
+		<Numeric name="SideFrameThick" value="[tecmodpar:SideFrameThick]"/>
+		<String name="SiFrSuppBoxMaterial" value="tecmaterial:TEC_SideFrSupBox"/>
+		<Numeric name="SideFrameRtheta" value="[SideFrameRtheta]"/>
+		<Numeric name="SideFrameRHeight" value="[SideFrameRHeight]"/>
+		<Numeric name="SideFrameRWidthLow" value="[SideFrameRWidthLow]"/>
+		<Numeric name="SideFrameRWidth" value="[SideFrameRWidth]"/>
+		<Numeric name="SideFrameLtheta" value="[SideFrameLtheta]"/>
+		<Numeric name="SideFrameLHeight" value="[SideFrameLHeight]"/>
+		<Numeric name="SideFrameLWidthLow" value="[SideFrameLWidthLow]"/>
+		<Numeric name="SideFrameLWidth" value="[SideFrameLWidth]"/>
+		<Numeric name="SiFrSuppBoxThick" value="[tecmodpar:SiFrSuppBoxThick]"/>
+		<Vector name="SiFrSuppBoxYPos" type="numeric" nEntries="1">
+			48.4*mm  </Vector>
+		<Vector name="SiFrSuppBoxHeight" type="numeric" nEntries="1">
+			28.9*mm  </Vector>
+		<Vector name="SiFrSuppBoxWidth" type="numeric" nEntries="1">
+			14.8*mm  </Vector>
+		<Numeric name="SideFrameZ" value="-[tecmodule0:SideFrameZ]"/>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[tecmodule0:SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[tecmodule0:SideWidthBottom]"/>
+		<String name="WaferRotation" value="tecmodpar:STER"/>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[tecmodule0:ActiveHeight]"/>
+		<Numeric name="WaferThick" value="[tecmodpar:WaferThick1]"/>
+		<String name="ActiveRotation" value="tecmodpar:AR05"/>
+		<Numeric name="ActiveZ" value="-[tecmodule0:ActiveZ]"/>
+		<Numeric name="BackPlaneThick" value="2*[tracker:BackPlaneDz]"/>
+		<String name="HybridMaterial" value="tecmaterial:TEC_Hybrid6APV"/>
+		<Numeric name="HybridHeight" value="[tecmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tecmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tecmodpar:HybridThick]"/>
+		<Numeric name="HybridZ" value="-[tecmodule0:HybridZ]"/>
+		<String name="PitchMaterial" value="tecmaterial:TEC_PitchAdapter"/>
+		<Numeric name="PitchHeight" value="[tecmodpar:PitchStereoHeight]"/>
+		<Numeric name="PitchThick" value="[tecmodpar:PitchThick]"/>
+		<Numeric name="PitchWidth" value="[tecmodule0:PitchWidth]"/>
+		<Numeric name="PitchZ" value="-[tecmodule0:PitchZ]"/>
+		<String name="PitchRotation" value="tecmodpar:PITC"/>
+		<Numeric name="BridgeWidth" value="[tecmodule0:BridgeWidth]"/>
+		<Numeric name="BridgeThick" value="[tecmodule0:BridgeThick]"/>
+		<Numeric name="BridgeHeight" value="[tecmodule0:BridgeHeight]"/>
+		<Numeric name="BridgeSeparation" value="[tecmodule0:BridgeSeparation]"/>
+		<String name="BridgeMaterial" value="None"/>
+		<Numeric name="WaferPosition" value="[tecmodpar:TopFrameHeight]"/>
+		<Vector name="SiReenforcementHeight" type="numeric" nEntries="1">
+			4.7*mm  </Vector>
+		<Vector name="SiReenforcementWidth" type="numeric" nEntries="1">
+			70.0*mm  </Vector>
+		<Vector name="SiReenforcementPosY" type="numeric" nEntries="1">
+			2*mm  </Vector>
+		<!-- they to be placed right! (are not due to problems with mother volume thickness)-->
+		<String name="SiReenforcementMaterial" value="tecmaterial:TEC_SiReenforcment"/>
+		<Numeric name="SiReenforcementThick" value="[tecmodpar:SiReenforcementThick]"/>
+		<Numeric name="NoOverlapShift" value="[tecmodpar:NoOverlapShift]"/>
+		<Numeric name="RPos" value="0.5*([tecmodule0:Rin]+[tecmodule0:Rout])+[PosCorrectionR]"/>
+		<String name="StandardRotation" value="tecmodpar:RPHI"/>
+		<Numeric name="PosCorrectionPhi" value="[PosCorrectionPhi]"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodule1.xml
+++ b/DetectorDescription/DDCMS/data/tecmodule1.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecmodule1.xml" eval="true">
+		<Constant name="Rin" value="31.74*cm"/>
+		<Constant name="Rout" value="45.93*cm"/>
+		<Constant name="FullHeight" value="9.0236000*cm"/>
+		<Constant name="ActiveHeight" value="8.8160000*cm"/>
+		<Constant name="DlTop" value="11.2202000*cm"/>
+		<Constant name="DlBottom" value="8.8096000*cm"/>
+		<Constant name="SideWidthTop" value="0.1076928*cm"/>
+		<Constant name="SideWidthBottom" value="0.0822066*cm"/>
+		<Constant name="HybridZ" value="[ActiveZ]+0.5*(-[tecmodpar:WaferThick1] + [tecmodpar:HybridThick])"/>
+		<Constant name="TopFrameZ" value="[HybridZ]+0.5*([tecmodpar:HybridThick]+[tecmodpar:TopFrameThick])"/>
+		<Constant name="SideFrameZ" value="[TopFrameZ]+0.5*(-[tecmodpar:TopFrameThick]+[tecmodpar:SideFrameThick])"/>
+		<Constant name="PitchZ" value="[TopFrameZ]-0.5*([tecmodpar:TopFrameThick] + [tecmodpar:PitchThick])"/>
+		<Constant name="DlHybrid" value="12.240*cm"/>
+		<Constant name="BridgeWidth" value="2.479*cm"/>
+		<Constant name="BridgeThick" value="0.204*cm"/>
+		<Constant name="BridgeHeight" value="2.3460*cm"/>
+		<Constant name="BridgeSeparation" value="7.150*cm"/>
+		<Constant name="ModuleThick" value="[tecmodpar:ModuleThickDS]"/>
+		<Constant name="ShiftZ" value="-([tecmodpar:ModuleThick]+                                             [tecmodpar:GapModule])/2"/>
+		<Constant name="TopFrameBotWidth" value="133.3*mm"/>
+		<Constant name="ActiveZ" value="([tecmodpar:ActiveZ1]+[ShiftZ])"/>
+		<Constant name="PitchWidth" value="112.1*mm"/>
+		<Constant name="dPhi" value="2.2*asin(0.5*[TopFrameBotWidth]/([Rin]+[FullHeight]))"/>
+	</ConstantsSection>
+	<SolidSection label="tecmodule1.xml">
+		<Tubs name="TECModule1" rMin="[Rin]" rMax="[Rout]" dz="0.5*[tecmodpar:ModuleThickDS]" startPhi="-[dPhi]/2" deltaPhi="[dPhi]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecmodule1.xml">
+		<LogicalPart name="TECModule1" category="unspecified">
+			<rSolid name="tecmodule1:TECModule1"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodule1r.xml
+++ b/DetectorDescription/DDCMS/data/tecmodule1r.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecmodule1r.xml" eval="true">
+		<Constant name="isStereo" value="0"/>
+		<Constant name="TopFrameTopWidth" value="95.6*mm"/>
+		<Constant name="TopFrameBotWidth" value="[tecmodule1:TopFrameBotWidth]"/>
+		<Constant name="TopFrameHeight" value="35.7*mm"/>
+		<Constant name="SideFrameRtheta" value="0.133*rad"/>
+		<Constant name="SideFrameRHeight" value="95.0*mm"/>
+		<Constant name="SideFrameRWidth" value="14.1*mm"/>
+		<Constant name="SideFrameLtheta" value="-0.133*rad"/>
+		<Constant name="SideFrameLHeight" value="99.2*mm"/>
+		<Constant name="SideFrameLWidth" value="16.7*mm"/>
+		<Constant name="PosCorrectionR" value="-2.668*mm"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDTECModuleAlgo">
+		<rParent name="tecmodule1:TECModule1"/>
+		<Numeric name="RingNo" value="1"/>
+		<Numeric name="isStereo" value="[isStereo]"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="ModuleThick" value="[tecmodpar:ModuleThick]"/>
+		<Numeric name="DetTilt" value="[tecmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[tecmodule1:FullHeight]"/>
+		<Numeric name="DlTop" value="[tecmodule1:DlTop]"/>
+		<Numeric name="DlBottom" value="[tecmodule1:DlBottom]"/>
+		<Numeric name="DlHybrid" value="[tecmodule1:DlHybrid]"/>
+		<Numeric name="FrameWidth" value="[tecmodpar:FrameWidth]"/>
+		<Numeric name="FrameThick" value="[tecmodule1:ModuleThick]"/>
+		<Numeric name="FrameOver" value="[tecmodpar:FrameOver]"/>
+		<String name="TopFrameMaterial" value="tecmaterial:TEC_frame_top"/>
+		<Numeric name="TopFrameTopWidth" value="[TopFrameTopWidth]"/>
+		<Numeric name="TopFrameBotWidth" value="[TopFrameBotWidth]"/>
+		<Numeric name="TopFrameHeight" value="[TopFrameHeight]"/>
+		<Numeric name="TopFrameThick" value="[tecmodpar:TopFrameThick]"/>
+		<Numeric name="TopFrameZ" value="[tecmodule1:TopFrameZ]"/>
+		<String name="SideFrameMaterial" value="tecmaterial:TEC_frame_side_1_4"/>
+		<Numeric name="SideFrameThick" value="[tecmodpar:SideFrameThick]"/>
+		<String name="SiFrSuppBoxMaterial" value="tecmaterial:TEC_SideFrSupBox"/>
+		<Numeric name="SideFrameRtheta" value="[SideFrameRtheta]"/>
+		<Numeric name="SideFrameRHeight" value="[SideFrameRHeight]"/>
+		<Numeric name="SideFrameRWidth" value="[SideFrameRWidth]"/>
+		<Numeric name="SideFrameLtheta" value="[SideFrameLtheta]"/>
+		<Numeric name="SideFrameLHeight" value="[SideFrameLHeight]"/>
+		<Numeric name="SideFrameLWidth" value="[SideFrameLWidth]"/>
+		<Numeric name="SiFrSuppBoxThick" value="[tecmodpar:SiFrSuppBoxThick]"/>
+		<Vector name="SiFrSuppBoxYPos" type="numeric" nEntries="1">
+			45.5*mm  </Vector>
+		<Vector name="SiFrSuppBoxHeight" type="numeric" nEntries="1">
+			37.9*mm  </Vector>
+		<Vector name="SiFrSuppBoxWidth" type="numeric" nEntries="1">
+			15.9*mm  </Vector>
+		<Numeric name="SideFrameZ" value="[tecmodule1:SideFrameZ]"/>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[tecmodule1:SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[tecmodule1:SideWidthBottom]"/>
+		<String name="WaferRotation" value="tecmodpar:RPHI"/>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[tecmodule1:ActiveHeight]"/>
+		<Numeric name="WaferThick" value="[tecmodpar:WaferThick1]"/>
+		<String name="ActiveRotation" value="tecmodpar:AR05"/>
+		<Numeric name="ActiveZ" value="[tecmodule1:ActiveZ]"/>
+		<Numeric name="BackPlaneThick" value="2*[tracker:BackPlaneDz]"/>
+		<String name="HybridMaterial" value="tecmaterial:TEC_Hybrid6APV"/>
+		<Numeric name="HybridHeight" value="[tecmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tecmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tecmodpar:HybridThick]"/>
+		<Numeric name="HybridZ" value="[tecmodule1:HybridZ]"/>
+		<String name="PitchMaterial" value="tecmaterial:TEC_PitchAdapter"/>
+		<Numeric name="PitchHeight" value="[tecmodpar:PitchHeight]"/>
+		<Numeric name="PitchThick" value="[tecmodpar:PitchThick]"/>
+		<Numeric name="PitchWidth" value="[tecmodule1:PitchWidth]"/>
+		<Numeric name="PitchZ" value="[tecmodule1:PitchZ]"/>
+		<String name="PitchRotation" value="tecmodpar:PITC"/>
+		<Numeric name="BridgeWidth" value="[tecmodule1:BridgeWidth]"/>
+		<Numeric name="BridgeThick" value="[tecmodule1:BridgeThick]"/>
+		<Numeric name="BridgeHeight" value="[tecmodule1:BridgeHeight]"/>
+		<Numeric name="BridgeSeparation" value="[tecmodule1:BridgeSeparation]"/>
+		<String name="BridgeMaterial" value="trackermaterial:T_Aluminium"/>
+		<Numeric name="WaferPosition" value="[tecmodpar:TopFrameHeight]"/>
+		<Vector name="SiReenforcementHeight" type="numeric" nEntries="1">
+			4.5*mm  </Vector>
+		<Vector name="SiReenforcementWidth" type="numeric" nEntries="1">
+			95.0*mm  </Vector>
+		<Vector name="SiReenforcementPosY" type="numeric" nEntries="1">
+			0.0001*mm  </Vector>
+		<String name="SiReenforcementMaterial" value="tecmaterial:TEC_SiReenforcment"/>
+		<Numeric name="SiReenforcementThick" value="[tecmodpar:SiReenforcementThick]"/>
+		<Numeric name="NoOverlapShift" value="[tecmodpar:NoOverlapShift]"/>
+		<Numeric name="RPos" value="0.5*([tecmodule1:Rin]+[tecmodule1:Rout])+[PosCorrectionR]"/>
+		<String name="StandardRotation" value="tecmodpar:RPHI"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodule1s.xml
+++ b/DetectorDescription/DDCMS/data/tecmodule1s.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecmodule1s.xml" eval="true">
+		<Constant name="isStereo" value="1"/>
+		<Constant name="TopFrameTopWidth" value="87.0*mm"/>
+		<Constant name="TopFrameBotWidth" value="134.3*mm"/>
+		<Constant name="TopFrameHeight" value="29.7*mm"/>
+		<Constant name="TopFrame2Width" value="134.3*mm"/>
+		<Constant name="TopFrame2LHeight" value="13.3*mm"/>
+		<Constant name="TopFrame2RHeight" value="0.1*fm"/>
+		<Constant name="SideFrameRtheta" value="0.178*rad"/>
+		<Constant name="SideFrameRHeight" value="94.9*mm"/>
+		<Constant name="SideFrameRWidthLow" value="10.4*mm"/>
+		<Constant name="SideFrameRWidth" value="21.4*mm"/>
+		<Constant name="SideFrameLtheta" value="-0.081*rad"/>
+		<Constant name="SideFrameLHeight" value="95.0*mm"/>
+		<Constant name="SideFrameLWidthLow" value="21.2*mm"/>
+		<Constant name="SideFrameLWidth" value="11.6*mm"/>
+		<Constant name="PosCorrectionR" value="-2.668*mm"/>
+		<Constant name="PosCorrectionPhi" value="0.000461*rad"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDTECModuleAlgo">
+		<rParent name="tecmodule1:TECModule1"/>
+		<Numeric name="RingNo" value="1"/>
+		<Numeric name="isStereo" value="[isStereo]"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="ModuleThick" value="[tecmodpar:ModuleThick]"/>
+		<Numeric name="DetTilt" value="[tecmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[tecmodule1:FullHeight]"/>
+		<Numeric name="DlTop" value="[tecmodule1:DlTop]"/>
+		<Numeric name="DlBottom" value="[tecmodule1:DlBottom]"/>
+		<Numeric name="DlHybrid" value="[tecmodule1:DlHybrid]"/>
+		<Numeric name="FrameWidth" value="[tecmodpar:FrameWidth]"/>
+		<Numeric name="FrameThick" value="[tecmodule1:ModuleThick]"/>
+		<Numeric name="FrameOver" value="[tecmodpar:FrameOver]"/>
+		<String name="TopFrameMaterial" value="tecmaterial:TEC_frame_top"/>
+		<Numeric name="TopFrameTopWidth" value="[TopFrameTopWidth]"/>
+		<Numeric name="TopFrameBotWidth" value="[TopFrameBotWidth]"/>
+		<Numeric name="TopFrameHeight" value="[TopFrameHeight]"/>
+		<Numeric name="TopFrame2Width" value="[TopFrame2Width]"/>
+		<Numeric name="TopFrame2LHeight" value="[TopFrame2LHeight]"/>
+		<Numeric name="TopFrame2RHeight" value="[TopFrame2RHeight]"/>
+		<Numeric name="TopFrameThick" value="[tecmodpar:TopFrameThick]"/>
+		<Numeric name="TopFrameZ" value="-[tecmodule1:TopFrameZ]"/>
+		<String name="SideFrameMaterial" value="tecmaterial:TEC_frame_side_1_4"/>
+		<Numeric name="SideFrameThick" value="[tecmodpar:SideFrameThick]"/>
+		<String name="SiFrSuppBoxMaterial" value="tecmaterial:TEC_SideFrSupBox"/>
+		<Numeric name="SideFrameRtheta" value="[SideFrameRtheta]"/>
+		<Numeric name="SideFrameRHeight" value="[SideFrameRHeight]"/>
+		<Numeric name="SideFrameRWidthLow" value="[SideFrameRWidthLow]"/>
+		<Numeric name="SideFrameRWidth" value="[SideFrameRWidth]"/>
+		<Numeric name="SideFrameLtheta" value="[SideFrameLtheta]"/>
+		<Numeric name="SideFrameLHeight" value="[SideFrameLHeight]"/>
+		<Numeric name="SideFrameLWidthLow" value="[SideFrameLWidthLow]"/>
+		<Numeric name="SideFrameLWidth" value="[SideFrameLWidth]"/>
+		<Numeric name="SiFrSuppBoxThick" value="[tecmodpar:SiFrSuppBoxThick]"/>
+		<Vector name="SiFrSuppBoxYPos" type="numeric" nEntries="1">
+			50.7*mm  </Vector>
+		<Vector name="SiFrSuppBoxHeight" type="numeric" nEntries="1">
+			30.8*mm  </Vector>
+		<Vector name="SiFrSuppBoxWidth" type="numeric" nEntries="1">
+			14.8*mm  </Vector>
+		<Numeric name="SideFrameZ" value="-[tecmodule1:SideFrameZ]"/>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[tecmodule1:SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[tecmodule1:SideWidthBottom]"/>
+		<String name="WaferRotation" value="tecmodpar:STER"/>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[tecmodule1:ActiveHeight]"/>
+		<Numeric name="WaferThick" value="[tecmodpar:WaferThick1]"/>
+		<String name="ActiveRotation" value="tecmodpar:AR05"/>
+		<Numeric name="ActiveZ" value="-[tecmodule1:ActiveZ]"/>
+		<Numeric name="BackPlaneThick" value="2*[tracker:BackPlaneDz]"/>
+		<String name="HybridMaterial" value="tecmaterial:TEC_Hybrid6APV"/>
+		<Numeric name="HybridHeight" value="[tecmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tecmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tecmodpar:HybridThick]"/>
+		<Numeric name="HybridZ" value="-[tecmodule1:HybridZ]"/>
+		<String name="PitchMaterial" value="tecmaterial:TEC_PitchAdapter"/>
+		<Numeric name="PitchHeight" value="[tecmodpar:PitchStereoHeight]"/>
+		<Numeric name="PitchThick" value="[tecmodpar:PitchThick]"/>
+		<Numeric name="PitchWidth" value="[tecmodule1:PitchWidth]"/>
+		<Numeric name="PitchZ" value="-[tecmodule1:PitchZ]"/>
+		<String name="PitchRotation" value="tecmodpar:PITC"/>
+		<Numeric name="BridgeWidth" value="[tecmodule1:BridgeWidth]"/>
+		<Numeric name="BridgeThick" value="[tecmodule1:BridgeThick]"/>
+		<Numeric name="BridgeHeight" value="[tecmodule1:BridgeHeight]"/>
+		<Numeric name="BridgeSeparation" value="[tecmodule1:BridgeSeparation]"/>
+		<String name="BridgeMaterial" value="None"/>
+		<Numeric name="WaferPosition" value="[tecmodpar:TopFrameHeight]"/>
+		<Vector name="SiReenforcementHeight" type="numeric" nEntries="1">
+			4.4*mm  </Vector>
+		<Vector name="SiReenforcementWidth" type="numeric" nEntries="1">
+			94.0*mm  </Vector>
+		<Vector name="SiReenforcementPosY" type="numeric" nEntries="1">
+			2*mm  </Vector>
+		<!-- they to be placed right! (are not due to problems with mother volume thickness)-->
+		<String name="SiReenforcementMaterial" value="tecmaterial:TEC_SiReenforcment"/>
+		<Numeric name="SiReenforcementThick" value="[tecmodpar:SiReenforcementThick]"/>
+		<Numeric name="NoOverlapShift" value="[tecmodpar:NoOverlapShift]"/>
+		<Numeric name="RPos" value="0.5*([tecmodule1:Rin]+[tecmodule1:Rout])+[PosCorrectionR]"/>
+		<String name="StandardRotation" value="tecmodpar:RPHI"/>
+		<Numeric name="PosCorrectionPhi" value="-[PosCorrectionPhi]"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodule2.xml
+++ b/DetectorDescription/DDCMS/data/tecmodule2.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecmodule2.xml" eval="true">
+		<Constant name="Rin" value="38.77*cm"/>
+		<Constant name="Rout" value="54.70*cm"/>
+		<Constant name="isStereo" value="0"/>
+		<Constant name="FullHeight" value="11.2736000*cm"/>
+		<Constant name="ActiveHeight" value="11.0660000*cm"/>
+		<Constant name="DlTop" value="8.3012000*cm"/>
+		<Constant name="DlBottom" value="6.4904000*cm"/>
+		<Constant name="SideWidthTop" value="0.1006846*cm"/>
+		<Constant name="SideWidthBottom" value="0.0866913*cm"/>
+		<Constant name="HybridZ" value="[TopFrameZ]+ 0.5*([tecmodpar:TopFrameThick] + [tecmodpar:HybridThick])"/>
+		<Constant name="TopFrameZ" value="[SideFrameZ]+ 0.5*(-[tecmodpar:SideFrameThick]+[tecmodpar:TopFrameThick])"/>
+		<Constant name="SideFrameZ" value="[ActiveZ]+0.5*(-[tecmodpar:WaferThick1] - [tecmodpar:SideFrameThick])"/>
+		<Constant name="PitchZ" value="[TopFrameZ] + 0.5*([tecmodpar:TopFrameThick] + [tecmodpar:PitchThick])"/>
+		<Constant name="DlHybrid" value="8.920*cm"/>
+		<Constant name="BridgeWidth" value="2.477*cm"/>
+		<Constant name="BridgeThick" value="0.209*cm"/>
+		<Constant name="BridgeHeight" value="2.53*cm"/>
+		<Constant name="BridgeSeparation" value="4.499*cm"/>
+		<Constant name="ModuleThick" value="[tecmodpar:ModuleThickSS]"/>
+		<Constant name="ShiftZ" value="0.5*[tecmodpar:SideFrameThick]"/>
+		<Constant name="TopFrameTopWidth" value="71.7*mm"/>
+		<Constant name="TopFrameBotWidth" value="103.7*mm"/>
+		<Constant name="TopFrameHeight" value="35.7*mm"/>
+		<Constant name="SideFrameRtheta" value="-0.081*rad"/>
+		<Constant name="SideFrameRHeight" value="119.6*mm"/>
+		<Constant name="SideFrameRWidth" value="13.9*mm"/>
+		<Constant name="SideFrameLtheta" value="0.081*rad"/>
+		<Constant name="SideFrameLHeight" value="119.6*mm"/>
+		<Constant name="SideFrameLWidth" value="15.2*mm"/>
+		<Constant name="ActiveZ" value="([tecmodpar:ActiveZ1]+[ShiftZ])"/>
+		<Constant name="PitchWidth" value="83.2*mm"/>
+		<Constant name="dPhi" value="2.2*asin(0.5*[TopFrameBotWidth]/([Rin]+[FullHeight]))"/>
+		<Constant name="PosCorrectionR" value="-1.318*mm"/>
+	</ConstantsSection>
+	<SolidSection label="tecmodule2.xml">
+		<Tubs name="TECModule2" rMin="[Rin]" rMax="[Rout]" dz="0.5*[tecmodpar:ModuleThickSS]" startPhi="-[dPhi]/2" deltaPhi="[dPhi]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecmodule2.xml">
+		<LogicalPart name="TECModule2" category="unspecified">
+			<rSolid name="tecmodule2:TECModule2"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECModuleAlgo">
+		<rParent name="tecmodule2:TECModule2"/>
+		<Numeric name="RingNo" value="2"/>
+		<Numeric name="isStereo" value="[isStereo]"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="ModuleThick" value="[tecmodpar:ModuleThick]"/>
+		<Numeric name="DetTilt" value="[tecmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[FullHeight]"/>
+		<Numeric name="DlTop" value="[DlTop]"/>
+		<Numeric name="DlBottom" value="[DlBottom]"/>
+		<Numeric name="DlHybrid" value="[DlHybrid]"/>
+		<Numeric name="FrameWidth" value="[tecmodpar:FrameWidth]"/>
+		<Numeric name="FrameThick" value="[ModuleThick]"/>
+		<Numeric name="FrameOver" value="[tecmodpar:FrameOver]"/>
+		<String name="TopFrameMaterial" value="tecmaterial:TEC_frame_top"/>
+		<Numeric name="TopFrameTopWidth" value="[TopFrameTopWidth]"/>
+		<Numeric name="TopFrameBotWidth" value="[TopFrameBotWidth]"/>
+		<Numeric name="TopFrameHeight" value="[TopFrameHeight]"/>
+		<Numeric name="TopFrameThick" value="[tecmodpar:TopFrameThick]"/>
+		<Numeric name="TopFrameZ" value="[TopFrameZ]"/>
+		<String name="SideFrameMaterial" value="tecmaterial:TEC_frame_side_1_4"/>
+		<Numeric name="SideFrameThick" value="[tecmodpar:SideFrameThick]"/>
+		<String name="SiFrSuppBoxMaterial" value="tecmaterial:TEC_SideFrSupBox"/>
+		<Numeric name="SideFrameRtheta" value="[SideFrameRtheta]"/>
+		<Numeric name="SideFrameRHeight" value="[SideFrameRHeight]"/>
+		<Numeric name="SideFrameRWidth" value="[SideFrameRWidth]"/>
+		<Numeric name="SideFrameLtheta" value="[SideFrameLtheta]"/>
+		<Numeric name="SideFrameLHeight" value="[SideFrameLHeight]"/>
+		<Numeric name="SideFrameLWidth" value="[SideFrameLWidth]"/>
+		<Numeric name="SiFrSuppBoxThick" value="[tecmodpar:SiFrSuppBoxThick]"/>
+		<Vector name="SiFrSuppBoxYPos" type="numeric" nEntries="1">
+			56.9*mm  </Vector>
+		<Vector name="SiFrSuppBoxHeight" type="numeric" nEntries="1">
+			30.2*mm  </Vector>
+		<Vector name="SiFrSuppBoxWidth" type="numeric" nEntries="1">
+			15.8*mm  </Vector>
+		<Numeric name="SideFrameZ" value="[SideFrameZ]"/>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[SideWidthBottom]"/>
+		<String name="WaferRotation" value="tecmodpar:RFI2"/>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[ActiveHeight]"/>
+		<Numeric name="WaferThick" value="[tecmodpar:WaferThick1]"/>
+		<String name="ActiveRotation" value="tecmodpar:AR05"/>
+		<Numeric name="ActiveZ" value="[ActiveZ]"/>
+		<Numeric name="BackPlaneThick" value="2*[tracker:BackPlaneDz]"/>
+		<String name="HybridMaterial" value="tecmaterial:TEC_Hybrid4APV"/>
+		<Numeric name="HybridHeight" value="[tecmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tecmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tecmodpar:HybridThick]"/>
+		<Numeric name="HybridZ" value="[HybridZ]"/>
+		<String name="PitchMaterial" value="tecmaterial:TEC_PitchAdapter"/>
+		<Numeric name="PitchHeight" value="[tecmodpar:PitchHeight]"/>
+		<Numeric name="PitchThick" value="[tecmodpar:PitchThick]"/>
+		<Numeric name="PitchWidth" value="[PitchWidth]"/>
+		<Numeric name="PitchZ" value="[PitchZ]"/>
+		<String name="PitchRotation" value="tecmodpar:PITC"/>
+		<Numeric name="BridgeWidth" value="[BridgeWidth]"/>
+		<Numeric name="BridgeThick" value="[BridgeThick]"/>
+		<Numeric name="BridgeHeight" value="[BridgeHeight]"/>
+		<Numeric name="BridgeSeparation" value="[BridgeSeparation]"/>
+		<String name="BridgeMaterial" value="trackermaterial:T_Aluminium"/>
+		<Numeric name="WaferPosition" value="[tecmodpar:TopFrameHeight]"/>
+		<Vector name="SiReenforcementHeight" type="numeric" nEntries="1">
+			4.7*mm  </Vector>
+		<Vector name="SiReenforcementWidth" type="numeric" nEntries="1">
+			69.0*mm  </Vector>
+		<Vector name="SiReenforcementPosY" type="numeric" nEntries="1">
+			0.0001*mm  </Vector>
+		<String name="SiReenforcementMaterial" value="tecmaterial:TEC_SiReenforcment"/>
+		<Numeric name="SiReenforcementThick" value="[tecmodpar:SiReenforcementThick]"/>
+		<Numeric name="NoOverlapShift" value="[tecmodpar:NoOverlapShift]"/>
+		<Numeric name="RPos" value="0.5*([tecmodule2:Rin]+[tecmodule2:Rout])+[PosCorrectionR]"/>
+		<String name="StandardRotation" value="tecmodpar:RPHI"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodule3.xml
+++ b/DetectorDescription/DDCMS/data/tecmodule3.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecmodule3.xml" eval="true">
+		<Constant name="Rin" value="50.00*cm"/>
+		<Constant name="Rout" value="66.242*cm"/>
+		<Constant name="isStereo" value="0"/>
+		<Constant name="FullHeight" value="11.7236000*cm"/>
+		<Constant name="ActiveHeight" value="11.5160000*cm"/>
+		<Constant name="DlTop" value="7.3179000*cm"/>
+		<Constant name="DlBottom" value="5.9730000*cm"/>
+		<Constant name="SideWidthTop" value="0.0979314*cm"/>
+		<Constant name="SideWidthBottom" value="0.0877023*cm"/>
+		<Constant name="HybridZ" value="[TopFrameZ]+ 0.5*([tecmodpar:TopFrameThick] + [tecmodpar:HybridThick])"/>
+		<Constant name="TopFrameZ" value="[SideFrameZ]+ 0.5*(-[tecmodpar:SideFrameThick]+[tecmodpar:TopFrameThick])"/>
+		<Constant name="SideFrameZ" value="[ActiveZ]+0.5*(-[tecmodpar:WaferThick1] - [tecmodpar:SideFrameThick])"/>
+		<Constant name="PitchZ" value="[TopFrameZ] + 0.5*([tecmodpar:TopFrameThick] + [tecmodpar:PitchThick])"/>
+		<Constant name="DlHybrid" value="7.770*cm"/>
+		<Constant name="BridgeWidth" value="2.471*cm"/>
+		<Constant name="BridgeThick" value="0.212*cm"/>
+		<Constant name="BridgeHeight" value="1.988*cm"/>
+		<Constant name="BridgeSeparation" value="3.750*cm"/>
+		<Constant name="ModuleThick" value="[tecmodpar:ModuleThickSS]"/>
+		<Constant name="ShiftZ" value="0.5*[tecmodpar:SideFrameThick]"/>
+		<Constant name="TopFrameTopWidth" value="88.9*mm"/>
+		<Constant name="TopFrameBotWidth" value="93.7*mm"/>
+		<Constant name="TopFrameHeight" value="35.7*mm"/>
+		<Constant name="SideFrameRtheta" value="-0.058*rad"/>
+		<Constant name="SideFrameRHeight" value="122.1*mm"/>
+		<Constant name="SideFrameRWidth" value="14.0*mm"/>
+		<Constant name="SideFrameLtheta" value="0.057*rad"/>
+		<Constant name="SideFrameLHeight" value="122.1*mm"/>
+		<Constant name="SideFrameLWidth" value="15.2*mm"/>
+		<Constant name="ActiveZ" value="([tecmodpar:ActiveZ1]+[ShiftZ])"/>
+		<Constant name="PitchWidth" value="73.3*mm"/>
+		<Constant name="dPhi" value="2.2*asin(0.5*[TopFrameBotWidth]/([Rin]+[FullHeight]))"/>
+		<Constant name="PosCorrectionR" value="-0.8287*mm"/>
+	</ConstantsSection>
+	<SolidSection label="tecmodule3.xml">
+		<Tubs name="TECModule3" rMin="[Rin]" rMax="[Rout]" dz="0.5*[tecmodpar:ModuleThickSS]" startPhi="-[dPhi]/2" deltaPhi="[dPhi]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecmodule3.xml">
+		<LogicalPart name="TECModule3" category="unspecified">
+			<rSolid name="tecmodule3:TECModule3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECModuleAlgo">
+		<rParent name="tecmodule3:TECModule3"/>
+		<Numeric name="RingNo" value="3"/>
+		<Numeric name="isStereo" value="[isStereo]"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="ModuleThick" value="[tecmodpar:ModuleThick]"/>
+		<Numeric name="DetTilt" value="[tecmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[FullHeight]"/>
+		<Numeric name="DlTop" value="[DlTop]"/>
+		<Numeric name="DlBottom" value="[DlBottom]"/>
+		<Numeric name="DlHybrid" value="[DlHybrid]"/>
+		<Numeric name="FrameWidth" value="[tecmodpar:FrameWidth]"/>
+		<Numeric name="FrameThick" value="[ModuleThick]"/>
+		<Numeric name="FrameOver" value="[tecmodpar:FrameOver]"/>
+		<String name="TopFrameMaterial" value="tecmaterial:TEC_frame_top"/>
+		<Numeric name="TopFrameTopWidth" value="[TopFrameTopWidth]"/>
+		<Numeric name="TopFrameBotWidth" value="[TopFrameBotWidth]"/>
+		<Numeric name="TopFrameHeight" value="[TopFrameHeight]"/>
+		<Numeric name="TopFrameThick" value="[tecmodpar:TopFrameThick]"/>
+		<Numeric name="TopFrameZ" value="[TopFrameZ]"/>
+		<String name="SideFrameMaterial" value="tecmaterial:TEC_frame_side_1_4"/>
+		<Numeric name="SideFrameThick" value="[tecmodpar:SideFrameThick]"/>
+		<String name="SiFrSuppBoxMaterial" value="tecmaterial:TEC_SideFrSupBox"/>
+		<Numeric name="SideFrameRtheta" value="[SideFrameRtheta]"/>
+		<Numeric name="SideFrameRHeight" value="[SideFrameRHeight]"/>
+		<Numeric name="SideFrameRWidth" value="[SideFrameRWidth]"/>
+		<Numeric name="SideFrameLtheta" value="[SideFrameLtheta]"/>
+		<Numeric name="SideFrameLHeight" value="[SideFrameLHeight]"/>
+		<Numeric name="SideFrameLWidth" value="[SideFrameLWidth]"/>
+		<Numeric name="SiFrSuppBoxThick" value="[tecmodpar:SiFrSuppBoxThick]"/>
+		<Vector name="SiFrSuppBoxYPos" type="numeric" nEntries="1">
+			59.3 *mm  </Vector>
+		<Vector name="SiFrSuppBoxHeight" type="numeric" nEntries="1">
+			30.3*mm  </Vector>
+		<Vector name="SiFrSuppBoxWidth" type="numeric" nEntries="1">
+			15.8*mm  </Vector>
+		<Numeric name="SideFrameZ" value="[SideFrameZ]"/>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[SideWidthBottom]"/>
+		<String name="WaferRotation" value="tecmodpar:RFI2"/>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[ActiveHeight]"/>
+		<Numeric name="WaferThick" value="[tecmodpar:WaferThick1]"/>
+		<String name="ActiveRotation" value="tecmodpar:AR05"/>
+		<Numeric name="ActiveZ" value="[ActiveZ]"/>
+		<Numeric name="BackPlaneThick" value="2*[tracker:BackPlaneDz]"/>
+		<String name="HybridMaterial" value="tecmaterial:TEC_Hybrid4APV"/>
+		<Numeric name="HybridHeight" value="[tecmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tecmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tecmodpar:HybridThick]"/>
+		<Numeric name="HybridZ" value="[HybridZ]"/>
+		<String name="PitchMaterial" value="tecmaterial:TEC_PitchAdapter"/>
+		<Numeric name="PitchHeight" value="[tecmodpar:PitchHeight]"/>
+		<Numeric name="PitchThick" value="[tecmodpar:PitchThick]"/>
+		<Numeric name="PitchWidth" value="[PitchWidth]"/>
+		<Numeric name="PitchZ" value="[PitchZ]"/>
+		<String name="PitchRotation" value="tecmodpar:PITC"/>
+		<Numeric name="BridgeWidth" value="[BridgeWidth]"/>
+		<Numeric name="BridgeThick" value="[BridgeThick]"/>
+		<Numeric name="BridgeHeight" value="[BridgeHeight]"/>
+		<Numeric name="BridgeSeparation" value="[BridgeSeparation]"/>
+		<String name="BridgeMaterial" value="trackermaterial:T_Aluminium"/>
+		<Numeric name="WaferPosition" value="[tecmodpar:TopFrameHeight]"/>
+		<Vector name="SiReenforcementHeight" type="numeric" nEntries="1">
+			4.8*mm  </Vector>
+		<Vector name="SiReenforcementWidth" type="numeric" nEntries="1">
+			61.0*mm  </Vector>
+		<Vector name="SiReenforcementPosY" type="numeric" nEntries="1">
+			0.0001*mm  </Vector>
+		<String name="SiReenforcementMaterial" value="tecmaterial:TEC_SiReenforcment"/>
+		<Numeric name="SiReenforcementThick" value="[tecmodpar:SiReenforcementThick]"/>
+		<Numeric name="NoOverlapShift" value="[tecmodpar:NoOverlapShift]"/>
+		<Numeric name="RPos" value="0.5*([tecmodule3:Rin]+[tecmodule3:Rout])-0.8287*mm"/>
+		<Numeric name="RPos" value="0.5*([tecmodule3:Rin]+[tecmodule3:Rout])+[PosCorrectionR]"/>
+		<String name="StandardRotation" value="tecmodpar:RPHI"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodule4.xml
+++ b/DetectorDescription/DDCMS/data/tecmodule4.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecmodule4.xml" eval="true">
+		<Constant name="Rin" value="59.67*cm"/>
+		<Constant name="Rout" value="79.76*cm"/>
+		<Constant name="FullHeight" value="15.0029000*cm"/>
+		<Constant name="ActiveHeight" value="14.7262500*cm"/>
+		<Constant name="DlTop" value="12.2914000*cm"/>
+		<Constant name="DlBottom" value="9.8952000*cm"/>
+		<Constant name="InactiveStart" value="65.983*mm"/>
+		<Constant name="SideWidthTop" value="0.1431406*cm"/>
+		<Constant name="SideWidthBottom" value="0.1229168*cm"/>
+		<Constant name="HybridZ" value="[ActiveZ]+ 0.5*(-[tecmodpar:WaferThick2] + [tecmodpar:HybridThick])"/>
+		<Constant name="TopFrameZ" value="[HybridZ]+ 0.5*([tecmodpar:HybridThick]+[tecmodpar:TopFrameThick])"/>
+		<Constant name="SideFrameZ" value="[TopFrameZ]+0.5*(-[tecmodpar:TopFrameThick]+[tecmodpar:SideFrameThick])"/>
+		<Constant name="PitchZ" value="[TopFrameZ] - 0.5*([tecmodpar:TopFrameThick] + [tecmodpar:PitchThick])"/>
+		<Constant name="DlHybrid" value="12.900*cm"/>
+		<Constant name="BridgeWidth" value="2.475*cm"/>
+		<Constant name="BridgeThick" value="0.176*cm"/>
+		<Constant name="BridgeHeight" value="2.60*cm"/>
+		<Constant name="BridgeSeparation" value="8.300*cm"/>
+		<Constant name="ModuleThick" value="[tecmodpar:ModuleThickDS]"/>
+		<Constant name="ShiftZ" value="-([tecmodpar:ModuleThick]+                                             [tecmodpar:GapModule])/2"/>
+		<Constant name="TopFrameBotWidth" value="143.3*mm"/>
+		<Constant name="ActiveZ" value="([tecmodpar:ActiveZ2]+[ShiftZ])"/>
+		<Constant name="PitchWidth" value="122.6*mm"/>
+		<Constant name="dPhi" value="2.2*asin(0.5*[TopFrameBotWidth]/([Rin]+[FullHeight]))"/>
+	</ConstantsSection>
+	<SolidSection label="tecmodule4.xml">
+		<Tubs name="TECModule4" rMin="[Rin]" rMax="[Rout]" dz="0.5*[tecmodpar:ModuleThickDS]" startPhi="-[dPhi]/2" deltaPhi="[dPhi]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecmodule4.xml">
+		<LogicalPart name="TECModule4" category="unspecified">
+			<rSolid name="tecmodule4:TECModule4"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodule4r.xml
+++ b/DetectorDescription/DDCMS/data/tecmodule4r.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecmodule4r.xml" eval="true">
+		<Constant name="isStereo" value="0"/>
+		<Constant name="TopFrameTopWidth" value="95.6*mm"/>
+		<Constant name="TopFrameBotWidth" value="[tecmodule4:TopFrameBotWidth]"/>
+		<Constant name="TopFrameHeight" value="37.2*mm"/>
+		<Constant name="SideFrameRtheta" value="0.080*rad"/>
+		<Constant name="SideFrameRHeight" value="158.9*mm"/>
+		<Constant name="SideFrameRWidth" value="14.5*mm"/>
+		<Constant name="SideFrameLtheta" value="-0.080*rad"/>
+		<Constant name="SideFrameLHeight" value="159.0*mm"/>
+		<Constant name="SideFrameLWidth" value="16.4*mm"/>
+		<Constant name="PosCorrectionR" value="-1.664*mm"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDTECModuleAlgo">
+		<rParent name="tecmodule4:TECModule4"/>
+		<Numeric name="RingNo" value="4"/>
+		<Numeric name="isStereo" value="[isStereo]"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="ModuleThick" value="[tecmodpar:ModuleThick]"/>
+		<Numeric name="DetTilt" value="[tecmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[tecmodule4:FullHeight]"/>
+		<Numeric name="DlTop" value="[tecmodule4:DlTop]"/>
+		<Numeric name="DlBottom" value="[tecmodule4:DlBottom]"/>
+		<Numeric name="DlHybrid" value="[tecmodule4:DlHybrid]"/>
+		<Numeric name="FrameWidth" value="[tecmodpar:FrameWidth]"/>
+		<Numeric name="FrameThick" value="[tecmodule4:ModuleThick]"/>
+		<Numeric name="FrameOver" value="[tecmodpar:FrameOver]"/>
+		<String name="TopFrameMaterial" value="tecmaterial:TEC_frame_top"/>
+		<Numeric name="TopFrameTopWidth" value="[TopFrameTopWidth]"/>
+		<Numeric name="TopFrameBotWidth" value="[TopFrameBotWidth]"/>
+		<Numeric name="TopFrameHeight" value="[TopFrameHeight]"/>
+		<Numeric name="TopFrameThick" value="[tecmodpar:TopFrameThick]"/>
+		<Numeric name="TopFrameZ" value="[tecmodule4:TopFrameZ]"/>
+		<String name="SideFrameMaterial" value="tecmaterial:TEC_frame_side_5_7"/>
+		<Numeric name="SideFrameThick" value="[tecmodpar:SideFrameThick]"/>
+		<String name="SiFrSuppBoxMaterial" value="tecmaterial:TEC_SideFrSupBox"/>
+		<Numeric name="SideFrameRtheta" value="[SideFrameRtheta]"/>
+		<Numeric name="SideFrameRHeight" value="[SideFrameRHeight]"/>
+		<Numeric name="SideFrameRWidth" value="[SideFrameRWidth]"/>
+		<Numeric name="SideFrameLtheta" value="[SideFrameLtheta]"/>
+		<Numeric name="SideFrameLHeight" value="[SideFrameLHeight]"/>
+		<Numeric name="SideFrameLWidth" value="[SideFrameLWidth]"/>
+		<Numeric name="SiFrSuppBoxThick" value="[tecmodpar:SiFrSuppBoxThick]"/>
+		<Vector name="SiFrSuppBoxYPos" type="numeric" nEntries="2">
+			37.8*mm, 112.3*mm </Vector>
+		<Vector name="SiFrSuppBoxHeight" type="numeric" nEntries="2">
+			30.7*mm, 26.5*mm </Vector>
+		<Vector name="SiFrSuppBoxWidth" type="numeric" nEntries="2">
+			16.0*mm, 15.2*mm </Vector>
+		<Numeric name="SideFrameZ" value="[tecmodule4:SideFrameZ]"/>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[tecmodule4:SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[tecmodule4:SideWidthBottom]"/>
+		<String name="WaferRotation" value="tecmodpar:RPHI"/>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[tecmodule4:ActiveHeight]"/>
+		<Numeric name="WaferThick" value="[tecmodpar:WaferThick2]"/>
+		<String name="ActiveRotation" value="tecmodpar:AR05"/>
+		<Numeric name="ActiveZ" value="[tecmodule4:ActiveZ]"/>
+		<Numeric name="BackPlaneThick" value="2*[tracker:BackPlaneDz]"/>
+		<Numeric name="InactiveDy" value="[tecmodpar:InactiveDy]"/>
+		<Numeric name="InactivePos" value="[tecmodule4:InactiveStart]+[tecmodpar:InactiveDy]"/>
+		<String name="InactiveMaterial" value="materials:Silicon"/>
+		<String name="HybridMaterial" value="tecmaterial:TEC_Hybrid6APV"/>
+		<Numeric name="HybridHeight" value="[tecmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tecmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tecmodpar:HybridThick]"/>
+		<Numeric name="HybridZ" value="[tecmodule4:HybridZ]"/>
+		<String name="PitchMaterial" value="tecmaterial:TEC_PitchAdapter"/>
+		<Numeric name="PitchHeight" value="[tecmodpar:PitchHeight]"/>
+		<Numeric name="PitchThick" value="[tecmodpar:PitchThick]"/>
+		<Numeric name="PitchWidth" value="[tecmodule4:PitchWidth]"/>
+		<Numeric name="PitchZ" value="[tecmodule4:PitchZ]"/>
+		<String name="PitchRotation" value="tecmodpar:PITC"/>
+		<Numeric name="BridgeWidth" value="[tecmodule4:BridgeWidth]"/>
+		<Numeric name="BridgeThick" value="[tecmodule4:BridgeThick]"/>
+		<Numeric name="BridgeHeight" value="[tecmodule4:BridgeHeight]"/>
+		<Numeric name="BridgeSeparation" value="[tecmodule4:BridgeSeparation]"/>
+		<String name="BridgeMaterial" value="trackermaterial:T_Aluminium"/>
+		<Numeric name="WaferPosition" value="[tecmodpar:TopFrameHeight]"/>
+		<Vector name="SiReenforcementHeight" type="numeric" nEntries="2">
+			4.51*mm, 8.1*mm  </Vector>
+		<Vector name="SiReenforcementWidth" type="numeric" nEntries="2">
+			102.0*mm, 98.0*mm  </Vector>
+		<Vector name="SiReenforcementPosY" type="numeric" nEntries="2">
+			0.0001*mm, [tecmodule4:InactiveStart] </Vector>
+		<String name="SiReenforcementMaterial" value="tecmaterial:TEC_SiReenforcment"/>
+		<Numeric name="SiReenforcementThick" value="[tecmodpar:SiReenforcementThick]"/>
+		<Numeric name="NoOverlapShift" value="[tecmodpar:NoOverlapShift]"/>
+		<Numeric name="RPos" value="0.5*([tecmodule4:Rin]+[tecmodule4:Rout])+[PosCorrectionR]"/>
+		<String name="StandardRotation" value="tecmodpar:RPHI"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodule4s.xml
+++ b/DetectorDescription/DDCMS/data/tecmodule4s.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecmodule4s.xml" eval="true">
+		<Constant name="isStereo" value="1"/>
+		<Constant name="TopFrameTopWidth" value="90.7*mm"/>
+		<Constant name="TopFrameBotWidth" value="145.3*mm"/>
+		<Constant name="TopFrameHeight" value="25.6*mm"/>
+		<Constant name="TopFrame2Width" value="121.7*mm"/>
+		<Constant name="TopFrame2LHeight" value="19.4*mm"/>
+		<Constant name="TopFrame2RHeight" value="7.3*mm"/>
+		<Constant name="SideFrameRtheta" value="0.139*rad"/>
+		<Constant name="SideFrameRHeight" value="153.4*mm"/>
+		<Constant name="SideFrameRWidthLow" value="7.8*mm"/>
+		<Constant name="SideFrameRWidth" value="21.8*mm"/>
+		<Constant name="SideFrameLtheta" value="-0.047*rad"/>
+		<Constant name="SideFrameLHeight" value="153.4*mm"/>
+		<Constant name="SideFrameLWidthLow" value="21.1*mm"/>
+		<Constant name="SideFrameLWidth" value="10.8*mm"/>
+		<Constant name="PosCorrectionR" value="-1.664*mm"/>
+		<Constant name="PosCorrectionPhi" value="-0.0003755*rad"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDTECModuleAlgo">
+		<rParent name="tecmodule4:TECModule4"/>
+		<Numeric name="RingNo" value="4"/>
+		<Numeric name="isStereo" value="[isStereo]"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="ModuleThick" value="[tecmodpar:ModuleThick]"/>
+		<Numeric name="DetTilt" value="[tecmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[tecmodule4:FullHeight]"/>
+		<Numeric name="DlTop" value="[tecmodule4:DlTop]"/>
+		<Numeric name="DlBottom" value="[tecmodule4:DlBottom]"/>
+		<Numeric name="DlHybrid" value="[tecmodule4:DlHybrid]"/>
+		<Numeric name="FrameWidth" value="[tecmodpar:FrameWidth]"/>
+		<Numeric name="FrameThick" value="[tecmodule4:ModuleThick]"/>
+		<Numeric name="FrameOver" value="[tecmodpar:FrameOver]"/>
+		<String name="TopFrameMaterial" value="tecmaterial:TEC_frame_top"/>
+		<Numeric name="TopFrameTopWidth" value="[TopFrameTopWidth]"/>
+		<Numeric name="TopFrameBotWidth" value="[TopFrameBotWidth]"/>
+		<Numeric name="TopFrameHeight" value="[TopFrameHeight]"/>
+		<Numeric name="TopFrame2Width" value="[TopFrame2Width]"/>
+		<Numeric name="TopFrame2LHeight" value="[TopFrame2LHeight]"/>
+		<Numeric name="TopFrame2RHeight" value="[TopFrame2RHeight]"/>
+		<Numeric name="TopFrameThick" value="[tecmodpar:TopFrameThick]"/>
+		<Numeric name="TopFrameZ" value="-[tecmodule4:TopFrameZ]"/>
+		<String name="SideFrameMaterial" value="tecmaterial:TEC_frame_side_5_7"/>
+		<Numeric name="SideFrameThick" value="[tecmodpar:SideFrameThick]"/>
+		<String name="SiFrSuppBoxMaterial" value="tecmaterial:TEC_SideFrSupBox"/>
+		<Numeric name="SideFrameRtheta" value="[SideFrameRtheta]"/>
+		<Numeric name="SideFrameRHeight" value="[SideFrameRHeight]"/>
+		<Numeric name="SideFrameRWidthLow" value="[SideFrameRWidthLow]"/>
+		<Numeric name="SideFrameRWidth" value="[SideFrameRWidth]"/>
+		<Numeric name="SideFrameLtheta" value="[SideFrameLtheta]"/>
+		<Numeric name="SideFrameLHeight" value="[SideFrameLHeight]"/>
+		<Numeric name="SideFrameLWidthLow" value="[SideFrameLWidthLow]"/>
+		<Numeric name="SideFrameLWidth" value="[SideFrameLWidth]"/>
+		<Numeric name="SiFrSuppBoxThick" value="[tecmodpar:SiFrSuppBoxThick]"/>
+		<Vector name="SiFrSuppBoxYPos" type="numeric" nEntries="2">
+			34.4*mm, 110.5*mm </Vector>
+		<Vector name="SiFrSuppBoxHeight" type="numeric" nEntries="2">
+			33.1*mm, 26.3*mm  </Vector>
+		<Vector name="SiFrSuppBoxWidth" type="numeric" nEntries="2">
+			16.2*mm, 15.3*mm  </Vector>
+		<Numeric name="SideFrameZ" value="-[tecmodule4:SideFrameZ]"/>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[tecmodule4:SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[tecmodule4:SideWidthBottom]"/>
+		<String name="WaferRotation" value="tecmodpar:STER"/>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[tecmodule4:ActiveHeight]"/>
+		<Numeric name="WaferThick" value="[tecmodpar:WaferThick2]"/>
+		<String name="ActiveRotation" value="tecmodpar:AR05"/>
+		<Numeric name="ActiveZ" value="-[tecmodule4:ActiveZ]"/>
+		<Numeric name="BackPlaneThick" value="2*[tracker:BackPlaneDz]"/>
+		<Numeric name="InactiveDy" value="[tecmodpar:InactiveDy]"/>
+		<Numeric name="InactivePos" value="[tecmodule4:InactiveStart]+[tecmodpar:InactiveDy]"/>
+		<String name="InactiveMaterial" value="materials:Silicon"/>
+		<String name="HybridMaterial" value="tecmaterial:TEC_Hybrid6APV"/>
+		<Numeric name="HybridHeight" value="[tecmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tecmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tecmodpar:HybridThick]"/>
+		<Numeric name="HybridZ" value="-[tecmodule4:HybridZ]"/>
+		<String name="PitchMaterial" value="tecmaterial:TEC_PitchAdapter"/>
+		<Numeric name="PitchHeight" value="[tecmodpar:PitchStereoHeight]"/>
+		<Numeric name="PitchThick" value="[tecmodpar:PitchThick]"/>
+		<Numeric name="PitchWidth" value="[tecmodule4:PitchWidth]"/>
+		<Numeric name="PitchZ" value="-[tecmodule4:PitchZ]"/>
+		<String name="PitchRotation" value="tecmodpar:PITC"/>
+		<Numeric name="BridgeWidth" value="[tecmodule4:BridgeWidth]"/>
+		<Numeric name="BridgeThick" value="[tecmodule4:BridgeThick]"/>
+		<Numeric name="BridgeHeight" value="[tecmodule4:BridgeHeight]"/>
+		<Numeric name="BridgeSeparation" value="[tecmodule4:BridgeSeparation]"/>
+		<String name="BridgeMaterial" value="None"/>
+		<Numeric name="WaferPosition" value="[tecmodpar:TopFrameHeight]"/>
+		<Vector name="SiReenforcementHeight" type="numeric" nEntries="2">
+			4.4*mm, 8.47*mm  </Vector>
+		<Vector name="SiReenforcementWidth" type="numeric" nEntries="2">
+			106.0*mm, 94.0*mm  </Vector>
+		<Vector name="SiReenforcementPosY" type="numeric" nEntries="2">
+			2.*mm, [tecmodule4:InactiveStart]-8.47*mm/2 </Vector>
+		<!-- they to be placed right! (are not due to problems with mother volume thickness)-->
+		<String name="SiReenforcementMaterial" value="tecmaterial:TEC_SiReenforcment"/>
+		<Numeric name="SiReenforcementThick" value="[tecmodpar:SiReenforcementThick]"/>
+		<Numeric name="NoOverlapShift" value="[tecmodpar:NoOverlapShift]"/>
+		<Numeric name="RPos" value="0.5*([tecmodule4:Rin]+[tecmodule4:Rout])+[PosCorrectionR]"/>
+		<String name="StandardRotation" value="tecmodpar:RPHI"/>
+		<Numeric name="PosCorrectionPhi" value="[PosCorrectionPhi]"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodule5.xml
+++ b/DetectorDescription/DDCMS/data/tecmodule5.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecmodule5.xml" eval="true">
+		<Constant name="Rin" value="72.11*cm"/>
+		<Constant name="Rout" value="95.61*cm"/>
+		<Constant name="isStereo" value="0"/>
+		<Constant name="FullHeight" value="18.6980000*cm"/>
+		<Constant name="ActiveHeight" value="18.4088000*cm"/>
+		<Constant name="DlTop" value="10.7285000*cm"/>
+		<Constant name="DlBottom" value="8.6184000*cm"/>
+		<Constant name="InactiveStart" value="87.840*mm"/>
+		<Constant name="SideWidthTop" value="0.1287673*cm"/>
+		<Constant name="SideWidthBottom" value="0.1315619*cm"/>
+		<!--Constant name="HybridZ"            value="[ActiveZ]+ 0.5*(-[tecmodpar:WaferThick2] + [tecmodpar:HybridThick])"/>
+		     <Constant name="TopFrameZ"          value="[HybridZ]+ 0.5*([tecmodpar:HybridThick]+[tecmodpar:TopFrameThick])"/>
+		     <Constant name="SideFrameZ"         value="[TopFrameZ]+0.5*(-[tecmodpar:TopFrameThick]+[tecmodpar:SideFrameThick])"/>
+		     <Constant name="PitchZ"             value="[TopFrameZ] - 0.5*([tecmodpar:TopFrameThick] + [tecmodpar:PitchThick])"/-->
+		<Constant name="HybridZ" value="[TopFrameZ]+ 0.5*([tecmodpar:TopFrameThick] + [tecmodpar:HybridThick])"/>
+		<Constant name="TopFrameZ" value="[SideFrameZ]+ 0.5*(-[tecmodpar:SideFrameThick]+[tecmodpar:TopFrameThick])"/>
+		<Constant name="SideFrameZ" value="[ActiveZ]+0.5*(-[tecmodpar:WaferThick2] - [tecmodpar:SideFrameThick])"/>
+		<Constant name="PitchZ" value="[TopFrameZ] + 0.5*([tecmodpar:TopFrameThick] + [tecmodpar:PitchThick])"/>
+		<Constant name="DlHybrid" value="11.190*cm"/>
+		<Constant name="BridgeWidth" value="1.90*cm"/>
+		<Constant name="BridgeThick" value="0.228*cm"/>
+		<Constant name="BridgeHeight" value="2.469*cm"/>
+		<Constant name="BridgeSeparation" value="6.800*cm"/>
+		<Constant name="ModuleThick" value="[tecmodpar:ModuleThickSS]"/>
+		<Constant name="ShiftZ" value="0.5*[tecmodpar:SideFrameThick]"/>
+		<Constant name="TopFrameTopWidth" value="89.3*mm"/>
+		<Constant name="TopFrameBotWidth" value="127.8*mm"/>
+		<Constant name="TopFrameHeight" value="37.2*mm"/>
+		<Constant name="SideFrameRtheta" value="-0.058*rad"/>
+		<Constant name="SideFrameRHeight" value="190.0*mm"/>
+		<Constant name="SideFrameRWidth" value="14.1*mm"/>
+		<Constant name="SideFrameLtheta" value="0.057*rad"/>
+		<Constant name="SideFrameLHeight" value="190.0*mm"/>
+		<Constant name="SideFrameLWidth" value="15.5*mm"/>
+		<Constant name="ActiveZ" value="([tecmodpar:ActiveZ2]+[ShiftZ])"/>
+		<Constant name="PitchWidth" value="107.6*mm"/>
+		<Constant name="dPhi" value="2.2*asin(0.5*[TopFrameBotWidth]/([Rin]+[FullHeight]))"/>
+		<Constant name="PosCorrectionR" value="-1.19*mm"/>
+	</ConstantsSection>
+	<SolidSection label="tecmodule5.xml">
+		<Tubs name="TECModule5" rMin="[Rin]" rMax="[Rout]" dz="0.5*[tecmodpar:ModuleThickSS]" startPhi="-[dPhi]/2" deltaPhi="[dPhi]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecmodule5.xml">
+		<LogicalPart name="TECModule5" category="unspecified">
+			<rSolid name="tecmodule5:TECModule5"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECModuleAlgo">
+		<rParent name="tecmodule5:TECModule5"/>
+		<Numeric name="RingNo" value="5"/>
+		<Numeric name="isStereo" value="[isStereo]"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="ModuleThick" value="[tecmodpar:ModuleThick]"/>
+		<Numeric name="DetTilt" value="[tecmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[FullHeight]"/>
+		<Numeric name="DlTop" value="[DlTop]"/>
+		<Numeric name="DlBottom" value="[DlBottom]"/>
+		<Numeric name="DlHybrid" value="[DlHybrid]"/>
+		<Numeric name="FrameWidth" value="[tecmodpar:FrameWidth]"/>
+		<Numeric name="FrameThick" value="[ModuleThick]"/>
+		<Numeric name="FrameOver" value="[tecmodpar:FrameOver]"/>
+		<String name="TopFrameMaterial" value="tecmaterial:TEC_frame_top"/>
+		<Numeric name="TopFrameTopWidth" value="[TopFrameTopWidth]"/>
+		<Numeric name="TopFrameBotWidth" value="[TopFrameBotWidth]"/>
+		<Numeric name="TopFrameHeight" value="[TopFrameHeight]"/>
+		<Numeric name="TopFrameThick" value="[tecmodpar:TopFrameThick]"/>
+		<Numeric name="TopFrameZ" value="[TopFrameZ]"/>
+		<String name="SideFrameMaterial" value="tecmaterial:TEC_frame_side_5_7"/>
+		<Numeric name="SideFrameThick" value="[tecmodpar:SideFrameThick]"/>
+		<String name="SiFrSuppBoxMaterial" value="tecmaterial:TEC_SideFrSupBox"/>
+		<Numeric name="SideFrameRtheta" value="[SideFrameRtheta]"/>
+		<Numeric name="SideFrameRHeight" value="[SideFrameRHeight]"/>
+		<Numeric name="SideFrameRWidth" value="[SideFrameRWidth]"/>
+		<Numeric name="SideFrameLtheta" value="[SideFrameLtheta]"/>
+		<Numeric name="SideFrameLHeight" value="[SideFrameLHeight]"/>
+		<Numeric name="SideFrameLWidth" value="[SideFrameLWidth]"/>
+		<Numeric name="SiFrSuppBoxThick" value="[tecmodpar:SiFrSuppBoxThick]"/>
+		<Vector name="SiFrSuppBoxYPos" type="numeric" nEntries="2">
+			44.0*mm, 137.9*mm  </Vector>
+		<Vector name="SiFrSuppBoxHeight" type="numeric" nEntries="2">
+			31.1*mm, 27.1*mm  </Vector>
+		<Vector name="SiFrSuppBoxWidth" type="numeric" nEntries="2">
+			15.7*mm, 15.7*mm  </Vector>
+		<Numeric name="SideFrameZ" value="[SideFrameZ]"/>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[SideWidthBottom]"/>
+		<String name="WaferRotation" value="tecmodpar:RFI2"/>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[ActiveHeight]"/>
+		<Numeric name="WaferThick" value="[tecmodpar:WaferThick2]"/>
+		<String name="ActiveRotation" value="tecmodpar:AR05"/>
+		<Numeric name="ActiveZ" value="[ActiveZ]"/>
+		<Numeric name="BackPlaneThick" value="2*[tracker:BackPlaneDz]"/>
+		<Numeric name="InactiveDy" value="[tecmodpar:InactiveDy]"/>
+		<Numeric name="InactivePos" value="[tecmodule5:InactiveStart]+[tecmodpar:InactiveDy]"/>
+		<String name="InactiveMaterial" value="materials:Silicon"/>
+		<String name="HybridMaterial" value="tecmaterial:TEC_Hybrid4APV"/>
+		<Numeric name="HybridHeight" value="[tecmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tecmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tecmodpar:HybridThick]"/>
+		<Numeric name="HybridZ" value="[HybridZ]"/>
+		<String name="PitchMaterial" value="tecmaterial:TEC_PitchAdapter"/>
+		<Numeric name="PitchHeight" value="[tecmodpar:PitchHeight]"/>
+		<Numeric name="PitchThick" value="[tecmodpar:PitchThick]"/>
+		<Numeric name="PitchWidth" value="[PitchWidth]"/>
+		<Numeric name="PitchZ" value="[PitchZ]"/>
+		<String name="PitchRotation" value="tecmodpar:PITC"/>
+		<Numeric name="BridgeWidth" value="[BridgeWidth]"/>
+		<Numeric name="BridgeThick" value="[BridgeThick]"/>
+		<Numeric name="BridgeHeight" value="[BridgeHeight]"/>
+		<Numeric name="BridgeSeparation" value="[BridgeSeparation]"/>
+		<String name="BridgeMaterial" value="trackermaterial:T_Aluminium"/>
+		<Numeric name="WaferPosition" value="[tecmodpar:TopFrameHeight]"/>
+		<Vector name="SiReenforcementHeight" type="numeric" nEntries="2">
+			4.5*mm, 8.0*mm  </Vector>
+		<Vector name="SiReenforcementWidth" type="numeric" nEntries="2">
+			95.0*mm, 85.0*mm  </Vector>
+		<Vector name="SiReenforcementPosY" type="numeric" nEntries="2">
+			0.0001*mm, [tecmodule5:InactiveStart] - 8.00*mm /2</Vector>
+		<String name="SiReenforcementMaterial" value="tecmaterial:TEC_SiReenforcment"/>
+		<Numeric name="SiReenforcementThick" value="[tecmodpar:SiReenforcementThick]"/>
+		<Numeric name="NoOverlapShift" value="[tecmodpar:NoOverlapShift]"/>
+		<Numeric name="RPos" value="0.5*([tecmodule5:Rin]+[tecmodule5:Rout])+[PosCorrectionR]"/>
+		<String name="StandardRotation" value="tecmodpar:RPHI"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecmodule6.xml
+++ b/DetectorDescription/DDCMS/data/tecmodule6.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecmodule6.xml" eval="true">
+		<Constant name="Rin" value="84.61*cm"/>
+		<Constant name="Rout" value="110.17*cm"/>
+		<Constant name="isStereo" value="0"/>
+		<Constant name="FullHeight" value="20.7474000*cm"/>
+		<Constant name="ActiveHeight" value="20.4715500*cm"/>
+		<Constant name="DlTop" value="9.0713000*cm"/>
+		<Constant name="DlBottom" value="7.4012000*cm"/>
+		<Constant name="InactiveStart" value="109.712*mm"/>
+		<Constant name="SideWidthTop" value="0.1376009*cm"/>
+		<Constant name="SideWidthBottom" value="0.1262048*cm"/>
+		<Constant name="HybridZ" value="[TopFrameZ]+ 0.5*([tecmodpar:TopFrameThick] + [tecmodpar:HybridThick])"/>
+		<Constant name="TopFrameZ" value="[SideFrameZ]+ 0.5*(-[tecmodpar:SideFrameThick]+[tecmodpar:TopFrameThick])"/>
+		<Constant name="SideFrameZ" value="[ActiveZ]+0.5*(-[tecmodpar:WaferThick2] - [tecmodpar:SideFrameThick])"/>
+		<Constant name="PitchZ" value="[TopFrameZ] + 0.5*([tecmodpar:TopFrameThick] + [tecmodpar:PitchThick])"/>
+		<Constant name="DlHybrid" value="7.120*cm"/>
+		<Constant name="BridgeWidth" value="2.474*cm"/>
+		<Constant name="BridgeThick" value="0.224*cm"/>
+		<Constant name="BridgeHeight" value="1.888*cm"/>
+		<Constant name="BridgeSeparation" value="5.350*cm"/>
+		<Constant name="ModuleThick" value="[tecmodpar:ModuleThickSS]"/>
+		<Constant name="TopFrameTopWidth" value="77.1*mm"/>
+		<Constant name="TopFrameBotWidth" value="94.2*mm"/>
+		<Constant name="TopFrameHeight" value="37.2*mm"/>
+		<Constant name="ShiftZ" value="0.5*[tecmodpar:SideFrameThick]"/>
+		<Constant name="SideFrameRtheta" value="-0.040*rad"/>
+		<Constant name="SideFrameRHeight" value="210.8*mm"/>
+		<Constant name="SideFrameRWidth" value="13.9*mm"/>
+		<Constant name="SideFrameLtheta" value="0.040*rad"/>
+		<Constant name="SideFrameLHeight" value="210.8*mm"/>
+		<Constant name="SideFrameLWidth" value="15.3*mm"/>
+		<Constant name="ActiveZ" value="([tecmodpar:ActiveZ2]+[ShiftZ])"/>
+		<Constant name="PitchWidth" value="74.1*mm"/>
+		<Constant name="dPhi" value="2.2*asin(0.5*[TopFrameBotWidth]/([Rin]+[TopFrameHeight]))"/>
+		<Constant name="PosCorrectionR" value="-1.8632*mm"/>
+	</ConstantsSection>
+	<SolidSection label="tecmodule6.xml">
+		<Tubs name="TECModule6" rMin="[Rin]" rMax="[Rout]" dz="0.5*[tecmodpar:ModuleThickSS]" startPhi="-[dPhi]/2" deltaPhi="[dPhi]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecmodule6.xml">
+		<LogicalPart name="TECModule6" category="unspecified">
+			<rSolid name="tecmodule6:TECModule6"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECModuleAlgo">
+		<rParent name="tecmodule6:TECModule6"/>
+		<Numeric name="RingNo" value="6"/>
+		<Numeric name="isStereo" value="[isStereo]"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="ModuleThick" value="[tecmodpar:ModuleThick]"/>
+		<Numeric name="DetTilt" value="[tecmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[FullHeight]"/>
+		<Numeric name="DlTop" value="[DlTop]"/>
+		<Numeric name="DlBottom" value="[DlBottom]"/>
+		<Numeric name="DlHybrid" value="[DlHybrid]"/>
+		<Numeric name="FrameWidth" value="[tecmodpar:FrameWidth]"/>
+		<Numeric name="FrameThick" value="[ModuleThick]"/>
+		<Numeric name="FrameOver" value="[tecmodpar:FrameOver]"/>
+		<String name="TopFrameMaterial" value="tecmaterial:TEC_frame_top"/>
+		<Numeric name="TopFrameTopWidth" value="[TopFrameTopWidth]"/>
+		<Numeric name="TopFrameBotWidth" value="[TopFrameBotWidth]"/>
+		<Numeric name="TopFrameHeight" value="[TopFrameHeight]"/>
+		<Numeric name="TopFrameThick" value="[tecmodpar:TopFrameThick]"/>
+		<Numeric name="TopFrameZ" value="[TopFrameZ]"/>
+		<String name="SideFrameMaterial" value="tecmaterial:TEC_frame_side_5_7"/>
+		<Numeric name="SideFrameThick" value="[tecmodpar:SideFrameThick]"/>
+		<String name="SiFrSuppBoxMaterial" value="tecmaterial:TEC_SideFrSupBox"/>
+		<Numeric name="SideFrameRtheta" value="[SideFrameRtheta]"/>
+		<Numeric name="SideFrameRHeight" value="[SideFrameRHeight]"/>
+		<Numeric name="SideFrameRWidth" value="[SideFrameRWidth]"/>
+		<Numeric name="SideFrameLtheta" value="[SideFrameLtheta]"/>
+		<Numeric name="SideFrameLHeight" value="[SideFrameLHeight]"/>
+		<Numeric name="SideFrameLWidth" value="[SideFrameLWidth]"/>
+		<Numeric name="SiFrSuppBoxThick" value="[tecmodpar:SiFrSuppBoxThick]"/>
+		<Vector name="SiFrSuppBoxYPos" type="numeric" nEntries="2">
+			57.8*mm,161.9*mm  </Vector>
+		<Vector name="SiFrSuppBoxHeight" type="numeric" nEntries="2">
+			31.9*mm,27.6*mm  </Vector>
+		<Vector name="SiFrSuppBoxWidth" type="numeric" nEntries="2">
+			15.7*mm,15.7*mm  </Vector>
+		<Numeric name="SideFrameZ" value="[SideFrameZ]"/>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[SideWidthBottom]"/>
+		<String name="WaferRotation" value="tecmodpar:RFI2"/>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[ActiveHeight]"/>
+		<Numeric name="WaferThick" value="[tecmodpar:WaferThick2]"/>
+		<String name="ActiveRotation" value="tecmodpar:ART6"/>
+		<Numeric name="ActiveZ" value="[ActiveZ]"/>
+		<Numeric name="BackPlaneThick" value="2*[tracker:BackPlaneDz]"/>
+		<Numeric name="InactiveDy" value="[tecmodpar:InactiveDy]"/>
+		<Numeric name="InactivePos" value="[tecmodule6:InactiveStart]+[tecmodpar:InactiveDy]"/>
+		<String name="InactiveMaterial" value="materials:Silicon"/>
+		<String name="HybridMaterial" value="tecmaterial:TEC_Hybrid4APV"/>
+		<Numeric name="HybridHeight" value="[tecmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tecmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tecmodpar:HybridThick]"/>
+		<Numeric name="HybridZ" value="[HybridZ]"/>
+		<String name="PitchMaterial" value="tecmaterial:TEC_PitchAdapter"/>
+		<Numeric name="PitchHeight" value="[tecmodpar:PitchHeight]"/>
+		<Numeric name="PitchThick" value="[tecmodpar:PitchThick]"/>
+		<Numeric name="PitchWidth" value="[PitchWidth]"/>
+		<Numeric name="PitchZ" value="[PitchZ]"/>
+		<String name="PitchRotation" value="tecmodpar:PITC"/>
+		<Numeric name="BridgeWidth" value="[BridgeWidth]"/>
+		<Numeric name="BridgeThick" value="[BridgeThick]"/>
+		<Numeric name="BridgeHeight" value="[BridgeHeight]"/>
+		<Numeric name="BridgeSeparation" value="[BridgeSeparation]"/>
+		<String name="BridgeMaterial" value="trackermaterial:T_Aluminium"/>
+		<Numeric name="WaferPosition" value="[tecmodpar:TopFrameHeight]"/>
+		<Vector name="SiReenforcementHeight" type="numeric" nEntries="2">
+			4.9*mm, 8.0*mm  </Vector>
+		<Vector name="SiReenforcementWidth" type="numeric" nEntries="2">
+			61.0*mm, 71.0*mm  </Vector>
+		<Vector name="SiReenforcementPosY" type="numeric" nEntries="2">
+			0.0001*mm, [tecmodule6:InactiveStart] -8.0*mm/2 </Vector>
+		<String name="SiReenforcementMaterial" value="tecmaterial:TEC_SiReenforcment"/>
+		<Numeric name="SiReenforcementThick" value="[tecmodpar:SiReenforcementThick]"/>
+		<Numeric name="NoOverlapShift" value="[tecmodpar:NoOverlapShift]"/>
+		<Numeric name="RPos" value="0.5*([tecmodule6:Rin]+[tecmodule6:Rout])+[PosCorrectionR]"/>
+		<String name="StandardRotation" value="tecmodpar:RPHI"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecpetal0.xml
+++ b/DetectorDescription/DDCMS/data/tecpetal0.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecpetal0.xml" eval="true">
+		<Constant name="PetalContRmin" value="22.90*cm"/>
+		<Constant name="PetalRmin" value="23.30*cm"/>
+	</ConstantsSection>
+	<SolidSection label="tecpetal0.xml">
+		<Tubs name="TECPetalCont0" rMin="[PetalContRmin]" rMax="[tecpetpar:PetalContRmax]" dz="[tecpetpar:PetalContThick]/2" startPhi="-[tecpetpar:PetalContWidth]/2" deltaPhi="[tecpetpar:PetalContWidth]"/>
+		<Tubs name="TECPetal0" rMin="[PetalRmin]" rMax="[tecpetpar:PetalRmax]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetpar:PetalWidth]/2" deltaPhi="[tecpetpar:PetalWidth]"/>
+		<Tubs name="TECICBCont0" rMin="[PetalRmin]" rMax="[tecpetpar:ICBRmax]" dz="[tecpetpar:ICBThick]/2" startPhi="-[tecpetpar:ICBWidth]/2" deltaPhi="[tecpetpar:ICBWidth]"/>
+	</SolidSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecpetal0b.xml
+++ b/DetectorDescription/DDCMS/data/tecpetal0b.xml
@@ -1,0 +1,445 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecpetal0b.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="ICCZ" value="([tecpetpar:ICBThick]-[tecpetpar:ICCThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecpetal0b.xml">
+		<Tubs name="TECPetal0B" rMin="[tecpetal0:PetalRmin]" rMax="[tecpetalb:PetalR1]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetalb:PetalWidth0]/2" deltaPhi="[tecpetalb:PetalWidth0]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecpetal0b.xml">
+		<LogicalPart name="TECPetalCont0B" category="unspecified">
+			<rSolid name="tecpetal0:TECPetalCont0"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetalFrame0B" category="unspecified">
+			<rSolid name="tecpetal0:TECPetal0"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal0B" category="unspecified">
+			<rSolid name="tecpetal0b:TECPetal0B"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal1B" category="unspecified">
+			<rSolid name="tecpetalb:TECPetal1B"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal2B" category="unspecified">
+			<rSolid name="tecpetalb:TECPetal2B"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont0B1" category="unspecified">
+			<rSolid name="tecpetal0:TECICBCont0"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont0B2" category="unspecified">
+			<rSolid name="tecpetal0:TECICBCont0"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tecpetal0b.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECPetalCont0B"/>
+			<rChild name="tecring0b:TECRing0B"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring0:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECPetalCont0B"/>
+			<rChild name="tecring1b:TECRing1B"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring1:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECPetalCont0B"/>
+			<rChild name="tecring2b:TECRing2B"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring2:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECPetalCont0B"/>
+			<rChild name="tecring3b:TECRing3B"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring3:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECPetalCont0B"/>
+			<rChild name="tecring4b:TECRing4B"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring4:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECPetalCont0B"/>
+			<rChild name="tecring5b:TECRing5B"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring5:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECPetalCont0B"/>
+			<rChild name="tecring6b:TECRing6B"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring6:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECPetalCont0B"/>
+			<rChild name="tecpetal0b:TECPetalFrame0B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B1"/>
+			<rChild name="tecpetalb:TECICC0LB1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B1"/>
+			<rChild name="tecpetalb:TECICC0LB2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B1"/>
+			<rChild name="tecpetalb:TECICC2B1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B1"/>
+			<rChild name="tecpetalb:TECICC2B2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B1"/>
+			<rChild name="tecpetalb:TECICC46B1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B1"/>
+			<rChild name="tecpetalb:TECICC46B2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B1"/>
+			<rChild name="tecpetalb:TECICC46B3"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B2"/>
+			<rChild name="tecpetalb:TECICC1B1"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B2"/>
+			<rChild name="tecpetalb:TECICC1B2"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B2"/>
+			<rChild name="tecpetalb:TECICC1B3"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B2"/>
+			<rChild name="tecpetalb:TECICC35B1"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B2"/>
+			<rChild name="tecpetalb:TECICC35B2"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B2"/>
+			<rChild name="tecpetalb:TECICC35B3"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B2"/>
+			<rChild name="tecpetalb:TECICC35B4"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B2"/>
+			<rChild name="tecpetalb:TECICC35B5"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal0b:TECPetal2B"/>
+			<rChild name="tecwheel:TECInnerManifold"/>
+			<Translation x="[zero]" y="[zero]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECPetalFrame0B"/>
+			<rChild name="tecpetal0b:TECPetal0B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECPetalFrame0B"/>
+			<rChild name="tecpetal0b:TECPetal1B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECPetalFrame0B"/>
+			<rChild name="tecpetal0b:TECPetal2B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECPetalCont0B"/>
+			<rChild name="tecpetal0b:TECICBCont0B1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECPetalCont0B"/>
+			<rChild name="tecpetal0b:TECICBCont0B2"/>
+			<Translation x="[zero]" y="[zero]" z="[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0b:TECICBCont0B2"/>
+			<rChild name="tecwheel:TECCCUM"/>
+			<Translation x="1050*mm" y="-100*mm" z="[tecpetpar:CCUMZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal0b:TECICBCont0B2"/>
+			<rChild name="tecwheel:TECCCUM"/>
+			<Translation x="700*mm" y="[zero]" z="[tecpetpar:CCUMZ]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal0B"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="RPosition" value="283.326*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="2">
+			8.9423*deg	,-8.9423*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="2">
+			tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal0B"/>
+		<Numeric name="StartCopyNo" value="3"/>
+		<Numeric name="RPosition" value="348.172*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="2">
+			6.1003*deg	,-6.1003*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="2">
+			tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal0B"/>
+		<Numeric name="StartCopyNo" value="5"/>
+		<Numeric name="RPosition" value="372.842*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			10.9517*deg	,8.6238*deg	,-8.6238*deg	,-10.9554*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool5,tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal0B"/>
+		<Numeric name="StartCopyNo" value="9"/>
+		<Numeric name="RPosition" value="438.663*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="2">
+			4.8385*deg	,-4.8385*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="2">
+			tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal0B"/>
+		<Numeric name="StartCopyNo" value="11"/>
+		<Numeric name="RPosition" value="451.736*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			9.9308*deg	,0.9308*deg	,-9.9308*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal0B"/>
+		<Numeric name="StartCopyNo" value="14"/>
+		<Numeric name="RPosition" value="491.272*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="2">
+			4.829*deg	,-2.1851*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="2">
+			tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal0B"/>
+		<Numeric name="StartCopyNo" value="16"/>
+		<Numeric name="RPosition" value="529.973*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			9*deg	,0*deg	,-9*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal1B"/>
+		<Numeric name="StartCopyNo" value="19"/>
+		<Numeric name="RPosition" value="565.026*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			10.3812*deg	,3.9526*deg	,-3.9526*deg	,-10.3812*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal1B"/>
+		<Numeric name="StartCopyNo" value="23"/>
+		<Numeric name="RPosition" value="646.359*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			9.6429*deg	,3.2143*deg	,-3.2143*deg	,-9.6429*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal1B"/>
+		<Numeric name="StartCopyNo" value="27"/>
+		<Numeric name="RPosition" value="688.526*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			14.144*deg	,5.144*deg	,-5.144*deg	,-14.144*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal1B"/>
+		<Numeric name="StartCopyNo" value="31"/>
+		<Numeric name="RPosition" value="705.35*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			5.0584*deg	,-3.2876*deg	,-7.7907*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal2B"/>
+		<Numeric name="StartCopyNo" value="34"/>
+		<Numeric name="RPosition" value="777.681*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			11.727*deg	,6.273*deg	,2.727*deg	,-2.727*deg	,-6.273*deg	,-11.727*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool4,tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal2B"/>
+		<Numeric name="StartCopyNo" value="40"/>
+		<Numeric name="RPosition" value="809.853*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="11">
+			11.729*deg	,9.3832*deg	,7.0374*deg	,4.6916*deg	,2.3458*deg	,0*deg	,-2.3458*deg	,-4.6916*deg	,-7.0374*deg	,-9.3832*deg	,-11.729*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="11">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal2B"/>
+		<Numeric name="StartCopyNo" value="51"/>
+		<Numeric name="RPosition" value="826.305*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			10.1935*deg	,3.7649*deg	,-3.7649*deg	,-10.1935*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal2B"/>
+		<Numeric name="StartCopyNo" value="55"/>
+		<Numeric name="RPosition" value="862.788*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			11.25*deg	,6.75*deg	,2.25*deg	,-2.25*deg	,-6.75*deg	,-11.25*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal2B"/>
+		<Numeric name="StartCopyNo" value="61"/>
+		<Numeric name="RPosition" value="937.93*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			8.6894*deg	,4.1677*deg	,2.2608*deg	,-2.2608*deg	,-4.1677*deg	,-8.6894*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool2,tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal2B"/>
+		<Numeric name="StartCopyNo" value="67"/>
+		<Numeric name="RPosition" value="997.895*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="8">
+			11.6983*deg	,6.3017*deg	,2.6983*deg	,-1.8017*deg	,-2.6983*deg	,-6.3017*deg	,-7.1983*deg	,-11.6983*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="8">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal2B"/>
+		<Numeric name="StartCopyNo" value="75"/>
+		<Numeric name="RPosition" value="1040.55*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			10.0576*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0b:TECPetal2B"/>
+		<Numeric name="StartCopyNo" value="76"/>
+		<Numeric name="RPosition" value="1068.17*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			10.0624*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0b:TECICBCont0B1"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybridShort"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="Rpos" value="357.959*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="2">
+			11.4354*deg	,-7.7539*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0b:TECICBCont0B2"/>
+		<Numeric name="StartCopyNo" value="3"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="471.195*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="2">
+			6.6727*deg	,-0.339*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0b:TECICBCont0B1"/>
+		<Numeric name="StartCopyNo" value="5"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="562.517*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="2">
+			5.4762*deg	,-2.429*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0b:TECICBCont0B2"/>
+		<Numeric name="StartCopyNo" value="7"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="685.152*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			6.3214*deg	,-2.0241*deg	,-6.5265*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0b:TECICBCont0B1"/>
+		<Numeric name="StartCopyNo" value="10"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="807.452*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="11">
+			12.7924*deg	,10.4466*deg	,8.1008*deg	,5.755*deg	,3.4092*deg	,1.0634*deg	,-1.2824*deg	,-3.6282*deg	,-5.974*deg	,-8.3197*deg	,-10.6655*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0b:TECICBCont0B2"/>
+		<Numeric name="StartCopyNo" value="21"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="977.634*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			7.1858*deg	,-0.9183*deg	,-6.3149*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0b:TECICBCont0B2"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<String name="ChildName" value="tecpetpar:TECDigiOptoHybModule"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:DOHMWidth]"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:DOHMHeight]"/>
+		<Numeric name="Rpos" value="1022.726*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:DOHMZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="1">
+			11.372*deg</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecpetal0f.xml
+++ b/DetectorDescription/DDCMS/data/tecpetal0f.xml
@@ -1,0 +1,445 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecpetal0f.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="ICCZ" value="([tecpetpar:ICBThick]-[tecpetpar:ICCThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecpetal0f.xml">
+		<Tubs name="TECPetal0F" rMin="[tecpetal0:PetalRmin]" rMax="[tecpetalf:PetalR1]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetalf:PetalWidth0]/2" deltaPhi="[tecpetalf:PetalWidth0]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecpetal0f.xml">
+		<LogicalPart name="TECPetalCont0F" category="unspecified">
+			<rSolid name="tecpetal0:TECPetalCont0"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetalFrame0F" category="unspecified">
+			<rSolid name="tecpetal0:TECPetal0"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal0F" category="unspecified">
+			<rSolid name="tecpetal0f:TECPetal0F"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal1F" category="unspecified">
+			<rSolid name="tecpetalf:TECPetal1F"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal2F" category="unspecified">
+			<rSolid name="tecpetalf:TECPetal2F"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont0F1" category="unspecified">
+			<rSolid name="tecpetal0:TECICBCont0"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont0F2" category="unspecified">
+			<rSolid name="tecpetal0:TECICBCont0"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tecpetal0f.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetalCont0F"/>
+			<rChild name="tecring0f:TECRing0F"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring0:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetalCont0F"/>
+			<rChild name="tecring1f:TECRing1F"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring1:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetalCont0F"/>
+			<rChild name="tecring2f:TECRing2F"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring2:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetalCont0F"/>
+			<rChild name="tecring3f:TECRing3F"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring3:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetalCont0F"/>
+			<rChild name="tecring4f:TECRing4F"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring4:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetalCont0F"/>
+			<rChild name="tecring5f:TECRing5F"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring5:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetalCont0F"/>
+			<rChild name="tecring6f:TECRing6F"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring6:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetalCont0F"/>
+			<rChild name="tecpetal0f:TECPetalFrame0F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetalFrame0F"/>
+			<rChild name="tecpetal0f:TECPetal0F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetalFrame0F"/>
+			<rChild name="tecpetal0f:TECPetal1F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetalFrame0F"/>
+			<rChild name="tecpetal0f:TECPetal2F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetalCont0F"/>
+			<rChild name="tecpetal0f:TECICBCont0F1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetalCont0F"/>
+			<rChild name="tecpetal0f:TECICBCont0F2"/>
+			<Translation x="[zero]" y="[zero]" z="[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F1"/>
+			<rChild name="tecpetalf:TECICC0F1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F1"/>
+			<rChild name="tecpetalf:TECICC0F2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F1"/>
+			<rChild name="tecpetalf:TECICC2F1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F1"/>
+			<rChild name="tecpetalf:TECICC2F2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F1"/>
+			<rChild name="tecpetalf:TECICC46F1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F1"/>
+			<rChild name="tecpetalf:TECICC46F2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F2"/>
+			<rChild name="tecpetalf:TECICC01LF1"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F2"/>
+			<rChild name="tecpetalf:TECICC01LF2"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F2"/>
+			<rChild name="tecpetalf:TECICC01LF3"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F2"/>
+			<rChild name="tecpetalf:TECICC01LF4"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F2"/>
+			<rChild name="tecpetalf:TECICC35F1"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F2"/>
+			<rChild name="tecpetalf:TECICC35F2"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F2"/>
+			<rChild name="tecpetalf:TECICC35F3"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F2"/>
+			<rChild name="tecpetalf:TECICC35F4"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F2"/>
+			<rChild name="tecpetalf:TECICC35F5"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECPetal2F"/>
+			<rChild name="tecwheel:TECInnerManifold"/>
+			<Translation x="[zero]" y="[zero]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal0f:TECICBCont0F2"/>
+			<rChild name="tecwheel:TECCCUM"/>
+			<Translation x="1050*mm" y="100*mm" z="[tecpetpar:CCUMZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal0f:TECICBCont0F2"/>
+			<rChild name="tecwheel:TECCCUM"/>
+			<Translation x="700*mm" y="[zero]" z="[tecpetpar:CCUMZ]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal0F"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="RPosition" value="283.326*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="7">
+			16.4423*deg	,12.3634*deg	,4.3695*deg	,-1.4423*deg	,-5.5235*deg	,-13.5079*deg	,-16.4423*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="7">
+			tecpetpar:TECCool3,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool3,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal0F"/>
+		<Numeric name="StartCopyNo" value="8"/>
+		<Numeric name="RPosition" value="348.172*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			13.6003*deg	,1.3997*deg	,-1.3997*deg	,-13.6003*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal0F"/>
+		<Numeric name="StartCopyNo" value="12"/>
+		<Numeric name="RPosition" value="373.084*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			16.1238*deg	,1.1238*deg	,-16.1238*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal0F"/>
+		<Numeric name="StartCopyNo" value="15"/>
+		<Numeric name="RPosition" value="438.663*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			12.3385*deg	,2.6615*deg	,-2.6615*deg	,-12.3385*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool4,tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal0F"/>
+		<Numeric name="StartCopyNo" value="19"/>
+		<Numeric name="RPosition" value="451.736*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			14.4308*deg	,5.4308*deg	,-5.4308*deg	,-14.4308*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal0F"/>
+		<Numeric name="StartCopyNo" value="23"/>
+		<Numeric name="RPosition" value="491.326*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			9.6429*deg	,5.2432*deg	,-5.3537*deg	,-9.7534*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal0F"/>
+		<Numeric name="StartCopyNo" value="27"/>
+		<Numeric name="RPosition" value="529.973*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			13.5*deg	,4.5*deg	,-4.5*deg	,-13.5*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal1F"/>
+		<Numeric name="StartCopyNo" value="31"/>
+		<Numeric name="RPosition" value="565.026*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="7">
+			13.5955*deg	,9.3071*deg	,5.6902*deg	,0.7383*deg	,-7.1669*deg	,-8.7012*deg	,-13.5955*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="7">
+			tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal1F"/>
+		<Numeric name="StartCopyNo" value="38"/>
+		<Numeric name="RPosition" value="646.359*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="5">
+			12.8571*deg	,6.4286*deg	,0*deg	,-6.4286*deg	,-12.8571*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="5">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal1F"/>
+		<Numeric name="StartCopyNo" value="43"/>
+		<Numeric name="RPosition" value="688.526*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			9.644*deg	,-0.644*deg	,-9.644*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal1F"/>
+		<Numeric name="StartCopyNo" value="46"/>
+		<Numeric name="RPosition" value="705.393*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			8.0585*deg	,2.4756*deg	,-5.2453*deg	,-11.2274*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal1F"/>
+		<Numeric name="StartCopyNo" value="50"/>
+		<Numeric name="RPosition" value="777.681*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			7.227*deg	,1.773*deg	,-1.773*deg	,-7.227*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal1F"/>
+		<Numeric name="StartCopyNo" value="54"/>
+		<Numeric name="RPosition" value="809.358*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="9">
+			8.8981*deg	,6.5507*deg	,4.2142*deg	,1.8718*deg	,-0.4758*deg	,-2.8175*deg	,-5.1527*deg	,-7.4972*deg	,-9.8497*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="9">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal1F"/>
+		<Numeric name="StartCopyNo" value="63"/>
+		<Numeric name="RPosition" value="826.305*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="5">
+			13.4078*deg	,5.8779*deg	,0.5506*deg	,-6.9792*deg	,-13.4078*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="5">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal1F"/>
+		<Numeric name="StartCopyNo" value="68"/>
+		<Numeric name="RPosition" value="862.788*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			11.25*deg	,6.75*deg	,2.25*deg	,-2.25*deg	,-6.75*deg	,-11.25*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal2F"/>
+		<Numeric name="StartCopyNo" value="74"/>
+		<Numeric name="RPosition" value="937.93*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="8">
+			11.9037*deg	,7.382*deg	,5.4751*deg	,0.9535*deg	,-0.9535*deg	,-5.4751*deg	,-7.382*deg	,-11.9037*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="8">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2,tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal2F"/>
+		<Numeric name="StartCopyNo" value="82"/>
+		<Numeric name="RPosition" value="997.895*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="8">
+			11.6983*deg	,7.1983*deg	,6.3017*deg	,2.6983*deg	,-2.6983*deg	,-6.3017*deg	,-10.1082*deg	,-11.6983*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="8">
+			tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal2F"/>
+		<Numeric name="StartCopyNo" value="90"/>
+		<Numeric name="RPosition" value="1037.61*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			-9.9912*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal0f:TECPetal2F"/>
+		<Numeric name="StartCopyNo" value="91"/>
+		<Numeric name="RPosition" value="1065.23*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			-9.9978*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0f:TECICBCont0F2"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="262.048*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="4">
+			16.4735*deg	,8.4741*deg	,-1.419*deg	,-9.4175*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0f:TECICBCont0F2"/>
+		<Numeric name="StartCopyNo" value="5"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="471.051*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="4">
+			11.9412*deg	,7.5404*deg	,-3.0597*deg	,-7.4597*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0f:TECICBCont0F1"/>
+		<Numeric name="StartCopyNo" value="9"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="562.721*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			11.2453*deg	,2.6765*deg	,-6.8472*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0f:TECICBCont0F2"/>
+		<Numeric name="StartCopyNo" value="12"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="685.052*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="4">
+			9.6425*deg	,4.0592*deg	,-3.6616*deg	,-9.643*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0f:TECICBCont0F1"/>
+		<Numeric name="StartCopyNo" value="16"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="807.002*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="9">
+			10.2499*deg	,7.9025*deg	,5.5659*deg	,3.2235*deg	,0.8753*deg	,-1.4658*deg	,-3.801*deg	,-6.1455*deg	,-8.5563*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0f:TECICBCont0F2"/>
+		<Numeric name="StartCopyNo" value="25"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="977.591*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			8.3153*deg	,3.8227*deg	,-5.1984*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal0f:TECICBCont0F2"/>
+		<Numeric name="StartCopyNo" value="28"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybridShort"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="Rpos" value="977.591*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="1">
+			-9.9916*deg</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecpetal3.xml
+++ b/DetectorDescription/DDCMS/data/tecpetal3.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecpetal3.xml" eval="true">
+		<Constant name="PetalContRmin" value="30.90*cm"/>
+		<Constant name="PetalRmin" value="31.30*cm"/>
+	</ConstantsSection>
+	<SolidSection label="tecpetal3.xml">
+		<Tubs name="TECPetalCont3" rMin="[PetalContRmin]" rMax="[tecpetpar:PetalContRmax]" dz="[tecpetpar:PetalContThick]/2" startPhi="-[tecpetpar:PetalContWidth]/2" deltaPhi="[tecpetpar:PetalContWidth]"/>
+		<Tubs name="TECPetal3" rMin="[PetalRmin]" rMax="[tecpetpar:PetalRmax]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetpar:PetalWidth]/2" deltaPhi="[tecpetpar:PetalWidth]"/>
+		<Tubs name="TECICBCont3" rMin="[PetalRmin]" rMax="[tecpetpar:ICBRmax]" dz="[tecpetpar:ICBThick]/2" startPhi="-[tecpetpar:ICBWidth]/2" deltaPhi="[tecpetpar:ICBWidth]"/>
+	</SolidSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecpetal3b.xml
+++ b/DetectorDescription/DDCMS/data/tecpetal3b.xml
@@ -1,0 +1,390 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecpetal3b.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="ICCZ" value="([tecpetpar:ICBThick]-[tecpetpar:ICCThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecpetal3b.xml">
+		<Tubs name="TECPetal3B" rMin="[tecpetal3:PetalRmin]" rMax="[tecpetalb:PetalR1]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetalb:PetalWidth0]/2" deltaPhi="[tecpetalb:PetalWidth0]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecpetal3b.xml">
+		<LogicalPart name="TECPetalCont3B" category="unspecified">
+			<rSolid name="tecpetal3:TECPetalCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetalFrame3B" category="unspecified">
+			<rSolid name="tecpetal3:TECPetal3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal3B" category="unspecified">
+			<rSolid name="tecpetal3b:TECPetal3B"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal4B" category="unspecified">
+			<rSolid name="tecpetalb:TECPetal1B"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal5B" category="unspecified">
+			<rSolid name="tecpetalb:TECPetal2B"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont3B1" category="unspecified">
+			<rSolid name="tecpetal3:TECICBCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont3B2" category="unspecified">
+			<rSolid name="tecpetal3:TECICBCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tecpetal3b.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3b:TECPetalCont3B"/>
+			<rChild name="tecring1b:TECRing1B"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring1:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3b:TECPetalCont3B"/>
+			<rChild name="tecring2b:TECRing2B"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring2:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3b:TECPetalCont3B"/>
+			<rChild name="tecring3b:TECRing3B"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring3:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3b:TECPetalCont3B"/>
+			<rChild name="tecring4b:TECRing4B"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring4:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3b:TECPetalCont3B"/>
+			<rChild name="tecring5b:TECRing5B"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring5:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3b:TECPetalCont3B"/>
+			<rChild name="tecring6b:TECRing6B"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring6:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3b:TECPetalCont3B"/>
+			<rChild name="tecpetal3b:TECPetalFrame3B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3b:TECPetalFrame3B"/>
+			<rChild name="tecpetal3b:TECPetal3B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3b:TECPetalFrame3B"/>
+			<rChild name="tecpetal3b:TECPetal4B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3b:TECPetalFrame3B"/>
+			<rChild name="tecpetal3b:TECPetal5B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3b:TECPetalCont3B"/>
+			<rChild name="tecpetal3b:TECICBCont3B1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3b:TECPetalCont3B"/>
+			<rChild name="tecpetal3b:TECICBCont3B2"/>
+			<Translation x="[zero]" y="[zero]" z="[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3b:TECICBCont3B1"/>
+			<rChild name="tecpetalb:TECICC2B1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3b:TECICBCont3B1"/>
+			<rChild name="tecpetalb:TECICC2B2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3b:TECICBCont3B1"/>
+			<rChild name="tecpetalb:TECICC46B1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3b:TECICBCont3B1"/>
+			<rChild name="tecpetalb:TECICC46B2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3b:TECICBCont3B1"/>
+			<rChild name="tecpetalb:TECICC46B3"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3b:TECICBCont3B2"/>
+			<rChild name="tecpetalb:TECICC1B1"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3b:TECICBCont3B2"/>
+			<rChild name="tecpetalb:TECICC1B2"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3b:TECICBCont3B2"/>
+			<rChild name="tecpetalb:TECICC1B3"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3b:TECICBCont3B2"/>
+			<rChild name="tecpetalb:TECICC35B1"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3b:TECICBCont3B2"/>
+			<rChild name="tecpetalb:TECICC35B2"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3b:TECICBCont3B2"/>
+			<rChild name="tecpetalb:TECICC35B3"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3b:TECICBCont3B2"/>
+			<rChild name="tecpetalb:TECICC35B4"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3b:TECICBCont3B2"/>
+			<rChild name="tecpetalb:TECICC35B5"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal3b:TECPetal5B"/>
+			<rChild name="tecwheel:TECInnerManifold"/>
+			<Translation x="[zero]" y="[zero]" z="[zero]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal3B"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="RPosition" value="372.842*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			10.9517*deg	,8.6238*deg	,-8.6238*deg	,-10.9554*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool5,tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal3B"/>
+		<Numeric name="StartCopyNo" value="5"/>
+		<Numeric name="RPosition" value="438.663*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="2">
+			4.8385*deg	,-4.8385*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="2">
+			tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal3B"/>
+		<Numeric name="StartCopyNo" value="7"/>
+		<Numeric name="RPosition" value="451.736*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			9.9308*deg	,0.9308*deg	,-9.9308*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal3B"/>
+		<Numeric name="StartCopyNo" value="10"/>
+		<Numeric name="RPosition" value="491.272*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="2">
+			4.829*deg	,-2.1851*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="2">
+			tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal3B"/>
+		<Numeric name="StartCopyNo" value="12"/>
+		<Numeric name="RPosition" value="529.973*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			9*deg	,0*deg	,-9*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal4B"/>
+		<Numeric name="StartCopyNo" value="15"/>
+		<Numeric name="RPosition" value="565.026*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			10.3812*deg	,3.9526*deg	,-3.9526*deg	,-10.3812*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal4B"/>
+		<Numeric name="StartCopyNo" value="19"/>
+		<Numeric name="RPosition" value="646.359*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			9.6429*deg	,3.2143*deg	,-3.2143*deg	,-9.6429*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal4B"/>
+		<Numeric name="StartCopyNo" value="23"/>
+		<Numeric name="RPosition" value="688.526*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			14.144*deg	,5.144*deg	,-5.144*deg	,-14.144*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal4B"/>
+		<Numeric name="StartCopyNo" value="27"/>
+		<Numeric name="RPosition" value="705.35*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			5.0584*deg	,-3.2876*deg	,-7.7907*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal5B"/>
+		<Numeric name="StartCopyNo" value="30"/>
+		<Numeric name="RPosition" value="777.681*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			11.727*deg	,6.273*deg	,2.727*deg	,-2.727*deg	,-6.273*deg	,-11.727*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool4,tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal5B"/>
+		<Numeric name="StartCopyNo" value="36"/>
+		<Numeric name="RPosition" value="809.853*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="11">
+			11.729*deg	,9.3832*deg	,7.0374*deg	,4.6916*deg	,2.3458*deg	,0*deg	,-2.3458*deg	,-4.6916*deg	,-7.0374*deg	,-9.3832*deg	,-11.729*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="11">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal5B"/>
+		<Numeric name="StartCopyNo" value="47"/>
+		<Numeric name="RPosition" value="826.305*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			10.1935*deg	,3.7649*deg	,-3.7649*deg	,-10.1935*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal5B"/>
+		<Numeric name="StartCopyNo" value="51"/>
+		<Numeric name="RPosition" value="862.788*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			11.25*deg	,6.75*deg	,2.25*deg	,-2.25*deg	,-6.75*deg	,-11.25*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal5B"/>
+		<Numeric name="StartCopyNo" value="57"/>
+		<Numeric name="RPosition" value="937.93*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			8.6894*deg	,4.1677*deg	,2.2608*deg	,-2.2608*deg	,-4.1677*deg	,-8.6894*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool2,tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal5B"/>
+		<Numeric name="StartCopyNo" value="63"/>
+		<Numeric name="RPosition" value="997.895*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="8">
+			11.6983*deg	,6.3017*deg	,2.6983*deg	,-1.8017*deg	,-2.6983*deg	,-6.3017*deg	,-7.1983*deg	,-11.6983*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="8">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal5B"/>
+		<Numeric name="StartCopyNo" value="71"/>
+		<Numeric name="RPosition" value="1040.55*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			10.0576*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3b:TECPetal5B"/>
+		<Numeric name="StartCopyNo" value="72"/>
+		<Numeric name="RPosition" value="1068.17*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			10.0624*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal3b:TECICBCont3B2"/>
+		<Numeric name="StartCopyNo" value="3"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="471.195*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="2">
+			6.6727*deg	,-0.339*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal3b:TECICBCont3B1"/>
+		<Numeric name="StartCopyNo" value="5"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="562.517*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="2">
+			5.4762*deg	,-2.429*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal3b:TECICBCont3B2"/>
+		<Numeric name="StartCopyNo" value="7"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="685.152*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			6.3214*deg	,-2.0241*deg	,-6.5265*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal3b:TECICBCont3B1"/>
+		<Numeric name="StartCopyNo" value="10"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="807.452*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="11">
+			12.7924*deg	,10.4466*deg	,8.1008*deg	,5.755*deg	,3.4092*deg	,1.0634*deg	,-1.2824*deg	,-3.6282*deg	,-5.974*deg	,-8.3197*deg	,-10.6655*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal3b:TECICBCont3B2"/>
+		<Numeric name="StartCopyNo" value="21"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="977.634*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			7.1858*deg	,-0.9183*deg	,-6.3149*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal3b:TECICBCont3B2"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<String name="ChildName" value="tecpetpar:TECDigiOptoHybModule"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:DOHMWidth]"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:DOHMHeight]"/>
+		<Numeric name="Rpos" value="1022.726*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:DOHMZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="1">
+			11.372*deg</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecpetal3f.xml
+++ b/DetectorDescription/DDCMS/data/tecpetal3f.xml
@@ -1,0 +1,385 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecpetal3f.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="ICCZ" value="([tecpetpar:ICBThick]-[tecpetpar:ICCThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecpetal3f.xml">
+		<Tubs name="TECPetal3F" rMin="[tecpetal3:PetalRmin]" rMax="[tecpetalf:PetalR1]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetalf:PetalWidth0]/2" deltaPhi="[tecpetalf:PetalWidth0]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecpetal3f.xml">
+		<LogicalPart name="TECPetalCont3F" category="unspecified">
+			<rSolid name="tecpetal3:TECPetalCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetalFrame3F" category="unspecified">
+			<rSolid name="tecpetal3:TECPetal3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal3F" category="unspecified">
+			<rSolid name="tecpetal3f:TECPetal3F"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal4F" category="unspecified">
+			<rSolid name="tecpetalf:TECPetal1F"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal5F" category="unspecified">
+			<rSolid name="tecpetalf:TECPetal2F"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont3F1" category="unspecified">
+			<rSolid name="tecpetal3:TECICBCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont3F2" category="unspecified">
+			<rSolid name="tecpetal3:TECICBCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tecpetal3f.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECPetalCont3F"/>
+			<rChild name="tecring1f:TECRing1F"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring1:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECPetalCont3F"/>
+			<rChild name="tecring2f:TECRing2F"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring2:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECPetalCont3F"/>
+			<rChild name="tecring3f:TECRing3F"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring3:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECPetalCont3F"/>
+			<rChild name="tecring4f:TECRing4F"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring4:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECPetalCont3F"/>
+			<rChild name="tecring5f:TECRing5F"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring5:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECPetalCont3F"/>
+			<rChild name="tecring6f:TECRing6F"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring6:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECPetalCont3F"/>
+			<rChild name="tecpetal3f:TECPetalFrame3F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECPetalFrame3F"/>
+			<rChild name="tecpetal3f:TECPetal3F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECPetalFrame3F"/>
+			<rChild name="tecpetal3f:TECPetal4F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECPetalFrame3F"/>
+			<rChild name="tecpetal3f:TECPetal5F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECPetalCont3F"/>
+			<rChild name="tecpetal3f:TECICBCont3F1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECPetalCont3F"/>
+			<rChild name="tecpetal3f:TECICBCont3F2"/>
+			<Translation x="[zero]" y="[zero]" z="[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3f:TECICBCont3F1"/>
+			<rChild name="tecpetalf:TECICC2F1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3f:TECICBCont3F1"/>
+			<rChild name="tecpetalf:TECICC2F2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3f:TECICBCont3F1"/>
+			<rChild name="tecpetalf:TECICC46F1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3f:TECICBCont3F1"/>
+			<rChild name="tecpetalf:TECICC46F2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECICBCont3F2"/>
+			<rChild name="tecpetalf:TECICC1SF1"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECICBCont3F2"/>
+			<rChild name="tecpetalf:TECICC1SF2"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal3f:TECICBCont3F2"/>
+			<rChild name="tecpetalf:TECICC1SF3"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3f:TECICBCont3F2"/>
+			<rChild name="tecpetalf:TECICC35F1"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3f:TECICBCont3F2"/>
+			<rChild name="tecpetalf:TECICC35F2"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3f:TECICBCont3F2"/>
+			<rChild name="tecpetalf:TECICC35F3"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3f:TECICBCont3F2"/>
+			<rChild name="tecpetalf:TECICC35F4"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecpetal3f:TECICBCont3F2"/>
+			<rChild name="tecpetalf:TECICC35F5"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal3f:TECPetal5F"/>
+			<rChild name="tecwheel:TECInnerManifold"/>
+			<Translation x="[zero]" y="[zero]" z="[zero]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal3F"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="RPosition" value="373.084*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			16.1238*deg	,1.1238*deg	,-16.1238*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal3F"/>
+		<Numeric name="StartCopyNo" value="4"/>
+		<Numeric name="RPosition" value="438.663*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			12.3385*deg	,2.6615*deg	,-2.6615*deg	,-12.3385*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool4,tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal3F"/>
+		<Numeric name="StartCopyNo" value="8"/>
+		<Numeric name="RPosition" value="451.736*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			14.4308*deg	,5.4308*deg	,-5.4308*deg	,-14.4308*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal3F"/>
+		<Numeric name="StartCopyNo" value="12"/>
+		<Numeric name="RPosition" value="491.326*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			9.6429*deg	,5.2432*deg	,-5.3537*deg	,-9.7534*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal3F"/>
+		<Numeric name="StartCopyNo" value="16"/>
+		<Numeric name="RPosition" value="529.973*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			13.5*deg	,4.5*deg	,-4.5*deg	,-13.5*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal4F"/>
+		<Numeric name="StartCopyNo" value="20"/>
+		<Numeric name="RPosition" value="565.026*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="7">
+			13.5955*deg	,9.3071*deg	,5.6902*deg	,0.7383*deg	,-7.1669*deg	,-8.7012*deg	,-13.5955*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="7">
+			tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal4F"/>
+		<Numeric name="StartCopyNo" value="27"/>
+		<Numeric name="RPosition" value="646.359*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="5">
+			12.8571*deg	,6.4286*deg	,0*deg	,-6.4286*deg	,-12.8571*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="5">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal4F"/>
+		<Numeric name="StartCopyNo" value="32"/>
+		<Numeric name="RPosition" value="688.526*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			9.644*deg	,-0.644*deg	,-9.644*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal4F"/>
+		<Numeric name="StartCopyNo" value="35"/>
+		<Numeric name="RPosition" value="705.393*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			8.0585*deg	,2.4756*deg	,-5.2453*deg	,-11.2274*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal4F"/>
+		<Numeric name="StartCopyNo" value="39"/>
+		<Numeric name="RPosition" value="777.681*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			7.227*deg	,1.773*deg	,-1.773*deg	,-7.227*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal4F"/>
+		<Numeric name="StartCopyNo" value="43"/>
+		<Numeric name="RPosition" value="809.358*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="9">
+			8.8981*deg	,6.5507*deg	,4.2142*deg	,1.8718*deg	,-0.4758*deg	,-2.8175*deg	,-5.1527*deg	,-7.4972*deg	,-9.8497*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="9">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal4F"/>
+		<Numeric name="StartCopyNo" value="52"/>
+		<Numeric name="RPosition" value="826.305*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="5">
+			13.4078*deg	,5.8779*deg	,0.5506*deg	,-6.9792*deg	,-13.4078*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="5">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal4F"/>
+		<Numeric name="StartCopyNo" value="57"/>
+		<Numeric name="RPosition" value="862.788*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			11.25*deg	,6.75*deg	,2.25*deg	,-2.25*deg	,-6.75*deg	,-11.25*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal5F"/>
+		<Numeric name="StartCopyNo" value="63"/>
+		<Numeric name="RPosition" value="937.93*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="8">
+			11.9037*deg	,7.382*deg	,5.4751*deg	,0.9535*deg	,-0.9535*deg	,-5.4751*deg	,-7.382*deg	,-11.9037*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="8">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2,tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal5F"/>
+		<Numeric name="StartCopyNo" value="71"/>
+		<Numeric name="RPosition" value="997.895*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="8">
+			11.6983*deg	,7.1983*deg	,6.3017*deg	,2.6983*deg	,-2.6983*deg	,-6.3017*deg	,-10.1082*deg	,-11.6983*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="8">
+			tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal5F"/>
+		<Numeric name="StartCopyNo" value="79"/>
+		<Numeric name="RPosition" value="1037.61*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			-9.9912*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal3f:TECPetal5F"/>
+		<Numeric name="StartCopyNo" value="80"/>
+		<Numeric name="RPosition" value="1065.23*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			-9.9978*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal3f:TECICBCont3F2"/>
+		<Numeric name="StartCopyNo" value="5"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="471.051*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="4">
+			11.9412*deg	,7.5404*deg	,-3.0597*deg	,-7.4597*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal3f:TECICBCont3F1"/>
+		<Numeric name="StartCopyNo" value="9"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="562.721*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			11.2453*deg	,2.6765*deg	,-6.8472*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal3f:TECICBCont3F2"/>
+		<Numeric name="StartCopyNo" value="12"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="685.052*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="4">
+			9.6425*deg	,4.0592*deg	,-3.6616*deg	,-9.643*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal3f:TECICBCont3F1"/>
+		<Numeric name="StartCopyNo" value="16"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="807.002*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="9">
+			10.2499*deg	,7.9025*deg	,5.5659*deg	,3.2235*deg	,0.8753*deg	,-1.4658*deg	,-3.801*deg	,-6.1455*deg	,-8.5563*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal3f:TECICBCont3F2"/>
+		<Numeric name="StartCopyNo" value="25"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="977.591*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			8.3153*deg	,3.8227*deg	,-5.1984*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal3f:TECICBCont3F2"/>
+		<Numeric name="StartCopyNo" value="28"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybridShort"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="Rpos" value="977.591*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="1">
+			-9.9916*deg</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecpetal6b.xml
+++ b/DetectorDescription/DDCMS/data/tecpetal6b.xml
@@ -1,0 +1,359 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecpetal6b.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="ICCZ" value="([tecpetpar:ICBThick]-[tecpetpar:ICCThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecpetal6b.xml">
+		<Tubs name="TECPetal6B" rMin="[tecpetal3:PetalRmin]" rMax="[tecpetalb:PetalR1]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetalb:PetalWidth0]/2" deltaPhi="[tecpetalb:PetalWidth0]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecpetal6b.xml">
+		<LogicalPart name="TECPetalCont6B" category="unspecified">
+			<rSolid name="tecpetal3:TECPetalCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetalFrame6B" category="unspecified">
+			<rSolid name="tecpetal3:TECPetal3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal6B" category="unspecified">
+			<rSolid name="tecpetal6b:TECPetal6B"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal7B" category="unspecified">
+			<rSolid name="tecpetalb:TECPetal1B"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetalaB" category="unspecified">
+			<rSolid name="tecpetalb:TECPetal2B"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont6B1" category="unspecified">
+			<rSolid name="tecpetal3:TECICBCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont6B2" category="unspecified">
+			<rSolid name="tecpetal3:TECICBCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tecpetal6b.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6b:TECPetalCont6B"/>
+			<rChild name="tecring2b:TECRing2B"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring2:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6b:TECPetalCont6B"/>
+			<rChild name="tecring3b:TECRing3B"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring3:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6b:TECPetalCont6B"/>
+			<rChild name="tecring4b:TECRing4B"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring4:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6b:TECPetalCont6B"/>
+			<rChild name="tecring5b:TECRing5B"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring5:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6b:TECPetalCont6B"/>
+			<rChild name="tecring6b:TECRing6B"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring6:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6b:TECPetalCont6B"/>
+			<rChild name="tecpetal6b:TECPetalFrame6B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6b:TECPetalFrame6B"/>
+			<rChild name="tecpetal6b:TECPetal6B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6b:TECPetalFrame6B"/>
+			<rChild name="tecpetal6b:TECPetal7B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6b:TECPetalFrame6B"/>
+			<rChild name="tecpetal6b:TECPetalaB"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6b:TECPetalCont6B"/>
+			<rChild name="tecpetal6b:TECICBCont6B1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6b:TECPetalCont6B"/>
+			<rChild name="tecpetal6b:TECICBCont6B2"/>
+			<Translation x="[zero]" y="[zero]" z="[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6b:TECICBCont6B1"/>
+			<rChild name="tecpetalb:TECICC2B1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6b:TECICBCont6B1"/>
+			<rChild name="tecpetalb:TECICC2B2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6b:TECICBCont6B1"/>
+			<rChild name="tecpetalb:TECICC46B1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6b:TECICBCont6B1"/>
+			<rChild name="tecpetalb:TECICC46B2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6b:TECICBCont6B1"/>
+			<rChild name="tecpetalb:TECICC46B3"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6b:TECICBCont6B2"/>
+			<rChild name="tecpetalb:TECICC35B1"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6b:TECICBCont6B2"/>
+			<rChild name="tecpetalb:TECICC35B2"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6b:TECICBCont6B2"/>
+			<rChild name="tecpetalb:TECICC35B3"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6b:TECICBCont6B2"/>
+			<rChild name="tecpetalb:TECICC35B4"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6b:TECICBCont6B2"/>
+			<rChild name="tecpetalb:TECICC35B5"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="6">
+			<rParent name="tecpetal6b:TECPetalaB"/>
+			<rChild name="tecwheel:TECInnerManifold"/>
+			<Translation x="[zero]" y="[zero]" z="[zero]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetal6B"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="RPosition" value="372.842*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			10.9517*deg	,8.6238*deg	,-8.6238*deg	,-10.9554*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool5,tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetal6B"/>
+		<Numeric name="StartCopyNo" value="5"/>
+		<Numeric name="RPosition" value="438.663*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="2">
+			4.8385*deg	,-4.8385*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="2">
+			tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetal6B"/>
+		<Numeric name="StartCopyNo" value="7"/>
+		<Numeric name="RPosition" value="451.736*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			9.9308*deg	,0.9308*deg	,-9.9308*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetal6B"/>
+		<Numeric name="StartCopyNo" value="10"/>
+		<Numeric name="RPosition" value="491.272*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="2">
+			4.829*deg	,-2.1851*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="2">
+			tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetal6B"/>
+		<Numeric name="StartCopyNo" value="12"/>
+		<Numeric name="RPosition" value="529.973*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			9*deg	,0*deg	,-9*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetal7B"/>
+		<Numeric name="StartCopyNo" value="15"/>
+		<Numeric name="RPosition" value="565.026*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			10.3812*deg	,3.9526*deg	,-3.9526*deg	,-10.3812*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetal7B"/>
+		<Numeric name="StartCopyNo" value="19"/>
+		<Numeric name="RPosition" value="646.359*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			9.6429*deg	,3.2143*deg	,-3.2143*deg	,-9.6429*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetal7B"/>
+		<Numeric name="StartCopyNo" value="23"/>
+		<Numeric name="RPosition" value="688.526*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			14.144*deg	,5.144*deg	,-5.144*deg	,-14.144*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetal7B"/>
+		<Numeric name="StartCopyNo" value="27"/>
+		<Numeric name="RPosition" value="705.35*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			5.0584*deg	,-3.2876*deg	,-7.7907*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetalaB"/>
+		<Numeric name="StartCopyNo" value="30"/>
+		<Numeric name="RPosition" value="777.681*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			11.727*deg	,6.273*deg	,2.727*deg	,-2.727*deg	,-6.273*deg	,-11.727*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool4,tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetalaB"/>
+		<Numeric name="StartCopyNo" value="36"/>
+		<Numeric name="RPosition" value="809.853*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="11">
+			11.729*deg	,9.3832*deg	,7.0374*deg	,4.6916*deg	,2.3458*deg	,0*deg	,-2.3458*deg	,-4.6916*deg	,-7.0374*deg	,-9.3832*deg	,-11.729*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="11">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetalaB"/>
+		<Numeric name="StartCopyNo" value="47"/>
+		<Numeric name="RPosition" value="826.305*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			10.1935*deg	,3.7649*deg	,-3.7649*deg	,-10.1935*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetalaB"/>
+		<Numeric name="StartCopyNo" value="51"/>
+		<Numeric name="RPosition" value="862.788*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			11.25*deg	,6.75*deg	,2.25*deg	,-2.25*deg	,-6.75*deg	,-11.25*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetalaB"/>
+		<Numeric name="StartCopyNo" value="57"/>
+		<Numeric name="RPosition" value="937.93*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			8.6894*deg	,4.1677*deg	,2.2608*deg	,-2.2608*deg	,-4.1677*deg	,-8.6894*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool2,tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetalaB"/>
+		<Numeric name="StartCopyNo" value="63"/>
+		<Numeric name="RPosition" value="997.895*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="8">
+			11.6983*deg	,6.3017*deg	,2.6983*deg	,-1.8017*deg	,-2.6983*deg	,-6.3017*deg	,-7.1983*deg	,-11.6983*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="8">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetalaB"/>
+		<Numeric name="StartCopyNo" value="71"/>
+		<Numeric name="RPosition" value="1040.55*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			10.0576*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6b:TECPetalaB"/>
+		<Numeric name="StartCopyNo" value="72"/>
+		<Numeric name="RPosition" value="1068.17*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			10.0624*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal6b:TECICBCont6B1"/>
+		<Numeric name="StartCopyNo" value="5"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="562.517*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="2">
+			5.4762*deg	,-2.429*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal6b:TECICBCont6B2"/>
+		<Numeric name="StartCopyNo" value="7"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="685.152*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			6.3214*deg	,-2.0241*deg	,-6.5265*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal6b:TECICBCont6B1"/>
+		<Numeric name="StartCopyNo" value="10"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="807.452*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="11">
+			12.7924*deg	,10.4466*deg	,8.1008*deg	,5.755*deg	,3.4092*deg	,1.0634*deg	,-1.2824*deg	,-3.6282*deg	,-5.974*deg	,-8.3197*deg	,-10.6655*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal6b:TECICBCont6B2"/>
+		<Numeric name="StartCopyNo" value="21"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="977.634*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			7.1858*deg	,-0.9183*deg	,-6.3149*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal6b:TECICBCont6B2"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<String name="ChildName" value="tecpetpar:TECDigiOptoHybModule"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:DOHMWidth]"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:DOHMHeight]"/>
+		<Numeric name="Rpos" value="1022.726*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:DOHMZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="1">
+			11.372*deg</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecpetal6f.xml
+++ b/DetectorDescription/DDCMS/data/tecpetal6f.xml
@@ -1,0 +1,354 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecpetal6f.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="ICCZ" value="([tecpetpar:ICBThick]-[tecpetpar:ICCThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecpetal6f.xml">
+		<Tubs name="TECPetal6F" rMin="[tecpetal3:PetalRmin]" rMax="[tecpetalf:PetalR1]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetalf:PetalWidth0]/2" deltaPhi="[tecpetalf:PetalWidth0]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecpetal6f.xml">
+		<LogicalPart name="TECPetalCont6F" category="unspecified">
+			<rSolid name="tecpetal3:TECPetalCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetalFrame6F" category="unspecified">
+			<rSolid name="tecpetal3:TECPetal3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal6F" category="unspecified">
+			<rSolid name="tecpetal6f:TECPetal6F"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal7F" category="unspecified">
+			<rSolid name="tecpetalf:TECPetal1F"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetalaF" category="unspecified">
+			<rSolid name="tecpetalf:TECPetal2F"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont6F1" category="unspecified">
+			<rSolid name="tecpetal3:TECICBCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont6F2" category="unspecified">
+			<rSolid name="tecpetal3:TECICBCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tecpetal6f.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6f:TECPetalCont6F"/>
+			<rChild name="tecring2f:TECRing2F"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring2:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6f:TECPetalCont6F"/>
+			<rChild name="tecring3f:TECRing3F"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring3:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6f:TECPetalCont6F"/>
+			<rChild name="tecring4f:TECRing4F"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring4:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6f:TECPetalCont6F"/>
+			<rChild name="tecring5f:TECRing5F"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring5:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6f:TECPetalCont6F"/>
+			<rChild name="tecring6f:TECRing6F"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring6:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6f:TECPetalCont6F"/>
+			<rChild name="tecpetal6f:TECPetalFrame6F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6f:TECPetalFrame6F"/>
+			<rChild name="tecpetal6f:TECPetal6F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6f:TECPetalFrame6F"/>
+			<rChild name="tecpetal6f:TECPetal7F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6f:TECPetalFrame6F"/>
+			<rChild name="tecpetal6f:TECPetalaF"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6f:TECPetalCont6F"/>
+			<rChild name="tecpetal6f:TECICBCont6F1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal6f:TECPetalCont6F"/>
+			<rChild name="tecpetal6f:TECICBCont6F2"/>
+			<Translation x="[zero]" y="[zero]" z="[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6f:TECICBCont6F1"/>
+			<rChild name="tecpetalf:TECICC2F1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6f:TECICBCont6F1"/>
+			<rChild name="tecpetalf:TECICC2F2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6f:TECICBCont6F1"/>
+			<rChild name="tecpetalf:TECICC46F1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6f:TECICBCont6F1"/>
+			<rChild name="tecpetalf:TECICC46F2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6f:TECICBCont6F2"/>
+			<rChild name="tecpetalf:TECICC35F1"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6f:TECICBCont6F2"/>
+			<rChild name="tecpetalf:TECICC35F2"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6f:TECICBCont6F2"/>
+			<rChild name="tecpetalf:TECICC35F3"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6f:TECICBCont6F2"/>
+			<rChild name="tecpetalf:TECICC35F4"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecpetal6f:TECICBCont6F2"/>
+			<rChild name="tecpetalf:TECICC35F5"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="5">
+			<rParent name="tecpetal6f:TECPetalaF"/>
+			<rChild name="tecwheel:TECInnerManifold"/>
+			<Translation x="[zero]" y="[zero]" z="[zero]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetal6F"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="RPosition" value="373.084*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			16.1238*deg	,1.1238*deg	,-16.1238*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetal6F"/>
+		<Numeric name="StartCopyNo" value="4"/>
+		<Numeric name="RPosition" value="438.663*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			12.3385*deg	,2.6615*deg	,-2.6615*deg	,-12.3385*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool4,tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetal6F"/>
+		<Numeric name="StartCopyNo" value="8"/>
+		<Numeric name="RPosition" value="451.736*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			14.4308*deg	,5.4308*deg	,-5.4308*deg	,-14.4308*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetal6F"/>
+		<Numeric name="StartCopyNo" value="12"/>
+		<Numeric name="RPosition" value="491.326*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			9.6429*deg	,5.2432*deg	,-5.3537*deg	,-9.7534*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetal6F"/>
+		<Numeric name="StartCopyNo" value="16"/>
+		<Numeric name="RPosition" value="529.973*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			13.5*deg	,4.5*deg	,-4.5*deg	,-13.5*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetal7F"/>
+		<Numeric name="StartCopyNo" value="20"/>
+		<Numeric name="RPosition" value="565.026*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="7">
+			13.5955*deg	,9.3071*deg	,5.6902*deg	,0.7383*deg	,-7.1669*deg	,-8.7012*deg	,-13.5955*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="7">
+			tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetal7F"/>
+		<Numeric name="StartCopyNo" value="27"/>
+		<Numeric name="RPosition" value="646.359*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="5">
+			12.8571*deg	,6.4286*deg	,0*deg	,-6.4286*deg	,-12.8571*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="5">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetal7F"/>
+		<Numeric name="StartCopyNo" value="32"/>
+		<Numeric name="RPosition" value="688.526*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			9.644*deg	,-0.644*deg	,-9.644*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetal7F"/>
+		<Numeric name="StartCopyNo" value="35"/>
+		<Numeric name="RPosition" value="705.393*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			8.0585*deg	,2.4756*deg	,-5.2453*deg	,-11.2274*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetal7F"/>
+		<Numeric name="StartCopyNo" value="39"/>
+		<Numeric name="RPosition" value="777.681*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			7.227*deg	,1.773*deg	,-1.773*deg	,-7.227*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetal7F"/>
+		<Numeric name="StartCopyNo" value="43"/>
+		<Numeric name="RPosition" value="809.358*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="9">
+			8.8981*deg	,6.5507*deg	,4.2142*deg	,1.8718*deg	,-0.4758*deg	,-2.8175*deg	,-5.1527*deg	,-7.4972*deg	,-9.8497*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="9">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetal7F"/>
+		<Numeric name="StartCopyNo" value="52"/>
+		<Numeric name="RPosition" value="826.305*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="5">
+			13.4078*deg	,5.8779*deg	,0.5506*deg	,-6.9792*deg	,-13.4078*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="5">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetal7F"/>
+		<Numeric name="StartCopyNo" value="57"/>
+		<Numeric name="RPosition" value="862.788*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			11.25*deg	,6.75*deg	,2.25*deg	,-2.25*deg	,-6.75*deg	,-11.25*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetalaF"/>
+		<Numeric name="StartCopyNo" value="63"/>
+		<Numeric name="RPosition" value="937.93*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="8">
+			11.9037*deg	,7.382*deg	,5.4751*deg	,0.9535*deg	,-0.9535*deg	,-5.4751*deg	,-7.382*deg	,-11.9037*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="8">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2,tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetalaF"/>
+		<Numeric name="StartCopyNo" value="71"/>
+		<Numeric name="RPosition" value="997.895*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="8">
+			11.6983*deg	,7.1983*deg	,6.3017*deg	,2.6983*deg	,-2.6983*deg	,-6.3017*deg	,-10.1082*deg	,-11.6983*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="8">
+			tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetalaF"/>
+		<Numeric name="StartCopyNo" value="79"/>
+		<Numeric name="RPosition" value="1037.61*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			-9.9912*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal6f:TECPetalaF"/>
+		<Numeric name="StartCopyNo" value="80"/>
+		<Numeric name="RPosition" value="1065.23*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			-9.9978*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal6f:TECICBCont6F1"/>
+		<Numeric name="StartCopyNo" value="9"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="562.721*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			11.2453*deg	,2.6765*deg	,-6.8472*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal6f:TECICBCont6F2"/>
+		<Numeric name="StartCopyNo" value="12"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="685.052*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="4">
+			9.6425*deg	,4.0592*deg	,-3.6616*deg	,-9.643*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal6f:TECICBCont6F1"/>
+		<Numeric name="StartCopyNo" value="16"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="807.002*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="9">
+			10.2499*deg	,7.9025*deg	,5.5659*deg	,3.2235*deg	,0.8753*deg	,-1.4658*deg	,-3.801*deg	,-6.1455*deg	,-8.5563*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal6f:TECICBCont6F2"/>
+		<Numeric name="StartCopyNo" value="25"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="977.591*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			8.3153*deg	,3.8227*deg	,-5.1984*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal6f:TECICBCont6F2"/>
+		<Numeric name="StartCopyNo" value="28"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybridShort"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="Rpos" value="977.591*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="1">
+			-9.9916*deg</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecpetal8b.xml
+++ b/DetectorDescription/DDCMS/data/tecpetal8b.xml
@@ -1,0 +1,332 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecpetal8b.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="ICCZ" value="([tecpetpar:ICBThick]-[tecpetpar:ICCThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecpetal8b.xml">
+		<Tubs name="TECPetal8B" rMin="[tecpetal3:PetalRmin]" rMax="[tecpetalb:PetalR1]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetalb:PetalWidth0]/2" deltaPhi="[tecpetalb:PetalWidth0]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecpetal8b.xml">
+		<LogicalPart name="TECPetalCont8B" category="unspecified">
+			<rSolid name="tecpetal3:TECPetalCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetalFrame8B" category="unspecified">
+			<rSolid name="tecpetal3:TECPetal3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal8B" category="unspecified">
+			<rSolid name="tecpetal8b:TECPetal8B"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal9B" category="unspecified">
+			<rSolid name="tecpetalb:TECPetal1B"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetalbB" category="unspecified">
+			<rSolid name="tecpetalb:TECPetal2B"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont8B1" category="unspecified">
+			<rSolid name="tecpetal3:TECICBCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont8B2" category="unspecified">
+			<rSolid name="tecpetal3:TECICBCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tecpetal8b.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8b:TECPetalCont8B"/>
+			<rChild name="tecring3b:TECRing3B"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring3:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8b:TECPetalCont8B"/>
+			<rChild name="tecring4b:TECRing4B"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring4:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8b:TECPetalCont8B"/>
+			<rChild name="tecring5b:TECRing5B"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring5:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8b:TECPetalCont8B"/>
+			<rChild name="tecring6b:TECRing6B"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring6:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8b:TECPetalCont8B"/>
+			<rChild name="tecpetal8b:TECPetalFrame8B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8b:TECPetalFrame8B"/>
+			<rChild name="tecpetal8b:TECPetal8B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8b:TECPetalFrame8B"/>
+			<rChild name="tecpetal8b:TECPetal9B"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8b:TECPetalFrame8B"/>
+			<rChild name="tecpetal8b:TECPetalbB"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8b:TECPetalCont8B"/>
+			<rChild name="tecpetal8b:TECICBCont8B1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8b:TECPetalCont8B"/>
+			<rChild name="tecpetal8b:TECICBCont8B2"/>
+			<Translation x="[zero]" y="[zero]" z="[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8b:TECICBCont8B1"/>
+			<rChild name="tecpetalb:TECICC46B1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8b:TECICBCont8B1"/>
+			<rChild name="tecpetalb:TECICC46B2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8b:TECICBCont8B1"/>
+			<rChild name="tecpetalb:TECICC46B3"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8b:TECICBCont8B2"/>
+			<rChild name="tecpetalb:TECICC35B1"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8b:TECICBCont8B2"/>
+			<rChild name="tecpetalb:TECICC35B2"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8b:TECICBCont8B2"/>
+			<rChild name="tecpetalb:TECICC35B3"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8b:TECICBCont8B2"/>
+			<rChild name="tecpetalb:TECICC35B4"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8b:TECICBCont8B2"/>
+			<rChild name="tecpetalb:TECICC35B5"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="8">
+			<rParent name="tecpetal8b:TECPetalbB"/>
+			<rChild name="tecwheel:TECInnerManifold"/>
+			<Translation x="[zero]" y="[zero]" z="[zero]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetal8B"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="RPosition" value="372.842*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			10.9517*deg	,8.6238*deg	,-8.6238*deg	,-10.9554*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool5,tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetal8B"/>
+		<Numeric name="StartCopyNo" value="5"/>
+		<Numeric name="RPosition" value="438.663*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="2">
+			4.8385*deg	,-4.8385*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="2">
+			tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetal8B"/>
+		<Numeric name="StartCopyNo" value="7"/>
+		<Numeric name="RPosition" value="451.736*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			9.9308*deg	,0.9308*deg	,-9.9308*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetal8B"/>
+		<Numeric name="StartCopyNo" value="10"/>
+		<Numeric name="RPosition" value="491.272*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="2">
+			4.829*deg	,-2.1851*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="2">
+			tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetal8B"/>
+		<Numeric name="StartCopyNo" value="12"/>
+		<Numeric name="RPosition" value="529.973*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			9*deg	,0*deg	,-9*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetal9B"/>
+		<Numeric name="StartCopyNo" value="15"/>
+		<Numeric name="RPosition" value="565.026*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			10.3812*deg	,3.9526*deg	,-3.9526*deg	,-10.3812*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetal9B"/>
+		<Numeric name="StartCopyNo" value="19"/>
+		<Numeric name="RPosition" value="646.359*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			9.6429*deg	,3.2143*deg	,-3.2143*deg	,-9.6429*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetal9B"/>
+		<Numeric name="StartCopyNo" value="23"/>
+		<Numeric name="RPosition" value="688.526*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			14.144*deg	,5.144*deg	,-5.144*deg	,-14.144*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetal9B"/>
+		<Numeric name="StartCopyNo" value="27"/>
+		<Numeric name="RPosition" value="705.35*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			5.0584*deg	,-3.2876*deg	,-7.7907*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetalbB"/>
+		<Numeric name="StartCopyNo" value="30"/>
+		<Numeric name="RPosition" value="777.681*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			11.727*deg	,6.273*deg	,2.727*deg	,-2.727*deg	,-6.273*deg	,-11.727*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool4,tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetalbB"/>
+		<Numeric name="StartCopyNo" value="36"/>
+		<Numeric name="RPosition" value="809.853*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="11">
+			11.729*deg	,9.3832*deg	,7.0374*deg	,4.6916*deg	,2.3458*deg	,0*deg	,-2.3458*deg	,-4.6916*deg	,-7.0374*deg	,-9.3832*deg	,-11.729*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="11">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetalbB"/>
+		<Numeric name="StartCopyNo" value="47"/>
+		<Numeric name="RPosition" value="826.305*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			10.1935*deg	,3.7649*deg	,-3.7649*deg	,-10.1935*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetalbB"/>
+		<Numeric name="StartCopyNo" value="51"/>
+		<Numeric name="RPosition" value="862.788*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			11.25*deg	,6.75*deg	,2.25*deg	,-2.25*deg	,-6.75*deg	,-11.25*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetalbB"/>
+		<Numeric name="StartCopyNo" value="57"/>
+		<Numeric name="RPosition" value="937.93*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			8.6894*deg	,4.1677*deg	,2.2608*deg	,-2.2608*deg	,-4.1677*deg	,-8.6894*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool2,tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetalbB"/>
+		<Numeric name="StartCopyNo" value="63"/>
+		<Numeric name="RPosition" value="997.895*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="8">
+			11.6983*deg	,6.3017*deg	,2.6983*deg	,-1.8017*deg	,-2.6983*deg	,-6.3017*deg	,-7.1983*deg	,-11.6983*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="8">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetalbB"/>
+		<Numeric name="StartCopyNo" value="71"/>
+		<Numeric name="RPosition" value="1040.55*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			10.0576*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8b:TECPetalbB"/>
+		<Numeric name="StartCopyNo" value="72"/>
+		<Numeric name="RPosition" value="1068.17*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			10.0624*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal8b:TECICBCont8B2"/>
+		<Numeric name="StartCopyNo" value="7"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="685.152*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			6.3214*deg	,-2.0241*deg	,-6.5265*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal8b:TECICBCont8B1"/>
+		<Numeric name="StartCopyNo" value="10"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="807.452*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="11">
+			12.7924*deg	,10.4466*deg	,8.1008*deg	,5.755*deg	,3.4092*deg	,1.0634*deg	,-1.2824*deg	,-3.6282*deg	,-5.974*deg	,-8.3197*deg	,-10.6655*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal8b:TECICBCont8B2"/>
+		<Numeric name="StartCopyNo" value="21"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="977.634*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			7.1858*deg	,-0.9183*deg	,-6.3149*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal8b:TECICBCont8B2"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<String name="ChildName" value="tecpetpar:TECDigiOptoHybModule"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:DOHMWidth]"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:DOHMHeight]"/>
+		<Numeric name="Rpos" value="1022.726*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:DOHMZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="1">
+			11.372*deg</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecpetal8f.xml
+++ b/DetectorDescription/DDCMS/data/tecpetal8f.xml
@@ -1,0 +1,327 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecpetal8f.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="ICCZ" value="([tecpetpar:ICBThick]-[tecpetpar:ICCThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecpetal8f.xml">
+		<Tubs name="TECPetal8F" rMin="[tecpetal3:PetalRmin]" rMax="[tecpetalf:PetalR1]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetalf:PetalWidth0]/2" deltaPhi="[tecpetalf:PetalWidth0]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecpetal8f.xml">
+		<LogicalPart name="TECPetalCont8F" category="unspecified">
+			<rSolid name="tecpetal3:TECPetalCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetalFrame8F" category="unspecified">
+			<rSolid name="tecpetal3:TECPetal3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal8F" category="unspecified">
+			<rSolid name="tecpetal8f:TECPetal8F"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetal9F" category="unspecified">
+			<rSolid name="tecpetalf:TECPetal1F"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECPetalbF" category="unspecified">
+			<rSolid name="tecpetalf:TECPetal2F"/>
+			<rMaterial name="tecmaterial:TEC_petal"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont8F1" category="unspecified">
+			<rSolid name="tecpetal3:TECICBCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECICBCont8F2" category="unspecified">
+			<rSolid name="tecpetal3:TECICBCont3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tecpetal8f.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8f:TECPetalCont8F"/>
+			<rChild name="tecring3f:TECRing3F"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring3:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8f:TECPetalCont8F"/>
+			<rChild name="tecring4f:TECRing4F"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring4:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8f:TECPetalCont8F"/>
+			<rChild name="tecring5f:TECRing5F"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring5:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8f:TECPetalCont8F"/>
+			<rChild name="tecring6f:TECRing6F"/>
+			<rRotation name="tecpetpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="[tecring6:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8f:TECPetalCont8F"/>
+			<rChild name="tecpetal8f:TECPetalFrame8F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8f:TECPetalFrame8F"/>
+			<rChild name="tecpetal8f:TECPetal8F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8f:TECPetalFrame8F"/>
+			<rChild name="tecpetal8f:TECPetal9F"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8f:TECPetalFrame8F"/>
+			<rChild name="tecpetal8f:TECPetalbF"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8f:TECPetalCont8F"/>
+			<rChild name="tecpetal8f:TECICBCont8F1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecpetal8f:TECPetalCont8F"/>
+			<rChild name="tecpetal8f:TECICBCont8F2"/>
+			<Translation x="[zero]" y="[zero]" z="[tecpetpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8f:TECICBCont8F1"/>
+			<rChild name="tecpetalf:TECICC46F1"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8f:TECICBCont8F1"/>
+			<rChild name="tecpetalf:TECICC46F2"/>
+			<Translation x="[zero]" y="[zero]" z="[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8f:TECICBCont8F2"/>
+			<rChild name="tecpetalf:TECICC35F1"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8f:TECICBCont8F2"/>
+			<rChild name="tecpetalf:TECICC35F2"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8f:TECICBCont8F2"/>
+			<rChild name="tecpetalf:TECICC35F3"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8f:TECICBCont8F2"/>
+			<rChild name="tecpetalf:TECICC35F4"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tecpetal8f:TECICBCont8F2"/>
+			<rChild name="tecpetalf:TECICC35F5"/>
+			<Translation x="[zero]" y="[zero]" z="-[ICCZ]"/>
+		</PosPart>
+		<PosPart copyNumber="7">
+			<rParent name="tecpetal8f:TECPetalbF"/>
+			<rChild name="tecwheel:TECInnerManifold"/>
+			<Translation x="[zero]" y="[zero]" z="[zero]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetal8F"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="RPosition" value="373.084*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			16.1238*deg	,1.1238*deg	,-16.1238*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetal8F"/>
+		<Numeric name="StartCopyNo" value="4"/>
+		<Numeric name="RPosition" value="438.663*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			12.3385*deg	,2.6615*deg	,-2.6615*deg	,-12.3385*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool4,tecpetpar:TECCool4,tecpetpar:TECCool3,tecpetpar:TECCool3</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetal8F"/>
+		<Numeric name="StartCopyNo" value="8"/>
+		<Numeric name="RPosition" value="451.736*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			14.4308*deg	,5.4308*deg	,-5.4308*deg	,-14.4308*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetal8F"/>
+		<Numeric name="StartCopyNo" value="12"/>
+		<Numeric name="RPosition" value="491.326*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			9.6429*deg	,5.2432*deg	,-5.3537*deg	,-9.7534*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetal8F"/>
+		<Numeric name="StartCopyNo" value="16"/>
+		<Numeric name="RPosition" value="529.973*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			13.5*deg	,4.5*deg	,-4.5*deg	,-13.5*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetal9F"/>
+		<Numeric name="StartCopyNo" value="20"/>
+		<Numeric name="RPosition" value="565.026*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="7">
+			13.5955*deg	,9.3071*deg	,5.6902*deg	,0.7383*deg	,-7.1669*deg	,-8.7012*deg	,-13.5955*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="7">
+			tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetal9F"/>
+		<Numeric name="StartCopyNo" value="27"/>
+		<Numeric name="RPosition" value="646.359*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="5">
+			12.8571*deg	,6.4286*deg	,0*deg	,-6.4286*deg	,-12.8571*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="5">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetal9F"/>
+		<Numeric name="StartCopyNo" value="32"/>
+		<Numeric name="RPosition" value="688.526*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="3">
+			9.644*deg	,-0.644*deg	,-9.644*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="3">
+			tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetal9F"/>
+		<Numeric name="StartCopyNo" value="35"/>
+		<Numeric name="RPosition" value="705.393*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			8.0585*deg	,2.4756*deg	,-5.2453*deg	,-11.2274*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetal9F"/>
+		<Numeric name="StartCopyNo" value="39"/>
+		<Numeric name="RPosition" value="777.681*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="4">
+			7.227*deg	,1.773*deg	,-1.773*deg	,-7.227*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="4">
+			tecpetpar:TECCool3,tecpetpar:TECCool3,tecpetpar:TECCool4,tecpetpar:TECCool4</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetal9F"/>
+		<Numeric name="StartCopyNo" value="43"/>
+		<Numeric name="RPosition" value="809.358*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="9">
+			8.8981*deg	,6.5507*deg	,4.2142*deg	,1.8718*deg	,-0.4758*deg	,-2.8175*deg	,-5.1527*deg	,-7.4972*deg	,-9.8497*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="9">
+			tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5,tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetal9F"/>
+		<Numeric name="StartCopyNo" value="52"/>
+		<Numeric name="RPosition" value="826.305*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="5">
+			13.4078*deg	,5.8779*deg	,0.5506*deg	,-6.9792*deg	,-13.4078*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="5">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetal9F"/>
+		<Numeric name="StartCopyNo" value="57"/>
+		<Numeric name="RPosition" value="862.788*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="6">
+			11.25*deg	,6.75*deg	,2.25*deg	,-2.25*deg	,-6.75*deg	,-11.25*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="6">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetalbF"/>
+		<Numeric name="StartCopyNo" value="63"/>
+		<Numeric name="RPosition" value="937.93*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="8">
+			11.9037*deg	,7.382*deg	,5.4751*deg	,0.9535*deg	,-0.9535*deg	,-5.4751*deg	,-7.382*deg	,-11.9037*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="8">
+			tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2,tecpetpar:TECCool2,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool2,tecpetpar:TECCool2</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetalbF"/>
+		<Numeric name="StartCopyNo" value="71"/>
+		<Numeric name="RPosition" value="997.895*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="8">
+			11.6983*deg	,7.1983*deg	,6.3017*deg	,2.6983*deg	,-2.6983*deg	,-6.3017*deg	,-10.1082*deg	,-11.6983*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="8">
+			tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool1,tecpetpar:TECCool5,tecpetpar:TECCool1</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetalbF"/>
+		<Numeric name="StartCopyNo" value="79"/>
+		<Numeric name="RPosition" value="1037.61*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			-9.9912*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECCoolAlgo">
+		<rParent name="tecpetal8f:TECPetalbF"/>
+		<Numeric name="StartCopyNo" value="80"/>
+		<Numeric name="RPosition" value="1065.23*mm"/>
+		<Vector name="PhiPosition" type="numeric" nEntries="1">
+			-9.9978*deg</Vector>
+		<Vector name="CoolInsert" type="string" nEntries="1">
+			tecpetpar:TECCool5</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal8f:TECICBCont8F2"/>
+		<Numeric name="StartCopyNo" value="12"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="685.052*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="4">
+			9.6425*deg	,4.0592*deg	,-3.6616*deg	,-9.643*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal8f:TECICBCont8F1"/>
+		<Numeric name="StartCopyNo" value="16"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="807.002*mm"/>
+		<Numeric name="Zpos" value="-[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="9">
+			10.2499*deg	,7.9025*deg	,5.5659*deg	,3.2235*deg	,0.8753*deg	,-1.4658*deg	,-3.801*deg	,-6.1455*deg	,-8.5563*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal8f:TECICBCont8F2"/>
+		<Numeric name="StartCopyNo" value="25"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybrid"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="Rpos" value="977.591*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="3">
+			8.3153*deg	,3.8227*deg	,-5.1984*deg</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTECOptoHybAlgo">
+		<rParent name="tecpetal8f:TECICBCont8F2"/>
+		<Numeric name="StartCopyNo" value="28"/>
+		<String name="ChildName" value="tecpetpar:TECOptoHybridShort"/>
+		<Numeric name="OptoWidth" value="[tecpetpar:HybridHeight]"/>
+		<Numeric name="OptoHeight" value="[tecpetpar:HybridWidth]"/>
+		<Numeric name="Rpos" value="977.591*mm"/>
+		<Numeric name="Zpos" value="[tecpetpar:HybridZ]"/>
+		<Vector name="Angles" type="numeric" nEntries="1">
+			-9.9916*deg</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecpetalb.xml
+++ b/DetectorDescription/DDCMS/data/tecpetalb.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecpetalb.xml" eval="true">
+		<Constant name="PetalWidth0" value="25.8*deg"/>
+		<Constant name="PetalWidth1" value="29.9*deg"/>
+		<Constant name="PetalWidth2" value="26.9*deg"/>
+		<Constant name="PetalR1" value="55.50*cm"/>
+		<Constant name="PetalR2" value="75.60*cm"/>
+		<Constant name="ICC35B5shift" value="-4.54*deg"/>
+	</ConstantsSection>
+	<SolidSection label="tecpetalb.xml">
+		<Tubs name="TECPetal1B" rMin="[tecpetalb:PetalR1]" rMax="[tecpetalb:PetalR2]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetalb:PetalWidth1]/2" deltaPhi="[tecpetalb:PetalWidth1]"/>
+		<Tubs name="TECPetal2B" rMin="[tecpetalb:PetalR2]" rMax="[tecpetpar:PetalRmax]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetalb:PetalWidth2]/2" deltaPhi="[tecpetalb:PetalWidth2]"/>
+		<Tubs name="TECICC1B1" rMin="391.89*mm" rMax="449.56*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-2.17643*deg" deltaPhi="4.35286*deg"/>
+		<Tubs name="TECICC1B2" rMin="449.56*mm" rMax="493.23*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-5.83087*deg" deltaPhi="11.6617*deg"/>
+		<Tubs name="TECICC1B3" rMin="493.23*mm" rMax="586.67*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-2.17298*deg" deltaPhi="4.34596*deg"/>
+		<Tubs name="TECICC35B1" rMin="586.67*mm" rMax="657.37*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-2.10147*deg" deltaPhi="4.20295*deg"/>
+		<Tubs name="TECICC35B2" rMin="657.37*mm" rMax="690.87*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-12.3423*deg" deltaPhi="24.6847*deg"/>
+		<Tubs name="TECICC35B3" rMin="690.87*mm" rMax="915.67*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-2.89888*deg" deltaPhi="5.79776*deg"/>
+		<Tubs name="TECICC35B4" rMin="915.67*mm" rMax="971.8*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-7.10953*deg" deltaPhi="14.2191*deg"/>
+		<Tubs name="TECICC35B5" rMin="971.8*mm" rMax="1085.91*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-3.62561*deg+[ICC35B5shift]" deltaPhi="7.25122*deg"/>
+		<Tubs name="TECICC0LB1" rMin="356.18*mm" rMax="390.57*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-9.12831*deg" deltaPhi="18.2566*deg"/>
+		<Tubs name="TECICC0LB2" rMin="390.57*mm" rMax="432.42*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-2.24672*deg" deltaPhi="4.49345*deg"/>
+		<Tubs name="TECICC2B1" rMin="542.92*mm" rMax="585.28*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-6.44875*deg" deltaPhi="12.8975*deg"/>
+		<Tubs name="TECICC2B2" rMin="585.28*mm" rMax="637.44*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-1.65027*deg" deltaPhi="3.30054*deg"/>
+		<Tubs name="TECICC46B1" rMin="764.83*mm" rMax="814.65*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-1.45104*deg" deltaPhi="2.90208*deg"/>
+		<Tubs name="TECICC46B2" rMin="814.65*mm" rMax="872.36*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-12.1736*deg" deltaPhi="24.3473*deg"/>
+		<Tubs name="TECICC46B3" rMin="872.36*mm" rMax="933.02*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-2.12357*deg" deltaPhi="4.24715*deg"/>
+	</SolidSection>
+	<LogicalPartSection label="tecpetalb.xml">
+		<LogicalPart name="TECICC1B1" category="unspecified">
+			<rSolid name="tecpetalb:TECICC1B1"/>
+			<rMaterial name="tecmaterial:TEC_ICC1B"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC1B2" category="unspecified">
+			<rSolid name="tecpetalb:TECICC1B2"/>
+			<rMaterial name="tecmaterial:TEC_ICC1B"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC1B3" category="unspecified">
+			<rSolid name="tecpetalb:TECICC1B3"/>
+			<rMaterial name="tecmaterial:TEC_ICC1B"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC35B1" category="unspecified">
+			<rSolid name="tecpetalb:TECICC35B1"/>
+			<rMaterial name="tecmaterial:TEC_ICC35B"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC35B2" category="unspecified">
+			<rSolid name="tecpetalb:TECICC35B2"/>
+			<rMaterial name="tecmaterial:TEC_ICC35B"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC35B3" category="unspecified">
+			<rSolid name="tecpetalb:TECICC35B3"/>
+			<rMaterial name="tecmaterial:TEC_ICC35B"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC35B4" category="unspecified">
+			<rSolid name="tecpetalb:TECICC35B4"/>
+			<rMaterial name="tecmaterial:TEC_ICC35B"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC35B5" category="unspecified">
+			<rSolid name="tecpetalb:TECICC35B5"/>
+			<rMaterial name="tecmaterial:TEC_ICC35B"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC0LB1" category="unspecified">
+			<rSolid name="tecpetalb:TECICC0LB1"/>
+			<rMaterial name="tecmaterial:TEC_ICC0LB"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC0LB2" category="unspecified">
+			<rSolid name="tecpetalb:TECICC0LB2"/>
+			<rMaterial name="tecmaterial:TEC_ICC0LB"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC2B1" category="unspecified">
+			<rSolid name="tecpetalb:TECICC2B1"/>
+			<rMaterial name="tecmaterial:TEC_ICC2B"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC2B2" category="unspecified">
+			<rSolid name="tecpetalb:TECICC2B2"/>
+			<rMaterial name="tecmaterial:TEC_ICC2B"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC46B1" category="unspecified">
+			<rSolid name="tecpetalb:TECICC46B1"/>
+			<rMaterial name="tecmaterial:TEC_ICC46B"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC46B2" category="unspecified">
+			<rSolid name="tecpetalb:TECICC46B2"/>
+			<rMaterial name="tecmaterial:TEC_ICC46B"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC46B3" category="unspecified">
+			<rSolid name="tecpetalb:TECICC46B3"/>
+			<rMaterial name="tecmaterial:TEC_ICC46B"/>
+		</LogicalPart>
+	</LogicalPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecpetalf.xml
+++ b/DetectorDescription/DDCMS/data/tecpetalf.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecpetalf.xml" eval="true">
+		<Constant name="PetalWidth0" value="37.4*deg"/>
+		<Constant name="PetalWidth1" value="30.3*deg"/>
+		<Constant name="PetalWidth2" value="26.9*deg"/>
+		<Constant name="PetalR1" value="53.60*cm"/>
+		<Constant name="PetalR2" value="88.20*cm"/>
+		<Constant name="ICC35F5shift" value="3.41*deg"/>
+	</ConstantsSection>
+	<!-- TECPetal0F is defined in tecpetal{N}f.xml so that the inner radius can be altered
+	     it would be most usefull to introduce i.e. TECPetal0Flong and TECPetal0Fshort with their 
+	     logical definitions here. then the CoolAlgo would not have to be called so often and 
+	     everything would be much tidier. However changing the names of anything seems to be no
+	     good idea so it will stay this way
+	     Matthias-->
+	<SolidSection label="tecpetalf.xml">
+		<Tubs name="TECPetal1F" rMin="[tecpetalf:PetalR1]" rMax="[tecpetalf:PetalR2]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetalf:PetalWidth1]/2" deltaPhi="[tecpetalf:PetalWidth1]"/>
+		<Tubs name="TECPetal2F" rMin="[tecpetalf:PetalR2]" rMax="[tecpetpar:PetalRmax]" dz="[tecpetpar:PetalThick]/2" startPhi="-[tecpetalf:PetalWidth2]/2" deltaPhi="[tecpetalf:PetalWidth2]"/>
+		<Tubs name="TECICC01LF1" rMin="256*mm" rMax="280.59*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-15.0295*deg" deltaPhi="30.059*deg"/>
+		<Tubs name="TECICC01LF2" rMin="280.59*mm" rMax="445.95*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-2.22838*deg" deltaPhi="4.45675*deg"/>
+		<Tubs name="TECICC01LF3" rMin="445.95*mm" rMax="489.83*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-14.4933*deg" deltaPhi="28.9867*deg"/>
+		<Tubs name="TECICC01LF4" rMin="489.83*mm" rMax="583.28*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-2.60597*deg" deltaPhi="5.21194*deg"/>
+		<Tubs name="TECICC35F1" rMin="583.28*mm" rMax="643.28*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-3.09787*deg" deltaPhi="6.19574*deg"/>
+		<Tubs name="TECICC35F2" rMin="643.28*mm" rMax="713.23*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-8.83675*deg" deltaPhi="17.6735*deg"/>
+		<Tubs name="TECICC35F3" rMin="713.23*mm" rMax="943.22*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-3.06064*deg" deltaPhi="6.12128*deg"/>
+		<Tubs name="TECICC35F4" rMin="943.22*mm" rMax="962.58*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-13.3485*deg" deltaPhi="26.697*deg"/>
+		<Tubs name="TECICC35F5" rMin="962.58*mm" rMax="1092.71*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-3.9312*deg+[ICC35F5shift]" deltaPhi="7.86239*deg"/>
+		<Tubs name="TECICC1SF1" rMin="407.84*mm" rMax="445.95*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-2.01346*deg" deltaPhi="4.02691*deg"/>
+		<Tubs name="TECICC1SF2" rMin="445.95*mm" rMax="489.48*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-14.1382*deg" deltaPhi="28.2764*deg"/>
+		<Tubs name="TECICC1SF3" rMin="489.48*mm" rMax="582.93*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-2.60767*deg" deltaPhi="5.21534*deg"/>
+		<Tubs name="TECICC0F1" rMin="361*mm" rMax="389.81*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-13.6144*deg" deltaPhi="27.2288*deg"/>
+		<Tubs name="TECICC0F2" rMin="389.81*mm" rMax="446.04*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-1.7847*deg" deltaPhi="3.56939*deg"/>
+		<Tubs name="TECICC2F1" rMin="543*mm" rMax="565.1*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-11.4782*deg" deltaPhi="22.9565*deg"/>
+		<Tubs name="TECICC2F2" rMin="565.1*mm" rMax="636.46*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-1.25806*deg" deltaPhi="2.51612*deg"/>
+		<Tubs name="TECICC46F1" rMin="795*mm" rMax="852.44*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-11.0046*deg" deltaPhi="22.0091*deg"/>
+		<Tubs name="TECICC46F2" rMin="852.44*mm" rMax="914.9*mm" dz="[tecpetpar:ICCThick]/2" startPhi="-1.47394*deg" deltaPhi="2.94789*deg"/>
+	</SolidSection>
+	<LogicalPartSection label="tecpetalf.xml">
+		<LogicalPart name="TECICC01LF1" category="unspecified">
+			<rSolid name="tecpetalf:TECICC01LF1"/>
+			<rMaterial name="tecmaterial:TEC_ICC01LF"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC01LF2" category="unspecified">
+			<rSolid name="tecpetalf:TECICC01LF2"/>
+			<rMaterial name="tecmaterial:TEC_ICC01LF"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC01LF3" category="unspecified">
+			<rSolid name="tecpetalf:TECICC01LF3"/>
+			<rMaterial name="tecmaterial:TEC_ICC01LF"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC01LF4" category="unspecified">
+			<rSolid name="tecpetalf:TECICC01LF4"/>
+			<rMaterial name="tecmaterial:TEC_ICC01LF"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC35F1" category="unspecified">
+			<rSolid name="tecpetalf:TECICC35F1"/>
+			<rMaterial name="tecmaterial:TEC_ICC35F"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC35F2" category="unspecified">
+			<rSolid name="tecpetalf:TECICC35F2"/>
+			<rMaterial name="tecmaterial:TEC_ICC35F"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC35F3" category="unspecified">
+			<rSolid name="tecpetalf:TECICC35F3"/>
+			<rMaterial name="tecmaterial:TEC_ICC35F"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC35F4" category="unspecified">
+			<rSolid name="tecpetalf:TECICC35F4"/>
+			<rMaterial name="tecmaterial:TEC_ICC35F"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC35F5" category="unspecified">
+			<rSolid name="tecpetalf:TECICC35F5"/>
+			<rMaterial name="tecmaterial:TEC_ICC35F"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC1SF1" category="unspecified">
+			<rSolid name="tecpetalf:TECICC1SF1"/>
+			<rMaterial name="tecmaterial:TEC_ICC1SF"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC1SF2" category="unspecified">
+			<rSolid name="tecpetalf:TECICC1SF2"/>
+			<rMaterial name="tecmaterial:TEC_ICC1SF"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC1SF3" category="unspecified">
+			<rSolid name="tecpetalf:TECICC1SF3"/>
+			<rMaterial name="tecmaterial:TEC_ICC1SF"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC0F1" category="unspecified">
+			<rSolid name="tecpetalf:TECICC0F1"/>
+			<rMaterial name="tecmaterial:TEC_ICC0F"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC0F2" category="unspecified">
+			<rSolid name="tecpetalf:TECICC0F2"/>
+			<rMaterial name="tecmaterial:TEC_ICC0F"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC2F1" category="unspecified">
+			<rSolid name="tecpetalf:TECICC2F1"/>
+			<rMaterial name="tecmaterial:TEC_ICC2F"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC2F2" category="unspecified">
+			<rSolid name="tecpetalf:TECICC2F2"/>
+			<rMaterial name="tecmaterial:TEC_ICC2F"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC46F1" category="unspecified">
+			<rSolid name="tecpetalf:TECICC46F1"/>
+			<rMaterial name="tecmaterial:TEC_ICC46F"/>
+		</LogicalPart>
+		<LogicalPart name="TECICC46F2" category="unspecified">
+			<rSolid name="tecpetalf:TECICC46F2"/>
+			<rMaterial name="tecmaterial:TEC_ICC46F"/>
+		</LogicalPart>
+	</LogicalPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecpetpar.xml
+++ b/DetectorDescription/DDCMS/data/tecpetpar.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecpetpar.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="PetalContThick" value="50.5*mm"/>
+		<Constant name="PetalContWidth" value="37.5*deg"/>
+		<Constant name="PetalContRmax" value="110.17*cm"/>
+		<Constant name="HybridWidth" value="29.97*mm"/>
+		<Constant name="HybridHeight" value="22.99*mm"/>
+		<Constant name="HybridThick" value="1.0*mm"/>
+		<!--(real 1.5mm) in reality this sticks out into the ring volume and is compressed to keep hirachy intact-->
+		<Constant name="CoolR1" value="4.1791*mm"/>
+		<Constant name="CoolR2" value="4.8276*mm"/>
+		<Constant name="CoolR3" value="4.6029*mm"/>
+		<Constant name="CoolR4" value="6.2889*mm"/>
+		<Constant name="CoolR5" value="2.9221*mm"/>
+		<Constant name="CoolL" value="10.00*mm"/>
+		<Constant name="PetalThick" value="10.0*mm"/>
+		<Constant name="PetalWidth" value="37.4*deg"/>
+		<Constant name="PetalRmax" value="109.9*cm"/>
+		<Constant name="ICBThick" value="2.222*mm"/>
+		<!-- see other comments-->
+		<Constant name="ICBWidth" value="37.4*deg"/>
+		<Constant name="ICBRmax" value="110.17*cm"/>
+		<Constant name="ICBZ" value="([PetalThick]+[ICBThick])/2"/>
+		<Constant name="ICCThick" value="1.20*mm"/>
+		<Constant name="HybridZ" value="([ICBThick]-[HybridThick])/2"/>
+		<Constant name="BridgeThick" value="0.25*cm"/>
+		<Constant name="DOHMWidth" value="76.12*mm"/>
+		<Constant name="DOHMHeight" value="40.82*mm"/>
+		<Constant name="DOHMZ" value="[zero]"/>
+		<Constant name="CCUMHeight" value="31*mm"/>
+		<Constant name="CCUMWidth" value="31*mm"/>
+		<Constant name="CCUMThick" value="1.0*mm"/>
+		<!-- (real: 2mm)in reality this sticks out into the ring volume and is compressed to keep hirachy intact-->
+		<Constant name="CCUMZ" value="([ICBThick]-[CCUMThick])/2"/>
+	</ConstantsSection>
+	<RotationSection label="tecpetpar.xml">
+		<Rotation name="180X" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="-90*deg" thetaZ="180*deg" phiZ="0*deg"/>
+	</RotationSection>
+	<SolidSection label="tecpetpar.xml">
+		<Tubs name="TECCool1" rMin="[tecpetpar:zero]" rMax="[tecpetpar:CoolR1]" dz="[tecpetpar:CoolL]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECCool2" rMin="[tecpetpar:zero]" rMax="[tecpetpar:CoolR2]" dz="[tecpetpar:CoolL]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECCool3" rMin="[tecpetpar:zero]" rMax="[tecpetpar:CoolR3]" dz="[tecpetpar:CoolL]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECCool4" rMin="[tecpetpar:zero]" rMax="[tecpetpar:CoolR4]" dz="[tecpetpar:CoolL]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECCool5" rMin="[tecpetpar:zero]" rMax="[tecpetpar:CoolR5]" dz="[tecpetpar:CoolL]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Box name="TECOptoHybrid" dx="[tecpetpar:HybridHeight]/2" dy="[tecpetpar:HybridWidth]/2" dz="[tecpetpar:HybridThick]/2"/>
+		<!-- this one is flipped by 90*deg -->
+		<Box name="TECOptoHybridShort" dx="[tecpetpar:HybridWidth]/2" dy="[tecpetpar:HybridHeight]/2" dz="[tecpetpar:HybridThick]/2"/>
+		<Box name="TECDigiOptoHybModule" dx="[tecpetpar:DOHMWidth]/2" dy="[tecpetpar:DOHMHeight]/2" dz="[tecpetpar:ICBThick]/2"/>
+	</SolidSection>
+	<LogicalPartSection label="tecpetpar.xml">
+		<LogicalPart name="TECCool1" category="unspecified">
+			<rSolid name="tecpetpar:TECCool1"/>
+			<rMaterial name="tecmaterial:TEC_petalinsert"/>
+		</LogicalPart>
+		<LogicalPart name="TECCool2" category="unspecified">
+			<rSolid name="tecpetpar:TECCool2"/>
+			<rMaterial name="tecmaterial:TEC_petalinsert"/>
+		</LogicalPart>
+		<LogicalPart name="TECCool3" category="unspecified">
+			<rSolid name="tecpetpar:TECCool3"/>
+			<rMaterial name="tecmaterial:TEC_petalinsert"/>
+		</LogicalPart>
+		<LogicalPart name="TECCool4" category="unspecified">
+			<rSolid name="tecpetpar:TECCool4"/>
+			<rMaterial name="tecmaterial:TEC_petalinsert"/>
+		</LogicalPart>
+		<LogicalPart name="TECCool5" category="unspecified">
+			<rSolid name="tecpetpar:TECCool5"/>
+			<rMaterial name="tecmaterial:TEC_petalinsert"/>
+		</LogicalPart>
+		<LogicalPart name="TECOptoHybrid" category="unspecified">
+			<rSolid name="tecpetpar:TECOptoHybrid"/>
+			<rMaterial name="tecmaterial:TEC_OptoH"/>
+		</LogicalPart>
+		<LogicalPart name="TECOptoHybridShort" category="unspecified">
+			<rSolid name="tecpetpar:TECOptoHybridShort"/>
+			<rMaterial name="tecmaterial:TEC_OptoH"/>
+		</LogicalPart>
+		<LogicalPart name="TECDigiOptoHybModule" category="unspecified">
+			<rSolid name="tecpetpar:TECDigiOptoHybModule"/>
+			<rMaterial name="tecmaterial:TEC_DOHM"/>
+		</LogicalPart>
+	</LogicalPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring0.xml
+++ b/DetectorDescription/DDCMS/data/tecring0.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring0.xml" eval="true">
+		<Constant name="Rin" value="[tecmodule0:Rin]"/>
+		<Constant name="Rout" value="[tecmodule0:Rout]"/>
+		<Constant name="Rmin" value="234.012*mm"/>
+		<Constant name="NPhi" value="24"/>
+		<Constant name="RPos" value="[Rmin]+([tecmodule0:FullHeight]+[tecmodpar:TopFrameHeight])/2"/>
+		<Constant name="ModuleGap" value="3.437*mm"/>
+		<Constant name="RingThick" value="(2*[tecmodpar:ModuleThickDS]+                                            [ModuleGap])"/>
+		<Constant name="ModuleZ" value="([tecmodpar:ModuleThickDS]+                                          [ModuleGap])/2"/>
+		<Constant name="RingZ" value="-17.2415*mm"/>
+		<Constant name="BridgeR" value="279.9*mm"/>
+		<Constant name="BridgeZ" value="([tecpetpar:BridgeThick]-[tecmodule0:BridgeThick])/2"/>
+		<Constant name="BridgeFrameZ" value="[RingZ]-([tecpetpar:BridgeThick]+            [RingThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecring0.xml">
+		<Tubs name="TECRing0" rMin="[Rin]" rMax="[Rout]" dz="[RingThick]/2" startPhi="-[tecpetpar:PetalContWidth]/2" deltaPhi="[tecpetpar:PetalContWidth]"/>
+	</SolidSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring0b.xml
+++ b/DetectorDescription/DDCMS/data/tecring0b.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring0b.xml" eval="true">
+		<Constant name="Modules" value="1"/>
+		<Constant name="DPhi" value="360*deg/[tecring0:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="Bridges" value="0"/>
+		<Constant name="PhiBridge" value="[Phi0]"/>
+		<Constant name="CoolIns0" value="3333"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring0b.xml">
+		<LogicalPart name="TECRing0B" category="unspecified">
+			<rSolid name="tecring0:TECRing0"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring0b:TECRing0B"/>
+		<String name="ChildName" value="tecmodule0:TECModule0"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring0:RPos]"/>
+		<Numeric name="ZIn" value="-[tecring0:ModuleZ]"/>
+		<Numeric name="ZOut" value="[tecring0:ModuleZ]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="3"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring0f.xml
+++ b/DetectorDescription/DDCMS/data/tecring0f.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring0f.xml" eval="true">
+		<Constant name="Modules" value="2"/>
+		<Constant name="DPhi" value="360*deg/[tecring0:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="AngleHyb0" value="-9.375*deg"/>
+		<Constant name="AngleHyb1" value="-3.125*deg"/>
+		<Constant name="AngleHyb2" value="3.125*deg"/>
+		<Constant name="AngleHyb3" value="9.375*deg"/>
+		<Constant name="Bridges" value="1"/>
+		<Constant name="PhiBridge" value="[Phi0]+[DPhi]"/>
+		<Constant name="CoolIns0" value="4404"/>
+		<Constant name="CoolIns1" value="3333"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring0f.xml">
+		<LogicalPart name="TECRing0F" category="unspecified">
+			<rSolid name="tecring0:TECRing0"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring0f:TECRing0F"/>
+		<String name="ChildName" value="tecmodule0:TECModule0"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring0:RPos]"/>
+		<Numeric name="ZIn" value="[tecring0:ModuleZ]"/>
+		<Numeric name="ZOut" value="-[tecring0:ModuleZ]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTECPhiAltAlgo">
+		<rParent name="tecring0f:TECRing0F"/>
+		<String name="ChildName" value="tecmodule0r:TECModule0Bridge"/>
+		<Numeric name="StartAngle" value="[PhiBridge]"/>
+		<Numeric name="IncrAngle" value="2*[DPhi]"/>
+		<Numeric name="Radius" value="[tecring0:BridgeR]"/>
+		<Numeric name="ZIn" value="[tecring0:BridgeZ]"/>
+		<Numeric name="ZOut" value="[tecring0:BridgeZ]"/>
+		<Numeric name="Number" value="[Bridges]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring1.xml
+++ b/DetectorDescription/DDCMS/data/tecring1.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring1.xml" eval="true">
+		<Constant name="Rin" value="[tecmodule1:Rin]"/>
+		<Constant name="Rout" value="[tecmodule1:Rout]"/>
+		<Constant name="Rmin" value="321.932*mm"/>
+		<Constant name="NPhi" value="24"/>
+		<Constant name="RPos" value="[Rmin]+([tecmodule1:FullHeight]+[tecmodpar:TopFrameHeight])/2"/>
+		<Constant name="ModuleGap" value="3.437*mm"/>
+		<Constant name="RingThick" value="(2*[tecmodpar:ModuleThickDS]+                                            [ModuleGap])"/>
+		<Constant name="ModuleZ" value="([tecmodpar:ModuleThickDS]+                                          [ModuleGap])/2"/>
+		<Constant name="RingZ" value="17.2785*mm"/>
+		<Constant name="BridgeR" value="368.9*mm"/>
+		<Constant name="BridgeZ" value="([tecpetpar:BridgeThick]-[tecmodule1:BridgeThick])/2"/>
+		<Constant name="BridgeFrameZ" value="[RingZ]+([tecpetpar:BridgeThick]+            [RingThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecring1.xml">
+		<Tubs name="TECRing1" rMin="[Rin]" rMax="[Rout]" dz="[RingThick]/2" startPhi="-[tecpetpar:PetalContWidth]/2" deltaPhi="[tecpetpar:PetalContWidth]"/>
+	</SolidSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring1b.xml
+++ b/DetectorDescription/DDCMS/data/tecring1b.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring1b.xml" eval="true">
+		<Constant name="Modules" value="1"/>
+		<Constant name="DPhi" value="360*deg/[tecring1:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="AngleHyb0" value="-10.0*deg"/>
+		<Constant name="AngleHyb1" value="10.0*deg"/>
+		<Constant name="Bridges" value="0"/>
+		<Constant name="PhiBridge" value="[Phi0]"/>
+		<Constant name="CoolIns0" value="3333"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring1b.xml">
+		<LogicalPart name="TECRing1B" category="unspecified">
+			<rSolid name="tecring1:TECRing1"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring1b:TECRing1B"/>
+		<String name="ChildName" value="tecmodule1:TECModule1"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring1:RPos]"/>
+		<Numeric name="ZIn" value="-[tecring1:ModuleZ]"/>
+		<Numeric name="ZOut" value="[tecring1:ModuleZ]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="3"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring1f.xml
+++ b/DetectorDescription/DDCMS/data/tecring1f.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring1f.xml" eval="true">
+		<Constant name="Modules" value="2"/>
+		<Constant name="DPhi" value="360*deg/[tecring1:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="Bridges" value="1"/>
+		<Constant name="PhiBridge" value="[Phi0]+[DPhi]"/>
+		<Constant name="CoolIns0" value="3333"/>
+		<Constant name="CoolIns1" value="4440"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring1f.xml">
+		<LogicalPart name="TECRing1F" category="unspecified">
+			<rSolid name="tecring1:TECRing1"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring1f:TECRing1F"/>
+		<String name="ChildName" value="tecmodule1:TECModule1"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring1:RPos]"/>
+		<Numeric name="ZIn" value="[tecring1:ModuleZ]"/>
+		<Numeric name="ZOut" value="-[tecring1:ModuleZ]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTECPhiAltAlgo">
+		<rParent name="tecring1f:TECRing1F"/>
+		<String name="ChildName" value="tecmodule1r:TECModule1Bridge"/>
+		<Numeric name="StartAngle" value="[PhiBridge]"/>
+		<Numeric name="IncrAngle" value="2*[DPhi]"/>
+		<Numeric name="Radius" value="[tecring1:BridgeR]"/>
+		<Numeric name="ZIn" value="[tecring1:BridgeZ]"/>
+		<Numeric name="ZOut" value="[tecring1:BridgeZ]"/>
+		<Numeric name="Number" value="[Bridges]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring2.xml
+++ b/DetectorDescription/DDCMS/data/tecring2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring2.xml" eval="true">
+		<Constant name="Rin" value="[tecmodule2:Rin]"/>
+		<Constant name="Rout" value="[tecmodule2:Rout]"/>
+		<Constant name="Rmin" value="391.032*mm"/>
+		<Constant name="NPhi" value="40"/>
+		<Constant name="RPos" value="[Rmin]+([tecmodule2:FullHeight]+[tecmodpar:TopFrameHeight])/2"/>
+		<Constant name="ModuleGap" value="3.45*mm"/>
+		<Constant name="RingThick" value="(2*[tecmodpar:ModuleThickSS]+                                            [ModuleGap])"/>
+		<Constant name="ModuleZ" value="([tecmodpar:ModuleThickSS]+                                          [ModuleGap])/2-[tecmodpar:SideFrameThick]"/>
+		<Constant name="RingZ" value="-13.236*mm"/>
+		<Constant name="BridgeR" value="449.8*mm"/>
+		<Constant name="BridgeZ" value="-0.5*[tecmodpar:SideFrameThick]"/>
+		<Constant name="BridgeFrameZ" value="[RingZ]-([tecpetpar:BridgeThick]+            [RingThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecring2.xml">
+		<Tubs name="TECRing2" rMin="[Rin]" rMax="[Rout]" dz="[RingThick]/2" startPhi="-[tecpetpar:PetalContWidth]/2" deltaPhi="[tecpetpar:PetalContWidth]"/>
+	</SolidSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring2b.xml
+++ b/DetectorDescription/DDCMS/data/tecring2b.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring2b.xml" eval="true">
+		<Constant name="Modules" value="2"/>
+		<Constant name="DPhi" value="360*deg/[tecring2:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="AngleHyb0" value="-5.00*deg"/>
+		<Constant name="AngleHyb1" value="5.00*deg"/>
+		<Constant name="Bridges" value="1"/>
+		<Constant name="PhiBridge" value="[Phi0]"/>
+		<Constant name="CoolIns0" value="1111"/>
+		<Constant name="CoolIns1" value="2020"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring2b.xml">
+		<LogicalPart name="TECRing2B" category="unspecified">
+			<rSolid name="tecring2:TECRing2"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring2b:TECRing2B"/>
+		<String name="ChildName" value="tecmodule2:TECModule2"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring2:RPos]"/>
+		<Numeric name="ZIn" value="-[tecring2:ModuleZ]-[tecmodpar:SideFrameThick]"/>
+		<Numeric name="ZOut" value="[tecring2:ModuleZ]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="4"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTECPhiAltAlgo">
+		<rParent name="tecring2b:TECRing2B"/>
+		<String name="ChildName" value="tecmodule2:TECModule2Bridge"/>
+		<Numeric name="StartAngle" value="[PhiBridge]"/>
+		<Numeric name="IncrAngle" value="2*[DPhi]"/>
+		<Numeric name="Radius" value="[tecring2:BridgeR]"/>
+		<Numeric name="ZIn" value="[tecring2:BridgeZ]"/>
+		<Numeric name="ZOut" value="[tecring2:BridgeZ]"/>
+		<Numeric name="Number" value="[Bridges]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring2f.xml
+++ b/DetectorDescription/DDCMS/data/tecring2f.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring2f.xml" eval="true">
+		<Constant name="Modules" value="3"/>
+		<Constant name="DPhi" value="360*deg/[tecring2:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="AngleHyb0" value="-9.375*deg"/>
+		<Constant name="AngleHyb1" value="-3.125*deg"/>
+		<Constant name="AngleHyb2" value="3.125*deg"/>
+		<Constant name="AngleHyb3" value="9.375*deg"/>
+		<Constant name="Bridges" value="1"/>
+		<Constant name="PhiBridge" value="[Phi0]+[DPhi]"/>
+		<Constant name="CoolIns0" value="0202"/>
+		<Constant name="CoolIns1" value="1111"/>
+		<Constant name="CoolIns2" value="2020"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring2f.xml">
+		<LogicalPart name="TECRing2F" category="unspecified">
+			<rSolid name="tecring2:TECRing2"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring2f:TECRing2F"/>
+		<String name="ChildName" value="tecmodule2:TECModule2"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring2:RPos]"/>
+		<Numeric name="ZIn" value="[tecring2:ModuleZ]"/>
+		<Numeric name="ZOut" value="-[tecring2:ModuleZ]-[tecmodpar:SideFrameThick]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTECPhiAltAlgo">
+		<rParent name="tecring2f:TECRing2F"/>
+		<String name="ChildName" value="tecmodule2:TECModule2Bridge"/>
+		<Numeric name="StartAngle" value="[PhiBridge]"/>
+		<Numeric name="IncrAngle" value="2*[DPhi]"/>
+		<Numeric name="Radius" value="[tecring2:BridgeR]"/>
+		<Numeric name="ZIn" value="[tecring2:BridgeZ]"/>
+		<Numeric name="ZOut" value="[tecring2:BridgeZ]"/>
+		<Numeric name="Number" value="[Bridges]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring3.xml
+++ b/DetectorDescription/DDCMS/data/tecring3.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring3.xml" eval="true">
+		<Constant name="Rin" value="[tecmodule3:Rin]"/>
+		<Constant name="Rout" value="[tecmodule3:Rout]"/>
+		<Constant name="Rmin" value="503.081*mm"/>
+		<Constant name="NPhi" value="56"/>
+		<Constant name="RPos" value="[Rmin]+([tecmodule3:FullHeight]+[tecmodpar:TopFrameHeight])/2"/>
+		<Constant name="ModuleGap" value="3.45*mm"/>
+		<Constant name="RingThick" value="(2*[tecmodpar:ModuleThickSS]+                                            [ModuleGap])"/>
+		<Constant name="ModuleZ" value="([tecmodpar:ModuleThickSS]+                                          [ModuleGap])/2 -[tecmodpar:SideFrameThick]"/>
+		<Constant name="RingZ" value="13.237*mm"/>
+		<Constant name="BridgeR" value="563.8*mm"/>
+		<Constant name="BridgeZ" value="-0.5*[tecmodpar:SideFrameThick]"/>
+		<Constant name="BridgeFrameZ" value="[RingZ]+([tecpetpar:BridgeThick]+            [RingThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecring3.xml">
+		<Tubs name="TECRing3" rMin="[Rin]" rMax="[Rout]" dz="[RingThick]/2" startPhi="-[tecpetpar:PetalContWidth]/2" deltaPhi="[tecpetpar:PetalContWidth]"/>
+	</SolidSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring3b.xml
+++ b/DetectorDescription/DDCMS/data/tecring3b.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring3b.xml" eval="true">
+		<Constant name="Modules" value="3"/>
+		<Constant name="DPhi" value="360*deg/[tecring3:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="AngleHyb0" value="-7.000*deg"/>
+		<Constant name="AngleHyb1" value="7.000*deg"/>
+		<Constant name="Bridges" value="1"/>
+		<Constant name="PhiBridge" value="[Phi0]+[DPhi]"/>
+		<Constant name="CoolIns0" value="0202"/>
+		<Constant name="CoolIns1" value="1111"/>
+		<Constant name="CoolIns2" value="2020"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring3b.xml">
+		<LogicalPart name="TECRing3B" category="unspecified">
+			<rSolid name="tecring3:TECRing3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring3b:TECRing3B"/>
+		<String name="ChildName" value="tecmodule3:TECModule3"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring3:RPos]"/>
+		<Numeric name="ZIn" value="[tecring3:ModuleZ]"/>
+		<Numeric name="ZOut" value="-[tecring3:ModuleZ]-[tecmodpar:SideFrameThick]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="5"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTECPhiAltAlgo">
+		<rParent name="tecring3b:TECRing3B"/>
+		<String name="ChildName" value="tecmodule3:TECModule3Bridge"/>
+		<Numeric name="StartAngle" value="[PhiBridge]"/>
+		<Numeric name="IncrAngle" value="2*[DPhi]"/>
+		<Numeric name="Radius" value="[tecring3:BridgeR]"/>
+		<Numeric name="ZIn" value="[tecring3:BridgeZ]"/>
+		<Numeric name="ZOut" value="[tecring3:BridgeZ]"/>
+		<Numeric name="Number" value="[Bridges]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring3f.xml
+++ b/DetectorDescription/DDCMS/data/tecring3f.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring3f.xml" eval="true">
+		<Constant name="Modules" value="4"/>
+		<Constant name="DPhi" value="360*deg/[tecring3:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="AngleHyb0" value="-9.375*deg"/>
+		<Constant name="AngleHyb1" value="0.000*deg"/>
+		<Constant name="AngleHyb2" value="9.375*deg"/>
+		<Constant name="Bridges" value="2"/>
+		<Constant name="PhiBridge" value="[Phi0]"/>
+		<Constant name="CoolIns0" value="0202"/>
+		<Constant name="CoolIns1" value="1111"/>
+		<Constant name="CoolIns2" value="0000"/>
+		<Constant name="CoolIns3" value="1111"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring3f.xml">
+		<LogicalPart name="TECRing3F" category="unspecified">
+			<rSolid name="tecring3:TECRing3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring3f:TECRing3F"/>
+		<String name="ChildName" value="tecmodule3:TECModule3"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring3:RPos]"/>
+		<Numeric name="ZIn" value="-[tecring3:ModuleZ]-[tecmodpar:SideFrameThick]"/>
+		<Numeric name="ZOut" value="[tecring3:ModuleZ]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTECPhiAltAlgo">
+		<rParent name="tecring3f:TECRing3F"/>
+		<String name="ChildName" value="tecmodule3:TECModule3Bridge"/>
+		<Numeric name="StartAngle" value="[PhiBridge]"/>
+		<Numeric name="IncrAngle" value="2*[DPhi]"/>
+		<Numeric name="Radius" value="[tecring3:BridgeR]"/>
+		<Numeric name="ZIn" value="[tecring3:BridgeZ]"/>
+		<Numeric name="ZOut" value="[tecring3:BridgeZ]"/>
+		<Numeric name="Number" value="[Bridges]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring4.xml
+++ b/DetectorDescription/DDCMS/data/tecring4.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring4.xml" eval="true">
+		<Constant name="Rin" value="[tecmodule4:Rin]"/>
+		<Constant name="Rout" value="[tecmodule4:Rout]"/>
+		<Constant name="Rmin" value="601.787*mm"/>
+		<Constant name="NPhi" value="40"/>
+		<Constant name="RPos" value="[Rmin]+([tecmodule4:FullHeight]+[tecmodpar:TopFrameHeight])/2"/>
+		<Constant name="ModuleGap" value="3.75*mm"/>
+		<Constant name="RingThick" value="(2*[tecmodpar:ModuleThickDS]+                                            [ModuleGap])"/>
+		<Constant name="ModuleZ" value="([tecmodpar:ModuleThickDS]+                                          [ModuleGap])/2"/>
+		<Constant name="RingZ" value="-17.229*mm"/>
+		<Constant name="BridgeR" value="685.9*mm"/>
+		<Constant name="BridgeZ" value="([tecpetpar:BridgeThick]-[tecmodule4:BridgeThick])/2"/>
+		<Constant name="BridgeFrameZ" value="[RingZ]-([tecpetpar:BridgeThick]+            [RingThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecring4.xml">
+		<Tubs name="TECRing4" rMin="[Rin]" rMax="[Rout]" dz="[RingThick]/2" startPhi="-[tecpetpar:PetalContWidth]/2" deltaPhi="[tecpetpar:PetalContWidth]"/>
+	</SolidSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring4b.xml
+++ b/DetectorDescription/DDCMS/data/tecring4b.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring4b.xml" eval="true">
+		<Constant name="Modules" value="3"/>
+		<Constant name="DPhi" value="360*deg/[tecring4:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="AngleHyb0" value="-10.000*deg"/>
+		<Constant name="AngleHyb1" value="0.000*deg"/>
+		<Constant name="AngleHyb2" value="10.000*deg"/>
+		<Constant name="Bridges" value="1"/>
+		<Constant name="PhiBridge" value="[Phi0]+[DPhi]"/>
+		<Constant name="CoolIns0" value="4404"/>
+		<Constant name="CoolIns1" value="3333"/>
+		<Constant name="CoolIns2" value="4440"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring4b.xml">
+		<LogicalPart name="TECRing4B" category="unspecified">
+			<rSolid name="tecring4:TECRing4"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring4b:TECRing4B"/>
+		<String name="ChildName" value="tecmodule4:TECModule4"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring4:RPos]"/>
+		<Numeric name="ZIn" value="[tecring4:ModuleZ]"/>
+		<Numeric name="ZOut" value="-[tecring4:ModuleZ]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="3"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTECPhiAltAlgo">
+		<rParent name="tecring4b:TECRing4B"/>
+		<String name="ChildName" value="tecmodule4r:TECModule4Bridge"/>
+		<Numeric name="StartAngle" value="[PhiBridge]"/>
+		<Numeric name="IncrAngle" value="2*[DPhi]"/>
+		<Numeric name="Radius" value="[tecring4:BridgeR]"/>
+		<Numeric name="ZIn" value="[tecring4:BridgeZ]"/>
+		<Numeric name="ZOut" value="[tecring4:BridgeZ]"/>
+		<Numeric name="Number" value="[Bridges]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring4f.xml
+++ b/DetectorDescription/DDCMS/data/tecring4f.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring4f.xml" eval="true">
+		<Constant name="Modules" value="2"/>
+		<Constant name="DPhi" value="360*deg/[tecring4:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="AngleHyb0" value="-9.375*deg"/>
+		<Constant name="AngleHyb1" value="-3.125*deg"/>
+		<Constant name="AngleHyb2" value="3.125*deg"/>
+		<Constant name="AngleHyb3" value="9.375*deg"/>
+		<Constant name="Bridges" value="1"/>
+		<Constant name="PhiBridge" value="[Phi0]+[DPhi]"/>
+		<Constant name="CoolIns0" value="4404"/>
+		<Constant name="CoolIns1" value="3333"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring4f.xml">
+		<LogicalPart name="TECRing4F" category="unspecified">
+			<rSolid name="tecring4:TECRing4"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring4f:TECRing4F"/>
+		<String name="ChildName" value="tecmodule4:TECModule4"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring4:RPos]"/>
+		<Numeric name="ZIn" value="[tecring4:ModuleZ]"/>
+		<Numeric name="ZOut" value="-[tecring4:ModuleZ]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTECPhiAltAlgo">
+		<rParent name="tecring4f:TECRing4F"/>
+		<String name="ChildName" value="tecmodule4r:TECModule4Bridge"/>
+		<Numeric name="StartAngle" value="[PhiBridge]"/>
+		<Numeric name="IncrAngle" value="2*[DPhi]"/>
+		<Numeric name="Radius" value="[tecring4:BridgeR]"/>
+		<Numeric name="ZIn" value="[tecring4:BridgeZ]"/>
+		<Numeric name="ZOut" value="[tecring4:BridgeZ]"/>
+		<Numeric name="Number" value="[Bridges]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring5.xml
+++ b/DetectorDescription/DDCMS/data/tecring5.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring5.xml" eval="true">
+		<Constant name="Rin" value="[tecmodule5:Rin]"/>
+		<Constant name="Rout" value="[tecmodule5:Rout]"/>
+		<Constant name="Rmin" value="725.41*mm"/>
+		<Constant name="NPhi" value="56"/>
+		<Constant name="RPos" value="[Rmin]+([tecmodule5:FullHeight]+[tecmodpar:TopFrameHeight])/2"/>
+		<Constant name="ModuleGap" value="3.45*mm"/>
+		<Constant name="RingThick" value="(2*[tecmodpar:ModuleThickSS]+                                            [ModuleGap])"/>
+		<Constant name="ModuleZ" value="([tecmodpar:ModuleThickSS]+                                          [ModuleGap])/2-[tecmodpar:SideFrameThick]"/>
+		<Constant name="RingZ" value="12.431*mm"/>
+		<Constant name="BridgeR" value="824.6*mm"/>
+		<Constant name="BridgeZ" value="-0.5*[tecmodpar:SideFrameThick]"/>
+		<Constant name="BridgeFrameZ" value="[RingZ]+([tecpetpar:BridgeThick]+            [RingThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecring5.xml">
+		<Tubs name="TECRing5" rMin="[Rin]" rMax="[Rout]" dz="[RingThick]/2" startPhi="-[tecpetpar:PetalContWidth]/2" deltaPhi="[tecpetpar:PetalContWidth]"/>
+	</SolidSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring5b.xml
+++ b/DetectorDescription/DDCMS/data/tecring5b.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring5b.xml" eval="true">
+		<Constant name="Modules" value="3"/>
+		<Constant name="DPhi" value="360*deg/[tecring5:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="AngleHyb0" value="-11.00*deg"/>
+		<Constant name="AngleHyb1" value="-8.80*deg"/>
+		<Constant name="AngleHyb2" value="-6.60*deg"/>
+		<Constant name="AngleHyb3" value="-4.40*deg"/>
+		<Constant name="AngleHyb4" value="-2.20*deg"/>
+		<Constant name="AngleHyb5" value="0.00*deg"/>
+		<Constant name="AngleHyb6" value="2.20*deg"/>
+		<Constant name="AngleHyb7" value="4.40*deg"/>
+		<Constant name="AngleHyb8" value="6.60*deg"/>
+		<Constant name="AngleHyb9" value="8.80*deg"/>
+		<Constant name="AngleHybA" value="11.00*deg"/>
+		<Constant name="Bridges" value="1"/>
+		<Constant name="PhiBridge" value="[Phi0]+[DPhi]"/>
+		<Constant name="CoolIns0" value="2202"/>
+		<Constant name="CoolIns1" value="1111"/>
+		<Constant name="CoolIns2" value="2220"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring5b.xml">
+		<LogicalPart name="TECRing5B" category="unspecified">
+			<rSolid name="tecring5:TECRing5"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring5b:TECRing5B"/>
+		<String name="ChildName" value="tecmodule5:TECModule5"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring5:RPos]"/>
+		<Numeric name="ZIn" value="[tecring5:ModuleZ]"/>
+		<Numeric name="ZOut" value="-[tecring5:ModuleZ]-[tecmodpar:SideFrameThick]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="5"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTECPhiAltAlgo">
+		<rParent name="tecring5b:TECRing5B"/>
+		<String name="ChildName" value="tecmodule5:TECModule5Bridge"/>
+		<Numeric name="StartAngle" value="[PhiBridge]"/>
+		<Numeric name="IncrAngle" value="2*[DPhi]"/>
+		<Numeric name="Radius" value="[tecring5:BridgeR]"/>
+		<Numeric name="ZIn" value="[tecring5:BridgeZ]"/>
+		<Numeric name="ZOut" value="[tecring5:BridgeZ]"/>
+		<Numeric name="Number" value="[Bridges]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring5f.xml
+++ b/DetectorDescription/DDCMS/data/tecring5f.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring5f.xml" eval="true">
+		<Constant name="Modules" value="4"/>
+		<Constant name="DPhi" value="360*deg/[tecring5:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="AngleHyb0" value="-11.00*deg"/>
+		<Constant name="AngleHyb1" value="-8.25*deg"/>
+		<Constant name="AngleHyb2" value="-5.50*deg"/>
+		<Constant name="AngleHyb3" value="-2.75*deg"/>
+		<Constant name="AngleHyb4" value="0.00*deg"/>
+		<Constant name="AngleHyb5" value="2.75*deg"/>
+		<Constant name="AngleHyb6" value="5.50*deg"/>
+		<Constant name="AngleHyb7" value="8.25*deg"/>
+		<Constant name="AngleHyb8" value="11.00*deg"/>
+		<Constant name="Bridges" value="2"/>
+		<Constant name="PhiBridge" value="[Phi0]"/>
+		<Constant name="CoolIns0" value="2202"/>
+		<Constant name="CoolIns1" value="1111"/>
+		<Constant name="CoolIns2" value="2200"/>
+		<Constant name="CoolIns3" value="1111"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring5f.xml">
+		<LogicalPart name="TECRing5F" category="unspecified">
+			<rSolid name="tecring5:TECRing5"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring5f:TECRing5F"/>
+		<String name="ChildName" value="tecmodule5:TECModule5"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring5:RPos]"/>
+		<Numeric name="ZIn" value="-[tecring5:ModuleZ]-[tecmodpar:SideFrameThick]"/>
+		<Numeric name="ZOut" value="[tecring5:ModuleZ]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTECPhiAltAlgo">
+		<rParent name="tecring5f:TECRing5F"/>
+		<String name="ChildName" value="tecmodule5:TECModule5Bridge"/>
+		<Numeric name="StartAngle" value="[PhiBridge]"/>
+		<Numeric name="IncrAngle" value="2*[DPhi]"/>
+		<Numeric name="Radius" value="[tecring5:BridgeR]"/>
+		<Numeric name="ZIn" value="[tecring5:BridgeZ]"/>
+		<Numeric name="ZOut" value="[tecring5:BridgeZ]"/>
+		<Numeric name="Number" value="[Bridges]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring6.xml
+++ b/DetectorDescription/DDCMS/data/tecring6.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring6.xml" eval="true">
+		<Constant name="Rin" value="[tecmodule6:Rin]"/>
+		<Constant name="Rout" value="[tecmodule6:Rout]"/>
+		<Constant name="Rmin" value="850.967*mm"/>
+		<Constant name="NPhi" value="80"/>
+		<Constant name="RPos" value="[Rmin]+([tecmodule6:FullHeight]+[tecmodpar:TopFrameHeight])/2"/>
+		<Constant name="ModuleGap" value="3.43*mm"/>
+		<Constant name="RingThick" value="(2*[tecmodpar:ModuleThickSS]+                                            [ModuleGap])"/>
+		<Constant name="ModuleZ" value="([tecmodpar:ModuleThickSS]+                                          [ModuleGap])/2-[tecmodpar:SideFrameThick]"/>
+		<Constant name="RingZ" value="-12.421*mm"/>
+		<Constant name="BridgeR" value="997.4*mm"/>
+		<Constant name="BridgeZ" value="-0.5*[tecmodpar:SideFrameThick]"/>
+		<Constant name="BridgeFrameZ" value="[RingZ]-([tecpetpar:BridgeThick]+            [RingThick])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecring6.xml">
+		<Tubs name="TECRing6" rMin="[Rin]" rMax="[Rout]" dz="[RingThick]/2" startPhi="-[tecpetpar:PetalContWidth]/2" deltaPhi="[tecpetpar:PetalContWidth]"/>
+	</SolidSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring6b.xml
+++ b/DetectorDescription/DDCMS/data/tecring6b.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring6b.xml" eval="true">
+		<Constant name="Modules" value="5"/>
+		<Constant name="DPhi" value="360*deg/[tecring6:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="AngleHyb0" value="-10.00*deg"/>
+		<Constant name="AngleHyb1" value="0.000*deg"/>
+		<Constant name="AngleHyb2" value="10.00*deg"/>
+		<Constant name="Bridges" value="3"/>
+		<Constant name="PhiBridge" value="[Phi0]"/>
+		<Constant name="CoolIns0" value="1111"/>
+		<Constant name="CoolIns1" value="0000"/>
+		<Constant name="CoolIns2" value="1111"/>
+		<Constant name="CoolIns3" value="0000"/>
+		<Constant name="CoolIns4" value="1111"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring6b.xml">
+		<LogicalPart name="TECRing6B" category="unspecified">
+			<rSolid name="tecring6:TECRing6"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring6b:TECRing6B"/>
+		<String name="ParentName" value="tecring6b:TECRing6B"/>
+		<String name="ChildName" value="tecmodule6:TECModule6"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring6:RPos]"/>
+		<Numeric name="ZIn" value="-[tecring6:ModuleZ]-[tecmodpar:SideFrameThick]"/>
+		<Numeric name="ZOut" value="[tecring6:ModuleZ]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="6"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTECPhiAltAlgo">
+		<rParent name="tecring6b:TECRing6B"/>
+		<String name="ChildName" value="tecmodule6:TECModule6Bridge"/>
+		<Numeric name="StartAngle" value="[PhiBridge]"/>
+		<Numeric name="IncrAngle" value="2*[DPhi]"/>
+		<Numeric name="Radius" value="[tecring6:BridgeR]"/>
+		<Numeric name="ZIn" value="[tecring6:BridgeZ]"/>
+		<Numeric name="ZOut" value="[tecring6:BridgeZ]"/>
+		<Numeric name="Number" value="[Bridges]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecring6f.xml
+++ b/DetectorDescription/DDCMS/data/tecring6f.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecring6f.xml" eval="true">
+		<Constant name="Modules" value="5"/>
+		<Constant name="DPhi" value="360*deg/[tecring6:NPhi]"/>
+		<Constant name="Phi" value="([Modules]-1)*[DPhi]"/>
+		<Constant name="Phi0" value="-[Phi]/2"/>
+		<Constant name="AngleHyb0" value="-9.375*deg"/>
+		<Constant name="AngleHyb1" value="-3.125*deg"/>
+		<Constant name="AngleHyb2" value="3.125*deg"/>
+		<Constant name="AngleHyb3" value="9.375*deg"/>
+		<Constant name="Bridges" value="3"/>
+		<Constant name="PhiBridge" value="[Phi0]"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tecring6f.xml">
+		<LogicalPart name="TECRing6F" category="unspecified">
+			<rSolid name="tecring6:TECRing6"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTECPhiAlgo">
+		<rParent name="tecring6f:TECRing6F"/>
+		<String name="ParentName" value="tecring6f:TECRing6F"/>
+		<String name="ChildName" value="tecmodule6:TECModule6"/>
+		<Numeric name="StartAngle" value="[Phi0]"/>
+		<Numeric name="IncrAngle" value="[DPhi]"/>
+		<Numeric name="Radius" value="[tecring6:RPos]"/>
+		<Numeric name="ZIn" value="-[tecring6:ModuleZ]-[tecmodpar:SideFrameThick]"/>
+		<Numeric name="ZOut" value="[tecring6:ModuleZ]"/>
+		<Numeric name="Number" value="[Modules]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTECPhiAltAlgo">
+		<rParent name="tecring6f:TECRing6F"/>
+		<String name="ChildName" value="tecmodule6:TECModule6Bridge"/>
+		<Numeric name="StartAngle" value="[PhiBridge]"/>
+		<Numeric name="IncrAngle" value="2*[DPhi]"/>
+		<Numeric name="Radius" value="[tecring6:BridgeR]"/>
+		<Numeric name="ZIn" value="[tecring6:BridgeZ]"/>
+		<Numeric name="ZOut" value="[tecring6:BridgeZ]"/>
+		<Numeric name="Number" value="[Bridges]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecservices.xml
+++ b/DetectorDescription/DDCMS/data/tecservices.xml
@@ -1,0 +1,924 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <ConstantsSection label="tecservices.xml" eval="true">
+    <Constant name="zero" value="0.0*fm"/>
+    <Constant name="Rin" value="[tec:WheelR]"/>
+    <Constant name="Rout" value="[tec:OuterSkinRin]"/>
+    <Constant name="Dz" value="[tec:TECDz]"/>
+    <Constant name="ChannelWidth" value="50*mm/([Rin]+0.5*30*mm)"/>
+    <Constant name="ChannelRin" value="[Rin]"/>
+    <Constant name="ChannelRout" value="[Rin]+30*mm"/>
+    <Constant name="ChannelHeight" value="1538*mm"/>
+    <Constant name="ChannelZ" value="0.5*[ChannelHeight]-[Dz]"/>
+    <!--[tec:Wheel0Z]-[tec:ZPos]-0.5*[tecwheel:DiskT]+0.5*[ChannelHeight]-77.5*mm"/-->
+    <Constant name="ChannelN" value="[tecwheel:FixServN]"/>
+    <Constant name="ChannelFi" value="[tecwheel:FixServFi]"/>
+    <Constant name="ChannelEndInsertWidth" value="[ChannelWidth]"/>
+    <Constant name="ChannelEndInsertRin" value="[ChannelRin]"/>
+    <Constant name="ChannelEndInsertRout" value="[ChannelRout]"/>
+    <Constant name="ChannelEndInsertHeight" value="21*mm"/>
+    <Constant name="ChannelEndInsertZ" value="0.5*[ChannelEndInsertHeight]-0.5*[ChannelHeight]"/>
+    <!--[tec:Wheel0Z]-[tec:ZPos]-0.5*[tecwheel:DiskT]+0.5*[ChannelHeight]-77.5*mm"/-->
+    <Constant name="AxialGroundingWidth" value="20*mm/([Rin]+0.5*2.5*mm)"/>
+    <Constant name="AxialGroundingRin" value="[Rin]"/>
+    <Constant name="AxialGroundingRout" value="[Rin]+2.5*mm"/>
+    <Constant name="AxialGroundingHeight" value="1538*mm"/>
+    <Constant name="AxialGroundingFi" value="0.5*[ChannelWidth]+0.5*[AxialGroundingWidth]"/>
+    <Constant name="GasPipeRin" value="0.5*10*mm"/>
+    <Constant name="GasPipeRout" value="0.5*12*mm"/>
+    <Constant name="GasPipeRpos" value="1119*mm"/>
+    <Constant name="GasPipeZ" value="[ChannelZ]+0.5*[ChannelHeight]"/>
+    <Constant name="GasPipeHeight" value="1460*mm"/>
+    <Constant name="GasPipePhi1" value="21.8*deg"/>
+    <Constant name="GasPipePhi2" value="66.8*deg"/>
+    <Constant name="GasPipePhi3" value="156.8*deg"/>
+    <Constant name="CoolPipeRin" value="0.5*11*mm"/>
+    <Constant name="CoolPipeRout" value="0.5*12*mm"/>
+    <Constant name="CoolPipeHeightS" value="1347*mm"/>
+    <Constant name="CoolPipeHeightL" value="1487*mm"/>
+    <Constant name="CoolPipeRpos" value="[Rin]+16.5*mm"/>
+    <Constant name="CoolPipeZ" value="[ChannelZ]+0.5*[ChannelHeight]"/>
+    <Constant name="CoolPipePhi1" value="-8.0*deg"/>
+    <!--relative to Service Channel -->
+    <Constant name="CoolPipePhi2" value="-6.33*deg"/>
+    <Constant name="CoolPipePhi3" value="-4.66*deg"/>
+    <Constant name="CoolPipePhi4" value="-3.0*deg"/>
+    <Constant name="CoolPipePhi5" value="3*deg"/>
+    <Constant name="CoolPipePhi6" value="4.66*deg"/>
+    <Constant name="CoolPipePhi7" value="6.33*deg"/>
+    <Constant name="CoolPipePhi8" value="8.0*deg"/>
+    <Constant name="CableRout" value="[Rout]-[CoolPipeRpos]"/>
+    <Constant name="CableBulkTo8" value="[Dz]-([tec:Wheel8Z]-[tec:ZPos]) - (2*[Dz]-[ChannelHeight])"/>
+    <Constant name="CableHeight86B" value="0.5*([tec:Wheel8Z]-[tec:Wheel6Z])+[CableBulkTo8]-0.5*[tecpetpar:PetalContThick]"/>
+    <Constant name="CableHeight86F" value="0.5*([tec:Wheel8Z]-[tec:Wheel6Z])+[CableBulkTo8]+0.5*[tecpetpar:PetalContThick]"/>
+    <Constant name="CableHeight54B" value="([tec:Wheel8Z]-[tec:Wheel5Z]) + 0.5*([tec:Wheel5Z]-[tec:Wheel4Z])+[CableBulkTo8]-0.5*[tecpetpar:PetalContThick]"/>
+    <Constant name="CableHeight54F" value="([tec:Wheel8Z]-[tec:Wheel5Z]) + 0.5*([tec:Wheel5Z]-[tec:Wheel4Z])+[CableBulkTo8]+0.5*[tecpetpar:PetalContThick]"/>
+    <Constant name="CableHeight32B" value="([tec:Wheel8Z]-[tec:Wheel3Z]) + 0.5*([tec:Wheel3Z]-[tec:Wheel2Z])+[CableBulkTo8]-0.5*[tecpetpar:PetalContThick]"/>
+    <Constant name="CableHeight32F" value="([tec:Wheel8Z]-[tec:Wheel3Z]) + 0.5*([tec:Wheel3Z]-[tec:Wheel2Z])+[CableBulkTo8]+0.5*[tecpetpar:PetalContThick]"/>
+    <Constant name="CableHeight10B" value="([tec:Wheel8Z]-[tec:Wheel1Z]) + 0.5*([tec:Wheel1Z]-[tec:Wheel0Z])+[CableBulkTo8]-0.5*[tecpetpar:PetalContThick]"/>
+    <Constant name="CableHeight10F" value="([tec:Wheel8Z]-[tec:Wheel1Z]) + 0.5*([tec:Wheel1Z]-[tec:Wheel0Z])+[CableBulkTo8]+0.5*[tecpetpar:PetalContThick]"/>
+    <Constant name="PhiCableRout" value="[Rout]"/>
+    <Constant name="PhiCableRin" value="[GasPipeRpos]+[GasPipeRout]"/>
+    <Constant name="PhiCableWidth" value="8*deg"/>
+    <Constant name="PhiCablePhiF" value="[ChannelFi]+[CoolPipePhi8]+asin([CableRout]/[CoolPipeRpos])"/>
+    <Constant name="PhiCablePhiB" value="[ChannelFi]+[CoolPipePhi1]-asin([CableRout]/[CoolPipeRpos])"/>
+    <Constant name="PhiCableZLF" value="[CoolPipeZ]-[CableHeight54F]-0.5*[PhiCableHeightLF]"/>
+    <!-- the Lower part for frontpetal-->
+    <Constant name="PhiCableHeightLF" value="[ChannelHeight]-[CableHeight54F]"/>
+    <Constant name="PhiCableZUF" value="[CoolPipeZ]-[CableHeight54F]+0.5*[PhiCableHeightUF]"/>
+    <!-- the Upper part for frontpetal-->
+    <Constant name="PhiCableHeightUF" value="[CableHeight54F]"/>
+    <Constant name="PhiCableZLB" value="[CoolPipeZ]-[CableHeight54B]-0.5*[PhiCableHeightLB]"/>
+    <!-- the Lower part for backpetal-->
+    <Constant name="PhiCableHeightLB" value="[ChannelHeight]-[CableHeight54B]"/>
+    <Constant name="PhiCableZUB" value="[CoolPipeZ]-[CableHeight54B]+0.5*[PhiCableHeightUB]"/>
+    <!-- the Upper part for backpetal-->
+    <Constant name="PhiCableHeightUB" value="[CableHeight54B]"/>
+    <Constant name="CraneBracketRin" value="[Rin]"/>
+    <Constant name="CraneBracketRout" value="[GasPipeRpos]-[GasPipeRout]"/>
+    <Constant name="CraneBracketHeight" value="[tecwheel:DiskT]"/>
+    <Constant name="CraneBracketWidth" value="2*atan(49.5*mm/[CraneBracketRout])*rad"/>
+    <Constant name="CraneBracketPhi1" value="90*deg"/>
+    <Constant name="CraneBracketPhi2" value="315*deg"/>
+    <Constant name="CraneBracketPhi3" value="225*deg"/>
+  </ConstantsSection>
+  <SolidSection label="tecservices.xml">
+    <Tubs name="TECServices" rMin="[Rin]" rMax="[Rout]" dz="[Dz]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECServChannel" rMin="[ChannelRin]" rMax="[ChannelRout]" dz="0.5*[ChannelHeight]" startPhi="-0.5*[ChannelWidth]" deltaPhi="[ChannelWidth]"/>
+    <Tubs name="TECAxGrounding" rMin="[AxialGroundingRin]" rMax="[AxialGroundingRout]" dz="0.5*[ChannelHeight]" startPhi="-0.5*[AxialGroundingWidth]" deltaPhi="[AxialGroundingWidth]"/>
+    <Tubs name="TECChannelEndInsert" rMin="[ChannelEndInsertRin]" rMax="[ChannelEndInsertRout]" dz="0.5*[ChannelEndInsertHeight]" startPhi="-0.5*[ChannelEndInsertWidth]" deltaPhi="[ChannelEndInsertWidth]"/>
+    <Tubs name="TECGasPipe" rMin="[GasPipeRin]" rMax="[GasPipeRout]" dz="0.5*[GasPipeHeight]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECCoolPipeS" rMin="[CoolPipeRin]" rMax="[CoolPipeRout]" dz="0.5*[CoolPipeHeightS]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECCoolPipeL" rMin="[CoolPipeRin]" rMax="[CoolPipeRout]" dz="0.5*[CoolPipeHeightL]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECCoolantS" rMin="[zero]" rMax="[CoolPipeRin]" dz="0.5*[CoolPipeHeightS]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECCoolantL" rMin="[zero]" rMax="[CoolPipeRin]" dz="0.5*[CoolPipeHeightL]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECCable86B" rMin="[CoolPipeRout]" rMax="[CableRout]" dz="0.5*[CableHeight86B]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECCable86F" rMin="[CoolPipeRout]" rMax="[CableRout]" dz="0.5*[CableHeight86F]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECCable54B" rMin="[CoolPipeRout]" rMax="[CableRout]" dz="0.5*[CableHeight54B]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECCable54F" rMin="[CoolPipeRout]" rMax="[CableRout]" dz="0.5*[CableHeight54F]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECCable32B" rMin="[CoolPipeRout]" rMax="[CableRout]" dz="0.5*[CableHeight32B]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECCable32F" rMin="[CoolPipeRout]" rMax="[CableRout]" dz="0.5*[CableHeight32F]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECCable10B" rMin="[CoolPipeRout]" rMax="[CableRout]" dz="0.5*[CableHeight10B]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECCable10F" rMin="[CoolPipeRout]" rMax="[CableRout]" dz="0.5*[CableHeight10F]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="TECPhiCableLF" rMin="[PhiCableRin]" rMax="[PhiCableRout]" dz="0.5*[PhiCableHeightLF]" startPhi="0*deg" deltaPhi="[PhiCableWidth]"/>
+    <Tubs name="TECPhiCableUF" rMin="[PhiCableRin]" rMax="[PhiCableRout]" dz="0.5*[PhiCableHeightUF]" startPhi="0*deg" deltaPhi="[PhiCableWidth]"/>
+    <Tubs name="TECPhiCableLB" rMin="[PhiCableRin]" rMax="[PhiCableRout]" dz="0.5*[PhiCableHeightLB]" startPhi="-[PhiCableWidth]" deltaPhi="[PhiCableWidth]"/>
+    <Tubs name="TECPhiCableUB" rMin="[PhiCableRin]" rMax="[PhiCableRout]" dz="0.5*[PhiCableHeightUB]" startPhi="-[PhiCableWidth]" deltaPhi="[PhiCableWidth]"/>
+    <Tubs name="TECCCraneBracket" rMin="[CraneBracketRin]" rMax="[CraneBracketRout]" dz="0.5*[CraneBracketHeight]" startPhi="-0.5*[CraneBracketWidth]" deltaPhi="[CraneBracketWidth]"/>
+  </SolidSection>
+  <LogicalPartSection label="tecservices.xml">
+    <!-- Service Channel -->
+    <LogicalPart name="TECServices" category="unspecified">
+      <rSolid name="tecservices:TECServices"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="TECServChannel" category="unspecified">
+      <rSolid name="tecservices:TECServChannel"/>
+      <rMaterial name="tecmaterial:TEC_ServChan"/>
+    </LogicalPart>
+    <LogicalPart name="TECAxGrounding" category="unspecified">
+      <rSolid name="tecservices:TECAxGrounding"/>
+      <rMaterial name="tecmaterial:TEC_AxGrounding"/>
+    </LogicalPart>
+    <LogicalPart name="TECChannelEndInsert" category="unspecified">
+      <rSolid name="tecservices:TECChannelEndInsert"/>
+      <rMaterial name="tecmaterial:TEC_ServChanIns"/>
+    </LogicalPart>
+    <!-- Gas Pipes -->
+    <LogicalPart name="TECGasPipe" category="unspecified">
+      <rSolid name="tecservices:TECGasPipe"/>
+      <rMaterial name="tecmaterial:TEC_GasPipe"/>
+    </LogicalPart>
+    <!-- Cooling Pipes -->
+    <LogicalPart name="TECCoolPipeS" category="unspecified">
+      <rSolid name="tecservices:TECCoolPipeS"/>
+      <rMaterial name="tecmaterial:TEC_CoolPipe"/>
+    </LogicalPart>
+    <LogicalPart name="TECCoolPipeL" category="unspecified">
+      <rSolid name="tecservices:TECCoolPipeL"/>
+      <rMaterial name="tecmaterial:TEC_CoolPipe"/>
+    </LogicalPart>
+    <LogicalPart name="TECCoolantS" category="unspecified">
+      <rSolid name="tecservices:TECCoolantS"/>
+      <rMaterial name="trackermaterial:T_C6F14_F2_-30C"/>
+    </LogicalPart>
+    <LogicalPart name="TECCoolantL" category="unspecified">
+      <rSolid name="tecservices:TECCoolantL"/>
+      <rMaterial name="trackermaterial:T_C6F14_F2_-30C"/>
+    </LogicalPart>
+    <LogicalPart name="TECCable86B" category="unspecified">
+      <rSolid name="tecservices:TECCable86B"/>
+      <rMaterial name="tecmaterial:TEC_AxCable"/>
+    </LogicalPart>
+    <LogicalPart name="TECCable86F" category="unspecified">
+      <rSolid name="tecservices:TECCable86F"/>
+      <rMaterial name="tecmaterial:TEC_AxCable"/>
+    </LogicalPart>
+    <LogicalPart name="TECCable54B" category="unspecified">
+      <rSolid name="tecservices:TECCable54B"/>
+      <rMaterial name="tecmaterial:TEC_AxCable"/>
+    </LogicalPart>
+    <LogicalPart name="TECCable54F" category="unspecified">
+      <rSolid name="tecservices:TECCable54F"/>
+      <rMaterial name="tecmaterial:TEC_AxCable"/>
+    </LogicalPart>
+    <LogicalPart name="TECCable32B" category="unspecified">
+      <rSolid name="tecservices:TECCable32B"/>
+      <rMaterial name="tecmaterial:TEC_AxCable"/>
+    </LogicalPart>
+    <LogicalPart name="TECCable32F" category="unspecified">
+      <rSolid name="tecservices:TECCable32F"/>
+      <rMaterial name="tecmaterial:TEC_AxCable"/>
+    </LogicalPart>
+    <LogicalPart name="TECCable10B" category="unspecified">
+      <rSolid name="tecservices:TECCable10B"/>
+      <rMaterial name="tecmaterial:TEC_AxCable"/>
+    </LogicalPart>
+    <LogicalPart name="TECCable10F" category="unspecified">
+      <rSolid name="tecservices:TECCable10F"/>
+      <rMaterial name="tecmaterial:TEC_AxCable"/>
+    </LogicalPart>
+    <!-- Phi Cables -->
+    <LogicalPart name="TECPhiCableLF" category="unspecified">
+      <rSolid name="tecservices:TECPhiCableLF"/>
+      <rMaterial name="tecmaterial:TEC_PhiCableL"/>
+    </LogicalPart>
+    <LogicalPart name="TECPhiCableUF" category="unspecified">
+      <rSolid name="tecservices:TECPhiCableUF"/>
+      <rMaterial name="tecmaterial:TEC_PhiCableU"/>
+    </LogicalPart>
+    <LogicalPart name="TECPhiCableLB" category="unspecified">
+      <rSolid name="tecservices:TECPhiCableLB"/>
+      <rMaterial name="tecmaterial:TEC_PhiCableL"/>
+    </LogicalPart>
+    <LogicalPart name="TECPhiCableUB" category="unspecified">
+      <rSolid name="tecservices:TECPhiCableUB"/>
+      <rMaterial name="tecmaterial:TEC_PhiCableU"/>
+    </LogicalPart>
+    <!-- Brackets-->
+    <LogicalPart name="TECCCraneBracket" category="unspecified">
+      <rSolid name="tecservices:TECCCraneBracket"/>
+      <rMaterial name="tecmaterial:TEC_CraneBracket"/>
+    </LogicalPart>
+  </LogicalPartSection>
+  <!-- Service Channel -->
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECServChannel"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [ChannelZ]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServChannel"/>
+    <String name="ChildName" value="tecservices:TECChannelEndInsert"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="0"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [ChannelEndInsertZ]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECAxGrounding"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[AxialGroundingFi]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [ChannelZ]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECAxGrounding"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1*[ChannelN]+1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]-[AxialGroundingFi]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [ChannelZ]  </Vector>
+  </Algorithm>
+  <!--Gas Pipes-->
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECGasPipe"/>
+    <Numeric name="N" value="2"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[GasPipePhi1]"/>
+    <Numeric name="Radius" value="[GasPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[GasPipeHeight]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECGasPipe"/>
+    <Numeric name="N" value="2"/>
+    <Numeric name="StartCopyNo" value="3"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[GasPipePhi2]"/>
+    <Numeric name="Radius" value="[GasPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[GasPipeHeight]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECGasPipe"/>
+    <Numeric name="N" value="2"/>
+    <Numeric name="StartCopyNo" value="5"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[GasPipePhi3]"/>
+    <Numeric name="Radius" value="[GasPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[GasPipeHeight]  </Vector>
+  </Algorithm>
+  <!-- Axial CoolingPipes and cables -->
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolPipeS"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi1]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightS]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolantS"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi1]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightS]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCable86B"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi1]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CableHeight86B]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolPipeS"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1*[ChannelN]+1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi2]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightS]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolantS"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1*[ChannelN]+1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi2]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightS]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCable54B"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi2]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CableHeight54B]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolPipeL"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi3]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightL]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolantL"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi3]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightL]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCable32B"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi3]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CableHeight32B]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolPipeL"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1*[ChannelN]+1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi4]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightL]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolantL"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1*[ChannelN]+1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi4]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightL]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCable10B"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi4]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CableHeight10B]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolPipeL"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="2*[ChannelN]+1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi5]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightL]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolantL"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="2*[ChannelN]+1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi5]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightL]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCable10F"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi5]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CableHeight10F]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolPipeL"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="3*[ChannelN]+1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi6]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightL]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolantL"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="3*[ChannelN]+1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi6]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightL]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCable32F"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi6]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CableHeight32F]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolPipeS"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="3*[ChannelN]+1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi7]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightS]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolantS"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="3*[ChannelN]+1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi7]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightS]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCable54F"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi7]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CableHeight54F]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolPipeS"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="4*[ChannelN]+1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi8]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightS]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCoolantS"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="4*[ChannelN]+1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi8]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CoolPipeHeightS]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCable86F"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[ChannelFi]+[CoolPipePhi8]"/>
+    <Numeric name="Radius" value="[CoolPipeRpos]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [CoolPipeZ]-0.5*[CableHeight86F]  </Vector>
+  </Algorithm>
+  <!-- Phi Cable -->
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECPhiCableLF"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[PhiCablePhiF]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [PhiCableZLF]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECPhiCableUF"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[PhiCablePhiF]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [PhiCableZUF]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECPhiCableLB"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[PhiCablePhiB]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [PhiCableZLB]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECPhiCableUB"/>
+    <Numeric name="N" value="[ChannelN]"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[PhiCablePhiB]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [PhiCableZUB]  </Vector>
+  </Algorithm>
+  <!-- Brackets -->
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="1"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi1]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel0Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="2"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi2]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel0Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="3"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi3]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel0Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="4"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi1]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel1Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="5"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi2]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel1Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="6"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi3]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel1Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="7"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi1]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel2Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="8"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi2]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel2Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="9"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi3]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel2Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="10"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi1]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel3Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="11"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi2]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel3Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="12"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi3]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel3Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="13"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi1]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel4Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="14"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi2]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel4Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="15"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi3]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel4Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="16"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi1]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel5Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="17"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi2]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel5Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="18"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi3]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel5Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="19"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi1]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel6Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="20"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi2]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel6Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="21"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi3]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel6Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="22"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi1]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel7Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="23"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi2]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel7Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="24"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi3]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel7Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="25"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi1]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel8Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="26"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi2]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel8Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="27"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi3]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:Wheel8Z]-[tec:ZPos]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="28"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi1]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:TECDz]-[tecbackplate:Thick]+0.5*[tecwheel:DiskT]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="29"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi2]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:TECDz]-[tecbackplate:Thick]+0.5*[tecwheel:DiskT]  </Vector>
+  </Algorithm>
+  <Algorithm name="track:DDTrackerAngular">
+    <rParent name="tecservices:TECServices"/>
+    <String name="ChildName" value="tecservices:TECCCraneBracket"/>
+    <Numeric name="N" value="1"/>
+    <Numeric name="StartCopyNo" value="30"/>
+    <Numeric name="IncrCopyNo" value="1"/>
+    <Numeric name="RangeAngle" value="360*deg"/>
+    <Numeric name="StartAngle" value="[CraneBracketPhi3]"/>
+    <Numeric name="Radius" value="[zero]"/>
+    <Vector name="Center" type="numeric" nEntries="3"> 0, 0, [tec:TECDz]-[tecbackplate:Thick]+0.5*[tecwheel:DiskT]  </Vector>
+  </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecwheel.xml
+++ b/DetectorDescription/DDCMS/data/tecwheel.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecwheel.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="WheelRmax" value="110.30*cm"/>
+		<Constant name="WheelT" value="12.22*cm"/>
+		<Constant name="DiskT" value="1.680*cm"/>
+		<Constant name="NomexT" value="1.600*cm"/>
+		<Constant name="NomexRmax" value="[WheelRmax] - [GroundingRingThick] "/>
+		<Constant name="PetalContN" value="8"/>
+		<Constant name="PetalContZ" value="3.583*cm"/>
+		<Constant name="PetalContFiF" value="0.00*deg"/>
+		<Constant name="PetalContFiB" value="22.5*deg"/>
+		<Constant name="InsertR" value="13.7514*mm"/>
+		<Constant name="InsertL" value="16.0*mm"/>
+		<Constant name="InsertN" value="8"/>
+		<Constant name="InsertR1" value="38.00*cm"/>
+		<Constant name="InsertR2" value="468.5451*mm"/>
+		<Constant name="InsertR3" value="84.00*cm"/>
+		<Constant name="InsertR4" value="84.00*cm"/>
+		<Constant name="InsertR5" value="983.5215*mm"/>
+		<Constant name="InsertR6" value="983.5215*mm"/>
+		<Constant name="InsertFi1" value="22.50*deg"/>
+		<Constant name="InsertFi2" value="44.2051*deg"/>
+		<Constant name="InsertFi3" value="13.50*deg"/>
+		<Constant name="InsertFi4" value="31.50*deg"/>
+		<Constant name="InsertFi5" value="8.6213*deg"/>
+		<Constant name="InsertFi6" value="35.6213*deg"/>
+		<Constant name="FixSuppA" value="1485.33*mm"/>
+		<!--Area to calculate the deltaPhi-->
+		<Constant name="FixSuppR" value="22.4428*mm*mm"/>
+		<Constant name="FixSuppW" value="40.00*mm"/>
+		<!--old-->
+		<Constant name="FixSuppT" value="1.000*cm"/>
+		<Constant name="FixSuppN" value="4"/>
+		<Constant name="FixSuppFi" value="-67.50*deg"/>
+		<Constant name="FixServR" value="22.5*mm"/>
+		<Constant name="FixServW" value="80.0*mm / ([WheelRmax]-0.5*[FixServR])"/>
+		<Constant name="FixServT" value="8.5*mm"/>
+		<Constant name="FixServN" value="8"/>
+		<Constant name="FixServFi" value="-11.25*deg"/>
+		<Constant name="OptConnRmin" value="[WheelRmax] - [OptConnHeight]"/>
+		<!--depreciated-->
+		<Constant name="OptConnRmax" value="[WheelRmax]"/>
+		<!--depreciated-->
+		<Constant name="OptConnHeight" value="171*mm"/>
+		<Constant name="OptConnThick" value="46*mm"/>
+		<Constant name="OptConnW" value="45*deg-[tecpetpar:PetalContWidth]"/>
+		<!--there is not enough room for the real width-->
+		<Constant name="OptConnN" value="8"/>
+		<Constant name="OptConnT1" value="2.475*cm"/>
+		<Constant name="OptConnT2" value="2.25*cm"/>
+		<Constant name="OptConnT3" value="1.80*cm"/>
+		<Constant name="OptConnZ1" value="([DiskT]+[OptConnT1])/2"/>
+		<Constant name="OptConnZ2" value="([DiskT]+[OptConnT2])/2"/>
+		<Constant name="OptConnZ3" value="([DiskT]+[OptConnT3])/2"/>
+		<Constant name="OptConnFI1" value="[PetalContFiF]+[OptConnW]/2+[tecpetpar:PetalContWidth]/2"/>
+		<Constant name="OptConnFI2" value="[PetalContFiB]+[OptConnW]/2+[tecpetpar:PetalContWidth]/2"/>
+		<Constant name="CableW" value="0.500*cm"/>
+		<Constant name="CableT" value="0.210*cm"/>
+		<Constant name="CableTolerR" value="0.350*cm"/>
+		<Constant name="CableZ2" value="([DiskT]+[CableT])/2"/>
+		<Constant name="CableZ1" value="-[CableZ2]"/>
+		<Constant name="CableFi1" value="-11.25*deg"/>
+		<Constant name="CableFi2" value="11.25*deg"/>
+		<Constant name="FixServRmin" value="[WheelRmax]-[FixServR]"/>
+		<Constant name="CableRmax" value="[WheelRmax]-[CableTolerR]"/>
+		<Constant name="PetalConnZ" value="0"/>
+		<Constant name="PetalInManifHeight" value="14.59*mm"/>
+		<Constant name="PetalInManifWidth" value="2*atan(64.5*mm/(2*[tecpetpar:PetalRmax]-[PetalInManifHeight]))*rad"/>
+		<Constant name="PetalOutManifHeight" value="18.04*mm"/>
+		<Constant name="PetalOutManifWidth" value="2*atan(46*mm/(2*[tecpetpar:PetalRmax]+[PetalInManifHeight]))*rad"/>
+		<Constant name="PetalManifThick" value="10*mm"/>
+		<Constant name="GroundingRingThick" value="0.150*mm"/>
+		<!-- this "thick" goes in R direction! -->
+		<Constant name="GroundingRingWidth" value="15*mm"/>
+		<Constant name="AlignHolderRin" value="[NomexRmax]-12.5*mm"/>
+		<Constant name="AlignHolderRout" value="[NomexRmax]"/>
+		<Constant name="AlignHolderWidth" value="2*atan(25.98*mm/[AlignHolderRout])*rad"/>
+		<Constant name="AlignHolderStartPhi" value="-67.5*deg"/>
+	</ConstantsSection>
+	<SolidSection label="tecwheel.xml">
+		<Tubs name="TECWheelInsert" rMin="[zero]" rMax="[InsertR]" dz="[InsertL]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECGroundingRing" rMin="[NomexRmax]" rMax="[WheelRmax]" dz="[GroundingRingWidth]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECFixService" rMin="[FixServRmin]" rMax="[NomexRmax]" dz="[FixServT]/2" startPhi="-[FixServW]/2" deltaPhi="[FixServW]"/>
+		<Tubs name="TECAlignHolder" rMin="[AlignHolderRin]" rMax="[AlignHolderRout]" dz="[NomexT]/2" startPhi="-[AlignHolderWidth]/2" deltaPhi="[AlignHolderWidth]"/>
+		<!-- the same for every petal -->
+		<Tubs name="TECInnerManifold" rMin="[tecpetpar:PetalRmax]-[PetalInManifHeight]" rMax="[tecpetpar:PetalRmax]" dz="[PetalManifThick]/2" startPhi="-[PetalInManifWidth]/2" deltaPhi="[PetalInManifWidth]"/>
+		<Tubs name="TECOuterManifold" rMin="[tecpetpar:PetalRmax]" rMax="[tecpetpar:PetalRmax]+[PetalOutManifHeight]" dz="[PetalManifThick]/2" startPhi="-[PetalOutManifWidth]/2" deltaPhi="[PetalOutManifWidth]"/>
+		<Tubs name="TECOptConnector" rMin="[tecpetpar:PetalRmax]-[OptConnHeight]" rMax="[tecpetpar:PetalRmax]" dz="[OptConnThick]/2" startPhi="-[OptConnW]/2" deltaPhi="[OptConnW]"/>
+		<Box name="TECCCUM" dx="[tecpetpar:CCUMWidth]/2" dy="[tecpetpar:CCUMHeight]/2" dz="[tecpetpar:CCUMThick]/2"/>
+	</SolidSection>
+	<LogicalPartSection label="tecwheel.xml">
+		<LogicalPart name="TECWheelInsert" category="unspecified">
+			<rSolid name="tecwheel:TECWheelInsert"/>
+			<rMaterial name="tecmaterial:TEC_wheelinsert"/>
+		</LogicalPart>
+		<LogicalPart name="TECFixService" category="unspecified">
+			<rSolid name="tecwheel:TECFixService"/>
+			<rMaterial name="tecmaterial:TEC_FixServ"/>
+		</LogicalPart>
+		<LogicalPart name="TECGroundingRing" category="unspecified">
+			<rSolid name="tecwheel:TECGroundingRing"/>
+			<rMaterial name="tecmaterial:TEC_GroundingRing"/>
+		</LogicalPart>
+		<LogicalPart name="TECAlignHolder" category="unspecified">
+			<rSolid name="tecwheel:TECAlignHolder"/>
+			<rMaterial name="tecmaterial:TEC_AlignHolder"/>
+		</LogicalPart>
+		<!-- the same for all petals-->
+		<LogicalPart name="TECInnerManifold" category="unspecified">
+			<rSolid name="tecwheel:TECInnerManifold"/>
+			<rMaterial name="tecmaterial:TEC_InnerManifold"/>
+		</LogicalPart>
+		<LogicalPart name="TECOuterManifold" category="unspecified">
+			<rSolid name="tecwheel:TECOuterManifold"/>
+			<rMaterial name="tecmaterial:TEC_InnerManifold"/>
+		</LogicalPart>
+		<LogicalPart name="TECOptConnector" category="unspecified">
+			<rSolid name="tecwheel:TECOptConnector"/>
+			<rMaterial name="tecmaterial:TEC_OptoCon"/>
+		</LogicalPart>
+		<LogicalPart name="TECCCUM" category="unspecified">
+			<rSolid name="tecwheel:TECCCUM"/>
+			<rMaterial name="tecmaterial:TEC_CCUM"/>
+		</LogicalPart>
+	</LogicalPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecwheel6.xml
+++ b/DetectorDescription/DDCMS/data/tecwheel6.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- This is the special disk which holdes the beam splitter! -->
+    <ConstantsSection label="tecwheel6.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FixSuppRmax" value="[tecpetal3:PetalContRmin]+            [tecwheel:FixSuppR]"/>
+        <Constant name="FixSuppW" value="2*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal3:PetalContRmin]*[tecpetal3:PetalContRmin])"/>
+        <!-- calculate the width to fit the area at this specific radius! thus the volume will be constant!-->
+        <Constant name="CableL" value="([tecwheel:CableRmax]-[tecring1:Rin])"/>
+        <Constant name="CableR" value="([tecwheel:CableRmax]+[tecring1:Rin])/2"/>
+        <Constant name="BeamsplitterHeight" value="68.62*mm"/>
+        <Constant name="BeamsplitterWidth" value="49.25*mm"/>
+        <Constant name="BeamsplitterThick" value="[tecwheel:NomexT]"/>
+        <Constant name="BeamsplitterRA" value="845.13*mm"/>
+        <Constant name="BeamsplitterRB" value="570.17*mm"/>
+        <Constant name="BeamsplitterStartPhi" value="114*deg"/>
+    </ConstantsSection>
+    <SolidSection label="tecwheel6.xml">
+        <Tubs name="TECWheel6" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:WheelT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+        <Tubs name="TECWheelDisk6" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+        <Tubs name="TECWheelNomex6" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+        <Tubs name="TECFixSupport6" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
+        <Tubs name="TECOptConnector6" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT2]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
+        <Box name="TECBeamsplitter" dx="0.5*[BeamsplitterHeight]" dy="0.5*[BeamsplitterWidth]" dz="0.5*[BeamsplitterThick]"/>
+    </SolidSection>
+    <LogicalPartSection label="tecwheel6.xml">
+        <LogicalPart name="TECWheel6" category="unspecified">
+            <rSolid name="tecwheel6:TECWheel6"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TECWheelDisk6" category="unspecified">
+            <rSolid name="tecwheel6:TECWheelDisk6"/>
+            <rMaterial name="tecmaterial:TEC_wheel6_CF"/>
+        </LogicalPart>
+        <LogicalPart name="TECWheelNomex6" category="unspecified">
+            <rSolid name="tecwheel6:TECWheelNomex6"/>
+            <rMaterial name="tecmaterial:TEC_wheel6_Nomex"/>
+        </LogicalPart>
+        <LogicalPart name="TECFixSupport6" category="unspecified">
+            <rSolid name="tecwheel6:TECFixSupport6"/>
+            <rMaterial name="tecmaterial:TEC_Fixframe"/>
+        </LogicalPart>
+        <LogicalPart name="TECOptConnector6" category="unspecified">
+            <rSolid name="tecwheel6:TECOptConnector6"/>
+            <rMaterial name="tecmaterial:TEC_OptoCon"/>
+        </LogicalPart>
+        <LogicalPart name="TECBeamsplitter" category="unspecified">
+            <rSolid name="tecwheel6:TECBeamsplitter"/>
+            <rMaterial name="tecmaterial:TEC_Beamsplitter"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <PosPartSection label="tecwheel6.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tecwheel6:TECWheel6"/>
+            <rChild name="tecwheel6:TECWheelDisk6"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tecwheel6:TECWheelDisk6"/>
+            <rChild name="tecwheel6:TECWheelNomex6"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tecwheel6:TECWheelDisk6"/>
+            <rChild name="tecwheel:TECGroundingRing"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheel6"/>
+        <String name="ChildName" value="tecpetal3f:TECPetalCont3F"/>
+        <Numeric name="N" value="[tecwheel:PetalContN]"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel:PetalContFiF]"/>
+        <Numeric name="Radius" value="[zero]"/>
+        <Vector name="Center" type="numeric" nEntries="3">
+            0, 0, -[tecwheel:PetalContZ]  </Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheel6"/>
+        <String name="ChildName" value="tecpetal3b:TECPetalCont3B"/>
+        <Numeric name="N" value="[tecwheel:PetalContN]"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel:PetalContFiB]"/>
+        <Numeric name="Radius" value="[zero]"/>
+        <Vector name="Center" type="numeric" nEntries="3">
+            0, 0, [tecwheel:PetalContZ]  </Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheelNomex6"/>
+        <String name="ChildName" value="tecwheel:TECWheelInsert"/>
+        <Numeric name="N" value="[tecwheel:InsertN]"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel:InsertFi1]"/>
+        <Numeric name="Radius" value="[tecwheel:InsertR1]"/>
+        <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheelNomex6"/>
+        <String name="ChildName" value="tecwheel:TECWheelInsert"/>
+        <Numeric name="N" value="[tecwheel:InsertN]"/>
+        <Numeric name="StartCopyNo" value="9"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel:InsertFi2]"/>
+        <Numeric name="Radius" value="[tecwheel:InsertR2]"/>
+        <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheelNomex6"/>
+        <String name="ChildName" value="tecwheel:TECWheelInsert"/>
+        <Numeric name="N" value="[tecwheel:InsertN]"/>
+        <Numeric name="StartCopyNo" value="17"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel:InsertFi3]"/>
+        <Numeric name="Radius" value="[tecwheel:InsertR3]"/>
+        <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheelNomex6"/>
+        <String name="ChildName" value="tecwheel:TECWheelInsert"/>
+        <Numeric name="N" value="[tecwheel:InsertN]"/>
+        <Numeric name="StartCopyNo" value="25"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel:InsertFi4]"/>
+        <Numeric name="Radius" value="[tecwheel:InsertR4]"/>
+        <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheelNomex6"/>
+        <String name="ChildName" value="tecwheel:TECWheelInsert"/>
+        <Numeric name="N" value="[tecwheel:InsertN]"/>
+        <Numeric name="StartCopyNo" value="33"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel:InsertFi5]"/>
+        <Numeric name="Radius" value="[tecwheel:InsertR5]"/>
+        <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheelNomex6"/>
+        <String name="ChildName" value="tecwheel:TECWheelInsert"/>
+        <Numeric name="N" value="[tecwheel:InsertN]"/>
+        <Numeric name="StartCopyNo" value="41"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel:InsertFi6]"/>
+        <Numeric name="Radius" value="[tecwheel:InsertR6]"/>
+        <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheelNomex6"/>
+        <String name="ChildName" value="tecwheel6:TECFixSupport6"/>
+        <Numeric name="N" value="[tecwheel:FixSuppN]"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel:FixSuppFi]"/>
+        <Numeric name="Radius" value="[zero]"/>
+        <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheelNomex6"/>
+        <String name="ChildName" value="tecwheel:TECFixService"/>
+        <Numeric name="N" value="[tecwheel:FixServN]"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel:FixServFi]"/>
+        <Numeric name="Radius" value="[zero]"/>
+        <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheel6"/>
+        <String name="ChildName" value="tecwheel6:TECOptConnector6"/>
+        <Numeric name="N" value="[tecwheel:OptConnN]"/>
+        <Numeric name="StartCopyNo" value="2"/>
+        <Numeric name="IncrCopyNo" value="2"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel:OptConnFI1]"/>
+        <Numeric name="Radius" value="[zero]"/>
+        <Vector name="Center" type="numeric" nEntries="3"> 
+            0, 0, -[tecwheel:OptConnZ2]  </Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheel6"/>
+        <String name="ChildName" value="tecwheel6:TECOptConnector6"/>
+        <Numeric name="N" value="[tecwheel:OptConnN]"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="2"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel:OptConnFI2]"/>
+        <Numeric name="Radius" value="[zero]"/>
+        <Vector name="Center" type="numeric" nEntries="3"> 
+            0, 0, [tecwheel:OptConnZ2]  </Vector>
+    </Algorithm>
+    <!-- Alignment Holder (Sphere holder) -->
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheelNomex6"/>
+        <String name="ChildName" value="tecwheel:TECAlignHolder"/>
+        <Numeric name="N" value="4"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel:AlignHolderStartPhi]"/>
+        <Numeric name="Radius" value="[zero]"/>
+        <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+    </Algorithm>
+    <!-- Beamsplitter -->
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheelNomex6"/>
+        <String name="ChildName" value="tecwheel6:TECBeamsplitter"/>
+        <Numeric name="N" value="8"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel6:BeamsplitterStartPhi]"/>
+        <Numeric name="Radius" value="[tecwheel6:BeamsplitterRA]"/>
+        <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerAngular">
+        <rParent name="tecwheel6:TECWheelNomex6"/>
+        <String name="ChildName" value="tecwheel6:TECBeamsplitter"/>
+        <Numeric name="N" value="8"/>
+        <Numeric name="StartCopyNo" value="9"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Numeric name="RangeAngle" value="360*deg"/>
+        <Numeric name="StartAngle" value="[tecwheel6:BeamsplitterStartPhi]"/>
+        <Numeric name="Radius" value="[tecwheel6:BeamsplitterRB]"/>
+        <Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecwheela.xml
+++ b/DetectorDescription/DDCMS/data/tecwheela.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecwheela.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="FixSuppRmax" value="[tecpetal0:PetalContRmin]+            [tecwheel:FixSuppR]"/>
+		<Constant name="FixSuppW" value="2*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal0:PetalContRmin]*[tecpetal0:PetalContRmin])"/>
+		<!-- calculate the width to fit the area at this specific radius! thus the volume will be constant!-->
+		<Constant name="CableL" value="([tecwheel:CableRmax]-[tecring0:Rin])"/>
+		<Constant name="CableR" value="([tecwheel:CableRmax]+[tecring0:Rin])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecwheela.xml">
+		<Tubs name="TECWheelA" rMin="[tecpetal0:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:WheelT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECWheelDiskA" rMin="[tecpetal0:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECWheelNomexA" rMin="[tecpetal0:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECFixSupportA" rMin="[tecpetal0:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
+		<Tubs name="TECOptConnectorA" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT1]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecwheela.xml">
+		<LogicalPart name="TECWheelA" category="unspecified">
+			<rSolid name="tecwheela:TECWheelA"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECWheelDiskA" category="unspecified">
+			<rSolid name="tecwheela:TECWheelDiskA"/>
+			<rMaterial name="tecmaterial:TEC_wheel_CF"/>
+		</LogicalPart>
+		<LogicalPart name="TECWheelNomexA" category="unspecified">
+			<rSolid name="tecwheela:TECWheelNomexA"/>
+			<rMaterial name="tecmaterial:TEC_wheel_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TECFixSupportA" category="unspecified">
+			<rSolid name="tecwheela:TECFixSupportA"/>
+			<rMaterial name="tecmaterial:TEC_Fixframe"/>
+		</LogicalPart>
+		<LogicalPart name="TECOptConnectorA" category="unspecified">
+			<rSolid name="tecwheela:TECOptConnectorA"/>
+			<rMaterial name="tecmaterial:TEC_OptoCon"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tecwheela.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tecwheela:TECWheelA"/>
+			<rChild name="tecwheela:TECWheelDiskA"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecwheela:TECWheelDiskA"/>
+			<rChild name="tecwheela:TECWheelNomexA"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecwheela:TECWheelDiskA"/>
+			<rChild name="tecwheel:TECGroundingRing"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheela:TECWheelA"/>
+		<String name="ChildName" value="tecpetal0f:TECPetalCont0F"/>
+		<Numeric name="N" value="[tecwheel:PetalContN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:PetalContFiF]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			0, 0, -[tecwheel:PetalContZ]  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheela:TECWheelA"/>
+		<String name="ChildName" value="tecpetal0b:TECPetalCont0B"/>
+		<Numeric name="N" value="[tecwheel:PetalContN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:PetalContFiB]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			0, 0, [tecwheel:PetalContZ]  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheela:TECWheelNomexA"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi1]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR1]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheela:TECWheelNomexA"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="9"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi2]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR2]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheela:TECWheelNomexA"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="17"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi3]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR3]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheela:TECWheelNomexA"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="25"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi4]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR4]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheela:TECWheelNomexA"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="33"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi5]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR5]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheela:TECWheelNomexA"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="41"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi6]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR6]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheela:TECWheelNomexA"/>
+		<String name="ChildName" value="tecwheela:TECFixSupportA"/>
+		<Numeric name="N" value="[tecwheel:FixSuppN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:FixSuppFi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheela:TECWheelNomexA"/>
+		<String name="ChildName" value="tecwheel:TECFixService"/>
+		<Numeric name="N" value="[tecwheel:FixServN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:FixServFi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheela:TECWheelA"/>
+		<String name="ChildName" value="tecwheela:TECOptConnectorA"/>
+		<Numeric name="N" value="[tecwheel:OptConnN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="2"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:OptConnFI2]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			0, 0, [tecwheel:OptConnZ1]  </Vector>
+	</Algorithm>
+	<!-- Alignment Holder (Sphere holder) -->
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheela:TECWheelNomexA"/>
+		<String name="ChildName" value="tecwheel:TECAlignHolder"/>
+		<Numeric name="N" value="4"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:AlignHolderStartPhi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecwheelb.xml
+++ b/DetectorDescription/DDCMS/data/tecwheelb.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecwheelb.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="FixSuppRmax" value="[tecpetal3:PetalContRmin]+            [tecwheel:FixSuppR]"/>
+		<Constant name="FixSuppW" value="2*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal3:PetalContRmin]*[tecpetal3:PetalContRmin])"/>
+		<!-- calculate the width to fit the area at this specific radius! thus the volume will be constant!-->
+		<Constant name="CableL" value="([tecwheel:CableRmax]-[tecring1:Rin])"/>
+		<Constant name="CableR" value="([tecwheel:CableRmax]+[tecring1:Rin])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecwheelb.xml">
+		<Tubs name="TECWheelB" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:WheelT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECWheelDiskB" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECWheelNomexB" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECFixSupportB" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
+		<Tubs name="TECOptConnectorB" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT2]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecwheelb.xml">
+		<LogicalPart name="TECWheelB" category="unspecified">
+			<rSolid name="tecwheelb:TECWheelB"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECWheelDiskB" category="unspecified">
+			<rSolid name="tecwheelb:TECWheelDiskB"/>
+			<rMaterial name="tecmaterial:TEC_wheel_CF"/>
+		</LogicalPart>
+		<LogicalPart name="TECWheelNomexB" category="unspecified">
+			<rSolid name="tecwheelb:TECWheelNomexB"/>
+			<rMaterial name="tecmaterial:TEC_wheel_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TECFixSupportB" category="unspecified">
+			<rSolid name="tecwheelb:TECFixSupportB"/>
+			<rMaterial name="tecmaterial:TEC_Fixframe"/>
+		</LogicalPart>
+		<LogicalPart name="TECOptConnectorB" category="unspecified">
+			<rSolid name="tecwheelb:TECOptConnectorB"/>
+			<rMaterial name="tecmaterial:TEC_OptoCon"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tecwheelb.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tecwheelb:TECWheelB"/>
+			<rChild name="tecwheelb:TECWheelDiskB"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecwheelb:TECWheelDiskB"/>
+			<rChild name="tecwheelb:TECWheelNomexB"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tecwheelb:TECWheelDiskB"/>
+			<rChild name="tecwheel:TECGroundingRing"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelb:TECWheelB"/>
+		<String name="ChildName" value="tecpetal3f:TECPetalCont3F"/>
+		<Numeric name="N" value="[tecwheel:PetalContN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:PetalContFiF]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			0, 0, -[tecwheel:PetalContZ]  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelb:TECWheelB"/>
+		<String name="ChildName" value="tecpetal3b:TECPetalCont3B"/>
+		<Numeric name="N" value="[tecwheel:PetalContN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:PetalContFiB]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			0, 0, [tecwheel:PetalContZ]  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelb:TECWheelNomexB"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi1]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR1]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelb:TECWheelNomexB"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="9"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi2]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR2]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelb:TECWheelNomexB"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="17"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi3]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR3]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelb:TECWheelNomexB"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="25"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi4]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR4]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelb:TECWheelNomexB"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="33"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi5]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR5]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelb:TECWheelNomexB"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="41"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi6]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR6]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelb:TECWheelNomexB"/>
+		<String name="ChildName" value="tecwheelb:TECFixSupportB"/>
+		<Numeric name="N" value="[tecwheel:FixSuppN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:FixSuppFi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelb:TECWheelNomexB"/>
+		<String name="ChildName" value="tecwheel:TECFixService"/>
+		<Numeric name="N" value="[tecwheel:FixServN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:FixServFi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelb:TECWheelB"/>
+		<String name="ChildName" value="tecwheelb:TECOptConnectorB"/>
+		<Numeric name="N" value="[tecwheel:OptConnN]"/>
+		<Numeric name="StartCopyNo" value="2"/>
+		<Numeric name="IncrCopyNo" value="2"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:OptConnFI1]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			0, 0, -[tecwheel:OptConnZ2]  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelb:TECWheelB"/>
+		<String name="ChildName" value="tecwheelb:TECOptConnectorB"/>
+		<Numeric name="N" value="[tecwheel:OptConnN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="2"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:OptConnFI2]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			0, 0, [tecwheel:OptConnZ2]  </Vector>
+	</Algorithm>
+	<!-- Alignment Holder (Sphere holder) -->
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelb:TECWheelNomexB"/>
+		<String name="ChildName" value="tecwheel:TECAlignHolder"/>
+		<Numeric name="N" value="4"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:AlignHolderStartPhi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecwheelc.xml
+++ b/DetectorDescription/DDCMS/data/tecwheelc.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecwheelc.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="FixSuppRmax" value="[tecpetal3:PetalContRmin]+            [tecwheel:FixSuppR]"/>
+		<Constant name="FixSuppW" value="2*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal3:PetalContRmin]*[tecpetal3:PetalContRmin])"/>
+		<!-- calculate the width to fit the area at this specific radius! thus the volume will be constant!-->
+		<Constant name="CableL" value="([tecwheel:CableRmax]-[tecring2:Rin])"/>
+		<Constant name="CableR" value="([tecwheel:CableRmax]+[tecring2:Rin])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecwheelc.xml">
+		<Tubs name="TECWheelC" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:WheelT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECWheelDiskC" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECWheelNomexC" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECFixSupportC" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
+		<Tubs name="TECOptConnectorC" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT3]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecwheelc.xml">
+		<LogicalPart name="TECWheelC" category="unspecified">
+			<rSolid name="tecwheelc:TECWheelC"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECWheelDiskC" category="unspecified">
+			<rSolid name="tecwheelc:TECWheelDiskC"/>
+			<rMaterial name="tecmaterial:TEC_wheel_CF"/>
+		</LogicalPart>
+		<LogicalPart name="TECWheelNomexC" category="unspecified">
+			<rSolid name="tecwheelc:TECWheelNomexC"/>
+			<rMaterial name="tecmaterial:TEC_wheel_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TECFixSupportC" category="unspecified">
+			<rSolid name="tecwheelc:TECFixSupportC"/>
+			<rMaterial name="tecmaterial:TEC_Fixframe"/>
+		</LogicalPart>
+		<LogicalPart name="TECOptConnectorC" category="unspecified">
+			<rSolid name="tecwheelc:TECOptConnectorC"/>
+			<rMaterial name="tecmaterial:TEC_OptoCon"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tecwheelc.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tecwheelc:TECWheelC"/>
+			<rChild name="tecwheelc:TECWheelDiskC"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecwheelc:TECWheelDiskC"/>
+			<rChild name="tecwheelc:TECWheelNomexC"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tecwheelc:TECWheelDiskC"/>
+			<rChild name="tecwheel:TECGroundingRing"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelc:TECWheelC"/>
+		<String name="ChildName" value="tecpetal6f:TECPetalCont6F"/>
+		<Numeric name="N" value="[tecwheel:PetalContN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:PetalContFiF]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			0, 0, -[tecwheel:PetalContZ]  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelc:TECWheelC"/>
+		<String name="ChildName" value="tecpetal6b:TECPetalCont6B"/>
+		<Numeric name="N" value="[tecwheel:PetalContN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:PetalContFiB]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			0, 0, [tecwheel:PetalContZ]  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelc:TECWheelNomexC"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi1]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR1]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelc:TECWheelNomexC"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="9"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi2]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR2]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelc:TECWheelNomexC"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="17"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi3]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR3]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelc:TECWheelNomexC"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="25"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi4]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR4]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelc:TECWheelNomexC"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="33"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi5]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR5]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelc:TECWheelNomexC"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="41"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi6]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR6]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelc:TECWheelNomexC"/>
+		<String name="ChildName" value="tecwheelc:TECFixSupportC"/>
+		<Numeric name="N" value="[tecwheel:FixSuppN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:FixSuppFi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelc:TECWheelNomexC"/>
+		<String name="ChildName" value="tecwheel:TECFixService"/>
+		<Numeric name="N" value="[tecwheel:FixServN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:FixServFi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelc:TECWheelC"/>
+		<String name="ChildName" value="tecwheelc:TECOptConnectorC"/>
+		<Numeric name="N" value="[tecwheel:OptConnN]"/>
+		<Numeric name="StartCopyNo" value="2"/>
+		<Numeric name="IncrCopyNo" value="2"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:OptConnFI1]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			0, 0, -[tecwheel:OptConnZ3]  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelc:TECWheelC"/>
+		<String name="ChildName" value="tecwheelc:TECOptConnectorC"/>
+		<Numeric name="N" value="[tecwheel:OptConnN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="2"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:OptConnFI2]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			0, 0, [tecwheel:OptConnZ3]  </Vector>
+	</Algorithm>
+	<!-- Alignment Holder (Sphere holder) -->
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheelc:TECWheelNomexC"/>
+		<String name="ChildName" value="tecwheel:TECAlignHolder"/>
+		<Numeric name="N" value="4"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:AlignHolderStartPhi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tecwheeld.xml
+++ b/DetectorDescription/DDCMS/data/tecwheeld.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tecwheeld.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="FixSuppRmax" value="[tecpetal3:PetalContRmin]+            [tecwheel:FixSuppR]"/>
+		<Constant name="FixSuppW" value="2*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal3:PetalContRmin]*[tecpetal3:PetalContRmin])"/>
+		<!-- calculate the width to fit the area at this specific radius! thus the volume will be constant!-->
+		<Constant name="CableL" value="([tecwheel:CableRmax]-[tecring3:Rin])"/>
+		<Constant name="CableR" value="([tecwheel:CableRmax]+[tecring3:Rin])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tecwheeld.xml">
+		<Tubs name="TECWheelD" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:WheelT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECWheelDiskD" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECWheelNomexD" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TECFixSupportD" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
+		<Tubs name="TECOptConnectorD" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT3]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
+	</SolidSection>
+	<LogicalPartSection label="tecwheeld.xml">
+		<LogicalPart name="TECWheelD" category="unspecified">
+			<rSolid name="tecwheeld:TECWheelD"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TECWheelDiskD" category="unspecified">
+			<rSolid name="tecwheeld:TECWheelDiskD"/>
+			<rMaterial name="tecmaterial:TEC_wheel_CF"/>
+		</LogicalPart>
+		<LogicalPart name="TECWheelNomexD" category="unspecified">
+			<rSolid name="tecwheeld:TECWheelNomexD"/>
+			<rMaterial name="tecmaterial:TEC_wheel_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TECFixSupportD" category="unspecified">
+			<rSolid name="tecwheeld:TECFixSupportD"/>
+			<rMaterial name="tecmaterial:TEC_Fixframe"/>
+		</LogicalPart>
+		<LogicalPart name="TECOptConnectorD" category="unspecified">
+			<rSolid name="tecwheeld:TECOptConnectorD"/>
+			<rMaterial name="tecmaterial:TEC_OptoCon"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tecwheeld.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tecwheeld:TECWheelD"/>
+			<rChild name="tecwheeld:TECWheelDiskD"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecwheeld:TECWheelDiskD"/>
+			<rChild name="tecwheeld:TECWheelNomexD"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tecwheeld:TECWheelDiskD"/>
+			<rChild name="tecwheel:TECGroundingRing"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheeld:TECWheelD"/>
+		<String name="ChildName" value="tecpetal8f:TECPetalCont8F"/>
+		<Numeric name="N" value="[tecwheel:PetalContN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:PetalContFiF]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			0, 0, -[tecwheel:PetalContZ]  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheeld:TECWheelD"/>
+		<String name="ChildName" value="tecpetal8b:TECPetalCont8B"/>
+		<Numeric name="N" value="[tecwheel:PetalContN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:PetalContFiB]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			0, 0, [tecwheel:PetalContZ]  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheeld:TECWheelNomexD"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi1]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR1]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheeld:TECWheelNomexD"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="9"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi2]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR2]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheeld:TECWheelNomexD"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="17"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi3]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR3]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheeld:TECWheelNomexD"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="25"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi4]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR4]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheeld:TECWheelNomexD"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="33"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi5]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR5]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheeld:TECWheelNomexD"/>
+		<String name="ChildName" value="tecwheel:TECWheelInsert"/>
+		<Numeric name="N" value="[tecwheel:InsertN]"/>
+		<Numeric name="StartCopyNo" value="41"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:InsertFi6]"/>
+		<Numeric name="Radius" value="[tecwheel:InsertR6]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheeld:TECWheelNomexD"/>
+		<String name="ChildName" value="tecwheeld:TECFixSupportD"/>
+		<Numeric name="N" value="[tecwheel:FixSuppN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:FixSuppFi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheeld:TECWheelNomexD"/>
+		<String name="ChildName" value="tecwheel:TECFixService"/>
+		<Numeric name="N" value="[tecwheel:FixServN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:FixServFi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheeld:TECWheelD"/>
+		<String name="ChildName" value="tecwheeld:TECOptConnectorD"/>
+		<Numeric name="N" value="[tecwheel:OptConnN]"/>
+		<Numeric name="StartCopyNo" value="2"/>
+		<Numeric name="IncrCopyNo" value="2"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:OptConnFI1]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			0, 0, -[tecwheel:OptConnZ3]  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheeld:TECWheelD"/>
+		<String name="ChildName" value="tecwheeld:TECOptConnectorD"/>
+		<Numeric name="N" value="[tecwheel:OptConnN]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="2"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:OptConnFI2]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			0, 0, [tecwheel:OptConnZ3]  </Vector>
+	</Algorithm>
+	<!-- Alignment Holder (Sphere holder) -->
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tecwheeld:TECWheelNomexD"/>
+		<String name="ChildName" value="tecwheel:TECAlignHolder"/>
+		<Numeric name="N" value="4"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tecwheel:AlignHolderStartPhi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tib.xml
+++ b/DetectorDescription/DDCMS/data/tib.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tib.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="Rin" value="22.20*cm"/>
+		<Constant name="Rout" value="54.00*cm"/>
+		<Constant name="TIBDz" value="716.00*mm"/>
+		<Constant name="SupportT" value="1.50*cm"/>
+		<Constant name="SupportRin" value="[tiblayer3:MFRingOutR]"/>
+		<Constant name="SupportRout" value="[SupportRin]+1.*mm"/>
+	</ConstantsSection>
+	<SolidSection label="tib.xml">
+		<Tubs name="TIB" rMin="[Rin]" rMax="[Rout]" dz="[tib:TIBDz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TIBOutSupport" rMin="[SupportRin]" rMax="[SupportRout]" dz="[tib:TIBDz]" startPhi="0*deg" deltaPhi="360*deg"/>
+	</SolidSection>
+	<LogicalPartSection label="tib.xml">
+		<LogicalPart name="TIB" category="unspecified">
+			<rSolid name="TIB"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIBOutSupport" category="unspecified">
+			<rSolid name="TIBOutSupport"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tib.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tib:TIB"/>
+			<rChild name="tib:TIBOutSupport"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tib:TIB"/>
+			<rChild name="tiblayer0:TIBLayer0"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tib:TIB"/>
+			<rChild name="tiblayer1:TIBLayer1"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tib:TIB"/>
+			<rChild name="tiblayer2:TIBLayer2"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tib:TIB"/>
+			<rChild name="tiblayer3:TIBLayer3"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tiblayer0.xml
+++ b/DetectorDescription/DDCMS/data/tiblayer0.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tiblayer0.xml" eval="true">
+		<Constant name="RadiusUp" value="([tiblayerpar:RadiusLo0]+                                          [tiblayerpar:DRUpLo])"/>
+		<Constant name="CylinderT" value="0.60*cm"/>
+		<Constant name="CylinderInR" value="253.0*mm"/>
+		<Constant name="MFRingInR" value="225.0*mm"/>
+		<Constant name="MFRingOutR" value="69.0*mm+[MFRingInR]"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDTIBLayerAlgo">
+		<rParent name="tiblayer0:TIBLayer0"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="DetectorTilt" value="[tiblayerpar:DetTilt]"/>
+		<Numeric name="LayerL" value="[tibstringpar:StringL]"/>
+		<Numeric name="RadiusLo" value="[tiblayerpar:RadiusLo0]"/>
+		<Numeric name="StringsLo" value="26"/>
+		<String name="StringDetLoName" value="tibstring0:TIBString0Lo1"/>
+		<Numeric name="RadiusUp" value="[tiblayer0:RadiusUp]"/>
+		<Numeric name="StringsUp" value="30"/>
+		<String name="StringDetUpName" value="tibstring0:TIBString0Up1"/>
+		<Numeric name="CylinderThickness" value="[CylinderT]"/>
+		<Numeric name="CylinderInnerRadius" value="[CylinderInR]"/>
+		<String name="CylinderMaterial" value="tibmaterial:TIB_CFCylinder"/>
+		<Numeric name="MFRingInnerRadius" value="[MFRingInR]"/>
+		<Numeric name="MFRingOuterRadius" value="[MFRingOutR]"/>
+		<Numeric name="MFRingThickness" value="[tiblayerpar:MFRingT]"/>
+		<Numeric name="MFRingDeltaz" value="[tiblayerpar:MFRingDz]"/>
+		<String name="MFIntRingMaterial" value="tibmaterial:TIB_MFIntRing"/>
+		<String name="MFExtRingMaterial" value="tibmaterial:TIB_MFExtRing"/>
+		<Numeric name="SupportThickness" value="[tiblayerpar:SupportT]"/>
+		<String name="CentRingMaterial" value="tibmaterial:TIB_CentRing"/>
+		<Vector name="CentRing1" type="numeric" nEntries="4">
+			-6.15*mm, 4.*mm, [MFRingOutR]-[tiblayerpar:MFRingT], [MFRingOutR]
+		</Vector>
+		<Vector name="CentRing2" type="numeric" nEntries="4">
+			36.88*mm, 4.*mm, [MFRingInR], [MFRingInR]+[tiblayerpar:MFRingT]
+		</Vector>
+		<String name="FillerMaterial" value="trackermaterial:T_G10"/>
+		<Numeric name="FillerDeltaz" value="10*mm"/>
+		<String name="RibMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Vector name="RibWidth" type="numeric" nEntries="6">
+			[tiblayerpar:RibWidth1], [tiblayerpar:RibWidth2], [tiblayerpar:RibWidth2], 
+			[tiblayerpar:RibWidth1], [tiblayerpar:RibWidth2], [tiblayerpar:RibWidth2] 
+		</Vector>
+		<Vector name="RibPhi" type="numeric" nEntries="6">
+			0*deg, 51.4*deg, 128.6*deg, 180.0*deg, 231.4*deg, 308.6*deg
+		</Vector>
+		<!-- DOHM Position in #string in the upper half shell; negative means place an AUX -->
+		<!-- NB String numbering here starts from 1 -->
+		<Vector name="DOHMListFW" type="numeric" nEntries="6">
+			2, 4, 7, 9, 12, 14
+		</Vector>
+		<Vector name="DOHMListBW" type="numeric" nEntries="6">
+			2, 4, 7, 9, 12, 14
+		</Vector>
+		<Numeric name="DOHMCarrierPhiOffset" value="[tiblayerpar:DOHMCarrierPhiOff]"/>
+		<Numeric name="DOHMtoMFDist" value="[tiblayerpar:DOHMtoMF]"/>
+		<String name="StringDOHMPrimName" value="tiblayerpar:TIBDOHMPrim"/>
+		<String name="StringDOHMAuxName" value="tiblayerpar:TIBDOHMAux"/>
+		<String name="DOHMCarrierMaterial" value="tibmaterial:TIB_DOHMCarrier"/>
+		<String name="DOHMCableMaterial" value="tibmaterial:TIB_DOHM_cable"/>
+		<String name="DOHMPRIMMaterial" value="tibmaterial:TIB_DOHM_PRIM"/>
+		<Numeric name="DOHMPRIMLength" value="[tiblayerpar:DOHM_PRIM_L]"/>
+		<String name="DOHMAUXMaterial" value="tibmaterial:TIB_DOHM_AUX"/>
+		<Numeric name="DOHMAUXLength" value="[tiblayerpar:DOHM_AUX_L]"/>
+		<!-- Pillar Material -->
+		<String name="PillarMaterial" value="tibmaterial:TIB_Pillar"/>
+		<!-- FW Internal Pillar Parameters -->
+		<Numeric name="FWIntPillarDz" value="1.0*mm"/>
+		<Numeric name="FWIntPillarDPhi" value="1.0*deg"/>
+		<Vector name="FWIntPillarPhi" type="numeric" nEntries="1">
+			-1.
+		</Vector>
+		<Vector name="FWIntPillarZ" type="numeric" nEntries="1"> 
+			0.
+		</Vector>
+		<!-- BW Internal Pillar Parameters -->
+		<Numeric name="BWIntPillarDz" value="1.0*cm"/>
+		<Numeric name="BWIntPillarDPhi" value="1.0*deg"/>
+		<Vector name="BWIntPillarPhi" type="numeric" nEntries="1">
+			-1.
+		</Vector>
+		<Vector name="BWIntPillarZ" type="numeric" nEntries="1">
+			0.
+		</Vector>
+		<!-- FW External Pillar Parameters -->
+		<Numeric name="FWExtPillarDz" value="20.5*mm"/>
+		<Numeric name="FWExtPillarDPhi" value="7.0*deg"/>
+		<Vector name="FWExtPillarPhi" type="numeric" nEntries="4">
+			56.*deg, 124.*deg, 236.*deg, 304.*deg 
+		</Vector>
+		<Vector name="FWExtPillarZ" type="numeric" nEntries="4">
+			200.*mm, 200.*mm, 200.*mm, 200.*mm
+		</Vector>
+		<!-- BW External Pillar Parameters -->
+		<Numeric name="BWExtPillarDz" value="8.0*mm"/>
+		<Numeric name="BWExtPillarDPhi" value="7.0*deg"/>
+		<Vector name="BWExtPillarPhi" type="numeric" nEntries="4">
+			56.*deg, 124.*deg, 236.*deg, 304.*deg 
+		</Vector>
+		<Vector name="BWExtPillarZ" type="numeric" nEntries="4">
+			-248.*mm, -248.*mm, -248.*mm, -248.*mm
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tiblayer1.xml
+++ b/DetectorDescription/DDCMS/data/tiblayer1.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tiblayer1.xml" eval="true">
+		<Constant name="RadiusUp" value="([tiblayerpar:RadiusLo1]+                                          [tiblayerpar:DRUpLo])"/>
+		<Constant name="CylinderT" value="0.60*cm"/>
+		<Constant name="CylinderInR" value="337.0*mm"/>
+		<Constant name="MFRingInR" value="300.0*mm"/>
+		<Constant name="MFRingOutR" value="75.75*mm+[MFRingInR]"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDTIBLayerAlgo">
+		<rParent name="tiblayer1:TIBLayer1"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="DetectorTilt" value="[tiblayerpar:DetTilt]"/>
+		<Numeric name="LayerL" value="[tibstringpar:StringL]"/>
+		<Numeric name="RadiusLo" value="[tiblayerpar:RadiusLo1]"/>
+		<Numeric name="StringsLo" value="34"/>
+		<String name="StringDetLoName" value="tibstring1:TIBString1Lo1"/>
+		<Numeric name="RadiusUp" value="[tiblayer1:RadiusUp]"/>
+		<Numeric name="StringsUp" value="38"/>
+		<String name="StringDetUpName" value="tibstring1:TIBString1Up1"/>
+		<Numeric name="CylinderThickness" value="[CylinderT]"/>
+		<Numeric name="CylinderInnerRadius" value="[CylinderInR]"/>
+		<String name="CylinderMaterial" value="tibmaterial:TIB_CFCylinder"/>
+		<Numeric name="MFRingInnerRadius" value="[MFRingInR]"/>
+		<Numeric name="MFRingOuterRadius" value="[MFRingOutR]"/>
+		<Numeric name="MFRingThickness" value="[tiblayerpar:MFRingT]"/>
+		<Numeric name="MFRingDeltaz" value="[tiblayerpar:MFRingDz]"/>
+		<String name="MFIntRingMaterial" value="tibmaterial:TIB_MFIntRing"/>
+		<String name="MFExtRingMaterial" value="tibmaterial:TIB_MFExtRing"/>
+		<Numeric name="SupportThickness" value="[tiblayerpar:SupportT]"/>
+		<String name="CentRingMaterial" value="tibmaterial:TIB_CentRing"/>
+		<Vector name="CentRing1" type="numeric" nEntries="4">
+			-3.805*mm, 4.*mm, [MFRingOutR]-[tiblayerpar:MFRingT], [MFRingOutR]
+		</Vector>
+		<Vector name="CentRing2" type="numeric" nEntries="4">
+			12.461*mm, 4.*mm, [MFRingOutR]-[tiblayerpar:MFRingT], [MFRingOutR]
+		</Vector>
+		<String name="FillerMaterial" value="trackermaterial:T_G10"/>
+		<Numeric name="FillerDeltaz" value="11*mm"/>
+		<String name="RibMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Vector name="RibWidth" type="numeric" nEntries="6">
+			[tiblayerpar:RibWidth1], [tiblayerpar:RibWidth2], [tiblayerpar:RibWidth2], 
+			[tiblayerpar:RibWidth1], [tiblayerpar:RibWidth2], [tiblayerpar:RibWidth2] 
+		</Vector>
+		<Vector name="RibPhi" type="numeric" nEntries="6">
+			0*deg, 56.8*deg, 123.2*deg, 180.0*deg, 236.8*deg, 303.2*deg
+		</Vector>
+		<!-- DOHM Position in #string in the upper half shell; negative means place an AUX -->
+		<!-- NB String numbering here starts from 1 -->
+		<Vector name="DOHMListFW" type="numeric" nEntries="8">
+			2, 4, 7, 9, 12, 14, 16, 18
+		</Vector>
+		<Vector name="DOHMListBW" type="numeric" nEntries="8">
+			2, 4, 7, 9, 11, 13, 16, 18
+		</Vector>
+		<Numeric name="DOHMCarrierPhiOffset" value="[tiblayerpar:DOHMCarrierPhiOff]"/>
+		<Numeric name="DOHMtoMFDist" value="[tiblayerpar:DOHMtoMF]"/>
+		<String name="StringDOHMPrimName" value="tiblayerpar:TIBDOHMPrim"/>
+		<String name="StringDOHMAuxName" value="tiblayerpar:TIBDOHMAux"/>
+		<String name="DOHMCarrierMaterial" value="tibmaterial:TIB_DOHMCarrier"/>
+		<String name="DOHMCableMaterial" value="tibmaterial:TIB_DOHM_cable"/>
+		<String name="DOHMPRIMMaterial" value="tibmaterial:TIB_DOHM_PRIM"/>
+		<Numeric name="DOHMPRIMLength" value="[tiblayerpar:DOHM_PRIM_L]"/>
+		<String name="DOHMAUXMaterial" value="tibmaterial:TIB_DOHM_AUX"/>
+		<Numeric name="DOHMAUXLength" value="[tiblayerpar:DOHM_AUX_L]"/>
+		<!-- Pillar Material -->
+		<String name="PillarMaterial" value="tibmaterial:TIB_Pillar"/>
+		<!-- FW Internal Pillar Parameters -->
+		<Numeric name="FWIntPillarDz" value="21.5*mm"/>
+		<Numeric name="FWIntPillarDPhi" value="6.*deg"/>
+		<Vector name="FWIntPillarPhi" type="numeric" nEntries="4">
+			56.*deg, 124.*deg, 236.*deg, 304.*deg 
+		</Vector>
+		<Vector name="FWIntPillarZ" type="numeric" nEntries="4">
+			173.*mm, 173.*mm, 173.*mm, 173.*mm
+		</Vector>
+		<!-- BW Internal Pillar Parameters -->
+		<Numeric name="BWIntPillarDz" value="13.5*mm"/>
+		<Numeric name="BWIntPillarDPhi" value="6.*deg"/>
+		<Vector name="BWIntPillarPhi" type="numeric" nEntries="4">
+			56.*deg, 124.*deg, 236.*deg, 304.*deg 
+		</Vector>
+		<Vector name="BWIntPillarZ" type="numeric" nEntries="4">
+			-235.5*mm, -235.5*mm, -235.5*mm, -235.5*mm
+		</Vector>
+		<!-- FW External Pillar Parameters -->
+		<Numeric name="FWExtPillarDz" value="17.5*mm"/>
+		<Numeric name="FWExtPillarDPhi" value="7.*deg"/>
+		<Vector name="FWExtPillarPhi" type="numeric" nEntries="4">
+			33.*deg, 147.*deg, 213.*deg, 327.*deg 
+		</Vector>
+		<Vector name="FWExtPillarZ" type="numeric" nEntries="4">
+			250.*mm, 250.*mm, 250.*mm, 250.*mm
+		</Vector>
+		<!-- BW External Pillar Parameters -->
+		<Numeric name="BWExtPillarDz" value="14.5*mm"/>
+		<Numeric name="BWExtPillarDPhi" value="7.*deg"/>
+		<Vector name="BWExtPillarPhi" type="numeric" nEntries="4">
+			33.*deg, 147.*deg, 213.*deg, 327.*deg 
+		</Vector>
+		<Vector name="BWExtPillarZ" type="numeric" nEntries="4">
+			-210.5*mm, -210.5*mm, -210.5*mm, -210.5*mm
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tiblayer2.xml
+++ b/DetectorDescription/DDCMS/data/tiblayer2.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tiblayer2.xml" eval="true">
+		<Constant name="RadiusUp" value="([tiblayerpar:RadiusLo2]+                                          [tiblayerpar:DRUpLo])"/>
+		<Constant name="CylinderT" value="0.80*cm"/>
+		<Constant name="CylinderInR" value="415.5*mm"/>
+		<Constant name="MFRingInR" value="382.75*mm"/>
+		<Constant name="MFRingOutR" value="71.5*mm+[MFRingInR]"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDTIBLayerAlgo">
+		<rParent name="tiblayer2:TIBLayer2"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="DetectorTilt" value="[tiblayerpar:DetTilt]"/>
+		<Numeric name="LayerL" value="[tibstringpar:StringL]"/>
+		<Numeric name="RadiusLo" value="[tiblayerpar:RadiusLo2]"/>
+		<Numeric name="StringsLo" value="44"/>
+		<String name="StringDetLoName" value="tibstring2:TIBString2Lo1"/>
+		<Numeric name="RadiusUp" value="[tiblayer2:RadiusUp]"/>
+		<Numeric name="StringsUp" value="46"/>
+		<String name="StringDetUpName" value="tibstring2:TIBString2Up1"/>
+		<Numeric name="CylinderThickness" value="[CylinderT]"/>
+		<Numeric name="CylinderInnerRadius" value="[CylinderInR]"/>
+		<String name="CylinderMaterial" value="tibmaterial:TIB_CFCylinder"/>
+		<Numeric name="MFRingInnerRadius" value="[MFRingInR]"/>
+		<Numeric name="MFRingOuterRadius" value="[MFRingOutR]"/>
+		<Numeric name="MFRingThickness" value="[tiblayerpar:MFRingT]"/>
+		<Numeric name="MFRingDeltaz" value="[tiblayerpar:MFRingDz]"/>
+		<String name="MFIntRingMaterial" value="tibmaterial:TIB_MFIntRing"/>
+		<String name="MFExtRingMaterial" value="tibmaterial:TIB_MFExtRing"/>
+		<Numeric name="SupportThickness" value="[tiblayerpar:SupportT]"/>
+		<String name="CentRingMaterial" value="tibmaterial:TIB_CentRing"/>
+		<Vector name="CentRing1" type="numeric" nEntries="4">
+			-15.00*mm, 4.*mm, [MFRingOutR]-[tiblayerpar:MFRingT], [MFRingOutR]
+		</Vector>
+		<Vector name="CentRing2" type="numeric" nEntries="4">
+			-6.00*mm, 4.*mm, [MFRingOutR]-[tiblayerpar:MFRingT], [MFRingOutR]
+		</Vector>
+		<String name="FillerMaterial" value="trackermaterial:T_G10"/>
+		<Numeric name="FillerDeltaz" value="11.5*mm"/>
+		<String name="RibMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Vector name="RibWidth" type="numeric" nEntries="6">
+			[tiblayerpar:RibWidth1], [tiblayerpar:RibWidth2], [tiblayerpar:RibWidth2], 
+			[tiblayerpar:RibWidth1], [tiblayerpar:RibWidth2], [tiblayerpar:RibWidth2] 
+		</Vector>
+		<Vector name="RibPhi" type="numeric" nEntries="6">
+			0*deg, 62.6*deg, 117.4*deg, 180.0*deg, 242.6*deg, 297.4*deg
+		</Vector>
+		<!-- DOHM Position in #string in the upper half shell; negative means place an AUX -->
+		<!-- NB String numbering here starts from 1 -->
+		<Vector name="DOHMListFW" type="numeric" nEntries="6">
+			3, -6, 10, -13, 18, -21
+		</Vector>
+		<Vector name="DOHMListBW" type="numeric" nEntries="6">
+			3, -6, 10, -13, 18, -21
+		</Vector>
+		<Numeric name="DOHMtoMFDist" value="[tiblayerpar:DOHMtoMF]"/>
+		<Numeric name="DOHMCarrierPhiOffset" value="[tiblayerpar:DOHMCarrierPhiOff]"/>
+		<String name="StringDOHMPrimName" value="tiblayerpar:TIBDOHMPrim"/>
+		<String name="StringDOHMAuxName" value="tiblayerpar:TIBDOHMAux"/>
+		<String name="DOHMCarrierMaterial" value="tibmaterial:TIB_DOHMCarrier"/>
+		<String name="DOHMCableMaterial" value="tibmaterial:TIB_DOHM_cable"/>
+		<String name="DOHMPRIMMaterial" value="tibmaterial:TIB_DOHM_PRIM"/>
+		<Numeric name="DOHMPRIMLength" value="[tiblayerpar:DOHM_PRIM_L]"/>
+		<String name="DOHMAUXMaterial" value="tibmaterial:TIB_DOHM_AUX"/>
+		<Numeric name="DOHMAUXLength" value="[tiblayerpar:DOHM_AUX_L]"/>
+		<!-- Pillar Material -->
+		<String name="PillarMaterial" value="tibmaterial:TIB_Pillar"/>
+		<!-- FW Internal Pillar Parameters -->
+		<Numeric name="FWIntPillarDz" value="14.*mm"/>
+		<Numeric name="FWIntPillarDPhi" value="7.5*deg"/>
+		<Vector name="FWIntPillarPhi" type="numeric" nEntries="4">
+			34.*deg, 146.*deg, 214.*deg, 326.*deg 
+		</Vector>
+		<Vector name="FWIntPillarZ" type="numeric" nEntries="4">
+			254.*mm, 254.*mm, 254.*mm, 254.*mm
+		</Vector>
+		<!-- BW Internal Pillar Parameters -->
+		<Numeric name="BWIntPillarDz" value="24.*mm"/>
+		<Numeric name="BWIntPillarDPhi" value="7.5*deg"/>
+		<Vector name="BWIntPillarPhi" type="numeric" nEntries="4">
+			34.*deg, 146.*deg, 214.*deg, 326.*deg 
+		</Vector>
+		<Vector name="BWIntPillarZ" type="numeric" nEntries="4">
+			-181.*mm, -181.*mm, -181.*mm, -181.*mm
+		</Vector>
+		<!-- FW External Pillar Parameters -->
+		<Numeric name="FWExtPillarDz" value="14.5*mm"/>
+		<Numeric name="FWExtPillarDPhi" value="4.5*deg"/>
+		<Vector name="FWExtPillarPhi" type="numeric" nEntries="4">
+			52.*deg, 128.*deg, 232.*deg, 308.*deg 
+		</Vector>
+		<Vector name="FWExtPillarZ" type="numeric" nEntries="4">
+			201.*mm, 201.*mm, 201.*mm, 201.*mm
+		</Vector>
+		<!-- BW External Pillar Parameters -->
+		<Numeric name="BWExtPillarDz" value="18.5*mm"/>
+		<Numeric name="BWExtPillarDPhi" value="4.5*deg"/>
+		<Vector name="BWExtPillarPhi" type="numeric" nEntries="4">
+			52.*deg, 128.*deg, 232.*deg, 308.*deg 
+		</Vector>
+		<Vector name="BWExtPillarZ" type="numeric" nEntries="4">
+			-256.5*mm, -256.5*mm, -256.5*mm, -256.5*mm
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tiblayer3.xml
+++ b/DetectorDescription/DDCMS/data/tiblayer3.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tiblayer3.xml" eval="true">
+		<Constant name="RadiusUp" value="([tiblayerpar:RadiusLo3]+                                          [tiblayerpar:DRUpLo])"/>
+		<Constant name="CylinderT" value="0.80*cm"/>
+		<Constant name="CylinderInR" value="495.0*mm"/>
+		<Constant name="MFRingInR" value="463.5*mm"/>
+		<Constant name="MFRingOutR" value="72.5*mm+[MFRingInR]"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDTIBLayerAlgo">
+		<rParent name="tiblayer3:TIBLayer3"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="DetectorTilt" value="[tiblayerpar:DetTilt]"/>
+		<Numeric name="LayerL" value="[tibstringpar:StringL]"/>
+		<Numeric name="RadiusLo" value="[tiblayerpar:RadiusLo3]"/>
+		<Numeric name="StringsLo" value="52"/>
+		<String name="StringDetLoName" value="tibstring3:TIBString3Lo1"/>
+		<Numeric name="RadiusUp" value="[tiblayer3:RadiusUp]"/>
+		<Numeric name="StringsUp" value="56"/>
+		<String name="StringDetUpName" value="tibstring3:TIBString3Up1"/>
+		<Numeric name="CylinderThickness" value="[CylinderT]"/>
+		<Numeric name="CylinderInnerRadius" value="[CylinderInR]"/>
+		<String name="CylinderMaterial" value="tibmaterial:TIB_CFCylinder"/>
+		<Numeric name="MFRingInnerRadius" value="[MFRingInR]"/>
+		<Numeric name="MFRingOuterRadius" value="[MFRingOutR]"/>
+		<Numeric name="MFRingThickness" value="[tiblayerpar:MFRingT]"/>
+		<Numeric name="MFRingDeltaz" value="[tiblayerpar:MFRingDz]"/>
+		<String name="MFIntRingMaterial" value="tibmaterial:TIB_MFIntRing"/>
+		<String name="MFExtRingMaterial" value="tibmaterial:TIB_MFExtRing"/>
+		<Numeric name="SupportThickness" value="[tiblayerpar:SupportT]"/>
+		<String name="CentRingMaterial" value="tibmaterial:TIB_CentRing"/>
+		<Vector name="CentRing1" type="numeric" nEntries="4">
+			-0.70*mm, 8.*mm, [MFRingOutR]-[tiblayerpar:MFRingT], [MFRingOutR]
+		</Vector>
+		<Vector name="CentRing2" type="numeric" nEntries="4">
+			12.20*mm, 8.*mm, [MFRingOutR]-[tiblayerpar:MFRingT], [MFRingOutR]
+		</Vector>
+		<String name="FillerMaterial" value="trackermaterial:T_G10"/>
+		<Numeric name="FillerDeltaz" value="9.75*mm"/>
+		<String name="RibMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Vector name="RibWidth" type="numeric" nEntries="6">
+			[tiblayerpar:RibWidth1], [tiblayerpar:RibWidth2], [tiblayerpar:RibWidth2], 
+			[tiblayerpar:RibWidth1], [tiblayerpar:RibWidth2], [tiblayerpar:RibWidth2] 
+		</Vector>
+		<Vector name="RibPhi" type="numeric" nEntries="6">
+			0*deg, 53.3*deg, 126.7*deg, 180.0*deg, 233.3*deg, 306.7*deg
+		</Vector>
+		<!-- DOHM Position in #string in the upper half shell; negative means place an AUX -->
+		<!-- NB String numbering here starts from 1 -->
+		<Vector name="DOHMListFW" type="numeric" nEntries="8">
+			3, -6, 10, -13, 16, -19, 24, -27
+		</Vector>
+		<Vector name="DOHMListBW" type="numeric" nEntries="8">
+			3, -6, 9, -12, 16, -19, 23, -26
+		</Vector>
+		<Numeric name="DOHMtoMFDist" value="[tiblayerpar:DOHMtoMF]"/>
+		<Numeric name="DOHMCarrierPhiOffset" value="[tiblayerpar:DOHMCarrierPhiOff]"/>
+		<String name="StringDOHMPrimName" value="tiblayerpar:TIBDOHMPrim"/>
+		<String name="StringDOHMAuxName" value="tiblayerpar:TIBDOHMAux"/>
+		<String name="DOHMCarrierMaterial" value="tibmaterial:TIB_DOHMCarrier"/>
+		<String name="DOHMCableMaterial" value="tibmaterial:TIB_DOHM_cable"/>
+		<String name="DOHMPRIMMaterial" value="tibmaterial:TIB_DOHM_PRIM"/>
+		<Numeric name="DOHMPRIMLength" value="[tiblayerpar:DOHM_PRIM_L]"/>
+		<String name="DOHMAUXMaterial" value="tibmaterial:TIB_DOHM_AUX"/>
+		<Numeric name="DOHMAUXLength" value="[tiblayerpar:DOHM_AUX_L]"/>
+		<!-- Pillar Material -->
+		<String name="PillarMaterial" value="tibmaterial:TIB_Pillar"/>
+		<!-- FW Internal Pillar Parameters -->
+		<Numeric name="FWIntPillarDz" value="23.5*mm"/>
+		<Numeric name="FWIntPillarDPhi" value="5.5*deg"/>
+		<Vector name="FWIntPillarPhi" type="numeric" nEntries="4">
+			52.*deg, 128.*deg, 232.*deg, 308.*deg 
+		</Vector>
+		<Vector name="FWIntPillarZ" type="numeric" nEntries="4">
+			182.*mm, 182.*mm, 182.*mm, 182.*mm
+		</Vector>
+		<!-- BW Internal Pillar Parameters -->
+		<Numeric name="BWIntPillarDz" value="16.0*mm"/>
+		<Numeric name="BWIntPillarDPhi" value="5.5*deg"/>
+		<Vector name="BWIntPillarPhi" type="numeric" nEntries="4">
+			52.*deg, 128.*deg, 232.*deg, 308.*deg 
+		</Vector>
+		<Vector name="BWIntPillarZ" type="numeric" nEntries="4">
+			-259.*mm, -259.*mm, -259.*mm, -259.*mm
+		</Vector>
+		<!-- FW External Pillar Parameters -->
+		<Numeric name="FWExtPillarDz" value="1.*cm"/>
+		<Numeric name="FWExtPillarDPhi" value="1.*deg"/>
+		<Vector name="FWExtPillarPhi" type="numeric" nEntries="1">
+			-1.
+		</Vector>
+		<Vector name="FWExtPillarZ" type="numeric" nEntries="1">
+			-1.
+		</Vector>
+		<!-- BW External Pillar Parameters -->
+		<Numeric name="BWExtPillarDz" value="1.*cm"/>
+		<Numeric name="BWExtPillarDPhi" value="1.*deg"/>
+		<Vector name="BWExtPillarPhi" type="numeric" nEntries="1">
+			-1.
+		</Vector>
+		<Vector name="BWExtPillarZ" type="numeric" nEntries="1">
+			-1.
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tiblayerpar.xml
+++ b/DetectorDescription/DDCMS/data/tiblayerpar.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tiblayerpar.xml" eval="true">
+		<Constant name="DetTilt" value="-9.00*deg"/>
+		<Constant name="Tolerance" value="0.25*cm"/>
+		<Constant name="SupportT" value="0.5*mm"/>
+		<Constant name="RibWidth1" value="3.50*cm"/>
+		<Constant name="RibWidth2" value="0.13*cm"/>
+		<Constant name="RadiusLo0" value="23.90*cm"/>
+		<Constant name="RadiusLo1" value="32.30*cm"/>
+		<Constant name="RadiusLo2" value="40.25*cm"/>
+		<Constant name="RadiusLo3" value="48.20*cm"/>
+		<Constant name="DRUpLo" value="3.20*cm"/>
+		<Constant name="MFRingT" value="8.0*mm"/>
+		<Constant name="MFRingDz" value="17.0*mm"/>
+		<Constant name="DOHMCarrierW" value="29.5*cm"/>
+		<Constant name="DOHMCarrierT" value="1.15*mm"/>
+		<Constant name="DOHMCarrierPhiOff" value="2.*deg"/>
+		<Constant name="DOHMtoMF" value="1.00*cm"/>
+		<Constant name="DOHM_PRIM_W" value="6.0*cm"/>
+		<Constant name="DOHM_PRIM_L" value="28.5*cm"/>
+		<Constant name="DOHM_PRIM_T" value="4.0*mm"/>
+		<Constant name="DOHM_AUX_W" value="6.0*cm"/>
+		<Constant name="DOHM_AUX_L" value="15.5*cm"/>
+		<Constant name="DOHM_AUX_T" value="4.0*mm"/>
+		<Constant name="Tol" value="0.1*mm"/>
+	</ConstantsSection>
+	<SolidSection label="tiblayerpar.xml">
+		<Box name="TIBDOHMPrim" dx="0.5*[tiblayerpar:DOHM_PRIM_W]" dy="0.5*[tiblayerpar:DOHM_PRIM_T]" dz="0.5*[tiblayerpar:DOHM_PRIM_L]"/>
+		<Box name="TIBDOHMAux" dx="0.5*[tiblayerpar:DOHM_AUX_W]" dy="0.5*[tiblayerpar:DOHM_AUX_T]" dz="0.5*[tiblayerpar:DOHM_AUX_L]"/>
+	</SolidSection>
+	<LogicalPartSection label="tiblayerpar.xml">
+		<LogicalPart name="TIBDOHMPrim" category="unspecified">
+			<rSolid name="tiblayerpar:TIBDOHMPrim"/>
+			<rMaterial name="tibmaterial:TIB_DOHM"/>
+		</LogicalPart>
+		<LogicalPart name="TIBDOHMAux" category="unspecified">
+			<rSolid name="tiblayerpar:TIBDOHMAux"/>
+			<rMaterial name="tibmaterial:TIB_AUX"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<RotationSection label="tiblayerpar.xml">
+		<Rotation name="D180" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="270*deg" thetaZ="180*deg" phiZ="0*deg"/>
+	</RotationSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibmaterial.xml
+++ b/DetectorDescription/DDCMS/data/tibmaterial.xml
@@ -1,0 +1,443 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <MaterialSection label="tibmaterial.xml">
+    <CompositeMaterial name="TIB_DOHM" density="1.61191*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.37005">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08736">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00142">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00354">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00254">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00254">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03447">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03446">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0136">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01693">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00542">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00325">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00726">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00453">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05037">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02052">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01489">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00352">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02114">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01107">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04416">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_CCUM" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05524">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_DOH" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02721">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00847">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00559">
+        <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02665">
+        <rMaterial name="tibtidcommonmaterial:T_MedusaWire" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01497">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10884">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_AUX" density="1.69155*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.34905">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08045">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00272">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00517">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00127">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00127">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06357">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06356">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11042">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04498">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01786">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00412">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02536">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01328">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02622">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1907">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_DOHMCarrier" density="0.37823*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.52099">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07514">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08092">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02081">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.26238">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_AmphCable" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03006">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0097">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_Flange" density="0.541944*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.71068">
+        <rMaterial name="tibtidcommonmaterial:T_MedusaWire" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10194">
+        <rMaterial name="tibtidcommonmaterial:T_Al6mmPipe" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08266">
+        <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04022">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_AmphCable" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02347">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01743">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0236">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_CFCylinder" density="1.74797*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.96684">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01343">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00714">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01259">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_ModKaptonBox" density="1.43380*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.39057">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00612">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00931">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14667">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.36669">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03667">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04398">
+        <rMaterial name="materials:Iron" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_SSAOHBox" density="0.99230*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.73275">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_AOH" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05655">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03887">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06715">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03882">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_HybridTails" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01559">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_HybridTails" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02375">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00532">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0212">
+        <rMaterial name="materials:Iron" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_DSAOHBox" density="1.19076*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1">
+        <rMaterial name="tibmaterial:TIB_SSAOHBox" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_ModHybLedge" density="5.85144*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.88449">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11551">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_ModDummyLedge" density="5.51982*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.8706">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1294">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_AOHLedge" density="5.57478*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_CoolPipe" density="2.00806*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.50397">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.49603">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_MCable" density="2.25395*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.38359">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.44832">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07394">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09415">
+        <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_SSMCModConn" density="1.23046*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.03675">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_HybridTails" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01862">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00418">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12499">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01191">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16248">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.37555">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.24997">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01556">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_DSMCModConn" density="1.67201*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1">
+        <rMaterial name="tibmaterial:TIB_SSMCModConn" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_MCHead" density="2.01518*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.34318">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_CCUM" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10297">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12034">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01985">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02114">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05639">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03524">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03524">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04229">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0141">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03524">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02819">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02819">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06344">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02584">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02834">
+        <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_MFIntRing" density="1.66403*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.34788">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08064">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02664">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.36336">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07841">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01023">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08908">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00375">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_MFExtRing" density="1.68430*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.98796">
+        <rMaterial name="tibmaterial:TIB_MFIntRing" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01204">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_AmphCable" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_CentRing" density="3.42188*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.92603">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07397">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_Spacer" density="2.88571*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.87129">
+        <rMaterial name="materials:Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12871">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_Pillar" density="1.7394*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.75785">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.24215">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+  </MaterialSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibmodpar.xml
+++ b/DetectorDescription/DDCMS/data/tibmodpar.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tibmodpar.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="ModuleDx" value="3.900*cm"/>
+		<Constant name="SSModuleDy" value="1.100*mm"/>
+		<Constant name="DSModuleDy" value="2.475*mm"/>
+		<Constant name="DSModuleSideCutDx" value="3.3*mm"/>
+		<Constant name="DSModuleSideCutDy" value="0.8*mm"/>
+		<Constant name="DSModuleSideCutX" value="36.*mm"/>
+		<Constant name="DSModuleSideCutY" value="1.775*mm"/>
+		<Constant name="SideCutExtraZ" value="0.1*mm"/>
+		<Constant name="ModuleDz" value="81.65*mm"/>
+		<Constant name="HybridDx" value="23.50*mm"/>
+		<Constant name="HybridDy" value="0.565*mm"/>
+		<Constant name="HybridDz" value="12.65*mm"/>
+		<Constant name="HybridZ" value="[ModuleDz]-[HybridDz]"/>
+		<Constant name="PARPhiDx" value="32.00*mm"/>
+		<Constant name="PADy" value="0.565*mm"/>
+		<Constant name="PARPhiDz" value="4.500*mm"/>
+		<Constant name="PAZ" value="[ModuleDz]-2*[HybridDz]-[PARPhiDz]"/>
+		<Constant name="CFFrameHybDz" value="12.40*mm"/>
+		<Constant name="CFFrameHybZ" value="-[tibmodpar:ModuleDz]+[tibmodpar:CFFrameHybDz]"/>
+		<Constant name="CFFrameHybRPhiDx" value="30.00*mm"/>
+		<Constant name="CFFrameDy" value="0.250*mm"/>
+		<Constant name="CFFrameDz" value="[ModuleDz]-[CFFrameHybDz]"/>
+		<Constant name="CFFrameZ" value="[ModuleDz]-[CFFrameDz]"/>
+		<Constant name="CFFrameHoleDx" value="30.00*mm"/>
+		<Constant name="CFFrameHoleDz" value="59.50*mm"/>
+		<Constant name="CFFrameHoleOffset" value="1.000*mm"/>
+		<Constant name="CFFrameHoleZ" value="[tibmodpar:WaferZ]-[tibmodpar:CFFrameHybDz]"/>
+		<Constant name="KaptonBoxDy" value="0.150*mm"/>
+		<Constant name="KaptonBoxDz" value="[ModuleDz]-[HybridDz]-[PARPhiDz]"/>
+		<Constant name="KaptonBoxZ" value="[tibmodpar:HybridDz]+[tibmodpar:PARPhiDz]"/>
+		<Constant name="KaptonBoxHoleDx" value="27.50*mm"/>
+		<Constant name="KaptonBoxHoleDz" value="57.50*mm"/>
+		<Constant name="KaptonBoxHoleZ" value="[tibmodpar:KaptonBoxHoleDz]-[tibmodpar:KaptonBoxDz]"/>
+		<Constant name="StereoAngle" value="5.729578*deg"/>
+		<Constant name="TrapSterTheta" value="atan(0.5*tan([tibmodpar:StereoAngle]))"/>
+		<!-- Trapezoid parameter -->
+		<Constant name="HybLedgeDz" value="3.60*mm"/>
+		<Constant name="HybLedgeSideDx" value="3.0*mm"/>
+		<Constant name="HybLedgeSideDz" value="12.0*mm"/>
+		<Constant name="DummyLedgeDz" value="5.0*mm"/>
+		<Constant name="LedgeBoxDx" value="[tibstringpar:CoolBoxDx]"/>
+		<Constant name="LedgeBoxDy" value="[tibstringpar:CoolBoxDy]-[tibstringpar:CoolPipeDy]"/>
+		<Constant name="SSLedgeBoxY" value="-[tibmodpar:SSModuleDy]-[tibmodpar:LedgeBoxDy]"/>
+		<Constant name="DSLedgeBoxY" value="-[tibmodpar:DSModuleDy]-[tibmodpar:LedgeBoxDy]"/>
+		<Constant name="AOHLedgeDz" value="1.5*mm"/>
+		<Constant name="AOHLedgeSideDx" value="1.5*mm"/>
+		<Constant name="AOHLedgeSideDz" value="15.0*mm"/>
+		<Constant name="AOHModOffset" value="6.0*mm"/>
+		<Constant name="AOHLedgeModOffset" value="[tibmodpar:AOHModOffset]+[tibmodpar:AOHLedgeSideDz]"/>
+		<Constant name="SSAOHBoxDx" value="18.0*mm"/>
+		<Constant name="DSAOHBoxDx" value="[tibstringpar:CoolBoxDx]"/>
+		<Constant name="AOHBoxDy" value="[tibmodpar:SSModuleDy]"/>
+		<Constant name="AOHToMod" value="6.0*mm"/>
+		<Constant name="AOHBoxDz" value="[tibmodpar:AOHLedgeSideDz]+0.5*[tibmodpar:AOHToMod]"/>
+		<Constant name="SSAOHBoxY" value="-[tibmodpar:SSModuleDy]+[tibmodpar:AOHBoxDy]"/>
+		<Constant name="SSAOHBoxX" value="[tibmodpar:LedgeBoxDx]-[tibmodpar:SSAOHBoxDx]"/>
+		<Constant name="DSAOHBoxY" value="-[tibmodpar:DSModuleDy]+[tibmodpar:AOHBoxDy]"/>
+		<Constant name="ModCool1Dx" value="2.350*cm"/>
+		<Constant name="ModCoolDy" value="0.015*cm"/>
+		<Constant name="ModCool1Dz" value="0.350*cm"/>
+		<Constant name="ModCool1X" value="0.000*cm"/>
+		<Constant name="ModCool1Z" value="7.800*cm"/>
+		<Constant name="ModCool2Dx" value="0.300*cm"/>
+		<Constant name="ModCool2Dz" value="1.250*cm"/>
+		<Constant name="ModCool2X" value="2.650*cm"/>
+		<Constant name="ModCool2Z" value="6.900*cm"/>
+		<Constant name="SSWaferDx" value="31.6440*mm"/>
+		<Constant name="DSWaferDx" value="31.6640*mm"/>
+		<Constant name="WaferDy" value="59.4805*mm"/>
+		<Constant name="WaferDz" value="0.160*mm"/>
+		<Constant name="ActiveDz" value="[WaferDz]-[tracker:BackPlaneDz]"/>
+		<Constant name="SSActiveDx" value="30.720*mm"/>
+		<!-- Actual ActiveDx=30.750mm; 30.720=pitch(=120micron)*512 -->
+		<Constant name="DSActiveDx" value="30.720*mm"/>
+		<!-- Actual ActiveDx=30.770mm; 30.720=pitch(=80micron)*768 -->
+		<Constant name="ActiveDy" value="58.4425*mm"/>
+		<Constant name="WaferZ" value="12.33*mm"/>
+		<Constant name="Tol" value="0.01*mm"/>
+	</ConstantsSection>
+	<SolidSection label="tibmodpar.xml">
+		<Box name="TIBSSModule" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:SSModuleDy]" dz="[tibmodpar:ModuleDz]"/>
+		<Box name="TIBDSModuleMainPart" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:DSModuleDy]" dz="[tibmodpar:ModuleDz]"/>
+		<Box name="TIBDSModuleSideCutL" dx="[tibmodpar:DSModuleSideCutDx]" dy="[tibmodpar:DSModuleSideCutDy]" dz="[tibmodpar:ModuleDz]+[tibmodpar:SideCutExtraZ]"/>
+		<Box name="TIBDSModuleSideCutR" dx="[tibmodpar:DSModuleSideCutDx]" dy="[tibmodpar:DSModuleSideCutDy]" dz="[tibmodpar:ModuleDz]+[tibmodpar:SideCutExtraZ]"/>
+		<SubtractionSolid name="TIBDSModuleLeftCutted">
+			<rSolid name="TIBDSModuleMainPart"/>
+			<rSolid name="TIBDSModuleSideCutL"/>
+			<Translation x="-[DSModuleSideCutX]" y="[DSModuleSideCutY]" z="0."/>
+		</SubtractionSolid>
+		<SubtractionSolid name="TIBDSModule">
+			<rSolid name="TIBDSModuleLeftCutted"/>
+			<rSolid name="TIBDSModuleSideCutR"/>
+			<Translation x="[DSModuleSideCutX]" y="[DSModuleSideCutY]" z="0."/>
+		</SubtractionSolid>
+		<Box name="TIBHybrid" dx="[tibmodpar:HybridDx]" dy="[tibmodpar:HybridDy]" dz="[tibmodpar:HybridDz]"/>
+		<Box name="TIBPA1" dx="[PARPhiDx]" dy="[PADy]" dz="[PARPhiDz]"/>
+		<Box name="TIBSSWafer" dx="[tibmodpar:SSWaferDx]" dy="[tibmodpar:WaferDy]" dz="[tibmodpar:WaferDz]"/>
+		<Box name="TIBSSActive" dx="[tibmodpar:SSActiveDx]" dy="[tibmodpar:ActiveDy]" dz="[tibmodpar:ActiveDz]"/>
+		<Box name="TIBDSWafer" dx="[tibmodpar:DSWaferDx]" dy="[tibmodpar:WaferDy]" dz="[tibmodpar:WaferDz]"/>
+		<Box name="TIBDSActive" dx="[tibmodpar:DSActiveDx]" dy="[tibmodpar:ActiveDy]" dz="[tibmodpar:ActiveDz]"/>
+		<Box name="TIBModCFFrame" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:CFFrameDy]" dz="[tibmodpar:CFFrameDz]"/>
+		<Box name="TIBModCFFrameHole" dx="[tibmodpar:CFFrameHoleDx]" dy="[tibmodpar:CFFrameDy]" dz="[tibmodpar:CFFrameHoleDz]"/>
+		<Box name="TIBModCFFrameHybRPhi" dx="[tibmodpar:CFFrameHybRPhiDx]" dy="[tibmodpar:CFFrameDy]" dz="[tibmodpar:CFFrameHybDz]"/>
+		<Box name="TIBModKaptonBoxRPhi" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:KaptonBoxDy]" dz="[tibmodpar:KaptonBoxDz]"/>
+		<Box name="TIBModKaptonBoxHole" dx="[tibmodpar:KaptonBoxHoleDx]" dy="[tibmodpar:KaptonBoxDy]" dz="[tibmodpar:KaptonBoxHoleDz]"/>
+		<!-- Module Ledges definitions -->
+		<Box name="TIBModLedgeBox" dx="[tibmodpar:LedgeBoxDx]" dy="[tibmodpar:LedgeBoxDy]" dz="[tibmodpar:ModuleDz]"/>
+		<Box name="TIBModHybLedgeNoCut" dx="[tibmodpar:LedgeBoxDx]" dy="[tibmodpar:LedgeBoxDy]" dz="[tibmodpar:HybLedgeSideDz]"/>
+		<Box name="TIBModHybLedgeCut" dx="[tibmodpar:LedgeBoxDx]-2*[tibmodpar:HybLedgeSideDx]" dy="[tibmodpar:LedgeBoxDy]" dz="[tibmodpar:HybLedgeSideDz]-[tibmodpar:HybLedgeDz]"/>
+		<SubtractionSolid name="TIBModHybLedge">
+			<rSolid name="TIBModHybLedgeNoCut"/>
+			<rSolid name="TIBModHybLedgeCut"/>
+			<Translation x="[zero]" y="[zero]" z="[tibmodpar:HybLedgeDz]"/>
+		</SubtractionSolid>
+		<Box name="TIBModDummyLedge" dx="[tibmodpar:LedgeBoxDx]" dy="[tibmodpar:LedgeBoxDy]" dz="[tibmodpar:DummyLedgeDz]"/>
+		<!-- AOH Ledges definitions -->
+		<Box name="TIBAOHLedgeNoCut" dx="[tibmodpar:LedgeBoxDx]" dy="[tibmodpar:LedgeBoxDy]" dz="[tibmodpar:AOHLedgeSideDz]"/>
+		<Box name="TIBAOHLedgeCut" dx="[tibmodpar:LedgeBoxDx]-2*[tibmodpar:AOHLedgeSideDx]" dy="[tibmodpar:LedgeBoxDy]" dz="[tibmodpar:AOHLedgeSideDz]-[tibmodpar:AOHLedgeDz]"/>
+		<SubtractionSolid name="TIBAOHLedge">
+			<rSolid name="TIBAOHLedgeNoCut"/>
+			<rSolid name="TIBAOHLedgeCut"/>
+			<Translation x="[zero]" y="[zero]" z="[tibmodpar:AOHLedgeDz]"/>
+		</SubtractionSolid>
+		<!-- AOH Boxes definitions -->
+		<Box name="TIBSSAOHBox" dx="[tibmodpar:SSAOHBoxDx]" dy="[tibmodpar:AOHBoxDy]" dz="[tibmodpar:AOHBoxDz]"/>
+		<Box name="TIBDSAOHBox" dx="[tibmodpar:DSAOHBoxDx]" dy="[tibmodpar:AOHBoxDy]" dz="[tibmodpar:AOHBoxDz]"/>
+	</SolidSection>
+	<LogicalPartSection label="tibmodpar.xml">
+		<LogicalPart name="TIBModCFFrameRPhi" category="unspecified">
+			<rSolid name="tibmodpar:TIBModCFFrame"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TIBModCFFrameHybRPhi" category="unspecified">
+			<rSolid name="tibmodpar:TIBModCFFrameHybRPhi"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TIBModCFFrameHole" category="unspecified">
+			<rSolid name="tibmodpar:TIBModCFFrameHole"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIBModKaptonBoxRPhi" category="unspecified">
+			<rSolid name="tibmodpar:TIBModKaptonBoxRPhi"/>
+			<rMaterial name="tibmaterial:TIB_ModKaptonBox"/>
+		</LogicalPart>
+		<LogicalPart name="TIBModKaptonBoxHole" category="unspecified">
+			<rSolid name="tibmodpar:TIBModKaptonBoxHole"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIBPA1" category="unspecified">
+			<rSolid name="TIBPA1"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_PA"/>
+		</LogicalPart>
+		<LogicalPart name="TIBModLedgeBox" category="unspecified">
+			<rSolid name="TIBModLedgeBox"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIBModHybLedge" category="unspecified">
+			<rSolid name="TIBModHybLedge"/>
+			<rMaterial name="tibmaterial:TIB_ModHybLedge"/>
+		</LogicalPart>
+		<LogicalPart name="TIBModDummyLedge" category="unspecified">
+			<rSolid name="TIBModDummyLedge"/>
+			<rMaterial name="tibmaterial:TIB_ModDummyLedge"/>
+		</LogicalPart>
+		<LogicalPart name="TIBAOHLedge" category="unspecified">
+			<rSolid name="TIBAOHLedge"/>
+			<rMaterial name="tibmaterial:TIB_AOHLedge"/>
+		</LogicalPart>
+		<LogicalPart name="TIBSSAOHBox" category="unspecified">
+			<rSolid name="TIBSSAOHBox"/>
+			<rMaterial name="tibmaterial:TIB_SSAOHBox"/>
+		</LogicalPart>
+		<LogicalPart name="TIBDSAOHBox" category="unspecified">
+			<rSolid name="TIBDSAOHBox"/>
+			<rMaterial name="tibmaterial:TIB_DSAOHBox"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<RotationSection label="tibmodpar.xml">
+		<Rotation name="Rphi" thetaX="90*deg" phiX="180*deg" thetaY="0*deg" phiY="90*deg" thetaZ="90*deg" phiZ="90*deg"/>
+		<Rotation name="SterB" thetaX="95.7296*deg" phiX="0*deg" thetaY="5.7296*deg" phiY="0*deg" thetaZ="90*deg" phiZ="270*deg"/>
+		<Rotation name="SterA" thetaX="84.2704*deg" phiX="0*deg" thetaY="-5.7296*deg" phiY="0*deg" thetaZ="90*deg" phiZ="270*deg"/>
+		<Rotation name="CFFrameSterB" thetaX="90.*deg" phiX="180.*deg" thetaY="90.*deg" phiY="270.*deg" thetaZ="0.*deg" phiZ="0.*deg"/>
+		<Rotation name="CFFrameHoleSterA" thetaX="90.*deg-[StereoAngle]" phiX="0.*deg" thetaY="90.*deg" phiY="90.*deg" thetaZ="[StereoAngle]" phiZ="180.*deg"/>
+		<Rotation name="KaptonBoxHoleSterB" thetaX="84.2704*deg" phiX="0*deg" thetaY="-5.7296*deg" phiY="0*deg" thetaZ="90*deg" phiZ="270*deg"/>
+		<Rotation name="KaptonBoxHoleSterA" thetaX="[StereoAngle]" phiX="180.*deg" thetaY="90.*deg" phiY="90.*deg" thetaZ="90.*deg+[StereoAngle]" phiZ="180.*deg"/>
+		<Rotation name="PAB" thetaX="180*deg" phiX="0*deg" thetaY="90*deg" phiY="270*deg" thetaZ="90*deg" phiZ="180*deg"/>
+		<Rotation name="PAA" thetaX="180*deg" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="90*deg" phiZ="0*deg"/>
+	</RotationSection>
+	<PosPartSection label="tibmodpar.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tibmodpar:TIBModCFFrameRPhi"/>
+			<rChild name="tibmodpar:TIBModCFFrameHole"/>
+			<Translation x="[zero]" y="[zero]" z="[tibmodpar:CFFrameHoleZ]-[tibmodpar:CFFrameHoleOffset]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodpar:TIBModKaptonBoxRPhi"/>
+			<rChild name="tibmodpar:TIBModKaptonBoxHole"/>
+			<Translation x="[zero]" y="[zero]" z="[tibmodpar:KaptonBoxHoleZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodpar:TIBModLedgeBox"/>
+			<rChild name="tibmodpar:TIBModHybLedge"/>
+			<Translation x="[zero]" y="[zero]" z="-[tibmodpar:ModuleDz]+[tibmodpar:HybLedgeSideDz]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodpar:TIBModLedgeBox"/>
+			<rChild name="tibmodpar:TIBModDummyLedge"/>
+			<Translation x="[zero]" y="[zero]" z="[tibmodpar:ModuleDz]-[tibmodpar:DummyLedgeDz]"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibmodule0.xml
+++ b/DetectorDescription/DDCMS/data/tibmodule0.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tibmodule0.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="ShiftX" value="5.948*mm"/>
+		<Constant name="SpacerDy" value="0.175*mm"/>
+		<Constant name="SpacerY" value="[zero]"/>
+		<Constant name="CFFrameRPhiY" value="[SpacerY]+[SpacerDy]+[tibmodpar:CFFrameDy]"/>
+		<Constant name="CFFrameSterY" value="[SpacerY]-[SpacerDy]-[tibmodpar:CFFrameDy]"/>
+		<Constant name="CFFrameHybSterDx" value="[tibmodpar:HybridDx]"/>
+		<Constant name="KaptonBoxRPhiY" value="[CFFrameRPhiY]+[tibmodpar:CFFrameDy]+[tibmodpar:KaptonBoxDy]"/>
+		<Constant name="KaptonBoxSterOffset" value="1.*mm"/>
+		<Constant name="KaptonBoxSterDz" value="([tibmodpar:WaferDy]+0.5*[tibmodule0:KaptonBoxSterOffset])/cos([tibmodpar:StereoAngle])"/>
+		<Constant name="KaptonBoxSterY" value="[CFFrameSterY]-[tibmodpar:CFFrameDy]-[tibmodpar:KaptonBoxDy]"/>
+		<Constant name="KaptonBoxHoleSterX" value="cos([tibmodpar:StereoAngle])*(cos([tibmodpar:StereoAngle])*([tibmodule0:KaptonBoxSterDz])-[tibmodpar:KaptonBoxHoleDz])"/>
+		<Constant name="KaptonBoxHoleSterZ" value="sin([tibmodpar:StereoAngle])*(cos([tibmodpar:StereoAngle])*([tibmodule0:KaptonBoxSterDz])-[tibmodpar:KaptonBoxHoleDz])"/>
+		<Constant name="HybridRPhiY" value="[CFFrameRPhiY]+[tibmodpar:CFFrameDy]+[tibmodpar:HybridDy]"/>
+		<Constant name="HybridSterY" value="[CFFrameSterY]-[tibmodpar:CFFrameDy]-[tibmodpar:HybridDy]"/>
+		<Constant name="PASterDx" value="0.5*63.680*mm"/>
+		<Constant name="PASterDz1" value="0.5*6.103*mm"/>
+		<Constant name="PASterDz2" value="[tibmodule0:PASterDz1]+[tibmodule0:PASterDx]*tan([tibmodpar:StereoAngle])"/>
+		<Constant name="PARPhiY" value="[tibmodule0:SpacerDy]+2*[tibmodpar:CFFrameDy]+[tibmodpar:PADy]"/>
+		<Constant name="PASterY" value="-[tibmodule0:SpacerDy]-2*[tibmodpar:CFFrameDy]-[tibmodpar:PADy]"/>
+		<Constant name="PASterX" value="5.927*mm"/>
+		<Constant name="PASterZ" value="[tibmodpar:ModuleDz]-2*[tibmodpar:HybridDz]-0.5*([tibmodule0:PASterDz1]+[tibmodule0:PASterDz2])"/>
+		<Constant name="LedgeSterDx" value="0.5*59.993*mm"/>
+		<Constant name="LedgeSterDy" value="0.5*([tibmodpar:DSModuleDy]-[tibmodule0:SpacerDy]-2.*[tibmodpar:CFFrameDy])"/>
+		<Constant name="LedgeSterDz1" value="[tibmodule0:LedgeSterDz2]+[tibmodule0:LedgeSterDx]*tan([tibmodpar:StereoAngle])"/>
+		<Constant name="LedgeSterDz2" value="1.600*mm"/>
+		<!-- Should be 2.200*mm, used 1.6*mm for weigth matching -->
+		<Constant name="LedgeSterY" value="-[tibmodpar:DSModuleDy]+[tibmodule0:LedgeSterDy]"/>
+		<Constant name="LedgeSterZ" value="[tibmodpar:ModuleDz]-0.5*[tibmodule0:LedgeSterDz1]-0.5*[tibmodule0:LedgeSterDz2]"/>
+		<Constant name="LedgeSideDx" value="0.5*([tibmodule0:SpacerHybDx]-[tibmodpar:HybridDx])"/>
+		<Constant name="LedgeSideDy" value="0.5*([tibmodpar:DSModuleDy]-[tibmodule0:SpacerDy])"/>
+		<Constant name="LedgeSideDz" value="12.00*mm"/>
+		<Constant name="LedgeSideX" value="[tibmodule0:SpacerHybDx]-[tibmodule0:LedgeSideDx]"/>
+		<Constant name="LedgeSideY" value="-[tibmodpar:DSModuleDy]+[tibmodule0:LedgeSideDy]"/>
+		<Constant name="LedgeSideZ" value="-[tibmodpar:ModuleDz]+[tibmodule0:LedgeSideDz]"/>
+		<Constant name="SpacerHybDx" value="[tibmodpar:CFFrameHybRPhiDx]"/>
+		<Constant name="SpacerHybDz" value="14.4*mm"/>
+		<Constant name="SpacerSideDx" value="4.00*mm"/>
+		<Constant name="SpacerSideDz" value="12.1*mm"/>
+		<Constant name="SpacerSideX" value="[SpacerHybDx]+[SpacerSideDx]"/>
+		<Constant name="SpacerSideZ" value="[tibmodpar:ModuleDz]-[SpacerSideDz]-25.8*mm"/>
+		<Constant name="SpacerLedgeDx" value="24.0*mm"/>
+		<Constant name="SpacerLedgeDz" value="4.00*mm"/>
+		<Constant name="SpacerLedgeZ" value="[tibmodpar:ModuleDz]-[SpacerLedgeDz]"/>
+		<Constant name="SpacerHybZ" value="[tibmodpar:ModuleDz]-[SpacerHybDz]"/>
+		<Constant name="ModCoolY" value="-0.1945*cm"/>
+		<Constant name="WaferRPhiY" value="1.135*mm"/>
+		<Constant name="WaferSterY" value="-1.135*mm"/>
+	</ConstantsSection>
+	<SolidSection label="tibmodule0.xml">
+		<Box name="TIBModCFFrameHybSter" dx="[tibmodule0:CFFrameHybSterDx]" dy="[tibmodpar:CFFrameDy]" dz="[tibmodpar:CFFrameHybDz]"/>
+		<Trapezoid name="TIBModKaptonBoxSter" dz="[tibmodpar:ModuleDx]" alp1="0*deg" bl1="[tibmodule0:KaptonBoxSterDz]" tl1="[tibmodule0:KaptonBoxSterDz]" h1="[tibmodpar:KaptonBoxDy]" alp2="0*deg" bl2="[tibmodule0:KaptonBoxSterDz]" tl2="[tibmodule0:KaptonBoxSterDz]" h2="[tibmodpar:KaptonBoxDy]" phi="0*deg" theta="-[tibmodpar:StereoAngle]"/>
+		<Trapezoid name="TIBPA2" dz="[tibmodule0:PASterDx]" alp1="0*deg" bl1="[tibmodule0:PASterDz1]" tl1="[tibmodule0:PASterDz1]" h1="[tibmodpar:PADy]" alp2="0*deg" bl2="[tibmodule0:PASterDz2]" tl2="[tibmodule0:PASterDz2]" h2="[tibmodpar:PADy]" phi="0*deg" theta="-[tibmodpar:TrapSterTheta]"/>
+		<Trapezoid name="TIBLedgeSter" dz="[LedgeSterDx]" alp1="0*deg" bl1="[LedgeSterDz1]" tl1="[LedgeSterDz1]" h1="[LedgeSterDy]" alp2="0*deg" bl2="[LedgeSterDz2]" tl2="[LedgeSterDz2]" h2="[LedgeSterDy]" phi="0*deg" theta="-[tibmodpar:TrapSterTheta]"/>
+		<Box name="TIBLedgeSide" dx="[tibmodule0:LedgeSideDx]" dy="[tibmodule0:LedgeSideDy]" dz="[tibmodule0:LedgeSideDz]"/>
+		<Box name="TIBSpacerLedge" dx="[SpacerLedgeDx]" dy="[SpacerDy]" dz="[SpacerLedgeDz]"/>
+		<Box name="TIBSpacerHyb" dx="[SpacerHybDx]" dy="[SpacerDy]" dz="[SpacerHybDz]"/>
+		<Box name="TIBSpacerSide" dx="[SpacerSideDx]" dy="[SpacerDy]" dz="[SpacerSideDz]"/>
+	</SolidSection>
+	<LogicalPartSection label="tibmodule0.xml">
+		<LogicalPart name="TIBModCFFrameSter" category="unspecified">
+			<rSolid name="tibmodpar:TIBModCFFrame"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TIBModCFFrameHybSter" category="unspecified">
+			<rSolid name="tibmodule0:TIBModCFFrameHybSter"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TIBHybrid0" category="unspecified">
+			<rSolid name="tibmodpar:TIBHybrid"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_Hybrid"/>
+		</LogicalPart>
+		<LogicalPart name="TIBModKaptonBoxSter" category="unspecified">
+			<rSolid name="tibmodule0:TIBModKaptonBoxSter"/>
+			<rMaterial name="tibmaterial:TIB_ModKaptonBox"/>
+		</LogicalPart>
+		<LogicalPart name="TIBPA2" category="unspecified">
+			<rSolid name="tibmodule0:TIBPA2"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_PA"/>
+		</LogicalPart>
+		<LogicalPart name="TIBLedgeSter" category="unspecified">
+			<rSolid name="tibmodule0:TIBLedgeSter"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="TIBSpacerLedge" category="unspecified">
+			<rSolid name="tibmodule0:TIBSpacerLedge"/>
+			<rMaterial name="tibmaterial:TIB_Spacer"/>
+		</LogicalPart>
+		<LogicalPart name="TIBLedgeSide" category="unspecified">
+			<rSolid name="tibmodule0:TIBLedgeSide"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="TIBSpacerHyb" category="unspecified">
+			<rSolid name="tibmodule0:TIBSpacerHyb"/>
+			<rMaterial name="tibmaterial:TIB_Spacer"/>
+		</LogicalPart>
+		<LogicalPart name="TIBSpacerSide" category="unspecified">
+			<rSolid name="tibmodule0:TIBSpacerSide"/>
+			<rMaterial name="tibmaterial:TIB_Spacer"/>
+		</LogicalPart>
+		<LogicalPart name="TIBWaferRphi0" category="unspecified">
+			<rSolid name="tibmodpar:TIBDSWafer"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="TIBActiveRphi0" category="unspecified">
+			<rSolid name="tibmodpar:TIBDSActive"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="TIBWaferSter0" category="unspecified">
+			<rSolid name="tibmodpar:TIBDSWafer"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="TIBActiveSter0" category="unspecified">
+			<rSolid name="tibmodpar:TIBDSActive"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tibmodule0.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0:TIBWaferRphi0"/>
+			<rChild name="tibmodule0:TIBActiveRphi0"/>
+			<Translation x="[zero]" y="[zero]" z="[tracker:BackPlaneDz]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0:TIBWaferSter0"/>
+			<rChild name="tibmodule0:TIBActiveSter0"/>
+			<Translation x="[zero]" y="[zero]" z="[tracker:BackPlaneDz]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0:TIBModKaptonBoxSter"/>
+			<rChild name="tibmodpar:TIBModKaptonBoxHole"/>
+			<Translation x="[KaptonBoxHoleSterX]" y="[zero]" z="[KaptonBoxHoleSterZ]"/>
+			<rRotation name="tibmodpar:KaptonBoxHoleSterA"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0:TIBModCFFrameSter"/>
+			<rChild name="tibmodpar:TIBModCFFrameHole"/>
+			<rRotation name="tibmodpar:CFFrameHoleSterA"/>
+			<Translation x="sin([tibmodpar:StereoAngle])*[tibmodpar:CFFrameHoleOffset]" y="[zero]" z="[tibmodpar:CFFrameHoleZ]-cos([tibmodpar:StereoAngle])*[tibmodpar:CFFrameHoleOffset]"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibmodule0a.xml
+++ b/DetectorDescription/DDCMS/data/tibmodule0a.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tibmodule0a.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tibmodule0a.xml">
+		<LogicalPart name="TIBModule0A" category="unspecified">
+			<rSolid name="tibmodpar:TIBDSModule"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tibmodule0a.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBWaferRphi0"/>
+			<rRotation name="tibmodpar:Rphi"/>
+			<Translation x="[zero]" y="[tibmodule0:WaferRPhiY]" z="[tibmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBWaferSter0"/>
+			<rRotation name="tibmodpar:SterA"/>
+			<Translation x="[zero]" y="[tibmodule0:WaferSterY]" z="[tibmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBHybrid0"/>
+			<Translation x="[zero]" y="[tibmodule0:HybridRPhiY]" z="-[tibmodpar:HybridZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBHybrid0"/>
+			<Translation x="[zero]" y="[tibmodule0:HybridSterY]" z="-[tibmodpar:HybridZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodpar:TIBPA1"/>
+			<Translation x="[zero]" y="[tibmodule0:PARPhiY]" z="-[tibmodpar:PAZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBPA2"/>
+			<rRotation name="tibmodpar:PAA"/>
+			<Translation x="[tibmodule0:PASterX]" y="[tibmodule0:PASterY]" z="-[tibmodule0:PASterZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBLedgeSter"/>
+			<rRotation name="tibmodpar:PAA"/>
+			<Translation x="[zero]" y="[tibmodule0:LedgeSterY]" z="[tibmodule0:LedgeSterZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBLedgeSide"/>
+			<Translation x="[tibmodule0:LedgeSideX]" y="[tibmodule0:LedgeSideY]" z="[tibmodule0:LedgeSideZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBLedgeSide"/>
+			<Translation x="-[tibmodule0:LedgeSideX]" y="[tibmodule0:LedgeSideY]" z="[tibmodule0:LedgeSideZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBSpacerLedge"/>
+			<Translation x="[zero]" y="[tibmodule0:SpacerY]" z="[tibmodule0:SpacerLedgeZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBSpacerHyb"/>
+			<Translation x="[zero]" y="[tibmodule0:SpacerY]" z="-[tibmodule0:SpacerHybZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBSpacerSide"/>
+			<Translation x="[tibmodule0:SpacerSideX]" y="[tibmodule0:SpacerY]" z="-[tibmodule0:SpacerSideZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBSpacerSide"/>
+			<Translation x="-[tibmodule0:SpacerSideX]" y="[tibmodule0:SpacerY]" z="-[tibmodule0:SpacerSideZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodpar:TIBModCFFrameRPhi"/>
+			<Translation x="[zero]" y="[tibmodule0:CFFrameRPhiY]" z="[tibmodpar:CFFrameZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodpar:TIBModCFFrameHybRPhi"/>
+			<Translation x="[zero]" y="[tibmodule0:CFFrameRPhiY]" z="[tibmodpar:CFFrameHybZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodpar:TIBModKaptonBoxRPhi"/>
+			<Translation x="[zero]" y="[tibmodule0:KaptonBoxRPhiY]" z="[tibmodpar:KaptonBoxZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBModCFFrameSter"/>
+			<Translation x="[zero]" y="[tibmodule0:CFFrameSterY]" z="[tibmodpar:CFFrameZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBModCFFrameHybSter"/>
+			<Translation x="[zero]" y="[tibmodule0:CFFrameSterY]" z="[tibmodpar:CFFrameHybZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0a:TIBModule0A"/>
+			<rChild name="tibmodule0:TIBModKaptonBoxSter"/>
+			<rRotation name="tibmodpar:PAA"/>
+			<Translation x="[zero]" y="[tibmodule0:KaptonBoxSterY]" z="[tibmodpar:WaferZ]+cos([tibmodpar:StereoAngle])*0.5*[tibmodule0:KaptonBoxSterOffset]"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibmodule0b.xml
+++ b/DetectorDescription/DDCMS/data/tibmodule0b.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tibmodule0b.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tibmodule0b.xml">
+		<LogicalPart name="TIBModule0B" category="unspecified">
+			<rSolid name="tibmodpar:TIBDSModule"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tibmodule0b.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBWaferRphi0"/>
+			<rRotation name="tibmodpar:Rphi"/>
+			<Translation x="[zero]" y="[tibmodule0:WaferRPhiY]" z="[tibmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBWaferSter0"/>
+			<rRotation name="tibmodpar:SterB"/>
+			<Translation x="[zero]" y="[tibmodule0:WaferSterY]" z="[tibmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBHybrid0"/>
+			<Translation x="[zero]" y="[tibmodule0:HybridRPhiY]" z="-[tibmodpar:HybridZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBHybrid0"/>
+			<Translation x="[zero]" y="[tibmodule0:HybridSterY]" z="-[tibmodpar:HybridZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodpar:TIBPA1"/>
+			<Translation x="[zero]" y="[tibmodule0:PARPhiY]" z="-[tibmodpar:PAZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBPA2"/>
+			<rRotation name="tibmodpar:PAB"/>
+			<Translation x="-[tibmodule0:PASterX]" y="[tibmodule0:PASterY]" z="-[tibmodule0:PASterZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBLedgeSter"/>
+			<rRotation name="tibmodpar:PAB"/>
+			<Translation x="[zero]" y="[tibmodule0:LedgeSterY]" z="[tibmodule0:LedgeSterZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBLedgeSide"/>
+			<Translation x="[tibmodule0:LedgeSideX]" y="[tibmodule0:LedgeSideY]" z="[tibmodule0:LedgeSideZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBLedgeSide"/>
+			<Translation x="-[tibmodule0:LedgeSideX]" y="[tibmodule0:LedgeSideY]" z="[tibmodule0:LedgeSideZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBSpacerLedge"/>
+			<Translation x="[zero]" y="[tibmodule0:SpacerY]" z="[tibmodule0:SpacerLedgeZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBSpacerHyb"/>
+			<Translation x="[zero]" y="[tibmodule0:SpacerY]" z="-[tibmodule0:SpacerHybZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBSpacerSide"/>
+			<Translation x="[tibmodule0:SpacerSideX]" y="[tibmodule0:SpacerY]" z="-[tibmodule0:SpacerSideZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBSpacerSide"/>
+			<Translation x="-[tibmodule0:SpacerSideX]" y="[tibmodule0:SpacerY]" z="-[tibmodule0:SpacerSideZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodpar:TIBModCFFrameRPhi"/>
+			<Translation x="[zero]" y="[tibmodule0:CFFrameRPhiY]" z="[tibmodpar:CFFrameZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodpar:TIBModCFFrameHybRPhi"/>
+			<Translation x="[zero]" y="[tibmodule0:CFFrameRPhiY]" z="[tibmodpar:CFFrameHybZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodpar:TIBModKaptonBoxRPhi"/>
+			<Translation x="[zero]" y="[tibmodule0:KaptonBoxRPhiY]" z="[tibmodpar:KaptonBoxZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBModCFFrameSter"/>
+			<Translation x="[zero]" y="[tibmodule0:CFFrameSterY]" z="[tibmodpar:CFFrameZ]"/>
+			<rRotation name="tibmodpar:CFFrameSterB"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBModCFFrameHybSter"/>
+			<Translation x="[zero]" y="[tibmodule0:CFFrameSterY]" z="[tibmodpar:CFFrameHybZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule0b:TIBModule0B"/>
+			<rChild name="tibmodule0:TIBModKaptonBoxSter"/>
+			<rRotation name="tibmodpar:PAB"/>
+			<Translation x="[zero]" y="[tibmodule0:KaptonBoxSterY]" z="[tibmodpar:WaferZ]+cos([tibmodpar:StereoAngle])*0.5*[tibmodule0:KaptonBoxSterOffset]"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibmodule2.xml
+++ b/DetectorDescription/DDCMS/data/tibmodule2.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tibmodule2.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="HybridY" value="[CFFrameY]+[tibmodpar:CFFrameDy]+[tibmodpar:HybridDy]"/>
+		<Constant name="PAY" value="[CFFrameY]+[tibmodpar:CFFrameDy]+[tibmodpar:PADy]"/>
+		<Constant name="CFFrameY" value="-[tibmodpar:SSModuleDy]+[tibmodpar:CFFrameDy]"/>
+		<Constant name="KaptonBoxY" value="[CFFrameY]+[tibmodpar:CFFrameDy]+[tibmodpar:KaptonBoxDy]"/>
+		<Constant name="WaferY" value="-0.140*mm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tibmodule2.xml">
+		<LogicalPart name="TIBModule2" category="unspecified">
+			<rSolid name="tibmodpar:TIBSSModule"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIBHybrid2" category="unspecified">
+			<rSolid name="tibmodpar:TIBHybrid"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_Hybrid"/>
+		</LogicalPart>
+		<LogicalPart name="TIBWaferRphi2" category="unspecified">
+			<rSolid name="tibmodpar:TIBSSWafer"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="TIBActiveRphi2" category="unspecified">
+			<rSolid name="tibmodpar:TIBSSActive"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tibmodule2.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule2:TIBWaferRphi2"/>
+			<rChild name="tibmodule2:TIBActiveRphi2"/>
+			<Translation x="[zero]" y="[zero]" z="[tracker:BackPlaneDz]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule2:TIBModule2"/>
+			<rChild name="tibmodule2:TIBWaferRphi2"/>
+			<rRotation name="tibmodpar:Rphi"/>
+			<Translation x="[zero]" y="[tibmodule2:WaferY]" z="[tibmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule2:TIBModule2"/>
+			<rChild name="tibmodule2:TIBHybrid2"/>
+			<Translation x="[zero]" y="[tibmodule2:HybridY]" z="-[tibmodpar:HybridZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule2:TIBModule2"/>
+			<rChild name="tibmodpar:TIBPA1"/>
+			<Translation x="[zero]" y="[tibmodule2:PAY]" z="-[tibmodpar:PAZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule2:TIBModule2"/>
+			<rChild name="tibmodpar:TIBModCFFrameRPhi"/>
+			<Translation x="[zero]" y="[tibmodule2:CFFrameY]" z="[tibmodpar:CFFrameZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule2:TIBModule2"/>
+			<rChild name="tibmodpar:TIBModCFFrameHybRPhi"/>
+			<Translation x="[zero]" y="[tibmodule2:CFFrameY]" z="[tibmodpar:CFFrameHybZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibmodule2:TIBModule2"/>
+			<rChild name="tibmodpar:TIBModKaptonBoxRPhi"/>
+			<Translation x="[zero]" y="[tibmodule2:KaptonBoxY]" z="[tibmodpar:KaptonBoxZ]"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring0.xml
+++ b/DetectorDescription/DDCMS/data/tibstring0.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tibstring0.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="StringIntOff" value="36.74*mm"/>
+		<Constant name="StringExtOff" value="-11.89*mm"/>
+		<Constant name="StringLoMinL" value="0.5*[tibstringpar:StringL]+[StringIntOff]"/>
+		<Constant name="StringUpMinL" value="0.5*[tibstringpar:StringL]+[StringExtOff]"/>
+		<Constant name="StringLoPlsL" value="0.5*[tibstringpar:StringL]-[StringIntOff]"/>
+		<Constant name="StringUpPlsL" value="0.5*[tibstringpar:StringL]-[StringExtOff]"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tibstring0.xml">
+		<LogicalPart name="TIBString0Lo1" category="unspecified">
+			<rSolid name="tibstringpar:TIBDSString1"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIBString0Up1" category="unspecified">
+			<rSolid name="tibstringpar:TIBDSString1"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tibstring0.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tibstring0:TIBString0Lo1"/>
+			<rChild name="tibstring0ll:TIBString0LoMin1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tibstring0:StringLoPlsL]/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibstring0:TIBString0Lo1"/>
+			<rChild name="tibstring0lr:TIBString0LoPls1"/>
+			<Translation x="[zero]" y="[zero]" z="[tibstring0:StringLoMinL]/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibstring0:TIBString0Up1"/>
+			<rChild name="tibstring0ul:TIBString0UpMin1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tibstring0:StringUpPlsL]/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibstring0:TIBString0Up1"/>
+			<rChild name="tibstring0ur:TIBString0UpPls1"/>
+			<Translation x="[zero]" y="[zero]" z="[tibstring0:StringUpMinL]/2"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring0ll.xml
+++ b/DetectorDescription/DDCMS/data/tibstring0ll.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 1 INT BW -->
+    <ConstantsSection label="tibstring0ll.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:BWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:INT1Sign]"/>
+        <Constant name="MotherCableL" value="59.91*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring0:StringLoMinL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]+24.88*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="-447.355*mm"/>
+        <Constant name="Det1Z" value="-242.709*mm"/>
+        <Constant name="Det2Z" value="-36.9380*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring0ll.xml">
+        <Box name="TIBString0LoMinCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString0LoMinMainPart" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:DSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString0LoMinSideCut" dx="[tibmodpar:DSModuleSideCutDx]" dy="[tibmodpar:DSModuleSideCutDy]" dz="[ThisStringL]/2+[tibmodpar:SideCutExtraZ]"/>
+        <Box name="TIBString0LoMinCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:DSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <SubtractionSolid name="TIBString0LoMinLeftCutted">
+            <rSolid name="TIBString0LoMinMainPart"/>
+            <rSolid name="TIBString0LoMinSideCut"/>
+            <Translation x="-[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="TIBString0LoMinModuleBox">
+            <rSolid name="TIBString0LoMinLeftCutted"/>
+            <rSolid name="TIBString0LoMinSideCut"/>
+            <Translation x="[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <UnionSolid name="TIBString0LoMinModAndCool">
+            <rSolid name="TIBString0LoMinModuleBox"/>
+            <rSolid name="TIBString0LoMinCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString0LoMin">
+            <rSolid name="TIBString0LoMinModAndCool"/>
+            <rSolid name="TIBString0LoMinCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString0LoMinCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString0LoMinCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString0LoMinCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring0ll.xml">
+        <LogicalPart name="TIBString0LoMin1" category="unspecified">
+            <rSolid name="TIBString0LoMin"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString0LoMinCable" category="unspecified">
+            <rSolid name="TIBString0LoMinCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString0LoMinCoolS" category="unspecified">
+            <rSolid name="TIBString0LoMinCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString0LoMinCoolW" category="unspecified">
+            <rSolid name="TIBString0LoMinCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring0ll:TIBString0LoMin1"/>
+        <String name="ChildName" value="tibmodule0b:TIBModule0B"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring0ll.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0ll:TIBString0LoMin1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:DSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0ll:TIBString0LoMin1"/>
+            <rChild name="tibstring0ll:TIBString0LoMinCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:DSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0ll:TIBString0LoMin1"/>
+            <rChild name="tibstring0ll:TIBString0LoMinCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring0ll:TIBString0LoMin1"/>
+            <rChild name="tibstring0ll:TIBString0LoMinCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0ll:TIBString0LoMin1"/>
+            <rChild name="tibstring0ll:TIBString0LoMinCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0ll:TIBString0LoMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0ll:TIBString0LoMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0ll:TIBString0LoMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBDSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0ll:TIBString0LoMin1"/>
+        <String name="ChildName" value="tibstringpar:DSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring0lr.xml
+++ b/DetectorDescription/DDCMS/data/tibstring0lr.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 1 INT FW -->
+    <ConstantsSection label="tibstring0lr.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:FWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:INT1Sign]"/>
+        <Constant name="MotherCableL" value="67.55*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring0:StringLoPlsL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]-39.50*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="169.080*mm"/>
+        <Constant name="Det1Z" value="374.129*mm"/>
+        <Constant name="Det2Z" value="578.058*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring0lr.xml">
+        <Box name="TIBString0LoPlsCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString0LoPlsMainPart" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:DSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString0LoPlsSideCut" dx="[tibmodpar:DSModuleSideCutDx]" dy="[tibmodpar:DSModuleSideCutDy]" dz="[ThisStringL]/2+[tibmodpar:SideCutExtraZ]"/>
+        <Box name="TIBString0LoPlsCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:DSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <SubtractionSolid name="TIBString0LoPlsLeftCutted">
+            <rSolid name="TIBString0LoPlsMainPart"/>
+            <rSolid name="TIBString0LoPlsSideCut"/>
+            <Translation x="-[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="TIBString0LoPlsModuleBox">
+            <rSolid name="TIBString0LoPlsLeftCutted"/>
+            <rSolid name="TIBString0LoPlsSideCut"/>
+            <Translation x="[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <UnionSolid name="TIBString0LoPlsModAndCool">
+            <rSolid name="TIBString0LoPlsModuleBox"/>
+            <rSolid name="TIBString0LoPlsCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString0LoPls">
+            <rSolid name="TIBString0LoPlsModAndCool"/>
+            <rSolid name="TIBString0LoPlsCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString0LoPlsCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString0LoPlsCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString0LoPlsCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring0lr.xml">
+        <LogicalPart name="TIBString0LoPls1" category="unspecified">
+            <rSolid name="TIBString0LoPls"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString0LoPlsCable" category="unspecified">
+            <rSolid name="TIBString0LoPlsCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString0LoPlsCoolS" category="unspecified">
+            <rSolid name="TIBString0LoPlsCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString0LoPlsCoolW" category="unspecified">
+            <rSolid name="TIBString0LoPlsCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring0lr:TIBString0LoPls1"/>
+        <String name="ChildName" value="tibmodule0b:TIBModule0B"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring0lr.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0lr:TIBString0LoPls1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:DSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0lr:TIBString0LoPls1"/>
+            <rChild name="tibstring0lr:TIBString0LoPlsCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:DSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0lr:TIBString0LoPls1"/>
+            <rChild name="tibstring0lr:TIBString0LoPlsCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring0lr:TIBString0LoPls1"/>
+            <rChild name="tibstring0lr:TIBString0LoPlsCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0lr:TIBString0LoPls1"/>
+            <rChild name="tibstring0lr:TIBString0LoPlsCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0lr:TIBString0LoPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0lr:TIBString0LoPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0lr:TIBString0LoPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBDSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0lr:TIBString0LoPls1"/>
+        <String name="ChildName" value="tibstringpar:DSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring0ul.xml
+++ b/DetectorDescription/DDCMS/data/tibstring0ul.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 1 EXT BW -->
+    <ConstantsSection label="tibstring0ul.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:BWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:EXT1Sign]"/>
+        <Constant name="MotherCableL" value="68.84*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring0:StringUpMinL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]-28.77*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="-605.456*mm"/>
+        <Constant name="Det1Z" value="-394.872*mm"/>
+        <Constant name="Det2Z" value="-160.198*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring0ul.xml">
+        <Box name="TIBString0UpMinCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString0UpMinMainPart" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:DSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString0UpMinSideCut" dx="[tibmodpar:DSModuleSideCutDx]" dy="[tibmodpar:DSModuleSideCutDy]" dz="[ThisStringL]/2+[tibmodpar:SideCutExtraZ]"/>
+        <Box name="TIBString0UpMinCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:DSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <SubtractionSolid name="TIBString0UpMinLeftCutted">
+            <rSolid name="TIBString0UpMinMainPart"/>
+            <rSolid name="TIBString0UpMinSideCut"/>
+            <Translation x="-[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="TIBString0UpMinModuleBox">
+            <rSolid name="TIBString0UpMinLeftCutted"/>
+            <rSolid name="TIBString0UpMinSideCut"/>
+            <Translation x="[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <UnionSolid name="TIBString0UpMinModAndCool">
+            <rSolid name="TIBString0UpMinModuleBox"/>
+            <rSolid name="TIBString0UpMinCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString0UpMin">
+            <rSolid name="TIBString0UpMinModAndCool"/>
+            <rSolid name="TIBString0UpMinCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString0UpMinCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString0UpMinCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString0UpMinCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring0ul.xml">
+        <LogicalPart name="TIBString0UpMin1" category="unspecified">
+            <rSolid name="TIBString0UpMin"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString0UpMinCable" category="unspecified">
+            <rSolid name="TIBString0UpMinCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString0UpMinCoolS" category="unspecified">
+            <rSolid name="TIBString0UpMinCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString0UpMinCoolW" category="unspecified">
+            <rSolid name="TIBString0UpMinCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring0ul:TIBString0UpMin1"/>
+        <String name="ChildName" value="tibmodule0a:TIBModule0A"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring0ul.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0ul:TIBString0UpMin1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:DSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0ul:TIBString0UpMin1"/>
+            <rChild name="tibstring0ul:TIBString0UpMinCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:DSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0ul:TIBString0UpMin1"/>
+            <rChild name="tibstring0ul:TIBString0UpMinCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring0ul:TIBString0UpMin1"/>
+            <rChild name="tibstring0ul:TIBString0UpMinCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0ul:TIBString0UpMin1"/>
+            <rChild name="tibstring0ul:TIBString0UpMinCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0ul:TIBString0UpMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0ul:TIBString0UpMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0ul:TIBString0UpMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBDSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0ul:TIBString0UpMin1"/>
+        <String name="ChildName" value="tibstringpar:DSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring0ur.xml
+++ b/DetectorDescription/DDCMS/data/tibstring0ur.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 1 EXT FW -->
+    <ConstantsSection label="tibstring0ur.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:FWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:EXT1Sign]"/>
+        <Constant name="MotherCableL" value="56.02*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring0:StringUpPlsL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]-14.07*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="75.7660*mm"/>
+        <Constant name="Det1Z" value="310.901*mm"/>
+        <Constant name="Det2Z" value="544.753*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring0ur.xml">
+        <Box name="TIBString0UpPlsCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString0UpPlsMainPart" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:DSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString0UpPlsSideCut" dx="[tibmodpar:DSModuleSideCutDx]" dy="[tibmodpar:DSModuleSideCutDy]" dz="[ThisStringL]/2+[tibmodpar:SideCutExtraZ]"/>
+        <Box name="TIBString0UpPlsCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:DSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <SubtractionSolid name="TIBString0UpPlsLeftCutted">
+            <rSolid name="TIBString0UpPlsMainPart"/>
+            <rSolid name="TIBString0UpPlsSideCut"/>
+            <Translation x="-[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="TIBString0UpPlsModuleBox">
+            <rSolid name="TIBString0UpPlsLeftCutted"/>
+            <rSolid name="TIBString0UpPlsSideCut"/>
+            <Translation x="[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <UnionSolid name="TIBString0UpPlsModAndCool">
+            <rSolid name="TIBString0UpPlsModuleBox"/>
+            <rSolid name="TIBString0UpPlsCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString0UpPls">
+            <rSolid name="TIBString0UpPlsModAndCool"/>
+            <rSolid name="TIBString0UpPlsCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString0UpPlsCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString0UpPlsCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString0UpPlsCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring0ur.xml">
+        <LogicalPart name="TIBString0UpPls1" category="unspecified">
+            <rSolid name="TIBString0UpPls"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString0UpPlsCable" category="unspecified">
+            <rSolid name="TIBString0UpPlsCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString0UpPlsCoolS" category="unspecified">
+            <rSolid name="TIBString0UpPlsCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString0UpPlsCoolW" category="unspecified">
+            <rSolid name="TIBString0UpPlsCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring0ur:TIBString0UpPls1"/>
+        <String name="ChildName" value="tibmodule0a:TIBModule0A"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring0ur.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0ur:TIBString0UpPls1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:DSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0ur:TIBString0UpPls1"/>
+            <rChild name="tibstring0ur:TIBString0UpPlsCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:DSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0ur:TIBString0UpPls1"/>
+            <rChild name="tibstring0ur:TIBString0UpPlsCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring0ur:TIBString0UpPls1"/>
+            <rChild name="tibstring0ur:TIBString0UpPlsCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring0ur:TIBString0UpPls1"/>
+            <rChild name="tibstring0ur:TIBString0UpPlsCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0ur:TIBString0UpPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0ur:TIBString0UpPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0ur:TIBString0UpPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBDSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring0ur:TIBString0UpPls1"/>
+        <String name="ChildName" value="tibstringpar:DSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring1.xml
+++ b/DetectorDescription/DDCMS/data/tibstring1.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tibstring1.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="StringIntOff" value="-45.15*mm"/>
+		<Constant name="StringExtOff" value="-2.35*mm"/>
+		<Constant name="StringLoMinL" value="0.5*[tibstringpar:StringL]+[StringIntOff]"/>
+		<Constant name="StringUpMinL" value="0.5*[tibstringpar:StringL]+[StringExtOff]"/>
+		<Constant name="StringLoPlsL" value="0.5*[tibstringpar:StringL]-[StringIntOff]"/>
+		<Constant name="StringUpPlsL" value="0.5*[tibstringpar:StringL]-[StringExtOff]"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tibstring1.xml">
+		<LogicalPart name="TIBString1Lo1" category="unspecified">
+			<rSolid name="tibstringpar:TIBDSString1"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIBString1Up1" category="unspecified">
+			<rSolid name="tibstringpar:TIBDSString1"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tibstring1.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tibstring1:TIBString1Lo1"/>
+			<rChild name="tibstring1ll:TIBString1LoMin1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tibstring1:StringLoPlsL]/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibstring1:TIBString1Lo1"/>
+			<rChild name="tibstring1lr:TIBString1LoPls1"/>
+			<Translation x="[zero]" y="[zero]" z="[tibstring1:StringLoMinL]/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibstring1:TIBString1Up1"/>
+			<rChild name="tibstring1ul:TIBString1UpMin1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tibstring1:StringUpPlsL]/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibstring1:TIBString1Up1"/>
+			<rChild name="tibstring1ur:TIBString1UpPls1"/>
+			<Translation x="[zero]" y="[zero]" z="[tibstring1:StringUpMinL]/2"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring1ll.xml
+++ b/DetectorDescription/DDCMS/data/tibstring1ll.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 2 INT BW -->
+    <ConstantsSection label="tibstring1ll.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:BWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:INT2Sign]"/>
+        <Constant name="MotherCableL" value="66.84*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring1:StringLoMinL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]-49.14*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="-597.651*mm"/>
+        <Constant name="Det1Z" value="-389.269*mm"/>
+        <Constant name="Det2Z" value="-180.228*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring1ll.xml">
+        <Box name="TIBString1LoMinCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString1LoMinMainPart" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:DSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString1LoMinSideCut" dx="[tibmodpar:DSModuleSideCutDx]" dy="[tibmodpar:DSModuleSideCutDy]" dz="[ThisStringL]/2+[tibmodpar:SideCutExtraZ]"/>
+        <Box name="TIBString1LoMinCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:DSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <SubtractionSolid name="TIBString1LoMinLeftCutted">
+            <rSolid name="TIBString1LoMinMainPart"/>
+            <rSolid name="TIBString1LoMinSideCut"/>
+            <Translation x="-[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="TIBString1LoMinModuleBox">
+            <rSolid name="TIBString1LoMinLeftCutted"/>
+            <rSolid name="TIBString1LoMinSideCut"/>
+            <Translation x="[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <UnionSolid name="TIBString1LoMinModAndCool">
+            <rSolid name="TIBString1LoMinModuleBox"/>
+            <rSolid name="TIBString1LoMinCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString1LoMin">
+            <rSolid name="TIBString1LoMinModAndCool"/>
+            <rSolid name="TIBString1LoMinCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString1LoMinCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString1LoMinCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString1LoMinCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring1ll.xml">
+        <LogicalPart name="TIBString1LoMin1" category="unspecified">
+            <rSolid name="TIBString1LoMin"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString1LoMinCable" category="unspecified">
+            <rSolid name="TIBString1LoMinCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString1LoMinCoolS" category="unspecified">
+            <rSolid name="TIBString1LoMinCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString1LoMinCoolW" category="unspecified">
+            <rSolid name="TIBString1LoMinCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring1ll:TIBString1LoMin1"/>
+        <String name="ChildName" value="tibmodule0a:TIBModule0A"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring1ll.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1ll:TIBString1LoMin1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:DSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1ll:TIBString1LoMin1"/>
+            <rChild name="tibstring1ll:TIBString1LoMinCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:DSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1ll:TIBString1LoMin1"/>
+            <rChild name="tibstring1ll:TIBString1LoMinCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring1ll:TIBString1LoMin1"/>
+            <rChild name="tibstring1ll:TIBString1LoMinCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1ll:TIBString1LoMin1"/>
+            <rChild name="tibstring1ll:TIBString1LoMinCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1ll:TIBString1LoMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1ll:TIBString1LoMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1ll:TIBString1LoMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBDSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1ll:TIBString1LoMin1"/>
+        <String name="ChildName" value="tibstringpar:DSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring1lr.xml
+++ b/DetectorDescription/DDCMS/data/tibstring1lr.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 2 INT FW -->
+    <ConstantsSection label="tibstring1lr.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:FWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:INT2Sign]"/>
+        <Constant name="MotherCableL" value="60.68*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring1:StringLoPlsL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]+32.44*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="29.3600*mm"/>
+        <Constant name="Det1Z" value="238.876*mm"/>
+        <Constant name="Det2Z" value="447.732*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring1lr.xml">
+        <Box name="TIBString1LoPlsCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString1LoPlsMainPart" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:DSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString1LoPlsSideCut" dx="[tibmodpar:DSModuleSideCutDx]" dy="[tibmodpar:DSModuleSideCutDy]" dz="[ThisStringL]/2+[tibmodpar:SideCutExtraZ]"/>
+        <Box name="TIBString1LoPlsCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:DSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <SubtractionSolid name="TIBString1LoPlsLeftCutted">
+            <rSolid name="TIBString1LoPlsMainPart"/>
+            <rSolid name="TIBString1LoPlsSideCut"/>
+            <Translation x="-[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="TIBString1LoPlsModuleBox">
+            <rSolid name="TIBString1LoPlsLeftCutted"/>
+            <rSolid name="TIBString1LoPlsSideCut"/>
+            <Translation x="[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <UnionSolid name="TIBString1LoPlsModAndCool">
+            <rSolid name="TIBString1LoPlsModuleBox"/>
+            <rSolid name="TIBString1LoPlsCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString1LoPls">
+            <rSolid name="TIBString1LoPlsModAndCool"/>
+            <rSolid name="TIBString1LoPlsCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString1LoPlsCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString1LoPlsCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString1LoPlsCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring1lr.xml">
+        <LogicalPart name="TIBString1LoPls1" category="unspecified">
+            <rSolid name="TIBString1LoPls"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString1LoPlsCable" category="unspecified">
+            <rSolid name="TIBString1LoPlsCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString1LoPlsCoolS" category="unspecified">
+            <rSolid name="TIBString1LoPlsCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString1LoPlsCoolW" category="unspecified">
+            <rSolid name="TIBString1LoPlsCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring1lr:TIBString1LoPls1"/>
+        <String name="ChildName" value="tibmodule0a:TIBModule0A"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring1lr.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1lr:TIBString1LoPls1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:DSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1lr:TIBString1LoPls1"/>
+            <rChild name="tibstring1lr:TIBString1LoPlsCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:DSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1lr:TIBString1LoPls1"/>
+            <rChild name="tibstring1lr:TIBString1LoPlsCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring1lr:TIBString1LoPls1"/>
+            <rChild name="tibstring1lr:TIBString1LoPlsCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1lr:TIBString1LoPls1"/>
+            <rChild name="tibstring1lr:TIBString1LoPlsCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1lr:TIBString1LoPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1lr:TIBString1LoPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1lr:TIBString1LoPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBDSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1lr:TIBString1LoPls1"/>
+        <String name="ChildName" value="tibstringpar:DSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring1ul.xml
+++ b/DetectorDescription/DDCMS/data/tibstring1ul.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 2 EXT BW -->
+    <ConstantsSection label="tibstring1ul.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:BWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:EXT2Sign]"/>
+        <Constant name="MotherCableL" value="55.23*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring1:StringUpMinL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]-14.30*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="-546.373*mm"/>
+        <Constant name="Det1Z" value="-315.364*mm"/>
+        <Constant name="Det2Z" value="-83.6250*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring1ul.xml">
+        <Box name="TIBString1UpMinCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString1UpMinMainPart" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:DSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString1UpMinSideCut" dx="[tibmodpar:DSModuleSideCutDx]" dy="[tibmodpar:DSModuleSideCutDy]" dz="[ThisStringL]/2+[tibmodpar:SideCutExtraZ]"/>
+        <Box name="TIBString1UpMinCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:DSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <SubtractionSolid name="TIBString1UpMinLeftCutted">
+            <rSolid name="TIBString1UpMinMainPart"/>
+            <rSolid name="TIBString1UpMinSideCut"/>
+            <Translation x="-[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="TIBString1UpMinModuleBox">
+            <rSolid name="TIBString1UpMinLeftCutted"/>
+            <rSolid name="TIBString1UpMinSideCut"/>
+            <Translation x="[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <UnionSolid name="TIBString1UpMinModAndCool">
+            <rSolid name="TIBString1UpMinModuleBox"/>
+            <rSolid name="TIBString1UpMinCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString1UpMin">
+            <rSolid name="TIBString1UpMinModAndCool"/>
+            <rSolid name="TIBString1UpMinCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString1UpMinCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString1UpMinCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString1UpMinCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring1ul.xml">
+        <LogicalPart name="TIBString1UpMin1" category="unspecified">
+            <rSolid name="TIBString1UpMin"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString1UpMinCable" category="unspecified">
+            <rSolid name="TIBString1UpMinCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString1UpMinCoolS" category="unspecified">
+            <rSolid name="TIBString1UpMinCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString1UpMinCoolW" category="unspecified">
+            <rSolid name="TIBString1UpMinCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring1ul:TIBString1UpMin1"/>
+        <String name="ChildName" value="tibmodule0b:TIBModule0B"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring1ul.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1ul:TIBString1UpMin1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:DSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1ul:TIBString1UpMin1"/>
+            <rChild name="tibstring1ul:TIBString1UpMinCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:DSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1ul:TIBString1UpMin1"/>
+            <rChild name="tibstring1ul:TIBString1UpMinCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring1ul:TIBString1UpMin1"/>
+            <rChild name="tibstring1ul:TIBString1UpMinCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1ul:TIBString1UpMin1"/>
+            <rChild name="tibstring1ul:TIBString1UpMinCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1ul:TIBString1UpMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1ul:TIBString1UpMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1ul:TIBString1UpMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBDSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1ul:TIBString1UpMin1"/>
+        <String name="ChildName" value="tibstringpar:DSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring1ur.xml
+++ b/DetectorDescription/DDCMS/data/tibstring1ur.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 2 EXT FW -->
+    <ConstantsSection label="tibstring1ur.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:FWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:EXT2Sign]"/>
+        <Constant name="MotherCableL" value="70.00*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring1:StringUpPlsL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]-18.66*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="148.641*mm"/>
+        <Constant name="Det1Z" value="380.176*mm"/>
+        <Constant name="Det2Z" value="605.456*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring1ur.xml">
+        <Box name="TIBString1UpPlsCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString1UpPlsMainPart" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:DSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString1UpPlsSideCut" dx="[tibmodpar:DSModuleSideCutDx]" dy="[tibmodpar:DSModuleSideCutDy]" dz="[ThisStringL]/2+[tibmodpar:SideCutExtraZ]"/>
+        <Box name="TIBString1UpPlsCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:DSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <SubtractionSolid name="TIBString1UpPlsLeftCutted">
+            <rSolid name="TIBString1UpPlsMainPart"/>
+            <rSolid name="TIBString1UpPlsSideCut"/>
+            <Translation x="-[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <SubtractionSolid name="TIBString1UpPlsModuleBox">
+            <rSolid name="TIBString1UpPlsLeftCutted"/>
+            <rSolid name="TIBString1UpPlsSideCut"/>
+            <Translation x="[tibmodpar:DSModuleSideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="0."/>
+        </SubtractionSolid>
+        <UnionSolid name="TIBString1UpPlsModAndCool">
+            <rSolid name="TIBString1UpPlsModuleBox"/>
+            <rSolid name="TIBString1UpPlsCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString1UpPls">
+            <rSolid name="TIBString1UpPlsModAndCool"/>
+            <rSolid name="TIBString1UpPlsCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString1UpPlsCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString1UpPlsCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString1UpPlsCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring1ur.xml">
+        <LogicalPart name="TIBString1UpPls1" category="unspecified">
+            <rSolid name="TIBString1UpPls"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString1UpPlsCable" category="unspecified">
+            <rSolid name="TIBString1UpPlsCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString1UpPlsCoolS" category="unspecified">
+            <rSolid name="TIBString1UpPlsCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString1UpPlsCoolW" category="unspecified">
+            <rSolid name="TIBString1UpPlsCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring1ur:TIBString1UpPls1"/>
+        <String name="ChildName" value="tibmodule0b:TIBModule0B"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring1ur.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1ur:TIBString1UpPls1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:DSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1ur:TIBString1UpPls1"/>
+            <rChild name="tibstring1ur:TIBString1UpPlsCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:DSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1ur:TIBString1UpPls1"/>
+            <rChild name="tibstring1ur:TIBString1UpPlsCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring1ur:TIBString1UpPls1"/>
+            <rChild name="tibstring1ur:TIBString1UpPlsCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:DSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring1ur:TIBString1UpPls1"/>
+            <rChild name="tibstring1ur:TIBString1UpPlsCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:DSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1ur:TIBString1UpPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1ur:TIBString1UpPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY], [tibmodpar:DSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1ur:TIBString1UpPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBDSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY], [tibmodpar:DSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring1ur:TIBString1UpPls1"/>
+        <String name="ChildName" value="tibstringpar:DSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY], [tibstringpar:DSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring2.xml
+++ b/DetectorDescription/DDCMS/data/tibstring2.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tibstring2.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="StringIntOff" value="38.87*mm"/>
+		<Constant name="StringExtOff" value="-8.73*mm"/>
+		<Constant name="StringLoMinL" value="0.5*[tibstringpar:StringL]+[StringIntOff]"/>
+		<Constant name="StringUpMinL" value="0.5*[tibstringpar:StringL]+[StringExtOff]"/>
+		<Constant name="StringLoPlsL" value="0.5*[tibstringpar:StringL]-[StringIntOff]"/>
+		<Constant name="StringUpPlsL" value="0.5*[tibstringpar:StringL]-[StringExtOff]"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tibstring2.xml">
+		<LogicalPart name="TIBString2Lo1" category="unspecified">
+			<rSolid name="tibstringpar:TIBSSString1"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIBString2Up1" category="unspecified">
+			<rSolid name="tibstringpar:TIBSSString1"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tibstring2.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tibstring2:TIBString2Lo1"/>
+			<rChild name="tibstring2ll:TIBString2LoMin1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tibstring2:StringLoPlsL]/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibstring2:TIBString2Lo1"/>
+			<rChild name="tibstring2lr:TIBString2LoPls1"/>
+			<Translation x="[zero]" y="[zero]" z="[tibstring2:StringLoMinL]/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibstring2:TIBString2Up1"/>
+			<rChild name="tibstring2ul:TIBString2UpMin1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tibstring2:StringUpPlsL]/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibstring2:TIBString2Up1"/>
+			<rChild name="tibstring2ur:TIBString2UpPls1"/>
+			<Translation x="[zero]" y="[zero]" z="[tibstring2:StringUpMinL]/2"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring2ll.xml
+++ b/DetectorDescription/DDCMS/data/tibstring2ll.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 3 INT BW -->
+    <ConstantsSection label="tibstring2ll.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:BWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:INT3Sign]"/>
+        <Constant name="MotherCableL" value="59.99*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring2:StringLoMinL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]+24.93*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="-456.191*mm"/>
+        <Constant name="Det1Z" value="-246.263*mm"/>
+        <Constant name="Det2Z" value="-36.0950*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring2ll.xml">
+        <Box name="TIBString2LoMinCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString2LoMinModuleBox" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:SSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString2LoMinCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:SSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <UnionSolid name="TIBString2LoMinModAndCool">
+            <rSolid name="TIBString2LoMinModuleBox"/>
+            <rSolid name="TIBString2LoMinCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString2LoMin">
+            <rSolid name="TIBString2LoMinModAndCool"/>
+            <rSolid name="TIBString2LoMinCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString2LoMinCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString2LoMinCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString2LoMinCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring2ll.xml">
+        <LogicalPart name="TIBString2LoMin1" category="unspecified">
+            <rSolid name="TIBString2LoMin"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString2LoMinCable" category="unspecified">
+            <rSolid name="TIBString2LoMinCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString2LoMinCoolS" category="unspecified">
+            <rSolid name="TIBString2LoMinCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString2LoMinCoolW" category="unspecified">
+            <rSolid name="TIBString2LoMinCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring2ll:TIBString2LoMin1"/>
+        <String name="ChildName" value="tibmodule2:TIBModule2"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring2ll.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2ll:TIBString2LoMin1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:SSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2ll:TIBString2LoMin1"/>
+            <rChild name="tibstring2ll:TIBString2LoMinCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:SSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2ll:TIBString2LoMin1"/>
+            <rChild name="tibstring2ll:TIBString2LoMinCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring2ll:TIBString2LoMin1"/>
+            <rChild name="tibstring2ll:TIBString2LoMinCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2ll:TIBString2LoMin1"/>
+            <rChild name="tibstring2ll:TIBString2LoMinCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2ll:TIBString2LoMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2ll:TIBString2LoMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2ll:TIBString2LoMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBSSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2ll:TIBString2LoMin1"/>
+        <String name="ChildName" value="tibstringpar:SSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring2lr.xml
+++ b/DetectorDescription/DDCMS/data/tibstring2lr.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 3 INT FW -->
+    <ConstantsSection label="tibstring2lr.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:FWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:INT3Sign]"/>
+        <Constant name="MotherCableL" value="67.44*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring2:StringLoPlsL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]-42.72*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="174.198*mm"/>
+        <Constant name="Det1Z" value="384.254*mm"/>
+        <Constant name="Det2Z" value="593.937*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring2lr.xml">
+        <Box name="TIBString2LoPlsCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString2LoPlsModuleBox" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:SSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString2LoPlsCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:SSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <UnionSolid name="TIBString2LoPlsModAndCool">
+            <rSolid name="TIBString2LoPlsModuleBox"/>
+            <rSolid name="TIBString2LoPlsCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString2LoPls">
+            <rSolid name="TIBString2LoPlsModAndCool"/>
+            <rSolid name="TIBString2LoPlsCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString2LoPlsCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString2LoPlsCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString2LoPlsCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring2lr.xml">
+        <LogicalPart name="TIBString2LoPls1" category="unspecified">
+            <rSolid name="TIBString2LoPls"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString2LoPlsCable" category="unspecified">
+            <rSolid name="TIBString2LoPlsCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString2LoPlsCoolS" category="unspecified">
+            <rSolid name="TIBString2LoPlsCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString2LoPlsCoolW" category="unspecified">
+            <rSolid name="TIBString2LoPlsCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring2lr:TIBString2LoPls1"/>
+        <String name="ChildName" value="tibmodule2:TIBModule2"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring2lr.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2lr:TIBString2LoPls1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:SSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2lr:TIBString2LoPls1"/>
+            <rChild name="tibstring2lr:TIBString2LoPlsCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:SSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2lr:TIBString2LoPls1"/>
+            <rChild name="tibstring2lr:TIBString2LoPlsCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring2lr:TIBString2LoPls1"/>
+            <rChild name="tibstring2lr:TIBString2LoPlsCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2lr:TIBString2LoPls1"/>
+            <rChild name="tibstring2lr:TIBString2LoPlsCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2lr:TIBString2LoPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2lr:TIBString2LoPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2lr:TIBString2LoPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBSSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2lr:TIBString2LoPls1"/>
+        <String name="ChildName" value="tibstringpar:SSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring2ul.xml
+++ b/DetectorDescription/DDCMS/data/tibstring2ul.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 3 EXT BW -->
+    <ConstantsSection label="tibstring2ul.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:BWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:EXT3Sign]"/>
+        <Constant name="MotherCableL" value="69.60*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring2:StringUpMinL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]-20.57*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="-605.456*mm"/>
+        <Constant name="Det1Z" value="-379.133*mm"/>
+        <Constant name="Det2Z" value="-152.408*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring2ul.xml">
+        <Box name="TIBString2UpMinCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString2UpMinModuleBox" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:SSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString2UpMinCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:SSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <UnionSolid name="TIBString2UpMinModAndCool">
+            <rSolid name="TIBString2UpMinModuleBox"/>
+            <rSolid name="TIBString2UpMinCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString2UpMin">
+            <rSolid name="TIBString2UpMinModAndCool"/>
+            <rSolid name="TIBString2UpMinCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString2UpMinCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString2UpMinCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString2UpMinCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring2ul.xml">
+        <LogicalPart name="TIBString2UpMin1" category="unspecified">
+            <rSolid name="TIBString2UpMin"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString2UpMinCable" category="unspecified">
+            <rSolid name="TIBString2UpMinCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString2UpMinCoolS" category="unspecified">
+            <rSolid name="TIBString2UpMinCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString2UpMinCoolW" category="unspecified">
+            <rSolid name="TIBString2UpMinCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring2ul:TIBString2UpMin1"/>
+        <String name="ChildName" value="tibmodule2:TIBModule2"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring2ul.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2ul:TIBString2UpMin1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:SSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2ul:TIBString2UpMin1"/>
+            <rChild name="tibstring2ul:TIBString2UpMinCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:SSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2ul:TIBString2UpMin1"/>
+            <rChild name="tibstring2ul:TIBString2UpMinCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring2ul:TIBString2UpMin1"/>
+            <rChild name="tibstring2ul:TIBString2UpMinCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2ul:TIBString2UpMin1"/>
+            <rChild name="tibstring2ul:TIBString2UpMinCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2ul:TIBString2UpMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2ul:TIBString2UpMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2ul:TIBString2UpMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBSSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2ul:TIBString2UpMin1"/>
+        <String name="ChildName" value="tibstringpar:SSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring2ur.xml
+++ b/DetectorDescription/DDCMS/data/tibstring2ur.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 3 EXT FW -->
+    <ConstantsSection label="tibstring2ur.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:FWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:EXT3Sign]"/>
+        <Constant name="MotherCableL" value="56.14*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring2:StringUpPlsL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]-13.76*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="74.5760*mm"/>
+        <Constant name="Det1Z" value="301.441*mm"/>
+        <Constant name="Det2Z" value="527.901*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring2ur.xml">
+        <Box name="TIBString2UpPlsCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString2UpPlsModuleBox" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:SSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString2UpPlsCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:SSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <UnionSolid name="TIBString2UpPlsModAndCool">
+            <rSolid name="TIBString2UpPlsModuleBox"/>
+            <rSolid name="TIBString2UpPlsCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString2UpPls">
+            <rSolid name="TIBString2UpPlsModAndCool"/>
+            <rSolid name="TIBString2UpPlsCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString2UpPlsCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString2UpPlsCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString2UpPlsCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring2ur.xml">
+        <LogicalPart name="TIBString2UpPls1" category="unspecified">
+            <rSolid name="TIBString2UpPls"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString2UpPlsCable" category="unspecified">
+            <rSolid name="TIBString2UpPlsCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString2UpPlsCoolS" category="unspecified">
+            <rSolid name="TIBString2UpPlsCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString2UpPlsCoolW" category="unspecified">
+            <rSolid name="TIBString2UpPlsCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring2ur:TIBString2UpPls1"/>
+        <String name="ChildName" value="tibmodule2:TIBModule2"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring2ur.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2ur:TIBString2UpPls1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:SSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2ur:TIBString2UpPls1"/>
+            <rChild name="tibstring2ur:TIBString2UpPlsCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:SSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2ur:TIBString2UpPls1"/>
+            <rChild name="tibstring2ur:TIBString2UpPlsCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring2ur:TIBString2UpPls1"/>
+            <rChild name="tibstring2ur:TIBString2UpPlsCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring2ur:TIBString2UpPls1"/>
+            <rChild name="tibstring2ur:TIBString2UpPlsCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2ur:TIBString2UpPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2ur:TIBString2UpPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2ur:TIBString2UpPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBSSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring2ur:TIBString2UpPls1"/>
+        <String name="ChildName" value="tibstringpar:SSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring3.xml
+++ b/DetectorDescription/DDCMS/data/tibstring3.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tibstring3.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="StringIntOff" value="-42.17*mm"/>
+		<Constant name="StringExtOff" value="6.59*mm"/>
+		<Constant name="StringLoMinL" value="0.5*[tibstringpar:StringL]+[StringIntOff]"/>
+		<Constant name="StringUpMinL" value="0.5*[tibstringpar:StringL]+[StringExtOff]"/>
+		<Constant name="StringLoPlsL" value="0.5*[tibstringpar:StringL]-[StringIntOff]"/>
+		<Constant name="StringUpPlsL" value="0.5*[tibstringpar:StringL]-[StringExtOff]"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tibstring3.xml">
+		<LogicalPart name="TIBString3Lo1" category="unspecified">
+			<rSolid name="tibstringpar:TIBSSString1"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIBString3Up1" category="unspecified">
+			<rSolid name="tibstringpar:TIBSSString1"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tibstring3.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tibstring3:TIBString3Lo1"/>
+			<rChild name="tibstring3ll:TIBString3LoMin1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tibstring3:StringLoPlsL]/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibstring3:TIBString3Lo1"/>
+			<rChild name="tibstring3lr:TIBString3LoPls1"/>
+			<Translation x="[zero]" y="[zero]" z="[tibstring3:StringLoMinL]/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibstring3:TIBString3Up1"/>
+			<rChild name="tibstring3ul:TIBString3UpMin1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tibstring3:StringUpPlsL]/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibstring3:TIBString3Up1"/>
+			<rChild name="tibstring3ur:TIBString3UpPls1"/>
+			<Translation x="[zero]" y="[zero]" z="[tibstring3:StringUpMinL]/2"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring3ll.xml
+++ b/DetectorDescription/DDCMS/data/tibstring3ll.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 4 INT BW -->
+    <ConstantsSection label="tibstring3ll.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:BWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:INT4Sign]"/>
+        <Constant name="MotherCableL" value="67.04*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring3:StringLoMinL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]-45.52*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="-605.456*mm"/>
+        <Constant name="Det1Z" value="-391.972*mm"/>
+        <Constant name="Det2Z" value="-178.218*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring3ll.xml">
+        <Box name="TIBString3LoMinCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString3LoMinModuleBox" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:SSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString3LoMinCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:SSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <UnionSolid name="TIBString3LoMinModAndCool">
+            <rSolid name="TIBString3LoMinModuleBox"/>
+            <rSolid name="TIBString3LoMinCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString3LoMin">
+            <rSolid name="TIBString3LoMinModAndCool"/>
+            <rSolid name="TIBString3LoMinCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString3LoMinCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString3LoMinCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString3LoMinCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring3ll.xml">
+        <LogicalPart name="TIBString3LoMin1" category="unspecified">
+            <rSolid name="TIBString3LoMin"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString3LoMinCable" category="unspecified">
+            <rSolid name="TIBString3LoMinCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString3LoMinCoolS" category="unspecified">
+            <rSolid name="TIBString3LoMinCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString3LoMinCoolW" category="unspecified">
+            <rSolid name="TIBString3LoMinCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring3ll:TIBString3LoMin1"/>
+        <String name="ChildName" value="tibmodule2:TIBModule2"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring3ll.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3ll:TIBString3LoMin1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:SSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3ll:TIBString3LoMin1"/>
+            <rChild name="tibstring3ll:TIBString3LoMinCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:SSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3ll:TIBString3LoMin1"/>
+            <rChild name="tibstring3ll:TIBString3LoMinCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring3ll:TIBString3LoMin1"/>
+            <rChild name="tibstring3ll:TIBString3LoMinCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3ll:TIBString3LoMin1"/>
+            <rChild name="tibstring3ll:TIBString3LoMinCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3ll:TIBString3LoMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3ll:TIBString3LoMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3ll:TIBString3LoMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBSSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3ll:TIBString3LoMin1"/>
+        <String name="ChildName" value="tibstringpar:SSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring3lr.xml
+++ b/DetectorDescription/DDCMS/data/tibstring3lr.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 4 INT FW -->
+    <ConstantsSection label="tibstring3lr.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:FWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:INT4Sign]"/>
+        <Constant name="MotherCableL" value="60.25*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring3:StringLoPlsL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]+38.08*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="33.5070*mm"/>
+        <Constant name="Det1Z" value="247.444*mm"/>
+        <Constant name="Det2Z" value="461.110*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring3lr.xml">
+        <Box name="TIBString3LoPlsCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString3LoPlsModuleBox" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:SSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString3LoPlsCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:SSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <UnionSolid name="TIBString3LoPlsModAndCool">
+            <rSolid name="TIBString3LoPlsModuleBox"/>
+            <rSolid name="TIBString3LoPlsCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString3LoPls">
+            <rSolid name="TIBString3LoPlsModAndCool"/>
+            <rSolid name="TIBString3LoPlsCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString3LoPlsCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString3LoPlsCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString3LoPlsCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring3lr.xml">
+        <LogicalPart name="TIBString3LoPls1" category="unspecified">
+            <rSolid name="TIBString3LoPls"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString3LoPlsCable" category="unspecified">
+            <rSolid name="TIBString3LoPlsCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString3LoPlsCoolS" category="unspecified">
+            <rSolid name="TIBString3LoPlsCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString3LoPlsCoolW" category="unspecified">
+            <rSolid name="TIBString3LoPlsCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring3lr:TIBString3LoPls1"/>
+        <String name="ChildName" value="tibmodule2:TIBModule2"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring3lr.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3lr:TIBString3LoPls1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:SSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3lr:TIBString3LoPls1"/>
+            <rChild name="tibstring3lr:TIBString3LoPlsCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:SSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3lr:TIBString3LoPls1"/>
+            <rChild name="tibstring3lr:TIBString3LoPlsCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring3lr:TIBString3LoPls1"/>
+            <rChild name="tibstring3lr:TIBString3LoPlsCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3lr:TIBString3LoPls1"/>
+            <rChild name="tibstring3lr:TIBString3LoPlsCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3lr:TIBString3LoPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3lr:TIBString3LoPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3lr:TIBString3LoPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBSSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3lr:TIBString3LoPls1"/>
+        <String name="ChildName" value="tibstringpar:SSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring3ul.xml
+++ b/DetectorDescription/DDCMS/data/tibstring3ul.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 4 EXT BW -->
+    <ConstantsSection label="tibstring3ul.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:BWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:EXT4Sign]"/>
+        <Constant name="MotherCableL" value="55.99*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring3:StringUpMinL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]-13.19*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="-531.792*mm"/>
+        <Constant name="Det1Z" value="-304.048*mm"/>
+        <Constant name="Det2Z" value="-76.0150*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring3ul.xml">
+        <Box name="TIBString3UpMinCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString3UpMinModuleBox" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:SSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString3UpMinCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:SSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <UnionSolid name="TIBString3UpMinModAndCool">
+            <rSolid name="TIBString3UpMinModuleBox"/>
+            <rSolid name="TIBString3UpMinCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString3UpMin">
+            <rSolid name="TIBString3UpMinModAndCool"/>
+            <rSolid name="TIBString3UpMinCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString3UpMinCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString3UpMinCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString3UpMinCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring3ul.xml">
+        <LogicalPart name="TIBString3UpMin1" category="unspecified">
+            <rSolid name="TIBString3UpMin"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString3UpMinCable" category="unspecified">
+            <rSolid name="TIBString3UpMinCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString3UpMinCoolS" category="unspecified">
+            <rSolid name="TIBString3UpMinCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString3UpMinCoolW" category="unspecified">
+            <rSolid name="TIBString3UpMinCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring3ul:TIBString3UpMin1"/>
+        <String name="ChildName" value="tibmodule2:TIBModule2"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring3ul.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3ul:TIBString3UpMin1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:SSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3ul:TIBString3UpMin1"/>
+            <rChild name="tibstring3ul:TIBString3UpMinCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:SSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3ul:TIBString3UpMin1"/>
+            <rChild name="tibstring3ul:TIBString3UpMinCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring3ul:TIBString3UpMin1"/>
+            <rChild name="tibstring3ul:TIBString3UpMinCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3ul:TIBString3UpMin1"/>
+            <rChild name="tibstring3ul:TIBString3UpMinCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3ul:TIBString3UpMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3ul:TIBString3UpMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:180D, tibstringpar:180D, tibstringpar:180D</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3ul:TIBString3UpMin1"/>
+        <String name="ChildName" value="tibmodpar:TIBSSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3ul:TIBString3UpMin1"/>
+        <String name="ChildName" value="tibstringpar:SSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstring3ur.xml
+++ b/DetectorDescription/DDCMS/data/tibstring3ur.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+    <!-- LAYER 4 EXT FW -->
+    <ConstantsSection label="tibstring3ur.xml" eval="true">
+        <Constant name="zero" value="0.0*fm"/>
+        <Constant name="FBSign" value="[tibstringpar:FWSign]"/>
+        <Constant name="IESign" value="[tibstringpar:EXT4Sign]"/>
+        <Constant name="MotherCableL" value="69.88*cm-2*[tibstringpar:MCHeadDz]"/>
+        <Constant name="ThisStringL" value="[tibstring3:StringUpPlsL]"/>
+        <Constant name="ThatStringL" value="[tibstringpar:StringL]-[ThisStringL]"/>
+        <Constant name="CoolL" value="0.5*[tibstringpar:StringL]-15.18*mm-2*[tibstringpar:CoolPipeDx]"/>
+        <Constant name="Det0Z" value="149.865*mm"/>
+        <Constant name="Det1Z" value="377.804*mm"/>
+        <Constant name="Det2Z" value="605.456*mm"/>
+        <Constant name="ShiftDet" value="-[FBSign]*0.5*[ThatStringL]+[IESign]*[tibmodpar:WaferZ]"/>
+        <Constant name="ShiftAOHLedge" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHLedgeModOffset])"/>
+        <Constant name="ShiftAOHBox" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibmodpar:AOHBoxDz])"/>
+        <Constant name="ShiftMCModConn" value="[ShiftDet]+[IESign]*([tibmodpar:ModuleDz]+[tibstringpar:MCModConnOffset])"/>
+        <Constant name="MCHeadZ" value="[FBSign]*(0.5*[ThisStringL]-[tibstringpar:MCHeadDz])"/>
+        <Constant name="MCZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[MotherCableL]-2*[tibstringpar:MCHeadDz])"/>
+        <Constant name="CoolSZ" value="[FBSign]*(0.5*[ThisStringL]-0.5*[CoolL])"/>
+        <Constant name="CoolWZ" value="[FBSign]*([ThisStringL]/2-[CoolL]-[tibstringpar:CoolPipeDx])"/>
+    </ConstantsSection>
+    <SolidSection label="tibstring3ur.xml">
+        <Box name="TIBString3UpPlsCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString3UpPlsModuleBox" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:SSModuleDy]" dz="[ThisStringL]/2"/>
+        <Box name="TIBString3UpPlsCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:SSCableBoxDy]" dz="[ThisStringL]/2"/>
+        <UnionSolid name="TIBString3UpPlsModAndCool">
+            <rSolid name="TIBString3UpPlsModuleBox"/>
+            <rSolid name="TIBString3UpPlsCoolBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <UnionSolid name="TIBString3UpPls">
+            <rSolid name="TIBString3UpPlsModAndCool"/>
+            <rSolid name="TIBString3UpPlsCableBox"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCableBoxY]" z="[zero]"/>
+        </UnionSolid>
+        <Box name="TIBString3UpPlsCable" dx="[tibstringpar:MotherCableW]/2" dy="[tibstringpar:MotherCableT]/2" dz="[MotherCableL]/2"/>
+        <Box name="TIBString3UpPlsCoolS" dx="[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[CoolL]/2"/>
+        <Box name="TIBString3UpPlsCoolW" dx="[tibstringpar:CoolPipeX]+[tibstringpar:CoolPipeDx]" dy="[tibstringpar:CoolPipeDy]" dz="[tibstringpar:CoolPipeDx]"/>
+    </SolidSection>
+    <LogicalPartSection label="tibstring3ur.xml">
+        <LogicalPart name="TIBString3UpPls1" category="unspecified">
+            <rSolid name="TIBString3UpPls"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString3UpPlsCable" category="unspecified">
+            <rSolid name="TIBString3UpPlsCable"/>
+            <rMaterial name="tibmaterial:TIB_MCable"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString3UpPlsCoolS" category="unspecified">
+            <rSolid name="TIBString3UpPlsCoolS"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+        <LogicalPart name="TIBString3UpPlsCoolW" category="unspecified">
+            <rSolid name="TIBString3UpPlsCoolW"/>
+            <rMaterial name="tibmaterial:TIB_CoolPipe"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    <Algorithm name="track:DDTrackerZPosAlgo">
+        <rParent name="tibstring3ur:TIBString3UpPls1"/>
+        <String name="ChildName" value="tibmodule2:TIBModule2"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <PosPartSection label="tibstring3ur.xml">
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3ur:TIBString3UpPls1"/>
+            <rChild name="tibstringpar:MCHead"/>
+            <Translation x="[tibstringpar:MCHeadX]" y="[tibstringpar:SSMCHeadY]" z="[MCHeadZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3ur:TIBString3UpPls1"/>
+            <rChild name="tibstring3ur:TIBString3UpPlsCable"/>
+            <Translation x="[tibstringpar:MotherCableX]" y="[tibstringpar:SSMotherCableY]" z="[MCZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3ur:TIBString3UpPls1"/>
+            <rChild name="tibstring3ur:TIBString3UpPlsCoolS"/>
+            <Translation x="-[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="tibstring3ur:TIBString3UpPls1"/>
+            <rChild name="tibstring3ur:TIBString3UpPlsCoolS"/>
+            <Translation x="[tibstringpar:CoolPipeX]" y="[tibstringpar:SSCoolPipeY]" z="[CoolSZ]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="tibstring3ur:TIBString3UpPls1"/>
+            <rChild name="tibstring3ur:TIBString3UpPlsCoolW"/>
+            <Translation x="[zero]" y="[tibstringpar:SSCoolPipeY]" z="[CoolWZ]"/>
+        </PosPart>
+    </PosPartSection>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3ur:TIBString3UpPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBModLedgeBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftDet]), ([Det1Z]+[ShiftDet]), ([Det2Z]+[ShiftDet]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3ur:TIBString3UpPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBAOHLedge"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [zero], [zero], [zero]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY], [tibmodpar:SSLedgeBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHLedge]), ([Det1Z]+[ShiftAOHLedge]), ([Det2Z]+[ShiftAOHLedge]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3ur:TIBString3UpPls1"/>
+        <String name="ChildName" value="tibmodpar:TIBSSAOHBox"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX], [tibmodpar:SSAOHBoxX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY], [tibmodpar:SSAOHBoxY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftAOHBox]), ([Det1Z]+[ShiftAOHBox]), ([Det2Z]+[ShiftAOHBox]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+    <Algorithm name="track:DDTrackerXYZPosAlgo">
+        <rParent name="tibstring3ur:TIBString3UpPls1"/>
+        <String name="ChildName" value="tibstringpar:SSMCModConn"/>
+        <Numeric name="StartCopyNo" value="1"/>
+        <Numeric name="IncrCopyNo" value="1"/>
+        <Vector name="XPositions" type="numeric" nEntries="3">
+            [tibstringpar:MCModConnX], [tibstringpar:MCModConnX], [tibstringpar:MCModConnX]</Vector>
+        <Vector name="YPositions" type="numeric" nEntries="3">
+            [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY], [tibstringpar:SSMCModConnY]</Vector>
+        <Vector name="ZPositions" type="numeric" nEntries="3">
+            ([Det0Z]+[ShiftMCModConn]), ([Det1Z]+[ShiftMCModConn]), ([Det2Z]+[ShiftMCModConn]) </Vector>
+        <Vector name="Rotations" type="string" nEntries="3">
+            tibstringpar:NULL, tibstringpar:NULL, tibstringpar:NULL</Vector>
+    </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibstringpar.xml
+++ b/DetectorDescription/DDCMS/data/tibstringpar.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tibstringpar.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="StringL" value="2*[tib:TIBDz]"/>
+		<Constant name="BWSign" value="-1."/>
+		<Constant name="FWSign" value="+1."/>
+		<Constant name="INT1Sign" value="-1."/>
+		<Constant name="EXT1Sign" value="+1."/>
+		<Constant name="INT2Sign" value="+1."/>
+		<Constant name="EXT2Sign" value="-1."/>
+		<Constant name="INT3Sign" value="-1."/>
+		<Constant name="EXT3Sign" value="+1."/>
+		<Constant name="INT4Sign" value="+1."/>
+		<Constant name="EXT4Sign" value="-1."/>
+		<Constant name="MCHeadDx" value="16.0*mm"/>
+		<Constant name="MCHeadDy" value="2.5*mm"/>
+		<Constant name="MCHeadDz" value="22.0*mm"/>
+		<Constant name="MCHeadX" value="[zero]"/>
+		<Constant name="SSMCHeadY" value="-[tibmodpar:SSModuleDy]-2*[tibstringpar:CoolBoxDy]-2*[tibstringpar:SSCableBoxDy]+[tibstringpar:MCHeadDy]"/>
+		<Constant name="DSMCHeadY" value="-[tibmodpar:DSModuleDy]-2*[tibstringpar:CoolBoxDy]-2*[tibstringpar:DSCableBoxDy]+[tibstringpar:MCHeadDy]"/>
+		<Constant name="MotherCableW" value="2.40*cm"/>
+		<Constant name="MotherCableT" value="1.20*mm"/>
+		<Constant name="MotherCableX" value="[zero]"/>
+		<Constant name="SSMotherCableY" value="-[tibmodpar:SSModuleDy]-2*[tibstringpar:CoolBoxDy]-2*[tibstringpar:SSCableBoxDy]+0.5*[tibstringpar:MotherCableT]"/>
+		<Constant name="DSMotherCableY" value="-[tibmodpar:DSModuleDy]-2*[tibstringpar:CoolBoxDy]-2*[tibstringpar:DSCableBoxDy]+0.5*[tibstringpar:MotherCableT]"/>
+		<Constant name="CoolTubeD" value="2.8*mm"/>
+		<!-- For bw comp to be removed -->
+		<Constant name="CoolPipeDx" value="2.25*mm"/>
+		<Constant name="CoolPipeDy" value="1.05*mm"/>
+		<Constant name="CoolPipeX" value="27.0*mm"/>
+		<Constant name="SSCoolPipeY" value="-[tibmodpar:SSModuleDy]-2*[tibstringpar:CoolBoxDy]+[tibstringpar:CoolPipeDy]"/>
+		<Constant name="DSCoolPipeY" value="-[tibmodpar:DSModuleDy]-2*[tibstringpar:CoolBoxDy]+[tibstringpar:CoolPipeDy]"/>
+		<Constant name="CoolTubeW" value="[CoolTubeD]+[CoolTubeSep]"/>
+		<!-- For bw comp to be removed -->
+		<Constant name="CoolBoxDx" value="30.0*mm"/>
+		<Constant name="CoolBoxDy" value="1.4*mm"/>
+		<Constant name="SSCoolBoxY" value="-[tibmodpar:SSModuleDy]-[tibstringpar:CoolBoxDy]"/>
+		<Constant name="DSCoolBoxY" value="-[tibmodpar:DSModuleDy]-[tibstringpar:CoolBoxDy]"/>
+		<Constant name="CoolTubeSep" value="5.40*cm"/>
+		<Constant name="CableBoxDx" value="16.0*mm"/>
+		<Constant name="SSCableBoxDy" value="2.3*mm"/>
+		<Constant name="SSCableBoxY" value="-[tibmodpar:SSModuleDy]-2*[tibstringpar:CoolBoxDy]-[tibstringpar:SSCableBoxDy]"/>
+		<Constant name="DSCableBoxDy" value="1.7*mm"/>
+		<Constant name="DSCableBoxY" value="-[tibmodpar:DSModuleDy]-2*[tibstringpar:CoolBoxDy]-[tibstringpar:DSCableBoxDy]"/>
+		<Constant name="SSMCModConnDx" value="6.9*mm"/>
+		<Constant name="DSMCModConnDx" value="7.4*mm"/>
+		<Constant name="SSMCModConnDy" value="0.5*([tibmodpar:SSAOHBoxY]-[tibmodpar:AOHBoxDy]-[tibstringpar:SSMotherCableY]-0.5*[tibstringpar:MotherCableT])"/>
+		<Constant name="DSMCModConnDy" value="0.5*([tibmodpar:DSAOHBoxY]-[tibmodpar:AOHBoxDy]-[tibstringpar:DSMotherCableY]-0.5*[tibstringpar:MotherCableT])"/>
+		<Constant name="SSMCModConnDz" value="5.7*mm"/>
+		<Constant name="DSMCModConnDz" value="9.7*mm"/>
+		<Constant name="MCModConnX" value="[zero]"/>
+		<Constant name="SSMCModConnY" value="-[tibmodpar:SSModuleDy]-2*[tibstringpar:CoolBoxDy]-2*[tibstringpar:SSCableBoxDy]+[tibstringpar:SSMCModConnDy]+[tibstringpar:MotherCableT]"/>
+		<Constant name="DSMCModConnY" value="-[tibmodpar:DSModuleDy]-2*[tibstringpar:CoolBoxDy]-2*[tibstringpar:DSCableBoxDy]+[tibstringpar:DSMCModConnDy]+[tibstringpar:MotherCableT]"/>
+		<Constant name="MCModConnOffset" value="[tibmodpar:AOHModOffset]+[tibmodpar:AOHLedgeSideDz]"/>
+		<Constant name="SideCutDx" value="[tibmodpar:DSModuleSideCutDx]"/>
+		<Constant name="SideCutX" value="[tibmodpar:ModuleDx]-[SideCutDx]+0.3*mm"/>
+	</ConstantsSection>
+	<SolidSection label="tibstringpar.xml">
+		<Box name="TIBStringCoolBox" dx="[tibstringpar:CoolBoxDx]" dy="[tibstringpar:CoolBoxDy]" dz="[tibstringpar:StringL]/2"/>
+		<Box name="TIBSSStringModuleBox" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:SSModuleDy]" dz="[tibstringpar:StringL]/2"/>
+		<Box name="TIBSSStringCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:SSCableBoxDy]" dz="[tibstringpar:StringL]/2"/>
+		<UnionSolid name="TIBSSStringModAndCool">
+			<rSolid name="TIBSSStringModuleBox"/>
+			<rSolid name="TIBStringCoolBox"/>
+			<Translation x="[zero]" y="[tibstringpar:SSCoolBoxY]" z="[zero]"/>
+		</UnionSolid>
+		<UnionSolid name="TIBSSString1">
+			<rSolid name="TIBSSStringModAndCool"/>
+			<rSolid name="TIBSSStringCableBox"/>
+			<Translation x="[zero]" y="[tibstringpar:SSCableBoxY]" z="[zero]"/>
+		</UnionSolid>
+		<Box name="TIBDSString1MainPart" dx="[tibmodpar:ModuleDx]" dy="[tibmodpar:DSModuleDy]" dz="[tibstringpar:StringL]/2"/>
+		<Box name="TIBDSString1SideCut" dx="[SideCutDx]" dy="[tibmodpar:DSModuleSideCutDy]" dz="[tibstringpar:StringL]/2+[tibmodpar:SideCutExtraZ]"/>
+		<Box name="TIBDSStringCableBox" dx="[tibstringpar:CableBoxDx]" dy="[tibstringpar:DSCableBoxDy]" dz="[tibstringpar:StringL]/2"/>
+		<SubtractionSolid name="TIBDSString1LeftCutted">
+			<rSolid name="TIBDSString1MainPart"/>
+			<rSolid name="TIBDSString1SideCut"/>
+			<Translation x="-[SideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="[zero]"/>
+		</SubtractionSolid>
+		<SubtractionSolid name="TIBDSStringModuleBox">
+			<rSolid name="TIBDSString1LeftCutted"/>
+			<rSolid name="TIBDSString1SideCut"/>
+			<Translation x="[SideCutX]" y="[tibmodpar:DSModuleSideCutY]" z="[zero]"/>
+		</SubtractionSolid>
+		<UnionSolid name="TIBDSStringModAndCool">
+			<rSolid name="TIBDSStringModuleBox"/>
+			<rSolid name="TIBStringCoolBox"/>
+			<Translation x="[zero]" y="[tibstringpar:DSCoolBoxY]" z="[zero]"/>
+		</UnionSolid>
+		<UnionSolid name="TIBDSString1">
+			<rSolid name="TIBDSStringModAndCool"/>
+			<rSolid name="TIBDSStringCableBox"/>
+			<Translation x="[zero]" y="[tibstringpar:DSCableBoxY]" z="[zero]"/>
+		</UnionSolid>
+		<Box name="MCHead" dx="[tibstringpar:MCHeadDx]" dy="[tibstringpar:MCHeadDy]" dz="[tibstringpar:MCHeadDz]"/>
+		<Box name="SSMCModConn" dx="[tibstringpar:SSMCModConnDx]" dy="[tibstringpar:SSMCModConnDy]" dz="[tibstringpar:SSMCModConnDz]"/>
+		<Box name="DSMCModConn" dx="[tibstringpar:DSMCModConnDx]" dy="[tibstringpar:DSMCModConnDy]" dz="[tibstringpar:DSMCModConnDz]"/>
+	</SolidSection>
+	<LogicalPartSection label="tibstringpar.xml">
+		<LogicalPart name="MCHead" category="unspecified">
+			<rSolid name="MCHead"/>
+			<rMaterial name="tibmaterial:TIB_MCHead"/>
+		</LogicalPart>
+		<LogicalPart name="SSMCModConn" category="unspecified">
+			<rSolid name="SSMCModConn"/>
+			<rMaterial name="tibmaterial:TIB_SSMCModConn"/>
+		</LogicalPart>
+		<LogicalPart name="DSMCModConn" category="unspecified">
+			<rSolid name="DSMCModConn"/>
+			<rMaterial name="tibmaterial:TIB_DSMCModConn"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<RotationSection label="tibstringpar.xml">
+		<Rotation name="180D" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="90*deg" thetaZ="180*deg" phiZ="0*deg"/>
+		<Rotation name="90XD" thetaX="90*deg" phiX="90*deg" thetaY="0*deg" phiY="0*deg" thetaZ="90*deg" phiZ="0*deg"/>
+	</RotationSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibtidcommonmaterial.xml
+++ b/DetectorDescription/DDCMS/data/tibtidcommonmaterial.xml
@@ -1,0 +1,570 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <MaterialSection label="tibtidcommonmaterial.xml">
+    <CompositeMaterial name="TIBTID_CCUM" density="0.81143*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.19505">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.37418">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00724">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02789">
+        <rMaterial name="materials:SMD_metal" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08519">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00067">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00469">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00322">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00067">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00808">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00556">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16432">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12324">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_FiberPigtail" density="1.08988*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.03793">
+        <rMaterial name="materials:Quartz" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0503">
+        <rMaterial name="materials:Acrylate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.50313">
+        <rMaterial name="materials:Acrylate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.40864">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_PigtailMUConn" density="1.09775*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.30468">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.56497">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13035">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_T_RuggRibbon" density="0.84212*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.67168">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13807">
+        <rMaterial name="trackermaterial:T_Kevlar" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06511">
+        <rMaterial name="materials:Acrylate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0538">
+        <rMaterial name="materials:Quartz" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07134">
+        <rMaterial name="materials:Acrylate" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_Cu10mmPipe" density="3.22429*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.5279">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.4721">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_Al6mmPipe" density="2.13004*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.3874">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.6126">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_MedCABMaleConn" density="1.65926*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.10693">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.37453">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11664">
+        <rMaterial name="materials:Tin" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.25758">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14432">
+        <rMaterial name="materials:Iron" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_MedCABFemaleConn" density="1.89866*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.34829">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.28641">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10193">
+        <rMaterial name="materials:Tin" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20814">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05522">
+        <rMaterial name="materials:Iron" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_MedPLCCMaleConn" density="1.45510*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.13829">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.31405">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11316">
+        <rMaterial name="materials:Tin" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.28495">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14956">
+        <rMaterial name="materials:Iron" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_MedPLCCFemaleConn" density="1.75960*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.39851">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.24109">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09357">
+        <rMaterial name="materials:Tin" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22177">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04505">
+        <rMaterial name="materials:Iron" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_MedusaWire" density="2.40567*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.70862">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.29138">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_ServiceCylinder" density="0.52518*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.47614">
+        <rMaterial name="tibtidcommonmaterial:T_MedusaWire" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.21076">
+        <rMaterial name="tibtidcommonmaterial:T_Al6mmPipe" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16286">
+        <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02128">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02601">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0604">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01334">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00686">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00231">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01469">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00536">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_ServiceDisk1" density="1.1412*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.26175">
+        <rMaterial name="tibtidcommonmaterial:T_MedusaWire" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10683">
+        <rMaterial name="tibtidcommonmaterial:T_Al6mmPipe" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0895">
+        <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01171">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01429">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.29722">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11443">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10428">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_ServiceDisk2" density="0.684*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.26175">
+        <rMaterial name="tibtidcommonmaterial:T_MedusaWire" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10683">
+        <rMaterial name="tibtidcommonmaterial:T_Al6mmPipe" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0895">
+        <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01171">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01429">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.29722">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11443">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10428">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_OptoPanelFront" density="0.077952*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.8808">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08973">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02947">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_OptoConnectors" density="0.530415*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.12072">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02314">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00586">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.43309">
+        <rMaterial name="trackermaterial:T_Ribbon12xMUConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.41719">
+        <rMaterial name="tibtidcommonmaterial:T_PigtailMUConn" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_OptoPanelBackInner" density="0.181308*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.19522">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.51268">
+        <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03886">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.25324">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_OptoPanelBackOuter" density="0.159924*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.20963">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20893">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.58144">
+        <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_Margherita" density="1.2580195*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.25645">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02389">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00576">
+        <rMaterial name="materials:Gold" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02917">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00414">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0032">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00158">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00751">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00228">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13467">
+        <rMaterial name="tibtidcommonmaterial:T_MedCABMaleConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03841">
+        <rMaterial name="tibtidcommonmaterial:T_MedPLCCMaleConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.39282">
+        <rMaterial name="tibtidcommonmaterial:T_MedusaWire" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07999">
+        <rMaterial name="tibtidcommonmaterial:T_Al6mmPipe" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02012">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_PowerConnectors" density="0.424932*g/cm3" method="mixture by weight"  symbol=" ">
+      <MaterialFraction fraction="0.1342">
+        <rMaterial name="trackermaterial:CAB_Al60TIBTID" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09401">
+        <rMaterial name="trackermaterial:MS_CntrlTIBTID" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05887">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.54781">
+        <rMaterial name="tibtidcommonmaterial:T_MedCABFemaleConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16511">
+        <rMaterial name="tibtidcommonmaterial:T_MedPLCCFemaleConn" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_TSTCabAxial" density="0.89492*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.31327">
+        <rMaterial name="trackermaterial:CAB_Al60TIBTID" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10473">
+        <rMaterial name="trackermaterial:MS_CntrlTIBTID" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.25567">
+        <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0473">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00356">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.27547">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_TSTCabRadial" density="0.30422*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.41686">
+        <rMaterial name="trackermaterial:CAB_Al60TIBTID" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13941">
+        <rMaterial name="trackermaterial:MS_CntrlTIBTID" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.38651">
+        <rMaterial name="tibtidcommonmaterial:T_Cu10mmPipe" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05722">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_T_RuggRibbon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_PA" density="2.74978*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.44428">
+        <rMaterial name="materials:Borosilicate_Glass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.48493">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07079">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_AOH" density="0.60091*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.31344">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.23771">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14423">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08645">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00612">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04437">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01304">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02075">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06154">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07235">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_DOH" density="0.79092*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.22923">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.18785">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04401">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02744">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00145">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01117">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01773">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02595">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03223">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07813">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07894">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.21661">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04926">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_AmphCable" density="2.05153*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.56777">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22996">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20227">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_HybridBoard" density="3.70257*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.26413">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03035">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05229">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.65323">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_HybridTails" density="1.61323*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.32847">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.34993">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.3216">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIBTID_Hybrid" density="2.16228*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.8733">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_HybridBoard" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07195">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00385">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00601">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00096">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00374">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00674">
+        <rMaterial name="materials:SMD_metal" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00466">
+        <rMaterial name="materials:Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00541">
+        <rMaterial name="materials:SMD_metal" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01636">
+        <rMaterial name="materials:Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00702">
+        <rMaterial name="materials:SMD_metal" />
+      </MaterialFraction>
+    </CompositeMaterial>
+  </MaterialSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibtidservices.xml
+++ b/DetectorDescription/DDCMS/data/tibtidservices.xml
@@ -1,0 +1,394 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tibtidservices.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<!-- Mother Volume (Polycone) -->
+		<Constant name="Rin1" value="22.20*cm"/>
+		<Constant name="Rin1bis" value="21.80*cm"/>
+		<Constant name="Rin2" value="[tid:Rout]"/>
+		<!-- 52.0 cm -->
+		<Constant name="Rin3" value="24.60*cm"/>
+		<!-- "dente" PXL flange -->
+		<Constant name="Rin4" value="113.51*cm"/>
+		<!-- inner R (vs beam) corrected to 113.51 cm as in reality-->
+		<Constant name="Rout1" value="[tib:Rout]"/>
+		<!-- 54.0 cm -->
+		<Constant name="Rout2" value="58.00*cm"/>
+		<!-- "dente" Margerita flange -->
+		<Constant name="Rout3" value="116.00*cm"/>
+		<!-- outer R (vs TST)  [was 115.0 cm in tib.xml]; max value: 116.0 tob.xml -->
+		<Constant name="Zv1" value="71.6*cm"/>
+		<Constant name="Zv2" value="73.6*cm"/>
+		<!-- begin of TID envelope cf. tid.xml -->
+		<Constant name="Zv3" value="110.0*cm"/>
+		<!-- "dente" Margherita flange -->
+		<Constant name="Zv4" value="111.3*cm"/>
+		<Constant name="Zv5" value="112.1*cm"/>
+		<Constant name="Zv5bis" value="113.1*cm"/>
+		<!-- "dente" PXL flange -->
+		<Constant name="Zv6" value="118.0*cm"/>
+		<Constant name="Zv7" value="123.0*cm"/>
+		<Constant name="Zv8" value="282.0*cm"/>
+		<!-- current Z_max in .xml (true: 274.0 cm) -->
+		<!-- TIB flange -->
+		<Constant name="TIBFlangeL" value="[Zv2]-[Zv1]"/>
+		<Constant name="TIBFlangeZ" value="[Zv1]+[TIBFlangeL]/2"/>
+		<!-- PixelSupport flanges -->
+		<Constant name="PixelSupportFlangeL" value="[Zv5]-[Zv4]"/>
+		<Constant name="PixelSupportFlange2L" value="[Zv5bis]-[Zv5]"/>
+		<Constant name="PixelSupportFlangeZ" value="[Zv4]+[PixelSupportFlangeL]/2"/>
+		<Constant name="PixelSupportFlange2Z" value="[Zv4]+[PixelSupportFlangeL]+[PixelSupportFlange2L]/2"/>
+		<Constant name="Rin3bis" value="24.0*cm"/>
+		<!-- final section of TID support tube -->
+		<Constant name="TIDSupportL" value="4.9*cm"/>
+		<Constant name="TIDSupportZ" value="[Zv4]+[TIDSupportL]/2"/>
+		<!-- 113.75*cm -->
+		<!-- Power/Control connectors (medusa->CAB60) -->
+		<Constant name="PowerConnectorsRin" value="76.7*cm"/>
+		<Constant name="PowerConnectorsRout" value="95.0*cm"/>
+		<Constant name="PowerConnectorsL" value="3.0*cm"/>
+		<Constant name="PowerConnectorsZ" value="121.5*cm"/>
+		<!-- Margherita -->
+		<Constant name="MargheritaRf" value="60.6*cm"/>
+		<!-- "front" (lower |z|) -->
+		<Constant name="MargheritaRb" value="56.0*cm"/>
+		<!-- "back"  (higher |z|) -->
+		<Constant name="MargheritaZf" value="[Zv6]"/>
+		<Constant name="MargheritaZm" value="119.7*cm"/>
+		<Constant name="MargheritaZb" value="[Zv7]-[PowerConnectorsL]"/>
+		<!-- 120.0cm -->
+		<!-- Service Cylinder:   73.6< |z| <116.2 cm -->
+		<Constant name="ServiceCylinderL" value="42.6*cm"/>
+		<Constant name="ServiceCylinderZ" value="[Zv2]+[ServiceCylinderL]/2"/>
+		<!-- Service Disk -->
+		<Constant name="ServiceDiskZf" value="[Zv2]+[ServiceCylinderL]"/>
+		<Constant name="ServiceDiskZm" value="[Zv6]"/>
+		<Constant name="ServiceDiskZb" value="[MargheritaZm]"/>
+		<Constant name="ServiceDiskRin" value="[tid:SupportRin]"/>
+		<Constant name="ServiceDiskRm" value="58.0*cm"/>
+		<Constant name="ServiceDiskRout" value="[MargheritaRf]"/>
+                <Constant name="ServiceDisk2Dz" value="[ServiceDiskZb]/2-[ServiceDiskZf]/2"/>
+                <Constant name="ServiceDisk2Z" value="[ServiceDiskZb]/2+[ServiceDiskZf]/2"/>
+		<!-- Optical Panel -->
+		<Constant name="OpticalPanelZf" value="[Zv4]"/>
+		<Constant name="OpticalPanelZ1" value="[MargheritaZm]"/>
+		<Constant name="OpticalPanelZ2" value="[MargheritaZb]"/>
+		<Constant name="OpticalPanelZb" value="[Zv7]"/>
+		<Constant name="OptoPanelFrontL" value="3.6*cm"/>
+		<Constant name="OptoPanelFrontZ" value="[OpticalPanelZf]+[OptoPanelFrontL]/2"/>
+		<Constant name="OptoConnectorsL" value="5.0*cm"/>
+		<Constant name="OptoConnectorsZ" value="[OpticalPanelZf]+[OptoPanelFrontL]+[OptoConnectorsL]/2"/>
+		<Constant name="OptoPanelBackL" value="[OpticalPanelZb]-[OpticalPanelZf]-([OptoPanelFrontL]+[OptoConnectorsL])"/>
+		<Constant name="OptoPanelBackZ" value="[OpticalPanelZf]+[OptoPanelFrontL]+[OptoConnectorsL]+[OptoPanelBackL]/2"/>
+		<!-- TST -->
+		<Constant name="TSTCabContRin" value="95.0*cm"/>
+		<Constant name="TSTCabAxialR" value="115.3*cm"/>
+		<Constant name="TSTCabAxialT" value="1.1*cm"/>
+		<Constant name="TSTCabAxialL" value="142.0*cm"/>
+		<Constant name="TSTCabAxialZ" value="[Zv7]+[TSTCabAxialL]/2"/>
+		<Constant name="TSTCabAxialAlT" value="0.1*cm"/>
+		<!-- TEC Rails -->
+		<Constant name="TECRailsRin" value="[Rin4]"/>
+		<!-- directly ontop of the TEC Skin-->
+		<Constant name="TECRailsRout" value="[TSTCabAxialR]-[TSTCabAxialT]/2"/>
+		<!-- directly under AxialCables-->
+		<Constant name="TECRailsPhi" value="-0.664*deg"/>
+		<Constant name="TECRailsDeltaPhi" value="7.409*deg"/>
+		<Constant name="TECRailsADz" value="15.30*cm"/>
+		<Constant name="TECRailsAZ" value="160.25*cm"/>
+		<Constant name="TECRailsBDz" value="26.65*cm"/>
+		<Constant name="TECRailsBZ" value="250.10*cm"/>
+		<Constant name="TECRailsConnectorDz" value="1.25*cm"/>
+		<Constant name="TECRailsConnectorZDist" value="14.0*cm"/>
+		<Constant name="TECRailsConnectorZDistB1" value="20.5*cm"/>
+		<Constant name="TECRailsConnectorZDistB2" value="21.5*cm"/>
+		<Constant name="TECRailsConnectorZDistB3" value="8.74*cm"/>
+		<Constant name="TECRailsSupportDz" value="2.85*cm"/>
+		<Constant name="TECRailsSupportZDist" value="8.0*cm"/>
+		<Constant name="TECRailsSupportDphi" value="2.877*deg"/>
+	</ConstantsSection>
+	<SolidSection label="tibtidservices.xml">
+		<Polycone name="TIBTIDServices" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="[Zv1]" rMin="[Rin1]" rMax="[Rout1]"/>
+			<ZSection z="[Zv2]" rMin="[Rin1]" rMax="[Rout1]"/>
+			<ZSection z="[Zv2]" rMin="[Rin2]" rMax="[Rout1]"/>
+			<ZSection z="[Zv3]" rMin="[Rin2]" rMax="[Rout1]"/>
+			<ZSection z="[Zv3]" rMin="[Rin2]" rMax="[Rout2]"/>
+			<ZSection z="[Zv4]" rMin="[Rin2]" rMax="[Rout2]"/>
+			<ZSection z="[Zv4]" rMin="[Rin1]" rMax="[Rout2]"/>
+			<ZSection z="[Zv5]" rMin="[Rin1]" rMax="[Rout2]"/>
+			<ZSection z="[Zv5]" rMin="[Rin1bis]" rMax="[Rout2]"/>
+			<ZSection z="[Zv5bis]" rMin="[Rin1bis]" rMax="[Rout2]"/>
+			<ZSection z="[Zv5bis]" rMin="[Rin3]" rMax="[Rout2]"/>
+			<ZSection z="[Zv6]" rMin="[Rin3]" rMax="[Rout2]"/>
+			<ZSection z="[Zv6]" rMin="[Rin3]" rMax="[Rout3]"/>
+			<ZSection z="[Zv7]" rMin="[Rin3]" rMax="[Rout3]"/>
+			<ZSection z="[Zv7]" rMin="[Rin4]" rMax="[Rout3]"/>
+			<ZSection z="[Zv8]" rMin="[Rin4]" rMax="[Rout3]"/>
+		</Polycone>
+		<!-- TID support tube not contained in tid.xml volume -->
+		<Tubs name="TIDSupport" rMin="[tid:SupportRin]" rMax="[tid:SupportRout]" dz="[TIDSupportL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TIDSupportIn" rMin="[tid:SupportInRin]" rMax="[tid:SupportInRout]" dz="[TIDSupportL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<!-- "Flangia" TIB -->
+		<Tubs name="TIBFlange" rMin="[tib:Rin]" rMax="[tib:Rout]" dz="[TIBFlangeL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<!-- "Service Cylinder  -->
+		<Tubs name="ServiceCylinder" rMin="[Rin2]" rMax="[Rout1]" dz="[ServiceCylinderL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<!-- Flanges PixelSupport -->
+		<Tubs name="PixelSupportFlange" rMin="[Rin1]" rMax="[Rin3]" dz="[PixelSupportFlangeL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="PixelSupportFlange2" rMin="[Rin1bis]" rMax="[Rin3bis]" dz="[PixelSupportFlange2L]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<!-- Optical Panel  -->
+		<Polycone name="OpticalPanel" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="[OpticalPanelZf]" rMin="[Rin3]" rMax="[tid:SupportRin]"/>
+			<ZSection z="[OpticalPanelZ1]" rMin="[Rin3]" rMax="[tid:SupportRin]"/>
+			<ZSection z="[OpticalPanelZ1]" rMin="[Rin3]" rMax="[MargheritaRb]"/>
+			<ZSection z="[OpticalPanelZ2]" rMin="[Rin3]" rMax="[MargheritaRb]"/>
+			<ZSection z="[OpticalPanelZ2]" rMin="[Rin3]" rMax="[PowerConnectorsRin]"/>
+			<ZSection z="[OpticalPanelZb]" rMin="[Rin3]" rMax="[PowerConnectorsRin]"/>
+		</Polycone>
+		<!-- Optical Panel Front  -->
+		<Tubs name="OptoPanelFront" rMin="[Rin3]" rMax="[tid:SupportRin]" dz="[OptoPanelFrontL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<!-- Optical Connectors  -->
+		<Tubs name="OpticalConnectors" rMin="[Rin3]" rMax="[tid:SupportRin]" dz="[OptoConnectorsL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<!-- Optical Panel Back  r<51.2 cm -->
+		<Tubs name="OptoPanelBackInner" rMin="[Rin3]" rMax="[tid:SupportRin]" dz="[OptoPanelBackL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<!-- Optical Panel Back  r>51.2 cm -->
+		<Polycone name="OptoPanelBackOuter" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="[OpticalPanelZ1]" rMin="[tid:SupportRin]" rMax="[MargheritaRb]"/>
+			<ZSection z="[OpticalPanelZ2]" rMin="[tid:SupportRin]" rMax="[MargheritaRb]"/>
+			<ZSection z="[OpticalPanelZ2]" rMin="[tid:SupportRin]" rMax="[PowerConnectorsRin]"/>
+			<ZSection z="[OpticalPanelZb]" rMin="[tid:SupportRin]" rMax="[PowerConnectorsRin]"/>
+		</Polycone>
+		<!-- "Margherita" Panel  -->
+		<Polycone name="Margherita" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="[MargheritaZf]" rMin="[MargheritaRf]" rMax="[TSTCabContRin]"/>
+			<ZSection z="[MargheritaZm]" rMin="[MargheritaRf]" rMax="[TSTCabContRin]"/>
+			<ZSection z="[MargheritaZm]" rMin="[MargheritaRb]" rMax="[TSTCabContRin]"/>
+			<ZSection z="[MargheritaZb]" rMin="[MargheritaRb]" rMax="[TSTCabContRin]"/>
+		</Polycone>
+		<!-- Service Disk  -->
+                <Polycone name="ServiceDisk1" startPhi="0*deg" deltaPhi="360*deg">
+                        <ZSection z="[ServiceDiskZf]" rMin="[MargheritaRb]" rMax="[ServiceDiskRm]"/>
+                        <ZSection z="[ServiceDiskZm]" rMin="[MargheritaRb]" rMax="[ServiceDiskRm]"/>
+                        <ZSection z="[ServiceDiskZm]" rMin="[MargheritaRb]" rMax="[ServiceDiskRout]"/>
+                        <ZSection z="[ServiceDiskZb]" rMin="[MargheritaRb]" rMax="[ServiceDiskRout]"/>
+		</Polycone>
+                <Tubs name="ServiceDisk2" rMin="[ServiceDiskRin]" rMax="[MargheritaRb]" dz="[ServiceDisk2Dz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<!-- Power/Control connectors  -->
+		<Tubs name="PowerConnectors" rMin="[PowerConnectorsRin]" rMax="[PowerConnectorsRout]" dz="[PowerConnectorsL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<!-- TST  -->
+		<Polycone name="TSTCabCont" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="[Zv6]" rMin="[TSTCabContRin]" rMax="[Rout3]"/>
+			<ZSection z="[Zv7]" rMin="[TSTCabContRin]" rMax="[Rout3]"/>
+			<ZSection z="[Zv7]" rMin="[Rin4]" rMax="[Rout3]"/>
+			<ZSection z="[Zv8]" rMin="[Rin4]" rMax="[Rout3]"/>
+		</Polycone>
+		<Tubs name="TSTCabAxial" rMin="[TSTCabAxialR]-[TSTCabAxialT]/2" rMax="[TSTCabAxialR]+[TSTCabAxialT]/2" dz="[TSTCabAxialL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Polycone name="TSTCabRadial" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="[Zv6]" rMin="[TSTCabContRin]" rMax="[TSTCabContRin]"/>
+			<ZSection z="[Zv6]+0.8*([Zv7]-[Zv6])" rMin="[TSTCabContRin]" rMax="[TSTCabAxialR]-[TSTCabAxialAlT]+[TSTCabAxialT]/2"/>
+			<ZSection z="[Zv7]" rMin="[TSTCabContRin]" rMax="[TSTCabAxialR]-[TSTCabAxialAlT]+[TSTCabAxialT]/2"/>
+		</Polycone>
+		<!-- TEC Rails -->
+		<Tubs name="TECRailsA" rMin="[TECRailsRin]" rMax="[TECRailsRout]" dz="[TECRailsADz]" startPhi="[TECRailsDeltaPhi]/2" deltaPhi="[TECRailsDeltaPhi]"/>
+		<Tubs name="TECRailsB" rMin="[TECRailsRin]" rMax="[TECRailsRout]" dz="[TECRailsBDz]" startPhi="[TECRailsDeltaPhi]/2" deltaPhi="[TECRailsDeltaPhi]"/>
+		<Tubs name="TECRailsConnector" rMin="[TECRailsRin]" rMax="[TECRailsRout]" dz="[TECRailsConnectorDz]" startPhi="[TECRailsDeltaPhi]/2" deltaPhi="[TECRailsDeltaPhi]"/>
+		<Tubs name="TECRailsSupport" rMin="[TECRailsRin]" rMax="[TECRailsRout]" dz="[TECRailsSupportDz]" startPhi="[TECRailsDeltaPhi]/2+[TECRailsSupportDphi]/4" deltaPhi="[TECRailsSupportDphi]"/>
+	</SolidSection>
+	<LogicalPartSection label="tibtidservices.xml">
+		<LogicalPart name="TIDSupport" category="unspecified">
+			<rSolid name="TIDSupport"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TIDSupportIn" category="unspecified">
+			<rSolid name="TIDSupportIn"/>
+			<rMaterial name="trackermaterial:T_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TIBFlange" category="unspecified">
+			<rSolid name="TIBFlange"/>
+			<rMaterial name="tibmaterial:TIB_Flange"/>
+		</LogicalPart>
+		<LogicalPart name="TIBTIDServiceCylinder" category="unspecified">
+			<rSolid name="ServiceCylinder"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_ServiceCylinder"/>
+		</LogicalPart>
+		<LogicalPart name="TIBTIDPxlFlange" category="unspecified">
+			<rSolid name="PixelSupportFlange"/>
+			<rMaterial name="trackermaterial:T_FR4"/>
+		</LogicalPart>
+		<LogicalPart name="TIBTIDPxlFlange2" category="unspecified">
+			<rSolid name="PixelSupportFlange2"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TIBTIDOpticalPanel" category="unspecified">
+			<rSolid name="OpticalPanel"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIBTIDOptoPanelFront" category="unspecified">
+			<rSolid name="OptoPanelFront"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_OptoPanelFront"/>
+		</LogicalPart>
+		<LogicalPart name="TIBTIDOptoConnectors" category="unspecified">
+			<rSolid name="OpticalConnectors"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_OptoConnectors"/>
+		</LogicalPart>
+		<LogicalPart name="TIBTIDOptoPanelBackInner" category="unspecified">
+			<rSolid name="OptoPanelBackInner"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_OptoPanelBackInner"/>
+		</LogicalPart>
+		<LogicalPart name="TIBTIDOptoPanelBackOuter" category="unspecified">
+			<rSolid name="OptoPanelBackOuter"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_OptoPanelBackOuter"/>
+		</LogicalPart>
+		<LogicalPart name="TIBTIDMargherita" category="unspecified">
+			<rSolid name="Margherita"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_Margherita"/>
+		</LogicalPart>
+                <LogicalPart name="TIBTIDServiceDisk1" category="unspecified">
+                        <rSolid name="ServiceDisk1"/>
+                        <rMaterial name="tibtidcommonmaterial:TIBTID_ServiceDisk1"/>
+                </LogicalPart>
+                <LogicalPart name="TIBTIDServiceDisk2" category="unspecified">
+                        <rSolid name="ServiceDisk2"/>
+                        <rMaterial name="tibtidcommonmaterial:TIBTID_ServiceDisk2"/>
+		</LogicalPart>
+		<LogicalPart name="TIBTIDPowerConnectors" category="unspecified">
+			<rSolid name="PowerConnectors"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_PowerConnectors"/>
+		</LogicalPart>
+		<LogicalPart name="TIBTIDTSTCabCont" category="unspecified">
+			<rSolid name="TSTCabCont"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIBTIDTSTCabAxial" category="unspecified">
+			<rSolid name="TSTCabAxial"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_TSTCabAxial"/>
+		</LogicalPart>
+		<LogicalPart name="TIBTIDTSTCabRadial" category="unspecified">
+			<rSolid name="TSTCabRadial"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_TSTCabRadial"/>
+		</LogicalPart>
+		<!-- TEC Rails -->
+		<LogicalPart name="TECRailsA" category="unspecified">
+			<rSolid name="tibtidservices:TECRailsA"/>
+			<rMaterial name="tecmaterial:TEC_Rails"/>
+		</LogicalPart>
+		<LogicalPart name="TECRailsB" category="unspecified">
+			<rSolid name="tibtidservices:TECRailsB"/>
+			<rMaterial name="tecmaterial:TEC_Rails"/>
+		</LogicalPart>
+		<LogicalPart name="TECRailsConnector" category="unspecified">
+			<rSolid name="tibtidservices:TECRailsConnector"/>
+			<rMaterial name="tecmaterial:TEC_RailsConnector"/>
+		</LogicalPart>
+		<LogicalPart name="TECRailsSupport" category="unspecified">
+			<rSolid name="tibtidservices:TECRailsSupport"/>
+			<rMaterial name="tecmaterial:TEC_RailsSupport"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tibtidservices.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservices:TIDSupport"/>
+			<rChild name="tibtidservices:TIDSupportIn"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservices:TIBTIDOpticalPanel"/>
+			<rChild name="tibtidservices:TIBTIDOptoPanelFront"/>
+			<Translation x="[zero]" y="[zero]" z="[OptoPanelFrontZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservices:TIBTIDOpticalPanel"/>
+			<rChild name="tibtidservices:TIBTIDOptoConnectors"/>
+			<Translation x="[zero]" y="[zero]" z="[OptoConnectorsZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservices:TIBTIDOpticalPanel"/>
+			<rChild name="tibtidservices:TIBTIDOptoPanelBackInner"/>
+			<Translation x="[zero]" y="[zero]" z="[OptoPanelBackZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservices:TIBTIDOpticalPanel"/>
+			<rChild name="tibtidservices:TIBTIDOptoPanelBackOuter"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservices:TIBTIDTSTCabCont"/>
+			<rChild name="tibtidservices:TIBTIDTSTCabAxial"/>
+			<Translation x="[zero]" y="[zero]" z="[TSTCabAxialZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservices:TIBTIDTSTCabCont"/>
+			<rChild name="tibtidservices:TIBTIDTSTCabRadial"/>
+		</PosPart>
+		<!-- TEC Rails: Connectors -->
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservices:TECRailsA"/>
+			<rChild name="tibtidservices:TECRailsConnector"/>
+			<Translation x="[zero]" y="[zero]" z="-[TECRailsConnectorZDist]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tibtidservices:TECRailsA"/>
+			<rChild name="tibtidservices:TECRailsConnector"/>
+			<Translation x="[zero]" y="[zero]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tibtidservices:TECRailsA"/>
+			<rChild name="tibtidservices:TECRailsConnector"/>
+			<Translation x="[zero]" y="[zero]" z="+[TECRailsConnectorZDist]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservices:TECRailsB"/>
+			<rChild name="tibtidservices:TECRailsConnector"/>
+			<Translation x="[zero]" y="[zero]" z="(-[TECRailsConnectorZDistB3]-[TECRailsConnectorZDistB2]-[TECRailsConnectorZDistB1])/2"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tibtidservices:TECRailsB"/>
+			<rChild name="tibtidservices:TECRailsConnector"/>
+			<Translation x="[zero]" y="[zero]" z="(-[TECRailsConnectorZDistB3]-[TECRailsConnectorZDistB2]+[TECRailsConnectorZDistB1])/2"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tibtidservices:TECRailsB"/>
+			<rChild name="tibtidservices:TECRailsConnector"/>
+			<Translation x="[zero]" y="[zero]" z="(-[TECRailsConnectorZDistB3]+[TECRailsConnectorZDistB2]+[TECRailsConnectorZDistB1])/2"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="tibtidservices:TECRailsB"/>
+			<rChild name="tibtidservices:TECRailsConnector"/>
+			<Translation x="[zero]" y="[zero]" z="(+[TECRailsConnectorZDistB3]+[TECRailsConnectorZDistB2]+[TECRailsConnectorZDistB1])/2"/>
+		</PosPart>
+		<!-- TEC Rails: Support -->
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservices:TECRailsA"/>
+			<rChild name="tibtidservices:TECRailsSupport"/>
+			<Translation x="[zero]" y="[zero]" z="[TECRailsSupportZDist]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservices:TECRailsB"/>
+			<rChild name="tibtidservices:TECRailsSupport"/>
+			<Translation x="[zero]" y="[zero]" z="[TECRailsSupportZDist]"/>
+		</PosPart>
+	</PosPartSection>
+	<!-- TEC Rails -->
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tibtidservices:TIBTIDTSTCabCont"/>
+		<String name="ChildName" value="tibtidservices:TECRailsA"/>
+		<Numeric name="N" value="2"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[TECRailsPhi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			0, 0, [TECRailsAZ] </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tibtidservices:TIBTIDTSTCabCont"/>
+		<String name="ChildName" value="tibtidservices:TECRailsB"/>
+		<Numeric name="N" value="2"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[TECRailsPhi]"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			0, 0, [TECRailsBZ] </Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibtidservicesb.xml
+++ b/DetectorDescription/DDCMS/data/tibtidservicesb.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tibtidservicesb.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tibtidservicesb.xml">
+		<LogicalPart name="TIBTIDServicesB" category="unspecified">
+			<rSolid name="tibtidservices:TIBTIDServices"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="servicescylinderb.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesb:TIBTIDServicesB"/>
+			<rChild name="tibtidservices:TIDSupport"/>
+			<Translation x="[zero]" y="[zero]" z="[tibtidservices:TIDSupportZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesb:TIBTIDServicesB"/>
+			<rChild name="tibtidservices:TIBFlange"/>
+			<Translation x="[zero]" y="[zero]" z="[tibtidservices:TIBFlangeZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesb:TIBTIDServicesB"/>
+			<rChild name="tibtidservices:TIBTIDServiceCylinder"/>
+			<Translation x="[zero]" y="[zero]" z="[tibtidservices:ServiceCylinderZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesb:TIBTIDServicesB"/>
+			<rChild name="tibtidservices:TIBTIDPxlFlange"/>
+			<Translation x="[zero]" y="[zero]" z="[tibtidservices:PixelSupportFlangeZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesb:TIBTIDServicesB"/>
+			<rChild name="tibtidservices:TIBTIDPxlFlange2"/>
+			<Translation x="[zero]" y="[zero]" z="[tibtidservices:PixelSupportFlange2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesb:TIBTIDServicesB"/>
+			<rChild name="tibtidservices:TIBTIDOpticalPanel"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesb:TIBTIDServicesB"/>
+			<rChild name="tibtidservices:TIBTIDMargherita"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesb:TIBTIDServicesB"/>
+                        <rChild name="tibtidservices:TIBTIDServiceDisk1"/>
+                </PosPart>
+                <PosPart copyNumber="1">
+                        <rParent name="tibtidservicesb:TIBTIDServicesB"/>
+                        <rChild name="tibtidservices:TIBTIDServiceDisk2"/>
+                        <Translation x="[zero]" y="[zero]" z="[tibtidservices:ServiceDisk2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesb:TIBTIDServicesB"/>
+			<rChild name="tibtidservices:TIBTIDPowerConnectors"/>
+			<Translation x="[zero]" y="[zero]" z="[tibtidservices:PowerConnectorsZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesb:TIBTIDServicesB"/>
+			<rChild name="tibtidservices:TIBTIDTSTCabCont"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tibtidservicesf.xml
+++ b/DetectorDescription/DDCMS/data/tibtidservicesf.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tibtidservicesf.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tibtidservicesf.xml">
+		<LogicalPart name="TIBTIDServicesF" category="unspecified">
+			<rSolid name="tibtidservices:TIBTIDServices"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="servicescylinderf.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesf:TIBTIDServicesF"/>
+			<rChild name="tibtidservices:TIDSupport"/>
+			<Translation x="[zero]" y="[zero]" z="[tibtidservices:TIDSupportZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesf:TIBTIDServicesF"/>
+			<rChild name="tibtidservices:TIBFlange"/>
+			<Translation x="[zero]" y="[zero]" z="[tibtidservices:TIBFlangeZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesf:TIBTIDServicesF"/>
+			<rChild name="tibtidservices:TIBTIDServiceCylinder"/>
+			<Translation x="[zero]" y="[zero]" z="[tibtidservices:ServiceCylinderZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesf:TIBTIDServicesF"/>
+			<rChild name="tibtidservices:TIBTIDPxlFlange"/>
+			<Translation x="[zero]" y="[zero]" z="[tibtidservices:PixelSupportFlangeZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesf:TIBTIDServicesF"/>
+			<rChild name="tibtidservices:TIBTIDPxlFlange2"/>
+			<Translation x="[zero]" y="[zero]" z="[tibtidservices:PixelSupportFlange2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesf:TIBTIDServicesF"/>
+			<rChild name="tibtidservices:TIBTIDOpticalPanel"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesf:TIBTIDServicesF"/>
+			<rChild name="tibtidservices:TIBTIDMargherita"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesf:TIBTIDServicesF"/>
+                        <rChild name="tibtidservices:TIBTIDServiceDisk1"/>
+                </PosPart>
+                <PosPart copyNumber="1">
+                        <rParent name="tibtidservicesf:TIBTIDServicesF"/>
+                        <rChild name="tibtidservices:TIBTIDServiceDisk2"/>
+                        <Translation x="[zero]" y="[zero]" z="[tibtidservices:ServiceDisk2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesf:TIBTIDServicesF"/>
+			<rChild name="tibtidservices:TIBTIDPowerConnectors"/>
+			<Translation x="[zero]" y="[zero]" z="[tibtidservices:PowerConnectorsZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tibtidservicesf:TIBTIDServicesF"/>
+			<rChild name="tibtidservices:TIBTIDTSTCabCont"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tid.xml
+++ b/DetectorDescription/DDCMS/data/tid.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tid.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="Rin" value="22.20*cm"/>
+		<Constant name="Rout" value="52.00*cm"/>
+		<Constant name="Zv1" value="73.6*cm"/>
+		<!-- begin of TID envelope  DO NOT TOUCH IT! -->
+		<Constant name="Zv2" value="111.3*cm"/>
+		<Constant name="WheelRin" value="22.38*cm"/>
+		<Constant name="WheelRout" value="51.20*cm"/>
+		<Constant name="WheelT" value="10.4*cm"/>
+		<!-- MAX ALLOWED VALUE 10.5 cm -->
+		<Constant name="WheelDZ0" value="5.5*cm"/>
+		<!-- Z off of Disk1 -->
+		<Constant name="WheelDZ" value="12.95*cm"/>
+		<!-- Z pitch of Disks -->
+		<Constant name="Wheel0Z" value="[Zv1]+[WheelDZ0]"/>
+		<Constant name="Wheel1Z" value="[Wheel0Z]+[WheelDZ]"/>
+		<Constant name="Wheel2Z" value="[Wheel1Z]+[WheelDZ]"/>
+		<Constant name="RingZ" value="3.50*cm"/>
+		<Constant name="SupportT" value="0.10*cm"/>
+		<Constant name="SupportRin" value="[WheelRout]"/>
+		<Constant name="SupportRout" value="52.00*cm"/>
+		<Constant name="SupportL" value="37.7*cm"/>
+		<!-- 37.2+0.5 ie [SideDiskT] included -->
+		<Constant name="SupportZ" value="[Zv1]+[SupportL]/2"/>
+		<Constant name="SupportInRin" value="[SupportRin]+[SupportT]"/>
+		<Constant name="SupportInRout" value="[SupportRout]-[SupportT]"/>
+		<Constant name="SideDiskRin" value="22.80*cm"/>
+		<Constant name="SideDiskT" value="0.50*cm"/>
+		<Constant name="SideDiskZ" value="[Zv1]+[SupportL]-[SideDiskT]/2"/>
+		<Constant name="SideDiskInT" value="0.50*cm"/>
+		<!-- "manine" -->
+		<Constant name="WheelFixDR" value="3.1*cm"/>
+		<Constant name="WheelFixRout" value="[tidringpar:Rout]"/>
+		<Constant name="WheelFixDZ" value="1.3*cm"/>
+		<!-- real value is 5,5 cm but set 1.3 cm to avoid overlaps -->
+		<Constant name="WheelFixDPhi" value="6.15*deg"/>
+		<Constant name="WheelFixTR" value="0.8*cm"/>
+		<Constant name="WheelFixTZ" value="0.4*cm"/>
+		<Constant name="WheelFixPhi" value="90.0*deg"/>
+	</ConstantsSection>
+	<SolidSection label="tid.xml">
+		<Polycone name="TID" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="[Zv1]" rMin="[Rin]" rMax="[Rout]"/>
+			<ZSection z="[Zv2]" rMin="[Rin]" rMax="[Rout]"/>
+		</Polycone>
+		<Tubs name="TIDWheel" rMin="[WheelRin]" rMax="[WheelRout]" dz="[WheelT]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TIDSupport" rMin="[SupportRin]" rMax="[SupportRout]" dz="[SupportL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TIDSupportIn" rMin="[SupportInRin]" rMax="[SupportInRout]" dz="[SupportL]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TIDSideDisk" rMin="[SideDiskRin]" rMax="[WheelRout]" dz="[SideDiskT]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TIDSideDiskIn" rMin="[SideDiskRin]" rMax="[WheelRout]" dz="[SideDiskInT]/2" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TIDWheelFix" rMin="[WheelFixRout]-[WheelFixDR]" rMax="[WheelFixRout]" dz="[WheelFixDZ]/2" startPhi="-[WheelFixDPhi]/2" deltaPhi="[WheelFixDPhi]"/>
+		<Tubs name="TIDWheelFixHole" rMin="[WheelFixRout]-[WheelFixDR]" rMax="[WheelFixRout]-[WheelFixTR]" dz="([WheelFixDZ]-[WheelFixTZ])/2" startPhi="-[WheelFixDPhi]/2" deltaPhi="[WheelFixDPhi]"/>
+		<SubtractionSolid name="TIDWheelFixCutted">
+			<rSolid name="TIDWheelFix"/>
+			<rSolid name="TIDWheelFixHole"/>
+			<Translation x="[zero]" y="[zero]" z="-[WheelFixTZ]/2"/>
+		</SubtractionSolid>
+	</SolidSection>
+	<LogicalPartSection label="tid.xml">
+		<LogicalPart name="TIDSupport" category="unspecified">
+			<rSolid name="TIDSupport"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TIDSupportIn" category="unspecified">
+			<rSolid name="TIDSupportIn"/>
+			<rMaterial name="trackermaterial:T_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TIDSideDisk" category="unspecified">
+			<rSolid name="TIDSideDisk"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TIDSideDiskIn" category="unspecified">
+			<rSolid name="TIDSideDiskIn"/>
+			<rMaterial name="trackermaterial:T_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TIDWheelFixCutted" category="unspecified">
+			<rSolid name="TIDWheelFixCutted"/>
+			<rMaterial name="tidmaterial:TID_WheelFixation"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tid.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tid:TIDSupport"/>
+			<rChild name="tid:TIDSupportIn"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tid:TIDSideDisk"/>
+			<rChild name="tid:TIDSideDiskIn"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidb.xml
+++ b/DetectorDescription/DDCMS/data/tidb.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidb.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tidb.xml">
+		<LogicalPart name="TIDB" category="unspecified">
+			<rSolid name="tid:TID"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIDWheelB" category="unspecified">
+			<rSolid name="tid:TIDWheel"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tidb.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tidb:TIDB"/>
+			<rChild name="tidb:TIDWheelB"/>
+			<Translation x="[zero]" y="[zero]" z="[tid:Wheel0Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidb:TIDB"/>
+			<rChild name="tidb:TIDWheelB"/>
+			<Translation x="[zero]" y="[zero]" z="[tid:Wheel1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tidb:TIDB"/>
+			<rChild name="tidb:TIDWheelB"/>
+			<Translation x="[zero]" y="[zero]" z="[tid:Wheel2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidb:TIDWheelB"/>
+			<rChild name="tidring0b:TIDRing0B"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidb:TIDWheelB"/>
+			<rChild name="tidring1b:TIDRing1B"/>
+			<Translation x="[zero]" y="[zero]" z="[tid:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tidb:TIDWheelB"/>
+			<rChild name="tidring2:TIDRing2"/>
+			<Translation x="[zero]" y="[zero]" z="-[tid:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidb:TIDB"/>
+			<rChild name="tid:TIDSupport"/>
+			<Translation x="[zero]" y="[zero]" z="[tid:SupportZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidb:TIDB"/>
+			<rChild name="tid:TIDSideDisk"/>
+			<Translation x="[zero]" y="[zero]" z="[tid:SideDiskZ]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring0b:TIDRing0B"/>
+		<String name="ChildName" value="tid:TIDWheelFixCutted"/>
+		<Numeric name="N" value="3"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tid:WheelFixPhi]"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			[zero], [zero], -([tidringpar:StructureT]+[tid:WheelFixDZ])/2
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidf.xml
+++ b/DetectorDescription/DDCMS/data/tidf.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidf.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tidf.xml">
+		<LogicalPart name="TIDF" category="unspecified">
+			<rSolid name="tid:TID"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIDWheelF" category="unspecified">
+			<rSolid name="tid:TIDWheel"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tidf.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tidf:TIDF"/>
+			<rChild name="tidf:TIDWheelF"/>
+			<Translation x="[zero]" y="[zero]" z="[tid:Wheel0Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidf:TIDF"/>
+			<rChild name="tidf:TIDWheelF"/>
+			<Translation x="[zero]" y="[zero]" z="[tid:Wheel1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tidf:TIDF"/>
+			<rChild name="tidf:TIDWheelF"/>
+			<Translation x="[zero]" y="[zero]" z="[tid:Wheel2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidf:TIDWheelF"/>
+			<rChild name="tidring0f:TIDRing0F"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidf:TIDWheelF"/>
+			<rChild name="tidring1f:TIDRing1F"/>
+			<Translation x="[zero]" y="[zero]" z="[tid:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="tidf:TIDWheelF"/>
+			<rChild name="tidring2:TIDRing2"/>
+			<Translation x="[zero]" y="[zero]" z="-[tid:RingZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidf:TIDF"/>
+			<rChild name="tid:TIDSupport"/>
+			<Translation x="[zero]" y="[zero]" z="[tid:SupportZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidf:TIDF"/>
+			<rChild name="tid:TIDSideDisk"/>
+			<Translation x="[zero]" y="[zero]" z="[tid:SideDiskZ]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring0f:TIDRing0F"/>
+		<String name="ChildName" value="tid:TIDWheelFixCutted"/>
+		<Numeric name="N" value="3"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[tid:WheelFixPhi]"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			[zero], [zero], -([tidringpar:StructureT]+[tid:WheelFixDZ])/2
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidmaterial.xml
+++ b/DetectorDescription/DDCMS/data/tidmaterial.xml
@@ -1,0 +1,340 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <MaterialSection label="tidmaterial.xml">
+    <CompositeMaterial name="TID_Mech" density="0.25139*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.11047">
+        <rMaterial name="trackermaterial:T_Nomex" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.83359">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02685">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02909">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_CoolPipe" density="2.17440*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.44661">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.55339">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_CoolManifold" density="2.20750*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.48924">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.51076">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_WheelFixation" density="4.95593*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.42707">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.57293">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_ICB1" density="2.21343*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.47891">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.43924">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00545">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03467">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02645">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00107">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00279">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0012">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00664">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00358">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_ICB2" density="2.18035*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.48128">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.44148">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0055">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03245">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02476">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00108">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00272">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00116">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00621">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00335">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_ICB3" density="2.83682*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.49183">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.45103">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00369">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02578">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01888">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00075">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00277">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00119">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00265">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00143">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_DOHM1" density="2.69687*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.6069">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12363">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00474">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07782">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04334">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00118">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00379">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00162">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00082">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0008">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09165">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_CCUM" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0169">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01248">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00259">
+        <rMaterial name="materials:Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00078">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00192">
+        <rMaterial name="materials:SMD_metal" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00526">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00044">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00332">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_DOHM2" density="2.43641*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.67179">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13681">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00337">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05528">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03079">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00084">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00269">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00115">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00058">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00057">
+        <rMaterial name="materials:Nickel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0651">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_CCUM" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.012">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00887">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00184">
+        <rMaterial name="materials:Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00056">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00136">
+        <rMaterial name="materials:SMD_metal" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00374">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00031">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00236">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_CoolInsert" density="5.46429*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_TIDModKaptonBox" density="1.25249*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.44711">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00555">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00844">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13306">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.33267">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03327">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0399">
+        <rMaterial name="materials:Iron" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_Spacer" density="2.98720*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.89555">
+        <rMaterial name="materials:Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10445">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_SSAOHBox" density="0.74445*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.61394">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_AOH" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04738">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03257">
+        <rMaterial name="materials:T_Bronze" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05626">
+        <rMaterial name="trackermaterial:T_FR4" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03252">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_HybridTails" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02612">
+        <rMaterial name="tibtidcommonmaterial:TIBTID_HybridTails" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01776">
+        <rMaterial name="materials:Iron" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.17345">
+        <rMaterial name="tidmaterial:TID_CoolPipe" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_DSAOHBox" density="0.74445*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1">
+        <rMaterial name="tidmaterial:TID_SSAOHBox" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_FiberLayer" density="1.13781*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.68491">
+        <rMaterial name="tibtidcommonmaterial:T_FiberPigtail" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.31509">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TID_ModuleFix" density="1.65714*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.50611">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.49389">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+  </MaterialSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidmodpar.xml
+++ b/DetectorDescription/DDCMS/data/tidmodpar.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidmodpar.xml" eval="true">
+		<Constant name="DetTilt" value="0.100*rad"/>
+		<Constant name="ModuleThickDS" value="0.710*cm"/>
+		<Constant name="ModuleThickSS" value="0.552*cm"/>
+		<Constant name="WaferThick" value="0.032*cm"/>
+		<Constant name="ActiveZDS" value="0.121*cm"/>
+		<Constant name="ActiveZSS" value="0*cm"/>
+		<Constant name="PitchThick" value="0.1130*cm"/>
+		<Constant name="PitchZDS" value="0.1315*cm"/>
+		<Constant name="PitchZSS" value="0.0105*cm"/>
+		<Constant name="HybridHeight" value="2.53*cm"/>
+		<Constant name="HybridWidth" value="4.70*cm"/>
+		<Constant name="HybridThick" value="[PitchThick]"/>
+		<Constant name="HybridZDS" value="[PitchZDS]"/>
+		<Constant name="HybridZSS" value="[PitchZSS]"/>
+		<Constant name="KaptonThick" value="0.030*cm"/>
+		<Constant name="KaptonZDS" value="0.090*cm"/>
+		<Constant name="KaptonZSS" value="-0.031*cm"/>
+		<Constant name="KaptonOver" value="0.400*cm"/>
+		<Constant name="BoxFrameWidth" value="7.70*cm"/>
+		<Constant name="BoxFrameHeightDS" value="1.95*cm"/>
+		<Constant name="BoxFrameHeightSS" value="[HybridHeight]"/>
+		<Constant name="BoxFrameThick" value="0.050*cm"/>
+		<Constant name="BoxFrameZDS" value="0.050*cm"/>
+		<Constant name="BoxFrameZSS" value="-0.071*cm"/>
+		<Constant name="SideFrameThick" value="[BoxFrameThick]"/>
+		<Constant name="SideFrameZDS" value="[BoxFrameZDS]"/>
+		<Constant name="SideFrameZSS" value="[BoxFrameZSS]"/>
+		<Constant name="SideFrameOver" value="0.200*cm"/>
+		<Constant name="BottomFrameOverDS" value="0.20*cm"/>
+		<Constant name="BottomFrameOverSS" value="0.15*cm"/>
+		<Constant name="TopFrameOverDS" value="0.15*cm"/>
+		<Constant name="TopFrameOverSS" value="0.20*cm"/>
+		<Constant name="PitchStereoTolerance" value="0.02*cm"/>
+		<!-- Cool Insert section -->
+		<Constant name="CoolInsertHeightSS" value="1.4*cm"/>
+		<Constant name="CoolInsertWidthSS" value="0.8*cm"/>
+		<Constant name="CoolInsertThickSS" value="0.18*cm"/>
+		<Constant name="CoolInsertZSS" value="[BoxFrameZSS]-0.5*([BoxFrameThick]+[CoolInsertThickSS])"/>
+		<Constant name="CoolInsertHeightDS" value="1.3*cm"/>
+		<Constant name="CoolInsertWidthDS" value="0.7*cm"/>
+		<Constant name="CoolInsertThickDS" value="0.25*cm"/>
+		<Constant name="CoolInsertZDS" value="-([KaptonZDS]+0.5*([KaptonThick]+[CoolInsertThickDS]))"/>
+		<!-- Spacers Section DS modules -->
+		<Constant name="BottomSpacersHeight" value="2.15*cm"/>
+		<Constant name="BottomSpacersWidth" value="7.70*cm"/>
+		<Constant name="BottomSpacersThick" value="0.050*cm"/>
+		<Constant name="BottomSpacersZ" value="[tid:zero]"/>
+		<Constant name="SideSpacersHeight" value="3.1*cm"/>
+		<Constant name="SideSpacersWidth" value="0.9*cm"/>
+		<!-- ~ 25% smaller then real ones -->
+		<Constant name="SideSpacersThick" value="[BottomSpacersThick]"/>
+		<Constant name="SideSpacersZ" value="[BottomSpacersZ]"/>
+	</ConstantsSection>
+	<SolidSection label="tidmodpar.xml">
+		<Box name="BottomSpacers" dx="[BottomSpacersWidth]/2" dy="[BottomSpacersThick]/2" dz="[BottomSpacersHeight]/2"/>
+		<Box name="SideSpacers" dx="[SideSpacersWidth]/2" dy="[SideSpacersThick]/2" dz="[SideSpacersHeight]/2"/>
+	</SolidSection>
+	<LogicalPartSection label="tidmodpar.xml">
+		<LogicalPart name="TIDBottomSpacers" category="unspecified">
+			<rSolid name="tidmodpar:BottomSpacers"/>
+			<rMaterial name="tidmaterial:TID_Spacer"/>
+		</LogicalPart>
+		<LogicalPart name="TIDSideSpacers" category="unspecified">
+			<rSolid name="tidmodpar:SideSpacers"/>
+			<rMaterial name="tidmaterial:TID_Spacer"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<RotationSection label="tidmodpar.xml">
+		<Rotation name="90ZD" thetaX="-90*deg" phiX="0*deg" thetaY="180*deg" phiY="0*deg" thetaZ="-90*deg" phiZ="90*deg"/>
+		<Rotation name="9NYX" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="-90*deg" phiZ="0*deg"/>
+		<Rotation name="9PYX" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="-90*deg" thetaZ="90*deg" phiZ="0*deg"/>
+		<Rotation name="RFI1" thetaX="-90*deg" phiX="0*deg" thetaY="-90*deg" phiY="90*deg" thetaZ="0*deg" phiZ="0*deg"/>
+		<Rotation name="RFI2" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="-90*deg" thetaZ="180*deg" phiZ="0*deg"/>
+		<Rotation name="F100" thetaX="84.2704*deg" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="5.7296*deg" phiZ="180*deg"/>
+		<Rotation name="G100" thetaX="-95.7296*deg" phiX="180*deg" thetaY="-90*deg" phiY="-90*deg" thetaZ="-5.7296*deg" phiZ="180*deg"/>
+		<Rotation name="R180" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="-90*deg" thetaZ="0*deg" phiZ="0*deg"/>
+	</RotationSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidmodule0.xml
+++ b/DetectorDescription/DDCMS/data/tidmodule0.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidmodule0.xml" eval="true">
+		<Constant name="FullHeight" value="11.2936000*cm"/>
+		<Constant name="ActiveHeight" value="11.0858000*cm"/>
+		<Constant name="DlTop" value="9.3754000*cm"/>
+		<Constant name="DlBottom" value="6.3588000*cm"/>
+		<Constant name="SideWidthTop" value="0.1082551*cm"/>
+		<Constant name="SideWidthBottom" value="0.0836793*cm"/>
+		<Constant name="DlHybrid" value="10.403*cm"/>
+		<Constant name="PitchHeight" value="1.30*cm"/>
+		<Constant name="BottomFrameHeight" value="0.70*cm"/>
+		<Constant name="TopFrameHeight" value="[PitchHeight]+[tidmodpar:TopFrameOverDS]+0.6*cm"/>
+		<Constant name="BoxFrameHeight" value="[tidmodpar:BoxFrameHeightDS]"/>
+		<Constant name="SideFrameWidth" value="1.35*cm"/>
+		<Constant name="CoolInsertShift" value="9.78*cm"/>
+		<Constant name="SideSpacersShift" value="[CoolInsertShift]"/>
+		<!-- alias for Module Height -->
+		<Constant name="ModuleHeight" value="[BoxFrameHeight]+[BottomFrameHeight]+[FullHeight]+[TopFrameHeight]-                                         [tidmodpar:TopFrameOverDS]-[tidmodpar:BottomFrameOverDS]"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDTIDModuleAlgo">
+		<rParent name="tidmodule0l:TIDModule0L"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="DetectorNumber" value="2"/>
+		<Numeric name="ModuleThick" value="[tidmodpar:ModuleThickDS]"/>
+		<Numeric name="DetTilt" value="[tidmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[tidmodule0:FullHeight]"/>
+		<Numeric name="DlTop" value="[tidmodule0:DlTop]"/>
+		<Numeric name="DlBottom" value="[tidmodule0:DlBottom]"/>
+		<Numeric name="DlHybrid" value="[tidmodule0:DlHybrid]"/>
+		<String name="DoComponents" value="Yes"/>
+		<String name="BoxFrameName" value="tidmodule0:TIDModule0BoxFrame"/>
+		<String name="BoxFrameMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Numeric name="BoxFrameWidth" value="[tidmodpar:BoxFrameWidth]"/>
+		<Numeric name="BoxFrameThick" value="[tidmodpar:BoxFrameThick]"/>
+		<Numeric name="BoxFrameHeight" value="[tidmodule0:BoxFrameHeight]"/>
+		<Numeric name="BottomFrameHeight" value="[tidmodule0:BottomFrameHeight]"/>
+		<Numeric name="BottomFrameOver" value="[tidmodpar:BottomFrameOverDS]"/>
+		<Numeric name="TopFrameHeight" value="[tidmodule0:TopFrameHeight]"/>
+		<Numeric name="TopFrameOver" value="[tidmodpar:TopFrameOverDS]"/>
+		<String name="SideFrameMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Numeric name="SideFrameWidth" value="[tidmodule0:SideFrameWidth]"/>
+		<Numeric name="SideFrameThick" value="[tidmodpar:SideFrameThick]"/>
+		<Numeric name="SideFrameOver" value="[tidmodpar:SideFrameOver]"/>
+		<Vector name="SideFrameName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiSideFrame,  tidmodule0:TIDModule0StereoSideFrame
+		</Vector>
+		<Vector name="HoleFrameName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiFrameHole,  tidmodule0:TIDModule0StereoFrameHole
+		</Vector>
+		<Vector name="HoleFrameRotation" type="string" nEntries="2">
+			tidmodpar:NULL, tidmodpar:F100
+		</Vector>
+		<String name="KaptonMaterial" value="tidmaterial:T_TIDModKaptonBox"/>
+		<Numeric name="KaptonThick" value="[tidmodpar:KaptonThick]"/>
+		<Numeric name="KaptonOver" value="[tidmodpar:KaptonOver]"/>
+		<Vector name="KaptonName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiKapton,  tidmodule0:TIDModule0StereoKapton
+		</Vector>
+		<Vector name="HoleKaptonName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiKaptonHole,  tidmodule0:TIDModule0StereoKaptonHole
+		</Vector>
+		<Vector name="HoleKaptonRotation" type="string" nEntries="2">
+			tidmodpar:NULL, tidmodpar:F100
+		</Vector>
+		<Vector name="WaferName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiWafer,  tidmodule0:TIDModule0StereoWafer
+		</Vector>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[SideWidthBottom]"/>
+		<Vector name="ActiveName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiActive, tidmodule0:TIDModule0StereoActive
+		</Vector>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[tidmodule0:ActiveHeight]"/>
+		<Vector name="WaferThick" type="numeric" nEntries="2">
+			[tidmodpar:WaferThick],   [tidmodpar:WaferThick]
+		</Vector>
+		<String name="ActiveRotation" value="tidmodpar:90ZD"/>
+		<Vector name="BackPlaneThick" type="numeric" nEntries="2">
+			2*[tracker:BackPlaneDz], 2*[tracker:BackPlaneDz]
+		</Vector>
+		<String name="HybridName" value="tidmodule0:TIDModule0Hybrid"/>
+		<String name="HybridMaterial" value="tibtidcommonmaterial:TIBTID_Hybrid"/>
+		<Numeric name="HybridHeight" value="[tidmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tidmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tidmodpar:HybridThick]"/>
+		<Vector name="PitchName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiPA,  tidmodule0:TIDModule0StereoPA
+		</Vector>
+		<String name="PitchMaterial" value="tibtidcommonmaterial:TIBTID_PA"/>
+		<Numeric name="PitchHeight" value="[tidmodule0:PitchHeight]"/>
+		<Numeric name="PitchThick" value="[tidmodpar:PitchThick]"/>
+		<Numeric name="PitchStereoTolerance" value="[tidmodpar:PitchStereoTolerance]"/>
+		<String name="CoolInsertName" value="tidmodule0:TIDCoolInsert"/>
+		<String name="CoolInsertMaterial" value="tidmaterial:TID_CoolInsert"/>
+		<Numeric name="CoolInsertHeight" value="[tidmodpar:CoolInsertHeightDS]"/>
+		<Numeric name="CoolInsertThick" value="[tidmodpar:CoolInsertThickDS]"/>
+		<Numeric name="CoolInsertWidth" value="[tidmodpar:CoolInsertWidthDS]"/>
+	</Algorithm>
+	<Algorithm name="track:DDTIDModuleAlgo">
+		<rParent name="tidmodule0r:TIDModule0R"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="DetectorNumber" value="2"/>
+		<Numeric name="ModuleThick" value="[tidmodpar:ModuleThickDS]"/>
+		<Numeric name="DetTilt" value="[tidmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[tidmodule0:FullHeight]"/>
+		<Numeric name="DlTop" value="[tidmodule0:DlTop]"/>
+		<Numeric name="DlBottom" value="[tidmodule0:DlBottom]"/>
+		<Numeric name="DlHybrid" value="[tidmodule0:DlHybrid]"/>
+		<String name="DoComponents" value="No"/>
+		<String name="BoxFrameName" value="tidmodule0:TIDModule0BoxFrame"/>
+		<String name="BoxFrameMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Numeric name="BoxFrameWidth" value="[tidmodpar:BoxFrameWidth]"/>
+		<Numeric name="BoxFrameThick" value="[tidmodpar:BoxFrameThick]"/>
+		<Numeric name="BoxFrameHeight" value="[tidmodule0:BoxFrameHeight]"/>
+		<Numeric name="BottomFrameHeight" value="[tidmodule0:BottomFrameHeight]"/>
+		<Numeric name="BottomFrameOver" value="[tidmodpar:BottomFrameOverDS]"/>
+		<Numeric name="TopFrameHeight" value="[tidmodule0:TopFrameHeight]"/>
+		<Numeric name="TopFrameOver" value="[tidmodpar:TopFrameOverDS]"/>
+		<String name="SideFrameMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Numeric name="SideFrameWidth" value="[tidmodule0:SideFrameWidth]"/>
+		<Numeric name="SideFrameThick" value="[tidmodpar:SideFrameThick]"/>
+		<Numeric name="SideFrameOver" value="[tidmodpar:SideFrameOver]"/>
+		<Vector name="SideFrameName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiSideFrame,  tidmodule0:TIDModule0StereoSideFrame
+		</Vector>
+		<Vector name="HoleFrameName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiFrameHole,  tidmodule0:TIDModule0StereoFrameHole
+		</Vector>
+		<Vector name="HoleFrameRotation" type="string" nEntries="2">
+			tidmodpar:NULL, tidmodpar:F100
+		</Vector>
+		<String name="KaptonMaterial" value="tidmaterial:T_TIDModKaptonBox"/>
+		<Numeric name="KaptonThick" value="[tidmodpar:KaptonThick]"/>
+		<Numeric name="KaptonOver" value="[tidmodpar:KaptonOver]"/>
+		<Vector name="KaptonName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiKapton,  tidmodule0:TIDModule0StereoKapton
+		</Vector>
+		<Vector name="HoleKaptonName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiKaptonHole,  tidmodule0:TIDModule0StereoKaptonHole
+		</Vector>
+		<Vector name="HoleKaptonRotation" type="string" nEntries="2">
+			tidmodpar:NULL, tidmodpar:F100
+		</Vector>
+		<Vector name="WaferName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiWafer,  tidmodule0:TIDModule0StereoWafer
+		</Vector>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[SideWidthBottom]"/>
+		<Vector name="ActiveName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiActive, tidmodule0:TIDModule0StereoActive
+		</Vector>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[tidmodule0:ActiveHeight]"/>
+		<Vector name="WaferThick" type="numeric" nEntries="2">
+			[tidmodpar:WaferThick],   [tidmodpar:WaferThick]
+		</Vector>
+		<String name="ActiveRotation" value="tidmodpar:90ZD"/>
+		<Vector name="BackPlaneThick" type="numeric" nEntries="2">
+			2*[tracker:BackPlaneDz], 2*[tracker:BackPlaneDz]
+		</Vector>
+		<String name="HybridName" value="tidmodule0:TIDModule0Hybrid"/>
+		<String name="HybridMaterial" value="tibtidcommonmaterial:TIBTID_Hybrid"/>
+		<Numeric name="HybridHeight" value="[tidmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tidmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tidmodpar:HybridThick]"/>
+		<Vector name="PitchName" type="string" nEntries="2">
+			tidmodule0:TIDModule0RphiPA,  tidmodule0:TIDModule0StereoPA
+		</Vector>
+		<String name="PitchMaterial" value="tibtidcommonmaterial:TIBTID_PA"/>
+		<Numeric name="PitchHeight" value="[tidmodule0:PitchHeight]"/>
+		<Numeric name="PitchThick" value="[tidmodpar:PitchThick]"/>
+		<Numeric name="PitchStereoTolerance" value="[tidmodpar:PitchStereoTolerance]"/>
+		<String name="CoolInsertName" value="tidmodule0:TIDCoolInsert"/>
+		<String name="CoolInsertMaterial" value="trackermaterial:T_Aluminium"/>
+		<Numeric name="CoolInsertHeight" value="[tidmodpar:CoolInsertHeightDS]"/>
+		<Numeric name="CoolInsertThick" value="[tidmodpar:CoolInsertThickDS]"/>
+		<Numeric name="CoolInsertWidth" value="[tidmodpar:CoolInsertWidthDS]"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidmodule0l.xml
+++ b/DetectorDescription/DDCMS/data/tidmodule0l.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <Algorithm name="track:DDTIDModulePosAlgo">
+  <rParent name="tidmodule0l:TIDModule0L"/>
+  <Numeric name="DetectorNumber" value="2"/>
+  <Numeric name="ModuleThick" value="[tidmodpar:ModuleThickDS]"/>
+  <Numeric name="DetTilt" value="-[tidmodpar:DetTilt]"/>
+  <Numeric name="FullHeight" value="[tidmodule0:FullHeight]"/>
+  <Numeric name="DlTop" value="[tidmodule0:DlTop]"/>
+  <Numeric name="DlBottom" value="[tidmodule0:DlBottom]"/>
+  <Numeric name="DlHybrid" value="[tidmodule0:DlHybrid]"/>
+  <String name="BoxFrameName" value="tidmodule0:TIDModule0BoxFrame"/>
+  <Numeric name="BoxFrameHeight" value="[tidmodule0:BoxFrameHeight]"/>
+  <Numeric name="BoxFrameWidth" value="[tidmodpar:BoxFrameWidth]"/>
+  <Vector name="BoxFrameZ" type="numeric" nEntries="2">
+   [tidmodpar:BoxFrameZDS],   -[tidmodpar:BoxFrameZDS] </Vector>
+  <Numeric name="BottomFrameHeight" value="[tidmodule0:BottomFrameHeight]"/>
+  <Numeric name="BottomFrameOver" value="[tidmodpar:BottomFrameOverDS]"/>
+  <Numeric name="TopFrameHeight" value="[tidmodule0:TopFrameHeight]"/>
+  <Numeric name="TopFrameOver" value="[tidmodpar:TopFrameOverDS]"/>
+  <Vector name="SideFrameName" type="string" nEntries="2">
+   tidmodule0:TIDModule0RphiSideFrame,  tidmodule0:TIDModule0StereoSideFrame</Vector>
+  <Vector name="SideFrameZ" type="numeric" nEntries="2">
+   [tidmodpar:SideFrameZDS],  -[tidmodpar:SideFrameZDS] </Vector>
+  <Vector name="SideFrameRotation" type="string" nEntries="2">
+   tidmodpar:NULL,  tidmodpar:NULL</Vector>
+  <Numeric name="SideFrameWidth" value="[tidmodule0:SideFrameWidth]"/>
+  <Numeric name="SideFrameOver" value="[tidmodpar:SideFrameOver]"/>
+  <Vector name="KaptonName" type="string" nEntries="2">
+   tidmodule0:TIDModule0RphiKapton,  tidmodule0:TIDModule0StereoKapton</Vector>
+  <Vector name="KaptonZ" type="numeric" nEntries="2">
+   [tidmodpar:KaptonZDS],  -[tidmodpar:KaptonZDS] </Vector>
+  <Vector name="KaptonRotation" type="string" nEntries="2">
+   tidmodpar:NULL,  tidmodpar:NULL</Vector>
+  <Vector name="WaferName" type="string" nEntries="2">
+   tidmodule0:TIDModule0RphiWafer,  tidmodule0:TIDModule0StereoWafer</Vector>
+  <Vector name="WaferZ" type="numeric" nEntries="2">
+   [tidmodpar:ActiveZDS],     -[tidmodpar:ActiveZDS] </Vector>
+  <Vector name="WaferRotation" type="string" nEntries="2">
+   tidmodpar:RFI1,  tidmodpar:F100</Vector>
+  <String name="HybridName" value="tidmodule0:TIDModule0Hybrid"/>
+  <Numeric name="HybridHeight" value="[tidmodpar:HybridHeight]"/>
+  <Vector name="HybridZ" type="numeric" nEntries="2">
+   [tidmodpar:HybridZDS],    -[tidmodpar:HybridZDS] </Vector>
+  <Vector name="PitchName" type="string" nEntries="2">
+   tidmodule0:TIDModule0RphiPA,  tidmodule0:TIDModule0StereoPA</Vector>
+  <Numeric name="PitchHeight" value="[tidmodule0:PitchHeight]"/>
+  <Vector name="PitchZ" type="numeric" nEntries="2">
+   [tidmodpar:PitchZDS],     -[tidmodpar:PitchZDS] </Vector>
+  <Vector name="PitchRotation" type="string" nEntries="2">
+   tidmodpar:NULL,  tidmodpar:9PYX</Vector>
+  <String name="CoolInsertName" value="tidmodule0:TIDCoolInsert"/>
+  <Numeric name="CoolInsertHeight" value="[tidmodpar:CoolInsertHeightDS]"/>
+  <Numeric name="CoolInsertWidth" value="[tidmodpar:CoolInsertWidthDS]"/>
+  <Numeric name="CoolInsertZ" value="[tidmodpar:CoolInsertZDS]"/>
+  <Vector name="CoolInsertShift" type="numeric" nEntries="2">
+   [tid:zero],  [tidmodule0:CoolInsertShift]  </Vector>
+  <String name="DoSpacers" value="Yes"/>
+  <String name="BottomSpacersName" value="tidmodpar:TIDBottomSpacers"/>
+  <Numeric name="BottomSpacersHeight" value="[tidmodpar:BottomSpacersHeight]"/>
+  <Numeric name="BottomSpacersZ" value="[tidmodpar:BottomSpacersZ]"/>
+  <String name="SideSpacersName" value="tidmodpar:TIDSideSpacers"/>
+  <Numeric name="SideSpacersHeight" value="[tidmodpar:SideSpacersHeight]"/>
+  <Numeric name="SideSpacersZ" value="[tidmodpar:SideSpacersZ]"/>
+  <Numeric name="SideSpacersThick" value="[tidmodpar:SideSpacersThick]"/>
+  <Numeric name="SideSpacersWidth" value="[tidmodpar:SideSpacersWidth]"/>
+  <Numeric name="SideSpacersShift" value="[tidmodule0:SideSpacersShift]"/>
+ </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidmodule0r.xml
+++ b/DetectorDescription/DDCMS/data/tidmodule0r.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <Algorithm name="track:DDTIDModulePosAlgo">
+  <rParent name="tidmodule0r:TIDModule0R"/>
+  <Numeric name="DetectorNumber" value="2"/>
+  <Numeric name="ModuleThick" value="[tidmodpar:ModuleThickDS]"/>
+  <Numeric name="DetTilt" value="[tidmodpar:DetTilt]"/>
+  <Numeric name="FullHeight" value="[tidmodule0:FullHeight]"/>
+  <Numeric name="DlTop" value="[tidmodule0:DlTop]"/>
+  <Numeric name="DlBottom" value="[tidmodule0:DlBottom]"/>
+  <Numeric name="DlHybrid" value="[tidmodule0:DlHybrid]"/>
+  <String name="BoxFrameName" value="tidmodule0:TIDModule0BoxFrame"/>
+  <Numeric name="BoxFrameHeight" value="[tidmodule0:BoxFrameHeight]"/>
+  <Numeric name="BoxFrameWidth" value="[tidmodpar:BoxFrameWidth]"/>
+  <Vector name="BoxFrameZ" type="numeric" nEntries="2">
+   [tidmodpar:BoxFrameZDS],   -[tidmodpar:BoxFrameZDS] </Vector>
+  <Numeric name="BottomFrameHeight" value="[tidmodule0:BottomFrameHeight]"/>
+  <Numeric name="BottomFrameOver" value="[tidmodpar:BottomFrameOverDS]"/>
+  <Numeric name="TopFrameHeight" value="[tidmodule0:TopFrameHeight]"/>
+  <Numeric name="TopFrameOver" value="[tidmodpar:TopFrameOverDS]"/>
+  <Vector name="SideFrameName" type="string" nEntries="2">
+   tidmodule0:TIDModule0RphiSideFrame,  tidmodule0:TIDModule0StereoSideFrame</Vector>
+  <Vector name="SideFrameZ" type="numeric" nEntries="2">
+   [tidmodpar:SideFrameZDS],  -[tidmodpar:SideFrameZDS] </Vector>
+  <Vector name="SideFrameRotation" type="string" nEntries="2">
+   tidmodpar:NULL,  tidmodpar:R180</Vector>
+  <Numeric name="SideFrameWidth" value="[tidmodule0:SideFrameWidth]"/>
+  <Numeric name="SideFrameOver" value="[tidmodpar:SideFrameOver]"/>
+  <Vector name="KaptonName" type="string" nEntries="2">
+   tidmodule0:TIDModule0RphiKapton,  tidmodule0:TIDModule0StereoKapton</Vector>
+  <Vector name="KaptonZ" type="numeric" nEntries="2">
+   [tidmodpar:KaptonZDS],  -[tidmodpar:KaptonZDS] </Vector>
+  <Vector name="KaptonRotation" type="string" nEntries="2">
+   tidmodpar:NULL,  tidmodpar:R180</Vector>
+  <Vector name="WaferName" type="string" nEntries="2">
+   tidmodule0:TIDModule0RphiWafer,  tidmodule0:TIDModule0StereoWafer</Vector>
+  <Vector name="WaferZ" type="numeric" nEntries="2">
+   [tidmodpar:ActiveZDS],     -[tidmodpar:ActiveZDS] </Vector>
+  <Vector name="WaferRotation" type="string" nEntries="2">
+   tidmodpar:RFI1,  tidmodpar:G100</Vector>
+  <String name="HybridName" value="tidmodule0:TIDModule0Hybrid"/>
+  <Numeric name="HybridHeight" value="[tidmodpar:HybridHeight]"/>
+  <Vector name="HybridZ" type="numeric" nEntries="2">
+   [tidmodpar:HybridZDS],    -[tidmodpar:HybridZDS] </Vector>
+  <Vector name="PitchName" type="string" nEntries="2">
+   tidmodule0:TIDModule0RphiPA,  tidmodule0:TIDModule0StereoPA</Vector>
+  <Numeric name="PitchHeight" value="[tidmodule0:PitchHeight]"/>
+  <Vector name="PitchZ" type="numeric" nEntries="2">
+   [tidmodpar:PitchZDS],     -[tidmodpar:PitchZDS] </Vector>
+  <Vector name="PitchRotation" type="string" nEntries="2">
+   tidmodpar:NULL,  tidmodpar:9NYX</Vector>
+  <String name="CoolInsertName" value="tidmodule0:TIDCoolInsert"/>
+  <Numeric name="CoolInsertHeight" value="[tidmodpar:CoolInsertHeightDS]"/>
+  <Numeric name="CoolInsertWidth" value="[tidmodpar:CoolInsertWidthDS]"/>
+  <Numeric name="CoolInsertZ" value="[tidmodpar:CoolInsertZDS]"/>
+  <Vector name="CoolInsertShift" type="numeric" nEntries="2">
+   [tid:zero],  [tidmodule0:CoolInsertShift]  </Vector>
+  <String name="DoSpacers" value="Yes"/>
+  <String name="BottomSpacersName" value="tidmodpar:TIDBottomSpacers"/>
+  <Numeric name="BottomSpacersHeight" value="[tidmodpar:BottomSpacersHeight]"/>
+  <Numeric name="BottomSpacersZ" value="[tidmodpar:BottomSpacersZ]"/>
+  <String name="SideSpacersName" value="tidmodpar:TIDSideSpacers"/>
+  <Numeric name="SideSpacersHeight" value="[tidmodpar:SideSpacersHeight]"/>
+  <Numeric name="SideSpacersZ" value="[tidmodpar:SideSpacersZ]"/>
+  <Numeric name="SideSpacersThick" value="[tidmodpar:SideSpacersThick]"/>
+  <Numeric name="SideSpacersWidth" value="[tidmodpar:SideSpacersWidth]"/>
+  <Numeric name="SideSpacersShift" value="[tidmodule0:SideSpacersShift]"/>
+ </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidmodule1.xml
+++ b/DetectorDescription/DDCMS/data/tidmodule1.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidmodule1.xml" eval="true">
+		<Constant name="FullHeight" value="9.0236000*cm"/>
+		<Constant name="ActiveHeight" value="8.8160000*cm"/>
+		<Constant name="DlTop" value="11.2202000*cm"/>
+		<Constant name="DlBottom" value="8.8096000*cm"/>
+		<Constant name="SideWidthTop" value="0.1076928*cm"/>
+		<Constant name="SideWidthBottom" value="0.0822066*cm"/>
+		<Constant name="DlHybrid" value="12.258*cm"/>
+		<Constant name="PitchHeight" value="1.40*cm"/>
+		<Constant name="BottomFrameHeight" value="0.85*cm"/>
+		<Constant name="TopFrameHeight" value="[PitchHeight]+[tidmodpar:TopFrameOverDS]+0.6*cm"/>
+		<Constant name="BoxFrameHeight" value="[tidmodpar:BoxFrameHeightDS]"/>
+		<Constant name="SideFrameWidth" value="1.30*cm"/>
+		<Constant name="CoolInsertShift" value="9.33*cm"/>
+		<Constant name="SideSpacersShift" value="[CoolInsertShift]"/>
+		<!-- alias for Module Height -->
+		<Constant name="ModuleHeight" value="[BoxFrameHeight]+[BottomFrameHeight]+[FullHeight]+[TopFrameHeight]-                                         [tidmodpar:TopFrameOverDS]-[tidmodpar:BottomFrameOverDS]"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDTIDModuleAlgo">
+		<rParent name="tidmodule1l:TIDModule1L"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="DetectorNumber" value="2"/>
+		<Numeric name="ModuleThick" value="[tidmodpar:ModuleThickDS]"/>
+		<Numeric name="DetTilt" value="[tidmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[tidmodule1:FullHeight]"/>
+		<Numeric name="DlTop" value="[tidmodule1:DlTop]"/>
+		<Numeric name="DlBottom" value="[tidmodule1:DlBottom]"/>
+		<Numeric name="DlHybrid" value="[tidmodule1:DlHybrid]"/>
+		<String name="DoComponents" value="Yes"/>
+		<String name="BoxFrameName" value="tidmodule1:TIDModule1BoxFrame"/>
+		<String name="BoxFrameMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Numeric name="BoxFrameWidth" value="[tidmodpar:BoxFrameWidth]"/>
+		<Numeric name="BoxFrameThick" value="[tidmodpar:BoxFrameThick]"/>
+		<Numeric name="BoxFrameHeight" value="[tidmodule1:BoxFrameHeight]"/>
+		<Numeric name="BottomFrameHeight" value="[tidmodule1:BottomFrameHeight]"/>
+		<Numeric name="BottomFrameOver" value="[tidmodpar:BottomFrameOverDS]"/>
+		<Numeric name="TopFrameHeight" value="[tidmodule1:TopFrameHeight]"/>
+		<Numeric name="TopFrameOver" value="[tidmodpar:TopFrameOverDS]"/>
+		<String name="SideFrameMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Numeric name="SideFrameWidth" value="[tidmodule1:SideFrameWidth]"/>
+		<Numeric name="SideFrameThick" value="[tidmodpar:SideFrameThick]"/>
+		<Numeric name="SideFrameOver" value="[tidmodpar:SideFrameOver]"/>
+		<Vector name="SideFrameName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiSideFrame,  tidmodule1:TIDModule1StereoSideFrame
+		</Vector>
+		<Vector name="HoleFrameName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiFrameHole,  tidmodule1:TIDModule1StereoFrameHole
+		</Vector>
+		<Vector name="HoleFrameRotation" type="string" nEntries="2">
+			tidmodpar:NULL, tidmodpar:F100
+		</Vector>
+		<String name="KaptonMaterial" value="tidmaterial:T_TIDModKaptonBox"/>
+		<Numeric name="KaptonThick" value="[tidmodpar:KaptonThick]"/>
+		<Numeric name="KaptonOver" value="[tidmodpar:KaptonOver]"/>
+		<Vector name="KaptonName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiKapton,  tidmodule1:TIDModule1StereoKapton
+		</Vector>
+		<Vector name="HoleKaptonName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiKaptonHole,  tidmodule1:TIDModule1StereoKaptonHole
+		</Vector>
+		<Vector name="HoleKaptonRotation" type="string" nEntries="2">
+			tidmodpar:NULL, tidmodpar:F100
+		</Vector>
+		<Vector name="WaferName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiWafer,  tidmodule1:TIDModule1StereoWafer
+		</Vector>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[SideWidthBottom]"/>
+		<Vector name="ActiveName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiActive, tidmodule1:TIDModule1StereoActive
+		</Vector>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[tidmodule1:ActiveHeight]"/>
+		<Vector name="WaferThick" type="numeric" nEntries="2">
+			[tidmodpar:WaferThick],   [tidmodpar:WaferThick]
+		</Vector>
+		<String name="ActiveRotation" value="tidmodpar:90ZD"/>
+		<Vector name="BackPlaneThick" type="numeric" nEntries="2">
+			2*[tracker:BackPlaneDz], 2*[tracker:BackPlaneDz]
+		</Vector>
+		<String name="HybridName" value="tidmodule1:TIDModule1Hybrid"/>
+		<String name="HybridMaterial" value="tibtidcommonmaterial:TIBTID_Hybrid"/>
+		<Numeric name="HybridHeight" value="[tidmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tidmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tidmodpar:HybridThick]"/>
+		<Vector name="PitchName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiPA,  tidmodule1:TIDModule1StereoPA
+		</Vector>
+		<String name="PitchMaterial" value="tibtidcommonmaterial:TIBTID_PA"/>
+		<Numeric name="PitchHeight" value="[tidmodule1:PitchHeight]"/>
+		<Numeric name="PitchThick" value="[tidmodpar:PitchThick]"/>
+		<Numeric name="PitchStereoTolerance" value="[tidmodpar:PitchStereoTolerance]"/>
+		<String name="CoolInsertName" value="tidmodule1:TIDCoolInsert"/>
+		<String name="CoolInsertMaterial" value="tidmaterial:TID_CoolInsert"/>
+		<Numeric name="CoolInsertHeight" value="[tidmodpar:CoolInsertHeightDS]"/>
+		<Numeric name="CoolInsertThick" value="[tidmodpar:CoolInsertThickDS]"/>
+		<Numeric name="CoolInsertWidth" value="[tidmodpar:CoolInsertWidthDS]"/>
+	</Algorithm>
+	<Algorithm name="track:DDTIDModuleAlgo">
+		<rParent name="tidmodule1r:TIDModule1R"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="DetectorNumber" value="2"/>
+		<Numeric name="ModuleThick" value="[tidmodpar:ModuleThickDS]"/>
+		<Numeric name="DetTilt" value="[tidmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[tidmodule1:FullHeight]"/>
+		<Numeric name="DlTop" value="[tidmodule1:DlTop]"/>
+		<Numeric name="DlBottom" value="[tidmodule1:DlBottom]"/>
+		<Numeric name="DlHybrid" value="[tidmodule1:DlHybrid]"/>
+		<String name="DoComponents" value="No"/>
+		<String name="BoxFrameName" value="tidmodule1:TIDModule1BoxFrame"/>
+		<String name="BoxFrameMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Numeric name="BoxFrameWidth" value="[tidmodpar:BoxFrameWidth]"/>
+		<Numeric name="BoxFrameThick" value="[tidmodpar:BoxFrameThick]"/>
+		<Numeric name="BoxFrameHeight" value="[tidmodule1:BoxFrameHeight]"/>
+		<Numeric name="BottomFrameHeight" value="[tidmodule1:BottomFrameHeight]"/>
+		<Numeric name="BottomFrameOver" value="[tidmodpar:BottomFrameOverDS]"/>
+		<Numeric name="TopFrameHeight" value="[tidmodule1:TopFrameHeight]"/>
+		<Numeric name="TopFrameOver" value="[tidmodpar:TopFrameOverDS]"/>
+		<String name="SideFrameMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Numeric name="SideFrameWidth" value="[tidmodule1:SideFrameWidth]"/>
+		<Numeric name="SideFrameThick" value="[tidmodpar:SideFrameThick]"/>
+		<Numeric name="SideFrameOver" value="[tidmodpar:SideFrameOver]"/>
+		<Vector name="SideFrameName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiSideFrame,  tidmodule1:TIDModule1StereoSideFrame
+		</Vector>
+		<Vector name="HoleFrameName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiFrameHole,  tidmodule1:TIDModule1StereoFrameHole
+		</Vector>
+		<Vector name="HoleFrameRotation" type="string" nEntries="2">
+			tidmodpar:NULL, tidmodpar:F100
+		</Vector>
+		<String name="KaptonMaterial" value="tidmaterial:T_TIDModKaptonBox"/>
+		<Numeric name="KaptonThick" value="[tidmodpar:KaptonThick]"/>
+		<Numeric name="KaptonOver" value="[tidmodpar:KaptonOver]"/>
+		<Vector name="KaptonName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiKapton,  tidmodule1:TIDModule1StereoKapton
+		</Vector>
+		<Vector name="HoleKaptonName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiKaptonHole,  tidmodule1:TIDModule1StereoKaptonHole
+		</Vector>
+		<Vector name="HoleKaptonRotation" type="string" nEntries="2">
+			tidmodpar:NULL, tidmodpar:F100
+		</Vector>
+		<Vector name="WaferName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiWafer,  tidmodule1:TIDModule1StereoWafer
+		</Vector>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[SideWidthBottom]"/>
+		<Vector name="ActiveName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiActive, tidmodule1:TIDModule1StereoActive
+		</Vector>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[tidmodule1:ActiveHeight]"/>
+		<Vector name="WaferThick" type="numeric" nEntries="2">
+			[tidmodpar:WaferThick],   [tidmodpar:WaferThick]
+		</Vector>
+		<String name="ActiveRotation" value="tidmodpar:90ZD"/>
+		<Vector name="BackPlaneThick" type="numeric" nEntries="2">
+			2*[tracker:BackPlaneDz], 2*[tracker:BackPlaneDz]
+		</Vector>
+		<String name="HybridName" value="tidmodule1:TIDModule1Hybrid"/>
+		<String name="HybridMaterial" value="tibtidcommonmaterial:TIBTID_Hybrid"/>
+		<Numeric name="HybridHeight" value="[tidmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tidmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tidmodpar:HybridThick]"/>
+		<Vector name="PitchName" type="string" nEntries="2">
+			tidmodule1:TIDModule1RphiPA,  tidmodule1:TIDModule1StereoPA
+		</Vector>
+		<String name="PitchMaterial" value="tibtidcommonmaterial:TIBTID_PA"/>
+		<Numeric name="PitchHeight" value="[tidmodule1:PitchHeight]"/>
+		<Numeric name="PitchThick" value="[tidmodpar:PitchThick]"/>
+		<Numeric name="PitchStereoTolerance" value="[tidmodpar:PitchStereoTolerance]"/>
+		<String name="CoolInsertName" value="tidmodule1:TIDCoolInsert"/>
+		<String name="CoolInsertMaterial" value="trackermaterial:T_Aluminium"/>
+		<Numeric name="CoolInsertHeight" value="[tidmodpar:CoolInsertHeightDS]"/>
+		<Numeric name="CoolInsertThick" value="[tidmodpar:CoolInsertThickDS]"/>
+		<Numeric name="CoolInsertWidth" value="[tidmodpar:CoolInsertWidthDS]"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidmodule1l.xml
+++ b/DetectorDescription/DDCMS/data/tidmodule1l.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <Algorithm name="track:DDTIDModulePosAlgo">
+  <rParent name="tidmodule1l:TIDModule1L"/>
+  <Numeric name="DetectorNumber" value="2"/>
+  <Numeric name="ModuleThick" value="[tidmodpar:ModuleThickDS]"/>
+  <Numeric name="DetTilt" value="-[tidmodpar:DetTilt]"/>
+  <Numeric name="FullHeight" value="[tidmodule1:FullHeight]"/>
+  <Numeric name="DlTop" value="[tidmodule1:DlTop]"/>
+  <Numeric name="DlBottom" value="[tidmodule1:DlBottom]"/>
+  <Numeric name="DlHybrid" value="[tidmodule1:DlHybrid]"/>
+  <String name="BoxFrameName" value="tidmodule1:TIDModule1BoxFrame"/>
+  <Numeric name="BoxFrameHeight" value="[tidmodule1:BoxFrameHeight]"/>
+  <Numeric name="BoxFrameWidth" value="[tidmodpar:BoxFrameWidth]"/>
+  <Vector name="BoxFrameZ" type="numeric" nEntries="2">
+   [tidmodpar:BoxFrameZDS],   -[tidmodpar:BoxFrameZDS] </Vector>
+  <Numeric name="BottomFrameHeight" value="[tidmodule1:BottomFrameHeight]"/>
+  <Numeric name="BottomFrameOver" value="[tidmodpar:BottomFrameOverDS]"/>
+  <Numeric name="TopFrameHeight" value="[tidmodule1:TopFrameHeight]"/>
+  <Numeric name="TopFrameOver" value="[tidmodpar:TopFrameOverDS]"/>
+  <Vector name="SideFrameName" type="string" nEntries="2">
+   tidmodule1:TIDModule1RphiSideFrame,  tidmodule1:TIDModule1StereoSideFrame</Vector>
+  <Vector name="SideFrameZ" type="numeric" nEntries="2">
+   [tidmodpar:SideFrameZDS],  -[tidmodpar:SideFrameZDS] </Vector>
+  <Vector name="SideFrameRotation" type="string" nEntries="2">
+   tidmodpar:NULL,  tidmodpar:NULL</Vector>
+  <Numeric name="SideFrameWidth" value="[tidmodule1:SideFrameWidth]"/>
+  <Numeric name="SideFrameOver" value="[tidmodpar:SideFrameOver]"/>
+  <Vector name="KaptonName" type="string" nEntries="2">
+   tidmodule1:TIDModule1RphiKapton,  tidmodule1:TIDModule1StereoKapton</Vector>
+  <Vector name="KaptonZ" type="numeric" nEntries="2">
+   [tidmodpar:KaptonZDS],  -[tidmodpar:KaptonZDS] </Vector>
+  <Vector name="KaptonRotation" type="string" nEntries="2">
+   tidmodpar:NULL,  tidmodpar:NULL</Vector>
+  <Vector name="WaferName" type="string" nEntries="2">
+   tidmodule1:TIDModule1RphiWafer,  tidmodule1:TIDModule1StereoWafer</Vector>
+  <Vector name="WaferZ" type="numeric" nEntries="2">
+   [tidmodpar:ActiveZDS],     -[tidmodpar:ActiveZDS] </Vector>
+  <Vector name="WaferRotation" type="string" nEntries="2">
+   tidmodpar:RFI1,  tidmodpar:F100</Vector>
+  <String name="HybridName" value="tidmodule1:TIDModule1Hybrid"/>
+  <Numeric name="HybridHeight" value="[tidmodpar:HybridHeight]"/>
+  <Vector name="HybridZ" type="numeric" nEntries="2">
+   [tidmodpar:HybridZDS],    -[tidmodpar:HybridZDS] </Vector>
+  <Vector name="PitchName" type="string" nEntries="2">
+   tidmodule1:TIDModule1RphiPA,  tidmodule1:TIDModule1StereoPA</Vector>
+  <Numeric name="PitchHeight" value="[tidmodule1:PitchHeight]"/>
+  <Vector name="PitchZ" type="numeric" nEntries="2">
+   [tidmodpar:PitchZDS],     -[tidmodpar:PitchZDS] </Vector>
+  <Vector name="PitchRotation" type="string" nEntries="2">
+   tidmodpar:NULL,  tidmodpar:9PYX</Vector>
+  <String name="CoolInsertName" value="tidmodule1:TIDCoolInsert"/>
+  <Numeric name="CoolInsertHeight" value="[tidmodpar:CoolInsertHeightDS]"/>
+  <Numeric name="CoolInsertWidth" value="[tidmodpar:CoolInsertWidthDS]"/>
+  <Numeric name="CoolInsertZ" value="[tidmodpar:CoolInsertZDS]"/>
+  <Vector name="CoolInsertShift" type="numeric" nEntries="2">
+   [tid:zero],  [tidmodule1:CoolInsertShift]
+  </Vector>
+  <String name="DoSpacers" value="Yes"/>
+  <String name="BottomSpacersName" value="tidmodpar:TIDBottomSpacers"/>
+  <Numeric name="BottomSpacersHeight" value="[tidmodpar:BottomSpacersHeight]"/>
+  <Numeric name="BottomSpacersZ" value="[tidmodpar:BottomSpacersZ]"/>
+  <String name="SideSpacersName" value="tidmodpar:TIDSideSpacers"/>
+  <Numeric name="SideSpacersHeight" value="[tidmodpar:SideSpacersHeight]"/>
+  <Numeric name="SideSpacersZ" value="[tidmodpar:SideSpacersZ]"/>
+  <Numeric name="SideSpacersThick" value="[tidmodpar:SideSpacersThick]"/>
+  <Numeric name="SideSpacersWidth" value="[tidmodpar:SideSpacersWidth]"/>
+  <Numeric name="SideSpacersShift" value="[tidmodule1:SideSpacersShift]"/>
+ </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidmodule1r.xml
+++ b/DetectorDescription/DDCMS/data/tidmodule1r.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <Algorithm name="track:DDTIDModulePosAlgo">
+  <rParent name="tidmodule1r:TIDModule1R"/>
+  <Numeric name="DetectorNumber" value="2"/>
+  <Numeric name="ModuleThick" value="[tidmodpar:ModuleThickDS]"/>
+  <Numeric name="DetTilt" value="[tidmodpar:DetTilt]"/>
+  <Numeric name="FullHeight" value="[tidmodule1:FullHeight]"/>
+  <Numeric name="DlTop" value="[tidmodule1:DlTop]"/>
+  <Numeric name="DlBottom" value="[tidmodule1:DlBottom]"/>
+  <Numeric name="DlHybrid" value="[tidmodule1:DlHybrid]"/>
+  <String name="BoxFrameName" value="tidmodule1:TIDModule1BoxFrame"/>
+  <Numeric name="BoxFrameHeight" value="[tidmodule1:BoxFrameHeight]"/>
+  <Numeric name="BoxFrameWidth" value="[tidmodpar:BoxFrameWidth]"/>
+  <Vector name="BoxFrameZ" type="numeric" nEntries="2">
+   [tidmodpar:BoxFrameZDS],   -[tidmodpar:BoxFrameZDS] </Vector>
+  <Numeric name="BottomFrameHeight" value="[tidmodule1:BottomFrameHeight]"/>
+  <Numeric name="BottomFrameOver" value="[tidmodpar:BottomFrameOverDS]"/>
+  <Numeric name="TopFrameHeight" value="[tidmodule1:TopFrameHeight]"/>
+  <Numeric name="TopFrameOver" value="[tidmodpar:TopFrameOverDS]"/>
+  <Vector name="SideFrameName" type="string" nEntries="2">
+   tidmodule1:TIDModule1RphiSideFrame,  tidmodule1:TIDModule1StereoSideFrame</Vector>
+  <Vector name="SideFrameZ" type="numeric" nEntries="2">
+   [tidmodpar:SideFrameZDS],  -[tidmodpar:SideFrameZDS] </Vector>
+  <Vector name="SideFrameRotation" type="string" nEntries="2">
+   tidmodpar:NULL,  tidmodpar:R180</Vector>
+  <Numeric name="SideFrameWidth" value="[tidmodule1:SideFrameWidth]"/>
+  <Numeric name="SideFrameOver" value="[tidmodpar:SideFrameOver]"/>
+  <Vector name="KaptonName" type="string" nEntries="2">
+   tidmodule1:TIDModule1RphiKapton,  tidmodule1:TIDModule1StereoKapton</Vector>
+  <Vector name="KaptonZ" type="numeric" nEntries="2">
+   [tidmodpar:KaptonZDS],  -[tidmodpar:KaptonZDS] </Vector>
+  <Vector name="KaptonRotation" type="string" nEntries="2">
+   tidmodpar:NULL,  tidmodpar:R180</Vector>
+  <Vector name="WaferName" type="string" nEntries="2">
+   tidmodule1:TIDModule1RphiWafer,  tidmodule1:TIDModule1StereoWafer</Vector>
+  <Vector name="WaferZ" type="numeric" nEntries="2">
+   [tidmodpar:ActiveZDS],     -[tidmodpar:ActiveZDS] </Vector>
+  <Vector name="WaferRotation" type="string" nEntries="2">
+   tidmodpar:RFI1,  tidmodpar:G100</Vector>
+  <String name="HybridName" value="tidmodule1:TIDModule1Hybrid"/>
+  <Numeric name="HybridHeight" value="[tidmodpar:HybridHeight]"/>
+  <Vector name="HybridZ" type="numeric" nEntries="2">
+   [tidmodpar:HybridZDS],    -[tidmodpar:HybridZDS] </Vector>
+  <Vector name="PitchName" type="string" nEntries="2">
+   tidmodule1:TIDModule1RphiPA,  tidmodule1:TIDModule1StereoPA</Vector>
+  <Numeric name="PitchHeight" value="[tidmodule1:PitchHeight]"/>
+  <Vector name="PitchZ" type="numeric" nEntries="2">
+   [tidmodpar:PitchZDS],     -[tidmodpar:PitchZDS] </Vector>
+  <Vector name="PitchRotation" type="string" nEntries="2">
+   tidmodpar:NULL,  tidmodpar:9NYX</Vector>
+  <String name="CoolInsertName" value="tidmodule1:TIDCoolInsert"/>
+  <Numeric name="CoolInsertHeight" value="[tidmodpar:CoolInsertHeightDS]"/>
+  <Numeric name="CoolInsertWidth" value="[tidmodpar:CoolInsertWidthDS]"/>
+  <Numeric name="CoolInsertZ" value="[tidmodpar:CoolInsertZDS]"/>
+  <Vector name="CoolInsertShift" type="numeric" nEntries="2">
+   [tid:zero],  [tidmodule1:CoolInsertShift]
+  </Vector>
+  <String name="DoSpacers" value="Yes"/>
+  <String name="BottomSpacersName" value="tidmodpar:TIDBottomSpacers"/>
+  <Numeric name="BottomSpacersHeight" value="[tidmodpar:BottomSpacersHeight]"/>
+  <Numeric name="BottomSpacersZ" value="[tidmodpar:BottomSpacersZ]"/>
+  <String name="SideSpacersName" value="tidmodpar:TIDSideSpacers"/>
+  <Numeric name="SideSpacersHeight" value="[tidmodpar:SideSpacersHeight]"/>
+  <Numeric name="SideSpacersZ" value="[tidmodpar:SideSpacersZ]"/>
+  <Numeric name="SideSpacersThick" value="[tidmodpar:SideSpacersThick]"/>
+  <Numeric name="SideSpacersWidth" value="[tidmodpar:SideSpacersWidth]"/>
+  <Numeric name="SideSpacersShift" value="[tidmodule1:SideSpacersShift]"/>
+ </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidmodule2.xml
+++ b/DetectorDescription/DDCMS/data/tidmodule2.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidmodule2.xml" eval="true">
+		<Constant name="FullHeight" value="11.2736000*cm"/>
+		<Constant name="ActiveHeight" value="11.0660000*cm"/>
+		<Constant name="DlTop" value="8.3012000*cm"/>
+		<Constant name="DlBottom" value="6.4904000*cm"/>
+		<Constant name="SideWidthTop" value="0.1006846*cm"/>
+		<Constant name="SideWidthBottom" value="0.0866913*cm"/>
+		<Constant name="DlHybrid" value="5.887*cm"/>
+		<Constant name="PitchHeight" value="0.90*cm"/>
+		<Constant name="BottomFrameHeight" value="[PitchHeight]+[tidmodpar:BottomFrameOverSS]"/>
+		<Constant name="TopFrameHeight" value="[tidmodpar:TopFrameOverSS]+0.4*cm"/>
+		<Constant name="BoxFrameHeight" value="[tidmodpar:BoxFrameHeightSS]"/>
+		<Constant name="SideFrameWidth" value="1.10*cm"/>
+		<Constant name="CoolInsertShift" value="9.58*cm"/>
+		<Constant name="SideSpacersShift" value="[CoolInsertShift]"/>
+		<!-- alias for Module Height -->
+		<Constant name="ModuleHeight" value="[BoxFrameHeight]+[BottomFrameHeight]+[FullHeight]+[TopFrameHeight]-                                            [tidmodpar:TopFrameOverSS]-[tidmodpar:BottomFrameOverSS]"/>
+	</ConstantsSection>
+	<Algorithm name="track:DDTIDModuleAlgo">
+		<rParent name="tidmodule2:TIDModule2"/>
+		<String name="GeneralMaterial" value="materials:Air"/>
+		<Numeric name="DetectorNumber" value="1"/>
+		<Numeric name="ModuleThick" value="[tidmodpar:ModuleThickSS]"/>
+		<Numeric name="DetTilt" value="[tidmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[tidmodule2:FullHeight]"/>
+		<Numeric name="DlTop" value="[tidmodule2:DlTop]"/>
+		<Numeric name="DlBottom" value="[tidmodule2:DlBottom]"/>
+		<Numeric name="DlHybrid" value="[tidmodule2:DlHybrid]"/>
+		<String name="DoComponents" value="Yes"/>
+		<String name="BoxFrameName" value="tidmodule2:TIDModule2BoxFrame"/>
+		<String name="BoxFrameMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Numeric name="BoxFrameWidth" value="[tidmodpar:BoxFrameWidth]"/>
+		<Numeric name="BoxFrameThick" value="[tidmodpar:BoxFrameThick]"/>
+		<Numeric name="BoxFrameHeight" value="[tidmodule2:BoxFrameHeight]"/>
+		<Numeric name="BottomFrameHeight" value="[tidmodule2:BottomFrameHeight]"/>
+		<Numeric name="BottomFrameOver" value="[tidmodpar:BottomFrameOverSS]"/>
+		<Numeric name="TopFrameHeight" value="[tidmodule2:TopFrameHeight]"/>
+		<Numeric name="TopFrameOver" value="[tidmodpar:TopFrameOverSS]"/>
+		<String name="SideFrameMaterial" value="trackermaterial:T_CarbonFibreStr"/>
+		<Numeric name="SideFrameWidth" value="[tidmodule2:SideFrameWidth]"/>
+		<Numeric name="SideFrameThick" value="[tidmodpar:SideFrameThick]"/>
+		<Numeric name="SideFrameOver" value="[tidmodpar:SideFrameOver]"/>
+		<Vector name="SideFrameName" type="string" nEntries="1">
+			tidmodule2:TIDModule2RphiSideFrame
+		</Vector>
+		<Vector name="HoleFrameName" type="string" nEntries="1">
+			tidmodule2:TIDModule2RphiFrameHole
+		</Vector>
+		<Vector name="HoleFrameRotation" type="string" nEntries="1">
+			tidmodpar:NULL
+		</Vector>
+		<String name="KaptonMaterial" value="tidmaterial:T_TIDModKaptonBox"/>
+		<Numeric name="KaptonThick" value="[tidmodpar:KaptonThick]"/>
+		<Numeric name="KaptonOver" value="[tidmodpar:KaptonOver]"/>
+		<Vector name="KaptonName" type="string" nEntries="1">
+			tidmodule2:TIDModule2RphiKapton
+		</Vector>
+		<Vector name="HoleKaptonName" type="string" nEntries="1">
+			tidmodule2:TIDModule2RphiKaptonHole
+		</Vector>
+		<Vector name="HoleKaptonRotation" type="string" nEntries="1">
+			tidmodpar:NULL
+		</Vector>
+		<Vector name="WaferName" type="string" nEntries="1">
+			tidmodule2:TIDModule2RphiWafer
+		</Vector>
+		<String name="WaferMaterial" value="materials:Silicon"/>
+		<Numeric name="SideWidthTop" value="[SideWidthTop]"/>
+		<Numeric name="SideWidthBottom" value="[SideWidthBottom]"/>
+		<Vector name="ActiveName" type="string" nEntries="1">
+			tidmodule2:TIDModule2RphiActive
+		</Vector>
+		<String name="ActiveMaterial" value="materials:Silicon"/>
+		<Numeric name="ActiveHeight" value="[tidmodule2:ActiveHeight]"/>
+		<Vector name="WaferThick" type="numeric" nEntries="1">
+			[tidmodpar:WaferThick]
+		</Vector>
+		<String name="ActiveRotation" value="tidmodpar:90ZD"/>
+		<Vector name="BackPlaneThick" type="numeric" nEntries="1">
+			2*[tracker:BackPlaneDz]
+		</Vector>
+		<String name="HybridName" value="tidmodule2:TIDModule2Hybrid"/>
+		<String name="HybridMaterial" value="tibtidcommonmaterial:TIBTID_Hybrid"/>
+		<Numeric name="HybridHeight" value="[tidmodpar:HybridHeight]"/>
+		<Numeric name="HybridWidth" value="[tidmodpar:HybridWidth]"/>
+		<Numeric name="HybridThick" value="[tidmodpar:HybridThick]"/>
+		<Vector name="PitchName" type="string" nEntries="1">
+			tidmodule2:TIDModule2RphiPA
+		</Vector>
+		<String name="PitchMaterial" value="tibtidcommonmaterial:TIBTID_PA"/>
+		<Numeric name="PitchHeight" value="[tidmodule2:PitchHeight]"/>
+		<Numeric name="PitchThick" value="[tidmodpar:PitchThick]"/>
+		<Numeric name="PitchStereoTolerance" value="[tidmodpar:PitchStereoTolerance]"/>
+		<String name="CoolInsertName" value="tidmodule2:TIDCoolInsert"/>
+		<String name="CoolInsertMaterial" value="tidmaterial:TID_CoolInsert"/>
+		<Numeric name="CoolInsertHeight" value="[tidmodpar:CoolInsertHeightSS]"/>
+		<Numeric name="CoolInsertThick" value="[tidmodpar:CoolInsertThickSS]"/>
+		<Numeric name="CoolInsertWidth" value="[tidmodpar:CoolInsertWidthSS]"/>
+	</Algorithm>
+	<Algorithm name="track:DDTIDModulePosAlgo">
+		<rParent name="tidmodule2:TIDModule2"/>
+		<Numeric name="DetectorNumber" value="1"/>
+		<Numeric name="ModuleThick" value="[tidmodpar:ModuleThickSS]"/>
+		<Numeric name="DetTilt" value="[tidmodpar:DetTilt]"/>
+		<Numeric name="FullHeight" value="[tidmodule2:FullHeight]"/>
+		<Numeric name="DlTop" value="[tidmodule2:DlTop]"/>
+		<Numeric name="DlBottom" value="[tidmodule2:DlBottom]"/>
+		<Numeric name="DlHybrid" value="[tidmodule2:DlHybrid]"/>
+		<String name="BoxFrameName" value="tidmodule2:TIDModule2BoxFrame"/>
+		<Numeric name="BoxFrameHeight" value="[tidmodule2:BoxFrameHeight]"/>
+		<Numeric name="BoxFrameWidth" value="[tidmodpar:BoxFrameWidth]"/>
+		<Vector name="BoxFrameZ" type="numeric" nEntries="1">
+			[tidmodpar:BoxFrameZSS]
+		</Vector>
+		<Numeric name="BottomFrameHeight" value="[tidmodule2:BottomFrameHeight]"/>
+		<Numeric name="BottomFrameOver" value="[tidmodpar:BottomFrameOverSS]"/>
+		<Numeric name="TopFrameHeight" value="[tidmodule2:TopFrameHeight]"/>
+		<Numeric name="TopFrameOver" value="[tidmodpar:TopFrameOverSS]"/>
+		<Vector name="SideFrameName" type="string" nEntries="1">
+			tidmodule2:TIDModule2RphiSideFrame
+		</Vector>
+		<Vector name="SideFrameZ" type="numeric" nEntries="1">
+			[tidmodpar:SideFrameZSS]
+		</Vector>
+		<Vector name="SideFrameRotation" type="string" nEntries="1">
+			tidmodpar:NULL
+		</Vector>
+		<Numeric name="SideFrameWidth" value="[tidmodule2:SideFrameWidth]"/>
+		<Numeric name="SideFrameOver" value="[tidmodpar:SideFrameOver]"/>
+		<Vector name="KaptonName" type="string" nEntries="1">
+			tidmodule2:TIDModule2RphiKapton
+		</Vector>
+		<Vector name="KaptonZ" type="numeric" nEntries="1">
+			[tidmodpar:KaptonZSS]
+		</Vector>
+		<Vector name="KaptonRotation" type="string" nEntries="1">
+			tidmodpar:NULL
+		</Vector>
+		<Vector name="WaferName" type="string" nEntries="1">
+			tidmodule2:TIDModule2RphiWafer
+		</Vector>
+		<Vector name="WaferZ" type="numeric" nEntries="1">
+			[tidmodpar:ActiveZSS]
+		</Vector>
+		<Vector name="WaferRotation" type="string" nEntries="1">
+			tidmodpar:RFI2
+		</Vector>
+		<String name="HybridName" value="tidmodule2:TIDModule2Hybrid"/>
+		<Numeric name="HybridHeight" value="[tidmodpar:HybridHeight]"/>
+		<Vector name="HybridZ" type="numeric" nEntries="1">
+			[tidmodpar:HybridZSS]
+		</Vector>
+		<Vector name="PitchName" type="string" nEntries="1">
+			tidmodule2:TIDModule2RphiPA
+		</Vector>
+		<Numeric name="PitchHeight" value="[tidmodule2:PitchHeight]"/>
+		<Vector name="PitchZ" type="numeric" nEntries="1">
+			[tidmodpar:PitchZSS]
+		</Vector>
+		<Vector name="PitchRotation" type="string" nEntries="1">
+			tidmodpar:NULL
+		</Vector>
+		<String name="CoolInsertName" value="tidmodule2:TIDCoolInsert"/>
+		<Numeric name="CoolInsertHeight" value="[tidmodpar:CoolInsertHeightSS]"/>
+		<Numeric name="CoolInsertWidth" value="[tidmodpar:CoolInsertWidthSS]"/>
+		<Numeric name="CoolInsertZ" value="[tidmodpar:CoolInsertZSS]"/>
+		<Vector name="CoolInsertShift" type="numeric" nEntries="2">
+			[tid:zero],  [tidmodule2:CoolInsertShift]</Vector>
+		<String name="DoSpacers" value="No"/>
+		<!-- everything below is dummy for SS -->
+		<String name="BottomSpacersName" value="tidmodpar:TIDBottomSpacers"/>
+		<Numeric name="BottomSpacersHeight" value="[tidmodpar:BottomSpacersHeight]"/>
+		<Numeric name="BottomSpacersZ" value="[tidmodpar:BottomSpacersZ]"/>
+		<String name="SideSpacersName" value="tidmodpar:TIDSideSpacers"/>
+		<Numeric name="SideSpacersHeight" value="[tidmodpar:SideSpacersHeight]"/>
+		<Numeric name="SideSpacersZ" value="[tidmodpar:SideSpacersZ]"/>
+		<Numeric name="SideSpacersThick" value="[tidmodpar:SideSpacersThick]"/>
+		<Numeric name="SideSpacersWidth" value="[tidmodpar:SideSpacersWidth]"/>
+		<Numeric name="SideSpacersShift" value="[tidmodule2:SideSpacersShift]"/>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidring0.xml
+++ b/DetectorDescription/DDCMS/data/tidring0.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidring0.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="Rmin" value="22.5261*cm"/>
+		<Constant name="NPhi" value="24"/>
+		<Constant name="PhiOff" value="0*deg"/>
+		<Constant name="ICBR" value="40.250*cm"/>
+		<Constant name="ICBTailR" value="[ICBR]+[tidringpar:ICBW]/2"/>
+		<Constant name="RPos" value="[Rmin]+[tidmodule0:ModuleHeight]/2"/>
+		<Constant name="ICCRPos" value="[Rmin]+[tidmodule0:ModuleHeight]+[tidringpar:ICCROffset]+[tidringpar:ICCH]/2"/>
+		<Constant name="ICBTailW" value="([tidringpar:Rout]-[ICBTailR]-            [tidringpar:ICBTailTol])"/>
+		<Constant name="ICBTailRPos" value="([tidringpar:Rout]+[ICBTailR]-            [tidringpar:ICBTailTol])/2"/>
+		<Constant name="CCUMrPos" value="[ICBTailR]+2*[tidringpar:ICBTailTol]+[tidringpar:CCUMW]/2"/>
+		<Constant name="CoolR1" value="[Rmin]+[tidmodule0:ModuleHeight]-[tidmodule0:CoolInsertShift]"/>
+		<Constant name="CoolR2" value="[Rmin]+[tidmodule0:ModuleHeight]-[tidmodpar:CoolInsertHeightDS]+[tidringpar:CoolD]/2"/>
+		<Constant name="DOHMrIn" value="44.5*cm"/>
+		<Constant name="DOHMrOut" value="50.5*cm"/>
+		<Constant name="DOHMrOff" value="-0.5*cm"/>
+		<Constant name="DOHMdPhi" value="18*deg"/>
+		<Constant name="CoolManifoldL" value="17*cm"/>
+		<Constant name="FlatCablerIn" value="[ICBR]+[tidringpar:ICBW]/2"/>
+		<Constant name="FlatCablerOut" value="[FlatCablerIn]+6*cm"/>
+		<Constant name="FlatCabledPhi" value="30*deg"/>
+		<Constant name="FlatCablephiPos" value="21*deg"/>
+		<!-- palced symmetrically wrt the MC at 21 deg -->
+		<Constant name="FlatCablephiPosOff" value="3*deg"/>
+		<Constant name="FlatCablephiPosL" value="[FlatCablephiPos]-[FlatCablephiPosOff]-[FlatCabledPhi]/2"/>
+		<Constant name="FlatCablephiPosR" value="[FlatCablephiPos]+[FlatCablephiPosOff]+[FlatCabledPhi]/2"/>
+		<Constant name="ModuleFixationInsertsInR" value="28.8*cm"/>
+		<Constant name="ModuleFixationInsertsOutR" value="37.7*cm"/>
+	</ConstantsSection>
+	<SolidSection label="tidring0.xml">
+		<Tubs name="TIDRing0ICB" rMin="([ICBR]-[tidringpar:ICBW]/2)" rMax="([ICBR]+[tidringpar:ICBW]/2)" dz="[tidringpar:ICBT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Box name="TIDRing0ICBTail" dx="[tidringpar:ICBTailH]/2" dy="[ICBTailW]/2" dz="[tidringpar:ICBTailT]/2"/>
+		<Torus name="TIDRing0Cool1" innerRadius="[zero]" outerRadius="[tidringpar:CoolD]/2" torusRadius="[CoolR1]" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Torus name="TIDRing0Cool2" innerRadius="[zero]" outerRadius="[tidringpar:CoolD]/2" torusRadius="[CoolR2]" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TIDRing0DOHM" rMin="([DOHMrIn])" rMax="([DOHMrOut])" dz="[tidringpar:DOHMT]/2" startPhi="-[DOHMdPhi]/2" deltaPhi="[DOHMdPhi]"/>
+		<Tubs name="TIDRing0FiberLayer" rMin="([ICBR]-[tidringpar:ICBW]/2)" rMax="([ICBR]+[tidringpar:ICBW]/2)" dz="[tidringpar:FiberLayerT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Box name="TIDRing0CoolManifold" dx="[tidringpar:CoolManifoldW]/2" dy="[CoolManifoldL]/2" dz="[tidringpar:CoolManifoldT]/2"/>
+		<Tubs name="TIDRing0FlatCable" rMin="[FlatCablerIn]" rMax="[FlatCablerOut]" dz="[tidringpar:FlatCableT]/2" startPhi="-[FlatCabledPhi]/2" deltaPhi="[FlatCabledPhi]"/>
+	</SolidSection>
+	<LogicalPartSection label="tidring0.xml">
+		<LogicalPart name="TIDStructure0" category="unspecified">
+			<rSolid name="tidringpar:TIDStructure"/>
+			<rMaterial name="tidmaterial:TID_Mech"/>
+		</LogicalPart>
+		<LogicalPart name="TIDICC0" category="unspecified">
+			<rSolid name="tidringpar:TIDICCDS"/>
+			<rMaterial name="tidmaterial:TID_DSAOHBox"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing0ICBTail" category="unspecified">
+			<rSolid name="tidring0:TIDRing0ICBTail"/>
+			<rMaterial name="tidmaterial:TID_ICB1"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing0ICB" category="unspecified">
+			<rSolid name="tidring0:TIDRing0ICB"/>
+			<rMaterial name="tidmaterial:TID_ICB1"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing0DOHM" category="unspecified">
+			<rSolid name="tidring0:TIDRing0DOHM"/>
+			<rMaterial name="tidmaterial:TID_DOHM1"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing0Cool1" category="unspecified">
+			<rSolid name="tidring0:TIDRing0Cool1"/>
+			<rMaterial name="tidmaterial:TID_CoolPipe"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing0Cool2" category="unspecified">
+			<rSolid name="tidring0:TIDRing0Cool2"/>
+			<rMaterial name="tidmaterial:TID_CoolPipe"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing0FiberLayer" category="unspecified">
+			<rSolid name="tidring0:TIDRing0FiberLayer"/>
+			<rMaterial name="tidmaterial:TID_FiberLayer"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing0CoolManifold" category="unspecified">
+			<rSolid name="tidring0:TIDRing0CoolManifold"/>
+			<rMaterial name="tidmaterial:TID_CoolManifold"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing0FlatCable" category="unspecified">
+			<rSolid name="tidring0:TIDRing0FlatCable"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_AmphCable"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring0:TIDStructure0"/>
+		<String name="ChildName" value="tidring0:TIDRing0CoolManifold"/>
+		<Numeric name="N" value="2"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="113*deg"/>
+		<Numeric name="Radius" value="[tidringpar:CoolManifoldR]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0 </Vector>
+	</Algorithm>
+	<!-- Inserts for module fixation  -->
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring0:TIDStructure0"/>
+		<String name="ChildName" value="tidringpar:TIDModuleFix"/>
+		<Numeric name="N" value="24"/>
+		<Numeric name="StartCopyNo" value="3"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="-9.90 *deg"/>
+		<Numeric name="Radius" value="[ModuleFixationInsertsInR]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring0:TIDStructure0"/>
+		<String name="ChildName" value="tidringpar:TIDModuleFix"/>
+		<Numeric name="N" value="24"/>
+		<Numeric name="StartCopyNo" value="27"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="+9.90*deg"/>
+		<Numeric name="Radius" value="[ModuleFixationInsertsInR]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring0:TIDStructure0"/>
+		<String name="ChildName" value="tidringpar:TIDModuleFix"/>
+		<Numeric name="N" value="24"/>
+		<Numeric name="StartCopyNo" value="51"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="-5.04*deg"/>
+		<Numeric name="Radius" value="[ModuleFixationInsertsOutR]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring0:TIDStructure0"/>
+		<String name="ChildName" value="tidringpar:TIDModuleFix"/>
+		<Numeric name="N" value="24"/>
+		<Numeric name="StartCopyNo" value="75"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="+5.04*deg"/>
+		<Numeric name="Radius" value="[ModuleFixationInsertsOutR]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidring0b.xml
+++ b/DetectorDescription/DDCMS/data/tidring0b.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidring0b.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tidring0b.xml">
+		<LogicalPart name="TIDRing0B" category="unspecified">
+			<rSolid name="tidringpar:TIDRing"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tidring0b.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tidring0b:TIDRing0B"/>
+			<rChild name="tidring0:TIDStructure0"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring0b:TIDRing0B"/>
+			<rChild name="tidring0:TIDRing0ICB"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring0b:TIDRing0B"/>
+			<rChild name="tidring0:TIDRing0ICB"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring0b:TIDRing0B"/>
+			<rChild name="tidring0:TIDRing0Cool1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring0b:TIDRing0B"/>
+			<rChild name="tidring0:TIDRing0Cool1"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring0b:TIDRing0B"/>
+			<rChild name="tidring0:TIDRing0Cool2"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring0b:TIDRing0B"/>
+			<rChild name="tidring0:TIDRing0Cool2"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring0b:TIDRing0B"/>
+			<rChild name="tidring0:TIDRing0FiberLayer"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:FiberLayerZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring0b:TIDRing0B"/>
+			<rChild name="tidring0:TIDRing0FiberLayer"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:FiberLayerZ]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring0b:TIDRing0B"/>
+		<String name="ChildName" value="tidring0:TIDRing0ICBTail"/>
+		<Numeric name="Radius" value="[tidring0:ICBTailRPos]"/>
+		<Numeric name="Tilt" value="-90*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="8">
+			165.0*deg,          60.0*deg,           24.0*deg,          21.0*deg,
+			345.0*deg,         240.0*deg,          204.0*deg,         201.0*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="8">
+			-[tidringpar:ICBZ], [tidringpar:ICBZ],  [tidringpar:ICBZ], -[tidringpar:ICBZ],
+			-[tidringpar:ICBZ], [tidringpar:ICBZ], -[tidringpar:ICBZ],  [tidringpar:ICBZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring0b:TIDRing0B"/>
+		<String name="ChildName" value="tidringpar:TIDCCUMBox"/>
+		<Numeric name="Radius" value="[tidring0:CCUMrPos]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="8">
+			165.0*deg,          60.0*deg,           24.0*deg,          21.0*deg,
+			345.0*deg,         240.0*deg,          204.0*deg,         201.0*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="8">
+			-[tidringpar:CCUMZ],  [tidringpar:CCUMZ], [tidringpar:CCUMZ], -[tidringpar:CCUMZ],
+			-[tidringpar:CCUMZ],  [tidringpar:CCUMZ],-[tidringpar:CCUMZ],  [tidringpar:CCUMZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring0b:TIDRing0B"/>
+		<String name="ChildName" value="tidring0:TIDRing0DOHM"/>
+		<Numeric name="Radius" value="[tidring0:DOHMrOff]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="2">
+			180.0*deg,          45.0*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="2">
+			-[tidringpar:DOHMZ], [tidringpar:DOHMZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring0b:TIDRing0B"/>
+		<String name="ChildName" value="tidring0:TIDRing0FlatCable"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="4">
+			[tidring0:FlatCablephiPosL],         [tidring0:FlatCablephiPosR],
+			[tidring0:FlatCablephiPosL]+180*deg, [tidring0:FlatCablephiPosR]+180*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="4">
+			-[tidringpar:FlatCableZ], -[tidringpar:FlatCableZ], 
+			[tidringpar:FlatCableZ],  [tidringpar:FlatCableZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTIDRingAlgo">
+		<rParent name="tidring0b:TIDRing0B"/>
+		<Vector name="ModuleName" type="string" nEntries="2">
+			tidmodule0l:TIDModule0L, tidmodule0r:TIDModule0R</Vector>
+		<String name="ICCName" value="tidring0:TIDICC0"/>
+		<Numeric name="Number" value="[tidring0:NPhi]"/>
+		<Numeric name="StartAngle" value="[tidring0:PhiOff]"/>
+		<Numeric name="ModuleR" value="[tidring0:RPos]"/>
+		<Vector name="ModuleZ" type="numeric" nEntries="2">
+			-[tidringpar:ModuleZDS],    [tidringpar:ModuleZDS]   </Vector>
+		<Numeric name="ICCR" value="[tidring0:ICCRPos]"/>
+		<Numeric name="ICCShift" value="[zero]"/>
+		<Vector name="ICCZ" type="numeric" nEntries="2">
+			-[tidringpar:ICCZ],         [tidringpar:ICCZ]        </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring0b:TIDRing0B"/>
+		<String name="ChildName" value="tidringpar:TIDManifoldFix"/>
+		<Numeric name="Radius" value="[tidringpar:CoolManifoldR]"/>
+		<Numeric name="Tilt" value="-90*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="4">
+			113.0*deg,         113.0*deg,          293.0*deg,         293.0*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="4">
+			[tidringpar:ManifoldFixZ], -[tidringpar:ManifoldFixZ],
+			[tidringpar:ManifoldFixZ], -[tidringpar:ManifoldFixZ]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidring0f.xml
+++ b/DetectorDescription/DDCMS/data/tidring0f.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidring0f.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tidring0f.xml">
+		<LogicalPart name="TIDRing0F" category="unspecified">
+			<rSolid name="tidringpar:TIDRing"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tidring0f.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tidring0f:TIDRing0F"/>
+			<rChild name="tidring0:TIDStructure0"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring0f:TIDRing0F"/>
+			<rChild name="tidring0:TIDRing0ICB"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring0f:TIDRing0F"/>
+			<rChild name="tidring0:TIDRing0ICB"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring0f:TIDRing0F"/>
+			<rChild name="tidring0:TIDRing0Cool1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring0f:TIDRing0F"/>
+			<rChild name="tidring0:TIDRing0Cool1"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring0f:TIDRing0F"/>
+			<rChild name="tidring0:TIDRing0Cool2"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring0f:TIDRing0F"/>
+			<rChild name="tidring0:TIDRing0Cool2"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring0f:TIDRing0F"/>
+			<rChild name="tidring0:TIDRing0FiberLayer"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:FiberLayerZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring0f:TIDRing0F"/>
+			<rChild name="tidring0:TIDRing0FiberLayer"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:FiberLayerZ]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring0f:TIDRing0F"/>
+		<String name="ChildName" value="tidring0:TIDRing0ICBTail"/>
+		<Numeric name="Radius" value="[tidring0:ICBTailRPos]"/>
+		<Numeric name="Tilt" value="-90*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="8">
+			165.0*deg,          60.0*deg,           24.0*deg,          21.0*deg,
+			345.0*deg,         240.0*deg,          204.0*deg,         201.0*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="8">
+			-[tidringpar:ICBZ], [tidringpar:ICBZ],  [tidringpar:ICBZ], -[tidringpar:ICBZ],
+			-[tidringpar:ICBZ], [tidringpar:ICBZ], -[tidringpar:ICBZ],  [tidringpar:ICBZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring0f:TIDRing0F"/>
+		<String name="ChildName" value="tidringpar:TIDCCUMBox"/>
+		<Numeric name="Radius" value="[tidring0:CCUMrPos]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="8">
+			165.0*deg,          60.0*deg,           24.0*deg,          21.0*deg,
+			345.0*deg,         240.0*deg,          204.0*deg,         201.0*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="8">
+			-[tidringpar:CCUMZ],  [tidringpar:CCUMZ], [tidringpar:CCUMZ], -[tidringpar:CCUMZ],
+			-[tidringpar:CCUMZ],  [tidringpar:CCUMZ],-[tidringpar:CCUMZ],  [tidringpar:CCUMZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring0f:TIDRing0F"/>
+		<String name="ChildName" value="tidring0:TIDRing0DOHM"/>
+		<Numeric name="Radius" value="[tidring0:DOHMrOff]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="2">
+			180.0*deg,          45.0*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="2">
+			-[tidringpar:DOHMZ], [tidringpar:DOHMZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring0f:TIDRing0F"/>
+		<String name="ChildName" value="tidring0:TIDRing0FlatCable"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="4">
+			[tidring0:FlatCablephiPosL],         [tidring0:FlatCablephiPosR],
+			[tidring0:FlatCablephiPosL]+180*deg, [tidring0:FlatCablephiPosR]+180*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="4">
+			-[tidringpar:FlatCableZ], -[tidringpar:FlatCableZ], 
+			[tidringpar:FlatCableZ],  [tidringpar:FlatCableZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTIDRingAlgo">
+		<rParent name="tidring0f:TIDRing0F"/>
+		<Vector name="ModuleName" type="string" nEntries="2">
+			tidmodule0l:TIDModule0L, tidmodule0r:TIDModule0R</Vector>
+		<String name="ICCName" value="tidring0:TIDICC0"/>
+		<Numeric name="Number" value="[tidring0:NPhi]"/>
+		<Numeric name="StartAngle" value="[tidring0:PhiOff]"/>
+		<Numeric name="ModuleR" value="[tidring0:RPos]"/>
+		<Vector name="ModuleZ" type="numeric" nEntries="2">
+			-[tidringpar:ModuleZDS],    [tidringpar:ModuleZDS]   </Vector>
+		<Numeric name="ICCR" value="[tidring0:ICCRPos]"/>
+		<Numeric name="ICCShift" value="[zero]"/>
+		<Vector name="ICCZ" type="numeric" nEntries="2">
+			-[tidringpar:ICCZ],         [tidringpar:ICCZ]        </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring0f:TIDRing0F"/>
+		<String name="ChildName" value="tidringpar:TIDManifoldFix"/>
+		<Numeric name="Radius" value="[tidringpar:CoolManifoldR]"/>
+		<Numeric name="Tilt" value="-90*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="4">
+			113.0*deg,         113.0*deg,          293.0*deg,         293.0*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="4">
+			[tidringpar:ManifoldFixZ], -[tidringpar:ManifoldFixZ],
+			[tidringpar:ManifoldFixZ], -[tidringpar:ManifoldFixZ]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidring1.xml
+++ b/DetectorDescription/DDCMS/data/tidring1.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidring1.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="Rmin" value="31.5462*cm"/>
+		<Constant name="NPhi" value="24"/>
+		<Constant name="PhiOff" value="0*deg"/>
+		<Constant name="ICBR" value="47.250*cm"/>
+		<Constant name="ICBTailR" value="[ICBR]+[tidringpar:ICBW]/2"/>
+		<Constant name="ICBTailH" value="8.6*cm"/>
+		<Constant name="RPos" value="[Rmin]+[tidmodule1:ModuleHeight]/2"/>
+		<Constant name="ICCRPos" value="[Rmin]+[tidmodule1:ModuleHeight]+[tidringpar:ICCROffset]+[tidringpar:ICCH]/2"/>
+		<Constant name="ICBTailW" value="([tidringpar:Rout]-[ICBTailR]-            4*[tidringpar:ICBTailTol])"/>
+		<Constant name="ICBTailRPos" value="([tidringpar:Rout]+[ICBTailR]-            4*[tidringpar:ICBTailTol])/2"/>
+		<Constant name="CCUMrPos" value="[tidringpar:Rout]-[tidringpar:CCUMH]/2-2*[tidringpar:ICBTailTol]"/>
+		<Constant name="CoolR1" value="[Rmin]+[tidmodule1:ModuleHeight]-[tidmodule1:CoolInsertShift]"/>
+		<Constant name="CoolR2" value="[Rmin]+[tidmodule1:ModuleHeight]-[tidmodpar:CoolInsertHeightDS]+[tidringpar:CoolD]/2"/>
+		<Constant name="DOHMrIn" value="44.5*cm"/>
+		<Constant name="DOHMrOut" value="50.5*cm"/>
+		<Constant name="DOHMrOff" value="-20.5*cm"/>
+		<Constant name="DOHMdPhi" value="18*deg"/>
+		<Constant name="DOHMphiPos" value="52.5*deg"/>
+		<Constant name="CoolManifoldL" value="14*cm"/>
+		<Constant name="FlatCablerIn" value="[tidringpar:Rin]"/>
+		<Constant name="FlatCablerOut" value="[FlatCablerIn]+22.5*cm"/>
+		<Constant name="FlatCabledPhi" value="90*deg"/>
+		<Constant name="FlatCableHolerIn" value="[tidringpar:Rin]+2.4*cm"/>
+		<Constant name="FlatCableHolerOut" value="[FlatCablerOut]"/>
+		<Constant name="FlatCableHoledPhi" value="84*deg"/>
+		<Constant name="FlatCablephiPosF" value="[DOHMphiPos]+[DOHMdPhi]+[FlatCabledPhi]/2"/>
+		<!-- tuned by eye -->
+		<Constant name="FlatCablephiPosB" value="[DOHMphiPos]-[DOHMdPhi]-[FlatCabledPhi]/2"/>
+		<!-- tuned by eye -->
+		<Constant name="ModuleFixationInsertsInR" value="36.4*cm"/>
+		<Constant name="ModuleFixationInsertsOutR" value="44.7*cm"/>
+	</ConstantsSection>
+	<SolidSection label="tidring1.xml">
+		<Tubs name="TIDRing1ICB" rMin="([ICBR]-[tidringpar:ICBW]/2)" rMax="([ICBR]+[tidringpar:ICBW]/2)" dz="[tidringpar:ICBT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Box name="TIDRing1ICBTail" dx="[ICBTailH]/2" dy="[ICBTailW]/2" dz="[tidringpar:ICBTailT]/2"/>
+		<Torus name="TIDRing1Cool1" innerRadius="[zero]" outerRadius="[tidringpar:CoolD]/2" torusRadius="[CoolR1]" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Torus name="TIDRing1Cool2" innerRadius="[zero]" outerRadius="[tidringpar:CoolD]/2" torusRadius="[CoolR2]" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TIDRing1DOHM" rMin="([DOHMrIn])" rMax="([DOHMrOut])" dz="[tidringpar:DOHMT]/2" startPhi="-[DOHMdPhi]/2" deltaPhi="[DOHMdPhi]"/>
+		<Tubs name="TIDRing1FiberLayer" rMin="([ICBR]-[tidringpar:ICBW]/2)" rMax="([ICBR]+[tidringpar:ICBW]/2)" dz="[tidringpar:FiberLayerT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Box name="TIDRing1CoolManifold" dx="[tidringpar:CoolManifoldW]/2" dy="[CoolManifoldL]/2" dz="[tidringpar:CoolManifoldT]/2"/>
+		<Tubs name="TIDRing1FlatCable" rMin="[FlatCablerIn]" rMax="[FlatCablerOut]" dz="[tidringpar:FlatCableT]/2" startPhi="-[FlatCabledPhi]/2" deltaPhi="[FlatCabledPhi]"/>
+		<Tubs name="TIDRing1FlatCableHole" rMin="[FlatCableHolerIn]" rMax="[FlatCableHolerOut]" dz="[tidringpar:FlatCableT]/2" startPhi="-[FlatCableHoledPhi]/2" deltaPhi="[FlatCableHoledPhi]"/>
+		<SubtractionSolid name="TIDRing1FlatCableCutted">
+			<rSolid name="TIDRing1FlatCable"/>
+			<rSolid name="TIDRing1FlatCableHole"/>
+		</SubtractionSolid>
+	</SolidSection>
+	<LogicalPartSection label="tidring1.xml">
+		<LogicalPart name="TIDStructure1" category="unspecified">
+			<rSolid name="tidringpar:TIDStructure"/>
+			<rMaterial name="tidmaterial:TID_Mech"/>
+		</LogicalPart>
+		<LogicalPart name="TIDICC1" category="unspecified">
+			<rSolid name="tidringpar:TIDICCDS"/>
+			<rMaterial name="tidmaterial:TID_DSAOHBox"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing1ICBTail" category="unspecified">
+			<rSolid name="tidring1:TIDRing1ICBTail"/>
+			<rMaterial name="tidmaterial:TID_ICB2"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing1ICB" category="unspecified">
+			<rSolid name="tidring1:TIDRing1ICB"/>
+			<rMaterial name="tidmaterial:TID_ICB2"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing1DOHM" category="unspecified">
+			<rSolid name="tidring1:TIDRing1DOHM"/>
+			<rMaterial name="tidmaterial:TID_DOHM1"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing1Cool1" category="unspecified">
+			<rSolid name="tidring1:TIDRing1Cool1"/>
+			<rMaterial name="tidmaterial:TID_CoolPipe"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing1Cool2" category="unspecified">
+			<rSolid name="tidring1:TIDRing1Cool2"/>
+			<rMaterial name="tidmaterial:TID_CoolPipe"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing1FiberLayer" category="unspecified">
+			<rSolid name="tidring1:TIDRing1FiberLayer"/>
+			<rMaterial name="tidmaterial:TID_FiberLayer"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing1CoolManifold" category="unspecified">
+			<rSolid name="tidring1:TIDRing1CoolManifold"/>
+			<rMaterial name="tidmaterial:TID_CoolManifold"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing1FlatCable" category="unspecified">
+			<rSolid name="tidring1:TIDRing1FlatCableCutted"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_AmphCable"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring1:TIDStructure1"/>
+		<String name="ChildName" value="tidring1:TIDRing1CoolManifold"/>
+		<Numeric name="N" value="2"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="52.5*deg"/>
+		<Numeric name="Radius" value="[tidringpar:CoolManifoldR]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0 </Vector>
+	</Algorithm>
+	<!-- Inserts for module fixation  -->
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring1:TIDStructure1"/>
+		<String name="ChildName" value="tidringpar:TIDModuleFix"/>
+		<Numeric name="N" value="24"/>
+		<Numeric name="StartCopyNo" value="3"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="-9.42*deg"/>
+		<Numeric name="Radius" value="[ModuleFixationInsertsInR]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring1:TIDStructure1"/>
+		<String name="ChildName" value="tidringpar:TIDModuleFix"/>
+		<Numeric name="N" value="24"/>
+		<Numeric name="StartCopyNo" value="27"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="+9.42*deg"/>
+		<Numeric name="Radius" value="[ModuleFixationInsertsInR]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring1:TIDStructure1"/>
+		<String name="ChildName" value="tidringpar:TIDModuleFix"/>
+		<Numeric name="N" value="24"/>
+		<Numeric name="StartCopyNo" value="51"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="-4.21*deg"/>
+		<Numeric name="Radius" value="[ModuleFixationInsertsOutR]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring1:TIDStructure1"/>
+		<String name="ChildName" value="tidringpar:TIDModuleFix"/>
+		<Numeric name="N" value="24"/>
+		<Numeric name="StartCopyNo" value="75"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="+4.21*deg"/>
+		<Numeric name="Radius" value="[ModuleFixationInsertsOutR]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidring1b.xml
+++ b/DetectorDescription/DDCMS/data/tidring1b.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidring1b.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tidring1b.xml">
+		<LogicalPart name="TIDRing1B" category="unspecified">
+			<rSolid name="tidringpar:TIDRing"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tidring1b.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tidring1b:TIDRing1B"/>
+			<rChild name="tidring1:TIDStructure1"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring1b:TIDRing1B"/>
+			<rChild name="tidring1:TIDRing1ICB"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring1b:TIDRing1B"/>
+			<rChild name="tidring1:TIDRing1ICB"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring1b:TIDRing1B"/>
+			<rChild name="tidring1:TIDRing1Cool1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring1b:TIDRing1B"/>
+			<rChild name="tidring1:TIDRing1Cool1"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring1b:TIDRing1B"/>
+			<rChild name="tidring1:TIDRing1Cool2"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring1b:TIDRing1B"/>
+			<rChild name="tidring1:TIDRing1Cool2"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring1b:TIDRing1B"/>
+			<rChild name="tidring1:TIDRing1FiberLayer"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:FiberLayerZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring1b:TIDRing1B"/>
+			<rChild name="tidring1:TIDRing1FiberLayer"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:FiberLayerZ]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring1b:TIDRing1B"/>
+		<String name="ChildName" value="tidring1:TIDRing1ICBTail"/>
+		<Numeric name="Radius" value="[tidring1:ICBTailRPos]"/>
+		<Numeric name="Tilt" value="-90*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="8">
+			167.5*deg,         117.5*deg,           77.5*deg,          27.5*deg,
+			347.5*deg,         297.5*deg,          257.5*deg,         207.5*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="8">
+			-[tidringpar:ICBZ], [tidringpar:ICBZ], -[tidringpar:ICBZ], [tidringpar:ICBZ],
+			-[tidringpar:ICBZ], [tidringpar:ICBZ], -[tidringpar:ICBZ], [tidringpar:ICBZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring1b:TIDRing1B"/>
+		<String name="ChildName" value="tidringpar:TIDCCUMBox"/>
+		<Numeric name="Radius" value="[tidring1:CCUMrPos]"/>
+		<Numeric name="Tilt" value="-90*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="8">
+			167.5*deg,         117.5*deg,           77.5*deg,          27.5*deg,
+			347.5*deg,         297.5*deg,          257.5*deg,         207.5*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="8">
+			-[tidringpar:CCUMZ],  [tidringpar:CCUMZ],-[tidringpar:CCUMZ],  [tidringpar:CCUMZ],
+			-[tidringpar:CCUMZ],  [tidringpar:CCUMZ],-[tidringpar:CCUMZ],  [tidringpar:CCUMZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring1b:TIDRing1B"/>
+		<String name="ChildName" value="tidring1:TIDRing1DOHM"/>
+		<Numeric name="Radius" value="[tidring1:DOHMrOff]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="2">
+			[tidring1:DOHMphiPos], [tidring1:DOHMphiPos]+180*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="2">
+			-[tidringpar:DOHMZ], [tidringpar:DOHMZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring1b:TIDRing1B"/>
+		<String name="ChildName" value="tidring1:TIDRing1FlatCable"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="4">
+			[tidring1:FlatCablephiPosF], [tidring1:FlatCablephiPosF]+180*deg, 
+			[tidring1:FlatCablephiPosB], [tidring1:FlatCablephiPosB]+180*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="4">
+			-[tidringpar:FlatCableZ], -[tidringpar:FlatCableZ], 
+			[tidringpar:FlatCableZ],  [tidringpar:FlatCableZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTIDRingAlgo">
+		<rParent name="tidring1b:TIDRing1B"/>
+		<Vector name="ModuleName" type="string" nEntries="2">
+			tidmodule1l:TIDModule1L, tidmodule1r:TIDModule1R</Vector>
+		<String name="ICCName" value="tidring1:TIDICC1"/>
+		<Numeric name="Number" value="[tidring1:NPhi]"/>
+		<Numeric name="StartAngle" value="[tidring1:PhiOff]"/>
+		<Numeric name="ModuleR" value="[tidring1:RPos]"/>
+		<Vector name="ModuleZ" type="numeric" nEntries="2">
+			-[tidringpar:ModuleZDS],    [tidringpar:ModuleZDS]   </Vector>
+		<Numeric name="ICCR" value="[tidring1:ICCRPos]"/>
+		<Numeric name="ICCShift" value="[zero]"/>
+		<Vector name="ICCZ" type="numeric" nEntries="2">
+			-[tidringpar:ICCZ],         [tidringpar:ICCZ]        </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring1b:TIDRing1B"/>
+		<String name="ChildName" value="tidringpar:TIDManifoldFix"/>
+		<Numeric name="Radius" value="[tidringpar:CoolManifoldR]"/>
+		<Numeric name="Tilt" value="-90*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="4">
+			52.5*deg,         52.5*deg,          232.5*deg,         232.5*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="4">
+			[tidringpar:ManifoldFixZ]+[tidringpar:FiberLayerT]+[tidringpar:ICBT] , 
+			-([tidringpar:ManifoldFixZ]+[tidringpar:FiberLayerT]+[tidringpar:ICBT]),
+			[tidringpar:ManifoldFixZ]+[tidringpar:FiberLayerT]+[tidringpar:ICBT] , 
+			-([tidringpar:ManifoldFixZ]+[tidringpar:FiberLayerT]+[tidringpar:ICBT])
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidring1f.xml
+++ b/DetectorDescription/DDCMS/data/tidring1f.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidring1f.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tidring1f.xml">
+		<LogicalPart name="TIDRing1F" category="unspecified">
+			<rSolid name="tidringpar:TIDRing"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tidring1f.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tidring1f:TIDRing1F"/>
+			<rChild name="tidring1:TIDStructure1"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring1f:TIDRing1F"/>
+			<rChild name="tidring1:TIDRing1ICB"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring1f:TIDRing1F"/>
+			<rChild name="tidring1:TIDRing1ICB"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring1f:TIDRing1F"/>
+			<rChild name="tidring1:TIDRing1Cool1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring1f:TIDRing1F"/>
+			<rChild name="tidring1:TIDRing1Cool1"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring1f:TIDRing1F"/>
+			<rChild name="tidring1:TIDRing1Cool2"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring1f:TIDRing1F"/>
+			<rChild name="tidring1:TIDRing1Cool2"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring1f:TIDRing1F"/>
+			<rChild name="tidring1:TIDRing1FiberLayer"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:FiberLayerZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring1f:TIDRing1F"/>
+			<rChild name="tidring1:TIDRing1FiberLayer"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:FiberLayerZ]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring1f:TIDRing1F"/>
+		<String name="ChildName" value="tidring1:TIDRing1ICBTail"/>
+		<Numeric name="Radius" value="[tidring1:ICBTailRPos]"/>
+		<Numeric name="Tilt" value="-90*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="8">
+			167.5*deg,         117.5*deg,           77.5*deg,          27.5*deg,
+			347.5*deg,         297.5*deg,          257.5*deg,         207.5*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="8">
+			-[tidringpar:ICBZ], [tidringpar:ICBZ], -[tidringpar:ICBZ], [tidringpar:ICBZ],
+			-[tidringpar:ICBZ], [tidringpar:ICBZ], -[tidringpar:ICBZ], [tidringpar:ICBZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring1f:TIDRing1F"/>
+		<String name="ChildName" value="tidringpar:TIDCCUMBox"/>
+		<Numeric name="Radius" value="[tidring1:CCUMrPos]"/>
+		<Numeric name="Tilt" value="-90*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="8">
+			167.5*deg,         117.5*deg,           77.5*deg,          27.5*deg,
+			347.5*deg,         297.5*deg,          257.5*deg,         207.5*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="8">
+			-[tidringpar:CCUMZ],  [tidringpar:CCUMZ],-[tidringpar:CCUMZ],  [tidringpar:CCUMZ],
+			-[tidringpar:CCUMZ],  [tidringpar:CCUMZ],-[tidringpar:CCUMZ],  [tidringpar:CCUMZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring1f:TIDRing1F"/>
+		<String name="ChildName" value="tidring1:TIDRing1DOHM"/>
+		<Numeric name="Radius" value="[tidring1:DOHMrOff]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="2">
+			[tidring1:DOHMphiPos], [tidring1:DOHMphiPos]+180*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="2">
+			-[tidringpar:DOHMZ], [tidringpar:DOHMZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring1f:TIDRing1F"/>
+		<String name="ChildName" value="tidring1:TIDRing1FlatCable"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="4">
+			[tidring1:FlatCablephiPosF], [tidring1:FlatCablephiPosF]+180*deg, 
+			[tidring1:FlatCablephiPosB], [tidring1:FlatCablephiPosB]+180*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="4">
+			-[tidringpar:FlatCableZ], -[tidringpar:FlatCableZ], 
+			[tidringpar:FlatCableZ],  [tidringpar:FlatCableZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTIDRingAlgo">
+		<rParent name="tidring1f:TIDRing1F"/>
+		<Vector name="ModuleName" type="string" nEntries="2">
+			tidmodule1l:TIDModule1L, tidmodule1r:TIDModule1R</Vector>
+		<String name="ICCName" value="tidring1:TIDICC1"/>
+		<Numeric name="Number" value="[tidring1:NPhi]"/>
+		<Numeric name="StartAngle" value="[tidring1:PhiOff]"/>
+		<Numeric name="ModuleR" value="[tidring1:RPos]"/>
+		<Vector name="ModuleZ" type="numeric" nEntries="2">
+			-[tidringpar:ModuleZDS],    [tidringpar:ModuleZDS]   </Vector>
+		<Numeric name="ICCR" value="[tidring1:ICCRPos]"/>
+		<Numeric name="ICCShift" value="[zero]"/>
+		<Vector name="ICCZ" type="numeric" nEntries="2">
+			-[tidringpar:ICCZ],         [tidringpar:ICCZ]        </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring1f:TIDRing1F"/>
+		<String name="ChildName" value="tidringpar:TIDManifoldFix"/>
+		<Numeric name="Radius" value="[tidringpar:CoolManifoldR]"/>
+		<Numeric name="Tilt" value="-90*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="4">
+			52.5*deg,         52.5*deg,          232.5*deg,         232.5*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="4">
+			[tidringpar:ManifoldFixZ]+[tidringpar:FiberLayerT]+[tidringpar:ICBT] , 
+			-([tidringpar:ManifoldFixZ]+[tidringpar:FiberLayerT]+[tidringpar:ICBT]),
+			[tidringpar:ManifoldFixZ]+[tidringpar:FiberLayerT]+[tidringpar:ICBT] , 
+			-([tidringpar:ManifoldFixZ]+[tidringpar:FiberLayerT]+[tidringpar:ICBT])
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidring2.xml
+++ b/DetectorDescription/DDCMS/data/tidring2.xml
@@ -1,0 +1,287 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidring2.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="Rmin" value="35.6762*cm"/>
+		<Constant name="NPhi" value="40"/>
+		<Constant name="PhiOff" value="0*deg"/>
+		<Constant name="ICBR" value="33.350*cm"/>
+		<Constant name="ICBTailR" value="[ICBR]+[tidringpar:ICBW]/2"/>
+		<Constant name="RPos" value="[Rmin]+[tidmodule2:ModuleHeight]/2"/>
+		<Constant name="ICCRPos" value="[Rmin]-[tidringpar:ICCROffset]-[tidringpar:ICCH]/2"/>
+		<Constant name="ICBTailW" value="([tidringpar:Rout]-[ICBTailR]-            [tidringpar:ICBTailTol])"/>
+		<Constant name="ICBTailRPos" value="([tidringpar:Rout]+[ICBTailR]-            [tidringpar:ICBTailTol])/2"/>
+		<Constant name="CCUMrPos" value="[ICBTailR]-[tidringpar:CCUMH]/2"/>
+		<Constant name="CoolR1" value="[Rmin]+[tidmodpar:CoolInsertHeightSS]-[tidringpar:CoolD]/2"/>
+		<Constant name="CoolR2" value="[Rmin]+[tidmodule2:CoolInsertShift]"/>
+		<Constant name="DOHMrIn" value="22.8*cm"/>
+		<Constant name="DOHMrMed" value="26.5*cm"/>
+		<Constant name="DOHMrOut" value="29.5*cm"/>
+		<Constant name="DOHMdPhiIn" value="37*deg"/>
+		<Constant name="DOHMdPhiOut" value="55*deg"/>
+		<Constant name="DOHMrOff" value="-0.15*cm"/>
+		<Constant name="DOHMphiPos" value="157.5*deg"/>
+		<Constant name="CoolManifoldL" value="8.0*cm"/>
+		<Constant name="FlatCablerIn" value="[tidringpar:Rin]"/>
+		<Constant name="FlatCablerOut" value="[FlatCablerIn]+4*cm"/>
+		<Constant name="FlatCabledPhi" value="35*deg"/>
+		<Constant name="FlatCablephiPosOff" value="3*deg"/>
+		<Constant name="FlatCablephiPosL" value="[DOHMphiPos]-[FlatCablephiPosOff]-([DOHMdPhiOut]+[FlatCabledPhi])/2"/>
+		<Constant name="FlatCablephiPosR" value="[DOHMphiPos]+[FlatCablephiPosOff]+([DOHMdPhiOut]+[FlatCabledPhi])/2"/>
+		<Constant name="ModuleFixationInsertsInR" value="36.4*cm"/>
+		<Constant name="ModuleFixationInsertsOutR" value="45.4*cm"/>
+	</ConstantsSection>
+	<SolidSection label="tidring2.xml">
+		<Tubs name="TIDRing2ICB" rMin="([ICBR]-[tidringpar:ICBW]/2)" rMax="([ICBR]+[tidringpar:ICBW]/2)" dz="[tidringpar:ICBT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Box name="TIDRing2ICBTail" dx="[tidringpar:ICBTailH]/2" dy="[ICBTailW]/2" dz="[tidringpar:ICBTailT]/2"/>
+		<Torus name="TIDRing2Cool1" innerRadius="[zero]" outerRadius="[tidringpar:CoolD]/2" torusRadius="[CoolR1]" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Torus name="TIDRing2Cool2" innerRadius="[zero]" outerRadius="[tidringpar:CoolD]/2" torusRadius="[CoolR2]" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TIDRing2DOHMIn" rMin="[DOHMrIn]" rMax="[DOHMrMed]" dz="[tidringpar:DOHMT]/2" startPhi="-[DOHMdPhiIn]/2" deltaPhi="[DOHMdPhiIn]"/>
+		<Tubs name="TIDRing2DOHMOut" rMin="[DOHMrMed]" rMax="[DOHMrOut]" dz="[tidringpar:DOHMT]/2" startPhi="-[DOHMdPhiOut]/2" deltaPhi="[DOHMdPhiOut]"/>
+		<UnionSolid name="TIDRing2DOHM">
+			<rSolid name="TIDRing2DOHMIn"/>
+			<rSolid name="TIDRing2DOHMOut"/>
+		</UnionSolid>
+		<Tubs name="TIDRing2FiberLayer" rMin="([ICBR]-[tidringpar:ICBW]/2)" rMax="([ICBR]+[tidringpar:ICBW]/2)" dz="[tidringpar:FiberLayerT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Box name="TIDRing2CoolManifold" dx="[tidringpar:CoolManifoldW]/2" dy="[CoolManifoldL]/2" dz="[tidringpar:CoolManifoldT]/2"/>
+		<Tubs name="TIDRing2FlatCable" rMin="[FlatCablerIn]" rMax="[FlatCablerOut]" dz="[tidringpar:FlatCableT]/2" startPhi="-[FlatCabledPhi]/2" deltaPhi="[FlatCabledPhi]"/>
+	</SolidSection>
+	<LogicalPartSection label="tidring2.xml">
+		<LogicalPart name="TIDRing2" category="unspecified">
+			<rSolid name="tidringpar:TIDRing"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIDStructure2" category="unspecified">
+			<rSolid name="tidringpar:TIDStructure"/>
+			<rMaterial name="tidmaterial:TID_Mech"/>
+		</LogicalPart>
+		<LogicalPart name="TIDICC2" category="unspecified">
+			<rSolid name="tidringpar:TIDICCSS"/>
+			<rMaterial name="tidmaterial:TID_SSAOHBox"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing2ICBTail" category="unspecified">
+			<rSolid name="tidring2:TIDRing2ICBTail"/>
+			<rMaterial name="tidmaterial:TID_ICB3"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing2ICB" category="unspecified">
+			<rSolid name="tidring2:TIDRing2ICB"/>
+			<rMaterial name="tidmaterial:TID_ICB3"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing2DOHM" category="unspecified">
+			<rSolid name="tidring2:TIDRing2DOHM"/>
+			<rMaterial name="tidmaterial:TID_DOHM2"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing2Cool1" category="unspecified">
+			<rSolid name="tidring2:TIDRing2Cool1"/>
+			<rMaterial name="tidmaterial:TID_CoolPipe"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing2Cool2" category="unspecified">
+			<rSolid name="tidring2:TIDRing2Cool2"/>
+			<rMaterial name="tidmaterial:TID_CoolPipe"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing2FiberLayer" category="unspecified">
+			<rSolid name="tidring2:TIDRing2FiberLayer"/>
+			<rMaterial name="tidmaterial:TID_FiberLayer"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing2CoolManifold" category="unspecified">
+			<rSolid name="tidring2:TIDRing2CoolManifold"/>
+			<rMaterial name="tidmaterial:TID_CoolManifold"/>
+		</LogicalPart>
+		<LogicalPart name="TIDRing2FlatCable" category="unspecified">
+			<rSolid name="tidring2:TIDRing2FlatCable"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_AmphCable"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tidring2.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tidring2:TIDRing2"/>
+			<rChild name="tidring2:TIDStructure2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring2:TIDRing2"/>
+			<rChild name="tidring2:TIDRing2ICB"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring2:TIDRing2"/>
+			<rChild name="tidring2:TIDRing2ICB"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:ICBZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring2:TIDRing2"/>
+			<rChild name="tidring2:TIDRing2Cool1"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring2:TIDRing2"/>
+			<rChild name="tidring2:TIDRing2Cool1"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring2:TIDRing2"/>
+			<rChild name="tidring2:TIDRing2Cool2"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring2:TIDRing2"/>
+			<rChild name="tidring2:TIDRing2Cool2"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:CoolZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tidring2:TIDRing2"/>
+			<rChild name="tidring2:TIDRing2FiberLayer"/>
+			<Translation x="[zero]" y="[zero]" z="-[tidringpar:FiberLayerZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tidring2:TIDRing2"/>
+			<rChild name="tidring2:TIDRing2FiberLayer"/>
+			<Translation x="[zero]" y="[zero]" z="[tidringpar:FiberLayerZ]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring2:TIDRing2"/>
+		<String name="ChildName" value="tidring2:TIDRing2ICBTail"/>
+		<Numeric name="Radius" value="[ICBTailRPos]"/>
+		<Numeric name="Tilt" value="-90*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="8">
+			180.0*deg,         135.0*deg,          126.0*deg,           9.0*deg,
+			360.0*deg,         315.0*deg,          306.0*deg,         189.0*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="8">
+			[tidringpar:ICBZ], -[tidringpar:ICBZ], [tidringpar:ICBZ], -[tidringpar:ICBZ],
+			[tidringpar:ICBZ], -[tidringpar:ICBZ], [tidringpar:ICBZ], -[tidringpar:ICBZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring2:TIDRing2"/>
+		<String name="ChildName" value="tidringpar:TIDCCUMBox"/>
+		<Numeric name="Radius" value="[CCUMrPos]"/>
+		<Numeric name="Tilt" value="-90*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="8">
+			180.0*deg,         135.0*deg,          126.0*deg,           9.0*deg,
+			360.0*deg,         315.0*deg,          306.0*deg,         189.0*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="8">
+			[tidringpar:CCUMZ], -[tidringpar:CCUMZ], [tidringpar:CCUMZ], -[tidringpar:CCUMZ],
+			[tidringpar:CCUMZ], -[tidringpar:CCUMZ], [tidringpar:CCUMZ], -[tidringpar:CCUMZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring2:TIDRing2"/>
+		<String name="ChildName" value="tidring2:TIDRing2DOHM"/>
+		<Numeric name="Radius" value="[tidring2:DOHMrOff]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="2">
+			[DOHMphiPos], [DOHMphiPos]+180*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="2">
+			-[tidringpar:DOHMZ], [tidringpar:DOHMZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring2:TIDRing2"/>
+		<String name="ChildName" value="tidring2:TIDRing2FlatCable"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="8">
+			[FlatCablephiPosL], [FlatCablephiPosR], [FlatCablephiPosL]+180*deg, [FlatCablephiPosR]+180*deg,
+			[FlatCablephiPosL], [FlatCablephiPosR], [FlatCablephiPosL]+180*deg, [FlatCablephiPosR]+180*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="8">
+			-[tidringpar:FlatCableZ], -[tidringpar:FlatCableZ],  -[tidringpar:FlatCableZ],  -[tidringpar:FlatCableZ], 
+			[tidringpar:FlatCableZ],  [tidringpar:FlatCableZ],   [tidringpar:FlatCableZ],   [tidringpar:FlatCableZ]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring2:TIDStructure2"/>
+		<String name="ChildName" value="tidring2:TIDRing2CoolManifold"/>
+		<Numeric name="N" value="2"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="63.0*deg"/>
+		<Numeric name="Radius" value="[tidringpar:CoolManifoldR]"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0 </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTIDRingAlgo">
+		<rParent name="tidring2:TIDRing2"/>
+		<Vector name="ModuleName" type="string" nEntries="2">
+			tidmodule2:TIDModule2,   tidmodule2:TIDModule2</Vector>
+		<String name="ICCName" value="tidring2:TIDICC2"/>
+		<Numeric name="Number" value="[NPhi]"/>
+		<Numeric name="StartAngle" value="[PhiOff]"/>
+		<Numeric name="ModuleR" value="[RPos]"/>
+		<Vector name="ModuleZ" type="numeric" nEntries="2">
+			-[tidringpar:ModuleZSS],    [tidringpar:ModuleZSS]   </Vector>
+		<Numeric name="ICCR" value="[ICCRPos]"/>
+		<Numeric name="ICCShift" value="[tidringpar:ICCW]/2"/>
+		<Vector name="ICCZ" type="numeric" nEntries="2">
+			-[tidringpar:ICCZ],         [tidringpar:ICCZ]        </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tidring2:TIDRing2"/>
+		<String name="ChildName" value="tidringpar:TIDManifoldFix"/>
+		<Numeric name="Radius" value="[tidringpar:CoolManifoldR]"/>
+		<Numeric name="Tilt" value="-90*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="4">
+			63.0*deg,         63.0*deg,          243.0*deg,         243.0*deg
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="4">
+			[tidringpar:ManifoldFixZ], -[tidringpar:ManifoldFixZ],
+			[tidringpar:ManifoldFixZ], -[tidringpar:ManifoldFixZ]
+		</Vector>
+	</Algorithm>
+	<!-- Inserts for module fixation  -->
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring2:TIDStructure2"/>
+		<String name="ChildName" value="tidringpar:TIDModuleFixSmall"/>
+		<Numeric name="N" value="40"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="-5.17*deg"/>
+		<Numeric name="Radius" value="[ModuleFixationInsertsInR]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring2:TIDStructure2"/>
+		<String name="ChildName" value="tidringpar:TIDModuleFixSmall"/>
+		<Numeric name="N" value="40"/>
+		<Numeric name="StartCopyNo" value="41"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="+5.17*deg"/>
+		<Numeric name="Radius" value="[ModuleFixationInsertsInR]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring2:TIDStructure2"/>
+		<String name="ChildName" value="tidringpar:TIDModuleFix"/>
+		<Numeric name="N" value="40"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="-5.54*deg"/>
+		<Numeric name="Radius" value="[ModuleFixationInsertsOutR]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tidring2:TIDStructure2"/>
+		<String name="ChildName" value="tidringpar:TIDModuleFix"/>
+		<Numeric name="N" value="40"/>
+		<Numeric name="StartCopyNo" value="41"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="+5.54*deg"/>
+		<Numeric name="Radius" value="[ModuleFixationInsertsOutR]"/>
+		<Vector name="Center" type="numeric" nEntries="3">
+			[zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tidringpar.xml
+++ b/DetectorDescription/DDCMS/data/tidringpar.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tidringpar.xml" eval="true">
+		<Constant name="Rin" value="22.50*cm"/>
+		<Constant name="Rout" value="50.90*cm"/>
+		<Constant name="RingT" value="3.40*cm"/>
+		<!-- MAX ALLOWED VALUE 3.5 cm -->
+		<Constant name="StructureT" value="0.80*cm"/>
+		<!-- DOHM  -->
+		<Constant name="DOHMT" value="0.22*cm"/>
+		<Constant name="DOHMZ" value="([StructureT]+[DOHMT])/2"/>
+		<!-- Flat Amphenol 26 -->
+		<Constant name="FlatCableT" value="0.06*cm"/>
+		<Constant name="FlatCableZ" value="([StructureT]+[FlatCableT])/2"/>
+		<!-- MotherCables -->
+		<Constant name="ICBW" value="2.50*cm"/>
+		<Constant name="ICBT" value="0.12*cm"/>
+		<Constant name="ICBZ" value="([StructureT]+[ICBT])/2"/>
+		<Constant name="ICBTailH" value="3.26*cm"/>
+		<Constant name="ICBTailT" value="[ICBT]"/>
+		<Constant name="ICBTailTol" value="0.05*cm"/>
+		<!-- Layer of the Fiber Pigtails -->
+		<Constant name="FiberLayerT" value="0.05*cm"/>
+		<Constant name="FiberLayerZ" value="([StructureT]+2*[ICBT]+[FiberLayerT])/2"/>
+		<!-- Cooling Pipes -->
+		<Constant name="CoolD" value="0.35*cm"/>
+		<!-- diameter of the pipe -->
+		<Constant name="CoolZ" value="([StructureT]/2)+0.375*cm"/>
+		<!-- Cooling Manifolds -->
+		<Constant name="CoolManifoldR" value="49.00*cm"/>
+		<Constant name="CoolManifoldW" value="2.00*cm"/>
+		<Constant name="CoolManifoldT" value="0.80*cm"/>
+		<Constant name="ManifoldFixH" value="4.0*cm"/>
+		<Constant name="ManifoldFixW" value="5.6*cm"/>
+		<Constant name="ManifoldFixT" value="0.20*cm"/>
+		<Constant name="ManifoldFixZ" value="([StructureT]+[ManifoldFixT])/2"/>
+		<!-- AOH boxes (bottom side at the same height of cooling pipes) -->
+		<Constant name="ICCH" value="2.70*cm"/>
+		<Constant name="ICCW" value="2.80*cm"/>
+		<Constant name="ICCT" value="0.60*cm"/>
+		<Constant name="ICCZ" value="[CoolZ]+([ICCT]-[CoolD])/2"/>
+		<Constant name="ICCROffset" value="0.60*cm"/>
+		<!-- Modules -->
+		<Constant name="ModuleZDS" value="1.305*cm"/>
+		<Constant name="ModuleZSS" value="1.226*cm"/>
+		<!--  Disk inserts for the fixation of the modules -->
+		<Constant name="ModuleFixRin" value="0.160*cm"/>
+		<Constant name="ModuleFixRout" value="0.515*cm"/>
+		<Constant name="ModuleFixRinSmall" value="0.140*cm"/>
+		<Constant name="ModuleFixRoutSmall" value="0.410*cm"/>
+		<Constant name="ModuleFixExtraT" value="[tid:zero]"/>
+		<!-- CCUM boxes -->
+		<Constant name="CCUMH" value="3.30*cm"/>
+		<Constant name="CCUMW" value="2.40*cm"/>
+		<Constant name="CCUMT" value="0.76*cm"/>
+		<Constant name="CCUMZ" value="[ICBT]+[FiberLayerT]+([StructureT]+[CCUMT])/2"/>
+	</ConstantsSection>
+	<SolidSection label="tidringpar.xml">
+		<Tubs name="TIDRing" rMin="[Rin]" rMax="[tid:WheelRout]" dz="[RingT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TIDStructure" rMin="[Rin]" rMax="[Rout]" dz="[StructureT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Box name="TIDICCSS" dx="[ICCW]/2" dy="[ICCT]/2" dz="[ICCH]/2"/>
+		<Box name="TIDICCDS" dx="[ICCW]" dy="[ICCT]/2" dz="[ICCH]/2"/>
+		<Box name="TIDCCUM" dx="[CCUMW]/2" dy="[CCUMH]/2" dz="[CCUMT]/2"/>
+		<Box name="TIDManifoldFix" dx="[ManifoldFixW]/2" dy="[ManifoldFixH]/2" dz="[ManifoldFixT]/2"/>
+		<Tubs name="TIDModuleFix" rMin="[ModuleFixRin]" rMax="[ModuleFixRout]" dz="[ModuleFixExtraT]+[StructureT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+		<Tubs name="TIDModuleFixSmall" rMin="[ModuleFixRinSmall]" rMax="[ModuleFixRoutSmall]" dz="[ModuleFixExtraT]+[StructureT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
+	</SolidSection>
+	<LogicalPartSection label="tidringpar.xml">
+		<LogicalPart name="TIDManifoldFix" category="unspecified">
+			<rSolid name="TIDManifoldFix"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="TIDModuleFix" category="unspecified">
+			<rSolid name="TIDModuleFix"/>
+			<rMaterial name="tidmaterial:TID_ModuleFix"/>
+		</LogicalPart>
+		<LogicalPart name="TIDModuleFixSmall" category="unspecified">
+			<rSolid name="TIDModuleFixSmall"/>
+			<rMaterial name="tidmaterial:TID_ModuleFix"/>
+		</LogicalPart>
+		<LogicalPart name="TIDCCUMBox" category="unspecified">
+			<rSolid name="TIDCCUM"/>
+			<rMaterial name="tibtidcommonmaterial:TIBTID_CCUM"/>
+		</LogicalPart>
+	</LogicalPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tob.xml
+++ b/DetectorDescription/DDCMS/data/tob.xml
@@ -1,0 +1,1404 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tob.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="Rin1" value="54.0*cm"/>
+		<Constant name="Rin2" value="58.0*cm"/>
+		<Constant name="Rin3" value="1.160*m"/>
+		<Constant name="Rout" value="1.169*m"/>
+		<Constant name="Zv0" value="1.100*m"/>
+		<Constant name="Zv1" value="1.160*m"/>
+		<Constant name="Zv2" value="1.180*m"/>
+		<Constant name="Zv3" value="2.820*m"/>
+		<Constant name="StiffenerL" value="720*mm"/>
+		<Constant name="StiffenerR" value="0.400*cm"/>
+		<Constant name="RailTopDy" value="8.5*mm"/>
+		<Constant name="RailBottomDy" value="15*mm"/>
+		<Constant name="RailDx" value="4.3*mm"/>
+		<Constant name="RailL" value="1.100*m"/>
+		<Constant name="RailInX" value="54.433*cm"/>
+		<Constant name="StiffenerY" value="2.700*cm"/>
+		<Constant name="AlPieceR0" value="1.161*m"/>
+		<Constant name="AlPieceR1" value="1.164*m"/>
+		<Constant name="AlPieceR2" value="1.169*m"/>
+		<Constant name="AlPiecePhi1" value="1.535*deg"/>
+		<Constant name="AlPiecePhi2" value="175.535*deg"/>
+		<Constant name="AlPiecePhi3" value="1.580*deg"/>
+		<Constant name="AlPiecePhi4" value="175.180*deg"/>
+		<Constant name="AlPieceDPhi1" value="4.930*deg"/>
+		<Constant name="AlPieceDPhi2" value="2.930*deg"/>
+		<Constant name="AlPieceDPhi3" value="0.240*deg"/>
+		<Constant name="AlPieceDPhi4" value="3.240*deg"/>
+		<Constant name="AlPieceDz1" value="5.000*cm"/>
+		<Constant name="AlPieceDz2" value="0.500*cm"/>
+		<Constant name="AlPieceZ" value="69.00*cm"/>
+		<Constant name="CFTubeRin1" value="1.142*m"/>
+		<Constant name="CFTubeRout1" value="1.160*m"/>
+		<Constant name="CFTubeRin2" value="55.00*cm"/>
+		<Constant name="CFTubeRout2" value="57.80*cm"/>
+		<Constant name="CFTubeL1" value="27.80*cm"/>
+		<Constant name="CFTubeL2" value="38.80*cm"/>
+		<Constant name="CFTubeZ" value="69.00*cm"/>
+		<Constant name="NomexTubeRin1" value="1.1425*m"/>
+		<Constant name="NomexTubeRout1" value="1.1595*m"/>
+		<Constant name="NomexTubeRin2" value="55.05*cm"/>
+		<Constant name="NomexTubeRout2" value="57.75*cm"/>
+		<Constant name="NomexTubeF1" value="48.633*deg"/>
+		<Constant name="NomexTubeF2" value="29.346*deg"/>
+		<Constant name="NomexTubeF3" value="35.774*deg"/>
+		<Constant name="NomexInPhi1" value="48.214*deg"/>
+		<Constant name="NomexInPhi2" value="90.000*deg"/>
+		<Constant name="NomexInPhi3" value="131.790*deg"/>
+		<Constant name="NomexInPhi4" value="183.214*deg"/>
+		<Constant name="NomexInPhi5" value="228.214*deg"/>
+		<Constant name="NomexInPhi6" value="273.214*deg"/>
+		<Constant name="NomexInPhi7" value="315.000*deg"/>
+		<Constant name="NomexInPhi8" value="356.785*deg"/>
+		<Constant name="AlignTubeDx" value="1.150*cm"/>
+		<Constant name="AlignTubeDy" value="1.338*cm"/>
+		<Constant name="AlignTubeT" value="0.200*cm"/>
+		<Constant name="AlignPhi1" value="22.500*deg"/>
+		<Constant name="AlignPhi2" value="73.928*deg"/>
+		<Constant name="AlignPhi3" value="106.071*deg"/>
+		<Constant name="AlignPhi4" value="157.500*deg"/>
+		<Constant name="AlignPhi5" value="208.929*deg"/>
+		<Constant name="AlignPhi6" value="247.500*deg"/>
+		<Constant name="AlignPhi7" value="298.929*deg"/>
+		<Constant name="AlignPhi8" value="331.071*deg"/>
+		<Constant name="PottingRin1" value="1.142*m"/>
+		<Constant name="PottingRout1" value="1.157*m"/>
+		<Constant name="PottingRin2" value="55.00*cm"/>
+		<Constant name="PottingRout2" value="57.80*cm"/>
+		<Constant name="PottingL" value="0.200*cm"/>
+		<Constant name="PottingZ1" value="108.00*cm"/>
+		<Constant name="PottingZ2" value="30.00*cm"/>
+		<Constant name="PottingZ3" value="28.20*cm"/>
+		<Constant name="ConnectRin1" value="1.157*m"/>
+		<Constant name="ConnectRout1" value="1.160*m"/>
+		<Constant name="ConnectL1" value="1.000*cm"/>
+		<Constant name="ConnectZ11" value="1.090*m"/>
+		<Constant name="ConnectZ12" value="29.00*cm"/>
+		<Constant name="ConnectDphi1" value="4.95*deg"/>
+		<Constant name="ConnectRin2" value="1.141*m"/>
+		<Constant name="ConnectRout2" value="1.142*m"/>
+		<Constant name="ExtraConnectL" value="1.360*cm"/>
+		<Constant name="ConnectStartPhi" value="11.25*deg"/>
+		<Constant name="ConnectL2" value="2.000*cm+[ExtraConnectL]"/>
+		<Constant name="ConnectZ21" value="1.058*m-[ExtraConnectL]"/>
+		<Constant name="ConnectZ22" value="32.20*cm+[ExtraConnectL]"/>
+		<Constant name="ConnectZ23" value="25.80*cm-[ExtraConnectL]"/>
+		<Constant name="ConnectDphi2" value="3.51*deg"/>
+		<Constant name="ConnectRin3" value="1.160*m"/>
+		<Constant name="ConnectRout3" value="1.161*m"/>
+		<Constant name="ConnectL3" value="2.000*cm+[ExtraConnectL]"/>
+		<Constant name="ConnectL23" value="1.000*mm"/>
+		<Constant name="Connect23ZOffset" value="([ConnectL3]-[ConnectL23])"/>
+		<Constant name="ConnectDphi3" value="3.46*deg"/>
+		<Constant name="ConnectRin4" value="57.80*cm"/>
+		<Constant name="ConnectRout4" value="58.10*cm"/>
+		<Constant name="ConnectL4" value="1.000*cm"/>
+		<Constant name="ConnectDphi4" value="9.89*deg"/>
+		<Constant name="ConnectRin5" value="54.90*cm"/>
+		<Constant name="ConnectRout5" value="55.00*cm"/>
+		<Constant name="ConnectL5" value="2.000*cm+[ExtraConnectL]"/>
+		<Constant name="ConnectDphi5" value="7.30*deg"/>
+		<Constant name="ConnectRin6" value="57.80*cm"/>
+		<Constant name="ConnectRout6" value="57.90*cm"/>
+		<Constant name="ConnectL6" value="2.000*cm+[ExtraConnectL]"/>
+		<Constant name="ConnectL56" value="[ConnectL23]"/>
+		<Constant name="Connect56ZOffset" value="([ConnectL6]-[ConnectL56])"/>
+		<Constant name="ConnectDphi6" value="6.93*deg"/>
+		<Constant name="Layer0Rin" value="58.20*cm"/>
+		<Constant name="Layer0Rout" value="64.24*cm"/>
+		<Constant name="Layer0LowR" value="59.20*cm"/>
+		<Constant name="Layer0HighR" value="62.40*cm"/>
+		<Constant name="Layer0CoolRa" value="65.40*cm"/>
+		<Constant name="Layer0CoolRr" value="66.40*cm"/>
+		<Constant name="Layer1Rin" value="66.60*cm"/>
+		<Constant name="Layer1Rout" value="72.80*cm"/>
+		<Constant name="Layer1LowR" value="67.60*cm"/>
+		<Constant name="Layer1HighR" value="70.80*cm"/>
+		<Constant name="Layer1CoolRa" value="74.00*cm"/>
+		<Constant name="Layer1CoolRr" value="75.00*cm"/>
+		<Constant name="Layer2Rin" value="75.40*cm"/>
+		<Constant name="Layer2Rout" value="81.40*cm"/>
+		<Constant name="Layer2LowR" value="76.40*cm"/>
+		<Constant name="Layer2HighR" value="79.60*cm"/>
+		<Constant name="Layer2CoolRa" value="82.50*cm"/>
+		<Constant name="Layer2CoolRr" value="83.50*cm"/>
+		<Constant name="Layer3Rin" value="84.10*cm"/>
+		<Constant name="Layer3Rout" value="89.90*cm"/>
+		<Constant name="Layer3LowR" value="85.20*cm"/>
+		<Constant name="Layer3HighR" value="88.40*cm"/>
+		<Constant name="Layer3CoolRa" value="91.10*cm"/>
+		<Constant name="Layer3CoolRr" value="92.10*cm"/>
+		<Constant name="Layer4Rin" value="93.80*cm"/>
+		<Constant name="Layer4Rout" value="99.60*cm"/>
+		<Constant name="Layer4LowR" value="94.90*cm"/>
+		<Constant name="Layer4HighR" value="98.10*cm"/>
+		<Constant name="Layer4CoolRa" value="100.70*cm"/>
+		<Constant name="Layer4CoolRr" value="101.70*cm"/>
+		<Constant name="Layer5Rin" value="105.30*cm"/>
+		<Constant name="Layer5Rout" value="111.10*cm"/>
+		<Constant name="Layer5LowR" value="106.40*cm"/>
+		<Constant name="Layer5HighR" value="109.60*cm"/>
+		<Constant name="Layer5CoolRa" value="112.20*cm"/>
+		<Constant name="Layer5CoolRr" value="113.20*cm"/>
+		<Constant name="RibRin" value="58.10*cm"/>
+		<Constant name="RibRout" value="115.70*cm"/>
+		<Constant name="RibDZ" value="0.350*cm"/>
+		<Constant name="RibZ1" value="109.0*cm"/>
+		<Constant name="RibZ2" value="29.00*cm"/>
+		<Constant name="SideDiskDz" value="3.250*cm"/>
+		<Constant name="SideDiskZ" value="114.05*cm"/>
+		<Constant name="DetectorTilt" value="0*deg"/>
+		<Constant name="AxCableRin" value="[Rin3]"/>
+		<Constant name="AxCableRout" value="[Rout]"/>
+		<Constant name="AxCableT" value="0.210*cm"/>
+		<Constant name="AxCableDz" value="([Zv3]-[Zv1])/2"/>
+		<Constant name="AxCableW" value="22.5*deg"/>
+		<Constant name="AxCableZ" value="([Zv1]+[Zv3])/2"/>
+		<Constant name="DOHMsDz" value="0.3*cm"/>
+		<Constant name="DOHMW" value="47*mm"/>
+		<Constant name="DOHML" value="71.5*mm"/>
+		<Constant name="DOHMT" value="3.0*mm"/>
+		<Constant name="DOHMRadius1" value="690*mm"/>
+		<Constant name="DOHMRadius2" value="860*mm"/>
+		<Constant name="DOHMRadius3" value="1040*mm"/>
+		<Constant name="DOHM_R1_phi1" value="9.417*deg"/>
+		<Constant name="DOHM_R1_phi2" value="45.383*deg"/>
+		<Constant name="DOHM_R1_phi3" value="65.583*deg"/>
+		<Constant name="DOHM_R1_phi4" value="85.118*deg"/>
+		<Constant name="DOHM_R1_phi5" value="108.583*deg"/>
+		<Constant name="DOHM_R1_phi6" value="135.918*deg"/>
+		<Constant name="DOHM_R1_phi7" value="162.083*deg"/>
+		<Constant name="DOHM_R1_phi8" value="186.918*deg"/>
+		<Constant name="DOHM_R1_phi9" value="208.083*deg"/>
+		<Constant name="DOHM_R1_phi10" value="227.418*deg"/>
+		<Constant name="DOHM_R1_phi11" value="251.083*deg"/>
+		<Constant name="DOHM_R1_phi12" value="282.418*deg"/>
+		<Constant name="DOHM_R1_phi13" value="302.083*deg"/>
+		<Constant name="DOHM_R1_phi14" value="325.918*deg"/>
+		<Constant name="DOHM_R1_phi15" value="346.083*deg"/>
+		<Constant name="DOHM_R2_phi1" value="4.066*deg"/>
+		<Constant name="DOHM_R2_phi2" value="20.066*deg"/>
+		<Constant name="DOHM_R2_phi3" value="52.066*deg"/>
+		<Constant name="DOHM_R2_phi4" value="68.066*deg"/>
+		<Constant name="DOHM_R2_phi5" value="105.567*deg"/>
+		<Constant name="DOHM_R2_phi6" value="134.067*deg"/>
+		<Constant name="DOHM_R2_phi7" value="153.067*deg"/>
+		<Constant name="DOHM_R2_phi8" value="176.067*deg"/>
+		<Constant name="DOHM_R2_phi9" value="194.067*deg"/>
+		<Constant name="DOHM_R2_phi10" value="225.567*deg"/>
+		<Constant name="DOHM_R2_phi11" value="244.067*deg"/>
+		<Constant name="DOHM_R2_phi12" value="276.067*deg"/>
+		<Constant name="DOHM_R2_phi13" value="291.067*deg"/>
+		<Constant name="DOHM_R2_phi14" value="322.067*deg"/>
+		<Constant name="DOHM_R2_phi15" value="341.067*deg"/>
+		<Constant name="DOHM_R3_phi1" value="4.055*deg"/>
+		<Constant name="DOHM_R3_phi2" value="36.055*deg"/>
+		<Constant name="DOHM_R3_phi3" value="50.055*deg"/>
+		<Constant name="DOHM_R3_phi4" value="78.055*deg"/>
+		<Constant name="DOHM_R3_phi5" value="92.055*deg"/>
+		<Constant name="DOHM_R3_phi6" value="125.055*deg"/>
+		<Constant name="DOHM_R3_phi7" value="140.055*deg"/>
+		<Constant name="DOHM_R3_phi8" value="176.055*deg"/>
+		<Constant name="DOHM_R3_phi9" value="189.055*deg"/>
+		<Constant name="DOHM_R3_phi10" value="218.055*deg"/>
+		<Constant name="DOHM_R3_phi11" value="231.055*deg"/>
+		<Constant name="DOHM_R3_phi12" value="257.055*deg"/>
+		<Constant name="DOHM_R3_phi13" value="270.055*deg"/>
+		<Constant name="DOHM_R3_phi14" value="303.055*deg"/>
+		<Constant name="DOHM_R3_phi15" value="317.055*deg"/>
+		<Constant name="DOHM_R3_phi16" value="350.055*deg"/>
+		<Constant name="Tol" value="0.0*mm"/>
+	</ConstantsSection>
+	<SolidSection label="tob.xml">
+		<Polycone name="TOB" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="-[Zv3]" rMin="[Rin3]" rMax="[Rout]"/>
+			<ZSection z="-[Zv2]" rMin="[Rin3]" rMax="[Rout]"/>
+			<ZSection z="-[Zv2]" rMin="[Rin2]" rMax="[Rout]"/>
+			<ZSection z="-[Zv1]" rMin="[Rin2]" rMax="[Rout]"/>
+			<ZSection z="-[Zv0]" rMin="[Rin2]" rMax="[Rout]"/>
+			<ZSection z="-[Zv0]" rMin="[Rin1]" rMax="[Rout]"/>
+			<ZSection z="[Zv0]" rMin="[Rin1]" rMax="[Rout]"/>
+			<ZSection z="[Zv0]" rMin="[Rin2]" rMax="[Rout]"/>
+			<ZSection z="[Zv1]" rMin="[Rin2]" rMax="[Rout]"/>
+			<ZSection z="[Zv2]" rMin="[Rin2]" rMax="[Rout]"/>
+			<ZSection z="[Zv2]" rMin="[Rin3]" rMax="[Rout]"/>
+			<ZSection z="[Zv3]" rMin="[Rin3]" rMax="[Rout]"/>
+		</Polycone>
+		<Tubs name="TIBStiffener" rMin="[zero]" rMax="[StiffenerR]" dz="[StiffenerL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Box name="TIBRailTop" dx="[RailDx]" dy="[RailTopDy]" dz="[RailL]"/>
+		<Box name="TIBRailBottom" dx="[RailDx]" dy="[RailBottomDy]" dz="[RailL]"/>
+		<Tubs name="TOBAlPiece1" rMin="[AlPieceR0]" rMax="[AlPieceR1]" dz="[AlPieceDz1]" startPhi="[AlPiecePhi1]" deltaPhi="[AlPieceDPhi1]"/>
+		<Tubs name="TOBAlPiece2" rMin="[AlPieceR0]" rMax="[AlPieceR1]" dz="[AlPieceDz1]" startPhi="[AlPiecePhi2]" deltaPhi="[AlPieceDPhi2]"/>
+		<Tubs name="TOBAlPiece3" rMin="[AlPieceR1]" rMax="[AlPieceR2]" dz="[AlPieceDz2]" startPhi="[AlPiecePhi3]" deltaPhi="[AlPieceDPhi3]"/>
+		<Tubs name="TOBAlPiece4" rMin="[AlPieceR1]" rMax="[AlPieceR2]" dz="[AlPieceDz2]" startPhi="[AlPiecePhi4]" deltaPhi="[AlPieceDPhi4]"/>
+		<Tubs name="TOBCFTube1" rMin="[CFTubeRin1]" rMax="[CFTubeRout1]" dz="[CFTubeL1]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBCFTube2" rMin="[CFTubeRin1]" rMax="[CFTubeRout1]" dz="[CFTubeL2]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBCFTube3" rMin="[CFTubeRin2]" rMax="[CFTubeRout2]" dz="[CFTubeL1]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBCFTube4" rMin="[CFTubeRin2]" rMax="[CFTubeRout2]" dz="[CFTubeL2]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBNomexTube1" rMin="[NomexTubeRin1]" rMax="[NomexTubeRout1]" dz="[CFTubeL1]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBNomexTube2" rMin="[NomexTubeRin1]" rMax="[NomexTubeRout1]" dz="[CFTubeL2]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBNomexTube3" rMin="[NomexTubeRin2]" rMax="[NomexTubeRout2]" dz="[CFTubeL1]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBNomexT3In1" rMin="[NomexTubeRin2]" rMax="[NomexTubeRout2]" dz="[CFTubeL1]" startPhi="-[NomexTubeF1]/2" deltaPhi="[NomexTubeF1]"/>
+		<Tubs name="TOBNomexT3In2" rMin="[NomexTubeRin2]" rMax="[NomexTubeRout2]" dz="[CFTubeL1]" startPhi="-[NomexTubeF2]/2" deltaPhi="[NomexTubeF2]"/>
+		<Tubs name="TOBNomexT3In3" rMin="[NomexTubeRin2]" rMax="[NomexTubeRout2]" dz="[CFTubeL1]" startPhi="-[NomexTubeF3]/2" deltaPhi="[NomexTubeF3]"/>
+		<Box name="TOBAlignTube3" dx="[AlignTubeDx]" dy="[AlignTubeDy]" dz="[CFTubeL1]"/>
+		<Box name="TOBAlignT3In" dx="([AlignTubeDx]-[AlignTubeT])" dy="([AlignTubeDy]-[AlignTubeT])" dz="[CFTubeL1]"/>
+		<Tubs name="TOBNomexTube4" rMin="[NomexTubeRin2]" rMax="[NomexTubeRout2]" dz="[CFTubeL2]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Box name="TOBAlignTube4" dx="[AlignTubeDx]" dy="[AlignTubeDy]" dz="[CFTubeL2]"/>
+		<Box name="TOBAlignT4In" dx="([AlignTubeDx]-[AlignTubeT])" dy="([AlignTubeDy]-[AlignTubeT])" dz="[CFTubeL2]"/>
+		<Tubs name="TOBNomexT4In1" rMin="[NomexTubeRin2]" rMax="[NomexTubeRout2]" dz="[CFTubeL2]" startPhi="-[NomexTubeF1]/2" deltaPhi="[NomexTubeF1]"/>
+		<Tubs name="TOBNomexT4In2" rMin="[NomexTubeRin2]" rMax="[NomexTubeRout2]" dz="[CFTubeL2]" startPhi="-[NomexTubeF2]/2" deltaPhi="[NomexTubeF2]"/>
+		<Tubs name="TOBNomexT4In3" rMin="[NomexTubeRin2]" rMax="[NomexTubeRout2]" dz="[CFTubeL2]" startPhi="-[NomexTubeF3]/2" deltaPhi="[NomexTubeF3]"/>
+		<Tubs name="TOBPotting1" rMin="[PottingRin1]" rMax="[PottingRout1]" dz="[PottingL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBPotting2" rMin="[PottingRin2]" rMax="[PottingRout2]" dz="[PottingL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBPotting2I1" rMin="[PottingRin2]" rMax="[PottingRout2]" dz="[PottingL]" startPhi="-[NomexTubeF1]/2" deltaPhi="[NomexTubeF1]"/>
+		<Tubs name="TOBPotting2I2" rMin="[PottingRin2]" rMax="[PottingRout2]" dz="[PottingL]" startPhi="-[NomexTubeF2]/2" deltaPhi="[NomexTubeF2]"/>
+		<Tubs name="TOBPotting2I3" rMin="[PottingRin2]" rMax="[PottingRout2]" dz="[PottingL]" startPhi="-[NomexTubeF3]/2" deltaPhi="[NomexTubeF3]"/>
+		<Tubs name="TOBConnect1" rMin="[ConnectRin1]" rMax="[ConnectRout1]" dz="[ConnectL1]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBAlConnect1" rMin="[ConnectRin1]" rMax="[ConnectRout1]" dz="[ConnectL1]" startPhi="-[ConnectDphi1]/2" deltaPhi="[ConnectDphi1]"/>
+		<Tubs name="TOBConnect2" rMin="[ConnectRin2]" rMax="[ConnectRout2]" dz="[ConnectL2]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBAlConnect2" rMin="[ConnectRin2]" rMax="[ConnectRout2]" dz="[ConnectL2]" startPhi="-[ConnectDphi2]/2" deltaPhi="[ConnectDphi2]"/>
+		<Tubs name="TOBConnect3" rMin="[ConnectRin3]" rMax="[ConnectRout3]" dz="[ConnectL3]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBAlConnect3" rMin="[ConnectRin3]" rMax="[ConnectRout3]" dz="[ConnectL3]" startPhi="-[ConnectDphi3]/2" deltaPhi="[ConnectDphi3]"/>
+		<Tubs name="TOBConnect23" rMin="[ConnectRout2]" rMax="[ConnectRin3]" dz="[ConnectL23]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBAlConnect23" rMin="[ConnectRout2]" rMax="[ConnectRin3]" dz="[ConnectL23]" startPhi="-[ConnectDphi3]/2" deltaPhi="[ConnectDphi3]"/>
+		<Tubs name="TOBConnect4" rMin="[ConnectRin4]" rMax="[ConnectRout4]" dz="[ConnectL4]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBAlConnect4" rMin="[ConnectRin4]" rMax="[ConnectRout4]" dz="[ConnectL4]" startPhi="-[ConnectDphi4]/2" deltaPhi="[ConnectDphi4]"/>
+		<Tubs name="TOBConnect5" rMin="[ConnectRin5]" rMax="[ConnectRout5]" dz="[ConnectL5]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBAlConnect5" rMin="[ConnectRin5]" rMax="[ConnectRout5]" dz="[ConnectL5]" startPhi="-[ConnectDphi5]/2" deltaPhi="[ConnectDphi5]"/>
+		<Tubs name="TOBConnect6" rMin="[ConnectRin6]" rMax="[ConnectRout6]" dz="[ConnectL6]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBAlConnect6" rMin="[ConnectRin6]" rMax="[ConnectRout6]" dz="[ConnectL6]" startPhi="-[ConnectDphi6]/2" deltaPhi="[ConnectDphi6]"/>
+		<Tubs name="TOBConnect56" rMin="[ConnectRout5]" rMax="[ConnectRin6]" dz="[ConnectL56]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBAlConnect56" rMin="[ConnectRout5]" rMax="[ConnectRin6]" dz="[ConnectL56]" startPhi="-[ConnectDphi6]/2" deltaPhi="[ConnectDphi6]"/>
+		<Tubs name="TOBMidRib0" rMin="[ConnectRin5]" rMax="[Layer0Rin]" dz="[RibDZ]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBMidRib1" rMin="[Layer0Rout]" rMax="[Layer1Rin]" dz="[RibDZ]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBMidRib2" rMin="[Layer1Rout]" rMax="[Layer2Rin]" dz="[RibDZ]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBMidRib3" rMin="[Layer2Rout]" rMax="[Layer3Rin]" dz="[RibDZ]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBMidRib4" rMin="[Layer3Rout]" rMax="[Layer4Rin]" dz="[RibDZ]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBMidRib5" rMin="[Layer4Rout]" rMax="[Layer5Rin]" dz="[RibDZ]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBMidRib6" rMin="[Layer5Rout]" rMax="[RibRout]" dz="[RibDZ]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBLayer0" rMin="[Layer0Rin]" rMax="[Layer0Rout]" dz="[tobrodpar:RodL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBLayer1" rMin="[Layer1Rin]" rMax="[Layer1Rout]" dz="[tobrodpar:RodL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBLayer2" rMin="[Layer2Rin]" rMax="[Layer2Rout]" dz="[tobrodpar:RodL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBLayer3" rMin="[Layer3Rin]" rMax="[Layer3Rout]" dz="[tobrodpar:RodL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBLayer4" rMin="[Layer4Rin]" rMax="[Layer4Rout]" dz="[tobrodpar:RodL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBLayer5" rMin="[Layer5Rin]" rMax="[Layer5Rout]" dz="[tobrodpar:RodL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBSideDisk" rMin="[Rin2]" rMax="[Rin3]" dz="[SideDiskDz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBAxCabCont" rMin="[AxCableRin]" rMax="[AxCableRout]" dz="[AxCableDz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBDOHMs" rMin="[Rin2]" rMax="[Rin3]" dz="[DOHMsDz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Box name="TOBDOHM" dx="[DOHMW]" dy="[DOHML]" dz="[DOHMT]-[Tol]"/>
+	</SolidSection>
+	<LogicalPartSection label="tob.xml">
+		<LogicalPart name="TOB" category="unspecified">
+			<rSolid name="TOB"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TIBStiffener" category="unspecified">
+			<rSolid name="TIBStiffener"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TIBRailTop" category="unspecified">
+			<rSolid name="TIBRailTop"/>
+			<rMaterial name="tobmaterial:TIB_RailTop"/>
+		</LogicalPart>
+		<LogicalPart name="TIBRailBottom" category="unspecified">
+			<rSolid name="TIBRailBottom"/>
+			<rMaterial name="tobmaterial:TIB_RailBottom"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlPiece1" category="unspecified">
+			<rSolid name="TOBAlPiece1"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlPiece2" category="unspecified">
+			<rSolid name="TOBAlPiece2"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlPiece3" category="unspecified">
+			<rSolid name="TOBAlPiece3"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlPiece4" category="unspecified">
+			<rSolid name="TOBAlPiece4"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="TOBCFTube1" category="unspecified">
+			<rSolid name="TOBCFTube1"/>
+			<rMaterial name="tobmaterial:TOB_CF_Str"/>
+		</LogicalPart>
+		<LogicalPart name="TOBCFTube2" category="unspecified">
+			<rSolid name="TOBCFTube2"/>
+			<rMaterial name="tobmaterial:TOB_CF_Str"/>
+		</LogicalPart>
+		<LogicalPart name="TOBCFTube3" category="unspecified">
+			<rSolid name="TOBCFTube3"/>
+			<rMaterial name="tobmaterial:TOB_CF_Str"/>
+		</LogicalPart>
+		<LogicalPart name="TOBCFTube4" category="unspecified">
+			<rSolid name="TOBCFTube4"/>
+			<rMaterial name="tobmaterial:TOB_CF_Str"/>
+		</LogicalPart>
+		<LogicalPart name="TOBNomexTube1" category="unspecified">
+			<rSolid name="TOBNomexTube1"/>
+			<rMaterial name="tobmaterial:TOB_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TOBNomexTube2" category="unspecified">
+			<rSolid name="TOBNomexTube2"/>
+			<rMaterial name="tobmaterial:TOB_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TOBNomexTube3" category="unspecified">
+			<rSolid name="TOBNomexTube3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBNomexT3In1" category="unspecified">
+			<rSolid name="TOBNomexT3In1"/>
+			<rMaterial name="tobmaterial:TOB_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TOBNomexT3In2" category="unspecified">
+			<rSolid name="TOBNomexT3In2"/>
+			<rMaterial name="tobmaterial:TOB_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TOBNomexT3In3" category="unspecified">
+			<rSolid name="TOBNomexT3In3"/>
+			<rMaterial name="tobmaterial:TOB_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlignTube3" category="unspecified">
+			<rSolid name="TOBAlignTube3"/>
+			<rMaterial name="tobmaterial:TOB_CF_Str"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlignT3In" category="unspecified">
+			<rSolid name="TOBAlignT3In"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBNomexTube4" category="unspecified">
+			<rSolid name="TOBNomexTube4"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBNomexT4In1" category="unspecified">
+			<rSolid name="TOBNomexT4In1"/>
+			<rMaterial name="tobmaterial:TOB_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TOBNomexT4In2" category="unspecified">
+			<rSolid name="TOBNomexT4In2"/>
+			<rMaterial name="tobmaterial:TOB_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TOBNomexT4In3" category="unspecified">
+			<rSolid name="TOBNomexT4In3"/>
+			<rMaterial name="tobmaterial:TOB_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlignTube4" category="unspecified">
+			<rSolid name="TOBAlignTube4"/>
+			<rMaterial name="tobmaterial:TOB_CF_Str"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlignT4In" category="unspecified">
+			<rSolid name="TOBAlignT4In"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPotting1" category="unspecified">
+			<rSolid name="TOBPotting1"/>
+			<rMaterial name="tobmaterial:TOB_Epoxy"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPotting2" category="unspecified">
+			<rSolid name="TOBPotting2"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPotting2I1" category="unspecified">
+			<rSolid name="TOBPotting2I1"/>
+			<rMaterial name="tobmaterial:TOB_Epoxy"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPotting2I2" category="unspecified">
+			<rSolid name="TOBPotting2I2"/>
+			<rMaterial name="tobmaterial:TOB_Epoxy"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPotting2I3" category="unspecified">
+			<rSolid name="TOBPotting2I3"/>
+			<rMaterial name="tobmaterial:TOB_Epoxy"/>
+		</LogicalPart>
+		<LogicalPart name="TOBConnect1" category="unspecified">
+			<rSolid name="TOBConnect1"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlConnect1" category="unspecified">
+			<rSolid name="TOBAlConnect1"/>
+			<rMaterial name="tobmaterial:TOB_AlCentralConnect"/>
+		</LogicalPart>
+		<LogicalPart name="TOBConnect2" category="unspecified">
+			<rSolid name="TOBConnect2"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlConnect2" category="unspecified">
+			<rSolid name="TOBAlConnect2"/>
+			<rMaterial name="tobmaterial:TOB_AlSideConnect"/>
+		</LogicalPart>
+		<LogicalPart name="TOBConnect3" category="unspecified">
+			<rSolid name="TOBConnect3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlConnect3" category="unspecified">
+			<rSolid name="TOBAlConnect3"/>
+			<rMaterial name="tobmaterial:TOB_AlSideConnect"/>
+		</LogicalPart>
+		<LogicalPart name="TOBConnect23" category="unspecified">
+			<rSolid name="TOBConnect23"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlConnect23" category="unspecified">
+			<rSolid name="TOBAlConnect23"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="TOBConnect4" category="unspecified">
+			<rSolid name="TOBConnect4"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlConnect4" category="unspecified">
+			<rSolid name="TOBAlConnect4"/>
+			<rMaterial name="tobmaterial:TOB_AlCentralConnect"/>
+		</LogicalPart>
+		<LogicalPart name="TOBConnect5" category="unspecified">
+			<rSolid name="TOBConnect5"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlConnect5" category="unspecified">
+			<rSolid name="TOBAlConnect5"/>
+			<rMaterial name="tobmaterial:TOB_AlSideConnect"/>
+		</LogicalPart>
+		<LogicalPart name="TOBConnect6" category="unspecified">
+			<rSolid name="TOBConnect6"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlConnect6" category="unspecified">
+			<rSolid name="TOBAlConnect6"/>
+			<rMaterial name="tobmaterial:TOB_AlSideConnect"/>
+		</LogicalPart>
+		<LogicalPart name="TOBConnect56" category="unspecified">
+			<rSolid name="TOBConnect56"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAlConnect56" category="unspecified">
+			<rSolid name="TOBAlConnect56"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="TOBMidRib0" category="unspecified">
+			<rSolid name="TOBMidRib0"/>
+			<rMaterial name="tobmaterial:TOB_middle_ribs"/>
+		</LogicalPart>
+		<LogicalPart name="TOBMidRib1" category="unspecified">
+			<rSolid name="TOBMidRib1"/>
+			<rMaterial name="tobmaterial:TOB_middle_ribs"/>
+		</LogicalPart>
+		<LogicalPart name="TOBMidRib2" category="unspecified">
+			<rSolid name="TOBMidRib2"/>
+			<rMaterial name="tobmaterial:TOB_middle_ribs"/>
+		</LogicalPart>
+		<LogicalPart name="TOBMidRib3" category="unspecified">
+			<rSolid name="TOBMidRib3"/>
+			<rMaterial name="tobmaterial:TOB_middle_ribs"/>
+		</LogicalPart>
+		<LogicalPart name="TOBMidRib4" category="unspecified">
+			<rSolid name="TOBMidRib4"/>
+			<rMaterial name="tobmaterial:TOB_middle_ribs"/>
+		</LogicalPart>
+		<LogicalPart name="TOBMidRib5" category="unspecified">
+			<rSolid name="TOBMidRib5"/>
+			<rMaterial name="tobmaterial:TOB_middle_ribs"/>
+		</LogicalPart>
+		<LogicalPart name="TOBMidRib6" category="unspecified">
+			<rSolid name="TOBMidRib6"/>
+			<rMaterial name="tobmaterial:TOB_middle_ribs"/>
+		</LogicalPart>
+		<LogicalPart name="TOBDOHM" category="unspecified">
+			<rSolid name="TOBDOHM"/>
+			<rMaterial name="tobmaterial:TOB_DOHM"/>
+		</LogicalPart>
+		<LogicalPart name="TOBLayer0" category="unspecified">
+			<rSolid name="TOBLayer0"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBLayer1" category="unspecified">
+			<rSolid name="TOBLayer1"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBLayer2" category="unspecified">
+			<rSolid name="TOBLayer2"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBLayer3" category="unspecified">
+			<rSolid name="TOBLayer3"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBLayer4" category="unspecified">
+			<rSolid name="TOBLayer4"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBLayer5" category="unspecified">
+			<rSolid name="TOBLayer5"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBSideDisk" category="unspecified">
+			<rSolid name="TOBSideDisk"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAxCabCont" category="unspecified">
+			<rSolid name="TOBAxCabCont"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBDOHMs" category="unspecified">
+			<rSolid name="TOBDOHMs"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tob.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TIBStiffener"/>
+			<Translation x="[RailInX]" y="[StiffenerY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TIBStiffener"/>
+			<Translation x="-[RailInX]" y="[StiffenerY]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TIBRailTop"/>
+			<Translation x="[RailInX]" y="-[RailTopDy]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TIBRailTop"/>
+			<Translation x="-[RailInX]" y="-[RailTopDy]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TIBRailBottom"/>
+			<Translation x="[RailInX]" y="-2*[RailTopDy]-[RailBottomDy]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TIBRailBottom"/>
+			<Translation x="-[RailInX]" y="-2*[RailTopDy]-[RailBottomDy]" z="[zero]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBAlPiece1"/>
+			<Translation x="[zero]" y="[zero]" z="-[AlPieceZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBAlPiece1"/>
+			<Translation x="[zero]" y="[zero]" z="[AlPieceZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBAlPiece2"/>
+			<Translation x="[zero]" y="[zero]" z="-[AlPieceZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBAlPiece2"/>
+			<Translation x="[zero]" y="[zero]" z="[AlPieceZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBAlPiece3"/>
+			<Translation x="[zero]" y="[zero]" z="-[AlPieceZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBAlPiece3"/>
+			<Translation x="[zero]" y="[zero]" z="[AlPieceZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBAlPiece4"/>
+			<Translation x="[zero]" y="[zero]" z="-[AlPieceZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBAlPiece4"/>
+			<Translation x="[zero]" y="[zero]" z="[AlPieceZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBCFTube1"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOBCFTube1"/>
+			<rChild name="tob:TOBNomexTube1"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBCFTube2"/>
+			<Translation x="[zero]" y="[zero]" z="[CFTubeZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBCFTube2"/>
+			<Translation x="[zero]" y="[zero]" z="-[CFTubeZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOBCFTube2"/>
+			<rChild name="tob:TOBNomexTube2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBCFTube3"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOBCFTube3"/>
+			<rChild name="tob:TOBNomexTube3"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOBAlignTube3"/>
+			<rChild name="tob:TOBAlignT3In"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBCFTube4"/>
+			<Translation x="[zero]" y="[zero]" z="[CFTubeZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBCFTube4"/>
+			<Translation x="[zero]" y="[zero]" z="-[CFTubeZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOBCFTube4"/>
+			<rChild name="tob:TOBNomexTube4"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOBAlignTube4"/>
+			<rChild name="tob:TOBAlignT4In"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBLayer0"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBLayer1"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBLayer2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBLayer3"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBLayer4"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBLayer5"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBSideDisk"/>
+			<Translation x="[zero]" y="[zero]" z="[SideDiskZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBSideDisk"/>
+			<rRotation name="tobrodpar:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[SideDiskZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBDOHMs"/>
+			<Translation x="[zero]" y="[zero]" z="[SideDiskZ]+[SideDiskDz]+[DOHMsDz]+[Tol]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBDOHMs"/>
+			<Translation x="[zero]" y="[zero]" z="-([SideDiskZ]+[SideDiskDz]+[DOHMsDz]+[Tol])"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBAxCabCont"/>
+			<Translation x="[zero]" y="[zero]" z="[AxCableZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tob:TOB"/>
+			<rChild name="tob:TOBAxCabCont"/>
+			<Translation x="[zero]" y="[zero]" z="-[AxCableZ]"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBPotting1"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="6">
+			-[PottingZ1],-[PottingZ2],-[PottingZ3], [PottingZ3], [PottingZ2], [PottingZ1]
+		</Vector>
+		<Vector name="Rotations" type="string" nEntries="6">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL, 
+			tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBPotting2"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="6">
+			-[PottingZ1],-[PottingZ2],-[PottingZ3], [PottingZ3], [PottingZ2], [PottingZ1]
+		</Vector>
+		<Vector name="Rotations" type="string" nEntries="6">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL, 
+			tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBConnect2"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="6">
+			-[ConnectZ21],-[ConnectZ22],-[ConnectZ23], [ConnectZ23], 
+			[ConnectZ22], [ConnectZ21] </Vector>
+		<Vector name="Rotations" type="string" nEntries="6">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL, 
+			tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tob:TOBConnect2"/>
+		<String name="ChildName" value="tob:TOBAlConnect2"/>
+		<Numeric name="N" value="16"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[ConnectStartPhi]"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tob:TOBConnect2"/>
+		<String name="ChildName" value="tob:TOBAlConnect2"/>
+		<Numeric name="N" value="2"/>
+		<Numeric name="StartCopyNo" value="17"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="0*deg"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBConnect3"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="6">
+			-[ConnectZ21],-[ConnectZ22],-[ConnectZ23], [ConnectZ23], 
+			[ConnectZ22], [ConnectZ21] </Vector>
+		<Vector name="Rotations" type="string" nEntries="6">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL, 
+			tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBConnect23"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="6">
+			-[ConnectZ21]-[Connect23ZOffset],-[ConnectZ22]+[Connect23ZOffset],-[ConnectZ23]-[Connect23ZOffset], [ConnectZ23]+[Connect23ZOffset], 
+			[ConnectZ22]-[Connect23ZOffset], [ConnectZ21]+[Connect23ZOffset] </Vector>
+		<Vector name="Rotations" type="string" nEntries="6">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL, 
+			tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tob:TOBConnect3"/>
+		<String name="ChildName" value="tob:TOBAlConnect3"/>
+		<Numeric name="N" value="16"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[ConnectStartPhi]"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tob:TOBConnect3"/>
+		<String name="ChildName" value="tob:TOBAlConnect3"/>
+		<Numeric name="N" value="2"/>
+		<Numeric name="StartCopyNo" value="17"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="0*deg"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tob:TOBConnect23"/>
+		<String name="ChildName" value="tob:TOBAlConnect23"/>
+		<Numeric name="N" value="16"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[ConnectStartPhi]"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tob:TOBConnect23"/>
+		<String name="ChildName" value="tob:TOBAlConnect23"/>
+		<Numeric name="N" value="2"/>
+		<Numeric name="StartCopyNo" value="17"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="0*deg"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tob:TOBConnect4"/>
+		<String name="ChildName" value="tob:TOBAlConnect4"/>
+		<Numeric name="N" value="2"/>
+		<Numeric name="StartCopyNo" value="17"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="0*deg"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBConnect5"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="6">
+			-[ConnectZ21],-[ConnectZ22],-[ConnectZ23], [ConnectZ23], 
+			[ConnectZ22], [ConnectZ21] </Vector>
+		<Vector name="Rotations" type="string" nEntries="6">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL, 
+			tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tob:TOBConnect5"/>
+		<String name="ChildName" value="tob:TOBAlConnect5"/>
+		<Numeric name="N" value="16"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[ConnectStartPhi]"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tob:TOBConnect5"/>
+		<String name="ChildName" value="tob:TOBAlConnect5"/>
+		<Numeric name="N" value="2"/>
+		<Numeric name="StartCopyNo" value="17"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="0*deg"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBConnect6"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="6">
+			-[ConnectZ21],-[ConnectZ22],-[ConnectZ23], [ConnectZ23], 
+			[ConnectZ22], [ConnectZ21] </Vector>
+		<Vector name="Rotations" type="string" nEntries="6">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL, 
+			tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBConnect56"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="6">
+			-[ConnectZ21]-[Connect56ZOffset],-[ConnectZ22]+[Connect56ZOffset],-[ConnectZ23]-[Connect56ZOffset], [ConnectZ23]+[Connect56ZOffset], 
+			[ConnectZ22]-[Connect56ZOffset], [ConnectZ21]+[Connect56ZOffset] </Vector>
+		<Vector name="Rotations" type="string" nEntries="6">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL, 
+			tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tob:TOBConnect6"/>
+		<String name="ChildName" value="tob:TOBAlConnect6"/>
+		<Numeric name="N" value="16"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[ConnectStartPhi]"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tob:TOBConnect6"/>
+		<String name="ChildName" value="tob:TOBAlConnect6"/>
+		<Numeric name="N" value="2"/>
+		<Numeric name="StartCopyNo" value="17"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="0*deg"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tob:TOBConnect56"/>
+		<String name="ChildName" value="tob:TOBAlConnect56"/>
+		<Numeric name="N" value="16"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="[ConnectStartPhi]"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerAngular">
+		<rParent name="tob:TOBConnect56"/>
+		<String name="ChildName" value="tob:TOBAlConnect56"/>
+		<Numeric name="N" value="2"/>
+		<Numeric name="StartCopyNo" value="17"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="StartAngle" value="0*deg"/>
+		<Numeric name="Radius" value="0"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 0, 0, 0  </Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBMidRib0"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="4">
+			-[RibZ1], -[RibZ2],  [RibZ2],  [RibZ1] </Vector>
+		<Vector name="Rotations" type="string" nEntries="4">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBMidRib1"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="4">
+			-[RibZ1], -[RibZ2],  [RibZ2],  [RibZ1] </Vector>
+		<Vector name="Rotations" type="string" nEntries="4">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBMidRib2"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="4">
+			-[RibZ1], -[RibZ2],  [RibZ2],  [RibZ1] </Vector>
+		<Vector name="Rotations" type="string" nEntries="4">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBMidRib3"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="4">
+			-[RibZ1], -[RibZ2],  [RibZ2],  [RibZ1] </Vector>
+		<Vector name="Rotations" type="string" nEntries="4">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBMidRib4"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="4">
+			-[RibZ1], -[RibZ2],  [RibZ2],  [RibZ1] </Vector>
+		<Vector name="Rotations" type="string" nEntries="4">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBMidRib5"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="4">
+			-[RibZ1], -[RibZ2],  [RibZ2],  [RibZ1] </Vector>
+		<Vector name="Rotations" type="string" nEntries="4">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerZPosAlgo">
+		<rParent name="tob:TOB"/>
+		<String name="ChildName" value="tob:TOBMidRib6"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="ZPositions" type="numeric" nEntries="4">
+			-[RibZ1], -[RibZ2],  [RibZ2],  [RibZ1] </Vector>
+		<Vector name="Rotations" type="string" nEntries="4">
+			tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL,  tobrodpar:NULL</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAltAlgo">
+		<rParent name="tob:TOBLayer0"/>
+		<String name="ChildName" value="tobrod0:TOBRod0"/>
+		<Numeric name="Tilt" value="[DetectorTilt]"/>
+		<Numeric name="StartAngle" value="5.3571*deg"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="RadiusIn" value="[Layer0LowR]"/>
+		<Numeric name="RadiusOut" value="[Layer0HighR]"/>
+		<Numeric name="ZPosition" value="[zero]"/>
+		<Numeric name="Number" value="42"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAltAlgo">
+		<rParent name="tob:TOBLayer1"/>
+		<String name="ChildName" value="tobrod1:TOBRod1"/>
+		<Numeric name="Tilt" value="[DetectorTilt]"/>
+		<Numeric name="StartAngle" value="2.1601*deg"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="RadiusIn" value="[Layer1LowR]"/>
+		<Numeric name="RadiusOut" value="[Layer1HighR]"/>
+		<Numeric name="ZPosition" value="[zero]"/>
+		<Numeric name="Number" value="48"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAltAlgo">
+		<rParent name="tob:TOBLayer2"/>
+		<String name="ChildName" value="tobrod2:TOBRod2"/>
+		<Numeric name="Tilt" value="[DetectorTilt]"/>
+		<Numeric name="StartAngle" value="13.0309*deg"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="RadiusIn" value="[Layer2LowR]"/>
+		<Numeric name="RadiusOut" value="[Layer2HighR]"/>
+		<Numeric name="ZPosition" value="[zero]"/>
+		<Numeric name="Number" value="54"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAltAlgo">
+		<rParent name="tob:TOBLayer3"/>
+		<String name="ChildName" value="tobrod3:TOBRod3"/>
+		<Numeric name="Tilt" value="[DetectorTilt]"/>
+		<Numeric name="StartAngle" value="1.5802*deg"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="RadiusIn" value="[Layer3LowR]"/>
+		<Numeric name="RadiusOut" value="[Layer3HighR]"/>
+		<Numeric name="ZPosition" value="[zero]"/>
+		<Numeric name="Number" value="60"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAltAlgo">
+		<rParent name="tob:TOBLayer4"/>
+		<String name="ChildName" value="tobrod4:TOBRod4"/>
+		<Numeric name="Tilt" value="[DetectorTilt]"/>
+		<Numeric name="StartAngle" value="8.4397*deg"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="RadiusIn" value="[Layer4LowR]"/>
+		<Numeric name="RadiusOut" value="[Layer4HighR]"/>
+		<Numeric name="ZPosition" value="[zero]"/>
+		<Numeric name="Number" value="66"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAltAlgo">
+		<rParent name="tob:TOBLayer5"/>
+		<String name="ChildName" value="tobrod5:TOBRod5"/>
+		<Numeric name="Tilt" value="[DetectorTilt]"/>
+		<Numeric name="StartAngle" value="1.3779*deg"/>
+		<Numeric name="RangeAngle" value="360*deg"/>
+		<Numeric name="RadiusIn" value="[Layer5LowR]"/>
+		<Numeric name="RadiusOut" value="[Layer5HighR]"/>
+		<Numeric name="ZPosition" value="[zero]"/>
+		<Numeric name="Number" value="74"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBNomexTube3"/>
+		<String name="ChildName" value="tob:TOBNomexT3In1"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="5">
+			[NomexInPhi1], [NomexInPhi3], [NomexInPhi4], [NomexInPhi6], [NomexInPhi8]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="5">
+			[zero], [zero], [zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBNomexTube3"/>
+		<String name="ChildName" value="tob:TOBNomexT3In2"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="2">
+			[NomexInPhi2], [NomexInPhi7]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="2">
+			[zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBNomexTube3"/>
+		<String name="ChildName" value="tob:TOBNomexT3In3"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="1">
+			[NomexInPhi5]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="1">
+			[zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBNomexTube3"/>
+		<String name="ChildName" value="tob:TOBAlignTube3"/>
+		<Numeric name="Radius" value="([NomexTubeRin2]+[NomexTubeRout2])/2"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="8">
+			[AlignPhi1], [AlignPhi2], [AlignPhi3], [AlignPhi4],
+			[AlignPhi5], [AlignPhi6], [AlignPhi7], [AlignPhi8]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="8">
+			[zero], [zero], [zero], [zero], [zero], [zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBNomexTube4"/>
+		<String name="ChildName" value="tob:TOBNomexT4In1"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="5">
+			[NomexInPhi1], [NomexInPhi3], [NomexInPhi4], [NomexInPhi6], [NomexInPhi8]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="5">
+			[zero], [zero], [zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBNomexTube4"/>
+		<String name="ChildName" value="tob:TOBNomexT4In2"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="2">
+			[NomexInPhi2], [NomexInPhi7]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="2">
+			[zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBNomexTube4"/>
+		<String name="ChildName" value="tob:TOBNomexT4In3"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="1">
+			[NomexInPhi5]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="1">
+			[zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBNomexTube4"/>
+		<String name="ChildName" value="tob:TOBAlignTube4"/>
+		<Numeric name="Radius" value="([NomexTubeRin2]+[NomexTubeRout2])/2"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="8">
+			[AlignPhi1], [AlignPhi2], [AlignPhi3], [AlignPhi4],
+			[AlignPhi5], [AlignPhi6], [AlignPhi7], [AlignPhi8]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="8">
+			[zero], [zero], [zero], [zero], [zero], [zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBPotting2"/>
+		<String name="ChildName" value="tob:TOBPotting2I1"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="5">
+			[NomexInPhi1], [NomexInPhi3], [NomexInPhi4], [NomexInPhi6], [NomexInPhi8]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="5">
+			[zero], [zero], [zero], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBPotting2"/>
+		<String name="ChildName" value="tob:TOBPotting2I2"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="2">
+			[NomexInPhi2], [NomexInPhi7]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="2">
+			[zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBPotting2"/>
+		<String name="ChildName" value="tob:TOBPotting2I3"/>
+		<Numeric name="Radius" value="[zero]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Vector name="Phi" type="numeric" nEntries="1">
+			[NomexInPhi5]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="1">
+			[zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTOBRadCableAlgo">
+		<rParent name="tob:TOBSideDisk"/>
+		<Numeric name="DiskDz" value="[SideDiskDz]"/>
+		<Numeric name="RMax" value="[Rin3]"/>
+		<Numeric name="CableT" value="0.7*cm"/>
+		<Vector name="RodRin" type="numeric" nEntries="6">
+			[Layer0LowR], [Layer1LowR], [Layer2LowR], 
+			[Layer3LowR], [Layer4LowR], [Layer5LowR]
+		</Vector>
+		<Vector name="RodRout" type="numeric" nEntries="6">
+			[Layer0HighR], [Layer1HighR], [Layer2HighR], 
+			[Layer3HighR], [Layer4HighR], [Layer5HighR]
+		</Vector>
+		<Vector name="CableMaterial" type="string" nEntries="6">
+			tobmaterial:TOB_rad_services1, tobmaterial:TOB_rad_services2, 
+			tobmaterial:TOB_rad_services3, tobmaterial:TOB_rad_services4, 
+			tobmaterial:TOB_rad_services5, tobmaterial:TOB_rad_services6
+		</Vector>
+		<Numeric name="ConnW" value="4.0*cm"/>
+		<Numeric name="ConnT" value="2.3*cm"/>
+		<Vector name="ConnMaterial" type="string" nEntries="6">
+			tobmaterial:TOB_rib1, tobmaterial:TOB_rib2, tobmaterial:TOB_rib3, 
+			tobmaterial:TOB_rib4, tobmaterial:TOB_rib5, tobmaterial:TOB_rib6
+		</Vector>
+		<Numeric name="CoolRin" value="[zero]"/>
+		<Numeric name="CoolRout1" value="3.0*mm"/>
+		<Numeric name="CoolRout2" value="2.8*mm"/>
+		<Numeric name="CoolStartPhi1" value="0*deg"/>
+		<Numeric name="CoolDeltaPhi1" value="360*deg"/>
+		<Numeric name="CoolStartPhi2" value="0*deg"/>
+		<Numeric name="CoolDeltaPhi2" value="360*deg"/>
+		<Vector name="CoolR1" type="numeric" nEntries="6">
+			[Layer0CoolRa], [Layer1CoolRa], [Layer2CoolRa], 
+			[Layer3CoolRa], [Layer4CoolRa], [Layer5CoolRa]
+		</Vector>
+		<Vector name="CoolR2" type="numeric" nEntries="6">
+			[Layer0CoolRr], [Layer1CoolRr], [Layer2CoolRr], 
+			[Layer3CoolRr], [Layer4CoolRr], [Layer5CoolRr]
+		</Vector>
+		<String name="CoolMaterial1" value="trackermaterial:T_CuNi"/>
+		<String name="CoolMaterial2" value="trackermaterial:T_C6F14_F2_-30C"/>
+		<Vector name="RingName" type="string" nEntries="6">
+			1, 2, 3, 4, 5, 6
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTOBAxCableAlgo">
+		<rParent name="tob:TOBAxCabCont"/>
+		<Vector name="SectorNumber" type="string" nEntries="18">
+			1 ,  2 ,  3 ,  4 ,  5 ,  6 ,
+			7 ,  8 ,  9 , 10 , 11 , 12 ,
+			13 , 14 , 15 , 16 , 17 , 18
+		</Vector>
+		<Numeric name="SectorRin" value="[AxCableRin]"/>
+		<Numeric name="SectorRout" value="[AxCableRout]"/>
+		<Numeric name="SectorDz" value="[AxCableDz]"/>
+		<Numeric name="SectorDeltaPhi_B" value="2*deg"/>
+		<Vector name="SectorStartPhi" type="numeric" nEntries="18">
+			-10*deg ,  10*deg ,  30*deg ,  50*deg ,  70*deg ,  90*deg ,
+			110*deg , 130*deg , 150*deg , 170*deg , 190*deg , 210*deg ,
+			230*deg , 250*deg , 270*deg , 290*deg , 310*deg , 330*deg
+		</Vector>
+		<Vector name="SectorMaterial_A" type="string" nEntries="18">
+			materials:Air                    , tobmaterial:TOB_ax_services_A2  ,
+			tobmaterial:TOB_ax_services_A3   , tobmaterial:TOB_ax_services_A4  ,
+			tobmaterial:TOB_ax_services_A5   , materials:Air                   , 
+			tobmaterial:TOB_ax_services_A7   , tobmaterial:TOB_ax_services_A8  ,
+			tobmaterial:TOB_ax_services_A9   , materials:Air                   ,
+			tobmaterial:TOB_ax_services_A11  , tobmaterial:TOB_ax_services_A12 ,
+			tobmaterial:TOB_ax_services_A13  , tobmaterial:TOB_ax_services_A14 ,
+			materials:Air                    , tobmaterial:TOB_ax_services_A16 ,
+			tobmaterial:TOB_ax_services_A17  , tobmaterial:TOB_ax_services_A18
+		</Vector>
+		<Vector name="SectorMaterial_B" type="string" nEntries="18">
+			materials:Air                    , tobmaterial:TOB_ax_services_B2  ,
+			tobmaterial:TOB_ax_services_B3   , tobmaterial:TOB_ax_services_B4  ,
+			tobmaterial:TOB_ax_services_B5   , tobmaterial:TOB_ax_services_B6  ,
+			tobmaterial:TOB_ax_services_B7   , tobmaterial:TOB_ax_services_B8  ,
+			tobmaterial:TOB_ax_services_B9   , materials:Air                   ,
+			tobmaterial:TOB_ax_services_B11  , tobmaterial:TOB_ax_services_B12 ,
+			tobmaterial:TOB_ax_services_B13  , tobmaterial:TOB_ax_services_B14 ,
+			tobmaterial:TOB_ax_services_B15  , tobmaterial:TOB_ax_services_B16 ,
+			tobmaterial:TOB_ax_services_B17  , tobmaterial:TOB_ax_services_B18
+		</Vector>
+		<Vector name="SectorMaterial_C" type="string" nEntries="18">
+			materials:Air                    , tobmaterial:TOB_ax_services_C2  ,
+			tobmaterial:TOB_ax_services_C3   , tobmaterial:TOB_ax_services_C4  ,
+			materials:Air                    , tobmaterial:TOB_ax_services_C6  ,
+			tobmaterial:TOB_ax_services_C7   , tobmaterial:TOB_ax_services_C8  ,
+			tobmaterial:TOB_ax_services_C9   , materials:Air                   ,
+			tobmaterial:TOB_ax_services_C11  , tobmaterial:TOB_ax_services_C12 ,
+			tobmaterial:TOB_ax_services_C13  , materials:Air                   ,
+			tobmaterial:TOB_ax_services_C15  , tobmaterial:TOB_ax_services_C16 ,
+			tobmaterial:TOB_ax_services_C17  , tobmaterial:TOB_ax_services_C18
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBDOHMs"/>
+		<String name="ChildName" value="tob:TOBDOHM"/>
+		<Numeric name="Radius" value="[DOHMRadius1]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="Phi" type="numeric" nEntries="15">
+			[DOHM_R1_phi1]  , [DOHM_R1_phi2]  , [DOHM_R1_phi3]  , [DOHM_R1_phi4]  , [DOHM_R1_phi5]  ,
+			[DOHM_R1_phi6]  , [DOHM_R1_phi7]  , [DOHM_R1_phi8]  , [DOHM_R1_phi9]  , [DOHM_R1_phi10] ,
+			[DOHM_R1_phi11] , [DOHM_R1_phi12] , [DOHM_R1_phi13] , [DOHM_R1_phi14] , [DOHM_R1_phi15]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="15">
+			[zero] , [zero] , [zero] , [zero] , [zero] ,
+			[zero] , [zero] , [zero] , [zero] , [zero] ,
+			[zero] , [zero] , [zero] , [zero] , [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBDOHMs"/>
+		<String name="ChildName" value="tob:TOBDOHM"/>
+		<Numeric name="Radius" value="[DOHMRadius2]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Numeric name="StartCopyNo" value="16"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="Phi" type="numeric" nEntries="15">
+			[DOHM_R2_phi1]  , [DOHM_R2_phi2]  , [DOHM_R2_phi3]  , [DOHM_R2_phi4]  , [DOHM_R2_phi5]  ,
+			[DOHM_R2_phi6]  , [DOHM_R2_phi7]  , [DOHM_R2_phi8]  , [DOHM_R2_phi9]  , [DOHM_R2_phi10] ,
+			[DOHM_R2_phi11] , [DOHM_R2_phi12] , [DOHM_R2_phi13] , [DOHM_R2_phi14] , [DOHM_R2_phi15]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="15">
+			[zero] , [zero] , [zero] , [zero] , [zero] ,
+			[zero] , [zero] , [zero] , [zero] , [zero] ,
+			[zero] , [zero] , [zero] , [zero] , [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerPhiAlgo">
+		<rParent name="tob:TOBDOHMs"/>
+		<String name="ChildName" value="tob:TOBDOHM"/>
+		<Numeric name="Radius" value="[DOHMRadius3]"/>
+		<Numeric name="Tilt" value="0*deg"/>
+		<Numeric name="StartCopyNo" value="31"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<Vector name="Phi" type="numeric" nEntries="16">
+			[DOHM_R3_phi1]  , [DOHM_R3_phi2]  , [DOHM_R3_phi3]  , [DOHM_R3_phi4]  , [DOHM_R3_phi5]  ,
+			[DOHM_R3_phi6]  , [DOHM_R3_phi7]  , [DOHM_R3_phi8]  , [DOHM_R3_phi9]  , [DOHM_R3_phi10] ,
+			[DOHM_R3_phi11] , [DOHM_R3_phi12] , [DOHM_R3_phi13] , [DOHM_R3_phi14] , [DOHM_R3_phi15] ,
+			[DOHM_R3_phi16]
+		</Vector>
+		<Vector name="ZPos" type="numeric" nEntries="16">
+			[zero] , [zero] , [zero] , [zero] , [zero] ,
+			[zero] , [zero] , [zero] , [zero] , [zero] ,
+			[zero] , [zero] , [zero] , [zero] , [zero] ,
+			[zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobmaterial.xml
+++ b/DetectorDescription/DDCMS/data/tobmaterial.xml
@@ -1,0 +1,2248 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <MaterialSection label="tobmaterial.xml">
+    <CompositeMaterial name="TOB_PA_rphi" density="2.33941*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.60133">
+        <rMaterial name="materials:Borosilicate_Glass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.39867">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_PA_ster" density="2.52355*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.61865">
+        <rMaterial name="materials:Borosilicate_Glass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.38135">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_frame_ele" density="1.53600*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.99614">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00386">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_hybrid_supp" density="3.05582*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_mod_cool1" density="3.96724*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.81568">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.18432">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_mod_cool2" density="4.39847*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.65993">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12667">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.21341">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_mod_comp" density="1.37093*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_sid_rail1" density="1.75613*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.77208">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11196">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06609">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00796">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00598">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00796">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01800">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00996">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_sid_rail2" density="1.51100*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.89734">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09311">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00955">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_sid_rail1st" density="1.74227*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.77823">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10526">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06627">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00802">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00603">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00802">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01815">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01004">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_sid_rail2st" density="1.50659*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.89997">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09045">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00958">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ele12" density="2.60162*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.07534">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.66125">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02667">
+        <rMaterial name="materials:SMD_metal" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09994">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00522">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03021">
+        <rMaterial name="materials:Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09855">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00282">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ele34" density="2.60162*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.07534">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.66125">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02667">
+        <rMaterial name="materials:SMD_metal" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09994">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00522">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03021">
+        <rMaterial name="materials:Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09855">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00282">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ele56" density="2.72686*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.07188">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.63088">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02842">
+        <rMaterial name="materials:SMD_metal" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09535">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00554">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03055">
+        <rMaterial name="materials:Alumina" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13336">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00403">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_Sens_Interface" density="0.75665*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.99111">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00881">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00008">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_L12_ICC1" density="1.21506*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.52633">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.23122">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12043">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00629">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09695">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00692">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01186">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_L12_ICC2" density="1.30529*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.48697">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.24364">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12506">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00606">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11564">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00834">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01428">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_L34_ICC1" density="0.82946*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.54002">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.23153">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11265">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.007">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09505">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00507">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00868">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_L34_ICC2" density="0.81274*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.50881">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22587">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11652">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00657">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12407">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00670">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01147">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_L56_ICC1" density="0.85619*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.51768">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1161">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05821">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09756">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00547">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00678">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09209">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00491">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00564">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00353">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04434">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00139">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00667">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00841">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="materials:Air" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03122">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_L56_ICC2" density="0.88614*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.45982">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09073">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07611">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12696">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00684">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00602">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11379">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00521">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00554">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00441">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05545">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00173">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00834">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="materials:Air" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03904">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_AOH" density="1.80152*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.26137">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.19822">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07208">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12027">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0051">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0276">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01088">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0173">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="materials:Air" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.27912">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00805">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_CCUM" density="0.92095*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.69356">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.17904">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08818">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00313">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03007">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00603">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_CONN12" density="1.41913*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00638">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.001">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0545">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01058">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00624">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02384">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10559">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00377">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00221">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03578">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00418">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00383">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00971">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00435">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00534">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00375">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0007">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00732">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0018">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00526">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00051">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01317">
+        <rMaterial name="trackermaterial:Optical_Fiber" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03821">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.31415">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.32868">
+        <rMaterial name="trackermaterial:T_Ribbon12xMUConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00914">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_CONN34" density="0.92279*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00982">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00154">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08382">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01627">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00959">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03667">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16238">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0058">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0034">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05502">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00643">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00588">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01494">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00669">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00821">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00576">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00108">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01126">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00276">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0081">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00079">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01013">
+        <rMaterial name="trackermaterial:Optical_Fiber" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03233">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.24158">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.25273">
+        <rMaterial name="trackermaterial:T_Ribbon12xMUConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00703">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_CONN56" density="1.29029*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00702">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0011">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05995">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01163">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00686">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02622">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11613">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00415">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00243">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03935">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0046">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00421">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01068">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00478">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00587">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00412">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00077">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00805">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00198">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00579">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00056">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01086">
+        <rMaterial name="trackermaterial:Optical_Fiber" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03467">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.25916">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.3615">
+        <rMaterial name="trackermaterial:T_Ribbon12xMUConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00754">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_optfib_L12" density="1.52360*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.28236">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22972">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03712">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.45081">
+        <rMaterial name="trackermaterial:Optical_Fiber" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_optfib_L34" density="0.84381*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.33607">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.27343">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04951">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.34099">
+        <rMaterial name="trackermaterial:Optical_Fiber" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_optfib_L56" density="0.98768*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.28712">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.2336">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0423">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.43699">
+        <rMaterial name="trackermaterial:Optical_Fiber" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ICB" density="3.22606*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.70424">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.2645">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00469">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02117">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00505">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00036">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_DOH" density="1.74606*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.10021">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08241">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01198">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01924">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00063">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00484">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00779">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01236">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="materials:Air" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="materials:Air" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="materials:Air" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00288">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22186">
+        <rMaterial name="trackermaterial:Optical_Fiber" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06318">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.47262">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_DOHM" density="1.63791*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.28501">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04856">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01248">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01885">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0002">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00419">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00399">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00255">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03088">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="materials:Air" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00398">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00254">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00142">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22035">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08615">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01596">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00131">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.15624">
+        <rMaterial name="trackermaterial:T_Ribbon12xMUConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10535">
+        <rMaterial name="tobmaterial:TOB_DOH" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_RailTop" density="1.97*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TIB_RailBottom" density="0.83*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.95">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05">
+        <rMaterial name="trackermaterial:T_Rohacell" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_AlSideConnect" density="4.54*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_AlCentralConnect" density="3.19*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_CF_Str" density="1.69*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_Epoxy" density="2.64*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_Nomex" density="32*mg/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.">
+        <rMaterial name="trackermaterial:T_Nomex" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_middle_ribs" density="1.55*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_plate_A" density="674*mg/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_plate_B" density="2.526*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_plate_C" density="2*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_rad_services1" density="0.78663*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.16746">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03062">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00452">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01166">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01448">
+        <rMaterial name="trackermaterial:TOB_Ribbon12xMUConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08301">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03826">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.64997">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_rad_services2" density="1.40155*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.17833">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03222">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00487">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00579">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00685">
+        <rMaterial name="trackermaterial:TOB_Ribbon12xMUConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0896">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03793">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.64441">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_rad_services3" density="1.76307*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.12662">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0707">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03052">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00536">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00411">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00487">
+        <rMaterial name="trackermaterial:TOB_Ribbon12xMUConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09163">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03703">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.62915">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_rad_services4" density="2.07459*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.09677">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11456">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03033">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.006">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00314">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00337">
+        <rMaterial name="trackermaterial:TOB_Ribbon12xMUConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09787">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03602">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.61194">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_rad_services5" density="2.42471*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.07424">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14105">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03734">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00703">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00241">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00218">
+        <rMaterial name="trackermaterial:TOB_Ribbon12xMUConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09683">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03552">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.60339">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_rad_services6" density="2.86547*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.05738">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.15196">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05736">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01002">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00186">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00242">
+        <rMaterial name="trackermaterial:TOB_Ribbon12xMUConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11577">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03353">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.56969">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_rib1" density="0.32766*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00231">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00029">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00244">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00037">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01656">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0135">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0797">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01456">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00856">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03531">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04779">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00438">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01044">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00319">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00204">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02224">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11503">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06666">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0184">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00876">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02224">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.005">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01222">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00958">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09861">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01571">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.19901">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16509">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_rib2" density="0.32900*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00231">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00029">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00244">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00037">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01656">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0135">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0797">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01456">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00856">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0353">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04778">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00438">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01044">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00319">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00204">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02224">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11503">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06667">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0184">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00876">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02224">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.005">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01222">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00958">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09861">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01571">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.19902">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1651">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_rib3" density="0.31373*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00188">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00024">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00198">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0003">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01348">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01099">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07554">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0138">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00811">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03346">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04529">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00356">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0085">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0026">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00166">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02328">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1204">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06978">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01926">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00917">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02328">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00524">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01279">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01002">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09605">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00822">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20831">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1728">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_rib4" density="0.31523*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00192">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00024">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00203">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00031">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01378">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01123">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07721">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01411">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00829">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0342">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04629">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00364">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00868">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00266">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0017">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02314">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11964">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06934">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01914">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00912">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02314">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0052">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01271">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00996">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09545">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00817">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.207">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.17172">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_rib5" density="0.31300*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00174">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00022">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00184">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00028">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01248">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01017">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07823">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0143">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0084">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03466">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04691">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0033">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00787">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00241">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00154">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02305">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11922">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06909">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01907">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00908">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02305">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00519">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01267">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00993">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09511">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01283">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20627">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.17111">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_rib6" density="0.30602*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00159">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0002">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00168">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00026">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01141">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0093">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0715">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01306">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00768">
+        <rMaterial name="trackermaterial:T_Silicone_Gel" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03167">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04287">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00302">
+        <rMaterial name="trackermaterial:T_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00719">
+        <rMaterial name="materials:Brass" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0022">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0014">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02362">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12216">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0708">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01954">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00931">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02362">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00531">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01298">
+        <rMaterial name="materials:BGA" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01017">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09746">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0133">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.21136">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.17533">
+        <rMaterial name="materials:Epoxy" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A2" density="0.89125*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.5716">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.18427">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07157">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00959">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16296">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A3" density="0.83126*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.55157">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.26343">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01028">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.17472">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A4" density="0.64868*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.62828">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.25318">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00659">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11195">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A5" density="0.88745*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.63146">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12337">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07188">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00963">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16366">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A7" density="0.75817*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.53755">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.36103">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00564">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09578">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A8" density="0.84410*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.48282">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.25942">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07557">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01013">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.17207">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A9" density="0.75437*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.60779">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.29028">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00567">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09627">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A11" density="0.89125*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.5716">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.18427">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07157">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00959">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16296">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A12" density="0.71200*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.57132">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.15348">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05961">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01198">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.2036">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A13" density="0.75437*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.60779">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.29028">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00567">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09627">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A14" density="0.88745*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.63146">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12337">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07188">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00963">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16366">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A16" density="0.81815*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.5604">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.26765">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07796">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00522">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08876">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A17" density="0.72557*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.5617">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22635">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01178">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20017">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_A18" density="0.75437*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.60779">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.29028">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00567">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09627">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B2" density="1.48936*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.51373">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.48627">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B3" density="1.35203*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.46433">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.53567">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B4" density="1.35203*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.46433">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.53567">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B5" density="1.46974*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.50723">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.49277">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B6" density="1.50898*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.52005">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.47995">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B7" density="1.27356*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.43133">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.56867">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B8" density="1.33241*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.45645">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.54355">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B9" density="1.50898*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.52005">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.47995">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B11" density="1.29318*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.43995">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.56005">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B12" density="1.50898*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.52005">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.47995">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B13" density="1.50898*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.52005">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.47995">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B14" density="1.50898*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.52005">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.47995">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B15" density="1.48936*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.51373">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.48627">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B16" density="1.43050*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.49372">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.50628">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B17" density="1.46974*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.50723">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.49277">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_B18" density="1.46974*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.50723">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.49277">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C2" density="0.87379*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.52472">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.25061">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04867">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00978">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16622">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C3" density="0.73462*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.55478">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14904">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08683">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01164">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.19771">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C4" density="0.74595*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.54636">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.29355">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05701">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00573">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09735">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C6" density="0.86619*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.64696">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1264">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04909">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00987">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16768">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C7" density="0.75057*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.67874">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.21881">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0057">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09675">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C8" density="0.71715*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.49725">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.229">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0593">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01192">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20252">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C9" density="0.81055*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.69136">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13508">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07869">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00527">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08959">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C11" density="0.83126*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.55157">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.26343">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01028">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.17472">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C12" density="0.73842*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.48294">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22241">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08638">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01158">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.19669">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C13" density="0.75437*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.60779">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.29028">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00567">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09627">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C15" density="0.88745*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.63146">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12337">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07188">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00963">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.16366">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C16" density="0.75437*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.60779">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.29028">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00567">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.09627">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C17" density="0.79316*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.4496">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.27608">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08042">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01078">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.18312">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_ax_services_C18" density="0.81055*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.69136">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13508">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07869">
+        <rMaterial name="trackermaterial:TOB_DOHM_PowerConn" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00527">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08959">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_rod" density="1.796*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.">
+        <rMaterial name="trackermaterial:T_CarbonFibreStr" />
+      </MaterialFraction>
+    </CompositeMaterial>
+  </MaterialSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobmodpar.xml
+++ b/DetectorDescription/DDCMS/data/tobmodpar.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobmodpar.xml" eval="true">
+		<Constant name="ModuleDx" value="6.000*cm"/>
+		<Constant name="ModuleDy" value="0.440*cm"/>
+		<Constant name="ModuleDz" value="12.075*cm"/>
+		<Constant name="HybridDx" value="3.000*cm"/>
+		<Constant name="HybridDy" value="0.025*cm"/>
+		<Constant name="HybridDz" value="1.250*cm"/>
+		<Constant name="HybridY" value="0.215*cm"/>
+		<Constant name="HybridZ" value="9.965*cm"/>
+		<Constant name="PADx" value="4.300*cm"/>
+		<Constant name="PADy" value="0.055*cm"/>
+		<Constant name="PA1Dz" value="0.625*cm"/>
+		<Constant name="PA2Dz1" value="0.8215*cm"/>
+		<Constant name="PA2Dz2" value="0.3900*cm"/>
+		<Constant name="PA2Theta" value="2.87237*deg"/>
+		<Constant name="PAY" value="0.185*cm"/>
+		<Constant name="PAZ" value="8.060*cm"/>
+		<Constant name="SideRailDx" value="0.850*cm"/>
+		<Constant name="SideRailDy" value="0.040*cm"/>
+		<Constant name="SideRailDz" value="10.50*cm"/>
+		<Constant name="SideRailX" value="5.150*cm"/>
+		<Constant name="SideRailY" value="0.125*cm"/>
+		<Constant name="SideRailZ" value="1.575*cm"/>
+		<Constant name="FrameDx" value="6.000*cm"/>
+		<Constant name="FrameDy" value="0.03125*cm"/>
+		<Constant name="FrameDz" value="2.250*cm"/>
+		<Constant name="FrameY" value="0.05275*cm"/>
+		<Constant name="FrameZ" value="9.825*cm"/>
+		<Constant name="HybSupDx" value="3.500*cm"/>
+		<Constant name="HybSupDy" value="0.030*cm"/>
+		<Constant name="HybSupDz" value="1.665*cm"/>
+		<Constant name="HybSupY" value="0.115*cm"/>
+		<Constant name="HybSupZ" value="10.35*cm"/>
+		<Constant name="ModCool1Dx" value="0.800*cm"/>
+		<Constant name="ModCoolDy" value="0.015*cm"/>
+		<Constant name="ModCool1Dz" value="1.000*cm"/>
+		<Constant name="ModCool1X" value="5.200*cm"/>
+		<Constant name="ModCool1Y" value="0.069*cm"/>
+		<Constant name="ModCool1Z" value="2.125*cm"/>
+		<Constant name="ModCool2Dx" value="0.750*cm"/>
+		<Constant name="ModCool2Dz" value="1.400*cm"/>
+		<Constant name="ModCool2X" value="5.250*cm"/>
+		<Constant name="ModCool2Y" value="0.100*cm"/>
+		<Constant name="ModCool2Z" value="10.325*cm"/>
+		<Constant name="ModCoolComp1Dx" value="0.800*cm"/>
+		<Constant name="ModCoolCompDy" value="0.015*cm"/>
+		<Constant name="ModCoolComp1Dz" value="1.300*cm"/>
+		<Constant name="ModCoolComp1X" value="5.200*cm"/>
+		<Constant name="ModCoolComp1Y" value="0.039*cm"/>
+		<Constant name="ModCoolComp1Z" value="2.125*cm"/>
+		<Constant name="ModCoolComp2Dx" value="0.800*cm"/>
+		<Constant name="ModCoolComp2Dz" value="1.300*cm"/>
+		<Constant name="ModCoolComp2X" value="5.200*cm"/>
+		<Constant name="ModCoolComp2Y" value="0.130*cm"/>
+		<Constant name="ModCoolComp2Z" value="10.325*cm"/>
+		<Constant name="Tilt" value="5.7296*deg"/>
+		<Constant name="TiltX" value="(90.0*deg-[Tilt])"/>
+		<Constant name="WaferDx" value="4.818*cm"/>
+		<Constant name="WaferDy" value="9.450*cm"/>
+		<Constant name="WaferDz" value="0.025*cm"/>
+		<Constant name="WaferY" value="0.215*cm"/>
+		<Constant name="WaferZ" value="2.125*cm"/>
+		<Constant name="ActiveDx" value="4.6848*cm"/>
+		<Constant name="ActiveDy" value="9.3067*cm"/>
+		<Constant name="ActiveDz" value="[WaferDz]-[tracker:BackPlaneDz]"/>
+		<Constant name="InactiveDy" value="0.1553*cm"/>
+		<Constant name="GlueDx1" value="4.6848*cm"/>
+		<Constant name="GlueDx2" value="4.30*cm"/>
+		<Constant name="GlueDy" value="0.275*cm"/>
+		<Constant name="GlueDz" value="0.1*cm"/>
+		<Constant name="GlueSi1Y" value="0.340*cm"/>
+		<Constant name="GlueSi2Y" value="0.015*cm"/>
+		<Constant name="GluePAY" value="0.340*cm"/>
+		<Constant name="GluePAZ" value="7.435*cm"/>
+		<Constant name="PAX" value="[WaferDy]*sin([Tilt])"/>
+		<Constant name="GluePAX" value="[WaferDy]*sin([Tilt])"/>
+		<Constant name="PAYst" value="0.260*cm"/>
+		<Constant name="GluePAYst" value="0.390*cm"/>
+	</ConstantsSection>
+	<SolidSection label="tobmodpar.xml">
+		<Box name="TOBModule" dx="[tobmodpar:ModuleDx]" dy="[tobmodpar:ModuleDy]" dz="[tobmodpar:ModuleDz]"/>
+		<Box name="TOBHybrid" dx="[tobmodpar:HybridDx]" dy="[tobmodpar:HybridDy]" dz="[tobmodpar:HybridDz]"/>
+		<Box name="TOBWaferRphi" dx="[tobmodpar:WaferDx]" dy="[tobmodpar:WaferDy]" dz="[tobmodpar:WaferDz]"/>
+		<Box name="TOBActiveRphi" dx="[tobmodpar:ActiveDx]" dy="[tobmodpar:ActiveDy]" dz="[tobmodpar:ActiveDz]"/>
+		<Box name="TOBPA1" dx="[PADx]" dy="[PADy]" dz="[PA1Dz]"/>
+		<Trapezoid name="TOBPA2" dz="[PADx]" alp1="0*deg" bl1="[PA2Dz1]" tl1="[PA2Dz1]" h1="[PADy]" alp2="0*deg" bl2="[PA2Dz2]" tl2="[PA2Dz2]" h2="[PADy]" phi="0*deg" theta="[PA2Theta]"/>
+		<Box name="TOBEncapsulant1" dx="[GlueDx1]" dy="[GlueDy]" dz="[GlueDz]"/>
+		<Box name="TOBEncapsulant2" dx="[GlueDx2]" dy="[GlueDy]" dz="[GlueDz]"/>
+		<Box name="TOBEncapsulant3" dx="[GlueDx1]" dy="[GlueDy]*2" dz="[GlueDz]/2"/>
+		<Box name="TOBSideRailL" dx="[SideRailDx]" dy="[SideRailDy]" dz="[SideRailDz]"/>
+		<Box name="TOBSideRailR" dx="[SideRailDx]" dy="[SideRailDy]" dz="[SideRailDz]"/>
+		<Box name="TOBFrame" dx="[FrameDx]" dy="[FrameDy]" dz="[FrameDz]"/>
+		<Box name="TOBHybSup" dx="[HybSupDx]" dy="[HybSupDy]" dz="[HybSupDz]"/>
+		<Box name="TOBModCool1" dx="[ModCool1Dx]" dy="[ModCoolDy]" dz="[ModCool1Dz]"/>
+		<Box name="TOBModCool2" dx="[ModCool2Dx]" dy="[ModCoolDy]" dz="[ModCool2Dz]"/>
+		<Box name="TOBModCoolComp1" dx="[ModCoolComp1Dx]" dy="[ModCoolCompDy]" dz="[ModCoolComp1Dz]"/>
+		<Box name="TOBModCoolComp2" dx="[ModCoolComp2Dx]" dy="[ModCoolCompDy]" dz="[ModCoolComp2Dz]"/>
+		<Box name="TOBInactive" dx="[ActiveDx]" dy="[InactiveDy]" dz="[ActiveDz]"/>
+	</SolidSection>
+	<LogicalPartSection label="tobmodpar.xml">
+		<LogicalPart name="TOBPA1" category="unspecified">
+			<rSolid name="TOBPA1"/>
+			<rMaterial name="tobmaterial:TOB_PA_rphi"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPA2" category="unspecified">
+			<rSolid name="TOBPA2"/>
+			<rMaterial name="tobmaterial:TOB_PA_ster"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPAEncaps" category="unspecified">
+			<rSolid name="TOBEncapsulant1"/>
+			<rMaterial name="tobmaterial:TOB_Sens_Interface"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPAEncapsSt" category="unspecified">
+			<rSolid name="TOBEncapsulant3"/>
+			<rMaterial name="tobmaterial:TOB_Sens_Interface"/>
+		</LogicalPart>
+		<LogicalPart name="TOBSideRailL" category="unspecified">
+			<rSolid name="TOBSideRailL"/>
+			<rMaterial name="tobmaterial:TOB_sid_rail1"/>
+		</LogicalPart>
+		<LogicalPart name="TOBSideRailR" category="unspecified">
+			<rSolid name="TOBSideRailR"/>
+			<rMaterial name="tobmaterial:TOB_sid_rail2"/>
+		</LogicalPart>
+		<LogicalPart name="TOBSideRailLst" category="unspecified">
+			<rSolid name="TOBSideRailL"/>
+			<rMaterial name="tobmaterial:TOB_sid_rail1st"/>
+		</LogicalPart>
+		<LogicalPart name="TOBSideRailRst" category="unspecified">
+			<rSolid name="TOBSideRailR"/>
+			<rMaterial name="tobmaterial:TOB_sid_rail2st"/>
+		</LogicalPart>
+		<LogicalPart name="TOBFrame" category="unspecified">
+			<rSolid name="TOBFrame"/>
+			<rMaterial name="tobmaterial:TOB_frame_ele"/>
+		</LogicalPart>
+		<LogicalPart name="TOBHybSup" category="unspecified">
+			<rSolid name="TOBHybSup"/>
+			<rMaterial name="tobmaterial:TOB_hybrid_supp"/>
+		</LogicalPart>
+		<LogicalPart name="TOBModCool1" category="unspecified">
+			<rSolid name="TOBModCool1"/>
+			<rMaterial name="tobmaterial:TOB_mod_cool1"/>
+		</LogicalPart>
+		<LogicalPart name="TOBModCool2" category="unspecified">
+			<rSolid name="TOBModCool2"/>
+			<rMaterial name="tobmaterial:TOB_mod_cool2"/>
+		</LogicalPart>
+		<LogicalPart name="TOBModCoolComp1" category="unspecified">
+			<rSolid name="TOBModCoolComp1"/>
+			<rMaterial name="tobmaterial:TOB_mod_comp"/>
+		</LogicalPart>
+		<LogicalPart name="TOBModCoolComp2" category="unspecified">
+			<rSolid name="TOBModCoolComp2"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TOBInactive" category="unspecified">
+			<rSolid name="TOBInactive"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="TOBSiEncaps" category="unspecified">
+			<rSolid name="TOBEncapsulant1"/>
+			<rMaterial name="tobmaterial:TOB_Sens_Interface"/>
+		</LogicalPart>
+		<LogicalPart name="TOBSiBackEncaps" category="unspecified">
+			<rSolid name="TOBEncapsulant2"/>
+			<rMaterial name="trackermaterial:T_Silicone_Gel"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<RotationSection label="tobmodpar.xml">
+		<Rotation name="Rphi" thetaX="90*deg" phiX="0*deg" thetaY="0*deg" phiY="0*deg" thetaZ="-90*deg" phiZ="90*deg"/>
+		<Rotation name="Ster" thetaX="[TiltX]" phiX="180*deg" thetaY="[Tilt]" phiY="0*deg" thetaZ="90*deg" phiZ="90*deg"/>
+		<Rotation name="PA" thetaX="0*deg" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="-90*deg" phiZ="0*deg"/>
+		<Rotation name="Activ" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="270*deg" thetaZ="0*deg" phiZ="0*deg"/>
+	</RotationSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobmodule0.xml
+++ b/DetectorDescription/DDCMS/data/tobmodule0.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobmodule0.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<SolidSection label="tobmodule0.xml">
+		<Box name="TOBModCool01" dx="[tobmodpar:ModCool1Dx]" dy="[tobmodpar:ModCoolDy]" dz="[tobmodpar:ModCool1Dz]"/>
+		<Box name="TOBModCool02" dx="[tobmodpar:ModCool2Dx]" dy="[tobmodpar:ModCoolDy]" dz="[tobmodpar:ModCool2Dz]"/>
+		<Box name="TOBWaferSter0" dx="[tobmodpar:WaferDx]" dy="[tobmodpar:WaferDy]" dz="[tobmodpar:WaferDz]"/>
+		<Box name="TOBActiveSter0" dx="[tobmodpar:ActiveDx]" dy="[tobmodpar:ActiveDy]" dz="[tobmodpar:ActiveDz]"/>
+		<Box name="TOBModCoolComp01" dx="[tobmodpar:ModCoolComp1Dx]" dy="[tobmodpar:ModCoolCompDy]" dz="[tobmodpar:ModCoolComp1Dz]"/>
+		<Box name="TOBModCoolComp02" dx="[tobmodpar:ModCoolComp2Dx]" dy="[tobmodpar:ModCoolCompDy]" dz="[tobmodpar:ModCoolComp2Dz]"/>
+	</SolidSection>
+	<LogicalPartSection label="tobmodule0.xml">
+		<LogicalPart name="TOBModule0" category="unspecified">
+			<rSolid name="tobmodpar:TOBModule"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBHybrid0" category="unspecified">
+			<rSolid name="tobmodpar:TOBHybrid"/>
+			<rMaterial name="tobmaterial:TOB_ele12"/>
+		</LogicalPart>
+		<LogicalPart name="TOBModCool01" category="unspecified">
+			<rSolid name="TOBModCool01"/>
+			<rMaterial name="tobmaterial:TOB_mod_cool1"/>
+		</LogicalPart>
+		<LogicalPart name="TOBModCool02" category="unspecified">
+			<rSolid name="TOBModCool02"/>
+			<rMaterial name="tobmaterial:TOB_mod_cool2"/>
+		</LogicalPart>
+		<LogicalPart name="TOBWaferRphi0" category="unspecified">
+			<rSolid name="tobmodpar:TOBWaferRphi"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="TOBActiveRphi0" category="unspecified">
+			<rSolid name="tobmodpar:TOBActiveRphi"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="TOBWaferSter0" category="unspecified">
+			<rSolid name="TOBWaferSter0"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="TOBActiveSter0" category="unspecified">
+			<rSolid name="TOBActiveSter0"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="TOBModCoolComp01" category="unspecified">
+			<rSolid name="TOBModCoolComp01"/>
+			<rMaterial name="tobmaterial:TOB_mod_comp"/>
+		</LogicalPart>
+		<LogicalPart name="TOBModCoolComp02" category="unspecified">
+			<rSolid name="TOBModCoolComp02"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobmodule0.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBWaferRphi0"/>
+			<rChild name="tobmodule0:TOBActiveRphi0"/>
+			<Translation x="[zero]" y="[zero]" z="[tracker:BackPlaneDz]"/>
+			<rRotation name="tobmodpar:Activ"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBActiveRphi0"/>
+			<rChild name="tobmodpar:TOBInactive"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBWaferSter0"/>
+			<rChild name="tobmodule0:TOBActiveSter0"/>
+			<Translation x="[zero]" y="[zero]" z="[tracker:BackPlaneDz]"/>
+			<rRotation name="tobmodpar:Activ"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBActiveSter0"/>
+			<rChild name="tobmodpar:TOBInactive"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodule0:TOBWaferRphi0"/>
+			<rRotation name="tobmodpar:Rphi"/>
+			<Translation x="[zero]" y="-[tobmodpar:WaferY]" z="-[tobmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodule0:TOBWaferSter0"/>
+			<rRotation name="tobmodpar:Ster"/>
+			<Translation x="[zero]" y="[tobmodpar:WaferY]" z="-[tobmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBSiEncaps"/>
+			<rRotation name="tobmodpar:Rphi"/>
+			<Translation x="[zero]" y="-[tobmodpar:GlueSi1Y]" z="-[tobmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBSiEncaps"/>
+			<rRotation name="tobmodpar:Ster"/>
+			<Translation x="[zero]" y="[tobmodpar:GlueSi1Y]" z="-[tobmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBSiBackEncaps"/>
+			<rRotation name="tobmodpar:Rphi"/>
+			<Translation x="[zero]" y="-[tobmodpar:GlueSi2Y]" z="-[tobmodpar:WaferZ]-[tobmodpar:GlueDy]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBSiBackEncaps"/>
+			<rRotation name="tobmodpar:Rphi"/>
+			<Translation x="[zero]" y="[tobmodpar:GlueSi2Y]" z="-[tobmodpar:WaferZ]+[tobmodpar:GlueDy]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodule0:TOBHybrid0"/>
+			<Translation x="[zero]" y="-[tobmodpar:HybridY]" z="[tobmodpar:HybridZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodule0:TOBHybrid0"/>
+			<Translation x="[zero]" y="[tobmodpar:HybridY]" z="[tobmodpar:HybridZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBPA1"/>
+			<Translation x="[zero]" y="-[tobmodpar:PAY]" z="[tobmodpar:PAZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBPA2"/>
+			<rRotation name="tobmodpar:PA"/>
+			<Translation x="[tobmodpar:PAX]" y="[tobmodpar:PAYst]" z="[tobmodpar:PAZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBPAEncaps"/>
+			<rRotation name="tobmodpar:Rphi"/>
+			<Translation x="[zero]" y="-[tobmodpar:GluePAY]" z="[tobmodpar:GluePAZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBPAEncapsSt"/>
+			<rRotation name="tobmodpar:Ster"/>
+			<Translation x="[tobmodpar:GluePAX]" y="[tobmodpar:GluePAYst]" z="[tobmodpar:GluePAZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBSideRailL"/>
+			<Translation x="-[tobmodpar:SideRailX]" y="-[tobmodpar:SideRailY]" z="-[tobmodpar:SideRailZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBSideRailR"/>
+			<Translation x="[tobmodpar:SideRailX]" y="-[tobmodpar:SideRailY]" z="-[tobmodpar:SideRailZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBSideRailLst"/>
+			<Translation x="[tobmodpar:SideRailX]" y="[tobmodpar:SideRailY]" z="-[tobmodpar:SideRailZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBSideRailRst"/>
+			<Translation x="-[tobmodpar:SideRailX]" y="[tobmodpar:SideRailY]" z="-[tobmodpar:SideRailZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBFrame"/>
+			<Translation x="[zero]" y="-[tobmodpar:FrameY]" z="[tobmodpar:FrameZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBFrame"/>
+			<Translation x="[zero]" y="[tobmodpar:FrameY]" z="[tobmodpar:FrameZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBHybSup"/>
+			<Translation x="[zero]" y="-[tobmodpar:HybSupY]" z="[tobmodpar:HybSupZ]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBHybSup"/>
+			<Translation x="[zero]" y="[tobmodpar:HybSupY]" z="[tobmodpar:HybSupZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBModCool1"/>
+			<Translation x="-[tobmodpar:ModCool1X]" y="-[tobmodpar:ModCool1Y]" z="-[tobmodpar:ModCool1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBModCool1"/>
+			<Translation x="[tobmodpar:ModCool1X]" y="-[tobmodpar:ModCool1Y]" z="-[tobmodpar:ModCool1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBModCoolComp1"/>
+			<Translation x="-[tobmodpar:ModCoolComp1X]" y="-[tobmodpar:ModCoolComp1Y]" z="-[tobmodpar:ModCoolComp1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBModCoolComp1"/>
+			<Translation x="[tobmodpar:ModCoolComp1X]" y="-[tobmodpar:ModCoolComp1Y]" z="-[tobmodpar:ModCoolComp1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBModCool2"/>
+			<Translation x="-[tobmodpar:ModCool2X]" y="-[tobmodpar:ModCool2Y]" z="[tobmodpar:ModCool2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBModCool2"/>
+			<Translation x="[tobmodpar:ModCool2X]" y="-[tobmodpar:ModCool2Y]" z="[tobmodpar:ModCool2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBModCoolComp2"/>
+			<Translation x="-[tobmodpar:ModCoolComp2X]" y="-[tobmodpar:ModCoolComp2Y]" z="[tobmodpar:ModCoolComp2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodpar:TOBModCoolComp2"/>
+			<Translation x="[tobmodpar:ModCoolComp2X]" y="-[tobmodpar:ModCoolComp2Y]" z="[tobmodpar:ModCoolComp2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodule0:TOBModCool01"/>
+			<Translation x="-[tobmodpar:ModCool1X]" y="[tobmodpar:ModCool1Y]" z="-[tobmodpar:ModCool1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodule0:TOBModCool01"/>
+			<Translation x="[tobmodpar:ModCool1X]" y="[tobmodpar:ModCool1Y]" z="-[tobmodpar:ModCool1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodule0:TOBModCoolComp01"/>
+			<Translation x="-[tobmodpar:ModCoolComp1X]" y="[tobmodpar:ModCoolComp1Y]" z="-[tobmodpar:ModCoolComp1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodule0:TOBModCoolComp01"/>
+			<Translation x="[tobmodpar:ModCoolComp1X]" y="[tobmodpar:ModCoolComp1Y]" z="-[tobmodpar:ModCoolComp1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodule0:TOBModCool02"/>
+			<Translation x="-[tobmodpar:ModCool2X]" y="[tobmodpar:ModCool2Y]" z="[tobmodpar:ModCool2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodule0:TOBModCool02"/>
+			<Translation x="[tobmodpar:ModCool2X]" y="[tobmodpar:ModCool2Y]" z="[tobmodpar:ModCool2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodule0:TOBModCoolComp02"/>
+			<Translation x="-[tobmodpar:ModCoolComp2X]" y="[tobmodpar:ModCoolComp2Y]" z="[tobmodpar:ModCoolComp2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule0:TOBModule0"/>
+			<rChild name="tobmodule0:TOBModCoolComp02"/>
+			<Translation x="[tobmodpar:ModCoolComp2X]" y="[tobmodpar:ModCoolComp2Y]" z="[tobmodpar:ModCoolComp2Z]"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobmodule2.xml
+++ b/DetectorDescription/DDCMS/data/tobmodule2.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobmodule2.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobmodule2.xml">
+		<LogicalPart name="TOBModule2" category="unspecified">
+			<rSolid name="tobmodpar:TOBModule"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBHybrid2" category="unspecified">
+			<rSolid name="tobmodpar:TOBHybrid"/>
+			<rMaterial name="tobmaterial:TOB_ele34"/>
+		</LogicalPart>
+		<LogicalPart name="TOBWaferRphi2" category="unspecified">
+			<rSolid name="tobmodpar:TOBWaferRphi"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="TOBActiveRphi2" category="unspecified">
+			<rSolid name="tobmodpar:TOBActiveRphi"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobmodule2.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBWaferRphi2"/>
+			<rChild name="tobmodule2:TOBActiveRphi2"/>
+			<Translation x="[zero]" y="[zero]" z="[tracker:BackPlaneDz]"/>
+			<rRotation name="tobmodpar:Activ"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBActiveRphi2"/>
+			<rChild name="tobmodpar:TOBInactive"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodule2:TOBWaferRphi2"/>
+			<rRotation name="tobmodpar:Rphi"/>
+			<Translation x="[zero]" y="-[tobmodpar:WaferY]" z="-[tobmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBSiEncaps"/>
+			<rRotation name="tobmodpar:Rphi"/>
+			<Translation x="[zero]" y="-[tobmodpar:GlueSi1Y]" z="-[tobmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBSiBackEncaps"/>
+			<rRotation name="tobmodpar:Rphi"/>
+			<Translation x="[zero]" y="-[tobmodpar:GlueSi2Y]" z="-[tobmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodule2:TOBHybrid2"/>
+			<Translation x="[zero]" y="-[tobmodpar:HybridY]" z="[tobmodpar:HybridZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBPA1"/>
+			<Translation x="[zero]" y="-[tobmodpar:PAY]" z="[tobmodpar:PAZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBPAEncaps"/>
+			<rRotation name="tobmodpar:Rphi"/>
+			<Translation x="[zero]" y="-[tobmodpar:GluePAY]" z="[tobmodpar:GluePAZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBSideRailL"/>
+			<Translation x="-[tobmodpar:SideRailX]" y="-[tobmodpar:SideRailY]" z="-[tobmodpar:SideRailZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBSideRailR"/>
+			<Translation x="[tobmodpar:SideRailX]" y="-[tobmodpar:SideRailY]" z="-[tobmodpar:SideRailZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBFrame"/>
+			<Translation x="[zero]" y="-[tobmodpar:FrameY]" z="[tobmodpar:FrameZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBHybSup"/>
+			<Translation x="[zero]" y="-[tobmodpar:HybSupY]" z="[tobmodpar:HybSupZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBModCool1"/>
+			<Translation x="-[tobmodpar:ModCool1X]" y="-[tobmodpar:ModCool1Y]" z="-[tobmodpar:ModCool1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBModCool1"/>
+			<Translation x="[tobmodpar:ModCool1X]" y="-[tobmodpar:ModCool1Y]" z="-[tobmodpar:ModCool1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBModCoolComp1"/>
+			<Translation x="-[tobmodpar:ModCoolComp1X]" y="-[tobmodpar:ModCoolComp1Y]" z="-[tobmodpar:ModCoolComp1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBModCoolComp1"/>
+			<Translation x="[tobmodpar:ModCoolComp1X]" y="-[tobmodpar:ModCoolComp1Y]" z="-[tobmodpar:ModCoolComp1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBModCool2"/>
+			<Translation x="-[tobmodpar:ModCool2X]" y="-[tobmodpar:ModCool2Y]" z="[tobmodpar:ModCool2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBModCool2"/>
+			<Translation x="[tobmodpar:ModCool2X]" y="-[tobmodpar:ModCool2Y]" z="[tobmodpar:ModCool2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBModCoolComp2"/>
+			<Translation x="-[tobmodpar:ModCoolComp2X]" y="-[tobmodpar:ModCoolComp2Y]" z="[tobmodpar:ModCoolComp2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule2:TOBModule2"/>
+			<rChild name="tobmodpar:TOBModCoolComp2"/>
+			<Translation x="[tobmodpar:ModCoolComp2X]" y="-[tobmodpar:ModCoolComp2Y]" z="[tobmodpar:ModCoolComp2Z]"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobmodule4.xml
+++ b/DetectorDescription/DDCMS/data/tobmodule4.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobmodule4.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobmodule4.xml">
+		<LogicalPart name="TOBModule4" category="unspecified">
+			<rSolid name="tobmodpar:TOBModule"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBHybrid4" category="unspecified">
+			<rSolid name="tobmodpar:TOBHybrid"/>
+			<rMaterial name="tobmaterial:TOB_ele56"/>
+		</LogicalPart>
+		<LogicalPart name="TOBWaferRphi4" category="unspecified">
+			<rSolid name="tobmodpar:TOBWaferRphi"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+		<LogicalPart name="TOBActiveRphi4" category="unspecified">
+			<rSolid name="tobmodpar:TOBActiveRphi"/>
+			<rMaterial name="materials:Silicon"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobmodule4.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBWaferRphi4"/>
+			<rChild name="tobmodule4:TOBActiveRphi4"/>
+			<Translation x="[zero]" y="[zero]" z="[tracker:BackPlaneDz]"/>
+			<rRotation name="tobmodpar:Activ"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBActiveRphi4"/>
+			<rChild name="tobmodpar:TOBInactive"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodule4:TOBWaferRphi4"/>
+			<rRotation name="tobmodpar:Rphi"/>
+			<Translation x="[zero]" y="-[tobmodpar:WaferY]" z="-[tobmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBSiEncaps"/>
+			<rRotation name="tobmodpar:Rphi"/>
+			<Translation x="[zero]" y="-[tobmodpar:GlueSi1Y]" z="-[tobmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBSiBackEncaps"/>
+			<rRotation name="tobmodpar:Rphi"/>
+			<Translation x="[zero]" y="-[tobmodpar:GlueSi2Y]" z="-[tobmodpar:WaferZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodule4:TOBHybrid4"/>
+			<Translation x="[zero]" y="-[tobmodpar:HybridY]" z="[tobmodpar:HybridZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBPA1"/>
+			<Translation x="[zero]" y="-[tobmodpar:PAY]" z="[tobmodpar:PAZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBPAEncaps"/>
+			<rRotation name="tobmodpar:Rphi"/>
+			<Translation x="[zero]" y="-[tobmodpar:GluePAY]" z="[tobmodpar:GluePAZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBSideRailL"/>
+			<Translation x="-[tobmodpar:SideRailX]" y="-[tobmodpar:SideRailY]" z="-[tobmodpar:SideRailZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBSideRailR"/>
+			<Translation x="[tobmodpar:SideRailX]" y="-[tobmodpar:SideRailY]" z="-[tobmodpar:SideRailZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBFrame"/>
+			<Translation x="[zero]" y="-[tobmodpar:FrameY]" z="[tobmodpar:FrameZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBHybSup"/>
+			<Translation x="[zero]" y="-[tobmodpar:HybSupY]" z="[tobmodpar:HybSupZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBModCool1"/>
+			<Translation x="-[tobmodpar:ModCool1X]" y="-[tobmodpar:ModCool1Y]" z="-[tobmodpar:ModCool1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBModCool1"/>
+			<Translation x="[tobmodpar:ModCool1X]" y="-[tobmodpar:ModCool1Y]" z="-[tobmodpar:ModCool1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBModCoolComp1"/>
+			<Translation x="-[tobmodpar:ModCoolComp1X]" y="-[tobmodpar:ModCoolComp1Y]" z="-[tobmodpar:ModCoolComp1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBModCoolComp1"/>
+			<Translation x="[tobmodpar:ModCoolComp1X]" y="-[tobmodpar:ModCoolComp1Y]" z="-[tobmodpar:ModCoolComp1Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBModCool2"/>
+			<Translation x="-[tobmodpar:ModCool2X]" y="-[tobmodpar:ModCool2Y]" z="[tobmodpar:ModCool2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBModCool2"/>
+			<Translation x="[tobmodpar:ModCool2X]" y="-[tobmodpar:ModCool2Y]" z="[tobmodpar:ModCool2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBModCoolComp2"/>
+			<Translation x="-[tobmodpar:ModCoolComp2X]" y="-[tobmodpar:ModCoolComp2Y]" z="[tobmodpar:ModCoolComp2Z]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tobmodule4:TOBModule4"/>
+			<rChild name="tobmodpar:TOBModCoolComp2"/>
+			<Translation x="[tobmodpar:ModCoolComp2X]" y="-[tobmodpar:ModCoolComp2Y]" z="[tobmodpar:ModCoolComp2Z]"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod0.xml
+++ b/DetectorDescription/DDCMS/data/tobrod0.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod0.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod0.xml">
+		<LogicalPart name="TOBRod0" category="unspecified">
+			<rSolid name="tobrodpar:TOBRod"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod0.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod0:TOBRod0"/>
+			<rChild name="tobrod0l:TOBRod0L"/>
+			<rRotation name="tobrodpar:R180"/>
+			<Translation x="[zero]" y="[zero]" z="-([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobrod0:TOBRod0"/>
+			<rChild name="tobrod0h:TOBRod0H"/>
+			<rRotation name="tobrodpar:R180"/>
+			<Translation x="[zero]" y="[zero]" z="([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod0c.xml
+++ b/DetectorDescription/DDCMS/data/tobrod0c.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod0c.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<SolidSection label="tobrod0c.xml">
+		<Tubs name="TOBSideCoolTube0" rMin="[zero]" rMax="[tobrodpar:CoolTubeHeavyR]" dz="[tobrodpar:SideCoolL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBSideCoolFluid0" rMin="[zero]" rMax="[tobrodpar:CoolFluidHeavyR]" dz="[tobrodpar:SideCoolL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBEndCoolTube0" rMin="[zero]" rMax="[tobrodpar:CoolTubeHeavyR]" dz="[tobrodpar:EndCoolL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBEndCoolFluid0" rMin="[zero]" rMax="[tobrodpar:CoolFluidHeavyR]" dz="[tobrodpar:EndCoolL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Box name="TOBOptFibre0" dx="[tobrodpar:OptFibreW]" dy="[tobrodpar:OptFibreH]" dz="[tobrodpar:OptFibreL]"/>
+		<Box name="TOBPlate01" dx="[tobrodpar:SideClampDx]" dy="[tobrodpar:SideClampDy]" dz="[tobrodpar:SideClampHDz]"/>
+		<Box name="TOBPlate02" dx="[tobrodpar:SideClampDx]" dy="[tobrodpar:SideClampDy]" dz="[tobrodpar:SideClampHDz]"/>
+	</SolidSection>
+	<LogicalPartSection label="tobrod0c.xml">
+		<LogicalPart name="TOBSideCoolTube0" category="unspecified">
+			<rSolid name="TOBSideCoolTube0"/>
+			<rMaterial name="trackermaterial:T_CuNi"/>
+		</LogicalPart>
+		<LogicalPart name="TOBSideCoolFluid0" category="unspecified">
+			<rSolid name="TOBSideCoolFluid0"/>
+			<rMaterial name="trackermaterial:T_C6F14_F2_-30C"/>
+		</LogicalPart>
+		<LogicalPart name="TOBEndCoolTube0" category="unspecified">
+			<rSolid name="TOBEndCoolTube0"/>
+			<rMaterial name="trackermaterial:T_CuNi"/>
+		</LogicalPart>
+		<LogicalPart name="TOBEndCoolFluid0" category="unspecified">
+			<rSolid name="TOBEndCoolFluid0"/>
+			<rMaterial name="trackermaterial:T_C6F14_F2_-30C"/>
+		</LogicalPart>
+		<LogicalPart name="TOBOptFibre0" category="unspecified">
+			<rSolid name="TOBOptFibre0"/>
+			<rMaterial name="tobmaterial:TOB_optfib_L12"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPlate01" category="unspecified">
+			<rSolid name="TOBPlate01"/>
+			<rMaterial name="tobmaterial:TOB_plate_B"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPlate02" category="unspecified">
+			<rSolid name="TOBPlate02"/>
+			<rMaterial name="tobmaterial:TOB_plate_C"/>
+		</LogicalPart>
+		<LogicalPart name="TOBICC01" category="unspecified">
+			<rSolid name="tobrodpar:TOBICC1"/>
+			<rMaterial name="tobmaterial:TOB_L12_ICC1"/>
+		</LogicalPart>
+		<LogicalPart name="TOBICC02" category="unspecified">
+			<rSolid name="tobrodpar:TOBICC2"/>
+			<rMaterial name="tobmaterial:TOB_L12_ICC2"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodConn0" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodConn"/>
+			<rMaterial name="tobmaterial:TOB_CONN12"/>
+		</LogicalPart>
+		<LogicalPart name="TOBCCUM0" category="unspecified">
+			<rSolid name="tobrodpar:TOBCCUM"/>
+			<rMaterial name="tobmaterial:TOB_CCUM"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod0c.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod0c:TOBSideCoolTube0"/>
+			<rChild name="tobrod0c:TOBSideCoolFluid0"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobrod0c:TOBEndCoolTube0"/>
+			<rChild name="tobrod0c:TOBEndCoolFluid0"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod0h.xml
+++ b/DetectorDescription/DDCMS/data/tobrod0h.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod0h.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod0h.xml">
+		<LogicalPart name="TOBRod0H" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodH"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodCentral0H" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodCentralH"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod0h.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod0h:TOBRod0H"/>
+			<rChild name="tobrod0h:TOBRodCentral0H"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTOBRodAlgo">
+		<rParent name="tobrod0h:TOBRod0H"/>
+		<Numeric name="Shift" value="-([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		<String name="CentralName" value="tobrod0h:TOBRodCentral0H"/>
+		<Vector name="SideRodName" type="string" nEntries="2">
+			tobrodpar:TOBSideRod1, tobrodpar:TOBSideRod2
+		</Vector>
+		<Vector name="SideRodX" type="numeric" nEntries="2">
+			-[tobrodpar:SideRodX],  [tobrodpar:SideRodX]
+		</Vector>
+		<Vector name="SideRodY" type="numeric" nEntries="2">
+			[tobrodpar:RodY],     -[tobrodpar:RodY]
+		</Vector>
+		<Vector name="SideRodZ" type="numeric" nEntries="2">
+			[zero],                [tobrodpar:RodDL]
+		</Vector>
+		<String name="EndRod1Name" value="tobrodpar:TOBEndRod1"/>
+		<Vector name="EndRod1Y" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="EndRod1Z" type="numeric" nEntries="2">
+			[tobrodpar:EndRod1Z],  [tobrodpar:EndRod1Z]
+		</Vector>
+		<String name="EndRod2Name" value="tobrodpar:TOBEndRod2"/>
+		<Numeric name="EndRod2Y" value="-[tobrodpar:EndRod2Y]"/>
+		<Numeric name="EndRod2Z" value="[tobrodpar:EndRod2Z]"/>
+		<String name="CableName" value="tobrodpar:TOBCable"/>
+		<Numeric name="CableZ" value="[tobrodpar:CableZ]"/>
+		<String name="ClampName" value="tobrodpar:TOBClamp"/>
+		<Vector name="ClampX" type="numeric" nEntries="4">
+			-[tobrodpar:ClampX],  -[tobrodpar:ClampX],   [tobrodpar:ClampX],
+			[tobrodpar:ClampX]
+		</Vector>
+		<Vector name="ClampZ" type="numeric" nEntries="4">
+			[tobrodpar:ClampZ2],  [tobrodpar:ClampZ1],  [tobrodpar:ClampZ2],
+			[tobrodpar:ClampZ1]
+		</Vector>
+		<String name="SideCoolName" value="tobrod0c:TOBSideCoolTube0"/>
+		<Vector name="SideCoolX" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolX],  [tobrodpar:SideCoolX]
+		</Vector>
+		<Vector name="SideCoolY" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolY],  -[tobrodpar:SideCoolY]
+		</Vector>
+		<Vector name="SideCoolZ" type="numeric" nEntries="2">
+			[tobrodpar:SideCoolZ],  [tobrodpar:SideCoolZ]
+		</Vector>
+		<String name="EndCoolName" value="tobrod0c:TOBEndCoolTube0"/>
+		<String name="EndCoolRot" value="tobrodpar:90XD"/>
+		<Numeric name="EndCoolY" value="-[tobrodpar:EndCoolY]"/>
+		<Numeric name="EndCoolZ" value="[tobrodpar:EndCoolZ]"/>
+		<String name="OptFibreName" value="tobrod0c:TOBOptFibre0"/>
+		<Vector name="optFibreX" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreX],  [tobrodpar:OptFibreX]
+		</Vector>
+		<Vector name="optFibreZ" type="numeric" nEntries="2">
+			[tobrodpar:OptFibreZ],  [tobrodpar:OptFibreZ]
+		</Vector>
+		<String name="SideClamp1Name" value="tobrod0c:TOBPlate01"/>
+		<Vector name="SideClampX" type="numeric" nEntries="12">
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX],
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX]
+		</Vector>
+		<Vector name="SideClamp1DZ" type="numeric" nEntries="12">
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z]
+		</Vector>
+		<String name="SideClamp2Name" value="tobrod0c:TOBPlate02"/>
+		<Vector name="SideClamp2DZ" type="numeric" nEntries="12">
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z]
+		</Vector>
+		<String name="ModuleName" value="tobmodule0:TOBModule0"/>
+		<Vector name="ModuleRot" type="string" nEntries="6">
+			tobrodpar:NULL, tobrodpar:NULL, tobrodpar:NULL,
+			tobrodpar:NULL, tobrodpar:180D, tobrodpar:180D</Vector>
+		<Vector name="ModuleY" type="numeric" nEntries="6">
+			[tobrodpar:ModuleY], -[tobrodpar:ModuleY],  [tobrodpar:ModuleY],
+			-[tobrodpar:ModuleY],  [tobrodpar:ModuleY], -[tobrodpar:ModuleY]
+		</Vector>
+		<Vector name="ModuleZ" type="numeric" nEntries="6">
+			[tobrodpar:ModuleZ07], [tobrodpar:ModuleZ08], [tobrodpar:ModuleZ09],
+			[tobrodpar:ModuleZ10], [tobrodpar:ModuleZ11], [tobrodpar:ModuleZ12]
+		</Vector>
+		<Vector name="ICCName" type="string" nEntries="6">
+			tobrod0c:TOBICC01, tobrod0c:TOBICC01, tobrod0c:TOBICC02, 
+			tobrod0c:TOBICC02, tobrod0c:TOBCCUM0, tobrod0c:TOBRodConn0
+		</Vector>
+		<Vector name="ICCY" type="numeric" nEntries="6">
+			[tobrodpar:ICCY1], -[tobrodpar:ICCY1],  [tobrodpar:ICCY1],
+			-[tobrodpar:ICCY1],  [tobrodpar:ICCY2],  [tobrodpar:ICCY1]
+		</Vector>
+		<Vector name="ICCZ" type="numeric" nEntries="6">
+			[tobrodpar:ICCZ07], [tobrodpar:ICCZ08], [tobrodpar:ICCZ09],
+			[tobrodpar:ICCZ10], [tobrodpar:ICCZ11], [tobrodpar:ICCZ12]
+		</Vector>
+		<String name="AOHName" value="tobrodpar:TOBAOH"/>
+		<Vector name="AOHCopies" type="numeric" nEntries="6">
+			2 , 2 , 4 , 4 , 0 , 0
+		</Vector>
+		<Vector name="AOHx" type="numeric" nEntries="6">
+			-[tobrodpar:AOHx] , [tobrodpar:AOHx] ,
+			[tobrodpar:AOHx]  , [tobrodpar:AOHx] ,
+			[zero] , [zero]
+		</Vector>
+		<Vector name="AOHy" type="numeric" nEntries="6">
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[zero] , [zero]
+		</Vector>
+		<Vector name="AOHz" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHz] , -[tobrodpar:AOHz] ,
+			[zero] , [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod0l.xml
+++ b/DetectorDescription/DDCMS/data/tobrod0l.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod0l.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod0l.xml">
+		<LogicalPart name="TOBRod0L" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodL"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodCentral0L" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodCentralL"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod0l.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod0l:TOBRod0L"/>
+			<rChild name="tobrod0l:TOBRodCentral0L"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTOBRodAlgo">
+		<rParent name="tobrod0l:TOBRod0L"/>
+		<Numeric name="Shift" value="([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		<String name="CentralName" value="tobrod0l:TOBRodCentral0L"/>
+		<Vector name="SideRodName" type="string" nEntries="2">
+			tobrodpar:TOBSideRod1, tobrodpar:TOBSideRod2
+		</Vector>
+		<Vector name="SideRodX" type="numeric" nEntries="2">
+			-[tobrodpar:SideRodX],  [tobrodpar:SideRodX]
+		</Vector>
+		<Vector name="SideRodY" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="SideRodZ" type="numeric" nEntries="2">
+			[zero],               -[tobrodpar:RodDL]
+		</Vector>
+		<String name="EndRod1Name" value="tobrodpar:TOBEndRod1"/>
+		<Vector name="EndRod1Y" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="EndRod1Z" type="numeric" nEntries="2">
+			-[tobrodpar:EndRod1Z], -[tobrodpar:EndRod1Z]
+		</Vector>
+		<String name="EndRod2Name" value="tobrodpar:TOBEndRod2"/>
+		<Numeric name="EndRod2Y" value="[tobrodpar:EndRod2Y]"/>
+		<Numeric name="EndRod2Z" value="-[tobrodpar:EndRod2Z]"/>
+		<String name="CableName" value="tobrodpar:TOBCable"/>
+		<Numeric name="CableZ" value="-[tobrodpar:CableZ]"/>
+		<String name="ClampName" value="tobrodpar:TOBClamp"/>
+		<Vector name="ClampX" type="numeric" nEntries="4">
+			-[tobrodpar:ClampX],  -[tobrodpar:ClampX],   [tobrodpar:ClampX],
+			[tobrodpar:ClampX]
+		</Vector>
+		<Vector name="ClampZ" type="numeric" nEntries="4">
+			-[tobrodpar:ClampZ1], -[tobrodpar:ClampZ2], -[tobrodpar:ClampZ1],
+			-[tobrodpar:ClampZ2]
+		</Vector>
+		<String name="SideCoolName" value="tobrod0c:TOBSideCoolTube0"/>
+		<Vector name="SideCoolX" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolX],  [tobrodpar:SideCoolX]
+		</Vector>
+		<Vector name="SideCoolY" type="numeric" nEntries="2">
+			[tobrodpar:SideCoolY],  [tobrodpar:SideCoolY]
+		</Vector>
+		<Vector name="SideCoolZ" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolZ], -[tobrodpar:SideCoolZ]
+		</Vector>
+		<String name="EndCoolName" value="tobrod0c:TOBEndCoolTube0"/>
+		<String name="EndCoolRot" value="tobrodpar:90XD"/>
+		<Numeric name="EndCoolY" value="[tobrodpar:EndCoolY]"/>
+		<Numeric name="EndCoolZ" value="-[tobrodpar:EndCoolZ]"/>
+		<String name="OptFibreName" value="tobrod0c:TOBOptFibre0"/>
+		<Vector name="optFibreX" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreX],  [tobrodpar:OptFibreX]
+		</Vector>
+		<Vector name="optFibreZ" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreZ], -[tobrodpar:OptFibreZ]
+		</Vector>
+		<String name="SideClamp1Name" value="tobrod0c:TOBPlate01"/>
+		<Vector name="SideClampX" type="numeric" nEntries="12">
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX],
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX]
+		</Vector>
+		<Vector name="SideClamp1DZ" type="numeric" nEntries="12">
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z]
+		</Vector>
+		<String name="SideClamp2Name" value="tobrod0c:TOBPlate02"/>
+		<Vector name="SideClamp2DZ" type="numeric" nEntries="12">
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z]
+		</Vector>
+		<String name="ModuleName" value="tobmodule0:TOBModule0"/>
+		<Vector name="ModuleRot" type="string" nEntries="6">
+			tobrodpar:NULL, tobrodpar:NULL, tobrodpar:180D, 
+			tobrodpar:180D, tobrodpar:180D, tobrodpar:180D</Vector>
+		<Vector name="ModuleY" type="numeric" nEntries="6">
+			[tobrodpar:ModuleY], -[tobrodpar:ModuleY],  [tobrodpar:ModuleY],
+			-[tobrodpar:ModuleY],  [tobrodpar:ModuleY], -[tobrodpar:ModuleY]
+		</Vector>
+		<Vector name="ModuleZ" type="numeric" nEntries="6">
+			[tobrodpar:ModuleZ01], [tobrodpar:ModuleZ02], [tobrodpar:ModuleZ03],
+			[tobrodpar:ModuleZ04], [tobrodpar:ModuleZ05], [tobrodpar:ModuleZ06]
+		</Vector>
+		<Vector name="ICCName" type="string" nEntries="6">
+			tobrod0c:TOBRodConn0, tobrod0c:TOBCCUM0, tobrod0c:TOBICC02, 
+			tobrod0c:TOBICC02, tobrod0c:TOBICC01, tobrod0c:TOBICC01
+		</Vector>
+		<Vector name="ICCY" type="numeric" nEntries="6">
+			-[tobrodpar:ICCY1], -[tobrodpar:ICCY2],  [tobrodpar:ICCY1],
+			-[tobrodpar:ICCY1],  [tobrodpar:ICCY1], -[tobrodpar:ICCY1]
+		</Vector>
+		<Vector name="ICCZ" type="numeric" nEntries="6">
+			[tobrodpar:ICCZ01], [tobrodpar:ICCZ02], [tobrodpar:ICCZ03],
+			[tobrodpar:ICCZ04], [tobrodpar:ICCZ05], [tobrodpar:ICCZ06]
+		</Vector>
+		<String name="AOHName" value="tobrodpar:TOBAOH"/>
+		<Vector name="AOHCopies" type="numeric" nEntries="6">
+			0 , 0 , 4 , 4 , 2 , 2
+		</Vector>
+		<Vector name="AOHx" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHx] , [tobrodpar:AOHx] ,
+			[tobrodpar:AOHx] , -[tobrodpar:AOHx]
+		</Vector>
+		<Vector name="AOHy" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy]
+		</Vector>
+		<Vector name="AOHz" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHz] , -[tobrodpar:AOHz] ,
+			[zero] , [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod1.xml
+++ b/DetectorDescription/DDCMS/data/tobrod1.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod1.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod1.xml">
+		<LogicalPart name="TOBRod1" category="unspecified">
+			<rSolid name="tobrodpar:TOBRod"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod1.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod1:TOBRod1"/>
+			<rChild name="tobrod1l:TOBRod1L"/>
+			<rRotation name="tobrodpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobrod1:TOBRod1"/>
+			<rChild name="tobrod1h:TOBRod1H"/>
+			<rRotation name="tobrodpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="-([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod1h.xml
+++ b/DetectorDescription/DDCMS/data/tobrod1h.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod1h.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod1h.xml">
+		<LogicalPart name="TOBRod1H" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodH"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodCentral1H" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodCentralH"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod1h.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod1h:TOBRod1H"/>
+			<rChild name="tobrod1h:TOBRodCentral1H"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTOBRodAlgo">
+		<rParent name="tobrod1h:TOBRod1H"/>
+		<Numeric name="Shift" value="-([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		<String name="CentralName" value="tobrod1h:TOBRodCentral1H"/>
+		<Vector name="SideRodName" type="string" nEntries="2">
+			tobrodpar:TOBSideRod1, tobrodpar:TOBSideRod2
+		</Vector>
+		<Vector name="SideRodX" type="numeric" nEntries="2">
+			-[tobrodpar:SideRodX],  [tobrodpar:SideRodX]
+		</Vector>
+		<Vector name="SideRodY" type="numeric" nEntries="2">
+			[tobrodpar:RodY],     -[tobrodpar:RodY]
+		</Vector>
+		<Vector name="SideRodZ" type="numeric" nEntries="2">
+			[zero],                [tobrodpar:RodDL]
+		</Vector>
+		<String name="EndRod1Name" value="tobrodpar:TOBEndRod1"/>
+		<Vector name="EndRod1Y" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="EndRod1Z" type="numeric" nEntries="2">
+			[tobrodpar:EndRod1Z],  [tobrodpar:EndRod1Z]
+		</Vector>
+		<String name="EndRod2Name" value="tobrodpar:TOBEndRod2"/>
+		<Numeric name="EndRod2Y" value="-[tobrodpar:EndRod2Y]"/>
+		<Numeric name="EndRod2Z" value="[tobrodpar:EndRod2Z]"/>
+		<String name="CableName" value="tobrodpar:TOBCable"/>
+		<Numeric name="CableZ" value="[tobrodpar:CableZ]"/>
+		<String name="ClampName" value="tobrodpar:TOBClamp"/>
+		<Vector name="ClampX" type="numeric" nEntries="4">
+			-[tobrodpar:ClampX],  -[tobrodpar:ClampX],   [tobrodpar:ClampX],
+			[tobrodpar:ClampX]
+		</Vector>
+		<Vector name="ClampZ" type="numeric" nEntries="4">
+			[tobrodpar:ClampZ2],  [tobrodpar:ClampZ1],  [tobrodpar:ClampZ2],
+			[tobrodpar:ClampZ1]
+		</Vector>
+		<String name="SideCoolName" value="tobrod0c:TOBSideCoolTube0"/>
+		<Vector name="SideCoolX" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolX],  [tobrodpar:SideCoolX]
+		</Vector>
+		<Vector name="SideCoolY" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolY],  -[tobrodpar:SideCoolY]
+		</Vector>
+		<Vector name="SideCoolZ" type="numeric" nEntries="2">
+			[tobrodpar:SideCoolZ],  [tobrodpar:SideCoolZ]
+		</Vector>
+		<String name="EndCoolName" value="tobrod0c:TOBEndCoolTube0"/>
+		<String name="EndCoolRot" value="tobrodpar:90XD"/>
+		<Numeric name="EndCoolY" value="-[tobrodpar:EndCoolY]"/>
+		<Numeric name="EndCoolZ" value="[tobrodpar:EndCoolZ]"/>
+		<String name="OptFibreName" value="tobrod0c:TOBOptFibre0"/>
+		<Vector name="optFibreX" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreX],  [tobrodpar:OptFibreX]
+		</Vector>
+		<Vector name="optFibreZ" type="numeric" nEntries="2">
+			[tobrodpar:OptFibreZ],  [tobrodpar:OptFibreZ]
+		</Vector>
+		<String name="SideClamp1Name" value="tobrod0c:TOBPlate01"/>
+		<Vector name="SideClampX" type="numeric" nEntries="12">
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX],
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX]
+		</Vector>
+		<Vector name="SideClamp1DZ" type="numeric" nEntries="12">
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z]
+		</Vector>
+		<String name="SideClamp2Name" value="tobrod0c:TOBPlate02"/>
+		<Vector name="SideClamp2DZ" type="numeric" nEntries="12">
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z]
+		</Vector>
+		<String name="ModuleName" value="tobmodule0:TOBModule0"/>
+		<Vector name="ModuleRot" type="string" nEntries="6">
+			tobrodpar:R180, tobrodpar:R180, tobrodpar:R180,
+			tobrodpar:R180, tobrodpar:180X, tobrodpar:180X</Vector>
+		<Vector name="ModuleY" type="numeric" nEntries="6">
+			[tobrodpar:ModuleY], -[tobrodpar:ModuleY],  [tobrodpar:ModuleY],
+			-[tobrodpar:ModuleY],  [tobrodpar:ModuleY], -[tobrodpar:ModuleY]
+		</Vector>
+		<Vector name="ModuleZ" type="numeric" nEntries="6">
+			[tobrodpar:ModuleZ07], [tobrodpar:ModuleZ08], [tobrodpar:ModuleZ09],
+			[tobrodpar:ModuleZ10], [tobrodpar:ModuleZ11], [tobrodpar:ModuleZ12]
+		</Vector>
+		<Vector name="ICCName" type="string" nEntries="6">
+			tobrod0c:TOBICC01, tobrod0c:TOBICC01, tobrod0c:TOBICC02, 
+			tobrod0c:TOBICC02, tobrod0c:TOBCCUM0, tobrod0c:TOBRodConn0
+		</Vector>
+		<Vector name="ICCY" type="numeric" nEntries="6">
+			[tobrodpar:ICCY1], -[tobrodpar:ICCY1],  [tobrodpar:ICCY1],
+			-[tobrodpar:ICCY1],  [tobrodpar:ICCY2],  [tobrodpar:ICCY1]
+		</Vector>
+		<Vector name="ICCZ" type="numeric" nEntries="6">
+			[tobrodpar:ICCZ07], [tobrodpar:ICCZ08], [tobrodpar:ICCZ09],
+			[tobrodpar:ICCZ10], [tobrodpar:ICCZ11], [tobrodpar:ICCZ12]
+		</Vector>
+		<String name="AOHName" value="tobrodpar:TOBAOH"/>
+		<Vector name="AOHCopies" type="numeric" nEntries="6">
+			2 , 2 , 4 , 4 , 0 , 0
+		</Vector>
+		<Vector name="AOHx" type="numeric" nEntries="6">
+			-[tobrodpar:AOHx] , [tobrodpar:AOHx] ,
+			[tobrodpar:AOHx]  , [tobrodpar:AOHx] ,
+			[zero] , [zero]
+		</Vector>
+		<Vector name="AOHy" type="numeric" nEntries="6">
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[zero] , [zero]
+		</Vector>
+		<Vector name="AOHz" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHz] , -[tobrodpar:AOHz] ,
+			[zero] , [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod1l.xml
+++ b/DetectorDescription/DDCMS/data/tobrod1l.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod1l.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod1l.xml">
+		<LogicalPart name="TOBRod1L" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodL"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodCentral1L" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodCentralL"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod1l.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod1l:TOBRod1L"/>
+			<rChild name="tobrod1l:TOBRodCentral1L"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTOBRodAlgo">
+		<rParent name="tobrod1l:TOBRod1L"/>
+		<Numeric name="Shift" value="([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		<String name="CentralName" value="tobrod1l:TOBRodCentral1L"/>
+		<Vector name="SideRodName" type="string" nEntries="2">
+			tobrodpar:TOBSideRod1, tobrodpar:TOBSideRod2
+		</Vector>
+		<Vector name="SideRodX" type="numeric" nEntries="2">
+			-[tobrodpar:SideRodX],  [tobrodpar:SideRodX]
+		</Vector>
+		<Vector name="SideRodY" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="SideRodZ" type="numeric" nEntries="2">
+			[zero],               -[tobrodpar:RodDL]
+		</Vector>
+		<String name="EndRod1Name" value="tobrodpar:TOBEndRod1"/>
+		<Vector name="EndRod1Y" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="EndRod1Z" type="numeric" nEntries="2">
+			-[tobrodpar:EndRod1Z], -[tobrodpar:EndRod1Z]
+		</Vector>
+		<String name="EndRod2Name" value="tobrodpar:TOBEndRod2"/>
+		<Numeric name="EndRod2Y" value="[tobrodpar:EndRod2Y]"/>
+		<Numeric name="EndRod2Z" value="-[tobrodpar:EndRod2Z]"/>
+		<String name="CableName" value="tobrodpar:TOBCable"/>
+		<Numeric name="CableZ" value="-[tobrodpar:CableZ]"/>
+		<String name="ClampName" value="tobrodpar:TOBClamp"/>
+		<Vector name="ClampX" type="numeric" nEntries="4">
+			-[tobrodpar:ClampX],  -[tobrodpar:ClampX],   [tobrodpar:ClampX],
+			[tobrodpar:ClampX]
+		</Vector>
+		<Vector name="ClampZ" type="numeric" nEntries="4">
+			-[tobrodpar:ClampZ1], -[tobrodpar:ClampZ2], -[tobrodpar:ClampZ1],
+			-[tobrodpar:ClampZ2]
+		</Vector>
+		<String name="SideCoolName" value="tobrod0c:TOBSideCoolTube0"/>
+		<Vector name="SideCoolX" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolX],  [tobrodpar:SideCoolX]
+		</Vector>
+		<Vector name="SideCoolY" type="numeric" nEntries="2">
+			[tobrodpar:SideCoolY],  [tobrodpar:SideCoolY]
+		</Vector>
+		<Vector name="SideCoolZ" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolZ], -[tobrodpar:SideCoolZ]
+		</Vector>
+		<String name="EndCoolName" value="tobrod0c:TOBEndCoolTube0"/>
+		<String name="EndCoolRot" value="tobrodpar:90XD"/>
+		<Numeric name="EndCoolY" value="[tobrodpar:EndCoolY]"/>
+		<Numeric name="EndCoolZ" value="-[tobrodpar:EndCoolZ]"/>
+		<String name="OptFibreName" value="tobrod0c:TOBOptFibre0"/>
+		<Vector name="optFibreX" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreX],  [tobrodpar:OptFibreX]
+		</Vector>
+		<Vector name="optFibreZ" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreZ], -[tobrodpar:OptFibreZ]
+		</Vector>
+		<String name="SideClamp1Name" value="tobrod0c:TOBPlate01"/>
+		<Vector name="SideClampX" type="numeric" nEntries="12">
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX],
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX]
+		</Vector>
+		<Vector name="SideClamp1DZ" type="numeric" nEntries="12">
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z]
+		</Vector>
+		<String name="SideClamp2Name" value="tobrod0c:TOBPlate02"/>
+		<Vector name="SideClamp2DZ" type="numeric" nEntries="12">
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z]
+		</Vector>
+		<String name="ModuleName" value="tobmodule0:TOBModule0"/>
+		<Vector name="ModuleRot" type="string" nEntries="6">
+			tobrodpar:R180, tobrodpar:R180, tobrodpar:180X, 
+			tobrodpar:180X, tobrodpar:180X, tobrodpar:180X</Vector>
+		<Vector name="ModuleY" type="numeric" nEntries="6">
+			[tobrodpar:ModuleY], -[tobrodpar:ModuleY],  [tobrodpar:ModuleY],
+			-[tobrodpar:ModuleY],  [tobrodpar:ModuleY], -[tobrodpar:ModuleY]
+		</Vector>
+		<Vector name="ModuleZ" type="numeric" nEntries="6">
+			[tobrodpar:ModuleZ01], [tobrodpar:ModuleZ02], [tobrodpar:ModuleZ03],
+			[tobrodpar:ModuleZ04], [tobrodpar:ModuleZ05], [tobrodpar:ModuleZ06]
+		</Vector>
+		<Vector name="ICCName" type="string" nEntries="6">
+			tobrod0c:TOBRodConn0, tobrod0c:TOBCCUM0, tobrod0c:TOBICC02, 
+			tobrod0c:TOBICC02, tobrod0c:TOBICC01, tobrod0c:TOBICC01
+		</Vector>
+		<Vector name="ICCY" type="numeric" nEntries="6">
+			-[tobrodpar:ICCY1], -[tobrodpar:ICCY2],  [tobrodpar:ICCY1],
+			-[tobrodpar:ICCY1],  [tobrodpar:ICCY1], -[tobrodpar:ICCY1]
+		</Vector>
+		<Vector name="ICCZ" type="numeric" nEntries="6">
+			[tobrodpar:ICCZ01], [tobrodpar:ICCZ02], [tobrodpar:ICCZ03],
+			[tobrodpar:ICCZ04], [tobrodpar:ICCZ05], [tobrodpar:ICCZ06]
+		</Vector>
+		<String name="AOHName" value="tobrodpar:TOBAOH"/>
+		<Vector name="AOHCopies" type="numeric" nEntries="6">
+			0 , 0 , 4 , 4 , 2 , 2
+		</Vector>
+		<Vector name="AOHx" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHx] , [tobrodpar:AOHx] ,
+			[tobrodpar:AOHx] , -[tobrodpar:AOHx]
+		</Vector>
+		<Vector name="AOHy" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy]
+		</Vector>
+		<Vector name="AOHz" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHz] , -[tobrodpar:AOHz] ,
+			[zero] , [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod2.xml
+++ b/DetectorDescription/DDCMS/data/tobrod2.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod2.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod2.xml">
+		<LogicalPart name="TOBRod2" category="unspecified">
+			<rSolid name="tobrodpar:TOBRod"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod2.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod2:TOBRod2"/>
+			<rChild name="tobrod2l:TOBRod2L"/>
+			<rRotation name="tobrodpar:R180"/>
+			<Translation x="[zero]" y="[zero]" z="-([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobrod2:TOBRod2"/>
+			<rChild name="tobrod2h:TOBRod2H"/>
+			<rRotation name="tobrodpar:R180"/>
+			<Translation x="[zero]" y="[zero]" z="([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod2c.xml
+++ b/DetectorDescription/DDCMS/data/tobrod2c.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod2c.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<SolidSection label="tobrod2c.xml">
+		<Tubs name="TOBSideCoolTube2" rMin="[zero]" rMax="[tobrodpar:CoolTubeLightR]" dz="[tobrodpar:SideCoolL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBSideCoolFluid2" rMin="[zero]" rMax="[tobrodpar:CoolFluidLightR]" dz="[tobrodpar:SideCoolL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBEndCoolTube2" rMin="[zero]" rMax="[tobrodpar:CoolTubeLightR]" dz="[tobrodpar:EndCoolL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBEndCoolFluid2" rMin="[zero]" rMax="[tobrodpar:CoolFluidLightR]" dz="[tobrodpar:EndCoolL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Box name="TOBOptFibre2" dx="[tobrodpar:OptFibreW]" dy="[tobrodpar:OptFibreH]" dz="[tobrodpar:OptFibreL]"/>
+		<Box name="TOBPlate21" dx="[tobrodpar:SideClampDx]" dy="[tobrodpar:SideClampDy]" dz="[tobrodpar:SideClampLDz]"/>
+		<Box name="TOBPlate22" dx="[tobrodpar:SideClampDx]" dy="[tobrodpar:SideClampDy]" dz="[tobrodpar:SideClampLDz]"/>
+	</SolidSection>
+	<LogicalPartSection label="tobrod2c.xml">
+		<LogicalPart name="TOBSideCoolTube2" category="unspecified">
+			<rSolid name="TOBSideCoolTube2"/>
+			<rMaterial name="trackermaterial:T_CuNi"/>
+		</LogicalPart>
+		<LogicalPart name="TOBSideCoolFluid2" category="unspecified">
+			<rSolid name="TOBSideCoolFluid2"/>
+			<rMaterial name="trackermaterial:T_C6F14_F2_-30C"/>
+		</LogicalPart>
+		<LogicalPart name="TOBEndCoolTube2" category="unspecified">
+			<rSolid name="TOBEndCoolTube2"/>
+			<rMaterial name="trackermaterial:T_CuNi"/>
+		</LogicalPart>
+		<LogicalPart name="TOBEndCoolFluid2" category="unspecified">
+			<rSolid name="TOBEndCoolFluid2"/>
+			<rMaterial name="trackermaterial:T_C6F14_F2_-30C"/>
+		</LogicalPart>
+		<LogicalPart name="TOBOptFibre2" category="unspecified">
+			<rSolid name="TOBOptFibre2"/>
+			<rMaterial name="tobmaterial:TOB_optfib_L34"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPlate21" category="unspecified">
+			<rSolid name="TOBPlate21"/>
+			<rMaterial name="tobmaterial:TOB_plate_B"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPlate22" category="unspecified">
+			<rSolid name="TOBPlate22"/>
+			<rMaterial name="tobmaterial:TOB_plate_C"/>
+		</LogicalPart>
+		<LogicalPart name="TOBICC21" category="unspecified">
+			<rSolid name="tobrodpar:TOBICC1"/>
+			<rMaterial name="tobmaterial:TOB_L34_ICC1"/>
+		</LogicalPart>
+		<LogicalPart name="TOBICC22" category="unspecified">
+			<rSolid name="tobrodpar:TOBICC2"/>
+			<rMaterial name="tobmaterial:TOB_L34_ICC2"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodConn2" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodConn"/>
+			<rMaterial name="tobmaterial:TOB_CONN34"/>
+		</LogicalPart>
+		<LogicalPart name="TOBCCUM2" category="unspecified">
+			<rSolid name="tobrodpar:TOBCCUM"/>
+			<rMaterial name="tobmaterial:TOB_CCUM"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod2c.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod2c:TOBSideCoolTube2"/>
+			<rChild name="tobrod2c:TOBSideCoolFluid2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobrod2c:TOBEndCoolTube2"/>
+			<rChild name="tobrod2c:TOBEndCoolFluid2"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod2h.xml
+++ b/DetectorDescription/DDCMS/data/tobrod2h.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod2h.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod2h.xml">
+		<LogicalPart name="TOBRod2H" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodH"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodCentral2H" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodCentralH"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod2h.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod2h:TOBRod2H"/>
+			<rChild name="tobrod2h:TOBRodCentral2H"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTOBRodAlgo">
+		<rParent name="tobrod2h:TOBRod2H"/>
+		<Numeric name="Shift" value="-([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		<String name="CentralName" value="tobrod2h:TOBRodCentral2H"/>
+		<Vector name="SideRodName" type="string" nEntries="2">
+			tobrodpar:TOBSideRod1, tobrodpar:TOBSideRod2
+		</Vector>
+		<Vector name="SideRodX" type="numeric" nEntries="2">
+			-[tobrodpar:SideRodX],  [tobrodpar:SideRodX]
+		</Vector>
+		<Vector name="SideRodY" type="numeric" nEntries="2">
+			[tobrodpar:RodY],     -[tobrodpar:RodY]
+		</Vector>
+		<Vector name="SideRodZ" type="numeric" nEntries="2">
+			[zero],                [tobrodpar:RodDL]
+		</Vector>
+		<String name="EndRod1Name" value="tobrodpar:TOBEndRod1"/>
+		<Vector name="EndRod1Y" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="EndRod1Z" type="numeric" nEntries="2">
+			[tobrodpar:EndRod1Z],  [tobrodpar:EndRod1Z]
+		</Vector>
+		<String name="EndRod2Name" value="tobrodpar:TOBEndRod2"/>
+		<Numeric name="EndRod2Y" value="-[tobrodpar:EndRod2Y]"/>
+		<Numeric name="EndRod2Z" value="[tobrodpar:EndRod2Z]"/>
+		<String name="CableName" value="tobrodpar:TOBCable"/>
+		<Numeric name="CableZ" value="[tobrodpar:CableZ]"/>
+		<String name="ClampName" value="tobrodpar:TOBClamp"/>
+		<Vector name="ClampX" type="numeric" nEntries="4">
+			-[tobrodpar:ClampX],  -[tobrodpar:ClampX],   [tobrodpar:ClampX],
+			[tobrodpar:ClampX]
+		</Vector>
+		<Vector name="ClampZ" type="numeric" nEntries="4">
+			[tobrodpar:ClampZ2],  [tobrodpar:ClampZ1],  [tobrodpar:ClampZ2],
+			[tobrodpar:ClampZ1]
+		</Vector>
+		<String name="SideCoolName" value="tobrod2c:TOBSideCoolTube2"/>
+		<Vector name="SideCoolX" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolX],  [tobrodpar:SideCoolX]
+		</Vector>
+		<Vector name="SideCoolY" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolY],  -[tobrodpar:SideCoolY]
+		</Vector>
+		<Vector name="SideCoolZ" type="numeric" nEntries="2">
+			[tobrodpar:SideCoolZ],  [tobrodpar:SideCoolZ]
+		</Vector>
+		<String name="EndCoolName" value="tobrod2c:TOBEndCoolTube2"/>
+		<String name="EndCoolRot" value="tobrodpar:90XD"/>
+		<Numeric name="EndCoolY" value="-[tobrodpar:EndCoolY]"/>
+		<Numeric name="EndCoolZ" value="[tobrodpar:EndCoolZ]"/>
+		<String name="OptFibreName" value="tobrod2c:TOBOptFibre2"/>
+		<Vector name="optFibreX" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreX],  [tobrodpar:OptFibreX]
+		</Vector>
+		<Vector name="optFibreZ" type="numeric" nEntries="2">
+			[tobrodpar:OptFibreZ],  [tobrodpar:OptFibreZ]
+		</Vector>
+		<String name="SideClamp1Name" value="tobrod2c:TOBPlate21"/>
+		<Vector name="SideClampX" type="numeric" nEntries="12">
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX],
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX]
+		</Vector>
+		<Vector name="SideClamp1DZ" type="numeric" nEntries="12">
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z]
+		</Vector>
+		<String name="SideClamp2Name" value="tobrod2c:TOBPlate22"/>
+		<Vector name="SideClamp2DZ" type="numeric" nEntries="12">
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z]
+		</Vector>
+		<String name="ModuleName" value="tobmodule2:TOBModule2"/>
+		<Vector name="ModuleRot" type="string" nEntries="6">
+			tobrodpar:NULL, tobrodpar:R180, tobrodpar:NULL, 
+			tobrodpar:R180, tobrodpar:180D, tobrodpar:180X</Vector>
+		<Vector name="ModuleY" type="numeric" nEntries="6">
+			[tobrodpar:ModuleY], -[tobrodpar:ModuleY],  [tobrodpar:ModuleY],
+			-[tobrodpar:ModuleY],  [tobrodpar:ModuleY], -[tobrodpar:ModuleY]
+		</Vector>
+		<Vector name="ModuleZ" type="numeric" nEntries="6">
+			[tobrodpar:ModuleZ07], [tobrodpar:ModuleZ08], [tobrodpar:ModuleZ09],
+			[tobrodpar:ModuleZ10], [tobrodpar:ModuleZ11], [tobrodpar:ModuleZ12]
+		</Vector>
+		<Vector name="ICCName" type="string" nEntries="6">
+			tobrod2c:TOBICC21, tobrod2c:TOBICC21, tobrod2c:TOBICC22, 
+			tobrod2c:TOBICC22, tobrod2c:TOBCCUM2, tobrod2c:TOBRodConn2
+		</Vector>
+		<Vector name="ICCY" type="numeric" nEntries="6">
+			[tobrodpar:ICCY1], -[tobrodpar:ICCY1],  [tobrodpar:ICCY1],
+			-[tobrodpar:ICCY1],  [tobrodpar:ICCY2],  [tobrodpar:ICCY1]
+		</Vector>
+		<Vector name="ICCZ" type="numeric" nEntries="6">
+			[tobrodpar:ICCZ07], [tobrodpar:ICCZ08], [tobrodpar:ICCZ09],
+			[tobrodpar:ICCZ10], [tobrodpar:ICCZ11], [tobrodpar:ICCZ12]
+		</Vector>
+		<String name="AOHName" value="tobrodpar:TOBAOH"/>
+		<Vector name="AOHCopies" type="numeric" nEntries="6">
+			1 , 1 , 2 , 2 , 0 , 0
+		</Vector>
+		<Vector name="AOHx" type="numeric" nEntries="6">
+			-[tobrodpar:AOHx] , [tobrodpar:AOHx] ,
+			[tobrodpar:AOHx]  , [tobrodpar:AOHx] ,
+			[zero] , [zero]
+		</Vector>
+		<Vector name="AOHy" type="numeric" nEntries="6">
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[zero] , [zero]
+		</Vector>
+		<Vector name="AOHz" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHz] , -[tobrodpar:AOHz] ,
+			[zero] , [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod2l.xml
+++ b/DetectorDescription/DDCMS/data/tobrod2l.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod2l.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod2l.xml">
+		<LogicalPart name="TOBRod2L" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodL"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodCentral2L" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodCentralL"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod2l.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod2l:TOBRod2L"/>
+			<rChild name="tobrod2l:TOBRodCentral2L"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTOBRodAlgo">
+		<rParent name="tobrod2l:TOBRod2L"/>
+		<Numeric name="Shift" value="([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		<String name="CentralName" value="tobrod2l:TOBRodCentral2L"/>
+		<Vector name="SideRodName" type="string" nEntries="2">
+			tobrodpar:TOBSideRod1, tobrodpar:TOBSideRod2
+		</Vector>
+		<Vector name="SideRodX" type="numeric" nEntries="2">
+			-[tobrodpar:SideRodX],  [tobrodpar:SideRodX]
+		</Vector>
+		<Vector name="SideRodY" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="SideRodZ" type="numeric" nEntries="2">
+			[zero],               -[tobrodpar:RodDL]
+		</Vector>
+		<String name="EndRod1Name" value="tobrodpar:TOBEndRod1"/>
+		<Vector name="EndRod1Y" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="EndRod1Z" type="numeric" nEntries="2">
+			-[tobrodpar:EndRod1Z], -[tobrodpar:EndRod1Z]
+		</Vector>
+		<String name="EndRod2Name" value="tobrodpar:TOBEndRod2"/>
+		<Numeric name="EndRod2Y" value="[tobrodpar:EndRod2Y]"/>
+		<Numeric name="EndRod2Z" value="-[tobrodpar:EndRod2Z]"/>
+		<String name="CableName" value="tobrodpar:TOBCable"/>
+		<Numeric name="CableZ" value="-[tobrodpar:CableZ]"/>
+		<String name="ClampName" value="tobrodpar:TOBClamp"/>
+		<Vector name="ClampX" type="numeric" nEntries="4">
+			-[tobrodpar:ClampX],  -[tobrodpar:ClampX],   [tobrodpar:ClampX],
+			[tobrodpar:ClampX]
+		</Vector>
+		<Vector name="ClampZ" type="numeric" nEntries="4">
+			-[tobrodpar:ClampZ1], -[tobrodpar:ClampZ2], -[tobrodpar:ClampZ1],
+			-[tobrodpar:ClampZ2]
+		</Vector>
+		<String name="SideCoolName" value="tobrod2c:TOBSideCoolTube2"/>
+		<Vector name="SideCoolX" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolX],  [tobrodpar:SideCoolX]
+		</Vector>
+		<Vector name="SideCoolY" type="numeric" nEntries="2">
+			[tobrodpar:SideCoolY],  [tobrodpar:SideCoolY]
+		</Vector>
+		<Vector name="SideCoolZ" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolZ], -[tobrodpar:SideCoolZ]
+		</Vector>
+		<String name="EndCoolName" value="tobrod2c:TOBEndCoolTube2"/>
+		<String name="EndCoolRot" value="tobrodpar:90XD"/>
+		<Numeric name="EndCoolY" value="[tobrodpar:EndCoolY]"/>
+		<Numeric name="EndCoolZ" value="-[tobrodpar:EndCoolZ]"/>
+		<String name="OptFibreName" value="tobrod2c:TOBOptFibre2"/>
+		<Vector name="optFibreX" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreX],  [tobrodpar:OptFibreX]
+		</Vector>
+		<Vector name="optFibreZ" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreZ], -[tobrodpar:OptFibreZ]
+		</Vector>
+		<String name="SideClamp1Name" value="tobrod2c:TOBPlate21"/>
+		<Vector name="SideClampX" type="numeric" nEntries="12">
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX],
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX]
+		</Vector>
+		<Vector name="SideClamp1DZ" type="numeric" nEntries="12">
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z]
+		</Vector>
+		<String name="SideClamp2Name" value="tobrod2c:TOBPlate22"/>
+		<Vector name="SideClamp2DZ" type="numeric" nEntries="12">
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z]
+		</Vector>
+		<String name="ModuleName" value="tobmodule2:TOBModule2"/>
+		<Vector name="ModuleRot" type="string" nEntries="6">
+			tobrodpar:NULL, tobrodpar:R180, tobrodpar:180D,
+			tobrodpar:180X, tobrodpar:180D, tobrodpar:180X</Vector>
+		<Vector name="ModuleY" type="numeric" nEntries="6">
+			[tobrodpar:ModuleY], -[tobrodpar:ModuleY],  [tobrodpar:ModuleY],
+			-[tobrodpar:ModuleY],  [tobrodpar:ModuleY], -[tobrodpar:ModuleY]
+		</Vector>
+		<Vector name="ModuleZ" type="numeric" nEntries="6">
+			[tobrodpar:ModuleZ01], [tobrodpar:ModuleZ02], [tobrodpar:ModuleZ03],
+			[tobrodpar:ModuleZ04], [tobrodpar:ModuleZ05], [tobrodpar:ModuleZ06]
+		</Vector>
+		<Vector name="ICCName" type="string" nEntries="6">
+			tobrod2c:TOBRodConn2, tobrod2c:TOBCCUM2, tobrod2c:TOBICC22, 
+			tobrod2c:TOBICC22, tobrod2c:TOBICC21, tobrod2c:TOBICC21
+		</Vector>
+		<Vector name="ICCY" type="numeric" nEntries="6">
+			-[tobrodpar:ICCY1], -[tobrodpar:ICCY2],  [tobrodpar:ICCY1],
+			-[tobrodpar:ICCY1],  [tobrodpar:ICCY1], -[tobrodpar:ICCY1]
+		</Vector>
+		<Vector name="ICCZ" type="numeric" nEntries="6">
+			[tobrodpar:ICCZ01], [tobrodpar:ICCZ02], [tobrodpar:ICCZ03],
+			[tobrodpar:ICCZ04], [tobrodpar:ICCZ05], [tobrodpar:ICCZ06]
+		</Vector>
+		<String name="AOHName" value="tobrodpar:TOBAOH"/>
+		<Vector name="AOHCopies" type="numeric" nEntries="6">
+			0 , 0 , 2 , 2 , 1 , 1
+		</Vector>
+		<Vector name="AOHx" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHx] , [tobrodpar:AOHx] ,
+			[tobrodpar:AOHx] , -[tobrodpar:AOHx]
+		</Vector>
+		<Vector name="AOHy" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy]
+		</Vector>
+		<Vector name="AOHz" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHz] , -[tobrodpar:AOHz] ,
+			[zero] , [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod3.xml
+++ b/DetectorDescription/DDCMS/data/tobrod3.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod3.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod3.xml">
+		<LogicalPart name="TOBRod3" category="unspecified">
+			<rSolid name="tobrodpar:TOBRod"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod3.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod3:TOBRod3"/>
+			<rChild name="tobrod3l:TOBRod3L"/>
+			<rRotation name="tobrodpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobrod3:TOBRod3"/>
+			<rChild name="tobrod3h:TOBRod3H"/>
+			<rRotation name="tobrodpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="-([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod3h.xml
+++ b/DetectorDescription/DDCMS/data/tobrod3h.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod3h.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod3h.xml">
+		<LogicalPart name="TOBRod3H" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodH"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodCentral3H" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodCentralH"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod3h.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod3h:TOBRod3H"/>
+			<rChild name="tobrod3h:TOBRodCentral3H"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTOBRodAlgo">
+		<rParent name="tobrod3h:TOBRod3H"/>
+		<Numeric name="Shift" value="-([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		<String name="CentralName" value="tobrod3h:TOBRodCentral3H"/>
+		<Vector name="SideRodName" type="string" nEntries="2">
+			tobrodpar:TOBSideRod1, tobrodpar:TOBSideRod2
+		</Vector>
+		<Vector name="SideRodX" type="numeric" nEntries="2">
+			-[tobrodpar:SideRodX],  [tobrodpar:SideRodX]
+		</Vector>
+		<Vector name="SideRodY" type="numeric" nEntries="2">
+			[tobrodpar:RodY],     -[tobrodpar:RodY]
+		</Vector>
+		<Vector name="SideRodZ" type="numeric" nEntries="2">
+			[zero],                [tobrodpar:RodDL]
+		</Vector>
+		<String name="EndRod1Name" value="tobrodpar:TOBEndRod1"/>
+		<Vector name="EndRod1Y" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="EndRod1Z" type="numeric" nEntries="2">
+			[tobrodpar:EndRod1Z],  [tobrodpar:EndRod1Z]
+		</Vector>
+		<String name="EndRod2Name" value="tobrodpar:TOBEndRod2"/>
+		<Numeric name="EndRod2Y" value="-[tobrodpar:EndRod2Y]"/>
+		<Numeric name="EndRod2Z" value="[tobrodpar:EndRod2Z]"/>
+		<String name="CableName" value="tobrodpar:TOBCable"/>
+		<Numeric name="CableZ" value="[tobrodpar:CableZ]"/>
+		<String name="ClampName" value="tobrodpar:TOBClamp"/>
+		<Vector name="ClampX" type="numeric" nEntries="4">
+			-[tobrodpar:ClampX],  -[tobrodpar:ClampX],   [tobrodpar:ClampX],
+			[tobrodpar:ClampX]
+		</Vector>
+		<Vector name="ClampZ" type="numeric" nEntries="4">
+			[tobrodpar:ClampZ2],  [tobrodpar:ClampZ1],  [tobrodpar:ClampZ2],
+			[tobrodpar:ClampZ1]
+		</Vector>
+		<String name="SideCoolName" value="tobrod2c:TOBSideCoolTube2"/>
+		<Vector name="SideCoolX" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolX],  [tobrodpar:SideCoolX]
+		</Vector>
+		<Vector name="SideCoolY" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolY],  -[tobrodpar:SideCoolY]
+		</Vector>
+		<Vector name="SideCoolZ" type="numeric" nEntries="2">
+			[tobrodpar:SideCoolZ],  [tobrodpar:SideCoolZ]
+		</Vector>
+		<String name="EndCoolName" value="tobrod2c:TOBEndCoolTube2"/>
+		<String name="EndCoolRot" value="tobrodpar:90XD"/>
+		<Numeric name="EndCoolY" value="-[tobrodpar:EndCoolY]"/>
+		<Numeric name="EndCoolZ" value="[tobrodpar:EndCoolZ]"/>
+		<String name="OptFibreName" value="tobrod2c:TOBOptFibre2"/>
+		<Vector name="optFibreX" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreX],  [tobrodpar:OptFibreX]
+		</Vector>
+		<Vector name="optFibreZ" type="numeric" nEntries="2">
+			[tobrodpar:OptFibreZ],  [tobrodpar:OptFibreZ]
+		</Vector>
+		<String name="SideClamp1Name" value="tobrod2c:TOBPlate21"/>
+		<Vector name="SideClampX" type="numeric" nEntries="12">
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX],
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX]
+		</Vector>
+		<Vector name="SideClamp1DZ" type="numeric" nEntries="12">
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z]
+		</Vector>
+		<String name="SideClamp2Name" value="tobrod2c:TOBPlate22"/>
+		<Vector name="SideClamp2DZ" type="numeric" nEntries="12">
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z]
+		</Vector>
+		<String name="ModuleName" value="tobmodule2:TOBModule2"/>
+		<Vector name="ModuleRot" type="string" nEntries="6">
+			tobrodpar:NULL, tobrodpar:R180, tobrodpar:NULL, 
+			tobrodpar:R180, tobrodpar:180D, tobrodpar:180X</Vector>
+		<Vector name="ModuleY" type="numeric" nEntries="6">
+			[tobrodpar:ModuleY], -[tobrodpar:ModuleY],  [tobrodpar:ModuleY],
+			-[tobrodpar:ModuleY],  [tobrodpar:ModuleY], -[tobrodpar:ModuleY]
+		</Vector>
+		<Vector name="ModuleZ" type="numeric" nEntries="6">
+			[tobrodpar:ModuleZ07], [tobrodpar:ModuleZ08], [tobrodpar:ModuleZ09],
+			[tobrodpar:ModuleZ10], [tobrodpar:ModuleZ11], [tobrodpar:ModuleZ12]
+		</Vector>
+		<Vector name="ICCName" type="string" nEntries="6">
+			tobrod2c:TOBICC21, tobrod2c:TOBICC21, tobrod2c:TOBICC22, 
+			tobrod2c:TOBICC22, tobrod2c:TOBCCUM2, tobrod2c:TOBRodConn2
+		</Vector>
+		<Vector name="ICCY" type="numeric" nEntries="6">
+			[tobrodpar:ICCY1], -[tobrodpar:ICCY1],  [tobrodpar:ICCY1],
+			-[tobrodpar:ICCY1],  [tobrodpar:ICCY2],  [tobrodpar:ICCY1]
+		</Vector>
+		<Vector name="ICCZ" type="numeric" nEntries="6">
+			[tobrodpar:ICCZ07], [tobrodpar:ICCZ08], [tobrodpar:ICCZ09],
+			[tobrodpar:ICCZ10], [tobrodpar:ICCZ11], [tobrodpar:ICCZ12]
+		</Vector>
+		<String name="AOHName" value="tobrodpar:TOBAOH"/>
+		<Vector name="AOHCopies" type="numeric" nEntries="6">
+			1 , 1 , 2 , 2 , 0 , 0
+		</Vector>
+		<Vector name="AOHx" type="numeric" nEntries="6">
+			-[tobrodpar:AOHx] , [tobrodpar:AOHx] ,
+			[tobrodpar:AOHx]  , [tobrodpar:AOHx] ,
+			[zero] , [zero]
+		</Vector>
+		<Vector name="AOHy" type="numeric" nEntries="6">
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[zero] , [zero]
+		</Vector>
+		<Vector name="AOHz" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHz] , -[tobrodpar:AOHz] ,
+			[zero] , [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod3l.xml
+++ b/DetectorDescription/DDCMS/data/tobrod3l.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod3l.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod3l.xml">
+		<LogicalPart name="TOBRod3L" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodL"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodCentral3L" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodCentralL"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod3l.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod3l:TOBRod3L"/>
+			<rChild name="tobrod3l:TOBRodCentral3L"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTOBRodAlgo">
+		<rParent name="tobrod3l:TOBRod3L"/>
+		<Numeric name="Shift" value="([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		<String name="CentralName" value="tobrod3l:TOBRodCentral3L"/>
+		<Vector name="SideRodName" type="string" nEntries="2">
+			tobrodpar:TOBSideRod1, tobrodpar:TOBSideRod2
+		</Vector>
+		<Vector name="SideRodX" type="numeric" nEntries="2">
+			-[tobrodpar:SideRodX],  [tobrodpar:SideRodX]
+		</Vector>
+		<Vector name="SideRodY" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="SideRodZ" type="numeric" nEntries="2">
+			[zero],               -[tobrodpar:RodDL]
+		</Vector>
+		<String name="EndRod1Name" value="tobrodpar:TOBEndRod1"/>
+		<Vector name="EndRod1Y" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="EndRod1Z" type="numeric" nEntries="2">
+			-[tobrodpar:EndRod1Z], -[tobrodpar:EndRod1Z]
+		</Vector>
+		<String name="EndRod2Name" value="tobrodpar:TOBEndRod2"/>
+		<Numeric name="EndRod2Y" value="[tobrodpar:EndRod2Y]"/>
+		<Numeric name="EndRod2Z" value="-[tobrodpar:EndRod2Z]"/>
+		<String name="CableName" value="tobrodpar:TOBCable"/>
+		<Numeric name="CableZ" value="-[tobrodpar:CableZ]"/>
+		<String name="ClampName" value="tobrodpar:TOBClamp"/>
+		<Vector name="ClampX" type="numeric" nEntries="4">
+			-[tobrodpar:ClampX],  -[tobrodpar:ClampX],   [tobrodpar:ClampX],
+			[tobrodpar:ClampX]
+		</Vector>
+		<Vector name="ClampZ" type="numeric" nEntries="4">
+			-[tobrodpar:ClampZ1], -[tobrodpar:ClampZ2], -[tobrodpar:ClampZ1],
+			-[tobrodpar:ClampZ2]
+		</Vector>
+		<String name="SideCoolName" value="tobrod2c:TOBSideCoolTube2"/>
+		<Vector name="SideCoolX" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolX],  [tobrodpar:SideCoolX]
+		</Vector>
+		<Vector name="SideCoolY" type="numeric" nEntries="2">
+			[tobrodpar:SideCoolY],  [tobrodpar:SideCoolY]
+		</Vector>
+		<Vector name="SideCoolZ" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolZ], -[tobrodpar:SideCoolZ]
+		</Vector>
+		<String name="EndCoolName" value="tobrod2c:TOBEndCoolTube2"/>
+		<String name="EndCoolRot" value="tobrodpar:90XD"/>
+		<Numeric name="EndCoolY" value="[tobrodpar:EndCoolY]"/>
+		<Numeric name="EndCoolZ" value="-[tobrodpar:EndCoolZ]"/>
+		<String name="OptFibreName" value="tobrod2c:TOBOptFibre2"/>
+		<Vector name="optFibreX" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreX],  [tobrodpar:OptFibreX]
+		</Vector>
+		<Vector name="optFibreZ" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreZ], -[tobrodpar:OptFibreZ]
+		</Vector>
+		<String name="SideClamp1Name" value="tobrod2c:TOBPlate21"/>
+		<Vector name="SideClampX" type="numeric" nEntries="12">
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX],
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX]
+		</Vector>
+		<Vector name="SideClamp1DZ" type="numeric" nEntries="12">
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z]
+		</Vector>
+		<String name="SideClamp2Name" value="tobrod2c:TOBPlate22"/>
+		<Vector name="SideClamp2DZ" type="numeric" nEntries="12">
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z]
+		</Vector>
+		<String name="ModuleName" value="tobmodule2:TOBModule2"/>
+		<Vector name="ModuleRot" type="string" nEntries="6">
+			tobrodpar:NULL, tobrodpar:R180, tobrodpar:180D,
+			tobrodpar:180X, tobrodpar:180D, tobrodpar:180X</Vector>
+		<Vector name="ModuleY" type="numeric" nEntries="6">
+			[tobrodpar:ModuleY], -[tobrodpar:ModuleY],  [tobrodpar:ModuleY],
+			-[tobrodpar:ModuleY],  [tobrodpar:ModuleY], -[tobrodpar:ModuleY]
+		</Vector>
+		<Vector name="ModuleZ" type="numeric" nEntries="6">
+			[tobrodpar:ModuleZ01], [tobrodpar:ModuleZ02], [tobrodpar:ModuleZ03],
+			[tobrodpar:ModuleZ04], [tobrodpar:ModuleZ05], [tobrodpar:ModuleZ06]
+		</Vector>
+		<Vector name="ICCName" type="string" nEntries="6">
+			tobrod2c:TOBRodConn2, tobrod2c:TOBCCUM2, tobrod2c:TOBICC22, 
+			tobrod2c:TOBICC22, tobrod2c:TOBICC21, tobrod2c:TOBICC21
+		</Vector>
+		<Vector name="ICCY" type="numeric" nEntries="6">
+			-[tobrodpar:ICCY1], -[tobrodpar:ICCY2],  [tobrodpar:ICCY1],
+			-[tobrodpar:ICCY1],  [tobrodpar:ICCY1], -[tobrodpar:ICCY1]
+		</Vector>
+		<Vector name="ICCZ" type="numeric" nEntries="6">
+			[tobrodpar:ICCZ01], [tobrodpar:ICCZ02], [tobrodpar:ICCZ03],
+			[tobrodpar:ICCZ04], [tobrodpar:ICCZ05], [tobrodpar:ICCZ06]
+		</Vector>
+		<String name="AOHName" value="tobrodpar:TOBAOH"/>
+		<Vector name="AOHCopies" type="numeric" nEntries="6">
+			0 , 0 , 2 , 2 , 1 , 1
+		</Vector>
+		<Vector name="AOHx" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHx] , [tobrodpar:AOHx] ,
+			[tobrodpar:AOHx] , -[tobrodpar:AOHx]
+		</Vector>
+		<Vector name="AOHy" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy]
+		</Vector>
+		<Vector name="AOHz" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHz] , -[tobrodpar:AOHz] ,
+			[zero] , [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod4.xml
+++ b/DetectorDescription/DDCMS/data/tobrod4.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod4.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod4.xml">
+		<LogicalPart name="TOBRod4" category="unspecified">
+			<rSolid name="tobrodpar:TOBRod"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod4.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod4:TOBRod4"/>
+			<rChild name="tobrod4l:TOBRod4L"/>
+			<rRotation name="tobrodpar:R180"/>
+			<Translation x="[zero]" y="[zero]" z="-([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobrod4:TOBRod4"/>
+			<rChild name="tobrod4h:TOBRod4H"/>
+			<rRotation name="tobrodpar:R180"/>
+			<Translation x="[zero]" y="[zero]" z="([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod4c.xml
+++ b/DetectorDescription/DDCMS/data/tobrod4c.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod4c.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<SolidSection label="tobrod4c.xml">
+		<Tubs name="TOBSideCoolTube4" rMin="[zero]" rMax="[tobrodpar:CoolTubeLightR]" dz="[tobrodpar:SideCoolL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBSideCoolFluid4" rMin="[zero]" rMax="[tobrodpar:CoolFluidLightR]" dz="[tobrodpar:SideCoolL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBEndCoolTube4" rMin="[zero]" rMax="[tobrodpar:CoolTubeLightR]" dz="[tobrodpar:EndCoolL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TOBEndCoolFluid4" rMin="[zero]" rMax="[tobrodpar:CoolFluidLightR]" dz="[tobrodpar:EndCoolL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Box name="TOBOptFibre4" dx="[tobrodpar:OptFibreW]" dy="[tobrodpar:OptFibreH]" dz="[tobrodpar:OptFibreL]"/>
+		<Box name="TOBPlate41" dx="[tobrodpar:SideClampDx]" dy="[tobrodpar:SideClampDy]" dz="[tobrodpar:SideClampLDz]"/>
+		<Box name="TOBPlate42" dx="[tobrodpar:SideClampDx]" dy="[tobrodpar:SideClampDy]" dz="[tobrodpar:SideClampLDz]"/>
+	</SolidSection>
+	<LogicalPartSection label="tobrod4c.xml">
+		<LogicalPart name="TOBSideCoolTube4" category="unspecified">
+			<rSolid name="TOBSideCoolTube4"/>
+			<rMaterial name="trackermaterial:T_CuNi"/>
+		</LogicalPart>
+		<LogicalPart name="TOBSideCoolFluid4" category="unspecified">
+			<rSolid name="TOBSideCoolFluid4"/>
+			<rMaterial name="trackermaterial:T_C6F14_F2_-30C"/>
+		</LogicalPart>
+		<LogicalPart name="TOBEndCoolTube4" category="unspecified">
+			<rSolid name="TOBEndCoolTube4"/>
+			<rMaterial name="trackermaterial:T_CuNi"/>
+		</LogicalPart>
+		<LogicalPart name="TOBEndCoolFluid4" category="unspecified">
+			<rSolid name="TOBEndCoolFluid4"/>
+			<rMaterial name="trackermaterial:T_C6F14_F2_-30C"/>
+		</LogicalPart>
+		<LogicalPart name="TOBOptFibre4" category="unspecified">
+			<rSolid name="TOBOptFibre4"/>
+			<rMaterial name="tobmaterial:TOB_optfib_L56"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPlate41" category="unspecified">
+			<rSolid name="TOBPlate41"/>
+			<rMaterial name="tobmaterial:TOB_plate_B"/>
+		</LogicalPart>
+		<LogicalPart name="TOBPlate42" category="unspecified">
+			<rSolid name="TOBPlate42"/>
+			<rMaterial name="tobmaterial:TOB_plate_C"/>
+		</LogicalPart>
+		<LogicalPart name="TOBICC41" category="unspecified">
+			<rSolid name="tobrodpar:TOBICC1"/>
+			<rMaterial name="tobmaterial:TOB_L56_ICC1"/>
+		</LogicalPart>
+		<LogicalPart name="TOBICC42" category="unspecified">
+			<rSolid name="tobrodpar:TOBICC2"/>
+			<rMaterial name="tobmaterial:TOB_L56_ICC2"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodConn4" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodConn"/>
+			<rMaterial name="tobmaterial:TOB_CONN56"/>
+		</LogicalPart>
+		<LogicalPart name="TOBCCUM4" category="unspecified">
+			<rSolid name="tobrodpar:TOBCCUM"/>
+			<rMaterial name="tobmaterial:TOB_CCUM"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod4c.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod4c:TOBSideCoolTube4"/>
+			<rChild name="tobrod4c:TOBSideCoolFluid4"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobrod4c:TOBEndCoolTube4"/>
+			<rChild name="tobrod4c:TOBEndCoolFluid4"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod4h.xml
+++ b/DetectorDescription/DDCMS/data/tobrod4h.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod4h.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod4h.xml">
+		<LogicalPart name="TOBRod4H" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodH"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodCentral4H" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodCentralH"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod4h.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod4h:TOBRod4H"/>
+			<rChild name="tobrod4h:TOBRodCentral4H"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTOBRodAlgo">
+		<rParent name="tobrod4h:TOBRod4H"/>
+		<Numeric name="Shift" value="-([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		<String name="CentralName" value="tobrod4h:TOBRodCentral4H"/>
+		<Vector name="SideRodName" type="string" nEntries="2">
+			tobrodpar:TOBSideRod1, tobrodpar:TOBSideRod2
+		</Vector>
+		<Vector name="SideRodX" type="numeric" nEntries="2">
+			-[tobrodpar:SideRodX],  [tobrodpar:SideRodX]
+		</Vector>
+		<Vector name="SideRodY" type="numeric" nEntries="2">
+			[tobrodpar:RodY],     -[tobrodpar:RodY]
+		</Vector>
+		<Vector name="SideRodZ" type="numeric" nEntries="2">
+			[zero],                [tobrodpar:RodDL]
+		</Vector>
+		<String name="EndRod1Name" value="tobrodpar:TOBEndRod1"/>
+		<Vector name="EndRod1Y" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="EndRod1Z" type="numeric" nEntries="2">
+			[tobrodpar:EndRod1Z],  [tobrodpar:EndRod1Z]
+		</Vector>
+		<String name="EndRod2Name" value="tobrodpar:TOBEndRod2"/>
+		<Numeric name="EndRod2Y" value="-[tobrodpar:EndRod2Y]"/>
+		<Numeric name="EndRod2Z" value="[tobrodpar:EndRod2Z]"/>
+		<String name="CableName" value="tobrodpar:TOBCable"/>
+		<Numeric name="CableZ" value="[tobrodpar:CableZ]"/>
+		<String name="ClampName" value="tobrodpar:TOBClamp"/>
+		<Vector name="ClampX" type="numeric" nEntries="4">
+			-[tobrodpar:ClampX],  -[tobrodpar:ClampX],   [tobrodpar:ClampX],
+			[tobrodpar:ClampX]
+		</Vector>
+		<Vector name="ClampZ" type="numeric" nEntries="4">
+			[tobrodpar:ClampZ2],  [tobrodpar:ClampZ1],  [tobrodpar:ClampZ2],
+			[tobrodpar:ClampZ1]
+		</Vector>
+		<String name="SideCoolName" value="tobrod4c:TOBSideCoolTube4"/>
+		<Vector name="SideCoolX" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolX],  [tobrodpar:SideCoolX]
+		</Vector>
+		<Vector name="SideCoolY" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolY],  -[tobrodpar:SideCoolY]
+		</Vector>
+		<Vector name="SideCoolZ" type="numeric" nEntries="2">
+			[tobrodpar:SideCoolZ],  [tobrodpar:SideCoolZ]
+		</Vector>
+		<String name="EndCoolName" value="tobrod4c:TOBEndCoolTube4"/>
+		<String name="EndCoolRot" value="tobrodpar:90XD"/>
+		<Numeric name="EndCoolY" value="-[tobrodpar:EndCoolY]"/>
+		<Numeric name="EndCoolZ" value="[tobrodpar:EndCoolZ]"/>
+		<String name="OptFibreName" value="tobrod4c:TOBOptFibre4"/>
+		<Vector name="optFibreX" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreX],  [tobrodpar:OptFibreX]
+		</Vector>
+		<Vector name="optFibreZ" type="numeric" nEntries="2">
+			[tobrodpar:OptFibreZ],  [tobrodpar:OptFibreZ]
+		</Vector>
+		<String name="SideClamp1Name" value="tobrod4c:TOBPlate41"/>
+		<Vector name="SideClampX" type="numeric" nEntries="12">
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX],
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX]
+		</Vector>
+		<Vector name="SideClamp1DZ" type="numeric" nEntries="12">
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z]
+		</Vector>
+		<String name="SideClamp2Name" value="tobrod4c:TOBPlate42"/>
+		<Vector name="SideClamp2DZ" type="numeric" nEntries="12">
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z]
+		</Vector>
+		<String name="ModuleName" value="tobmodule4:TOBModule4"/>
+		<Vector name="ModuleRot" type="string" nEntries="6">
+			tobrodpar:NULL, tobrodpar:R180, tobrodpar:NULL, 
+			tobrodpar:R180, tobrodpar:180D, tobrodpar:180X</Vector>
+		<Vector name="ModuleY" type="numeric" nEntries="6">
+			[tobrodpar:ModuleY], -[tobrodpar:ModuleY],  [tobrodpar:ModuleY],
+			-[tobrodpar:ModuleY],  [tobrodpar:ModuleY], -[tobrodpar:ModuleY]
+		</Vector>
+		<Vector name="ModuleZ" type="numeric" nEntries="6">
+			[tobrodpar:ModuleZ07], [tobrodpar:ModuleZ08], [tobrodpar:ModuleZ09],
+			[tobrodpar:ModuleZ10], [tobrodpar:ModuleZ11], [tobrodpar:ModuleZ12]
+		</Vector>
+		<Vector name="ICCName" type="string" nEntries="6">
+			tobrod4c:TOBICC41, tobrod4c:TOBICC41, tobrod4c:TOBICC42, 
+			tobrod4c:TOBICC42, tobrod4c:TOBCCUM4, tobrod4c:TOBRodConn4
+		</Vector>
+		<Vector name="ICCY" type="numeric" nEntries="6">
+			[tobrodpar:ICCY1], -[tobrodpar:ICCY1],  [tobrodpar:ICCY1],
+			-[tobrodpar:ICCY1],  [tobrodpar:ICCY2],  [tobrodpar:ICCY1]
+		</Vector>
+		<Vector name="ICCZ" type="numeric" nEntries="6">
+			[tobrodpar:ICCZ07], [tobrodpar:ICCZ08], [tobrodpar:ICCZ09],
+			[tobrodpar:ICCZ10], [tobrodpar:ICCZ11], [tobrodpar:ICCZ12]
+		</Vector>
+		<String name="AOHName" value="tobrodpar:TOBAOH"/>
+		<Vector name="AOHCopies" type="numeric" nEntries="6">
+			1 , 1 , 2 , 2 , 0 , 0
+		</Vector>
+		<Vector name="AOHx" type="numeric" nEntries="6">
+			-[tobrodpar:AOHx] , [tobrodpar:AOHx] ,
+			[tobrodpar:AOHx]  , [tobrodpar:AOHx] ,
+			[zero] , [zero]
+		</Vector>
+		<Vector name="AOHy" type="numeric" nEntries="6">
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[zero] , [zero]
+		</Vector>
+		<Vector name="AOHz" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHz] , -[tobrodpar:AOHz] ,
+			[zero] , [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod4l.xml
+++ b/DetectorDescription/DDCMS/data/tobrod4l.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod4l.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod4l.xml">
+		<LogicalPart name="TOBRod4L" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodL"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodCentral4L" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodCentralL"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod4l.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod4l:TOBRod4L"/>
+			<rChild name="tobrod4l:TOBRodCentral4L"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTOBRodAlgo">
+		<rParent name="tobrod4l:TOBRod4L"/>
+		<Numeric name="Shift" value="([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		<String name="CentralName" value="tobrod4l:TOBRodCentral4L"/>
+		<Vector name="SideRodName" type="string" nEntries="2">
+			tobrodpar:TOBSideRod1, tobrodpar:TOBSideRod2
+		</Vector>
+		<Vector name="SideRodX" type="numeric" nEntries="2">
+			-[tobrodpar:SideRodX],  [tobrodpar:SideRodX]
+		</Vector>
+		<Vector name="SideRodY" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="SideRodZ" type="numeric" nEntries="2">
+			[zero],               -[tobrodpar:RodDL]
+		</Vector>
+		<String name="EndRod1Name" value="tobrodpar:TOBEndRod1"/>
+		<Vector name="EndRod1Y" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="EndRod1Z" type="numeric" nEntries="2">
+			-[tobrodpar:EndRod1Z], -[tobrodpar:EndRod1Z]
+		</Vector>
+		<String name="EndRod2Name" value="tobrodpar:TOBEndRod2"/>
+		<Numeric name="EndRod2Y" value="[tobrodpar:EndRod2Y]"/>
+		<Numeric name="EndRod2Z" value="-[tobrodpar:EndRod2Z]"/>
+		<String name="CableName" value="tobrodpar:TOBCable"/>
+		<Numeric name="CableZ" value="-[tobrodpar:CableZ]"/>
+		<String name="ClampName" value="tobrodpar:TOBClamp"/>
+		<Vector name="ClampX" type="numeric" nEntries="4">
+			-[tobrodpar:ClampX],  -[tobrodpar:ClampX],   [tobrodpar:ClampX],
+			[tobrodpar:ClampX]
+		</Vector>
+		<Vector name="ClampZ" type="numeric" nEntries="4">
+			-[tobrodpar:ClampZ1], -[tobrodpar:ClampZ2], -[tobrodpar:ClampZ1],
+			-[tobrodpar:ClampZ2]
+		</Vector>
+		<String name="SideCoolName" value="tobrod4c:TOBSideCoolTube4"/>
+		<Vector name="SideCoolX" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolX],  [tobrodpar:SideCoolX]
+		</Vector>
+		<Vector name="SideCoolY" type="numeric" nEntries="2">
+			[tobrodpar:SideCoolY],  [tobrodpar:SideCoolY]
+		</Vector>
+		<Vector name="SideCoolZ" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolZ], -[tobrodpar:SideCoolZ]
+		</Vector>
+		<String name="EndCoolName" value="tobrod4c:TOBEndCoolTube4"/>
+		<String name="EndCoolRot" value="tobrodpar:90XD"/>
+		<Numeric name="EndCoolY" value="[tobrodpar:EndCoolY]"/>
+		<Numeric name="EndCoolZ" value="-[tobrodpar:EndCoolZ]"/>
+		<String name="OptFibreName" value="tobrod4c:TOBOptFibre4"/>
+		<Vector name="optFibreX" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreX],  [tobrodpar:OptFibreX]
+		</Vector>
+		<Vector name="optFibreZ" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreZ], -[tobrodpar:OptFibreZ]
+		</Vector>
+		<String name="SideClamp1Name" value="tobrod4c:TOBPlate41"/>
+		<Vector name="SideClampX" type="numeric" nEntries="12">
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX],
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX]
+		</Vector>
+		<Vector name="SideClamp1DZ" type="numeric" nEntries="12">
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z]
+		</Vector>
+		<String name="SideClamp2Name" value="tobrod4c:TOBPlate42"/>
+		<Vector name="SideClamp2DZ" type="numeric" nEntries="12">
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z]
+		</Vector>
+		<String name="ModuleName" value="tobmodule4:TOBModule4"/>
+		<Vector name="ModuleRot" type="string" nEntries="6">
+			tobrodpar:NULL, tobrodpar:R180, tobrodpar:180D,
+			tobrodpar:180X, tobrodpar:180D, tobrodpar:180X</Vector>
+		<Vector name="ModuleY" type="numeric" nEntries="6">
+			[tobrodpar:ModuleY], -[tobrodpar:ModuleY],  [tobrodpar:ModuleY],
+			-[tobrodpar:ModuleY],  [tobrodpar:ModuleY], -[tobrodpar:ModuleY]
+		</Vector>
+		<Vector name="ModuleZ" type="numeric" nEntries="6">
+			[tobrodpar:ModuleZ01], [tobrodpar:ModuleZ02], [tobrodpar:ModuleZ03],
+			[tobrodpar:ModuleZ04], [tobrodpar:ModuleZ05], [tobrodpar:ModuleZ06]
+		</Vector>
+		<Vector name="ICCName" type="string" nEntries="6">
+			tobrod4c:TOBRodConn4, tobrod4c:TOBCCUM4, tobrod4c:TOBICC42, 
+			tobrod4c:TOBICC42, tobrod4c:TOBICC41, tobrod4c:TOBICC41
+		</Vector>
+		<Vector name="ICCY" type="numeric" nEntries="6">
+			-[tobrodpar:ICCY1], -[tobrodpar:ICCY2],  [tobrodpar:ICCY1],
+			-[tobrodpar:ICCY1],  [tobrodpar:ICCY1], -[tobrodpar:ICCY1]
+		</Vector>
+		<Vector name="ICCZ" type="numeric" nEntries="6">
+			[tobrodpar:ICCZ01], [tobrodpar:ICCZ02], [tobrodpar:ICCZ03],
+			[tobrodpar:ICCZ04], [tobrodpar:ICCZ05], [tobrodpar:ICCZ06]
+		</Vector>
+		<String name="AOHName" value="tobrodpar:TOBAOH"/>
+		<Vector name="AOHCopies" type="numeric" nEntries="6">
+			0 , 0 , 2 , 2 , 1 , 1
+		</Vector>
+		<Vector name="AOHx" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHx] , [tobrodpar:AOHx] ,
+			[tobrodpar:AOHx] , -[tobrodpar:AOHx]
+		</Vector>
+		<Vector name="AOHy" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy]
+		</Vector>
+		<Vector name="AOHz" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHz] , -[tobrodpar:AOHz] ,
+			[zero] , [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod5.xml
+++ b/DetectorDescription/DDCMS/data/tobrod5.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod5.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod5.xml">
+		<LogicalPart name="TOBRod5" category="unspecified">
+			<rSolid name="tobrodpar:TOBRod"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod5.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod5:TOBRod5"/>
+			<rChild name="tobrod5l:TOBRod5L"/>
+			<rRotation name="tobrodpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="tobrod5:TOBRod5"/>
+			<rChild name="tobrod5h:TOBRod5H"/>
+			<rRotation name="tobrodpar:180X"/>
+			<Translation x="[zero]" y="[zero]" z="-([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod5h.xml
+++ b/DetectorDescription/DDCMS/data/tobrod5h.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod5h.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod5h.xml">
+		<LogicalPart name="TOBRod5H" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodH"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodCentral5H" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodCentralH"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod5h.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod5h:TOBRod5H"/>
+			<rChild name="tobrod5h:TOBRodCentral5H"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTOBRodAlgo">
+		<rParent name="tobrod5h:TOBRod5H"/>
+		<Numeric name="Shift" value="-([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		<String name="CentralName" value="tobrod5h:TOBRodCentral5H"/>
+		<Vector name="SideRodName" type="string" nEntries="2">
+			tobrodpar:TOBSideRod1, tobrodpar:TOBSideRod2
+		</Vector>
+		<Vector name="SideRodX" type="numeric" nEntries="2">
+			-[tobrodpar:SideRodX],  [tobrodpar:SideRodX]
+		</Vector>
+		<Vector name="SideRodY" type="numeric" nEntries="2">
+			[tobrodpar:RodY],     -[tobrodpar:RodY]
+		</Vector>
+		<Vector name="SideRodZ" type="numeric" nEntries="2">
+			[zero],                [tobrodpar:RodDL]
+		</Vector>
+		<String name="EndRod1Name" value="tobrodpar:TOBEndRod1"/>
+		<Vector name="EndRod1Y" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="EndRod1Z" type="numeric" nEntries="2">
+			[tobrodpar:EndRod1Z],  [tobrodpar:EndRod1Z]
+		</Vector>
+		<String name="EndRod2Name" value="tobrodpar:TOBEndRod2"/>
+		<Numeric name="EndRod2Y" value="-[tobrodpar:EndRod2Y]"/>
+		<Numeric name="EndRod2Z" value="[tobrodpar:EndRod2Z]"/>
+		<String name="CableName" value="tobrodpar:TOBCable"/>
+		<Numeric name="CableZ" value="[tobrodpar:CableZ]"/>
+		<String name="ClampName" value="tobrodpar:TOBClamp"/>
+		<Vector name="ClampX" type="numeric" nEntries="4">
+			-[tobrodpar:ClampX],  -[tobrodpar:ClampX],   [tobrodpar:ClampX],
+			[tobrodpar:ClampX]
+		</Vector>
+		<Vector name="ClampZ" type="numeric" nEntries="4">
+			[tobrodpar:ClampZ2],  [tobrodpar:ClampZ1],  [tobrodpar:ClampZ2],
+			[tobrodpar:ClampZ1]
+		</Vector>
+		<String name="SideCoolName" value="tobrod4c:TOBSideCoolTube4"/>
+		<Vector name="SideCoolX" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolX],  [tobrodpar:SideCoolX]
+		</Vector>
+		<Vector name="SideCoolY" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolY],  -[tobrodpar:SideCoolY]
+		</Vector>
+		<Vector name="SideCoolZ" type="numeric" nEntries="2">
+			[tobrodpar:SideCoolZ],  [tobrodpar:SideCoolZ]
+		</Vector>
+		<String name="EndCoolName" value="tobrod4c:TOBEndCoolTube4"/>
+		<String name="EndCoolRot" value="tobrodpar:90XD"/>
+		<Numeric name="EndCoolY" value="-[tobrodpar:EndCoolY]"/>
+		<Numeric name="EndCoolZ" value="[tobrodpar:EndCoolZ]"/>
+		<String name="OptFibreName" value="tobrod4c:TOBOptFibre4"/>
+		<Vector name="optFibreX" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreX],  [tobrodpar:OptFibreX]
+		</Vector>
+		<Vector name="optFibreZ" type="numeric" nEntries="2">
+			[tobrodpar:OptFibreZ],  [tobrodpar:OptFibreZ]
+		</Vector>
+		<String name="SideClamp1Name" value="tobrod4c:TOBPlate41"/>
+		<Vector name="SideClampX" type="numeric" nEntries="12">
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX],
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX]
+		</Vector>
+		<Vector name="SideClamp1DZ" type="numeric" nEntries="12">
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z]
+		</Vector>
+		<String name="SideClamp2Name" value="tobrod4c:TOBPlate42"/>
+		<Vector name="SideClamp2DZ" type="numeric" nEntries="12">
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z]
+		</Vector>
+		<String name="ModuleName" value="tobmodule4:TOBModule4"/>
+		<Vector name="ModuleRot" type="string" nEntries="6">
+			tobrodpar:NULL, tobrodpar:R180, tobrodpar:NULL, 
+			tobrodpar:R180, tobrodpar:180D, tobrodpar:180X</Vector>
+		<Vector name="ModuleY" type="numeric" nEntries="6">
+			[tobrodpar:ModuleY], -[tobrodpar:ModuleY],  [tobrodpar:ModuleY],
+			-[tobrodpar:ModuleY],  [tobrodpar:ModuleY], -[tobrodpar:ModuleY]
+		</Vector>
+		<Vector name="ModuleZ" type="numeric" nEntries="6">
+			[tobrodpar:ModuleZ07], [tobrodpar:ModuleZ08], [tobrodpar:ModuleZ09],
+			[tobrodpar:ModuleZ10], [tobrodpar:ModuleZ11], [tobrodpar:ModuleZ12]
+		</Vector>
+		<Vector name="ICCName" type="string" nEntries="6">
+			tobrod4c:TOBICC41, tobrod4c:TOBICC41, tobrod4c:TOBICC42, 
+			tobrod4c:TOBICC42, tobrod4c:TOBCCUM4, tobrod4c:TOBRodConn4
+		</Vector>
+		<Vector name="ICCY" type="numeric" nEntries="6">
+			[tobrodpar:ICCY1], -[tobrodpar:ICCY1],  [tobrodpar:ICCY1],
+			-[tobrodpar:ICCY1],  [tobrodpar:ICCY2],  [tobrodpar:ICCY1]
+		</Vector>
+		<Vector name="ICCZ" type="numeric" nEntries="6">
+			[tobrodpar:ICCZ07], [tobrodpar:ICCZ08], [tobrodpar:ICCZ09],
+			[tobrodpar:ICCZ10], [tobrodpar:ICCZ11], [tobrodpar:ICCZ12]
+		</Vector>
+		<String name="AOHName" value="tobrodpar:TOBAOH"/>
+		<Vector name="AOHCopies" type="numeric" nEntries="6">
+			1 , 1 , 2 , 2 , 0 , 0
+		</Vector>
+		<Vector name="AOHx" type="numeric" nEntries="6">
+			-[tobrodpar:AOHx] , [tobrodpar:AOHx] ,
+			[tobrodpar:AOHx]  , [tobrodpar:AOHx] ,
+			[zero] , [zero]
+		</Vector>
+		<Vector name="AOHy" type="numeric" nEntries="6">
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[zero] , [zero]
+		</Vector>
+		<Vector name="AOHz" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHz] , -[tobrodpar:AOHz] ,
+			[zero] , [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrod5l.xml
+++ b/DetectorDescription/DDCMS/data/tobrod5l.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrod5l.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<LogicalPartSection label="tobrod5l.xml">
+		<LogicalPart name="TOBRod5L" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodL"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRodCentral5L" category="unspecified">
+			<rSolid name="tobrodpar:TOBRodCentralL"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="tobrod5l.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tobrod5l:TOBRod5L"/>
+			<rChild name="tobrod5l:TOBRodCentral5L"/>
+		</PosPart>
+	</PosPartSection>
+	<Algorithm name="track:DDTOBRodAlgo">
+		<rParent name="tobrod5l:TOBRod5L"/>
+		<Numeric name="Shift" value="([tobrodpar:RodL]-[tobrodpar:RodDL])/2"/>
+		<String name="CentralName" value="tobrod5l:TOBRodCentral5L"/>
+		<Vector name="SideRodName" type="string" nEntries="2">
+			tobrodpar:TOBSideRod1, tobrodpar:TOBSideRod2
+		</Vector>
+		<Vector name="SideRodX" type="numeric" nEntries="2">
+			-[tobrodpar:SideRodX],  [tobrodpar:SideRodX]
+		</Vector>
+		<Vector name="SideRodY" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="SideRodZ" type="numeric" nEntries="2">
+			[zero],               -[tobrodpar:RodDL]
+		</Vector>
+		<String name="EndRod1Name" value="tobrodpar:TOBEndRod1"/>
+		<Vector name="EndRod1Y" type="numeric" nEntries="2">
+			-[tobrodpar:RodY],      [tobrodpar:RodY]
+		</Vector>
+		<Vector name="EndRod1Z" type="numeric" nEntries="2">
+			-[tobrodpar:EndRod1Z], -[tobrodpar:EndRod1Z]
+		</Vector>
+		<String name="EndRod2Name" value="tobrodpar:TOBEndRod2"/>
+		<Numeric name="EndRod2Y" value="[tobrodpar:EndRod2Y]"/>
+		<Numeric name="EndRod2Z" value="-[tobrodpar:EndRod2Z]"/>
+		<String name="CableName" value="tobrodpar:TOBCable"/>
+		<Numeric name="CableZ" value="-[tobrodpar:CableZ]"/>
+		<String name="ClampName" value="tobrodpar:TOBClamp"/>
+		<Vector name="ClampX" type="numeric" nEntries="4">
+			-[tobrodpar:ClampX],  -[tobrodpar:ClampX],   [tobrodpar:ClampX],
+			[tobrodpar:ClampX]
+		</Vector>
+		<Vector name="ClampZ" type="numeric" nEntries="4">
+			-[tobrodpar:ClampZ1], -[tobrodpar:ClampZ2], -[tobrodpar:ClampZ1],
+			-[tobrodpar:ClampZ2]
+		</Vector>
+		<String name="SideCoolName" value="tobrod4c:TOBSideCoolTube4"/>
+		<Vector name="SideCoolX" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolX],  [tobrodpar:SideCoolX]
+		</Vector>
+		<Vector name="SideCoolY" type="numeric" nEntries="2">
+			[tobrodpar:SideCoolY],  [tobrodpar:SideCoolY]
+		</Vector>
+		<Vector name="SideCoolZ" type="numeric" nEntries="2">
+			-[tobrodpar:SideCoolZ], -[tobrodpar:SideCoolZ]
+		</Vector>
+		<String name="EndCoolName" value="tobrod4c:TOBEndCoolTube4"/>
+		<String name="EndCoolRot" value="tobrodpar:90XD"/>
+		<Numeric name="EndCoolY" value="[tobrodpar:EndCoolY]"/>
+		<Numeric name="EndCoolZ" value="-[tobrodpar:EndCoolZ]"/>
+		<String name="OptFibreName" value="tobrod4c:TOBOptFibre4"/>
+		<Vector name="optFibreX" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreX],  [tobrodpar:OptFibreX]
+		</Vector>
+		<Vector name="optFibreZ" type="numeric" nEntries="2">
+			-[tobrodpar:OptFibreZ], -[tobrodpar:OptFibreZ]
+		</Vector>
+		<String name="SideClamp1Name" value="tobrod4c:TOBPlate41"/>
+		<Vector name="SideClampX" type="numeric" nEntries="12">
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX],
+			-[tobrodpar:SideClampX],  [tobrodpar:SideClampX], -[tobrodpar:SideClampX],
+			[tobrodpar:SideClampX], -[tobrodpar:SideClampX],  [tobrodpar:SideClampX]
+		</Vector>
+		<Vector name="SideClamp1DZ" type="numeric" nEntries="12">
+			-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],-[tobrodpar:SideClamp1Z],
+			-[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z],
+			[tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z], [tobrodpar:SideClamp1Z]
+		</Vector>
+		<String name="SideClamp2Name" value="tobrod4c:TOBPlate42"/>
+		<Vector name="SideClamp2DZ" type="numeric" nEntries="12">
+			[tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z], [tobrodpar:SideClamp2Z],
+			[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],
+			-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z],-[tobrodpar:SideClamp2Z]
+		</Vector>
+		<String name="ModuleName" value="tobmodule4:TOBModule4"/>
+		<Vector name="ModuleRot" type="string" nEntries="6">
+			tobrodpar:NULL, tobrodpar:R180, tobrodpar:180D,
+			tobrodpar:180X, tobrodpar:180D, tobrodpar:180X</Vector>
+		<Vector name="ModuleY" type="numeric" nEntries="6">
+			[tobrodpar:ModuleY], -[tobrodpar:ModuleY],  [tobrodpar:ModuleY],
+			-[tobrodpar:ModuleY],  [tobrodpar:ModuleY], -[tobrodpar:ModuleY]
+		</Vector>
+		<Vector name="ModuleZ" type="numeric" nEntries="6">
+			[tobrodpar:ModuleZ01], [tobrodpar:ModuleZ02], [tobrodpar:ModuleZ03],
+			[tobrodpar:ModuleZ04], [tobrodpar:ModuleZ05], [tobrodpar:ModuleZ06]
+		</Vector>
+		<Vector name="ICCName" type="string" nEntries="6">
+			tobrod4c:TOBRodConn4, tobrod4c:TOBCCUM4, tobrod4c:TOBICC42, 
+			tobrod4c:TOBICC42, tobrod4c:TOBICC41, tobrod4c:TOBICC41
+		</Vector>
+		<Vector name="ICCY" type="numeric" nEntries="6">
+			-[tobrodpar:ICCY1], -[tobrodpar:ICCY2],  [tobrodpar:ICCY1],
+			-[tobrodpar:ICCY1],  [tobrodpar:ICCY1], -[tobrodpar:ICCY1]
+		</Vector>
+		<Vector name="ICCZ" type="numeric" nEntries="6">
+			[tobrodpar:ICCZ01], [tobrodpar:ICCZ02], [tobrodpar:ICCZ03],
+			[tobrodpar:ICCZ04], [tobrodpar:ICCZ05], [tobrodpar:ICCZ06]
+		</Vector>
+		<String name="AOHName" value="tobrodpar:TOBAOH"/>
+		<Vector name="AOHCopies" type="numeric" nEntries="6">
+			0 , 0 , 2 , 2 , 1 , 1
+		</Vector>
+		<Vector name="AOHx" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHx] , [tobrodpar:AOHx] ,
+			[tobrodpar:AOHx] , -[tobrodpar:AOHx]
+		</Vector>
+		<Vector name="AOHy" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy] ,
+			[tobrodpar:AOHy] , -[tobrodpar:AOHy]
+		</Vector>
+		<Vector name="AOHz" type="numeric" nEntries="6">
+			[zero] , [zero] ,
+			[tobrodpar:AOHz] , -[tobrodpar:AOHz] ,
+			[zero] , [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tobrodpar.xml
+++ b/DetectorDescription/DDCMS/data/tobrodpar.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrodpar.xml" eval="true">
+		<Constant name="RodW" value="8.250*cm"/>
+		<Constant name="RodT" value="1.000*cm"/>
+		<Constant name="RodL" value="110.80*cm"/>
+		<Constant name="RodDL" value="1.00*cm"/>
+		<Constant name="CentralRodW" value="6.250*cm"/>
+		<Constant name="SideRodW" value="0.600*cm"/>
+		<Constant name="SideRodT" value="0.060*cm"/>
+		<Constant name="SideRodX" value="6.850*cm"/>
+		<Constant name="RodY" value="0.790*cm"/>
+		<Constant name="EndRod1Z" value="110.2*cm"/>
+		<Constant name="EndRodT" value="0.055*cm"/>
+		<Constant name="EndRodL" value="1.300*cm"/>
+		<Constant name="EndRod2Y" value="0.845*cm"/>
+		<Constant name="EndRod2Z" value="2.450*cm"/>
+		<Constant name="CoolTubeLightR" value="0.110*cm"/>
+		<Constant name="CoolTubeHeavyR" value="0.125*cm"/>
+		<Constant name="CoolFluidLightR" value="0.100*cm"/>
+		<Constant name="CoolFluidHeavyR" value="0.115*cm"/>
+		<Constant name="SideCoolL" value="53.95*cm"/>
+		<Constant name="SideCoolX" value="6.550*cm"/>
+		<Constant name="SideCoolY" value="0.200*cm"/>
+		<Constant name="SideCoolZ" value="56.85*cm"/>
+		<Constant name="EndCoolL" value="6.250*cm"/>
+		<Constant name="EndCoolY" value="0.200*cm"/>
+		<Constant name="EndCoolZ" value="3.100*cm"/>
+		<Constant name="OptFibreW" value="0.150*cm"/>
+		<Constant name="OptFibreH" value="0.330*cm"/>
+		<Constant name="OptFibreL" value="37.50*cm"/>
+		<Constant name="OptFibreX" value="7.100*cm"/>
+		<Constant name="OptFibreZ" value="63.35*cm"/>
+		<Constant name="ClampDx" value="0.350*cm"/>
+		<Constant name="ClampDy" value="0.780*cm"/>
+		<Constant name="ClampDz" value="0.850*cm"/>
+		<Constant name="ClampX" value="7.850*cm"/>
+		<Constant name="ClampZ1" value="109.0*cm"/>
+		<Constant name="ClampZ2" value="29.00*cm"/>
+		<Constant name="SideClampDx" value="0.575*cm"/>
+		<Constant name="SideClampDy" value="0.145*cm"/>
+		<Constant name="SideClampLDz" value="1.900*cm"/>
+		<Constant name="SideClampHDz" value="2.000*cm"/>
+		<Constant name="SideClampX" value="6.825*cm"/>
+		<Constant name="SideClamp1Z" value="2.125*cm"/>
+		<Constant name="SideClamp2Z" value="9.775*cm"/>
+		<Constant name="CableDx" value="2.500*cm"/>
+		<Constant name="CableDy" value="0.050*cm"/>
+		<Constant name="CableDz" value="38.25*cm"/>
+		<Constant name="CableZ" value="62.25*cm"/>
+		<Constant name="ICCDx" value="5.900*cm"/>
+		<Constant name="ICCDy" value="0.125*cm"/>
+		<Constant name="ICC1Dz" value="2.200*cm"/>
+		<Constant name="ICC2Dz" value="3.400*cm"/>
+		<Constant name="ConnDx" value="5.900*cm"/>
+		<Constant name="ConnDy" value="0.250*cm"/>
+		<Constant name="ConnDz" value="3.750*cm"/>
+		<Constant name="CCUMDx" value="5.900*cm"/>
+		<Constant name="CCUMDy" value="0.125*cm"/>
+		<Constant name="CCUMDz" value="3.500*cm"/>
+		<Constant name="ModuleY" value="0.5425*cm"/>
+		<Constant name="ModuleZ01" value="-96.8564*cm"/>
+		<Constant name="ModuleZ02" value="-78.3454*cm"/>
+		<Constant name="ModuleZ03" value="-65.5084*cm"/>
+		<Constant name="ModuleZ04" value="-47.1914*cm"/>
+		<Constant name="ModuleZ05" value="-29.4404*cm"/>
+		<Constant name="ModuleZ06" value="-11.3564*cm"/>
+		<Constant name="ModuleZ07" value="11.3564*cm"/>
+		<Constant name="ModuleZ08" value="29.4404*cm"/>
+		<Constant name="ModuleZ09" value="48.1014*cm"/>
+		<Constant name="ModuleZ10" value="65.5084*cm"/>
+		<Constant name="ModuleZ11" value="80.1174*cm"/>
+		<Constant name="ModuleZ12" value="96.8564*cm"/>
+		<Constant name="ICCY1" value="0.525*cm"/>
+		<Constant name="ICCY2" value="0.400*cm"/>
+		<Constant name="ICCZ01" value="-105.00*cm"/>
+		<Constant name="ICCZ02" value="-96.60*cm"/>
+		<Constant name="ICCZ03" value="-81.20*cm"/>
+		<Constant name="ICCZ04" value="-62.75*cm"/>
+		<Constant name="ICCZ05" value="-44.05*cm"/>
+		<Constant name="ICCZ06" value="-25.85*cm"/>
+		<Constant name="ICCZ07" value="25.85*cm"/>
+		<Constant name="ICCZ08" value="44.05*cm"/>
+		<Constant name="ICCZ09" value="64.10*cm"/>
+		<Constant name="ICCZ10" value="81.20*cm"/>
+		<Constant name="ICCZ11" value="96.60*cm"/>
+		<Constant name="ICCZ12" value="105.00*cm"/>
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="Tol" value="0.0*mm"/>
+		<Constant name="AOHDx" value="0.5*3.000*cm"/>
+		<Constant name="AOHDy" value="0.5*0.200*cm"/>
+		<Constant name="AOHDz" value="0.5*2.300*cm"/>
+		<Constant name="AOHx" value="[ICCDx]-[AOHDx]-13*mm"/>
+		<Constant name="AOHy" value="[ICCDy]+[AOHDy]+[Tol]"/>
+		<Constant name="AOHz" value="12*mm"/>
+	</ConstantsSection>
+	<RotationSection label="tobrodpar.xml">
+		<Rotation name="000D" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="0*deg" phiZ="0*deg"/>
+		<Rotation name="180D" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="90*deg" thetaZ="180*deg" phiZ="0*deg"/>
+		<Rotation name="180X" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="-90*deg" thetaZ="180*deg" phiZ="0*deg"/>
+		<Rotation name="90XD" thetaX="90*deg" phiX="90*deg" thetaY="0*deg" phiY="0*deg" thetaZ="90*deg" phiZ="0*deg"/>
+		<Rotation name="R180" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="-90*deg" thetaZ="0*deg" phiZ="0*deg"/>
+	</RotationSection>
+	<SolidSection label="tobrodpar.xml">
+		<Box name="TOBSideRod1" dx="[SideRodW]" dy="[SideRodT]" dz="([RodL]+[RodDL])/2"/>
+		<Box name="TOBSideRod2" dx="[SideRodW]" dy="[SideRodT]" dz="([RodL]-[RodDL])/2"/>
+		<Box name="TOBEndRod1" dx="[CentralRodW]" dy="[SideRodT]" dz="[SideRodW]"/>
+		<Box name="TOBEndRod2" dx="[CentralRodW]" dy="[EndRodT]" dz="[EndRodL]"/>
+		<Box name="TOBClamp" dx="[ClampDx]" dy="[ClampDy]" dz="[ClampDz]"/>
+		<Box name="TOBCable" dx="[CableDx]" dy="[CableDy]" dz="[CableDz]"/>
+		<Box name="TOBICC1" dx="[ICCDx]" dy="[ICCDy]" dz="[ICC1Dz]"/>
+		<Box name="TOBICC2" dx="[ICCDx]" dy="[ICCDy]" dz="[ICC2Dz]"/>
+		<Box name="TOBRodConn" dx="[ConnDx]" dy="[ConnDy]" dz="[ConnDz]"/>
+		<Box name="TOBCCUM" dx="[CCUMDx]" dy="[CCUMDy]" dz="[CCUMDz]"/>
+		<Box name="TOBRod" dx="[RodW]" dy="[RodT]" dz="[RodL]"/>
+		<Box name="TOBRodout" dx="[RodW]" dy="[RodT]" dz="([RodL]+[RodDL])/2"/>
+		<Box name="TOBRodin" dx="[RodW]+[Tol]" dy="([RodT]/2+[Tol])" dz="[RodDL]"/>
+		<Box name="TOBAOH" dx="[AOHDx]" dy="[AOHDy]" dz="[AOHDz]"/>
+		<SubtractionSolid name="TOBRodL">
+			<rSolid name="TOBRodout"/>
+			<rSolid name="TOBRodin"/>
+			<rRotation name="tobrodpar:000D"/>
+			<Translation x="[zero]" y="[RodT]/2" z="([RodL]-[RodDL])/2"/>
+		</SubtractionSolid>
+		<SubtractionSolid name="TOBRodH">
+			<rSolid name="TOBRodout"/>
+			<rSolid name="TOBRodin"/>
+			<rRotation name="tobrodpar:000D"/>
+			<Translation x="[zero]" y="-[RodT]/2" z="-([RodL]-[RodDL])/2"/>
+		</SubtractionSolid>
+		<Box name="TOBRod1Cent" dx="[CentralRodW]" dy="[RodT]" dz="([RodL]+[RodDL])/2"/>
+		<Box name="TOBRod2Cent" dx="([CentralRodW]+[Tol])" dy="([RodT]/2+[Tol])" dz="[RodDL]"/>
+		<SubtractionSolid name="TOBRodCentralL">
+			<rSolid name="TOBRod1Cent"/>
+			<rSolid name="TOBRod2Cent"/>
+			<rRotation name="tobrodpar:000D"/>
+			<Translation x="[zero]" y="[RodT]/2" z="([RodL]-[RodDL])/2"/>
+		</SubtractionSolid>
+		<SubtractionSolid name="TOBRodCentralH">
+			<rSolid name="TOBRod1Cent"/>
+			<rSolid name="TOBRod2Cent"/>
+			<rRotation name="tobrodpar:000D"/>
+			<Translation x="[zero]" y="-[RodT]/2" z="-([RodL]-[RodDL])/2"/>
+		</SubtractionSolid>
+	</SolidSection>
+	<LogicalPartSection label="tobrodpar.xml">
+		<LogicalPart name="TOBSideRod1" category="unspecified">
+			<rSolid name="TOBSideRod1"/>
+			<rMaterial name="tobmaterial:TOB_rod"/>
+		</LogicalPart>
+		<LogicalPart name="TOBSideRod2" category="unspecified">
+			<rSolid name="TOBSideRod2"/>
+			<rMaterial name="tobmaterial:TOB_rod"/>
+		</LogicalPart>
+		<LogicalPart name="TOBEndRod1" category="unspecified">
+			<rSolid name="TOBEndRod1"/>
+			<rMaterial name="tobmaterial:TOB_rod"/>
+		</LogicalPart>
+		<LogicalPart name="TOBEndRod2" category="unspecified">
+			<rSolid name="TOBEndRod2"/>
+			<rMaterial name="tobmaterial:TOB_rod"/>
+		</LogicalPart>
+		<LogicalPart name="TOBClamp" category="unspecified">
+			<rSolid name="TOBClamp"/>
+			<rMaterial name="tobmaterial:TOB_plate_A"/>
+		</LogicalPart>
+		<LogicalPart name="TOBCable" category="unspecified">
+			<rSolid name="TOBCable"/>
+			<rMaterial name="tobmaterial:TOB_ICB"/>
+		</LogicalPart>
+		<LogicalPart name="TOBAOH" category="unspecified">
+			<rSolid name="TOBAOH"/>
+			<rMaterial name="tobmaterial:TOB_AOH"/>
+		</LogicalPart>
+	</LogicalPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/tracker.xml
+++ b/DetectorDescription/DDCMS/data/tracker.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="tobrodpar.xml" eval="true">
+		<Constant name="BackPlaneDz" value="0.015*mm"/>
+	</ConstantsSection>
+	<SolidSection label="tracker.xml">
+		<Polycone name="Tracker" startPhi="0*deg" deltaPhi="360*deg">
+			<ZSection z="-[cms:TrackBeamZ2]" rMin="[cms:TrackBeamR2]" rMax="[cms:TrackCalorR]"/>
+			<ZSection z="-[cms:TrackBeamZ1]" rMin="[cms:TrackBeamR1]" rMax="[cms:TrackCalorR]"/>
+			<ZSection z="[cms:TrackBeamZ1]" rMin="[cms:TrackBeamR1]" rMax="[cms:TrackCalorR]"/>
+			<ZSection z="[cms:TrackBeamZ2]" rMin="[cms:TrackBeamR2]" rMax="[cms:TrackCalorR]"/>
+		</Polycone>
+	</SolidSection>
+	<LogicalPartSection label="tracker.xml">
+		<LogicalPart name="Tracker" category="unspecified">
+			<rSolid name="Tracker"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<RotationSection label="tracker.xml">
+		<Rotation name="180D" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="90*deg" thetaZ="180*deg" phiZ="0*deg"/>
+		<Rotation name="R180" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="-90*deg" thetaZ="0*deg" phiZ="0*deg"/>
+		<Rotation name="PAA" thetaX="180*deg" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="90*deg" phiZ="0*deg"/>
+	</RotationSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/trackerParameters.xml
+++ b/DetectorDescription/DDCMS/data/trackerParameters.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <ConstantsSection  label="trackerParameters.xml" eval="true">
+  <Vector name="vPars" type="numeric" nEntries="6">
+    80, 52, 1, 2, 0, 0
+  </Vector>
+  <Vector name="Subdetector1" type="numeric" nEntries="6">
+    16, 8, 2, 0xF, 0xFF, 0x3F
+  </Vector>
+  <Vector name="Subdetector2" type="numeric" nEntries="10">
+    23, 16, 10, 8, 2, 0x3, 0xF, 0x3F, 0x3, 0x3F
+  </Vector>
+  <Vector name="Subdetector3" type="numeric" nEntries="12">
+    14, 12, 10, 4, 2, 0, 0x7, 0x3, 0x3, 0x3F, 0x3, 0x3
+  </Vector>
+  <Vector name="Subdetector4" type="numeric" nEntries="12">
+    13, 11, 9, 7, 2, 0, 0x3, 0x3, 0x3, 0x3, 0x1F, 0x3
+  </Vector>
+  <Vector name="Subdetector5" type="numeric" nEntries="10">
+    14, 12, 5, 2, 0, 0x7, 0x3, 0x7F, 0x7, 0x3
+  </Vector>
+  <Vector name="Subdetector6" type="numeric" nEntries="14">
+    18, 14, 12, 8, 5, 2, 0, 0x3, 0xF, 0x3, 0xF, 0x7, 0x7, 0x3
+  </Vector>
+  <Vector name="detIdShifts" type="numeric" nEntries="36">
+    -1, 23, -1,
+    13, -1, 18,
+
+    16, 16, 14,
+    11, 14, 14,
+    
+     8,  8,  4,
+     9,  5,  8,
+
+     2,  2,  2,
+     2,  2,  5,
+
+     0,  0,  0,
+     0,  0,  2,
+
+    -1, -1, -1,
+    -1, -1,  0
+  </Vector>
+ </ConstantsSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/trackerStructureTopology.xml
+++ b/DetectorDescription/DDCMS/data/trackerStructureTopology.xml
@@ -1,0 +1,321 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <SpecParSection label="spec-pars2.xml">
+    <SpecPar name="FullTrackerPar">
+      <PartSelector path="//Tracker"/>
+      <Parameter name="TkDDDStructure" value="FullTracker"/>
+    </SpecPar>
+    <SpecPar name="PixelBarrelSubDetPar">
+      <PartSelector path="//PixelBarrel"/>
+      <Parameter name="TkDDDStructure" value="PixelBarrel"/>
+    </SpecPar>
+    <SpecPar name="PixelBarrelLayerPar">
+      <PartSelector path="//PixelBarrelLayer0"/>
+      <PartSelector path="//PixelBarrelLayer1"/>
+      <PartSelector path="//PixelBarrelLayer2"/>
+      <Parameter name="TkDDDStructure" value="PixelBarrelLayer"/>
+    </SpecPar>
+    <SpecPar name="PixelBarrelLadderPar">
+      <PartSelector path="//PixelBarrelLadderHalf"/>
+      <PartSelector path="//PixelBarrelLadderFull"/>
+      <Parameter name="TkDDDStructure" value="PixelBarrelLadder"/>
+    </SpecPar>
+    <SpecPar name="PixelBarrelModulePar">
+      <PartSelector path="//PixelBarrelActiveFull"/>
+      <PartSelector path="//PixelBarrelActiveHalf"/>
+      <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
+    </SpecPar>
+    <SpecPar name="PixelEndcapSubDetPar">
+      <PartSelector path="//PixelForwardZPlus"/>
+      <PartSelector path="//PixelForwardZMinus"/>
+      <Parameter name="TkDDDStructure" value="PixelEndcapSubDet"/>
+    </SpecPar>
+    <SpecPar name="PixelEndcapDiskPar">
+      <PartSelector path="//PixelForwardDiskZMinus"/>
+      <PartSelector path="//PixelForwardDiskZPlus"/>
+      <Parameter name="TkDDDStructure" value="PixelEndcapDisk"/>
+    </SpecPar>
+    <SpecPar name="PixelEndcapPanelPar">
+      <PartSelector path="//PixelForwardPanel3Left"/>
+      <PartSelector path="//PixelForwardPanel3Right"/>
+      <PartSelector path="//PixelForwardPanel4Right"/>
+      <PartSelector path="//PixelForwardPanel4Left"/>
+      <Parameter name="TkDDDStructure" value="PixelEndcapPanel"/>
+    </SpecPar>
+    <SpecPar name="PixelEndcapDetPar">
+      <PartSelector path="//PixelForwardActive1x2"/>
+      <PartSelector path="//PixelForwardActive1x5"/>
+      <PartSelector path="//PixelForwardActive2x3"/>
+      <PartSelector path="//PixelForwardActive2x4"/>
+      <PartSelector path="//PixelForwardActive2x5"/>
+      <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
+    </SpecPar>
+    <SpecPar name="TIBSubDetPar">
+      <PartSelector path="//TIB"/>
+      <Parameter name="TkDDDStructure" value="TIB"/>
+    </SpecPar>
+    <SpecPar name="TIBSubDetLayerPar">
+      <PartSelector path="//TIBLayer0"/>
+      <PartSelector path="//TIBLayer1"/>
+      <PartSelector path="//TIBLayer2"/>
+      <PartSelector path="//TIBLayer3"/>
+      <Parameter name="TkDDDStructure" value="TIBLayer"/>
+    </SpecPar>
+    <!--definire plus e minus-->
+    <SpecPar name="TIBSubDetStringPar">
+      <PartSelector path="//TIBString0LoMin1"/>
+      <PartSelector path="//TIBString0LoPls1"/>
+      <PartSelector path="//TIBString0UpMin1"/>
+      <PartSelector path="//TIBString0UpPls1"/>
+      <PartSelector path="//TIBString1LoMin1"/>
+      <PartSelector path="//TIBString1LoPls1"/>
+      <PartSelector path="//TIBString1UpMin1"/>
+      <PartSelector path="//TIBString1UpPls1"/>
+      <PartSelector path="//TIBString2LoMin1"/>
+      <PartSelector path="//TIBString2LoPls1"/>
+      <PartSelector path="//TIBString2UpMin1"/>
+      <PartSelector path="//TIBString2UpPls1"/>
+      <PartSelector path="//TIBString3LoMin1"/>
+      <PartSelector path="//TIBString3LoPls1"/>
+      <PartSelector path="//TIBString3UpMin1"/>
+      <PartSelector path="//TIBString3UpPls1"/>
+      <Parameter name="TkDDDStructure" value="TIBString"/>
+    </SpecPar>
+    <SpecPar name="TIBSubDetGluedDetPar">
+      <PartSelector path="//TIBModule0A"/>
+      <PartSelector path="//TIBModule0B"/>
+      <Parameter name="TkDDDStructure" value="TIBGluedDet"/>
+    </SpecPar>
+    <SpecPar name="TIBSubDetDetPar">
+      <PartSelector path="//TIBActiveRphi0"/>
+      <PartSelector path="//TIBActiveSter0"/>
+      <PartSelector path="//TIBActiveRphi2"/>
+      <Parameter name="TkDDDStructure" value="TIBDet"/>
+    </SpecPar>
+    <SpecPar name="TIDSubDetPar">
+      <PartSelector path="//TIDB"/>
+      <PartSelector path="//TIDF"/>
+      <Parameter name="TkDDDStructure" value="TID"/>
+    </SpecPar>
+    <SpecPar name="TIDSubDetWheelPar">
+      <PartSelector path="//TIDWheelB"/>
+      <PartSelector path="//TIDWheelF"/>
+      <Parameter name="TkDDDStructure" value="TIDWheel"/>
+    </SpecPar>
+    <SpecPar name="TIDSubDetRingPar">
+      <PartSelector path="//TIDRing0F"/>
+      <PartSelector path="//TIDRing1F"/>
+      <PartSelector path="//TIDRing0B"/>
+      <PartSelector path="//TIDRing1B"/>
+      <PartSelector path="//TIDRing2"/>
+      <Parameter name="TkDDDStructure" value="TIDRing"/>
+    </SpecPar>
+    <SpecPar name="TIDSubDetGluedDetPar">
+      <PartSelector path="//TIDModule0L"/>
+      <PartSelector path="//TIDModule0R"/>
+      <PartSelector path="//TIDModule1L"/>
+      <PartSelector path="//TIDModule1R"/>
+      <Parameter name="TkDDDStructure" value="TIDGluedDet"/>
+    </SpecPar>
+    <SpecPar name="TIDSubDetDetPar">
+      <PartSelector path="//TIDModule0RphiActive"/>
+      <PartSelector path="//TIDModule0StereoActive"/>
+      <PartSelector path="//TIDModule1RphiActive"/>
+      <PartSelector path="//TIDModule1StereoActive"/>
+      <PartSelector path="//TIDModule2RphiActive"/>
+      <Parameter name="TkDDDStructure" value="TIDDet"/>
+    </SpecPar>
+    <SpecPar name="TOBSubDetPar">
+      <PartSelector path="//TOB"/>
+      <Parameter name="TkDDDStructure" value="TOB"/>
+    </SpecPar>
+    <SpecPar name="TOBSubDetLayerPar">
+      <PartSelector path="//TOBLayer0"/>
+      <PartSelector path="//TOBLayer1"/>
+      <PartSelector path="//TOBLayer2"/>
+      <PartSelector path="//TOBLayer3"/>
+      <PartSelector path="//TOBLayer4"/>
+      <PartSelector path="//TOBLayer5"/>
+      <Parameter name="TkDDDStructure" value="TOBLayer"/>
+    </SpecPar>
+    <SpecPar name="TOBSubDetRodPar">
+      <PartSelector path="//TOBRod0L"/>
+      <PartSelector path="//TOBRod0H"/>
+      <PartSelector path="//TOBRod1L"/>
+      <PartSelector path="//TOBRod1H"/>
+      <PartSelector path="//TOBRod2L"/>
+      <PartSelector path="//TOBRod2H"/>
+      <PartSelector path="//TOBRod3L"/>
+      <PartSelector path="//TOBRod3H"/>
+      <PartSelector path="//TOBRod4L"/>
+      <PartSelector path="//TOBRod4H"/>
+      <PartSelector path="//TOBRod5L"/>
+      <PartSelector path="//TOBRod5H"/>
+      <Parameter name="TkDDDStructure" value="TOBRod"/>
+    </SpecPar>
+    <SpecPar name="TOBSubDetGluedDetPar">
+      <PartSelector path="//TOBModule0"/>
+      <Parameter name="TkDDDStructure" value="TOBGluedDet"/>
+    </SpecPar>
+    <SpecPar name="TOBSubDetDetPar">
+      <PartSelector path="//TOBActiveRphi0"/>
+      <PartSelector path="//TOBActiveSter0"/>
+      <PartSelector path="//TOBActiveRphi2"/>
+      <PartSelector path="//TOBActiveRphi4"/>
+      <Parameter name="TkDDDStructure" value="TOBDet"/>
+    </SpecPar>
+    <SpecPar name="TECSubDetPar">
+      <PartSelector path="//TEC"/>
+      <Parameter name="TkDDDStructure" value="TEC"/>
+    </SpecPar>
+    <SpecPar name="TECSubDetWheelPar">
+      <PartSelector path="//TECWheelA"/>
+      <PartSelector path="//TECWheelB"/>
+      <PartSelector path="//TECWheel6"/>
+      <!-- special disk that contains the beamsplitters (for alignment)-->
+      <PartSelector path="//TECWheelC"/>
+      <PartSelector path="//TECWheelD"/>
+      <Parameter name="TkDDDStructure" value="TECWheel"/>
+    </SpecPar>
+    <SpecPar name="TECSubDetPetalPar">
+      <PartSelector path="//TECPetalCont0F"/>
+      <PartSelector path="//TECPetalCont0B"/>
+      <PartSelector path="//TECPetalCont3F"/>
+      <PartSelector path="//TECPetalCont3B"/>
+      <PartSelector path="//TECPetalCont6F"/>
+      <PartSelector path="//TECPetalCont6B"/>
+      <PartSelector path="//TECPetalCont8F"/>
+      <PartSelector path="//TECPetalCont8B"/>
+      <Parameter name="TkDDDStructure" value="TECPetal"/>
+    </SpecPar>
+    <SpecPar name="TECSubDetRingPar">
+      <PartSelector path="//TECRing0F"/>
+      <PartSelector path="//TECRing0B"/>
+      <PartSelector path="//TECRing1F"/>
+      <PartSelector path="//TECRing1B"/>
+      <PartSelector path="//TECRing2F"/>
+      <PartSelector path="//TECRing2B"/>
+      <PartSelector path="//TECRing3F"/>
+      <PartSelector path="//TECRing3B"/>
+      <PartSelector path="//TECRing4F"/>
+      <PartSelector path="//TECRing4B"/>
+      <PartSelector path="//TECRing5F"/>
+      <PartSelector path="//TECRing5B"/>
+      <PartSelector path="//TECRing6F"/>
+      <PartSelector path="//TECRing6B"/>
+      <Parameter name="TkDDDStructure" value="TECRing"/>
+    </SpecPar>
+    <SpecPar name="TECSubDetGluedDetPar">
+      <PartSelector path="//TECModule0"/>
+      <PartSelector path="//TECModule1"/>
+      <PartSelector path="//TECModule4"/>
+      <Parameter name="TkDDDStructure" value="TECGluedDet"/>
+    </SpecPar>
+    <SpecPar name="TECSubDetDetPar">
+      <PartSelector path="//TECModule0RphiActive"/>
+      <PartSelector path="//TECModule0StereoActive"/>
+      <PartSelector path="//TECModule1RphiActive"/>
+      <PartSelector path="//TECModule1StereoActive"/>
+      <PartSelector path="//TECModule2RphiActive"/>
+      <PartSelector path="//TECModule3RphiActive"/>
+      <PartSelector path="//TECModule4RphiActive"/>
+      <PartSelector path="//TECModule4StereoActive"/>
+      <PartSelector path="//TECModule5RphiActive"/>
+      <PartSelector path="//TECModule6RphiActive"/>
+      <Parameter name="TkDDDStructure" value="TECDet"/>
+    </SpecPar>
+    <SpecPar name="TrackerStereoDetectorsPar">
+      <PartSelector path="//TIBActiveSter0"/>
+      <PartSelector path="//TIDModule0StereoActive"/>
+      <PartSelector path="//TIDModule1StereoActive"/>
+      <PartSelector path="//TOBActiveSter0"/>
+      <PartSelector path="//TECModule0StereoActive"/>
+      <PartSelector path="//TECModule1StereoActive"/>
+      <PartSelector path="//TECModule4StereoActive"/>
+      <Parameter name="TrackerStereoDetectors" value="true"/>
+    </SpecPar>
+    <SpecPar name="TrackerAPVNumber6Par">
+      <PartSelector path="//TIBActiveRphi0"/>
+      <PartSelector path="//TIBActiveSter0"/>
+      <PartSelector path="//TIDModule0RphiActive"/>
+      <PartSelector path="//TIDModule0StereoActive"/>
+      <PartSelector path="//TIDModule1RphiActive"/>
+      <PartSelector path="//TIDModule1StereoActive"/>
+      <PartSelector path="//TOBActiveRphi4"/>
+      <PartSelector path="//TECModule0RphiActive"/>
+      <PartSelector path="//TECModule0StereoActive"/>
+      <PartSelector path="//TECModule1RphiActive"/>
+      <PartSelector path="//TECModule1StereoActive"/>
+      <PartSelector path="//TECModule4RphiActive"/>
+      <PartSelector path="//TECModule4StereoActive"/>
+      <Parameter name="SiliconAPVNumber" value="6"/>
+    </SpecPar>
+    <SpecPar name="TrackerAPVNumber4Par">
+      <PartSelector path="//TIBActiveRphi2"/>
+      <PartSelector path="//TIDModule2RphiActive"/>
+      <PartSelector path="//TOBActiveRphi0"/>
+      <PartSelector path="//TOBActiveSter0"/>
+      <PartSelector path="//TOBActiveRphi2"/>
+      <PartSelector path="//TECModule2RphiActive"/>
+      <PartSelector path="//TECModule3RphiActive"/>
+      <PartSelector path="//TECModule5RphiActive"/>
+      <PartSelector path="//TECModule6RphiActive"/>
+      <Parameter name="SiliconAPVNumber" value="4"/>
+    </SpecPar>
+    <SpecPar name="PixelROCRowsPar">
+      <PartSelector path="//PixelBarrelActiveFull"/>
+      <PartSelector path="//PixelBarrelActiveHalf"/>
+      <PartSelector path="//PixelForwardActive1x2"/>
+      <PartSelector path="//PixelForwardActive1x5"/>
+      <PartSelector path="//PixelForwardActive2x3"/>
+      <PartSelector path="//PixelForwardActive2x4"/>
+      <PartSelector path="//PixelForwardActive2x5"/>
+      <Parameter name="PixelROCRows" value="80"/>
+    </SpecPar>
+    <SpecPar name="PixelROCColsPar">
+      <PartSelector path="//PixelBarrelActiveFull"/>
+      <PartSelector path="//PixelBarrelActiveHalf"/>
+      <PartSelector path="//PixelForwardActive1x2"/>
+      <PartSelector path="//PixelForwardActive1x5"/>
+      <PartSelector path="//PixelForwardActive2x3"/>
+      <PartSelector path="//PixelForwardActive2x4"/>
+      <PartSelector path="//PixelForwardActive2x5"/>
+      <Parameter name="PixelROCCols" value="52"/>
+    </SpecPar>
+    <SpecPar name="PixelROC_XPar">
+      <PartSelector path="//PixelBarrelActiveFull"/>
+      <PartSelector path="//PixelForwardActive2x3"/>
+      <PartSelector path="//PixelForwardActive2x4"/>
+      <PartSelector path="//PixelForwardActive2x5"/>
+      <Parameter name="PixelROC_X" value="2"/>
+    </SpecPar>
+    <SpecPar name="PixelROC_X_HalfPar">
+      <PartSelector path="//PixelBarrelActiveHalf"/>
+      <PartSelector path="//PixelForwardActive1x2"/>
+      <PartSelector path="//PixelForwardActive1x5"/>
+      <Parameter name="PixelROC_X" value="1"/>
+    </SpecPar>
+    <SpecPar name="PixelROC_YPar">
+      <PartSelector path="//PixelBarrelActiveFull"/>
+      <PartSelector path="//PixelBarrelActiveHalf"/>
+      <Parameter name="PixelROC_Y" value="8"/>
+    </SpecPar>
+    <SpecPar name="PixelROC_Y2Par">
+      <PartSelector path="//PixelForwardActive1x2"/>
+      <Parameter name="PixelROC_Y" value="2"/>
+    </SpecPar>
+    <SpecPar name="PixelROC_Y3Par">
+      <PartSelector path="//PixelForwardActive2x3"/>
+      <Parameter name="PixelROC_Y" value="3"/>
+    </SpecPar>
+    <SpecPar name="PixelROC_Y4Par">
+      <PartSelector path="//PixelForwardActive2x4"/>
+      <Parameter name="PixelROC_Y" value="4"/>
+    </SpecPar>
+    <SpecPar name="PixelROC_Y5Par">
+      <PartSelector path="//PixelForwardActive1x5"/>
+      <PartSelector path="//PixelForwardActive2x5"/>
+      <Parameter name="PixelROC_Y" value="5"/>
+    </SpecPar>
+  </SpecParSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/trackerbulkhead.xml
+++ b/DetectorDescription/DDCMS/data/trackerbulkhead.xml
@@ -1,0 +1,293 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <ConstantsSection label="trackerbulkhead.xml" eval="true">
+  <Constant name="zero" value="0.0*fm"/>
+  <Constant name="Rin" value="190*mm"/>
+  <Constant name="Rout" value="1.233*m"/>
+  <Constant name="Thick" value="[BulkheadThick]+[BHDiskThick]+[BHCoversThick]"/>
+  <Constant name="BulkheadZ" value="[tob:Zv3]+0.5*[Thick]"/>
+  <!--should be 4mm behind TEC is at the end of tob to prevent overlaps-->
+  <Constant name="BulkheadThick" value="89*mm"/>
+  <Constant name="BulkheadRout" value="1053*mm"/>
+  <Constant name="BulkheadRin" value="[tecpetal3:PetalContRmin]"/>
+  <Constant name="PatchpanelR4" value="1105*mm"/>
+  <!-- inside of the outer cable region. NOTE: there is a (historical?) gap between R3 and R4 -->
+  <Constant name="PatchpanelR3" value="[BulkheadRout]"/>
+  <!-- outside of bulkhead region-->
+  <Constant name="PatchpanelR2" value="645*mm"/>
+  <!-- outside of the inner pixel region-->
+  <Constant name="PatchpanelR1" value="[AlignRingRout]"/>
+  <!-- inside of the inner pixel region-->
+  <Constant name="PatchpanelThick" value="[BulkheadThick]"/>
+  <Constant name="TECPatchpanelWidth" value="35*deg"/>
+  <!-- <Constant name="PIXPatchpanelWidth1" value="20*deg"/> -->
+  <Constant name="PIXPatchpanelWidth1" value="10*deg"/>
+  <Constant name="PIXPatchpanelWidth2" value="160*deg"/>
+  <Constant name="PIXPatchpanelPhi" value="-100*deg"/>
+  <Constant name="TECPatchpanelPhi" value="10*deg"/>
+  <Constant name="PpBoxWidth" value="175*mm"/>
+  <!-- <Constant name="PpBoxLengthL" value="298.19*mm"/> -->
+  <Constant name="PpConnectorsLength" value="50.*mm"/>
+  <Constant name="PpConnectorsThick"  value="15.*mm"/>
+  <!-- <Constant name="PpBoxLengthL" value="154.96*mm"/> -->
+  <!-- <Constant name="PpBoxLengthL" value="129.96*mm"/> -->
+  <Constant name="PpBoxLengthL" value="104.96*mm"/>
+  <!-- <Constant name="PpBoxLengthS" value="143.23*mm"/> -->
+  <!-- <Constant name="PpBoxLengthS" value="118.23*mm"/> -->
+  <Constant name="PpBoxLengthS" value="93.23*mm"/>
+  <Constant name="PpBoxThick" value="0.5*43.43*mm"/>
+  <Constant name="PpBoxSideX" value="20.2*mm"/>
+  <Constant name="PpBoxSideY" value="12.5*mm"/>
+  <Constant name="PpBoxDistX" value="35*mm"/>
+  <Constant name="PpBoxDistY" value="14*mm"/>
+  <Constant name="CtrlBoxWidth" value="75*mm"/>
+  <Constant name="CtrlBoxLength" value="195*mm"/>
+  <Constant name="CtrlBoxThick" value="25*mm"/>
+  <Constant name="CtrlBoxDistX" value="73.35*mm"/>
+  <Constant name="CtrlBoxDistY" value="12.85*mm"/>
+  <Constant name="AlignRingRin" value="235*mm"/>
+  <Constant name="AlignRingRout" value="365*mm"/>
+  <Constant name="AlignRingThick" value="48.5*mm"/>
+  <Constant name="PixelCablesRin" value="[Rin]"/>
+  <!-- cables going to pixel patchpanel -->
+  <Constant name="PixelCablesRout" value="[AlignRingRout]"/>
+  <Constant name="PixelCablesThick" value="12.2*mm"/>
+  <Constant name="BHDiskRin" value="[BulkheadRin]"/>
+  <Constant name="BHDiskRout" value="[BulkheadRout]"/>
+  <Constant name="BHDiskThick" value="5*mm"/>
+  <Constant name="BHCoversRin" value="[BulkheadRin]"/>
+  <Constant name="BHCoversRout" value="[BulkheadRout]"/>
+  <Constant name="BHCoversThick" value="1.1*mm"/>
+ </ConstantsSection>
+ <SolidSection label="trackerbulkhead.xml">
+  <Tubs name="TrackerBulkhead" rMin="[Rin]" rMax="[Rout]" dz="0.5*[Thick]" startPhi="0*deg" deltaPhi="360*deg"/>
+  <Tubs name="BHDisk" rMin="[BHDiskRin]" rMax="[BHDiskRout]" dz="0.5*[BHDiskThick]" startPhi="0*deg" deltaPhi="360*deg"/>
+  <Tubs name="BHCovers" rMin="[BHCoversRin]" rMax="[BHCoversRout]" dz="0.5*[BHCoversThick]" startPhi="0*deg" deltaPhi="360*deg"/>
+  <Tubs name="OuterCables" rMin="[PatchpanelR4]" rMax="[Rout]" dz="0.5*[Thick]" startPhi="0*deg" deltaPhi="360*deg"/>
+  <Tubs name="TECPatchpanel" rMin="[PatchpanelR2]" rMax="[PatchpanelR3]" dz="0.5*[PatchpanelThick]" startPhi="-[TECPatchpanelWidth]" deltaPhi="[TECPatchpanelWidth]"/>
+  <Tubs name="PIXPatchpanel1" rMin="[PatchpanelR1]" rMax="[PatchpanelR3]" dz="0.5*[PatchpanelThick]" startPhi="-2*[PIXPatchpanelWidth1]" deltaPhi="[PIXPatchpanelWidth1]"/>
+  <Tubs name="PIXPatchpanel1b" rMin="[PatchpanelR1]" rMax="[PatchpanelR3]" dz="0.5*[PatchpanelThick]" startPhi="-2*[PIXPatchpanelWidth1]" deltaPhi="[PIXPatchpanelWidth1]"/>
+  <Tubs name="PIXPatchpanel2" rMin="[PatchpanelR1]" rMax="[PatchpanelR2]" dz="0.5*[PatchpanelThick]" startPhi="-[PIXPatchpanelWidth2]" deltaPhi="[PIXPatchpanelWidth2]"/>
+  <Tubs name="TECAlignRing" rMin="[AlignRingRin]" rMax="[AlignRingRout]" dz="0.5*[AlignRingThick]" startPhi="0*deg" deltaPhi="360*deg"/>
+  <Tubs name="PixelCables" rMin="[PixelCablesRin]" rMax="[PixelCablesRout]" dz="0.5*[PixelCablesThick]" startPhi="0*deg" deltaPhi="360*deg"/>
+  <Box name="TECPpConnectors" dx="0.5*[PpConnectorsLength]" dy="0.5*[PpBoxWidth]" dz="0.5*[PpConnectorsThick]"/>
+  <Box name="TECPpBoxC" dx="0.5*[PpConnectorsLength]" dy="0.5*[PpBoxWidth]" dz="0.5*[PpBoxThick]"/>
+  <Box name="TECPpBoxL" dx="0.5*[PpBoxLengthL]" dy="0.5*[PpBoxWidth]" dz="0.5*[PpBoxThick]"/>
+  <Box name="TECPpBoxS" dx="0.5*[PpBoxLengthS]" dy="0.5*[PpBoxWidth]" dz="[PpBoxThick]"/>
+  <Box name="TECCtrlBox" dx="0.5*[CtrlBoxLength]" dy="0.5*[CtrlBoxWidth]" dz="0.5*[CtrlBoxThick]"/>
+ </SolidSection>
+ <LogicalPartSection label="trackerbulkhead.xml">
+  <LogicalPart name="TrackerBulkhead" category="unspecified">
+   <rSolid name="trackerbulkhead:TrackerBulkhead"/>
+   <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="BHDisk" category="unspecified">
+   <rSolid name="BHDisk"/>
+   <rMaterial name="tecmaterial:TEC_BHDisk"/>
+  </LogicalPart>
+  <LogicalPart name="BHCovers" category="unspecified">
+   <rSolid name="BHCovers"/>
+   <rMaterial name="tecmaterial:TEC_BHCovers"/>
+  </LogicalPart>
+  <LogicalPart name="OuterCables" category="unspecified">
+   <rSolid name="trackerbulkhead:OuterCables"/>
+   <rMaterial name="trackermaterial:Tk_panels_up"/>
+  </LogicalPart>
+  <LogicalPart name="TECPatchpanel" category="unspecified">
+   <rSolid name="trackerbulkhead:TECPatchpanel"/>
+   <rMaterial name="materials:Air"/>
+  </LogicalPart>
+  <LogicalPart name="PIXPatchpanel1" category="unspecified">
+   <rSolid name="trackerbulkhead:PIXPatchpanel1"/>
+   <rMaterial name="trackermaterial:Tk_panels_mid1"/>
+  </LogicalPart>
+  <LogicalPart name="PIXPatchpanel1b" category="unspecified">
+   <rSolid name="trackerbulkhead:PIXPatchpanel1b"/>
+   <rMaterial name="trackermaterial:Tk_panels_mid1b"/>
+  </LogicalPart>
+  <LogicalPart name="PIXPatchpanel2" category="unspecified">
+   <rSolid name="trackerbulkhead:PIXPatchpanel2"/>
+   <rMaterial name="trackermaterial:Tk_panels_mid2"/>
+  </LogicalPart>
+  <LogicalPart name="TECAlignRing" category="unspecified">
+   <rSolid name="trackerbulkhead:TECAlignRing"/>
+   <rMaterial name="tecmaterial:TEC_AlignRing"/>
+  </LogicalPart>
+  <LogicalPart name="PixelCables" category="unspecified">
+   <rSolid name="trackerbulkhead:PixelCables"/>
+   <rMaterial name="pixbarmaterial:PixelBarrelSupTubCables"/>
+  </LogicalPart>
+  <LogicalPart name="TECPpConnectors" category="unspecified">
+   <rSolid name="trackerbulkhead:TECPpConnectors"/>
+   <rMaterial name="tecmaterial:TEC_Connectors"/>
+  </LogicalPart>
+  <LogicalPart name="TECPpBoxC" category="unspecified">
+   <rSolid name="trackerbulkhead:TECPpBoxC"/>
+   <rMaterial name="tecmaterial:TEC_PatchpanelBox"/>
+  </LogicalPart>
+  <LogicalPart name="TECPpBoxL" category="unspecified">
+   <rSolid name="trackerbulkhead:TECPpBoxL"/>
+   <rMaterial name="tecmaterial:TEC_PatchpanelBox"/>
+  </LogicalPart>
+  <LogicalPart name="TECPpBoxS" category="unspecified">
+   <rSolid name="trackerbulkhead:TECPpBoxS"/>
+   <rMaterial name="tecmaterial:TEC_PatchpanelBox"/>
+  </LogicalPart>
+  <LogicalPart name="TECCtrlBox" category="unspecified">
+   <rSolid name="trackerbulkhead:TECCtrlBox"/>
+   <rMaterial name="tecmaterial:TEC_PatchCtrlBox"/>
+  </LogicalPart>
+ </LogicalPartSection>
+ <PosPartSection label="trackerbulkhead.xml">
+  <PosPart copyNumber="1">
+   <rParent name="tracker:Tracker"/>
+   <rChild name="trackerbulkhead:TrackerBulkhead"/>
+   <Translation x="[zero]" y="[zero]" z="[BulkheadZ]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+   <rParent name="tracker:Tracker"/>
+   <rChild name="trackerbulkhead:TrackerBulkhead"/>
+   <Translation x="[zero]" y="[zero]" z="-[BulkheadZ]"/>
+   <rRotation name="tracker:180D"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="trackerbulkhead:TrackerBulkhead"/>
+   <rChild name="trackerbulkhead:BHDisk"/>
+   <Translation x="[zero]" y="[zero]" z="-0.5*[Thick]+0.5*[BHDiskThick]"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="trackerbulkhead:TrackerBulkhead"/>
+   <rChild name="trackerbulkhead:BHCovers"/>
+   <Translation x="[zero]" y="[zero]" z="0.5*[Thick]-0.5*[BHCoversThick]"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="trackerbulkhead:TrackerBulkhead"/>
+   <rChild name="trackerbulkhead:OuterCables"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="trackerbulkhead:TrackerBulkhead"/>
+   <rChild name="trackerbulkhead:TECAlignRing"/>
+   <Translation x="[zero]" y="[zero]" z="-0.5*[Thick]+0.5*[AlignRingThick]+[BHDiskThick]"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="trackerbulkhead:TrackerBulkhead"/>
+   <rChild name="trackerbulkhead:PixelCables"/>
+   <Translation x="[zero]" y="[zero]" z="-0.5*[Thick]+0.5*[PixelCablesThick]+[AlignRingThick]+[BHDiskThick]"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="trackerbulkhead:TECPatchpanel"/>
+   <rChild name="trackerbulkhead:TECPpConnectors"/>
+   <Translation x="[PatchpanelR2]+0.5*[PpConnectorsLength]+[PpBoxSideX]" y="-0.5*[PpBoxWidth]-[PpBoxSideY]" z="-0.5*[PatchpanelThick]+0.5*[PpBoxThick]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+   <rParent name="trackerbulkhead:TECPatchpanel"/>
+   <rChild name="trackerbulkhead:TECPpConnectors"/>
+   <Translation x="[PatchpanelR2]+[PpConnectorsLength]+[PpBoxLengthL]+0.5*[PpConnectorsLength]+[PpBoxSideX]" y="-0.5*[PpBoxWidth]-[PpBoxSideY]" z="-0.5*[PatchpanelThick]+0.5*[PpBoxThick]"/>
+  </PosPart>
+  <PosPart copyNumber="3">
+   <rParent name="trackerbulkhead:TECPatchpanel"/>
+   <rChild name="trackerbulkhead:TECPpConnectors"/>
+   <Translation x="[PatchpanelR2]+0.5*[PpConnectorsLength]+[PpBoxSideX]-[PpBoxDistX]" y="-1.5*[PpBoxWidth]-[PpBoxSideY]-[PpBoxDistY]" z="-0.5*[PatchpanelThick]+0.5*[PpBoxThick]"/>
+  </PosPart>
+  <PosPart copyNumber="4">
+   <rParent name="trackerbulkhead:TECPatchpanel"/>
+   <rChild name="trackerbulkhead:TECPpConnectors"/>
+   <Translation x="[PatchpanelR2]+[PpConnectorsLength]+[PpBoxLengthL]+0.5*[PpConnectorsLength]+[PpBoxSideX]-[PpBoxDistX]" y="-1.5*[PpBoxWidth]-[PpBoxSideY]-[PpBoxDistY]" z="-0.5*[PatchpanelThick]+0.5*[PpBoxThick]"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="trackerbulkhead:TECPatchpanel"/>
+   <rChild name="trackerbulkhead:TECPpBoxC"/>
+    <Translation x="[PatchpanelR2]+[PpConnectorsLength]+[PpBoxLengthL]+0.5*[PpConnectorsLength]+[PpBoxSideX]" y="-0.5*[PpBoxWidth]-[PpBoxSideY]" z="-0.5*[PatchpanelThick]+[PpConnectorsThick]+0.5*[PpBoxThick]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+   <rParent name="trackerbulkhead:TECPatchpanel"/>
+   <rChild name="trackerbulkhead:TECPpBoxC"/>
+   <Translation x="[PatchpanelR2]+[PpConnectorsLength]+[PpBoxLengthL]+0.5*[PpConnectorsLength]+[PpBoxSideX]-[PpBoxDistX]" y="-1.5*[PpBoxWidth]-[PpBoxSideY]-[PpBoxDistY]" z="-0.5*[PatchpanelThick]+[PpConnectorsThick]+0.5*[PpBoxThick]"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="trackerbulkhead:TECPatchpanel"/>
+   <rChild name="trackerbulkhead:TECPpBoxL"/>
+   <Translation x="[PatchpanelR2]+[PpConnectorsLength]+0.5*[PpBoxLengthL]+[PpBoxSideX]" y="-0.5*[PpBoxWidth]-[PpBoxSideY]" z="-0.5*[PatchpanelThick]+0.5*[PpBoxThick]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+   <rParent name="trackerbulkhead:TECPatchpanel"/>
+   <rChild name="trackerbulkhead:TECPpBoxL"/>
+   <Translation x="[PatchpanelR2]+[PpConnectorsLength]+0.5*[PpBoxLengthL]+[PpBoxSideX]-[PpBoxDistX]" y="-1.5*[PpBoxWidth]-[PpBoxSideY]-[PpBoxDistY]" z="-0.5*[PatchpanelThick]+0.5*[PpBoxThick]"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="trackerbulkhead:TECPatchpanel"/>
+   <rChild name="trackerbulkhead:TECPpBoxS"/>
+   <Translation x="[PatchpanelR2]+[PpConnectorsLength]+[PpBoxLengthL]+[PpConnectorsLength]+0.5*[PpBoxLengthS]+[PpBoxSideX]" y="-0.5*[PpBoxWidth]-[PpBoxSideY]" z="-0.5*[PatchpanelThick]+[PpBoxThick]"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+   <rParent name="trackerbulkhead:TECPatchpanel"/>
+   <rChild name="trackerbulkhead:TECPpBoxS"/>
+   <Translation x="[PatchpanelR2]+[PpConnectorsLength]+[PpBoxLengthL]+[PpConnectorsLength]+0.5*[PpBoxLengthS]+[PpBoxSideX]-[PpBoxDistX]" y="-1.5*[PpBoxWidth]-[PpBoxSideY]-[PpBoxDistY]" z="-0.5*[PatchpanelThick]+[PpBoxThick]"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+   <rParent name="trackerbulkhead:TECPatchpanel"/>
+   <rChild name="trackerbulkhead:TECCtrlBox"/>
+   <Translation x="[PatchpanelR2]+0.5*[CtrlBoxLength]+[PpBoxSideX]+[CtrlBoxDistX]" y="-[PpBoxSideY]-2*[PpBoxWidth]-[PpBoxDistY]-[CtrlBoxDistY]-0.5*[CtrlBoxWidth]" z="-0.5*[PatchpanelThick]+0.5*[CtrlBoxThick]"/>
+  </PosPart>
+ </PosPartSection>
+ <Algorithm name="track:DDTrackerAngular">
+  <rParent name="trackerbulkhead:TrackerBulkhead"/>
+  <String name="ChildName" value="trackerbulkhead:TECPatchpanel"/>
+  <Numeric name="N" value="4"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="RangeAngle" value="360*deg"/>
+  <Numeric name="StartAngle" value="-[TECPatchpanelPhi]"/>
+  <Numeric name="Radius" value="[zero]"/>
+  <Vector name="Center" type="numeric" nEntries="3">
+   0, 0, 0.5*([BHDiskThick] - [BHCoversThick])  </Vector>
+ </Algorithm>
+ <Algorithm name="track:DDTrackerAngular">
+  <rParent name="trackerbulkhead:TrackerBulkhead"/>
+  <String name="ChildName" value="trackerbulkhead:TECPatchpanel"/>
+  <Numeric name="N" value="4"/>
+  <Numeric name="StartCopyNo" value="5"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="RangeAngle" value="360*deg"/>
+  <Numeric name="StartAngle" value="-[TECPatchpanelPhi]-[TECPatchpanelWidth]"/>
+  <Numeric name="Radius" value="[zero]"/>
+  <Vector name="Center" type="numeric" nEntries="3">
+   0, 0, 0.5*([BHDiskThick] - [BHCoversThick])  </Vector>
+ </Algorithm>
+ <Algorithm name="track:DDTrackerAngular">
+  <rParent name="trackerbulkhead:TrackerBulkhead"/>
+  <String name="ChildName" value="trackerbulkhead:PIXPatchpanel1"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="RangeAngle" value="360*deg"/>
+  <Numeric name="StartAngle" value="-[PIXPatchpanelPhi]"/>
+  <Numeric name="Radius" value="[zero]"/>
+  <Vector name="Center" type="numeric" nEntries="3">
+   0, 0,0.5*([BHDiskThick] - [BHCoversThick])   </Vector>
+</Algorithm>
+ <Algorithm name="track:DDTrackerAngular">
+  <rParent name="trackerbulkhead:TrackerBulkhead"/>
+  <String name="ChildName" value="trackerbulkhead:PIXPatchpanel1b"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="RangeAngle" value="360*deg"/>
+  <Numeric name="StartAngle" value="-[PIXPatchpanelPhi]+10*deg"/>
+  <Numeric name="Radius" value="[zero]"/>
+  <Vector name="Center" type="numeric" nEntries="3">
+   0, 0,0.5*([BHDiskThick] - [BHCoversThick])   </Vector>
+ </Algorithm>
+ <Algorithm name="track:DDTrackerAngular">
+  <rParent name="trackerbulkhead:TrackerBulkhead"/>
+  <String name="ChildName" value="trackerbulkhead:PIXPatchpanel2"/>
+  <Numeric name="N" value="2"/>
+  <Numeric name="StartCopyNo" value="1"/>
+  <Numeric name="IncrCopyNo" value="1"/>
+  <Numeric name="RangeAngle" value="360*deg"/>
+  <Numeric name="StartAngle" value="-[TECPatchpanelPhi]-2*[TECPatchpanelWidth]-2*[PIXPatchpanelWidth1]"/>
+  <Numeric name="Radius" value="[zero]"/>
+  <Vector name="Center" type="numeric" nEntries="3">
+   0, 0, 0.5*([BHDiskThick] - [BHCoversThick]) </Vector>
+ </Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/trackermaterial.xml
+++ b/DetectorDescription/DDCMS/data/trackermaterial.xml
@@ -1,0 +1,504 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <MaterialSection label="trackermaterial.xml">
+    <CompositeMaterial name="T_Barium_Titanate" density="6.02*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:Barium_Titanate" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_Aluminium" density="2.7*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_Beryllium" density="1.848*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:Beryllium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_C6F14_F2_-30C" density="1.87917*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:C6F14" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_C6F14_F2_-20C" density="1.84675*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:C6F14" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_CarbonFibreStr" density="1.69*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:Carbon fibre str." />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_Copper" density="8.96*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_CuNi" density="8.94*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:CuNi" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_Kevlar" density="1.44*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:Kevlar" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_Nomex" density="32*mg/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:Nomex" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_Rohacell" density="52*mg/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:Rohacell" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_FR4" density="1.7*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.18077359">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.4056325">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.27804208">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.068442752">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.067109079">
+        <rMaterial name="materials:Bromine" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_G10" density="1.9*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.13232243">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.032572448">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.48316123">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.35194389">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_Silicone_Gel" density="0.965*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:Silicone_Gel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_StainlessSteel" density="8.02*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1.00000000">
+        <rMaterial name="materials:StainlessSteel" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Fibre_Ribbon" density="1.219*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.16050082">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.18283037">
+        <rMaterial name="materials:Oxygen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.56229533">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.094373484">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="MS_Cu60" density="2.382*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.85086214">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12770444">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.021433422">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="MS_cntrl_cable" density="1.63*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.74181259">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22108188">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.037105532">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TS_Cooling" density="1.62562*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.82993">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.17007">
+        <rMaterial name="materials:C6F14_3M_-15C" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TS_Shield" density="0.35161*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.60198">
+        <rMaterial name="materials:Inconel600" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.39802">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Optical_Fiber" density="1.08326*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.40031">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.49827">
+        <rMaterial name="materials:Acrylate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06248">
+        <rMaterial name="materials:Acrylate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03895">
+        <rMaterial name="materials:Silica" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_RuggRibbon" density="0.83457*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.67776">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13932">
+        <rMaterial name="trackermaterial:T_Kevlar" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06569">
+        <rMaterial name="materials:Acrylate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04524">
+        <rMaterial name="materials:Silica" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07199">
+        <rMaterial name="materials:Acrylate" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="T_Ribbon12xMUConn" density="0.86000*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.78488">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.18412">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01163">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01937">
+        <rMaterial name="materials:Iron" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_Ribbon12xMUConn" density="0.77667*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.7618">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.20388">
+        <rMaterial name="materials:Ceramic" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01287">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02145">
+        <rMaterial name="materials:Iron" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TOB_DOHM_PowerConn" density="3.73770*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.0271">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05322">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13372">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.78596">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="MS_Al36" density="1.403*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.379586">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.27524785">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.26823734">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.045019923">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.03190889">
+        <rMaterial name="materials:Silver" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="MS_Al48" density="1.373*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.40684004">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.25552552">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.26144891">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.043880579">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.032304952">
+        <rMaterial name="materials:Silver" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="MS_Al60" density="971*mg/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.43940244">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22781143">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.25517545">
+        <rMaterial name="materials:Carbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.042827665">
+        <rMaterial name="materials:Hydrogen" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.034783015">
+        <rMaterial name="materials:Silver" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="MS_CntrlTIBTID" density="1.58489*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.44981">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.51013">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04006">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="CAB_Al60TIBTID" density="1.16581*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.30189">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.38768">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22266">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02323">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06455">
+        <rMaterial name="materials:Silver" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="CAB_Al60" density="1.37448*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.29872">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.35518">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.2691">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02224">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05475">
+        <rMaterial name="materials:Silver" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="CAB_Al48" density="1.14748*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.31894">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.32994">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.28131">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02411">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.0457">
+        <rMaterial name="materials:Silver" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="CAB_Al36" density="1.06783*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.32521">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.31456">
+        <rMaterial name="trackermaterial:T_Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.29435">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.02564">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.04024">
+        <rMaterial name="materials:Silver" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TS_PowerCable" density="4.02080*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.10028">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.89972">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="TS_SignalCable" density="3.13035*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.10018">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.89982">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Tk_Cables_PP1" density="2.07590*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.00998">
+        <rMaterial name="trackermaterial:TS_PowerCable" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06704">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0">
+        <rMaterial name="materials:C6F14_3M_-15C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22783">
+        <rMaterial name="trackermaterial:CAB_Al60" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01863">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13358">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.10686">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08857">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.12643">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.21136">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00972">
+        <rMaterial name="trackermaterial:TS_SignalCable" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Tk_Connectors_PP1" density="0.30245*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.22194">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08451">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.27443">
+        <rMaterial name="trackermaterial:CAB_Al60" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.13535">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01331">
+        <rMaterial name="trackermaterial:T_RuggRibbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01320">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.22420">
+        <rMaterial name="trackermaterial:T_C6F14_F2_-30C" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01676">
+        <rMaterial name="trackermaterial:TS_PowerCable" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01631">
+        <rMaterial name="trackermaterial:TS_SignalCable" />
+      </MaterialFraction>
+    </CompositeMaterial>
+      <CompositeMaterial name="Tk_panels_mid1" density="1.17876*0.67*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1e-05">
+        <rMaterial name="materials:Quartz" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08405">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.84501">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07094">
+        <rMaterial name="materials:C6F14" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Tk_panels_mid1b" density="1.17876*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1e-05">
+         <rMaterial name="materials:Quartz"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.08405">
+         <rMaterial name="materials:Polyethylene"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.84501">
+         <rMaterial name="trackermaterial:T_Copper"/>
+      </MaterialFraction>
+      <MaterialFraction fraction="0.07094">
+         <rMaterial name="materials:C6F14"/>
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Tk_panels_mid2" density="0.35866*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="1e-05">
+        <rMaterial name="materials:Quartz" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.14595">
+        <rMaterial name="materials:T_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.11911">
+        <rMaterial name="materials:Polyethylene" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.73492">
+        <rMaterial name="trackermaterial:T_Copper" />
+      </MaterialFraction>
+    </CompositeMaterial>
+    <CompositeMaterial name="Tk_panels_up" density="0.221000*g/cm3" method="mixture by weight" symbol=" ">
+      <MaterialFraction fraction="0.281640">
+        <rMaterial name="trackermaterial:CAB_Al36" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.044540">
+        <rMaterial name="trackermaterial:CAB_Al48" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.058950">
+        <rMaterial name="trackermaterial:CAB_Al60" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.058290">
+        <rMaterial name="trackermaterial:MS_cntrl_cable" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.380440">
+        <rMaterial name="trackermaterial:MS_Cu60" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.013530">
+        <rMaterial name="trackermaterial:Fibre_Ribbon" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.026340">
+        <rMaterial name="materials:Steel-008" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.136270">
+        <rMaterial name="materials:C6F14" />
+      </MaterialFraction>
+    </CompositeMaterial>
+  </MaterialSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/trackerother.xml
+++ b/DetectorDescription/DDCMS/data/trackerother.xml
@@ -1,0 +1,388 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="trackerother.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="OuterCylinderRin" value="1.169*m"/>
+		<Constant name="OuterCylinderRout" value="1.223*m"/>
+		<Constant name="OuterCylinderL" value="2.650*m"/>
+		<Constant name="ThermalScreenRin" value="1.181*m"/>
+		<Constant name="ThermalScreenRout" value="1.193*m"/>
+		<Constant name="ThermalScreenL" value="2.450*m"/>
+		<Constant name="ThermalScreenR1" value="[ThermalScreenRin]+3*mm"/>
+		<Constant name="ThermalScreenR2" value="[ThermalScreenR1]+8*mm"/>
+		<Constant name="SupportTubeRin" value="[ThermalScreenRout]"/>
+		<Constant name="SupportTubeRout" value="1.223*m"/>
+		<Constant name="SupportTubeR1" value="[SupportTubeRin]+2*mm"/>
+		<Constant name="SupportTubeR2" value="[SupportTubeR1]+25.950*mm"/>
+		<Constant name="SupportTubeR3" value="[SupportTubeR2]+2*mm"/>
+		<Constant name="SupportTubeL" value="2.650*m"/>
+		<Constant name="SupportTubeInsertR" value="5*mm"/>
+		<Constant name="SupportTubeInsertDz" value="([SupportTubeRout]-[SupportTubeRin])/2-0.010*mm"/>
+		<Constant name="SupportTubeInsert1Dz" value="([SupportTubeR1]-[SupportTubeRin])/2-0.010*mm"/>
+		<Constant name="SupportTubeInsert2Dz" value="([SupportTubeR2]-[SupportTubeR1])/2-0.010*mm"/>
+		<Constant name="SupportTubeInsert3Dz" value="([SupportTubeR3]-[SupportTubeR2])/2-0.010*mm"/>
+		<Constant name="SupportTubeInsert4Dz" value="([SupportTubeRout]-[SupportTubeR3])/2-0.010*mm"/>
+		<Constant name="SupportTubeInsertZoff" value="-2.574*m"/>
+		<Constant name="SupportTubeInsertZpitch" value="143*mm"/>
+		<Constant name="ThermalScreenManifoldL" value="([SupportTubeL]-[ThermalScreenL])/2"/>
+		<Constant name="ThermalScreenPlaceholderL" value="3*mm"/>
+		<Constant name="TrackerRailRout" value="[ThermalScreenRout]"/>
+		<Constant name="TrackerRailRin" value="[TrackerRailRout]-24*mm"/>
+		<Constant name="TrackerRailPhiLo" value="-0.067*rad"/>
+		<Constant name="TrackerRailPhiRange" value="0.10*rad"/>
+		<Constant name="TrackerRailDR1" value="2*mm"/>
+		<Constant name="TrackerRailPhi1" value="-0.066892*rad"/>
+		<Constant name="TrackerRailPhi2" value="-0.012701*rad"/>
+		<Constant name="TrackerRailPhi3" value="0.016935*rad"/>
+		<Constant name="TrackerRailPhi4" value="0.0212*rad"/>
+		<Constant name="TOBRailR" value="5*mm"/>
+		<Constant name="TOBRailRpos" value="1177*mm"/>
+		<Constant name="Tol" value="0.0*mm"/>
+	</ConstantsSection>
+	<SolidSection label="trackerother.xml">
+		<!-- TRACKER SUPPORT TUBE AND THERMAL SCREEN -->
+		<Tubs name="TrackerOuterCylinder" rMin="[OuterCylinderRin]+[Tol]" rMax="[OuterCylinderRout]" dz="[OuterCylinderL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TrackerThermalScreen" rMin="[ThermalScreenRin]+[Tol]" rMax="[ThermalScreenRout]-[Tol]" dz="[ThermalScreenL]" startPhi="4*deg" deltaPhi="172*deg"/>
+		<Tubs name="TrackerThermalScreenCooling" rMin="[ThermalScreenRin]+[Tol]" rMax="[ThermalScreenR1]-[Tol]" dz="[ThermalScreenL]" startPhi="4*deg" deltaPhi="172*deg"/>
+		<Tubs name="TrackerThermalScreenFoam" rMin="[ThermalScreenR1]+[Tol]" rMax="[ThermalScreenR2]-[Tol]" dz="[ThermalScreenL]" startPhi="4*deg" deltaPhi="172*deg"/>
+		<Tubs name="TrackerThermalScreenShield" rMin="[ThermalScreenR2]+[Tol]" rMax="[ThermalScreenRout]-[Tol]" dz="[ThermalScreenL]" startPhi="4*deg" deltaPhi="172*deg"/>
+		<Tubs name="TrackerThermalScreenManifold" rMin="[ThermalScreenRin]+[Tol]" rMax="[ThermalScreenRout]-[Tol]" dz="[ThermalScreenManifoldL]" startPhi="4*deg" deltaPhi="172*deg"/>
+		<Tubs name="TrackerThermalScreenPlaceholder" rMin="[ThermalScreenRin]+[Tol]" rMax="[ThermalScreenRout]-[Tol]" dz="[ThermalScreenPlaceholderL]" startPhi="4*deg" deltaPhi="172*deg"/>
+		<Tubs name="TrackerSupportTube" rMin="[SupportTubeRin]+[Tol]" rMax="[SupportTubeRout]-[Tol]" dz="[SupportTubeL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TrackerSupportTubeCFSkin1" rMin="[SupportTubeRin]+[Tol]" rMax="[SupportTubeR1]-[Tol]" dz="[SupportTubeL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TrackerSupportTubeNomex" rMin="[SupportTubeR1]+[Tol]" rMax="[SupportTubeR2]-[Tol]" dz="[SupportTubeL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TrackerSupportTubeCFSkin2" rMin="[SupportTubeR2]+[Tol]" rMax="[SupportTubeR3]-[Tol]" dz="[SupportTubeL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TrackerSupportTubeShield" rMin="[SupportTubeR3]+[Tol]" rMax="[SupportTubeRout]-[Tol]" dz="[SupportTubeL]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TrackerSupportTubeInsert" rMin="[zero]" rMax="[SupportTubeInsertR]" dz="[SupportTubeInsertDz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TrackerSupportTubeInsertCFSkin1" rMin="[zero]" rMax="[SupportTubeInsertR]" dz="[SupportTubeInsert1Dz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TrackerSupportTubeInsertNomex" rMin="[zero]" rMax="[SupportTubeInsertR]" dz="[SupportTubeInsert2Dz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TrackerSupportTubeInsertCFSkin2" rMin="[zero]" rMax="[SupportTubeInsertR]" dz="[SupportTubeInsert3Dz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TrackerSupportTubeInsertShield" rMin="[zero]" rMax="[SupportTubeInsertR]" dz="[SupportTubeInsert4Dz]" startPhi="0*deg" deltaPhi="360*deg"/>
+		<Tubs name="TrackerRail" rMin="[TrackerRailRin]+[Tol]" rMax="[TrackerRailRout]-[Tol]" dz="[SupportTubeL]" startPhi="[TrackerRailPhiLo]" deltaPhi="[TrackerRailPhiRange]"/>
+		<Tubs name="TrackerRailNomex" rMin="[TrackerRailRin]+[TrackerRailDR1]+[Tol]" rMax="[TrackerRailRout]-[TrackerRailDR1]-[Tol]" dz="[SupportTubeL]" startPhi="[TrackerRailPhi1]" deltaPhi="[TrackerRailPhi2]-[TrackerRailPhi1]"/>
+		<Tubs name="TrackerRailCFSkin1" rMin="[TrackerRailRin]+[Tol]" rMax="[TrackerRailRin]+[TrackerRailDR1]-[Tol]" dz="[SupportTubeL]" startPhi="[TrackerRailPhi1]" deltaPhi="[TrackerRailPhi2]-[TrackerRailPhi1]"/>
+		<Tubs name="TrackerRailCFSkin2" rMin="[TrackerRailRout]-[TrackerRailDR1]+[Tol]" rMax="[TrackerRailRout]-[Tol]" dz="[SupportTubeL]" startPhi="[TrackerRailPhi1]" deltaPhi="[TrackerRailPhi2]-[TrackerRailPhi1]"/>
+		<Tubs name="TrackerRailCF" rMin="[TrackerRailRin]+[Tol]" rMax="[TrackerRailRout]-[Tol]" dz="[SupportTubeL]" startPhi="[TrackerRailPhi2]" deltaPhi="[TrackerRailPhi3]-[TrackerRailPhi2]"/>
+		<Tubs name="TOBRail" rMin="[zero]" rMax="[TOBRailR]" dz="[SupportTubeL]" startPhi="0*deg" deltaPhi="360*deg"/>
+	</SolidSection>
+	<LogicalPartSection label="trackerother.xml">
+		<!-- TRACKER SUPPORT TUBE AND THERMAL SCREEN -->
+		<LogicalPart name="TrackerOuterCylinder" category="unspecified">
+			<rSolid name="TrackerOuterCylinder"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerThermalScreen" category="unspecified">
+			<rSolid name="TrackerThermalScreen"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerThermalScreenCooling" category="unspecified">
+			<rSolid name="TrackerThermalScreenCooling"/>
+			<rMaterial name="trackermaterial:TS_Cooling"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerThermalScreenFoam" category="unspecified">
+			<rSolid name="TrackerThermalScreenFoam"/>
+			<rMaterial name="trackermaterial:T_Rohacell"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerThermalScreenShield" category="unspecified">
+			<rSolid name="TrackerThermalScreenShield"/>
+			<rMaterial name="trackermaterial:TS_Shield"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerThermalScreenManifold" category="unspecified">
+			<rSolid name="TrackerThermalScreenManifold"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerThermalScreenPlaceholder" category="unspecified">
+			<rSolid name="TrackerThermalScreenPlaceholder"/>
+			<rMaterial name="trackermaterial:T_StainlessSteel"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerSupportTube" category="unspecified">
+			<rSolid name="TrackerSupportTube"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerSupportTubeCFSkin1" category="unspecified">
+			<rSolid name="TrackerSupportTubeCFSkin1"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerSupportTubeNomex" category="unspecified">
+			<rSolid name="TrackerSupportTubeNomex"/>
+			<rMaterial name="trackermaterial:T_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerSupportTubeCFSkin2" category="unspecified">
+			<rSolid name="TrackerSupportTubeCFSkin2"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerSupportTubeShield" category="unspecified">
+			<rSolid name="TrackerSupportTubeShield"/>
+			<rMaterial name="trackermaterial:T_Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerSupportTubeInsert" category="unspecified">
+			<rSolid name="TrackerSupportTubeInsert"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerSupportTubeInsertCFSkin1" category="unspecified">
+			<rSolid name="TrackerSupportTubeInsertCFSkin1"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerSupportTubeInsertNomex" category="unspecified">
+			<rSolid name="TrackerSupportTubeInsertNomex"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerSupportTubeInsertCFSkin2" category="unspecified">
+			<rSolid name="TrackerSupportTubeInsertCFSkin2"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerSupportTubeInsertShield" category="unspecified">
+			<rSolid name="TrackerSupportTubeInsertShield"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerRail" category="unspecified">
+			<rSolid name="TrackerRail"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerRailNomex" category="unspecified">
+			<rSolid name="TrackerRailNomex"/>
+			<rMaterial name="trackermaterial:T_Nomex"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerRailCFSkin1" category="unspecified">
+			<rSolid name="TrackerRailCFSkin1"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerRailCFSkin2" category="unspecified">
+			<rSolid name="TrackerRailCFSkin2"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TrackerRailCF" category="unspecified">
+			<rSolid name="TrackerRailCF"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+		<LogicalPart name="TOBRail" category="unspecified">
+			<rSolid name="TOBRail"/>
+			<rMaterial name="trackermaterial:T_CarbonFibreStr"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="trackerother.xml">
+		<!-- TRACKER SUPPORT TUBE AND THERMAL SCREEN -->
+		<PosPart copyNumber="1">
+			<rParent name="tracker:Tracker"/>
+			<rChild name="trackerother:TrackerOuterCylinder"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerOuterCylinder"/>
+			<rChild name="trackerother:TrackerThermalScreen"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="trackerother:TrackerOuterCylinder"/>
+			<rChild name="trackerother:TrackerThermalScreen"/>
+			<rRotation name="tracker:R180"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerThermalScreen"/>
+			<rChild name="trackerother:TrackerThermalScreenCooling"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerThermalScreen"/>
+			<rChild name="trackerother:TrackerThermalScreenFoam"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerThermalScreen"/>
+			<rChild name="trackerother:TrackerThermalScreenShield"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerOuterCylinder"/>
+			<rChild name="trackerother:TrackerSupportTube"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerSupportTube"/>
+			<rChild name="trackerother:TrackerSupportTubeCFSkin1"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerSupportTube"/>
+			<rChild name="trackerother:TrackerSupportTubeNomex"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerSupportTube"/>
+			<rChild name="trackerother:TrackerSupportTubeCFSkin2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerSupportTube"/>
+			<rChild name="trackerother:TrackerSupportTubeShield"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerThermalScreenManifold"/>
+			<rChild name="trackerother:TrackerThermalScreenPlaceholder"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerOuterCylinder"/>
+			<rChild name="trackerother:TrackerThermalScreenManifold"/>
+			<Translation x="[zero]" y="[zero]" z="[ThermalScreenL]+[ThermalScreenManifoldL]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="trackerother:TrackerOuterCylinder"/>
+			<rChild name="trackerother:TrackerThermalScreenManifold"/>
+			<rRotation name="tracker:R180"/>
+			<Translation x="[zero]" y="[zero]" z="[ThermalScreenL]+[ThermalScreenManifoldL]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="trackerother:TrackerOuterCylinder"/>
+			<rChild name="trackerother:TrackerThermalScreenManifold"/>
+			<Translation x="[zero]" y="[zero]" z="-([ThermalScreenL]+[ThermalScreenManifoldL])"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="trackerother:TrackerOuterCylinder"/>
+			<rChild name="trackerother:TrackerThermalScreenManifold"/>
+			<rRotation name="tracker:R180"/>
+			<Translation x="[zero]" y="[zero]" z="-([ThermalScreenL]+[ThermalScreenManifoldL])"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerOuterCylinder"/>
+			<rChild name="trackerother:TrackerRail"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="trackerother:TrackerOuterCylinder"/>
+			<rChild name="trackerother:TrackerRail"/>
+			<rRotation name="tracker:180D"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerRail"/>
+			<rChild name="trackerother:TrackerRailNomex"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerRail"/>
+			<rChild name="trackerother:TrackerRailCFSkin1"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerRail"/>
+			<rChild name="trackerother:TrackerRailCFSkin2"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerRail"/>
+			<rChild name="trackerother:TrackerRailCF"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="trackerother:TrackerRail"/>
+			<rChild name="trackerother:TOBRail"/>
+			<Translation x="[TOBRailRpos]*cos([TrackerRailPhi4])" y="[TOBRailRpos]*sin([TrackerRailPhi4])" z="[zero]"/>
+		</PosPart>
+	</PosPartSection>
+	<!-- TRACKER SUPPORT TUBE AND THERMAL SCREEN -->
+	<Algorithm name="track:DDTrackerLinear">
+		<rParent name="trackerother:TrackerSupportTubeCFSkin1"/>
+		<String name="ChildName" value="trackerother:TrackerSupportTubeInsertCFSkin1"/>
+		<Numeric name="Number" value="36"/>
+		<Numeric name="Theta" value="0*deg"/>
+		<Numeric name="Phi" value="0*deg"/>
+		<Numeric name="Offset" value="[SupportTubeInsertZoff]"/>
+		<Numeric name="Delta" value="[SupportTubeInsertZpitch]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<String name="Rotation" value="tracker:PAA"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			[SupportTubeRin]+[SupportTubeInsert1Dz], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerLinear">
+		<rParent name="trackerother:TrackerSupportTubeCFSkin1"/>
+		<String name="ChildName" value="trackerother:TrackerSupportTubeInsertCFSkin1"/>
+		<Numeric name="Number" value="36"/>
+		<Numeric name="Theta" value="0*deg"/>
+		<Numeric name="Phi" value="0*deg"/>
+		<Numeric name="Offset" value="[SupportTubeInsertZoff]"/>
+		<Numeric name="Delta" value="[SupportTubeInsertZpitch]"/>
+		<Numeric name="StartCopyNo" value="37"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<String name="Rotation" value="tracker:PAA"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			-([SupportTubeRin]+[SupportTubeInsert1Dz]), [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerLinear">
+		<rParent name="trackerother:TrackerSupportTubeNomex"/>
+		<String name="ChildName" value="trackerother:TrackerSupportTubeInsertNomex"/>
+		<Numeric name="Number" value="36"/>
+		<Numeric name="Theta" value="0*deg"/>
+		<Numeric name="Phi" value="0*deg"/>
+		<Numeric name="Offset" value="[SupportTubeInsertZoff]"/>
+		<Numeric name="Delta" value="[SupportTubeInsertZpitch]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<String name="Rotation" value="tracker:PAA"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			[SupportTubeR1]+[SupportTubeInsert2Dz], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerLinear">
+		<rParent name="trackerother:TrackerSupportTubeNomex"/>
+		<String name="ChildName" value="trackerother:TrackerSupportTubeInsertNomex"/>
+		<Numeric name="Number" value="36"/>
+		<Numeric name="Theta" value="0*deg"/>
+		<Numeric name="Phi" value="0*deg"/>
+		<Numeric name="Offset" value="[SupportTubeInsertZoff]"/>
+		<Numeric name="Delta" value="[SupportTubeInsertZpitch]"/>
+		<Numeric name="StartCopyNo" value="37"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<String name="Rotation" value="tracker:PAA"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			-([SupportTubeR1]+[SupportTubeInsert2Dz]), [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerLinear">
+		<rParent name="trackerother:TrackerSupportTubeCFSkin2"/>
+		<String name="ChildName" value="trackerother:TrackerSupportTubeInsertCFSkin2"/>
+		<Numeric name="Number" value="36"/>
+		<Numeric name="Theta" value="0*deg"/>
+		<Numeric name="Phi" value="0*deg"/>
+		<Numeric name="Offset" value="[SupportTubeInsertZoff]"/>
+		<Numeric name="Delta" value="[SupportTubeInsertZpitch]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<String name="Rotation" value="tracker:PAA"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			[SupportTubeR2]+[SupportTubeInsert3Dz], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerLinear">
+		<rParent name="trackerother:TrackerSupportTubeCFSkin2"/>
+		<String name="ChildName" value="trackerother:TrackerSupportTubeInsertCFSkin2"/>
+		<Numeric name="Number" value="36"/>
+		<Numeric name="Theta" value="0*deg"/>
+		<Numeric name="Phi" value="0*deg"/>
+		<Numeric name="Offset" value="[SupportTubeInsertZoff]"/>
+		<Numeric name="Delta" value="[SupportTubeInsertZpitch]"/>
+		<Numeric name="StartCopyNo" value="37"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<String name="Rotation" value="tracker:PAA"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			-([SupportTubeR2]+[SupportTubeInsert3Dz]), [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerLinear">
+		<rParent name="trackerother:TrackerSupportTubeShield"/>
+		<String name="ChildName" value="trackerother:TrackerSupportTubeInsertShield"/>
+		<Numeric name="Number" value="36"/>
+		<Numeric name="Theta" value="0*deg"/>
+		<Numeric name="Phi" value="0*deg"/>
+		<Numeric name="Offset" value="[SupportTubeInsertZoff]"/>
+		<Numeric name="Delta" value="[SupportTubeInsertZpitch]"/>
+		<Numeric name="StartCopyNo" value="1"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<String name="Rotation" value="tracker:PAA"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			[SupportTubeR3]+[SupportTubeInsert4Dz], [zero], [zero]
+		</Vector>
+	</Algorithm>
+	<Algorithm name="track:DDTrackerLinear">
+		<rParent name="trackerother:TrackerSupportTubeShield"/>
+		<String name="ChildName" value="trackerother:TrackerSupportTubeInsertShield"/>
+		<Numeric name="Number" value="36"/>
+		<Numeric name="Theta" value="0*deg"/>
+		<Numeric name="Phi" value="0*deg"/>
+		<Numeric name="Offset" value="[SupportTubeInsertZoff]"/>
+		<Numeric name="Delta" value="[SupportTubeInsertZpitch]"/>
+		<Numeric name="StartCopyNo" value="37"/>
+		<Numeric name="IncrCopyNo" value="1"/>
+		<String name="Rotation" value="tracker:PAA"/>
+		<Vector name="Center" type="numeric" nEntries="3"> 
+			-([SupportTubeR3]+[SupportTubeInsert4Dz]), [zero], [zero]
+		</Vector>
+	</Algorithm>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/trackerpixbar.xml
+++ b/DetectorDescription/DDCMS/data/trackerpixbar.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <PosPartSection label="trackerpixbar.xml">
+  <PosPart copyNumber="1">
+   <rParent name="tracker:Tracker"/>
+   <rChild name="pixbar:PixelBarrel"/>
+  </PosPart>
+ </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/trackerpixfwd.xml
+++ b/DetectorDescription/DDCMS/data/trackerpixfwd.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="trackerpixfwd.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+		<Constant name="zPos" value="[pixfwd:ZPixelForward]"/>
+	</ConstantsSection>
+	<PosPartSection label="trackerpixfwd.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tracker:Tracker"/>
+			<rChild name="pixfwd:PixelForwardZPlus"/>
+			<Translation x="[zero]" y="[zero]" z="[zPos]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tracker:Tracker"/>
+			<rChild name="pixfwd:PixelForwardZMinus"/>
+			<Translation x="[zero]" y="[zero]" z="-[zPos]"/>
+			<rRotation name="pixfwdCommon:Y180"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/trackertec.xml
+++ b/DetectorDescription/DDCMS/data/trackertec.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="trackertec.xml" eval="true">
+		<Constant name="zero" value="0.0*fm"/>
+	</ConstantsSection>
+	<PosPartSection label="trackertec.xml">
+		<PosPart copyNumber="1">
+			<rParent name="tracker:Tracker"/>
+			<rChild name="tec:TEC"/>
+			<Translation x="[zero]" y="[zero]" z="[tec:ZPos]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="tracker:Tracker"/>
+			<rChild name="tec:TEC"/>
+			<rRotation name="tracker:180D"/>
+			<Translation x="[zero]" y="[zero]" z="-[tec:ZPos]"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/trackertib.xml
+++ b/DetectorDescription/DDCMS/data/trackertib.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <PosPartSection label="trackertib.xml">
+  <PosPart copyNumber="1">
+   <rParent name="tracker:Tracker"/>
+   <rChild name="tib:TIB"/>
+  </PosPart>
+ </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/trackertibtidservices.xml
+++ b/DetectorDescription/DDCMS/data/trackertibtidservices.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <PosPartSection label="tibtidservices.xml">
+  <PosPart copyNumber="1">
+   <rParent name="tracker:Tracker"/>
+   <rChild name="tibtidservicesf:TIBTIDServicesF"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+   <rParent name="tracker:Tracker"/>
+   <rChild name="tibtidservicesb:TIBTIDServicesB"/>
+   <rRotation name="tracker:180D"/>
+  </PosPart>
+ </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/trackertid.xml
+++ b/DetectorDescription/DDCMS/data/trackertid.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <PosPartSection label="trackertid.xml">
+  <PosPart copyNumber="1">
+   <rParent name="tracker:Tracker"/>
+   <rChild name="tidf:TIDF"/>
+  </PosPart>
+  <PosPart copyNumber="2">
+   <rParent name="tracker:Tracker"/>
+   <rChild name="tidb:TIDB"/>
+   <rRotation name="tracker:180D"/>
+  </PosPart>
+ </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/trackertob.xml
+++ b/DetectorDescription/DDCMS/data/trackertob.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <PosPartSection label="trackertob.xml">
+  <PosPart copyNumber="1">
+   <rParent name="tracker:Tracker"/>
+   <rChild name="tob:TOB"/>
+  </PosPart>
+ </PosPartSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/data/vacuum.xml
+++ b/DetectorDescription/DDCMS/data/vacuum.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <MaterialSection>
+  <CompositeMaterial name="Air" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Vacuum" density="1e-10*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+ </MaterialSection>
+</DDDefinition>

--- a/DetectorDescription/DDCMS/plugins/BuildFile.xml
+++ b/DetectorDescription/DDCMS/plugins/BuildFile.xml
@@ -1,0 +1,6 @@
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/ParameterSet"/>
+<library file="*.cc" name="DetectorDescriptionDD4HepPlugins">
+ <use name="DetectorDescription/DDCMS"/>
+</library>
+<flags   EDM_PLUGIN="1"/>

--- a/DetectorDescription/DDCMS/plugins/DDCMSDetector.cc
+++ b/DetectorDescription/DDCMS/plugins/DDCMSDetector.cc
@@ -1,0 +1,48 @@
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DD4hep/Detector.h"
+
+#include <memory>
+#include <string>
+
+class DDCMSDetector : public edm::one::EDAnalyzer<> {
+public:
+  explicit DDCMSDetector(const edm::ParameterSet& p);
+
+  void beginJob() override {}
+  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+  void endJob() override {}
+
+private:
+  
+  std::string confGeomXMLFiles_;
+  std::vector< std::string > relFiles_;
+  std::vector< std::string > files_;
+};
+
+DDCMSDetector::DDCMSDetector(const edm::ParameterSet& iConfig)
+  : confGeomXMLFiles_(iConfig.getParameter<std::string>("confGeomXMLFiles"))
+{
+  relFiles_ = iConfig.getParameter<std::vector<std::string> >("geomXMLFiles");
+  for( auto rit : relFiles_ ) {
+    edm::FileInPath fp(rit);
+    files_.emplace_back(fp.fullPath());
+  }
+}
+
+void
+DDCMSDetector::analyze( const edm::Event& /*iEvent*/, const edm::EventSetup& /*iSetup*/ )
+{
+  dd4hep::Detector& description = dd4hep::Detector::getInstance();
+
+  std::string name("DD4hepCompactLoader");
+  const char* files[] = { confGeomXMLFiles_.c_str(), nullptr };
+  description.apply(name.c_str(),2,(char**)files);
+  for( auto it : files_ )
+    std::cout << it << std::endl;
+}
+
+DEFINE_FWK_MODULE(DDCMSDetector);

--- a/DetectorDescription/DDCMS/plugins/DDCMSDetector.cc
+++ b/DetectorDescription/DDCMS/plugins/DDCMSDetector.cc
@@ -38,7 +38,7 @@ DDCMSDetector::analyze( const edm::Event& /*iEvent*/, const edm::EventSetup& /*i
 {
   dd4hep::Detector& description = dd4hep::Detector::getInstance();
 
-  std::string name("DD4hepCompactLoader");
+  std::string name("DD4hep_CompactLoader");
   const char* files[] = { confGeomXMLFiles_.c_str(), nullptr };
   description.apply(name.c_str(),2,(char**)files);
   for( auto it : files_ )

--- a/DetectorDescription/DDCMS/python/dump.py
+++ b/DetectorDescription/DDCMS/python/dump.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DDCMSDetectorTest")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.test = cms.EDAnalyzer("DDCMSDetector",
+                              geomXMLFiles = cms.vstring('Geometry/CMSCommonData/data/materials.xml',
+                                                         'Geometry/CMSCommonData/data/rotations.xml',
+                                                         'Geometry/TrackerCommonData/data/pixbarmaterial.xml', 
+                                                         'Geometry/TrackerCommonData/data/pixbarladder.xml', 
+                                                         'Geometry/TrackerCommonData/data/pixbarladderfull.xml', 
+                                                         'Geometry/TrackerCommonData/data/pixbarladderhalf.xml', 
+                                                         'Geometry/TrackerCommonData/data/pixbarlayer.xml', 
+                                                         'Geometry/TrackerCommonData/data/pixbarlayer0.xml', 
+                                                         'Geometry/TrackerCommonData/data/pixbarlayer1.xml', 
+                                                         'Geometry/TrackerCommonData/data/pixbarlayer2.xml', 
+                                                         'Geometry/TrackerCommonData/data/pixbar.xml', 
+                                                         'Geometry/TrackerCommonData/data/trackerpixbar.xml', 
+                                                         'Geometry/TrackerCommonData/data/tracker.xml',
+                                                         'Geometry/TrackerCommonData/data/trackermaterial.xml',
+                                                         'Geometry/TrackerCommonData/data/pixfwdMaterials.xml',
+                                                         'Geometry/CMSCommonData/data/cmsMother.xml',
+                                                         'Geometry/CMSCommonData/data/normal/cmsextent.xml', 
+                                                         'Geometry/CMSCommonData/data/cms.xml'),
+                              confGeomXMLFiles = cms.string('DetectorDescription/DDCMS/data/cms-tracker.xml')
+                              )
+
+process.p = cms.Path(process.test)


### PR DESCRIPTION
* Proof of principle example

this test parses CMS XML files for run 1 Tracker.

To run the test:
```
cmsRun DetectorDescription/DDCMS/python/dump.py
```
This PR replaces https://github.com/cms-sw/cmssw/pull/21945.