### PR TITLE
Revert "Restore the original behaviour of PR 22131, revert PR 22239"

### DIFF
--- a/PhysicsTools/PatAlgos/python/triggerLayer1/triggerProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/triggerLayer1/triggerProducer_cfi.py
@@ -33,3 +33,5 @@ patTrigger = cms.EDProducer( "PATTriggerProducer"
 , packTriggerLabels = cms.bool(False)
 )
 
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+run2_miniAOD_80XLegacy.toModify(patTrigger, ReadPrescalesFromFile = True)


### PR DESCRIPTION
Reverts cms-sw/cmssw#22338

in order to restore meaningful timing performance on data

https://github.com/cms-sw/cmssw/pull/22338#issuecomment-369021969

e.g. in 136.7611 the time per event for patTrigger module has increased by a factor of about 20E3.