### PR TITLE
Removed GBRForestFileName, prepare for new era 2018, 10_1_X

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("BeamMonitor", eras.Run2_2017)
+process = cms.Process("BeamMonitor", eras.Run2_2018)
 
 #----------------------------------------------                                                                                                                                    
 # Switch to change between firstStep and Pixel
@@ -131,7 +131,6 @@ process.pixelTracksCutClassifier = cms.EDProducer( "TrackCutClassifier",
       minLayers = cms.vint32( 0, 2, 3 )
     ),
     ignoreVertices = cms.bool( True ),
-    GBRForestFileName = cms.string( "" )
 )
 process.pixelTracksHP = cms.EDProducer( "TrackCollectionFilterCloner",
     minQuality = cms.string( "highPurity" ),

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("BeamMonitor", eras.Run2_2017)
+process = cms.Process("BeamMonitor", eras.Run2_2018)
 
 # Message logger
 #process.load("FWCore.MessageLogger.MessageLogger_cfi")


### PR DESCRIPTION
There was a crush running on current P5 data, related to GBRForestFileName ￼
seen in CMSSW_10_0_X and 10_1_X
problem seen for beam_dqm_sourceclient-live_cfg.py
reason: GBRForestFileName should have been removed, but did not happen (back in September last year)
thanks to Matti, problem fixed, and in addition era is now properly set to eras.Run2_2018