### PR TITLE
Enable option for ALCT-centric matching

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -116,11 +116,13 @@ class CSCCorrelatedLCTDigi
 
   /// SIMULATION ONLY ////
   enum Type{CLCTALCT, // CLCT-centric
-	    ALCTCLCT, // ALCT-centric
-	    ALCTCLCTGEM, // ALCT-CLCT-1 GEM pad
-	    ALCTCLCT2GEM, // ALCT-CLCT-2 GEM pads in coincidence
-	    ALCT2GEM, // ALCT-2 GEM pads in coincidence
-	    CLCT2GEM  // CLCT-2 GEM pads in coincidence
+            ALCTCLCT, // ALCT-centric
+            ALCTCLCTGEM, // ALCT-CLCT-1 GEM pad
+            ALCTCLCT2GEM, // ALCT-CLCT-2 GEM pads in coincidence
+            ALCT2GEM, // ALCT-2 GEM pads in coincidence
+            CLCT2GEM,  // CLCT-2 GEM pads in coincidence
+            CLCTONLY, // Missing ALCT
+            ALCTONLY // Missing CLCT
   };
   
   int getType() {return type_;}

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -263,8 +263,18 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
 
         # For CLCT-centric matching, whether to drop ALCTs that were matched
         # to CLCTs in this BX, and not use them in the following BX
