### PR TITLE
Kinfitter available from python

### DIFF
--- a/PhysicsTools/KinFitter/interface/TFitConstraintEp.h
+++ b/PhysicsTools/KinFitter/interface/TFitConstraintEp.h
@@ -56,6 +56,7 @@ private:
   Double_t _constraint;                   // Value of constraint
   TFitConstraintEp::component _component; // 4vector component to be constrained
 
+  ClassDef(TFitConstraintEp, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitConstraintM.h
+++ b/PhysicsTools/KinFitter/interface/TFitConstraintM.h
@@ -50,7 +50,10 @@ protected :
   std::vector<TAbsFitParticle*> _ParList1;   // Vector containing first list of constrained particles ( sum[ m_i ] - sum[ m_j ] == 0 )
   std::vector<TAbsFitParticle*> _ParList2;   // Vector containing second list of constrained particles ( sum[ m_i ] - sum[ m_j ] == 0 )
   Double_t _TheMassConstraint;
-  
+
+private :
+
+  ClassDef(TFitConstraintM, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitConstraintMGaus.h
+++ b/PhysicsTools/KinFitter/interface/TFitConstraintMGaus.h
@@ -37,7 +37,9 @@ protected :
 
   void init();
 
+private :
 
+  ClassDef(TFitConstraintMGaus, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleCart.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleCart.h
@@ -34,7 +34,8 @@ protected :
 
 
 private:
-  
+
+  ClassDef(TFitParticleCart, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleECart.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleECart.h
@@ -34,7 +34,8 @@ protected :
 
 
 private:
-  
+
+  ClassDef(TFitParticleECart, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleEMomDev.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleEMomDev.h
@@ -36,7 +36,8 @@ protected :
 
 
 private:
-  
+
+  ClassDef(TFitParticleEMomDev, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleEScaledMomDev.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleEScaledMomDev.h
@@ -30,6 +30,9 @@ protected :
 
   void init(TLorentzVector* pini, const TMatrixD* theCovMatrix);
 
+private :
+
+  ClassDef(TFitParticleEScaledMomDev, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleESpher.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleESpher.h
@@ -34,7 +34,8 @@ protected :
 
 
 private:
-  
+
+  ClassDef(TFitParticleESpher, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleEtEtaPhi.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleEtEtaPhi.h
@@ -34,7 +34,8 @@ protected :
 
 
 private:
-  
+
+  ClassDef(TFitParticleEtEtaPhi, 0)
 };
 
 

--- a/PhysicsTools/KinFitter/interface/TFitParticleEtThetaPhi.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleEtThetaPhi.h
@@ -34,7 +34,8 @@ protected :
 
 
 private:
-  
+
+  ClassDef(TFitParticleEtThetaPhi, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleMCCart.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleMCCart.h
@@ -31,8 +31,10 @@ protected :
 
   void init(TVector3* p, Double_t M, const TMatrixD* theCovMatrix);
 
-  
+
 private:
+
+  ClassDef(TFitParticleMCCart, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleMCMomDev.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleMCMomDev.h
@@ -32,8 +32,10 @@ protected :
 
   void init(TVector3* p, Double_t M, const TMatrixD* theCovMatrix);
 
-  
+
 private:
+
+  ClassDef(TFitParticleMCMomDev, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleMCPInvSpher.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleMCPInvSpher.h
@@ -31,8 +31,10 @@ protected :
 
   void init(TVector3* p, Double_t M, const TMatrixD* theCovMatrix);
 
-  
+
 private:
+
+  ClassDef(TFitParticleMCPInvSpher, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleMCSpher.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleMCSpher.h
@@ -31,8 +31,10 @@ protected :
 
   void init(TVector3* p, Double_t M, const TMatrixD* theCovMatrix);
 
-  
+
 private:
+
+  ClassDef(TFitParticleMCSpher, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleMomDev.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleMomDev.h
@@ -36,7 +36,8 @@ protected :
 
 
 private:
-  
+
+  ClassDef(TFitParticleMomDev, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleSpher.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleSpher.h
@@ -34,7 +34,8 @@ protected :
 
 
 private:
-  
+
+  ClassDef(TFitParticleSpher, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TKinFitter.h
+++ b/PhysicsTools/KinFitter/interface/TKinFitter.h
@@ -148,6 +148,7 @@ private :
   Int_t _status;        // Status of the last fit;_
   Int_t _nbIter;        // number of iteration performed in the fit
 
+  ClassDef(TKinFitter, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TSLToyGen.h
+++ b/PhysicsTools/KinFitter/interface/TSLToyGen.h
@@ -92,6 +92,7 @@ private :
   Bool_t _withMPDGCons;
   Bool_t _doCheckConstraintsTruth;
 
+  ClassDef(TSLToyGen, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/src/classes.h
+++ b/PhysicsTools/KinFitter/src/classes.h
@@ -1,0 +1,47 @@
+#include "PhysicsTools/KinFitter/interface/TAbsFitConstraint.h"
+#include "PhysicsTools/KinFitter/interface/TAbsFitParticle.h"
+#include "PhysicsTools/KinFitter/interface/TFitConstraintEp.h"
+#include "PhysicsTools/KinFitter/interface/TFitConstraintM.h"
+#include "PhysicsTools/KinFitter/interface/TFitConstraintMGaus.h"
+#include "PhysicsTools/KinFitter/interface/TFitParticleCart.h"
+#include "PhysicsTools/KinFitter/interface/TFitParticleECart.h"
+#include "PhysicsTools/KinFitter/interface/TFitParticleEMomDev.h"
+#include "PhysicsTools/KinFitter/interface/TFitParticleEScaledMomDev.h"
+#include "PhysicsTools/KinFitter/interface/TFitParticleESpher.h"
+#include "PhysicsTools/KinFitter/interface/TFitParticleEtEtaPhi.h"
+#include "PhysicsTools/KinFitter/interface/TFitParticleEtThetaPhi.h"
+#include "PhysicsTools/KinFitter/interface/TFitParticleMCCart.h"
+#include "PhysicsTools/KinFitter/interface/TFitParticleMCMomDev.h"
+#include "PhysicsTools/KinFitter/interface/TFitParticleMCPInvSpher.h"
+#include "PhysicsTools/KinFitter/interface/TFitParticleMCSpher.h"
+#include "PhysicsTools/KinFitter/interface/TFitParticleMomDev.h"
+#include "PhysicsTools/KinFitter/interface/TFitParticleSpher.h"
+#include "PhysicsTools/KinFitter/interface/TKinFitter.h"
+#include "PhysicsTools/KinFitter/interface/TSLToyGen.h"
+
+
+namespace PhysicsTools_KinFitter {
+  struct dictionary {
+
+//     TFitConstraintEp fce;
+//     TFitConstraintEp::component fce_c;
+//     TFitConstraintM fcm;
+//     TFitConstraintMGaus fcmg;
+//     TFitParticleCart fpc;
+//     TFitParticleECart fpec;
+//     TFitParticleEMomDev fpemd;
+//     TFitParticleEScaledMomDev fpesmd;
+//     TFitParticleESpher fpes;
+//     TFitParticleEtEtaPhi fpeep;
+//     TFitParticleEtThetaPhi fpetp;
+//     TFitParticleMCCart fpmcc;
+//     TFitParticleMCMomDev fmmccd;
+//     TFitParticleMCPInvSpher fpmcpis;
+//     TFitParticleMCSpher fpmcs;
+//     TFitParticleMomDev fpmd;
+//     TFitParticleSpher fps;
+//     TKinFitter kf;
+//     TSLToyGen sltg;
+
+  };
+}

--- a/PhysicsTools/KinFitter/src/classes.h
+++ b/PhysicsTools/KinFitter/src/classes.h
@@ -23,25 +23,25 @@
 namespace PhysicsTools_KinFitter {
   struct dictionary {
 
-//     TFitConstraintEp fce;
-//     TFitConstraintEp::component fce_c;
-//     TFitConstraintM fcm;
-//     TFitConstraintMGaus fcmg;
-//     TFitParticleCart fpc;
-//     TFitParticleECart fpec;
-//     TFitParticleEMomDev fpemd;
-//     TFitParticleEScaledMomDev fpesmd;
-//     TFitParticleESpher fpes;
-//     TFitParticleEtEtaPhi fpeep;
-//     TFitParticleEtThetaPhi fpetp;
-//     TFitParticleMCCart fpmcc;
-//     TFitParticleMCMomDev fmmccd;
-//     TFitParticleMCPInvSpher fpmcpis;
-//     TFitParticleMCSpher fpmcs;
-//     TFitParticleMomDev fpmd;
-//     TFitParticleSpher fps;
-//     TKinFitter kf;
-//     TSLToyGen sltg;
+     TFitConstraintEp fce;
+     TFitConstraintEp::component fce_c;
+     TFitConstraintM fcm;
+     TFitConstraintMGaus fcmg;
+     TFitParticleCart fpc;
+     TFitParticleECart fpec;
+     TFitParticleEMomDev fpemd;
+     TFitParticleEScaledMomDev fpesmd;
+     TFitParticleESpher fpes;
+     TFitParticleEtEtaPhi fpeep;
+     TFitParticleEtThetaPhi fpetp;
+     TFitParticleMCCart fpmcc;
+     TFitParticleMCMomDev fmmccd;
+     TFitParticleMCPInvSpher fpmcpis;
+     TFitParticleMCSpher fpmcs;
+     TFitParticleMomDev fpmd;
+     TFitParticleSpher fps;
+     TKinFitter kf;
+     TSLToyGen sltg;
 
   };
 }

--- a/PhysicsTools/KinFitter/src/classes_def.xml
+++ b/PhysicsTools/KinFitter/src/classes_def.xml
@@ -1,0 +1,20 @@
+<lcgdict>
+    <class name="TFitConstraintEp" class_version="0"/>
+    <class name="TFitConstraintM" class_version="0"/>
+    <class name="TFitConstraintMGaus" class_version="0"/>
+    <class name="TFitParticleCart" class_version="0"/>
+    <class name="TFitParticleECart" class_version="0"/>
+    <class name="TFitParticleEMomDev" class_version="0"/>
+    <class name="TFitParticleEScaledMomDev" class_version="0"/>
+    <class name="TFitParticleESpher" class_version="0"/>
+    <class name="TFitParticleEtEtaPhi" class_version="0"/>
+    <class name="TFitParticleEtThetaPhi" class_version="0"/>
+    <class name="TFitParticleMCCart" class_version="0"/>
+    <class name="TFitParticleMCMomDev" class_version="0"/>
+    <class name="TFitParticleMCPInvSpher" class_version="0"/>
+    <class name="TFitParticleMCSpher" class_version="0"/>
+    <class name="TFitParticleMomDev" class_version="0"/>
+    <class name="TFitParticleSpher" class_version="0"/>
+    <class name="TKinFitter" class_version="0"/>
+    <class name="TSLToyGen" class_version="0"/>
+</lcgdict>


### PR DESCRIPTION
Adding ClassDef's, classes.h and classes_def.xml in order to make TKinFitter and related classes available from python. This is practical for development, e.g. with jupyter notebooks.