### PR TITLE
DataFormats/V0Candidate: fix for clang warning -Woverloaded-virtual

### DIFF
--- a/DataFormats/V0Candidate/interface/V0Candidate.h
+++ b/DataFormats/V0Candidate/interface/V0Candidate.h
@@ -19,7 +19,7 @@ namespace reco{
     const Vertex::CovarianceMatrix vtxCovariance() { 
       return recoVertex.covariance(); 
     }
-
+    using LeafCandidate::setVertex;
     void setVertex( const Vertex & vtxIn );
     //    virtual int pdgId() const { return PDGid; }
     //    void setPdgId( const int & Id ) { PDGid = Id; }

--- a/DataFormats/V0Candidate/interface/V0Candidate.h
+++ b/DataFormats/V0Candidate/interface/V0Candidate.h
@@ -19,8 +19,7 @@ namespace reco{
     const Vertex::CovarianceMatrix vtxCovariance() { 
       return recoVertex.covariance(); 
     }
-    using LeafCandidate::setVertex;
-    void setVertex( const Vertex & vtxIn );
+    void setRecoVertex( const Vertex & vtxIn );
     //    virtual int pdgId() const { return PDGid; }
     //    void setPdgId( const int & Id ) { PDGid = Id; }
   private:

--- a/DataFormats/V0Candidate/src/V0Candidate.cc
+++ b/DataFormats/V0Candidate/src/V0Candidate.cc
@@ -2,7 +2,7 @@
 
 using namespace reco;
 
-void V0Candidate::setVertex( const Vertex & vtxIn ) {
+void V0Candidate::setRecoVertex( const Vertex & vtxIn ) {
   recoVertex = vtxIn;
   LeafCandidate::setVertex( vtxIn.position() );
 }


### PR DESCRIPTION
In file included from /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/DataFormats/V0Candidate/src/V0Candidate.cc:1:
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/DataFormats/V0Candidate/interface/V0Candidate.h:23:10: warning: 'reco::V0Candidate::setVertex' hides overloaded virtual function [-Woverloaded-virtual]
     void setVertex( const Vertex & vtxIn );
         ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/DataFormats/Candidate/interface/LeafCandidate.h:158:10: note: hidden overloaded virtual function 'reco::LeafCandidate::setVertex' declared here: type mismatch at 1st parameter ('const reco::LeafCandidate::Point &' (aka 'const PositionVector3D<ROOT::Math::Cartesian3D<double> > &') vs 'const reco::Vertex &')
    void setVertex( const Point & vertex ) override   { m_state.setVertex(vertex); }
         ^
1 warning generated.