### PR TITLE
Fix in MET tool when reclustering jets and MET on the fly [backport]

### DIFF
--- a/PhysicsTools/PatAlgos/python/tools/helpers.py
+++ b/PhysicsTools/PatAlgos/python/tools/helpers.py
@@ -119,15 +119,19 @@ def applyPostfix(process, label, postfix):
     return result
 
 def removeIfInSequence(process, target,  sequenceLabel, postfix=""):
-    labels = __labelsInSequence(process, sequenceLabel, postfix)
+    labels = __labelsInSequence(process, sequenceLabel, postfix, True)
     if target+postfix in labels:
         getattr(process, sequenceLabel+postfix).remove(
             getattr(process, target+postfix)
             )
 
-def __labelsInSequence(process, sequenceLabel, postfix=""):
-    result = [ m.label()[:-len(postfix)] for m in listModules( getattr(process,sequenceLabel+postfix))]
-    result.extend([ m.label()[:-len(postfix)] for m in listSequences( getattr(process,sequenceLabel+postfix))]  )
+def __labelsInSequence(process, sequenceLabel, postfix="", keepPostFix=False):
+    position = -len(postfix)
+    if keepPostFix: 
+        position = None
+
+    result = [ m.label()[:position] for m in listModules( getattr(process,sequenceLabel+postfix))]
+    result.extend([ m.label()[:position] for m in listSequences( getattr(process,sequenceLabel+postfix))]  )
     if postfix == "":
         result = [ m.label() for m in listModules( getattr(process,sequenceLabel+postfix))]
         result.extend([ m.label() for m in listSequences( getattr(process,sequenceLabel+postfix))]  )

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -335,7 +335,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             self.miniAODConfigurationPre(process, patMetModuleSequence, pfCandCollection, postfix)
 
         #default MET production
-        self.produceMET(process, metType,patMetModuleSequence, jetCollectionUnskimmed, postfix)
+        self.produceMET(process, metType,patMetModuleSequence, postfix)
         
             
         
@@ -440,7 +440,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             process.patDefaultSequence += getattr(process, "fullPatMetSequence"+postfix)
     
 #====================================================================================================
-    def produceMET(self, process,  metType, metModuleSequence, jetCollectionUnskimmed, postfix):
+    def produceMET(self, process,  metType, metModuleSequence, postfix):
 
         task = getPatAlgosToolsTask(process)
 
@@ -450,13 +450,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             task.add(process.patPFMetT2SmearCorrTask)
             task.add(process.patPFMetTxyCorrTask)
             task.add(process.jetCorrectorsTask)
+
         if postfix != "" and metType == "PF" and not hasattr(process, 'pat'+metType+'Met'+postfix):
             noClonesTmp = [ "particleFlowDisplacedVertex", "pfCandidateToVertexAssociation" ]
             configtools.cloneProcessingSnippet(process, getattr(process,"producePatPFMETCorrections"), postfix, noClones = noClonesTmp, addToTask = True)
-            #MM FIXME, this could be done in a mch better way, this is not
-            #handled by the above cloning sequence
-            getattr(process,"selectedPatJetsForMetT1T2Corr").src=jetCollectionUnskimmed #cms.InputTag("patJets"+postfix)
-            getattr(process,"selectedPatJetsForMetT2Corr").src=jetCollectionUnskimmed #cms.InputTag("patJets"+postfix)
             addToProcessAndTask('pat'+metType+'Met'+postfix,  getattr(process,'patPFMet' ).clone(), process, task)
             getattr(process, "patPFMet"+postfix).metSource = cms.InputTag("pfMet"+postfix)
             getattr(process, "patPFMet"+postfix).srcPFCands = self._parameters["pfCandCollection"].value


### PR DESCRIPTION
Backporting #22273 in 94X for legacy reminiAOD.

This PR fixes an issue with the MET tool when trying to recluster jets/MET on the fly.
It does not change the data content
Package modified: PhysicsTools/PatUtils/