### PR TITLE
Fix compilation warning RecoJets/JetAlgorithms

### DIFF
--- a/RecoJets/JetAlgorithms/src/Qjets.cc
+++ b/RecoJets/JetAlgorithms/src/Qjets.cc
@@ -97,7 +97,7 @@ void Qjets::Cluster(fastjet::ClusterSequence & cs){
   } 
 
   extras->_wij = omega;
-  cs.plugin_associate_extras(std::auto_ptr<fastjet::ClusterSequence::Extras>(extras));
+  cs.plugin_associate_extras(extras);
 
   // merge remaining jets with beam
   int num_merged_final(0);


### PR DESCRIPTION
Pass only the object as recommended by the warning itself. FIx for https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc630/CMSSW_10_1_X_2018-02-20-2300/RecoJets/JetAlgorithms