### PR TITLE
Sped up call to SiPixelFrameConverter::hasDetUnit

### DIFF
--- a/CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h
@@ -21,6 +21,8 @@ public:
   virtual std::vector<sipixelobjects::CablingPathToDetUnit> pathToDetUnit(
       uint32_t rawDetId) const = 0;
 
+  virtual bool pathToDetUnitHasDetUnit(uint32_t rawDetId, unsigned int fedId) const =0;
+
   virtual std::unordered_map<uint32_t, unsigned int> det2fedMap() const =0; 
 
   virtual std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > det2PathMap() const=0;

--- a/CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h
@@ -38,12 +38,14 @@ public:
   std::string version() const override { return theVersion; }
 
   const sipixelobjects::PixelROC* findItem(
-      const sipixelobjects::CablingPathToDetUnit & path) const override;
+      const sipixelobjects::CablingPathToDetUnit & path) const final;
 
-  std::vector<sipixelobjects::CablingPathToDetUnit> pathToDetUnit(uint32_t rawDetId) const override;
+  std::vector<sipixelobjects::CablingPathToDetUnit> pathToDetUnit(uint32_t rawDetId) const final;
 
-  std::unordered_map<uint32_t, unsigned int> det2fedMap() const override;
-  std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > det2PathMap() const override;
+  bool pathToDetUnitHasDetUnit(uint32_t rawDetId, unsigned int fedId) const final;
+
+  std::unordered_map<uint32_t, unsigned int> det2fedMap() const final;
+  std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > det2PathMap() const final;
 
 
   std::vector<unsigned int> fedIds() const;

--- a/CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h
@@ -32,16 +32,17 @@ public:
 
   void addItem(unsigned int fedId, unsigned int linkId, const sipixelobjects::PixelROC& roc);
 
-  std::vector<sipixelobjects::CablingPathToDetUnit> pathToDetUnit(uint32_t rawDetId) const override;
+  std::vector<sipixelobjects::CablingPathToDetUnit> pathToDetUnit(uint32_t rawDetId) const final;
+  bool pathToDetUnitHasDetUnit(uint32_t rawDetId, unsigned int fedId) const final;
 
-  const sipixelobjects::PixelROC* findItem(const sipixelobjects::CablingPathToDetUnit & path) const override;  
+  const sipixelobjects::PixelROC* findItem(const sipixelobjects::CablingPathToDetUnit & path) const final;  
 
   const sipixelobjects::PixelROC* findItemInFed(const sipixelobjects::CablingPathToDetUnit & path, 
 						const PixelFEDCabling * aFed) const;  
 
 
-  std::unordered_map<uint32_t, unsigned int> det2fedMap() const override;
-  std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > det2PathMap() const override;
+  std::unordered_map<uint32_t, unsigned int> det2fedMap() const final;
+  std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > det2PathMap() const final;
 
 
   int checkNumbering() const;

--- a/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
@@ -160,3 +160,15 @@ std::vector<sipixelobjects::CablingPathToDetUnit> SiPixelFedCablingMap::pathToDe
   return result;
 }
 
+bool SiPixelFedCablingMap::pathToDetUnitHasDetUnit(uint32_t rawDetId, unsigned int fedId) const {
+
+  auto end = theMap.end();
+  for (auto im = theMap.lower_bound( {fedId, 0, 0} ); 
+       im != end and im->first.fed == fedId; ++im) {
+    if(im->second.rawId()==rawDetId ) {
+      return true;
+    }
+  }
+  return false;
+}
+

--- a/CondFormats/SiPixelObjects/src/SiPixelFedCablingTree.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFedCablingTree.cc
@@ -30,6 +30,26 @@ std::vector<sipixelobjects::CablingPathToDetUnit> SiPixelFedCablingTree::pathToD
   return result;
 }
 
+bool SiPixelFedCablingTree::pathToDetUnitHasDetUnit(uint32_t rawDetId, unsigned int fedId) const {
+  for (auto im = theFedCablings.begin(); im != theFedCablings.end(); ++im) {
+    const PixelFEDCabling & aFed = im->second;
+    if(aFed.id() == fedId) {
+      for (unsigned int idxLink = 1; idxLink <= aFed.numberOfLinks(); idxLink++) {
+        const PixelFEDLink * link = aFed.link(idxLink);
+        if (!link) continue;
+        unsigned int numberOfRocs = link->numberOfROCs();
+        for(unsigned int idxRoc = 1; idxRoc <= numberOfRocs; idxRoc++) {
+          const PixelROC * roc = link->roc(idxRoc);
+          if (rawDetId == roc->rawId() ) {
+            return true;
+          } 
+        }
+      }
+    }
+  }
+  return false;
+}
+
 std::unordered_map<uint32_t, unsigned int> SiPixelFedCablingTree::det2fedMap() const {
   std::unordered_map<uint32_t, unsigned int> result;
   for (auto im = theFedCablings.begin(); im != theFedCablings.end(); ++im) {

--- a/CondFormats/SiPixelObjects/src/SiPixelFrameConverter.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFrameConverter.cc
@@ -19,12 +19,7 @@ SiPixelFrameConverter::SiPixelFrameConverter(const SiPixelFedCabling* map, int f
 
 bool SiPixelFrameConverter::hasDetUnit(uint32_t rawId) const
 {
-  std::vector<CablingPathToDetUnit> paths = theMap->pathToDetUnit(rawId);
-  typedef std::vector<CablingPathToDetUnit>::const_iterator IT;
-  for (IT it=paths.begin(); it!=paths.end();++it) {
-    if(it->fed==static_cast<unsigned int>(theFedId)) return true;
-  }
-  return false;
+  return theMap->pathToDetUnitHasDetUnit(rawId, static_cast<unsigned int>(theFedId));
 }
 
 


### PR DESCRIPTION
Sped up call to SiPixelFrameConverter::hasDetUnit by adding a
specialized function to SiPixelFedCabling. This avoids creating
and destroying a temporary vector just to look for a DetUnit.