### PR TITLE
Example of passing data to/from CmsRun module

### DIFF
--- a/FWCore/PythonFramework/test/BuildFile.xml
+++ b/FWCore/PythonFramework/test/BuildFile.xml
@@ -2,4 +2,10 @@
   <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/PythonFramework/test runPythonTests.sh"/>
   <use name="FWCore/Utilities"/>
 </bin>
+<library   file="PythonTestProducer.cc" name="PythonTestProducer">
+  <flags   EDM_PLUGIN="1"/>
+  <use   name="FWCore/ParameterSet"/>
+  <use   name="FWCore/Framework"/>
+  <use name="boost"/>
+</library>
 

--- a/FWCore/PythonFramework/test/PythonTestProducer.cc
+++ b/FWCore/PythonFramework/test/PythonTestProducer.cc
@@ -1,0 +1,62 @@
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+
+#include <boost/python.hpp>
+#include <iostream>
+
+namespace edmtest {
+  class PythonTestProducer : public edm::one::EDProducer<edm::one::SharedResources> {
+    
+  public:
+    PythonTestProducer(edm::ParameterSet const&);
+    
+    void produce(edm::Event& iEvent, edm::EventSetup const&) override;
+    
+  private:
+    edm::EDGetTokenT<IntProduct> get_;
+    edm::EDPutTokenT<int> put_;
+    int value_;
+    boost::python::list outputList_;
+  };
+  
+  PythonTestProducer::PythonTestProducer(edm::ParameterSet const& iPS):
+  get_(consumes<IntProduct>(iPS.getParameter<edm::InputTag>("source")))
+   {
+     using namespace boost::python;
+    object main_module{ boost::python::handle<>(boost::python::borrowed(PyImport_AddModule(const_cast<char*>("__main__")))) };
+    auto main_namespace = main_module.attr("__dict__");
+
+    //NOTE attempts to hold the object directly and read it in `produce` lead to segmentation faults
+    value_ = extract<int>(main_namespace[iPS.getParameter<std::string>("inputVariable")]);
+    
+    outputList_ = extract<list>( main_namespace[iPS.getParameter<std::string>("outputListVariable")]);
+    
+    put_ = produces<int>();
+    
+    usesResource("python");
+  }
+  
+  void
+    PythonTestProducer::produce(edm::Event& iEvent, edm::EventSetup const& ) {
+      using namespace boost::python;
+
+      edm::Handle<IntProduct> h;
+      iEvent.getByToken(get_, h);
+      
+      outputList_.append(h->value );
+      
+      iEvent.put(put_,std::make_unique<int>( h->value +value_ ));
+      //iEvent.put(put_,std::make_unique<int>( h->value ) );
+    }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(edmtest::PythonTestProducer);
+

--- a/FWCore/PythonFramework/test/runPythonTests.sh
+++ b/FWCore/PythonFramework/test/runPythonTests.sh
@@ -10,3 +10,6 @@ do
      python "$file" || die "unit tests for $bn failed" $?
   fi
 done
+
+echo "running test_producer.py"
+python ${LOCAL_TEST_DIR}/test_producer.py || die "test_producer.py failed"

--- a/FWCore/PythonFramework/test/test_producer.py
+++ b/FWCore/PythonFramework/test/test_producer.py
@@ -1,0 +1,26 @@
+from FWCore.PythonFramework.CmsRun import CmsRun
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Test")
+
+process.source = cms.Source("EmptySource")
+
+nEvents = 10
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(nEvents))
+
+var = 5
+outList = []
+
+process.m = cms.EDProducer("edmtest::PythonTestProducer", inputVariable = cms.string("var"),
+                            outputListVariable = cms.string("outList"),
+                            source = cms.InputTag("ints"))
+
+process.ints = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+process.p = cms.Path(process.m, cms.Task(process.ints))
+
+cmsRun = CmsRun(process)
+
+cmsRun.run()
+
+assert (outList == [1]*nEvents)
+


### PR DESCRIPTION
Added an example of using boost python to be able to pass data into
and out of the CmsRun python module.