### PR TITLE
Pixel 3d reco with cluster repair 10 1 x

### DIFF
--- a/CalibTracker/SiPixelESProducers/interface/SiPixel2DTemplateDBObjectESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixel2DTemplateDBObjectESProducer.h
@@ -1,0 +1,33 @@
+#ifndef CalibTracker_SiPixelESProducers_SiPixel2DTemplateDBObjectESProducer_h
+#define CalibTracker_SiPixelESProducers_SiPixel2DTemplateDBObjectESProducer_h
+// -*- C++ -*-
+//
+// Package:    SiPixel2DTemplateDBObjectESProducer
+// Class:      SiPixel2DTemplateDBObjectESProducer
+// 
+/**\class SiPixel2DTemplateDBObjectESProducer SiPixel2DTemplateDBObjectESProducer.cc CalibTracker/SiPixelESProducers/plugin/SiPixel2DTemplateDBObjectESProducer.cc
+
+ Description: ESProducer for magnetic-field-dependent local reco templates
+
+ Implementation: Used inside the RecoLocalTracker/Records/TkPixelRecord to select the correct db for given magnetic field
+*/
+//
+// Original Author:  D.Fehling
+//         Created:  Tue Sep 29 14:49:31 CET 2009
+//
+//
+
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h"
+#include "CalibTracker/Records/interface/SiPixel2DTemplateDBObjectESProducerRcd.h"
+
+class SiPixel2DTemplateDBObjectESProducer : public edm::ESProducer  {
+
+public:
+
+	SiPixel2DTemplateDBObjectESProducer(const edm::ParameterSet& iConfig);
+        ~SiPixel2DTemplateDBObjectESProducer() override;
+	std::shared_ptr<SiPixel2DTemplateDBObject> produce(const SiPixel2DTemplateDBObjectESProducerRcd &);
+ };
+#endif

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
@@ -39,8 +39,10 @@ std::shared_ptr<SiPixel2DTemplateDBObject> SiPixel2DTemplateDBObjectESProducer::
 	GlobalPoint center(0.0, 0.0, 0.0);
 	float theMagField = magfield.product()->inTesla(center).mag();
 
-	std::string label = "numerator";   // &&& Temporary: matches Barrel Layer1 for 2017 data
-	
+	//  std::string label = "numerator";   // &&& Temporary: matches Barrel Layer1 for 2017 data
+	//  std::string label = "denominator"; // &&& Temporary: matches Barrel Layer1 fullsim MC
+	std::string label = "";      // the correct default
+
 	if(     theMagField>=-0.1 && theMagField<1.0 ) label = "0T";
 	else if(theMagField>=1.0  && theMagField<2.5 ) label = "2T";
 	else if(theMagField>=2.5  && theMagField<3.25) label = "3T";

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
@@ -39,7 +39,7 @@ std::shared_ptr<SiPixel2DTemplateDBObject> SiPixel2DTemplateDBObjectESProducer::
 	GlobalPoint center(0.0, 0.0, 0.0);
 	float theMagField = magfield.product()->inTesla(center).mag();
 
-	std::string label = "";
+	std::string label = "numerator";   // &&& Temporary: matches Barrel Layer1 for 2017 data
 	
 	if(     theMagField>=-0.1 && theMagField<1.0 ) label = "0T";
 	else if(theMagField>=1.0  && theMagField<2.5 ) label = "2T";

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
@@ -1,0 +1,62 @@
+// -*- C++ -*-
+// Package:    SiPixelESProducers
+// Class:      SiPixel2DTemplateDBObjectESProducer
+// Original Author:  D.Fehling
+//         Created:  Tue Sep 29 14:49:31 CET 2009
+//
+
+#include "CalibTracker/SiPixelESProducers/interface/SiPixel2DTemplateDBObjectESProducer.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/do_nothing_deleter.h"
+
+#include <memory>
+#include "boost/mpl/vector.hpp"
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+
+using namespace edm;
+
+SiPixel2DTemplateDBObjectESProducer::SiPixel2DTemplateDBObjectESProducer(const edm::ParameterSet& iConfig) {
+	setWhatProduced(this);
+}
+
+
+SiPixel2DTemplateDBObjectESProducer::~SiPixel2DTemplateDBObjectESProducer(){
+}
+
+
+
+
+std::shared_ptr<SiPixel2DTemplateDBObject> SiPixel2DTemplateDBObjectESProducer::produce(const SiPixel2DTemplateDBObjectESProducerRcd & iRecord) {
+	
+	ESHandle<MagneticField> magfield;
+	iRecord.getRecord<IdealMagneticFieldRecord>().get(magfield);
+
+	GlobalPoint center(0.0, 0.0, 0.0);
+	float theMagField = magfield.product()->inTesla(center).mag();
+
+	std::string label = "";
+	
+	if(     theMagField>=-0.1 && theMagField<1.0 ) label = "0T";
+	else if(theMagField>=1.0  && theMagField<2.5 ) label = "2T";
+	else if(theMagField>=2.5  && theMagField<3.25) label = "3T";
+	else if(theMagField>=3.25 && theMagField<3.65) label = "35T";
+	else if(theMagField>=3.9  && theMagField<4.1 ) label = "4T";
+	else {
+		//label = "3.8T";
+		if(theMagField>=4.1 || theMagField<-0.1) edm::LogWarning("UnexpectedMagneticFieldUsingDefaultPixel2DTemplate") << "Magnetic field is " << theMagField;
+	}
+	ESHandle<SiPixel2DTemplateDBObject> dbobject;
+	iRecord.getRecord<SiPixel2DTemplateDBObjectRcd>().get(label,dbobject);
+
+	if(std::fabs(theMagField-dbobject->sVector()[22])>0.1)
+		edm::LogWarning("UnexpectedMagneticFieldUsingNonIdealPixel2DTemplate") << "Magnetic field is " << theMagField << " Template Magnetic field is " << dbobject->sVector()[22];
+	
+	return std::shared_ptr<SiPixel2DTemplateDBObject>(const_cast<SiPixel2DTemplateDBObject*>(&(*dbobject)), edm::do_nothing_deleter());
+}
+
+DEFINE_FWK_EVENTSETUP_MODULE(SiPixel2DTemplateDBObjectESProducer);

--- a/CalibTracker/SiPixelESProducers/python/SiPixel2DTemplateDBObjectESProducer_cfi.py
+++ b/CalibTracker/SiPixelESProducers/python/SiPixel2DTemplateDBObjectESProducer_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-siPixel2D2DTemplateDBObjectESProducer = cms.ESProducer("SiPixel2DTemplateDBObjectESProducer")
+siPixel2DTemplateDBObjectESProducer = cms.ESProducer("SiPixel2DTemplateDBObjectESProducer")
  

--- a/CalibTracker/SiPixelESProducers/python/SiPixel2DTemplateDBObjectESProducer_cfi.py
+++ b/CalibTracker/SiPixelESProducers/python/SiPixel2DTemplateDBObjectESProducer_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-siPixelTemplateDBObjectESProducer = cms.ESProducer("SiPixel2DTemplateDBObjectESProducer")
+siPixel2D2DTemplateDBObjectESProducer = cms.ESProducer("SiPixel2DTemplateDBObjectESProducer")
  

--- a/CalibTracker/SiPixelESProducers/python/SiPixel2DTemplateDBObjectESProducer_cfi.py
+++ b/CalibTracker/SiPixelESProducers/python/SiPixel2DTemplateDBObjectESProducer_cfi.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+siPixelTemplateDBObjectESProducer = cms.ESProducer("SiPixel2DTemplateDBObjectESProducer")
+ 

--- a/CondCore/SiPixelPlugins/src/plugin.cc
+++ b/CondCore/SiPixelPlugins/src/plugin.cc
@@ -10,8 +10,6 @@
 #include "CondFormats/DataRecord/interface/SiPixelGainCalibrationRcd.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelLorentzAngle.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelDynamicInefficiency.h"
-#include "CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h"
-#include "CondFormats/DataRecord/interface/SiPixel2DTemplateDBObjectRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelLorentzAngleRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelDynamicInefficiencyRcd.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelCalibConfiguration.h"
@@ -23,11 +21,19 @@
 #include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelCPEGenericErrorParm.h"
 #include "CondFormats/DataRecord/interface/SiPixelCPEGenericErrorParmRcd.h"
+
 #include "CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h"
 #include "CondFormats/DataRecord/interface/SiPixelTemplateDBObjectRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelTemplateDBObject38TRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelTemplateDBObject4TRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelTemplateDBObject0TRcd.h"
+
+#include "CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h"
+#include "CondFormats/DataRecord/interface/SiPixel2DTemplateDBObjectRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject38TRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject4TRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject0TRcd.h"
+
 #include "CondFormats/SiPixelObjects/interface/SiPixelGenErrorDBObject.h"
 #include "CondFormats/DataRecord/interface/SiPixelGenErrorDBObjectRcd.h"
 #include "CondFormats/SiPixelObjects/interface/PixelDCSObject.h"
@@ -61,6 +67,9 @@ REGISTER_PLUGIN(SiPixelTemplateDBObject38TRcd,SiPixelTemplateDBObject);
 REGISTER_PLUGIN(SiPixelTemplateDBObject4TRcd,SiPixelTemplateDBObject);
 REGISTER_PLUGIN(SiPixelTemplateDBObject0TRcd,SiPixelTemplateDBObject);
 REGISTER_PLUGIN(SiPixel2DTemplateDBObjectRcd,SiPixel2DTemplateDBObject);
+REGISTER_PLUGIN(SiPixel2DTemplateDBObject38TRcd,SiPixel2DTemplateDBObject);
+REGISTER_PLUGIN(SiPixel2DTemplateDBObject4TRcd,SiPixel2DTemplateDBObject);
+REGISTER_PLUGIN(SiPixel2DTemplateDBObject0TRcd,SiPixel2DTemplateDBObject);
 REGISTER_PLUGIN(SiPixelGenErrorDBObjectRcd,SiPixelGenErrorDBObject);
 
 REGISTER_PLUGIN(PixelCaenChannelIsOnRcd, PixelDCSObject<bool>);

--- a/CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject0TRcd.h
+++ b/CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject0TRcd.h
@@ -1,0 +1,26 @@
+#ifndef DataRecord_SiPixel2DTemplateDBObject0TRcd_h
+#define DataRecord_SiPixel2DTemplateDBObject0TRcd_h
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     SiPixel2DTemplateDBObject0TRcd
+// 
+/**\class SiPixel2DTemplateDBObject0TRcd SiPixel2DTemplateDBObject0TRcd.h CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject0TRcd.h
+
+ Description: <one line class summary>
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      
+// Created:     Mon Sep 28 15:40:32 CEST 2009
+// $Id$
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class SiPixel2DTemplateDBObject0TRcd : public edm::eventsetup::EventSetupRecordImplementation<SiPixel2DTemplateDBObject0TRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject38TRcd.h
+++ b/CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject38TRcd.h
@@ -1,0 +1,26 @@
+#ifndef DataRecord_SiPixel2DTemplateDBObject38TRcd_h
+#define DataRecord_SiPixel2DTemplateDBObject38TRcd_h
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     SiPixel2DTemplateDBObject38TRcd
+// 
+/**\class SiPixel2DTemplateDBObject38TRcd SiPixel2DTemplateDBObject38TRcd.h CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject38TRcd.h
+
+ Description: <one line class summary>
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      
+// Created:     Mon Sep 28 15:40:47 CEST 2009
+// $Id$
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class SiPixel2DTemplateDBObject38TRcd : public edm::eventsetup::EventSetupRecordImplementation<SiPixel2DTemplateDBObject38TRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject4TRcd.h
+++ b/CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject4TRcd.h
@@ -1,0 +1,26 @@
+#ifndef DataRecord_SiPixel2DTemplateDBObject4TRcd_h
+#define DataRecord_SiPixel2DTemplateDBObject4TRcd_h
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     SiPixel2DTemplateDBObject4TRcd
+// 
+/**\class SiPixel2DTemplateDBObject4TRcd SiPixel2DTemplateDBObject4TRcd.h CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject4TRcd.h
+
+ Description: <one line class summary>
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      
+// Created:     Mon Sep 28 15:40:50 CEST 2009
+// $Id$
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class SiPixel2DTemplateDBObject4TRcd : public edm::eventsetup::EventSetupRecordImplementation<SiPixel2DTemplateDBObject4TRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/SiPixel2DTemplateDBObject0TRcd.cc
+++ b/CondFormats/DataRecord/src/SiPixel2DTemplateDBObject0TRcd.cc
@@ -1,0 +1,16 @@
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     SiPixel2DTemplateDBObject0TRcd
+// 
+// Implementation:
+//     <Notes on implementation>
+//
+// Author:      
+// Created:     Mon Sep 28 15:40:32 CEST 2009
+// $Id$
+
+#include "CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject0TRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(SiPixel2DTemplateDBObject0TRcd);

--- a/CondFormats/DataRecord/src/SiPixel2DTemplateDBObject38TRcd.cc
+++ b/CondFormats/DataRecord/src/SiPixel2DTemplateDBObject38TRcd.cc
@@ -1,0 +1,16 @@
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     SiPixel2DTemplateDBObject38TRcd
+// 
+// Implementation:
+//     <Notes on implementation>
+//
+// Author:      
+// Created:     Mon Sep 28 15:40:47 CEST 2009
+// $Id$
+
+#include "CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject38TRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(SiPixel2DTemplateDBObject38TRcd);

--- a/CondFormats/DataRecord/src/SiPixel2DTemplateDBObject4TRcd.cc
+++ b/CondFormats/DataRecord/src/SiPixel2DTemplateDBObject4TRcd.cc
@@ -1,0 +1,16 @@
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     SiPixel2DTemplateDBObject4TRcd
+// 
+// Implementation:
+//     <Notes on implementation>
+//
+// Author:      
+// Created:     Mon Sep 28 15:40:50 CEST 2009
+// $Id$
+
+#include "CondFormats/DataRecord/interface/SiPixel2DTemplateDBObject4TRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(SiPixel2DTemplateDBObject4TRcd);

--- a/RecoLocalTracker/Records/interface/TkPixelCPERecord.h
+++ b/RecoLocalTracker/Records/interface/TkPixelCPERecord.h
@@ -10,11 +10,12 @@
 //#include "CondFormats/DataRecord/interface/SiPixelCPEGenericErrorParmRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelGenErrorDBObjectRcd.h"
 #include "CalibTracker/Records/interface/SiPixelTemplateDBObjectESProducerRcd.h"
+#include "CalibTracker/Records/interface/SiPixel2DTemplateDBObjectESProducerRcd.h"
 
 #include "boost/mpl/vector.hpp"
 
 class  TkPixelCPERecord: public edm::eventsetup::DependentRecordImplementation<TkPixelCPERecord,
-  boost::mpl::vector<TrackerDigiGeometryRecord,IdealMagneticFieldRecord,SiPixelLorentzAngleRcd,SiPixelGenErrorDBObjectRcd,SiPixelTemplateDBObjectESProducerRcd> > {};
+  boost::mpl::vector<TrackerDigiGeometryRecord,IdealMagneticFieldRecord,SiPixelLorentzAngleRcd,SiPixelGenErrorDBObjectRcd,SiPixelTemplateDBObjectESProducerRcd,SiPixel2DTemplateDBObjectESProducerRcd> > {};
 
 #endif 
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -113,6 +113,9 @@ public:
       // ggiurgiu@jhu.edu (10/18/2008)
       bool with_track_angle; // filled in computeAnglesFrom....
 
+     // More detailed edge information (for CPE ClusterRepair, and elsewhere...)
+     int   edgeTypeX_ = 0;   // 0: not on edge, 1: low end on edge, 2: high end
+     int   edgeTypeY_ = 0;   // 0: not on edge, 1: low end on edge, 2: high end
    };
    
 public:

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
@@ -1,0 +1,116 @@
+#ifndef RecoLocalTracker_SiPixelRecHits_PixelCPEClusterRepair_H
+#define RecoLocalTracker_SiPixelRecHits_PixelCPEClusterRepair_H
+
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h"
+
+// Already in the base class
+//#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+//#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+//#include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
+//#include "Geometry/CommonDetAlgo/interface/MeasurementPoint.h"
+//#include "Geometry/CommonDetAlgo/interface/MeasurementError.h"
+//#include "Geometry/Surface/interface/GloballyPositioned.h"
+//#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+// The template header files
+//
+#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate2D.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h"
+
+#include <utility>
+#include <vector>
+
+
+#if 0
+/** \class PixelCPEClusterRepair
+ * Perform the position and error evaluation of pixel hits using
+ * the Det angle to estimate the track impact angle
+ */
+#endif
+
+class MagneticField;
+class PixelCPEClusterRepair : public PixelCPEBase
+{
+public:
+   struct ClusterParamTemplate : ClusterParam
+   {
+      ClusterParamTemplate(const SiPixelCluster & cl) : ClusterParam(cl){}
+      // The result of PixelTemplateReco2D
+      float templXrec_ ;
+      float templYrec_ ;
+      float templSigmaX_ ;
+      float templSigmaY_ ;
+      // Add new information produced by SiPixelTemplateReco::PixelTempReco2D &&&
+      // These can only be accessed if we change silicon pixel data formats and add them to the rechit
+      float templProbX_ ;
+      float templProbY_ ;
+      float templProbQ_;
+      int   templQbin_ ;
+      int   ierr;
+
+
+      // 2D fit stuff.
+      float templProbXY_ ;
+      bool  recommended3D_ ;
+      int   ierr2;
+   };
+   
+   // PixelCPEClusterRepair( const DetUnit& det );
+   PixelCPEClusterRepair(edm::ParameterSet const& conf, const MagneticField *, const TrackerGeometry&, const TrackerTopology&,
+			 const SiPixelLorentzAngle *, const SiPixelTemplateDBObject *, const SiPixel2DTemplateDBObject * );
+   
+   ~PixelCPEClusterRepair() override;
+   
+private:
+   ClusterParam * createClusterParam(const SiPixelCluster & cl) const override;
+   
+   // Calculate local position.  (Calls TemplateReco)
+   LocalPoint localPosition (DetParam const & theDetParam, ClusterParam & theClusterParam) const override;
+   // Calculate local error. Note: it MUST be called AFTER localPosition() !!!
+   LocalError localError   (DetParam const & theDetParam, ClusterParam & theClusterParam) const override;
+   
+   // Helper functions: 
+
+   // Call vanilla template reco, then clean-up
+   void callTempReco2D( DetParam const & theDetParam, 
+			ClusterParamTemplate & theClusterParam, 
+			SiPixelTemplateReco::ClusMatrix & clusterPayload,
+			int ID, LocalPoint & lp ) const;
+
+   // Call 2D template reco, then clean-up
+   void callTempReco3D( DetParam const & theDetParam, 
+			ClusterParamTemplate & theClusterParam, 
+			SiPixelTemplateReco2D::ClusMatrix & clusterPayload,
+			int ID, LocalPoint & lp ) const;
+   
+
+   // Template storage
+   std::vector< SiPixelTemplateStore >   thePixelTemp_;
+   std::vector< SiPixelTemplateStore2D > thePixelTemp2D_;
+
+   int speed_ ;
+   
+   bool UseClusterSplitter_;
+
+   // Template file management (when not getting the templates from the DB)
+   int barrelTemplateID_ ;
+   int forwardTemplateID_ ;
+   std::string templateDir_ ;
+
+   // Configure 3D reco.
+   float minProbY_ ;
+   int   maxSizeMismatchInY_ ;
+   
+   //bool DoCosmics_;
+   //bool LoadTemplatesFromDB_;
+   
+};
+
+#endif
+
+
+
+

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepairESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepairESProducer.h
@@ -1,0 +1,26 @@
+#ifndef RecoLocaltracker_SiPixelRecHits_PixelCPEClusterRepairESProducer_h
+#define RecoLocaltracker_SiPixelRecHits_PixelCPEClusterRepairESProducer_h
+
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
+#include <memory>
+
+class  PixelCPEClusterRepairESProducer: public edm::ESProducer{
+ public:
+  PixelCPEClusterRepairESProducer(const edm::ParameterSet & p);
+  ~PixelCPEClusterRepairESProducer() override; 
+  std::shared_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
+ private:
+  std::shared_ptr<PixelClusterParameterEstimator> cpe_;
+  edm::ParameterSet pset_;
+  bool DoLorentz_;
+};
+
+
+#endif
+
+
+
+

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepairESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepairESProducer.h
@@ -11,9 +11,8 @@ class  PixelCPEClusterRepairESProducer: public edm::ESProducer{
  public:
   PixelCPEClusterRepairESProducer(const edm::ParameterSet & p);
   ~PixelCPEClusterRepairESProducer() override; 
-  std::shared_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
+  std::unique_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
  private:
-  std::shared_ptr<PixelClusterParameterEstimator> cpe_;
   edm::ParameterSet pset_;
   bool DoLorentz_;
 };

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
@@ -11,9 +11,8 @@ class  PixelCPEGenericESProducer: public edm::ESProducer{
  public:
   PixelCPEGenericESProducer(const edm::ParameterSet & p);
   ~PixelCPEGenericESProducer() override; 
-  std::shared_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
+  std::unique_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
  private:
-  std::shared_ptr<PixelClusterParameterEstimator> cpe_;
   edm::ParameterSet pset_;
   edm::ESInputTag magname_;
   bool useLAWidthFromDB_;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
@@ -11,8 +11,9 @@ class  PixelCPEGenericESProducer: public edm::ESProducer{
  public:
   PixelCPEGenericESProducer(const edm::ParameterSet & p);
   ~PixelCPEGenericESProducer() override; 
-  std::unique_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
+  std::shared_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
  private:
+  std::shared_ptr<PixelClusterParameterEstimator> cpe_;
   edm::ParameterSet pset_;
   edm::ESInputTag magname_;
   bool useLAWidthFromDB_;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
@@ -78,6 +78,11 @@ private:
    int speed_ ;
    
    bool UseClusterSplitter_;
+
+   // Template file management (when not getting the templates from the DB)
+   int barrelTemplateID_ ;
+   int forwardTemplateID_ ;
+   std::string templateDir_ ;
    
    //bool DoCosmics_;
    //bool LoadTemplatesFromDB_;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateRecoESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateRecoESProducer.h
@@ -11,9 +11,8 @@ class  PixelCPETemplateRecoESProducer: public edm::ESProducer{
  public:
   PixelCPETemplateRecoESProducer(const edm::ParameterSet & p);
   ~PixelCPETemplateRecoESProducer() override; 
-  std::shared_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
+  std::unique_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
  private:
-  std::shared_ptr<PixelClusterParameterEstimator> cpe_;
   edm::ParameterSet pset_;
   bool DoLorentz_;
 };

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateRecoESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateRecoESProducer.h
@@ -11,8 +11,9 @@ class  PixelCPETemplateRecoESProducer: public edm::ESProducer{
  public:
   PixelCPETemplateRecoESProducer(const edm::ParameterSet & p);
   ~PixelCPETemplateRecoESProducer() override; 
-  std::unique_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
+  std::shared_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
  private:
+  std::shared_ptr<PixelClusterParameterEstimator> cpe_;
   edm::ParameterSet pset_;
   bool DoLorentz_;
 };

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelGenError.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelGenError.h
@@ -1,11 +1,17 @@
 //
-//  SiPixelGenError.h (v2.00)
+//  SiPixelGenError.h (v2.20)
 //
 //  Object to contain Lorentz drift and error information for the Generic Algorithm
 //
 // Created by Morris Swartz on 1/10/2014.
 //
 // Update for Phase 1 FPix, M.S. 1/15/17
+//  V2.01 - Allow subdetector ID=5 for FPix R2P2, Fix error message
+//  V2.10 - Update the variable size [SI_PIXEL_TEMPLATE_USE_BOOST] option so that it works with VI's enhancements
+//  V2.20 - Add directory path selection to the ascii pushfile method
+
+
+
 //
 
 // Build the template storage structure from several pieces
@@ -16,6 +22,7 @@
 
 #include<vector>
 #include<cassert>
+#include "boost/multi_array.hpp"
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
 #include "CondFormats/SiPixelObjects/interface/SiPixelGenErrorDBObject.h"
@@ -77,11 +84,19 @@ struct SiPixelGenErrorHeader {           //!< template header structure
 
 struct SiPixelGenErrorStore { //!< template storage structure
    SiPixelGenErrorHeader head;
+#ifndef SI_PIXEL_TEMPLATE_USE_BOOST
    float cotbetaY[60];
    float cotbetaX[5];
    float cotalphaX[29];
    SiPixelGenErrorEntry enty[60];     //!< 60 Barrel y templates spanning cluster lengths from 0px to +18px [28 entries for fpix]
    SiPixelGenErrorEntry entx[5][29];  //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
+#else
+   float* cotbetaY;
+   float* cotbetaX;
+   float* cotalphaX;   
+   boost::multi_array<SiPixelGenErrorEntry,1> enty;     //!< use 1d entry to store [60] barrel entries or [28] fpix entries
+   boost::multi_array<SiPixelGenErrorEntry,2> entx;     //!< use 2d entry to store [5][29] barrel entries or [3][29] fpix entries
+#endif
 } ;
 
 
@@ -104,9 +119,10 @@ class SiPixelGenError {
 public:
    SiPixelGenError(const std::vector< SiPixelGenErrorStore > & thePixelTemp) : thePixelTemp_(thePixelTemp) { id_current_ = -1; index_id_ = -1;} //!< Constructor for cases in which template store already exists
    
-   static bool pushfile(int filenum, std::vector< SiPixelGenErrorStore > & thePixelTemp_);     // load the private store with info from the
-   // file with the index (int) filenum
-   
+// Load the private store with info from the file with the index (int) filenum from directory dir:
+//   ${dir}generror_summary_zp${filenum}.out
+   static bool pushfile(int filenum, std::vector< SiPixelGenErrorStore > & thePixelTemp_ , std::string dir = "");
+    
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
    static bool pushfile(const SiPixelGenErrorDBObject& dbobject, std::vector< SiPixelGenErrorStore > & thePixelTemp_);     // load the private store with info from db
 #endif
@@ -118,6 +134,11 @@ public:
    // Interpolate input beta angle to estimate the average charge. return qbin flag for input cluster charge, and estimate y/x errors and biases for the Generic Algorithm.
    int qbin(int id, float cotalpha, float cotbeta, float locBz, float locBx, float qclus, bool irradiationCorrections,
             int& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax,
+            float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2);
+            
+// Overload to provide backward compatibility
+
+   int qbin(int id, float cotalpha, float cotbeta, float locBz, float locBx, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax,
             float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2);
    // Overloaded method to provide only the LA parameters
    int qbin(int id);

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelGenError.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelGenError.h
@@ -9,10 +9,8 @@
 //  V2.01 - Allow subdetector ID=5 for FPix R2P2, Fix error message
 //  V2.10 - Update the variable size [SI_PIXEL_TEMPLATE_USE_BOOST] option so that it works with VI's enhancements
 //  V2.20 - Add directory path selection to the ascii pushfile method
+//  V2.21 - Move templateStore to the heap, fix variable name in pushfile()
 
-
-
-//
 
 // Build the template storage structure from several pieces
 
@@ -121,10 +119,10 @@ public:
    
 // Load the private store with info from the file with the index (int) filenum from directory dir:
 //   ${dir}generror_summary_zp${filenum}.out
-   static bool pushfile(int filenum, std::vector< SiPixelGenErrorStore > & thePixelTemp_ , std::string dir = "");
+   static bool pushfile(int filenum, std::vector< SiPixelGenErrorStore > & pixelTemp , std::string dir = "");
     
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   static bool pushfile(const SiPixelGenErrorDBObject& dbobject, std::vector< SiPixelGenErrorStore > & thePixelTemp_);     // load the private store with info from db
+   static bool pushfile(const SiPixelGenErrorDBObject& dbobject, std::vector< SiPixelGenErrorStore > & pixelTemp);     // load the private store with info from db
 #endif
    
    // initialize the binary search information;

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
@@ -259,10 +259,10 @@ public:
 
 // Load the private store with info from the file with the index (int) filenum from directory dir:
 //   ${dir}template_summary_zp${filenum}.out
+#ifdef SI_PIXEL_TEMPLATE_STANDALONE
    static bool pushfile(int filenum, std::vector< SiPixelTemplateStore > & thePixelTemp_ , std::string dir = "");
-   
-   
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+#else   
+   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore > & thePixelTemp_ , std::string dir = "CalibTracker/SiPixelESProducers/data/");   // *&^%$#@!  Different default dir -- remove once FastSim is updated.
    static bool pushfile(const SiPixelTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore > & thePixelTemp_);     // load the private store with info from db
 #endif
    

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplate.h (v10.13)
+//  SiPixelTemplate.h (v10.20)
 //
 //  Add goodness-of-fit info and spare entries to templates, version number in template header, more error checking
 //  Add correction for (Q_F-Q_L)/(Q_F+Q_L) bias
@@ -76,6 +76,8 @@
 //  V10.11 - Allow subdetector ID=5 for FPix R2P2 [allows better internal labeling of templates]
 //  V10.12 - Enforce minimum signal size in pixel charge uncertainty calculation
 //  V10.13 - Update the variable size [SI_PIXEL_TEMPLATE_USE_BOOST] option so that it works with VI's enhancements
+//  V10.20 - Add directory path selection to the ascii pushfile method
+
 
 
 
@@ -217,9 +219,9 @@ struct SiPixelTemplateStore { //!< template storage structure
    SiPixelTemplateEntry entx[5][29];  //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
    void destroy() {};
 #else
-   float* cotbetaY=nullptr;
-   float* cotbetaX=nullptr;
-   float* cotalphaX=nullptr;
+   float* cotbetaY;
+   float* cotbetaX;
+   float* cotalphaX;
    boost::multi_array<SiPixelTemplateEntry,1> enty;     //!< use 1d entry to store [60] barrel entries or [28] fpix entries
    boost::multi_array<SiPixelTemplateEntry,2> entx;     //!< use 2d entry to store [5][29] barrel entries or [3][29] fpix entries
    void destroy() {  // deletes arrays created by pushfile method of SiPixelTemplate
@@ -254,8 +256,11 @@ class SiPixelTemplate {
 public:
    SiPixelTemplate(const std::vector< SiPixelTemplateStore > & thePixelTemp) : thePixelTemp_(thePixelTemp) { id_current_ = -1; index_id_ = -1; cota_current_ = 0.; cotb_current_ = 0.; } //!< Constructor for cases in which template store already exists
    
-   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore > & thePixelTemp_);     // load the private store with info from the
-   // file with the index (int) filenum
+
+// Load the private store with info from the file with the index (int) filenum from directory dir:
+//   ${dir}template_summary_zp${filenum}.out
+   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore > & thePixelTemp_ , std::string dir = "");
+   
    
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
    static bool pushfile(const SiPixelTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore > & thePixelTemp_);     // load the private store with info from db

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
@@ -77,6 +77,8 @@
 //  V10.12 - Enforce minimum signal size in pixel charge uncertainty calculation
 //  V10.13 - Update the variable size [SI_PIXEL_TEMPLATE_USE_BOOST] option so that it works with VI's enhancements
 //  V10.20 - Add directory path selection to the ascii pushfile method
+//  V10.21 - Address runtime issues in pushfile() for gcc 7.X due to using tempfile as char string + misc. cleanup [Petar]
+//  V10.22 - Move templateStore to the heap, fix variable name in pushfile() [Petar]
 
 
 
@@ -260,10 +262,10 @@ public:
 // Load the private store with info from the file with the index (int) filenum from directory dir:
 //   ${dir}template_summary_zp${filenum}.out
 #ifdef SI_PIXEL_TEMPLATE_STANDALONE
-   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore > & thePixelTemp_ , std::string dir = "");
+   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore > & pixelTemp , std::string dir = "");
 #else   
-   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore > & thePixelTemp_ , std::string dir = "CalibTracker/SiPixelESProducers/data/");   // *&^%$#@!  Different default dir -- remove once FastSim is updated.
-   static bool pushfile(const SiPixelTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore > & thePixelTemp_);     // load the private store with info from db
+   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore > & pixelTemp , std::string dir = "CalibTracker/SiPixelESProducers/data/");   // *&^%$#@!  Different default dir -- remove once FastSim is updated.
+   static bool pushfile(const SiPixelTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore > & pixelTemp);     // load the private store with info from db
 #endif
    
    // initialize the rest;

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
@@ -219,9 +219,9 @@ struct SiPixelTemplateStore { //!< template storage structure
    SiPixelTemplateEntry entx[5][29];  //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
    void destroy() {};
 #else
-   float* cotbetaY;
-   float* cotbetaX;
-   float* cotalphaX;
+   float* cotbetaY = nullptr;
+   float* cotbetaX = nullptr;
+   float* cotalphaX = nullptr;
    boost::multi_array<SiPixelTemplateEntry,1> enty;     //!< use 1d entry to store [60] barrel entries or [28] fpix entries
    boost::multi_array<SiPixelTemplateEntry,2> entx;     //!< use 2d entry to store [5][29] barrel entries or [3][29] fpix entries
    void destroy() {  // deletes arrays created by pushfile method of SiPixelTemplate

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate2D.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate2D.h
@@ -14,6 +14,7 @@
 // v2.25 - Resize template store to accommodate FPix Templates
 // v2.30 - Fix bug found by P. Shuetze that compromises sqlite file loading
 // v2.35 - Add directory path selection to the ascii pushfile method
+// V2.36 - Move templateStore to the heap, fix variable name in pushfile()
 //
 
 // Build the template storage structure from several pieces
@@ -136,10 +137,10 @@ public:
    
 // load the private store with info from the
    // file with the index (int) filenum ${dir}template_summary_zp${filenum}.out
-   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore2D > & thePixelTemp_, std::string dir = "");     
+   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore2D > & pixelTemp, std::string dir = "");     
    
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   static bool pushfile(const SiPixel2DTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore2D > & thePixelTemp_);     // load the private store with info from db
+   static bool pushfile(const SiPixel2DTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore2D > & pixelTemp);     // load the private store with info from db
 #endif
    
    //  Initialize things before interpolating

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateDefs.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateDefs.h
@@ -1,8 +1,10 @@
 //
