### PR TITLE
speeding up L1TGlobalProducer

### DIFF
--- a/L1Trigger/L1TGlobal/interface/GlobalScales.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalScales.h
@@ -80,16 +80,16 @@ public:
     inline void setScalesName(const std::string & name) { m_ScaleSetName = name; }
     virtual std::string getScalesName() const;
 
-    inline ScaleParameters getMUScales() const    { return m_muScales; }
-    inline ScaleParameters getEGScales() const    { return m_egScales; }
-    inline ScaleParameters getTAUScales() const   { return m_tauScales; }
-    inline ScaleParameters getJETScales() const   { return m_jetScales; }
-    inline ScaleParameters getETTScales() const   { return m_ettScales; }
-    inline ScaleParameters getETTEmScales() const { return m_ettEmScales; }
-    inline ScaleParameters getETMScales() const   { return m_etmScales; }
-    inline ScaleParameters getETMHFScales() const { return m_etmHfScales; }
-    inline ScaleParameters getHTTScales() const   { return m_httScales; }
-    inline ScaleParameters getHTMScales() const   { return m_htmScales; }
+    inline const ScaleParameters& getMUScales() const    { return m_muScales; }
+    inline const ScaleParameters& getEGScales() const    { return m_egScales; }
+    inline const ScaleParameters& getTAUScales() const   { return m_tauScales; }
+    inline const ScaleParameters& getJETScales() const   { return m_jetScales; }
+    inline const ScaleParameters& getETTScales() const   { return m_ettScales; }
+    inline const ScaleParameters& getETTEmScales() const { return m_ettEmScales; }
+    inline const ScaleParameters& getETMScales() const   { return m_etmScales; }
+    inline const ScaleParameters& getETMHFScales() const { return m_etmHfScales; }
+    inline const ScaleParameters& getHTTScales() const   { return m_httScales; }
+    inline const ScaleParameters& getHTMScales() const   { return m_htmScales; }
 
 
     long long getLUT_CalMuEta(const std::string & lutName, int element) const;

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -370,12 +370,12 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 // Determine the number of phi bins to get cutoff at pi
     int phiBound = 0;
     if(cond0Categ == CondMuon || cond1Categ == CondMuon) {
-        GlobalScales::ScaleParameters par = m_gtScales->getMUScales();
+        const GlobalScales::ScaleParameters& par = m_gtScales->getMUScales();
         //phiBound = par.phiBins.size()/2;
 	phiBound = (int)((par.phiMax - par.phiMin)/par.phiStep)/2;
     } else {
         //Assumes all calorimeter objects are on same phi scale
-        GlobalScales::ScaleParameters par = m_gtScales->getEGScales();
+        const GlobalScales::ScaleParameters& par = m_gtScales->getEGScales();
         //phiBound = par.phiBins.size()/2;
 	phiBound = (int)((par.phiMax - par.phiMin)/par.phiStep)/2;
     }


### PR DESCRIPTION
Inside the L1TGlobalProducer objects were accidentally being returned by value not reference, leading to an unnecessary ~1.4% in HLT timing which I feel would be much better spent on other things, such as, for example, E/gamma track isolation :) 

This simple patch fixes it. As the only change is now objects which were copies are now constant references, zero output changes are expected. 

pre fix igprof:
sharper.web.cern.ch/sharper/cgi-bin/igprof-navigator/1001HLTTiming/igreport_HLT10XWithTrkIso

post fix igprof
http://sharper.web.cern.ch/sharper/cgi-bin/igprof-navigator/1001HLTTiming/igreport_HLT10XWithTrkIsoL1Fix

From timeDiffFromReport.sh
 -0.918408      -1.40%         5.55 ms/ev ->         2.06 ms/ev hltGtStage2ObjectMap

FYI: @Martin-Grunewald 