### PR TITLE
introduce RunInfo Payload Inspector

### DIFF
--- a/CondCore/RunInfoPlugins/interface/RunInfoPayloadInspectoHelper.h
+++ b/CondCore/RunInfoPlugins/interface/RunInfoPayloadInspectoHelper.h
@@ -1,0 +1,99 @@
+#ifndef CONDCORE_RUNINFOPLUGINS_RUNINFOPAYLOADINSPECTORHELPER_H
+#define CONDCORE_RUNINFOPLUGINS_RUNINFOPAYLOADINSPECTORHELPER_H
+
+#include <vector>
+#include <string>
+#include "TH1.h"
+#include "TH2.h"
+#include "TStyle.h"
+#include "TPaveText.h"
+#include "TStyle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h" 
+
+namespace RunInfoPI {
+  
+  // values are taken from https://github.com/cms-sw/cmssw/blob/master/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducerFromDB.cc#L74-L75
+  constexpr std::array<int,7>   nominalCurrents {{-1  ,0  ,9558,14416,16819,18268,19262}};
+  constexpr std::array<float,7> nominalFields   {{3.8 ,0. ,  2.,    3., 3.5,  3.8,   4.}};
+
+  // all parameter than can be displayed
+  enum parameters {m_run,                               // int      	            
+		   m_start_time_ll,		        // long long;      
+		   m_stop_time_ll,		        // long long       
+		   m_start_current, 		        // float    
+		   m_stop_current,		        // float           
+		   m_avg_current,		        // float   
+		   m_max_current,			// float 
+		   m_min_current,			// float 
+		   m_run_intervall_micros,    		// float 
+		   m_fedIN,                             // unsigned int 
+		   m_BField,                            // float
+		   END_OF_TYPES};
+
+  /************************************************/
+  float theBField (const float current){
+      
+    // logic is taken from https://github.com/cms-sw/cmssw/blob/master/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducerFromDB.cc#L156
+  
+    int i=0;
+    for(;i<(int)nominalFields.size()-1;i++) {
+      if(2*current < nominalCurrents[i]+nominalCurrents[i+1] ){
+	return nominalFields[i];
+      }
+    }
+    return nominalFields[i];
+  }
+  
+  /************************************************/
+  std::string getStringFromTypeEnum (const parameters &parameter){
+    switch(parameter){
+    case m_run		        : return "run number";		  
+    case m_start_time_ll        : return "start time";		
+    case m_stop_time_ll	  	: return "stop time";			
+    case m_start_current  	: return "start current [A]";		
+    case m_stop_current	  	: return "stop current [A]";  	
+    case m_avg_current	  	: return "average current [A]";  	
+    case m_max_current	  	: return "max current [A]";		
+    case m_min_current	       	: return "min current [A]";           
+    case m_run_intervall_micros : return "run duration [#mus]";
+    case m_fedIN                : return "n. FEDs";
+    case m_BField               : return "B-field intensity [T]";
+    default: return "should never be here";
+    }
+  }
+
+  /************************************************/
+  void reportSummaryMapPalette(TH2* obj){
+
+    static int pcol[20];
+
+    float rgb[20][3];
+
+    for( int i=0; i<20; i++ ) {
+      if ( i < 17 ){
+	rgb[i][0] = 0.80+0.01*i;
+	rgb[i][1] = 0.00+0.03*i;
+	rgb[i][2] = 0.00;
+      } else if ( i < 19 ) {
+	rgb[i][0] = 0.80+0.01*i;
+	rgb[i][1] = 0.00+0.03*i+0.15+0.10*(i-17);
+	rgb[i][2] = 0.00;
+      } else if ( i == 19 ){
+	rgb[i][0] = 0.00;
+	rgb[i][1] = 0.80;
+	rgb[i][2] = 0.00;
+      }
+      pcol[i] = TColor::GetColor(rgb[i][0], rgb[i][1], rgb[i][2]);
+    }
+  
+    gStyle->SetPalette(20, pcol);
+  
+    if( obj ){
+      obj->SetMinimum(-1.e-15);
+      obj->SetMaximum(+1.0);
+      obj->SetOption("colz");
+    }
+  }
+
+};
+#endif

