### PR TITLE
Fixed bug in CTPPSDiamondRecHitProducer

### DIFF
--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -52,8 +52,8 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry* geom, const edm
       rec_hits.push_back( CTPPSDiamondRecHit( x_pos, x_width, y_pos, y_width, z_pos, z_width, // spatial information
                                               ( t0 * ts_to_ns_ ),
                                               ( tot * ts_to_ns_),
-                                              time_slice,
                                               0., // time precision
+                                              time_slice,
                                               digi.getHPTDCErrorFlags(),
                                               digi.getMultipleHit() ) );
     }


### PR DESCRIPTION
Fixing of a bug introduced with PR  #21426. The inversion of two lines gives an Out Of Time Index == 0 for all the rechits.
The testing procedure missed this because the OOTIndex is expected to be always 0 for run > 302159 and it gives "reasonable" values also for previous run. 

@forthommel @fabferro 