### PR TITLE
optimize and clean up EventShapeVariables code, add Fox-Wolfram moments

### DIFF
--- a/PhysicsTools/CandAlgos/plugins/EventShapeVarsProducer.cc
+++ b/PhysicsTools/CandAlgos/plugins/EventShapeVarsProducer.cc
@@ -4,10 +4,14 @@
 
 #include "PhysicsTools/CandUtils/interface/Thrust.h"
 
+#include <vector>
+#include <memory>
+
 EventShapeVarsProducer::EventShapeVarsProducer(const edm::ParameterSet& cfg)
 {
   srcToken_ = consumes<edm::View<reco::Candidate> >(cfg.getParameter<edm::InputTag>("src"));
   r_ = cfg.exists("r") ? cfg.getParameter<double>("r") : 2.;
+  fwmax_ = cfg.exists("fwmax") ? cfg.getParameter<unsigned>("fwmax") : 0;
 
   produces<double>("thrust");
   //produces<double>("oblateness");
@@ -17,7 +21,7 @@ EventShapeVarsProducer::EventShapeVarsProducer(const edm::ParameterSet& cfg)
   produces<double>("aplanarity");
   produces<double>("C");
   produces<double>("D");
-
+  if(fwmax_ > 0) produces<std::vector<double>>("FWmoments");
 }
 
 void put(edm::Event& evt, double value, const char* instanceName)
