### PR TITLE
New DQM plots for CSV PF b tag trigger paths

### DIFF
--- a/DQMOffline/Trigger/interface/BTVHLTOfflineSource.h
+++ b/DQMOffline/Trigger/interface/BTVHLTOfflineSource.h
@@ -2,7 +2,7 @@
 #define BTVHLTOfflineSource_H
 /*
   BTVHLTOffline DQM code
-*/  
+*/
 //
 // Originally created by:  Anne-Catherine Le Bihan
 //                         June 2015
@@ -53,10 +53,10 @@ class BTVHLTOfflineSource : public DQMEDAnalyzer {
   std::string dirname_;
   std::string processname_;
   std::string pathname_;
-  std::string filtername_; 
-  
+  std::string filtername_;
+
   std::vector<std::pair<std::string, std::string> > custompathnamepairs_;
-  
+
   edm::InputTag triggerSummaryLabel_;
   edm::InputTag triggerResultsLabel_;
 
@@ -67,22 +67,28 @@ class BTVHLTOfflineSource : public DQMEDAnalyzer {
   edm::EDGetTokenT<std::vector<reco::Vertex> > hltPFPVToken_;
   edm::EDGetTokenT<std::vector<reco::Vertex> > hltCaloPVToken_;
   edm::EDGetTokenT<std::vector<reco::Vertex> > offlinePVToken_;
-  
+
   edm::EDGetTokenT <edm::TriggerResults> triggerResultsToken;
   edm::EDGetTokenT <edm::TriggerResults> triggerResultsFUToken;
   edm::EDGetTokenT <trigger::TriggerEvent> triggerSummaryToken;
   edm::EDGetTokenT <trigger::TriggerEvent> triggerSummaryFUToken;
-  
+
+  edm::EDGetTokenT<std::vector<reco::TemplatedSecondaryVertexTagInfo<reco::IPTagInfo<edm::RefVector<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,reco::JTATagInfo>,reco::Vertex> > >
+       csvPfTagInfosToken_;
+
+  edm::Handle<std::vector<reco::TemplatedSecondaryVertexTagInfo<reco::IPTagInfo<edm::RefVector<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,reco::JTATagInfo>,reco::Vertex> > >
+       csvPfTagInfos;
+
   edm::EDGetTokenT<reco::JetTagCollection> csvCaloTagsToken_;
   edm::EDGetTokenT<reco::JetTagCollection> csvPfTagsToken_;
   edm::Handle<reco::JetTagCollection> csvCaloTags;
   edm::Handle<reco::JetTagCollection> csvPfTags;
-  
+
   HLTConfigProvider hltConfig_;
   edm::Handle<edm::TriggerResults> triggerResults_;
   edm::TriggerNames triggerNames_;
   edm::Handle<trigger::TriggerEvent> triggerObj_;
-  
+
   class PathInfo {
     PathInfo():
       prescaleUsed_(-1),
@@ -92,25 +98,33 @@ class BTVHLTOfflineSource : public DQMEDAnalyzer {
       objectType_(-1),
       triggerType_("unset")
       {};
-  
+
   public:
     void setHistos(
-		   MonitorElement* const CSV, MonitorElement* const Pt, MonitorElement* const Eta,
-		   MonitorElement* const CSV_RECOvsHLT, MonitorElement* const PVz, MonitorElement* const fastPVz,
-		   MonitorElement* const PVz_HLTMinusRECO, MonitorElement* const fastPVz_HLTMinusRECO
-		   )
+       MonitorElement* const CSV, MonitorElement* const Pt, MonitorElement* const Eta,
+       MonitorElement* const CSV_RECOvsHLT, MonitorElement* const PVz, MonitorElement* const fastPVz,
+       MonitorElement* const PVz_HLTMinusRECO, MonitorElement* const fastPVz_HLTMinusRECO,
+       MonitorElement* const n_vtx, MonitorElement* const vtx_mass, MonitorElement* const n_vtx_trks,
+       MonitorElement* const n_sel_tracks, MonitorElement* const h_3d_ip_distance,
+       MonitorElement* const h_3d_ip_error, MonitorElement* const h_3d_ip_sig,
+       MonitorElement* const n_pixel_hits, MonitorElement* const n_total_hits
+    )
     { CSV_ = CSV; Pt_ = Pt; Eta_ = Eta; CSV_RECOvsHLT_ = CSV_RECOvsHLT; PVz_ = PVz; fastPVz_ = fastPVz;
       PVz_HLTMinusRECO_ = PVz_HLTMinusRECO; fastPVz_HLTMinusRECO_ = fastPVz_HLTMinusRECO;
+      n_vtx_ = n_vtx; vtx_mass_ = vtx_mass; n_vtx_trks_ = n_vtx_trks;
+      n_sel_tracks_ = n_sel_tracks; h_3d_ip_distance_ = h_3d_ip_distance;
+      h_3d_ip_error_ = h_3d_ip_error; h_3d_ip_sig_ = h_3d_ip_sig;
+      n_pixel_hits_ = n_pixel_hits; n_total_hits_ = n_total_hits;
     };
 
 
     ~PathInfo() = default;;
     PathInfo(int prescaleUsed,
-	     std::string pathName,
-	     std::string filterName,
-	     std::string processName,
-	     size_t type,
-	     std::string triggerType):
+        std::string pathName,
+        std::string filterName,
+        std::string processName,
+        size_t type,
+        std::string triggerType):
       prescaleUsed_(prescaleUsed),
       pathName_(std::move(pathName)),
       filterName_(std::move(filterName)),
@@ -128,40 +142,49 @@ class BTVHLTOfflineSource : public DQMEDAnalyzer {
       MonitorElement * getMEhisto_fastPVz()           { return fastPVz_;}
       MonitorElement * getMEhisto_PVz_HLTMinusRECO()      { return PVz_HLTMinusRECO_;}
       MonitorElement * getMEhisto_fastPVz_HLTMinusRECO()  { return fastPVz_HLTMinusRECO_;}
-     
+      MonitorElement * getMEhisto_n_vtx()             { return n_vtx_; }
+      MonitorElement * getMEhisto_vtx_mass()          { return vtx_mass_; }
+      MonitorElement * getMEhisto_n_vtx_trks()        { return n_vtx_trks_; }
+      MonitorElement * getMEhisto_n_sel_tracks()      { return n_sel_tracks_; }
+      MonitorElement * getMEhisto_h_3d_ip_distance()  { return h_3d_ip_distance_; }
+      MonitorElement * getMEhisto_h_3d_ip_error()     { return h_3d_ip_error_; }
+      MonitorElement * getMEhisto_h_3d_ip_sig()       { return h_3d_ip_sig_; }
+      MonitorElement * getMEhisto_n_pixel_hits()      { return n_pixel_hits_; }
+      MonitorElement * getMEhisto_n_total_hits()            { return n_total_hits_; }
+
       const std::string getLabel( ) const {
-	return filterName_;
+          return filterName_;
       }
       void setLabel(std::string labelName){
-	filterName_ = std::move(labelName);
-	return;
+          filterName_ = std::move(labelName);
+          return;
       }
       const std::string getPath( ) const {
-	return pathName_;
+          return pathName_;
       }
       const int getprescaleUsed() const {
-	return prescaleUsed_;
+          return prescaleUsed_;
       }
       const std::string getProcess( ) const {
-	return processName_;
+          return processName_;
       }
       const int getObjectType( ) const {
-	return objectType_;
+          return objectType_;
       }
       const std::string getTriggerType( ) const {
-	return triggerType_;
+          return triggerType_;
       }
       const edm::InputTag getTag() const{
-	edm::InputTag tagName(filterName_,"",processName_);
-	return tagName;
+          edm::InputTag tagName(filterName_,"",processName_);
+          return tagName;
       }
       bool operator==(const std::string& v)
       {
-	return v==pathName_;
+          return v==pathName_;
       }
 
   private:
-  
+
       int prescaleUsed_;
       std::string pathName_;
       std::string filterName_;
@@ -172,14 +195,24 @@ class BTVHLTOfflineSource : public DQMEDAnalyzer {
       MonitorElement*  CSV_;
       MonitorElement*  Pt_;
       MonitorElement*  Eta_;
-      MonitorElement*  CSV_RECOvsHLT_;   
+      MonitorElement*  CSV_RECOvsHLT_;
       MonitorElement*  PVz_;
       MonitorElement*  fastPVz_;
       MonitorElement*  PVz_HLTMinusRECO_;
       MonitorElement*  fastPVz_HLTMinusRECO_;
-     
+      MonitorElement*  n_vtx_;
+      MonitorElement*  vtx_mass_;
+      MonitorElement*  n_vtx_trks_;
+      MonitorElement*  n_sel_tracks_;
+      MonitorElement*  h_3d_ip_distance_;
+      MonitorElement*  h_3d_ip_error_;
+      MonitorElement*  h_3d_ip_sig_;
+      MonitorElement*  n_pixel_hits_;
+      MonitorElement*  n_total_hits_;
+
+
       };
- 
+
   class PathInfoCollection: public std::vector<PathInfo> {
   public:
     PathInfoCollection(): std::vector<PathInfo>()

--- a/DQMOffline/Trigger/src/BTVHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/src/BTVHLTOfflineSource.cc
@@ -29,16 +29,17 @@
 #include "TPRegexp.h"
 
 #include <cmath>
+#include <iostream>
 
 using namespace edm;
 using namespace reco;
 using namespace std;
 using namespace trigger;
-  
+
 BTVHLTOfflineSource::BTVHLTOfflineSource(const edm::ParameterSet& iConfig)
 {
   LogDebug("BTVHLTOfflineSource") << "constructor....";
-  
+
   dirname_                = iConfig.getUntrackedParameter("dirname",std::string("HLT/BTV/"));
   processname_            = iConfig.getParameter<std::string>("processname");
   verbose_                = iConfig.getUntrackedParameter< bool >("verbose", false);
@@ -48,6 +49,8 @@ BTVHLTOfflineSource::BTVHLTOfflineSource(const edm::ParameterSet& iConfig)
   triggerResultsToken     = consumes <edm::TriggerResults>   (triggerResultsLabel_);
   triggerSummaryFUToken   = consumes <trigger::TriggerEvent> (edm::InputTag(triggerSummaryLabel_.label(),triggerSummaryLabel_.instance(),std::string("FU")));
   triggerResultsFUToken   = consumes <edm::TriggerResults>   (edm::InputTag(triggerResultsLabel_.label(),triggerResultsLabel_.instance(),std::string("FU")));
+  csvPfTagInfosToken_     = consumes<vector<reco::TemplatedSecondaryVertexTagInfo<reco::IPTagInfo<edm::RefVector<vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<vector<reco::Track>,reco::Track> >,reco::JTATagInfo>,reco::Vertex> > > (
+                                edm::InputTag("hltSecondaryVertexTagInfosPF"));
   csvCaloTagsToken_       = consumes<reco::JetTagCollection> (edm::InputTag("hltCombinedSecondaryVertexBJetTagsCalo"));
   csvPfTagsToken_         = consumes<reco::JetTagCollection> (edm::InputTag("hltCombinedSecondaryVertexBJetTagsPF"));
   offlineCSVTokenPF_      = consumes<reco::JetTagCollection> (iConfig.getParameter<edm::InputTag>("offlineCSVLabelPF"));
@@ -56,9 +59,9 @@ BTVHLTOfflineSource::BTVHLTOfflineSource(const edm::ParameterSet& iConfig)
   hltPFPVToken_           = consumes<std::vector<reco::Vertex> > (iConfig.getParameter<edm::InputTag>("hltPFPVLabel"));
   hltCaloPVToken_         = consumes<std::vector<reco::Vertex> > (iConfig.getParameter<edm::InputTag>("hltCaloPVLabel"));
   offlinePVToken_         = consumes<std::vector<reco::Vertex> > (iConfig.getParameter<edm::InputTag>("offlinePVLabel"));
- 
+
   std::vector<edm::ParameterSet> paths =  iConfig.getParameter<std::vector<edm::ParameterSet> >("pathPairs");
-  for(auto & path : paths) { 
+  for(auto & path : paths) {
     custompathnamepairs_.push_back(make_pair(
 					     path.getParameter<std::string>("pathname"),
 					     path.getParameter<std::string>("pathtype")
@@ -73,7 +76,7 @@ void BTVHLTOfflineSource::dqmBeginRun(const edm::Run& run, const edm::EventSetup
     if (!hltConfig_.init(run, c, processname_, changed)) {
     LogDebug("BTVHLTOfflineSource") << "HLTConfigProvider failed to initialize.";
     }
-    
+
   const unsigned int numberOfPaths(hltConfig_.size());
   for(unsigned int i=0; i!=numberOfPaths; ++i){
     pathname_      = hltConfig_.triggerName(i);
@@ -82,22 +85,22 @@ void BTVHLTOfflineSource::dqmBeginRun(const edm::Run& run, const edm::EventSetup
     unsigned int objectType = 0;
     std::string triggerType = "";
     bool trigSelected = false;
-    
+
     for (auto & custompathnamepair : custompathnamepairs_){
        if(pathname_.find(custompathnamepair.first)!=std::string::npos) { trigSelected = true; triggerType = custompathnamepair.second;}
       }
-    
+
     if (!trigSelected) continue;
-    
-    hltPathsAll_.push_back(PathInfo(usedPrescale, pathname_, "dummy", processname_, objectType, triggerType)); 
+
+    hltPathsAll_.push_back(PathInfo(usedPrescale, pathname_, "dummy", processname_, objectType, triggerType));
    }
-  
+
 
 }
 
 void
 BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{ 
+{
   iEvent.getByToken(triggerResultsToken, triggerResults_);
   if(!triggerResults_.isValid()) {
     iEvent.getByToken(triggerResultsFUToken,triggerResults_);
@@ -107,9 +110,9 @@ BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       return;
     }
   }
-  
+
   triggerNames_ = iEvent.triggerNames(*triggerResults_);
-  
+
   iEvent.getByToken(triggerSummaryToken,triggerObj_);
   if(!triggerObj_.isValid()) {
     iEvent.getByToken(triggerSummaryFUToken,triggerObj_);
@@ -118,45 +121,50 @@ BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 	"skipping event";
       return;
     }
-  } 
-  
+  }
+
   iEvent.getByToken(csvCaloTagsToken_, csvCaloTags);
   iEvent.getByToken(csvPfTagsToken_, csvPfTags);
-  
+
   Handle<reco::VertexCollection> VertexHandler;
-  
+
   Handle<reco::JetTagCollection> offlineJetTagHandlerPF;
   iEvent.getByToken(offlineCSVTokenPF_, offlineJetTagHandlerPF);
-  
+
   Handle<reco::JetTagCollection> offlineJetTagHandlerCalo;
   iEvent.getByToken(offlineCSVTokenCalo_, offlineJetTagHandlerCalo);
-  
+
   Handle<reco::VertexCollection> offlineVertexHandler;
   iEvent.getByToken(offlinePVToken_, offlineVertexHandler);
-  
+
   if(verbose_ && iEvent.id().event()%10000==0)
-    cout<<"Run = "<<iEvent.id().run()<<", LS = "<<iEvent.luminosityBlock()<<", Event = "<<iEvent.id().event()<<endl;  
-  
+    cout<<"Run = "<<iEvent.id().run()<<", LS = "<<iEvent.luminosityBlock()<<", Event = "<<iEvent.id().event()<<endl;
+
   if(!triggerResults_.isValid()) return;
-   
+
   for(auto & v : hltPathsAll_){
-    unsigned index = triggerNames_.triggerIndex(v.getPath()); 
-    if (index < triggerNames_.size() ){     
+    unsigned index = triggerNames_.triggerIndex(v.getPath());
+    if (index < triggerNames_.size() ){
      float DR  = 9999.;
+//                                                                                _|_|_|    _|_|_|_|
+//                                                                                _|    _|  _|
+//                                                                                _|_|_|    _|_|_|
+//                                                                                _|        _|
+//                                                                                _|        _|
      if (csvPfTags.isValid() && v.getTriggerType() == "PF")
      {
       auto iter = csvPfTags->begin();
-      
+
       float CSV_online = iter->second;
       if (CSV_online<0) CSV_online = -0.05;
-    
-      v.getMEhisto_CSV()->Fill(CSV_online);  
-      v.getMEhisto_Pt()->Fill(iter->first->pt()); 
+
+      v.getMEhisto_CSV()->Fill(CSV_online);
+      v.getMEhisto_Pt()->Fill(iter->first->pt());
       v.getMEhisto_Eta()->Fill(iter->first->eta());
-      
+
       DR  = 9999.;
       if(offlineJetTagHandlerPF.isValid()){
-          for (auto const & iterO : *offlineJetTagHandlerPF){ 
+          for (auto const & iterO : *offlineJetTagHandlerPF){
             float CSV_offline = iterO.second;
             if (CSV_offline<0) CSV_offline = -0.05;
             DR = reco::deltaR(iterO.first->eta(),iterO.first->phi(),iter->first->eta(),iter->first->phi());
@@ -165,26 +173,65 @@ BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
                }
           }
       }
-    
+
       iEvent.getByToken(hltPFPVToken_, VertexHandler);
       if (VertexHandler.isValid())
-      { 
-        v.getMEhisto_PVz()->Fill(VertexHandler->begin()->z()); 
+      {
+        v.getMEhisto_PVz()->Fill(VertexHandler->begin()->z());
         if (offlineVertexHandler.isValid()) v.getMEhisto_PVz_HLTMinusRECO()->Fill(VertexHandler->begin()->z()-offlineVertexHandler->begin()->z());
         }
       }
-      
-     if (csvCaloTags.isValid() && v.getTriggerType() == "Calo" && !csvCaloTags->empty()) 
-     { 
+
+      iEvent.getByToken(csvPfTagInfosToken_, csvPfTagInfos);
+      if (csvPfTagInfos.isValid() && v.getTriggerType() == "PF") {
+
+        // loop over secondary vertex tag infos
+        for (const auto & csvPfTagInfo : *csvPfTagInfos) {
+          v.getMEhisto_n_vtx()->Fill(csvPfTagInfo.nVertexCandidates());
+          v.getMEhisto_n_sel_tracks()->Fill(csvPfTagInfo.nSelectedTracks());
+
+          // loop over selected tracks in each tag info
+          for (unsigned i_trk=0; i_trk < csvPfTagInfo.nSelectedTracks(); i_trk++) {
+            const auto & ip3d = csvPfTagInfo.trackIPData(i_trk).ip3d;
+            v.getMEhisto_h_3d_ip_distance()->Fill(ip3d.value());
+            v.getMEhisto_h_3d_ip_error()->Fill(ip3d.error());
+            v.getMEhisto_h_3d_ip_sig()->Fill(ip3d.significance());
+          }
+
+          // loop over vertex candidates in each tag info
+          for (unsigned i_sv=0; i_sv < csvPfTagInfo.nVertexCandidates(); i_sv++) {
+            const auto & sv = csvPfTagInfo.secondaryVertex(i_sv);
+            v.getMEhisto_vtx_mass()->Fill(sv.p4().mass());
+            v.getMEhisto_n_vtx_trks()->Fill(sv.nTracks());
+
+            // loop over tracks for number of pixel and total hits
+            const auto & trkIPTagInfo = csvPfTagInfo.trackIPTagInfoRef().get();
+            for (const auto & trk : trkIPTagInfo->selectedTracks()) {
+              v.getMEhisto_n_pixel_hits()->Fill(trk.get()->hitPattern().numberOfValidPixelHits());
+              v.getMEhisto_n_total_hits()->Fill(trk.get()->hitPattern().numberOfValidHits());
+            }
+          }
+        }
+      }
+
+//                                                                    _|_|_|            _|
+//                                                                  _|          _|_|_|  _|    _|_|
+//                                                                  _|        _|    _|  _|  _|    _|
+//                                                                  _|        _|    _|  _|  _|    _|
+//                                                                    _|_|_|    _|_|_|  _|    _|_|
+
+     if (csvCaloTags.isValid() && v.getTriggerType() == "Calo" && !csvCaloTags->empty())
+     {
+
       auto iter = csvCaloTags->begin();
-      
+
       float CSV_online = iter->second;
       if (CSV_online<0) CSV_online = -0.05;
-    
-      v.getMEhisto_CSV()->Fill(CSV_online);  
-      v.getMEhisto_Pt()->Fill(iter->first->pt()); 
+
+      v.getMEhisto_CSV()->Fill(CSV_online);
+      v.getMEhisto_Pt()->Fill(iter->first->pt());
       v.getMEhisto_Eta()->Fill(iter->first->eta());
-      
+
       DR  = 9999.;
       if(offlineJetTagHandlerCalo.isValid()){
           for (auto const & iterO : *offlineJetTagHandlerCalo)
@@ -192,82 +239,121 @@ BTVHLTOfflineSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
             float CSV_offline = iterO.second;
             if (CSV_offline<0) CSV_offline = -0.05;
             DR = reco::deltaR(iterO.first->eta(),iterO.first->phi(),iter->first->eta(),iter->first->phi());
-            if (DR<0.3) 
+            if (DR<0.3)
             {
                 v.getMEhisto_CSV_RECOvsHLT()->Fill(CSV_offline,CSV_online); continue;
-            }  
-          }     
+            }
+          }
       }
-      
+
       iEvent.getByToken(hltFastPVToken_, VertexHandler);
-      if (VertexHandler.isValid()) 
+      if (VertexHandler.isValid())
       {
-        v.getMEhisto_PVz()->Fill(VertexHandler->begin()->z()); 
+        v.getMEhisto_PVz()->Fill(VertexHandler->begin()->z());
 	if (offlineVertexHandler.isValid()) v.getMEhisto_fastPVz_HLTMinusRECO()->Fill(VertexHandler->begin()->z()-offlineVertexHandler->begin()->z());
        }
-      
+
       iEvent.getByToken(hltCaloPVToken_, VertexHandler);
       if (VertexHandler.isValid())
       {
-        v.getMEhisto_fastPVz()->Fill(VertexHandler->begin()->z()); 
+        v.getMEhisto_fastPVz()->Fill(VertexHandler->begin()->z());
 	if (offlineVertexHandler.isValid()) v.getMEhisto_PVz_HLTMinusRECO()->Fill(VertexHandler->begin()->z()-offlineVertexHandler->begin()->z());
        }
-       
+
       }
-      
-      
+
+
     }
    }
-  
 }
 
-void 
+void
 BTVHLTOfflineSource::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const & run, edm::EventSetup const & c)
 {
-  iBooker.setCurrentFolder(dirname_);
+   iBooker.setCurrentFolder(dirname_);
    for(auto & v : hltPathsAll_){
      //
      std::string trgPathName = HLTConfigProvider::removeVersion(v.getPath());
      std::string subdirName  = dirname_ +"/"+ trgPathName;
      std::string trigPath    = "("+trgPathName+")";
-     iBooker.setCurrentFolder(subdirName);  
+     iBooker.setCurrentFolder(subdirName);
 
      std::string labelname("HLT");
      std::string histoname(labelname+"");
      std::string title(labelname+"");
-      
+
      histoname = labelname+"_CSV";
      title = labelname+"_CSV "+trigPath;
      MonitorElement * CSV =  iBooker.book1D(histoname.c_str(),title.c_str(),110,-0.1,1);
-     
+
      histoname = labelname+"_Pt";
      title = labelname+"_Pt "+trigPath;
      MonitorElement * Pt =  iBooker.book1D(histoname.c_str(),title.c_str(),100,0,400);
-     
+
      histoname = labelname+"_Eta";
      title = labelname+"_Eta "+trigPath;
      MonitorElement * Eta =  iBooker.book1D(histoname.c_str(),title.c_str(),60,-3.0,3.0);
-    
+
      histoname = "RECOvsHLT_CSV";
      title = "offline CSV vs online CSV "+trigPath;
      MonitorElement * CSV_RECOvsHLT =  iBooker.book2D(histoname.c_str(),title.c_str(),110,-0.1,1,110,-0.1,1);
-    
+
      histoname = labelname+"_PVz";
      title = "online z(PV) "+trigPath;
      MonitorElement * PVz =  iBooker.book1D(histoname.c_str(),title.c_str(),80,-20,20);
-     
+
      histoname = labelname+"_fastPVz";
      title = "online z(fastPV) "+trigPath;
      MonitorElement * fastPVz =  iBooker.book1D(histoname.c_str(),title.c_str(),80,-20,20);
-     
+
      histoname = "HLTMinusRECO_PVz";
      title = "online z(PV) - offline z(PV) "+trigPath;
      MonitorElement * PVz_HLTMinusRECO =  iBooker.book1D(histoname.c_str(),title.c_str(),200,-0.5,0.5);
-     
+
      histoname = "HLTMinusRECO_fastPVz";
      title = "online z(fastPV) - offline z(PV) "+trigPath;
      MonitorElement * fastPVz_HLTMinusRECO =  iBooker.book1D(histoname.c_str(),title.c_str(),100,-2,2);
-    
-     v.setHistos(CSV,Pt,Eta,CSV_RECOvsHLT,PVz,fastPVz,PVz_HLTMinusRECO,fastPVz_HLTMinusRECO);  
+
+     histoname = "n_vtx";
+     title = "N vertex candidates "+trigPath;
+     MonitorElement * n_vtx =  iBooker.book1D(histoname.c_str(),title.c_str(), 10, -0.5, 9.5);
+
+     histoname = "vtx_mass";
+     title = "secondary vertex mass (GeV)"+trigPath;
+     MonitorElement * vtx_mass = iBooker.book1D(histoname.c_str(), title.c_str(), 20, 0, 10);
+
+     histoname = "n_vtx_trks";
+     title = "N tracks associated to secondary vertex"+trigPath;
+     MonitorElement * n_vtx_trks = iBooker.book1D(histoname.c_str(), title.c_str(), 20, -0.5, 19.5);
+
+     histoname = "n_sel_tracks";
+     title = "N selected tracks"+trigPath;
+     MonitorElement * n_sel_tracks = iBooker.book1D(histoname.c_str(), title.c_str(), 25, -0.5, 24.5);
+
+     histoname = "3d_ip_distance";
+     title = "3D IP distance of tracks (cm)"+trigPath;
+     MonitorElement * h_3d_ip_distance = iBooker.book1D(histoname.c_str(), title.c_str(), 40, -0.1, 0.1);
+
+     histoname = "3d_ip_error";
+     title = "3D IP error of tracks (cm)"+trigPath;
+     MonitorElement * h_3d_ip_error = iBooker.book1D(histoname.c_str(), title.c_str(), 40, 0., 0.1);
+
+     histoname = "3d_ip_sig";
+     title = "3D IP significance of tracks (cm)"+trigPath;
+     MonitorElement * h_3d_ip_sig = iBooker.book1D(histoname.c_str(), title.c_str(), 40, -40, 40);
+
+     histoname = "n_pixel_hits";
+     title = "N pixel hits"+trigPath;
+     MonitorElement * n_pixel_hits = iBooker.book1D(histoname.c_str(), title.c_str(), 16, -0.5, 15.5);
+
+     histoname = "n_total_hits";
+     title = "N hits"+trigPath;
+     MonitorElement * n_total_hits = iBooker.book1D(histoname.c_str(), title.c_str(), 40, -0.5, 39.5);
+
+
+     v.setHistos(
+        CSV,Pt,Eta,CSV_RECOvsHLT,PVz,fastPVz,PVz_HLTMinusRECO,fastPVz_HLTMinusRECO,
+        n_vtx, vtx_mass, n_vtx_trks, n_sel_tracks, h_3d_ip_distance, h_3d_ip_error, h_3d_ip_sig, n_pixel_hits, n_total_hits
+     );
    }
 }


### PR DESCRIPTION
Adding new DQM plots for CSV PF b tag trigger paths. 

Here's the last presentation on the topic:
https://indico.cern.ch/event/700252/#3-trigger-dqm-update

It's planned to add the complementary implementation for Calo b tagging as well. 