### PR TITLE
RecoTracker/TkNavigation: fix clang warning: -Woverloaded-virtual

### DIFF
--- a/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
@@ -44,6 +44,7 @@ private:
   //FakeDetLayer* theFakeDetLayer;
   void linkBarrelLayers( SymmetricLayerFinder& symFinder) override;
   //void linkForwardLayers( SymmetricLayerFinder& symFinder); 
+  void establishInverseRelations() override {};
   void establishInverseRelations( SymmetricLayerFinder& symFinder );
   void buildAdditionalBarrelLinks();
   void buildAdditionalForwardLinks(SymmetricLayerFinder& symFinder);
@@ -209,7 +210,6 @@ linkBarrelLayers( SymmetricLayerFinder& symFinder)
                                    rightFL,theField, 5.,false));
   }
 }
-
 
 // identical to  SimpleNavigationSchool but for the last additional stuff
 void CosmicNavigationSchool::establishInverseRelations(SymmetricLayerFinder& symFinder) {

--- a/RecoTracker/TkNavigation/plugins/SimpleNavigableLayer.h
+++ b/RecoTracker/TkNavigation/plugins/SimpleNavigableLayer.h
@@ -32,6 +32,13 @@ public:
 
   void setCheckCrossingSide(bool docheck) {theCheckCrossingSide = docheck;}
 
+  virtual std::vector<const DetLayer*> 
+  compatibleLayers( NavigationDirection direction) const = 0;
+
+  virtual std::vector<const DetLayer*> 
+  compatibleLayers( const FreeTrajectoryState& fts, 
+		    PropagationDirection timeDirection) const {int counter =0; return compatibleLayers(fts,timeDirection,counter);};
+
 
   std::vector< const DetLayer * > compatibleLayers (const FreeTrajectoryState &fts, 
 							    PropagationDirection timeDirection,


### PR DESCRIPTION
src/RecoTracker/TkNavigation/plugins/SimpleBarrelNavigableLayer.h:34:3: warning: 'SimpleBarrelNavigableLayer::compatibleLayers' hides overloaded virtual function [-Woverloaded-virtual]
   compatibleLayers( NavigationDirection direction) const override;
  ^
src/RecoTracker/TkNavigation/plugins/SimpleNavigableLayer.h:36:35: note: hidden overloaded virtual function 'SimpleNavigableLayer::compatibleLayers' declared here: different number of parameters (3 vs 1)
  std::vector< const DetLayer * > compatibleLayers (const FreeTrajectoryState &fts,
                                  ^

src/RecoTracker/TkNavigation/plugins/SimpleBarrelNavigableLayer.h:37:3: warning: 'SimpleBarrelNavigableLayer::compatibleLayers' hides overloaded virtual function [-Woverloaded-virtual]
   compatibleLayers( const FreeTrajectoryState& fts,
  ^
src/RecoTracker/TkNavigation/plugins/SimpleNavigableLayer.h:36:35: note: hidden overloaded virtual function 'SimpleNavigableLayer::compatibleLayers' declared here: different number of parameters (3 vs 2)
  std::vector< const DetLayer * > compatibleLayers (const FreeTrajectoryState &fts,
                                  ^

src/RecoTracker/TkNavigation/plugins/SimpleForwardNavigableLayer.h:29:3: warning: 'SimpleForwardNavigableLayer::compatibleLayers' hides overloaded virtual function [-Woverloaded-virtual]
   compatibleLayers( NavigationDirection direction) const override;
  ^
src/RecoTracker/TkNavigation/plugins/SimpleNavigableLayer.h:36:35: note: hidden overloaded virtual function 'SimpleNavigableLayer::compatibleLayers' declared here: different number of parameters (3 vs 1)
  std::vector< const DetLayer * > compatibleLayers (const FreeTrajectoryState &fts,
                                  ^

src/RecoTracker/TkNavigation/plugins/SimpleForwardNavigableLayer.h:32:3: warning: 'SimpleForwardNavigableLayer::compatibleLayers' hides overloaded virtual function [-Woverloaded-virtual]
   compatibleLayers( const FreeTrajectoryState& fts,
  ^
src/RecoTracker/TkNavigation/plugins/SimpleNavigableLayer.h:36:35: note: hidden overloaded virtual function 'SimpleNavigableLayer::compatibleLayers' declared here: different number of parameters (3 vs 2)
  std::vector< const DetLayer * > compatibleLayers (const FreeTrajectoryState &fts,
                                  ^

src/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc:47:8: warning: 'CosmicNavigationSchool::establishInverseRelations' hides overloaded virtual function [-Woverloaded-virtual]
   void establishInverseRelations( SymmetricLayerFinder& symFinder );
       ^
src/RecoTracker/TkNavigation/plugins/SimpleNavigationSchool.h:73:16: note: hidden overloaded virtual function 'SimpleNavigationSchool::establishInverseRelations' declared here: different number of parameters (0 vs 1)
  virtual void establishInverseRelations();
               ^