### PR TITLE
add exo hlt monitoring in HLTriggerOffline/Exotica for 4 new displaced muon paths (10_2_X)

### DIFF
--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDimuon_cff.py
@@ -4,6 +4,8 @@ DisplacedDimuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_DoubleMu43NoFiltersNoVtx_v", # 2017 displaced mu-mu (main)
         "HLT_DoubleMu48NoFiltersNoVtx_v", # 2017 displaced mu-mu (backup)
+        "HLT_DoubleMu33NoFiltersNoVtxDisplaced_v", # 2017 displaced mu-mu, muons with dxy> 0.01 cm (main)
+        "HLT_DoubleMu40NoFiltersNoVtxDisplaced_v", # 2017 displaced mu-mu, muons with dxy> 0.01 cm (backup)
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedMuEG_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedMuEG_cff.py
@@ -4,6 +4,8 @@ DisplacedMuEGPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v", # 2017 displaced e-mu (main)
         "HLT_Mu48NoFiltersNoVtx_Photon48_CaloIdL_v", # 2017 displaced e-mu (backup)
+        "HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v", # 2017 displaced e-mu, muon with dxy> 0.01cm (main)
+        "HLT_Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_v", # 2017 displaced e-mu, muon with dxy> 0.01cm (backup)
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     recMuonLabel  = cms.InputTag("muons"),


### PR DESCRIPTION
This PR adds monitoring in HLTriggerOffline/Exotica of 4 new displaced muon versions of paths, for 2018 pp running, used for the displaced leptons analysis. 

The corresponding HLT JIRA ticket is here: https://its.cern.ch/jira/browse/CMSHLT-1786
The approval presentation in a TSG meeting is here: https://indico.cern.ch/event/716973/contributions/2949157/attachments/1624468/2586312/displacedSUSYTriggers_TSGMeeting_28March2018.pdf