### PR TITLE
Bring back M0 as default for HCAL AlCa/NSZ/Cosmics

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBiasNoise_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBiasNoise_cff.py
@@ -24,6 +24,7 @@ hbherecoNoise = RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi.hbhep
     tsFromDB = cms.bool(False),
     dropZSmarkedPassed = cms.bool(False),
     algorithm = dict(
+        useMahi = cms.bool(False),
         useM2 = cms.bool(False),
         useM3 = cms.bool(False)
     ),

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBias_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBias_cff.py
@@ -20,6 +20,7 @@ hbherecoMBNZS = RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi.hbhep
     tsFromDB = cms.bool(False),
     dropZSmarkedPassed = cms.bool(False),
     algorithm = dict(
+        useMahi = cms.bool(False),
         useM2 = cms.bool(False),
         useM3 = cms.bool(False)
     ),

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
@@ -38,6 +38,7 @@ hbherecoPedestal = RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi.hb
     tsFromDB = cms.bool(False),
     dropZSmarkedPassed = cms.bool(False),
     algorithm = dict(
+        useMahi = cms.bool(False),
         useM2 = cms.bool(False),
         useM3 = cms.bool(False)
     ),

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -23,6 +23,7 @@ def hbheCosmic(module):
         tsFromDB = cms.bool(False),
         recoParamsFromDB = cms.bool(False),
         algorithm = dict(
+            useMahi = cms.bool(False),
             useM2 = cms.bool(False),
             useM3 = cms.bool(False),
             firstSampleShift = cms.int32(-1000),

--- a/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
@@ -4,6 +4,7 @@ import RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi
 hbherecoMB = RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi.hbheprereco.clone(
     dropZSmarkedPassed = cms.bool(False),
     algorithm = dict(
+        useMahi = cms.bool(False),
         useM2 = cms.bool(False),
         useM3 = cms.bool(False)
     ),


### PR DESCRIPTION
When MAHI was introduced as the default for local HCAL reco, several  HCAL AlCa/NSZ/Cosmics configs didn't get modified appropriately to keep M0 as (their) default. This PR fixes the omission. 