### PR TITLE
CTPPS: updated DQM for 2018 data taking

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -214,7 +214,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 // Values for all constants
 const double    CTPPSDiamondDQMSource::SEC_PER_LUMI_SECTION = 23.31;
 const int       CTPPSDiamondDQMSource::CHANNEL_OF_VFAT_CLOCK = 30;
-const double    CTPPSDiamondDQMSource::DISPLAY_RESOLUTION_FOR_HITS_MM = 0.01;
+const double    CTPPSDiamondDQMSource::DISPLAY_RESOLUTION_FOR_HITS_MM = 0.1;
 const double    CTPPSDiamondDQMSource::INV_DISPLAY_RESOLUTION_FOR_HITS_MM = 1./DISPLAY_RESOLUTION_FOR_HITS_MM;
 const double    CTPPSDiamondDQMSource::HPTDC_BIN_WIDTH_NS = 25./1024;
 const int       CTPPSDiamondDQMSource::CTPPS_NUM_OF_ARMS = 2;
@@ -833,8 +833,8 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         if ( pixId.station() != CTPPS_PIXEL_STATION_ID || pixId.rp() != CTPPS_FAR_RP_ID ) continue;
         for ( const auto& lt : ds ) {
           if ( lt.isValid() && pixId.arm() == detId_pot.arm() ) {
-            if ( rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.getOOTIndex() - centralOOT_ + 1 < (int) potPlots_[detId_pot].pixelTomographyAll.size() && rechit.getOOTIndex() - centralOOT_ + 1  >= 0 )
-              potPlots_[detId_pot].pixelTomographyAll.at( rechit.getOOTIndex() - centralOOT_ + 1  )->Fill( lt.getX0() - horizontalShiftBwDiamondPixels_ + 25*detId.plane(), lt.getY0() );
+            if ( rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.getOOTIndex() - centralOOT_ < (int) potPlots_[detId_pot].pixelTomographyAll.size() && rechit.getOOTIndex() - centralOOT_  >= 0 )
+              potPlots_[detId_pot].pixelTomographyAll.at( rechit.getOOTIndex() - centralOOT_  )->Fill( lt.getX0() - horizontalShiftBwDiamondPixels_ + 25*detId.plane(), lt.getY0() );
           }
         }
       }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -414,14 +414,9 @@ CTPPSDiamondDQMSource::dqmBeginRun( const edm::Run& iRun, const edm::EventSetup&
   
   // Rough alignement of pixel detector for diamond thomography
   const CTPPSPixelDetId pixid(0, CTPPS_PIXEL_STATION_ID, CTPPS_FAR_RP_ID, 0);
-  try {
+  if ( iRun.run()>300000 ) {    //Pixel installed
     det = geom->getSensor( pixid );
     horizontalShiftBwDiamondPixels_ = det->translation().x() - det->params().at( 0 ) - horizontalShiftOfDiamond_ - 3;
-  }
-  catch (...)
-  {
-    // Pixel not yet installed... tomography will be empty
-    horizontalShiftBwDiamondPixels_ = 0;
   }
 }
 

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -28,12 +28,33 @@
 #include "DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h"
 #include "DataFormats/CTPPSDigi/interface/CTPPSDiamondDigi.h"
 
+#include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h"
+#include "DataFormats/CTPPSDetId/interface/CTPPSPixelDetId.h"
+
 #include "DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h"
+#include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
+#include "Geometry/Records/interface/VeryForwardRealGeometryRecord.h"
 
 #include <string>
 
 //----------------------------------------------------------------------------------------------------
+
+
+// Utility for efficiency computations
+bool channelAlignedWithTrack( const CTPPSGeometry* geom, const CTPPSDiamondDetId& detid, const CTPPSDiamondLocalTrack& localTrack, const float tolerance=1) {
+  const DetGeomDesc* det = geom->getSensor( detid );
+  const float x_pos = det->translation().x(),
+              x_width = 2.0 * det->params().at( 0 ); // parameters stand for half the size
+  return
+          ( ( x_pos + 0.5 * x_width > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
+          && x_pos + 0.5 * x_width < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
+        || ( x_pos - 0.5 * x_width > localTrack.getX0() - localTrack.getX0Sigma() - tolerance
+          && x_pos - 0.5 * x_width < localTrack.getX0() + localTrack.getX0Sigma() + tolerance )
+        || ( x_pos - 0.5 * x_width < localTrack.getX0() - localTrack.getX0Sigma() - tolerance
+          && x_pos + 0.5 * x_width > localTrack.getX0() + localTrack.getX0Sigma() + tolerance ) );
+}
+      
 
 class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 {
@@ -59,6 +80,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     static const int CTPPS_NUM_OF_ARMS;
     static const int CTPPS_DIAMOND_STATION_ID;
     static const int CTPPS_DIAMOND_RP_ID;
+    static const int CTPPS_PIXEL_STATION_ID;
     static const int CTPPS_NEAR_RP_ID;
     static const int CTPPS_FAR_RP_ID;
     static const int CTPPS_DIAMOND_NUM_OF_PLANES;
@@ -68,14 +90,15 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 
     edm::EDGetTokenT< edm::DetSetVector<TotemVFATStatus> > tokenStatus_;
     edm::EDGetTokenT< edm::DetSetVector<TotemRPLocalTrack> > tokenLocalTrack_;
+    edm::EDGetTokenT< edm::DetSetVector<CTPPSPixelLocalTrack> > tokenPixelTrack_;
     edm::EDGetTokenT< edm::DetSetVector<CTPPSDiamondDigi> > tokenDigi_;
     edm::EDGetTokenT< edm::DetSetVector<CTPPSDiamondRecHit> > tokenDiamondHit_;
     edm::EDGetTokenT< edm::DetSetVector<CTPPSDiamondLocalTrack> > tokenDiamondTrack_;
     edm::EDGetTokenT< std::vector<TotemFEDInfo> > tokenFEDInfo_;
 
     bool excludeMultipleHits_;
-    double minimumStripAngleForTomography_;
-    double maximumStripAngleForTomography_;
+    double horizontalShiftBwDiamondPixels_;
+    double horizontalShiftOfDiamond_;
     std::vector< std::pair<edm::EventRange, int> > runParameters_;
     int centralOOT_;
     unsigned int verbosity_;
@@ -108,12 +131,12 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* trackDistribution = nullptr;
       MonitorElement* trackDistributionOOT = nullptr;
 
-      MonitorElement* stripTomographyAllFar_0_25 = nullptr;
-      MonitorElement* stripTomographyAllFar_25_50 = nullptr;
-      MonitorElement* stripTomographyAllFar_50_75 = nullptr;
-      std::vector< MonitorElement* > stripTomographyAllFar;
+      MonitorElement* pixelTomographyAll_0_25 = nullptr;
+      MonitorElement* pixelTomographyAll_25_50 = nullptr;
+      MonitorElement* pixelTomographyAll_50_75 = nullptr;
+      std::vector< MonitorElement* > pixelTomographyAll;
 
-      MonitorElement* leadingEdgeCumulative_both = nullptr, *leadingEdgeCumulative_le = nullptr, *trailingEdgeCumulative_te = nullptr;
+      MonitorElement* leadingEdgeCumulative_both = nullptr, *leadingEdgeCumulative_all = nullptr, *leadingEdgeCumulative_le = nullptr, *trailingEdgeCumulative_te = nullptr;
       MonitorElement* timeOverThresholdCumulativePot = nullptr, *leadingTrailingCorrelationPot = nullptr;
       MonitorElement* leadingWithoutTrailingCumulativePot = nullptr;
 
@@ -129,7 +152,12 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 
       unsigned int HitCounter, MHCounter, LeadingOnlyCounter, TrailingOnlyCounter, CompleteCounter;
       
-      PotPlots() {};
+      std::map<int, int> effTriplecountingChMap;
+      std::map<int, int> effDoublecountingChMap;
+      MonitorElement* EfficiencyOfChannelsInPot = nullptr;
+      TH2F pixelTracksMap;
+      
+      PotPlots() {}
       PotPlots( DQMStore::IBooker& ibooker, unsigned int id );
     };
 
@@ -143,7 +171,10 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* hitProfile = nullptr;
       MonitorElement* hit_multiplicity = nullptr;
 
-      MonitorElement* stripTomography_far = nullptr;
+      MonitorElement* pixelTomography_far = nullptr;
+      MonitorElement* EfficiencyWRTPixelsInPlane = nullptr;
+      
+      TH2F pixelTracksMapWithDiamonds;
 
       PlanePlots() {}
       PlanePlots( DQMStore::IBooker& ibooker, unsigned int id );
@@ -164,7 +195,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* TimeOverThresholdCumulativePerChannel = nullptr;
       MonitorElement* LeadingTrailingCorrelationPerChannel = nullptr;
       MonitorElement* leadingWithoutTrailing = nullptr;
-      MonitorElement* stripTomography_far = nullptr;
+      MonitorElement* pixelTomography_far = nullptr;
       MonitorElement* hit_rate = nullptr;
       MonitorElement* ECCheckPerChannel = nullptr;
       unsigned long hitsCounterPerLumisection;
@@ -183,11 +214,12 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 // Values for all constants
 const double    CTPPSDiamondDQMSource::SEC_PER_LUMI_SECTION = 23.31;
 const int       CTPPSDiamondDQMSource::CHANNEL_OF_VFAT_CLOCK = 30;
-const double    CTPPSDiamondDQMSource::DISPLAY_RESOLUTION_FOR_HITS_MM = 0.1;
+const double    CTPPSDiamondDQMSource::DISPLAY_RESOLUTION_FOR_HITS_MM = 0.01;
 const double    CTPPSDiamondDQMSource::INV_DISPLAY_RESOLUTION_FOR_HITS_MM = 1./DISPLAY_RESOLUTION_FOR_HITS_MM;
 const double    CTPPSDiamondDQMSource::HPTDC_BIN_WIDTH_NS = 25./1024;
 const int       CTPPSDiamondDQMSource::CTPPS_NUM_OF_ARMS = 2;
 const int       CTPPSDiamondDQMSource::CTPPS_DIAMOND_STATION_ID = 1;
+const int       CTPPSDiamondDQMSource::CTPPS_PIXEL_STATION_ID = 2;
 const int       CTPPSDiamondDQMSource::CTPPS_DIAMOND_RP_ID = 6;
 const int       CTPPSDiamondDQMSource::CTPPS_NEAR_RP_ID = 2;
 const int       CTPPSDiamondDQMSource::CTPPS_FAR_RP_ID = 3;
@@ -216,7 +248,7 @@ CTPPSDiamondDQMSource::GlobalPlots::GlobalPlots( DQMStore::IBooker& ibooker )
 //----------------------------------------------------------------------------------------------------
 
 
-CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned int id ): HitCounter(0), MHCounter(0), LeadingOnlyCounter(0), TrailingOnlyCounter(0), CompleteCounter(0)
+CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned int id ): HitCounter(0), MHCounter(0), LeadingOnlyCounter(0), TrailingOnlyCounter(0), CompleteCounter(0), pixelTracksMap("Pixel track maps for efficiency", "Pixel track maps for efficiency", 27, -2, 25, 18, -4, 14 )
 {
   std::string path, title;
   CTPPSDiamondDetId( id ).rpName( path, CTPPSDiamondDetId::nPath );
@@ -231,26 +263,27 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   activity_per_bx_50_75 = ibooker.book1D( "activity per BX 50 75", title+" Activity per BX 50 - 75 ns;Event.BX", 3600, -1.5, 3598. + 0.5 );
   activity_per_bx.emplace_back(activity_per_bx_50_75);
 
-  hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  hitDistribution2d_lumisection = ibooker.book2D( "hits in planes lumisection", title+" hits in planes in the last lumisection;plane number;x (mm)", 10, -0.5, 4.5, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.25 OOT;x (mm)", 17, -0.25, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  hitDistribution2dOOT_le= ibooker.book2D( "hits with OOT in planes (le only)", title+" hits with OOT in planes (le only);plane number + 0.25 OOT;x (mm)", 17, -0.25, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -0.5, 18.5 );
+  hitDistribution2d_lumisection = ibooker.book2D( "hits in planes lumisection", title+" hits in planes in the last lumisection;plane number;x (mm)", 10, -0.5, 4.5, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -0.5, 18.5 );
+  hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.25 OOT;x (mm)", 17, -0.25, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -0.5, 18.5 );
+  hitDistribution2dOOT_le= ibooker.book2D( "hits with OOT in planes (le only)", title+" hits with OOT in planes (le only);plane number + 0.25 OOT;x (mm)", 17, -0.25, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -0.5, 18.5 );
   activePlanes = ibooker.book1D( "active planes", title+" active planes (per event);number of active planes", 6, -0.5, 5.5 );
   activePlanesInclusive = ibooker.book1D( "active planes inclusive", title+" active planes, MH and le only included (per event);number of active planes", 6, -0.5, 5.5 );
 
-  trackDistribution = ibooker.book1D( "tracks", title+" tracks;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  trackDistribution = ibooker.book1D( "tracks", title+" tracks;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -0.5, 18.5 );
+  trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -0.5, 18.5 );
 
-  stripTomographyAllFar_0_25 = ibooker.book2D( "tomography all far 0 25", title+" tomography with strips far 0 - 25 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 12, -2, 10 );
-  stripTomographyAllFar.emplace_back(stripTomographyAllFar_0_25);
-  stripTomographyAllFar_25_50 = ibooker.book2D( "tomography all far 25 50", title+" tomography with strips far 25 - 50 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 12, -2, 10 );
-  stripTomographyAllFar.emplace_back(stripTomographyAllFar_25_50);
-  stripTomographyAllFar_50_75 = ibooker.book2D( "tomography all far 50 75", title+" tomography with strips far 50 - 75 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 12, -2, 10 );
-  stripTomographyAllFar.emplace_back(stripTomographyAllFar_50_75);
+  pixelTomographyAll_0_25 = ibooker.book2D( "tomography pixel 0 25", title+" tomography with pixel 0 - 25 ns (all planes);x + 25*plane(mm);y (mm)", 100, -2, 98, 12, -2, 10 );
+  pixelTomographyAll.emplace_back(pixelTomographyAll_0_25);
+  pixelTomographyAll_25_50 = ibooker.book2D( "tomography pixel 25 50", title+" tomography with pixel 25 - 50 ns (all planes);x + 25*plane(mm);y (mm)", 100, -2, 98, 12, -2, 10 );
+  pixelTomographyAll.emplace_back(pixelTomographyAll_25_50);
+  pixelTomographyAll_50_75 = ibooker.book2D( "tomography pixel 50 75", title+" tomography with pixel 50 - 75 ns (all planes);x + 25*plane(mm);y (mm)", 100, -2, 98, 12, -2, 10 );
+  pixelTomographyAll.emplace_back(pixelTomographyAll_50_75);
 
-  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 125, 0, 125 );
-  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 125, 0, 125 );
-  trailingEdgeCumulative_te = ibooker.book1D( "trailing edge (te only)", title+" trailing edge (te only); trailing edge (ns)", 125, 0, 125 );
+  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te) (recHits); leading edge (ns)", 125, 0, 125 );
+  leadingEdgeCumulative_all = ibooker.book1D( "leading edge (all)", title+" leading edge (all) (DIGIs); leading edge (ns)", 125, 0, 125 );
+  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only) (DIGIs); leading edge (ns)", 125, 0, 125 );
+  trailingEdgeCumulative_te = ibooker.book1D( "trailing edge (te only)", title+" trailing edge (te only) (DIGIs); trailing edge (ns)", 125, 0, 125 );
   timeOverThresholdCumulativePot = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 250, -25, 100 );
   leadingTrailingCorrelationPot = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 75, 0, 75, 75, 0, 75 );
 
