### PR TITLE
RecoMuon/MuonIsolation: Fixes for these clang warnings: -Wlogical-not-parentheses -Woverloaded-virtual

### DIFF
--- a/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc
+++ b/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc
@@ -105,9 +105,9 @@ std::vector<IsoDeposit> CaloExtractorByAssociator::deposits( const Event & event
   if (theDepositInstanceLabels.size() != 3){
     LogError("MuonIsolation")<<"Configuration is inconsistent: Need 3 deposit instance labels";
   }
-  if (! theDepositInstanceLabels[0].compare(0,1, std::string("e")) == 0
-      || ! theDepositInstanceLabels[1].compare(0,1, std::string("h")) == 0
-      || ! theDepositInstanceLabels[2].compare(0,2, std::string("ho")) == 0){
+  if (! (theDepositInstanceLabels[0].compare(0,1, std::string("e")) == 0)
+      || ! (theDepositInstanceLabels[1].compare(0,1, std::string("h")) == 0)
+      || ! (theDepositInstanceLabels[2].compare(0,2, std::string("ho")) == 0)){
     LogWarning("MuonIsolation")<<"Deposit instance labels do not look like  (e*, h*, ho*):"
 			       <<"proceed at your own risk. The extractor interprets lab0=from ecal; lab1=from hcal; lab2=from ho";
   }

--- a/RecoMuon/MuonIsolation/plugins/ExtractorFromDeposits.h
+++ b/RecoMuon/MuonIsolation/plugins/ExtractorFromDeposits.h
@@ -26,6 +26,7 @@ public:
       const reco::TrackCollection & tracks) override;
   reco::IsoDeposit deposit (const edm::Event & ev, const edm::EventSetup & evSetup,
       const reco::Track & track) const override;
+  using reco::isodeposit::IsoDepositExtractor::deposit;
   virtual reco::IsoDeposit deposit (const edm::Event & ev, const edm::EventSetup & evSetup,
       const reco::TrackRef & track) const;
 

--- a/RecoMuon/MuonIsolation/plugins/ExtractorFromDeposits.h
+++ b/RecoMuon/MuonIsolation/plugins/ExtractorFromDeposits.h
@@ -26,7 +26,6 @@ public:
       const reco::TrackCollection & tracks) override;
   reco::IsoDeposit deposit (const edm::Event & ev, const edm::EventSetup & evSetup,
       const reco::Track & track) const override;
-
   virtual reco::IsoDeposit deposit (const edm::Event & ev, const edm::EventSetup & evSetup,
       const reco::TrackRef & track) const;
 

--- a/RecoMuon/MuonIsolation/plugins/ExtractorFromDeposits.h
+++ b/RecoMuon/MuonIsolation/plugins/ExtractorFromDeposits.h
@@ -26,7 +26,7 @@ public:
       const reco::TrackCollection & tracks) override;
   reco::IsoDeposit deposit (const edm::Event & ev, const edm::EventSetup & evSetup,
       const reco::Track & track) const override;
-  using reco::isodeposit::IsoDepositExtractor::deposit;
+
   virtual reco::IsoDeposit deposit (const edm::Event & ev, const edm::EventSetup & evSetup,
       const reco::TrackRef & track) const;
 


### PR DESCRIPTION


