### PR TITLE
Complete integration of HP beamspot workflow for PCL

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdBeamSpotHP_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdBeamSpotHP_Output_cff.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+
+
+
+OutALCARECOPromptCalibProdBeamSpotHP_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOPromptCalibProdBeamSpotHP')
+    ),
+    outputCommands = cms.untracked.vstring(
+        'keep *_alcaBeamSpotProducerHP_*_*')
+)
+
+import copy
+
+OutALCARECOPromptCalibProdBeamSpotHP=copy.deepcopy(OutALCARECOPromptCalibProdBeamSpotHP_noDrop)
+OutALCARECOPromptCalibProdBeamSpotHP.outputCommands.insert(0, "drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdBeamSpotHP_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdBeamSpotHP_cff.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+
+# ------------------------------------------------------------------------------
+# configure a filter to run only on the events selected by TkAlMinBias AlcaReco
+import copy
+from HLTrigger.HLTfilters.hltHighLevel_cfi import *
+ALCARECOTkAlMinBiasFilterForBSHP = copy.deepcopy(hltHighLevel)
+ALCARECOTkAlMinBiasFilterForBSHP.HLTPaths = ['pathALCARECOTkAlMinBias']
+ALCARECOTkAlMinBiasFilterForBSHP.throw = True ## dont throw on unknown path names
+ALCARECOTkAlMinBiasFilterForBSHP.TriggerResultsTag = cms.InputTag("TriggerResults","","RECO")
+#process.TkAlMinBiasFilterForBS.eventSetupPathsKey = 'pathALCARECOTkAlMinBias:RECO'
+#ALCARECODtCalibHLTFilter.andOr = True ## choose logical OR between Triggerbits
+
+
+# ------------------------------------------------------------------------------
+# configure the beam-spot production
+from Calibration.TkAlCaRecoProducers.AlcaBeamSpotProducerHP_cff import *
+#alcaBeamSpotProducerHP.BeamFitter.TrackCollection = 'ALCARECOTkAlMinBias'
+#alcaBeamSpotProducerHP.BeamFitter.MinimumTotalLayers = 6
+#alcaBeamSpotProducerHP.BeamFitter.MinimumPixelLayers = -1
+#alcaBeamSpotProducerHP.BeamFitter.MaximumNormChi2 = 10
+#alcaBeamSpotProducerHP.BeamFitter.MinimumInputTracks = 50
+#alcaBeamSpotProducerHP.BeamFitter.MinimumPt = 1.0
+#alcaBeamSpotProducerHP.BeamFitter.MaximumImpactParameter = 1.0
+#alcaBeamSpotProducerHP.BeamFitter.TrackAlgorithm =  cms.untracked.vstring()
+#alcaBeamSpotProducerHP.BeamFitter.Debug = True
+#alcaBeamSpotProducerHP.PVFitter.Apply3DFit = True
+#alcaBeamSpotProducerHP.PVFitter.minNrVerticesForFit = 10 
+
+# fit as function of lumi sections
+#alcaBeamSpotProducerHP.AlcaBeamSpotProducerParameters.fitEveryNLumi = 1
+#alcaBeamSpotProducerHP.AlcaBeamSpotProducerParameters.resetEveryNLumi = 1
+
+
+# ------------------------------------------------------------------------------
+# this is for filtering on L1 technical trigger bit
+# Set the HLT paths
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+ALCARECOHltFilterForBSHP = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
+    andOr = True, ## choose logical OR between Triggerbits
+##     HLTPaths = [
+##     #Minimum Bias
+##     "HLT_MinBias*"
+##     ],
+    eventSetupPathsKey = 'PromptCalibProd',
+    throw = False # tolerate triggers stated above, but not available
+    )
+
+seqALCARECOPromptCalibProd = cms.Sequence(ALCARECOTkAlMinBiasFilterForBSHP *
+                                          ALCARECOHltFilterForBSHP *
+                                          alcaBeamSpotProducerHP)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdBeamSpotHP_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdBeamSpotHP_cff.py
@@ -15,21 +15,6 @@ ALCARECOTkAlMinBiasFilterForBSHP.TriggerResultsTag = cms.InputTag("TriggerResult
 # ------------------------------------------------------------------------------
 # configure the beam-spot production
 from Calibration.TkAlCaRecoProducers.AlcaBeamSpotProducerHP_cff import *
-#alcaBeamSpotProducerHP.BeamFitter.TrackCollection = 'ALCARECOTkAlMinBias'
-#alcaBeamSpotProducerHP.BeamFitter.MinimumTotalLayers = 6
-#alcaBeamSpotProducerHP.BeamFitter.MinimumPixelLayers = -1
-#alcaBeamSpotProducerHP.BeamFitter.MaximumNormChi2 = 10
-#alcaBeamSpotProducerHP.BeamFitter.MinimumInputTracks = 50
-#alcaBeamSpotProducerHP.BeamFitter.MinimumPt = 1.0
-#alcaBeamSpotProducerHP.BeamFitter.MaximumImpactParameter = 1.0
-#alcaBeamSpotProducerHP.BeamFitter.TrackAlgorithm =  cms.untracked.vstring()
-#alcaBeamSpotProducerHP.BeamFitter.Debug = True
-#alcaBeamSpotProducerHP.PVFitter.Apply3DFit = True
-#alcaBeamSpotProducerHP.PVFitter.minNrVerticesForFit = 10 
-
-# fit as function of lumi sections
-#alcaBeamSpotProducerHP.AlcaBeamSpotProducerParameters.fitEveryNLumi = 1
-#alcaBeamSpotProducerHP.AlcaBeamSpotProducerParameters.resetEveryNLumi = 1
 
 
 # ------------------------------------------------------------------------------
@@ -46,6 +31,6 @@ ALCARECOHltFilterForBSHP = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.cl
     throw = False # tolerate triggers stated above, but not available
     )
 
