### PR TITLE
Binning fixes, calibration patch, cosmics false alarm fix, noise tolerance (for P5 production)

### DIFF
--- a/DQM/EcalCommon/interface/MESetNonObject.h
+++ b/DQM/EcalCommon/interface/MESetNonObject.h
@@ -29,6 +29,8 @@ namespace ecaldqm
 
     double getBinContent(int, int = 0) const override;
 
+    double getFloatValue() const;
+
     double getBinError(int, int = 0) const override;
 
     double getBinEntries(int, int = 0) const override;

--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -726,11 +726,13 @@ namespace ecaldqm
         case kEB:
           xbin = 4 * ((iDCC - 9) % 18) + (isEBm ? towerid - 1 : 68 - towerid) % 4 + 1;
           ybin = (towerid - 1) / 4 * (isEBm ? -1 : 1) + (isEBm ? 18 : 17);
+          nbinsX = 72;
           break;
         case kSM:
         case kEBSM:
           xbin = (towerid - 1) / 4 + 1;
           ybin = (isEBm ? towerid - 1 : 68 - towerid) % 4 + 1;
+          nbinsX = 17;
           break;
         default:
           break;

--- a/DQM/EcalCommon/src/MESetNonObject.cc
+++ b/DQM/EcalCommon/src/MESetNonObject.cc
@@ -48,7 +48,7 @@ namespace ecaldqm
   MESetNonObject::clone(std::string const& _path/* = ""*/) const
   {
     std::string path(path_);
-    if(_path != "") path_ = _path;
+    if(!_path.empty()) path_ = _path;
     MESet* copy(new MESetNonObject(*this));
     path_ = path;
     return copy;

--- a/DQM/EcalCommon/src/MESetNonObject.cc
+++ b/DQM/EcalCommon/src/MESetNonObject.cc
@@ -265,6 +265,13 @@ namespace ecaldqm
   }
 
   double
+  MESetNonObject::getFloatValue() const
+  {
+    if(kind_ == MonitorElement::DQM_KIND_REAL) return mes_[0]->getFloatValue();
+    else return 0.;
+  }
+
+  double
   MESetNonObject::getBinError(int _bin, int) const
   {
     if(!active_) return 0.;

--- a/DQM/EcalMonitorClient/interface/PresampleClient.h
+++ b/DQM/EcalMonitorClient/interface/PresampleClient.h
@@ -17,7 +17,8 @@ namespace ecaldqm
 
     int minChannelEntries_;
     float expectedMean_;
-    float toleranceMean_;
+    float toleranceLow_;
+    float toleranceHigh_;
     float toleranceRMS_;
     float toleranceRMSFwd_;
   };

--- a/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
@@ -5,7 +5,8 @@ from DQM.EcalMonitorClient.IntegrityClient_cfi import ecalIntegrityClient
 
 minChannelEntries = 6
 expectedMean = 200.0
-toleranceMean = 25.0
+toleranceLow = 25.0
+toleranceHigh = 40.0
 toleranceRMS = 3.0
 toleranceRMSFwd = 6.0
 
@@ -13,7 +14,8 @@ ecalPresampleClient = cms.untracked.PSet(
     params = cms.untracked.PSet(
         minChannelEntries = cms.untracked.int32(minChannelEntries),
         expectedMean = cms.untracked.double(expectedMean),
-        toleranceMean = cms.untracked.double(toleranceMean),
+        toleranceLow = cms.untracked.double(toleranceLow),
+        toleranceHigh = cms.untracked.double(toleranceHigh),
         toleranceRMS = cms.untracked.double(toleranceRMS),
         toleranceRMSFwd = cms.untracked.double(toleranceRMSFwd)
     ),
@@ -84,14 +86,14 @@ ecalPresampleClient = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('Crystal'),
-            description = cms.untracked.string('Summary of the presample data quality. A channel is red if presample mean is off by ' + str(toleranceMean) + ' from ' + str(expectedMean) + ' or RMS is greater than ' + str(toleranceRMS) + '. RMS threshold is ' + str(toleranceRMSFwd) + ' in the forward region (|eta| > 2.1). Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')
+            description = cms.untracked.string('Summary of the presample data quality. A channel is red if presample mean is outside the range (' + str(expectedMean - toleranceLow) + ', ' + str(expectedMean + toleranceHigh) + '), or RMS is greater than ' + str(toleranceRMS) + '. RMS threshold is ' + str(toleranceRMSFwd) + ' in the forward region (|eta| > 2.1). Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')
         ),
         Quality = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sPedestalOnlineClient/%(prefix)sPOT pedestal quality G12 %(sm)s'),
             kind = cms.untracked.string('TH2F'),
             otype = cms.untracked.string('SM'),
             btype = cms.untracked.string('Crystal'),
