### PR TITLE
Create new collection for Hcal lasermon digis + Hcal unpacker updates

### DIFF
--- a/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
+++ b/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
@@ -148,6 +148,11 @@ bool HcalText2DetIdConverter::init (DetId fId) {
       setField (1, calibId.channel());
       setField (2, -999);
       setField (3, -999);
+    } else if (calibId.calibFlavor()==HcalCalibDetId::LASERMON) {
+      flavorName="LASERMON";
+      setField (1, calibId.ieta());
+      setField (2, calibId.iphi());
+      setField (3, calibId.cboxChannel() );
     } else if (calibId.calibFlavor()==HcalCalibDetId::CastorRadFacility) {
       flavorName="CRF";
       setField (1, calibId.rm());
@@ -234,10 +239,10 @@ bool HcalText2DetIdConverter::init (const std::string& fFlavor, const std::strin
     mId = HcalCalibDetId (HcalCalibDetId::uMNqie,channel);
   }
   else if (flavorName == "LASMON" ) {
-    int rm = 1;
-    int fiber = getField(2);
+    int ieta = getField(1);
+    int iphi = getField(2);
     int channel = getField(3);
-    mId = HcalCalibDetId (HcalCalibDetId::LASERMON,rm, fiber, channel);
+    mId = HcalCalibDetId (HcalCalibDetId::LASERMON, ieta, iphi, channel);
   }
   else if (flavorName=="CRF") {
     int rm=getField(1);

--- a/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
+++ b/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
@@ -149,7 +149,7 @@ bool HcalText2DetIdConverter::init (DetId fId) {
       setField (2, -999);
       setField (3, -999);
     } else if (calibId.calibFlavor()==HcalCalibDetId::LASERMON) {
-      flavorName="LASERMON";
+      flavorName="LASMON";
       setField (1, calibId.ieta());
       setField (2, calibId.iphi());
       setField (3, calibId.cboxChannel() );

--- a/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
+++ b/CalibFormats/HcalObjects/src/HcalText2DetIdConverter.cc
@@ -233,6 +233,12 @@ bool HcalText2DetIdConverter::init (const std::string& fFlavor, const std::strin
     int channel=getField(1);
     mId = HcalCalibDetId (HcalCalibDetId::uMNqie,channel);
   }
+  else if (flavorName == "LASMON" ) {
+    int rm = 1;
+    int fiber = getField(2);
+    int channel = getField(3);
+    mId = HcalCalibDetId (HcalCalibDetId::LASERMON,rm, fiber, channel);
+  }
   else if (flavorName=="CRF") {
     int rm=getField(1);
     int fiber=getField(2);

--- a/DataFormats/HcalDetId/interface/HcalCalibDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalCalibDetId.h
@@ -35,7 +35,7 @@
 class HcalCalibDetId : public HcalOtherDetId {
 public:
   /** Type identifier within calibration det ids */
-  enum CalibDetType { CalibrationBox = 1, HOCrosstalk = 2, uMNqie = 3, CastorRadFacility = 4 };
+  enum CalibDetType { CalibrationBox = 1, HOCrosstalk = 2, uMNqie = 3, CastorRadFacility = 4, LASERMON = 5 };
 
   /** Create a null det id */
   HcalCalibDetId();

--- a/DataFormats/HcalDetId/src/HcalCalibDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalCalibDetId.cc
@@ -67,7 +67,7 @@ HcalCalibDetId& HcalCalibDetId::operator=(const DetId& gen) {
 }
 
 int HcalCalibDetId::cboxChannel() const {
-  return (calibFlavor()==CalibrationBox)?(id_&0xF):(0);
+  return (calibFlavor()==CalibrationBox || calibFlavor() == LASERMON)?(id_&0xF):(0);
 }
 
 HcalSubdetector HcalCalibDetId::hcalSubdet() const {  
@@ -75,11 +75,11 @@ HcalSubdetector HcalCalibDetId::hcalSubdet() const {
 }
     
 int HcalCalibDetId::ieta() const {
-  return (calibFlavor()==CalibrationBox)?(((id_>>11)&0x7)-2):((calibFlavor()==HOCrosstalk)?(((id_>>7)&0xF)*zside()):(0));
+  return (calibFlavor()==CalibrationBox)?(((id_>>11)&0x7)-2):((calibFlavor()==HOCrosstalk)?(((id_>>7)&0xF)*zside()):(calibFlavor()==LASERMON?((id_>>10)&0x3F):(0)));
 }
 
 int HcalCalibDetId::iphi() const {
-  return (calibFlavor()==CalibrationBox)?((id_>>4)&0x7F):((calibFlavor()==HOCrosstalk)?(id_&0x7F):(0));
+  return (calibFlavor()==CalibrationBox)?((id_>>4)&0x7F):((calibFlavor()==HOCrosstalk)?(id_&0x7F):(calibFlavor()==LASERMON?((id_>>5)&0x1F):(0)));
 }
 
 int HcalCalibDetId::zside() const {

--- a/DataFormats/HcalDetId/src/HcalCalibDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalCalibDetId.cc
@@ -126,6 +126,8 @@ std::ostream& operator<<(std::ostream& s,const HcalCalibDetId& id) {
 	     << ')';
   case (HcalCalibDetId::uMNqie):
     return s << "(uMNqie " << id.channel() << ')';
+  case (HcalCalibDetId::LASERMON):
+    return s << "(LASERMON" << id.channel() << ')';
   case (HcalCalibDetId::CastorRadFacility):
     return s << "(CastorRadFacility " << id.rm() << " / " << id.fiber() << " / " << id.channel() << ')';
   default: return s;

--- a/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
@@ -34,6 +34,9 @@ public:
     QIE10DigiCollection* qie10;
     QIE10DigiCollection* qie10ZDC;
     QIE11DigiCollection* qie11;
+    // additional qie10 and qie11 data collections
+    std::map<int, QIE10DigiCollection*> qie10Addtl;
+    std::map<int, QIE11DigiCollection*> qie11Addtl;
     HcalUMNioDigi* umnio;
 
   };

--- a/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
@@ -35,8 +35,8 @@ public:
     QIE10DigiCollection* qie10ZDC;
     QIE11DigiCollection* qie11;
     // additional qie10 and qie11 data collections
-    std::map<int, QIE10DigiCollection*> qie10Addtl;
-    std::map<int, QIE11DigiCollection*> qie11Addtl;
+    std::unordered_map<int, QIE10DigiCollection*> qie10Addtl;
+    std::unordered_map<int, QIE11DigiCollection*> qie11Addtl;
     HcalUMNioDigi* umnio;
 
   };
@@ -54,6 +54,7 @@ private:
   void unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& emap, Collections& conts, HcalUnpackerReport& report, bool silent=false);
   void unpackUMNio(const FEDRawData& raw, int slot, Collections& colls);
 
+  void printInvalidDataMessage( const std::string &coll_type, int default_ns, int conflict_ns );
 
   int sourceIdOffset_; ///< number to subtract from the source id to get the dcc id
   int startSample_; ///< first sample from fed raw data to copy 

--- a/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
@@ -43,7 +43,7 @@ public:
   };
 
   /// for normal data
-  HcalUnpacker(int sourceIdOffset, int beg, int end) : sourceIdOffset_(sourceIdOffset), startSample_(beg), endSample_(end), expectedOrbitMessageTime_(-1), mode_(0) { }
+  HcalUnpacker(int sourceIdOffset, int beg, int end) : sourceIdOffset_(sourceIdOffset), startSample_(beg), endSample_(end), expectedOrbitMessageTime_(-1), mode_(0), nPrinted_ (0){ }
   /// For histograms, no begin and end
   HcalUnpacker(int sourceIdOffset) : sourceIdOffset_(sourceIdOffset), startSample_(-1), endSample_(-1),  expectedOrbitMessageTime_(-1), mode_(0) { }
   void setExpectedOrbitMessageTime(int time) { expectedOrbitMessageTime_=time; }
@@ -63,6 +63,8 @@ private:
   int expectedOrbitMessageTime_; ///< Expected orbit bunch time (needed to evaluate time differences)
   int mode_;
   std::set<HcalElectronicsId> unknownIds_,unknownIdsTrig_; ///< Recorded to limit number of times a log message is generated
+
+  int nPrinted_;
 };
 
 #endif // HcalUnpacker_h_included

--- a/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
@@ -32,6 +32,8 @@ public:
     std::vector<HOTriggerPrimitiveDigi>* tphoCont;
     std::vector<HcalTTPDigi>* ttp;
     QIE10DigiCollection* qie10;
+    QIE10DigiCollection* qie10ZDC;
+    QIE10DigiCollection* qie10Lasermon;
     QIE11DigiCollection* qie11;
     // additional qie10 and qie11 data collections
     std::unordered_map<int, QIE10DigiCollection*> qie10Addtl;

--- a/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
@@ -55,7 +55,7 @@ private:
   void unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& emap, Collections& conts, HcalUnpackerReport& report, bool silent=false);
   void unpackUMNio(const FEDRawData& raw, int slot, Collections& colls);
 
-  void printInvalidDataMessage( const std::string &coll_type, int default_ns, int conflict_ns );
+  void printInvalidDataMessage( const std::string &coll_type, int default_ns, int conflict_ns, bool extended=false );
 
   int sourceIdOffset_; ///< number to subtract from the source id to get the dcc id
   int startSample_; ///< first sample from fed raw data to copy 

--- a/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
@@ -32,7 +32,6 @@ public:
     std::vector<HOTriggerPrimitiveDigi>* tphoCont;
     std::vector<HcalTTPDigi>* ttp;
     QIE10DigiCollection* qie10;
-    QIE10DigiCollection* qie10ZDC;
     QIE11DigiCollection* qie11;
     // additional qie10 and qie11 data collections
     std::unordered_map<int, QIE10DigiCollection*> qie10Addtl;

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -69,7 +69,6 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
     produces<HcalUMNioDigi>();
   produces<QIE10DigiCollection>();
   produces<QIE11DigiCollection>();
-  produces<QIE10DigiCollection>("ZDC");
 
   // Print a warning if the two vectors
   // for additional qie10 or qie11 data
@@ -98,6 +97,12 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
 
       saveQIE10Info_[nsamples] = tag;
   }
+
+  // add LASERMON and ZDC
+  saveQIE10Info_[-1] = "ZDC";
+  saveQIE10Info_[-2] = "LASERMON";
+  produces<QIE10DigiCollection>("ZDC");
+  produces<QIE10DigiCollection>("LASERMON");
 
   // If additional qie11 samples were requested,
   // declare that we will produce this collection
@@ -288,10 +293,6 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
     colls.qie10 = new QIE10DigiCollection(); 
   }
   std::unique_ptr<QIE10DigiCollection> qie10_prod(colls.qie10);
