### PR TITLE
Various packages: clean up clang warning unknown warning group

### DIFF
--- a/CondFormats/RunInfo/test/fromXML.cpp
+++ b/CondFormats/RunInfo/test/fromXML.cpp
@@ -14,8 +14,9 @@
 
 // The compiler knows our default-constructed objects' members
 // may not be initialized when we serialize them.
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-
+#endif
 
 template <typename T>
 void toXML( std::string filename="" )

--- a/CondFormats/Serialization/interface/Test.h
+++ b/CondFormats/Serialization/interface/Test.h
@@ -11,8 +11,9 @@
 
 // The compiler knows our default-constructed objects' members
 // may not be initialized when we serialize them.
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-
+#endif
 // The main test: constructs an object using the default constructor,
 // serializes it, deserializes it and finally checks whether they are equal.
 // Mainly used to see if all the required templates compile.

--- a/FWCore/Services/plugins/DependencyGraph.cc
+++ b/FWCore/Services/plugins/DependencyGraph.cc
@@ -17,7 +17,9 @@
 
 // boost optional (used by boost graph) results in some false positives with -Wmaybe-uninitialized
 #pragma GCC diagnostic push
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/graphviz.hpp>
 #include <boost/graph/lookup_edge.hpp>

--- a/HLTrigger/Timer/interface/ProcessCallGraph.h
+++ b/HLTrigger/Timer/interface/ProcessCallGraph.h
@@ -13,7 +13,9 @@
 
 // boost optional (used by boost graph) results in some false positives with -Wmaybe-uninitialized
 #pragma GCC diagnostic push
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/lookup_edge.hpp>
 #include <boost/graph/subgraph.hpp>

--- a/HLTrigger/Timer/src/ProcessCallGraph.cc
+++ b/HLTrigger/Timer/src/ProcessCallGraph.cc
@@ -10,7 +10,9 @@
 
 // boost optional (used by boost graph) results in some false positives with -Wmaybe-uninitialized
 #pragma GCC diagnostic push
+#ifndef __clang__ 
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #include <boost/graph/depth_first_search.hpp>
 #pragma GCC diagnostic pop
 

--- a/PerfTools/Callgrind/plugins/CallgrindAnalyzer.cc
+++ b/PerfTools/Callgrind/plugins/CallgrindAnalyzer.cc
@@ -91,7 +91,9 @@ Profiler::~Profiler()
 
 // ------------ method called to for each event  ------------
 #pragma GCC diagnostic push
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
 void
 Profiler::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {

--- a/PerfTools/Callgrind/src/ProfilerService.cc
+++ b/PerfTools/Callgrind/src/ProfilerService.cc
@@ -43,7 +43,9 @@ ProfilerService::~ProfilerService(){
 }
 
 #pragma GCC diagnostic push
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
 bool ProfilerService::startInstrumentation(){
   // FIXME here or in client?
   if (!doEvent()) return false;


### PR DESCRIPTION
 warning: unknown warning group '-Wmaybe-uninitialized', ignored [-Wunknown-warning-option]
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
                               ^

warning: unknown warning group '-Wunused-but-set-variable', ignored [-Wunknown-warning-option]
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
                               ^