### PR TITLE
set LD_PRELOAD for oracle unittests

### DIFF
--- a/CondTools/Ecal/test/BuildFile.xml
+++ b/CondTools/Ecal/test/BuildFile.xml
@@ -1,6 +1,9 @@
 <use name="CondTools/Ecal"/>
 
 <architecture name="slc.*_amd64_.*">
+  <ifcxx11_abi value="1">
+    <flags SETENV="LD_PRELOAD=$(CMS_ORACLEOCCI_LIB)"/>
+  </ifcxx11_abi>
   <test name="EcalDAQ_O2O_test" command="EcalDAQ_O2O_test.sh"/>
   <test name="EcalDCS_O2O_test" command="EcalDCS_O2O_test.sh"/>
   <test name="EcalLaser_O2O_test" command="EcalLaser_O2O_test.sh"/>

--- a/CondTools/SiStrip/test/BuildFile.xml
+++ b/CondTools/SiStrip/test/BuildFile.xml
@@ -1,4 +1,7 @@
 <architecture name="slc.*_amd64_.*">
+  <ifcxx11_abi value="1">
+    <flags SETENV="LD_PRELOAD=$(CMS_ORACLEOCCI_LIB)"/>
+  </ifcxx11_abi>
   <test name="SiStripDCS_O2O_test" command="testSiStripDCSO2O.sh"/>
   <test name="SiStripDAQ_O2O_test" command="testSiStripDAQO2O.sh"/>
 </architecture>


### PR DESCRIPTION
make use of ifcxx11_abi filter in BuildFile to set LD_PRELOAD for oracle occi unit tests.
Changes in PR https://github.com/cms-sw/cmssw/pull/22353 and https://github.com/cms-sw/cmssw/pull/22355 are not needed once this is merged.