### PR TITLE
Temporarily disable SiStripMonitorClient BadChannel sequences (crash due to PR 22373)

### DIFF
--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
@@ -21,29 +21,30 @@ siStripQTester = cms.EDAnalyzer("QualityTester",
     getQualityTestsFromFile = cms.untracked.bool(True)
 )
 
-from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
-siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
-siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
+# from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
+# siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
+# siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
 
-from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
-siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
-       cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
-       cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
-       cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
-       cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
-       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
-       cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
-       )
-siStripQualityESProducer.ReduceGranularity = cms.bool(False)
-siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
-siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
+# from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
+# siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
+#        cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
+#        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
+#        cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
+#        cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
+#        cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
+#        cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
+#        )
+# siStripQualityESProducer.ReduceGranularity = cms.bool(False)
+# siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
+# siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
 
-siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
-    StripQualityLabel = cms.string('MergedBadComponent')
-)
+# siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
+#     StripQualityLabel = cms.string('MergedBadComponent')
+# )
 
 # Sequence
-SiStripCosmicDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser*siStripBadComponentInfo)
+# SiStripCosmicDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser*siStripBadComponentInfo)
+SiStripCosmicDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser)
 #removed modules using TkDetMap
 #SiStripCosmicDQMClient = cms.Sequence(siStripQTester)
 

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
@@ -32,31 +32,32 @@ siStripQTesterHI = cms.EDAnalyzer("QualityTester",
     getQualityTestsFromFile = cms.untracked.bool(True)
 )
 
-from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
-siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
-siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
+# from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
+# siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
+# siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
 
-from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
-siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
-       cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
-       cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
-       cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
-       cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
-       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
-       cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
-       )
-siStripQualityESProducer.ReduceGranularity = cms.bool(False)
-siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
-siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
+# from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
+# siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
+#        cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
+#        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
+#        cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
+#        cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
+#        cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
+#        cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
+#        )
+# siStripQualityESProducer.ReduceGranularity = cms.bool(False)
+# siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
+# siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
 
-siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
-    StripQualityLabel = cms.string('MergedBadComponent')
-)
+# siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
+#     StripQualityLabel = cms.string('MergedBadComponent')
+# )
 
 # define new HI sequence
 #removed modules using TkDetMap
 #SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI)
-SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI*siStripOfflineAnalyser*siStripBadComponentInfo)
+# SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI*siStripOfflineAnalyser*siStripBadComponentInfo)
+SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI*siStripOfflineAnalyser)
 
 # Services needed for TkHistoMap
 from CalibTracker.SiStripCommon.TkDetMap_cff import *

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
@@ -37,30 +37,31 @@ siStripQTester = cms.EDAnalyzer("QualityTester",
     getQualityTestsFromFile = cms.untracked.bool(True)
 )
 
-from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
-siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
-siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
+# from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
+# siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
+# siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
 
-from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
-siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
-       cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
-       cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
-       cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
-       cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
-       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
-       cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
-       )
-siStripQualityESProducer.ReduceGranularity = cms.bool(False)
-siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
-siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
+# from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
+# siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
+#        cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
+#        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
+#        cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
+#        cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
+#        cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
+#        cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
+#        )
+# siStripQualityESProducer.ReduceGranularity = cms.bool(False)
+# siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
+# siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
 
-siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
-    StripQualityLabel = cms.string('MergedBadComponent')
-)
+# siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
+#     StripQualityLabel = cms.string('MergedBadComponent')
+# )
 
 
 # Sequence
-SiStripOfflineDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser*siStripBadComponentInfo)
+# SiStripOfflineDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser*siStripBadComponentInfo)
+SiStripOfflineDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser)
 #removed modules using TkDetMap
 #SiStripOfflineDQMClient = cms.Sequence(siStripQTester)
 


### PR DESCRIPTION
#22373 add a new DQM harvester, that unfortunately crashes several workflows (4.28, 136.754, 136.757, ...) see https://cms-sw.github.io/relvalLogDetail.html#slc6_amd64_gcc630;CMSSW_10_1_X_2018-03-20-2300

This PR temporarily disable the new code in standard sequences, pending a fix for the problem