### PR TITLE
remove all zero pt particles in constituent subtraction used for heavy ion events

### DIFF
--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -111,6 +111,7 @@ void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iS
     subtractor.set_max_distance(csRParam_); // free parameter for the maximal allowed distance between particle i and ghost k
     subtractor.set_alpha(csAlpha_);  // free parameter for the distance measure (the exponent of particle pt). Note that in older versions of the package alpha was multiplied by two but in newer versions this is not the case anymore
     subtractor.set_do_mass_subtraction(true);
+    subtractor.set_remove_all_zero_pt_particles(true);
 
     std::vector<fastjet::PseudoJet> subtracted_particles = subtractor.do_subtraction(particles,ghosts);
 


### PR DESCRIPTION
this defaults back the constituent subtraction to the previous behaviour since the default changed in 1.032 of the contrib package. See discussion here cms-sw/cmsdist#3732

It has been tested with wf 150.0 and the updated cms external fastjet packages

@rappoccio @slava77 @mandrenguyen 