### PR TITLE
OutputModules now write Run and LuminosityBlocks asynchronously

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -209,7 +209,8 @@ namespace edm {
 
     void beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalBeginSucceeded);
     void endRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalBeginSucceeded, bool cleaningUpAfterException);
-
+    void endUnfinishedRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalBeginSucceeded, bool cleaningUpAfterException);
+    
     InputSource::ItemType processLumis(std::shared_ptr<void> const& iRunResource);
     void endUnfinishedLumi();
     
@@ -226,9 +227,9 @@ namespace edm {
     std::pair<ProcessHistoryID,RunNumber_t> readAndMergeRun();
     void readLuminosityBlock(LuminosityBlockProcessingStatus&);
     int readAndMergeLumi(LuminosityBlockProcessingStatus&);
-    void writeRun(ProcessHistoryID const& phid, RunNumber_t run);
+    void writeRunAsync(WaitingTaskHolder, ProcessHistoryID const& phid, RunNumber_t run);
     void deleteRunFromCache(ProcessHistoryID const& phid, RunNumber_t run);
-    void writeLumi(LuminosityBlockProcessingStatus& );
+    void writeLumiAsync(WaitingTaskHolder, std::shared_ptr<LuminosityBlockProcessingStatus> );
     void deleteLumiFromCache(LuminosityBlockProcessingStatus&);
 
     bool shouldWeStop() const;

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -88,6 +88,9 @@ namespace edm {
 
     SerialTaskQueue* globalRunsQueue() { return &runQueue_;}
     SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_;}
+    SharedResourcesAcquirer& sharedResourcesAcquirer() {
+      return resourceAcquirer_;
+    }
 
     bool wantAllEvents() const {return wantAllEvents_;}
 
@@ -198,10 +201,6 @@ namespace edm {
 
     std::string workerType() const {return "WorkerT<OutputModule>";}
     
-    SharedResourcesAcquirer& sharedResourcesAcquirer() {
-      return resourceAcquirer_;
-    }
-
     /// Tell the OutputModule that is must end the current file.
     void doCloseFile();
 

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -164,14 +164,16 @@ namespace edm {
     void endStream(unsigned int);
 
     // Write the luminosity block
-    void writeLumi(LuminosityBlockPrincipal const& lbp,
-                   ProcessContext const*,
-                   ActivityRegistry*);
+    void writeLumiAsync(WaitingTaskHolder iTask,
+                        LuminosityBlockPrincipal const& lbp,
+                        ProcessContext const*,
+                        ActivityRegistry*);
 
     // Write the run
-    void writeRun(RunPrincipal const& rp,
-                  ProcessContext const*,
-                  ActivityRegistry*);
+    void writeRunAsync(WaitingTaskHolder iTask,
+                       RunPrincipal const& rp,
+                       ProcessContext const*,
+                       ActivityRegistry*);
 
     // Call closeFile() on all OutputModules.
     void closeOutputFiles();

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -109,12 +109,12 @@ namespace edm {
 
 
     // Write the luminosity block
-    void writeLumi(LuminosityBlockPrincipal&);
+    void writeLumiAsync(WaitingTaskHolder, LuminosityBlockPrincipal&);
 
     void deleteLumiFromCache(LuminosityBlockPrincipal&);
 
     // Write the run
-    void writeRun(ProcessHistoryID const& parentPhID, int runNumber);
+    void writeRunAsync(WaitingTaskHolder, ProcessHistoryID const& parentPhID, int runNumber);
 
     void deleteRunFromCache(ProcessHistoryID const& parentPhID, int runNumber);
 

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -102,6 +102,9 @@ namespace edm {
 
       SerialTaskQueue* globalRunsQueue() { return &runQueue_;}
       SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_;}
+      SharedResourcesAcquirer& sharedResourcesAcquirer() {
+        return resourcesAcquirer_;
+      }
 
       bool wantAllEvents() const {return wantAllEvents_;}
       
@@ -212,10 +215,6 @@ namespace edm {
                                          ThinnedAssociationsHelper&) { }
 
       std::string workerType() const {return "WorkerT<edm::one::OutputModuleBase>";}
-      
-      SharedResourcesAcquirer& sharedResourcesAcquirer() {
-        return resourcesAcquirer_;
-      }
       
       /// Tell the OutputModule that is must end the current file.
       void doCloseFile();

--- a/FWCore/Framework/src/OutputModuleCommunicator.h
+++ b/FWCore/Framework/src/OutputModuleCommunicator.h
@@ -33,6 +33,7 @@ namespace edm {
   class ActivityRegistry;
   class ProcessContext;
   class ThinnedAssociationsHelper;
+  class WaitingTaskHolder;
 
   class OutputModuleCommunicator
   {
@@ -51,13 +52,15 @@ namespace edm {
     
     virtual void openFile(FileBlock const& fb) = 0;
     
-    virtual void writeRun(RunPrincipal const& rp,
-                          ProcessContext const*,
-                          ActivityRegistry*) = 0;
+    virtual void writeRunAsync(WaitingTaskHolder iTask,
+                               RunPrincipal const& rp,
+                               ProcessContext const*,
+                               ActivityRegistry*) = 0;
     
-    virtual void writeLumi(LuminosityBlockPrincipal const& lbp,
-                           ProcessContext const*,
-                           ActivityRegistry*) = 0;
+    virtual void writeLumiAsync(WaitingTaskHolder iTask,
+                                LuminosityBlockPrincipal const& lbp,
+                                ProcessContext const*,
+                                ActivityRegistry*) = 0;
     
     ///\return true if OutputModule has reached its limit on maximum number of events it wants to see
     virtual bool limitReached() const = 0;

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.cc
@@ -9,10 +9,41 @@
 #include "FWCore/ServiceRegistry/interface/GlobalContext.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Concurrency/interface/FunctorTask.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/make_sentry.h"
 
 #include "FWCore/Framework/src/OutputModuleCommunicatorT.h"
+
+#include "FWCore/Framework/interface/OutputModule.h"
+#include "FWCore/Framework/interface/global/OutputModuleBase.h"
+#include "FWCore/Framework/interface/one/OutputModuleBase.h"
+#include "FWCore/Framework/interface/limited/OutputModuleBase.h"
+
+namespace {
+  template <typename F>
+  void async( edm::OutputModule& iMod, F&& iFunc ) {
+    iMod.sharedResourcesAcquirer().serialQueueChain().push(std::move(iFunc));
+  }
+  
+  template <typename F>
+  void async( edm::one::OutputModuleBase& iMod, F&& iFunc ) {
+    iMod.sharedResourcesAcquirer().serialQueueChain().push(std::move(iFunc));
+  }
+  
+  template <typename F>
+  void async( edm::limited::OutputModuleBase& iMod, F&& iFunc ) {
+    iMod.queue().push(std::move(iFunc));
+  }
+  
+  template <typename F>
+  void async( edm::global::OutputModuleBase&, F iFunc ) {
+    auto t = edm::make_functor_task(tbb::task::allocate_root(), iFunc);
+    tbb::task::spawn(*t);
+  }
+}
 
 namespace edm {
 
@@ -36,46 +67,71 @@ namespace edm {
 
   template<typename T>
   void
-  OutputModuleCommunicatorT<T>::writeRun(edm::RunPrincipal const& rp,
-                                         ProcessContext const* processContext,
-                                         ActivityRegistry* activityRegistry) {
+  OutputModuleCommunicatorT<T>::writeRunAsync(WaitingTaskHolder iTask,
+                                              edm::RunPrincipal const& rp,
+                                              ProcessContext const* processContext,
+                                              ActivityRegistry* activityRegistry) {
+    auto token = ServiceRegistry::instance().presentToken();
     GlobalContext globalContext(GlobalContext::Transition::kWriteRun,
                                 LuminosityBlockID(rp.run(), 0),
                                 rp.index(),
                                 LuminosityBlockIndex::invalidLuminosityBlockIndex(),
                                 rp.endTime(),
                                 processContext);
-    ParentContext parentContext(&globalContext);
-    ModuleCallingContext mcc(&description());
-    ModuleContextSentry moduleContextSentry(&mcc, parentContext);
-    activityRegistry->preModuleWriteRunSignal_(globalContext, mcc);
-    auto sentry( make_sentry(activityRegistry,
-                             [&globalContext, &mcc](ActivityRegistry* activityRegistry) {
-                               activityRegistry->postModuleWriteRunSignal_(globalContext, mcc);
-                             }));
-    module().doWriteRun(rp, &mcc);
+    auto t = [&mod = module(), &rp, globalContext, token, desc = &description(), activityRegistry, iTask]() mutable {
+      std::exception_ptr ex;
+      try {
+        ServiceRegistry::Operate op(token);
+        ParentContext parentContext(&globalContext);
+        ModuleCallingContext mcc(desc);
+        ModuleContextSentry moduleContextSentry(&mcc, parentContext);
+        activityRegistry->preModuleWriteRunSignal_(globalContext, mcc);
+        auto sentry( make_sentry(activityRegistry,
+                               [&globalContext, &mcc](ActivityRegistry* activityRegistry) {
+                                 activityRegistry->postModuleWriteRunSignal_(globalContext, mcc);
+                               }));
+        mod.doWriteRun(rp, &mcc);
+      } catch(...) {
+        ex = std::current_exception();
+      }
+      iTask.doneWaiting(ex);
+    };
+    async(module(), std::move(t));
   }
 
   template<typename T>
   void
-  OutputModuleCommunicatorT<T>::writeLumi(edm::LuminosityBlockPrincipal const& lbp,
-                                          ProcessContext const* processContext,
-                                          ActivityRegistry* activityRegistry) {
+  OutputModuleCommunicatorT<T>::writeLumiAsync(WaitingTaskHolder iTask,
+                                               edm::LuminosityBlockPrincipal const& lbp,
+                                               ProcessContext const* processContext,
+                                               ActivityRegistry* activityRegistry) {
+    auto token = ServiceRegistry::instance().presentToken();
     GlobalContext globalContext(GlobalContext::Transition::kWriteLuminosityBlock,
                                 lbp.id(),
                                 lbp.runPrincipal().index(),
                                 lbp.index(),
                                 lbp.beginTime(),
                                 processContext);
-    ParentContext parentContext(&globalContext);
-    ModuleCallingContext mcc(&description());
-    ModuleContextSentry moduleContextSentry(&mcc, parentContext);
-    activityRegistry->preModuleWriteLumiSignal_(globalContext, mcc);
-    auto sentry( make_sentry(activityRegistry,
-                             [&globalContext, &mcc](ActivityRegistry* activityRegistry) {
-                               activityRegistry->postModuleWriteLumiSignal_(globalContext, mcc);
-                             }));
-    module().doWriteLuminosityBlock(lbp, &mcc);
+    auto t=[&mod = module(), &lbp, activityRegistry, token, globalContext,desc = &description(),iTask]() mutable {
+      std::exception_ptr ex;
+      try {
+        ServiceRegistry::Operate op(token);
+
+        ParentContext parentContext(&globalContext);
+        ModuleCallingContext mcc(desc);
+        ModuleContextSentry moduleContextSentry(&mcc, parentContext);
+        activityRegistry->preModuleWriteLumiSignal_(globalContext, mcc);
+        auto sentry( make_sentry(activityRegistry,
+                               [&globalContext, &mcc](ActivityRegistry* activityRegistry) {
+                                 activityRegistry->postModuleWriteLumiSignal_(globalContext, mcc);
+                               }));
+        mod.doWriteLuminosityBlock(lbp, &mcc);
+      } catch(...) {
+        ex = std::current_exception();
+      }
+      iTask.doneWaiting(ex);
+    };
+    async(module(), std::move(t));
   }
 
   template<typename T>
@@ -126,11 +182,6 @@ namespace edm {
     }
   }
 }
-
-#include "FWCore/Framework/interface/OutputModule.h"
-#include "FWCore/Framework/interface/global/OutputModuleBase.h"
-#include "FWCore/Framework/interface/one/OutputModuleBase.h"
-#include "FWCore/Framework/interface/limited/OutputModuleBase.h"
 
 namespace edm {
   template class OutputModuleCommunicatorT<OutputModule>;

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.h
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.h
@@ -44,13 +44,15 @@ namespace edm {
     
     void openFile(edm::FileBlock const& fb) override;
     
-    void writeRun(edm::RunPrincipal const& rp,
-                  ProcessContext const*,
-                  ActivityRegistry*) override;
+    void writeRunAsync(WaitingTaskHolder iTask,
+                       edm::RunPrincipal const& rp,
+                       ProcessContext const*,
+                       ActivityRegistry*) override;
     
-    void writeLumi(edm::LuminosityBlockPrincipal const& lbp,
-                   ProcessContext const*,
-                   ActivityRegistry*) override;
+    void writeLumiAsync(WaitingTaskHolder iTask,
+                        edm::LuminosityBlockPrincipal const& lbp,
+                        ProcessContext const*,
+                        ActivityRegistry*) override;
     
     ///\return true if OutputModule has reached its limit on maximum number of events it wants to see
     bool limitReached() const override;

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -991,22 +991,22 @@ namespace edm {
     for_all(all_output_communicators_, std::bind(&OutputModuleCommunicator::openFile, _1, std::cref(fb)));
   }
 
-  void Schedule::writeRun(RunPrincipal const& rp,
-                          ProcessContext const* processContext,
-                          ActivityRegistry* activityRegistry) {
-    using std::placeholders::_1;
-    for_all(all_output_communicators_,
-            std::bind(&OutputModuleCommunicator::writeRun, _1, std::cref(rp),
-                      processContext, activityRegistry));
+  void Schedule::writeRunAsync(WaitingTaskHolder task,
+                               RunPrincipal const& rp,
+                               ProcessContext const* processContext,
+                               ActivityRegistry* activityRegistry) {
+    for(auto& c: all_output_communicators_) {
+      c->writeRunAsync(task, rp, processContext, activityRegistry);
+    }
   }
 
-  void Schedule::writeLumi(LuminosityBlockPrincipal const& lbp,
-                           ProcessContext const* processContext,
-                           ActivityRegistry* activityRegistry) {
-    using std::placeholders::_1;
-    for_all(all_output_communicators_,
-            std::bind(&OutputModuleCommunicator::writeLumi, _1,
-                      std::cref(lbp), processContext, activityRegistry));
+  void Schedule::writeLumiAsync(WaitingTaskHolder task,
+                                LuminosityBlockPrincipal const& lbp,
+                                ProcessContext const* processContext,
+                                ActivityRegistry* activityRegistry) {
+    for(auto& c: all_output_communicators_) {
+      c->writeLumiAsync(task, lbp, processContext, activityRegistry);
+    }
   }
 
   bool Schedule::shouldWeCloseOutput() const {

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -43,12 +43,7 @@ struct RunResources {
   ~RunResources() noexcept {
     try {
       //If we skip empty runs, this would be called conditionally
-      ep_.endRun(processHistoryID(), run(), globalTransitionSucceeded_, cleaningUpAfterException_);
-      
-      if(success_) {
-        ep_.writeRun(processHistoryID(), run());
-      }
-      ep_.deleteRunFromCache(processHistoryID(), run());
+      ep_.endUnfinishedRun(processHistoryID(), run(), globalTransitionSucceeded_, cleaningUpAfterException_);
     }
     catch(...) {
       if(cleaningUpAfterException_ or not ep_.setDeferredException(std::current_exception())) {

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -246,6 +246,14 @@ namespace edm {
     output_ << "\tendRun " << run << postfix;
   }
 
+  void MockEventProcessor::endUnfinishedRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalTransitionSucceeded, bool cleaningUpAfterException ) {
+    endRun(phid,run,globalTransitionSucceeded,cleaningUpAfterException);
+    if(globalTransitionSucceeded) {
+      writeRun(phid,run);
+    }
+    deleteRunFromCache(phid,run);
+  }
+
   InputSource::ItemType MockEventProcessor::processLumis(std::shared_ptr<void> iRunResource) {
     
     if(lumiStatus_ and

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -55,6 +55,8 @@ namespace edm {
     void doErrorStuff();
 
     void beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalTransitionSucceeded);
+    void endUnfinishedRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalTranstitionSucceeded, bool cleaningUpAfterException);
+
     void endRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalTranstitionSucceeded, bool cleaningUpAfterException);
 
     InputSource::ItemType processLumis(std::shared_ptr<void>);

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -25,6 +25,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Framework/interface/FileBlock.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 
 #include "FWCore/Utilities/interface/Exception.h"
@@ -220,14 +221,26 @@ m_ep()
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_lbp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
-    iComm->writeLumi(*m_lbp, nullptr, &activityRegistry);
+    auto t = edm::make_empty_waiting_task();
+    t->increment_ref_count();
+    iComm->writeLumiAsync(edm::WaitingTaskHolder(t.get()), *m_lbp, nullptr, &activityRegistry);
+    t->wait_for_all();
+    if(t->exceptionPtr() != nullptr) {
+      std::rethrow_exception(*t->exceptionPtr());
+    }
   };
 
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
-    iComm->writeRun(*m_rp, nullptr, &activityRegistry);
+    auto t = edm::make_empty_waiting_task();
+    t->increment_ref_count();
+    iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry);
+    t->wait_for_all();
+    if(t->exceptionPtr() != nullptr) {
+      std::rethrow_exception(*t->exceptionPtr());
+    }
   };
   
   m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -25,6 +25,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Framework/interface/FileBlock.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 
 #include "FWCore/Utilities/interface/Exception.h"
@@ -219,14 +220,26 @@ m_ep()
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_lbp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
-    iComm->writeLumi(*m_lbp, nullptr, &activityRegistry);
+    auto t = edm::make_empty_waiting_task();
+    t->increment_ref_count();
+    iComm->writeLumiAsync(edm::WaitingTaskHolder(t.get()), *m_lbp, nullptr, &activityRegistry);
+    t->wait_for_all();
+    if(t->exceptionPtr() != nullptr) {
+      std::rethrow_exception(*t->exceptionPtr());
+    }
   };
 
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
-    iComm->writeRun(*m_rp, nullptr, &activityRegistry);
+    auto t = edm::make_empty_waiting_task();
+    t->increment_ref_count();
+    iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry);
+    t->wait_for_all();
+    if(t->exceptionPtr() != nullptr) {
+      std::rethrow_exception(*t->exceptionPtr());
+    }
   };
   
   m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -27,7 +27,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Framework/interface/FileBlock.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
-
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
 
@@ -298,14 +298,26 @@ m_ep()
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_lbp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
-    iComm->writeLumi(*m_lbp, nullptr, &activityRegistry);
+    auto t = edm::make_empty_waiting_task();
+    t->increment_ref_count();
+    iComm->writeLumiAsync(edm::WaitingTaskHolder(t.get()), *m_lbp, nullptr, &activityRegistry);
+    t->wait_for_all();
+    if(t->exceptionPtr() != nullptr) {
+      std::rethrow_exception(*t->exceptionPtr());
+    }
   };
 
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
-    iComm->writeRun(*m_rp, nullptr, &activityRegistry);
+    auto t = edm::make_empty_waiting_task();
+    t->increment_ref_count();
+    iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry);
+    t->wait_for_all();
+    if(t->exceptionPtr() != nullptr) {
+      std::rethrow_exception(*t->exceptionPtr());
+    }
   };
   
   m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -1080,10 +1080,10 @@
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 24
+++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
@@ -1866,10 +1866,10 @@
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 24
+++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
@@ -2328,10 +2328,10 @@
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 24
+++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ starting: end run: stream = 0 run = 1 time = 50000001
 ++++ finished: end run: stream = 0 run = 1 time = 50000001
 ++++ starting: end run: stream = 0 run = 1 time = 0
@@ -2398,10 +2398,10 @@
 ++++++ starting: global end run for module: label = 'out' id = 24
 ++++++ finished: global end run for module: label = 'out' id = 24
 ++++ finished: global end run 1 : time = 0
-++++++ starting: write run for module: label = 'out' id = 24
-++++++ finished: write run for module: label = 'out' id = 24
 ++++++ starting: write run for module: label = 'out' id = 37
 ++++++ finished: write run for module: label = 'out' id = 37
+++++++ starting: write run for module: label = 'out' id = 24
+++++++ finished: write run for module: label = 'out' id = 24
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 2 : time = 55000001
@@ -3252,10 +3252,10 @@
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 24
+++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
@@ -4038,10 +4038,10 @@
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 24
+++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
@@ -4500,10 +4500,10 @@
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 24
+++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ starting: end run: stream = 0 run = 2 time = 100000001
 ++++ finished: end run: stream = 0 run = 2 time = 100000001
 ++++ starting: end run: stream = 0 run = 2 time = 0
@@ -4570,10 +4570,10 @@
 ++++++ starting: global end run for module: label = 'out' id = 24
 ++++++ finished: global end run for module: label = 'out' id = 24
 ++++ finished: global end run 2 : time = 0
-++++++ starting: write run for module: label = 'out' id = 24
-++++++ finished: write run for module: label = 'out' id = 24
 ++++++ starting: write run for module: label = 'out' id = 37
 ++++++ finished: write run for module: label = 'out' id = 37
+++++++ starting: write run for module: label = 'out' id = 24
+++++++ finished: write run for module: label = 'out' id = 24
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 3 : time = 105000001
@@ -5424,10 +5424,10 @@
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 24
+++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
@@ -6210,10 +6210,10 @@
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 24
+++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
@@ -6672,10 +6672,10 @@
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 24
+++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ starting: end run: stream = 0 run = 3 time = 150000001
 ++++ finished: end run: stream = 0 run = 3 time = 150000001
 ++++ starting: end run: stream = 0 run = 3 time = 0
@@ -6742,10 +6742,10 @@
 ++++++ starting: global end run for module: label = 'out' id = 24
 ++++++ finished: global end run for module: label = 'out' id = 24
 ++++ finished: global end run 3 : time = 0
-++++++ starting: write run for module: label = 'out' id = 24
-++++++ finished: write run for module: label = 'out' id = 24
 ++++++ starting: write run for module: label = 'out' id = 37
 ++++++ finished: write run for module: label = 'out' id = 37
+++++++ starting: write run for module: label = 'out' id = 24
+++++++ finished: write run for module: label = 'out' id = 24
 ++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ starting: end stream for module: stream = 0 label = 'get' id = 6


### PR DESCRIPTION
The framework now has OutputModules write Run and LuminosityBlocks in an asynchronous manner. The necessary serialization for legacy, one and limited modules is also applied.

This fixes a bug when using concurrent LuminosityBlocks.