### PR TITLE
SimG4CMS/Forward: Fix clang warnings -Woverloaded-virtual -Wself-assign

### DIFF
--- a/SimG4CMS/Forward/interface/ZdcSD.h
+++ b/SimG4CMS/Forward/interface/ZdcSD.h
@@ -20,7 +20,7 @@ public:
   ~ZdcSD() override;
   bool ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
   uint32_t setDetUnitId(const G4Step* step) override;
-  double getEnergyDeposit(const G4Step*, edm::ParameterSet const &);
+  double getEnergyDeposit(G4Step*) override;
  
   void setNumberingScheme(ZdcNumberingScheme* scheme);
   void getFromLibrary(G4Step * step);
@@ -28,7 +28,7 @@ public:
 protected:
   void initRun() override;
 private:    
-
+  edm::ParameterSet m_ZdcSD;
   int verbosity;
   bool  useShowerLibrary,useShowerHits; 
   int   setTrackID(G4Step * step);

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -687,10 +687,8 @@ void CastorSD::getFromLibrary (G4Step* aStep) {
 	//Non compensation 
 	if (isHAD){
 		scale=scale*non_compensation_factor; // if hadronic extend the scale with the non-compensation factor
-	} else {
-		scale=scale; // if electromagnetic, don't do anything
-	}
-	
+	} 
+
   
 /*    double theTrackEnergy = theTrack->GetTotalEnergy() ; 
   

--- a/SimG4CMS/Forward/src/ZdcSD.cc
+++ b/SimG4CMS/Forward/src/ZdcSD.cc
@@ -24,7 +24,7 @@ ZdcSD::ZdcSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg,
 	     edm::ParameterSet const & p,const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
-  edm::ParameterSet m_ZdcSD = p.getParameter<edm::ParameterSet>("ZdcSD");
+  m_ZdcSD = p.getParameter<edm::ParameterSet>("ZdcSD");
   useShowerLibrary = m_ZdcSD.getParameter<bool>("UseShowerLibrary");
   useShowerHits    = m_ZdcSD.getParameter<bool>("UseShowerHits");
   zdcHitEnergyCut  = m_ZdcSD.getParameter<double>("ZdcHitEnergyCut")*GeV;
@@ -179,7 +179,8 @@ void ZdcSD::getFromLibrary (G4Step* aStep) {
   }
 }
 
-double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p ) {
+double ZdcSD::getEnergyDeposit(G4Step * aStep //, edm::ParameterSet const & p
+ ) {
 
   float NCherPhot = 0.;
   //std::cout<<"I go through here"<<std::endl;
@@ -260,8 +261,7 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p
       float thFullRefl = 23.;
       float thFullReflRad = thFullRefl*pi/180.;
 
-      edm::ParameterSet m_ZdcSD = p.getParameter<edm::ParameterSet>("ZdcSD");
-      thFibDir  = m_ZdcSD.getParameter<double>("FiberDirection");
+      auto thFibDir  = m_ZdcSD.getParameter<double>("FiberDirection");
       //float thFibDir = 90.;
       float thFibDirRad = thFibDir*pi/180.;
 


### PR DESCRIPTION
Changed the parameters of getEnergyDeposit to match base class by making second parameter a class member.
Remove self assign statement.

SimG4CMS/Forward/interface/ZdcSD.h:23:10: warning: 'ZdcSD::getEnergyDeposit' hides overloaded virtual function [-Woverloaded-virtual]
   double getEnergyDeposit(const G4Step*, edm::ParameterSet const &);
         ^
/SimG4CMS/Calo/interface/CaloSD.h:60:18: note: hidden overloaded virtual function 'CaloSD::getEnergyDeposit' declared here: different number of parameters (1 vs 2)
  virtual double getEnergyDeposit(G4Step* step);
                 ^

SimG4CMS/Forward/src/CastorSD.cc:691:8: warning: explicitly assigning value of variable of type 'double' to itself [-Wself-assign]
                 scale=scale; // if electromagnetic, don't do anything
                ~~~~~^~~~~~