### PR TITLE
HLTriggerOffline packages: clean up clang warnings:

### DIFF
--- a/HLTriggerOffline/Egamma/interface/EmDQM.h
+++ b/HLTriggerOffline/Egamma/interface/EmDQM.h
@@ -76,8 +76,6 @@ public:
   // Operations
 
   void analyze(const edm::Event & event, const edm::EventSetup&) override;
-  void beginJob();
-  void endJob();
 
   void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;

--- a/HLTriggerOffline/Egamma/src/EmDQM.cc
+++ b/HLTriggerOffline/Egamma/src/EmDQM.cc
@@ -62,14 +62,6 @@ EmDQM::EmDQM(const edm::ParameterSet& pset_) : pset(pset_)
   }
 }
 
-////////////////////////////////////////////////////////////////////////////////
-//       method called once each job just before starting event loop          //
-////////////////////////////////////////////////////////////////////////////////
-void 
-EmDQM::beginJob()
-{
-
-}
 
 void 
 EmDQM::dqmBeginRun(edm::Run const &iRun, edm::EventSetup const &iSetup)
@@ -1084,14 +1076,6 @@ EmDQM::endRun(edm::Run const &iRun, edm::EventSetup const &iSetup)
            edm::LogPrint("EmDQM") << "  " << tag;
       }
    }
-}
-
-//////////////////////////////////////////////////////////////////////////////// 
-//      method called once each job just after ending the event loop          //
-//////////////////////////////////////////////////////////////////////////////// 
-void EmDQM::endJob()
-{
-
 }
 
 // returns count of non-overlapping occurrences of 'sub' in 'str'

--- a/HLTriggerOffline/Exotica/interface/HLTExoticaValidator.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaValidator.h
@@ -46,13 +46,13 @@ protected:
     void bookHistograms(DQMStore::IBooker &iBooker, const edm::Run &iRun, const edm::EventSetup &iSetup) override;
 
 private:
-    virtual void beginJob();
+    void beginJob() override;
     /// Method called by the framework just before dqmBeginRun()
     void dqmBeginRun(const edm::Run &iRun, const edm::EventSetup & iSetup) override;
     /// Method called for each event.
     void analyze(const edm::Event & iEvent, const edm::EventSetup & iSetup) override;
     void endRun(const edm::Run & iRun, const edm::EventSetup & iSetup) override;
-    virtual void endJob();
+    void endJob() override;
 
     /// Copy (to be modified) of the input ParameterSet from configuration file.
     edm::ParameterSet _pset;

--- a/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
@@ -48,12 +48,10 @@ public:
 private:
 
   // Analyzer Methods
-  virtual void beginJob();
   void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void endRun(const edm::Run &, const edm::EventSetup &) override;
-  virtual void endJob();
 
   // Extra Methods
   std::vector<std::string> moduleLabels(std::string);
@@ -236,13 +234,6 @@ HLTMuonValidator::analyze(const Event& iEvent,
 
 
 
-void 
-HLTMuonValidator::beginJob()
-{
-
-}
-
-
 
 void 
 HLTMuonValidator::endRun(const edm::Run & iRun, 
@@ -257,12 +248,6 @@ HLTMuonValidator::endRun(const edm::Run & iRun,
 }
 
 
-
-void 
-HLTMuonValidator::endJob()
-{
-
-}
 
 
 


### PR DESCRIPTION
HLTriggerOffline/Egamma/interface/EmDQM.h:79:8: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   void beginJob();
       ^

HLTriggerOffline/Egamma/interface/EmDQM.h:80:8: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   void endJob();
       ^

HLTriggerOffline/Exotica/interface/HLTExoticaValidator.h:49:18: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
     virtual void beginJob();
                 ^

HLTriggerOffline/Exotica/interface/HLTExoticaValidator.h:55:18: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
     virtual void endJob();
                 ^

HLTriggerOffline/Muon/src/HLTMuonValidator.cc:51:16: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void beginJob();
               ^

HLTriggerOffline/Muon/src/HLTMuonValidator.cc:56:16: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void endJob();
               ^