### PR TITLE
[10_0_X] Hcal TP fix ngHE saturation + switch from bare to effective pedestals

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -61,7 +61,9 @@ public:
 
   static const int QIE8_LUT_BITMASK = 0x3FF;
   static const int QIE10_LUT_BITMASK = 0x7FF;
-  static const int QIE11_LUT_BITMASK = 0x3FF;
+  static const int QIE11_LUT_BITMASK = 0x7FF;
+  // only the lowest 10 bits were used in 2017
+  static const int QIE11_LUT_BITMASK_2017 = 0x3FF;
 
 private:
   // typedef
@@ -74,8 +76,8 @@ private:
   static const int    nFi_ = 72;
 
   static const int QIE8_LUT_MSB = 0x400;
-  static const int QIE11_LUT_MSB0 = 0x400;
-  static const int QIE11_LUT_MSB1 = 0x800;
+  static const int QIE11_LUT_MSB0 = 0x800;
+  static const int QIE11_LUT_MSB1 = 0x1000;
   static const int QIE10_LUT_MSB  = 0x1000;
   
   // member variables

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -280,7 +280,7 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
 	if (LUTGenerationMode_){
 	    const HcalCalibrations& calibrations = conditions.getHcalCalibrations(cell);
 	    for (auto capId : {0,1,2,3}){
-		ped += calibrations.pedestal(capId);
+		ped += calibrations.effpedestal(capId);
 		gain += calibrations.LUTrespcorrgain(capId);
 	    }
 	    ped /= 4.0;

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -34,6 +34,7 @@ const float HcaluLUTTPGCoder::lsb_=1./16;
 const int HcaluLUTTPGCoder::QIE8_LUT_BITMASK;
 const int HcaluLUTTPGCoder::QIE10_LUT_BITMASK;
 const int HcaluLUTTPGCoder::QIE11_LUT_BITMASK;
+const int HcaluLUTTPGCoder::QIE11_LUT_BITMASK_2017;
 
 
 HcaluLUTTPGCoder::HcaluLUTTPGCoder(const HcalTopology* top) : topo_(top), LUTGenerationMode_(true), bitToMask_(0), allLinear_(false), linearLSB_QIE8_(1.), linearLSB_QIE11_(1.) {
@@ -311,7 +312,8 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
 
 	const size_t SIZE = qieType==QIE8 ? INPUT_LUT_SIZE : UPGRADE_LUT_SIZE;
 	const int MASK = qieType==QIE8 ? QIE8_LUT_BITMASK :
-                         qieType==QIE10 ? QIE10_LUT_BITMASK : QIE11_LUT_BITMASK;
+                         qieType==QIE10 ? QIE10_LUT_BITMASK :
+                         is2018OrLater ? QIE11_LUT_BITMASK : QIE11_LUT_BITMASK_2017;
         double linearLSB = linearLSB_QIE8_;
         if (qieType == QIE11 and cell.ietaAbs() == topo_->lastHBRing())
            linearLSB = linearLSB_QIE11Overlap_;

--- a/CaloOnlineTools/HcalOnlineDb/src/WriteL1TriggerObjectsTxt.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/WriteL1TriggerObjectsTxt.cc
@@ -85,7 +85,7 @@ WriteL1TriggerObjectsTxt::analyze(const edm::Event& iEvent, const edm::EventSetu
        
 	for (auto i : {0,1,2,3}){
 	    gain += calibrations.LUTrespcorrgain(i);
-	    ped += calibrations.pedestal(i);
+	    ped += calibrations.effpedestal(i);
 	}
 
 	gain /= 4.;

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
@@ -46,7 +46,7 @@ HcalFeatureHFEMBit::getE(const T& f, int idx) const
    CaloSamples samples;
    db.adc2fC(f, samples);
 
-   auto ped = calibrations.pedestal(f[idx].capid());
+   auto ped = calibrations.effpedestal(f[idx].capid());
    auto corr = calibrations.respcorrgain(f[idx].capid());
 
    return (samples[idx] - ped) * corr;


### PR DESCRIPTION
Backport #22262 

This backport is needed so that analysis of 10_0_X samples, in particular those for Layer-1 calibrations, use the same HCAL TP generation as that anticipated for 2018 data-taking.

Note that #22263 has not yet been merged, but the 10_1_X version of this PR included #22121, so comparison tests will not show exactly identical results as those from #22262.