### PR TITLE
Add tracking on pixel phase1 client

### DIFF
--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -4,7 +4,7 @@ from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process("PIXELDQMLIVE", eras.Run2_2017)
 
-live=True  #set to false for lxplus offline testing
+live=False  #set to false for lxplus offline testing
 offlineTesting=not live
 
 TAG ="PixelPhase1" 
@@ -47,6 +47,13 @@ process.load("DQM.Integration.config.environment_cfi")
 process.dqmEnv.subSystemFolder = TAG
 process.dqmSaver.tag = TAG
 
+#from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+#process.dqmEnvTr = DQMEDAnalyzer('DQMEventInfo',
+#                 subSystemFolder = cms.untracked.string('TrackTimingPixelPhase1'),
+#                 eventRateWindow = cms.untracked.double(0.5),
+#                 eventInfoFolder = cms.untracked.string('EventInfo')
+#)
+
 process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/pixel_reference_pp.root'
 if (process.runType.getRunType() == process.runType.hi_run):
     process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/pixel_reference_hi.root'
@@ -78,7 +85,7 @@ if (live):
 elif(offlineTesting):
     process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+    process.GlobalTag = gtCustomise(process.GlobalTag, '100X_dataRun2_v1', '')
 
 #-----------------------
 #  Reconstruction Modules
@@ -86,10 +93,12 @@ elif(offlineTesting):
 
 # Real data raw to digi
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
-process.load("RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi")
+#process.load("RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi")
 process.load("RecoLocalTracker.SiStripZeroSuppression.SiStripZeroSuppression_cfi")
 process.load("RecoLocalTracker.SiStripClusterizer.SiStripClusterizer_RealData_cfi")
 
+# PixelPhase1 Real data raw to digi
+process.load("EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi")
 process.siPixelDigis.IncludeErrors = True
 
 process.siPixelDigis.InputLabel   = cms.InputTag("rawDataCollector")
@@ -104,14 +113,33 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.load('Configuration.StandardSequences.RawToDigi_Repacked_cff')
     process.siPixelDigis.InputLabel   = cms.InputTag("rawDataRepacker")
 
+# Phase1 DQM cosmic/pp settings
+#process.load("DQM.SiPixelPhase1Config.SiPixelPhase1OnlineDQM_Timing_cff")
 
-# Phase1 DQM
+## Collision Reconstruction
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
+
+## Cosmic Track Reconstruction
+if (process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.cosmic_run_stage1):
+    process.load("RecoTracker.Configuration.RecoTrackerP5_cff")
+    process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")
+
+else:
+    process.load("Configuration.StandardSequences.Reconstruction_cff")
+
+import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
+process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
+
 process.load("DQM.SiPixelPhase1Config.SiPixelPhase1OnlineDQM_cff")
 
 process.PerModule.enabled=True
 process.PerReadout.enabled=True
 process.OverlayCurvesForTiming.enabled=False
 process.IsOffline.enabled=False
+
+
+#import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
+#process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 
 #--------------------------
 # Service
@@ -129,7 +157,8 @@ process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
 )
 
 process.load('HLTrigger.HLTfilters.hltHighLevel_cfi')
-process.hltHighLevel.HLTPaths = cms.vstring( 'HLT_ZeroBias_*' , 'HLT_ZeroBias1_*' , 'HLT_PAZeroBias_*' , 'HLT_PAZeroBias1_*', 'HLT_PAL1MinimumBiasHF_OR_SinglePixelTrack_*', 'HLT*SingleMu*')
+#process.hltHighLevel.HLTPaths = cms.vstring( 'HLT_ZeroBias_*' , 'HLT_ZeroBias1_*' , 'HLT_PAZeroBias_*' , 'HLT_PAZeroBias1_*', 'HLT_PAL1MinimumBiasHF_OR_SinglePixelTrack_*', 'HLT*SingleMu*')
+process.hltHighLevel.HLTPaths = cms.vstring( 'HLT_ZeroBias_*' , 'HLT_ZeroBias1_*' , 'HLT_PAZeroBias_*' , 'HLT_PAZeroBias1_*', 'HLT_PAL1MinimumBiasHF_OR_SinglePixelTrack_*')
 process.hltHighLevel.andOr = cms.bool(True)
 process.hltHighLevel.throw =  cms.bool(False)
 
@@ -137,22 +166,80 @@ process.hltHighLevel.throw =  cms.bool(False)
 # Scheduling
 #--------------------------
 
