### PR TITLE
Re-structure visualization client configuration

### DIFF
--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -29,12 +29,18 @@ except Exception as ex:
     msg += str(ex)
     raise RuntimeError(msg)
 
+# A hack necessary to prevert scenario.visualizationProcessing
+# from overriding the connect string
+from DQM.Integration.config.FrontierCondition_GT_autoExpress_cfi import GlobalTag
+kwds = {
+   'globalTag': GlobalTag.globaltag.value(),
+   'globalTagConnect': GlobalTag.connect.value()
+}
 
-kwds = {}
 # example of how to add a filer IN FRONT of all the paths, eg for HLT selection
 #kwds['preFilter'] = 'DQM/Integration/python/config/visualizationPreFilter.hltfilter'
 
-process = scenario.visualizationProcessing(globalTag='DUMMY', writeTiers=['FEVT'], **kwds)
+process = scenario.visualizationProcessing(writeTiers=['FEVT'], **kwds)
 
 process.source = source
 process.source.inputFileTransitionsEachEvent = cms.untracked.bool(True)
@@ -52,8 +58,6 @@ try:
     os.makedirs(outDir)
 except:
     pass
-
-process.load("DQM.Integration.config.FrontierCondition_GT_autoExpress_cfi")
 
 process.options = cms.untracked.PSet(
         Rethrow = cms.untracked.vstring('ProductNotFound'),

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -20,7 +20,6 @@ scenarioName = scenarios[runType.getRunTypeName()]
 
 print "Using scenario:",scenarioName
 
-
 try:
     scenario = getScenario(scenarioName)
 except Exception as ex:
@@ -30,11 +29,18 @@ except Exception as ex:
     raise RuntimeError(msg)
 
 
-kwds = {}
+# A hack necessary to prevert scenario.visualizationProcessing
+# from overriding the connect string
+from DQM.Integration.config.FrontierCondition_GT_autoExpress_cfi import GlobalTag
+kwds = {
+   'globalTag': GlobalTag.globaltag.value(),
+   'globalTagConnect': GlobalTag.connect.value()
+}
+
 # example of how to add a filer IN FRONT of all the paths, eg for HLT selection
 #kwds['preFilter'] = 'DQM/Integration/python/config/visualizationPreFilter.hltfilter'
 
-process = scenario.visualizationProcessing(globalTag='DUMMY', writeTiers=['FEVT'], **kwds)
+process = scenario.visualizationProcessing(writeTiers=['FEVT'], **kwds)
 
 process.source = source
 process.source.inputFileTransitionsEachEvent = cms.untracked.bool(True)
@@ -52,8 +58,6 @@ try:
     os.makedirs(outDir)
 except:
     pass
-
-process.load("DQM.Integration.config.FrontierCondition_GT_autoExpress_cfi")
 
 process.options = cms.untracked.PSet(
         Rethrow = cms.untracked.vstring('ProductNotFound'),


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/22283

The connect string was incorrectly overriden into 'PromtProd'.
For online DQM, it should it be 'FrontierProd'.

The override was done because 'globalTagConnect' was not passed
to the scenario.visualizationProcessing and the default value was used.

https://github.com/cms-sw/cmssw/blob/fc7e8c9e38c6569e65e1cd16e37df0f797af82fe/Configuration/DataProcessing/python/Utils.py#L141

This PR moves loading of the DQM GT configuration _before_
calling the scenario config and then properly passes GT and connect
to the call.