### PR TITLE
Make available a custom function for uncollapsed HE depths at HLT

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -48,7 +48,8 @@ def customiseForUncollapsed(process):
 
     #remove collapser from sequence
     process.hltHbhereco = process.hltHbhePhase1Reco.clone()
-    process.HLTDoLocalHcalSequence = cms.Sequence( process.hltHcalDigis + process.hltHbhereco + process.hltHfprereco + process.hltHfreco + process.hltHoreco )
+    process.HLTDoLocalHcalSequence      = cms.Sequence( process.hltHcalDigis + process.hltHbhereco + process.hltHfprereco + process.hltHfreco + process.hltHoreco )
+    process.HLTStoppedHSCPLocalHcalReco = cms.Sequence( process.hltHcalDigis + process.hltHbhereco )
 
 
     return process    


### PR DESCRIPTION
this PR doesn't impact any central workflow.
a custom function to switch on and off the HCAL depth collapsing at HLT is made available.

- the current default configuration at HLT is `COLLAPSED`
- the `UNCOLLAPSED` configuration can be generated via `cmsDriver` adding the following customize:

```--customise HLTrigger/Configuration/customizeHLTforCMSSW.customiseForUncollapsed```


@mariadalfonso @silviodonato @abdoulline