### PR TITLE
New fastsim geometry fix

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
@@ -84,8 +84,8 @@ class FastSimProducer : public edm::stream::EDProducer<> {
     std::unique_ptr<RandomEngineAndDistribution> _randomEngine;  //!< The random engine
 
     bool simulateCalorimetry;
-    edm::ESWatcher<CaloGeometryRecord> watchCaloGeometry_;  //!< Watch calorimeter geometry
-    edm::ESWatcher<CaloTopologyRecord> watchCaloTopology_;  //!< Watch calorimeter geometry
+    edm::ESWatcher<CaloGeometryRecord> watchCaloGeometry_;  
+    edm::ESWatcher<CaloTopologyRecord> watchCaloTopology_;  
     std::unique_ptr<CalorimetryManager> myCalorimetry; // unfortunately, default constructor cannot be called 
     bool simulateMuons;    
 
@@ -201,7 +201,7 @@ FastSimProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     if(simulateCalorimetry)
     {
         if(watchCaloGeometry_.check(iSetup) || watchCaloTopology_.check(iSetup)){
-           edm::ESHandle<CaloGeometry> pG;
+            edm::ESHandle<CaloGeometry> pG;
             iSetup.get<CaloGeometryRecord>().get(pG);   
             myCalorimetry->getCalorimeter()->setupGeometry(*pG); 
                 

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
@@ -13,6 +13,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
 
 // data formats
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
@@ -83,7 +84,9 @@ class FastSimProducer : public edm::stream::EDProducer<> {
     std::unique_ptr<RandomEngineAndDistribution> _randomEngine;  //!< The random engine
 
     bool simulateCalorimetry;
-    std::unique_ptr<CalorimetryManager> myCalorimetry; // unfortunately, default constructor cannot be called
+    edm::ESWatcher<CaloGeometryRecord> watchCaloGeometry_;  //!< Watch calorimeter geometry
+    edm::ESWatcher<CaloTopologyRecord> watchCaloTopology_;  //!< Watch calorimeter geometry
+    std::unique_ptr<CalorimetryManager> myCalorimetry; // unfortunately, default constructor cannot be called 
     bool simulateMuons;    
 
     fastsim::Decayer decayer_;  //!< Handles decays of non-stable particles using pythia
@@ -197,17 +200,20 @@ FastSimProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     //  Initialize the calorimeter geometry
     if(simulateCalorimetry)
     {
-        edm::ESHandle<CaloGeometry> pG;
-        iSetup.get<CaloGeometryRecord>().get(pG);   
-        myCalorimetry->getCalorimeter()->setupGeometry(*pG);
+        if(watchCaloGeometry_.check(iSetup) || watchCaloTopology_.check(iSetup)){
+           edm::ESHandle<CaloGeometry> pG;
+            iSetup.get<CaloGeometryRecord>().get(pG);   
+            myCalorimetry->getCalorimeter()->setupGeometry(*pG); 
+                
+            edm::ESHandle<CaloTopology> theCaloTopology;
+            iSetup.get<CaloTopologyRecord>().get(theCaloTopology);     
+            myCalorimetry->getCalorimeter()->setupTopology(*theCaloTopology);
+            myCalorimetry->getCalorimeter()->initialize(geometry_.getMagneticFieldZ(math::XYZTLorentzVector(0., 0., 0., 0.)));
 
-        edm::ESHandle<CaloTopology> theCaloTopology;
-        iSetup.get<CaloTopologyRecord>().get(theCaloTopology);     
-        myCalorimetry->getCalorimeter()->setupTopology(*theCaloTopology);
-        myCalorimetry->getCalorimeter()->initialize(geometry_.getMagneticFieldZ(math::XYZTLorentzVector(0., 0., 0., 0.)));
+            myCalorimetry->getHFShowerLibrary()->initHFShowerLibrary(iSetup);
+        }
 
-        myCalorimetry->getHFShowerLibrary()->initHFShowerLibrary(iSetup);
-
+        // Important: this also cleans the calorimetry information from the last event
         myCalorimetry->initialize(_randomEngine.get());
     }
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/HelixTrajectory.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/HelixTrajectory.cc
@@ -97,7 +97,7 @@ double fastsim::HelixTrajectory::nextCrossingTimeC(const BarrelSimplifiedGeometr
     {   
         // Should not be reached: Full Propagation does always have a solution "if(crosses(layer)) == -1"
         // Even if particle is outside all layers -> can turn around in magnetic field
-        throw cms::Exception("FastSimulation") << "HelixTrajectory: should not be reached (no solution).";
+        return -1;
     }
 
     // Uses a numerically more stable procedure:


### PR DESCRIPTION
Fixes 2 important issues with PR 20666
https://github.com/cms-sw/cmssw/pull/20666

- Calorimetry was initialized for every event which increased timing by about 30s/evt
- An exception left from debugging was still in the code. Instead -1 is return now, to make sure the code does not crash (safety for numerical instabilites for 'strange' tracks)