### PR TITLE
set serial option for TH1::Fit in BeamSpotProducer

### DIFF
--- a/RecoVertex/BeamSpotProducer/src/BSFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BSFitter.cc
@@ -371,7 +371,7 @@ reco::BeamSpot BSFitter::Fit_z_chi2(double *inipar) {
 	//Use our own copy for thread safety
         // also do not add to global list of functions
 	TF1 fgaus("fgaus","gaus",0.,1.,TF1::EAddToList::kNo);
-	h1z->Fit(&fgaus,"QLMN0");
+	h1z->Fit(&fgaus,"QLMN0 SERIAL");
 	//std::cout << "fitted "<< std::endl;
 
 	//std::cout << "got function" << std::endl;
@@ -581,7 +581,7 @@ reco::BeamSpot BSFitter::Fit_d0phi() {
 	TF1 fgaus("fgaus","gaus",0.,1.,TF1::EAddToList::kNo);
 	//returns 0 if OK
 	//auto status = h1z->Fit(&fgaus,"QLM0","",h1z->GetMean() -2.*h1z->GetRMS(),h1z->GetMean() +2.*h1z->GetRMS());
-	auto status = h1z->Fit(&fgaus,"QLN0","",h1z->GetMean() -2.*h1z->GetRMS(),h1z->GetMean() +2.*h1z->GetRMS());
+	auto status = h1z->Fit(&fgaus,"QLN0 SERIAL","",h1z->GetMean() -2.*h1z->GetRMS(),h1z->GetMean() +2.*h1z->GetRMS());
 
 	//std::cout << "fitted "<< std::endl;
 

--- a/RecoVertex/BeamSpotProducer/src/PVFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/PVFitter.cc
@@ -335,9 +335,9 @@ bool PVFitter::runFitter() {
     TF1 gausy("localGausY","gaus",0.,1.,TF1::EAddToList::kNo);
     TF1 gausz("localGausZ","gaus",0.,1.,TF1::EAddToList::kNo);
 
-    h1PVx->Fit(&gausx,"QLMN0");
-    h1PVy->Fit(&gausy,"QLMN0");
-    h1PVz->Fit(&gausz,"QLMN0");
+    h1PVx->Fit(&gausx,"QLMN0 SERIAL");
+    h1PVy->Fit(&gausy,"QLMN0 SERIAL");
+    h1PVz->Fit(&gausz,"QLMN0 SERIAL");
 
 
     fwidthX     = gausx.GetParameter(2);


### PR DESCRIPTION
Interactions between TMinuit thread local variables and implicit multi-threading in the evaluation of the fit are suspected to be a cause of crashes in AlcaBeamMonitor, details are in #21769 (long).  This PR sets the SERIAL option to the calls to TH1::Fit, which turns off the use of IMT in the fit evaluation.