### PR TITLE
RFC: DQMStore index logic rewrite

### DIFF
--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -153,7 +153,7 @@ class WorkFlowRunner(Thread):
                         cmd+=' --fileout file:step%s.root '%(istep,)
                 if self.jobReport:
                   cmd += ' --suffix "-j JobReport%s.xml " ' % istep
-                if (self.nThreads > 1) and ('HARVESTING' not in cmd) :
+                if (self.nThreads > 1) and ('HARVESTING' not in cmd) and ('ALCAHARVEST' not in cmd):
                   cmd += ' --nThreads %s' % self.nThreads
                 cmd+=closeCmd(istep,self.wf.nameId)            
                 retStep = 0

--- a/DQMServices/Components/plugins/EDMtoMEConverter.cc
+++ b/DQMServices/Components/plugins/EDMtoMEConverter.cc
@@ -10,6 +10,7 @@
 #include "DQMServices/Components/plugins/EDMtoMEConverter.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/Histograms/interface/DQMToken.h"
 
 using namespace lat;
 
@@ -259,6 +260,8 @@ EDMtoMEConverter::EDMtoMEConverter(const edm::ParameterSet & iPSet) :
   iCount.clear();
 
   assert(sizeof(int64_t) == sizeof(long long));
+  usesResource("DQMStore");
+  produces<DQMToken,edm::Transition::EndLuminosityBlock>();
 
 } // end constructor
 
@@ -322,9 +325,6 @@ void EDMtoMEConverter::endLuminosityBlock(const edm::LuminosityBlock& iLumi, con
   }
 }
 
-void EDMtoMEConverter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-}
 
 template <class T>
 void

--- a/DQMServices/Components/plugins/EDMtoMEConverter.h
+++ b/DQMServices/Components/plugins/EDMtoMEConverter.h
@@ -10,7 +10,7 @@
  */
 
 // framework & common header files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -47,7 +47,7 @@
 #include "classlib/utils/StringList.h"
 #include "classlib/utils/StringOps.h"
 
-class EDMtoMEConverter : public edm::EDAnalyzer
+class EDMtoMEConverter : public edm::one::EDProducer<edm::one::WatchRuns,edm::one::WatchLuminosityBlocks,edm::one::SharedResources,edm::EndLuminosityBlockProducer>
 {
 
  public:
@@ -56,12 +56,13 @@ class EDMtoMEConverter : public edm::EDAnalyzer
   ~EDMtoMEConverter() override;
   void beginJob() override;
   void endJob() override;  
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void endRun(const edm::Run&, const edm::EventSetup&) override;
   void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
-  void respondToOpenInputFile(const edm::FileBlock&) override;
+  void respondToOpenInputFile(const edm::FileBlock&) ;
+  void produce(edm::Event&, edm::EventSetup const&) final {};
+  void endLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) final {};
 
   template <class T>
   void getData(T& iGetFrom);

--- a/DQMServices/Components/plugins/MEtoEDMConverter.cc
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.cc
@@ -80,8 +80,8 @@ MEtoEDMConverter::MEtoEDMConverter(const edm::ParameterSet & iPSet) :
   produces<MEtoEDM<long long>, edm::Transition::EndLuminosityBlock>(sName);
   produces<MEtoEDM<TString>, edm::Transition::EndLuminosityBlock>(sName);
 
-  consumesMany<DQMToken>();
-  consumesMany<DQMRunToken>();
+  consumesMany<DQMToken, edm::InLumi>();
+  consumesMany<DQMRunToken, edm::InRun>();
   usesResource("DQMStore");
 
   static_assert(sizeof(int64_t) == sizeof(long long),"type int64_t is not the same length as long long");

--- a/DQMServices/Components/plugins/MEtoEDMConverter.cc
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.cc
@@ -94,7 +94,7 @@ void
 MEtoEDMConverter::beginJob()
 {
   // Determine if we are running multithreading asking to the DQMStore. Not to be moved in the ctor
-  enableMultiThread_ = dbe->enableMultiThread_;
+  //enableMultiThread_ = dbe->enableMultiThread_;
 }
 
 void
@@ -541,8 +541,8 @@ MEtoEDMConverter::putData(T& iPutTo,
 
     if (!iLumiOnly) {
       // remove ME after copy to EDM is done.
-      if (deleteAfterCopy)
-        dbe->removeElement(me->getPathname(),me->getName());
+      //if (deleteAfterCopy)
+      //  dbe->removeElement(me->getPathname(),me->getName());
     }
 
   } // end loop through monitor elements

--- a/DQMServices/Components/plugins/MEtoEDMConverter.cc
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.cc
@@ -81,6 +81,8 @@ MEtoEDMConverter::MEtoEDMConverter(const edm::ParameterSet & iPSet) :
   produces<MEtoEDM<TString>, edm::Transition::EndLuminosityBlock>(sName);
 
   consumesMany<DQMToken>();
+  consumesMany<DQMRunToken>();
+  usesResource("DQMStore");
 
   static_assert(sizeof(int64_t) == sizeof(long long),"type int64_t is not the same length as long long");
 

