### PR TITLE
Fireworks 10_0: disable tree cache prefetching by default

### DIFF
--- a/Fireworks/Core/src/CmsShowMain.cc
+++ b/Fireworks/Core/src/CmsShowMain.cc
@@ -92,6 +92,7 @@ static const char* const kLoopCommandOpt       = "loop";
 static const char* const kLogLevelCommandOpt   = "log";
 static const char* const kLogTreeCacheOpt      = "log-tree-cache";
 static const char* const kSizeTreeCacheOpt     = "tree-cache-size";
+static const char* const kPrefetchTreeCacheOpt = "tree-cache-prefetch";
 static const char* const kEveOpt               = "eve";
 static const char* const kEveCommandOpt        = "eve";
 static const char* const kAdvancedRenderOpt        = "shine";
@@ -192,7 +193,8 @@ CmsShowMain::CmsShowMain(int argc, char *argv[])
  po::options_description tcachedesc("TreeCache");
  tcachedesc.add_options()
     (kLogTreeCacheOpt,                                 "Log tree cache operations and status")
-    (kSizeTreeCacheOpt, po::value<int>(),              "Set size of TTreeCache for data access in MB (default is 50)");
+    (kSizeTreeCacheOpt, po::value<int>(),              "Set size of TTreeCache for data access in MB (default is 50)")
+    (kPrefetchTreeCacheOpt,                            "Enable prefetching");
 
  po::options_description rnrdesc("Appearance");
  rnrdesc.add_options()
@@ -241,6 +243,11 @@ CmsShowMain::CmsShowMain(int argc, char *argv[])
    if(vm.count(kLogTreeCacheOpt)) {
       fwLog(fwlog::kInfo) << "Enabling logging of TTreCache operations." << std::endl;
       FWTTreeCache::LoggingOn();
+   }
+
+   if(vm.count(kPrefetchTreeCacheOpt)) {
+      fwLog(fwlog::kInfo) << "Enabling TTreCache prefetching." << std::endl;
+      FWTTreeCache::PrefetchingOn();
    }
 
    if(vm.count(kSizeTreeCacheOpt)) {

--- a/Fireworks/Core/src/FWFileEntry.cc
+++ b/Fireworks/Core/src/FWFileEntry.cc
@@ -120,8 +120,7 @@ void FWFileEntry::openFile(bool checkVersion)
 
    auto tc = new FWTTreeCache(m_eventTree, FWTTreeCache::GetDefaultCacheSize());
    m_file->SetCacheRead(tc, m_eventTree);
-   gEnv->SetValue("TFile.AsyncReading", 1);
-   tc->SetEnablePrefetching(true);
+   tc->SetEnablePrefetching(FWTTreeCache::IsPrefetching());
    tc->SetLearnEntries(20);
    tc->SetLearnPrefill(TTreeCache::kAllBranches);
    tc->StartLearningPhase();
@@ -342,7 +341,7 @@ void FWFileEntry::runFilter(Filter* filter, const FWEventItemsManager* eiMng)
    auto interCache = new TTreeCache(m_eventTree, 10*1024*1024);
    // Do not disconnect the cache, it will be reattached after filtering.
    m_file->SetCacheRead(interCache, m_eventTree, TFile::kDoNotDisconnect);
-   interCache->SetEnablePrefetching(true);
+   interCache->SetEnablePrefetching(FWTTreeCache::IsPrefetching());
    for (auto & b : branch_names)
      interCache->AddBranch(b.c_str(), true);
    interCache->StopLearningPhase();

--- a/Fireworks/Core/src/FWTTreeCache.cc
+++ b/Fireworks/Core/src/FWTTreeCache.cc
@@ -19,12 +19,17 @@ FWTTreeCache::~FWTTreeCache()
 
 //==============================================================================
 
-bool FWTTreeCache::s_logging = false;
+bool FWTTreeCache::s_logging      = false;
+bool FWTTreeCache::s_prefetching  = false;
 int  FWTTreeCache::s_default_size = 50 * 1024 * 1024;
 
 void FWTTreeCache::LoggingOn()  { s_logging = true;  }
 void FWTTreeCache::LoggingOff() { s_logging = false; }
 bool FWTTreeCache::IsLogging()  { return s_logging;  }
+
+void FWTTreeCache::PrefetchingOn()  { s_prefetching = true;  }
+void FWTTreeCache::PrefetchingOff() { s_prefetching = false; }
+bool FWTTreeCache::IsPrefetching()  { return s_prefetching;  }
 
 void FWTTreeCache::SetDefaultCacheSize(int def_size) { s_default_size = def_size; }
 int  FWTTreeCache::GetDefaultCacheSize()             { return s_default_size; }

--- a/Fireworks/Core/src/FWTTreeCache.h
+++ b/Fireworks/Core/src/FWTTreeCache.h
@@ -13,6 +13,7 @@ class FWTTreeCache : public TTreeCache
 
    static int            s_default_size;
    static bool           s_logging;
+   static bool           s_prefetching;
 
 protected:
    bool is_branch_in_cache(const char* name) { return (m_branch_set.find(name) != m_branch_set.end()); }
@@ -47,6 +48,9 @@ public:
    static void LoggingOn();
    static void LoggingOff();
    static bool IsLogging();
+   static void PrefetchingOn();
+   static void PrefetchingOff();
+   static bool IsPrefetching();
    static void SetDefaultCacheSize(int def_size);
    static int  GetDefaultCacheSize();
 


### PR DESCRIPTION
 * added prefetching control / commandline option
* disable tree cache prefetching by default, waiting to resolve bug https://sft.its.cern.ch/jira/browse/ROOT-9282