### PR TITLE
PPS Timing Detector: Updated mapping for 2018

### DIFF
--- a/CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2018.xml
+++ b/CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2018.xml
@@ -1,0 +1,129 @@
+<top>   
+  <arm id="0">  <!-- 45 -->
+    <station id="1">        <!-- 215 m -->
+      <rp_detector_set id="6">        <!-- Timing -->
+        <rp_plane_diamond id="0"> 
+          <diamond_channel id="0"         hw_id="0x206"           FEDId="583"             GOHId="3"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x201"           FEDId="583"             GOHId="3"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x205"           FEDId="583"             GOHId="3"               IdxInFiber="5"/>
+          <diamond_channel id="3"         hw_id="0x20D"           FEDId="583"             GOHId="3"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x20A"           FEDId="583"             GOHId="3"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x202"           FEDId="583"             GOHId="3"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x204"           FEDId="583"             GOHId="3"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x20C"           FEDId="583"             GOHId="3"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x20B"           FEDId="583"             GOHId="3"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x203"           FEDId="583"             GOHId="3"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x209"           FEDId="583"             GOHId="3"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x20E"           FEDId="583"             GOHId="3"               IdxInFiber="14"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="1"> 
+          <diamond_channel id="0"         hw_id="0x216"           FEDId="583"             GOHId="4"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x211"           FEDId="583"             GOHId="4"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x215"           FEDId="583"             GOHId="4"               IdxInFiber="5"/>
+          <diamond_channel id="3"         hw_id="0x21D"           FEDId="583"             GOHId="4"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x21A"           FEDId="583"             GOHId="4"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x212"           FEDId="583"             GOHId="4"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x214"           FEDId="583"             GOHId="4"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x21C"           FEDId="583"             GOHId="4"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x21B"           FEDId="583"             GOHId="4"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x213"           FEDId="583"             GOHId="4"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x219"           FEDId="583"             GOHId="4"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x21E"           FEDId="583"             GOHId="4"               IdxInFiber="14"/>
+          <diamond_channel id="30"        hw_id="0x21F"           FEDId="583"             GOHId="4"               IdxInFiber="15"/>
+        </rp_plane_diamond>                             <!-- DONE -->
+        <rp_plane_diamond id="2"> 
+          <diamond_channel id="0"         hw_id="0x106"           FEDId="583"             GOHId="1"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x101"           FEDId="583"             GOHId="1"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x105"           FEDId="583"             GOHId="1"               IdxInFiber="5"/>
+          <diamond_channel id="3"         hw_id="0x10D"           FEDId="583"             GOHId="1"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x10A"           FEDId="583"             GOHId="1"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x102"           FEDId="583"             GOHId="1"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x104"           FEDId="583"             GOHId="1"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x10C"           FEDId="583"             GOHId="1"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x10B"           FEDId="583"             GOHId="1"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x103"           FEDId="583"             GOHId="1"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x109"           FEDId="583"             GOHId="1"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x10E"           FEDId="583"             GOHId="1"               IdxInFiber="14"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="3">
+          <diamond_channel id="0"         hw_id="0x116"           FEDId="583"             GOHId="2"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x111"           FEDId="583"             GOHId="2"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x115"           FEDId="583"             GOHId="2"               IdxInFiber="5"/>
+          <diamond_channel id="3"         hw_id="0x11D"           FEDId="583"             GOHId="2"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x11A"           FEDId="583"             GOHId="2"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x112"           FEDId="583"             GOHId="2"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x114"           FEDId="583"             GOHId="2"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x11C"           FEDId="583"             GOHId="2"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x11B"           FEDId="583"             GOHId="2"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x113"           FEDId="583"             GOHId="2"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x119"           FEDId="583"             GOHId="2"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x11E"           FEDId="583"             GOHId="2"               IdxInFiber="14"/>
+          <diamond_channel id="30"        hw_id="0x11F"           FEDId="583"             GOHId="2"               IdxInFiber="15"/>
+        </rp_plane_diamond>
+      </rp_detector_set>
+    </station>
+  </arm>
+  <arm id="1">  <!-- 56 -->
+    <station id="1">        <!-- 215 m -->
+      <rp_detector_set id="6">        <!-- Timing -->
+        <rp_plane_diamond id="0"> 
+          <diamond_channel id="0"         hw_id="0x306"           FEDId="583"             GOHId="7"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x301"           FEDId="583"             GOHId="7"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x305"           FEDId="583"             GOHId="7"               IdxInFiber="5"/>
+          <diamond_channel id="3"         hw_id="0x30D"           FEDId="583"             GOHId="7"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x30A"           FEDId="583"             GOHId="7"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x302"           FEDId="583"             GOHId="7"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x304"           FEDId="583"             GOHId="7"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x30C"           FEDId="583"             GOHId="7"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x30B"           FEDId="583"             GOHId="7"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x303"           FEDId="583"             GOHId="7"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x309"           FEDId="583"             GOHId="7"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x30E"           FEDId="583"             GOHId="7"               IdxInFiber="14"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="1"> 
+          <diamond_channel id="0"         hw_id="0x316"           FEDId="583"             GOHId="8"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x311"           FEDId="583"             GOHId="8"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x315"           FEDId="583"             GOHId="8"               IdxInFiber="5"/>
+          <diamond_channel id="3"         hw_id="0x31D"           FEDId="583"             GOHId="8"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x31A"           FEDId="583"             GOHId="8"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x312"           FEDId="583"             GOHId="8"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x314"           FEDId="583"             GOHId="8"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x31C"           FEDId="583"             GOHId="8"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x31B"           FEDId="583"             GOHId="8"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x313"           FEDId="583"             GOHId="8"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x319"           FEDId="583"             GOHId="8"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x31E"           FEDId="583"             GOHId="8"               IdxInFiber="14"/>
+          <diamond_channel id="30"        hw_id="0x31F"           FEDId="582"             GOHId="8"               IdxInFiber="15"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="2"> 
+          <diamond_channel id="0"         hw_id="0x406"           FEDId="583"             GOHId="3"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x401"           FEDId="583"             GOHId="3"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x405"           FEDId="583"             GOHId="3"               IdxInFiber="5"/>
+          <diamond_channel id="3"         hw_id="0x40D"           FEDId="583"             GOHId="3"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x40A"           FEDId="583"             GOHId="3"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x402"           FEDId="583"             GOHId="3"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x404"           FEDId="583"             GOHId="3"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x40C"           FEDId="583"             GOHId="3"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x40B"           FEDId="583"             GOHId="3"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x403"           FEDId="583"             GOHId="3"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x409"           FEDId="583"             GOHId="3"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x40E"           FEDId="583"             GOHId="3"               IdxInFiber="14"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="3">
+          <diamond_channel id="0"         hw_id="0x416"           FEDId="583"             GOHId="4"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x411"           FEDId="583"             GOHId="4"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x415"           FEDId="583"             GOHId="4"               IdxInFiber="5"/>
+          <diamond_channel id="3"         hw_id="0x41D"           FEDId="583"             GOHId="4"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x41A"           FEDId="583"             GOHId="4"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x412"           FEDId="583"             GOHId="4"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x414"           FEDId="583"             GOHId="4"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x41C"           FEDId="583"             GOHId="4"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x41B"           FEDId="583"             GOHId="4"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x413"           FEDId="583"             GOHId="4"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x419"           FEDId="583"             GOHId="4"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x41E"           FEDId="583"             GOHId="4"               IdxInFiber="14"/>
+          <diamond_channel id="30"        hw_id="0x41F"           FEDId="582"             GOHId="4"               IdxInFiber="15"/>
+        </rp_plane_diamond>
+      </rp_detector_set>
+    </station>
+  </arm>

