### PR TITLE
fix missing else before if in HcalTextCalibrations

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
@@ -43,7 +43,7 @@ HcalTextCalibrations::HcalTextCalibrations ( const edm::ParameterSet& iConfig )
       setWhatProduced (this, &HcalTextCalibrations::producePedestalWidths);
       findingRecord <HcalPedestalWidthsRcd> ();
     }
-    if (objectName == "EffectivePedestals") {
+    else if (objectName == "EffectivePedestals") {
       setWhatProduced (this, &HcalTextCalibrations::produceEffectivePedestals, edm::es::Label("effective"));
       findingRecord <HcalPedestalsRcd> ();
     }


### PR DESCRIPTION
A typo introduced in #21438 was just noticed by @christopheralanwest.

This PR will be backported to 100X.