### PR TITLE
use DeltaZCut=0.3 for Phase2 Puppi

### DIFF
--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -85,7 +85,6 @@ puppi = cms.EDProducer("PuppiProducer",#cms.PSet(#"PuppiProducer",
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(
     puppi,
-    DeltaZCut = cms.double(0.1),
     algos = cms.VPSet( 
         cms.PSet( 
              etaMin = cms.vdouble(0.,  2.5),


### PR DESCRIPTION
For the Phase 2 endcap TDR and b-tagging validation studies, DeltaZCut=0.3 was found to give better b-tagging performance than DeltaZCut=0.1. Since 0.3 is the default value for Run2, I just removed the Phase2 customization.

This PR will be backported to 93X.