### PR TITLE
Run2-alca120 Modify the output contents of AlCaReco streams

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalHBHEMuonFilter_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalHBHEMuonFilter_Output_cff.py
@@ -10,7 +10,6 @@ OutALCARECOHcalCalHBHEMuonFilter_noDrop = cms.PSet(
         ),
     outputCommands = cms.untracked.vstring(
         'keep *_hbhereco_*_*',
-        'keep *_hbheprereco_*_*',
         'keep *_ecalRecHit_*_*',
         'keep *_offlineBeamSpot_*_*',
         'keep *_TriggerResults_*_*',

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalHBHEMuonFilter_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalHBHEMuonFilter_Output_cff.py
@@ -22,6 +22,7 @@ OutALCARECOHcalCalHBHEMuonFilter_noDrop = cms.PSet(
         'keep recoTracks_tevMuons_*_*',
         'keep recoTrackExtras_tevMuons_*_*',
         'keep *_offlinePrimaryVertices_*_*',
+        'keep *_scalersRawToDigi_*_*',
         'keep *_muons_*_*',
         )
     )

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIterativePhiSym_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIterativePhiSym_Output_cff.py
@@ -9,11 +9,11 @@ OutALCARECOHcalCalIterativePhiSym_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOHcalCalIterativePhiSym')
     ),
     outputCommands = cms.untracked.vstring(
-
                                             "keep *_horeco_*_*",
                                             "keep *_hfreco_*_*",
                                             "keep *_hbhereco_*_*",
                                             "keep *_offlinePrimaryVertices_*_*",
+                                            "keep *_scalersRawToDigi_*_*",
                                             "keep edmTriggerResults_*_*_HLT")
 
 )


### PR DESCRIPTION
Add lumi scalars for iterative phi symmetry which will be used also for Radiation damage studies. Get rid of pre-rechit collection for HBHEMuonFIlter which is no longer needed for 2018 data taking