### PR TITLE
Allowing Easy Disabling/Enabling of E/gamma HLT track matching cuts

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTGsfTrackVarProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTGsfTrackVarProducer.h
@@ -81,6 +81,8 @@ class EgammaHLTGsfTrackVarProducer : public edm::stream::EDProducer<> {
   TrackExtrapolator trackExtrapolator_;
   const int upperTrackNrToRemoveCut_;
   const int lowerTrackNrToRemoveCut_;
+  const bool useDefaultValuesForBarrel_;
+  const bool useDefaultValuesForEndcap_;
 };
 
 #endif

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
@@ -36,7 +36,10 @@ EgammaHLTGsfTrackVarProducer::EgammaHLTGsfTrackVarProducer(const edm::ParameterS
   inputCollectionTag2_     (consumes<reco::GsfTrackCollection>(config.getParameter<edm::InputTag>("inputCollection"))),
   beamSpotTag_             (consumes<reco::BeamSpot>(config.getParameter<edm::InputTag>("beamSpotProducer"))),
   upperTrackNrToRemoveCut_ (config.getParameter<int>("upperTrackNrToRemoveCut")),
-  lowerTrackNrToRemoveCut_ (config.getParameter<int>("lowerTrackNrToRemoveCut")) {
+  lowerTrackNrToRemoveCut_ (config.getParameter<int>("lowerTrackNrToRemoveCut")),
+  useDefaultValuesForBarrel_  (config.getParameter<bool>("useDefaultValuesForBarrel")),
+  useDefaultValuesForEndcap_  (config.getParameter<bool>("useDefaultValuesForEndcap"))
+{
  
   //register your products
   produces < reco::RecoEcalCandidateIsolationMap >( "Deta" ).setBranchAlias( "deta" );
@@ -59,6 +62,9 @@ void EgammaHLTGsfTrackVarProducer::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<edm::InputTag>(("beamSpotProducer"), edm::InputTag("hltOnlineBeamSpot"));
   desc.add<int>(("upperTrackNrToRemoveCut"), 9999); 
   desc.add<int>(("lowerTrackNrToRemoveCut"), -1);
+  desc.add<bool>(("useDefaultValuesForBarrel"),false);
+  desc.add<bool>(("useDefaultValuesForEndcap"),false);
+  
   descriptions.add("hltEgammaHLTGsfTrackVarProducer", desc);
 }
 void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -97,7 +103,7 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
     reco::RecoEcalCandidateRef recoEcalCandRef(recoEcalCandHandle,iRecoEcalCand-recoEcalCandHandle->begin());
    
     const reco::SuperClusterRef scRef = recoEcalCandRef->superCluster();
-   
+    bool isBarrel = std::abs(recoEcalCandRef->eta())<1.479;
     //the idea is that we can take the tracks from properly associated electrons or just take all gsf tracks with that sc as a seed
     std::vector<const reco::GsfTrack*> gsfTracks;
     if(electronHandle.isValid()){
@@ -119,7 +125,7 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
       
     }
 
-    int validHitsValue = 9999999;
+    int validHitsValue = 0;
     float chi2Value = 9999999.;
     float missingHitsValue = 9999999;
     float dEtaInValue=999999;
@@ -128,20 +134,18 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
     float oneOverESuperMinusOneOverPValue=999999;
     float oneOverESeedMinusOneOverPValue=999999;
     
-    if(static_cast<int>(gsfTracks.size())>=upperTrackNrToRemoveCut_){
+    if(static_cast<int>(gsfTracks.size())>=upperTrackNrToRemoveCut_ || 
+       static_cast<int>(gsfTracks.size())<=lowerTrackNrToRemoveCut_ ||
+       (isBarrel && useDefaultValuesForBarrel_) ||
+       (!isBarrel && useDefaultValuesForEndcap_)){
       dEtaInValue=0;
       dEtaSeedInValue=0;
       dPhiInValue=0;
       missingHitsValue = 0;
-      validHitsValue = 0;
+      validHitsValue = 100;
       chi2Value = 0;
-    }else if(static_cast<int>(gsfTracks.size())<=lowerTrackNrToRemoveCut_){
-      dEtaInValue=0;
-      dEtaSeedInValue=0;
-      dPhiInValue=0;
-      missingHitsValue = 0;
-      validHitsValue = 0;
-      chi2Value = 0;
+      oneOverESuperMinusOneOverPValue = 1;
+      oneOverESeedMinusOneOverPValue = 1;
     }else{
       for(size_t trkNr=0;trkNr<gsfTracks.size();trkNr++){
       


### PR DESCRIPTION
At startup, the ECAL endcap is often missaligned w.r.t to the tracker which impacts the track matching cuts.

This has been the case for 2015, 2016 and 2017 and will be the case for 2018.  In the past, we have manually changed the cuts (well via scripts) to fully relax the endcap cuts. Every year we have partially messed this up (some triggers slip through the cracks etc). So this year, we're controlling this with a central bool which can be easily toggled. When toggled, it zeros (or sets it to an other appropriate variable) all track matching cuts in the endcap.  Right now it does it for all produced values including E/p which is probably not strickly necessary but this is on the safe side. 

hltEgammaGsfTrackVars.useDefaultValuesForEndcap = cms.bool(True) and all E/gamma track cuts will automatically pass for endcap electrons. 

@Martin-Grunewald 