### PR TITLE
Adding plugin to monitor Pixel dead FED channels

### DIFF
--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_harvesting_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_harvesting_cff.py
@@ -5,6 +5,7 @@ from  DQM.SiPixelPhase1Config.SiPixelPhase1OfflineDQM_source_cff import *
 
 siPixelPhase1OfflineDQM_harvesting = cms.Sequence(SiPixelPhase1RawDataHarvester 
                                                 + SiPixelPhase1DigisHarvester 
+                                                + SiPixelPhase1DeadFEDChannelsHarvester
                                                 + SiPixelPhase1ClustersHarvester
                                                 + SiPixelPhase1RecHitsHarvester
                                                 + SiPixelPhase1TrackResidualsHarvester

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
@@ -10,6 +10,7 @@ from DQM.SiPixelPhase1Clusters.SiPixelPhase1Clusters_cfi import *
 from DQM.SiPixelPhase1RecHits.SiPixelPhase1RecHits_cfi import *
 # Residuals
 from DQM.SiPixelPhase1TrackResiduals.SiPixelPhase1TrackResiduals_cfi import *
+from DQM.SiPixelPhase1DeadFEDChannels.SiPixelPhase1DeadFEDChannels_cfi import *
 # Clusters ontrack/offtrack (also general tracks)
 from DQM.SiPixelPhase1TrackClusters.SiPixelPhase1TrackClusters_cfi import *
 # Hit Efficiencies
@@ -24,6 +25,7 @@ IsOffline.enabled=True
 
 siPixelPhase1OfflineDQM_source = cms.Sequence(SiPixelPhase1RawDataAnalyzer
                                             + SiPixelPhase1DigisAnalyzer
+                                            + SiPixelPhase1DeadFEDChannelsAnalyzer
                                             + SiPixelPhase1ClustersAnalyzer
                                             + SiPixelPhase1RecHitsAnalyzer
                                             + SiPixelPhase1TrackResidualsAnalyzer

--- a/DQM/SiPixelPhase1DeadFEDChannels/BuildFile.xml
+++ b/DQM/SiPixelPhase1DeadFEDChannels/BuildFile.xml
@@ -1,0 +1,3 @@
+<use   name="DQMServices/Core"/>
+<use   name="DQM/SiPixelPhase1Common"/>
+<flags   EDM_PLUGIN="1"/>

--- a/DQM/SiPixelPhase1DeadFEDChannels/python/SiPixelPhase1DeadFEDChannels_cfi.py
+++ b/DQM/SiPixelPhase1DeadFEDChannels/python/SiPixelPhase1DeadFEDChannels_cfi.py
@@ -1,0 +1,122 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+import DQM.SiPixelPhase1Common.TriggerEventFlag_cfi as trigger
+
+# this might also go into te Common config,as we do not reference it
+from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
+
+SiPixelPhase1DeadChannelsPerFED = DefaultHisto.clone(
+topFolderName = DefaultHisto.topFolderName.value() +"/FED",
+  name = "Dead Channels",
+  title = "Dead Channels",
+  xlabel = "dead channels",
+  #range_min = 1199.5, range_max = 1338.5, range_nbins = 139,
+  range_min = 0, range_max = 1000, range_nbins = 100,
+  dimensions = 0,
+  specs = VPSet(
+    Specification().groupBy("FED/Event")
+                   .reduce("COUNT")
+                   .groupBy("FED")
+                   .reduce("MEAN")
+                   .groupBy("","EXTEND_X")
+                   .save(), #average dead channels per event and FED                  
+    Specification().groupBy("FED/Event")
+                   .reduce("COUNT")
+                   .groupBy("FED/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("FED","EXTEND_X")
+                   .groupBy("","EXTEND_Y")
+                   .save(), #average dead channels per event and FED per LumiBlock 
+    Specification().groupBy("LumiBlock/Event")
+                   .reduce("COUNT")
+                   .groupBy("LumiBlock") #average number of dead channels per Lumisection
+                   .reduce("MEAN")
+                   .groupBy("", "EXTEND_X")
+                   .save(),
+    Specification().groupBy("PXBarrel/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel")
+                   .save(),
+    Specification().groupBy("PXForward/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward")
+                   .save(),
+    Specification().groupBy("PXBarrel/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel","EXTEND_X")
+                   .save(),
+    Specification().groupBy("PXForward/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward","EXTEND_X")
+                   .save(),
+    Specification().groupBy("PXBarrel/PXLayer/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/PXLayer/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer","EXTEND_X")
+                   .groupBy("PXBarrel", "EXTEND_Y")
+                   .save(),
+    Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/PXDisk/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk","EXTEND_X")
+                   .groupBy("PXForward", "EXTEND_Y")
+                   .save(),
+    Specification().groupBy("FED/LinkInFed/Event")
+                   .reduce("COUNT")
+                   .groupBy("FED/LinkInFed")
+                   .reduce("MEAN")
+                   .groupBy("FED","EXTEND_X")
+                   .groupBy("","EXTEND_Y")
+                   .save()
+    )
+)
+
+
+SiPixelPhase1DeadChannelsPerROC = DefaultHisto.clone(
+topFolderName = DefaultHisto.topFolderName.value() +"/FED",
+  name = "Dead Channels per ROC",
+  title = "Dead Channels per ROC",
+  xlabel = "dead channels per ROC",
+  #range_min = 1199.5, range_max = 1338.5, range_nbins = 139,
+  range_min = 0, range_max = 1000, range_nbins = 100,
+  dimensions = 0,
+  specs = VPSet(
+
+    Specification(PerLayer2D)
+       .groupBy("PXLayer/SignedLadderCoord/SignedModuleCoord")
+       .groupBy("PXLayer/SignedLadderCoord", "EXTEND_X")
+       .groupBy("PXLayer", "EXTEND_Y")
+       .save(),
+    Specification(PerLayer2D)
+       .groupBy("PXRing/SignedBladePanelCoord/SignedDiskCoord")
+       .groupBy("PXRing/SignedBladePanelCoord", "EXTEND_X")
+       .groupBy("PXRing", "EXTEND_Y")
+       .save()
+    )
+)
+
+
+
+# This has to match the order of the names in the C++ enum.
+SiPixelPhase1DeadFEDChannelsConf = cms.VPSet(
+SiPixelPhase1DeadChannelsPerFED ,
+SiPixelPhase1DeadChannelsPerROC 
+)
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+SiPixelPhase1DeadFEDChannelsAnalyzer = DQMEDAnalyzer('SiPixelPhase1DeadFEDChannels',
+        histograms = SiPixelPhase1DeadFEDChannelsConf,
+        geometry = SiPixelPhase1Geometry,
+        triggerflags = trigger.SiPixelPhase1Triggers
+)
+
+SiPixelPhase1DeadFEDChannelsHarvester = DQMEDHarvester("SiPixelPhase1Harvester",
+        histograms = SiPixelPhase1DeadFEDChannelsConf,
+        geometry = SiPixelPhase1Geometry
+)

--- a/DQM/SiPixelPhase1DeadFEDChannels/src/SiPixelPhase1DeadFEDChannels.cc
+++ b/DQM/SiPixelPhase1DeadFEDChannels/src/SiPixelPhase1DeadFEDChannels.cc
@@ -1,0 +1,111 @@
+// -*- C++ -*-
+//
+// Package:    SiPixelPhase1DeadFEDChannels
+// Class:      SiPixelPhase1DeadFEDChannels
+//
+
+// Original Author: F.Fiori
+
+// C++ stuff
+#include <iostream>
+
+// CMSSW stuff
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+
+// DQM Stuff
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+// Input data stuff
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
+
+// PixelDQM Framework
+#include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
+
+namespace {
+
+  class SiPixelPhase1DeadFEDChannels final : public SiPixelPhase1Base {
+    // List of quantities to be plotted. 
+    enum {
+      DEADCHAN,
+      DEADCHANROC
+
+    };
+
+  public:
+
+    explicit SiPixelPhase1DeadFEDChannels(const edm::ParameterSet& conf);
+    void analyze(const edm::Event&, const edm::EventSetup&) override ;
+
+  private:
+    edm::EDGetTokenT<PixelFEDChannelCollection> pixelFEDChannelCollectionToken_;
+
+    bool firstEvent_;
+    const TrackerGeometry* trackerGeometry_ = nullptr;
+    const SiPixelFedCabling* cablingMap = nullptr;
+  };
+
+  SiPixelPhase1DeadFEDChannels::SiPixelPhase1DeadFEDChannels(const edm::ParameterSet& iConfig) :
+    SiPixelPhase1Base(iConfig)
+  {
+    pixelFEDChannelCollectionToken_ = consumes<PixelFEDChannelCollection>(edm::InputTag("siPixelDigis"));
+    firstEvent_=true;
+  }; 
+
+  void SiPixelPhase1DeadFEDChannels::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+    if( !checktrigger(iEvent,iSetup,DCS) ) return;
+    
+    if(firstEvent_){
+      edm::ESHandle<TrackerGeometry> tmpTkGeometry;
+      iSetup.get<TrackerDigiGeometryRecord>().get(tmpTkGeometry);
+      trackerGeometry_=&(*tmpTkGeometry);
+
+      edm::ESHandle<SiPixelFedCablingMap> pixelCabling;
+      iSetup.get<SiPixelFedCablingMapRcd>().get(pixelCabling);
+      cablingMap = pixelCabling.product();
+
+      firstEvent_=false;
+    }
+
+    edm::Handle<edmNew::DetSetVector<PixelFEDChannel> > input;
+
+    iEvent.getByToken(pixelFEDChannelCollectionToken_, input);
+    if (!input.isValid()) return; 
+
+    for(const auto& disabledOnDetId: *input){
+
+      for(const auto& ch: disabledOnDetId) {
+
+	sipixelobjects::CablingPathToDetUnit path = {ch.fed, ch.link, 0};
+
+	for (path.roc=1; path.roc<=(ch.roc_last-ch.roc_first)+1; path.roc++){
+	  const sipixelobjects::PixelROC *roc = cablingMap->findItem(path);
+	  assert(roc!=nullptr);
+	  assert(roc->rawId()==disabledOnDetId.detId());
+
+	  const PixelGeomDetUnit * theGeomDet = dynamic_cast<const PixelGeomDetUnit*> (trackerGeometry_->idToDet(roc->rawId()));
+	  PixelTopology const * topology = &(theGeomDet->specificTopology());
+	  sipixelobjects::LocalPixel::RocRowCol local = {topology->rowsperroc()/2, topology->colsperroc()/2};   //center of ROC
+	  sipixelobjects::GlobalPixel global = roc->toGlobal(sipixelobjects::LocalPixel(local));
+	  histo[DEADCHANROC].fill(disabledOnDetId.detId(), &iEvent, global.col, global.row);
+	}
+
+	histo[DEADCHAN].fill(disabledOnDetId.detId(), &iEvent); // global count
+      }
+    }  
+    
+    histo[DEADCHAN].executePerEventHarvesting(&iEvent);
+  }
+} //namespace
+
+DEFINE_FWK_MODULE(SiPixelPhase1DeadFEDChannels);
+

--- a/DQM/SiPixelPhase1RawData/python/SiPixelPhase1RawData_cfi.py
+++ b/DQM/SiPixelPhase1RawData/python/SiPixelPhase1RawData_cfi.py
@@ -11,27 +11,17 @@ topFolderName = DefaultHisto.topFolderName.value() +"/FED",
   range_min = 0, range_max = 30, range_nbins = 30,
   dimensions = 0,
   specs = VPSet(
-    Specification().groupBy("FED/FED/Event")
-                   .reduce("COUNT")
-                   .groupBy("FED/FED").save(),
-    Specification().groupBy("FED/FED/LinkInFed")
-                   .groupBy("FED/FED", "EXTEND_X")
-                   .save(),
     Specification().groupBy("FED/LinkInFed")
                    .groupBy("FED", "EXTEND_X")
                    .groupBy("", "EXTEND_Y")
-                   .save(),
-    Specification().groupBy("FED/FED/Lumisection")
-    .groupBy("FED/FED","EXTEND_X")
-    .save()
-    .groupBy("")
-    .save()
+                   .save()
   )
 )
 
 SiPixelPhase1RawDataFIFOFull = DefaultHisto.clone(
     topFolderName = DefaultHisto.topFolderName.value() +"/FED", 
     name = "fifofull",
+    enabled=False,
     title = "Type of FIFO full",
     xlabel = "FIFO (data bit #)",
     range_min = -0.5, range_max = 7.5, range_nbins = 8,
@@ -44,6 +34,7 @@ SiPixelPhase1RawDataFIFOFull = DefaultHisto.clone(
 SiPixelPhase1RawDataTBMMessage = DefaultHisto.clone(
   topFolderName = DefaultHisto.topFolderName.value() +"/FED",
   name = "tbmmessage",
+  enabled=False,
   title = "TBM trailer message",
   xlabel = "TBM message (data bit #)",
   range_min = -0.5, range_max = 7.5, range_nbins = 8,
@@ -56,6 +47,7 @@ SiPixelPhase1RawDataTBMMessage = DefaultHisto.clone(
 SiPixelPhase1RawDataTBMType = DefaultHisto.clone(
   topFolderName = DefaultHisto.topFolderName.value() +"/FED",
   name = "tbmtype",
+  enabled=False,
   title = "Type of TBM trailer",
   xlabel = "TBM type",
   range_min = -0.5, range_max = 4.5, range_nbins = 5,
@@ -73,12 +65,8 @@ SiPixelPhase1RawDataTypeNErrors = DefaultHisto.clone(
   range_min = 24.5, range_max = 40.5, range_nbins = 16,
   dimensions = 1,
   specs = VPSet(
-    Specification().groupBy("FED/FED").save(),
     Specification().groupBy("FED")
-                   .groupBy("", "EXTEND_Y").save(),
-    Specification().groupBy("FED/FED/LinkInFed")
-                   .groupBy("FED/FED","EXTEND_Y").save()                  
-
+                   .groupBy("", "EXTEND_Y").save()
   )
 )
 


### PR DESCRIPTION
With this PR a separate plugin to monitor Pixel dead FED channels is added, this is fundamental to keep under control the "stuck TBM" issue and hence to assess the Powercycling procedure and rate for 2018.

In the same PR a significant number of less useful plots is disabled in the RAWData plugin