### PR TITLE
HCALDQM: Add monitoring for HF TP TDC cut (10_1_X)

### DIFF
--- a/DQM/HcalTasks/interface/HcalOnlineHarvesting.h
+++ b/DQM/HcalTasks/interface/HcalOnlineHarvesting.h
@@ -88,6 +88,11 @@ class HcalOnlineHarvesting : public hcaldqm::DQHarvester
 		//	reportSummaryMap
 		MonitorElement *_reportSummaryMap;
 		MonitorElement *_runSummary;
+
+		// Efficiencies
+		hcaldqm::ContainerSingle2D _cTDCCutEfficiency_depth;
+		hcaldqm::ContainerSingle1D _cTDCCutEfficiency_ieta;
+
 };
 
 #endif

--- a/DQM/HcalTasks/interface/TPTask.h
+++ b/DQM/HcalTasks/interface/TPTask.h
@@ -72,7 +72,6 @@ class TPTask : public hcaldqm::DQTask
 		hcaldqm::filter::HashFilter _filter_VME;
 		hcaldqm::filter::HashFilter _filter_uTCA;
 		hcaldqm::filter::HashFilter _filter_depth0;
-		hcaldqm::filter::HashFilter _filter_HF;
 
 		//	Et/FG
 		hcaldqm::Container1D _cEtData_TTSubdet;

--- a/DQM/HcalTasks/interface/TPTask.h
+++ b/DQM/HcalTasks/interface/TPTask.h
@@ -173,11 +173,9 @@ class TPTask : public hcaldqm::DQTask
 		hcaldqm::ContainerXXX<uint32_t> _xEtMsm, _xFGMsm, _xNumCorr,
 			_xDataMsn, _xDataTotal, _xEmulMsn, _xEmulTotal;
 
-		hcaldqm::ContainerSingle2D _cTDCCutEfficiency_depth;
-		hcaldqm::ContainerSingle1D _cTDCCutEfficiency_ieta;
 		// Temporary storage for occupancy with and without HF TDC cut
-		hcaldqm::ContainerXXX<int> _xOccupancy_HF_depth, _xOccupancyNoTDC_HF_depth;
-		hcaldqm::ContainerXXX<int> _xOccupancy_HF_ieta, _xOccupancyNoTDC_HF_ieta;
+		hcaldqm::ContainerSingle2D _cOccupancy_HF_depth, _cOccupancyNoTDC_HF_depth;
+		hcaldqm::ContainerSingle1D _cOccupancy_HF_ieta, _cOccupancyNoTDC_HF_ieta;
 };
 
 #endif

--- a/DQM/HcalTasks/interface/TPTask.h
+++ b/DQM/HcalTasks/interface/TPTask.h
@@ -38,8 +38,10 @@ class TPTask : public hcaldqm::DQTask
 
 		edm::InputTag		_tagData;
 		edm::InputTag		_tagEmul;
+		edm::InputTag		_tagEmulNoTDCCut;
 		edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokData;
 		edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokEmul;
+		edm::EDGetTokenT<HcalTrigPrimDigiCollection> _tokEmulNoTDCCut;
 
 		//	flag vector
 		std::vector<hcaldqm::flag::Flag> _vflags;
@@ -70,6 +72,7 @@ class TPTask : public hcaldqm::DQTask
 		hcaldqm::filter::HashFilter _filter_VME;
 		hcaldqm::filter::HashFilter _filter_uTCA;
 		hcaldqm::filter::HashFilter _filter_depth0;
+		hcaldqm::filter::HashFilter _filter_HF;
 
 		//	Et/FG
 		hcaldqm::Container1D _cEtData_TTSubdet;
@@ -169,6 +172,12 @@ class TPTask : public hcaldqm::DQTask
 		hcaldqm::ContainerSingle2D _cSummaryvsLS; // online only
 		hcaldqm::ContainerXXX<uint32_t> _xEtMsm, _xFGMsm, _xNumCorr,
 			_xDataMsn, _xDataTotal, _xEmulMsn, _xEmulTotal;
+
+		hcaldqm::ContainerSingle2D _cTDCCutEfficiency_depth;
+		hcaldqm::ContainerSingle1D _cTDCCutEfficiency_ieta;
+		// Temporary storage for occupancy with and without HF TDC cut
+		hcaldqm::ContainerXXX<int> _xOccupancy_HF_depth, _xOccupancyNoTDC_HF_depth;
+		hcaldqm::ContainerXXX<int> _xOccupancy_HF_ieta, _xOccupancyNoTDC_HF_ieta;
 };
 
 #endif

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -156,11 +156,20 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 			MonitorElement* meEfficiency_HF_depth = ib.book2D("TDCCutEfficiency_depth", "TDC cut efficiency", hOccupancy_HF_depth->GetNbinsX(), hOccupancy_HF_depth->GetXaxis()->GetXmin(), hOccupancy_HF_depth->GetXaxis()->GetXmax(), hOccupancy_HF_depth->GetNbinsY(), hOccupancy_HF_depth->GetYaxis()->GetXmin(), hOccupancy_HF_depth->GetYaxis()->GetXmax());
 			meEfficiency_HF_depth->setEfficiencyFlag();
 			TH2F *hEfficiency_HF_depth = meEfficiency_HF_depth->getTH2F();
