### PR TITLE
Ignore invalid IOVs when determining interval

### DIFF
--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -784,7 +784,9 @@ EventSetupProvider::proxyProviderDescriptions() const
 bool
 EventSetupProvider::isWithinValidityInterval(IOVSyncValue const& iSync) const {
   for( auto const& provider: providers_) {
-    if(not provider.second->validityInterval().validFor(iSync)) {
+    auto const& iov =provider.second->validityInterval();
+    if( (iov != ValidityInterval::invalidInterval()) and
+        (not provider.second->validityInterval().validFor(iSync)) ) {
       return false;
     }
   }


### PR DESCRIPTION
If we previously set the RecordProvider to have an invalid IOV, do not use it to calculate if the new IOVSyncValue falls within its present IOV range.