### PR TITLE
Print correct timestamp in HP beamspot txt file

### DIFF
--- a/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotManager.h
+++ b/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotManager.h
@@ -11,7 +11,6 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-//#include "DataFormats/Provenance/interface/LuminosityBlockID.h"
 #include <string>
 #include <map>
 #include <utility>
@@ -26,16 +25,16 @@ class AlcaBeamSpotManager {
   void reset(void);   
   void readLumi(const edm::LuminosityBlock&);   
   void createWeightedPayloads(void);   
-  const std::map<edm::LuminosityBlockNumber_t,reco::BeamSpot>& getPayloads(void){return beamSpotMap_;}   
+  const std::map<edm::LuminosityBlockNumber_t,std::pair<edm::Timestamp,reco::BeamSpot> >& getPayloads(void){return beamSpotMap_;}   
 
-  typedef std::map<edm::LuminosityBlockNumber_t,reco::BeamSpot>::iterator bsMap_iterator;
+  typedef std::map<edm::LuminosityBlockNumber_t,std::pair<edm::Timestamp,reco::BeamSpot> >::iterator bsMap_iterator;
  private:
   reco::BeamSpot         weight  (const bsMap_iterator& begin,
                                   const bsMap_iterator& end);
   void                   weight  (double& mean,double& meanError,const double& val,const double& valError);
   std::pair<float,float> delta   (const float& x, const float& xError, const float& nextX, const float& nextXError);
   float                  deltaSig(const float& num, const float& den);
-  std::map<edm::LuminosityBlockNumber_t,reco::BeamSpot> beamSpotMap_;
+  std::map<edm::LuminosityBlockNumber_t,std::pair<edm::Timestamp,reco::BeamSpot> > beamSpotMap_;
 
   std::string beamSpotOutputBase_;
   std::string beamSpotModuleName_;

--- a/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotHarvester.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotHarvester.cc
@@ -164,28 +164,28 @@ void AlcaBeamSpotHarvester::endRun(const edm::Run& iRun, const edm::EventSetup&)
             beamspot::dumpBeamSpotTxt(outFile, currentBS);
         }
       }
-// 
-// 
-// 
-// /*
-//       int         argc = 15;
-//       const char* argv[] = {"endRun"
-//                            ,"-d","sqlite_file:combined.db"
-//                            ,"-s","sqlite_file:testbs2.db"
-//                            ,"-l","sqlite_file:log.db"
-// 			   ,"-i","TestLSBasedBS"
-// 			   ,"-t","TestLSBasedBS"
-// 			   ,"-b","1"
-// 			   ,"-e","10"
-// 			   };
-// 
-//       edm::LogInfo("AlcaBeamSpotHarvester")
-//         << "Running utilities!"
-// 	<< utilities.run(argc,(char**)argv);
-//       edm::LogInfo("AlcaBeamSpotHarvester")
-//         << "Run utilities!"
-// 	<< std::endl;
-// */
+
+
+
+/*
+      int         argc = 15;
+      const char* argv[] = {"endRun"
+                           ,"-d","sqlite_file:combined.db"
+                           ,"-s","sqlite_file:testbs2.db"
+                           ,"-l","sqlite_file:log.db"
+			   ,"-i","TestLSBasedBS"
+			   ,"-t","TestLSBasedBS"
+			   ,"-b","1"
+			   ,"-e","10"
+			   };
+
+      edm::LogInfo("AlcaBeamSpotHarvester")
+        << "Running utilities!"
+	<< utilities.run(argc,(char**)argv);
+      edm::LogInfo("AlcaBeamSpotHarvester")
+        << "Run utilities!"
+	<< std::endl;
+*/
     }
 
   }

