### PR TITLE
GT Updates : SIM geometry update for 2018 to remove TOTEM

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -48,11 +48,11 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '101X_upgrade2018_design_v5',
+    'phase1_2018_design'       : '101X_upgrade2018_design_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v4',
+    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v5',
+    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '101X_postLS2_design_v3', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
As requested here : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3528.html and discussed at last ORP yesterday, we have updated the 2018 MC GTs with the SIM geometry which removes the TOTEM (which hardware wise has already been removed).

The GT differences are : 

Cosmics : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2018cosmics_realistic_deco_v6/101X_upgrade2018cosmics_realistic_deco_v5

Realistic : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2018_realistic_v5/101X_upgrade2018_realistic_v4

Design : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2018_design_v6/101X_upgrade2018_design_v5

FYI @ianna