### PR TITLE
Add puppi multiplicities to MiniAOD - 94X backport

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -407,10 +407,26 @@ def miniAOD_customizeCommon(process):
 
     task.add(process.slimmedJets)
     task.add(process.slimmedJetsAK8)
-    addToProcessAndTask('slimmedJetsPuppi', process.slimmedJetsNoDeepFlavour.clone(), process, task)
-    process.slimmedJetsPuppi.src = cms.InputTag("selectedPatJetsPuppi")    
-    process.slimmedJetsPuppi.packedPFCandidates = cms.InputTag("packedPFCandidates")
 
+    addToProcessAndTask('slimmedJetsPuppiNoMultiplicties', process.slimmedJetsNoDeepFlavour.clone(), process, task)
+    process.slimmedJetsPuppiNoMultiplicties.src = cms.InputTag("selectedPatJetsPuppi")
+    process.slimmedJetsPuppiNoMultiplicties.packedPFCandidates = cms.InputTag("packedPFCandidates")
+
+    from PhysicsTools.PatAlgos.patPuppiJetSpecificProducer_cfi import patPuppiJetSpecificProducer
+    process.patPuppiJetSpecificProducer = patPuppiJetSpecificProducer.clone(
+      src=cms.InputTag("slimmedJetsPuppiNoMultiplicties"),
+    )
+    task.add(process.patPuppiJetSpecificProducer)
+    updateJetCollection(
+       process,
+       labelName = 'PuppiJetSpecific',
+       jetSource = cms.InputTag('slimmedJetsPuppiNoMultiplicties'),
+    )
+    process.updatedPatJetsPuppiJetSpecific.userData.userFloats.src = ['patPuppiJetSpecificProducer:puppiMultiplicity', 'patPuppiJetSpecificProducer:neutralPuppiMultiplicity', 'patPuppiJetSpecificProducer:neutralHadronPuppiMultiplicity', 'patPuppiJetSpecificProducer:photonPuppiMultiplicity', 'patPuppiJetSpecificProducer:HFHadronPuppiMultiplicity', 'patPuppiJetSpecificProducer:HFEMPuppiMultiplicity' ]
+    process.slimmedJetsPuppi = process.updatedPatJetsPuppiJetSpecific.clone()
+    delattr(process, 'updatedPatJetsPuppiJetSpecific')
+
+    task.add(process.slimmedJetsPuppi)
     
     ## puppi met
     from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppies

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -408,19 +408,19 @@ def miniAOD_customizeCommon(process):
     task.add(process.slimmedJets)
     task.add(process.slimmedJetsAK8)
 
-    addToProcessAndTask('slimmedJetsPuppiNoMultiplicties', process.slimmedJetsNoDeepFlavour.clone(), process, task)
-    process.slimmedJetsPuppiNoMultiplicties.src = cms.InputTag("selectedPatJetsPuppi")
-    process.slimmedJetsPuppiNoMultiplicties.packedPFCandidates = cms.InputTag("packedPFCandidates")
+    addToProcessAndTask('slimmedJetsPuppiNoMultiplicities', process.slimmedJetsNoDeepFlavour.clone(), process, task)
+    process.slimmedJetsPuppiNoMultiplicities.src = cms.InputTag("selectedPatJetsPuppi")
+    process.slimmedJetsPuppiNoMultiplicities.packedPFCandidates = cms.InputTag("packedPFCandidates")
 
     from PhysicsTools.PatAlgos.patPuppiJetSpecificProducer_cfi import patPuppiJetSpecificProducer
     process.patPuppiJetSpecificProducer = patPuppiJetSpecificProducer.clone(
-      src=cms.InputTag("slimmedJetsPuppiNoMultiplicties"),
+      src=cms.InputTag("slimmedJetsPuppiNoMultiplicities"),
     )
     task.add(process.patPuppiJetSpecificProducer)
     updateJetCollection(
        process,
        labelName = 'PuppiJetSpecific',
-       jetSource = cms.InputTag('slimmedJetsPuppiNoMultiplicties'),
+       jetSource = cms.InputTag('slimmedJetsPuppiNoMultiplicities'),
     )
     process.updatedPatJetsPuppiJetSpecific.userData.userFloats.src = ['patPuppiJetSpecificProducer:puppiMultiplicity', 'patPuppiJetSpecificProducer:neutralPuppiMultiplicity', 'patPuppiJetSpecificProducer:neutralHadronPuppiMultiplicity', 'patPuppiJetSpecificProducer:photonPuppiMultiplicity', 'patPuppiJetSpecificProducer:HFHadronPuppiMultiplicity', 'patPuppiJetSpecificProducer:HFEMPuppiMultiplicity' ]
     process.slimmedJetsPuppi = process.selectedUpdatedPatJetsPuppiJetSpecific.clone()

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -423,8 +423,8 @@ def miniAOD_customizeCommon(process):
        jetSource = cms.InputTag('slimmedJetsPuppiNoMultiplicties'),
     )
     process.updatedPatJetsPuppiJetSpecific.userData.userFloats.src = ['patPuppiJetSpecificProducer:puppiMultiplicity', 'patPuppiJetSpecificProducer:neutralPuppiMultiplicity', 'patPuppiJetSpecificProducer:neutralHadronPuppiMultiplicity', 'patPuppiJetSpecificProducer:photonPuppiMultiplicity', 'patPuppiJetSpecificProducer:HFHadronPuppiMultiplicity', 'patPuppiJetSpecificProducer:HFEMPuppiMultiplicity' ]
-    process.slimmedJetsPuppi = process.updatedPatJetsPuppiJetSpecific.clone()
-    delattr(process, 'updatedPatJetsPuppiJetSpecific')
+    process.slimmedJetsPuppi = process.selectedUpdatedPatJetsPuppiJetSpecific.clone()
+    delattr(process, 'selectedUpdatedPatJetsPuppiJetSpecific')
 
     task.add(process.slimmedJetsPuppi)
     


### PR DESCRIPTION
backport of #22396

PUPPI-weighted multiplicities were found useful to define pileup-safe jet ID criteria and will shortly be recommended for analyses as discussed during this presentation:
https://indico.cern.ch/event/707753/contributions/2905460/attachments/1607520/2551266/JetID_run2017_AK4_PUPPI_recommendations_27022018_v1.pdf
We would therefore like to include them into MiniAOD (and backport to 94 asap).

It was checked that the new userfloats are added correctly to the slimmedJetsPuppi collection running the standard MiniAOD sequence.

Timing and size was checked using test/patMiniAOD_standard_cfg.py with 1000 events of RelValZEE_13/GEN-SIM-RECO/PU25ns_92X_upgrade2017_realistic_v7-v1:

Without this PR:
TimeReport 0.000082 0.000082 0.000082 slimmedJetsPuppi
patJets_slimmedJetsPuppi__PAT. 5769.94 668.333

With this PR:
TimeReport 0.000235 0.000235 0.000235 slimmedJetsPuppi
TimeReport 0.000071 0.000071 0.000071 slimmedJetsPuppiNoMultiplicties
TimeReport 0.000054 0.000054 0.000054 patPuppiJetSpecificProducer
patJets_slimmedJetsPuppi__PAT. 6953.5 705.626