### PR TITLE
CASTOR reconstruction and simulation updates

### DIFF
--- a/SimCalorimetry/CastorSim/src/CastorAmplifier.cc
+++ b/SimCalorimetry/CastorSim/src/CastorAmplifier.cc
@@ -37,6 +37,7 @@ void CastorAmplifier::amplify(CaloSamples & frame, CLHEP::HepRandomEngine* engin
     double gauss [32]; //big enough
     double noise [32]; //big enough
     double fCperPE = parameters.photoelectronsToAnalog(frame.id());
+    double nominalfCperPE = parameters.getNominalfCperPE();
 
     for (int i = 0; i < frame.size(); i++) { gauss[i] = CLHEP::RandGaussQ::shoot(engine, 0., 1.); }
     if(addNoise_) {
@@ -44,9 +45,9 @@ void CastorAmplifier::amplify(CaloSamples & frame, CLHEP::HepRandomEngine* engin
     }
     for(int tbin = 0; tbin < frame.size(); ++tbin) {
       int capId = (theStartingCapId + tbin)%4;
-      double pedestal = peds->getValue (capId);
+      double pedestal = peds->getValue(capId);
       if(addNoise_) {
-	pedestal += noise [tbin];
+	pedestal += noise [tbin]*(fCperPE/nominalfCperPE);
       }
       frame[tbin] *= fCperPE;
       frame[tbin] += pedestal;
@@ -54,4 +55,3 @@ void CastorAmplifier::amplify(CaloSamples & frame, CLHEP::HepRandomEngine* engin
   }
   LogDebug("CastorAmplifier") << frame;
 }
-

--- a/SimCalorimetry/CastorSim/src/CastorSimParameters.cc
+++ b/SimCalorimetry/CastorSim/src/CastorSimParameters.cc
@@ -11,7 +11,8 @@
 CastorSimParameters::CastorSimParameters(double simHitToPhotoelectrons, double photoelectronsToAnalog,double samplingFactor, double timePhase, bool syncPhase)
 : CaloSimParameters(simHitToPhotoelectrons, photoelectronsToAnalog, samplingFactor, timePhase, 6, 4, false, syncPhase),
   theDbService(nullptr),
-  theSamplingFactor( samplingFactor )
+  theSamplingFactor( samplingFactor ),
+  nominalfCperPE( 1)
 {
 }
 
@@ -19,29 +20,20 @@ CastorSimParameters::CastorSimParameters(double simHitToPhotoelectrons, double p
 CastorSimParameters::CastorSimParameters(const edm::ParameterSet & p)
 :  CaloSimParameters(p),
    theDbService(nullptr),
-   theSamplingFactor( p.getParameter<double>("samplingFactor") )
+   theSamplingFactor( p.getParameter<double>("samplingFactor") ),
+   nominalfCperPE( p.getParameter<double>("photoelectronsToAnalog") )
 {
 }
 
-/*
-double CastorSimParameters::simHitToPhotoelectrons(const DetId & detId) const 
+double CastorSimParameters::getNominalfCperPE() const 
 {
-  // the gain is in units of GeV/fC.  We want a constant with pe/dGeV
-  // pe/dGeV = (GeV/dGeV) / (GeV/fC) / (fC/pe) 
-  double result = CaloSimParameters::simHitToPhotoelectrons(detId);
-  if(HcalGenericDetId(detId).genericSubdet() != HcalGenericDetId::HcalGenForward
-     || HcalGenericDetId(detId).genericSubdet() != HcalGenericDetId::HcalGenCastor)
-    { 
-      result = samplingFactor(detId) / fCtoGeV(detId) / photoelectronsToAnalog();
-    }
-  return result;
+  // return the nominal PMT gain value of CASTOR from the config file.
+  return nominalfCperPE;
 }
-*/
 
 double CastorSimParameters::photoelectronsToAnalog(const DetId & detId) const
 {
   // calculate factor (PMT gain) using sampling factor value & available electron gain
-  //std::cout << " sampling factor = " << theSamplingFactor << " fCtoGeV = " << fCtoGeV(detId) << " and photoelectronsToAnalog = " << theSamplingFactor/fCtoGeV(detId) << std::endl;
   return theSamplingFactor/fCtoGeV(detId);
 }
 
@@ -62,16 +54,6 @@ double CastorSimParameters::fCtoGeV(const DetId & detId) const
   {
     // only one gain will be recorded per channel, so just use capID 0 for now
     result = gains->getValue(0);
-    //  if(doNoise_)
-    ///  {
-    //    result += CLHEP::RandGaussQ::shoot(0.,  gwidths->getValue(0));
-    //  }
   }
   return result;
 }
-/*
-double CastorSimParameters::samplingFactor(const DetId & detId) const {  
-HcalDetId hcalDetId(detId); 
-return theSamplingFactors[hcalDetId.ietaAbs()-theFirstRing];
-}
-*/

--- a/SimCalorimetry/CastorSim/src/CastorSimParameters.h
+++ b/SimCalorimetry/CastorSim/src/CastorSimParameters.h
@@ -12,35 +12,21 @@ public:
 CastorSimParameters(double simHitToPhotoelectrons, double photoelectronsToAnalog, double samplingFactor, double timePhase, bool syncPhase);
 CastorSimParameters(const edm::ParameterSet & p);
 
-  /*
-  CastorSimParameters(double simHitToPhotoelectrons, double photoelectronsToAnalog,
-                double samplingFactor, double timePhase,
-                int readoutFrameSize, int binOfMaximum,
-                bool doPhotostatistics, bool syncPhase,
-                int firstRing, const std::vector<double> & samplingFactors);
- CastorSimParameters(const edm::ParameterSet & p);
-  */
-
 ~CastorSimParameters() override {}
 
 void setDbService(const CastorDbService * service) {theDbService = service;}
 
-//virtual double simHitToPhotoelectrons(const DetId & detId) const;
+double getNominalfCperPE() const;
 
 double photoelectronsToAnalog(const DetId & detId) const override;
 
 double fCtoGeV(const DetId & detId) const;
 
-  /// the ratio of actual incident energy to deposited energy
-  /// in the SimHit
-//  virtual double samplingFactor(const DetId & detId) const;
-
 
 private:
 const CastorDbService * theDbService;
 double theSamplingFactor;
-//std::vector<double> theSamplingFactors;
+double nominalfCperPE;
 };
 
 #endif
-  

--- a/SimGeneral/MixingModule/python/castorDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/castorDigitizer_cfi.py
@@ -12,7 +12,7 @@ castorDigitizer = cms.PSet(
         samplingFactor = cms.double(0.062577), ## GeV/pe
 
         doPhotoStatistics = cms.bool(True),
-        photoelectronsToAnalog = cms.double(4.009),
+        photoelectronsToAnalog = cms.double(4.1718),
         simHitToPhotoelectrons = cms.double(1000.0),
         syncPhase = cms.bool(True),
         timePhase = cms.double(-4.0)


### PR DESCRIPTION
This pull request contains updates for CASTOR reconstruction and simulation.
After integration of this in master, the request is that these changes are also allowed to be back ported to the 76X and 80X branches for use with 2015 and 2016 data.

Reconstruction:
* Fix of RecHitCorrector class: 
   - this class is not used during default reconstruction sequence, but it is important for analyses, as it can very easily reprocess CASTOR objects on the fly during ntuple steps. 
   - the code is updated with: memory leak fix, removal of obsolete factor 2, cleaning up code following comments from a previous PR (https://github.com/cms-sw/cmssw/pull/21860#issuecomment-357963218). 
   - I tried to replace the for loops with range-based for loop, but could not figure it out for the line "for (unsigned int i=0;i<rechits->size();i++)". If someone can provide an alternative for this then please let me know.

Simulation:
* A long time ago we discovered a small bug in the CASTOR noise addition (during digi step), which would overestimate the noise, especially in case of pA and AA collisions. Now finally I managed to prepare the code for submission. This change has already been validated within CASTOR group. These classes are used during production whenever the CASTOR simulation is executed/included in the config.