-            description = cms.untracked.string('Summary of the presample data quality. A channel is red if presample mean is off by ' + str(toleranceMean) + ' from ' + str(expectedMean) + ' or RMS is greater than ' + str(toleranceRMS) + '. RMS threshold is ' + str(toleranceRMSFwd) + ' in the forward region (|eta| > 2.1). Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')            
+            description = cms.untracked.string('Summary of the presample data quality. A channel is red if presample mean is outside the range (' + str(expectedMean - toleranceLow) + ', ' + str(expectedMean + toleranceHigh) + '), or RMS is greater than ' + str(toleranceRMS) + '. RMS threshold is ' + str(toleranceRMSFwd) + ' in the forward region (|eta| > 2.1). Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')
         ),
         ErrorsSummary = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sSummaryClient/%(prefix)sPOT pedestal quality errors summary G12'),

--- a/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
@@ -17,6 +17,7 @@ ecalTrigPrimClient = cms.untracked.PSet(
         TTFlags4 = ecalTrigPrimTask.MEs.TTFlags4,
         TTMaskMapAll = ecalTrigPrimTask.MEs.TTMaskMapAll,
         TTFMismatch = ecalTrigPrimTask.MEs.TTFMismatch,
+        LHCStatusByLumi = ecalTrigPrimTask.MEs.LHCStatusByLumi,
         TPDigiThrAll = ecalOccupancyTask.MEs.TPDigiThrAll
     ),
     MEs = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/src/PresampleClient.cc
+++ b/DQM/EcalMonitorClient/src/PresampleClient.cc
@@ -15,7 +15,8 @@ namespace ecaldqm
     DQWorkerClient(),
     minChannelEntries_(0),
     expectedMean_(0.),
