### PR TITLE
RecoLocalFastTime/FTLRecProducers: fix clang warning: -Wpessimizing-move

### DIFF
--- a/RecoLocalFastTime/FTLRecProducers/plugins/FTLRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/FTLRecHitProducer.cc
@@ -72,7 +72,7 @@ FTLRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   barrelRechits->reserve(hBarrel->size()/2);
   for(const auto& uhit : *hBarrel) {
     uint32_t flags = FTLRecHit::kGood;
-    auto rechit = std::move(barrel_->makeRecHit(uhit, flags));
+    auto rechit = barrel_->makeRecHit(uhit, flags);
     if( flags == FTLRecHit::kGood ) barrelRechits->push_back( std::move(rechit) );
   }
 
@@ -81,7 +81,7 @@ FTLRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   endcapRechits->reserve(hEndcap->size()/2);
   for(const auto& uhit : *hEndcap) {
     uint32_t flags = FTLRecHit::kGood;
-    auto rechit = std::move(endcap_->makeRecHit(uhit, flags));
+    auto rechit = endcap_->makeRecHit(uhit, flags);
     if( flags == FTLRecHit::kGood ) endcapRechits->push_back( std::move(rechit) );
   }
       

--- a/RecoLocalFastTime/FTLRecProducers/plugins/FTLUncalibratedRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/FTLUncalibratedRecHitProducer.cc
@@ -71,14 +71,14 @@ FTLUncalibratedRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& e
   evt.getByToken( ftlbDigis_, hBarrel );  
   barrelRechits->reserve(hBarrel->size()/2);
   for(const auto& digi : *hBarrel) {
-    barrelRechits->push_back( std::move(barrel_->makeRecHit(digi)) );
+    barrelRechits->push_back( barrel_->makeRecHit(digi) );
   }
 
   edm::Handle< FTLDigiCollection > hEndcap;
   evt.getByToken( ftleDigis_, hEndcap );  
   endcapRechits->reserve(hEndcap->size()/2);
   for(const auto& digi : *hEndcap) {
-    endcapRechits->push_back( std::move(endcap_->makeRecHit(digi)) );
+    endcapRechits->push_back( endcap_->makeRecHit(digi) );
   }
       
   // put the collection of recunstructed hits in the event

--- a/RecoLocalFastTime/FTLRecProducers/plugins/FTLUncalibratedRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/FTLUncalibratedRecHitProducer.cc
@@ -71,14 +71,14 @@ FTLUncalibratedRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& e
   evt.getByToken( ftlbDigis_, hBarrel );  
   barrelRechits->reserve(hBarrel->size()/2);
   for(const auto& digi : *hBarrel) {
-    barrelRechits->push_back( barrel_->makeRecHit(digi) );
+    barrelRechits->emplace_back( barrel_->makeRecHit(digi) );
   }
 
   edm::Handle< FTLDigiCollection > hEndcap;
   evt.getByToken( ftleDigis_, hEndcap );  
   endcapRechits->reserve(hEndcap->size()/2);
   for(const auto& digi : *hEndcap) {
-    endcapRechits->push_back( endcap_->makeRecHit(digi) );
+    endcapRechits->emplace_back( endcap_->makeRecHit(digi) );
   }
       
   // put the collection of recunstructed hits in the event


### PR DESCRIPTION
&& return value is implied in assignment operator.

/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/llvm/5.0.0-jpkldn/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=60300 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DCMSSW_GIT_HASH='CMSSW_10_1_CLANG_X_2018-03-27-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_10_1_CLANG_X_2018-03-27-2300' -I/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/lcg/root/6.10.09-jpkldn/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/boost/1.63.0-jpkldn/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/pcre/8.37-oenich/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/bz2lib/1.0.6/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/clhep/2.4.0.0-jpkldn/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/gsl/2.2.1/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/libuuid/2.22.2/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/python/2.7.11-jpkldn/include/python2.7 -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/tbb/2018_U1/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/xerces-c/3.1.3/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/xz/5.2.2-oenich/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/zlib-x86_64/1.2.11/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/md5/1.0.0/include -I/build/cmsbld/jenkins/workspace/build-any-ib/w/slc6_amd64_gcc630/external/tinyxml/2.5.3-jpkldn/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=uninitialized -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -Wno-unknown-warning-option -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -Wno-error=unused-variable -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS   -fPIC      -MMD -MF tmp/slc6_amd64_gcc630/src/RecoLocalFastTime/FTLRecProducers/plugins/RecoLocalFastTimeFTLRecProducersPlugins/FTLUncalibratedRecHitProducer.d /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoLocalFastTime/FTLRecProducers/plugins/FTLUncalibratedRecHitProducer.cc -o tmp/slc6_amd64_gcc630/src/RecoLocalFastTime/FTLRecProducers/plugins/RecoLocalFastTimeFTLRecProducersPlugins/FTLUncalibratedRecHitProducer.o
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoLocalFastTime/FTLRecProducers/plugins/FTLRecHitProducer.cc:75:19: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
     auto rechit = std::move(barrel_->makeRecHit(uhit, flags));
                  ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoLocalFastTime/FTLRecProducers/plugins/FTLRecHitProducer.cc:75:19: note: remove std::move call here
    auto rechit = std::move(barrel_->makeRecHit(uhit, flags));
                  ^~~~~~~~~~                                ~
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoLocalFastTime/FTLRecProducers/plugins/FTLRecHitProducer.cc:84:19: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
     auto rechit = std::move(endcap_->makeRecHit(uhit, flags));
                  ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoLocalFastTime/FTLRecProducers/plugins/FTLRecHitProducer.cc:84:19: note: remove std::move call here
    auto rechit = std::move(endcap_->makeRecHit(uhit, flags));
                  ^~~~~~~~~~                                ~
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoLocalFastTime/FTLRecProducers/plugins/FTLUncalibratedRecHitProducer.cc:74:31: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
     barrelRechits->push_back( std::move(barrel_->makeRecHit(digi)) );
                              ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoLocalFastTime/FTLRecProducers/plugins/FTLUncalibratedRecHitProducer.cc:74:31: note: remove std::move call here
    barrelRechits->push_back( std::move(barrel_->makeRecHit(digi)) );
                              ^~~~~~~~~~                         ~
  /build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoLocalFastTime/FTLRecProducers/plugins/FTLUncalibratedRecHitProducer.cc:81:31: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
     endcapRechits->push_back( std::move(endcap_->makeRecHit(digi)) );
                              ^
/build/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82a05c04338ac50120cfd99cab7eced5/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_10_1_CLANG_X_2018-03-27-2300/src/RecoLocalFastTime/FTLRecProducers/plugins/FTLUncalibratedRecHitProducer.cc:81:31: note: remove std::move call here
    endcapRechits->push_back( std::move(endcap_->makeRecHit(digi)) );
                              ^~~~~~~~~~                         ~