### PR TITLE
Run2-alca124 Change default settings for EE thresholds

### DIFF
--- a/Calibration/HcalIsolatedTrackReco/src/IsolatedEcalPixelTrackCandidateProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/IsolatedEcalPixelTrackCandidateProducer.cc
@@ -61,10 +61,10 @@ void IsolatedEcalPixelTrackCandidateProducer::fillDescriptions(edm::Configuratio
   desc.add<edm::InputTag>("EERecHitSource",edm::InputTag("hltEcalRecHit", "EcalRecHitsEE"));
   desc.add<double>("EBHitEnergyThreshold",0.10);
   desc.add<double>("EBHitCountEnergyThreshold",0.5);
-  desc.add<double>("EEHitEnergyThreshold0",-20.5332);
-  desc.add<double>("EEHitEnergyThreshold1",34.3975);
-  desc.add<double>("EEHitEnergyThreshold2",-19.0741);
-  desc.add<double>("EEHitEnergyThreshold3",3.52151);
+  desc.add<double>("EEHitEnergyThreshold0",-41.0664);
+  desc.add<double>("EEHitEnergyThreshold1",68.7950);
+  desc.add<double>("EEHitEnergyThreshold2",-38.1483);
+  desc.add<double>("EEHitEnergyThreshold3",7.04303);
   desc.add<double>("EEFacHitCountEnergyThreshold",10.0);
   desc.add<double>("EcalConeSizeEta0",0.09);
   desc.add<double>("EcalConeSizeEta1",0.14);

--- a/HLTrigger/special/plugins/HLTEcalPixelIsolTrackFilter.cc
+++ b/HLTrigger/special/plugins/HLTEcalPixelIsolTrackFilter.cc
@@ -25,8 +25,8 @@ void HLTEcalPixelIsolTrackFilter::fillDescriptions(edm::ConfigurationDescription
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
   desc.add<edm::InputTag>("candTag",edm::InputTag("hltIsolEcalPixelTrackProd"));
-  desc.add<double>("MaxEnergyInEB",1.2);
-  desc.add<double>("MaxEnergyInEE",2.0);
+  desc.add<double>("MaxEnergyInEB",2.0);
+  desc.add<double>("MaxEnergyInEE",4.0);
   desc.add<double>("MaxEnergyOutEB",1.2);
   desc.add<double>("MaxEnergyOutEE",2.0);
   desc.add<int>("NMaxTrackCandidates",10);


### PR DESCRIPTION
The changes are made in view of ECAL DPG and EGamma POG's recommendation for the usage of threshold values.