### PR TITLE
92X-tuned electron ID and removing upper bound for Zmass

### DIFF
--- a/DPGAnalysis/Skims/python/ZElectronSkim_cff.py
+++ b/DPGAnalysis/Skims/python/ZElectronSkim_cff.py
@@ -18,13 +18,13 @@ else:
                                     cut = cms.string(ELECTRON_CUT)
                                     )
 
-eleIDWP = cms.PSet( #first for barrel, second for endcap. All values from cutBasedElectronID-Summer16-80X-V1-veto
-    full5x5_sigmaIEtaIEtaCut       = cms.vdouble(0.0115 ,0.0370 )  , # full5x5_sigmaIEtaIEtaCut
-    dEtaInSeedCut                  = cms.vdouble(0.00749,0.00895)  , # dEtaInSeedCut
-    dPhiInCut                      = cms.vdouble(0.228  ,0.213  )  , # dPhiInCut
-    hOverECut                      = cms.vdouble(0.356  ,0.211  )  , # hOverECut
-    relCombIsolationWithEACut = cms.vdouble(0.175  ,0.159  )  , # relCombIsolationWithEALowPtCut
-    EInverseMinusPInverseCut       = cms.vdouble(0.299  ,0.15   )  ,                
+eleIDWP = cms.PSet( #first for barrel, second for endcap. All values from https://indico.cern.ch/event/699197/contributions/2900013/attachments/1604361/2544765/Zee.pdf
+    full5x5_sigmaIEtaIEtaCut       = cms.vdouble(0.0128 ,0.0445 )  , # full5x5_sigmaIEtaIEtaCut
+    dEtaInSeedCut                  = cms.vdouble(0.00523,0.00984)  , # dEtaInSeedCut
+    dPhiInCut                      = cms.vdouble(0.159  ,0.157  )  , # dPhiInCut
+    hOverECut                      = cms.vdouble(0.247  ,0.0982  )  , # hOverECut
+    relCombIsolationWithEACut      = cms.vdouble(0.168  ,0.185  )  , # relCombIsolationWithEALowPtCut
+    EInverseMinusPInverseCut       = cms.vdouble(0.193  ,0.0962   )  ,                
     missingHitsCut                 = cms.vint32(2       ,3      )    # missingHitsCut
 ) 
 
@@ -37,7 +37,7 @@ identifiedElectrons = cms.EDFilter("ZElectronsSelectorAndSkim",
                                    effectiveAreaValues=cms.vdouble( 0.1703, 0.1715, 0.1213, 0.1230, 0.1635, 0.1937, 0.2393),
                                    rho = cms.InputTag("fixedGridRhoFastjetCentralCalo") #from https://github.com/cms-sw/cmssw/blob/09c3fce6626f70fd04223e7dacebf0b485f73f54/RecoEgamma/ElectronIdentification/python/Identification/cutBasedElectronID_tools.py#L564
                          )
-DIELECTRON_CUT=("mass > 40 && mass < 140 && daughter(0).pt>20 && daughter(1).pt()>10")
+DIELECTRON_CUT=("mass > 40  && daughter(0).pt>20 && daughter(1).pt()>10")
 
 diZeeElectrons = cms.EDProducer("CandViewShallowCloneCombiner",
                                 decay       = cms.string("identifiedElectrons identifiedElectrons"),


### PR DESCRIPTION
92X tuned electron ID and no upper bound for Z Mass in the ZElectron skim used by ecal DPG
Presented at MoCa meeting on 21st February 2018. https://indico.cern.ch/event/699197/contributions/2900013/attachments/1604361/2544765/Zee.pdf
 For CMSSW_10_1_X 
@amassiro @crovelli @bmarzocc 