### PR TITLE
CommonTools-Statistics: Fix bug found from clang warning -Wunsequenced

### DIFF
--- a/CommonTools/Statistics/interface/SequentialCombinationGenerator.h
+++ b/CommonTools/Statistics/interface/SequentialCombinationGenerator.h
@@ -102,7 +102,7 @@ private:
       Vecint::iterator j1=find_if(ss.begin(),ss.end(),bind2nd(std::greater<int>(),mincnew2));
       if (ss.end()-j1 < p[i]) return empty;
       Vecint sss(j1,ss.end());
-      for (int j=0;j<p[i];cnew[ip+j]=cnew2[j]=sss[j++]);
+      for (int j=0;j<p[i];j++){cnew[ip+j]=cnew2[j]=sss[j];}
       int n2=ss.size()-cnew2.size();
       if (n2==0) return cnew;
       Vecint s(n2);


### PR DESCRIPTION
The value of j is undefined because j might be incremented before access.

In file included from /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/CommonTools/Statistics/src/SequentialCombinationGenerator.cc:1:
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/CommonTools/Statistics/interface/SequentialCombinationGenerator.h:105:52: warning: unsequenced modification and access to 'j' [-Wunsequenced]
       for (int j=0;j<p[i];cnew[ip+j]=cnew2[j]=sss[j++]);
                                  ~                ^