### PR TITLE
Calibration packages: cleanup clang warnings:

### DIFF
--- a/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLworker.h
+++ b/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLworker.h
@@ -41,10 +41,10 @@ public:
 
 
 private:
-    virtual void beginJob() ;
+    void beginJob() override;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;   
     void analyze(const edm::Event&, const edm::EventSetup&) override ;
-    virtual void endJob() ;
+    void endJob() override;
 
 
     edm::EDGetTokenT<EBDigiCollection> digiTokenEB_; 


### PR DESCRIPTION
Calibration/EcalCalibAlgos/interface/ECALpedestalPCLworker.h:44:18: warning: 'beginJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
     virtual void beginJob() ;
                 ^
Calibration/EcalCalibAlgos/interface/ECALpedestalPCLworker.h:47:18: warning: 'endJob' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
     virtual void endJob() ;
                 ^