@@ -268,16 +301,19 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
 
   MHComprensive = ibooker.book2D( "MH in channels", title+" MH (%) in channels;plane number;ch number", 10, -0.5, 4.5, 14, -1, 13 );
 
+  EfficiencyOfChannelsInPot = ibooker.book2D( "Efficiency in channels", title+" Efficiency (%) in channels (diamonds only);plane number;ch number", 10, -0.5, 4.5, 14, -1, 13 );
+  
   ibooker.setCurrentFolder( path+"/clock/" );
   clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 1250, 0, 125 );
   clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 75, 0, 75 );
   clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 1250, 0, 125 );
   clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 75, 0, 75 );
+  
 }
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsigned int id )
+CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsigned int id ) : pixelTracksMapWithDiamonds("Pixel track maps for efficiency with coincidence", "Pixel track maps for efficiency with coincidence", 27, -2, 25, 18, -4, 14 )
 {
   std::string path, title;
   CTPPSDiamondDetId( id ).planeName( path, CTPPSDiamondDetId::nPath );
@@ -286,10 +322,12 @@ CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsig
   CTPPSDiamondDetId( id ).planeName( title, CTPPSDiamondDetId::nFull );
 
   digiProfileCumulativePerPlane = ibooker.book1D( "digi profile", title+" digi profile; ch number", 12, -0.5, 11.5 );
-  hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -0.5, 18.5 );
   hit_multiplicity = ibooker.book1D( "channels per plane", title+" channels per plane; ch per plane", 13, -0.5, 12.5 );
 