--- a/CondCore/RunInfoPlugins/plugins/BuildFile.xml
+++ b/CondCore/RunInfoPlugins/plugins/BuildFile.xml
@@ -1,0 +1,8 @@
+<flags CXX_FLAGS="-Wno-unused-variable"/>
+
+<library   file="RunInfo_PayloadInspector.cc" name="RunInfo_PayloadInspector">
+  <use   name="CondCore/Utilities"/>
+  <use   name="CondCore/CondDB"/>
+  <use   name="CondFormats/Common"/>
+  <use   name="boost_python"/>
+</library>

--- a/CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc
@@ -1,0 +1,233 @@
+/*!
+  \file RunInfo_PayloadInspector
+  \Payload Inspector Plugin for RunInfo
+  \author M. Musich
+  \version $Revision: 1.0 $
+  \date $Date: 2018/03/18 10:01:00 $
+*/
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+
+// the data format of the condition to be inspected
+#include "CondFormats/RunInfo/interface/RunInfo.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h" 
+
+// helper
+#include "CondCore/RunInfoPlugins/interface/RunInfoPayloadInspectoHelper.h"
+
+// system includes
+#include <memory>
+#include <sstream>
+#include <iostream>
+
+// include ROOT 
+#include "TProfile.h"
+#include "TH2F.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+#include "TPaletteAxis.h"
+
+namespace {
+
+  /************************************************
+     RunInfo Payload Inspector of 1 IOV 
+  *************************************************/
+  class RunInfoTest : public cond::payloadInspector::Histogram1D<RunInfo> {
+    
+  public:
+    RunInfoTest() : cond::payloadInspector::Histogram1D<RunInfo>( "Test RunInfo", "Test RunInfo",10,0.0,10.0)
+    {
+      Base::setSingleIov( true );
+    }
+  
+    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+      auto iov = iovs.front();
+      std::shared_ptr<RunInfo> payload = Base::fetchPayload( std::get<1>(iov) );
+      
+      if(payload.get() ) {
+	payload->printAllValues();
+      }
+      return true;
+    }
+  };
+
+  /************************************************
+    Summary of RunInfo of 1 IOV 
+  *************************************************/
+  class RunInfoParameters : public cond::payloadInspector::PlotImage<RunInfo> {
+  public:
+    RunInfoParameters() : cond::payloadInspector::PlotImage<RunInfo>( "Display of RunInfo parameters" ){
+      setSingleIov( true );
+    }
+  
+    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+      auto iov = iovs.front();
+      std::shared_ptr<RunInfo> payload = fetchPayload( std::get<1>(iov) );
+      
+      TCanvas canvas("Beam Spot Parameters Summary","RunInfo Parameters summary",1000,1000); 
+      canvas.cd();
+
+      gStyle->SetHistMinimumZero();
+
+      canvas.SetTopMargin(0.08);
+      canvas.SetBottomMargin(0.06);
+      canvas.SetLeftMargin(0.3);
+      canvas.SetRightMargin(0.02);
+      canvas.Modified();
+      canvas.SetGrid();
+
+      auto h2_RunInfoParameters = std::unique_ptr<TH2F>(new TH2F("Parameters","",1,0.0,1.0,11,0,11.));
+      auto h2_RunInfoState      = std::unique_ptr<TH2F>(new TH2F("State","",1,0.0,1.0,11,0,11.));
+      h2_RunInfoParameters->SetStats(false);
+      h2_RunInfoState->SetStats(false);
+      
+      float fieldIntensity = RunInfoPI::theBField(payload->m_avg_current);
+
+      std::function<float(RunInfoPI::parameters)> cutFunctor = [&payload,fieldIntensity](RunInfoPI::parameters my_param) {
+	float ret(-999.);
+	switch(my_param){
+	case RunInfoPI::m_run		        : return float(payload->m_run);		    
+	case RunInfoPI::m_start_time_ll	        : return float(payload->m_start_time_ll);	     
+	case RunInfoPI::m_stop_time_ll	        : return float(payload->m_stop_time_ll);	    
+	case RunInfoPI::m_start_current         : return payload->m_start_current; 	    
+	case RunInfoPI::m_stop_current	        : return payload->m_stop_current;	    
+	case RunInfoPI::m_avg_current	        : return payload->m_avg_current;	       
+	case RunInfoPI::m_max_current	        : return payload->m_max_current;	     
+	case RunInfoPI::m_min_current	        : return payload->m_min_current;	     
+	case RunInfoPI::m_run_intervall_micros  : return payload->m_run_intervall_micros; 
+	case RunInfoPI::m_BField                : return fieldIntensity;
+	case RunInfoPI::m_fedIN                 : return float((payload->m_fed_in).size());
+	case RunInfoPI::END_OF_TYPES            : return ret;
+	default : return ret;
+	}
+      }; 
+
+      h2_RunInfoParameters->GetXaxis()->SetBinLabel(1,"Value");
+      h2_RunInfoState->GetXaxis()->SetBinLabel(1,"Value");
+
+      unsigned int yBin=11;
+      for(int foo = RunInfoPI::m_run; foo != RunInfoPI::END_OF_TYPES; foo++ ){
+	RunInfoPI::parameters param = static_cast<RunInfoPI::parameters>(foo);
+	std::string theLabel =  RunInfoPI::getStringFromTypeEnum(param);
+	h2_RunInfoState->GetYaxis()->SetBinLabel(yBin,theLabel.c_str());
+	h2_RunInfoParameters->GetYaxis()->SetBinLabel(yBin,theLabel.c_str());
+	h2_RunInfoParameters->SetBinContent(1,yBin,cutFunctor(param)); 
+	// non-fake payload
+	if((payload->m_run)!=-1){
+	  if ((payload->m_avg_current)<=-1){
+	    // go in error state
+	    h2_RunInfoState->SetBinContent(1,yBin,0.);
+	  } else {
+	    // all is OK
+	    h2_RunInfoState->SetBinContent(1,yBin,1.);
+	  }
+	} else {
+	  // this is a fake payload
+	  h2_RunInfoState->SetBinContent(1,yBin,0.9);
+	}
+	yBin--;
+
+      }
+      
+      h2_RunInfoParameters->GetXaxis()->LabelsOption("h");
+      h2_RunInfoParameters->GetYaxis()->SetLabelSize(0.05);
+      h2_RunInfoParameters->GetXaxis()->SetLabelSize(0.05);
+      h2_RunInfoParameters->SetMarkerSize(1.5);
+
+      h2_RunInfoState->GetXaxis()->LabelsOption("h");
+      h2_RunInfoState->GetYaxis()->SetLabelSize(0.05);
+      h2_RunInfoState->GetXaxis()->SetLabelSize(0.05);
+      h2_RunInfoState->SetMarkerSize(1.5);
+
+      RunInfoPI::reportSummaryMapPalette(h2_RunInfoState.get());
+      h2_RunInfoState->Draw("col");
+
+      h2_RunInfoParameters->Draw("TEXTsame");
+      
+      TLatex t1;
+      t1.SetNDC();
+      t1.SetTextAlign(12);
+      t1.SetTextSize(0.03);
+      t1.DrawLatex(0.1,  0.98,"RunInfo parameters:");
+      t1.DrawLatex(0.1,  0.95,"payload:");
+
+      t1.SetTextFont(42);
+      t1.SetTextColor(4);
+      t1.DrawLatex(0.37, 0.982,Form("IOV %s",std::to_string(+std::get<0>(iov)).c_str()));
+      t1.DrawLatex(0.21, 0.952,Form(" %s",(std::get<1>(iov)).c_str()));
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+    
+
+  };
+
+  /************************************************
+    time history of Magnet currents from RunInfo
+  *************************************************/
+
+  template<RunInfoPI::parameters param> class RunInfoCurrentHistory : public cond::payloadInspector::HistoryPlot<RunInfo,float> {
+  public:
+    RunInfoCurrentHistory() : cond::payloadInspector::HistoryPlot<RunInfo,float>(getStringFromTypeEnum(param),getStringFromTypeEnum(param)+" value"){}
+   ~RunInfoCurrentHistory() override = default;
+
+    float getFromPayload( RunInfo& payload ) override{
+
+      float fieldIntensity = RunInfoPI::theBField(payload.m_avg_current);
+
+      switch(param){
+      case RunInfoPI::m_start_current 	     : return payload.m_start_current; 	    
+      case RunInfoPI::m_stop_current	     : return payload.m_stop_current;	    
+      case RunInfoPI::m_avg_current	     : return payload.m_avg_current;	       
+      case RunInfoPI::m_max_current	     : return payload.m_max_current;	     
+      case RunInfoPI::m_min_current	     : return payload.m_min_current;	     
+      case RunInfoPI::m_BField               : return fieldIntensity;
+      default:
+	edm::LogWarning("LogicError") << "Unknown parameter: " <<  param; 
+	break;
+      }
+      
+    } // payload
+
+    /************************************************/
+    std::string getStringFromTypeEnum (const RunInfoPI::parameters &parameter){
+      switch(parameter){
+      case RunInfoPI::m_start_current 	  : return "Magent start current [A]";
+      case RunInfoPI::m_stop_current	  : return "Magnet stop current [A]";  
+      case RunInfoPI::m_avg_current	  : return "Magnet average current [A]";  
+      case RunInfoPI::m_max_current	  : return "Magnet max current [A]";
+      case RunInfoPI::m_min_current	  : return "Magnet min current [A]";
+      case RunInfoPI::m_BField               : return "B-field intensity [T]";
+      default: return "should never be here";
+      }
+    }
+  };
+
+  typedef RunInfoCurrentHistory<RunInfoPI::m_start_current>  RunInfoStartCurrentHistory;
+  typedef RunInfoCurrentHistory<RunInfoPI::m_stop_current>   RunInfoStopCurrentHistory;
+  typedef RunInfoCurrentHistory<RunInfoPI::m_avg_current>    RunInfoAverageCurrentHistory;
+  typedef RunInfoCurrentHistory<RunInfoPI::m_max_current>    RunInfoMaxCurrentHistory;
+  typedef RunInfoCurrentHistory<RunInfoPI::m_min_current>    RunInfoMinCurrentHistory;
+  typedef RunInfoCurrentHistory<RunInfoPI::m_BField>         RunInfoBFieldHistory;               
+
+} // close namespace
+
+PAYLOAD_INSPECTOR_MODULE( RunInfo ){
+  PAYLOAD_INSPECTOR_CLASS( RunInfoTest );
+  PAYLOAD_INSPECTOR_CLASS( RunInfoParameters ) ;
+  PAYLOAD_INSPECTOR_CLASS( RunInfoStopCurrentHistory   ) ;
+  PAYLOAD_INSPECTOR_CLASS( RunInfoAverageCurrentHistory) ;
+  PAYLOAD_INSPECTOR_CLASS( RunInfoMaxCurrentHistory    ) ;
+  PAYLOAD_INSPECTOR_CLASS( RunInfoMinCurrentHistory    ) ;
+  PAYLOAD_INSPECTOR_CLASS( RunInfoBFieldHistory        ) ;
+}

