### PR TITLE
Make ROOT file support concurrent LuminosityBlocks

### DIFF
--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -51,7 +51,7 @@ There can also be multiple lumi entries associated with
 the same lumi number, run number, and ProcessHistoryID.
 Both sorting orders will make these subgroups contiguous,
 but beyond that is up to the client (normally PoolSource,
-which passes them up to the EventProcessor and EPStates)
+which passes them up to the EventProcessor)
 to deal with merging the multiple run (or lumi) entries
 together.
 
@@ -85,13 +85,37 @@ This vector holds one element per entry in the run
 TTree and one element per entry in the lumi TTree.
 When sorted, everything associated with a given run and
 ProcessHistoryID will be contiguous in the vector.
-These groups of entries will be put in the order they
+These groups of elements will be sorted in the order they
 first appear in the input file. Within each of
-these groups the run entries come first in entry order,
-followed by the entries associated with the lumis.
+these groups the run entries come first in order,
+followed by the elements associated with the lumis.
 The lumis are also contiguous and sorted by first
 appearance in the input file. Within a lumi they
-are sorted by entry order.
+are sorted by entry order. And each luminosity
+element corresponds to one contiguous sequence
+of Events in the Events TTree. Before we implemented
+concurrent processing of luminosity blocks that
+was the full story. After that it became more complicated
+because the sequence of events written to an output
+file that were associated with a particular luminosity
+block TTree entry might no longer be contiguous. Events
+from another concurrent luminosity block could get
+mixed in because with multiple events processing simultaneously,
+there is no longer any guarantee they will finish in the
+same order that they were read. This is handled by writing
+additional elements to the runOrLumiEntries_ vector, one for
+each contiguous block of events associated with a particular
+luminosity block. Only one of these vector elements will
+be associated with each entry in the luminosity block TTree
+and all the others will contain a TTree entry number that
+is invalid (note the one element with a valid entry might
+or might not be associated with a contiguous block of
+events). In the sort of elements related to a particular
+luminosity block, the entries with invalid entry numbers
+will come before the valid ones. (It has not happened
+yet as I am writing this, but a similar thing will
+likely occur for runs if/when we ever implement concurrent
+runs)
 
 There are a number of transient data members also.
 The 3 most important of these are vectors.  To
@@ -107,7 +131,14 @@ in numerical order and also fast lookup based on run
 number and lumi number. Each element also has indexes
 into the eventNumbers_ and eventEntries_ vectors which
 hold the information giving the event numbers and
-event entry numbers.
+event entry numbers. Note this vector is initially
+formed in the identical order as runOrLumiEntries_
+and then sorted with a stable sort. The fact that it
+is a stable sort means that within the subrange associated
+with a particular luminosity block the elements with
+an invalid TTree entry number come first and the later
+come the elements with a valid TTree entry number
+which are in order of TTree entry number.
 
 eventNumbers_ is a std::vector containing EventNumber_t's.
 eventEntries_ is a std::vector containing EventEntry's.
@@ -115,12 +146,12 @@ If filled, both vectors contain the same number of
 entries with identical event numbers sorted in the
 same order.  The only difference is that one includes
 the entry numbers and thus takes more memory.
-Each element of runOrLumiIndexes_ has the indexes necessary
-to find the range inside eventNumbers_ or eventEntries_
-corresponding to its lumi.  Within that range the elements
-are sorted by event number, which is used for the
-numerical order iteration and to find an event by the
-event number.
+Each element of runOrLumiIndexes_ associated with a luminosity
+block has the indexes necessary to find the range inside
+eventNumbers_ or eventEntries_ corresponding to its lumi.
+Within that range the elements are sorted by event number,
+which is used for the numerical order iteration and to
+find an event by the event number.
 
 The details of the data structure are a little different
 when reading files written before release 3_8_0
@@ -142,10 +173,10 @@ optimal structure for a very sparse skim, but the overheads
 should be tolerable given the number of runs and luminosity
 blocks that should occur in CMS data.
 
