### PR TITLE
New psets for Phase2PixelNtuple 

### DIFF
--- a/SLHCUpgradeSimulations/Geometry/test/README.Phase2PixelNtuple.md
+++ b/SLHCUpgradeSimulations/Geometry/test/README.Phase2PixelNtuple.md
@@ -2,65 +2,41 @@ This is a short description of the content of the ntuple produced by Phase2Pixel
 
 ### GEOMETRY 
 
-* subid = 1: TBPX
-
-  layer  = 1..4 
-
-  ladder = 1..28 depending on the layer
-
-  nRowsInDet =  656 layer 1,2
-
-             = 1320 layer 3,4
-
-  nColsInDet =  442 layer 1,2
-
-                442 layer 3,4
-		     
-
-* subid = 2: TFPX, TEPX
-
-  side = 1 (-z), 2 (+z)
-
-  disk = 1..12 (disk = 1..8 TFPX; disk = 9..12 TEPX)
-
-  blade = 1..4 TFPX 
-
-        = 1..5 TEPX
-
-  NB: 'blade' corresponds to a ring
-
-  panel = 1 (?)
-
-  nRowsInDet =  656 blade 1,2
-
-             = 1320 blade 3,4,5
-
-  nColsInDet =  442 blade 1,2
-
-                442 blade 3,4,5
+* `subid` = 1 TBPX                             </br>
+	`layer`  = 1..4                         </br>
+	`ladder` = 1..28 depending on the layer </br>
+	`nRowsInDet` =  656 for `layer` = 1,2   </br>
+	`nRowsInDet` = 1320 for `layer` = 3,4   </br>
+	`nColsInDet` = 442 for `layer` = 1,2    </br>
+	`nColsInDet` = 442 for `layer` = 3,4    
+				 
+* `subid` = 2: TFPX and TEPX </br>
+        `side` = 1 (-z), 2 (+z)  </br>
+        `disk` = 1..12 (disk = 1..8 for TFPX; disk = 9..12 for TEPX) </br>
+        `blade` = 1..4 TFPX     </br>
+        `blade` = 1..5 TEPX     </br>
+        NB: the variable named `blade` corresponds to a phase2 ring </br>
+        `panel` = 1 (always?)                   </br>
+        `nRowsInDet` =  656 for `blade` = 1,2   </br>
+        `nRowsInDet` = 1320 for `blade` = 3,4,5 </br>
+        `nColsInDet` =  442 for `blade` = 1,2   </br>
+        `nColsInDet` =  442 for `blade` = 3,4,5
 
 ### RECHIT
     
-* Local position of the SimHit (approx)
+* Local position of the `SimHit` (ranges below are approx) </br>
+        `hx` [-0.83,+0.83] cm  for 1x2 modules             </br>
+        `hx` [-1.67,+1.67] cm  for 2x2 modules             </br>
+        `hy` [-2.24,+2.24] cm                  
 
-    hx [-0.83,+0.83] cm   1x2 modules
-
-       [-1.67,+1.67] cm   2x2 modules
-
-    hy [-2.24,+2.24] cm    
-
-    q = charge of RecHit in e
-
-    DgCharge = charge of pixel in ke
-
-               to get the ADC count (integer): DgCharge*1000./600. or DgCharge*1000./135. 
-
-               Check the value in the pset, e.g.
-               
-               SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
-
-               process.mix.digitizers.pixel.PixelDigitizerAlgorithm.ElectronPerAdc = cms.double(135.)
-
-               RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
-
-               process.siPixelClusters.ElectronPerADCGain=cms.double(135.)
+* Charge and ADC </br>
+        `q` = charge of `RecHit` in e               </br>
+        `DgCharge` = charge of a single pixel in ke </br>
+        NB: to get the ADC count (integer): `DgCharge*1000./600`. or `DgCharge*1000./135.` </br>
+        Check always the value in the pset, e.g. </br>
+        ```
+        SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+        process.mix.digitizers.pixel.PixelDigitizerAlgorithm.ElectronPerAdc = cms.double(135.)
+        RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+        process.siPixelClusters.ElectronPerADCGain=cms.double(135.)
+        ```

