### PR TITLE
[101X][GT updates] ECAL threshold, PF corrections, GEM geometry, HCAL conditions for 2018

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,27 +2,27 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '101X_mcRun1_design_v2',
+    'run1_design'       :   '101X_mcRun1_design_v3',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '101X_mcRun1_realistic_v2',
+    'run1_mc'           :   '101X_mcRun1_realistic_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '101X_mcRun1_HeavyIon_v2',
+    'run1_mc_hi'        :   '101X_mcRun1_HeavyIon_v3',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '101X_mcRun1_pA_v2',
+    'run1_mc_pa'        :   '101X_mcRun1_pA_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '101X_mcRun2_design_v3',
+    'run2_design'       :   '101X_mcRun2_design_v4',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '101X_mcRun2_startup_v3',
+    'run2_mc_50ns'      :   '101X_mcRun2_startup_v4',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '101X_mcRun2_asymptotic_v3',
+    'run2_mc'           :   '101X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v4',
+    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v5',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '101X_mcRun2cosmics_startup_deco_v3',
+    'run2_mc_cosmics'   :   '101X_mcRun2cosmics_startup_deco_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '101X_mcRun2_HeavyIon_v4',
+    'run2_mc_hi'        :   '101X_mcRun2_HeavyIon_v5',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '101X_mcRun2_pA_v3',
+    'run2_mc_pa'        :   '101X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '101X_dataRun2_v7',
     # GlobalTag for Run2 data reprocessing
@@ -40,25 +40,25 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v5',
+    'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '101X_mc2017_realistic_v5',
+    'phase1_2017_realistic'    : '101X_mc2017_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '101X_mc2017cosmics_realistic_deco_v5',
+    'phase1_2017_cosmics'      : '101X_mc2017cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v5',
+    'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '101X_upgrade2018_design_v7',
+    'phase1_2018_design'       : '101X_upgrade2018_design_v8',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v6',
+    'phase1_2018_realistic'    : '101X_upgrade2018_realistic_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v7',
+    'phase1_2018_cosmics'      :   '101X_upgrade2018cosmics_realistic_deco_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '101X_postLS2_design_v4', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '101X_postLS2_design_v5', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'       : '101X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'       : '101X_postLS2_realistic_v5', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '101X_upgrade2023_realistic_v4'
+    'phase2_realistic'         : '101X_upgrade2023_realistic_v5'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,21 +24,21 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '101X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '101X_dataRun2_v7',
+    'run1_data'         :   '101X_dataRun2_v8',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '101X_dataRun2_v7',
+    'run2_data'         :   '101X_dataRun2_v8',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '101X_dataRun2_relval_v7',
+    'run2_data_relval'  :   '101X_dataRun2_relval_v8',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '101X_dataRun2_PromptLike_v7',
+    'run2_data_promptlike' : '101X_dataRun2_PromptLike_v8',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v5',
+    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v5',
+    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '101X_dataRun2_HLT_relval_v6',
+    'run2_hlt_relval'   :   '101X_dataRun2_HLT_relval_v7',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v6',
+    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,27 +2,27 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '101X_mcRun1_design_v3',
+    'run1_design'       :   '101X_mcRun1_design_v4',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '101X_mcRun1_realistic_v3',
+    'run1_mc'           :   '101X_mcRun1_realistic_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '101X_mcRun1_HeavyIon_v3',
+    'run1_mc_hi'        :   '101X_mcRun1_HeavyIon_v4',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '101X_mcRun1_pA_v3',
+    'run1_mc_pa'        :   '101X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '101X_mcRun2_design_v4',
+    'run2_design'       :   '101X_mcRun2_design_v5',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '101X_mcRun2_startup_v4',
+    'run2_mc_50ns'      :   '101X_mcRun2_startup_v5',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '101X_mcRun2_asymptotic_v4',
+    'run2_mc'           :   '101X_mcRun2_asymptotic_v5',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v5',
+    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v6',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '101X_mcRun2cosmics_startup_deco_v4',
+    'run2_mc_cosmics'   :   '101X_mcRun2cosmics_startup_deco_v5',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '101X_mcRun2_HeavyIon_v5',
+    'run2_mc_hi'        :   '101X_mcRun2_HeavyIon_v6',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '101X_mcRun2_pA_v4',
+    'run2_mc_pa'        :   '101X_mcRun2_pA_v5',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '101X_dataRun2_v8',
     # GlobalTag for Run2 data reprocessing
