### PR TITLE
added module to apply some ID selection at HLT

### DIFF
--- a/RecoMuon/MuonIdentification/plugins/Module.cc
+++ b/RecoMuon/MuonIdentification/plugins/Module.cc
@@ -10,6 +10,7 @@
 #include "RecoMuon/MuonIdentification/plugins/MuonTimingProducer.h"
 #include "RecoMuon/MuonIdentification/plugins/MuonSelectionTypeValueMapProducer.h"
 #include "RecoMuon/MuonIdentification/plugins/InterestingEcalDetIdProducer.h"
+#include "RecoMuon/MuonIdentification/plugins/MuonIDFilterProducerForHLT.h"
 
 
 DEFINE_FWK_MODULE(MuonIdProducer);
@@ -20,6 +21,7 @@ DEFINE_FWK_MODULE(MuonProducer);
 DEFINE_FWK_MODULE(MuonTimingProducer);
 DEFINE_FWK_MODULE(MuonSelectionTypeValueMapProducer);
 DEFINE_FWK_MODULE(InterestingEcalDetIdProducer);
+DEFINE_FWK_MODULE(MuonIDFilterProducerForHLT);
 
 // For the VID framework
 #include "PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h"

--- a/RecoMuon/MuonIdentification/plugins/MuonIDFilterProducerForHLT.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIDFilterProducerForHLT.cc
@@ -1,0 +1,103 @@
+/** \class MuonIDFilterProducerForHLT
+ *
+ *  \author S. Folgueras <santiago.folgueras@cern.ch>
+ */
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "RecoMuon/MuonIdentification/plugins/MuonIDFilterProducerForHLT.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+//#include <algorithm>
+
+MuonIDFilterProducerForHLT::MuonIDFilterProducerForHLT(const edm::ParameterSet& iConfig)
+{
+   produces<reco::MuonCollection>();
+   muonTag_             = iConfig.getParameter<edm::InputTag>("inputMuonCollection");
+   muonToken_           = consumes<reco::MuonCollection>(muonTag_);
+   applyTriggerIdLoose_ = iConfig.getParameter<bool>("applyTriggerIdLoose");
+   type_                = muon::SelectionType(iConfig.getParameter<unsigned int>("typeMuon"));
+   allowedTypeMask_     = iConfig.getParameter<unsigned int>("allowedTypeMask");
+   requiredTypeMask_    = iConfig.getParameter<unsigned int>("requiredTypeMask");
+   min_NMuonHits_       = iConfig.getParameter<int>("minNMuonHits");    
+   min_NMuonStations_   = iConfig.getParameter<int>("minNMuonStations");
+   min_NTrkLayers_      = iConfig.getParameter<int>("minNTrkLayers"); 
+   min_NTrkHits_        = iConfig.getParameter<int>("minTrkHits"); 
+   min_PixLayers_       = iConfig.getParameter<int>("minPixLayer");
+   min_PixHits_         = iConfig.getParameter<int>("minPixHits");
+   min_Pt_              = iConfig.getParameter<double>("minPt");           
+   max_NormalizedChi2_  = iConfig.getParameter<double>("maxNormalizedChi2"); 
+}
+
+MuonIDFilterProducerForHLT::~MuonIDFilterProducerForHLT()
+{
+}
+void MuonIDFilterProducerForHLT::fillDescriptions(edm::ConfigurationDescriptions & descriptions){
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("inputMuonCollection",edm::InputTag("hltIterL3MuonsNoID"));
+  desc.add<bool>("applyTriggerIdLoose",true);
+  desc.add<unsigned int>("typeMuon",0);
+  desc.add<unsigned int>("allowedTypeMask",0);
+  desc.add<unsigned int>("requiredTypeMask",0);
+  desc.add<int>("minNMuonHits",0);    
+  desc.add<int>("minNMuonStations",0);
+  desc.add<int>("minNTrkLayers",0); 
+  desc.add<int>("minTrkHits",0); 
+  desc.add<int>("minPixLayer",0);
+  desc.add<int>("minPixHits",0);
+  desc.add<double>("minPt",0.);           
+  desc.add<double>("maxNormalizedChi2",9999.); 
+  descriptions.addDefault(desc);
+}
+void MuonIDFilterProducerForHLT::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
+{
+   auto output = std::make_unique<reco::MuonCollection>();
+
+   edm::Handle<reco::MuonCollection> muons; 
+   iEvent.getByToken(muonToken_, muons);
+   
+   for ( unsigned int i=0; i<muons->size(); ++i ){
+     const reco::Muon& muon(muons->at(i));
+     if (applyTriggerIdLoose_ && muon::isLooseTriggerMuon(muon)) { 
+       output->push_back(muon);
+     }
+     else {  // Implement here manually all the required/desired cuts 
+
+       
+       if ( (muon.type() & allowedTypeMask_) == 0 )                  continue;
+       if ( (muon.type() & requiredTypeMask_) != requiredTypeMask_ ) continue;
+       // tracker cuts
+       if ( !muon.innerTrack().isNull() ){
+	 if (muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() < min_NTrkLayers_) continue;
+	 if (muon.innerTrack()->numberOfValidHits()<  min_NTrkHits_) continue;
+	 if (muon.innerTrack()->hitPattern().pixelLayersWithMeasurement() < min_PixLayers_) continue;
+	 if (muon.innerTrack()->hitPattern().numberOfValidPixelHits()<  min_PixHits_) continue;
+       }
+       // muon cuts
+       if ( muon.numberOfMatchedStations()< min_NMuonStations_ )     continue;
+       if ( !muon.globalTrack().isNull() ){
+	 if (muon.globalTrack()->normalizedChi2() > max_NormalizedChi2_) continue;
+	 if (muon.globalTrack()->hitPattern().numberOfValidMuonHits() < min_NMuonHits_) continue;
+       }
+       if ( !muon::isGoodMuon(muon,type_) ) continue;
+       if ( muon.pt() < min_Pt_ ) continue;
+
+       output->push_back(muon);
+     }
+   }
+     
+   iEvent.put(std::move(output));
+}

