### PR TITLE
Created and added the query to obtain the values of the ECAL attributes.

### DIFF
--- a/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
@@ -446,7 +446,7 @@ void LHCInfoPopConSourceHandler::getNewObjects() {
 	conditionStr = std::string( "FILL_NUMBER = :currentFill" );
 	CTPPSDataQuery->setCondition( conditionStr, CTPPSDataBindVariables );
 	//ORDER BY clause
-	CTPPSDataQuery->addToOrderList( std::string( "DIP_UPDATE_TIME" ) );
+	CTPPSDataQuery->addToOrderList( std::string( "DIP_UPDATE_TIME DESC" ) ); //Only the latest value is fetched.
 	//define query output
 	coral::AttributeList CTPPSDataOutput;
 	CTPPSDataOutput.extend<std::string>( std::string( "LHC_STATE" ) );
@@ -512,12 +512,6 @@ void LHCInfoPopConSourceHandler::getNewObjects() {
 	ECALDataQuery->addToOutputList( std::string( "element_nr" ) );
 	//WHERE CLAUSE
 	coral::AttributeList ECALDataBindVariables;
-	/*ECALDataBindVariables.extend<coral::TimeStamp>( std::string( "stableBeamStartTimeStamp" ) );
-	ECALDataBindVariables[ std::string( "stableBeamStartTimeStamp" ) ].data<coral::TimeStamp>() = stableBeamStartTimeStamp;
-	ECALDataBindVariables.extend<coral::TimeStamp>( std::string( "beamDumpTimeStamp" ) );
-	ECALDataBindVariables[ std::string( "beamDumpTimeStamp" ) ].data<coral::TimeStamp>() = beamDumpTimeStamp;
-	conditionStr = std::string( "CHANGE_DATE BETWEEN :stableBeamStartTimeStamp AND :beamDumpTimeStamp AND (DIP_value LIKE '%beamPhaseMean%' OR DIP_value LIKE '%cavPhaseMean%') " );
-	*/
 	conditionStr = std::string( "DIP_value LIKE '%beamPhaseMean%' OR DIP_value LIKE '%cavPhaseMean%'" );
 	
 	ECALDataQuery->setCondition( conditionStr, ECALDataBindVariables );
@@ -569,7 +563,7 @@ void LHCInfoPopConSourceHandler::getNewObjects() {
 				beam1RF.push_back(elementNrAttribute.data<float>());
 				break;
 			case 4:
-				beam1RF.push_back(elementNrAttribute.data<float>());
+				beam2RF.push_back(elementNrAttribute.data<float>());
 				break;
 			default:
 				break;


### PR DESCRIPTION
Hello, @franzoni, @arunhep, @lpernie and @ggovi.

@ravindkv and I have created and inserted a query to the BEAM_PHASE view of the CMS_DCS_ENV_PVSS_COND schema, in order to obtain the values of the ECAL attributes.

This query completes the LHCInfo package that was merged through this [pull request](https://github.com/cms-sw/cmssw/pull/22527) and replaces the earlier dummy values with actual values from the OMDS.

I request you to kindly scrutinize our work and provide us with your valuable suggestions so that we can improve this pull request and get it merged.

Thank you for your time.

Sincerely,
Amey & Ravindra.