-  stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 50, 0, 50, 12, -2, 10 );
+  pixelTomography_far = ibooker.book2D( "tomography pixel", title+" tomography with pixel;x + 25 OOT (mm);y (mm)", 100, -2, 98, 12, -2, 10 );
+  EfficiencyWRTPixelsInPlane = ibooker.book2D( "Efficieny wrt pixel", title+" Efficieny wrt pixel;x (mm);y (mm)", 27, -2, 25, 18, -4, 14 );
+  
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -319,15 +357,15 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
     HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( error_index, HPTDCErrorFlags::getHPTDCErrorName( error_index-1 ).c_str() );
   HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( 16, "MH  (%)" );
 
-  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge; leading edge (ns)", 125, 0, 125 );
-  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge; leading edge (ns)", 125, 0, 125 );
-  trailingEdgeCumulative_te = ibooker.book1D( "trailing edge (te only)", title+" trailing edge (te only); trailing edge (ns)", 125, 0, 125 );
+  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (recHits); leading edge (ns)", 125, 0, 125 );
+  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (DIGIs); leading edge (ns)", 125, 0, 125 );
+  trailingEdgeCumulative_te = ibooker.book1D( "trailing edge (te only)", title+" trailing edge (te only) (DIGIs); trailing edge (ns)", 125, 0, 125 );
   TimeOverThresholdCumulativePerChannel = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 75, -25, 50 );
   LeadingTrailingCorrelationPerChannel = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 75, 0, 75, 75, 0, 75 );
 
   ECCheckPerChannel = ibooker.book1D("optorxEC(8bit) - vfatEC vs optorxEC", title+" EC Error;optorxEC-vfatEC", 128, -64, 64 );
 
-  stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 25 OOT (mm);y (mm)", 50, 0, 50, 12, -2, 10 );
+  pixelTomography_far = ibooker.book2D( "tomography pixel", "tomography with pixel;x + 25 OOT (mm);y (mm)", 100, -2, 98, 12, -2, 10 );
 
   hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 40, 0, 20);
 }
