### PR TITLE
Fix testRandomService.sh unit test

### DIFF
--- a/IOMC/RandomEngine/test/testRandomService.sh
+++ b/IOMC/RandomEngine/test/testRandomService.sh
@@ -107,15 +107,15 @@ pushd ${LOCAL_TMP_DIR}
   then
     echo running cmsRun with StashStateStream.data_2
     mv stream2LastEvent.txt lastEvent.txt
-  elif [ -f StashStateFork.data_1 ]
+  elif [ -f StashStateStream.data_1 ]
   then
-    echo running cmsRun with StashStateFork.data_1
-    mv StashStateFork.data_1 StashStateFork.data_2
+    echo running cmsRun with StashStateStream.data_1
+    mv StashStateStream.data_1 StashStateStream.data_2
     mv stream1LastEvent.txt lastEvent.txt
-  elif [ -f StashStateFork.data_0 ]
+  elif [ -f StashStateStream.data_0 ]
   then
-    echo running cmsRun with StashStateFork.data_0
-    mv StashStateFork.data_0 StashStateFork.data_2
+    echo running cmsRun with StashStateStream.data_0
+    mv StashStateStream.data_0 StashStateStream.data_2
     mv stream0LastEvent.txt lastEvent.txt
   else
     echo Error: Text file containing states not found


### PR DESCRIPTION
If the multistream test doesn't run any event on stream 2, the file `StashStateStream.data_2` is not created. The logic in the test script looks like it should fall back to `StashStateStream.data_1` (and `..._0`), but the subsequent tests are done agains `StashStateFork.data_1` (and `..._0`). This PR fixes the unit test by replacing all `StashStateFork` with `StashStateStream`. I tested that the fix works by manually removing the `..._2/1/0` files (within the script).

I can only wonder why we haven't seen this case before the PR tests #22069 (where it has failed twice; or maybe we have seen it and it has just been though transient and ignored).

Tested in CMSSW_10_1_X_2018-02-08-2300, no changes expected.