### PR TITLE
RecoLocalTracker/SiStripRecHitConverter: Fix bug found by clang warningand fix clang warnings:

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTemplate.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTemplate.h
@@ -12,6 +12,7 @@ class StripCPEfromTemplate : public StripCPE
 
  public:
   
+  using StripCPE::localParameters;
 
   StripClusterParameterEstimator::LocalValues 
     localParameters( const SiStripCluster&, const GeomDetUnit&, const LocalTrajectoryParameters&) const override;

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEgeometric.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEgeometric.h
@@ -8,7 +8,8 @@ class StripCPEgeometric : public StripCPE
 {
 
  public:
- 
+
+  using StripCPE::localParameters;
   StripClusterParameterEstimator::LocalValues 
     localParameters( const SiStripCluster&, const GeomDetUnit&, const LocalTrajectoryParameters&) const override;
 

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripTemplate.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripTemplate.cc
@@ -552,7 +552,7 @@ bool SiStripTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vec
 				qavg_avg = 0.f;
 				for (j=0; j<9; ++j) {
 					
-					for (l=0; l<TSXSIZE; ++k) {db >> theCurrentTemp.entx[k][i].xtemp[j][l]; qavg_avg += theCurrentTemp.entx[k][i].xtemp[j][l];} 
+					for (l=0; l<TSXSIZE; ++l) {db >> theCurrentTemp.entx[k][i].xtemp[j][l]; qavg_avg += theCurrentTemp.entx[k][i].xtemp[j][l];} 
 					
 					if(db.fail()) {LOGERROR("SiStripTemplate") << "Error reading file 20, no template load, run # " << theCurrentTemp.entx[k][i].runnum << ENDL; return false;}
 				}


### PR DESCRIPTION
Loop counter not incremented in body. 

src/RecoLocalTracker/SiStripRecHitConverter/src/SiStripTemplate.cc:555:16: warning: variable 'l' used in loop condition not modified in loop body [-Wfor-loop-analysis]
                                         for (l=0; l<TSXSIZE; ++k) {db >> theCurrentTemp.entx[k][i].xtemp[j][l]; qavg_avg += theCurrentTemp.entx[k][i].xtemp[j][l];}


Warnings: 

RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEgeometric.h:13:5: warning: 'StripCPEgeometric::localParameters' hides overloaded virtual functions [-Woverloaded-virtual]
     localParameters( const SiStripCluster&, const GeomDetUnit&, const LocalTrajectoryParameters&) const override;
    ^

src/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTemplate.h:17:5: warning: 'StripCPEfromTemplate::localParameters' hides overloaded virtual functions [-Woverloaded-virtual]
     localParameters( const SiStripCluster&, const GeomDetUnit&, const LocalTrajectoryParameters&) const override;
    ^