### PR TITLE
Do not fit vertex for single track in PFTauSecondaryVertexProducer

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PFTauSecondaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauSecondaryVertexProducer.cc
@@ -103,11 +103,15 @@ void PFTauSecondaryVertexProducer::produce(edm::StreamID, edm::Event& iEvent,con
 	// Fit the secondary vertex
 	bool FitOk(true);
 	KalmanVertexFitter kvf(true);
-	try{
-	  transVtx = kvf.vertex(transTrk); //KalmanVertexFitter  
-	}catch(...){
-	  FitOk=false;
-	}
+        if(transTrk.size() > 1) {
+          try{
+            transVtx = kvf.vertex(transTrk); //KalmanVertexFitter  
+          }catch(...){
+            FitOk=false;
+          }
+        } else {
+          FitOk = false;
+        }
 	if(!transVtx.hasRefittedTracks()) FitOk=false;
 	if(transVtx.refittedTracks().size()!=transTrk.size()) FitOk=false;
 	if(FitOk){


### PR DESCRIPTION
By requiring at least 2 tracks when doing a vertex, we can avoid most
of the possible exceptions.