@@ -337,13 +375,12 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
 CTPPSDiamondDQMSource::CTPPSDiamondDQMSource( const edm::ParameterSet& ps ) :
   tokenStatus_      ( consumes< edm::DetSetVector<TotemVFATStatus> >       ( ps.getParameter<edm::InputTag>( "tagStatus" ) ) ),
   tokenLocalTrack_  ( consumes< edm::DetSetVector<TotemRPLocalTrack> >     ( ps.getParameter<edm::InputTag>( "tagLocalTrack" ) ) ),
+  tokenPixelTrack_  ( consumes< edm::DetSetVector<CTPPSPixelLocalTrack> >     ( ps.getParameter<edm::InputTag>( "tagPixelLocalTracks" ) ) ),
   tokenDigi_        ( consumes< edm::DetSetVector<CTPPSDiamondDigi> >      ( ps.getParameter<edm::InputTag>( "tagDigi" ) ) ),
   tokenDiamondHit_  ( consumes< edm::DetSetVector<CTPPSDiamondRecHit> >    ( ps.getParameter<edm::InputTag>( "tagDiamondRecHits" ) ) ),
   tokenDiamondTrack_( consumes< edm::DetSetVector<CTPPSDiamondLocalTrack> >( ps.getParameter<edm::InputTag>( "tagDiamondLocalTracks" ) ) ),
   tokenFEDInfo_     ( consumes< std::vector<TotemFEDInfo> >                ( ps.getParameter<edm::InputTag>( "tagFEDInfo" ) ) ),
-  excludeMultipleHits_           ( ps.getParameter<bool>( "excludeMultipleHits" ) ),
-  minimumStripAngleForTomography_( ps.getParameter<double>( "minimumStripAngleForTomography" ) ),
-  maximumStripAngleForTomography_( ps.getParameter<double>( "maximumStripAngleForTomography" ) ),
+  excludeMultipleHits_                  ( ps.getParameter<bool>( "excludeMultipleHits" ) ),
   centralOOT_( -999 ),
   verbosity_                     ( ps.getUntrackedParameter<unsigned int>( "verbosity", 0 ) ),
   EC_difference_56_( -500 ), EC_difference_45_( -500 )
@@ -361,7 +398,7 @@ CTPPSDiamondDQMSource::~CTPPSDiamondDQMSource()
 //----------------------------------------------------------------------------------------------------
 
 void
-CTPPSDiamondDQMSource::dqmBeginRun( const edm::Run& iRun, const edm::EventSetup& )
+CTPPSDiamondDQMSource::dqmBeginRun( const edm::Run& iRun, const edm::EventSetup& iSetup )
 {
   centralOOT_ = -999;
   for ( const auto& oot : runParameters_ ) {
@@ -369,6 +406,19 @@ CTPPSDiamondDQMSource::dqmBeginRun( const edm::Run& iRun, const edm::EventSetup&
       centralOOT_ = oot.second; break;
     }
   }
+  
+  // Get detector shifts from the geometry
+  edm::ESHandle<CTPPSGeometry> geometry_;
+  iSetup.get<VeryForwardRealGeometryRecord>().get( geometry_ );
+  const CTPPSGeometry *geom = geometry_.product();
+  const CTPPSDiamondDetId detid(0, CTPPS_DIAMOND_STATION_ID, CTPPS_DIAMOND_RP_ID, 0, 0 );
+  const DetGeomDesc* det = geom->getSensor( detid );
+  horizontalShiftOfDiamond_ = det->translation().x() - det->params().at( 0 );
+  
+  // Rough alignement of pixel detector for diamond thomography
+  const CTPPSPixelDetId pixid(0, CTPPS_PIXEL_STATION_ID, CTPPS_FAR_RP_ID, 0);
+  det = geom->getSensor( pixid );
+  horizontalShiftBwDiamondPixels_ = det->translation().x() - det->params().at( 0 ) - horizontalShiftOfDiamond_ - 3;
 }
 
 
