### PR TITLE
Modifications to HCAL trigger LUTs

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h
@@ -13,6 +13,7 @@ public:
   const HcalPulseContainmentCorrection * get(const HcalDetId & detId, int toAdd, float fixedphase_ns);
 
   void beginRun(edm::EventSetup const & es);
+  void beginRun(const HcalTopology *topo, const edm::ESHandle<HcalMCParams>& mcParams, const edm::ESHandle<HcalRecoParams>& recoParams);
   void endRun();
 
   void setTimeSlew(const HcalTimeSlew* timeSlew) {

--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h
@@ -13,7 +13,7 @@ public:
   const HcalPulseContainmentCorrection * get(const HcalDetId & detId, int toAdd, float fixedphase_ns);
 
   void beginRun(edm::EventSetup const & es);
-  void beginRun(const HcalTopology *topo, const edm::ESHandle<HcalMCParams>& mcParams, const edm::ESHandle<HcalRecoParams>& recoParams);
+  void beginRun(const HcalTopology *topo, const edm::ESHandle<HcalTimeSlew>& delay, const edm::ESHandle<HcalMCParams>& mcParams, const edm::ESHandle<HcalRecoParams>& recoParams);
   void endRun();
 
   void setTimeSlew(const HcalTimeSlew* timeSlew) {

--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
@@ -29,8 +29,8 @@ public:
   void beginRun(edm::EventSetup const & es);
   void endRun();
 
-  const Shape& hbShape() const { return hpdShape_; }
-  const Shape& heShape() const { return hpdShape_; }
+  const Shape& hbShape() const { return hpdShape_v3; }
+  const Shape& heShape() const { return siPMShapeMC2018_; }
   const Shape& hfShape() const { return hfShape_; }
   const Shape& hoShape(bool sipm=false) const { return sipm ? siPMShapeHO_ : hpdShape_; }
   //  return Shape for given shapeType.

--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
@@ -7,6 +7,7 @@
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseShape.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 
 /** \class HcalPulseShapes
   *  
@@ -28,9 +29,10 @@ public:
   // only needed if you'll be getting shapes by DetId
   void beginRun(edm::EventSetup const & es);
   void endRun();
+  void beginRun(const HcalTopology* topo, const edm::ESHandle<HcalMCParams>& mcParams, const edm::ESHandle<HcalRecoParams>& recoParams);
 
-  const Shape& hbShape() const { return hpdShape_v3; }
-  const Shape& heShape() const { return siPMShapeMC2018_; }
+  const Shape& hbShape() const { return hpdShape_; }
+  const Shape& heShape() const { return hpdShape_; }
   const Shape& hfShape() const { return hfShape_; }
   const Shape& hoShape(bool sipm=false) const { return sipm ? siPMShapeHO_ : hpdShape_; }
   //  return Shape for given shapeType.

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentManager.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentManager.cc
@@ -26,8 +26,10 @@ void HcalPulseContainmentManager::endRun()
   shapes_.endRun();
 }
 
-void HcalPulseContainmentManager::beginRun(const HcalTopology *topo, const edm::ESHandle<HcalMCParams>& mcParams, const edm::ESHandle<HcalRecoParams>& recoParams)
+void HcalPulseContainmentManager::beginRun(const HcalTopology *topo, const edm::ESHandle<HcalTimeSlew>& delay, const edm::ESHandle<HcalMCParams>& mcParams, const edm::ESHandle<HcalRecoParams>& recoParams)
 {
+  hcalTimeSlew_delay_ = &*delay;
+
   shapes_.beginRun(topo, mcParams, recoParams);
 }
 

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentManager.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentManager.cc
@@ -26,6 +26,11 @@ void HcalPulseContainmentManager::endRun()
   shapes_.endRun();
 }
 
+void HcalPulseContainmentManager::beginRun(const HcalTopology *topo, const edm::ESHandle<HcalMCParams>& mcParams, const edm::ESHandle<HcalRecoParams>& recoParams)
+{
+  shapes_.beginRun(topo, mcParams, recoParams);
+}
+
 double HcalPulseContainmentManager::correction(const HcalDetId & detId, 
                                                int toAdd, float fixedphase_ns, double fc_ampl)
 {

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
@@ -506,7 +506,7 @@ HcalPulseShapes::shapeForReco(const HcalDetId & detId) const
 const HcalPulseShapes::Shape &
 HcalPulseShapes::defaultShape(const HcalDetId & detId) const
 {
-  edm::LogWarning("HcalPulseShapes") << "Cannot find HCAL MC Params ";
+  //  edm::LogWarning("HcalPulseShapes") << "Cannot find HCAL MC Params ";
   HcalSubdetector subdet = detId.subdet();
   switch(subdet) {
   case HcalBarrel:

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
@@ -127,6 +127,17 @@ void HcalPulseShapes::beginRun(edm::EventSetup const & es)
   theRecoParams->setTopo(theTopology);
 }
 
+void HcalPulseShapes::beginRun(const HcalTopology* topo, const edm::ESHandle<HcalMCParams>& mcParams, const edm::ESHandle<HcalRecoParams>& recoParams)
+{
+  theTopology = topo;
+
+  theMCParams = new HcalMCParams(*mcParams.product());
+  theMCParams->setTopo(theTopology);
+
+  theRecoParams = new HcalRecoParams(*recoParams.product());
+  theRecoParams->setTopo(theTopology);
+}
+
 
 void HcalPulseShapes::endRun()
 {
@@ -506,7 +517,7 @@ HcalPulseShapes::shapeForReco(const HcalDetId & detId) const
 const HcalPulseShapes::Shape &
 HcalPulseShapes::defaultShape(const HcalDetId & detId) const
 {
-  //  edm::LogWarning("HcalPulseShapes") << "Cannot find HCAL MC Params ";
+  edm::LogWarning("HcalPulseShapes") << "Cannot find HCAL MC Params ";
   HcalSubdetector subdet = detId.subdet();
   switch(subdet) {
   case HcalBarrel:

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
@@ -129,13 +129,11 @@ void HcalPulseShapes::beginRun(edm::EventSetup const & es)
 
 void HcalPulseShapes::beginRun(const HcalTopology* topo, const edm::ESHandle<HcalMCParams>& mcParams, const edm::ESHandle<HcalRecoParams>& recoParams)
 {
-  theTopology = topo;
-
   theMCParams = new HcalMCParams(*mcParams.product());
-  theMCParams->setTopo(theTopology);
+  theMCParams->setTopo(topo);
 
   theRecoParams = new HcalRecoParams(*recoParams.product());
-  theRecoParams->setTopo(theTopology);
+  theRecoParams->setTopo(topo);
 }
 
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -665,49 +665,8 @@ std::unique_ptr<HcalLutMetadata> HcalHardcodeCalibrations::produceLutMetadata (c
     int granularity = 1;
     int threshold = 0;
 
-    if (dbHardcode.useHEUpgrade() or dbHardcode.useHFUpgrade()) {
-       // Use values from 2016 as starting conditions for 2017+.  These are
-       // averaged over the subdetectors, with the last two HE towers split
-       // off due to diverging correction values.
-       switch (cell.genericSubdet()) {
-          case HcalGenericDetId::HcalGenBarrel:
-             rcalib = 1.128;
-             break;
-         case HcalGenericDetId::HcalGenEndcap:
-             {
-	         HcalDetId id(cell);
-	         if (id.ietaAbs() >= 28)
-                   rcalib = 1.188;
-                else
-                   rcalib = 1.117;
-		// granularity is equal to 1 only for |ieta| == 17
-		if(id.ietaAbs() >= 18 && id.ietaAbs() <= 26) granularity = 2;
-		else if(id.ietaAbs() >=27 && id.ietaAbs() <= 29) granularity = 5;
-	     }
-             break;
-        case HcalGenericDetId::HcalGenForward:
-             rcalib = 1.02;
-             break;
-         default:
-             break;
-       }
-
-       if (cell.isHcalTrigTowerDetId()) {
-	  rcalib = 0.;
-	  HcalTrigTowerDetId id(cell);
-	  if(id.ietaAbs() <= 17) {
-	    granularity = 1;
-	  }
-	  else if(id.ietaAbs() >= 18 && id.ietaAbs() <= 26) {
-	    granularity = 2;
-	  }
-	  else if(id.ietaAbs() >= 27 && id.ietaAbs() <= 28) {
-	    granularity = 5;
-	  }
-	  else {
-	    granularity = 0;
-	  }
-       }
+    if (cell.isHcalTrigTowerDetId()) {
+      rcalib = 0.;
     }
 
     HcalLutMetadatum item(cell.rawId(), rcalib, granularity, threshold);

--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -5,6 +5,7 @@
 #include "CalibFormats/HcalObjects/interface/HcalNominalCoder.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h"
 
 #include <bitset>
 #include <vector>
@@ -96,6 +97,7 @@ private:
   float cosh_ieta_28_HE_low_depths_, cosh_ieta_28_HE_high_depths_, cosh_ieta_29_HE_;
   bool allLinear_;
   double linearLSB_QIE8_, linearLSB_QIE11_, linearLSB_QIE11Overlap_;
+  std::unique_ptr<HcalPulseContainmentManager> pulseCorr_;
 };
 
 #endif

--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -33,7 +33,7 @@ class HcaluLUTTPGCoder : public HcalTPGCoder {
 public:
   static const float  lsb_;
 
-  HcaluLUTTPGCoder(const HcalTopology* topo);
+  HcaluLUTTPGCoder(const HcalTopology* topo, const edm::ESHandle<HcalMCParams>& mcParams, const edm::ESHandle<HcalRecoParams>& recoParams);
   ~HcaluLUTTPGCoder() override;
   void adc2Linear(const HBHEDataFrame& df, IntegerCaloSamples& ics) const override;
   void adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics) const override;
@@ -45,7 +45,7 @@ public:
   float getLUTGain(HcalDetId id) const override;
   std::vector<unsigned short> getLinearizationLUT(HcalDetId id) const override;
 
-  float cosh_ieta(int ieta, int depth, HcalSubdetector subdet);
+  double cosh_ieta(int ieta, int depth, HcalSubdetector subdet);
   void make_cosh_ieta_map(void);
   void update(const HcalDbService& conditions);
   void update(const char* filename, bool appendMSB = false);
@@ -83,6 +83,8 @@ private:
   
   // member variables
   const HcalTopology* topo_;
+  const edm::ESHandle<HcalMCParams>& mcParams_;
+  const edm::ESHandle<HcalRecoParams>& recoParams_;
   bool LUTGenerationMode_;
   unsigned int FG_HF_threshold_;
   int  bitToMask_;
@@ -92,9 +94,9 @@ private:
   std::vector< Lut > inputLUT_;
   std::vector<float> gain_;
   std::vector<float> ped_;
-  std::map<int, double> cosh_ieta_;
+  std::vector<double> cosh_ieta_;
   // edge cases not covered by the cosh_ieta_ map
-  float cosh_ieta_28_HE_low_depths_, cosh_ieta_28_HE_high_depths_, cosh_ieta_29_HE_;
+  double cosh_ieta_28_HE_low_depths_, cosh_ieta_28_HE_high_depths_, cosh_ieta_29_HE_;
   bool allLinear_;
   double linearLSB_QIE8_, linearLSB_QIE11_, linearLSB_QIE11Overlap_;
   std::unique_ptr<HcalPulseContainmentManager> pulseCorr_;

--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -44,6 +44,8 @@ public:
   float getLUTGain(HcalDetId id) const override;
   std::vector<unsigned short> getLinearizationLUT(HcalDetId id) const override;
 
+  float cosh_ieta(int ieta, int depth, HcalSubdetector subdet);
+  void make_cosh_ieta_map(void);
   void update(const HcalDbService& conditions);
   void update(const char* filename, bool appendMSB = false);
   void updateXML(const char* filename);
@@ -89,6 +91,9 @@ private:
   std::vector< Lut > inputLUT_;
   std::vector<float> gain_;
   std::vector<float> ped_;
+  std::map<int, double> cosh_ieta_;
+  // edge cases not covered by the cosh_ieta_ map
+  float cosh_ieta_28_HE_low_depths_, cosh_ieta_28_HE_high_depths_, cosh_ieta_29_HE_;
   bool allLinear_;
   double linearLSB_QIE8_, linearLSB_QIE11_, linearLSB_QIE11Overlap_;
 };

--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -33,7 +33,7 @@ class HcaluLUTTPGCoder : public HcalTPGCoder {
 public:
   static const float  lsb_;
 
-  HcaluLUTTPGCoder(const HcalTopology* topo, const edm::ESHandle<HcalMCParams>& mcParams, const edm::ESHandle<HcalRecoParams>& recoParams);
+  HcaluLUTTPGCoder(const HcalTopology* topo, const edm::ESHandle<HcalTimeSlew>& delay, const edm::ESHandle<HcalMCParams>& mcParams, const edm::ESHandle<HcalRecoParams>& recoParams);
   ~HcaluLUTTPGCoder() override;
   void adc2Linear(const HBHEDataFrame& df, IntegerCaloSamples& ics) const override;
   void adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics) const override;
@@ -83,6 +83,7 @@ private:
   
   // member variables
   const HcalTopology* topo_;
+  const edm::ESHandle<HcalTimeSlew>& delay_;
   const edm::ESHandle<HcalMCParams>& mcParams_;
   const edm::ESHandle<HcalRecoParams>& recoParams_;
   bool LUTGenerationMode_;

--- a/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
+++ b/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
@@ -47,7 +47,7 @@ public:
 
   ReturnType produce(const HcalTPGRecord&);
 private:
-  void buildCoder(const HcalTopology*);
+  void buildCoder(const HcalTopology*, const edm::ESHandle<HcalMCParams>&, const edm::ESHandle<HcalRecoParams>&);
   // ----------member data ---------------------------
   ReturnType coder_;  
   HcaluLUTTPGCoder* theCoder_;
@@ -96,9 +96,9 @@ HcalTPGCoderULUT::HcalTPGCoderULUT(const edm::ParameterSet& iConfig)
 }
 
   
-void HcalTPGCoderULUT::buildCoder(const HcalTopology* topo) {  
+void HcalTPGCoderULUT::buildCoder(const HcalTopology* topo, const edm::ESHandle<HcalMCParams>& mcParams, const edm::ESHandle<HcalRecoParams>& recoParams) {
   using namespace edm::es;
-  theCoder_ = new HcaluLUTTPGCoder(topo);
+  theCoder_ = new HcaluLUTTPGCoder(topo, mcParams, recoParams);
   if (read_Ascii_ || read_XML_){
     edm::LogInfo("HCAL") << "Using ASCII/XML LUTs" << ifilename_.fullPath() << " for HcalTPGCoderULUT initialization";
     if (read_Ascii_) {
@@ -139,7 +139,14 @@ HcalTPGCoderULUT::produce(const HcalTPGRecord& iRecord)
     edm::ESHandle<HcalTopology> htopo;
     iRecord.getRecord<HcalRecNumberingRecord>().get(htopo);
     const HcalTopology* topo=&(*htopo);
-    buildCoder(topo);
+
+    edm::ESHandle<HcalMCParams> mcParams;
+    iRecord.getRecord<HcalMCParamsRcd>().get(mcParams);
+
+    edm::ESHandle<HcalRecoParams> recoParams;
+    iRecord.getRecord<HcalRecoParamsRcd>().get(recoParams);
+
+    buildCoder(topo, mcParams, recoParams);
   }
   
 
@@ -153,7 +160,12 @@ void HcalTPGCoderULUT::dbRecordCallback(const HcalDbRecord& theRec) {
   theRec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  buildCoder(topo);
+  edm::ESHandle<HcalMCParams> mcParams;
+  theRec.getRecord<HcalMCParamsRcd>().get(mcParams);
+  edm::ESHandle<HcalRecoParams> recoParams;
+  theRec.getRecord<HcalRecoParamsRcd>().get(recoParams);
+
+  buildCoder(topo, mcParams, recoParams);
 
   theCoder_->update(*conditions);
 

--- a/CalibFormats/HcalObjects/interface/HcalDbRecord.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbRecord.h
@@ -28,10 +28,10 @@
 // class HcalDbRecord : public edm::eventsetup::EventSetupRecordImplementation<HcalDbRecord> {};
 
 class HcalDbRecord : public edm::eventsetup::DependentRecordImplementation <HcalDbRecord,  
-  boost::mpl::vector24<HcalRecNumberingRecord, IdealGeometryRecord, HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalGainsRcd, HcalGainWidthsRcd,
+  boost::mpl::vector25<HcalRecNumberingRecord, IdealGeometryRecord, HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalGainsRcd, HcalGainWidthsRcd,
   HcalQIEDataRcd, HcalQIETypesRcd, HcalChannelQualityRcd, HcalZSThresholdsRcd, HcalRespCorrsRcd, 
   HcalL1TriggerObjectsRcd, HcalElectronicsMapRcd, HcalTimeCorrsRcd, HcalLUTCorrsRcd, HcalPFCorrsRcd,
   HcalFrontEndMapRcd, HcalSiPMCharacteristicsRcd, HcalSiPMParametersRcd, HcalTPParametersRcd, HcalTPChannelParametersRcd,
-  HcalLutMetadataRcd, HcalMCParamsRcd, HcalRecoParamsRcd > > {};
+  HcalLutMetadataRcd, HcalMCParamsRcd, HcalRecoParamsRcd, HcalTimeSlewRecord > > {};
 
 #endif /* HCALDBPRODUCER_HCALDBRECORD_H */

--- a/CalibFormats/HcalObjects/interface/HcalDbRecord.h
+++ b/CalibFormats/HcalObjects/interface/HcalDbRecord.h
@@ -28,10 +28,10 @@
 // class HcalDbRecord : public edm::eventsetup::EventSetupRecordImplementation<HcalDbRecord> {};
 
 class HcalDbRecord : public edm::eventsetup::DependentRecordImplementation <HcalDbRecord,  
-  boost::mpl::vector23<HcalRecNumberingRecord, IdealGeometryRecord, HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalGainsRcd, HcalGainWidthsRcd, 
+  boost::mpl::vector24<HcalRecNumberingRecord, IdealGeometryRecord, HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalGainsRcd, HcalGainWidthsRcd,
   HcalQIEDataRcd, HcalQIETypesRcd, HcalChannelQualityRcd, HcalZSThresholdsRcd, HcalRespCorrsRcd, 
   HcalL1TriggerObjectsRcd, HcalElectronicsMapRcd, HcalTimeCorrsRcd, HcalLUTCorrsRcd, HcalPFCorrsRcd,
   HcalFrontEndMapRcd, HcalSiPMCharacteristicsRcd, HcalSiPMParametersRcd, HcalTPParametersRcd, HcalTPChannelParametersRcd,
-  HcalLutMetadataRcd, HcalMCParamsRcd > > {}; 
+  HcalLutMetadataRcd, HcalMCParamsRcd, HcalRecoParamsRcd > > {};
 
 #endif /* HCALDBPRODUCER_HCALDBRECORD_H */

--- a/CalibFormats/HcalObjects/interface/HcalTPGRecord.h
+++ b/CalibFormats/HcalObjects/interface/HcalTPGRecord.h
@@ -22,6 +22,6 @@
 #include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
-class HcalTPGRecord : public edm::eventsetup::DependentRecordImplementation<HcalTPGRecord, boost::mpl::vector<HcalRecNumberingRecord,IdealGeometryRecord,HcalDbRecord> >{};
+class HcalTPGRecord : public edm::eventsetup::DependentRecordImplementation<HcalTPGRecord, boost::mpl::vector<HcalRecNumberingRecord,IdealGeometryRecord,HcalDbRecord,HcalMCParamsRcd,HcalRecoParamsRcd> >{};
 
 #endif

--- a/CalibFormats/HcalObjects/interface/HcalTPGRecord.h
+++ b/CalibFormats/HcalObjects/interface/HcalTPGRecord.h
@@ -22,6 +22,6 @@
 #include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
-class HcalTPGRecord : public edm::eventsetup::DependentRecordImplementation<HcalTPGRecord, boost::mpl::vector<HcalRecNumberingRecord,IdealGeometryRecord,HcalDbRecord,HcalMCParamsRcd,HcalRecoParamsRcd> >{};
+class HcalTPGRecord : public edm::eventsetup::DependentRecordImplementation<HcalTPGRecord, boost::mpl::vector<HcalRecNumberingRecord,IdealGeometryRecord,HcalDbRecord> >{};
 
 #endif

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -48,11 +48,11 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' : '100X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '100X_upgrade2018_design_IdealBS_v6',
+    'phase1_2018_design'       : '100X_upgrade2018_design_IdealBS_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v10',
+    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v11',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v8',
+    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '100X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
Backport #22121 

This backport is needed for two reasons:

- To be able to generate HCAL trigger primitive LUTs in 10_0_X using the same procedure as that envisioned for 2018 data-taking
- To ensure that a consistent set of code+conditions are used even if a newer GT that includes the changes to the HcalLutMetadata in this PR is introduced for 10_0_X