### PR TITLE
NoProcessProductResolver needs to reset at end Run and Lumi

### DIFF
--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -757,6 +757,10 @@ namespace edm {
     }
   }
 
+  void NoProcessProductResolver::resetFailedFromThisProcess() {
+    resetProductData_(false);
+  }
+
   namespace {
     class TryNextResolverWaitingTask : public edm::WaitingTask {
     public:

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -329,6 +329,9 @@ namespace edm {
                         Principal const& principal,
                         bool iSkipCurrentProcess,
                         std::exception_ptr iExceptPtr) const;
+
+    void resetFailedFromThisProcess() override;
+
     private:
       unsigned int unsetIndexValue() const;
       Resolution resolveProduct_(Principal const& principal,


### PR DESCRIPTION
NoProcessProductResolver needs to reset its WaitingTaskLists at the
end LuminosityBlock and Run boundaries in order to properly handle
the case where the data product is made at the end transition instead
of at the begin transition.