-Normally the only the persistent part of the data structure is
-filled in the output module using two functions designed specifically
-for that purpose. The functions are addEntry and
-sortVector_Run_Or_Lumi_Entries.
+Normally only the persistent parts of the data structure are
+filled in the output module. The output module fills them using
+two functions designed specifically for that purpose. The
+functions are addEntry and sortVector_Run_Or_Lumi_Entries.
 
 There are some complexities associated with filling the data structure,
 mostly revolving around optimizations to minimize the per event memory
@@ -355,10 +386,18 @@ namespace edm {
         // ProcessHistory, Run, and Lumi in the same input file are
         // processed contiguously.  This parameter establishes the
         // default order of processing of these contiguous subsets
-        // of data which have the same ProcessHistory and Run.
+        // of data.
         EntryNumber_t orderPHIDRunLumi_; // -1 if a run
 
         // TTree entry number of Run or Lumi
+        // Always will be valid except when the IndexIntoFile was
+        // created while processing more than 1 luminosity block
+        // at a time (multiple concurrent lumis). In that case
+        // there can be multiple contiguous event ranges associated
+        // with the same lumi TTree entry. Exactly one of those will
+        // have a valid entry_ number and the rest will be set
+        // to the invalid value (-1). For a particular lumi, the
+        // invalid ones sort before the valid ones.
         EntryNumber_t entry_;
 
         int processHistoryIDIndex_;
@@ -523,6 +562,7 @@ namespace edm {
         EntryNumber_t firstEventEntryThisRun();
         EntryNumber_t firstEventEntryThisLumi();
         virtual bool skipLumiInRun() = 0;
+        virtual bool lumiEntryValid(int index) const = 0;
 
         void advanceToNextRun();
         void advanceToNextLumiOrRun();
@@ -599,6 +639,7 @@ namespace edm {
         LuminosityBlockNumber_t peekAheadAtLumi() const override;
         EntryNumber_t peekAheadAtEventEntry() const override;
         bool skipLumiInRun() override;
+        bool lumiEntryValid(int index) const override;
 
       private:
 
@@ -632,6 +673,7 @@ namespace edm {
         LuminosityBlockNumber_t peekAheadAtLumi() const override;
         EntryNumber_t peekAheadAtEventEntry() const override;
         bool skipLumiInRun() override;
+        bool lumiEntryValid(int index) const override;
 
       private:
 
@@ -1015,8 +1057,8 @@ namespace edm {
         Transients();
         void reset();
         int previousAddedIndex_;
-        std::map<IndexRunKey, EntryNumber_t> runToFirstEntry_;
-        std::map<IndexRunLumiKey, EntryNumber_t> lumiToFirstEntry_;
+        std::map<IndexRunKey, EntryNumber_t> runToOrder_;
+        std::map<IndexRunLumiKey, EntryNumber_t> lumiToOrder_;
         EntryNumber_t beginEvents_;
         EntryNumber_t endEvents_;
         int currentIndex_;
@@ -1051,8 +1093,8 @@ namespace edm {
       void sortEvents() const;
       void sortEventEntries() const;
       int& previousAddedIndex() const {return transient_.previousAddedIndex_;}
-      std::map<IndexRunKey, EntryNumber_t>& runToFirstEntry() const {return transient_.runToFirstEntry_;}
-      std::map<IndexRunLumiKey, EntryNumber_t>& lumiToFirstEntry() const {return transient_.lumiToFirstEntry_;}
+      std::map<IndexRunKey, EntryNumber_t>& runToOrder() const {return transient_.runToOrder_;}
+      std::map<IndexRunLumiKey, EntryNumber_t>& lumiToOrder() const {return transient_.lumiToOrder_;}
       EntryNumber_t& beginEvents() const {return transient_.beginEvents_;}
       EntryNumber_t& endEvents() const {return transient_.endEvents_;}
       int& currentIndex() const {return transient_.currentIndex_;}

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -195,12 +195,12 @@ namespace edm {
       class SortedRunOrLumiItr;
       class IndexRunLumiEventKey;
 
-      typedef long long EntryNumber_t;
-      static int const invalidIndex = -1;
-      static RunNumber_t const invalidRun = 0U;
-      static LuminosityBlockNumber_t const invalidLumi = 0U;
-      static EventNumber_t const invalidEvent = 0U;
-      static EntryNumber_t const invalidEntry = -1LL;
+      using EntryNumber_t = long long ;
+      static constexpr int invalidIndex = -1;
+      static constexpr RunNumber_t invalidRun = 0U;
+      static constexpr LuminosityBlockNumber_t invalidLumi = 0U;
+      static constexpr EventNumber_t invalidEvent = 0U;
+      static constexpr EntryNumber_t invalidEntry = -1LL;
 
       enum EntryType {kRun, kLumi, kEvent, kEnd};
 
@@ -529,7 +529,7 @@ namespace edm {
         bool skipToNextEventInLumi();
         void initializeRun();
 
-        void initializeLumi() {initializeLumi_();}
+        void initializeLumi() ;
 
         bool operator==(IndexIntoFileItrImpl const& right) const;
 
@@ -908,6 +908,8 @@ namespace edm {
       /// works in cases where those corrections are not needed.
       void sortVector_Run_Or_Lumi_Entries();
 
+      //used internally by addEntry
+      void addLumi(int index, RunNumber_t run, LuminosityBlockNumber_t lumi, EntryNumber_t entry);
       //*****************************************************************************
       //*****************************************************************************
 

--- a/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
@@ -184,9 +184,9 @@ void TestIndexIntoFile2::testAddEntryAndFixAndSort() {
   CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[4].orderPHIDRunLumi() == IndexIntoFile::invalidEntry);
   CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[5].orderPHIDRunLumi() == 1);
   CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[6].orderPHIDRunLumi() == IndexIntoFile::invalidEntry);
-  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[7].orderPHIDRunLumi() == 3);
-  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[8].orderPHIDRunLumi() == 4);
-  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[9].orderPHIDRunLumi() == 4);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[7].orderPHIDRunLumi() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[8].orderPHIDRunLumi() == 3);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[9].orderPHIDRunLumi() == 3);
 
   CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[0].entry() == 0);
   CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[1].entry() == 2);