@@ -40,13 +40,13 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v6',
+    'phase1_2017_design'       :  '101X_mc2017_design_IdealBS_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '101X_mc2017_realistic_v6',
+    'phase1_2017_realistic'    : '101X_mc2017_realistic_v7',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '101X_mc2017cosmics_realistic_deco_v6',
+    'phase1_2017_cosmics'      : '101X_mc2017cosmics_realistic_deco_v7',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v6',
+    'phase1_2017_cosmics_peak' : '101X_mc2017cosmics_realistic_peak_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '101X_upgrade2018_design_v8',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,7 +16,7 @@ autoCond = {
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '101X_mcRun2_asymptotic_v5',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v6',
+    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '101X_mcRun2cosmics_startup_deco_v5',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2


### PR DESCRIPTION
# Summary of changes in Global Tags

## RunII data

   * **RunII HLTHI processing** : [101X_dataRun2_HLTHI_frozen_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLTHI_frozen_v7) as [101X_dataRun2_HLTHI_frozen_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLTHI_frozen_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_HLTHI_frozen_v7/101X_dataRun2_HLTHI_frozen_v6):
      * Ecal PFRecHit Thresholds 
      * PFClusterCor (ecal and jetmet)

   * **RunII HLT relval processing** : [101X_dataRun2_HLT_relval_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLT_relval_v7) as [101X_dataRun2_HLT_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLT_relval_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_HLT_relval_v7/101X_dataRun2_HLT_relval_v6):
      * Ecal PFRecHit Thresholds 
      * PFClusterCor (ecal)
      * L1Menu_Collisions2018_v0_0_1

   * **RunII Offline processing** : [101X_dataRun2_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_v8) as [101X_dataRun2_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_v8/101X_dataRun2_v7):
      * Ecal PFRecHit Thresholds
      * PFClusterCor (ecal)
      * Hcal offline RespCorrs, RecoParams
      * PFCalibration_v9_mc

   * **RunII Offline relval processing** : [101X_dataRun2_relval_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_relval_v8) as [101X_dataRun2_relval_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_relval_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_relval_v8/101X_dataRun2_relval_v7):
      * Ecal PFRecHit Thresholds
      * Hcal offline RespCorrs, RecoParams
      * PFClusterCor (ecal)
      * PFCalibration_v9_mc
      * L1Menu_Collisions2018_v0_0_1

   * **RunII Prompt processing** : [101X_dataRun2_PromptLike_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_PromptLike_v8) as [101X_dataRun2_PromptLike_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_PromptLike_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_PromptLike_v8/101X_dataRun2_PromptLike_v7):
      * Ecal PFRecHit Thresholds
      * ecalPFClusterCor2018V1_E
      * L1Menu_Collisions2018_v0_0_1
      * PFCalibration_v9_mc

   * **RunI HLT processing** : [101X_dataRun2_HLT_frozen_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLT_frozen_v6) as [101X_dataRun2_HLT_frozen_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_dataRun2_HLT_frozen_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_HLT_frozen_v6/101X_dataRun2_HLT_frozen_v5):
      * Ecal PFRecHit Thresholds

