### PR TITLE
Adapt DQMGenericClient to be able to run every LS

### DIFF
--- a/DQM/L1TMonitorClient/python/L1TStage2uGTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGTClient_cff.py
@@ -30,6 +30,8 @@ dqmRatioTimingPlots = DQMEDHarvester("DQMGenericClient",
     resolution = cms.vstring(),
     outputFileName = cms.untracked.string(""),
     verbose = cms.untracked.uint32(0),
+    runOnEndLumi = cms.untracked.bool(True),
+    makeGlobalEffienciesPlot = cms.untracked.bool(False)
 )
     
 

--- a/DQMServices/ClientConfig/interface/DQMGenericClient.h
+++ b/DQMServices/ClientConfig/interface/DQMGenericClient.h
@@ -31,6 +31,7 @@ class DQMGenericClient : public DQMEDHarvester
   DQMGenericClient(const edm::ParameterSet& pset);
   ~DQMGenericClient() override {};
 
+  void dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,DQMStore::IGetter& igetter,const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c) override;
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
 
   enum class EfficType {
@@ -115,6 +116,9 @@ class DQMGenericClient : public DQMEDHarvester
 
  private:
   unsigned int verbose_;
+  bool runOnEndLumi_;
+  bool runOnEndJob_;
+  bool makeGlobalEffPlot_;
   bool isWildcardUsed_;
   bool resLimitedFit_;
 
@@ -136,6 +140,10 @@ class DQMGenericClient : public DQMEDHarvester
 			      std::string dir,
 			      std::set<std::string> * myList,
 			      const TString& pattern);
+
+  void makeAllPlots(DQMStore::IBooker &, DQMStore::IGetter &);
+
+  void removeMEIfBooked(const std::string& meName, DQMStore::IGetter& igetter);
 
 #if ROOT_VERSION_CODE >= ROOT_VERSION(5,27,0)
 

--- a/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
+++ b/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
@@ -546,7 +546,7 @@ void DQMGenericClient::computeEfficiency (DQMStore::IBooker& ibooker, DQMStore::
       efficHist->SetBinEntries(i, 1);
       efficHist->SetBinError(i, std::hypot(effVal, errVal));
     }
-    removeMEIfBooked(efficDir+"/"+newEfficMEName, igetter);
+    removeMEIfBooked(newEfficMEName, igetter);
     ibooker.bookProfile(newEfficMEName, efficHist);
     delete efficHist;  
   }
@@ -567,13 +567,13 @@ void DQMGenericClient::computeEfficiency (DQMStore::IBooker& ibooker, DQMStore::
     TString histClassName = myHistClass->GetName();
   
     if (histClassName == "TH1F"){
-      removeMEIfBooked(efficDir+"/"+newEfficMEName, igetter);
+      removeMEIfBooked(newEfficMEName, igetter);
       efficME = ibooker.book1D(newEfficMEName, (TH1F*)efficHist);
     } else if (histClassName == "TH2F"){
-      removeMEIfBooked(efficDir+"/"+newEfficMEName, igetter);
+      removeMEIfBooked(newEfficMEName, igetter);
       efficME = ibooker.book2D(newEfficMEName, (TH2F*)efficHist);    
     } else if (histClassName == "TH3F"){
-      removeMEIfBooked(efficDir+"/"+newEfficMEName, igetter);
+      removeMEIfBooked(newEfficMEName, igetter);
       efficME = ibooker.book3D(newEfficMEName, (TH3F*)efficHist);    
     } 
   
@@ -690,8 +690,8 @@ void DQMGenericClient::computeResolution(DQMStore::IBooker& ibooker, DQMStore::I
   float * lowedgesfloats = new float[nBin+1];
   ME* meanME;
   ME* sigmaME;
-  removeMEIfBooked(newDir+"/"+newPrefix+"_Mean", igetter);
-  removeMEIfBooked(newDir+"/"+newPrefix+"_Sigme", igetter);
+  removeMEIfBooked(newPrefix+"_Mean", igetter);
+  removeMEIfBooked(newPrefix+"_Sigme", igetter);
   if (hSrc->GetXaxis()->GetXbins()->GetSize())
   {
     for (int j=0; j<nBin+1; ++j)
@@ -766,7 +766,7 @@ void DQMGenericClient::computeProfile(DQMStore::IBooker& ibooker, DQMStore::IGet
 
   std::unique_ptr<TProfile> profile(hSrc->ProfileX()); // We own the pointer
   profile->SetTitle(profileMETitle.c_str());
-  removeMEIfBooked(profileDir+"/"+profileMEName, igetter);
+  removeMEIfBooked(profileMEName, igetter);
   ibooker.bookProfile(profileMEName, profile.get()); // ibooker makes a copy
 }
 

--- a/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
+++ b/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
@@ -546,8 +546,8 @@ void DQMGenericClient::computeEfficiency (DQMStore::IBooker& ibooker, DQMStore::
       efficHist->SetBinEntries(i, 1);
       efficHist->SetBinError(i, std::hypot(effVal, errVal));
     }
-    removeMEIfBooked(newEfficMEName, igetter);
-    ibooker.bookProfile(efficDir+"/"+newEfficMEName,efficHist);
+    removeMEIfBooked(efficDir+"/"+newEfficMEName, igetter);
+    ibooker.bookProfile(newEfficMEName, efficHist);
     delete efficHist;  
   }
 

--- a/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
+++ b/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
@@ -534,7 +534,7 @@ void DQMGenericClient::computeEfficiency (DQMStore::IBooker& ibooker, DQMStore::
       const double nReco = hReco->GetBinContent(i);
       const double nSim  = hSim->GetBinContent(i);
 
-      if(std::string(hSim->GetXaxis()->GetBinLabel(i)) != "")
+      if(!std::string(hSim->GetXaxis()->GetBinLabel(i)).empty())
         efficHist->GetXaxis()->SetBinLabel(i, hSim->GetXaxis()->GetBinLabel(i));
       
       if (nSim == 0 or nReco < 0 or nReco > nSim) continue;


### PR DESCRIPTION
In order to use the DQMGenericClient in the online DQM the ratios must be calculated in the dqmEndLuminositySection function as well to have updates in the live DQM GUI.
To rebook existing histograms for every LS the booking is done after eventually existing histograms with the same name have been removed from the DQMStore.

In addition, an opt-out parameter was introduced for the generation of the global efficiency plot.