### PR TITLE
Migrate SiStripGainsPCLWorker to concurrent and global DQM

### DIFF
--- a/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
@@ -1,67 +1,116 @@
 #ifndef CALIBTRACKER_SISTRIPCHANNELGAIN_APVGAINHELPERS_H
 #define CALIBTRACKER_SISTRIPCHANNELGAIN_APVGAINHELPERS_H
 
+#include "CalibTracker/SiStripChannelGain/interface/APVGainStruct.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQMServices/Core/interface/ConcurrentMonitorElement.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
 
 #include <string>
 #include <vector>
 #include <utility>
 #include <cstdint>
-
+#include <unordered_map>
 
 namespace APVGain {
-    int subdetectorId(uint32_t);
-    int subdetectorId(const std::string&);
-    int subdetectorSide(uint32_t,const TrackerTopology*);
-    int subdetectorSide(const std::string&);
-    int subdetectorPlane(uint32_t,const TrackerTopology*);
-    int subdetectorPlane(const std::string&);
 
-    std::vector<std::pair<std::string,std::string>> monHnames(std::vector<std::string>,bool,const char* tag);
+  int subdetectorId(uint32_t);
+  int subdetectorId(const std::string&);
+  int subdetectorSide(uint32_t,const TrackerTopology*);
+  int subdetectorSide(const std::string&);
+  int subdetectorPlane(uint32_t,const TrackerTopology*);
+  int subdetectorPlane(const std::string&);
 
-    struct APVmon{
+  std::vector<std::pair<std::string,std::string>> monHnames(std::vector<std::string>,bool,const char* tag);
+
+  struct APVmon{
       
-    public:
+  public:
 
-    APVmon(int v1, int v2, int v3, MonitorElement* v4) :
-      m_subdetectorId(v1),m_subdetectorSide(v2),m_subdetectorPlane(v3),m_monitor(v4){}
+  APVmon(int v1, int v2, int v3,MonitorElement* v4) :
+    m_subdetectorId(v1),m_subdetectorSide(v2),m_subdetectorPlane(v3),m_monitor(v4){}
+      
+    int getSubdetectorId(){
+      return m_subdetectorId;
+    }
+    
+    int getSubdetectorSide(){
+      return m_subdetectorSide;
+    }
 
-      int getSubdetectorId(){
-	return m_subdetectorId;
-      }
+    int getSubdetectorPlane(){
+      return m_subdetectorPlane;
+    }
+      
+    MonitorElement* getMonitor(){
+      return m_monitor;
+    }
 
-      int getSubdetectorSide(){
-	return m_subdetectorSide;
-      }
+    void printAll(){
+      LogDebug("APVGainHelpers")<< "subDetectorID:" << m_subdetectorId << std::endl;
+      LogDebug("APVGainHelpers")<< "subDetectorSide:" << m_subdetectorSide << std::endl;
+      LogDebug("APVGainHelpers")<< "subDetectorPlane:" << m_subdetectorPlane << std::endl;
+      LogDebug("APVGainHelpers")<< "histoName:" << m_monitor->getName() << std::endl;
+      return;
+    }
+      
+  private:
 
-      int getSubdetectorPlane(){
-	return m_subdetectorPlane;
-      }
+    int m_subdetectorId;
+    int m_subdetectorSide;
+    int m_subdetectorPlane;
+    MonitorElement* m_monitor;
+    
+  };
 
-      MonitorElement* getMonitor(){
-	return m_monitor;
-      }
+  struct APVGainHistograms {
+  public:
+    APVGainHistograms():
+      Charge_Vs_Index(7),
+      Charge_1(),
+      Charge_2(),
+      Charge_3(),
+      Charge_4(),
+      Charge_Vs_PathlengthTIB(7), 
+      Charge_Vs_PathlengthTOB(7),
+      Charge_Vs_PathlengthTIDP(7),
+      Charge_Vs_PathlengthTIDM(7),
+      Charge_Vs_PathlengthTECP1(7),
+      Charge_Vs_PathlengthTECP2(7),
+      Charge_Vs_PathlengthTECM1(7),
+      Charge_Vs_PathlengthTECM2(7),
+      NStripAPVs(0),
+      NPixelDets(0),
+      APVsCollOrdered(),
+      APVsColl()
+    {
+    }
+    
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_Index;  /*!< Charge per cm for each detector id */
+    std::array< std::vector<ConcurrentMonitorElement>,7 > Charge_1;   /*!< Charge per cm per layer / wheel */
+    std::array< std::vector<ConcurrentMonitorElement>,7 > Charge_2;   /*!< Charge per cm per layer / wheel without G2 */
+    std::array< std::vector<ConcurrentMonitorElement>,7 > Charge_3;   /*!< Charge per cm per layer / wheel without G1 */
+    std::array< std::vector<ConcurrentMonitorElement>,7 > Charge_4;   /*!< Charge per cm per layer / wheel without G1 and G1*/
 
-      void printAll(){
-	LogDebug("APVGainHelpers")<< "subDetectorID:" << m_subdetectorId << std::endl;
-	LogDebug("APVGainHelpers")<< "subDetectorSide:" << m_subdetectorSide << std::endl;
-	LogDebug("APVGainHelpers")<< "subDetectorPlane:" << m_subdetectorPlane << std::endl;
-	LogDebug("APVGainHelpers")<< "histoName:" << m_monitor->getName() << std::endl;
-	return;
-      }
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTIB;   /*!< Charge vs pathlength in TIB */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTOB;   /*!< Charge vs pathlength in TOB */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTIDP;  /*!< Charge vs pathlength in TIDP */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTIDM;  /*!< Charge vs pathlength in TIDM */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTECP1; /*!< Charge vs pathlength in TECP thin */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTECP2; /*!< Charge vs pathlength in TECP thick */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTECM1; /*!< Charge vs pathlength in TECP thin */
+    std::vector<ConcurrentMonitorElement>  Charge_Vs_PathlengthTECM2; /*!< Charge vs pathlength in TECP thick */
+    mutable std::atomic<unsigned int> NStripAPVs;
+    mutable std::atomic<unsigned int> NPixelDets;
+    std::vector<std::shared_ptr<stAPVGain> > APVsCollOrdered;
+    std::unordered_map<unsigned int, std::shared_ptr<stAPVGain> > APVsColl; 
 
-    private:
+  };
+  
+  std::vector<MonitorElement*> FetchMonitor(std::vector<APVmon>, uint32_t, const TrackerTopology* topo=nullptr);
+  std::vector<unsigned int> FetchIndices(std::map<unsigned int,APVloc>, uint32_t, const TrackerTopology* topo=nullptr);
 
-      int m_subdetectorId;
-      int m_subdetectorSide;
-      int m_subdetectorPlane;
-      MonitorElement* m_monitor;
-
-    };
-
-    std::vector<MonitorElement*> FetchMonitor(std::vector<APVmon>, uint32_t, const TrackerTopology* topo=nullptr);
 };
 
 #endif