@@ -409,7 +459,7 @@ CTPPSDiamondDQMSource::beginLuminosityBlock( const edm::LuminosityBlock&, const 
 //----------------------------------------------------------------------------------------------------
 
 void
-CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& )
+CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& iSetup )
 {
   // get event data
   edm::Handle< edm::DetSetVector<TotemVFATStatus> > diamondVFATStatus;
@@ -417,6 +467,9 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
 
   edm::Handle< edm::DetSetVector<TotemRPLocalTrack> > stripTracks;
   event.getByToken( tokenLocalTrack_, stripTracks );
+  
+  edm::Handle< edm::DetSetVector<CTPPSPixelLocalTrack> > pixelTracks;
+  event.getByToken( tokenPixelTrack_, pixelTracks );
 
   edm::Handle< edm::DetSetVector<CTPPSDiamondDigi> > diamondDigis;
   event.getByToken( tokenDigi_, diamondDigis );
@@ -430,6 +483,9 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   edm::Handle< edm::DetSetVector<CTPPSDiamondLocalTrack> > diamondLocalTracks;
   event.getByToken( tokenDiamondTrack_, diamondLocalTracks );
 
+  edm::ESHandle<CTPPSGeometry> geometry_;
+  iSetup.get<VeryForwardRealGeometryRecord>().get( geometry_ );
+  
   // check validity
   bool valid = true;
   valid &= diamondVFATStatus.isValid();
@@ -537,6 +593,9 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       //Leading without trailing investigation
       if ( digi.getLeadingEdge() != 0 || digi.getTrailingEdge() != 0 ) {
         ++(potPlots_[detId_pot].HitCounter);
+        if ( digi.getLeadingEdge() != 0 ) {
+          potPlots_[detId_pot].leadingEdgeCumulative_all->Fill( HPTDC_BIN_WIDTH_NS * digi.getLeadingEdge() );
+        }
         if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() == 0 ) {
           ++(potPlots_[detId_pot].LeadingOnlyCounter);
           potPlots_[detId_pot].leadingEdgeCumulative_le->Fill( HPTDC_BIN_WIDTH_NS * digi.getLeadingEdge() );
@@ -622,7 +681,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       if ( rechit.getToT() != 0 && centralOOT_ != -999 && rechit.getOOTIndex() == centralOOT_ ) {
         TH2F *hitHistoTmp = potPlots_[detId_pot].hitDistribution2d->getTH2F();
         TAxis *hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
-        int startBin = hitHistoTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
+        int startBin = hitHistoTmpYAxis->FindBin( rechit.getX() - horizontalShiftOfDiamond_ - 0.5*rechit.getXWidth() );
         int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for ( int i=0; i<numOfBins; ++i) {
           hitHistoTmp->Fill( detId.plane() + UFSDShift, hitHistoTmpYAxis->GetBinCenter(startBin+i) );
@@ -630,7 +689,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         
         hitHistoTmp = potPlots_[detId_pot].hitDistribution2d_lumisection->getTH2F();
         hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
-        startBin = hitHistoTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
+        startBin = hitHistoTmpYAxis->FindBin( rechit.getX() - horizontalShiftOfDiamond_ - 0.5*rechit.getXWidth() );
         numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for ( int i=0; i<numOfBins; ++i) {
           hitHistoTmp->Fill( detId.plane() + UFSDShift, hitHistoTmpYAxis->GetBinCenter(startBin+i) );
@@ -645,25 +704,25 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
 
         TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT->getTH2F();
         TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
-        int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
+        int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - horizontalShiftOfDiamond_ - 0.5*rechit.getXWidth() );
         int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for ( int i=0; i<numOfBins; ++i) {
           hitHistoOOTTmp->Fill( detId.plane() + 0.2 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
         }
       }
       else {
-        if ( rechit.getT() != 0 ) {
+        if ( rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING ) {
           // Only leading
           TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT_le->getTH2F();
           TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
-          int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
+          int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - horizontalShiftOfDiamond_ - 0.5*rechit.getXWidth() );
           int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
           for ( int i=0; i<numOfBins; ++i) {
             hitHistoOOTTmp->Fill( detId.plane() + 0.2 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
           }
         }
       }
-      if ( (unsigned int) rechit.getOOTIndex() < potPlots_[detId_pot].activity_per_bx.size() )
+      if ( rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.getOOTIndex() < (int) potPlots_[detId_pot].activity_per_bx.size() )
         potPlots_[detId_pot].activity_per_bx.at( rechit.getOOTIndex() )->Fill( event.bunchCrossing() );
     }
   }
@@ -682,12 +741,13 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
 
     for ( const auto& track : tracks ) {
       if ( ! track.isValid() ) continue;
+      if ( track.getOOTIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING ) continue;
       if ( excludeMultipleHits_ && track.getMultipleHits() > 0 ) continue;
       if ( potPlots_.find( detId_pot ) == potPlots_.end() ) continue;
 
       TH2F *trackHistoOOTTmp = potPlots_[detId_pot].trackDistributionOOT->getTH2F();
       TAxis *trackHistoOOTTmpYAxis = trackHistoOOTTmp->GetYaxis();
-      int startBin = trackHistoOOTTmpYAxis->FindBin( track.getX0() - track.getX0Sigma() );
+      int startBin = trackHistoOOTTmpYAxis->FindBin( track.getX0() - horizontalShiftOfDiamond_ - track.getX0Sigma() );
       int numOfBins = 2*track.getX0Sigma()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
       for ( int i=0; i<numOfBins; ++i) {
         trackHistoOOTTmp->Fill( track.getOOTIndex(), trackHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
@@ -695,7 +755,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
 
       if ( centralOOT_ != -999 && track.getOOTIndex() == centralOOT_ ) {
         TH1F *trackHistoInTimeTmp = potPlots_[detId_pot].trackDistribution->getTH1F();
-        int startBin = trackHistoInTimeTmp->FindBin( track.getX0() - track.getX0Sigma() );
+        int startBin = trackHistoInTimeTmp->FindBin( track.getX0() - horizontalShiftOfDiamond_ - track.getX0Sigma() );
         int numOfBins = 2*track.getX0Sigma()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for ( int i=0; i<numOfBins; ++i) {
           trackHistoInTimeTmp->Fill( trackHistoInTimeTmp->GetBinCenter(startBin+i) );
@@ -703,30 +763,78 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       }
     }
   }
+  
+  // Channel efficiency using CTPPSDiamondLocalTrack
+  for ( const auto& tracks : *diamondLocalTracks ) {
+    CTPPSDiamondDetId detId_pot( tracks.detId() );
+    detId_pot.setPlane( 0 );
+    detId_pot.setChannel( 0 );
+    for ( const auto& track : tracks ) {
+      // Find hits and planes in the track
+      int numOfHits = 0;
+      std::set<int> planesInTrackSet;
+      for ( const auto& vec : *diamondRecHits ) {
+        const CTPPSDiamondDetId detid( vec.detId() );
+        if ( detid.arm() != detId_pot.arm() ) continue;
 
-  // Tomography of diamonds using strips
+        for ( const auto& hit : vec ) {
+          // first check if the hit contributes to the track
+          if ( track.containsHit(hit) ) {
+            ++numOfHits;
+            planesInTrackSet.insert(detid.plane());
+          }
+        }
+      }      
+      
+      if ( numOfHits > 0 && numOfHits <= 10 && planesInTrackSet.size() > 2 ) {         
+        for ( int plane=0; plane<4; ++plane ) {
+          for ( int channel=0; channel<12; ++channel ) {
+            int map_index = plane*100 + channel;
+            if ( potPlots_[detId_pot].effDoublecountingChMap.find( map_index ) == potPlots_[detId_pot].effDoublecountingChMap.end() ) {
+              potPlots_[detId_pot].effTriplecountingChMap[map_index] = 0;
+              potPlots_[detId_pot].effDoublecountingChMap[map_index] = 0;
+            }
+            CTPPSDiamondDetId detId( detId_pot.arm(), CTPPS_DIAMOND_STATION_ID, CTPPS_DIAMOND_RP_ID, plane, channel);
+            if ( channelAlignedWithTrack( geometry_.product(), detId, track, 0.1) ) {
+              // Channel should fire
+              ++(potPlots_[detId_pot].effDoublecountingChMap[map_index]);
+              for ( const auto& rechits : *diamondRecHits ) {
+                CTPPSDiamondDetId detId_hit( rechits.detId() );
+                if ( detId_hit == detId ) {
+                  for ( const auto& rechit : rechits ) {
+                    if ( track.containsHit( rechit, 1 ) ) {
+                      // Channel fired
+                      ++(potPlots_[detId_pot].effTriplecountingChMap[map_index]);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Tomography of diamonds using pixel
   for ( const auto& rechits : *diamondRecHits ) {
     CTPPSDiamondDetId detId_pot( rechits.detId() );
     detId_pot.setPlane( 0 );
     detId_pot.setChannel( 0 );
     const CTPPSDiamondDetId detId( rechits.detId() );
-
     for ( const auto& rechit : rechits ) {
       if ( excludeMultipleHits_ && rechit.getMultipleHits() > 0 ) continue;
       if ( rechit.getToT() == 0 ) continue;
-      if ( !stripTracks.isValid() ) continue;
+      if ( !pixelTracks.isValid() ) continue;
       if ( potPlots_.find( detId_pot ) == potPlots_.end() ) continue;
 
-      for ( const auto& ds : *stripTracks ) {
-        const CTPPSDetId stripId( ds.detId() );
-        for ( const auto& striplt : ds ) {
-          if ( !striplt.isValid() ) continue;
-          if ( stripId.arm() != detId_pot.arm() ) continue;
-          if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
-          if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
-          if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-            if ( (unsigned int) rechit.getOOTIndex() < potPlots_[detId_pot].stripTomographyAllFar.size() )
-              potPlots_[detId_pot].stripTomographyAllFar.at( rechit.getOOTIndex() )->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
+      for ( const auto& ds : *pixelTracks ) {
+        const CTPPSPixelDetId pixId( ds.detId() );
+        if ( pixId.station() != CTPPS_PIXEL_STATION_ID || pixId.rp() != CTPPS_FAR_RP_ID ) continue;
+        for ( const auto& lt : ds ) {
+          if ( lt.isValid() && pixId.arm() == detId_pot.arm() ) {
+            if ( rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.getOOTIndex() - centralOOT_ + 1 < (int) potPlots_[detId_pot].pixelTomographyAll.size() && rechit.getOOTIndex() - centralOOT_ + 1  >= 0 )
+              potPlots_[detId_pot].pixelTomographyAll.at( rechit.getOOTIndex() - centralOOT_ + 1  )->Fill( lt.getX0() - horizontalShiftBwDiamondPixels_ + 25*detId.plane(), lt.getY0() );
           }
         }
       }
@@ -794,7 +902,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       if ( planePlots_.find( detId_plane ) != planePlots_.end() ) {
         if ( centralOOT_ != -999 && rechit.getOOTIndex() == centralOOT_ ) {
           TH1F *hitHistoTmp = planePlots_[detId_plane].hitProfile->getTH1F();
-          int startBin = hitHistoTmp->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
+          int startBin = hitHistoTmp->FindBin( rechit.getX() - horizontalShiftOfDiamond_ - 0.5*rechit.getXWidth() );
           int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
           for ( int i=0; i<numOfBins; ++i) {
             hitHistoTmp->Fill( hitHistoTmp->GetBinCenter(startBin+i) );
@@ -803,31 +911,44 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       }
     }
   }
-
-  // Tomography of diamonds using strips
-  for ( const auto& rechits : *diamondRecHits ) {
-    CTPPSDiamondDetId detId_plane( rechits.detId() );
-    detId_plane.setChannel( 0 );
-    for ( const auto& rechit : rechits ) {
-      if ( excludeMultipleHits_ && rechit.getMultipleHits() > 0 ) continue;
-      if ( rechit.getToT() == 0 ) continue;
-      if ( !stripTracks.isValid() ) continue;
-      if (planePlots_.find(detId_plane) == planePlots_.end()) continue;
-
-      for ( const auto& ds : *stripTracks ) {
-        const CTPPSDetId stripId(ds.detId());
-        for ( const auto& striplt : ds ) {
-          if (! striplt.isValid()) continue;
-          if ( stripId.arm() != detId_plane.arm() ) continue;
-          if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
-          if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
-          if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-            planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0() + 25*rechit.getOOTIndex() , striplt.getY0() );
+  
+  
+  //Tomography of diamonds using pixel and Efficiency WRT Pixels
+  for ( const auto& ds : *pixelTracks ) {
+    const CTPPSPixelDetId pixId( ds.detId() );
+    if ( pixId.station() != CTPPS_PIXEL_STATION_ID || pixId.rp() != CTPPS_FAR_RP_ID ) continue;
+    if ( ds.size() > 1 ) continue;
+    for ( const auto& lt : ds ) {
+      if ( lt.isValid() ) {
+        // For efficieny
+        CTPPSDiamondDetId detId_pot( pixId.arm(), CTPPS_DIAMOND_STATION_ID, CTPPS_DIAMOND_RP_ID );
+        potPlots_[detId_pot].pixelTracksMap.Fill(  lt.getX0() - horizontalShiftBwDiamondPixels_, lt.getY0() );         
+        
+        std::set< CTPPSDiamondDetId > planesWitHits_set;
+        for ( const auto& rechits : *diamondRecHits ) {
+          CTPPSDiamondDetId detId_plane( rechits.detId() );
+          detId_plane.setChannel( 0 );
+          for ( const auto& rechit : rechits ) {
+            if ( excludeMultipleHits_ && rechit.getMultipleHits() > 0 ) continue;
+            if ( rechit.getOOTIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING || rechit.getToT() == 0 ) continue;
+            if ( planePlots_.find(detId_plane) == planePlots_.end() ) continue;
+            if ( pixId.arm() == detId_plane.arm() ) {
+              planePlots_[detId_plane].pixelTomography_far->Fill( lt.getX0() - horizontalShiftBwDiamondPixels_ + 25*rechit.getOOTIndex(), lt.getY0() );
+              if ( centralOOT_ != -999 && rechit.getOOTIndex() == centralOOT_ ) planesWitHits_set.insert( detId_plane );
+            }
+            
           }
         }
+        
+        for (auto& planeId : planesWitHits_set)
+          planePlots_[planeId].pixelTracksMapWithDiamonds.Fill( lt.getX0() - horizontalShiftBwDiamondPixels_, lt.getY0() );
+        
       }
+        
     }
   }
+  
+  
   //------------------------------
   // Channel Plots
   //------------------------------
@@ -885,41 +1006,39 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
     for ( const auto& rechit : rechits ) {
       if ( excludeMultipleHits_ && rechit.getMultipleHits() > 0 ) continue;
       if ( channelPlots_.find( detId ) != channelPlots_.end() ) {
-        if ( rechit.getToT() != 0 ) {
+        if ( rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.getToT() != 0 ) {
           channelPlots_[detId].leadingEdgeCumulative_both->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
           channelPlots_[detId].TimeOverThresholdCumulativePerChannel->Fill( rechit.getToT() );
         }
         ++(channelPlots_[detId].hitsCounterPerLumisection);
       }
 
-      if ( (unsigned int) rechit.getOOTIndex() < channelPlots_[detId].activity_per_bx.size() )
+      if ( rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.getOOTIndex() < (int) channelPlots_[detId].activity_per_bx.size() )
         channelPlots_[detId].activity_per_bx.at( rechit.getOOTIndex() )->Fill( event.bunchCrossing() );
     }
 
   }
 
-  // Tomography of diamonds using strips
+  // Tomography of diamonds using pixel
   for ( const auto& rechits : *diamondRecHits ) {
     const CTPPSDiamondDetId detId( rechits.detId() );
     for ( const auto& rechit : rechits ) {
       if ( excludeMultipleHits_ && rechit.getMultipleHits() > 0 ) continue;
-      if ( stripTracks.isValid() ) {
-        if (channelPlots_.find(detId) == channelPlots_.end()) continue;
-        for ( const auto& ds : *stripTracks ) {
-          for ( const auto& striplt : ds ) {
-            CTPPSDetId stripId(ds.detId());
-            if ( !striplt.isValid() ) continue;
-            if ( stripId.arm() != detId.arm() ) continue;
-            if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
-            if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
-            if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-              channelPlots_[detId].stripTomography_far->Fill( striplt.getX0() + 25*rechit.getOOTIndex(), striplt.getY0() );
-            }
-          }
+      if ( rechit.getOOTIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING || rechit.getToT() == 0 ) continue;
+      if ( !pixelTracks.isValid() ) continue;
+      if (channelPlots_.find(detId) == channelPlots_.end()) continue;
+
+      for ( const auto& ds : *pixelTracks ) {
+        const CTPPSPixelDetId pixId( ds.detId() );
+        if ( pixId.station() != CTPPS_PIXEL_STATION_ID || pixId.rp() != CTPPS_FAR_RP_ID ) continue;
+        for ( const auto& lt : ds ) {
+          if ( lt.isValid() && pixId.arm() == detId.arm() )
+            channelPlots_[detId].pixelTomography_far->Fill( lt.getX0() - horizontalShiftBwDiamondPixels_ + 25*rechit.getOOTIndex(), lt.getY0() );
         }
       }
     }
   }
+  
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -962,6 +1081,32 @@ CTPPSDiamondDQMSource::endLuminosityBlock( const edm::LuminosityBlock&, const ed
     
   }
   
+  // Efficiencies of single channels
+  for ( auto& plot : potPlots_ ) {
+  plot.second.EfficiencyOfChannelsInPot->Reset();
+    for ( auto& element : plot.second.effTriplecountingChMap ) { 
+      if ( plot.second.effDoublecountingChMap[ element.first ] > 0) {
+        int plane = element.first / 100;
+        int channel = element.first % 100;
+        double counted = element.second;
+        double total = plot.second.effDoublecountingChMap[ element.first ];
+        double efficiency = counted / total;
+//         double error = std::sqrt( efficiency * ( 1 - efficiency ) / total );
+        
+        plot.second.EfficiencyOfChannelsInPot->Fill(plane, channel, 100*efficiency);        
+      }
+    }
+  }
+  
+  // Efficeincy wrt pixels  //TODO
+  for ( auto& plot : planePlots_ ) {
+    TH2F *hitHistoTmp = plot.second.EfficiencyWRTPixelsInPlane->getTH2F();
+    
+    CTPPSDiamondDetId detId_pot( plot.first );
+    detId_pot.setPlane( 0 );
+    
+    hitHistoTmp->Divide( &(plot.second.pixelTracksMapWithDiamonds), &(potPlots_[detId_pot].pixelTracksMap) );
+  }
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -8,10 +8,9 @@ ctppsDiamondDQMSource = DQMEDAnalyzer('CTPPSDiamondDQMSource',
     tagDiamondRecHits = cms.InputTag("ctppsDiamondRecHits"),
     tagDiamondLocalTracks = cms.InputTag("ctppsDiamondLocalTracks"),
     tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
+    tagPixelLocalTracks = cms.InputTag("ctppsPixelLocalTracks"),
     
     excludeMultipleHits = cms.bool(True),
-    minimumStripAngleForTomography = cms.double(0),
-    maximumStripAngleForTomography = cms.double(1),
 
     offsetsOOT = cms.VPSet( # cut on the OOT bin for physics hits
         # 2016, after TS2

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -7,7 +7,6 @@ ctppsDiamondDQMSource = DQMEDAnalyzer('CTPPSDiamondDQMSource',
     tagFEDInfo = cms.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
     tagDiamondRecHits = cms.InputTag("ctppsDiamondRecHits"),
     tagDiamondLocalTracks = cms.InputTag("ctppsDiamondLocalTracks"),
-    tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
     tagPixelLocalTracks = cms.InputTag("ctppsPixelLocalTracks"),
     
     excludeMultipleHits = cms.bool(True),

--- a/DQM/CTPPS/test/diamond_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/diamond_dqm_test_cfg.py
@@ -14,6 +14,12 @@ process.MessageLogger = cms.Service("MessageLogger",
         threshold = cms.untracked.string('WARNING')
     )
 )
+    
+    # import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 # load DQM framework
 process.load("DQM.Integration.config.environment_cfi")
@@ -23,14 +29,52 @@ process.dqmSaver.path = ""
 process.dqmSaver.tag = "CTPPS"
 
 # raw data source
-process.source = cms.Source("NewEventStreamFileReader",
-  fileNames = cms.untracked.vstring(
-    #'file:/afs/cern.ch/user/j/jkaspar/public/run273062_ls0001-2_stream.root'
-    #'/store/t0streamer/Data/Physics/000/294/737/run294737_ls0011_streamPhysics_StorageManager.dat',
-    '/store/t0streamer/Minidaq/A/000/295/626/run295626_ls0001_streamA_StorageManager.dat',
-  )
+process.source = cms.Source("PoolSource",
+    # replace 'myfile.root',',' with the source file you want to use
+    fileNames = cms.untracked.vstring(
+    *(
+           '/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/02448DBC-0A77-E711-8240-02163E01A2ED.root',
+#'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/106FE4C4-0D77-E711-8785-02163E01373C.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/469D8C89-1477-E711-A6A4-02163E01190C.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/4C729FDF-0C77-E711-A078-02163E014548.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/664E5FE8-0C77-E711-917D-02163E01469B.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/6A5C61DE-0C77-E711-A08C-02163E013720.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/6A76D2EC-0E77-E711-8903-02163E01A7A5.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/82937E4A-0C77-E711-8725-02163E01421E.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/8A8595B1-1177-E711-B1E8-02163E014761.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/A2BDBF69-1677-E711-83E2-02163E01A4ED.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/A4F9404C-0B77-E711-ADB0-02163E0134D7.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/A615970E-1177-E711-9AA8-02163E0139D9.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/ACBCD4BB-0F77-E711-9AB2-02163E014342.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/C2D92F59-0C77-E711-B3AD-02163E01A5B4.root',
+#'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/E041BD4B-0B77-E711-A90A-02163E012140.root',
+
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/1E2FB550-5190-E711-8010-02163E01A731.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/ECE07B13-5C90-E711-AA7C-02163E011DDC.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/AABBE824-5990-E711-BE37-02163E0144E2.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/562C1C92-5A90-E711-904D-02163E01A2C7.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/D23D5509-6390-E711-B82E-02163E014785.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/88377025-5990-E711-8E26-02163E01A4E6.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/FE7699DC-5990-E711-8DF5-02163E011D9E.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/600BB493-5A90-E711-84EE-02163E01A1EB.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/AA6E5A99-6090-E711-B9AA-02163E012B3A.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/F45AD155-5B90-E711-8ACE-02163E019C49.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/909B3BB3-5C90-E711-8649-02163E01A1EB.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/ACC8407D-5890-E711-A88A-02163E0134FB.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/A4DF7114-5E90-E711-9BD7-02163E011D9E.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/9EF2EBDC-5990-E711-BC87-02163E0138EC.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/DE7748D6-5C90-E711-A008-02163E011B3C.root',
+
+     )
+    ),
+    #inputCommands = cms.untracked.vstring(
+       #'drop CTPPSPixelCluseredmDetSetVector_ctppsPixelClusters__RECO'
+    #)
 )
 
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_hlt_relval', '')
 
 # raw-to-digi conversion
 process.load("EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff")
@@ -45,19 +89,23 @@ process.load('RecoCTPPS.TotemRPLocal.ctppsDiamondRecHits_cfi')
 # local tracks fitter
 process.load('RecoCTPPS.TotemRPLocal.ctppsDiamondLocalTracks_cfi')
 
+# pixel
+process.load('RecoCTPPS.PixelLocal.ctppsPixelLocalTracks_cfi')
 
 # CTPPS DQM modules
 process.load("DQM.CTPPS.ctppsDQM_cff")
 process.ctppsDiamondDQMSource.excludeMultipleHits = cms.bool(True);
 
 process.path = cms.Path(
-    process.ctppsRawToDigi *
+    #process.ctppsRawToDigi *
     process.recoCTPPS *
-    process.ctppsDiamondRawToDigi *
+    #process.ctppsDiamondRawToDigi *
     process.ctppsDiamondRecHits *
     process.ctppsDiamondLocalTracks *
+    process.ctppsPixelLocalTracks *
     process.ctppsDQM
-)
+    )
+
 
 process.end_path = cms.EndPath(
     process.dqmEnv +

--- a/DQM/CTPPS/test/diamond_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/diamond_dqm_test_cfg.py
@@ -30,46 +30,12 @@ process.dqmSaver.tag = "CTPPS"
 
 # raw data source
 process.source = cms.Source("PoolSource",
-    # replace 'myfile.root',',' with the source file you want to use
+    # replace '*.root',',' with the source file you want to use
     fileNames = cms.untracked.vstring(
     *(
-           '/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/02448DBC-0A77-E711-8240-02163E01A2ED.root',
-#'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/106FE4C4-0D77-E711-8785-02163E01373C.root',
 '/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/469D8C89-1477-E711-A6A4-02163E01190C.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/4C729FDF-0C77-E711-A078-02163E014548.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/664E5FE8-0C77-E711-917D-02163E01469B.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/6A5C61DE-0C77-E711-A08C-02163E013720.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/6A76D2EC-0E77-E711-8903-02163E01A7A5.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/82937E4A-0C77-E711-8725-02163E01421E.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/8A8595B1-1177-E711-B1E8-02163E014761.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/A2BDBF69-1677-E711-83E2-02163E01A4ED.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/A4F9404C-0B77-E711-ADB0-02163E0134D7.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/A615970E-1177-E711-9AA8-02163E0139D9.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/ACBCD4BB-0F77-E711-9AB2-02163E014342.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/C2D92F59-0C77-E711-B3AD-02163E01A5B4.root',
-#'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/E041BD4B-0B77-E711-A90A-02163E012140.root',
-
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/1E2FB550-5190-E711-8010-02163E01A731.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/ECE07B13-5C90-E711-AA7C-02163E011DDC.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/AABBE824-5990-E711-BE37-02163E0144E2.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/562C1C92-5A90-E711-904D-02163E01A2C7.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/D23D5509-6390-E711-B82E-02163E014785.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/88377025-5990-E711-8E26-02163E01A4E6.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/FE7699DC-5990-E711-8DF5-02163E011D9E.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/600BB493-5A90-E711-84EE-02163E01A1EB.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/AA6E5A99-6090-E711-B9AA-02163E012B3A.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/F45AD155-5B90-E711-8ACE-02163E019C49.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/909B3BB3-5C90-E711-8649-02163E01A1EB.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/ACC8407D-5890-E711-A88A-02163E0134FB.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/A4DF7114-5E90-E711-9BD7-02163E011D9E.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/9EF2EBDC-5990-E711-BC87-02163E0138EC.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/DE7748D6-5C90-E711-A008-02163E011B3C.root',
-
      )
     ),
-    #inputCommands = cms.untracked.vstring(
-       #'drop CTPPSPixelCluseredmDetSetVector_ctppsPixelClusters__RECO'
-    #)
 )
 
 

--- a/DQM/CTPPS/test/diamond_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/diamond_dqm_test_cfg.py
@@ -49,7 +49,6 @@ process.load("EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff")
 process.load("RecoCTPPS.Configuration.recoCTPPS_cff")
 
 # rechits production
-process.load('Geometry.VeryForwardGeometry.geometryRP_cfi')
 process.load('RecoCTPPS.TotemRPLocal.ctppsDiamondRecHits_cfi')
 
 # local tracks fitter


### PR DESCRIPTION
This PR updates the DQM:
- Tomography is now using pixel detectors instead of strip (not installed anymore)
- Efficiency of diamond channels wrt to other diamonds and wrt to pixel detectors
- Increased flexibility of hitmaps: the horizontal position of diamond (horizontalShiftOfDiamond_) is retrieved from the geometry and this value is subtracted such that the hitmaps are always starting from x=0. In a similar way, the offset with pixel detectors is used to properly display the tomography. 
- Updated tests to cope with PR 22264