### PR TITLE
Pr93x TTStubCluster Association in FEVTDEBUG eventcontent

### DIFF
--- a/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
+++ b/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
@@ -13,7 +13,10 @@ SimTrackerFEVTDEBUG = cms.PSet(
         'keep *_assoc2thStepTk_*_*', 
         'keep *_assoc2GsfTracks_*_*', 
         'keep *_assocOutInConversionTracks_*_*', 
-        'keep *_assocInOutConversionTracks_*_*')
+        'keep *_assocInOutConversionTracks_*_*',
+        'keep *_TTClusterAssociatorFromPixelDigis_*_*',
+        'keep *_TTStubAssociatorFromPixelDigis_*_*')
+
 )
 
 SimTrackerDEBUG = cms.PSet(


### PR DESCRIPTION
93x version of simple #22415 :

 Adding TTStub && TTCluster Association products to  `SimTrackerFEVTDEBUG` EventContent:

```
'keep *_TTClusterAssociatorFromPixelDigis_*_*',
'keep *_TTStubAssociatorFromPixelDigis_*_*'
```