### PR TITLE
Enable comparison of HF minBias feature bit readout in CaloLayer1

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -8,18 +8,12 @@ process = cms.Process("L1TStage2EmulatorDQM", eras.Run2_2016)
 
 # Live Online DQM in P5
 process.load("DQM.Integration.config.inputsource_cfi")
-process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-# Due to the GT override in the above include, we have trouble with
-# conflicting CaloParams from stage1 and stage2.  This workaround
-# can go away once either the es_prefer is removed from DQM or the
-# new L1TCaloStage2ParamsRcd is integrated into CMSSW.
-if 'es_prefer_GlobalTag' in process.__dict__:
-    process.__dict__.pop('es_prefer_GlobalTag')
-    process._Process__esprefers.pop('es_prefer_GlobalTag')
 
 # Testing in lxplus
 #process.load("DQM.Integration.config.fileinputsource_cfi")
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
+
+# Required to load Global Tag
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
 # Required to load EcalMappingRecord
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")

--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
@@ -61,12 +61,12 @@ namespace ComparisonHelper {
 class L1TStage2CaloLayer1 : public DQMEDAnalyzer {
   public:
     L1TStage2CaloLayer1(const edm::ParameterSet& ps);
-    virtual ~L1TStage2CaloLayer1();
+    ~L1TStage2CaloLayer1() override;
   
   protected:
     void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-    virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
-    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+    void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
+    void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
     void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
     void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   

--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
@@ -84,6 +84,7 @@ class L1TStage2CaloLayer1 : public DQMEDAnalyzer {
     edm::EDGetTokenT<FEDRawDataCollection> fedRawData_;
     std::string histFolder_;
     int tpFillThreshold_;
+    bool ignoreHFfb2_;
 
     MonitorElement *ecalDiscrepancy_;
     MonitorElement *ecalLinkError_;
@@ -107,8 +108,13 @@ class L1TStage2CaloLayer1 : public DQMEDAnalyzer {
     MonitorElement *ecalTPRawEtSentAndRecd_;
     MonitorElement *ecalTPRawEtSent_;
 
+    MonitorElement *ecalOccSentNotRecd_;
+    MonitorElement *ecalOccRecdNotSent_;
+    MonitorElement *ecalOccNoMatch_;
+
     MonitorElement *hcalOccEtDiscrepancy_;
     MonitorElement *hcalOccFbDiscrepancy_;
+    MonitorElement *hcalOccFb2Discrepancy_;
     MonitorElement *hcalOccLinkMasked_;
     MonitorElement *hcalOccRecdEtWgt_;
     MonitorElement *hcalOccRecdFb_;

--- a/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
@@ -28,12 +28,12 @@ using namespace l1t;
 class L1TdeStage2CaloLayer1 : public DQMEDAnalyzer {
   public:
     L1TdeStage2CaloLayer1(const edm::ParameterSet& ps);
-    virtual ~L1TdeStage2CaloLayer1();
+    ~L1TdeStage2CaloLayer1() override;
   
   protected:
     void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-    virtual void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
-    virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+    void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
+    void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
     void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
     void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   

--- a/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
@@ -71,6 +71,18 @@ class L1TdeStage2CaloLayer1 : public DQMEDAnalyzer {
     };
     typedef std::set<SimpleTower> SimpleTowerSet;
 
+    enum SummaryColumn {
+      EtMismatch,
+      ErMismatch,
+      FbMismatch,
+      TowerCountMismatch,
+      NSummaryColumns,
+    };
+    MonitorElement *dataEmulSummary_;
+    std::array<double, NSummaryColumns> dataEmulNumerator_;
+    double dataEmulDenominator_;
+    MonitorElement *mismatchesPerBxMod9_;
+
     MonitorElement *dataOcc_;
     MonitorElement *emulOcc_;
     MonitorElement *matchOcc_;
@@ -86,12 +98,15 @@ class L1TdeStage2CaloLayer1 : public DQMEDAnalyzer {
     MonitorElement *etCorrelation_;
     MonitorElement *matchEtDistribution_;
     MonitorElement *etMismatchDiff_;
+    MonitorElement *fbCorrelation_;
     MonitorElement *fbCorrelationHF_;
 
     MonitorElement *etMismatchByLumi_;
     MonitorElement *erMismatchByLumi_;
     MonitorElement *fbMismatchByLumi_;
 
+    MonitorElement *etMismatchesPerBx_;
+    MonitorElement *erMismatchesPerBx_;
     MonitorElement *fbMismatchesPerBx_;
     MonitorElement *towerCountMismatchesPerBx_;
 

--- a/DQM/L1TMonitor/python/L1TStage2CaloLayer1_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2CaloLayer1_cfi.py
@@ -7,4 +7,6 @@ l1tStage2CaloLayer1 = cms.EDAnalyzer("L1TStage2CaloLayer1",
     hcalTPSourceSent = cms.InputTag("hcalDigis"),
     fedRawDataLabel  = cms.InputTag("rawDataCollector"),
     histFolder = cms.string('L1T/L1TStage2CaloLayer1'),
+    # HF minBias bit is not yet unpacked on HCAL side, so we don't compare them
+    ignoreHFfb2 = cms.untracked.bool(True),
 )

--- a/DQM/L1TMonitor/python/L1TStage2CaloLayer1_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2CaloLayer1_cfi.py
@@ -7,6 +7,5 @@ l1tStage2CaloLayer1 = cms.EDAnalyzer("L1TStage2CaloLayer1",
     hcalTPSourceSent = cms.InputTag("hcalDigis"),
     fedRawDataLabel  = cms.InputTag("rawDataCollector"),
     histFolder = cms.string('L1T/L1TStage2CaloLayer1'),
-    # HF minBias bit is not yet unpacked on HCAL side, so we don't compare them
-    ignoreHFfb2 = cms.untracked.bool(True),
+    ignoreHFfb2 = cms.untracked.bool(False),
 )

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
@@ -27,7 +27,8 @@ L1TStage2CaloLayer1::L1TStage2CaloLayer1(const edm::ParameterSet & ps) :
   hcalTPSourceSentLabel_(ps.getParameter<edm::InputTag>("hcalTPSourceSent").label()),
   fedRawData_(consumes<FEDRawDataCollection>(ps.getParameter<edm::InputTag>("fedRawDataLabel"))),
   histFolder_(ps.getParameter<std::string>("histFolder")),
-  tpFillThreshold_(ps.getUntrackedParameter<int>("etDistributionsFillThreshold", 0))
+  tpFillThreshold_(ps.getUntrackedParameter<int>("etDistributionsFillThreshold", 0)),
+  ignoreHFfb2_(ps.getUntrackedParameter<bool>("ignoreHFfb2", false))
 {
   ecalTPSentRecd_.reserve(28*2*72);
   hcalTPSentRecd_.reserve(41*2*72);
@@ -43,10 +44,43 @@ void L1TStage2CaloLayer1::dqmBeginRun(const edm::Run&, const edm::EventSetup&)
 
 void L1TStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSetup & es)
 {
+  // Monitorables stored in Layer 1 raw data but
+  // not accessible from existing persistent data formats
+  edm::Handle<FEDRawDataCollection> fedRawDataCollection;
+  event.getByToken(fedRawData_, fedRawDataCollection);
+  bool caloLayer1OutOfRun{true};
+  if (fedRawDataCollection.isValid()) {
+    caloLayer1OutOfRun = false;
+    for(int iFed=1354; iFed<1360; iFed+=2) {
+      const FEDRawData& fedRawData = fedRawDataCollection->FEDData(iFed);
+      if ( fedRawData.size() == 0 ) {
+        caloLayer1OutOfRun = true;
+        continue;  // In case one of 3 layer 1 FEDs not in
+      }
+      const uint64_t *fedRawDataArray = (const uint64_t *) fedRawData.data();
+      UCTDAQRawData daqData(fedRawDataArray);
+      for(uint32_t i = 0; i < daqData.nAMCs(); i++) {
+        UCTAMCRawData amcData(daqData.amcPayload(i));
+        int lPhi = amcData.layer1Phi();
+        if ( daqData.BXID() != amcData.BXID() ) {
+          bxidErrors_->Fill(lPhi);
+        }
+        if ( daqData.L1ID() != amcData.L1ID() ) {
+          l1idErrors_->Fill(lPhi);
+        }
+        // AMC payload header has 16 bit orbit number, AMC13 header is full 32
+        if ( (daqData.orbitNumber() & 0xFFFF) != amcData.orbitNo() ) {
+          orbitErrors_->Fill(lPhi);
+        }
+      }
+    }
+  }
+
+
   edm::Handle<EcalTrigPrimDigiCollection> ecalTPsSent;
   event.getByToken(ecalTPSourceSent_, ecalTPsSent);
+  // either ECAL is out of run or some problem
   bool tccFullReadout = ( ecalTPsSent->size() == 28*72*2 );
-  if ( ! tccFullReadout ) updateMismatch(event, 4);
   edm::Handle<EcalTrigPrimDigiCollection> ecalTPsRecd;
   event.getByToken(ecalTPSourceRecd_, ecalTPsRecd);
 
@@ -94,7 +128,7 @@ void L1TStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSetu
       ecalOccSentFgVB_->Fill(ieta, iphi);
     }
 
-    if ( towerMasked ) {
+    if ( towerMasked || caloLayer1OutOfRun ) {
       // Do not compare if we have a mask applied
       continue;
     }
@@ -103,6 +137,8 @@ void L1TStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSetu
       ecalLinkError_->Fill(ieta, iphi);
       ecalLinkErrorByLumi_->Fill(event.id().luminosityBlock());
       nEcalLinkErrors++;
+      // Don't compare anymore, we already know its bad
+      continue;
     }
 
     ecalTPRawEtCorrelation_->Fill(sentTp.compressedEt(), recdTp.compressedEt());
@@ -118,7 +154,9 @@ void L1TStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSetu
 
     // Now for comparisons
 
-    if ( sentTp.compressedEt() == recdTp.compressedEt() && sentTp.fineGrain() == recdTp.fineGrain() ) {
+    const bool EetAgreement = sentTp.compressedEt() == recdTp.compressedEt();
+    const bool EfbAgreement = sentTp.fineGrain() == recdTp.fineGrain();
+    if ( EetAgreement && EfbAgreement ) {
       // Full match
       if ( sentTp.compressedEt() > tpFillThreshold_ ) {
         ecalOccSentAndRecd_->Fill(ieta, iphi);
@@ -132,12 +170,16 @@ void L1TStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSetu
       ECALmismatchesPerBx_->Fill(event.bunchCrossing());
       nEcalMismatch++;
 
-      if ( sentTp.compressedEt() != recdTp.compressedEt() ) {
+      if ( not EetAgreement ) {
         ecalOccEtDiscrepancy_->Fill(ieta, iphi);
         ecalTPRawEtDiffNoMatch_->Fill(recdTp.compressedEt()-sentTp.compressedEt());
         updateMismatch(event, 0);
+
+        if ( sentTp.compressedEt() == 0 ) ecalOccRecdNotSent_->Fill(ieta, iphi);
+        else if ( recdTp.compressedEt() == 0 ) ecalOccSentNotRecd_->Fill(ieta, iphi);
+        else ecalOccNoMatch_->Fill(ieta, iphi);
       }
-      if ( sentTp.fineGrain() != recdTp.fineGrain() ) {
+      if ( not EfbAgreement ) {
         // occ for fine grain mismatch
         ecalOccFgDiscrepancy_->Fill(ieta, iphi);
         updateMismatch(event, 1);
@@ -196,7 +238,7 @@ void L1TStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSetu
       hcalOccSentFb2_->Fill(ieta, iphi);
     }
 
-    if ( towerMasked ) {
+    if ( towerMasked || caloLayer1OutOfRun ) {
       // Do not compare if we have a mask applied
       continue;
     }
@@ -205,6 +247,8 @@ void L1TStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSetu
       hcalLinkError_->Fill(ieta, iphi);
       hcalLinkErrorByLumi_->Fill(event.id().luminosityBlock());
       nHcalLinkErrors++;
+      // Don't compare anymore, we already know its bad
+      continue;
     }
 
     if ( recdTp.SOI_compressedEt() > tpFillThreshold_ ) {
@@ -225,7 +269,10 @@ void L1TStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSetu
       hcalTPRawEtCorrelationHBHE_->Fill(sentTp.SOI_compressedEt(), recdTp.SOI_compressedEt());
     }
 
-    if ( sentTp.SOI_compressedEt() == recdTp.SOI_compressedEt() && sentTp.SOI_fineGrain() == recdTp.SOI_fineGrain() ) {
+    const bool HetAgreement = sentTp.SOI_compressedEt() == recdTp.SOI_compressedEt();
+    const bool Hfb1Agreement = sentTp.SOI_fineGrain() == recdTp.SOI_fineGrain();
+    const bool Hfb2Agreement = ( abs(ieta) < 29 ) ? true : ((sentTp.SOI_fineGrain(1) == recdTp.SOI_fineGrain(1)) || ignoreHFfb2_);
+    if ( HetAgreement && Hfb1Agreement && Hfb2Agreement ) {
       // Full match
       if ( sentTp.SOI_compressedEt() > tpFillThreshold_ ) {
         hcalOccSentAndRecd_->Fill(ieta, iphi);
@@ -238,7 +285,7 @@ void L1TStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSetu
       hcalMismatchByLumi_->Fill(event.id().luminosityBlock());
       nHcalMismatch++;
 
-      if ( sentTp.SOI_compressedEt() != recdTp.SOI_compressedEt() ) {
+      if ( not HetAgreement ) {
         if ( abs(ieta) > 29 ) {
           HFmismatchesPerBx_->Fill(event.bunchCrossing());
         } else {
@@ -253,10 +300,14 @@ void L1TStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSetu
         else if ( recdTp.SOI_compressedEt() == 0 ) hcalOccSentNotRecd_->Fill(ieta, iphi);
         else hcalOccNoMatch_->Fill(ieta, iphi);
       }
-      if ( sentTp.SOI_fineGrain() != recdTp.SOI_fineGrain() ) {
+      if ( not Hfb1Agreement ) {
         // Handle fine grain discrepancies
-        // TODO: HF has two bits to compare, not sure how packed in hcalDigis
         hcalOccFbDiscrepancy_->Fill(ieta, iphi);
+        updateMismatch(event, 3);
+      }
+      if ( not Hfb2Agreement ) {
+        // Handle fine grain discrepancies
+        hcalOccFb2Discrepancy_->Fill(ieta, iphi);
         updateMismatch(event, 3);
       }
     }
@@ -269,34 +320,6 @@ void L1TStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSetu
   }
   if ( nHcalMismatch > maxEvtMismatchHCALCurrentLumi_ ) {
     maxEvtMismatchHCALCurrentLumi_ = nHcalMismatch;
-  }
-
-
-  // Monitorables stored in Layer 1 raw data but
-  // not accessible from existing persistent data formats
-  edm::Handle<FEDRawDataCollection> fedRawDataCollection;
-  event.getByToken(fedRawData_, fedRawDataCollection);
-  if (fedRawDataCollection.isValid()) {
-    for(int iFed=1354; iFed<1360; iFed+=2) {
-      const FEDRawData& fedRawData = fedRawDataCollection->FEDData(iFed);
-      if ( fedRawData.size() == 0 ) continue;  // In case one of 3 layer 1 FEDs not in
-      const uint64_t *fedRawDataArray = (const uint64_t *) fedRawData.data();
-      UCTDAQRawData daqData(fedRawDataArray);
-      for(uint32_t i = 0; i < daqData.nAMCs(); i++) {
-        UCTAMCRawData amcData(daqData.amcPayload(i));
-        int lPhi = amcData.layer1Phi();
-        if ( daqData.BXID() != amcData.BXID() ) {
-          bxidErrors_->Fill(lPhi);
-        }
-        if ( daqData.L1ID() != amcData.L1ID() ) {
-          l1idErrors_->Fill(lPhi);
-        }
-        // AMC payload header has 16 bit orbit number, AMC13 header is full 32
-        if ( (daqData.orbitNumber() & 0xFFFF) != amcData.orbitNo() ) {
-          orbitErrors_->Fill(lPhi);
-        }
-      }
-    }
   }
 
 }
@@ -391,9 +414,11 @@ void L1TStage2CaloLayer1::bookHistograms(DQMStore::IBooker &ibooker, const edm::
   ecalDiscrepancy_ = bookEcalOccupancy("ecalDiscrepancy", "ECAL Discrepancies between TCC and Layer1 Readout");
   ecalLinkError_   = bookEcalOccupancy("ecalLinkError", "ECAL Link Errors");
   ecalOccupancy_   = bookEcalOccupancy("ecalOccupancy", "ECAL TP Occupancy at Layer1");
+  ecalOccRecdEtWgt_= bookEcalOccupancy("ecalOccRecdEtWgt", "ECal TP ET-weighted Occupancy at Layer1");
   hcalDiscrepancy_ = bookHcalOccupancy("hcalDiscrepancy", "HCAL Discrepancies between uHTR and Layer1 Readout");
   hcalLinkError_   = bookHcalOccupancy("hcalLinkError", "HCAL Link Errors");
   hcalOccupancy_   = bookHcalOccupancy("hcalOccupancy", "HCAL TP Occupancy at Layer1");
+  hcalOccRecdEtWgt_= bookHcalOccupancy("hcalOccRecdEtWgt", "HCal TP ET-weighted Occupancy at Layer1");
 
 
   ibooker.setCurrentFolder(histFolder_+"/ECalDetail");
@@ -401,7 +426,6 @@ void L1TStage2CaloLayer1::bookHistograms(DQMStore::IBooker &ibooker, const edm::
   ecalOccEtDiscrepancy_     = bookEcalOccupancy("ecalOccEtDiscrepancy", "ECal Et Discrepancy Occupancy");
   ecalOccFgDiscrepancy_     = bookEcalOccupancy("ecalOccFgDiscrepancy", "ECal FG Veto Bit Discrepancy Occupancy");
   ecalOccLinkMasked_        = bookEcalOccupancy("ecalOccLinkMasked", "ECal Masked Links");
-  ecalOccRecdEtWgt_         = bookEcalOccupancy("ecalOccRecdEtWgt", "ECal TP ET-weighted Occupancy at Layer1");
   ecalOccRecdFgVB_          = bookEcalOccupancy("ecalOccRecdFgVB", "ECal FineGrain Veto Bit Occupancy at Layer1");
   ecalOccSentAndRecd_       = bookEcalOccupancy("ecalOccSentAndRecd", "ECal TP Occupancy FULL MATCH");
   ecalOccSentFgVB_          = bookEcalOccupancy("ecalOccSentFgVB", "ECal FineGrain Veto Bit Occupancy at TCC");
@@ -413,13 +437,18 @@ void L1TStage2CaloLayer1::bookHistograms(DQMStore::IBooker &ibooker, const edm::
   ecalTPRawEtSentAndRecd_   = bookEt("ecalTPRawEtMatch", "ECal Raw Et FULL MATCH");
   ecalTPRawEtSent_          = bookEt("ecalTPRawEtSent", "ECal Raw Et TCC Readout");
 
+  ibooker.setCurrentFolder(histFolder_+"/ECalDetail/TCCDebug");
+  ecalOccSentNotRecd_        = bookHcalOccupancy("ecalOccSentNotRecd", "ECal TP Occupancy sent by TCC, zero at Layer1");
+  ecalOccRecdNotSent_        = bookHcalOccupancy("ecalOccRecdNotSent", "ECal TP Occupancy received by Layer1, zero at TCC");
+  ecalOccNoMatch_            = bookHcalOccupancy("ecalOccNoMatch", "ECal TP Occupancy for TCC and Layer1 nonzero, not matching");
+
 
   ibooker.setCurrentFolder(histFolder_+"/HCalDetail");
 
   hcalOccEtDiscrepancy_      = bookHcalOccupancy("hcalOccEtDiscrepancy", "HCal Et Discrepancy Occupancy");
   hcalOccFbDiscrepancy_      = bookHcalOccupancy("hcalOccFbDiscrepancy", "HCal Feature Bit Discrepancy Occupancy");
+  hcalOccFb2Discrepancy_     = bookHcalOccupancy("hcalOccFb2Discrepancy", "HCal Second Feature Bit Discrepancy Occupancy");
   hcalOccLinkMasked_         = bookHcalOccupancy("hcalOccLinkMasked", "HCal Masked Links");
-  hcalOccRecdEtWgt_          = bookHcalOccupancy("hcalOccRecdEtWgt", "HCal TP ET-weighted Occupancy at Layer1");
   hcalOccRecdFb_             = bookHcalOccupancy("hcalOccRecdFb", "HCal Feature Bit Occupancy at Layer1");
   hcalOccRecdFb2_            = bookHcalOccupancy("hcalOccRecdFb2", "HF Second Feature Bit Occupancy at Layer1");
   hcalOccSentAndRecd_        = bookHcalOccupancy("hcalOccSentAndRecd", "HCal TP Occupancy FULL MATCH");

--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
@@ -24,6 +24,10 @@ L1TdeStage2CaloLayer1::L1TdeStage2CaloLayer1(const edm::ParameterSet & ps) :
   histFolder_(ps.getParameter<std::string>("histFolder")),
   tpFillThreshold_(ps.getUntrackedParameter<int>("etDistributionsFillThreshold", 0))
 {
+  dataEmulDenominator_ = 0.;
+  for(size_t i=0; i<NSummaryColumns; ++i) {
+    dataEmulNumerator_[i] = 0.;
+  }
 }
 
 L1TdeStage2CaloLayer1::~L1TdeStage2CaloLayer1()
@@ -67,54 +71,85 @@ void L1TdeStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSe
     }
   }
   
+  bool etMsmThisEvent{false};
+  bool erMsmThisEvent{false};
+  bool fbMsmThisEvent{false};
+  bool towerCountMsmThisEvent{false};
+
   if ( dataTowerSet.size() != emulTowerSet.size() ) {
-    LogDebug("L1TdeStage2CaloLayer1") << "Data and Emulation have different number of trigger towers! data=" << dataTowerSet.size() << ", emul=" << emulTowerSet.size() << std::endl;
+    // This will happen if either CaloLayer1 or CaloLayer2 are out of run
+    // The problematic situation that we are monitoring is when we see both in, but one MP7 card is not sending fat events when it should
     towerCountMismatchesPerBx_->Fill(event.bunchCrossing());
-    return;
+    towerCountMsmThisEvent = true;
+  }
+  else {
+    auto dataIter = dataTowerSet.begin();
+    auto emulIter = emulTowerSet.begin();
+    while ( dataIter != dataTowerSet.end() && emulIter != emulTowerSet.end() ) {
+      auto dataTower = *(dataIter++);
+      auto emulTower = *(emulIter++);
+      assert(dataTower.ieta_==emulTower.ieta_ && dataTower.iphi_==emulTower.iphi_);
+
+      etCorrelation_->Fill(dataTower.et(), emulTower.et());
+
+      if ( abs(dataTower.ieta_) >= 30 ) {
+        fbCorrelationHF_->Fill(dataTower.fb(), emulTower.fb());
+      } else {
+        fbCorrelation_->Fill(dataTower.fb(), emulTower.fb());
+      }
+
+      if ( dataTower.data_ == emulTower.data_ ) {
+        // Perfect match
+        if ( dataTower.et() > tpFillThreshold_ ) {
+          matchOcc_->Fill(dataTower.ieta_, dataTower.iphi_);
+        }
+      } else {
+        // Ok, now dissect the failure
+        if ( dataTower.et() != emulTower.et() ) {
+          if      ( dataTower.et() == 0 ) failureOccEtDataZero_->Fill(dataTower.ieta_, dataTower.iphi_);
+          else if ( emulTower.et() == 0 ) failureOccEtEmulZero_->Fill(dataTower.ieta_, dataTower.iphi_);
+          else failureOccEtMismatch_->Fill(dataTower.ieta_, dataTower.iphi_);
+
+          etMismatchDiff_->Fill(dataTower.et() - emulTower.et());
+          etMismatchByLumi_->Fill(event.id().luminosityBlock());
+          etMismatchesPerBx_->Fill(event.bunchCrossing());
+          etMsmThisEvent = true;
+          updateMismatch(event, 0);
+        }
+        if ( dataTower.er() != emulTower.er() ) {
+          failureOccErMismatch_->Fill(dataTower.ieta_, dataTower.iphi_);
+          erMismatchByLumi_->Fill(event.id().luminosityBlock());
+          erMismatchesPerBx_->Fill(event.bunchCrossing());
+          erMsmThisEvent = true;
+          updateMismatch(event, 1);
+        }
+        if ( dataTower.fb() != emulTower.fb() ) {
+          failureOccFbMismatch_->Fill(dataTower.ieta_, dataTower.iphi_);
+          fbMismatchByLumi_->Fill(event.id().luminosityBlock());
+          fbMismatchesPerBx_->Fill(event.bunchCrossing());
+          dataEtDistributionFBMismatch_->Fill(dataTower.et());
+          fbMsmThisEvent = true;
+          updateMismatch(event, 2);
+        }
+      }
+    }
   }
 
-  auto dataIter = dataTowerSet.begin();
-  auto emulIter = emulTowerSet.begin();
-  while ( dataIter != dataTowerSet.end() && emulIter != emulTowerSet.end() ) {
-    auto dataTower = *(dataIter++);
-    auto emulTower = *(emulIter++);
-    assert(dataTower.ieta_==emulTower.ieta_ && dataTower.iphi_==emulTower.iphi_);
+  dataEmulDenominator_ += 1;
+  if ( etMsmThisEvent ) dataEmulNumerator_[EtMismatch] += 1;
+  if ( erMsmThisEvent ) dataEmulNumerator_[ErMismatch] += 1;
+  if ( fbMsmThisEvent ) dataEmulNumerator_[FbMismatch] += 1;
+  if ( towerCountMsmThisEvent ) dataEmulNumerator_[TowerCountMismatch] += 1;
 
-    etCorrelation_->Fill(dataTower.et(), emulTower.et());
+  for(size_t i=0; i<NSummaryColumns; ++i) {
+    dataEmulSummary_->getTH1F()->SetBinContent(1+i, dataEmulNumerator_[i]/dataEmulDenominator_);
+  }
+  // GetEntries() increments every SetBinContent() call
+  dataEmulSummary_->getTH1F()->SetEntries(dataEmulDenominator_);
 
-    if ( abs(dataTower.ieta_) >= 30 ) {
-      fbCorrelationHF_->Fill(dataTower.fb(), emulTower.fb());
-    }
-
-    if ( dataTower.data_ == emulTower.data_ ) {
-      // Perfect match
-      if ( dataTower.et() > tpFillThreshold_ ) {
-        matchOcc_->Fill(dataTower.ieta_, dataTower.iphi_);
-      }
-    } else {
-      // Ok, now dissect the failure
-      if ( dataTower.et() != emulTower.et() ) {
-        if      ( dataTower.et() == 0 ) failureOccEtDataZero_->Fill(dataTower.ieta_, dataTower.iphi_);
-        else if ( emulTower.et() == 0 ) failureOccEtEmulZero_->Fill(dataTower.ieta_, dataTower.iphi_);
-        else failureOccEtMismatch_->Fill(dataTower.ieta_, dataTower.iphi_);
-
-        etMismatchDiff_->Fill(dataTower.et() - emulTower.et());
-        etMismatchByLumi_->Fill(event.id().luminosityBlock());
-        updateMismatch(event, 0);
-      }
-      if ( dataTower.er() != emulTower.er() ) {
-        failureOccErMismatch_->Fill(dataTower.ieta_, dataTower.iphi_);
-        erMismatchByLumi_->Fill(event.id().luminosityBlock());
-        updateMismatch(event, 1);
-      }
-      if ( dataTower.fb() != emulTower.fb() ) {
-        failureOccFbMismatch_->Fill(dataTower.ieta_, dataTower.iphi_);
-        fbMismatchByLumi_->Fill(event.id().luminosityBlock());
-        fbMismatchesPerBx_->Fill(event.bunchCrossing());
-        dataEtDistributionFBMismatch_->Fill(dataTower.et());
-        updateMismatch(event, 2);
-      }
-    }
+  // To see if problems correlate with TMT cycle (i.e. an MP7-side issue)
+  if ( etMsmThisEvent or erMsmThisEvent or fbMsmThisEvent or towerCountMsmThisEvent ) {
+    mismatchesPerBxMod9_->Fill(event.bunchCrossing()%9);
   }
 }
 
@@ -154,18 +189,29 @@ void L1TdeStage2CaloLayer1::endLuminosityBlock(const edm::LuminosityBlock& lumi,
 void L1TdeStage2CaloLayer1::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run& run , const edm::EventSetup& es) 
 {
   auto bookEt = [&ibooker](std::string name, std::string title) {
-    return ibooker.book1D(name, title, 256, -0.5, 255.5);
+    title += ";Raw ET value";
+    return ibooker.book1D(name, title, 512, -0.5, 511.5);
   };
   auto bookEtDiff = [&ibooker](std::string name, std::string title) {
-    return ibooker.book1D(name, title, 511, -255.5, 255.5);
+    title += ";#Delta raw ET value";
+    return ibooker.book1D(name, title, 1023, -511.5, 511.5);
   };
   auto bookEtCorrelation = [&ibooker](std::string name, std::string title) {
-    return ibooker.book2D(name, title, 256, -0.5, 255.5, 256, -0.5, 255.5);
+    return ibooker.book2D(name, title, 512, -0.5, 511.5, 512, -0.5, 511.5);
   };
   auto bookOccupancy = [&ibooker](std::string name, std::string title) {
+    title += ";i#eta;i#phi";
     return ibooker.book2D(name, title, 83, -41.5, 41.5, 72, 0.5, 72.5);
   };
 
+  ibooker.setCurrentFolder(histFolder_+"/");
+  dataEmulSummary_ = ibooker.book1D("dataEmulSummary", "CaloLayer1 data-emul mismatch frac. (entries=evts processed)", NSummaryColumns, 0., double(NSummaryColumns));
+  dataEmulSummary_->getTH1F()->GetYaxis()->SetTitle("Fraction events with mismatch");
+  dataEmulSummary_->getTH1F()->GetXaxis()->SetBinLabel(1+EtMismatch, "Et");
+  dataEmulSummary_->getTH1F()->GetXaxis()->SetBinLabel(1+ErMismatch, "Et ratio");
+  dataEmulSummary_->getTH1F()->GetXaxis()->SetBinLabel(1+FbMismatch, "Feature bit");
+  dataEmulSummary_->getTH1F()->GetXaxis()->SetBinLabel(1+TowerCountMismatch, "CaloTower readout");
+  mismatchesPerBxMod9_ = ibooker.book1D("mismatchesPerBxMod9", "CaloLayer1 data-emulator mismatch per bx%9;Bunch crossing mod 9;Counts", 9, -0.5, 8.5);
 
   ibooker.setCurrentFolder(histFolder_+"/Occupancies");
 
@@ -185,15 +231,18 @@ void L1TdeStage2CaloLayer1::bookHistograms(DQMStore::IBooker &ibooker, const edm
   etCorrelation_ = bookEtCorrelation("EtCorrelation", "Et correlation for all towers;Data tower Et;Emulator tower Et");
   matchEtDistribution_ = bookEt("matchEtDistribution", "ET distribution for towers matched between data and emulator");
   etMismatchDiff_ = bookEtDiff("etMismatchDiff", "ET difference (data-emulator) for ET mismatches");
+  fbCorrelation_ = ibooker.book2D("FbCorrelation", "Feature Bit correlation for BE;Data;Emulator", 16, -0.5, 15.5, 16, -0.5, 15.5);
   fbCorrelationHF_ = ibooker.book2D("FbCorrelationHF", "Feature Bit correlation for HF;Data;Emulator", 16, -0.5, 15.5, 16, -0.5, 15.5);
 
-  ibooker.setCurrentFolder(histFolder_+"/Mismatch");
+  ibooker.setCurrentFolder(histFolder_+"/MismatchDetail");
 
   const int nLumis = 2000;
   etMismatchByLumi_  = ibooker.book1D("etMismatchByLumi", "ET Mismatch counts per lumi section;LumiSection;Counts", nLumis, .5, nLumis+0.5);
   erMismatchByLumi_  = ibooker.book1D("erMismatchByLumi", "ET Ratio Mismatch counts per lumi section;LumiSection;Counts", nLumis, .5, nLumis+0.5);
   fbMismatchByLumi_  = ibooker.book1D("fbMismatchByLumi", "Feature Bit Mismatch counts per lumi section;LumiSection;Counts", nLumis, .5, nLumis+0.5);
 
+  etMismatchesPerBx_   = ibooker.book1D("etMismatchesPerBx", "ET Mismatch counts per bunch crossing", 3564, -.5, 3563.5);
+  erMismatchesPerBx_   = ibooker.book1D("erMismatchesPerBx", "ET Ratio Mismatch counts per bunch crossing", 3564, -.5, 3563.5);
   fbMismatchesPerBx_   = ibooker.book1D("fbMismatchesPerBx", "Feature Bit Mismatch counts per bunch crossing", 3564, -.5, 3563.5);
   towerCountMismatchesPerBx_ = ibooker.book1D("towerCountMismatchesPerBx", "CaloTower size mismatch counts per bunch crossing", 3564, -.5, 3563.5);
 

--- a/DQM/L1TMonitorClient/data/L1TStage2CaloLayer1DEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2CaloLayer1DEQualityTests.xml
@@ -1,0 +1,16 @@
+<TESTSCONFIGURATION>
+
+  <QTEST name="Layer1DEMismatchThreshold">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="warning">0.</PARAM>
+      <PARAM name="error">1.</PARAM>
+      <PARAM name="ymin">0.</PARAM>
+      <PARAM name="ymax">0.001</PARAM>
+      <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+
+  <LINK name="*L1TdeStage2CaloLayer1/dataEmulSummary">
+      <TestName activate="true">Layer1DEMismatchThreshold</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/python/L1TStage2CaloLayer1DEQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2CaloLayer1DEQualityTests_cfi.py
@@ -1,0 +1,16 @@
+# quality tests for L1 GCT trigger
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2CaloLayer1DEQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2CaloLayer1DEQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)
+

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
@@ -69,9 +69,9 @@ l1tStage2EmulatorEventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
+                                QualityTestName = cms.string("Layer1DEMismatchThreshold"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2CaloLayer1/dataEmulSummary"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             )
                         ),
@@ -181,7 +181,165 @@ l1tStage2EmulatorEventInfoClient = DQMEDHarvester("L1TEventInfoClient",
     #
     # the position in the parameter set gives, in reverse order, the position in the reportSummaryMap
     # in the trigger object column (right column)
-    L1Objects = cms.VPSet(),
+    # N.B. (nick): max(# entries in this VPset, # entries in L1Systems) determines the number of columns drawn
+    # hence the ugliness of the overlay if not the same as the overlay code
+    # which is here-ish: https://github.com/dmwm/deployment/blob/master/dqmgui/style/L1TStage2RenderPlugin.cc#L143-L199
+    L1Objects = cms.VPSet(
+                    cms.PSet(
+                        ObjectLabel = cms.string("TechTrig"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("GtExternal"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("HfRingEtSums"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("HfBitCounts"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("HTM"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("HTT"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("ETM"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("ETT"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("Tau"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("ForJet"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("CenJet"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("IsoEG"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("NoIsoEG"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("Mu"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        )
+                    ),
     #
     # fast over-mask a system: if the name of the system is in the list, the system will be masked
     # (the default mask value is given in L1Systems VPSet)

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorQualityTests_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorQualityTests_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 # L1 systems quality tests
 
 # Stage 2 L1 Emulator Quality tests
+from DQM.L1TMonitorClient.L1TStage2CaloLayer1DEQualityTests_cfi import *
 from DQM.L1TMonitorClient.L1TStage2uGMTDEQualityTests_cfi import *
 from DQM.L1TMonitorClient.L1TStage2BMTFDEQualityTests_cfi import *
 from DQM.L1TMonitorClient.L1TStage2OMTFDEQualityTests_cfi import *
@@ -14,6 +15,7 @@ from DQM.L1TMonitorClient.L1TStage2EMTFDEQualityTests_cfi import *
 
 # sequence for L1 systems
 l1TEmulatorSystemQualityTests = cms.Sequence(
+                                  l1TStage2CaloLayer1DEQualityTests +
                                   l1TStage2uGMTDEQualityTests +
                                   l1TStage2BMTFDEQualityTests +
                                   l1TStage2OMTFDEQualityTests +


### PR DESCRIPTION
backport of #22348 
For use in online DQM at P5 for commissioning running.  Includes a merge of #20465 because it was left unmerged for several months on master, and ended up only in 10_1_X.  Once this is added to DQM tag collector, #20465 can be removed.