### PR TITLE
Run2-hgx102 Transfer the hash for DetId in DetId.h

### DIFF
--- a/DataFormats/DetId/interface/DetId.h
+++ b/DataFormats/DetId/interface/DetId.h
@@ -69,5 +69,14 @@ inline bool operator<(DetId id, uint32_t i) { return id()<i; }
 
 //std::ostream& operator<<(std::ostream& s, const DetId& id);
 
+namespace std {
+  template<> struct hash<DetId> {
+    typedef DetId argument_type;
+    typedef std::size_t result_type;
+    result_type operator()(argument_type const& id) const noexcept {
+      return std::hash<uint32_t>()(id.rawId());            
+    }
+  };
+}
 
 #endif

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -44,15 +44,6 @@
 
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
 
-namespace std {
-  template<> 
-  struct hash<DetId> {
-    size_t operator()(const DetId& id) const {
-      return std::hash<uint32_t>()(id.rawId());
-    }
-  };  
-}
-
 ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config) :
   photonT_(consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("photons"))),
   ootPhotonT_(consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("ootPhotons"))),

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerTypes.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerTypes.h
@@ -7,15 +7,6 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 
-namespace std {
-  template<>
-  struct hash<DetId> {
-    std::size_t operator()(const DetId& id) const {      
-      return std::hash<uint32_t>()(id.rawId());
-    }
-  };
-}
-
 namespace hgc_digi {
 
   //15 time samples: 9 pre-samples, 1 in-time, 5 post-samples

--- a/SimFastTiming/FastTimingCommon/interface/FTLDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/FTLDigitizer.h
@@ -24,16 +24,6 @@
 #include <tuple>
 
 
-
-namespace std {
-  template<>
-  struct hash<DetId> {
-    std::size_t operator()(const DetId& detid) const {
-      return hash<uint32_t>()(detid.rawId());
-    }
-  };
-}
-
 namespace ftl_digitizer {
   
   namespace FTLHelpers {


### PR DESCRIPTION
The same hash was declared in many places. For more economic use of unsorted_set it is now put in DetId.h