### PR TITLE
Fix l1 emulation in HLT scripts (102X)

### DIFF
--- a/HLTrigger/Configuration/python/CustomConfigs.py
+++ b/HLTrigger/Configuration/python/CustomConfigs.py
@@ -134,7 +134,7 @@ def L1REPACK(process,sequence="Full"):
         getattr(process,path).insert(0,process.SimL1Emulator)
 
     # special L1T cleanup
-    for obj in ('SimL1TCalorimeter','SimL1TMuonCommon','SimL1TMuon','SimL1TechnicalTriggers','SimL1EmulatorCore','ecalDigiSequence','hcalDigiSequence','calDigi','me0TriggerPseudoDigiSequence'):
+    for obj in ('SimL1TCalorimeter','SimL1TMuonCommon','SimL1TMuon','SimL1TechnicalTriggers','SimL1EmulatorCore','ecalDigiSequence','hcalDigiSequence','calDigi','me0TriggerPseudoDigiSequence','hgcalTriggerGeometryESProducer'):
         if hasattr(process,obj):
             delattr(process,obj)
 


### PR DESCRIPTION
This PR fix a segmentation fault that is obtained running hltGetConfiguration with l1 emulation in 101X and 102X.
It simply removes "hgcalTriggerGeometryESProducer" from HLT+L1 configuration.

Command to reproduce the error:
`hltGetConfiguration /dev/CMSSW_10_0_0/GRun   --l1-emulator uGT --l1 L1Menu_Collisions2018_v0_0_1 --globaltag 100X_dataRun2_relval_ForTSG_v1  --path HLTriggerFirstPath,HLTriggerFinalPath    --input root://eoscms.cern.ch//eos/cms/store/data/Run2017C/MuonEG/RAW/v1/000/302/029/00000/F4E8E245-608D-E711-9483-02163E014146.root  --process MYHLT --full --offline   --unprescale --max-events -1    --output none   > hltData.py   && cmsRun hltData.py >& logData & `