### PR TITLE
overriding inefficient CalosubdetectorGeometry::present function :100X backport

### DIFF
--- a/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
@@ -103,6 +103,9 @@ class EcalBarrelGeometry final : public CaloSubdetectorGeometry
 			    const GlobalPoint& f3 ,
 			    const CCGFloat*    parm ,
 			    const DetId&       detId ) override ;
+
+      bool present( const DetId& id ) const override;
+
    protected:
 
       // Modify the RawPtr class

--- a/Geometry/EcalAlgo/interface/EcalEndcapGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalEndcapGeometry.h
@@ -99,6 +99,8 @@ class EcalEndcapGeometry final: public CaloSubdetectorGeometry
 			    const CCGFloat*    parm ,
 			    const DetId&       detId   ) override ;
 
+      bool present( const DetId& id ) const override;
+
    protected:
 
       // Modify the RawPtr class

--- a/Geometry/EcalAlgo/src/EcalBarrelGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalBarrelGeometry.cc
@@ -499,3 +499,14 @@ const CaloCellGeometry* EcalBarrelGeometry::getGeometryRawPtr (uint32_t index) c
   return (m_cellVec.size() < index ||
 	  nullptr == cell->param() ? nullptr : cell);
 }
+
+bool EcalBarrelGeometry::present( const DetId& id ) const
+{
+  if(id.det()==DetId::Ecal && id.subdetId()==EcalBarrel){
+    EBDetId ebId(id);
+    if(EBDetId::validDetId(ebId.ieta(),ebId.iphi())) return true;
+  }
+  return false;
+
+}
+ 

--- a/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
@@ -522,3 +522,12 @@ const CaloCellGeometry* EcalEndcapGeometry::getGeometryRawPtr(uint32_t index) co
   return (m_cellVec.size() < index ||
 	  nullptr == cell->param() ? nullptr : cell);
 }
+
+bool EcalEndcapGeometry::present( const DetId& id ) const
+{
+  if(id.det()==DetId::Ecal && id.subdetId()==EcalEndcap){
+    EEDetId eeId(id);
+    if(EEDetId::validDetId(eeId.ix(),eeId.iy(),eeId.zside())) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Dear All,

This is the 100X backport of https://github.com/cms-sw/cmssw/pull/22205 which addresses prohibitive HLT CPU issues in 10X. 