-        # (default non-upgrade TMB behavior).
-        tmbDropUsedAlcts = cms.bool(True)
+        tmbDropUsedAlcts = cms.bool(True),
+
+        # For ALCT-centric matching, whether to drop CLCTs that were matched
+        # to ALCTs in this BX, and not use them in the following BX
+        tmbDropUsedClcts = cms.bool(False),
+
+        # Switch to enable
+        #  True = CLCT-centric matching (default non-upgrade behavior,
+        #         take CLCTs in BX look for matching ALCTs in window)
+        #  False = ALCT-centric matching (recommended for SLHC,
+        #         take ALCTs in BX look for matching CLCTs in window)
+        clctToAlct = cms.bool(True),
     ),
 
     # to be used by ME11 chambers with upgraded TMB and ALCT

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -141,6 +141,9 @@ CSCMotherboard::CSCMotherboard(unsigned endcap, unsigned station,
 
   // whether to not reuse ALCTs that were used by previous matching CLCTs
   drop_used_alcts = tmbParams.getParameter<bool>("tmbDropUsedAlcts");
+  drop_used_clcts = tmbParams.getParameter<bool>("tmbDropUsedClcts");
+
+  clct_to_alct = tmbParams.getParameter<bool>("clctToAlct");
 
   // whether to readout only the earliest two LCTs in readout window
   readout_earliest_2 = tmbParams.getParameter<bool>("tmbReadoutEarliest2");
@@ -149,8 +152,6 @@ CSCMotherboard::CSCMotherboard(unsigned endcap, unsigned station,
 
   alct.reset( new CSCAnodeLCTProcessor(endcap, station, sector, subsector, chamber, alctParams, commonParams) );
   clct.reset( new CSCCathodeLCTProcessor(endcap, station, sector, subsector, chamber, clctParams, commonParams, tmbParams) );
-
-  //if (theStation==1 && CSCTriggerNumbering::ringFromTriggerLabels(theStation, theTrigChamber)==2) infoV = 3;
 
   // Check and print configuration parameters.
   checkConfigParameters();
@@ -355,85 +356,164 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
 
   if (alct && clct) {
     {
-      std::vector<CSCALCTDigi> alctV = alct->run(wiredc); // run anodeLCT
+      const std::vector<CSCALCTDigi>& alctV = alct->run(wiredc); // run anodeLCT
     }
     {
-      std::vector<CSCCLCTDigi> clctV = clct->run(compdc); // run cathodeLCT
+      const std::vector<CSCCLCTDigi>& clctV = clct->run(compdc); // run cathodeLCT
     }
 
-    int used_alct_mask[20];
-    for (int a=0;a<20;++a) used_alct_mask[a]=0;
+    // CLCT-centric matching
+    if (clct_to_alct){
+      int used_alct_mask[20];
+      for (int a=0;a<20;++a) used_alct_mask[a]=0;
 
-    int bx_alct_matched = 0; // bx of last matched ALCT
-    for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_TBINS;
-         bx_clct++) {
-      // There should be at least one valid ALCT or CLCT for a
-      // correlated LCT to be formed.  Decision on whether to reject
-      // non-complete LCTs (and if yes of which type) is made further
-      // upstream.
-      if (clct->bestCLCT[bx_clct].isValid()) {
-        // Look for ALCTs within the match-time window.  The window is
-        // centered at the CLCT bx; therefore, we make an assumption
-        // that anode and cathode hits are perfectly synchronized.  This
-        // is always true for MC, but only an approximation when the
-        // data is analyzed (which works fairly good as long as wide
-        // windows are used).  To get rid of this assumption, one would
-        // need to access "full BX" words, which are not readily
-        // available.
-        bool is_matched = false;
-        int bx_alct_start = bx_clct - match_trig_window_size/2;
-        int bx_alct_stop  = bx_clct + match_trig_window_size/2;
-        // Empirical correction to match 2009 collision data (firmware change?)
-        // (but don't do it for SLHC case, assume it would not be there)
-        if (!isSLHC) bx_alct_stop += match_trig_window_size%2;
+      int bx_alct_matched = 0; // bx of last matched ALCT
+      for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_TBINS;
+           bx_clct++) {
+        // There should be at least one valid ALCT or CLCT for a
+        // correlated LCT to be formed.  Decision on whether to reject
+        // non-complete LCTs (and if yes of which type) is made further
+        // upstream.
+        if (clct->bestCLCT[bx_clct].isValid()) {
+          // Look for ALCTs within the match-time window.  The window is
+          // centered at the CLCT bx; therefore, we make an assumption
+          // that anode and cathode hits are perfectly synchronized.  This
+          // is always true for MC, but only an approximation when the
+          // data is analyzed (which works fairly good as long as wide
+          // windows are used).  To get rid of this assumption, one would
+          // need to access "full BX" words, which are not readily
+          // available.
+          bool is_matched = false;
+          int bx_alct_start = bx_clct - match_trig_window_size/2;
+          int bx_alct_stop  = bx_clct + match_trig_window_size/2;
+          // Empirical correction to match 2009 collision data (firmware change?)
+          // (but don't do it for SLHC case, assume it would not be there)
+          if (!isSLHC) bx_alct_stop += match_trig_window_size%2;
 
-        for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++) {
-          if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_TBINS)
-            continue;
-          // default: do not reuse ALCTs that were used with previous CLCTs
-          if (drop_used_alcts && used_alct_mask[bx_alct]) continue;
-          if (alct->bestALCT[bx_alct].isValid()) {
-            if (infoV > 1) LogTrace("CSCMotherboard")
-              << "Successful ALCT-CLCT match: bx_clct = " << bx_clct
-                << "; match window: [" << bx_alct_start << "; " << bx_alct_stop
-                << "]; bx_alct = " << bx_alct;
-            correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
-                          clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
-            used_alct_mask[bx_alct] += 1;
-            is_matched = true;
-            bx_alct_matched = bx_alct;
-            break;
+          for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++) {
+            if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_TBINS)
+              continue;
+            // default: do not reuse ALCTs that were used with previous CLCTs
+            if (drop_used_alcts && used_alct_mask[bx_alct]) continue;
+            if (alct->bestALCT[bx_alct].isValid()) {
+              if (infoV > 1) LogTrace("CSCMotherboard")
+                               << "Successful ALCT-CLCT match: bx_clct = " << bx_clct
+                               << "; match window: [" << bx_alct_start << "; " << bx_alct_stop
+                               << "]; bx_alct = " << bx_alct;
+              correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
+                            clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
+              used_alct_mask[bx_alct] += 1;
+              is_matched = true;
+              bx_alct_matched = bx_alct;
+              break;
+            }
           }
-        }
-        // No ALCT within the match time interval found: report CLCT-only LCT
-        // (use dummy ALCTs).
-        if (!is_matched) {
-          if (infoV > 1) LogTrace("CSCMotherboard")
-            << "Unsuccessful ALCT-CLCT match (CLCT only): bx_clct = "
-            << bx_clct << "; match window: [" << bx_alct_start
-            << "; " << bx_alct_stop << "]";
-          correlateLCTs(alct->bestALCT[bx_clct], alct->secondALCT[bx_clct],
-                        clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
-        }
-      }
-      // No valid CLCTs; attempt to make ALCT-only LCT.  Use only ALCTs
-      // which have zeroth chance to be matched at later cathode times.
-      // (I am not entirely sure this perfectly matches the firmware logic.)
-      // Use dummy CLCTs.
-      else {
-        int bx_alct = bx_clct - match_trig_window_size/2;
-        if (bx_alct >= 0 && bx_alct > bx_alct_matched) {
-          if (alct->bestALCT[bx_alct].isValid()) {
+          // No ALCT within the match time interval found: report CLCT-only LCT
+          // (use dummy ALCTs).
+          if (!is_matched) {
             if (infoV > 1) LogTrace("CSCMotherboard")
-              << "Unsuccessful ALCT-CLCT match (ALCT only): bx_alct = "
-              << bx_alct;
-            correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
+                             << "Unsuccessful ALCT-CLCT match (CLCT only): bx_clct = "
+                             << bx_clct << "; match window: [" << bx_alct_start
+                             << "; " << bx_alct_stop << "]";
+            correlateLCTs(alct->bestALCT[bx_clct], alct->secondALCT[bx_clct],
                           clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
           }
         }
+        // No valid CLCTs; attempt to make ALCT-only LCT.  Use only ALCTs
+        // which have zeroth chance to be matched at later cathode times.
+        // (I am not entirely sure this perfectly matches the firmware logic.)
+        // Use dummy CLCTs.
+        else {
+          int bx_alct = bx_clct - match_trig_window_size/2;
+          if (bx_alct >= 0 && bx_alct > bx_alct_matched) {
+            if (alct->bestALCT[bx_alct].isValid()) {
+              if (infoV > 1) LogTrace("CSCMotherboard")
+                               << "Unsuccessful ALCT-CLCT match (ALCT only): bx_alct = "
+                               << bx_alct;
+              correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
+                            clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
+            }
+          }
+        }
+      }
+    }
+    // ALCT-centric matching
+    else {
+      int used_clct_mask[20];
+      for (int a=0;a<20;++a) used_clct_mask[a]=0;
+
+      int bx_clct_matched = 0; // bx of last matched CLCT
+      for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS;
+           bx_alct++) {
+        // There should be at least one valid CLCT or ALCT for a
+        // correlated LCT to be formed.  Decision on whether to reject
+        // non-complete LCTs (and if yes of which type) is made further
+        // upstream.
+        if (alct->bestALCT[bx_alct].isValid()) {
+          // Look for CLCTs within the match-time window.  The window is
+          // centered at the ALCT bx; therefore, we make an assumption
+          // that anode and cathode hits are perfectly synchronized.  This
+          // is always true for MC, but only an approximation when the
+          // data is analyzed (which works fairly good as long as wide
+          // windows are used).  To get rid of this assumption, one would
+          // need to access "full BX" words, which are not readily
+          // available.
+          bool is_matched = false;
+          int bx_clct_start = bx_alct - match_trig_window_size/2;
+          int bx_clct_stop  = bx_alct + match_trig_window_size/2;
+          // Empirical correction to match 2009 collision data (firmware change?)
+          // (but don't do it for SLHC case, assume it would not be there)
+          if (!isSLHC) bx_clct_stop += match_trig_window_size%2;
+
+          for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++) {
+            if (bx_clct < 0 || bx_clct >= CSCConstants::MAX_CLCT_TBINS)
+              continue;
+            // default: do not reuse CLCTs that were used with previous ALCTs
+            if (drop_used_clcts && used_clct_mask[bx_clct]) continue;
+            if (clct->bestCLCT[bx_clct].isValid()) {
+              if (infoV > 1) LogTrace("CSCMotherboard")
+                               << "Successful CLCT-ALCT match: bx_alct = " << bx_alct
+                               << "; match window: [" << bx_clct_start << "; " << bx_clct_stop
+                               << "]; bx_clct = " << bx_clct;
+              correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
+                            clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
+              used_clct_mask[bx_clct] += 1;
+              is_matched = true;
+              bx_clct_matched = bx_clct;
+              break;
+            }
+          }
+          // No CLCT within the match time interval found: report ALCT-only LCT
+          // (use dummy CLCTs).
+          if (!is_matched) {
+            if (infoV > 1) LogTrace("CSCMotherboard")
+                             << "Unsuccessful CLCT-ALCT match (ALCT only): bx_alct = "
+                             << bx_alct << "; match window: [" << bx_clct_start
+                             << "; " << bx_clct_stop << "]";
+            correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
+                          clct->bestCLCT[bx_alct], clct->secondCLCT[bx_alct]);
+          }
+        }
+        // No valid ALCTs; attempt to make CLCT-only LCT.  Use only CLCTs
+        // which have zeroth chance to be matched at later cathode times.
+        // (I am not entirely sure this perfectly matches the firmware logic.)
+        // Use dummy ALCTs.
+        else {
+          int bx_clct = bx_alct - match_trig_window_size/2;
+          if (bx_clct >= 0 && bx_clct > bx_clct_matched) {
+            if (clct->bestCLCT[bx_clct].isValid()) {
+              if (infoV > 1) LogTrace("CSCMotherboard")
+                               << "Unsuccessful CLCT-ALCT match (CLCT only): bx_clct = "
+                               << bx_clct;
+              correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
+                            clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
+            }
+          }
+        }
       }
     }
 
+    // Debug first and second LCTs
     if (infoV > 0) {
       for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
         if (firstLCT[bx].isValid())
@@ -443,6 +523,7 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
       }
     }
   }
