### PR TITLE
[101X] [New GTs] Updated conditions for 2018,7,6 MC scenarios, and for Data (CTPPS geometry added)

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,21 +24,21 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '101X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '101X_dataRun2_v4',
+    'run1_data'         :   '101X_dataRun2_v5',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '101X_dataRun2_v4',
+    'run2_data'         :   '101X_dataRun2_v5',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '101X_dataRun2_relval_v4',
+    'run2_data_relval'  :   '101X_dataRun2_relval_v5',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '101X_dataRun2_PromptLike_v3',
+    'run2_data_promptlike' : '101X_dataRun2_PromptLike_v4',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v2',
+    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v3',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v2',
+    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v3',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '101X_dataRun2_HLT_relval_v3',
+    'run2_hlt_relval'   :   '101X_dataRun2_HLT_relval_v4',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v3',
+    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '101X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '101X_dataRun2_v2',
+    'run1_data'         :   '101X_dataRun2_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '101X_dataRun2_v2',
+    'run2_data'         :   '101X_dataRun2_v3',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '101X_dataRun2_relval_v2',
+    'run2_data_relval'  :   '101X_dataRun2_relval_v3',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '101X_dataRun2_PromptLike_v1',
     # GlobalTag for Run1 HLT: it points to the online GT
@@ -40,13 +40,13 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v1',
+    'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '101X_mc2017_realistic_v1',
+    'phase1_2017_realistic'    : '101X_mc2017_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '101X_mc2017cosmics_realistic_deco_v1',
+    'phase1_2017_cosmics'      : '101X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v1',
+    'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '101X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,21 +24,21 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '101X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '100X_dataRun2_v1',
+    'run1_data'         :   '101X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '100X_dataRun2_v1',
+    'run2_data'         :   '101X_dataRun2_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '100X_dataRun2_relval_v1',
+    'run2_data_relval'  :   '101X_dataRun2_relval_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '100X_dataRun2_PromptLike_v1',
+    'run2_data_promptlike' : '101X_dataRun2_PromptLike_v1',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '100X_dataRun2_HLT_frozen_v1',
+    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v1',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '100X_dataRun2_HLT_frozen_v1',
+    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v1',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '100X_dataRun2_HLT_relval_v1',
+    'run2_hlt_relval'   :   '101X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '100X_dataRun2_HLTHI_frozen_v1',
+    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,63 +2,63 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '100X_mcRun1_design_v2',
+    'run1_design'       :   '101X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '100X_mcRun1_realistic_v2',
+    'run1_mc'           :   '101X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '100X_mcRun1_HeavyIon_v2',
+    'run1_mc_hi'        :   '101X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '100X_mcRun1_pA_v2',
+    'run1_mc_pa'        :   '101X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '101X_mcRun2_design_v1',
+    'run2_design'       :   '101X_mcRun2_design_v2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '101X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '101X_mcRun2_startup_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '101X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '101X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '101X_mcRun2cosmics_startup_deco_v1',
+    'run2_mc_cosmics'   :   '101X_mcRun2cosmics_startup_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '101X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'        :   '101X_mcRun2_HeavyIon_v3',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '101X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '101X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '101X_dataRun2_v3',
+    'run1_data'         :   '101X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '101X_dataRun2_v3',
+    'run2_data'         :   '101X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '101X_dataRun2_relval_v3',
+    'run2_data_relval'  :   '101X_dataRun2_relval_v4',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '101X_dataRun2_PromptLike_v1',
+    'run2_data_promptlike' : '101X_dataRun2_PromptLike_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v1',
+    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v2',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v1',
+    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v2',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '101X_dataRun2_HLT_relval_v2',
+    'run2_hlt_relval'   :   '101X_dataRun2_HLT_relval_v3',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v2',
+    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v2',
+    'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '101X_mc2017_realistic_v2',
+    'phase1_2017_realistic'    : '101X_mc2017_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '101X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'      : '101X_mc2017cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '101X_upgrade2018_design_v3',
+    'phase1_2018_design'       : '101X_upgrade2018_design_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v2',
+    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v3',
+    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '101X_postLS2_design_v1', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '101X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'       : '101X_postLS2_realistic_v1', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'       : '101X_postLS2_realistic_v2', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '101X_upgrade2023_realistic_v1'
+    'phase2_realistic'         : '101X_upgrade2023_realistic_v2'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -48,11 +48,11 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '101X_upgrade2018_design_v2',
+    'phase1_2018_design'       : '101X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v2',
+    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '101X_postLS2_design_v1', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -20,7 +20,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '101X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '101X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'        :   '101X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '101X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '101X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '101X_dataRun2_v1',
+    'run1_data'         :   '101X_dataRun2_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '101X_dataRun2_v1',
+    'run2_data'         :   '101X_dataRun2_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '101X_dataRun2_relval_v1',
+    'run2_data_relval'  :   '101X_dataRun2_relval_v2',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '101X_dataRun2_PromptLike_v1',
     # GlobalTag for Run1 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,19 +10,19 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '100X_mcRun1_pA_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '100X_mcRun2_design_v2',
