### PR TITLE
Validation/RecoParticleFlow: Cleanup clang warning:

### DIFF
--- a/Validation/RecoParticleFlow/bin/include/HistoData.h
+++ b/Validation/RecoParticleFlow/bin/include/HistoData.h
@@ -90,7 +90,7 @@ public:
 
   // Misc Functions
   void drawResult(TH1 *Summary, bool Vertical = true, bool SetLabels = false);
-  void clear() { memset(this,0,sizeof(*this)); }
+  void clear() { memset(static_cast<void *>(this),0,sizeof(*this)); }
   inline void dump();
 
 private:

--- a/Validation/RecoParticleFlow/bin/include/HistoData.h
+++ b/Validation/RecoParticleFlow/bin/include/HistoData.h
@@ -3,9 +3,9 @@
 
 #include <string>
 #include <cstring>
+#include <TH1.h>
+#include <TFile.h>
 
-class TFile;
-class TH1;
 
 class HistoData {
 public:
@@ -90,7 +90,7 @@ public:
 
   // Misc Functions
   void drawResult(TH1 *Summary, bool Vertical = true, bool SetLabels = false);
-  void clear() { memset(static_cast<void *>(this),0,sizeof(*this)); }
+  void clear(){ newHisto->Clear(); refHisto->Clear(); };
   inline void dump();
 
 private:


### PR DESCRIPTION
Apply the change suggested by compiler.

bin/include/HistoData.h:93:25: warning: destination for this 'memset' call is a pointer to dynamic class 'HistoData'; vtable pointer will be overwritten [-Wdynamic-class-memaccess]
   void clear() { memset(this,0,sizeof(*this)); }
                 ~~~~~~ ^

src/Validation/RecoParticleFlow/bin/include/HistoData.h:93:25: note: explicitly cast the pointer to silence this warning
  void clear() { memset(this,0,sizeof(*this)); }
                        ^
                        (void*)
