### PR TITLE
 modify the track type to allow for L2 muons to pass through 

### DIFF
--- a/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducerFromMuons.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducerFromMuons.cc
@@ -1,7 +1,7 @@
 /**  \class L3MuonCandidateProducerFromMuons
  * 
- *   This class takes the tracker muons (which are reco::Muons) 
- *   and creates the correspondent reco::RecoChargedCandidate.
+ *   This class takes reco::Muons and creates
+ *   the correspondent reco::RecoChargedCandidate..
  *
  */
 
@@ -60,8 +60,8 @@ void L3MuonCandidateProducerFromMuons::produce(StreamID, Event& event, const Eve
     LogError(category) << muons.whyFailed()->what();
   } else { 
     for (unsigned int i=0; i<muons->size(); i++) {
-      TrackRef tkref = (*muons)[i].innerTrack();
-
+      TrackRef tkref = (*muons)[i].muonBestTrack(); // avoids crashing in case the muon is SA only. 
+      
       Particle::Charge q = tkref->charge();
       Particle::LorentzVector p4(tkref->px(), tkref->py(), tkref->pz(), tkref->p());
       Particle::Point vtx(tkref->vx(),tkref->vy(), tkref->vz());


### PR DESCRIPTION
backport of  #22183, needed for trigger development. 