### PR TITLE
Migrate Validation/DTRecHit clients to DQMEDHarvester + update efficiency plots

### DIFF
--- a/Validation/DTRecHits/plugins/BuildFile.xml
+++ b/Validation/DTRecHits/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="FWCore/Framework"/>
+<use   name="DQMServices/Core"/>
 <use   name="DataFormats/DTRecHit"/>
 <use   name="Geometry/Records"/>
 <use   name="Geometry/DTGeometry"/>

--- a/Validation/DTRecHits/plugins/DT2DSegmentClients.cc
+++ b/Validation/DTRecHits/plugins/DT2DSegmentClients.cc
@@ -4,32 +4,44 @@
 #include "Validation/DTRecHits/interface/utils.h"
 
 #include "DT2DSegmentClients.h"
+#include "Histograms.h"
 
 using namespace std;
 using namespace edm;
 
-DT2DSegmentClients::DT2DSegmentClients(edm::ParameterSet const& config)
+DT2DSegmentClients::DT2DSegmentClients(edm::ParameterSet const& pset)
+{
+  do2D_    = pset.getUntrackedParameter<bool>("do2D", false);
+  doSLPhi_ = pset.getUntrackedParameter<bool>("doSLPhi", false);
+}
+
+DT2DSegmentClients::~DT2DSegmentClients()
 {
 }
 
-void DT2DSegmentClients::endLuminosityBlock(edm::LuminosityBlock const& lumi,
-  edm::EventSetup const& setup)
+void DT2DSegmentClients::dqmEndJob(DQMStore::IBooker & booker, DQMStore::IGetter & getter)
 {
-  DQMStore* dbe = Service<DQMStore>().operator->();
-  MonitorElement * hResPos    = dbe->get("DT/2DSegments/Res/2D_SuperPhi_hResPos");
-  MonitorElement * hResAngle  = dbe->get("DT/2DSegments/Res/2D_SuperPhi_hResAngle");
-  MonitorElement * hPullPos   = dbe->get("DT/2DSegments/Pull/2D_SuperPhi_hPullPos");
-  MonitorElement * hPullAngle = dbe->get("DT/2DSegments/Pull/2D_SuperPhi_hPullAngle");
+  MonitorElement * hResPos    = getter.get("DT/2DSegments/Res/2D_SuperPhi_hResPos");
+  MonitorElement * hResAngle  = getter.get("DT/2DSegments/Res/2D_SuperPhi_hResAngle");
+  MonitorElement * hPullPos   = getter.get("DT/2DSegments/Pull/2D_SuperPhi_hPullPos");
+  MonitorElement * hPullAngle = getter.get("DT/2DSegments/Pull/2D_SuperPhi_hPullAngle");
 
   Tutils util;
   util.drawGFit(hResPos->getTH1(), -0.1, 0.1, -0.1, 0.1);
   util.drawGFit(hResAngle->getTH1(), -0.1, 0.1, -0.1, 0.1);
   util.drawGFit(hPullPos->getTH1(), -5, 5, -5, 5);
   util.drawGFit(hPullAngle->getTH1(), -5, 5, -5, 5);
-}
 
-void DT2DSegmentClients::analyze(Event const& event, EventSetup const& setup)
-{
+  if (do2D_) {
+    HEff2DHitHarvest hEff_RPhi("RPhi", booker, getter);  
+    HEff2DHitHarvest hEff_RZ("RZ", booker, getter);    
+    HEff2DHitHarvest hEff_RZ_W0("RZ_W0", booker, getter); 
+    HEff2DHitHarvest hEff_RZ_W1("RZ_W1", booker, getter); 
+    HEff2DHitHarvest hEff_RZ_W2("RZ_W2", booker, getter); 
+  }
+  if (doSLPhi_) {
+    HEff2DHitHarvest hEff_SuperPhi("SuperPhi", booker, getter);  
+  }
 }
 
 // declare this as a framework plugin

--- a/Validation/DTRecHits/plugins/DT2DSegmentClients.h
+++ b/Validation/DTRecHits/plugins/DT2DSegmentClients.h
@@ -9,21 +9,26 @@
  *   
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class DT2DSegmentClients: public edm::EDAnalyzer {
-public:
+class DT2DSegmentClients: public DQMEDHarvester {
+
+public: 
   /// Constructor
   DT2DSegmentClients(const edm::ParameterSet& ps);
 
-  /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg,
-      edm::EventSetup const& c) override;
+  /// Destructor
+  virtual ~DT2DSegmentClients();
+
+protected:
+  /// End Job
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
+
+private:
+  bool do2D_;
+  bool doSLPhi_;
+
 };
 
 #endif // Validation_DTRecHits_DT2DSegmentClients_h

--- a/Validation/DTRecHits/plugins/DT2DSegmentClients.h
+++ b/Validation/DTRecHits/plugins/DT2DSegmentClients.h
@@ -19,7 +19,7 @@ public:
   DT2DSegmentClients(const edm::ParameterSet& ps);
 
   /// Destructor
