### PR TITLE
[HBHE] Remove Phase 1 HE from HBHE noise filter consideration

### DIFF
--- a/DataFormats/METReco/interface/HcalNoiseHPD.h
+++ b/DataFormats/METReco/interface/HcalNoiseHPD.h
@@ -17,6 +17,7 @@
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/HcalRecHit/interface/HBHERecHitAuxSetter.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"

--- a/DataFormats/METReco/interface/HcalNoiseHPD.h
+++ b/DataFormats/METReco/interface/HcalNoiseHPD.h
@@ -18,6 +18,7 @@
 #include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/HcalRecHit/interface/HBHERecHitAuxSetter.h"
+#include "DataFormats/HcalRecHit/interface/CaloRecHitAuxSetter.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"

--- a/DataFormats/METReco/src/HcalNoiseHPD.cc
+++ b/DataFormats/METReco/src/HcalNoiseHPD.cc
@@ -159,8 +159,6 @@ int HcalNoiseHPD::numRecHits(const float threshold) const
   int count=0;
   for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it) {
     // Exclude uncollapsed QIE11 channels
-    //if((((*it)->auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) &&
-    //   !(((*it)->auxPhase1()>>HBHERecHitAuxSetter::OFF_COMBINED)&1) ) continue;
     if( CaloRecHitAuxSetter::getBit((*it)->auxPhase1(), HBHERecHitAuxSetter::OFF_TDC_TIME) &&
        !CaloRecHitAuxSetter::getBit((*it)->auxPhase1(), HBHERecHitAuxSetter::OFF_COMBINED) ) continue;
     if((*it)->eraw()>=threshold) ++count;

--- a/DataFormats/METReco/src/HcalNoiseHPD.cc
+++ b/DataFormats/METReco/src/HcalNoiseHPD.cc
@@ -160,7 +160,7 @@ int HcalNoiseHPD::numRecHits(const float threshold) const
   for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it) {
     // Exclude uncollapsed QIE11 channels
     if((((*it)->auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) &&
-       (((*it)->auxPhase1()>>HBHERecHitAuxSetter::OFF_COMBINED)&0) ) continue;
+       !(((*it)->auxPhase1()>>HBHERecHitAuxSetter::OFF_COMBINED)&1) ) continue;
     if((*it)->eraw()>=threshold) ++count;
   }
   return count;

--- a/DataFormats/METReco/src/HcalNoiseHPD.cc
+++ b/DataFormats/METReco/src/HcalNoiseHPD.cc
@@ -158,7 +158,9 @@ int HcalNoiseHPD::numRecHits(const float threshold) const
 {
   int count=0;
   for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it) {
-    if(((*it)->auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) continue; // Exclude QIE11 channels 
+    // Exclude uncollapsed QIE11 channels
+    if((((*it)->auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) &&
+       (((*it)->auxPhase1()>>HBHERecHitAuxSetter::OFF_COMBINED)&0) ) continue;
     if((*it)->eraw()>=threshold) ++count;
   }
   return count;

--- a/DataFormats/METReco/src/HcalNoiseHPD.cc
+++ b/DataFormats/METReco/src/HcalNoiseHPD.cc
@@ -157,8 +157,10 @@ float HcalNoiseHPD::maxRecHitTime(const float threshold) const
 int HcalNoiseHPD::numRecHits(const float threshold) const
 {
   int count=0;
-  for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it)
+  for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it) {
+    if(((*it)->auxPhase1()>>26)&1) continue; // Jae
     if((*it)->eraw()>=threshold) ++count;
+  }
   return count;
 }
 