-  if (colls.qie10ZDC == nullptr) {
-    colls.qie10ZDC = new QIE10DigiCollection(); 
-  }
-  std::unique_ptr<QIE10DigiCollection> qie10ZDC_prod(colls.qie10ZDC);
   if (colls.qie11 == nullptr) {
     colls.qie11 = new QIE11DigiCollection(); 
   }
@@ -351,7 +352,6 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   htp_prod->sort();
   hotp_prod->sort();
   qie10_prod->sort();
-  qie10ZDC_prod->sort();
   qie11_prod->sort();
 
   // sort the additional collections
@@ -368,7 +368,6 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   e.put(std::move(htp_prod));
   e.put(std::move(hotp_prod));
   e.put(std::move(qie10_prod));
-  e.put(std::move(qie10ZDC_prod),"ZDC");
   e.put(std::move(qie11_prod));
 
   // put the qie10 and qie11 collections into the event

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -73,6 +73,23 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
   produces<QIE10DigiCollection>("ZDC");
   produces<QIE10DigiCollection>("LASERMON");
 
+  // Print a warning if an already
+  // used tag was requested
+  if( std::find( saveQIE10DataTags_.begin(), saveQIE10DataTags_.end(), "ZDC") 
+          != saveQIE10DataTags_.end()  ) {
+    edm::LogError("HcalRawToDigi") << "Cannot create an additional QIE10 sample with name ZDC, it is already created!  It must be removed along with the corresponding entry in saveQIE10DataNSamples" << std::endl;
+    saveQIE10DataTags_.clear();
+    saveQIE10DataNSamples_.clear();
+  }
+  // Print a warning if an already
+  // used tag was requested
+  if( std::find( saveQIE10DataTags_.begin(), saveQIE10DataTags_.end(), "LASERMON") 
+          != saveQIE10DataTags_.end()  ) {
+    edm::LogError("HcalRawToDigi") << "Cannot create an additional QIE10 sample with name LASERMON, it is already created!  It must be removed along with the corresponding entry in saveQIE10DataNSamples" << std::endl;
+    saveQIE10DataTags_.clear();
+    saveQIE10DataNSamples_.clear();
+  }
+
   // Print a warning if the two vectors
   // for additional qie10 or qie11 data
   // are not the same length

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -77,7 +77,7 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
   // used tag was requested
   if( std::find( saveQIE10DataTags_.begin(), saveQIE10DataTags_.end(), "ZDC") 
           != saveQIE10DataTags_.end()  ) {
-    edm::LogError("HcalRawToDigi") << "Cannot create an additional QIE10 sample with name ZDC, it is already created!  It must be removed along with the corresponding entry in saveQIE10DataNSamples" << std::endl;
+    edm::LogWarning("HcalRawToDigi") << "Cannot create an additional QIE10 sample with name ZDC, it is already created!  It must be removed along with the corresponding entry in saveQIE10DataNSamples" << std::endl;
     saveQIE10DataTags_.clear();
     saveQIE10DataNSamples_.clear();
   }
@@ -85,7 +85,7 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
   // used tag was requested
   if( std::find( saveQIE10DataTags_.begin(), saveQIE10DataTags_.end(), "LASERMON") 
           != saveQIE10DataTags_.end()  ) {
-    edm::LogError("HcalRawToDigi") << "Cannot create an additional QIE10 sample with name LASERMON, it is already created!  It must be removed along with the corresponding entry in saveQIE10DataNSamples" << std::endl;
+    edm::LogWarning("HcalRawToDigi") << "Cannot create an additional QIE10 sample with name LASERMON, it is already created!  It must be removed along with the corresponding entry in saveQIE10DataNSamples" << std::endl;
     saveQIE10DataTags_.clear();
     saveQIE10DataNSamples_.clear();
   }
@@ -94,12 +94,12 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
   // for additional qie10 or qie11 data
   // are not the same length
   if( saveQIE10DataTags_.size() != saveQIE10DataNSamples_.size() ) {
-    edm::LogError("HcalRawToDigi") << "The saveQIE10DataTags and saveQIE10DataNSamples inputs must be the same length!  These will be ingored" << std::endl;
+    edm::LogWarning("HcalRawToDigi") << "The saveQIE10DataTags and saveQIE10DataNSamples inputs must be the same length!  These will be ignored" << std::endl;
     saveQIE10DataTags_.clear();
     saveQIE10DataNSamples_.clear();
   }
   if( saveQIE11DataTags_.size() != saveQIE11DataNSamples_.size() ) {
-    edm::LogError("HcalRawToDigi") << "The saveQIE11DataTags and saveQIE11DataNSamples inputs must be the same length!  These will be ingored" << std::endl;
+    edm::LogWarning("HcalRawToDigi") << "The saveQIE11DataTags and saveQIE11DataNSamples inputs must be the same length!  These will be ignored" << std::endl;
     saveQIE11DataTags_.clear();
     saveQIE11DataNSamples_.clear();
   }