-//  SiPixelTemplateDefs.h (v1.10)
+//  SiPixelTemplateDefs.h (v2.00)
 //
 // Created by Morris Swartz on 12/01/09.
 // 2009 __TheJohnsHopkinsUniversity__.
+//
+// V2.00 - Resize the 2D objects to improve angle acceptance
 //
 //
 
@@ -33,9 +35,10 @@
 #define BXM1 TXSIZE+3
 #define BXM2 TXSIZE+2
 #define BXM3 TXSIZE+1
-#define T2YSIZE 13
+#define T2YSIZE 21
 #define T2XSIZE 7
-#define T2HY 6  // = T2YSIZE/2
+#define T2HY 10  // = T2YSIZE/2
+#define T2HYP1 T2HY+1 // = T2YSIZE/2+1
 #define T2HX 3  // = T2XSIZE/2
 
 #endif

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h
@@ -1,0 +1,56 @@
+//
+//  SiPixelTemplateReco2D.cc (Version 2.20)
+//  Updated to work with the 2D template generation code
+//  2.10 - Add y-lorentz drift to estimate starting point [for FPix]
+//  2.10 - Remove >1 pixel requirement
+//  2.20 - Fix major bug, change chi2 scan to 9x5 [YxX]
+
+
+//
+//
+//  Created by Morris Swartz on 7/13/17.
+//
+//
+
+#ifndef SiPixelTemplateReco2D_h
+#define SiPixelTemplateReco2D_h 1
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateDefs.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate2D.h"
+#else
+#include "SiPixelTemplateDefs.h"
+#include "SiPixelTemplate2D.h"
+#endif
+
+#define NPIXMAX 200
+
+#include <vector>
+
+#ifndef SiPixelTemplateClusMatrix2D
+#define SiPixelTemplateClusMatrix2D 1
+
+namespace SiPixelTemplateReco2D {
+   
+   struct ClusMatrix {
+      float & operator()(int x, int y) { return matrix[mcol*x+y];}
+      float operator()(int x, int y) const { return matrix[mcol*x+y];}
+      float * matrix;
+      bool * xdouble;
+      bool * ydouble;
+      int mrow, mcol;
+   };
+#endif
+   
+   int PixelTempReco3D(int id, float cotalpha, float cotbeta, float locBz, float locBx, int edgeflagy, int edgeflagx,
+                       ClusMatrix & cluster, SiPixelTemplate2D& templ,
+                       float& yrec, float& sigmay, float& xrec, float& sigmax, float& probxy, float& probQ, int& qbin, float& deltay, int& npixel);
+   
+   int PixelTempReco3D(int id, float cotalpha, float cotbeta, float locBz, float locBx, int edgeflagy, int edgeflagx,
+                       ClusMatrix & cluster, SiPixelTemplate2D& templ,
+                       float& yrec, float& sigmay, float& xrec, float& sigmax, float& probxy, float& probQ, int& qbin, float& deltay);
+   
+   
+}
+
+#endif

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h
@@ -23,8 +23,6 @@
 #include "SiPixelTemplate2D.h"
 #endif
 