-seqALCARECOPromptCalibProd = cms.Sequence(ALCARECOTkAlMinBiasFilterForBSHP *
-                                          ALCARECOHltFilterForBSHP *
-                                          alcaBeamSpotProducerHP)
+seqALCARECOPromptCalibProdBeamSpotHP = cms.Sequence(ALCARECOTkAlMinBiasFilterForBSHP *
+                                                    ALCARECOHltFilterForBSHP *
+                                                    alcaBeamSpotProducerHP)

--- a/Calibration/TkAlCaRecoProducers/python/AlcaBeamSpotProducerHP_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaBeamSpotProducerHP_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+from Calibration.TkAlCaRecoProducers.AlcaBeamSpotProducerHP_cfi import alcaBeamSpotProducerHP
+alcaBeamSpotHP = cms.Sequence( alcaBeamSpotProducerHP )

--- a/Calibration/TkAlCaRecoProducers/python/AlcaBeamSpotProducerHP_cfi.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaBeamSpotProducerHP_cfi.py
@@ -1,0 +1,58 @@
+import FWCore.ParameterSet.Config as cms
+
+alcaBeamSpotProducerHP = cms.EDProducer("AlcaBeamSpotProducer",
+    AlcaBeamSpotProducerParameters = cms.PSet(
+        RunAllFitters = cms.bool(False), ## False: run only default fitter
+        RunBeamWidthFit = cms.bool(False), 
+        WriteToDB = cms.bool(False), ## do not write results to DB
+        fitEveryNLumi = cms.untracked.int32( 1 ),
+        resetEveryNLumi = cms.untracked.int32( 1 )
+    ),
+    BeamFitter = cms.PSet(
+        Debug = cms.untracked.bool(False),
+        TrackCollection = cms.untracked.InputTag('ALCARECOTkAlMinBias'),
+        IsMuonCollection = cms.untracked.bool(False),
+        WriteAscii = cms.untracked.bool(False),
+        AsciiFileName = cms.untracked.string('BeamFit.txt'), ## all results
+        AppendRunToFileName = cms.untracked.bool(True), #runnumber will be inserted to the file name
+        WriteDIPAscii = cms.untracked.bool(False),
+        DIPFileName = cms.untracked.string('BeamFitDIP.txt'), ## only the last results, for DIP
+        SaveNtuple = cms.untracked.bool(False),
+        SaveFitResults = cms.untracked.bool(False),
+        SavePVVertices = cms.untracked.bool(False),
+        OutputFileName = cms.untracked.string('analyze_d0_phi.root'),
+        MinimumPt = cms.untracked.double(1.0),
+        MaximumEta = cms.untracked.double(2.4),
+        MaximumImpactParameter = cms.untracked.double(1.0),
+        MaximumZ = cms.untracked.double(60),
+        MinimumTotalLayers = cms.untracked.int32(6),
+        MinimumPixelLayers = cms.untracked.int32(-1),
+        MaximumNormChi2 = cms.untracked.double(10),
+        TrackAlgorithm = cms.untracked.vstring(), ## ctf,rs,cosmics,initialStep,lowPtTripletStep...; for all algos, leave it blank
+        TrackQuality = cms.untracked.vstring(), ## loose, tight, highPurity...; for all qualities, leave it blank
+        InputBeamWidth = cms.untracked.double(-1.0), ## if -1 use the value calculated by the analyzer
+        FractionOfFittedTrks = cms.untracked.double(0.9),
+        MinimumInputTracks = cms.untracked.int32(50)
+     ),
+     PVFitter = cms.PSet(
+        Debug = cms.untracked.bool(False),
+        Apply3DFit = cms.untracked.bool(True),
+        VertexCollection = cms.untracked.InputTag('offlinePrimaryVertices'),
+        #WriteAscii = cms.untracked.bool(True),
+        #AsciiFileName = cms.untracked.string('PVFit.txt'),
+        maxNrStoredVertices = cms.untracked.uint32(10000),
+        minNrVerticesForFit = cms.untracked.uint32(10),
+        minVertexNdf = cms.untracked.double(10.),
+        maxVertexNormChi2 = cms.untracked.double(10.),
+        minVertexNTracks = cms.untracked.uint32(30),
+        minVertexMeanWeight = cms.untracked.double(0.5),
+        maxVertexR = cms.untracked.double(2),
+        maxVertexZ = cms.untracked.double(10),
+        errorScale = cms.untracked.double(0.9),
+        nSigmaCut = cms.untracked.double(50.),
+        FitPerBunchCrossing = cms.untracked.bool(False),
+        useOnlyFirstPV = cms.untracked.bool(True),
+        minSumPt = cms.untracked.double(50.)
+     )
+)
+

