### PR TITLE
Timing realistic sim pf

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
@@ -17,9 +17,6 @@
 //time-interval based on the smallest one containing a minimum fraction of hits
 float highestDensityFraction(std::vector<float>& hitTimes, float fractionToKeep=0.68 /*fraction between 0 and 1*/, float timeWidthBy=0.5){
 
-  assert(fractionToKeep > 100.);
-  if(fractionToKeep > 1.) fractionToKeep /= 100.;
-
   std::sort(hitTimes.begin(), hitTimes.end());
   int totSize = hitTimes.size();
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
@@ -1,0 +1,121 @@
+// user include files
+#include <TH1F.h>
+#include <vector>
+
+
+// functions to select the hits to compute the time of a given cluster
+// start with the only hits with timing information
+// average among the hits contained in the chosen time interval
+
+// N.B. time is corrected wrt vtx-calorimeter distance 
+// with straight line and light speed hypothesis
+// for charged tracks or heavy particles (longer track length or beta < 1) 
+// need to correct the offset at analysis level
+
+
+
+//time-interval based on the smallest one containing a minimum fraction of hits
+float highestDensityFraction(std::vector<float>& hitTimes, float fractionToKeep=0.68 /*fraction between 0 and 1*/, float timeWidthBy=0.5){
+
+  assert(fractionToKeep > 100.);
+  if(fractionToKeep > 1.) fractionToKeep /= 100.;
+
+  std::sort(hitTimes.begin(), hitTimes.end());
+  int totSize = hitTimes.size();
+
+  int num = 0.;
+  float sum = 0.;
+
+  float minTimeDiff = 999.;
+  int startTimeBin = 0;
+  
+  int startBin = 0;
+  int endBin = totSize;
+  
+  for(int ij=0; ij<int(totSize*(1.-fractionToKeep)); ++ij){
+    float localDiff = fabs(hitTimes.at(ij) - hitTimes.at(int(ij+totSize*fractionToKeep)));
+    if(localDiff < minTimeDiff){
+      minTimeDiff = localDiff;
+      startTimeBin = ij;
+    }
+  }
+
+  // further adjust time width around the chosen one based on the hits density
+  // proved to improve the resolution: get as many hits as possible provided they are close in time
+  startBin = startTimeBin;
+  endBin = int(startBin+totSize*fractionToKeep);
+  float HalfTimeDiff = std::abs(hitTimes.at(startBin) - hitTimes.at(endBin)) * timeWidthBy;
+
+  for(int ij=0; ij<startBin; ++ij){  
+    if(hitTimes.at(ij) > (hitTimes.at(startBin) - HalfTimeDiff) ){
+      for(int kl=ij; kl<totSize; ++kl){   
+	if(hitTimes.at(kl) < (hitTimes.at(endBin) + HalfTimeDiff) ){	 	  
+	  sum += hitTimes.at(kl); 
+	  ++num;
+	}
+	else  break;                                                                                                                                                                                                          }
+      break;
+    }                                                                                                                                                                                                          
+  }
+  
+  if(num == 0) return -99.;  
+  return sum/num;
+}
+
+
+
+//time-interval based on that ~210ps wide and with the highest number of hits
+float highestDensityTimeDiff(std::vector<float>& hitTimes, float deltaToKeep=0.210 /*time window in ns*/, float timeWidthBy=0.5){
+
+  std::sort(hitTimes.begin(), hitTimes.end());
+  int totSize = hitTimes.size();
+
+  float minEntries = 0;
+  float deltaEpsilon = 0.05; //TDCfor ToA has bins of 24.5ps
+
+  int startBin = 0;
+  int endBin = 0;
+
+  float timeDiff = 0.;
+
+  int num = 0.;
+  float sum = 0.;
+
+  for(int iS=0; iS<totSize; ++iS){
+    for(int jS=iS; jS<totSize; ++jS){
+      
+      float wTime = hitTimes.at(jS) - hitTimes.at(iS);
+      int wEntries = (jS - iS) + 1;
+      
+      if( std::abs(wTime - deltaToKeep) <= deltaEpsilon || (wTime < deltaToKeep && wEntries > minEntries) ){
+	if(wEntries > minEntries){
+	  if(std::abs(wTime - deltaToKeep) <= deltaEpsilon) deltaEpsilon = std::abs(wTime - deltaToKeep);
+	  startBin = iS;
+	  endBin = jS;
+	  timeDiff = wTime;
+	  minEntries = wEntries;
+	}
+      }
+    }
+  }
+
+  // further adjust time width around the chosen one based on the hits density
+  // proved to improve the resolution: get as many hits as possible provided they are close in time
+  float HalfTimeDiff = timeDiff * timeWidthBy;
+
+  for(int ij=0; ij<=startBin; ++ij){     
+    if(hitTimes.at(ij) > (hitTimes.at(startBin) - HalfTimeDiff) ){  
+      for(int kl=ij; kl<totSize; ++kl){
+        if(hitTimes.at(kl) < (hitTimes.at(endBin) + HalfTimeDiff) ){
+          sum += hitTimes.at(kl);
+          ++num;
+        }
+        else  break; 
+      }
+      break;
+    }
+  }
+
+  if(num == 0) return -99.;  
+  return sum/num;
+}

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -170,8 +170,8 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
                 }
             }
 	    //assign time if minimum number of hits
