### PR TITLE
Fixing SiStripGainsPCLWorker when running on AlCaReco input dataset

### DIFF
--- a/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
@@ -21,13 +21,48 @@ namespace APVGain {
     std::vector<std::pair<std::string,std::string>> monHnames(std::vector<std::string>,bool,const char* tag);
 
     struct APVmon{
-        int subdetectorId;
-        int subdetectorSide;
-        int subdetectorPlane;
-        MonitorElement* monitor;
+      
+      APVmon(int v1, int v2, int v3, MonitorElement* v4) :
+	subdetectorId(v1),
+	subdetectorSide(v2),
+	subdetectorPlane(v3),
+	monitor(std::move(v4)) 
+      {
+      }
 
-        APVmon(int v1, int v2, int v3, MonitorElement* v4) :
-            subdetectorId(v1),subdetectorSide(v2),subdetectorPlane(v3),monitor(v4) {}
+    public:
+
+      int getSubdetectorId(){
+	return subdetectorId;
+      }
+
+      int getSubdetectorSide(){
+	return subdetectorSide;
+      }
+
+      int getSubdetectorPlane(){
+	return subdetectorPlane;
+      }
+
+      MonitorElement* getTheMon(){
+	return monitor;
+      }
+
+      void printAll(){
+	std::cout<< "subDetectorID:" << subdetectorId << std::endl;
+	std::cout<< "subDetectorSide:" << subdetectorSide << std::endl;
+	std::cout<< "subDetectorPlane:" << subdetectorPlane << std::endl;
+	std::cout<< "histoName:" << monitor->getName() << std::endl;
+	return;
+      }
+
+    private:
+
+      int subdetectorId;
+      int subdetectorSide;
+      int subdetectorPlane;
+      MonitorElement* monitor;
+
     };
 
     std::vector<MonitorElement*> FetchMonitor(std::vector<APVmon>, uint32_t, const TrackerTopology* topo=nullptr);

--- a/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
@@ -23,10 +23,10 @@ namespace APVGain {
 
     struct APVmon{
       
-      APVmon(int v1, int v2, int v3, MonitorElement* v4) :
-	m_subdetectorId(v1),m_subdetectorSide(v2),m_subdetectorPlane(v3),m_monitor(std::move(v4)){}
-
     public:
+
+    APVmon(int v1, int v2, int v3, MonitorElement* v4) :
+      m_subdetectorId(v1),m_subdetectorSide(v2),m_subdetectorPlane(v3),m_monitor(v4){}
 
       int getSubdetectorId(){
 	return m_subdetectorId;

--- a/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <string>
 #include <vector>
@@ -23,45 +24,40 @@ namespace APVGain {
     struct APVmon{
       
       APVmon(int v1, int v2, int v3, MonitorElement* v4) :
-	subdetectorId(v1),
-	subdetectorSide(v2),
-	subdetectorPlane(v3),
-	monitor(std::move(v4)) 
-      {
-      }
+	m_subdetectorId(v1),m_subdetectorSide(v2),m_subdetectorPlane(v3),m_monitor(std::move(v4)){}
 
     public:
 
       int getSubdetectorId(){
-	return subdetectorId;
+	return m_subdetectorId;
       }
 
       int getSubdetectorSide(){
-	return subdetectorSide;
+	return m_subdetectorSide;
       }
 
       int getSubdetectorPlane(){
-	return subdetectorPlane;
+	return m_subdetectorPlane;
       }
 
-      MonitorElement* getTheMon(){
-	return monitor;
+      MonitorElement* getMonitor(){
+	return m_monitor;
       }
 
       void printAll(){
-	std::cout<< "subDetectorID:" << subdetectorId << std::endl;
-	std::cout<< "subDetectorSide:" << subdetectorSide << std::endl;
-	std::cout<< "subDetectorPlane:" << subdetectorPlane << std::endl;
-	std::cout<< "histoName:" << monitor->getName() << std::endl;
+	LogDebug("APVGainHelpers")<< "subDetectorID:" << m_subdetectorId << std::endl;
+	LogDebug("APVGainHelpers")<< "subDetectorSide:" << m_subdetectorSide << std::endl;
+	LogDebug("APVGainHelpers")<< "subDetectorPlane:" << m_subdetectorPlane << std::endl;
+	LogDebug("APVGainHelpers")<< "histoName:" << m_monitor->getName() << std::endl;
 	return;
       }
 
     private:
 
-      int subdetectorId;
-      int subdetectorSide;
-      int subdetectorPlane;
-      MonitorElement* monitor;
+      int m_subdetectorId;
+      int m_subdetectorSide;
+      int m_subdetectorPlane;
+      MonitorElement* m_monitor;
 
     };
 

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
@@ -106,8 +106,6 @@ private:
     std::vector<MonitorElement*>  Charge_Vs_PathlengthTECM1; /*!< Charge vs pathlength in TECP thin */
     std::vector<MonitorElement*>  Charge_Vs_PathlengthTECM2; /*!< Charge vs pathlength in TECP thick */
 
-    
-
     unsigned int NEvent;    
     unsigned int NTrack;
     unsigned int NClusterStrip;

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -945,20 +945,20 @@ void SiStripGainFromCalibTree::algoEndRun(const edm::Run& run, const edm::EventS
                 for (unsigned int i=0;i<tags.size();i++){
                     std::string tag = DQM_dir + "/" + (tags[i]).first + stag;
                     Charge_1[elepos].push_back( APVGain::APVmon(0,0,0,dbe->get( tag) ) );
-                    if ( (Charge_1[elepos][i]).monitor==nullptr ) {
+                    if ( (Charge_1[elepos][i]).getTheMon()==nullptr ) {
                          edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << tag.c_str()
                                                                    << ", statistics will not be summed!" << std::endl;
-                    } else (Charge_1[Harvest][i]).monitor->getTH1D()->Add((Charge_1[elepos][i]).monitor->getTH1D());
+                    } else (Charge_1[Harvest][i]).getTheMon()->getTH1D()->Add((Charge_1[elepos][i]).getTheMon()->getTH1D());
                 }
 
                 tags = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG2");
                 for (unsigned int i=0;i<tags.size();i++){
                     std::string tag = DQM_dir + "/" + (tags[i]).first + stag;
                     Charge_2[elepos].push_back( APVGain::APVmon(0,0,0,dbe->get( tag) ) );
-                    if ( (Charge_2[elepos][i]).monitor==nullptr ) {
+                    if ( (Charge_2[elepos][i]).getTheMon()==nullptr ) {
                          edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << tag.c_str()
                                                                    << ", statistics will not be summed!" << std::endl;
-                    } else (Charge_2[Harvest][i]).monitor->getTH1D()->Add((Charge_2[elepos][i]).monitor->getTH1D());
+                    } else (Charge_2[Harvest][i]).getTheMon()->getTH1D()->Add((Charge_2[elepos][i]).getTheMon()->getTH1D());
 
                 }
 
@@ -966,10 +966,10 @@ void SiStripGainFromCalibTree::algoEndRun(const edm::Run& run, const edm::EventS
                 for (unsigned int i=0;i<tags.size();i++){
                     std::string tag = DQM_dir + "/" + (tags[i]).first + stag;
                     Charge_3[elepos].push_back( APVGain::APVmon(0,0,0,dbe->get( tag) ) );
-                    if ( (Charge_3[elepos][i]).monitor==nullptr ) {
+                    if ( (Charge_3[elepos][i]).getTheMon()==nullptr ) {
                          edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << tag.c_str()
                                                                    << ", statistics will not be summed!" << std::endl;
-                    } else (Charge_3[Harvest][i]).monitor->getTH1D()->Add((Charge_3[elepos][i]).monitor->getTH1D());
+                    } else (Charge_3[Harvest][i]).getTheMon()->getTH1D()->Add((Charge_3[elepos][i]).getTheMon()->getTH1D());
 
                 }
 
@@ -977,10 +977,10 @@ void SiStripGainFromCalibTree::algoEndRun(const edm::Run& run, const edm::EventS
                 for (unsigned int i=0;i<tags.size();i++){
                     std::string tag = DQM_dir + "/" + (tags[i]).first + stag;
                     Charge_4[elepos].push_back( APVGain::APVmon(0,0,0,dbe->get( tag) ) );
-                    if ( (Charge_4[elepos][i]).monitor==nullptr ) {
+                    if ( (Charge_4[elepos][i]).getTheMon()==nullptr ) {
                          edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << tag.c_str()
                                                                    << ", statistics will not be summed!" << std::endl;
-                    } else (Charge_4[Harvest][i]).monitor->getTH1D()->Add((Charge_4[elepos][i]).monitor->getTH1D());
+                    } else (Charge_4[Harvest][i]).getTheMon()->getTH1D()->Add((Charge_4[elepos][i]).getTheMon()->getTH1D());
                 }
 
             }

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -945,20 +945,20 @@ void SiStripGainFromCalibTree::algoEndRun(const edm::Run& run, const edm::EventS
                 for (unsigned int i=0;i<tags.size();i++){
                     std::string tag = DQM_dir + "/" + (tags[i]).first + stag;
                     Charge_1[elepos].push_back( APVGain::APVmon(0,0,0,dbe->get( tag) ) );
-                    if ( (Charge_1[elepos][i]).getTheMon()==nullptr ) {
+                    if ( (Charge_1[elepos][i]).getMonitor()==nullptr ) {
                          edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << tag.c_str()
                                                                    << ", statistics will not be summed!" << std::endl;
-                    } else (Charge_1[Harvest][i]).getTheMon()->getTH1D()->Add((Charge_1[elepos][i]).getTheMon()->getTH1D());
+                    } else (Charge_1[Harvest][i]).getMonitor()->getTH1D()->Add((Charge_1[elepos][i]).getMonitor()->getTH1D());
                 }
 
                 tags = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG2");
                 for (unsigned int i=0;i<tags.size();i++){
                     std::string tag = DQM_dir + "/" + (tags[i]).first + stag;
                     Charge_2[elepos].push_back( APVGain::APVmon(0,0,0,dbe->get( tag) ) );
-                    if ( (Charge_2[elepos][i]).getTheMon()==nullptr ) {
+                    if ( (Charge_2[elepos][i]).getMonitor()==nullptr ) {
                          edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << tag.c_str()
                                                                    << ", statistics will not be summed!" << std::endl;
-                    } else (Charge_2[Harvest][i]).getTheMon()->getTH1D()->Add((Charge_2[elepos][i]).getTheMon()->getTH1D());
+                    } else (Charge_2[Harvest][i]).getMonitor()->getTH1D()->Add((Charge_2[elepos][i]).getMonitor()->getTH1D());
 
                 }
 
@@ -966,10 +966,10 @@ void SiStripGainFromCalibTree::algoEndRun(const edm::Run& run, const edm::EventS
                 for (unsigned int i=0;i<tags.size();i++){
                     std::string tag = DQM_dir + "/" + (tags[i]).first + stag;
                     Charge_3[elepos].push_back( APVGain::APVmon(0,0,0,dbe->get( tag) ) );
-                    if ( (Charge_3[elepos][i]).getTheMon()==nullptr ) {
+                    if ( (Charge_3[elepos][i]).getMonitor()==nullptr ) {
                          edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << tag.c_str()
                                                                    << ", statistics will not be summed!" << std::endl;
-                    } else (Charge_3[Harvest][i]).getTheMon()->getTH1D()->Add((Charge_3[elepos][i]).getTheMon()->getTH1D());
+                    } else (Charge_3[Harvest][i]).getMonitor()->getTH1D()->Add((Charge_3[elepos][i]).getMonitor()->getTH1D());
 
                 }
 
@@ -977,10 +977,10 @@ void SiStripGainFromCalibTree::algoEndRun(const edm::Run& run, const edm::EventS
                 for (unsigned int i=0;i<tags.size();i++){
                     std::string tag = DQM_dir + "/" + (tags[i]).first + stag;
                     Charge_4[elepos].push_back( APVGain::APVmon(0,0,0,dbe->get( tag) ) );
-                    if ( (Charge_4[elepos][i]).getTheMon()==nullptr ) {
+                    if ( (Charge_4[elepos][i]).getMonitor()==nullptr ) {
                          edm::LogError("SiStripGainFromCalibTree") << "Harvesting: could not retrieve " << tag.c_str()
                                                                    << ", statistics will not be summed!" << std::endl;
-                    } else (Charge_4[Harvest][i]).getTheMon()->getTH1D()->Add((Charge_4[elepos][i]).getTheMon()->getTH1D());
+                    } else (Charge_4[Harvest][i]).getMonitor()->getTH1D()->Add((Charge_4[elepos][i]).getMonitor()->getTH1D());
                 }
 
             }

--- a/CalibTracker/SiStripChannelGain/src/APVGainHelpers.cc
+++ b/CalibTracker/SiStripChannelGain/src/APVGainHelpers.cc
@@ -114,23 +114,20 @@ std::vector<MonitorElement*> APVGain::FetchMonitor(std::vector<APVGain::APVmon> 
   int sSide  = APVGain::subdetectorSide((uint32_t)det_id, topo);
   std::vector<APVGain::APVmon>::iterator it= histos.begin();
     
-  //std::cout<<"sId: "<<sId<<" sPlane: "<<sPlane<<" sSide: "<<sSide<<std::endl;
+  LogDebug("APVGainHelpers")<<"sId: "<<sId<<" sPlane: "<<sPlane<<" sSide: "<<sSide<<std::endl;
 
   while (it!=histos.end()) {
-    std::string tag = (*it).getTheMon()->getName();
+    std::string tag = (*it).getMonitor()->getName();
     int subdetectorId    = (*it).getSubdetectorId();
     int subdetectorSide  = (*it).getSubdetectorSide();
     int subdetectorPlane = (*it).getSubdetectorPlane();
     
-    //(*it).printAll();
-
     bool match = (subdetectorId==0 || subdetectorId==sId) && (subdetectorPlane==0 || subdetectorPlane==sPlane) && (subdetectorSide==0  || subdetectorSide==sSide);
 
-    //bool match = (subdetectorId==sId) && (subdetectorPlane==sPlane) && (subdetectorSide==sSide);
-
     if (match) {
-      found.push_back((*it).getTheMon());
-      //std::cout<<det_id<<" found: "<< tag << std::endl;
+      found.push_back((*it).getMonitor());
+      LogDebug("APVGainHelpers")<<det_id<<" found: "<< tag << std::endl;
+      (*it).printAll();
     }
     it++;
   }

--- a/CalibTracker/SiStripChannelGain/src/APVGainHelpers.cc
+++ b/CalibTracker/SiStripChannelGain/src/APVGainHelpers.cc
@@ -109,9 +109,9 @@ std::vector<MonitorElement*> APVGain::FetchMonitor(std::vector<APVGain::APVmon> 
 						   const TrackerTopology* topo) {
 
   std::vector<MonitorElement*> found = std::vector<MonitorElement*>();
-  int sId    = APVGain::subdetectorId((uint32_t)det_id);
-  int sPlane = APVGain::subdetectorPlane((uint32_t)det_id, topo);
-  int sSide  = APVGain::subdetectorSide((uint32_t)det_id, topo);
+  int sId    = APVGain::subdetectorId(det_id);
+  int sPlane = APVGain::subdetectorPlane(det_id, topo);
+  int sSide  = APVGain::subdetectorSide(det_id, topo);
   std::vector<APVGain::APVmon>::iterator it= histos.begin();
     
   LogDebug("APVGainHelpers")<<"sId: "<<sId<<" sPlane: "<<sPlane<<" sSide: "<<sSide<<std::endl;
@@ -140,7 +140,12 @@ std::vector<std::pair<std::string,std::string>>
 APVGain::monHnames(std::vector<std::string> VH, bool allPlanes, const char* tag) {
 
   std::vector<std::pair<std::string,std::string>> out;
-  int re = (allPlanes)? 34 + VH.size() : VH.size();
+
+  // total number of measurement layers/wheels in the Strips Tracker
+  // 4(TIB) + 6(TOB) + 3(TID+) + 3(TID-) + 9(TEC+) + 9(TEC-)
+  constexpr int countOfPlanes = 34;  
+
+  int re = (allPlanes)? countOfPlanes + VH.size() : VH.size();
   out.reserve( re );
 
   std::string Tag = tag;
@@ -151,21 +156,21 @@ APVGain::monHnames(std::vector<std::string> VH, bool allPlanes, const char* tag)
 
   if (allPlanes) {
     // Names of monitoring histogram for TIB layers
-    int TIBlayers = 4;  //number of TIB layers.
+    constexpr int TIBlayers = 4;  //number of TIB layers.
     for(int i=1; i<=TIBlayers; i++) {
       h_tag = "TIB_layer_" + std::to_string(i) + Tag;
       h_tit = h_tag; std::replace(h_tit.begin(),h_tit.end(),'_',' ');
       out.push_back(std::pair<std::string,std::string>(h_tag,h_tit));
     }
     // Names of monitoring histogram for TOB layers
-    int TOBlayers = 6;  //number of TOB layers
+    constexpr int TOBlayers = 6;  //number of TOB layers
     for(int i=1; i<=TOBlayers; i++) {
       h_tag = "TOB_layer_" + std::to_string(i) + Tag;
       h_tit = h_tag; std::replace(h_tit.begin(),h_tit.end(),'_',' ');
       out.push_back(std::pair<std::string,std::string>(h_tag,h_tit));
     }
     // Names of monitoring histogram for TID wheels
-    int TIDwheels = 3;  //number of TID wheels
+    constexpr int TIDwheels = 3;  //number of TID wheels
     for(int i=-TIDwheels; i<=TIDwheels; i++) {
       if (i==0) continue;
       if (i<0)  h_tag = "TIDminus_wheel_" + std::to_string(i) + Tag;
@@ -174,7 +179,7 @@ APVGain::monHnames(std::vector<std::string> VH, bool allPlanes, const char* tag)
       out.push_back(std::pair<std::string,std::string>(h_tag,h_tit));
     }
     // Names of monitoring histogram for TEC wheels
-    int TECwheels = 9;  //number of TEC wheels
+    constexpr int TECwheels = 9;  //number of TEC wheels
     for(int i=-TECwheels; i<=TECwheels; i++) {
       if (i==0) continue;
       if (i<0) h_tag = "TECminus_wheel_" + std::to_string(i) + Tag;

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -106,8 +106,6 @@ SiStripGainsPCLWorker::SiStripGainsPCLWorker(const edm::ParameterSet& iConfig) :
 void 
 SiStripGainsPCLWorker::dqmBeginRun(edm::Run const& run, const edm::EventSetup& iSetup){
   
-  std::cout<<"======================================> dqmBeginRun"<< std::endl;
-
   using namespace edm;
 
   this->checkBookAPVColls(iSetup); // check whether APV colls are booked and do so if not yet done
@@ -148,8 +146,6 @@ SiStripGainsPCLWorker::dqmBeginRun(edm::Run const& run, const edm::EventSetup& i
 void
 SiStripGainsPCLWorker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  std::cout<<"======================================> analyze"<< std::endl;
-
   using namespace edm;
 
   //  this->checkBookAPVColls(iSetup); // check whether APV colls are booked and do so if not yet done
@@ -203,7 +199,7 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
   NEvent++;
   NTrack+=(*trackp).size();
 
-  edm::LogInfo("SiStripGainsPCLWorker")
+  LogDebug("SiStripGainsPCLWorker")
     <<"for mode"<< m_calibrationMode 
     <<" Nevent:"<<NEvent 
     <<" NTrack:"<<NTrack
@@ -275,7 +271,7 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
     // keep processing of pixel cluster charge until here
     if(APV->SubDet<=2) continue;
     
-    edm::LogInfo("SiStripGainsPCLWorker") <<" for mode "<< m_calibrationMode << "\n"
+    LogDebug("SiStripGainsPCLWorker") <<" for mode "<< m_calibrationMode << "\n"
 				      <<" i "<< i
 				      <<" NClusterStrip "<< NClusterStrip
 				      <<" useCalibration "<< useCalibration
@@ -288,7 +284,6 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
   
     // real histogram for calibration
     (Charge_Vs_Index[elepos])->Fill(APV->Index,ClusterChargeOverPath);
-    
     
     // Fill monitoring histograms
     int mCharge1 = 0;
@@ -311,12 +306,12 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
       mCharge4 *= ( (*gainused)[i] * (*gainusedTick)[i]); // remove G1 and G2
     } 
 
-    edm::LogInfo("SiStripGainsPCLWorker") <<" full charge "<< mCharge1 
-					  <<" remove G2 "<< mCharge2
-					  <<" remove G1 "<< mCharge3
-					  <<" remove G1*G2 "<< mCharge4
-					  <<std::endl;
-
+    LogDebug("SiStripGainsPCLWorker") <<" full charge "<< mCharge1 
+				      <<" remove G2 "<< mCharge2
+				      <<" remove G1 "<< mCharge3
+				      <<" remove G1*G2 "<< mCharge4
+				      <<std::endl;
+    
     std::vector<MonitorElement*> cmon1 = APVGain::FetchMonitor(Charge_1[elepos], (*rawid)[i], topo);
     for(unsigned int m=0; m<cmon1.size(); m++) cmon1[m]->Fill(( (double) mCharge1 )/(*path)[i]);
 
@@ -326,21 +321,8 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
     std::vector<MonitorElement*> cmon3 = APVGain::FetchMonitor(Charge_3[elepos], (*rawid)[i], topo);
     for(unsigned int m=0; m<cmon3.size(); m++) cmon3[m]->Fill(( (double) mCharge3 )/(*path)[i]);
 
-    //std::vector<APVGain::APVmon>& v4 = Charge_4[elepos];
-    for(auto &test : Charge_4[elepos]){
-      test.printAll();
-    }
-
-    std::cout<<"====> Charge_4[elepos] size: "<<Charge_4[elepos].size()<<std::endl;
     std::vector<MonitorElement*> cmon4 = APVGain::FetchMonitor(Charge_4[elepos], (*rawid)[i], topo);
-
-    //for(unsigned int m=0; m<cmon4.size(); m++){
-    for(const auto &mon : cmon4){
-      //edm::LogInfo("SiStripGainsPCLWorker")<<" checkpoint 9.9: m index: " << m << std::endl;
-      //cmon4[m]->Fill(( (double) mCharge4 )/(*path)[i]);
-      //edm::LogInfo("SiStripGainsPCLWorker")<<" checkpoint 9.9: "<< mon->getName() << " " << mon->getTitle() << std::endl;
-      mon->Fill(( (double) mCharge4 )/(*path)[i]);
-    }
+    for(unsigned int m=0; m<cmon4.size(); m++) cmon4[m]->Fill(( (double) mCharge4 )/(*path)[i]);
 
     if(APV->SubDet==StripSubdetector::TIB){
       (Charge_Vs_PathlengthTIB[elepos])->Fill((*path)[i],Charge);  // TIB
@@ -512,8 +494,6 @@ SiStripGainsPCLWorker::fillDescriptions(edm::ConfigurationDescriptions& descript
 void 
 SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & run, edm::EventSetup const & es){
 
-  std::cout<<"======================================> bookHistograms"<< std::endl;
-
   ibooker.cd();
   std::string dqm_dir = m_DQMdir;
   const char* tag = dqm_tag_[statCollectionFromMode(m_calibrationMode.c_str())].c_str();
@@ -587,7 +567,7 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
     int id    = APVGain::subdetectorId((hnames[i]).first);
     int side  = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    if(Charge_1[elepos].size()<=VChargeHisto.size()) Charge_1[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
+    if(Charge_1[elepos].size()<=VChargeHisto.size()) Charge_1[elepos].emplace_back(id,side,plane,monitor);
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG2");
@@ -597,7 +577,7 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
     int id    = APVGain::subdetectorId((hnames[i]).first);
     int side  = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    if(Charge_2[elepos].size()<=VChargeHisto.size()) Charge_2[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
+    if(Charge_2[elepos].size()<=VChargeHisto.size()) Charge_2[elepos].emplace_back(id,side,plane,monitor);
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG1");
@@ -607,7 +587,7 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
     int id    = APVGain::subdetectorId((hnames[i]).first);
     int side  = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    if(Charge_3[elepos].size()<=VChargeHisto.size()) Charge_3[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
+    if(Charge_3[elepos].size()<=VChargeHisto.size()) Charge_3[elepos].emplace_back(id,side,plane,monitor);
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG1G2");
@@ -617,11 +597,7 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
     int id    = APVGain::subdetectorId((hnames[i]).first);
     int side  = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-
-    std::cout<<"in the booking: "<< monitor->getName() << " id: "<< id << " side: "<< side << " plane: " << plane << std::endl;
-
-    //Charge_4[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
     if(Charge_4[elepos].size()<=VChargeHisto.size()) Charge_4[elepos].emplace_back(id,side,plane,monitor);
-    Charge_4[elepos].back().printAll();
+
   }
 }

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -106,6 +106,8 @@ SiStripGainsPCLWorker::SiStripGainsPCLWorker(const edm::ParameterSet& iConfig) :
 void 
 SiStripGainsPCLWorker::dqmBeginRun(edm::Run const& run, const edm::EventSetup& iSetup){
   
+  std::cout<<"======================================> dqmBeginRun"<< std::endl;
+
   using namespace edm;
 
   this->checkBookAPVColls(iSetup); // check whether APV colls are booked and do so if not yet done
@@ -146,6 +148,8 @@ SiStripGainsPCLWorker::dqmBeginRun(edm::Run const& run, const edm::EventSetup& i
 void
 SiStripGainsPCLWorker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
+  std::cout<<"======================================> analyze"<< std::endl;
+
   using namespace edm;
 
   //  this->checkBookAPVColls(iSetup); // check whether APV colls are booked and do so if not yet done
@@ -224,7 +228,7 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
     if((*trackhitsvalid)[TI]  < MinTrackHits         )continue;
     if((*trackchi2ndof )[TI]  > MaxTrackChiOverNdf   )continue;
     if((*trackalgo     )[TI]  > MaxTrackingIteration )continue;
-    
+
     std::shared_ptr<stAPVGain> APV = APVsColl[((*rawid)[i]<<4) | ((*firststrip)[i]/128)];   //works for both strip and pixel thanks to firstStrip encoding for pixel in the calibTree
     
     if(APV->SubDet>2 && (*farfromedge)[i]        == false           )continue;
@@ -270,11 +274,8 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
 
     // keep processing of pixel cluster charge until here
     if(APV->SubDet<=2) continue;
-      
-    // real histogram for calibration
-    (Charge_Vs_Index[elepos])->Fill(APV->Index,ClusterChargeOverPath);
     
-    LogDebug("SiStripGainsPCLWorker") <<" for mode "<< m_calibrationMode << "\n"
+    edm::LogInfo("SiStripGainsPCLWorker") <<" for mode "<< m_calibrationMode << "\n"
 				      <<" i "<< i
 				      <<" NClusterStrip "<< NClusterStrip
 				      <<" useCalibration "<< useCalibration
@@ -284,6 +285,10 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
 				      <<" Charge "<< Charge
 				      <<" ClusterChargeOverPath "<< ClusterChargeOverPath
 				      <<std::endl;
+  
+    // real histogram for calibration
+    (Charge_Vs_Index[elepos])->Fill(APV->Index,ClusterChargeOverPath);
+    
     
     // Fill monitoring histograms
     int mCharge1 = 0;
@@ -305,22 +310,37 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
       mCharge3 *= (*gainusedTick)[i];                     // remove G1
       mCharge4 *= ( (*gainused)[i] * (*gainusedTick)[i]); // remove G1 and G2
     } 
-    std::vector<APVGain::APVmon>& v1 = Charge_1[elepos];
-    std::vector<MonitorElement*> cmon1 = APVGain::FetchMonitor(v1, (*rawid)[i], topo);
+
+    edm::LogInfo("SiStripGainsPCLWorker") <<" full charge "<< mCharge1 
+					  <<" remove G2 "<< mCharge2
+					  <<" remove G1 "<< mCharge3
+					  <<" remove G1*G2 "<< mCharge4
+					  <<std::endl;
+
+    std::vector<MonitorElement*> cmon1 = APVGain::FetchMonitor(Charge_1[elepos], (*rawid)[i], topo);
     for(unsigned int m=0; m<cmon1.size(); m++) cmon1[m]->Fill(( (double) mCharge1 )/(*path)[i]);
 
-    std::vector<APVGain::APVmon>& v2 = Charge_2[elepos];
-    std::vector<MonitorElement*> cmon2 = APVGain::FetchMonitor(v2, (*rawid)[i], topo);
+    std::vector<MonitorElement*> cmon2 = APVGain::FetchMonitor(Charge_2[elepos], (*rawid)[i], topo);
     for(unsigned int m=0; m<cmon2.size(); m++) cmon2[m]->Fill(( (double) mCharge2 )/(*path)[i]);
 
-    std::vector<APVGain::APVmon>& v3 = Charge_3[elepos];
-    std::vector<MonitorElement*> cmon3 = APVGain::FetchMonitor(v3, (*rawid)[i], topo);
+    std::vector<MonitorElement*> cmon3 = APVGain::FetchMonitor(Charge_3[elepos], (*rawid)[i], topo);
     for(unsigned int m=0; m<cmon3.size(); m++) cmon3[m]->Fill(( (double) mCharge3 )/(*path)[i]);
 
-    std::vector<APVGain::APVmon>& v4 = Charge_4[elepos];
-    std::vector<MonitorElement*> cmon4 = APVGain::FetchMonitor(v4, (*rawid)[i], topo);
-    for(unsigned int m=0; m<cmon4.size(); m++) cmon4[m]->Fill(( (double) mCharge4 )/(*path)[i]);
+    //std::vector<APVGain::APVmon>& v4 = Charge_4[elepos];
+    for(auto &test : Charge_4[elepos]){
+      test.printAll();
+    }
 
+    std::cout<<"====> Charge_4[elepos] size: "<<Charge_4[elepos].size()<<std::endl;
+    std::vector<MonitorElement*> cmon4 = APVGain::FetchMonitor(Charge_4[elepos], (*rawid)[i], topo);
+
+    //for(unsigned int m=0; m<cmon4.size(); m++){
+    for(const auto &mon : cmon4){
+      //edm::LogInfo("SiStripGainsPCLWorker")<<" checkpoint 9.9: m index: " << m << std::endl;
+      //cmon4[m]->Fill(( (double) mCharge4 )/(*path)[i]);
+      //edm::LogInfo("SiStripGainsPCLWorker")<<" checkpoint 9.9: "<< mon->getName() << " " << mon->getTitle() << std::endl;
+      mon->Fill(( (double) mCharge4 )/(*path)[i]);
+    }
 
     if(APV->SubDet==StripSubdetector::TIB){
       (Charge_Vs_PathlengthTIB[elepos])->Fill((*path)[i],Charge);  // TIB
@@ -492,11 +512,13 @@ SiStripGainsPCLWorker::fillDescriptions(edm::ConfigurationDescriptions& descript
 void 
 SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & run, edm::EventSetup const & es){
 
+  std::cout<<"======================================> bookHistograms"<< std::endl;
+
   ibooker.cd();
   std::string dqm_dir = m_DQMdir;
   const char* tag = dqm_tag_[statCollectionFromMode(m_calibrationMode.c_str())].c_str();
 
-  edm::LogInfo("SiStripGainsPCLWorker") << "Setting " << dqm_dir << "in DQM and booking histograms for tag "
+  edm::LogInfo("SiStripGainsPCLWorker") << "Setting " << dqm_dir << " in DQM and booking histograms for tag "
 					<< tag << std::endl;
   
   ibooker.setCurrentFolder(dqm_dir);
@@ -542,7 +564,7 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
      else y = ( p0 - log(exp(p0-p1*y) - p2*p1)) / p1;
   }
   binYarray[687] = 4000.;
-  
+ 
   Charge_Vs_Index[elepos]           = ibooker.book2S(cvi.c_str()     , cvi.c_str()     , NStripAPVs, &binXarray[0], 687, binYarray.data());
   Charge_Vs_PathlengthTIB[elepos]   = ibooker.book2S(cvpTIB.c_str()  , cvpTIB.c_str()  , 20   , 0.3 , 1.3  , 250,0,2000);
   Charge_Vs_PathlengthTOB[elepos]   = ibooker.book2S(cvpTOB.c_str()  , cvpTOB.c_str()  , 20   , 0.3 , 1.3  , 250,0,2000);
@@ -553,6 +575,11 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
   Charge_Vs_PathlengthTECM1[elepos] = ibooker.book2S(cvpTECM1.c_str(), cvpTECM1.c_str(), 20   , 0.3 , 1.3  , 250,0,2000);
   Charge_Vs_PathlengthTECM2[elepos] = ibooker.book2S(cvpTECM2.c_str(), cvpTECM2.c_str(), 20   , 0.3 , 1.3  , 250,0,2000);
 
+  Charge_1[elepos].clear();
+  Charge_2[elepos].clear();
+  Charge_3[elepos].clear();
+  Charge_4[elepos].clear();
+
   std::vector<std::pair<std::string,std::string>> hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"");
   for (unsigned int i=0;i<hnames.size();i++){
     std::string htag = (hnames[i]).first + stag;
@@ -560,7 +587,7 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
     int id    = APVGain::subdetectorId((hnames[i]).first);
     int side  = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    Charge_1[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
+    if(Charge_1[elepos].size()<=VChargeHisto.size()) Charge_1[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG2");
@@ -570,7 +597,7 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
     int id    = APVGain::subdetectorId((hnames[i]).first);
     int side  = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    Charge_2[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
+    if(Charge_2[elepos].size()<=VChargeHisto.size()) Charge_2[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG1");
@@ -580,7 +607,7 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
     int id    = APVGain::subdetectorId((hnames[i]).first);
     int side  = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    Charge_3[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
+    if(Charge_3[elepos].size()<=VChargeHisto.size()) Charge_3[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG1G2");
@@ -590,6 +617,11 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
     int id    = APVGain::subdetectorId((hnames[i]).first);
     int side  = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    Charge_4[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
+
+    std::cout<<"in the booking: "<< monitor->getName() << " id: "<< id << " side: "<< side << " plane: " << plane << std::endl;
+
+    //Charge_4[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
+    if(Charge_4[elepos].size()<=VChargeHisto.size()) Charge_4[elepos].emplace_back(id,side,plane,monitor);
+    Charge_4[elepos].back().printAll();
   }
 }

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -270,7 +270,10 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
 
     // keep processing of pixel cluster charge until here
     if(APV->SubDet<=2) continue;
-    
+
+    // real histogram for calibration
+    (Charge_Vs_Index[elepos])->Fill(APV->Index,ClusterChargeOverPath);
+
     LogDebug("SiStripGainsPCLWorker") <<" for mode "<< m_calibrationMode << "\n"
 				      <<" i "<< i
 				      <<" NClusterStrip "<< NClusterStrip
@@ -281,9 +284,6 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
 				      <<" Charge "<< Charge
 				      <<" ClusterChargeOverPath "<< ClusterChargeOverPath
 				      <<std::endl;
-  
-    // real histogram for calibration
-    (Charge_Vs_Index[elepos])->Fill(APV->Index,ClusterChargeOverPath);
     
     // Fill monitoring histograms
     int mCharge1 = 0;
@@ -567,7 +567,7 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
     int id    = APVGain::subdetectorId((hnames[i]).first);
     int side  = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    if(Charge_1[elepos].size()<=VChargeHisto.size()) Charge_1[elepos].emplace_back(id,side,plane,monitor);
+    Charge_1[elepos].emplace_back(id,side,plane,monitor);
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG2");
@@ -577,7 +577,7 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
     int id    = APVGain::subdetectorId((hnames[i]).first);
     int side  = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    if(Charge_2[elepos].size()<=VChargeHisto.size()) Charge_2[elepos].emplace_back(id,side,plane,monitor);
+    Charge_2[elepos].emplace_back(id,side,plane,monitor);
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG1");
@@ -587,7 +587,7 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
     int id    = APVGain::subdetectorId((hnames[i]).first);
     int side  = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    if(Charge_3[elepos].size()<=VChargeHisto.size()) Charge_3[elepos].emplace_back(id,side,plane,monitor);
+    Charge_3[elepos].emplace_back(id,side,plane,monitor);
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG1G2");
@@ -597,7 +597,6 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
     int id    = APVGain::subdetectorId((hnames[i]).first);
     int side  = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    if(Charge_4[elepos].size()<=VChargeHisto.size()) Charge_4[elepos].emplace_back(id,side,plane,monitor);
-
+    Charge_4[elepos].emplace_back(id,side,plane,monitor);
   }
 }

--- a/CalibTracker/SiStripChannelGain/test/BuildFile.xml
+++ b/CalibTracker/SiStripChannelGain/test/BuildFile.xml
@@ -1,0 +1,5 @@
+<bin   name="testSSTGainPCL_fromRECO" file="testSSTGain_PCL_FromRECO.cpp">
+  <flags   TEST_RUNNER_ARGS="/bin/bash
+  CalibTracker/SiStripChannelGain/test testSSTGain_PCL_FromRECO.sh"/>
+  <use   name="FWCore/Utilities"/>
+</bin>

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.cpp
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.cpp
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.sh
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+(cmsRun ${LOCAL_TEST_DIR}/testSSTGain_PCL_FromRECO_cfg.py 0) || die 'Failure running cmsRun phase2_digi_reco_pixelntuple_cfg.py 0' $?

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO_cfg.py
@@ -39,9 +39,9 @@ def getFileNames_das_client():
 
     files = []
     for row in data:
-        file = [r for r in das_client.get_value(row, filters['grep'])][0]
-        if len(file) > 0 and not file in files:
-            files.append(file)
+        the_file = [r for r in das_client.get_value(row, filters['grep'])][0]
+        if len(the_file) > 0 and not the_file in files:
+            files.append(the_file)
 
     return files
 

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO_cfg.py
@@ -1,0 +1,133 @@
+# Auto generated configuration file
+# with command line options: stepALCA --datatier ALCARECO --conditions auto:run2_data -s ALCA:PromptCalibProdSiStripGains --eventcontent ALCARECO -n 1000 --dasquery=file dataset=/ZeroBias/Run2016C-SiStripCalMinBias-18Apr2017-v1/ALCARECO run=276243 --no_exec
+import FWCore.ParameterSet.Config as cms
+import os
+
+from Configuration.StandardSequences.Eras import eras
+import Utilities.General.cmssw_das_client as das_client
+
+###################################################################
+def getFileNames_das_client():
+###################################################################
+    """Return files for given DAS query via das_client"""
+    files = []
+
+    query = "dataset dataset=/ZeroBias/Run2*SiStripCalMinBias-*/ALCARECO site=T2_CH_CERN" 
+    jsondict = das_client.get_data(query)
+    status = jsondict['status']
+    if status != 'ok':
+        print "DAS query status: %s"%(status)
+        return files
+
+    data =  jsondict['data']
+    viableDS = []
+    for element in data:
+        viableDS.append(element['dataset'][0]['name'])
+
+    print "Using Dataset:",viableDS[-1]
+
+    query = "file dataset=%s site=T2_CH_CERN | grep file.name" % viableDS[-1]
+    jsondict = das_client.get_data(query)
+    status = jsondict['status']
+    if status != 'ok':
+        print "DAS query status: %s"%(status)
+        return files
+
+    mongo_query = jsondict['mongo_query']
+    filters = mongo_query['filters']
+    data = jsondict['data']
+
+    files = []
+    for row in data:
+        file = [r for r in das_client.get_value(row, filters['grep'])][0]
+        if len(file) > 0 and not file in files:
+            files.append(file)
+
+    return files
+
+###################################################################
+process = cms.Process('testFromALCARECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+
+###################################################################
+# Messages
+###################################################################
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.categories.append("SiStripGainsPCLWorker")  
+process.MessageLogger.destinations = cms.untracked.vstring("cout")
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string("DEBUG"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    SiStripGainsPCLWorker = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    )
+process.MessageLogger.statistics.append('cout') 
+
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.AlCaRecoStreams_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10)
+    )
+
+
+INPUTFILES=getFileNames_das_client()
+
+if len(INPUTFILES)==0: 
+    print "** WARNING: ** According to a DAS query no suitable data for test is available. Skipping test"
+    os._exit(0)
+
+myFiles = cms.untracked.vstring()
+myFiles.extend([INPUTFILES[0][0].replace("\"","")])
+# Input source
+process.source = cms.Source("PoolSource",
+                            fileNames = myFiles,
+                            secondaryFileNames = cms.untracked.vstring()
+                            )
+
+process.options = cms.untracked.PSet()
+
+# Additional output definition
+process.ALCARECOStreamPromptCalibProdSiStripGains = cms.OutputModule("PoolOutputModule",
+                                                                     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('pathALCARECOPromptCalibProdSiStripGains')
+                                                                                                       ),
+                                                                     dataset = cms.untracked.PSet(dataTier = cms.untracked.string('ALCARECO'),
+                                                                                                  filterName = cms.untracked.string('PromptCalibProdSiStripGains')
+                                                                                                  ),
+                                                                     eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+                                                                     fileName = cms.untracked.string('PromptCalibProdSiStripGains.root'),
+                                                                     outputCommands = cms.untracked.vstring('drop *', 
+                                                                                                            'keep *_alcaBeamSpotProducer_*_*', 
+                                                                                                            'keep *_MEtoEDMConvertSiStripGains_*_*'
+                                                                                                            )
+                                                                     )
+
+# Other statements
+process.ALCARECOEventContent.outputCommands.extend(process.OutALCARECOPromptCalibProdSiStripGains_noDrop.outputCommands)
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+
+# Path and EndPath definitions
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.ALCARECOStreamPromptCalibProdSiStripGainsOutPath = cms.EndPath(process.ALCARECOStreamPromptCalibProdSiStripGains)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.pathALCARECOPromptCalibProdSiStripGains,process.endjob_step,process.ALCARECOStreamPromptCalibProdSiStripGainsOutPath)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion
+


### PR DESCRIPTION
When trying to reproduce some `ALCAPROMPT` files of the flavour `PromptCalibProdSiStripGains`, starting from the EOY 2016 ReReco `ALCARECO` data, a segmentation fault was encountered, basically due to the overwriting of the elements of a vector of `MonitorElements`.  
This occurred whenever two calls of `dqmBeginRun` happened at the same event (not sure why this should happen at all, framework-wise). 
I think this has not been seen at Tier-0 due to lack of run transitions in the express `ALCAPROMPT` production (?).
Anyway a reproducer can be found [here](https://gist.github.com/mmusich/f70abd1a51f030bd8bddcf76801739a1), while the original stack of the segfault [here](https://gist.github.com/mmusich/292c77b1efe4df715592e807d3acbc53).
This is fixed by clearing the vectors of `MonitorElements` each time the `dqmBeginRun` method is entered.  
I profited of this PR to reorganize slightly the code avoiding to copy MonitorElement pointers in several places and added a unit-test, as this is a production mode we would like to support. 

To be sure the (already large) memory footprint for this workflow is not increased I plot the RSS vs processing time for step2 of worfklow 1001.0 in the:

   * single-threaded case:
 
![image](https://user-images.githubusercontent.com/5082376/36263158-ce3d0a98-1269-11e8-81ac-eced2afbec76.png)

   * multi-threaded case (via `process.options.numberOfStreams = cms.untracked.uint32(8)` )

![image](https://user-images.githubusercontent.com/5082376/36263177-deebffe8-1269-11e8-8e32-d1855e8c2de1.png)
