### PR TITLE
one::OutputModules optionally called for Run or LuminosityBlock

### DIFF
--- a/FWCore/Framework/interface/one/OutputModule.h
+++ b/FWCore/Framework/interface/one/OutputModule.h
@@ -44,7 +44,13 @@ namespace edm {
 #endif
       
       // ---------- const member functions ---------------------
-      
+      bool wantsGlobalRuns() const final {
+        return WantsGlobalRunTransitions<T...>::value;
+      }
+      bool wantsGlobalLuminosityBlocks() const final {
+        return WantsGlobalLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -95,8 +95,8 @@ namespace edm {
       static void prevalidate(ConfigurationDescriptions& );
       
       //Output modules always need writeRun and writeLumi to be called
-      bool wantsGlobalRuns() const {return true;}
-      bool wantsGlobalLuminosityBlocks() const {return true;}
+      virtual bool wantsGlobalRuns() const = 0;
+      virtual bool wantsGlobalLuminosityBlocks() const = 0;
       bool wantsStreamRuns() const {return false;}
       bool wantsStreamLuminosityBlocks() const {return false;};
 

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -120,8 +120,6 @@ GlobalContext: transition = BeginRun
 ++++++ finished: global begin run for module: label = 'a2' id = 6
 ++++++ starting: global begin run for module: label = 'a3' id = 7
 ++++++ finished: global begin run for module: label = 'a3' id = 7
-++++++ starting: global begin run for module: label = 'out' id = 8
-++++++ finished: global begin run for module: label = 'out' id = 8
 ++++ finished: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
@@ -214,8 +212,6 @@ GlobalContext: transition = BeginLuminosityBlock
 ++++++ finished: global begin lumi for module: label = 'a2' id = 6
 ++++++ starting: global begin lumi for module: label = 'a3' id = 7
 ++++++ finished: global begin lumi for module: label = 'a3' id = 7
-++++++ starting: global begin lumi for module: label = 'out' id = 8
-++++++ finished: global begin lumi for module: label = 'out' id = 8
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -890,8 +886,6 @@ GlobalContext: transition = EndLuminosityBlock
 ++++++ finished: global end lumi for module: label = 'a2' id = 6
 ++++++ starting: global end lumi for module: label = 'a3' id = 7
 ++++++ finished: global end lumi for module: label = 'a3' id = 7
-++++++ starting: global end lumi for module: label = 'out' id = 8
-++++++ finished: global end lumi for module: label = 'out' id = 8
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -984,8 +978,6 @@ GlobalContext: transition = EndRun
 ++++++ finished: global end run for module: label = 'a2' id = 6
 ++++++ starting: global end run for module: label = 'a3' id = 7
 ++++++ finished: global end run for module: label = 'a3' id = 7
-++++++ starting: global end run for module: label = 'out' id = 8
-++++++ finished: global end run for module: label = 'out' id = 8
 ++++ finished: global end run 1 : time = 15000001
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -85,8 +85,6 @@ GlobalContext: transition = BeginRun
 
 ++++++ starting: global begin run for module: label = 'intVectorProducer' id = 7
 ++++++ finished: global begin run for module: label = 'intVectorProducer' id = 7
-++++++ starting: global begin run for module: label = 'out' id = 5
-++++++ finished: global begin run for module: label = 'out' id = 5
 ++++ finished: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
@@ -141,8 +139,6 @@ GlobalContext: transition = BeginLuminosityBlock
 
 ++++++ starting: global begin lumi for module: label = 'intVectorProducer' id = 7
 ++++++ finished: global begin lumi for module: label = 'intVectorProducer' id = 7
-++++++ starting: global begin lumi for module: label = 'out' id = 5
-++++++ finished: global begin lumi for module: label = 'out' id = 5
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -683,8 +679,6 @@ GlobalContext: transition = EndLuminosityBlock
 
 ++++++ starting: global end lumi for module: label = 'intVectorProducer' id = 7
 ++++++ finished: global end lumi for module: label = 'intVectorProducer' id = 7
-++++++ starting: global end lumi for module: label = 'out' id = 5
-++++++ finished: global end lumi for module: label = 'out' id = 5
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -739,8 +733,6 @@ GlobalContext: transition = EndRun
 
 ++++++ starting: global end run for module: label = 'intVectorProducer' id = 7
 ++++++ finished: global end run for module: label = 'intVectorProducer' id = 7
-++++++ starting: global end run for module: label = 'out' id = 5
-++++++ finished: global end run for module: label = 'out' id = 5
 ++++ finished: global end run 1 : time = 15000001
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -258,8 +258,6 @@
 ++++++ finished: global begin run for module: label = 'getInt' id = 35
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin run for module: label = 'out' id = 37
-++++++ finished: global begin run for module: label = 'out' id = 37
 ++++ finished: global begin run 1 : time = 1
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
@@ -271,8 +269,6 @@
 ++++++ finished: global begin run for module: label = 'getInt' id = 22
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin run for module: label = 'out' id = 24
-++++++ finished: global begin run for module: label = 'out' id = 24
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
@@ -326,8 +322,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'out' id = 37
-++++++ finished: global begin lumi for module: label = 'out' id = 37
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -339,8 +333,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'out' id = 24
-++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
@@ -1064,8 +1056,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'out' id = 37
-++++++ finished: global end lumi for module: label = 'out' id = 37
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -1077,8 +1067,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
@@ -1112,8 +1100,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'out' id = 37
-++++++ finished: global begin lumi for module: label = 'out' id = 37
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -1125,8 +1111,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'out' id = 24
-++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
@@ -1850,8 +1834,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'out' id = 37
-++++++ finished: global end lumi for module: label = 'out' id = 37
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -1863,8 +1845,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
@@ -1898,8 +1878,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'out' id = 37
-++++++ finished: global begin lumi for module: label = 'out' id = 37
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -1911,8 +1889,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'out' id = 24
-++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
@@ -2312,8 +2288,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'out' id = 37
-++++++ finished: global end lumi for module: label = 'out' id = 37
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -2325,8 +2299,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
@@ -2382,8 +2354,6 @@
 ++++++ finished: global end run for module: label = 'getInt' id = 35
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end run for module: label = 'out' id = 37
-++++++ finished: global end run for module: label = 'out' id = 37
 ++++ finished: global end run 1 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
@@ -2395,8 +2365,6 @@
 ++++++ finished: global end run for module: label = 'getInt' id = 22
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end run for module: label = 'out' id = 24
-++++++ finished: global end run for module: label = 'out' id = 24
 ++++ finished: global end run 1 : time = 0
 ++++++ starting: write run for module: label = 'out' id = 24
 ++++++ finished: write run for module: label = 'out' id = 24
@@ -2430,8 +2398,6 @@
 ++++++ finished: global begin run for module: label = 'getInt' id = 35
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin run for module: label = 'out' id = 37
-++++++ finished: global begin run for module: label = 'out' id = 37
 ++++ finished: global begin run 2 : time = 55000001
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
@@ -2443,8 +2409,6 @@
 ++++++ finished: global begin run for module: label = 'getInt' id = 22
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin run for module: label = 'out' id = 24
-++++++ finished: global begin run for module: label = 'out' id = 24
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
@@ -2498,8 +2462,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'out' id = 37
-++++++ finished: global begin lumi for module: label = 'out' id = 37
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -2511,8 +2473,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'out' id = 24
-++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
@@ -3236,8 +3196,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'out' id = 37
-++++++ finished: global end lumi for module: label = 'out' id = 37
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -3249,8 +3207,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
@@ -3284,8 +3240,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'out' id = 37
-++++++ finished: global begin lumi for module: label = 'out' id = 37
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -3297,8 +3251,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'out' id = 24
-++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
@@ -4022,8 +3974,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'out' id = 37
-++++++ finished: global end lumi for module: label = 'out' id = 37
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -4035,8 +3985,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
@@ -4070,8 +4018,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'out' id = 37
-++++++ finished: global begin lumi for module: label = 'out' id = 37
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -4083,8 +4029,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'out' id = 24
-++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
@@ -4484,8 +4428,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'out' id = 37
-++++++ finished: global end lumi for module: label = 'out' id = 37
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -4497,8 +4439,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
@@ -4554,8 +4494,6 @@
 ++++++ finished: global end run for module: label = 'getInt' id = 35
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end run for module: label = 'out' id = 37
-++++++ finished: global end run for module: label = 'out' id = 37
 ++++ finished: global end run 2 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
@@ -4567,8 +4505,6 @@
 ++++++ finished: global end run for module: label = 'getInt' id = 22
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end run for module: label = 'out' id = 24
-++++++ finished: global end run for module: label = 'out' id = 24
 ++++ finished: global end run 2 : time = 0
 ++++++ starting: write run for module: label = 'out' id = 24
 ++++++ finished: write run for module: label = 'out' id = 24
@@ -4602,8 +4538,6 @@
 ++++++ finished: global begin run for module: label = 'getInt' id = 35
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin run for module: label = 'out' id = 37
-++++++ finished: global begin run for module: label = 'out' id = 37
 ++++ finished: global begin run 3 : time = 105000001
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
@@ -4615,8 +4549,6 @@
 ++++++ finished: global begin run for module: label = 'getInt' id = 22
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin run for module: label = 'out' id = 24
-++++++ finished: global begin run for module: label = 'out' id = 24
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
@@ -4670,8 +4602,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'out' id = 37
-++++++ finished: global begin lumi for module: label = 'out' id = 37
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -4683,8 +4613,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'out' id = 24
-++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
@@ -5408,8 +5336,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'out' id = 37
-++++++ finished: global end lumi for module: label = 'out' id = 37
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -5421,8 +5347,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
@@ -5456,8 +5380,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'out' id = 37
-++++++ finished: global begin lumi for module: label = 'out' id = 37
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -5469,8 +5391,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'out' id = 24
-++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
@@ -6194,8 +6114,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'out' id = 37
-++++++ finished: global end lumi for module: label = 'out' id = 37
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -6207,8 +6125,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
@@ -6242,8 +6158,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'out' id = 37
-++++++ finished: global begin lumi for module: label = 'out' id = 37
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -6255,8 +6169,6 @@
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'out' id = 24
-++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
@@ -6656,8 +6568,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'out' id = 37
-++++++ finished: global end lumi for module: label = 'out' id = 37
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -6669,8 +6579,6 @@
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
@@ -6726,8 +6634,6 @@
 ++++++ finished: global end run for module: label = 'getInt' id = 35
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end run for module: label = 'out' id = 37
-++++++ finished: global end run for module: label = 'out' id = 37
 ++++ finished: global end run 3 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
@@ -6739,8 +6645,6 @@
 ++++++ finished: global end run for module: label = 'getInt' id = 22
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end run for module: label = 'out' id = 24
-++++++ finished: global end run for module: label = 'out' id = 24
 ++++ finished: global end run 3 : time = 0
 ++++++ starting: write run for module: label = 'out' id = 24
 ++++++ finished: write run for module: label = 'out' id = 24


### PR DESCRIPTION
The one::OutputModules now only get begin/end transition calls for Run or LuminosityBlocks if the module explicitly requests them. This avoid unnecessary synchronization when using concurrent LuminosityBlocks.
The writeRun and writeLuminosityBlocks were always handed separately from the the other transition calls and are unaffected.