### PR TITLE
Configure Geant4 physics list to be similar to GeantV

### DIFF
--- a/SimG4Core/PhysicsLists/interface/DummyEMPhysics.h
+++ b/SimG4Core/PhysicsLists/interface/DummyEMPhysics.h
@@ -9,7 +9,7 @@ class DummyEMPhysics : public G4VPhysicsConstructor {
 
 public:
   DummyEMPhysics(G4int verb);
-  ~DummyEMPhysics() = default;
+  ~DummyEMPhysics() override = default;
   void ConstructParticle() override;
   void ConstructProcess() override;
 

--- a/SimG4Core/PhysicsLists/interface/DummyEMPhysics.h
+++ b/SimG4Core/PhysicsLists/interface/DummyEMPhysics.h
@@ -1,15 +1,21 @@
 #ifndef SimG4Core_PhysicsLists_DummyEMPhysics_h
 #define SimG4Core_PhysicsLists_DummyEMPhysics_h
 
+// Physics List equivalent to GeantV 
+
 #include "G4VPhysicsConstructor.hh"
 
 class DummyEMPhysics : public G4VPhysicsConstructor {
 
 public:
-  DummyEMPhysics(const std::string name = "dummyEM");
-  ~DummyEMPhysics() override;
+  DummyEMPhysics(G4int verb);
+  ~DummyEMPhysics() = default;
   void ConstructParticle() override;
   void ConstructProcess() override;
+
+private:
+
+  G4int verbose;
 };
 
 #endif

--- a/SimG4Core/PhysicsLists/plugins/DummyPhysics.cc
+++ b/SimG4Core/PhysicsLists/plugins/DummyPhysics.cc
@@ -10,12 +10,12 @@ DummyPhysics::DummyPhysics(G4LogicalVolumeToDDLogicalPartMap& map,
 			   const edm::ParameterSet & p) : PhysicsList(map, table_, chordFinderSetter_, p) {
 
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  RegisterPhysics(new G4DecayPhysics("decay"));
-  if (emPhys) 
-    RegisterPhysics(new DummyEMPhysics("dummyEM"));
+  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
+  if (emPhys) {
+    RegisterPhysics(new DummyEMPhysics(ver));
+  }
+  RegisterPhysics(new G4DecayPhysics(ver));
   edm::LogInfo("PhysicsList") << "DummyPhysics constructed with EM Physics "
 			      << emPhys << " and Decay";
 }
-
-DummyPhysics::~DummyPhysics() {}
 

--- a/SimG4Core/PhysicsLists/plugins/DummyPhysics.h
+++ b/SimG4Core/PhysicsLists/plugins/DummyPhysics.h
@@ -8,7 +8,7 @@ class DummyPhysics : public PhysicsList {
 
 public:
   DummyPhysics(G4LogicalVolumeToDDLogicalPartMap&, const HepPDT::ParticleDataTable *, sim::ChordFinderSetter *, const edm::ParameterSet &);
-  ~DummyPhysics() = default;
+  ~DummyPhysics() override = default;
 };
  
 #endif

--- a/SimG4Core/PhysicsLists/plugins/DummyPhysics.h
+++ b/SimG4Core/PhysicsLists/plugins/DummyPhysics.h
@@ -8,7 +8,7 @@ class DummyPhysics : public PhysicsList {
 
 public:
   DummyPhysics(G4LogicalVolumeToDDLogicalPartMap&, const HepPDT::ParticleDataTable *, sim::ChordFinderSetter *, const edm::ParameterSet &);
-  ~DummyPhysics() override;
+  ~DummyPhysics() = default;
 };
  
 #endif

--- a/SimG4Core/PhysicsLists/src/DummyEMPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/DummyEMPhysics.cc
@@ -1,26 +1,79 @@
 #include "SimG4Core/PhysicsLists/interface/DummyEMPhysics.h"
+#include "G4EmParameters.hh"
+#include "G4ParticleTable.hh"
 
 #include "G4ParticleDefinition.hh"
-#include "G4ParticleTypes.hh"
-#include "G4ParticleTable.hh"
-#include "G4ProcessManager.hh"
+
+#include "G4ComptonScattering.hh"
+#include "G4GammaConversion.hh"
+#include "G4PhotoElectricEffect.hh"
+
+#include "G4eMultipleScattering.hh"
 #include "G4eIonisation.hh"
-#include "G4MuIonisation.hh"
+#include "G4eBremsstrahlung.hh"
+#include "G4eplusAnnihilation.hh"
 
-DummyEMPhysics::DummyEMPhysics(const std::string name) 
-  : G4VPhysicsConstructor(name) {}
+#include "G4Gamma.hh"
+#include "G4Electron.hh"
+#include "G4Positron.hh"
+#include "G4LeptonConstructor.hh"
 
-DummyEMPhysics::~DummyEMPhysics() {}
+#include "G4PhysicsListHelper.hh"
+#include "G4BuilderType.hh"
+
+#include "G4SystemOfUnits.hh"
+
+DummyEMPhysics::DummyEMPhysics(G4int ver) :
+  G4VPhysicsConstructor("CMSEmGeantV"), verbose(ver) {
+  G4EmParameters* param = G4EmParameters::Instance();
+  param->SetDefaults();
+  param->SetVerbose(verbose);
+  param->SetApplyCuts(true);
+  param->SetStepFunction(0.8, 1*CLHEP::mm);
+  param->SetLossFluctuations(false);
+  param->SetMscRangeFactor(0.2);
+  param->SetMscStepLimitType(fMinimal);
+  SetPhysicsType(bElectromagnetic);
+}
 
 void DummyEMPhysics::ConstructParticle() {
-  G4Electron::ElectronDefinition();     
-  G4MuonMinus::MuonMinusDefinition();
+  // gamma
+  G4Gamma::Gamma();
+
+  // leptons
+  G4Electron::Electron();
+  G4Positron::Positron();
+
+  G4LeptonConstructor pLeptonConstructor;
+  pLeptonConstructor.ConstructParticle();
 }
 
 void DummyEMPhysics::ConstructProcess() {
-  G4ProcessManager * man = nullptr;
-  man = G4Electron::Electron()->GetProcessManager();
-  man->AddProcess(new G4eIonisation,	  -1, 2,2);
-  man = G4MuonMinus::MuonMinus()->GetProcessManager();
-  man->AddProcess(new G4MuIonisation,	  -1, 2,2);
+
+  if(verbose > 0) {
+    G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
+  }
+
+  // This EM builder takes GeantV variant of physics
+
+  G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
+
+  G4ParticleDefinition* particle = G4Gamma::Gamma();
+
+  ph->RegisterProcess(new G4PhotoElectricEffect(), particle);
+  ph->RegisterProcess(new G4ComptonScattering(), particle);
+  ph->RegisterProcess(new G4GammaConversion(), particle);
+
+  particle = G4Electron::Electron();
+
+  ph->RegisterProcess(new G4eMultipleScattering(), particle);
+  ph->RegisterProcess(new G4eIonisation(), particle);
+  ph->RegisterProcess(new G4eBremsstrahlung(), particle);
+
+  particle = G4Positron::Positron();
+
+  ph->RegisterProcess(new G4eMultipleScattering(), particle);
+  ph->RegisterProcess(new G4eIonisation(), particle);
+  ph->RegisterProcess(new G4eBremsstrahlung(), particle);
+  ph->RegisterProcess(new G4eplusAnnihilation(), particle);
 }


### PR DESCRIPTION
For comparison of the default Geant4 and new GeantV tracking an equivalent to GeanV EM physics constructor is proposed, where only gamma, e+, e- interactions are included.

This PR should not affect any production. 