--- a/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
@@ -846,62 +846,124 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
 
 void TestIndexIntoFile3::testOverlappingLumis() {
   edm::IndexIntoFile indexIntoFile;
-  indexIntoFile.addEntry(fakePHID1, 11, 101, 7, 0); // Event
-  indexIntoFile.addEntry(fakePHID1, 11, 101, 6, 1); // Event
-  indexIntoFile.addEntry(fakePHID1, 11, 101, 5, 2); // Event
-  indexIntoFile.addEntry(fakePHID1, 11, 101, 4, 3); // Event
+  indexIntoFile.addEntry(fakePHID1, 11, 104, 0, 0); // Lumi
+  indexIntoFile.addEntry(fakePHID1, 11, 103, 7, 0); // Event
+  indexIntoFile.addEntry(fakePHID1, 11, 103, 6, 1); // Event
+  indexIntoFile.addEntry(fakePHID1, 11, 103, 5, 2); // Event
+  indexIntoFile.addEntry(fakePHID1, 11, 103, 4, 3); // Event
   //Dummy Lumi gets added
   indexIntoFile.addEntry(fakePHID1, 11, 102, 5, 4); // Event
   //Another dummy lumi gets added
-  indexIntoFile.addEntry(fakePHID1, 11, 101, 0, 0); // Lumi
+  indexIntoFile.addEntry(fakePHID1, 11, 103, 0, 1); // Lumi
   
   indexIntoFile.addEntry(fakePHID1, 11, 102, 4, 5); // Event
-  indexIntoFile.addEntry(fakePHID1, 11, 102, 0, 1); // Lumi
+  indexIntoFile.addEntry(fakePHID1, 11, 102, 0, 2); // Lumi
   indexIntoFile.addEntry(fakePHID1, 11,   0, 0, 0); // Run
   indexIntoFile.addEntry(fakePHID2, 11,   0, 0, 1); // Run
-  indexIntoFile.addEntry(fakePHID2, 11, 101, 0, 2); // Lumi
-  indexIntoFile.addEntry(fakePHID2, 11, 102, 0, 3); // Lumi
-  indexIntoFile.addEntry(fakePHID2, 11, 102, 4, 6); // Event
+  indexIntoFile.addEntry(fakePHID2, 11, 101, 0, 3); // Lumi
   indexIntoFile.addEntry(fakePHID2, 11, 102, 0, 4); // Lumi
+  indexIntoFile.addEntry(fakePHID2, 11, 102, 4, 6); // Event
+  indexIntoFile.addEntry(fakePHID2, 11, 102, 0, 5); // Lumi
   indexIntoFile.addEntry(fakePHID2, 11,   0, 0, 2); // Run
   indexIntoFile.sortVector_Run_Or_Lumi_Entries();
   
+  std::vector<IndexIntoFile::EventEntry>&  eventEntries  = indexIntoFile.eventEntries();
+  eventEntries.emplace_back(5, 4);
+  eventEntries.emplace_back(4, 5);
+  eventEntries.emplace_back(7, 0);
+  eventEntries.emplace_back(6, 1);
+  eventEntries.emplace_back(5, 2);
+  eventEntries.emplace_back(4, 3);
+  eventEntries.emplace_back(4, 6);
+  indexIntoFile.sortEventEntries();
+
   edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
   edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::firstAppearanceOrder);
   int i = 0;
   for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
     if (i == 0) {
-      check(iterFirst, kRun, 0, 2, 1, 0, 4);
+      check(iterFirst, kRun, 0, 1, -1, 0, 0);
       CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
-      CPPUNIT_ASSERT(iterFirst.size() == 10);
+      CPPUNIT_ASSERT(iterFirst.size() == 11);
     }
     //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
