### PR TITLE
Update on L2 muon seeding

### DIFF
--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
@@ -77,8 +77,8 @@ L2MuonSeedGeneratorFromL1T::L2MuonSeedGeneratorFromL1T(const edm::ParameterSet& 
   matchingDR(iConfig.getParameter<std::vector<double> >("MatchDR")),          
   etaBins(iConfig.getParameter<std::vector<double> >("EtaMatchingBins")),          
   centralBxOnly_( iConfig.getParameter<bool>("CentralBxOnly") ),
-  matchType( iConfig.getParameter<int>("MatchType") ),
-  sortType( iConfig.getParameter<int>("SortType") )
+  matchType( iConfig.getParameter<unsigned int>("MatchType") ),
+  sortType( iConfig.getParameter<unsigned int>("SortType") )
   {
 
   muCollToken_ = consumes<MuonBxCollection>(theSource);
@@ -135,8 +135,8 @@ L2MuonSeedGeneratorFromL1T::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<std::vector<double>>("MatchDR", {0.3});
   desc.add<std::vector<double>>("EtaMatchingBins", {0., 2.5});
   desc.add<bool>("CentralBxOnly", true);
-  desc.add<int>("MatchType", 0)->setComment("MatchType : 0 Old matching,   1 L1 Order(1to1), 2 Min dR(1to1), 3 Higher Q(1to1), 4 All matched L1");
-  desc.add<int>("SortType", 0)->setComment("SortType :  0 not sort,       1 Pt, 2 Q and Pt");
+  desc.add<unsigned int>("MatchType", 0)->setComment("MatchType : 0 Old matching,   1 L1 Order(1to1), 2 Min dR(1to1), 3 Higher Q(1to1), 4 All matched L1");
+  desc.add<unsigned int>("SortType", 0)->setComment("SortType :  0 not sort,       1 Pt, 2 Q and Pt");
   desc.addUntracked<edm::InputTag>("OfflineSeedLabel", edm::InputTag(""));
 
   edm::ParameterSetDescription psd0;

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
@@ -657,9 +657,6 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
           if( !(tempDR < newDRcone) )  continue;
 
           // Remove column for given offSeed
-          for(i=0; i<nMuColl; ++i) {
-            dRmtx[i][theOffs] = 999;
-          }
           removed_col[theOffs] = true;
 
           if( selOffseeds[nL1][theOffs] != nullptr ) {
@@ -711,13 +708,7 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
           if( !(tempDR < newDRcone) )  continue;
 
           // Remove row and column for given (L1mu, offSeed)
-          for(i=0; i<nMuColl; ++i) {
-            dRmtx[i][theOffs] = 999;
-          }
           removed_col[theOffs] = true;
-          for(j=0; j<nOfflineSeed1; ++j) {
-            dRmtx[theL1][j] = 999;
-          }
           removed_row[theL1] = true;
 
           if( selOffseeds[theL1][theOffs] != nullptr ) {
@@ -810,13 +801,7 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
           if( !(tempDR < newDRcone) )  continue;
 
           // Remove row and column for given (L1mu, offSeed)
-          for(i=0; i<nMuColl; ++i) {
-            dRmtx[i][theOffs] = 999;
-          }
           removed_col[theOffs] = true;
-          for(j=0; j<nOfflineSeed1; ++j) {
-            dRmtx[theL1][j] = 999;
-          }
           removed_row[theL1] = true;
 
           if( selOffseeds[theL1][theOffs] != nullptr ) {

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
@@ -11,6 +11,8 @@
  *   \author  A.Everett, R.Bellan, J. Alcaraz
  *
  *    ORCA's author: N. Neumeister 
+ *
+ *    Modified by M.Oh
  */
 //
 //--------------------------------------------------
@@ -41,6 +43,28 @@ using namespace std;
 using namespace edm;
 using namespace l1t;
 
+//--- Functions used in output sorting
+bool SortByL1Pt(L2MuonTrajectorySeed &A, L2MuonTrajectorySeed &B) {
+  l1t::MuonRef Ref_L1A = A.l1tParticle();
+  l1t::MuonRef Ref_L1B = B.l1tParticle();
+  return (Ref_L1A->pt() > Ref_L1B->pt());
+};
+
+bool SortByL1QandPt(L2MuonTrajectorySeed &A, L2MuonTrajectorySeed &B) {
+  l1t::MuonRef Ref_L1A = A.l1tParticle();
+  l1t::MuonRef Ref_L1B = B.l1tParticle();
+
+  // Compare quality first
+  if (Ref_L1A->hwQual() > Ref_L1B->hwQual())  return true;
+  if (Ref_L1A->hwQual() < Ref_L1B->hwQual())  return false;
+
+  // For same quality L1s compare pT
+  if (Ref_L1A->pt() > Ref_L1B->pt())  return true;
+  if (Ref_L1A->pt() < Ref_L1B->pt())  return false;
+
+  return false;
+};
+
 // constructors
 L2MuonSeedGeneratorFromL1T::L2MuonSeedGeneratorFromL1T(const edm::ParameterSet& iConfig) : 
   theSource(iConfig.getParameter<InputTag>("InputObjects")),
@@ -54,7 +78,12 @@ L2MuonSeedGeneratorFromL1T::L2MuonSeedGeneratorFromL1T(const edm::ParameterSet& 
             iConfig.getParameter<bool>("UseUnassociatedL1") : true),
   matchingDR(iConfig.getParameter<std::vector<double> >("MatchDR")),          
   etaBins(iConfig.getParameter<std::vector<double> >("EtaMatchingBins")),          
-  centralBxOnly_( iConfig.getParameter<bool>("CentralBxOnly") )
+  centralBxOnly_( iConfig.getParameter<bool>("CentralBxOnly") ),
+
+  // MatchType : 0 Old matching,   1 L1 Order(1to1), 2 Min dR(1to1), 3 Higher Q(1to1), 4 All matched L1
+  // SortType :  0 not sort,       1 Pt, 2 Q and Pt
+  matchType( iConfig.getParameter<int>("MatchType") ),
+  sortType( iConfig.getParameter<int>("SortType") )
   {
 
   muCollToken_ = consumes<MuonBxCollection>(theSource);
@@ -105,6 +134,10 @@ L2MuonSeedGeneratorFromL1T::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<std::vector<double>>("MatchDR", {0.3});
   desc.add<std::vector<double>>("EtaMatchingBins", {0., 2.5});
   desc.add<bool>("CentralBxOnly", true);
+
+  desc.add<int>("MatchType", 0);
+  desc.add<int>("SortType", 0);
+
   desc.addUntracked<edm::InputTag>("OfflineSeedLabel", edm::InputTag(""));
 
   edm::ParameterSetDescription psd0;
@@ -124,246 +157,804 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
 
   auto output = std::make_unique<L2MuonTrajectorySeedCollection>();
   
+  if(matchType>4 || sortType>3) {
+    throw cms::Exception("Configuration") << "Wrong MatchType or SortType" << endl;
+  }
+
   edm::Handle<MuonBxCollection> muColl;
   iEvent.getByToken(muCollToken_, muColl);
   LogTrace(metname) << "Number of muons " << muColl->size() << endl;
 
-  edm::Handle<edm::View<TrajectorySeed> > offlineSeedHandle;
-  vector<int> offlineSeedMap;
-  if(useOfflineSeed) {
-    iEvent.getByToken(offlineSeedToken_, offlineSeedHandle);
-    LogTrace(metname) << "Number of offline seeds " << offlineSeedHandle->size() << endl;
-    offlineSeedMap = vector<int>(offlineSeedHandle->size(), 0);
+  /*
+  if(muColl->size()>3){
+    cout << endl;
+    cout << iEvent.id().run() << ":" << iEvent.id().luminosityBlock() << ":" << iEvent.id().event() << endl;
   }
+  */
 
-  for (int ibx = muColl->getFirstBX(); ibx <= muColl->getLastBX(); ++ibx) {
-    if (centralBxOnly_ && (ibx != 0)) continue;
-    for (auto it = muColl->begin(ibx); it != muColl->end(ibx); it++){
-  
-      unsigned int quality = it->hwQual();
-      int valid_charge = it->hwChargeValid();
-  
-      float pt    =  it->pt();
-      float eta   =  it->eta();
-      float theta =  2*atan(exp(-eta));
-      float phi   =  it->phi();      
-      int charge  =  it->charge();
-      // Set charge=0 for the time being if the valid charge bit is zero
-      if (!valid_charge) charge = 0;
+  //--- matchType 0 : Old logic
+  if(matchType == 0) {
 
-      int link = 36 + (int)(it -> tfMuonIndex() / 3.);
-      bool barrel = true;
-      if ( (link >= 36 && link <= 41) || (link >= 66 && link <= 71)) barrel = false;
+    edm::Handle<edm::View<TrajectorySeed> > offlineSeedHandle;
+    vector<int> offlineSeedMap;
+    if(useOfflineSeed) {
+      iEvent.getByToken(offlineSeedToken_, offlineSeedHandle);
+      LogTrace(metname) << "Number of offline seeds " << offlineSeedHandle->size() << endl;
+      offlineSeedMap = vector<int>(offlineSeedHandle->size(), 0);
+    }
 
-      if ( pt < theL1MinPt || fabs(eta) > theL1MaxEta ) continue;
-  
-      LogTrace(metname) << "New L2 Muon Seed" ;
-      LogTrace(metname) << "Pt = "         << pt     << " GeV/c";
-      LogTrace(metname) << "eta = "        << eta; 
-      LogTrace(metname) << "theta = "      << theta  << " rad";
-      LogTrace(metname) << "phi = "        << phi    << " rad";
-      LogTrace(metname) << "charge = "     << charge;
-      LogTrace(metname) << "In Barrel? = " << barrel;
-  
-      if ( quality <= theL1MinQuality ) continue;
-      LogTrace(metname) << "quality = "<< quality; 
-  
-      // Update the services
-      theService->update(iSetup);
+    for (int ibx = muColl->getFirstBX(); ibx <= muColl->getLastBX(); ++ibx) {
+      if (centralBxOnly_ && (ibx != 0)) continue;
+      for (auto it = muColl->begin(ibx); it != muColl->end(ibx); it++){
 
-      const DetLayer *detLayer = nullptr;
-      float radius = 0.;
+        unsigned int quality = it->hwQual();
+        int valid_charge = it->hwChargeValid();
 
-      CLHEP::Hep3Vector vec(0.,1.,0.);
-      vec.setTheta(theta);
-      vec.setPhi(phi);
-  
-      DetId theid; 
-      // Get the det layer on which the state should be put
-      if ( barrel ){
-        LogTrace(metname) << "The seed is in the barrel";
-    
-        // MB2
-        DetId id = DTChamberId(0,2,0);
-        detLayer = theService->detLayerGeometry()->idToLayer(id);
-        LogTrace(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
-    
-        const BoundSurface* sur = &(detLayer->surface());
-        const BoundCylinder* bc = dynamic_cast<const BoundCylinder*>(sur);
+        float pt    =  it->pt();
+        float eta   =  it->eta();
+        float theta =  2*atan(exp(-eta));
+        float phi   =  it->phi();      
+        int charge  =  it->charge();
+        // Set charge=0 for the time being if the valid charge bit is zero
+        if (!valid_charge) charge = 0;
 
-        radius = fabs(bc->radius()/sin(theta));
-        theid  = id;    
+        int link = 36 + (int)(it -> tfMuonIndex() / 3.);
+        bool barrel = true;
+        if ( (link >= 36 && link <= 41) || (link >= 66 && link <= 71)) barrel = false;
 
-        LogTrace(metname) << "radius "<<radius;
+        if ( pt < theL1MinPt || fabs(eta) > theL1MaxEta ) continue;
 
-        if ( pt < 3.5 ) pt = 3.5;
+        LogTrace(metname) << "New L2 Muon Seed" ;
+        LogTrace(metname) << "Pt = "         << pt     << " GeV/c";
+        LogTrace(metname) << "eta = "        << eta; 
+        LogTrace(metname) << "theta = "      << theta  << " rad";
+        LogTrace(metname) << "phi = "        << phi    << " rad";
+        LogTrace(metname) << "charge = "     << charge;
+        LogTrace(metname) << "In Barrel? = " << barrel;
+
+        if ( quality <= theL1MinQuality ) continue;
+        LogTrace(metname) << "quality = "<< quality; 
+
+        // Update the services
+        theService->update(iSetup);
+
+        const DetLayer *detLayer = nullptr;
+        float radius = 0.;
+
+        CLHEP::Hep3Vector vec(0.,1.,0.);
+        vec.setTheta(theta);
+        vec.setPhi(phi);
+
+        DetId theid; 
+        // Get the det layer on which the state should be put
+        if ( barrel ){
+          LogTrace(metname) << "The seed is in the barrel";
+
+          // MB2
+          DetId id = DTChamberId(0,2,0);
+          detLayer = theService->detLayerGeometry()->idToLayer(id);
+          LogTrace(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
+
+          const BoundSurface* sur = &(detLayer->surface());
+          const BoundCylinder* bc = dynamic_cast<const BoundCylinder*>(sur);
+
+          radius = fabs(bc->radius()/sin(theta));
+          theid  = id;    
+
+          LogTrace(metname) << "radius "<<radius;
+
+          if ( pt < 3.5 ) pt = 3.5;
+        }
+        else {
+          LogTrace(metname) << "The seed is in the endcap";
+
+          DetId id;
+          // ME2
+          if ( theta < Geom::pi()/2. )
+            id = CSCDetId(1,2,0,0,0); 
+          else
+            id = CSCDetId(2,2,0,0,0); 
+
+          detLayer = theService->detLayerGeometry()->idToLayer(id);
+          LogTrace(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
+
+          radius = fabs(detLayer->position().z()/cos(theta));      
+          theid = id;    
+
+          if( pt < 1.0) pt = 1.0;
+        }
+
+        // Fallback solution using ME2
+        DetId fallback_id;
+        theta < Geom::pi()/2. ? fallback_id = CSCDetId(1,2,0,0,0) : fallback_id = CSCDetId(2,2,0,0,0); 
+        const DetLayer* ME2DetLayer = theService->detLayerGeometry()->idToLayer(fallback_id);
+
+        vec.setMag(radius);
+
+        GlobalPoint pos(vec.x(),vec.y(),vec.z());
+
+        GlobalVector mom(pt*cos(phi), pt*sin(phi), pt*cos(theta)/sin(theta));
+
+        GlobalTrajectoryParameters param(pos,mom,charge,&*theService->magneticField());
+        AlgebraicSymMatrix55 mat;
+
+        mat[0][0] = (0.25/pt)*(0.25/pt);  // sigma^2(charge/abs_momentum)
+        if ( !barrel ) mat[0][0] = (0.4/pt)*(0.4/pt);
+
+        //Assign q/pt = 0 +- 1/pt if charge has been declared invalid
+        if (!valid_charge) mat[0][0] = (1./pt)*(1./pt);
+
+        mat[1][1] = 0.05*0.05;        // sigma^2(lambda)
+        mat[2][2] = 0.2*0.2;          // sigma^2(phi)
+        mat[3][3] = 20.*20.;          // sigma^2(x_transverse))
+        mat[4][4] = 20.*20.;          // sigma^2(y_transverse))
+
+        CurvilinearTrajectoryError error(mat);
+
+        const FreeTrajectoryState state(param,error);
+
+        LogTrace(metname) << "Free trajectory State from the parameters";
+        LogTrace(metname) << debug.dumpFTS(state);
+
+        // Propagate the state on the MB2/ME2 surface
+        TrajectoryStateOnSurface tsos = theService->propagator(thePropagatorName)->propagate(state, detLayer->surface());
+
+        LogTrace(metname) << "State after the propagation on the layer";
+        LogTrace(metname) << debug.dumpLayer(detLayer);
+        LogTrace(metname) << debug.dumpTSOS(tsos);
+
+      double dRcone = matchingDR[0];
+      if ( fabs(eta) < etaBins.back() ){
+      std::vector<double>::iterator lowEdge = std::upper_bound (etaBins.begin(), etaBins.end(), fabs(eta));
+      dRcone    =  matchingDR.at( lowEdge - etaBins.begin() - 1);   
       }
-      else { 
-        LogTrace(metname) << "The seed is in the endcap";
-    
-        DetId id;
-        // ME2
-        if ( theta < Geom::pi()/2. )
-          id = CSCDetId(1,2,0,0,0); 
-        else
-          id = CSCDetId(2,2,0,0,0); 
-    
-        detLayer = theService->detLayerGeometry()->idToLayer(id);
-        LogTrace(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
 
-        radius = fabs(detLayer->position().z()/cos(theta));      
-        theid = id;    
-    
-        if( pt < 1.0) pt = 1.0;
-      }
-      
-      // Fallback solution using ME2
-      DetId fallback_id;
-      theta < Geom::pi()/2. ? fallback_id = CSCDetId(1,2,0,0,0) : fallback_id = CSCDetId(2,2,0,0,0); 
-      const DetLayer* ME2DetLayer = theService->detLayerGeometry()->idToLayer(fallback_id);
+        if (tsos.isValid()) {
 
-      vec.setMag(radius);
-  
-      GlobalPoint pos(vec.x(),vec.y(),vec.z());
-    
-      GlobalVector mom(pt*cos(phi), pt*sin(phi), pt*cos(theta)/sin(theta));
+          edm::OwnVector<TrackingRecHit> container;
 
-      GlobalTrajectoryParameters param(pos,mom,charge,&*theService->magneticField());
-      AlgebraicSymMatrix55 mat;
-  
-      mat[0][0] = (0.25/pt)*(0.25/pt);  // sigma^2(charge/abs_momentum)
-      if ( !barrel ) mat[0][0] = (0.4/pt)*(0.4/pt);
+          if(useOfflineSeed && ( !valid_charge || charge == 0) ) {
 
-      //Assign q/pt = 0 +- 1/pt if charge has been declared invalid
-      if (!valid_charge) mat[0][0] = (1./pt)*(1./pt);
-  
-      mat[1][1] = 0.05*0.05;        // sigma^2(lambda)
-      mat[2][2] = 0.2*0.2;          // sigma^2(phi)
-      mat[3][3] = 20.*20.;          // sigma^2(x_transverse))
-      mat[4][4] = 20.*20.;          // sigma^2(y_transverse))
-  
-      CurvilinearTrajectoryError error(mat);
+            const TrajectorySeed *assoOffseed = 
+              associateOfflineSeedToL1(offlineSeedHandle, offlineSeedMap, tsos, dRcone );
 
-      const FreeTrajectoryState state(param,error);
- 
-      LogTrace(metname) << "Free trajectory State from the parameters";
-      LogTrace(metname) << debug.dumpFTS(state);
-
-      // Propagate the state on the MB2/ME2 surface
-      TrajectoryStateOnSurface tsos = theService->propagator(thePropagatorName)->propagate(state, detLayer->surface());
- 
-      LogTrace(metname) << "State after the propagation on the layer";
-      LogTrace(metname) << debug.dumpLayer(detLayer);
-      LogTrace(metname) << debug.dumpTSOS(tsos);
-
- 	  double dRcone = matchingDR[0];
-	  if ( fabs(eta) < etaBins.back() ){
-		std::vector<double>::iterator lowEdge = std::upper_bound (etaBins.begin(), etaBins.end(), fabs(eta));     
-		dRcone    =  matchingDR.at( lowEdge - etaBins.begin() - 1);   
-	  }
-
-      if (tsos.isValid()) {
-
-        edm::OwnVector<TrackingRecHit> container;
-   
-        if(useOfflineSeed && ( !valid_charge || charge == 0) ) {
-
-          const TrajectorySeed *assoOffseed = 
-   	        associateOfflineSeedToL1(offlineSeedHandle, offlineSeedMap, tsos, dRcone );
-    
-          if(assoOffseed!=nullptr) {
-            PTrajectoryStateOnDet const & seedTSOS = assoOffseed->startingState();
-            TrajectorySeed::const_iterator 
-            tsci  = assoOffseed->recHits().first,
-            tscie = assoOffseed->recHits().second;
-            for(; tsci!=tscie; ++tsci) {
-              container.push_back(*tsci);
-            }
-            output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
-                              MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
-          }
-          else {
-            if(useUnassociatedL1) {
-              // convert the TSOS into a PTSOD
-              PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( tsos, theid.rawId());
+            if(assoOffseed!=nullptr) {
+              PTrajectoryStateOnDet const & seedTSOS = assoOffseed->startingState();
+              TrajectorySeed::const_iterator 
+              tsci  = assoOffseed->recHits().first,
+              tscie = assoOffseed->recHits().second;
+              for(; tsci!=tscie; ++tsci) {
+                container.push_back(*tsci);
+              }
               output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
                                 MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
             }
-          }
-        }
-        else if (useOfflineSeed && valid_charge){
-          // Get the compatible dets on the layer
-          std::vector< pair<const GeomDet*,TrajectoryStateOnSurface> > 
-            detsWithStates = detLayer->compatibleDets(tsos, 
-                              *theService->propagator(thePropagatorName), 
-                              *theEstimator);   
-
-          if (detsWithStates.empty() && barrel ) {
-            // try again to propagate but using ME2 as reference
-            tsos = theService->propagator(thePropagatorName)->propagate(state, ME2DetLayer->surface());
-            detsWithStates = ME2DetLayer->compatibleDets(tsos, 
-                                           *theService->propagator(thePropagatorName), 
-                                           *theEstimator);   
-          }
-
-          if (!detsWithStates.empty()){
-  
-            TrajectoryStateOnSurface newTSOS = detsWithStates.front().second;
-            const GeomDet *newTSOSDet = detsWithStates.front().first;
-    
-            LogTrace(metname) << "Most compatible det";
-            LogTrace(metname) << debug.dumpMuonId(newTSOSDet->geographicalId());
-  
-            LogDebug(metname) << "L1 info: Det and State:";
-            LogDebug(metname) << debug.dumpMuonId(newTSOSDet->geographicalId());
-  
-            if (newTSOS.isValid()){
-  
-              //LogDebug(metname) << "(x, y, z) = (" << newTSOS.globalPosition().x() << ", " 
-              //                  << newTSOS.globalPosition().y() << ", " << newTSOS.globalPosition().z() << ")";
-              LogDebug(metname) << "pos: (r=" << newTSOS.globalPosition().mag() << ", phi=" 
-                                << newTSOS.globalPosition().phi() << ", eta=" << newTSOS.globalPosition().eta() << ")";
-              LogDebug(metname) << "mom: (q*pt=" << newTSOS.charge()*newTSOS.globalMomentum().perp() << ", phi=" 
-                                << newTSOS.globalMomentum().phi() << ", eta=" << newTSOS.globalMomentum().eta() << ")";
-  
-              //LogDebug(metname) << "State on it";
-              //LogDebug(metname) << debug.dumpTSOS(newTSOS);
-  
-              const TrajectorySeed *assoOffseed = 
-                associateOfflineSeedToL1(offlineSeedHandle, offlineSeedMap, newTSOS, dRcone);
-  
-              if(assoOffseed!=nullptr) {
-                PTrajectoryStateOnDet const & seedTSOS = assoOffseed->startingState();
-                TrajectorySeed::const_iterator 
-                  tsci  = assoOffseed->recHits().first,
-                  tscie = assoOffseed->recHits().second;
-                for(; tsci!=tscie; ++tsci) {
-                  container.push_back(*tsci);
-                }
+            else {
+              if(useUnassociatedL1) {
+                // convert the TSOS into a PTSOD
+                PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( tsos, theid.rawId());
                 output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
                                   MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
               }
-              else {
-                if(useUnassociatedL1) {
-                  // convert the TSOS into a PTSOD
-                  PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( newTSOS,newTSOSDet->geographicalId().rawId());
+            }
+          }
+          else if (useOfflineSeed && valid_charge){
+            // Get the compatible dets on the layer
+            std::vector< pair<const GeomDet*,TrajectoryStateOnSurface> > 
+              detsWithStates = detLayer->compatibleDets(tsos, 
+                                *theService->propagator(thePropagatorName), 
+                                *theEstimator);   
+
+            if (detsWithStates.empty() && barrel ) {
+              // try again to propagate but using ME2 as reference
+              tsos = theService->propagator(thePropagatorName)->propagate(state, ME2DetLayer->surface());
+              detsWithStates = ME2DetLayer->compatibleDets(tsos, 
+                                             *theService->propagator(thePropagatorName), 
+                                             *theEstimator);   
+            }
+
+            if (!detsWithStates.empty()){
+
+              TrajectoryStateOnSurface newTSOS = detsWithStates.front().second;
+              const GeomDet *newTSOSDet = detsWithStates.front().first;
+
+              LogTrace(metname) << "Most compatible det";
+              LogTrace(metname) << debug.dumpMuonId(newTSOSDet->geographicalId());
+
+              LogDebug(metname) << "L1 info: Det and State:";
+              LogDebug(metname) << debug.dumpMuonId(newTSOSDet->geographicalId());
+
+              if (newTSOS.isValid()){
+
+                //LogDebug(metname) << "(x, y, z) = (" << newTSOS.globalPosition().x() << ", "
+                //                  << newTSOS.globalPosition().y() << ", " << newTSOS.globalPosition().z() << ")";
+                LogDebug(metname) << "pos: (r=" << newTSOS.globalPosition().mag() << ", phi="
+                                  << newTSOS.globalPosition().phi() << ", eta=" << newTSOS.globalPosition().eta() << ")";
+                LogDebug(metname) << "mom: (q*pt=" << newTSOS.charge()*newTSOS.globalMomentum().perp() << ", phi="
+                                  << newTSOS.globalMomentum().phi() << ", eta=" << newTSOS.globalMomentum().eta() << ")";
+
+                //LogDebug(metname) << "State on it";
+                //LogDebug(metname) << debug.dumpTSOS(newTSOS);
+
+                const TrajectorySeed *assoOffseed =
+                  associateOfflineSeedToL1(offlineSeedHandle, offlineSeedMap, newTSOS, dRcone);
+
+                if(assoOffseed!=nullptr) {
+                  PTrajectoryStateOnDet const & seedTSOS = assoOffseed->startingState();
+                  TrajectorySeed::const_iterator
+                    tsci  = assoOffseed->recHits().first,
+                    tscie = assoOffseed->recHits().second;
+                  for(; tsci!=tscie; ++tsci) {
+                    container.push_back(*tsci);
+                  }
                   output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
                                     MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
                 }
-              } 
-            }
-          } 
+                else {
+                  if(useUnassociatedL1) {
+                    // convert the TSOS into a PTSOD
+                    PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( newTSOS,newTSOSDet->geographicalId().rawId());
+                    output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
+                                      MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+                  }
+                } 
+              }
+            } 
+          }
+          else {
+            // convert the TSOS into a PTSOD
+            PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( tsos, theid.rawId());
+            output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
+                              MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+          }      
+        }  
+      }
+    }
+
+  } // End of matchType 0
+
+  //--- matchType > 0 : Updated logics
+  else if(matchType > 0) {
+
+    unsigned int NmuColl = muColl->size();
+
+    vector< vector<double> > dRmtx;
+    vector< vector<const TrajectorySeed *> > selOffseeds;
+
+    edm::Handle<edm::View<TrajectorySeed> > offlineSeedHandle;
+    if(useOfflineSeed) {
+      iEvent.getByToken(offlineSeedToken_, offlineSeedHandle);
+      unsigned int NofflineSeed = offlineSeedHandle->size();
+      LogTrace(metname) << "Number of offline seeds " << NofflineSeed << endl;
+
+      // Initialize dRmtx and selOffseeds
+      dRmtx = vector< vector<double> >(NmuColl, vector<double>(NofflineSeed, 999.0));
+      selOffseeds = vector< vector <const TrajectorySeed *> >(NmuColl, vector<const TrajectorySeed *>(NofflineSeed, nullptr));
+    }
+
+    // At least one L1 muons are associated with offSeed
+    bool isAsso = false;
+
+    //--- Fill dR matrix
+    for (int ibx = muColl->getFirstBX(); ibx <= muColl->getLastBX(); ++ibx) {
+      if (centralBxOnly_ && (ibx != 0)) continue;
+      for (auto it = muColl->begin(ibx); it != muColl->end(ibx); it++){
+
+        //Position of given L1mu
+        unsigned int imu = distance(muColl->begin(muColl->getFirstBX()),it);
+
+        unsigned int quality = it->hwQual();
+        int valid_charge = it->hwChargeValid();
+
+        float pt    =  it->pt();
+        float eta   =  it->eta();
+        float theta =  2*atan(exp(-eta));
+        float phi   =  it->phi();
+        int charge  =  it->charge();
+        // Set charge=0 for the time being if the valid charge bit is zero
+        if (!valid_charge) charge = 0;
+
+        int link = 36 + (int)(it -> tfMuonIndex() / 3.);
+        bool barrel = true;
+        if ( (link >= 36 && link <= 41) || (link >= 66 && link <= 71)) barrel = false;
+
+        if ( pt < theL1MinPt || fabs(eta) > theL1MaxEta ) continue;
+
+        LogTrace(metname) << "New L2 Muon Seed" ;
+        LogTrace(metname) << "Pt = "         << pt     << " GeV/c";
+        LogTrace(metname) << "eta = "        << eta;
+        LogTrace(metname) << "theta = "      << theta  << " rad";
+        LogTrace(metname) << "phi = "        << phi    << " rad";
+        LogTrace(metname) << "charge = "     << charge;
+        LogTrace(metname) << "In Barrel? = " << barrel;
+
+        if ( quality <= theL1MinQuality ) continue;
+        LogTrace(metname) << "quality = "<< quality;
+
+        // Update the services
+        theService->update(iSetup);
+
+        const DetLayer *detLayer = nullptr;
+        float radius = 0.;
+
+        CLHEP::Hep3Vector vec(0.,1.,0.);
+        vec.setTheta(theta);
+        vec.setPhi(phi);
+
+        DetId theid;
+        // Get the det layer on which the state should be put
+        if ( barrel ){
+          LogTrace(metname) << "The seed is in the barrel";
+
+          // MB2
+          DetId id = DTChamberId(0,2,0);
+          detLayer = theService->detLayerGeometry()->idToLayer(id);
+          LogTrace(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
+
+          const BoundSurface* sur = &(detLayer->surface());
+          const BoundCylinder* bc = dynamic_cast<const BoundCylinder*>(sur);
+
+          radius = fabs(bc->radius()/sin(theta));
+          theid  = id;
+
+          LogTrace(metname) << "radius "<<radius;
+
+          if ( pt < 3.5 ) pt = 3.5;
         }
         else {
-          // convert the TSOS into a PTSOD
-          PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( tsos, theid.rawId());
-          output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
-                            MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
-        }      
-      }  
+          LogTrace(metname) << "The seed is in the endcap";
+
+          DetId id;
+          // ME2
+          if ( theta < Geom::pi()/2. )
+            id = CSCDetId(1,2,0,0,0);
+          else
+            id = CSCDetId(2,2,0,0,0);
+
+          detLayer = theService->detLayerGeometry()->idToLayer(id);
+          LogTrace(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
+
+          radius = fabs(detLayer->position().z()/cos(theta));
+          theid = id;
+
+          if( pt < 1.0) pt = 1.0;
+        }
+
+        // Fallback solution using ME2
+        DetId fallback_id;
+        theta < Geom::pi()/2. ? fallback_id = CSCDetId(1,2,0,0,0) : fallback_id = CSCDetId(2,2,0,0,0);
+        const DetLayer* ME2DetLayer = theService->detLayerGeometry()->idToLayer(fallback_id);
+
+        vec.setMag(radius);
+
+        GlobalPoint pos(vec.x(),vec.y(),vec.z());
+
+        GlobalVector mom(pt*cos(phi), pt*sin(phi), pt*cos(theta)/sin(theta));
+
+        GlobalTrajectoryParameters param(pos,mom,charge,&*theService->magneticField());
+        AlgebraicSymMatrix55 mat;
+
+        mat[0][0] = (0.25/pt)*(0.25/pt);  // sigma^2(charge/abs_momentum)
+        if ( !barrel ) mat[0][0] = (0.4/pt)*(0.4/pt);
+
+        //Assign q/pt = 0 +- 1/pt if charge has been declared invalid
+        if (!valid_charge) mat[0][0] = (1./pt)*(1./pt);
+
+        mat[1][1] = 0.05*0.05;        // sigma^2(lambda)
+        mat[2][2] = 0.2*0.2;          // sigma^2(phi)
+        mat[3][3] = 20.*20.;          // sigma^2(x_transverse))
+        mat[4][4] = 20.*20.;          // sigma^2(y_transverse))
+
+        CurvilinearTrajectoryError error(mat);
+
+        const FreeTrajectoryState state(param,error);
+
+        LogTrace(metname) << "Free trajectory State from the parameters";
+        LogTrace(metname) << debug.dumpFTS(state);
+
+        // Propagate the state on the MB2/ME2 surface
+        TrajectoryStateOnSurface tsos = theService->propagator(thePropagatorName)->propagate(state, detLayer->surface());
+
+        LogTrace(metname) << "State after the propagation on the layer";
+        LogTrace(metname) << debug.dumpLayer(detLayer);
+        LogTrace(metname) << debug.dumpTSOS(tsos);
+
+        double dRcone = matchingDR[0];
+        if ( fabs(eta) < etaBins.back() ){
+          std::vector<double>::iterator lowEdge = std::upper_bound (etaBins.begin(), etaBins.end(), fabs(eta));
+          dRcone    =  matchingDR.at( lowEdge - etaBins.begin() - 1);
+        }
+
+        if (tsos.isValid()) {
+
+          edm::OwnVector<TrackingRecHit> container;
+
+          if(useOfflineSeed) {
+
+            if( ( !valid_charge || charge == 0 ) ) {
+
+              bool isAssoOffseed = isAssociateOfflineSeedToL1(offlineSeedHandle, dRmtx, tsos, imu, selOffseeds, dRcone );
+
+              if(isAssoOffseed) {
+                isAsso = true;
+              }
+
+              // Using old way
+              else {
+                if(useUnassociatedL1) {
+                  // convert the TSOS into a PTSOD
+                  PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( tsos, theid.rawId());
+                  output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
+                                    MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+                }
+              }
+
+            }
+
+            else if( valid_charge ) {
+
+              // Get the compatible dets on the layer
+              std::vector< pair<const GeomDet*,TrajectoryStateOnSurface> >
+                detsWithStates = detLayer->compatibleDets(tsos,
+                                  *theService->propagator(thePropagatorName),
+                                  *theEstimator);
+
+              if (detsWithStates.empty() && barrel ) {
+                // try again to propagate but using ME2 as reference
+                tsos = theService->propagator(thePropagatorName)->propagate(state, ME2DetLayer->surface());
+                detsWithStates = ME2DetLayer->compatibleDets(tsos,
+                                               *theService->propagator(thePropagatorName),
+                                               *theEstimator);
+              }
+
+              if (!detsWithStates.empty()){
+
+                TrajectoryStateOnSurface newTSOS = detsWithStates.front().second;
+                const GeomDet *newTSOSDet = detsWithStates.front().first;
+
+                LogTrace(metname) << "Most compatible det";
+                LogTrace(metname) << debug.dumpMuonId(newTSOSDet->geographicalId());
+
+                LogDebug(metname) << "L1 info: Det and State:";
+                LogDebug(metname) << debug.dumpMuonId(newTSOSDet->geographicalId());
+
+                if (newTSOS.isValid()){
+
+                  //LogDebug(metname) << "(x, y, z) = (" << newTSOS.globalPosition().x() << ", "
+                  //                  << newTSOS.globalPosition().y() << ", " << newTSOS.globalPosition().z() << ")";
+                  LogDebug(metname) << "pos: (r=" << newTSOS.globalPosition().mag() << ", phi="
+                                    << newTSOS.globalPosition().phi() << ", eta=" << newTSOS.globalPosition().eta() << ")";
+                  LogDebug(metname) << "mom: (q*pt=" << newTSOS.charge()*newTSOS.globalMomentum().perp() << ", phi="
+                                    << newTSOS.globalMomentum().phi() << ", eta=" << newTSOS.globalMomentum().eta() << ")";
+
+                  //LogDebug(metname) << "State on it";
+                  //LogDebug(metname) << debug.dumpTSOS(newTSOS);
+
+                  bool isAssoOffseed = isAssociateOfflineSeedToL1(offlineSeedHandle, dRmtx, newTSOS, imu, selOffseeds, dRcone );
+
+                  if(isAssoOffseed) {
+                    isAsso = true;
+                  }
+
+                  // Using old way
+                  else {
+                    if(useUnassociatedL1) {
+                      // convert the TSOS into a PTSOD
+                      PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( newTSOS,newTSOSDet->geographicalId().rawId());
+                      output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
+                                        MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+                    }
+                  }
+
+                }
+              }
+            }
+          } // useOfflineSeed
+
+          else {
+            // convert the TSOS into a PTSOD
+            PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( tsos, theid.rawId());
+            output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
+                              MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+          }
+
+        }
+      }
+    }
+
+    // MatchType : 0 Old matching,   1 L1 Order(1to1), 2 Min dR(1to1), 3 Higher Q(1to1), 4 All matched L1
+    if(useOfflineSeed && isAsso) {
+      unsigned int NofflineSeed1 = offlineSeedHandle->size();
+
+      unsigned int nL1;
+      unsigned int i, j; // for the matrix element
+
+      /*
+      if(muColl->size()>3){
+        cout << "New Logic" << endl;
+        cout << "nL1 = " << muColl->size() << endl;
+        cout << "nOffseed = " << NofflineSeed1 << endl;
+        cout << "L1" << endl;
+        for (int ibx = muColl->getFirstBX(); ibx <= muColl->getLastBX(); ++ibx) {
+          for (auto tempit = muColl->begin(ibx); tempit != muColl->end(ibx); tempit++){
+            cout << "\t[BX " << ibx << "]\tpT=" << tempit->pt() << "\tEta=" << tempit->eta() << "\tQ=" << tempit->hwQual() << endl;
+          }
+        }
+
+        cout << endl;
+        cout << "|| New  Matrix ||" << endl;
+        for(i=0; i<NmuColl; ++i) {
+          for(j=0; j<NofflineSeed1; ++j) {
+            cout << dRmtx[i][j] << "    ";
+          }
+          cout << endl;
+        }
+        cout << endl;
+        cout << "|| New SelOffSeeds ||" << endl;
+        for(i=0; i<NmuColl; ++i) {
+          for(j=0; j<NofflineSeed1; ++j) {
+            cout << selOffseeds[i][j] << "    ";
+          }
+          cout << endl;
+        }
+      }
+      */
+
+      if(matchType==1) {
+
+        for(nL1=0; nL1 < NmuColl; ++nL1) {
+          double tempDR = 999;
+          int theL1 = nL1;
+          int theOffs = 0;
+
+          for(j=0; j<NofflineSeed1; ++j) {
+            if( tempDR > dRmtx[theL1][j] ) {
+              tempDR = dRmtx[theL1][j];
+              theOffs = j;
+            }
+          }
+
+          auto Newit = muColl->begin(muColl->getFirstBX()) + theL1;
+
+          double NewdRcone = matchingDR[0];
+          if ( fabs(Newit->eta()) < etaBins.back() ){
+            std::vector<double>::iterator lowEdge = std::upper_bound (etaBins.begin(), etaBins.end(), fabs(Newit->eta()));
+            NewdRcone    =  matchingDR.at( lowEdge - etaBins.begin() - 1);
+          }
+
+          if( !(tempDR < NewdRcone) )  continue;
+
+          // Remove row and column for given (L1mu, offSeed)
+          for(i=0; i<NmuColl; ++i) {
+            for(j=0; j<NofflineSeed1; ++j) {
+              dRmtx[theL1][j] = 999;
+              dRmtx[i][theOffs] = 999;
+            }
+          }
+
+          if( selOffseeds[theL1][theOffs] != nullptr ) {
+            //put given L1mu and offSeed to output
+            edm::OwnVector<TrackingRecHit> Newcontainer;
+
+            PTrajectoryStateOnDet const & seedTSOS = selOffseeds[theL1][theOffs] ->startingState();
+                          TrajectorySeed::const_iterator
+                          tsci  = selOffseeds[theL1][theOffs]->recHits().first,
+                          tscie = selOffseeds[theL1][theOffs]->recHits().second;
+                          for(; tsci!=tscie; ++tsci) {
+                            Newcontainer.push_back(*tsci);
+                          }
+                          output->push_back(L2MuonTrajectorySeed(seedTSOS,Newcontainer,alongMomentum,
+                                            MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),Newit)  )));
+          }
+        }
+      }
+
+      else if(matchType==2) {
+
+        for(nL1=0; nL1 < NmuColl; ++nL1) {
+          double tempDR = 999;
+          int theL1 = 0;
+          int theOffs = 0;
+
+          for(i=0; i<NmuColl; ++i) {
+            for(j=0; j<NofflineSeed1; ++j) {
+              if(tempDR > dRmtx[i][j]) {
+                tempDR = dRmtx[i][j];
+                theL1 = i;
+                theOffs = j;
+              }
+            }
+          }
+
+          auto Newit = muColl->begin(muColl->getFirstBX()) + theL1;
+
+          double NewdRcone = matchingDR[0];
+          if ( fabs(Newit->eta()) < etaBins.back() ){
+            std::vector<double>::iterator lowEdge = std::upper_bound (etaBins.begin(), etaBins.end(), fabs(Newit->eta()));
+            NewdRcone    =  matchingDR.at( lowEdge - etaBins.begin() - 1);
+          }
+
+          if( !(tempDR < NewdRcone) )  continue;
+
+          // Remove row and column for given (L1mu, offSeed)
+          for(i=0; i<NmuColl; ++i) {
+            for(j=0; j<NofflineSeed1; ++j) {
+              dRmtx[theL1][j] = 999;
+              dRmtx[i][theOffs] = 999;
+            }
+          }
+
+          if( selOffseeds[theL1][theOffs] != nullptr ) {
+            //put given L1mu and offSeed to output
+            edm::OwnVector<TrackingRecHit> Newcontainer;
+
+            PTrajectoryStateOnDet const & seedTSOS = selOffseeds[theL1][theOffs] ->startingState();
+                          TrajectorySeed::const_iterator
+                          tsci  = selOffseeds[theL1][theOffs]->recHits().first,
+                          tscie = selOffseeds[theL1][theOffs]->recHits().second;
+                          for(; tsci!=tscie; ++tsci) {
+                            Newcontainer.push_back(*tsci);
+                          }
+                          output->push_back(L2MuonTrajectorySeed(seedTSOS,Newcontainer,alongMomentum,
+                                            MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),Newit)  )));
+          }
+        }
+      }
+
+      else if(matchType==3) {
+
+        for(nL1=0; nL1 < NmuColl; ++nL1) {
+          double tempDR = 999;
+          int theL1 = 0;
+          int theOffs = 0;
+          auto theit = muColl->begin(muColl->getFirstBX());
+
+          // L1Q > 10 (L1Q = 12)
+          for(i=0; i<NmuColl; ++i) {
+            theit = muColl->begin(muColl->getFirstBX()) + i;
+            if (theit->hwQual() > 10) {
+              for(j=0; j<NofflineSeed1; ++j) {
+                if(tempDR > dRmtx[i][j]) {
+                  tempDR = dRmtx[i][j];
+                  theL1 = i;
+                  theOffs = j;
+                }
+              }
+            }
+          }
+
+          // 6 < L1Q <= 10 (L1Q = 8)
+          if (tempDR == 999) {
+            for(i=0; i<NmuColl; ++i) {
+              theit = muColl->begin(muColl->getFirstBX()) + i;
+              if ( (theit->hwQual() <= 10) && (theit->hwQual() > 6) ) {
+                for(j=0; j<NofflineSeed1; ++j) {
+                  if(tempDR > dRmtx[i][j]) {
+                    tempDR = dRmtx[i][j];
+                    theL1 = i;
+                    theOffs = j;
+                  }
+                }
+              }
+            }
+          }
+
+          // L1Q <= 6 (L1Q = 4)
+          if (tempDR == 999) {
+            for(i=0; i<NmuColl; ++i) {
+              theit = muColl->begin(muColl->getFirstBX()) + i;
+              if (theit->hwQual() <= 6) {
+                for(j=0; j<NofflineSeed1; ++j) {
+                  if(tempDR > dRmtx[i][j]) {
+                    tempDR = dRmtx[i][j];
+                    theL1 = i;
+                    theOffs = j;
+                  }
+                }
+              }
+            }
+          }
+
+          auto Newit = muColl->begin(muColl->getFirstBX()) + theL1;
+
+          double NewdRcone = matchingDR[0];
+          if ( fabs(Newit->eta()) < etaBins.back() ){
+            std::vector<double>::iterator lowEdge = std::upper_bound (etaBins.begin(), etaBins.end(), fabs(Newit->eta()));
+            NewdRcone    =  matchingDR.at( lowEdge - etaBins.begin() - 1);
+          }
+
+          if( !(tempDR < NewdRcone) )  continue;
+
+          // Remove row and column for given (L1mu, offSeed)
+          for(i=0; i<NmuColl; ++i) {
+            for(j=0; j<NofflineSeed1; ++j) {
+              dRmtx[theL1][j] = 999;
+              dRmtx[i][theOffs] = 999;
+            }
+          }
+
+          if( selOffseeds[theL1][theOffs] != nullptr ) {
+            //put given L1mu and offSeed to output
+            edm::OwnVector<TrackingRecHit> Newcontainer;
+
+            PTrajectoryStateOnDet const & seedTSOS = selOffseeds[theL1][theOffs] ->startingState();
+                          TrajectorySeed::const_iterator
+                          tsci  = selOffseeds[theL1][theOffs]->recHits().first,
+                          tscie = selOffseeds[theL1][theOffs]->recHits().second;
+                          for(; tsci!=tscie; ++tsci) {
+                            Newcontainer.push_back(*tsci);
+                          }
+                          output->push_back(L2MuonTrajectorySeed(seedTSOS,Newcontainer,alongMomentum,
+                                            MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),Newit)  )));
+          }
+        }
+      }
+
+      else if(matchType==4) {
+
+        for(i=0; i<NmuColl; ++i) {
+
+          auto Newit = muColl->begin(muColl->getFirstBX()) + i;
+
+          double tempDR = 999;
+          int theOffs = 0;
+
+          double NewdRcone = matchingDR[0];
+          if ( fabs(Newit->eta()) < etaBins.back() ){
+            std::vector<double>::iterator lowEdge = std::upper_bound (etaBins.begin(), etaBins.end(), fabs(Newit->eta()));
+            NewdRcone    =  matchingDR.at( lowEdge - etaBins.begin() - 1);
+          }
+
+          for(j=0; j<NofflineSeed1; ++j) {
+            if( tempDR > dRmtx[i][j] ) {
+              tempDR = dRmtx[i][j];
+              theOffs = j;
+            }
+          }
+
+          if( !(tempDR < NewdRcone) )  continue;
+
+          if( selOffseeds[i][theOffs] != nullptr ) {
+            //put given L1mu and offSeed to output
+            edm::OwnVector<TrackingRecHit> Newcontainer;
+
+            PTrajectoryStateOnDet const & seedTSOS = selOffseeds[i][theOffs] ->startingState();
+                          TrajectorySeed::const_iterator
+                          tsci  = selOffseeds[i][theOffs]->recHits().first,
+                          tscie = selOffseeds[i][theOffs]->recHits().second;
+                          for(; tsci!=tscie; ++tsci) {
+                            Newcontainer.push_back(*tsci);
+                          }
+                          output->push_back(L2MuonTrajectorySeed(seedTSOS,Newcontainer,alongMomentum,
+                                            MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),Newit)  )));
+          }
+        }
+      }
+
+    } // useOfflineSeed && isAsso
+
+  } // matchType > 0
+
+  //--- SortType 1 : by L1 pT
+  if(sortType == 1) {
+    sort(output->begin(),output->end(),SortByL1Pt);
+  }
+
+  //--- SortType 2 : by L1 quality and pT
+  else if(sortType == 2) {
+    sort(output->begin(),output->end(),SortByL1QandPt);
+  }
+
+  /*
+  if(muColl->size()>3){
+    cout << "Output" << endl;
+    for(unsigned int k=0; k<output->size(); ++k){
+      l1t::MuonRef Ref_L1 = output->at(k).l1tParticle();
+      cout << "\tpT=" << Ref_L1->pt() << "\tEta=" << Ref_L1->eta() << "\tQ=" << Ref_L1->hwQual() << endl;
     }
   }
-  
+  */
+
   iEvent.put(std::move(output));
 }
 
@@ -434,4 +1025,89 @@ const TrajectorySeed* L2MuonSeedGeneratorFromL1T::associateOfflineSeedToL1( edm:
   }
 
   return selOffseed;
+}
+
+
+bool L2MuonSeedGeneratorFromL1T::isAssociateOfflineSeedToL1( edm::Handle<edm::View<TrajectorySeed> > & offseeds,
+                                     std::vector< std::vector<double> > & dRmtx,
+                                     TrajectoryStateOnSurface & newTsos,
+                                     unsigned int imu,
+                                     std::vector< std::vector<const TrajectorySeed *> > & selOffseeds,
+                                     double dRcone ) {
+
+  const std::string metlabel = "Muon|RecoMuon|L2MuonSeedGeneratorFromL1T";
+  bool isAssociated = false;
+  MuonPatternRecoDumper debugtmp;
+
+  edm::View<TrajectorySeed>::const_iterator offseed, endOffseed = offseeds->end();
+  unsigned int nOffseed(0);
+
+  LogDebug(metlabel) << endl;
+  LogDebug(metlabel) << "[~ loop on L2 off seeds ~]" << endl;
+  LogDebug(metlabel) << endl;
+
+  for(offseed=offseeds->begin(); offseed!=endOffseed; ++offseed, ++nOffseed) {
+    LogDebug(metlabel) << "||||||||||||||||||||||||" << endl;
+    LogDebug(metlabel) << "||| " << nOffseed << "th Offline Seed |||" << endl;
+    LogDebug(metlabel) << "||||||||||||||||||||||||" << endl;
+
+
+    GlobalPoint  glbPos = theService->trackingGeometry()->idToDet(offseed->startingState().detId())->surface().toGlobal(offseed->startingState().parameters().position());
+    GlobalVector glbMom = theService->trackingGeometry()->idToDet(offseed->startingState().detId())->surface().toGlobal(offseed->startingState().parameters().momentum());
+
+    // Preliminary check
+    double preDr = deltaR( newTsos.globalPosition().eta(), newTsos.globalPosition().phi(), glbPos.eta(), glbPos.phi() );
+    if(preDr > 1.0) {
+      LogDebug(metlabel) << "!(preDr > 1.0)" << endl;
+      continue;
+    }
+
+    const FreeTrajectoryState offseedFTS(glbPos, glbMom, offseed->startingState().parameters().charge(), &*theService->magneticField());
+    TrajectoryStateOnSurface offseedTsos = theService->propagator(thePropagatorName)->propagate(offseedFTS, newTsos.surface());
+    LogDebug(metlabel) << "Offline seed info: Det and State" << std::endl;
+    LogDebug(metlabel) << debugtmp.dumpMuonId(offseed->startingState().detId()) << std::endl;
+    //LogDebug(metlabel) << "(x, y, z) = (" << newTSOS.globalPosition().x() << ", "
+    //                     << newTSOS.globalPosition().y() << ", " << newTSOS.globalPosition().z() << ")" << std::endl;
+    LogDebug(metlabel) << "pos: (r=" << offseedFTS.position().mag() <<
+                              ", phi=" << offseedFTS.position().phi() <<
+                              ", eta=" << offseedFTS.position().eta() << ")" << std::endl;
+    LogDebug(metlabel) << "mom: (q*pt=" << offseedFTS.charge()*offseedFTS.momentum().perp() <<
+                              ", phi=" << offseedFTS.momentum().phi() <<
+                              ", eta=" << offseedFTS.momentum().eta() << ")" << std::endl << std::endl;
+    //LogDebug(metlabel) << debugtmp.dumpFTS(offseedFTS) << std::endl;
+
+    if(offseedTsos.isValid()) {
+      LogDebug(metlabel) << "Offline seed info after propagation to L1 layer:" << std::endl;
+      //LogDebug(metlabel) << "(x, y, z) = (" << offseedTsos.globalPosition().x() << ", "
+      //                   << offseedTsos.globalPosition().y() << ", " << offseedTsos.globalPosition().z() << ")" << std::endl;
+      LogDebug(metlabel) << "pos: (r=" << offseedTsos.globalPosition().mag() <<
+                                ", phi=" << offseedTsos.globalPosition().phi() <<
+                                ", eta=" << offseedTsos.globalPosition().eta() << ")" << std::endl;
+      LogDebug(metlabel) << "mom: (q*pt=" << offseedTsos.charge()*offseedTsos.globalMomentum().perp() <<
+                                ", phi=" << offseedTsos.globalMomentum().phi() <<
+                                ", eta=" << offseedTsos.globalMomentum().eta() << ")" << std::endl << std::endl;
+      //LogDebug(metlabel) << debugtmp.dumpTSOS(offseedTsos) << std::endl;
+      double newDr = deltaR( newTsos.globalPosition().eta(),     newTsos.globalPosition().phi(),
+                             offseedTsos.globalPosition().eta(), offseedTsos.globalPosition().phi() );
+
+
+      LogDebug(metlabel) << "   -- DR = " << newDr << std::endl;
+      if( newDr < dRcone ) {
+        LogDebug(metlabel) << "          --> OK! " << newDr << std::endl << std::endl;
+
+        dRmtx[imu][nOffseed] = newDr;
+        selOffseeds[imu][nOffseed] = &*offseed;
+
+        isAssociated = true;
+      }
+      else {
+        LogDebug(metlabel) << "          --> Rejected. " << newDr << std::endl << std::endl;
+      }
+    }
+    else {
+      LogDebug(metlabel) << "Invalid offline seed TSOS after propagation!" << std::endl << std::endl;
+    }
+  }
+
+  return isAssociated;
 }

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h
@@ -71,10 +71,8 @@ class L2MuonSeedGeneratorFromL1T : public edm::stream::EDProducer<> {
   const double theL1MinPt;
   const double theL1MaxEta;
   const unsigned theL1MinQuality;
-
   const double theMinPtBarrel;
   const double theMinPtEndcap;
-
   const bool useOfflineSeed;
   const bool useUnassociatedL1;
   std::vector<double> matchingDR;
@@ -82,7 +80,6 @@ class L2MuonSeedGeneratorFromL1T : public edm::stream::EDProducer<> {
 
   /// use central bx only muons
   bool centralBxOnly_;
-
   const int matchType;
   const int sortType;
 

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h
@@ -71,6 +71,10 @@ class L2MuonSeedGeneratorFromL1T : public edm::stream::EDProducer<> {
   const double theL1MinPt;
   const double theL1MaxEta;
   const unsigned theL1MinQuality;
+
+  const double theMinPtBarrel;
+  const double theMinPtEndcap;
+
   const bool useOfflineSeed;
   const bool useUnassociatedL1;
   std::vector<double> matchingDR;

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h
@@ -80,8 +80,8 @@ class L2MuonSeedGeneratorFromL1T : public edm::stream::EDProducer<> {
 
   /// use central bx only muons
   bool centralBxOnly_;
-  const int matchType;
-  const int sortType;
+  const unsigned matchType;
+  const unsigned sortType;
 
   /// the event setup proxy, it takes care the services update
   MuonServiceProxy *theService;  

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h
@@ -14,6 +14,8 @@
  *   \author  A.Everett, R.Bellan
  *
  *    ORCA's author: N. Neumeister 
+ *
+ *    Modified by M.Oh
  */
 //L2MuonSeedGeneratorFromL1T
 //--------------------------------------------------
@@ -77,6 +79,9 @@ class L2MuonSeedGeneratorFromL1T : public edm::stream::EDProducer<> {
   /// use central bx only muons
   bool centralBxOnly_;
 
+  const int matchType;
+  const int sortType;
+
   /// the event setup proxy, it takes care the services update
   MuonServiceProxy *theService;  
 
@@ -86,6 +91,13 @@ class L2MuonSeedGeneratorFromL1T : public edm::stream::EDProducer<> {
 						  std::vector<int> &, 
 						  TrajectoryStateOnSurface &,
 						  double );
+
+  bool isAssociateOfflineSeedToL1( edm::Handle<edm::View<TrajectorySeed> > &,
+              std::vector< std::vector<double> > &,
+              TrajectoryStateOnSurface &,
+              unsigned int,
+              std::vector< std::vector<const TrajectorySeed *> > &,
+              double );
 
 };
 


### PR DESCRIPTION
This PR updates the L2 Muon seeding logic.

involving,

- Fix dependency on the order of the L1 candidates
- Be more robust to ghost muons/duplicates from the L1 muon system
- Make sure to keep all the needed informations from L1 muons for further HLT muon reconstruction

In order to make it work in the HLT menu, one should add below two lines at the end of given menu,
process.hltL2MuonSeeds.MatchType = cms.int32(0)
process.hltL2MuonSeeds.SortType = cms.int32(0)


Latest performance tests are done within 92X and they can be found in below link [1].
Efficiency drop in slide 5 of [1] was due to simple typo in 'hadd' command and it recovered  after the fix [2].

[1] https://indico.cern.ch/event/694534/contributions/2848643/attachments/1583751/2503305/L2Seeding_MuonHLT_Min_20180116_v2.pdf
[2] https://cernbox.cern.ch/index.php/s/n8fBQECa10OTjof