### PR TITLE
Temporary fix for wf 1020.0 failing when multithreaded

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1415,6 +1415,7 @@ steps['TIER0EXPLP']={'-s': 'ALCAPRODUCER:AlCaPCCRandom',
                         }
 
 steps['TIER0PROMPTLP']={'-s': 'ALCAPRODUCER:AlCaPCCZeroBias+RawPCCProducer',
+                        '--nThreads':'1',
                         '--conditions': 'auto:run2_data',
                         '--datatier':'ALCARECO',
                         '--eventcontent':'ALCARECO',


### PR DESCRIPTION
The new wf 1020.0 to test the ALCA PCC PCL introduced in #22590 works correctly in 10_1_X but fails in step5 (RawPCCProucer) in 10_0_X (back-port #22617 ) due to the multithreading. This PR applies a trivial protection on the number of threads to let the wf run in 10_0_X .