### PR TITLE
Offline PF hadron cluster calibration

### DIFF
--- a/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
@@ -188,16 +188,24 @@ PFEnergyCalibration::energyEmHad(double t, double& e, double&h, double eta, doub
     double dEta = std::abs( absEta - 1.5 );
     double etaPow = dEta * dEta * dEta * dEta;
 
+
     if ( e > 0. && thresh > 0. ) {
-      etaCorrE = 1. + aEtaEndcapEH(t) + 1.3*bEtaEndcapEH(t)*(0.04 + etaPow);
+      if(absEta<2.5) {
+        etaCorrE = 1. + aEtaEndcapEH(t) ;
+      }
+      else {
+        etaPow = dEta * dEta;
+        etaCorrE = 1. + aEtaEndcapEH(t) + 1.3*bEtaEndcapEH(t)*(0.6 + etaPow);
+      }
+      etaPow = dEta * dEta * dEta * dEta;
       etaCorrH = 1. + aEtaEndcapEH(t) + bEtaEndcapEH(t)*(0.04 + etaPow);
     } else {
       etaCorrE = 1. + aEtaEndcapH(t) + 1.3*bEtaEndcapH(t)*(0.04 + etaPow);
       if(absEta<2.5) {
-	etaCorrH = 1. + aEtaEndcapH(t) + 0.05*bEtaEndcapH(t);
+        etaCorrH = 1. + aEtaEndcapH(t) + 0.05*bEtaEndcapH(t);
       }
       else {
-	etaCorrH = 1. + aEtaEndcapH(t) + bEtaEndcapH(t)*(0.04 + etaPow);
+        etaCorrH = 1. + aEtaEndcapH(t) + bEtaEndcapH(t)*(etaPow - 1.1);
       }
     }
 


### PR DESCRIPTION
Offline PF hadron cluster calibration for phase1 upgrade

Updated eta dependent corrections in the EndCap region.

Summary was presented in RECO/AT meeting on 23 Feb 2018: 
https://indico.cern.ch/event/706643/contributions/2899998/attachments/1606000/2548367/PF_Calibration_upgrade2018_23Feb2018.pdf

Please see slide no. 14 and beyond.

Involves following package:
RecoParticleFlow/PFClusterTools/