### PR TITLE
Validate top level ParameterSets like options

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -11,6 +11,7 @@ PSet script.   See notes in EventProcessor.cpp for details about it.
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ProcessDesc.h"
+#include "FWCore/ParameterSet/interface/validateTopLevelParameterSets.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/PresenceFactory.h"
 #include "FWCore/PluginManager/interface/standard.h"
@@ -133,7 +134,7 @@ int main(int argc, char* argv[]) {
   //NOTE: with new version of TBB (44_20160316oss) we can only construct 1 tbb::task_scheduler_init per job
   // else we get a crash. So for now we can't have any services use tasks in their constructors.
   bool setNThreadsOnCommandLine = false;
-  std::unique_ptr<tbb::task_scheduler_init> tsiPtr = std::make_unique<tbb::task_scheduler_init>(1);
+  std::unique_ptr<tbb::task_scheduler_init> tsiPtr = std::make_unique<tbb::task_scheduler_init>(edm::s_defaultNumberOfThreads);
   std::shared_ptr<edm::Presence> theMessageServicePresence;
   std::unique_ptr<std::ofstream> jobReportStreamPtr;
   std::shared_ptr<edm::serviceregistry::ServiceWrapper<edm::JobReport> > jobRep;
@@ -254,7 +255,7 @@ int main(int argc, char* argv[]) {
       }
       if(not tsiPtr) {
         //If we haven't initialized TBB yet, do it here
-        tsiPtr = std::make_unique<tbb::task_scheduler_init>(1);
+        tsiPtr = std::make_unique<tbb::task_scheduler_init>(edm::s_defaultNumberOfThreads);
       }
 
       if (!vm.count(kParameterSetOpt)) {

--- a/FWCore/Framework/src/ExceptionActions.cc
+++ b/FWCore/Framework/src/ExceptionActions.cc
@@ -48,10 +48,9 @@ namespace edm {
 
 //	cerr << pset.toString() << std::endl;
 
-      ParameterSet defopts;
-      ParameterSet const& opts = pset.getUntrackedParameterSet("options", defopts);
+      ParameterSet const& opts = pset.getUntrackedParameterSet("options");
       //cerr << "looking for " << actionName(code) << std::endl;
-      for(auto const& v: opts.getUntrackedParameter(actionName(code),vstring())) {
+      for(auto const& v: opts.getUntrackedParameter<std::vector<std::string>>(actionName(code))) {
         out[v] = code;
       }
 

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -641,7 +641,7 @@ namespace edm {
                         SubProcessParentageHelper const* subProcessParentageHelper) {
     std::string const output("output");
 
-    ParameterSet const& maxEventsPSet = proc_pset.getUntrackedParameterSet("maxEvents", ParameterSet());
+    ParameterSet const& maxEventsPSet = proc_pset.getUntrackedParameterSet("maxEvents");
     int maxEventSpecs = 0;
     int maxEventsOut = -1;
     ParameterSet const* vMaxEventsOut = nullptr;

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -125,11 +125,11 @@ namespace edm {
     processConfiguration_ = std::make_shared<ProcessConfiguration>(processName, getReleaseVersion(), getPassID()); // propagate_const<T> has no reset() function
     auto common = std::make_shared<CommonParams>(
                                 parameterSet.getUntrackedParameterSet(
-                                   "maxEvents", ParameterSet()).getUntrackedParameter<int>("input", -1),
+                                   "maxEvents").getUntrackedParameter<int>("input"),
                                 parameterSet.getUntrackedParameterSet(
-                                   "maxLuminosityBlocks", ParameterSet()).getUntrackedParameter<int>("input", -1),
+                                   "maxLuminosityBlocks").getUntrackedParameter<int>("input"),
                                 parameterSet.getUntrackedParameterSet(
-                                   "maxSecondsUntilRampdown", ParameterSet()).getUntrackedParameter<int>("input", -1));
+                                   "maxSecondsUntilRampdown").getUntrackedParameter<int>("input"));
     return common;
   }
 

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -88,7 +88,7 @@ namespace edm {
                                     std::multimap<std::string,Worker*>& branchToReadingWorker)
     {
       // See if any data has been marked to be deleted early (removing any duplicates)
-      auto vBranchesToDeleteEarly = opts.getUntrackedParameter<std::vector<std::string>>("canDeleteEarly",std::vector<std::string>());
+      auto vBranchesToDeleteEarly = opts.getUntrackedParameter<std::vector<std::string>>("canDeleteEarly");
       if(not vBranchesToDeleteEarly.empty()) {
         std::sort(vBranchesToDeleteEarly.begin(),vBranchesToDeleteEarly.end(),std::less<std::string>());
         vBranchesToDeleteEarly.erase(std::unique(vBranchesToDeleteEarly.begin(),vBranchesToDeleteEarly.end()),

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -28,6 +28,7 @@
 #include "FWCore/Framework/src/globalTransitionAsync.h"
 #include "FWCore/ParameterSet/interface/IllegalParameters.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/validateTopLevelParameterSets.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Concurrency/interface/WaitingTask.h"
@@ -121,11 +122,13 @@ namespace edm {
     auto subProcessVParameterSet = popSubProcessVParameterSet(*processParameterSet_);
     bool hasSubProcesses = subProcessVParameterSet.size() != 0ull;
 
+    // Validates the parameters in the 'options', 'maxEvents', and 'maxLuminosityBlocks'
+    // top level parameter sets. Default values are also set in here if the
+    // parameters were not explicitly set.
+    validateTopLevelParameterSets(processParameterSet_.get());
+
     ScheduleItems items(*parentProductRegistry, *this);
     actReg_ = items.actReg_;
-
-    ParameterSet const& optionsPset(processParameterSet_->getUntrackedParameterSet("options", ParameterSet()));
-    IllegalParameters::setThrowAnException(optionsPset.getUntrackedParameter<bool>("throwIfIllegalParameter", true));
 
     //initialize the services
     ServiceToken iToken;

--- a/FWCore/Framework/test/test_dependentRunDataAndException_cfg.py
+++ b/FWCore/Framework/test/test_dependentRunDataAndException_cfg.py
@@ -11,4 +11,5 @@ process.consumer = cms.EDAnalyzer("edmtest::IntFromRunConsumingAnalyzer",
 
 process.p = cms.Path(process.consumer,cms.Task(process.intMaker))
 
-process.options = cms.untracked.PSet(numberOfThreads = cms.untracked.uint32(2))
+process.options = cms.untracked.PSet(numberOfThreads = cms.untracked.uint32(2),
+                                     numberOfStreams = cms.untracked.uint32(1))

--- a/FWCore/Framework/test/test_tbb_threads_cfg.py
+++ b/FWCore/Framework/test/test_tbb_threads_cfg.py
@@ -6,7 +6,8 @@ process.source = cms.Source("EmptySource")
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
-process.options = cms.untracked.PSet( numberOfThreads = cms.untracked.uint32(8))
+process.options = cms.untracked.PSet( numberOfThreads = cms.untracked.uint32(8),
+                                      numberOfStreams = cms.untracked.uint32(1))
 
 process.tester = cms.EDAnalyzer("TestTBBTasksAnalyzer",
                                 numTasksToRun = cms.untracked.uint32(10),

--- a/FWCore/Integration/test/run_ParameterSet.sh
+++ b/FWCore/Integration/test/run_ParameterSet.sh
@@ -61,6 +61,10 @@ pushd ${LOCAL_TMP_DIR}
   edmPluginHelp -p ProducerWithPSetDesc -b &> testProducerWithPsetDesc_briefdoc.txt || die "edmPluginHelp -p ProducerWithPSetDesc -b" $?
   diff ${LOCAL_TMP_DIR}/testProducerWithPsetDesc_briefdoc.txt ${LOCAL_TEST_DIR}/unit_test_outputs/testProducerWithPsetDesc_briefdoc.txt || die "comparing testProducerWithPsetDesc_briefdoc.txt" $?
 
+  echo edmPluginHelp -t options -b ---------------------------
+  edmPluginHelp -t options -b &> testEdmPluginHelpOptions.txt || die "edmPluginHelp -t options -b" $?
+  grep "numberOfThreads[[:blank:]]\+untracked uint32[[:blank:]]\+1" testEdmPluginHelpOptions.txt || die "testing edmPluginHelp -t options -b" $?
+
 # Test for errors and success when importing a restricted file in various ways
   echo cmsRun importRestrictions1.py ------------------------------------------------------------
   cmsRun -p ${LOCAL_TEST_DIR}/importRestrictions1.py 2> importRestrictions1.txt

--- a/FWCore/ParameterSet/bin/edmPluginHelp.cpp
+++ b/FWCore/ParameterSet/bin/edmPluginHelp.cpp
@@ -13,6 +13,10 @@
 #include "FWCore/PluginManager/interface/PluginInfo.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescriptionFillerPluginFactory.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescriptionFillerBase.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/validateTopLevelParameterSets.h"
+#include "FWCore/ParameterSet/interface/DocFormatHelper.h"
+
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
@@ -51,6 +55,8 @@ static char const* const kPrintOnlyPluginsOpt = "printOnlyPlugins";
 static char const* const kPrintOnlyPluginsCommandOpt = "printOnlyPlugins,q";
 static char const* const kLineWidthOpt = "lineWidth";
 static char const* const kLineWidthCommandOpt = "lineWidth,w";
+static char const* const kTopLevelOpt = "topLevel";
+static char const* const kTopLevelCommandOpt = "topLevel,t";
 
 namespace {
 
@@ -168,8 +174,42 @@ namespace {
       return;
     }
   }
-}
 
+  void printTopLevelParameterSets(bool brief, size_t lineWidth, std::string const& psetName) {
+
+    std::ostream & os = std::cout;
+
+    edm::ParameterSetDescription description;
+
+    if (psetName == "options") {
+      os << "\nDescription of \'options\' top level ParameterSet\n\n";
+      edm::fillOptionsDescription(description);
+
+    } else if (psetName == "maxEvents") {
+      os << "\nDescription of \'maxEvents\' top level ParameterSet\n\n";
+      edm::fillMaxEventsDescription(description);
+
+    } else if (psetName == "maxLuminosityBlocks") {
+      os << "\nDescription of \'maxLuminosityBlocks\' top level ParameterSet\n\n";
+      edm::fillMaxLuminosityBlocksDescription(description);
+
+    } else if (psetName == "maxSecondsUntilRampdown") {
+      os << "\nDescription of \'maxSecondsUntilRampdown\' top level ParameterSet\n\n";
+      edm::fillMaxSecondsUntilRampdownDescription(description);
+    } else {
+      throw cms::Exception("CommandLineArgument") << "Unrecognized name for top level parameter set. "
+        << "Allowed values are 'options', 'maxEvents', 'maxLuminosityBlocks', and 'maxSecondsUntilRampdown'";
+    }
+
+    edm::DocFormatHelper dfh;
+    dfh.setBrief(brief);
+    dfh.setLineWidth(lineWidth);
+    dfh.setSection("1");
+
+    description.print(os, dfh);
+    os << "\n";
+  }
+}
 // ---------------------------------------------------------------------------------
 
 int main (int argc, char **argv)
@@ -187,7 +227,7 @@ try {
   descString += "For more information about the output format see:\n";
   descString += "https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideConfigurationValidationAndHelp\n\n";
 
-  descString += "At least one of the following options must be used: -p, -l, -a, or -q\n\n";
+  descString += "At least one of the following options must be used: -p, -l, -a, -q, or -t\n\n";
   descString += "Allowed options:";
   boost::program_options::options_description desc(descString);   
   desc.add_options()
@@ -213,7 +253,9 @@ try {
                    "do not print parameter descriptions or module labels, just list plugins matching selection criteria")
                   (kLineWidthCommandOpt,
                    boost::program_options::value<unsigned>(),
-                   "try to limit lines to this length by inserting newlines between words in comments. Long words or names can cause the line length to exceed this limit. Defaults to terminal screen width or 80");
+                   "try to limit lines to this length by inserting newlines between words in comments. Long words or names can cause the line length to exceed this limit. Defaults to terminal screen width or 80")
+                  (kTopLevelCommandOpt, boost::program_options::value<std::string>(),
+                   "print only the description for the top level parameter set with this name. Allowed names are 'options', 'maxEvents', 'maxLuminosityBlocks', and 'maxSecondsUntilRampdown'.");
 
   boost::program_options::variables_map vm;
   try {
@@ -237,6 +279,7 @@ try {
   bool brief = false;
   bool printOnlyLabels = false;
   bool printOnlyPlugins = false;
+  std::string printOnlyTopLevel;
 
   if (vm.count(kPluginOpt)) {
     plugin = vm[kPluginOpt].as<std::string>();
@@ -247,8 +290,9 @@ try {
   if (!vm.count(kAllLibrariesOpt)) {
     if (!vm.count(kPluginOpt) &&
         !vm.count(kLibraryOpt) &&
-        !vm.count(kPrintOnlyPluginsOpt)) {
-      std::cerr << "\nERROR: At least one of the following options must be used: -p, -l, -a, or -q\n\n";
+        !vm.count(kPrintOnlyPluginsOpt) &&
+        !vm.count(kTopLevelOpt)) {
+      std::cerr << "\nERROR: At least one of the following options must be used: -p, -l, -a, -q, or -t\n\n";
       std::cerr << desc << std::endl;
       return 1;
     }
@@ -303,6 +347,12 @@ try {
 
   if (vm.count(kLineWidthOpt)) {
     lineWidth = vm[kLineWidthOpt].as<unsigned>();
+  }
+
+  if (vm.count(kTopLevelOpt)) {
+    printOnlyTopLevel = vm[kTopLevelOpt].as<std::string>();
+    printTopLevelParameterSets(brief, lineWidth, printOnlyTopLevel);
+    return 0;
   }
 
   // Get the list of plugins from the plugin cache

--- a/FWCore/ParameterSet/interface/validateTopLevelParameterSets.h
+++ b/FWCore/ParameterSet/interface/validateTopLevelParameterSets.h
@@ -1,0 +1,17 @@
+#ifndef FWCore_ParameterSet_validateTopLevelParameterSets_h
+#define FWCore_ParameterSet_validateTopLevelParameterSets_h
+
+namespace edm {
+
+  class ParameterSet;
+  class ParameterSetDescription;
+
+  const unsigned int s_defaultNumberOfThreads = 1;
+
+  void validateTopLevelParameterSets(ParameterSet* processParameterSet);
+  void fillOptionsDescription(ParameterSetDescription& description);
+  void fillMaxEventsDescription(ParameterSetDescription& description);
+  void fillMaxLuminosityBlocksDescription(ParameterSetDescription& description);
+  void fillMaxSecondsUntilRampdownDescription(ParameterSetDescription& description);
+}
+#endif

--- a/FWCore/ParameterSet/interface/validateTopLevelParameterSets.h
+++ b/FWCore/ParameterSet/interface/validateTopLevelParameterSets.h
@@ -6,7 +6,7 @@ namespace edm {
   class ParameterSet;
   class ParameterSetDescription;
 
-  const unsigned int s_defaultNumberOfThreads = 1;
+  constexpr unsigned int s_defaultNumberOfThreads = 1;
 
   void validateTopLevelParameterSets(ParameterSet* processParameterSet);
   void fillOptionsDescription(ParameterSetDescription& description);

--- a/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
+++ b/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
@@ -1,0 +1,120 @@
+#include "FWCore/ParameterSet/interface/validateTopLevelParameterSets.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include <sstream>
+#include <vector>
+#include <string>
+
+namespace edm {
+
+void fillOptionsDescription(ParameterSetDescription& description) {
+
+  description.addUntracked<unsigned int>("numberOfThreads", s_defaultNumberOfThreads)->
+    setComment("If zero, let TBB use its default which is normally the number of CPUs on the machine");
+  description.addUntracked<unsigned int>("numberOfStreams", 0)->
+    setComment("If zero, then set the number of streams to be the same as the number of threads");
+  description.addUntracked<unsigned int>("numberOfConcurrentRuns", 1);
+  description.addUntracked<unsigned int>("numberOfConcurrentLuminosityBlocks", 1)->
+    setComment("If zero, then set the same as the number of runs");
+  description.addUntracked<bool>("wantSummary", false)->
+    setComment("Set true to print a report on the trigger decisions and timing of modules");
+  description.addUntracked<std::string>("fileMode", "FULLMERGE")->
+    setComment("Legal values are 'NOMERGE' and 'FULLMERGE'");
+  description.addUntracked<bool>("forceEventSetupCacheClearOnNewRun", false);
+  description.addUntracked<bool>("throwIfIllegalParameter", true)->
+    setComment("Set false to disable exception throws when configuration validation detects illegal parameters");
+  description.addUntracked<bool>("printDependencies", false)->
+    setComment("Print data dependencies between modules");
+
+
+  // No default for this one because the parameter value is
+  // actually used in the main function in cmsRun.cpp before
+  // the parameter set is validated here.
+  description.addOptionalUntracked<unsigned int>("sizeOfStackForThreadsInKB");
+
+  std::vector<std::string> emptyVector;
+
+  description.addUntracked<std::vector<std::string>>("Rethrow", emptyVector);
+  description.addUntracked<std::vector<std::string>>("SkipEvent", emptyVector);
+  description.addUntracked<std::vector<std::string>>("FailPath", emptyVector);
+  description.addUntracked<std::vector<std::string>>("IgnoreCompletely", emptyVector);
+
+  description.addUntracked<std::vector<std::string>>("canDeleteEarly", emptyVector)->
+    setComment("Branch names of products that the Framework can try to delete before the end of the Event");
+
+  description.addOptionalUntracked<bool>("allowUnscheduled")->
+    setComment("Obsolete. Has no effect. Allowed only for backward compatibility for old Python configuration files.");
+  description.addOptionalUntracked<std::string>("emptyRunLumiMode")->
+    setComment("Obsolete. Has no effect. Allowed only for backward compatibility for old Python configuration files.");
+  description.addOptionalUntracked<bool>("makeTriggerResults")->
+    setComment("Obsolete. Has no effect. Allowed only for backward compatibility for old Python configuration files.");
+}
+
+void fillMaxEventsDescription(ParameterSetDescription& description) {
+  description.addUntracked<int>("input", -1)->
+    setComment("Default of -1 implies no limit.");
+
+  ParameterSetDescription nestedDescription;
+  nestedDescription.addWildcardUntracked<int>("*");
+  description.addOptionalNode(ParameterDescription<int>("output", false) xor
+                              ParameterDescription<ParameterSetDescription>("output", nestedDescription, false), false);
+}
+
+void fillMaxLuminosityBlocksDescription(ParameterSetDescription& description) {
+  description.addUntracked<int>("input", -1)->
+    setComment("Default of -1 implies no limit.");
+}
+
+void fillMaxSecondsUntilRampdownDescription(ParameterSetDescription& description) {
+  description.addUntracked<int>("input", -1)->
+    setComment("Default of -1 implies no limit.");
+}
+
+void validateTopLevelParameterSets(ParameterSet* processParameterSet) {
+
+  std::string processName = processParameterSet->getParameter<std::string>("@process_name");
+
+  std::vector<std::string> psetNames {"options", "maxEvents", "maxLuminosityBlocks", "maxSecondsUntilRampdown"};
+
+  for (auto const& psetName : psetNames) {
+
+    bool isTracked {false};
+    ParameterSet* pset = processParameterSet->getPSetForUpdate(psetName, isTracked);
+    if (pset == nullptr) {
+      ParameterSet emptyPset;
+      processParameterSet->addUntrackedParameter<ParameterSet>(psetName, emptyPset);
+      pset = processParameterSet->getPSetForUpdate(psetName, isTracked);
+    }
+    if (isTracked) {
+      throw Exception(errors::Configuration)
+        << "In the configuration the top level parameter set named \'" << psetName << "\' in process \'" << processName << "\' is tracked.\n"
+        << "It must be untracked";
+    }
+
+    ParameterSetDescription description;
+    if (psetName == "options") {
+      fillOptionsDescription(description);
+    } else if (psetName == "maxEvents") {
+      fillMaxEventsDescription(description);
+    } else if (psetName == "maxLuminosityBlocks") {
+      fillMaxLuminosityBlocksDescription(description);
+    } else if (psetName == "maxSecondsUntilRampdown") {
+      fillMaxSecondsUntilRampdownDescription(description);
+    }
+
+    try {
+      description.validate(*pset);
+    } catch(cms::Exception& ex) {
+      std::ostringstream ost;
+      ost << "Validating top level \'" << psetName << "\' ParameterSet for process \'" << processName << "\'";
+      ex.addContext(ost.str());
+      throw;
+    }
+  }
+}
+
+}


### PR DESCRIPTION
One change of behavior comes with this PR. Previously if the configuration did not explicitly specify numberOfStreams it defaulted to 1. After this PR it will default to the number of threads.