### PR TITLE
EMTF April 2018 emulator update part 1 - whitespace cleanup

### DIFF
--- a/DataFormats/L1TMuon/interface/EMTFTrack.h
+++ b/DataFormats/L1TMuon/interface/EMTFTrack.h
@@ -13,7 +13,7 @@
 #include "DataFormats/L1TMuon/interface/EMTF/SP.h"
 
 namespace l1t {
-  
+
   struct EMTFPtLUT {
     uint64_t address;
     uint16_t mode;
@@ -31,31 +31,31 @@ namespace l1t {
     uint16_t bt_ci    [5]; // ^
     uint16_t bt_si    [5]; // ^
   };
-  
-  
+
+
   class EMTFTrack {
   public:
-    
-  EMTFTrack() :
-    _PtLUT(), endcap(-99), sector(-99), sector_idx(-99), 
+
+    EMTFTrack() :
+      _PtLUT(), endcap(-99), sector(-99), sector_idx(-99),
       mode(-99), mode_CSC(0), mode_RPC(0), mode_neighbor(0), mode_inv(-99),
       rank(-99), winner(-99), charge(-99), bx(-99), first_bx(-99), second_bx(-99),
       pt(-99), pt_XML(-99), zone(-99), ph_num(-99), ph_q(-99),
       theta_fp(-99), theta(-99), eta(-99), phi_fp(-99), phi_loc(-99), phi_glob(-999),
       gmt_pt(-99), gmt_phi(-999), gmt_eta(-999), gmt_quality(-99), gmt_charge(-99), gmt_charge_valid(-99),
-      track_num(-99), numHits(-99) 
+      track_num(-99), numHits(-99)
       {};
-    
+
     virtual ~EMTFTrack() {};
-    
+
     void ImportSP( const emtf::SP _SP, int _sector );
     // void ImportPtLUT( int _mode, unsigned long _address );
-    
 
     void clear_Hits() { 
       _Hits.clear();  numHits = 0;
       mode_CSC = 0;  mode_RPC = 0;  mode_neighbor = 0;
     }
+
     void push_Hit(const EMTFHit& hit) {
       _Hits.push_back( hit );  
       numHits = _Hits.size();  
@@ -63,10 +63,11 @@ namespace l1t {
       mode_RPC      += ( hit.Is_RPC()   ? pow(2, 4 - hit.Station()) : 0 ); 
       mode_neighbor += ( hit.Neighbor() ? pow(2, 4 - hit.Station()) : 0 ); 
     }
+
     void set_Hits(const EMTFHitCollection& hits) {
       clear_Hits();
       for (const auto& hit : hits)
-	push_Hit( hit );
+        push_Hit( hit );
     }
 
     void set_HitIdx(const std::vector<unsigned int>& bits) { _HitIdx = bits;          }

--- a/DataFormats/L1TMuon/src/EMTFHit.cc
+++ b/DataFormats/L1TMuon/src/EMTFHit.cc
@@ -5,11 +5,11 @@ namespace l1t {
 
   CSCDetId EMTFHit::CreateCSCDetId() const {
     return CSCDetId( (endcap == 1) ? 1 : 2, station,
-		     (ring == 4) ? 1 : ring, chamber, 0 ); 
+                     (ring == 4) ? 1 : ring, chamber, 0 );
     // Layer always filled as 0 (indicates "whole chamber")
     // See http://cmslxr.fnal.gov/source/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc#0198
   }
-  
+
   // // Not yet implemented - AWB 15.03.17
   // RPCDetId EMTFHit::CreateRPCDetId() const {
   //   return RPCDetId( endcap, ring, station, sector, rpc_layer, subsector, roll );
@@ -23,10 +23,10 @@ namespace l1t {
     // May consider filling "trknmb" with 2 for 2nd LCT in the same chamber. - AWB 24.05.17
     // trknmb and bx0 are unused in the EMTF emulator code. mpclink = 0 (after bx) indicates unsorted.
   }
-  
+
   // // Not yet implemented - AWB 15.03.17
   // RPCDigi EMTFHit::CreateRPCDigi() const {
   //   return RPCDigi( (strip_hi + strip_lo) / 2, bx + CSCConstants::LCT_CENTRAL_BX );
   // }
-  
+
 } // End namespace l1t

--- a/L1Trigger/L1TMuon/interface/GeometryTranslator.h
+++ b/L1Trigger/L1TMuon/interface/GeometryTranslator.h
@@ -7,7 +7,7 @@
 //       digi information into local or global CMS coordinates for all
 //       types of L1 trigger primitives that we want to consider for
 //       use in the integrated muon trigger.
-//       
+//
 // Note: This should be considered as a base class to some sort of global
 //       look-up table
 //

--- a/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
+++ b/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
@@ -70,8 +70,8 @@ namespace L1TMuon {
 
     struct CSCData {
       CSCData() : trknmb(0), valid(0), quality(0), keywire(0), strip(0),
-		  pattern(0), bend(0), bx(0), mpclink(0), bx0(0), syncErr(0),
-		  cscID(0) {}
+                  pattern(0), bend(0), bx(0), mpclink(0), bx0(0), syncErr(0),
+                  cscID(0) {}
       uint16_t trknmb;
       uint16_t valid;
       uint16_t quality;
@@ -88,9 +88,9 @@ namespace L1TMuon {
 
     struct DTData {
       DTData() : bx(0), wheel(0), sector(0), station(0), radialAngle(0),
-		 bendingAngle(0), qualityCode(0), Ts2TagCode(0), BxCntCode(0),
-		 theta_bti_group(0), segment_number(0), theta_code(0),
-		 theta_quality(0) {}
+                 bendingAngle(0), qualityCode(0), Ts2TagCode(0), BxCntCode(0),
+                 theta_bti_group(0), segment_number(0), theta_code(0),
+                 theta_quality(0) {}
       // from ChambPhDigi (corresponds to a TRACO)
       // this gives us directly the phi
       int bx; // relative? bx number
@@ -126,18 +126,18 @@ namespace L1TMuon {
 
     //DT
     TriggerPrimitive(const DTChamberId&,
-		     const L1MuDTChambPhDigi&,
-		     const int segment_number);
+                     const L1MuDTChambPhDigi&,
+                     const int segment_number);
     TriggerPrimitive(const DTChamberId&,
-		     const L1MuDTChambThDigi&,
-		     const int segment_number);
+                     const L1MuDTChambThDigi&,
+                     const int segment_number);
     TriggerPrimitive(const DTChamberId&,
-		     const L1MuDTChambPhDigi&,
-		     const L1MuDTChambThDigi&,
-		     const int theta_bti_group);
+                     const L1MuDTChambPhDigi&,
+                     const L1MuDTChambThDigi&,
+                     const int theta_bti_group);
     //CSC
     TriggerPrimitive(const CSCDetId&,
-		     const CSCCorrelatedLCTDigi&);
+                     const CSCCorrelatedLCTDigi&);
     //RPC
     TriggerPrimitive(const RPCDetId& detid,
                      const unsigned strip,

--- a/L1Trigger/L1TMuon/interface/MuonTriggerPrimitiveFwd.h
+++ b/L1Trigger/L1TMuon/interface/MuonTriggerPrimitiveFwd.h
@@ -6,11 +6,11 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/Ptr.h"
 
-namespace L1TMuon{
+namespace L1TMuon {
   class TriggerPrimitive;
 
   typedef std::vector<TriggerPrimitive> TriggerPrimitiveCollection;
-  
+
   //typedef edm::Ref<TriggerPrimitiveCollection> TriggerPrimitiveRef;
   //typedef std::vector<TriggerPrimitiveRef> TriggerPrimitiveList;
   //typedef edm::Ptr<TriggerPrimitive> TriggerPrimitivePtr;

--- a/L1Trigger/L1TMuon/src/GeometryTranslator.cc
+++ b/L1Trigger/L1TMuon/src/GeometryTranslator.cc
@@ -25,10 +25,10 @@ GeometryTranslator::GeometryTranslator():
   _geom_cache_id(0ULL), _magfield_cache_id(0ULL) {
 }
 
-GeometryTranslator::~GeometryTranslator() {  
+GeometryTranslator::~GeometryTranslator() {
 }
 
-double 
+double
 GeometryTranslator::calculateGlobalEta(const TriggerPrimitive& tp) const {
   switch(tp.subsystem()) {
   case TriggerPrimitive::kDT:
@@ -44,12 +44,12 @@ GeometryTranslator::calculateGlobalEta(const TriggerPrimitive& tp) const {
     return calcGEMSpecificEta(tp);
     break;
   default:
-    return std::nan("Invalid TP type!"); 
+    return std::nan("Invalid TP type!");
     break;
   }
 }
 
-double 
+double
 GeometryTranslator::calculateGlobalPhi(const TriggerPrimitive& tp) const {
   switch(tp.subsystem()) {
   case TriggerPrimitive::kDT:
@@ -70,7 +70,7 @@ GeometryTranslator::calculateGlobalPhi(const TriggerPrimitive& tp) const {
   }
 }
 
-double 
+double
 GeometryTranslator::calculateBendAngle(const TriggerPrimitive& tp) const {
   switch(tp.subsystem()) {
   case TriggerPrimitive::kDT:
@@ -174,23 +174,23 @@ GeometryTranslator::getRPCSpecificPoint(const TriggerPrimitive& tp) const {
   const GlobalPoint gp = roll->toGlobal(lp);
   
   //roll.release();
- 
+
   return gp;
 }
 
-double 
-GeometryTranslator::calcRPCSpecificEta(const TriggerPrimitive& tp) const {  
+double
+GeometryTranslator::calcRPCSpecificEta(const TriggerPrimitive& tp) const {
   return getRPCSpecificPoint(tp).eta();
 }
 
-double 
-GeometryTranslator::calcRPCSpecificPhi(const TriggerPrimitive& tp) const {  
+double
+GeometryTranslator::calcRPCSpecificPhi(const TriggerPrimitive& tp) const {
   return getRPCSpecificPoint(tp).phi();
 }
 
 // this function actually does nothing since RPC
 // hits are point-like objects
-double 
+double
 GeometryTranslator::calcRPCSpecificBend(const TriggerPrimitive& tp) const {
   return 0.0;
 }
@@ -198,11 +198,11 @@ GeometryTranslator::calcRPCSpecificBend(const TriggerPrimitive& tp) const {
 
 // alot of this is transcription and consolidation of the CSC
 // global phi calculation code
-// this works directly with the geometry 
+// this works directly with the geometry
 // rather than using the old phi luts
-GlobalPoint 
+GlobalPoint
 GeometryTranslator::getCSCSpecificPoint(const TriggerPrimitive& tp) const {
-  const CSCDetId id(tp.detId<CSCDetId>()); 
+  const CSCDetId id(tp.detId<CSCDetId>());
   // we should change this to weak_ptrs at some point
   // requires introducing std::shared_ptrs to geometry
   std::unique_ptr<const CSCChamber> chamb(_geocsc->chamber(id));
@@ -212,13 +212,13 @@ GeometryTranslator::getCSCSpecificPoint(const TriggerPrimitive& tp) const {
   std::unique_ptr<const CSCLayer> layer(
     chamb->layer(CSCConstants::KEY_ALCT_LAYER)
     );
-  
+
   const uint16_t halfstrip = tp.getCSCData().strip;
   const uint16_t pattern = tp.getCSCData().pattern;
-  const uint16_t keyWG = tp.getCSCData().keywire; 
-  //const unsigned maxStrips = layer_geom->numberOfStrips();  
+  const uint16_t keyWG = tp.getCSCData().keywire;
+  //const unsigned maxStrips = layer_geom->numberOfStrips();
 
-  // so we can extend this later 
+  // so we can extend this later
   // assume TMB2007 half-strips only as baseline
   double offset = 0.0;
   switch(1) {
@@ -230,46 +230,46 @@ GeometryTranslator::getCSCSpecificPoint(const TriggerPrimitive& tp) const {
 
   // the rough location of the hit at the ALCT key layer
   // we will refine this using the half strip information
-  const LocalPoint coarse_lp = 
-    layer_geom->stripWireGroupIntersection(strip,keyWG);  
-  const GlobalPoint coarse_gp = layer->surface().toGlobal(coarse_lp);  
-  
+  const LocalPoint coarse_lp =
+    layer_geom->stripWireGroupIntersection(strip,keyWG);
+  const GlobalPoint coarse_gp = layer->surface().toGlobal(coarse_lp);
+
   // the strip width/4.0 gives the offset of the half-strip
   // center with respect to the strip center
   const double hs_offset = layer_geom->stripPhiPitch()/4.0;
-  
+
   // determine handedness of the chamber
   const bool ccw = isCSCCounterClockwise(layer);
   // we need to subtract the offset of even half strips and add the odd ones
   const double phi_offset = ( ( halfstrip_offs%2 ? 1 : -1)*
-			      ( ccw ? -hs_offset : hs_offset ) );
-  
+                              ( ccw ? -hs_offset : hs_offset ) );
+
   // the global eta calculation uses the middle of the strip
   // so no need to increment it
   const GlobalPoint final_gp( GlobalPoint::Polar( coarse_gp.theta(),
-						  (coarse_gp.phi().value() + 
-						   phi_offset),
-						  coarse_gp.mag() ) );
-    
+                                                  (coarse_gp.phi().value() +
+                                                   phi_offset),
+                                                  coarse_gp.mag() ) );
+
   // We need to add in some notion of the 'error' on trigger primitives
   // like the width of the wire group by the width of the strip
-  // or something similar      
+  // or something similar
 
   // release ownership of the pointers
   chamb.release();
   layer_geom.release();
   layer.release();
-  
+
   return final_gp;
 }
 
-double 
-GeometryTranslator::calcCSCSpecificEta(const TriggerPrimitive& tp) const {  
+double
+GeometryTranslator::calcCSCSpecificEta(const TriggerPrimitive& tp) const {
   return getCSCSpecificPoint(tp).eta();
 }
 
-double 
-GeometryTranslator::calcCSCSpecificPhi(const TriggerPrimitive& tp) const {  
+double
+GeometryTranslator::calcCSCSpecificPhi(const TriggerPrimitive& tp) const {
   return getCSCSpecificPoint(tp).phi();
 }
 
@@ -279,55 +279,55 @@ GeometryTranslator::calcCSCSpecificBend(const TriggerPrimitive& tp) const {
 }
 
 GlobalPoint
-GeometryTranslator::calcDTSpecificPoint(const TriggerPrimitive& tp) const {  
+GeometryTranslator::calcDTSpecificPoint(const TriggerPrimitive& tp) const {
   const DTChamberId baseid(tp.detId<DTChamberId>());
   // do not use this pointer for anything other than creating a trig geom
   std::unique_ptr<DTChamber> chamb(
-    const_cast<DTChamber*>(_geodt->chamber(baseid)) 
+    const_cast<DTChamber*>(_geodt->chamber(baseid))
     );
   std::unique_ptr<DTTrigGeom> trig_geom( new DTTrigGeom(chamb.get(),false) );
-  chamb.release(); // release it here so no one gets funny ideas  
+  chamb.release(); // release it here so no one gets funny ideas
   // super layer one is the theta superlayer in a DT chamber
   // station 4 does not have a theta super layer
   // the BTI index from the theta trigger is an OR of some BTI outputs
   // so, we choose the BTI that's in the middle of the group
   // as the BTI that we get theta from
   // TODO:::::>>> need to make sure this ordering doesn't flip under wheel sign
-  const int NBTI_theta = ( (baseid.station() != 4) ? 
-			   trig_geom->nCell(2) : trig_geom->nCell(3) );
+  const int NBTI_theta = ( (baseid.station() != 4) ?
+                           trig_geom->nCell(2) : trig_geom->nCell(3) );
   const int bti_group = tp.getDTData().theta_bti_group;
-  const unsigned bti_actual = bti_group*NBTI_theta/7 + NBTI_theta/14 + 1;  
-  DTBtiId thetaBTI;  
+  const unsigned bti_actual = bti_group*NBTI_theta/7 + NBTI_theta/14 + 1;
+  DTBtiId thetaBTI;
   if ( baseid.station() != 4 && bti_group != -1) {
     thetaBTI = DTBtiId(baseid,2,bti_actual);
   } else {
     // since this is phi oriented it'll give us theta in the middle
     // of the chamber
-    thetaBTI = DTBtiId(baseid,3,1); 
+    thetaBTI = DTBtiId(baseid,3,1);
   }
   const GlobalPoint theta_gp = trig_geom->CMSPosition(thetaBTI);
-  
+
   // local phi in sector -> global phi
-  double phi = ((double)tp.getDTData().radialAngle)/4096.0; 
-  phi += tp.getDTData().sector*M_PI/6.0; // add sector offset  
+  double phi = ((double)tp.getDTData().radialAngle)/4096.0;
+  phi += tp.getDTData().sector*M_PI/6.0; // add sector offset
 
   return GlobalPoint( GlobalPoint::Polar( theta_gp.theta(),
-					  phi,
-					  theta_gp.mag() ) );
+                                          phi,
+                                          theta_gp.mag() ) );
 }
 
-double 
-GeometryTranslator::calcDTSpecificEta(const TriggerPrimitive& tp) const {  
+double
+GeometryTranslator::calcDTSpecificEta(const TriggerPrimitive& tp) const {
   return calcDTSpecificPoint(tp).eta();
 }
 
-double 
+double
 GeometryTranslator::calcDTSpecificPhi(const TriggerPrimitive& tp) const {
   return calcDTSpecificPoint(tp).phi();
 }
 
 // we have the bend except for station 3
-double 
+double
 GeometryTranslator::calcDTSpecificBend(const TriggerPrimitive& tp) const {
   int bend = tp.getDTData().bendingAngle;
   double bendf = bend/512.0;
@@ -339,6 +339,6 @@ isCSCCounterClockwise(const std::unique_ptr<const CSCLayer>& layer) const {
   const int nStrips = layer->geometry()->numberOfStrips();
   const double phi1 = layer->centerOfStrip(1).phi();
   const double phiN = layer->centerOfStrip(nStrips).phi();
-  return ( (std::abs(phi1 - phiN) < M_PI  && phi1 >= phiN) || 
-	   (std::abs(phi1 - phiN) >= M_PI && phi1 < phiN)     );  
+  return ( (std::abs(phi1 - phiN) < M_PI  && phi1 >= phiN) ||
+           (std::abs(phi1 - phiN) >= M_PI && phi1 < phiN)     );
 }

--- a/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
+++ b/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
@@ -21,8 +21,8 @@ namespace {
 
 //constructors from DT data
 TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
-				   const L1MuDTChambPhDigi& digi_phi,
-				   const int segment_number):
+                                   const L1MuDTChambPhDigi& digi_phi,
+                                   const int segment_number):
   _id(detid),
   _subsystem(TriggerPrimitive::kDT) {
   calculateDTGlobalSector(detid,_globalsector,_subsector);
@@ -44,8 +44,8 @@ TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
 }
 
 TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
-				   const L1MuDTChambThDigi& digi_th,
-				   const int theta_bti_group):
+                                   const L1MuDTChambThDigi& digi_th,
+                                   const int theta_bti_group):
   _id(detid),
   _subsystem(TriggerPrimitive::kDT) {
   calculateDTGlobalSector(detid,_globalsector,_subsector);
@@ -67,9 +67,9 @@ TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
 }
 
 TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
-				   const L1MuDTChambPhDigi& digi_phi,
-				   const L1MuDTChambThDigi& digi_th,
-				   const int theta_bti_group):
+                                   const L1MuDTChambPhDigi& digi_phi,
+                                   const L1MuDTChambThDigi& digi_th,
+                                   const int theta_bti_group):
   _id(detid),
   _subsystem(TriggerPrimitive::kDT) {
   calculateDTGlobalSector(detid,_globalsector,_subsector);
@@ -92,7 +92,7 @@ TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
 
 //constructor from CSC data
 TriggerPrimitive::TriggerPrimitive(const CSCDetId& detid,
-				   const CSCCorrelatedLCTDigi& digi):
+                                   const CSCCorrelatedLCTDigi& digi):
   _id(detid),
   _subsystem(TriggerPrimitive::kCSC) {
   calculateCSCGlobalSector(detid,_globalsector,_subsector);
@@ -132,6 +132,7 @@ TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid,
   _rpc.bx = bx;
   _rpc.valid = 1;
 }
+
 
 // constructor from GEM data
 TriggerPrimitive::TriggerPrimitive(const GEMDetId& detid,

--- a/L1Trigger/L1TMuonEndCap/interface/Common.h
+++ b/L1Trigger/L1TMuonEndCap/interface/Common.h
@@ -47,20 +47,20 @@ namespace emtf {
   // from DataFormats/MuonDetId/interface/CSCDetId.h
   constexpr int MIN_ENDCAP = 1;
   constexpr int MAX_ENDCAP = 2;
-  
+
   // from DataFormats/MuonDetId/interface/CSCTriggerNumbering.h
   constexpr int MIN_TRIGSECTOR = 1;
   constexpr int MAX_TRIGSECTOR = 6;
   constexpr int NUM_SECTORS = 12;
-  
+
   // Zones
   constexpr int NUM_ZONES = 4;
   constexpr int NUM_ZONE_HITS = 160;
-  
+
   // Stations
   constexpr int NUM_STATIONS = 4;
   constexpr int NUM_STATION_PAIRS = 6;
-  
+
   // Fixed-size arrays
   template<typename T>
   using sector_array = std::array<T, NUM_SECTORS>;

--- a/L1Trigger/L1TMuonEndCap/interface/EndCapParamsHelper.h
+++ b/L1Trigger/L1TMuonEndCap/interface/EndCapParamsHelper.h
@@ -39,7 +39,7 @@ namespace l1t {
   class EndCapParamsHelper {
   public:
     enum {VERSION = 1};
-    
+
     ~EndCapParamsHelper();
 
     //ctor if creating a new table (e.g. from XML or python file)
@@ -54,7 +54,7 @@ namespace l1t {
     // "PhiMatchWindowSt1" arbitrarily re-mapped to Primitive conversion (PC LUT) version
     // because of rigid CondFormats naming conventions - AWB 02.06.17
     void SetPrimConvVersion (unsigned version) {write_->PhiMatchWindowSt1_ = version;}
-    
+
     unsigned GetPtAssignVersion() const {return read_->PtAssignVersion_;}
     unsigned GetFirmwareVersion() const {return read_->firmwareVersion_;}
     unsigned GetPrimConvVersion() const {return read_->PhiMatchWindowSt1_;}
@@ -65,14 +65,14 @@ namespace l1t {
     // access to underlying pointers, mainly for ESProducer:
     const L1TMuonEndCapParams *  getReadInstance() const {return read_;}
     L1TMuonEndCapParams *  getWriteInstance(){return write_; }
-       
+
   private:
     EndCapParamsHelper(const L1TMuonEndCapParams * es);
     void useCopy();
     void check_write() { assert(write_); }
     // separating read from write allows for a high-performance read-only mode (as no copy is made):
     const L1TMuonEndCapParams * read_;  // when reading/getting, use this.
-    L1TMuonEndCapParams * write_; // when writing/setting, use this.     
+    L1TMuonEndCapParams * write_; // when writing/setting, use this.
     bool we_own_write_;
   };
 

--- a/L1Trigger/L1TMuonEndCap/interface/PtAssignmentEngineAux2017.h
+++ b/L1Trigger/L1TMuonEndCap/interface/PtAssignmentEngineAux2017.h
@@ -29,10 +29,10 @@ public:
   void unpack2bRPC(int rpc_2b, int& rpcA, int& rpcB, int& rpcC) const;
 
   int get8bMode15(int theta, int st1_ring2, int endcap, int sPhiAB,
-		  int clctA, int clctB, int clctC, int clctD) const;
+                  int clctA, int clctB, int clctC, int clctD) const;
 
   void unpack8bMode15( int mode15_8b, int& theta, int& st1_ring2, int endcap, int sPhiAB,
-		       int& clctA, int& rpcA, int& rpcB, int& rpcC, int& rpcD) const;
+                       int& clctA, int& rpcA, int& rpcB, int& rpcC, int& rpcD) const;
 
   // Need to re-check / verify this - AWB 17.03.17
   // int getFRLUT(int sector, int station, int chamber) const;

--- a/L1Trigger/L1TMuonEndCap/interface/PtLutVarCalc.h
+++ b/L1Trigger/L1TMuonEndCap/interface/PtLutVarCalc.h
@@ -5,18 +5,18 @@ int CalcTrackTheta( const int th1, const int th2, const int th3, const int th4,
                     const int ring1, const int mode, const bool BIT_COMP=false );
 
 void CalcDeltaPhis( int& dPh12, int& dPh13, int& dPh14, int& dPh23, int& dPh24, int& dPh34, int& dPhSign,
-		    int& dPhSum4, int& dPhSum4A, int& dPhSum3, int& dPhSum3A, int& outStPh,
-		    const int ph1, const int ph2, const int ph3, const int ph4, const int mode, const bool BIT_COMP=false );
+                    int& dPhSum4, int& dPhSum4A, int& dPhSum3, int& dPhSum3A, int& outStPh,
+                    const int ph1, const int ph2, const int ph3, const int ph4, const int mode, const bool BIT_COMP=false );
 
 void CalcDeltaThetas( int& dTh12, int& dTh13, int& dTh14, int& dTh23, int& dTh24, int& dTh34,
-		      const int th1, const int th2, const int th3, const int th4, const int mode, const bool BIT_COMP=false );
+                      const int th1, const int th2, const int th3, const int th4, const int mode, const bool BIT_COMP=false );
 
 void CalcBends( int& bend1, int& bend2, int& bend3, int& bend4,
-		const int pat1, const int pat2, const int pat3, const int pat4,
-		const int dPhSign, const int endcap, const int mode, const bool BIT_COMP=false );
+                const int pat1, const int pat2, const int pat3, const int pat4,
+                const int dPhSign, const int endcap, const int mode, const bool BIT_COMP=false );
 
-void CalcRPCs( int& RPC1, int& RPC2, int& RPC3, int& RPC4, const int mode, 
-	       const int st1_ring2, const int theta, const bool BIT_COMP=false );
+void CalcRPCs( int& RPC1, int& RPC2, int& RPC3, int& RPC4, const int mode,
+               const int st1_ring2, const int theta, const bool BIT_COMP=false );
 
 int CalcBendFromPattern( const int pattern, const int endcap );
 

--- a/L1Trigger/L1TMuonEndCap/interface/bdt/Event.h
+++ b/L1Trigger/L1TMuonEndCap/interface/bdt/Event.h
@@ -27,8 +27,8 @@ struct Event
     int Quality;
 
     static int sortingIndex;
-    int id;    
-    std::vector<double> data;         
+    int id;
+    std::vector<double> data;
 
     bool operator< (const Event &rhs) const
     {
@@ -45,9 +45,9 @@ struct Event
             std::cout << "x"<< i << "=" << data[i] << ", ";
         }
         std::cout << std::endl;
-     
+
     }
-  
+
     void resetPredictedValue(){ predictedValue = 0; }
 };
 

--- a/L1Trigger/L1TMuonEndCap/interface/bdt/Forest.h
+++ b/L1Trigger/L1TMuonEndCap/interface/bdt/Forest.h
@@ -31,7 +31,7 @@ class Forest
 
         // Get info on variable importance.
         void rankVariables(std::vector<int>& rank);
- 
+
         // Output the list of split values used for each variable.
         void saveSplitValues(const char* savefilename);
 
@@ -39,17 +39,17 @@ class Forest
         void listEvents(std::vector< std::vector<Event*> >& e);
         void sortEventVectors(std::vector< std::vector<Event*> >& e);
         void generate(int numTrainEvents, int numTestEvents, double sigma);
-        void loadForestFromXML(const char* directory, unsigned int numTrees); 
+        void loadForestFromXML(const char* directory, unsigned int numTrees);
         void loadFromCondPayload(const L1TMuonEndCapForest::DForest& payload);
 
         // Perform the regression
         void updateRegTargets(Tree *tree, double learningRate, LossFunction* l);
-        void doRegression(int nodeLimit, int treeLimit, double learningRate, LossFunction* l, 
+        void doRegression(int nodeLimit, int treeLimit, double learningRate, LossFunction* l,
                           const char* savetreesdirectory, bool saveTrees);
 
         // Stochastic Gradient Boosting
         void prepareRandomSubsample(double fraction);
-        void doStochasticRegression(int nodeLimit, int treeLimit, double learningRate, 
+        void doStochasticRegression(int nodeLimit, int treeLimit, double learningRate,
                                     double fraction, LossFunction* l);
 
         // Predict some events

--- a/L1Trigger/L1TMuonEndCap/interface/bdt/LossFunctions.h
+++ b/L1Trigger/L1TMuonEndCap/interface/bdt/LossFunctions.h
@@ -1,6 +1,6 @@
 // LossFunctions.h
 // Here we define the different loss functions that can be used
-// with the BDT system. 
+// with the BDT system.
 
 #ifndef L1Trigger_L1TMuonEndCap_emtf_LossFunctions
 #define L1Trigger_L1TMuonEndCap_emtf_LossFunctions
@@ -30,7 +30,7 @@ class LossFunction
         virtual double fit(std::vector<Event*>& v) = 0;
         virtual std::string name() = 0;
         virtual int id() = 0;
-	virtual ~LossFunction() = default;
+        virtual ~LossFunction() = default;
 };
 
 // ========================================================
@@ -59,12 +59,12 @@ class LeastSquares : public LossFunction
                 Event* e = v[i];
                 SUM += e->trueValue - e->predictedValue;
             }
-    
+
             return SUM/v.size();
         }
         std::string name() override { return "Least_Squares"; }
         int id() override{ return 1; }
-       
+
 };
 
 // ========================================================
@@ -91,8 +91,8 @@ class AbsoluteDeviation : public LossFunction
         // The median of the residuals minimizes absolute deviation.
             if(v.empty()) return 0;
             std::vector<double> residuals(v.size());
-       
-            // Load the residuals into a vector. 
+
+            // Load the residuals into a vector.
             for(unsigned int i=0; i<v.size(); i++)
             {
                 Event* e = v[i];
@@ -108,7 +108,7 @@ class AbsoluteDeviation : public LossFunction
                 std::nth_element(residuals.begin(), residuals.begin()+median_loc, residuals.end());
                 return residuals[median_loc];
             }
-            
+
             // Even.
             else
             {
@@ -132,7 +132,7 @@ class Huber : public LossFunction
     public:
         Huber(){}
         ~Huber() override{}
- 
+
         double quantile;
         double residual_median;
 
@@ -151,19 +151,19 @@ class Huber : public LossFunction
         // The constant fit that minimizes Huber in a region.
 
             quantile = calculateQuantile(v, 0.7);
-            residual_median = calculateQuantile(v, 0.5); 
+            residual_median = calculateQuantile(v, 0.5);
 
             double x = 0;
             for(unsigned int i=0; i<v.size(); i++)
             {
                 Event* e = v[i];
                 double residual = e->trueValue - e->predictedValue;
-                double diff = residual - residual_median; 
+                double diff = residual - residual_median;
                 x += ((diff > 0)?1.0:-1.0)*std::min(quantile, std::abs(diff));
             }
 
            return (residual_median + x/v.size());
-            
+
         }
 
         std::string name() override { return "Huber"; }
@@ -173,18 +173,18 @@ class Huber : public LossFunction
         {
             // Container for the residuals.
             std::vector<double> residuals(v.size());
-       
-            // Load the residuals into a vector. 
+
+            // Load the residuals into a vector.
             for(unsigned int i=0; i<v.size(); i++)
             {
                 Event* e = v[i];
                 residuals[i] = std::abs(e->trueValue - e->predictedValue);
             }
 
-            std::sort(residuals.begin(), residuals.end());             
+            std::sort(residuals.begin(), residuals.end());
             unsigned int quantile_location = whichQuantile*(residuals.size()-1);
             return residuals[quantile_location];
-        }        
+        }
 };
 
 // ========================================================
@@ -198,28 +198,28 @@ class PercentErrorSquared : public LossFunction
         ~PercentErrorSquared() override{}
 
         double target(Event* e) override
-        {   
+        {
         // The gradient of the squared percent error.
             return (e->trueValue - e->predictedValue)/(e->trueValue * e->trueValue);
-        }   
+        }
 
         double fit(std::vector<Event*>& v) override
-        {   
+        {
         // The average of the weighted residuals minimizes the squared percent error.
-        // Weight(i) = 1/true(i)^2. 
-    
+        // Weight(i) = 1/true(i)^2.
+
             double SUMtop = 0;
             double SUMbottom = 0;
-    
+
             for(unsigned int i=0; i<v.size(); i++)
-            {   
+            {
                 Event* e = v[i];
-                SUMtop += (e->trueValue - e->predictedValue)/(e->trueValue*e->trueValue); 
+                SUMtop += (e->trueValue - e->predictedValue)/(e->trueValue*e->trueValue);
                 SUMbottom += 1/(e->trueValue*e->trueValue);
-            }   
-    
+            }
+
             return SUMtop/SUMbottom;
-        }   
+        }
         std::string name() override { return "Percent_Error"; }
         int id() override{ return 4; }
 };

--- a/L1Trigger/L1TMuonEndCap/interface/bdt/Node.h
+++ b/L1Trigger/L1TMuonEndCap/interface/bdt/Node.h
@@ -59,7 +59,7 @@ class Node
         Node* filterEventToDaughter(Event* e);
         void listEvents();
         void theMiracleOfChildBirth();
- 
+
     private:
         Node(const Node &) = delete;
         Node& operator=(const Node &) = delete;

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapForestESProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapForestESProducer.cc
@@ -95,10 +95,10 @@ L1TMuonEndCapForestESProducer::produce(const L1TMuonEndCapForestRcd& iRecord)
   PtAssignmentEngine* pt_assign_engine_;
   std::unique_ptr<PtAssignmentEngine> pt_assign_engine_2016_;
   std::unique_ptr<PtAssignmentEngine> pt_assign_engine_2017_;
-  
+
   pt_assign_engine_2016_.reset(new PtAssignmentEngine2016());
   pt_assign_engine_2017_.reset(new PtAssignmentEngine2017());
-  
+
   if (ptLUTVersion <= 5) pt_assign_engine_ = pt_assign_engine_2016_.get();
   else                   pt_assign_engine_ = pt_assign_engine_2017_.get();
 
@@ -125,7 +125,7 @@ L1TMuonEndCapForestESProducer::produce(const L1TMuonEndCapForestRcd& iRecord)
     // of course, move has no effect here, but I'll keep it in case move constructor will be provided some day
     pEMTFForest->forest_coll_.push_back( std::move( cond_forest ) );
   }
-  
+
   return pEMTFForest;
 }
 

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapParamsESProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapParamsESProducer.cc
@@ -22,7 +22,7 @@ class L1TMuonEndCapParamsESProducer : public edm::ESProducer {
 public:
   L1TMuonEndCapParamsESProducer(const edm::ParameterSet&);
   ~L1TMuonEndCapParamsESProducer() override;
-  
+
   typedef std::shared_ptr<L1TMuonEndCapParams> ReturnType;
 
   ReturnType produce(const L1TMuonEndCapParamsRcd&);
@@ -60,7 +60,7 @@ L1TMuonEndCapParamsESProducer::produce(const L1TMuonEndCapParamsRcd& iRecord)
    using namespace edm::es;
    auto pEMTFParams = std::make_shared<L1TMuonEndCapParams>(*data_.getWriteInstance());
    return pEMTFParams;
-   
+
 }
 
 // Define this as a plug-in

--- a/L1Trigger/L1TMuonEndCap/src/AngleCalculation.cc
+++ b/L1Trigger/L1TMuonEndCap/src/AngleCalculation.cc
@@ -339,7 +339,7 @@ void AngleCalculation::calculate_angles(EMTFTrack& track) const {
     // if (subsystem == TriggerPrimitive::kRPC)
     //   return (station == 2);
 
-    // In EMTF firmware, RPC hits are treated as if they came from the corresponding 
+    // In EMTF firmware, RPC hits are treated as if they came from the corresponding
     // CSC chamber, so the FR bit assignment is the same as for CSCs - AWB 06.06.17
 
     // GEMs are in front of the CSCs
@@ -372,7 +372,7 @@ void AngleCalculation::calculate_angles(EMTFTrack& track) const {
     const auto& v = st_conv_hits.at(i);
     ptlut_data.cpattern[i] = v.empty() ? 0 : v.front().Pattern();  // Automatically set to 0 for RPCs
     ptlut_data.fr[i]       = v.empty() ? 0 : isFront(v.front().Station(), v.front().Ring(), v.front().Chamber(), v.front().Subsystem());
-    if (i == 0) 
+    if (i == 0)
       ptlut_data.st1_ring2 = v.empty() ? 0 : (v.front().Station() == 1 && (v.front().Ring() == 2 || v.front().Ring() == 3));
   }
 

--- a/L1Trigger/L1TMuonEndCap/src/BestTrackSelection.cc
+++ b/L1Trigger/L1TMuonEndCap/src/BestTrackSelection.cc
@@ -72,7 +72,7 @@ void BestTrackSelection::cancel_one_bx(
     const std::deque<EMTFTrackCollection>& extended_best_track_cands,
     EMTFTrackCollection& best_tracks
 ) const {
-  const int max_z = emtf::NUM_ZONES;        // = 4 zones
+  const int max_z = emtf::NUM_ZONES;  // = 4 zones
   const int max_n = maxRoadsPerZone_; // = 3 candidates per zone
   const int max_zn = max_z * max_n;   // = 12 total candidates
   if (not (maxTracks_ <= max_zn))
@@ -259,7 +259,7 @@ void BestTrackSelection::cancel_multi_bx(
     EMTFTrackCollection& best_tracks
 ) const {
   const int max_h = bxWindow_;        // = 3 bx history
-  const int max_z = emtf::NUM_ZONES;        // = 4 zones
+  const int max_z = emtf::NUM_ZONES;  // = 4 zones
   const int max_n = maxRoadsPerZone_; // = 3 candidates per zone
   const int max_zn = max_z * max_n;   // = 12 total candidates
   const int max_hzn = max_h * max_zn; // = 36 total candidates

--- a/L1Trigger/L1TMuonEndCap/src/EndCapParamsHelper.cc
+++ b/L1Trigger/L1TMuonEndCap/src/EndCapParamsHelper.cc
@@ -16,11 +16,11 @@ EndCapParamsHelper *  EndCapParamsHelper::readAndWriteFromEventSetup(const L1TMu
 }
 
 EndCapParamsHelper::EndCapParamsHelper(L1TMuonEndCapParams * w) {
-  write_ = w; 
-  check_write(); 
+  write_ = w;
+  check_write();
   we_own_write_ = false;
-  //write_->m_version = VERSION; 
-  read_ = write_; 
+  //write_->m_version = VERSION;
+  read_ = write_;
 }
 
 EndCapParamsHelper::EndCapParamsHelper(const L1TMuonEndCapParams * es) {read_ = es; write_=nullptr;}

--- a/L1Trigger/L1TMuonEndCap/src/MicroGMTConverter.cc
+++ b/L1Trigger/L1TMuonEndCap/src/MicroGMTConverter.cc
@@ -109,7 +109,7 @@ void MicroGMTConverter::convert_all(
 
   // Sort by processor to match uGMT unpacked order
   emtf::sort_uGMT_muons(out_cands);
-  
+
 }
 
 
@@ -118,12 +118,12 @@ namespace emtf {
 void sort_uGMT_muons(
    l1t::RegionalMuonCandBxCollection& cands
 ) {
-  
+
   int minBX = cands.getFirstBX();
   int maxBX = cands.getLastBX();
   int emtfMinProc =  0; // ME+ sector 1
   int emtfMaxProc = 11; // ME- sector 6
-  
+
   // New collection, sorted by processor to match uGMT unpacked order
   auto sortedCands = std::make_unique<l1t::RegionalMuonCandBxCollection>();
   sortedCands->clear();
@@ -131,14 +131,14 @@ void sort_uGMT_muons(
   for (int iBX = minBX; iBX <= maxBX; ++iBX) {
     for (int proc = emtfMinProc; proc <= emtfMaxProc; proc++) {
       for (l1t::RegionalMuonCandBxCollection::const_iterator cand = cands.begin(iBX); cand != cands.end(iBX); ++cand) {
-	int cand_proc = cand->processor();
-	if (cand->trackFinderType() == l1t::tftype::emtf_neg) cand_proc += 6;
-	if (cand_proc != proc) continue;
-	sortedCands->push_back(iBX, *cand);
+        int cand_proc = cand->processor();
+        if (cand->trackFinderType() == l1t::tftype::emtf_neg) cand_proc += 6;
+        if (cand_proc != proc) continue;
+        sortedCands->push_back(iBX, *cand);
       }
     }
   }
-  
+
   // Return sorted collection
   std::swap(cands, *sortedCands);
   sortedCands.reset();

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
@@ -446,7 +446,7 @@ void PrimitiveConversion::convert_rpc(
   int tp_station   = tp_detId.station();    // 1 - 4
   int tp_ring      = tp_detId.ring();       // 2 - 3 (increasing theta)
   int tp_roll      = tp_detId.roll();       // 1 - 3 (decreasing theta; aka A - C; space between rolls is 9 - 15 in theta_fp)
-  // int tp_layer     = tp_detId.layer();
+  //int tp_layer     = tp_detId.layer();
 
   int tp_bx        = tp_data.bx;
   int tp_strip     = ((tp_data.strip_low + tp_data.strip_hi) / 2);  // in full-strip unit
@@ -533,8 +533,8 @@ void PrimitiveConversion::convert_rpc_details(EMTFHit& conv_hit) const {
   const int pc_chamber = conv_hit.PC_chamber();
   const int pc_segment = conv_hit.PC_segment();
 
-  // const int fw_endcap  = (endcap_-1);
-  // const int fw_sector  = (sector_-1);
+  //const int fw_endcap  = (endcap_-1);
+  //const int fw_sector  = (sector_-1);
   const int fw_station = (conv_hit.Station() == 1) ? (is_neighbor ? 0 : pc_station) : conv_hit.Station();
 
   int fw_cscid = pc_chamber;
@@ -613,7 +613,7 @@ void PrimitiveConversion::convert_gem(
   int tp_station   = tp_detId.station();
   int tp_ring      = tp_detId.ring();
   int tp_roll      = tp_detId.roll();
-  // int tp_layer     = tp_detId.layer();
+  //int tp_layer     = tp_detId.layer();
   int tp_chamber   = tp_detId.chamber();
 
   int tp_bx        = tp_data.bx;

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveSelection.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveSelection.cc
@@ -74,23 +74,23 @@ void PrimitiveSelection::process(
 
     if (selected_csc >= 0) {
       if (not(selected_csc < NUM_CSC_CHAMBERS))
-	{ edm::LogError("L1T") << "selected_csc = " << selected_csc << ", NUM_CSC_CHAMBERS = " << NUM_CSC_CHAMBERS; return; }
-      
+        { edm::LogError("L1T") << "selected_csc = " << selected_csc << ", NUM_CSC_CHAMBERS = " << NUM_CSC_CHAMBERS; return; }
+
       if (selected_csc_map[selected_csc].size() < 2) {
-	selected_csc_map[selected_csc].push_back(new_tp);
+        selected_csc_map[selected_csc].push_back(new_tp);
       }
       else {
-	edm::LogWarning("L1T") << "\n******************* EMTF EMULATOR: SUPER-BIZZARE CASE *******************";
-	edm::LogWarning("L1T") << "Found 3 CSC trigger primitives in the same chamber";
-	for (int ii = 0; ii < 3; ii++) {
-	  TriggerPrimitive tp_err = (ii < 2 ? selected_csc_map[selected_csc].at(ii) : new_tp);
-	  edm::LogWarning("L1T") << "LCT #" << ii+1 << ": BX " << tp_err.getBX() 
-		    << ", endcap " << tp_err.detId<CSCDetId>().endcap() << ", sector " << tp_err.detId<CSCDetId>().triggerSector()
-		    << ", station " << tp_err.detId<CSCDetId>().station() << ", ring " << tp_err.detId<CSCDetId>().ring()
-		    << ", chamber " << tp_err.detId<CSCDetId>().chamber() << ", CSC ID " << tp_err.getCSCData().cscID
-		    << ": strip " << tp_err.getStrip() << ", wire " << tp_err.getWire();
-	}
-	edm::LogWarning("L1T") << "************************* ONLY KEEP FIRST TWO *************************\n\n";
+        edm::LogWarning("L1T") << "\n******************* EMTF EMULATOR: SUPER-BIZZARE CASE *******************";
+        edm::LogWarning("L1T") << "Found 3 CSC trigger primitives in the same chamber";
+        for (int ii = 0; ii < 3; ii++) {
+          TriggerPrimitive tp_err = (ii < 2 ? selected_csc_map[selected_csc].at(ii) : new_tp);
+          edm::LogWarning("L1T") << "LCT #" << ii+1 << ": BX " << tp_err.getBX()
+                    << ", endcap " << tp_err.detId<CSCDetId>().endcap() << ", sector " << tp_err.detId<CSCDetId>().triggerSector()
+                    << ", station " << tp_err.detId<CSCDetId>().station() << ", ring " << tp_err.detId<CSCDetId>().ring()
+                    << ", chamber " << tp_err.detId<CSCDetId>().chamber() << ", CSC ID " << tp_err.getCSCData().cscID
+                    << ": strip " << tp_err.getStrip() << ", wire " << tp_err.getWire();
+        }
+        edm::LogWarning("L1T") << "************************* ONLY KEEP FIRST TWO *************************\n\n";
       }
 
     } // End conditional: if (selected_csc >= 0)

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
@@ -73,9 +73,9 @@ void PtAssignment::process(
 
       // Check address packing / unpacking
       if (not( fabs(xmlpt - pt_assign_engine_->calculate_pt(track)) < 0.001 ) )
-	{ edm::LogWarning("L1T") << "EMTF pT assignment mismatch: xmlpt = " << xmlpt 
-				 << ", pt_assign_engine_->calculate_pt(track)) = " 
-				 << pt_assign_engine_->calculate_pt(track); }
+        { edm::LogWarning("L1T") << "EMTF pT assignment mismatch: xmlpt = " << xmlpt
+                                 << ", pt_assign_engine_->calculate_pt(track)) = "
+                                 << pt_assign_engine_->calculate_pt(track); }
 
       pt  = (xmlpt < 0.) ? 1. : xmlpt;  // Matt used fabs(-1) when mode is invalid
       pt *= pt_assign_engine_->scale_pt(pt, track.Mode());  // Multiply by some factor to achieve 90% efficiency at threshold

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine.cc
@@ -49,13 +49,13 @@ void PtAssignmentEngine::load(const L1TMuonEndCapForest *payload) {
     
   for (unsigned i = 0; i < allowedModes_.size(); ++i) {
     int mode = allowedModes_.at(i);
-    
+
     L1TMuonEndCapForest::DForestMap::const_iterator index = payload->forest_map_.find(mode); // associates mode to index
     if (index == payload->forest_map_.end())  continue;
-    
+
     forests_.at(mode).loadFromCondPayload(payload->forest_coll_[index->second]);
-    
-    double boostWeight_ = payload->forest_map_.find(mode+16)->second / 1000000.;  
+
+    double boostWeight_ = payload->forest_map_.find(mode+16)->second / 1000000.;
     // std::cout << "Loaded forest for mode " << mode << " with boostWeight_ = " << boostWeight_ << std::endl;
     // std::cout << "  * ptLUTVersion_ = " << ptLUTVersion_ << std::endl;
     forests_.at(mode).getTree(0)->setBoostWeight( boostWeight_ );

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine2016.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine2016.cc
@@ -705,4 +705,4 @@ float PtAssignmentEngine2016::calculate_pt_xml(const EMTFTrack& track) const {
   float pt = 0.;
 
   return pt;
-} 
+}

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine2017.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine2017.cc
@@ -21,7 +21,7 @@ float PtAssignmentEngine2017::scale_pt(const float pt, const int mode) const {
   // Scaling to achieve 90% efficency at any given L1 pT threshold
   // For now, a linear scaling based on SingleMu-quality (modes 11, 13, 14, 15), CSC+RPC tracks
   // Should maybe scale each mode differently in the future - AWB 31.05.17
-  
+
   // TRG       = (1.2 + 0.015*TRG) * XML
   // TRG       = 1.2*XML / (1 - 0.015*XML)
   // TRG / XML = 1.2 / (1 - 0.015*XML)
@@ -55,7 +55,7 @@ PtAssignmentEngine::address_t PtAssignmentEngine2017::calculate_address(const EM
     address_t address = 0;
 
     EMTFPtLUT data = track.PtLUT();
-    
+
     int mode   = track.Mode();
     int theta  = track.Theta_fp();
     int endcap = track.Endcap();
@@ -88,7 +88,7 @@ PtAssignmentEngine::address_t PtAssignmentEngine2017::calculate_address(const EM
     iBC = (iB >= 0 && iC >= 0) ? iB + iC             : -1;
     iCD = (iC >= 0 && iD >= 0) ? 5                   : -1;
 
-    
+
     // Fill variable info from pT LUT data
     int st1_ring2, dTheta;
     int dPhiAB, dPhiBC, dPhiCD;
@@ -156,7 +156,7 @@ PtAssignmentEngine::address_t PtAssignmentEngine2017::calculate_address(const EM
       theta  = aux().getTheta     ( theta, st1_ring2, 5 );
     }
 
-    
+
     // Form the pT LUT address
     if      (nHits == 4) {
       address |= (dPhiAB    & ((1<<7)-1)) << (0);
@@ -178,8 +178,8 @@ PtAssignmentEngine::address_t PtAssignmentEngine2017::calculate_address(const EM
       address |= (dTheta    & ((1<<3)-1)) << (0+7+5+1);
       address |= (frA       & ((1<<1)-1)) << (0+7+5+1+3);
       int bit = 0;
-      if (mode != 7) { 
-	address |= (frB     & ((1<<1)-1)) << (0+7+5+1+3+1); bit = 1;
+      if (mode != 7) {
+        address |= (frB     & ((1<<1)-1)) << (0+7+5+1+3+1); bit = 1;
       }
       address |= (clctA     & ((1<<2)-1)) << (0+7+5+1+3+1+bit);
       address |= (rpc_2b    & ((1<<2)-1)) << (0+7+5+1+3+1+bit+2);
@@ -193,8 +193,8 @@ PtAssignmentEngine::address_t PtAssignmentEngine2017::calculate_address(const EM
 	if (not(address < pow(2, 27) && address >= pow(2, 26)))
 	  { edm::LogError("L1T") << "address = " << address; return 0; }
       }
-    } 
-    else if (nHits == 2) { 
+    }
+    else if (nHits == 2) {
       address |= (dPhiAB    & ((1<<7)-1)) << (0);
       address |= (dTheta    & ((1<<3)-1)) << (0+7);
       address |= (frA       & ((1<<1)-1)) << (0+7+3);
@@ -228,10 +228,10 @@ float PtAssignmentEngine2017::calculate_pt_xml(const address_t& address) const {
     { edm::LogError("L1T") << "address = " << address; return 0; }
   if      (address >= pow(2, 29)) { nHits = 4; mode = 15; }
   else if (address >= pow(2, 27)) { nHits = 3;            }
-  else if (address >= pow(2, 26)) { nHits = 3; mode =  7; } 
+  else if (address >= pow(2, 26)) { nHits = 3; mode =  7; }
   else if (address >= pow(2, 24)) { nHits = 2;            }
   else return pt_xml;
-  
+
   // Variables to unpack from the pT LUT address
   int mode_ID, theta, dTheta;
   int dPhiAB, dPhiBC = -1, dPhiCD = -1;
@@ -242,33 +242,33 @@ float PtAssignmentEngine2017::calculate_pt_xml(const address_t& address) const {
   int endcap = 1; sPhiAB = 1;  // Assume positive endcap and dPhiAB for unpacking CLCT bend
   int mode15_8b = -1; // Combines track theta, stations with RPC hits, and station 1 bend information
   int rpc_2b = -1; // Identifies which stations have RPC hits in 3-station tracks
-  
-  
+
+
   // Unpack variable words from the pT LUT address
   if      (nHits == 4) {
-    dPhiAB    = (address >> (0) 		& ((1<<7)-1));
-    dPhiBC    = (address >> (0+7) 		& ((1<<5)-1));
-    dPhiCD    = (address >> (0+7+5) 		& ((1<<4)-1));
+    dPhiAB    = (address >> (0)                 & ((1<<7)-1));
+    dPhiBC    = (address >> (0+7)               & ((1<<5)-1));
+    dPhiCD    = (address >> (0+7+5)             & ((1<<4)-1));
     sPhiBC    = (address >> (0+7+5+4)           & ((1<<1)-1));
     sPhiCD    = (address >> (0+7+5+4+1)         & ((1<<1)-1));
     dTheta    = (address >> (0+7+5+4+1+1)       & ((1<<2)-1));
-    frA       = (address >> (0+7+5+4+1+1+2) 	& ((1<<1)-1));
+    frA       = (address >> (0+7+5+4+1+1+2)     & ((1<<1)-1));
     mode15_8b = (address >> (0+7+5+4+1+1+2+1)   & ((1<<8)-1));
     mode_ID   = (address >> (0+7+5+4+1+1+2+1+8) & ((1<<1)-1));
     if (not(address < pow(2, 30)))
       { edm::LogError("L1T") << "address = " << address; return 0; }
   } 
   else if (nHits == 3) {
-    dPhiAB    = (address >> (0)	                    & ((1<<7)-1));
-    dPhiBC    = (address >> (0+7)	            & ((1<<5)-1));
-    sPhiBC    = (address >> (0+7+5)	            & ((1<<1)-1));
-    dTheta    = (address >> (0+7+5+1)	            & ((1<<3)-1));
+    dPhiAB    = (address >> (0)                     & ((1<<7)-1));
+    dPhiBC    = (address >> (0+7)                   & ((1<<5)-1));
+    sPhiBC    = (address >> (0+7+5)                 & ((1<<1)-1));
+    dTheta    = (address >> (0+7+5+1)               & ((1<<3)-1));
     frA       = (address >> (0+7+5+1+3)             & ((1<<1)-1));
     int bit = 0;
-    if (mode != 7) { 
+    if (mode != 7) {
       frB     = (address >> (0+7+5+1+3+1)           & ((1<<1)-1)); bit = 1;
     }
-    clctA     = (address >> (0+7+5+1+3+1+bit)	    & ((1<<2)-1));
+    clctA     = (address >> (0+7+5+1+3+1+bit)       & ((1<<2)-1));
     rpc_2b    = (address >> (0+7+5+1+3+1+bit+2)     & ((1<<2)-1));
     theta     = (address >> (0+7+5+1+3+1+bit+2+2)   & ((1<<5)-1));
     if (mode != 7) {
@@ -281,12 +281,12 @@ float PtAssignmentEngine2017::calculate_pt_xml(const address_t& address) const {
 	{ edm::LogError("L1T") << "address = " << address; return 0; }
     }
   }
-  else if (nHits == 2) { 
+  else if (nHits == 2) {
     dPhiAB    = (address >> (0)               & ((1<<7)-1));
-    dTheta    = (address >> (0+7)	      & ((1<<3)-1));
-    frA       = (address >> (0+7+3)	      & ((1<<1)-1));
-    frB       = (address >> (0+7+3+1)	      & ((1<<1)-1));
-    clctA     = (address >> (0+7+3+1+1)	      & ((1<<3)-1));
+    dTheta    = (address >> (0+7)             & ((1<<3)-1));
+    frA       = (address >> (0+7+3)           & ((1<<1)-1));
+    frB       = (address >> (0+7+3+1)         & ((1<<1)-1));
+    clctA     = (address >> (0+7+3+1+1)       & ((1<<3)-1));
     clctB     = (address >> (0+7+3+1+1+3)     & ((1<<3)-1));
     theta     = (address >> (0+7+3+1+1+3+3)   & ((1<<5)-1));
     mode_ID   = (address >> (0+7+3+1+1+3+3+5) & ((1<<3)-1));
@@ -334,7 +334,7 @@ float PtAssignmentEngine2017::calculate_pt_xml(const address_t& address) const {
     dPhiBC    = aux().getdPhiFromBin( dPhiBC, 5, 256 ) * (sPhiBC == 1 ? 1 : -1);
     St1_ring2 = aux().unpackSt1Ring2( theta, 5 );
     aux().unpack2bRPC    ( rpc_2b, rpcA, rpcB, rpcC );
-    
+
     // // Check bit-wise compression / de-compression
     // if (not( dTheta == aux().getdTheta( aux().unpackdTheta( dTheta, 3), 3) );
     // { edm::LogError("L1T") << " = " << ; return; }
@@ -368,39 +368,39 @@ float PtAssignmentEngine2017::calculate_pt_xml(const address_t& address) const {
   // Fill vectors of variables for XMLs
   // KK: sequence of variables here should exaclty match <Variables> block produced by TMVA
   std::vector<int> predictors;
-  
+
   // Variables for input to XMLs
   int dPhiSum4, dPhiSum4A, dPhiSum3, dPhiSum3A, outStPhi;
 
   // Convert words into variables for XMLs
   if      (nHits == 4) {
-    predictors = { theta, St1_ring2, dPhiAB, dPhiBC, dPhiCD, dPhiAB + dPhiBC, 
-		   dPhiAB + dPhiBC + dPhiCD, dPhiBC + dPhiCD, frA, clctA };
+    predictors = { theta, St1_ring2, dPhiAB, dPhiBC, dPhiCD, dPhiAB + dPhiBC,
+                   dPhiAB + dPhiBC + dPhiCD, dPhiBC + dPhiCD, frA, clctA };
 
     CalcDeltaPhiSums( dPhiSum4, dPhiSum4A, dPhiSum3, dPhiSum3A, outStPhi,
-                      dPhiAB, dPhiAB + dPhiBC, dPhiAB + dPhiBC + dPhiCD, 
-		      dPhiBC, dPhiBC + dPhiCD, dPhiCD );
+                      dPhiAB, dPhiAB + dPhiBC, dPhiAB + dPhiBC + dPhiCD,
+                      dPhiBC, dPhiBC + dPhiCD, dPhiCD );
 
     int tmp[10] = {dPhiSum4, dPhiSum4A, dPhiSum3, dPhiSum3A, outStPhi, dTheta, rpcA, rpcB, rpcC, rpcD };
     predictors.insert( predictors.end(), tmp, tmp+10 );
   }
   else if (nHits == 3) {
-    if      (mode == 14) 
-      predictors = { theta, St1_ring2, dPhiAB, dPhiBC, dPhiAB + dPhiBC, 
-		     frA, frB, clctA, dTheta, rpcA, rpcB, rpcC };
+    if      (mode == 14)
+      predictors = { theta, St1_ring2, dPhiAB, dPhiBC, dPhiAB + dPhiBC,
+                     frA, frB, clctA, dTheta, rpcA, rpcB, rpcC };
     else if (mode == 13)
-      predictors = { theta, St1_ring2, dPhiAB, dPhiAB + dPhiBC, dPhiBC, 
-		     frA, frB, clctA, dTheta, rpcA, rpcB, rpcC };
+      predictors = { theta, St1_ring2, dPhiAB, dPhiAB + dPhiBC, dPhiBC,
+                     frA, frB, clctA, dTheta, rpcA, rpcB, rpcC };
     else if (mode == 11)
       predictors = { theta, St1_ring2, dPhiBC, dPhiAB, dPhiAB + dPhiBC,
-		     frA, frB, clctA, dTheta, rpcA, rpcB, rpcC };
+                     frA, frB, clctA, dTheta, rpcA, rpcB, rpcC };
     else if (mode ==  7)
-      predictors = { theta,            dPhiAB, dPhiBC, dPhiAB + dPhiBC, 
-		     frA,      clctA, dTheta, rpcA, rpcB, rpcC };
+      predictors = { theta,            dPhiAB, dPhiBC, dPhiAB + dPhiBC,
+                     frA,      clctA, dTheta, rpcA, rpcB, rpcC };
   }
   else if (nHits == 2 && mode >= 8) {
     predictors = { theta, St1_ring2, dPhiAB, frA, frB, clctA, clctB, dTheta, (clctA == 0), (clctB == 0) };
-  } 
+  }
   else if (nHits == 2 && mode <  8) {
     predictors = { theta,            dPhiAB, frA, frB, clctA, clctB, dTheta, (clctA == 0), (clctB == 0) };
   }
@@ -409,15 +409,15 @@ float PtAssignmentEngine2017::calculate_pt_xml(const address_t& address) const {
 
   // Retreive pT from XMLs
   std::vector<double> tree_data(predictors.cbegin(),predictors.cend());
-  
+
   auto tree_event = std::make_unique<emtf::Event>();
   tree_event->predictedValue = 0;
   tree_event->data = tree_data;
-  
+
   // forests_.at(mode).predictEvent(tree_event.get(), 400);
   emtf::Forest &forest = const_cast<emtf::Forest&>(forests_.at(mode));
   forest.predictEvent(tree_event.get(), 400);
-  
+
   // // Adjust this for different XMLs
   // float log2_pt = tree_event->predictedValue;
   // pt_xml = pow(2, fmax(0.0, log2_pt)); // Protect against negative values
@@ -429,13 +429,13 @@ float PtAssignmentEngine2017::calculate_pt_xml(const address_t& address) const {
 
 } // End function: float PtAssignmentEngine2017::calculate_pt_xml(const address_t& address)
 
-  
+
 // Calculate XML pT directly from track quantities, without forming an address
 float PtAssignmentEngine2017::calculate_pt_xml(const EMTFTrack& track) const {
   float pt_xml = 0.;
-  
+
   EMTFPtLUT data = track.PtLUT();
-  
+
   auto contain = [](const std::vector<int>& vec, int elem) {
     return (std::find(vec.begin(), vec.end(), elem) != vec.end());
   };
@@ -452,7 +452,7 @@ float PtAssignmentEngine2017::calculate_pt_xml(const EMTFTrack& track) const {
   int st2 = ((mode % 8) >= 4);
   int st3 = ((mode % 4) >= 2);
   int st4 = ((mode % 2) == 1);
-  
+
   // Variables for input to XMLs
   int dPhi_12, dPhi_13, dPhi_14, dPhi_23, dPhi_24, dPhi_34, dPhiSign;
   int dPhiSum4, dPhiSum4A, dPhiSum3, dPhiSum3A, outStPhi;
@@ -461,11 +461,11 @@ float PtAssignmentEngine2017::calculate_pt_xml(const EMTFTrack& track) const {
   int bend_1, bend_2, bend_3, bend_4;
   int RPC_1, RPC_2, RPC_3, RPC_4;
   int St1_ring2 = data.st1_ring2;
-  
+
   int  ph1 = -99,  ph2 = -99,  ph3 = -99,  ph4 = -99;
   int  th1 = -99,  th2 = -99,  th3 = -99,  th4 = -99;
   int pat1 = -99, pat2 = -99, pat3 = -99, pat4 = -99;
-  
+
   // Compute the original phi and theta coordinates
   if        (st2) {
     ph2 = phi;   // Track phi is from station 2 (if it exists), otherwise 3 or 4
@@ -476,13 +476,13 @@ float PtAssignmentEngine2017::calculate_pt_xml(const EMTFTrack& track) const {
     // Important that phi be from adjacent station pairs (see note below)
     if (st3 && st4) ph4 = ph3 + data.delta_ph[5]*(data.sign_ph[5] ? 1 : -1);
     else if   (st4) ph4 = ph2 + data.delta_ph[4]*(data.sign_ph[4] ? 1 : -1);
-    // Important that theta be from first-last station pair, not adjacent pairs: delta_th values are "best" for each pair, but 
+    // Important that theta be from first-last station pair, not adjacent pairs: delta_th values are "best" for each pair, but
     // thanks to duplicated CSC LCTs, are not necessarily consistent (or physical) between pairs or between delta_th and delta_ph.
     // This is an artifact of the firmware implementation of deltas: see src/AngleCalculation.cc.
     if (st1 && st3) th3 = th1 + data.delta_th[1]*(data.sign_th[1] ? 1 : -1);
     else if   (st3) th3 = th2 + data.delta_th[3]*(data.sign_th[3] ? 1 : -1);
-    if (st1 && st4) th4 = th1 + data.delta_th[2]*(data.sign_th[2] ? 1 : -1); 
-    else if   (st4) th4 = th2 + data.delta_th[4]*(data.sign_th[4] ? 1 : -1); 
+    if (st1 && st4) th4 = th1 + data.delta_th[2]*(data.sign_th[2] ? 1 : -1);
+    else if   (st4) th4 = th2 + data.delta_th[4]*(data.sign_th[4] ? 1 : -1);
   } else if (st3) {
     ph3 = phi;
     th3 = theta;
@@ -506,40 +506,40 @@ float PtAssignmentEngine2017::calculate_pt_xml(const EMTFTrack& track) const {
   // BEGIN: Identical (almost) to BDT training code in EMTFPtAssign2017/PtRegression_Apr_2017.C
 
   theta = CalcTrackTheta( th1, th2, th3, th4, St1_ring2, mode, true );
-  
+
   CalcDeltaPhis( dPhi_12, dPhi_13, dPhi_14, dPhi_23, dPhi_24, dPhi_34, dPhiSign,
-		 dPhiSum4, dPhiSum4A, dPhiSum3, dPhiSum3A, outStPhi,
-		 ph1, ph2, ph3, ph4, mode, true );
-  
+                 dPhiSum4, dPhiSum4A, dPhiSum3, dPhiSum3A, outStPhi,
+                 ph1, ph2, ph3, ph4, mode, true );
+
   CalcDeltaThetas( dTh_12, dTh_13, dTh_14, dTh_23, dTh_24, dTh_34,
-		   th1, th2, th3, th4, mode, true );
-  
+                   th1, th2, th3, th4, mode, true );
+
   FR_1 = (st1 ? data.fr[0] : -99);
   FR_2 = (st2 ? data.fr[1] : -99);
   FR_3 = (st3 ? data.fr[2] : -99);
   FR_4 = (st4 ? data.fr[3] : -99);
-  
+
   CalcBends( bend_1, bend_2, bend_3, bend_4,
-	     pat1, pat2, pat3, pat4,
-	     dPhiSign, endcap, mode, true );
-  
+             pat1, pat2, pat3, pat4,
+             dPhiSign, endcap, mode, true );
+
   RPC_1 = (st1 ? (pat1 == 0) : -99);
   RPC_2 = (st2 ? (pat2 == 0) : -99);
   RPC_3 = (st3 ? (pat3 == 0) : -99);
   RPC_4 = (st4 ? (pat4 == 0) : -99);
 
   CalcRPCs( RPC_1, RPC_2, RPC_3, RPC_4, mode, St1_ring2, theta, true );
-  
+
   // END: Identical (almost) to BDT training code in EMTFPtAssign2017/PtRegression_Apr_2017.C
-  
-  
+
+
   // Fill vectors of variables for XMLs
   // KK: sequence of variables here should exaclty match <Variables> block produced by TMVA
   std::vector<int> predictors;
   switch (mode) {
   case 15: // 1-2-3-4
     predictors = { theta, St1_ring2, dPhi_12, dPhi_23, dPhi_34, dPhi_13, dPhi_14, dPhi_24, FR_1, bend_1,
-		   dPhiSum4, dPhiSum4A, dPhiSum3, dPhiSum3A, outStPhi, dTh_14, RPC_1, RPC_2, RPC_3, RPC_4 };
+                   dPhiSum4, dPhiSum4A, dPhiSum3, dPhiSum3A, outStPhi, dTh_14, RPC_1, RPC_2, RPC_3, RPC_4 };
     break;
   case 14: // 1-2-3
     predictors = { theta, St1_ring2, dPhi_12, dPhi_23, dPhi_13, FR_1, FR_2, bend_1, dTh_13, RPC_1, RPC_2, RPC_3 }; break;
@@ -547,7 +547,7 @@ float PtAssignmentEngine2017::calculate_pt_xml(const EMTFTrack& track) const {
     predictors = { theta, St1_ring2, dPhi_12, dPhi_14, dPhi_24, FR_1, FR_2, bend_1, dTh_14, RPC_1, RPC_2, RPC_4 }; break;
   case 11: // 1-3-4
     predictors = { theta, St1_ring2, dPhi_34, dPhi_13, dPhi_14, FR_1, FR_3, bend_1, dTh_14, RPC_1, RPC_3, RPC_4 }; break;
-  case  7: // 2-3-4                  
+  case  7: // 2-3-4
     predictors = { theta,            dPhi_23, dPhi_34, dPhi_24, FR_2,       bend_2, dTh_24, RPC_2, RPC_3, RPC_4 }; break;
   case 12: // 1-2
     predictors = { theta, St1_ring2, dPhi_12, FR_1, FR_2, bend_1, bend_2, dTh_12, RPC_1, RPC_2 }; break;
@@ -564,15 +564,15 @@ float PtAssignmentEngine2017::calculate_pt_xml(const EMTFTrack& track) const {
   }
 
   std::vector<double> tree_data(predictors.cbegin(),predictors.cend());
-  
+
   auto tree_event = std::make_unique<emtf::Event>();
   tree_event->predictedValue = 0;
   tree_event->data = tree_data;
-  
+
   // forests_.at(mode).predictEvent(tree_event.get(), 400);
   emtf::Forest &forest = const_cast<emtf::Forest&>(forests_.at(mode));
   forest.predictEvent(tree_event.get(), 400);
-  
+
   // // Adjust this for different XMLs
   // float log2_pt = tree_event->predictedValue;
   // pt_xml = pow(2, fmax(0.0, log2_pt)); // Protect against negative values

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineAux2017.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineAux2017.cc
@@ -14,18 +14,18 @@
 static const int dPhiNLBMap_4bit_256Max[16] = {0, 1, 2, 3, 4, 6, 8, 10, 12, 16, 20, 25, 31, 46, 68, 136};
 
 // For use in dPhi23, dPhi24, and dPhi34 in 3- and 4-station modes (7, 11, 13, 14, 15), except for dPhi23 in mode 7 and dPhi34 in mode 15
-static const int dPhiNLBMap_5bit_256Max[32] = { 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 
-					       16, 17, 19, 20, 21, 23, 25, 28, 31, 34, 39, 46, 55, 68, 91, 136};
+static const int dPhiNLBMap_5bit_256Max[32] = { 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+                                               16, 17, 19, 20, 21, 23, 25, 28, 31, 34, 39, 46, 55, 68, 91, 136};
 // 512 max units----
 // For use in all dPhiAB (where "A" and "B" are the first two stations in the track) in all modes
-static const int dPhiNLBMap_7bit_512Max[128] =  {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15, 
-						  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31, 
-						  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47, 
-						  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63, 
-						  64,  65,  66,  67,  68,  69,  71,  72,  73,  74,  75,  76,  77,  79,  80,  81, 
-						  83,  84,  86,  87,  89,  91,  92,  94,  96,  98, 100, 102, 105, 107, 110, 112, 
-						 115, 118, 121, 124, 127, 131, 135, 138, 143, 147, 152, 157, 162, 168, 174, 181, 
-						 188, 196, 204, 214, 224, 235, 247, 261, 276, 294, 313, 336, 361, 391, 427, 470};
+static const int dPhiNLBMap_7bit_512Max[128] =  {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,
+                                                  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,
+                                                  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,
+                                                  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,
+                                                  64,  65,  66,  67,  68,  69,  71,  72,  73,  74,  75,  76,  77,  79,  80,  81,
+                                                  83,  84,  86,  87,  89,  91,  92,  94,  96,  98, 100, 102, 105, 107, 110, 112,
+                                                 115, 118, 121, 124, 127, 131, 135, 138, 143, 147, 152, 157, 162, 168, 174, 181,
+                                                 188, 196, 204, 214, 224, 235, 247, 261, 276, 294, 313, 336, 361, 391, 427, 470};
 
 
 int PtAssignmentEngineAux2017::getNLBdPhi(int dPhi, int bits, int max) const {
@@ -44,8 +44,8 @@ int PtAssignmentEngineAux2017::getNLBdPhi(int dPhi, int bits, int max) const {
     if (bits == 4) {
       dPhi_ = dPhiNLBMap_4bit_256Max[(1 << bits) - 1];
       for (int edge = 0; edge < (1 << bits) - 1; edge++) {
-        if (dPhiNLBMap_4bit_256Max[edge]  <= dPhi && 
-	    dPhiNLBMap_4bit_256Max[edge+1] > dPhi) {
+        if (dPhiNLBMap_4bit_256Max[edge]  <= dPhi &&
+            dPhiNLBMap_4bit_256Max[edge+1] > dPhi) {
           dPhi_ = dPhiNLBMap_4bit_256Max[edge];
           break;
         }
@@ -54,8 +54,8 @@ int PtAssignmentEngineAux2017::getNLBdPhi(int dPhi, int bits, int max) const {
     if (bits == 5) {
       dPhi_ = dPhiNLBMap_5bit_256Max[(1 << bits) - 1];
       for (int edge = 0; edge < (1 << bits) - 1; edge++) {
-        if (dPhiNLBMap_5bit_256Max[edge]  <= dPhi && 
-	    dPhiNLBMap_5bit_256Max[edge+1] > dPhi) {
+        if (dPhiNLBMap_5bit_256Max[edge]  <= dPhi &&
+            dPhiNLBMap_5bit_256Max[edge+1] > dPhi) {
           dPhi_ = dPhiNLBMap_5bit_256Max[edge];
           break;
         }
@@ -67,8 +67,8 @@ int PtAssignmentEngineAux2017::getNLBdPhi(int dPhi, int bits, int max) const {
     if (bits == 7) {
       dPhi_ = dPhiNLBMap_7bit_512Max[(1 << bits) - 1];
       for (int edge = 0; edge < (1 << bits) - 1; edge++) {
-        if (dPhiNLBMap_7bit_512Max[edge]  <= dPhi && 
-	    dPhiNLBMap_7bit_512Max[edge+1] > dPhi) {
+        if (dPhiNLBMap_7bit_512Max[edge]  <= dPhi &&
+            dPhiNLBMap_7bit_512Max[edge+1] > dPhi) {
           dPhi_ = dPhiNLBMap_7bit_512Max[edge];
           break;
         }
@@ -93,12 +93,12 @@ int PtAssignmentEngineAux2017::getNLBdPhiBin(int dPhi, int bits, int max) const 
   if (dPhi < 0)
     sign_ = -1;
   dPhi = sign_ * dPhi;
-  
+
   if (max == 256) {
     if (bits == 4) {
       for (int edge = 0; edge < (1 << bits) - 1; edge++) {
-        if (dPhiNLBMap_4bit_256Max[edge] <= dPhi && 
-	    dPhiNLBMap_4bit_256Max[edge+1] > dPhi) {
+        if (dPhiNLBMap_4bit_256Max[edge] <= dPhi &&
+            dPhiNLBMap_4bit_256Max[edge+1] > dPhi) {
           dPhiBin_ = edge;
           break;
         }
@@ -106,20 +106,20 @@ int PtAssignmentEngineAux2017::getNLBdPhiBin(int dPhi, int bits, int max) const 
     } // End conditional: if (bits == 4)
     if (bits == 5) {
       for (int edge = 0; edge < (1 << bits) - 1; edge++) {
-        if (dPhiNLBMap_5bit_256Max[edge]  <= dPhi && 
-	    dPhiNLBMap_5bit_256Max[edge+1] > dPhi) {
+        if (dPhiNLBMap_5bit_256Max[edge]  <= dPhi &&
+            dPhiNLBMap_5bit_256Max[edge+1] > dPhi) {
           dPhiBin_ = edge;
           break;
         }
       }
-    } // End conditional: if (bits == 5) 
+    } // End conditional: if (bits == 5)
   } // End conditional: if (max == 256)
 
   else if (max == 512) {
     if (bits == 7) {
       for (int edge = 0; edge < (1 << bits) - 1; edge++) {
-        if (dPhiNLBMap_7bit_512Max[edge]  <= dPhi && 
-	    dPhiNLBMap_7bit_512Max[edge+1] > dPhi) {
+        if (dPhiNLBMap_7bit_512Max[edge]  <= dPhi &&
+            dPhiNLBMap_7bit_512Max[edge+1] > dPhi) {
           dPhiBin_ = edge;
           break;
         }
@@ -143,7 +143,7 @@ int PtAssignmentEngineAux2017::getdPhiFromBin(int dPhiBin, int bits, int max) co
 
   if (dPhiBin > (1 << bits) - 1)
     dPhiBin = (1 << bits) - 1;
-  
+
   if (max == 256) {
     if (bits == 4)
       dPhi_ = dPhiNLBMap_4bit_256Max[dPhiBin];
@@ -164,8 +164,8 @@ int PtAssignmentEngineAux2017::getdPhiFromBin(int dPhiBin, int bits, int max) co
 
 int PtAssignmentEngineAux2017::getCLCT(int clct, int endcap, int dPhiSign, int bits) const {
 
-  // std::cout << "Inside getCLCT: clct = " << clct << ", endcap = " << endcap 
-  // 	    << ", dPhiSign = " << dPhiSign << ", bits = " << bits << std::endl;
+  // std::cout << "Inside getCLCT: clct = " << clct << ", endcap = " << endcap
+  //             << ", dPhiSign = " << dPhiSign << ", bits = " << bits << std::endl;
 
   if (not( clct >= 0 && clct <= 10 && abs(endcap) == 1 && 
 	   abs(dPhiSign) == 1 && (bits == 2 || bits == 3) ))
@@ -179,7 +179,7 @@ int PtAssignmentEngineAux2017::getCLCT(int clct, int endcap, int dPhiSign, int b
   // CLCT pattern can be converted into |bend| x sign as follows:
   // |bend| = (10 + (pattern % 2) - pattern) / 2
   //   * 10 --> 0, 9/8 --> 1, 7/6 --> 2, 5/4 --> 3, 3/2 --> 4, 0 indicates RPC hit
-  //  sign  = ((pattern % 2) == 1 ? -1 : 1) * (endcap == 1 ? -1 : 1)   
+  //  sign  = ((pattern % 2) == 1 ? -1 : 1) * (endcap == 1 ? -1 : 1)
   //   * In ME+, even CLCTs have negative sign, odd CLCTs have positive
 
   // For use in all 3- and 4-station modes (7, 11, 13, 14, 15)
@@ -230,8 +230,8 @@ int PtAssignmentEngineAux2017::getCLCT(int clct, int endcap, int dPhiSign, int b
 
 int PtAssignmentEngineAux2017::unpackCLCT(int clct, int endcap, int dPhiSign, int bits) const {
 
-  // std::cout << "Inside unpackCLCT: clct = " << clct << ", endcap = " << endcap 
-  // 	    << ", dPhiSign = " << dPhiSign << ", bits = " << bits << std::endl;
+  // std::cout << "Inside unpackCLCT: clct = " << clct << ", endcap = " << endcap
+  //             << ", dPhiSign = " << dPhiSign << ", bits = " << bits << std::endl;
 
   if (not(bits == 2 || bits == 3))
   { edm::LogError("L1T") << "bits = " << bits; return 0; }
@@ -251,7 +251,7 @@ int PtAssignmentEngineAux2017::unpackCLCT(int clct, int endcap, int dPhiSign, in
     case 3: clct_ = (sign_ > 0 ? 4 : 5); break;
     case 0: clct_ =  0;                  break;
     default: break;
-    } 
+    }
   } else if (bits == 3) {
     switch (clct) {
     case 4: clct_ = 10;                  break;
@@ -365,14 +365,14 @@ int PtAssignmentEngineAux2017::getTheta(int theta, int st1_ring2, int bits) cons
     if (st1_ring2 == 0) {
       // Should rarely fail ... should change to using ME1 for track theta - AWB 05.06.17
       if (theta > 52) {
-	// std::cout << "\n\n*** Bizzare case of mode 15 track with ME1/1 LCT and track theta = " << theta << std::endl;
-      }     
+        // std::cout << "\n\n*** Bizzare case of mode 15 track with ME1/1 LCT and track theta = " << theta << std::endl;
+      }
       theta_ = (std::min( std::max(theta, 5), 52) - 5) / 6;
     }
     else if (st1_ring2 == 1) {
       // Should rarely fail ... should change to using ME1 for track theta - AWB 05.06.17
       if (theta < 46 || theta > 87) {
-	// std::cout << "\n\n*** Bizzare case of mode 15 track with ME1/2 LCT and track theta = " << theta << std::endl;
+        // std::cout << "\n\n*** Bizzare case of mode 15 track with ME1/2 LCT and track theta = " << theta << std::endl;
       }
       theta_ = ((std::min( std::max(theta, 46), 87) - 46) / 7) + 8;
     }
@@ -447,10 +447,10 @@ int PtAssignmentEngineAux2017::get2bRPC(int clctA, int clctB, int clctC) const {
 
   int rpc_2b = -99;
 
-  if      (clctA == 0) rpc_2b = 0; 
-  else if (clctC == 0) rpc_2b = 1; 
-  else if (clctB == 0) rpc_2b = 2; 
-  else                 rpc_2b = 3; 
+  if      (clctA == 0) rpc_2b = 0;
+  else if (clctC == 0) rpc_2b = 1;
+  else if (clctB == 0) rpc_2b = 2;
+  else                 rpc_2b = 3;
 
   if (not(rpc_2b >= 0 && rpc_2b < 4))
   { edm::LogError("L1T") << "rpc_2b = " << rpc_2b; return 0; }
@@ -473,10 +473,10 @@ void PtAssignmentEngineAux2017::unpack2bRPC(int rpc_2b, int& rpcA, int& rpcB, in
 
 
 int PtAssignmentEngineAux2017::get8bMode15(int theta, int st1_ring2, int endcap, int sPhiAB,
-					   int clctA, int clctB, int clctC, int clctD) const {
+                                           int clctA, int clctB, int clctC, int clctD) const {
 
-  // std::cout << "Inside get8bMode15, theta = " << theta << ", st1_ring2 = " << st1_ring2 << ", endcap = " << endcap << ", sPhiAB = " << sPhiAB 
-  // 	    << ", clctA = " << clctA << ", clctB = " << clctB << ", clctC = " << clctC << ", clctD = " << clctD << std::endl;
+  // std::cout << "Inside get8bMode15, theta = " << theta << ", st1_ring2 = " << st1_ring2 << ", endcap = " << endcap << ", sPhiAB = " << sPhiAB
+  //             << ", clctA = " << clctA << ", clctB = " << clctB << ", clctC = " << clctC << ", clctD = " << clctD << std::endl;
 
   if (st1_ring2) theta = (std::min( std::max(theta, 46), 87) - 46) / 7;
   else           theta = (std::min( std::max(theta,  5), 52) -  5) / 6;
@@ -484,28 +484,28 @@ int PtAssignmentEngineAux2017::get8bMode15(int theta, int st1_ring2, int endcap,
     { edm::LogError("L1T") << "theta = " << theta; return 0; }
   
   int clctA_2b = getCLCT(clctA, endcap, sPhiAB, 2);
-  
+
   int nRPC = (clctA == 0) + (clctB == 0) + (clctC == 0) + (clctD == 0);
   int rpc_word, rpc_clct, mode15_8b;
 
   if (st1_ring2) {
-    if      (nRPC >= 2 && clctA == 0 && clctB == 0) rpc_word =  0; 
-    else if (nRPC >= 2 && clctA == 0 && clctC == 0) rpc_word =  1; 
-    else if (nRPC >= 2 && clctA == 0 && clctD == 0) rpc_word =  2; 
-    else if (nRPC == 1 && clctA == 0              ) rpc_word =  3; 
-    else if (nRPC >= 2 && clctD == 0 && clctB == 0) rpc_word =  4; 
-    else if (nRPC >= 2 && clctD == 0 && clctC == 0) rpc_word =  8; 
-    else if (nRPC >= 2 && clctB == 0 && clctC == 0) rpc_word = 12; 
-    else if (nRPC == 1 && clctD == 0              ) rpc_word = 16; 
-    else if (nRPC == 1 && clctB == 0              ) rpc_word = 20; 
-    else if (nRPC == 1 && clctC == 0              ) rpc_word = 24; 
+    if      (nRPC >= 2 && clctA == 0 && clctB == 0) rpc_word =  0;
+    else if (nRPC >= 2 && clctA == 0 && clctC == 0) rpc_word =  1;
+    else if (nRPC >= 2 && clctA == 0 && clctD == 0) rpc_word =  2;
+    else if (nRPC == 1 && clctA == 0              ) rpc_word =  3;
+    else if (nRPC >= 2 && clctD == 0 && clctB == 0) rpc_word =  4;
+    else if (nRPC >= 2 && clctD == 0 && clctC == 0) rpc_word =  8;
+    else if (nRPC >= 2 && clctB == 0 && clctC == 0) rpc_word = 12;
+    else if (nRPC == 1 && clctD == 0              ) rpc_word = 16;
+    else if (nRPC == 1 && clctB == 0              ) rpc_word = 20;
+    else if (nRPC == 1 && clctC == 0              ) rpc_word = 24;
     else                                            rpc_word = 28;
     rpc_clct  = rpc_word + clctA_2b;
     mode15_8b = (theta*32) + rpc_clct + 64;
   } else {
-    if      (theta >= 4 && clctD == 0) rpc_word = 0; 
-    else if (theta >= 4 && clctC == 0) rpc_word = 1;             
-    else if (theta >= 4              ) rpc_word = 2;             
+    if      (theta >= 4 && clctD == 0) rpc_word = 0;
+    else if (theta >= 4 && clctC == 0) rpc_word = 1;
+    else if (theta >= 4              ) rpc_word = 2;
     else                               rpc_word = 3;
     rpc_clct  = rpc_word*4 + clctA_2b;
     mode15_8b = ((theta % 4)*16) + rpc_clct;
@@ -542,7 +542,7 @@ void PtAssignmentEngineAux2017::unpack8bMode15( int mode15_8b, int& theta, int& 
   if (st1_ring2) {
 
     rpc_clct = (mode15_8b % 32);
-    theta    = (mode15_8b - 64 - rpc_clct) / 32; 
+    theta    = (mode15_8b - 64 - rpc_clct) / 32;
     theta   += 8;
 
     if (rpc_clct < 4) clctA_2b = 0;
@@ -587,7 +587,7 @@ void PtAssignmentEngineAux2017::unpack8bMode15( int mode15_8b, int& theta, int& 
   }
 
   // std::cout << "  * Output theta = " << theta << ", st1_ring2 = " << st1_ring2 << ", clctA = " << clctA
-  // 	    << ", rpcA = " << rpcA << ", rpcB = " << rpcB << ", rpcC = " << rpcC << ", rpcD = " << rpcD << std::endl;
+  //             << ", rpcA = " << rpcA << ", rpcB = " << rpcB << ", rpcC = " << rpcC << ", rpcD = " << rpcD << std::endl;
 
   if (not(nRPC >= 0))
     { edm::LogError("L1T") << "nRPC = " << nRPC; return; }

--- a/L1Trigger/L1TMuonEndCap/src/PtLUTWriter.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtLUTWriter.cc
@@ -40,7 +40,7 @@ void PtLUTWriter::write(const std::string& lut_full_path, const uint16_t num_, c
     throw std::invalid_argument(what);
   }
 
-  if (num_ == 1) 
+  if (num_ == 1)
     ptlut_.at(0) = version_;  // address 0 is the pT LUT version number
 
   typedef uint64_t full_word_t;

--- a/L1Trigger/L1TMuonEndCap/src/PtLutVarCalc.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtLutVarCalc.cc
@@ -10,7 +10,7 @@ PtAssignmentEngineAux2017 ENG;
 
 
 int CalcTrackTheta( const int th1, const int th2, const int th3, const int th4,
-		    const int st1_ring2, const int mode, const bool BIT_COMP ) {
+                    const int st1_ring2, const int mode, const bool BIT_COMP ) {
 
   int theta = -99;
 
@@ -34,8 +34,8 @@ int CalcTrackTheta( const int th1, const int th2, const int th3, const int th4,
 
 
 void CalcDeltaPhis( int& dPh12, int& dPh13, int& dPh14, int& dPh23, int& dPh24, int& dPh34, int& dPhSign,
-		    int& dPhSum4, int& dPhSum4A, int& dPhSum3, int& dPhSum3A, int& outStPh,
-		    const int ph1, const int ph2, const int ph3, const int ph4, const int mode, const bool BIT_COMP ) {
+                    int& dPhSum4, int& dPhSum4A, int& dPhSum3, int& dPhSum3A, int& outStPh,
+                    const int ph1, const int ph2, const int ph3, const int ph4, const int mode, const bool BIT_COMP ) {
 
   dPh12 = ph2 - ph1;
   dPh13 = ph3 - ph1;
@@ -116,15 +116,15 @@ void CalcDeltaPhis( int& dPh12, int& dPh13, int& dPh14, int& dPh23, int& dPh24, 
 
   // Compute summed quantities
   if (mode == 15) CalcDeltaPhiSums( dPhSum4, dPhSum4A, dPhSum3, dPhSum3A, outStPh,
-				    dPh12,  dPh13,  dPh14,  dPh23,  dPh24,  dPh34 );
+                                    dPh12,  dPh13,  dPh14,  dPh23,  dPh24,  dPh34 );
 
 } // End function: CalcDeltaPhis()
 
 
 
 void CalcDeltaThetas( int& dTh12, int& dTh13, int& dTh14, int& dTh23, int& dTh24, int& dTh34,
-		      const int th1, const int th2, const int th3, const int th4, const int mode, const bool BIT_COMP ) {
-  
+                      const int th1, const int th2, const int th3, const int th4, const int mode, const bool BIT_COMP ) {
+
   dTh12 = th2 - th1;
   dTh13 = th3 - th1;
   dTh14 = th4 - th1;
@@ -148,14 +148,14 @@ void CalcDeltaThetas( int& dTh12, int& dTh13, int& dTh14, int& dTh23, int& dTh24
 
 
 void CalcBends( int& bend1, int& bend2, int& bend3, int& bend4,
-		const int pat1, const int pat2, const int pat3, const int pat4,
-		const int dPhSign, const int endcap, const int mode, const bool BIT_COMP ) {
+                const int pat1, const int pat2, const int pat3, const int pat4,
+                const int dPhSign, const int endcap, const int mode, const bool BIT_COMP ) {
 
   bend1 = CalcBendFromPattern( pat1, endcap );
   bend2 = CalcBendFromPattern( pat2, endcap );
   bend3 = CalcBendFromPattern( pat3, endcap );
   bend4 = CalcBendFromPattern( pat4, endcap );
-  
+
   if (BIT_COMP) {
     int nBits = 3;
     if (mode == 7 || mode == 11 || mode > 12)
@@ -170,11 +170,11 @@ void CalcBends( int& bend1, int& bend2, int& bend3, int& bend4,
     if ( (mode % 2)     > 0 ) // Has station 4 hit
       bend4 = ENG.getCLCT( pat4, endcap, dPhSign, nBits );
   } // End conditional: if (BIT_COMP)
-  
+
 } // End function: CalcBends()
 
 void CalcRPCs( int& RPC1, int& RPC2, int& RPC3, int& RPC4, const int mode,
-	       const int st1_ring2, const int theta, const bool BIT_COMP ) {
+               const int st1_ring2, const int theta, const bool BIT_COMP ) {
 
   if (BIT_COMP) {
 
@@ -184,55 +184,55 @@ void CalcRPCs( int& RPC1, int& RPC2, int& RPC3, int& RPC4, const int mode,
       RPC1 = 0;
       RPC2 = 0;
       if (theta < 4) {
-	RPC3 = 0;
-	RPC4 = 0;
+        RPC3 = 0;
+        RPC4 = 0;
       }
     }
 
     int nRPC = (RPC1 == 1) + (RPC2 == 1) + (RPC3 == 1) + (RPC4 == 1);
-    
+
     // In 3- and 4-station modes, only specify some combinations of RPCs
     if (nRPC >= 2) {
 
       if        (mode == 15) {
-	if        (RPC1 == 1 && RPC2 == 1) {
-	  RPC3 = 0;
-	  RPC4 = 0;
-	} else if (RPC1 == 1 && RPC3 == 1) {
-	  RPC4 = 0;
-	} else if (RPC4 == 1 && RPC2 == 1) {
-	  RPC3 = 0;
-	} else if (RPC3 == 1 && RPC4 == 1 && !st1_ring2) {
-	  RPC3 = 0;
-	}
+        if        (RPC1 == 1 && RPC2 == 1) {
+          RPC3 = 0;
+          RPC4 = 0;
+        } else if (RPC1 == 1 && RPC3 == 1) {
+          RPC4 = 0;
+        } else if (RPC4 == 1 && RPC2 == 1) {
+          RPC3 = 0;
+        } else if (RPC3 == 1 && RPC4 == 1 && !st1_ring2) {
+          RPC3 = 0;
+        }
       } else if (mode == 14) {
-	if        (RPC1 == 1) {
-	  RPC2 = 0;
-	  RPC3 = 0;
-	} else if (RPC3 == 1) {
-	  RPC2 = 0;
-	}
+        if        (RPC1 == 1) {
+          RPC2 = 0;
+          RPC3 = 0;
+        } else if (RPC3 == 1) {
+          RPC2 = 0;
+        }
       } else if (mode == 13) {
-	if        (RPC1 == 1) {
-	  RPC2 = 0;
-	  RPC4 = 0;
-	} else if (RPC4 == 1) {
-	  RPC2 = 0;
-	}
+        if        (RPC1 == 1) {
+          RPC2 = 0;
+          RPC4 = 0;
+        } else if (RPC4 == 1) {
+          RPC2 = 0;
+        }
       } else if (mode == 11) {
-	if        (RPC1 == 1) {
-	  RPC3 = 0;
-	  RPC4 = 0;
-	} else if (RPC4 == 1) {
-	  RPC3 = 0;
-	}
+        if        (RPC1 == 1) {
+          RPC3 = 0;
+          RPC4 = 0;
+        } else if (RPC4 == 1) {
+          RPC3 = 0;
+        }
       } else if (mode == 7) {
-	if        (RPC2 == 1) {
-	  RPC3 = 0;
-	  RPC4 = 0;
-	} else if (RPC4 == 1) {
-	  RPC3 = 0;
-	}
+        if        (RPC2 == 1) {
+          RPC3 = 0;
+          RPC4 = 0;
+        } else if (RPC4 == 1) {
+          RPC3 = 0;
+        }
       }
 
     } // End conditional: if (nRPC >= 2)
@@ -265,7 +265,7 @@ int CalcBendFromPattern( const int pattern, const int endcap ) {
 
 
 void CalcDeltaPhiSums( int& dPhSum4, int& dPhSum4A, int& dPhSum3, int& dPhSum3A, int& outStPh,
-		       const int dPh12, const int dPh13, const int dPh14, const int dPh23, const int dPh24, const int dPh34 ) {
+                       const int dPh12, const int dPh13, const int dPh14, const int dPh23, const int dPh24, const int dPh34 ) {
 
     dPhSum4  = dPh12 + dPh13 + dPh14 + dPh23 + dPh24 + dPh34;
     dPhSum4A = abs(dPh12) + abs(dPh13) + abs(dPh14) + abs(dPh23) + abs(dPh24) + abs(dPh34);
@@ -273,13 +273,13 @@ void CalcDeltaPhiSums( int& dPhSum4, int& dPhSum4A, int& dPhSum3, int& dPhSum3A,
     int devSt2 = abs(dPh12) + abs(dPh23) + abs(dPh24);
     int devSt3 = abs(dPh13) + abs(dPh23) + abs(dPh34);
     int devSt4 = abs(dPh14) + abs(dPh24) + abs(dPh34);
-    
+
     if      (devSt4 > devSt3 && devSt4 > devSt2 && devSt4 > devSt1)  outStPh = 4;
     else if (devSt3 > devSt4 && devSt3 > devSt2 && devSt3 > devSt1)  outStPh = 3;
     else if (devSt2 > devSt4 && devSt2 > devSt3 && devSt2 > devSt1)  outStPh = 2;
     else if (devSt1 > devSt4 && devSt1 > devSt3 && devSt1 > devSt2)  outStPh = 1;
     else                                                             outStPh = 0;
-    
+
     if      (outStPh == 4) {
       dPhSum3  = dPh12 + dPh13 + dPh23;
       dPhSum3A = abs(dPh12) + abs(dPh13) + abs(dPh23);

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessor.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessor.cc
@@ -111,7 +111,7 @@ void SectorProcessor::configure_by_fw_version(unsigned fw_version) {
 
     // ___________________________________________________________________________
     // Versions in 2017 - no full documentation, can refer to https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1KnownIssues
-    
+
     // Before July 9th (runs < 298653), all mode 7 tracks (station 2-3-4) assigned quality 11
     // July 9th - 29th (runs 298653 - 300087), mode 7 tracks with |eta| > 1.6 in sector -6 assigned quality 12
     // After July 29th (runs >= 300088), mode 7 track promotion applied in all sectors
@@ -140,20 +140,20 @@ void SectorProcessor::configure_by_fw_version(unsigned fw_version) {
     fixME11Edges_    = false;
 
     pattDefinitions_    = { "4,15:15,7:7,7:7,7:7",
-			    "3,16:16,7:7,7:6,7:6",
-			    "3,14:14,7:7,8:7,8:7",
-			    "2,18:17,7:7,7:5,7:5",  // Should be 7:4 in ME3,4 (FW bug)
-			    "2,13:12,7:7,10:7,10:7",
-			    "1,22:19,7:7,7:0,7:0",
-			    "1,11:8,7:7,14:7,14:7",
-			    "0,30:23,7:7,7:0,7:0",
-			    "0,7:0,7:7,14:7,14:7" };
+                            "3,16:16,7:7,7:6,7:6",
+                            "3,14:14,7:7,8:7,8:7",
+                            "2,18:17,7:7,7:5,7:5",  // Should be 7:4 in ME3,4 (FW bug)
+                            "2,13:12,7:7,10:7,10:7",
+                            "1,22:19,7:7,7:0,7:0",
+                            "1,11:8,7:7,14:7,14:7",
+                            "0,30:23,7:7,7:0,7:0",
+                            "0,7:0,7:7,14:7,14:7" };
     // Straightness, hits in ME1, hits in ME2, hits in ME3, hits in ME4
     symPattDefinitions_ = { "4,15:15:15:15,7:7:7:7,7:7:7:7,7:7:7:7",
-			    "3,16:16:14:14,7:7:7:7,8:7:7:6,8:7:7:6",
-			    "2,18:17:13:12,7:7:7:7,10:7:7:4,10:7:7:4",
-			    "1,22:19:11:8,7:7:7:7,14:7:7:0,14:7:7:0",
-			    "0,30:23:7:0,7:7:7:7,14:7:7:0,14:7:7:0" };
+                            "3,16:16:14:14,7:7:7:7,8:7:7:6,8:7:7:6",
+                            "2,18:17:13:12,7:7:7:7,10:7:7:4,10:7:7:4",
+                            "1,22:19:11:8,7:7:7:7,14:7:7:0,14:7:7:0",
+                            "0,30:23:7:0,7:7:7:7,14:7:7:0,14:7:7:0" };
 
     thetaWindow_   = 4;      // Maximum dTheta between primitives in the same track
     useSingleHits_ = false;  // Build "tracks" from single LCTs in ME1/1
@@ -164,7 +164,7 @@ void SectorProcessor::configure_by_fw_version(unsigned fw_version) {
     bugGMTPhi_ = true;
     promoteMode7_ = false;  // Assign station 2-3-4 tracks with |eta| > 1.6 SingleMu quality
   } // End default settings for 2016
-			    
+
 
   // ___________________________________________________________________________
   // Versions in 2016 - refer to docs/EMTF_FW_LUT_versions_2016_draft2.xlsx

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
@@ -26,7 +26,7 @@ void SectorProcessorLUT::read(unsigned pc_lut_version) {
     coord_lut_dir = "ph_lut_v1";  // All year 2016
   else if (pc_lut_version == 1)
     coord_lut_dir = "ph_lut_v2";  // Beginning of 2017
-  else 
+  else
     throw cms::Exception("SectorProcessorLUT")
       << "Trying to use EMTF pc_lut_version = " << pc_lut_version << ", does not exist!";
   // Will catch user trying to run with Global Tag settings on 2016 data, rather than fakeEmtfParams. - AWB 08.06.17

--- a/L1Trigger/L1TMuonEndCap/src/SingleHitTrack.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SingleHitTrack.cc
@@ -42,19 +42,19 @@ void SingleHitTrack::process(
 
       // Require subsector and CSC ID to match
       if (conv_hits_it.Subsector() != subsector || conv_hits_it.CSC_ID() != CSC_ID)
-	continue;
+        continue;
 
       // Only consider CSC LCTs
       if (conv_hits_it.Is_CSC() != 1)
-	continue;
-      
+        continue;
+
       // Only consider hits in station 1, ring 1
       if (conv_hits_it.Station() != 1 || (conv_hits_it.Ring() % 3) != 1)
-	continue;
-      
+        continue;
+
       // Only consider hits in the same sector (not neighbor hits)
       if ( (conv_hits_it.Endcap() == 1) != (endcap_ == 1) || conv_hits_it.Sector() != sector_ )
-	continue;
+        continue;
 
       // Check if a hit has already been used in a track
       bool already_used = false;
@@ -62,34 +62,34 @@ void SingleHitTrack::process(
       // Loop over existing multi-hit tracks
       for (const auto & best_tracks_it : best_tracks) {
 
-	// Only consider tracks with a hit in station 1
-	if (best_tracks_it.Mode() < 8)
-	  continue;
-	
-	// Check if hit in track is identical
-	// "Duplicate" hits (with same strip but different wire) are considered identical
-	// const EMTFHit& conv_hit_i = *conv_hits_it;
-	const EMTFHit& conv_hit_j = best_tracks_it.Hits().front();
-	
-	if (
-	    (conv_hits_it.Subsystem()  == conv_hit_j.Subsystem()) &&
-	    (conv_hits_it.PC_station() == conv_hit_j.PC_station()) &&
-	    (conv_hits_it.PC_chamber() == conv_hit_j.PC_chamber()) &&
-	    ((conv_hits_it.Ring() % 3) == (conv_hit_j.Ring() % 3)) &&  // because of ME1/1
-	    (conv_hits_it.Strip()      == conv_hit_j.Strip()) &&
-	    // (conv_hits_it.Wire()       == conv_hit_j.Wire()) &&
-	    (conv_hits_it.BX()         == conv_hit_j.BX()) &&
-	    true
-	    ) {
-	  already_used = true;
-	  break;
-	}
+        // Only consider tracks with a hit in station 1
+        if (best_tracks_it.Mode() < 8)
+          continue;
+
+        // Check if hit in track is identical
+        // "Duplicate" hits (with same strip but different wire) are considered identical
+        // const EMTFHit& conv_hit_i = *conv_hits_it;
+        const EMTFHit& conv_hit_j = best_tracks_it.Hits().front();
+
+        if (
+            (conv_hits_it.Subsystem()  == conv_hit_j.Subsystem()) &&
+            (conv_hits_it.PC_station() == conv_hit_j.PC_station()) &&
+            (conv_hits_it.PC_chamber() == conv_hit_j.PC_chamber()) &&
+            ((conv_hits_it.Ring() % 3) == (conv_hit_j.Ring() % 3)) &&  // because of ME1/1
+            (conv_hits_it.Strip()      == conv_hit_j.Strip()) &&
+            // (conv_hits_it.Wire()       == conv_hit_j.Wire()) &&
+            (conv_hits_it.BX()         == conv_hit_j.BX()) &&
+            true
+            ) {
+          already_used = true;
+          break;
+        }
       } // End loop: for (const auto & best_tracks_it : best_tracks)
 
       // Only use hits that have not been used in a track
       if (already_used)
-	continue;
-      
+        continue;
+
       int zone = -1;
       int zone_code = conv_hits_it.Zone_code();
       if      (zone_code & 0b1000) zone = 4;
@@ -102,10 +102,10 @@ void SingleHitTrack::process(
 
       EMTFTrack new_trk;
       new_trk.push_Hit ( conv_hits_it );
-      
+
       EMTFPtLUT empty_LUT = {};
       new_trk.set_PtLUT ( empty_LUT );
-      
+
       new_trk.set_endcap       ( conv_hits_it.Endcap()     );
       new_trk.set_sector       ( conv_hits_it.Sector()     );
       new_trk.set_sector_idx   ( conv_hits_it.Sector_idx() );
@@ -126,19 +126,19 @@ void SingleHitTrack::process(
       new_trk.set_phi_loc      ( conv_hits_it.Phi_loc() );
       new_trk.set_phi_glob     ( conv_hits_it.Phi_glob() );
       new_trk.set_track_num    ( maxTracks_ - 1 );
-      
+
       one_hit_trks.push_back( new_trk );
-      
+
       if (int(best_tracks.size()) + int(one_hit_trks.size()) >= maxTracks_)
-	break;
-    
+        break;
+
       // Firmware only sends one single-hit track per sector
-      if (!one_hit_trks.empty()) 
-	break;
+      if (!one_hit_trks.empty())
+        break;
 
     } // End loop:  for (const auto & conv_hits_it : conv_hits)
 
-    if (!one_hit_trks.empty()) 
+    if (!one_hit_trks.empty())
       break;
 
   } // End loop: for (int sub_ID = 5; sub_ID > 0; sub_ID--) {

--- a/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
@@ -79,7 +79,7 @@ TrackFinder::TrackFinder(const edm::ParameterSet& iConfig, edm::ConsumesCollecto
   for (int endcap = emtf::MIN_ENDCAP; endcap <= emtf::MAX_ENDCAP; ++endcap) {
     for (int sector = emtf::MIN_TRIGSECTOR; sector <= emtf::MAX_TRIGSECTOR; ++sector) {
       const int es = (endcap - emtf::MIN_ENDCAP) * (emtf::MAX_TRIGSECTOR - emtf::MIN_TRIGSECTOR + 1) + (sector - emtf::MIN_TRIGSECTOR);
-      
+
       sector_processors_.at(es).configure(
           &geometry_translator_,
           &condition_helper_,

--- a/L1Trigger/L1TMuonEndCap/src/bdt/Forest.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Forest.cc
@@ -8,7 +8,7 @@
 //     Tibshirani, and Friedman.                                        //
 //    *Greedy Function Approximation: A Gradient Boosting Machine.      //
 //     Friedman. The Annals of Statistics, Vol. 29, No. 5. Oct 2001.    //
-//    *Inductive Learning of Tree-based Regression Models. Luis Torgo.  //    
+//    *Inductive Learning of Tree-based Regression Models. Luis Torgo.  //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
@@ -80,7 +80,7 @@ Forest::Forest(const Forest &forest)
 Forest& Forest::operator=(const Forest &forest)
 {
     for(unsigned int i=0; i < trees.size(); i++)
-    { 
+    {
         if(trees[i]) delete trees[i];
     }
     trees.resize(0);
@@ -104,14 +104,14 @@ void Forest::setTrainingEvents(std::vector<Event*>& trainingEvents)
     Event* e = trainingEvents[0];
     // Unused variable
     // unsigned int numrows = e->data.size();
-   
-    // Reset the events matrix. 
+
+    // Reset the events matrix.
     events = std::vector< std::vector<Event*> >();
 
-    for(unsigned int i=0; i<e->data.size(); i++) 
-    {    
+    for(unsigned int i=0; i<e->data.size(); i++)
+    {
         events.push_back(trainingEvents);
-    }    
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -127,8 +127,8 @@ std::vector<Event*> Forest::getTrainingEvents(){ return events[0]; }
 
 // return the ith tree
 Tree* Forest::getTree(unsigned int i)
-{ 
-    if(/*i>=0 && */i<trees.size()) return trees[i]; 
+{
+    if(/*i>=0 && */i<trees.size()) return trees[i];
     else
     {
       //std::cout << i << "is an invalid input for getTree. Out of range." << std::endl;
@@ -169,7 +169,7 @@ void Forest::listEvents(std::vector< std::vector<Event*> >& e)
         for(unsigned int j=0; j<e[i].size(); j++)
         {
             e[i][j]->outputEvent();
-        }   
+        }
        std::cout << std::endl;
     }
 }
@@ -221,7 +221,7 @@ void Forest::rankVariables(std::vector<int>& rank)
 // This function ranks the determining variables according to their importance
 // in determining the fit. Use a low learning rate for better results.
 // Separates completely useless variables from useful ones well,
-// but isn't the best at separating variables of similar importance. 
+// but isn't the best at separating variables of similar importance.
 // This is calculated using the error reduction on the training set. The function
 // should be changed to use the testing set, but this works fine for now.
 // I will try to change this in the future.
@@ -234,18 +234,18 @@ void Forest::rankVariables(std::vector<int>& rank)
 
     for(unsigned int j=0; j < trees.size(); j++)
     {
-        trees[j]->rankVariables(v); 
+        trees[j]->rankVariables(v);
     }
 
     double max = *std::max_element(v.begin(), v.end());
-   
+
     // Scale the importance. Maximum importance = 100.
     for(unsigned int i=0; i < v.size(); i++)
     {
         v[i] = 100*v[i]/max;
     }
 
-    // Change the storage format so that we can keep the index 
+    // Change the storage format so that we can keep the index
     // and the value associated after sorting.
     std::vector< std::pair<double, int> > w(events.size());
 
@@ -261,9 +261,9 @@ void Forest::rankVariables(std::vector<int>& rank)
     for(int i=(v.size()-1); i>=0; i--)
     {
         rank.push_back(w[i].second);
-       // std::cout << "x" << w[i].second  << ": " << w[i].first  << std::endl; 
+       // std::cout << "x" << w[i].second  << ": " << w[i].first  << std::endl;
     }
-    
+
     // std::cout << std::endl << "Done." << std::endl << std::endl;
 }
 
@@ -287,7 +287,7 @@ void Forest::saveSplitValues(const char* savefilename)
     // Gather the split values from each tree in the forest.
     for(unsigned int j=0; j<trees.size(); j++)
     {
-        trees[j]->getSplitValues(v); 
+        trees[j]->getSplitValues(v);
     }
 
     // Sort the lists of split values and remove the duplicates.
@@ -307,7 +307,7 @@ void Forest::saveSplitValues(const char* savefilename)
         std::stringstream ss;
         ss.precision(14);
         ss << std::scientific << v[i][j];
-        splitValues+=","; 
+        splitValues+=",";
         splitValues+=ss.str().c_str();
       }
 
@@ -330,7 +330,7 @@ void Forest::updateRegTargets(Tree* tree, double learningRate, LossFunction* l)
 
     // Loop through the terminal nodes.
     for(std::list<Node*>::iterator it=tn.begin(); it!=tn.end(); it++)
-    {   
+    {
         // Get the events in the current terminal region.
         std::vector<Event*>& v = (*it)->getEvents()[0];
 
@@ -370,21 +370,21 @@ void Forest::updateEvents(Tree* tree)
 
     // Loop through the terminal nodes.
     for(std::list<Node*>::iterator it=tn.begin(); it!=tn.end(); it++)
-    {   
+    {
         std::vector<Event*>& v = (*it)->getEvents()[0];
         double fit = (*it)->getFitValue();
 
         // Loop through each event in the terminal region and update the
         // the global event it maps to.
         for(unsigned int j=0; j<v.size(); j++)
-        {   
+        {
             Event* e = v[j];
             e->predictedValue += fit;
-        }   
+        }
 
         // Release memory.
         (*it)->getEvents() = std::vector< std::vector<Event*> >();
-    }   
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -414,14 +414,14 @@ void Forest::doRegression(int nodeLimit, int treeLimit, double learningRate, Los
     {
        // std::cout << "++Building Tree " << i << "... " << std::endl;
         Tree* tree = new Tree(events);
-        trees.push_back(tree);    
+        trees.push_back(tree);
         tree->buildTree(nodeLimit);
 
         // Update the targets for the next tree to fit.
         updateRegTargets(tree, learningRate, l);
 
         // Save trees to xml in some directory.
-        std::ostringstream ss; 
+        std::ostringstream ss;
         ss << savetreesdirectory << "/" << i << ".xml";
         std::string s = ss.str();
         const char* c = s.c_str();
@@ -450,7 +450,7 @@ void Forest::predictEvents(std::vector<Event*>& eventsp, unsigned int numtrees)
     }
 
     // i iterates through the trees in the forest. Each tree corrects the last prediction.
-    for(unsigned int i=0; i < numtrees; i++) 
+    for(unsigned int i=0; i < numtrees; i++)
     {
         //std::cout << "++Tree " << i << "..." << std::endl;
         appendCorrection(eventsp, i);
@@ -466,7 +466,7 @@ void Forest::appendCorrection(std::vector<Event*>& eventsp, int treenum)
 // Update the prediction by appending the next correction.
 
     Tree* tree = trees[treenum];
-    tree->filterEvents(eventsp); 
+    tree->filterEvents(eventsp);
 
     // Update the events with their new prediction.
     updateEvents(tree);
@@ -488,10 +488,10 @@ void Forest::predictEvent(Event* e, unsigned int numtrees)
     }
 
     // just like in line #2470 of https://root.cern.ch/doc/master/MethodBDT_8cxx_source.html for gradient boosting
-    e->predictedValue = trees[0]->getBoostWeight(); 
+    e->predictedValue = trees[0]->getBoostWeight();
 
     // i iterates through the trees in the forest. Each tree corrects the last prediction.
-    for(unsigned int i=0; i < numtrees; i++) 
+    for(unsigned int i=0; i < numtrees; i++)
     {
         //std::cout << "++Tree " << i << "..." << std::endl;
         appendCorrection(e, i);
@@ -507,7 +507,7 @@ void Forest::appendCorrection(Event* e, int treenum)
 // Update the prediction by appending the next correction.
 
     Tree* tree = trees[treenum];
-    Node* terminalNode = tree->filterEvent(e); 
+    Node* terminalNode = tree->filterEvent(e);
 
     // Update the event with its new prediction.
     double fit = terminalNode->getFitValue();
@@ -526,15 +526,15 @@ void Forest::loadForestFromXML(const char* directory, unsigned int numTrees)
 
     // Load the Forest.
     // std::cout << std::endl << "Loading Forest from XML ... " << std::endl;
-    for(unsigned int i=0; i < numTrees; i++) 
-    {   
-        trees[i] = new Tree(); 
+    for(unsigned int i=0; i < numTrees; i++)
+    {
+        trees[i] = new Tree();
 
         std::stringstream ss;
         ss << directory << "/" << i << ".xml";
 
         trees[i]->loadFromXML(edm::FileInPath(ss.str().c_str()).fullPath().c_str());
-    }   
+    }
 
     //std::cout << "Done." << std::endl << std::endl;
 }
@@ -579,14 +579,14 @@ void Forest::prepareRandomSubsample(double fraction)
     shuffle(events[0].begin(), events[0].end(), subSampleSize);
 
     // Get a copy of the random subset we just made.
-    std::vector<Event*> v(events[0].begin(), events[0].begin()+subSampleSize); 
+    std::vector<Event*> v(events[0].begin(), events[0].begin()+subSampleSize);
 
     // Initialize and sort the subSample collection.
     for(unsigned int i=0; i<subSample.size(); i++)
     {
         subSample[i] = v;
     }
-    
+
     sortEventVectors(subSample);
 }
 
@@ -597,7 +597,7 @@ void Forest::prepareRandomSubsample(double fraction)
 void Forest::doStochasticRegression(int nodeLimit, int treeLimit, double learningRate, double fraction, LossFunction* l)
 {
 // If the fraction of events to use is one then this algorithm is slower than doRegression due to the fact
-// that we have to sort the events every time we extract a subsample. Without random sampling we simply 
+// that we have to sort the events every time we extract a subsample. Without random sampling we simply
 // use all of the events and keep them sorted.
 
 // Anyways, this algorithm uses a portion of the events to train each tree. All of the events are updated
@@ -609,7 +609,7 @@ void Forest::doStochasticRegression(int nodeLimit, int treeLimit, double learnin
 
     // See how long the regression takes.
     TStopwatch timer;
-    timer.Start(kTRUE); 
+    timer.Start(kTRUE);
 
     // Output the current settings.
    // std::cout << std::endl << "Running stochastic regression ... " << std::endl;
@@ -617,13 +617,13 @@ void Forest::doStochasticRegression(int nodeLimit, int treeLimit, double learnin
     //std::cout << "Learning Rate: " << learningRate << std::endl;
     //std::cout << "Bagging Fraction: " << fraction << std::endl;
     //std::cout << std::endl;
-    
+
 
     for(unsigned int i=0; i< (unsigned) treeLimit; i++)
     {
         // Build the tree using a random subsample.
         prepareRandomSubsample(fraction);
-        trees[i] = new Tree(subSample);    
+        trees[i] = new Tree(subSample);
         trees[i]->buildTree(nodeLimit);
 
         // Fit all of the events based upon the tree we built using
@@ -634,7 +634,7 @@ void Forest::doStochasticRegression(int nodeLimit, int treeLimit, double learnin
         updateRegTargets(trees[i], learningRate, l);
 
         // Save trees to xml in some directory.
-        std::ostringstream ss; 
+        std::ostringstream ss;
         ss << "trees/" << i << ".xml";
         std::string s = ss.str();
         const char* c = s.c_str();

--- a/L1Trigger/L1TMuonEndCap/src/bdt/Node.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Node.cc
@@ -2,13 +2,13 @@
 //                            Node.cxx                                  //
 // =====================================================================//
 // This is the object implementation of a node, which is the            //
-// fundamental unit of a decision tree.                                 //                                    
+// fundamental unit of a decision tree.                                 //
 // References include                                                   //
 //    *Elements of Statistical Learning by Hastie,                      //
 //     Tibshirani, and Friedman.                                        //
 //    *Greedy Function Approximation: A Gradient Boosting Machine.      //
 //     Friedman. The Annals of Statistics, Vol. 29, No. 5. Oct 2001.    //
-//    *Inductive Learning of Tree-based Regression Models. Luis Torgo.  //    
+//    *Inductive Learning of Tree-based Regression Models. Luis Torgo.  //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
@@ -219,7 +219,7 @@ void Node::calcOptimumSplit()
 
     // Intialize some variables.
     double bestSplitValue = 0;
-    int bestSplitVariable = -1; 
+    int bestSplitVariable = -1;
     double bestErrorReduction = -1;
 
     double SUM = 0;
@@ -231,17 +231,17 @@ void Node::calcOptimumSplit()
     // Calculate the sum of the target variables and the sum of
     // the target variables squared. We use these later.
     for(unsigned int i=0; i<events[0].size(); i++)
-    {   
+    {
         double target = events[0][i]->data[0];
         SUM += target;
         SSUM += target*target;
-    }  
+    }
 
     unsigned int numVars = events.size();
 
     // Calculate the best split point for each variable
     for(unsigned int variableToCheck = 1; variableToCheck < numVars; variableToCheck++)
-    { 
+    {
 
         // The sum of the target variables in the left, right nodes
         double SUMleft = 0;
@@ -255,15 +255,15 @@ void Node::calcOptimumSplit()
 
         std::vector<Event*>& v = events[variableToCheck];
 
-        // Find the best split point for this variable 
+        // Find the best split point for this variable
         for(unsigned int i=1; i<v.size(); i++)
         {
-            // As the candidate split point interates, the number of events in the 
+            // As the candidate split point interates, the number of events in the
             // left/right node increases/decreases and SUMleft/right increases/decreases.
 
             SUMleft = SUMleft + v[i-1]->data[0];
             SUMright = SUMright - v[i-1]->data[0];
-             
+
             // No need to check the split point if x on both sides is equal
             if(v[i-1]->data[candidateSplitVariable] < v[i]->data[candidateSplitVariable])
             {
@@ -271,7 +271,7 @@ void Node::calcOptimumSplit()
                 // the following statement.
                 candidateErrorReduction = SUMleft*SUMleft/nleft + SUMright*SUMright/nright - SUM*SUM/numEvents;
 //                std::cout << "candidateErrorReduction= " << candidateErrorReduction << std::endl << std::endl;
-                
+
                 // if the new candidate is better than the current best, then we have a new overall best.
                 if(candidateErrorReduction > bestErrorReduction)
                 {
@@ -285,7 +285,7 @@ void Node::calcOptimumSplit()
             nleft = nleft+1;
         }
     }
- 
+
     // Store the information gained from our computations.
 
     // The fit value is the average for least squares.
@@ -299,7 +299,7 @@ void Node::calcOptimumSplit()
     // [ <y^2>-k^2 ]
     avgError = totalError/numEvents;
 //    std::cout << "avgError= " << avgError << std::endl;
-    
+
 
     errorReduction = bestErrorReduction;
 //    std::cout << "errorReduction= " << errorReduction << std::endl;
@@ -320,21 +320,21 @@ void Node::listEvents()
     std::cout << std::endl << "Listing Events... " << std::endl;
 
     for(unsigned int i=0; i < events.size(); i++)
-    {   
+    {
         std::cout << std::endl << "Variable " << i << " vector contents: " << std::endl;
         for(unsigned int j=0; j < events[i].size(); j++)
-        {   
+        {
             events[i][j]->outputEvent();
-        }   
+        }
        std::cout << std::endl;
-    }   
+    }
 }
 
 // ----------------------------------------------------------------------
 
 void Node::theMiracleOfChildBirth()
-{ 
-    // Create Daughter Nodes 
+{
+    // Create Daughter Nodes
     Node* left = new Node(name + " left");
     Node* right = new Node(name + " right");
 
@@ -342,7 +342,7 @@ void Node::theMiracleOfChildBirth()
     leftDaughter = left;
     rightDaughter = right;
     left->setParent(this);
-    right->setParent(this); 
+    right->setParent(this);
 }
 
 // ----------------------------------------------------------------------
@@ -359,7 +359,7 @@ void Node::filterEventsToDaughters()
 // Anyways, this function takes events from the parent node
 // and filters an event into the left or right daughter
 // node depending on whether it is < or > the split point
-// for the given split variable. 
+// for the given split variable.
 
     int sv = splitVariable;
     double sp = splitValue;
@@ -380,10 +380,10 @@ void Node::filterEventsToDaughters()
         }
     }
 
-    events = std::vector< std::vector<Event*> >();    
+    events = std::vector< std::vector<Event*> >();
 
     left->getEvents().swap(l);
-    right->getEvents().swap(r);    
+    right->getEvents().swap(r);
 
     // Set the number of events in the node.
     left->setNumEvents(left->getEvents()[0].size());
@@ -397,7 +397,7 @@ Node* Node::filterEventToDaughter(Event* e)
 // Anyways, this function takes an event from the parent node
 // and filters an event into the left or right daughter
 // node depending on whether it is < or > the split point
-// for the given split variable. 
+// for the given split variable.
 
     int sv = splitVariable;
     double sp = splitValue;
@@ -410,6 +410,6 @@ Node* Node::filterEventToDaughter(Event* e)
 
     if(e->data[sv] <  sp) nextNode = left;
     if(e->data[sv] >= sp) nextNode = right;
-    
+
     return nextNode;
 }

--- a/L1Trigger/L1TMuonEndCap/src/bdt/Tree.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Tree.cc
@@ -7,7 +7,7 @@
 //     Tibshirani, and Friedman.                                        //
 //    *Greedy Function Approximation: A Gradient Boosting Machine.      //
 //     Friedman. The Annals of Statistics, Vol. 29, No. 5. Oct 2001.    //
-//    *Inductive Learning of Tree-based Regression Models. Luis Torgo.  //    
+//    *Inductive Learning of Tree-based Regression Models. Luis Torgo.  //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
@@ -155,7 +155,7 @@ void Tree::setRootNode(Node *sRootNode)
 {
     rootNode = sRootNode;
 }
- 
+
 Node * Tree::getRootNode()
 {
      return rootNode;
@@ -184,19 +184,19 @@ int Tree::getNumTerminalNodes()
 // ______________________Performace_____________________________________//
 //////////////////////////////////////////////////////////////////////////
 
-void Tree::calcError() 
-{ 
-// Loop through the separate predictive regions (terminal nodes) and 
-// add up the errors to get the error of the entire space.  
- 
-    double totalSquaredError = 0; 
- 
-    for(std::list<Node*>::iterator it=terminalNodes.begin(); it!=terminalNodes.end(); it++) 
-    { 
-        totalSquaredError += (*it)->getTotalError();  
-    } 
-    rmsError = sqrt( totalSquaredError/rootNode->getNumEvents() ); 
-} 
+void Tree::calcError()
+{
+// Loop through the separate predictive regions (terminal nodes) and
+// add up the errors to get the error of the entire space.
+
+    double totalSquaredError = 0;
+
+    for(std::list<Node*>::iterator it=terminalNodes.begin(); it!=terminalNodes.end(); it++)
+    {
+        totalSquaredError += (*it)->getTotalError();
+    }
+    rmsError = sqrt( totalSquaredError/rootNode->getNumEvents() );
+}
 
 // ----------------------------------------------------------------------
 
@@ -207,20 +207,20 @@ void Tree::buildTree(int nodeLimit)
     Node* nodeToSplit = nullptr;
 
     if(numTerminalNodes == 1)
-    {   
+    {
         rootNode->calcOptimumSplit();
         calcError();
 //        std::cout << std::endl << "  " << numTerminalNodes << " Nodes : " << rmsError << std::endl;
     }
 
     for(std::list<Node*>::iterator it=terminalNodes.begin(); it!=terminalNodes.end(); it++)
-    {   
-       if( (*it)->getErrorReduction() > bestNodeErrorReduction ) 
-       {   
+    {
+       if( (*it)->getErrorReduction() > bestNodeErrorReduction )
+       {
            bestNodeErrorReduction = (*it)->getErrorReduction();
            nodeToSplit = (*it);
-       }    
-    }   
+       }
+    }
 
     //std::cout << "nodeToSplit size = " << nodeToSplit->getNumEvents() << std::endl;
 
@@ -233,7 +233,7 @@ void Tree::buildTree(int nodeLimit)
     // Get left and right daughters for reference.
     Node* left = nodeToSplit->getLeftDaughter();
     Node* right = nodeToSplit->getRightDaughter();
- 
+
     // Update the list of terminal nodes.
     terminalNodes.remove(nodeToSplit);
     terminalNodes.push_back(left);
@@ -241,7 +241,7 @@ void Tree::buildTree(int nodeLimit)
     numTerminalNodes++;
 
     // Filter the events from the parent into the daughters.
-    nodeToSplit->filterEventsToDaughters();  
+    nodeToSplit->filterEventsToDaughters();
 
     // Calculate the best splits for the new nodes.
     left->calcOptimumSplit();
@@ -249,7 +249,7 @@ void Tree::buildTree(int nodeLimit)
 
     // See if the error reduces as we add more nodes.
     calcError();
- 
+
     if(numTerminalNodes % 1 == 0)
     {
 //        std::cout << "  " << numTerminalNodes << " Nodes : " << rmsError << std::endl;
@@ -349,7 +349,7 @@ void Tree::rankVariablesRecursive(Node* node, std::vector<double>& v)
     v[sv] += er;
 
     rankVariablesRecursive(left, v);
-    rankVariablesRecursive(right, v); 
+    rankVariablesRecursive(right, v);
 
 }
 
@@ -387,7 +387,7 @@ void Tree::getSplitValuesRecursive(Node* node, std::vector<std::vector<double>>&
     v[sv].push_back(sp);
 
     getSplitValuesRecursive(left, v);
-    getSplitValuesRecursive(right, v); 
+    getSplitValuesRecursive(right, v);
 
 }
 
@@ -416,7 +416,7 @@ std::string numToStr( T num )
 
 void Tree::addXMLAttributes(TXMLEngine* xml, Node* node, XMLNodePointer_t np)
 {
-    // Convert Node members into XML attributes    
+    // Convert Node members into XML attributes
     // and add them to the XMLEngine.
     xml->NewAttr(np, nullptr, "splitVar", numToStr(node->getSplitVariable()).c_str());
     xml->NewAttr(np, nullptr, "splitVal", numToStr(node->getSplitValue()).c_str());
@@ -458,7 +458,7 @@ void Tree::saveToXMLRecursive(TXMLEngine* xml, Node* node, XMLNodePointer_t np)
 
     if(l==nullptr || r==nullptr) return;
 
-    // Add children to the XMLEngine. 
+    // Add children to the XMLEngine.
     XMLNodePointer_t left = xml->NewChild(np, nullptr, "left");
     XMLNodePointer_t right = xml->NewChild(np, nullptr, "right");
 
@@ -474,7 +474,7 @@ void Tree::saveToXMLRecursive(TXMLEngine* xml, Node* node, XMLNodePointer_t np)
 // ----------------------------------------------------------------------
 
 void Tree::loadFromXML(const char* filename)
-{   
+{
     // First create the engine.
     TXMLEngine* xml = new TXMLEngine;
 
@@ -483,7 +483,7 @@ void Tree::loadFromXML(const char* filename)
     if (xmldoc==nullptr)
     {
         delete xml;
-        return;  
+        return;
     }
 
     // Get access to main node of the xml file.
@@ -505,7 +505,7 @@ void Tree::loadFromXML(const char* filename)
     }
     // Recursively connect nodes together.
     loadFromXMLRecursive(xml, mainnode, rootNode);
-   
+
     // Release memory before exit
     xml->FreeDoc(xmldoc);
     delete xml;
@@ -513,7 +513,7 @@ void Tree::loadFromXML(const char* filename)
 
 // ----------------------------------------------------------------------
 
-void Tree::loadFromXMLRecursive(TXMLEngine* xml, XMLNodePointer_t xnode, Node* tnode) 
+void Tree::loadFromXMLRecursive(TXMLEngine* xml, XMLNodePointer_t xnode, Node* tnode)
 {
 
     // Get the split information from xml.
@@ -525,21 +525,21 @@ void Tree::loadFromXMLRecursive(TXMLEngine* xml, XMLNodePointer_t xnode, Node* t
           if(i==3 || i==4 || i==6){
               splitInfo[j++] = xml->GetAttrValue(attr);
           }
-          attr = xml->GetNextAttr(attr);  
+          attr = xml->GetNextAttr(attr);
         }
     } else {
         for(unsigned int i=0; i<3; i++)
         {
-            splitInfo[i] = xml->GetAttrValue(attr); 
-            attr = xml->GetNextAttr(attr);  
+            splitInfo[i] = xml->GetAttrValue(attr);
+            attr = xml->GetNextAttr(attr);
         }
     }
- 
+
     // Convert strings into numbers.
     std::stringstream converter;
     int splitVar;
     double splitVal;
-    double fitVal;  
+    double fitVal;
 
     converter << splitInfo[0];
     converter >> splitVar;
@@ -561,7 +561,7 @@ void Tree::loadFromXMLRecursive(TXMLEngine* xml, XMLNodePointer_t xnode, Node* t
     tnode->setSplitValue(splitVal);
     tnode->setFitValue(fitVal);
 
-    // Get the xml daughters of the current xml node. 
+    // Get the xml daughters of the current xml node.
     XMLNodePointer_t xleft = xml->GetChild(xnode);
     XMLNodePointer_t xright = xml->GetNext(xleft);
 

--- a/L1Trigger/L1TMuonEndCap/src/bdt/Utilities.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Utilities.cc
@@ -49,7 +49,7 @@ const std::vector<double> emtf::twoJetsScale = std::vector<double>(twoJets_scale
 
 float processPrediction(float BDTPt, int Quality, float PrelimFit)
 {
-// Discretize and scale the BDTPt prediction 
+// Discretize and scale the BDTPt prediction
 
 
     // Fix terrible predictions

--- a/L1Trigger/L1TMuonEndCap/test/unittests/TestPhiMemoryImage.cpp
+++ b/L1Trigger/L1TMuonEndCap/test/unittests/TestPhiMemoryImage.cpp
@@ -110,7 +110,7 @@ void TestPhiMemoryImage::test_rotation()
       CPPUNIT_ASSERT_EQUAL(image.get_word(0, 0), (word1 << (i-128)) | (word0 >> (192-i)));
     else
       CPPUNIT_ASSERT_EQUAL(image.get_word(0, 0), (word0));
-    
+
     image.rotr(i);
 
     CPPUNIT_ASSERT_EQUAL(image.get_word(0, 0), word0);


### PR DESCRIPTION
Hi all,

This is part 1 of a series of PRs (4 or 5 total) which will bring the EMTF emulator up-to-date for 2018 running.  In particular, changes will include:

  * Improved code style
  * Logic cleanup for EMTF emulator in <= 2017
  * Features in emulator to match EMTF firmware at start-of-2018
  * Ability to process additional simulated TPs (e.g. from GEMs and ME0) through the EMTF emulator, with output in a consistent format with TPs from the existing CSCs and RPCs.  This feature is critical for Run 3 and Phase II studies.

To facilitate and speed up the review process, I have split Jia Fu's PR here (https://github.com/cms-l1t-offline/cmssw/pull/649) into logical, independent parts as much as possible.  That said, some changes cannot be disentangled, so there will be some unavoidable cross-over, for example between updates for start-of-2018 and the Phase-II TP processing.

This PR is very simple - it is just corrections to whitespace, e.g. cleaning up leading and trailing whitespace in lines.  This can be verified by adding "?w=1" to the end of the PR diff path as follows:
https://github.com/cms-sw/cmssw/pull/22820/files?w=1

(HT to @jiafulow for that.). Hopefully we can get this in quite quickly, and move on to the next step. @rekovic , @thomreis please take a look.

Best regards,
Andrew


