### PR TITLE
Update L1T DQM clients to 2018 era

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.Eras import eras
-process = cms.Process("L1TStage2DQM", eras.Run2_2017)
+process = cms.Process("L1TStage2DQM", eras.Run2_2018)
 
 #--------------------------------------------------
 # Event Source and Condition

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.Eras import eras
-process = cms.Process("L1TStage2EmulatorDQM", eras.Run2_2017)
+process = cms.Process("L1TStage2EmulatorDQM", eras.Run2_2018)
 
 #--------------------------------------------------
 # Event Source and Condition


### PR DESCRIPTION
backport of #22350 
For use in online DQM at P5 for commissioning running.