## RunI simulation

   * **RunI Heavy Ions scenario** : [101X_mcRun1_HeavyIon_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_HeavyIon_v4) as [101X_mcRun1_HeavyIon_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun1_HeavyIon_v4/101X_mcRun1_HeavyIon_v2):
      * PF Calibration (ecal, jetmet)
      * Ecal PFRecHit Thresholds

   * **RunI Ideal scenario** : [101X_mcRun1_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_design_v4) as [101X_mcRun1_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_design_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun1_design_v4/101X_mcRun1_design_v2):
      * PF Calibration (ecal, jetmet) 
      * PFCalibration (jet met)

   * **RunI Proton-Lead scenario** : [101X_mcRun1_pA_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_pA_v4) as [101X_mcRun1_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_pA_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun1_pA_v4/101X_mcRun1_pA_v2):
      * EcalPFRecHitThresholds_2018_v1_mc 
      * PF Calibration (ecal, jetmet)

   * **RunI Realistic scenario** : [101X_mcRun1_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_realistic_v4) as [101X_mcRun1_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun1_realistic_v4/101X_mcRun1_realistic_v2):
      * EcalPFRecHitThresholds_2018_v1_mc
      * PF Calibration (ecal, jetmet)

## RunII simulation

   * **RunII Asymptotic scenario** : [101X_mcRun2_asymptotic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_asymptotic_v6) as [101X_mcRun2_asymptotic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_asymptotic_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun2_asymptotic_v6/101X_mcRun2_asymptotic_v4):
      * EcalPFRecHitThresholds
      * PF Calibration (ecal, jetmet)

   * **RunII CRAFT scenario** : [101X_mcRun2cosmics_startup_deco_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2cosmics_startup_deco_v5) as [101X_mcRun2cosmics_startup_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2cosmics_startup_deco_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun2cosmics_startup_deco_v5/101X_mcRun2cosmics_startup_deco_v3):
      * EcalPFRecHitThresholds
      * PF Calibration (ecal, jetmet)

   * **RunII Heavy Ions scenario** : [101X_mcRun2_HeavyIon_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_HeavyIon_v6) as [101X_mcRun2_HeavyIon_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_HeavyIon_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun2_HeavyIon_v6/101X_mcRun2_HeavyIon_v4):
      * EcalPFRecHitThresholds
      * PF Calibration (ecal, jetmet)

   * **RunII Ideal scenario** : [101X_mcRun2_design_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_design_v5) as [101X_mcRun2_design_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_design_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun2_design_v5/101X_mcRun2_design_v3):
      * EcalPFRecHitThresholds
      * PF Calibration (ecal, jetmet)

   * **RunII Proton-Lead scenario** : [101X_mcRun2_pA_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_pA_v5) as [101X_mcRun2_pA_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_pA_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun2_pA_v5/101X_mcRun2_pA_v3):
      * EcalPFRecHitThresholds
      * PF Calibration (ecal, jetmet)

   * **RunII Startup scenario** : [101X_mcRun2_startup_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_startup_v5) as [101X_mcRun2_startup_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun2_startup_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun2_startup_v5/101X_mcRun2_startup_v3):
      * EcalPFRecHitThresholds
      * PF Calibration (ecal, jetmet)

