### PR TITLE
HCALDQM: Fix digi size reference for summary plots (10_0_X)

### DIFF
--- a/DQM/HcalCommon/interface/Constants.h
+++ b/DQM/HcalCommon/interface/Constants.h
@@ -180,7 +180,6 @@ namespace hcaldqm
 		int const HF = 4;
 		int const SUBDET_NUM = 4;
 		int const TPSUBDET_NUM = 2;
-		int const DIGISIZE[SUBDET_NUM] = {10, 10, 10, 3};
 		std::string const SUBDET_NAME[SUBDET_NUM]={"HB", "HE", "HO", "HF"};
 		std::string const SUBDETPM_NAME[2*SUBDET_NUM] = { "HBM", "HBP",
 			"HEM", "HEP", "HOM", "HOP", "HFM", "HFP"};

--- a/DQM/HcalTasks/interface/DigiRunSummary.h
+++ b/DQM/HcalTasks/interface/DigiRunSummary.h
@@ -3,6 +3,7 @@
 
 #include "DQM/HcalCommon/interface/DQClient.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
 namespace hcaldqm
 {
@@ -37,6 +38,8 @@ namespace hcaldqm
 
 			ContainerXXX<uint32_t> _xDead, _xDigiSize, _xUniHF,
 				_xUni, _xNChs, _xNChsNominal;
+
+			std::map<HcalSubdetector, uint32_t> _refDigiSize;
 
 			//	flag enum
 			enum DigiLSFlag

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -69,6 +69,8 @@ class DigiTask : public hcaldqm::DQTask
 		//	hashes/FED vectors
 		std::vector<uint32_t> _vhashFEDs;
 
+		std::map<HcalSubdetector, int> _refDigiSize;
+
 		//	emap
 		hcaldqm::electronicsmap::ElectronicsMap _ehashmap; // online only
 		hcaldqm::electronicsmap::ElectronicsMap _dhashmap;

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -34,6 +34,13 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_vflags[fUnknownIds]=hcaldqm::flag::Flag("UnknownIds");
 
 	_qie10InConditions = ps.getUntrackedParameter<bool>("qie10InConditions", true);
+
+	// Get reference digi sizes. Convert from unsigned to signed int, because <digi>::size()/samples() return ints for some reason.
+	std::vector<uint32_t> vrefDigiSize = ps.getUntrackedParameter<std::vector<uint32_t>>("refDigiSize");
+	_refDigiSize[HcalBarrel]  = (int)vrefDigiSize[0];
+	_refDigiSize[HcalEndcap]  = (int)vrefDigiSize[1];
+	_refDigiSize[HcalOuter]   = (int)vrefDigiSize[2];
+	_refDigiSize[HcalForward] = (int)vrefDigiSize[3];
 }
 
 /* virtual */ void DigiTask::bookHistograms(DQMStore::IBooker& ib,
@@ -645,7 +652,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		if (_ptype==fOnline)
 		{
 			_cDigiSizevsLS_FED.fill(eid, _currentLS, it->size());
-			it->size()!=constants::DIGISIZE[did.subdet()-1]?
+			it->size()!=_refDigiSize[did.subdet()]?
 				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
 			_cOccupancyvsiphi_SubdetPM.fill(did);
 			_cOccupancyvsieta_Subdet.fill(did);
@@ -768,7 +775,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		if (_ptype==fOnline)
 		{
 			_cDigiSizevsLS_FED.fill(eid, _currentLS, digi.samples());
-			digi.samples()!=constants::DIGISIZE[did.subdet()-1]?
+			digi.samples()!=_refDigiSize[did.subdet()]?
 				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
 			_cOccupancyvsiphi_SubdetPM.fill(did);
 			_cOccupancyvsieta_Subdet.fill(did);
@@ -895,7 +902,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		if (_ptype==fOnline)
 		{
 			_cDigiSizevsLS_FED.fill(eid, _currentLS, it->size());
-			it->size()!=constants::DIGISIZE[did.subdet()-1]?
+			it->size()!=_refDigiSize[did.subdet()]?
 				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
 			_cOccupancyvsiphi_SubdetPM.fill(did);
 			_cOccupancyvsieta_Subdet.fill(did);
@@ -1039,7 +1046,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			{
 				_xNChs.get(eid)++;
 				_cDigiSizevsLS_FED.fill(eid, _currentLS, digi.samples());
-				digi.samples()!=constants::DIGISIZE[did.subdet()-1]?
+				digi.samples()!=_refDigiSize[did.subdet()]?
 					_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
 				_cOccupancyvsiphi_SubdetPM.fill(did);
 				_cOccupancyvsieta_Subdet.fill(did);

--- a/DQM/HcalTasks/python/DigiTask.py
+++ b/DQM/HcalTasks/python/DigiTask.py
@@ -28,13 +28,13 @@ digiTask = cms.EDAnalyzer(
 	qie10InConditions = cms.untracked.bool(False),
 
 	# Reference digi sizes
-	refDigiSize = cms.untracked.vint32(10, 10, 10, 4), # HB, HE, HF, HO
+	refDigiSize = cms.untracked.vuint32(10, 10, 10, 4), # HB, HE, HF, HO
 )
 
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 run2_HF_2017.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
-run2_HF_2017.toModify(digiTask, refDigiSize=cms.untracked.vint32(10, 10, 10, 3))
+run2_HF_2017.toModify(digiTask, refDigiSize=cms.untracked.vuint32(10, 10, 10, 3))
 
 from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
 run2_HCAL_2018.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
-run2_HCAL_2018.toModify(digiTask, refDigiSize=cms.untracked.vint32(8, 8, 10, 3))
+run2_HCAL_2018.toModify(digiTask, refDigiSize=cms.untracked.vuint32(8, 8, 10, 3))

--- a/DQM/HcalTasks/python/DigiTask.py
+++ b/DQM/HcalTasks/python/DigiTask.py
@@ -28,7 +28,7 @@ digiTask = cms.EDAnalyzer(
 	qie10InConditions = cms.untracked.bool(False),
 
 	# Reference digi sizes
-	refDigiSize = cms.untracked.vuint32(10, 10, 10, 4), # HB, HE, HF, HO
+	refDigiSize = cms.untracked.vuint32(10, 10, 10, 4), # HB, HE, HO, HF
 )
 
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017

--- a/DQM/HcalTasks/python/DigiTask.py
+++ b/DQM/HcalTasks/python/DigiTask.py
@@ -26,7 +26,15 @@ digiTask = cms.EDAnalyzer(
 	thresh_unifh = cms.untracked.double(0.2),
 
 	qie10InConditions = cms.untracked.bool(False),
+
+	# Reference digi sizes
+	refDigiSize = cms.untracked.vint32(10, 10, 10, 4), # HB, HE, HF, HO
 )
 
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 run2_HF_2017.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
+run2_HF_2017.toModify(digiTask, refDigiSize=cms.untracked.vint32(10, 10, 10, 3))
+
+from Configuration.StandardSequences.Eras import eras
+eras.Run2_2018.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
+eras.Run2_2018.toModify(digiTask, refDigiSize=cms.untracked.vint32(8, 8, 10, 3))

--- a/DQM/HcalTasks/python/DigiTask.py
+++ b/DQM/HcalTasks/python/DigiTask.py
@@ -35,6 +35,6 @@ from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 run2_HF_2017.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
 run2_HF_2017.toModify(digiTask, refDigiSize=cms.untracked.vint32(10, 10, 10, 3))
 
-from Configuration.StandardSequences.Eras import eras
-eras.Run2_2018.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
-eras.Run2_2018.toModify(digiTask, refDigiSize=cms.untracked.vint32(8, 8, 10, 3))
+from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+run2_HCAL_2018.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
+run2_HCAL_2018.toModify(digiTask, refDigiSize=cms.untracked.vint32(8, 8, 10, 3))

--- a/DQM/HcalTasks/python/HcalOfflineHarvesting.py
+++ b/DQM/HcalTasks/python/HcalOfflineHarvesting.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQM.HcalTasks.DigiTask import digiTask
 
 hcalOfflineHarvesting = DQMEDHarvester(
 	"HcalOfflineHarvesting",
@@ -17,5 +18,6 @@ hcalOfflineHarvesting = DQMEDHarvester(
 	thresh_FGMsmRate_high = cms.untracked.double(0.2),
 	thresh_FGMsmRate_low = cms.untracked.double(0.1),
 	thresh_unihf = cms.untracked.double(0.2),
-	thresh_tcds = cms.untracked.double(1.5)
+	thresh_tcds = cms.untracked.double(1.5),
+	refDigiSize = digiTask.refDigiSize,
 )

--- a/DQM/HcalTasks/python/HcalOnlineHarvesting.py
+++ b/DQM/HcalTasks/python/HcalOnlineHarvesting.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
-from DQM.HcalTasks.DigiTask import DigiTask
+from DQM.HcalTasks.DigiTask import digiTask
 
 hcalOnlineHarvesting = DQMEDHarvester(
 	"HcalOnlineHarvesting",

--- a/DQM/HcalTasks/python/HcalOnlineHarvesting.py
+++ b/DQM/HcalTasks/python/HcalOnlineHarvesting.py
@@ -12,5 +12,5 @@ hcalOnlineHarvesting = DQMEDHarvester(
 	ptype = cms.untracked.int32(0),
 	mtype = cms.untracked.bool(True),
 	subsystem = cms.untracked.string("Hcal"),
-	refDigiSize = DigiTask.refDigiSize,
+	refDigiSize = digiTask.refDigiSize,
 )

--- a/DQM/HcalTasks/python/HcalOnlineHarvesting.py
+++ b/DQM/HcalTasks/python/HcalOnlineHarvesting.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQM.HcalTasks.DigiTask import DigiTask
 
 hcalOnlineHarvesting = DQMEDHarvester(
 	"HcalOnlineHarvesting",
@@ -11,4 +12,5 @@ hcalOnlineHarvesting = DQMEDHarvester(
 	ptype = cms.untracked.int32(0),
 	mtype = cms.untracked.bool(True),
 	subsystem = cms.untracked.string("Hcal"),
+	refDigiSize = DigiTask.refDigiSize,
 )

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -8,6 +8,12 @@ namespace hcaldqm
 	{
 		_thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf",
 			0.2);
+
+		std::vector<uint32_t> vrefDigiSize = ps.getUntrackedParameter<std::vector<uint32_t>>("refDigiSize");
+		_refDigiSize[HcalBarrel]  = vrefDigiSize[0];
+		_refDigiSize[HcalEndcap]  = vrefDigiSize[1];
+		_refDigiSize[HcalOuter]   = vrefDigiSize[2];
+		_refDigiSize[HcalForward] = vrefDigiSize[3];
 	}
 
 	/* virtual */ void DigiRunSummary::beginRun(edm::Run const& r,
@@ -140,7 +146,7 @@ namespace hcaldqm
 			_cOccupancy_depth.fill(did, cOccupancy_depth.getBinContent(did));
 			//	digi size
 			cDigiSize_Crate.getMean(eid)!=
-				constants::DIGISIZE[did.subdet()-1]?
+				_refDigiSize[did.subdet()]?
 				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
 			cDigiSize_Crate.getRMS(eid)!=0?
 				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;


### PR DESCRIPTION
Fixes the digi size reference (HB, HE from 10 to 8) for the summary plots. Also moves the location of the reference from C++ (HcalCommon/interface/Constants.h) to python (DigiTask.py, and copied via import to HcalOnlineHarvesting.py and HcalOfflineHarvesting.py).

10_0_X backport of https://github.com/cms-sw/cmssw/pull/22595.