### PR TITLE
Bug fix in the processing of RunInfo O2O magnet current

### DIFF
--- a/CondTools/RunInfo/src/RunInfoRead.cc
+++ b/CondTools/RunInfo/src/RunInfoRead.cc
@@ -251,6 +251,7 @@ RunInfoRead::readData( const std::string & runinfo_schema
     std::vector<double> time_curr;
 
     bool changeFound = false;
+    // first process the changes found within the run boundaries
     while( magnetCurrentCursor.next() ) {
       std::ostringstream oscurrentdebug;
       magnetCurrentCursor.currentRow().toOutputStream( oscurrentdebug );
@@ -283,6 +284,7 @@ RunInfoRead::readData( const std::string & runinfo_schema
       edm::LogInfo( "RunInfoReader" ) << ostrans.str() << std::endl;
     }
 
+    // if not change is found within run boundaries, search for the most recent change 
     if ( !changeFound ){ 
       // we should deal with stable currents... so the query is returning no value and we should take the last modified current value...
       edm::LogInfo( "RunInfoReader" ) << "[RunInfoRead::" << __func__ << "]: The magnet current did not change during run " << r_number


### PR DESCRIPTION
This fix changes the processing of the Magnet Current changes:
- first the changes within the Run boundaries are considered
- if no change has been found within Run boundaries, the most recent change is considered