--- a/CalibTracker/SiStripChannelGain/interface/APVGainStruct.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainStruct.h
@@ -2,6 +2,7 @@
 #define CALIBTRACKER_SISTRIPCHANNELGAIN_STAPVGAIN_H
 
 class TH1F;
+#include <string>
 
 struct stAPVGain{
   unsigned int Index; 
@@ -30,6 +31,27 @@ struct stAPVGain{
   TH1F*        HCharge;
   TH1F*        HChargeN;
   bool         isMasked;
+};
+
+struct APVloc{
+    
+public:
+  
+APVloc(int v1, int v2, int v3,const std::string& s) :
+  m_subdetectorId(v1),m_subdetectorSide(v2),m_subdetectorPlane(v3),m_string(s){}
+      
+  int m_subdetectorId;
+  int m_subdetectorSide;
+  int m_subdetectorPlane;
+  std::string m_string;
+
+  bool operator==(const APVloc& a) const
+  {
+    return (m_subdetectorId == a.m_subdetectorId && 
+	    m_subdetectorSide == a.m_subdetectorSide &&
+	    m_subdetectorPlane == a.m_subdetectorPlane);
+  }
+  
 };
 
 enum statistic_type {None=-1, StdBunch, StdBunch0T, FaABunch, FaABunch0T, IsoBunch, IsoBunch0T, Harvest};

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLHarvester.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLHarvester.h
@@ -57,7 +57,6 @@ class SiStripGainsPCLHarvester : public  DQMEDHarvester {
 
       void gainQualityMonitor(DQMStore::IBooker& ibooker_, const MonitorElement* Charge_Vs_Index) const;
 
-
       int statCollectionFromMode(const char* tag) const;
 
       void algoComputeMPVandGain(const MonitorElement* Charge_Vs_Index);
@@ -87,8 +86,6 @@ class SiStripGainsPCLHarvester : public  DQMEDHarvester {
       std::vector<std::string> VChargeHisto;  /*!< Charge monitor plots to be output */
 
       std::vector<std::string> dqm_tag_;  
-
-      
 
       int CalibrationLevel;
 

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
@@ -25,7 +25,7 @@
 #include "CalibTracker/Records/interface/SiStripGainRcd.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 #include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
@@ -48,6 +48,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Framework/interface/ESWatcher.h" 
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
@@ -71,49 +72,25 @@
 // class declaration
 //
 
-class SiStripGainsPCLWorker : public  DQMEDAnalyzer {
+class SiStripGainsPCLWorker : public  DQMGlobalEDAnalyzer<APVGain::APVGainHistograms> {
 public:
     explicit SiStripGainsPCLWorker(const edm::ParameterSet&);
      
+    void bookHistograms(DQMStore::ConcurrentBooker &, edm::Run const&, edm::EventSetup const&, APVGain::APVGainHistograms &) const override;
+    void dqmAnalyze(edm::Event const&, edm::EventSetup const&, APVGain::APVGainHistograms const&) const override;
+
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-    void beginJob() override;
-    void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;   
-    void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
-    void analyze(const edm::Event&, const edm::EventSetup&) override;
-    void endJob() override;
-    
-    void processEvent(const TrackerTopology* topo); //what really does the job
-    virtual void checkBookAPVColls(const edm::EventSetup& setup);
+    void beginJob() override ;
+    void dqmBeginRun(edm::Run const&, edm::EventSetup const&, APVGain::APVGainHistograms &) const override;
+    void endJob() override ;
+    void checkBookAPVColls(const TrackerGeometry *bareTkGeomPtr,APVGain::APVGainHistograms & histograms) const;
+
 
     std::vector<std::string> dqm_tag_;
 
     int statCollectionFromMode(const char* tag) const;
-
-    std::vector<MonitorElement*>  Charge_Vs_Index;           /*!< Charge per cm for each detector id */
-    std::array< std::vector<APVGain::APVmon>,7 > Charge_1;   /*!< Charge per cm per layer / wheel */
-    std::array< std::vector<APVGain::APVmon>,7 > Charge_2;   /*!< Charge per cm per layer / wheel without G2 */
-    std::array< std::vector<APVGain::APVmon>,7 > Charge_3;   /*!< Charge per cm per layer / wheel without G1 */
-    std::array< std::vector<APVGain::APVmon>,7 > Charge_4;   /*!< Charge per cm per layer / wheel without G1 and G1*/
-
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTIB;   /*!< Charge vs pathlength in TIB */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTOB;   /*!< Charge vs pathlength in TOB */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTIDP;  /*!< Charge vs pathlength in TIDP */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTIDM;  /*!< Charge vs pathlength in TIDM */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTECP1; /*!< Charge vs pathlength in TECP thin */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTECP2; /*!< Charge vs pathlength in TECP thick */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTECM1; /*!< Charge vs pathlength in TECP thin */
-    std::vector<MonitorElement*>  Charge_Vs_PathlengthTECM2; /*!< Charge vs pathlength in TECP thick */
-
-    unsigned int NEvent;    
-    unsigned int NTrack;
-    unsigned int NClusterStrip;
-    unsigned int NClusterPixel;
-    int NStripAPVs;
-    int NPixelDets;
-    unsigned int SRun;
-    unsigned int ERun;
   
     double       MinTrackMomentum;
     double       MaxTrackMomentum;
@@ -133,43 +110,33 @@ private:
     std::string  m_DQMdir;                  /*!< DQM folder hosting the charge statistics and the monitor plots */
     std::string  m_calibrationMode;         /*!< Type of statistics for the calibration */
     std::vector<std::string> VChargeHisto;  /*!< Charge monitor plots to be output */
-
-    edm::ESHandle<TrackerGeometry> tkGeom_;
-    const TrackerGeometry *bareTkGeomPtr_;   // ugly hack to fill APV colls only once, but checks
-
+  
     //Data members for processing
 
-    //Event data
-    unsigned int                       eventnumber    =0;
-    unsigned int                       runnumber      =0;
-    const std::vector<bool>*           TrigTech       =nullptr;  edm::EDGetTokenT<std::vector<bool>           > TrigTech_token_;
-
-    // Track data
-    const std::vector<double>*         trackchi2ndof  =nullptr;  edm::EDGetTokenT<std::vector<double>         > trackchi2ndof_token_;
-    const std::vector<float>*          trackp         =nullptr;  edm::EDGetTokenT<std::vector<float>          > trackp_token_;
-    const std::vector<float>*          trackpt        =nullptr;  edm::EDGetTokenT<std::vector<float>          > trackpt_token_;
-    const std::vector<double>*         tracketa       =nullptr;  edm::EDGetTokenT<std::vector<double>         > tracketa_token_;
-    const std::vector<double>*         trackphi       =nullptr;  edm::EDGetTokenT<std::vector<double>         > trackphi_token_;
-    const std::vector<unsigned int>*   trackhitsvalid =nullptr;  edm::EDGetTokenT<std::vector<unsigned int>   > trackhitsvalid_token_;
-    const std::vector<int>*            trackalgo      =nullptr;  edm::EDGetTokenT<std::vector<int>   >          trackalgo_token_;
-
-    // CalibTree data
-    const std::vector<int>*            trackindex     =nullptr;  edm::EDGetTokenT<std::vector<int>            > trackindex_token_;
-    const std::vector<unsigned int>*   rawid          =nullptr;  edm::EDGetTokenT<std::vector<unsigned int>   > rawid_token_;
-    const std::vector<double>*         localdirx      =nullptr;  edm::EDGetTokenT<std::vector<double>         > localdirx_token_;
-    const std::vector<double>*         localdiry      =nullptr;  edm::EDGetTokenT<std::vector<double>         > localdiry_token_;
-    const std::vector<double>*         localdirz      =nullptr;  edm::EDGetTokenT<std::vector<double>         > localdirz_token_;
-    const std::vector<unsigned short>* firststrip     =nullptr;  edm::EDGetTokenT<std::vector<unsigned short> > firststrip_token_;
-    const std::vector<unsigned short>* nstrips        =nullptr;  edm::EDGetTokenT<std::vector<unsigned short> > nstrips_token_;
-    const std::vector<bool>*           saturation     =nullptr;  edm::EDGetTokenT<std::vector<bool>           > saturation_token_;
-    const std::vector<bool>*           overlapping    =nullptr;  edm::EDGetTokenT<std::vector<bool>           > overlapping_token_;
-    const std::vector<bool>*           farfromedge    =nullptr;  edm::EDGetTokenT<std::vector<bool>           > farfromedge_token_;
-    const std::vector<unsigned int>*   charge         =nullptr;  edm::EDGetTokenT<std::vector<unsigned int>   > charge_token_;
-    const std::vector<double>*         path           =nullptr;  edm::EDGetTokenT<std::vector<double>         > path_token_;
-    const std::vector<double>*         chargeoverpath =nullptr;  edm::EDGetTokenT<std::vector<double>         > chargeoverpath_token_;
-    const std::vector<unsigned char>*  amplitude      =nullptr;  edm::EDGetTokenT<std::vector<unsigned char>  > amplitude_token_;
-    const std::vector<double>*         gainused       =nullptr;  edm::EDGetTokenT<std::vector<double>         > gainused_token_;
-    const std::vector<double>*         gainusedTick   =nullptr;  edm::EDGetTokenT<std::vector<double>         > gainusedTick_token_;
+    edm::EDGetTokenT<std::vector<bool>           > TrigTech_token_;
+    edm::EDGetTokenT<std::vector<double>         > trackchi2ndof_token_;
+    edm::EDGetTokenT<std::vector<float>          > trackp_token_;
+    edm::EDGetTokenT<std::vector<float>          > trackpt_token_;
+    edm::EDGetTokenT<std::vector<double>         > tracketa_token_;
+    edm::EDGetTokenT<std::vector<double>         > trackphi_token_;
+    edm::EDGetTokenT<std::vector<unsigned int>   > trackhitsvalid_token_;
+    edm::EDGetTokenT<std::vector<int>            > trackalgo_token_;
+    edm::EDGetTokenT<std::vector<int>            > trackindex_token_;
+    edm::EDGetTokenT<std::vector<unsigned int>   > rawid_token_;
+    edm::EDGetTokenT<std::vector<double>         > localdirx_token_;
+    edm::EDGetTokenT<std::vector<double>         > localdiry_token_;
+    edm::EDGetTokenT<std::vector<double>         > localdirz_token_;
+    edm::EDGetTokenT<std::vector<unsigned short> > firststrip_token_;
+    edm::EDGetTokenT<std::vector<unsigned short> > nstrips_token_;
+    edm::EDGetTokenT<std::vector<bool>           > saturation_token_;
+    edm::EDGetTokenT<std::vector<bool>           > overlapping_token_;
+    edm::EDGetTokenT<std::vector<bool>           > farfromedge_token_;
+    edm::EDGetTokenT<std::vector<unsigned int>   > charge_token_;
+    edm::EDGetTokenT<std::vector<double>         > path_token_;
+    edm::EDGetTokenT<std::vector<double>         > chargeoverpath_token_;
+    edm::EDGetTokenT<std::vector<unsigned char>  > amplitude_token_;
+    edm::EDGetTokenT<std::vector<double>         > gainused_token_;
+    edm::EDGetTokenT<std::vector<double>         > gainusedTick_token_;
 
     std::string EventPrefix_; //("");
     std::string EventSuffix_; //("");
@@ -178,9 +145,9 @@ private:
     std::string CalibPrefix_; //("GainCalibration");
     std::string CalibSuffix_; //("");
 
-    std::vector<std::shared_ptr<stAPVGain> > APVsCollOrdered;
-    std::unordered_map<unsigned int, std::shared_ptr<stAPVGain> > APVsColl; 
-    
+    // maps histograms index to topology 
+    std::map<unsigned int,APVloc> theTopologyMap;
+
 };
 
 inline int
@@ -192,15 +159,8 @@ SiStripGainsPCLWorker::statCollectionFromMode(const char* tag) const
     it++;
   }
   
-  if (std::string(tag)=="") return 0;  // return StdBunch calibration mode for backward compatibility
+  if (std::string(tag).empty()) return 0;  // return StdBunch calibration mode for backward compatibility
   
   return None;
 }
 
-template<typename T>
-inline edm::Handle<T> connect(const T* &ptr, edm::EDGetTokenT<T> token, const edm::Event &evt) {
-  edm::Handle<T> handle;
-  evt.getByToken(token, handle);
-  ptr = handle.product();
-  return handle; //return handle to keep alive pointer (safety first)
-}

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -319,7 +319,7 @@ SiStripGainFromCalibTree::statCollectionFromMode(const char* tag) const
         it++;
     }
 
-    if (std::string(tag)=="") return 0;  // return StdBunch calibration mode for backward compatibility
+    if (std::string(tag).empty()) return 0;  // return StdBunch calibration mode for backward compatibility
 
     return None;
 }

