### PR TITLE
EG Pixel Match Speed updates

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/src/FTSFromVertexToPointFactory.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/FTSFromVertexToPointFactory.cc
@@ -25,7 +25,8 @@ FreeTrajectoryState FTSFromVertexToPointFactory::get( MagneticField const & magF
                                                       float momentum, 
                                                       TrackCharge charge )
 {
-  auto BInTesla = magField.inTesla(xmeas).z();
+  auto magFieldAtPoint = magField.inTesla(xmeas);
+  auto BInTesla = magFieldAtPoint.z();
   GlobalVector xdiff = xmeas - xvert;
   auto mom = momentum*xdiff.unit();
   auto pt = mom.perp();
@@ -48,7 +49,7 @@ FreeTrajectoryState FTSFromVertexToPointFactory::get( MagneticField const & magF
   auto pyNew =  -sa*pxOld + ca*pyOld;
   GlobalVector pNew(pxNew, pyNew, pz);  
 
-  GlobalTrajectoryParameters gp(xmeas, pNew, charge, & magField);
+  GlobalTrajectoryParameters gp(xmeas, pNew, charge, & magField, std::move(magFieldAtPoint));
   
   return FreeTrajectoryState(gp);
 }


### PR DESCRIPTION
Dear All,

Calculuate the B-field at a point is expensive and this function needlessly does it twice because the   GlobalTrajectoryParameters  also calculates the magnetic field when its created:

https://github.com/Sam-Harper/cmssw/blob/3b6bd6fd98d97088bf612c71ae5e81c6d24b32e5/TrackingTools/TrajectoryParametrization/src/GlobalTrajectoryParameters.cc#L35-L37

This class already has an option to pass the already computed value into its constructor, therefore I fixed the function to do this. From tests, this trivial and safe change saved another 1.5% CPU at the HLT. 

   -0.281609      -0.08%         0.79 ms/ev ->         0.60 ms/ev hltEgammaElectronPixelSeedsUnseeded
   -0.227384      -1.40%        16.88 ms/ev ->        13.43 ms/ev hltEgammaElectronPixelSeeds

@Martin-Grunewald 
