### PR TITLE
DAQ file locking compatibility fix for CC 7.4 (master)

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -128,7 +128,7 @@ namespace evf{
 
     private:
       bool bumpFile(unsigned int& ls, unsigned int& index, std::string& nextFile, uint32_t& fsize, int maxLS);
-      void openFULockfileStream(std::string& fuLockFilePath, bool create);
+      void openFULockfileStream(bool create);
       std::string inputFileNameStem(const unsigned int ls, const unsigned int index) const;
       std::string outputFileNameStem(const unsigned int ls, std::string const& stream) const;
       std::string mergedFileNameStem(const unsigned int ls, std::string const& stream) const;
@@ -153,6 +153,7 @@ namespace evf{
       std::string run_dir_;
       std::string bu_run_dir_;
       std::string bu_run_open_dir_;
+      std::string fulockfile_;
 
       int bu_readlock_fd_;
       int bu_writelock_fd_;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -791,7 +791,7 @@ namespace evf {
 		<< fu_readwritelock_fd_;
 
     fu_rw_lock_stream = fdopen(fu_readwritelock_fd_, "r+");
-    if (fu_rw_lock_stream == NULL)
+    if (fu_rw_lock_stream == nullptr)
       edm::LogError("EvFDaqDirector") << "problem with opening fuwritelock file stream -: " << strerror(errno);
 
   }
@@ -926,12 +926,12 @@ namespace evf {
       }
     }
     //return empty if strict check parameter is not on
-    if (!requireTSPSet_ && (selectedTransferMode_=="" || selectedTransferMode_=="null")) {
+    if (!requireTSPSet_ && (selectedTransferMode_.empty() || selectedTransferMode_=="null")) {
       edm::LogWarning("EvFDaqDirector") << "Selected mode string is not provided as DaqDirector parameter."
                                         << "Switch on requireTSPSet parameter to enforce this requirement. Setting mode to empty string.";
       return std::string("Failsafe");
     }
-    if (requireTSPSet_ && (selectedTransferMode_=="" || selectedTransferMode_=="null")) {
+    if (requireTSPSet_ && (selectedTransferMode_.empty() || selectedTransferMode_=="null")) {
       throw cms::Exception("EvFDaqDirector") << "Selected mode string is not provided as DaqDirector parameter.";
     }
     //check if stream has properly listed transfer stream
@@ -951,7 +951,7 @@ namespace evf {
     std::string ret;
     for (Json::Value::iterator it = destsVec.begin(); it!=destsVec.end(); it++)
     {
-      if (ret!="") ret +=",";
+      if (!ret.empty()) ret +=",";
       ret+=(*it).asString();
     }
     return ret;


### PR DESCRIPTION
In CERN CentOS 7.4 a different behavior of file locking on NFS (v4) was observed, causing modifications of the locked file not being properly synchronized over NFS between client hosts.
Workaround, which has been proven to fix the problem in production DAQ, consists of opening another file descriptor and file stream for the same lock file within the critical section of the file locking code.

This modification is necessary to have functional HLT processing on hostswith CC 7.4

#22215 is a backport to 10X.