### PR TITLE
Avoid reading memory after delete in CosMuoGenProducer

### DIFF
--- a/GeneratorInterface/CosmicMuonGenerator/interface/CosMuoGenProducer.h
+++ b/GeneratorInterface/CosmicMuonGenerator/interface/CosMuoGenProducer.h
@@ -15,6 +15,8 @@
 
 #include "GeneratorInterface/CosmicMuonGenerator/interface/CosmicMuonGenerator.h"
 
+#include <memory>
+
 namespace edm
 {
   class CosMuoGenProducer : public one::EDProducer<EndRunProducer, one::WatchLuminosityBlocks> {
@@ -81,9 +83,8 @@ namespace edm
     double       extCrossSect;
     double       extFilterEff;
 
-    CosmicMuonGenerator* CosMuoGen;
+    std::unique_ptr<CosmicMuonGenerator> CosMuoGen;
     // the event format itself
-    HepMC::GenEvent* fEvt;
     bool cmVerbosity_;
 
     bool isInitialized_;


### PR DESCRIPTION
The HepMC::GenEvent instance was being inspected after it was deleted
when the HepMCProduct was put into the event. Changing the order of
calls avoids the problem.

Additionally, the use of bare pointers was changed to std::unique_ptr.