### PR TITLE
Updating MET Significance Parameters with 80X Run2016 tune

### DIFF
--- a/RecoMET/METProducers/python/METSignificanceParams_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceParams_cfi.py
@@ -15,10 +15,9 @@ METSignificanceParams = cms.PSet(
       #Run I, based on 53X / JME-13-003
       #jpar = cms.vdouble(1.20,1.13,1.03,0.96,1.08),
       #pjpar = cms.vdouble(-1.9,0.6383)
-      #Run II MC, based on 76X
-      #https://indico.cern.ch/event/527789/contributions/2160488/attachments/1271716/1884792/nmirman_20160511.pdf
-      jpar = cms.vdouble(1.29,1.19,1.07,1.13,1.12),
-      pjpar = cms.vdouble(-0.04,0.6504),
+      #Run II MC, based on 80X
+      jpar = cms.vdouble(1.39,1.26,1.21,1.23,1.28),
+      pjpar = cms.vdouble(-0.2586,0.6173),
       )
 
 METSignificanceParams_Data=cms.PSet(
@@ -36,8 +35,7 @@ METSignificanceParams_Data=cms.PSet(
       #Run I, based on 53X / JME-13-003
       #jpar = cms.vdouble(1.20,1.13,1.03,0.96,1.08),
       #pjpar = cms.vdouble(-1.9,0.6383)
-      #Run II data, based on 76X
-      #https://indico.cern.ch/event/527789/contributions/2160488/attachments/1271716/1884792/nmirman_20160511.pdf
-      jpar = cms.vdouble(1.26,1.14,1.13,1.13,1.06),
-      pjpar = cms.vdouble(-3.3,0.5961),
+      #Run II data, based on 80X
+      jpar = cms.vdouble(1.38,1.28,1.22,1.16,1.10),
+      pjpar = cms.vdouble(0.0033,0.5802),
       )


### PR DESCRIPTION
Updating the parameters for MET Significance with the latest tune (as used in JME-17-001).