@@ -27,7 +31,6 @@ void put(edm::Event& evt, double value, const char* instanceName)
 
 void EventShapeVarsProducer::produce(edm::Event& evt, const edm::EventSetup&)
 {
-  //std::cout << "<EventShapeVarsProducer::produce>:" << std::endl;
 
   edm::Handle<edm::View<reco::Candidate> > objects;
   evt.getByToken(srcToken_, objects);
@@ -37,12 +40,18 @@ void EventShapeVarsProducer::produce(edm::Event& evt, const edm::EventSetup&)
   //put(evt, thrustAlgo.oblateness(), "oblateness");
 
   EventShapeVariables eventShapeVarsAlgo(*objects);
+  eventShapeVarsAlgo.set_r(r_);
   put(evt, eventShapeVarsAlgo.isotropy(), "isotropy");
   put(evt, eventShapeVarsAlgo.circularity(), "circularity");
-  put(evt, eventShapeVarsAlgo.sphericity(r_), "sphericity");
-  put(evt, eventShapeVarsAlgo.aplanarity(r_), "aplanarity");
-  put(evt, eventShapeVarsAlgo.C(r_), "C");
-  put(evt, eventShapeVarsAlgo.D(r_), "D");
+  put(evt, eventShapeVarsAlgo.sphericity(), "sphericity");
+  put(evt, eventShapeVarsAlgo.aplanarity(), "aplanarity");
+  put(evt, eventShapeVarsAlgo.C(), "C");
+  put(evt, eventShapeVarsAlgo.D(), "D");
+  if(fwmax_ > 0){
+    eventShapeVarsAlgo.setFWmax(fwmax_);
+    auto vfw = std::make_unique<std::vector<double>>(eventShapeVarsAlgo.getFWmoments());
+    evt.put(std::move(vfw),"FWmoments");
+  }
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/CandAlgos/plugins/EventShapeVarsProducer.h
+++ b/PhysicsTools/CandAlgos/plugins/EventShapeVarsProducer.h
@@ -17,10 +17,10 @@
  *  - aplanarity
  *  - C
  *  - D
+ *  - Fox-Wolfram moments
  *
- *  See http://cepa.fnal.gov/psm/simulation/mcgen/lund/pythia_manual/pythia6.3/pythia6301/node213.html
- *  ( http://cepa.fnal.gov/psm/simulation/mcgen/lund/pythia_manual/pythia6.3/pythia6301/node214.html )
- *  for an explanation of sphericity, aplanarity and the quantities C and D (thrust and oblateness).
+ *  See https://arxiv.org/pdf/hep-ph/0603175v2.pdf#page=524
+ *  for an explanation of sphericity, aplanarity, the quantities C and D, thrust, oblateness, Fox-Wolfram moments.
  *
  * \author Christian Veelken, UC Davis
  *
@@ -47,6 +47,7 @@ class EventShapeVarsProducer : public edm::EDProducer
 
   edm::EDGetTokenT<edm::View<reco::Candidate> > srcToken_;
   double r_;
+  unsigned fwmax_;
 
   void beginJob() override {}
   void produce(edm::Event&, const edm::EventSetup&) override;

--- a/PhysicsTools/CandAlgos/python/EventShapeVars_cff.py
+++ b/PhysicsTools/CandAlgos/python/EventShapeVars_cff.py
@@ -8,11 +8,15 @@ caloEventShapeVars = cms.EDProducer("EventShapeVarsProducer",
 
     # momentum dependence of sphericity and aplanarity variables and of C and D quantities 
     # (r = 2. corresponds to the conventionally used default, but raises issues of infrared safety in QCD calculations;
-    #  see http://cepa.fnal.gov/psm/simulation/mcgen/lund/pythia_manual/pythia6.3/pythia6301/node213.html for more details)
-    r = cms.double(2.)
+    #  see https://arxiv.org/pdf/hep-ph/0603175v2.pdf#page=524 for more details)
+    r = cms.double(2.),
+
+    # number of Fox-Wolfram moments to compute
+    fwmax = cms.uint32(0),
 )
 
-pfEventShapeVars = copy.deepcopy(caloEventShapeVars)
-pfEventShapeVars.src = cms.InputTag("pfNoPileUp")
+pfEventShapeVars = caloEventShapeVars.clone(
+    src = cms.InputTag("pfNoPileUp")
+)
 
 produceEventShapeVars = cms.Sequence( caloEventShapeVars * pfEventShapeVars )

--- a/PhysicsTools/CandUtils/interface/EventShapeVariables.h
+++ b/PhysicsTools/CandUtils/interface/EventShapeVariables.h
@@ -12,7 +12,7 @@
    cartesian, cylindrical or polar coordinates. It exploits the ROOT::TMatrixDSym 
    for the calculation of the sphericity and aplanarity.
 
-   See http://cepa.fnal.gov/psm/simulation/mcgen/lund/pythia_manual/pythia6.3/pythia6301/node213.html
+   See https://arxiv.org/pdf/hep-ph/0603175v2.pdf#page=524
    for an explanation of sphericity, aplanarity and the quantities C and D.
 
    Author: Sebastian Naumann-Emme, University of Hamburg
@@ -52,31 +52,59 @@ class EventShapeVariables {
   /// number of steps to determine how fine the granularity of the algorithm in phi should be
   double circularity(const unsigned int& numberOfSteps = 1000) const;
 
-  /// 1.5*(q1+q2) where 0<=q1<=q2<=q3 are the eigenvalues of the momemtum tensor 
+  /// set exponent for computation of momentum tensor and related products
+  void set_r(double r);
+
+  /// set number of Fox-Wolfram moments to compute
+  void setFWmax(unsigned m);
+
+  /// 1.5*(q1+q2) where q0>=q1>=q2>=0 are the eigenvalues of the momentum tensor 
   /// sum{p_j[a]*p_j[b]}/sum{p_j**2} normalized to 1. Return values are 1 for spherical, 3/4 for 
   /// plane and 0 for linear events
-  double sphericity(double = 2.)  const;
-  /// 1.5*q1 where 0<=q1<=q2<=q3 are the eigenvalues of the momemtum tensor 
+  double sphericity();
+  /// 1.5*q2 where q0>=q1>=q2>=0 are the eigenvalues of the momentum tensor 
   /// sum{p_j[a]*p_j[b]}/sum{p_j**2} normalized to 1. Return values are 0.5 for spherical and 0 
   /// for plane and linear events
-  double aplanarity(double = 2.)  const;
-  /// 3.*(q1*q2+q1*q3+q2*q3) where 0<=q1<=q2<=q3 are the eigenvalues of the momemtum tensor 
+  double aplanarity();
+  /// 3.*(q0*q1+q0*q2+q1*q2) where q0>=q1>=q2>=0 are the eigenvalues of the momentum tensor 
   /// sum{p_j[a]*p_j[b]}/sum{p_j**2} normalized to 1. Return value is between 0 and 1 
   /// and measures the 3-jet structure of the event (C vanishes for a "perfect" 2-jet event)
-  double C(double = 2.) const;
-  /// 27.*(q1*q2*q3) where 0<=q1<=q2<=q3 are the eigenvalues of the momemtum tensor 
+  double C();
+  /// 27.*(q0*q1*q2) where q0>=q1>=q2>=0 are the eigenvalues of the momentum tensor 
   /// sum{p_j[a]*p_j[b]}/sum{p_j**2} normalized to 1. Return value is between 0 and 1 
   /// and measures the 4-jet structure of the event (D vanishes for a planar event)
-  double D(double = 2.) const;
-  
- private:
-  /// helper function to fill the 3 dimensional momentum tensor from the inputVectors where 
-  /// needed
-  TMatrixDSym compMomentumTensor(double = 2.) const;
-  TVectorD compEigenValues(double = 2.) const;
+  double D();
 
-  /// cashing of input vectors
+  const std::vector<double>& getEigenValues() { if(!tensors_computed_) compTensorsAndVectors(); return eigenValues_; }
+  const std::vector<double>& getEigenValuesNoNorm() { if(!tensors_computed_) compTensorsAndVectors(); return eigenValuesNoNorm_; }
+  const TMatrixD& getEigenVectors() { if(!tensors_computed_) compTensorsAndVectors(); return eigenVectors_; }
+
+  double getFWmoment( unsigned l ) ;
+  const std::vector<double>& getFWmoments();
+
+ private:
+  /// helper function to fill the 3 dimensional momentum tensor from the inputVectors where needed
+  /// also fill the 3 dimensional vectors of eigen-values and eigen-vectors;
+  /// the largest (smallest) eigen-value is stored at index position 0 (2)
+  void compTensorsAndVectors() ;
+
+  void computeFWmoments() ;
+
+  /// caching of input vectors
   std::vector<math::XYZVector> inputVectors_;
+
+  /// caching of output
+  double r_;
+  bool tensors_computed_;
+  TMatrixD eigenVectors_;
+  TVectorD eigenValuesTmp_, eigenValuesNoNormTmp_;
+  std::vector<double> eigenValues_, eigenValuesNoNorm_;
+
+  /// Owen ; save computed Fox-Wolfram moments
+  unsigned fwmom_maxl_;
+  std::vector<double> fwmom_;
+  bool   fwmom_computed_ ;
+
 };
 
 #endif

--- a/PhysicsTools/CandUtils/src/EventShapeVariables.cc
+++ b/PhysicsTools/CandUtils/src/EventShapeVariables.cc
@@ -3,36 +3,48 @@
 #include "TMath.h"
 
 /// constructor from reco::Candidates
-EventShapeVariables::EventShapeVariables(const edm::View<reco::Candidate>& inputVectors)
+EventShapeVariables::EventShapeVariables(const edm::View<reco::Candidate>& inputVectors) : eigenVectors_(3,3)
 {
-  //std::cout << "inputVectors.size = " << inputVectors.size() << std::endl;
   inputVectors_.reserve( inputVectors.size() );
-  for ( edm::View<reco::Candidate>::const_iterator vec = inputVectors.begin(); vec != inputVectors.end(); ++vec){
-    inputVectors_.push_back(math::XYZVector(vec->px(), vec->py(), vec->pz()));
+  for (const auto& vec : inputVectors){
+    inputVectors_.push_back(math::XYZVector(vec.px(), vec.py(), vec.pz()));
   }
+  //default values
+  set_r(2.);
+  setFWmax(10);
 }
 
+
 /// constructor from XYZ coordinates
-EventShapeVariables::EventShapeVariables(const std::vector<math::XYZVector>& inputVectors) 
-  : inputVectors_(inputVectors)
-{}
+EventShapeVariables::EventShapeVariables(const std::vector<math::XYZVector>& inputVectors) : inputVectors_(inputVectors), eigenVectors_(3,3)
+{
+  //default values
+  set_r(2.);
+  setFWmax(10);
+}
 
 /// constructor from rho eta phi coordinates
-EventShapeVariables::EventShapeVariables(const std::vector<math::RhoEtaPhiVector>& inputVectors)
+EventShapeVariables::EventShapeVariables(const std::vector<math::RhoEtaPhiVector>& inputVectors) : eigenVectors_(3,3)
 {
   inputVectors_.reserve( inputVectors.size() );
-  for ( std::vector<math::RhoEtaPhiVector>::const_iterator vec = inputVectors.begin(); vec != inputVectors.end(); ++vec ){
-    inputVectors_.push_back(math::XYZVector(vec->x(), vec->y(), vec->z()));
+  for (const auto& vec : inputVectors){
+    inputVectors_.push_back(math::XYZVector(vec.x(), vec.y(), vec.z()));
   }
+  //default values
+  set_r(2.);
+  setFWmax(10);
 }
 
 /// constructor from r theta phi coordinates
-EventShapeVariables::EventShapeVariables(const std::vector<math::RThetaPhiVector>& inputVectors)
+EventShapeVariables::EventShapeVariables(const std::vector<math::RThetaPhiVector>& inputVectors) : eigenVectors_(3,3)
 {
   inputVectors_.reserve( inputVectors.size() );
-  for(std::vector<math::RThetaPhiVector>::const_iterator vec = inputVectors.begin(); vec != inputVectors.end(); ++vec ){
-    inputVectors_.push_back(math::XYZVector(vec->x(), vec->y(), vec->z()));
+  for (const auto& vec : inputVectors){
+    inputVectors_.push_back(math::XYZVector(vec.x(), vec.y(), vec.z()));
   }
+  //default values
+  set_r(2.);
+  setFWmax(10);
 }
   
 /// the return value is 1 for spherical events and 0 for events linear in r-phi. This function 
@@ -46,9 +58,11 @@ EventShapeVariables::isotropy(const unsigned int& numberOfSteps) const
   for(unsigned int i=0; i<numberOfSteps; ++i){
     phi+=deltaPhi;
     double sum=0;
-    for(unsigned int j=0; j<inputVectors_.size(); ++j){
+    double cosphi = TMath::Cos(phi);
+    double sinphi = TMath::Sin(phi);
+    for(const auto& vec : inputVectors_){
       // sum over inner product of unit vectors and momenta
-      sum+=TMath::Abs(TMath::Cos(phi)*inputVectors_[j].x()+TMath::Sin(phi)*inputVectors_[j].y());
+      sum+=TMath::Abs(cosphi*vec.x()+sinphi*vec.y());
     }
     if( eOut<0. || sum<eOut ) eOut=sum;
     if( eIn <0. || sum>eIn  ) eIn =sum;
@@ -63,14 +77,16 @@ EventShapeVariables::circularity(const unsigned int& numberOfSteps) const
 {
   const double deltaPhi=2*TMath::Pi()/numberOfSteps;
   double circularity=-1, phi=0, area = 0;
-  for(unsigned int i=0;i<inputVectors_.size();i++) {
-    area+=TMath::Sqrt(inputVectors_[i].x()*inputVectors_[i].x()+inputVectors_[i].y()*inputVectors_[i].y());
+  for(const auto& vec: inputVectors_) {
+    area+=TMath::Sqrt(vec.x()*vec.x()+vec.y()*vec.y());
   }
   for(unsigned int i=0; i<numberOfSteps; ++i){
     phi+=deltaPhi;
     double sum=0, tmp=0.;
-    for(unsigned int j=0; j<inputVectors_.size(); ++j){
-      sum+=TMath::Abs(TMath::Cos(phi)*inputVectors_[j].x()+TMath::Sin(phi)*inputVectors_[j].y());
+    double cosphi = TMath::Cos(phi);
+    double sinphi = TMath::Sin(phi);
+    for(const auto& vec: inputVectors_){
+      sum+=TMath::Abs(cosphi*vec.x()+sinphi*vec.y());
     }
     tmp=TMath::Pi()/2*sum/area;
     if( circularity<0 || tmp<circularity ){
@@ -80,101 +96,192 @@ EventShapeVariables::circularity(const unsigned int& numberOfSteps) const
   return circularity;
 }
 
-/// helper function to fill the 3 dimensional momentum tensor from the inputVecotrs where needed
-TMatrixDSym 
-EventShapeVariables::compMomentumTensor(double r) const
+/// set exponent for computation of momentum tensor and related products
+void 
+EventShapeVariables::set_r(double r)
 {
+  r_ = r;
+  /// invalidate previous cached computations
+  tensors_computed_ = false;
+  eigenValues_ = std::vector<double>(3,0);
+  eigenValuesNoNorm_ = std::vector<double>(3,0);
+}
+
+/// helper function to fill the 3 dimensional momentum tensor from the inputVectors where needed
+/// also fill the 3 dimensional vectors of eigen-values and eigen-vectors;
+/// the largest (smallest) eigen-value is stored at index position 0 (2)
+void 
+EventShapeVariables::compTensorsAndVectors()
+{
+  if(tensors_computed_) return;
+
+  if ( inputVectors_.size() < 2 ){
+    tensors_computed_ = true;
+    return;
+  }
+
   TMatrixDSym momentumTensor(3);
   momentumTensor.Zero();
 
-  if ( inputVectors_.size() < 2 ){
-    return momentumTensor;
-  }
-
   // fill momentumTensor from inputVectors
   double norm = 0.;
-  for ( int i = 0; i < (int)inputVectors_.size(); ++i ){
-    double p2 = inputVectors_[i].Dot(inputVectors_[i]);
-    double pR = ( r == 2. ) ? p2 : TMath::Power(p2, 0.5*r);
+  for (const auto& vec: inputVectors_){
+    double p2 = vec.Dot(vec);
+    double pR = ( r_ == 2. ) ? p2 : TMath::Power(p2, 0.5*r_);
     norm += pR;
-    double pRminus2 = ( r == 2. ) ? 1. : TMath::Power(p2, 0.5*r - 1.);
-    momentumTensor(0,0) += pRminus2*inputVectors_[i].x()*inputVectors_[i].x();
-    momentumTensor(0,1) += pRminus2*inputVectors_[i].x()*inputVectors_[i].y();
-    momentumTensor(0,2) += pRminus2*inputVectors_[i].x()*inputVectors_[i].z();
-    momentumTensor(1,0) += pRminus2*inputVectors_[i].y()*inputVectors_[i].x();
-    momentumTensor(1,1) += pRminus2*inputVectors_[i].y()*inputVectors_[i].y();
-    momentumTensor(1,2) += pRminus2*inputVectors_[i].y()*inputVectors_[i].z();
-    momentumTensor(2,0) += pRminus2*inputVectors_[i].z()*inputVectors_[i].x();
-    momentumTensor(2,1) += pRminus2*inputVectors_[i].z()*inputVectors_[i].y();
-    momentumTensor(2,2) += pRminus2*inputVectors_[i].z()*inputVectors_[i].z();
+    double pRminus2 = ( r_ == 2. ) ? 1. : TMath::Power(p2, 0.5*r_ - 1.);
+    momentumTensor(0,0) += pRminus2*vec.x()*vec.x();
+    momentumTensor(0,1) += pRminus2*vec.x()*vec.y();
+    momentumTensor(0,2) += pRminus2*vec.x()*vec.z();
+    momentumTensor(1,0) += pRminus2*vec.y()*vec.x();
+    momentumTensor(1,1) += pRminus2*vec.y()*vec.y();
+    momentumTensor(1,2) += pRminus2*vec.y()*vec.z();
+    momentumTensor(2,0) += pRminus2*vec.z()*vec.x();
+    momentumTensor(2,1) += pRminus2*vec.z()*vec.y();
+    momentumTensor(2,2) += pRminus2*vec.z()*vec.z();
   }
 
-  //std::cout << "momentumTensor:" << std::endl;
-  //std::cout << momentumTensor(0,0) << " " << momentumTensor(0,1) << " " << momentumTensor(0,2) 
-  //          << momentumTensor(1,0) << " " << momentumTensor(1,1) << " " << momentumTensor(1,2) 
-  //	      << momentumTensor(2,0) << " " << momentumTensor(2,1) << " " << momentumTensor(2,2) << std::endl;
-
-  // return momentumTensor normalized to determinant 1
-  return (1./norm)*momentumTensor;
-}
-
-/// helper function to fill the 3 dimensional vector of eigen-values;
-/// the largest (smallest) eigen-value is stored at index position 0 (2)
-TVectorD
-EventShapeVariables::compEigenValues(double r) const
-{
-  TVectorD eigenValues(3);
-  TMatrixDSym myTensor = compMomentumTensor(r);
-  if( myTensor.IsSymmetric() ){
-    if( myTensor.NonZeros() != 0 ) myTensor.EigenVectors(eigenValues);
+  if( momentumTensor.IsSymmetric() && ( momentumTensor.NonZeros() != 0 ) ){
+    momentumTensor.EigenVectors(eigenValuesNoNormTmp_);
   }
+  eigenValuesNoNorm_[0] = eigenValuesNoNormTmp_(0);
+  eigenValuesNoNorm_[1] = eigenValuesNoNormTmp_(1);
+  eigenValuesNoNorm_[2] = eigenValuesNoNormTmp_(2);
 
-  // CV: TMatrixDSym::EigenVectors returns eigen-values and eigen-vectors
-  //     ordered by descending eigen-values, so no need to do any sorting here...
-  //std::cout << "eigenValues(0) = " << eigenValues(0) << ","
-  //	      << " eigenValues(1) = " << eigenValues(1) << ","
-  //	      << " eigenValues(2) = " << eigenValues(2) << std::endl;
+  // momentumTensor normalized to determinant 1
+  momentumTensor *= (1./norm);
 
-  return eigenValues;
+  // now get eigens
+  if( momentumTensor.IsSymmetric() && ( momentumTensor.NonZeros() != 0 ) ){
+    eigenVectors_ = momentumTensor.EigenVectors(eigenValuesTmp_);
+  }
+  eigenValues_[0] = eigenValuesTmp_(0);
+  eigenValues_[1] = eigenValuesTmp_(1);
+  eigenValues_[2] = eigenValuesTmp_(2);
+
+  tensors_computed_ = true;  
 }
 
-/// 1.5*(q1+q2) where 0<=q1<=q2<=q3 are the eigenvalues of the momentum tensor sum{p_j[a]*p_j[b]}/sum{p_j**2} 
+/// 1.5*(q1+q2) where q0>=q1>=q2>=0 are the eigenvalues of the momentum tensor sum{p_j[a]*p_j[b]}/sum{p_j**2} 
 /// normalized to 1. Return values are 1 for spherical, 3/4 for plane and 0 for linear events
 double 
-EventShapeVariables::sphericity(double r) const
+EventShapeVariables::sphericity()
 {
-  TVectorD eigenValues = compEigenValues(r);
-  return 1.5*(eigenValues(1) + eigenValues(2));
+  if(!tensors_computed_) compTensorsAndVectors();
+  return 1.5*(eigenValues_[1] + eigenValues_[2]);
 }
 
-/// 1.5*q1 where 0<=q1<=q2<=q3 are the eigenvalues of the momentum tensor sum{p_j[a]*p_j[b]}/sum{p_j**2} 
+/// 1.5*q2 where q0>=q1>=q2>=0 are the eigenvalues of the momentum tensor sum{p_j[a]*p_j[b]}/sum{p_j**2} 
 /// normalized to 1. Return values are 0.5 for spherical and 0 for plane and linear events
 double 
-EventShapeVariables::aplanarity(double r) const
+EventShapeVariables::aplanarity()
 {
-  TVectorD eigenValues = compEigenValues(r);
-  return 1.5*eigenValues(2);
+  if(!tensors_computed_) compTensorsAndVectors();
+  return 1.5*eigenValues_[2];
 }
 
-/// 3.*(q1*q2+q1*q3+q2*q3) where 0<=q1<=q2<=q3 are the eigenvalues of the momentum tensor sum{p_j[a]*p_j[b]}/sum{p_j**2} 
+/// 3.*(q0*q1+q0*q2+q1*q2) where q0>=q1>=q2>=0 are the eigenvalues of the momentum tensor sum{p_j[a]*p_j[b]}/sum{p_j**2} 
 /// normalized to 1. Return value is between 0 and 1 
 /// and measures the 3-jet structure of the event (C vanishes for a "perfect" 2-jet event)
 double 
-EventShapeVariables::C(double r) const
+EventShapeVariables::C()
 {
-  TVectorD eigenValues = compEigenValues(r);
-  return 3.*(eigenValues(0)*eigenValues(1) + eigenValues(0)*eigenValues(2) + eigenValues(1)*eigenValues(2));
+  if(!tensors_computed_) compTensorsAndVectors();
+  return 3.*(eigenValues_[0]*eigenValues_[1] + eigenValues_[0]*eigenValues_[2] + eigenValues_[1]*eigenValues_[2]);
 }
 
-/// 27.*(q1*q2*q3) where 0<=q1<=q2<=q3 are the eigenvalues of the momemtum tensor sum{p_j[a]*p_j[b]}/sum{p_j**2} 
+/// 27.*(q0*q1*q2) where q0>=q1>=q2>=0 are the eigenvalues of the momemtum tensor sum{p_j[a]*p_j[b]}/sum{p_j**2} 
 /// normalized to 1. Return value is between 0 and 1 
 /// and measures the 4-jet structure of the event (D vanishes for a planar event)
 double 
-EventShapeVariables::D(double r) const
+EventShapeVariables::D()
 {
-  TVectorD eigenValues = compEigenValues(r);
-  return 27.*eigenValues(0)*eigenValues(1)*eigenValues(2);
+  if(!tensors_computed_) compTensorsAndVectors();
+  return 27.*eigenValues_[0]*eigenValues_[1]*eigenValues_[2];
 }
 
+//========================================================================================================
 
+/// set number of Fox-Wolfram moments to compute
+void 
+EventShapeVariables::setFWmax(unsigned m)
+{
+  fwmom_maxl_ = m;
+  fwmom_computed_ = false;
+  fwmom_ = std::vector<double>(fwmom_maxl_,0.);
+}
 
+double EventShapeVariables::getFWmoment( unsigned l ) {
+
+  if ( l > fwmom_maxl_ ) return 0. ;
+
+  if ( !fwmom_computed_ ) computeFWmoments() ;
+
+  return fwmom_[l] ;
+
+} // getFWmoment
+
+const std::vector<double>& EventShapeVariables::getFWmoments() {
+  if ( !fwmom_computed_ ) computeFWmoments() ;
+
+  return fwmom_;
+}
+
+void EventShapeVariables::computeFWmoments() {
+  if(fwmom_computed_) return;
+
+  double esum_total(0.) ;
+  for ( unsigned int i = 0 ; i < inputVectors_.size() ; i ++ ) {
+     esum_total += inputVectors_[i].R() ;
+  } // i
+  double esum_total_sq = esum_total * esum_total ;
+
+  for ( unsigned int i = 0 ; i < inputVectors_.size() ; i ++ ) {
+
+     double p_i = inputVectors_[i].R() ;
+     if ( p_i <= 0 ) continue ;
+
+     for ( unsigned int j = 0 ; j <= i ; j ++ ) {
+
+        double p_j = inputVectors_[j].R() ;
+        if ( p_j <= 0 ) continue ;
+
+        /// reduce computation by exploiting symmetry:
+        /// all off-diagonal elements appear twice in the sum
+        int symmetry_factor = 2;
+        if( j == i ) symmetry_factor = 1;
+        double p_ij = p_i * p_j;
+        double cosTheta = inputVectors_[i].Dot( inputVectors_[j] ) / (p_ij) ;
+        double pi_pj_over_etot2 = p_ij / esum_total_sq ;
+
+        /// compute higher legendre polynomials recursively
+        /// need to keep track of two previous values
+        double Pn1 = 0;
+        double Pn2 = 0;
+        for ( unsigned n = 0; n < fwmom_maxl_; n ++ ) {
+            /// initial cases
+            if ( n == 0 ) {
+                Pn2 = pi_pj_over_etot2;
+                fwmom_[0] += Pn2*symmetry_factor;
+            }
+            else if ( n == 1 ) {
+                Pn1 = pi_pj_over_etot2 * cosTheta;
+                fwmom_[1] += Pn1*symmetry_factor;
+            }
+            else {
+                double Pn = ((2*n-1)*cosTheta*Pn1 - (n-1)*Pn2)/n;
+                fwmom_[n] += Pn*symmetry_factor;
+                /// store new value
+                Pn2 = Pn1;
+                Pn1 = Pn;
+            }
+        }
+
+     } // j
+  } // i
+
+  fwmom_computed_ = true;
+
+} // computeFWmoments
+
+//========================================================================================================


### PR DESCRIPTION
I was looking at these variables for an analysis and became dissatisfied with inefficiencies in the code. My changes include:
* remove commented-out code
* update documentation in comments
* use range-based loops
* avoid repeated computations of momentum tensor and eigenvalues
* avoid unnecessary use of `TVectorD::operator()` (incredibly slow for some reason, thanks ROOT)
  * assignment of ROOT matrix objects is also slow, so tried to avoid that
* avoid repeated trig computations

In addition, @owen234 had introduced the calculation of Fox-Wolfram moments in a private version of this code. I optimized it as follows:
* calculate Legendre polynomials using recursive definition (minimize computation)
* use symmetry factor to reduce summation (i,j term same as j,i term)

The updates are propagated to the associated producer.

attn: @justinrpilot @nstrobbe