+  // No valid ALCT and/or CLCT processor
   else {
     if (infoV >= 0) edm::LogError("L1CSCTPEmulatorSetupError")
       << "+++ run() called for non-existing ALCT/CLCT processor! +++ \n";
@@ -452,7 +533,7 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
 // Returns vector of read-out correlated LCTs, if any.  Starts with
 // the vector of all found LCTs and selects the ones in the read-out
 // time window.
-std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::readoutLCTs() {
+std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::readoutLCTs() const {
   std::vector<CSCCorrelatedLCTDigi> tmpV;
 
   // The start time of the L1A*LCT coincidence window should be related
@@ -486,9 +567,8 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::readoutLCTs() {
   // Start from the vector of all found correlated LCTs and select
   // those within the LCT*L1A coincidence window.
   int bx_readout = -1;
-  std::vector<CSCCorrelatedLCTDigi> all_lcts = getLCTs();
-  for (std::vector <CSCCorrelatedLCTDigi>::const_iterator plct =
-       all_lcts.begin(); plct != all_lcts.end(); plct++) {
+  const std::vector<CSCCorrelatedLCTDigi>& all_lcts = getLCTs();
+  for (auto plct = all_lcts.begin(); plct != all_lcts.end(); plct++) {
     if (!plct->isValid()) continue;
 
     int bx = (*plct).getBX();
@@ -528,7 +608,7 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::readoutLCTs() {
 }
 
 // Returns vector of all found correlated LCTs, if any.
-std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::getLCTs() {
+std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::getLCTs() const {
   std::vector<CSCCorrelatedLCTDigi> tmpV;
 
   bool me11 = (theStation == 1 &&

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -319,7 +319,8 @@ void CSCMotherboard::run(
           continue;
         if (alct->bestALCT[bx_alct].isValid()) {
           correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
-                        clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
+                        clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
+                        CSCCorrelatedLCTDigi::CLCTALCT);
           is_matched = true;
           bx_alct_matched = bx_alct;
           break;
@@ -329,7 +330,8 @@ void CSCMotherboard::run(
       // (use dummy ALCTs).
       if (!is_matched) {
         correlateLCTs(alct->bestALCT[bx_clct], alct->secondALCT[bx_clct],
-                      clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
+                      clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
+                      CSCCorrelatedLCTDigi::CLCTONLY);
       }
     }
     // No valid CLCTs; attempt to make ALCT-only LCT (use dummy CLCTs).
@@ -338,7 +340,8 @@ void CSCMotherboard::run(
       if (bx_alct >= 0 && bx_alct > bx_alct_matched) {
         if (alct->bestALCT[bx_alct].isValid()) {
           correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
-                        clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
+                        clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
+                        CSCCorrelatedLCTDigi::ALCTONLY);
         }
       }
     }
@@ -418,7 +421,7 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
                              << "; " << bx_alct_stop << "]";
             correlateLCTs(alct->bestALCT[bx_clct], alct->secondALCT[bx_clct],
                           clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
-                          CSCCorrelatedLCTDigi::CLCTALCT);
+                          CSCCorrelatedLCTDigi::CLCTONLY);
           }
         }
         // No valid CLCTs; attempt to make ALCT-only LCT.  Use only ALCTs
@@ -434,7 +437,7 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
                                << bx_alct;
               correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
                             clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
-                            CSCCorrelatedLCTDigi::CLCTALCT);
+                            CSCCorrelatedLCTDigi::ALCTONLY);
             }
           }
         }
@@ -496,7 +499,7 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
                              << "; " << bx_clct_stop << "]";
             correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
                           clct->bestCLCT[bx_alct], clct->secondCLCT[bx_alct],
-                          CSCCorrelatedLCTDigi::ALCTCLCT);
+                          CSCCorrelatedLCTDigi::ALCTONLY);
           }
         }
         // No valid ALCTs; attempt to make CLCT-only LCT.  Use only CLCTs
