### PR TITLE
overriding inefficient CalosubdetectorGeometry::present function

### DIFF
--- a/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
@@ -103,6 +103,9 @@ class EcalBarrelGeometry final : public CaloSubdetectorGeometry
 			    const GlobalPoint& f3 ,
 			    const CCGFloat*    parm ,
 			    const DetId&       detId ) override ;
+
+      bool present( const DetId& id ) const override;
+
    protected:
 
       // Modify the RawPtr class

--- a/Geometry/EcalAlgo/interface/EcalEndcapGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalEndcapGeometry.h
@@ -99,6 +99,8 @@ class EcalEndcapGeometry final: public CaloSubdetectorGeometry
 			    const CCGFloat*    parm ,
 			    const DetId&       detId   ) override ;
 
+      bool present( const DetId& id ) const override;
+
    protected:
 
       // Modify the RawPtr class

--- a/Geometry/EcalAlgo/src/EcalBarrelGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalBarrelGeometry.cc
@@ -499,3 +499,14 @@ const CaloCellGeometry* EcalBarrelGeometry::getGeometryRawPtr (uint32_t index) c
   return (m_cellVec.size() < index ||
 	  nullptr == cell->param() ? nullptr : cell);
 }
+
+bool EcalBarrelGeometry::present( const DetId& id ) const
+{
+  if(id.det()==DetId::Ecal && id.subdetId()==EcalBarrel){
+    EBDetId ebId(id);
+    if(EBDetId::validDetId(ebId.ieta(),ebId.iphi())) return true;
+  }
+  return false;
+
+}
+ 

--- a/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
@@ -522,3 +522,12 @@ const CaloCellGeometry* EcalEndcapGeometry::getGeometryRawPtr(uint32_t index) co
   return (m_cellVec.size() < index ||
 	  nullptr == cell->param() ? nullptr : cell);
 }
+
+bool EcalEndcapGeometry::present( const DetId& id ) const
+{
+  if(id.det()==DetId::Ecal && id.subdetId()==EcalEndcap){
+    EEDetId eeId(id);
+    if(EEDetId::validDetId(eeId.ix(),eeId.iy(),eeId.zside())) return true;
+  }
+  return false;
+}


### PR DESCRIPTION

First, I suspect this is a blocker for all 10_X MC production as it will take a larger than expected CPU time which may or may not be significant.

Also this is a bit of a drive by bug fix as I happened to come across it and needed it fixed for my own purposes. If this fix requires things beyond what is already here, I'm sure @bsunanda as the author of the problem PR will be able to assist in fixing it promptly. 

https://github.com/cms-sw/cmssw/pull/21808 updated the CalosubdetectorGeometry::present function with an non-optimally coded version (it has a vector of all valid DetIds and basically compares the current DetId one by one with these to see if its valid).  
This cripples the HLT from a timing perspective (doubles it) due to PFRecHit associating its neighbours which involves a lot of calo topology operations which each time requires a call to CalosubdetectorGeometry::present to check its a valid ID.  It surprises me that it does not also significantly impact RECO timing, something is odd here. Regardless the HLT timing issue is real and needs to be urgently fixed.  This PR solves the issue. 

igprof: pre this PR (10_0_1, HLT Physics sample): http://sharper.web.cern.ch/sharper/cgi-bin/igprof-navigator/1001HLTTiming/igreport_default
igprof: post this PR (10_0_1, HLT Physics sample): http://sharper.web.cern.ch/sharper/cgi-bin/igprof-navigator/1001HLTTiming/igreport_ecalGeomFix

Time from ~500ms / event to 250 ms / event based on 1K input. 

@Martin-Grunewald FYI