### PR TITLE
Bug fix: remove empty or undefined methods

### DIFF
--- a/DQM/TrigXMonitor/interface/HLTScalers.h
+++ b/DQM/TrigXMonitor/interface/HLTScalers.h
@@ -66,8 +66,8 @@
 class HLTScalers : public DQMEDAnalyzer {
  public:
   HLTScalers(const edm::ParameterSet &ps);
-  ~HLTScalers() override{};
-  void beginJob(void);
+  ~HLTScalers() override = default;
+
   void dqmBeginRun(const edm::Run &run, const edm::EventSetup &c) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &,
                       edm::EventSetup const &) override;

--- a/DQMOffline/CalibCalo/src/DQMSourcePi0.cc
+++ b/DQMOffline/CalibCalo/src/DQMSourcePi0.cc
@@ -321,25 +321,9 @@ void DQMSourcePi0::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & 
 
   hS4S92EtaEE_ = ibooker.book1D("S4S92EtaEE","S4S9 2nd most energetic Pi0 photon in EE",50,0.,1.);
   hS4S92EtaEE_->setAxisTitle("S4S9 of the 2nd Eta Photon",1);
-
-  
-
-
-}
-
-//--------------------------------------------------------
-//void DQMSourcePi0::beginRun(const edm::Run& r, const EventSetup& context) {
-//
-//}
-
-//--------------------------------------------------------
-void DQMSourcePi0::beginLuminosityBlock(const LuminosityBlock& lumiSeg, 
-     const EventSetup& context) {
-  
 }
 
 //-------------------------------------------------------------
-
 void DQMSourcePi0::analyze(const Event& iEvent, 
 			       const EventSetup& iSetup ){  
  
@@ -1499,28 +1483,6 @@ void DQMSourcePi0::analyze(const Event& iEvent,
 
 
 } 
-
-
-
-
-//--------------------------------------------------------
-void DQMSourcePi0::endLuminosityBlock(const LuminosityBlock& lumiSeg, 
-                                          const EventSetup& context) {
-}
-//--------------------------------------------------------
-void DQMSourcePi0::endRun(const Run& r, const EventSetup& context){
-
-}
-//--------------------------------------------------------
-void DQMSourcePi0::endJob(){
-
-//  if(dbe_) {  
-//    if (saveToFile_) {
-//      dbe_->save(fileName_);
-//    }
-//  }
-}
-
 
 void DQMSourcePi0::convxtalid(Int_t &nphi,Int_t &neta)
 {

--- a/DQMOffline/CalibCalo/src/DQMSourcePi0.h
+++ b/DQMOffline/CalibCalo/src/DQMSourcePi0.h
@@ -50,30 +50,14 @@ public:
 
 protected:
    
-  void beginJob();
-
-//  void beginRun(const edm::Run& r, const edm::EventSetup& c);
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event& e, const edm::EventSetup& c) override ;
-
-  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                            const edm::EventSetup& context)  override;
-
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                          const edm::EventSetup& c) override;
-
-  void endRun(const edm::Run& r, const edm::EventSetup& c) override;
-
-  void endJob();
 
   void convxtalid(int & , int &);
   int diff_neta_s(int,int);
   int diff_nphi_s(int,int);
 
-
-
 private:
- 
 
   int eventCounter_;      
   PositionCalc posCalculator_ ;                        
@@ -344,4 +328,3 @@ private:
 };
 
 #endif
-

--- a/HLTriggerOffline/Egamma/interface/EmDQMReco.h
+++ b/HLTriggerOffline/Egamma/interface/EmDQMReco.h
@@ -90,11 +90,8 @@ public:
   ~EmDQMReco() override;
 
   // Operations
-
   void analyze(const edm::Event & event, const edm::EventSetup&) override;
-  void beginJob();
-  void endJob();
-  void dqmBeginRun( const edm::Run&, const edm::EventSetup& ) override;
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup& ) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:

--- a/HLTriggerOffline/Egamma/src/EmDQMReco.cc
+++ b/HLTriggerOffline/Egamma/src/EmDQMReco.cc
@@ -889,11 +889,4 @@ template <class T> void HistoFillerReco<T>::fillHistos(edm::Handle<trigger::Trig
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-//      method called once each job just after ending the event loop          //
-////////////////////////////////////////////////////////////////////////////////
-void EmDQMReco::endJob(){
-
-}
-
 DEFINE_FWK_MODULE(EmDQMReco);


### PR DESCRIPTION
Remove undefined methods that can lead to vtable link errors.
At the same time, remove unused or empty methods in the same files.