### PR TITLE
Update the protection to force TIER0PROMPTLP wfs to run in single threaded mode in 100X

### DIFF
--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -153,7 +153,7 @@ class WorkFlowRunner(Thread):
                         cmd+=' --fileout file:step%s.root '%(istep,)
                 if self.jobReport:
                   cmd += ' --suffix "-j JobReport%s.xml " ' % istep
-                if (self.nThreads > 1) and ('HARVESTING' not in cmd) :
+                if (self.nThreads > 1) and ('HARVESTING' not in cmd) and ('TIER0PROMPTLP' not in cmd):
                   cmd += ' --nThreads %s' % self.nThreads
                 cmd+=closeCmd(istep,self.wf.nameId)            
                 retStep = 0

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1415,7 +1415,6 @@ steps['TIER0EXPLP']={'-s': 'ALCAPRODUCER:AlCaPCCRandom',
                         }
 
 steps['TIER0PROMPTLP']={'-s': 'ALCAPRODUCER:AlCaPCCZeroBias+RawPCCProducer',
-                        '--nThreads':'1',
                         '--conditions': 'auto:run2_data',
                         '--datatier':'ALCARECO',
                         '--eventcontent':'ALCARECO',


### PR DESCRIPTION
The protection of #22736 to force the run of wfs with the TIER0PROMPTLP command in single mode works in "please test" but it was too naive, as in IBs the number of threads is overwritten, see

https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc630/CMSSW_10_0_X_2018-03-26-1100/pyRelValMatrixLogs/run/1020.0_AlCaLumiPixels2016H+AlCaLumiPixels2016H+TIER0EXPLP+ALCAEXPLP+ALCAHARVLP+TIER0PROMPTLP/step5_AlCaLumiPixels2016H+AlCaLumiPixels2016H+TIER0EXPLP+ALCAEXPLP+ALCAHARVLP+TIER0PROMPTLP.log

Now the protection uses the same logic as that for HARVESTING and should work correctly (a standalone test confirms that the -t 4 option of runTheMatrix.py is ineffective for this wf, while other test wfs are unaffected).