### PR TITLE
Add check for file open to edmWriteConfigs

### DIFF
--- a/FWCore/ParameterSet/src/ConfigurationDescriptions.cc
+++ b/FWCore/ParameterSet/src/ConfigurationDescriptions.cc
@@ -21,6 +21,8 @@
 #include <iomanip>
 #include <sstream>
 #include <cstring>
+#include <cerrno>
+#include <cstring>
 
 namespace {
   void matchLabel(std::pair<std::string, edm::ParameterSetDescription> const& thePair,
@@ -223,6 +225,15 @@ namespace edm {
       throw ex;
     }
     std::ofstream outFile(cfi_filename.c_str());
+    if(outFile.fail()) {
+      edm::Exception ex(edm::errors::LogicError,
+                        "Creating cfi file failed.\n");
+      ex << "Opening a file '" << cfi_filename << "' for module '" << labelAndDesc.first << "' failed.\n";
+      ex << "Error code from errno " << errno << ": " << std::strerror(errno) << "\n";
+      
+      ex.addContext("Executing function ConfigurationDescriptions::writeCfiForLabel");
+      throw ex;
+    }
 
     outFile << "import FWCore.ParameterSet.Config as cms\n\n";
     outFile << labelAndDesc.first << " = cms." << baseType << "('" << pluginName << "'";


### PR DESCRIPTION
#21818 revealed a case where the module label in `fillDescriptions()` exceeded the file system limit, while `edmWriteConfigs` did not complain anything. This PR adds a check if opening the file succeeded, and throws an exception (with `errno` value and more descriptive message) if it fails.

Tested in 10_1_0_pre3.

@Dr15Jones @wddgit 