### PR TITLE
Revert "Do not truncate QIE11 linearization LUTs at 10 bits"

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -64,9 +64,7 @@ public:
 
   static const int QIE8_LUT_BITMASK = 0x3FF;
   static const int QIE10_LUT_BITMASK = 0x7FF;
-  static const int QIE11_LUT_BITMASK = 0x7FF;
-  // only the lowest 10 bits were used in 2017
-  static const int QIE11_LUT_BITMASK_2017 = 0x3FF;
+  static const int QIE11_LUT_BITMASK = 0x3FF;
 
 private:
   // typedef
@@ -79,8 +77,8 @@ private:
   static const int    nFi_ = 72;
 
   static const int QIE8_LUT_MSB = 0x400;
-  static const int QIE11_LUT_MSB0 = 0x800;
-  static const int QIE11_LUT_MSB1 = 0x1000;
+  static const int QIE11_LUT_MSB0 = 0x400;
+  static const int QIE11_LUT_MSB1 = 0x800;
   static const int QIE10_LUT_MSB  = 0x1000;
   
   // member variables

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -35,7 +35,6 @@ const float HcaluLUTTPGCoder::lsb_=1./16;
 const int HcaluLUTTPGCoder::QIE8_LUT_BITMASK;
 const int HcaluLUTTPGCoder::QIE10_LUT_BITMASK;
 const int HcaluLUTTPGCoder::QIE11_LUT_BITMASK;
-const int HcaluLUTTPGCoder::QIE11_LUT_BITMASK_2017;
 
 constexpr double MaximumFractionalError = 0.002; // 0.2% error allowed from this source
 
@@ -350,8 +349,7 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
 
 	const size_t SIZE = qieType==QIE8 ? INPUT_LUT_SIZE : UPGRADE_LUT_SIZE;
 	const int MASK = qieType==QIE8 ? QIE8_LUT_BITMASK :
-                         qieType==QIE10 ? QIE10_LUT_BITMASK :
-                         is2018OrLater ? QIE11_LUT_BITMASK : QIE11_LUT_BITMASK_2017;
+                         qieType==QIE10 ? QIE10_LUT_BITMASK : QIE11_LUT_BITMASK;
         double linearLSB = linearLSB_QIE8_;
         if (qieType == QIE11 and cell.ietaAbs() == topo_->lastHBRing())
            linearLSB = linearLSB_QIE11Overlap_;


### PR DESCRIPTION
Backport #22848 

This version is based on 10_0_4, for use as a patch in the online DQM.

This reverts commit 21db65c2e43b405e3a19f60230f7b7c72165c001.