### PR TITLE
[101X] [Update GT ] Fix PromptLike GT, Rereco GT, and Fix CTPPS geometry BUG in 2017

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,29 +24,29 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '101X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '101X_dataRun2_v5',
+    'run1_data'         :   '101X_dataRun2_v6',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '101X_dataRun2_v5',
+    'run2_data'         :   '101X_dataRun2_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '101X_dataRun2_relval_v5',
+    'run2_data_relval'  :   '101X_dataRun2_relval_v6',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '101X_dataRun2_PromptLike_v5',
+    'run2_data_promptlike' : '101X_dataRun2_PromptLike_v6',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v3',
+    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v4',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v3',
+    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v4',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '101X_dataRun2_HLT_relval_v4',
+    'run2_hlt_relval'   :   '101X_dataRun2_HLT_relval_v5',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v4',
+    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v3',
+    'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '101X_mc2017_realistic_v3',
+    'phase1_2017_realistic'    : '101X_mc2017_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '101X_mc2017cosmics_realistic_deco_v3',
+    'phase1_2017_cosmics'      : '101X_mc2017cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v3',
+    'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '101X_upgrade2018_design_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -30,7 +30,7 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '101X_dataRun2_relval_v5',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '101X_dataRun2_PromptLike_v4',
+    'run2_data_promptlike' : '101X_dataRun2_PromptLike_v5',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v3',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
This PR should fix the issue reported in https://github.com/cms-sw/cmssw/issues/22449
Basically the only new TAGs in 101X_dataRun2_PromptLike_v4 should have been:
CTPPS geometry and ECAL PFrechit tags, but by mistake some other TAGs were changed.
I now created  a new TAG (101X_dataRun2_PromptLike_v5) that solve the problem
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_PromptLike_v5/100X_dataRun2_PromptLike_v1

Similar comment for Rereco GT

Plus this PR fix a bug in 2017 CTPPS geometry (in MC and data TAGs)