### PR TITLE
Validation/TrackingMCTruth : Clean up clang warnings:

### DIFF
--- a/Validation/TrackingMCTruth/interface/TrackingTruthValid.h
+++ b/Validation/TrackingMCTruth/interface/TrackingTruthValid.h
@@ -23,9 +23,8 @@ class TrackingTruthValid  : public  DQMEDAnalyzer {
   void analyze(const edm::Event&, const edm::EventSetup& ) override;
 
   void bookHistograms(DQMStore::IBooker & ibooker,const edm::Run& run, const edm::EventSetup& es) override;
-  void beginJob() override;
-  void endJob() override;
-  
+  void endJob() override; 
+
  private:
   bool runStandalone;
   std::string outputFile;

--- a/Validation/TrackingMCTruth/interface/TrackingTruthValid.h
+++ b/Validation/TrackingMCTruth/interface/TrackingTruthValid.h
@@ -23,8 +23,8 @@ class TrackingTruthValid  : public  DQMEDAnalyzer {
   void analyze(const edm::Event&, const edm::EventSetup& ) override;
 
   void bookHistograms(DQMStore::IBooker & ibooker,const edm::Run& run, const edm::EventSetup& es) override;
-  void beginJob(const edm::ParameterSet& conf);
-  void endJob();
+  void beginJob() override;
+  void endJob() override;
   
  private:
   bool runStandalone;

--- a/Validation/TrackingMCTruth/plugins/TrackingTruthValid.cc
+++ b/Validation/TrackingMCTruth/plugins/TrackingTruthValid.cc
@@ -29,7 +29,7 @@ typedef TrackingVertex::genv_iterator                   genv_iterator;
 typedef TrackingVertex::g4v_iterator                     g4v_iterator;
 
 
-void TrackingTruthValid::beginJob(const edm::ParameterSet& conf) {}
+void TrackingTruthValid::beginJob() {}
 
 TrackingTruthValid::TrackingTruthValid(const edm::ParameterSet& conf)
   : runStandalone( conf.getParameter<bool>("runStandalone") )

--- a/Validation/TrackingMCTruth/plugins/TrackingTruthValid.cc
+++ b/Validation/TrackingMCTruth/plugins/TrackingTruthValid.cc
@@ -29,8 +29,6 @@ typedef TrackingVertex::genv_iterator                   genv_iterator;
 typedef TrackingVertex::g4v_iterator                     g4v_iterator;
 
 
-void TrackingTruthValid::beginJob() {}
-
 TrackingTruthValid::TrackingTruthValid(const edm::ParameterSet& conf)
   : runStandalone( conf.getParameter<bool>("runStandalone") )
   , outputFile( conf.getParameter<std::string>( "outputFile" ) )


### PR DESCRIPTION
Validation/TrackingMCTruth/interface/TrackingTruthValid.h:26:8: warning: 'TrackingTruthValid::beginJob' hides overloaded virtual functions [-Woverloaded-virtual]

Validation/TrackingMCTruth/interface/TrackingTruthValid.h:27:8: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   void endJob();
       ^