### PR TITLE
Make IPCutPFCandidateSelector a stream module

### DIFF
--- a/CommonTools/ParticleFlow/plugins/IPCutPFCandidateSelector.cc
+++ b/CommonTools/ParticleFlow/plugins/IPCutPFCandidateSelector.cc
@@ -4,9 +4,9 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 #include "CommonTools/ParticleFlow/interface/IPCutPFCandidateSelectorDefinition.h"
 
-typedef ObjectSelector<pf2pat::IPCutPFCandidateSelectorDefinition> IPCutPFCandidateSelector;
+typedef ObjectSelectorStream<pf2pat::IPCutPFCandidateSelectorDefinition> IPCutPFCandidateSelector;
 
 DEFINE_FWK_MODULE(IPCutPFCandidateSelector);


### PR DESCRIPTION
As a legacy module, IPCutPFCandidateSelector was preventing the
framework from utilizing concurrent LuminosityBlocks.