### PR TITLE
pr10_1_X Enbale TrackTriggerAssociatorClustersStubs in L1TrackTrigger sequence

### DIFF
--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.TrackTrigger.TrackTrigger_cff import *
-##from SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff import *
+from SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff import *
 
 #L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackTriggerTTTracks*TrackTriggerAssociatorTracks)
-L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs)
+L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs)
 
 TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = cms.bool(True)


### PR DESCRIPTION
(master version of 93X PR #22190)

Test: 
PR 10_1_x.  Add `TrackTriggerAssociatorClustersStubs` in `L1TrackTrigger` sequence.
Potentially used for L1Trigger studies.

With PU 200 it takes ~20sec/ev.  
Too long, prefer not to run offline in post-production,

Note:
At the moment not adding products to the EventContent (additional total of 1MB/ev at PU 200)

```
outputCommands.extend(cms.untracked.vstring(
'keep *_TTClusterAssociatorFromPixelDigis_*_*',
'keep *_TTStubAssociatorFromPixelDigis_*_*'))
```