## Upgrade
   * **LS2 realistic scenario** : [101X_postLS2_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_postLS2_realistic_v5) as [101X_postLS2_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_postLS2_realistic_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_postLS2_realistic_v5/101X_postLS2_realistic_v4):
      * CSC Chamber Time Corrections
      * L1Menu_Collisions2018_v0_0_1
      * GEM Geometry
      * PF Correction (ECAL)
      * EcalPFRecHitThresholds
      * PFCalibration (jet met)

   * **LS2 ideal scenario** : [101X_postLS2_design_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_postLS2_design_v5) as [101X_postLS2_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_postLS2_design_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_postLS2_design_v5/101X_postLS2_design_v4):
      * CSC Chamber Time Corrections
      * L1Menu_Collisions2018_v0_0_1
      * GEM Geometry
      * PF Correction (ECAL)
      * EcalPFRecHitThresholds
      * PFCalibration (jet met)

   * **PhaseII realistic scenario** : [101X_upgrade2023_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2023_realistic_v5) as [101X_upgrade2023_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2023_realistic_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2023_realistic_v5/101X_upgrade2023_realistic_v4):
      * CSC Chamber Time Corrections
      * L1Menu_Collisions2018_v0_0_1
      * GEM Geometry
      * PF Correction (ECAL)
      * EcalPFRecHitThresholds
      * PFCalibration (jet met)

   * **PhaseI 2018 cosmics scenario** : [101X_upgrade2018cosmics_realistic_deco_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018cosmics_realistic_deco_v8) as [101X_upgrade2018cosmics_realistic_deco_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018cosmics_realistic_deco_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2018cosmics_realistic_deco_v8/101X_upgrade2018cosmics_realistic_deco_v5):
      * CSC Chamber Time Corrections
      * L1Menu_Collisions2018_v0_0_1
      * GEM Geometry
      * PF Correction (ECAL)
      * EcalPFRecHitThresholds
      * PFCalibration (jet met)
      * Hcal QIEData, SiPMParam, Gains, Pedestal, Widths (effective and not)

   * **PhaseI 2018 design scenario** : [101X_upgrade2018_design_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018_design_v8) as [101X_upgrade2018_design_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018_design_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2018_design_v8/101X_upgrade2018_design_v7):
      * CSC Chamber Time Corrections
      * L1Menu_Collisions2018_v0_0_1
      * GEM Geometry
      * PF Correction (ECAL)
      * EcalPFRecHitThresholds
      * PFCalibration (jet met)
      * Hcal QIEData, SiPMParam, Gains, Pedestal, Widths (effective and not)

   * **PhaseI 2018 realistic scenario** : [101X_upgrade2018_realistic_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018_realistic_v7) as [101X_upgrade2018_realistic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_upgrade2018_realistic_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_upgrade2018_realistic_v7/101X_upgrade2018_realistic_v6):
      * CSC Chamber Time Corrections
      * L1Menu_Collisions2018_v0_0_1
      * GEM Geometry
      * PF Correction (ECAL)
      * EcalPFRecHitThresholds
      * PFCalibration (jet met)
      * Hcal QIEData, SiPMParam, Gains, Pedestal, Widths (effective and not)

## 2017_MC

   * **PhaseI 2017 cosmics peak scenario** : [101X_mc2017cosmics_realistic_peak_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017cosmics_realistic_peak_v7) as [101X_mc2017cosmics_realistic_peak_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017cosmics_realistic_peak_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mc2017cosmics_realistic_peak_v7/101X_mc2017cosmics_realistic_peak_v5):
      * PF Calibration (ecal, jetmet)
      * EcalPFRecHitThresholds

   * **PhaseI 2017 cosmics scenario** : [101X_mc2017cosmics_realistic_deco_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017cosmics_realistic_deco_v7) as [101X_mc2017cosmics_realistic_deco_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017cosmics_realistic_deco_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mc2017cosmics_realistic_deco_v7/101X_mc2017cosmics_realistic_deco_v5):
      * PF Calibration (ecal, jetmet)
      * EcalPFRecHitThresholds

   * **PhaseI 2017 design scenario** : [101X_mc2017_design_IdealBS_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017_design_IdealBS_v7) as [101X_mc2017_design_IdealBS_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017_design_IdealBS_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mc2017_design_IdealBS_v7/101X_mc2017_design_IdealBS_v5):
      * PF Calibration (ecal, jetmet)
      * EcalPFRecHitThresholds

   * **PhaseI 2017 realistic scenario** : [101X_mc2017_realistic_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017_realistic_v7) as [101X_mc2017_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mc2017_realistic_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mc2017_realistic_v7/101X_mc2017_realistic_v5):
      * PF Calibration (ecal, jetmet)
      * EcalPFRecHitThresholds