### PR TITLE
Addition of histograms to the Muon DQM 

### DIFF
--- a/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
@@ -93,10 +93,6 @@ looseAnalyzerTnP.inputTags.offlinePVs = cms.InputTag("hiSelectedVertex")
 
 pvMonitor.vertexLabel = cms.InputTag("hiSelectedVertex")
 
-muonRecoAnalyzer.inputTagVertex = cms.InputTag("")
-muonRecoAnalyzer.inputTagBeamSpot = cms.InputTag("")
-muonRecoAnalyzer.inputTagVertex = cms.InputTag("")
-muonRecoAnalyzer.inputTagBeamSpot = cms.InputTag("")
 
 
 DQMOfflineHeavyIonsPrePOG = cms.Sequence( muonMonitors

--- a/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
@@ -93,6 +93,11 @@ looseAnalyzerTnP.inputTags.offlinePVs = cms.InputTag("hiSelectedVertex")
 
 pvMonitor.vertexLabel = cms.InputTag("hiSelectedVertex")
 
+muonRecoAnalyzer.inputTagVertex = cms.InputTag("")
+muonRecoAnalyzer.inputTagBeamSpot = cms.InputTag("")
+muonRecoAnalyzer.inputTagVertex = cms.InputTag("")
+muonRecoAnalyzer.inputTagBeamSpot = cms.InputTag("")
+
 
 DQMOfflineHeavyIonsPrePOG = cms.Sequence( muonMonitors
                                           * TrackMonDQMTier0_hi

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -148,6 +148,9 @@ DQMOfflineCommonSiStripZeroBias = cms.Sequence( dqmDcsInfo *
                                  )
 DQMOfflineLumi = cms.Sequence ( zcounting )
 
+muonRecoAnalyzer.doMVA =         cms.bool( True )
+muonRecoAnalyzer_miniAOD.doMVA = cms.bool( True )
+
 DQMOfflineMuon = cms.Sequence( dtSources *
                                rpcTier0Source *
                                cscSources *

--- a/DQMOffline/Muon/interface/DiMuonHistograms.h
+++ b/DQMOffline/Muon/interface/DiMuonHistograms.h
@@ -83,6 +83,10 @@ class DiMuonHistograms : public DQMEDAnalyzer {
   std::vector<MonitorElement*> MediumMediumMuon;
   std::vector<MonitorElement*> TightTightMuon;
   std::vector<MonitorElement*> SoftSoftMuon;
+  std::vector<MonitorElement*> LooseLooseMuonBadFrac;
+  std::vector<MonitorElement*> MediumMediumMuonBadFrac;
+  std::vector<MonitorElement*> TightTightMuonBadFrac;
+  std::vector<MonitorElement*> SoftSoftMuonBadFrac;
   
   MonitorElement* test; // my test
 

--- a/DQMOffline/Muon/interface/EfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/EfficiencyAnalyzer.h
@@ -74,6 +74,9 @@ class EfficiencyAnalyzer : public DQMEDAnalyzer {
   std::string ID_;
 
   MonitorElement* h_passProbes_ID_pt;
+  MonitorElement* h_passProbes_ID_inner_pt;
+  MonitorElement* h_passProbes_ID_inner_eta;
+  MonitorElement* h_passProbes_ID_inner_phi;
   MonitorElement* h_passProbes_ID_EB_pt;
   MonitorElement* h_passProbes_ID_EE_pt;
   MonitorElement* h_passProbes_ID_eta;
@@ -103,6 +106,9 @@ class EfficiencyAnalyzer : public DQMEDAnalyzer {
   MonitorElement* h_allProbes_hp_eta;
   MonitorElement* h_allProbes_phi;
   MonitorElement* h_allProbes_ID_pt;
+  MonitorElement* h_allProbes_inner_pt;
+  MonitorElement* h_allProbes_inner_eta;
+  MonitorElement* h_allProbes_inner_phi;
   MonitorElement* h_allProbes_EB_ID_pt;
   MonitorElement* h_allProbes_EE_ID_pt;
   MonitorElement* h_allProbes_ID_nVtx;

--- a/DQMOffline/Muon/interface/EfficiencyPlotter.h
+++ b/DQMOffline/Muon/interface/EfficiencyPlotter.h
@@ -73,6 +73,9 @@ private:
 
   // efficiency histograms
   MonitorElement* h_eff_pt_ID;
+  MonitorElement* h_eff_inner_pt_ID;
+  MonitorElement* h_eff_inner_eta_ID;
+  MonitorElement* h_eff_inner_phi_ID;
   MonitorElement* h_eff_pt_EB_ID;
   MonitorElement* h_eff_pt_EE_ID;
   MonitorElement* h_eff_eta_ID;

--- a/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
@@ -65,7 +65,9 @@ class MuonRecoAnalyzer : public DQMEDAnalyzer {
 
   // Switch for verbosity
   std::string metname;
-    
+  std::string theVertexName;  
+  std::string theBeamSpotName;  
+  bool doMVA;
 
   //histo binning parameters
   int etaBin;

--- a/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
@@ -25,6 +25,11 @@
 
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h" 
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Scalers/interface/DcsStatus.h"
+
 
 class MuonRecoAnalyzer : public DQMEDAnalyzer {
  public:
@@ -42,12 +47,22 @@ class MuonRecoAnalyzer : public DQMEDAnalyzer {
   //calculate residual & pull:
   void GetRes( reco::TrackRef t1, reco::TrackRef t2, std::string par, float &res, float &pull);
 
+  //Functions needed by the SoftMuon MVA monitoring
+  double getDeltaR(reco::Track track1, reco::Track track2);
+
+  int getPv(int tidx, const reco::VertexCollection *vc);
+
  private:
   // ----------member data ---------------------------
     MuonServiceProxy *theService;
   edm::ParameterSet parameters;
   
   edm::EDGetTokenT<edm::View<reco::Muon> >   theMuonCollectionLabel_;
+  edm::EDGetTokenT<reco::VertexCollection>      theVertexLabel_;
+  edm::EDGetTokenT<reco::BeamSpot>              theBeamSpotLabel_;
+  edm::EDGetTokenT<DcsStatusCollection> dcsStatusCollection_;
+
+
   // Switch for verbosity
   std::string metname;
     
@@ -89,6 +104,7 @@ class MuonRecoAnalyzer : public DQMEDAnalyzer {
   double tunePMin;
   double tunePMax;
 
+
   //the histos
   MonitorElement* muReco;
   // global muon
@@ -110,6 +126,40 @@ class MuonRecoAnalyzer : public DQMEDAnalyzer {
   std::vector<MonitorElement*> rhAnalysis;
   std::vector<MonitorElement*> muVStkSytemRotation;
   std::vector<MonitorElement*> phiVsetaGlbTrack;
+  std::vector<MonitorElement*> phiVsetaGlbTrack_badlumi;
+
+
+  //Soft MVA Muon
+  MonitorElement * ptSoftMuonMVA;
+  MonitorElement * deltaRSoftMuonMVA;
+  MonitorElement * gNchi2SoftMuonMVA;
+  MonitorElement * vMuHitsSoftMuonMVA;
+  MonitorElement * mNuStationsSoftMuonMVA;
+  MonitorElement * dxyRefSoftMuonMVA;
+  MonitorElement * dzRefSoftMuonMVA;
+  MonitorElement * LWHSoftMuonMVA;
+  MonitorElement * valPixHitsSoftMuonMVA;
+  MonitorElement * innerChi2SoftMuonMVA;
+  MonitorElement * outerChi2SoftMuonMVA;
+  MonitorElement * iValFracSoftMuonMVA;
+  MonitorElement * segCompSoftMuonMVA;
+  MonitorElement * chi2LocMomSoftMuonMVA;
+  MonitorElement * chi2LocPosSoftMuonMVA;
+  MonitorElement * glbTrackTailProbSoftMuonMVA;
+  MonitorElement * NTrkVHitsSoftMuonMVA;
+  MonitorElement * kinkFinderSoftMuonMVA;
+  MonitorElement * vRPChitsSoftMuonMVA;
+  MonitorElement * glbKinkFinderSoftMuonMVA;
+  MonitorElement * glbKinkFinderLogSoftMuonMVA;
+  MonitorElement * staRelChi2SoftMuonMVA;
+  MonitorElement * glbDeltaEtaPhiSoftMuonMVA;
+  MonitorElement * trkRelChi2SoftMuonMVA;
+  MonitorElement * vDThitsSoftMuonMVA ;
+  MonitorElement * vCSChitsSoftMuonMVA;
+  MonitorElement * timeAtIpInOutSoftMuonMVA;
+  MonitorElement * timeAtIpInOutErrSoftMuonMVA;
+  MonitorElement * getMuonHitsPerStationSoftMuonMVA;
+  MonitorElement * QprodSoftMuonMVA;
 
  
   MonitorElement* tunePResolution;

--- a/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
@@ -65,8 +65,6 @@ class MuonRecoAnalyzer : public DQMEDAnalyzer {
 
   // Switch for verbosity
   std::string metname;
-  std::string theVertexName;  
-  std::string theBeamSpotName;  
   bool doMVA;
 
   //histo binning parameters

--- a/DQMOffline/Muon/python/muonMonitors_cff.py
+++ b/DQMOffline/Muon/python/muonMonitors_cff.py
@@ -22,13 +22,13 @@ dqmInfoMuons = DQMEDAnalyzer('DQMEventInfo',
 
 muonTrackAnalyzers = cms.Sequence(MonitorTrackSTAMuons*MonitorTrackGLBMuons*MonitorTrackINNMuons)
 
-muonMonitors = cms.Sequence(#muonTrackAnalyzers*
-                            #dtSegmentsMonitor*
-                            #cscMonitor*
-                            muonAnalyzer)
-                            #muonIdDQM*
-                            #dqmInfoMuons*
-                            #muIsoDQM_seq)
+muonMonitors = cms.Sequence(muonTrackAnalyzers*
+                            dtSegmentsMonitor*
+                            cscMonitor*
+                            muonAnalyzer*
+                            muonIdDQM*
+                            dqmInfoMuons*
+                            muIsoDQM_seq)
 
 muonMonitors_miniAOD = cms.Sequence( muonAnalyzer_miniAOD*
                                      muIsoDQM_seq_miniAOD)

--- a/DQMOffline/Muon/python/muonMonitors_cff.py
+++ b/DQMOffline/Muon/python/muonMonitors_cff.py
@@ -22,13 +22,13 @@ dqmInfoMuons = DQMEDAnalyzer('DQMEventInfo',
 
 muonTrackAnalyzers = cms.Sequence(MonitorTrackSTAMuons*MonitorTrackGLBMuons*MonitorTrackINNMuons)
 
-muonMonitors = cms.Sequence(muonTrackAnalyzers*
-                            dtSegmentsMonitor*
-                            cscMonitor*
-                            muonAnalyzer*
-                            muonIdDQM*
-                            dqmInfoMuons*
-                            muIsoDQM_seq)
+muonMonitors = cms.Sequence(#muonTrackAnalyzers*
+                            #dtSegmentsMonitor*
+                            #cscMonitor*
+                            muonAnalyzer)
+                            #muonIdDQM*
+                            #dqmInfoMuons*
+                            #muIsoDQM_seq)
 
 muonMonitors_miniAOD = cms.Sequence( muonAnalyzer_miniAOD*
                                      muIsoDQM_seq_miniAOD)

--- a/DQMOffline/Muon/python/muonRecoAnalyzer_cfi.py
+++ b/DQMOffline/Muon/python/muonRecoAnalyzer_cfi.py
@@ -6,6 +6,8 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 muonRecoAnalyzer = DQMEDAnalyzer('MuonRecoAnalyzer',
                                   MuonServiceProxy, 
                                   MuonCollection       = cms.InputTag("muons"),
+                                  inputTagVertex       = cms.InputTag("offlinePrimaryVertices"),
+                                  inputTagBeamSpot     = cms.InputTag("offlineBeamSpot"),
                                   IsminiAOD            = cms.bool( False ),
                                   # histograms parameters
                                   thetaBin = cms.int32(100),
@@ -48,6 +50,8 @@ muonRecoAnalyzer = DQMEDAnalyzer('MuonRecoAnalyzer',
 muonRecoAnalyzer_miniAOD = DQMEDAnalyzer('MuonRecoAnalyzer',
                                           MuonServiceProxy, 
                                           MuonCollection = cms.InputTag("slimmedMuons"),
+                                          inputTagVertex       = cms.InputTag("offlinePrimaryVertices"),
+                                          inputTagBeamSpot     = cms.InputTag("offlineBeamSpot"),
                                           IsminiAOD            = cms.bool( True ),
                                           
                                           # histograms parameters

--- a/DQMOffline/Muon/python/muonRecoAnalyzer_cfi.py
+++ b/DQMOffline/Muon/python/muonRecoAnalyzer_cfi.py
@@ -6,9 +6,10 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 muonRecoAnalyzer = DQMEDAnalyzer('MuonRecoAnalyzer',
                                   MuonServiceProxy, 
                                   MuonCollection       = cms.InputTag("muons"),
-                                  inputTagVertex       = cms.InputTag("offlinePrimaryVertices"),
-                                  inputTagBeamSpot     = cms.InputTag("offlineBeamSpot"),
+                                  inputTagVertex       = cms.InputTag("offlinePrimaryVerticescaca"),
+                                  inputTagBeamSpot     = cms.InputTag("offlineBeamSpotcaca"),
                                   IsminiAOD            = cms.bool( False ),
+                                  doMVA                = cms.bool( False ),
                                   # histograms parameters
                                   thetaBin = cms.int32(100),
                                   thetaMin = cms.double(0.0),
@@ -53,7 +54,7 @@ muonRecoAnalyzer_miniAOD = DQMEDAnalyzer('MuonRecoAnalyzer',
                                           inputTagVertex       = cms.InputTag("offlinePrimaryVertices"),
                                           inputTagBeamSpot     = cms.InputTag("offlineBeamSpot"),
                                           IsminiAOD            = cms.bool( True ),
-                                          
+                                          doMVA                = cms.bool( False ),
                                           # histograms parameters
                                           thetaBin = cms.int32(100),
                                           thetaMin = cms.double(0.0),

--- a/DQMOffline/Muon/python/muonRecoAnalyzer_cfi.py
+++ b/DQMOffline/Muon/python/muonRecoAnalyzer_cfi.py
@@ -6,8 +6,8 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 muonRecoAnalyzer = DQMEDAnalyzer('MuonRecoAnalyzer',
                                   MuonServiceProxy, 
                                   MuonCollection       = cms.InputTag("muons"),
-                                  inputTagVertex       = cms.InputTag("offlinePrimaryVerticescaca"),
-                                  inputTagBeamSpot     = cms.InputTag("offlineBeamSpotcaca"),
+                                  inputTagVertex       = cms.InputTag("offlinePrimaryVertices"),
+                                  inputTagBeamSpot     = cms.InputTag("offlineBeamSpot"),
                                   IsminiAOD            = cms.bool( False ),
                                   doMVA                = cms.bool( False ),
                                   # histograms parameters

--- a/DQMOffline/Muon/src/DiMuonHistograms.cc
+++ b/DQMOffline/Muon/src/DiMuonHistograms.cc
@@ -89,9 +89,15 @@ void DiMuonHistograms::bookHistograms(DQMStore::IBooker & ibooker,
     TightTightMuon.push_back(ibooker.book1D("TightTightMuon"+EtaName[iEtaRegion],"InvMass_{Tight,Tight}"+EtaName[iEtaRegion], nBin[iEtaRegion], LowMassMin, LowMassMax));
     MediumMediumMuon.push_back(ibooker.book1D("MediumMediumMuon"+EtaName[iEtaRegion],"InvMass_{Medium,Medium}"+EtaName[iEtaRegion],nBin[iEtaRegion], LowMassMin, LowMassMax));
     LooseLooseMuon.push_back(ibooker.book1D("LooseLooseMuon"+EtaName[iEtaRegion],"InvMass_{Loose,Loose}"+EtaName[iEtaRegion], nBin[iEtaRegion], LowMassMin, LowMassMax));
+    //Fraction of bad hits in the tracker track to the total
+    TightTightMuonBadFrac.push_back(ibooker.book1D("TightTightMuonBadFrac"+EtaName[iEtaRegion],"BadFrac_{Tight,Tight}"+EtaName[iEtaRegion], 10, 0, 0.4));
+    MediumMediumMuonBadFrac.push_back(ibooker.book1D("MediumMediumMuonBadFrac"+EtaName[iEtaRegion],"BadFrac_{Medium,Medium}"+EtaName[iEtaRegion], 10, 0, 0.4));
+    LooseLooseMuonBadFrac.push_back(ibooker.book1D("LooseLooseMuonBadFrac"+EtaName[iEtaRegion],"BadFrac_{Loose,Loose}"+EtaName[iEtaRegion], 10, 0, 0.4));
 
     // low-mass resonances
     SoftSoftMuon.push_back(ibooker.book1D("SoftSoftMuon"+EtaName[iEtaRegion],"InvMass_{Soft,Soft}"+EtaName[iEtaRegion],nBin[iEtaRegion], 0.0, 55.0));
+    SoftSoftMuonBadFrac.push_back(ibooker.book1D("SoftSoftMuonBadFrac"+EtaName[iEtaRegion],"BadFrac_{Soft,Soft}"+EtaName[iEtaRegion], 10, 0, 0.4));
+
   }
 }
 
@@ -184,7 +190,10 @@ void DiMuonHistograms::analyze(const edm::Event & iEvent,const edm::EventSetup& 
 	    for (unsigned int iEtaRegion=0; iEtaRegion<3; iEtaRegion++){
 	      if(fabs(recoCombinedGlbTrack1->eta())>EtaCutMin[iEtaRegion] && fabs(recoCombinedGlbTrack1->eta())<EtaCutMax[iEtaRegion] && 
 		 fabs(recoCombinedGlbTrack2->eta())>EtaCutMin[iEtaRegion] && fabs(recoCombinedGlbTrack2->eta())<EtaCutMax[iEtaRegion]){
-		if (InvMass > 55. && InvMass < 125.) TightTightMuon[iEtaRegion]->Fill(InvMass);
+		if (InvMass > 55. && InvMass < 125.) {
+			TightTightMuon[iEtaRegion]->Fill(InvMass);
+			TightTightMuonBadFrac[iEtaRegion]->Fill(muon1->innerTrack()->lost()/muon1->innerTrack()->found());
+		}
 	      }
 	    }
 	  }
@@ -198,7 +207,10 @@ void DiMuonHistograms::analyze(const edm::Event & iEvent,const edm::EventSetup& 
 	    for (unsigned int iEtaRegion=0; iEtaRegion<3; iEtaRegion++){
 	      if(fabs(recoCombinedGlbTrack1->eta())>EtaCutMin[iEtaRegion] && fabs(recoCombinedGlbTrack1->eta())<EtaCutMax[iEtaRegion] && 
 		 fabs(recoCombinedGlbTrack2->eta())>EtaCutMin[iEtaRegion] && fabs(recoCombinedGlbTrack2->eta())<EtaCutMax[iEtaRegion]){
-		if (InvMass > 55. && InvMass < 125.) MediumMediumMuon[iEtaRegion]->Fill(InvMass);
+		if (InvMass > 55. && InvMass < 125.) {
+			MediumMediumMuon[iEtaRegion]->Fill(InvMass);
+			MediumMediumMuonBadFrac[iEtaRegion]->Fill(muon1->innerTrack()->lost()/muon1->innerTrack()->found());
+		}
 	      }
 	    }
 	  }
@@ -212,7 +224,10 @@ void DiMuonHistograms::analyze(const edm::Event & iEvent,const edm::EventSetup& 
 	    for (unsigned int iEtaRegion=0; iEtaRegion<3; iEtaRegion++){
 	      if(fabs(recoCombinedGlbTrack1->eta())>EtaCutMin[iEtaRegion] && fabs(recoCombinedGlbTrack1->eta())<EtaCutMax[iEtaRegion] && 
 		 fabs(recoCombinedGlbTrack2->eta())>EtaCutMin[iEtaRegion] && fabs(recoCombinedGlbTrack2->eta())<EtaCutMax[iEtaRegion]){
-		if (InvMass > 55. && InvMass < 125.) LooseLooseMuon[iEtaRegion]->Fill(InvMass);
+		if (InvMass > 55. && InvMass < 125.) {
+			LooseLooseMuon[iEtaRegion]->Fill(InvMass);
+			LooseLooseMuonBadFrac[iEtaRegion]->Fill(muon1->innerTrack()->lost()/muon1->innerTrack()->found());
+		}
 	      }
 	    }
 	  }
@@ -291,7 +306,8 @@ void DiMuonHistograms::analyze(const edm::Event & iEvent,const edm::EventSetup& 
 	      
 	      if(fabs(recoTrack1->eta())>EtaCutMin[iEtaRegion] && fabs(recoTrack1->eta())<EtaCutMax[iEtaRegion] &&
 		 fabs(recoTrack2->eta())>EtaCutMin[iEtaRegion] && fabs(recoTrack2->eta())<EtaCutMax[iEtaRegion]){
-		SoftSoftMuon[iEtaRegion]->Fill(InvMass); 
+		    SoftSoftMuon[iEtaRegion]->Fill(InvMass); 
+		    SoftSoftMuonBadFrac[iEtaRegion]->Fill(muon1->innerTrack()->lost()/muon1->innerTrack()->found());
 	      }
 	    }
 	  }

--- a/DQMOffline/Muon/src/EfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/EfficiencyAnalyzer.cc
@@ -72,6 +72,9 @@ void EfficiencyAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
   ibooker.setCurrentFolder(theFolder+ID_);  
 
   h_allProbes_pt     = ibooker.book1D("allProbes_pt","All Probes Pt",              ptBin_, ptMin_, ptMax_);
+  h_allProbes_inner_pt  = ibooker.book1D("allProbes_inner_pt","All Probes inner Pt",   ptBin_, ptMin_, ptMax_);
+  h_allProbes_inner_eta  = ibooker.book1D("allProbes_inner_eta","All Probes inner eta",   etaBin_, etaMin_, etaMax_);
+  h_allProbes_inner_phi  = ibooker.book1D("allProbes_inner_phi","All Probes inner phi",   phiBin_, phiMin_, phiMax_);
   h_allProbes_EB_pt  = ibooker.book1D("allProbes_EB_pt","Barrel: all Probes Pt",   ptBin_, ptMin_, ptMax_);
   h_allProbes_EE_pt  = ibooker.book1D("allProbes_EE_pt","Endcap: all Probes Pt",   ptBin_, ptMin_, ptMax_);
   h_allProbes_eta    = ibooker.book1D("allProbes_eta","All Probes Eta",            etaBin_, etaMin_, etaMax_);
@@ -86,6 +89,9 @@ void EfficiencyAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
   h_allProbes_EE_ID_nVtx = ibooker.book1D("allProbes_EE_ID_nVtx","Endcap: All Probes (ID) nVtx", vtxBin_, vtxMin_, vtxMax_);
 
   h_passProbes_ID_pt     = ibooker.book1D("passProbes_ID_pt","ID Passing Probes Pt", ptBin_ , ptMin_ , ptMax_ );
+  h_passProbes_ID_inner_pt  = ibooker.book1D("passProbes_ID_inner_pt","ID Passing Probes inner Pt",   ptBin_, ptMin_, ptMax_);
+  h_passProbes_ID_inner_eta  = ibooker.book1D("passProbes_ID_inner_eta","ID Passing Probes inner eta",   etaBin_, etaMin_, etaMax_);
+  h_passProbes_ID_inner_phi  = ibooker.book1D("passProbes_ID_inner_phi","ID Passing Probes inner phi",   phiBin_, phiMin_, phiMax_);
   h_passProbes_ID_EB_pt  = ibooker.book1D("passProbes_ID_EB_pt","Barrel: ID Passing Probes Pt", ptBin_ , ptMin_ , ptMax_ );
   h_passProbes_ID_EE_pt  = ibooker.book1D("passProbes_ID_EE_pt","Endcap: ID Passing Probes Pt", ptBin_ , ptMin_ , ptMax_ );
   h_passProbes_ID_eta    = ibooker.book1D("passProbes_ID_eta","ID Passing Probes #eta", etaBin_, etaMin_, etaMax_);
@@ -114,7 +120,7 @@ void EfficiencyAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
   h_passProbes_EB_pfIsodBID_pt = ibooker.book1D("passProbes_EB_pfIsodBID_pt","Barrel: pfIsoID Passing Probes Pt (deltaB PU correction)", ptBin_, ptMin_, ptMax_);
   h_passProbes_EE_pfIsodBID_pt = ibooker.book1D("passProbes_EE_pfIsodBID_pt","Endcap: pfIsoID Passing Probes Pt (deltaB PU correction)", ptBin_, ptMin_, ptMax_);
   h_passProbes_pfIsodBID_nVtx     = ibooker.book1D("passProbes_pfIsodBID_nVtx",    "pfIsoID Passing Probes nVtx (R04) (deltaB PU correction)",  vtxBin_, vtxMin_, vtxMax_);
-h_passProbes_EB_pfIsodBID_nVtx  = ibooker.book1D("passProbes_EB_pfIsodBID_nVtx", "Barrel: pfIsoID Passing Probes nVtx (R04) (deltaB PU correction)",  vtxBin_, vtxMin_, vtxMax_);
+  h_passProbes_EB_pfIsodBID_nVtx  = ibooker.book1D("passProbes_EB_pfIsodBID_nVtx", "Barrel: pfIsoID Passing Probes nVtx (R04) (deltaB PU correction)",  vtxBin_, vtxMin_, vtxMax_);
   h_passProbes_EE_pfIsodBID_nVtx  = ibooker.book1D("passProbes_EE_pfIsodBID_nVtx", "Endcap: pfIsoID Passing Probes nVtx (R04) (deltaB PU correction)",  vtxBin_, vtxMin_, vtxMax_);
 
 #ifdef DEBUG
@@ -264,6 +270,9 @@ void EfficiencyAnalyzer::analyze(const edm::Event & iEvent,const edm::EventSetup
       h_allProbes_pt->Fill(muon2->pt());
       h_allProbes_eta->Fill(muon2->eta());
       h_allProbes_phi->Fill(muon2->phi());
+      h_allProbes_inner_pt->Fill(muon2->innerTrack()->innerMomentum().Rho());
+      h_allProbes_inner_eta->Fill(muon2->innerTrack()->innerPosition().Eta());
+      h_allProbes_inner_phi->Fill(muon2->innerTrack()->innerPosition().Phi());
       
       if (isMB)               h_allProbes_EB_pt->Fill(muon2->pt());
       if (isME)               h_allProbes_EE_pt->Fill(muon2->pt());
@@ -279,6 +288,9 @@ void EfficiencyAnalyzer::analyze(const edm::Event & iEvent,const edm::EventSetup
       h_passProbes_ID_pt->Fill(muon2->pt());
       h_passProbes_ID_eta->Fill(muon2->eta());
       h_passProbes_ID_phi->Fill(muon2->phi());
+      h_passProbes_ID_inner_pt->Fill(muon2->innerTrack()->innerMomentum().Rho());
+      h_passProbes_ID_inner_eta->Fill(muon2->innerTrack()->innerPosition().Eta());
+      h_passProbes_ID_inner_phi->Fill(muon2->innerTrack()->innerPosition().Phi());
       
       if (isMB) h_passProbes_ID_EB_pt->Fill(muon2->pt());
       if (isME) h_passProbes_ID_EE_pt->Fill(muon2->pt());

--- a/DQMOffline/Muon/src/EfficiencyPlotter.cc
+++ b/DQMOffline/Muon/src/EfficiencyPlotter.cc
@@ -59,6 +59,9 @@ void EfficiencyPlotter::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGetter
   
   // efficiency plot
   h_eff_eta_ID          = ibooker.book1D("Eff_eta_"+ID_,          ID_+" Eff. vs #eta",                  etaBin, etaMin, etaMax);
+  h_eff_inner_pt_ID     = ibooker.book1D("Eff_inner_pt_"+ID_,     ID_+" Eff. vs pt",                    ptBin, ptMin, ptMax);
+  h_eff_inner_eta_ID    = ibooker.book1D("Eff_inner_eta_"+ID_,    ID_+" Eff. vs #eta",                  etaBin, etaMin, etaMax);
+  h_eff_inner_phi_ID    = ibooker.book1D("Eff_inner_phi_"+ID_,    ID_+" Eff. vs #phi",                  phiBin, phiMin, phiMax);
   h_eff_hp_eta_ID       = ibooker.book1D("Eff_hp_eta_"+ID_,       "High Pt "+ID_+" Eff. vs #eta",       etaBin, etaMin, etaMax);
   h_eff_phi_ID          = ibooker.book1D("Eff_phi_"+ID_,          ID_+" Eff. vs #phi",                  phiBin, phiMin, phiMax);
   h_eff_pt_ID           = ibooker.book1D("Eff_pt_"+ID_,           ID_+" Eff. vs Pt",                    ptBin, ptMin, ptMax);
@@ -86,6 +89,9 @@ void EfficiencyPlotter::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGetter
 
   // This prevents this ME to be normalized when drawn into the GUI
   h_eff_eta_ID         ->setEfficiencyFlag();
+  h_eff_inner_eta_ID   ->setEfficiencyFlag();
+  h_eff_inner_pt_ID    ->setEfficiencyFlag();
+  h_eff_inner_phi_ID   ->setEfficiencyFlag();
   h_eff_hp_eta_ID      ->setEfficiencyFlag();
   h_eff_phi_ID         ->setEfficiencyFlag();
   h_eff_pt_ID          ->setEfficiencyFlag();
@@ -114,6 +120,9 @@ void EfficiencyPlotter::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGetter
 
   // AXIS TITLES....
   h_eff_hp_eta_ID      ->setAxisTitle("#eta",         1);  
+  h_eff_inner_eta_ID   ->setAxisTitle("#eta",         1);  
+  h_eff_inner_pt_ID    ->setAxisTitle("#eta",         1);  
+  h_eff_inner_phi_ID   ->setAxisTitle("#eta",         1);  
   h_eff_eta_ID         ->setAxisTitle("#eta",         1);  
   h_eff_phi_ID         ->setAxisTitle("#phi",         1);  
   h_eff_pt_ID          ->setAxisTitle("p_{T} (GeV)",  1);  
@@ -156,6 +165,54 @@ void EfficiencyPlotter::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGetter
     if (h_eff_pt->GetSumw2N() == 0) h_eff_pt->Sumw2();  
     h_eff_pt->Divide(h_numerator_pt, h_denominator_pt, 1., 1., "B");
   }
+  
+  /// --- Tight Muon efficiency vs muon inner Pt 
+  string numpath_inner_pt = inputdir+"/passProbes_ID_inner_pt";
+  string denpath_inner_pt = inputdir+"/allProbes_inner_pt";
+  
+  MonitorElement *Numerator_inner_pt   = igetter.get(numpath_inner_pt);
+  MonitorElement *Denominator_inner_pt = igetter.get(denpath_inner_pt);
+  
+  if (Numerator_inner_pt && Denominator_inner_pt){
+    TH1F *h_numerator_inner_pt   = Numerator_inner_pt->getTH1F();
+    TH1F *h_denominator_inner_pt = Denominator_inner_pt->getTH1F();
+    TH1F *h_eff_inner_pt         = h_eff_inner_pt_ID->getTH1F();
+    
+    if (h_eff_inner_pt->GetSumw2N() == 0) h_eff_inner_pt->Sumw2();  
+    h_eff_inner_pt->Divide(h_numerator_inner_pt, h_denominator_inner_pt, 1., 1., "B");
+  }
+
+  /// --- Tight Muon efficiency vs muon inner eta 
+  string numpath_inner_eta = inputdir+"/passProbes_ID_inner_eta";
+  string denpath_inner_eta = inputdir+"/allProbes_inner_eta";
+  
+  MonitorElement *Numerator_inner_eta   = igetter.get(numpath_inner_eta);
+  MonitorElement *Denominator_inner_eta = igetter.get(denpath_inner_eta);
+  
+  if (Numerator_inner_eta && Denominator_inner_eta){
+    TH1F *h_numerator_inner_eta   = Numerator_inner_eta->getTH1F();
+    TH1F *h_denominator_inner_eta = Denominator_inner_eta->getTH1F();
+    TH1F *h_eff_inner_eta         = h_eff_inner_eta_ID->getTH1F();
+    
+    if (h_eff_inner_eta->GetSumw2N() == 0) h_eff_inner_eta->Sumw2();  
+    h_eff_inner_eta->Divide(h_numerator_inner_eta, h_denominator_inner_eta, 1., 1., "B");
+  }
+
+  /// --- Tight Muon efficiency vs muon inner phi 
+  string numpath_inner_phi = inputdir+"/passProbes_ID_inner_phi";
+  string denpath_inner_phi = inputdir+"/allProbes_inner_phi";
+  
+  MonitorElement *Numerator_inner_phi   = igetter.get(numpath_inner_phi);
+  MonitorElement *Denominator_inner_phi = igetter.get(denpath_inner_phi);
+  
+  if (Numerator_inner_phi && Denominator_inner_phi){
+    TH1F *h_numerator_inner_phi   = Numerator_inner_phi->getTH1F();
+    TH1F *h_denominator_inner_phi = Denominator_inner_phi->getTH1F();
+    TH1F *h_eff_inner_phi         = h_eff_inner_phi_ID->getTH1F();
+    
+    if (h_eff_inner_phi->GetSumw2N() == 0) h_eff_inner_phi->Sumw2();  
+    h_eff_inner_phi->Divide(h_numerator_inner_phi, h_denominator_inner_phi, 1., 1., "B");
+  }  
   
   /// --- Tight Muon efficiency vs muon Pt [EB]
   string numpath_EB_pt = inputdir+"/passProbes_ID_EB_pt";

--- a/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
@@ -4,7 +4,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h" 
 #include "DataFormats/MuonReco/interface/MuonEnergy.h"
-
+#include "DataFormats/Scalers/interface/DcsStatus.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
@@ -26,6 +26,9 @@ MuonRecoAnalyzer::MuonRecoAnalyzer(const edm::ParameterSet& pSet) {
   // the services:
   theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
   theMuonCollectionLabel_ = consumes<edm::View<reco::Muon> >  (parameters.getParameter<edm::InputTag>("MuonCollection"));
+  theVertexLabel_   = consumes<reco::VertexCollection>     (pSet.getParameter<InputTag>("inputTagVertex"));
+  theBeamSpotLabel_ = consumes<reco::BeamSpot>             (pSet.getParameter<InputTag>("inputTagBeamSpot"));
+  dcsStatusCollection_ = consumes<DcsStatusCollection>(pSet.getUntrackedParameter<std::string>("dcsStatusCollection","scalersRawToDigi"));
 
   ptBin = parameters.getParameter<int>("ptBin");
   ptMin = parameters.getParameter<double>("ptMin");
@@ -196,6 +199,42 @@ void MuonRecoAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
   ptStaTrack = ibooker.book1D("StaMuon_pt", "pt_{STA}", ptBin, ptMin, pMax);
   ptStaTrack->setAxisTitle("GeV"); 
 
+
+  //monitoring of variables needed by the MVA soft muon
+  
+  ptSoftMuonMVA =                       ibooker.book1D("ptSoftMuonMVA", "pt_{SoftMuon}", 50, 0, 50);
+  deltaRSoftMuonMVA =                   ibooker.book1D("deltaRSoftMuonMVA", "#Delta R", 50, 0, 5);
+  gNchi2SoftMuonMVA =                   ibooker.book1D("gNchi2SoftMuonMVA", "gNchi2", 50, 0, 3);
+  vMuHitsSoftMuonMVA =                  ibooker.book1D("vMuHitsSoftMuonMVA", "vMuHits", 50, 0, 50);
+  mNuStationsSoftMuonMVA =              ibooker.book1D("mNuStationsSoftMuonMVA", "mNuStations", 6, 0, 6);
+  dxyRefSoftMuonMVA =                   ibooker.book1D("dxyRefSoftMuonMVA", "dxyRef", 50, -0.1, 0.1);
+  dzRefSoftMuonMVA =                    ibooker.book1D("dzRefSoftMuonMVA", "dzRef", 50, -0.1, 0.1);
+  LWHSoftMuonMVA =                      ibooker.book1D("LWHSoftMuonMVA", "LWH", 20, 0, 20);
+  valPixHitsSoftMuonMVA =               ibooker.book1D("valPixHitsSoftMuonMVA", "valPixHits", 8, 0, 8);
+  innerChi2SoftMuonMVA =                ibooker.book1D("innerChi2SoftMuonMVA", "innerChi2", 50, 0, 3);
+  outerChi2SoftMuonMVA =                ibooker.book1D("outerChi2SoftMuonMVA", "outerChi2", 50, 0, 4);
+  iValFracSoftMuonMVA =                 ibooker.book1D("iValFracSoftMuonMVA", "iValFrac", 50, 0.5, 1.0);
+  segCompSoftMuonMVA =                  ibooker.book1D("segCompSoftMuonMVA", "segComp", 50, 0, 1.2);
+  chi2LocMomSoftMuonMVA =               ibooker.book1D("chi2LocMomSoftMuonMVA", "chi2LocMom", 50, 0, 40);
+  chi2LocPosSoftMuonMVA =               ibooker.book1D("chi2LocPosSoftMuonMVA", "chi2LocPos", 0, 0, 8);
+  glbTrackTailProbSoftMuonMVA =         ibooker.book1D("glbTrackTailProbSoftMuonMVA", "glbTrackTailProb", 50, 0, 8);
+  NTrkVHitsSoftMuonMVA =                ibooker.book1D("NTrkVHitsSoftMuonMVA", "NTrkVHits", 50, 0, 35);
+  kinkFinderSoftMuonMVA =               ibooker.book1D("kinkFinderSoftMuonMVA", "kinkFinder", 50, 0, 30);
+  vRPChitsSoftMuonMVA =                 ibooker.book1D("vRPChitsSoftMuonMVA", "vRPChits", 50, 0, 50);
+  glbKinkFinderSoftMuonMVA =            ibooker.book1D("glbKinkFinderSoftMuonMVA", "glbKinkFinder", 50, 0, 50);
+  glbKinkFinderLogSoftMuonMVA =         ibooker.book1D("glbKinkFinderLogSoftMuonMVA", "glbKinkFinderLog", 50, 0, 50);
+  staRelChi2SoftMuonMVA =               ibooker.book1D("staRelChi2SoftMuonMVA", "staRelChi2", 50, 0, 2);
+  glbDeltaEtaPhiSoftMuonMVA =           ibooker.book1D("glbDeltaEtaPhiSoftMuonMVA", "glbDeltaEtaPhi", 50, 0, 0.15);
+  trkRelChi2SoftMuonMVA =               ibooker.book1D("trkRelChi2SoftMuonMVA", "trkRelChi2", 50, 0, 1.2);
+  vDThitsSoftMuonMVA =                  ibooker.book1D("vDThitsSoftMuonMVA", "vDThits", 50, 0, 50);
+  vCSChitsSoftMuonMVA =                 ibooker.book1D("vCSChitsSoftMuonMVA", "vCSChits", 50, 0, 50);
+  timeAtIpInOutSoftMuonMVA =            ibooker.book1D("timeAtIpInOutSoftMuonMVA", "timeAtIpInOut", 50, -10.0, 10.0);
+  timeAtIpInOutErrSoftMuonMVA =         ibooker.book1D("timeAtIpInOutErrSoftMuonMVA", "timeAtIpInOutErr", 50, 0, 3.5);
+  getMuonHitsPerStationSoftMuonMVA =    ibooker.book1D("getMuonHitsPerStationSoftMuonMVA", "getMuonHitsPerStation", 6, 0, 6);
+  QprodSoftMuonMVA =                    ibooker.book1D("QprodSoftMuonMVA", "Qprod", 4, -2, 2);
+    
+
+
   // monitoring of the muon charge
   qGlbTrack.push_back(ibooker.book1D(histname+"Glb_q", "q_{GLB}", 5, -2.5, 2.5));
   qGlbTrack.push_back(ibooker.book1D(histname+"Tk_q", "q_{TKfromGLB}", 5, -2.5, 2.5));
@@ -277,6 +316,10 @@ void MuonRecoAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
   phiVsetaGlbTrack.push_back(ibooker.book2D(histname+"Tk_phiVSeta",       "#phi vs #eta (TKfromGLB)",  etaBin/2, etaMin, etaMax, phiBin/2, phiMin, phiMax));
   phiVsetaGlbTrack.push_back(ibooker.book2D(histname+"Sta_phiVseta",      "#phi vs #eta (STAfromGLB)", etaBin/2, etaMin, etaMax, phiBin/2, phiMin, phiMax));
   
+  phiVsetaGlbTrack_badlumi.push_back(ibooker.book2D(histname+"Glb_phiVSeta_badlumi",      "#phi vs #eta (GLB)",        etaBin/2, etaMin, etaMax, phiBin/2, phiMin, phiMax));
+  phiVsetaGlbTrack_badlumi.push_back(ibooker.book2D(histname+"Tk_phiVSeta_badlumi",       "#phi vs #eta (TKfromGLB)",  etaBin/2, etaMin, etaMax, phiBin/2, phiMin, phiMax));
+  phiVsetaGlbTrack_badlumi.push_back(ibooker.book2D(histname+"Sta_phiVseta_badlumi",      "#phi vs #eta (STAfromGLB)", etaBin/2, etaMin, etaMax, phiBin/2, phiMin, phiMax));
+  
   
   //////////////////////////////////////////////////////////////
   // monitoring of the recHits provenance
@@ -332,6 +375,15 @@ void MuonRecoAnalyzer::GetRes( reco::TrackRef t1, reco::TrackRef t2, string par,
   else pull = -99;
   return;
 }
+
+
+
+
+
+
+
+
+
 void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup){
   LogTrace(metname)<<"[MuonRecoAnalyzer] Analyze the mu";
   theService->update(iSetup);
@@ -339,22 +391,112 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   // Take the muon container
   edm::Handle<edm::View<reco::Muon> > muons; 
   iEvent.getByToken(theMuonCollectionLabel_,muons);
- 
+
+  Handle<reco::BeamSpot> beamSpot;
+  iEvent.getByToken(theBeamSpotLabel_, beamSpot);
+
+  Handle<reco::VertexCollection> vertex;
+  iEvent.getByToken(theVertexLabel_, vertex);
+
+  //In this part we determine if we want to fill the plots for events where the DCS flag was set to bad
+  edm::Handle<DcsStatusCollection> dcsStatus;
+  bool fillBadLumi = false;
+  if(iEvent.getByToken(dcsStatusCollection_, dcsStatus) && dcsStatus.isValid()) {
+     for (auto const & dcsStatusItr : *dcsStatus) {
+       if (!dcsStatusItr.ready(DcsStatus::CSCp))   fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::CSCm))   fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::DT0))    fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::DTp))    fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::DTm))    fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::EBp))    fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::EBm))    fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::EEp))    fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::EEm))    fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::ESp))    fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::ESm))    fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::HBHEa))  fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::HBHEb))  fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::HBHEc))  fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::HF))     fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::HO))     fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::BPIX))   fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::FPIX))   fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::RPC))    fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::TIBTID)) fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::TOB))    fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::TECp))   fillBadLumi = true;
+       if (!dcsStatusItr.ready(DcsStatus::TECm))   fillBadLumi = true;
+       //if (!dcsStatusItr.ready(DcsStatus::CASTOR)) fillBadLumi = true;
+    }
+  }
 
   float res=0, pull=0;
   if(!muons.isValid()) return;
 
   for (edm::View<reco::Muon>::const_iterator muon = muons->begin(); muon != muons->end(); ++muon){
+
+
+    //Needed for MVA soft muon
+    
+    reco::TrackRef gTrack = muon->globalTrack();
+    reco::TrackRef iTrack = muon->innerTrack();
+    reco::TrackRef oTrack = muon->outerTrack();
+    if ( iTrack.isNonnull() && oTrack.isNonnull() && gTrack.isNonnull() ) {
+      const reco::HitPattern gHits = gTrack->hitPattern();
+      const reco::HitPattern iHits = iTrack->hitPattern();
+      const reco::MuonQuality muonQuality = muon->combinedQuality();
       
+      int pvIndex = getPv(iTrack.index(), &(*vertex)); //HFDumpUtitilies
+      math::XYZPoint refPoint;
+      if (pvIndex > -1) {
+	refPoint = vertex->at(pvIndex).position();
+      } else {
+	if (&(*beamSpot)==NULL) {
+	  refPoint = beamSpot->position();
+	} else {
+	  cout << "ERROR: No beam sport found!" << endl;
+	}
+      }
+      ptSoftMuonMVA->Fill(iTrack->eta());
+      deltaRSoftMuonMVA->Fill(getDeltaR(*iTrack,*oTrack));
+      gNchi2SoftMuonMVA->Fill(gTrack->normalizedChi2());
+      vMuHitsSoftMuonMVA->Fill(gHits.numberOfValidMuonHits());
+      mNuStationsSoftMuonMVA->Fill(muon->numberOfMatchedStations());
+      dxyRefSoftMuonMVA->Fill(iTrack->dxy(refPoint));
+      dzRefSoftMuonMVA->Fill(iTrack->dz(refPoint));
+      LWHSoftMuonMVA->Fill(iHits.trackerLayersWithMeasurement());
+      valPixHitsSoftMuonMVA->Fill(iHits.numberOfValidPixelHits());
+      innerChi2SoftMuonMVA->Fill(iTrack->normalizedChi2());
+      outerChi2SoftMuonMVA->Fill(oTrack->normalizedChi2());
+      iValFracSoftMuonMVA->Fill(iTrack->validFraction());
+      //segCompSoftMuonMVA->Fill(reco::Muon::segmentCompatibility(*muon));
+      chi2LocMomSoftMuonMVA->Fill(muonQuality.chi2LocalMomentum);
+      chi2LocPosSoftMuonMVA->Fill(muonQuality.chi2LocalPosition);
+      glbTrackTailProbSoftMuonMVA->Fill(muonQuality.glbTrackProbability);
+      NTrkVHitsSoftMuonMVA->Fill(iHits.numberOfValidTrackerHits());
+      kinkFinderSoftMuonMVA->Fill(muonQuality.trkKink);
+      vRPChitsSoftMuonMVA->Fill(gHits.numberOfValidMuonRPCHits());
+      glbKinkFinderSoftMuonMVA->Fill(muonQuality.glbKink);
+      glbKinkFinderLogSoftMuonMVA->Fill(TMath::Log(2+muonQuality.glbKink));
+      staRelChi2SoftMuonMVA->Fill(muonQuality.staRelChi2);
+      glbDeltaEtaPhiSoftMuonMVA->Fill(muonQuality.globalDeltaEtaPhi);
+      trkRelChi2SoftMuonMVA->Fill(muonQuality.trkRelChi2);
+      vDThitsSoftMuonMVA->Fill(gHits.numberOfValidMuonDTHits());
+      vCSChitsSoftMuonMVA->Fill(gHits.numberOfValidMuonCSCHits());
+      timeAtIpInOutSoftMuonMVA->Fill(muon->time().timeAtIpInOut);
+      timeAtIpInOutErrSoftMuonMVA->Fill(muon->time().timeAtIpInOutErr);
+      //getMuonHitsPerStationSoftMuonMVA->Fill(gTrack);
+      QprodSoftMuonMVA->Fill((iTrack->charge() * oTrack->charge()));
+    }
+    
     if(muon->isGlobalMuon()) {
       LogTrace(metname)<<"[MuonRecoAnalyzer] The mu is global - filling the histos";
       if(muon->isTrackerMuon() && muon->isStandAloneMuon())
-  	muReco->Fill(1);
+	muReco->Fill(1);
       if(!(muon->isTrackerMuon()) && muon->isStandAloneMuon())
-  	muReco->Fill(2);
+	muReco->Fill(2);
       if(!muon->isStandAloneMuon())
-  	LogTrace(metname)<<"[MuonRecoAnalyzer] ERROR: the mu is global but not standalone!";
-
+	LogTrace(metname)<<"[MuonRecoAnalyzer] ERROR: the mu is global but not standalone!";
       // get the track combinig the information from both the Tracker and the Spectrometer
       reco::TrackRef recoCombinedGlbTrack = muon->combinedMuon();
       
@@ -362,7 +504,6 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       reco::TrackRef recoTkGlbTrack = muon->track();
       // get the track using only the mu spectrometer data
       reco::TrackRef recoStaGlbTrack = muon->standAloneMuon();
-
       etaGlbTrack[0]->Fill(recoCombinedGlbTrack->eta());
       etaGlbTrack[1]->Fill(recoTkGlbTrack->eta());
       etaGlbTrack[2]->Fill(recoStaGlbTrack->eta());
@@ -370,7 +511,13 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       phiVsetaGlbTrack[0]->Fill(recoCombinedGlbTrack->eta(), recoCombinedGlbTrack->phi());
       phiVsetaGlbTrack[1]->Fill(recoTkGlbTrack->eta()      , recoTkGlbTrack->phi());
       phiVsetaGlbTrack[2]->Fill(recoStaGlbTrack->eta()     , recoStaGlbTrack->phi());
-      
+     
+      if(fillBadLumi) {
+          phiVsetaGlbTrack_badlumi[0]->Fill(recoCombinedGlbTrack->eta(), recoCombinedGlbTrack->phi());
+          phiVsetaGlbTrack_badlumi[1]->Fill(recoTkGlbTrack->eta()      , recoTkGlbTrack->phi());
+          phiVsetaGlbTrack_badlumi[2]->Fill(recoStaGlbTrack->eta()     , recoStaGlbTrack->phi());
+      }
+ 
       GetRes(recoTkGlbTrack, recoCombinedGlbTrack, "eta", res, pull);
       etaResolution[0]->Fill(res);
       GetRes(recoCombinedGlbTrack, recoStaGlbTrack, "eta", res, pull);
@@ -378,30 +525,25 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       GetRes(recoTkGlbTrack, recoStaGlbTrack, "eta", res, pull);
       etaResolution[2]->Fill(res);
       etaPull->Fill(pull);
-
       etaResolution[3]->Fill(recoCombinedGlbTrack->eta(), recoTkGlbTrack->eta()-recoCombinedGlbTrack->eta());
       etaResolution[4]->Fill(recoCombinedGlbTrack->eta(), -recoStaGlbTrack->eta()+recoCombinedGlbTrack->eta());
       etaResolution[5]->Fill(recoCombinedGlbTrack->eta(), recoTkGlbTrack->eta()-recoStaGlbTrack->eta());
- 
-
+      
       thetaGlbTrack[0]->Fill(recoCombinedGlbTrack->theta());
       thetaGlbTrack[1]->Fill(recoTkGlbTrack->theta());
       thetaGlbTrack[2]->Fill(recoStaGlbTrack->theta());
       GetRes(recoTkGlbTrack, recoCombinedGlbTrack, "theta", res, pull);
       thetaResolution[0]->Fill(res);
-
       GetRes(recoCombinedGlbTrack, recoStaGlbTrack, "theta", res, pull);
       thetaResolution[1]->Fill(res);
-
+      
       GetRes(recoTkGlbTrack, recoStaGlbTrack, "theta", res, pull);
       thetaResolution[2]->Fill(res);
       thetaPull->Fill(pull);
-
       thetaResolution[3]->Fill(recoCombinedGlbTrack->theta(), recoTkGlbTrack->theta()-recoCombinedGlbTrack->theta());
       thetaResolution[4]->Fill(recoCombinedGlbTrack->theta(), -recoStaGlbTrack->theta()+recoCombinedGlbTrack->theta());
       thetaResolution[5]->Fill(recoCombinedGlbTrack->theta(), recoTkGlbTrack->theta()-recoStaGlbTrack->theta());
-
-     
+      
       phiGlbTrack[0]->Fill(recoCombinedGlbTrack->phi());
       phiGlbTrack[1]->Fill(recoTkGlbTrack->phi());
       phiGlbTrack[2]->Fill(recoStaGlbTrack->phi());
@@ -415,7 +557,7 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       phiResolution[3]->Fill(recoCombinedGlbTrack->phi(), recoTkGlbTrack->phi()-recoCombinedGlbTrack->phi());
       phiResolution[4]->Fill(recoCombinedGlbTrack->phi(), -recoStaGlbTrack->phi()+recoCombinedGlbTrack->phi());
       phiResolution[5]->Fill(recoCombinedGlbTrack->phi(), recoTkGlbTrack->phi()-recoStaGlbTrack->phi());
-    
+      
       chi2OvDFGlbTrack[0]->Fill(recoCombinedGlbTrack->normalizedChi2());
       chi2OvDFGlbTrack[1]->Fill(recoTkGlbTrack->normalizedChi2());
       chi2OvDFGlbTrack[2]->Fill(recoStaGlbTrack->normalizedChi2());
@@ -427,15 +569,15 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       probchi2GlbTrack[2]->Fill(TMath::Prob(recoStaGlbTrack->chi2(),recoStaGlbTrack->ndof()));
       //    cout << "rellenados histos."<<endl;
       //-------------------------
-
+      
       pGlbTrack[0]->Fill(recoCombinedGlbTrack->p());
       pGlbTrack[1]->Fill(recoTkGlbTrack->p());
       pGlbTrack[2]->Fill(recoStaGlbTrack->p());
-
+      
       ptGlbTrack[0]->Fill(recoCombinedGlbTrack->pt());
       ptGlbTrack[1]->Fill(recoTkGlbTrack->pt());
       ptGlbTrack[2]->Fill(recoStaGlbTrack->pt());
-
+      
       qGlbTrack[0]->Fill(recoCombinedGlbTrack->charge());
       qGlbTrack[1]->Fill(recoTkGlbTrack->charge());
       qGlbTrack[2]->Fill(recoStaGlbTrack->charge());
@@ -447,7 +589,7 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       else qGlbTrack[3]->Fill(6);
       if(recoCombinedGlbTrack->charge()!=recoStaGlbTrack->charge() && recoCombinedGlbTrack->charge()!=recoTkGlbTrack->charge()) qGlbTrack[3]->Fill(7);
       if(recoCombinedGlbTrack->charge()==recoStaGlbTrack->charge() && recoCombinedGlbTrack->charge()==recoTkGlbTrack->charge()) qGlbTrack[3]->Fill(8);
-    
+      
       GetRes(recoTkGlbTrack, recoCombinedGlbTrack, "qOverp", res, pull);
       qOverpResolution[0]->Fill(res);
       GetRes(recoCombinedGlbTrack, recoStaGlbTrack, "qOverp", res, pull);
@@ -455,8 +597,8 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       GetRes(recoTkGlbTrack, recoStaGlbTrack, "qOverp", res, pull);
       qOverpResolution[2]->Fill(res);
       qOverpPull->Fill(pull);
-
-
+      
+      
       GetRes(recoTkGlbTrack, recoCombinedGlbTrack, "oneOverp", res, pull);
       oneOverpResolution[0]->Fill(res);
       GetRes(recoCombinedGlbTrack, recoStaGlbTrack, "oneOverp", res, pull);
@@ -464,8 +606,8 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       GetRes(recoTkGlbTrack, recoStaGlbTrack, "oneOverp", res, pull);
       oneOverpResolution[2]->Fill(res);
       oneOverpPull->Fill(pull);
-    
-
+      
+      
       GetRes(recoTkGlbTrack, recoCombinedGlbTrack, "qOverpt", res, pull);
       qOverptResolution[0]->Fill(res);
       GetRes(recoCombinedGlbTrack, recoStaGlbTrack, "qOverpt", res, pull);
@@ -473,7 +615,7 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       GetRes(recoTkGlbTrack, recoStaGlbTrack, "qOverpt", res, pull);
       qOverptResolution[2]->Fill(res);
       qOverptPull->Fill(pull);
-
+      
       GetRes(recoTkGlbTrack, recoCombinedGlbTrack, "oneOverpt", res, pull);
       oneOverptResolution[0]->Fill(res);
       GetRes(recoCombinedGlbTrack, recoStaGlbTrack, "oneOverpt", res, pull);
@@ -481,22 +623,22 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       GetRes(recoTkGlbTrack, recoStaGlbTrack, "oneOverpt", res, pull);
       oneOverptResolution[2]->Fill(res);
       oneOverptPull->Fill(pull);
-
-
+      
+      
       // //--- Test new tunePMuonBestTrack() method from Muon.h
-
+      
       reco::TrackRef recoBestTrack = muon->muonBestTrack();
-
+      
       reco::TrackRef recoTunePBestTrack = muon->tunePMuonBestTrack();
-
+      
       double bestTrackPt =  recoBestTrack->pt();
-
+      
       double tunePBestTrackPt =  recoTunePBestTrack->pt();
-
+      
       double tunePBestTrackRes =  (bestTrackPt - tunePBestTrackPt) / bestTrackPt;
-
+      
       tunePResolution->Fill(tunePBestTrackRes); 
-   
+      
       oneOverptResolution[3]->Fill(recoCombinedGlbTrack->eta(),(1/recoTkGlbTrack->pt())-(1/recoCombinedGlbTrack->pt()));
       oneOverptResolution[4]->Fill(recoCombinedGlbTrack->eta(),-(1/recoStaGlbTrack->pt())+(1/recoCombinedGlbTrack->pt()));
       oneOverptResolution[5]->Fill(recoCombinedGlbTrack->eta(),(1/recoTkGlbTrack->pt())-(1/recoStaGlbTrack->pt()));
@@ -506,8 +648,8 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       oneOverptResolution[9]->Fill(recoCombinedGlbTrack->pt(),(1/recoTkGlbTrack->pt())-(1/recoCombinedGlbTrack->pt()));
       oneOverptResolution[10]->Fill(recoCombinedGlbTrack->pt(),-(1/recoStaGlbTrack->pt())+(1/recoCombinedGlbTrack->pt()));
       oneOverptResolution[11]->Fill(recoCombinedGlbTrack->pt(),(1/recoTkGlbTrack->pt())-(1/recoStaGlbTrack->pt()));
-            
-
+      
+      
       if (!IsminiAOD){ 
 	// valid hits Glb track
 	double rhGlb = recoCombinedGlbTrack->found();
@@ -551,18 +693,18 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 	muVStkSytemRotation[1]->Fill(recoCombinedGlbTrack->pt(),recoTkGlbTrack->pt()/recoCombinedGlbTrack->pt());
     }
     
-
-
+    
+    
     if(muon->isTrackerMuon() && !(muon->isGlobalMuon())) {
       LogTrace(metname)<<"[MuonRecoAnalyzer] The mu is tracker only - filling the histos";
       if(muon->isStandAloneMuon())
-    	muReco->Fill(3);
+	muReco->Fill(3);
       if(!(muon->isStandAloneMuon()))
-    	muReco->Fill(4);
-
+	muReco->Fill(4);
+      
       // get the track using only the tracker data
       reco::TrackRef recoTrack = muon->track();
-
+      
       etaTrack->Fill(recoTrack->eta());
       thetaTrack->Fill(recoTrack->theta());
       phiTrack->Fill(recoTrack->phi());
@@ -571,17 +713,17 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       pTrack->Fill(recoTrack->p());
       ptTrack->Fill(recoTrack->pt());
       qTrack->Fill(recoTrack->charge());
-    
+      
     }
-
+    
     if(muon->isStandAloneMuon() && !(muon->isGlobalMuon())) {
       LogTrace(metname)<<"[MuonRecoAnalyzer] The mu is STA only - filling the histos";
       if(!(muon->isTrackerMuon()))
-  	muReco->Fill(5);
-     
+	muReco->Fill(5);
+      
       // get the track using only the mu spectrometer data
       reco::TrackRef recoStaTrack = muon->standAloneMuon();
-
+      
       etaStaTrack->Fill(recoStaTrack->eta());
       thetaStaTrack->Fill(recoStaTrack->theta());
       phiStaTrack->Fill(recoStaTrack->phi());
@@ -590,17 +732,17 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       pStaTrack->Fill(recoStaTrack->p());
       ptStaTrack->Fill(recoStaTrack->pt());
       qStaTrack->Fill(recoStaTrack->charge());
-
+      
     }
     
     if(muon->isCaloMuon() && !(muon->isGlobalMuon()) && !(muon->isTrackerMuon()) && !(muon->isStandAloneMuon()))
       muReco->Fill(6);
-  
+    
     //efficiency plots
-  
+	    
     // get the track using only the mu spectrometer data
     reco::TrackRef recoStaGlbTrack = muon->standAloneMuon();
-  
+	    
     if(muon->isStandAloneMuon()){
       etaEfficiency[0]->Fill(recoStaGlbTrack->eta());
       phiEfficiency[0]->Fill(recoStaGlbTrack->phi());
@@ -610,7 +752,35 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       phiEfficiency[1]->Fill(recoStaGlbTrack->phi());
     }
   }
-
-
-
+  
 }
