### PR TITLE
Avoid unnecessarily including MEtoEDMConverter

### DIFF
--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -123,8 +123,8 @@ def OptionsFromItems(items):
 
     options.step = options.step.replace("SIM_CHAIN","GEN,SIM,DIGI,L1,DIGI2RAW")
 
-    # add on the end of job sequence...
-    addEndJob = True
+    # add on the end of job sequence which brings in MEtoEDMConverter
+    addEndJob = "VALIDATION" in options.step or "DQM" in options.step
     if ("FASTSIM" in options.step and not "VALIDATION" in options.step) or "HARVESTING" in options.step or "ALCAHARVEST" in options.step or "ALCAOUTPUT" in options.step or options.step == "": 
         addEndJob = False
     if ("SKIM" in options.step and not "RECO" in options.step):


### PR DESCRIPTION
The EndJob option creates an endjob_step in the configuration that
primarily loads the endOfProcess sequence which normally only holds
the MEtoEDMConverter. The MEtoEDMConverter is only needed for job
that want to write DQM histograms to the ROOT output file.