### PR TITLE
[10.1.X] Resurrection of Lorentz angle calibration integrated into MillePede alignment

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationBase.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationBase.h
@@ -92,6 +92,10 @@ public:
 			  AlignableMuon *muon,
 			  AlignableExtras *extras) {};
 
+  /// Call at beginning of run:
+  /// default implementation is dummy, to be overwritten in derived class if useful.
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&) {};
+
   /// Called at beginning of a loop of the AlignmentProducer,
   /// to be used for iterative algorithms, default does nothing.
   /// FIXME: move call to algorithm?

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
@@ -41,7 +41,6 @@
 #include "TFile.h"
 #include "TString.h"
 
-#include <boost/assign/list_of.hpp>
 #include <vector>
 #include <map>
 #include <sstream>
@@ -247,7 +246,7 @@ void SiPixelLorentzAngleCalibration::beginOfJob(AlignableTracker *aliTracker,
                                                 AlignableExtras * /*aliExtras*/)
 {
   //specify the sub-detectors for which the LA is determined
-  const std::vector<int> sdets = boost::assign::list_of(PixelSubdetector::PixelBarrel)(PixelSubdetector::PixelEndcap);
+  const std::vector<int> sdets = {PixelSubdetector::PixelBarrel, PixelSubdetector::PixelEndcap};
   
   moduleGroupSelector_ =
     std::make_unique<TkModuleGroupSelector>(aliTracker, moduleGroupSelCfg_, sdets);

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
@@ -25,6 +25,7 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Alignment/CommonAlignment/interface/Alignable.h"
 
@@ -55,28 +56,20 @@ class SiPixelLorentzAngleCalibration : public IntegratedCalibrationBase
 public:
   /// Constructor
   explicit SiPixelLorentzAngleCalibration(const edm::ParameterSet &cfg);
-  
+
   /// Destructor
   ~SiPixelLorentzAngleCalibration() override = default;
 
   /// How many parameters does this calibration define?
   unsigned int numParameters() const override;
 
-  // /// Return all derivatives,
-  // /// default implementation uses other derivatives(..) method,
-  // /// but can be overwritten in derived class for efficiency.
-  // virtual std::vector<double> derivatives(const TransientTrackingRecHit &hit,
-  // 					  const TrajectoryStateOnSurface &tsos,
-  // 					  const edm::EventSetup &setup,
-  // 					  const EventInfo &eventInfo) const;
-
   /// Return non-zero derivatives for x- and y-measurements with their indices by reference.
   /// Return value is their number.
   unsigned int derivatives(std::vector<ValuesIndexPair> &outDerivInds,
-				   const TransientTrackingRecHit &hit,
-				   const TrajectoryStateOnSurface &tsos,
-				   const edm::EventSetup &setup,
-				   const EventInfo &eventInfo) const override;
+                           const TransientTrackingRecHit &hit,
+                           const TrajectoryStateOnSurface &tsos,
+                           const edm::EventSetup &setup,
+                           const EventInfo &eventInfo) const override;
 
   /// Setting the determined parameter identified by index,
   /// returns false if out-of-bounds, true otherwise.
@@ -94,34 +87,33 @@ public:
   /// Returns 0. if index out-of-bounds or if errors undetermined.
   double getParameterError(unsigned int index) const override;
 
-  // /// Call at beginning of job:
+  /// Call at beginning of job:
   void beginOfJob(AlignableTracker *tracker,
-  			  AlignableMuon *muon,
-  			  AlignableExtras *extras) override;
+                  AlignableMuon *muon,
+                  AlignableExtras *extras) override;
 
-
+  /// Call at beginning of run:
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
 
   /// Called at end of a the job of the AlignmentProducer.
   /// Write out determined parameters.
   void endOfJob() override;
 
 private:
-  /// If called the first time, fill 'siPixelLorentzAngleInput_',
-  /// later check that LorentzAngle has not changed.
-  bool checkLorentzAngleInput(const edm::EventSetup &setup, const EventInfo &eventInfo);
   /// Input LorentzAngle values:
   /// - either from EventSetup of first call to derivatives(..)
   /// - or created from files of passed by configuration (i.e. from parallel processing)
-  const SiPixelLorentzAngle* getLorentzAnglesInput();
+  const SiPixelLorentzAngle* getLorentzAnglesInput(const align::RunNumber& = 0);
 
   /// Determined parameter value for this detId (detId not treated => 0.)
   /// and the given run.
   double getParameterForDetId(unsigned int detId, edm::RunNumber_t run) const;
 
   void writeTree(const SiPixelLorentzAngle *lorentzAngle,
-		 const std::map<unsigned int,TreeStruct>& treeInfo, const char *treeName) const;
-  SiPixelLorentzAngle* createFromTree(const char *fileName, const char *treeName) const;
-  
+                 const std::map<unsigned int,TreeStruct>& treeInfo,
+                 const char *treeName) const;
+  SiPixelLorentzAngle createFromTree(const char *fileName, const char *treeName) const;
+
   const bool saveToDB_;
   const std::string recordNameDBwrite_;
   const std::string outFileName_;
@@ -131,7 +123,9 @@ private:
   edm::ESWatcher<SiPixelLorentzAngleRcd> watchLorentzAngleRcd_;
 
   // const AlignableTracker *alignableTracker_;
-  std::unique_ptr<SiPixelLorentzAngle> siPixelLorentzAngleInput_;
+  std::map<align::RunNumber, SiPixelLorentzAngle> cachedLorentzAngleInputs_;
+  SiPixelLorentzAngle* siPixelLorentzAngleInput_{nullptr};
+  align::RunNumber currentIOV_{0};
   std::vector<double> parameters_;
   std::vector<double> paramUncertainties_;
 
@@ -162,21 +156,64 @@ unsigned int SiPixelLorentzAngleCalibration::numParameters() const
 }
 
 //======================================================================
+void
+SiPixelLorentzAngleCalibration::beginRun(const edm::Run& run,
+                                         const edm::EventSetup& setup) {
+
+  // no action needed if the LA record didn't change
+  if (!(watchLorentzAngleRcd_.check(setup))) return;
+
+  const auto runNumber = run.run();
+  auto firstRun = cond::timeTypeSpecs[cond::runnumber].beginValue;
+
+  // avoid infinite loop due to wrap-around of unsigned variable 'i' including
+  // arrow from i to zero and a nice smiley ;)
+  for (unsigned int i = moduleGroupSelector_->numIovs(); i-->0 ;) {
+    const auto firstRunOfIOV = moduleGroupSelector_->firstRunOfIOV(i);
+    if (runNumber >= firstRunOfIOV) {
+      firstRun = firstRunOfIOV;
+      break;
+    }
+  }
+
+  edm::ESHandle<SiPixelLorentzAngle> lorentzAngleHandle;
+  const auto& lorentzAngleRcd = setup.get<SiPixelLorentzAngleRcd>();
+  lorentzAngleRcd.get(lorentzAngleLabel_, lorentzAngleHandle);
+  if (cachedLorentzAngleInputs_.find(firstRun) == cachedLorentzAngleInputs_.end()) {
+    cachedLorentzAngleInputs_.emplace(firstRun, SiPixelLorentzAngle(*lorentzAngleHandle));
+  } else {
+    if (lorentzAngleRcd.validityInterval().first().eventID().run() > firstRun &&
+        lorentzAngleHandle->getLorentzAngles()  // only bad if non-identical values
+        != cachedLorentzAngleInputs_[firstRun].getLorentzAngles()) { // (comparing maps)
+      // Maps are containers sorted by key, but comparison problems may arise from
+      // 'floating point comparison' problems (FIXME?)
+      throw cms::Exception("BadInput")
+        << "Trying to cache SiPixelLorentzAngle payload for a run (" << runNumber
+        << ") in an IOV (" << firstRun << ") that was already cached.\n"
+        << "The following record in your input database tag has an IOV "
+        << "boundary that does not match your IOV definition:\n"
+        << " - SiPixelLorentzAngleRcd '" << lorentzAngleRcd.key().name()
+        << "' (since "
+        << lorentzAngleRcd.validityInterval().first().eventID().run() << ")\n";
+    }
+  }
+
+  siPixelLorentzAngleInput_ = &(cachedLorentzAngleInputs_[firstRun]);
+  currentIOV_ = firstRun;
+}
+
+//======================================================================
 unsigned int
 SiPixelLorentzAngleCalibration::derivatives(std::vector<ValuesIndexPair> &outDerivInds,
-					    const TransientTrackingRecHit &hit,
-					    const TrajectoryStateOnSurface &tsos,
-					    const edm::EventSetup &setup,
-					    const EventInfo &eventInfo) const
+                                            const TransientTrackingRecHit &hit,
+                                            const TrajectoryStateOnSurface &tsos,
+                                            const edm::EventSetup &setup,
+                                            const EventInfo &eventInfo) const
 {
-  // ugly const-cast:
-  // But it is either only first initialisation or throwing an exception...
-  const_cast<SiPixelLorentzAngleCalibration*>(this)->checkLorentzAngleInput(setup, eventInfo);
-
   outDerivInds.clear();
 
   if (hit.det()) { // otherwise 'constraint hit' or whatever
-    
+
     const int index = moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(),
                                                                        eventInfo.eventId().run());
     if (index >= 0) { // otherwise not treated
@@ -191,15 +228,15 @@ SiPixelLorentzAngleCalibration::derivatives(std::vector<ValuesIndexPair> &outDer
       const double xDerivative = bFieldLocal.y() * dZ * -0.5; // parameter is mobility!
       const double yDerivative = bFieldLocal.x() * dZ * 0.5; // parameter is mobility!
       if (xDerivative || yDerivative) { // If field is zero, this is zero: do not return it
-	const Values derivs{xDerivative, yDerivative};
-	outDerivInds.push_back(ValuesIndexPair(derivs, index));
+        const Values derivs{xDerivative, yDerivative};
+        outDerivInds.push_back(ValuesIndexPair(derivs, index));
       }
     }
   } else {
     edm::LogWarning("Alignment") << "@SUB=SiPixelLorentzAngleCalibration::derivatives2"
-				 << "Hit without GeomDet, skip!";
+                                 << "Hit without GeomDet, skip!";
   }
-  
+
   return outDerivInds.size();
 }
 
