### PR TITLE
GT Updates with GEM electronics map, hadronic PF calibrations, JECs for 2017 MC

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,63 +2,63 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '101X_mcRun1_design_v1',
+    'run1_design'       :   '101X_mcRun1_design_v2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '101X_mcRun1_realistic_v1',
+    'run1_mc'           :   '101X_mcRun1_realistic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '101X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '101X_mcRun1_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '101X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '101X_mcRun1_pA_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '101X_mcRun2_design_v2',
+    'run2_design'       :   '101X_mcRun2_design_v3',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '101X_mcRun2_startup_v2',
+    'run2_mc_50ns'      :   '101X_mcRun2_startup_v3',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '101X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '101X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v4',
+    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v5',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '101X_mcRun2cosmics_startup_deco_v2',
+    'run2_mc_cosmics'   :   '101X_mcRun2cosmics_startup_deco_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '101X_mcRun2_HeavyIon_v3',
+    'run2_mc_hi'        :   '101X_mcRun2_HeavyIon_v4',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '101X_mcRun2_pA_v2',
+    'run2_mc_pa'        :   '101X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '101X_dataRun2_v6',
+    'run1_data'         :   '101X_dataRun2_v7',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '101X_dataRun2_v6',
+    'run2_data'         :   '101X_dataRun2_v7',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '101X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '101X_dataRun2_relval_v7',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '101X_dataRun2_PromptLike_v6',
+    'run2_data_promptlike' : '101X_dataRun2_PromptLike_v7',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v4',
+    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v5',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v4',
+    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v5',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '101X_dataRun2_HLT_relval_v5',
+    'run2_hlt_relval'   :   '101X_dataRun2_HLT_relval_v6',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v5',
+    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v4',
+    'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '101X_mc2017_realistic_v4',
+    'phase1_2017_realistic'    : '101X_mc2017_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '101X_mc2017cosmics_realistic_deco_v4',
+    'phase1_2017_cosmics'      : '101X_mc2017cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v4',
+    'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '101X_upgrade2018_design_v4',
+    'phase1_2018_design'       : '101X_upgrade2018_design_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v3',
+    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v4',
+    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '101X_postLS2_design_v2', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '101X_postLS2_design_v3', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'       : '101X_postLS2_realistic_v2', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'       : '101X_postLS2_realistic_v3', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '101X_upgrade2023_realistic_v2'
+    'phase2_realistic'         : '101X_upgrade2023_realistic_v3'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,7 +16,7 @@ autoCond = {
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '101X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v5',
+    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '101X_mcRun2cosmics_startup_deco_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## RunI simulation 
 
   * **RunI Heavy Ions scenario** : [101X_mcRun1_HeavyIon_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_HeavyIon_v2) as [101X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_HeavyIon_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun1_HeavyIon_v2/101X_mcRun1_HeavyIon_v1): 
      * update of hadronic PF calibrations

   * **RunI Ideal scenario** : [101X_mcRun1_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_design_v2) as [101X_mcRun1_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_design_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun1_design_v2/101X_mcRun1_design_v1): 
      * update of hadronic PF calibrations

   * **RunI Proton-Lead scenario** : [101X_mcRun1_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_pA_v2) as [101X_mcRun1_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_pA_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun1_pA_v2/101X_mcRun1_pA_v1): 
      * update of hadronic PF calibrations

   * **RunI Realistic scenario** : [101X_mcRun1_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_realistic_v2) as [101X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun1_realistic_v2/101X_mcRun1_realistic_v1): 
      * update of hadronic PF calibrations

## RunII simulation 
 
   * **RunII Asymptotic scenario** : [101X_mcRun2_asymptotic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_asymptotic_v3) as [101X_mcRun2_asymptotic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_asymptotic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun2_asymptotic_v3/101X_mcRun2_asymptotic_v2): 
      * update of hadronic PF calibrations

   * **RunII CRAFT scenario** : [101X_mcRun2cosmics_startup_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2cosmics_startup_deco_v3) as [101X_mcRun2cosmics_startup_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2cosmics_startup_deco_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun2cosmics_startup_deco_v3/101X_mcRun2cosmics_startup_deco_v2): 
      * update of hadronic PF calibrations

   * **RunII Heavy Ions scenario** : [101X_mcRun2_HeavyIon_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_HeavyIon_v4) as [101X_mcRun2_HeavyIon_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_HeavyIon_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun2_HeavyIon_v4/101X_mcRun2_HeavyIon_v3): 
      * update of hadronic PF calibrations

   * **RunII Ideal scenario** : [101X_mcRun2_design_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_design_v3) as [101X_mcRun2_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_design_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun2_design_v3/101X_mcRun2_design_v2): 
      * update of hadronic PF calibrations

   * **RunII Proton-Lead scenario** : [101X_mcRun2_pA_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_pA_v3) as [101X_mcRun2_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_pA_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun2_pA_v3/101X_mcRun2_pA_v2): 
      * update of hadronic PF calibrations

   * **RunII Startup scenario** : [101X_mcRun2_startup_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_startup_v3) as [101X_mcRun2_startup_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_startup_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun2_startup_v3/101X_mcRun2_startup_v2): 
      * update of hadronic PF calibrations

## RunI data 
 
   * **RunI HLT processing** : [101X_dataRun2_HLT_frozen_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLT_frozen_v5) as [101X_dataRun2_HLT_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLT_frozen_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_HLT_frozen_v5/101X_dataRun2_HLT_frozen_v4): 
      * update of hadronic PF calibrations
      * update of SiPixel 0T templates

   * **RunI Offline processing** : [101X_dataRun2_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_v7) as [101X_dataRun2_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_v7/101X_dataRun2_v6): 
      * update of hadronic PF calibrations
      * update of GEM electronics map
      * update of LumiPCC

## RunII data 
 
   * **RunII HLTHI processing** : [101X_dataRun2_HLTHI_frozen_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLTHI_frozen_v6) as [101X_dataRun2_HLTHI_frozen_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLTHI_frozen_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_HLTHI_frozen_v6/101X_dataRun2_HLTHI_frozen_v5): 
      * update of hadronic PF calibrations
      * update of GEM electronics map
      * update of SiPixel 0T tag

   * **RunII HLT relval processing** : [101X_dataRun2_HLT_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLT_relval_v6) as [101X_dataRun2_HLT_relval_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLT_relval_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_HLT_relval_v6/101X_dataRun2_HLT_relval_v5): 
      * update of hadronic PF calibrations
      * update of GEM electronics map
      * update of SiPixel 0T tag

   * **RunII Offline processing** : [101X_dataRun2_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_v7) as [101X_dataRun2_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_v7/101X_dataRun2_v6): 
      * update of hadronic PF calibrations
      * update of GEM electronics map
      * update of LumiPCC

   * **RunII Offline relval processing** : [101X_dataRun2_relval_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_relval_v7) as [101X_dataRun2_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_relval_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_relval_v7/101X_dataRun2_relval_v6): 
      * update of hadronic PF calibrations
      * update of GEM electronics map

   * **RunII Prompt processing** : [101X_dataRun2_PromptLike_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_PromptLike_v7) as [101X_dataRun2_PromptLike_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_PromptLike_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_PromptLike_v7/101X_dataRun2_PromptLike_v6): 
      * update of hadronic PF calibrations
      * update of GEM electronics map
      * update of SiPixel 0T tag

   * **RunI HLT processing** : [101X_dataRun2_HLT_frozen_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLT_frozen_v5) as [101X_dataRun2_HLT_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLT_frozen_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_HLT_frozen_v5/101X_dataRun2_HLT_frozen_v4): 
      * update of hadronic PF calibrations
      * update of GEM electronics map
      * update of SiPixel 0T tag

## Upgrade 
 
   * **PhaseII realistic scenario** : [101X_upgrade2023_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2023_realistic_v3) as [101X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2023_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2023_realistic_v3/101X_upgrade2023_realistic_v2): 
      * update of hadronic PF calibrations
      * update of GEM electronics map

   * **PhaseI 2018 cosmics scenario** : [101X_upgrade2018cosmics_realistic_deco_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018cosmics_realistic_deco_v5) as [101X_upgrade2018cosmics_realistic_deco_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018cosmics_realistic_deco_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2018cosmics_realistic_deco_v5/101X_upgrade2018cosmics_realistic_deco_v4): 
      * update of GEM electronics map
      * update of hadronic PF calibrations

   * **PhaseI 2018 design scenario** : [101X_upgrade2018_design_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018_design_v5) as [101X_upgrade2018_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018_design_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2018_design_v5/101X_upgrade2018_design_v4): 
      * update of hadronic PF calibrations
      * update of GEM electronics map

   * **PhaseI 2018 realistic scenario** : [101X_upgrade2018_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018_realistic_v4) as [101X_upgrade2018_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018_realistic_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2018_realistic_v4/101X_upgrade2018_realistic_v3): 
      * update of GEM electronics map
      * update of hadronic PF calibrations

   * **PostLS2 design scenario** : [101X_postLS2_design_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_postLS2_design_v3) as [101X_postLS2_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_postLS2_design_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_postLS2_design_v3/101X_postLS2_design_v2): 
      * update of hadronic PF calibrations
      * update of GEM electronics map

   * **PostLS2 realistic scenario** : [101X_postLS2_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_postLS2_realistic_v3) as [101X_postLS2_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_postLS2_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_postLS2_realistic_v3/101X_postLS2_realistic_v2): 
      * update of GEM electronics map
      * update of hadronic PF calibrations

## 2017_MC 
 
   * **PhaseI 2017 cosmics peak scenario** : [101X_mc2017cosmics_realistic_peak_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017cosmics_realistic_peak_v5) as [101X_mc2017cosmics_realistic_peak_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017cosmics_realistic_peak_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mc2017cosmics_realistic_peak_v5/101X_mc2017cosmics_realistic_peak_v4): 
      * update of hadronic PF calibrations
      * update of GEM electronics map
      * update of JECs

   * **PhaseI 2017 cosmics scenario** : [101X_mc2017cosmics_realistic_deco_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017cosmics_realistic_deco_v5) as [101X_mc2017cosmics_realistic_deco_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017cosmics_realistic_deco_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mc2017cosmics_realistic_deco_v5/101X_mc2017cosmics_realistic_deco_v4): 
      * update of hadronic PF calibrations
      * update of GEM electronics map
      * update of JECs

   * **PhaseI 2017 design scenario** : [101X_mc2017_design_IdealBS_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017_design_IdealBS_v5) as [101X_mc2017_design_IdealBS_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017_design_IdealBS_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mc2017_design_IdealBS_v5/101X_mc2017_design_IdealBS_v4): 
      * update of hadronic PF calibrations
      * update of GEM electronics map
      * update of JECs

   * **PhaseI 2017 realistic scenario** : [101X_mc2017_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017_realistic_v5) as [101X_mc2017_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017_realistic_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mc2017_realistic_v5/101X_mc2017_realistic_v4): 
      * update of hadronic PF calibrations
      * update of GEM electronics map
      * update of JECs