+
+
+//Needed by MVA Soft Muon
+double MuonRecoAnalyzer::getDeltaR(reco::Track track1,reco::Track track2) {
+  
+  double dphi = acos(cos(track1.phi() - track2.phi()));
+  double deta = track1.eta() - track2.eta();
+  return sqrt(dphi*dphi + deta*deta);
+  
+}
+
+
+// ----------------------------------------------------------------------
+int MuonRecoAnalyzer::getPv(int tidx, const reco::VertexCollection *vc) {
+  if (vc) {
+    for (unsigned int i = 0; i < vc->size(); ++i) {
+      reco::Vertex::trackRef_iterator v1TrackIter;
+      reco::Vertex::trackRef_iterator v1TrackBegin = vc->at(i).tracks_begin();
+      reco::Vertex::trackRef_iterator v1TrackEnd   = vc->at(i).tracks_end();
+      for (v1TrackIter = v1TrackBegin; v1TrackIter != v1TrackEnd; v1TrackIter++) {
+	if (static_cast<unsigned int>(tidx) == v1TrackIter->key()) return i;
+      }
+    }
+  }
+  return -1;
+}
+
+
+
+

--- a/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
@@ -22,17 +22,13 @@ MuonRecoAnalyzer::MuonRecoAnalyzer(const edm::ParameterSet& pSet) {
 
   // Input booleans
   IsminiAOD = parameters.getParameter<bool>("IsminiAOD");
-  
+  doMVA     = parameters.getParameter<bool>("doMVA"); 
   // the services:
   theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
   theMuonCollectionLabel_ = consumes<edm::View<reco::Muon> >  (parameters.getParameter<edm::InputTag>("MuonCollection"));
   theVertexLabel_   = consumes<reco::VertexCollection>     (pSet.getParameter<InputTag>("inputTagVertex"));
   theBeamSpotLabel_ = consumes<reco::BeamSpot>             (pSet.getParameter<InputTag>("inputTagBeamSpot"));
   dcsStatusCollection_ = consumes<DcsStatusCollection>(pSet.getUntrackedParameter<std::string>("dcsStatusCollection","scalersRawToDigi"));
-  theVertexName = parameters.getParameter<string>("inputTagVertex");
-  theBeamSpotName = parameters.getParameter<string>("inputTagBeamSpot");
-  doMVA = true;
-  if(theVertexName == "" || theBeamSpotName == "") doMVA = false;
 
   ptBin = parameters.getParameter<int>("ptBin");
   ptMin = parameters.getParameter<double>("ptMin");

--- a/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
@@ -396,8 +396,11 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   Handle<reco::VertexCollection> vertex;
   if(doMVA) {
      iEvent.getByToken(theBeamSpotLabel_, beamSpot);
+     if(!beamSpot.isValid()) {edm::LogInfo("MuonRecoAnalyzer") << "Error: Can't get the beamspot" << endl; doMVA = false;} 
      iEvent.getByToken(theVertexLabel_, vertex);
+     if(!vertex.isValid()) {edm::LogInfo("MuonRecoAnalyzer") << "Error: Can't get the vertex collection" << endl; doMVA = false;}
   }
+
   //In this part we determine if we want to fill the plots for events where the DCS flag was set to bad
   edm::Handle<DcsStatusCollection> dcsStatus;
   bool fillBadLumi = false;


### PR DESCRIPTION
In this pull request I'm adding histograms to the Muon DQM in order to correct/improve three aspects:

- Try to improve the monitoring of the pixel problem from the muon perspective:

+ Two Monitor Elements per Muon ID have been added in EfficiencyAnalyzer.cc and EfficiencyPlotter.cc showing the efficiency as a function of the phi and eta of the innermost hit of the innertrack of the muon.

+ One Monitor Element per Muon ID (Loose, Medium, Tight) has been added to DiMuonAnalyzer.cc to monitor the ratio between the number of bad hits and good hits in the inner track for events where the two leptons have a mass compatible with the Z mass.


- Monitor variables used by the Soft Muon MVA ID

+ About 15 new monitor elements have been added to MuonRecoAnalyzer.cc to monitor the variables used by the Soft Muon MVA as requested by the POG.


- Occupancy plot for monitoring of bad lumis

+ One Occupancy plot per muon ID has been added to MuonRecoAnalyzer.cc to be filled only with events where the DCS flags are not OK.

