### PR TITLE
Add Run2_2017_lowPU era for Run2017H

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_lowPU.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_lowPU.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2017_lowpU_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run2_2017_lowPU_cff import Run2_2017_lowPU
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run2_2017_lowPU(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.addEI=True
+        self.isRepacked=True
+        self.eras=Run2_2017_lowPU
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_lowPU' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_lowPU' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_lowPU' ]
+    """
+    _ppEra_Run2_2017_lowPU_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -67,6 +67,10 @@ def customisePostEra_Run2_2017_pp_on_XeXe(process):
 def customisePostEra_Run2_2017_ppRef(process):
     customisePostEra_Run2_2017(process)
     return process
+  
+def customisePostEra_Run2_2017_lowPU(process):
+    customisePostEra_Run2_2017(process)
+    return process
 
 ##############################################################################
 def customisePPData(process):

--- a/Configuration/Eras/python/Era_Run2_2017_lowPU_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_lowPU_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2017_ppRef_cff import Run2_2017_ppRef
+from Configuration.Eras.Modifier_lowPU_2017_cff import lowPU_2017
+
+Run2_2017_lowPU = cms.ModifierChain(Run2_2017_ppRef, lowPU_2017)

--- a/Configuration/Eras/python/Modifier_lowPU_2017_cff.py
+++ b/Configuration/Eras/python/Modifier_lowPU_2017_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+lowPU_2017 =  cms.Modifier()
+

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -25,6 +25,7 @@ class Eras (object):
                  'Run2_2017_trackingLowPU',
                  'Run2_2017_pp_on_XeXe',
                  'Run2_2017_ppRef',
+                 'Run2_2017_lowPU',
                  'Run2_2018',
                  'Run3',
                  'Phase2',

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -16,7 +16,7 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
            cms.PSet(
              name = cms.string("PFEBRecHitCreator"),
              src  = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
-             srFlags = cms.InputTag("ecalDigis"),
+             srFlags = particle_flow_sr_flags.pfsrFlags,
              qualityTests = cms.VPSet(
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECALMultiThreshold"),
@@ -34,7 +34,7 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
           cms.PSet(
             name = cms.string("PFEERecHitCreator"),
             src  = cms.InputTag("ecalRecHit","EcalRecHitsEE"),
-            srFlags = cms.InputTag("ecalDigis"),
+            srFlags = particle_flow_sr_flags.pfsrFlags,
             qualityTests = cms.VPSet(
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECALMultiThreshold"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
@@ -27,6 +27,14 @@ _particle_flow_zero_suppression_ECAL_2017 = cms.PSet(
     thresholds = cms.vdouble(_pfZeroSuppressionThresholds_EB_2017 + _pfZeroSuppressionThresholds_EEminus_2017 + _pfZeroSuppressionThresholds_EEplus_2017
         )
     )
+    
+particle_flow_sr_flags = cms.PSet(    
+  pfsrFlags = cms.InputTag("ecalDigis")
+)
+
+_particle_flow_sr_flags_2016 = cms.PSet(    
+  pfsrFlags = cms.InputTag("")
+)
 
 from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
 run2_ECAL_2017.toReplaceWith(particle_flow_zero_suppression_ECAL, _particle_flow_zero_suppression_ECAL_2017)
@@ -36,3 +44,4 @@ phase2_ecal.toReplaceWith(particle_flow_zero_suppression_ECAL, _particle_flow_ze
 
 from Configuration.Eras.Modifier_lowPU_2017_cff import lowPU_2017
 lowPU_2017.toReplaceWith(particle_flow_zero_suppression_ECAL, _particle_flow_zero_suppression_ECAL_2016)
+lowPU_2017.toReplaceWith(particle_flow_sr_flags, _particle_flow_sr_flags_2016)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
@@ -17,6 +17,11 @@ particle_flow_zero_suppression_ECAL = cms.PSet(
     thresholds = cms.vdouble(pfZeroSuppressionThresholds_EB + pfZeroSuppressionThresholds_EEminus + pfZeroSuppressionThresholds_EEplus
         )
     )
+    
+_particle_flow_zero_suppression_ECAL_2016 = cms.PSet(
+    thresholds = cms.vdouble(pfZeroSuppressionThresholds_EB + pfZeroSuppressionThresholds_EEminus + pfZeroSuppressionThresholds_EEplus
+        )
+    )
 
 _particle_flow_zero_suppression_ECAL_2017 = cms.PSet(
     thresholds = cms.vdouble(_pfZeroSuppressionThresholds_EB_2017 + _pfZeroSuppressionThresholds_EEminus_2017 + _pfZeroSuppressionThresholds_EEplus_2017
@@ -28,3 +33,6 @@ run2_ECAL_2017.toReplaceWith(particle_flow_zero_suppression_ECAL, _particle_flow
 
 from Configuration.Eras.Modifier_phase2_ecal_cff import phase2_ecal
 phase2_ecal.toReplaceWith(particle_flow_zero_suppression_ECAL, _particle_flow_zero_suppression_ECAL_2017)
+
+from Configuration.Eras.Modifier_lowPU_2017_cff import lowPU_2017
+lowPU_2017.toReplaceWith(particle_flow_zero_suppression_ECAL, _particle_flow_zero_suppression_ECAL_2016)


### PR DESCRIPTION
Run2017H (13TeV low pileup run) was collected with ECAL Zero Suppression and selective readout settings in hardware reverted to 2016 conditions.

This adds a dedicated era (building off Run2_2017_ppRef) which reverts the corresponding ecal pf thresholds to the 2016 settings, as well as disabling offline selective readout in pflow.  This would be possibly intended to be used for the ReReco of Run2017H (and possibly also G) plus corresponding low PU 13 TeV (and possibly 5 TeV) Monte Carlo.

This era therefore is identical to the Run 2 default in CMSSW 10x in this respect, and therefore there is no need for any change in master, and the dedicated era is only required for 94x.

IMPORTANT:  This should not be merged yet, pending the discussion in the PPD meeting Feb. 15, since it's not decided yet whether or not to do this (and if so only for Run2017H or also for Run2017G)