+    'run2_design'       :   '101X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '100X_mcRun2_startup_v2',
+    'run2_mc_50ns'      :   '101X_mcRun2_startup_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '100X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '101X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '100X_mcRun2cosmics_startup_deco_v2',
+    'run2_mc_cosmics'   :   '101X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '100X_mcRun2_HeavyIon_v3',
+    'run2_mc_hi'        :   '101X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '100X_mcRun2_pA_v2',
+    'run2_mc_pa'        :   '101X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '100X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
@@ -40,25 +40,25 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '100X_dataRun2_HLTHI_frozen_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '100X_mc2017_design_IdealBS_v3',
+    'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '100X_mc2017_realistic_v3',
+    'phase1_2017_realistic'    : '101X_mc2017_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '100X_mc2017cosmics_realistic_deco_v3',
+    'phase1_2017_cosmics'      : '101X_mc2017cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '100X_mc2017cosmics_realistic_peak_v3',
+    'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '100X_upgrade2018_design_IdealBS_v7',
+    'phase1_2018_design'       : '101X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v11',
+    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v9',
+    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '100X_postLS2_design_v2', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '101X_postLS2_design_v1', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'       : '100X_postLS2_realistic_v2', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'       : '101X_postLS2_realistic_v1', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '100X_upgrade2023_realistic_v1'
+    'phase2_realistic'         : '101X_upgrade2023_realistic_v1'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -48,11 +48,11 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '101X_upgrade2018_design_v3',
+    'phase1_2018_design'       : '101X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v2',
+    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v3',
+    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '101X_postLS2_design_v1', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
# Summary of changes in Global Tags

## RunI data

   * **RunI HLT processing** : [100X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_HLT_frozen_v1) as [101X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLT_frozen_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_HLT_frozen_v1/101X_dataRun2_HLT_frozen_v1):
      * CTPPS_Geometry
      * EcalPFRecHitThresholds

   * **RunI Offline processing** : [100X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_v1) as [101X_dataRun2_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_v1/101X_dataRun2_v3):
      * CTPPS_Geometry
      * EcalPFRecHitThresholds

## RunII data

   * **RunII HLTHI processing** : [100X_dataRun2_HLTHI_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_HLTHI_frozen_v1) as [101X_dataRun2_HLTHI_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLTHI_frozen_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_HLTHI_frozen_v1/101X_dataRun2_HLTHI_frozen_v2):
      * CTPPS_Geometry
      * EcalPFRecHitThresholds

   * **RunII HLT relval processing** : [100X_dataRun2_HLT_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_HLT_relval_v1) as [101X_dataRun2_HLT_relval_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLT_relval_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_HLT_relval_v1/101X_dataRun2_HLT_relval_v2):
      * CTPPS_Geometry
      * EcalPFRecHitThresholds

   * **RunII Offline processing** : [100X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_v1) as [101X_dataRun2_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_v1/101X_dataRun2_v3):
      * CTPPS_Geometry
      * SiPixelGainCalibrationHLT
      * JEC data
      * EcalPFRecHitThresholds

   * **RunII Offline relval processing** : [100X_dataRun2_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_relval_v1) as [101X_dataRun2_relval_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_relval_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_relval_v1/101X_dataRun2_relval_v3):
      * CTPPS_Geometry
      * SiPixelGainCalibrationHLT
      * JEC data
      * EcalPFRecHitThresholds

   * **RunII Prompt processing** : [100X_dataRun2_PromptLike_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_PromptLike_v1) as [101X_dataRun2_PromptLike_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_PromptLike_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_PromptLike_v1/101X_dataRun2_PromptLike_v1):
      * CTPPS_Geometry
      * EcalPFRecHitThresholds

   * **RunI HLT processing** : [100X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_HLT_frozen_v1) as [101X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLT_frozen_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_HLT_frozen_v1/101X_dataRun2_HLT_frozen_v1):
      * CTPPS_Geometry
      * EcalPFRecHitThresholds

## RunI simulation
Added EcalPFRecHitThresholds in all GTs

## RunII simulation

   * **RunII Asymptotic scenario** : [100X_mcRun2_asymptotic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun2_asymptotic_v2) as [101X_mcRun2_asymptotic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_asymptotic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun2_asymptotic_v2/101X_mcRun2_asymptotic_v1):
      * CTPPS_Geometry_2016
      * EcalPFRecHitThresholds

   * **RunII CRAFT scenario** : [100X_mcRun2cosmics_startup_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun2cosmics_startup_deco_v2) as [101X_mcRun2cosmics_startup_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2cosmics_startup_deco_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun2cosmics_startup_deco_v2/101X_mcRun2cosmics_startup_deco_v1):
      * CTPPS_Geometry_2016
      * EcalPFRecHitThresholds

   * **RunII Heavy Ions scenario** : [100X_mcRun2_HeavyIon_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun2_HeavyIon_v3) as [101X_mcRun2_HeavyIon_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun2_HeavyIon_v3/101X_mcRun2_HeavyIon_v2):
      * CTPPS_Geometry_2016
      * EcalPFRecHitThresholds

   * **RunII Ideal scenario** : [100X_mcRun2_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun2_design_v2) as [101X_mcRun2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_design_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun2_design_v2/101X_mcRun2_design_v1):
      * CTPPS_Geometry_2016
      * EcalPFRecHitThresholds

   * **RunII Proton-Lead scenario** : [100X_mcRun2_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun2_pA_v2) as [101X_mcRun2_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_pA_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun2_pA_v2/101X_mcRun2_pA_v1):
      * CTPPS_Geometry_2016
      * EcalPFRecHitThresholds

   * **RunII Startup scenario** : [100X_mcRun2_startup_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun2_startup_v2) as [101X_mcRun2_startup_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_startup_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun2_startup_v2/101X_mcRun2_startup_v1):
      * CTPPS_Geometry_2016
      * EcalPFRecHitThresholds


