### PR TITLE
Improve event setup usage in HCAL digitization

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
@@ -14,7 +14,6 @@
 class CaloVShape;
 class DetId;
 class HcalMCParams;
-class HcalTopology;
 
 class HcalShapes : public CaloShapes
 {
@@ -33,8 +32,7 @@ private:
   // hardcoded, if we can't figure it out from the DB
   const CaloVShape * defaultShape(const DetId & detId, bool precise=false) const;
   const ShapeMap& getShapeMap(bool precise) const;
-  HcalMCParams * theMCParams;
-  const HcalTopology * theTopology;
+  const HcalMCParams * theMCParams;
   ShapeMap theShapes;
   ShapeMap theShapesPrecise;
   ZDCShape theZDCShape;

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
@@ -9,11 +9,11 @@
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloShapes.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalShape.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/ZDCShape.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 #include <vector>
 #include <map>
 class CaloVShape;
 class DetId;
-class HcalMCParams;
 
 class HcalShapes : public CaloShapes
 {
@@ -22,7 +22,7 @@ public:
   HcalShapes();
   ~HcalShapes() override;
 
-  void setup(edm::EventSetup const & es);
+  void setDbService(const HcalDbService * service) {theDbService = service;}
 
   const CaloVShape * shape(const DetId & detId, bool precise=false) const override;
 
@@ -31,7 +31,7 @@ private:
   // hardcoded, if we can't figure it out from the DB
   const CaloVShape * defaultShape(const DetId & detId, bool precise=false) const;
   const ShapeMap& getShapeMap(bool precise) const;
-  const HcalMCParams * theMCParams;
+  const HcalDbService * theDbService;
   ShapeMap theShapes;
   ShapeMap theShapesPrecise;
   ZDCShape theZDCShape;

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
@@ -22,8 +22,7 @@ public:
   HcalShapes();
   ~HcalShapes() override;
 
-  void beginRun(edm::EventSetup const & es);
-  void endRun();
+  void setup(edm::EventSetup const & es);
 
   const CaloVShape * shape(const DetId & detId, bool precise=false) const override;
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
@@ -10,8 +10,7 @@
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 
 HcalShapes::HcalShapes()
-: theMCParams(nullptr),
-  theTopology(nullptr)
+: theMCParams(nullptr)
  {
 /*
          00 - not used (reserved)
@@ -50,8 +49,6 @@ HcalShapes::~HcalShapes()
     delete shapeItr.second;
   }
   theShapes.clear();
-  if (theMCParams!=nullptr) delete theMCParams;
-  if (theTopology!=nullptr) delete theTopology;
 }
 
 
@@ -59,23 +56,12 @@ void HcalShapes::beginRun(edm::EventSetup const & es)
 {
   edm::ESHandle<HcalMCParams> p;
   es.get<HcalMCParamsRcd>().get(p);
-  theMCParams = new HcalMCParams(*p.product()); 
-
-// here we are making a _copy_ so we need to add a copy of the topology...
-  
-  edm::ESHandle<HcalTopology> htopo;
-  es.get<HcalRecNumberingRecord>().get(htopo);
-  theTopology=new HcalTopology(*htopo);
-  theMCParams->setTopo(theTopology);
+  theMCParams = &*p;
 }
 
 
 void HcalShapes::endRun()
 {
-  if (theMCParams) delete theMCParams;
-  theMCParams = nullptr;
-  if (theTopology) delete theTopology;
-  theTopology = nullptr;
 }
 
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
@@ -52,16 +52,11 @@ HcalShapes::~HcalShapes()
 }
 
 
-void HcalShapes::beginRun(edm::EventSetup const & es)
+void HcalShapes::setup(edm::EventSetup const & es)
 {
   edm::ESHandle<HcalMCParams> p;
   es.get<HcalMCParamsRcd>().get(p);
   theMCParams = &*p;
-}
-
-
-void HcalShapes::endRun()
-{
 }
 
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
@@ -10,7 +10,7 @@
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 
 HcalShapes::HcalShapes()
-: theMCParams(nullptr)
+: theDbService(nullptr)
  {
 /*
          00 - not used (reserved)
@@ -52,20 +52,12 @@ HcalShapes::~HcalShapes()
 }
 
 
-void HcalShapes::setup(edm::EventSetup const & es)
-{
-  edm::ESHandle<HcalMCParams> p;
-  es.get<HcalMCParamsRcd>().get(p);
-  theMCParams = &*p;
-}
-
-
 const CaloVShape * HcalShapes::shape(const DetId & detId, bool precise) const
 {
-  if(!theMCParams) {
+  if(!theDbService) {
     return defaultShape(detId);
   }
-  int shapeType = theMCParams->getValues(detId)->signalShape();
+  int shapeType = theDbService->getHcalMCParam(detId)->signalShape();
   const auto& myShapes = getShapeMap(precise);
   auto shapeMapItr = myShapes.find(shapeType);
   if(shapeMapItr == myShapes.end()) {

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -15,6 +15,9 @@
 #include "DataFormats/HcalCalibObjects/interface/HFRecalibration.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
 #include <vector>
 
@@ -50,8 +53,6 @@ public:
   void accumulate(edm::Event const& e, edm::EventSetup const& c, CLHEP::HepRandomEngine*);
   void accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& c, CLHEP::HepRandomEngine*);
   void finalizeEvent(edm::Event& e, edm::EventSetup const& c, CLHEP::HepRandomEngine*);
-  void beginRun(const edm::EventSetup & es);
-  void endRun();
   
   void setHBHENoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
   void setHFNoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
@@ -61,6 +62,7 @@ public:
   void setQIE11NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
 
 private:
+  void setup(const edm::EventSetup & es);
   void accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const& hcalHits, edm::Handle<std::vector<PCaloHit> > const& zdcHits, int bunchCrossing, CLHEP::HepRandomEngine*, const HcalTopology *h);
 
   /// some hits in each subdetector, just for testing purposes
@@ -68,6 +70,8 @@ private:
   /// make sure the digitizer has the correct list of all cells that
   /// exist in the geometry
   void checkGeometry(const edm::EventSetup& eventSetup);
+  edm::ESWatcher<CaloGeometryRecord> theGeometryWatcher_;
+  edm::ESWatcher<HcalRecNumberingRecord> theRecNumberWatcher_;
   const CaloGeometry * theGeometry;
   const HcalDDDRecConstants * theRecNumber;
   void updateGeometry(const edm::EventSetup& eventSetup);

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
@@ -50,14 +50,10 @@ HcalDigiProducer::accumulate(PileUpEventPrincipal const& event, edm::EventSetup 
 }
 
 void
-HcalDigiProducer::beginRun(edm::Run const&, edm::EventSetup const& es) {
-  theDigitizer_.beginRun(es);
-}
+HcalDigiProducer::beginRun(edm::Run const&, edm::EventSetup const& es) {}
 
 void
-HcalDigiProducer::endRun(edm::Run const&, edm::EventSetup const&) {
-  theDigitizer_.endRun();
-}
+HcalDigiProducer::endRun(edm::Run const&, edm::EventSetup const&) {}
 
 void
 HcalDigiProducer::setHBHENoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator) {

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -557,7 +557,6 @@ void HcalDigitizer::setup(const edm::EventSetup & es) {
 
 
 void HcalDigitizer::checkGeometry(const edm::EventSetup & eventSetup) {
-  // TODO find a way to avoid doing this every event
   edm::ESHandle<CaloGeometry> geometry;
   eventSetup.get<CaloGeometryRecord>().get(geometry);
   theGeometry = &*geometry;

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -301,6 +301,8 @@ void HcalDigitizer::initializeEvent(edm::Event const& e, edm::EventSetup const& 
   edm::ESHandle<HcalDbService> conditions;
   eventSetup.get<HcalDbRecord>().get(conditions);
   
+  theShapes->setDbService(conditions.product());
+
   theHBHEAmplifier->setDbService(conditions.product());
   theHFAmplifier->setDbService(conditions.product());
   theHOAmplifier->setDbService(conditions.product());
@@ -531,7 +533,6 @@ void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSet
 
 void HcalDigitizer::setup(const edm::EventSetup & es) {
   checkGeometry(es);
-  theShapes->setup(es);
 
   if (agingFlagHB) {
     edm::ESHandle<HBHEDarkening> hdark;


### PR DESCRIPTION
A while ago, @ianna noticed (https://github.com/cms-sw/cmssw/pull/19147#issuecomment-307371771) that `HcalDigitizer::checkGeometry()` was using more CPU than should be necessary. More recently, a comment by @Dr15Jones (https://github.com/cms-sw/cmssw/pull/20666#issuecomment-365267856) helped me realize how to avoid calling `updateGeometry()` unnecessarily. I also removed unnecessary copying of objects in `HcalShapes`. With these changes, @ianna confirms that `HcalDigitizer` CPU usage is reduced.