### PR TITLE
Completed test coverage for Ecal O2Os

### DIFF
--- a/CondCore/Utilities/python/popcon2dropbox.py
+++ b/CondCore/Utilities/python/popcon2dropbox.py
@@ -8,10 +8,6 @@ import shutil
 import logging
 from datetime import datetime
 
-dbName = datetime.datetime.utcnow().strftime('%Y-%m-%d_%H-%M-%S-%f')
-dbFileName = '%s.db' %dbName
-dbFileForDropBox = dbFileName
-dbLogFile = '%s_log.db' %dbName
 errorInImportFileFolder = 'import_errors'
 dateformatForFolder = "%y-%m-%d-%H-%M-%S"
 dateformatForLabel = "%y-%m-%d %H:%M:%S"
@@ -32,7 +28,8 @@ consoleHandler = logging.StreamHandler(sys.stdout)
 consoleHandler.setFormatter(logFormatter)
 logger.addHandler(consoleHandler)
 
-def checkFile():
+def checkFile( dbName ):
+    dbFileName = '%s.db' %dbName
     # check if the expected input file is there... 
     # exit code < 0 => error
     # exit code = 0 => skip
@@ -58,7 +55,7 @@ def checkFile():
        logger.error('Check on input data failed: %s' %str(e))
        return -2
 
-def saveFileForImportErrors( datef, withMetadata=False ):
+def saveFileForImportErrors( datef, dbName, withMetadata=False ):
     # save a copy of the files in case of upload failure...
     leafFolderName = datef.strftime(dateformatForFolder)
     fileFolder = os.path.join( errorInImportFileFolder, leafFolderName)
@@ -75,7 +72,7 @@ def saveFileForImportErrors( datef, withMetadata=False ):
             shutil.copy2(df, metadataDestFile)
     logger.error("Upload failed. Data file and metadata saved in folder '%s'" %os.path.abspath(fileFolder))
     
-def upload( args ):
+def upload( args, dbName ):
     destDb = args.destDb
     destTag = args.destTag
     comment = args.comment
@@ -114,14 +111,15 @@ def upload( args ):
        print stdout
        retCode = pipe.returncode
        if retCode != 0:
-           saveFileForImportErrors( datef, True )
+           saveFileForImportErrors( datef, dbName, True )
        ret |= retCode
     except Exception as e:
        ret |= 1
        logger.error(str(e))
     return ret
 
-def copy( args ):
+def copy( args, dbName ):
+    dbFileName = '%s.db' %dbName
     destDb = args.destDb
     destTag = args.destTag
     comment = args.comment
@@ -147,7 +145,7 @@ def copy( args ):
         print stdout
         retCode = pipe.returncode
         if retCode != 0:
-            saveFileForImportErrors( datef )
+            saveFileForImportErrors( datef, dbName )
         ret = retCode
     except Exception as e:
         ret = 1
@@ -155,6 +153,10 @@ def copy( args ):
     return ret
 
 def run( args ):
+    
+    dbName = datetime.utcnow().strftime('%Y-%m-%d_%H-%M-%S-%f')
+    dbFileName = '%s.db' %dbName
+
     if args.auth is not None and not args.auth=='':
         if auth_path_key in os.environ:
             logger.warning("Cannot set authentication path to %s in the environment, since it is already set." %args.auth)
@@ -167,6 +169,7 @@ def run( args ):
     if os.path.exists( '%s.txt' %dbName ):
        os.remove( '%s.txt' %dbName )
     command = 'cmsRun %s ' %args.job_file
+    command += ' targetFile=%s' %dbFileName
     command += ' destinationDatabase=%s' %args.destDb
     command += ' destinationTag=%s' %args.destTag
     command += ' 2>&1'
@@ -179,11 +182,11 @@ def run( args ):
        logger.error( 'O2O job failed. Skipping upload.' )
        return retCode
 
