### PR TITLE
AnalysisDataFormats/TopObjects: Fix bug found by clang warning:

### DIFF
--- a/AnalysisDataFormats/TopObjects/interface/TtDilepEvtSolution.h
+++ b/AnalysisDataFormats/TopObjects/interface/TtDilepEvtSolution.h
@@ -81,7 +81,7 @@ class TtDilepEvtSolution {
   //-------------------------------------------
   double getJetResidual()    const;
   double getLeptonResidual() const;
-  double getFullResidual()   const { return getJetResidual()+getFullResidual(); }
+  double getFullResidual()   const { return getJetResidual()+getLeptonResidual(); }
   bool   getBestSol()      const { return bestSol_; }
   double getRecTopMass()   const {return topmass_; }
   double getRecWeightMax() const {return weightmax_; }


### PR DESCRIPTION
AnalysisDataFormats/TopObjects/interface/TtDilepEvtSolution.h:84:36: warning: all paths through this function will call itself [-Winfinite-recursion]
   double getFullResidual()   const { return getJetResidual()+getFullResidual(); }
                                   ^

I beleive the bug was introduced in commit
https://github.com/cms-sw/cmssw/commit/065ecddd40bbd619b1756736ba4587c4589cef50

-  double getResidual()     const;
 +  double getJetResidual()    const;
 +  double getLeptonResidual() const;
 +  double getFullResidual()   const { return getJetResidual()+getFullResidual(); }
