### PR TITLE
RFC: Migrate SiStripGainsPCLWorker to concurrent and global DQM

### DIFF
--- a/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
@@ -1,67 +1,118 @@
 #ifndef CALIBTRACKER_SISTRIPCHANNELGAIN_APVGAINHELPERS_H
 #define CALIBTRACKER_SISTRIPCHANNELGAIN_APVGAINHELPERS_H
 
+
+#include "CalibTracker/SiStripChannelGain/interface/APVGainStruct.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQMServices/Core/interface/ConcurrentMonitorElement.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
 
 #include <string>
 #include <vector>
 #include <utility>
 #include <cstdint>
-
+#include <unordered_map>
 
 namespace APVGain {
-    int subdetectorId(uint32_t);
-    int subdetectorId(const std::string&);
-    int subdetectorSide(uint32_t,const TrackerTopology*);
-    int subdetectorSide(const std::string&);
-    int subdetectorPlane(uint32_t,const TrackerTopology*);
-    int subdetectorPlane(const std::string&);
 
-    std::vector<std::pair<std::string,std::string>> monHnames(std::vector<std::string>,bool,const char* tag);
+  int subdetectorId(uint32_t);
+  int subdetectorId(const std::string&);
+  int subdetectorSide(uint32_t,const TrackerTopology*);
+  int subdetectorSide(const std::string&);
+  int subdetectorPlane(uint32_t,const TrackerTopology*);
+  int subdetectorPlane(const std::string&);
 
-    struct APVmon{
+  std::vector<std::pair<std::string,std::string>> monHnames(std::vector<std::string>,bool,const char* tag);
+
+  struct APVmon{
       
-    public:
+  public:
 
-    APVmon(int v1, int v2, int v3, MonitorElement* v4) :
-      m_subdetectorId(v1),m_subdetectorSide(v2),m_subdetectorPlane(v3),m_monitor(v4){}
+  APVmon(int v1, int v2, int v3,MonitorElement* v4) :
+    m_subdetectorId(v1),m_subdetectorSide(v2),m_subdetectorPlane(v3),m_monitor(v4){}
+      
+    int getSubdetectorId(){
+      return m_subdetectorId;
+    }
+    
+    int getSubdetectorSide(){
+      return m_subdetectorSide;
+    }
 
-      int getSubdetectorId(){
-	return m_subdetectorId;
-      }
+    int getSubdetectorPlane(){
+      return m_subdetectorPlane;
+    }
+      
+    MonitorElement* getMonitor(){
+      return std::move(m_monitor);
+    }
 
-      int getSubdetectorSide(){
-	return m_subdetectorSide;
-      }
+    void printAll(){
+      LogDebug("APVGainHelpers")<< "subDetectorID:" << m_subdetectorId << std::endl;
+      LogDebug("APVGainHelpers")<< "subDetectorSide:" << m_subdetectorSide << std::endl;
+      LogDebug("APVGainHelpers")<< "subDetectorPlane:" << m_subdetectorPlane << std::endl;
+      LogDebug("APVGainHelpers")<< "histoName:" << m_monitor->getName() << std::endl;
+      return;
+    }
+      
+  private:
 
-      int getSubdetectorPlane(){
-	return m_subdetectorPlane;
-      }
+    int m_subdetectorId;
+    int m_subdetectorSide;
+    int m_subdetectorPlane;
+    MonitorElement* m_monitor;
+    
+  };
 
-      MonitorElement* getMonitor(){
-	return m_monitor;
-      }
+  std::vector<MonitorElement*> FetchMonitor(std::vector<APVmon>, uint32_t, const TrackerTopology* topo=nullptr);
 
-      void printAll(){
-	LogDebug("APVGainHelpers")<< "subDetectorID:" << m_subdetectorId << std::endl;
-	LogDebug("APVGainHelpers")<< "subDetectorSide:" << m_subdetectorSide << std::endl;
-	LogDebug("APVGainHelpers")<< "subDetectorPlane:" << m_subdetectorPlane << std::endl;
-	LogDebug("APVGainHelpers")<< "histoName:" << m_monitor->getName() << std::endl;
-	return;
-      }
+  std::vector<unsigned int> FetchIndices(std::map<unsigned int,APVloc>, uint32_t, const TrackerTopology* topo=nullptr);
 
-    private:
+  struct APVGainHistograms {
+  public:
+    APVGainHistograms():
+      Charge_Vs_Index(7),
+      Charge_1(),
+      Charge_2(),
+      Charge_3(),
+      Charge_4(),
+      Charge_Vs_PathlengthTIB(7), 
+      Charge_Vs_PathlengthTOB(7),
+      Charge_Vs_PathlengthTIDP(7),
+      Charge_Vs_PathlengthTIDM(7),
+      Charge_Vs_PathlengthTECP1(7),
+      Charge_Vs_PathlengthTECP2(7),
+      Charge_Vs_PathlengthTECM1(7),
+      Charge_Vs_PathlengthTECM2(7),
+      NStripAPVs(0),
+      NPixelDets(0),
+      APVsCollOrdered(),
+      APVsColl()
+    {
+    }
+    
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_Index;  /*!< Charge per cm for each detector id */
+    std::array< std::vector<ConcurrentMonitorElement>,7 > Charge_1;   /*!< Charge per cm per layer / wheel */
+    std::array< std::vector<ConcurrentMonitorElement>,7 > Charge_2;   /*!< Charge per cm per layer / wheel without G2 */
+    std::array< std::vector<ConcurrentMonitorElement>,7 > Charge_3;   /*!< Charge per cm per layer / wheel without G1 */
+    std::array< std::vector<ConcurrentMonitorElement>,7 > Charge_4;   /*!< Charge per cm per layer / wheel without G1 and G1*/
 
-      int m_subdetectorId;
-      int m_subdetectorSide;
-      int m_subdetectorPlane;
-      MonitorElement* m_monitor;
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTIB;   /*!< Charge vs pathlength in TIB */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTOB;   /*!< Charge vs pathlength in TOB */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTIDP;  /*!< Charge vs pathlength in TIDP */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTIDM;  /*!< Charge vs pathlength in TIDM */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTECP1; /*!< Charge vs pathlength in TECP thin */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTECP2; /*!< Charge vs pathlength in TECP thick */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTECM1; /*!< Charge vs pathlength in TECP thin */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTECM2; /*!< Charge vs pathlength in TECP thick */
+    mutable std::atomic<unsigned int> NStripAPVs;
+    mutable std::atomic<unsigned int> NPixelDets;
+    std::vector<std::shared_ptr<stAPVGain> > APVsCollOrdered;
+    std::unordered_map<unsigned int, std::shared_ptr<stAPVGain> > APVsColl; 
 
-    };
+  };
 
-    std::vector<MonitorElement*> FetchMonitor(std::vector<APVmon>, uint32_t, const TrackerTopology* topo=nullptr);
 };
 
 #endif

--- a/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
@@ -1,7 +1,6 @@
 #ifndef CALIBTRACKER_SISTRIPCHANNELGAIN_APVGAINHELPERS_H
 #define CALIBTRACKER_SISTRIPCHANNELGAIN_APVGAINHELPERS_H
 
-
 #include "CalibTracker/SiStripChannelGain/interface/APVGainStruct.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -45,7 +44,7 @@ namespace APVGain {
     }
       
     MonitorElement* getMonitor(){
-      return std::move(m_monitor);
+      return m_monitor;
     }
 
     void printAll(){
@@ -64,10 +63,6 @@ namespace APVGain {
     MonitorElement* m_monitor;
     
   };
-
-  std::vector<MonitorElement*> FetchMonitor(std::vector<APVmon>, uint32_t, const TrackerTopology* topo=nullptr);
-
-  std::vector<unsigned int> FetchIndices(std::map<unsigned int,APVloc>, uint32_t, const TrackerTopology* topo=nullptr);
 
   struct APVGainHistograms {
   public:
@@ -112,6 +107,9 @@ namespace APVGain {
     std::unordered_map<unsigned int, std::shared_ptr<stAPVGain> > APVsColl; 
 
   };
+  
+  std::vector<MonitorElement*> FetchMonitor(std::vector<APVmon>, uint32_t, const TrackerTopology* topo=nullptr);
+  std::vector<unsigned int> FetchIndices(std::map<unsigned int,APVloc>, uint32_t, const TrackerTopology* topo=nullptr);
 
 };
 

--- a/CalibTracker/SiStripChannelGain/interface/APVGainStruct.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainStruct.h
@@ -54,8 +54,6 @@ APVloc(int v1, int v2, int v3,const std::string& s) :
   
 };
 
-
-
 enum statistic_type {None=-1, StdBunch, StdBunch0T, FaABunch, FaABunch0T, IsoBunch, IsoBunch0T, Harvest};
 
 #endif

--- a/CalibTracker/SiStripChannelGain/interface/APVGainStruct.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainStruct.h
@@ -2,6 +2,7 @@
 #define CALIBTRACKER_SISTRIPCHANNELGAIN_STAPVGAIN_H
 
 class TH1F;