@@ -512,7 +515,7 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
                                << bx_clct;
               correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
                             clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
-                            CSCCorrelatedLCTDigi::ALCTCLCT);
+                            CSCCorrelatedLCTDigi::CLCTONLY);
             }
           }
         }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -401,7 +401,8 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
                                << "; match window: [" << bx_alct_start << "; " << bx_alct_stop
                                << "]; bx_alct = " << bx_alct;
               correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
-                            clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
+                            clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
+                            CSCCorrelatedLCTDigi::CLCTALCT);
               used_alct_mask[bx_alct] += 1;
               is_matched = true;
               bx_alct_matched = bx_alct;
@@ -416,7 +417,8 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
                              << bx_clct << "; match window: [" << bx_alct_start
                              << "; " << bx_alct_stop << "]";
             correlateLCTs(alct->bestALCT[bx_clct], alct->secondALCT[bx_clct],
-                          clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
+                          clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
+                          CSCCorrelatedLCTDigi::CLCTALCT);
           }
         }
         // No valid CLCTs; attempt to make ALCT-only LCT.  Use only ALCTs
@@ -431,7 +433,8 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
                                << "Unsuccessful ALCT-CLCT match (ALCT only): bx_alct = "
                                << bx_alct;
               correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
-                            clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
+                            clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
+                            CSCCorrelatedLCTDigi::CLCTALCT);
             }
           }
         }