-#define NPIXMAX 200
-
 #include <vector>
 
 #ifndef SiPixelTemplateClusMatrix2D

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
@@ -1,0 +1,80 @@
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepairESProducer.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "CalibTracker/Records/interface/SiPixelTemplateDBObjectESProducerRcd.h"
+#include "CalibTracker/Records/interface/SiPixel2DTemplateDBObjectESProducerRcd.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+
+
+
+#include <string>
+#include <memory>
+
+using namespace edm;
+
+PixelCPEClusterRepairESProducer::PixelCPEClusterRepairESProducer(const edm::ParameterSet & p) 
+{
+  std::string myname = p.getParameter<std::string>("ComponentName");
+
+  //DoLorentz_ = p.getParameter<bool>("DoLorentz"); // True when LA from alignment is used
+  DoLorentz_ = p.existsAs<bool>("DoLorentz")?p.getParameter<bool>("DoLorentz"):false;
+
+  pset_ = p;
+  setWhatProduced(this,myname);
+
+  //std::cout<<" from ES Producer Templates "<<myname<<" "<<DoLorentz_<<std::endl;  //dk
+
+}
+
+PixelCPEClusterRepairESProducer::~PixelCPEClusterRepairESProducer() {}
+
+std::shared_ptr<PixelClusterParameterEstimator> 
+PixelCPEClusterRepairESProducer::produce(const TkPixelCPERecord & iRecord){ 
+
+  ESHandle<MagneticField> magfield;
+  iRecord.getRecord<IdealMagneticFieldRecord>().get(magfield );
+
+  edm::ESHandle<TrackerGeometry> pDD;
+  iRecord.getRecord<TrackerDigiGeometryRecord>().get( pDD );
+
+  edm::ESHandle<TrackerTopology> hTT;
+  iRecord.getRecord<TrackerDigiGeometryRecord>().getRecord<TrackerTopologyRcd>().get(hTT);
+
+  edm::ESHandle<SiPixelLorentzAngle> lorentzAngle;
+  const SiPixelLorentzAngle * lorentzAngleProduct = nullptr;
+  if(DoLorentz_) { //  LA correction from alignment 
+    iRecord.getRecord<SiPixelLorentzAngleRcd>().get("fromAlignment",lorentzAngle);
+    lorentzAngleProduct = lorentzAngle.product();
+  } else { // Normal, deafult LA actually is NOT needed
+    //iRecord.getRecord<SiPixelLorentzAngleRcd>().get(lorentzAngle);
+    lorentzAngleProduct=nullptr;  // null is ok becuse LA is not use by templates in this mode
+  }
+
+  ESHandle<SiPixelTemplateDBObject> templateDBobject;
+  iRecord.getRecord<SiPixelTemplateDBObjectESProducerRcd>().get(templateDBobject);
+
+  ESHandle<SiPixel2DTemplateDBObject> templateDBobject2D;
+  iRecord.getRecord<SiPixel2DTemplateDBObjectESProducerRcd>().get(templateDBobject2D);
+
+  //  cpe_  = std::make_shared<PixelCPEClusterRepair>(pset_,magfield.product(),lorentzAngle.product(),templateDBobject.product() );
+  cpe_  =
+    std::make_shared<PixelCPEClusterRepair>(pset_,
+					    magfield.product(),
+					    *pDD.product(),
+					    *hTT.product(),
+					    lorentzAngleProduct,
+					    templateDBobject.product(),
+					    templateDBobject2D.product() );
+  return cpe_;
+}
+
+

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
@@ -37,7 +37,7 @@ PixelCPEClusterRepairESProducer::PixelCPEClusterRepairESProducer(const edm::Para
 
 PixelCPEClusterRepairESProducer::~PixelCPEClusterRepairESProducer() {}
 
-std::shared_ptr<PixelClusterParameterEstimator> 
+std::unique_ptr<PixelClusterParameterEstimator> 
 PixelCPEClusterRepairESProducer::produce(const TkPixelCPERecord & iRecord){ 
 
   ESHandle<MagneticField> magfield;
@@ -65,16 +65,14 @@ PixelCPEClusterRepairESProducer::produce(const TkPixelCPERecord & iRecord){
   ESHandle<SiPixel2DTemplateDBObject> templateDBobject2D;
   iRecord.getRecord<SiPixel2DTemplateDBObjectESProducerRcd>().get(templateDBobject2D);
 
-  //  cpe_  = std::make_shared<PixelCPEClusterRepair>(pset_,magfield.product(),lorentzAngle.product(),templateDBobject.product() );
-  cpe_  =
-    std::make_shared<PixelCPEClusterRepair>(pset_,
+  return
+    std::make_unique<PixelCPEClusterRepair>(pset_,
 					    magfield.product(),
 					    *pDD.product(),
 					    *hTT.product(),
 					    lorentzAngleProduct,
 					    templateDBobject.product(),
 					    templateDBobject2D.product() );
-  return cpe_;
 }
 
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -45,7 +45,7 @@ PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet & p
 
 PixelCPEGenericESProducer::~PixelCPEGenericESProducer() {}
 
-std::shared_ptr<PixelClusterParameterEstimator>
+std::unique_ptr<PixelClusterParameterEstimator>
 PixelCPEGenericESProducer::produce(const TkPixelCPERecord & iRecord){ 
 
   ESHandle<MagneticField> magfield;
@@ -83,12 +83,10 @@ PixelCPEGenericESProducer::produce(const TkPixelCPERecord & iRecord){
     //} else {
     //std::cout<<" pass an empty GenError pointer"<<std::endl;
   }
-  cpe_  = std::make_shared<PixelCPEGeneric>(
+  return std::make_unique<PixelCPEGeneric>(
                          pset_,magfield.product(),*pDD.product(),
 			 *hTT.product(),lorentzAngle.product(),
 			 genErrorDBObjectProduct,lorentzAngleWidthProduct);
-
-  return cpe_;
 }
 
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -45,7 +45,7 @@ PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet & p
 
 PixelCPEGenericESProducer::~PixelCPEGenericESProducer() {}
 
-std::unique_ptr<PixelClusterParameterEstimator>
+std::shared_ptr<PixelClusterParameterEstimator>
 PixelCPEGenericESProducer::produce(const TkPixelCPERecord & iRecord){ 
 
   ESHandle<MagneticField> magfield;
@@ -83,11 +83,12 @@ PixelCPEGenericESProducer::produce(const TkPixelCPERecord & iRecord){
     //} else {
     //std::cout<<" pass an empty GenError pointer"<<std::endl;
   }
-  return std::make_unique<PixelCPEGeneric>(
+  cpe_  = std::make_shared<PixelCPEGeneric>(
                          pset_,magfield.product(),*pDD.product(),
 			 *hTT.product(),lorentzAngle.product(),
 			 genErrorDBObjectProduct,lorentzAngleWidthProduct);
 
+  return cpe_;
 }
 
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
@@ -35,7 +35,7 @@ PixelCPETemplateRecoESProducer::PixelCPETemplateRecoESProducer(const edm::Parame
 
 PixelCPETemplateRecoESProducer::~PixelCPETemplateRecoESProducer() {}
 
-std::shared_ptr<PixelClusterParameterEstimator> 
+std::unique_ptr<PixelClusterParameterEstimator> 
 PixelCPETemplateRecoESProducer::produce(const TkPixelCPERecord & iRecord){ 
 
   ESHandle<MagneticField> magfield;
@@ -60,9 +60,7 @@ PixelCPETemplateRecoESProducer::produce(const TkPixelCPERecord & iRecord){
   ESHandle<SiPixelTemplateDBObject> templateDBobject;
   iRecord.getRecord<SiPixelTemplateDBObjectESProducerRcd>().get(templateDBobject);
 
-  //  cpe_  = std::make_shared<PixelCPETemplateReco>(pset_,magfield.product(),lorentzAngle.product(),templateDBobject.product() );
-  cpe_  = std::make_shared<PixelCPETemplateReco>(pset_,magfield.product(),*pDD.product(),*hTT.product(),lorentzAngleProduct,templateDBobject.product() );
-  return cpe_;
+  return std::make_unique<PixelCPETemplateReco>(pset_,magfield.product(),*pDD.product(),*hTT.product(),lorentzAngleProduct,templateDBobject.product() );
 }
 
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
@@ -35,7 +35,7 @@ PixelCPETemplateRecoESProducer::PixelCPETemplateRecoESProducer(const edm::Parame
 
 PixelCPETemplateRecoESProducer::~PixelCPETemplateRecoESProducer() {}
 
-std::unique_ptr<PixelClusterParameterEstimator> 
+std::shared_ptr<PixelClusterParameterEstimator> 
 PixelCPETemplateRecoESProducer::produce(const TkPixelCPERecord & iRecord){ 
 
   ESHandle<MagneticField> magfield;
@@ -60,7 +60,9 @@ PixelCPETemplateRecoESProducer::produce(const TkPixelCPERecord & iRecord){
   ESHandle<SiPixelTemplateDBObject> templateDBobject;
   iRecord.getRecord<SiPixelTemplateDBObjectESProducerRcd>().get(templateDBobject);
 
-  return std::make_unique<PixelCPETemplateReco>(pset_,magfield.product(),*pDD.product(),*hTT.product(),lorentzAngleProduct,templateDBobject.product() );
+  //  cpe_  = std::make_shared<PixelCPETemplateReco>(pset_,magfield.product(),lorentzAngle.product(),templateDBobject.product() );
+  cpe_  = std::make_shared<PixelCPETemplateReco>(pset_,magfield.product(),*pDD.product(),*hTT.product(),lorentzAngleProduct,templateDBobject.product() );
+  return cpe_;
 }
 
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SealModules.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SealModules.cc
@@ -7,6 +7,7 @@
 //--- The CPE ES Producers
 #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h"
 #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateRecoESProducer.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepairESProducer.h"
 //---- The RecHit ED producer
 #include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelRecHitConverter.h"
 //--- The header files for the Framework infrastructure (macros etc):
@@ -23,4 +24,5 @@ using cms::SiPixelRecHitConverter;
 DEFINE_FWK_MODULE(SiPixelRecHitConverter);
 DEFINE_FWK_EVENTSETUP_MODULE(PixelCPEGenericESProducer);
 DEFINE_FWK_EVENTSETUP_MODULE(PixelCPETemplateRecoESProducer);
+DEFINE_FWK_EVENTSETUP_MODULE(PixelCPEClusterRepairESProducer);
 

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+
+templates = cms.ESProducer("PixelCPEClusterRepairESProducer",
+    ComponentName = cms.string('PixelCPEClusterRepair'),
+    speed = cms.int32(-2),
+    #PixelErrorParametrization = cms.string('NOTcmsim'),
+    Alpha2Order = cms.bool(True),
+    UseClusterSplitter = cms.bool(False),
+
+    # petar, for clusterProbability() from TTRHs
+    ClusterProbComputationFlag = cms.int32(0),
+    # gavril
+    DoCosmics = cms.bool(False), 
+    # The flag to regulate if the LA offset is taken from Alignment 
+    # True in Run II for offline RECO
+    DoLorentz = cms.bool(True),
+ 
+    LoadTemplatesFromDB = cms.bool(True)
+
+)
+
+# This customization will be removed once we get the templates for phase2 pixel
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(templates,
+  LoadTemplatesFromDB = False,
+  DoLorentz = False,
+)
+

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-templates = cms.ESProducer("PixelCPEClusterRepairESProducer",
+templates2 = cms.ESProducer("PixelCPEClusterRepairESProducer",
     ComponentName = cms.string('PixelCPEClusterRepair'),
     speed = cms.int32(-2),
     #PixelErrorParametrization = cms.string('NOTcmsim'),
@@ -21,7 +21,7 @@ templates = cms.ESProducer("PixelCPEClusterRepairESProducer",
 
 # This customization will be removed once we get the templates for phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(templates,
+phase2_tracker.toModify(templates2,
   LoadTemplatesFromDB = False,
   DoLorentz = False,
 )

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEESProducers_cff.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEESProducers_cff.py
@@ -20,7 +20,8 @@ from RecoLocalTracker.SiPixelRecHits.PixelCPETemplateReco_cfi import *
 #
 from RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi import *
 #
-# 5. The new ESProducer for the Magnetic-field dependent template record
+# 5. ESProducer for the Magnetic-field dependent template records
 #
 from CalibTracker.SiPixelESProducers.SiPixelTemplateDBObjectESProducer_cfi import *
+from CalibTracker.SiPixelESProducers.SiPixel2DTemplateDBObjectESProducer_cfi import *
 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -239,9 +239,24 @@ PixelCPEBase::setTheClu( DetParam const & theDetParam, ClusterParam & theCluster
    minInY = theClusterParam.theCluster->minPixelCol();
    maxInX = theClusterParam.theCluster->maxPixelRow();
    maxInY = theClusterParam.theCluster->maxPixelCol();
+
+   if      ( theDetParam.theRecTopol->isItEdgePixelInX(minInX) )
+     theClusterParam.edgeTypeX_ = 1;
+   else if ( theDetParam.theRecTopol->isItEdgePixelInX(maxInX) )
+     theClusterParam.edgeTypeX_ = 2;
+   else
+     theClusterParam.edgeTypeX_ = 0;
+     
+   if      ( theDetParam.theRecTopol->isItEdgePixelInY(minInY) )
+     theClusterParam.edgeTypeY_ = 1;
+   else if ( theDetParam.theRecTopol->isItEdgePixelInY(maxInY) )
+     theClusterParam.edgeTypeY_ = 2;
+   else
+     theClusterParam.edgeTypeY_ = 0;
    
-   theClusterParam.isOnEdge_ = theDetParam.theRecTopol->isItEdgePixelInX(minInX) | theDetParam.theRecTopol->isItEdgePixelInX(maxInX) |
-   theDetParam.theRecTopol->isItEdgePixelInY(minInY) | theDetParam.theRecTopol->isItEdgePixelInY(maxInY) ;
+   theClusterParam.isOnEdge_ = ( theClusterParam.edgeTypeX_ || theClusterParam.edgeTypeY_ );
+   // theClusterParam.isOnEdge_ = theDetParam.theRecTopol->isItEdgePixelInX(minInX) | theDetParam.theRecTopol->isItEdgePixelInX(maxInX) |
+   // theDetParam.theRecTopol->isItEdgePixelInY(minInY) | theDetParam.theRecTopol->isItEdgePixelInY(maxInY) ;
    
    // FOR NOW UNUSED. KEEP IT IN CASE WE WANT TO USE IT IN THE FUTURE
    // Bad Pixels have their charge set to 0 in the clusterizer

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -55,7 +55,6 @@ magfield_(mag), geom_(geom), ttopo_(ttopo)
    
    //-- GenError Calibration Object (different from SiPixelCPEGenericErrorParm) from DB
    genErrorDBObject_ = genErrorDBObject;
-   //cout<<" new errors "<<genErrorDBObject<<" "<<genErrorDBObject_<<endl;
    
    //-- Template Calibration Object from DB
    if(theFlag_!=0) templateDBobject_ = templateDBobject; // flag to check if it is generic or templates
@@ -65,7 +64,6 @@ magfield_(mag), geom_(geom), ttopo_(ttopo)
    
    // Read templates and/or generic errors from DB
    LoadTemplatesFromDB_ = conf.getParameter<bool>("LoadTemplatesFromDB");
-   //cout<<" use generros/templaets "<<LoadTemplatesFromDB_<<endl;
    
    //--- Algorithm's verbosity
    theVerboseLevel =
@@ -92,6 +90,7 @@ magfield_(mag), geom_(geom), ttopo_(ttopo)
    conf.getParameter<bool>("useLAWidthFromDB"):false;
    
    // Use Alignment LA-offset in generic
+   // (Experimental; leave commented out)
    //useLAAlignmentOffsets_ = conf.existsAs<bool>("useLAAlignmentOffsets")?
    //conf.getParameter<bool>("useLAAlignmentOffsets"):false;
    
@@ -104,9 +103,11 @@ magfield_(mag), geom_(geom), ttopo_(ttopo)
    conf.getParameter<double>("lAWidthFPix"):0.0;
    
    // Use LA-offset from config, for testing only
-   if(lAOffset_>0.0) useLAOffsetFromConfig_ = true;
+   if (lAOffset_>0.0) 
+     useLAOffsetFromConfig_ = true;
    // Use LA-width from config, split into fpix & bpix, for testing only
-   if(lAWidthBPix_>0.0 || lAWidthFPix_>0.0) useLAWidthFromConfig_ = true;
+   if (lAWidthBPix_>0.0 || lAWidthFPix_>0.0) 
+     useLAWidthFromConfig_ = true;
    
    
    // For Templates only
@@ -114,24 +115,23 @@ magfield_(mag), geom_(geom), ttopo_(ttopo)
    DoLorentz_ = conf.existsAs<bool>("DoLorentz")?conf.getParameter<bool>("DoLorentz"):false;
    
    LogDebug("PixelCPEBase") <<" LA constants - "
-   <<lAOffset_<<" "<<lAWidthBPix_<<" "<<lAWidthFPix_<<endl; //dk
+			    << lAOffset_ << " " << lAWidthBPix_ << " " <<lAWidthFPix_ << endl; //dk
    
    fillDetParams();
-   
-   //cout<<" LA "<<lAOffset_<<" "<<lAWidthBPix_<<" "<<lAWidthFPix_<<endl; //dk
 }
+
 
 //-----------------------------------------------------------------------------
 //  Fill all variables which are constant for an event (geometry)
 //-----------------------------------------------------------------------------
 void PixelCPEBase::fillDetParams()
 {
-   //cout<<" in fillDetParams "<<theFlag_<<endl;
-   
+  // &&& PM: I have no idea what this code is doing, and what it is doing here!???
+  //
    auto const & dus = geom_.detUnits();
    unsigned m_detectors = dus.size();
    for(unsigned int i=1;i<7;++i) {
-      LogDebug("LookingForFirstStrip") << "Subdetector " << i
+      LogDebug("PixelCPEBase:: LookingForFirstStrip") << "Subdetector " << i
       << " GeomDetEnumerator " << GeomDetEnumerators::tkDetEnum[i]
       << " offset " << geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i])
       << " is it strip? " << (geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i]) != dus.size() ?
@@ -145,7 +145,7 @@ void PixelCPEBase::fillDetParams()
    
    
    m_DetParams.resize(m_detectors);
-   //cout<<"caching "<<m_detectors<<" pixel detectors"<<endl;
+   LogDebug("PixelCPEBase::fillDetParams():") <<"caching "<<m_detectors<<" pixel detectors"<<endl;
    for (unsigned i=0; i!=m_detectors;++i) {
       auto & p=m_DetParams[i];
       p.theDet = dynamic_cast<const PixelGeomDetUnit*>(dus[i]);
@@ -157,7 +157,6 @@ void PixelCPEBase::fillDetParams()
       //--- p.theDet->type() returns a GeomDetType, which implements subDetector()
       p.thePart = p.theDet->type().subDetector();
       
-      //cout<<" in PixelCPEBase - in det "<<thePart<<endl; //dk
       
       //--- The location in of this DetUnit in a cyllindrical coord system (R,Z)
       //--- The call goes via BoundSurface, returned by p.theDet->surface(), but
@@ -179,6 +178,7 @@ void PixelCPEBase::fillDetParams()
          p.detTemplateId = templateDBobject_->getTemplateID(p.theDet->geographicalId());
       }
       
+      // &&& PM: I'm not sure what this does. Ask around.
       // just for testing
       //int i1 = 0;
       //if(theFlag_==0) i1 = genErrorDBObject_->getGenErrorID(p.theDet->geographicalId().rawId());
@@ -194,28 +194,28 @@ void PixelCPEBase::fillDetParams()
       else p.theRecTopol = dynamic_cast<const RectangularPixelTopology*>(p.theTopol);
       assert(p.theRecTopol);
       
-      //---- The geometrical description of one module/plaquette
-      //p.theNumOfRow = p.theRecTopol->nrows();	// rows in x //Not used, AH
-      //p.theNumOfCol = p.theRecTopol->ncolumns();	// cols in y //Not used, AH
+      //--- The geometrical description of one module/plaquette
+      //p.theNumOfRow = p.theRecTopol->nrows();	// rows in x //Not used, AH. PM: leave commented out.
+      //p.theNumOfCol = p.theRecTopol->ncolumns();	// cols in y //Not used, AH. PM: leave commented out.
       std::pair<float,float> pitchxy = p.theRecTopol->pitch();
       p.thePitchX = pitchxy.first;	     // pitch along x
       p.thePitchY = pitchxy.second;	     // pitch along y
       
-      //p.theSign = isFlipped(&p) ? -1 : 1; //Not used, AH
+      //p.theSign = isFlipped(&p) ? -1 : 1; //Not used, AH.  PM: leave commented out.
       
       LocalVector Bfield = p.theDet->surface().toLocal(magfield_->inTesla(p.theDet->surface().position()));
       p.bz = Bfield.z();
       p.bx = Bfield.x();
       
       
-      // Compute the Lorentz shifts for this detector element
+      //---  Compute the Lorentz shifts for this detector element
       if ( (theFlag_==0) || DoLorentz_ ) {  // do always for generic and if(DOLorentz) for templates
          p.driftDirection = driftDirection(p, Bfield );
          computeLorentzShifts(p);
       }
       
       
-      LogDebug("PixelCPEBase") << "***** PIXEL LAYOUT *****"
+      LogDebug("PixelCPEBase::fillDetParams()") << "***** PIXEL LAYOUT *****"
       << " thePart = " << p.thePart
       << " theThickness = " << p.theThickness
       << " thePitchX  = " << p.thePitchX
@@ -255,10 +255,8 @@ PixelCPEBase::setTheClu( DetParam const & theDetParam, ClusterParam & theCluster
      theClusterParam.edgeTypeY_ = 0;
    
    theClusterParam.isOnEdge_ = ( theClusterParam.edgeTypeX_ || theClusterParam.edgeTypeY_ );
-   // theClusterParam.isOnEdge_ = theDetParam.theRecTopol->isItEdgePixelInX(minInX) | theDetParam.theRecTopol->isItEdgePixelInX(maxInX) |
-   // theDetParam.theRecTopol->isItEdgePixelInY(minInY) | theDetParam.theRecTopol->isItEdgePixelInY(maxInY) ;
    
-   // FOR NOW UNUSED. KEEP IT IN CASE WE WANT TO USE IT IN THE FUTURE
+   // &&& FOR NOW UNUSED. KEEP IT IN CASE WE WANT TO USE IT IN THE FUTURE
    // Bad Pixels have their charge set to 0 in the clusterizer
    //hasBadPixels_ = false;
    //for(unsigned int i=0; i<theClusterParam.theCluster->pixelADC().size(); ++i) {
@@ -279,6 +277,7 @@ void PixelCPEBase::
 computeAnglesFromTrajectory( DetParam const & theDetParam, ClusterParam & theClusterParam,
                             const LocalTrajectoryParameters & ltp) const
 {
+  // &&& PM: this comment is a candidate for deletion, but ask around first.
    //cout<<" in PixelCPEBase:computeAnglesFromTrajectory - "<<endl; //dk
    /*
    //theClusterParam.loc_traj_param = ltp;   
@@ -304,7 +303,7 @@ computeAnglesFromTrajectory( DetParam const & theDetParam, ClusterParam & theClu
    
    theClusterParam.with_track_angle = true;
    
-   // ggiurgiu@jhu.edu 12/09/2010 : needed to correct for bows/kinks
+   // GG: needed to correct for bows/kinks
    theClusterParam.loc_trk_pred = 
       Topology::LocalTrackPred(theClusterParam.trk_lp_x, theClusterParam.trk_lp_y, 
                                theClusterParam.cotalpha,theClusterParam.cotbeta);
@@ -334,7 +333,7 @@ computeAnglesFromTrajectory( DetParam const & theDetParam, ClusterParam & theClu
 void PixelCPEBase::
 computeAnglesFromDetPosition(DetParam const & theDetParam, ClusterParam & theClusterParam ) const
 {
-   
+  // &&& PM: darn, we have a lot of junk here.  Need to clean up.
    
    /*
     // get cluster center of gravity (of charge)
@@ -392,8 +391,7 @@ computeAnglesFromDetPosition(DetParam const & theDetParam, ClusterParam & theClu
    auto gvx = lp.x()-theDetParam.theOrigin.x();
    auto gvy = lp.y()-theDetParam.theOrigin.y();
    auto gvz = -1.f/theDetParam.theOrigin.z();
-   //  normalization not required as only ratio used...
-   
+   //--- Note that the normalization is not required as only the ratio used  
    
    //theClusterParam.zneg = (gvz < 0); // Not used, AH
    
@@ -438,12 +436,12 @@ bool PixelCPEBase::isFlipped(DetParam const & theDetParam) const
    // Check the relative position of the local +/- z in global coordinates.
    float tmp1 = theDetParam.theDet->surface().toGlobal(Local3DPoint(0.,0.,0.)).perp2();
    float tmp2 = theDetParam.theDet->surface().toGlobal(Local3DPoint(0.,0.,1.)).perp2();
-   //cout << " 1: " << tmp1 << " 2: " << tmp2 << endl;
-   if ( tmp2<tmp1 ) return true;
+   if ( tmp2 < tmp1 ) return true;
    else return false;
 }
 //------------------------------------------------------------------------
-PixelCPEBase::DetParam const & PixelCPEBase::detParam(const GeomDetUnit & det) const {
+PixelCPEBase::DetParam const & PixelCPEBase::detParam(const GeomDetUnit & det) const 
+{
    auto i = det.index();
    //cout << "get parameters of detector " << i << endl;
    assert(i<int(m_DetParams.size()));
@@ -457,35 +455,35 @@ PixelCPEBase::DetParam const & PixelCPEBase::detParam(const GeomDetUnit & det) c
 //  Works OK for barrel and forward.
 //  The formulas used for dir_x,y,z have to be exactly the same as the ones
 //  used in the digitizer (SiPixelDigitizerAlgorithm.cc).
-//
+//  &&& PM: needs to be consolidated, discuss with PS.
 //-----------------------------------------------------------------------------
 LocalVector
-PixelCPEBase::driftDirection(DetParam & theDetParam, GlobalVector bfield ) const {
-   
+PixelCPEBase::driftDirection(DetParam & theDetParam, GlobalVector bfield ) const 
+{
    Frame detFrame(theDetParam.theDet->surface().position(), theDetParam.theDet->surface().rotation());
    LocalVector Bfield = detFrame.toLocal(bfield);
    return driftDirection(theDetParam,Bfield);
-   
 }
 
+
 LocalVector
-PixelCPEBase::driftDirection(DetParam & theDetParam, LocalVector Bfield ) const {
-   const bool LocalPrint = false;
-   
+PixelCPEBase::driftDirection(DetParam & theDetParam, LocalVector Bfield ) const 
+{
    // Use LA from DB or from config
    float langle = 0.;
    if( !useLAOffsetFromConfig_ ) {  // get it from DB
       if(lorentzAngle_ != nullptr) {  // a real LA object
          langle = lorentzAngle_->getLorentzAngle(theDetParam.theDet->geographicalId().rawId());
-         //cout<<" la "<<langle<<" "<< theDetParam.theDet->geographicalId().rawId() <<endl;
+         LogDebug("PixelCPEBase::driftDirection()") 
+	   <<" la "<<langle<<" "<< theDetParam.theDet->geographicalId().rawId() <<endl;
       } else { // no LA, unused
-         //cout<<" LA object is NULL, assume LA = 0"<<endl; //dk
-         langle = 0; // set to a fake value
+	 langle = 0; // set to a fake value
+	 LogDebug("PixelCPEBase::driftDirection()") <<" LA object is NULL, assume LA = 0"<<endl; //dk
       }
-      if(LocalPrint) cout<<" Will use LA Offset from DB "<<langle<<endl;
+      LogDebug("PixelCPEBase::driftDirection()") << " Will use LA Offset from DB "<<langle<<endl;
    } else {  // from config file
       langle = lAOffset_;
-      if(LocalPrint) cout<<" Will use LA Offset from config "<<langle<<endl;
+      LogDebug("PixelCPEBase::driftDirection()") << " Will use LA Offset from config "<<langle<<endl;
    }
    
    // Now do the LA width stuff
@@ -496,7 +494,7 @@ PixelCPEBase::driftDirection(DetParam & theDetParam, LocalVector Bfield ) const 
    if(theFlag_==0) {
       
       if(useLAWidthFromDB_ && (lorentzAngleWidth_ != nullptr) ) {
-         // take it from a seperate, special LA DB object (forWidth)
+         // take it from a separate, special LA DB object (forWidth)
          
          auto langleWidth = lorentzAngleWidth_->getLorentzAngle(theDetParam.theDet->geographicalId().rawId());
          if(langleWidth!=0.0) theDetParam.widthLAFractionX = std::abs(langleWidth/langle);
@@ -524,9 +522,7 @@ PixelCPEBase::driftDirection(DetParam & theDetParam, LocalVector Bfield ) const 
       
    }  // if flag
    
-   
-   if(LocalPrint) cout<<" in PixelCPEBase:driftDirection - "<<langle<<" "<<Bfield<<endl; //dk
-   
+
    float alpha2 = alpha2Order ?  langle*langle : 0; //
    
    // **********************************************************************
@@ -551,21 +547,16 @@ PixelCPEBase::driftDirection(DetParam & theDetParam, LocalVector Bfield ) const 
 //  One-shot computation of the driftDirection and both lorentz shifts
 //-----------------------------------------------------------------------------
 void
-PixelCPEBase::computeLorentzShifts(DetParam & theDetParam) const {
-   
-   //cout<<" in PixelCPEBase:computeLorentzShifts - "<<driftDirection_<<endl; //dk
-   
+PixelCPEBase::computeLorentzShifts(DetParam & theDetParam) const 
+{
    // Max shift (at the other side of the sensor) in cm
    theDetParam.lorentzShiftInCmX = theDetParam.driftDirection.x()/theDetParam.driftDirection.z() * theDetParam.theThickness;  //
    theDetParam.lorentzShiftInCmY = theDetParam.driftDirection.y()/theDetParam.driftDirection.z() * theDetParam.theThickness;  //
    
-   //cout<<" in PixelCPEBase:computeLorentzShifts - "
-   //<<lorentzShiftInCmX_<<" "
-   //<<lorentzShiftInCmY_<<" "
-   //<<endl; //dk
-   
-   LogDebug("PixelCPEBase") << " The drift direction in local coordinate is "
-   << theDetParam.driftDirection    ;
+   LogDebug("PixelCPEBase::computeLorentzShifts()") << " lorentzShiftsInCmX,Y = "
+						    << theDetParam.lorentzShiftInCmX <<" "
+						    << theDetParam.lorentzShiftInCmY <<" "
+						    << theDetParam.driftDirection;
 }
 
 //-----------------------------------------------------------------------------

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -1,0 +1,628 @@
+// Include our own header first
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h"
+
+// Geometry services
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
+
+//#define DEBUG
+
+// MessageLogger
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+// Magnetic field
+#include "MagneticField/Engine/interface/MagneticField.h"
+
+
+// Commented for now (3/10/17) until we figure out how to resuscitate 2D template splitter
+/// #include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateSplit.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <vector>
+#include "boost/multi_array.hpp"
+
+#include <iostream>
+
+using namespace SiPixelTemplateReco;
+//using namespace SiPixelTemplateSplit;
+using namespace std;
+
+namespace {
+   constexpr float micronsToCm = 1.0e-4;
+   constexpr int cluster_matrix_size_x = 13;
+   constexpr int cluster_matrix_size_y = 21;
+}
+
+//-----------------------------------------------------------------------------
+//  Constructor.
+//
+//-----------------------------------------------------------------------------
+PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const & conf,
+                                           const MagneticField * mag,
+                                           const TrackerGeometry& geom,
+                                           const TrackerTopology& ttopo,
+                                           const SiPixelLorentzAngle * lorentzAngle,
+					   const SiPixelTemplateDBObject * templateDBobject,
+					   const SiPixel2DTemplateDBObject * templateDBobject2D )
+: PixelCPEBase(conf, mag, geom, ttopo, lorentzAngle, nullptr, templateDBobject, nullptr,1)
+{
+   //cout << endl;
+   //cout << "Constructing PixelCPEClusterRepair::PixelCPEClusterRepair(...)................................................." << endl;
+   //cout << endl;
+   
+   // Configurable parameters
+   //DoCosmics_ = conf.getParameter<bool>("DoCosmics"); // Not used in templates
+   //LoadTemplatesFromDB_ = conf.getParameter<bool>("LoadTemplatesFromDB"); // Moved to Base
+   
+   //cout << " PixelCPEClusterRepair : (int)LoadTemplatesFromDB_ = " << (int)LoadTemplatesFromDB_ << endl;
+   //cout << "field_magnitude = " << field_magnitude << endl;
+   
+   // configuration parameter to decide between DB or text file template access
+   
+   if ( LoadTemplatesFromDB_ )
+   {
+      //cout << "PixelCPEClusterRepair: Loading templates from database (DB) --------- " << endl;
+      
+      // Initialize template store to the selected ID [Morris, 6/25/08]
+      if ( !SiPixelTemplate::pushfile( *templateDBobject_, thePixelTemp_) )
+         throw cms::Exception("PixelCPEClusterRepair")
+         << "\nERROR: Templates not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "
+         << (*templateDBobject_).version() << "\n\n";
+
+      // Initialize template store to the selected ID [Morris, 6/25/08]
+      if ( !SiPixelTemplate2D::pushfile( *templateDBobject2D , thePixelTemp2D_) )
+         throw cms::Exception("PixelCPEClusterRepair")
+         << "\nERROR: Templates not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "
+         << (*templateDBobject_).version() << "\n\n";
+   }
+   else
+   {
+      //cout << "PixelCPEClusterRepair : Loading templates for barrel and forward from ASCII files ----------" << endl;
+      //--- (Archaic) Get configurable template IDs.  This code executes only if we loading pixels from ASCII
+      //    files, and then they are mandatory.
+      barrelTemplateID_  = conf.getParameter<int>( "barrelTemplateID" );
+      forwardTemplateID_ = conf.getParameter<int>( "forwardTemplateID" );
+      templateDir_       = conf.getParameter<int>( "directoryWithTemplates" );
+     
+      if ( !SiPixelTemplate::pushfile( barrelTemplateID_  , thePixelTemp_ , templateDir_ ) )
+         throw cms::Exception("PixelCPEClusterRepair")
+	 << "\nERROR: Template ID " << barrelTemplateID_ << " not loaded correctly from text file. Reconstruction will fail.\n\n";
+      
+      if ( !SiPixelTemplate::pushfile( forwardTemplateID_ , thePixelTemp_ , templateDir_ ) )
+         throw cms::Exception("PixelCPEClusterRepair")
+	 << "\nERROR: Template ID " << forwardTemplateID_ << " not loaded correctly from text file. Reconstruction will fail.\n\n";
+   }
+   
+   speed_ = conf.getParameter<int>( "speed");
+   LogDebug("PixelCPEClusterRepair::PixelCPEClusterRepair:") <<
+   "Template speed = " << speed_ << "\n";
+   
+   UseClusterSplitter_ = conf.getParameter<bool>("UseClusterSplitter");   
+
+
+   //--- Configure 3D reco.
+   if ( conf.exists("MinProbY") )
+     minProbY_ = conf.getParameter<double>("MinProbY");
+   else
+     minProbY_ = 0.001;           // probabilityY < 0.001
+
+   if ( conf.exists("MaxSizeMismatchInY") )
+     maxSizeMismatchInY_ = conf.getParameter<int>("MaxSizeMismatchInY");
+   else
+     maxSizeMismatchInY_ = 1;     // ( templ.clsleny() - nypix > 1)
+
+}
+
+
+
+//-----------------------------------------------------------------------------
+//  Clean up.
+//-----------------------------------------------------------------------------
+PixelCPEClusterRepair::~PixelCPEClusterRepair()
+{
+   for(auto x : thePixelTemp_) x.destroy();
+   // Note: this is not needed for Template 2D
+}
+
+PixelCPEBase::ClusterParam* PixelCPEClusterRepair::createClusterParam(const SiPixelCluster & cl) const
+{
+   return new ClusterParamTemplate(cl);
+}
+
+
+
+//------------------------------------------------------------------
+//  Public methods mandated by the base class.
+//------------------------------------------------------------------
+
+//------------------------------------------------------------------
+//  The main call to the template code.
+//------------------------------------------------------------------
+LocalPoint
+PixelCPEClusterRepair::localPosition(DetParam const & theDetParam, ClusterParam & theClusterParamBase) const
+{
+   
+   ClusterParamTemplate & theClusterParam = static_cast<ClusterParamTemplate &>(theClusterParamBase);
+   
+   if(!GeomDetEnumerators::isTrackerPixel(theDetParam.thePart))
+      throw cms::Exception("PixelCPEClusterRepair::localPosition :")
+      << "A non-pixel detector type in here?";
+   
+   int ID = -9999;
+   if ( LoadTemplatesFromDB_ ) {
+      int ID0 = templateDBobject_->getTemplateID(theDetParam.theDet->geographicalId()); // just to comapre
+      ID = theDetParam.detTemplateId;
+      if(ID0!=ID) cout<<" different id"<< ID<<" "<<ID0<<endl;
+   } else { // from asci file
+      if ( ! GeomDetEnumerators::isEndcap(theDetParam.thePart) )
+	ID = barrelTemplateID_  ; // barrel
+      else
+	ID = forwardTemplateID_ ; // forward
+   }
+   //cout << "PixelCPEClusterRepair : ID = " << ID << endl;
+
+   // &&& PM, note for later: PixelCPEBase calculates minInX,Y, and maxInX,Y
+   //     Why can't we simply use that and save time with row_offset, col_offset
+   //     and mrow = maxInX-minInX, mcol = maxInY-minInY ... Except that we
+   //     also need to take into account cluster_matrix_size_x,y.
+
+   
+   //--- Preparing to retrieve ADC counts from the SiPixeltheClusterParam.theCluster
+   //    The pixels from minPixelRow() will go into clust_array_2d[0][*],
+   //    and the pixels from minPixelCol() will go into clust_array_2d[*][0].
+   int row_offset = theClusterParam.theCluster->minPixelRow();
+   int col_offset = theClusterParam.theCluster->minPixelCol();
+   
+   //--- Store the coordinates of the center of the (0,0) pixel of the array that
+   //    gets passed to PixelTempReco2D.  Will add these values to the output of TemplReco2D
+   float tmp_x = float(row_offset) + 0.5f;
+   float tmp_y = float(col_offset) + 0.5f;
+
+   
+   //--- Store these offsets (to be added later) in a LocalPoint after tranforming
+   //    them from measurement units (pixel units) to local coordinates (cm)
+   LocalPoint lp;
+   if ( theClusterParam.with_track_angle )
+      //--- Update call with trk angles needed for bow/kink corrections  // Gavril
+      lp = theDetParam.theTopol->localPosition( MeasurementPoint(tmp_x, tmp_y), theClusterParam.loc_trk_pred );
+   else
+   {
+      edm::LogError("PixelCPEClusterRepair")
+      << "@SUB = PixelCPEClusterRepair::localPosition"
+      << "Should never be here. PixelCPEClusterRepair should always be called with track angles. This is a bad error !!! ";
+      lp = theDetParam.theTopol->localPosition( MeasurementPoint(tmp_x, tmp_y) );
+   }
+   
+   //--- Compute the size of the matrix which will be passed to TemplateReco.
+   //    We'll later make  clustMatrix[ mrow ][ mcol ]
+   int mrow=0, mcol=0;
+   for (int i=0 ; i!=theClusterParam.theCluster->size(); ++i )
+   {
+      auto pix = theClusterParam.theCluster->pixel(i);
+      int irow = int(pix.x);
+      int icol = int(pix.y);
+      mrow = std::max(mrow,irow);
+      mcol = std::max(mcol,icol);
+   }
+   mrow -= row_offset; mrow+=1; mrow = std::min(mrow,cluster_matrix_size_x);
+   mcol -= col_offset; mcol+=1; mcol = std::min(mcol,cluster_matrix_size_y);
+   assert(mrow>0); assert(mcol>0);
+
+
+   //--- Make and fill the bool arrays flagging double pixels
+   bool xdouble[mrow], ydouble[mcol];
+   // x directions (shorter), rows
+   for (int irow = 0; irow < mrow; ++irow)
+      xdouble[irow] = theDetParam.theRecTopol->isItBigPixelInX( irow+row_offset );
+   //
+   // y directions (longer), columns
+   for (int icol = 0; icol < mcol; ++icol)
+      ydouble[icol] = theDetParam.theRecTopol->isItBigPixelInY( icol+col_offset );
+
+   //--- C-style matrix.  We'll need it in either case.
+   float clustMatrix[mrow][mcol];
+   float clustMatrix2[mrow][mcol];
+
+   //--- Prepare struct that passes pointers to TemplateReco.  It doesn't own anything.
+   SiPixelTemplateReco::ClusMatrix   clusterPayload  { &clustMatrix[0][0], xdouble, ydouble, mrow,mcol};
+   SiPixelTemplateReco2D::ClusMatrix clusterPayload2d{ &clustMatrix2[0][0], xdouble, ydouble, mrow,mcol};
+
+
+   //--- Copy clust's pixels (calibrated in electrons) into clustMatrix;
+   memset( clustMatrix, 0, sizeof(float)*mrow*mcol );   // Wipe it clean.
+   for (int i=0 ; i!=theClusterParam.theCluster->size(); ++i )
+   {
+      auto pix = theClusterParam.theCluster->pixel(i);
+      int irow = int(pix.x) - row_offset;
+      int icol = int(pix.y) - col_offset;
+      // &&& Do we ever get pixels that are out of bounds ???  Need to check.
+      if ( (irow<mrow) & (icol<mcol) ) clustMatrix[irow][icol] =  float(pix.adc);
+   }
+   // fillClustMatrix( float * clustMatrix );
+
+   //--- Save a copy of clustMatrix into clustMatrix2
+   memcpy( clustMatrix2, clustMatrix, sizeof(float)*mrow*mcol);
+
+   //--- Set both return statuses, since we may call only one.
+   theClusterParam.ierr  = 0;
+   theClusterParam.ierr2 = 0;
+
+
+
+   //--- Are we on edge?
+   if ( theClusterParam.isOnEdge_ ) {
+     //--- Call the Template Reco 2d with cluster repair.0
+     callTempReco3D( theDetParam, theClusterParam, clusterPayload2d, ID, lp );
+   }
+   else {
+     theClusterParam.recommended3D_ = false;
+     //--- Call the vanilla Template Reco
+     callTempReco2D( theDetParam, theClusterParam, clusterPayload, ID, lp );
+
+     //--- Did we find a cluster which has bad probability and not enough charge?
+     if ( theClusterParam.recommended3D_ ) {
+       //--- Yes. So run Template Reco 2d with cluster repair.
+       
+       // //--- Once again (!) copy clust's pixels (calibrated in electrons) into 
+       // //    clustMatrix.  We need to do that because the vanilla template reco
+       // //    will modify the ADC counts in situ (during decapitation)
+       // memset( clustMatrix, 0, sizeof(float)*mrow*mcol );   // Wipe it clean.
+       // for (int i=0 ; i!=theClusterParam.theCluster->size(); ++i )
+       // 	 {
+       // 	   auto pix = theClusterParam.theCluster->pixel(i);
+       // 	   int irow = int(pix.x) - row_offset;
+       // 	   int icol = int(pix.y) - col_offset;
+       // 	   // &&& Do we ever get pixels that are out of bounds ???  Need to check.
+       // 	   if ( (irow<mrow) & (icol<mcol) ) clustMatrix[irow][icol] =  float(pix.adc);
+       // 	 }
+       // // fillClustMatrix( float * clustMatrix );
+       
+
+       //--- Call the Template Reco 2d with cluster repair
+       callTempReco3D( theDetParam, theClusterParam, clusterPayload2d, ID, lp );
+     }
+
+   }
+
+
+   
+   return LocalPoint( theClusterParam.templXrec_, theClusterParam.templYrec_ );
+}
+
+
+//------------------------------------------------------------------
+//  Helper function to aggregate call & handling of Template Reco
+//------------------------------------------------------------------
+void 
+PixelCPEClusterRepair::callTempReco2D( DetParam const & theDetParam, 
+				       ClusterParamTemplate & theClusterParam,
+				       SiPixelTemplateReco::ClusMatrix & clusterPayload,
+				       int ID, LocalPoint & lp ) const
+{
+   SiPixelTemplate templ(thePixelTemp_);
+   
+   // Output:
+   float nonsense = -99999.9f; // nonsense init value
+   theClusterParam.templXrec_ = theClusterParam.templYrec_ = theClusterParam.templSigmaX_ = theClusterParam.templSigmaY_ = nonsense;
+   // If the template recontruction fails, we want to return 1.0 for now
+   theClusterParam.templProbY_ = theClusterParam.templProbX_ = theClusterParam.templProbQ_ = 1.0f;
+   theClusterParam.templQbin_ = 0;
+   // We have a boolean denoting whether the reco failed or not
+   theClusterParam.hasFilledProb_ = false;
+   
+   // ******************************************************************
+   //--- Call normal TemplateReco
+   //
+   float locBz = theDetParam.bz;
+   float locBx = theDetParam.bx;
+   //
+   const bool deadpix = false;
+   std::vector<std::pair<int, int> > zeropix;
+   int nypix =0, nxpix = 0;
+   //
+   theClusterParam.ierr =
+   PixelTempReco2D( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
+                   locBz, locBx,
+                   clusterPayload,
+                   templ,
+                   theClusterParam.templYrec_, theClusterParam.templSigmaY_, theClusterParam.probabilityY_,
+                   theClusterParam.templXrec_, theClusterParam.templSigmaX_, theClusterParam.probabilityX_,
+                   theClusterParam.qBin_,
+		   speed_, deadpix, zeropix,
+		   theClusterParam.probabilityQ_, nypix, nxpix
+                   );
+   // ******************************************************************
+   
+   //--- Check exit status
+   if unlikely( theClusterParam.ierr != 0 )
+   {
+      LogDebug("PixelCPEClusterRepair::localPosition") <<
+      "reconstruction failed with error " << theClusterParam.ierr << "\n";
+      
+      // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
+      // In the x case, apply a rough Lorentz drift average correction
+      // To do: call PixelCPEGeneric whenever PixelTempReco2D fails
+      float lorentz_drift = -999.9;
+      if ( ! GeomDetEnumerators::isEndcap(theDetParam.thePart) )
+         lorentz_drift = 60.0f; // in microns
+      else
+         lorentz_drift = 10.0f; // in microns
+      // ggiurgiu@jhu.edu, 21/09/2010 : trk angles needed to correct for bows/kinks
+      if ( theClusterParam.with_track_angle )
+      {
+         theClusterParam.templXrec_ = theDetParam.theTopol->localX( theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred ) - lorentz_drift * micronsToCm; // rough Lorentz drift correction
+         theClusterParam.templYrec_ = theDetParam.theTopol->localY( theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred );
+      }
+      else
+      {
+         edm::LogError("PixelCPEClusterRepair")
+         << "@SUB = PixelCPEClusterRepair::localPosition"
+         << "Should never be here. PixelCPEClusterRepair should always be called with track angles. This is a bad error !!! ";
+         
+         theClusterParam.templXrec_ = theDetParam.theTopol->localX( theClusterParam.theCluster->x() ) - lorentz_drift * micronsToCm; // rough Lorentz drift correction
+         theClusterParam.templYrec_ = theDetParam.theTopol->localY( theClusterParam.theCluster->y() );
+      }
+   }   
+   else 
+   {
+      //--- Template Reco succeeded.  The probabilities are filled.
+      theClusterParam.hasFilledProb_ = true;
+
+      //--- templ.clsleny() is the expected length of the cluster along y axis.
+      if ( (theClusterParam.probabilityY_ < minProbY_ ) && (templ.clsleny() - nypix > 1) ) {
+	theClusterParam.recommended3D_ = true;
+      }
+      
+      //--- Go from microns to centimeters
+      theClusterParam.templXrec_ *= micronsToCm;
+      theClusterParam.templYrec_ *= micronsToCm;
+      
+      //--- Go back to the module coordinate system
+      theClusterParam.templXrec_ += lp.x();
+      theClusterParam.templYrec_ += lp.y();
+            
+   }
+   return;
+}
+
+
+
+
+//------------------------------------------------------------------
+//  Helper function to aggregate call & handling of Template 2D fit
+//------------------------------------------------------------------
+void 
+PixelCPEClusterRepair::callTempReco3D( DetParam const & theDetParam, 
+				       ClusterParamTemplate & theClusterParam,
+				       SiPixelTemplateReco2D::ClusMatrix & clusterPayload,
+				       int ID, LocalPoint & lp ) const
+{
+   SiPixelTemplate2D templ2d(thePixelTemp2D_);
+   
+   // Output:
+   float nonsense = -99999.9f; // nonsense init value
+   theClusterParam.templXrec_ = theClusterParam.templYrec_ = theClusterParam.templSigmaX_ = theClusterParam.templSigmaY_ = nonsense;
+   // If the template recontruction fails, we want to return 1.0 for now
+   theClusterParam.templProbY_ = theClusterParam.templProbX_ = theClusterParam.templProbQ_ = 1.0f;
+   theClusterParam.templQbin_ = 0;
+   // We have a boolean denoting whether the reco failed or not
+   theClusterParam.hasFilledProb_ = false;
+   
+   // ******************************************************************
+   //--- Call 2D TemplateReco
+   //
+   float locBz = theDetParam.bz;
+   float locBx = theDetParam.bx;
+
+   //--- Input:
+   //   edgeflagy - (input) flag to indicate the present of edges in y: 
+   //           0=none (or interior gap),1=edge at small y, 2=edge at large y, 3=edge at either end
+   //
+   //   edgeflagx - (input) flag to indicate the present of edges in x: 
+   //           0=none, 1=edge at small x, 2=edge at large x
+   //
+   //   These two variables are calculated in setTheClu() and stored in edgeTypeX_ and edgeTypeY_
+   //
+   //--- Output:
+   //   deltay - (output) template y-length - cluster length [when > 0, possibly missing end]
+   //   npixels - ???     &&& Ask Morris
+
+   float deltay = 0;
+   int npixels = 0;
+
+   theClusterParam.ierr2 =
+   PixelTempReco3D( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
+                   locBz, locBx,
+		   theClusterParam.edgeTypeY_ , theClusterParam.edgeTypeX_ ,
+                   clusterPayload,
+                   templ2d,
+                   theClusterParam.templYrec_, theClusterParam.templSigmaY_, 
+                   theClusterParam.templXrec_, theClusterParam.templSigmaX_, 
+		   theClusterParam.templProbXY_,
+         	   theClusterParam.probabilityQ_,
+		   theClusterParam.qBin_,
+		   deltay, npixels
+                   );
+   // ******************************************************************
+   
+   //--- Check exit status
+   if unlikely( theClusterParam.ierr2 != 0 )
+   {
+      LogDebug("PixelCPEClusterRepair::localPosition") <<
+      "3D reconstruction failed with error " << theClusterParam.ierr2 << "\n";
+      
+      // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
+      // In the x case, apply a rough Lorentz drift average correction
+      // To do: call PixelCPEGeneric whenever PixelTempReco2D fails
+      float lorentz_drift = -999.9;
+      if ( ! GeomDetEnumerators::isEndcap(theDetParam.thePart) )
+         lorentz_drift = 60.0f; // in microns
+      else
+         lorentz_drift = 10.0f; // in microns
+      // ggiurgiu@jhu.edu, 21/09/2010 : trk angles needed to correct for bows/kinks
+      if ( theClusterParam.with_track_angle )
+      {
+         theClusterParam.templXrec_ = theDetParam.theTopol->localX( theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred ) - lorentz_drift * micronsToCm; // rough Lorentz drift correction
+         theClusterParam.templYrec_ = theDetParam.theTopol->localY( theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred );
+      }
+      else
+      {
+         edm::LogError("PixelCPEClusterRepair")
+         << "@SUB = PixelCPEClusterRepair::localPosition"
+         << "Should never be here. PixelCPEClusterRepair should always be called with track angles. This is a bad error !!! ";
+         
+         theClusterParam.templXrec_ = theDetParam.theTopol->localX( theClusterParam.theCluster->x() ) - lorentz_drift * micronsToCm; // rough Lorentz drift correction
+         theClusterParam.templYrec_ = theDetParam.theTopol->localY( theClusterParam.theCluster->y() );
+      }
+   }   
+   else 
+   {
+      //--- Template Reco succeeded.
+      theClusterParam.hasFilledProb_ = true;
+
+      //--- Go from microns to centimeters
+      theClusterParam.templXrec_ *= micronsToCm;
+      theClusterParam.templYrec_ *= micronsToCm;
+      
+      //--- Go back to the module coordinate system
+      theClusterParam.templXrec_ += lp.x();
+      theClusterParam.templYrec_ += lp.y();
+   }
+   return;
+}
+
+
+
+
+//------------------------------------------------------------------
+//  localError() relies on localPosition() being called FIRST!!!
+//------------------------------------------------------------------
+LocalError
+PixelCPEClusterRepair::localError(DetParam const & theDetParam,  ClusterParam & theClusterParamBase) const
+{
+   
+   ClusterParamTemplate & theClusterParam = static_cast<ClusterParamTemplate &>(theClusterParamBase);
+   
+   //cout << endl;
+   //cout << "Set PixelCPETemplate errors .............................................." << endl;
+   
+   //cout << "CPETemplate : " << endl;
+   
+   //--- Default is the maximum error used for edge clusters.
+   //--- (never used, in fact: let comment it out, shut up the complains of the static analyzer, and save a few CPU cycles)
+   //   const float sig12 = 1./sqrt(12.0);
+   //   float xerr = theDetParam.thePitchX *sig12;
+   //   float yerr = theDetParam.thePitchY *sig12;
+   float xerr = 0.0f, yerr = 0.0f;
+   
+   // Check if the errors were already set at the clusters splitting level
+   if ( theClusterParam.theCluster->getSplitClusterErrorX() > 0.0f && theClusterParam.theCluster->getSplitClusterErrorX() < 7777.7f &&
+       theClusterParam.theCluster->getSplitClusterErrorY() > 0.0f && theClusterParam.theCluster->getSplitClusterErrorY() < 7777.7f )
+   {
+      xerr = theClusterParam.theCluster->getSplitClusterErrorX() * micronsToCm;
+      yerr = theClusterParam.theCluster->getSplitClusterErrorY() * micronsToCm;
+      
+      //cout << "Errors set at cluster splitting level : " << endl;
+      //cout << "xerr = " << xerr << endl;
+      //cout << "yerr = " << yerr << endl;
+   }
+   else
+   {
+      // &&& Duplicate from above! Argh!
+      int maxPixelCol = theClusterParam.theCluster->maxPixelCol();
+      int maxPixelRow = theClusterParam.theCluster->maxPixelRow();
+      int minPixelCol = theClusterParam.theCluster->minPixelCol();
+      int minPixelRow = theClusterParam.theCluster->minPixelRow();
+      
+      //--- Are we near either of the edges?
+      bool edgex = ( theDetParam.theRecTopol->isItEdgePixelInX( minPixelRow ) || theDetParam.theRecTopol->isItEdgePixelInX( maxPixelRow ) );
+      bool edgey = ( theDetParam.theRecTopol->isItEdgePixelInY( minPixelCol ) || theDetParam.theRecTopol->isItEdgePixelInY( maxPixelCol ) );
+      
+
+      //--- Check status of both template calls.
+      if ( (theClusterParam.ierr !=0) || (theClusterParam.ierr2 !=0) )   
+      {
+         // If reconstruction fails the hit position is calculated from cluster center of gravity
+         // corrected in x by average Lorentz drift. Assign huge errors.
+         //xerr = 10.0 * (float)theClusterParam.theCluster->sizeX() * xerr;
+         //yerr = 10.0 * (float)theClusterParam.theCluster->sizeX() * yerr;
+         
+         if(!GeomDetEnumerators::isTrackerPixel(theDetParam.thePart))
+            throw cms::Exception("PixelCPEClusterRepair::localPosition :")
+            << "A non-pixel detector type in here?";
+         
+         // Assign better errors based on the residuals for failed template cases
+         if ( GeomDetEnumerators::isBarrel(theDetParam.thePart) )
+         {
+            xerr = 55.0f * micronsToCm;
+            yerr = 36.0f * micronsToCm;
+         }
+         else
+         {
+            xerr = 42.0f * micronsToCm;
+            yerr = 39.0f * micronsToCm;
+         }
+         
+         //cout << "xerr = " << xerr << endl;
+         //cout << "yerr = " << yerr << endl;
+         
+         //return LocalError(xerr*xerr, 0, yerr*yerr);
+      }
+      else if ( theClusterParam.edgeTypeX_ || theClusterParam.edgeTypeY_ )
+      {
+         // for edge pixels assign errors according to observed residual RMS
+         if      ( theClusterParam.edgeTypeX_ && !theClusterParam.edgeTypeY_ )
+         {
+            xerr = 23.0f * micronsToCm;
+            yerr = 39.0f * micronsToCm;
+         }
+         else if ( !theClusterParam.edgeTypeX_ && theClusterParam.edgeTypeY_ )
+         {
+            xerr = 24.0f * micronsToCm;
+            yerr = 96.0f * micronsToCm;
+         }
+         else if ( theClusterParam.edgeTypeX_ && theClusterParam.edgeTypeY_ )
+         {
+            xerr = 31.0f * micronsToCm;
+            yerr = 90.0f * micronsToCm;
+         }
+      }
+      else 
+      {
+         xerr = theClusterParam.templSigmaX_ * micronsToCm;
+         yerr = theClusterParam.templSigmaY_ * micronsToCm;
+                  
+         // &&& should also check ierr (saved as class variable) and return
+         // &&& nonsense (another class static) if the template fit failed.
+      }       
+      
+      //cout << "xerr = " << xerr << endl;
+      //cout << "yerr = " << yerr << endl;
+
+      if (theVerboseLevel > 9) 
+      {
+         LogDebug("PixelCPEClusterRepair") <<
+         " Sizex = " << theClusterParam.theCluster->sizeX() << " Sizey = " << theClusterParam.theCluster->sizeY() << " Edgex = " << edgex << " Edgey = " << edgey << 
+         " ErrX  = " << xerr            << " ErrY  = " << yerr;
+      }
+      
+   } // else
+   
+   if ( !(xerr > 0.0f) )
+      throw cms::Exception("PixelCPEClusterRepair::localError") 
+      << "\nERROR: Negative pixel error xerr = " << xerr << "\n\n";
+   
+   if ( !(yerr > 0.0f) )
+      throw cms::Exception("PixelCPEClusterRepair::localError") 
+      << "\nERROR: Negative pixel error yerr = " << yerr << "\n\n";
+   
+   //cout << "Final errors set to: " << endl;
+   //cout << "xerr = " << xerr << endl;
+   //cout << "yerr = " << yerr << endl;
+   //cout << "Out of PixelCPETemplateREco..........................................................................." << endl;
+   //cout << endl;
+   
+   return LocalError(xerr*xerr, 0, yerr*yerr);
+}
+

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -73,15 +73,18 @@ PixelCPETemplateReco::PixelCPETemplateReco(edm::ParameterSet const & conf,
    }
    else
    {
-      //cout << "PixelCPETemplateReco : Loading templates 40 and 41 from ASCII files ------------------------" << endl;
-      
-      if ( !SiPixelTemplate::pushfile( 40, thePixelTemp_ ) )
+      //cout << "PixelCPETemplateReco : Loading templates for barrel and forward from ASCII files ----------" << endl;
+      barrelTemplateID_  = conf.getParameter<int>( "barrelTemplateID" );
+      forwardTemplateID_ = conf.getParameter<int>( "forwardTemplateID" );
+      templateDir_       = conf.getParameter<int>( "directoryWithTemplates" );
+     
+      if ( !SiPixelTemplate::pushfile( barrelTemplateID_  , thePixelTemp_ , templateDir_ ) )
          throw cms::Exception("PixelCPETemplateReco")
-         << "\nERROR: Templates 40 not loaded correctly from text file. Reconstruction will fail.\n\n";
+	 << "\nERROR: Template ID " << barrelTemplateID_ << " not loaded correctly from text file. Reconstruction will fail.\n\n";
       
-      if ( !SiPixelTemplate::pushfile( 41, thePixelTemp_ ) )
+      if ( !SiPixelTemplate::pushfile( forwardTemplateID_ , thePixelTemp_ , templateDir_ ) )
          throw cms::Exception("PixelCPETemplateReco")
-         << "\nERROR: Templates 41 not loaded correctly from text file. Reconstruction will fail.\n\n";
+	 << "\nERROR: Template ID " << forwardTemplateID_ << " not loaded correctly from text file. Reconstruction will fail.\n\n";
    }
    
    speed_ = conf.getParameter<int>( "speed");
@@ -131,8 +134,10 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
       ID = theDetParam.detTemplateId;
       if(ID0!=ID) cout<<" different id"<< ID<<" "<<ID0<<endl;
    } else { // from asci file
-      if ( !fpix ) ID = 40; // barrel
-      else ID = 41; // endcap
+      if ( !fpix )
+	ID = barrelTemplateID_  ; // barrel
+      else
+	ID = forwardTemplateID_ ; // forward
    }
    //cout << "PixelCPETemplateReco : ID = " << ID << endl;
    

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -132,7 +132,7 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
    if ( LoadTemplatesFromDB_ ) {
       int ID0 = templateDBobject_->getTemplateID(theDetParam.theDet->geographicalId()); // just to comapre
       ID = theDetParam.detTemplateId;
-      if(ID0!=ID) cout<<" different id"<< ID<<" "<<ID0<<endl;
+      if(ID0!=ID) edm::LogError("PixelCPETemplateReco") <<" different id"<< ID<<" "<<ID0<<endl;
    } else { // from asci file
       if ( !fpix )
 	ID = barrelTemplateID_  ; // barrel

--- a/RecoLocalTracker/SiPixelRecHits/src/SealModules.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SealModules.cc
@@ -8,6 +8,7 @@
 //--- The CPE ES Producers
 #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h"
 #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateRecoESProducer.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepairESProducer.h"
 //---- The RecHit ED producer
 #include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelRecHitConverter.h"
 //--- The header files for the Framework infrastructure (macros etc):

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
@@ -319,7 +319,7 @@ bool SiPixelGenError::pushfile(const SiPixelGenErrorDBObject& dbobject,
       
       // next, layout the 1-d/2-d structures needed to store GenError
       
-      
+      // &&&  Who is going to delete these?  Are we leaking memory?
       theCurrentTemp.cotbetaY = new float[theCurrentTemp.head.NTy];
       theCurrentTemp.cotbetaX = new float[theCurrentTemp.head.NTyx];
       theCurrentTemp.cotalphaX = new float[theCurrentTemp.head.NTxx];

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
@@ -9,10 +9,8 @@
 //  V2.01 - Allow subdetector ID=5 for FPix R2P2, Fix error message
 //  V2.10 - Update the variable size [SI_PIXEL_TEMPLATE_USE_BOOST] option so that it works with VI's enhancements
 //  V2.20 - Add directory path selection to the ascii pushfile method
+//  V2.21 - Move templateStore to the heap, fix variable name in pushfile()
 
-
-
-//
 
 //#include <stdlib.h>
 //#include <stdio.h>
@@ -56,7 +54,7 @@ using namespace edm;
 //! digits of filenum.
 //! \param filenum - an integer NNNN used in the filename generror_summary_zpNNNN
 //****************************************************************
-bool SiPixelGenError::pushfile(int filenum, std::vector< SiPixelGenErrorStore > & thePixelTemp_ , std::string dir)
+bool SiPixelGenError::pushfile(int filenum, std::vector< SiPixelGenErrorStore > & pixelTemp , std::string dir)
 {
    // Add info stored in external file numbered filenum to theGenErrorStore
    
@@ -225,9 +223,9 @@ bool SiPixelGenError::pushfile(int filenum, std::vector< SiPixelGenErrorStore > 
       
       // Add this info to the store
       
-      thePixelTemp_.push_back(theCurrentTemp);
+      pixelTemp.push_back(theCurrentTemp);
       
-      postInit(thePixelTemp_);
+      postInit(pixelTemp);
       
       return true;
       
@@ -251,7 +249,7 @@ bool SiPixelGenError::pushfile(int filenum, std::vector< SiPixelGenErrorStore > 
 //! \param dbobject - db storing multiple generic calibrations
 //****************************************************************
 bool SiPixelGenError::pushfile(const SiPixelGenErrorDBObject& dbobject,
-                               std::vector< SiPixelGenErrorStore > & thePixelTemp_) {
+                               std::vector< SiPixelGenErrorStore > & pixelTemp) {
    // Add GenError stored in external dbobject to theGenErrorStore
    
    // Local variables
@@ -264,7 +262,9 @@ bool SiPixelGenError::pushfile(const SiPixelGenErrorDBObject& dbobject,
    SiPixelGenErrorDBObject db = dbobject;
    
    // Create a local GenError storage entry
-   SiPixelGenErrorStore theCurrentTemp;
+   /// SiPixelGenErrorStore theCurrentTemp;    // not on the stack...
+   auto tmpPtr = std::make_unique<SiPixelGenErrorStore>(); // must be allocated on the heap instead
+   auto & theCurrentTemp = *tmpPtr;
    
    // Fill the GenError storage for each GenError calibration stored in the db
    for(int m=0; m<db.numOfTempl(); ++m) {
@@ -398,9 +398,9 @@ bool SiPixelGenError::pushfile(const SiPixelGenErrorDBObject& dbobject,
       
       // Add this GenError to the store
       
-      thePixelTemp_.push_back(theCurrentTemp);
+      pixelTemp.push_back(theCurrentTemp);
       
-      postInit(thePixelTemp_);
+      postInit(pixelTemp);
       
    }
    return true;

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
@@ -1,11 +1,17 @@
 //
-//  SiPixelGenError.cc  Version 2.00
+//  SiPixelGenError.cc  Version 2.20
 //
 //  Object stores Lorentz widths, bias corrections, and errors for the Generic Algorithm
 //
 //  Created by Morris Swartz on 10/27/06.
 //  Add some debugging messages. d.k. 5/14
 //  Update for Phase 1 FPix, M.S. 1/15/17
+//  V2.01 - Allow subdetector ID=5 for FPix R2P2, Fix error message
+//  V2.10 - Update the variable size [SI_PIXEL_TEMPLATE_USE_BOOST] option so that it works with VI's enhancements
+//  V2.20 - Add directory path selection to the ascii pushfile method
+
+
+
 //
 
 //#include <stdlib.h>
@@ -50,7 +56,7 @@ using namespace edm;
 //! digits of filenum.
 //! \param filenum - an integer NNNN used in the filename generror_summary_zpNNNN
 //****************************************************************
-bool SiPixelGenError::pushfile(int filenum, std::vector< SiPixelGenErrorStore > & thePixelTemp_)
+bool SiPixelGenError::pushfile(int filenum, std::vector< SiPixelGenErrorStore > & thePixelTemp_ , std::string dir)
 {
    // Add info stored in external file numbered filenum to theGenErrorStore
    
@@ -71,7 +77,7 @@ bool SiPixelGenError::pushfile(int filenum, std::vector< SiPixelGenErrorStore > 
    //  Create different path in CMSSW than standalone
    
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   tout << "CalibTracker/SiPixelESProducers/data/generror_summary_zp"
+   tout << dir << "generror_summary_zp"
    << std::setw(4) << std::setfill('0') << std::right << filenum << ".out" << std::ends;
    std::string tempf = tout.str();
    edm::FileInPath file( tempf.c_str() );
@@ -127,6 +133,11 @@ bool SiPixelGenError::pushfile(int filenum, std::vector< SiPixelGenErrorStore > 
 #ifdef SI_PIXEL_TEMPLATE_USE_BOOST
       
       // next, layout the 1-d/2-d structures needed to store GenError info
+      
+       
+      theCurrentTemp.cotbetaY = new float[theCurrentTemp.head.NTy];
+      theCurrentTemp.cotbetaX = new float[theCurrentTemp.head.NTyx];
+      theCurrentTemp.cotalphaX = new float[theCurrentTemp.head.NTxx];
       
       theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);
       
@@ -307,6 +318,11 @@ bool SiPixelGenError::pushfile(const SiPixelGenErrorDBObject& dbobject,
 #ifdef SI_PIXEL_TEMPLATE_USE_BOOST
       
       // next, layout the 1-d/2-d structures needed to store GenError
+      
+      
+      theCurrentTemp.cotbetaY = new float[theCurrentTemp.head.NTy];
+      theCurrentTemp.cotbetaX = new float[theCurrentTemp.head.NTyx];
+      theCurrentTemp.cotalphaX = new float[theCurrentTemp.head.NTxx];
       
       theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);
       
@@ -543,6 +559,7 @@ int SiPixelGenError::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
       case 2:
       case 3:
       case 4:
+      case 5:
          if(locBx*locBz < 0.f) {
             cota = -cotalpha;
             flip_x = true;
@@ -556,9 +573,9 @@ int SiPixelGenError::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
          break;
       default:
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-         throw cms::Exception("DataCorrupt") << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
+         throw cms::Exception("DataCorrupt") << "SiPixelGenError::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
 #else
-         std::cout << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
+         std::cout << "SiPixelGenError::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
 #endif
    }
    
@@ -657,8 +674,7 @@ int SiPixelGenError::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
    
    auto yrmsgen =(1.f - yratio)*thePixelTemp_[index].enty[ilow].yrmsgen[binq] + yratio*thePixelTemp_[index].enty[ihigh].yrmsgen[binq];
    sy1 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].syone + yratio*thePixelTemp_[index].enty[ihigh].syone;
-   sy2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].sytwo + yratio*thePixelTemp_[index].enty[ihigh].sytwo;
-   
+   sy2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].sytwo + yratio*thePixelTemp_[index].enty[ihigh].sytwo;   
    
    // next, loop over all x-angle entries, first, find relevant y-slices
    
@@ -738,3 +754,22 @@ int SiPixelGenError::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
    return binq;
    
 } // qbin
+
+int SiPixelGenError::qbin(int id, float cotalpha, float cotbeta, float locBz, float locBx, float qclus,
+                          float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax,
+                          float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1,
+                          float& sx2, float& dx2)
+{
+   // Interpolate for a new set of track angles
+   
+   bool irradiationCorrections = true;
+   int ipixmx, ibin;
+   
+   ibin = SiPixelGenError::qbin(id, cotalpha, cotbeta, locBz, locBx, qclus, irradiationCorrections,
+                                ipixmx, sigmay, deltay, sigmax, deltax, sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2);
+                                
+   pixmx = (float)ipixmx;
+   
+   return ibin;
+   
+}

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -1497,10 +1497,9 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta)
    // Interpolate for a new set of track angles
    
    // Local variables
-   float locBx, locBz;
-   locBx = 1.f;
+   float locBx = 1.f;
    if(cotbeta < 0.f) {locBx = -1.f;}
-   locBz = locBx;
+   float locBz = locBx;
    if(cotalpha < 0.f) {locBz = -locBx;}
    return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx);
 }
@@ -1519,8 +1518,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
    // Interpolate for a new set of track angles
    
    // Local variables
-   float locBx;
-   locBx = 1.f;
+   float locBx = 1.f;
    return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx);
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplate.cc  Version 10.13
+//  SiPixelTemplate.cc  Version 10.20
 //
 //  Add goodness-of-fit info and spare entries to templates, version number in template header, more error checking
 //  Add correction for (Q_F-Q_L)/(Q_F+Q_L) bias
@@ -78,6 +78,7 @@
 //  V10.11 - Allow subdetector ID=5 for FPix R2P2 [allows better internal labeling of templates]
 //  V10.12 - Enforce minimum signal size in pixel charge uncertainty calculation
 //  V10.13 - Update the variable size [SI_PIXEL_TEMPLATE_USE_BOOST] option so that it works with VI's enhancements
+//  V10.20 - Add directory path selection to the ascii pushfile method
 
 
 
@@ -126,7 +127,7 @@ using namespace edm;
 //! digits of filenum.
 //! \param filenum - an integer NNNN used in the filename template_summary_zpNNNN
 //****************************************************************
-bool SiPixelTemplate::pushfile(int filenum, std::vector< SiPixelTemplateStore > & thePixelTemp_)
+bool SiPixelTemplate::pushfile(int filenum, std::vector< SiPixelTemplateStore > & thePixelTemp_ , std::string dir)
 {
    // Add template stored in external file numbered filenum to theTemplateStore
    
@@ -147,8 +148,8 @@ bool SiPixelTemplate::pushfile(int filenum, std::vector< SiPixelTemplateStore > 
    //  Create different path in CMSSW than standalone
    
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   tout << "CalibTracker/SiPixelESProducers/data/template_summary_zp"
-   << std::setw(4) << std::setfill('0') << std::right << filenum << ".out" << std::ends;
+   tout << dir << "template_summary_zp"
+	<< std::setw(4) << std::setfill('0') << std::right << filenum << ".out" << std::ends;
    std::string tempf = tout.str();
    edm::FileInPath file( tempf.c_str() );
    tempfile = (file.fullPath()).c_str();
@@ -2573,6 +2574,7 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
    
    
    
+   ilow = ihigh = 0;
    auto xxratio = 0.f;
    
    {

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate2D.cc
@@ -267,14 +267,14 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject, std:
    SiPixel2DTemplateDBObject db = dbobject;
    
    // Create a local template storage entry
-   SiPixelTemplateStore2D theCurrentTemp;
-   
+   /// SiPixelTemplateStore2D theCurrentTemp;   // can't do this (crashes): too large (14 MB) for stack!
+   auto tmpPtr = std::make_unique<SiPixelTemplateStore2D>(); // must be allocated on the heap instead
+   auto & theCurrentTemp = *tmpPtr;
+
    // Fill the template storage for each template calibration stored in the db
    for(int m=0; m<db.numOfTempl(); ++m)
    {
-      
       // Read-in a header string first and print it
-      
       SiPixel2DTemplateDBObject::char2float temp;
       for (i=0; i<20; ++i) {
          temp.f = db.sVector()[db.index()];

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate2D.cc
@@ -259,7 +259,7 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject, std:
    // Add template stored in external dbobject to theTemplateStore
    
    // Local variables
-   int i, j, k, l, iy, jx;
+   int i, j, k, l, iy, jx;       // &&& Do we need them?  Move to the lowest scope...
    //	const char *tempfile;
    const int code_version={21};
    

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate2D.cc
@@ -16,7 +16,7 @@
 // v2.25 - Resize template store to accommodate FPix Templates
 // v2.30 - Fix bug found by P. Shuetze that compromises sqlite file loading
 // v2.35 - Add directory path selection to the ascii pushfile method
-//
+// V2.36 - Move templateStore to the heap, fix variable name in pushfile()
 //
 
 //#include <stdlib.h>
@@ -57,7 +57,7 @@ using namespace edm;
 //! digits of filenum.
 //! \param filenum - an integer NNNN used in the filename template_summary_zpNNNN
 //****************************************************************
-bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2D > & thePixelTemp_, std::string dir)
+bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2D > & pixelTemp, std::string dir)
 {
    // Add template stored in external file numbered filenum to theTemplateStore
    
@@ -231,7 +231,7 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2
       
       // Add this template to the store
       
-      thePixelTemp_.push_back(theCurrentTemp);
+      pixelTemp.push_back(theCurrentTemp);
       
       return true;
       
@@ -254,7 +254,7 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2
 //! external file template_summary_zpNNNN where NNNN are four digits
 //! \param dbobject - db storing multiple template calibrations
 //****************************************************************
-bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore2D > & thePixelTemp_)
+bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore2D > & pixelTemp)
 {
    // Add template stored in external dbobject to theTemplateStore
    
@@ -421,7 +421,7 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject, std:
          
 // Add this template to the store
    
-   thePixelTemp_.push_back(theCurrentTemp);    
+   pixelTemp.push_back(theCurrentTemp);    
      
    }
    

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate2D.cc
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplate2D.cc  Version 1.03
+//  SiPixelTemplate2D.cc  Version 2.35
 //
 //  Full 2-D templates for cluster splitting, simulated cluster reweighting, and improved cluster probability
 //
@@ -9,6 +9,14 @@
 // V1.01 - fix qavg_ filling
 // V1.02 - Add locBz to test if FPix use is out of range
 // V1.03 - Fix edge checking on final template to increase template size and to properly truncate cluster
+// v2.00 - Major changes to accommodate 2D reconstruction
+// v2.10 - Change chi2 and error scaling information to work with partially reconstructed clusters
+// v2.20 - Add cluster charge probability information, side loading for template generation
+// v2.21 - Double derivative interval [improves fit convergence]
+// v2.25 - Resize template store to accommodate FPix Templates
+// v2.30 - Fix bug found by P. Shuetze that compromises sqlite file loading
+// v2.35 - Add directory path selection to the ascii pushfile method
+//
 //
 
 //#include <stdlib.h>
@@ -49,7 +57,7 @@ using namespace edm;
 //! digits of filenum.
 //! \param filenum - an integer NNNN used in the filename template_summary_zpNNNN
 //****************************************************************
-bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2D > & thePixelTemp_)
+bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2D > & thePixelTemp_, std::string dir)
 {
    // Add template stored in external file numbered filenum to theTemplateStore
    
@@ -58,7 +66,7 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2
    const char *tempfile;
    //	char title[80]; remove this
    char c;
-   const int code_version={16};
+   const int code_version={21};
    
    
    
@@ -69,7 +77,7 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2
    //  Create different path in CMSSW than standalone
    
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   tout << "CalibTracker/SiPixelESProducers/data/template_summary2D_zp"
+   tout << dir << "template_summary2D_zp"
    << std::setw(4) << std::setfill('0') << std::right << filenum << ".out" << std::ends;
    std::string tempf = tout.str();
    edm::FileInPath file( tempf.c_str() );
@@ -100,27 +108,51 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2
       LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
       
       // next, the header information
-      
       in_file >> theCurrentTemp.head.ID  >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >> theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx
       >> theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale
       >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >> theCurrentTemp.head.zsize;
       
-      if(in_file.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file, no template load" << ENDL; return false;}
+      if(in_file.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 0A, no template load" << ENDL; return false;}
+      
+      if(theCurrentTemp.head.templ_version > 17) {
+         in_file >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias
+         >> theCurrentTemp.head.lorxbias >> theCurrentTemp.head.fbin[0]
+         >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
+         
+         if(in_file.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 0B, no template load"
+            << ENDL; return false;}
+      } else {
+         theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
+         theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth/2.f;
+         theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth/2.f;
+         theCurrentTemp.head.fbin[0] = 1.5f;
+         theCurrentTemp.head.fbin[1] = 1.00f;
+         theCurrentTemp.head.fbin[2] = 0.85f;
+      }
       
       LOGINFO("SiPixelTemplate2D") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version " << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield
       << ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx<< ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
       << ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
       << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence << ", Q-scaling factor " << theCurrentTemp.head.qscale
-      << ", 1/2 threshold " << theCurrentTemp.head.s50 << ", y Lorentz Width " << theCurrentTemp.head.lorywidth << ", x Lorentz width " << theCurrentTemp.head.lorxwidth
+      << ", 1/2 multi dcol threshold " << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold " << theCurrentTemp.head.ss50
+      << ", y Lorentz Width " << theCurrentTemp.head.lorywidth << ", y Lorentz Bias " << theCurrentTemp.head.lorybias
+      << ", x Lorentz width " << theCurrentTemp.head.lorxwidth << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
+      << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0] << ", " << theCurrentTemp.head.fbin[1]
+      << ", " << theCurrentTemp.head.fbin[2]
       << ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
       
-      if(theCurrentTemp.head.templ_version != code_version) {LOGERROR("SiPixelTemplate2D") << "code expects version " << code_version << ", no template load" << ENDL; return false;}
+      if(theCurrentTemp.head.templ_version < code_version) {LOGERROR("SiPixelTemplate2D") << "code expects version " << code_version << ", no template load" << ENDL; return false;}
       
       if(theCurrentTemp.head.NTy != 0) {LOGERROR("SiPixelTemplate2D") << "Trying to load 1-d template info into the 2-d template object, check your DB/global tag!" << ENDL; return false;}
+      
+      
+#ifdef SI_PIXEL_TEMPLATE_USE_BOOST
       
       // next, layout the 2-d structure needed to store template
       
       theCurrentTemp.entry.resize(boost::extents[theCurrentTemp.head.NTyx][theCurrentTemp.head.NTxx]);
+      
+#endif
       
       // Read in the file info
       
@@ -173,23 +205,23 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2
             }
             
             
-            in_file >> theCurrentTemp.entry[iy][jx].chi2minone >> theCurrentTemp.entry[iy][jx].chi2avgone >> theCurrentTemp.entry[iy][jx].chi2min[0] >> theCurrentTemp.entry[iy][jx].chi2avg[0]
-            >> theCurrentTemp.entry[iy][jx].chi2min[1] >> theCurrentTemp.entry[iy][jx].chi2avg[1]>> theCurrentTemp.entry[iy][jx].chi2min[2] >> theCurrentTemp.entry[iy][jx].chi2avg[2]
-            >> theCurrentTemp.entry[iy][jx].chi2min[3] >> theCurrentTemp.entry[iy][jx].chi2avg[3];
+            in_file >> theCurrentTemp.entry[iy][jx].chi2ppix >> theCurrentTemp.entry[iy][jx].chi2scale >> theCurrentTemp.entry[iy][jx].offsetx[0] >> theCurrentTemp.entry[iy][jx].offsetx[1]
+            >> theCurrentTemp.entry[iy][jx].offsetx[2] >> theCurrentTemp.entry[iy][jx].offsetx[3]>> theCurrentTemp.entry[iy][jx].offsety[0] >> theCurrentTemp.entry[iy][jx].offsety[1]
+            >> theCurrentTemp.entry[iy][jx].offsety[2] >> theCurrentTemp.entry[iy][jx].offsety[3];
             
             if(in_file.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 6, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; return false;}
             
-            in_file >> theCurrentTemp.entry[iy][jx].spare[0] >> theCurrentTemp.entry[iy][jx].spare[1] >> theCurrentTemp.entry[iy][jx].spare[2] >> theCurrentTemp.entry[iy][jx].spare[3]
-            >> theCurrentTemp.entry[iy][jx].spare[4] >> theCurrentTemp.entry[iy][jx].spare[5] >> theCurrentTemp.entry[iy][jx].spare[6] >> theCurrentTemp.entry[iy][jx].spare[7]
-            >> theCurrentTemp.entry[iy][jx].spare[8]  >> theCurrentTemp.entry[iy][jx].spare[9];
+            in_file >> theCurrentTemp.entry[iy][jx].clsleny >> theCurrentTemp.entry[iy][jx].clslenx >> theCurrentTemp.entry[iy][jx].mpvvav >> theCurrentTemp.entry[iy][jx].sigmavav
+            >> theCurrentTemp.entry[iy][jx].kappavav >> theCurrentTemp.entry[iy][jx].scalexavg >> theCurrentTemp.entry[iy][jx].scaleyavg >> theCurrentTemp.entry[iy][jx].delyavg >> theCurrentTemp.entry[iy][jx].delysig >> theCurrentTemp.entry[iy][jx].spare[0];
             
             if(in_file.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 7, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; return false;}
             
-            in_file >> theCurrentTemp.entry[iy][jx].spare[10] >> theCurrentTemp.entry[iy][jx].spare[11] >> theCurrentTemp.entry[iy][jx].spare[12] >> theCurrentTemp.entry[iy][jx].spare[13]
-            >> theCurrentTemp.entry[iy][jx].spare[14] >> theCurrentTemp.entry[iy][jx].spare[15] >> theCurrentTemp.entry[iy][jx].spare[16] >> theCurrentTemp.entry[iy][jx].spare[17]
-            >> theCurrentTemp.entry[iy][jx].spare[18]  >> theCurrentTemp.entry[iy][jx].spare[19];
+            in_file >> theCurrentTemp.entry[iy][jx].scalex[0] >> theCurrentTemp.entry[iy][jx].scalex[1] >> theCurrentTemp.entry[iy][jx].scalex[2] >> theCurrentTemp.entry[iy][jx].scalex[3]
+            >> theCurrentTemp.entry[iy][jx].scaley[0] >> theCurrentTemp.entry[iy][jx].scaley[1] >> theCurrentTemp.entry[iy][jx].scaley[2] >> theCurrentTemp.entry[iy][jx].scaley[3]
+            >> theCurrentTemp.entry[iy][jx].spare[1]  >> theCurrentTemp.entry[iy][jx].spare[2];
             
             if(in_file.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 8, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; return false;}
+            
          }
          
       }
@@ -222,17 +254,17 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2
 //! external file template_summary_zpNNNN where NNNN are four digits
 //! \param dbobject - db storing multiple template calibrations
 //****************************************************************
-bool SiPixelTemplate2D::pushfile(const SiPixelTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore2D > & thePixelTemp_)
+bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore2D > & thePixelTemp_)
 {
    // Add template stored in external dbobject to theTemplateStore
    
    // Local variables
    int i, j, k, l, iy, jx;
    //	const char *tempfile;
-   const int code_version={16};
+   const int code_version={21};
    
    // We must create a new object because dbobject must be a const and our stream must not be
-   SiPixelTemplateDBObject db = dbobject;
+   SiPixel2DTemplateDBObject db = dbobject;
    
    // Create a local template storage entry
    SiPixelTemplateStore2D theCurrentTemp;
@@ -243,7 +275,7 @@ bool SiPixelTemplate2D::pushfile(const SiPixelTemplateDBObject& dbobject, std::v
       
       // Read-in a header string first and print it
       
-      SiPixelTemplateDBObject::char2float temp;
+      SiPixel2DTemplateDBObject::char2float temp;
       for (i=0; i<20; ++i) {
          temp.f = db.sVector()[db.index()];
          theCurrentTemp.head.title[4*i] = temp.c[0];
@@ -254,29 +286,67 @@ bool SiPixelTemplate2D::pushfile(const SiPixelTemplateDBObject& dbobject, std::v
       }
       theCurrentTemp.head.title[79] = '\0';
       LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
-      
+	  	  
       // next, the header information
       
       db >> theCurrentTemp.head.ID  >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >> theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx
-      >> theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale
-      >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >> theCurrentTemp.head.zsize;
+	     >> theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale
+	     >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >> theCurrentTemp.head.zsize;
       
-      if(db.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file, no template load" << ENDL; return false;}
+      if(db.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 0A, no template load" << ENDL; return false;}
       
-      LOGINFO("SiPixelTemplate2D") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version " << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield
-      << ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx<< ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
-      << ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
-      << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence << ", Q-scaling factor " << theCurrentTemp.head.qscale
-      << ", 1/2 threshold " << theCurrentTemp.head.s50 << ", y Lorentz Width " << theCurrentTemp.head.lorywidth << ", x Lorentz width " << theCurrentTemp.head.lorxwidth
-      << ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
+      LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title
+      <<" code version = "<<code_version
+      <<" object version "<<theCurrentTemp.head.templ_version
+      << ENDL;
       
-      if(theCurrentTemp.head.templ_version != code_version) {LOGERROR("SiPixelTemplate2D") << "code expects version " << code_version << ", no template load" << ENDL; return false;}
+      if(theCurrentTemp.head.templ_version > 17) {
+         db >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias >> theCurrentTemp.head.lorxbias >> theCurrentTemp.head.fbin[0] >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
+         
+         if(db.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 0B, no template load"
+            << ENDL; return false;}
+      } else {
+         theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
+         theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth/2.f;
+         theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth/2.f;
+         theCurrentTemp.head.fbin[0] = 1.50f;
+         theCurrentTemp.head.fbin[1] = 1.00f;
+         theCurrentTemp.head.fbin[2] = 0.85f;
+         //std::cout<<" set fbin  "<< theCurrentTemp.head.fbin[0]<<" "<<theCurrentTemp.head.fbin[1]<<" "
+         //	     <<theCurrentTemp.head.fbin[2]<<std::endl;
+      }
+      
+      LOGINFO("SiPixelTemplate2D")
+      << "Template ID = " << theCurrentTemp.head.ID << ", Template Version "
+      << theCurrentTemp.head.templ_version << ", Bfield = "
+      << theCurrentTemp.head.Bfield<< ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = "
+      << theCurrentTemp.head.NTyx<< ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = "
+      << theCurrentTemp.head.Dtype<< ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
+      << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence
+      << ", Q-scaling factor " << theCurrentTemp.head.qscale
+      << ", 1/2 multi dcol threshold " << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold "
+      << theCurrentTemp.head.ss50<< ", y Lorentz Width " << theCurrentTemp.head.lorywidth
+      << ", y Lorentz Bias " << theCurrentTemp.head.lorybias
+      << ", x Lorentz width " << theCurrentTemp.head.lorxwidth
+      << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
+      << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0]
+      << ", " << theCurrentTemp.head.fbin[1]
+      << ", " << theCurrentTemp.head.fbin[2]
+      << ", pixel x-size " << theCurrentTemp.head.xsize
+      << ", y-size " << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
+      
+      if(theCurrentTemp.head.templ_version < code_version) {
+         LOGINFO("SiPixelTemplate2D") << "code expects version "<< code_version << " finds "
+         << theCurrentTemp.head.templ_version <<", load anyway " << ENDL;
+      }
       
       if(theCurrentTemp.head.NTy != 0) {LOGERROR("SiPixelTemplate2D") << "Trying to load 1-d template info into the 2-d template object, check your DB/global tag!" << ENDL; return false;}
       
+#ifdef SI_PIXEL_TEMPLATE_USE_BOOST
       // next, layout the 2-d structure needed to store template
       
       theCurrentTemp.entry.resize(boost::extents[theCurrentTemp.head.NTyx][theCurrentTemp.head.NTxx]);
+#endif
       
       // Read in the file info
       
@@ -328,34 +398,33 @@ bool SiPixelTemplate2D::pushfile(const SiPixelTemplateDBObject& dbobject, std::v
                }
             }
             
-            
-            db >> theCurrentTemp.entry[iy][jx].chi2minone >> theCurrentTemp.entry[iy][jx].chi2avgone >> theCurrentTemp.entry[iy][jx].chi2min[0] >> theCurrentTemp.entry[iy][jx].chi2avg[0]
-            >> theCurrentTemp.entry[iy][jx].chi2min[1] >> theCurrentTemp.entry[iy][jx].chi2avg[1]>> theCurrentTemp.entry[iy][jx].chi2min[2] >> theCurrentTemp.entry[iy][jx].chi2avg[2]
-            >> theCurrentTemp.entry[iy][jx].chi2min[3] >> theCurrentTemp.entry[iy][jx].chi2avg[3];
+            db >> theCurrentTemp.entry[iy][jx].chi2ppix >> theCurrentTemp.entry[iy][jx].chi2scale >> theCurrentTemp.entry[iy][jx].offsetx[0] >> theCurrentTemp.entry[iy][jx].offsetx[1]
+            >> theCurrentTemp.entry[iy][jx].offsetx[2] >> theCurrentTemp.entry[iy][jx].offsetx[3]>> theCurrentTemp.entry[iy][jx].offsety[0] >> theCurrentTemp.entry[iy][jx].offsety[1]
+            >> theCurrentTemp.entry[iy][jx].offsety[2] >> theCurrentTemp.entry[iy][jx].offsety[3];
             
             if(db.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 6, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; return false;}
             
-            db >> theCurrentTemp.entry[iy][jx].spare[0] >> theCurrentTemp.entry[iy][jx].spare[1] >> theCurrentTemp.entry[iy][jx].spare[2] >> theCurrentTemp.entry[iy][jx].spare[3]
-            >> theCurrentTemp.entry[iy][jx].spare[4] >> theCurrentTemp.entry[iy][jx].spare[5] >> theCurrentTemp.entry[iy][jx].spare[6] >> theCurrentTemp.entry[iy][jx].spare[7]
-            >> theCurrentTemp.entry[iy][jx].spare[8]  >> theCurrentTemp.entry[iy][jx].spare[9];
+            db >> theCurrentTemp.entry[iy][jx].clsleny >> theCurrentTemp.entry[iy][jx].clslenx >> theCurrentTemp.entry[iy][jx].mpvvav >> theCurrentTemp.entry[iy][jx].sigmavav
+            >> theCurrentTemp.entry[iy][jx].kappavav >> theCurrentTemp.entry[iy][jx].scalexavg >> theCurrentTemp.entry[iy][jx].scaleyavg >> theCurrentTemp.entry[iy][jx].delyavg >> theCurrentTemp.entry[iy][jx].delysig >> theCurrentTemp.entry[iy][jx].spare[0];
             
             if(db.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 7, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; return false;}
             
-            db >> theCurrentTemp.entry[iy][jx].spare[10] >> theCurrentTemp.entry[iy][jx].spare[11] >> theCurrentTemp.entry[iy][jx].spare[12] >> theCurrentTemp.entry[iy][jx].spare[13]
-            >> theCurrentTemp.entry[iy][jx].spare[14] >> theCurrentTemp.entry[iy][jx].spare[15] >> theCurrentTemp.entry[iy][jx].spare[16] >> theCurrentTemp.entry[iy][jx].spare[17]
-            >> theCurrentTemp.entry[iy][jx].spare[18]  >> theCurrentTemp.entry[iy][jx].spare[19];
+            db >> theCurrentTemp.entry[iy][jx].scalex[0] >> theCurrentTemp.entry[iy][jx].scalex[1] >> theCurrentTemp.entry[iy][jx].scalex[2] >> theCurrentTemp.entry[iy][jx].scalex[3]
+            >> theCurrentTemp.entry[iy][jx].scaley[0] >> theCurrentTemp.entry[iy][jx].scaley[1] >> theCurrentTemp.entry[iy][jx].scaley[2] >> theCurrentTemp.entry[iy][jx].scaley[3]
+            >> theCurrentTemp.entry[iy][jx].spare[1]  >> theCurrentTemp.entry[iy][jx].spare[2];
             
             if(db.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 8, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; return false;}
             
+            
          }
       }
-      
+         
+// Add this template to the store
+   
+   thePixelTemp_.push_back(theCurrentTemp);    
+     
    }
    
-   
-   // Add this template to the store
-   
-   thePixelTemp_.push_back(theCurrentTemp);
    
    return true;
    
@@ -364,34 +433,30 @@ bool SiPixelTemplate2D::pushfile(const SiPixelTemplateDBObject& dbobject, std::v
 #endif
 
 
-
 // *************************************************************************************************************************************
-//! Interpolate stored 2-D information for input angles and hit position to make a 2-D template
+//! Interpolate stored 2-D information for input angles
 //! \param         id - (input) the id of the template
 //! \param   cotalpha - (input) the cotangent of the alpha track angle (see CMS IN 2004/014)
 //! \param    cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
-//! \param      locBz - (input) the sign of this quantity is used to determine whether to flip cot(beta)<0 quantities from cot(beta)>0 (FPix only)
-//!                             for FPix IP-related tracks, locBz < 0 for cot(beta) > 0 and locBz > 0 for cot(beta) < 0
-//! \param       xhit - (input) x-position of hit relative to the lower left corner of pixel[1][1] (to allow for the "padding" of the two-d clusters in the splitter)
-//! \param       yhit - (input) y-position of hit relative to the lower left corner of pixel[1][1]
-//! \param    ydouble - (input) STL vector of 21 element array to flag a double-pixel starting at cluster[1][1]
-//! \param    xdouble - (input) STL vector of 11 element array to flag a double-pixel starting at cluster[1][1]
-//! \param template2d - (output) 2d template of size matched to the cluster.  Input must be zeroed since charge is added only.
+//! \param locBz - (input) the sign of this quantity is used to determine whether to flip cot(beta)<0 quantities from cot(beta)>0 (FPix only)
+//!                    for Phase 0 FPix IP-related tracks, locBz < 0 for cot(beta) > 0 and locBz > 0 for cot(beta) < 0
+//!                    for Phase 1 FPix IP-related tracks, see next comment
+//! \param locBx - (input) the sign of this quantity is used to determine whether to flip cot(alpha/beta)<0 quantities from cot(alpha/beta)>0 (FPix only)
+//!                    for Phase 1 FPix IP-related tracks, locBx/locBz > 0 for cot(alpha) > 0 and locBx/locBz < 0 for cot(alpha) < 0
+//!                    for Phase 1 FPix IP-related tracks, locBx > 0 for cot(beta) > 0 and locBx < 0 for cot(beta) < 0
 // *************************************************************************************************************************************
 
-bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float locBz, float xhit, float yhit, std::vector<bool>& ydouble, std::vector<bool>& xdouble, float template2d[BXM2][BYM2])
+bool SiPixelTemplate2D::interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx)
 {
+   
+   
    // Interpolate for a new set of track angles
    
    // Local variables
-   int i, j;
-   int pixx, pixy, k0, k1, l0, l1, imidx, deltax, deltay, iflipy, imin, imax, jmin, jmax;
-   int m, n;
-   float acotb, dcota, dcotb, dx, dy, ddx, ddy, adx, ady, tmpxy;
-   bool flip_y;
-   //	std::vector <float> xrms(4), xgsig(4), xrmsc2m(4), xgsigc2m(4);
-   std::vector <float> chi2xavg(4), chi2xmin(4);
-   
+   int i, j, imidx;
+   //   int pixx, pixy, k0, k1, l0, l1, deltax, deltay, iflipy, jflipx, imin, imax, jmin, jmax;
+   //   int m, n;
+   float acotb, dcota, dcotb;
    
    // Check to see if interpolation is valid
    
@@ -422,6 +487,10 @@ bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float locB
                // Copy the pseudopixel signal size to the private variable
                
                s50_ = thePixelTemp_[index_id_].head.s50;
+               
+               // Copy Qbinning info to private variables
+               
+               for(j=0; j<3; ++j) {fbin_[j] = thePixelTemp_[index_id_].head.fbin[j];}
                
                // Copy the Lorentz widths to private variables
                
@@ -512,67 +581,302 @@ bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float locB
    
    // This works only for IP-related tracks
    
-   flip_y = false;
-   if(cotbeta < 0.f) {flip_y = true;}
-   
-   // If Fpix-related track has wrong cotbeta-field correlation, return false to trigger simple template instead
-   
-   if(Dtype_ == 1) {
-      if(cotbeta*locBz > 0.f) success_ = false;
+   flip_x_ = false;
+   flip_y_ = false;
+   switch(Dtype_) {
+      case 0:
+         if(cotbeta < 0.f) {flip_y_ = true;}
+         break;
+      case 1:
+         if(locBz > 0.f) {
+            flip_y_ = true;
+         }
+         break;
+      case 2:
+      case 3:
+      case 4:
+      case 5:
+         if(locBx*locBz < 0.f) {
+            flip_x_ = true;
+         }
+         if(locBx < 0.f) {
+            flip_y_ = true;
+         }
+         break;
+      default:
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+         throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
+#else
+         std::cout << "SiPixelTemplate:2D:illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
+#endif
    }
+   
+   //  Calculate signed quantities
+   
+   lorydrift_ = lorywidth_/2.;
+   if(flip_y_) lorydrift_ = -lorydrift_;
+   lorxdrift_ = lorxwidth_/2.;
+   if(flip_x_) lorxdrift_ = -lorxdrift_;
+   
+   // Use pointers to the three angle pairs used in the interpolation
+   
+   
+   entry00_ = &thePixelTemp_[index_id_].entry[iy0_][jx0_];
+   entry10_ = &thePixelTemp_[index_id_].entry[iy1_][jx0_];
+   entry01_ = &thePixelTemp_[index_id_].entry[iy0_][jx1_];
    
    // Interpolate things in cot(alpha)-cot(beta)
    
-   qavg_ = thePixelTemp_[index_id_].entry[iy0_][jx0_].qavg
-   +adcota_*(thePixelTemp_[index_id_].entry[iy0_][jx1_].qavg - thePixelTemp_[index_id_].entry[iy0_][jx0_].qavg)
-   +adcotb_*(thePixelTemp_[index_id_].entry[iy1_][jx0_].qavg - thePixelTemp_[index_id_].entry[iy0_][jx0_].qavg);
+   qavg_ = entry00_->qavg
+   +adcota_*(entry01_->qavg - entry00_->qavg)
+   +adcotb_*(entry10_->qavg - entry00_->qavg);
    
-   pixmax_ = thePixelTemp_[index_id_].entry[iy0_][jx0_].pixmax
-   +adcota_*(thePixelTemp_[index_id_].entry[iy0_][jx1_].pixmax - thePixelTemp_[index_id_].entry[iy0_][jx0_].pixmax)
-   +adcotb_*(thePixelTemp_[index_id_].entry[iy1_][jx0_].pixmax - thePixelTemp_[index_id_].entry[iy0_][jx0_].pixmax);
+   pixmax_ = entry00_->pixmax
+   +adcota_*(entry01_->pixmax - entry00_->pixmax)
+   +adcotb_*(entry10_->pixmax - entry00_->pixmax);
    
-   sxymax_ = thePixelTemp_[index_id_].entry[iy0_][jx0_].sxymax
-   +adcota_*(thePixelTemp_[index_id_].entry[iy0_][jx1_].sxymax - thePixelTemp_[index_id_].entry[iy0_][jx0_].sxymax)
-   +adcotb_*(thePixelTemp_[index_id_].entry[iy1_][jx0_].sxymax - thePixelTemp_[index_id_].entry[iy0_][jx0_].sxymax);
+   sxymax_ = entry00_->sxymax
+   +adcota_*(entry01_->sxymax - entry00_->sxymax)
+   +adcotb_*(entry10_->sxymax - entry00_->sxymax);
    
-   chi2avgone_ = thePixelTemp_[index_id_].entry[iy0_][jx0_].chi2avgone
-   +adcota_*(thePixelTemp_[index_id_].entry[iy0_][jx1_].chi2avgone - thePixelTemp_[index_id_].entry[iy0_][jx0_].chi2avgone)
-   +adcotb_*(thePixelTemp_[index_id_].entry[iy1_][jx0_].chi2avgone - thePixelTemp_[index_id_].entry[iy0_][jx0_].chi2avgone);
+   chi2avgone_ = entry00_->chi2avgone
+   +adcota_*(entry01_->chi2avgone - entry00_->chi2avgone)
+   +adcotb_*(entry10_->chi2avgone - entry00_->chi2avgone);
    
-   chi2minone_ = thePixelTemp_[index_id_].entry[iy0_][jx0_].chi2minone
-   +adcota_*(thePixelTemp_[index_id_].entry[iy0_][jx1_].chi2minone - thePixelTemp_[index_id_].entry[iy0_][jx0_].chi2minone)
-   +adcotb_*(thePixelTemp_[index_id_].entry[iy1_][jx0_].chi2minone - thePixelTemp_[index_id_].entry[iy0_][jx0_].chi2minone);
+   chi2minone_ = entry00_->chi2minone
+   +adcota_*(entry01_->chi2minone - entry00_->chi2minone)
+   +adcotb_*(entry10_->chi2minone - entry00_->chi2minone);
+   
+   clsleny_ = entry00_->clsleny
+   +adcota_*(entry01_->clsleny - entry00_->clsleny)
+   +adcotb_*(entry10_->clsleny - entry00_->clsleny);
+   
+   clslenx_ = entry00_->clslenx
+   +adcota_*(entry01_->clslenx - entry00_->clslenx)
+   +adcotb_*(entry10_->clslenx - entry00_->clslenx);
+   
+   
+   chi2ppix_ = entry00_->chi2ppix
+   +adcota_*(entry01_->chi2ppix - entry00_->chi2ppix)
+   +adcotb_*(entry10_->chi2ppix - entry00_->chi2ppix);
+   
+   chi2scale_ = entry00_->chi2scale
+   +adcota_*(entry01_->chi2scale - entry00_->chi2scale)
+   +adcotb_*(entry10_->chi2scale - entry00_->chi2scale);
+   
+   scaleyavg_ = entry00_->scaleyavg
+   +adcota_*(entry01_->scaleyavg - entry00_->scaleyavg)
+   +adcotb_*(entry10_->scaleyavg - entry00_->scaleyavg);
+   
+   scalexavg_ = entry00_->scalexavg
+   +adcota_*(entry01_->scalexavg - entry00_->scalexavg)
+   +adcotb_*(entry10_->scalexavg - entry00_->scalexavg);
+   
+   delyavg_ = entry00_->delyavg
+   +adcota_*(entry01_->delyavg - entry00_->delyavg)
+   +adcotb_*(entry10_->delyavg - entry00_->delyavg);
+   
+   delysig_ = entry00_->delysig
+   +adcota_*(entry01_->delysig - entry00_->delysig)
+   +adcotb_*(entry10_->delysig - entry00_->delysig);
+   
+   mpvvav_ = entry00_->mpvvav
+   +adcota_*(entry01_->mpvvav - entry00_->mpvvav)
+   +adcotb_*(entry10_->mpvvav - entry00_->mpvvav);
+   
+   sigmavav_ = entry00_->sigmavav
+   +adcota_*(entry01_->sigmavav - entry00_->sigmavav)
+   +adcotb_*(entry10_->sigmavav - entry00_->sigmavav);
+   
+   kappavav_ = entry00_->kappavav
+   +adcota_*(entry01_->kappavav - entry00_->kappavav)
+   +adcotb_*(entry10_->kappavav - entry00_->kappavav);
    
    for(i=0; i<4 ; ++i) {
-      chi2avg_[i] = thePixelTemp_[index_id_].entry[iy0_][jx0_].chi2avg[i]
-      +adcota_*(thePixelTemp_[index_id_].entry[iy0_][jx1_].chi2avg[i] - thePixelTemp_[index_id_].entry[iy0_][jx0_].chi2avg[i])
-      +adcotb_*(thePixelTemp_[index_id_].entry[iy1_][jx0_].chi2avg[i] - thePixelTemp_[index_id_].entry[iy0_][jx0_].chi2avg[i]);
+      scalex_[i] = entry00_->scalex[i]
+      +adcota_*(entry01_->scalex[i] - entry00_->scalex[i])
+      +adcotb_*(entry10_->scalex[i] - entry00_->scalex[i]);
       
-      chi2min_[i] = thePixelTemp_[index_id_].entry[iy0_][jx0_].chi2min[i]
-      +adcota_*(thePixelTemp_[index_id_].entry[iy0_][jx1_].chi2min[i] - thePixelTemp_[index_id_].entry[iy0_][jx0_].chi2min[i])
-      +adcotb_*(thePixelTemp_[index_id_].entry[iy1_][jx0_].chi2min[i] - thePixelTemp_[index_id_].entry[iy0_][jx0_].chi2min[i]);
+      scaley_[i] = entry00_->scaley[i]
+      +adcota_*(entry01_->scaley[i] - entry00_->scaley[i])
+      +adcotb_*(entry10_->scaley[i] - entry00_->scaley[i]);
+      
+      offsetx_[i] = entry00_->offsetx[i]
+      +adcota_*(entry01_->offsetx[i] - entry00_->offsetx[i])
+      +adcotb_*(entry10_->offsetx[i] - entry00_->offsetx[i]);
+      if(flip_x_) offsetx_[i] = -offsetx_[i];
+      
+      offsety_[i] = entry00_->offsety[i]
+      +adcota_*(entry01_->offsety[i] - entry00_->offsety[i])
+      +adcotb_*(entry10_->offsety[i] - entry00_->offsety[i]);
+      if(flip_y_) offsety_[i] = -offsety_[i];
    }
    
    for(i=0; i<2 ; ++i) {
       for(j=0; j<5 ; ++j) {
          // Charge loss switches sides when cot(beta) changes sign
-         if(flip_y) {
-            xypary0x0_[1-i][j] = thePixelTemp_[index_id_].entry[iy0_][jx0_].xypar[i][j];
-            xypary1x0_[1-i][j] = thePixelTemp_[index_id_].entry[iy1_][jx0_].xypar[i][j];
-            xypary0x1_[1-i][j] = thePixelTemp_[index_id_].entry[iy0_][jx1_].xypar[i][j];
-            lanpar_[1-i][j] = thePixelTemp_[index_id_].entry[iy0_][jx0_].lanpar[i][j]
-            +adcota_*(thePixelTemp_[index_id_].entry[iy0_][jx1_].lanpar[i][j] - thePixelTemp_[index_id_].entry[iy0_][jx0_].lanpar[i][j])
-            +adcotb_*(thePixelTemp_[index_id_].entry[iy1_][jx0_].lanpar[i][j] - thePixelTemp_[index_id_].entry[iy0_][jx0_].lanpar[i][j]);
+         if(flip_y_) {
+            xypary0x0_[1-i][j] = entry00_->xypar[i][j];
+            xypary1x0_[1-i][j] = entry10_->xypar[i][j];
+            xypary0x1_[1-i][j] = entry01_->xypar[i][j];
+            lanpar_[1-i][j] = entry00_->lanpar[i][j]
+            +adcota_*(entry01_->lanpar[i][j] - entry00_->lanpar[i][j])
+            +adcotb_*(entry10_->lanpar[i][j] - entry00_->lanpar[i][j]);
          } else {
-            xypary0x0_[i][j] = thePixelTemp_[index_id_].entry[iy0_][jx0_].xypar[i][j];
-            xypary1x0_[i][j] = thePixelTemp_[index_id_].entry[iy1_][jx0_].xypar[i][j];
-            xypary0x1_[i][j] = thePixelTemp_[index_id_].entry[iy0_][jx1_].xypar[i][j];
-            lanpar_[i][j] = thePixelTemp_[index_id_].entry[iy0_][jx0_].lanpar[i][j]
-            +adcota_*(thePixelTemp_[index_id_].entry[iy0_][jx1_].lanpar[i][j] - thePixelTemp_[index_id_].entry[iy0_][jx0_].lanpar[i][j])
-            +adcotb_*(thePixelTemp_[index_id_].entry[iy1_][jx0_].lanpar[i][j] - thePixelTemp_[index_id_].entry[iy0_][jx0_].lanpar[i][j]);
+            xypary0x0_[i][j] = entry00_->xypar[i][j];
+            xypary1x0_[i][j] = entry10_->xypar[i][j];
+            xypary0x1_[i][j] = entry01_->xypar[i][j];
+            lanpar_[i][j] = entry00_->lanpar[i][j]
+            +adcota_*(entry01_->lanpar[i][j] - entry00_->lanpar[i][j])
+            +adcotb_*(entry10_->lanpar[i][j] - entry00_->lanpar[i][j]);
          }
       }
    }
+   
+   return success_;
+} // interpolate
+
+
+// *************************************************************************************************************************************
+//! Load template info for single angle point to invoke template reco for template generation
+//! \param      entry - (input) pointer to template entry
+//! \param      sizex - (input) pixel x-size
+//! \param      sizey - (input) pixel y-size
+//! \param      sizez - (input) pixel z-size
+// *************************************************************************************************************************************
+
+void SiPixelTemplate2D::sideload(SiPixelTemplateEntry2D* entry, int iDtype, float locBx, float locBz, float lorwdy, float lorwdx, float q50, float fbin[3], float xsize, float ysize, float zsize)
+{
+   
+   // Set class variables to the input parameters
+   
+   entry00_ = entry;
+   entry01_ = entry;
+   entry10_ = entry;
+   Dtype_ = iDtype;
+   lorywidth_ = lorwdy;
+   lorxwidth_ = lorwdx;
+   xsize_ = xsize;
+   ysize_ = ysize;
+   zsize_ = zsize;
+   s50_ = q50;
+   qscale_ = 1.f;
+   for(int i=0; i<3; ++i) {fbin_[i] = fbin[i];}
+   
+   // Set other class variables
+   
+   adcota_ = 0.f;
+   adcotb_ = 0.f;
+   
+   // Interpolate things in cot(alpha)-cot(beta)
+   
+   qavg_ = entry00_->qavg;
+   
+   pixmax_ = entry00_->pixmax;
+   
+   sxymax_ = entry00_->sxymax;
+   
+   clsleny_ = entry00_->clsleny;
+   
+   clslenx_ = entry00_->clslenx;
+   
+   scaleyavg_ = 1.f;
+   
+   scalexavg_ = 1.f;
+   
+   delyavg_ = 0.f;
+   
+   delysig_ = 0.f;
+   
+   for(int i=0; i<4 ; ++i) {
+      scalex_[i] = 1.f;
+      scaley_[i] = 1.f;
+      offsetx_[i] = 0.f;
+      offsety_[i] = 0.f;
+   }
+   
+   // This works only for IP-related tracks
+   
+   flip_x_ = false;
+   flip_y_ = false;
+   float cotbeta = entry00_->cotbeta;
+   switch(Dtype_) {
+      case 0:
+         if(cotbeta < 0.f) {flip_y_ = true;}
+         break;
+      case 1:
+         if(locBz > 0.f) {
+            flip_y_ = true;
+         }
+         break;
+      case 2:
+      case 3:
+      case 4:
+      case 5:
+         if(locBx*locBz < 0.f) {
+            flip_x_ = true;
+         }
+         if(locBx < 0.f) {
+            flip_y_ = true;
+         }
+         break;
+      default:
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+         throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::illegal subdetector ID = " << iDtype << std::endl;
+#else
+         std::cout << "SiPixelTemplate:2D:illegal subdetector ID = " << iDtype << std::endl;
+#endif
+   }
+   
+   //  Calculate signed quantities
+   
+   lorydrift_ = lorywidth_/2.;
+   if(flip_y_) lorydrift_ = -lorydrift_;
+   lorxdrift_ = lorxwidth_/2.;
+   if(flip_x_) lorxdrift_ = -lorxdrift_;
+   
+   for(int i=0; i<2 ; ++i) {
+      for(int j=0; j<5 ; ++j) {
+         // Charge loss switches sides when cot(beta) changes sign
+         if(flip_y_) {
+            xypary0x0_[1-i][j] = entry00_->xypar[i][j];
+            xypary1x0_[1-i][j] = entry00_->xypar[i][j];
+            xypary0x1_[1-i][j] = entry00_->xypar[i][j];
+            lanpar_[1-i][j] = entry00_->lanpar[i][j];
+         } else {
+            xypary0x0_[i][j] = entry00_->xypar[i][j];
+            xypary1x0_[i][j] = entry00_->xypar[i][j];
+            xypary0x1_[i][j] = entry00_->xypar[i][j];
+            lanpar_[i][j] = entry00_->lanpar[i][j];
+         }
+      }
+   }
+   return;
+}
+
+
+// *************************************************************************************************************************************
+//! \param       xhit - (input) x-position of hit relative to the lower left corner of pixel[1][1] (to allow for the "padding" of the two-d clusters in the splitter)
+//! \param       yhit - (input) y-position of hit relative to the lower left corner of pixel[1][1]
+//! \param    ydouble - (input) STL vector of 21 element array to flag a double-pixel starting at cluster[1][1]
+//! \param    xdouble - (input) STL vector of 11 element array to flag a double-pixel starting at cluster[1][1]
+//! \param template2d - (output) 2d template of size matched to the cluster.  Input must be zeroed since charge is added only.
+// *************************************************************************************************************************************
+
+bool SiPixelTemplate2D::xytemp(float xhit, float yhit, bool ydouble[BYM2], bool xdouble[BXM2], float template2d[BXM2][BYM2], bool derivatives, float dpdx2d[2][BXM2][BYM2], float& QTemplate)
+{
+   // Interpolate for a new set of track angles
+   
+   // Local variables
+   int i, j, k;
+   int pixx, pixy, k0, k1, l0, l1, deltax, deltay, iflipy, jflipx, imin, imax, jmin, jmax;
+   int m, n;
+   float dx, dy, ddx, ddy, adx, ady, tmpxy;
+//   const float deltaxy[2] = {8.33f, 12.5f};
+   const float deltaxy[2] = {16.67f, 25.0f};
+   
+   // Check to see if interpolation is valid
+   
    
    // next, determine the indices of the closest point in k (y-displacement), l (x-displacement)
    // pixy and pixx are the indices of the struck pixel in the (Ty,Tx) system
@@ -581,7 +885,7 @@ bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float locB
    
    pixy = (int)floorf(yhit/ysize_);
    dy = yhit-(pixy+0.5f)*ysize_;
-   if(flip_y) {dy = -dy;}
+   if(flip_y_) {dy = -dy;}
    k0 = (int)(dy/ysize_*6.f+3.5f);
    if(k0 < 0) k0 = 0;
    if(k0 > 6) k0 = 6;
@@ -590,6 +894,7 @@ bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float locB
    if(ddy > 0.f) {k1 = k0 + 1; if(k1 > 6) k1 = k0-1;} else {k1 = k0 - 1; if(k1 < 0) k1 = k0+1;}
    pixx = (int)floorf(xhit/xsize_);
    dx = xhit-(pixx+0.5f)*xsize_;
+   if(flip_x_) {dx = -dx;}
    l0 = (int)(dx/xsize_*6.f+3.5f);
    if(l0 < 0) l0 = 0;
    if(l0 > 6) l0 = 6;
@@ -601,17 +906,17 @@ bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float locB
    
    // First find the limits of the indices for non-zero pixels
    
-   imin = std::min(thePixelTemp_[index_id_].entry[iy0_][jx0_].iymin,thePixelTemp_[index_id_].entry[iy1_][jx0_].iymin);
-   imin = std::min(imin,thePixelTemp_[index_id_].entry[iy0_][jx1_].iymin);
+   imin = std::min(entry00_->iymin,entry10_->iymin);
+   imin_ = std::min(imin,entry01_->iymin);
    
-   jmin = std::min(thePixelTemp_[index_id_].entry[iy0_][jx0_].jxmin,thePixelTemp_[index_id_].entry[iy1_][jx0_].jxmin);
-   jmin = std::min(jmin,thePixelTemp_[index_id_].entry[iy0_][jx1_].jxmin);
+   jmin = std::min(entry00_->jxmin,entry10_->jxmin);
+   jmin_ = std::min(jmin,entry01_->jxmin);
    
-   imax = std::max(thePixelTemp_[index_id_].entry[iy0_][jx0_].iymax,thePixelTemp_[index_id_].entry[iy1_][jx0_].iymax);
-   imax = std::max(imax,thePixelTemp_[index_id_].entry[iy0_][jx1_].iymax);
+   imax = std::max(entry00_->iymax,entry10_->iymax);
+   imax_ = std::max(imax,entry01_->iymax);
    
-   jmax = std::max(thePixelTemp_[index_id_].entry[iy0_][jx0_].jxmax,thePixelTemp_[index_id_].entry[iy1_][jx0_].jxmax);
-   jmax = std::max(jmax,thePixelTemp_[index_id_].entry[iy0_][jx1_].jxmax);
+   jmax = std::max(entry00_->jxmax,entry10_->jxmax);
+   jmax_ = std::max(jmax,entry01_->jxmax);
    
    // Calculate the x and y offsets to make the new template
    
@@ -630,20 +935,22 @@ bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float locB
    
    // Loop over the non-zero part of the template index space and interpolate
    
-   for(j=jmin; j<=jmax; ++j) {
-      for(i=imin; i<=imax; ++i) {
-         m = deltax+j;
-         
-         // If cot(beta) < 0, we must flip the cluster, iflipy is the flipped y-index
-         
-         if(flip_y) {iflipy=T2YSIZE-1-i; n = deltay+iflipy;} else {n = deltay+i;}
+   for(j=jmin_; j<=jmax_; ++j) {
+      // Flip indices as needed
+      if(flip_x_) {jflipx=T2XSIZE-1-j; m = deltax+jflipx;} else {m = deltax+j;}
+      for(i=imin_; i<=imax_; ++i) {
+         if(flip_y_) {iflipy=T2YSIZE-1-i; n = deltay+iflipy;} else {n = deltay+i;}
          if(m>=0 && m<=BXM3 && n>=0 && n<=BYM3) {
-            tmpxy = thePixelTemp_[index_id_].entry[iy0_][jx0_].xytemp[k0][l0][i][j]
-            + adx*(thePixelTemp_[index_id_].entry[iy0_][jx0_].xytemp[k0][l1][i][j] - thePixelTemp_[index_id_].entry[iy0_][jx0_].xytemp[k0][l0][i][j])
-            + ady*(thePixelTemp_[index_id_].entry[iy0_][jx0_].xytemp[k1][l0][i][j] - thePixelTemp_[index_id_].entry[iy0_][jx0_].xytemp[k0][l0][i][j])
-            + adcota_*(thePixelTemp_[index_id_].entry[iy0_][jx1_].xytemp[k0][l0][i][j] - thePixelTemp_[index_id_].entry[iy0_][jx0_].xytemp[k0][l0][i][j])
-            + adcotb_*(thePixelTemp_[index_id_].entry[iy1_][jx0_].xytemp[k0][l0][i][j] - thePixelTemp_[index_id_].entry[iy0_][jx0_].xytemp[k0][l0][i][j]);
-            if(tmpxy > 0.f) {xytemp_[m][n] = tmpxy;} else {xytemp_[m][n] = 0.f;}
+            tmpxy = entry00_->xytemp[k0][l0][i][j]
+            + adx*(entry00_->xytemp[k0][l1][i][j] - entry00_->xytemp[k0][l0][i][j])
+            + ady*(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
+            + adcota_*(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
+            + adcotb_*(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
+            if(tmpxy > 0.f) {
+               xytemp_[m][n] = tmpxy;
+            } else {
+               xytemp_[m][n] = 0.f;
+            }
          }
       }
    }
@@ -684,13 +991,384 @@ bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float locB
    
    //  Finally, loop through and increment the external template
    
+   float qtemptot = 0.f;
+   
    for(n=1; n<BYM3; ++n) {
       for(m=1; m<BXM3; ++m) {
-         if(xytemp_[m][n] > 0.f) {template2d[m][n] += xytemp_[m][n];}
+         if(xytemp_[m][n] > 0.f) {template2d[m][n] += xytemp_[m][n]; qtemptot += xytemp_[m][n];}
+      }
+   }
+   
+   QTemplate = qtemptot;
+   
+   if(derivatives) {
+      
+      float dxytempdx[2][BXM2][BYM2], dxytempdy[2][BXM2][BYM2];
+      
+      // First do shifted +x template
+      
+      pixx = (int)floorf((xhit+deltaxy[0])/xsize_);
+      dx = (xhit+deltaxy[0])-(pixx+0.5f)*xsize_;
+      if(flip_x_) {dx = -dx;}
+      l0 = (int)(dx/xsize_*6.f+3.5f);
+      if(l0 < 0) l0 = 0;
+      if(l0 > 6) l0 = 6;
+      ddx = 6.f*dx/xsize_ - (l0-3);
+      adx = fabs(ddx);
+      if(ddx > 0.f) {l1 = l0 + 1; if(l1 > 6) l1 = l0-1;} else {l1 = l0 - 1; if(l1 < 0) l1 = l0+1;}
+      
+      // OK, lets do the template interpolation.
+      
+      // Calculate the x and y offsets to make the new template
+      
+      // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
+      
+      ++pixx;
+      
+      // In the template store, the struck pixel is always (THy,THx)
+      
+      deltax = pixx - T2HX;
+      
+      //  First zero the local 2-d template
+      
+      for(k=0; k<2; ++k) {for(j=0; j<BXM2; ++j) {for(i=0; i<BYM2; ++i) {dxytempdx[k][j][i] = 0.f;}}}
+      
+      // Loop over the non-zero part of the template index space and interpolate
+      
+      for(j=jmin_; j<=jmax_; ++j) {
+         // Flip indices as needed
+         if(flip_x_) {jflipx=T2XSIZE-1-j; m = deltax+jflipx;} else {m = deltax+j;}
+         for(i=imin_; i<=imax_; ++i) {
+            if(flip_y_) {iflipy=T2YSIZE-1-i; n = deltay+iflipy;} else {n = deltay+i;}
+            if(m>=0 && m<=BXM3 && n>=0 && n<=BYM3) {
+               tmpxy = entry00_->xytemp[k0][l0][i][j]
+               + adx*(entry00_->xytemp[k0][l1][i][j] -   entry00_->xytemp[k0][l0][i][j])
+               + ady*(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
+               + adcota_*(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
+               + adcotb_*(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
+               if(tmpxy > 0.f) {dxytempdx[1][m][n] = tmpxy;} else {dxytempdx[1][m][n] = 0.f;}
+            }
+         }
+      }
+      
+      //combine rows and columns to simulate double pixels
+      
+      for(n=1; n<BYM3; ++n) {
+         if(ydouble[n-1]) {
+            //  Combine the y-columns
+            for(m=1; m<BXM3; ++m) {
+               dxytempdx[1][m][n] += dxytempdx[1][m][n+1];
+            }
+            //  Now shift the remaining pixels over by one column
+            for(i=n+1; i<BYM3; ++i) {
+               for(m=1; m<BXM3; ++m) {
+                  dxytempdx[1][m][i] = dxytempdx[1][m][i+1];
+               }
+            }
+         }
+      }
+      
+      //combine rows and columns to simulate double pixels
+      
+      for(m=1; m<BXM3; ++m) {
+         if(xdouble[m-1]) {
+            //  Combine the x-rows
+            for(n=1; n<BYM3; ++n) {
+               dxytempdx[1][m][n] += dxytempdx[1][m+1][n];
+            }
+            //  Now shift the remaining pixels over by one row
+            for(j=m+1; j<BXM3; ++j) {
+               for(n=1; n<BYM3; ++n) {
+                  dxytempdx[1][j][n] = dxytempdx[1][j+1][n];
+               }
+            }
+         }
+      }
+      
+      // Next do shifted -x template
+      
+      pixx = (int)floorf((xhit-deltaxy[0])/xsize_);
+      dx = (xhit-deltaxy[0])-(pixx+0.5f)*xsize_;
+      if(flip_x_) {dx = -dx;}
+      l0 = (int)(dx/xsize_*6.f+3.5f);
+      if(l0 < 0) l0 = 0;
+      if(l0 > 6) l0 = 6;
+      ddx = 6.f*dx/xsize_ - (l0-3);
+      adx = fabs(ddx);
+      if(ddx > 0.f) {l1 = l0 + 1; if(l1 > 6) l1 = l0-1;} else {l1 = l0 - 1; if(l1 < 0) l1 = l0+1;}
+      
+      // OK, lets do the template interpolation.
+      
+      // Calculate the x and y offsets to make the new template
+      
+      // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
+      
+      ++pixx;
+      
+      // In the template store, the struck pixel is always (THy,THx)
+      
+      deltax = pixx - T2HX;
+      
+      // Loop over the non-zero part of the template index space and interpolate
+      
+      for(j=jmin_; j<=jmax_; ++j) {
+         // Flip indices as needed
+         if(flip_x_) {jflipx=T2XSIZE-1-j; m = deltax+jflipx;} else {m = deltax+j;}
+         for(i=imin_; i<=imax_; ++i) {
+            if(flip_y_) {iflipy=T2YSIZE-1-i; n = deltay+iflipy;} else {n = deltay+i;}
+            if(m>=0 && m<=BXM3 && n>=0 && n<=BYM3) {
+               tmpxy = entry00_->xytemp[k0][l0][i][j]
+               + adx*(entry00_->xytemp[k0][l1][i][j] -   entry00_->xytemp[k0][l0][i][j])
+               + ady*(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
+               + adcota_*(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
+               + adcotb_*(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
+               if(tmpxy > 0.f) {dxytempdx[0][m][n] = tmpxy;} else {dxytempdx[0][m][n] = 0.f;}
+            }
+         }
+      }
+      
+      //combine rows and columns to simulate double pixels
+      
+      for(n=1; n<BYM3; ++n) {
+         if(ydouble[n-1]) {
+            //  Combine the y-columns
+            for(m=1; m<BXM3; ++m) {
+               dxytempdx[0][m][n] += dxytempdx[0][m][n+1];
+            }
+            //  Now shift the remaining pixels over by one column
+            for(i=n+1; i<BYM3; ++i) {
+               for(m=1; m<BXM3; ++m) {
+                  dxytempdx[0][m][i] = dxytempdx[0][m][i+1];
+               }
+            }
+         }
+      }
+      
+      //combine rows and columns to simulate double pixels
+      
+      for(m=1; m<BXM3; ++m) {
+         if(xdouble[m-1]) {
+            //  Combine the x-rows
+            for(n=1; n<BYM3; ++n) {
+               dxytempdx[0][m][n] += dxytempdx[0][m+1][n];
+            }
+            //  Now shift the remaining pixels over by one row
+            for(j=m+1; j<BXM3; ++j) {
+               for(n=1; n<BYM3; ++n) {
+                  dxytempdx[0][j][n] = dxytempdx[0][j+1][n];
+               }
+            }
+         }
+      }
+      
+      
+      //  Finally, normalize the derivatives and copy the results to the output array
+      
+      for(n=1; n<BYM3; ++n) {
+         for(m=1; m<BXM3; ++m) {
+            dpdx2d[0][m][n] = (dxytempdx[1][m][n] - dxytempdx[0][m][n])/(2.*deltaxy[0]);
+         }
+      }
+      
+      // Next, do shifted y template
+      
+      pixy = (int)floorf((yhit+deltaxy[1])/ysize_);
+      dy = (yhit+deltaxy[1])-(pixy+0.5f)*ysize_;
+      if(flip_y_) {dy = -dy;}
+      k0 = (int)(dy/ysize_*6.f+3.5f);
+      if(k0 < 0) k0 = 0;
+      if(k0 > 6) k0 = 6;
+      ddy = 6.f*dy/ysize_ - (k0-3);
+      ady = fabs(ddy);
+      if(ddy > 0.f) {k1 = k0 + 1; if(k1 > 6) k1 = k0-1;} else {k1 = k0 - 1; if(k1 < 0) k1 = k0+1;}
+      pixx = (int)floorf(xhit/xsize_);
+      dx = xhit-(pixx+0.5f)*xsize_;
+      if(flip_x_) {dx = -dx;}
+      l0 = (int)(dx/xsize_*6.f+3.5f);
+      if(l0 < 0) l0 = 0;
+      if(l0 > 6) l0 = 6;
+      ddx = 6.f*dx/xsize_ - (l0-3);
+      adx = fabs(ddx);
+      if(ddx > 0.f) {l1 = l0 + 1; if(l1 > 6) l1 = l0-1;} else {l1 = l0 - 1; if(l1 < 0) l1 = l0+1;}
+      
+      // OK, lets do the template interpolation.
+      
+      // Calculate the x and y offsets to make the new template
+      
+      // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
+      
+      ++pixy; ++pixx;
+      
+      // In the template store, the struck pixel is always (THy,THx)
+      
+      deltax = pixx - T2HX;
+      deltay = pixy - T2HY;
+      
+      //  First zero the local 2-d template
+      
+      for(k=0; k<2; ++k) {for(j=0; j<BXM2; ++j) {for(i=0; i<BYM2; ++i) {dxytempdy[k][j][i] = 0.f;}}}
+      
+      // Loop over the non-zero part of the template index space and interpolate
+      
+      for(j=jmin_; j<=jmax_; ++j) {
+         // Flip indices as needed
+         if(flip_x_) {jflipx=T2XSIZE-1-j; m = deltax+jflipx;} else {m = deltax+j;}
+         for(i=imin_; i<=imax_; ++i) {
+            if(flip_y_) {iflipy=T2YSIZE-1-i; n = deltay+iflipy;} else {n = deltay+i;}
+            if(m>=0 && m<=BXM3 && n>=0 && n<=BYM3) {
+               tmpxy = entry00_->xytemp[k0][l0][i][j]
+               + adx*(entry00_->xytemp[k0][l1][i][j] - entry00_->xytemp[k0][l0][i][j])
+               + ady*(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
+               + adcota_*(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
+               + adcotb_*(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
+               if(tmpxy > 0.f) {dxytempdy[1][m][n] = tmpxy;} else {dxytempdy[1][m][n] = 0.f;}
+            }
+         }
+      }
+      
+      //combine rows and columns to simulate double pixels
+      
+      for(n=1; n<BYM3; ++n) {
+         if(ydouble[n-1]) {
+            //  Combine the y-columns
+            for(m=1; m<BXM3; ++m) {
+               dxytempdy[1][m][n] += dxytempdy[1][m][n+1];
+            }
+            //  Now shift the remaining pixels over by one column
+            for(i=n+1; i<BYM3; ++i) {
+               for(m=1; m<BXM3; ++m) {
+                  dxytempdy[1][m][i] = dxytempdy[1][m][i+1];
+               }
+            }
+         }
+      }
+      
+      //combine rows and columns to simulate double pixels
+      
+      for(m=1; m<BXM3; ++m) {
+         if(xdouble[m-1]) {
+            //  Combine the x-rows
+            for(n=1; n<BYM3; ++n) {
+               dxytempdy[1][m][n] += dxytempdy[1][m+1][n];
+            }
+            //  Now shift the remaining pixels over by one row
+            for(j=m+1; j<BXM3; ++j) {
+               for(n=1; n<BYM3; ++n) {
+                  dxytempdy[1][j][n] = dxytempdy[1][j+1][n];
+               }
+            }
+         }
+      }
+      
+      // Next, do shifted -y template
+      
+      pixy = (int)floorf((yhit-deltaxy[1])/ysize_);
+      dy = (yhit-deltaxy[1])-(pixy+0.5f)*ysize_;
+      if(flip_y_) {dy = -dy;}
+      k0 = (int)(dy/ysize_*6.f+3.5f);
+      if(k0 < 0) k0 = 0;
+      if(k0 > 6) k0 = 6;
+      ddy = 6.f*dy/ysize_ - (k0-3);
+      ady = fabs(ddy);
+      if(ddy > 0.f) {k1 = k0 + 1; if(k1 > 6) k1 = k0-1;} else {k1 = k0 - 1; if(k1 < 0) k1 = k0+1;}
+      
+      // OK, lets do the template interpolation.
+      
+      // Calculate the x and y offsets to make the new template
+      
+      // First, shift the struck pixel coordinates to the (Ty+2, Tx+2) system
+      
+      ++pixy;
+      
+      // In the template store, the struck pixel is always (THy,THx)
+      
+      deltay = pixy - T2HY;
+      
+      // Loop over the non-zero part of the template index space and interpolate
+      
+      for(j=jmin_; j<=jmax_; ++j) {
+         // Flip indices as needed
+         if(flip_x_) {jflipx=T2XSIZE-1-j; m = deltax+jflipx;} else {m = deltax+j;}
+         for(i=imin_; i<=imax_; ++i) {
+            if(flip_y_) {iflipy=T2YSIZE-1-i; n = deltay+iflipy;} else {n = deltay+i;}
+            if(m>=0 && m<=BXM3 && n>=0 && n<=BYM3) {
+               tmpxy = entry00_->xytemp[k0][l0][i][j]
+               + adx*(entry00_->xytemp[k0][l1][i][j] - entry00_->xytemp[k0][l0][i][j])
+               + ady*(entry00_->xytemp[k1][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
+               + adcota_*(entry01_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j])
+               + adcotb_*(entry10_->xytemp[k0][l0][i][j] - entry00_->xytemp[k0][l0][i][j]);
+               if(tmpxy > 0.f) {dxytempdy[0][m][n] = tmpxy;} else {dxytempdy[0][m][n] = 0.f;}
+            }
+         }
+      }
+      
+      //combine rows and columns to simulate double pixels
+      
+      for(n=1; n<BYM3; ++n) {
+         if(ydouble[n-1]) {
+            //  Combine the y-columns
+            for(m=1; m<BXM3; ++m) {
+               dxytempdy[0][m][n] += dxytempdy[0][m][n+1];
+            }
+            //  Now shift the remaining pixels over by one column
+            for(i=n+1; i<BYM3; ++i) {
+               for(m=1; m<BXM3; ++m) {
+                  dxytempdy[0][m][i] = dxytempdy[0][m][i+1];
+               }
+            }
+         }
+      }
+      
+      //combine rows and columns to simulate double pixels
+      
+      for(m=1; m<BXM3; ++m) {
+         if(xdouble[m-1]) {
+            //  Combine the x-rows
+            for(n=1; n<BYM3; ++n) {
+               dxytempdy[0][m][n] += dxytempdy[0][m+1][n];
+            }
+            //  Now shift the remaining pixels over by one row
+            for(j=m+1; j<BXM3; ++j) {
+               for(n=1; n<BYM3; ++n) {
+                  dxytempdy[0][j][n] = dxytempdy[0][j+1][n];
+               }
+            }
+         }
+      }
+      
+      //  Finally, normalize the derivatives and copy the results to the output array
+      
+      for(n=1; n<BYM3; ++n) {
+         for(m=1; m<BXM3; ++m) {
+            dpdx2d[1][m][n] = (dxytempdy[1][m][n] - dxytempdy[0][m][n])/(2.*deltaxy[1]);
+         }
       }
    }
    
    return success_;
+} // xytemp
+
+
+
+// *************************************************************************************************************************************
+//! Interpolate stored 2-D information for input angles and hit position to make a 2-D template
+//! \param       xhit - (input) x-position of hit relative to the lower left corner of pixel[1][1] (to allow for the "padding" of the two-d clusters in the splitter)
+//! \param       yhit - (input) y-position of hit relative to the lower left corner of pixel[1][1]
+//! \param    ydouble - (input) STL vector of 21 element array to flag a double-pixel starting at cluster[1][1]
+//! \param    xdouble - (input) STL vector of 11 element array to flag a double-pixel starting at cluster[1][1]
+//! \param template2d - (output) 2d template of size matched to the cluster.  Input must be zeroed since charge is added only.
+// *************************************************************************************************************************************
+
+bool SiPixelTemplate2D::xytemp(float xhit, float yhit, bool ydouble[BYM2], bool xdouble[BXM2], float template2d[BXM2][BYM2])
+{
+   // Interpolate for a new set of track angles
+   
+   bool derivatives = false;
+   float dpdx2d[2][BXM2][BYM2];
+   float QTemplate;
+   
+   return SiPixelTemplate2D::xytemp(xhit, yhit, ydouble, xdouble, template2d, derivatives, dpdx2d, QTemplate);
+   
 } // xytemp
 
 
@@ -709,16 +1387,35 @@ bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float locB
 
 bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float xhit, float yhit, std::vector<bool>& ydouble, std::vector<bool>& xdouble, float template2d[BXM2][BYM2])
 {
-   // Interpolate for a new set of track angles
    
    // Local variables
-   float locBz = -1;
-   if(cotbeta < 0.f) {locBz = -locBz;}
    
-   return SiPixelTemplate2D::xytemp(id, cotalpha, cotbeta, locBz, xhit, yhit, ydouble, xdouble, template2d);
+   bool derivatives = false;
+   float dpdx2d[2][BXM2][BYM2];
+   float QTemplate;
+   float locBx = 1.f;
+   if(cotbeta < 0.f) {locBx = -1.f;}
+   float locBz = locBx;
+   if(cotalpha < 0.f) {locBz = -locBx;}
+   
+   bool yd[BYM2], xd[BXM2];
+   
+   yd[0] = false; yd[BYM2-1] = false;
+   for(int i=0; i<TYSIZE; ++i) { yd[i+1] = ydouble[i];}
+   xd[0] = false; xd[BXM2-1] = false;
+   for(int j=0; j<TXSIZE; ++j) { xd[j+1] = xdouble[j];}
+   
+   
+   // Interpolate for a new set of track angles
+   
+   if(SiPixelTemplate2D::interpolate(id, cotalpha, cotbeta, locBz, locBx)) {
+      
+      return SiPixelTemplate2D::xytemp(xhit, yhit, yd, xd, template2d, derivatives, dpdx2d, QTemplate);
+   } else {
+      return false;
+   }
    
 } // xytemp
-
 
 
 // ************************************************************************************************************
@@ -727,28 +1424,28 @@ bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float xhit
 //! \param qpixel - (input) pixel charge
 //! \param index - (input) y-index index of pixel
 //! \param xysig2 - (output) square error
-// ************************************************************************************************************ 
+// ************************************************************************************************************
 void SiPixelTemplate2D::xysigma2(float qpixel, int index, float& xysig2)
 
 {
    // Interpolate using quantities already stored in the private variables
    
-   // Local variables 
+   // Local variables
    float sigi, sigi2, sigi3, sigi4, qscale, err2, err00;
    
    // Make sure that input is OK
    
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-   if(index < 2 || index >= BYM2) {
+   if(index < 1 || index >= BYM2) {
       throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::ysigma2 called with index = " << index << std::endl;
    }
 #else
-   assert(index > 1 && index < BYM2);
+   assert(index > 0 && index < BYM2);
 #endif
    
-   // Define the maximum signal to use in the parameterization 
+   // Define the maximum signal to use in the parameterization
    
-   // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis 
+   // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis
    
 			if(qpixel < sxymax_) {
             sigi = qpixel;
@@ -758,7 +1455,7 @@ void SiPixelTemplate2D::xysigma2(float qpixel, int index, float& xysig2)
             qscale = qpixel/sxymax_;
          }
 			sigi2 = sigi*sigi; sigi3 = sigi2*sigi; sigi4 = sigi3*sigi;
-			if(index <= THXP1) {
+			if(index <= T2HYP1) {
             err00 = xypary0x0_[0][0]+xypary0x0_[0][1]*sigi+xypary0x0_[0][2]*sigi2+xypary0x0_[0][3]*sigi3+xypary0x0_[0][4]*sigi4;
             err2 = err00
             +adcota_*(xypary0x1_[0][0]+xypary0x1_[0][1]*sigi+xypary0x1_[0][2]*sigi2+xypary0x1_[0][3]*sigi3+xypary0x1_[0][4]*sigi4 - err00)
@@ -770,7 +1467,7 @@ void SiPixelTemplate2D::xysigma2(float qpixel, int index, float& xysig2)
             +adcotb_*(xypary1x0_[1][0]+xypary1x0_[1][1]*sigi+xypary1x0_[1][2]*sigi2+xypary1x0_[1][3]*sigi3+xypary1x0_[1][4]*sigi4 - err00);
          }
 			xysig2 =qscale*err2;
-			if(xysig2 <= 0.f) {LOGERROR("SiPixelTemplate2D") << "neg y-error-squared, id = " << id_current_ << ", index = " << index_id_ << 
+			if(xysig2 <= 0.f) {LOGERROR("SiPixelTemplate2D") << "neg y-error-squared, id = " << id_current_ << ", index = " << index_id_ <<
             ", cot(alpha) = " << cota_current_ << ", cot(beta) = " << cotb_current_ <<  ", sigi = " << sigi << ENDL;}
    
    return;
@@ -778,15 +1475,15 @@ void SiPixelTemplate2D::xysigma2(float qpixel, int index, float& xysig2)
 } // End xysigma2
 
 
-// ************************************************************************************************************ 
+// ************************************************************************************************************
 //! Return the Landau probability parameters for this set of cot(alpha, cot(beta)
-// ************************************************************************************************************ 
+// ************************************************************************************************************
 void SiPixelTemplate2D::landau_par(float lanpar[2][5])
 
 {
    // Interpolate using quantities already stored in the private variables
    
-   // Local variables 
+   // Local variables
    int i,j;
    for(i=0; i<2; ++i) {
       for(j=0; j<5; ++j) {

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
@@ -1,0 +1,654 @@
+//
+//  SiPixelTemplateReco2D.cc (Version 2.20)
+//  Updated to work with the 2D template generation code
+//  Include all bells and whistles for edge clusters
+//  2.10 - Add y-lorentz drift to estimate starting point [for FPix]
+//  2.10 - Remove >1 pixel requirement
+//  2.20 - Fix major bug, change chi2 scan to 9x5 [YxX]
+
+
+//
+//
+//  Created by Morris Swartz on 7/13/17.
+//
+//
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+//#include <cmath.h>
+#else
+#include <math.h>
+#endif
+#include <algorithm>
+#include <vector>
+#include <utility>
+#include <iostream>
+// ROOT::Math has a c++ function that does the probability calc, but only in v5.12 and later
+#include "TMath.h"
+#include "Math/DistFunc.h"
+// Use current version of gsl instead of ROOT::Math
+//#include <gsl/gsl_cdf.h>
+
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/VVIObjF.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#define LOGERROR(x) edm::LogError(x)
+#define LOGDEBUG(x) LogDebug(x)
+static const int theVerboseLevel = 2;
+#define ENDL " "
+#include "FWCore/Utilities/interface/Exception.h"
+#else
+#include "SiPixelTemplateReco2D.h"
+#include "VVIObjF.h"
+//static int theVerboseLevel = {2};
+#define LOGERROR(x) std::cout << x << ": "
+#define LOGDEBUG(x) std::cout << x << ": "
+#define ENDL std::endl
+#endif
+
+using namespace SiPixelTemplateReco2D;
+
+// *************************************************************************************************************************************
+//! Reconstruct the best estimate of the hit position for pixel clusters.
+//! \param         id - (input) identifier of the template to use
+//! \param   cotalpha - (input) the cotangent of the alpha track angle (see CMS IN 2004/014)
+//! \param    cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
+//! \param locBz - (input) the sign of this quantity is used to determine whether to flip cot(beta)<0 quantities from cot(beta)>0 (FPix only)
+//!                    for Phase 0 FPix IP-related tracks, locBz < 0 for cot(beta) > 0 and locBz > 0 for cot(beta) < 0
+//!                    for Phase 1 FPix IP-related tracks, see next comment
+//! \param locBx - (input) the sign of this quantity is used to determine whether to flip cot(alpha/beta)<0 quantities from cot(alpha/beta)>0 (FPix only)
+//!                    for Phase 1 FPix IP-related tracks, locBx/locBz > 0 for cot(alpha) > 0 and locBx/locBz < 0 for cot(alpha) < 0
+//!                    for Phase 1 FPix IP-related tracks, locBx > 0 for cot(beta) > 0 and locBx < 0 for cot(beta) < 0
+//! \param   edgeflagy - (input) flag to indicate the present of edges in y: 0-none (or interior gap), 1-edge at small y, 2-edge at large y,
+//!                                                                          3-edge at either end
+//! \param   edgeflagx - (input) flag to indicate the present of edges in x: 0-none, 1-edge at small x, 2-edge at large x
+//! \param    cluster - (input) pixel array struct with double pixel flags and bounds
+//!           origin of local coords (0,0) at center of pixel cluster[0][0].
+//! \param    templ2D - (input) the 2D template used in the reconstruction
+//! \param       yrec - (output) best estimate of y-coordinate of hit in microns
+//! \param     sigmay - (output) best estimate of uncertainty on yrec in microns
+//! \param       xrec - (output) best estimate of x-coordinate of hit in microns
+//! \param     sigmax - (output) best estimate of uncertainty on xrec in microns
+//! \param     probxy - (output) probability describing goodness-of-fit
+//! \param     probQ  - (output) probability describing upper cluster charge tail
+//! \param       qbin - (output) index (0-4) describing the charge of the cluster
+//!                       qbin = 0        Q/Q_avg > 1.5   [few % of all hits]
+//!                              1  1.5 > Q/Q_avg > 1.0   [~30% of all hits]
+//!                              2  1.0 > Q/Q_avg > 0.85  [~30% of all hits]
+//!                              3 0.85 > Q/Q_avg > min1  [~30% of all hits]
+//! \param     deltay - (output) template y-length - cluster length [when > 0, possibly missing end]
+// *************************************************************************************************************************************
+int SiPixelTemplateReco2D::PixelTempReco3D(int id, float cotalpha, float cotbeta, float locBz, float locBx, int edgeflagy, int edgeflagx,
+                                           ClusMatrix & cluster, SiPixelTemplate2D& templ2D,float& yrec, float& sigmay,
+                                           float& xrec, float& sigmax, float& probxy, float& probQ, int& qbin, float& deltay, int& npixels)
+
+{
+   // Local variables
+   int i, j, k;
+   float template2d[BXM2][BYM2], dpdx2d[2][BXM2][BYM2], fbin[3];
+   
+   // fraction of truncation signal to measure the cluster ends
+   const float fracpix = 0.45f;
+   
+   
+   // Extract some relevant info from the 2D template
+   
+   if(id > 0) {templ2D.interpolate(id, cotalpha, cotbeta, locBz, locBx);}
+   float xsize = templ2D.xsize();
+   float ysize = templ2D.ysize();
+   
+   // Allow Qbin Q/Q_avg fractions to vary to optimize error estimation
+   
+   for(i=0; i<3; ++i) {fbin[i] = templ2D.fbin(i);}
+   
+   float q50 = templ2D.s50();
+   float pseudopix = 0.1f*q50;
+   float pseudopix2 = q50*q50;
+   
+   
+   // Get charge scaling factor
+   
+   float qscale = templ2D.qscale();
+   
+   // Check that the cluster container is (up to) a 7x21 matrix and matches the dimensions of the double pixel flags
+   
+   int nclusx = cluster.mrow;
+   int nclusy = (int)cluster.mcol;
+   bool * xdouble = cluster.xdouble;
+   bool * ydouble = cluster.ydouble;
+   
+   // First, rescale all pixel charges and compute total charge
+   float qtotal = 0.f;
+   for(i=0; i<nclusx*nclusy; ++i) {
+      cluster.matrix[i] *= qscale;
+      qtotal +=cluster.matrix[i];
+   }
+   
+   // uncertainty and final corrections depend upon total charge bin
+   
+   float fq0 = qtotal/templ2D.qavg();
+   
+   // Next, copy the cluster and double pixel flags into a shifted workspace to
+   // allow for significant zeros [pseudopixels] to be added
+   
+   float clusxy[BXM2][BYM2];
+   for(j=0; j<BXM2; ++j) {for(i=0; i<BYM2; ++i) {clusxy[j][i] = 0.f;}}
+   
+   int indexxy[2][NPIXMAX];
+   float pixel[NPIXMAX];
+   float sigma2[NPIXMAX];
+   float minmax = templ2D.pixmax();
+   int imin=BYM2, imax=0, jmin=BXM2, jmax=0;
+   float ylow0 = 0.f, yhigh0 = 0.f, xlow0 = 0.f, xhigh0 = 0.f;
+   float ye = 0.f, xe;
+   int npixel = 0;
+   float ysum[BYM2], ypos[BYM2];
+   //   float xq = 0.f, qtot = 0.f;
+   
+   //Truncate pixels and make a y-projection
+   
+   ysum[0] = 0.f;
+   ypos[0] = -0.5f*ysize;
+   for(i=1; i<nclusy+1; ++i) {
+      float ypitch = ysize;
+      float maxpix = minmax;
+      if(ydouble[i-1]) {ypitch += ysize; maxpix *=2.f;}
+      ypos[i] = ye + ypitch/2.;
+      xe = 0.f;
+      ysum[i] = 0.f;
+      for(j=1; j<nclusx+1; ++j) {
+         float xpitch = xsize;
+         if(xdouble[j-1]) {xpitch += xsize;}
+         // Truncate pixel charges
+         if(cluster(j-1,i-1) > maxpix) {
+            clusxy[j][i] = maxpix;
+         } else {
+            clusxy[j][i] = cluster(j-1,i-1);
+         }
+         if(clusxy[j][i] > 0.) {
+            ysum[i] += clusxy[j][i];
+            //          xq += (xe + xpitch/2.)*clusxy[j][i];
+            if(j < jmin) {jmin = j; xlow0 = xe;}
+            if(j > jmax) {jmax = j; xhigh0 = xe+xpitch;}
+            if(i < imin) {imin = i; ylow0 = ye;}
+            if(i > imax) {imax = i; yhigh0 = ye+ypitch;}
+            indexxy[0][npixel] = j;
+            indexxy[1][npixel] = i;
+            pixel[npixel] = clusxy[j][i];
+            ++npixel;
+         }
+         xe += xpitch;
+      }
+      //      qtot += ysum[i];
+      ye += ypitch;
+   }
+   ysum[nclusy+1] = 0.f;
+   ypos[nclusy+1] = yhigh0+0.5f*ysize;
+   
+   //   float xbaryc = xq/qtot;
+   
+   // Quit if only one pixel in cluster
+   
+      if(npixel < 2 ) {
+//         LOGDEBUG("SiPixelTemplateReco2D") << "2D fit not possible with single pixel" << ENDL;
+         return 1;
+      }
+   
+   
+   //   if(jmax-jmin == 0 ) {
+   //      LOGDEBUG("SiPixelTemplateReco2D") << "2D fit not possible with single x-pixel" << ENDL;
+   //      return 1;
+   //   }
+   
+   // Quit if only one pixel in cluster
+   
+   //   if(imax-imin == 0) {
+   //      LOGDEBUG("SiPixelTemplateReco2D") << "2D fit not possible with single y-pixel" << ENDL;
+   //      return 1;
+   //   }
+   
+   // Next, calculate the error^2 [need to know which is the middle y pixel of the cluster]
+   
+   int ypixoff = T2HYP1 - (imin+imax)/2;
+   for(k=0; k<npixel; ++k) {
+      i = indexxy[1][k];
+      int ypixeff = ypixoff + i;
+      templ2D.xysigma2(pixel[k], ypixeff, sigma2[k]);
+   }
+   
+   // Next, find the half-height edges of the y-projection and identify any
+   // missing columns to remove from the fit
+   
+   int imisslow = -1, imisshigh = -1, jmisslow = -1, jmisshigh = -1;
+   float ylow = -1.f, yhigh = -1.f;
+   float hmaxpix = fracpix*templ2D.sxymax();
+   for(i=imin; i<=imax; ++i) {
+      if(ysum[i] > hmaxpix && ysum[i-1] < hmaxpix && ylow < 0.f) {
+         ylow = ypos[i-1] + (ypos[i]-ypos[i-1])*(hmaxpix-ysum[i-1])/(ysum[i]-ysum[i-1]);
+      }
+      if(ysum[i] < q50) {
+         if(imisslow < 0) imisslow = i;
+         imisshigh = i;
+      }
+      if(ysum[i] > hmaxpix && ysum[i+1] < hmaxpix) {
+         yhigh = ypos[i] + (ypos[i+1]-ypos[i])*(ysum[i]-hmaxpix)/(ysum[i]-ysum[i+1]);
+      }
+   }
+   if(ylow < 0.f || yhigh < 0.f) {
+      ylow = ylow0;
+      yhigh = yhigh0;
+   }
+   
+   float templeny = templ2D.clsleny();
+   deltay = templeny - (yhigh - ylow)/ysize;
+   
+   // Calculate the corrected distance from the ylow and yhigh to the cluster center
+   
+//   float delycor = templ2D.delyavg();
+//   float halfy = 0.5f*(templeny-delycor)*ysize;
+   
+//   printf("templeny = %f, deltay = %f, delycor = %f, halfy = %f \n", templeny, deltay, delycor, halfy);
+   
+   //  x0 and y0 are best guess seeds for the fit
+   
+   //   float x0 = 0.5f*(xlow0 + xhigh0) + 0.5f*xsize;
+   float x0 = 0.5f*(xlow0 + xhigh0) - templ2D.lorxdrift();
+   float y0 = 0.5f*(ylow + yhigh) - templ2D.lorydrift();
+//   float y1 = yhigh - halfy - templ2D.lorydrift();
+//   printf("y0 = %f, y1 = %f \n", y0, y1);
+   //   float y0 = 0.5f*(ylow + yhigh);
+   
+   // If there are missing edge columns, set up missing column flags and number
+   // of minimization passes
+   
+   int npass = 1;
+   
+   switch(edgeflagy) {
+      case 0:
+         break;
+      case 1:
+//         y0 = yhigh - halfy - templ2D.lorydrift();
+         imisshigh = imin-1;
+         imisslow = -1;
+         break;
+      case 2:
+//         y0 = ylow + halfy - templ2D.lorydrift();
+         imisshigh = -1;
+         imisslow = imax+1;
+         break;
+      case 3:
+//         y0 = yhigh - halfy - templ2D.lorydrift();
+         imisshigh = imin-1;
+         imisslow = -1;
+         npass = 2;
+         break;
+      default:
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+         throw cms::Exception("DataCorrupt") << "PixelTemplateReco3D::illegal edgeflagy = " << edgeflagy << std::endl;
+#else
+         std::cout << "PixelTemplate:3D:illegal edgeflagy = " << edgeflagy << std::endl;
+#endif
+   }
+   
+   switch(edgeflagx) {
+      case 0:
+         break;
+      case 1:
+         jmisshigh = jmin-1;
+         jmisslow = -1;
+         break;
+      case 2:
+         jmisshigh = -1;
+         jmisslow = jmax+1;
+         break;
+      default:
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+         throw cms::Exception("DataCorrupt") << "PixelTemplateReco3D::illegal edgeflagx = " << edgeflagx << std::endl;
+#else
+         std::cout << "PixelTemplate:3D:illegal edgeflagx = " << edgeflagx << std::endl;
+#endif
+   }
+   
+   // Define quantities to be saved for each pass
+   
+   
+   float chi2min[2], xerr2[2], yerr2[2];
+   float x2D0[2], y2D0[2], qtfrac0[2];
+   int ipass, niter0[2];
+   
+   for(ipass = 0; ipass < npass; ++ipass) {
+      
+      if(ipass == 1) {
+         
+         // Now try again if both edges are possible
+         
+         //         y0 = ylow + halfy - templ2D.lorydrift();
+         imisshigh = -1;
+         imisslow = imax+1;
+      }
+      
+      // Next, add pseudo pixels around the periphery of the cluster
+      
+      int tpixel = npixel;
+      for(k=0; k<npixel; ++k) {
+         j = indexxy[0][k];
+         i = indexxy[1][k];
+         if((j-1) != jmisshigh) {
+            if(clusxy[j-1][i] < pseudopix) {
+               indexxy[0][tpixel] = j-1;
+               indexxy[1][tpixel] = i;
+               clusxy[j-1][i] = pseudopix;
+               pixel[tpixel] = pseudopix;
+               sigma2[tpixel] = pseudopix2;
+               ++tpixel;
+            }
+         }
+         if((j+1) != jmisslow) {
+            if(clusxy[j+1][i] < pseudopix) {
+               indexxy[0][tpixel] = j+1;
+               indexxy[1][tpixel] = i;
+               clusxy[j+1][i] = pseudopix;
+               pixel[tpixel] = pseudopix;
+               sigma2[tpixel] = pseudopix2;
+               ++tpixel;
+            }
+         }
+         // Don't add them if this is a dead column
+         if((i+1) != imisslow) {
+            if((j-1) != jmisshigh) {
+               if(clusxy[j-1][i+1] < pseudopix) {
+                  indexxy[0][tpixel] = j-1;
+                  indexxy[1][tpixel] = i+1;
+                  clusxy[j-1][i+1] = pseudopix;
+                  pixel[tpixel] = pseudopix;
+                  sigma2[tpixel] = pseudopix2;
+                  ++tpixel;
+               }
+            }
+            if(clusxy[j][i+1] < pseudopix) {
+               indexxy[0][tpixel] = j;
+               indexxy[1][tpixel] = i+1;
+               clusxy[j][i+1] = pseudopix;
+               pixel[tpixel] = pseudopix;
+               sigma2[tpixel] = pseudopix2;
+               ++tpixel;
+            }
+            if((j+1) != jmisslow) {
+               if(clusxy[j+1][i+1] < pseudopix) {
+                  indexxy[0][tpixel] = j+1;
+                  indexxy[1][tpixel] = i+1;
+                  clusxy[j+1][i+1] = pseudopix;
+                  pixel[tpixel] = pseudopix;
+                  sigma2[tpixel] = pseudopix2;
+                  ++tpixel;
+               }
+            }
+         }
+         // Don't add them if this is a dead column
+         if((i-1) != imisshigh) {
+            if((j-1) != jmisshigh) {
+               if(clusxy[j-1][i-1] < pseudopix) {
+                  indexxy[0][tpixel] = j-1;
+                  indexxy[1][tpixel] = i-1;
+                  clusxy[j-1][i-1] = pseudopix;
+                  pixel[tpixel] = pseudopix;
+                  sigma2[tpixel] = pseudopix2;
+                  ++tpixel;
+               }
+            }
+            if(clusxy[j][i-1] < pseudopix) {
+               indexxy[0][tpixel] = j;
+               indexxy[1][tpixel] = i-1;
+               clusxy[j][i-1] = pseudopix;
+               pixel[tpixel] = pseudopix;
+               sigma2[tpixel] = pseudopix2;
+               ++tpixel;
+            }
+            if((j+1) != jmisslow) {
+               if(clusxy[j+1][i-1] < pseudopix) {
+                  indexxy[0][tpixel] = j+1;
+                  indexxy[1][tpixel] = i-1;
+                  clusxy[j+1][i-1] = pseudopix;
+                  pixel[tpixel] = pseudopix;
+                  sigma2[tpixel] = pseudopix2;
+                  ++tpixel;
+               }
+            }
+         }
+      }
+      
+      
+      //   		 printf("** 2D-cluster, cotalpha = %f, cotbeta = %f **\n", cotalpha, cotbeta);
+      
+      //		 for (k=1; k < BXM3; ++k) {
+      //			 printf("%5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f \n",
+      //clusxy[k][1],clusxy[k][2],clusxy[k][3],clusxy[k][4],clusxy[k][5],clusxy[k][6],clusxy[k][7],clusxy[k][8],clusxy[k][9],
+      //clusxy[k][10],clusxy[k][11],clusxy[k][12],clusxy[k][13],clusxy[k][14],clusxy[k][15],clusxy[k][16],clusxy[k][17],clusxy[k][18],
+      //					  clusxy[k][19],clusxy[k][20],clusxy[k][21]);
+      //		 }
+      
+      
+      
+      // Calculate chi2 over a grid of several seeds and choose the smallest
+      
+      chi2min[ipass] = 1000000.f;
+      float chi2, qtemplate, qactive, qtfrac = 0.f, x2D = 0.f, y2D = 0.f;
+      for(int is = -4; is<5; ++is) {
+         for(int js = -2; js<3; ++js) {
+            float xtry = x0 + js*xsize/4.;
+            float ytry = y0 + is*ysize/4.;
+//      for(int is = -8; is<9; ++is) {
+//         for(int js = -4; js<5; ++js) {
+//            float xtry = x0 + js*xsize/8.;
+//            float ytry = y0 + is*ysize/8.;
+            chi2 = 0.f;
+            qactive = 0.f;
+            for(j=0; j<BXM2; ++j) {for(i=0; i<BYM2; ++i) {template2d[j][i] = 0.f;}}
+            templ2D.xytemp(xtry, ytry, ydouble, xdouble, template2d, false, dpdx2d, qtemplate);
+            for(k=0; k<tpixel; ++k) {
+               int jpix = indexxy[0][k];
+               int ipix = indexxy[1][k];
+               float qtpixel = template2d[jpix][ipix];
+               float pt = pixel[k]-qtpixel;
+               chi2 += pt*pt/sigma2[k];
+               if(k < npixel) {qactive += qtpixel;}
+            }
+            if(chi2 < chi2min[ipass]) {
+               chi2min[ipass] = chi2;
+               x2D = xtry;
+               y2D = ytry;
+               qtfrac = qactive/qtemplate;
+            }
+         }
+      }
+      //      printf("jsel/isel = %d/%d\n", jsel, isel);
+      
+      
+      //   printf("\n begin iterative minimization \n");
+
+      
+      int niter = 0;
+      float xstep = 1.0f, ystep = 1.0f;
+      float minv11 = 1000.f, minv12 = 1000.f, minv22 = 1000.f;
+      //      chi2min[ipass] = 100000.f;
+      //      chi2 = 10000.f;
+      chi2 = chi2min[ipass];
+      while(chi2 <= chi2min[ipass] && niter < 15 && (niter < 2 || (fabs(xstep) > 0.2 && fabs(ystep) > 0.2))) {
+         
+         // Remember the present parameters
+         x2D0[ipass] = x2D;
+         y2D0[ipass] = y2D;
+         qtfrac0[ipass] = qtfrac;
+         xerr2[ipass] = minv11;
+         yerr2[ipass] = minv22;
+         chi2min[ipass] = chi2;
+         niter0[ipass] = niter;
+         
+         // Calculate the initial template which also allows the error calculation for the struck pixels
+         
+         for(j=0; j<BXM2; ++j) {for(i=0; i<BYM2; ++i) {template2d[j][i] = 0.f;}}
+         templ2D.xytemp(x2D, y2D, ydouble, xdouble, template2d, true, dpdx2d, qtemplate);
+         
+         float sumptdt1 = 0.f, sumptdt2 = 0.f;
+         float sumdtdt11 = 0.f, sumdtdt12 = 0.f, sumdtdt22 = 0.f;
+         chi2 = 0.f;
+         qactive = 0.f;
+         // Loop over all pixels and calculate matrices
+         
+         for(k=0; k<tpixel; ++k) {
+            int jpix = indexxy[0][k];
+            int ipix = indexxy[1][k];
+            float qtpixel = template2d[jpix][ipix];
+            float pt = pixel[k]-qtpixel;
+            chi2 += pt*pt/sigma2[k];
+            sumptdt1 += pt*dpdx2d[0][jpix][ipix]/sigma2[k];
+            sumptdt2 += pt*dpdx2d[1][jpix][ipix]/sigma2[k];
+            sumdtdt11 += dpdx2d[0][jpix][ipix]*dpdx2d[0][jpix][ipix]/sigma2[k];
+            sumdtdt12 += dpdx2d[0][jpix][ipix]*dpdx2d[1][jpix][ipix]/sigma2[k];
+            sumdtdt22 += dpdx2d[1][jpix][ipix]*dpdx2d[1][jpix][ipix]/sigma2[k];
+            if(k < npixel) {qactive += qtpixel;}
+         }
+         
+         // invert the parameter covariance matrix
+         
+         float D = sumdtdt11*sumdtdt22 - sumdtdt12*sumdtdt12;
+         minv11 = sumdtdt22/D;
+         minv12 = -sumdtdt12/D;
+         minv22 = sumdtdt11/D;
+         
+         qtfrac = qactive/qtemplate;
+         
+         //Calculate the step size
+         
+         xstep = minv11*sumptdt1 + minv12*sumptdt2;
+         xstep *= 0.9f;
+         ystep = minv12*sumptdt1 + minv22*sumptdt2;
+         ystep *= 0.9f;
+//         printf("niter = %d, chisq = %f, xstep = %f, ystep = %f \n", niter, chi2, xstep, ystep);
+         if(fabs(xstep) > 2.*xsize || fabs(ystep) > 2.*ysize) break;
+         x2D += xstep;
+         y2D += ystep;
+         ++niter;
+      }
+   }
+   
+   ipass = 0;
+   if(npass == 1) {
+      // one pass, require that it have iterated
+      if(niter0[0] == 0) {return 2;}
+   } else {
+      // two passes
+      if(niter0[0] == 0 && niter0[1] == 0) {return 2;}
+      if(niter0[0] > 0 && niter0[1] > 0) {
+         // if both have iterated, take the smaller chi2
+         if(chi2min[1] < chi2min[0]) {ipass = 1;}
+      } else {
+         // if one has iterated, take it
+         if(niter0[1] > 0) {ipass = 1;}
+      }
+   }
+   
+   //   printf("niter = %d \n", niter);
+   
+   // Correct the charge ratio for missing pixels
+   
+   float fq;
+   if(qtfrac0[ipass] < 0.10f || qtfrac0[ipass] > 1.f) {qtfrac0[ipass] = 1.f;}
+   fq = fq0/qtfrac0[ipass];
+   
+   //   printf("qtfrac0 = %f \n", qtfrac0);
+   
+   if(fq > fbin[0]) {
+      qbin=0;
+   } else {
+      if(fq > fbin[1]) {
+         qbin=1;
+      } else {
+         if(fq > fbin[2]) {
+            qbin=2;
+         } else {
+            qbin=3;
+         }
+      }
+   }
+   
+   // Get charge related quantities
+   
+   float scalex = templ2D.scalex(qbin);
+   float scaley = templ2D.scaley(qbin);
+   float offsetx = templ2D.offsetx(qbin);
+   float offsety = templ2D.offsety(qbin);
+//   printf("scalex = %f, scaley = %f, offsetx = %f, offsety = %f \n", scalex, scaley, offsetx, offsety);
+   
+   // This 2D code has the origin (0,0) at the lower left edge of the input cluster
+   // That is now pixel [1,1] and the template reco convention is the middle
+   // of that pixel, so we need to correct
+   
+   xrec = x2D0[ipass] - xsize/2. - offsetx;
+   if(xdouble[0]) xrec -= xsize/2.f;
+   yrec = y2D0[ipass] - ysize/2. - offsety;
+   if(ydouble[0]) yrec -= ysize/2.f;
+   if(xerr2[ipass] > 0.f) {
+      sigmax = scalex*sqrt(xerr2[ipass]);
+      if(sigmax < 3.f) sigmax = 3.f;
+   } else {
+      sigmax = 10000.f;
+   }
+   if(yerr2[ipass] > 0.f) {
+      sigmay = scaley*sqrt(yerr2[ipass]);
+      if(sigmay < 3.f) sigmay = 3.f;
+   } else {
+      sigmay = 10000.f;
+   }
+   if(id > 0) {
+      // Do chi2 probability calculation
+      double meanxy = (double)(npixel*templ2D.chi2ppix());
+      double chi2scale = (double)templ2D.chi2scale();
+      if(meanxy < 0.01) {meanxy = 0.01;}
+      double hndof = meanxy/2.f;
+      double hchi2 = chi2scale*chi2min[ipass]/2.f;
+      probxy = (float)(1. - TMath::Gamma(hndof, hchi2));
+      // Do the charge probability
+      float mpv = templ2D.mpvvav();
+      float sigmaQ = templ2D.sigmavav();
+      float kappa = templ2D.kappavav();
+      float xvav = (qtotal/qtfrac0[ipass]-mpv)/sigmaQ;
+      float beta2 = 1.f;
+      //  VVIObj is a private port of CERNLIB VVIDIS
+      VVIObjF vvidist(kappa, beta2, 1);
+      float prvav = vvidist.fcn(xvav);
+      probQ = 1.f - prvav;
+   } else {
+      probxy = chi2min[ipass];
+      npixels = npixel;
+      probQ = 0.f;
+   }
+   
+   // Now
+   
+   //   printf("end minimization, errors = %f, %f \n\n", sqrt(xerr2), sqrt(yerr2));
+   
+   //   		 printf("** 2D-template, cotalpha = %f, cotbeta = %f, x2D = %f, y2D = %f **\n", cotalpha, cotbeta, x2D, y2D);
+		 
+   //		 for (k=1; k < BXM3; ++k) {
+   //			 printf("%5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f // %5.0f %5.0f %5.0f \n",
+   //template2d[k][1],template2d[k][2],template2d[k][3],template2d[k][4],template2d[k][5],template2d[k][6],template2d[k][7],template2d[k][8],template2d[k][9],
+   //template2d[k][10],template2d[k][11],template2d[k][12],template2d[k][13],template2d[k][14],template2d[k][15],template2d[k][16],template2d[k][17],template2d[k][18],
+   //					  template2d[k][19],template2d[k][20],template2d[k][21]);
+   //		 }
+		 
+   
+   
+   return 0;
+} // PixelTempReco2D
+
+int SiPixelTemplateReco2D::PixelTempReco3D(int id, float cotalpha, float cotbeta, float locBz, float locBx, int edgeflagy,
+                                           int edgeflagx, ClusMatrix & cluster, SiPixelTemplate2D& templ2D,float& yrec, float& sigmay, float& xrec, float& sigmax,
+                                           float& probxy, float& probQ, int& qbin, float& deltay)
+
+{
+   // Local variables
+   int npixels;
+   return SiPixelTemplateReco2D::PixelTempReco3D(id, cotalpha, cotbeta, locBz, locBx, edgeflagy, edgeflagx, cluster,
+                                                 templ2D, yrec, sigmay, xrec, sigmax, probxy, probQ, qbin, deltay, npixels);
+} // PixelTempReco2D

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
@@ -133,7 +133,9 @@ int SiPixelTemplateReco2D::PixelTempReco3D(int id, float cotalpha, float cotbeta
    
    float clusxy[BXM2][BYM2];
    for(j=0; j<BXM2; ++j) {for(i=0; i<BYM2; ++i) {clusxy[j][i] = 0.f;}}
-   
+
+   const unsigned int NPIXMAX = 200;
+
    int indexxy[2][NPIXMAX];
    float pixel[NPIXMAX];
    float sigma2[NPIXMAX];

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -11,3 +11,6 @@ TTRHBuilderAngleAndTemplate = cms.ESProducer("TkTransientTrackingRecHitBuilderES
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, Phase2StripCPE = cms.string('Phase2StripCPE'))
 
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = cms.string('PixelCPEClusterRepair'))
+

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -11,6 +11,6 @@ TTRHBuilderAngleAndTemplate = cms.ESProducer("TkTransientTrackingRecHitBuilderES
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, Phase2StripCPE = cms.string('Phase2StripCPE'))
 
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = cms.string('PixelCPEClusterRepair'))
+# from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+# phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = cms.string('PixelCPEClusterRepair'))
 

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
@@ -8,5 +8,6 @@ from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelPairs_cfi import *
 from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelTriplets_cfi import *
 #TransientTRH builder with template
 from RecoLocalTracker.SiPixelRecHits.PixelCPETemplateReco_cfi import *
+from RecoLocalTracker.SiPixelRecHits.PixelCPEClusterRepair_cfi import *
 from RecoTracker.TransientTrackingRecHit.TTRHBuilderWithTemplate_cfi import *
 


### PR DESCRIPTION
The 2D pixel cluster reconstruction.  For normal undamaged clusters, the 2D fit is as good or better as the usual combination of two 1D fits of cluster projections onto the local x and y axes.  However, the 2D fit is able to fit even clusters that are damaged by (a) edge of sensor, or (b) dead double-column or ROC next door.  The 2D pixel reco is done within a new CPE, called PixelCPEClusterRepair (since it can "repair" damaged clusters), which subsumes the default reconstruction, and can perform it as well, and then optionally (if the 2* 1D reco recommends based on its fit outputs) do the 2D fit.  

All this code is by default TURNED OFF.  We want it in the release though to simplify testing and enable future development in the near term.