### PR TITLE
Provide guard for streamLumiStatus_

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -304,6 +304,7 @@ namespace edm {
     std::vector<edm::SerialTaskQueue> streamQueues_;
     std::unique_ptr<edm::LimitedTaskQueue> lumiQueue_;
     std::vector<std::shared_ptr<LuminosityBlockProcessingStatus>> streamLumiStatus_;
+    std::atomic<unsigned int> streamLumiActive_{0}; //works as guard for streamLumiStatus
     
     std::vector<SubProcess> subProcesses_;
     edm::propagate_const<std::unique_ptr<HistoryAppender>> historyAppender_;


### PR DESCRIPTION
The member variable streamLumiStatus_ in EventProcessor is a vector containing status information for each stream. The framework needs to know how many streams are still processing a Lumi. Before, it checked the status of each item in the container. However, looking at that entry was not guaranteed to be synchronized across all threads. Adding streamLumiActive_ atomic variable allows the check to be done just by reading the atomic plus the atomic functions as a way to guarantee that the entry information can safely be read across threads. This is done by having streamLumiActive_ be written right after streamLumiStatus_ entry was changed and then read from streamLumiActive_ before reading the entry from streamLumiStatus_.