### PR TITLE
Revert "Revert "Restore the original behaviour of PR 22131, revert PR 22239""

### DIFF
--- a/PhysicsTools/PatAlgos/python/triggerLayer1/triggerProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/triggerLayer1/triggerProducer_cfi.py
@@ -33,5 +33,3 @@ patTrigger = cms.EDProducer( "PATTriggerProducer"
 , packTriggerLabels = cms.bool(False)
 )
 
-from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
-run2_miniAOD_80XLegacy.toModify(patTrigger, ReadPrescalesFromFile = True)


### PR DESCRIPTION
Reverts cms-sw/cmssw#22379
with  #22519 there is now expectation that timing of miniAOD workflows on runs with bx masking is now acceptable (as e.g. in 136.7611 wf )
