### PR TITLE
RecoTracker/NuclearSeedGenerator: remove unused function causing clang warning:

### DIFF
--- a/RecoTracker/NuclearSeedGenerator/interface/TangentCircle.h
+++ b/RecoTracker/NuclearSeedGenerator/interface/TangentCircle.h
@@ -47,7 +47,6 @@ class TangentCircle
 
      int charge(float magz);
 
-     bool isValid() const { return isValid(); } 
 
  private :
      GlobalPoint theInnerPoint;


### PR DESCRIPTION


RecoTracker/NuclearSeedGenerator/interface/TangentCircle.h:50:27: warning: all paths through this function will call itself [-Winfinite-recursion]
      bool isValid() const { return isValid(); }
                          ^