### PR TITLE
EventFilter/SiStripRawToDigi: clean up clang warnings:

### DIFF
--- a/Alignment/LaserAlignment/plugins/LaserAlignmentEventFilter.cc
+++ b/Alignment/LaserAlignment/plugins/LaserAlignmentEventFilter.cc
@@ -73,7 +73,7 @@ bool LaserAlignmentEventFilter::filter(edm::StreamID sid, edm::Event& iEvent, co
 
     // construct FEDBuffer
     sistrip::FEDBuffer buffer(input.data(), input.size());
-    if (not buffer.doChecks()) {
+    if (not buffer.doChecks(true)) {
       edm::LogWarning("LaserAlignmentEventFilter") << "FED Buffer check fails for FED ID " << *ifed << ".";
       continue;
     }

--- a/DQM/SiStripMonitorHardware/src/FEDErrors.cc
+++ b/DQM/SiStripMonitorHardware/src/FEDErrors.cc
@@ -322,7 +322,7 @@ float FEDErrors::fillNonFatalFEDErrors(const sistrip::FEDBuffer* aBuffer,
 
     if (!lIsConnected) continue;
     lTotChans++;
-    if (!aBuffer->channelGood(iCh)) lBadChans++;
+    if (!aBuffer->channelGood(iCh, true)) lBadChans++;
   }
 
   return static_cast<float>(lBadChans*1.0/lTotChans);
@@ -589,7 +589,7 @@ bool FEDErrors::fillChannelErrors(const sistrip::FEDBuffer* aBuffer,
 
   for (unsigned int iCh = 0; iCh < sistrip::FEDCH_PER_FED; iCh++) {//loop on channels
 
-    bool lFailUnpackerChannelCheck = (!aBuffer->channelGood(iCh) && connected_[iCh]) || failUnpackerFEDCheck_;
+    bool lFailUnpackerChannelCheck = (!aBuffer->channelGood(iCh, true) && connected_[iCh]) || failUnpackerFEDCheck_;
     bool lFailMonitoringChannelCheck = !lPassedMonitoringFEDcheck && connected_[iCh];
 
 

--- a/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
@@ -279,7 +279,7 @@ SiStripCMMonitorPlugin::analyze(const edm::Event& iEvent,
 
       if (!lDetId || lDetId == sistrip::invalid32_) continue;
 
-      bool lFailUnpackerChannelCheck = !buffer->channelGood(iCh) && connected;
+      bool lFailUnpackerChannelCheck = !buffer->channelGood(iCh, true) && connected;
 
       if (lFailUnpackerChannelCheck) {
 	continue;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
@@ -123,7 +123,7 @@ namespace sistrip {
         LogDebug(messageLabel_) << "Failed to build FED buffer for FED ID " << *iFedId << ". Exception was " << e.what();
         continue;
       }
-      if (!buffer->doChecks()) {
+      if (!buffer->doChecks(true)) {
         LogDebug(messageLabel_) << "Buffer check failed for FED ID " << *iFedId;
         continue;
       }
@@ -141,7 +141,7 @@ namespace sistrip {
           if (!iConn->isConnected()) {
             continue;
           }
-          if ( !buffer->channelGood(iConn->fedCh()) ) {
+          if ( !buffer->channelGood(iConn->fedCh(), true) ) {
             continue;
           } else {
             apvAddress = header->feUnitMajorityAddress(iConn->fedCh()/FEDCH_PER_FEUNIT);

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -36,11 +36,13 @@ namespace sistrip {
       //The FE length from the full debug header is used in full debug mode.
       bool fePresent(uint8_t internalFEUnitNum) const;
       //check that a channel is present in data, found, on a good FE unit and has no errors flagged in status bits
+      using sistrip::FEDBufferBase::channelGood;
       virtual bool channelGood(const uint8_t internalFEDannelNum, const bool doAPVeCheck=true) const;
       void setLegacyMode(bool legacy) { legacyUnpacker_ = legacy;}
 
       //functions to check buffer. All return true if there is no problem.
       //minimum checks to do before using buffer
+      using sistrip::FEDBufferBase::doChecks;
       virtual bool doChecks(bool doCRC=true) const;
   
       //additional checks to check for corrupt buffers

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -181,7 +181,7 @@ namespace sistrip {
       try {
         buffer.reset(new sistrip::FEDBuffer(input.data(),input.size()));
         buffer->setLegacyMode(legacy_);
-        if (!buffer->doChecks()) {
+        if (!buffer->doChecks(bool(1))) {
           if (!unpackBadChannels_ || !buffer->checkNoFEOverflows() )
             throw cms::Exception("FEDBuffer") << "FED Buffer check fails for FED ID " << *ifed << ".";
         }

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -181,7 +181,7 @@ namespace sistrip {
       try {
         buffer.reset(new sistrip::FEDBuffer(input.data(),input.size()));
         buffer->setLegacyMode(legacy_);
-        if (!buffer->doChecks(bool(1))) {
+        if (!buffer->doChecks(true)) {
           if (!unpackBadChannels_ || !buffer->checkNoFEOverflows() )
             throw cms::Exception("FEDBuffer") << "FED Buffer check fails for FED ID " << *ifed << ".";
         }
@@ -1246,7 +1246,7 @@ namespace sistrip {
 	std::stringstream ss;
 	ss << "[sistrip::RawToDigiUnpacker::" << __func__ << "]"
 	   << " Caught std::exception!" << std::endl;
-	if ( extra_info != "" ) { 
+	if ( !extra_info.empty() ) { 
 	  ss << " Information: " << extra_info << std::endl;
 	}
 	ss << " Caught std::exception in ["
@@ -1261,7 +1261,7 @@ namespace sistrip {
 	std::stringstream ss;
 	ss << "[sistrip::RawToDigiUnpacker::" << __func__ << "]"
 	   << " Caught unknown exception!" << std::endl;
-	if ( extra_info != "" ) { 
+	if ( !extra_info.empty() ) { 
 	  ss << " Information: " << extra_info << std::endl;
 	}
 	ss << "Caught unknown exception in ["

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
@@ -244,7 +244,7 @@ namespace sistrip {
 	continue;
       }
       //only check enabled, working channels
-      if (channelGood(iCh)) {
+      if (FEDBuffer::channelGood(iCh, bool(1))) {
 	//if a channel is bad then return false
 	if (channels_[iCh].packetCode() != correctPacketCode) return false;
       }

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
@@ -244,7 +244,7 @@ namespace sistrip {
 	continue;
       }
       //only check enabled, working channels
-      if (FEDBuffer::channelGood(iCh, bool(1))) {
+      if (FEDBuffer::channelGood(iCh, true)) {
 	//if a channel is bad then return false
 	if (channels_[iCh].packetCode() != correctPacketCode) return false;
       }

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
@@ -216,7 +216,7 @@ void SiStripFEDRawDataAnalyzer::analyze( const edm::Event& event, const edm::Eve
 
 	// check if channel is good
 
-	if (!buffer->channelGood(ichan)) {channel_construct[ifed].push_back(ichan);continue;}
+	if (!buffer->channelGood(ichan, bool(1))) {channel_construct[ifed].push_back(ichan);continue;}
 
 	// find channel data
 

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
@@ -216,7 +216,7 @@ void SiStripFEDRawDataAnalyzer::analyze( const edm::Event& event, const edm::Eve
 
 	// check if channel is good
 
-	if (!buffer->channelGood(ichan, bool(1))) {channel_construct[ifed].push_back(ichan);continue;}
+	if (!buffer->channelGood(ichan, true)) {channel_construct[ifed].push_back(ichan);continue;}
 
 	// find channel data
 

--- a/RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBuilder.h
+++ b/RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBuilder.h
@@ -20,6 +20,7 @@ class MuonTransientTrackingRecHitBuilder: public TransientTrackingRecHitBuilder 
 
   ~MuonTransientTrackingRecHitBuilder() override {} ;
 
+  using TransientTrackingRecHitBuilder::build;
   /// Call the MuonTransientTrackingRecHit::specificBuild
   RecHitPointer build(const TrackingRecHit *p, 
 		      edm::ESHandle<GlobalTrackingGeometry> trackingGeometry) const ;


### PR DESCRIPTION
src/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h:39:20: warning: 'sistrip::FEDBuffer::channelGood' hides overloaded virtual function [-Woverloaded-virtual]
       virtual bool channelGood(const uint8_t internalFEDannelNum, const bool doAPVeCheck=true) const;
                   ^
src/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h:44:20: warning: 'sistrip::FEDBuffer::doChecks' hides overloaded virtual function [-Woverloaded-virtual]
       virtual bool doChecks(bool doCRC=true) const;
                   ^