### PR TITLE
add 2018 HI MC wf 150.0 to the short matrix

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -59,6 +59,7 @@ if __name__ == '__main__':
                      136.7611, #2016E JetHT reMINIAOD from 80X legacy
                      136.788, #2017B Photon data
                      140.53, #2011 HI data
+                     150.0, #2018 HI MC
                      1325.7, #test NanoAOD from existing MINI
                      1330, #Run2 MC Zmm
                      135.4, #Run 2 Zee ttbar


### PR DESCRIPTION
One large mission for sw developments of 2018 is the preparation for HI data taking.
This PR is to add a 2018 HI MC test to the standard tests.

I thought that a heavier event may be a better choice, but then maybe we should instead have more lighter events instead.