### PR TITLE
RecoEgamma/PhotonIdentification: fix clang warnings: -Wpessimizing-move, -Winconsistent-missing-override

### DIFF
--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
@@ -52,7 +52,7 @@ float PhotonMVAEstimatorRun2Phys14NonTrig::
 mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event& iEvent) const {
   
   const int iCategory = findCategory( particle );
-  const std::vector<float> vars = std::move( fillMVAVariables( particle, iEvent ) );  
+  const std::vector<float> vars =  fillMVAVariables( particle, iEvent ) ;  
   const float result = _gbrForests.at(iCategory)->GetClassifier(vars.data());
 
   // DEBUG
@@ -306,7 +306,7 @@ std::vector<float> PhotonMVAEstimatorRun2Phys14NonTrig::fillMVAVariables(const e
 
   std::vector<float> vars;
   if( isEndcapCategory( findCategory( particle ) ) ) {
-    vars = std::move( packMVAVariables(allMVAVars.varPhi,
+    vars =  packMVAVariables(allMVAVars.varPhi,
                                        allMVAVars.varR9,
                                        allMVAVars.varSieie,
                                        allMVAVars.varSieip,
@@ -326,9 +326,9 @@ std::vector<float> PhotonMVAEstimatorRun2Phys14NonTrig::fillMVAVariables(const e
                                        // Declare spectator vars
                                        allMVAVars.varPt,
                                        allMVAVars.varEta) 
-                      ); 
+                      ; 
   } else {
-    vars = std::move( packMVAVariables(allMVAVars.varPhi,
+    vars =  packMVAVariables(allMVAVars.varPhi,
                                        allMVAVars.varR9,
                                        allMVAVars.varSieie,
                                        allMVAVars.varSieip,
@@ -346,7 +346,7 @@ std::vector<float> PhotonMVAEstimatorRun2Phys14NonTrig::fillMVAVariables(const e
                                        // Declare spectator vars
                                        allMVAVars.varPt,
                                        allMVAVars.varEta) 
-                      );
+                      ;
   }
 
   return vars;

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
@@ -59,7 +59,7 @@ float PhotonMVAEstimatorRun2Spring15NonTrig::
 mvaValue(const edm::Ptr<reco::Candidate>& particle, const edm::Event& iEvent) const {  
 
   const int iCategory = findCategory( particle );
-  const std::vector<float> vars = std::move( fillMVAVariables( particle, iEvent ) );  
+  const std::vector<float> vars =  fillMVAVariables( particle, iEvent ) ;  
   
   const float result = _gbrForests.at(iCategory)->GetClassifier(vars.data());
 
@@ -318,7 +318,7 @@ std::vector<float> PhotonMVAEstimatorRun2Spring15NonTrig::fillMVAVariables(const
 
   std::vector<float> vars;
   if( isEndcapCategory( findCategory( particle ) ) ) {
-    vars = std::move( packMVAVariables(allMVAVars.varPhi,
+    vars =  packMVAVariables(allMVAVars.varPhi,
                                        allMVAVars.varR9,
                                        allMVAVars.varSieie,
                                        allMVAVars.varSieip,
@@ -338,9 +338,9 @@ std::vector<float> PhotonMVAEstimatorRun2Spring15NonTrig::fillMVAVariables(const
                                        // Declare spectator vars
                                        allMVAVars.varPt,
                                        allMVAVars.varEta) 
-                      ); 
+                      ; 
   } else {
-    vars = std::move( packMVAVariables(allMVAVars.varPhi,
+    vars =  packMVAVariables(allMVAVars.varPhi,
                                        allMVAVars.varR9,
                                        allMVAVars.varSieie,
                                        allMVAVars.varSieip,
@@ -358,7 +358,7 @@ std::vector<float> PhotonMVAEstimatorRun2Spring15NonTrig::fillMVAVariables(const
                                        // Declare spectator vars
                                        allMVAVars.varPt,
                                        allMVAVars.varEta) 
-                      );
+                      ;
   }
   return vars;
 }

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring16NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring16NonTrig.cc
@@ -53,7 +53,7 @@ float PhotonMVAEstimatorRun2Spring16NonTrig::
 mvaValue(const edm::Ptr<reco::Candidate>& particle, const edm::Event& iEvent) const {  
 
   const int iCategory = findCategory( particle );
-  const std::vector<float> vars = std::move( fillMVAVariables( particle, iEvent ) );  
+  const std::vector<float> vars =  fillMVAVariables( particle, iEvent ) ;  
   
   const float result = gbrForests_.at(iCategory)->GetClassifier(vars.data());
 
@@ -279,7 +279,7 @@ std::vector<float> PhotonMVAEstimatorRun2Spring16NonTrig::fillMVAVariables(const
   //
   std::vector<float> vars;
   if( isEndcapCategory( findCategory( particle ) ) ) {
-    vars = std::move( packMVAVariables(
+    vars =  packMVAVariables(
 				       allMVAVars.scPhi,
                                        allMVAVars.varR9,
                                        allMVAVars.varSieie,
@@ -296,9 +296,9 @@ std::vector<float> PhotonMVAEstimatorRun2Spring16NonTrig::fillMVAVariables(const
 				       allMVAVars.varESEffSigmaRR,
 				       allMVAVars.varESEnOverRawE
 				       ) 
-                      ); 
+                      ; 
   } else {
-    vars = std::move( packMVAVariables(
+    vars =  packMVAVariables(
 				       allMVAVars.scPhi,
                                        allMVAVars.varR9,
                                        allMVAVars.varSieie,
@@ -313,7 +313,7 @@ std::vector<float> PhotonMVAEstimatorRun2Spring16NonTrig::fillMVAVariables(const
                                        allMVAVars.varChIsoRaw,
                                        allMVAVars.varWorstChRaw
 				       ) 
-                      );
+                      ;
   }
   return vars;
 }

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRunIIFall17.h
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRunIIFall17.h
@@ -61,12 +61,12 @@ class PhotonMVAEstimatorRunIIFall17 : public AnyMVAEstimatorRun2Base{
   ~PhotonMVAEstimatorRunIIFall17();
 
   // Calculation of the MVA value
-  float mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const;
+  float mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const override;
  
   // Utility functions
   std::unique_ptr<const GBRForest> createSingleReader(const int iCategory, const edm::FileInPath &weightFile);
   
-  virtual int getNCategories() const { return nCategories; }
+  virtual int getNCategories() const override { return nCategories; }
   bool isEndcapCategory( int category ) const;
   virtual const std::string& getName() const override final { return name_; }
   virtual const std::string& getTag() const override final { return tag_; }


### PR DESCRIPTION


std::vector<>&&  is implied in return values of the functions used for assignment.

/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/llvm/5.0.0-jpkldn/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=60300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DCMSSW_GIT_HASH='CMSSW_10_1_CLANG_X_2018-03-27-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_10_1_CLANG_X_2018-03-27-2300' -I/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/cms/coral/CORAL_2_3_21-jpkldn/include/LCG -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/lcg/root/6.10.09-jpkldn/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/boost/1.63.0-jpkldn/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/pcre/8.37-oenich/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/clhep/2.4.0.0-jpkldn/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/gsl/2.2.1/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/hepmc/2.06.07-oenich/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/openssl/1.0.2d/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/python/2.7.11-jpkldn/include/python2.7 -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/sigcpp/2.6.2-oenich/include/sigc++-2.0 -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/tbb/2018_U1/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/cms/vdt/0.4.0/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/xz/5.2.2-oenich/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/zlib-x86_64/1.2.11/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/eigen/1ae2849542a7892089f81f2ee460b510cdb0a16d/include/eigen3 -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/md5/1.0.0/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/tinyxml/2.5.3-jpkldn/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -Wno-unknown-warning-option -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS   -fPIC      -MMD -MF tmp/slc6_amd64_gcc630/src/RecoEgamma/PhotonIdentification/plugins/RecoEgammaPhotonIdentificationPlugins/PhotonMVAValueMapProducer.d /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAValueMapProducer.cc -o tmp/slc6_amd64_gcc630/src/RecoEgamma/PhotonIdentification/plugins/RecoEgammaPhotonIdentificationPlugins/PhotonMVAValueMapProducer.o
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc:55:35: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
   const std::vector<float> vars = std::move( fillMVAVariables( particle, iEvent ) );
                                  ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc:55:35: note: remove std::move call here
  const std::vector<float> vars = std::move( fillMVAVariables( particle, iEvent ) );
                                  ^~~~~~~~~~~                                     ~
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc:309:12: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
     vars = std::move( packMVAVariables(allMVAVars.varPhi,
           ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc:309:12: note: remove std::move call here
    vars = std::move( packMVAVariables(allMVAVars.varPhi,
           ^~~~~~~~~~~
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc:331:12: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
     vars = std::move( packMVAVariables(allMVAVars.varPhi,
           ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc:331:12: note: remove std::move call here
    vars = std::move( packMVAVariables(allMVAVars.varPhi,
           ^~~~~~~~~~~
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc:62:35: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
   const std::vector<float> vars = std::move( fillMVAVariables( particle, iEvent ) );
                                  ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc:62:35: note: remove std::move call here
  const std::vector<float> vars = std::move( fillMVAVariables( particle, iEvent ) );
                                  ^~~~~~~~~~~                                     ~
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc:321:12: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
     vars = std::move( packMVAVariables(allMVAVars.varPhi,
           ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc:321:12: note: remove std::move call here
    vars = std::move( packMVAVariables(allMVAVars.varPhi,
           ^~~~~~~~~~~
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc:343:12: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
     vars = std::move( packMVAVariables(allMVAVars.varPhi,
           ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc:343:12: note: remove std::move call here
    vars = std::move( packMVAVariables(allMVAVars.varPhi,
           ^~~~~~~~~~~
In file included from /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRunIIFall17.cc:1:
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRunIIFall17.h:64:9: warning: 'mvaValue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   float mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const;
        ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/EgammaTools/interface/AnyMVAEstimatorRun2Base.h:22:17: note: overridden virtual function is here
  virtual float mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const = 0;
                ^
In file included from /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRunIIFall17.cc:1:
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRunIIFall17.h:69:15: warning: 'getNCategories' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   virtual int getNCategories() const { return nCategories; }
              ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoEgamma/EgammaTools/interface/AnyMVAEstimatorRun2Base.h:32:15: note: overridden virtual function is here
  virtual int getNCategories() const = 0;
              ^