### PR TITLE
TopQuarkAnalysis packages: clean up clang warnings:

### DIFF
--- a/TopQuarkAnalysis/TopPairBSM/src/BoostedTopProducer.cc
+++ b/TopQuarkAnalysis/TopPairBSM/src/BoostedTopProducer.cc
@@ -370,17 +370,6 @@ BoostedTopProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void
-BoostedTopProducer::beginJob(const edm::EventSetup&)
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void
-BoostedTopProducer::endJob() {
-}
-
 double
 BoostedTopProducer::Psi(const TLorentzVector& p1, const TLorentzVector& p2, double mass) {
 

--- a/TopQuarkAnalysis/TopPairBSM/src/BoostedTopProducer.h
+++ b/TopQuarkAnalysis/TopPairBSM/src/BoostedTopProducer.h
@@ -86,9 +86,7 @@ class BoostedTopProducer : public edm::EDProducer {
       ~BoostedTopProducer() override;
 
    private:
-      virtual void beginJob(const edm::EventSetup&) ;
       void produce(edm::Event&, const edm::EventSetup&) override;
-      void endJob() override ;
 
       // ----------member data ---------------------------
 


### PR DESCRIPTION
TopQuarkAnalysis/TopPairBSM/src/BoostedTopProducer.h:89:20: warning: 'BoostedTopProducer::beginJob' hides overloaded virtual function [-Woverloaded-virtual]
       virtual void beginJob(const edm::EventSetup&) ;
                   ^

Remove empty functions.