### PR TITLE
RecoParticleFlow/PFClusterTools: fix clang warnings by updating function signatures to match base class.

### DIFF
--- a/RecoParticleFlow/PFClusterTools/interface/PFResolutionMap.h
+++ b/RecoParticleFlow/PFClusterTools/interface/PFResolutionMap.h
@@ -42,7 +42,7 @@ class PFResolutionMap : public TH2D {
   bool WriteMapFile(const char* mapfile);
 
   ///  extrapolation requires overloading of this function
-  int  FindBin(double eta, double e, double z) override;
+  int  FindBin(double eta, double e, double z = 0 ) override;
 
   double getRes(double eta, double phi, double e,int MapEta = -1); 
 

--- a/RecoParticleFlow/PFClusterTools/interface/PFResolutionMap.h
+++ b/RecoParticleFlow/PFClusterTools/interface/PFResolutionMap.h
@@ -42,7 +42,7 @@ class PFResolutionMap : public TH2D {
   bool WriteMapFile(const char* mapfile);
 
   ///  extrapolation requires overloading of this function
-  int  FindBin(double eta, double e);
+  int  FindBin(double eta, double e, double z) override;
 
   double getRes(double eta, double phi, double e,int MapEta = -1); 
 

--- a/RecoParticleFlow/PFClusterTools/src/PFResolutionMap.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFResolutionMap.cc
@@ -240,7 +240,7 @@ double PFResolutionMap::getRes(double eta, double phi, double e, int MapEta){
   if( e<fMinE ) e = fMinE+0.001;
   if( e>fMaxE ) e = fMaxE-0.001;
 
-  unsigned bin = FindBin(TMath::Abs(eta),e);
+  unsigned bin = FindBin(TMath::Abs(eta),e, 0);
 
   double res= GetBinContent(bin);
   if(MapEta>-1){
@@ -254,11 +254,11 @@ double PFResolutionMap::getRes(double eta, double phi, double e, int MapEta){
 
 
 
-int PFResolutionMap::FindBin(double eta, double e) {
+int PFResolutionMap::FindBin(double eta, double e, double z) {
   if(e >= GetYaxis()->GetXmax() )
     e = GetYaxis()->GetXmax() - 0.001;
   
-  return TH2D::FindBin(eta,e);
+  return TH2D::FindBin(eta,e,z);
 }
 
 

--- a/RecoParticleFlow/PFClusterTools/src/PFResolutionMap.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFResolutionMap.cc
@@ -240,7 +240,7 @@ double PFResolutionMap::getRes(double eta, double phi, double e, int MapEta){
   if( e<fMinE ) e = fMinE+0.001;
   if( e>fMaxE ) e = fMaxE-0.001;
 
-  unsigned bin = FindBin(TMath::Abs(eta),e, 0);
+  unsigned bin = FindBin(TMath::Abs(eta),e);
 
   double res= GetBinContent(bin);
   if(MapEta>-1){
@@ -258,7 +258,7 @@ int PFResolutionMap::FindBin(double eta, double e, double z) {
   if(e >= GetYaxis()->GetXmax() )
     e = GetYaxis()->GetXmax() - 0.001;
   
-  return TH2D::FindBin(eta,e,z);
+  return TH2D::FindBin(eta,e);
 }
 
 


### PR DESCRIPTION


In file included from /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoParticleFlow/PFClusterTools/src/PFResolutionMap.cc:1:
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c6796210c53b02f1870cdf07f5d562c4/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-26-2300/src/RecoParticleFlow/PFClusterTools/interface/PFResolutionMap.h:45:8: warning: 'PFResolutionMap::FindBin' hides overloaded virtual function [-Woverloaded-virtual]
   int  FindBin(double eta, double e);
       ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/lcg/root/6.10.09-jpkldn/include/TH1.h:216:21: note: hidden overloaded virtual function 'TH1::FindBin' declared here: different number of parameters (3 vs 2)
   virtual Int_t    FindBin(Double_t x, Double_t y=0, Double_t z=0);
                    ^