-process.DQMmodules = cms.Sequence(process.dqmEnv*process.dqmSaver)
+process.DQMmodules = cms.Sequence(process.dqmEnv*
+                                  #process.dqmEnvTr*
+                                  process.dqmSaver)
 
-if (process.runType.getRunType() == process.runType.hi_run):
-    process.SiPixelClusterSource.src = cms.InputTag("siPixelClustersPreSplitting")
-    process.Reco = cms.Sequence(process.siPixelDigis*process.pixeltrackerlocalreco)
 
-else:
-    process.Reco = cms.Sequence(process.siPixelDigis*process.siStripDigis*process.siStripZeroSuppression*process.siStripClusters*process.siPixelClusters)
+### COSMIC RUN SETTING
+if (process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.cosmic_run_stage1):
+        
+    # Reco for cosmic data
+    process.load('RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cfi')
+    process.simpleCosmicBONSeeds.ClusterCheckPSet.MaxNumberOfCosmicClusters = 450
+    process.combinatorialcosmicseedfinderP5.MaxNumberOfCosmicClusters = 450
 
-process.p = cms.Path(
-  process.hltHighLevel #trigger selection
- *process.Reco
- *process.DQMmodules
- *process.siPixelPhase1OnlineDQM_source
- *process.siPixelPhase1OnlineDQM_harvesting
-)
+    process.RecoForDQM_TrkReco_cosmic = cms.Sequence(process.offlineBeamSpot*process.MeasurementTrackerEvent*process.tracksP5)
+    
+    process.p = cms.Path(
+                         ##### TRIGGER SELECTION #####
+                         process.hltHighLevel*
+                         process.scalersRawToDigi*
+                         process.APVPhases*
+                         process.consecutiveHEs*
+                         process.hltTriggerTypeFilter*
+                         process.RecoForDQM_LocalReco*
+                         process.DQMCommon*
+                         process.RecoForDQM_TrkReco_cosmic*
+                         process.siPixelPhase1OnlineDQM_source_cosmics*
+                         process.siPixelPhase1OnlineDQM_harvesting
+                         )
+   
+### pp COLLISION SETTING
+
+if (process.runType.getRunType() == process.runType.pp_run or process.runType.getRunType() == process.runType.pp_run_stage1):
+    # Reco for pp collisions
+    process.load('RecoTracker.IterativeTracking.InitialStepPreSplitting_cff')
+    process.InitialStepPreSplittingTask.remove(process.initialStepTrackRefsForJetsPreSplitting)
+    process.InitialStepPreSplittingTask.remove(process.caloTowerForTrkPreSplitting)
+    process.InitialStepPreSplittingTask.remove(process.ak4CaloJetsForTrkPreSplitting)
+    process.InitialStepPreSplittingTask.remove(process.jetsForCoreTrackingPreSplitting)
+    process.InitialStepPreSplittingTask.remove(process.siPixelClusters)
+    process.InitialStepPreSplittingTask.remove(process.siPixelRecHits)
+    process.InitialStepPreSplittingTask.remove(process.MeasurementTrackerEvent)
+    process.InitialStepPreSplittingTask.remove(process.siPixelClusterShapeCache)
+
+    # Redefinition of siPixelClusters: has to be after RecoTracker.IterativeTracking.InitialStepPreSplitting_cff 
+    process.load("RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi")
+
+    from RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi import *
+    process.PixelLayerTriplets.BPix.HitProducer = cms.string('siPixelRecHitsPreSplitting')
+    process.PixelLayerTriplets.FPix.HitProducer = cms.string('siPixelRecHitsPreSplitting')
+    from RecoPixelVertexing.PixelTrackFitting.PixelTracks_cff import *
+    process.pixelTracksHitTriplets.SeedComparitorPSet.clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting'
+    process.RecoForDQM_TrkReco = cms.Sequence(process.offlineBeamSpot*process.MeasurementTrackerEventPreSplitting*process.siPixelClusterShapeCachePreSplitting*process.recopixelvertexing*process.InitialStepPreSplitting)
+
+    if (process.runType.getRunType() == process.runType.hi_run):
+        process.SiPixelClusterSource.src = cms.InputTag("siPixelClustersPreSplitting")
+        process.Reco = cms.Sequence(process.siPixelDigis*process.pixeltrackerlocalreco)
+
+    else:
+        process.Reco = cms.Sequence(process.siPixelDigis*process.siStripDigis
+                                    #*process.siStripZeroSuppression
+                                    *process.trackerlocalreco)
+                                    #*process.siStripClusters*process.siPixelClusters)
+
+
+    process.p = cms.Path(
+      process.hltHighLevel #trigger selection
+     *process.scalersRawToDigi
+     *process.Reco
+     *process.siPixelClusters
+     *process.DQMmodules
+     *process.RecoForDQM_TrkReco
+     *process.siPixelPhase1OnlineDQM_source_pprun
+     *process.siPixelPhase1OnlineDQM_harvesting
+    )
     
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *
@@ -163,3 +250,4 @@ process = customise(process)
 #--------------------------------------------------
 
 print "Running with run type = ", process.runType.getRunType()