-    else if (i == 1)  check(iterFirst, kLumi,  0, 2,  1, 0, 4);
-    else if (i == 2)  check(iterFirst, kEvent, 0, 2,  1, 0, 4);
-    else if (i == 3)  check(iterFirst, kEvent, 0, 2,  1, 1, 4);
-    else if (i == 4)  check(iterFirst, kEvent, 0, 2,  1, 2, 4);
-    else if (i == 5)  check(iterFirst, kEvent, 0, 2,  1, 3, 4);
-    else if (i == 6)  check(iterFirst, kLumi,  0, 4,  3, 0, 1);
-    else if (i == 7)  check(iterFirst, kEvent, 0, 4,  3, 0, 1);
-    else if (i == 8) check(iterFirst, kEvent, 0, 4,  4, 0, 1);
-    else if (i == 9) check(iterFirst, kRun,   5, 7, -1, 0, 0);
-    else if (i == 10) check(iterFirst, kRun,   6, 7, -1, 0, 0);
-    else if (i == 11) check(iterFirst, kLumi,  6, 7, -1, 0, 0);
-    else if (i == 12) check(iterFirst, kLumi,  6, 8,  9, 0, 1);
-    else if (i == 13) check(iterFirst, kLumi,  6, 9,  9, 0, 1);
-    else if (i == 14) check(iterFirst, kEvent, 6, 9,  9, 0, 1);
+    else if (i == 1)  check(iterFirst, kLumi,  0, 1, -1, 0, 0);
+    else if (i == 2)  check(iterFirst, kLumi,  0, 3,  2, 0, 4);
+    else if (i == 3)  check(iterFirst, kEvent, 0, 3,  2, 0, 4);
+    else if (i == 4)  check(iterFirst, kEvent, 0, 3,  2, 1, 4);
+    else if (i == 5)  check(iterFirst, kEvent, 0, 3,  2, 2, 4);
+    else if (i == 6)  check(iterFirst, kEvent, 0, 3,  2, 3, 4);
+    else if (i == 7)  check(iterFirst, kLumi,  0, 5,  4, 0, 1);
+    else if (i == 8)  check(iterFirst, kEvent, 0, 5,  4, 0, 1);
+    else if (i == 9)  check(iterFirst, kEvent, 0, 5,  5, 0, 1);
+    else if (i == 10) check(iterFirst, kRun,   6, 8, -1, 0, 0);
+    else if (i == 11) check(iterFirst, kRun,   7, 8, -1, 0, 0);
+    else if (i == 12) check(iterFirst, kLumi,  7, 8, -1, 0, 0);
+    else if (i == 13) check(iterFirst, kLumi,  7, 9, 10, 0, 1);
+    else if (i == 14) check(iterFirst, kLumi,  7,10, 10, 0, 1);
+    else if (i == 15) check(iterFirst, kEvent, 7,10, 10, 0, 1);
     else CPPUNIT_ASSERT(false);
     