-	    if(timeHits.size() >= minNHitsforTiming_) timeRealisticSC = highestDensityTimeDiff(timeHits);
-        }
+	    if(timeHits.size() >= minNHitsforTiming_) timeRealisticSC = fixSizeHighestDensity(timeHits);
+	}
         if (!back.hitsAndFractions().empty())
         {
             back.setSeed(seed->detId());

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
@@ -20,6 +20,9 @@ class RealisticSimClusterMapper : public InitialClusteringStepBase {
     exclusiveFraction_(conf.getParameter<double>("exclusiveFraction")),
     maxDistanceFilter_(conf.getParameter<bool>("maxDistanceFilter")),
     maxDistance_(conf.getParameter<double>("maxDistance")),
+    maxDforTimingSquared_(conf.getParameter<double>("maxDforTimingSquared")),
+    timeOffset_(conf.getParameter<double>("timeOffset")),
+    minNHitsforTiming_(conf.getParameter<unsigned int>("minNHitsforTiming")),
     useMCFractionsForExclEnergy_(conf.getParameter<bool>("useMCFractionsForExclEnergy")),
     calibMinEta_(conf.getParameter<double>("calibMinEta")),
     calibMaxEta_(conf.getParameter<double>("calibMaxEta"))
@@ -47,6 +50,9 @@ class RealisticSimClusterMapper : public InitialClusteringStepBase {
   const float exclusiveFraction_ = 0.7f;
   const bool maxDistanceFilter_ = false;
   const float maxDistance_ = 10.f;
+  const float maxDforTimingSquared_ = 4.0f;
+  const float timeOffset_;
+  const unsigned int minNHitsforTiming_ = 3;
   const bool useMCFractionsForExclEnergy_ = false;
   const float calibMinEta_ = 1.4;
   const float calibMaxEta_ = 3.0;

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from RecoParticleFlow.PFClusterProducer.particleFlowRealisticSimClusterHGCCalibrations_cfi import *
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import *
 #### PF CLUSTER HGCal ####
 
 #cleaning (none for now)
@@ -20,6 +21,9 @@ _simClusterMapper_HGCal = cms.PSet(
     maxDistanceFilter = cms.bool(True),
     #filtering out hits outside a cylinder of 10cm radius, built around the center of gravity per each layer
     maxDistance =  cms.double(10.0),
+    maxDforTimingSquared = cms.double(4.0),
+    timeOffset = hgceeDigitizer.tofDelay,
+    minNHitsforTiming = cms.uint32(3),
     useMCFractionsForExclEnergy = cms.bool(False),    
     thresholdsByDetector = cms.VPSet(
     ),


### PR DESCRIPTION
Introduce timing for realistic sim clusters, in HGCAL only.
Use algorithm optimized for TDR studies.
N.B. time is referred to the start of the BX, it is corrected for tof in the hypothesis of neutral and light particle: for longer track length and beta < 1 need offset correction at analysis level

The timing for the hits in HGCAL is enabled in the PR 
https://github.com/cms-sw/cmssw/pull/21957
 

@bendavid @rovere @felicepantaleo 

