### PR TITLE
SimG4Core packages: clean up clang warnings:

### DIFF
--- a/SimG4Core/HelpfulWatchers/src/G4StepStatistics.h
+++ b/SimG4Core/HelpfulWatchers/src/G4StepStatistics.h
@@ -126,7 +126,7 @@ class StepID {
 };
 
 #define OBSERVES(type) public Observer<const type*>
-#define UPDATE(type) void update(const type*) { std::cout <<"++ signal " #type<<std::endl; }
+#define UPDATE(type) void update(const type*) override { std::cout <<"++ signal " #type<<std::endl; }
 class G4StepStatistics : public SimWatcher, 
 OBSERVES(DDDWorld),
 OBSERVES(BeginOfJob),

--- a/SimG4Core/HelpfulWatchers/src/SimTracer.h
+++ b/SimG4Core/HelpfulWatchers/src/SimTracer.h
@@ -40,7 +40,7 @@ class EndOfEvent;
 class EndOfTrack;
 
 #define OBSERVES(type) public Observer<const type*>
-#define UPDATE(type) void update(const type*) { std::cout <<"++ signal " #type<<std::endl; }
+#define UPDATE(type) void update(const type*) override { std::cout <<"++ signal " #type<<std::endl; }
 class SimTracer : public SimWatcher, 
 OBSERVES(DDDWorld),
 OBSERVES(BeginOfJob),

--- a/SimG4Core/PhysicsLists/interface/CMSFTFPNeutronBuilder.hh
+++ b/SimG4Core/PhysicsLists/interface/CMSFTFPNeutronBuilder.hh
@@ -30,8 +30,8 @@ class CMSFTFPNeutronBuilder : public G4VNeutronBuilder
     void Build(G4HadronCaptureProcess * aP) override;
     void Build(G4NeutronInelasticProcess * aP) override;
     
-    void SetMinEnergy(G4double aM) {theMin = aM;}
-    void SetMaxEnergy(G4double aM) {theMax = aM;}
+    void SetMinEnergy(G4double aM) override {theMin = aM;}
+    void SetMaxEnergy(G4double aM) override {theMax = aM;}
 
   private:
     G4TheoFSGenerator * theModel;

--- a/SimG4Core/PhysicsLists/interface/CMSFTFPPiKBuilder.hh
+++ b/SimG4Core/PhysicsLists/interface/CMSFTFPPiKBuilder.hh
@@ -35,8 +35,8 @@ class CMSFTFPPiKBuilder : public G4VPiKBuilder
     void Build(G4KaonZeroLInelasticProcess * aP) override;
     void Build(G4KaonZeroSInelasticProcess * aP) override;
     
-    void SetMinEnergy(G4double aM) {theMin = aM;}
-    void SetMaxEnergy(G4double aM) {theMax = aM;}
+    void SetMinEnergy(G4double aM) override {theMin = aM;}
+    void SetMaxEnergy(G4double aM) override {theMax = aM;}
 
   private:
     G4TheoFSGenerator * theModel;

--- a/SimG4Core/PhysicsLists/interface/CMSFTFPProtonBuilder.hh
+++ b/SimG4Core/PhysicsLists/interface/CMSFTFPProtonBuilder.hh
@@ -28,8 +28,8 @@ class CMSFTFPProtonBuilder : public G4VProtonBuilder
     void Build(G4HadronElasticProcess * aP) override;
     void Build(G4ProtonInelasticProcess * aP) override;
     
-    void SetMinEnergy(G4double aM) {theMin = aM;}
-    void SetMaxEnergy(G4double aM) {theMax = aM;}
+    void SetMinEnergy(G4double aM) override {theMin = aM;}
+    void SetMaxEnergy(G4double aM) override {theMax = aM;}
 
   private:
     G4TheoFSGenerator * theModel;


### PR DESCRIPTION
SimG4Core/HelpfulWatchers/src/SimTracer.h:67:1: warning: 'update' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
 UPDATE(DDDWorld)
^
SimG4Core/HelpfulWatchers/src/SimTracer.h:43:27: note: expanded from macro 'UPDATE'
                          ^

SimG4Core/HelpfulWatchers/src/G4StepStatistics.h:156:1: warning: 'update' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
 UPDATE(DDDWorld)
^

SimG4Core/HelpfulWatchers/src/G4StepStatistics.h:129:27: note: expanded from macro 'UPDATE'
                          ^

SimG4Core/PhysicsLists/interface/CMSFTFPNeutronBuilder.hh:33:10: warning: 'SetMinEnergy' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
     void SetMinEnergy(G4double aM) {theMin = aM;}
         ^

SimG4Core/PhysicsLists/interface/CMSFTFPNeutronBuilder.hh:34:10: warning: 'SetMaxEnergy' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
     void SetMaxEnergy(G4double aM) {theMax = aM;}
         ^

SimG4Core/PhysicsLists/interface/CMSFTFPPiKBuilder.hh:38:10: warning: 'SetMinEnergy' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
     void SetMinEnergy(G4double aM) {theMin = aM;}
         ^

SimG4Core/PhysicsLists/interface/CMSFTFPPiKBuilder.hh:39:10: warning: 'SetMaxEnergy' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
     void SetMaxEnergy(G4double aM) {theMax = aM;}
         ^

SimG4Core/PhysicsLists/interface/CMSFTFPProtonBuilder.hh:31:10: warning: 'SetMinEnergy' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
     void SetMinEnergy(G4double aM) {theMin = aM;}
         ^

SimG4Core/PhysicsLists/interface/CMSFTFPProtonBuilder.hh:32:10: warning: 'SetMaxEnergy' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
     void SetMaxEnergy(G4double aM) {theMax = aM;}
         ^