### PR TITLE
Allow ECAL pfrechit thresholds eta dependent in all regions, disregarding if ZS of FR (10-1-X)

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -166,7 +166,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
-
+    process = customiseForEcalTestPR22254Default(process)
     process = customiseFor21821(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -68,6 +68,99 @@ def customiseFor2017DtUnpacking(process):
 
     return process
 
+
+
+# particleFlowRechitECAL new default value "false" flag to be added
+def customiseForEcalTestPR22254Default(process):
+    from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
+
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
+        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
+            module = getattr(process,hltParticleFlowRecHitECAL)
+
+            for producer in module.producers: 
+                if hasattr(producer,'srFlags'):
+                    producer.srFlags = cms.InputTag("")
+                if hasattr(producer,'qualityTests'):
+                    for qualityTest in producer.qualityTests:
+                        if hasattr(qualityTest,'thresholds'):
+                            qualityTest.applySelectionsToAllCrystals = cms.bool(True)
+                        
+    return process
+
+
+
+# Test thresholds for particleFlowRechitECAL   ~ 0.5 sigma
+def customiseForEcalTestPR22254thresholdA(process):
+    from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
+    from RecoParticleFlow.PFClusterProducer.particleFlowZeroSuppressionECAL_cff import _particle_flow_zero_suppression_ECAL_2018_A
+
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
+        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
+            module = getattr(process,hltParticleFlowRecHitECAL)
+
+            for producer in module.producers: 
+                if hasattr(producer,'srFlags'):
+                    producer.srFlags = cms.InputTag("")
+                if hasattr(producer,'qualityTests'):
+                    for qualityTest in producer.qualityTests:
+                        if hasattr(qualityTest,'thresholds'):
+                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_A.thresholds 
+                            qualityTest.applySelectionsToAllCrystals = cms.bool(True)
+                        
+    return process
+
+                   
+
+
+
+# Test thresholds for particleFlowRechitECAL   ~ 1 sigma
+def customiseForEcalTestPR22254thresholdB(process):
+    from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
+    from RecoParticleFlow.PFClusterProducer.particleFlowZeroSuppressionECAL_cff import _particle_flow_zero_suppression_ECAL_2018_B
+
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
+        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
+            module = getattr(process,hltParticleFlowRecHitECAL)
+
+            for producer in module.producers: 
+                if hasattr(producer,'srFlags'):
+                    producer.srFlags = cms.InputTag("")
+                if hasattr(producer,'qualityTests'):
+                    for qualityTest in producer.qualityTests:
+                        if hasattr(qualityTest,'thresholds'):
+                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_B.thresholds 
+                            qualityTest.applySelectionsToAllCrystals = cms.bool(True)
+                        
+    return process
+
+
+
+
+# Test thresholds for particleFlowRechitECAL   ~ 2 sigma
+def customiseForEcalTestPR22254thresholdC(process):
+    from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
+    from RecoParticleFlow.PFClusterProducer.particleFlowZeroSuppressionECAL_cff import _particle_flow_zero_suppression_ECAL_2018_C
+
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
+        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
+            module = getattr(process,hltParticleFlowRecHitECAL)
+
+            for producer in module.producers: 
+                if hasattr(producer,'srFlags'):
+                    producer.srFlags = cms.InputTag("")
+                if hasattr(producer,'qualityTests'):
+                    for qualityTest in producer.qualityTests:
+                        if hasattr(qualityTest,'thresholds'):
+                            qualityTest.thresholds = _particle_flow_zero_suppression_ECAL_2018_C.thresholds 
+                            qualityTest.applySelectionsToAllCrystals = cms.bool(True)
+                        
+    return process
+
+
+
+
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -166,7 +166,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
-    process = customiseForEcalTestPR22254Default(process)
     process = customiseFor21821(process)
+    process = customiseForEcalTestPR22254Default(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -72,7 +72,6 @@ def customiseFor2017DtUnpacking(process):
 
 # particleFlowRechitECAL new default value "false" flag to be added
 def customiseForEcalTestPR22254Default(process):
-    from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
 
     for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
         if hasattr(process,hltParticleFlowRecHitECAL):                                                 
@@ -89,6 +88,12 @@ def customiseForEcalTestPR22254Default(process):
     return process
 
 
+
+# 
+# The three different set of thresholds will be used to study
+# possible new thresholds of pfrechits and effects on high level objects
+# The values proposed (A, B, C) are driven by expected noise levels
+#
 
 # Test thresholds for particleFlowRechitECAL   ~ 0.5 sigma
 def customiseForEcalTestPR22254thresholdA(process):

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -391,11 +391,12 @@ public:
 
   PFRecHitQTestECALMultiThreshold(const edm::ParameterSet& iConfig):
     PFRecHitQTestBase(iConfig),
-    thresholds_(iConfig.getParameter<std::vector<double> >("thresholds"))
-  {
+    thresholds_(iConfig.getParameter<std::vector<double> >("thresholds")),
+    applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals"))
+    {
     if (thresholds_.size() != EcalRingCalibrationTools::N_RING_TOTAL)
       throw edm::Exception(edm::errors::Configuration, "ValueError")
-        << "thresholds is expected to have " << EcalRingCalibrationTools::N_RING_TOTAL << " elements but has " << thresholds_.size();
+        << "thresholds is expected to have " << EcalRingCalibrationTools::N_RING_TOTAL << " elements but has " << thresholds_.size();   
   }
 
   void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
@@ -410,7 +411,8 @@ public:
   }
 
   bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-    return fullReadOut or pass(hit);
+    if (applySelectionsToAllCrystals_) return pass(hit);
+    else return fullReadOut or pass(hit);
   }
   bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
     return true;
@@ -435,6 +437,10 @@ protected:
   const std::vector<double> thresholds_;
   bool endcapGeometrySet_;
 
+  // apply selections to all crystals
+  bool applySelectionsToAllCrystals_;
+  
+  
   bool pass(const reco::PFRecHit& hit){
 
     DetId detId(hit.detId());

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -20,7 +20,8 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
              qualityTests = cms.VPSet(
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECALMultiThreshold"),
-                  thresholds = particle_flow_zero_suppression_ECAL.thresholds
+                  thresholds = particle_flow_zero_suppression_ECAL.thresholds,
+                  applySelectionsToAllCrystals = cms.bool(False)
                   ),
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECAL"),
@@ -38,7 +39,8 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
             qualityTests = cms.VPSet(
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECALMultiThreshold"),
-                 thresholds = particle_flow_zero_suppression_ECAL.thresholds
+                 thresholds = particle_flow_zero_suppression_ECAL.thresholds,
+                 applySelectionsToAllCrystals = cms.bool(False)
                  ),
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECAL"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -21,7 +21,7 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECALMultiThreshold"),
                   thresholds = particle_flow_zero_suppression_ECAL.thresholds,
-                  applySelectionsToAllCrystals = cms.bool(False)
+                  applySelectionsToAllCrystals = cms.bool(True)
                   ),
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECAL"),
@@ -40,7 +40,7 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECALMultiThreshold"),
                  thresholds = particle_flow_zero_suppression_ECAL.thresholds,
