### PR TITLE
[HCAL] Sanitize Mahi HCAL local reconstruction pulse arrival time values

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -137,6 +137,10 @@ class MahiFit
 
   static constexpr int pedestalBX_ = 100;
 
+  // used to restrict returned time value to a 25 ns window centered 
+  // on the nominal arrival time
+  static constexpr float timeLimit_ = 12.5;
+
   // Python-configurables
   bool dynamicPed_;
   float ts4Thresh_; 

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -223,8 +223,12 @@ void MahiFit::doFit(std::array<float,3> &correctedOutput, int nbx, const HcalTim
 
   if (foundintime) {
     correctedOutput.at(0) = nnlsWork_.ampVec.coeff(ipulseintime); //charge
-    double arrivalTime = calculateArrivalTime();
-    correctedOutput.at(1) = arrivalTime; //time
+    if (correctedOutput.at(0)!=0) {
+	double arrivalTime = calculateArrivalTime();
+	correctedOutput.at(1) = arrivalTime; //time
+    }
+    else correctedOutput.at(1) = -9999;//time
+
     correctedOutput.at(2) = chiSq; //chi2
 
   }

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -366,7 +366,11 @@ double MahiFit::calculateArrivalTime() const {
   }
 
   PulseVector solution = nnlsWork_.pulseDerivMat.colPivHouseholderQr().solve(nnlsWork_.residuals);
-  return solution.coeff(itIndex)/nnlsWork_.ampVec.coeff(itIndex);
+  float t = solution.coeff(itIndex)/nnlsWork_.ampVec.coeff(itIndex);
+  t = (t>timeLimit_) ?  timeLimit_ : 
+    ((t<-timeLimit_) ? -timeLimit_ : t);
+
+  return t;
 
 }
   


### PR DESCRIPTION
The current version of Mahi can return a pulse arrival time that is NaN because there is no check for division by zero. Additionally, we limit the pulse arrival time to +/- 12.5 ns from the nominal time, because if the hit is put in the in-time sample (bx=0), it does belong in that sample. This removes large tails in the timing distribution induced by deviations from the default pulse shape template and/or the existence of pulses in bunch crossing we don't allow pulses to exist in the fit.

For example, some recHits from the default release:
```
root [5] HcalTree->Scan("ieta:iphi:depth:mahiE:mahiT")
************************************************************************
*    Row   *      ieta *      iphi *     depth *     mahiE *     mahiT *
************************************************************************
*        0 *        -1 *         1 *         1 *         0 *       inf *
*        1 *        -1 *         7 *         1 *         0 *     -9999 *
*        2 *        -1 *         8 *         1 * 0.0201498 * -2.192569 *
*        3 *        -1 *         9 *         1 * 0.5976437 * -0.054388 *
*        4 *        -1 *        14 *         1 * 0.2618228 * 0.0405726 *
*        5 *        -1 *        19 *         1 * 0.2631363 * -3.694539 *
*        6 *        -1 *        23 *         1 *         0 *     -9999 *
*        7 *        -1 *        24 *         1 *         0 *       inf *
*        8 *        -1 *        25 *         1 *         0 *       inf *
*        9 *        -1 *        28 *         1 *         0 *       inf *
*       10 *        -1 *        29 *         1 *         0 *     -9999 *
```
become
```
root [3] HcalTree->Scan("ieta:iphi:depth:mahiE:mahiT")
************************************************************************
*    Row   *      ieta *      iphi *     depth *     mahiE *     mahiT *
************************************************************************
*        0 *        -1 *         1 *         1 *         0 *     -9999 *
*        1 *        -1 *         7 *         1 *         0 *     -9999 *
*        2 *        -1 *         8 *         1 * 0.0201498 * -2.192569 *
*        3 *        -1 *         9 *         1 * 0.5976437 * -0.054388 *
*        4 *        -1 *        14 *         1 * 0.2618228 * 0.0405726 *
*        5 *        -1 *        19 *         1 * 0.2631363 * -3.694539 *
*        6 *        -1 *        23 *         1 *         0 *     -9999 *
*        7 *        -1 *        24 *         1 *         0 *     -9999 *
*        8 *        -1 *        25 *         1 *         0 *     -9999 *
*        9 *        -1 *        28 *         1 *         0 *     -9999 *
*       10 *        -1 *        29 *         1 *         0 *     -9999 *
```
where -9999 is the default value corresponding to zero in-time energy.

The following plot demonstrates the truncation of the ~1% tails in the pulse shape arrival time:

![mahit_fix](https://user-images.githubusercontent.com/6333978/36806040-1f6eb7ea-1cbf-11e8-918a-4f928568d703.png)

@mariadalfonso @deguio @jaehyeok 