### PR TITLE
Fix customiseForPremixingInput for DQM EDAnalyzer->EDProducer change

### DIFF
--- a/SimGeneral/DataMixingModule/python/customiseForPremixingInput.py
+++ b/SimGeneral/DataMixingModule/python/customiseForPremixingInput.py
@@ -21,6 +21,25 @@ def customiseForPreMixingInput(process):
     def replaceHcalTp(tag):
         replaceInputTag(tag, "simHcalTriggerPrimitiveDigis", "DMHcalTriggerPrimitiveDigis")
 
+    def replaceAnalyzer(label, analyzer):
+        if analyzer.type_() == "GlobalRecHitsAnalyzer":
+            replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
+            replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
+        if analyzer.type_() == "SiPixelTrackingRecHitsValid":
+            replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
+            replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
+        if analyzer.type_() == "SiStripTrackingRecHitsValid":
+            replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
+            replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
+        if analyzer.type_() == "SiPixelRecHitsValid":
+            replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
+            replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
+        if analyzer.type_() == "SiStripRecHitsValid":
+            replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
+            replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
+        if analyzer.type_() == "HcalDigisValidation":
+            replaceHcalTp(analyzer.dataTPs)
+
     for label, producer in process.producers_().iteritems():
         if producer.type_() == "ClusterTPAssociationProducer":
             replacePixelDigiSimLink(producer.pixelSimLinkSrc)
@@ -45,26 +64,11 @@ def customiseForPreMixingInput(process):
             producer.RPCdigisimlinkTag = cms.InputTag("mixData","RPCDigiSimLink")
             replacePixelDigiSimLink(producer.pixelSimLinkSrc)
             replaceStripDigiSimLink(producer.stripSimLinkSrc)
+        # Most of DQM analyzers are nowadays EDProducers
+        replaceAnalyzer(label, producer)
 
     for label, analyzer in process.analyzers_().iteritems():
-        if analyzer.type_() == "GlobalRecHitsAnalyzer":
-            replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
-            replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
-        if analyzer.type_() == "SiPixelTrackingRecHitsValid":
-            replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
-            replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
-        if analyzer.type_() == "SiStripTrackingRecHitsValid":
-            replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
-            replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
-        if analyzer.type_() == "SiPixelRecHitsValid":
-            replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
-            replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
-        if analyzer.type_() == "SiStripRecHitsValid":
-            replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
-            replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
-        if analyzer.type_() == "HcalDigisValidation":
-            replaceHcalTp(analyzer.dataTPs)
-
+        replaceAnalyzer(label, analyzer)
 
 
     return process


### PR DESCRIPTION
While trying to make a PR on premixing development (*), I noticed that the `customiseForPremixingInput` is not working in recent IBs for DQM analyzers. This is caused by the customize function looping over analyzers, while (most of) the DQM analyzers were transformed to producers in #22319. 

Tested in CMSSW_10_1_X_2018-03-05-2300, expect changes in the affected analyzers.

(*) that will replace the customize function with `premix_stage2` modifier, but I think it is better to fix the customize function first

@mdhildreth @kpedro88 
