### PR TITLE
Fix for observed muon efficiency loss in new FastSim geometry

### DIFF
--- a/FastSimulation/Event/src/FSimTrack.cc
+++ b/FastSimulation/Event/src/FSimTrack.cc
@@ -29,13 +29,15 @@ FSimTrack::FSimTrack(const RawParticle* p,
 
          
 //! Hack to interface "old" calorimetry with "new" propagation in tracker (need to construct FSimTracks)
-// Not sure if momentum in constructor of SimTrack and momentum_ are correctly set...
 FSimTrack::FSimTrack(int ipart, const math::XYZTLorentzVector& p, int iv, int ig, int id, double charge, const math::XYZTLorentzVector& tkp, const math::XYZTLorentzVector& tkm, const SimVertex& tkv) :
   SimTrack(ipart, p, iv, ig, math::XYZVectorD(tkp.X(), tkp.Y(), tkp.Z()),  tkm), vertex_(tkv),
   mom_(nullptr), id_(id), charge_(charge), endv_(-1),
   layer1(0), layer2(0), ecal(0), hcal(0), vfcal(0), hcalexit(0), hoentr(0), prop(false),
   closestDaughterId_(-1), info_(nullptr), momentum_(tkm),
-  properDecayTime(-1) {;}
+  properDecayTime(-1)
+  {
+    setTrackId(id);
+  }
 
 FSimTrack::~FSimTrack() {;}
 


### PR DESCRIPTION
One of the MC validators observed a loss in the muon efficiency for FastSim, related with the new FastSim geometry. This could be traced back to a bad index of the corresponding muon SimTracks, so most of the muons were identified as fakes.