### PR TITLE
RecoLocalTracker/SiStripClusterizer: clean up clang warnings:

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h
@@ -27,7 +27,7 @@ class StripClusterizerAlgorithm {
     float noise(const uint16_t& strip) const { return SiStripNoises::getNoise( strip, noiseRange ); }
     float gain(const uint16_t& strip)  const { return SiStripGain::getStripGain( strip, gainRange ); }
     bool bad(const uint16_t& strip)    const { return quality->IsStripBad( qualityRange, strip ); }
-    bool allBadBetween(uint16_t L, const uint16_t& R) const { while( ++L < R  &&  bad(L)) {}; { return L == R;} }
+    bool allBadBetween(uint16_t L, const uint16_t& R) const { while( ++L < R  &&  bad(L)) {}; return L == R; }
     SiStripQuality const * quality;
     SiStripApvGain::Range gainRange;
     SiStripNoises::Range  noiseRange;

--- a/RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h
@@ -27,7 +27,7 @@ class StripClusterizerAlgorithm {
     float noise(const uint16_t& strip) const { return SiStripNoises::getNoise( strip, noiseRange ); }
     float gain(const uint16_t& strip)  const { return SiStripGain::getStripGain( strip, gainRange ); }
     bool bad(const uint16_t& strip)    const { return quality->IsStripBad( qualityRange, strip ); }
-    bool allBadBetween(uint16_t L, const uint16_t& R) const { while( ++L < R  &&  bad(L) ); return L == R; }
+    bool allBadBetween(uint16_t L, const uint16_t& R) const { while( ++L < R  &&  bad(L)) {}; { return L == R;} }
     SiStripQuality const * quality;
     SiStripApvGain::Range gainRange;
     SiStripNoises::Range  noiseRange;

--- a/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
@@ -26,7 +26,7 @@ class ThreeThresholdAlgorithm final : public StripClusterizerAlgorithm {
       unpacker++;
     }
   }
-
+  using StripClusterizerAlgorithm::addFed;
   // detset interface
   void addFed(State & state, sistrip::FEDZSChannelUnpacker & unpacker, uint16_t ipair, output_t::TSFastFiller & out) const override {
     while (unpacker.hasData()) {


### PR DESCRIPTION
src/RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h:30:91: warning: while loop has empty body [-Wempty-body]
     bool allBadBetween(uint16_t L, const uint16_t& R) const { while( ++L < R  &&  bad(L) ); return L == R; }
                                                                                          ^

src/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h:23:8: warning: 'ThreeThresholdAlgorithm::addFed' hides overloaded virtual function [-Woverloaded-virtual]
   void addFed(State & state, sistrip::FEDZSChannelUnpacker & unpacker, uint16_t ipair, std::vector<SiStripCluster>& out) const {
       ^