### PR TITLE
Add premixing workflows for phase2

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2477,6 +2477,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
         # simplification later
         for step in upgradeSteps['baseline']['steps']:
             if "GenSim" in step:
+                stepName = step + upgradeSteps['baseline']['suffix']
                 stepNamePmx = step.replace('GenSim', 'Premix') + 'PU' + upgradeSteps['Premix']['suffix']
                 d = merge([{'-s'            : 'GEN,SIM,DIGI:pdigi_valid,L1,DIGI2RAW',
                             '--datatier'    : 'PREMIX',
@@ -2487,11 +2488,12 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                 upgradeStepDict[stepNamePmx][k] = d
 
         for stepType in upgradeSteps.keys():
+            if "Premix" in stepType:
+                # Premix stage1 is already set above, and there are no non-PU steps so has to be ignored here
+                continue
             for step in upgradeSteps[stepType]['PU']:
                 stepName = step + upgradeSteps[stepType]['suffix']
                 stepNamePU = step + 'PU' + upgradeSteps[stepType]['suffix']
-                if stepType == 'Premix':
-                    stepName = stepNamePU
                 upgradeStepDict[stepNamePU][k]=merge([PUDataSets[k2],upgradeStepDict[stepName][k]])
 
                 # Setup premixing stage2

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -165,6 +165,18 @@ upgradeSteps['heCollapse'] = {
     'suffix' : '_heCollapse',
     'offset' : 0.6,
 }
+upgradeSteps['Premix'] = {
+    'steps' : [],
+    'PU': [
+        'PremixFull',
+        'PremixHLBeamSpotFull',
+        'PremixHLBeamSpotFull14',
+    ],
+    'suffix': '_Premix',
+    'offset': 0.98,
+}
+# Premix stage2 is derived from baseline+PU in relval_upgrade.py
+premixS2_offset = 0.99
 
 upgradeProperties = {}
 


### PR DESCRIPTION
This PR adds premixing workflows for phase2 as variations of the PU workflows as discussed in Feb 6th simulation meeting
https://indico.cern.ch/event/702324/contributions/2885358/attachments/1596021/2527902/slides_mk_simulation_20180206.pdf

* Stage 1 uses variation number `.98` and it is added only for the `NuGun` fragment
* Stage 2 uses variation number `.99` and it is, for now, added only for the `TTbar_14TeV` fragment

The workflows are close copies from the run2 premixing workflows, so supposedly they do not run (a bit accidentally `.98` does not crash if one gives it privately generated `MinBias` events as input). The main benefit is to be able to generate the workflow configurations.

Tested in CMSSW_10_1_X_2018-02-26-2300, no changes expected in standard workflows.

@mdhildreth @kpedro88 