### PR TITLE
do not build cuda plugins for non-AMD64 archs

### DIFF
--- a/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
@@ -1,3 +1,7 @@
+#Skip building plugins by dropping all files for none-AMD64 build
+<architecture match="!_amd64_">
+  <flags SKIP_FILES="*"/>
+</architecture>
 <use   name="DataFormats/Provenance"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Streamer"/>


### PR DESCRIPTION
We do not have cuda for aarch64. So this PR will skip building these plugins for non-AMD64 archs. This is done by dropping all files