--- a/SLHCUpgradeSimulations/Geometry/test/README.Phase2PixelNtuple.md
+++ b/SLHCUpgradeSimulations/Geometry/test/README.Phase2PixelNtuple.md
@@ -1,0 +1,47 @@
+This is a short description of the content of the ntuple produced by Phase2PixelNtuple.cc
+
+### GEOMETRY 
+
+* subid = 1: TBPX
+  layer  = 1..4 
+  ladder = 1..28 depending on the layer
+
+  nRowsInDet =  656 layer 1,2
+             = 1320 layer 3,4
+  nColsInDet =  442 layer 1,2
+                442 layer 3,4
+		     
+
+* subid = 2: TFPX, TEPX
+  side = 1 (-z), 2 (+z)
+  disk = 1..12 (disk = 1..8 TFPX; disk = 9..12 TEPX)
+  blade = 1..4 TFPX 
+        = 1..5 TEPX
+  NB: 'blade' corresponds to a ring
+  panel = 1 (?)
+
+  nRowsInDet =  656 blade 1,2
+             = 1320 blade 3,4,5
+
+  nColsInDet =  442 blade 1,2
+                442 blade 3,4,5
+
+### RECHIT
+    
+* Local position of the SimHit (approx)
+
+    hx [-0.83,+0.83] cm   1x2 modules
+       [-1.67,+1.67] cm   2x2 modules
+    hy [-2.24,+2.24] cm    
+
+    q = charge of RecHit in e
+    DgCharge = charge of pixel in ke
+               to get the ADC count (integer): DgCharge*1000./600. or DgCharge*1000./135. 
+
+               Check the value in the pset, e.g.
+               
+               SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+               process.mix.digitizers.pixel.PixelDigitizerAlgorithm.ElectronPerAdc = cms.double(135.)
+
+               RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+               process.siPixelClusters.ElectronPerADCGain=cms.double(135.)

--- a/SLHCUpgradeSimulations/Geometry/test/README.Phase2PixelNtuple.md
+++ b/SLHCUpgradeSimulations/Geometry/test/README.Phase2PixelNtuple.md
@@ -3,27 +3,40 @@ This is a short description of the content of the ntuple produced by Phase2Pixel
 ### GEOMETRY 
 
 * subid = 1: TBPX
+
   layer  = 1..4 
+
   ladder = 1..28 depending on the layer
 
   nRowsInDet =  656 layer 1,2
+
              = 1320 layer 3,4
+
   nColsInDet =  442 layer 1,2
+
                 442 layer 3,4
 		     
 
 * subid = 2: TFPX, TEPX
+
   side = 1 (-z), 2 (+z)
+
   disk = 1..12 (disk = 1..8 TFPX; disk = 9..12 TEPX)
+
   blade = 1..4 TFPX 
+
         = 1..5 TEPX
+
   NB: 'blade' corresponds to a ring
+
   panel = 1 (?)
 
   nRowsInDet =  656 blade 1,2
+
              = 1320 blade 3,4,5
 
   nColsInDet =  442 blade 1,2
+
                 442 blade 3,4,5
 
 ### RECHIT
@@ -31,17 +44,23 @@ This is a short description of the content of the ntuple produced by Phase2Pixel
 * Local position of the SimHit (approx)
 
     hx [-0.83,+0.83] cm   1x2 modules
+
        [-1.67,+1.67] cm   2x2 modules
+
     hy [-2.24,+2.24] cm    
 
     q = charge of RecHit in e
+
     DgCharge = charge of pixel in ke
+
                to get the ADC count (integer): DgCharge*1000./600. or DgCharge*1000./135. 
 
                Check the value in the pset, e.g.
                
                SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+
                process.mix.digitizers.pixel.PixelDigitizerAlgorithm.ElectronPerAdc = cms.double(135.)
 
                RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+
                process.siPixelClusters.ElectronPerADCGain=cms.double(135.)

