### PR TITLE
Enable comparison of HF minBias feature bit readout in CaloLayer1

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2CaloLayer1_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2CaloLayer1_cfi.py
@@ -8,6 +8,5 @@ l1tStage2CaloLayer1 = DQMEDAnalyzer('L1TStage2CaloLayer1',
     hcalTPSourceSent = cms.InputTag("hcalDigis"),
     fedRawDataLabel  = cms.InputTag("rawDataCollector"),
     histFolder = cms.string('L1T/L1TStage2CaloLayer1'),
-    # HF minBias bit is not yet unpacked on HCAL side, so we don't compare them
-    ignoreHFfb2 = cms.untracked.bool(True),
+    ignoreHFfb2 = cms.untracked.bool(False),
 )


### PR DESCRIPTION
Prompted by the additions to HCAL unpacker to read this bit into digis.