### PR TITLE
Switch random number generator to mixmax

### DIFF
--- a/IOMC/RandomEngine/python/IOMC_cff.py
+++ b/IOMC/RandomEngine/python/IOMC_cff.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-FullSimEngine = cms.untracked.string('HepJamesRandom')
-#FullSimEngine = cms.untracked.string('MixMaxRng')
-FastSimEngine = cms.untracked.string('TRandom3')
+FullSimEngine = cms.untracked.string('MixMaxRng')
+FastSimEngine = cms.untracked.string('MixMaxRng')
+#FastSimEngine = cms.untracked.string('TRandom3')
 RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
 #
 #  seed for a source no longer needed - replaces by "generator"


### PR DESCRIPTION
New random number generator MIXMAX has better properties and is thread safe. It is proposed to be used in the ROOT6 branch both for Full and Fast SIM. The simulation histories will be different, so only statistical comparison of results is possible.