### PR TITLE
Remove incorrectly placed customizations from RecoParticleFlow_cff

### DIFF
--- a/RecoParticleFlow/Configuration/python/RecoParticleFlow_cff.py
+++ b/RecoParticleFlow/Configuration/python/RecoParticleFlow_cff.py
@@ -60,16 +60,6 @@ _phase2_hgcal_particleFlowReco = cms.Sequence( _phase2_hgcal_simPFSequence * par
 _phase2_hgcal_particleFlowReco.replace( particleFlowTmpSeq, cms.Sequence( particleFlowTmpBarrel * particleFlowTmp ) )
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toModify( quickTrackAssociatorByHits,
-                            pixelSimLinkSrc = cms.InputTag("simSiPixelDigis","Pixel"),
-                            stripSimLinkSrc = cms.InputTag("simSiPixelDigis","Tracker")
-                            )
-
-phase2_hgcal.toModify( tpClusterProducer,
-                            pixelSimLinkSrc = cms.InputTag("simSiPixelDigis", "Pixel"),
-                            phase2OTSimLinkSrc = cms.InputTag("simSiPixelDigis","Tracker")
-                            )
-
 phase2_hgcal.toReplaceWith( particleFlowTmp, _phase2_hgcal_particleFlowTmp )
 phase2_hgcal.toReplaceWith( particleFlowReco, _phase2_hgcal_particleFlowReco )
 


### PR DESCRIPTION
Title says it all. These customizations are already done in the proper places
https://github.com/cms-sw/cmssw/blob/225ca5009bec119907444f0f79c5036f9b0aad67/SimTracker/TrackAssociatorProducers/python/quickTrackAssociatorByHits_cfi.py#L26-L31
and
https://github.com/cms-sw/cmssw/blob/225ca5009bec119907444f0f79c5036f9b0aad67/SimTracker/TrackerHitAssociation/python/tpClusterProducer_cfi.py#L7-L12
with the proper era (`phase2_tracker`), so there is no need to repeat them here.

Tested in CMSSW_10_1_X_2018-03-05-2300, no changes expected.