--- a/Configuration/AlCa/python/autoPCL.py
+++ b/Configuration/AlCa/python/autoPCL.py
@@ -1,4 +1,5 @@
 autoPCL = {'PromptCalibProd' : 'BeamSpotByRun+BeamSpotByLumi',
+           'PromptCalibProdBeamSpotHP' : 'BeamSpotHPByRun+BeamSpotHPByLumi',
            'PromptCalibProdSiStrip' : 'SiStripQuality',
            'PromptCalibProdSiStripGains' : 'SiStripGains',
            'PromptCalibProdSiPixelAli' : 'SiPixelAli',

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
@@ -26,7 +26,6 @@ class ppEra_Run2_2017_trackingOnly(trackingOnly):
         self.eras=Run2_2017
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_express_trackingOnly' ]
-        self.alcaHarvCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_harvesting_trackingOnly' ]
         self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
 
     """

--- a/Configuration/DataProcessing/python/Impl/trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/trackingOnly.py
@@ -38,7 +38,7 @@ class trackingOnly(pp):
                 args['skims'].append('TkAlMinBias')
 
         # reco sequence is limited to tracking => DQM accordingly
-        if not args.has_key('dqmSeq') :
+        if not args.has_key('dqmSeq') or len(args['dqmSeq'])==0:
             args['dqmSeq'] = ['DQMOfflineTracking']
 
         process = pp.expressProcessing(self, globalTag, **args)

--- a/Configuration/DataProcessing/python/Impl/trackingOnlyEra_Run2_2017.py
+++ b/Configuration/DataProcessing/python/Impl/trackingOnlyEra_Run2_2017.py
@@ -26,7 +26,6 @@ class trackingOnlyEra_Run2_2017(trackingOnly):
         self.eras=Run2_2017
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_express_trackingOnly' ]
-        self.alcaHarvCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_harvesting_trackingOnly' ]
         self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
 
     """

--- a/Configuration/DataProcessing/python/Impl/trackingOnlyEra_Run2_2018.py
+++ b/Configuration/DataProcessing/python/Impl/trackingOnlyEra_Run2_2018.py
@@ -26,7 +26,6 @@ class trackingOnlyEra_Run2_2018(trackingOnly):
         self.eras=Run2_2018
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018_express_trackingOnly' ]
-        self.alcaHarvCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018_harvesting_trackingOnly' ]
         self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
 
     """

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -44,12 +44,12 @@ done
 
 runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario AlCaTestEnable --global-tag GLOBALTAG --lfn /store/whatever --alcareco PromptCalibProdEcalPedestals "
 runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario AlCaTestEnable --lfn=/store/whatever --global-tag GLOBALTAG --skims PromptCalibProdEcalPedestals"
-runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario AlCaTestEnable --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --workflows=EcalPedestals"
+runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario AlCaTestEnable --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --alcapromptdataset=PromptCalibProdEcalPedestals"
 
 declare -a arr=("trackingOnlyEra_Run2_2017" "trackingOnlyEra_Run2_2018")
 for scenario in "${arr[@]}"
 do
-    runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG  --lfn /store/whatever  --alcarecos=TkAlMinBias"
-    runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn /store/whatever --global-tag GLOBALTAG --skims TkAlMinBias"
-    runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario $scenario --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG"
+    runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG  --lfn /store/whatever  --alcarecos=TkAlMinBias+PromptCalibProdBeamSpotHP"
+    runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn /store/whatever --global-tag GLOBALTAG --skims TkAlMinBias,PromptCalibProdBeamSpotHP"
+    runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario $scenario --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --alcapromptdataset=PromptCalibProdBeamSpotHP"
 done

--- a/Configuration/EventContent/python/AlCaRecoOutput_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_cff.py
@@ -128,6 +128,7 @@ from CalibMuon.DTCalibration.ALCARECODtCalibCosmics_Output_cff import *
 # stream for prompt-calibration @ Tier0
 ###############################################################
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProd_Output_cff import *
+from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdBeamSpotHP_Output_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStrip_Output_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStripGains_Output_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStripGainsAAG_Output_cff import *

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1431,7 +1431,7 @@ steps['TIER0EXPHPBS']={'-s':'RAW2DIGI,L1Reco,RECO:reconstruction_trackingOnly,AL
                           '--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_express_trackingOnly',
                           }
 
-steps['ALCASPLITHPBS']={'-s':'ALCAOUTPUT:TkAlMinBias,ALCA:PromptCalibProd',
+steps['ALCASPLITHPBS']={'-s':'ALCAOUTPUT:TkAlMinBias,ALCA:PromptCalibProdBeamSpotHP',
                         '--scenario':'pp',
                         '--data':'',
                         '--era':'Run2_2017',
@@ -1441,14 +1441,14 @@ steps['ALCASPLITHPBS']={'-s':'ALCAOUTPUT:TkAlMinBias,ALCA:PromptCalibProd',
                         '--triggerResultsProcess':'RECO',
                         }
 
-steps['ALCAHARVDHPBS']={'-s':'ALCAHARVEST:%s'%(autoPCL['PromptCalibProd']),
+steps['ALCAHARVDHPBS']={'-s':'ALCAHARVEST:%s'%(autoPCL['PromptCalibProdBeamSpotHP']),
                         #'--conditions':'auto:run2_data_promptlike',
                         '--conditions':'92X_dataRun2_Express_v2_snapshotted', # to replaced with line above once run2_data_promptlike will contain DropBoxMetadata
                         '--scenario':'pp',
                         '--data':'',
                         '--era':'Run2_2017',
                         '--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_harvesting_trackingOnly',
-                        '--filein':'file:PromptCalibProd.root'}
+                        '--filein':'file:PromptCalibProdBeamSpotHP.root'}
 
 
 steps['RECOCOSD']=merge([{'--scenario':'cosmics',

--- a/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
+++ b/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
@@ -28,7 +28,9 @@ dqmSaver.workflow = '/Express/PCLTest/ALCAPROMPT'
 #dqmSaver.saveAtJobEnd = True
 
 # workflow definitions
-
+# --------------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------------
+# BeamSpot by Run
 ALCAHARVESTBeamSpotByRun = alcaBeamSpotHarvester.clone()
 ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.BeamSpotOutputBase = cms.untracked.string("runbased")
 ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName = cms.untracked.string("BeamSpotObjectsRcdByRun")
@@ -40,6 +42,8 @@ ALCAHARVESTBeamSpotByRun_dbOutput = cms.PSet(record = cms.string('BeamSpotObject
                                              timetype   = cms.untracked.string('runnumber')
                                              )
 
+# --------------------------------------------------------------------------------------
+# BeamSpot by Lumi
 ALCAHARVESTBeamSpotByLumi = alcaBeamSpotHarvester.clone()
 ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.BeamSpotOutputBase = cms.untracked.string("lumibased")
 ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName = cms.untracked.string("BeamSpotObjectsRcdByLumi")
@@ -52,6 +56,35 @@ ALCAHARVESTBeamSpotByLumi_dbOutput = cms.PSet(record = cms.string('BeamSpotObjec
                                               timetype   = cms.untracked.string('lumiid')
                                               )
 
+# --------------------------------------------------------------------------------------
+# BeamSpot HP by Run
+ALCAHARVESTBeamSpotHPByRun = alcaBeamSpotHarvester.clone()
+ALCAHARVESTBeamSpotHPByRun.AlcaBeamSpotHarvesterParameters.BeamSpotOutputBase = cms.untracked.string("runbased")
+ALCAHARVESTBeamSpotHPByRun.AlcaBeamSpotHarvesterParameters.outputRecordName = cms.untracked.string("BeamSpotObjectsRcdHPByRun")
+
+ALCAHARVESTBeamSpotHPByRun_metadata = cms.PSet(record = cms.untracked.string('BeamSpotObjectsRcdHPByRun'))
+
+ALCAHARVESTBeamSpotHPByRun_dbOutput = cms.PSet(record = cms.string('BeamSpotObjectsRcdHPByRun'),
+                                             tag = cms.string('BeamSpotObjectHP_ByRun'),
+                                             timetype   = cms.untracked.string('runnumber')
+                                             )
+
+# --------------------------------------------------------------------------------------
+# BeamSpot HP by Lumi
+ALCAHARVESTBeamSpotHPByLumi = alcaBeamSpotHarvester.clone()
+ALCAHARVESTBeamSpotHPByLumi.AlcaBeamSpotHarvesterParameters.BeamSpotOutputBase = cms.untracked.string("lumibased")
+ALCAHARVESTBeamSpotHPByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName = cms.untracked.string("BeamSpotObjectsRcdHPByLumi")
+ALCAHARVESTBeamSpotHPByLumi.AlcaBeamSpotHarvesterParameters.DumpTxt = cms.untracked.bool(True)
+
+# configuration of DropBox metadata and DB output
+ALCAHARVESTBeamSpotHPByLumi_metadata = cms.PSet(record = cms.untracked.string('BeamSpotObjectsRcdHPByLumi'))
+
+ALCAHARVESTBeamSpotHPByLumi_dbOutput = cms.PSet(record = cms.string('BeamSpotObjectsRcdHPByLumi'),
+                                              tag = cms.string('BeamSpotObjectHP_ByLumi'),
+                                              timetype   = cms.untracked.string('lumiid')
+                                              )
+
+# --------------------------------------------------------------------------------------
 # SiStrip Quality
 ALCAHARVESTSiStripQuality_metadata = cms.PSet(record = cms.untracked.string('SiStripBadStripRcd'))
 
@@ -60,6 +93,7 @@ ALCAHARVESTSiStripQuality_dbOutput = cms.PSet(record = cms.string('SiStripBadStr
                                               timetype   = cms.untracked.string('runnumber')
                                               )
 
+# --------------------------------------------------------------------------------------
 # SiStrip Gains
 ALCAHARVESTSiStripGains_metadata = cms.PSet(record = cms.untracked.string('SiStripApvGainRcd'))
 
@@ -68,6 +102,7 @@ ALCAHARVESTSiStripGains_dbOutput = cms.PSet(record = cms.string('SiStripApvGainR
                                             timetype   = cms.untracked.string('runnumber')
                                             )
 
+# --------------------------------------------------------------------------------------
 # SiStrip Gains (AAG)
 ALCAHARVESTSiStripGainsAAG_metadata = cms.PSet(record = cms.untracked.string('SiStripApvGainRcdAAG'))
 
@@ -76,6 +111,7 @@ ALCAHARVESTSiStripGainsAAG_dbOutput = cms.PSet(record = cms.string('SiStripApvGa
                                                          timetype   = cms.untracked.string('runnumber')
                                                          )
 
+# --------------------------------------------------------------------------------------
 # SiPixel Alignment
 ALCAHARVESTSiPixelAli_metadata = cms.PSet(record = cms.untracked.string('TrackerAlignmentRcd'))
 
@@ -84,6 +120,8 @@ ALCAHARVESTSiPixelAli_dbOutput = cms.PSet(record = cms.string('TrackerAlignmentR
                                           timetype   = cms.untracked.string('runnumber')
                                           )
 
+# --------------------------------------------------------------------------------------
+# ECAL Pedestals
 ALCAHARVESTEcalPedestals_metadata = cms.PSet(record = cms.untracked.string('EcalPedestalsRcd'))
 
 ALCAHARVESTEcalPedestals_dbOutput = cms.PSet(record = cms.string('EcalPedestalsRcd'),
@@ -92,9 +130,11 @@ ALCAHARVESTEcalPedestals_dbOutput = cms.PSet(record = cms.string('EcalPedestalsR
                                              )
 
 
-# define the paths
+# define all the paths
 BeamSpotByRun  = cms.Path(ALCAHARVESTBeamSpotByRun)
 BeamSpotByLumi = cms.Path(ALCAHARVESTBeamSpotByLumi)
+BeamSpotHPByRun  = cms.Path(ALCAHARVESTBeamSpotHPByRun)
+BeamSpotHPByLumi = cms.Path(ALCAHARVESTBeamSpotHPByLumi)
 SiStripQuality = cms.Path(ALCAHARVESTSiStripQuality)
 SiStripGains   = cms.Path(ALCAHARVESTSiStripGains)
 SiPixelAli     = cms.Path(ALCAHARVESTSiPixelAli)

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -125,6 +125,8 @@ from Alignment.CommonAlignmentProducer.ALCARECOMuAlBeamHaloOverlaps_cff import *
 # stream for prompt-calibration @ Tier0
 ###############################################################
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProd_cff import *
+from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdBeamSpotHP_cff import *
+
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStrip_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStripGains_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStripGainsAAG_cff import *
@@ -218,6 +220,7 @@ pathALCARECOTkAlCosmicsRegional0THLT = cms.Path(seqALCARECOTkAlCosmicsRegional0T
 pathALCARECOMuAlGlobalCosmicsInCollisions = cms.Path(seqALCARECOMuAlGlobalCosmicsInCollisions*ALCARECOMuAlGlobalCosmicsInCollisionsDQM)
 pathALCARECOMuAlGlobalCosmics = cms.Path(seqALCARECOMuAlGlobalCosmics*ALCARECOMuAlGlobalCosmicsDQM)
 pathALCARECOPromptCalibProd = cms.Path(seqALCARECOPromptCalibProd)
+pathALCARECOPromptCalibProdBeamSpotHP = cms.Path(seqALCARECOPromptCalibProdBeamSpotHP)
 pathALCARECOPromptCalibProdSiStrip = cms.Path(seqALCARECOPromptCalibProdSiStrip)
 pathALCARECOPromptCalibProdSiStripGains = cms.Path(seqALCARECOPromptCalibProdSiStripGains)
 pathALCARECOPromptCalibProdSiStripGainsAAG = cms.Path(seqALCARECOPromptCalibProdSiStripGainsAAG)
@@ -728,6 +731,14 @@ ALCARECOStreamPromptCalibProd = cms.FilteredStream(
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 
+ALCARECOStreamPromptCalibProdBeamSpotHP = cms.FilteredStream(
+	responsible = 'Gianluca Cerminara',
+	name = 'PromptCalibProdBeamSpotHP',
+	paths  = (pathALCARECOPromptCalibProdBeamSpotHP),
+	content = OutALCARECOPromptCalibProdBeamSpotHP.outputCommands,
+	selectEvents = OutALCARECOPromptCalibProdBeamSpotHP.SelectEvents,
+	dataTier = cms.untracked.string('ALCARECO')
+	)
 
 
 ALCARECOStreamPromptCalibProdSiStrip = cms.FilteredStream(


### PR DESCRIPTION
This PR completes the work needed to feed High-Precision beamspot measurements out of PCL to the LHC.

Dedicated workflow names are introduced duplicating the config. w.r.t to the normal workflow to allow for customization of the selections dropping confusing customization functions. (eventually we might drop the old version).

Relvals and ConfigDP tests are updated accordingly.