--- a/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
@@ -29,7 +29,7 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(5)
+    input = cms.untracked.int32(10)
 )
 
 process.source = cms.Source("PoolSource",
@@ -76,7 +76,6 @@ process.ReadLocalMeasurement = cms.EDAnalyzer("Phase2PixelNtuple",
    usePhase2Tracker = cms.bool(True),
    pixelSimLinkSrc = cms.InputTag("simSiPixelDigis", "Pixel"),
    phase2TrackerSimLinkSrc = cms.InputTag("simSiPixelDigis", "Tracker")
-
 )
 
 
@@ -84,6 +83,14 @@ process.ReadLocalMeasurement = cms.EDAnalyzer("Phase2PixelNtuple",
 
 # Other statements
 process.mix.digitizers = cms.PSet(process.theDigitizersValid)
+
+# This pset is specific for producing simulated events for the designers of the PROC (InnerTracker)
+# They need pixel RecHits where the charge is stored with high-granularity and large dinamic range
+process.mix.digitizers.pixel.PixelDigitizerAlgorithm.AdcFullScale   = cms.int32(255)
+process.mix.digitizers.pixel.PixelDigitizerAlgorithm.ElectronPerAdc = cms.double(135.)
+process.siPixelClusters.ElectronPerADCGain=cms.double(135.)
+process.siPixelClustersPreSplitting.ElectronPerADCGain=cms.double(135.)
+
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
@@ -114,19 +121,7 @@ from HLTrigger.Configuration.customizeHLTforMC import customizeHLTforMC
 #call to customisation function customizeHLTforMC imported from HLTrigger.Configuration.customizeHLTforMC
 process = customizeHLTforMC(process)
 
-# This pset is specific for producing simulated events for the designers of the PROC (InnerTracker)
-# They need pixel RecHits where the charge is stored with high-granularity and large dinamic range
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(process.mix.digitizers.pixel.PixelDigitizerAlgorithm,
-  AdcFullScale   = cms.int32(255),
-  ElectronPerAdc = cms.double(135)
-)
-phase2_tracker.toModify(process.siPixelClusters, 
-  ElectronPerADCGain = cms.double(135) 
-)
-
 # End of customisation functions
-
 #do not add changes to your config after this point (unless you know what you are doing)
 from FWCore.ParameterSet.Utilities import convertToUnscheduled
 process=convertToUnscheduled(process)

--- a/SLHCUpgradeSimulations/Geometry/test/phase2_reco_pixelntuple_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_reco_pixelntuple_cfg.py
@@ -29,12 +29,12 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(5)
+    input = cms.untracked.int32(10)
 )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-'/store/relval/CMSSW_10_0_0_pre1/RelValSingleMuPt10/GEN-SIM-DIGI-RAW/94X_upgrade2023_realistic_v2_2023D21noPU-v2/10000/0E747454-F7CE-E711-B528-0CC47A7C34C8.root'
+	'/store/relval/CMSSW_10_0_0_pre1/RelValSingleMuPt10/GEN-SIM-DIGI-RAW/94X_upgrade2023_realistic_v2_2023D21noPU-v2/10000/0E747454-F7CE-E711-B528-0CC47A7C34C8.root'
     )
 )
 
@@ -76,7 +76,6 @@ process.ReadLocalMeasurement = cms.EDAnalyzer("Phase2PixelNtuple",
    usePhase2Tracker = cms.bool(True),
    pixelSimLinkSrc = cms.InputTag("simSiPixelDigis", "Pixel"),
    phase2TrackerSimLinkSrc = cms.InputTag("simSiPixelDigis", "Tracker")
-
 )
 
 

--- a/SLHCUpgradeSimulations/Geometry/test/phase2_reco_pixelntuple_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_reco_pixelntuple_cfg.py
@@ -34,7 +34,7 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-       '/store/relval/CMSSW_10_0_0_pre1/RelValSingleMuPt10/GEN-SIM/94X_upgrade2023_realistic_v2_2023D21noPU-v2/10000/F2B83850-E6CE-E711-8185-0CC47A78A4B0.root'
+'/store/relval/CMSSW_10_0_0_pre1/RelValSingleMuPt10/GEN-SIM-DIGI-RAW/94X_upgrade2023_realistic_v2_2023D21noPU-v2/10000/0E747454-F7CE-E711-B528-0CC47A7C34C8.root'
     )
 )
 
@@ -100,7 +100,7 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 #process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.digitisation_step,process.L1simulation_step,process.L1TrackTrigger_step,process.digi2raw_step)
+process.schedule = cms.Schedule()
 process.schedule.extend(process.HLTSchedule)
 process.schedule.extend([process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.endjob_step])
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
@@ -114,19 +114,7 @@ from HLTrigger.Configuration.customizeHLTforMC import customizeHLTforMC
 #call to customisation function customizeHLTforMC imported from HLTrigger.Configuration.customizeHLTforMC
 process = customizeHLTforMC(process)
 
-# This pset is specific for producing simulated events for the designers of the PROC (InnerTracker)
-# They need pixel RecHits where the charge is stored with high-granularity and large dinamic range
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(process.mix.digitizers.pixel.PixelDigitizerAlgorithm,
-  AdcFullScale   = cms.int32(255),
-  ElectronPerAdc = cms.double(135)
-)
-phase2_tracker.toModify(process.siPixelClusters, 
-  ElectronPerADCGain = cms.double(135) 
-)
-
 # End of customisation functions
-
 #do not add changes to your config after this point (unless you know what you are doing)
 from FWCore.ParameterSet.Utilities import convertToUnscheduled
 process=convertToUnscheduled(process)
@@ -145,5 +133,3 @@ process = customiseEarlyDelete(process)
 process.TFileService = cms.Service('TFileService',
 fileName = cms.string("pixelntuple.root")
 )
-
-


### PR DESCRIPTION
This is an update of PR #22204. Two psets are provided:
1/ phase2_reco_pixelntuple_cfg.py: ntuples from DIGI to perform RECO level studies, e.g. CPE errors calibration)
2/ phase2_digi_reco_pixelntuple_cfg.py ntuples from SIM to produce "stimuli" for RD53 studies (InnerTracker PROC deisgn)