-    ret = checkFile()
+    ret = checkFile( dbName )
     if ret < 0:
         return ret
     elif ret == 0:
         return 0
     if args.copy:
-        return copy( args )
-    return upload( args )
+        return copy( args, dbName )
+    return upload( args, dbName )

--- a/CondCore/Utilities/python/popcon2dropbox.py
+++ b/CondCore/Utilities/python/popcon2dropbox.py
@@ -1,4 +1,4 @@
-import subprocess
+1;2cimport subprocess
 import json
 import netrc
 import sqlite3
@@ -8,7 +8,7 @@ import shutil
 import logging
 from datetime import datetime
 
-dbName = 'popcon'
+dbName = datetime.datetime.utcnow().strftime('%Y-%m-%d_%H-%M-%S-%f')
 dbFileName = '%s.db' %dbName
 dbFileForDropBox = dbFileName
 dbLogFile = '%s_log.db' %dbName

--- a/CondCore/Utilities/python/popcon2dropbox.py
+++ b/CondCore/Utilities/python/popcon2dropbox.py
@@ -1,4 +1,4 @@
-1;2cimport subprocess
+import subprocess
 import json
 import netrc
 import sqlite3

--- a/CondCore/Utilities/python/popcon2dropbox_job_conf.py
+++ b/CondCore/Utilities/python/popcon2dropbox_job_conf.py
@@ -3,6 +3,11 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 import popcon2dropbox
 
 options = VarParsing.VarParsing()
+options.register('targetFile',
+                'popcon.db',
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.string,
+                "the target sqlite file name")
 options.register('destinationDatabase',
                 '',
                 VarParsing.VarParsing.multiplicity.singleton,
@@ -23,11 +28,10 @@ def setup_popcon( recordName, tagTimeType ):
                                     )
                           )
 
-    sqliteConnect = 'sqlite:%s' %popcon2dropbox.dbFileForDropBox
+    sqliteConnect = 'sqlite:%s' %options.targetFile
     process = cms.Process("PopCon")
     process.load("CondCore.CondDB.CondDB_cfi")
     process.CondDB.DBParameters.messageLevel = cms.untracked.int32( 3 )
