### PR TITLE
Fix after urgent message from validation campaign

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/interface/BarrelSimplifiedGeometry.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/BarrelSimplifiedGeometry.h
@@ -68,7 +68,7 @@ namespace fastsim{
         {
             // Do projection of norm(layer) on momentum vector
             // CosTheta = (momentum dot norm) / (length(momentum) / length(norm))
-            return getThickness(position) / fabs(momentum.X() * position.X() + momentum.Y() * position.Y()) / (momentum.P() * std::sqrt(position.X() * position.X() + position.Y() * position.Y()));
+            return getThickness(position) / (fabs(momentum.X() * position.X() + momentum.Y() * position.Y()) / (momentum.P() * std::sqrt(position.X() * position.X() + position.Y() * position.Y())));
         }
         
         //! Return magnetic field (field only has Z component!) on the barrel layer.


### PR DESCRIPTION
We received messages from PdmV validation campaign for fastsim 10_1_0_pre1 vs 10_0_2 , where unfortunately an unexpected increase in the tracking efficiency got noticed. This is related to a last minute change that I did for PR20666, and unfortunetaly I introduced a bug (missing brackets).