### PR TITLE
RecoHI/HiCentralityAlgos: cleanup clang warning:

### DIFF
--- a/RecoHI/HiCentralityAlgos/plugins/CentralityTableProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/CentralityTableProducer.cc
@@ -43,7 +43,6 @@ class CentralityTableProducer : public edm::EDAnalyzer {
       ~CentralityTableProducer() override;
 
    private:
-      virtual void beginRun(const edm::EventSetup&) ;
       void analyze(const edm::Event&, const edm::EventSetup&) override;
       void endJob() override ;
    void printBin(const CentralityTable::CBin*);
@@ -120,11 +119,6 @@ CentralityTableProducer::analyze(const edm::Event& iEvent, const edm::EventSetup
   }    
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-CentralityTableProducer::beginRun(const edm::EventSetup& iSetup)
-{
-}
 
 // ------------ method called once each job just after ending the event loop  ------------
 void 


### PR DESCRIPTION
RecoHI/HiCentralityAlgos/plugins/CentralityTableProducer.cc:46:20: warning: 'CentralityTableProducer::beginRun' hides overloaded virtual function [-Woverloaded-virtual]
       virtual void beginRun(const edm::EventSetup&) ;
                   ^