### PR TITLE
Cleanup definition of exotic particles

### DIFF
--- a/SimG4Core/CustomPhysics/interface/CustomPhysicsList.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPhysicsList.h
@@ -7,7 +7,6 @@
 #include <string>
 
 class G4ProcessHelper;
-class G4Decay;
 class CustomParticleFactory;
 
 class CustomPhysicsList : public G4VPhysicsConstructor 
@@ -21,9 +20,7 @@ public:
 
 private:
 
-  static G4ThreadLocal std::unique_ptr<G4Decay> fDecayProcess;
   static G4ThreadLocal std::unique_ptr<G4ProcessHelper> myHelper;
-
   std::unique_ptr<CustomParticleFactory> fParticleFactory;
 
   bool fHadronicInteraction;

--- a/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
+++ b/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
@@ -4,7 +4,7 @@ def customise(process):
     
     FLAVOR = process.generator.hscpFlavor.value()
     MASS_POINT = process.generator.massPoint.value()
-    SLHA_FILE = process.generator.slhaFile.value()
+    SLHA_FILE = process.generator.SLHAFileForPythia8.value()
     PROCESS_FILE = process.generator.processFile.value()
     PARTICLE_FILE = process.generator.particleFile.value()
     USE_REGGE = process.generator.useregge.value()

--- a/SimG4Core/CustomPhysics/src/CustomPhysics.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysics.cc
@@ -27,7 +27,7 @@ CustomPhysics::CustomPhysics(G4LogicalVolumeToDDLogicalPartMap& map,
   bool ssPhys  = p.getUntrackedParameter<bool>("ExoticaPhysicsSS",false);
   double timeLimit = p.getParameter<double>("MaxTrackTime")*ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_FTFP_BERT_EML for regular particles \n"
+			      << "FTFP_BERT_EMM for regular particles \n"
 			      << "CustomPhysicsList " << ssPhys << " for exotics; "
                               << " tracking cut " << tracking << "  t(ns)= " << timeLimit/ns;
   // EM Physics

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -9,7 +9,6 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "G4Decay.hh"
 #include "G4hMultipleScattering.hh"
 #include "G4hIonisation.hh"
 #include "G4ProcessManager.hh"
@@ -19,7 +18,6 @@
 
 using namespace CLHEP;
 
-G4ThreadLocal std::unique_ptr<G4Decay> CustomPhysicsList::fDecayProcess;
 G4ThreadLocal std::unique_ptr<G4ProcessHelper> CustomPhysicsList::myHelper;
 
 CustomPhysicsList::CustomPhysicsList(const std::string& name, const edm::ParameterSet & p)  
@@ -33,7 +31,6 @@ CustomPhysicsList::CustomPhysicsList(const std::string& name, const edm::Paramet
   particleDefFilePath = fp.fullPath();
 
   fParticleFactory.reset(new CustomParticleFactory());
-  fDecayProcess.reset(nullptr);
   myHelper.reset(nullptr);
 
   edm::LogInfo("SimG4CoreCustomPhysics") 
@@ -56,7 +53,6 @@ void CustomPhysicsList::ConstructProcess() {
     <<"CustomPhysicsList: adding CustomPhysics processes "
     << "for the list of particles";
 
-  fDecayProcess.reset(new G4Decay());
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
   for(auto particle : fParticleFactory.get()->GetCustomParticles()) {
@@ -71,9 +67,6 @@ void CustomPhysicsList::ConstructProcess() {
 	if(particle->GetPDGCharge() != 0.0) {
 	  ph->RegisterProcess(new G4hMultipleScattering, particle);
 	  ph->RegisterProcess(new G4hIonisation, particle);
-	}
-	if(fDecayProcess.get()->IsApplicable(*particle)) {
-	  ph->RegisterProcess(fDecayProcess.get(), particle);
 	}
 	if(cp->GetCloud() && fHadronicInteraction && 
 	   CustomPDGParser::s_isRHadron(particle->GetPDGEncoding())) {


### PR DESCRIPTION
Exotic particles are not part of Geant4 particle table. For Geant4 tracking of such particles they should be defined and corresponding physics processes (decay, ionisation...) should be assigned. This is done inside CustomPhysics sub-library, which is cleaned up in this PR:
 1) fixed reading of decay channels from slha data file (end of list of channels was not treated correctly
 2) added protection against double instantiation of G4Decay for an exotic particle
 3) Exclude decays with zero branching ratios
 4) improved LogDebug and LogInfo printouts

Should not affect mainstream MC production.