### PR TITLE
SimDataFormats/GeneratorProducts: fix bug found by clang self-move warnings

### DIFF
--- a/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
@@ -29,20 +29,20 @@ class LHEEventProduct {
 	  comments_ = std::move(other.comments_);
 	  pdf_ = other.pdf_; // auto_ptr, so copy is actually a move
 	  weights_ = std::move(other.weights_);
-	  originalXWGTUP_ = std::move(originalXWGTUP_);
-	  scales_ = std::move(scales_);
-	  npLO_ = std::move(npLO_);
-	  npNLO_ = std::move(npNLO_);
+	  originalXWGTUP_ = std::move(other.originalXWGTUP_);
+	  scales_ = std::move(other.scales_);
+	  npLO_ = std::move(other.npLO_);
+	  npNLO_ = std::move(other.npNLO_);
 	}
 	LHEEventProduct& operator=(LHEEventProduct&& other) {
 	  hepeup_ = std::move(other.hepeup_);
 	  comments_ = std::move(other.comments_);
 	  pdf_ = other.pdf_; // auto_ptr, so copy is actually a move
 	  weights_ = std::move(other.weights_);
-	  originalXWGTUP_ = std::move(originalXWGTUP_);
-	  scales_ = std::move(scales_);
-	  npLO_ = std::move(npLO_);
-	  npNLO_ = std::move(npNLO_);
+	  originalXWGTUP_ = std::move(other.originalXWGTUP_);
+	  scales_ = std::move(other.scales_);
+	  npLO_ = std::move(other.npLO_);
+	  npNLO_ = std::move(other.npNLO_);
 	  return *this;
 	}
 	~LHEEventProduct() {}


### PR DESCRIPTION

SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h:32:20: warning: explicitly moving variable of type 'double' to itself [-Wself-move]