### PR TITLE
Reduce customization duplication in muon associator

### DIFF
--- a/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
+++ b/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
@@ -94,6 +94,13 @@ muonAssociatorByHitsCommonParameters = cms.PSet(
     inputCSCSegmentCollection = cms.InputTag("cscSegments"),
 )
 
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+run3_GEM.toModify(muonAssociatorByHitsCommonParameters, useGEMs = True)
+phase2_tracker.toModify(muonAssociatorByHitsCommonParameters,
+    usePhase2Tracker = True,
+    pixelSimLinkSrc = "simSiPixelDigis:Pixel",
+)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(muonAssociatorByHitsCommonParameters,
@@ -139,8 +146,3 @@ muonAssociatorByHits = cms.EDProducer("MuonAssociatorEDProducer",
     ignoreMissingTrackCollection = cms.untracked.bool(False),
 )
 
-from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-run3_GEM.toModify( muonAssociatorByHits, useGEMs = cms.bool(True) )
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify( muonAssociatorByHits, usePhase2Tracker = cms.bool(True) )
-phase2_tracker.toModify( muonAssociatorByHits, pixelSimLinkSrc = "simSiPixelDigis:Pixel" )

--- a/SimMuon/MCTruth/python/muonAssociatorByHitsNoSimHitsHelper_cfi.py
+++ b/SimMuon/MCTruth/python/muonAssociatorByHitsNoSimHitsHelper_cfi.py
@@ -24,9 +24,3 @@ muonAssociatorByHitsNoSimHitsHelper.DTsimhitsTag  = ""
    
 # use only muon system
 muonAssociatorByHitsNoSimHitsHelper.UseTracker = False
-
-from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-run3_GEM.toModify( muonAssociatorByHitsNoSimHitsHelper, useGEMs = cms.bool(True) )
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify( muonAssociatorByHitsNoSimHitsHelper, usePhase2Tracker = cms.bool(True) )
-phase2_tracker.toModify( muonAssociatorByHitsNoSimHitsHelper, pixelSimLinkSrc = "simSiPixelDigis:Pixel" )


### PR DESCRIPTION
This PR suggests to reduce duplication of muon associator customizations by customizing directly `muonAssociatorByHitsCommonParameters` instead of `muonAssociatorByHits` and `muonAssociatorByHitsNoSimHitsHelper`.

Tested in CMSSW_10_1_X_2018-03-05-2300, no changes expected.
