### PR TITLE
DQM: SiPixelPhase1- Added Big Pixel Charge Plots

### DIFF
--- a/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
+++ b/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
@@ -18,33 +18,32 @@ SiPixelPhase1ClustersCharge = DefaultHistoDigiCluster.clone(
   )
 )
 
-SiPixelPhase1ClustersBPCharge = DefaultHistoDigiCluster.clone(
-  name = "bpcharge",
+SiPixelPhase1ClustersBigPixelCharge = DefaultHistoDigiCluster.clone(
+  name = "bigpixelcharge",
   title = "Big Pixel Charge",
-  range_min = 0, range_max = 70, range_nbins = 300,
-  xlabel = "Mysterious units",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
 
   specs = VPSet(
-    StandardSpecification2DProfile,
-    StandardSpecificationPixelmapProfile,
-    StandardSpecificationTrend,
-    StandardSpecifications1D,
-    StandardSpecificationTrend2D
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
   )
 )
 
-SiPixelPhase1ClustersPCharge = DefaultHistoDigiCluster.clone(
-  name = "pcharge",
-  title = "All Pixel Charge",
-  range_min = 0, range_max = 70, range_nbins = 300,
-  xlabel = "Mysterious units",
+SiPixelPhase1ClustersNotBigPixelCharge = DefaultHistoDigiCluster.clone(
+  name = "notbigpixelcharge",
+  title = "Not Big Pixel Charge",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+  enabled=False,
 
   specs = VPSet(
-    StandardSpecification2DProfile,
-    StandardSpecificationPixelmapProfile,
-    StandardSpecificationTrend,
-    StandardSpecifications1D,
-    StandardSpecificationTrend2D
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
   )
 )
 
@@ -268,8 +267,8 @@ SiPixelPhase1ClustersPixelToStripRatio = DefaultHistoDigiCluster.clone(
 
 SiPixelPhase1ClustersConf = cms.VPSet(
   SiPixelPhase1ClustersCharge,
-  SiPixelPhase1ClustersBPCharge,
-  SiPixelPhase1ClustersPCharge,
+  SiPixelPhase1ClustersBigPixelCharge,
+  SiPixelPhase1ClustersNotBigPixelCharge,
   SiPixelPhase1ClustersSize,
   SiPixelPhase1ClustersSizeX,
   SiPixelPhase1ClustersSizeY,

--- a/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
+++ b/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
@@ -18,6 +18,36 @@ SiPixelPhase1ClustersCharge = DefaultHistoDigiCluster.clone(
   )
 )
 
+SiPixelPhase1ClustersBPCharge = DefaultHistoDigiCluster.clone(
+  name = "bpcharge",
+  title = "Big Pixel Charge",
+  range_min = 0, range_max = 70, range_nbins = 300,
+  xlabel = "Mysterious units",
+
+  specs = VPSet(
+    StandardSpecification2DProfile,
+    StandardSpecificationPixelmapProfile,
+    StandardSpecificationTrend,
+    StandardSpecifications1D,
+    StandardSpecificationTrend2D
+  )
+)
+
+SiPixelPhase1ClustersPCharge = DefaultHistoDigiCluster.clone(
+  name = "pcharge",
+  title = "All Pixel Charge",
+  range_min = 0, range_max = 70, range_nbins = 300,
+  xlabel = "Mysterious units",
+
+  specs = VPSet(
+    StandardSpecification2DProfile,
+    StandardSpecificationPixelmapProfile,
+    StandardSpecificationTrend,
+    StandardSpecifications1D,
+    StandardSpecificationTrend2D
+  )
+)
+
 SiPixelPhase1ClustersSize = DefaultHistoDigiCluster.clone(
   name = "size",
   title = "Total Cluster Size",
@@ -74,11 +104,11 @@ SiPixelPhase1ClustersNClusters = DefaultHistoDigiCluster.clone(
     StandardSpecifications1D_Num,
 
     Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
-                             .reduce("COUNT")    
+                             .reduce("COUNT")
                              .groupBy("PXBarrel/PXLayer")
                              .save(nbins=50, xmin=0, xmax=10000),
     Specification().groupBy("PXForward/PXDisk/Event")
-                             .reduce("COUNT")    
+                             .reduce("COUNT")
                              .groupBy("PXForward/PXDisk/")
                              .save(nbins=50, xmin=0, xmax=5000),
   )
@@ -219,18 +249,18 @@ SiPixelPhase1ClustersPixelToStripRatio = DefaultHistoDigiCluster.clone(
   enabled = False,
   name = "cluster_ratio",
   title = "Pixel to Strip clusters ratio",
-  
+
   xlabel = "ratio",
   dimensions = 1,
-  
+
   specs = VPSet(
-    Specification().groupBy("PXAll").save(100, 0, 1), 
+    Specification().groupBy("PXAll").save(100, 0, 1),
     Specification().groupBy("PXAll/LumiBlock")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXAll", "EXTEND_X")
                    .save(),
     Specification().groupBy("PXAll/BX")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXAll", "EXTEND_X")
                    .save(),
   )
@@ -238,6 +268,8 @@ SiPixelPhase1ClustersPixelToStripRatio = DefaultHistoDigiCluster.clone(
 
 SiPixelPhase1ClustersConf = cms.VPSet(
   SiPixelPhase1ClustersCharge,
+  SiPixelPhase1ClustersBPCharge,
+  SiPixelPhase1ClustersPCharge,
   SiPixelPhase1ClustersSize,
   SiPixelPhase1ClustersSizeX,
   SiPixelPhase1ClustersSizeY,

--- a/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
+++ b/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
@@ -7,6 +7,7 @@
 // Original Author: Marcel Schneider
 
 #include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -21,105 +22,126 @@
 
 namespace {
 
-class SiPixelPhase1Clusters final : public SiPixelPhase1Base {
-  enum {
-    CHARGE,
-    SIZE,
-    SIZEX,
-    SIZEY,
-    NCLUSTERS,
-    NCLUSTERSINCLUSIVE,
-    EVENTRATE,
-    POSITION_B,
-    POSITION_F,
-    POSITION_XZ,
-    POSITION_YZ,
-    SIZE_VS_ETA,
-    READOUT_CHARGE,
-    READOUT_NCLUSTERS,
-    PIXEL_TO_STRIP_RATIO
-  };
+  class SiPixelPhase1Clusters final : public SiPixelPhase1Base {
+    enum {
+      CHARGE,
+      BPCHARGE,
+      PCHARGE,
+      SIZE,
+      SIZEX,
+      SIZEY,
+      NCLUSTERS,
+      NCLUSTERSINCLUSIVE,
+      EVENTRATE,
+      POSITION_B,
+      POSITION_F,
+      POSITION_XZ,
+      POSITION_YZ,
+      SIZE_VS_ETA,
+      READOUT_CHARGE,
+      READOUT_NCLUSTERS,
+      PIXEL_TO_STRIP_RATIO
+    };
 
   public:
-  explicit SiPixelPhase1Clusters(const edm::ParameterSet& conf);
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
+    explicit SiPixelPhase1Clusters(const edm::ParameterSet& conf);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   private:
-  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelSrcToken_;
-  edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > stripSrcToken_;
-};
+    edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelSrcToken_;
+    edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > stripSrcToken_;
+  };
 
-SiPixelPhase1Clusters::SiPixelPhase1Clusters(const edm::ParameterSet& iConfig) :
+  SiPixelPhase1Clusters::SiPixelPhase1Clusters(const edm::ParameterSet& iConfig) :
   SiPixelPhase1Base(iConfig)
-{
-  pixelSrcToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("pixelSrc"));
-
-  stripSrcToken_ = consumes<edmNew::DetSetVector<SiStripCluster>>(iConfig.getParameter<edm::InputTag>("stripSrc"));
-}
-
-void SiPixelPhase1Clusters::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  if( !checktrigger(iEvent,iSetup,DCS) ) return;
-
-  edm::Handle<edmNew::DetSetVector<SiPixelCluster>> inputPixel;
-  iEvent.getByToken(pixelSrcToken_, inputPixel);
-  if (!inputPixel.isValid()) return;
-
-  edm::Handle<edmNew::DetSetVector<SiStripCluster>> inputStrip;
-  iEvent.getByToken(stripSrcToken_, inputStrip);
-  if (inputStrip.isValid())
   {
-    if (!inputStrip.product()->data().empty())
-    {
-      histo[PIXEL_TO_STRIP_RATIO].fill((double)inputPixel.product()->data().size() / (double) inputStrip.product()->data().size(), DetId(0), &iEvent);
-    }
-  } 
+    pixelSrcToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("pixelSrc"));
 
-  bool hasClusters=false;
-
-  edm::ESHandle<TrackerGeometry> tracker;
-  iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
-  assert(tracker.isValid());
-
-  edmNew::DetSetVector<SiPixelCluster>::const_iterator it;
-  for (it = inputPixel->begin(); it != inputPixel->end(); ++it) {
-    auto id = DetId(it->detId());
-
-    const PixelGeomDetUnit* theGeomDet = dynamic_cast<const PixelGeomDetUnit*> ( tracker->idToDet(id) );
-    const PixelTopology& topol = theGeomDet->specificTopology();
-
-    for(SiPixelCluster const& cluster : *it) {
-      int row = cluster.x()-0.5, col = cluster.y()-0.5;
-      histo[READOUT_CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
-      histo[CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
-      histo[SIZE  ].fill(double(cluster.size()  ), id, &iEvent, col, row);
-      histo[SIZEX  ].fill(double(cluster.sizeX()  ), id, &iEvent, col, row);
-      histo[SIZEY  ].fill(double(cluster.sizeY()  ), id, &iEvent, col, row);
-      histo[NCLUSTERS].fill(id, &iEvent, col, row);
-      histo[NCLUSTERSINCLUSIVE].fill(id, &iEvent);
-      hasClusters=true;
-      if (cluster.size()>1){
-        histo[READOUT_NCLUSTERS].fill(id, &iEvent);
-      }
-
-      LocalPoint clustlp = topol.localPosition(MeasurementPoint(cluster.x(), cluster.y()));
-      GlobalPoint clustgp = theGeomDet->surface().toGlobal(clustlp);
-      histo[POSITION_B ].fill(clustgp.z(),   clustgp.phi(),   id, &iEvent);
-      histo[POSITION_F ].fill(clustgp.x(),   clustgp.y(),     id, &iEvent);
-      histo[POSITION_XZ].fill(clustgp.x(),   clustgp.z(),     id, &iEvent);
-      histo[POSITION_YZ].fill(clustgp.y(),   clustgp.z(),     id, &iEvent);
-      histo[SIZE_VS_ETA].fill(clustgp.eta(), cluster.sizeY(), id, &iEvent);
-
-    }
+    stripSrcToken_ = consumes<edmNew::DetSetVector<SiStripCluster>>(iConfig.getParameter<edm::InputTag>("stripSrc"));
   }
 
+  void SiPixelPhase1Clusters::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+    if( !checktrigger(iEvent,iSetup,DCS) ) return;
 
-  if (hasClusters) histo[EVENTRATE].fill(DetId(0), &iEvent);
+    edm::Handle<edmNew::DetSetVector<SiPixelCluster>> inputPixel;
+    iEvent.getByToken(pixelSrcToken_, inputPixel);
+    if (!inputPixel.isValid()) return;
 
-  histo[NCLUSTERS].executePerEventHarvesting(&iEvent);
-  histo[READOUT_NCLUSTERS].executePerEventHarvesting(&iEvent);
-  histo[NCLUSTERSINCLUSIVE].executePerEventHarvesting(&iEvent);
+    edm::Handle<edmNew::DetSetVector<SiStripCluster>> inputStrip;
+    iEvent.getByToken(stripSrcToken_, inputStrip);
+    if (inputStrip.isValid())
+    {
+      if (!inputStrip.product()->data().empty())
+      {
+        histo[PIXEL_TO_STRIP_RATIO].fill((double)inputPixel.product()->data().size() / (double) inputStrip.product()->data().size(), DetId(0), &iEvent);
+      }
+    }
 
-}
+    bool hasClusters=false;
+
+    edm::ESHandle<TrackerGeometry> tracker;
+    iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
+    assert(tracker.isValid());
+
+    edmNew::DetSetVector<SiPixelCluster>::const_iterator it;
+
+  for (it = inputPixel->begin(); it != inputPixel->end(); ++it) {
+      auto id = DetId(it->detId());
+
+      const PixelGeomDetUnit* theGeomDet = dynamic_cast<const PixelGeomDetUnit*> ( tracker->idToDet(id) );
+      const PixelTopology& topol = theGeomDet->specificTopology();
+
+      for(SiPixelCluster const& cluster : *it) {
+        int row = cluster.x()-0.5, col = cluster.y()-0.5;
+
+        const std::vector<SiPixelCluster::Pixel> pixelsVec = cluster.pixels();
+
+        for (unsigned int i = 0;  i < pixelsVec.size(); ++i) {
+
+          float pixx = pixelsVec[i].x; // index as float=iteger, row index
+          float pixy = pixelsVec[i].y; // same, col index
+
+          bool bigInX = topol.isItBigPixelInX(int(pixx));
+          bool bigInY = topol.isItBigPixelInY(int(pixy));
+          float pixel_charge = pixelsVec[i].adc/1000;
+          histo[PCHARGE].fill(pixel_charge, id, &iEvent, col, row);
+          if (bigInX || bigInY) histo[BPCHARGE].fill(pixel_charge, id, &iEvent, col, row);
+        }
+
+
+        histo[READOUT_CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
+        histo[CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
+        histo[SIZE  ].fill(double(cluster.size()  ), id, &iEvent, col, row);
+        histo[SIZEX  ].fill(double(cluster.sizeX()  ), id, &iEvent, col, row);
+        histo[SIZEY  ].fill(double(cluster.sizeY()  ), id, &iEvent, col, row);
+        histo[NCLUSTERS].fill(id, &iEvent, col, row);
+        histo[NCLUSTERSINCLUSIVE].fill(id, &iEvent);
+        hasClusters=true;
+
+        //if (bigInX || bigInY) histo_BigPixCharge.fill(double(cluster.charge()), id, &iEvent, col, row);
+
+        if (cluster.size()>1){
+          histo[READOUT_NCLUSTERS].fill(id, &iEvent);
+        }
+
+        LocalPoint clustlp = topol.localPosition(MeasurementPoint(cluster.x(), cluster.y()));
+        GlobalPoint clustgp = theGeomDet->surface().toGlobal(clustlp);
+        histo[POSITION_B ].fill(clustgp.z(),   clustgp.phi(),   id, &iEvent);
+        histo[POSITION_F ].fill(clustgp.x(),   clustgp.y(),     id, &iEvent);
+        histo[POSITION_XZ].fill(clustgp.x(),   clustgp.z(),     id, &iEvent);
+        histo[POSITION_YZ].fill(clustgp.y(),   clustgp.z(),     id, &iEvent);
+        histo[SIZE_VS_ETA].fill(clustgp.eta(), cluster.sizeY(), id, &iEvent);
+
+      }
+    }
+
+    if (hasClusters) histo[EVENTRATE].fill(DetId(0), &iEvent);
+
+    histo[NCLUSTERS].executePerEventHarvesting(&iEvent);
+    histo[READOUT_NCLUSTERS].executePerEventHarvesting(&iEvent);
+    histo[NCLUSTERSINCLUSIVE].executePerEventHarvesting(&iEvent);
+
+  }
 
 } // namespace
 

--- a/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
+++ b/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
@@ -25,8 +25,8 @@ namespace {
   class SiPixelPhase1Clusters final : public SiPixelPhase1Base {
     enum {
       CHARGE,
-      BPCHARGE,
-      PCHARGE,
+      BIGPIXELCHARGE,
+      NOTBIGPIXELCHARGE,
       SIZE,
       SIZEX,
       SIZEY,
@@ -103,9 +103,9 @@ namespace {
 
           bool bigInX = topol.isItBigPixelInX(int(pixx));
           bool bigInY = topol.isItBigPixelInY(int(pixy));
-          float pixel_charge = pixelsVec[i].adc/1000;
-          histo[PCHARGE].fill(pixel_charge, id, &iEvent, col, row);
-          if (bigInX || bigInY) histo[BPCHARGE].fill(pixel_charge, id, &iEvent, col, row);
+          float pixel_charge = pixelsVec[i].adc;
+          if (bigInX || bigInY) histo[BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent, col, row);
+          else histo[NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent, col, row);
         }
 
 

--- a/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
+++ b/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
@@ -7,7 +7,6 @@
 // Original Author: Marcel Schneider
 
 #include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -22,126 +21,127 @@
 
 namespace {
 
-  class SiPixelPhase1Clusters final : public SiPixelPhase1Base {
-    enum {
-      CHARGE,
-      BIGPIXELCHARGE,
-      NOTBIGPIXELCHARGE,
-      SIZE,
-      SIZEX,
-      SIZEY,
-      NCLUSTERS,
-      NCLUSTERSINCLUSIVE,
-      EVENTRATE,
-      POSITION_B,
-      POSITION_F,
-      POSITION_XZ,
-      POSITION_YZ,
-      SIZE_VS_ETA,
-      READOUT_CHARGE,
-      READOUT_NCLUSTERS,
-      PIXEL_TO_STRIP_RATIO
-    };
-
-  public:
-    explicit SiPixelPhase1Clusters(const edm::ParameterSet& conf);
-    void analyze(const edm::Event&, const edm::EventSetup&) override;
-
-  private:
-    edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelSrcToken_;
-    edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > stripSrcToken_;
+class SiPixelPhase1Clusters final : public SiPixelPhase1Base {
+  enum {
+    CHARGE,
+    BIGPIXELCHARGE,
+    NOTBIGPIXELCHARGE,
+    SIZE,
+    SIZEX,
+    SIZEY,
+    NCLUSTERS,
+    NCLUSTERSINCLUSIVE,
+    EVENTRATE,
+    POSITION_B,
+    POSITION_F,
+    POSITION_XZ,
+    POSITION_YZ,
+    SIZE_VS_ETA,
+    READOUT_CHARGE,
+    READOUT_NCLUSTERS,
+    PIXEL_TO_STRIP_RATIO
   };
 
-  SiPixelPhase1Clusters::SiPixelPhase1Clusters(const edm::ParameterSet& iConfig) :
+  public:
+  explicit SiPixelPhase1Clusters(const edm::ParameterSet& conf);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  private:
+  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelSrcToken_;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > stripSrcToken_;
+};
+
+SiPixelPhase1Clusters::SiPixelPhase1Clusters(const edm::ParameterSet& iConfig) :
   SiPixelPhase1Base(iConfig)
+{
+  pixelSrcToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("pixelSrc"));
+
+  stripSrcToken_ = consumes<edmNew::DetSetVector<SiStripCluster>>(iConfig.getParameter<edm::InputTag>("stripSrc"));
+}
+
+void SiPixelPhase1Clusters::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  if( !checktrigger(iEvent,iSetup,DCS) ) return;
+
+  edm::Handle<edmNew::DetSetVector<SiPixelCluster>> inputPixel;
+  iEvent.getByToken(pixelSrcToken_, inputPixel);
+  if (!inputPixel.isValid()) return;
+
+  edm::Handle<edmNew::DetSetVector<SiStripCluster>> inputStrip;
+  iEvent.getByToken(stripSrcToken_, inputStrip);
+  if (inputStrip.isValid())
   {
-    pixelSrcToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("pixelSrc"));
-
-    stripSrcToken_ = consumes<edmNew::DetSetVector<SiStripCluster>>(iConfig.getParameter<edm::InputTag>("stripSrc"));
-  }
-
-  void SiPixelPhase1Clusters::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-    if( !checktrigger(iEvent,iSetup,DCS) ) return;
-
-    edm::Handle<edmNew::DetSetVector<SiPixelCluster>> inputPixel;
-    iEvent.getByToken(pixelSrcToken_, inputPixel);
-    if (!inputPixel.isValid()) return;
-
-    edm::Handle<edmNew::DetSetVector<SiStripCluster>> inputStrip;
-    iEvent.getByToken(stripSrcToken_, inputStrip);
-    if (inputStrip.isValid())
+    if (!inputStrip.product()->data().empty())
     {
-      if (!inputStrip.product()->data().empty())
-      {
-        histo[PIXEL_TO_STRIP_RATIO].fill((double)inputPixel.product()->data().size() / (double) inputStrip.product()->data().size(), DetId(0), &iEvent);
-      }
+      histo[PIXEL_TO_STRIP_RATIO].fill((double)inputPixel.product()->data().size() / (double) inputStrip.product()->data().size(), DetId(0), &iEvent);
     }
-
-    bool hasClusters=false;
-
-    edm::ESHandle<TrackerGeometry> tracker;
-    iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
-    assert(tracker.isValid());
-
-    edmNew::DetSetVector<SiPixelCluster>::const_iterator it;
-
-  for (it = inputPixel->begin(); it != inputPixel->end(); ++it) {
-      auto id = DetId(it->detId());
-
-      const PixelGeomDetUnit* theGeomDet = dynamic_cast<const PixelGeomDetUnit*> ( tracker->idToDet(id) );
-      const PixelTopology& topol = theGeomDet->specificTopology();
-
-      for(SiPixelCluster const& cluster : *it) {
-        int row = cluster.x()-0.5, col = cluster.y()-0.5;
-
-        const std::vector<SiPixelCluster::Pixel> pixelsVec = cluster.pixels();
-
-        for (unsigned int i = 0;  i < pixelsVec.size(); ++i) {
-
-          float pixx = pixelsVec[i].x; // index as float=iteger, row index
-          float pixy = pixelsVec[i].y; // same, col index
-
-          bool bigInX = topol.isItBigPixelInX(int(pixx));
-          bool bigInY = topol.isItBigPixelInY(int(pixy));
-          float pixel_charge = pixelsVec[i].adc;
-          if (bigInX || bigInY) histo[BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent, col, row);
-          else histo[NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent, col, row);
-        }
-
-
-        histo[READOUT_CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
-        histo[CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
-        histo[SIZE  ].fill(double(cluster.size()  ), id, &iEvent, col, row);
-        histo[SIZEX  ].fill(double(cluster.sizeX()  ), id, &iEvent, col, row);
-        histo[SIZEY  ].fill(double(cluster.sizeY()  ), id, &iEvent, col, row);
-        histo[NCLUSTERS].fill(id, &iEvent, col, row);
-        histo[NCLUSTERSINCLUSIVE].fill(id, &iEvent);
-        hasClusters=true;
-
-        //if (bigInX || bigInY) histo_BigPixCharge.fill(double(cluster.charge()), id, &iEvent, col, row);
-
-        if (cluster.size()>1){
-          histo[READOUT_NCLUSTERS].fill(id, &iEvent);
-        }
-
-        LocalPoint clustlp = topol.localPosition(MeasurementPoint(cluster.x(), cluster.y()));
-        GlobalPoint clustgp = theGeomDet->surface().toGlobal(clustlp);
-        histo[POSITION_B ].fill(clustgp.z(),   clustgp.phi(),   id, &iEvent);
-        histo[POSITION_F ].fill(clustgp.x(),   clustgp.y(),     id, &iEvent);
-        histo[POSITION_XZ].fill(clustgp.x(),   clustgp.z(),     id, &iEvent);
-        histo[POSITION_YZ].fill(clustgp.y(),   clustgp.z(),     id, &iEvent);
-        histo[SIZE_VS_ETA].fill(clustgp.eta(), cluster.sizeY(), id, &iEvent);
-
-      }
-    }
-
-    if (hasClusters) histo[EVENTRATE].fill(DetId(0), &iEvent);
-
-    histo[NCLUSTERS].executePerEventHarvesting(&iEvent);
-    histo[READOUT_NCLUSTERS].executePerEventHarvesting(&iEvent);
-    histo[NCLUSTERSINCLUSIVE].executePerEventHarvesting(&iEvent);
-
   }
+
+  bool hasClusters=false;
+
+  edm::ESHandle<TrackerGeometry> tracker;
+  iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
+  assert(tracker.isValid());
+
+  edmNew::DetSetVector<SiPixelCluster>::const_iterator it;
+  for (it = inputPixel->begin(); it != inputPixel->end(); ++it) {
+    auto id = DetId(it->detId());
+
+    const PixelGeomDetUnit* theGeomDet = dynamic_cast<const PixelGeomDetUnit*> ( tracker->idToDet(id) );
+    const PixelTopology& topol = theGeomDet->specificTopology();
+
+    for(SiPixelCluster const& cluster : *it) {
+      int row = cluster.x()-0.5, col = cluster.y()-0.5;
+      const std::vector<SiPixelCluster::Pixel> pixelsVec = cluster.pixels();
+
+      for (unsigned int i = 0;  i < pixelsVec.size(); ++i) {
+
+        float pixx = pixelsVec[i].x; // index as float=iteger, row index
+        float pixy = pixelsVec[i].y; // same, col index
+
+        bool bigInX = topol.isItBigPixelInX(int(pixx));
+        bool bigInY = topol.isItBigPixelInY(int(pixy));
+        float pixel_charge = pixelsVec[i].adc;
+
+
+        if (bigInX==true || bigInY==true) {
+          histo[BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent, col, row);
+        }
+
+        else {
+          histo[NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent, col, row);
+        }
+      }
+      histo[READOUT_CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
+      histo[CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
+      histo[SIZE  ].fill(double(cluster.size()  ), id, &iEvent, col, row);
+      histo[SIZEX  ].fill(double(cluster.sizeX()  ), id, &iEvent, col, row);
+      histo[SIZEY  ].fill(double(cluster.sizeY()  ), id, &iEvent, col, row);
+      histo[NCLUSTERS].fill(id, &iEvent, col, row);
+      histo[NCLUSTERSINCLUSIVE].fill(id, &iEvent);
+      hasClusters=true;
+      if (cluster.size()>1){
+        histo[READOUT_NCLUSTERS].fill(id, &iEvent);
+      }
+
+      LocalPoint clustlp = topol.localPosition(MeasurementPoint(cluster.x(), cluster.y()));
+      GlobalPoint clustgp = theGeomDet->surface().toGlobal(clustlp);
+      histo[POSITION_B ].fill(clustgp.z(),   clustgp.phi(),   id, &iEvent);
+      histo[POSITION_F ].fill(clustgp.x(),   clustgp.y(),     id, &iEvent);
+      histo[POSITION_XZ].fill(clustgp.x(),   clustgp.z(),     id, &iEvent);
+      histo[POSITION_YZ].fill(clustgp.y(),   clustgp.z(),     id, &iEvent);
+      histo[SIZE_VS_ETA].fill(clustgp.eta(), cluster.sizeY(), id, &iEvent);
+
+    }
+  }
+
+
+  if (hasClusters) histo[EVENTRATE].fill(DetId(0), &iEvent);
+
+  histo[NCLUSTERS].executePerEventHarvesting(&iEvent);
+  histo[READOUT_NCLUSTERS].executePerEventHarvesting(&iEvent);
+  histo[NCLUSTERSINCLUSIVE].executePerEventHarvesting(&iEvent);
+
+}
 
 } // namespace
 

--- a/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
@@ -10,10 +10,70 @@ SiPixelPhase1TrackClustersOnTrackCharge = DefaultHistoTrack.clone(
   xlabel = "Charge (electrons)",
 
   specs = VPSet(
-    StandardSpecifications1D,    
+    StandardSpecifications1D,
     StandardSpecification2DProfile,
-    
-    #what is below is only for the timing client    
+
+    #what is below is only for the timing client
+    Specification(OverlayCurvesForTiming).groupBy("PXBarrel/OnlineBlock")
+         .groupBy("PXBarrel", "EXTEND_Y")
+         .save(),
+    Specification(OverlayCurvesForTiming).groupBy("PXForward/OnlineBlock")
+         .groupBy("PXForward", "EXTEND_Y")
+         .save(),
+
+    Specification().groupBy("PXForward/PXRing").save(),
+
+    Specification(PerModule).groupBy("PXForward/PXRing/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXRing","EXTEND_X")
+                   .save(),
+
+    Specification(IsOffline).groupBy("PXForward/PXRing/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXRing","EXTEND_X")
+                   .save(),
+
+
+    Specification(PerModule).groupBy("PXBarrel/PXLayer/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                   .save(),
+
+    Specification(PerModule).groupBy("PXForward/PXDisk/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk", "EXTEND_X")
+                   .save(),
+
+    Specification(IsOffline).groupBy("PXBarrel/PXLayer/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                   .save(),
+
+    Specification(IsOffline).groupBy("PXForward/PXDisk/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk", "EXTEND_X")
+                   .save(),
+
+    Specification(OverlayCurvesForTiming).groupBy("PXForward/PXDisk/OnlineBlock") # per-layer with history for online
+                   .groupBy("PXForward/PXDisk", "EXTEND_Y")
+                   .save(),
+    Specification(OverlayCurvesForTiming).groupBy("PXBarrel/PXLayer/OnlineBlock") # per-layer with history for online
+                   .groupBy("PXBarrel/PXLayer", "EXTEND_Y")
+                   .save()
+  )
+)
+
+SiPixelPhase1TrackClustersOnTrackBPCharge = DefaultHistoTrack.clone(
+  name = "bpcharge",
+  title = "Corrected Big Pixel Charge (OnTrack)",
+  range_min = 0, range_max = 80, range_nbins = 100,
+  xlabel = "Mysterious units",
+
+  specs = VPSet(
+    StandardSpecifications1D,
+    StandardSpecification2DProfile,
+
+    #what is below is only for the timing client
     Specification(OverlayCurvesForTiming).groupBy("PXBarrel/OnlineBlock")
          .groupBy("PXBarrel", "EXTEND_Y")
          .save(),
@@ -70,7 +130,7 @@ SiPixelPhase1TrackClustersOnTrackSize = DefaultHistoTrack.clone(
   xlabel = "size[pixels]",
 
   specs = VPSet(
-        StandardSpecifications1D,    
+        StandardSpecifications1D,
         StandardSpecification2DProfile,
 
         Specification().groupBy("PXForward/PXRing").save(),
@@ -159,12 +219,12 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
     StandardSpecification2DProfile_Num,
 
     Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
-                             .reduce("COUNT")    
+                             .reduce("COUNT")
                              .groupBy("PXBarrel/PXLayer")
                              .save(nbins=50, xmin=0, xmax=5000),
 
     Specification().groupBy("PXForward/PXDisk/Event")
-                             .reduce("COUNT")    
+                             .reduce("COUNT")
                              .groupBy("PXForward/PXDisk/")
                              .save(nbins=50, xmin=0, xmax=2000),
 
@@ -226,7 +286,7 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
                     .groupBy("PXBarrel/OnlineBlock")
                     .groupBy("PXBarrel", "EXTEND_Y")
                     .save()
-   
+
   )
 )
 
@@ -365,7 +425,7 @@ SiPixelPhase1TrackClustersOnTrackSizeXYOuter = SiPixelPhase1TrackClustersOnTrack
   xlabel = "y size",
   ylabel = "x size",
   range_min = 0, range_max  = 20, range_nbins   = 20,
-  range_y_min = 0, range_y_max = 10, range_y_nbins = 10 
+  range_y_min = 0, range_y_max = 10, range_y_nbins = 10
 )
 
 SiPixelPhase1TrackClustersOnTrackSizeXYInner = SiPixelPhase1TrackClustersOnTrackSizeXYOuter.clone(
@@ -407,11 +467,11 @@ SiPixelPhase1TrackClustersOnTrackChargeOuter = DefaultHistoTrack.clone(
     Specification().groupBy("PXBarrel/PXLayer").save()
   )
 )
-  
+
 SiPixelPhase1TrackClustersOnTrackChargeInner = SiPixelPhase1TrackClustersOnTrackChargeOuter.clone(
   name = "chargeInner",
   title = "Corrected Cluster Charge (OnTrack) inner ladders"
-)  
+)
 
 SiPixelPhase1TrackClustersOnTrackShapeOuter = DefaultHistoTrack.clone(
   topFolderName = "PixelPhase1/ClusterShape",
@@ -432,6 +492,7 @@ SiPixelPhase1TrackClustersOnTrackShapeInner = SiPixelPhase1TrackClustersOnTrackS
 # copy this in the enum
 SiPixelPhase1TrackClustersConf = cms.VPSet(
   SiPixelPhase1TrackClustersOnTrackCharge,
+  SiPixelPhase1TrackClustersOnTrackBPCharge,
   SiPixelPhase1TrackClustersOnTrackSize,
   SiPixelPhase1TrackClustersOnTrackShape,
   SiPixelPhase1TrackClustersOnTrackNClusters,
@@ -478,7 +539,3 @@ SiPixelPhase1TrackClustersHarvester = DQMEDHarvester("SiPixelPhase1Harvester",
         histograms = SiPixelPhase1TrackClustersConf,
         geometry = SiPixelPhase1Geometry
 )
-
-
-
-

--- a/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
@@ -63,63 +63,32 @@ SiPixelPhase1TrackClustersOnTrackCharge = DefaultHistoTrack.clone(
   )
 )
 
-SiPixelPhase1TrackClustersOnTrackBPCharge = DefaultHistoTrack.clone(
-  name = "bpcharge",
+SiPixelPhase1TrackClustersOnTrackBigPixelCharge = DefaultHistoTrack.clone(
+  name = "bigpixelcharge",
   title = "Corrected Big Pixel Charge (OnTrack)",
-  range_min = 0, range_max = 80, range_nbins = 100,
-  xlabel = "Mysterious units",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
 
   specs = VPSet(
-    StandardSpecifications1D,
-    StandardSpecification2DProfile,
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
+  )
+)
 
-    #what is below is only for the timing client
-    Specification(OverlayCurvesForTiming).groupBy("PXBarrel/OnlineBlock")
-         .groupBy("PXBarrel", "EXTEND_Y")
-         .save(),
-    Specification(OverlayCurvesForTiming).groupBy("PXForward/OnlineBlock")
-         .groupBy("PXForward", "EXTEND_Y")
-         .save(),
+SiPixelPhase1TrackClustersOnTrackNotBigPixelCharge = DefaultHistoTrack.clone(
+  name = "notbigpixelcharge",
+  title = "Corrected Not Big Pixel Charge (OnTrack)",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+  enabled=False,
 
-    Specification().groupBy("PXForward/PXRing").save(),
-
-    Specification(PerModule).groupBy("PXForward/PXRing/Lumisection")
-                   .reduce("MEAN")
-                   .groupBy("PXForward/PXRing","EXTEND_X")
-                   .save(),
-
-    Specification(IsOffline).groupBy("PXForward/PXRing/LumiBlock")
-                   .reduce("MEAN")
-                   .groupBy("PXForward/PXRing","EXTEND_X")
-                   .save(),
-
-
-    Specification(PerModule).groupBy("PXBarrel/PXLayer/Lumisection")
-                   .reduce("MEAN")
-                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
-                   .save(),
-
-    Specification(PerModule).groupBy("PXForward/PXDisk/Lumisection")
-                   .reduce("MEAN")
-                   .groupBy("PXForward/PXDisk", "EXTEND_X")
-                   .save(),
-
-    Specification(IsOffline).groupBy("PXBarrel/PXLayer/LumiBlock")
-                   .reduce("MEAN")
-                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
-                   .save(),
-
-    Specification(IsOffline).groupBy("PXForward/PXDisk/LumiBlock")
-                   .reduce("MEAN")
-                   .groupBy("PXForward/PXDisk", "EXTEND_X")
-                   .save(),
-
-    Specification(OverlayCurvesForTiming).groupBy("PXForward/PXDisk/OnlineBlock") # per-layer with history for online
-                   .groupBy("PXForward/PXDisk", "EXTEND_Y")
-                   .save(),
-    Specification(OverlayCurvesForTiming).groupBy("PXBarrel/PXLayer/OnlineBlock") # per-layer with history for online
-                   .groupBy("PXBarrel/PXLayer", "EXTEND_Y")
-                   .save()
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
   )
 )
 
@@ -492,7 +461,8 @@ SiPixelPhase1TrackClustersOnTrackShapeInner = SiPixelPhase1TrackClustersOnTrackS
 # copy this in the enum
 SiPixelPhase1TrackClustersConf = cms.VPSet(
   SiPixelPhase1TrackClustersOnTrackCharge,
-  SiPixelPhase1TrackClustersOnTrackBPCharge,
+  SiPixelPhase1TrackClustersOnTrackBigPixelCharge,
+  SiPixelPhase1TrackClustersOnTrackNotBigPixelCharge,
   SiPixelPhase1TrackClustersOnTrackSize,
   SiPixelPhase1TrackClustersOnTrackShape,
   SiPixelPhase1TrackClustersOnTrackNClusters,

--- a/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
@@ -187,11 +187,7 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
       auto clustp = pixhit->cluster();
       if (clustp.isNull()) continue;
       auto const & cluster = *clustp;
-
-
       const std::vector<SiPixelCluster::Pixel> pixelsVec = cluster.pixels();
-
-
       for (unsigned int i = 0;  i < pixelsVec.size(); ++i) {
 
         float pixx = pixelsVec[i].x; // index as float=iteger, row index
@@ -201,12 +197,17 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
         bool bigInY = topol.isItBigPixelInY(int(pixy));
         float pixel_charge = pixelsVec[i].adc;
 
-        if (bigInX || bigInY) histo[ON_TRACK_BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
-        else histo[ON_TRACK_NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
-      }
+        if (bigInX==true || bigInY==true) {
+          std::cout<<"Failure here 1?"<<std::endl;
+          histo[ON_TRACK_BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
+        }
+        else {
+          std::cout<<"Failure here 2?"<<std::endl;
+          histo[ON_TRACK_NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
+          std::cout<<"Did this pass?????"<<std::endl;
 
-
-
+        }
+      } // End loop over pixels
       auto const & ltp = trajParams[h];
 
       auto localDir = ltp.momentum() / ltp.momentum().mag();

--- a/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-// 
+//
 // Package:     SiPixelPhase1TrackClusters
 // Class  :     SiPixelPhase1TrackClusters
 //
@@ -35,8 +35,9 @@
 namespace {
 
 class SiPixelPhase1TrackClusters final : public SiPixelPhase1Base {
-enum {  
+enum {
   ON_TRACK_CHARGE,
+  ON_TRACK_BPCHARGE,
   ON_TRACK_SIZE,
   ON_TRACK_SHAPE,
   ON_TRACK_NCLUSTERS,
@@ -54,20 +55,20 @@ enum {
 
   ON_TRACK_SHAPE_OUTER,
   ON_TRACK_SHAPE_INNER,
- 
+
   ON_TRACK_SIZE_X_OUTER,
   ON_TRACK_SIZE_X_INNER,
   ON_TRACK_SIZE_X_F,
   ON_TRACK_SIZE_Y_OUTER,
   ON_TRACK_SIZE_Y_INNER,
   ON_TRACK_SIZE_Y_F,
-    
+
   ON_TRACK_SIZE_XY_OUTER,
   ON_TRACK_SIZE_XY_INNER,
   ON_TRACK_SIZE_XY_F,
   CHARGE_VS_SIZE_ON_TRACK,
 
-  ENUM_SIZE        
+  ENUM_SIZE
 };
 
 public:
@@ -87,11 +88,11 @@ SiPixelPhase1TrackClusters::SiPixelPhase1TrackClusters(const edm::ParameterSet& 
   applyVertexCut_(iConfig.getUntrackedParameter<bool>("VertexCut", true))
 {
   tracksToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
-  
+
   offlinePrimaryVerticesToken_ = applyVertexCut_ ?
                                   consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices")) :
                                   edm::EDGetTokenT<reco::VertexCollection>();
-                              
+
   pixelClusterShapeCacheToken_ = consumes<SiPixelClusterShapeCache>(iConfig.getParameter<edm::InputTag>("clusterShapeCache"));
 }
 
@@ -137,18 +138,18 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
   if ( !pixelClusterShapeCacheH.isValid() ) {
     edm::LogWarning("SiPixelPhase1TrackClusters")  << "PixelClusterShapeCache collection is not valid";
     return;
-  }  
+  }
   auto const & pixelClusterShapeCache = *pixelClusterShapeCacheH;
 
   for (auto const & track : *tracks) {
 
-    if (applyVertexCut_ && 
+    if (applyVertexCut_ &&
         (track.pt() < 0.75 || std::abs( track.dxy((*vertices)[0].position()) ) > 5 * track.dxyError())) continue;
 
     bool isBpixtrack = false, isFpixtrack = false, crossesPixVol = false;
 
     // find out whether track crosses pixel fiducial volume (for cosmic tracks)
-    auto d0 = track.d0(), dz = track.dz(); 
+    auto d0 = track.d0(), dz = track.dz();
     if (std::abs(d0) < 15 && std::abs(dz) < 50) crossesPixVol = true;
 
     auto etatk = track.eta();
@@ -156,9 +157,9 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
     auto const & trajParams = track.extra()->trajParams();
     assert(trajParams.size()==track.recHitsSize());
     auto hb = track.recHitsBegin();
-    
+
     for (unsigned int h = 0; h < track.recHitsSize(); h++){
-      
+
       auto hit = *(hb + h);
       if (!hit->isValid()) continue;
       auto id = hit->geographicalId();
@@ -169,25 +170,43 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
       if (subdetid == PixelSubdetector::PixelEndcap) isFpixtrack = true;
       if (subdetid != PixelSubdetector::PixelBarrel && subdetid != PixelSubdetector::PixelEndcap) continue;
       bool iAmBarrel = subdetid == PixelSubdetector::PixelBarrel;
-      
+
       // PXB_L4 IS IN THE OTHER WAY
       // CAN BE XORed BUT LETS KEEP THINGS SIMPLE
-      bool iAmOuter = ((tkTpl.pxbLadder(id) % 2 == 1) && tkTpl.pxbLayer(id) != 4) || 
+      bool iAmOuter = ((tkTpl.pxbLadder(id) % 2 == 1) && tkTpl.pxbLayer(id) != 4) ||
                       ((tkTpl.pxbLadder(id) % 2 != 1) && tkTpl.pxbLayer(id) == 4);
-                      
+
       auto pixhit = dynamic_cast<const SiPixelRecHit*>(hit->hit());
       if (!pixhit) continue;
 
-      // auto geomdetunit = dynamic_cast<const PixelGeomDetUnit*>(pixhit->detUnit());
-      // auto const & topol = geomdetunit->specificTopology();
-      
+      auto geomdetunit = dynamic_cast<const PixelGeomDetUnit*>(pixhit->detUnit());
+      auto const & topol = geomdetunit->specificTopology();
+
       // get the cluster
       auto clustp = pixhit->cluster();
-      if (clustp.isNull()) continue; 
+      if (clustp.isNull()) continue;
       auto const & cluster = *clustp;
 
+
+      const std::vector<SiPixelCluster::Pixel> pixelsVec = cluster.pixels();
+
+
+      for (unsigned int i = 0;  i < pixelsVec.size(); ++i) {
+
+        float pixx = pixelsVec[i].x; // index as float=iteger, row index
+        float pixy = pixelsVec[i].y; // same, col index
+
+        bool bigInX = topol.isItBigPixelInX(int(pixx));
+        bool bigInY = topol.isItBigPixelInY(int(pixy));
+        float pixel_charge = pixelsVec[i].adc/1000;
+
+        if (bigInX || bigInY) histo[ON_TRACK_BPCHARGE].fill(pixel_charge, id, &iEvent);
+      }
+
+
+
       auto const & ltp = trajParams[h];
-      
+
       auto localDir = ltp.momentum() / ltp.momentum().mag();
 
       // correct charge for track impact angle
@@ -201,7 +220,7 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
       if(shapeFilter.getSizes(*pixhit, localDir, pixelClusterShapeCache, part, meas, pred)) {
        auto shape = shapeFilter.isCompatible(*pixhit, localDir, pixelClusterShapeCache);
        unsigned shapeVal = (shape ? 1 : 0);
-       
+
        if (iAmBarrel) {
          if(iAmOuter) {
            histo[ON_TRACK_SIZE_X_OUTER].fill(pred.first, cluster.sizeX(), id, &iEvent);
@@ -237,7 +256,7 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
       histo[ON_TRACK_POSITIONF].fill(clustgp.x(),   clustgp.y(),     id, &iEvent);
 
       histo[CHARGE_VS_SIZE_ON_TRACK].fill(cluster.size(), charge, id, &iEvent);
-      
+
       if (iAmBarrel)  // Avoid mistakes even if specification < should > handle it
       {
         if(iAmOuter) {
@@ -252,17 +271,17 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
 
     // statistics on tracks
     histo[NTRACKS].fill(1, DetId(0), &iEvent);
-    if (isBpixtrack || isFpixtrack) 
+    if (isBpixtrack || isFpixtrack)
       histo[NTRACKS].fill(2, DetId(0), &iEvent);
-    if (isBpixtrack) 
+    if (isBpixtrack)
       histo[NTRACKS].fill(3, DetId(0), &iEvent);
-    if (isFpixtrack) 
+    if (isFpixtrack)
       histo[NTRACKS].fill(4, DetId(0), &iEvent);
 
     if (crossesPixVol) {
       if (isBpixtrack || isFpixtrack)
         histo[NTRACKS_INVOLUME].fill(1, DetId(0), &iEvent);
-      else 
+      else
         histo[NTRACKS_INVOLUME].fill(0, DetId(0), &iEvent);
     }
   }
@@ -275,4 +294,3 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SiPixelPhase1TrackClusters);
-

--- a/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
@@ -37,7 +37,8 @@ namespace {
 class SiPixelPhase1TrackClusters final : public SiPixelPhase1Base {
 enum {
   ON_TRACK_CHARGE,
-  ON_TRACK_BPCHARGE,
+  ON_TRACK_BIGPIXELCHARGE,
+  ON_TRACK_NOTBIGPIXELCHARGE,
   ON_TRACK_SIZE,
   ON_TRACK_SHAPE,
   ON_TRACK_NCLUSTERS,
@@ -198,9 +199,10 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
 
         bool bigInX = topol.isItBigPixelInX(int(pixx));
         bool bigInY = topol.isItBigPixelInY(int(pixy));
-        float pixel_charge = pixelsVec[i].adc/1000;
+        float pixel_charge = pixelsVec[i].adc;
 
-        if (bigInX || bigInY) histo[ON_TRACK_BPCHARGE].fill(pixel_charge, id, &iEvent);
+        if (bigInX || bigInY) histo[ON_TRACK_BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
+        else histo[ON_TRACK_NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
       }
 
 

--- a/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+0;95;0c// -*- C++ -*-
 //
 // Package:     SiPixelPhase1TrackClusters
 // Class  :     SiPixelPhase1TrackClusters
@@ -198,14 +198,11 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
         float pixel_charge = pixelsVec[i].adc;
 
         if (bigInX==true || bigInY==true) {
-          std::cout<<"Failure here 1?"<<std::endl;
-          histo[ON_TRACK_BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
+                histo[ON_TRACK_BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
         }
         else {
-          std::cout<<"Failure here 2?"<<std::endl;
-          histo[ON_TRACK_NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
-          std::cout<<"Did this pass?????"<<std::endl;
-
+                histo[ON_TRACK_NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
+      
         }
       } // End loop over pixels
       auto const & ltp = trajParams[h];

--- a/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
@@ -1,4 +1,4 @@
-0;95;0c// -*- C++ -*-
+// -*- C++ -*-
 //
 // Package:     SiPixelPhase1TrackClusters
 // Class  :     SiPixelPhase1TrackClusters
@@ -202,7 +202,7 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
         }
         else {
                 histo[ON_TRACK_NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
-      
+
         }
       } // End loop over pixels
       auto const & ltp = trajParams[h];

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Cluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Cluster_cff.py
@@ -3,13 +3,13 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 from DQMOffline.Trigger.SiPixel_OfflineMonitoring_HistogramManager_cfi import *
 
-# order is important and it should follow ordering in .h !!!
+# order is important and it should follow ordering in hltSiPixelPhase1ClustersConf VPSet
 hltSiPixelPhase1ClustersCharge = hltDefaultHistoDigiCluster.clone(
   name = "charge",
   title = "Cluster Charge",
   range_min = 0, range_max = 200e3, range_nbins = 200,
   xlabel = "Charge (electrons)",
-  
+
   specs = VPSet(
     #StandardSpecification2DProfile,
     hltStandardSpecificationPixelmapProfile,
@@ -17,6 +17,36 @@ hltSiPixelPhase1ClustersCharge = hltDefaultHistoDigiCluster.clone(
 #    StandardSpecifications1D,
     hltStandardSpecifications1D,
     StandardSpecificationTrend2D
+  )
+)
+
+hltSiPixelPhase1ClustersBigPixelCharge = DefaultHistoDigiCluster.clone(
+  name = "bigpixelcharge",
+  title = "Big Pixel Charge",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+  enabled=False,
+
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
+  )
+)
+
+hltSiPixelPhase1ClustersNotBigPixelCharge = DefaultHistoDigiCluster.clone(
+  name = "notbigpixelcharge",
+  title = "Not Big Pixel Charge",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+  enabled=False,
+
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
   )
 )
 
@@ -220,18 +250,18 @@ hltSiPixelPhase1ClustersReadoutNClusters = hltDefaultHistoReadout.clone(
 hltSiPixelPhase1ClustersPixelToStripRatio = hltDefaultHistoDigiCluster.clone(
   name = "cluster_ratio",
   title = "Pixel to Strip clusters ratio",
-  
+
   xlabel = "ratio",
   dimensions = 1,
-  
+
   specs = VPSet(
-    Specification().groupBy("PXAll").save(100, 0, 1), 
+    Specification().groupBy("PXAll").save(100, 0, 1),
     Specification().groupBy("PXAll/Lumisection")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXAll", "EXTEND_X")
                    .save(),
     Specification().groupBy("PXAll/BX")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXAll", "EXTEND_X")
                    .save(),
   )
@@ -239,6 +269,8 @@ hltSiPixelPhase1ClustersPixelToStripRatio = hltDefaultHistoDigiCluster.clone(
 
 hltSiPixelPhase1ClustersConf = cms.VPSet(
   hltSiPixelPhase1ClustersCharge,
+  hltSiPixelPhase1ClustersBigPixelCharge,
+  hltSiPixelPhase1ClustersNotBigPixelCharge,
   hltSiPixelPhase1ClustersSize,
   hltSiPixelPhase1ClustersSizeX,
   hltSiPixelPhase1ClustersSizeY,
@@ -275,4 +307,3 @@ hltSiPixelPhase1ClustersHarvester = DQMEDHarvester("SiPixelPhase1Harvester",
         histograms = hltSiPixelPhase1ClustersConf,
         geometry   = hltSiPixelPhase1Geometry
 )
-

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
@@ -3,7 +3,7 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 from DQMOffline.Trigger.SiPixel_OfflineMonitoring_HistogramManager_cfi import *
 
-# order is important and it should follow ordering in .h !!!
+# order is important and it should follow ordering in hltSiPixelPhase1ClustersConf VPSet
 hltSiPixelPhase1TrackClustersOnTrackCharge = hltDefaultHistoTrack.clone(
   name = "charge",
   title = "Corrected Cluster Charge (OnTrack)",
@@ -15,6 +15,36 @@ hltSiPixelPhase1TrackClustersOnTrackCharge = hltDefaultHistoTrack.clone(
   )
 )
 
+hltSiPixelPhase1TrackClustersOnTrackBigPixelCharge = DefaultHistoTrack.clone(
+  name = "bigpixelcharge",
+  title = "Corrected Big Pixel Charge (OnTrack)",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+  enabled=False,
+
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
+  )
+)
+
+hltSiPixelPhase1TrackClustersOnTrackNotBigPixelCharge = DefaultHistoTrack.clone(
+  name = "notbigpixelcharge",
+  title = "Corrected Not Big Pixel Charge (OnTrack)",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+  enabled=False,
+
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
+  )
+)
+
 hltSiPixelPhase1TrackClustersOnTrackSize = hltDefaultHistoTrack.clone(
   name = "size",
   title = "Total Cluster Size (OnTrack)",
@@ -22,7 +52,7 @@ hltSiPixelPhase1TrackClustersOnTrackSize = hltDefaultHistoTrack.clone(
   xlabel = "size[pixels]",
 
   specs = VPSet(
-    hltStandardSpecifications1D    
+    hltStandardSpecifications1D
   )
 )
 
@@ -58,12 +88,12 @@ hltSiPixelPhase1TrackClustersOnTrackNClusters = hltDefaultHistoTrack.clone(
   xlabel = "clusters",
   dimensions = 0,
   specs = VPSet(
-    Specification().groupBy("PXBarrel/PXLayer" + "/DetId/Event") 
-                   .reduce("COUNT") 
+    Specification().groupBy("PXBarrel/PXLayer" + "/DetId/Event")
+                   .reduce("COUNT")
                    .groupBy("PXBarrel/PXLayer")
                    .saveAll(),
-    Specification().groupBy("PXForward/PXDisk" + "/DetId/Event") 
-                   .reduce("COUNT") 
+    Specification().groupBy("PXForward/PXDisk" + "/DetId/Event")
+                   .reduce("COUNT")
                    .groupBy("PXForward/PXDisk")
                    .saveAll(),
     StandardSpecificationInclusive_Num,
@@ -205,7 +235,7 @@ hltSiPixelPhase1TrackClustersOnTrackSizeXYOuter = hltSiPixelPhase1TrackClustersO
   xlabel = "y size",
   ylabel = "x size",
   range_min = 0, range_max  = 20, range_nbins   = 20,
-  range_y_min = 0, range_y_max = 10, range_y_nbins = 10 
+  range_y_min = 0, range_y_max = 10, range_y_nbins = 10
 )
 
 hltSiPixelPhase1TrackClustersOnTrackSizeXYInner = hltSiPixelPhase1TrackClustersOnTrackSizeXYOuter.clone(
@@ -247,11 +277,11 @@ hltSiPixelPhase1TrackClustersOnTrackChargeOuter = hltDefaultHistoTrack.clone(
     Specification().groupBy("PXBarrel/PXLayer").save()
   )
 )
-  
+
 hltSiPixelPhase1TrackClustersOnTrackChargeInner = hltSiPixelPhase1TrackClustersOnTrackChargeOuter.clone(
   name = "chargeInner",
   title = "Corrected Cluster Charge (OnTrack) inner ladders"
-)  
+)
 
 hltSiPixelPhase1TrackClustersOnTrackShapeOuter = hltDefaultHistoTrack.clone(
   enabled = False,
@@ -275,31 +305,33 @@ hltSiPixelPhase1TrackClustersConf = cms.VPSet(
 ### THE LIST DEFINED IN THE ENUM
 ### https://cmssdt.cern.ch/lxr/source/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc#0063
    hltSiPixelPhase1TrackClustersOnTrackCharge,
+   hltSiPixelPhase1TrackClustersOnTrackBigPixelCharge,
+   hltSiPixelPhase1TrackClustersOnTrackNotBigPixelCharge,
    hltSiPixelPhase1TrackClustersOnTrackSize,
    hltSiPixelPhase1TrackClustersOnTrackShape,
    hltSiPixelPhase1TrackClustersOnTrackNClusters,
    hltSiPixelPhase1TrackClustersOnTrackPositionB,
    hltSiPixelPhase1TrackClustersOnTrackPositionF,
    hltSiPixelPhase1DigisHitmapOnTrack,
- 
+
    hltSiPixelPhase1TrackClustersNTracks,
    hltSiPixelPhase1TrackClustersNTracksInVolume,
- 
+
    hltSiPixelPhase1ClustersSizeVsEtaOnTrackOuter,
    hltSiPixelPhase1ClustersSizeVsEtaOnTrackInner,
    hltSiPixelPhase1TrackClustersOnTrackChargeOuter,
    hltSiPixelPhase1TrackClustersOnTrackChargeInner,
- 
+
    hltSiPixelPhase1TrackClustersOnTrackShapeOuter,
    hltSiPixelPhase1TrackClustersOnTrackShapeInner,
- 
+
    hltSiPixelPhase1TrackClustersOnTrackSizeXOuter,
    hltSiPixelPhase1TrackClustersOnTrackSizeXInner,
    hltSiPixelPhase1TrackClustersOnTrackSizeXF,
    hltSiPixelPhase1TrackClustersOnTrackSizeYOuter,
    hltSiPixelPhase1TrackClustersOnTrackSizeYInner,
    hltSiPixelPhase1TrackClustersOnTrackSizeYF,
- 
+
    hltSiPixelPhase1TrackClustersOnTrackSizeXYOuter,
    hltSiPixelPhase1TrackClustersOnTrackSizeXYInner,
    hltSiPixelPhase1TrackClustersOnTrackSizeXYF,
@@ -321,4 +353,3 @@ hltSiPixelPhase1TrackClustersHarvester = DQMEDHarvester("SiPixelPhase1Harvester"
         histograms = hltSiPixelPhase1TrackClustersConf,
         geometry   = hltSiPixelPhase1Geometry
 )
-


### PR DESCRIPTION
Added the charge of the big pixels for the barrel and the forward region, as well as per layer and per disk
For inclusive clusters and on-track clusters (for inclusive clusters the plots are disabled by default)