### PR TITLE
EMTF April 2018 emulator update part 2 - GEM and Track Trigger data formats

### DIFF
--- a/DataFormats/L1TMuon/interface/EMTFHit.h
+++ b/DataFormats/L1TMuon/interface/EMTFHit.h
@@ -11,9 +11,11 @@
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/MuonDetId/interface/ME0DetId.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
 #include "DataFormats/RPCDigi/interface/RPCDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigi.h"
 #include "DataFormats/L1TMuon/interface/EMTF/ME.h"
 
 namespace l1t {
@@ -22,15 +24,16 @@ namespace l1t {
   public:
 
     EMTFHit() :
-    endcap(-99), station(-99), ring(-99), sector(-99), sector_RPC(-99), sector_idx(-99), 
-      subsector(-99), subsector_RPC(-99), chamber(-99), csc_ID(-99), csc_nID(-99), roll(-99), 
+      rawDetId(0),
+      endcap(-99), station(-99), ring(-99), sector(-99), sector_RPC(-99), sector_idx(-99),
+      subsector(-99), subsector_RPC(-99), chamber(-99), csc_ID(-99), csc_nID(-99), roll(-99),
       neighbor(-99), mpc_link(-99), pc_sector(-99), pc_station(-99), pc_chamber(-99), pc_segment(-99),
       wire(-99), strip(-99), strip_hi(-99), strip_low(-99), track_num(-99), quality(-99),
       pattern(-99), bend(-99), valid(-99), sync_err(-99), bc0(-99), bx(-99), stub_num(-99),
       phi_fp(-99), theta_fp(-99), phzvl(-99), ph_hit(-99), zone_hit(-99), zone_code(-99),
       fs_segment(-99), fs_zone_code(-99), bt_station(-99), bt_segment(-99),
-      phi_loc(-99), phi_glob(-999), theta(-99), eta(-99),
-      phi_sim(-999), theta_sim(-99), eta_sim(-99),
+      phi_loc(-99), phi_glob(-999), theta(-99), eta(-99), time(-99),
+      phi_sim(-999), theta_sim(-99), eta_sim(-99), rho_sim(-99), z_sim(-99),
       is_CSC(-99), is_RPC(-99), is_GEM(-99), subsystem(-99)
       {};
 
@@ -52,19 +55,27 @@ namespace l1t {
     // void PrintSimulatorHeader() const;
     // void PrintForSimulator() const;
 
-    void SetCSCDetId   (const CSCDetId& id)                 { csc_DetId         = id;        }
-    void SetRPCDetId   (const RPCDetId& id)                 { rpc_DetId         = id;        }
-    void SetGEMDetId   (const GEMDetId& id)                 { gem_DetId         = id;        }
-    void SetCSCLCTDigi (const CSCCorrelatedLCTDigi& digi)   { csc_LCTDigi       = digi;      }
-    void SetRPCDigi    (const RPCDigi& digi)                { rpc_Digi          = digi;      }
-    void SetGEMPadDigi (const GEMPadDigi& digi)             { gem_PadDigi       = digi;      }
+    //void SetCSCDetId   (const CSCDetId& id)                 { csc_DetId         = id;        }
+    //void SetRPCDetId   (const RPCDetId& id)                 { rpc_DetId         = id;        }
+    //void SetGEMDetId   (const GEMDetId& id)                 { gem_DetId         = id;        }
+    //void SetCSCLCTDigi (const CSCCorrelatedLCTDigi& digi)   { csc_LCTDigi       = digi;      }
+    //void SetRPCDigi    (const RPCDigi& digi)                { rpc_Digi          = digi;      }
+    //void SetGEMPadDigi (const GEMPadDigi& digi)             { gem_PadDigi       = digi;      }
+    void SetCSCDetId   (const CSCDetId& id)                 { rawDetId = id.rawId(); }
+    void SetRPCDetId   (const RPCDetId& id)                 { rawDetId = id.rawId(); }
+    void SetGEMDetId   (const GEMDetId& id)                 { rawDetId = id.rawId(); }
+    void SetME0DetId   (const ME0DetId& id)                 { rawDetId = id.rawId(); }
 
-    CSCDetId CSC_DetId                          () const { return csc_DetId;    }
-    RPCDetId RPC_DetId                          () const { return rpc_DetId;    }
-    GEMDetId GEM_DetId                          () const { return gem_DetId;    }
-    CSCCorrelatedLCTDigi CSC_LCTDigi            () const { return csc_LCTDigi;  }
-    RPCDigi RPC_Digi                            () const { return rpc_Digi;     }
-    GEMPadDigi GEM_PadDigi                      () const { return gem_PadDigi;  }
+    //CSCDetId CSC_DetId                          () const { return csc_DetId;    }
+    //RPCDetId RPC_DetId                          () const { return rpc_DetId;    }
+    //GEMDetId GEM_DetId                          () const { return gem_DetId;    }
+    //CSCCorrelatedLCTDigi CSC_LCTDigi            () const { return csc_LCTDigi;  }
+    //RPCDigi RPC_Digi                            () const { return rpc_Digi;     }
+    //GEMPadDigi GEM_PadDigi                      () const { return gem_PadDigi;  }
+    CSCDetId CSC_DetId                          () const { return CSCDetId(rawDetId); }
+    RPCDetId RPC_DetId                          () const { return RPCDetId(rawDetId); }
+    GEMDetId GEM_DetId                          () const { return GEMDetId(rawDetId); }
+    ME0DetId ME0_DetId                          () const { return ME0DetId(rawDetId); }
 
     void set_endcap       (int  bits) { endcap       = bits; }
     void set_station      (int  bits) { station      = bits; }
@@ -111,9 +122,12 @@ namespace l1t {
     void set_phi_glob     (float val) { phi_glob     = val;  }
     void set_theta        (float val) { theta        = val;  }
     void set_eta          (float val) { eta          = val;  }
+    void set_time         (float val) { time         = val;  }
     void set_phi_sim      (float val) { phi_sim      = val;  }
     void set_theta_sim    (float val) { theta_sim    = val;  }
     void set_eta_sim      (float val) { eta_sim      = val;  }
+    void set_rho_sim      (float val) { rho_sim      = val;  }
+    void set_z_sim        (float val) { z_sim        = val;  }
     void set_is_CSC       (int  bits) { is_CSC       = bits; }
     void set_is_RPC       (int  bits) { is_RPC       = bits; }
     void set_is_GEM       (int  bits) { is_GEM       = bits; }
@@ -164,9 +178,12 @@ namespace l1t {
     float Phi_glob     ()  const { return phi_glob    ; }
     float Theta        ()  const { return theta       ; }
     float Eta          ()  const { return eta         ; }
+    float Time         ()  const { return time        ; }
     float Phi_sim      ()  const { return phi_sim     ; }
     float Theta_sim    ()  const { return theta_sim   ; }
     float Eta_sim      ()  const { return eta_sim     ; }
+    float Rho_sim      ()  const { return rho_sim     ; }
+    float Z_sim        ()  const { return z_sim       ; }
     int   Is_CSC       ()  const { return is_CSC      ; }
     int   Is_RPC       ()  const { return is_RPC      ; }
     int   Is_GEM       ()  const { return is_GEM      ; }
@@ -175,12 +192,14 @@ namespace l1t {
 
   private:
 
-    CSCDetId csc_DetId;
-    RPCDetId rpc_DetId;
-    GEMDetId gem_DetId;
-    CSCCorrelatedLCTDigi csc_LCTDigi;
-    RPCDigi rpc_Digi;
-    GEMPadDigi gem_PadDigi;
+    //CSCDetId csc_DetId;
+    //RPCDetId rpc_DetId;
+    //GEMDetId gem_DetId;
+    //CSCCorrelatedLCTDigi csc_LCTDigi;
+    //RPCDigi rpc_Digi;
+    //GEMPadDigi gem_PadDigi;
+
+    uint32_t rawDetId;  // raw CMSSW DetId
 
     int   endcap      ; //    +/-1.  For ME+ and ME-.
     int   station     ; //  1 -  4.
@@ -227,9 +246,12 @@ namespace l1t {
     float phi_glob    ; // +/-180.
     float theta       ; // 0 - 90.
     float eta         ; // +/-2.5.
+    float time        ; //  ? -  ?.  RPC time information
     float phi_sim     ; // +/-180.
     float theta_sim   ; // 0 - 90.
     float eta_sim     ; // +/-2.5.
+    float rho_sim     ; //  ? -  ?.
+    float z_sim       ; //  ? -  ?.
     int   is_CSC      ; //  0 or 1.
     int   is_RPC      ; //  0 or 1.
     int   is_GEM      ; //  0 or 1.

--- a/DataFormats/L1TMuon/interface/EMTFTrack.h
+++ b/DataFormats/L1TMuon/interface/EMTFTrack.h
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 #include <vector>
-#include <cmath>
 
 #include "DataFormats/L1TMuon/interface/EMTFHit.h"
 #include "DataFormats/L1TMuon/interface/EMTFRoad.h"
@@ -51,17 +50,21 @@ namespace l1t {
     void ImportSP( const emtf::SP _SP, int _sector );
     // void ImportPtLUT( int _mode, unsigned long _address );
 
-    void clear_Hits() { 
-      _Hits.clear();  numHits = 0;
-      mode_CSC = 0;  mode_RPC = 0;  mode_neighbor = 0;
+
+    void clear_Hits() {
+      _Hits.clear();
+      numHits       = 0;
+      mode_CSC      = 0;
+      mode_RPC      = 0;
+      mode_neighbor = 0;
     }
 
     void push_Hit(const EMTFHit& hit) {
-      _Hits.push_back( hit );  
-      numHits = _Hits.size();  
-      mode_CSC      += ( hit.Is_CSC()   ? pow(2, 4 - hit.Station()) : 0 ); 
-      mode_RPC      += ( hit.Is_RPC()   ? pow(2, 4 - hit.Station()) : 0 ); 
-      mode_neighbor += ( hit.Neighbor() ? pow(2, 4 - hit.Station()) : 0 ); 
+      _Hits.push_back( hit );
+      numHits       = _Hits.size();
+      if (hit.Is_CSC())   mode_CSC      |= (1 << (4 - hit.Station()));
+      if (hit.Is_RPC())   mode_RPC      |= (1 << (4 - hit.Station()));
+      if (hit.Neighbor()) mode_neighbor |= (1 << (4 - hit.Station()));
     }
 
     void set_Hits(const EMTFHitCollection& hits) {
@@ -70,9 +73,9 @@ namespace l1t {
         push_Hit( hit );
     }
 
-    void set_HitIdx(const std::vector<unsigned int>& bits) { _HitIdx = bits;          }
     void clear_HitIdx()                                    { _HitIdx.clear();         }
     void push_HitIdx(unsigned int bits)                    { _HitIdx.push_back(bits); }
+    void set_HitIdx(const std::vector<unsigned int>& bits) { _HitIdx = bits;          }
 
     int NumHits                      () const { return numHits; }
     EMTFHitCollection Hits           () const { return _Hits;   }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
@@ -190,7 +190,7 @@ namespace l1t {
 	(res->at(iOut)).push_ME(ME_);
 	res_hit->push_back(Hit_);
 	if (not duplicate_hit_exists) // Don't write duplicate LCTs from adjacent sectors
-	  res_LCT->insertDigi( Hit_.CSC_DetId(), Hit_.CSC_LCTDigi() );
+	  res_LCT->insertDigi( Hit_.CSC_DetId(), Hit_.CreateCSCCorrelatedLCTDigi() );
 
 	// Finished with unpacking one ME Data Record
 	return true;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
@@ -31,7 +31,7 @@ namespace l1t {
 							_hit.Subsector(), _hit.Ring(), _hit.CSC_ID() ) );
 
         _hit.SetCSCDetId   ( _hit.CreateCSCDetId() );
-        _hit.SetCSCLCTDigi ( _hit.CreateCSCCorrelatedLCTDigi() );
+        //_hit.SetCSCLCTDigi ( _hit.CreateCSCCorrelatedLCTDigi() );
 	
 	// Station, CSC_ID, Sector, Subsector, and Neighbor filled in
 	// EventFilter/L1TRawToDigi/src/implementations_stage2/EMTFBlockME.cc

--- a/L1Trigger/L1TMuon/BuildFile.xml
+++ b/L1Trigger/L1TMuon/BuildFile.xml
@@ -29,3 +29,6 @@
 
 <use name="MagneticField/Engine"/>
 <use name="MagneticField/Records"/>
+
+<use name="DataFormats/L1TrackTrigger"/>
+<use name="Geometry/TrackerGeometryBuilder"/>

--- a/L1Trigger/L1TMuon/interface/GeometryTranslator.h
+++ b/L1Trigger/L1TMuon/interface/GeometryTranslator.h
@@ -1,6 +1,6 @@
-#ifndef __L1TMUON_GEOMETRYTRANSLATOR_H__
-#define __L1TMUON_GEOMETRYTRANSLATOR_H__
-// 
+#ifndef __L1TMuon_GeometryTranslator_h__
+#define __L1TMuon_GeometryTranslator_h__
+//
 // Class: L1TMuon::GeometryTranslator
 //
 // Info: This class implements a the translations from packed bits or
@@ -21,10 +21,11 @@
 
 
 // forwards
-namespace edm {  
+namespace edm {
   class EventSetup;
 }
 
+class ME0Geometry;
 class GEMGeometry;
 class RPCGeometry;
 class CSCGeometry;
@@ -48,6 +49,7 @@ namespace L1TMuon {
 
     void checkAndUpdateGeometry(const edm::EventSetup&);
 
+    const ME0Geometry& getME0Geometry() const { return *_geome0; }
     const GEMGeometry& getGEMGeometry() const { return *_geogem; }
     const RPCGeometry& getRPCGeometry() const { return *_georpc; }
     const CSCGeometry& getCSCGeometry() const { return *_geocsc; }
@@ -58,6 +60,7 @@ namespace L1TMuon {
   private:
     // pointers to the current geometry records
     unsigned long long _geom_cache_id;
+    edm::ESHandle<ME0Geometry> _geome0;
     edm::ESHandle<GEMGeometry> _geogem;
     edm::ESHandle<RPCGeometry> _georpc;
     edm::ESHandle<CSCGeometry> _geocsc;

--- a/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
+++ b/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
@@ -1,5 +1,5 @@
-#ifndef __L1TMUON_TRIGGERPRIMITIVE_H__
-#define __L1TMUON_TRIGGERPRIMITIVE_H__
+#ifndef __L1TMuon_TriggerPrimitive_h__
+#define __L1TMuon_TriggerPrimitive_h__
 //
 // Class: L1TMuon::TriggerPrimitive
 //
@@ -26,9 +26,6 @@
 //Global point (created on the fly)
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
-// Forward declaration
-#include "L1Trigger/L1TMuon/interface/MuonTriggerPrimitiveFwd.h"
-
 // DT digi types
 class DTChamberId;
 class L1MuDTChambPhDigi;
@@ -39,12 +36,16 @@ class CSCCorrelatedLCTDigi;
 class CSCDetId;
 
 // RPC digi types
-class RPCDigiL1Link;
+class RPCDigi;
 class RPCDetId;
 
 // GEM digi types
 class GEMPadDigi;
 class GEMDetId;
+
+// ME0 digi types
+class ME0PadDigi;
+class ME0DetId;
 
 
 namespace L1TMuon {
@@ -59,13 +60,14 @@ namespace L1TMuon {
     // within a subsystem
     // for RPCs you have to unroll the digi-link and raw det-id
     struct RPCData {
-    RPCData() : strip(0), strip_low(0), strip_hi(0), layer(0), bx(0), valid(0) {}
+      RPCData() : strip(0), strip_low(0), strip_hi(0), layer(0), bx(0), valid(0), time(0.) {}
       uint16_t strip;
       uint16_t strip_low; // for use in clustering
       uint16_t strip_hi;  // for use in clustering
       uint16_t layer;
       int16_t bx;
       uint16_t valid;
+      double time;  // why double?
     };
 
     struct CSCData {
@@ -114,11 +116,13 @@ namespace L1TMuon {
     };
 
     struct GEMData {
-      GEMData() : pad(0), pad_low(0), pad_hi(0), bx(0) {}
+      GEMData() : pad(0), pad_low(0), pad_hi(0), bx(0), bend(0), isME0(false) {}
       uint16_t pad;
       uint16_t pad_low; // for use in clustering
       uint16_t pad_hi;  // for use in clustering
       int16_t bx;
+      int16_t bend;
+      bool isME0;
     };
 
     //Persistency
@@ -140,6 +144,8 @@ namespace L1TMuon {
                      const CSCCorrelatedLCTDigi&);
     //RPC
     TriggerPrimitive(const RPCDetId& detid,
+                     const RPCDigi& digi);
+    TriggerPrimitive(const RPCDetId& detid,  // keep this version for backward compatibility
                      const unsigned strip,
                      const unsigned layer,
                      const int bx);
@@ -147,6 +153,8 @@ namespace L1TMuon {
     // GEM
     TriggerPrimitive(const GEMDetId& detid,
                      const GEMPadDigi& digi);
+    TriggerPrimitive(const ME0DetId& detid,
+                     const ME0PadDigi& digi);
 
     //copy
     TriggerPrimitive(const TriggerPrimitive&);
@@ -208,18 +216,14 @@ namespace L1TMuon {
   private:
     // Translate to 'global' position information at the level of 60
     // degree sectors. Use CSC sectors as a template
-    void calculateDTGlobalSector(const DTChamberId& chid,
-				 unsigned& global_sector,
-				 unsigned& subsector );
-    void calculateCSCGlobalSector(const CSCDetId& chid,
-				  unsigned& global_sector,
-				  unsigned& subsector );
-    void calculateRPCGlobalSector(const RPCDetId& chid,
-                                  unsigned& global_sector,
-                                  unsigned& subsector );
-    void calculateGEMGlobalSector(const GEMDetId& chid,
-                                  unsigned& global_sector,
-                                  unsigned& subsector );
+    template<typename IDType>
+      void calculateGlobalSector(const IDType& chid,
+                                 unsigned& globalsector,
+                                 unsigned& subsector ) {
+        // Not sure if this is ever going to get implemented
+        globalsector = 0;
+        subsector = 0;
+      }
 
     DTData  _dt;
     CSCData _csc;

--- a/L1Trigger/L1TMuon/interface/MuonTriggerPrimitiveFwd.h
+++ b/L1Trigger/L1TMuon/interface/MuonTriggerPrimitiveFwd.h
@@ -1,5 +1,5 @@
-#ifndef __L1TMUON_TRIGGERPRIMITIVEFWD_H__
-#define __L1TMUON_TRIGGERPRIMITIVEFWD_H__
+#ifndef __L1TMuon_TriggerPrimitiveFwd_h__
+#define __L1TMuon_TriggerPrimitiveFwd_h__
 
 #include <vector>
 #include <map>
@@ -14,7 +14,11 @@ namespace L1TMuon {
   //typedef edm::Ref<TriggerPrimitiveCollection> TriggerPrimitiveRef;
   //typedef std::vector<TriggerPrimitiveRef> TriggerPrimitiveList;
   //typedef edm::Ptr<TriggerPrimitive> TriggerPrimitivePtr;
-  typedef std::map<unsigned,TriggerPrimitiveCollection> TriggerPrimitiveStationMap;
+  //typedef std::map<unsigned,TriggerPrimitiveCollection> TriggerPrimitiveStationMap;
+
+  class TTTriggerPrimitive;  // Track Trigger hits
+
+  typedef std::vector<TTTriggerPrimitive> TTTriggerPrimitiveCollection;
 }
 
 #endif

--- a/L1Trigger/L1TMuon/interface/TTGeometryTranslator.h
+++ b/L1Trigger/L1TMuon/interface/TTGeometryTranslator.h
@@ -1,0 +1,74 @@
+#ifndef __L1TMuon_TTGeometryTranslator_h__
+#define __L1TMuon_TTGeometryTranslator_h__
+
+//
+// This class implements the translations from trigger primitive to
+// global CMS coordinates for the Tracker trigger primitives analogous to
+// the class GeometryTranslator.
+//
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include <memory>
+
+
+// forwards
+namespace edm {
+  class EventSetup;
+}
+
+class TrackerGeometry;
+class TrackerTopology;
+class MagneticField;
+
+namespace L1TMuon {
+
+  class TTTriggerPrimitive;
+
+  class TTGeometryTranslator {
+  public:
+    TTGeometryTranslator();
+    ~TTGeometryTranslator();
+
+    // Things you have to do to just get simple det id info...
+    bool isBarrel  (const TTTriggerPrimitive&) const;
+    bool isPSModule(const TTTriggerPrimitive&) const;
+    int  region    (const TTTriggerPrimitive&) const;  // 0 for Barrel, +/-1 for +/- Endcap
+    int  layer     (const TTTriggerPrimitive&) const;
+    int  ring      (const TTTriggerPrimitive&) const;
+    int  module    (const TTTriggerPrimitive&) const;
+
+    // The translations
+    double calculateGlobalEta(const TTTriggerPrimitive&) const;
+    double calculateGlobalPhi(const TTTriggerPrimitive&) const;
+    double calculateBendAngle(const TTTriggerPrimitive&) const;
+
+    GlobalPoint getGlobalPoint(const TTTriggerPrimitive&) const;
+
+    // Update geometry if necessary
+    void checkAndUpdateGeometry(const edm::EventSetup&);
+
+    // Retrieve the geometry records
+    const TrackerGeometry& getTrackerGeometry() const { return *_geom; }
+    const TrackerTopology& getTrackerTopology() const { return *_topo; }
+    const MagneticField& getMagneticField() const { return *_magfield; }
+
+  private:
+    // Pointers to the current geometry records
+    unsigned long long _geom_cache_id;
+    edm::ESHandle<TrackerGeometry> _geom;
+
+    unsigned long long _topo_cache_id;
+    edm::ESHandle<TrackerTopology> _topo;
+
+    unsigned long long _magfield_cache_id;
+    edm::ESHandle<MagneticField> _magfield;
+
+    GlobalPoint getTTSpecificPoint(const TTTriggerPrimitive&) const;
+    double calcTTSpecificEta(const TTTriggerPrimitive&) const;
+    double calcTTSpecificPhi(const TTTriggerPrimitive&) const;
+    double calcTTSpecificBend(const TTTriggerPrimitive&) const;
+  };
+}
+
+#endif

--- a/L1Trigger/L1TMuon/interface/TTMuonTriggerPrimitive.h
+++ b/L1Trigger/L1TMuon/interface/TTMuonTriggerPrimitive.h
@@ -1,0 +1,121 @@
+#ifndef __L1TMuon_TTMuonTriggerPrimitive_h__
+#define __L1TMuon_TTMuonTriggerPrimitive_h__
+
+//
+// This class implements a layer for Phase 2 Tracker trigger primitive
+// analogous to the class MuonTriggerPrimitive.
+//
+
+#include <cstdint>
+#include <vector>
+#include <iosfwd>
+
+// DetId
+#include "DataFormats/DetId/interface/DetId.h"
+// Global point
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+// Track trigger data formats
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+
+namespace L1TMuon {
+
+  class TTTriggerPrimitive {
+  public:
+    // Define the subsystems that we have available (none at the moment).
+    // Start at 20 for TTMuonTriggerPrimitive to avoid collision with MuonTriggerPrimitive
+    enum subsystem_type{kTT = 20, kNSubsystems};
+
+    // Rename these
+    typedef TTStub<Ref_Phase2TrackerDigi_>  TTDigi;
+    typedef DetId                           TTDetId;
+
+    // Define the raw data
+    struct TTData {
+      TTData() : row_f(0.), col_f(0.), bend(0), bx(0) {}
+      float row_f;  // why float?
+      float col_f;  // why float?
+      int bend;
+      int16_t bx;
+    };
+
+    // Persistency
+    TTTriggerPrimitive(): _subsystem(kNSubsystems) {}
+
+    // Constructor from track trigger digi
+    TTTriggerPrimitive(const TTDetId& detid, const TTDigi& digi);
+
+    // Copy constructor
+    TTTriggerPrimitive(const TTTriggerPrimitive&);
+
+    // Destructor
+    ~TTTriggerPrimitive() {}
+
+    // Assignment operator
+    TTTriggerPrimitive& operator=(const TTTriggerPrimitive& tp);
+
+    // Equality operator
+    bool operator==(const TTTriggerPrimitive& tp) const;
+
+    // Subsystem type
+    const subsystem_type subsystem() const { return _subsystem; }
+
+    // Global coordinates
+    const double getCMSGlobalEta() const { return _eta; }
+    void         setCMSGlobalEta(const double eta) { _eta = eta; }
+    const double getCMSGlobalPhi() const { return _phi; }
+    void         setCMSGlobalPhi(const double phi) { _phi = phi; }
+    const double getCMSGlobalRho() const { return _rho; }
+    void         setCMSGlobalRho(const double rho) { _rho = rho; }
+
+    const GlobalPoint getCMSGlobalPoint() const {
+      double theta = 2. * atan( exp(-_eta) );
+      return GlobalPoint( GlobalPoint::Cylindrical( _rho, _phi, _rho/tan(theta)) );
+    };
+
+
+    // Detector id
+    TTDetId detId() const { return _id; }
+
+    TTDetId rawId() const { return detId(); }
+
+    // Accessors to raw data
+    void setTTData(const TTData& data) { _data = data; }
+
+    const TTData  getTTData()  const { return _data; }
+
+    TTData&  accessTTData()  { return _data; }
+
+    // Accessors to common information
+    const int getStrip() const;
+    const int getSegment() const;
+    const int getBend() const;
+    const int getBX() const;
+
+    const unsigned getGlobalSector() const { return _globalsector; }
+    const unsigned getSubSector() const { return _subsector; }
+
+    void print(std::ostream&) const;
+
+  private:
+    // Translate to 'global' position information at the level of 60
+    // degree sectors. Use CSC sectors as a template
+    void calculateTTGlobalSector(const TTDetId& detid,
+                                 unsigned& globalsector,
+                                 unsigned& subsector );
+
+    TTData _data;
+
+    TTDetId _id;
+
+    subsystem_type _subsystem;
+
+    unsigned _globalsector; // [1,6] in 60 degree sectors
+    unsigned _subsector; // [1,2] in 30 degree partitions of a sector
+    double _eta, _phi, _rho;  // global pseudorapidity, phi, rho
+    double _theta; // bend angle with respect to ray from (0,0,0). // NOT USED
+  };
+
+}  // namespace L1TMuon
+
+#endif

--- a/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
+++ b/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
@@ -4,14 +4,16 @@
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhDigi.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThDigi.h"
-#include "DataFormats/RPCDigi/interface/RPCDigiL1Link.h"
+#include "DataFormats/RPCDigi/interface/RPCDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigi.h"
 
 // detector ID types
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/MuonDetId/interface/ME0DetId.h"
 
 using namespace L1TMuon;
 
@@ -25,7 +27,7 @@ TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
                                    const int segment_number):
   _id(detid),
   _subsystem(TriggerPrimitive::kDT) {
-  calculateDTGlobalSector(detid,_globalsector,_subsector);
+  calculateGlobalSector(detid,_globalsector,_subsector);
   // fill in information from theta trigger
   _dt.theta_bti_group = -1;
   _dt.segment_number = segment_number;
@@ -48,7 +50,7 @@ TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
                                    const int theta_bti_group):
   _id(detid),
   _subsystem(TriggerPrimitive::kDT) {
-  calculateDTGlobalSector(detid,_globalsector,_subsector);
+  calculateGlobalSector(detid,_globalsector,_subsector);
   // fill in information from theta trigger
   _dt.theta_bti_group = theta_bti_group;
   _dt.segment_number = digi_th.position(theta_bti_group);
@@ -72,7 +74,7 @@ TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
                                    const int theta_bti_group):
   _id(detid),
   _subsystem(TriggerPrimitive::kDT) {
-  calculateDTGlobalSector(detid,_globalsector,_subsector);
+  calculateGlobalSector(detid,_globalsector,_subsector);
   // fill in information from theta trigger
   _dt.theta_bti_group = theta_bti_group;
   _dt.segment_number = digi_th.position(theta_bti_group);
@@ -95,7 +97,7 @@ TriggerPrimitive::TriggerPrimitive(const CSCDetId& detid,
                                    const CSCCorrelatedLCTDigi& digi):
   _id(detid),
   _subsystem(TriggerPrimitive::kCSC) {
-  calculateCSCGlobalSector(detid,_globalsector,_subsector);
+  calculateGlobalSector(detid,_globalsector,_subsector);
   _csc.trknmb  = digi.getTrknmb();
   _csc.valid   = digi.isValid();
   _csc.quality = digi.getQuality();
@@ -119,18 +121,33 @@ TriggerPrimitive::TriggerPrimitive(const CSCDetId& detid,
 
 // constructor from RPC data
 TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid,
+                                   const RPCDigi& digi):
+  _id(detid),
+  _subsystem(TriggerPrimitive::kRPC) {
+  calculateGlobalSector(detid,_globalsector,_subsector);
+  _rpc.strip = digi.strip();
+  _rpc.strip_low = digi.strip();
+  _rpc.strip_hi = digi.strip();
+  _rpc.layer = detid.layer();
+  _rpc.bx = digi.bx();
+  _rpc.valid = 1;
+  _rpc.time = digi.time();
+}
+
+TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid,
                                    const unsigned strip,
                                    const unsigned layer,
                                    const int bx):
   _id(detid),
   _subsystem(TriggerPrimitive::kRPC) {
-  calculateRPCGlobalSector(detid,_globalsector,_subsector);
+  calculateGlobalSector(detid,_globalsector,_subsector);
   _rpc.strip = strip;
   _rpc.strip_low = strip;
   _rpc.strip_hi = strip;
   _rpc.layer = layer;
   _rpc.bx = bx;
   _rpc.valid = 1;
+  _rpc.time = -999999.;
 }
 
 
@@ -139,11 +156,26 @@ TriggerPrimitive::TriggerPrimitive(const GEMDetId& detid,
                                    const GEMPadDigi& digi):
   _id(detid),
   _subsystem(TriggerPrimitive::kGEM) {
-  calculateGEMGlobalSector(detid,_globalsector,_subsector);
+  calculateGlobalSector(detid,_globalsector,_subsector);
   _gem.pad = digi.pad();
   _gem.pad_low = digi.pad();
   _gem.pad_hi = digi.pad();
   _gem.bx = digi.bx();
+  _gem.bend = 0;
+  _gem.isME0 = false;
+}
+
+TriggerPrimitive::TriggerPrimitive(const ME0DetId& detid,
+                                   const ME0PadDigi& digi):
+  _id(detid),
+  _subsystem(TriggerPrimitive::kGEM) {
+  calculateGlobalSector(detid,_globalsector,_subsector);
+  _gem.pad = digi.pad();
+  _gem.pad_low = digi.pad();
+  _gem.pad_hi = digi.pad();
+  _gem.bx = digi.bx();
+  _gem.bend = 0;
+  _gem.isME0 = true;
 }
 
 TriggerPrimitive::TriggerPrimitive(const TriggerPrimitive& tp):
@@ -209,10 +241,13 @@ bool TriggerPrimitive::operator==(const TriggerPrimitive& tp) const {
            this->_rpc.layer == tp._rpc.layer &&
            this->_rpc.bx == tp._rpc.bx &&
            this->_rpc.valid == tp._rpc.valid &&
+           //this->_rpc.time == tp._rpc.time &&
            this->_gem.pad == tp._gem.pad &&
            this->_gem.pad_low == tp._gem.pad_low &&
            this->_gem.pad_hi == tp._gem.pad_hi &&
            this->_gem.bx == tp._gem.bx &&
+           this->_gem.bend == tp._gem.bend &&
+           this->_gem.isME0 == tp._gem.isME0 &&
            this->_id == tp._id &&
            this->_subsystem == tp._subsystem &&
            this->_globalsector == tp._globalsector &&
@@ -291,39 +326,11 @@ const int TriggerPrimitive::getPattern() const {
   return -1;
 }
 
-void TriggerPrimitive::calculateDTGlobalSector(const DTChamberId& chid,
-                                               unsigned& global_sector,
-                                               unsigned& subsector ) {
-  global_sector = 0;
-  subsector = 0;
-}
-
-void TriggerPrimitive::calculateCSCGlobalSector(const CSCDetId& chid,
-                                                unsigned& global_sector,
-                                                unsigned& subsector ) {
-  global_sector = 0;
-  subsector = 0;
-}
-
-void TriggerPrimitive::calculateRPCGlobalSector(const RPCDetId& chid,
-                                                unsigned& global_sector,
-                                                unsigned& subsector ) {
-  global_sector = 0;
-  subsector = 0;
-}
-
-void TriggerPrimitive::calculateGEMGlobalSector(const GEMDetId& chid,
-                                                unsigned& global_sector,
-                                                unsigned& subsector ) {
-  global_sector = 0;
-  subsector = 0;
-}
-
 void TriggerPrimitive::print(std::ostream& out) const {
   unsigned idx = (unsigned) _subsystem;
   out << subsystem_names[idx] << " Trigger Primitive" << std::endl;
-  out << "eta: " << _eta << " phi: " << _phi
-      << " bend: " << _theta << std::endl;
+  out << "eta: " << _eta << " phi: " << _phi << " rho: " << _rho
+      << " theta: " << _theta << std::endl;
   switch(_subsystem) {
   case kDT:
     out << detId<DTChamberId>() << std::endl;
@@ -361,13 +368,19 @@ void TriggerPrimitive::print(std::ostream& out) const {
     out << "Strip High    : " << _rpc.strip_hi << std::endl;
     out << "Layer         : " << _rpc.layer << std::endl;
     out << "Valid         : " << _rpc.valid << std::endl;
+    out << "Time          : " << _rpc.time << std::endl;
     break;
   case kGEM:
-    out << detId<GEMDetId>() << std::endl;
+    if (!_gem.isME0)
+      out << detId<GEMDetId>() << std::endl;
+    else
+      out << detId<ME0DetId>() << std::endl;
     out << "Local BX      : " << _gem.bx << std::endl;
     out << "Pad           : " << _gem.pad << std::endl;
     out << "Pad Low       : " << _gem.pad_low << std::endl;
     out << "Pad High      : " << _gem.pad_hi << std::endl;
+    out << "Packed Bend   : " << _gem.bend << std::endl;
+    out << "Is ME0        : " << _gem.isME0 << std::endl;
     break;
   default:
     throw cms::Exception("Invalid Subsytem")

--- a/L1Trigger/L1TMuon/src/TTGeometryTranslator.cc
+++ b/L1Trigger/L1TMuon/src/TTGeometryTranslator.cc
@@ -1,0 +1,195 @@
+#include "L1Trigger/L1TMuon/interface/TTGeometryTranslator.h"
+#include "L1Trigger/L1TMuon/interface/TTMuonTriggerPrimitive.h"
+
+// event setup stuff / geometries
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+using Phase2TrackerGeomDetUnit = PixelGeomDetUnit;
+using Phase2TrackerTopology    = PixelTopology;
+
+using namespace L1TMuon;
+
+
+TTGeometryTranslator::TTGeometryTranslator():
+  _geom_cache_id(0ULL), _topo_cache_id(0ULL), _magfield_cache_id(0ULL) {
+}
+
+TTGeometryTranslator::~TTGeometryTranslator() {
+}
+
+bool TTGeometryTranslator::isBarrel(const TTTriggerPrimitive& tp) const {
+  const DetId detId = tp.detId();
+  bool isBarrel = (detId.subdetId() == StripSubdetector::TOB);
+  //bool isEndcap = (detId.subdetId() == StripSubdetector::TID);
+  return isBarrel;
+}
+
+bool TTGeometryTranslator::isPSModule(const TTTriggerPrimitive& tp) const {
+  const DetId detId = tp.detId();
+  const TrackerGeometry::ModuleType moduleType = _geom->getDetectorType(detId);
+  bool isPSModule = (moduleType == TrackerGeometry::ModuleType::Ph2PSP) || (moduleType == TrackerGeometry::ModuleType::Ph2PSS);
+  //bool isSSModule = (moduleType == TrackerGeometry::ModuleType::Ph2SS);
+  return isPSModule;
+}
+
+int TTGeometryTranslator::region(const TTTriggerPrimitive& tp) const {
+  int region = 0;
+
+  const DetId detId = tp.detId();
+  if (detId.subdetId() == StripSubdetector::TOB) {  // barrel
+    region = 0;
+  } else if (detId.subdetId() == StripSubdetector::TID) {  // endcap
+    int type = _topo->tidSide(detId);   // 1=-ve 2=+ve
+    if (type == 1) {
+      region = -1;
+    } else if (type == 2) {
+      region = +1;
+    }
+  }
+  return region;
+}
+
+int TTGeometryTranslator::layer(const TTTriggerPrimitive& tp) const {
+  int layer = 0;
+
+  const DetId detId = tp.detId();
+  if (detId.subdetId() == StripSubdetector::TOB) {  // barrel
+    layer = static_cast<int>(_topo->layer(detId));
+  } else if (detId.subdetId() == StripSubdetector::TID) {  // endcap
+    layer = static_cast<int>(_topo->layer(detId));
+  }
+  return layer;
+}
+
+int TTGeometryTranslator::ring(const TTTriggerPrimitive& tp) const {
+  int ring = 0;
+
+  const DetId detId = tp.detId();
+  if (detId.subdetId() == StripSubdetector::TOB) {  // barrel
+    ring = static_cast<int>(_topo->tobRod(detId));
+  } else if (detId.subdetId() == StripSubdetector::TID) {  // endcap
+    ring = static_cast<int>(_topo->tidRing(detId));
+  }
+  return ring;
+}
+
+int TTGeometryTranslator::module(const TTTriggerPrimitive& tp) const {
+  int module = 0;
+
+  const DetId detId = tp.detId();
+  if (detId.subdetId() == StripSubdetector::TOB) {  // barrel
+    module = static_cast<int>(_topo->module(detId));
+  } else if (detId.subdetId() == StripSubdetector::TID) {  // endcap
+    module = static_cast<int>(_topo->module(detId));
+  }
+  return module;
+}
+
+double
+TTGeometryTranslator::calculateGlobalEta(const TTTriggerPrimitive& tp) const {
+  switch(tp.subsystem()) {
+  case TTTriggerPrimitive::kTT:
+    return calcTTSpecificEta(tp);
+    break;
+  default:
+    return std::nan("Invalid TP type!");
+    break;
+  }
+}
+
+double
+TTGeometryTranslator::calculateGlobalPhi(const TTTriggerPrimitive& tp) const {
+  switch(tp.subsystem()) {
+  case TTTriggerPrimitive::kTT:
+    return calcTTSpecificPhi(tp);
+    break;
+  default:
+    return std::nan("Invalid TP type!");
+    break;
+  }
+}
+
+double
+TTGeometryTranslator::calculateBendAngle(const TTTriggerPrimitive& tp) const {
+  switch(tp.subsystem()) {
+  case TTTriggerPrimitive::kTT:
+    return calcTTSpecificBend(tp);
+    break;
+  default:
+    return std::nan("Invalid TP type!");
+    break;
+  }
+}
+
+GlobalPoint
+TTGeometryTranslator::getGlobalPoint(const TTTriggerPrimitive& tp) const {
+  switch(tp.subsystem()) {
+  case TTTriggerPrimitive::kTT:
+    return getTTSpecificPoint(tp);
+    break;
+  default:
+    GlobalPoint ret(GlobalPoint::Polar(std::nan("Invalid TP type!"), std::nan("Invalid TP type!"), std::nan("Invalid TP type!")));
+    return ret;
+    break;
+  }
+}
+
+void TTGeometryTranslator::checkAndUpdateGeometry(const edm::EventSetup& es) {
+  const TrackerDigiGeometryRecord& geom = es.get<TrackerDigiGeometryRecord>();
+  unsigned long long geomid = geom.cacheIdentifier();
+  if( _geom_cache_id != geomid ) {
+    geom.get(_geom);
+    _geom_cache_id = geomid;
+  }
+
+  const TrackerTopologyRcd& topo = es.get<TrackerTopologyRcd>();
+  unsigned long long topoid = topo.cacheIdentifier();
+  if( _topo_cache_id != topoid ) {
+    topo.get(_topo);
+    _topo_cache_id = topoid;
+  }
+
+  const IdealMagneticFieldRecord& magfield = es.get<IdealMagneticFieldRecord>();
+  unsigned long long magfieldid = magfield.cacheIdentifier();
+  if( _magfield_cache_id != magfieldid ) {
+    magfield.get(_magfield);
+    _magfield_cache_id = magfieldid;
+  }
+}
+
+GlobalPoint
+TTGeometryTranslator::getTTSpecificPoint(const TTTriggerPrimitive& tp) const {
+  // Check L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
+  const DetId detId = tp.detId();
+  const GeomDetUnit* geoUnit = _geom->idToDetUnit(detId+1);  // det0
+  //const GeomDetUnit* geoUnit = _geom->idToDetUnit(detId+2);  // det1
+  const Phase2TrackerGeomDetUnit* ph2TkGeoUnit = dynamic_cast<const Phase2TrackerGeomDetUnit*>(geoUnit);
+  const MeasurementPoint mp(tp.getTTData().row_f, tp.getTTData().col_f);
+  const GlobalPoint gp = ph2TkGeoUnit->surface().toGlobal(ph2TkGeoUnit->specificTopology().localPosition(mp));
+  return gp;
+}
+
+double
+TTGeometryTranslator::calcTTSpecificEta(const TTTriggerPrimitive& tp) const {
+  return getTTSpecificPoint(tp).eta();
+}
+
+double
+TTGeometryTranslator::calcTTSpecificPhi(const TTTriggerPrimitive& tp) const {
+  return getTTSpecificPoint(tp).phi();
+}
+
+double
+TTGeometryTranslator::calcTTSpecificBend(const TTTriggerPrimitive& tp) const {
+  return tp.getTTData().bend;
+}

--- a/L1Trigger/L1TMuon/src/TTMuonTriggerPrimitive.cc
+++ b/L1Trigger/L1TMuon/src/TTMuonTriggerPrimitive.cc
@@ -1,0 +1,142 @@
+#include "L1Trigger/L1TMuon/interface/TTMuonTriggerPrimitive.h"
+
+#include <iostream>
+
+using namespace L1TMuon;
+
+namespace {
+  const char subsystem_names[][3] = {"TT"};
+}
+
+// Constructor from track trigger digi
+TTTriggerPrimitive::TTTriggerPrimitive(const TTDetId& detid, const TTDigi& digi):
+  _id(detid),
+  _subsystem(kTT) {
+  calculateTTGlobalSector(detid,_globalsector,_subsector);
+
+  const MeasurementPoint& mp = digi.getClusterRef(0)->findAverageLocalCoordinatesCentered();
+  _data.row_f = mp.x();
+  _data.col_f = mp.y();
+  _data.bend = digi.getTriggerBend();
+  _data.bx = 0;
+}
+
+// Copy constructor
+TTTriggerPrimitive::TTTriggerPrimitive(const TTTriggerPrimitive& tp):
+  _data(tp._data),
+  _id(tp._id),
+  _subsystem(tp._subsystem),
+  _globalsector(tp._globalsector),
+  _subsector(tp._subsector),
+  _eta(tp._eta),
+  _phi(tp._phi),
+  _rho(tp._rho),
+  _theta(tp._theta){
+}
+
+// Assignment operator
+TTTriggerPrimitive& TTTriggerPrimitive::operator=(const TTTriggerPrimitive& tp) {
+  this->_data = tp._data;
+  this->_id = tp._id;
+  this->_subsystem = tp._subsystem;
+  this->_globalsector = tp._globalsector;
+  this->_subsector = tp._subsector;
+  this->_eta = tp._eta;
+  this->_phi = tp._phi;
+  this->_rho = tp._rho;
+  this->_theta = tp._theta;
+  return *this;
+}
+
+// Equality operator
+bool TTTriggerPrimitive::operator==(const TTTriggerPrimitive& tp) const {
+  return ( static_cast<int>(this->_data.row_f) == static_cast<int>(tp._data.row_f) &&
+           static_cast<int>(this->_data.col_f) == static_cast<int>(tp._data.col_f) &&
+           this->_data.bend == tp._data.bend &&
+           this->_data.bx == tp._data.bx &&
+           this->_id == tp._id &&
+           this->_subsystem == tp._subsystem &&
+           this->_globalsector == tp._globalsector &&
+           this->_subsector == tp._subsector );
+}
+
+const int TTTriggerPrimitive::getBX() const {
+  switch(_subsystem) {
+  case kTT:
+    return _data.bx;
+  default:
+    throw cms::Exception("Invalid Subsytem")
+      << "The specified subsystem for this track stub is out of range"
+      << std::endl;
+  }
+  return -1;
+}
+
+const int TTTriggerPrimitive::getStrip() const {
+  switch(_subsystem) {
+  case kTT:
+    return static_cast<int>(_data.row_f);
+  default:
+    throw cms::Exception("Invalid Subsytem")
+      << "The specified subsystem for this track stub is out of range"
+      << std::endl;
+  }
+  return -1;
+}
+
+const int TTTriggerPrimitive::getSegment() const {
+  switch(_subsystem) {
+  case kTT:
+    return static_cast<int>(_data.col_f);
+  default:
+    throw cms::Exception("Invalid Subsytem")
+      << "The specified subsystem for this track stub is out of range"
+      << std::endl;
+  }
+  return -1;
+}
+
+const int TTTriggerPrimitive::getBend() const {
+  switch(_subsystem) {
+  case kTT:
+    return static_cast<int>(_data.bend);
+  default:
+    throw cms::Exception("Invalid Subsytem")
+      << "The specified subsystem for this track stub is out of range"
+      << std::endl;
+  }
+  return -1;
+}
+
+void TTTriggerPrimitive::calculateTTGlobalSector(const TTDetId& detid,
+                                                 unsigned& globalsector,
+                                                 unsigned& subsector ) {
+  globalsector = 0;
+  subsector = 0;
+}
+
+std::ostream& operator<<(std::ostream& os, const TTTriggerPrimitive::TTDetId& detid) {
+  // Note that there is no endl to end the output
+  os << " undefined";
+  return os;
+}
+
+void TTTriggerPrimitive::print(std::ostream& out) const {
+  unsigned idx = (unsigned) _subsystem;
+  out << subsystem_names[idx] << " Trigger Primitive" << std::endl;
+  out << "eta: " << _eta << " phi: " << _phi << " rho: " << _rho
+      << " bend: " << _theta << std::endl;
+  switch(_subsystem) {
+  case kTT:
+    out << detId() << std::endl;
+    out << "Strip         : " << static_cast<int>(_data.row_f) << std::endl;
+    out << "Segment       : " << static_cast<int>(_data.col_f) << std::endl;
+    out << "Bend          : " << _data.bend << std::endl;
+    out << "BX            : " << _data.bx << std::endl;
+    break;
+  default:
+    throw cms::Exception("Invalid Subsytem")
+      << "The specified subsystem for this track stub is out of range"
+      << std::endl;
+  }
+}

--- a/L1Trigger/L1TMuonEndCap/interface/Common.h
+++ b/L1Trigger/L1TMuonEndCap/interface/Common.h
@@ -9,6 +9,9 @@
 #include "L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h"
 #include "L1Trigger/L1TMuon/interface/MuonTriggerPrimitiveFwd.h"
 
+#include "L1Trigger/L1TMuon/interface/TTGeometryTranslator.h"
+#include "L1Trigger/L1TMuon/interface/TTMuonTriggerPrimitive.h"
+
 #include "L1Trigger/L1TMuonEndCap/interface/EMTFSubsystemTag.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -29,21 +32,26 @@ typedef L1TMuon::GeometryTranslator         GeometryTranslator;
 typedef L1TMuon::TriggerPrimitive           TriggerPrimitive;
 typedef L1TMuon::TriggerPrimitiveCollection TriggerPrimitiveCollection;
 
-typedef TriggerPrimitive::CSCData CSCData;
-typedef TriggerPrimitive::RPCData RPCData;
-typedef TriggerPrimitive::GEMData GEMData;
+typedef L1TMuon::TTGeometryTranslator         TTGeometryTranslator;
+typedef L1TMuon::TTTriggerPrimitive           TTTriggerPrimitive;
+typedef L1TMuon::TTTriggerPrimitiveCollection TTTriggerPrimitiveCollection;
 
-typedef emtf::CSCTag CSCTag;
-typedef emtf::RPCTag RPCTag;
-typedef emtf::GEMTag GEMTag;
+typedef TriggerPrimitive::CSCData   CSCData;
+typedef TriggerPrimitive::RPCData   RPCData;
+typedef TriggerPrimitive::GEMData   GEMData;
+typedef TTTriggerPrimitive::TTData  TTData;
+
+typedef emtf::CSCTag  CSCTag;
+typedef emtf::RPCTag  RPCTag;
+typedef emtf::GEMTag  GEMTag;
+typedef emtf::IRPCTag IRPCTag;
+typedef emtf::ME0Tag  ME0Tag;
+typedef emtf::TTTag   TTTag;
 
 namespace emtf {
 
   // Constants
 
-  // Phase 2 Geometry a.k.a. HL-LHC
-  constexpr int PHASE_TWO_GEOMETRY = 0;
-  
   // from DataFormats/MuonDetId/interface/CSCDetId.h
   constexpr int MIN_ENDCAP = 1;
   constexpr int MAX_ENDCAP = 2;

--- a/L1Trigger/L1TMuonEndCap/interface/EMTFGEMDetId.h
+++ b/L1Trigger/L1TMuonEndCap/interface/EMTFGEMDetId.h
@@ -4,7 +4,7 @@
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "DataFormats/MuonDetId/interface/ME0DetId.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <iosfwd>
 
 

--- a/L1Trigger/L1TMuonEndCap/interface/EMTFGEMDetId.h
+++ b/L1Trigger/L1TMuonEndCap/interface/EMTFGEMDetId.h
@@ -1,0 +1,44 @@
+#ifndef L1TMuonEndCap_EMTFGEMDetId_h
+#define L1TMuonEndCap_EMTFGEMDetId_h
+
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/MuonDetId/interface/ME0DetId.h"
+
+#include <stdint.h>
+#include <iosfwd>
+
+
+class GEMDetId;
+class ME0DetId;
+
+class EMTFGEMDetId {
+public:
+  explicit EMTFGEMDetId(const GEMDetId& id);
+  explicit EMTFGEMDetId(const ME0DetId& id);
+
+  /// Sort Operator based on the raw detector id
+  bool operator < (const EMTFGEMDetId& r) const;
+
+  /// The identifiers
+  int region() const;
+  int ring() const;  // NOTE: use ME0 --> ring 4 convention
+  int station() const;  // NOTE: use ME0 --> station 1 convention
+  int layer() const;
+  int chamber() const;
+  int roll() const;
+
+  bool isME0() const { return isME0_; }
+
+  GEMDetId getGEMDetId() const { return gemDetId_; }
+
+  ME0DetId getME0DetId() const { return me0DetId_; }
+
+private:
+  GEMDetId gemDetId_;
+  ME0DetId me0DetId_;
+  bool isME0_;
+};
+
+std::ostream& operator<<( std::ostream& os, const EMTFGEMDetId& id );
+
+#endif

--- a/L1Trigger/L1TMuonEndCap/interface/EMTFGEMDetIdImpl.h
+++ b/L1Trigger/L1TMuonEndCap/interface/EMTFGEMDetIdImpl.h
@@ -1,0 +1,24 @@
+#ifndef L1TMuonEndCap_EMTFGEMDetIdImpl_h
+#define L1TMuonEndCap_EMTFGEMDetIdImpl_h
+
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/MuonDetId/interface/ME0DetId.h"
+
+//#include "L1Trigger/L1TMuonEndCap/interface/EMTFGEMDetId.h"
+
+namespace emtf {
+
+  template<typename T=void>
+  EMTFGEMDetId construct_EMTFGEMDetId(const TriggerPrimitive& tp) {
+    if (!tp.getGEMData().isME0) {
+      GEMDetId id(tp.detId<GEMDetId>());
+      return EMTFGEMDetId(id);
+    } else {
+      ME0DetId id(tp.detId<ME0DetId>());
+      return EMTFGEMDetId(id);
+    }
+  };
+
+}  // namespace emtf
+
+#endif

--- a/L1Trigger/L1TMuonEndCap/interface/EMTFSubsystemTag.h
+++ b/L1Trigger/L1TMuonEndCap/interface/EMTFSubsystemTag.h
@@ -7,6 +7,9 @@
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigi.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigiCollection.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
 
 namespace emtf {
@@ -24,6 +27,22 @@ namespace emtf {
   struct GEMTag {
     typedef GEMPadDigi           digi_type;
     typedef GEMPadDigiCollection digi_collection;
+  };
+
+  struct IRPCTag {
+    typedef RPCDigi           digi_type;
+    typedef RPCDigiCollection digi_collection;
+  };
+
+  struct ME0Tag {
+    typedef ME0PadDigi           digi_type;
+    typedef ME0PadDigiCollection digi_collection;
+  };
+
+  struct TTTag {
+    typedef Ref_Phase2TrackerDigi_            digi_ref;
+    typedef TTStub<digi_ref>                  digi_type;
+    typedef edmNew::DetSetVector<digi_type>   digi_collection;
   };
 
 }  //  namespace emtf

--- a/L1Trigger/L1TMuonEndCap/interface/TTPrimitiveConversion.h
+++ b/L1Trigger/L1TMuonEndCap/interface/TTPrimitiveConversion.h
@@ -1,0 +1,44 @@
+#ifndef L1TMuonEndCap_TTPrimitiveConversion_h
+#define L1TMuonEndCap_TTPrimitiveConversion_h
+
+#include "L1Trigger/L1TMuonEndCap/interface/Common.h"
+
+
+class SectorProcessorLUT;
+
+class TTPrimitiveConversion {
+public:
+  void configure(
+      const TTGeometryTranslator* tp_ttgeom,
+      const SectorProcessorLUT* lut,
+      int verbose, int endcap, int sector, int bx
+  );
+
+  void process(
+      const std::map<int, TTTriggerPrimitiveCollection>& selected_ttprim_map,
+      EMTFHitCollection& conv_hits
+  ) const;
+
+  void process_no_prim_sel(
+      const TTTriggerPrimitiveCollection& ttmuon_primitives,
+      EMTFHitCollection& conv_hits
+  ) const;
+
+  const SectorProcessorLUT& lut() const { return *lut_; }
+
+  // TT functions
+  void convert_tt(
+      const TTTriggerPrimitive& ttmuon_primitive,
+      EMTFHit& conv_hit
+  ) const;
+
+private:
+  const TTGeometryTranslator* tp_ttgeom_;
+
+  const SectorProcessorLUT* lut_;
+
+  int verbose_, endcap_, sector_, bx_;
+};
+
+#endif
+

--- a/L1Trigger/L1TMuonEndCap/python/customise_Phase2C2.py
+++ b/L1Trigger/L1TMuonEndCap/python/customise_Phase2C2.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+def customise(process):
+
+    # From python/simEmtfDigis_cfi.py
+    if hasattr(process, 'simEmtfDigis'):
+        process.simEmtfDigis.spPCParams16.ZoneBoundaries = [0,36,54,96,127]
+        process.simEmtfDigis.spPCParams16.UseNewZones    = True
+        process.simEmtfDigis.RPCEnable                   = True
+        process.simEmtfDigis.GEMEnable                   = True
+        process.simEmtfDigis.IRPCEnable                  = True
+        process.simEmtfDigis.ME0Enable                   = True
+        process.simEmtfDigis.TTEnable                    = False
+        process.simEmtfDigis.ME0Input                    = cms.InputTag('fakeSimMuonME0PadDigis')
+        process.simEmtfDigis.Era                         = cms.string('Phase2C2')
+        process.simEmtfDigis.spPAParams16.PtLUTVersion   = cms.int32(7)
+
+    # From python/fakeEmtfParams_cff.py
+    if hasattr(process, 'emtfParams'):
+        process.emtfParams.PtAssignVersion = cms.int32(7)
+
+    if hasattr(process, 'emtfForestsDB'):
+        process.emtfForestsDB = cms.ESSource(
+            "EmptyESSource",
+            recordName = cms.string('L1TMuonEndCapForestRcd'),
+            iovIsRunNotTime = cms.bool(True),
+            firstValid = cms.vuint32(1)
+            )
+
+        process.emtfForests = cms.ESProducer(
+            "L1TMuonEndCapForestESProducer",
+            PtAssignVersion = cms.int32(7),
+            bdtXMLDir = cms.string("2017_v7")
+            )
+
+    return process
+

--- a/L1Trigger/L1TMuonEndCap/src/EMTFGEMDetId.cc
+++ b/L1Trigger/L1TMuonEndCap/src/EMTFGEMDetId.cc
@@ -1,0 +1,82 @@
+#include "L1Trigger/L1TMuonEndCap/interface/EMTFGEMDetId.h"
+
+
+EMTFGEMDetId::EMTFGEMDetId(const GEMDetId& id) :
+    gemDetId_(id),
+    me0DetId_(),
+    isME0_(false)
+{
+
+}
+
+EMTFGEMDetId::EMTFGEMDetId(const ME0DetId& id) :
+    gemDetId_(),
+    me0DetId_(id),
+    isME0_(true)
+{
+
+}
+
+/// Sort Operator based on the raw detector id
+bool EMTFGEMDetId::operator < (const EMTFGEMDetId& r) const {
+  if (!isME0() && !r.isME0()) {
+    return getGEMDetId() < r.getGEMDetId(); // compare GEM with GEM
+  } else if (r.isME0() && r.isME0()) {
+    return getME0DetId() < r.getME0DetId(); // compare ME0 with ME0
+  } else {
+    return !r.isME0();                      // compare GEM with ME0
+  }
+}
+
+/// The identifiers
+int EMTFGEMDetId::region() const {
+  if (!isME0())
+    return getGEMDetId().region();
+  else
+    return getME0DetId().region();
+}
+
+int EMTFGEMDetId::ring() const {
+  if (!isME0())
+    return getGEMDetId().ring();
+  else
+    //return getME0DetId().ring();
+    return 4;  // NOTE: use ME0 --> ring 4 convention
+}
+
+int EMTFGEMDetId::station() const {
+  if (!isME0())
+    return getGEMDetId().station();
+  else
+    //return getME0DetId().station();
+    return 1;  // use ME0 --> station 1 convention
+}
+
+int EMTFGEMDetId::layer() const {
+  if (!isME0())
+    return getGEMDetId().layer();
+  else
+    return getME0DetId().layer();
+}
+
+int EMTFGEMDetId::chamber() const {
+  if (!isME0())
+    return getGEMDetId().chamber();
+  else
+    return getME0DetId().chamber();
+}
+
+int EMTFGEMDetId::roll() const {
+  if (!isME0())
+    return getGEMDetId().roll();
+  else
+    return getME0DetId().roll();
+}
+
+std::ostream& operator<<( std::ostream& os, const EMTFGEMDetId& id ) {
+  if (!id.isME0())
+    os << id.getGEMDetId();
+  else
+    os << id.getME0DetId();
+  return os;
+}

--- a/L1Trigger/L1TMuonEndCap/src/TTPrimitiveConversion.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TTPrimitiveConversion.cc
@@ -1,0 +1,133 @@
+#include "L1Trigger/L1TMuonEndCap/interface/TTPrimitiveConversion.h"
+
+#include "L1Trigger/L1TMuonEndCap/interface/SectorProcessorLUT.h"
+#include "L1Trigger/L1TMuonEndCap/interface/TrackTools.h"
+
+
+void TTPrimitiveConversion::configure(
+    const TTGeometryTranslator* tp_ttgeom,
+    const SectorProcessorLUT* lut,
+    int verbose, int endcap, int sector, int bx
+) {
+  assert(tp_ttgeom != nullptr);
+  assert(lut != nullptr);
+
+  tp_ttgeom_ = tp_ttgeom;
+  lut_       = lut;  // not used
+
+  verbose_ = verbose;
+  endcap_  = endcap; // 1 for ME+, 2 for ME-
+  sector_  = sector;
+  bx_      = bx;
+}
+
+void TTPrimitiveConversion::process(
+    const std::map<int, TTTriggerPrimitiveCollection>& selected_ttprim_map,
+    EMTFHitCollection& conv_hits
+) const {
+  std::map<int, TTTriggerPrimitiveCollection>::const_iterator map_tp_it  = selected_ttprim_map.begin();
+  std::map<int, TTTriggerPrimitiveCollection>::const_iterator map_tp_end = selected_ttprim_map.end();
+
+  for (; map_tp_it != map_tp_end; ++map_tp_it) {
+    TTTriggerPrimitiveCollection::const_iterator tp_it  = map_tp_it->second.begin();
+    TTTriggerPrimitiveCollection::const_iterator tp_end = map_tp_it->second.end();
+
+    for (; tp_it != tp_end; ++tp_it) {
+      EMTFHit conv_hit;
+      convert_tt(*tp_it, conv_hit);
+      conv_hits.push_back(conv_hit);
+    }
+  }
+}
+
+void TTPrimitiveConversion::process_no_prim_sel(
+    const TTTriggerPrimitiveCollection& ttmuon_primitives,
+    EMTFHitCollection& conv_hits
+) const {
+  TTTriggerPrimitiveCollection::const_iterator tp_it  = ttmuon_primitives.begin();
+  TTTriggerPrimitiveCollection::const_iterator tp_end = ttmuon_primitives.end();
+
+  for (; tp_it != tp_end; ++tp_it) {
+    if (endcap_ == 1 && sector_ == 1 && bx_ == tp_it->getTTData().bx) {  //FIXME: stupidly put everything into sector +1, to be fixed.
+      EMTFHit conv_hit;
+      convert_tt(*tp_it, conv_hit);
+      conv_hits.push_back(conv_hit);
+    }
+  }
+}
+
+
+// _____________________________________________________________________________
+// TT functions
+void TTPrimitiveConversion::convert_tt(
+    const TTTriggerPrimitive& ttmuon_primitive,
+    EMTFHit& conv_hit
+) const {
+  //const DetId&   tp_detId = ttmuon_primitive.detId();
+  const TTData&  tp_data  = ttmuon_primitive.getTTData();
+
+  int tp_region    = tp_ttgeom_->region(ttmuon_primitive);     // 0 for Barrel, +/-1 for +/- Endcap
+  int tp_endcap    = (tp_region == -1) ? 2 : tp_region;
+  int tp_station   = tp_ttgeom_->layer(ttmuon_primitive);
+  int tp_ring      = tp_ttgeom_->ring(ttmuon_primitive);
+  int tp_chamber   = tp_ttgeom_->module(ttmuon_primitive);
+  int tp_sector    = 1;  //FIXME
+  int tp_subsector = 0;  //FIXME
+
+  const bool is_neighbor = false;  //FIXME
+
+  // Set properties
+  //conv_hit.SetTTDetId      ( tp_detId );
+
+  conv_hit.set_endcap      ( (tp_endcap == 2) ? -1 : tp_endcap );
+  conv_hit.set_station     ( tp_station );
+  conv_hit.set_ring        ( tp_ring );
+  //conv_hit.set_roll        ( tp_roll );
+  conv_hit.set_chamber     ( tp_chamber );
+  conv_hit.set_sector      ( tp_sector );
+  conv_hit.set_subsector   ( tp_subsector );
+  //conv_hit.set_csc_ID      ( tp_csc_ID );
+  //conv_hit.set_csc_nID     ( csc_nID );
+  //conv_hit.set_track_num   ( tp_data.trknmb );
+  //conv_hit.set_sync_err    ( tp_data.syncErr );
+
+  conv_hit.set_bx          ( tp_data.bx );
+  conv_hit.set_subsystem   ( TTTriggerPrimitive::kTT );
+  conv_hit.set_is_CSC      ( false );
+  conv_hit.set_is_RPC      ( false );
+  conv_hit.set_is_GEM      ( false );
+
+  //conv_hit.set_pc_sector   ( pc_sector );
+  //conv_hit.set_pc_station  ( pc_station );
+  //conv_hit.set_pc_chamber  ( pc_chamber );
+  //conv_hit.set_pc_segment  ( pc_segment );
+
+  conv_hit.set_valid       ( true );
+  conv_hit.set_strip       ( static_cast<int>(tp_data.row_f) );
+  //conv_hit.set_strip_low   ( tp_data.strip_low );
+  //conv_hit.set_strip_hi    ( tp_data.strip_hi );
+  conv_hit.set_wire        ( static_cast<int>(tp_data.col_f) );
+  //conv_hit.set_quality     ( tp_data.quality );
+  //conv_hit.set_pattern     ( tp_data.pattern );
+  conv_hit.set_bend        ( tp_data.bend );
+  //conv_hit.set_time        ( tp_data.time );
+
+  conv_hit.set_neighbor    ( is_neighbor );
+  conv_hit.set_sector_idx  ( (endcap_ == 1) ? sector_ - 1 : sector_ + 5 );
+
+  // Add coordinates from fullsim
+  {
+    const GlobalPoint& gp = tp_ttgeom_->getGlobalPoint(ttmuon_primitive);
+    double glob_phi   = emtf::rad_to_deg(gp.phi().value());
+    double glob_theta = emtf::rad_to_deg(gp.theta());
+    double glob_eta   = gp.eta();
+    double glob_rho   = gp.perp();
+    double glob_z     = gp.z();
+
+    conv_hit.set_phi_sim   ( glob_phi );
+    conv_hit.set_theta_sim ( glob_theta );
+    conv_hit.set_eta_sim   ( glob_eta );
+    conv_hit.set_rho_sim   ( glob_rho );
+    conv_hit.set_z_sim     ( glob_z );
+  }
+}

--- a/L1Trigger/L1TMuonEndCap/src/TTPrimitiveConversion.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TTPrimitiveConversion.cc
@@ -25,16 +25,11 @@ void TTPrimitiveConversion::process(
     const std::map<int, TTTriggerPrimitiveCollection>& selected_ttprim_map,
     EMTFHitCollection& conv_hits
 ) const {
-  std::map<int, TTTriggerPrimitiveCollection>::const_iterator map_tp_it  = selected_ttprim_map.begin();
-  std::map<int, TTTriggerPrimitiveCollection>::const_iterator map_tp_end = selected_ttprim_map.end();
 
-  for (; map_tp_it != map_tp_end; ++map_tp_it) {
-    TTTriggerPrimitiveCollection::const_iterator tp_it  = map_tp_it->second.begin();
-    TTTriggerPrimitiveCollection::const_iterator tp_end = map_tp_it->second.end();
-
-    for (; tp_it != tp_end; ++tp_it) {
+  for (const auto& map_tp_it : selected_ttprim_map) {
+    for (const auto& tp_it : map_tp_it.second) {
       EMTFHit conv_hit;
-      convert_tt(*tp_it, conv_hit);
+      convert_tt(tp_it, conv_hit);
       conv_hits.push_back(conv_hit);
     }
   }
@@ -44,13 +39,11 @@ void TTPrimitiveConversion::process_no_prim_sel(
     const TTTriggerPrimitiveCollection& ttmuon_primitives,
     EMTFHitCollection& conv_hits
 ) const {
-  TTTriggerPrimitiveCollection::const_iterator tp_it  = ttmuon_primitives.begin();
-  TTTriggerPrimitiveCollection::const_iterator tp_end = ttmuon_primitives.end();
 
-  for (; tp_it != tp_end; ++tp_it) {
-    if (endcap_ == 1 && sector_ == 1 && bx_ == tp_it->getTTData().bx) {  //FIXME: stupidly put everything into sector +1, to be fixed.
+  for (const auto& tp_it : ttmuon_primitives) {
+    if (endcap_ == 1 && sector_ == 1 && bx_ == tp_it.getTTData().bx) {  //FIXME: stupidly put everything into sector +1, to be fixed.
       EMTFHit conv_hit;
-      convert_tt(*tp_it, conv_hit);
+      convert_tt(tp_it, conv_hit);
       conv_hits.push_back(conv_hit);
     }
   }


### PR DESCRIPTION
Part 2 of a series of PRs from @jiafulow (following #22820 ) which will bring the EMTF emulator up-to-date for 2018 running.  This PR adds data formats for Run 3 and Phase II trigger primitives in the endcaps, and creates a framework for these TPs to be processed by the EMTF emulator.  These changes will benefit various groups developing L1T muon for post-2020 running, including @dildick , @mmaggi , @camilocarrillo , @gabrielhpugliese , and others.

This PR adds no new functionalities on its own, and changes nothing about how the EMTF emulator runs.  It only provides foundational elements (data formats and TP processing framework) for following PRs, in which TP processing in EMTF will be actually enabled when running a "future" scenario.  @rekovic , @thomreis please take a look.

Best regards,
Andrew