@@ -247,20 +284,20 @@ void SiPixelLorentzAngleCalibration::beginOfJob(AlignableTracker *aliTracker,
 {
   //specify the sub-detectors for which the LA is determined
   const std::vector<int> sdets = {PixelSubdetector::PixelBarrel, PixelSubdetector::PixelEndcap};
-  
+
   moduleGroupSelector_ =
     std::make_unique<TkModuleGroupSelector>(aliTracker, moduleGroupSelCfg_, sdets);
 
   parameters_.resize(moduleGroupSelector_->getNumberOfParameters(), 0.);
   paramUncertainties_.resize(moduleGroupSelector_->getNumberOfParameters(), 0.);
-  
+
   edm::LogInfo("Alignment") << "@SUB=SiPixelLorentzAngleCalibration" << "Created with name "
                             << this->name() << "',\n" << this->numParameters() << " parameters to be determined,"
                             << "\n saveToDB = " << saveToDB_
                             << "\n outFileName = " << outFileName_
                             << "\n N(merge files) = " << mergeFileNames_.size()
                             << "\n number of IOVs = " << moduleGroupSelector_->numIovs();
-     
+
   if (!mergeFileNames_.empty()) {
     edm::LogInfo("Alignment") << "@SUB=SiPixelLorentzAngleCalibration"
                               << "First file to merge: " << mergeFileNames_[0];
@@ -281,15 +318,21 @@ void SiPixelLorentzAngleCalibration::endOfJob()
 
   std::map<unsigned int, TreeStruct> treeInfo; // map of TreeStruct for each detId
 
-  // now write 'input' tree
-  const SiPixelLorentzAngle *input = this->getLorentzAnglesInput(); // never NULL
-  const std::string treeName(this->name() + '_');
-  this->writeTree(input, treeInfo, (treeName + "input").c_str()); // empty treeInfo for input...
+  // now write 'input' tree(s)
+  const std::string treeName{this->name() + '_'};
+  std::vector<const SiPixelLorentzAngle*> inputs{};
+  inputs.reserve(moduleGroupSelector_->numIovs());
+  for (unsigned int iIOV = 0; iIOV < moduleGroupSelector_->numIovs(); ++iIOV) {
+    const auto firstRunOfIOV = moduleGroupSelector_->firstRunOfIOV(iIOV);
+    inputs.push_back(this->getLorentzAnglesInput(firstRunOfIOV)); // never NULL
+    this->writeTree(inputs.back(), treeInfo,
+                    (treeName + "input_" + std::to_string(firstRunOfIOV)).c_str()); // empty treeInfo for input...
 
-  if (input->getLorentzAngles().empty()) {
-    edm::LogError("Alignment") << "@SUB=SiPixelLorentzAngleCalibration::endOfJob"
-			       << "Input Lorentz angle map is empty, skip writing output!";
-    return;
+    if (inputs.back()->getLorentzAngles().empty()) {
+      edm::LogError("Alignment") << "@SUB=SiPixelLorentzAngleCalibration::endOfJob"
+                                 << "Input Lorentz angle map is empty, skip writing output!";
+      return;
+    }
   }
 
   const unsigned int nonZeroParamsOrErrors =   // Any determined value?
@@ -298,100 +341,73 @@ void SiPixelLorentzAngleCalibration::endOfJob()
                std::bind2nd(std::not_equal_to<double>(), 0.));
 
   for (unsigned int iIOV = 0; iIOV < moduleGroupSelector_->numIovs(); ++iIOV) {
-    //  for (unsigned int iIOV = 0; iIOV < 1; ++iIOV) {   // For writing out the modified values
-    cond::Time_t firstRunOfIOV = moduleGroupSelector_->firstRunOfIOV(iIOV);
-    SiPixelLorentzAngle *output = new SiPixelLorentzAngle;
+    auto firstRunOfIOV = static_cast<cond::Time_t>(moduleGroupSelector_->firstRunOfIOV(iIOV));
+    SiPixelLorentzAngle output{};
     // Loop on map of values from input and add (possible) parameter results
-    for (auto iterIdValue = input->getLorentzAngles().begin();
-	 iterIdValue != input->getLorentzAngles().end(); ++iterIdValue) {
-      // type of (*iterIdValue) is pair<unsigned int, float>
-      const unsigned int detId = iterIdValue->first; // key of map is DetId
-      const double param = this->getParameterForDetId(detId, firstRunOfIOV);
+    for (const auto& iterIdValue: inputs[iIOV]->getLorentzAngles()) {
+      // type of 'iterIdValue' is pair<unsigned int, float>
+      const auto detId = iterIdValue.first; // key of map is DetId
+      const auto param = this->getParameterForDetId(detId, firstRunOfIOV);
       // put result in output, i.e. sum of input and determined parameter, but the nasty
       // putLorentzAngle(..) takes float by reference - not even const reference:
-      float value = iterIdValue->second + param;
-      output->putLorentzAngle(detId, value);
+      auto value = iterIdValue.second + static_cast<float>(param);
+      output.putLorentzAngle(detId, value);
       const int paramIndex = moduleGroupSelector_->getParameterIndexFromDetId(detId,firstRunOfIOV);
       treeInfo[detId] = TreeStruct(param, this->getParameterError(paramIndex), paramIndex);
     }
 
     if (saveToDB_ || nonZeroParamsOrErrors != 0) { // Skip writing mille jobs...
-      this->writeTree(output, treeInfo, (treeName + Form("result_%lld", firstRunOfIOV)).c_str());
+      this->writeTree(&output, treeInfo, (treeName + Form("result_%lld", firstRunOfIOV)).c_str());
     }
 
-    if (saveToDB_) { // If requested, write out to DB 
+    if (saveToDB_) { // If requested, write out to DB
       edm::Service<cond::service::PoolDBOutputService> dbService;
       if (dbService.isAvailable()) {
-	dbService->writeOne(output, firstRunOfIOV, recordNameDBwrite_);
-	// no 'delete output;': writeOne(..) took over ownership
+        dbService->writeOne(&output, firstRunOfIOV, recordNameDBwrite_);
       } else {
-	delete output;
-	edm::LogError("BadConfig") << "@SUB=SiPixelLorentzAngleCalibration::endOfJob"
-				   << "No PoolDBOutputService available, but saveToDB true!";
+        edm::LogError("BadConfig") << "@SUB=SiPixelLorentzAngleCalibration::endOfJob"
+                                   << "No PoolDBOutputService available, but saveToDB true!";
       }
-    } else {
-      delete output;
     }
   } // end loop on IOVs
 
 }
 
 //======================================================================
-bool SiPixelLorentzAngleCalibration::checkLorentzAngleInput(const edm::EventSetup &setup,
-							    const EventInfo &eventInfo)
+const SiPixelLorentzAngle*
+SiPixelLorentzAngleCalibration::getLorentzAnglesInput(const align::RunNumber& run)
 {
-  edm::ESHandle<SiPixelLorentzAngle> lorentzAngleHandle;
-  if (!siPixelLorentzAngleInput_) {
-    setup.get<SiPixelLorentzAngleRcd>().get(lorentzAngleLabel_, lorentzAngleHandle);
-    siPixelLorentzAngleInput_ = std::make_unique<SiPixelLorentzAngle>(*lorentzAngleHandle);
-  } else {
-    if (watchLorentzAngleRcd_.check(setup)) { // new IOV of input
-      setup.get<SiPixelLorentzAngleRcd>().get(lorentzAngleHandle);
-      if (lorentzAngleHandle->getLorentzAngles() // but only bad if non-identical values
-	  != siPixelLorentzAngleInput_->getLorentzAngles()) { // (comparing maps)
-	// Maps are containers sorted by key, but comparison problems may arise from
-	// 'floating point comparison' problems (FIXME?)
-	throw cms::Exception("BadInput")
-	  << "SiPixelLorentzAngleCalibration::checkLorentzAngleInput:\n"
-	  << "Content of SiPixelLorentzAngle changed at run " << eventInfo.eventId().run()
-	  << ", but algorithm expects constant input!\n";
-	return false; // not reached...
-      }
-    }
-  }
-  
-  return true;
-}
-
-//======================================================================
-const SiPixelLorentzAngle* SiPixelLorentzAngleCalibration::getLorentzAnglesInput()
-{
+  const auto& resolvedRun = run > 0 ? run : currentIOV_;
   // For parallel processing in Millepede II, create SiPixelLorentzAngle
   // from info stored in files of parallel jobs and check that they are identical.
   // If this job has run on data, still check that LA is identical to the ones
   // from mergeFileNames_.
-  const std::string treeName(this->name() + "_input");
-  for (auto iFile = mergeFileNames_.begin(); iFile != mergeFileNames_.end(); ++iFile) {
-    auto la = std::unique_ptr<SiPixelLorentzAngle>(this->createFromTree(iFile->c_str(), treeName.c_str()));
+  const std::string treeName{this->name()+"_input_"+std::to_string(resolvedRun)};
+  for (const auto& iFile: mergeFileNames_) {
+    auto la = this->createFromTree(iFile.c_str(), treeName.c_str());
     // siPixelLorentzAngleInput_ could be non-null from previous file of this loop
     // or from checkLorentzAngleInput(..) when running on data in this job as well
     if (!siPixelLorentzAngleInput_ || siPixelLorentzAngleInput_->getLorentzAngles().empty()) {
-      siPixelLorentzAngleInput_ = std::move(la);
+      cachedLorentzAngleInputs_[resolvedRun] = la;
+      siPixelLorentzAngleInput_ = &(cachedLorentzAngleInputs_[resolvedRun]);
+      currentIOV_ = resolvedRun;
     } else {
       // FIXME: about comparison of maps see comments in checkLorentzAngleInput
-      if (la && !la->getLorentzAngles().empty() && // single job might not have got events
-          la->getLorentzAngles() != siPixelLorentzAngleInput_->getLorentzAngles()) {
+      if (!la.getLorentzAngles().empty() && // single job might not have got events
+          la.getLorentzAngles() != siPixelLorentzAngleInput_->getLorentzAngles()) {
         // Throw exception instead of error?
         edm::LogError("NoInput") << "@SUB=SiPixelLorentzAngleCalibration::getLorentzAnglesInput"
                                  << "Different input values from tree " << treeName
-                                 << " in file " << *iFile << ".";
-        
+                                 << " in file " << iFile << ".";
+
       }
     }
   }
 
   if (!siPixelLorentzAngleInput_) { // no files nor ran on events
-    siPixelLorentzAngleInput_ = std::make_unique<SiPixelLorentzAngle>();
+    // [] operator default-constructs an empty SiPixelLorentzAngle object in place:
+    siPixelLorentzAngleInput_ = &(cachedLorentzAngleInputs_[resolvedRun]);
+    currentIOV_ = resolvedRun;
     edm::LogError("NoInput") << "@SUB=SiPixelLorentzAngleCalibration::getLorentzAnglesInput"
                              << "No input, create an empty one!";
   } else if (siPixelLorentzAngleInput_->getLorentzAngles().empty()) {
@@ -399,12 +415,12 @@ const SiPixelLorentzAngle* SiPixelLorentzAngleCalibration::getLorentzAnglesInput
                              << "Empty result!";
   }
 
-  return siPixelLorentzAngleInput_.get();
+  return siPixelLorentzAngleInput_;
 }
 
 //======================================================================
 double SiPixelLorentzAngleCalibration::getParameterForDetId(unsigned int detId,
-							    edm::RunNumber_t run) const
+                                                            edm::RunNumber_t run) const
 {
   const int index = moduleGroupSelector_->getParameterIndexFromDetId(detId, run);
   return (index < 0 ? 0. : parameters_[index]);
@@ -412,15 +428,15 @@ double SiPixelLorentzAngleCalibration::getParameterForDetId(unsigned int detId,
 
 //======================================================================
 void SiPixelLorentzAngleCalibration::writeTree(const SiPixelLorentzAngle *lorentzAngle,
-					       const std::map<unsigned int,TreeStruct> &treeInfo, 
-					       const char *treeName) const
+                                               const std::map<unsigned int,TreeStruct> &treeInfo,
+                                               const char *treeName) const
 {
   if (!lorentzAngle) return;
 
   TFile* file = TFile::Open(outFileName_.c_str(), "UPDATE");
   if (!file) {
     edm::LogError("BadConfig") << "@SUB=SiPixelLorentzAngleCalibration::writeTree"
-			       << "Could not open file '" << outFileName_ << "'.";
+                               << "Could not open file '" << outFileName_ << "'.";
     return;
   }
 
@@ -454,7 +470,7 @@ void SiPixelLorentzAngleCalibration::writeTree(const SiPixelLorentzAngle *lorent
 }
 
 //======================================================================
-SiPixelLorentzAngle* 
+SiPixelLorentzAngle
 SiPixelLorentzAngleCalibration::createFromTree(const char *fileName, const char *treeName) const
 {
   // Check for file existence on your own to work around
@@ -469,18 +485,17 @@ SiPixelLorentzAngleCalibration::createFromTree(const char *fileName, const char 
   TTree *tree = nullptr;
   if (file) file->GetObject(treeName, tree);
 
-  SiPixelLorentzAngle *result = nullptr;
+  SiPixelLorentzAngle result{};
   if (tree) {
     unsigned int id = 0;
     float value = 0.;
     tree->SetBranchAddress("detId", &id);
     tree->SetBranchAddress("value", &value);
 
-    result = new SiPixelLorentzAngle;
     const Long64_t nEntries = tree->GetEntries();
     for (Long64_t iEntry = 0; iEntry < nEntries; ++iEntry) {
       tree->GetEntry(iEntry);
-      result->putLorentzAngle(id, value);
+      result.putLorentzAngle(id, value);
     }
   } else { // Warning only since could be parallel job on no events.
     edm::LogWarning("Alignment") << "@SUB=SiPixelLorentzAngleCalibration::createFromTree"

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
@@ -127,6 +127,7 @@ private:
   const std::string recordNameDBwrite_;
   const std::string outFileName_;
   const std::vector<std::string> mergeFileNames_;
+  const std::string lorentzAngleLabel_;
 
   edm::ESWatcher<SiPixelLorentzAngleRcd> watchLorentzAngleRcd_;
 
@@ -149,6 +150,7 @@ SiPixelLorentzAngleCalibration::SiPixelLorentzAngleCalibration(const edm::Parame
     recordNameDBwrite_(cfg.getParameter<std::string>("recordNameDBwrite")),
     outFileName_(cfg.getParameter<std::string>("treeFile")),
     mergeFileNames_(cfg.getParameter<std::vector<std::string> >("mergeTreeFiles")),
+    lorentzAngleLabel_(cfg.getParameter<std::string>("lorentzAngleLabel")),
     siPixelLorentzAngleInput_(nullptr),
     moduleGroupSelector_(nullptr),
     moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("LorentzAngleModuleGroups"))
@@ -349,7 +351,7 @@ bool SiPixelLorentzAngleCalibration::checkLorentzAngleInput(const edm::EventSetu
 {
   edm::ESHandle<SiPixelLorentzAngle> lorentzAngleHandle;
   if (!siPixelLorentzAngleInput_) {
-    setup.get<SiPixelLorentzAngleRcd>().get(lorentzAngleHandle);
+    setup.get<SiPixelLorentzAngleRcd>().get(lorentzAngleLabel_, lorentzAngleHandle);
     siPixelLorentzAngleInput_ = new SiPixelLorentzAngle(*lorentzAngleHandle);
   } else {
     if (watchLorentzAngleRcd_.check(setup)) { // new IOV of input

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
@@ -197,11 +197,12 @@ SiPixelLorentzAngleCalibration::derivatives(std::vector<ValuesIndexPair> &outDer
       const LocalVector bFieldLocal(hit.det()->surface().toLocal(bField));
       const double dZ = hit.det()->surface().bounds().thickness(); // it is a float only...
       // shift due to LA: dx = tan(LA) * dz/2 = mobility * B_y * dz/2,
+      // shift due to LA: dy = - mobility * B_x * dz/2,
       // '-' since we have derivative of the residual r = trk -hit
       const double xDerivative = bFieldLocal.y() * dZ * -0.5; // parameter is mobility!
-      // FIXME: Have to treat that for FPIX yDerivative != 0., due to higher order effects! 
-      if (xDerivative) { // If field is zero, this is zero: do not return it
-	const Values derivs(xDerivative, 0.); // yDerivative = 0.
+      const double yDerivative = bFieldLocal.x() * dZ * 0.5; // parameter is mobility!
+      if (xDerivative || yDerivative) { // If field is zero, this is zero: do not return it
+	const Values derivs{xDerivative, yDerivative};
 	outDerivInds.push_back(ValuesIndexPair(derivs, index));
       }
     }

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
@@ -29,6 +29,7 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -42,11 +43,11 @@
 #include "TFile.h"
 #include "TString.h"
 
-// #include <iostream>
 #include <vector>
 #include <map>
 #include <sstream>
 #include <cstdio>
+#include <memory>
 #include <functional>
 
 class SiStripLorentzAngleCalibration : public IntegratedCalibrationBase
@@ -54,28 +55,20 @@ class SiStripLorentzAngleCalibration : public IntegratedCalibrationBase
 public:
   /// Constructor
   explicit SiStripLorentzAngleCalibration(const edm::ParameterSet &cfg);
-  
+
   /// Destructor
-  ~SiStripLorentzAngleCalibration() override;
+  ~SiStripLorentzAngleCalibration() override = default;
 
   /// How many parameters does this calibration define?
   unsigned int numParameters() const override;
 
-  // /// Return all derivatives,
-  // /// default implementation uses other derivatives(..) method,
-  // /// but can be overwritten in derived class for efficiency.
-  // virtual std::vector<double> derivatives(const TransientTrackingRecHit &hit,
-  // 					  const TrajectoryStateOnSurface &tsos,
-  // 					  const edm::EventSetup &setup,
-  // 					  const EventInfo &eventInfo) const;
-
   /// Return non-zero derivatives for x- and y-measurements with their indices by reference.
   /// Return value is their number.
   unsigned int derivatives(std::vector<ValuesIndexPair> &outDerivInds,
-				   const TransientTrackingRecHit &hit,
-				   const TrajectoryStateOnSurface &tsos,
-				   const edm::EventSetup &setup,
-				   const EventInfo &eventInfo) const override;
+                           const TransientTrackingRecHit &hit,
+                           const TrajectoryStateOnSurface &tsos,
+                           const edm::EventSetup &setup,
+                           const EventInfo &eventInfo) const override;
 
   /// Setting the determined parameter identified by index,
   /// returns false if out-of-bounds, true otherwise.
@@ -95,22 +88,21 @@ public:
 
   // /// Call at beginning of job:
   void beginOfJob(AlignableTracker *tracker,
-  			  AlignableMuon *muon,
-  			  AlignableExtras *extras) override;
-  
+                  AlignableMuon *muon,
+                  AlignableExtras *extras) override;
+
+  /// Call at beginning of run:
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
 
   /// Called at end of a the job of the AlignmentProducer.
   /// Write out determined parameters.
   void endOfJob() override;
 
 private:
-  /// If called the first time, fill 'siStripLorentzAngleInput_',
-  /// later check that LorentzAngle has not changed.
-  bool checkLorentzAngleInput(const edm::EventSetup &setup, const EventInfo &eventInfo);
   /// Input LorentzAngle values:
   /// - either from EventSetup of first call to derivatives(..)
   /// - or created from files of passed by configuration (i.e. from parallel processing)
-  const SiStripLorentzAngle* getLorentzAnglesInput();
+  const SiStripLorentzAngle* getLorentzAnglesInput(const align::RunNumber& = 0);
   /// in non-peak mode the effective thickness is reduced...
   double effectiveThickness(const GeomDet *det, int16_t mode, const edm::EventSetup &setup) const;
 
@@ -119,9 +111,9 @@ private:
   double getParameterForDetId(unsigned int detId, edm::RunNumber_t run) const;
 
   void writeTree(const SiStripLorentzAngle *lorentzAngle,
-		 const std::map<unsigned int,TreeStruct> &treeInfo, const char *treeName) const;
-  SiStripLorentzAngle* createFromTree(const char *fileName, const char *treeName) const;
-  
+                 const std::map<unsigned int,TreeStruct> &treeInfo, const char *treeName) const;
+  SiStripLorentzAngle createFromTree(const char *fileName, const char *treeName) const;
+
   const std::string readoutModeName_;
   int16_t readoutMode_;
   const bool saveToDB_;
@@ -131,12 +123,14 @@ private:
 
   edm::ESWatcher<SiStripLorentzAngleRcd> watchLorentzAngleRcd_;
 
-  SiStripLorentzAngle *siStripLorentzAngleInput_;
+  std::map<align::RunNumber, SiStripLorentzAngle> cachedLorentzAngleInputs_;
+  SiStripLorentzAngle* siStripLorentzAngleInput_{nullptr};
+  align::RunNumber currentIOV_{0};
 
   std::vector<double> parameters_;
   std::vector<double> paramUncertainties_;
 
-  TkModuleGroupSelector *moduleGroupSelector_;
+  std::unique_ptr<TkModuleGroupSelector> moduleGroupSelector_;
   const edm::ParameterSet moduleGroupSelCfg_;
 };
 
@@ -151,8 +145,6 @@ SiStripLorentzAngleCalibration::SiStripLorentzAngleCalibration(const edm::Parame
     recordNameDBwrite_(cfg.getParameter<std::string>("recordNameDBwrite")),
     outFileName_(cfg.getParameter<std::string>("treeFile")),
     mergeFileNames_(cfg.getParameter<std::vector<std::string> >("mergeTreeFiles")),
-    siStripLorentzAngleInput_(nullptr),
-    moduleGroupSelector_(nullptr),
     moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("LorentzAngleModuleGroups"))
 {
 
@@ -165,18 +157,10 @@ SiStripLorentzAngleCalibration::SiStripLorentzAngleCalibration(const edm::Parame
     readoutMode_ = kDeconvolutionMode;
   } else {
     throw cms::Exception("BadConfig")
-	  << "SiStripLorentzAngleCalibration:\n" << "Unknown mode '" 
-	  << readoutModeName_ << "', should be 'peak' or 'deconvolution' .\n";
+      << "SiStripLorentzAngleCalibration:\n" << "Unknown mode '"
+      << readoutModeName_ << "', should be 'peak' or 'deconvolution' .\n";
   }
 
-}
-  
-//======================================================================
-SiStripLorentzAngleCalibration::~SiStripLorentzAngleCalibration()
-{
-  delete moduleGroupSelector_;
-  //  std::cout << "Destroy SiStripLorentzAngleCalibration named " << this->name() << std::endl;
-  delete siStripLorentzAngleInput_;
 }
 
 //======================================================================
@@ -186,27 +170,70 @@ unsigned int SiStripLorentzAngleCalibration::numParameters() const
 }
 
 //======================================================================
+void
+SiStripLorentzAngleCalibration::beginRun(const edm::Run& run,
+                                         const edm::EventSetup& setup) {
+
+  // no action needed if the LA record didn't change
+  if (!(watchLorentzAngleRcd_.check(setup))) return;
+
+  const auto runNumber = run.run();
+  auto firstRun = cond::timeTypeSpecs[cond::runnumber].beginValue;
+
+  // avoid infinite loop due to wrap-around of unsigned variable 'i' including
+  // arrow from i to zero and a nice smiley ;)
+  for (unsigned int i = moduleGroupSelector_->numIovs(); i-->0 ;) {
+    const auto firstRunOfIOV = moduleGroupSelector_->firstRunOfIOV(i);
+    if (runNumber >= firstRunOfIOV) {
+      firstRun = firstRunOfIOV;
+      break;
+    }
+  }
+
+  edm::ESHandle<SiStripLorentzAngle> lorentzAngleHandle;
+  const auto& lorentzAngleRcd = setup.get<SiStripLorentzAngleRcd>();
+  lorentzAngleRcd.get(readoutModeName_, lorentzAngleHandle);
+  if (cachedLorentzAngleInputs_.find(firstRun) == cachedLorentzAngleInputs_.end()) {
+    cachedLorentzAngleInputs_.emplace(firstRun, SiStripLorentzAngle(*lorentzAngleHandle));
+  } else {
+    if (lorentzAngleRcd.validityInterval().first().eventID().run() > firstRun &&
+        lorentzAngleHandle->getLorentzAngles()  // only bad if non-identical values
+        != cachedLorentzAngleInputs_[firstRun].getLorentzAngles()) { // (comparing maps)
+      // Maps are containers sorted by key, but comparison problems may arise from
+      // 'floating point comparison' problems (FIXME?)
+      throw cms::Exception("BadInput")
+        << "Trying to cache SiStripLorentzAngle payload for a run (" << runNumber
+        << ") in an IOV (" << firstRun << ") that was already cached.\n"
+        << "The following record in your input database tag has an IOV "
+        << "boundary that does not match your IOV definition:\n"
+        << " - SiStripLorentzAngleRcd '" << lorentzAngleRcd.key().name()
+        << "' (since "
+        << lorentzAngleRcd.validityInterval().first().eventID().run() << ")\n";
+    }
+  }
+
+  siStripLorentzAngleInput_ = &(cachedLorentzAngleInputs_[firstRun]);
+  currentIOV_ = firstRun;
+}
+
+//======================================================================
 unsigned int
 SiStripLorentzAngleCalibration::derivatives(std::vector<ValuesIndexPair> &outDerivInds,
-					    const TransientTrackingRecHit &hit,
-					    const TrajectoryStateOnSurface &tsos,
-					    const edm::EventSetup &setup,
-					    const EventInfo &eventInfo) const
+                                            const TransientTrackingRecHit &hit,
+                                            const TrajectoryStateOnSurface &tsos,
+                                            const edm::EventSetup &setup,
+                                            const EventInfo &eventInfo) const
 {
-  // ugly const-cast:
-  // But it is either only first initialisation or throwing an exception...
-  const_cast<SiStripLorentzAngleCalibration*>(this)->checkLorentzAngleInput(setup, eventInfo);
-
   outDerivInds.clear();
 
-  edm::ESHandle<SiStripLatency> latency;  
+  edm::ESHandle<SiStripLatency> latency;
   setup.get<SiStripLatencyRcd>().get(latency);
   const int16_t mode = latency->singleReadOutMode();
   if (mode == readoutMode_) {
     if (hit.det()) { // otherwise 'constraint hit' or whatever
-      
+
       const int index = moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(),
-									 eventInfo.eventId().run());
+                                                                         eventInfo.eventId().run());
       if (index >= 0) { // otherwise not treated
         edm::ESHandle<MagneticField> magneticField;
         setup.get<IdealMagneticFieldRecord>().get(magneticField);
@@ -216,9 +243,9 @@ SiStripLorentzAngleCalibration::derivatives(std::vector<ValuesIndexPair> &outDer
         const double dZ = this->effectiveThickness(hit.det(), mode, setup);
         // shift due to LA: dx = tan(LA) * dz/2 = mobility * B_y * dz/2,
         // '-' since we have derivative of the residual r = hit - trk and mu is part of trk model
-	//   (see GF's presentation in alignment meeting 25.10.2012,
-	//    https://indico.cern.ch/conferenceDisplay.py?confId=174266#2012-10-25)
-        // Hmm! StripCPE::fillParams() defines, together with 
+        //   (see GF's presentation in alignment meeting 25.10.2012,
+        //    https://indico.cern.ch/conferenceDisplay.py?confId=174266#2012-10-25)
+        // Hmm! StripCPE::fillParams() defines, together with
         //      StripCPE::driftDirection(...):
         //      drift.x = -mobility * by * thickness (full drift from backside)
         //      So '-' already comes from that, not from mobility being part of
@@ -234,12 +261,12 @@ SiStripLorentzAngleCalibration::derivatives(std::vector<ValuesIndexPair> &outDer
                                    << "Hit without GeomDet, skip!";
     }
   } else if (mode != kDeconvolutionMode && mode != kPeakMode) {
-    // warn only if unknown/mixed mode  
+    // warn only if unknown/mixed mode
     edm::LogWarning("Alignment") << "@SUB=SiStripLorentzAngleCalibration::derivatives2"
                                  << "Readout mode is " << mode << ", but looking for "
                                  << readoutMode_ << " (" << readoutModeName_ << ").";
   }
-  
+
   return outDerivInds.size();
 }
 
@@ -284,14 +311,15 @@ void SiStripLorentzAngleCalibration::beginOfJob(AlignableTracker *aliTracker,
 {
   //specify the sub-detectors for which the LA is determined
   const std::vector<int> sdets = {SiStripDetId::TIB, SiStripDetId::TOB}; //no TEC,TID
-  moduleGroupSelector_ = new TkModuleGroupSelector(aliTracker, moduleGroupSelCfg_, sdets);
- 
+  moduleGroupSelector_ =
+    std::make_unique<TkModuleGroupSelector>(aliTracker, moduleGroupSelCfg_, sdets);
+
   parameters_.resize(moduleGroupSelector_->getNumberOfParameters(), 0.);
   paramUncertainties_.resize(moduleGroupSelector_->getNumberOfParameters(), 0.);
 
   edm::LogInfo("Alignment") << "@SUB=SiStripLorentzAngleCalibration" << "Created with name "
                             << this->name() << " for readout mode '" << readoutModeName_
-			    << "',\n" << this->numParameters() << " parameters to be determined."
+                            << "',\n" << this->numParameters() << " parameters to be determined."
                             << "\nsaveToDB = " << saveToDB_
                             << "\n outFileName = " << outFileName_
                             << "\n N(merge files) = " << mergeFileNames_.size()
@@ -318,15 +346,21 @@ void SiStripLorentzAngleCalibration::endOfJob()
   std::map<unsigned int, TreeStruct> treeInfo; // map of TreeStruct for each detId
 
   // now write 'input' tree
-  const SiStripLorentzAngle *input = this->getLorentzAnglesInput(); // never NULL
-  const std::string treeName(this->name() + '_' + readoutModeName_ + '_');
-  this->writeTree(input, treeInfo, (treeName + "input").c_str()); // empty treeInfo for input...
+  const std::string treeName{this->name() + '_' + readoutModeName_ + '_'};
+  std::vector<const SiStripLorentzAngle*> inputs{};
+  inputs.reserve(moduleGroupSelector_->numIovs());
+  for (unsigned int iIOV = 0; iIOV < moduleGroupSelector_->numIovs(); ++iIOV) {
+    const auto firstRunOfIOV = moduleGroupSelector_->firstRunOfIOV(iIOV);
+    inputs.push_back(this->getLorentzAnglesInput(firstRunOfIOV)); // never NULL
+    this->writeTree(inputs.back(), treeInfo,
+                    (treeName + "input_" + std::to_string(firstRunOfIOV)).c_str()); // empty treeInfo for input...
 
-  if (input->getLorentzAngles().empty()) {
-    edm::LogError("Alignment") << "@SUB=SiStripLorentzAngleCalibration::endOfJob"
-			       << "Input Lorentz angle map is empty ('"
-			       << readoutModeName_ << "' mode), skip writing output!";
-    return;
+    if (inputs.back()->getLorentzAngles().empty()) {
+      edm::LogError("Alignment") << "@SUB=SiStripLorentzAngleCalibration::endOfJob"
+                                 << "Input Lorentz angle map is empty ('"
+                                 << readoutModeName_ << "' mode), skip writing output!";
+      return;
+    }
   }
 
   const unsigned int nonZeroParamsOrErrors =   // Any determined value?
@@ -335,13 +369,12 @@ void SiStripLorentzAngleCalibration::endOfJob()
                std::bind2nd(std::not_equal_to<double>(), 0.));
 
   for (unsigned int iIOV = 0; iIOV < moduleGroupSelector_->numIovs(); ++iIOV) {
-    cond::Time_t firstRunOfIOV = moduleGroupSelector_->firstRunOfIOV(iIOV);
-    SiStripLorentzAngle *output = new SiStripLorentzAngle;
+    auto firstRunOfIOV = static_cast<cond::Time_t>(moduleGroupSelector_->firstRunOfIOV(iIOV));
+    SiStripLorentzAngle output{};
     // Loop on map of values from input and add (possible) parameter results
-    for (auto iterIdValue = input->getLorentzAngles().begin();
-	 iterIdValue != input->getLorentzAngles().end(); ++iterIdValue) {
-      // type of (*iterIdValue) is pair<unsigned int, float>
-      const unsigned int detId = iterIdValue->first; // key of map is DetId
+    for (const auto& iterIdValue: inputs[iIOV]->getLorentzAngles()) {
+      // type of 'iterIdValue' is pair<unsigned int, float>
+      const auto detId = iterIdValue.first; // key of map is DetId
       // Some code one could use to miscalibrate wrt input:
       // double param = 0.;
       // const DetId id(detId);
@@ -352,65 +385,32 @@ void SiStripLorentzAngleCalibration::endOfJob()
       // }
       const double param = this->getParameterForDetId(detId, firstRunOfIOV);
       // put result in output, i.e. sum of input and determined parameter:
-      output->putLorentzAngle(detId, iterIdValue->second + param);
+      auto value = iterIdValue.second + static_cast<float>(param);
+      output.putLorentzAngle(detId, value);
       const int paramIndex = moduleGroupSelector_->getParameterIndexFromDetId(detId,firstRunOfIOV);
       treeInfo[detId] = TreeStruct(param, this->getParameterError(paramIndex), paramIndex);
     }
 
     if (saveToDB_ || nonZeroParamsOrErrors != 0) { // Skip writing mille jobs...
-      this->writeTree(output, treeInfo, (treeName + Form("result_%lld", firstRunOfIOV)).c_str());
+      this->writeTree(&output, treeInfo, (treeName + Form("result_%lld", firstRunOfIOV)).c_str());
     }
 
-    if (saveToDB_) { // If requested, write out to DB 
+    if (saveToDB_) { // If requested, write out to DB
       edm::Service<cond::service::PoolDBOutputService> dbService;
       if (dbService.isAvailable()) {
-	dbService->writeOne(output, firstRunOfIOV, recordNameDBwrite_);
-	// no 'delete output;': writeOne(..) took over ownership
+        dbService->writeOne(&output, firstRunOfIOV, recordNameDBwrite_);
       } else {
-	delete output;
-	edm::LogError("BadConfig") << "@SUB=SiStripLorentzAngleCalibration::endOfJob"
-				   << "No PoolDBOutputService available, but saveToDB true!";
+        edm::LogError("BadConfig") << "@SUB=SiStripLorentzAngleCalibration::endOfJob"
+                                   << "No PoolDBOutputService available, but saveToDB true!";
       }
-    } else {
-      delete output;
     }
   } // end loop on IOVs
 }
 
 //======================================================================
-bool SiStripLorentzAngleCalibration::checkLorentzAngleInput(const edm::EventSetup &setup,
-							    const EventInfo &eventInfo)
-{
-  edm::ESHandle<SiStripLorentzAngle> lorentzAngleHandle;
-  if (!siStripLorentzAngleInput_) {
-    setup.get<SiStripLorentzAngleRcd>().get(readoutModeName_, lorentzAngleHandle);
-    siStripLorentzAngleInput_ = new SiStripLorentzAngle(*lorentzAngleHandle);
-    // FIXME: Should we call 'watchLorentzAngleRcd_.check(setup)' as well?
-    //        Otherwise could be that next check has to check via following 'else', though
-    //        no new IOV has started... (to be checked)
-  } else {
-    if (watchLorentzAngleRcd_.check(setup)) { // new IOV of input - but how to check peak vs deco?
-      setup.get<SiStripLorentzAngleRcd>().get(readoutModeName_, lorentzAngleHandle);
-      if (lorentzAngleHandle->getLorentzAngles() // but only bad if non-identical values
-	  != siStripLorentzAngleInput_->getLorentzAngles()) { // (comparing maps)
-	// Maps are containers sorted by key, but comparison problems may arise from
-	// 'floating point comparison' problems (FIXME?)
-	throw cms::Exception("BadInput")
-	  << "SiStripLorentzAngleCalibration::checkLorentzAngleInput:\n"
-	  << "Content of SiStripLorentzAngle changed at run " << eventInfo.eventId().run()
-	  << ", but algorithm expects constant input!\n";
-	return false; // not reached...
-      }
-    }
-  }
-  
-  return true;
-}
-
-//======================================================================
 double SiStripLorentzAngleCalibration::effectiveThickness(const GeomDet *det,
-							  int16_t mode,
-							  const edm::EventSetup &setup) const
+                                                          int16_t mode,
+                                                          const edm::EventSetup &setup) const
 {
   if (!det) return 0.;
   double dZ = det->surface().bounds().thickness(); // it is a float only...
@@ -422,46 +422,51 @@ double SiStripLorentzAngleCalibration::effectiveThickness(const GeomDet *det,
   const double bpCor = backPlaneHandle->getBackPlaneCorrection(id); // it's a float...
   //  std::cout << "bpCor " << bpCor << " in subdet " << id.subdetId() << std::endl;
   dZ *= (1. - bpCor);
- 
+
   return dZ;
-} 
+}
 
 //======================================================================
-const SiStripLorentzAngle* SiStripLorentzAngleCalibration::getLorentzAnglesInput()
+const SiStripLorentzAngle*
+SiStripLorentzAngleCalibration::getLorentzAnglesInput(const align::RunNumber& run)
 {
+  const auto& resolvedRun = run > 0 ? run : currentIOV_;
   // For parallel processing in Millepede II, create SiStripLorentzAngle
   // from info stored in files of parallel jobs and check that they are identical.
   // If this job has run on events, still check that LA is identical to the ones
   // from mergeFileNames_.
-  const std::string treeName(((this->name() + '_') += readoutModeName_) += "_input");
-  for (auto iFile = mergeFileNames_.begin(); iFile != mergeFileNames_.end(); ++iFile) {
-    SiStripLorentzAngle* la = this->createFromTree(iFile->c_str(), treeName.c_str());
+  const std::string treeName{this->name()+"_"+readoutModeName_+"_input_"+
+                             std::to_string(resolvedRun)};
+  for (const auto& iFile: mergeFileNames_) {
+    auto la = this->createFromTree(iFile.c_str(), treeName.c_str());
     // siStripLorentzAngleInput_ could be non-null from previous file of this loop
     // or from checkLorentzAngleInput(..) when running on data in this job as well
     if (!siStripLorentzAngleInput_ || siStripLorentzAngleInput_->getLorentzAngles().empty()) {
-      delete siStripLorentzAngleInput_; // NULL or empty
-      siStripLorentzAngleInput_ = la;
+      cachedLorentzAngleInputs_[resolvedRun] = la;
+      siStripLorentzAngleInput_ = &(cachedLorentzAngleInputs_[resolvedRun]);
+      currentIOV_ = resolvedRun;
     } else {
       // FIXME: about comparison of maps see comments in checkLorentzAngleInput
-      if (la && !la->getLorentzAngles().empty() && // single job might not have got events
-          la->getLorentzAngles() != siStripLorentzAngleInput_->getLorentzAngles()) {
+      if (!la.getLorentzAngles().empty() && // single job might not have got events
+          la.getLorentzAngles() != siStripLorentzAngleInput_->getLorentzAngles()) {
         // Throw exception instead of error?
         edm::LogError("NoInput") << "@SUB=SiStripLorentzAngleCalibration::getLorentzAnglesInput"
                                  << "Different input values from tree " << treeName
-                                 << " in file " << *iFile << ".";
-        
+                                 << " in file " << iFile << ".";
+
       }
-      delete la;
     }
   }
 
   if (!siStripLorentzAngleInput_) { // no files nor ran on events
-    siStripLorentzAngleInput_ = new SiStripLorentzAngle;
+    // [] operator default-constructs an empty SiStripLorentzAngle object in place:
+    siStripLorentzAngleInput_ = &(cachedLorentzAngleInputs_[resolvedRun]);
+    currentIOV_ = resolvedRun;
     edm::LogError("NoInput") << "@SUB=SiStripLorentzAngleCalibration::getLorentzAnglesInput"
-			     << "No input, create an empty one ('" << readoutModeName_ << "' mode)!";
+                             << "No input, create an empty one ('" << readoutModeName_ << "' mode)!";
   } else if (siStripLorentzAngleInput_->getLorentzAngles().empty()) {
     edm::LogError("NoInput") << "@SUB=SiStripLorentzAngleCalibration::getLorentzAnglesInput"
-			     << "Empty result ('" << readoutModeName_ << "' mode)!";
+                             << "Empty result ('" << readoutModeName_ << "' mode)!";
   }
 
   return siStripLorentzAngleInput_;
@@ -469,7 +474,7 @@ const SiStripLorentzAngle* SiStripLorentzAngleCalibration::getLorentzAnglesInput
 
 //======================================================================
 double SiStripLorentzAngleCalibration::getParameterForDetId(unsigned int detId,
-							    edm::RunNumber_t run) const
+                                                            edm::RunNumber_t run) const
 {
   const int index = moduleGroupSelector_->getParameterIndexFromDetId(detId, run);
 
@@ -478,15 +483,15 @@ double SiStripLorentzAngleCalibration::getParameterForDetId(unsigned int detId,
 
 //======================================================================
 void SiStripLorentzAngleCalibration::writeTree(const SiStripLorentzAngle *lorentzAngle,
-					       const std::map<unsigned int, TreeStruct> &treeInfo,
-					       const char *treeName) const
+                                               const std::map<unsigned int, TreeStruct> &treeInfo,
+                                               const char *treeName) const
 {
   if (!lorentzAngle) return;
 
   TFile* file = TFile::Open(outFileName_.c_str(), "UPDATE");
   if (!file) {
     edm::LogError("BadConfig") << "@SUB=SiStripLorentzAngleCalibration::writeTree"
-			       << "Could not open file '" << outFileName_ << "'.";
+                               << "Could not open file '" << outFileName_ << "'.";
     return;
   }
 
@@ -519,7 +524,7 @@ void SiStripLorentzAngleCalibration::writeTree(const SiStripLorentzAngle *lorent
 }
 
 //======================================================================
-SiStripLorentzAngle* 
+SiStripLorentzAngle
 SiStripLorentzAngleCalibration::createFromTree(const char *fileName, const char *treeName) const
 {
   // Check for file existence on your own to work around
@@ -534,18 +539,17 @@ SiStripLorentzAngleCalibration::createFromTree(const char *fileName, const char 
   TTree *tree = nullptr;
   if (file) file->GetObject(treeName, tree);
 
-  SiStripLorentzAngle *result = nullptr;
+  SiStripLorentzAngle result{};
   if (tree) {
     unsigned int id = 0;
     float value = 0.;
     tree->SetBranchAddress("detId", &id);
     tree->SetBranchAddress("value", &value);
 
-    result = new SiStripLorentzAngle;
     const Long64_t nEntries = tree->GetEntries();
     for (Long64_t iEntry = 0; iEntry < nEntries; ++iEntry) {
       tree->GetEntry(iEntry);
-      result->putLorentzAngle(id, value);
+      result.putLorentzAngle(id, value);
     }
   } else { // Warning only since could be parallel job on no events.
     edm::LogWarning("Alignment") << "@SUB=SiStripLorentzAngleCalibration::createFromTree"
@@ -565,4 +569,4 @@ SiStripLorentzAngleCalibration::createFromTree(const char *fileName, const char 
 #include "Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationPluginFactory.h"
 
 DEFINE_EDM_PLUGIN(IntegratedCalibrationPluginFactory,
-		   SiStripLorentzAngleCalibration, "SiStripLorentzAngleCalibration");
+                  SiStripLorentzAngleCalibration, "SiStripLorentzAngleCalibration");

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
@@ -43,7 +43,6 @@
 #include "TString.h"
 
 // #include <iostream>
-#include <boost/assign/list_of.hpp>
 #include <vector>
 #include <map>
 #include <sstream>
@@ -284,7 +283,7 @@ void SiStripLorentzAngleCalibration::beginOfJob(AlignableTracker *aliTracker,
                                                 AlignableExtras * /*aliExtras*/)
 {
   //specify the sub-detectors for which the LA is determined
-  const std::vector<int> sdets = boost::assign::list_of(SiStripDetId::TIB)(SiStripDetId::TOB); //no TEC,TID
+  const std::vector<int> sdets = {SiStripDetId::TIB, SiStripDetId::TOB}; //no TEC,TID
   moduleGroupSelector_ = new TkModuleGroupSelector(aliTracker, moduleGroupSelCfg_, sdets);
  
   parameters_.resize(moduleGroupSelector_->getNumberOfParameters(), 0.);

--- a/Alignment/CommonAlignmentAlgorithm/python/SiPixelLorentzAngleCalibration_cff.py
+++ b/Alignment/CommonAlignmentAlgorithm/python/SiPixelLorentzAngleCalibration_cff.py
@@ -15,4 +15,10 @@ SiPixelLorentzAngleCalibration = cms.PSet(
     
     # Configuration of the granularity for the Lorentz angle calibration
     LorentzAngleModuleGroups = cms.PSet(),
+
+    # depending on the TTRHBuilder one has to use different
+    # 'SiPixelLorentzAngleRcd' flavors, e.g. when using template hit
+    # reconstruction one has to use "fromAlignment" and for the generic version
+    # one directly uses the unlabelled version, i.e. ""
+    lorentzAngleLabel = cms.string("fromAlignment"),
     )

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -925,8 +925,6 @@ AlignmentProducerBase::finish()
     return false;
   }
 
-  for (const auto& iCal:calibrations_) iCal->endOfJob();
-
   if (saveToDB_ || saveApeToDB_ || saveDeformationsToDB_) {
     if (alignmentAlgo_->storeAlignments()) storeAlignmentsToDB();
   } else {
@@ -934,6 +932,10 @@ AlignmentProducerBase::finish()
       << "@SUB=AlignmentProducerBase::finish"
       << "No payload to be stored!";
   }
+
+  // takes care of storing output of calibrations, but needs to be called only
+  // after 'storeAlignmentsToDB()'
+  for (const auto& iCal:calibrations_) iCal->endOfJob();
 
   return true;
 }

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -260,6 +260,8 @@ AlignmentProducerBase::beginRunImpl(const edm::Run& run, const edm::EventSetup& 
   alignmentAlgo_->beginRun(run, setup,
                            changed && (runAtPCL_ || enableAlignableUpdates_));
 
+  for (const auto& iCal:calibrations_) iCal->beginRun(run, setup);
+
   //store the first run analyzed to be used for setting the IOV (for PCL)
   if (firstRun_ > static_cast<cond::Time_t>(run.id().run())) {
     firstRun_ = static_cast<cond::Time_t>(run.id().run());

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -363,20 +363,6 @@ AlignmentProducerBase::createCalibrations()
                             ->create(iCalib.getParameter<std::string>("calibrationName"),
                                      iCalib));
   }
-
-  // Not all algorithms support calibrations - so do not pass empty vector
-  // and throw if non-empty and not supported:
-  if (!calibrations_.empty()) {
-    if (alignmentAlgo_->supportsCalibrations()) {
-      alignmentAlgo_->addCalibrations(calibrations_);
-
-    } else {
-      throw cms::Exception("BadConfig")
-        << "@SUB=AlignmentProducerBase::createCalibrations\n"
-        << "Configured " << calibrations_.size() << " calibration(s) "
-        << "for algorithm not supporting it.";
-    }
-  }
 }
 
 
@@ -442,7 +428,7 @@ AlignmentProducerBase::initAlignmentAlgorithm(const edm::EventSetup& setup,
 {
   edm::LogInfo("Alignment")
     << "@SUB=AlignmentProducerBase::initAlignmentAlgorithm"
-    << "Bwgin";
+    << "Begin";
 
   auto isTrueUpdate = update && isAlgoInitialized_;
 
@@ -469,6 +455,20 @@ AlignmentProducerBase::initAlignmentAlgorithm(const edm::EventSetup& setup,
                              alignableMuon_,
                              alignableExtras_,
                              alignmentParameterStore_);
+
+  // Not all algorithms support calibrations - so do not pass empty vector
+  // and throw if non-empty and not supported:
+  if (!calibrations_.empty()) {
+    if (alignmentAlgo_->supportsCalibrations()) {
+      alignmentAlgo_->addCalibrations(calibrations_);
+    } else {
+      throw cms::Exception("BadConfig")
+        << "@SUB=AlignmentProducerBase::createCalibrations\n"
+        << "Configured " << calibrations_.size() << " calibration(s) "
+        << "for algorithm not supporting it.";
+    }
+  }
+
   isAlgoInitialized_ = true;
 
   applyAlignmentsToGeometry();

--- a/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/MilleSetup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/MilleSetup.py
@@ -26,6 +26,14 @@ def setup(process, input_files, collection,
     process.AlignmentProducer.saveDeformationsToDB = False
 
 
+    # align calibrations to general settings
+    # --------------------------------------------------------------------------
+    for calib in process.AlignmentProducer.calibrations:
+        calib.saveToDB       = process.AlignmentProducer.saveToDB
+        calib.treeFile       = process.AlignmentProducer.algoConfig.treeFile
+        calib.mergeTreeFiles = process.AlignmentProducer.algoConfig.mergeTreeFiles
+
+
     # Track selection and refitting
     # --------------------------------------------------------------------------
     import Alignment.CommonAlignment.tools.trackselectionRefitting as trackRefitter

--- a/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/PedeSetup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/PedeSetup.py
@@ -56,6 +56,14 @@ def setup(process, binary_files, tree_files, run_start_geometry):
     process.AlignmentProducer.algoConfig.mergeTreeFiles   = tree_files
 
 
+    # align calibrations to general settings
+    # --------------------------------------------------------------------------
+    for calib in process.AlignmentProducer.calibrations:
+        calib.saveToDB       = process.AlignmentProducer.saveToDB
+        calib.treeFile       = process.AlignmentProducer.algoConfig.treeFile
+        calib.mergeTreeFiles = process.AlignmentProducer.algoConfig.mergeTreeFiles
+
+
     # Configure the empty source to include all needed runs
     # --------------------------------------------------------------------------
     iovs = mps_tools.make_unique_runranges(process.AlignmentProducer)

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/Mpslibclass.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/Mpslibclass.py
@@ -96,8 +96,9 @@ class jobdatabase:
 
 
         for line in DBFILE:
-            line = line.rstrip('\n')                #removes the pesky \n from line
-            parts = line.split(":")                 #read each line and split into parts list
+            if line.strip() == "": continue # ignore empty lines
+            line = line.rstrip('\n')        # removes the pesky \n from line
+            parts = line.split(":")         # read each line and split into parts list
             self.JOBNUMBER.append(int(parts[0]))
             self.JOBDIR.append(parts[1].strip())
             self.JOBID.append(parts[2])

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/universalConfigTemplate.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/universalConfigTemplate.py
@@ -110,6 +110,11 @@ import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.SetCondition as tagw
 #       connect = "frontier://FrontierProd/CMS_CONDITIONS",
 #       record = "TrackerAlignmentErrorExtendedRcd",
 #       tag = "TrackerAlignmentErrorsExtended_Upgrade2017_design_v0")
+# tagwriter.setCondition(process,
+#       connect = "frontier://FrontierProd/CMS_CONDITIONS",
+#       record = "SiPixelLorentzAngleRcd",
+#       label = "fromAlignment",
+#       tag = "SiPixelLorentzAngle_fromAlignment_phase1_mc_v1")
 
 
 #######################
@@ -200,6 +205,54 @@ import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.SetCondition as tagw
 #     )
 # ] # end of process.AlignmentProducer.RunRangeSelection
 
+# # To run simultaneous calibrations of the pixel Lorentz angle you need to
+# # include the corresponding config fragment and configure the granularity and
+# # IOVs (must be consistent with input LA/template/alignment IOVs) for it.
+# # Note: There are different version of the LA record available in the global
+# #       tag. Depending on the TTRHBuilder, one has to set a label to configure
+# #       which of them is to be used. The default TTRHBuilder uses pixel
+# #       templates which ignores the unlabelled LA record and uses only the one
+# #       labelled "fromAlignment". This is also the default value in the
+# #       integrated LA calibration. If you are using the generic CPE instead of
+# #       the template CPE you have to use the following setting:
+# #
+# #       siPixelLA.lorentzAngleLabel = ""
+#
+# from Alignment.CommonAlignmentAlgorithm.SiPixelLorentzAngleCalibration_cff \
+#     import SiPixelLorentzAngleCalibration as siPixelLA
+# siPixelLA.LorentzAngleModuleGroups.Granularity = cms.VPSet()
+# siPixelLA.LorentzAngleModuleGroups.RunRange = cms.vuint32(290550,
+#                                                           295000,
+#                                                           298100)
+#
+# siPixelLA.LorentzAngleModuleGroups.Granularity.extend([
+#     cms.PSet(
+#         levels = cms.PSet(
+#             alignParams = cms.vstring(
+#                 'TrackerP1PXBModule,,RINGLAYER'
+#             ),
+#             RINGLAYER = cms.PSet(
+#                 pxbDetId  = cms.PSet(
+#                     moduleRanges = cms.vint32(ring, ring),
+#                     layerRanges = cms.vint32(layer, layer)
+#                 )
+#             )
+#         )
+#     )
+#     for ring in xrange(1,9) # [1,8]
+#     for layer in xrange(1,5) # [1,4]
+# ])
+# siPixelLA.LorentzAngleModuleGroups.Granularity.append(
+#     cms.PSet(
+#         levels = cms.PSet(
+#             alignParams = cms.vstring('TrackerP1PXECModule,,posz'),
+#             posz = cms.PSet(zRanges = cms.vdouble(-9999.0, 9999.0))
+#         )
+#     )
+# )
+#
+# process.AlignmentProducer.calibrations.append(siPixelLA)
+
 
 #########################
 ## insert Pedesettings ##
@@ -208,13 +261,13 @@ import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.SetCondition as tagw
 # # reasonable pede settings are already defined in
 # # 'confAliProducer.setConfiguration' above
 # #
-# # if you want obtain alignment errors, use "inversion 3 0.8" as
-# # process.AlignmentProducer.algoConfig.pedeSteerer.method
+# # if you want to obtain alignment errors, use the following setting:
+# # process.AlignmentProducer.algoConfig.pedeSteerer.method = "inversion 3 0.8"
 # #
 # # a list of possible options is documented here:
 # # http://www.desy.de/~kleinwrt/MP2/doc/html/option_page.html#sec-cmd
 # #
-# # you can change or drop pede settings as follows:
+# # you can change or drop pede options as follows:
 #
 # import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.helper as helper
 # helper.set_pede_option(process, "entries 50 10 2")


### PR DESCRIPTION
- integrated Lorentz angle calibration allows to use 0T and 3.8T data simultaneously in an alignment
- fixes code that was broken by alignment framework changes that happened since this became unmaintained
- changes have been validated and presented during the [Tracker DPG meeting on 21-March-2018](https://indico.cern.ch/event/688840/?showDate=all&showSession=all#35-la-calibration-in-alignment)