+			for (int xbin = 1; xbin <= hEfficiency_HF_depth->GetNbinsX(); ++xbin) {
+				hEfficiency_HF_depth->GetXaxis()->SetBinLabel(xbin, hOccupancy_HF_depth->GetXaxis()->GetBinLabel(xbin));
+			}
+			for (int ybin = 1; ybin <= hEfficiency_HF_depth->GetNbinsY(); ++ybin) {
+				hEfficiency_HF_depth->GetYaxis()->SetBinLabel(ybin, hOccupancy_HF_depth->GetYaxis()->GetBinLabel(ybin));
+			}
 			hEfficiency_HF_depth->Divide(hOccupancy_HF_depth, hOccupancyNoTDC_HF_depth);
 
 			MonitorElement* meEfficiency_HF_ieta = ib.book1D("TDCCutEfficiency_ieta", "TDC cut efficiency", hOccupancy_HF_ieta->GetNbinsX(), hOccupancy_HF_ieta->GetXaxis()->GetXmin(), hOccupancy_HF_ieta->GetXaxis()->GetXmax());			
 			meEfficiency_HF_ieta->setEfficiencyFlag();	
 			TH1F *hEfficiency_HF_ieta = meEfficiency_HF_ieta->getTH1F();
+			for (int xbin = 1; xbin <= hEfficiency_HF_ieta->GetNbinsX(); ++xbin) {
+				hEfficiency_HF_ieta->GetXaxis()->SetBinLabel(xbin, hOccupancy_HF_ieta->GetXaxis()->GetBinLabel(xbin));
+			}
 			hEfficiency_HF_ieta->Divide(hOccupancy_HF_ieta, hOccupancyNoTDC_HF_ieta);
 		}	
 	}

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -138,6 +138,29 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 		_runSummary->setBinContent(1,1, int(hcaldqm::flag::fNCDAQ));
 	else
 		_runSummary->setBinContent(1,1, int(hcaldqm::flag::fGOOD));