-    #process.CondDB.connect = 'sqlite:%s' %popcon2dropbox.dbFileForDropBox
 
     process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                               DBParameters = cms.PSet( messageLevel = cms.untracked.int32( 3 ),

--- a/CondTools/Ecal/python/updateADCToGeV_test.py
+++ b/CondTools/Ecal/python/updateADCToGeV_test.py
@@ -21,11 +21,11 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
-process.CondDB.connect = 'sqlite_file:EcalADCToGeV.db'
+process.CondDB.connect = conddb_init.options.destinationDatabase
+if process.CondDB.connect == '':
+    process.CondDB.connect = 'sqlite_file:EcalADCToGeV.db'
 
 process.CondDB.DBParameters.authenticationPath = ''
-
-process.CondDB.connect = conddb_init.options.destinationDatabase
 
 db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
 

--- a/CondTools/Ecal/test/BuildFile.xml
+++ b/CondTools/Ecal/test/BuildFile.xml
@@ -21,6 +21,5 @@
   <test name="EcalTPGCrystalStatus_O2O_test" command="EcalTPGCrystalStatus_O2O_test.sh"/>
   <test name="EcalTPGTowerStatus_O2O_test" command="EcalTPGTowerStatus_O2O_test.sh"/>
   <test name="EcalADCToGeV_update_test" command="EcalADCToGeV_update_test.sh"/>
-  <test name="EcalIntercalib_update_test" command="EcalIntercalib_update_test.sh"/>
   <test name="EcalIntercalibConstants_O2O_test" command="EcalIntercalibConstants_O2O_test.sh"/>
 </architecture>

--- a/CondTools/Ecal/test/BuildFile.xml
+++ b/CondTools/Ecal/test/BuildFile.xml
@@ -2,4 +2,25 @@
 
 <architecture name="slc.*_amd64_.*">
   <test name="EcalDAQ_O2O_test" command="EcalDAQ_O2O_test.sh"/>
+  <test name="EcalDCS_O2O_test" command="EcalDCS_O2O_test.sh"/>
+  <test name="EcalLaser_O2O_test" command="EcalLaser_O2O_test.sh"/>
+  <test name="EcalTPGBadStripStatus_O2O_test" command="EcalTPGBadStripStatus_O2O_test.sh"/>
+  <test name="EcalTPGSpike_O2O_test" command="EcalTPGSpike_O2O_test.sh"/>
+  <test name="EcalTPGWeightIdMap_O2O_test" command="EcalTPGWeightIdMap_O2O_test.sh"/>
+  <test name="EcalTPGWeightGroup_O2O_test" command="EcalTPGWeightGroup_O2O_test.sh"/>
+  <test name="EcalTPGSlidingWindow_O2O_test" command="EcalTPGSlidingWindow_O2O_test.sh"/>
+  <test name="EcalTPGPhysicsConst_O2O_test" command="EcalTPGPhysicsConst_O2O_test.sh"/>
+  <test name="EcalTPGLutIdMap_O2O_test" command="EcalTPGLutIdMap_O2O_test.sh"/>
+  <test name="EcalTPGPedestals_O2O_test" command="EcalTPGPedestals_O2O_test.sh"/>
+  <test name="EcalTPGLutGroup_O2O_test" command="EcalTPGLutGroup_O2O_test.sh"/>
+  <test name="EcalTPGLinearizationConst_O2O_test" command="EcalTPGLinearizationConst_O2O_test.sh"/>
+  <test name="EcalTPGFineGrainTowerEE_O2O_test" command="EcalTPGFineGrainTowerEE_O2O_test.sh"/>
+  <test name="EcalTPGFineGrainStripEE_O2O_test" command="EcalTPGFineGrainStripEE_O2O_test.sh"/>
+  <test name="EcalTPGFineGrainEBIdMap_O2O_test" command="EcalTPGFineGrainEBIdMap_O2O_test.sh"/>
+  <test name="EcalTPGFineGrainEBGroup_O2O_test" command="EcalTPGFineGrainEBGroup_O2O_test.sh"/>
+  <test name="EcalTPGCrystalStatus_O2O_test" command="EcalTPGCrystalStatus_O2O_test.sh"/>
+  <test name="EcalTPGTowerStatus_O2O_test" command="EcalTPGTowerStatus_O2O_test.sh"/>
+  <test name="EcalADCToGeV_update_test" command="EcalADCToGeV_update_test.sh"/>
+  <test name="EcalIntercalib_update_test" command="EcalIntercalib_update_test.sh"/>
+  <test name="EcalIntercalibConstants_O2O_test" command="EcalIntercalibConstants_O2O_test.sh"/>
 </architecture>

--- a/CondTools/Ecal/test/EcalADCToGeV_update_test.sh
+++ b/CondTools/Ecal/test/EcalADCToGeV_update_test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+cmsRun ./src/CondTools/Ecal/python/updateADCToGeV_test.py
+ret=$?
+conddb --db EcalADCToGeV.db list EcalADCToGeV_test
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalDCS_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalDCS_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalDCSTowerStatus_online --destdb EcalDCSTowerStatus_online_O2OTEST.db --o2oTest
+popconRun ./src/CondTools/Ecal/python/EcalDCS_popcon.py -d sqlite_file:EcalDCSTowerStatus_online_O2OTEST.db -t EcalDCSTowerStatus_online -c
+ret=$?
+conddb --db EcalDCSTowerStatus_online_O2OTEST.db list EcalDCSTowerStatus_online
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalIntercalibConstants_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalIntercalibConstants_O2O_test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+conddb --yes copy EcalIntercalibConstants_V1_hlt --destdb EcalIntercalibConstants_V1_hlt_O2OTEST.db --o2oTest
+conddb --yes copy EcalIntercalibConstants_0 --destdb EcalIntercalibConstants_V1_hlt_O2OTEST.db
+conddb --yes copy EcalIntercalibConstants_3.8T_v2 --destdb EcalIntercalibConstants_V1_hlt_O2OTEST.db
+lastRun=`conddb list EcalIntercalibConstants_V1_hlt  | tail -2 | awk '{print $1}'`
+conddb --yes copy runinfo_start_31X_hlt --destdb EcalIntercalibConstants_V1_hlt_O2OTEST.db -f $lastRun -t $lastRun
+cmsRun ./src/CondTools/Ecal/python/EcalIntercalibConstantsPopConBTransitionAnalyzer_cfg.py runNumber=$lastRun destinationDatabase=sqlite_file:EcalIntercalibConstants_V1_hlt_O2OTEST.db destinationTag=EcalIntercalibConstants_V1_hlt tagForRunInfo=runinfo_start_31X_hlt tagForBOff=EcalIntercalibConstants_0T tagForBOn=EcalIntercalibConstants_3.8T_v2
+ret=$?
+conddb --db EcalIntercalibConstants_V1_hlt_O2OTEST.db list EcalIntercalibConstants_V1_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalIntercalib_update_test.sh
+++ b/CondTools/Ecal/test/EcalIntercalib_update_test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+cmsRun ./src/CondTools/Ecal/python/updateIntercali_test.py
+ret=$?
+conddb --db EcalIntercalibConstants_test.db list EcalIntercalib_test
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalLaser_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalLaser_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalLaserAPDPNRatios_prompt_v2 --destdb EcalLaserAPDPNRatios_prompt_v2_O2OTEST.db --o2oTest
+popconRun ./src/CondTools/Ecal/python/EcalLaser_prompt_popcon.py -d sqlite_file:EcalLaserAPDPNRatios_prompt_v2_O2OTEST.db -t EcalLaserAPDPNRatios_prompt_v2 -c
+ret=$?
+conddb --db EcalLaserAPDPNRatios_prompt_v2_O2OTEST.db list EcalLaserAPDPNRatios_prompt_v2
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGBadStripStatus_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGBadStripStatus_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGStripStatus_v3_hlt --destdb EcalTPGStripStatus_v3_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyBadStrip_cfg.py destinationDatabase=sqlite_file:EcalTPGStripStatus_v3_hlt_O2OTEST.db destinationTag=EcalTPGStripStatus_v3_hlt
+ret=$?
+conddb --db EcalTPGStripStatus_v3_hlt_O2OTEST.db list EcalTPGStripStatus_v3_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGCrystalStatus_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGCrystalStatus_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGCrystalStatus_v2_hlt --destdb EcalTPGCrystalStatus_v2_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyBadXT_cfg.py destinationDatabase=sqlite_file:EcalTPGCrystalStatus_v2_hlt_O2OTEST.db destinationTag=EcalTPGCrystalStatus_v2_hlt
+ret=$?
+conddb --db EcalTPGCrystalStatus_v2_hlt_O2OTEST.db list EcalTPGCrystalStatus_v2_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGFineGrainEBGroup_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGFineGrainEBGroup_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGFineGrainEBGroup_v2_hlt --destdb EcalTPGFineGrainEBGroup_v2_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyFgrGroup_cfg.py destinationDatabase=sqlite_file:EcalTPGFineGrainEBGroup_v2_hlt_O2OTEST.db destinationTag=EcalTPGFineGrainEBGroup_v2_hlt
+ret=$?
+conddb --db EcalTPGFineGrainEBGroup_v2_hlt_O2OTEST.db list EcalTPGFineGrainEBGroup_v2_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGFineGrainEBIdMap_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGFineGrainEBIdMap_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGFineGrainEBIdMap_v2_hlt --destdb EcalTPGFineGrainEBIdMap_v2_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyFgrIdMap_cfg.py destinationDatabase=sqlite_file:EcalTPGFineGrainEBIdMap_v2_hlt_O2OTEST.db destinationTag=EcalTPGFineGrainEBIdMap_v2_hlt
+ret=$?
+conddb --db EcalTPGFineGrainEBIdMap_v2_hlt_O2OTEST.db list EcalTPGFineGrainEBIdMap_v2_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGFineGrainStripEE_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGFineGrainStripEE_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGFineGrainStripEE_v2_hlt --destdb EcalTPGFineGrainStripEE_v2_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyLutGroup_cfg.py destinationDatabase=sqlite_file:EcalTPGFineGrainStripEE_v2_hlt_O2OTEST.db destinationTag=EcalTPGFineGrainStripEE_v2_hlt
+ret=$?
+conddb --db EcalTPGFineGrainStripEE_v2_hlt_O2OTEST.db list EcalTPGFineGrainStripEE_v2_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGFineGrainTowerEE_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGFineGrainTowerEE_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGFineGrainTowerEE_v2_hlt --destdb EcalTPGFineGrainTowerEE_v2_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyFgrTowerEE_cfg.py destinationDatabase=sqlite_file:EcalTPGFineGrainTowerEE_v2_hlt_O2OTEST.db destinationTag=EcalTPGFineGrainTowerEE_v2_hlt
+ret=$?
+conddb --db EcalTPGFineGrainTowerEE_v2_hlt_O2OTEST.db list EcalTPGFineGrainTowerEE_v2_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGLinearizationConst_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGLinearizationConst_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGLinearizationConst_v2_hlt --destdb EcalTPGLinearizationConst_v2_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyLin_cfg.py destinationDatabase=sqlite_file:EcalTPGLinearizationConst_v2_hlt_O2OTEST.db destinationTag=EcalTPGLinearizationConst_v2_hlt
+ret=$?
+conddb --db EcalTPGLinearizationConst_v2_hlt_O2OTEST.db list EcalTPGLinearizationConst_v2_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGLutGroup_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGLutGroup_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGLutGroup_v2_hlt --destdb EcalTPGLutGroup_v2_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyLutGroup_cfg.py destinationDatabase=sqlite_file:EcalTPGLutGroup_v2_hlt_O2OTEST.db destinationTag=EcalTPGLutGroup_v2_hlt
+ret=$?
+conddb --db EcalTPGLutGroup_v2_hlt_O2OTEST.db list EcalTPGLutGroup_v2_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGLutIdMap_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGLutIdMap_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGLutIdMap_v2_hlt --destdb EcalTPGLutIdMap_v2_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyLutIdMap_cfg.py destinationDatabase=sqlite_file:EcalTPGLutIdMap_v2_hlt_O2OTEST.db destinationTag=EcalTPGLutIdMap_v2_hlt
+ret=$?
+conddb --db EcalTPGLutIdMap_v2_hlt_O2OTEST.db list EcalTPGLutIdMap_v2_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGPedestals_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGPedestals_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGPedestals_v2_hlt --destdb EcalTPGPedestals_v2_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyPed_cfg.py destinationDatabase=sqlite_file:EcalTPGPedestals_v2_hlt_O2OTEST.db destinationTag=EcalTPGPedestals_v2_hlt
+ret=$?
+conddb --db EcalTPGPedestals_v2_hlt_O2OTEST.db list EcalTPGPedestals_v2_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGPhysicsConst_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGPhysicsConst_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGPhysicsConst_v2_hlt --destdb EcalTPGPhysicsConst_v2_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyPhysConst_cfg.py destinationDatabase=sqlite_file:EcalTPGPhysicsConst_v2_hlt_O2OTEST.db destinationTag=EcalTPGPhysicsConst_v2_hlt
+ret=$?
+conddb --db EcalTPGPhysicsConst_v2_hlt_O2OTEST.db list EcalTPGPhysicsConst_v2_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGSlidingWindow_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGSlidingWindow_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGSlidingWindow_v2_hlt --destdb EcalTPGSlidingWindow_v2_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copySli_cfg.py destinationDatabase=sqlite_file:EcalTPGSlidingWindow_v2_hlt_O2OTEST.db destinationTag=EcalTPGSlidingWindow_v2_hlt
+ret=$?
+conddb --db EcalTPGSlidingWindow_v2_hlt_O2OTEST.db list EcalTPGSlidingWindow_v2_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGSpike_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGSpike_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGSpike_v3_hlt --destdb EcalTPGSpike_v3_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copySpikeTh_cfg.py destinationDatabase=sqlite_file:EcalTPGSpike_v3_hlt_O2OTEST.db destinationTag=EcalTPGSpike_v3_hlt
+ret=$?
+conddb --db EcalTPGSpike_v3_hlt_O2OTEST.db list EcalTPGSpike_v3_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGTowerStatus_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGTowerStatus_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGTowerStatus_hlt --destdb EcalTPGTowerStatus_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyBadTT_cfg.py destinationDatabase=sqlite_file:EcalTPGTowerStatus_hlt_O2OTEST.db destinationTag=EcalTPGTowerStatus_hlt
+ret=$?
+conddb --db EcalTPGTowerStatus_hlt_O2OTEST.db list EcalTPGTowerStatus_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGWeightGroup_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGWeightGroup_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGWeightGroup_v2_hlt --destdb EcalTPGWeightGroup_v2_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyWGroup_cfg.py destinationDatabase=sqlite_file:EcalTPGWeightGroup_v2_hlt_O2OTEST.db destinationTag=EcalTPGWeightGroup_v2_hlt
+ret=$?
+conddb --db EcalTPGWeightGroup_v2_hlt_O2OTEST.db list EcalTPGWeightGroup_v2_hlt
+echo "return code is $ret"
+exit $ret

--- a/CondTools/Ecal/test/EcalTPGWeightIdMap_O2O_test.sh
+++ b/CondTools/Ecal/test/EcalTPGWeightIdMap_O2O_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+conddb --yes copy EcalTPGWeightIdMap_v2_hlt --destdb EcalTPGWeightIdMap_v2_hlt_O2OTEST.db --o2oTest
+cmsRun ./src/CondTools/Ecal/python/copyWIdMap_cfg.py destinationDatabase=sqlite_file:EcalTPGWeightIdMap_v2_hlt_O2OTEST.db destinationTag=EcalTPGWeightIdMap_v2_hlt
+ret=$?
+conddb --db EcalTPGWeightIdMap_v2_hlt_O2OTEST.db list EcalTPGWeightIdMap_v2_hlt
+echo "return code is $ret"
+exit $ret


### PR DESCRIPTION
Added tests for Ecal code accessing Oracle with OCCI  - production related use cases:
EcalADCToGeV update
EcalIntercalib update
EcalDCS o2o
EcalIntercalibConstants o2o
EcalLaser o2o
EcalTPGBadStripStatus o2o
EcalTPGCrystalStatus o2o
EcalTPGFineGrainEBGroup o2o
EcalTPGFineGrainEBIdMap o2o
EcalTPGFineGrainStripEE o2o
EcalTPGFineGrainTowerEE o2o
EcalTPGLinearizationConst o2o
EcalTPGLutGroup o2o
EcalTPGLutIdMap o2o
EcalTPGPedestals o2o
EcalTPGPhysicsConst o2o
EcalTPGSlidingWindow o2o
EcalTPGSpike o2o
EcalTPGTowerStatus o2o
EcalTPGWeightGroup o2o
EcalTPGWeightIdMap o2o
