### PR TITLE
changes for 10X related to ECALELF

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalCalIsolElectron_Output_cff.py
+++ b/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalCalIsolElectron_Output_cff.py
@@ -24,8 +24,8 @@ OutALCARECOEcalCalElectron_noDrop = cms.PSet(
     ),
     outputCommands = cms.untracked.vstring( 
     'keep *_pfMet_*_*', # met for Wenu selection
-    'keep *_kt6PFJetsForRhoCorrection_rho_*', #rho for effective area subtraction
-    'keep *_kt6PFJets_rho_*', #rho for effective area subtraction
+    #'keep *_kt6PFJetsForRhoCorrection_rho_*', #rho for effective area subtraction
+    #'keep *_kt6PFJets_rho_*', #rho for effective area subtraction
     #'keep recoVertexs_offlinePrimaryVertices*_*_*',
     'keep recoVertexs_offlinePrimaryVertices_*_*',
     'keep recoVertexs_offlinePrimaryVerticesWithBS_*_*',
@@ -34,14 +34,14 @@ OutALCARECOEcalCalElectron_noDrop = cms.PSet(
     'keep *_conversions_*_*',
     #'keep *GsfTrack*_*_*_*',
     'keep *GsfTrack*_electronGsfTracks_*_*',
-    'keep *GsfTrack*_uncleanedOnlyElectronGsfTracks_*_*',
+#    'keep *GsfTrack*_uncleanedOnlyElectronGsfTracks_*_*',
     'keep *_generator_*_*',
     'keep *_addPileupInfo_*_*',
     'keep *_genParticles_*_*',
     'keep recoGsfElectron*_gsfElectron*_*_*',
     #'keep recoGsfElectron*_gedGsfElectron*_*_*',
     'keep recoGsfElectron*_gedGsfElectrons_*_*',
-    'keep recoGsfElectron*_gedGsfElectronsTmp_*_*',
+#    'keep recoGsfElectron*_gedGsfElectronsTmp_*_*',
     'keep recoGsfElectron*_gedGsfElectronCores_*_*',
     'keep recoPhoton*_gedPhoton_*_*',
     #'keep recoCaloClusters_*_*_*',
@@ -94,6 +94,8 @@ OutALCARECOEcalCalElectron_noDrop = cms.PSet(
     # pfisolation CMSSW_5_3_X
     'keep *EcalRecHit*_alCaIsolatedElectrons_*_*',
     'keep *EcalRecHit*_reducedEcalRecHitsES_alCaRecHitsES_*',
+    'keep *_fixedGridRhoFastjetAll_*_*'
+    
     )
 )
 

--- a/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalUncalIsolElectron_Output_cff.py
+++ b/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalUncalIsolElectron_Output_cff.py
@@ -18,7 +18,15 @@ OutALCARECOEcalUncalElectron.outputCommands += cms.untracked.vstring(
     'drop recoSuperClusters_*_*_*',
     'drop recoPreshowerCluster*_*_*_*',
     'drop *EcalRecHit*_reducedEcalRecHitsES*_*_*',
-    'keep reco*Clusters_pfElectronTranslator_*_*'
+    'keep reco*Clusters_pfElectronTranslator_*_*',
+    'drop TrajectorysToOnerecoGsfTracksAssociation_electronGsfTracks_*_*',
+    'drop TrajectorysToOnerecoGsfTracksAssociation_uncleanedOnlyElectronGsfTracks_*_*',
+    'drop recoGsfElectronsrecoGsfElectronrecoGsfElectronsrecoGsfElectronedmrefhelperFindUsingAdvanceedmRefedmValueMap_gedGsfElectronsTmp_*_*',
+    'drop recoConversions_conversions_uncleanedConversions_*',
+    'drop recoGsfElectrons_gedGsfElectronsTmp_*_*',
+    'drop recoGsfTracks_uncleanedOnlyElectronGsfTracks_*_*',
+    'drop recoGsfTrackExtras_uncleanedOnlyElectronGsfTracks_*_*'
+
     )
 
 OutALCARECOEcalUncalElectron.SelectEvents = cms.untracked.PSet(


### PR DESCRIPTION
This is related to the branches we want to keep and discard for ALCA:EcalUncalZElectron stream.
Since EGM uses "fixedGridRhoFastjetAll", we have kept this branch. We have dropped the following [1] as well as these branches were not used further. 

Checked by running over 1000 events. The file size on disk is reduced by ~3.2%  
Original file size:42870459
New file size 41536985

@shervin86 
==================================================================
[1]
 *_kt6PFJetsForRhoCorrection_rho_*', 
 *_kt6PFJets_rho_*', 
edm::AssociationMap<edm::OneToOne<vector<Trajectory>,vector<reco::GsfTrack>,unsigned short> >    "electronGsfTracks"         ""                "RECO"
edm::AssociationMap<edm::OneToOne<vector<Trajectory>,vector<reco::GsfTrack>,unsigned short> >    "uncleanedOnlyElectronGsfTracks"   ""                "RECO"
edm::ValueMap<edm::Ref<vector<reco::GsfElectron>,reco::GsfElectron,edm::refhelper::FindUsingAdvance<vector<reco::GsfElectron>,reco::GsfElectron> > >    "gedGsfElectronsTmp"      ""                "RECO"
vector<reco::Conversion>              "conversions"               "uncleanedConversions"   "RECO"
vector<reco::GsfElectron>             "gedGsfElectronsTmp"        ""                "RECO"
vector<reco::GsfTrackExtra>           "uncleanedOnlyElectronGsfTracks"   ""                "RECO"
vector<reco::GsfTrack>                "uncleanedOnlyElectronGsfTracks"   ""                "RECO"