@@ -476,7 +479,8 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
                                << "; match window: [" << bx_clct_start << "; " << bx_clct_stop
                                << "]; bx_clct = " << bx_clct;
               correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
-                            clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
+                            clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
+                            CSCCorrelatedLCTDigi::ALCTCLCT);
               used_clct_mask[bx_clct] += 1;
               is_matched = true;
               bx_clct_matched = bx_clct;
@@ -491,7 +495,8 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
                              << bx_alct << "; match window: [" << bx_clct_start
                              << "; " << bx_clct_stop << "]";
             correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
-                          clct->bestCLCT[bx_alct], clct->secondCLCT[bx_alct]);
+                          clct->bestCLCT[bx_alct], clct->secondCLCT[bx_alct],
+                          CSCCorrelatedLCTDigi::ALCTCLCT);
           }
         }
         // No valid ALCTs; attempt to make CLCT-only LCT.  Use only CLCTs
@@ -506,7 +511,8 @@ CSCMotherboard::run(const CSCWireDigiCollection* wiredc,
                                << "Unsuccessful CLCT-ALCT match (CLCT only): bx_clct = "
                                << bx_clct;
               correlateLCTs(alct->bestALCT[bx_alct], alct->secondALCT[bx_alct],
-                            clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct]);
+                            clct->bestCLCT[bx_clct], clct->secondCLCT[bx_clct],
+                            CSCCorrelatedLCTDigi::ALCTCLCT);
             }
           }
         }