-                 applySelectionsToAllCrystals = cms.bool(False)
+                 applySelectionsToAllCrystals = cms.bool(True)
                  ),
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECAL"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
@@ -11,6 +11,38 @@ _pfZeroSuppressionThresholds_EB_2017 = pfZeroSuppressionThresholds_EB
 _pfZeroSuppressionThresholds_EEminus_2017 = pfZeroSuppressionThresholds_EEminus
 _pfZeroSuppressionThresholds_EEplus_2017 = _pfZeroSuppressionThresholds_EEminus_2017
 
+# A
+_pfZeroSuppressionThresholds_EB_2018_A = [0.180]*170
+_pfZeroSuppressionThresholds_EEminus_2018_A = [0.22, 0.22, 0.24, 0.26, 0.28, 0.3, 0.32, 0.34, 0.34, 0.36, 0.36, 0.38, 0.38, 0.4, 0.44, 0.46, 0.5, 0.54, 0.58, 0.62, 0.68, 0.72, 0.78, 0.84, 0.9, 1.0, 1.14, 1.36, 1.68, 2.14, 2.8, 3.76, 5.1, 6.94, 9.46, 12.84, 17.3, 23.2, 30.8]
+_pfZeroSuppressionThresholds_EEplus_2018_A = _pfZeroSuppressionThresholds_EEminus_2018_A
+
+_particle_flow_zero_suppression_ECAL_2018_A = cms.PSet(
+    thresholds = cms.vdouble(_pfZeroSuppressionThresholds_EB_2018_A + _pfZeroSuppressionThresholds_EEminus_2018_A + _pfZeroSuppressionThresholds_EEplus_2018_A
+        )
+    )
+
+# B
+_pfZeroSuppressionThresholds_EB_2018_B = [0.140]*170
+_pfZeroSuppressionThresholds_EEminus_2018_B = [0.11, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.17, 0.18, 0.18, 0.19, 0.19, 0.20, 0.22, 0.23, 0.25, 0.27, 0.29, 0.31, 0.34, 0.36, 0.39, 0.42, 0.45, 0.50, 0.57, 0.68, 0.84, 1.07, 1.40, 1.88, 2.55, 3.47, 4.73, 6.42, 8.65, 11.6, 15.4]
+_pfZeroSuppressionThresholds_EEplus_2018_B = _pfZeroSuppressionThresholds_EEminus_2018_B
+
+
+_particle_flow_zero_suppression_ECAL_2018_B = cms.PSet(
+    thresholds = cms.vdouble(_pfZeroSuppressionThresholds_EB_2018_B + _pfZeroSuppressionThresholds_EEminus_2018_B + _pfZeroSuppressionThresholds_EEplus_2018_B
+        )
+    )
+
+# C
+_pfZeroSuppressionThresholds_EB_2018_C = [0.100]*170
+_pfZeroSuppressionThresholds_EEminus_2018_C = [0.055, 0.055, 0.06, 0.065, 0.07, 0.075, 0.08, 0.085, 0.085, 0.09, 0.09, 0.095, 0.095, 0.1, 0.11, 0.115, 0.125, 0.135, 0.145, 0.155, 0.17, 0.18, 0.195, 0.21, 0.225, 0.25, 0.285, 0.34, 0.42, 0.535, 0.7, 0.94, 1.275, 1.735, 2.365, 3.21, 4.325, 5.8, 7.7 ]
+_pfZeroSuppressionThresholds_EEplus_2018_C = _pfZeroSuppressionThresholds_EEminus_2018_C
+
+
+_particle_flow_zero_suppression_ECAL_2018_C = cms.PSet(
+    thresholds = cms.vdouble(_pfZeroSuppressionThresholds_EB_2018_C + _pfZeroSuppressionThresholds_EEminus_2018_C + _pfZeroSuppressionThresholds_EEplus_2018_C
+        )
+    )
+
 
 
 particle_flow_zero_suppression_ECAL = cms.PSet(

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
@@ -16,9 +16,9 @@ _pfZeroSuppressionThresholds_EEplus_2017 = _pfZeroSuppressionThresholds_EEminus_
 # The three different set of thresholds will be used to study
 # possible new thresholds of pfrechits and effects on high level objects
 # The values proposed (A, B, C) are driven by expected noise levels
-# A ~ 0.5 sigma noise equivalent thresholds
+# A ~ 2.0 sigma noise equivalent thresholds
 # B ~ 1.0 sigma noise equivalent thresholds
-# C ~ 2.0 sigma noise equivalent thresholds
+# C ~ 0.5 sigma noise equivalent thresholds
 #
 
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
@@ -11,6 +11,17 @@ _pfZeroSuppressionThresholds_EB_2017 = pfZeroSuppressionThresholds_EB
 _pfZeroSuppressionThresholds_EEminus_2017 = pfZeroSuppressionThresholds_EEminus
 _pfZeroSuppressionThresholds_EEplus_2017 = _pfZeroSuppressionThresholds_EEminus_2017
 
+
+# 
+# The three different set of thresholds will be used to study
+# possible new thresholds of pfrechits and effects on high level objects
+# The values proposed (A, B, C) are driven by expected noise levels
+# A ~ 0.5 sigma noise equivalent thresholds
+# B ~ 1.0 sigma noise equivalent thresholds
+# C ~ 2.0 sigma noise equivalent thresholds
+#
+
+
 # A
 _pfZeroSuppressionThresholds_EB_2018_A = [0.180]*170
 _pfZeroSuppressionThresholds_EEminus_2018_A = [0.22, 0.22, 0.24, 0.26, 0.28, 0.3, 0.32, 0.34, 0.34, 0.36, 0.36, 0.38, 0.38, 0.4, 0.44, 0.46, 0.5, 0.54, 0.58, 0.62, 0.68, 0.72, 0.78, 0.84, 0.9, 1.0, 1.14, 1.36, 1.68, 2.14, 2.8, 3.76, 5.1, 6.94, 9.46, 12.84, 17.3, 23.2, 30.8]


### PR DESCRIPTION
Allow ECAL pfrechit thresholds eta dependent in all regions, disregarding if they have been read in Zero Suppression (ZS) of Full Readout (FR).

In the previous version we could activate these thresholds only in ZS regions, or de-activate the application of the thresholds everywhere.

With this PR we can activate the thresholds everywhere, by means of the boolean: "applySelectionsToAllCrystals"

HLT customization added as well, given the new parameter added in the pfrechit producer..

In addition, definition of reasonable thresholds that can be used by jetmet/HLT/EGamma/Tau POGs to estimate possible changes in pf-rechit thresholds to adapt to 2018 data-taking conditions.
