### PR TITLE
RecoTracker/TrackProducer: fix for clang warning -Woverloaded-virtual

### DIFF
--- a/RecoTracker/TrackProducer/plugins/DAFTrackProducer.h
+++ b/RecoTracker/TrackProducer/plugins/DAFTrackProducer.h
@@ -26,6 +26,7 @@ public:
 
 private:
   DAFTrackProducerAlgorithm theAlgo;
+  using TrackProducerBase<reco::Track>::getFromEvt;
   void getFromEvt(edm::Event&, edm::Handle<TrajTrackAssociationCollection>&, reco::BeamSpot&);
   void putInEvtTrajAnn(edm::Event& theEvent, TrajAnnealingCollection & trajannResults,
                 std::unique_ptr<TrajAnnealingCollection>& selTrajAnn);


### PR DESCRIPTION
In file included from /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoTracker/TrackProducer/plugins/SealModules.cc:3:
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoTracker/TrackProducer/plugins/DAFTrackProducer.h:29:8: warning: 'DAFTrackProducer::getFromEvt' hides overloaded virtual functions [-Woverloaded-virtual]
   void getFromEvt(edm::Event&, edm::Handle<TrajTrackAssociationCollection>&, reco::BeamSpot&);
       ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoTracker/TrackProducer/interface/TrackProducerBase.h:66:16: note: hidden overloaded virtual function 'TrackProducerBase<reco::Track>::getFromEvt' declared here: type mismatch at 2nd parameter ('edm::Handle<TrackCandidateCollection> &' (aka 'Handle<vector<TrackCandidate> > &') vs 'edm::Handle<TrajTrackAssociationCollection> &' (aka 'Handle<AssociationMap<OneToOne<vector<Trajectory>, vector<reco::Track>, unsigned short> > > &'))
  virtual void getFromEvt(edm::Event&, edm::Handle<TrackCandidateCollection>&, reco::BeamSpot&);
               ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoTracker/TrackProducer/interface/TrackProducerBase.h:68:16: note: hidden overloaded virtual function 'TrackProducerBase<reco::Track>::getFromEvt' declared here: type mismatch at 2nd parameter ('edm::Handle<TrackView> &' (aka 'Handle<View<reco::Track> > &') vs 'edm::Handle<TrajTrackAssociationCollection> &' (aka 'Handle<AssociationMap<OneToOne<vector<Trajectory>, vector<reco::Track>, unsigned short> > > &'))
  virtual void getFromEvt(edm::Event&, edm::Handle<TrackView>&, reco::BeamSpot&);
               ^