--- a/CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2018.xml
+++ b/CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2018.xml
@@ -67,61 +67,61 @@
     <station id="1">        <!-- 215 m -->
       <rp_detector_set id="6">        <!-- Timing -->
         <rp_plane_diamond id="0"> 
-          <diamond_channel id="0"         hw_id="0x306"           FEDId="583"             GOHId="7"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x301"           FEDId="583"             GOHId="7"               IdxInFiber="1"/>
-          <diamond_channel id="2"         hw_id="0x305"           FEDId="583"             GOHId="7"               IdxInFiber="5"/>
-          <diamond_channel id="3"         hw_id="0x30D"           FEDId="583"             GOHId="7"               IdxInFiber="13"/>     
-          <diamond_channel id="4"         hw_id="0x30A"           FEDId="583"             GOHId="7"               IdxInFiber="10"/>
-          <diamond_channel id="5"         hw_id="0x302"           FEDId="583"             GOHId="7"               IdxInFiber="2"/>
-          <diamond_channel id="6"         hw_id="0x304"           FEDId="583"             GOHId="7"               IdxInFiber="4"/>
-          <diamond_channel id="7"         hw_id="0x30C"           FEDId="583"             GOHId="7"               IdxInFiber="12"/>
-          <diamond_channel id="8"         hw_id="0x30B"           FEDId="583"             GOHId="7"               IdxInFiber="11"/>
-          <diamond_channel id="9"         hw_id="0x303"           FEDId="583"             GOHId="7"               IdxInFiber="3"/>
-          <diamond_channel id="10"        hw_id="0x309"           FEDId="583"             GOHId="7"               IdxInFiber="9"/>
-          <diamond_channel id="11"        hw_id="0x30E"           FEDId="583"             GOHId="7"               IdxInFiber="14"/>
+          <diamond_channel id="0"         hw_id="0x306"           FEDId="582"             GOHId="7"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x301"           FEDId="582"             GOHId="7"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x305"           FEDId="582"             GOHId="7"               IdxInFiber="5"/>
+          <diamond_channel id="3"         hw_id="0x30D"           FEDId="582"             GOHId="7"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x30A"           FEDId="582"             GOHId="7"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x302"           FEDId="582"             GOHId="7"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x304"           FEDId="582"             GOHId="7"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x30C"           FEDId="582"             GOHId="7"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x30B"           FEDId="582"             GOHId="7"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x303"           FEDId="582"             GOHId="7"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x309"           FEDId="582"             GOHId="7"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x30E"           FEDId="582"             GOHId="7"               IdxInFiber="14"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="1"> 
-          <diamond_channel id="0"         hw_id="0x316"           FEDId="583"             GOHId="8"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x311"           FEDId="583"             GOHId="8"               IdxInFiber="1"/>
-          <diamond_channel id="2"         hw_id="0x315"           FEDId="583"             GOHId="8"               IdxInFiber="5"/>
-          <diamond_channel id="3"         hw_id="0x31D"           FEDId="583"             GOHId="8"               IdxInFiber="13"/>     
-          <diamond_channel id="4"         hw_id="0x31A"           FEDId="583"             GOHId="8"               IdxInFiber="10"/>
-          <diamond_channel id="5"         hw_id="0x312"           FEDId="583"             GOHId="8"               IdxInFiber="2"/>
-          <diamond_channel id="6"         hw_id="0x314"           FEDId="583"             GOHId="8"               IdxInFiber="4"/>
-          <diamond_channel id="7"         hw_id="0x31C"           FEDId="583"             GOHId="8"               IdxInFiber="12"/>
-          <diamond_channel id="8"         hw_id="0x31B"           FEDId="583"             GOHId="8"               IdxInFiber="11"/>
-          <diamond_channel id="9"         hw_id="0x313"           FEDId="583"             GOHId="8"               IdxInFiber="3"/>
-          <diamond_channel id="10"        hw_id="0x319"           FEDId="583"             GOHId="8"               IdxInFiber="9"/>
-          <diamond_channel id="11"        hw_id="0x31E"           FEDId="583"             GOHId="8"               IdxInFiber="14"/>
+          <diamond_channel id="0"         hw_id="0x316"           FEDId="582"             GOHId="8"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x311"           FEDId="582"             GOHId="8"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x315"           FEDId="582"             GOHId="8"               IdxInFiber="5"/>
+          <diamond_channel id="3"         hw_id="0x31D"           FEDId="582"             GOHId="8"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x31A"           FEDId="582"             GOHId="8"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x312"           FEDId="582"             GOHId="8"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x314"           FEDId="582"             GOHId="8"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x31C"           FEDId="582"             GOHId="8"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x31B"           FEDId="582"             GOHId="8"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x313"           FEDId="582"             GOHId="8"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x319"           FEDId="582"             GOHId="8"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x31E"           FEDId="582"             GOHId="8"               IdxInFiber="14"/>
           <diamond_channel id="30"        hw_id="0x31F"           FEDId="582"             GOHId="8"               IdxInFiber="15"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="2"> 