--- a/Calibration/TkAlCaRecoProducers/src/AlcaBeamSpotManager.cc
+++ b/Calibration/TkAlCaRecoProducers/src/AlcaBeamSpotManager.cc
@@ -50,8 +50,9 @@ void AlcaBeamSpotManager::readLumi(const LuminosityBlock& iLumi){
   iLumi.getByToken(beamSpotToken_, beamSpotHandle);
 
   if(beamSpotHandle.isValid()) { // check the product
-    beamSpotMap_[iLumi.luminosityBlock()] = *beamSpotHandle;
-    const BeamSpot* aBeamSpot =  &beamSpotMap_[iLumi.luminosityBlock()];
+    std::pair<edm::Timestamp,reco::BeamSpot> time_bs (iLumi.beginTime(), *beamSpotHandle);
+    beamSpotMap_[iLumi.luminosityBlock()] = time_bs;
+    const BeamSpot* aBeamSpot =  &beamSpotMap_[iLumi.luminosityBlock()].second;
     aBeamSpot = beamSpotHandle.product();
     LogInfo("AlcaBeamSpotManager")
       << "Lumi: " << iLumi.luminosityBlock() << std::endl;
@@ -71,7 +72,7 @@ void AlcaBeamSpotManager::readLumi(const LuminosityBlock& iLumi){
 void AlcaBeamSpotManager::createWeightedPayloads(void){
   vector<bsMap_iterator> listToErase;
   for(bsMap_iterator it=beamSpotMap_.begin(); it!=beamSpotMap_.end();it++){
-    if(it->second.type() != BeamSpot::Tracker || it->second.sigmaZ()<sigmaZCut_ ) {
+    if(it->second.second.type() != BeamSpot::Tracker || it->second.second.sigmaZ()<sigmaZCut_ ) {
       listToErase.push_back(it);
     }
   }
@@ -92,8 +93,11 @@ void AlcaBeamSpotManager::createWeightedPayloads(void){
     bsMap_iterator currentBS   = beamSpotMap_.begin();
     bsMap_iterator nextBS      = ++beamSpotMap_.begin();
     bsMap_iterator nextNextBS  = ++(++(beamSpotMap_.begin()));
+    
+    reco::BeamSpot currentBSObj;
+    reco::BeamSpot nextBSObj;
 
-    map<LuminosityBlockNumber_t,BeamSpot> tmpBeamSpotMap_;
+    map<LuminosityBlockNumber_t,std::pair<edm::Timestamp, BeamSpot>> tmpBeamSpotMap_;
     bool docreate = true;
     bool endOfRun = false;//Added
     bool docheck = true;//Added
@@ -111,12 +115,12 @@ void AlcaBeamSpotManager::createWeightedPayloads(void){
       LogInfo("AlcaBeamSpotManager")
         << "Iteration: " << iteration << " size: " << beamSpotMap_.size() << "\n"
         << "Lumi: " << currentBS->first  << "\n" 
-        << currentBS->second
-        << "\n" << nextBS->first     << "\n" << nextBS->second  
+        << currentBS->second.second
+        << "\n" << nextBS->first     << "\n" << nextBS->second.second
         << endl;  
       if (nextNextBS!=beamSpotMap_.end())
 	LogInfo("AlcaBeamSpotManager")
-	  << nextNextBS->first << "\n" << nextNextBS->second
+	  << nextNextBS->first << "\n" << nextNextBS->second.second
 	  << endl;
 
 
@@ -171,16 +175,19 @@ void AlcaBeamSpotManager::createWeightedPayloads(void){
         float min_limit = 0.0025;
         
         // limit for x and y
-        limit = currentBS->second.BeamWidthX()/2.;																										  		    
+        limit = currentBS->second.second.BeamWidthX()/2.;
         if(limit < min_limit){
 	  limit = min_limit;
         }
 	
+	currentBSObj = currentBS->second.second;
+	nextBSObj = nextBS->second.second;
+	
 	//check movements in X																														  		    
-	adelta1 = delta(currentBS->second.x0(), currentBS->second.x0Error(), nextBS->second.x0(), nextBS->second.x0Error());																	  		    
+	adelta1 = delta(currentBSObj.x0(), currentBSObj.x0Error(), nextBSObj.x0(), nextBSObj.x0Error());
         adelta2 = pair<float,float>(0.,1.e9);																													    
-        if (nextNextBS->second.type() != -1){																											  		    
-            adelta2 = delta(nextBS->second.x0(), nextBS->second.x0Error(), nextNextBS->second.x0(), nextNextBS->second.x0Error());																  		    
+        if (nextNextBS->second.second.type() != -1){
+            adelta2 = delta(nextBS->second.second.x0(), nextBSObj.x0Error(), nextNextBS->second.second.x0(), nextNextBS->second.second.x0Error());
         }																															  		    
         bool deltaX = (deltaSig(adelta1.first,adelta1.second) > 3.5 && adelta1.first >= limit)?true:false;																			  		    
         if(iteration < beamSpotMap_.size()-2){  																										  		    
@@ -197,46 +204,46 @@ void AlcaBeamSpotManager::createWeightedPayloads(void){
         }																															  
 
         //calculating all deltas																														  		    
-        adelta1dxdz = delta(currentBS->second.dxdz(), currentBS->second.dxdzError(), nextBS->second.dxdz(), nextBS->second.dxdzError());
+        adelta1dxdz = delta(currentBSObj.dxdz(), currentBSObj.dxdzError(), nextBSObj.dxdz(), nextBSObj.dxdzError());
         adelta2dxdz = pair<float,float>(0.,1.e9);
-        adelta1dydz = delta(currentBS->second.dydz(), currentBS->second.dydzError(), nextBS->second.dydz(), nextBS->second.dydzError());
+        adelta1dydz = delta(currentBSObj.dydz(), currentBSObj.dydzError(), nextBSObj.dydz(), nextBSObj.dydzError());
         adelta2dydz = pair<float,float>(0.,1.e9);
-        adelta1widthX = delta(currentBS->second.BeamWidthX(), currentBS->second.BeamWidthXError(), nextBS->second.BeamWidthX(), nextBS->second.BeamWidthXError());
+        adelta1widthX = delta(currentBSObj.BeamWidthX(), currentBSObj.BeamWidthXError(), nextBSObj.BeamWidthX(), nextBSObj.BeamWidthXError());
         adelta2widthX = pair<float,float>(0.,1.e9);
-        adelta1widthY = delta(currentBS->second.BeamWidthY(), currentBS->second.BeamWidthYError(), nextBS->second.BeamWidthY(), nextBS->second.BeamWidthYError());
+        adelta1widthY = delta(currentBSObj.BeamWidthY(), currentBSObj.BeamWidthYError(), nextBSObj.BeamWidthY(), nextBSObj.BeamWidthYError());
         adelta2widthY = pair<float,float>(0.,1.e9);
-	adelta1z0 = delta(currentBS->second.z0(), currentBS->second.z0Error(), nextBS->second.z0(), nextBS->second.z0Error());
-	adelta1sigmaZ = delta(currentBS->second.sigmaZ(), currentBS->second.sigmaZ0Error(), nextBS->second.sigmaZ(), nextBS->second.sigmaZ0Error());
+	adelta1z0 = delta(currentBSObj.z0(), currentBSObj.z0Error(), nextBSObj.z0(), nextBSObj.z0Error());
+	adelta1sigmaZ = delta(currentBSObj.sigmaZ(), currentBSObj.sigmaZ0Error(), nextBSObj.sigmaZ(), nextBSObj.sigmaZ0Error());
 	
-	//check movements in Y																														  		    
-        adelta1 = delta(currentBS->second.y0(), currentBS->second.y0Error(), nextBS->second.y0(), nextBS->second.y0Error());																			    
-        adelta2 = pair<float,float>(0.,1.e9);																													    
-        if( nextNextBS->second.type() != BeamSpot::Unknown){																										  	    
-          adelta2 = delta(nextBS->second.y0(), nextBS->second.y0Error(), nextNextBS->second.y0(), nextNextBS->second.y0Error());																  		    
-          adelta2dxdz = delta(nextBS->second.dxdz(), nextBS->second.dxdzError(), nextNextBS->second.dxdz(), nextNextBS->second.dxdzError());
-          adelta2dydz = delta(nextBS->second.dydz(), nextBS->second.dydzError(), nextNextBS->second.dydz(), nextNextBS->second.dydzError());
-          adelta2widthX = delta(nextBS->second.BeamWidthX(), nextBS->second.BeamWidthXError(), nextNextBS->second.BeamWidthX(), nextNextBS->second.BeamWidthXError());
-          adelta2widthY = delta(nextBS->second.BeamWidthY(), nextBS->second.BeamWidthYError(), nextNextBS->second.BeamWidthY(), nextNextBS->second.BeamWidthYError());
+	//check movements in Y
+        adelta1 = delta(currentBSObj.y0(), currentBSObj.y0Error(), nextBSObj.y0(), nextBSObj.y0Error());
+        adelta2 = pair<float,float>(0.,1.e9);
+        if( nextNextBS->second.second.type() != BeamSpot::Unknown){
+          adelta2 = delta(nextBSObj.y0(), nextBSObj.y0Error(), nextNextBS->second.second.y0(), nextNextBS->second.second.y0Error());
+          adelta2dxdz = delta(nextBSObj.dxdz(), nextBSObj.dxdzError(), nextNextBS->second.second.dxdz(), nextNextBS->second.second.dxdzError());
+          adelta2dydz = delta(nextBSObj.dydz(), nextBSObj.dydzError(), nextNextBS->second.second.dydz(), nextNextBS->second.second.dydzError());
+          adelta2widthX = delta(nextBSObj.BeamWidthX(), nextBSObj.BeamWidthXError(), nextNextBS->second.second.BeamWidthX(), nextNextBS->second.second.BeamWidthXError());
+          adelta2widthY = delta(nextBSObj.BeamWidthY(), nextBSObj.BeamWidthYError(), nextNextBS->second.second.BeamWidthY(), nextNextBS->second.second.BeamWidthYError());
 
-        }																															  		    
-        bool deltaY = (deltaSig(adelta1.first,adelta1.second) > 3.5 && adelta1.first >= limit)?true:false;																			  		    
-        if(iteration < beamSpotMap_.size()-2){  																										  		    
-          if( !deltaY && adelta1.first*adelta2.first > 0. &&  fabs(adelta1.first+adelta2.first) >= limit){																					  
-            LogInfo("AlcaBeamSpotManager")																													  
-              << " positive, " << (adelta1.first+adelta2.first) << " limit=" << limit << endl;  																						  
-              deltaY = true;																															  
+        }
+        bool deltaY = (deltaSig(adelta1.first,adelta1.second) > 3.5 && adelta1.first >= limit)?true:false;
+        if(iteration < beamSpotMap_.size()-2){
+          if( !deltaY && adelta1.first*adelta2.first > 0. &&  fabs(adelta1.first+adelta2.first) >= limit){
+            LogInfo("AlcaBeamSpotManager")
+              << " positive, " << (adelta1.first+adelta2.first) << " limit=" << limit << endl; 
+              deltaY = true;
           }
-          else if( deltaY && adelta1.first*adelta2.first < 0 && adelta2.first != 0 && fabs(adelta1.first/adelta2.first) > 0.33 && fabs(adelta1.first/adelta2.first) < 3){																  
-            LogInfo("AlcaBeamSpotManager")																													  
-              << " negative, " << adelta1.first/adelta2.first << endl;  																									  
-              deltaY = false;																															  
+          else if( deltaY && adelta1.first*adelta2.first < 0 && adelta2.first != 0 && fabs(adelta1.first/adelta2.first) > 0.33 && fabs(adelta1.first/adelta2.first) < 3){  
+            LogInfo("AlcaBeamSpotManager")  
+              << " negative, " << adelta1.first/adelta2.first << endl;    
+              deltaY = false;	  
           }
 	}
 
-	limit = currentBS->second.sigmaZ()/2.;														    														
-	bool deltaZ = (deltaSig(adelta1z0.first,adelta1z0.second) > 3.5 && fabs(adelta1z0.first) >= limit)?true:false;						      
-	adelta = delta(currentBS->second.sigmaZ(), currentBS->second.sigmaZ0Error(), nextBS->second.sigmaZ(), nextBS->second.sigmaZ0Error()); 		    														
-	bool deltasigmaZ = (deltaSig(adelta.first,adelta.second) > 5.0)?true:false;										    														
+	limit = currentBSObj.sigmaZ()/2.;    
+	bool deltaZ = (deltaSig(adelta1z0.first,adelta1z0.second) > 3.5 && fabs(adelta1z0.first) >= limit)?true:false;      
+	adelta = delta(currentBSObj.sigmaZ(), currentBSObj.sigmaZ0Error(), nextBSObj.sigmaZ(), nextBSObj.sigmaZ0Error());     
+	bool deltasigmaZ = (deltaSig(adelta.first,adelta.second) > 5.0)?true:false;    
 	bool deltadxdz = false;
         bool deltadydz = false;
         bool deltawidthX = false;
@@ -244,26 +251,26 @@ void AlcaBeamSpotManager::createWeightedPayloads(void){
 
 	if(iteration < beamSpotMap_.size()-2){                                                                                                                                                              
 
-          adelta = delta(currentBS->second.dxdz(), currentBS->second.dxdzError(), nextBS->second.dxdz(), nextBS->second.dxdzError());				    														      
-          deltadxdz   = (deltaSig(adelta.first,adelta.second) > 5.0)?true:false;										    														
+          adelta = delta(currentBSObj.dxdz(), currentBSObj.dxdzError(), nextBSObj.dxdz(), nextBSObj.dxdzError());
+          deltadxdz   = (deltaSig(adelta.first,adelta.second) > 5.0)?true:false;
           if(deltadxdz && (adelta1dxdz.first*adelta2dxdz.first) < 0 && adelta2dxdz.first != 0 && fabs(adelta1dxdz.first/adelta2dxdz.first) > 0.33 && fabs(adelta1dxdz.first/adelta2dxdz.first) < 3){
             deltadxdz = false;
 	  }
 
-          adelta = delta(currentBS->second.dydz(), currentBS->second.dydzError(), nextBS->second.dydz(), nextBS->second.dydzError());				    														      
-          deltadydz   = (deltaSig(adelta.first,adelta.second) > 5.0)?true:false;										    														
+          adelta = delta(currentBSObj.dydz(), currentBSObj.dydzError(), nextBSObj.dydz(), nextBSObj.dydzError());
+          deltadydz   = (deltaSig(adelta.first,adelta.second) > 5.0)?true:false;
           if(deltadydz && (adelta1dydz.first*adelta2dydz.first) < 0 && adelta2dydz.first != 0 && fabs(adelta1dydz.first/adelta2dydz.first) > 0.33 && fabs(adelta1dydz.first/adelta2dydz.first) < 3){
             deltadydz = false;
 	  }
 
-          adelta = delta(currentBS->second.BeamWidthX(), currentBS->second.BeamWidthXError(), nextBS->second.BeamWidthX(), nextBS->second.BeamWidthXError());	    														
-          deltawidthX = (deltaSig(adelta.first,adelta.second) > 5.0)?true:false;										    														
+          adelta = delta(currentBSObj.BeamWidthX(), currentBSObj.BeamWidthXError(), nextBSObj.BeamWidthX(), nextBSObj.BeamWidthXError());
+          deltawidthX = (deltaSig(adelta.first,adelta.second) > 5.0)?true:false;
           if(deltawidthX && (adelta1widthX.first*adelta2widthX.first) < 0 && adelta2widthX.first != 0 && fabs(adelta1widthX.first/adelta2widthX.first) > 0.33 && fabs(adelta1widthX.first/adelta2widthX.first) < 3){
             deltawidthX = false;
 	  }
 
-          adelta = delta(currentBS->second.BeamWidthY(), currentBS->second.BeamWidthYError(), nextBS->second.BeamWidthY(), nextBS->second.BeamWidthYError());	    														
-          deltawidthY = (deltaSig(adelta.first,adelta.second) > 5.0)?true:false;										    														
+          adelta = delta(currentBSObj.BeamWidthY(), currentBSObj.BeamWidthYError(), nextBSObj.BeamWidthY(), nextBSObj.BeamWidthYError());
+          deltawidthY = (deltaSig(adelta.first,adelta.second) > 5.0)?true:false;
           if(deltawidthY && (adelta1widthY.first*adelta2widthY.first) < 0 && adelta2widthY.first != 0 && fabs(adelta1widthY.first/adelta2widthY.first) > 0.33 && fabs(adelta1widthY.first/adelta2widthY.first) < 3){
             deltawidthY = false;
 	  }
@@ -287,19 +294,24 @@ void AlcaBeamSpotManager::createWeightedPayloads(void){
 
       }
       if(docreate){
+        std::pair<edm::Timestamp,reco::BeamSpot> thepair;
 	if(foundShift){
-	  tmpBeamSpotMap_[firstBS->first] = weight(firstBS,nextBS);
+	  thepair = std::make_pair( currentBS->second.first, weight(firstBS,nextBS));
+	  tmpBeamSpotMap_[firstBS->first] = thepair;
 	  if (endOfRun){ 
 	    //if we're here, then we need to found a shift in the last LS
 	    //We already created a new IOV, now create one just for the last LS
-	    tmpBeamSpotMap_[nextBS->first] = nextBS->second;
+  	    thepair = std::make_pair( nextBS->second.first, nextBSObj);
+      	    tmpBeamSpotMap_[nextBS->first] = thepair;
 	  }
 	}
 	else if(!foundShift && !endOfRun){ //maxLS reached
-          tmpBeamSpotMap_[firstBS->first] = weight(firstBS,nextBS);
+          thepair = std::make_pair( currentBS->second.first, weight(firstBS,nextBS));
+          tmpBeamSpotMap_[firstBS->first] = thepair;
 	}
 	else { // end of run with no shift detectred in last LS
-	  tmpBeamSpotMap_[firstBS->first] = weight(firstBS,beamSpotMap_.end());
+          thepair = std::make_pair( currentBS->second.first, weight(firstBS,beamSpotMap_.end()));
+          tmpBeamSpotMap_[firstBS->first] = thepair;
 	}
 	firstBS = nextBS;
           countlumi = 0;
@@ -318,10 +330,10 @@ void AlcaBeamSpotManager::createWeightedPayloads(void){
     beamSpotMap_ = tmpBeamSpotMap_;
   }
   else if(beamSpotOutputBase_ == "runbased"){
-    BeamSpot aBeamSpot = weight(beamSpotMap_.begin(),beamSpotMap_.end());
     LuminosityBlockNumber_t firstLumi = beamSpotMap_.begin()->first;
+    std::pair<edm::Timestamp,reco::BeamSpot> thepair (beamSpotMap_.begin()->second.first, weight(beamSpotMap_.begin(),beamSpotMap_.end()));
     beamSpotMap_.clear();
-    beamSpotMap_[firstLumi] = aBeamSpot;
+    beamSpotMap_[firstLumi] = thepair;
   }
   else{
     LogInfo("AlcaBeamSpotManager")
@@ -348,15 +360,15 @@ BeamSpot AlcaBeamSpotManager::weight(const bsMap_iterator& begin,
 
   BeamSpot::BeamType type = BeamSpot::Unknown;
   for(bsMap_iterator it=begin; it!=end; it++){
-    weight(x     , xError     , it->second.x0()        , it->second.x0Error());
-    weight(y     , yError     , it->second.y0()        , it->second.y0Error());
-    weight(z     , zError     , it->second.z0()        , it->second.z0Error());
-    weight(sigmaZ, sigmaZError, it->second.sigmaZ()    , it->second.sigmaZ0Error());
-    weight(dxdz  , dxdzError  , it->second.dxdz()      , it->second.dxdzError());
-    weight(dydz  , dydzError  , it->second.dydz()      , it->second.dydzError());
-    weight(widthX, widthXError, it->second.BeamWidthX(), it->second.BeamWidthXError());
-    weight(widthY, widthYError, it->second.BeamWidthY(), it->second.BeamWidthYError());
-    if(it->second.type() == BeamSpot::Tracker){
+    weight(x     , xError     , it->second.second.x0()        , it->second.second.x0Error());
+    weight(y     , yError     , it->second.second.y0()        , it->second.second.y0Error());
+    weight(z     , zError     , it->second.second.z0()        , it->second.second.z0Error());
+    weight(sigmaZ, sigmaZError, it->second.second.sigmaZ()    , it->second.second.sigmaZ0Error());
+    weight(dxdz  , dxdzError  , it->second.second.dxdz()      , it->second.second.dxdzError());
+    weight(dydz  , dydzError  , it->second.second.dydz()      , it->second.second.dydzError());
+    weight(widthX, widthXError, it->second.second.BeamWidthX(), it->second.second.BeamWidthXError());
+    weight(widthY, widthYError, it->second.second.BeamWidthY(), it->second.second.BeamWidthYError());
+    if(it->second.second.type() == BeamSpot::Tracker){
       type = BeamSpot::Tracker;
     }
   }


### PR DESCRIPTION
This PR is a further refinement of the HP beamspot workflow (integrated with #22299).
It allows to print in the output .txt file the correct beginning-time of the lumi-section for which the BS is measured.