### PR TITLE
PhysicsTools/JetCharge: clean up clang warnings:

### DIFF
--- a/PhysicsTools/JetCharge/test/JetChargeAnalyzer.cc
+++ b/PhysicsTools/JetCharge/test/JetChargeAnalyzer.cc
@@ -37,7 +37,7 @@ class JetChargeAnalyzer : public edm::EDAnalyzer {
         explicit JetChargeAnalyzer(const edm::ParameterSet&);
         ~JetChargeAnalyzer() {}
 
-        virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+        virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
     private:
         // physics stuff
         edm::EDGetTokenT<JetChargeCollection>         srcToken_;

--- a/PhysicsTools/JetCharge/test/JetChargeAnalyzer.cc
+++ b/PhysicsTools/JetCharge/test/JetChargeAnalyzer.cc
@@ -38,7 +38,6 @@ class JetChargeAnalyzer : public edm::EDAnalyzer {
         ~JetChargeAnalyzer() {}
 
         virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
-        virtual void endJob(const edm::EventSetup& iSetup);
     private:
         // physics stuff
         edm::EDGetTokenT<JetChargeCollection>         srcToken_;
@@ -106,8 +105,6 @@ void JetChargeAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
     charge_[k]->Fill(hJC->value(i));
   }
 
-}
-void JetChargeAnalyzer::endJob(const edm::EventSetup& iSetup) {
 }
 
 DEFINE_FWK_MODULE(JetChargeAnalyzer);


### PR DESCRIPTION
PhysicsTools/JetCharge/test/JetChargeAnalyzer.cc:41:22: warning: 'JetChargeAnalyzer::endJob' hides overloaded virtual function [-Woverloaded-virtual]
         virtual void endJob(const edm::EventSetup& iSetup);
                     ^