@@ -630,7 +636,8 @@ std::vector<CSCCorrelatedLCTDigi> CSCMotherboard::getLCTs() const {
 void CSCMotherboard::correlateLCTs(const CSCALCTDigi& bALCT,
                                    const CSCALCTDigi& sALCT,
                                    const CSCCLCTDigi& bCLCT,
-                                   const CSCCLCTDigi& sCLCT)
+                                   const CSCCLCTDigi& sCLCT,
+                                   int type)
 {
   CSCALCTDigi bestALCT = bALCT;
   CSCALCTDigi secondALCT = sALCT;
@@ -652,7 +659,7 @@ void CSCMotherboard::correlateLCTs(const CSCALCTDigi& bALCT,
   if ((alct_trig_enable  && bestALCT.isValid()) ||
       (clct_trig_enable  && bestCLCT.isValid()) ||
       (match_trig_enable && bestALCT.isValid() && bestCLCT.isValid())) {
-    CSCCorrelatedLCTDigi lct = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::CLCTALCT, 1);
+    const CSCCorrelatedLCTDigi& lct = constructLCTs(bestALCT, bestCLCT, type, 1);
     int bx = lct.getBX();
     if (bx >= 0 && bx < CSCConstants::MAX_LCT_TBINS) {
       firstLCT[bx] = lct;
@@ -669,7 +676,7 @@ void CSCMotherboard::correlateLCTs(const CSCALCTDigi& bALCT,
       ((alct_trig_enable  && secondALCT.isValid()) ||
        (clct_trig_enable  && secondCLCT.isValid()) ||
        (match_trig_enable && secondALCT.isValid() && secondCLCT.isValid()))) {
-    CSCCorrelatedLCTDigi lct = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::CLCTALCT, 2);
+    const CSCCorrelatedLCTDigi& lct = constructLCTs(secondALCT, secondCLCT, type, 2);
     int bx = lct.getBX();
     if (bx >= 0 && bx < CSCConstants::MAX_LCT_TBINS) {
       secondLCT[bx] = lct;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -64,10 +64,10 @@ class CSCMotherboard
   void run(const CSCWireDigiCollection* wiredc, const CSCComparatorDigiCollection* compdc);
 
   /** Returns vector of correlated LCTs in the read-out time window, if any. */
-  std::vector<CSCCorrelatedLCTDigi> readoutLCTs();
+  std::vector<CSCCorrelatedLCTDigi> readoutLCTs() const;
 
   /** Returns vector of all found correlated LCTs, if any. */
-  std::vector<CSCCorrelatedLCTDigi> getLCTs();
+  std::vector<CSCCorrelatedLCTDigi> getLCTs() const;
 
   /** Clears correlated LCT and passes clear signal on to cathode and anode
       LCT processors. */
@@ -118,11 +118,18 @@ class CSCMotherboard
   /** SLHC: whether to not reuse ALCTs that were used by previous matching CLCTs */
   bool drop_used_alcts;
 
+  /** SLHC: whether to not reuse CLCTs that were used by previous matching ALCTs */
+  bool drop_used_clcts;
+
   /** SLHC: separate handle for early time bins */
   int early_tbins;
 
   /** SLHC: whether to readout only the earliest two LCTs in readout window */
   bool readout_earliest_2;
+
+  /** if true: use regular CLCT-to-ALCT matching in TMB
+      if false: do ALCT-to-CLCT matching */
+  bool clct_to_alct;
 
   /** Default values of configuration parameters. */
   static const unsigned int def_mpc_block_me1a;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -147,7 +147,8 @@ class CSCMotherboard
   void checkConfigParameters();
 
   void correlateLCTs(const CSCALCTDigi& bestALCT, const CSCALCTDigi& secondALCT,
-                     const CSCCLCTDigi& bestCLCT, const CSCCLCTDigi& secondCLCT);
+                     const CSCCLCTDigi& bestCLCT, const CSCCLCTDigi& secondCLCT,
+                     int type);
 
   // This method calculates all the TMB words and then passes them to the
   // constructor of correlated LCTs.


### PR DESCRIPTION
The default CLCT-ALCT matching algorithm in the CSC trigger simulation is CLCT-centric, i.e. a matching ALCT is searched in a BX window around the BX of a valid CLCT. It was always assumed that this was also the case in the firmware.  However, a recent investigation of the TMB verilog firmware code showed that in fact it is the other way around (and has been since the start of data taking), namely that the matching is ALCT-centric. 

This pull request enables the ALCT-centric option in the TMB. The default option is still CLCT-centric for now. I plan to make the switch soon. This option was not enabled for the test run function that relies both on half-strips and distrips.

Also in this PR:
* `vector<T>` was made `const vector<T>&` when an object was instantiated by function's `vector<T>` return value
* Two extra types of LCT in the CSCCorrelatedLCTDigi were defined
*  Certain functions were made `const`

There should be no changes in the performance of the CSC local trigger. 

@tahuang1991 