/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/llvm/5.0.0-jpkldn/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=60300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DCMSSW_GIT_HASH='CMSSW_10_1_CLANG_X_2018-03-26-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_10_1_CLANG_X_2018-03-26-2300' -I/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/lcg/root/6.10.09-jpkldn/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/boost/1.63.0-jpkldn/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/pcre/8.37-oenich/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/clhep/2.4.0.0-jpkldn/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/gsl/2.2.1/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/hepmc/2.06.07-oenich/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/python/2.7.11-jpkldn/include/python2.7 -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/tbb/2018_U1/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/cms/vdt/0.4.0/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/xz/5.2.2-oenich/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/zlib-x86_64/1.2.11/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/md5/1.0.0/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/tinyxml/2.5.3-jpkldn/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -Wno-unknown-warning-option -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS   -fPIC      -MMD -MF tmp/slc6_amd64_gcc630/src/RecoMuon/MuonIsolation/plugins/RecoMuonMuonIsolationPlugins/CutsIsolatorWithCorrection.d /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoMuon/MuonIsolation/plugins/CutsIsolatorWithCorrection.cc -o tmp/slc6_amd64_gcc630/src/RecoMuon/MuonIsolation/plugins/RecoMuonMuonIsolationPlugins/CutsIsolatorWithCorrection.o
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc:108:7: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
   if (! theDepositInstanceLabels[0].compare(0,1, std::string("e")) == 0
      ^                                                            ~~
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc:108:7: note: add parentheses after the '!' to evaluate the comparison first
  if (! theDepositInstanceLabels[0].compare(0,1, std::string("e")) == 0
      ^
        (                                                              )
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc:108:7: note: add parentheses around left hand side expression to silence this warning
  if (! theDepositInstanceLabels[0].compare(0,1, std::string("e")) == 0
      ^
      (                                                           )
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc:109:10: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
       || ! theDepositInstanceLabels[1].compare(0,1, std::string("h")) == 0
         ^                                                            ~~
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc:109:10: note: add parentheses after the '!' to evaluate the comparison first
      || ! theDepositInstanceLabels[1].compare(0,1, std::string("h")) == 0
         ^
           (                                                              )
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc:109:10: note: add parentheses around left hand side expression to silence this warning
      || ! theDepositInstanceLabels[1].compare(0,1, std::string("h")) == 0
         ^
         (                                                           )
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc:110:10: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
       || ! theDepositInstanceLabels[2].compare(0,2, std::string("ho")) == 0){
         ^                                                             ~~
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc:110:10: note: add parentheses after the '!' to evaluate the comparison first
      || ! theDepositInstanceLabels[2].compare(0,2, std::string("ho")) == 0){
         ^
           (                                                               )
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc:110:10: note: add parentheses around left hand side expression to silence this warning
      || ! theDepositInstanceLabels[2].compare(0,2, std::string("ho")) == 0){
         ^
         (                                                            )
1 warning generated.

In file included from /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoMuon/MuonIsolation/plugins/ExtractorFromDeposits.cc:1:
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoMuon/MuonIsolation/plugins/ExtractorFromDeposits.h:29:28: warning: 'muonisolation::ExtractorFromDeposits::deposit' hides overloaded virtual functions [-Woverloaded-virtual]
   virtual reco::IsoDeposit deposit (const edm::Event & ev, const edm::EventSetup & evSetup,
                           ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/PhysicsTools/IsolationAlgos/interface/IsoDepositExtractor.h:44:32: note: hidden overloaded virtual function 'reco::isodeposit::IsoDepositExtractor::deposit' declared here: type mismatch at 3rd parameter ('const reco::TrackBaseRef &' (aka 'const RefToBase<reco::Track> &') vs 'const reco::TrackRef &' (aka 'const Ref<vector<reco::Track> > &'))
      virtual reco::IsoDeposit deposit(const edm::Event & ev, const edm::EventSetup & evSetup,
                               ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/PhysicsTools/IsolationAlgos/interface/IsoDepositExtractor.h:51:32: note: hidden overloaded virtual function 'reco::isodeposit::IsoDepositExtractor::deposit' declared here: type mismatch at 3rd parameter ('const reco::Candidate &' vs 'const reco::TrackRef &' (aka 'const Ref<vector<reco::Track> > &'))
      virtual reco::IsoDeposit deposit(const edm::Event & ev, const edm::EventSetup & evSetup,
                               ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/PhysicsTools/IsolationAlgos/interface/IsoDepositExtractor.h:60:32: note: hidden overloaded virtual function 'reco::isodeposit::IsoDepositExtractor::deposit' declared here: type mismatch at 3rd parameter ('const reco::CandidateBaseRef &' (aka 'const RefToBase<reco::Candidate> &') vs 'const reco::TrackRef &' (aka 'const Ref<vector<reco::Track> > &'))
      virtual reco::IsoDeposit deposit(const edm::Event & ev, const edm::EventSetup & evSetup,
                               ^
1 warning generated.