### PR TITLE
Read ECAL PF thresholds from DB rather than config file

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,7 +16,7 @@ autoCond = {
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '100X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v3',
+    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '100X_mcRun2cosmics_startup_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -3,6 +3,8 @@
 
 #include <memory>
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h"
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 
@@ -52,6 +54,67 @@ protected:
 
   bool pass(const reco::PFRecHit& hit){
     if (hit.energy()>threshold_) return true;
+
+    return false;
+  }
+};
+
+
+
+//
+//  Quality test that checks threshold read from the DB
+//
+class PFRecHitQTestDBThreshold : public PFRecHitQTestBase {
+public:
+    PFRecHitQTestDBThreshold():eventSetup_(0){
+    }
+
+    PFRecHitQTestDBThreshold(const edm::ParameterSet& iConfig):
+     PFRecHitQTestBase(iConfig),
+     applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals")),    
+     eventSetup_(0){
+    }
+
+    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
+        eventSetup_=&iSetup;
+    }
+
+    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
+      if (applySelectionsToAllCrystals_) return pass(hit);  
+      return fullReadOut or pass(hit);
+    }
+    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
+      return pass(hit);
+    }
+
+    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
+      return pass(hit);
+    }
+    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
+      return pass(hit);
+    }
+
+    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
+      return pass(hit);
+    }
+
+    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
+      return pass(hit);
+    }
+
+protected:
+    
+  bool applySelectionsToAllCrystals_;
+  const edm::EventSetup * eventSetup_;
+
+  
+  bool pass(const reco::PFRecHit& hit){
+
+    edm::ESHandle<EcalPFRecHitThresholds> ths;
+    (*eventSetup_).get<EcalPFRecHitThresholdsRcd>().get(ths);
+
+    float threshold = (*ths)[hit.detId()];
+    if (hit.energy()>threshold) return true;
 
     return false;
   }

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -66,13 +66,13 @@ protected:
 //
 class PFRecHitQTestDBThreshold : public PFRecHitQTestBase {
 public:
-    PFRecHitQTestDBThreshold():eventSetup_(0){
+    PFRecHitQTestDBThreshold():eventSetup_(nullptr){
     }
 
     PFRecHitQTestDBThreshold(const edm::ParameterSet& iConfig):
      PFRecHitQTestBase(iConfig),
      applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals")),    
-     eventSetup_(0){
+     eventSetup_(nullptr){
     }
 
     void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {

--- a/RecoParticleFlow/PFClusterProducer/plugins/RecHitQualityTests.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/RecHitQualityTests.cc
@@ -5,6 +5,7 @@
 
 EDM_REGISTER_PLUGINFACTORY(PFRecHitQTestFactory, "PFRecHitQTestFactory");
 DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestThreshold, "PFRecHitQTestThreshold");
+DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestDBThreshold, "PFRecHitQTestDBThreshold");
 DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestHOThreshold, "PFRecHitQTestHOThreshold");
 
 DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestECAL, "PFRecHitQTestECAL");

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -19,9 +19,8 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
              srFlags = cms.InputTag(""),
              qualityTests = cms.VPSet(
                   cms.PSet(
-                  name = cms.string("PFRecHitQTestECALMultiThreshold"),
-                  thresholds = particle_flow_zero_suppression_ECAL.thresholds,
-                  applySelectionsToAllCrystals = cms.bool(True)
+                  name = cms.string("PFRecHitQTestDBThreshold"),
+                  applySelectionsToAllCrystals=cms.bool(True),    
                   ),
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECAL"),
@@ -38,9 +37,8 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
             srFlags = cms.InputTag(""),
             qualityTests = cms.VPSet(
                  cms.PSet(
-                 name = cms.string("PFRecHitQTestECALMultiThreshold"),
-                 thresholds = particle_flow_zero_suppression_ECAL.thresholds,
-                 applySelectionsToAllCrystals = cms.bool(True)
+                 name = cms.string("PFRecHitQTestDBThreshold"),
+                 applySelectionsToAllCrystals=cms.bool(True),     
                  ),
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECAL"),


### PR DESCRIPTION
Use new record in DB as a source of threshold for Ecal PF reconstruction. Needs new GT as submitted in #22290