### PR TITLE
CalibTracker: cleanup clang warnings

### DIFF
--- a/CalibTracker/SiPixelTools/plugins/SiPixelErrorsDigisToCalibDigis.cc
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelErrorsDigisToCalibDigis.cc
@@ -146,7 +146,7 @@ SiPixelErrorsDigisToCalibDigis::endJob() {
   if (!outputFilename_.empty() && createOutputFile_)
     {
       edm::LogInfo("SiPixelErrorCalibDigis") << "Writing ROOT file to: " << outputFilename_ << std::endl;
-      if ( &*edm::Service<DQMStore>()) edm::Service<DQMStore>()->save (outputFilename_);
+      if ( edm::Service<DQMStore>().isAvailable() ) edm::Service<DQMStore>()->save (outputFilename_);
     }
 }
 

--- a/CalibTracker/SiPixelTools/plugins/SiPixelFedFillerWordEventNumber.cc
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelFedFillerWordEventNumber.cc
@@ -56,17 +56,17 @@ unsigned int SiPixelFedFillerWordEventNumber ::CalibStatFillWord(unsigned int to
   //     according to the value of the totword.
   if ((status == 0x1)||(status == 0x9)){
     CalibFiller1 = Filler1;
-    if((status == 0x9)){CalibFiller2 = Filler14;}
+    if( status == 0x9 ){CalibFiller2 = Filler14;}
   }
   if ((status == 0x2)||(status == 0xa)){
     CalibFiller1 = Filler2;
-    if((status == 0xa)){CalibFiller2 = Filler24;}
+    if( status == 0xa ){CalibFiller2 = Filler24;}
   }
   if ((status == 0x4)||(status == 0xc)){
     CalibFiller1 = Filler3;
-    if((status == 0xc)){CalibFiller2 = Filler4;}
+    if( status == 0xc ){CalibFiller2 = Filler4;}
   }
-  if ((status == 0x8)){CalibFiller2 = Filler4;}  
+  if ( status == 0x8 ){CalibFiller2 = Filler4;}
   if((status == 0x7)||(status == 0xf)){
     if((Filler1 == Filler2)&&(Filler1 == Filler3)&&(Filler2 == Filler3)){
       CalibFiller1 = Filler1;
@@ -81,7 +81,7 @@ unsigned int SiPixelFedFillerWordEventNumber ::CalibStatFillWord(unsigned int to
     }
   }
   if((status == 0x3)||(status == 0xb)){
-    if((Filler1 == Filler2)){
+    if( Filler1 == Filler2 ){
       CalibFiller1 = Filler1;
       BoolStat = true;
       if(status == 0xb){CalibFiller2 = Filler14;}
@@ -93,7 +93,7 @@ unsigned int SiPixelFedFillerWordEventNumber ::CalibStatFillWord(unsigned int to
     }
   }
   if((status == 0x5)||(status == 0xd)){
-    if((Filler1 == Filler3)){
+    if( Filler1 == Filler3 ){
       CalibFiller1 = Filler1;
       BoolStat = true;
       if(status == 0xd){CalibFiller2 = Filler4;}
@@ -105,7 +105,7 @@ unsigned int SiPixelFedFillerWordEventNumber ::CalibStatFillWord(unsigned int to
     }
   }
   if((status == 0x6)||(status == 0xe)){
-    if((Filler2 == Filler3)){
+    if( Filler2 == Filler3 ){
       CalibFiller1 = Filler2;
       BoolStat = true;
       if(status == 0xe){CalibFiller2 = Filler4;}
@@ -135,7 +135,7 @@ unsigned int SiPixelFedFillerWordEventNumber ::CalibStatFillWord(unsigned int to
     if((status == 0x9)||(status == 0xa)||(status == 0xc)){
       vecFillerWordsEventNumber2.push_back((((CalibFiller2%65536)&(0xff00))>>8));
       edm::LogInfo("AnazrFedFillerWords")<<"Filler2 Event ID:"<<(((CalibFiller2%65536)&(0xff00))>>8)<<std::endl;
-    }else if((status == 0x8)){
+    }else if( status == 0x8 ){
       edm::LogError("AnazrFedFillerWords")<<"Status: "<<status 
                                           <<" No Filler1 found, is not possible get any Event ID Number"
                                           <<std::endl;

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
@@ -78,11 +78,11 @@ public:
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-    virtual void beginJob() ;
+    virtual void beginJob() override;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;   
     void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
     void analyze(const edm::Event&, const edm::EventSetup&) override;
-    virtual void endJob() ;
+    virtual void endJob() override;
     
     void processEvent(const TrackerTopology* topo); //what really does the job
     virtual void checkBookAPVColls(const edm::EventSetup& setup);

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
@@ -78,11 +78,11 @@ public:
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-    virtual void beginJob() override;
+    void beginJob() override;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;   
     void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
     void analyze(const edm::Event&, const edm::EventSetup&) override;
-    virtual void endJob() override;
+    void endJob() override;
     
     void processEvent(const TrackerTopology* topo); //what really does the job
     virtual void checkBookAPVColls(const edm::EventSetup& setup);

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -95,7 +95,7 @@ class SiStripHitEffFromCalibTree : public ConditionDBWriter<SiStripBadStrip> {
     ~SiStripHitEffFromCalibTree() override;
 
   private:
-    virtual void algoBeginJob();
+    virtual void algoBeginJob(const edm::EventSetup&) override;
     void algoEndJob() override;
     void algoAnalyze(const edm::Event& e, const edm::EventSetup& c) override;
     void SetBadComponents(int i, int component,SiStripQuality::BadComponent& BC, std::stringstream ssV[4][19], int NBadComponent[4][19][4]);
@@ -199,7 +199,7 @@ SiStripHitEffFromCalibTree::SiStripHitEffFromCalibTree(const edm::ParameterSet& 
 
 SiStripHitEffFromCalibTree::~SiStripHitEffFromCalibTree() { }
 
-void SiStripHitEffFromCalibTree::algoBeginJob() {
+void SiStripHitEffFromCalibTree::algoBeginJob(const edm::EventSetup&) {
   //I have no idea what goes here
   //fs->make<TTree>("HitEffHistos","Tree of the inefficient hit histograms");
 }

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -95,7 +95,7 @@ class SiStripHitEffFromCalibTree : public ConditionDBWriter<SiStripBadStrip> {
     ~SiStripHitEffFromCalibTree() override;
 
   private:
-    virtual void algoBeginJob(const edm::EventSetup&) override;
+    void algoBeginJob(const edm::EventSetup&) override;
     void algoEndJob() override;
     void algoAnalyze(const edm::Event& e, const edm::EventSetup& c) override;
     void SetBadComponents(int i, int component,SiStripQuality::BadComponent& BC, std::stringstream ssV[4][19], int NBadComponent[4][19][4]);
@@ -223,7 +223,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
   // read bad modules to mask
   ifstream badModules_file;
   set<uint32_t> badModules_list;
-  if(_badModulesFile!="") {
+  if(!_badModulesFile.empty()) {
 	badModules_file.open(_badModulesFile.c_str());
 	uint32_t badmodule_detid;
 	int mods, fiber1, fiber2, fiber3;


### PR DESCRIPTION
Cleanup these clang warnings in CalibTracker packages:
CalibTracker/SiPixelTools/plugins/SiPixelFedFillerWordEventNumber.cc:63:16: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
CalibTracker/SiPixelTools/plugins/SiPixelErrorsDigisToCalibDigis.cc:149:13: warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; pointer may be assumed to always convert to true [-Wundefined-bool-conversion]
CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h:81:18: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc:98:18: warning: 'SiStripHitEffFromCalibTree::algoBeginJob' hides overloaded virtual function [-Woverloaded-virtual]


