### PR TITLE
Fix missing plots in Tau Validation

### DIFF
--- a/Validation/RecoTau/plugins/DQMHistEffProducer.cc
+++ b/Validation/RecoTau/plugins/DQMHistEffProducer.cc
@@ -115,7 +115,7 @@ void TauDQMHistEffProducer::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGette
       std::string effHistogramName, effHistogramDirectory, dummy;
       separateHistogramFromDirectoryName(plot->efficiency_, effHistogramName, effHistogramDirectory);
       //if ( effHistogramDirectory == "" ) separateHistogramFromDirectoryName(numeratorHistogramName, dummy, effHistogramDirectory);
-      if ( effHistogramDirectory != "" ) 
+      if ( !effHistogramDirectory.empty() ) 
 	{
 	  if(iget.dirExists(effHistogramDirectory))
 	    ibook.setCurrentFolder(effHistogramDirectory);

--- a/Validation/RecoTau/plugins/DQMHistEffProducer.cc
+++ b/Validation/RecoTau/plugins/DQMHistEffProducer.cc
@@ -82,22 +82,9 @@ TauDQMHistEffProducer::~TauDQMHistEffProducer()
 //--- nothing to be done yet
 }
 
-void TauDQMHistEffProducer::analyze(const edm::Event&, const edm::EventSetup&)
-{
-//--- nothing to be done yet
-}
-
-void TauDQMHistEffProducer::endRun(const edm::Run& r, const edm::EventSetup& c)
+void TauDQMHistEffProducer::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& iget)
 {
   //std::cout << "<TauDQMHistEffProducer::endJob>:" << std::endl;
-
-//--- check that DQMStore service is available
-  if ( !edm::Service<DQMStore>().isAvailable() ) {
-    edm::LogError ("endJob") << " Failed to access dqmStore --> histograms will NOT be plotted !!";
-    return;
-  }
-
-  DQMStore& dqmStore = (*edm::Service<DQMStore>());
 
   for ( std::vector<cfgEntryPlot>::const_iterator plot = cfgEntryPlot_.begin(); plot != cfgEntryPlot_.end(); ++plot ) {
     //std::cout << "plot->numerator_ = " << plot->numerator_ << std::endl;
@@ -105,7 +92,7 @@ void TauDQMHistEffProducer::endRun(const edm::Run& r, const edm::EventSetup& c)
     separateHistogramFromDirectoryName(plot->numerator_, numeratorHistogramName, numeratorHistogramDirectory);
     //std::cout << "numeratorHistogramName = " << numeratorHistogramName << std::endl;
     //std::cout << "numeratorHistogramDirectory = " << numeratorHistogramDirectory << std::endl;
-    MonitorElement* meNumerator = dqmStore.get(std::string(numeratorHistogramDirectory).append(dqmSeparator).append(numeratorHistogramName));
+    MonitorElement* meNumerator = iget.get(std::string(numeratorHistogramDirectory).append(dqmSeparator).append(numeratorHistogramName));
     //std::cout << "meNumerator = " << meNumerator << std::endl;
     TH1* histoNumerator = ( meNumerator != nullptr ) ? meNumerator->getTH1() : nullptr;
     
@@ -114,7 +101,7 @@ void TauDQMHistEffProducer::endRun(const edm::Run& r, const edm::EventSetup& c)
     separateHistogramFromDirectoryName(plot->denominator_, denominatorHistogramName, denominatorHistogramDirectory);
     //std::cout << "denominatorHistogramName = " << denominatorHistogramName << std::endl;
     //std::cout << "denominatorHistogramDirectory = " << denominatorHistogramDirectory << std::endl;
-    MonitorElement* meDenominator = dqmStore.get(std::string(denominatorHistogramDirectory).append(dqmSeparator).append(denominatorHistogramName));
+    MonitorElement* meDenominator = iget.get(std::string(denominatorHistogramDirectory).append(dqmSeparator).append(denominatorHistogramName));
     //std::cout << "meDenominator = " << meDenominator << std::endl;
     TH1* histoDenominator = ( meDenominator != nullptr ) ? meDenominator->getTH1() : nullptr;
     
@@ -130,13 +117,13 @@ void TauDQMHistEffProducer::endRun(const edm::Run& r, const edm::EventSetup& c)
       //if ( effHistogramDirectory == "" ) separateHistogramFromDirectoryName(numeratorHistogramName, dummy, effHistogramDirectory);
       if ( effHistogramDirectory != "" ) 
 	{
-	  if(dqmStore.dirExists(effHistogramDirectory))
-	    dqmStore.setCurrentFolder(effHistogramDirectory);
+	  if(iget.dirExists(effHistogramDirectory))
+	    ibook.setCurrentFolder(effHistogramDirectory);
 	  else
 	    std::cout<<"TauDQMHistEffProducer:: Directory: "<<effHistogramDirectory<<" does not exist!"<<std::endl;
 	}
       
-      MonitorElement* histoEfficiency = dqmStore.book1D(effHistogramName, effHistogramName, 
+      MonitorElement* histoEfficiency = ibook.book1D(effHistogramName, effHistogramName, 
 							histoNumerator->GetNbinsX(), histoNumerator->GetXaxis()->GetXmin(), histoNumerator->GetXaxis()->GetXmax());
       
       histoEfficiency->getTH1F()->Divide(histoNumerator, histoDenominator, 1., 1., "B");

--- a/Validation/RecoTau/plugins/DQMHistEffProducer.h
+++ b/Validation/RecoTau/plugins/DQMHistEffProducer.h
@@ -34,7 +34,7 @@ class TauDQMHistEffProducer : public DQMEDHarvester
  public:
   explicit TauDQMHistEffProducer(const edm::ParameterSet&);
   ~TauDQMHistEffProducer() override;
-  void dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& iget);
+  void dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& iget) override;
 
 private:
   std::vector<cfgEntryPlot> cfgEntryPlot_;

--- a/Validation/RecoTau/plugins/DQMHistEffProducer.h
+++ b/Validation/RecoTau/plugins/DQMHistEffProducer.h
@@ -15,11 +15,12 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
 
 #include <string>
 #include <vector>
 
-class TauDQMHistEffProducer : public edm::EDAnalyzer
+class TauDQMHistEffProducer : public DQMEDHarvester
 {
   struct cfgEntryPlot
   {
@@ -33,9 +34,7 @@ class TauDQMHistEffProducer : public edm::EDAnalyzer
  public:
   explicit TauDQMHistEffProducer(const edm::ParameterSet&);
   ~TauDQMHistEffProducer() override;
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override{}
-  void endRun(const edm::Run& r, const edm::EventSetup& c) override;
+  void dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& iget);
 
 private:
   std::vector<cfgEntryPlot> cfgEntryPlot_;

--- a/Validation/RecoTau/python/RecoTauValidation_cfi.py
+++ b/Validation/RecoTau/python/RecoTauValidation_cfi.py
@@ -221,7 +221,8 @@ EFFICIENCY
 """
 
 plotPset = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominator)
-proc.efficiencies = cms.EDAnalyzer(
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+proc.efficiencies = DQMEDHarvester(
    "TauDQMHistEffProducer",
    plots = plotPset    
    )

--- a/Validation/RecoTau/python/ValidationUtils.py
+++ b/Validation/RecoTau/python/ValidationUtils.py
@@ -133,8 +133,7 @@ def SetPlotSequence(sequence):
     scanner = Scanner()
     sequence.visit(scanner)
     for analyzer in scanner.modules():#The first one is the sequence itself
-        if type(analyzer) is cms.EDAnalyzer:
-            PlotAnalyzer(pset, analyzer)
+        PlotAnalyzer(pset, analyzer)
     return pset
 
 def SpawnPSet(lArgument, subPset):


### PR DESCRIPTION
The `*Effeta, *Effpt, *Effphi, *Effpileup` histograms in the `RecoTauV` folder of DQM went missing in pre2. The reason is that the fancy configuration logic in this package expected DQM modules to be `EDAnalyzer`s, which is no longer correct. This PR fixes the issue.

I also migrated the Efficiency plugin to be a non-legacy `DQMEDHarvester`, which turned out to be unrelated but is better that way.

@steggema FYI