### PR TITLE
changed eta ZS mask for null-word check

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
@@ -13,7 +13,7 @@ l1tStage2BmtfZeroSupp = cms.EDAnalyzer(
                                       0x01c00000,
                                       0x01c00000,
                                       0x01c00000,
-                                      0x00000000,
+                                      0x00200000,
                                       0x00000000),
     # mask for outputs (pt==0 defines empty muon)
     maskCapId2 = cms.untracked.vint32(0x000001FF,


### PR DESCRIPTION
backport of #22371 