-    if (i == 0) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
-    if (i == 8) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
-    if (i == 10) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 6);
+    if (i == 1) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+    if (i == 9) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+    if (i == 11) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 6);
     
-    if (i == 0) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
-    if (i == 8) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 4);
-    if (i == 10) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
+    if (i == 2) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+    if (i == 9) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 4);
+    if (i == 11) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
   }
-  CPPUNIT_ASSERT(i == 15);
-  
+  CPPUNIT_ASSERT(i == 16);
+
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::numericalOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::numericalOrder);
+    int i = 0;
+    for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
+      //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
+      if (i == 0)       check(iterFirst, kRun,   0, 2,  1, 0, 2);
+      else if (i == 1)  check(iterFirst, kLumi,  0, 2,  1, 0, 2);
+      else if (i == 2)  check(iterFirst, kEvent, 0, 2,  1, 0, 2);
+      else if (i == 3)  check(iterFirst, kEvent, 0, 2,  1, 1, 2);
+      else if (i == 4)  check(iterFirst, kLumi,  0, 4,  3, 0, 4);
+      else if (i == 5)  check(iterFirst, kEvent, 0, 4,  3, 0, 4);
+      else if (i == 6)  check(iterFirst, kEvent, 0, 4,  3, 1, 4);
+      else if (i == 7)  check(iterFirst, kEvent, 0, 4,  3, 2, 4);
+      else if (i == 8)  check(iterFirst, kEvent, 0, 4,  3, 3, 4);
+      else if (i == 9)  check(iterFirst, kLumi,  0, 5, -1, 0, 0);
+      else if (i == 10) check(iterFirst, kRun,   6, 8, -1, 0, 0);
+      else if (i == 11) check(iterFirst, kRun,   7, 8, -1, 0, 0);
+      else if (i == 12) check(iterFirst, kLumi,  7, 8, -1, 0, 0);
+      else if (i == 13) check(iterFirst, kLumi,  7, 9,  9, 0, 1);
+      else if (i == 14) check(iterFirst, kLumi,  7,10,  9, 0, 1);
+      else if (i == 15) check(iterFirst, kEvent, 7,10,  9, 0, 1);
+      else CPPUNIT_ASSERT(false);
+    }
+    CPPUNIT_ASSERT(i == 16);
+
+  }
+
+  edm::IndexIntoFile::IndexIntoFileItr testIter = indexIntoFile.findPosition(11, 103, 7);
+  check(testIter, kRun, 0, 4, 3, 3, 4);
+  ++testIter;
+  check(testIter, kLumi, 0, 4, 3, 3, 4);
+  ++testIter;
+  check(testIter, kEvent, 0, 4, 3, 3, 4);
+  ++testIter;
+  check(testIter, kLumi, 0, 5, -1, 0, 0);
+
+  {
+    edm::IndexIntoFile::IndexIntoFileItr testIter = indexIntoFile.findPosition(11, 0, 7);
+    check(testIter, kRun, 0, 4, 3, 3, 4);
+    ++testIter;
+    check(testIter, kLumi, 0, 4, 3, 3, 4);
+    ++testIter;
+    check(testIter, kEvent, 0, 4, 3, 3, 4);
+    ++testIter;
+    check(testIter, kLumi, 0, 5, -1, 0, 0);
+    skipEventBackward(testIter);
+    check(testIter, kLumi, 0, 4, 3, 3, 4);
+  }
+
   {
     edm::IndexIntoFile indexIntoFile;
     indexIntoFile.addEntry(fakePHID1, 11, 101, 7, 0); // Event

--- a/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
@@ -21,6 +21,7 @@ class TestIndexIntoFile3: public CppUnit::TestFixture
 {
   CPPUNIT_TEST_SUITE(TestIndexIntoFile3);  
   CPPUNIT_TEST(testIterEndWithEvent);
+  CPPUNIT_TEST(testOverlappingLumis);
   CPPUNIT_TEST_SUITE_END();
   
 public:
@@ -71,6 +72,7 @@ public:
   void tearDown() { }
 
   void testIterEndWithEvent();
+  void testOverlappingLumis();
 
   ProcessHistoryID nullPHID;
   ProcessHistoryID fakePHID1;
@@ -840,4 +842,124 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
   skipEventBackward(iterNum);
   checkSkipped(0, 11, 102, 4);
   check(iterNum, kRun, 0, 4, 4, 1, 2);
+}
+
+void TestIndexIntoFile3::testOverlappingLumis() {
+  edm::IndexIntoFile indexIntoFile;
+  indexIntoFile.addEntry(fakePHID1, 11, 101, 7, 0); // Event
+  indexIntoFile.addEntry(fakePHID1, 11, 101, 6, 1); // Event
+  indexIntoFile.addEntry(fakePHID1, 11, 101, 5, 2); // Event
+  indexIntoFile.addEntry(fakePHID1, 11, 101, 4, 3); // Event
+  //Dummy Lumi gets added
+  indexIntoFile.addEntry(fakePHID1, 11, 102, 5, 4); // Event
+  //Another dummy lumi gets added
+  indexIntoFile.addEntry(fakePHID1, 11, 101, 0, 0); // Lumi
+  
+  indexIntoFile.addEntry(fakePHID1, 11, 102, 4, 5); // Event
+  indexIntoFile.addEntry(fakePHID1, 11, 102, 0, 1); // Lumi
+  indexIntoFile.addEntry(fakePHID1, 11,   0, 0, 0); // Run
+  indexIntoFile.addEntry(fakePHID2, 11,   0, 0, 1); // Run
+  indexIntoFile.addEntry(fakePHID2, 11, 101, 0, 2); // Lumi
+  indexIntoFile.addEntry(fakePHID2, 11, 102, 0, 3); // Lumi
+  indexIntoFile.addEntry(fakePHID2, 11, 102, 4, 6); // Event
+  indexIntoFile.addEntry(fakePHID2, 11, 102, 0, 4); // Lumi
+  indexIntoFile.addEntry(fakePHID2, 11,   0, 0, 2); // Run
+  indexIntoFile.sortVector_Run_Or_Lumi_Entries();
+  
+  edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
+  edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::firstAppearanceOrder);
+  int i = 0;
+  for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
+    if (i == 0) {
+      check(iterFirst, kRun, 0, 2, 1, 0, 4);
+      CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
+      CPPUNIT_ASSERT(iterFirst.size() == 10);
+    }
+    //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
+    else if (i == 1)  check(iterFirst, kLumi,  0, 2,  1, 0, 4);
+    else if (i == 2)  check(iterFirst, kEvent, 0, 2,  1, 0, 4);
+    else if (i == 3)  check(iterFirst, kEvent, 0, 2,  1, 1, 4);
+    else if (i == 4)  check(iterFirst, kEvent, 0, 2,  1, 2, 4);
+    else if (i == 5)  check(iterFirst, kEvent, 0, 2,  1, 3, 4);
+    else if (i == 6)  check(iterFirst, kLumi,  0, 4,  3, 0, 1);
+    else if (i == 7)  check(iterFirst, kEvent, 0, 4,  3, 0, 1);
+    else if (i == 8) check(iterFirst, kEvent, 0, 4,  4, 0, 1);
+    else if (i == 9) check(iterFirst, kRun,   5, 7, -1, 0, 0);
+    else if (i == 10) check(iterFirst, kRun,   6, 7, -1, 0, 0);
+    else if (i == 11) check(iterFirst, kLumi,  6, 7, -1, 0, 0);
+    else if (i == 12) check(iterFirst, kLumi,  6, 8,  9, 0, 1);
+    else if (i == 13) check(iterFirst, kLumi,  6, 9,  9, 0, 1);
+    else if (i == 14) check(iterFirst, kEvent, 6, 9,  9, 0, 1);
+    else CPPUNIT_ASSERT(false);
+    
+    if (i == 0) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+    if (i == 8) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+    if (i == 10) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 6);
+    
+    if (i == 0) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+    if (i == 8) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 4);
+    if (i == 10) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
+  }
+  CPPUNIT_ASSERT(i == 15);
+  
+  {
+    edm::IndexIntoFile indexIntoFile;
+    indexIntoFile.addEntry(fakePHID1, 11, 101, 7, 0); // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 101, 6, 1); // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 101, 5, 2); // Event
+                                                      //Dummy Lumi gets added
+    indexIntoFile.addEntry(fakePHID1, 11, 102, 5, 4); // Event
+                                                      //Another dummy lumi gets added
+    indexIntoFile.addEntry(fakePHID1, 11, 101, 4, 3); // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 101, 0, 0); // Lumi
+    
+    indexIntoFile.addEntry(fakePHID1, 11, 102, 4, 5); // Event
+    indexIntoFile.addEntry(fakePHID1, 11, 102, 0, 1); // Lumi
+    indexIntoFile.addEntry(fakePHID1, 11,   0, 0, 0); // Run
+    indexIntoFile.addEntry(fakePHID2, 11,   0, 0, 1); // Run
+    indexIntoFile.addEntry(fakePHID2, 11, 101, 0, 2); // Lumi
+    indexIntoFile.addEntry(fakePHID2, 11, 102, 0, 3); // Lumi
+    indexIntoFile.addEntry(fakePHID2, 11, 102, 4, 6); // Event
+    indexIntoFile.addEntry(fakePHID2, 11, 102, 0, 4); // Lumi
+    indexIntoFile.addEntry(fakePHID2, 11,   0, 0, 2); // Run
+    indexIntoFile.sortVector_Run_Or_Lumi_Entries();
+
+    edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::firstAppearanceOrder);
+    int i = 0;
+    for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
+      if (i == 0) {
+        check(iterFirst, kRun, 0, 2, 1, 0, 3);
+        CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
+        CPPUNIT_ASSERT(iterFirst.size() == 10);
+      }
+      //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
+      else if (i == 1)  check(iterFirst, kLumi,  0, 2,  1, 0, 3);
+      else if (i == 2)  check(iterFirst, kEvent, 0, 2,  1, 0, 3);
+      else if (i == 3)  check(iterFirst, kEvent, 0, 2,  1, 1, 3);
+      else if (i == 4)  check(iterFirst, kEvent, 0, 2,  1, 2, 3);
+      else if (i == 5)  check(iterFirst, kEvent, 0, 2,  2, 0, 1);
+      else if (i == 6)  check(iterFirst, kLumi,  0, 4,  3, 0, 1);
+      else if (i == 7)  check(iterFirst, kEvent, 0, 4,  3, 0, 1);
+      else if (i == 8) check(iterFirst, kEvent, 0, 4,  4, 0, 1);
+      else if (i == 9) check(iterFirst, kRun,   5, 7, -1, 0, 0);
+      else if (i == 10) check(iterFirst, kRun,   6, 7, -1, 0, 0);
+      else if (i == 11) check(iterFirst, kLumi,  6, 7, -1, 0, 0);
+      else if (i == 12) check(iterFirst, kLumi,  6, 8,  9, 0, 1);
+      else if (i == 13) check(iterFirst, kLumi,  6, 9,  9, 0, 1);
+      else if (i == 14) check(iterFirst, kEvent, 6, 9,  9, 0, 1);
+      else CPPUNIT_ASSERT(false);
+      
+      if (i == 0) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+      if (i == 8) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
+      if (i == 10) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 6);
+      
+      if (i == 0) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+      if (i == 8) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 4);
+      if (i == 10) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
+    }
+    CPPUNIT_ASSERT(i == 15);
+
+  }
+
 }

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -105,4 +105,8 @@ cmsRun ${LOCAL_TEST_DIR}/test_reduced_ProcessHistory_end_cfg.py merged_files.roo
 
 cmsRun ${LOCAL_TEST_DIR}/test_make_multi_lumi_cfg.py || die 'Failure using test_make_multi_lumi_cfg.py' $?
 cmsRun ${LOCAL_TEST_DIR}/test_read_multi_lumi_as_one_cfg.py || die 'Failure using test_read_multi_lumi_as_one_cfg.py' $?
