### PR TITLE
DQM: SiPixelPhase1- Added Big Pixel Charge Plots  [Backport for 10_1_X of #22324 ]

### DIFF
--- a/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
+++ b/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
@@ -103,11 +103,11 @@ SiPixelPhase1ClustersNClusters = DefaultHistoDigiCluster.clone(
     StandardSpecifications1D_Num,
 
     Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
-                             .reduce("COUNT")    
+                             .reduce("COUNT")
                              .groupBy("PXBarrel/PXLayer")
                              .save(nbins=50, xmin=0, xmax=10000),
     Specification().groupBy("PXForward/PXDisk/Event")
-                             .reduce("COUNT")    
+                             .reduce("COUNT")
                              .groupBy("PXForward/PXDisk/")
                              .save(nbins=50, xmin=0, xmax=5000),
   )
@@ -248,18 +248,18 @@ SiPixelPhase1ClustersPixelToStripRatio = DefaultHistoDigiCluster.clone(
   enabled = False,
   name = "cluster_ratio",
   title = "Pixel to Strip clusters ratio",
-  
+
   xlabel = "ratio",
   dimensions = 1,
-  
+
   specs = VPSet(
-    Specification().groupBy("PXAll").save(100, 0, 1), 
+    Specification().groupBy("PXAll").save(100, 0, 1),
     Specification().groupBy("PXAll/LumiBlock")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXAll", "EXTEND_X")
                    .save(),
     Specification().groupBy("PXAll/BX")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXAll", "EXTEND_X")
                    .save(),
   )

--- a/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
+++ b/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
@@ -18,6 +18,35 @@ SiPixelPhase1ClustersCharge = DefaultHistoDigiCluster.clone(
   )
 )
 
+SiPixelPhase1ClustersBigPixelCharge = DefaultHistoDigiCluster.clone(
+  name = "bigpixelcharge",
+  title = "Big Pixel Charge",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
+  )
+)
+
+SiPixelPhase1ClustersNotBigPixelCharge = DefaultHistoDigiCluster.clone(
+  name = "notbigpixelcharge",
+  title = "Not Big Pixel Charge",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+  enabled=False,
+
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
+  )
+)
+
 SiPixelPhase1ClustersSize = DefaultHistoDigiCluster.clone(
   name = "size",
   title = "Total Cluster Size",
@@ -238,6 +267,8 @@ SiPixelPhase1ClustersPixelToStripRatio = DefaultHistoDigiCluster.clone(
 
 SiPixelPhase1ClustersConf = cms.VPSet(
   SiPixelPhase1ClustersCharge,
+  SiPixelPhase1ClustersBigPixelCharge,
+  SiPixelPhase1ClustersNotBigPixelCharge,
   SiPixelPhase1ClustersSize,
   SiPixelPhase1ClustersSizeX,
   SiPixelPhase1ClustersSizeY,

--- a/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
+++ b/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
@@ -24,6 +24,8 @@ namespace {
 class SiPixelPhase1Clusters final : public SiPixelPhase1Base {
   enum {
     CHARGE,
+    BIGPIXELCHARGE,
+    NOTBIGPIXELCHARGE,
     SIZE,
     SIZEX,
     SIZEY,
@@ -89,6 +91,26 @@ void SiPixelPhase1Clusters::analyze(const edm::Event& iEvent, const edm::EventSe
 
     for(SiPixelCluster const& cluster : *it) {
       int row = cluster.x()-0.5, col = cluster.y()-0.5;
+      const std::vector<SiPixelCluster::Pixel> pixelsVec = cluster.pixels();
+
+      for (unsigned int i = 0;  i < pixelsVec.size(); ++i) {
+
+	float pixx = pixelsVec[i].x; // index as float=iteger, row index
+	float pixy = pixelsVec[i].y; // same, col index
+
+	bool bigInX = topol.isItBigPixelInX(int(pixx));
+	bool bigInY = topol.isItBigPixelInY(int(pixy));
+	float pixel_charge = pixelsVec[i].adc;
+
+
+	if (bigInX==true || bigInY==true) {
+	  histo[BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent, col, row);
+	}
+
+	else {
+	  histo[NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent, col, row);
+	}
+      }
       histo[READOUT_CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
       histo[CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
       histo[SIZE  ].fill(double(cluster.size()  ), id, &iEvent, col, row);

--- a/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
+++ b/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
@@ -74,7 +74,7 @@ void SiPixelPhase1Clusters::analyze(const edm::Event& iEvent, const edm::EventSe
     {
       histo[PIXEL_TO_STRIP_RATIO].fill((double)inputPixel.product()->data().size() / (double) inputStrip.product()->data().size(), DetId(0), &iEvent);
     }
-  } 
+  }
 
   bool hasClusters=false;
 
@@ -95,21 +95,21 @@ void SiPixelPhase1Clusters::analyze(const edm::Event& iEvent, const edm::EventSe
 
       for (unsigned int i = 0;  i < pixelsVec.size(); ++i) {
 
-	float pixx = pixelsVec[i].x; // index as float=iteger, row index
-	float pixy = pixelsVec[i].y; // same, col index
+        float pixx = pixelsVec[i].x; // index as float=iteger, row index
+        float pixy = pixelsVec[i].y; // same, col index
 
-	bool bigInX = topol.isItBigPixelInX(int(pixx));
-	bool bigInY = topol.isItBigPixelInY(int(pixy));
-	float pixel_charge = pixelsVec[i].adc;
+        bool bigInX = topol.isItBigPixelInX(int(pixx));
+        bool bigInY = topol.isItBigPixelInY(int(pixy));
+        float pixel_charge = pixelsVec[i].adc;
 
 
-	if (bigInX==true || bigInY==true) {
-	  histo[BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent, col, row);
-	}
+        if (bigInX==true || bigInY==true) {
+          histo[BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent, col, row);
+        }
 
-	else {
-	  histo[NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent, col, row);
-	}
+        else {
+          histo[NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent, col, row);
+        }
       }
       histo[READOUT_CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
       histo[CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);

--- a/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
@@ -63,6 +63,35 @@ SiPixelPhase1TrackClustersOnTrackCharge = DefaultHistoTrack.clone(
   )
 )
 
+SiPixelPhase1TrackClustersOnTrackBigPixelCharge = DefaultHistoTrack.clone(
+  name = "bigpixelcharge",
+  title = "Corrected Big Pixel Charge (OnTrack)",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
+  )
+)
+
+SiPixelPhase1TrackClustersOnTrackNotBigPixelCharge = DefaultHistoTrack.clone(
+  name = "notbigpixelcharge",
+  title = "Corrected Not Big Pixel Charge (OnTrack)",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+  enabled=False,
+
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
+  )
+)
+
 SiPixelPhase1TrackClustersOnTrackSize = DefaultHistoTrack.clone(
   name = "size",
   title = "Total Cluster Size (OnTrack)",
@@ -432,6 +461,8 @@ SiPixelPhase1TrackClustersOnTrackShapeInner = SiPixelPhase1TrackClustersOnTrackS
 # copy this in the enum
 SiPixelPhase1TrackClustersConf = cms.VPSet(
   SiPixelPhase1TrackClustersOnTrackCharge,
+  SiPixelPhase1TrackClustersOnTrackBigPixelCharge,
+  SiPixelPhase1TrackClustersOnTrackNotBigPixelCharge,
   SiPixelPhase1TrackClustersOnTrackSize,
   SiPixelPhase1TrackClustersOnTrackShape,
   SiPixelPhase1TrackClustersOnTrackNClusters,

--- a/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
@@ -10,10 +10,10 @@ SiPixelPhase1TrackClustersOnTrackCharge = DefaultHistoTrack.clone(
   xlabel = "Charge (electrons)",
 
   specs = VPSet(
-    StandardSpecifications1D,    
+    StandardSpecifications1D,
     StandardSpecification2DProfile,
-    
-    #what is below is only for the timing client    
+
+    #what is below is only for the timing client
     Specification(OverlayCurvesForTiming).groupBy("PXBarrel/OnlineBlock")
          .groupBy("PXBarrel", "EXTEND_Y")
          .save(),
@@ -99,7 +99,7 @@ SiPixelPhase1TrackClustersOnTrackSize = DefaultHistoTrack.clone(
   xlabel = "size[pixels]",
 
   specs = VPSet(
-        StandardSpecifications1D,    
+        StandardSpecifications1D,
         StandardSpecification2DProfile,
 
         Specification().groupBy("PXForward/PXRing").save(),
@@ -188,12 +188,12 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
     StandardSpecification2DProfile_Num,
 
     Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
-                             .reduce("COUNT")    
+                             .reduce("COUNT")
                              .groupBy("PXBarrel/PXLayer")
                              .save(nbins=50, xmin=0, xmax=5000),
 
     Specification().groupBy("PXForward/PXDisk/Event")
-                             .reduce("COUNT")    
+                             .reduce("COUNT")
                              .groupBy("PXForward/PXDisk/")
                              .save(nbins=50, xmin=0, xmax=2000),
 
@@ -255,7 +255,7 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
                     .groupBy("PXBarrel/OnlineBlock")
                     .groupBy("PXBarrel", "EXTEND_Y")
                     .save()
-   
+
   )
 )
 
@@ -394,7 +394,7 @@ SiPixelPhase1TrackClustersOnTrackSizeXYOuter = SiPixelPhase1TrackClustersOnTrack
   xlabel = "y size",
   ylabel = "x size",
   range_min = 0, range_max  = 20, range_nbins   = 20,
-  range_y_min = 0, range_y_max = 10, range_y_nbins = 10 
+  range_y_min = 0, range_y_max = 10, range_y_nbins = 10
 )
 
 SiPixelPhase1TrackClustersOnTrackSizeXYInner = SiPixelPhase1TrackClustersOnTrackSizeXYOuter.clone(
@@ -436,11 +436,11 @@ SiPixelPhase1TrackClustersOnTrackChargeOuter = DefaultHistoTrack.clone(
     Specification().groupBy("PXBarrel/PXLayer").save()
   )
 )
-  
+
 SiPixelPhase1TrackClustersOnTrackChargeInner = SiPixelPhase1TrackClustersOnTrackChargeOuter.clone(
   name = "chargeInner",
   title = "Corrected Cluster Charge (OnTrack) inner ladders"
-)  
+)
 
 SiPixelPhase1TrackClustersOnTrackShapeOuter = DefaultHistoTrack.clone(
   topFolderName = "PixelPhase1/ClusterShape",
@@ -509,7 +509,3 @@ SiPixelPhase1TrackClustersHarvester = DQMEDHarvester("SiPixelPhase1Harvester",
         histograms = SiPixelPhase1TrackClustersConf,
         geometry = SiPixelPhase1Geometry
 )
-
-
-
-

--- a/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
@@ -180,8 +180,8 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
       auto pixhit = dynamic_cast<const SiPixelRecHit*>(hit->hit());
       if (!pixhit) continue;
 
-      // auto geomdetunit = dynamic_cast<const PixelGeomDetUnit*>(pixhit->detUnit());
-      // auto const & topol = geomdetunit->specificTopology();
+       auto geomdetunit = dynamic_cast<const PixelGeomDetUnit*>(pixhit->detUnit());
+       auto const & topol = geomdetunit->specificTopology();
       
       // get the cluster
       auto clustp = pixhit->cluster();

--- a/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-// 
+//
 // Package:     SiPixelPhase1TrackClusters
 // Class  :     SiPixelPhase1TrackClusters
 //
@@ -35,10 +35,10 @@
 namespace {
 
 class SiPixelPhase1TrackClusters final : public SiPixelPhase1Base {
-enum {  
+enum {
   ON_TRACK_CHARGE,
   ON_TRACK_BIGPIXELCHARGE,
-  ON_TRACK_NOTBIGPIXELCHARGE,  
+  ON_TRACK_NOTBIGPIXELCHARGE,
   ON_TRACK_SIZE,
   ON_TRACK_SHAPE,
   ON_TRACK_NCLUSTERS,
@@ -56,20 +56,20 @@ enum {
 
   ON_TRACK_SHAPE_OUTER,
   ON_TRACK_SHAPE_INNER,
- 
+
   ON_TRACK_SIZE_X_OUTER,
   ON_TRACK_SIZE_X_INNER,
   ON_TRACK_SIZE_X_F,
   ON_TRACK_SIZE_Y_OUTER,
   ON_TRACK_SIZE_Y_INNER,
   ON_TRACK_SIZE_Y_F,
-    
+
   ON_TRACK_SIZE_XY_OUTER,
   ON_TRACK_SIZE_XY_INNER,
   ON_TRACK_SIZE_XY_F,
   CHARGE_VS_SIZE_ON_TRACK,
 
-  ENUM_SIZE        
+  ENUM_SIZE
 };
 
 public:
@@ -89,11 +89,11 @@ SiPixelPhase1TrackClusters::SiPixelPhase1TrackClusters(const edm::ParameterSet& 
   applyVertexCut_(iConfig.getUntrackedParameter<bool>("VertexCut", true))
 {
   tracksToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
-  
+
   offlinePrimaryVerticesToken_ = applyVertexCut_ ?
                                   consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices")) :
                                   edm::EDGetTokenT<reco::VertexCollection>();
-                              
+
   pixelClusterShapeCacheToken_ = consumes<SiPixelClusterShapeCache>(iConfig.getParameter<edm::InputTag>("clusterShapeCache"));
 }
 
@@ -139,18 +139,18 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
   if ( !pixelClusterShapeCacheH.isValid() ) {
     edm::LogWarning("SiPixelPhase1TrackClusters")  << "PixelClusterShapeCache collection is not valid";
     return;
-  }  
+  }
   auto const & pixelClusterShapeCache = *pixelClusterShapeCacheH;
 
   for (auto const & track : *tracks) {
 
-    if (applyVertexCut_ && 
+    if (applyVertexCut_ &&
         (track.pt() < 0.75 || std::abs( track.dxy((*vertices)[0].position()) ) > 5 * track.dxyError())) continue;
 
     bool isBpixtrack = false, isFpixtrack = false, crossesPixVol = false;
 
     // find out whether track crosses pixel fiducial volume (for cosmic tracks)
-    auto d0 = track.d0(), dz = track.dz(); 
+    auto d0 = track.d0(), dz = track.dz();
     if (std::abs(d0) < 15 && std::abs(dz) < 50) crossesPixVol = true;
 
     auto etatk = track.eta();
@@ -158,9 +158,9 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
     auto const & trajParams = track.extra()->trajParams();
     assert(trajParams.size()==track.recHitsSize());
     auto hb = track.recHitsBegin();
-    
+
     for (unsigned int h = 0; h < track.recHitsSize(); h++){
-      
+
       auto hit = *(hb + h);
       if (!hit->isValid()) continue;
       auto id = hit->geographicalId();
@@ -171,42 +171,42 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
       if (subdetid == PixelSubdetector::PixelEndcap) isFpixtrack = true;
       if (subdetid != PixelSubdetector::PixelBarrel && subdetid != PixelSubdetector::PixelEndcap) continue;
       bool iAmBarrel = subdetid == PixelSubdetector::PixelBarrel;
-      
+
       // PXB_L4 IS IN THE OTHER WAY
       // CAN BE XORed BUT LETS KEEP THINGS SIMPLE
-      bool iAmOuter = ((tkTpl.pxbLadder(id) % 2 == 1) && tkTpl.pxbLayer(id) != 4) || 
+      bool iAmOuter = ((tkTpl.pxbLadder(id) % 2 == 1) && tkTpl.pxbLayer(id) != 4) ||
                       ((tkTpl.pxbLadder(id) % 2 != 1) && tkTpl.pxbLayer(id) == 4);
-                      
+
       auto pixhit = dynamic_cast<const SiPixelRecHit*>(hit->hit());
       if (!pixhit) continue;
 
-       auto geomdetunit = dynamic_cast<const PixelGeomDetUnit*>(pixhit->detUnit());
-       auto const & topol = geomdetunit->specificTopology();
-      
+      auto geomdetunit = dynamic_cast<const PixelGeomDetUnit*>(pixhit->detUnit());
+      auto const & topol = geomdetunit->specificTopology();
+
       // get the cluster
       auto clustp = pixhit->cluster();
-      if (clustp.isNull()) continue; 
+      if (clustp.isNull()) continue;
       auto const & cluster = *clustp;
       const std::vector<SiPixelCluster::Pixel> pixelsVec = cluster.pixels();
       for (unsigned int i = 0;  i < pixelsVec.size(); ++i) {
 
-	float pixx = pixelsVec[i].x; // index as float=iteger, row index
-	float pixy = pixelsVec[i].y; // same, col index
+        float pixx = pixelsVec[i].x; // index as float=iteger, row index
+        float pixy = pixelsVec[i].y; // same, col index
 
-	bool bigInX = topol.isItBigPixelInX(int(pixx));
-	bool bigInY = topol.isItBigPixelInY(int(pixy));
-	float pixel_charge = pixelsVec[i].adc;
+        bool bigInX = topol.isItBigPixelInX(int(pixx));
+        bool bigInY = topol.isItBigPixelInY(int(pixy));
+        float pixel_charge = pixelsVec[i].adc;
 
-	if (bigInX==true || bigInY==true) {
-		histo[ON_TRACK_BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
-	}
-	else {
-		histo[ON_TRACK_NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
+        if (bigInX==true || bigInY==true) {
+                histo[ON_TRACK_BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
+        }
+        else {
+                histo[ON_TRACK_NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
 
-	}
+        }
       } // End loop over pixels
       auto const & ltp = trajParams[h];
-      
+
       auto localDir = ltp.momentum() / ltp.momentum().mag();
 
       // correct charge for track impact angle
@@ -220,7 +220,7 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
       if(shapeFilter.getSizes(*pixhit, localDir, pixelClusterShapeCache, part, meas, pred)) {
        auto shape = shapeFilter.isCompatible(*pixhit, localDir, pixelClusterShapeCache);
        unsigned shapeVal = (shape ? 1 : 0);
-       
+
        if (iAmBarrel) {
          if(iAmOuter) {
            histo[ON_TRACK_SIZE_X_OUTER].fill(pred.first, cluster.sizeX(), id, &iEvent);
@@ -256,7 +256,7 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
       histo[ON_TRACK_POSITIONF].fill(clustgp.x(),   clustgp.y(),     id, &iEvent);
 
       histo[CHARGE_VS_SIZE_ON_TRACK].fill(cluster.size(), charge, id, &iEvent);
-      
+
       if (iAmBarrel)  // Avoid mistakes even if specification < should > handle it
       {
         if(iAmOuter) {
@@ -271,17 +271,17 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
 
     // statistics on tracks
     histo[NTRACKS].fill(1, DetId(0), &iEvent);
-    if (isBpixtrack || isFpixtrack) 
+    if (isBpixtrack || isFpixtrack)
       histo[NTRACKS].fill(2, DetId(0), &iEvent);
-    if (isBpixtrack) 
+    if (isBpixtrack)
       histo[NTRACKS].fill(3, DetId(0), &iEvent);
-    if (isFpixtrack) 
+    if (isFpixtrack)
       histo[NTRACKS].fill(4, DetId(0), &iEvent);
 
     if (crossesPixVol) {
       if (isBpixtrack || isFpixtrack)
         histo[NTRACKS_INVOLUME].fill(1, DetId(0), &iEvent);
-      else 
+      else
         histo[NTRACKS_INVOLUME].fill(0, DetId(0), &iEvent);
     }
   }
@@ -294,4 +294,3 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SiPixelPhase1TrackClusters);
-

--- a/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
@@ -37,6 +37,8 @@ namespace {
 class SiPixelPhase1TrackClusters final : public SiPixelPhase1Base {
 enum {  
   ON_TRACK_CHARGE,
+  ON_TRACK_BIGPIXELCHARGE,
+  ON_TRACK_NOTBIGPIXELCHARGE,  
   ON_TRACK_SIZE,
   ON_TRACK_SHAPE,
   ON_TRACK_NCLUSTERS,
@@ -185,7 +187,24 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
       auto clustp = pixhit->cluster();
       if (clustp.isNull()) continue; 
       auto const & cluster = *clustp;
+      const std::vector<SiPixelCluster::Pixel> pixelsVec = cluster.pixels();
+      for (unsigned int i = 0;  i < pixelsVec.size(); ++i) {
 
+	float pixx = pixelsVec[i].x; // index as float=iteger, row index
+	float pixy = pixelsVec[i].y; // same, col index
+
+	bool bigInX = topol.isItBigPixelInX(int(pixx));
+	bool bigInY = topol.isItBigPixelInY(int(pixy));
+	float pixel_charge = pixelsVec[i].adc;
+
+	if (bigInX==true || bigInY==true) {
+		histo[ON_TRACK_BIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
+	}
+	else {
+		histo[ON_TRACK_NOTBIGPIXELCHARGE].fill(pixel_charge, id, &iEvent);
+
+	}
+      } // End loop over pixels
       auto const & ltp = trajParams[h];
       
       auto localDir = ltp.momentum() / ltp.momentum().mag();

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Cluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Cluster_cff.py
@@ -9,7 +9,7 @@ hltSiPixelPhase1ClustersCharge = hltDefaultHistoDigiCluster.clone(
   title = "Cluster Charge",
   range_min = 0, range_max = 200e3, range_nbins = 200,
   xlabel = "Charge (electrons)",
-  
+
   specs = VPSet(
     #StandardSpecification2DProfile,
     hltStandardSpecificationPixelmapProfile,
@@ -250,18 +250,18 @@ hltSiPixelPhase1ClustersReadoutNClusters = hltDefaultHistoReadout.clone(
 hltSiPixelPhase1ClustersPixelToStripRatio = hltDefaultHistoDigiCluster.clone(
   name = "cluster_ratio",
   title = "Pixel to Strip clusters ratio",
-  
+
   xlabel = "ratio",
   dimensions = 1,
-  
+
   specs = VPSet(
-    Specification().groupBy("PXAll").save(100, 0, 1), 
+    Specification().groupBy("PXAll").save(100, 0, 1),
     Specification().groupBy("PXAll/Lumisection")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXAll", "EXTEND_X")
                    .save(),
     Specification().groupBy("PXAll/BX")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXAll", "EXTEND_X")
                    .save(),
   )
@@ -307,4 +307,3 @@ hltSiPixelPhase1ClustersHarvester = DQMEDHarvester("SiPixelPhase1Harvester",
         histograms = hltSiPixelPhase1ClustersConf,
         geometry   = hltSiPixelPhase1Geometry
 )
-

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Cluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Cluster_cff.py
@@ -3,7 +3,7 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 from DQMOffline.Trigger.SiPixel_OfflineMonitoring_HistogramManager_cfi import *
 
-# order is important and it should follow ordering in .h !!!
+# order is important and it should follow ordering in hltSiPixelPhase1ClustersConf VPSet
 hltSiPixelPhase1ClustersCharge = hltDefaultHistoDigiCluster.clone(
   name = "charge",
   title = "Cluster Charge",
@@ -17,6 +17,36 @@ hltSiPixelPhase1ClustersCharge = hltDefaultHistoDigiCluster.clone(
 #    StandardSpecifications1D,
     hltStandardSpecifications1D,
     StandardSpecificationTrend2D
+  )
+)
+
+hltSiPixelPhase1ClustersBigPixelCharge = DefaultHistoDigiCluster.clone(
+  name = "bigpixelcharge",
+  title = "Big Pixel Charge",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+  enabled=False,
+
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
+  )
+)
+
+hltSiPixelPhase1ClustersNotBigPixelCharge = DefaultHistoDigiCluster.clone(
+  name = "notbigpixelcharge",
+  title = "Not Big Pixel Charge",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+  enabled=False,
+
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
   )
 )
 
@@ -239,6 +269,8 @@ hltSiPixelPhase1ClustersPixelToStripRatio = hltDefaultHistoDigiCluster.clone(
 
 hltSiPixelPhase1ClustersConf = cms.VPSet(
   hltSiPixelPhase1ClustersCharge,
+  hltSiPixelPhase1ClustersBigPixelCharge,
+  hltSiPixelPhase1ClustersNotBigPixelCharge,
   hltSiPixelPhase1ClustersSize,
   hltSiPixelPhase1ClustersSizeX,
   hltSiPixelPhase1ClustersSizeY,

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
@@ -3,7 +3,7 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 from DQMOffline.Trigger.SiPixel_OfflineMonitoring_HistogramManager_cfi import *
 
-# order is important and it should follow ordering in .h !!!
+# order is important and it should follow ordering in hltSiPixelPhase1ClustersConf VPSet
 hltSiPixelPhase1TrackClustersOnTrackCharge = hltDefaultHistoTrack.clone(
   name = "charge",
   title = "Corrected Cluster Charge (OnTrack)",
@@ -12,6 +12,36 @@ hltSiPixelPhase1TrackClustersOnTrackCharge = hltDefaultHistoTrack.clone(
   specs = VPSet(
     hltStandardSpecifications1D,
     StandardSpecification2DProfile
+  )
+)
+
+hltSiPixelPhase1TrackClustersOnTrackBigPixelCharge = DefaultHistoTrack.clone(
+  name = "bigpixelcharge",
+  title = "Corrected Big Pixel Charge (OnTrack)",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+  enabled=False,
+
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
+  )
+)
+
+hltSiPixelPhase1TrackClustersOnTrackNotBigPixelCharge = DefaultHistoTrack.clone(
+  name = "notbigpixelcharge",
+  title = "Corrected Not Big Pixel Charge (OnTrack)",
+  range_min = 0, range_max = 80e3, range_nbins = 100,
+  xlabel = "Charge (electrons)",
+  enabled=False,
+
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
   )
 )
 
@@ -275,6 +305,8 @@ hltSiPixelPhase1TrackClustersConf = cms.VPSet(
 ### THE LIST DEFINED IN THE ENUM
 ### https://cmssdt.cern.ch/lxr/source/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc#0063
    hltSiPixelPhase1TrackClustersOnTrackCharge,
+   hltSiPixelPhase1TrackClustersOnTrackBigPixelCharge,
+   hltSiPixelPhase1TrackClustersOnTrackNotBigPixelCharge,
    hltSiPixelPhase1TrackClustersOnTrackSize,
    hltSiPixelPhase1TrackClustersOnTrackShape,
    hltSiPixelPhase1TrackClustersOnTrackNClusters,

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
@@ -52,7 +52,7 @@ hltSiPixelPhase1TrackClustersOnTrackSize = hltDefaultHistoTrack.clone(
   xlabel = "size[pixels]",
 
   specs = VPSet(
-    hltStandardSpecifications1D    
+    hltStandardSpecifications1D
   )
 )
 
@@ -88,12 +88,12 @@ hltSiPixelPhase1TrackClustersOnTrackNClusters = hltDefaultHistoTrack.clone(
   xlabel = "clusters",
   dimensions = 0,
   specs = VPSet(
-    Specification().groupBy("PXBarrel/PXLayer" + "/DetId/Event") 
-                   .reduce("COUNT") 
+    Specification().groupBy("PXBarrel/PXLayer" + "/DetId/Event")
+                   .reduce("COUNT")
                    .groupBy("PXBarrel/PXLayer")
                    .saveAll(),
-    Specification().groupBy("PXForward/PXDisk" + "/DetId/Event") 
-                   .reduce("COUNT") 
+    Specification().groupBy("PXForward/PXDisk" + "/DetId/Event")
+                   .reduce("COUNT")
                    .groupBy("PXForward/PXDisk")
                    .saveAll(),
     StandardSpecificationInclusive_Num,
@@ -235,7 +235,7 @@ hltSiPixelPhase1TrackClustersOnTrackSizeXYOuter = hltSiPixelPhase1TrackClustersO
   xlabel = "y size",
   ylabel = "x size",
   range_min = 0, range_max  = 20, range_nbins   = 20,
-  range_y_min = 0, range_y_max = 10, range_y_nbins = 10 
+  range_y_min = 0, range_y_max = 10, range_y_nbins = 10
 )
 
 hltSiPixelPhase1TrackClustersOnTrackSizeXYInner = hltSiPixelPhase1TrackClustersOnTrackSizeXYOuter.clone(
@@ -277,11 +277,11 @@ hltSiPixelPhase1TrackClustersOnTrackChargeOuter = hltDefaultHistoTrack.clone(
     Specification().groupBy("PXBarrel/PXLayer").save()
   )
 )
-  
+
 hltSiPixelPhase1TrackClustersOnTrackChargeInner = hltSiPixelPhase1TrackClustersOnTrackChargeOuter.clone(
   name = "chargeInner",
   title = "Corrected Cluster Charge (OnTrack) inner ladders"
-)  
+)
 
 hltSiPixelPhase1TrackClustersOnTrackShapeOuter = hltDefaultHistoTrack.clone(
   enabled = False,
@@ -313,25 +313,25 @@ hltSiPixelPhase1TrackClustersConf = cms.VPSet(
    hltSiPixelPhase1TrackClustersOnTrackPositionB,
    hltSiPixelPhase1TrackClustersOnTrackPositionF,
    hltSiPixelPhase1DigisHitmapOnTrack,
- 
+
    hltSiPixelPhase1TrackClustersNTracks,
    hltSiPixelPhase1TrackClustersNTracksInVolume,
- 
+
    hltSiPixelPhase1ClustersSizeVsEtaOnTrackOuter,
    hltSiPixelPhase1ClustersSizeVsEtaOnTrackInner,
    hltSiPixelPhase1TrackClustersOnTrackChargeOuter,
    hltSiPixelPhase1TrackClustersOnTrackChargeInner,
- 
+
    hltSiPixelPhase1TrackClustersOnTrackShapeOuter,
    hltSiPixelPhase1TrackClustersOnTrackShapeInner,
- 
+
    hltSiPixelPhase1TrackClustersOnTrackSizeXOuter,
    hltSiPixelPhase1TrackClustersOnTrackSizeXInner,
    hltSiPixelPhase1TrackClustersOnTrackSizeXF,
    hltSiPixelPhase1TrackClustersOnTrackSizeYOuter,
    hltSiPixelPhase1TrackClustersOnTrackSizeYInner,
    hltSiPixelPhase1TrackClustersOnTrackSizeYF,
- 
+
    hltSiPixelPhase1TrackClustersOnTrackSizeXYOuter,
    hltSiPixelPhase1TrackClustersOnTrackSizeXYInner,
    hltSiPixelPhase1TrackClustersOnTrackSizeXYF,
@@ -353,4 +353,3 @@ hltSiPixelPhase1TrackClustersHarvester = DQMEDHarvester("SiPixelPhase1Harvester"
         histograms = hltSiPixelPhase1TrackClustersConf,
         geometry   = hltSiPixelPhase1Geometry
 )
-


### PR DESCRIPTION
Added the charge of the big pixels for the barrel and the forward region, as well as per layer and per disk
For inclusive clusters and on-track clusters (for inclusive clusters the plots are disabled by default)

Exact backport of the already merged PR  #22324

Work done by  @emacdonald16 