--- a/DQMServices/Components/plugins/MEtoEDMConverter.h
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.h
@@ -51,8 +51,10 @@
 #include "TObjString.h"
 
 class MEtoEDMConverter : public edm::one::EDProducer<edm::one::WatchRuns,
+                                                     edm::one::WatchLuminosityBlocks,
                                                      edm::EndLuminosityBlockProducer,
-                                                     edm::EndRunProducer>
+                                                     edm::EndRunProducer,
+                                                     edm::one::SharedResources>
 {
 public:
   explicit MEtoEDMConverter(const edm::ParameterSet&);
@@ -64,6 +66,8 @@ public:
   void endRun(edm::Run const&, const edm::EventSetup&) override;
   void endRunProduce(edm::Run&, const edm::EventSetup&) override;
   void endLuminosityBlockProduce(edm::LuminosityBlock&, const edm::EventSetup&) override;
+  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {};
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {};
 
   template <class T>
       void putData(T& iPutTo, bool iLumiOnly, uint32_t run, uint32_t lumi);

--- a/DQMServices/Components/python/EDMtoMEConverter_cfi.py
+++ b/DQMServices/Components/python/EDMtoMEConverter_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-EDMtoMEConverter = cms.EDAnalyzer("EDMtoMEConverter",
+EDMtoMEConverter = cms.EDProducer("EDMtoMEConverter",
     Name = cms.untracked.string('EDMtoMEConverter'),
     Verbosity = cms.untracked.int32(0), # 0 provides no output
                                         # 1 provides basic output

--- a/DQMServices/Components/python/test/create_file1_cfg.py
+++ b/DQMServices/Components/python/test/create_file1_cfg.py
@@ -42,8 +42,6 @@ process.o = cms.EndPath(process.out+process.reader)
 process.add_(cms.Service("DQMStore"))
 
 if b.multithread():
-    process.out.enableMultiThread = cms.untracked.bool(True)
-    process.DQMStore.enableMultiThread = cms.untracked.bool(True)
     process.o.remove(process.reader)
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))

--- a/DQMServices/Components/python/test/create_file1_oldf_cfg.py
+++ b/DQMServices/Components/python/test/create_file1_oldf_cfg.py
@@ -42,8 +42,6 @@ process.o = cms.EndPath(process.endOfProcess+process.out)
 
 process.add_(cms.Service("DQMStore"))
 
-if b.multithread():
-
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
 #process.DQMStore.verbose = cms.untracked.int32(3)

--- a/DQMServices/Components/python/test/create_file1_oldf_cfg.py
+++ b/DQMServices/Components/python/test/create_file1_oldf_cfg.py
@@ -43,8 +43,6 @@ process.o = cms.EndPath(process.endOfProcess+process.out)
 process.add_(cms.Service("DQMStore"))
 
 if b.multithread():
-    process.MEtoEDMConverter.enableMultiThread = cms.untracked.bool(True)
-    process.DQMStore.enableMultiThread = cms.untracked.bool(True)
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 

--- a/DQMServices/Components/python/test/create_file2_cfg.py
+++ b/DQMServices/Components/python/test/create_file2_cfg.py
@@ -42,8 +42,6 @@ process.o = cms.EndPath(process.out+process.reader)
 process.add_(cms.Service("DQMStore"))
 
 if b.multithread():
-    process.out.enableMultiThread = cms.untracked.bool(True)
-    process.DQMStore.enableMultiThread = cms.untracked.bool(True)
     process.o.remove(process.reader)
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))

--- a/DQMServices/Components/python/test/create_file2_oldf_cfg.py
+++ b/DQMServices/Components/python/test/create_file2_oldf_cfg.py
@@ -42,8 +42,6 @@ process.o = cms.EndPath(process.endOfProcess+process.out)
 
 process.add_(cms.Service("DQMStore"))
 
-if b.multithread():
-
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
 process.DQMStore.verbose = cms.untracked.int32(3)

--- a/DQMServices/Components/python/test/create_file2_oldf_cfg.py
+++ b/DQMServices/Components/python/test/create_file2_oldf_cfg.py
@@ -43,8 +43,6 @@ process.o = cms.EndPath(process.endOfProcess+process.out)
 process.add_(cms.Service("DQMStore"))
 
 if b.multithread():
-    process.MEtoEDMConverter.enableMultiThread = cms.untracked.bool(True)
-    process.DQMStore.enableMultiThread = cms.untracked.bool(True)
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 

--- a/DQMServices/Components/python/test/create_file3_cfg.py
+++ b/DQMServices/Components/python/test/create_file3_cfg.py
@@ -44,8 +44,6 @@ process.o = cms.EndPath(process.out+process.reader)
 process.add_(cms.Service("DQMStore"))
 
 if b.multithread():
-    process.out.enableMultiThread = cms.untracked.bool(True)
-    process.DQMStore.enableMultiThread = cms.untracked.bool(True)
     process.o.remove(process.reader)
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))

--- a/DQMServices/Components/python/test/create_file3_oldf_cfg.py
+++ b/DQMServices/Components/python/test/create_file3_oldf_cfg.py
@@ -43,8 +43,6 @@ process.o = cms.EndPath(process.endOfProcess+process.out)
 
 process.add_(cms.Service("DQMStore"))
 
