### PR TITLE
DQM Packages: clean up clang warnings:

### DIFF
--- a/DQM/EcalPreshowerMonitorModule/interface/ESFEDIntegrityTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESFEDIntegrityTask.h
@@ -26,7 +26,7 @@ class ESFEDIntegrityTask : public DQMEDAnalyzer {
   /// Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-  void endJob();
+  void endJob() override;
   
  private:
   

--- a/DQM/EcalPreshowerMonitorModule/interface/ESIntegrityTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESIntegrityTask.h
@@ -25,7 +25,7 @@ class ESIntegrityTask : public DQMEDAnalyzer {
       void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
       /// EndJob
-      void endJob(void);
+      void endJob(void) override;
 
       /// EndRun
       void endRun(const edm::Run & r, const edm::EventSetup & c) override;

--- a/DQM/EcalPreshowerMonitorModule/interface/ESPedestalTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESPedestalTask.h
@@ -22,7 +22,7 @@ class ESPedestalTask : public DQMEDAnalyzer {
 
       void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
       void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob(void);
+      void endJob(void) override;
 
       edm::EDGetTokenT<ESDigiCollection> digitoken_;
       edm::FileInPath lookup_;

--- a/DQM/EcalPreshowerMonitorModule/interface/ESRawDataTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESRawDataTask.h
@@ -25,7 +25,7 @@ class ESRawDataTask : public DQMEDAnalyzer {
       void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
       /// EndJob
-      void endJob(void);
+      void endJob(void) override;
 
       /// Setup
       void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorPedestals.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorPedestals.h
@@ -58,10 +58,9 @@ class SiStripMonitorPedestals : public DQMEDAnalyzer {
   explicit SiStripMonitorPedestals(const edm::ParameterSet&);
   ~SiStripMonitorPedestals() override;
   
-  virtual void beginJob() ;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
-  virtual void endJob();
+  void endJob() override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
    
  private:

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h
@@ -49,11 +49,10 @@ class SiStripMonitorQuality : public DQMEDAnalyzer {
   explicit SiStripMonitorQuality(const edm::ParameterSet&);
   ~SiStripMonitorQuality() override;
   
-  virtual void beginJob() ;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
-  virtual void endJob() ;
+  void endJob() override;
   
   
  private:

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h
@@ -51,11 +51,10 @@ class SiStripMonitorRawData : public DQMEDAnalyzer {
   explicit SiStripMonitorRawData(const edm::ParameterSet&);
   ~SiStripMonitorRawData() override;
   
-  virtual void beginJob() ;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
-  virtual void endJob() ;
+  void endJob() override;
   
   
  private:

--- a/DQM/SiStripMonitorPedestals/src/SiStripMonitorPedestals.cc
+++ b/DQM/SiStripMonitorPedestals/src/SiStripMonitorPedestals.cc
@@ -85,11 +85,6 @@ SiStripMonitorPedestals::~SiStripMonitorPedestals()
   if (apvFactory_) {delete apvFactory_;} 
 }
 //
-// -- Begin Job
-//
-void SiStripMonitorPedestals::beginJob() {
-}
-//
 // -- BeginRun
 //
 

--- a/DQM/SiStripMonitorPedestals/src/SiStripMonitorQuality.cc
+++ b/DQM/SiStripMonitorPedestals/src/SiStripMonitorQuality.cc
@@ -59,11 +59,6 @@ SiStripMonitorQuality::~SiStripMonitorQuality()
 					  << " Destructing....... ";     
 }
 //
-// -- Begin Job
-//
-void SiStripMonitorQuality::beginJob() {
-}
-//
 void SiStripMonitorQuality::bookHistograms(DQMStore::IBooker & ibooker , const edm::Run & run, const edm::EventSetup & eSetup){
 
   unsigned long long cacheID = eSetup.get<SiStripQualityRcd>().cacheIdentifier();  

--- a/DQM/SiStripMonitorPedestals/src/SiStripMonitorRawData.cc
+++ b/DQM/SiStripMonitorPedestals/src/SiStripMonitorRawData.cc
@@ -63,11 +63,6 @@ SiStripMonitorRawData::~SiStripMonitorRawData()
 					  << " Destructing....... ";     
 }
 //
-// -- Begin Job
-//
-void SiStripMonitorRawData::beginJob() {
-}
-//
 // -- BeginRun
 //
 

--- a/DQM/TrackingMonitor/interface/LogMessageMonitor.h
+++ b/DQM/TrackingMonitor/interface/LogMessageMonitor.h
@@ -61,7 +61,7 @@ class LogMessageMonitor : public DQMEDAnalyzer {
    private:
   //      virtual void beginJob() ;
       void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
+      void endJob() override;
 
   //      virtual void beginRun(edm::Run const&, edm::EventSetup const&);
       void endRun(edm::Run const&, edm::EventSetup const&) override;

--- a/DQM/TrackingMonitor/interface/TrackEfficiencyMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackEfficiencyMonitor.h
@@ -46,8 +46,8 @@ class TrackEfficiencyMonitor : public DQMEDAnalyzer {
       typedef reco::TrackCollection TrackCollection;
       explicit TrackEfficiencyMonitor(const edm::ParameterSet&);
       ~TrackEfficiencyMonitor() override;
-      virtual void beginJob(void);
-      virtual void endJob(void);
+      void beginJob(void) override;
+      void endJob(void) override;
       void analyze(const edm::Event&, const edm::EventSetup&) override;
 
       void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -65,7 +65,6 @@ class TrackingMonitor : public DQMEDAnalyzer
 
         explicit TrackingMonitor(const edm::ParameterSet&);
         ~TrackingMonitor() override;
-        virtual void beginJob(void);
 
 	virtual void setMaxMinBin(std::vector<double> & ,std::vector<double> &  ,std::vector<int> &  ,double, double, int, double, double, int);
 	virtual void setNclus(const edm::Event&, std::vector<int> & );

--- a/DQM/TrackingMonitor/interface/dEdxAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/dEdxAnalyzer.h
@@ -39,10 +39,8 @@ class dEdxAnalyzer : public DQMEDAnalyzer {
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
-  virtual void beginJob();
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-  virtual void endJob() ;
-
+  void endJob() override;
   double mass(double P, double I);
   
   //  virtual void beginRun(const edm::Run&, const edm::EventSetup&); 

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -229,7 +229,7 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
    MEFolderName = conf->getParameter<std::string>("FolderName"); 
 
    // test for the Quality veriable validity
-   if( Quality_ != "") {
+   if( !Quality_.empty()) {
      if( Quality_ != "highPurity" && Quality_ != "tight" && Quality_ != "loose") {
        edm::LogWarning("TrackingMonitor")  << "Qualty Name is invalid, using no quality criterea by default";
        Quality_ = "";
@@ -237,7 +237,7 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
    }
 
    // use the AlgoName and Quality Name
-   std::string CategoryName = Quality_ != "" ? AlgoName_ + "_" + Quality_ : AlgoName_;
+   std::string CategoryName = !Quality_.empty() ? AlgoName_ + "_" + Quality_ : AlgoName_;
 
    // get binning from the configuration
    int    TKNoBin     = conf->getParameter<int>(   "TkSizeBin");

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -216,11 +216,6 @@ TrackingMonitor::~TrackingMonitor()
 }
 
 
-void TrackingMonitor::beginJob(void) 
-{
-
-    
-}
 
 void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
 				     edm::Run const & iRun,

--- a/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
@@ -153,10 +153,6 @@ void dEdxAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
 
 }
 
-void dEdxAnalyzer::beginJob()
-{
-}
-
 
 double dEdxAnalyzer::mass(double P, double I){
    if(I-dEdxC<0)return -1;


### PR DESCRIPTION
DQM/EcalPreshowerMonitorModule/interface/ESPedestalTask.h:25:12: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
       void endJob(void);
           ^
DQM/EcalPreshowerMonitorModule/interface/ESIntegrityTask.h:28:12: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
       void endJob(void);
           ^
DQM/EcalPreshowerMonitorModule/interface/ESRawDataTask.h:28:12: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
       void endJob(void);
           ^
DQM/EcalPreshowerMonitorModule/interface/ESFEDIntegrityTask.h:29:8: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   void endJob();
       ^
DQM/EcalPreshowerMonitorModule/interface/ESTrendTask.h:35:8: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   void endJob(void);
       ^
DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h:52:16: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void beginJob() ;
               ^
DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h:56:16: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void endJob() ;
               ^
DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h:54:16: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void beginJob() ;
               ^
DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h:58:16: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void endJob() ;
               ^
DQM/SiStripMonitorPedestals/interface/SiStripMonitorPedestals.h:61:16: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void beginJob() ;
               ^
DQM/SiStripMonitorPedestals/interface/SiStripMonitorPedestals.h:64:16: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void endJob();
               ^
DQM/TrackingMonitor/interface/TrackEfficiencyMonitor.h:49:20: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
       virtual void beginJob(void);
                   ^
DQM/TrackingMonitor/interface/TrackEfficiencyMonitor.h:50:20: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
       virtual void endJob(void);
                   ^
DQM/TrackingMonitor/interface/TrackingMonitor.h:68:22: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
         virtual void beginJob(void);
                     ^
DQM/TrackingMonitor/interface/LogMessageMonitor.h:64:20: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
       virtual void endJob() ;
                   ^
DQM/TrackingMonitor/interface/dEdxAnalyzer.h:42:16: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void beginJob();
               ^
DQM/TrackingMonitor/interface/dEdxAnalyzer.h:44:16: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual void endJob() ;
               ^