### PR TITLE
Fix for Ecal O2O test

### DIFF
--- a/CondTools/Ecal/test/BuildFile.xml
+++ b/CondTools/Ecal/test/BuildFile.xml
@@ -24,6 +24,5 @@
   <test name="EcalTPGCrystalStatus_O2O_test" command="EcalTPGCrystalStatus_O2O_test.sh"/>
   <test name="EcalTPGTowerStatus_O2O_test" command="EcalTPGTowerStatus_O2O_test.sh"/>
   <test name="EcalADCToGeV_update_test" command="EcalADCToGeV_update_test.sh"/>
-  <test name="EcalIntercalib_update_test" command="EcalIntercalib_update_test.sh"/>
   <test name="EcalIntercalibConstants_O2O_test" command="EcalIntercalibConstants_O2O_test.sh"/>
 </architecture>


### PR DESCRIPTION
Removed execution of EcalIntercalib_update_test since it requires specific input file