### PR TITLE
DQMOffline packages: Cleanup clang warnings:

### DIFF
--- a/DQMOffline/Hcal/interface/CaloTowersAnalyzer.h
+++ b/DQMOffline/Hcal/interface/CaloTowersAnalyzer.h
@@ -44,8 +44,8 @@ class CaloTowersAnalyzer : public DQMEDAnalyzer {
   ~CaloTowersAnalyzer() override;
   
   void analyze(edm::Event const& e, edm::EventSetup const& c) override;
-  virtual void beginJob() ;
-  virtual void endJob() ;
+  void beginJob() override;
+  void endJob() override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void dqmBeginRun(const edm::Run& run, const edm::EventSetup& c) override;
 

--- a/DQMOffline/Hcal/interface/HcalNoiseRates.h
+++ b/DQMOffline/Hcal/interface/HcalNoiseRates.h
@@ -49,9 +49,9 @@ class HcalNoiseRates : public DQMEDAnalyzer {
   
   
  private:
-  virtual void beginJob();
+  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob();
+  void endJob() override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   std::string outputFile_;

--- a/DQMOffline/PFTau/plugins/MatchMETBenchmarkAnalyzer.h
+++ b/DQMOffline/PFTau/plugins/MatchMETBenchmarkAnalyzer.h
@@ -14,7 +14,6 @@ class MatchMETBenchmarkAnalyzer: public BenchmarkAnalyzer, public MatchMETBenchm
   MatchMETBenchmarkAnalyzer(const edm::ParameterSet& parameterSet);
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void beginJob(){};
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
  protected:

--- a/DQMOffline/Trigger/src/HLTMuonOfflineAnalyzer.cc
+++ b/DQMOffline/Trigger/src/HLTMuonOfflineAnalyzer.cc
@@ -50,12 +50,10 @@ public:
 private:
 
   // Analyzer Methods
-  virtual void beginJob();
   void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;  
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void endRun(const edm::Run &, const edm::EventSetup &) override;
-  virtual void endJob();
 
   // Extra Methods
   std::vector<std::string> moduleLabels(const std::string&);
@@ -190,12 +188,6 @@ HLTMuonOfflineAnalyzer::analyze(const Event& iEvent,
 
 
 
-void 
-HLTMuonOfflineAnalyzer::beginJob()
-{
-  
-}
-
 
 
 void 
@@ -208,12 +200,6 @@ HLTMuonOfflineAnalyzer::endRun(const edm::Run & iRun,
 }
 
 
-
-void 
-HLTMuonOfflineAnalyzer::endJob()
-{
-  
-}
 
 
 


### PR DESCRIPTION
DQMOffline/Trigger/src/HLTMuonOfflineAnalyzer.cc:53:16: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void beginJob();
               ^

DQMOffline/Trigger/src/HLTMuonOfflineAnalyzer.cc:58:16: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void endJob();
               ^

DQMOffline/PFTau/plugins/MatchMETBenchmarkAnalyzer.h:17:8: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   void beginJob(){};
       ^

DQMOffline/PFTau/plugins/MatchMETBenchmarkAnalyzer.h:17:8: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   void beginJob(){};
       ^

DQMOffline/Hcal/interface/CaloTowersAnalyzer.h:47:16: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void beginJob() ;
               ^

DQMOffline/Hcal/interface/CaloTowersAnalyzer.h:48:16: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void endJob() ;
               ^

DQMOffline/Hcal/interface/HcalNoiseRates.h:52:16: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void beginJob();
               ^

DQMOffline/Hcal/interface/HcalNoiseRates.h:54:16: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void endJob();
               ^