@@ -277,7 +277,7 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   for( const auto & addtl: colls.qie10Addtl ) {
       if( addtl.second->samples() == colls.qie10->samples() ) {
           std::string tag = saveQIE10Info_[addtl.second->samples()];
-          edm::LogError("HcalRawToDigi") << "QIE10 data requested to be stored in tag " 
+          edm::LogWarning("HcalRawToDigi") << "QIE10 data requested to be stored in tag " 
               << tag << " is already stored in the default QIE10 collection.  "
               << "To avoid duplicating, remove the tag " << tag 
               << " from the saveQIE10DataTags and the value of " 
@@ -288,7 +288,7 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   for( const auto & addtl: colls.qie11Addtl ) {
       if( addtl.second->samples() == colls.qie11->samples() ) {
           std::string tag = saveQIE11Info_[addtl.second->samples()];
-          edm::LogError("HcalRawToDigi") << "QIE11 data requested to be stored in tag " 
+          edm::LogWarning("HcalRawToDigi") << "QIE11 data requested to be stored in tag " 
               << tag << " is already stored in the default QIE11 collection.  "
               << "To avoid duplicating, remove the tag " << tag 
               << " from the saveQIE11DataTags and the value of " 

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -70,6 +70,9 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
   produces<QIE10DigiCollection>();
   produces<QIE11DigiCollection>();
 
+  produces<QIE10DigiCollection>("ZDC");
+  produces<QIE10DigiCollection>("LASERMON");
+
   // Print a warning if the two vectors
   // for additional qie10 or qie11 data
   // are not the same length
@@ -97,12 +100,6 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
 
       saveQIE10Info_[nsamples] = tag;
   }
-
-  // add LASERMON and ZDC
-  saveQIE10Info_[-1] = "ZDC";
-  saveQIE10Info_[-2] = "LASERMON";
-  produces<QIE10DigiCollection>("ZDC");
-  produces<QIE10DigiCollection>("LASERMON");
 
   // If additional qie11 samples were requested,
   // declare that we will produce this collection
@@ -289,10 +286,24 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   auto ho_prod = std::make_unique<HODigiCollection>();
   auto htp_prod = std::make_unique<HcalTrigPrimDigiCollection>();
   auto hotp_prod = std::make_unique<HOTrigPrimDigiCollection>();
+  // make qie10 collection if it wasn't made in theunpacker
   if (colls.qie10 == nullptr) {
     colls.qie10 = new QIE10DigiCollection(); 
   }
   std::unique_ptr<QIE10DigiCollection> qie10_prod(colls.qie10);
+
+  // make qie10ZDC collection if it wasn't made in theunpacker
+  if (colls.qie10ZDC == nullptr) {
+    colls.qie10ZDC = new QIE10DigiCollection(); 
+  }
+  std::unique_ptr<QIE10DigiCollection> qie10ZDC_prod(colls.qie10ZDC);
+
+  // make qie10Lasermon collection if it wasn't made in theunpacker
+  if (colls.qie10Lasermon == nullptr) {
+    colls.qie10Lasermon = new QIE10DigiCollection(); 
+  }
+  std::unique_ptr<QIE10DigiCollection> qie10Lasermon_prod(colls.qie10Lasermon);
+
   if (colls.qie11 == nullptr) {
     colls.qie11 = new QIE11DigiCollection(); 
   }
@@ -323,7 +334,7 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
     HFDigiCollection filtered_hf=filter_.filter(*hf_prod,*report);
     QIE10DigiCollection filtered_qie10=filter_.filter(*qie10_prod,*report);
     QIE11DigiCollection filtered_qie11=filter_.filter(*qie11_prod,*report);
-    
+
     hbhe_prod->swap(filtered_hbhe);
     ho_prod->swap(filtered_ho);
     hf_prod->swap(filtered_hf);    
@@ -352,6 +363,8 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   htp_prod->sort();
   hotp_prod->sort();
   qie10_prod->sort();
+  qie10ZDC_prod->sort();
+  qie10Lasermon_prod->sort();
   qie11_prod->sort();
 
   // sort the additional collections
@@ -368,6 +381,8 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   e.put(std::move(htp_prod));
   e.put(std::move(hotp_prod));
   e.put(std::move(qie10_prod));
+  e.put(std::move(qie10ZDC_prod), "ZDC");
+  e.put(std::move(qie10Lasermon_prod), "LASERMON");
   e.put(std::move(qie11_prod));
 
   // put the qie10 and qie11 collections into the event

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h
@@ -41,9 +41,24 @@ private:
   const int firstFED_;
   const bool unpackCalib_, unpackZDC_, unpackTTP_;
   bool unpackUMNio_;
+
+  // input configs for additional QIE10 samples
+  std::vector<int> saveQIE10DataNSamples_;
+  std::vector<std::string> saveQIE10DataTags_;
+
+  // input configs for additional QIE11 samples
+  std::vector<int> saveQIE11DataNSamples_;
+  std::vector<std::string> saveQIE11DataTags_;
+
   const bool silent_, complainEmptyData_;
   const int unpackerMode_, expectedOrbitMessageTime_;
   std::string electronicsMapLabel_;
+
+  // maps to easily associate nSamples to 
+  // the tag for additional qie10 and qie11 info
+  std::map<int, std::string> saveQIE10Info_;
+  std::map<int, std::string> saveQIE11Info_;
+
 
   struct Statistics {
     int max_hbhe, ave_hbhe;

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h
@@ -56,8 +56,8 @@ private:
 
   // maps to easily associate nSamples to 
   // the tag for additional qie10 and qie11 info
-  std::map<int, std::string> saveQIE10Info_;
-  std::map<int, std::string> saveQIE11Info_;
+  std::unordered_map<int, std::string> saveQIE10Info_;
+  std::unordered_map<int, std::string> saveQIE11Info_;
 
 
   struct Statistics {

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -707,7 +707,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
           // if this sample type hasn't been requested to be saved
           // warn the user to provide a configuration that prompts it to be saved
           if( colls.qie10Addtl.find( ns ) == colls.qie10Addtl.end() ) {
-            printInvalidDataMessage( "QIE10", colls.qie11->samples(), ns );
+            printInvalidDataMessage( "QIE10", colls.qie10->samples(), ns );
           }
 	}
 

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -938,6 +938,16 @@ void HcalUnpacker::unpackUMNio(const FEDRawData& raw, int slot, Collections& col
 
 void HcalUnpacker::printInvalidDataMessage( const std::string &coll_type, int default_ns, int conflict_ns, bool extended ) {
 
+  nPrinted_++;
+
+  int limit = 50;
+  if( nPrinted_ >= limit ) {
+
+      if( nPrinted_ == limit ) edm::LogError("Invalid Data") << "Suppresing further error messages" << std::endl;
+      
+      return;
+  }
+
   std::stringstream message;
 
   message << "The default " << coll_type << " Collection has " 

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -644,15 +644,30 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
               colls.qie11 = new QIE11DigiCollection(ns);
           }
           else if (colls.qie11->samples() != ns) {
-              // This is horrible
-              edm::LogError("Invalid Data") << "QIE11 Collection has " << colls.qie11->samples() << " samples per digi, raw data has " << ns << "!";
-              return;
+            // if this sample type hasn't been requested to be saved
+            // warn the user to provide a configuration that prompts it to be saved
+            if( colls.qie11Addtl.find( ns ) == colls.qie11Addtl.end() ) {
+	      edm::LogError("Invalid Data") << "The default QIE11 Collection has " 
+                  << colls.qie10->samples() << " samples per digi, while the current data has " 
+                  << ns << "!  This data cannot be included with the default collection.\n"
+                  << "In order to store this data in the event, it must have a unique tag.  "
+                  << "To accomplish this, provide two lists to HcalRawToDigi \n"
+                  << "1) that specifies the number of samples and "
+                  << "2) that gives tags with which these data are saved.\n"
+                  << "For example in this case you might add \n"
+                  << "hcaldigis.saveQIE11DataNSamples = cms.untracked.vint32( " 
+                  << ns << ") \nhcaldigis.saveQIE11DataTags = cms.untracked.vstring( \"MYDATA\" )" << std::endl;
+            }
           }
 
           // Insert data
           /////////////////////////////////////////////CODE FROM OLD STYLE DIGIS///////////////////////////////////////////////////////////////
           if (!did.null()) { // unpack and store...
               colls.qie11->addDataFrame(did, head_pos);
+              // fill the additional qie11 collections
+              if( colls.qie11Addtl.find( ns ) != colls.qie11Addtl.end() ) {
+                  colls.qie11Addtl[ns]->addDataFrame( did, head_pos );
+              }
           } else {
               report.countUnmappedDigi(eid);
               if (unknownIds_.find(eid)==unknownIds_.end()) {
@@ -681,12 +696,14 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 	  ns++; 
 	}
 
+        bool isZDC = (did.det()==DetId::Calo && did.subdetId()==HcalZDCDetId::SubdetectorId);
+
 	// Check QEI10 container exists
 	if (colls.qie10ZDC == nullptr) {
 	  colls.qie10ZDC = new QIE10DigiCollection(ns);
 	}
-	else if (colls.qie10ZDC->samples() != ns) {
-	  // This is horrible
+	else if (colls.qie10ZDC->samples() != ns && isZDC ) {
+	  // This should only print if we have this conflict within ZDC type data
 	  edm::LogError("Invalid Data") << "QIE10ZDC Collection has " << colls.qie10ZDC->samples() << " samples per digi, raw data has " << ns << "!";
 	  return;
 	}
@@ -695,18 +712,33 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 	  colls.qie10 = new QIE10DigiCollection(ns);
 	}
 	else if (colls.qie10->samples() != ns) {
-	  // This is horrible
-	  edm::LogError("Invalid Data") << "QIE10 Collection has " << colls.qie10->samples() << " samples per digi, raw data has " << ns << "!";
-	  return;
+          // if this sample type hasn't been requested to be saved
+          // warn the user to provide a configuration that prompts it to be saved
+          if( colls.qie10Addtl.find( ns ) == colls.qie10Addtl.end() ) {
+	    edm::LogError("Invalid Data") << "The default QIE10 Collection has " 
+                << colls.qie10->samples() << " samples per digi, while the current data has " 
+                << ns << "!  This data cannot be included with the default collection.\n"
+                << "In order to store this data in the event, it must have a unique tag.  "
+                << "To accomplish this, provide two lists to HcalRawToDigi \n"
+                << "1) that specifies the number of samples and "
+                << "2) that gives tags with which these data are saved.\n"
+                << "For example in this case you might add \n"
+                << "hcaldigis.saveQIE10DataNSamples = cms.untracked.vint32( " 
+                << ns << ") \nhcaldigis.saveQIE10DataTags = cms.untracked.vstring( \"MYDATA\" )" << std::endl;
+          }
 	}
 
 	// Insert data
     /////////////////////////////////////////////CODE FROM OLD STYLE DIGIS///////////////////////////////////////////////////////////////
-	if (!did.null() && did.det()==DetId::Calo && did.subdetId()==HcalZDCDetId::SubdetectorId) { // unpack and store...
-		colls.qie10ZDC->addDataFrame(did, head_pos);
+	if (!did.null() && isZDC ) { // unpack and store...
+          colls.qie10ZDC->addDataFrame(did, head_pos);
 	} 
 	else if (!did.null()) { // unpack and store...
-		colls.qie10->addDataFrame(did, head_pos);
+          colls.qie10->addDataFrame(did, head_pos);
+          // fill the additional qie10 collections
+          if( colls.qie10Addtl.find( ns ) != colls.qie10Addtl.end() ) {
+            colls.qie10Addtl[ns]->addDataFrame( did, head_pos );
+          }
 	} else {
 		report.countUnmappedDigi(eid);
 		if (unknownIds_.find(eid)==unknownIds_.end()) {

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -105,6 +105,7 @@ namespace HcalUnpacker_impl {
 	  digi.setSample(ntaken,sample);
 	  ++ntaken;
 	}
+
 	ncurr++;
       }
       digi.setSize(ntaken);
@@ -647,27 +648,18 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
             // if this sample type hasn't been requested to be saved
             // warn the user to provide a configuration that prompts it to be saved
             if( colls.qie11Addtl.find( ns ) == colls.qie11Addtl.end() ) {
-	      edm::LogError("Invalid Data") << "The default QIE11 Collection has " 
-                  << colls.qie10->samples() << " samples per digi, while the current data has " 
-                  << ns << "!  This data cannot be included with the default collection.\n"
-                  << "In order to store this data in the event, it must have a unique tag.  "
-                  << "To accomplish this, provide two lists to HcalRawToDigi \n"
-                  << "1) that specifies the number of samples and "
-                  << "2) that gives tags with which these data are saved.\n"
-                  << "For example in this case you might add \n"
-                  << "hcaldigis.saveQIE11DataNSamples = cms.untracked.vint32( " 
-                  << ns << ") \nhcaldigis.saveQIE11DataTags = cms.untracked.vstring( \"MYDATA\" )" << std::endl;
+              printInvalidDataMessage( "QIE11", colls.qie11->samples(), ns );
             }
           }
 
           // Insert data
           /////////////////////////////////////////////CODE FROM OLD STYLE DIGIS///////////////////////////////////////////////////////////////
           if (!did.null()) { // unpack and store...
-              colls.qie11->addDataFrame(did, head_pos);
-              // fill the additional qie11 collections
-              if( colls.qie11Addtl.find( ns ) != colls.qie11Addtl.end() ) {
-                  colls.qie11Addtl[ns]->addDataFrame( did, head_pos );
-              }
+            colls.qie11->addDataFrame(did, head_pos);
+            // fill the additional qie11 collections
+            if( colls.qie11Addtl.find( ns ) != colls.qie11Addtl.end() ) {
+              colls.qie11Addtl[ns]->addDataFrame( did, head_pos );
+            }
           } else {
               report.countUnmappedDigi(eid);
               if (unknownIds_.find(eid)==unknownIds_.end()) {
@@ -715,16 +707,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
           // if this sample type hasn't been requested to be saved
           // warn the user to provide a configuration that prompts it to be saved
           if( colls.qie10Addtl.find( ns ) == colls.qie10Addtl.end() ) {
-	    edm::LogError("Invalid Data") << "The default QIE10 Collection has " 
-                << colls.qie10->samples() << " samples per digi, while the current data has " 
-                << ns << "!  This data cannot be included with the default collection.\n"
-                << "In order to store this data in the event, it must have a unique tag.  "
-                << "To accomplish this, provide two lists to HcalRawToDigi \n"
-                << "1) that specifies the number of samples and "
-                << "2) that gives tags with which these data are saved.\n"
-                << "For example in this case you might add \n"
-                << "hcaldigis.saveQIE10DataNSamples = cms.untracked.vint32( " 
-                << ns << ") \nhcaldigis.saveQIE10DataTags = cms.untracked.vstring( \"MYDATA\" )" << std::endl;
+            printInvalidDataMessage( "QIE10", colls.qie11->samples(), ns );
           }
 	}
 
@@ -935,3 +918,18 @@ void HcalUnpacker::unpackUMNio(const FEDRawData& raw, int slot, Collections& col
   *(colls.umnio) = HcalUMNioDigi(data, nwords);
   
 }
+
+void HcalUnpacker::printInvalidDataMessage( const std::string &coll_type, int default_ns, int conflict_ns ) {
+
+  edm::LogError("Invalid Data") << "The default " << coll_type << " Collection has " 
+        << conflict_ns << " samples per digi, while the current data has " 
+        << default_ns << "!  This data cannot be included with the default collection.\n"
+        << "In order to store this data in the event, it must have a unique tag.  "
+        << "To accomplish this, provide two lists to HcalRawToDigi \n"
+        << "1) that specifies the number of samples and "
+        << "2) that gives tags with which these data are saved.\n"
+        << "For example in this case you might add \n"
+        << "process.hcalDigis.saveQIE11DataNSamples = cms.untracked.vint32( " 
+        << conflict_ns << ") \nprocess.hcalDigis.saveQIE11DataTags = cms.untracked.vstring( \"MYDATA\" )" << std::endl;
+}
+

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -648,7 +648,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
             // if this sample type hasn't been requested to be saved
             // warn the user to provide a configuration that prompts it to be saved
             if( colls.qie11Addtl.find( ns ) == colls.qie11Addtl.end() ) {
-              printInvalidDataMessage( "QIE11", colls.qie11->samples(), ns );
+              printInvalidDataMessage( "QIE11", colls.qie11->samples(), ns, true );
             }
           }
 
@@ -695,25 +695,24 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
           if( colls.qie10ZDC == nullptr ) {
             colls.qie10ZDC = new QIE10DigiCollection(ns);
           } else if (colls.qie10ZDC->samples() != ns) {
-            printInvalidDataMessage( "QIE10ZDC", colls.qie10ZDC->samples(), ns );
+            printInvalidDataMessage( "QIE10ZDC", colls.qie10ZDC->samples(), ns, false );
           }
 	}
         else if( isLasmon ) {
           if (colls.qie10Lasermon == nullptr ) {
             colls.qie10Lasermon = new QIE10DigiCollection(ns);
           } else if (colls.qie10Lasermon->samples() != ns) {
-            printInvalidDataMessage( "QIE10LASMON", colls.qie10Lasermon->samples(), ns );
+            printInvalidDataMessage( "QIE10LASMON", colls.qie10Lasermon->samples(), ns, false );
           }
         } else { // these are the default qie10 channels
           if (colls.qie10 == nullptr) { 
-              std::cout << "Create qie10 collection with " << ns << " samples" << std::endl;
 	    colls.qie10 = new QIE10DigiCollection(ns);
           }
           else if (colls.qie10->samples() != ns) {
             // if this sample type hasn't been requested to be saved
             // warn the user to provide a configuration that prompts it to be saved
             if( colls.qie10Addtl.find( ns ) == colls.qie10Addtl.end() ) {
-              printInvalidDataMessage( "QIE10", colls.qie10->samples(), ns );
+              printInvalidDataMessage( "QIE10", colls.qie10->samples(), ns, true );
             }
           }
         }
@@ -930,17 +929,24 @@ void HcalUnpacker::unpackUMNio(const FEDRawData& raw, int slot, Collections& col
   
 }
 
-void HcalUnpacker::printInvalidDataMessage( const std::string &coll_type, int default_ns, int conflict_ns ) {
+void HcalUnpacker::printInvalidDataMessage( const std::string &coll_type, int default_ns, int conflict_ns, bool extended ) {
 
-  edm::LogError("Invalid Data") << "The default " << coll_type << " Collection has " 
+  std::stringstream message;
+
+  message << "The default " << coll_type << " Collection has " 
         << default_ns << " samples per digi, while the current data has " 
-        << conflict_ns << "!  This data cannot be included with the default collection.\n"
-        << "In order to store this data in the event, it must have a unique tag.  "
-        << "To accomplish this, provide two lists to HcalRawToDigi \n"
-        << "1) that specifies the number of samples and "
-        << "2) that gives tags with which these data are saved.\n"
-        << "For example in this case you might add \n"
-        << "process.hcalDigis.save" << coll_type << "DataNSamples = cms.untracked.vint32( " 
-        << conflict_ns << ") \nprocess.hcalDigis.save" << coll_type << "DataTags = cms.untracked.vstring( \"MYDATA\" )" << std::endl;
+        << conflict_ns << "!  This data cannot be included with the default collection.";
+
+  if( extended ) {
+      message << "\nIn order to store this data in the event, it must have a unique tag.  "
+              << "To accomplish this, provide two lists to HcalRawToDigi \n"
+              << "1) that specifies the number of samples and "
+              << "2) that gives tags with which these data are saved.\n"
+              << "For example in this case you might add \n"
+              << "process.hcalDigis.save" << coll_type << "DataNSamples = cms.untracked.vint32( " 
+              << conflict_ns << ") \nprocess.hcalDigis.save" << coll_type << "DataTags = cms.untracked.vstring( \"MYDATA\" )" ;
+  }
+
+  edm::LogError("Invalid Data") << message.str() << std::endl;
 }
 

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -655,7 +655,10 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
           // Insert data
           /////////////////////////////////////////////CODE FROM OLD STYLE DIGIS///////////////////////////////////////////////////////////////
           if (!did.null()) { // unpack and store...
-            colls.qie11->addDataFrame(did, head_pos);
+            // only fill the default collection if we have the correct number of samples
+            if (colls.qie11->samples() == ns) {
+              colls.qie11->addDataFrame(did, head_pos);
+            }
             // fill the additional qie11 collections
             if( colls.qie11Addtl.find( ns ) != colls.qie11Addtl.end() ) {
               colls.qie11Addtl[ns]->addDataFrame( did, head_pos );
@@ -725,8 +728,12 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
           else if( isLasmon) colls.qie10Lasermon->addDataFrame( did, head_pos );
           else {
 
-            colls.qie10->addDataFrame(did, head_pos);
+            // only fill the default collection if we have the correct number of samples
+            if (colls.qie10->samples() == ns) {
+              colls.qie10->addDataFrame(did, head_pos);
+            }
               
+            // fill the additional qie10 collections
             if( colls.qie10Addtl.find( ns ) != colls.qie10Addtl.end() ) {
               colls.qie10Addtl[ns]->addDataFrame( did, head_pos );
             }

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -405,7 +405,7 @@ void HcalUnpacker::unpackVME(const FEDRawData& raw, const HcalElectronicsMap& em
 	  ncurr=0;
 	  valid=true;
 	}      
-	// add the word (if within settings or recent firmware [recent firmware Suppressing startSample/endSample])
+	// add the word (if within settings or recent firmware [recent firmware ignores startSample/endSample])
 	if (valid && ((tpgSOIbitInUse && ncurr<10) || (ncurr>=startSample_ && ncurr<=endSample_))) {
 	  colls.tpCont->back().setSample(colls.tpCont->back().size(),*tp_work);
 	  colls.tpCont->back().setSize(colls.tpCont->back().size()+1);

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -405,7 +405,7 @@ void HcalUnpacker::unpackVME(const FEDRawData& raw, const HcalElectronicsMap& em
 	  ncurr=0;
 	  valid=true;
 	}      
-	// add the word (if within settings or recent firmware [recent firmware ignores startSample/endSample])
+	// add the word (if within settings or recent firmware [recent firmware Suppressing startSample/endSample])
 	if (valid && ((tpgSOIbitInUse && ncurr<10) || (ncurr>=startSample_ && ncurr<=endSample_))) {
 	  colls.tpCont->back().setSample(colls.tpCont->back().size(),*tp_work);
 	  colls.tpCont->back().setSize(colls.tpCont->back().size()+1);
@@ -597,8 +597,6 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
     // ok, now we're work-able
     int slot=amc13->AMCSlot(iamc);
     int crate=amc13->AMCId(iamc)&0xFF;
-    // this is used only for the 1.6 Gbps link data
-    int nps=(amc13->AMCId(iamc)>>12)&0xF;
     
     HcalUHTRData uhtr(amc13->AMCPayload(iamc),amc13->AMCSize(iamc));
     //Check to make sure uMNio is not unpacked here
@@ -614,7 +612,8 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 #endif
 
     //use uhtr presamples since amc header not properly packed in simulation
-    nps = uhtr.presamples();
+    int nps = uhtr.presamples();
+
     HcalUHTRData::const_iterator i=uhtr.begin(), iend=uhtr.end();
     while (i!=iend) {
 #ifdef DebugLog
@@ -940,10 +939,10 @@ void HcalUnpacker::printInvalidDataMessage( const std::string &coll_type, int de
 
   nPrinted_++;
 
-  int limit = 50;
+  int limit = 20;
   if( nPrinted_ >= limit ) {
 
-      if( nPrinted_ == limit ) edm::LogError("Invalid Data") << "Suppresing further error messages" << std::endl;
+      if( nPrinted_ == limit ) edm::LogWarning("Invalid Data") << "Suppressing further error messages" << std::endl;
       
       return;
   }
@@ -964,6 +963,6 @@ void HcalUnpacker::printInvalidDataMessage( const std::string &coll_type, int de
               << conflict_ns << ") \nprocess.hcalDigis.save" << coll_type << "DataTags = cms.untracked.vstring( \"MYDATA\" )" ;
   }
 
-  edm::LogError("Invalid Data") << message.str() << std::endl;
+  edm::LogWarning("Invalid Data") << message.str() << std::endl;
 }
 

--- a/RecoMET/METProducers/interface/HcalNoiseInfoProducer.h
+++ b/RecoMET/METProducers/interface/HcalNoiseInfoProducer.h
@@ -107,6 +107,7 @@ namespace reco {
 
     edm::EDGetTokenT<HBHEDigiCollection> hbhedigi_token_;
     edm::EDGetTokenT<HcalCalibDigiCollection> hcalcalibdigi_token_;
+    edm::EDGetTokenT<QIE10DigiCollection> lasermondigi_token_;
     edm::EDGetTokenT<HBHERecHitCollection> hbherechit_token_;
     edm::EDGetTokenT<CaloTowerCollection> calotower_token_;
     edm::EDGetTokenT<reco::TrackCollection> track_token_;

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -668,30 +668,27 @@ HcalNoiseInfoProducer::filldigis(edm::Event& iEvent, const edm::EventSetup& iSet
       int ieta    = calibId.ieta();
 
       // only check channels having the requested cboxch
-      if (std::find( laserMonCBoxList_.begin(), laserMonCBoxList_.end(),
-                     cboxch ) != laserMonCBoxList_.end() ) {
-        // find the index of this channel by matching cBox, iEta, iPhi
-        for( unsigned idx = 0; idx < laserMonCBoxList_.size(); ++idx ) {
-          if( cboxch == laserMonCBoxList_[idx] &&
-            iphi  == laserMonIPhiList_[idx] && 
-            ieta  == laserMonIEtaList_[idx] ) {
+      // find the index of this channel by matching cBox, iEta, iPhi
+      for( unsigned idx = 0; idx < laserMonCBoxList_.size(); ++idx ) {
+        if( cboxch == laserMonCBoxList_[idx] &&
+          iphi  == laserMonIPhiList_[idx] && 
+          ieta  == laserMonIEtaList_[idx] ) {
 
-            // now get the digis
-            unsigned ts_size = df.samples();
-            if( ts_size > max_nsamples ) max_nsamples = ts_size;
-            for(unsigned i = 0; i < ts_size; i++) {
-              bool ok = df[i].ok();
-              if( !ok ) { // protection against QIE reset
-                lasmon_adcs[idx].push_back( -1 );
-                lasmon_capids[idx].push_back( -1 );
-              } else {
-                lasmon_adcs[idx].push_back( df[i].adc() );
-                lasmon_capids[idx].push_back( df[i].capid() );
-              }
-            } // end digi loop
-          } // end matching channel if
-        } // end fiber order loop
-      } // end cboxch check
+          // now get the digis
+          unsigned ts_size = df.samples();
+          if( ts_size > max_nsamples ) max_nsamples = ts_size;
+          for(unsigned i = 0; i < ts_size; i++) {
+            bool ok = df[i].ok();
+            if( !ok ) { // protection against QIE reset
+              lasmon_adcs[idx].push_back( -1 );
+              lasmon_capids[idx].push_back( -1 );
+            } else {
+              lasmon_adcs[idx].push_back( df[i].adc() );
+              lasmon_capids[idx].push_back( df[i].capid() );
+            }
+          } // end digi loop
+        } // end matching channel if
+      } // end fiber order loop
     } // end loop over digis
 
     // now match the laser monitor data by fiber (in time) 

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -137,6 +137,7 @@ HcalNoiseInfoProducer::HcalNoiseInfoProducer(const edm::ParameterSet& iConfig) :
 
   hbhedigi_token_      = consumes<HBHEDigiCollection>(edm::InputTag(digiCollName_));
   hcalcalibdigi_token_ = consumes<HcalCalibDigiCollection>(edm::InputTag("hcalDigis"));
+  lasermondigi_token_  = consumes<QIE10DigiCollection>(iConfig.getParameter<edm::InputTag>("lasermonDigis"));
   hbherechit_token_    = consumes<HBHERecHitCollection>(edm::InputTag(recHitCollName_));
   calotower_token_     = consumes<CaloTowerCollection>(edm::InputTag(caloTowerCollName_));
   track_token_         = consumes<reco::TrackCollection>(edm::InputTag(trackCollName_));
@@ -249,11 +250,11 @@ void HcalNoiseInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   // define the channels used for laser monitoring
   // note that the order here indicates the time order
   // of the channels
-  desc.add<std::vector<int>>("laserMonCBoxList", {6,6,6,6,6,6,6,6,})->
+  desc.add<std::vector<int>>("laserMonCBoxList", {5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,})->
       setComment("time ordered list of the cBox values of laser monitor channels");
-  desc.add<std::vector<int>>("laserMonIPhiList", {23,17,11,5,29,35,41,47,})->
+  desc.add<std::vector<int>>("laserMonIPhiList", {23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0})->
       setComment("time ordered list of the iPhi values of laser monitor channels");
-  desc.add<std::vector<int>>("laserMonIEtaList", {0,0,0,0,0,0,0,0,})->
+  desc.add<std::vector<int>>("laserMonIEtaList", {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,})->
       setComment("time ordered list of the iEta values of laser monitor channels");
 
   // boundaries for total charge integration
@@ -291,6 +292,7 @@ void HcalNoiseInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<std::string>("caloTowerCollName", "towerMaker");
   desc.add<std::string>("trackCollName", "generalTracks");
   desc.add<std::string>("jetCollName", "ak4PFJets");
+  desc.add<edm::InputTag>("lasermonDigis", edm::InputTag( "hcalDigis", "LASERMON"));
 
   // severity level
   desc.add<unsigned int>("HcalAcceptSeverityLevel", 9);
@@ -590,44 +592,19 @@ HcalNoiseInfoProducer::filldigis(edm::Event& iEvent, const edm::EventSetup& iSet
   //  iEvent.getByLabel("hcalDigis", hCalib);
   iEvent.getByToken(hcalcalibdigi_token_, hCalib);
 
+
+  // get the lasermon digis
+  edm::Handle<QIE10DigiCollection> hLasermon;
+  iEvent.getByToken(lasermondigi_token_, hLasermon);
+
   // get total charge in calibration channels
   if(hCalib.isValid() == true)
   {
-
-
-     std::vector<std::vector<int> > lasmon_adcs(laserMonCBoxList_.size(), std::vector<int>());
-     std::vector<std::vector<int> > lasmon_capids(laserMonCBoxList_.size(), std::vector<int>());
 
      for(HcalCalibDigiCollection::const_iterator digi = hCalib->begin(); digi != hCalib->end(); digi++)
      {
         if(digi->id().hcalSubdet() == 0)
            continue;
-
-        // Fill the lasermonitor channels
-        if( fillLaserMonitor_ ) {
-          int cboxch  = digi->id().cboxChannel( );
-          int iphi    = digi->id().iphi();
-          int ieta    = digi->id().ieta();
-         
-          // only check channels having the requested cboxch
-          if (std::find( laserMonCBoxList_.begin(), laserMonCBoxList_.end(),
-                         cboxch ) != laserMonCBoxList_.end() ) {
-            // find the index of this channel by matching cBox, iEta, iPhi
-            for( unsigned idx = 0; idx < laserMonCBoxList_.size(); ++idx ) {
-              if( cboxch == laserMonCBoxList_[idx] &&
-                iphi  == laserMonIPhiList_[idx] && 
-                ieta  == laserMonIEtaList_[idx] ) {
-
-                // now get the digis
-                unsigned ts_size = digi->size();
-                for(unsigned i = 0; i < ts_size; i++) {
-                  lasmon_adcs[idx].push_back( digi->sample(i).adc() );
-                  lasmon_capids[idx].push_back( digi->sample(i).capid() );
-                } // end digi loop
-              } // end matching channel if
-            } // end fiber order loop
-          } // end cboxch check
-        } // end filllasmon check
 
 
 	for(unsigned i = 0; i < (unsigned)digi->size(); i++)
@@ -672,137 +649,176 @@ HcalNoiseInfoProducer::filldigis(edm::Event& iEvent, const edm::EventSetup& iSet
           } // end of HBHE check
      } // loop on HcalCalibDigiCollection
 
-     // now match the laser monitor data by fiber (in time) 
-     if( fillLaserMonitor_ ) {
-       // check for any fibers without data and fill
-       // them so we dont run into problems later
-       for( unsigned idx = 0; idx < laserMonCBoxList_.size(); ++idx ) {
-           if( lasmon_adcs[idx].empty() ) {
-               lasmon_adcs[idx] = std::vector<int>(10, -1);
-           }
-           if( lasmon_capids[idx].empty() ) {
-               lasmon_capids[idx] = std::vector<int>(10, -1);
-           }
-       }
-       unsigned nFibers = laserMonIEtaList_.size();
-       // for each fiber we need to find the index at with the 
-       // data from the next fiber matches in order to stitch them together.
-       // When there is an overlap, the data from the end of the
-       // earlier fiber is removed.  There is no removal of the last fiber
-       std::vector<unsigned> matching_idx; 
-       // we assume that the list of fibers was given in time order
-       // (if this was not the case, then we just end up using 
-       // all data from all fibers )
-       for( unsigned fidx = 0; nFibers > 0 && (fidx < (nFibers - 1)); ++fidx ) {
-
-         unsigned nts = lasmon_capids[fidx].size();  // number of time slices
-
-         // start by checking just the last TS of the earlier fiber
-         // against the first TS of the later fiber
-         // on each iteration, check one additional TS
-         // moving back in time on the earlier fiber and
-         // forward in time in the later fiber
-         
-         int start_ts = nts - 1; // start_ts will be decrimented on each loop where a match is not found
-
-         // in the case that our stringent check below doesn't work 
-         // store the latest capID that has a match
-         int latest_cap_match = -1;
-
-         // loop over the number of checks to make
-         for( unsigned ncheck = 1; ncheck <= nts ; ncheck++ ) {
-           bool cap_match = true; //will be set to false if at least one check fails below
-           bool adc_match = true; //will be set to false if at least one check fails below
-
-           // loop over the channel TS, this is for the later fiber in time
-           for( unsigned lidx = 0; lidx < ncheck; lidx++) {
-             // we are looping over the TS of the later fiber in time
-             // the TS of the earlier fiber starts from the end
-             unsigned eidx = nts-ncheck+lidx;
-             // if we get an invald value, this fiber has no data
-             // the check and match will fail, so the start_ts will 
-             // be decrimented
-             if( lasmon_capids[fidx][eidx] == -1 || lasmon_capids[fidx+1][lidx] == -1 ) {
-               cap_match = false;
-               adc_match = false;
-               break;
-             }
-
-             if( lasmon_capids[fidx][eidx] != lasmon_capids[fidx+1][lidx] ) {
-               cap_match = false;
-             }
-             // check the data values as well
-             if( lasmon_adcs[fidx][eidx] != lasmon_adcs[fidx+1][lidx] ) {
-               adc_match = false;
-             }
-           }
-           if( cap_match && (start_ts > latest_cap_match) ) {
-             latest_cap_match = start_ts;
-           }
-           if( cap_match && adc_match ) {
-             // end the loop and we'll take the current start_ts
-             // as the end of the data for this fiber
-             break;
-           }
-           else {
-             // if we don't have a match, then decrement the 
-             // starting TS and check again
-             start_ts--;
-           }
-         }
-
-         // now make some sanity checks on the determined overlap index
-         if( start_ts == -1 ) {
-           // if we didn't find any match, use the capID only to compare
-           if( latest_cap_match < 0 ) {
-             //this shouldn't happen, in this case use all the data from the fiber
-             start_ts = nts;
-           }
-           else {
-             // its possible that the timing of the fibers
-             // is shifted such that they do not overlap
-             // and we just want to stitch the fibers
-             // together with no removal.
-             // In this case the capIDs will match at the
-             // N-4 spot (and the ADCs will not)
-             // if this is not the case, then we just take
-             // the value of latest match
-             if( latest_cap_match == int(nts - 4) ) {
-               start_ts = nts;
-             } else {
-               start_ts = latest_cap_match;
-             }
-           }
-         }
-
-         // now store as the matching index
-         matching_idx.push_back(start_ts);
-       }
-
-       // for the last fiber we always use all of the data
-       matching_idx.push_back(10);
-
-       // now loop over the time slices of each fiber and make the sum
-       int icombts = -1;
-       for( unsigned fidx = 0 ; fidx < nFibers; ++fidx ) {
-         for( unsigned its = 0; its < matching_idx[fidx]; ++its ) {
-           icombts++;
-
-           // apply integration limits
-           if( icombts < laserMonitorTSStart_ ) continue;
-           if( laserMonitorTSEnd_ > 0 && icombts > laserMonitorTSEnd_ ) continue;
-
-           int adc = lasmon_adcs[fidx][its];
-
-           if( adc >= 0 ) { // skip invalid data
-             float fc = adc2fCHF[adc];
-             totalLasmonCharge += fc;
-           }
-
-         } 
-       }
-     } // if( fillLaserMonitor_ )
   } // if (hCalib.isValid()==true)
+  if( fillLaserMonitor_ ) {
+    if( hLasermon.isValid()  == true ) {
+
+      std::vector<std::vector<int> > lasmon_adcs(laserMonCBoxList_.size(), std::vector<int>());
+      std::vector<std::vector<int> > lasmon_capids(laserMonCBoxList_.size(), std::vector<int>());
+
+      unsigned max_nsamples = 0;
+      for(QIE10DigiCollection::const_iterator digi = hLasermon->begin(); digi != hLasermon->end(); digi++) {
+
+        QIE10DataFrame df = static_cast<QIE10DataFrame>(*digi);
+
+        HcalCalibDetId calibId( digi->id() );
+
+        // Fill the lasermonitor channels
+        int cboxch  = calibId.cboxChannel( );
+        int iphi    = calibId.iphi();
+        int ieta    = calibId.ieta();
+
+        // only check channels having the requested cboxch
+        if (std::find( laserMonCBoxList_.begin(), laserMonCBoxList_.end(),
+                       cboxch ) != laserMonCBoxList_.end() ) {
+          // find the index of this channel by matching cBox, iEta, iPhi
+          for( unsigned idx = 0; idx < laserMonCBoxList_.size(); ++idx ) {
+            if( cboxch == laserMonCBoxList_[idx] &&
+              iphi  == laserMonIPhiList_[idx] && 
+              ieta  == laserMonIEtaList_[idx] ) {
+
+              // now get the digis
+              unsigned ts_size = df.samples();
+              if( ts_size > max_nsamples ) max_nsamples = ts_size;
+              for(unsigned i = 0; i < ts_size; i++) {
+                lasmon_adcs[idx].push_back( df[i].adc() );
+                lasmon_capids[idx].push_back( df[i].capid() );
+              } // end digi loop
+            } // end matching channel if
+          } // end fiber order loop
+        } // end cboxch check
+      } // end loop over digis
+
+      // now match the laser monitor data by fiber (in time) 
+      // check for any fibers without data and fill
+      // them so we dont run into problems later
+      for( unsigned idx = 0; idx < laserMonCBoxList_.size(); ++idx ) {
+          if( lasmon_adcs[idx].empty() ) {
+              lasmon_adcs[idx] = std::vector<int>(max_nsamples, -1);
+          }
+          if( lasmon_capids[idx].empty() ) {
+              lasmon_capids[idx] = std::vector<int>(max_nsamples, -1);
+          }
+      }
+      unsigned nFibers = laserMonIEtaList_.size();
+      // for each fiber we need to find the index at with the 
+      // data from the next fiber matches in order to stitch them together.
+      // When there is an overlap, the data from the end of the
+      // earlier fiber is removed.  There is no removal of the last fiber
+      std::vector<unsigned> matching_idx; 
+      // we assume that the list of fibers was given in time order
+      // (if this was not the case, then we just end up using 
+      // all data from all fibers )
+      for( unsigned fidx = 0; nFibers > 0 && (fidx < (nFibers - 1)); ++fidx ) {
+
+        unsigned nts = lasmon_capids[fidx].size();  // number of time slices
+
+        // start by checking just the last TS of the earlier fiber
+        // against the first TS of the later fiber
+        // on each iteration, check one additional TS
+        // moving back in time on the earlier fiber and
+        // forward in time in the later fiber
+        
+        int start_ts = nts - 1; // start_ts will be decrimented on each loop where a match is not found
+
+        // in the case that our stringent check below doesn't work 
+        // store the latest capID that has a match
+        int latest_cap_match = -1;
+
+        // loop over the number of checks to make
+        for( unsigned ncheck = 1; ncheck <= nts ; ncheck++ ) {
+          bool cap_match = true; //will be set to false if at least one check fails below
+          bool adc_match = true; //will be set to false if at least one check fails below
+
+          // loop over the channel TS, this is for the later fiber in time
+          for( unsigned lidx = 0; lidx < ncheck; lidx++) {
+            // we are looping over the TS of the later fiber in time
+            // the TS of the earlier fiber starts from the end
+            unsigned eidx = nts-ncheck+lidx;
+            // if we get an invald value, this fiber has no data
+            // the check and match will fail, so the start_ts will 
+            // be decrimented
+            if( lasmon_capids[fidx][eidx] == -1 || lasmon_capids[fidx+1][lidx] == -1 ) {
+              cap_match = false;
+              adc_match = false;
+              break;
+            }
+
+            if( lasmon_capids[fidx][eidx] != lasmon_capids[fidx+1][lidx] ) {
+              cap_match = false;
+            }
+            // check the data values as well
+            if( lasmon_adcs[fidx][eidx] != lasmon_adcs[fidx+1][lidx] ) {
+              adc_match = false;
+            }
+          }
+          if( cap_match && (start_ts > latest_cap_match) ) {
+            latest_cap_match = start_ts;
+          }
+          if( cap_match && adc_match ) {
+            // end the loop and we'll take the current start_ts
+            // as the end of the data for this fiber
+            break;
+          }
+          else {
+            // if we don't have a match, then decrement the 
+            // starting TS and check again
+            start_ts--;
+          }
+        }
+
+        // now make some sanity checks on the determined overlap index
+        if( start_ts == -1 ) {
+          // if we didn't find any match, use the capID only to compare
+          if( latest_cap_match < 0 ) {
+            //this shouldn't happen, in this case use all the data from the fiber
+            start_ts = nts;
+          }
+          else {
+            // its possible that the timing of the fibers
+            // is shifted such that they do not overlap
+            // and we just want to stitch the fibers
+            // together with no removal.
+            // In this case the capIDs will match at the
+            // N-4 spot (and the ADCs will not)
+            // if this is not the case, then we just take
+            // the value of latest match
+            if( latest_cap_match == int(nts - 4) ) {
+              start_ts = nts;
+            } else {
+              start_ts = latest_cap_match;
+            }
+          }
+        }
+
+        // now store as the matching index
+        matching_idx.push_back(start_ts);
+      }
+
+      // for the last fiber we always use all of the data
+      matching_idx.push_back(max_nsamples);
+
+      // now loop over the time slices of each fiber and make the sum
+      int icombts = -1;
+      for( unsigned fidx = 0 ; fidx < nFibers; ++fidx ) {
+        for( unsigned its = 0; its < matching_idx[fidx]; ++its ) {
+          icombts++;
+
+          // apply integration limits
+          if( icombts < laserMonitorTSStart_ ) continue;
+          if( laserMonitorTSEnd_ > 0 && icombts > laserMonitorTSEnd_ ) continue;
+
+          int adc = lasmon_adcs[fidx][its];
+
+          if( adc >= 0 ) { // skip invalid data
+            float fc = adc2fCHF[adc];
+            totalLasmonCharge += fc;
+            
+          }
+        } 
+      }
+    } // end isValid check
+  } // end filllasmon check
 
   summary.calibCharge_ = totalCalibCharge;
   summary.lasmonCharge_ = totalLasmonCharge;

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -680,8 +680,14 @@ HcalNoiseInfoProducer::filldigis(edm::Event& iEvent, const edm::EventSetup& iSet
             unsigned ts_size = df.samples();
             if( ts_size > max_nsamples ) max_nsamples = ts_size;
             for(unsigned i = 0; i < ts_size; i++) {
-              lasmon_adcs[idx].push_back( df[i].adc() );
-              lasmon_capids[idx].push_back( df[i].capid() );
+              bool ok = df[i].ok();
+              if( !ok ) { // protection against QIE reset
+                lasmon_adcs[idx].push_back( -1 );
+                lasmon_capids[idx].push_back( -1 );
+              } else {
+                lasmon_adcs[idx].push_back( df[i].adc() );
+                lasmon_capids[idx].push_back( df[i].capid() );
+              }
             } // end digi loop
           } // end matching channel if
         } // end fiber order loop


### PR DESCRIPTION
This pull request addresses three issues related to Hcal data unpacking.  (See more detailed explanations below) : 

1) Add a QIE10DigiCollection with tag "LASERMON" to keep laser monitoring data in the event
2) Improvements to the HcalUnpacker that are related to 1) 
3) Updates to RecoMET/METProducers/HcalNoiseInfoProducer to reflect the changes in 1)

Additional information to (1)
-------------------------------------
As we plan to use the lasermon channels to clean the data of any possible laser contamination, we desire to keep them in the emap so that we have a versioned accounting of them.  This requires changes to : 
- CalibFormats/HcalObjects/HcalTextToDetIdConverter, To parse the new emap entries from the .txt file
- DataFormats/HcalDetId/HcalCalibDetId, To add a unique CalibDetType
- EventFilter/HcalRawToDigi/HcalRawToDigi, to make the new collection and put it in the event
- EventFilter/HcalRawToDigi/HcalUnpacer, to unpack into the new collection

Additional information to (2)
-------------------------------------------
We often run into an issue with the HcalUnpacker where it encounters data having a different number of samples than the default collection (the number of samples is determined by the first FED of that type that is unpacked).  Currently the unpacker stops unpacking at this point and any data beyond that is not unpacked.  At this point in the code there are even comments that say "this is horrible".  The aim of this update is to avoid this situation and to provide access to this new data for private studies without making by-hand modifications to the unpacker.

This update does not change the default behavior of the unpacker except for 
1) The unpacker will no longer stop unpacking after encountering non-conforming data
2) the message that is printed in this case is modified to direct the user how to access the data

To access the data, the user can provide two lists to HcalRawToDigi, one that specifies the number of samples in the data, and a tag so the data can be stored in a unique collection.  There are two additional maps of integers (number of samples) to QIE10/11DataCollections.  The unpacker looks for these maps to be filled and unpacks accordingly.  Otherwise they follow the same processing as other QIE10/11 collections

Additional information to (3)
---------------------------------------
This just updates the code to read the lasermon channels from a QIE10DigiColleciton.  The algorithm does not change, there is just some structural reordering of the code to use the new collection

I have run the runTheMatrix tests and will soon provide instructions for testing the new features