### PR TITLE
Enable premixing stage1 workflow for phase2

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -546,6 +546,40 @@ PREMIXEventContent.outputCommands.append('keep StripDigiSimLinkedmDetSetVector_s
 PREMIXEventContent.outputCommands.append('keep RPCDigiSimLinkedmDetSetVector_*_*_*')
 PREMIXEventContent.outputCommands.append('keep DTLayerIdDTDigiSimLinkMuonDigiCollection_*_*_*')
 fastSim.toModify(PREMIXEventContent, outputCommands = PREMIXEventContent.outputCommands+fastSimEC.extraPremixContent)
+# Phase2 essentially extends the content to DIGI
+# We could split this by subdetector-eras, but let's start with simple
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(PREMIXEventContent, outputCommands = PREMIXEventContent.outputCommands+[
+        # Tracker
+        'keep Phase2TrackerDigiedmDetSetVector_mix_*_*',
+        'keep *_simSiPixelDigis_*_*', # covers digis and digiSimLinks
+        # MTD
+        # ???
+        # ECAL
+        'keep *_simEcalDigis_ebDigis_*',
+        'keep ESDigiCollection_simEcalUnsuppressedDigis_*_*',
+        # HCAL
+        'keep *_simHcalDigis_*_*',
+        'keep ZDCDataFramesSorted_simHcalUnsuppressedDigis_*_*',
+        # HGCAL
+        'keep *_mix_HGCDigisEE_*',
+        'keep *_mix_HGCDigisHEfront_*',
+        'keep *_mix_HGCDigisHEback_*',
+        # DT
+        'keep *_simMuonDTDigis_*_*',
+        # CSC
+        'keep *_simMuonCSCDigis_*_*',
+        'keep *_simMuonCscTriggerPrimitiveDigis_*_*',
+        # RPC
+        'keep *_simMuonRPCDigis_*_*',
+        # GEM
+        'keep *_simMuonGEMDigis_*_*',
+        # ME0
+        'keep *_simMuonME0Digis_*_*',
+        # CaloParticles
+        'keep *_mix_MergedCaloTruth_*',
+])
+
 
 from Configuration.Eras.Modifier_hcalSkipPacker_cff import hcalSkipPacker
 hcalSkipPacker.toModify(PREMIXEventContent.outputCommands,

--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -14,7 +14,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 
 #2023 WFs to run in IB (TTbar, TTbar+Timing)
 numWFIB = [20034.0,20034.1,20034.11] #2023D17 w/ special tracking and timing workflows
-numWFIB.extend([20261.98]) # 2023D7 premixing stage1 (NuGun+PU)
+numWFIB.extend([20261.98]) # 2023D17 premixing stage1 (NuGun+PU)
 numWFIB.extend([20434.0]) #2023D19 (already has timing)
 numWFIB.extend([21234.0,21234.11]) #2023D21  
 for numWF in numWFIB:

--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -14,6 +14,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 
 #2023 WFs to run in IB (TTbar, TTbar+Timing)
 numWFIB = [20034.0,20034.1,20034.11] #2023D17 w/ special tracking and timing workflows
+numWFIB.extend([20261.98]) # 2023D7 premixing stage1 (NuGun+PU)
 numWFIB.extend([20434.0]) #2023D19 (already has timing)
 numWFIB.extend([21234.0,21234.11]) #2023D21  
 for numWF in numWFIB:

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2495,7 +2495,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                             '--eventcontent': 'PREMIX',
                             '--procModifiers': 'premix_stage1',
                            },
-                           upgradeStepDict[stepName][k]])
+                           PUDataSets[k2],upgradeStepDict[stepName][k]])
                 upgradeStepDict[stepNamePmx][k] = d
 
         for stepType in upgradeSteps.keys():

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2245,7 +2245,7 @@ defaultDataSets['2018']='CMSSW_10_0_2-100X_upgrade2018_realistic_v10-v'
 defaultDataSets['2018Design']='CMSSW_10_0_2-100X_upgrade2018_design_IdealBS_v6-v'
 #defaultDataSets['2019']=''
 #defaultDataSets['2019Design']=''
-defaultDataSets['2023D17']=''
+defaultDataSets['2023D17']='CMSSW_9_3_2-93X_upgrade2023_realistic_v2_2023D17noPU-v'
 defaultDataSets['2023D19']=''
 defaultDataSets['2023D21']=''
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2490,7 +2490,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
             if "GenSim" in step:
                 stepName = step + upgradeSteps['baseline']['suffix']
                 stepNamePmx = step.replace('GenSim', 'Premix') + 'PU' + upgradeSteps['Premix']['suffix']
-                d = merge([{'-s'            : 'GEN,SIM,DIGI:pdigi_valid,L1,DIGI2RAW',
+                d = merge([{'-s'            : 'GEN,SIM,DIGI:pdigi_valid,L1',
                             '--datatier'    : 'PREMIX',
                             '--eventcontent': 'PREMIX',
                             '--procModifiers': 'premix_stage1',


### PR DESCRIPTION
This PR enables premixing stage1 workflow for phase2 (ttbar D17 for now) in the default matrix. It does some finishing touches on top of #22375 :
* Add PU definition to the workflow parameters
* Drop DIGI2RAW from the workflow steps
* Customize `PREMIX` event content to include digis
   * Here I'm unsure if it would be better to defined another event content (e.g. `PREMIXDIGI`) and use that

I can't exclude further changes on the stage1 workflow, but this setup turned out to be enough to get work on stage2 workflow started. I think it is in good-enough shape now to be tested regularly in IBs.

Tested in CMSSW_10_1_X_2018-03-05-2300, no changes expected in existing workflows.

@mdhildreth @kpedro88 