-  virtual ~DT2DSegmentClients();
+  ~DT2DSegmentClients() override;
 
 protected:
   /// End Job

--- a/Validation/DTRecHits/plugins/DT4DSegmentClients.cc
+++ b/Validation/DTRecHits/plugins/DT4DSegmentClients.cc
@@ -7,74 +7,78 @@
 #include "Validation/DTRecHits/interface/utils.h"
 
 #include "DT4DSegmentClients.h"
+#include "Histograms.h"
 
 using namespace std;
 using namespace edm;
 
-DT4DSegmentClients::DT4DSegmentClients(edm::ParameterSet const& config)
+DT4DSegmentClients::DT4DSegmentClients(edm::ParameterSet const& pset)
+{
+  doall_ = pset.getUntrackedParameter<bool>("doall", false);
+}
+
+DT4DSegmentClients::~DT4DSegmentClients()
 {
 }
 
-void DT4DSegmentClients::endLuminosityBlock(edm::LuminosityBlock const& lumi,
-  edm::EventSetup const& setup)
+void DT4DSegmentClients::dqmEndJob(DQMStore::IBooker & booker, DQMStore::IGetter & getter)
 {
-  DQMStore* dbe = Service<DQMStore>().operator->();
-  
-  MonitorElement * hResAlpha = dbe->get("DT/4DSegments/Res/4D_All_hResAlpha");
-  MonitorElement * hResBeta = dbe->get("DT/4DSegments/Res/4D_All_hResBeta");
-  MonitorElement * hResX = dbe->get("DT/4DSegments/Res/4D_All_hResX");
-  MonitorElement * hResY = dbe->get("DT/4DSegments/Res/4D_All_hResY");
-  MonitorElement * hResBetaRZ = dbe->get("DT/4DSegments/Res/4D_All_hResBetaRZ");
-  MonitorElement * hResYRZ = dbe->get("DT/4DSegments/Res/4D_All_hResYRZ");
 
-  MonitorElement * hResAlpha_W0 = dbe->get("DT/4DSegments/Res/4D_W0_hResAlpha");
-  MonitorElement * hResBeta_W0 = dbe->get("DT/4DSegments/Res/4D_W0_hResBeta");
-  MonitorElement * hResX_W0 = dbe->get("DT/4DSegments/Res/4D_W0_hResX");
-  MonitorElement * hResY_W0 = dbe->get("DT/4DSegments/Res/4D_W0_hResY");
-  MonitorElement * hResBetaRZ_W0 = dbe->get("DT/4DSegments/Res/4D_W0_hResBetaRZ");
-  MonitorElement * hResYRZ_W0 = dbe->get("DT/4DSegments/Res/4D_W0_hResYRZ");
+  MonitorElement * hResAlpha = getter.get("DT/4DSegments/Res/4D_All_hResAlpha");
+  MonitorElement * hResBeta = getter.get("DT/4DSegments/Res/4D_All_hResBeta");
+  MonitorElement * hResX = getter.get("DT/4DSegments/Res/4D_All_hResX");
+  MonitorElement * hResY = getter.get("DT/4DSegments/Res/4D_All_hResY");
+  MonitorElement * hResBetaRZ = getter.get("DT/4DSegments/Res/4D_All_hResBetaRZ");
+  MonitorElement * hResYRZ = getter.get("DT/4DSegments/Res/4D_All_hResYRZ");
 
-  MonitorElement * hResAlpha_W1 = dbe->get("DT/4DSegments/Res/4D_W1_hResAlpha");
-  MonitorElement * hResBeta_W1 = dbe->get("DT/4DSegments/Res/4D_W1_hResBeta");
-  MonitorElement * hResX_W1 = dbe->get("DT/4DSegments/Res/4D_W1_hResX");
-  MonitorElement * hResY_W1 = dbe->get("DT/4DSegments/Res/4D_W1_hResY");
-  MonitorElement * hResBetaRZ_W1 = dbe->get("DT/4DSegments/Res/4D_W1_hResBetaRZ");
-  MonitorElement * hResYRZ_W1 = dbe->get("DT/4DSegments/Res/4D_W1_hResYRZ");
+  MonitorElement * hResAlpha_W0 = getter.get("DT/4DSegments/Res/4D_W0_hResAlpha");
+  MonitorElement * hResBeta_W0 = getter.get("DT/4DSegments/Res/4D_W0_hResBeta");
+  MonitorElement * hResX_W0 = getter.get("DT/4DSegments/Res/4D_W0_hResX");
+  MonitorElement * hResY_W0 = getter.get("DT/4DSegments/Res/4D_W0_hResY");
+  MonitorElement * hResBetaRZ_W0 = getter.get("DT/4DSegments/Res/4D_W0_hResBetaRZ");
+  MonitorElement * hResYRZ_W0 = getter.get("DT/4DSegments/Res/4D_W0_hResYRZ");
 
-  MonitorElement * hResAlpha_W2 = dbe->get("DT/4DSegments/Res/4D_W2_hResAlpha");
-  MonitorElement * hResBeta_W2 = dbe->get("DT/4DSegments/Res/4D_W2_hResBeta");
-  MonitorElement * hResX_W2 = dbe->get("DT/4DSegments/Res/4D_W2_hResX");
-  MonitorElement * hResY_W2 = dbe->get("DT/4DSegments/Res/4D_W2_hResY");
-  MonitorElement * hResBetaRZ_W2 = dbe->get("DT/4DSegments/Res/4D_W2_hResBetaRZ");
-  MonitorElement * hResYRZ_W2 = dbe->get("DT/4DSegments/Res/4D_W2_hResYRZ");
+  MonitorElement * hResAlpha_W1 = getter.get("DT/4DSegments/Res/4D_W1_hResAlpha");
+  MonitorElement * hResBeta_W1 = getter.get("DT/4DSegments/Res/4D_W1_hResBeta");
+  MonitorElement * hResX_W1 = getter.get("DT/4DSegments/Res/4D_W1_hResX");
+  MonitorElement * hResY_W1 = getter.get("DT/4DSegments/Res/4D_W1_hResY");
+  MonitorElement * hResBetaRZ_W1 = getter.get("DT/4DSegments/Res/4D_W1_hResBetaRZ");
+  MonitorElement * hResYRZ_W1 = getter.get("DT/4DSegments/Res/4D_W1_hResYRZ");
 
-  MonitorElement * hPullAlpha = dbe->get("DT/4DSegments/Pull/4D_All_hPullAlpha");
-  MonitorElement * hPullBeta = dbe->get("DT/4DSegments/Pull/4D_All_hPullBeta");
-  MonitorElement * hPullX = dbe->get("DT/4DSegments/Pull/4D_All_hPullX");
-  MonitorElement * hPullY = dbe->get("DT/4DSegments/Pull/4D_All_hPullY");
-  MonitorElement * hPullBetaRZ = dbe->get("DT/4DSegments/Pull/4D_All_hPullBetaRZ");
-  MonitorElement * hPullYRZ = dbe->get("DT/4DSegments/Pull/4D_All_hPullYRZ");
+  MonitorElement * hResAlpha_W2 = getter.get("DT/4DSegments/Res/4D_W2_hResAlpha");
+  MonitorElement * hResBeta_W2 = getter.get("DT/4DSegments/Res/4D_W2_hResBeta");
+  MonitorElement * hResX_W2 = getter.get("DT/4DSegments/Res/4D_W2_hResX");
+  MonitorElement * hResY_W2 = getter.get("DT/4DSegments/Res/4D_W2_hResY");
+  MonitorElement * hResBetaRZ_W2 = getter.get("DT/4DSegments/Res/4D_W2_hResBetaRZ");
+  MonitorElement * hResYRZ_W2 = getter.get("DT/4DSegments/Res/4D_W2_hResYRZ");
 
-  MonitorElement * hPullAlpha_W0 = dbe->get("DT/4DSegments/Pull/4D_W0_hPullAlpha");
-  MonitorElement * hPullBeta_W0 = dbe->get("DT/4DSegments/Pull/4D_W0_hPullBeta");
-  MonitorElement * hPullX_W0 = dbe->get("DT/4DSegments/Pull/4D_W0_hPullX");
-  MonitorElement * hPullY_W0 = dbe->get("DT/4DSegments/Pull/4D_W0_hPullY");
-  MonitorElement * hPullBetaRZ_W0 = dbe->get("DT/4DSegments/Pull/4D_W0_hPullBetaRZ");
-  MonitorElement * hPullYRZ_W0 = dbe->get("DT/4DSegments/Pull/4D_W0_hPullYRZ");
+  MonitorElement * hPullAlpha = getter.get("DT/4DSegments/Pull/4D_All_hPullAlpha");
+  MonitorElement * hPullBeta = getter.get("DT/4DSegments/Pull/4D_All_hPullBeta");
+  MonitorElement * hPullX = getter.get("DT/4DSegments/Pull/4D_All_hPullX");
+  MonitorElement * hPullY = getter.get("DT/4DSegments/Pull/4D_All_hPullY");
+  MonitorElement * hPullBetaRZ = getter.get("DT/4DSegments/Pull/4D_All_hPullBetaRZ");
+  MonitorElement * hPullYRZ = getter.get("DT/4DSegments/Pull/4D_All_hPullYRZ");
 
-  MonitorElement * hPullAlpha_W1 = dbe->get("DT/4DSegments/Pull/4D_W1_hPullAlpha");
-  MonitorElement * hPullBeta_W1 = dbe->get("DT/4DSegments/Pull/4D_W1_hPullBeta");
-  MonitorElement * hPullX_W1 = dbe->get("DT/4DSegments/Pull/4D_W1_hPullX");
-  MonitorElement * hPullY_W1 = dbe->get("DT/4DSegments/Pull/4D_W1_hPullY");
-  MonitorElement * hPullBetaRZ_W1 = dbe->get("DT/4DSegments/Pull/4D_W1_hPullBetaRZ");
-  MonitorElement * hPullYRZ_W1 = dbe->get("DT/4DSegments/Pull/4D_W1_hPullYRZ");
+  MonitorElement * hPullAlpha_W0 = getter.get("DT/4DSegments/Pull/4D_W0_hPullAlpha");
+  MonitorElement * hPullBeta_W0 = getter.get("DT/4DSegments/Pull/4D_W0_hPullBeta");
+  MonitorElement * hPullX_W0 = getter.get("DT/4DSegments/Pull/4D_W0_hPullX");
+  MonitorElement * hPullY_W0 = getter.get("DT/4DSegments/Pull/4D_W0_hPullY");
+  MonitorElement * hPullBetaRZ_W0 = getter.get("DT/4DSegments/Pull/4D_W0_hPullBetaRZ");
+  MonitorElement * hPullYRZ_W0 = getter.get("DT/4DSegments/Pull/4D_W0_hPullYRZ");
 
-  MonitorElement * hPullAlpha_W2 = dbe->get("DT/4DSegments/Pull/4D_W2_hPullAlpha");
-  MonitorElement * hPullBeta_W2 = dbe->get("DT/4DSegments/Pull/4D_W2_hPullBeta");
-  MonitorElement * hPullX_W2 = dbe->get("DT/4DSegments/Pull/4D_W2_hPullX");
-  MonitorElement * hPullY_W2 = dbe->get("DT/4DSegments/Pull/4D_W2_hPullY");
-  MonitorElement * hPullBetaRZ_W2 = dbe->get("DT/4DSegments/Pull/4D_W2_hPullBetaRZ");
-  MonitorElement * hPullYRZ_W2 = dbe->get("DT/4DSegments/Pull/4D_W2_hPullYRZ");
+  MonitorElement * hPullAlpha_W1 = getter.get("DT/4DSegments/Pull/4D_W1_hPullAlpha");
+  MonitorElement * hPullBeta_W1 = getter.get("DT/4DSegments/Pull/4D_W1_hPullBeta");
+  MonitorElement * hPullX_W1 = getter.get("DT/4DSegments/Pull/4D_W1_hPullX");
+  MonitorElement * hPullY_W1 = getter.get("DT/4DSegments/Pull/4D_W1_hPullY");
+  MonitorElement * hPullBetaRZ_W1 = getter.get("DT/4DSegments/Pull/4D_W1_hPullBetaRZ");
+  MonitorElement * hPullYRZ_W1 = getter.get("DT/4DSegments/Pull/4D_W1_hPullYRZ");
+
+  MonitorElement * hPullAlpha_W2 = getter.get("DT/4DSegments/Pull/4D_W2_hPullAlpha");
+  MonitorElement * hPullBeta_W2 = getter.get("DT/4DSegments/Pull/4D_W2_hPullBeta");
+  MonitorElement * hPullX_W2 = getter.get("DT/4DSegments/Pull/4D_W2_hPullX");
+  MonitorElement * hPullY_W2 = getter.get("DT/4DSegments/Pull/4D_W2_hPullY");
+  MonitorElement * hPullBetaRZ_W2 = getter.get("DT/4DSegments/Pull/4D_W2_hPullBetaRZ");
+  MonitorElement * hPullYRZ_W2 = getter.get("DT/4DSegments/Pull/4D_W2_hPullYRZ");
   
   Tutils util;
   util.drawGFit(hResAlpha->getTH1(),-0.2,0.2,-0.1,0.1);
@@ -132,10 +136,14 @@ void DT4DSegmentClients::endLuminosityBlock(edm::LuminosityBlock const& lumi,
   util.drawGFit(hPullY_W2->getTH1(),-0.2,0.2,-0.1,0.1);
   util.drawGFit(hPullBetaRZ_W2->getTH1(),-0.2,0.2,-0.1,0.1);
   util.drawGFit(hPullYRZ_W2->getTH1(),-0.2,0.2,-0.1,0.1);
-}
 
-void DT4DSegmentClients::analyze(Event const& event, EventSetup const& setup)
-{
+  if (doall_) {
+    HEff4DHitHarvest hEff_S3RPhi("All", booker, getter);  
+    HEff4DHitHarvest hEff_S3RZ_W0("W0", booker, getter); 
+    HEff4DHitHarvest hEff_S3RZ_W1("W1", booker, getter); 
+    HEff4DHitHarvest hEff_S3RZ_W2("W2", booker, getter); 
+  }
+
 }
 
 // declare this as a framework plugin

--- a/Validation/DTRecHits/plugins/DT4DSegmentClients.h
+++ b/Validation/DTRecHits/plugins/DT4DSegmentClients.h
@@ -18,7 +18,7 @@ public:
   /// Constructor
   DT4DSegmentClients(const edm::ParameterSet& ps);
   /// Destructor
-  virtual ~DT4DSegmentClients();
+  ~DT4DSegmentClients() override;
 
 protected:
   /// End Job

--- a/Validation/DTRecHits/plugins/DT4DSegmentClients.h
+++ b/Validation/DTRecHits/plugins/DT4DSegmentClients.h
@@ -9,20 +9,24 @@
  *   
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class DT4DSegmentClients: public edm::EDAnalyzer {
+class DT4DSegmentClients: public DQMEDHarvester {
+
 public:
   /// Constructor
   DT4DSegmentClients(const edm::ParameterSet& ps);
+  /// Destructor
+  virtual ~DT4DSegmentClients();
 
-  /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& c) override;
+protected:
+  /// End Job
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
+
+private:
+  bool doall_;
+
 };
 
 #endif // Validation_DTRecHits_DT4DSegmentClients_h

--- a/Validation/DTRecHits/plugins/DTRecHitClients.cc
+++ b/Validation/DTRecHits/plugins/DTRecHitClients.cc
@@ -4,29 +4,38 @@
 #include "Validation/DTRecHits/interface/utils.h"
 
 #include "DTRecHitClients.h"
+#include "Histograms.h"
 
 using namespace std;
 using namespace edm;
 
-DTRecHitClients::DTRecHitClients(edm::ParameterSet const& config)
+DTRecHitClients::DTRecHitClients(edm::ParameterSet const& pset)
+{
+  // Switches for analysis at various steps
+  doStep1_ = pset.getUntrackedParameter<bool>("doStep1", false);
+  doStep2_ = pset.getUntrackedParameter<bool>("doStep2", false);
+  doStep3_ = pset.getUntrackedParameter<bool>("doStep3", false);
+  doall_ = pset.getUntrackedParameter<bool>("doall", false);
+  local_ = pset.getUntrackedParameter<bool>("local", true);
+}
+
+DTRecHitClients::~DTRecHitClients()
 {
 }
 
-void DTRecHitClients::endLuminosityBlock(edm::LuminosityBlock const& lumi,
-    edm::EventSetup const& setup)
+void DTRecHitClients::dqmEndJob(DQMStore::IBooker & booker, DQMStore::IGetter & getter)
 {
-  DQMStore* dbe = Service<DQMStore>().operator->();
-  MonitorElement * hRes_S3RPhi = dbe->get("DT/1DRecHits/Res/1D_S3RPhi_hRes");
-  MonitorElement * hRes_S3RZ = dbe->get("DT/1DRecHits/Res/1D_S3RZ_hRes");
-  MonitorElement * hRes_S3RZ_W0 = dbe->get("DT/1DRecHits/Res/1D_S3RZ_W0_hRes");
-  MonitorElement * hRes_S3RZ_W1 = dbe->get("DT/1DRecHits/Res/1D_S3RZ_W1_hRes");
-  MonitorElement * hRes_S3RZ_W2 = dbe->get("DT/1DRecHits/Res/1D_S3RZ_W2_hRes");
+  MonitorElement * hRes_S3RPhi = getter.get("DT/1DRecHits/Res/1D_S3RPhi_hRes");
+  MonitorElement * hRes_S3RZ = getter.get("DT/1DRecHits/Res/1D_S3RZ_hRes");
+  MonitorElement * hRes_S3RZ_W0 = getter.get("DT/1DRecHits/Res/1D_S3RZ_W0_hRes");
+  MonitorElement * hRes_S3RZ_W1 = getter.get("DT/1DRecHits/Res/1D_S3RZ_W1_hRes");
+  MonitorElement * hRes_S3RZ_W2 = getter.get("DT/1DRecHits/Res/1D_S3RZ_W2_hRes");
 
-  MonitorElement * hPull_S3RPhi = dbe->get("DT/1DRecHits/Pull/1D_S3RPhi_hPull");
-  MonitorElement * hPull_S3RZ = dbe->get("DT/1DRecHits/Pull/1D_S3RZ_hPull");
-  MonitorElement * hPull_S3RZ_W0 = dbe->get("DT/1DRecHits/Pull/1D_S3RZ_W0_hPull");
-  MonitorElement * hPull_S3RZ_W1 = dbe->get("DT/1DRecHits/Pull/1D_S3RZ_W1_hPull");
-  MonitorElement * hPull_S3RZ_W2 = dbe->get("DT/1DRecHits/Pull/1D_S3RZ_W2_hPull");
+  MonitorElement * hPull_S3RPhi = getter.get("DT/1DRecHits/Pull/1D_S3RPhi_hPull");
+  MonitorElement * hPull_S3RZ = getter.get("DT/1DRecHits/Pull/1D_S3RZ_hPull");
+  MonitorElement * hPull_S3RZ_W0 = getter.get("DT/1DRecHits/Pull/1D_S3RZ_W0_hPull");
+  MonitorElement * hPull_S3RZ_W1 = getter.get("DT/1DRecHits/Pull/1D_S3RZ_W1_hPull");
+  MonitorElement * hPull_S3RZ_W2 = getter.get("DT/1DRecHits/Pull/1D_S3RZ_W2_hPull");
 
   Tutils util;
   util.drawGFit(hRes_S3RPhi->getTH1(),-0.2,0.2,-0.1,0.1);
@@ -40,10 +49,46 @@ void DTRecHitClients::endLuminosityBlock(edm::LuminosityBlock const& lumi,
   util.drawGFit(hPull_S3RZ_W0->getTH1(),-5,5,-5,5);
   util.drawGFit(hPull_S3RZ_W1->getTH1(),-5,5,-5,5);
   util.drawGFit(hPull_S3RZ_W2->getTH1(),-5,5,-5,5);
-}
 
-void DTRecHitClients::analyze(Event const& event, EventSetup const& setup)
-{
+  if (doall_) {
+    HEff1DHitHarvest hEff_S3RPhi("S3RPhi", booker, getter);  
+    HEff1DHitHarvest hEff_S3RZ("S3RZ", booker, getter);    
+    HEff1DHitHarvest hEff_S3RZ_W0("S3RZ_W0", booker, getter); 
+    HEff1DHitHarvest hEff_S3RZ_W1("S3RZ_W1", booker, getter); 
+    HEff1DHitHarvest hEff_S3RZ_W2("S3RZ_W2", booker, getter); 
+
+    if (doStep1_) {
+      HEff1DHitHarvest hEff_S1RPhi("S1RPhi", booker, getter); 
+      HEff1DHitHarvest hEff_S1RZ("S1RZ", booker, getter);   
+      HEff1DHitHarvest hEff_S1RZ_W0("S1RZ_W0", booker, getter);
+      HEff1DHitHarvest hEff_S1RZ_W1("S1RZ_W1", booker, getter);
+      HEff1DHitHarvest hEff_S1RZ_W2("S1RZ_W2", booker, getter);
+    }
+
+    if (doStep2_) {
+      HEff1DHitHarvest hEff_S2RPhi("S2RPhi", booker, getter); 
+      HEff1DHitHarvest hEff_S2RZ_W0("S2RZ_W0", booker, getter);
+      HEff1DHitHarvest hEff_S2RZ_W1("S2RZ_W1", booker, getter);
+      HEff1DHitHarvest hEff_S2RZ_W2("S2RZ_W2", booker, getter);
+      HEff1DHitHarvest hEff_S2RZ("S2RZ", booker, getter);   
+    }
+  }
+
+  if (local_) {
+    // Plots with finer granularity, not to be included in DQM
+    TString name1 = "RPhi_W";
+    TString name2 = "RZ_W";
+    for (long w = 0; w <= 2; ++w) {
+      for (long s = 1;s <= 4; ++s) {
+	HEff1DHitHarvest hEff_S1RPhiWS(("S1"+name1+w+"_St"+s).Data(), booker, getter);
+	HEff1DHitHarvest hEff_S3RPhiWS(("S3"+name1+w+"_St"+s).Data(), booker, getter);
+	if (s != 4) {
+	  HEff1DHitHarvest hEff_S1RZWS(("S1"+name2+w+"_St"+s).Data(), booker, getter);
+	  HEff1DHitHarvest hEff_S3RZWS(("S3"+name2+w+"_St"+s).Data(), booker, getter);
+	}
+      }
+    }
+  }
 }
 
 // declare this as a framework plugin

--- a/Validation/DTRecHits/plugins/DTRecHitClients.h
+++ b/Validation/DTRecHits/plugins/DTRecHitClients.h
@@ -17,9 +17,8 @@ class DTRecHitClients: public DQMEDHarvester {
 public:
   /// Constructor
   DTRecHitClients(const edm::ParameterSet& ps);
-
   /// Destructor
-  ~ DTRecHitClients();
+  ~DTRecHitClients() override;
 
 protected:
   /// End Job

--- a/Validation/DTRecHits/plugins/DTRecHitClients.h
+++ b/Validation/DTRecHits/plugins/DTRecHitClients.h
@@ -9,21 +9,30 @@
  *   
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class DTRecHitClients: public edm::EDAnalyzer {
+class DTRecHitClients: public DQMEDHarvester {
+
 public:
   /// Constructor
   DTRecHitClients(const edm::ParameterSet& ps);
 
-  /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg,
-      edm::EventSetup const& c) override;
+  /// Destructor
+  ~ DTRecHitClients();
+
+protected:
+  /// End Job
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
+
+private:
+  // Switches for analysis at various steps
+  bool doStep1_;
+  bool doStep2_;
+  bool doStep3_;
+  bool local_;
+  bool doall_;
+
 };
 
 #endif // Validation_DTRecHits_DTRecHitClients_h

--- a/Validation/DTRecHits/plugins/DTRecHitQuality.cc
+++ b/Validation/DTRecHits/plugins/DTRecHitQuality.cc
@@ -51,8 +51,8 @@ DTRecHitQuality::DTRecHitQuality(const ParameterSet& pset) {
   doStep1_ = pset.getUntrackedParameter<bool>("doStep1", false);
   doStep2_ = pset.getUntrackedParameter<bool>("doStep2", false);
   doStep3_ = pset.getUntrackedParameter<bool>("doStep3", false);
-  doall_   = pset.getUntrackedParameter<bool>("doall", false);
-  local_   = pset.getUntrackedParameter<bool>("local", true);
+  doall_ = pset.getUntrackedParameter<bool>("doall", false);
+  local_ = pset.getUntrackedParameter<bool>("local", true);
 }
 
 void DTRecHitQuality::bookHistograms(DQMStore::ConcurrentBooker & booker, edm::Run const& run, edm::EventSetup const& setup, Histograms & histograms) const {
@@ -123,35 +123,6 @@ void DTRecHitQuality::bookHistograms(DQMStore::ConcurrentBooker & booker, edm::R
     }
   }
 }
-
-/* FIXME these shoud be moved to the harvesting step
-void DTRecHitQuality::endRun(... histograms) {
-  // Write the histos to file
-  if (doall_) {
-    if (doStep1_) {
-      histograms.hEff_S1RPhi->computeEfficiency();
-      histograms.hEff_S1RZ->computeEfficiency();
-      histograms.hEff_S1RZ_W0->computeEfficiency();
-      histograms.hEff_S1RZ_W1->computeEfficiency();
-      histograms.hEff_S1RZ_W2->computeEfficiency();
-    }
-    if (doStep2_) {
-      histograms.hEff_S2RPhi->computeEfficiency();
-      histograms.hEff_S2RZ->computeEfficiency();
-      histograms.hEff_S2RZ_W0->computeEfficiency();
-      histograms.hEff_S2RZ_W1->computeEfficiency();
-      histograms.hEff_S2RZ_W2->computeEfficiency();
-    }
-    if (doStep3_) {
-      histograms.hEff_S3RPhi->computeEfficiency();
-      histograms.hEff_S3RZ->computeEfficiency();
-      histograms.hEff_S3RZ_W0->computeEfficiency();
-      histograms.hEff_S3RZ_W1->computeEfficiency();
-      histograms.hEff_S3RZ_W2->computeEfficiency();
-    }
-  }
-}
-*/
 
 // The real analysis
 void DTRecHitQuality::dqmAnalyze(edm::Event const& event, edm::EventSetup const& setup, Histograms const& histograms) const {

--- a/Validation/DTRecHits/plugins/DTSegment2DQuality.cc
+++ b/Validation/DTRecHits/plugins/DTSegment2DQuality.cc
@@ -61,18 +61,8 @@ void DTSegment2DQuality::bookHistograms(DQMStore::ConcurrentBooker & booker, edm
   histograms.h2DHitEff_RZ_W2 = new HEff2DHit ("RZ_W2", booker);
   if (debug_) {
     cout << "[DTSegment2DQuality] hitsos created " << endl;
+  }
 }
-}
-
-/* FIXME these shoud be moved to the harvesting step
-void DTSegment2DQuality::endJob() {
-  histograms.h2DHitEff_RPhi->computeEfficiency();
-  histograms.h2DHitEff_RZ->computeEfficiency();
-  histograms.h2DHitEff_RZ_W0->computeEfficiency();
-  histograms.h2DHitEff_RZ_W1->computeEfficiency();
-  histograms.h2DHitEff_RZ_W2->computeEfficiency();
-}
-*/
 
 // The real analysis
 void DTSegment2DQuality::dqmAnalyze(edm::Event const& event, edm::EventSetup const& setup, Histograms const& histograms) const {
@@ -265,7 +255,7 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const& event, edm::EventSetup con
         hEff = histograms.h2DHitEff_RZ_W1;
       } else if (abs((*slId).wheel()) == 2) {
         hEff = histograms.h2DHitEff_RZ_W2;
-}
+      }
     }
     hEff->fill(etaSimSeg, phiSimSeg, posSimSeg, angleSimSeg, recHitFound);
   } // End of loop over superlayers

