### PR TITLE
Fixes to TkMap script

### DIFF
--- a/CommonTools/TrackerMap/src/TrackerMap.cc
+++ b/CommonTools/TrackerMap/src/TrackerMap.cc
@@ -913,7 +913,7 @@ void TrackerMap::save(bool print_total,float minval, float maxval,std::string s,
     arphi.Draw();
     TLegend *MyL = buildLegend();
     
-    if (((title.find("QTestAlarm")!=std::string::npos) || (maxvalue == minvalue))){
+    if (title.find("QTestAlarm")!=std::string::npos){
 
       MyL->Draw();
     }

--- a/CommonTools/TrackerMap/src/TrackerMap.cc
+++ b/CommonTools/TrackerMap/src/TrackerMap.cc
@@ -3519,7 +3519,7 @@ save_as_HVtrackermap(true,0.,0.,outs6.str(),3000,1600);
 std::ifstream * TrackerMap::findfile(std::string filename) {
   std::ifstream * ifilename;
   std::string ifname;
-  if(jsPath!=""){
+  if(!jsPath.empty()){
   ifname=jsPath+filename;
   ifilename = new std::ifstream(edm::FileInPath(ifname).fullPath().c_str(),std::ios::in);
   if(!ifilename){

--- a/DQM/SiStripMonitorClient/scripts/TkMap_script_phase1.py
+++ b/DQM/SiStripMonitorClient/scripts/TkMap_script_phase1.py
@@ -28,7 +28,11 @@ else:
 #########Checking Data taking period##########
 for i in range(len(Run_Number)):
 
-    if Run_Number[i] > 294644:
+    if Run_Number[i] > 308336:
+    	DataLocalDir='Data2018'
+	DataOfflineDir='Commissioning2018'
+
+    elif Run_Number[i] > 294644:
         DataLocalDir='Data2017'
         DataOfflineDir='Run2017'
 
@@ -95,6 +99,7 @@ for i in range(len(Run_Number)):
     index = f.readlines()
     if any(str(Run_Number[i]) in s for s in index):
         for s in index:
+	    print s
             if (str(Run_Number[i]) in s) and ("__DQMIO.root" in s):
                 File_Name = str(str(s).split("xx/")[1].split("'>DQM")[0])
     else:
@@ -137,13 +142,14 @@ for i in range(len(Run_Number)):
             print 'No Online DQM file available. Skip dead roc map'
             deadRocMap = False
 
-    print 'Downloading DQM file:'+File_Name_online
+    if deadRocMap == True:		    
+    	print 'Downloading DQM file:'+File_Name_online
 
 
-    os.system('curl -k --cert /data/users/cctrkdata/current/auth/proxy/proxy.cert --key /data/users/cctrkdata/current/auth/proxy/proxy.cert -X GET https://cmsweb.cern.ch/dqm/online/data/browse/Original/000'+str(nnnOnline)+'xxxx/000'+str(nnn)+'xx/'+File_Name_online+' > /tmp/'+File_Name_online)
+    	os.system('curl -k --cert /data/users/cctrkdata/current/auth/proxy/proxy.cert --key /data/users/cctrkdata/current/auth/proxy/proxy.cert -X GET https://cmsweb.cern.ch/dqm/online/data/browse/Original/000'+str(nnnOnline)+'xxxx/000'+str(nnn)+'xx/'+File_Name_online+' > /tmp/'+File_Name_online)
 
-    os.remove('index_online.html')
-    os.remove('index_online_backup.html')
+    	os.remove('index_online.html')
+   	os.remove('index_online_backup.html')
 
 
 
@@ -184,7 +190,7 @@ for i in range(len(Run_Number)):
     globalTag = globalTag_v0
 
     for z in range(len(globalTag_v0)-2):#clean up the garbage string in the GT
-        if (globalTag_v0[z].isdigit()) and  (globalTag_v0[z+1].isdigit()) and(globalTag_v0[z+2].isupper()):
+        if (globalTag_v0[z].isdigit()) and  (globalTag_v0[z+1].isdigit()) and (globalTag_v0[z+2].isdigit()) and (globalTag_v0[z+3].isupper()):
             globalTag = globalTag_v0[z:]
 
     ####################################################


### PR DESCRIPTION
This PR fixes a crash in the Tracker Map production script in the case the DQM Online file for Pixels is not available and prevent to Draw a misleading legend on empty Tracker Maps.

No interference with any production sequences, the code is only used Offline by Tracker shifters.