### PR TITLE
BugFix for L3MuonCandidateProducerFromMuons

### DIFF
--- a/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducerFromMuons.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducerFromMuons.cc
@@ -60,8 +60,10 @@ void L3MuonCandidateProducerFromMuons::produce(StreamID, Event& event, const Eve
     LogError(category) << muons.whyFailed()->what();
   } else { 
     for (unsigned int i=0; i<muons->size(); i++) {
-      TrackRef tkref = (*muons)[i].muonBestTrack();  // avoids crashing in case the muon is SA only. 
-
+      
+      // avoids crashing in case the muon is SA only. 
+      TrackRef tkref = ((*muons)[i].innerTrack().isNonnull())? (*muons)[i].innerTrack() : (*muons)[i].muonBestTrack();
+      
       Particle::Charge q = tkref->charge();
       Particle::LorentzVector p4(tkref->px(), tkref->py(), tkref->pz(), tkref->p());
       Particle::Point vtx(tkref->vx(),tkref->vy(), tkref->vz());


### PR DESCRIPTION
Matching efficiency was degrading for very high-pt muons, this brings back the possibility of using the innerTrack when available and using the outerTrack otherwise. 

This is a backport of #22774 