--- a/DataFormats/METReco/src/HcalNoiseHPD.cc
+++ b/DataFormats/METReco/src/HcalNoiseHPD.cc
@@ -159,8 +159,10 @@ int HcalNoiseHPD::numRecHits(const float threshold) const
   int count=0;
   for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it) {
     // Exclude uncollapsed QIE11 channels
-    if((((*it)->auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) &&
-       !(((*it)->auxPhase1()>>HBHERecHitAuxSetter::OFF_COMBINED)&1) ) continue;
+    //if((((*it)->auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) &&
+    //   !(((*it)->auxPhase1()>>HBHERecHitAuxSetter::OFF_COMBINED)&1) ) continue;
+    if( CaloRecHitAuxSetter::getBit((*it)->auxPhase1(), HBHERecHitAuxSetter::OFF_TDC_TIME) &&
+       !CaloRecHitAuxSetter::getBit((*it)->auxPhase1(), HBHERecHitAuxSetter::OFF_COMBINED) ) continue;
     if((*it)->eraw()>=threshold) ++count;
   }
   return count;

--- a/DataFormats/METReco/src/HcalNoiseHPD.cc
+++ b/DataFormats/METReco/src/HcalNoiseHPD.cc
@@ -158,7 +158,7 @@ int HcalNoiseHPD::numRecHits(const float threshold) const
 {
   int count=0;
   for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it) {
-    if(((*it)->auxPhase1()>>26)&1) continue; // Exclude QIE11 channels 
+    if(((*it)->auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) continue; // Exclude QIE11 channels 
     if((*it)->eraw()>=threshold) ++count;
   }
   return count;

--- a/DataFormats/METReco/src/HcalNoiseHPD.cc
+++ b/DataFormats/METReco/src/HcalNoiseHPD.cc
@@ -158,7 +158,7 @@ int HcalNoiseHPD::numRecHits(const float threshold) const
 {
   int count=0;
   for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it) {
-    if(((*it)->auxPhase1()>>26)&1) continue; // Jae
+    if(((*it)->auxPhase1()>>26)&1) continue; // Exclude QIE11 channels 
     if((*it)->eraw()>=threshold) ++count;
   }
   return count;

--- a/HLTrigger/JetMET/src/HLTHcalTowerNoiseCleanerWithrechit.cc
+++ b/HLTrigger/JetMET/src/HLTHcalTowerNoiseCleanerWithrechit.cc
@@ -218,7 +218,17 @@ void HLTHcalTowerNoiseCleanerWithrechit::produce(edm::Event& iEvent, const edm::
 	  passEMF=false;
 	}
       }
-      
+     std::cout << "r45="<< passRechitr45 << ";" 
+		     << "energy=" << it.energy() << "; "
+		     << "ratio=" << it.ratio() << "; "
+		     << "# RBX hits=" << it.numRBXHits() << "; "
+		     << "# HPD hits=" << it.numHPDHits() << "; "
+		     << "# HPD NoOther hits=" << it.numHPDNoOtherHits() << "; "
+		     << "# Zeros=" << it.numZeros() << "; "
+		     << "min time=" << it.minHighEHitTime() << "; "
+		     << "max time=" << it.maxHighEHitTime() << "; "
+		     << "RBX EMF=" << it.RBXEMF()
+		     << std::endl;
       if((needEMFCoincidence_ && !passEMF && !passFilter) ||
 	 (!needEMFCoincidence_ && !passFilter)) { // check for noise
 	LogDebug("") << "HLTHcalTowerNoiseCleanerWithrechit debug: Found a noisy RBX: "

--- a/HLTrigger/JetMET/src/HLTHcalTowerNoiseCleanerWithrechit.cc
+++ b/HLTrigger/JetMET/src/HLTHcalTowerNoiseCleanerWithrechit.cc
@@ -218,17 +218,7 @@ void HLTHcalTowerNoiseCleanerWithrechit::produce(edm::Event& iEvent, const edm::
 	  passEMF=false;
 	}
       }
-     std::cout << "r45="<< passRechitr45 << ";" 
-		     << "energy=" << it.energy() << "; "
-		     << "ratio=" << it.ratio() << "; "
-		     << "# RBX hits=" << it.numRBXHits() << "; "
-		     << "# HPD hits=" << it.numHPDHits() << "; "
-		     << "# HPD NoOther hits=" << it.numHPDNoOtherHits() << "; "
-		     << "# Zeros=" << it.numZeros() << "; "
-		     << "min time=" << it.minHighEHitTime() << "; "
-		     << "max time=" << it.maxHighEHitTime() << "; "
-		     << "RBX EMF=" << it.RBXEMF()
-		     << std::endl;
+      
       if((needEMFCoincidence_ && !passEMF && !passFilter) ||
 	 (!needEMFCoincidence_ && !passFilter)) { // check for noise
 	LogDebug("") << "HLTHcalTowerNoiseCleanerWithrechit debug: Found a noisy RBX: "

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -862,8 +862,6 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
   for(HBHERecHitCollection::const_iterator it=handle->begin(); it!=handle->end(); ++it) {
     const HBHERecHit &rechit=(*it);
 
-    if((rechit.auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) continue; // Exclude QIE11 channels  
-
     // skip bad rechits (other than those flagged by the isolated noise, triangle, flat, and spike algorithms)
     const DetId id = rechit.idFront();
 
@@ -906,6 +904,9 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
       summary.rechitCount15_ = summary.rechitCount15_ + 1;
       summary.rechitEnergy15_ = summary.rechitEnergy15_ + rechit.eraw();
     }
+    
+    // Exclude QIE11 channels  
+    if((rechit.auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) continue; 
 
     // if it was ID'd as isolated noise, update the summary object
     if(rechit.flags() & isolbitset) {

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -18,6 +18,7 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
 #include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
+#include "DataFormats/HcalRecHit/interface/HBHERecHitAuxSetter.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
@@ -861,7 +862,7 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
   for(HBHERecHitCollection::const_iterator it=handle->begin(); it!=handle->end(); ++it) {
     const HBHERecHit &rechit=(*it);
 
-    if((rechit.auxPhase1()>>26)&1) continue; // Exclude QIE11 channels  
+    if((rechit.auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) continue; // Exclude QIE11 channels  
 
     // skip bad rechits (other than those flagged by the isolated noise, triangle, flat, and spike algorithms)
     const DetId id = rechit.idFront();

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -19,6 +19,7 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
 #include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
 #include "DataFormats/HcalRecHit/interface/HBHERecHitAuxSetter.h"
+#include "DataFormats/HcalRecHit/interface/CaloRecHitAuxSetter.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
@@ -906,9 +907,11 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
     }
     
     // Exclude uncollapsed QIE11 channels
-    if(((rechit.auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) &&
-       ((rechit.auxPhase1()>>HBHERecHitAuxSetter::OFF_COMBINED)&0) ) continue;
-    
+    //if(((rechit.auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) &&
+    //   !((rechit.auxPhase1()>>HBHERecHitAuxSetter::OFF_COMBINED)&1) ) continue;
+    if( CaloRecHitAuxSetter::getBit(rechit.auxPhase1(), HBHERecHitAuxSetter::OFF_TDC_TIME) &&
+       !CaloRecHitAuxSetter::getBit(rechit.auxPhase1(), HBHERecHitAuxSetter::OFF_COMBINED) ) continue;
+   
     // if it was ID'd as isolated noise, update the summary object
     if(rechit.flags() & isolbitset) {
       summary.nisolnoise_++;

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -905,9 +905,10 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
       summary.rechitEnergy15_ = summary.rechitEnergy15_ + rechit.eraw();
     }
     
-    // Exclude QIE11 channels  
-    if((rechit.auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) continue; 
-
+    // Exclude uncollapsed QIE11 channels
+    if(((rechit.auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) &&
+       ((rechit.auxPhase1()>>HBHERecHitAuxSetter::OFF_COMBINED)&0) ) continue;
+    
     // if it was ID'd as isolated noise, update the summary object
     if(rechit.flags() & isolbitset) {
       summary.nisolnoise_++;

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -907,8 +907,6 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
     }
     
     // Exclude uncollapsed QIE11 channels
-    //if(((rechit.auxPhase1()>>HBHERecHitAuxSetter::OFF_TDC_TIME)&1) &&
-    //   !((rechit.auxPhase1()>>HBHERecHitAuxSetter::OFF_COMBINED)&1) ) continue;
     if( CaloRecHitAuxSetter::getBit(rechit.auxPhase1(), HBHERecHitAuxSetter::OFF_TDC_TIME) &&
        !CaloRecHitAuxSetter::getBit(rechit.auxPhase1(), HBHERecHitAuxSetter::OFF_COMBINED) ) continue;
    

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -861,6 +861,8 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
   for(HBHERecHitCollection::const_iterator it=handle->begin(); it!=handle->end(); ++it) {
     const HBHERecHit &rechit=(*it);
 
+    if((rechit.auxPhase1()>>26)&1) continue; // Jae
+
     // skip bad rechits (other than those flagged by the isolated noise, triangle, flat, and spike algorithms)
     const DetId id = rechit.idFront();
 

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -861,7 +861,7 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
   for(HBHERecHitCollection::const_iterator it=handle->begin(); it!=handle->end(); ++it) {
     const HBHERecHit &rechit=(*it);
 
-    if((rechit.auxPhase1()>>26)&1) continue; // Jae
+    if((rechit.auxPhase1()>>26)&1) continue; // Exclude QIE11 channels  
 
     // skip bad rechits (other than those flagged by the isolated noise, triangle, flat, and spike algorithms)
     const DetId id = rechit.idFront();


### PR DESCRIPTION
With full depths in Phase 1 HE we found that some variables used in the HBHE noise filter decision need to be updated. 

Phase 1 HE (SiPM+QIE11) has more channels than phase 0 HE, _i.e._, 46 vs 18 channels per RM. Some of the variables in HBHE noise filters use rechit multiplicity per RM, so cut values should be updated accordingly to account for the increase of rechit multiplicity. But, we know that the QIE11 channels don’t have coherent noise [1], so we decided to exclude HE channels in the construction of filter variables; we use only HB channels to calculate the variables to cut on.

We use `HBHERecHitAuxSetter::OFF_TDC_TIME` bit in `HBHERecHit.auxPhase1()` to exclude QIE11 channels because the bit is set to 1 for QIE11 channels and to 0 for QIE8 channels. 

This update will have a visible effect in MC reconstructed with full HE depth segmentation and a small effect in data. 

More details can be found in [2]. 

[1] https://twiki.cern.ch/twiki/pub/CMSPublic/HcalDPGResultsCMSDPS2017042/HEP17noise.pdf
[2] https://indico.cern.ch/event/708228/contributions/2907553/attachments/1605989/2548603/20180223_Jae_HCAL_RemoveHEForNoise.pdf