--- a/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLWorker_cfi.py
+++ b/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLWorker_cfi.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-SiStripGainsPCLWorker = DQMEDAnalyzer(
+SiStripGainsPCLWorker = cms.EDAnalyzer( 
     "SiStripGainsPCLWorker",
     minTrackMomentum    = cms.untracked.double(2),
     maxNrStrips         = cms.untracked.uint32(8),

--- a/CalibTracker/SiStripChannelGain/src/APVGainHelpers.cc
+++ b/CalibTracker/SiStripChannelGain/src/APVGainHelpers.cc
@@ -1,9 +1,7 @@
 #include "CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h"
-
 #include "DataFormats/DetId/interface/DetId.h"
 
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-
 
 /** Brief Extract from the DetId the subdetector type.
  * Return an integer which is associated to the subdetector type. The integer
@@ -107,14 +105,14 @@ int APVGain::subdetectorPlane(const std::string& tag) {
  *  */
 std::vector<MonitorElement*> APVGain::FetchMonitor(std::vector<APVGain::APVmon> histos, uint32_t det_id, 
 						   const TrackerTopology* topo) {
-
+				       
   std::vector<MonitorElement*> found = std::vector<MonitorElement*>();
   int sId    = APVGain::subdetectorId(det_id);
   int sPlane = APVGain::subdetectorPlane(det_id, topo);
   int sSide  = APVGain::subdetectorSide(det_id, topo);
-  std::vector<APVGain::APVmon>::iterator it= histos.begin();
-    
-  LogDebug("APVGainHelpers")<<"sId: "<<sId<<" sPlane: "<<sPlane<<" sSide: "<<sSide<<std::endl;
+  auto it = histos.begin();
+
+  LogDebug("APVGainHelpers")<<"sId: "<<sId<<" sPlane: "<<sPlane<<" sSide: "<<sSide<<std::endl; 
 
   while (it!=histos.end()) {
     std::string tag = (*it).getMonitor()->getName();
@@ -122,10 +120,10 @@ std::vector<MonitorElement*> APVGain::FetchMonitor(std::vector<APVGain::APVmon> 
     int subdetectorSide  = (*it).getSubdetectorSide();
     int subdetectorPlane = (*it).getSubdetectorPlane();
     
-    bool match = (subdetectorId==0 || subdetectorId==sId) && (subdetectorPlane==0 || subdetectorPlane==sPlane) && (subdetectorSide==0  || subdetectorSide==sSide);
+    bool match = (subdetectorId==0  || subdetectorId==sId) && (subdetectorPlane==0 || subdetectorPlane==sPlane) && (subdetectorSide==0  || subdetectorSide==sSide);
 
     if (match) {
-      found.push_back((*it).getMonitor());
+      found.emplace_back((*it).getMonitor());
       LogDebug("APVGainHelpers")<<det_id<<" found: "<< tag << std::endl;
       (*it).printAll();
     }
@@ -134,7 +132,30 @@ std::vector<MonitorElement*> APVGain::FetchMonitor(std::vector<APVGain::APVmon> 
   return found;
 }
 
+/** Brief Fetch the Monitor Element index corresponding to a DetId.
+ *  */
+std::vector<unsigned int> APVGain::FetchIndices(std::map<unsigned int,APVloc> theMap, uint32_t det_id, const TrackerTopology* topo){
 
+  std::vector<unsigned int> found_indices = std::vector<unsigned int>();
+
+  int sId    = APVGain::subdetectorId(det_id);
+  int sPlane = APVGain::subdetectorPlane(det_id, topo);
+  int sSide  = APVGain::subdetectorSide(det_id, topo);
+ 
+  for(auto &element : theMap){
+
+    int subdetectorId    = element.second.m_subdetectorId;
+    int subdetectorSide  = element.second.m_subdetectorSide;
+    int subdetectorPlane = element.second.m_subdetectorPlane;
+
+    bool match = (subdetectorId==0  || subdetectorId==sId) && (subdetectorPlane==0 || subdetectorPlane==sPlane) && (subdetectorSide==0  || subdetectorSide==sSide);
+
+      if (match ){
+      found_indices.push_back(element.first);
+    }
+  }
+  return found_indices;
+}
 
 std::vector<std::pair<std::string,std::string>> 
 APVGain::monHnames(std::vector<std::string> VH, bool allPlanes, const char* tag) {

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_HARVEST_FromRECO.py
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_HARVEST_FromRECO.py
@@ -1,0 +1,66 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: stepHarvest --data --conditions auto:run2_data --scenario pp -s ALCAHARVEST:SiStripGains --filein file:PromptCalibProdSiStripGains.root -n -1 --fileout file:calib.root
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process('ALCAHARVEST')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.AlCaHarvesting_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:PromptCalibProdSiStripGains.root'),
+    processingMode = cms.untracked.string('RunsAndLumis'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    Rethrow = cms.untracked.vstring('ProductNotFound'),
+    fileMode = cms.untracked.string('FULLMERGE')
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('stepHarvest nevts:-1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+# Additional output definition
+
+# Other statements
+process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiStripGains_dbOutput)
+process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiStripGains_metadata)
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+
+# Path and EndPath definitions
+process.SiStripGains = cms.Path(process.ALCAHARVESTSiStripGains)
+process.ALCAHARVESTDQMSaveAndMetadataWriter = cms.Path(process.dqmSaver+process.pclMetadataWriter)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.SiStripGains,process.ALCAHARVESTDQMSaveAndMetadataWriter)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.sh
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
-(cmsRun ${LOCAL_TEST_DIR}/testSSTGain_PCL_FromRECO_cfg.py 0) || die 'Failure running cmsRun phase2_digi_reco_pixelntuple_cfg.py 0' $?
+(cmsRun ${LOCAL_TEST_DIR}/testSSTGain_PCL_FromRECO_cfg.py 0) || die 'Failure running cmsRun testSSTGain_PCL_FromRECO_cfg.py 0' $?
+(cmsRun ${LOCAL_TEST_DIR}/testSSTGain_HARVEST_FromRECO.py 0) || die 'Failure running cmsRun testSSTGain_HARVEST_FromRECO.py 0' $?

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO_cfg.py
@@ -105,7 +105,6 @@ process.ALCARECOStreamPromptCalibProdSiStripGains = cms.OutputModule("PoolOutput
                                                                      eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
                                                                      fileName = cms.untracked.string('PromptCalibProdSiStripGains.root'),
                                                                      outputCommands = cms.untracked.vstring('drop *', 
-                                                                                                            'keep *_alcaBeamSpotProducer_*_*', 
                                                                                                             'keep *_MEtoEDMConvertSiStripGains_*_*'
                                                                                                             )
                                                                      )


### PR DESCRIPTION
   Greetings,
I am re-proposing #22320 with a clean git history this time, and some further cleaning. 
The purpose of https://github.com/cms-sw/cmssw/commit/ec655a6e3d1afabbe57d1a786e79246c7a1a898d remains the same, moving the "worker" step of the SiStrip gains PCL workflow to concurrent and global DQM.
The advantage in terms of memory consumption, after the migration to `edm::one` of the `DQMEDAnalyzer`, of running step3 of `runTheMatrix.py -l 1001.0 -t 4` is reduced, but still visible.
![image](https://user-images.githubusercontent.com/5082376/37102823-ff93df6c-2228-11e8-8314-d1b1f42f2a93.png)
The other advantage I can see is that if running (in standalone mode) the Gain Calibration in a plain `CMSSW_10_1_0_pre2`  (in single-threaded mode) via:

```bash
cmsDriver.py step3 --datatier ALCARECO --conditions auto:run2_data -s ALCA:PromptCalibProdSiStripGains --eventcontent ALCARECO -n 100 --dasquery='file dataset=/ZeroBias/Run2016C-SiStripCalMinBias-18Apr2017-v1/ALCARECO run=276097'
```
followed by:

```bash
cmsDriver.py stepHarvest --data --conditions auto:run2_data --scenario pp -s ALCAHARVEST:SiStripGains --filein file:PromptCalibProdSiStripGains.root -n 100 --fileout file:calib.root
```
one receives a segmentation fault (stack is available [here](https://gist.github.com/mmusich/4441a57cfe2af315ce1e3be7a3abbf34) ), while this PR changes this is not the case.
Running the step3 in MT mode even in `CMSSW_10_1_0_pre2` with:

```bash
cmsDriver.py step3 --datatier ALCARECO --conditions auto:run2_data -s ALCA:PromptCalibProdSiStripGains --eventcontent ALCARECO -n 100 --dasquery='file dataset=/ZeroBias/Run2016C-SiStripCalMinBias-18Apr2017-v1/ALCARECO run=276097' --nThreads 4
```
doesn't produce a segfault.
I profit of this PR to update the unit test with the standalone harvester step  to be run in sequence after the Analyzer step in https://github.com/cms-sw/cmssw/commit/5fa99ece8b8e3b2421925eb555c2b683419cb302. 
As a final note to the reviewers no algorithmic change is intended by this PR, so both calibration output and monitoring plots shall remain the same. This is validated cross-checking the outputs of running the workflow on 1000 events of run 276097 [here](http://musich.web.cern.ch/musich/display/diff_gains_final.pdf).







  
