### PR TITLE
Fix RecoTrack/DebugTools BuildFile.xml

### DIFF
--- a/RecoTracker/DebugTools/plugins/BuildFile.xml
+++ b/RecoTracker/DebugTools/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="RecoTracker/DebugTools"/>
 <use   name="RecoTracker/CkfPattern"/>
 <use   name="SimTracker/Records"/>
 <use   name="SimTracker/TrackAssociation"/>


### PR DESCRIPTION
I got tired on seeing scram complaining a non-existing library in this `BuildFile.xml`.

Tested in CMSSW_10_1_X_2018-02-08-2300, no changes expected.