### PR TITLE
fix preexisting tracker alignment validation

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
@@ -1,7 +1,7 @@
 import os
 from genericValidation import GenericValidation, GenericValidationData
 from geometryComparison import GeometryComparison
-from helperFunctions import getCommandOutput2, parsecolor, parsestyle
+from helperFunctions import boolfromstring, getCommandOutput2, parsecolor, parsestyle
 from monteCarloValidation import MonteCarloValidation
 from offlineValidation import OfflineValidation
 from plottingOptions import PlottingOptions
@@ -31,7 +31,7 @@ class PreexistingValidation(GenericValidation):
         if "|" in self.title or "," in self.title or '"' in self.title:
             msg = "The characters '|', '\"', and ',' cannot be used in the alignment title!"
             raise AllInOneError(msg)
-        self.needsproxy = bool(int(self.general["needsproxy"]))
+        self.needsproxy = boolfromstring(self.general["needsproxy"], "needsproxy")
         self.jobid = self.general["jobid"]
         if self.jobid:
             try:  #make sure it's actually a valid jobid

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -297,7 +297,7 @@ def createMergeScript( path, validations, options ):
     for validation in validations:
         for referenceName in validation.filesToCompare:
             validationtype = type(validation)
-            if isinstance(validationtype, PreexistingValidation):
+            if issubclass(validationtype, PreexistingValidation):
                 #find the actual validationtype
                 for parentclass in validationtype.mro():
                     if not issubclass(parentclass, PreexistingValidation):


### PR DESCRIPTION
backport of #22799

Fixing a stupid mistake.  The default behavior is setting this parameter to "true" which doesn't work with int.  I missed this one place in 297cb18bf0610f3184fb2ce9b4466b6ebddc6c05.