### PR TITLE
Removing SiStripDetIds dependencies on SiStripTKNumbers. Replacing Si…

### DIFF
--- a/DPGAnalysis/SiStripTools/interface/SiStripTKNumbers.h
+++ b/DPGAnalysis/SiStripTools/interface/SiStripTKNumbers.h
@@ -3,7 +3,7 @@
 
 #include <map>
 
-class SiStripDetId;
+class DetId;
 
 class SiStripTKNumbers {
 
@@ -11,16 +11,16 @@ class SiStripTKNumbers {
 
   SiStripTKNumbers();
 
-  int  nmodules(const SiStripDetId& detid) const;
+  int  nmodules(const DetId& detid) const;
   int  nmodules(const int id) const;
 
-  int  nfibres(const SiStripDetId& detid) const;
+  int  nfibres(const DetId& detid) const;
   int  nfibres(const int id) const;
 
-  int  napvs(const SiStripDetId& detid) const;
+  int  napvs(const DetId& detid) const;
   int  napvs(const int id) const;
 
-  int  nstrips(const SiStripDetId& detid) const;
+  int  nstrips(const DetId& detid) const;
   int  nstrips(const int id) const;
   
  private:

--- a/DPGAnalysis/SiStripTools/src/SiStripTKNumbers.cc
+++ b/DPGAnalysis/SiStripTools/src/SiStripTKNumbers.cc
@@ -1,53 +1,52 @@
 //#include <map>
 
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DPGAnalysis/SiStripTools/interface/SiStripTKNumbers.h"
 
 SiStripTKNumbers::SiStripTKNumbers() {
 
-  SiStripDetId tk(DetId::Tracker,0);
+  DetId tk(DetId::Tracker,0);
   _nmodules[tk.rawId()] = (3540-816)+816+5208+6400;
   _nfibres[tk.rawId()] = (9192-2208)+2208+12906+15104;
   _nmodules[tk.subdetId()] = _nmodules[tk.rawId()];
   _nfibres[tk.subdetId()] = _nfibres[tk.rawId()];
 
-  SiStripDetId tib(DetId::Tracker,SiStripDetId::TIB);
+  DetId tib(DetId::Tracker, StripSubdetector::TIB);
   _nmodules[tib.rawId()] = 3540-816;
   _nfibres[tib.rawId()] = 9192-2208;
   _nmodules[tib.subdetId()] = _nmodules[tib.rawId()];
   _nfibres[tib.subdetId()] = _nfibres[tib.rawId()];
 
-  SiStripDetId tid(DetId::Tracker,SiStripDetId::TID);
+  DetId tid(DetId::Tracker, StripSubdetector::TID);
   _nmodules[tid.rawId()] = 816;
   _nfibres[tid.rawId()] = 2208;
   _nmodules[tid.subdetId()] = _nmodules[tid.rawId()];
   _nfibres[tid.subdetId()] = _nfibres[tid.rawId()];
 
-  SiStripDetId tob(DetId::Tracker,SiStripDetId::TOB);
+  DetId tob(DetId::Tracker, StripSubdetector::TOB);
   _nmodules[tob.rawId()] = 5208;
   _nfibres[tob.rawId()] = 12906;
   _nmodules[tob.subdetId()] = _nmodules[tob.rawId()];
   _nfibres[tob.subdetId()] = _nfibres[tob.rawId()];
 
-  SiStripDetId tec(DetId::Tracker,SiStripDetId::TEC);
+  DetId tec(DetId::Tracker, StripSubdetector::TEC);
   _nmodules[tec.rawId()] = 6400;
   _nfibres[tec.rawId()] = 15104;
   _nmodules[tec.subdetId()] = _nmodules[tec.rawId()];
   _nfibres[tec.subdetId()] = _nfibres[tec.rawId()];
 
-  TECDetId tecp(1,0,0,0,0,0,0);
+  DetId tecp(DetId(DetId::Tracker, StripSubdetector::TEC).rawId() | ( (1& 0x3) << 18)); 
   _nmodules[tecp.rawId()] = 3200;
   _nfibres[tecp.rawId()] = 7552;
 
-  TECDetId tecm(2,0,0,0,0,0,0);
+  DetId tecm(DetId(DetId::Tracker, StripSubdetector::TEC).rawId() | ( (2& 0x3) << 18)); 
   _nmodules[tecm.rawId()] = 3200;
   _nfibres[tecm.rawId()] = 7552;
 
 }
   
-int SiStripTKNumbers::nmodules(const SiStripDetId& detid) const {
+int SiStripTKNumbers::nmodules(const DetId& detid) const {
 
   int subd = detid.subdetId();
   if(_nmodules.find(subd)!=_nmodules.end()) return _nmodules.find(subd)->second;
@@ -62,7 +61,7 @@ int SiStripTKNumbers::nmodules(const int id) const {
   return 0;
 }
 
-int SiStripTKNumbers::nfibres(const SiStripDetId& detid) const {
+int SiStripTKNumbers::nfibres(const DetId& detid) const {
 
   int subd = detid.subdetId();
   if(_nfibres.find(subd)!=_nfibres.end()) return _nfibres.find(subd)->second;
@@ -77,7 +76,7 @@ int SiStripTKNumbers::nfibres(const int id) const {
   return 0;
 }
 
-int SiStripTKNumbers::napvs(const SiStripDetId& detid) const {
+int SiStripTKNumbers::napvs(const DetId& detid) const {
   
   return nfibres(detid)*_apvsperfibre;
 }
@@ -87,7 +86,7 @@ int SiStripTKNumbers::napvs(const int id) const {
   return nfibres(id)*_apvsperfibre;
 }
 
-int SiStripTKNumbers::nstrips(const SiStripDetId& detid) const {
+int SiStripTKNumbers::nstrips(const DetId& detid) const {
   
   return nfibres(detid)*_apvsperfibre*_stripsperapv;
 }


### PR DESCRIPTION
cc @alesaggio @OlivierBondu @pieterdavid 

Removing SiStripDetIds dependencies replaced by DetId objects. 

To the experts (@boudoul) please advice if some test is needed to double check that everything works within DPGAnalysis.