### PR TITLE
Improve seed finding for L3 muon reconstruction at HLT 

### DIFF
--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
@@ -103,7 +103,6 @@ private:
 				unsigned int& numSeedsMade,
 				unsigned int& numOfMaxSeeds,
 				unsigned int& layerCount,
-				bool& foundHitlessSeed,
 				bool& analysedL2,
 				std::unique_ptr<std::vector<TrajectorySeed> >& out) const;
 
@@ -120,9 +119,13 @@ private:
 				const MeasurementTrackerEvent &measurementTracker,
 				edm::ESHandle<Chi2MeasurementEstimatorBase>& estimator_,
 				unsigned int& numSeedsMade,
-				const double errorSF) const;
+				const double errorSF,
+				const double l2Eta) const;
 
-
+        //Find compatability between two TSOSs
+        double match_Chi2(const TrajectoryStateOnSurface& tsos1,
+        		  const TrajectoryStateOnSurface& tsos2) const;
+                                          
 };
 
 #endif


### PR DESCRIPTION
This PR improves the seed finding for the outside-in muon reconstruction in the HLT. 

it involves: 

- Restricting the useStereoLayersInTEC_ option to the barrel-endcap overlap
- Introduces a more sophisticated comparisons of Trajectory States on Surface
- Uses both TSOSs when they disagree too much 
- Uses hitless seeds on all visited layers

The efficiency gain for the OI L3 reconstructions is documented in these slides https://cernbox.cern.ch/index.php/s/chcY6XHGUGDV9Xk, which include links to the discussion on this topic in the Muon HLT Task Force. 