+print process.dumpPython()

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -4,7 +4,7 @@ from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process("PIXELDQMLIVE", eras.Run2_2017)
 
-live=False  #set to false for lxplus offline testing
+live=True  #set to false for lxplus offline testing
 offlineTesting=not live
 
 TAG ="PixelPhase1" 
@@ -47,12 +47,6 @@ process.load("DQM.Integration.config.environment_cfi")
 process.dqmEnv.subSystemFolder = TAG
 process.dqmSaver.tag = TAG
 
-#from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-#process.dqmEnvTr = DQMEDAnalyzer('DQMEventInfo',
-#                 subSystemFolder = cms.untracked.string('TrackTimingPixelPhase1'),
-#                 eventRateWindow = cms.untracked.double(0.5),
-#                 eventInfoFolder = cms.untracked.string('EventInfo')
-#)
 
 process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/pixel_reference_pp.root'
 if (process.runType.getRunType() == process.runType.hi_run):
@@ -85,7 +79,7 @@ if (live):
 elif(offlineTesting):
     process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-    process.GlobalTag = gtCustomise(process.GlobalTag, '100X_dataRun2_v1', '')
+    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 #-----------------------
 #  Reconstruction Modules
@@ -93,7 +87,6 @@ elif(offlineTesting):
 
 # Real data raw to digi
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
-#process.load("RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi")
 process.load("RecoLocalTracker.SiStripZeroSuppression.SiStripZeroSuppression_cfi")
 process.load("RecoLocalTracker.SiStripClusterizer.SiStripClusterizer_RealData_cfi")
 
@@ -112,9 +105,6 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.load('Configuration.StandardSequences.ReconstructionHeavyIons_cff')
     process.load('Configuration.StandardSequences.RawToDigi_Repacked_cff')
     process.siPixelDigis.InputLabel   = cms.InputTag("rawDataRepacker")
-
-# Phase1 DQM cosmic/pp settings
-#process.load("DQM.SiPixelPhase1Config.SiPixelPhase1OnlineDQM_Timing_cff")
 
 ## Collision Reconstruction
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
@@ -157,7 +147,6 @@ process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
 )
 
 process.load('HLTrigger.HLTfilters.hltHighLevel_cfi')
-#process.hltHighLevel.HLTPaths = cms.vstring( 'HLT_ZeroBias_*' , 'HLT_ZeroBias1_*' , 'HLT_PAZeroBias_*' , 'HLT_PAZeroBias1_*', 'HLT_PAL1MinimumBiasHF_OR_SinglePixelTrack_*', 'HLT*SingleMu*')
 process.hltHighLevel.HLTPaths = cms.vstring( 'HLT_ZeroBias_*' , 'HLT_ZeroBias1_*' , 'HLT_PAZeroBias_*' , 'HLT_PAZeroBias1_*', 'HLT_PAL1MinimumBiasHF_OR_SinglePixelTrack_*')
 process.hltHighLevel.andOr = cms.bool(True)
 process.hltHighLevel.throw =  cms.bool(False)
@@ -167,7 +156,6 @@ process.hltHighLevel.throw =  cms.bool(False)
 #--------------------------
 
 process.DQMmodules = cms.Sequence(process.dqmEnv*
-                                  #process.dqmEnvTr*
                                   process.dqmSaver)
 
 

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -250,4 +250,3 @@ process = customise(process)
 #--------------------------------------------------
 
 print "Running with run type = ", process.runType.getRunType()
-print process.dumpPython()

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -95,10 +95,16 @@ from DQM.SiPixelPhase1Common.SiPixelPhase1GeometryDebug_cfi import *
 #Summary maps
 from DQM.SiPixelPhase1Summary.SiPixelPhase1Summary_cfi import *
 
+# Track cluster                                                                                                                                                                            
+from DQM.SiPixelPhase1TrackClusters.SiPixelPhase1TrackClusters_cfi import *
+from DQM.SiPixelPhase1TrackResiduals.SiPixelPhase1TrackResiduals_cfi import *
+
 siPixelPhase1OnlineDQM_source = cms.Sequence(
    SiPixelPhase1DigisAnalyzer
  + SiPixelPhase1ClustersAnalyzer
  + SiPixelPhase1RawDataAnalyzer
+ + SiPixelPhase1TrackClustersAnalyzer
+ + SiPixelPhase1TrackResidualsAnalyzer
 # + SiPixelPhase1GeometryDebugAnalyzer
 )
 
