### PR TITLE
GT Updates : CTPPS Geometry update

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -48,17 +48,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '101X_upgrade2018_design_v6',
+    'phase1_2018_design'       : '101X_upgrade2018_design_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v5',
+    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v6',
+    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '101X_postLS2_design_v3', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '101X_postLS2_design_v4', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'       : '101X_postLS2_realistic_v3', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'       : '101X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '101X_upgrade2023_realistic_v3'
+    'phase2_realistic'         : '101X_upgrade2023_realistic_v4'
 }
 
 aliases = {


### PR DESCRIPTION
GT updates to fix the CTPPS reco geometry.
The request is made here : 
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3533.html

and corresponding PR from CTPPS is here : https://github.com/cms-sw/cmssw/pull/22547

difference of GTs : 

- 2018_MC

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2018_design_v7/101X_upgrade2018_design_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2018_realistic_v6/101X_upgrade2018_realistic_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2018cosmics_realistic_deco_v7/101X_upgrade2018cosmics_realistic_deco_v6

- Upgrade : 

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_postLS2_design_v4/101X_postLS2_design_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_postLS2_realistic_v4/101X_postLS2_realistic_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2023_realistic_v4/101X_upgrade2023_realistic_v3
