### PR TITLE
Fix Calibation/LumiAlcaRecoProducers/plugins/BuildFile.xml

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/plugins/BuildFile.xml
+++ b/Calibration/LumiAlCaRecoProducers/plugins/BuildFile.xml
@@ -10,7 +10,6 @@
 <use   name="CondCore/DBOutputService"/>
 <use name="CondCore/ESSources"/>
 
-<use   name="Calibration/LumiAlCaRecoProducers"/>
 <use   name="DataFormats/Luminosity"/>
 <use name="CondFormats/DataRecord"/>
 <flags EDM_PLUGIN="1"/>


### PR DESCRIPTION
Fixes the following warning from scram
```
****WARNING: Invalid tool Calibration/LumiAlCaRecoProducers. Please fix src/Calibration/LumiAlCaRecoProducers/plugins/BuildFile.xml file.
```

Tested in 10_1_0_pre3, no changes expected.