### PR TITLE
Initialize array to prevent warning

### DIFF
--- a/FWCore/ParameterSet/interface/getFixedSizeArray.h
+++ b/FWCore/ParameterSet/interface/getFixedSizeArray.h
@@ -22,7 +22,7 @@ namespace edm {
         << "' should have " << N << " elements, but has " << vec.size()
         << " elements in the configuration.\n";
     }
-    std::array<T, N> a;
+    std::array<T, N> a {};
     std::copy_n(vec.begin(), N, a.begin());
     return a;
   }


### PR DESCRIPTION
Fix for this comp warnings https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc700/CMSSW_10_1_X_2018-02-27-1100/FWCore/Integration