--- a/CondCore/RunInfoPlugins/test/BuildFile.xml
+++ b/CondCore/RunInfoPlugins/test/BuildFile.xml
@@ -1,0 +1,8 @@
+<use   name="CondCore/CondDB"/>
+<use   name="CondCore/Utilities"/>
+<use   name="CondFormats/Common"/>
+<use   name="FWCore/PluginManager"/>
+<use   name="FWCore/Utilities"/>
+<bin   
+   file="testRunInfoPayloadInspector.cpp" name="testRunInfoPayloadInspector">
+</bin>

--- a/CondCore/RunInfoPlugins/test/testRunInfoPayloadInspector.cpp
+++ b/CondCore/RunInfoPlugins/test/testRunInfoPayloadInspector.cpp
@@ -1,0 +1,44 @@
+#include<iostream>
+#include<sstream>
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc"
+
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/PluginManager/interface/SharedLibrary.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+
+int main(int argc, char** argv) {
+  
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::vector<edm::ParameterSet> psets;
+  edm::ParameterSet pSet;
+  pSet.addParameter("@service_type",std::string("SiteLocalConfigService"));
+  psets.push_back(pSet);
+  edm::ServiceToken servToken(edm::ServiceRegistry::createSet(psets));
+  edm::ServiceRegistry::Operate operate(servToken);
+
+  std::string connectionString("frontier://FrontierProd/CMS_CONDITIONS");
+
+  std::string tag = "runinfo_31X_hlt";
+  std::string runTimeType = cond::time::timeTypeName(cond::runnumber);
+  cond::Time_t start = boost::lexical_cast<unsigned long long>(311950);
+  cond::Time_t end   = boost::lexical_cast<unsigned long long>(312237);
+
+  std::cout <<"## RunInfo testing"<<std::endl;
+
+  RunInfoTest histo0;
+  histo0.process( connectionString, tag, runTimeType,end,end);
+  std::cout <<histo0.data()<<std::endl;
+
+  RunInfoParameters histo1;
+  histo1.process( connectionString, tag, runTimeType,end,end);
+  std::cout <<histo1.data()<<std::endl;
+
+  RunInfoBFieldHistory histo2;
+  histo2.process( connectionString, tag, runTimeType, start, end );
+  std::cout <<histo2.data()<<std::endl;
+
+}

