### PR TITLE
fix segmentation fault in SiStripBadComponentInfo

### DIFF
--- a/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.cc
@@ -34,7 +34,9 @@ SiStripBadComponentInfo::SiStripBadComponentInfo(edm::ParameterSet const& pSet) 
 //
 SiStripBadComponentInfo::~SiStripBadComponentInfo() {
   LogDebug("SiStripBadComponentInfo") << "SiStripBadComponentInfo::Deleting SiStripBadComponentInfo ";
-
+  mapBadAPV.clear();
+  mapBadFiber.clear();
+  mapBadStrip.clear();
 }
 //
 // -- Begin Run
@@ -226,12 +228,15 @@ void SiStripBadComponentInfo::fillBadComponentMaps(int xbin,int component,SiStri
     mapBadStrip[index]=val;
   }   
 }
-void SiStripBadComponentInfo::createSummary(MonitorElement* me,std::map<std::pair<int,int>,float > map) {
+void SiStripBadComponentInfo::createSummary(MonitorElement* me,const std::map<std::pair<int,int>,float >& map) {
   for (int i=1; i<nSubSystem_+1; i++) {
     float sum = 0.0;
     for (int k=1; k<me->getNbinsY(); k++) {
-      me->setBinContent(i,k,map[std::make_pair(i,k)]); // fill the layer/wheel bins
-      if (map[std::make_pair(i,k)]) sum+= map[std::make_pair(i,k)];      
+      auto index = std::make_pair(i,k);
+      if (map.find(index)!=map.end()){
+	me->setBinContent(i,k,map.at(index)); // fill the layer/wheel bins
+	sum += map.at(index);      
+      }
     }
     me->setBinContent(i,me->getNbinsY(), sum); // fill the summary bin (last one)
   }

--- a/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.h
+++ b/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.h
@@ -50,18 +50,22 @@ class SiStripBadComponentInfo: public DQMEDHarvester {
 protected:
 
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
 
 private:
-  void checkBadComponents();
+  void checkBadComponents(edm::EventSetup const& eSetup);
   void bookBadComponentHistos(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter);
-  void fillBadComponentHistos(int xbin, int component,SiStripQuality::BadComponent& BC);
-  void createSummary(MonitorElement* me);
+  void fillBadComponentMaps(int xbin, int component,SiStripQuality::BadComponent& BC);
+  void createSummary(MonitorElement* me,std::map<std::pair<int,int>,float > map);
 
   MonitorElement * badAPVME_;
   MonitorElement * badFiberME_;
   MonitorElement * badStripME_;
 
+  std::map<std::pair<int,int>,float > mapBadAPV;
+  std::map<std::pair<int,int>,float > mapBadFiber;
+  std::map<std::pair<int,int>,float > mapBadStrip;
 
   unsigned long long m_cacheID_;
   bool bookedStatus_;

--- a/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.h
+++ b/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.h
@@ -57,7 +57,7 @@ private:
   void checkBadComponents(edm::EventSetup const& eSetup);
   void bookBadComponentHistos(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter);
   void fillBadComponentMaps(int xbin, int component,SiStripQuality::BadComponent& BC);
-  void createSummary(MonitorElement* me,std::map<std::pair<int,int>,float > map);
+  void createSummary(MonitorElement* me,const std::map<std::pair<int,int>,float >& map);
 
   MonitorElement * badAPVME_;
   MonitorElement * badFiberME_;

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
@@ -21,30 +21,29 @@ siStripQTester = cms.EDAnalyzer("QualityTester",
     getQualityTestsFromFile = cms.untracked.bool(True)
 )
 
-# from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
-# siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
-# siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
+from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
+siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
+siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
 
-# from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
-# siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
-#        cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
-#        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
-#        cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
-#        cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
-#        cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
-#        cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
-#        )
-# siStripQualityESProducer.ReduceGranularity = cms.bool(False)
-# siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
-# siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
+from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
+siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
+       cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
+       cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
+       cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
+       cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
+       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
+       cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
+       )
+siStripQualityESProducer.ReduceGranularity = cms.bool(False)
+siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
+siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
 
-# siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
-#     StripQualityLabel = cms.string('MergedBadComponent')
-# )
+siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
+    StripQualityLabel = cms.string('MergedBadComponent')
+)
 
 # Sequence
-# SiStripCosmicDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser*siStripBadComponentInfo)
-SiStripCosmicDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser)
+SiStripCosmicDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser*siStripBadComponentInfo)
 #removed modules using TkDetMap
 #SiStripCosmicDQMClient = cms.Sequence(siStripQTester)
 

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
@@ -32,32 +32,31 @@ siStripQTesterHI = cms.EDAnalyzer("QualityTester",
     getQualityTestsFromFile = cms.untracked.bool(True)
 )
 
-# from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
-# siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
-# siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
+from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
+siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
+siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
 
-# from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
-# siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
-#        cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
-#        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
-#        cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
-#        cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
-#        cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
-#        cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
-#        )
-# siStripQualityESProducer.ReduceGranularity = cms.bool(False)
-# siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
-# siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
+from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
+siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
+       cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
+       cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
+       cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
+       cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
+       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
+       cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
+       )
+siStripQualityESProducer.ReduceGranularity = cms.bool(False)
+siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
+siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
 
-# siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
-#     StripQualityLabel = cms.string('MergedBadComponent')
-# )
+siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
+    StripQualityLabel = cms.string('MergedBadComponent')
+)
 
 # define new HI sequence
 #removed modules using TkDetMap
 #SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI)
-# SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI*siStripOfflineAnalyser*siStripBadComponentInfo)
-SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI*siStripOfflineAnalyser)
+SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI*siStripOfflineAnalyser*siStripBadComponentInfo)
 
 # Services needed for TkHistoMap
 from CalibTracker.SiStripCommon.TkDetMap_cff import *

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
@@ -37,31 +37,30 @@ siStripQTester = cms.EDAnalyzer("QualityTester",
     getQualityTestsFromFile = cms.untracked.bool(True)
 )
 
-# from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
-# siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
-# siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
+from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
+siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
+siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
 
-# from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
-# siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
-#        cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
-#        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
-#        cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
-#        cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
-#        cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
-#        cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
-#        )
-# siStripQualityESProducer.ReduceGranularity = cms.bool(False)
-# siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
-# siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
+from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
+siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
+       cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
+       cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
+       cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
+       cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
+       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
+       cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
+       )
+siStripQualityESProducer.ReduceGranularity = cms.bool(False)
+siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
+siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
 
-# siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
-#     StripQualityLabel = cms.string('MergedBadComponent')
-# )
+siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
+    StripQualityLabel = cms.string('MergedBadComponent')
+)
 
 
 # Sequence
-# SiStripOfflineDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser*siStripBadComponentInfo)
-SiStripOfflineDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser)
+SiStripOfflineDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser*siStripBadComponentInfo)
 #removed modules using TkDetMap
 #SiStripOfflineDQMClient = cms.Sequence(siStripQTester)
 


### PR DESCRIPTION
Title says is it all: attempt to fix issue #22695.
Access to the `TrackerTopology` from DB is moved from `dqmEndJob` to `endRun` where framework should guarantee `edm::EventSetup` components are still accessible. Bin contents of the output monitor element are cached in a `std::map`.
This reverts also https://github.com/cms-sw/cmssw/pull/22690.
Tested locally with wf. `runTheMatrix.py -l 4.6 -t 4`