### PR TITLE
Hcal TP fix ngHE saturation + switch from bare to effective pedestals

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -64,7 +64,9 @@ public:
 
   static const int QIE8_LUT_BITMASK = 0x3FF;
   static const int QIE10_LUT_BITMASK = 0x7FF;
-  static const int QIE11_LUT_BITMASK = 0x3FF;
+  static const int QIE11_LUT_BITMASK = 0x7FF;
+  // only the lowest 10 bits were used in 2017
+  static const int QIE11_LUT_BITMASK_2017 = 0x3FF;
 
 private:
   // typedef
@@ -77,8 +79,8 @@ private:
   static const int    nFi_ = 72;
 
   static const int QIE8_LUT_MSB = 0x400;
-  static const int QIE11_LUT_MSB0 = 0x400;
-  static const int QIE11_LUT_MSB1 = 0x800;
+  static const int QIE11_LUT_MSB0 = 0x800;
+  static const int QIE11_LUT_MSB1 = 0x1000;
   static const int QIE10_LUT_MSB  = 0x1000;
   
   // member variables

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -318,7 +318,7 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
 	if (LUTGenerationMode_){
 	    const HcalCalibrations& calibrations = conditions.getHcalCalibrations(cell);
 	    for (auto capId : {0,1,2,3}){
-		ped += calibrations.pedestal(capId);
+		ped += calibrations.effpedestal(capId);
 		gain += calibrations.LUTrespcorrgain(capId);
 	    }
 	    ped /= 4.0;

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -35,6 +35,7 @@ const float HcaluLUTTPGCoder::lsb_=1./16;
 const int HcaluLUTTPGCoder::QIE8_LUT_BITMASK;
 const int HcaluLUTTPGCoder::QIE10_LUT_BITMASK;
 const int HcaluLUTTPGCoder::QIE11_LUT_BITMASK;
+const int HcaluLUTTPGCoder::QIE11_LUT_BITMASK_2017;
 
 constexpr double MaximumFractionalError = 0.002; // 0.2% error allowed from this source
 
@@ -349,7 +350,8 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
 
 	const size_t SIZE = qieType==QIE8 ? INPUT_LUT_SIZE : UPGRADE_LUT_SIZE;
 	const int MASK = qieType==QIE8 ? QIE8_LUT_BITMASK :
-                         qieType==QIE10 ? QIE10_LUT_BITMASK : QIE11_LUT_BITMASK;
+                         qieType==QIE10 ? QIE10_LUT_BITMASK :
+                         is2018OrLater ? QIE11_LUT_BITMASK : QIE11_LUT_BITMASK_2017;
         double linearLSB = linearLSB_QIE8_;
         if (qieType == QIE11 and cell.ietaAbs() == topo_->lastHBRing())
            linearLSB = linearLSB_QIE11Overlap_;

--- a/CaloOnlineTools/HcalOnlineDb/src/WriteL1TriggerObjectsTxt.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/WriteL1TriggerObjectsTxt.cc
@@ -85,7 +85,7 @@ WriteL1TriggerObjectsTxt::analyze(const edm::Event& iEvent, const edm::EventSetu
        
 	for (auto i : {0,1,2,3}){
 	    gain += calibrations.LUTrespcorrgain(i);
-	    ped += calibrations.pedestal(i);
+	    ped += calibrations.effpedestal(i);
 	}
 
 	gain /= 4.;

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
@@ -46,7 +46,7 @@ HcalFeatureHFEMBit::getE(const T& f, int idx) const
    CaloSamples samples;
    db.adc2fC(f, samples);
 
-   auto ped = calibrations.pedestal(f[idx].capid());
+   auto ped = calibrations.effpedestal(f[idx].capid());
    auto corr = calibrations.respcorrgain(f[idx].capid());
 
    return (samples[idx] - ped) * corr;


### PR DESCRIPTION
Two changes to the HCAL trigger LUTs are implemented in this PR:

- a bug fix for the size of the ngHE linearization LUTs (10 bits in 2017 -> 11 bits in 2018)
- a switch from bare pedestals to effective pedestals

To avoid increased quantization errors as a consequence of the increased longitudinal segmentation after the HE upgrade, the energies that enter each trigger tower sum are represented with an additional bit of precision (11 bits) relative to the equivalent quantities in the legacy HE (10 bits). See the bullet "Linearization LUT" on page 23 of the [uHTR spec](https://cms-docdb.cern.ch/cgi-bin/DocDB/ShowDocument?docid=12306) for details. For the 2017 run, in view of the very compressed schedule for preparing Plan 1, it was requested that the HEP17 appear technically as similar to the legacy system as possible.

The change of the linearization LUT LSB to 1/16 GeV needed in order to implement the originally envisioned scheme has already been integrated (https://github.com/cms-sw/cmssw/pull/21756/commits/d95fcf402f3c0d7f0be723ee7924fcd04500dd66#diff-5e541a4bbf886fa4e796702c32e8fe71R10). But the maximum number of bits representing the (transverse) energy was not changed, effectively truncating the linearized transverse energy entering the trigger tower sum sum at 64 GeV rather than 128 GeV. This gives rise to spurious outliers in the RecHit/TP ratio. The plots below compare the trigger tower sum with the equivalent method 0 RECO quantity before and after the changes, using the RelValQCD_FlatPt_15_3000HS_13 samples [1] to emphasize the behavior at high p<sub>T</sub>. These plots were generated including the recently merged PR #22121, and impose a requirement of p<sub>T</sub> > 30 GeV, with saturated towers excluded.


Before changes | After changes
---------------- | ----------------
![m0_vs_tp_before_fix](https://user-images.githubusercontent.com/6534323/36355326-0e305a94-14a7-11e8-8e1d-1a71168bc192.png) | ![m0_vs_tp_after_sat_fix](https://user-images.githubusercontent.com/6534323/36355329-1820e0e6-14a7-11e8-84ee-041ef03b05fb.png)

The treatment of 2017 era is unchanged, aside from a change in the numbering of the bits used for generating ngHE depth feature bits; this functionality was not used in 2017.

The second change, a switch from bare to effective pedestals in LUT generation to take into account the effect of radiation damage on SiPMs, is negligible except for a modest effect in trigger tower 28. Though this change is logically unrelated to the first, since it modifies some of the same files as the first change, the effects are negligible, and has already been presented to L1 experts at a recent [L1 trigger primitives meeting](https://indico.cern.ch/event/704862/contributions/2891729/attachments/1599264/2534797/13FEB2018_cawest_trigger.pdf), it has been included here for simplicity.

This PR should only change quantities involving ngHE TP, and all changes should be small.

[1] 
/RelValQCD_FlatPt_15_3000HS_13/CMSSW_10_0_0-100X_upgrade2018_realistic_v6_mahiOFF-v1/GEN-SIM-DIGI-RAW
/RelValQCD_FlatPt_15_3000HS_13/CMSSW_10_0_0-100X_upgrade2018_realistic_v6_mahiOFF-v1/GEN-SIM-RECO