### PR TITLE
Implemented pixel inefficiency at ROC level

### DIFF
--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -247,6 +247,8 @@ class SiPixelDigitizerAlgorithm  {
 
      // Read factors from DB and fill containers
      std::map<uint32_t, double> PixelGeomFactors;
+     std::map<uint32_t, std::vector<double> > PixelGeomFactorsROCStdPixels;     
+     std::map<uint32_t, std::vector<double> > PixelGeomFactorsROCBigPixels;
      std::map<uint32_t, double> ColGeomFactors;
      std::map<uint32_t, double> ChipGeomFactors;
      std::map<uint32_t, size_t > iPU;

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -252,7 +252,10 @@ class SiPixelDigitizerAlgorithm  {
      std::map<uint32_t, double> ColGeomFactors;
      std::map<uint32_t, double> ChipGeomFactors;
      std::map<uint32_t, size_t > iPU;
-
+     
+     // constants for ROC level simulation for Phase1
+     enum shiftEnumerator {FPixRocIdShift = 3, BPixRocIdShift = 6};     
+     static const int rocIdMaskBits = 0x1F;      
      void init_from_db(const edm::ESHandle<TrackerGeometry>&, const edm::ESHandle<SiPixelDynamicInefficiency>&);
      bool matches(const DetId&, const DetId&, const std::vector<uint32_t >&);
    };


### PR DESCRIPTION
The PR extends the functionality of the pixel inefficiency simulation (SiPixelDynamicInefficiency) in digitizer from the module to the ROC level. It was needed to simulate the damage in ROCs caused by the DCDC issue. The damage is bigger for the modules operated longer in such conditions (LV off/HV on), effect is also larger for ROCs closer to the beam.
The damage first appears in big pixels and then the standard size pixels. For that reason, the first 5% (percentage of the big pixels in the ROC) of bad pixels is assigned to the big ones, and the remaining part to the standard pixels.

As SiPixelDynamicInefficiency DB object has not been updated yet, no changes expected with this PR.

The plots showing pixelAlive measurements and results of the simulation for several modules are attached below. 
[PR_bpix.pdf](https://github.com/cms-sw/cmssw/files/1782047/PR_bpix.pdf)
[PR_fpix.pdf](https://github.com/cms-sw/cmssw/files/1782048/PR_fpix.pdf)

@veszpv @tvami @boudoul @jkarancs @ferencek 