-    toleranceMean_(0.),
+    toleranceLow_(0.),
+    toleranceHigh_(0.),
     toleranceRMS_(0.),
     toleranceRMSFwd_(0.)
   {
@@ -28,7 +29,8 @@ namespace ecaldqm
   {
     minChannelEntries_ = _params.getUntrackedParameter<int>("minChannelEntries");
     expectedMean_ = _params.getUntrackedParameter<double>("expectedMean");
-    toleranceMean_ = _params.getUntrackedParameter<double>("toleranceMean");
+    toleranceLow_ = _params.getUntrackedParameter<double>("toleranceLow");
+    toleranceHigh_ = _params.getUntrackedParameter<double>("toleranceHigh");
     toleranceRMS_ = _params.getUntrackedParameter<double>("toleranceRMS");
     toleranceRMSFwd_ = _params.getUntrackedParameter<double>("toleranceRMSFwd");
   }
@@ -93,7 +95,7 @@ namespace ecaldqm
       meRMSMap.setBinContent(id, rms);
       meRMSMapAllByLumi.setBinContent(id, rmsLS);
 
-      if(std::abs(mean - expectedMean_) > toleranceMean_ || rms > rmsThresh){
+      if(((mean > expectedMean_ + toleranceHigh_) || (mean < expectedMean_ - toleranceLow_)) || rms > rmsThresh){
         qItr->setBinContent(doMask ? kMBad : kBad);
         meQualitySummary.setBinContent(id, doMask ? kMBad : kBad);
         if(!doMask) meErrorsSummary.fill(id);

--- a/DQM/EcalMonitorTasks/BuildFile.xml
+++ b/DQM/EcalMonitorTasks/BuildFile.xml
@@ -7,6 +7,7 @@
 <use   name="DataFormats/EcalRecHit"/>
 <use   name="DataFormats/EgammaReco"/>
 <use   name="DataFormats/Math"/>
+<use   name="DataFormats/TCDS"/>
 <use   name="DataFormats/L1GlobalTrigger"/>
 <use   name="DataFormats/L1GlobalMuonTrigger"/>
 <use   name="FWCore/Framework"/>

--- a/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
+++ b/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
@@ -4,8 +4,12 @@
 #include "DQWorkerTask.h"
 
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+#include "DataFormats/TCDS/interface/TCDSRecord.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGStripStatus.h"
@@ -28,6 +32,8 @@ namespace ecaldqm {
     void runOnRealTPs(EcalTrigPrimDigiCollection const&);
     void runOnEmulTPs(EcalTrigPrimDigiCollection const&);
     template<typename DigiCollection> void runOnDigis(DigiCollection const&);
+
+    void setTokens(edm::ConsumesCollector&) override;
 
     enum Constants {
       nBXBins = 15
@@ -52,6 +58,10 @@ namespace ecaldqm {
 
     edm::ESHandle<EcalTPGTowerStatus> TTStatusRcd;
     edm::ESHandle<EcalTPGStripStatus> StripStatusRcd;
+
+    edm::InputTag lhcStatusInfoCollectionTag_;
+    edm::EDGetTokenT<TCDSRecord> lhcStatusInfoRecordToken_;
+    bool lhcStatusSet_;
 
   };
 

--- a/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
@@ -23,7 +23,8 @@ ecalTrigPrimTask = cms.untracked.PSet(
     params = cms.untracked.PSet(
         #    HLTMuonPath = cms.untracked.string('HLT_Mu5_v*'),
         #    HLTCaloPath = cms.untracked.string('HLT_SingleJet*'),
-        runOnEmul = cms.untracked.bool(True)
+        runOnEmul = cms.untracked.bool(True),
+        lhcStatusInfoCollectionTag = cms.untracked.InputTag("tcdsDigis","tcdsRecord")
     ),
     MEs = cms.untracked.PSet(
         LowIntMap = cms.untracked.PSet(
@@ -268,6 +269,13 @@ ecalTrigPrimTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT Real vs Emulated TP Et%(suffix)s'),
             description = cms.untracked.string('Real data VS emulated TP Et (in-time)')
+        ),
+        LHCStatusByLumi = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/LHC status by lumi'),
+            kind = cms.untracked.string('REAL'),
+            otype = cms.untracked.string('None'),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('LHC Status in this lumisection. The convention for the value is the same as in the plot Info/LhcInfo/beamMode')
         )
     )
 )

--- a/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
+++ b/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
@@ -1,6 +1,7 @@
 #include "../interface/PNDiodeTask.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace ecaldqm {
 
@@ -59,7 +60,12 @@ namespace ecaldqm {
     }
 
     std::for_each(_ids.begin(), _ids.end(), [&](EcalElectronicsIdCollection::value_type const& id){
-        set->fill(EcalElectronicsId(id.dccId(), id.towerId(), 1, id.xtalId()));
+        if (id.towerId() == 69) {
+          edm::LogWarning("EcalDQM") << "PNDiodeTask::runOnErrors : one of the ids in the electronics ID collection is unphysical in lumi number " << timestamp_.iLumi << ", event number " << timestamp_.iEvt; // Added March 2018 because some events have this unphysical tower ID and cause the ECAL calibration application to crash.
+        }
+        else {
+          set->fill(EcalElectronicsId(id.dccId(), id.towerId(), 1, id.xtalId()));
+        }
       });
   }
 

--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -1,5 +1,6 @@
 ### AUTO-GENERATED CMSRUN CONFIGURATION FOR ECAL DQM ###
 import FWCore.ParameterSet.Config as cms
+from EventFilter.Utilities.tcdsRawToDigi_cfi import * # To monitor LHC status, e.g. to mask trigger primitives quality alarm during Cosmics
 
 process = cms.Process("process")
 
@@ -92,6 +93,9 @@ process.GlobalTag.toGet = cms.VPSet(cms.PSet(
 
 process.preScaler.prescaleFactor = 1
 
+process.tcdsDigis = tcdsRawToDigi.clone()
+process.tcdsDigis.InputLabel = cms.InputTag("rawDataCollector")
+
 process.DQMStore.referenceFileName = "/dqmdata/dqm/reference/ecal_reference.root"
 
 process.dqmEnv.subSystemFolder = cms.untracked.string('Ecal')
@@ -122,7 +126,7 @@ process.hybridClusteringSequence = cms.Sequence(process.cleanedHybridSuperCluste
 
 ### Paths ###
 
-process.ecalMonitorPath = cms.Path(process.preScaler+process.ecalPreRecoSequence+process.ecalPhysicsFilter+process.ecalRecoSequence+process.ecalMonitorTask)
+process.ecalMonitorPath = cms.Path(process.preScaler+process.ecalPreRecoSequence+process.ecalPhysicsFilter+process.ecalRecoSequence+process.tcdsDigis+process.ecalMonitorTask)
 process.ecalClientPath = cms.Path(process.preScaler+process.ecalPreRecoSequence+process.ecalPhysicsFilter+process.ecalMonitorClient)
 
 process.dqmEndPath = cms.EndPath(process.dqmEnv)


### PR DESCRIPTION
This PR reintroduces a few changes that were merged with the production CMSSW version last year but were not integrated with CMSSW master. In addition, there are a couple of new commits implementing some changes requested by ECAL experts. Here is a summary of the changes:

---> From 2017:

(1) Fixed bug in binning that led to incorrect bin numbers while filling many 2D histograms by supercrystal based on the electronics ID.

(2) Using beam status information from TCDS Digis, implemented a mask on the usual false alarms on TP occupancy during cosmics for ECAL.

---> New commits:

(3) Improved patch to ignore events causing ECAL DQM Calibration application crashes. This was what caused the delay in merging my commits into CMSSW master last year -- at the time, the code used a try-catch block which was not good from the efficiency point of view. This try-catch block has now been replaced with a much simpler if condition.

(4) Modified noise tolerance in presample plots to range (175, 240) ADC counts instead of the current (175, 225) ADC counts, because the pedestal value in some towers has been drifting higher especially in the endcaps causing the presample plots to be liberally peppered with RED channels.

Link to the corresponding PR to CMSSW master: https://github.com/cms-sw/cmssw/pull/22689