--- a/RecoMuon/MuonIdentification/plugins/MuonIDFilterProducerForHLT.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIDFilterProducerForHLT.h
@@ -1,0 +1,48 @@
+#ifndef MuonIdentification_MuonIDFilterProducerForHLT_h
+#define MuonIdentification_MuonIDFilterProducerForHLT_h
+
+/** \class MuonIDFilterProducerForHLT
+ *
+ * Simple filter to apply ID to the reco::Muon collection 
+ * for the HLT reconstruction.
+ *
+ *  \author S. Folgueras <santiago.folgueras@cern.ch>
+ */
+
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
+
+class MuonIDFilterProducerForHLT : public edm::global::EDProducer<> {
+ public:
+   explicit MuonIDFilterProducerForHLT(const edm::ParameterSet&);
+   
+   ~MuonIDFilterProducerForHLT() override;
+   
+   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
+ private:
+   edm::InputTag muonTag_;
+   edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+   
+   bool applyTriggerIdLoose_;
+   muon::SelectionType  type_;
+   unsigned int allowedTypeMask_;
+   unsigned int requiredTypeMask_;
+   int    min_NMuonHits_;    // threshold on number of hits on muon
+   int    min_NMuonStations_;    // threshold on number of hits on muon
+   int    min_NTrkLayers_; 
+   int    min_NTrkHits_; 
+   int    min_PixLayers_;
+   int    min_PixHits_;
+   double min_Pt_;           // pt threshold in GeV
+   double max_NormalizedChi2_; // cutoff in normalized chi2
+};
+#endif


### PR DESCRIPTION
Added a module inside RecoMuon/MuonIdentification that allows to apply some ID to a collection of reco::muon objects and provides a new collection of reco::muons. It is meant to be used at HLT to apply some mild ID requirements inside the reconstruction sequence.

Backport to 10_0_X of #22662 