@@ -106,9 +112,50 @@ siPixelPhase1OnlineDQM_harvesting = cms.Sequence(
    SiPixelPhase1DigisHarvester 
  + SiPixelPhase1ClustersHarvester
  + SiPixelPhase1RawDataHarvester
+ + SiPixelPhase1TrackClustersHarvester
+ + SiPixelPhase1TrackResidualsHarvester
  + RunQTests_online
  + SiPixelPhase1SummaryOnline
 # + SiPixelPhase1GeometryDebugHarvester
+)
+
+## Additional settings for cosmic runs                                                                                                                                                     
+
+SiPixelPhase1TrackClustersAnalyzer_cosmics = SiPixelPhase1TrackClustersAnalyzer.clone()
+SiPixelPhase1TrackClustersAnalyzer_cosmics.tracks  = cms.InputTag( "ctfWithMaterialTracksP5" )
+SiPixelPhase1TrackClustersAnalyzer_cosmics.VertexCut = cms.untracked.bool(False)
+
+SiPixelPhase1TrackResidualsAnalyzer_cosmics = SiPixelPhase1TrackResidualsAnalyzer.clone()
+SiPixelPhase1TrackResidualsAnalyzer_cosmics.Tracks = cms.InputTag( "ctfWithMaterialTracksP5" )
+SiPixelPhase1TrackResidualsAnalyzer_cosmics.trajectoryInput = "ctfWithMaterialTracksP5"
+SiPixelPhase1TrackResidualsAnalyzer_cosmics.VertexCut = cms.untracked.bool(False)
+
+siPixelPhase1OnlineDQM_source_cosmics = cms.Sequence(
+   SiPixelPhase1DigisAnalyzer
+ + SiPixelPhase1ClustersAnalyzer
+ + SiPixelPhase1RawDataAnalyzer
+ + SiPixelPhase1TrackClustersAnalyzer_cosmics
+ + SiPixelPhase1TrackResidualsAnalyzer_cosmics
+)
+
+## Additional settings for pp_run (Phase 0 test)                                                                                                                                           
+SiPixelPhase1TrackClustersAnalyzer_pprun = SiPixelPhase1TrackClustersAnalyzer.clone()
+SiPixelPhase1TrackClustersAnalyzer_pprun.tracks  = cms.InputTag( "initialStepTracksPreSplitting" )
+SiPixelPhase1TrackClustersAnalyzer_pprun.clusterShapeCache = cms.InputTag("siPixelClusterShapeCachePreSplitting")
+SiPixelPhase1TrackClustersAnalyzer_pprun.vertices = cms.InputTag('firstStepPrimaryVerticesPreSplitting')
+SiPixelPhase1TrackClustersAnalyzer_pprun.VertexCut = cms.untracked.bool(False)
+
+SiPixelPhase1TrackResidualsAnalyzer_pprun = SiPixelPhase1TrackResidualsAnalyzer.clone()
+SiPixelPhase1TrackResidualsAnalyzer_pprun.Tracks = cms.InputTag( "initialStepTracksPreSplitting" )
+SiPixelPhase1TrackResidualsAnalyzer_pprun.trajectoryInput = "initialStepTracksPreSplitting"
+SiPixelPhase1TrackResidualsAnalyzer_pprun.VertexCut = cms.untracked.bool(False)
+
+siPixelPhase1OnlineDQM_source_pprun = cms.Sequence(
+   SiPixelPhase1DigisAnalyzer
+ + SiPixelPhase1ClustersAnalyzer
+ + SiPixelPhase1RawDataAnalyzer
+ + SiPixelPhase1TrackClustersAnalyzer_pprun
+ + SiPixelPhase1TrackResidualsAnalyzer_pprun
 )
 
 siPixelPhase1OnlineDQM_timing_harvesting = siPixelPhase1OnlineDQM_harvesting.copyAndExclude([


### PR DESCRIPTION
Adding tracking information merging special client pixel_timingScan_dqm_sourceclient-live_cfg.py with pixel_dqm_sourceclient-live_cfg.py. Needed to modify SiPixelPhase1OnlineDQM_Timing_cff.py for the same purpose.  CMSSW release: CMSSW_10_1_X_2018-02-22-1100.