+
+cmsRun ${LOCAL_TEST_DIR}/test_make_overlapping_lumis_cfg.py || die 'Failure using test_make_overlapping_lumis_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/test_read_overlapping_lumis_cfg.py || die 'Failure using test_read_overlapping_lumis_cfg.py' $?
+
 popd

--- a/IOPool/Input/test/test_make_overlapping_lumis_cfg.py
+++ b/IOPool/Input/test/test_make_overlapping_lumis_cfg.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("WRITE")
+
+process.a = cms.EDProducer("IntProducer",
+                             ivalue = cms.int32(10))
+
+process.b = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(100*1000))
+
+process.f = cms.EDFilter("ModuloEventIDFilter", modulo = cms.uint32(3), offset = cms.uint32(2) )
+
+process.p = cms.Path(process.f+process.b, cms.Task(process.a) )
+
+process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("overlap.root"), 
+                               outputCommands = cms.untracked.vstring("drop *", "keep *_b_*_*","keep *_a_*_*") )
+
+process.prnt = cms.OutputModule("AsciiOutputModule", 
+                               outputCommands = cms.untracked.vstring("drop *", "keep *_b_*_*","keep *_a_*_*") )
+
+process.source = cms.Source("EmptySource", numberEventsInLuminosityBlock = cms.untracked.uint32(3))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
+
+process.o = cms.EndPath(process.out)
+process.o2 = cms.EndPath(process.prnt) 
+
+process.options = cms.untracked.PSet( numberOfThreads = cms.untracked.uint32(3),
+                                      numberOfStreams = cms.untracked.uint32(0),
+                                      numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(2))