+
+	// HF TDC TP efficiency
+	if (_vmarks[fTP]) {
+		MonitorElement* meOccupancy_HF_depth = ig.get("Hcal/Run Summary/TPTask/OccupancyHF_depth");
+		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/Run Summary/TPTask/OccupancyHFNoTDCCut_depth");
+		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/Run Summary/TPTask/OccupancyHF_ieta");
+		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/Run Summary/TPTask/OccupancyHFNoTDCCut_ieta");
+
+		TH2F* hOccupancy_HF_depth = meOccupancy_HF_depth->getTH2F();
+		TH2F* hOccupancyNoTDC_HF_depth = meOccupancyNoTDC_HF_depth->getTH2F();
+		TH1F* hOccupancy_HF_ieta = meOccupancy_HF_ieta->getTH1F();
+		TH1F* hOccupancyNoTDC_HF_ieta = meOccupancyNoTDC_HF_ieta->getTH1F();
+
+		TH2F *hEfficiency_HF_depth = (TH2F*)hOccupancy_HF_depth->Clone();
+		hEfficiency_HF_depth->Divide(hOccupancyNoTDC_HF_depth);
+		TH2F *hEfficiency_HF_ieta = (TH2F*)hOccupancy_HF_ieta->Clone();
+		hEfficiency_HF_ieta->Divide(hOccupancyNoTDC_HF_ieta);
+
+		MonitorElement* meEfficiency_HF_depth = ib.book2D("Hcal/Run Summary/TPTask/TDCCutEfficiency_depth", hEfficiency_HF_depth);
+		meEfficiency_HF_depth->setEfficiencyFlag();
+		MonitorElement* meEfficiency_HF_ieta = ib.book2D("Hcal/Run Summary/TPTask/TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
+		meEfficiency_HF_ieta->setEfficiencyFlag();		
+	}
 }
 
 /*

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -152,17 +152,16 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 			TH1F* hOccupancy_HF_ieta = meOccupancy_HF_ieta->getTH1F();
 			TH1F* hOccupancyNoTDC_HF_ieta = meOccupancyNoTDC_HF_ieta->getTH1F();
 
-			TH2F *hEfficiency_HF_depth = (TH2F*)hOccupancy_HF_depth->Clone();
-			hEfficiency_HF_depth->Divide(hOccupancyNoTDC_HF_depth);
-			TH1F *hEfficiency_HF_ieta = (TH1F*)hOccupancy_HF_ieta->Clone();
-			hEfficiency_HF_ieta->Divide(hOccupancyNoTDC_HF_ieta);
-
 			ib.setCurrentFolder("Hcal/TPTask");
-
-			MonitorElement* meEfficiency_HF_depth = ib.book2D("TDCCutEfficiency_depth", hEfficiency_HF_depth);
+			MonitorElement* meEfficiency_HF_depth = ib.book2D("TDCCutEfficiency_depth", "TDC cut efficiency", hOccupancy_HF_depth->GetNbinsX(), hOccupancy_HF_depth->GetXaxis()->GetXmin(), hOccupancy_HF_depth->GetXaxis()->GetXmax(), hOccupancy_HF_depth->GetNbinsY(), hOccupancy_HF_depth->GetYaxis()->GetXmin(), hOccupancy_HF_depth->GetYaxis()->GetXmax());
 			meEfficiency_HF_depth->setEfficiencyFlag();
-			MonitorElement* meEfficiency_HF_ieta = ib.book1D("TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
+			TH2F *hEfficiency_HF_depth = meEfficiency_HF_depth->getTH2F();
+			hEfficiency_HF_depth->Divide(hOccupancy_HF_depth, hOccupancyNoTDC_HF_depth);
+
+			MonitorElement* meEfficiency_HF_ieta = ib.book1D("TDCCutEfficiency_ieta", "TDC cut efficiency", hOccupancy_HF_ieta->GetNbinsX(), hOccupancy_HF_ieta->GetXaxis()->GetXmin(), hOccupancy_HF_ieta->GetXaxis()->GetXmax());			
 			meEfficiency_HF_ieta->setEfficiencyFlag();	
+			TH1F *hEfficiency_HF_ieta = meEfficiency_HF_ieta->getTH1F();
+			hEfficiency_HF_ieta->Divide(hOccupancy_HF_ieta, hOccupancyNoTDC_HF_ieta);
 		}	
 	}
 }

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -142,9 +142,9 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 	// HF TDC TP efficiency
 	if (_vmarks[fTP]) {
 		MonitorElement* meOccupancy_HF_depth = ig.get("Hcal/TPTask/OccupancyHF_depth/OccupancyHF_depth");
-		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/TPTask/OccupancyHFNoTDC_depth/OccupancyHFNoTDCCut_depth");
+		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/TPTask/OccupancyHFNoTDC_depth/OccupancyHFNoTDC_depth");
 		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/TPTask/OccupancyHF_ieta/OccupancyHF_ieta");
-		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/TPTask/OccupancyHFNoTDC_ieta/OccupancyHFNoTDCCut_ieta");
+		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/TPTask/OccupancyHFNoTDC_ieta/OccupancyHFNoTDC_ieta");
 
 		//if (meOccupancy_HF_depth && meOccupancyNoTDC_HF_depth && meOccupancy_HF_ieta && meOccupancyNoTDC_HF_ieta) {
 			TH2F* hOccupancy_HF_depth = meOccupancy_HF_depth->getTH2F();

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -152,25 +152,20 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 			TH1F* hOccupancy_HF_ieta = meOccupancy_HF_ieta->getTH1F();
 			TH1F* hOccupancyNoTDC_HF_ieta = meOccupancyNoTDC_HF_ieta->getTH1F();
 
-			ib.setCurrentFolder("Hcal/TPTask");
-			MonitorElement* meEfficiency_HF_depth = ib.book2D("TDCCutEfficiency_depth", "TDC cut efficiency", hOccupancy_HF_depth->GetNbinsX(), hOccupancy_HF_depth->GetXaxis()->GetXmin(), hOccupancy_HF_depth->GetXaxis()->GetXmax(), hOccupancy_HF_depth->GetNbinsY(), hOccupancy_HF_depth->GetYaxis()->GetXmin(), hOccupancy_HF_depth->GetYaxis()->GetXmax());
-			meEfficiency_HF_depth->setEfficiencyFlag();
-			TH2F *hEfficiency_HF_depth = meEfficiency_HF_depth->getTH2F();
-			for (int xbin = 1; xbin <= hEfficiency_HF_depth->GetNbinsX(); ++xbin) {
-				hEfficiency_HF_depth->GetXaxis()->SetBinLabel(xbin, hOccupancy_HF_depth->GetXaxis()->GetBinLabel(xbin));
-			}
-			for (int ybin = 1; ybin <= hEfficiency_HF_depth->GetNbinsY(); ++ybin) {
-				hEfficiency_HF_depth->GetYaxis()->SetBinLabel(ybin, hOccupancy_HF_depth->GetYaxis()->GetBinLabel(ybin));
-			}
-			hEfficiency_HF_depth->Divide(hOccupancy_HF_depth, hOccupancyNoTDC_HF_depth);
+			TH2F *hEfficiency_HF_depth = (TH2F*)hOccupancy_HF_depth->Clone();
+			hEfficiency_HF_depth->Divide(hOccupancyNoTDC_HF_depth);
+			TH1F *hEfficiency_HF_ieta = (TH1F*)hOccupancy_HF_ieta->Clone();
+			hEfficiency_HF_ieta->Divide(hOccupancyNoTDC_HF_ieta);
 
-			MonitorElement* meEfficiency_HF_ieta = ib.book1D("TDCCutEfficiency_ieta", "TDC cut efficiency", hOccupancy_HF_ieta->GetNbinsX(), hOccupancy_HF_ieta->GetXaxis()->GetXmin(), hOccupancy_HF_ieta->GetXaxis()->GetXmax());			
+			ib.setCurrentFolder("Hcal/TPTask");
+
+			MonitorElement* meEfficiency_HF_depth = ib.book2D("TDCCutEfficiency_depth", hEfficiency_HF_depth);
+			meEfficiency_HF_depth->setEfficiencyFlag();
+			MonitorElement* meEfficiency_HF_ieta = ib.book1D("TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
 			meEfficiency_HF_ieta->setEfficiencyFlag();	
-			TH1F *hEfficiency_HF_ieta = meEfficiency_HF_ieta->getTH1F();
-			for (int xbin = 1; xbin <= hEfficiency_HF_ieta->GetNbinsX(); ++xbin) {
-				hEfficiency_HF_ieta->GetXaxis()->SetBinLabel(xbin, hOccupancy_HF_ieta->GetXaxis()->GetBinLabel(xbin));
-			}
-			hEfficiency_HF_ieta->Divide(hOccupancy_HF_ieta, hOccupancyNoTDC_HF_ieta);
+
+			delete hEfficiency_HF_depth;
+			delete hEfficiency_HF_ieta;
 		}	
 	}
 }

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -141,10 +141,10 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 
 	// HF TDC TP efficiency
 	if (_vmarks[fTP]) {
-		MonitorElement* meOccupancy_HF_depth = ig.get("Hcal/Run Summary/TPTask/OccupancyHF_depth");
-		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/Run Summary/TPTask/OccupancyHFNoTDCCut_depth");
-		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/Run Summary/TPTask/OccupancyHF_ieta");
-		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/Run Summary/TPTask/OccupancyHFNoTDCCut_ieta");
+		MonitorElement* meOccupancy_HF_depth = ig.get("Hcal/Run summary/TPTask/OccupancyHF_depth");
+		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/Run summary/TPTask/OccupancyHFNoTDCCut_depth");
+		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/Run summary/TPTask/OccupancyHF_ieta");
+		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/Run summary/TPTask/OccupancyHFNoTDCCut_ieta");
 
 		TH2F* hOccupancy_HF_depth = meOccupancy_HF_depth->getTH2F();
 		TH2F* hOccupancyNoTDC_HF_depth = meOccupancyNoTDC_HF_depth->getTH2F();
@@ -156,9 +156,9 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 		TH2F *hEfficiency_HF_ieta = (TH2F*)hOccupancy_HF_ieta->Clone();
 		hEfficiency_HF_ieta->Divide(hOccupancyNoTDC_HF_ieta);
 
-		MonitorElement* meEfficiency_HF_depth = ib.book2D("Hcal/Run Summary/TPTask/TDCCutEfficiency_depth", hEfficiency_HF_depth);
+		MonitorElement* meEfficiency_HF_depth = ib.book2D("Hcal/Run summary/TPTask/TDCCutEfficiency_depth", hEfficiency_HF_depth);
 		meEfficiency_HF_depth->setEfficiencyFlag();
-		MonitorElement* meEfficiency_HF_ieta = ib.book2D("Hcal/Run Summary/TPTask/TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
+		MonitorElement* meEfficiency_HF_ieta = ib.book2D("Hcal/Run summary/TPTask/TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
 		meEfficiency_HF_ieta->setEfficiencyFlag();		
 	}
 }

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -142,9 +142,9 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 	// HF TDC TP efficiency
 	if (_vmarks[fTP]) {
 		MonitorElement* meOccupancy_HF_depth = ig.get("Hcal/TPTask/OccupancyHF_depth/OccupancyHF_depth");
-		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/TPTask/OccupancyHFNoTDCCut_depth/OccupancyHFNoTDCCut_depth");
+		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/TPTask/OccupancyHFNoTDC_depth/OccupancyHFNoTDCCut_depth");
 		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/TPTask/OccupancyHF_ieta/OccupancyHF_ieta");
-		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/TPTask/OccupancyHFNoTDCCut_ieta/OccupancyHFNoTDCCut_ieta");
+		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/TPTask/OccupancyHFNoTDC_ieta/OccupancyHFNoTDCCut_ieta");
 
 		//if (meOccupancy_HF_depth && meOccupancyNoTDC_HF_depth && meOccupancy_HF_ieta && meOccupancyNoTDC_HF_ieta) {
 			TH2F* hOccupancy_HF_depth = meOccupancy_HF_depth->getTH2F();

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -141,10 +141,10 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 
 	// HF TDC TP efficiency
 	if (_vmarks[fTP]) {
-		MonitorElement* meOccupancy_HF_depth = ig.get("Hcal/Run summary/TPTask/OccupancyHF_depth/OccupancyHF_depth");
-		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/Run summary/TPTask/OccupancyHFNoTDCCut_depth/OccupancyHFNoTDCCut_depth");
-		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/Run summary/TPTask/OccupancyHF_ieta/OccupancyHF_ieta");
-		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/Run summary/TPTask/OccupancyHFNoTDCCut_ieta/OccupancyHFNoTDCCut_ieta");
+		MonitorElement* meOccupancy_HF_depth = ig.get("Hcal/TPTask/OccupancyHF_depth/OccupancyHF_depth");
+		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/TPTask/OccupancyHFNoTDCCut_depth/OccupancyHFNoTDCCut_depth");
+		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/TPTask/OccupancyHF_ieta/OccupancyHF_ieta");
+		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/TPTask/OccupancyHFNoTDCCut_ieta/OccupancyHFNoTDCCut_ieta");
 
 		//if (meOccupancy_HF_depth && meOccupancyNoTDC_HF_depth && meOccupancy_HF_ieta && meOccupancyNoTDC_HF_ieta) {
 			TH2F* hOccupancy_HF_depth = meOccupancy_HF_depth->getTH2F();

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -157,9 +157,11 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 			TH2F *hEfficiency_HF_ieta = (TH2F*)hOccupancy_HF_ieta->Clone();
 			hEfficiency_HF_ieta->Divide(hOccupancyNoTDC_HF_ieta);
 
-			MonitorElement* meEfficiency_HF_depth = ib.book2D("Hcal/Run summary/TPTask/TDCCutEfficiency_depth", hEfficiency_HF_depth);
+			ib.setCurrentFolder("Hcal/TPTask");
+
+			MonitorElement* meEfficiency_HF_depth = ib.book2D("TDCCutEfficiency_depth", hEfficiency_HF_depth);
 			meEfficiency_HF_depth->setEfficiencyFlag();
-			MonitorElement* meEfficiency_HF_ieta = ib.book2D("Hcal/Run summary/TPTask/TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
+			MonitorElement* meEfficiency_HF_ieta = ib.book2D("TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
 			meEfficiency_HF_ieta->setEfficiencyFlag();	
 		//}	
 	}

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -141,10 +141,10 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 
 	// HF TDC TP efficiency
 	if (_vmarks[fTP]) {
-		MonitorElement* meOccupancy_HF_depth = ig.get("Hcal/Run summary/TPTask/OccupancyHF_depth");
-		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/Run summary/TPTask/OccupancyHFNoTDCCut_depth");
-		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/Run summary/TPTask/OccupancyHF_ieta");
-		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/Run summary/TPTask/OccupancyHFNoTDCCut_ieta");
+		MonitorElement* meOccupancy_HF_depth = ig.get("Hcal/Run summary/TPTask/OccupancyHF_depth/OccupancyHF_depth");
+		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/Run summary/TPTask/OccupancyHFNoTDCCut_depth/OccupancyHFNoTDCCut_depth");
+		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/Run summary/TPTask/OccupancyHF_ieta/OccupancyHF_ieta");
+		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/Run summary/TPTask/OccupancyHFNoTDCCut_ieta/OccupancyHFNoTDCCut_ieta");
 
 		if (meOccupancy_HF_depth && meOccupancyNoTDC_HF_depth && meOccupancy_HF_ieta && meOccupancyNoTDC_HF_ieta) {
 			TH2F* hOccupancy_HF_depth = meOccupancy_HF_depth->getTH2F();

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -161,7 +161,7 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 
 			MonitorElement* meEfficiency_HF_depth = ib.book2D("TDCCutEfficiency_depth", hEfficiency_HF_depth);
 			meEfficiency_HF_depth->setEfficiencyFlag();
-			MonitorElement* meEfficiency_HF_ieta = ib.book2D("TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
+			MonitorElement* meEfficiency_HF_ieta = ib.book1D("TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
 			meEfficiency_HF_ieta->setEfficiencyFlag();	
 		//}	
 	}

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -154,7 +154,7 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 
 			TH2F *hEfficiency_HF_depth = (TH2F*)hOccupancy_HF_depth->Clone();
 			hEfficiency_HF_depth->Divide(hOccupancyNoTDC_HF_depth);
-			TH2F *hEfficiency_HF_ieta = (TH2F*)hOccupancy_HF_ieta->Clone();
+			TH1F *hEfficiency_HF_ieta = (TH1F*)hOccupancy_HF_ieta->Clone();
 			hEfficiency_HF_ieta->Divide(hOccupancyNoTDC_HF_ieta);
 
 			ib.setCurrentFolder("Hcal/TPTask");

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -146,20 +146,22 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/Run summary/TPTask/OccupancyHF_ieta");
 		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/Run summary/TPTask/OccupancyHFNoTDCCut_ieta");
 
-		TH2F* hOccupancy_HF_depth = meOccupancy_HF_depth->getTH2F();
-		TH2F* hOccupancyNoTDC_HF_depth = meOccupancyNoTDC_HF_depth->getTH2F();
-		TH1F* hOccupancy_HF_ieta = meOccupancy_HF_ieta->getTH1F();
-		TH1F* hOccupancyNoTDC_HF_ieta = meOccupancyNoTDC_HF_ieta->getTH1F();
+		if (meOccupancy_HF_depth && meOccupancyNoTDC_HF_depth && meOccupancy_HF_ieta && meOccupancyNoTDC_HF_ieta) {
+			TH2F* hOccupancy_HF_depth = meOccupancy_HF_depth->getTH2F();
+			TH2F* hOccupancyNoTDC_HF_depth = meOccupancyNoTDC_HF_depth->getTH2F();
+			TH1F* hOccupancy_HF_ieta = meOccupancy_HF_ieta->getTH1F();
+			TH1F* hOccupancyNoTDC_HF_ieta = meOccupancyNoTDC_HF_ieta->getTH1F();
 
-		TH2F *hEfficiency_HF_depth = (TH2F*)hOccupancy_HF_depth->Clone();
-		hEfficiency_HF_depth->Divide(hOccupancyNoTDC_HF_depth);
-		TH2F *hEfficiency_HF_ieta = (TH2F*)hOccupancy_HF_ieta->Clone();
-		hEfficiency_HF_ieta->Divide(hOccupancyNoTDC_HF_ieta);
+			TH2F *hEfficiency_HF_depth = (TH2F*)hOccupancy_HF_depth->Clone();
+			hEfficiency_HF_depth->Divide(hOccupancyNoTDC_HF_depth);
+			TH2F *hEfficiency_HF_ieta = (TH2F*)hOccupancy_HF_ieta->Clone();
+			hEfficiency_HF_ieta->Divide(hOccupancyNoTDC_HF_ieta);
 
-		MonitorElement* meEfficiency_HF_depth = ib.book2D("Hcal/Run summary/TPTask/TDCCutEfficiency_depth", hEfficiency_HF_depth);
-		meEfficiency_HF_depth->setEfficiencyFlag();
-		MonitorElement* meEfficiency_HF_ieta = ib.book2D("Hcal/Run summary/TPTask/TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
-		meEfficiency_HF_ieta->setEfficiencyFlag();		
+			MonitorElement* meEfficiency_HF_depth = ib.book2D("Hcal/Run summary/TPTask/TDCCutEfficiency_depth", hEfficiency_HF_depth);
+			meEfficiency_HF_depth->setEfficiencyFlag();
+			MonitorElement* meEfficiency_HF_ieta = ib.book2D("Hcal/Run summary/TPTask/TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
+			meEfficiency_HF_ieta->setEfficiencyFlag();	
+		}	
 	}
 }
 

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -146,7 +146,7 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/TPTask/OccupancyHF_ieta/OccupancyHF_ieta");
 		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/TPTask/OccupancyHFNoTDC_ieta/OccupancyHFNoTDC_ieta");
 
-		//if (meOccupancy_HF_depth && meOccupancyNoTDC_HF_depth && meOccupancy_HF_ieta && meOccupancyNoTDC_HF_ieta) {
+		if (meOccupancy_HF_depth && meOccupancyNoTDC_HF_depth && meOccupancy_HF_ieta && meOccupancyNoTDC_HF_ieta) {
 			TH2F* hOccupancy_HF_depth = meOccupancy_HF_depth->getTH2F();
 			TH2F* hOccupancyNoTDC_HF_depth = meOccupancyNoTDC_HF_depth->getTH2F();
 			TH1F* hOccupancy_HF_ieta = meOccupancy_HF_ieta->getTH1F();
@@ -163,7 +163,7 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 			meEfficiency_HF_depth->setEfficiencyFlag();
 			MonitorElement* meEfficiency_HF_ieta = ib.book1D("TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
 			meEfficiency_HF_ieta->setEfficiencyFlag();	
-		//}	
+		}	
 	}
 }
 

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -146,7 +146,7 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/Run summary/TPTask/OccupancyHF_ieta/OccupancyHF_ieta");
 		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/Run summary/TPTask/OccupancyHFNoTDCCut_ieta/OccupancyHFNoTDCCut_ieta");
 
-		if (meOccupancy_HF_depth && meOccupancyNoTDC_HF_depth && meOccupancy_HF_ieta && meOccupancyNoTDC_HF_ieta) {
+		//if (meOccupancy_HF_depth && meOccupancyNoTDC_HF_depth && meOccupancy_HF_ieta && meOccupancyNoTDC_HF_ieta) {
 			TH2F* hOccupancy_HF_depth = meOccupancy_HF_depth->getTH2F();
 			TH2F* hOccupancyNoTDC_HF_depth = meOccupancyNoTDC_HF_depth->getTH2F();
 			TH1F* hOccupancy_HF_ieta = meOccupancy_HF_ieta->getTH1F();
@@ -161,7 +161,7 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 			meEfficiency_HF_depth->setEfficiencyFlag();
 			MonitorElement* meEfficiency_HF_ieta = ib.book2D("Hcal/Run summary/TPTask/TDCCutEfficiency_ieta", hEfficiency_HF_ieta);
 			meEfficiency_HF_ieta->setEfficiencyFlag();	
-		}	
+		//}	
 	}
 }
 

--- a/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
+++ b/DQM/HcalTasks/plugins/HcalOnlineHarvesting.cc
@@ -141,10 +141,10 @@ HcalOnlineHarvesting::HcalOnlineHarvesting(edm::ParameterSet const& ps) :
 
 	// HF TDC TP efficiency
 	if (_vmarks[fTP]) {
-		MonitorElement* meOccupancy_HF_depth = ig.get("Hcal/TPTask/OccupancyHF_depth/OccupancyHF_depth");
-		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/TPTask/OccupancyHFNoTDC_depth/OccupancyHFNoTDC_depth");
-		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/TPTask/OccupancyHF_ieta/OccupancyHF_ieta");
-		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/TPTask/OccupancyHFNoTDC_ieta/OccupancyHFNoTDC_ieta");
+		MonitorElement* meOccupancy_HF_depth = ig.get("Hcal/TPTask/OccupancyDataHF_depth/OccupancyDataHF_depth");
+		MonitorElement* meOccupancyNoTDC_HF_depth = ig.get("Hcal/TPTask/OccupancyEmulHFNoTDC_depth/OccupancyEmulHFNoTDC_depth");
+		MonitorElement* meOccupancy_HF_ieta = ig.get("Hcal/TPTask/OccupancyDataHF_ieta/OccupancyDataHF_ieta");
+		MonitorElement* meOccupancyNoTDC_HF_ieta = ig.get("Hcal/TPTask/OccupancyEmulHFNoTDC_ieta/OccupancyEmulHFNoTDC_ieta");
 
 		if (meOccupancy_HF_depth && meOccupancyNoTDC_HF_depth && meOccupancy_HF_ieta && meOccupancyNoTDC_HF_ieta) {
 			TH2F* hOccupancy_HF_depth = meOccupancy_HF_depth->getTH2F();

--- a/DQM/HcalTasks/plugins/TPTask.cc
+++ b/DQM/HcalTasks/plugins/TPTask.cc
@@ -556,10 +556,6 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 		_xEmulMsn.book(_emap);
 		_xEmulTotal.book(_emap);
 
-		//std::vector<uint32_t> vHF;
-		//vHF.push_back(HcalTrigTowerDetId(-41, 0, 0).rawId());
-		//_filter_HF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fTTSubdet, vHF);
-
 		_cOccupancy_HF_depth.book(ib, _subsystem);
 		_cOccupancyNoTDC_HF_depth.book(ib, _subsystem);
 		_cOccupancy_HF_ieta.book(ib, _subsystem);

--- a/DQM/HcalTasks/plugins/TPTask.cc
+++ b/DQM/HcalTasks/plugins/TPTask.cc
@@ -677,9 +677,11 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 		_cOccupancyData_depthlike.fill(tid);
 
 		if (_ptype == fOnline) {
-			if (soiEt_d > 0) {
-				_cOccupancy_HF_depth.fill(tid);
-				_cOccupancy_HF_ieta.fill(tid);
+			if (tid.ietaAbs()>=29) {
+				if (soiEt_d > 0) {
+					_cOccupancy_HF_depth.fill(tid);
+					_cOccupancy_HF_ieta.fill(tid);
+				}
 			}
 		}
 		if (_ptype != fOffline) { // hidefed2crate
@@ -825,9 +827,11 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 				continue;
 			}
 			int soiEt_e = it->SOI_compressedEt();
-			if (soiEt_e > 0) {
-				_cOccupancyNoTDC_HF_depth.fill(tid);
-				_cOccupancyNoTDC_HF_ieta.fill(tid);
+			if (tid.ietaAbs() >= 29) {
+				if (soiEt_e > 0) {
+					_cOccupancyNoTDC_HF_depth.fill(tid);
+					_cOccupancyNoTDC_HF_ieta.fill(tid);
+				}
 			}
 		}
 	}

--- a/DQM/HcalTasks/plugins/TPTask.cc
+++ b/DQM/HcalTasks/plugins/TPTask.cc
@@ -677,8 +677,10 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 		_cOccupancyData_depthlike.fill(tid);
 
 		if (_ptype == fOnline) {
-			_cOccupancy_HF_depth.fill(tid);
-			_cOccupancy_HF_ieta.fill(tid);
+			if (soiEt_d > 0) {
+				_cOccupancy_HF_depth.fill(tid);
+				_cOccupancy_HF_ieta.fill(tid);
+			}
 		}
 		if (_ptype != fOffline) { // hidefed2crate
 			if (eid.isVMEid())
@@ -822,8 +824,11 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 			{
 				continue;
 			}
-			_cOccupancyNoTDC_HF_depth.fill(tid);
-			_cOccupancyNoTDC_HF_ieta.fill(tid);
+			int soiEt_e = it->SOI_compressedEt();
+			if (soiEt_e > 0) {
+				_cOccupancyNoTDC_HF_depth.fill(tid);
+				_cOccupancyNoTDC_HF_ieta.fill(tid);
+			}
 		}
 	}
 

--- a/DQM/HcalTasks/plugins/TPTask.cc
+++ b/DQM/HcalTasks/plugins/TPTask.cc
@@ -287,18 +287,18 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
 
-		_cOccupancy_HF_depth.initialize(_name, "OccupancyHF_depth", 
+		_cOccupancy_HF_depth.initialize(_name, "OccupancyDataHF_depth", 
 			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
 			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cOccupancyNoTDC_HF_depth.initialize(_name, "OccupancyHFNoTDC_depth", 
+		_cOccupancyNoTDC_HF_depth.initialize(_name, "OccupancyEmulHFNoTDC_depth", 
 			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
 			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTiphi),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cOccupancy_HF_ieta.initialize(_name, "OccupancyHF_ieta", 
+		_cOccupancy_HF_ieta.initialize(_name, "OccupancyDataHF_ieta", 
 			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0),
-		_cOccupancyNoTDC_HF_ieta.initialize(_name, "OccupancyHFNoTDC_ieta", 
+		_cOccupancyNoTDC_HF_ieta.initialize(_name, "OccupancyEmulHFNoTDC_ieta", 
 			new hcaldqm::quantity::TrigTowerQuantity(hcaldqm::quantity::fTTieta),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 	}
@@ -634,8 +634,11 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 		//	Explicit check on the DetIds present in the Collection
 		HcalTrigTowerDetId tid = it->id();
 		uint32_t rawid = _ehashmap.lookup(tid);
-		if (rawid==0)
-		{meUnknownIds1LS->Fill(1); _unknownIdsPresent = true; continue;}
+		if (rawid==0) {
+			meUnknownIds1LS->Fill(1); 
+			_unknownIdsPresent = true; 
+			continue;
+		}
 		HcalElectronicsId const& eid(rawid);
 		if (tid.ietaAbs()>=29)
 			rawidHFValid = tid.rawId();
@@ -648,7 +651,7 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 		if (tid.version()==0 && tid.ietaAbs()>=29)
 		{
 			//	do this only for online processing
-			if (_ptype==fOnline)
+			if (_ptype == fOnline)
 			{
 				_cOccupancyData2x3_depthlike.fill(tid);
 				HcalTrigPrimDigiCollection::const_iterator jt=cemul->find(tid);
@@ -673,8 +676,10 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 		_cEtData_depthlike.fill(tid, soiEt_d);
 		_cOccupancyData_depthlike.fill(tid);
 
-		_cOccupancy_HF_depth.fill(tid);
-		_cOccupancy_HF_ieta.fill(tid);
+		if (_ptype == fOnline) {
+			_cOccupancy_HF_depth.fill(tid);
+			_cOccupancy_HF_ieta.fill(tid);
+		}
 		if (_ptype != fOffline) { // hidefed2crate
 			if (eid.isVMEid())
 			{

--- a/DQM/HcalTasks/plugins/TPTask.cc
+++ b/DQM/HcalTasks/plugins/TPTask.cc
@@ -594,14 +594,17 @@ TPTask::TPTask(edm::ParameterSet const& ps):
 	edm::Handle<HcalTrigPrimDigiCollection> cemul;
 	edm::Handle<HcalTrigPrimDigiCollection> cemul_noTDCCut;
 	if (!e.getByToken(_tokData, cdata))
-		_logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available"
+		_logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available: "
 			+ _tagData.label() + " " + _tagData.instance());
 	if (!e.getByToken(_tokEmul, cemul))
-		_logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available"
+		_logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available: "
 			+ _tagEmul.label() + " " + _tagEmul.instance());
-	if (!e.getByToken(_tokEmulNoTDCCut, cemul_noTDCCut))
-		_logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available"
-			+ _tagEmulNoTDCCut.label() + " " + _tagEmulNoTDCCut.instance());
+	if (_ptype == fOnline) {
+		if (!e.getByToken(_tokEmulNoTDCCut, cemul_noTDCCut)) {
+			_logger.dqmthrow("Collection HcalTrigPrimDigiCollection isn't available: "
+				+ _tagEmulNoTDCCut.label() + " " + _tagEmulNoTDCCut.instance());
+		}
+	}
 
 	//	extract some info per event
 	int bx = e.bunchCrossing();

--- a/DQM/HcalTasks/python/TPTask.py
+++ b/DQM/HcalTasks/python/TPTask.py
@@ -18,6 +18,7 @@ tpTask = cms.EDAnalyzer(
 	#	tags
 	tagData = cms.untracked.InputTag("hcalDigis"),
 	tagEmul = cms.untracked.InputTag("emulTPDigis"),
+	tagEmulNoTDCCut = cms.untracked.InputTag("emulTPDigisNoTDCCut"),
 
 	#	cut to put on Et to get the occupancy
 	cutEt = cms.untracked.int32(3),

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -49,7 +49,6 @@ process = customise(process)
 process.DQMStore.verbose = 0
 process.source.minEventsPerLumi=100
 
-
 #-------------------------------------
 #	CMSSW/Hcal non-DQM Related Module import
 #-------------------------------------
@@ -100,8 +99,13 @@ process.emulTPDigis.RunZS = cms.bool(True)
 process.emulTPDigis.ZS_threshold = cms.uint32(0)
 process.hcalDigis.InputLabel = rawTag
 process.emulTPDigisNoTDCCut = process.emulTPDigis.clone()
-process.emulTPDigisNoTDCCut.ADCThresholdHF = cms.uint32(255)
-process.emulTPDigisNoTDCCut.TDCMaskHF = cms.uint64(0xFFFFFFFFFFFFFFFF)
+#process.emulTPDigisNoTDCCut.ADCThresholdHF = cms.uint32(255)
+#process.emulTPDigisNoTDCCut.TDCMaskHF = cms.uint64(0xFFFFFFFFFFFFFFFF)
+
+# For testing on cosmics: 12.5 ns cut = 50% efficiency
+process.emulTPDigisNoTDCCut.ADCThresholdHF = cms.uint32(0)
+process.emulTPDigisNoTDCCut.TDCMaskHF = cms.uint64(0xFFFFFFFFFE000000)
+
 
 
 # Exclude the laser FEDs. They contaminate the QIE10/11 digi collections. 

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -99,12 +99,8 @@ process.emulTPDigis.RunZS = cms.bool(True)
 process.emulTPDigis.ZS_threshold = cms.uint32(0)
 process.hcalDigis.InputLabel = rawTag
 process.emulTPDigisNoTDCCut = process.emulTPDigis.clone()
-#process.emulTPDigisNoTDCCut.ADCThresholdHF = cms.uint32(255)
-#process.emulTPDigisNoTDCCut.TDCMaskHF = cms.uint64(0xFFFFFFFFFFFFFFFF)
-
-# For testing on cosmics: 12.5 ns cut = 50% efficiency
-process.emulTPDigisNoTDCCut.ADCThresholdHF = cms.uint32(0)
-process.emulTPDigisNoTDCCut.TDCMaskHF = cms.uint64(0xFFFFFFFFFE000000)
+process.emulTPDigisNoTDCCut.ADCThresholdHF = cms.uint32(255)
+process.emulTPDigisNoTDCCut.TDCMaskHF = cms.uint64(0xFFFFFFFFFFFFFFFF)
 
 
 

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -99,6 +99,10 @@ process.emulTPDigis.inputUpgradeLabel = cms.VInputTag("hcalDigis", "hcalDigis")
 process.emulTPDigis.RunZS = cms.bool(True)
 process.emulTPDigis.ZS_threshold = cms.uint32(0)
 process.hcalDigis.InputLabel = rawTag
+process.emulTPDigisNoTDCCut = process.emulTPDigis.clone()
+process.emulTPDigisNoTDCCut.ADCThresholdHF = cms.uint32(255)
+process.emulTPDigisNoTDCCut.TDCMaskHF = cms.uint64(0xFFFFFFFFFFFFFFFF)
+
 
 # Exclude the laser FEDs. They contaminate the QIE10/11 digi collections. 
 #from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
@@ -177,6 +181,7 @@ process.preRecoPath = cms.Path(
 		process.hcalDigis
 		*process.castorDigis
 		*process.emulTPDigis
+		*process.emulTPDigisNoTDCCut
 )
 
 process.dqmPath = cms.EndPath(


### PR DESCRIPTION
Adds monitoring plots for HF TP TDC cut: efficiency of cut vs. ieta vs iphi and ieta. Also adds the numerator and denominator of the efficiency calculation (i.e. data TP occupancy / emulated TP occupancy with no TDC cut).