### PR TITLE
More config changes for DQMEDAnalyzer

### DIFF
--- a/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLWorker_cfi.py
+++ b/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLWorker_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-SiStripGainsPCLWorker = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+SiStripGainsPCLWorker = DQMEDAnalyzer(
     "SiStripGainsPCLWorker",
     minTrackMomentum    = cms.untracked.double(2),
     maxNrStrips         = cms.untracked.uint32(8),

--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
@@ -12,6 +12,7 @@
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/isFinite.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 
 #include <Math/Minimizer.h>
 #include <Math/Factory.h>

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -14,6 +14,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/Run.h"
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -11,6 +11,8 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 

--- a/DQM/EcalMonitorTasks/python/EcalFEDMonitor_cfi.py
+++ b/DQM/EcalMonitorTasks/python/EcalFEDMonitor_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-ecalFEDMonitor = cms.EDAnalyzer("EcalFEDMonitor",
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+ecalFEDMonitor = DQMEDAnalyzer("EcalFEDMonitor",
     folderName = cms.untracked.string("FEDIntegrity"),
     FEDRawDataCollection = cms.InputTag("rawDataCollector"),
     EBDetIdCollection1 = cms.InputTag("ecalDigis", "EcalIntegrityGainErrors"),

--- a/DQM/HcalCommon/src/DQHarvester.cc
+++ b/DQM/HcalCommon/src/DQHarvester.cc
@@ -1,4 +1,5 @@
 #include "DQM/HcalCommon/interface/DQHarvester.h"
+#include "FWCore/Framework/interface/Run.h"
 
 namespace hcaldqm
 {

--- a/DQM/HcalTasks/interface/LEDTask.h
+++ b/DQM/HcalTasks/interface/LEDTask.h
@@ -17,6 +17,7 @@
 #include "DQM/HcalCommon/interface/ContainerSingleProf2D.h"
 #include "DQM/HcalCommon/interface/ContainerProf1D.h"
 #include "DQM/HcalCommon/interface/ContainerProf2D.h"
+#include "FWCore/Framework/interface/Run.h"
 
 class LEDTask : public hcaldqm::DQTask
 {

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -17,6 +17,7 @@
 #include "DQM/HcalCommon/interface/ContainerSingleProf2D.h"
 #include "DQM/HcalCommon/interface/ContainerProf1D.h"
 #include "DQM/HcalCommon/interface/ContainerProf2D.h"
+#include "FWCore/Framework/interface/Run.h"
 
 class LaserTask : public hcaldqm::DQTask
 {

--- a/DQM/HcalTasks/interface/UMNioTask.h
+++ b/DQM/HcalTasks/interface/UMNioTask.h
@@ -18,6 +18,7 @@
 #include "DQM/HcalCommon/interface/ContainerSingleProf2D.h"
 #include "DQM/HcalCommon/interface/ContainerProf1D.h"
 #include "DQM/HcalCommon/interface/ContainerProf2D.h"
+#include "FWCore/Framework/interface/Run.h"
 
 class UMNioTask : public hcaldqm::DQTask
 {

--- a/DQM/HcalTasks/plugins/PedestalTask.cc
+++ b/DQM/HcalTasks/plugins/PedestalTask.cc
@@ -1,4 +1,5 @@
 #include "DQM/HcalTasks/interface/PedestalTask.h"
+#include "FWCore/Framework/interface/Run.h"
 
 using namespace hcaldqm;
 using namespace hcaldqm::constants;

--- a/DQM/HcalTasks/plugins/QIE10Task.cc
+++ b/DQM/HcalTasks/plugins/QIE10Task.cc
@@ -1,5 +1,6 @@
 
 #include "DQM/HcalTasks/interface/QIE10Task.h"
+#include "FWCore/Framework/interface/Run.h"
 #include <map>
 
 using namespace hcaldqm;

--- a/DQM/HcalTasks/plugins/QIE11Task.cc
+++ b/DQM/HcalTasks/plugins/QIE11Task.cc
@@ -1,4 +1,5 @@
 #include "DQM/HcalTasks/interface/QIE11Task.h"
+#include "FWCore/Framework/interface/Run.h"
 
 using namespace hcaldqm;
 using namespace hcaldqm::constants;

--- a/DQM/HcalTasks/python/DigiComparisonTask.py
+++ b/DQM/HcalTasks/python/DigiComparisonTask.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-digiComparisonTask = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+digiComparisonTask = DQMEDAnalyzer(
 	"DigiComparisonTask",
 
 	name = cms.untracked.string("DigiComparisonTask"),

--- a/DQM/HcalTasks/python/DigiPhase1Task.py
+++ b/DQM/HcalTasks/python/DigiPhase1Task.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-digiPhase1Task = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+digiPhase1Task = DQMEDAnalyzer(
 	"DigiPhase1Task",
 	
 	#	standard parameters

--- a/DQM/HcalTasks/python/DigiTask.py
+++ b/DQM/HcalTasks/python/DigiTask.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-digiTask = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+digiTask = DQMEDAnalyzer(
 	"DigiTask",
 	
 	#	standard parameters

--- a/DQM/HcalTasks/python/HFRaddamTask.py
+++ b/DQM/HcalTasks/python/HFRaddamTask.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-hfRaddamTask = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+hfRaddamTask = DQMEDAnalyzer(
 	"HFRaddamTask",
 	
 	#	standard parameters

--- a/DQM/HcalTasks/python/LEDTask.py
+++ b/DQM/HcalTasks/python/LEDTask.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-ledTask = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+ledTask = DQMEDAnalyzer(
 	"LEDTask",
 	
 	#	standard parameters

--- a/DQM/HcalTasks/python/LaserTask.py
+++ b/DQM/HcalTasks/python/LaserTask.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-laserTask = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+laserTask = DQMEDAnalyzer(
 	"LaserTask",
 	
 	#	standard parameters

--- a/DQM/HcalTasks/python/NoCQTask.py
+++ b/DQM/HcalTasks/python/NoCQTask.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-nocqTask = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+nocqTask = DQMEDAnalyzer(
 	"NoCQTask",
 	
 	#	standard parameters

--- a/DQM/HcalTasks/python/PedestalTask.py
+++ b/DQM/HcalTasks/python/PedestalTask.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-pedestalTask = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+pedestalTask = DQMEDAnalyzer(
 	"PedestalTask",
 	
 	#	standard parameters

--- a/DQM/HcalTasks/python/QIE10Task.py
+++ b/DQM/HcalTasks/python/QIE10Task.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-qie10Task = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+qie10Task = DQMEDAnalyzer(
 	"QIE10Task",
 
 	#	standard

--- a/DQM/HcalTasks/python/QIE11Task.py
+++ b/DQM/HcalTasks/python/QIE11Task.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-qie11Task = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+qie11Task = DQMEDAnalyzer(
 	"QIE11Task",
 
 	#	standard

--- a/DQM/HcalTasks/python/RawTask.py
+++ b/DQM/HcalTasks/python/RawTask.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 # prep a FED skip list
 
-rawTask = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+rawTask = DQMEDAnalyzer(
 	"RawTask",
 	
 	#	standard parameters

--- a/DQM/HcalTasks/python/RecHitTask.py
+++ b/DQM/HcalTasks/python/RecHitTask.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-recHitTask = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+recHitTask = DQMEDAnalyzer(
 	"RecHitTask",
 	
 	#	standard parameters

--- a/DQM/HcalTasks/python/TPComparisonTask.py
+++ b/DQM/HcalTasks/python/TPComparisonTask.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-tpComparisonTask = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+tpComparisonTask = DQMEDAnalyzer(
 	"TPComparisonTask",
 
 	name = cms.untracked.string("TPComparisonTask"),

--- a/DQM/HcalTasks/python/TPTask.py
+++ b/DQM/HcalTasks/python/TPTask.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 fgbits = [1 for x in range(5)]
 fgbits.append(0)
 
-tpTask = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+tpTask = DQMEDAnalyzer(
 	"TPTask",
 	
 	#	standard parameters

--- a/DQM/HcalTasks/python/UMNioTask.py
+++ b/DQM/HcalTasks/python/UMNioTask.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-umnioTask = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+umnioTask = DQMEDAnalyzer(
 	"UMNioTask",
 	
 	#	standard parameters

--- a/DQM/HcalTasks/python/ZDCTask.py
+++ b/DQM/HcalTasks/python/ZDCTask.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-zdcTask = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+zdcTask = DQMEDAnalyzer(
 	"ZDCTask",
 
 	#	standard

--- a/DQM/L1TMonitor/python/L1TCSCTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TCSCTF_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tCsctf = cms.EDAnalyzer("L1TCSCTF",
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tCsctf = DQMEDAnalyzer("L1TCSCTF",
     gmtProducer = cms.InputTag("l1GtUnpack"),
 
     statusProducer = cms.InputTag("csctfDigis"),

--- a/DQM/L1TMonitor/python/L1TObjectsTiming_cfi.py
+++ b/DQM/L1TMonitor/python/L1TObjectsTiming_cfi.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 # the uGMT eta/phi map DQM module
-l1tObjectsTiming = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tObjectsTiming = DQMEDAnalyzer(
     "L1TObjectsTiming",
     muonProducer  = cms.InputTag("gtStage2Digis", "Muon"),
     stage2CaloLayer2JetProducer = cms.InputTag("gtStage2Digis","Jet"),

--- a/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
@@ -4,7 +4,8 @@ import FWCore.ParameterSet.Config as cms
 from DQM.L1TMonitor.L1TStage2BMTF_cfi import *
 
 # zero suppression DQM
-l1tStage2BmtfZeroSupp = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tStage2BmtfZeroSupp = DQMEDAnalyzer(
     "L1TMP7ZeroSupp",
     fedIds = cms.vint32(1376, 1377),
     rawData = cms.InputTag("rawDataCollector"),

--- a/DQM/L1TMonitor/python/L1TStage2BMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2BMTF_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tStage2Bmtf = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tStage2Bmtf = DQMEDAnalyzer(
     "L1TStage2BMTF",
     bmtfSource = cms.InputTag("bmtfDigis", "BMTF"),
 #    bmtfSourceTwinMux1 = cms.InputTag("BMTFStage2Digis", "TheDigis"),

--- a/DQM/L1TMonitor/python/L1TStage2EMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2EMTF_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tStage2Emtf = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tStage2Emtf = DQMEDAnalyzer(
     "L1TStage2EMTF",
     emtfSource = cms.InputTag("emtfStage2Digis"),
     monitorDir = cms.untracked.string("L1T/L1TStage2EMTF"), 

--- a/DQM/L1TMonitor/python/L1TStage2OMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2OMTF_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tStage2Omtf = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tStage2Omtf = DQMEDAnalyzer(
     "L1TStage2OMTF",
     omtfSource = cms.InputTag("omtfStage2Digis", ""),
     monitorDir = cms.untracked.string("L1T/L1TStage2OMTF"),

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -4,7 +4,8 @@ import FWCore.ParameterSet.Config as cms
 from DQM.L1TMonitor.L1TStage2uGMT_cfi import *
 
 # the uGMT intermediate muon DQM modules
-l1tStage2uGMTIntermediateBMTF = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tStage2uGMTIntermediateBMTF = DQMEDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsBMTF"),
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/BMTF"),
@@ -12,7 +13,7 @@ l1tStage2uGMTIntermediateBMTF = cms.EDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
-l1tStage2uGMTIntermediateOMTFNeg = cms.EDAnalyzer(
+l1tStage2uGMTIntermediateOMTFNeg = DQMEDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsOMTFNeg"),
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/OMTF_neg"),
@@ -20,7 +21,7 @@ l1tStage2uGMTIntermediateOMTFNeg = cms.EDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
-l1tStage2uGMTIntermediateOMTFPos = cms.EDAnalyzer(
+l1tStage2uGMTIntermediateOMTFPos = DQMEDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsOMTFPos"),
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/OMTF_pos"),
@@ -28,7 +29,7 @@ l1tStage2uGMTIntermediateOMTFPos = cms.EDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
-l1tStage2uGMTIntermediateEMTFNeg = cms.EDAnalyzer(
+l1tStage2uGMTIntermediateEMTFNeg = DQMEDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsEMTFNeg"),
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/EMTF_neg"),
@@ -36,7 +37,7 @@ l1tStage2uGMTIntermediateEMTFNeg = cms.EDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
-l1tStage2uGMTIntermediateEMTFPos = cms.EDAnalyzer(
+l1tStage2uGMTIntermediateEMTFPos = DQMEDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsEMTFPos"),
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/EMTF_pos"),
@@ -45,7 +46,7 @@ l1tStage2uGMTIntermediateEMTFPos = cms.EDAnalyzer(
 )
 
 # zero suppression DQM
-l1tStage2uGMTZeroSupp = cms.EDAnalyzer(
+l1tStage2uGMTZeroSupp = DQMEDAnalyzer(
     "L1TMP7ZeroSupp",
     fedIds = cms.vint32(1402),
     rawData = cms.InputTag("rawDataCollector"),
@@ -88,7 +89,7 @@ ignoreBins = {
 
 # compares the unpacked BMTF output regional muon collection with the unpacked uGMT input regional muon collection from BMTF
 # only muons that do not match are filled in the histograms
-l1tStage2BmtfOutVsuGMTIn = cms.EDAnalyzer(
+l1tStage2BmtfOutVsuGMTIn = DQMEDAnalyzer(
     "L1TStage2RegionalMuonCandComp",
     regionalMuonCollection1 = cms.InputTag("bmtfDigis", "BMTF"),
     regionalMuonCollection2 = cms.InputTag("gmtStage2Digis", "BMTF"),
@@ -102,7 +103,7 @@ l1tStage2BmtfOutVsuGMTIn = cms.EDAnalyzer(
 
 # compares the unpacked OMTF output regional muon collection with the unpacked uGMT input regional muon collection from OMTF
 # only muons that do not match are filled in the histograms
-l1tStage2OmtfOutVsuGMTIn = cms.EDAnalyzer(
+l1tStage2OmtfOutVsuGMTIn = DQMEDAnalyzer(
     "L1TStage2RegionalMuonCandComp",
     regionalMuonCollection1 = cms.InputTag("omtfStage2Digis", ""),
     regionalMuonCollection2 = cms.InputTag("gmtStage2Digis", "OMTF"),
@@ -115,7 +116,7 @@ l1tStage2OmtfOutVsuGMTIn = cms.EDAnalyzer(
 
 # compares the unpacked EMTF output regional muon collection with the unpacked uGMT input regional muon collection from EMTF
 # only muons that do not match are filled in the histograms
-l1tStage2EmtfOutVsuGMTIn = cms.EDAnalyzer(
+l1tStage2EmtfOutVsuGMTIn = DQMEDAnalyzer(
     "L1TStage2RegionalMuonCandComp",
     regionalMuonCollection1 = cms.InputTag("emtfStage2Digis"),
     regionalMuonCollection2 = cms.InputTag("gmtStage2Digis", "EMTF"),
@@ -130,7 +131,7 @@ l1tStage2EmtfOutVsuGMTIn = cms.EDAnalyzer(
 # The five modules below compare the primary unpacked uGMT muon collection to goes to uGT board 0
 # to the unpacked uGMT muon collections that are sent to uGT boards 1 to 5.
 # Only muons that do not match are filled in the histograms
-l1tStage2uGMTMuonVsuGMTMuonCopy1 = cms.EDAnalyzer(
+l1tStage2uGMTMuonVsuGMTMuonCopy1 = DQMEDAnalyzer(
     "L1TStage2MuonComp",
     muonCollection1 = cms.InputTag("gmtStage2Digis", "Muon"),
     muonCollection2 = cms.InputTag("gmtStage2Digis", "MuonCopy1"),

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 # the uGMT DQM module
-l1tStage2uGMT = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tStage2uGMT = DQMEDAnalyzer(
     "L1TStage2uGMT",
     bmtfProducer = cms.InputTag("gmtStage2Digis", "BMTF"),
     omtfProducer = cms.InputTag("gmtStage2Digis", "OMTF"),

--- a/DQM/L1TMonitor/python/L1TStage2uGTCaloLayer2Comp_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTCaloLayer2Comp_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tStage2uGTCaloLayer2Comp = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tStage2uGTCaloLayer2Comp = DQMEDAnalyzer(
     "L1TStage2uGTCaloLayer2Comp",
     calol2JetCollection    = cms.InputTag("caloStage2Digis", "Jet"),
     uGTJetCollection       = cms.InputTag("gtStage2Digis", "Jet"),

--- a/DQM/L1TMonitor/python/L1TStage2uGT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGT_cff.py
@@ -5,7 +5,8 @@ from DQM.L1TMonitor.L1TStage2uGT_cfi import *
 
 # compares the unpacked uGMT muon collection to the unpacked uGT muon collection
 # only muons that do not match are filled in the histograms
-l1tStage2uGMTOutVsuGTIn = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tStage2uGMTOutVsuGTIn = DQMEDAnalyzer(
     "L1TStage2MuonComp",
     muonCollection1 = cms.InputTag("gmtStage2Digis", "Muon"),
     muonCollection2 = cms.InputTag("gtStage2Digis", "Muon"),

--- a/DQM/L1TMonitor/python/L1TdeStage2BMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2BMTF_cfi.py
@@ -5,7 +5,8 @@ ignoreBinsDeStage2Bmtf = [1]
 
 # compares the unpacked BMTF regional muon collection to the emulated BMTF regional muon collection
 # only muons that do not match are filled in the histograms
-l1tdeStage2Bmtf = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tdeStage2Bmtf = DQMEDAnalyzer(
     "L1TStage2RegionalMuonCandComp",
     regionalMuonCollection1 = cms.InputTag("bmtfDigis", "BMTF"),
     regionalMuonCollection2 = cms.InputTag("valBmtfDigis", "BMTF"),

--- a/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
@@ -7,7 +7,8 @@ ignoreBinsDeStage2Emtf = [1]
 
 # compares the unpacked EMTF regional muon collection to the emulated EMTF regional muon collection
 # only muons that do not match are filled in the histograms
-l1tdeStage2EmtfComp = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tdeStage2EmtfComp = DQMEDAnalyzer(
     "L1TStage2RegionalMuonCandComp",
     regionalMuonCollection1 = cms.InputTag("emtfStage2Digis"),
     regionalMuonCollection2 = cms.InputTag("valEmtfStage2Digis", "EMTF"),

--- a/DQM/L1TMonitor/python/L1TdeStage2EMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2EMTF_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tdeStage2Emtf = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tdeStage2Emtf = DQMEDAnalyzer(
     "L1TdeStage2EMTF",
     dataSource = cms.InputTag("emtfStage2Digis"),
     emulSource = cms.InputTag("valEmtfStage2Digis", "EMTF"),

--- a/DQM/L1TMonitor/python/L1TdeStage2OMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2OMTF_cfi.py
@@ -4,7 +4,8 @@ ignoreBinsDeStage2Omtf = [1, 14]
 
 # compares the unpacked OMTF regional muon collection to the emulated OMTF regional muon collection
 # only muons that do not match are filled in the histograms
-l1tdeStage2Omtf = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tdeStage2Omtf = DQMEDAnalyzer(
     "L1TStage2RegionalMuonCandComp",
     regionalMuonCollection1 = cms.InputTag("omtfStage2Digis", ""),
     regionalMuonCollection2 = cms.InputTag("valOmtfDigis", "OMTF"),

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -20,7 +20,8 @@ l1tStage2uGMTEmul.monitorDir = cms.untracked.string(ugmtEmuDqmDir)
 l1tStage2uGMTEmul.emulator = cms.untracked.bool(True)
 
 # the uGMT intermediate muon DQM modules
-l1tStage2uGMTIntermediateBMTFEmul = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tStage2uGMTIntermediateBMTFEmul = DQMEDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag(emulatorModule, "imdMuonsBMTF"),
     monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/BMTF"),
@@ -28,7 +29,7 @@ l1tStage2uGMTIntermediateBMTFEmul = cms.EDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
-l1tStage2uGMTIntermediateOMTFNegEmul = cms.EDAnalyzer(
+l1tStage2uGMTIntermediateOMTFNegEmul = DQMEDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag(emulatorModule, "imdMuonsOMTFNeg"),
     monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/OMTF_neg"),
@@ -36,7 +37,7 @@ l1tStage2uGMTIntermediateOMTFNegEmul = cms.EDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
-l1tStage2uGMTIntermediateOMTFPosEmul = cms.EDAnalyzer(
+l1tStage2uGMTIntermediateOMTFPosEmul = DQMEDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag(emulatorModule, "imdMuonsOMTFPos"),
     monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/OMTF_pos"),
@@ -44,7 +45,7 @@ l1tStage2uGMTIntermediateOMTFPosEmul = cms.EDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
-l1tStage2uGMTIntermediateEMTFNegEmul = cms.EDAnalyzer(
+l1tStage2uGMTIntermediateEMTFNegEmul = DQMEDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag(emulatorModule, "imdMuonsEMTFNeg"),
     monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/EMTF_neg"),
@@ -52,7 +53,7 @@ l1tStage2uGMTIntermediateEMTFNegEmul = cms.EDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
-l1tStage2uGMTIntermediateEMTFPosEmul = cms.EDAnalyzer(
+l1tStage2uGMTIntermediateEMTFPosEmul = DQMEDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag(emulatorModule, "imdMuonsEMTFPos"),
     monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/EMTF_pos"),
@@ -62,7 +63,7 @@ l1tStage2uGMTIntermediateEMTFPosEmul = cms.EDAnalyzer(
 
 # compares the unpacked uGMT muon collection to the emulated uGMT muon collection
 # only muons that do not match are filled in the histograms
-l1tdeStage2uGMT = cms.EDAnalyzer(
+l1tdeStage2uGMT = DQMEDAnalyzer(
     "L1TStage2MuonComp",
     muonCollection1 = cms.InputTag(unpackerModule, "Muon"),
     muonCollection2 = cms.InputTag(emulatorModule),

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
@@ -8,6 +8,7 @@
 #include "DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 
 #include "CondFormats/RunInfo/interface/RunInfo.h"

--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
@@ -8,6 +8,7 @@
 #include "DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 

--- a/DQM/Physics/python/B2GDQM_cfi.py
+++ b/DQM/Physics/python/B2GDQM_cfi.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from math import pi
 
-B2GDQM = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+B2GDQM = DQMEDAnalyzer(
     "B2GDQM",
 
     #Trigger Results

--- a/DQM/Physics/python/CentralityDQM_cfi.py
+++ b/DQM/Physics/python/CentralityDQM_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-CentralityDQM = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+CentralityDQM = DQMEDAnalyzer(
     "CentralityDQM",
     centralitycollection = cms.InputTag("hiCentrality"),
     centralitybincollection = cms.InputTag("centralityBin","HFtowers"),

--- a/DQM/Physics/python/ExoticaDQM_cfi.py
+++ b/DQM/Physics/python/ExoticaDQM_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-ExoticaDQM = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+ExoticaDQM = DQMEDAnalyzer(
     "ExoticaDQM",
 
     #Trigger Results

--- a/DQM/Physics/python/ewkMuLumiMonitorDQM_cfi.py
+++ b/DQM/Physics/python/ewkMuLumiMonitorDQM_cfi.py
@@ -25,7 +25,8 @@ TrkIsoCuts = cms.PSet(
 
 
 
-ewkMuLumiMonitorDQM = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+ewkMuLumiMonitorDQM = DQMEDAnalyzer(
     "EwkMuLumiMonitorDQM",
     # isolation cuts
     TrkIsoCuts,

--- a/DQM/Physics/python/susyDQM_cfi.py
+++ b/DQM/Physics/python/susyDQM_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-susyDQM = cms.EDAnalyzer("RecoSusyDQM",
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+susyDQM = DQMEDAnalyzer("RecoSusyDQM",
 
     moduleName     = cms.untracked.string('Physics/Susy'),
 

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
@@ -20,6 +20,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 // DQM Framework
 #include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/DQM/SiStripMonitorHardware/python/SiStripSpyMonitor_cfi.py
+++ b/DQM/SiStripMonitorHardware/python/SiStripSpyMonitor_cfi.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 
-SiStripSpyMonitor = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+SiStripSpyMonitor = DQMEDAnalyzer(
     "SiStripSpyMonitorModule",
     #Raw data collection
     SpyScopeRawDigisTag = cms.untracked.InputTag('SiStripSpyUnpacker','ScopeRawDigis'),

--- a/DQM/SiStripMonitorHardware/python/siStripCMMonitor_cfi.py
+++ b/DQM/SiStripMonitorHardware/python/siStripCMMonitor_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-siStripCMMonitor = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+siStripCMMonitor = DQMEDAnalyzer(
     "SiStripCMMonitorPlugin",
     #Raw data collection
     RawDataTag = cms.untracked.InputTag('source'),

--- a/DQM/SiStripMonitorPedestals/src/SiStripMonitorPedestals.cc
+++ b/DQM/SiStripMonitorPedestals/src/SiStripMonitorPedestals.cc
@@ -375,7 +375,7 @@ void SiStripMonitorPedestals::analyze(const edm::Event& iEvent, const edm::Event
 	    std::vector<float> myPedPerApv;
 	    apvFactory_->getPedestal(id, i, myPedPerApv);
 	    float avarage = 0;
-	    avarage = accumulate(myPedPerApv.begin(), myPedPerApv.end(), avarage);
+	    avarage = std::accumulate(myPedPerApv.begin(), myPedPerApv.end(), avarage);
 	    avarage = avarage/128.;
 	    (local_modmes.PedsEvolution)->setBinContent(i+1,nIteration_,avarage);
 	      

--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 # MonitorTrackGlobal
-SiStripMonitorTrack = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+SiStripMonitorTrack = DQMEDAnalyzer(
     "SiStripMonitorTrack",
 
     TopFolderName = cms.string('SiStrip'),

--- a/DQM/TrackerMonitorTrack/python/MonitorTrackResiduals_cfi.py
+++ b/DQM/TrackerMonitorTrack/python/MonitorTrackResiduals_cfi.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 # MonitorTrackResiduals
-MonitorTrackResiduals = cms.EDAnalyzer("MonitorTrackResiduals",
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+MonitorTrackResiduals = DQMEDAnalyzer("MonitorTrackResiduals",
     OutputMEsInRootFile = cms.bool(False),
     # should histogramms on module level be booked and filled?
     Mod_On = cms.bool(True),

--- a/DQM/TrackerMonitorTrack/python/SiPixelMonitorTrackResiduals_cfi.py
+++ b/DQM/TrackerMonitorTrack/python/SiPixelMonitorTrackResiduals_cfi.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 # SiPixelMonitorTrackResiduals
-SiPixelMonitorTrackResiduals = cms.EDAnalyzer("SiPixelMonitorTrackResiduals",
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+SiPixelMonitorTrackResiduals = DQMEDAnalyzer("SiPixelMonitorTrackResiduals",
     OutputMEsInRootFile = cms.bool(False),
     # should histogramms on module level be booked and filled?
     Mod_On = cms.bool(False),

--- a/DQMOffline/Alignment/python/LaserAlignmentT0ProducerDQM_cfi.py
+++ b/DQMOffline/Alignment/python/LaserAlignmentT0ProducerDQM_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-LaserAlignmentT0ProducerDQM = cms.EDAnalyzer( "LaserAlignmentT0ProducerDQM",
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+LaserAlignmentT0ProducerDQM = DQMEDAnalyzer( 'LaserAlignmentT0ProducerDQM',
   # specify the input digi collections to run on
   DigiProducerList = cms.VPSet(
     cms.PSet(

--- a/DQMOffline/JetMET/python/RecHits_cfi.py
+++ b/DQMOffline/JetMET/python/RecHits_cfi.py
@@ -5,7 +5,8 @@ import FWCore.ParameterSet.Config as cms
 # Date: 03.04.2008
 #
 # Fill validation histograms for ECAL and HCAL RecHits.
-ECALAnalyzer = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+ECALAnalyzer = DQMEDAnalyzer(
     "ECALRecHitAnalyzer",
     EBRecHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
     EERecHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE"),
@@ -13,7 +14,7 @@ ECALAnalyzer = cms.EDAnalyzer(
     FineBinning = cms.untracked.bool(True),
     FolderName = cms.untracked.string("JetMET/ECALRecHits")
 )
-HCALAnalyzer = cms.EDAnalyzer(
+HCALAnalyzer = DQMEDAnalyzer(
     "HCALRecHitAnalyzer",
     HORecHitsLabel = cms.InputTag("horeco"),
     HBHERecHitsLabel = cms.InputTag("hbhereco"),

--- a/DQMOffline/JetMET/python/caloTowers_cfi.py
+++ b/DQMOffline/JetMET/python/caloTowers_cfi.py
@@ -5,7 +5,8 @@ import FWCore.ParameterSet.Config as cms
 # Date: 03.04.2008
 #
 # Fill validation histograms for caloTowers.
-towerSchemeBAnalyzer = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+towerSchemeBAnalyzer = DQMEDAnalyzer(
     "CaloTowerAnalyzer",
     Debug = cms.bool(False),
     CaloTowersLabel = cms.InputTag("towerMaker"),

--- a/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
@@ -22,7 +22,8 @@ probeToL1Offset = 10
 photonEfficiencyThresholds = electronEfficiencyThresholds
 photonEfficiencyBins = electronEfficiencyBins
 
-l1tEGammaOfflineDQM = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tEGammaOfflineDQM = DQMEDAnalyzer(
     "L1TEGammaOffline",
     electronCollection=cms.InputTag("gedGsfElectrons"),
     photonCollection=cms.InputTag("photons"),

--- a/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
@@ -41,7 +41,8 @@ httEfficiencyBins.extend(list(xrange(200, 400, 20)))
 httEfficiencyBins.extend(list(xrange(400, 500, 50)))
 httEfficiencyBins.extend(list(xrange(500, 601, 10)))
 
-l1tEtSumJetOfflineDQM = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tEtSumJetOfflineDQM = DQMEDAnalyzer(
     "L1TStage2CaloLayer2Offline",
     electronCollection=cms.InputTag("gedGsfElectrons"),
     caloJetCollection=cms.InputTag("ak4CaloJets"),

--- a/DQMOffline/L1Trigger/python/L1TTauOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TTauOffline_cfi.py
@@ -13,7 +13,8 @@ tauEfficiencyBins.extend(list(xrange(300, 400, 50)))
 tauEfficiencyBins.extend(list(xrange(400, 600, 100)))
 tauEfficiencyBins.extend(list(xrange(600, 1200, 200)))
 
-l1tTauOfflineDQM = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tTauOfflineDQM = DQMEDAnalyzer(
     "L1TTauOffline",
     verbose   = cms.untracked.bool(False),
 

--- a/DQMOffline/Trigger/python/B2GTnPMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/B2GTnPMonitor_cfi.py
@@ -118,7 +118,8 @@ egammaStdFiltersToMonitor= cms.VPSet(
   
  
 
-B2GegHLTDQMOfflineTnPSource = cms.EDAnalyzer("HLTEleTagAndProbeOfflineSource",
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+B2GegHLTDQMOfflineTnPSource = DQMEDAnalyzer("HLTEleTagAndProbeOfflineSource",
                                           tagAndProbeCollections = cms.VPSet(
         cms.PSet( 
             tagAndProbeConfigEle50CaloIdVTGsfTrkIdT,

--- a/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-BTVHLTOfflineSource = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+BTVHLTOfflineSource = DQMEDAnalyzer(
     "BTVHLTOfflineSource",
     #
     dirname = cms.untracked.string("HLT/BTV"),

--- a/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
@@ -851,7 +851,8 @@ egammaMuEleFiltersToMonitor= cms.VPSet(
         ),
 )
 
-egHLTDQMOfflineTnPSource = cms.EDAnalyzer("HLTEleTagAndProbeOfflineSource",
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+egHLTDQMOfflineTnPSource = DQMEDAnalyzer("HLTEleTagAndProbeOfflineSource",
                                           tagAndProbeCollections = cms.VPSet(
         cms.PSet( 
             tagAndProbeConfigEle27WPTight,
@@ -875,7 +876,7 @@ egHLTDQMOfflineTnPSource = cms.EDAnalyzer("HLTEleTagAndProbeOfflineSource",
         )
 )
 
-egHLTElePhoHighEtaDQMOfflineTnPSource = cms.EDAnalyzer("HLTElePhoTagAndProbeOfflineSource",
+egHLTElePhoHighEtaDQMOfflineTnPSource = DQMEDAnalyzer("HLTElePhoTagAndProbeOfflineSource",
                                                        tagAndProbeCollections = cms.VPSet(
         cms.PSet( 
             tagAndProbeElePhoHighEtaConfigEle27WPTight,
@@ -898,7 +899,7 @@ egHLTElePhoHighEtaDQMOfflineTnPSource = cms.EDAnalyzer("HLTElePhoTagAndProbeOffl
            
         )
                                                 )
-egHLTElePhoDQMOfflineTnPSource = cms.EDAnalyzer("HLTElePhoTagAndProbeOfflineSource",
+egHLTElePhoDQMOfflineTnPSource = DQMEDAnalyzer("HLTElePhoTagAndProbeOfflineSource",
                                                 tagAndProbeCollections = cms.VPSet(
         cms.PSet( 
             tagAndProbeElePhoConfigEle27WPTight,
@@ -922,7 +923,7 @@ egHLTElePhoDQMOfflineTnPSource = cms.EDAnalyzer("HLTElePhoTagAndProbeOfflineSour
         )
 )
 
-egHLTMuonEleDQMOfflineTnPSource = cms.EDAnalyzer("HLTMuEleTagAndProbeOfflineSource",
+egHLTMuonEleDQMOfflineTnPSource = DQMEDAnalyzer("HLTMuEleTagAndProbeOfflineSource",
                                                  tagAndProbeCollections = cms.VPSet(
         cms.PSet( 
             tagAndProbeMuonEleConfigIsoMu,
@@ -945,7 +946,7 @@ egHLTMuonEleDQMOfflineTnPSource = cms.EDAnalyzer("HLTMuEleTagAndProbeOfflineSour
            
         )
 )
-egHLTMuonPhoDQMOfflineTnPSource = cms.EDAnalyzer("HLTMuPhoTagAndProbeOfflineSource",
+egHLTMuonPhoDQMOfflineTnPSource = DQMEDAnalyzer("HLTMuPhoTagAndProbeOfflineSource",
                                                  tagAndProbeCollections = cms.VPSet(
         cms.PSet( 
             tagAndProbeMuonPhoConfigIsoMu,

--- a/DQMOffline/Trigger/python/HLTInclusiveVBFSource_cfi.py
+++ b/DQMOffline/Trigger/python/HLTInclusiveVBFSource_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-hltInclusiveVBFSource = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+hltInclusiveVBFSource = DQMEDAnalyzer(
     "HLTInclusiveVBFSource",
     dirname     = cms.untracked.string("HLT/InclusiveVBF"),
     processname = cms.string("HLT"),

--- a/DQMOffline/Trigger/python/HigPhotonJetHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/HigPhotonJetHLTOfflineSource_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-higPhotonJetHLTOfflineSource = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+higPhotonJetHLTOfflineSource = DQMEDAnalyzer(
     "HigPhotonJetHLTOfflineSource",
     # Used when fetching triggerSummary and triggerResults
     hltProcessName = cms.string("HLT"),

--- a/DQMOffline/Trigger/python/JetMETHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/JetMETHLTOfflineSource_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-jetMETHLTOfflineSourceAK4 = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+jetMETHLTOfflineSourceAK4 = DQMEDAnalyzer(
     "JetMETHLTOfflineSource",
     dirname = cms.untracked.string("HLT/JME/Jets/AK4"),
     #

--- a/DQMOffline/Trigger/python/MssmHbbBtagTriggerMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/MssmHbbBtagTriggerMonitor_cfi.py
@@ -14,7 +14,8 @@ triggerFlagPSet = cms.PSet(
   verbosityLevel = cms.uint32(1)
 )
 
-mssmHbbBtagTriggerMonitor = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+mssmHbbBtagTriggerMonitor = DQMEDAnalyzer(
     "TagAndProbeBtagTriggerMonitor",
     dirname = cms.string("HLT/Higgs/MssmHbb/"),
     processname = cms.string("HLT"),

--- a/FastSimulation/MaterialEffects/test/testMaterialEffects_cfg.py
+++ b/FastSimulation/MaterialEffects/test/testMaterialEffects_cfg.py
@@ -52,7 +52,8 @@ process.TrackerInteractionGeometryESProducer.TrackerMaterial.TrackerMaterialVers
 
 
 #process.testME = cms.EDFilter(
-process.testME = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+process.testME = DQMEDAnalyzer(
    "testMaterialEffects",
 
     # Full, Fast radii and lengths for plots

--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -41,7 +41,8 @@ from HLTriggerOffline.Exotica.analyses.hltExoticaDSTJets_cff           import DS
 from HLTriggerOffline.Exotica.analyses.hltExoticaDSTMuons_cff          import DSTMuonsPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaTracklessJets_cff     import TracklessJetsPSet
 
-hltExoticaValidator = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+hltExoticaValidator = DQMEDAnalyzer(
 
     "HLTExoticaValidator",
 		

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -2,7 +2,8 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.nanoDQM_tools_cff import *
 
-nanoDQM = cms.EDAnalyzer("NanoAODDQM",
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+nanoDQM = DQMEDAnalyzer("NanoAODDQM",
     vplots = cms.PSet(
         CaloMET = cms.PSet(
             sels = cms.PSet(),

--- a/Validation/RecoMET/python/METValidation_cfi.py
+++ b/Validation/RecoMET/python/METValidation_cfi.py
@@ -5,63 +5,64 @@ import FWCore.ParameterSet.Config as cms
 # Date: 03.04.2008
 #
 # Fill validation histograms for MET
-metAnalyzer = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+metAnalyzer = DQMEDAnalyzer(
     "METTester",
     InputMETLabel = cms.InputTag("caloMet"),
     METType = cms.untracked.string("calo"),
     PrimaryVertices = cms.InputTag("offlinePrimaryVertices")
     )
 
-#metHOAnalyzer = cms.EDAnalyzer(
+#metHOAnalyzer = DQMEDAnalyzer(
 #    "METTester",
 #    OutputFile = cms.untracked.string(''),
 #    InputMETLabel = cms.InputTag("metHO")
 #    )
 #
-#metNoHFAnalyzer = cms.EDAnalyzer(
+#metNoHFAnalyzer = DQMEDAnalyzer(
 #    "METTester",
 #    OutputFile = cms.untracked.string(''),
 #    InputMETLabel = cms.InputTag("metNoHF")
 #    )
 #
-#metNoHFHOAnalyzer = cms.EDAnalyzer(
+#metNoHFHOAnalyzer = DQMEDAnalyzer(
 #    "METTester",
 #    OutputFile = cms.untracked.string(''),
 #    InputMETLabel = cms.InputTag("metNoHFHO")
 #    )
 #
-#metOptAnalyzer = cms.EDAnalyzer(
+#metOptAnalyzer = DQMEDAnalyzer(
 #    "METTester",
 #    OutputFile = cms.untracked.string(''),
 #    InputMETLabel = cms.InputTag("metOpt")
 #    )
 #
-#metOptHOAnalyzer = cms.EDAnalyzer(
+#metOptHOAnalyzer = DQMEDAnalyzer(
 #    "METTester",
 #    OutputFile = cms.untracked.string(''),
 #    InputMETLabel = cms.InputTag("metOptHO")
 #    )
 #
-#metOptNoHFAnalyzer = cms.EDAnalyzer(
+#metOptNoHFAnalyzer = DQMEDAnalyzer(
 #    "METTester",
 #    OutputFile = cms.untracked.string(''),
 #    InputMETLabel = cms.InputTag("metOptNoHF")
 #    )
 #
-#metOptNoHFHOAnalyzer = cms.EDAnalyzer(
+#metOptNoHFHOAnalyzer = DQMEDAnalyzer(
 #    "METTester",
 #    OutputFile = cms.untracked.string(''),
 #    InputMETLabel = cms.InputTag("metOptNoHFHO")
 #    )
 
-pfMetAnalyzer = cms.EDAnalyzer(
+pfMetAnalyzer = DQMEDAnalyzer(
    "METTester",
    InputMETLabel = cms.InputTag("pfMet"),
    METType = cms.untracked.string("pf"),
    PrimaryVertices = cms.InputTag("offlinePrimaryVertices")
    ) 
 
-#tcMetAnalyzer = cms.EDAnalyzer(
+#tcMetAnalyzer = DQMEDAnalyzer(
 #    "METTester",
 #    OutputFile = cms.untracked.string(''),
 #    InputMETLabel = cms.InputTag("tcMet"),
@@ -82,7 +83,7 @@ pfMetAnalyzer = cms.EDAnalyzer(
 #    METType = cms.untracked.string("tc")
 #    ) 
 
-#corMetGlobalMuonsAnalyzer = cms.EDAnalyzer(
+#corMetGlobalMuonsAnalyzer = DQMEDAnalyzer(
 #    "METTester",
 #     OutputFile = cms.untracked.string(''),
 #    InputMETLabel = cms.InputTag("caloMetM"),
@@ -90,63 +91,63 @@ pfMetAnalyzer = cms.EDAnalyzer(
 #    ) 
 
 
-#genMptTrueAnalyzer = cms.EDAnalyzer(
+#genMptTrueAnalyzer = DQMEDAnalyzer(
 #    "METTester",
 #    OutputFile = cms.untracked.string(''),
 #    InputMETLabel = cms.InputTag("genMptTrue"),
 #    )
 
-genMetTrueAnalyzer = cms.EDAnalyzer(
+genMetTrueAnalyzer = DQMEDAnalyzer(
     "METTester",
     InputMETLabel = cms.InputTag("genMetTrue"),
     METType = cms.untracked.string("gen"),
     PrimaryVertices = cms.InputTag("offlinePrimaryVertices")
     )
 
-#genMetCaloAnalyzer = cms.EDAnalyzer(
+#genMetCaloAnalyzer = DQMEDAnalyzer(
 #    "METTester",
 #    OutputFile = cms.untracked.string(''),
 #    InputMETLabel = cms.InputTag("genMetCalo")
 #    )
 #
-#genMptCaloAnalyzer = cms.EDAnalyzer(
+#genMptCaloAnalyzer = DQMEDAnalyzer(
 #    "METTester",
 #    OutputFile = cms.untracked.string(''),
 #    InputMETLabel = cms.InputTag("genMptCalo")
 #    )
 #
 #
-#genMetCaloAndNonPromptAnalyzer = cms.EDAnalyzer(
+#genMetCaloAndNonPromptAnalyzer = DQMEDAnalyzer(
 #    "METTester",
 #    OutputFile = cms.untracked.string(''),
 #    InputMETLabel = cms.InputTag("genMetCaloAndNonPrompt")
 #    )
-pfType0CorrectedMetAnalyzer = cms.EDAnalyzer(
+pfType0CorrectedMetAnalyzer = DQMEDAnalyzer(
    "METTester",
    InputMETLabel = cms.InputTag("pfMetT0pc"),
    METType = cms.untracked.string("pf"),
    PrimaryVertices = cms.InputTag("offlinePrimaryVertices")
    )
-pfType1CorrectedMetAnalyzer = cms.EDAnalyzer(
+pfType1CorrectedMetAnalyzer = DQMEDAnalyzer(
    "METTester",
    InputMETLabel = cms.InputTag("PfMetT1"),
    METType = cms.untracked.string("pf"),
    PrimaryVertices = cms.InputTag("offlinePrimaryVertices")
    )
-pfType01CorrectedMetAnalyzer = cms.EDAnalyzer(
+pfType01CorrectedMetAnalyzer = DQMEDAnalyzer(
    "METTester",
    InputMETLabel = cms.InputTag("PfMetT0pcT1"),
    METType = cms.untracked.string("pf"),
    PrimaryVertices = cms.InputTag("offlinePrimaryVertices")
    )
-pfType1CorrectedMetAnalyzerMiniAOD = cms.EDAnalyzer(
+pfType1CorrectedMetAnalyzerMiniAOD = DQMEDAnalyzer(
    "METTester",
    InputMETLabel = cms.InputTag("slimmedMETs"),
    METType = cms.untracked.string("miniaod"),
    PrimaryVertices = cms.InputTag("offlineSlimmedPrimaryVertices")
    )
 
-pfPuppiMetAnalyzerMiniAOD = cms.EDAnalyzer(
+pfPuppiMetAnalyzerMiniAOD = DQMEDAnalyzer(
    "METTester",
    InputMETLabel = cms.InputTag("slimmedMETsPuppi"),
    METType = cms.untracked.string("miniaod"),

--- a/Validation/RecoTau/python/RecoTauValidation_cfi.py
+++ b/Validation/RecoTau/python/RecoTauValidation_cfi.py
@@ -220,7 +220,7 @@ EFFICIENCY
 """
 
 plotPset = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominator)
-proc.efficiencies = cms.EDAnalyzer(
+proc.efficiencies = DQMEDAnalyzer(
    "TauDQMHistEffProducer",
    plots = plotPset    
    )
@@ -232,7 +232,7 @@ proc.efficiencies = cms.EDAnalyzer(
 #
 ################################################
 
-proc.normalizePlots = cms.EDAnalyzer(
+proc.normalizePlots = DQMEDAnalyzer(
    "DQMHistNormalizer",
    plotNamesToNormalize = cms.vstring('*_pTRatio_*','*_Size_*','*_SumPt_*','*_dRTauRefJet*'),
    reference = cms.string('*_pTRatio_allHadronic')
@@ -252,7 +252,7 @@ PLOTTING
 
 """
 
-loadTau = cms.EDAnalyzer("TauDQMFileLoader",
+loadTau = DQMEDAnalyzer("TauDQMFileLoader",
   test = cms.PSet(
     #inputFileNames = cms.vstring('/afs/cern.ch/user/f/friis/scratch0/MyValidationArea/310pre6NewTags/src/Validation/RecoTau/test/CMSSW_3_1_0_pre6_ZTT_0505Fixes.root'),
     inputFileNames = cms.vstring('/opt/sbg/cms/ui4_data1/dbodin/CMSSW_3_5_1/src/TauID/QCD_recoFiles/TauVal_CMSSW_3_6_0_QCD.root'),
@@ -393,7 +393,7 @@ standardCompareTestAndReference = cms.PSet(
 #   The plotting of HPS Efficiencies
 #
 ##################################################
-## plotHPSEfficiencies = cms.EDAnalyzer("TauDQMHistPlotter",
+## plotHPSEfficiencies = DQMEDAnalyzer("TauDQMHistPlotter",
 ##                                      standardDrawingStuff,
 ##                                      standardCompareTestAndReference,
 ##                                      drawJobs = Utils.SpawnDrawJobs(RunHPSValidation, plotPset),
@@ -409,7 +409,7 @@ standardCompareTestAndReference = cms.PSet(
 #   The plotting of all the Shrinking cone leading pion efficiencies
 #
 ##################################################
-## plotPFTauHighEfficiencyEfficienciesLeadingPion = cms.EDAnalyzer("TauDQMHistPlotter",
+## plotPFTauHighEfficiencyEfficienciesLeadingPion = DQMEDAnalyzer("TauDQMHistPlotter",
 ##                                                                 standardDrawingStuff,
 ##                                                                 standardCompareTestAndReference,
 ##                                                                 drawJobs = Utils.SpawnDrawJobs(PFTausHighEfficiencyLeadingPionBothProngs, plotPset),

--- a/Validation/RecoTau/python/RecoTauValidation_cfi.py
+++ b/Validation/RecoTau/python/RecoTauValidation_cfi.py
@@ -111,7 +111,8 @@ GenericTriggerSelectionParameters = cms.PSet(
    verbosityLevel = cms.uint32(0) #0: complete silence (default), needed for T0 processing;
 )
 
-proc.templateAnalyzer = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+proc.templateAnalyzer = DQMEDAnalyzer(
    "TauTagValidation",
    StandardMatchingParameters,
    GenericTriggerSelection = GenericTriggerSelectionParameters,
@@ -220,7 +221,7 @@ EFFICIENCY
 """
 
 plotPset = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominator)
-proc.efficiencies = DQMEDAnalyzer(
+proc.efficiencies = cms.EDAnalyzer(
    "TauDQMHistEffProducer",
    plots = plotPset    
    )
@@ -232,7 +233,7 @@ proc.efficiencies = DQMEDAnalyzer(
 #
 ################################################
 
-proc.normalizePlots = DQMEDAnalyzer(
+proc.normalizePlots = cms.EDAnalyzer(
    "DQMHistNormalizer",
    plotNamesToNormalize = cms.vstring('*_pTRatio_*','*_Size_*','*_SumPt_*','*_dRTauRefJet*'),
    reference = cms.string('*_pTRatio_allHadronic')

--- a/Validation/RecoTrack/python/MultiTrackValidatorGenPs_cfi.py
+++ b/Validation/RecoTrack/python/MultiTrackValidatorGenPs_cfi.py
@@ -6,7 +6,8 @@ from SimTracker.TrackAssociation.LhcParametersDefinerForTP_cfi import *
 from SimTracker.TrackAssociation.CosmicParametersDefinerForTP_cfi import *
 from Validation.RecoTrack.MTVHistoProducerAlgoForTrackerBlock_cfi import *
 
-multiTrackValidatorGenPs = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+multiTrackValidatorGenPs = DQMEDAnalyzer(
     "MultiTrackValidatorGenPs",
 
     ### general settings ###

--- a/Validation/RecoTrack/python/MultiTrackValidator_cfi.py
+++ b/Validation/RecoTrack/python/MultiTrackValidator_cfi.py
@@ -5,7 +5,8 @@ from SimTracker.TrackAssociation.LhcParametersDefinerForTP_cfi import *
 from SimTracker.TrackAssociation.CosmicParametersDefinerForTP_cfi import *
 from Validation.RecoTrack.MTVHistoProducerAlgoForTrackerBlock_cfi import *
 
-multiTrackValidator = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+multiTrackValidator = DQMEDAnalyzer(
     "MultiTrackValidator",
 
     ### general settings ###

--- a/Validation/RecoTrack/python/MultiTrackValidator_cfi.py
+++ b/Validation/RecoTrack/python/MultiTrackValidator_cfi.py
@@ -5,8 +5,7 @@ from SimTracker.TrackAssociation.LhcParametersDefinerForTP_cfi import *
 from SimTracker.TrackAssociation.CosmicParametersDefinerForTP_cfi import *
 from Validation.RecoTrack.MTVHistoProducerAlgoForTrackerBlock_cfi import *
 
-from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-multiTrackValidator = DQMEDAnalyzer(
+multiTrackValidator = cms.EDAnalyzer(
     "MultiTrackValidator",
 
     ### general settings ###


### PR DESCRIPTION
This PR is a followup to #21871, and does the same thing, to more files.

It is split out of #22157, and supersedes it partially.

Additionally, there are some includes added that were previously pulled in via `DQMEDAnalyzer.h`. This is not strictly necessary, since this file is not changed here, but simplifies moving forward.

There is a conflict with #21794: The two might not conflict formally, and will also not cause problem if both get merged (for now), but the later of the two should be corrected to not touch the freshly converted `DQMGlobalEDAnalyzer` modules (Edit: resolved here, but not dramatic until we switch to EDProducer anyways).