+#include <string>
 
 struct stAPVGain{
   unsigned int Index; 
@@ -31,6 +32,29 @@ struct stAPVGain{
   TH1F*        HChargeN;
   bool         isMasked;
 };
+
+struct APVloc{
+    
+public:
+  
+APVloc(int v1, int v2, int v3,const std::string& s) :
+  m_subdetectorId(v1),m_subdetectorSide(v2),m_subdetectorPlane(v3),m_string(s){}
+      
+  int m_subdetectorId;
+  int m_subdetectorSide;
+  int m_subdetectorPlane;
+  std::string m_string;
+
+  bool operator==(const APVloc& a) const
+  {
+    return (m_subdetectorId == a.m_subdetectorId && 
+	    m_subdetectorSide == a.m_subdetectorSide &&
+	    m_subdetectorPlane == a.m_subdetectorPlane);
+  }
+  
+};
+
+
 
 enum statistic_type {None=-1, StdBunch, StdBunch0T, FaABunch, FaABunch0T, IsoBunch, IsoBunch0T, Harvest};
 

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLHarvester.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLHarvester.h
@@ -57,7 +57,6 @@ class SiStripGainsPCLHarvester : public  DQMEDHarvester {
 
       void gainQualityMonitor(DQMStore::IBooker& ibooker_, const MonitorElement* Charge_Vs_Index) const;
 
-
       int statCollectionFromMode(const char* tag) const;
 
       void algoComputeMPVandGain(const MonitorElement* Charge_Vs_Index);
@@ -87,8 +86,6 @@ class SiStripGainsPCLHarvester : public  DQMEDHarvester {
       std::vector<std::string> VChargeHisto;  /*!< Charge monitor plots to be output */
 
       std::vector<std::string> dqm_tag_;  
-
-      
 
       int CalibrationLevel;
 

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
@@ -144,8 +144,9 @@ private:
     std::string CalibPrefix_; //("GainCalibration");
     std::string CalibSuffix_; //("");
 
+    // maps histograms index to topology 
     std::map<unsigned int,APVloc> theTopologyMap;
-    
+
 };
 
 inline int
@@ -162,10 +163,3 @@ SiStripGainsPCLWorker::statCollectionFromMode(const char* tag) const
   return None;
 }
 
-template<typename T>
-inline edm::Handle<T> connectTokens(const T* ptr, edm::EDGetTokenT<T> token,const edm::Event &evt) {
-  edm::Handle<T> handle;
-  evt.getByToken(token, handle);
-  ptr = handle.product();
-  return handle; //return handle to keep alive pointer (safety first)
-}

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
@@ -25,7 +25,7 @@
 #include "CalibTracker/Records/interface/SiStripGainRcd.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 #include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
@@ -48,6 +48,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Framework/interface/ESWatcher.h" 
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
@@ -71,49 +72,24 @@
 // class declaration
 //
 
-class SiStripGainsPCLWorker : public  DQMEDAnalyzer {
+class SiStripGainsPCLWorker : public  DQMGlobalEDAnalyzer<APVGain::APVGainHistograms> {
 public:
     explicit SiStripGainsPCLWorker(const edm::ParameterSet&);
      
+    void bookHistograms(DQMStore::ConcurrentBooker &, edm::Run const&, edm::EventSetup const&, APVGain::APVGainHistograms &) const override;
+    void dqmAnalyze(edm::Event const&, edm::EventSetup const&, APVGain::APVGainHistograms const&) const override;
+
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
     virtual void beginJob() ;
-    void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;   
-    void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
-    void analyze(const edm::Event&, const edm::EventSetup&) override;
+    void dqmBeginRun(edm::Run const&, edm::EventSetup const&, APVGain::APVGainHistograms &) const override;
     virtual void endJob() ;
-    
-    void processEvent(const TrackerTopology* topo); //what really does the job
-    virtual void checkBookAPVColls(const edm::EventSetup& setup);
+    void checkBookAPVColls(const TrackerGeometry *bareTkGeomPtr,APVGain::APVGainHistograms & histograms) const;
 
     std::vector<std::string> dqm_tag_;
 
     int statCollectionFromMode(const char* tag) const;
-
-    std::vector<MonitorElement*>  Charge_Vs_Index;           /*!< Charge per cm for each detector id */
-    std::array< std::vector<APVGain::APVmon>,7 > Charge_1;   /*!< Charge per cm per layer / wheel */
-    std::array< std::vector<APVGain::APVmon>,7 > Charge_2;   /*!< Charge per cm per layer / wheel without G2 */
-    std::array< std::vector<APVGain::APVmon>,7 > Charge_3;   /*!< Charge per cm per layer / wheel without G1 */
-    std::array< std::vector<APVGain::APVmon>,7 > Charge_4;   /*!< Charge per cm per layer / wheel without G1 and G1*/
-
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTIB;   /*!< Charge vs pathlength in TIB */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTOB;   /*!< Charge vs pathlength in TOB */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTIDP;  /*!< Charge vs pathlength in TIDP */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTIDM;  /*!< Charge vs pathlength in TIDM */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTECP1; /*!< Charge vs pathlength in TECP thin */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTECP2; /*!< Charge vs pathlength in TECP thick */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTECM1; /*!< Charge vs pathlength in TECP thin */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTECM2; /*!< Charge vs pathlength in TECP thick */
-
-    unsigned int NEvent;    
-    unsigned int NTrack;
-    unsigned int NClusterStrip;
-    unsigned int NClusterPixel;
-    int NStripAPVs;
-    int NPixelDets;
-    unsigned int SRun;
-    unsigned int ERun;
   
     double       MinTrackMomentum;
     double       MaxTrackMomentum;
@@ -133,43 +109,33 @@ private:
     std::string  m_DQMdir;                  /*!< DQM folder hosting the charge statistics and the monitor plots */
     std::string  m_calibrationMode;         /*!< Type of statistics for the calibration */
     std::vector<std::string> VChargeHisto;  /*!< Charge monitor plots to be output */
-
-    edm::ESHandle<TrackerGeometry> tkGeom_;
-    const TrackerGeometry *bareTkGeomPtr_;   // ugly hack to fill APV colls only once, but checks
-
+  
     //Data members for processing
 
-    //Event data
-    unsigned int                       eventnumber    =0;
-    unsigned int                       runnumber      =0;
-    const std::vector<bool>*           TrigTech       =nullptr;  edm::EDGetTokenT<std::vector<bool>           > TrigTech_token_;
-
-    // Track data
-    const std::vector<double>*         trackchi2ndof  =nullptr;  edm::EDGetTokenT<std::vector<double>         > trackchi2ndof_token_;
-    const std::vector<float>*          trackp         =nullptr;  edm::EDGetTokenT<std::vector<float>          > trackp_token_;
-    const std::vector<float>*          trackpt        =nullptr;  edm::EDGetTokenT<std::vector<float>          > trackpt_token_;
-    const std::vector<double>*         tracketa       =nullptr;  edm::EDGetTokenT<std::vector<double>         > tracketa_token_;
-    const std::vector<double>*         trackphi       =nullptr;  edm::EDGetTokenT<std::vector<double>         > trackphi_token_;
-    const std::vector<unsigned int>*   trackhitsvalid =nullptr;  edm::EDGetTokenT<std::vector<unsigned int>   > trackhitsvalid_token_;
-    const std::vector<int>*            trackalgo      =nullptr;  edm::EDGetTokenT<std::vector<int>   >          trackalgo_token_;
-
-    // CalibTree data
-    const std::vector<int>*            trackindex     =nullptr;  edm::EDGetTokenT<std::vector<int>            > trackindex_token_;
-    const std::vector<unsigned int>*   rawid          =nullptr;  edm::EDGetTokenT<std::vector<unsigned int>   > rawid_token_;
-    const std::vector<double>*         localdirx      =nullptr;  edm::EDGetTokenT<std::vector<double>         > localdirx_token_;
-    const std::vector<double>*         localdiry      =nullptr;  edm::EDGetTokenT<std::vector<double>         > localdiry_token_;
-    const std::vector<double>*         localdirz      =nullptr;  edm::EDGetTokenT<std::vector<double>         > localdirz_token_;
-    const std::vector<unsigned short>* firststrip     =nullptr;  edm::EDGetTokenT<std::vector<unsigned short> > firststrip_token_;
-    const std::vector<unsigned short>* nstrips        =nullptr;  edm::EDGetTokenT<std::vector<unsigned short> > nstrips_token_;
-    const std::vector<bool>*           saturation     =nullptr;  edm::EDGetTokenT<std::vector<bool>           > saturation_token_;
-    const std::vector<bool>*           overlapping    =nullptr;  edm::EDGetTokenT<std::vector<bool>           > overlapping_token_;
-    const std::vector<bool>*           farfromedge    =nullptr;  edm::EDGetTokenT<std::vector<bool>           > farfromedge_token_;
-    const std::vector<unsigned int>*   charge         =nullptr;  edm::EDGetTokenT<std::vector<unsigned int>   > charge_token_;
-    const std::vector<double>*         path           =nullptr;  edm::EDGetTokenT<std::vector<double>         > path_token_;
-    const std::vector<double>*         chargeoverpath =nullptr;  edm::EDGetTokenT<std::vector<double>         > chargeoverpath_token_;
-    const std::vector<unsigned char>*  amplitude      =nullptr;  edm::EDGetTokenT<std::vector<unsigned char>  > amplitude_token_;
-    const std::vector<double>*         gainused       =nullptr;  edm::EDGetTokenT<std::vector<double>         > gainused_token_;
-    const std::vector<double>*         gainusedTick   =nullptr;  edm::EDGetTokenT<std::vector<double>         > gainusedTick_token_;
+    edm::EDGetTokenT<std::vector<bool>           > TrigTech_token_;
+    edm::EDGetTokenT<std::vector<double>         > trackchi2ndof_token_;
+    edm::EDGetTokenT<std::vector<float>          > trackp_token_;
+    edm::EDGetTokenT<std::vector<float>          > trackpt_token_;
+    edm::EDGetTokenT<std::vector<double>         > tracketa_token_;
+    edm::EDGetTokenT<std::vector<double>         > trackphi_token_;
+    edm::EDGetTokenT<std::vector<unsigned int>   > trackhitsvalid_token_;
+    edm::EDGetTokenT<std::vector<int>            > trackalgo_token_;
+    edm::EDGetTokenT<std::vector<int>            > trackindex_token_;
+    edm::EDGetTokenT<std::vector<unsigned int>   > rawid_token_;
+    edm::EDGetTokenT<std::vector<double>         > localdirx_token_;
+    edm::EDGetTokenT<std::vector<double>         > localdiry_token_;
+    edm::EDGetTokenT<std::vector<double>         > localdirz_token_;
+    edm::EDGetTokenT<std::vector<unsigned short> > firststrip_token_;
+    edm::EDGetTokenT<std::vector<unsigned short> > nstrips_token_;
+    edm::EDGetTokenT<std::vector<bool>           > saturation_token_;
+    edm::EDGetTokenT<std::vector<bool>           > overlapping_token_;
+    edm::EDGetTokenT<std::vector<bool>           > farfromedge_token_;
+    edm::EDGetTokenT<std::vector<unsigned int>   > charge_token_;
+    edm::EDGetTokenT<std::vector<double>         > path_token_;
+    edm::EDGetTokenT<std::vector<double>         > chargeoverpath_token_;
+    edm::EDGetTokenT<std::vector<unsigned char>  > amplitude_token_;
+    edm::EDGetTokenT<std::vector<double>         > gainused_token_;
+    edm::EDGetTokenT<std::vector<double>         > gainusedTick_token_;
 
     std::string EventPrefix_; //("");
     std::string EventSuffix_; //("");
@@ -178,8 +144,7 @@ private:
     std::string CalibPrefix_; //("GainCalibration");
     std::string CalibSuffix_; //("");
 
-    std::vector<std::shared_ptr<stAPVGain> > APVsCollOrdered;
-    std::unordered_map<unsigned int, std::shared_ptr<stAPVGain> > APVsColl; 
+    std::map<unsigned int,APVloc> theTopologyMap;
     
 };
 
@@ -198,7 +163,7 @@ SiStripGainsPCLWorker::statCollectionFromMode(const char* tag) const
 }
 
 template<typename T>
-inline edm::Handle<T> connect(const T* &ptr, edm::EDGetTokenT<T> token, const edm::Event &evt) {
+inline edm::Handle<T> connectTokens(const T* ptr, edm::EDGetTokenT<T> token,const edm::Event &evt) {
   edm::Handle<T> handle;
   evt.getByToken(token, handle);
   ptr = handle.product();

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
@@ -82,9 +82,9 @@ public:
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-    virtual void beginJob() ;
+    void beginJob() override ;
     void dqmBeginRun(edm::Run const&, edm::EventSetup const&, APVGain::APVGainHistograms &) const override;
-    virtual void endJob() ;
+    void endJob() override ;
     void checkBookAPVColls(const TrackerGeometry *bareTkGeomPtr,APVGain::APVGainHistograms & histograms) const;
 
     std::vector<std::string> dqm_tag_;
@@ -157,7 +157,7 @@ SiStripGainsPCLWorker::statCollectionFromMode(const char* tag) const
     it++;
   }
   
-  if (std::string(tag)=="") return 0;  // return StdBunch calibration mode for backward compatibility
+  if (std::string(tag).empty()) return 0;  // return StdBunch calibration mode for backward compatibility
   
   return None;
 }

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -319,7 +319,7 @@ SiStripGainFromCalibTree::statCollectionFromMode(const char* tag) const
         it++;
     }
 
