### PR TITLE
Adding an hlt filter for CTPPS local tracks

### DIFF
--- a/HLTrigger/special/plugins/BuildFile.xml
+++ b/HLTrigger/special/plugins/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="CondFormats/L1TObjects"/>
 <use name="DataFormats/CSCDigi"/>
 <use name="DataFormats/CSCRecHit"/>
+<use name="DataFormats/CTPPSDetId"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/DTDigi"/>
 <use name="DataFormats/DetId"/>

--- a/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.cc
+++ b/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.cc
@@ -126,7 +126,7 @@ bool HLTCTPPSLocalTrackFilter::filter(edm::StreamID, edm::Event& iEvent, const e
 
     for(const auto &rpv : (*pixelTracks))
     {
-      CTPPSPixelDetId id(rpv.id);
+      const CTPPSPixelDetId id(rpv.id);
       if(tracksPerPot.count(rpv.id) == 0)
         tracksPerPot[rpv.id] = 0;
 
@@ -149,7 +149,7 @@ bool HLTCTPPSLocalTrackFilter::filter(edm::StreamID, edm::Event& iEvent, const e
 
     for(const auto &rpv : (*stripTracks))
     {
-      TotemRPDetId id(rpv.id);
+      const TotemRPDetId id(rpv.id);
       if(tracksPerPot.count(rpv.id) == 0)
         tracksPerPot[rpv.id] = 0;
 
@@ -172,7 +172,7 @@ bool HLTCTPPSLocalTrackFilter::filter(edm::StreamID, edm::Event& iEvent, const e
 
     for(const auto &rpv : (*diamondTracks))
     {
-      CTPPSDiamondDetId id(rpv.id);
+      const CTPPSDiamondDetId id(rpv.id);
       if(tracksPerPot.count(rpv.id) == 0)
         tracksPerPot[rpv.id] = 0;
 

--- a/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.cc
+++ b/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.cc
@@ -111,10 +111,6 @@ bool HLTCTPPSLocalTrackFilter::filter(edm::StreamID, edm::Event& iEvent, const e
   int arm56Tracks = 0;
   std::map<uint32_t, int> tracksPerPot;
 
-  typedef edm::Ref<edm::DetSetVector<CTPPSPixelLocalTrack>> PixelRef;
-  typedef edm::Ref<edm::DetSetVector<TotemRPLocalTrack>> StripRef;
-  typedef edm::Ref<edm::DetSetVector<CTPPSDiamondLocalTrack>> DiamondRef;
-
   //   Note that there is no matching between the tracks from the several roman pots
   // so tracks from separate pots might correspond to the same particle.
   // When the pixels are used in more than one RP (in 2018), then the same situation can

--- a/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.cc
+++ b/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.cc
@@ -105,7 +105,7 @@ HLTCTPPSLocalTrackFilter::HLTCTPPSLocalTrackFilter(const edm::ParameterSet& iCon
 //
 // member functions
 //
-bool HLTCTPPSLocalTrackFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
+bool HLTCTPPSLocalTrackFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
   int arm45Tracks = 0;
   int arm56Tracks = 0;

--- a/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.cc
+++ b/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.cc
@@ -1,0 +1,234 @@
+// <author>Cristovao Beirao da Cruz e Silva</author>
+// <email>cbeiraod@cern.ch</email>
+// <created>2017-10-26</created>
+// <description>
+// HLT filter module to select events with tracks in the CTPPS detector
+// </description>
+
+// system include files
+#include <map>
+#include <iostream>
+#include <memory>
+
+// user include files
+#include "HLTCTPPSLocalTrackFilter.h"
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/Common/interface/DetSet.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+
+#include "DataFormats/CTPPSDetId/interface/CTPPSPixelDetId.h"
+#include "DataFormats/CTPPSDetId/interface/TotemRPDetId.h"
+#include "DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h"
+
+//
+// fill discriptions
+//
+void HLTCTPPSLocalTrackFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+
+  desc.add<edm::InputTag>("pixelLocalTrackInputTag",   edm::InputTag("ctppsPixelLocalTracks"))
+    ->setComment("input tag of the pixel local track collection");
+  desc.add<edm::InputTag>("stripLocalTrackInputTag",   edm::InputTag("totemRPLocalTrackFitter"))
+    ->setComment("input tag of the strip local track collection");
+  desc.add<edm::InputTag>("diamondLocalTrackInputTag", edm::InputTag("ctppsDiamondLocalTracks"))
+    ->setComment("input tag of the diamond local track collection");
+
+  desc.add<unsigned int>("detectorBitset", static_cast<unsigned int>(1))
+    ->setComment("bitset of which detector types to consider: bit 1 -> pixel; bit 2 -> strips; bit 3 -> diamonds. eg. the value 1 will only consider the pixel detectors, the value 5 will consider the diamond and pixel detectors");
+
+  desc.add<int>("minTracks", 2)
+    ->setComment("minimum number of tracks");
+  desc.add<int>("minTracksPerArm", 1)
+    ->setComment("minimum number of tracks per arm of the CTPPS detector");
+
+  desc.add<int>("maxTracks", -1)
+    ->setComment("maximum number of tracks, if smaller than minTracks it will be ignored");
+  desc.add<int>("maxTracksPerArm", -1)
+    ->setComment("maximum number of tracks per arm of the CTPPS detector, if smaller than minTrackPerArm it will be ignored");
+  desc.add<int>("maxTracksPerPot", -1)
+    ->setComment("maximum number of tracks per roman pot of the CTPPS detector, if negative it will be ignored");
+
+  desc.add<int>("triggerType", trigger::TriggerTrack);
+
+  descriptions.add("hltCTPPSLocalTrackFilter", desc);
+  return;
+}
+
+//
+// destructor and constructor
+//
+HLTCTPPSLocalTrackFilter::~HLTCTPPSLocalTrackFilter()= default;
+
+HLTCTPPSLocalTrackFilter::HLTCTPPSLocalTrackFilter(const edm::ParameterSet& iConfig):
+  HLTFilter(iConfig),
+  pixelLocalTrackInputTag_   (iConfig.getParameter< edm::InputTag > ("pixelLocalTrackInputTag")),
+  stripLocalTrackInputTag_   (iConfig.getParameter< edm::InputTag > ("stripLocalTrackInputTag")),
+  diamondLocalTrackInputTag_ (iConfig.getParameter< edm::InputTag > ("diamondLocalTrackInputTag")),
+  detectorBitset_            (iConfig.getParameter< unsigned int  > ("detectorBitset")),
+  minTracks_                 (iConfig.getParameter< int           > ("minTracks")),
+  minTracksPerArm_           (iConfig.getParameter< int           > ("minTracksPerArm")),
+  maxTracks_                 (iConfig.getParameter< int           > ("maxTracks")),
+  maxTracksPerArm_           (iConfig.getParameter< int           > ("maxTracksPerArm")),
+  maxTracksPerPot_           (iConfig.getParameter< int           > ("maxTracksPerPot")),
+  usePixel_   (false),
+  useStrip_   (false),
+  useDiamond_ (false)
+{
+  if(detectorBitset_ & 1)
+    usePixel_ = true;
+  if(detectorBitset_ & 2)
+    useStrip_ = true;
+  if(detectorBitset_ & 4)
+    useDiamond_ = true;
+
+  if(usePixel_)
+    pixelLocalTrackToken_   = consumes<edm::DetSetVector<CTPPSPixelLocalTrack>>(pixelLocalTrackInputTag_);
+  if(useStrip_)
+    stripLocalTrackToken_   = consumes<edm::DetSetVector<TotemRPLocalTrack>>(stripLocalTrackInputTag_);
+  if(useDiamond_)
+    diamondLocalTrackToken_ = consumes<edm::DetSetVector<CTPPSDiamondLocalTrack>>(diamondLocalTrackInputTag_);
+
+  LogDebug("") << "HLTCTPPSLocalTrackFilter: pixelTag/stripTag/diamondTag/bitset/minTracks/minTracksPerArm/maxTracks/maxTracksPerArm/maxTracksPerPot : "
+               << pixelLocalTrackInputTag_.encode() << " "
+               << stripLocalTrackInputTag_.encode() << " "
+               << diamondLocalTrackInputTag_.encode() << " "
+               << detectorBitset_ << " "
+               << minTracks_ << " "
+               << minTracksPerArm_ << " "
+               << maxTracks_ << " "
+               << maxTracksPerArm_ << " "
+               << maxTracksPerPot_;
+}
+
+//
+// member functions
+//
+bool HLTCTPPSLocalTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs& filterproduct) const
+{
+  int arm45Tracks = 0;
+  int arm56Tracks = 0;
+  std::map<uint32_t, int> tracksPerPot;
+
+  if (saveTags())
+  {
+    if(usePixel_)   filterproduct.addCollectionTag(pixelLocalTrackInputTag_);
+    if(useStrip_)   filterproduct.addCollectionTag(stripLocalTrackInputTag_);
+    if(useDiamond_) filterproduct.addCollectionTag(diamondLocalTrackInputTag_);
+  }
+
+  typedef edm::Ref<edm::DetSetVector<CTPPSPixelLocalTrack>> PixelRef;
+  typedef edm::Ref<edm::DetSetVector<TotemRPLocalTrack>> StripRef;
+  typedef edm::Ref<edm::DetSetVector<CTPPSDiamondLocalTrack>> DiamondRef;
+
+  //   Note that there is no matching between the tracks from the several roman pots
+  // so tracks from separate pots might correspond to the same particle.
+  // When the pixels are used in more than one RP (in 2018), then the same situation can
+  // happen within the pixels themselves.
+  if(usePixel_) // Pixels correspond to RP 220 in 2017 data
+  {
+    edm::Handle<edm::DetSetVector<CTPPSPixelLocalTrack>> pixelTracks;
+    iEvent.getByToken(pixelLocalTrackToken_, pixelTracks);
+
+    for(const auto &rpv : (*pixelTracks))
+    {
+      CTPPSPixelDetId id(rpv.id);
+      if(tracksPerPot.count(rpv.id) == 0)
+        tracksPerPot[rpv.id] = 0;
+
+      for(auto & track : rpv)
+      {
+        if(track.isValid())
+        {
+          if(id.arm() == 0) ++arm45Tracks;
+          if(id.arm() == 1) ++arm56Tracks;
+          ++tracksPerPot[rpv.id];
+        }
+      }
+    }
+  }
+
+  if(useStrip_) // Strips correspond to RP 210 in 2017 data
+  {
+    edm::Handle<edm::DetSetVector<TotemRPLocalTrack>> stripTracks;
+    iEvent.getByToken(stripLocalTrackToken_, stripTracks);
+
+    for(const auto &rpv : (*stripTracks))
+    {
+      TotemRPDetId id(rpv.id);
+      if(tracksPerPot.count(rpv.id) == 0)
+        tracksPerPot[rpv.id] = 0;
+
+      for(auto & track : rpv)
+      {
+        if(track.isValid())
+        {
+          if(id.arm() == 0) ++arm45Tracks;
+          if(id.arm() == 1) ++arm56Tracks;
+          ++tracksPerPot[rpv.id];
+        }
+      }
+    }
+  }
+
+  if(useDiamond_)
+  {
+    edm::Handle<edm::DetSetVector<CTPPSDiamondLocalTrack>> diamondTracks;
+    iEvent.getByToken(diamondLocalTrackToken_, diamondTracks);
+
+    for(const auto &rpv : (*diamondTracks))
+    {
+      CTPPSDiamondDetId id(rpv.id);
+      if(tracksPerPot.count(rpv.id) == 0)
+        tracksPerPot[rpv.id] = 0;
+
+      for(auto & track : rpv)
+      {
+        if(track.isValid())
+        {
+          if(id.arm() == 0) ++arm45Tracks;
+          if(id.arm() == 1) ++arm56Tracks;
+          ++tracksPerPot[rpv.id];
+        }
+      }
+    }
+  }
+
+
+  bool accept = true;
+
+  if(arm45Tracks + arm56Tracks < minTracks_ || arm45Tracks < minTracksPerArm_ || arm56Tracks < minTracksPerArm_)
+    accept = false;
+
+  if(maxTracks_ >= minTracks_ && arm45Tracks + arm56Tracks > maxTracks_)
+    accept = false;
+
+  if(maxTracksPerArm_ >= minTracksPerArm_ && (arm45Tracks > maxTracksPerArm_ || arm56Tracks > maxTracksPerArm_))
+    accept = false;
+
+  if(maxTracksPerPot_ >= 0)
+  {
+    for(auto& pot : tracksPerPot)
+    {
+      if(pot.second > maxTracksPerPot_)
+      {
+        accept = false;
+        break;
+      }
+    }
+  }
+
+  return accept;
+}
+
+// define as a framework module
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(HLTCTPPSLocalTrackFilter);

--- a/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.h
+++ b/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.h
@@ -9,7 +9,8 @@
 
 
 // include files
-#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
 
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
@@ -25,14 +26,14 @@
 // class declaration
 //
 
-class HLTCTPPSLocalTrackFilter : public HLTFilter
+class HLTCTPPSLocalTrackFilter : public edm::EDFilter
 {
 public:
   explicit HLTCTPPSLocalTrackFilter(const edm::ParameterSet&);
   ~HLTCTPPSLocalTrackFilter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions&);
-  bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs&) const override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
 
 private:
   edm::ParameterSet param_;
@@ -46,7 +47,9 @@ private:
   edm::InputTag diamondLocalTrackInputTag_; // Input tag identifying the diamond detector
   edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondLocalTrack>> diamondLocalTrackToken_;
 
-  unsigned int detectorBitset_;
+  bool usePixel_;
+  bool useStrip_;
+  bool useDiamond_;
 
   int minTracks_;
   int minTracksPerArm_;
@@ -54,10 +57,6 @@ private:
   int maxTracks_;
   int maxTracksPerArm_;
   int maxTracksPerPot_;
-
-  bool usePixel_;
-  bool useStrip_;
-  bool useDiamond_;
 
 protected:
 };

--- a/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.h
+++ b/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.h
@@ -1,0 +1,65 @@
+#ifndef HLTCTPPSLocalTrackFilter_h
+#define HLTCTPPSLocalTrackFilter_h
+// <author>Cristovao Beirao da Cruz e Silva</author>
+// <email>cbeiraod@cern.ch</email>
+// <created>2017-10-26</created>
+// <description>
+// HLT filter module to select events with tracks in the CTPPS detector
+// </description>
+
+
+// include files
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h"     // pixel
+#include "DataFormats/CTPPSReco/interface/TotemRPLocalTrack.h"        // strip
+#include "DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h"   // diamond
+
+//
+// class declaration
+//
+
+class HLTCTPPSLocalTrackFilter : public HLTFilter
+{
+public:
+  explicit HLTCTPPSLocalTrackFilter(const edm::ParameterSet&);
+  ~HLTCTPPSLocalTrackFilter() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+  bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs&) const override;
+
+private:
+  edm::ParameterSet param_;
+
+  edm::InputTag pixelLocalTrackInputTag_; // Input tag identifying the pixel detector
+  edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelLocalTrack>> pixelLocalTrackToken_;
+
+  edm::InputTag stripLocalTrackInputTag_; // Input tag identifying the strip detector
+  edm::EDGetTokenT<edm::DetSetVector<TotemRPLocalTrack>> stripLocalTrackToken_;
+
+  edm::InputTag diamondLocalTrackInputTag_; // Input tag identifying the diamond detector
+  edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondLocalTrack>> diamondLocalTrackToken_;
+
+  unsigned int detectorBitset_;
+
+  int minTracks_;
+  int minTracksPerArm_;
+
+  int maxTracks_;
+  int maxTracksPerArm_;
+  int maxTracksPerPot_;
+
+  bool usePixel_;
+  bool useStrip_;
+  bool useDiamond_;
+
+protected:
+};
+
+#endif

--- a/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.h
+++ b/HLTrigger/special/plugins/HLTCTPPSLocalTrackFilter.h
@@ -9,7 +9,7 @@
 
 
 // include files
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
@@ -26,14 +26,14 @@
 // class declaration
 //
 
-class HLTCTPPSLocalTrackFilter : public edm::EDFilter
+class HLTCTPPSLocalTrackFilter : public edm::global::EDFilter<>
 {
 public:
   explicit HLTCTPPSLocalTrackFilter(const edm::ParameterSet&);
   ~HLTCTPPSLocalTrackFilter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions&);
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 private:
   edm::ParameterSet param_;
@@ -57,8 +57,6 @@ private:
   int maxTracks_;
   int maxTracksPerArm_;
   int maxTracksPerPot_;
-
-protected:
 };
 
 #endif


### PR DESCRIPTION
This PR implements a first hlt filter using the local track multiplicity from the CT-PPS detector.

The filter allows to set a minimum multiplicity of CT-PPS tracks per event and per arm of the detector, for example this allows to require a coincidence between the two arms. It is also possible to set a maximum multiplicity, per event, arms and roman pot.