### PR TITLE
Introduce possibility to choose not to use Joseph Form in KU updater

### DIFF
--- a/TrackingTools/KalmanUpdators/src/KFUpdator.cc
+++ b/TrackingTools/KalmanUpdators/src/KFUpdator.cc
@@ -7,10 +7,13 @@
 #include "DataFormats/Math/interface/invertPosDefMatrix.h"
 #include "DataFormats/Math/interface/ProjectMatrix.h"
 
+
+// test of joseph form
+#ifdef KU_JF_TEST
+
 #include<atomic>
 #include<iostream>
 namespace {
-
   struct Stat {
     Stat(): tot(0),
     nopd(0), jnopd(0), fnopd(0),
@@ -48,6 +51,7 @@ namespace {
     return m(0,0)<0 || m(1,1)<0 || m(2,2)<0 || m(3,3)<0 || m(4,4)<0;
   }
 }
+#endif
 
 
 namespace {
@@ -94,6 +98,9 @@ TrajectoryStateOnSurface lupdate(const TrajectoryStateOnSurface& tsos,
   // Compute covariance matrix of local filtered state vector
   AlgebraicSymMatrix55 fse = ROOT::Math::Similarity(M, C) + ROOT::Math::Similarity(K, V);
 
+// test	of joseph form
+#ifdef KU_JF_TEST
+
   AlgebraicSymMatrix55 fse2;  ROOT::Math::AssignSym::Evaluate(fse2, M*C);
 
   // std::cout << "Joseph Form \n" << fse << std::endl;
@@ -131,7 +138,7 @@ TrajectoryStateOnSurface lupdate(const TrajectoryStateOnSurface& tsos,
   if (n1&&n2) stat.inopd++;
   if (n1) stat.ijnopd++;
   if (n2) stat.ifnopd++;
-
+#endif
 
   /*
   // expanded similariy

--- a/TrackingTools/KalmanUpdators/src/KFUpdator.cc
+++ b/TrackingTools/KalmanUpdators/src/KFUpdator.cc
@@ -95,8 +95,14 @@ TrajectoryStateOnSurface lupdate(const TrajectoryStateOnSurface& tsos,
 
   // Compute local filtered state vector
   AlgebraicVector5 fsv = x + K * r;
-  // Compute covariance matrix of local filtered state vector
+
+  // Compute covariance matrix of local filtered state vector 
+#define KU_JosephForm
+#ifdef KU_JosephForm
   AlgebraicSymMatrix55 fse = ROOT::Math::Similarity(M, C) + ROOT::Math::Similarity(K, V);
+#else
+  AlgebraicSymMatrix55 fse;  ROOT::Math::AssignSym::Evaluate(fse, M*C);
+#endif
 
 // test	of joseph form
 #ifdef KU_JF_TEST


### PR DESCRIPTION
This PR introduces the possibility to choose at compile time between the Joseph Form (current default) and the short, faster form in KU updater
(
see for instance https://en.wikipedia.org/wiki/Kalman_filter#Simplification_of_the_a_posteriori_error_covariance_formula
)
A comparison of the two forms is also coded in

I have tested and compared both approaches on ttbar 50PU and data 2017 High luminosity including a test with APE increased by a factor 10.

MVA results for pu50 in http://innocent.home.cern.ch/innocent/RelVal/pu50_noJF
(spot the difference!)

in general the Joseph form is indeed more stable:
for instance on ttbar pu50 
on 230M invocation of the updater
~1000 times the fast version produces a matrix with negative elements on the diagonal while the Joseph form NEVER.
The maximal difference between for instance the sqrt of the diagonal values can be very large,
still their rms are pretty small (0.00147328/0.000522762/0.000464533/0.043233/0.0130172)
similar results on data
(0.00214165/0.00168747/0.00222978/0.0768335/0.0321059 rms on data)
Unexpectedly with 10xAPE the difference between Joseph and fast form is smaller...
(rms of difference of sqrt of diagonal on data 0.00118256/0.00038112/0.000281301/0.0215102/0.0083532)

For what concern timing gain in NOT using the Joseph Form 
the KU itself speeds up of about 40% while the total tracking time reduces of  ~2%.

As the default stays the Joseph Form NO regression is expected.
