### PR TITLE
remove useless triplication of After Abort Gap data in the SiStrip calibTree

### DIFF
--- a/CalibTracker/SiStripChannelGain/python/ntuple_cff.py
+++ b/CalibTracker/SiStripChannelGain/python/ntuple_cff.py
@@ -6,29 +6,23 @@ from CalibTracker.SiStripCommon.ShallowGainCalibration_cfi import *
 from CalibTracker.SiStripCommon.SiStripBFieldFilter_cfi import *
 
 from HLTrigger.HLTfilters.triggerResultsFilter_cfi import *
-AAGFilter = triggerResultsFilter.clone(
-#                       triggerConditions = cms.vstring("HLT_ZeroBias_*"),
-                        triggerConditions = cms.vstring("HLT_ZeroBias_FirstCollisionAfterAbortGap_*"),
-                        hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
-                        l1tResults = cms.InputTag( "" ),
-                        throw = cms.bool(False)
-                   )
+AAGFilter = triggerResultsFilter.clone(triggerConditions = cms.vstring("HLT_ZeroBias_FirstCollisionAfterAbortGap_*"),
+                                       hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
+                                       l1tResults = cms.InputTag( "" ),
+                                       throw = cms.bool(False)
+                                       )
 
-IsolatedMuonFilter = triggerResultsFilter.clone(
-#                       triggerConditions = cms.vstring("HLT_ZeroBias_*"),
-                        triggerConditions = cms.vstring("HLT_IsoMu20_*"),
-                        hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
-                        l1tResults = cms.InputTag( "" ),
-                        throw = cms.bool(False)
-                   )
+IsolatedMuonFilter = triggerResultsFilter.clone(triggerConditions = cms.vstring("HLT_IsoMu20_*"),
+                                                hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
+                                                l1tResults = cms.InputTag( "" ),
+                                                throw = cms.bool(False)
+                                                )
 
-ZeroBiasFilter = triggerResultsFilter.clone(
-#                       triggerConditions = cms.vstring("HLT_ZeroBias_*"),
-                        triggerConditions = cms.vstring("HLT_ZeroBias_*"),
-                        hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
-                        l1tResults = cms.InputTag( "" ),
-                        throw = cms.bool(False)
-                   )
+ZeroBiasFilter = triggerResultsFilter.clone(triggerConditions = cms.vstring("HLT_ZeroBias_*",),
+                                            hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
+                                            l1tResults = cms.InputTag( "" ),
+                                            throw = cms.bool(False)
+                                            )
 
 
 OfflineChannelGainOutputCommands =  [
@@ -65,10 +59,10 @@ gainCalibrationTreeIsoMuon0T.outputCommands += OfflineChannelGainOutputCommands
 
 inputDataSequence = cms.Sequence( shallowEventRun + shallowTracks + shallowGainCalibration )
 
-OfflineGainNtuple_StdBunch = cms.Sequence( ZeroBiasFilter + siStripBFieldOnFilter + 
+OfflineGainNtuple_StdBunch = cms.Sequence( ZeroBiasFilter + ~AAGFilter + siStripBFieldOnFilter + 
                                            inputDataSequence * gainCalibrationTreeStdBunch )
 
-OfflineGainNtuple_StdBunch0T = cms.Sequence( ZeroBiasFilter + siStripBFieldOffFilter + 
+OfflineGainNtuple_StdBunch0T = cms.Sequence( ZeroBiasFilter + ~AAGFilter + siStripBFieldOffFilter + 
                                            inputDataSequence * gainCalibrationTreeStdBunch0T )
 
 OfflineGainNtuple_AagBunch = cms.Sequence( siStripBFieldOnFilter + AAGFilter +
@@ -77,10 +71,10 @@ OfflineGainNtuple_AagBunch = cms.Sequence( siStripBFieldOnFilter + AAGFilter +
 OfflineGainNtuple_AagBunch0T = cms.Sequence( siStripBFieldOffFilter + AAGFilter +
                                              inputDataSequence * gainCalibrationTreeAagBunch0T )
 
-OfflineGainNtuple_IsoMuon = cms.Sequence( siStripBFieldOnFilter + AAGFilter +
+OfflineGainNtuple_IsoMuon = cms.Sequence( siStripBFieldOnFilter + IsolatedMuonFilter +
                                            inputDataSequence * gainCalibrationTreeIsoMuon )
 
-OfflineGainNtuple_IsoMuon0T = cms.Sequence( siStripBFieldOffFilter + AAGFilter +
+OfflineGainNtuple_IsoMuon0T = cms.Sequence( siStripBFieldOffFilter + IsolatedMuonFilter +
                                              inputDataSequence * gainCalibrationTreeIsoMuon0T )
 
 #OfflineGainNtuple = cms.Sequence( (shallowEventRun+


### PR DESCRIPTION
Trivial fix in the SiStrip calibration trees setup to avoid triplication of the AfterAbortGap data branches.
   * _first issue_ is due to the fact that `OfflineGainNtuple_IsoMuon(0T)`  sequences are currently populating the ntuple branches with events passing the `AAGFilter` (while they shall not).
   * _second issue_  is due to the fact that the sequence  `OfflineGainNtuple_StdBunch(0T)`, as it is currently configured, lets pass events triggered also by `HLT_ZeroBias_FirstCollisionAfterAbortGap_*` while those should be filtered out and accepted only by the `OfflineGainNtuple_AagBunch(0T)`  sequences.

The projected space saving on eos storage is of about 270Gb for each (1/fb). 
Issue has been find out by @mdelcourt and is documented [here](https://indico.cern.ch/event/709594/contributions/2927403/attachments/1617150/2570663/180314_CT_Size.pdf).