### PR TITLE
Adding a pt3 member to L1TJetsMatching class, for HLT development

### DIFF
--- a/RecoTauTag/HLTProducers/interface/L1TJetsMatching.h
+++ b/RecoTauTag/HLTProducers/interface/L1TJetsMatching.h
@@ -63,6 +63,7 @@ class L1TJetsMatching: public edm::global::EDProducer<> {
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> jetTrigger_;
   const double pt1Min_;
   const double pt2Min_;
+  const double pt3Min_;
   const double mjjMin_;
   const double matchingR_;
   const double matchingR2_;
@@ -71,7 +72,7 @@ class L1TJetsMatching: public edm::global::EDProducer<> {
     // class decleration
     //
     template< typename T>
-    std::pair<std::vector<T>,std::vector<T>> categorise(const std::vector<T>& pfMatchedJets, double pt1, double pt2, double Mjj)
+    std::pair<std::vector<T>,std::vector<T>> categorise(const std::vector<T>& pfMatchedJets, double pt1, double pt2, double pt3, double Mjj)
     {
         std::pair<std::vector<T>,std::vector<T>> output;
         unsigned int i1 = 0;
@@ -108,11 +109,11 @@ class L1TJetsMatching: public edm::global::EDProducer<> {
                 
             }
             
-            if ((mjj > Mjj) && (myJet1.pt() < pt1) && (myJet1.pt() > pt2) && (myJet2.pt() > pt2))
+            if ((mjj > Mjj) && (myJet1.pt() < pt3) && (myJet1.pt() > pt2) && (myJet2.pt() > pt2))
             {
                 
                 const T &  myJetTest = (pfMatchedJets)[0];
-                if (myJetTest.pt()>pt1){
+                if (myJetTest.pt()>pt3){
                     output.second.push_back(myJet1);
                     output.second.push_back(myJet2);
                     output.second.push_back(myJetTest);
@@ -131,6 +132,7 @@ class L1TJetsMatching: public edm::global::EDProducer<> {
     jetTrigger_( consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<edm::InputTag>("L1JetTrigger") ) ),
     pt1Min_   ( iConfig.getParameter<double>("pt1Min")),
     pt2Min_   ( iConfig.getParameter<double>("pt2Min")),
+    pt3Min_   ( iConfig.getParameter<double>("pt3Min")),
     mjjMin_   ( iConfig.getParameter<double>("mjjMin")),
     matchingR_ ( iConfig.getParameter<double>("matchingR")),
     matchingR2_ ( matchingR_*matchingR_ )
@@ -177,7 +179,7 @@ class L1TJetsMatching: public edm::global::EDProducer<> {
             }
         }
         
-        output= categorise(*pfMatchedJets,pt1Min_,pt2Min_, mjjMin_);
+        output= categorise(*pfMatchedJets,pt1Min_, pt2Min_, pt3Min_,  mjjMin_);
         unique_ptr<std::vector<T>> output1(new std::vector<T>(output.first));
         unique_ptr<std::vector<T>> output2(new std::vector<T>(output.second));
         
@@ -191,8 +193,9 @@ class L1TJetsMatching: public edm::global::EDProducer<> {
      edm::ParameterSetDescription desc;
      desc.add<edm::InputTag>("L1JetTrigger", edm::InputTag("hltL1DiJetVBF"))->setComment("Name of trigger filter"    );
      desc.add<edm::InputTag>("JetSrc"      , edm::InputTag("hltAK4PFJetsTightIDCorrected"))->setComment("Input collection of PFJets");
-     desc.add<double>       ("pt1Min",95.0)->setComment("Minimal pT1 of PFJets to match");
+     desc.add<double>       ("pt1Min",110.0)->setComment("Minimal pT1 of PFJets to match");
      desc.add<double>       ("pt2Min",35.0)->setComment("Minimal pT2 of PFJets to match");
+     desc.add<double>       ("pt3Min",110.0)->setComment("Minimum pT3 of PFJets to match");
      desc.add<double>       ("mjjMin",650.0)->setComment("Minimal mjj of matched PFjets");
      desc.add<double>       ("matchingR",0.5)->setComment("dR value used for matching");
      descriptions.setComment("This module produces collection of PFJetss matched to L1 Taus / Jets passing a HLT filter (Only p4 and vertex of returned PFJetss are set).");


### PR DESCRIPTION
This change adds a new member to the L1TJetsMatching class (pt3Min_) that allows one to use the L1TJetsMatching module and it's 'ThreeJets' output collection when pt1Min = pt2Min. The only triggers that use this module are VBF + MET and VBF + Tau triggers. 

The VBF + Tau triggers under development are 
`HLT_(VBF_DoubleJet115_40)_DiTau_20`
`HLT_(VBF_DoubleJet40)_DiTau_115_20`
`HLT_(VBF_DoubleJet40)_+SingleJet115_DiTau_20`.
Especially for the third case this change is required.


Note:
The VBF + MET configs should remain unchanged with this addition, since the default setting of pt3Min_ is set to the same as the pt1Min_ used in all of its configurations, namely 110 GeV (see `hltL1TPFJetsMatching` which is the filter used in all the VBF + MET triggers  `HLT_DiJet110_35_Mjj650_PFMET*_v` and `HLT_TripleJet110_35_Mjj650_PFMET*_v`).
