### PR TITLE
Created OneLumiPoolSource for testing

### DIFF
--- a/IOPool/Input/src/OneLumiPoolSource.cc
+++ b/IOPool/Input/src/OneLumiPoolSource.cc
@@ -1,0 +1,68 @@
+/*----------------------------------------------------------------------
+----------------------------------------------------------------------*/
+#include "PoolSource.h"
+#include "FWCore/Framework/interface/InputSourceMacros.h"
+#include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
+#include "FWCore/Framework/interface/EventPrincipal.h"
+
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+
+namespace edm {
+  
+  class OneLumiPoolSource : public PoolSource {
+  public:
+    explicit OneLumiPoolSource(ParameterSet const& pset, InputSourceDescription const& desc);
+    
+  private:
+    ItemType getNextItemType() override;
+    std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
+
+    void readEvent_(EventPrincipal& eventPrincipal) override {
+      PoolSource::readEvent_(eventPrincipal);
+      eventPrincipal.setRunAndLumiNumber(eventPrincipal.run(),1);
+    }
+
+    bool seenFirstLumi_ = false;
+  };
+
+  OneLumiPoolSource::OneLumiPoolSource(ParameterSet const& pset, InputSourceDescription const& desc) :
+    PoolSource(pset, desc)
+  {
+  }
+
+  std::shared_ptr<LuminosityBlockAuxiliary>
+  OneLumiPoolSource::readLuminosityBlockAuxiliary_() {
+    auto ret = PoolSource::readLuminosityBlockAuxiliary_();
+    auto hist = ret->processHistoryID();
+    *ret = LuminosityBlockAuxiliary(ret->run(), 1, ret->beginTime(), ret->endTime());
+    ret->setProcessHistoryID(hist);
+    return ret;
+  }
+
+  InputSource::ItemType
+  OneLumiPoolSource::getNextItemType() {
+    auto type = PoolSource::getNextItemType();
+    if(type==IsLumi) {
+      if(seenFirstLumi_) {
+        do {
+          edm::HistoryAppender historyAppender;
+          auto prodReg = std::make_shared<edm::ProductRegistry>();
+          prodReg->setFrozen();
+          edm::ProcessConfiguration procConfig;
+
+          LuminosityBlockPrincipal temp(prodReg, procConfig, &historyAppender,0);
+          readLuminosityBlock_(temp);
+          type =PoolSource::getNextItemType();
+        } while(type == IsLumi);
+      } else {
+        seenFirstLumi_ = true;
+      }
+    }
+    return type;
+  }
+}
+using namespace edm;
+
+DEFINE_FWK_INPUT_SOURCE(OneLumiPoolSource);
+

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -47,17 +47,18 @@ namespace edm {
     RunHelperBase* runHelper() {return runHelper_.get();}
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
+  protected:
+    ItemType getNextItemType() override;
+    void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) override;
+    std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
+    void readEvent_(EventPrincipal& eventPrincipal) override;
 
   private:
-    void readEvent_(EventPrincipal& eventPrincipal) override;
-    std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
-    void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) override;
     std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
     void readRun_(RunPrincipal& runPrincipal) override;
     std::unique_ptr<FileBlock> readFile_() override;
     void closeFile_() override;
     void endJob() override;
-    ItemType getNextItemType() override;
     bool readIt(EventID const& id, EventPrincipal& eventPrincipal, StreamContext& streamContext) override;
     void skip(int offset) override;
     bool goToEvent_(EventID const& eventID) override;

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -103,4 +103,6 @@ cmsRun ${LOCAL_TEST_DIR}/test_reduced_ProcessHistory_dup_cfg.py merged_files.roo
 
 cmsRun ${LOCAL_TEST_DIR}/test_reduced_ProcessHistory_end_cfg.py merged_files.root || die 'Failure using test_reduced_ProcessHistory_end_cfg.py' $?
 
+cmsRun ${LOCAL_TEST_DIR}/test_make_multi_lumi_cfg.py || die 'Failure using test_make_multi_lumi_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/test_read_multi_lumi_as_one_cfg.py || die 'Failure using test_read_multi_lumi_as_one_cfg.py' $?
 popd

--- a/IOPool/Input/test/test_make_multi_lumi_cfg.py
+++ b/IOPool/Input/test/test_make_multi_lumi_cfg.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("WRITE")
+
+process.source = cms.Source("EmptySource", numberEventsInLuminosityBlock = cms.untracked.uint32(4))
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(20))
+
+process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("multi_lumi.root"))
+
+process.o = cms.EndPath(process.out)

--- a/IOPool/Input/test/test_read_multi_lumi_as_one_cfg.py
+++ b/IOPool/Input/test/test_read_multi_lumi_as_one_cfg.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("READ")
+
+process.source = cms.Source("OneLumiPoolSource", fileNames = cms.untracked.vstring("file:multi_lumi.root") )
+
+process.tst = cms.EDAnalyzer("RunLumiEventChecker",
+                             eventSequence = cms.untracked.VEventID(
+                                                                    cms.EventID(1,0,0),
+                                                                    cms.EventID(1,1,0),
+                                                                    cms.EventID(1,1,1),
+                                                                    cms.EventID(1,1,2),
+                                                                    cms.EventID(1,1,3),
+                                                                    cms.EventID(1,1,4),
+                                                                    cms.EventID(1,1,5),
+                                                                    cms.EventID(1,1,6),
+                                                                    cms.EventID(1,1,7),
+                                                                    cms.EventID(1,1,8),
+                                                                    cms.EventID(1,1,9),
+                                                                    cms.EventID(1,1,10),
+                                                                    cms.EventID(1,1,11),
+                                                                    cms.EventID(1,1,12),
+                                                                    cms.EventID(1,1,13),
+                                                                    cms.EventID(1,1,14),
+                                                                    cms.EventID(1,1,15),
+                                                                    cms.EventID(1,1,16),
+                                                                    cms.EventID(1,1,17),
+                                                                    cms.EventID(1,1,18),
+                                                                    cms.EventID(1,1,19),
+                                                                    cms.EventID(1,1,20),
+                                                                    cms.EventID(1,1,0),
+                                                                    cms.EventID(1,0,0)
+                             )
+                             )
+process.dump = cms.OutputModule("AsciiOutputModule")
+
+process.d = cms.EndPath(process.dump+process.tst)
+
+#process.add_(cms.Service("Tracer"))


### PR DESCRIPTION
OneLumiPoolSource allows one to read a file containing multiple LuminosityBlocks and then have all but the first LuminosityBlocks discarded. This allows testing of concurrency using available files rather than ones with large number of Events in a LuminosityBlock.

This is not intended for production, just testing.