-    if (std::string(tag)=="") return 0;  // return StdBunch calibration mode for backward compatibility
+    if (std::string(tag).empty()) return 0;  // return StdBunch calibration mode for backward compatibility
 
     return None;
 }

--- a/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLWorker_cfi.py
+++ b/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLWorker_cfi.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-SiStripGainsPCLWorker = DQMEDAnalyzer(
+SiStripGainsPCLWorker = cms.EDAnalyzer( 
     "SiStripGainsPCLWorker",
     minTrackMomentum    = cms.untracked.double(2),
     maxNrStrips         = cms.untracked.uint32(8),

--- a/CalibTracker/SiStripChannelGain/src/APVGainHelpers.cc
+++ b/CalibTracker/SiStripChannelGain/src/APVGainHelpers.cc
@@ -103,7 +103,6 @@ int APVGain::subdetectorPlane(const std::string& tag) {
 
 /** Brief Fetch the Monitor Element corresponding to a DetId.
  *  */
-
 std::vector<MonitorElement*> APVGain::FetchMonitor(std::vector<APVGain::APVmon> histos, uint32_t det_id, 
 						   const TrackerTopology* topo) {
 				       
@@ -113,13 +112,15 @@ std::vector<MonitorElement*> APVGain::FetchMonitor(std::vector<APVGain::APVmon> 
   int sSide  = APVGain::subdetectorSide(det_id, topo);
   auto it = histos.begin();
 
+  LogDebug("APVGainHelpers")<<"sId: "<<sId<<" sPlane: "<<sPlane<<" sSide: "<<sSide<<std::endl; 
+
   while (it!=histos.end()) {
     std::string tag = (*it).getMonitor()->getName();
     int subdetectorId    = (*it).getSubdetectorId();
     int subdetectorSide  = (*it).getSubdetectorSide();
     int subdetectorPlane = (*it).getSubdetectorPlane();
     
-    bool match = (subdetectorId==0    || subdetectorId==sId) && (subdetectorPlane==0 || subdetectorPlane==sPlane) && (subdetectorSide==0  || subdetectorSide==sSide);
+    bool match = (subdetectorId==0  || subdetectorId==sId) && (subdetectorPlane==0 || subdetectorPlane==sPlane) && (subdetectorSide==0  || subdetectorSide==sSide);
 
     if (match) {
       found.emplace_back((*it).getMonitor());
@@ -153,7 +154,6 @@ std::vector<unsigned int> APVGain::FetchIndices(std::map<unsigned int,APVloc> th
       found_indices.push_back(element.first);
     }
   }
-
   return found_indices;
 }
 

--- a/CalibTracker/SiStripChannelGain/src/APVGainHelpers.cc
+++ b/CalibTracker/SiStripChannelGain/src/APVGainHelpers.cc
@@ -1,9 +1,7 @@
 #include "CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h"
-
 #include "DataFormats/DetId/interface/DetId.h"
 
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-
 
 /** Brief Extract from the DetId the subdetector type.
  * Return an integer which is associated to the subdetector type. The integer
@@ -105,16 +103,15 @@ int APVGain::subdetectorPlane(const std::string& tag) {
 
 /** Brief Fetch the Monitor Element corresponding to a DetId.
  *  */
+
 std::vector<MonitorElement*> APVGain::FetchMonitor(std::vector<APVGain::APVmon> histos, uint32_t det_id, 
 						   const TrackerTopology* topo) {
-
+				       
   std::vector<MonitorElement*> found = std::vector<MonitorElement*>();
   int sId    = APVGain::subdetectorId(det_id);
   int sPlane = APVGain::subdetectorPlane(det_id, topo);
   int sSide  = APVGain::subdetectorSide(det_id, topo);
-  std::vector<APVGain::APVmon>::iterator it= histos.begin();
-    
-  LogDebug("APVGainHelpers")<<"sId: "<<sId<<" sPlane: "<<sPlane<<" sSide: "<<sSide<<std::endl;
+  auto it = histos.begin();
 
   while (it!=histos.end()) {
     std::string tag = (*it).getMonitor()->getName();
@@ -122,10 +119,10 @@ std::vector<MonitorElement*> APVGain::FetchMonitor(std::vector<APVGain::APVmon> 
     int subdetectorSide  = (*it).getSubdetectorSide();
     int subdetectorPlane = (*it).getSubdetectorPlane();
     
-    bool match = (subdetectorId==0 || subdetectorId==sId) && (subdetectorPlane==0 || subdetectorPlane==sPlane) && (subdetectorSide==0  || subdetectorSide==sSide);
+    bool match = (subdetectorId==0    || subdetectorId==sId) && (subdetectorPlane==0 || subdetectorPlane==sPlane) && (subdetectorSide==0  || subdetectorSide==sSide);
 
     if (match) {
-      found.push_back((*it).getMonitor());
+      found.emplace_back((*it).getMonitor());
       LogDebug("APVGainHelpers")<<det_id<<" found: "<< tag << std::endl;
       (*it).printAll();
     }
@@ -134,7 +131,31 @@ std::vector<MonitorElement*> APVGain::FetchMonitor(std::vector<APVGain::APVmon> 
   return found;
 }
 
+/** Brief Fetch the Monitor Element index corresponding to a DetId.
+ *  */
+std::vector<unsigned int> APVGain::FetchIndices(std::map<unsigned int,APVloc> theMap, uint32_t det_id, const TrackerTopology* topo){
 
+  std::vector<unsigned int> found_indices = std::vector<unsigned int>();
+
+  int sId    = APVGain::subdetectorId(det_id);
+  int sPlane = APVGain::subdetectorPlane(det_id, topo);
+  int sSide  = APVGain::subdetectorSide(det_id, topo);
+ 
+  for(auto &element : theMap){
+
+    int subdetectorId    = element.second.m_subdetectorId;
+    int subdetectorSide  = element.second.m_subdetectorSide;
+    int subdetectorPlane = element.second.m_subdetectorPlane;
+
+    bool match = (subdetectorId==0  || subdetectorId==sId) && (subdetectorPlane==0 || subdetectorPlane==sPlane) && (subdetectorSide==0  || subdetectorSide==sSide);
+
+      if (match ){
+      found_indices.push_back(element.first);
+    }
+  }
+
+  return found_indices;
+}
 
 std::vector<std::pair<std::string,std::string>> 
 APVGain::monHnames(std::vector<std::string> VH, bool allPlanes, const char* tag) {

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -26,6 +26,7 @@ SiStripGainsPCLWorker::SiStripGainsPCLWorker(const edm::ParameterSet& iConfig)
   m_calibrationMode       = iConfig.getUntrackedParameter<std::string>  ("calibrationMode"    , "StdBunch");
   VChargeHisto            = iConfig.getUntrackedParameter<std::vector<std::string> >  ("ChargeHisto");
 
+  // fill in the mapping between the histogram indices and the (id,side,plane) tuple
   std::vector<std::pair<std::string,std::string>> hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"");
   for (unsigned int i=0;i<hnames.size();i++){
 
@@ -100,11 +101,11 @@ SiStripGainsPCLWorker::dqmBeginRun(edm::Run const& run, edm::EventSetup const& i
   
   using namespace edm;
   
+  // fills the APV collections at each begin run 
   edm::ESHandle<TrackerGeometry> tkGeom_;
   iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom_ );
   const TrackerGeometry *bareTkGeomPtr = &(*tkGeom_);
-  
-  checkBookAPVColls(bareTkGeomPtr,histograms); // check whether APV colls are booked and do so if not yet done
+  checkBookAPVColls(bareTkGeomPtr,histograms); 
 
   edm::ESHandle<SiStripGain> gainHandle;
   iSetup.get<SiStripGainRcd>().get(gainHandle);
@@ -162,84 +163,84 @@ SiStripGainsPCLWorker::dqmAnalyze(edm::Event const& iEvent, edm::EventSetup cons
   //Event data					       
   
   // Track data					       
-  Handle<const std::vector<double>> handle02;
-  iEvent.getByToken(trackchi2ndof_token_,handle02);
-  auto trackchi2ndof = handle02.product(); 
+  Handle<const std::vector<double>> handle01;
+  iEvent.getByToken(trackchi2ndof_token_,handle01);
+  auto trackchi2ndof = handle01.product(); 
 
-  Handle<const std::vector<float>> handle03;
-  iEvent.getByToken(trackp_token_,handle03);
-  auto trackp = handle03.product(); 
+  Handle<const std::vector<float>> handle02;
+  iEvent.getByToken(trackp_token_,handle02);
+  auto trackp = handle02.product(); 
 
-  Handle<const std::vector<double>> handle05;
-  iEvent.getByToken(tracketa_token_,handle05);
-  auto tracketa = handle05.product(); 
+  Handle<const std::vector<double>> handle03;
+  iEvent.getByToken(tracketa_token_,handle03);
+  auto tracketa = handle03.product(); 
   
-  Handle<const std::vector<unsigned int>> handle07;
-  iEvent.getByToken(trackhitsvalid_token_,handle07);
-  auto trackhitsvalid = handle07.product(); 
+  Handle<const std::vector<unsigned int>> handle04;
+  iEvent.getByToken(trackhitsvalid_token_,handle04);
+  auto trackhitsvalid = handle04.product(); 
 
-  Handle<const std::vector<int>> handle08;
-  iEvent.getByToken(trackalgo_token_,handle08);
-  auto trackalgo = handle08.product(); 
+  Handle<const std::vector<int>> handle05;
+  iEvent.getByToken(trackalgo_token_,handle05);
+  auto trackalgo = handle05.product(); 
 
   // CalibTree data					       
-  Handle<const std::vector<int>> handle09;
-  iEvent.getByToken(trackindex_token_,handle09);
-  auto trackindex = handle09.product(); 
+  Handle<const std::vector<int>> handle06;
+  iEvent.getByToken(trackindex_token_,handle06);
+  auto trackindex = handle06.product(); 
 
-  Handle<const std::vector<unsigned int>> handle10;
-  iEvent.getByToken(rawid_token_,handle10);
-  auto rawid = handle10.product(); 
+  Handle<const std::vector<unsigned int>> handle07;
+  iEvent.getByToken(rawid_token_,handle07);
+  auto rawid = handle07.product(); 
 
-  Handle<const std::vector<unsigned short>> handle14;
-  iEvent.getByToken(firststrip_token_,handle14);
-  auto firststrip = handle14.product(); 
+  Handle<const std::vector<unsigned short>> handle08;
+  iEvent.getByToken(firststrip_token_,handle08);
+  auto firststrip = handle08.product(); 
 
-  Handle<const std::vector<unsigned short>> handle15;
-  iEvent.getByToken(nstrips_token_,handle15);
-  auto nstrips = handle15.product(); 
+  Handle<const std::vector<unsigned short>> handle09;
+  iEvent.getByToken(nstrips_token_,handle09);
+  auto nstrips = handle09.product(); 
 
-  Handle<const std::vector<bool>> handle16;
-  iEvent.getByToken(saturation_token_,handle16);
-  auto saturation = handle16.product(); 
+  Handle<const std::vector<bool>> handle10;
+  iEvent.getByToken(saturation_token_,handle10);
+  auto saturation = handle10.product(); 
 
-  Handle<const std::vector<bool>> handle17;
-  iEvent.getByToken(overlapping_token_,handle17);
-  auto overlapping = handle17.product(); 
+  Handle<const std::vector<bool>> handle11;
+  iEvent.getByToken(overlapping_token_,handle11);
+  auto overlapping = handle11.product(); 
 
-  Handle<const std::vector<bool>> handle18;
-  iEvent.getByToken(farfromedge_token_,handle18);
-  auto farfromedge = handle18.product(); 
+  Handle<const std::vector<bool>> handle12;
+  iEvent.getByToken(farfromedge_token_,handle12);
+  auto farfromedge = handle12.product(); 
 
-  Handle<const std::vector<unsigned int>> handle19;
-  iEvent.getByToken(charge_token_,handle19);
-  auto charge = handle19.product(); 
+  Handle<const std::vector<unsigned int>> handle13;
+  iEvent.getByToken(charge_token_,handle13);
+  auto charge = handle13.product(); 
 
-  Handle<const std::vector<double>> handle20;
-  iEvent.getByToken(path_token_,handle20);
-  auto path = handle20.product(); 
+  Handle<const std::vector<double>> handle14;
+  iEvent.getByToken(path_token_,handle14);
+  auto path = handle14.product(); 
 
-  Handle<const std::vector<double>> handle21;
-  iEvent.getByToken(chargeoverpath_token_,handle21);
-  auto chargeoverpath = handle21.product();
+  Handle<const std::vector<double>> handle15;
+  iEvent.getByToken(chargeoverpath_token_,handle15);
+  auto chargeoverpath = handle15.product();
 
-  Handle<const std::vector<unsigned char>> handle23;
-  iEvent.getByToken(amplitude_token_,handle23);
-  auto amplitude = handle23.product(); 
+  Handle<const std::vector<unsigned char>> handle16;
+  iEvent.getByToken(amplitude_token_,handle16);
+  auto amplitude = handle16.product(); 
 
-  Handle<const std::vector<double>> handle24;
-  iEvent.getByToken(gainused_token_,handle24);
-  auto gainused = handle24.product(); 
+  Handle<const std::vector<double>> handle17;
+  iEvent.getByToken(gainused_token_,handle17);
+  auto gainused = handle17.product(); 
 
-  Handle<const std::vector<double>> handle25;
-  iEvent.getByToken(gainusedTick_token_,handle25);
-  auto gainusedTick = handle25.product(); 
+  Handle<const std::vector<double>> handle18;
+  iEvent.getByToken(gainusedTick_token_,handle18);
+  auto gainusedTick = handle18.product(); 
 
   for (const auto &elem : theTopologyMap){
     LogDebug("SiStripGainsPCLWorker") << elem.first << " - " << elem.second.m_string << " " << elem.second.m_subdetectorId << " " << elem.second.m_subdetectorSide << " " << elem.second.m_subdetectorPlane << std::endl;
   }
 
-  edm::LogInfo("SiStripGainsPCLWorker") <<"for mode"<< m_calibrationMode <<std::endl;
+  LogDebug("SiStripGainsPCLWorker") <<"for mode"<< m_calibrationMode <<std::endl;
 
   int elepos = statCollectionFromMode(m_calibrationMode.c_str());
   
@@ -542,9 +543,6 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::ConcurrentBooker & ibooker, edm:
   histograms.Charge_Vs_PathlengthTECM1.reserve(dqm_tag_.size());
   histograms.Charge_Vs_PathlengthTECM2.reserve(dqm_tag_.size());
 
-  edm::LogInfo("SiStripGainsPCLWorker")<<" for mode"<< m_calibrationMode 
-				       <<" check-point 1: elepos"<< elepos << std::endl; 
-
   // The cluster charge is stored by exploiting a non uniform binning in order 
   // reduce the histogram memory size. The bin width is relaxed with a falling
   // exponential function and the bin boundaries are stored in the binYarray. 
@@ -608,7 +606,6 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::ConcurrentBooker & ibooker, edm:
   for (unsigned int i=0;i<hnames.size();i++){
     std::string htag = (hnames[i]).first + stag;
     histograms.Charge_1[elepos].push_back(ibooker.book1DD( htag.c_str(), (hnames[i]).second.c_str(), 100   , 0. , 1000. ));
-
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG2");
@@ -621,7 +618,6 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::ConcurrentBooker & ibooker, edm:
   for (unsigned int i=0;i<hnames.size();i++){
     std::string htag = (hnames[i]).first + stag;
     histograms.Charge_3[elepos].push_back(ibooker.book1DD( htag.c_str(), (hnames[i]).second.c_str(), 100   , 0. , 1000. ));
-
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG1G2");
@@ -629,5 +625,4 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::ConcurrentBooker & ibooker, edm:
     std::string htag = (hnames[i]).first + stag;   
     histograms.Charge_4[elepos].push_back(ibooker.book1DD( htag.c_str(), (hnames[i]).second.c_str(), 100   , 0. , 1000. ));
   }
-  
 }

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -100,6 +100,12 @@ SiStripGainsPCLWorker::dqmBeginRun(edm::Run const& run, edm::EventSetup const& i
   
   using namespace edm;
   
+  edm::ESHandle<TrackerGeometry> tkGeom_;
+  iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom_ );
+  const TrackerGeometry *bareTkGeomPtr = &(*tkGeom_);
+  
+  checkBookAPVColls(bareTkGeomPtr,histograms); // check whether APV colls are booked and do so if not yet done
+
   edm::ESHandle<SiStripGain> gainHandle;
   iSetup.get<SiStripGainRcd>().get(gainHandle);
   if(!gainHandle.isValid()){edm::LogError("SiStripGainPCLWorker")<< "gainHandle is not valid\n"; exit(0);}
@@ -297,9 +303,12 @@ SiStripGainsPCLWorker::dqmAnalyze(edm::Event const& iEvent, edm::EventSetup cons
 				      <<" i "<< i
 				      <<" useCalibration "<< useCalibration
 				      <<" FirstSetOfConstants "<< FirstSetOfConstants
+				      <<" APV->PreviousGain " << APV->PreviousGain
+				      <<" APV->CalibGain " << APV->CalibGain
 				      <<" APV->DetId "<< APV->DetId
 				      <<" APV->Index "<< APV->Index 
 				      <<" Charge "<< Charge
+				      <<" Path "<< (*path)[i]
 				      <<" ClusterChargeOverPath "<< ClusterChargeOverPath
 				      <<std::endl;
     
@@ -498,12 +507,6 @@ SiStripGainsPCLWorker::fillDescriptions(edm::ConfigurationDescriptions& descript
 //********************************************************************************//
 void 
 SiStripGainsPCLWorker::bookHistograms(DQMStore::ConcurrentBooker & ibooker, edm::Run const& run, edm::EventSetup const& setup, APVGain::APVGainHistograms & histograms) const {
-
-  edm::ESHandle<TrackerGeometry> tkGeom_;
-  setup.get<TrackerDigiGeometryRecord>().get( tkGeom_ );
-  const TrackerGeometry *bareTkGeomPtr = &(*tkGeom_);
-
-  checkBookAPVColls(bareTkGeomPtr,histograms); // check whether APV colls are booked and do so if not yet done
 
   ibooker.cd();
   std::string dqm_dir = m_DQMdir;

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -6,18 +6,8 @@
 #include <sstream>
 
 //********************************************************************************//
-SiStripGainsPCLWorker::SiStripGainsPCLWorker(const edm::ParameterSet& iConfig) :
-  NEvent(0),
-  NTrack(0),
-  NClusterStrip(0),
-  NClusterPixel(0),
-  NStripAPVs(0),
-  NPixelDets(0),
-  SRun(1<<31),
-  ERun(0),
-  bareTkGeomPtr_(nullptr)
-{
-  
+SiStripGainsPCLWorker::SiStripGainsPCLWorker(const edm::ParameterSet& iConfig) 
+{  
   MinTrackMomentum        = iConfig.getUntrackedParameter<double>  ("minTrackMomentum"        ,  3.0);
   MaxTrackMomentum        = iConfig.getUntrackedParameter<double>  ("maxTrackMomentum"        ,  99999.0);
   MinTrackEta             = iConfig.getUntrackedParameter<double>  ("minTrackEta"             , -5.0);
@@ -36,6 +26,18 @@ SiStripGainsPCLWorker::SiStripGainsPCLWorker(const edm::ParameterSet& iConfig) :
   m_calibrationMode       = iConfig.getUntrackedParameter<std::string>  ("calibrationMode"    , "StdBunch");
   VChargeHisto            = iConfig.getUntrackedParameter<std::vector<std::string> >  ("ChargeHisto");
 
+  std::vector<std::pair<std::string,std::string>> hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"");
+  for (unsigned int i=0;i<hnames.size();i++){
+
+    int id    = APVGain::subdetectorId((hnames[i]).first);
+    int side  = APVGain::subdetectorSide((hnames[i]).first);
+    int plane = APVGain::subdetectorPlane((hnames[i]).first);
+    std::string s = hnames[i].first;
+
+    auto loc = APVloc(id,side,plane,s);
+    theTopologyMap.insert(std::make_pair(i,loc));
+  }
+
   //Set the monitoring element tag and store
   dqm_tag_.reserve(7);
   dqm_tag_.clear();
@@ -47,16 +49,6 @@ SiStripGainsPCLWorker::SiStripGainsPCLWorker(const edm::ParameterSet& iConfig) :
   dqm_tag_.push_back( "IsoMuon0T" );     // statistic collection from Isolated Muon @ 0 T
   dqm_tag_.push_back( "Harvest" );       // statistic collection: Harvest
   
-  Charge_Vs_Index.insert( Charge_Vs_Index.begin(), dqm_tag_.size(), nullptr);
-  Charge_Vs_PathlengthTIB.insert( Charge_Vs_PathlengthTIB.begin(), dqm_tag_.size(), nullptr);
-  Charge_Vs_PathlengthTOB.insert( Charge_Vs_PathlengthTOB.begin(), dqm_tag_.size(), nullptr);
-  Charge_Vs_PathlengthTIDP.insert( Charge_Vs_PathlengthTIDP.begin(), dqm_tag_.size(), nullptr);
-  Charge_Vs_PathlengthTIDM.insert( Charge_Vs_PathlengthTIDM.begin(), dqm_tag_.size(), nullptr);
-  Charge_Vs_PathlengthTECP1.insert( Charge_Vs_PathlengthTECP1.begin(), dqm_tag_.size(), nullptr);
-  Charge_Vs_PathlengthTECP2.insert( Charge_Vs_PathlengthTECP2.begin(), dqm_tag_.size(), nullptr);
-  Charge_Vs_PathlengthTECM1.insert( Charge_Vs_PathlengthTECM1.begin(), dqm_tag_.size(), nullptr);
-  Charge_Vs_PathlengthTECM2.insert( Charge_Vs_PathlengthTECM2.begin(), dqm_tag_.size(), nullptr);
-
   // configure token for gathering the ntuple variables 
   edm::ParameterSet swhallowgain_pset = iConfig.getUntrackedParameter<edm::ParameterSet>("gain");
 
@@ -104,11 +96,9 @@ SiStripGainsPCLWorker::SiStripGainsPCLWorker(const edm::ParameterSet& iConfig) :
 
 //********************************************************************************//
 void 
-SiStripGainsPCLWorker::dqmBeginRun(edm::Run const& run, const edm::EventSetup& iSetup){
+SiStripGainsPCLWorker::dqmBeginRun(edm::Run const& run, edm::EventSetup const& iSetup, APVGain::APVGainHistograms & histograms) const {
   
   using namespace edm;
-
-  this->checkBookAPVColls(iSetup); // check whether APV colls are booked and do so if not yet done
   
   edm::ESHandle<SiStripGain> gainHandle;
   iSetup.get<SiStripGainRcd>().get(gainHandle);
@@ -117,9 +107,9 @@ SiStripGainsPCLWorker::dqmBeginRun(edm::Run const& run, const edm::EventSetup& i
   edm::ESHandle<SiStripQuality> SiStripQuality_;
   iSetup.get<SiStripQualityRcd>().get(SiStripQuality_);
 
-  for(unsigned int a=0;a<APVsCollOrdered.size();a++){
+  for(unsigned int a=0;a<histograms.APVsCollOrdered.size();a++){
 
-    std::shared_ptr<stAPVGain> APV = APVsCollOrdered[a];
+    std::shared_ptr<stAPVGain> APV = histograms.APVsCollOrdered[a];
 
     if(APV->SubDet==PixelSubdetector::PixelBarrel || APV->SubDet==PixelSubdetector::PixelEndcap) continue;
     
@@ -144,75 +134,111 @@ SiStripGainsPCLWorker::dqmBeginRun(edm::Run const& run, const edm::EventSetup& i
 //********************************************************************************//
 // ------------ method called for each event  ------------
 void
-SiStripGainsPCLWorker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+SiStripGainsPCLWorker::dqmAnalyze(edm::Event const& iEvent, edm::EventSetup const& iSetup,  APVGain::APVGainHistograms const& histograms) const 
 {
   using namespace edm;
 
-  //  this->checkBookAPVColls(iSetup); // check whether APV colls are booked and do so if not yet done
-
-  eventnumber   = iEvent.id().event();
-  runnumber     = iEvent.id().run();
-
-  auto handle01 = connect(TrigTech      , TrigTech_token_      , iEvent);
-  auto handle02 = connect(trackchi2ndof , trackchi2ndof_token_ , iEvent);
-  auto handle03 = connect(trackp        , trackp_token_        , iEvent);
-  auto handle04 = connect(trackpt       , trackpt_token_       , iEvent);
-  auto handle05 = connect(tracketa      , tracketa_token_      , iEvent);
-  auto handle06 = connect(trackphi      , trackphi_token_      , iEvent);
-  auto handle07 = connect(trackhitsvalid, trackhitsvalid_token_, iEvent);
-  auto handle08 = connect(trackindex    , trackindex_token_    , iEvent);
-  auto handle09 = connect(rawid         , rawid_token_         , iEvent);
-  auto handle11 = connect(localdirx     , localdirx_token_     , iEvent);
-  auto handle12 = connect(localdiry     , localdiry_token_     , iEvent);
-  auto handle13 = connect(localdirz     , localdirz_token_     , iEvent);
-  auto handle14 = connect(firststrip    , firststrip_token_    , iEvent);
-  auto handle15 = connect(nstrips       , nstrips_token_       , iEvent);
-  auto handle16 = connect(saturation    , saturation_token_    , iEvent);
-  auto handle17 = connect(overlapping   , overlapping_token_   , iEvent);
-  auto handle18 = connect(farfromedge   , farfromedge_token_   , iEvent);
-  auto handle19 = connect(charge        , charge_token_        , iEvent);
-  auto handle21 = connect(path          , path_token_          , iEvent);
-  auto handle22 = connect(chargeoverpath, chargeoverpath_token_, iEvent);
-  auto handle23 = connect(amplitude     , amplitude_token_     , iEvent);
-  auto handle24 = connect(gainused      , gainused_token_      , iEvent);
-  auto handle25 = connect(gainusedTick  , gainusedTick_token_  , iEvent);
-  auto handle26 = connect(trackalgo     , trackalgo_token_     , iEvent);
- 
+  unsigned int eventnumber = iEvent.id().event();
+  unsigned int runnumber   = iEvent.id().run();
+  
+  edm::LogInfo("SiStripGainsPCLWorker") << "Processing run " << runnumber 
+					<< " and event " << eventnumber 
+					<< std::endl;
+   
   edm::ESHandle<TrackerTopology> TopoHandle;
   iSetup.get<TrackerTopologyRcd>().get( TopoHandle );
   const TrackerTopology* topo = TopoHandle.product();
 
-  processEvent(topo);
+  // *****************************
+  // * Event data handles
+  // *****************************
 
-}
-
-//********************************************************************************//
-void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
-
-  edm::LogInfo("SiStripGainsPCLWorker") << "Processing run " << runnumber 
-					<< " and event " << eventnumber 
-					<< std::endl;
-
-  if(runnumber<SRun)SRun=runnumber;
-  if(runnumber>ERun)ERun=runnumber;
+  //Event data					       
   
-  NEvent++;
-  NTrack+=(*trackp).size();
+  // Track data					       
+  Handle<const std::vector<double>> handle02;
+  iEvent.getByToken(trackchi2ndof_token_,handle02);
+  auto trackchi2ndof = handle02.product(); 
 
-  LogDebug("SiStripGainsPCLWorker")
-    <<"for mode"<< m_calibrationMode 
-    <<" Nevent:"<<NEvent 
-    <<" NTrack:"<<NTrack
-    <<" NClusterStrip:"<<NClusterStrip
-    <<" NClusterPixel:"<<NClusterPixel
-    <<" NStripAPVs:"<<NStripAPVs
-    <<" NPixelDets:"<<NPixelDets
-    <<std::endl;
+  Handle<const std::vector<float>> handle03;
+  iEvent.getByToken(trackp_token_,handle03);
+  auto trackp = handle03.product(); 
+
+  Handle<const std::vector<double>> handle05;
+  iEvent.getByToken(tracketa_token_,handle05);
+  auto tracketa = handle05.product(); 
+  
+  Handle<const std::vector<unsigned int>> handle07;
+  iEvent.getByToken(trackhitsvalid_token_,handle07);
+  auto trackhitsvalid = handle07.product(); 
+
+  Handle<const std::vector<int>> handle08;
+  iEvent.getByToken(trackalgo_token_,handle08);
+  auto trackalgo = handle08.product(); 
+
+  // CalibTree data					       
+  Handle<const std::vector<int>> handle09;
+  iEvent.getByToken(trackindex_token_,handle09);
+  auto trackindex = handle09.product(); 
+
+  Handle<const std::vector<unsigned int>> handle10;
+  iEvent.getByToken(rawid_token_,handle10);
+  auto rawid = handle10.product(); 
+
+  Handle<const std::vector<unsigned short>> handle14;
+  iEvent.getByToken(firststrip_token_,handle14);
+  auto firststrip = handle14.product(); 
+
+  Handle<const std::vector<unsigned short>> handle15;
+  iEvent.getByToken(nstrips_token_,handle15);
+  auto nstrips = handle15.product(); 
+
+  Handle<const std::vector<bool>> handle16;
+  iEvent.getByToken(saturation_token_,handle16);
+  auto saturation = handle16.product(); 
+
+  Handle<const std::vector<bool>> handle17;
+  iEvent.getByToken(overlapping_token_,handle17);
+  auto overlapping = handle17.product(); 
+
+  Handle<const std::vector<bool>> handle18;
+  iEvent.getByToken(farfromedge_token_,handle18);
+  auto farfromedge = handle18.product(); 
+
+  Handle<const std::vector<unsigned int>> handle19;
+  iEvent.getByToken(charge_token_,handle19);
+  auto charge = handle19.product(); 
+
+  Handle<const std::vector<double>> handle20;
+  iEvent.getByToken(path_token_,handle20);
+  auto path = handle20.product(); 
+
+  Handle<const std::vector<double>> handle21;
+  iEvent.getByToken(chargeoverpath_token_,handle21);
+  auto chargeoverpath = handle21.product();
+
+  Handle<const std::vector<unsigned char>> handle23;
+  iEvent.getByToken(amplitude_token_,handle23);
+  auto amplitude = handle23.product(); 
+
+  Handle<const std::vector<double>> handle24;
+  iEvent.getByToken(gainused_token_,handle24);
+  auto gainused = handle24.product(); 
+
+  Handle<const std::vector<double>> handle25;
+  iEvent.getByToken(gainusedTick_token_,handle25);
+  auto gainusedTick = handle25.product(); 
+
+  for (const auto &elem : theTopologyMap){
+    LogDebug("SiStripGainsPCLWorker") << elem.first << " - " << elem.second.m_string << " " << elem.second.m_subdetectorId << " " << elem.second.m_subdetectorSide << " " << elem.second.m_subdetectorPlane << std::endl;
+  }
+
+  edm::LogInfo("SiStripGainsPCLWorker") <<"for mode"<< m_calibrationMode <<std::endl;
 
   int elepos = statCollectionFromMode(m_calibrationMode.c_str());
   
   unsigned int FirstAmplitude=0;
-  for(unsigned int i=0;i<(*chargeoverpath).size();i++){
+  for(unsigned int i=0;i<chargeoverpath->size();i++){
     
     FirstAmplitude+=(*nstrips)[i];
     int    TI = (*trackindex)[i];
@@ -225,19 +251,13 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
     if((*trackchi2ndof )[TI]  > MaxTrackChiOverNdf   )continue;
     if((*trackalgo     )[TI]  > MaxTrackingIteration )continue;
 
-    std::shared_ptr<stAPVGain> APV = APVsColl[((*rawid)[i]<<4) | ((*firststrip)[i]/128)];   //works for both strip and pixel thanks to firstStrip encoding for pixel in the calibTree
+    std::shared_ptr<stAPVGain> APV = histograms.APVsColl.at(((*rawid)[i]<<4) | ((*firststrip)[i]/128));   //works for both strip and pixel thanks to firstStrip encoding for pixel in the calibTree
     
     if(APV->SubDet>2 && (*farfromedge)[i]        == false           )continue;
     if(APV->SubDet>2 && (*overlapping)[i]        == true            )continue;
     if(APV->SubDet>2 && (*saturation )[i]        && !AllowSaturation)continue;
     if(APV->SubDet>2 && (*nstrips    )[i]      > MaxNrStrips        )continue;
-    
-    if(APV->SubDet>2){
-      NClusterStrip++;
-    } else {
-      NClusterPixel++;
-    }
-    
+       
     int Charge = 0;
     if(APV->SubDet>2 && (useCalibration || !FirstSetOfConstants)){
       bool Saturation = false;
@@ -272,11 +292,9 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
     if(APV->SubDet<=2) continue;
 
     // real histogram for calibration
-    (Charge_Vs_Index[elepos])->Fill(APV->Index,ClusterChargeOverPath);
-
+    histograms.Charge_Vs_Index[elepos].fill(APV->Index,ClusterChargeOverPath);
     LogDebug("SiStripGainsPCLWorker") <<" for mode "<< m_calibrationMode << "\n"
 				      <<" i "<< i
-				      <<" NClusterStrip "<< NClusterStrip
 				      <<" useCalibration "<< useCalibration
 				      <<" FirstSetOfConstants "<< FirstSetOfConstants
 				      <<" APV->DetId "<< APV->DetId
@@ -311,47 +329,41 @@ void SiStripGainsPCLWorker::processEvent(const TrackerTopology* topo) {
 				      <<" remove G1 "<< mCharge3
 				      <<" remove G1*G2 "<< mCharge4
 				      <<std::endl;
-    
-    std::vector<MonitorElement*> cmon1 = APVGain::FetchMonitor(Charge_1[elepos], (*rawid)[i], topo);
-    for(unsigned int m=0; m<cmon1.size(); m++) cmon1[m]->Fill(( (double) mCharge1 )/(*path)[i]);
 
-    std::vector<MonitorElement*> cmon2 = APVGain::FetchMonitor(Charge_2[elepos], (*rawid)[i], topo);
-    for(unsigned int m=0; m<cmon2.size(); m++) cmon2[m]->Fill(( (double) mCharge2 )/(*path)[i]);
+    auto indices = APVGain::FetchIndices(theTopologyMap,(*rawid)[i], topo);
 
-    std::vector<MonitorElement*> cmon3 = APVGain::FetchMonitor(Charge_3[elepos], (*rawid)[i], topo);
-    for(unsigned int m=0; m<cmon3.size(); m++) cmon3[m]->Fill(( (double) mCharge3 )/(*path)[i]);
-
-    std::vector<MonitorElement*> cmon4 = APVGain::FetchMonitor(Charge_4[elepos], (*rawid)[i], topo);
-    for(unsigned int m=0; m<cmon4.size(); m++) cmon4[m]->Fill(( (double) mCharge4 )/(*path)[i]);
+    for(auto m : indices) histograms.Charge_1[elepos][m].fill(( (double) mCharge1 )/(*path)[i]);
+    for(auto m : indices) histograms.Charge_2[elepos][m].fill(( (double) mCharge2 )/(*path)[i]);
+    for(auto m : indices) histograms.Charge_3[elepos][m].fill(( (double) mCharge3 )/(*path)[i]);
+    for(auto m : indices) histograms.Charge_4[elepos][m].fill(( (double) mCharge4 )/(*path)[i]);
 
     if(APV->SubDet==StripSubdetector::TIB){
-      (Charge_Vs_PathlengthTIB[elepos])->Fill((*path)[i],Charge);  // TIB
+      histograms.Charge_Vs_PathlengthTIB[elepos].fill((*path)[i],Charge);  // TIB
 
     }else if(APV->SubDet==StripSubdetector::TOB){
-      (Charge_Vs_PathlengthTOB[elepos])->Fill((*path)[i],Charge);  // TOB
+      histograms.Charge_Vs_PathlengthTOB[elepos].fill((*path)[i],Charge);  // TOB
 
     }else if(APV->SubDet==StripSubdetector::TID){
-      if(APV->Eta<0)     { (Charge_Vs_PathlengthTIDM[elepos])->Fill((*path)[i],Charge); }  // TID minus
-      else if(APV->Eta>0){ (Charge_Vs_PathlengthTIDP[elepos])->Fill((*path)[i],Charge); }  // TID plus
+      if(APV->Eta<0)     { histograms.Charge_Vs_PathlengthTIDM[elepos].fill((*path)[i],Charge); }  // TID minus
+      else if(APV->Eta>0){ histograms.Charge_Vs_PathlengthTIDP[elepos].fill((*path)[i],Charge); }  // TID plus
 
     }else if(APV->SubDet==StripSubdetector::TEC){
       if(APV->Eta<0){
-        if(APV->Thickness<0.04)     { (Charge_Vs_PathlengthTECM1[elepos])->Fill((*path)[i],Charge); } // TEC minus, type 1
-        else if(APV->Thickness>0.04){ (Charge_Vs_PathlengthTECM2[elepos])->Fill((*path)[i],Charge); } // TEC minus, type 2
+        if(APV->Thickness<0.04)     { histograms.Charge_Vs_PathlengthTECM1[elepos].fill((*path)[i],Charge); } // TEC minus, type 1
+        else if(APV->Thickness>0.04){ histograms.Charge_Vs_PathlengthTECM2[elepos].fill((*path)[i],Charge); } // TEC minus, type 2
       } else if(APV->Eta>0){
-        if(APV->Thickness<0.04)     { (Charge_Vs_PathlengthTECP1[elepos])->Fill((*path)[i],Charge); } // TEC plus, type 1
-        else if(APV->Thickness>0.04){ (Charge_Vs_PathlengthTECP2[elepos])->Fill((*path)[i],Charge); } // TEC plus, type 2
+        if(APV->Thickness<0.04)     { histograms.Charge_Vs_PathlengthTECP1[elepos].fill((*path)[i],Charge); } // TEC plus, type 1
+        else if(APV->Thickness>0.04){ histograms.Charge_Vs_PathlengthTECP2[elepos].fill((*path)[i],Charge); } // TEC plus, type 2
       }
     }
 
   }// END OF ON-CLUSTER LOOP
 
-  LogDebug("SiStripGainsPCLWorker")<<" for mode"<< m_calibrationMode 
-				   <<" entries in histogram:"<< (Charge_Vs_Index[elepos])->getTH2S()->GetEntries()
-				   <<std::endl;
+  //LogDebug("SiStripGainsPCLWorker")<<" for mode"<< m_calibrationMode 
+  //				   <<" entries in histogram:"<< histograms.Charge_Vs_Index[elepos].getEntries()
+  //				   <<std::endl;
 
-}//END OF processEvent()
-
+}
 
 //********************************************************************************//
 void 
@@ -362,17 +374,12 @@ SiStripGainsPCLWorker::beginJob()
 //********************************************************************************//
 // ------------ method called once each job just before starting event loop  ------------
 void
-SiStripGainsPCLWorker::checkBookAPVColls(const edm::EventSetup& es){
-
-  es.get<TrackerDigiGeometryRecord>().get( tkGeom_ );
-  const TrackerGeometry *newBareTkGeomPtr = &(*tkGeom_);
-  if (newBareTkGeomPtr == bareTkGeomPtr_) return; // already filled APVColls, nothing changed
-
-  if (!bareTkGeomPtr_) { // pointer not yet set: called the first time => fill the APVColls
-    auto const & Det = newBareTkGeomPtr->dets();
+SiStripGainsPCLWorker::checkBookAPVColls(const TrackerGeometry *bareTkGeomPtr,APVGain::APVGainHistograms & histograms) const
+{
+  if (bareTkGeomPtr) { // pointer not yet set: called the first time => fill the APVColls
+    auto const & Det = bareTkGeomPtr->dets();
     
-    edm::LogInfo("SiStripGainsPCLWorker")
-      <<" Resetting APV struct"<<std::endl;
+    edm::LogInfo("SiStripGainsPCLWorker") <<" Resetting APV struct"<<std::endl;
 
     unsigned int Index=0;
 
@@ -416,10 +423,10 @@ SiStripGainsPCLWorker::checkBookAPVColls(const edm::EventSetup& es){
 	  APV->NEntries      = 0;
 	  APV->isMasked      = false;
 	  
-	  APVsCollOrdered.push_back(APV);
-	  APVsColl[(APV->DetId<<4) | APV->APVId] = APV;
+	  histograms.APVsCollOrdered.push_back(APV);
+	  histograms.APVsColl[(APV->DetId<<4) | APV->APVId] = APV;
 	  Index++;
-	  NStripAPVs++;
+	  histograms.NStripAPVs++;
 	} // loop on APVs
       } // if is Strips
     } // loop on dets
@@ -462,19 +469,17 @@ SiStripGainsPCLWorker::checkBookAPVColls(const edm::EventSetup& es){
 	    APV->isMasked      = false; //SiPixelQuality_->IsModuleBad(Detid.rawId());
 	    APV->NEntries      = 0;
 	    
-	    APVsCollOrdered.push_back(APV);
-	    APVsColl[(APV->DetId<<4) | APV->APVId] = APV;
+	    histograms.APVsCollOrdered.push_back(APV);
+	    histograms.APVsColl[(APV->DetId<<4) | APV->APVId] = APV;
 	    Index++;
-	    NPixelDets++;
+	    histograms.NPixelDets++;
 
 	  } // loop on ROC cols
 	} // loop on ROC rows
       } // if Pixel
     } // loop on Dets  
   }  //if (!bareTkGeomPtr_) ...
-  bareTkGeomPtr_ = newBareTkGeomPtr;
 }
-
 
 //********************************************************************************//
 void 
@@ -492,7 +497,13 @@ SiStripGainsPCLWorker::fillDescriptions(edm::ConfigurationDescriptions& descript
 
 //********************************************************************************//
 void 
-SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & run, edm::EventSetup const & es){
+SiStripGainsPCLWorker::bookHistograms(DQMStore::ConcurrentBooker & ibooker, edm::Run const& run, edm::EventSetup const& setup, APVGain::APVGainHistograms & histograms) const {
+
+  edm::ESHandle<TrackerGeometry> tkGeom_;
+  setup.get<TrackerDigiGeometryRecord>().get( tkGeom_ );
+  const TrackerGeometry *bareTkGeomPtr = &(*tkGeom_);
+
+  checkBookAPVColls(bareTkGeomPtr,histograms); // check whether APV colls are booked and do so if not yet done
 
   ibooker.cd();
   std::string dqm_dir = m_DQMdir;
@@ -517,6 +528,19 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
   std::string cvpTECM2 = std::string("Charge_Vs_PathlengthTECM2") + stag;
   
   int elepos = statCollectionFromMode(tag);
+  
+  histograms.Charge_Vs_Index.reserve(dqm_tag_.size());
+  histograms.Charge_Vs_PathlengthTIB.reserve(dqm_tag_.size());
+  histograms.Charge_Vs_PathlengthTOB.reserve(dqm_tag_.size());
+  histograms.Charge_Vs_PathlengthTIDP.reserve(dqm_tag_.size());
+  histograms.Charge_Vs_PathlengthTIDM.reserve(dqm_tag_.size());
+  histograms.Charge_Vs_PathlengthTECP1.reserve(dqm_tag_.size());
+  histograms.Charge_Vs_PathlengthTECP2.reserve(dqm_tag_.size());
+  histograms.Charge_Vs_PathlengthTECM1.reserve(dqm_tag_.size());
+  histograms.Charge_Vs_PathlengthTECM2.reserve(dqm_tag_.size());
+
+  edm::LogInfo("SiStripGainsPCLWorker")<<" for mode"<< m_calibrationMode 
+				       <<" check-point 1: elepos"<< elepos << std::endl; 
 
   // The cluster charge is stored by exploiting a non uniform binning in order 
   // reduce the histogram memory size. The bin width is relaxed with a falling
@@ -527,12 +551,11 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
   // https://indico.cern.ch/event/649344/contributions/2672267/attachments/1498323/2332518/OptimizeChHisto.pdf
 
   std::vector<float> binXarray;
-  binXarray.reserve( NStripAPVs+1 );
-  for(int a=0;a<=NStripAPVs;a++){
+  binXarray.reserve( histograms.NStripAPVs+1 );
+  for(unsigned int a=0;a<=histograms.NStripAPVs;a++){
      binXarray.push_back( (float)a );
   }
-
-
+  
   std::array<float,688> binYarray;
   double p0 = 5.445;
   double p1 = 0.002113;
@@ -544,59 +567,64 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
      else y = ( p0 - log(exp(p0-p1*y) - p2*p1)) / p1;
   }
   binYarray[687] = 4000.;
+
+  histograms.Charge_1[elepos].clear();
+  histograms.Charge_2[elepos].clear();
+  histograms.Charge_3[elepos].clear();
+  histograms.Charge_4[elepos].clear();
+
+
+  auto it = histograms.Charge_Vs_Index.begin();
+  histograms.Charge_Vs_Index.insert(it+elepos,ibooker.book2S(cvi.c_str()     , cvi.c_str()     , histograms.NStripAPVs, &binXarray[0], 687, binYarray.data()));
+
+  it = histograms.Charge_Vs_PathlengthTIB.begin();
+  histograms.Charge_Vs_PathlengthTIB.insert(it+elepos,ibooker.book2S(cvpTIB.c_str()  , cvpTIB.c_str()  , 20   , 0.3 , 1.3  , 250,0,2000));
+
+  it = histograms.Charge_Vs_PathlengthTOB.begin();
+  histograms.Charge_Vs_PathlengthTOB.insert(it+elepos,ibooker.book2S(cvpTOB.c_str()  , cvpTOB.c_str()  , 20   , 0.3 , 1.3  , 250,0,2000));  
+
+  it = histograms.Charge_Vs_PathlengthTIDP.begin();
+  histograms.Charge_Vs_PathlengthTIDP.insert(it+elepos,ibooker.book2S(cvpTIDP.c_str() , cvpTIDP.c_str() , 20   , 0.3 , 1.3  , 250,0,2000));
+
+  it = histograms.Charge_Vs_PathlengthTIDM.begin();
+  histograms.Charge_Vs_PathlengthTIDM.insert(it+elepos,ibooker.book2S(cvpTIDM.c_str() , cvpTIDM.c_str() , 20   , 0.3 , 1.3  , 250,0,2000));
+
+  it = histograms.Charge_Vs_PathlengthTECP1.begin();
+  histograms.Charge_Vs_PathlengthTECP1.insert(it+elepos,ibooker.book2S(cvpTECP1.c_str(), cvpTECP1.c_str(), 20   , 0.3 , 1.3  , 250,0,2000));
+
+  it = histograms.Charge_Vs_PathlengthTECP2.begin();
+  histograms.Charge_Vs_PathlengthTECP2.insert(it+elepos,ibooker.book2S(cvpTECP2.c_str(), cvpTECP2.c_str(), 20   , 0.3 , 1.3  , 250,0,2000));
+
+  it = histograms.Charge_Vs_PathlengthTECM1.begin();
+  histograms.Charge_Vs_PathlengthTECM1.insert(it+elepos,ibooker.book2S(cvpTECM1.c_str(), cvpTECM1.c_str(), 20   , 0.3 , 1.3  , 250,0,2000));
+
+  it = histograms.Charge_Vs_PathlengthTECM2.begin();
+  histograms.Charge_Vs_PathlengthTECM2.insert(it+elepos,ibooker.book2S(cvpTECM2.c_str(), cvpTECM2.c_str(), 20   , 0.3 , 1.3  , 250,0,2000));
  
-  Charge_Vs_Index[elepos]           = ibooker.book2S(cvi.c_str()     , cvi.c_str()     , NStripAPVs, &binXarray[0], 687, binYarray.data());
-  Charge_Vs_PathlengthTIB[elepos]   = ibooker.book2S(cvpTIB.c_str()  , cvpTIB.c_str()  , 20   , 0.3 , 1.3  , 250,0,2000);
-  Charge_Vs_PathlengthTOB[elepos]   = ibooker.book2S(cvpTOB.c_str()  , cvpTOB.c_str()  , 20   , 0.3 , 1.3  , 250,0,2000);
-  Charge_Vs_PathlengthTIDP[elepos]  = ibooker.book2S(cvpTIDP.c_str() , cvpTIDP.c_str() , 20   , 0.3 , 1.3  , 250,0,2000);
-  Charge_Vs_PathlengthTIDM[elepos]  = ibooker.book2S(cvpTIDM.c_str() , cvpTIDM.c_str() , 20   , 0.3 , 1.3  , 250,0,2000);
-  Charge_Vs_PathlengthTECP1[elepos] = ibooker.book2S(cvpTECP1.c_str(), cvpTECP1.c_str(), 20   , 0.3 , 1.3  , 250,0,2000);
-  Charge_Vs_PathlengthTECP2[elepos] = ibooker.book2S(cvpTECP2.c_str(), cvpTECP2.c_str(), 20   , 0.3 , 1.3  , 250,0,2000);
-  Charge_Vs_PathlengthTECM1[elepos] = ibooker.book2S(cvpTECM1.c_str(), cvpTECM1.c_str(), 20   , 0.3 , 1.3  , 250,0,2000);
-  Charge_Vs_PathlengthTECM2[elepos] = ibooker.book2S(cvpTECM2.c_str(), cvpTECM2.c_str(), 20   , 0.3 , 1.3  , 250,0,2000);
-
-  Charge_1[elepos].clear();
-  Charge_2[elepos].clear();
-  Charge_3[elepos].clear();
-  Charge_4[elepos].clear();
-
   std::vector<std::pair<std::string,std::string>> hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"");
   for (unsigned int i=0;i<hnames.size();i++){
     std::string htag = (hnames[i]).first + stag;
-    MonitorElement* monitor = ibooker.book1DD( htag.c_str(), (hnames[i]).second.c_str(), 100   , 0. , 1000. );
-    int id    = APVGain::subdetectorId((hnames[i]).first);
-    int side  = APVGain::subdetectorSide((hnames[i]).first);
-    int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    Charge_1[elepos].emplace_back(id,side,plane,monitor);
+    histograms.Charge_1[elepos].push_back(ibooker.book1DD( htag.c_str(), (hnames[i]).second.c_str(), 100   , 0. , 1000. ));
+
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG2");
   for (unsigned int i=0;i<hnames.size();i++){
     std::string htag = (hnames[i]).first + stag;
-    MonitorElement* monitor = ibooker.book1DD( htag.c_str(), (hnames[i]).second.c_str(), 100   , 0. , 1000. );
-    int id    = APVGain::subdetectorId((hnames[i]).first);
-    int side  = APVGain::subdetectorSide((hnames[i]).first);
-    int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    Charge_2[elepos].emplace_back(id,side,plane,monitor);
+    histograms.Charge_2[elepos].push_back(ibooker.book1DD( htag.c_str(), (hnames[i]).second.c_str(), 100   , 0. , 1000. ));
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG1");
   for (unsigned int i=0;i<hnames.size();i++){
     std::string htag = (hnames[i]).first + stag;
-    MonitorElement* monitor = ibooker.book1DD( htag.c_str(), (hnames[i]).second.c_str(), 100   , 0. , 1000. );
-    int id    = APVGain::subdetectorId((hnames[i]).first);
-    int side  = APVGain::subdetectorSide((hnames[i]).first);
-    int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    Charge_3[elepos].emplace_back(id,side,plane,monitor);
+    histograms.Charge_3[elepos].push_back(ibooker.book1DD( htag.c_str(), (hnames[i]).second.c_str(), 100   , 0. , 1000. ));
+
   }
 
   hnames = APVGain::monHnames(VChargeHisto,doChargeMonitorPerPlane,"woG1G2");
   for (unsigned int i=0;i<hnames.size();i++){
-    std::string htag = (hnames[i]).first + stag;
-    MonitorElement* monitor = ibooker.book1DD( htag.c_str(), (hnames[i]).second.c_str(), 100   , 0. , 1000. );
-    int id    = APVGain::subdetectorId((hnames[i]).first);
-    int side  = APVGain::subdetectorSide((hnames[i]).first);
-    int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    Charge_4[elepos].emplace_back(id,side,plane,monitor);
+    std::string htag = (hnames[i]).first + stag;   
+    histograms.Charge_4[elepos].push_back(ibooker.book1DD( htag.c_str(), (hnames[i]).second.c_str(), 100   , 0. , 1000. ));
   }
+  
 }

--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -75,18 +75,16 @@ private:
   MonitorElement *initialise(Kind kind, TH1 *rootobj);
   MonitorElement *initialise(Kind kind, const std::string &value);
   void globalize() {
-    data_.streamId = 0;
     data_.moduleId = 0;
   }
-  void setLumi(uint32_t ls) {data_.lumi = ls;}
+  void setLumi(uint32_t ls) {
+    data_.lumi = ls;
+  }
 
 public:
   MonitorElement();
-  MonitorElement(const std::string *path,
-                 const std::string &name,
-                 uint32_t run = 0,
-                 uint32_t streamId = 0,
-                 uint32_t moduleId = 0);
+  MonitorElement(const std::string *path, const std::string &name);
+  MonitorElement(const std::string *path, const std::string &name, uint32_t run, uint32_t moduleId);
   MonitorElement(const MonitorElement &, MonitorElementNoCloneTag);
   MonitorElement(const MonitorElement &);
   MonitorElement(MonitorElement &&);
@@ -388,7 +386,6 @@ public:
 
   const uint32_t run() const {return data_.run;}
   const uint32_t lumi() const {return data_.lumi;}
-  const uint32_t streamId() const {return data_.streamId;}
   const uint32_t moduleId() const {return data_.moduleId;}
 };
 

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -166,10 +166,28 @@ MonitorElement::MonitorElement()
 }
 
 MonitorElement::MonitorElement(const std::string *path,
+                               const std::string &name)
+  : object_(nullptr),
+    reference_(nullptr),
+    refvalue_(nullptr)
+{
+  data_.version  = 0;
+  data_.run      = 0;
+  data_.lumi     = 0;
+  data_.streamId = 0;
+  data_.moduleId = 0;
+  data_.dirname  = path;
+  data_.objname  = name;
+  data_.tag = 0;
+  data_.flags = DQM_KIND_INVALID | DQMNet::DQM_PROP_NEW;
+  scalar_.num = 0;
+  scalar_.real = 0;
+}
+
+MonitorElement::MonitorElement(const std::string *path,
                                const std::string &name,
-                               uint32_t run /* = 0 */,
-                               uint32_t streamId /* = 0 */,
-                               uint32_t moduleId /* = 0 */)
+                               uint32_t run,
+                               uint32_t moduleId)
   : object_(nullptr),
     reference_(nullptr),
     refvalue_(nullptr)
@@ -177,7 +195,7 @@ MonitorElement::MonitorElement(const std::string *path,
   data_.version  = 0;
   data_.run      = run;
   data_.lumi     = 0;
-  data_.streamId = streamId;
+  data_.streamId = 0;
   data_.moduleId = moduleId;
   data_.dirname  = path;
   data_.objname  = name;

--- a/DQMServices/Core/test/DQMTestMultiThread.cc
+++ b/DQMServices/Core/test/DQMTestMultiThread.cc
@@ -63,7 +63,6 @@ void DQMTestMultiThread::dumpMe(MonitorElement const& me,
   std::cout << "Run: " << me.run()
             << " Lumi: " << me.lumi()
             << " LumiFlag: " << me.getLumiFlag()
-            << " streamId: " << me.streamId()
             << " moduleId: " << me.moduleId()
             << " fullpathname: " << me.getPathname();
   if (printStat)


### PR DESCRIPTION
In an attempt to solve the issue in https://github.com/cms-sw/cmssw/issues/22281, I've tried to migrate `SiStripGainsPCLWorker` from `DQMEDAnalyzer` to `DQMGlobalEDAnalyzer`. 
Will probably push more commits to clean the code (and I would  also like to make some more extended tests), but comments are already welcome.
Running in a `CMSSW_10_1_X_2018-02-21-2300`, the command `runTheMatrix.py -l 1001.0 -t 4 --ibeos` runs to completion, at variance with the vanilla IB which is segfaulting at [step8](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc630/CMSSW_10_1_X_2018-02-21-2300/pyRelValMatrixLogs/run/1001.0_RunMinBias2011A+RunMinBias2011A+TIER0EXP+ALCAEXP+ALCAHARVD1+ALCAHARVD2+ALCAHARVD3+ALCAHARVD4+ALCAHARVD5/step8_RunMinBias2011A+RunMinBias2011A+TIER0EXP+ALCAEXP+ALCAHARVD1+ALCAHARVD2+ALCAHARVD3+ALCAHARVD4+ALCAHARVD5.log). 
Incidentally, I've measured the decrease of RSS memory consumption of step3 of  `runTheMatrix.py -l 1001.0 -t 4` and looks sizable (barring errors on my side)
![image](https://user-images.githubusercontent.com/5082376/36603941-9efb60be-18bc-11e8-9f2d-015da1fa214a.png)
