### PR TITLE
EventFilter packages: Cleanup for the following clang warnings:

### DIFF
--- a/EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h
@@ -15,7 +15,7 @@ class CSCVTMBHeaderFormat {
 public:
   virtual ~CSCVTMBHeaderFormat() {}
   void init() {
-    bzero(this, sizeInWords()*2);
+    bzero(static_cast<void *>(this), sizeInWords()*2);
   }
   
   virtual void setEventInformation(const CSCDMBHeader &) = 0;

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -36,6 +36,7 @@ namespace sistrip {
       //The FE length from the full debug header is used in full debug mode.
       bool fePresent(uint8_t internalFEUnitNum) const;
       //check that a channel is present in data, found, on a good FE unit and has no errors flagged in status bits
+      using FEDBufferBase::channelGood;
       virtual bool channelGood(const uint8_t internalFEDannelNum, const bool doAPVeCheck=true) const;
       void setLegacyMode(bool legacy) { legacyUnpacker_ = legacy;}
 

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -36,7 +36,6 @@ namespace sistrip {
       //The FE length from the full debug header is used in full debug mode.
       bool fePresent(uint8_t internalFEUnitNum) const;
       //check that a channel is present in data, found, on a good FE unit and has no errors flagged in status bits
-      using FEDBufferBase::channelGood;
       virtual bool channelGood(const uint8_t internalFEDannelNum, const bool doAPVeCheck=true) const;
       void setLegacyMode(bool legacy) { legacyUnpacker_ = legacy;}
 


### PR DESCRIPTION
EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h:18:11: warning: destination for this 'bzero' call is a pointer to dynamic class 'CSCVTMBHeaderFormat'; vtable pointer will be overwritten [-Wdynamic-class-memaccess]
     bzero(this, sizeInWords()*2);
    ~~~~~ ^
