### PR TITLE
Fix a.clone(b=dict(c=None))

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -2962,9 +2962,10 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             #test removal of parameter
             m1 = Modifier()
             p = Process("test",m1)
-            p.a = EDAnalyzer("MyAnalyzer", fred = int32(1), wilma = int32(1))
-            m1.toModify(p.a, fred = None)
+            p.a = EDAnalyzer("MyAnalyzer", fred = int32(1), wilma = int32(1), fintstones = PSet(fred = int32(1)))
+            m1.toModify(p.a, fred = None, fintstones = dict(fred = None))
             self.assertEqual(hasattr(p.a, "fred"), False)
+            self.assertEqual(hasattr(p.a.fintstones, "fred"), False)
             self.assertEqual(p.a.wilma.value(),1)
             #test adding a parameter
             m1 = Modifier()

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -636,11 +636,18 @@ def _modifyParametersFromDict(params, newParams, errorRaiser, keyDepth=""):
                     if isinstance(params[key],_Parameterizable):
                         pset = params[key]
                         p =pset.parameters_()
+                        oldkeys = set(p.keys())
                         _modifyParametersFromDict(p,
                                                   value,errorRaiser,
                                                   ("%s.%s" if type(key)==str else "%s[%s]")%(keyDepth,key))
                         for k,v in p.iteritems():
                             setattr(pset,k,v)
+                            try:
+                                oldkeys.remove(k)
+                            except KeyError:
+                                pass
+                        for k in oldkeys:
+                            delattr(pset,k)
                     elif isinstance(params[key],_ValidatingParameterListBase):
                         if any(type(k) != int for k in value.keys()):
                             raise TypeError("Attempted to change a list using a dict whose keys are not integers")
@@ -750,6 +757,7 @@ if __name__ == "__main__":
                         x = dict(a = 7,
                                  c = dict(gamma = 8),
                                  d = __TestType(9)))
+            c = a.clone(x = dict(a=None, c=None))
             self.assertEqual(a.t.value(),1)
             self.assertEqual(a.u.value(),2)
             self.assertEqual(b.t.value(),3)
@@ -760,6 +768,8 @@ if __name__ == "__main__":
             self.assertEqual(b.x.c.gamma.value(),8)
             self.assertEqual(b.x.d.value(),9)
             self.assertEqual(hasattr(b,"w"), False)
+            self.assertEqual(hasattr(c.x,"a"), False)
+            self.assertEqual(hasattr(c.x,"c"), False)
             self.assertRaises(TypeError,a.clone,None,**{"v":1})
         def testModified(self):
             class __TestType(_SimpleParameterTypeBase):

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -642,10 +642,7 @@ def _modifyParametersFromDict(params, newParams, errorRaiser, keyDepth=""):
                                                   ("%s.%s" if type(key)==str else "%s[%s]")%(keyDepth,key))
                         for k,v in p.iteritems():
                             setattr(pset,k,v)
-                            try:
-                                oldkeys.remove(k)
-                            except KeyError:
-                                pass
+                            oldkeys.discard(k)
                         for k in oldkeys:
                             delattr(pset,k)
                     elif isinstance(params[key],_ValidatingParameterListBase):


### PR DESCRIPTION
I noticed that
```
a = cms.PSet(b = cms.PSet(c = ...))
d = a.clone(b=dict(c=None))
```
did not remove `d.b.c`. This PR adds a unit test for this case and attempts to fix it.

Tested in CMSSW_10_1_X_2018-02-27-2300, no changes expected (I assume we have not hit this bug before).