--- a/CondCore/RunInfoPlugins/test/testRunInfoPayloadInspector.sh
+++ b/CondCore/RunInfoPlugins/test/testRunInfoPayloadInspector.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc6_amd64_gcc630;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+# Run get payload data script
+
+if [ -d $W_DIR/plots ]; then
+    rm -fr $W_DIR/plots
+fi
+
+mkdir $W_DIR/plots
+
+####################
+# Test RunInfo
+####################
+getPayloadData.py --plugin pluginRunInfo_PayloadInspector --plot plot_RunInfoParameters --tag runinfo_31X_hlt --time_type Run --iovs '{"start_iov": "311957", "end_iov": "311957"}' --db Prod --test ;
+mv *.png $W_DIR/plots/wrong_payload.png
+
+getPayloadData.py --plugin pluginRunInfo_PayloadInspector --plot plot_RunInfoParameters --tag runinfo_31X_hlt --time_type Run --iovs '{"start_iov": "312257", "end_iov": "312257"}' --db Prod --test ;
+mv *.png $W_DIR/plots/fake_payload.png
+
+getPayloadData.py --plugin pluginRunInfo_PayloadInspector --plot plot_RunInfoParameters --tag runinfo_31X_hlt --time_type Run --iovs '{"start_iov": "312259", "end_iov": "312259"}' --db Prod --test ;
+mv *.png $W_DIR/plots/OK_payload.png


### PR DESCRIPTION
In this PR, I've added two basic plots for the `RunInfo` payload inspection, which shall help spotting possible issues without dumping the payload:
   *  `RunInfoParameters` adds a synoptic table of the values of the magnet current stored in the payload and gets a background color according to the content.
      * for "regular" payloads (real run and magnet current is not defaulted to -1) in green:
![ok_payload](https://user-images.githubusercontent.com/5082376/37801667-bbb0f1b2-2e27-11e8-9065-ef6df3901720.png)
      * for "fake" payloads (run number and magnet current to default), in yellow:
![fake_payload](https://user-images.githubusercontent.com/5082376/37801768-1e9432b2-2e28-11e8-96bd-8cfd4afc0ffa.png)
     * for "wrong" payloads (real run number, but magnet current is defaulted) in red:
![wrong_payload](https://user-images.githubusercontent.com/5082376/37801964-da122f62-2e28-11e8-890c-0dd8da204481.png)
   * `RunInfoStopCurrentHistory` , provides the time-series of the magnet currents stored in the payload. 
 