--- a/Validation/DTRecHits/plugins/DTSegment2DSLPhiQuality.cc
+++ b/Validation/DTRecHits/plugins/DTSegment2DSLPhiQuality.cc
@@ -53,12 +53,6 @@ void DTSegment2DSLPhiQuality::bookHistograms(DQMStore::ConcurrentBooker & booker
 }
 }
 
-/* FIXME these shoud be moved to the harvesting step
-void DTSegment2DSLPhiQuality::endJob() {
-   if (doall_) histograms.h2DHitEff_SuperPhi->computeEfficiency();
-}
-*/
-
 // The real analysis
 void DTSegment2DSLPhiQuality::dqmAnalyze(edm::Event const& event, edm::EventSetup const& setup, Histograms const& histograms) const {
   // Get the DT Geometry

--- a/Validation/DTRecHits/plugins/DTSegment4DQuality.cc
+++ b/Validation/DTRecHits/plugins/DTSegment4DQuality.cc
@@ -86,17 +86,6 @@ void DTSegment4DQuality::bookHistograms(DQMStore::ConcurrentBooker & booker, edm
   }
 };
 
-/* FIXME these shoud be moved to the harvesting step
-void DTSegment4DQuality::endJob() {
-  if (doall_) {
-    histograms.hEff_All->computeEfficiency();
-    histograms.hEff_W0->computeEfficiency();
-    histograms.hEff_W1->computeEfficiency();
-    histograms.hEff_W2->computeEfficiency();
-  }
-}
-*/
-
 // The real analysis
 void DTSegment4DQuality::dqmAnalyze(edm::Event const& event, edm::EventSetup const& setup, Histograms const& histograms) const {
   const float epsilon = 5e-5; // numerical accuracy on angles [rad}

--- a/Validation/DTRecHits/plugins/Histograms.h
+++ b/Validation/DTRecHits/plugins/Histograms.h
@@ -138,6 +138,7 @@ class HEff1DHit {
       name_ = pre;
       booker.setCurrentFolder("DT/1DRecHits/");
       hEtaMuSimHit  = booker.book1D(pre + "_hEtaMuSimHit", "SimHit Eta distribution", 100, -1.5, 1.5);
+      hEtaRecHit    = booker.book1D(pre + "_hEtaRecHit", "SimHit Eta distribution with 1D RecHit", 100, -1.5, 1.5);
       hPhiMuSimHit  = booker.book1D(pre + "_hPhiMuSimHit", "SimHit Phi distribution", 100, -M_PI, M_PI);
       hPhiRecHit    = booker.book1D(pre + "_hPhiRecHit", "SimHit Phi distribution with 1D RecHit", 100, -M_PI, M_PI);
       hDistMuSimHit = booker.book1D(pre + "_hDistMuSimHit", "SimHit Distance from wire distribution", 100, 0, 2.5);

--- a/Validation/DTRecHits/python/DTRecHitClients_cfi.py
+++ b/Validation/DTRecHits/python/DTRecHitClients_cfi.py
@@ -1,8 +1,22 @@
 import FWCore.ParameterSet.Config as cms
 
-dtrechitclients = cms.EDAnalyzer("DTRecHitClients")
-dt2dsegmentclients = cms.EDAnalyzer("DT2DSegmentClients")
-dt4dsegmentclients = cms.EDAnalyzer("DT4DSegmentClients")
+dtrechitclients = cms.EDProducer("DTRecHitClients",
+    doStep2 = cms.untracked.bool(False),
+    # Switches for analysis at various steps
+    doStep1 = cms.untracked.bool(False),
+    # Lable to retrieve RecHits from the event
+    doStep3 = cms.untracked.bool(True),
+    doall   = cms.untracked.bool(False),
+    local   = cms.untracked.bool(False)
+)
+
+dt2dsegmentclients = cms.EDProducer("DT2DSegmentClients",
+    do2D    = cms.untracked.bool(False),
+    doSLPhi = cms.untracked.bool(False)
+)
+dt4dsegmentclients = cms.EDProducer("DT4DSegmentClients",
+    doall = cms.untracked.bool(False)
+)
                                
 ##dtLocalRecoValidationClients = cms.Sequence(dt2dsegmentclients*dt4dsegmentclients)
 dtLocalRecoValidationClients = cms.Sequence(dtrechitclients*dt2dsegmentclients*dt4dsegmentclients)

--- a/Validation/DTRecHits/python/DTRecHitQuality_cfi.py
+++ b/Validation/DTRecHits/python/DTRecHitQuality_cfi.py
@@ -13,7 +13,6 @@ rechivalidation = cms.EDAnalyzer("DTRecHitQuality",
     segment4DLabel = cms.untracked.InputTag('dt4DSegments'),
     doall = cms.untracked.bool(False),
     local = cms.untracked.bool(False)
-
 )
 
 seg2dvalidation = cms.EDAnalyzer("DTSegment2DQuality",


### PR DESCRIPTION
This PR follows up on the migration of the DQM clients of Validation/DTRecHit not touched in [PR 22082](https://github.com/cms-sw/cmssw/pull/22082) (from @fwyzard).

Includes:
- new classes to handle efficiencies harvesting in `plugins/Histograms.h`
- migration of the existing clients to `DQMEDHarvester`
- moving the computation of efficiency plots into clients
- extension of the `DTRecHitClients_cfi` configuration