### PR TITLE
Do not produce a new payload if low stat

### DIFF
--- a/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLHarvester.h
+++ b/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLHarvester.h
@@ -65,5 +65,6 @@ class ECALpedestalPCLHarvester : public  DQMEDHarvester {
       std::string labelG6G1_;    // DB label from which pedestals for G6 and G1 are to be copied
       float threshDiffEB_;       // if the new pedestals differs more than this from old, keep old
       float threshDiffEE_;         // same as above for EE. Stray channel protection
+      float threshChannelsAnalyzed_; // threshold for minimum percentage of channels analized to produce DQM plots
 
 };

--- a/Calibration/EcalCalibAlgos/python/ecalPedestalPCLHarvester_cfi.py
+++ b/Calibration/EcalCalibAlgos/python/ecalPedestalPCLHarvester_cfi.py
@@ -11,5 +11,6 @@ ECALpedestalPCLHarvester = DQMEDHarvester('ECALpedestalPCLHarvester',
                                           labelG6G1   = cms.string('HLT'), #use the HLT tag as source for G6 and G1 pedestals
                                           threshDiffEB= cms.double(5.0), # if pedestal has changed more then this wrt old value, keep old value. Unit = ADC count
                                           threshDiffEE= cms.double(8.0),
+                                          threshChannelsAnalyzed = cms.double(0.3), # threshold for minimum percentage of channels analized to produce DQM plots
 
                                           )


### PR DESCRIPTION
With the current behaviour, the Ecal pedestal PCL generates a new payload even if the stat is insufficient. The new payload is identical to the old.
With the new behaviour, a new payload is _not_ created if statistics is low.