### PR TITLE
OnlineDB/EcalCondDB: Clean up the following clang warnings:

### DIFF
--- a/OnlineDB/EcalCondDB/interface/LMFCorrCoefDatComponent.h
+++ b/OnlineDB/EcalCondDB/interface/LMFCorrCoefDatComponent.h
@@ -40,6 +40,8 @@ class LMFCorrCoefDatComponent: public LMFDat {
 
   LMFLmrSubIOV        getLMFLmrSubIOV() const;
   int                 getLMFLmrSubIOVID() const;
+  friend class LMFUnique;
+  using LMFUnique::getParameters;
   std::vector<float>  getParameters(const EcalLogicID &id);
   std::vector<float>  getParameterErrors(const EcalLogicID &id);
   std::vector<float>  getParameters(int id);

--- a/OnlineDB/EcalCondDB/interface/LMFUnique.h
+++ b/OnlineDB/EcalCondDB/interface/LMFUnique.h
@@ -86,11 +86,11 @@ class LMFUnique: public IUniqueDBObject {
   virtual std::string setByIDSql(Statement *stmt, 
 				 int id) { return ""; }
 
-  virtual void getParameters(ResultSet *rset) {}
   virtual void fetchParentIDs() {}
   virtual LMFUnique * createObject() const;
 
  protected:
+  virtual void getParameters(ResultSet *rset) {}
   virtual int writeDB() noexcept(false);
   virtual int writeForeignKeys() noexcept(false);
   virtual void setClassName(std::string s) { m_className = s; }


### PR DESCRIPTION
OnlineDB/EcalCondDB/interface/LMFCorrCoefDatComponent.h:43:23: warning: 'LMFCorrCoefDatComponent::getParameters' hides overloaded virtual function [-Woverloaded-virtual]

OnlineDB/EcalCondDB/interface/LMFCorrCoefDatComponent.h:45:23: warning: 'LMFCorrCoefDatComponent::getParameters' hides overloaded virtual function [-Woverloaded-virtual]