-          <diamond_channel id="0"         hw_id="0x406"           FEDId="583"             GOHId="3"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x401"           FEDId="583"             GOHId="3"               IdxInFiber="1"/>
-          <diamond_channel id="2"         hw_id="0x405"           FEDId="583"             GOHId="3"               IdxInFiber="5"/>
-          <diamond_channel id="3"         hw_id="0x40D"           FEDId="583"             GOHId="3"               IdxInFiber="13"/>     
-          <diamond_channel id="4"         hw_id="0x40A"           FEDId="583"             GOHId="3"               IdxInFiber="10"/>
-          <diamond_channel id="5"         hw_id="0x402"           FEDId="583"             GOHId="3"               IdxInFiber="2"/>
-          <diamond_channel id="6"         hw_id="0x404"           FEDId="583"             GOHId="3"               IdxInFiber="4"/>
-          <diamond_channel id="7"         hw_id="0x40C"           FEDId="583"             GOHId="3"               IdxInFiber="12"/>
-          <diamond_channel id="8"         hw_id="0x40B"           FEDId="583"             GOHId="3"               IdxInFiber="11"/>
-          <diamond_channel id="9"         hw_id="0x403"           FEDId="583"             GOHId="3"               IdxInFiber="3"/>
-          <diamond_channel id="10"        hw_id="0x409"           FEDId="583"             GOHId="3"               IdxInFiber="9"/>
-          <diamond_channel id="11"        hw_id="0x40E"           FEDId="583"             GOHId="3"               IdxInFiber="14"/>
+          <diamond_channel id="0"         hw_id="0x406"           FEDId="582"             GOHId="3"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x401"           FEDId="582"             GOHId="3"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x405"           FEDId="582"             GOHId="3"               IdxInFiber="5"/>
+          <diamond_channel id="3"         hw_id="0x40D"           FEDId="582"             GOHId="3"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x40A"           FEDId="582"             GOHId="3"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x402"           FEDId="582"             GOHId="3"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x404"           FEDId="582"             GOHId="3"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x40C"           FEDId="582"             GOHId="3"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x40B"           FEDId="582"             GOHId="3"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x403"           FEDId="582"             GOHId="3"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x409"           FEDId="582"             GOHId="3"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x40E"           FEDId="582"             GOHId="3"               IdxInFiber="14"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="3">
-          <diamond_channel id="0"         hw_id="0x416"           FEDId="583"             GOHId="4"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x411"           FEDId="583"             GOHId="4"               IdxInFiber="1"/>
-          <diamond_channel id="2"         hw_id="0x415"           FEDId="583"             GOHId="4"               IdxInFiber="5"/>
-          <diamond_channel id="3"         hw_id="0x41D"           FEDId="583"             GOHId="4"               IdxInFiber="13"/>     
-          <diamond_channel id="4"         hw_id="0x41A"           FEDId="583"             GOHId="4"               IdxInFiber="10"/>
-          <diamond_channel id="5"         hw_id="0x412"           FEDId="583"             GOHId="4"               IdxInFiber="2"/>
-          <diamond_channel id="6"         hw_id="0x414"           FEDId="583"             GOHId="4"               IdxInFiber="4"/>
-          <diamond_channel id="7"         hw_id="0x41C"           FEDId="583"             GOHId="4"               IdxInFiber="12"/>
-          <diamond_channel id="8"         hw_id="0x41B"           FEDId="583"             GOHId="4"               IdxInFiber="11"/>
-          <diamond_channel id="9"         hw_id="0x413"           FEDId="583"             GOHId="4"               IdxInFiber="3"/>
-          <diamond_channel id="10"        hw_id="0x419"           FEDId="583"             GOHId="4"               IdxInFiber="9"/>
-          <diamond_channel id="11"        hw_id="0x41E"           FEDId="583"             GOHId="4"               IdxInFiber="14"/>
+          <diamond_channel id="0"         hw_id="0x416"           FEDId="582"             GOHId="4"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x411"           FEDId="582"             GOHId="4"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x415"           FEDId="582"             GOHId="4"               IdxInFiber="5"/>
+          <diamond_channel id="3"         hw_id="0x41D"           FEDId="582"             GOHId="4"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x41A"           FEDId="582"             GOHId="4"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x412"           FEDId="582"             GOHId="4"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x414"           FEDId="582"             GOHId="4"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x41C"           FEDId="582"             GOHId="4"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x41B"           FEDId="582"             GOHId="4"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x413"           FEDId="582"             GOHId="4"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x419"           FEDId="582"             GOHId="4"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x41E"           FEDId="582"             GOHId="4"               IdxInFiber="14"/>
           <diamond_channel id="30"        hw_id="0x41F"           FEDId="582"             GOHId="4"               IdxInFiber="15"/>
         </rp_plane_diamond>
       </rp_detector_set>

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -68,8 +68,14 @@ totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSource
     ),
     # 2017
     cms.PSet(
-      validityRange = cms.EventRange("292521:min - 999999999:max"),
+      validityRange = cms.EventRange("292521:min - 310000:max"),
       mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2017.xml"),
+      maskFileNames = cms.vstring()
+    )
+    # 2018
+    cms.PSet(
+      validityRange = cms.EventRange("310001:min - 999999999:max"),
+      mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2018.xml"),
       maskFileNames = cms.vstring()
     )
   )

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -71,7 +71,7 @@ totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSource
       validityRange = cms.EventRange("292521:min - 310000:max"),
       mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2017.xml"),
       maskFileNames = cms.vstring()
-    )
+    ),
     # 2018
     cms.PSet(
       validityRange = cms.EventRange("310001:min - 999999999:max"),


### PR DESCRIPTION
We are updating the mapping of the PPS Timing Diamond detector to reflect the different cabling done during YETS.
During 2017 we had some bugs in the front-end electronics that were fixed with the Digitizer Board V3. Moreover, the new cabling is optimized to balance the occupancy in the HPTDCs to not saturate the read-out fifos.
The cabling will not change anymore during 2018.