-if b.multithread():
-
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
 #process.add_(cms.Service("Tracer"))

--- a/DQMServices/Components/python/test/create_file3_oldf_cfg.py
+++ b/DQMServices/Components/python/test/create_file3_oldf_cfg.py
@@ -44,8 +44,6 @@ process.o = cms.EndPath(process.endOfProcess+process.out)
 process.add_(cms.Service("DQMStore"))
 
 if b.multithread():
-    process.MEtoEDMConverter.enableMultiThread = cms.untracked.bool(True)
-    process.DQMStore.enableMultiThread = cms.untracked.bool(True)
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 

--- a/DQMServices/Components/python/test/create_file4_cfg.py
+++ b/DQMServices/Components/python/test/create_file4_cfg.py
@@ -36,8 +36,6 @@ process.o = cms.EndPath(process.out)
 process.add_(cms.Service("DQMStore"))
 
 if b.multithread():
-    process.out.enableMultiThread = cms.untracked.bool(True)
-    process.DQMStore.enableMultiThread = cms.untracked.bool(True)
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(20))
 

--- a/DQMServices/Components/python/test/create_file4_cfg.py
+++ b/DQMServices/Components/python/test/create_file4_cfg.py
@@ -35,8 +35,6 @@ process.o = cms.EndPath(process.out)
 
 process.add_(cms.Service("DQMStore"))
 
-if b.multithread():
-
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(20))
 
 

--- a/DQMServices/Components/python/test/create_file4_oldf_cfg.py
+++ b/DQMServices/Components/python/test/create_file4_oldf_cfg.py
@@ -42,8 +42,6 @@ process.o = cms.EndPath(process.endOfProcess+process.out)
 
 process.add_(cms.Service("DQMStore"))
 
-if b.multithread():
-
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(20))
 
 

--- a/DQMServices/Components/python/test/create_file4_oldf_cfg.py
+++ b/DQMServices/Components/python/test/create_file4_oldf_cfg.py
@@ -43,8 +43,6 @@ process.o = cms.EndPath(process.endOfProcess+process.out)
 process.add_(cms.Service("DQMStore"))
 
 if b.multithread():
-    process.MEtoEDMConverter.enableMultiThread = cms.untracked.bool(True)
-    process.DQMStore.enableMultiThread = cms.untracked.bool(True)
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(20))
 

