### PR TITLE
Add delayReadingEventProducts option to PoolSource

### DIFF
--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -80,6 +80,7 @@ namespace edm {
     productSelectorRules_(pset, "inputCommands", "InputSource"),
     dropDescendants_(pset.getUntrackedParameter<bool>("dropDescendantsOfDroppedBranches")),
     labelRawDataLikeMC_(pset.getUntrackedParameter<bool>("labelRawDataLikeMC")),
+    delayReadingEventProducts_(pset.getUntrackedParameter<bool>("delayReadingEventProducts")),
     runHelper_(makeRunHelper(pset)),
     resourceSharedWithDelayedReaderPtr_(),
     // Note: primaryFileSequence_ and secondaryFileSequence_ need to be initialized last, because they use data members
@@ -247,6 +248,9 @@ namespace edm {
           eventPrincipal.id() << " is not found in the secondary input files\n";
       }
     }
+    if(not delayReadingEventProducts_) {
+      eventPrincipal.readAllFromSourceAndMergeImmediately();
+    }
   }
 
   bool
@@ -322,6 +326,7 @@ namespace edm {
         ->setComment("If True, also drop on input any descendent of any branch dropped on input.");
     desc.addUntracked<bool>("labelRawDataLikeMC", true)
         ->setComment("If True: replace module label for raw data to match MC. Also use 'LHC' as process.");
+    desc.addUntracked<bool>("delayReadingEventProducts",true)->setComment("If True: do not read a data product from the file until it is requested. If False: all event data products are read upfront.");
     ProductSelectorRules::fillDescription(desc, "inputCommands");
     InputSource::fillDescription(desc);
     RootPrimaryFileSequence::fillDescription(desc);

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -84,6 +84,7 @@ namespace edm {
     ProductSelectorRules productSelectorRules_;
     bool dropDescendants_;
     bool labelRawDataLikeMC_;
+    bool delayReadingEventProducts_;
     
     edm::propagate_const<std::unique_ptr<RunHelperBase>> runHelper_;
     std::unique_ptr<SharedResourcesAcquirer> resourceSharedWithDelayedReaderPtr_; // We do not use propagate_const because the acquirer is itself mutable.

--- a/IOPool/Input/test/PoolInputTest_noDelay_cfg.py
+++ b/IOPool/Input/test/PoolInputTest_noDelay_cfg.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TESTRECO")
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+process.OtherThing = cms.EDProducer("OtherThingProducer")
+
+process.Analysis = cms.EDAnalyzer("OtherThingAnalyzer")
+
+process.source = cms.Source("PoolSource",
+                            delayReadingEventProducts = cms.untracked.bool(False),
+    setRunNumber = cms.untracked.uint32(621),
+    fileNames = cms.untracked.vstring('file:PoolInputTest.root')
+)
+
+process.p = cms.Path(process.OtherThing*process.Analysis)
+
+process.add_(cms.Service("Tracer"))

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -9,6 +9,8 @@ cmsRun ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py PoolInputTest.root 11 561 7 6 3
 cp PoolInputTest.root PoolInputOther.root
 
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest_cfg.py || die 'Failure using PoolInputTest_cfg.py' $?
+cmsRun  ${LOCAL_TEST_DIR}/PoolInputTest_noDelay_cfg.py >& ${LOCAL_TMP_DIR}/PoolInputTest_noDelay_cfg.txt || die 'Failure using PoolInputTest_noDelay_cfg.py' $?
+grep 'event delayed read from source' ${LOCAL_TMP_DIR}/PoolInputTest_noDelay_cfg.txt && die 'Failure in PoolInputTest_noDelay_cfg.py, found delay reads from source' 1
 
 cmsRun ${LOCAL_TEST_DIR}/PrePool2FileInputTest_cfg.py || die 'Failure using PrePool2FileInputTest_cfg.py' $?
 cmsRun ${LOCAL_TEST_DIR}/Pool2FileInputTest_cfg.py || die 'Failure using Pool2FileInputTest_cfg.py' $?
@@ -106,3 +108,4 @@ cmsRun ${LOCAL_TEST_DIR}/test_reduced_ProcessHistory_end_cfg.py merged_files.roo
 cmsRun ${LOCAL_TEST_DIR}/test_make_multi_lumi_cfg.py || die 'Failure using test_make_multi_lumi_cfg.py' $?
 cmsRun ${LOCAL_TEST_DIR}/test_read_multi_lumi_as_one_cfg.py || die 'Failure using test_read_multi_lumi_as_one_cfg.py' $?
 popd
+exit 0


### PR DESCRIPTION
One can now tell the PoolSource to avoid delayed reads of Event data products. This can be useful when running jobs with many streams and where all event data products will be read anyway.