### PR TITLE
Fix L1T muon copy comparison DQM harvesting path

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2uGT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGT_cff.py
@@ -14,6 +14,7 @@ l1tStage2uGMTOutVsuGTIn = DQMEDAnalyzer(
     muonCollection1Title = cms.untracked.string("uGMT output muons"),
     muonCollection2Title = cms.untracked.string("uGT input muons"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT output muons and uGT input muons"),
+    ignoreBin = cms.untracked.vint32([1]), # ignore the BX range bin
     verbose = cms.untracked.bool(False),
 )
 

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -12,9 +12,9 @@ errHistDenStr = 'errorSummaryDen'
 
 # Muons
 l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient = DQMEDHarvester("L1TStage2RatioClient",
-    monitorDir = cms.untracked.string(ugmtDqmDir+'/uGMTMuonCopy1'),
-    inputNum = cms.untracked.string(ugmtDqmDir+'/uGMTMuonCopy1/'+errHistNumStr),
-    inputDen = cms.untracked.string(ugmtDqmDir+'/uGMTMuonCopy1/'+errHistDenStr),
+    monitorDir = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy1'),
+    inputNum = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy1/'+errHistNumStr),
+    inputDen = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy1/'+errHistDenStr),
     ratioName = cms.untracked.string('mismatchRatio'),
     ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 1'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),

--- a/DQM/L1TMonitorClient/python/L1TStage2uGTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGTClient_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQM.L1TMonitor.L1TStage2uGT_cff import l1tStage2uGMTOutVsuGTIn
 
 # directory path shortening
 ugtDqmDir = 'L1T/L1TStage2uGT'
@@ -12,6 +13,7 @@ l1tStage2uGMTOutVsuGTInRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string(ugtDqmDir+'/uGMToutput_vs_uGTinput'),
     inputNum = cms.untracked.string(ugtDqmDir+'/uGMToutput_vs_uGTinput/'+errHistNumStr),
     inputDen = cms.untracked.string(ugtDqmDir+'/uGMToutput_vs_uGTinput/'+errHistDenStr),
+    ignoreBin = cms.untracked.vint32(l1tStage2uGMTOutVsuGTIn.ignoreBin),
     ratioName = cms.untracked.string('mismatchRatio'),
     ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT output muons and uGT input muons'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
@@ -21,7 +23,6 @@ l1tStage2uGMTOutVsuGTInRatioClient = DQMEDHarvester("L1TStage2RatioClient",
 
 dqmRatioTimingPlots = DQMEDHarvester("DQMGenericClient",
     subDirs = cms.untracked.vstring("L1T/L1TStage2uGT/"),
-    monitorDir = cms.untracked.string(ugtDqmDir),
     efficiency = cms.vstring(
        "Ratio_First_Bunch_In_Train 'First Bunch In Train Ratio; Bunch crossing number relative to L1A; Algorithm trigger bit' first_bunch_in_train den_first_bunch_in_train",
        "Ratio_Last_Bunch_In_Train 'Last Bunch In Train Ratio; Bunch crossing number relative to L1A; Algorithm trigger bit' last_bunch_in_train den_last_bunch_in_train",


### PR DESCRIPTION
Set the correct path for the harvesting of the L1T muon copy 1 comparison.
This PR also masks the BX range check bin in the uGMT to uGT comparison in order to not show mismatches if the uGMT is not in the run.