--- a/DQMServices/Components/python/test/create_filePB_cfg.py
+++ b/DQMServices/Components/python/test/create_filePB_cfg.py
@@ -49,8 +49,6 @@ process.schedule = cms.Schedule(
 process.add_(cms.Service("DQMStore"))
 
 if b.multithread():
-    process.out.enableMultiThread = cms.untracked.bool(True)
-    process.DQMStore.enableMultiThread = cms.untracked.bool(True)
     process.options = cms.untracked.PSet(
         numberOfThreads = cms.untracked.uint32(4),
         numberOfStreams = cms.untracked.uint32(4)

--- a/DQMServices/Components/python/test/create_filePB_ref_cfg.py
+++ b/DQMServices/Components/python/test/create_filePB_ref_cfg.py
@@ -48,8 +48,6 @@ process.schedule = cms.Schedule(
 process.add_(cms.Service("DQMStore"))
 
 if b.multithread():
-    process.out.enableMultiThread = cms.untracked.bool(True)
-    process.DQMStore.enableMultiThread = cms.untracked.bool(True)
     process.options = cms.untracked.PSet(
         numberOfThreads = cms.untracked.uint32(4),
         numberOfStreams = cms.untracked.uint32(4)

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -644,7 +644,7 @@ DQMFileSaver::beginJob()
   nrun_ = nlumi_ = irun_ = 0;
   
   // Determine if we are running multithreading asking to the DQMStore. Not to be moved in the ctor
-  enableMultiThread_ = dbe_->enableMultiThread_;
+  enableMultiThread_ = true; //dbe_->enableMultiThread_;
 
   if ((convention_ == FilterUnit) && (!fakeFilterUnitMode_))
   {

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -644,7 +644,7 @@ DQMFileSaver::beginJob()
   nrun_ = nlumi_ = irun_ = 0;
   
   // Determine if we are running multithreading asking to the DQMStore. Not to be moved in the ctor
-  enableMultiThread_ = true; //dbe_->enableMultiThread_;
+  enableMultiThread_ = false; //dbe_->enableMultiThread_;
 
   if ((convention_ == FilterUnit) && (!fakeFilterUnitMode_))
   {

--- a/DQMServices/Core/interface/DQMEDAnalyzer.h
+++ b/DQMServices/Core/interface/DQMEDAnalyzer.h
@@ -12,11 +12,12 @@
 
 class DQMEDAnalyzer : public edm::one::EDProducer<edm::Accumulator,
                                                   edm::EndLuminosityBlockProducer,
+                                                  edm::EndRunProducer,
                                                   edm::one::WatchLuminosityBlocks,
                                                   edm::one::WatchRuns> 
 {
 public:
-  DQMEDAnalyzer() = default;
+  DQMEDAnalyzer();
   ~DQMEDAnalyzer() override = default;
   DQMEDAnalyzer(DQMEDAnalyzer const&) = delete;
   DQMEDAnalyzer(DQMEDAnalyzer &&) = delete;
@@ -24,6 +25,7 @@ public:
   void beginRun(edm::Run const& run, edm::EventSetup const& setup) final;
 
   void endRun(edm::Run const& run, edm::EventSetup const& setup) override;
+  void endRunProduce(edm::Run& run, edm::EventSetup const& setup) override;
 
   void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) override;
 

--- a/DQMServices/Core/interface/DQMNet.h
+++ b/DQMServices/Core/interface/DQMNet.h
@@ -101,7 +101,6 @@ public:
     uint64_t		version;
     uint32_t            run;
     uint32_t            lumi;
-    uint32_t            streamId;
     uint32_t            moduleId;
     const std::string	*dirname;
     std::string		objname;
@@ -181,16 +180,13 @@ public:
     {
       if (a.run == b.run) {
         if (a.lumi == b.lumi) {
-          if (a.streamId == b.streamId) {
-            if (a.moduleId == b.moduleId) {
-              if (*a.dirname == *b.dirname) {
-                return a.objname < b.objname;
-              }
-              return *a.dirname < *b.dirname;
+          if (a.moduleId == b.moduleId) {
+            if (*a.dirname == *b.dirname) {
+              return a.objname < b.objname;
             }
-            return a.moduleId < b.moduleId;
+            return *a.dirname < *b.dirname;
           }
-          return a.streamId < b.streamId;
+          return a.moduleId < b.moduleId;
         }
         return a.lumi < b.lumi;
       }

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -354,36 +354,24 @@ class DQMStore
   template <typename iFunc>
   void bookTransaction(iFunc f, uint32_t run, uint32_t moduleId) {
     std::lock_guard<std::mutex> guard(book_mutex_);
-    /* Set the run number and module id only if multithreading is enabled */
-    if (enableMultiThread_) {
-      run_ = run;
-      moduleId_ = moduleId;
-    }
+    run_ = run;
+    moduleId_ = moduleId;
     f(*ibooker_);
 
-    /* Reset the run number and module id only if multithreading is enabled */
-    if (enableMultiThread_) {
-      run_ = 0;
-      moduleId_ = 0;
-    }
+    run_ = 0;
+    moduleId_ = 0;
   }
 
   // Similar function used to book "global" histograms via the
   // ConcurrentMonitorElement interface.
+  // TODO: Maybe we should add the moduleId here as well.
   template <typename iFunc>
   void bookConcurrentTransaction(iFunc f, uint32_t run) {
     std::lock_guard<std::mutex> guard(book_mutex_);
-    /* Set the run_ member only if enableMultiThread is enabled */
-    if (enableMultiThread_) {
-      run_ = run;
-    }
+    run_ = run;
     ConcurrentBooker booker(this);
     f(booker);
-
-    /* Reset the run_ member only if enableMultiThread is enabled */
-    if (enableMultiThread_) {
-      run_ = 0;
-    }
+    run_ = 0;
   }
 
   // Signature needed in the harvesting where the booking is done
@@ -677,7 +665,8 @@ class DQMStore
   bool                          load(const std::string &filename,
                                      OpenRunDirs stripdirs = StripRunDirs,
                                      bool fileMustExist = true);
-  bool                          mtEnabled() { return enableMultiThread_; };
+  // TODO: this should go away
+  bool                          mtEnabled() { return true; };
 
 
  public:
@@ -842,7 +831,6 @@ class DQMStore
   bool                          reset_;
   double                        scaleFlag_;
   bool                          collateHistograms_;
-  bool                          enableMultiThread_;
   bool                          LSbasedMode_;
   bool                          forceResetOnBeginLumi_;
   std::string                   readSelectedDirectory_;

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -666,7 +666,7 @@ class DQMStore
                                      OpenRunDirs stripdirs = StripRunDirs,
                                      bool fileMustExist = true);
   // TODO: this should go away
-  bool                          mtEnabled() { return true; };
+  bool                          mtEnabled() { return false; };
 
 
  public:

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -808,8 +808,8 @@ class DQMStore
   void                          saveMonitorElementRangeToPB(
                                     std::string const& dir,
                                     unsigned int run,
-                                    MEMap::const_iterator begin,
-                                    MEMap::const_iterator end,
+                                    std::vector<MonitorElement*>::const_iterator begin,
+                                    std::vector<MonitorElement*>::const_iterator end,
                                     dqmstorepb::ROOTFilePB & file,
                                     unsigned int & counter);
   void                          saveMonitorElementToROOT(
@@ -821,8 +821,8 @@ class DQMStore
                                     SaveReferenceTag ref,
                                     int minStatus,
                                     unsigned int run,
-                                    MEMap::const_iterator begin,
-                                    MEMap::const_iterator end,
+                                    std::vector<MonitorElement*>::const_iterator begin,
+                                    std::vector<MonitorElement*>::const_iterator end,
                                     TFile & file,
                                     unsigned int & counter);
 

--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -75,7 +75,6 @@ private:
   MonitorElement *initialise(Kind kind, TH1 *rootobj);
   MonitorElement *initialise(Kind kind, const std::string &value);
   void globalize() {
-    data_.streamId = 0;
     data_.moduleId = 0;
   }
   void setLumi(uint32_t ls) {data_.lumi = ls;}
@@ -85,7 +84,6 @@ public:
   MonitorElement(const std::string *path,
                  const std::string &name,
                  uint32_t run = 0,
-                 uint32_t streamId = 0,
                  uint32_t moduleId = 0);
   MonitorElement(const MonitorElement &, MonitorElementNoCloneTag);
   MonitorElement(const MonitorElement &);
@@ -388,7 +386,6 @@ public:
 
   const uint32_t run() const {return data_.run;}
   const uint32_t lumi() const {return data_.lumi;}
-  const uint32_t streamId() const {return data_.streamId;}
   const uint32_t moduleId() const {return data_.moduleId;}
 };
 

--- a/DQMServices/Core/python/DQMEDAnalyzer.py
+++ b/DQMServices/Core/python/DQMEDAnalyzer.py
@@ -1,1 +1,1 @@
-from FWCore.ParameterSet.Config import EDAnalyzer as DQMEDAnalyzer
+from FWCore.ParameterSet.Config import EDProducer as DQMEDAnalyzer

--- a/DQMServices/Core/python/DQMStore_cfi.py
+++ b/DQMServices/Core/python/DQMStore_cfi.py
@@ -5,10 +5,8 @@ DQMStore = cms.Service("DQMStore",
     verbose = cms.untracked.int32(0),
     verboseQT = cms.untracked.int32(0),
     collateHistograms = cms.untracked.bool(False),
-    enableMultiThread = cms.untracked.bool(False),
     #the LSbasedMode flag is needed for the online. All the
     #MEs are flagged to be LS based.
     LSbasedMode = cms.untracked.bool(False),
-    #this is bound to the enableMultiThread flag.
     forceResetOnBeginLumi = cms.untracked.bool(False)
 )

--- a/DQMServices/Core/python/test/dqm_testMultiThread_DQMIO_cfg.py
+++ b/DQMServices/Core/python/test/dqm_testMultiThread_DQMIO_cfg.py
@@ -63,9 +63,6 @@ process.options = cms.untracked.PSet(
 )
 
 # Enable MultiThread DQM
-process.dqmSaver.enableMultiThread = cms.untracked.bool(True)
-process.DQMoutput.enableMultiThread = cms.untracked.bool(True)
-process.DQMStore.enableMultiThread = cms.untracked.bool(True)
 
 
 #process.Tracer = cms.Service('Tracer')

--- a/DQMServices/Core/python/test/dqm_testMultiThread_MEtoEDM_cfg.py
+++ b/DQMServices/Core/python/test/dqm_testMultiThread_MEtoEDM_cfg.py
@@ -66,8 +66,6 @@ process.options = cms.untracked.PSet(
 )
 
 # Enable MultiThread DQM
-process.dqmSaver.enableMultiThread = cms.untracked.bool(True)
-process.MEtoEDMConverter.enableMultiThread = cms.untracked.bool(True)
 
 
 #process.Tracer = cms.Service('Tracer')

--- a/DQMServices/Core/src/DQMEDAnalyzer.cc
+++ b/DQMServices/Core/src/DQMEDAnalyzer.cc
@@ -1,0 +1,41 @@
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+
+void DQMEDAnalyzer::beginRun(edm::Run const& run, edm::EventSetup const& setup) 
+{
+  dqmBeginRun(run, setup);
+  edm::Service<DQMStore>()->bookTransaction(
+    [this, &run, &setup](DQMStore::IBooker & booker)
+    {
+      booker.cd();
+      this->bookHistograms(booker, run, setup);
+    },
+    run.run(),
+    run.moduleCallingContext()->moduleDescription()->id());
+}
+
+void DQMEDAnalyzer::endRun(edm::Run const& run, edm::EventSetup const& setup) 
+{ }
+
+void DQMEDAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) 
+{ }
+
+void DQMEDAnalyzer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) 
+{ }
+
+void DQMEDAnalyzer::endLuminosityBlockProduce(edm::LuminosityBlock & lumi, edm::EventSetup const& setup) 
+{
+  edm::Service<DQMStore>()->cloneLumiHistograms(
+      lumi.run(),
+      lumi.luminosityBlock(),
+      lumi.moduleCallingContext()->moduleDescription()->id());
+}
+
+
+void DQMEDAnalyzer::dqmBeginRun(edm::Run const&, edm::EventSetup const&) {}
+
+void DQMEDAnalyzer::analyze(edm::Event const&, edm::EventSetup const&) {}
+void DQMEDAnalyzer::accumulate(edm::Event const& ev, edm::EventSetup const& es) 
+{
+  analyze(ev, es);
+}
+

--- a/DQMServices/Core/src/DQMEDAnalyzer.cc
+++ b/DQMServices/Core/src/DQMEDAnalyzer.cc
@@ -1,4 +1,10 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DataFormats/Histograms/interface/DQMToken.h"
+
+DQMEDAnalyzer::DQMEDAnalyzer() {
+  produces<DQMToken,edm::Transition::EndLuminosityBlock>();
+  produces<DQMRunToken,edm::Transition::EndRun>();
+}
 
 void DQMEDAnalyzer::beginRun(edm::Run const& run, edm::EventSetup const& setup) 
 {
@@ -16,6 +22,11 @@ void DQMEDAnalyzer::beginRun(edm::Run const& run, edm::EventSetup const& setup)
 void DQMEDAnalyzer::endRun(edm::Run const& run, edm::EventSetup const& setup) 
 { }
 
+void DQMEDAnalyzer::endRunProduce(edm::Run& run, edm::EventSetup const& setup) 
+{
+  run.put(std::make_unique<DQMRunToken>());
+}
+
 void DQMEDAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) 
 { }
 
@@ -28,6 +39,7 @@ void DQMEDAnalyzer::endLuminosityBlockProduce(edm::LuminosityBlock & lumi, edm::
       lumi.run(),
       lumi.luminosityBlock(),
       lumi.moduleCallingContext()->moduleDescription()->id());
+  lumi.put(std::make_unique<DQMToken>());
 }
 
 

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -3274,9 +3274,10 @@ DQMStore::removeElement(const std::string &dir, const std::string &name, bool wa
   auto pos = data_.find(proto);
   if (pos != data_.end())
     data_.erase(pos);
-  else if (warning)
+  else if (warning) {
     std::cout << "DQMStore: WARNING: attempt to remove non-existent"
               << " monitor element '" << name << "' in '" << dir << "'\n";
+  }
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -1892,7 +1892,7 @@ DQMStore::getAllContents(const std::string &path,
   if (lumi != 0) {
     // only save global per-lumi clones.
     // with LSbasedMode, all histos are cloned, so all are saved.
-    MonitorElement proto(cleaned, std::string(), runNumber, 0, 0);
+    MonitorElement proto(cleaned, std::string(), runNumber, 0);
     proto.setLumi(lumi);
     auto begin = data_.lower_bound(proto);
     proto.setLumi(lumi+1);
@@ -1905,7 +1905,7 @@ DQMStore::getAllContents(const std::string &path,
     // we start with the lumi=0 ones, and saveMonitorElementRangeToROOT will
     // stop before running into the per-lumi ones.
     if (runNumber == 0) {
-      MonitorElement runproto(cleaned, std::string(), 0, 0, 0);
+      MonitorElement runproto(cleaned, std::string(), 0, 0);
       auto runit = data_.lower_bound(runproto);
       if (runit != data_.end()) {
         runNumber = runit->run();
@@ -1913,9 +1913,9 @@ DQMStore::getAllContents(const std::string &path,
     }
     uint32_t moduleId = 0;
     for(;;) {
-      MonitorElement proto1(cleaned, std::string(), runNumber, 0, moduleId);
+      MonitorElement proto1(cleaned, std::string(), runNumber, moduleId);
       auto begin = data_.lower_bound(proto1);
-      MonitorElement proto2(cleaned, std::string(), runNumber, 0, moduleId+1);
+      MonitorElement proto2(cleaned, std::string(), runNumber, moduleId+1);
       auto end   = data_.lower_bound(proto2);
       if (begin == end) break; // nothing to do
       if (begin->lumi() == 0) { // in case there are no global MEs
@@ -2030,8 +2030,8 @@ DQMStore::postGlobalBeginLumi(const edm::GlobalContext &gc)
 
   // find the range of non-legacy global MEs for the current run:
   // run != 0, lumi == 0 (implicit), stream id == 0, module id == 0
-  const MonitorElement begin(&null_str, null_str, run, 0, 0);
-  const MonitorElement end(&null_str, null_str, run, 0, 1);
+  const MonitorElement begin(&null_str, null_str, run, 0);
+  const MonitorElement end(&null_str, null_str, run, 1);
   auto i = data_.lower_bound(begin);
   const auto e = data_.lower_bound(end);
   while (i != e) {
@@ -2680,7 +2680,7 @@ DQMStore::save(const std::string &filename,
     if (lumi != 0) {
       // only save global per-lumi clones.
       // with LSbasedMode, all histos are cloned, so all are saved.
-      MonitorElement proto(&dir, std::string(), run, 0, 0);
+      MonitorElement proto(&dir, std::string(), run, 0);
       proto.setLumi(lumi);
       auto begin = data_.lower_bound(proto);
       proto.setLumi(lumi+1);
@@ -2693,15 +2693,15 @@ DQMStore::save(const std::string &filename,
       // we start with the lumi=0 ones, and saveMonitorElementRangeToROOT will
       // stop before running into the per-lumi ones.
       if (run == 0) {
-        MonitorElement runproto(&dir, std::string(), 0, 0, 0);
+        MonitorElement runproto(&dir, std::string(), 0, 0);
         auto runit = data_.lower_bound(runproto);
         run = runit->run();
       }
       uint32_t moduleId = 0;
       for(;;) {
-        MonitorElement proto1(&dir, std::string(), run, 0, moduleId);
+        MonitorElement proto1(&dir, std::string(), run, moduleId);
         auto begin = data_.lower_bound(proto1);
-        MonitorElement proto2(&dir, std::string(), run, 0, moduleId+1);
+        MonitorElement proto2(&dir, std::string(), run, moduleId+1);
         auto end   = data_.lower_bound(proto2);
         if (begin == end) break; // nothing to do
         if (begin->lumi() > 0) break; // in case there are no global MEs
@@ -2846,7 +2846,7 @@ DQMStore::savePB(const std::string &filename,
     if (lumi != 0) {
       // only save global per-lumi clones.
       // with LSbasedMode, all histos are cloned, so all are saved.
-      MonitorElement proto(&dir, std::string(), run, 0, 0);
+      MonitorElement proto(&dir, std::string(), run, 0);
       proto.setLumi(lumi);
       auto begin = data_.lower_bound(proto);
       proto.setLumi(lumi+1);
@@ -2859,15 +2859,15 @@ DQMStore::savePB(const std::string &filename,
       // we start with the lumi=0 ones, and saveMonitorElementRangeToROOT will
       // stop before running into the per-lumi ones.
       if (run == 0) {
-        MonitorElement runproto(&dir, std::string(), 0, 0, 0);
+        MonitorElement runproto(&dir, std::string(), 0, 0);
         auto runit = data_.lower_bound(runproto);
         run = runit->run();
       }
       uint32_t moduleId = 0;
       for(;;) {
-        MonitorElement proto1(&dir, std::string(), run, 0, moduleId);
+        MonitorElement proto1(&dir, std::string(), run, moduleId);
         auto begin = data_.lower_bound(proto1);
-        MonitorElement proto2(&dir, std::string(), run, 0, moduleId+1);
+        MonitorElement proto2(&dir, std::string(), run, moduleId+1);
         auto end   = data_.lower_bound(proto2);
         if (begin == end) break; // nothing to do
         if (begin->lumi() > 0) break; // in case there are no global MEs

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -2568,7 +2568,7 @@ DQMStore::save(const std::string &filename,
                const std::string &path /* = "" */,
                const std::string &pattern /* = "" */,
                const std::string &rewrite /* = "" */,
-               const uint32_t run /* = 0 */,
+                     uint32_t run /* = 0 */,
                const uint32_t lumi /* = 0 */,
                SaveReferenceTag ref /* = SaveWithReference */,
                int minStatus /* = dqm::qstatus::STATUS_OK */,
@@ -2646,9 +2646,9 @@ DQMStore::save(const std::string &filename,
     // - "normal" MEs (default, moduleId set, lumi=0)
     // - per-lumi clones (perLumiFlag=true, moduleId=0, lumi set)
     // the sort order is run, lumi, module, dir, name
-    // TODO: for now we use the old MT behavoiur and only save per-lumi histos.
-    //       Maybe we should *also* save all others, but that was not done before.
     // Restrict the loop to the monitor elements for the current lumisection
+    // If the run is 0 (former non-MT mode), return the first run
+    // TODO(schneiml): I think this is the semantics that legacy stuff expects. 
     if (lumi != 0) {
       // only save global per-lumi clones.
       // with LSbasedMode, all histos are cloned, so all are saved.
@@ -2664,6 +2664,11 @@ DQMStore::save(const std::string &filename,
       // even if there are per-lumi clones in the moduleId=0 sapce,
       // we start with the lumi=0 ones, and saveMonitorElementRangeToROOT will
       // stop before running into the per-lumi ones.
+      if (run == 0) {
+        MonitorElement runproto(&dir, std::string(), 0, 0, 0);
+        auto runit = data_.lower_bound(runproto);
+        run = runit->run();
+      }
       uint32_t moduleId = 0;
       for(;;) {
         MonitorElement proto1(&dir, std::string(), run, 0, moduleId);
@@ -2770,7 +2775,7 @@ DQMStore::saveMonitorElementRangeToPB(
 void
 DQMStore::savePB(const std::string &filename,
                  const std::string &path /* = "" */,
-                 const uint32_t run /* = 0 */,
+                       uint32_t run /* = 0 */,
                  const uint32_t lumi /* = 0 */)
 {
   using google::protobuf::io::FileOutputStream;
@@ -2805,9 +2810,9 @@ DQMStore::savePB(const std::string &filename,
     // - "normal" MEs (default, moduleId set, lumi=0)
     // - per-lumi clones (perLumiFlag=true, moduleId=0, lumi set)
     // the sort order is run, lumi, module, dir, name
-    // TODO: for now we use the old MT behavoiur and only save per-lumi histos.
-    //       Maybe we should *also* save all others, but that was not done before.
     // Restrict the loop to the monitor elements for the current lumisection
+    // If the run is 0 (former non-MT mode), return the first run
+    // TODO(schneiml): I think this is the semantics that legacy stuff expects. 
     if (lumi != 0) {
       // only save global per-lumi clones.
       // with LSbasedMode, all histos are cloned, so all are saved.
@@ -2823,6 +2828,11 @@ DQMStore::savePB(const std::string &filename,
       // even if there are per-lumi clones in the moduleId=0 sapce,
       // we start with the lumi=0 ones, and saveMonitorElementRangeToROOT will
       // stop before running into the per-lumi ones.
+      if (run == 0) {
+        MonitorElement runproto(&dir, std::string(), 0, 0, 0);
+        auto runit = data_.lower_bound(runproto);
+        run = runit->run();
+      }
       uint32_t moduleId = 0;
       for(;;) {
         MonitorElement proto1(&dir, std::string(), run, 0, moduleId);

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -177,7 +177,7 @@ MonitorElement::MonitorElement(const std::string *path,
   data_.version  = 0;
   data_.run      = run;
   data_.lumi     = 0;
-  data_.streamId = streamId;
+  data_.streamId = 0;
   data_.moduleId = moduleId;
   data_.dirname  = path;
   data_.objname  = name;

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -157,7 +157,6 @@ MonitorElement::MonitorElement()
   data_.dirname  = nullptr;
   data_.run      = 0;
   data_.lumi     = 0;
-  data_.streamId = 0;
   data_.moduleId = 0;
   data_.tag = 0;
   data_.flags = DQM_KIND_INVALID | DQMNet::DQM_PROP_NEW;
@@ -168,7 +167,6 @@ MonitorElement::MonitorElement()
 MonitorElement::MonitorElement(const std::string *path,
                                const std::string &name,
                                uint32_t run /* = 0 */,
-                               uint32_t streamId /* = 0 */,
                                uint32_t moduleId /* = 0 */)
   : object_(nullptr),
     reference_(nullptr),
@@ -177,7 +175,6 @@ MonitorElement::MonitorElement(const std::string *path,
   data_.version  = 0;
   data_.run      = run;
   data_.lumi     = 0;
-  data_.streamId = 0;
   data_.moduleId = moduleId;
   data_.dirname  = path;
   data_.objname  = name;

--- a/DQMServices/Core/test/DQMTestMultiThread.cc
+++ b/DQMServices/Core/test/DQMTestMultiThread.cc
@@ -63,7 +63,6 @@ void DQMTestMultiThread::dumpMe(MonitorElement const& me,
   std::cout << "Run: " << me.run()
             << " Lumi: " << me.lumi()
             << " LumiFlag: " << me.getLumiFlag()
-            << " streamId: " << me.streamId()
             << " moduleId: " << me.moduleId()
             << " fullpathname: " << me.getPathname();
   if (printStat)

--- a/DataFormats/Histograms/interface/DQMToken.h
+++ b/DataFormats/Histograms/interface/DQMToken.h
@@ -25,5 +25,12 @@ class DQMToken
       DQMToken() {}
 };
 
+class DQMRunToken
+{
+
+   public:
+      DQMRunToken() {}
+};
+
 
 #endif

--- a/DataFormats/Histograms/src/classes_def.xml
+++ b/DataFormats/Histograms/src/classes_def.xml
@@ -73,4 +73,6 @@
 
  <class name="DQMToken" ClassVersion="0"/>
  <class name="edm::Wrapper<DQMToken>" persistent="false"/>
+ <class name="DQMRunToken" ClassVersion="0"/>
+ <class name="edm::Wrapper<DQMRunToken>" persistent="false"/>
 </lcgdict>

--- a/Validation/CaloTowers/test/client_data_cfg.py
+++ b/Validation/CaloTowers/test/client_data_cfg.py
@@ -76,7 +76,6 @@ process.options = cms.untracked.PSet(
 #process.load('Configuration/StandardSequences/EDMtoMEAtRunEnd_cff')
 ##process.EDMtoMEConverter.convertOnEndLumi = False
 #process.dqmSaver.referenceHandling = cms.untracked.string('all')
-## Don't do this: process.dqmSaver.enableMultiThread = cms.untracked.bool(True)
 
 cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
 Workflow = '/HcalValidation/'+'Harvesting/'+str(cmssw_version)

--- a/Validation/CaloTowers/test/run_onRelVal_data_cfg.py
+++ b/Validation/CaloTowers/test/run_onRelVal_data_cfg.py
@@ -136,7 +136,6 @@ process.p2 = cms.Path( process.hcalTowerAnalyzer * process.noiseRates * process.
 #
 # DQMIO
 #
-#process.DQMStore.enableMultiThread = cms.untracked.bool(False)
 process.load('Configuration.EventContent.EventContent_cff')
 process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
     splitLevel = cms.untracked.int32(0),

--- a/Validation/RecoTau/python/DQMSequences_cfi.py
+++ b/Validation/RecoTau/python/DQMSequences_cfi.py
@@ -2,7 +2,8 @@ from Validation.RecoTau.dataTypes.ValidateTausOnRealElectronsData_cff import *
 from Validation.RecoTau.dataTypes.ValidateTausOnRealData_cff import *
 from Validation.RecoTau.dataTypes.ValidateTausOnRealMuonsData_cff import *
 
-dqmInfoTauV = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+dqmInfoTauV = DQMEDAnalyzer(
     "DQMEventInfo",
     subSystemFolder = cms.untracked.string('RecoTauV')
     )


### PR DESCRIPTION
This PR attempts to complete the complete the conversion from #22157, via #22218 and #22243 et. al. It eliminates `streamId` and `enableMultiThread` from the DQMStore.

This needs to be merged/cherry-picked with #22319 and #22364, it adds another change on top: re-doing the logic that queries MEs out of the set in the DQMStore.

It needs to be discussed if the handling of the runNumber is actually what we want.

This is likely to break multi-run harvesting and online (needs testing).