### PR TITLE
Updated cfg file for beampixel application for 2018 run

### DIFF
--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("BeamPixel", eras.Run2_2017)
+process = cms.Process("BeamPixel", eras.Run2_2018)
 
 
 #----------------------------
@@ -127,7 +127,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
     process.siPixelClusterShapeCachePreSplitting = siPixelClusterShapeCache.clone(src = 'siPixelClustersPreSplitting')
     process.load("RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi")
-    process.load("RecoPixelVertexing.PixelTrackFitting.PixelTracks_2017_cff")
+    process.load("RecoPixelVertexing.PixelTrackFitting.PixelTracks_cff")
     process.load("RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi")
     process.recopixelvertexing = cms.Sequence(process.pixelTracksSequence + process.pixelVertices)
     process.pixelVertices.TkFilterParameters.minPt = process.pixelTracksTrackingRegions.RegionPSet.ptMin


### PR DESCRIPTION
I changed from eras.Run2_2017 to eras.Run2_2018
and from PixelTracks_2017_cff to PixelTracks_cff
- Mauro.