### PR TITLE
Use edm::ProducerBase in DigiAccumulatorMixModFactory parameters

### DIFF
--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
@@ -1,12 +1,12 @@
 #include "FastSimulation/Tracking/plugins/RecoTrackAccumulator.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
 
-RecoTrackAccumulator::RecoTrackAccumulator(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+RecoTrackAccumulator::RecoTrackAccumulator(const edm::ParameterSet& conf, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) :
   signalTracksTag(conf.getParameter<edm::InputTag>("signalTracks")),
   pileUpTracksTag(conf.getParameter<edm::InputTag>("pileUpTracks")),
   outputLabel(conf.getParameter<std::string>("outputLabel"))

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
@@ -26,9 +26,7 @@
 namespace edm {
   class ConsumesCollector;
   template<typename T> class Handle;
-  namespace stream {
-    class EDProducerBase;
-  }
+  class ProducerBase;
   class StreamID;
 }
 
@@ -36,7 +34,7 @@ namespace edm {
 class RecoTrackAccumulator : public DigiAccumulatorMixMod 
 {
  public:
-  explicit RecoTrackAccumulator(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  explicit RecoTrackAccumulator(const edm::ParameterSet& conf, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
   ~RecoTrackAccumulator() override;
   
   void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
@@ -19,7 +19,7 @@
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
-CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet& ps, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) 
+CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet& ps, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC)
 : theParameterMap(new CastorSimParameterMap(ps)),
   theCastorShape(new CastorShape()),
   theCastorIntegratedShape(new CaloShapeIntegrator(theCastorShape)),

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
@@ -1,7 +1,7 @@
 #ifndef CastorDigiProducer_h
 #define CastorDigiProducer_h
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -22,6 +22,7 @@
 
 namespace edm {
   class StreamID;
+  class ConsumesCollector;
 }
 
 namespace CLHEP {
@@ -34,7 +35,7 @@ class PileUpEventPrincipal;
 class CastorDigiProducer : public DigiAccumulatorMixMod {
 public:
 
-  explicit CastorDigiProducer(const edm::ParameterSet& ps, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  explicit CastorDigiProducer(const edm::ParameterSet& ps, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
   ~CastorDigiProducer() override;
 
   void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;

--- a/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
@@ -43,9 +43,7 @@ class PileUpEventPrincipal ;
 
 namespace edm {
   class ConsumesCollector;
-  namespace stream {
-    class EDProducerBase;
-  }
+  class ProducerBase;
   class Event;
   class EventSetup;
   template<typename T> class Handle;
@@ -60,7 +58,7 @@ namespace CLHEP {
 class EcalDigiProducer : public DigiAccumulatorMixMod {
    public:
 
-      EcalDigiProducer( const edm::ParameterSet& params , edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+      EcalDigiProducer( const edm::ParameterSet& params , edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
       EcalDigiProducer( const edm::ParameterSet& params , edm::ConsumesCollector& iC);
       ~EcalDigiProducer() override;
 

--- a/SimCalorimetry/EcalSimProducers/interface/EcalTimeDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalTimeDigiProducer.h
@@ -11,7 +11,7 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 
 #include <vector>
 
@@ -32,7 +32,7 @@ namespace edm {
 class EcalTimeDigiProducer : public DigiAccumulatorMixMod {
    public:
 
-  EcalTimeDigiProducer( const edm::ParameterSet& params , edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector&);
+  EcalTimeDigiProducer( const edm::ParameterSet& params , edm::ProducerBase& mixMod, edm::ConsumesCollector&);
       ~EcalTimeDigiProducer() override;
 
       void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -19,7 +19,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
@@ -54,7 +54,7 @@
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
 
 
-EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) :
    DigiAccumulatorMixMod(),
    m_APDShape         ( params.getParameter<double>( "apdShapeTstart" ) ,
 			params.getParameter<double>( "apdShapeTau"    )   )  ,

--- a/SimCalorimetry/EcalSimProducers/src/EcalTimeDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalTimeDigiProducer.cc
@@ -21,7 +21,7 @@
 
 //#define ecal_time_debug 1
 
-EcalTimeDigiProducer::EcalTimeDigiProducer( const edm::ParameterSet& params, edm::stream::EDProducerBase& mixMod,edm::ConsumesCollector& sumes) :
+EcalTimeDigiProducer::EcalTimeDigiProducer( const edm::ParameterSet& params, edm::ProducerBase& mixMod,edm::ConsumesCollector& sumes) :
    DigiAccumulatorMixMod(),
    m_EBdigiCollection ( params.getParameter<std::string>("EBtimeDigiCollection") ) ,
    m_EEdigiCollection ( params.getParameter<std::string>("EEtimeDigiCollection") ) ,

--- a/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
+++ b/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
@@ -9,9 +9,7 @@
 
 namespace edm {
   class ConsumesCollector;
-  namespace stream {
-    class EDProducerBase;
-  }
+  class ProducerBase;
   class Event;
   class EventSetup;
   class ParameterSet;
@@ -23,7 +21,7 @@ class EcalTBDigiProducer : public EcalDigiProducer
 {
    public:
 
-      EcalTBDigiProducer( const edm::ParameterSet& params, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) ;
+      EcalTBDigiProducer( const edm::ParameterSet& params, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) ;
       ~EcalTBDigiProducer() override ;
 
 

--- a/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
+++ b/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
@@ -2,7 +2,7 @@
 #include "SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h"
 #include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -12,7 +12,7 @@
 #include "SimCalorimetry/EcalSimAlgos/interface/EBHitResponse.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EEHitResponse.h"
 
-EcalTBDigiProducer::EcalTBDigiProducer( const edm::ParameterSet& params, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+EcalTBDigiProducer::EcalTBDigiProducer( const edm::ParameterSet& params, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) :
    EcalDigiProducer(params, mixMod, iC)
 {
    std::string const instance("simEcalUnsuppressedDigis");

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
@@ -8,7 +8,7 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 
 //
-HGCDigiProducer::HGCDigiProducer(edm::ParameterSet const& pset, edm::stream::EDProducerBase& mixMod, 
+HGCDigiProducer::HGCDigiProducer(edm::ParameterSet const& pset, edm::ProducerBase& mixMod,
                                  edm::ConsumesCollector& iC) :
   DigiAccumulatorMixMod(),
   theDigitizer_(new HGCDigitizer(pset, iC) ) 

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.h
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.h
@@ -22,7 +22,7 @@ namespace CLHEP {
 
 class HGCDigiProducer : public DigiAccumulatorMixMod {
 public:
-  HGCDigiProducer(edm::ParameterSet const& pset, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  HGCDigiProducer(edm::ParameterSet const& pset, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
   HGCDigiProducer(edm::ParameterSet const& pset, edm::ConsumesCollector& iC);
 
   void initializeEvent(edm::Event const&, edm::EventSetup const&) override;

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
@@ -8,9 +8,7 @@
 
 namespace edm {
   class ConsumesCollector;
-  namespace stream {
-    class EDProducerBase;
-  }
+  class ProducerBase;
   class ParameterSet;
   class StreamID;
 }
@@ -21,7 +19,7 @@ namespace CLHEP {
 
 class HcalDigiProducer : public DigiAccumulatorMixMod {
 public:
-  HcalDigiProducer(edm::ParameterSet const& pset, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  HcalDigiProducer(edm::ParameterSet const& pset, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
 
   HcalDigiProducer(edm::ParameterSet const& pset, edm::ConsumesCollector& iC);
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
@@ -1,11 +1,11 @@
 #include "SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
-HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const& pset, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const& pset, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) :
   DigiAccumulatorMixMod(),
   theDigitizer_(pset, iC) {
   mixMod.produces<HBHEDigiCollection>();

--- a/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
+++ b/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
@@ -1,7 +1,7 @@
 #ifndef SimCalorimetry_HcalTestBeam_HcalTBDigiProducer_h
 #define SimCalorimetry_HcalTestBeam_HcalTBDigiProducer_h
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -25,6 +25,7 @@ class PEcalTBInfo;
 
 namespace edm {
   class StreamID;
+  class ConsumesCollector;
 }
 
 namespace CLHEP {
@@ -34,7 +35,7 @@ namespace CLHEP {
 class HcalTBDigiProducer : public DigiAccumulatorMixMod {
 public:
 
-  explicit HcalTBDigiProducer(const edm::ParameterSet& ps, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  explicit HcalTBDigiProducer(const edm::ParameterSet& ps, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
   ~HcalTBDigiProducer() override;
 
   void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;

--- a/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
+++ b/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
@@ -19,7 +19,7 @@
 
 #include "CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h"
 
-HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet& ps, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet& ps, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) :
   theParameterMap(new HcalTBSimParameterMap(ps)), 
   theHcalShape(new HcalShape()),
   theHcalIntegratedShape(new CaloShapeIntegrator(theHcalShape)),

--- a/SimFastTiming/FastTimingCommon/interface/FTLDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/FTLDigitizer.h
@@ -7,6 +7,7 @@
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -60,7 +61,7 @@ namespace ftl_digitizer {
     
   FTLDigitizer(const edm::ParameterSet& config, 
 	       edm::ConsumesCollector& iC,
-	       edm::stream::EDProducerBase& parent) :
+	       edm::ProducerBase& parent) :
     FTLDigitizerBase(config,iC,parent),
     deviceSim_( config.getParameterSet("DeviceSimulation") ),
     electronicsSim_( config.getParameterSet("ElectronicsSimulation") ),        

--- a/SimFastTiming/FastTimingCommon/interface/FTLDigitizerBase.h
+++ b/SimFastTiming/FastTimingCommon/interface/FTLDigitizerBase.h
@@ -1,7 +1,7 @@
 #ifndef FastTimingSimProducers_FastTimingCommon_FTLDigitizerBase_h
 #define FastTimingSimProducers_FastTimingCommon_FTLDigitizerBase_h
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -31,7 +31,7 @@ class FTLDigitizerBase {
  public:
  FTLDigitizerBase(const edm::ParameterSet& config, 
 		  edm::ConsumesCollector& iC,
-		  edm::stream::EDProducerBase& parent) :
+		  edm::ProducerBase& parent) :
   inputSimHits_( config.getParameter<edm::InputTag>("inputSimHits") ),
   digiCollection_( config.getParameter<std::string>("digiCollectionTag") ),
   mySubDet_(FastTime),
@@ -87,7 +87,7 @@ class FTLDigitizerBase {
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< FTLDigitizerBase* (const edm::ParameterSet&, edm::ConsumesCollector&, edm::stream::EDProducerBase&) > FTLDigitizerFactory;
+typedef edmplugin::PluginFactory< FTLDigitizerBase* (const edm::ParameterSet&, edm::ConsumesCollector&, edm::ProducerBase&) > FTLDigitizerFactory;
 
 
 

--- a/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.cc
+++ b/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.cc
@@ -1,14 +1,14 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
 #include "SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
 //
-FTLDigiProducer::FTLDigiProducer(edm::ParameterSet const& pset, edm::stream::EDProducerBase& mixMod, 
+FTLDigiProducer::FTLDigiProducer(edm::ParameterSet const& pset, edm::ProducerBase& mixMod,
                                  edm::ConsumesCollector& iC) :
   DigiAccumulatorMixMod() {
   std::vector<std::string> psetNames;

--- a/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.h
+++ b/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.h
@@ -9,9 +9,7 @@
 
 namespace edm {
   class ConsumesCollector;
-  namespace stream {
-    class EDProducerBase;
-  }
+  class ProducerBase;
   class ParameterSet;
   class StreamID;
 }
@@ -22,7 +20,7 @@ namespace CLHEP {
 
 class FTLDigiProducer : public DigiAccumulatorMixMod {
 public:
-  FTLDigiProducer(edm::ParameterSet const& pset, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  FTLDigiProducer(edm::ParameterSet const& pset, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
   FTLDigiProducer(edm::ParameterSet const& pset, edm::ConsumesCollector& iC)
   {
     throw cms::Exception("DeprecatedConstructor") << "Please make sure you're calling this with the threaded mixing module...";

--- a/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
@@ -297,7 +297,7 @@ SimClusterCollection CaloTruthAccumulator::descendantSimClusters( Barcode_t barc
     //return result;
   }
 
-  std::unique_ptr<SimHitInfoPerSimTrack_t> hit_info = std::move(CaloTruthAccumulator::attachedSimHitInfo(barcode,hits, true, false, false));
+  std::unique_ptr<SimHitInfoPerSimTrack_t> hit_info = CaloTruthAccumulator::attachedSimHitInfo(barcode,hits, true, false, false);
   //std::unique_ptr<SimHitInfoPerSimTrack_t> inclusive_hit_info = std::move(CaloTruthAccumulator::allAttachedSimHitInfo(barcode,hits, false) );
 
   const auto& simTrack = simTracks[m_simTrackBarcodeToIndex[barcode]];
@@ -312,9 +312,9 @@ SimClusterCollection CaloTruthAccumulator::descendantSimClusters( Barcode_t barc
     
     
     if( isInCalo  ) {
-      marked_hit_info = std::move( CaloTruthAccumulator::allAttachedSimHitInfo(barcode,hits,true) );
+      marked_hit_info = CaloTruthAccumulator::allAttachedSimHitInfo(barcode,hits,true) ;
     } else {    
-      marked_hit_info = std::move( CaloTruthAccumulator::attachedSimHitInfo(barcode,hits,true,false,true) );
+      marked_hit_info = CaloTruthAccumulator::attachedSimHitInfo(barcode,hits,true,false,true) ;
     }   
     
     if( !marked_hit_info->empty() ) {
@@ -395,10 +395,10 @@ std::unique_ptr<SimHitInfoPerSimTrack_t> CaloTruthAccumulator::attachedSimHitInf
 	  const auto& daughter = simTracks[m_simTrackBarcodeToIndex[track_iter->second]];
 
 	  if( includeOther || nextInCalo ) {
-	    std::unique_ptr<SimHitInfoPerSimTrack_t> daughter_result = std::move(CaloTruthAccumulator::allAttachedSimHitInfo(track_iter->second,hits,markUsed));
+	    std::unique_ptr<SimHitInfoPerSimTrack_t> daughter_result = CaloTruthAccumulator::allAttachedSimHitInfo(track_iter->second,hits,markUsed);
 	    result->insert(result->end(),daughter_result->begin(),daughter_result->end());
 	  } else if ( daughter.type() == simTrack.type() ) {
-	    std::unique_ptr<SimHitInfoPerSimTrack_t> daughter_result = std::move(CaloTruthAccumulator::attachedSimHitInfo(track_iter->second,hits,includeOwn, includeOther, markUsed));
+	    std::unique_ptr<SimHitInfoPerSimTrack_t> daughter_result = CaloTruthAccumulator::attachedSimHitInfo(track_iter->second,hits,includeOwn, includeOther, markUsed);
 	     result->insert(result->end(),daughter_result->begin(),daughter_result->end());
 	  }
 	}

--- a/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
@@ -18,7 +18,7 @@
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "SimGeneral/TrackingAnalysis/interface/EncodedTruthId.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
@@ -38,7 +38,7 @@
 
 #include <iterator>
 
-CaloTruthAccumulator::CaloTruthAccumulator( const edm::ParameterSet & config, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+CaloTruthAccumulator::CaloTruthAccumulator( const edm::ParameterSet & config, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) :
 		messageCategory_("CaloTruthAccumulator"),
 		maximumPreviousBunchCrossing_( config.getParameter<unsigned int>("maximumPreviousBunchCrossing") ),
 		maximumSubsequentBunchCrossing_( config.getParameter<unsigned int>("maximumSubsequentBunchCrossing") ),

--- a/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.h
+++ b/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.h
@@ -12,6 +12,7 @@
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 typedef unsigned Index_t;
 typedef int Barcode_t;
@@ -29,9 +30,7 @@ typedef std::vector<SimHitInfoPerRecoDetId_t> SimHitInfoPerSimTrack_t;
 namespace edm {
   class ParameterSet;
   class ConsumesCollector;
-  namespace stream {
-    class EDProducerBase;
-  }
+  class ProducerBase;
   class Event;
   class EventSetup;
   class StreamID;
@@ -43,7 +42,7 @@ class SimVertex;
 
 class CaloTruthAccumulator : public DigiAccumulatorMixMod {
  public:
-  explicit CaloTruthAccumulator( const edm::ParameterSet& config, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  explicit CaloTruthAccumulator( const edm::ParameterSet& config, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
  private:
   void initializeEvent( const edm::Event& event, const edm::EventSetup& setup ) override;
   void accumulate( const edm::Event& event, const edm::EventSetup& setup ) override;

--- a/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
+++ b/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
@@ -3,16 +3,13 @@
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 
 namespace edm {
   class ConsumesCollector;
   class ParameterSet;
-  namespace one {
-    class EDProducerBase;
-  }
 
-  typedef DigiAccumulatorMixMod*(DAFunc)(ParameterSet const&, stream::EDProducerBase&, ConsumesCollector&);
+  typedef DigiAccumulatorMixMod*(DAFunc)(ParameterSet const&, ProducerBase&, ConsumesCollector&);
   typedef edmplugin::PluginFactory<DAFunc> DigiAccumulatorMixModPluginFactory;
 
   class DigiAccumulatorMixModFactory {
@@ -22,7 +19,7 @@ namespace edm {
     static DigiAccumulatorMixModFactory const* get();
 
     std::unique_ptr<DigiAccumulatorMixMod>
-      makeDigiAccumulator(ParameterSet const&, stream::EDProducerBase&, ConsumesCollector&) const;
+      makeDigiAccumulator(ParameterSet const&, ProducerBase&, ConsumesCollector&) const;
 
   private:
     DigiAccumulatorMixModFactory();

--- a/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
+++ b/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
@@ -9,10 +9,6 @@
 EDM_REGISTER_PLUGINFACTORY(edm::DigiAccumulatorMixModPluginFactory,"DigiAccumulator");
 
 namespace edm {
-  namespace one {
-    class EDProducerBase;
-  }
-
   DigiAccumulatorMixModFactory::~DigiAccumulatorMixModFactory() {
   }
 
@@ -30,7 +26,7 @@ namespace edm {
   }
 
   std::unique_ptr<DigiAccumulatorMixMod>
-  DigiAccumulatorMixModFactory::makeDigiAccumulator(ParameterSet const& conf, stream::EDProducerBase& mixMod, ConsumesCollector& iC) const {
+  DigiAccumulatorMixModFactory::makeDigiAccumulator(ParameterSet const& conf, ProducerBase& mixMod, ConsumesCollector& iC) const {
     std::string accumulatorType = conf.getParameter<std::string>("accumulatorType");
     FDEBUG(1) << "DigiAccumulatorMixModFactory: digi_accumulator_type = " << accumulatorType << std::endl;
     std::unique_ptr<DigiAccumulatorMixMod> wm;

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
@@ -26,7 +26,6 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -67,7 +66,7 @@
 
 namespace cms
 {
-  PileupVertexAccumulator::PileupVertexAccumulator(const edm::ParameterSet& iConfig, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+  PileupVertexAccumulator::PileupVertexAccumulator(const edm::ParameterSet& iConfig, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) :
     Mtag_(iConfig.getParameter<edm::InputTag>("vtxTag")),
     fallbackMtag_(iConfig.getParameter<edm::InputTag>("vtxFallbackTag")),
     saveVtxTimes_(iConfig.getParameter<bool>("saveVtxTimes"))

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.h
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.h
@@ -18,16 +18,14 @@
 #include <vector>
 
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 namespace edm {
   class ConsumesCollector;
-  namespace one {
-    class EDProducerBase;
-  }
+  class ProducerBase;
   class Event;
   class EventSetup;
   class ParameterSet;
@@ -41,7 +39,7 @@ namespace cms {
   class PileupVertexAccumulator : public DigiAccumulatorMixMod {
   public:
 
-    explicit PileupVertexAccumulator(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+    explicit PileupVertexAccumulator(const edm::ParameterSet& conf, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
 
     ~PileupVertexAccumulator() override;
 

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -37,7 +37,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "SimGeneral/TrackingAnalysis/interface/EncodedTruthId.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
@@ -221,7 +221,7 @@ namespace
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
 
-TrackingTruthAccumulator::TrackingTruthAccumulator( const edm::ParameterSet & config, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+TrackingTruthAccumulator::TrackingTruthAccumulator( const edm::ParameterSet & config, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) :
 		messageCategory_("TrackingTruthAccumulator"),
 		volumeRadius_( config.getParameter<double>("volumeRadius") ),
 		volumeZ_( config.getParameter<double>("volumeZ") ),

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
@@ -13,9 +13,7 @@ namespace edm
 {
 	class ParameterSet;
         class ConsumesCollector;
-  namespace stream {
-	class EDProducerBase;
-  }
+	class ProducerBase;
 	class Event;
 	class EventSetup;
         class StreamID;
@@ -75,7 +73,7 @@ class PSimHit;
 class TrackingTruthAccumulator : public DigiAccumulatorMixMod
 {
 public:
-	explicit TrackingTruthAccumulator( const edm::ParameterSet& config, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+	explicit TrackingTruthAccumulator( const edm::ParameterSet& config, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
 private:
 	void initializeEvent( const edm::Event& event, const edm::EventSetup& setup ) override;
 	void accumulate( const edm::Event& event, const edm::EventSetup& setup ) override;

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
@@ -59,6 +59,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -76,7 +77,7 @@
 namespace cms
 {
 
-  Phase2TrackerDigitizer::Phase2TrackerDigitizer(const edm::ParameterSet& iConfig, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
+  Phase2TrackerDigitizer::Phase2TrackerDigitizer(const edm::ParameterSet& iConfig, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) :
     first_(true),
     hitsProducer_(iConfig.getParameter<std::string>("hitsProducer")),
     trackerContainers_(iConfig.getParameter<std::vector<std::string> >("ROUList")),

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
@@ -21,7 +21,7 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerFwd.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
-#include "FWCore/Framework/interface/stream/EDProducerBase.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #include <unordered_map>
@@ -52,7 +52,7 @@ namespace cms
   public:
     typedef std::unordered_map<unsigned, TrackerGeometry::ModuleType>  ModuleTypeCache;
 
-    explicit Phase2TrackerDigitizer(const edm::ParameterSet& iConfig, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+    explicit Phase2TrackerDigitizer(const edm::ParameterSet& iConfig, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
     ~Phase2TrackerDigitizer() override;
     void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;
     void accumulate(edm::Event const& e, edm::EventSetup const& c) override;

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -29,7 +29,7 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -91,7 +91,7 @@ namespace CLHEP {
 
 namespace cms
 {
-  SiPixelDigitizer::SiPixelDigitizer(const edm::ParameterSet& iConfig, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC):
+  SiPixelDigitizer::SiPixelDigitizer(const edm::ParameterSet& iConfig, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC):
     firstInitializeEvent_(true),
     firstFinalizeEvent_(true),
     _pixeldigialgo(),

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -24,9 +24,7 @@
 
 namespace edm {
   class ConsumesCollector;
-  namespace stream {
-    class EDProducerBase;
-  }
+  class ProducerBase;
   class Event;
   class EventSetup;
   class ParameterSet;
@@ -49,7 +47,7 @@ namespace cms {
   class SiPixelDigitizer : public DigiAccumulatorMixMod {
   public:
 
-    explicit SiPixelDigitizer(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+    explicit SiPixelDigitizer(const edm::ParameterSet& conf, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
 
     ~SiPixelDigitizer() override;
 

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -55,7 +55,7 @@
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC) : 
+SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) : 
   gainLabel(conf.getParameter<std::string>("Gain")),
   hitsProducer(conf.getParameter<std::string>("hitsProducer")),
   trackerContainers(conf.getParameter<std::vector<std::string> >("ROUList")),

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -18,9 +18,7 @@ namespace CLHEP {
 
 namespace edm {
   class ConsumesCollector;
-  namespace stream {
-    class EDProducerBase;
-  }
+  class ProducerBase;
   class Event;
   class EventSetup;
   class ParameterSet;
@@ -45,7 +43,7 @@ class TrackerGeometry;
  */
 class SiStripDigitizer : public DigiAccumulatorMixMod {
 public:
-  explicit SiStripDigitizer(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+  explicit SiStripDigitizer(const edm::ParameterSet& conf, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
   
   ~SiStripDigitizer() override;
   


### PR DESCRIPTION
This PR replaces the `edm::stream::EDProducerBase` parameter with more general `edm::ProducerBase` in `DigiAccumulatorMixModFactory`. The argument is used to call `produces<T>()`, so there is no need to restrict to `stream` producers.

Tested in 10_1_0_pre1, no changes expected.