--- a/IOPool/Input/test/test_read_overlapping_lumis_cfg.py
+++ b/IOPool/Input/test/test_read_overlapping_lumis_cfg.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("READ")
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:overlap.root"))
+process.tst = cms.EDAnalyzer("RunLumiEventChecker",
+                             eventSequence = cms.untracked.VEventID(
+        cms.EventID(1,0,0),
+        cms.EventID(1,1,0),
+        cms.EventID(1,1,1),
+        cms.EventID(1,1,2),
+        cms.EventID(1,1,3),
+        cms.EventID(1,1,0),
+        cms.EventID(1,2,0),
+        cms.EventID(1,2,4),
+        cms.EventID(1,2,5),
+        cms.EventID(1,2,6),
+        cms.EventID(1,2,0),
+        cms.EventID(1,3,0),
+        cms.EventID(1,3,7),
+        cms.EventID(1,3,8),
+        cms.EventID(1,3,9),
+        cms.EventID(1,3,0),
+        cms.EventID(1,4,0),
+        cms.EventID(1,4,10),
+        cms.EventID(1,4,0),
+        cms.EventID(1,0,0)
+        ),
+                             unorderedEvents = cms.untracked.bool(True))
+
+process.out = cms.EndPath(process.tst)


### PR DESCRIPTION
The PoolOutputModule can now write files where an Event from the next LuminosityBlock is written to the output file before the end LuminosityBlock transition occurs. It can even handle interleaving Events from two different LuminosityBlocks before the previous LuminosityBlock ends.

The PoolSource can read files containing such interleaved Events. When reading back, it returns all the Events for one LuminosityBlock before going onto the next LuminosityBlock. [We already did such behavior in the cases where the output file was created by a job which read the LuminosityBlock from different files].