### PR TITLE
Fix compilation warnings in gcc7 IBs

### DIFF
--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -60,7 +60,7 @@ namespace edm {
   public:
     typedef ProductRegistryHelper::TypeLabelList TypeLabelList;
     ProducerBase ();
-    virtual ~ProducerBase() noexcept(false);
+    ~ProducerBase() override;
  
     /// used by the fwk to register list of products
     std::function<void(BranchDescription const&)> registrationCallback() const;

--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -21,10 +21,10 @@ namespace edm {
   struct DoNotRecordParents;
   
   class ProductRegistryHelper {
-  public:
-
-    ProductRegistryHelper() : typeLabelList_() {}
+  protected:
     ~ProductRegistryHelper();
+  public:
+    ProductRegistryHelper() : typeLabelList_() {}
 
     // has_donotrecordparents<T>::value is true if we should not
     // record parentage for type T, and false otherwise.

--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -21,9 +21,8 @@ namespace edm {
   struct DoNotRecordParents;
   
   class ProductRegistryHelper {
-  protected:
-    ~ProductRegistryHelper();
   public:
+    virtual ~ProductRegistryHelper() noexcept(false);
     ProductRegistryHelper() : typeLabelList_() {}
 
     // has_donotrecordparents<T>::value is true if we should not

--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -14,7 +14,7 @@
 #include <typeindex>
 
 namespace edm {
-  ProductRegistryHelper::~ProductRegistryHelper() { }
+  ProductRegistryHelper::~ProductRegistryHelper() noexcept(false) { }
 
   ProductRegistryHelper::TypeLabelList const& ProductRegistryHelper::typeLabelList() const {
     return typeLabelList_;


### PR DESCRIPTION
PR https://github.com/cms-sw/cmssw/pull/22560 introduced some warnings
 https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc7_amd64_gcc700/www/tue/10.1-tue-11/CMSSW_10_1_X_2018-03-13-1100
 adding virtual methods to a class with publicly accessible destructor this is fix. 