## 2017_MC

   * **PhaseI 2017 cosmics peak scenario** : [100X_mc2017cosmics_realistic_peak_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017cosmics_realistic_peak_v3) as [101X_mc2017cosmics_realistic_peak_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017cosmics_realistic_peak_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mc2017cosmics_realistic_peak_v3/101X_mc2017cosmics_realistic_peak_v2):
      * CTPPS_Geometry_101YV2
      * PixelGain DAQ AnalysisMask
      * JEC 2017
      * EcalPFRecHitThresholds

   * **PhaseI 2017 cosmics scenario** : [100X_mc2017cosmics_realistic_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017cosmics_realistic_deco_v3) as [101X_mc2017cosmics_realistic_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017cosmics_realistic_deco_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mc2017cosmics_realistic_deco_v3/101X_mc2017cosmics_realistic_deco_v2):
      * CTPPS_Geometry_101YV2
      * PixelGain DAQ AnalysisMask
      * JEC 2017
      * EcalPFRecHitThresholds

   * **PhaseI 2017 design scenario** : [100X_mc2017_design_IdealBS_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017_design_IdealBS_v3) as [101X_mc2017_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017_design_IdealBS_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mc2017_design_IdealBS_v3/101X_mc2017_design_IdealBS_v2):
      * CTPPS_Geometry_101YV2
      * PixelGain DAQ AnalysisMask
      * JEC 2017
      * EcalPFRecHitThresholds

   * **PhaseI 2017 realistic scenario** : [100X_mc2017_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017_realistic_v3) as [101X_mc2017_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mc2017_realistic_v3/101X_mc2017_realistic_v2):
      * CTPPS_Geometry_101YV2
      * PixelGain DAQ AnalysisMask
      * JEC 2017
      * EcalPFRecHitThresholds

## 2018

   * **PhaseI 2018 cosmics scenario** : [100X_upgrade2018cosmics_realistic_deco_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018cosmics_realistic_deco_v9) as [101X_upgrade2018cosmics_realistic_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018cosmics_realistic_deco_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018cosmics_realistic_deco_v9/101X_upgrade2018cosmics_realistic_deco_v3):
      * SiPixelQuality
      * HcalChannelQuality HcalGains HcalSiPMParameters
      * ZeroMaterial
      * CTPPS_Geometry_2018
      * PixelGain DAQ AnalysisMask
      * EcalPFRecHitThresholds

   * **PhaseI 2018 design scenario** : [100X_upgrade2018_design_IdealBS_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018_design_IdealBS_v7) as [101X_upgrade2018_design_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018_design_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018_design_IdealBS_v7/101X_upgrade2018_design_v3):
      * HcalChannelQuality HcalGains HcalSiPMParameters
      * ZeroMaterial
      * CTPPS_Geometry_2018
      * PixelGain DAQ AnalysisMask
      * EcalPFRecHitThresholds

   * **PhaseI 2018 realistic scenario** : [100X_upgrade2018_realistic_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018_realistic_v11) as [101X_upgrade2018_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018_realistic_v11/101X_upgrade2018_realistic_v2):
      * SiPixelQuality HcalGains HcalSiPMParameters
      * HcalChannelQuality
      * ZeroMaterial
      * CTPPS_Geometry_2018
      * PixelGain DAQ AnalysisMask
      * EcalPFRecHitThresholds

## Upgrade
   
   * **PhaseII realistic scenario** : [100X_upgrade2023_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2023_realistic_v1) as [101X_upgrade2023_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2023_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2023_realistic_v1/101X_upgrade2023_realistic_v1):
      * CTPPS_Geometry_2018
      * CTPPSPixelGain
      * CTPPSPixelDAQCTPPSPixelAnalysisMask
      * SiPixelQuality
      * EcalPFRecHitThresholds

   * **postLS2 realistic scenario** : [100X_postLS2_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_postLS2_realistic_v2) as [101X_postLS2_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_postLS2_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_postLS2_realistic_v2/101X_postLS2_realistic_v1):
      * CTPPS_Geometry_2018
      * EcalPFRecHitThresholds

   * **postLS2 design scenario** : [100X_postLS2_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_postLS2_realistic_v2) as [101X_postLS2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_postLS2_design_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_postLS2_design_v2/101X_postLS2_design_v1):
      * CTPPS_Geometry_2018
      * EcalPFRecHitThresholds