### PR TITLE
SiPixelQuality update and bugfix for CMSSW 10_2_X

### DIFF
--- a/CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h
@@ -26,10 +26,10 @@ public:
 
   // fill hit in double idc in ROC roc into module detid
   void fillDIGI(int detid, int roc);
-  // fill stuck TBM info
-  void fillStuckTBM(int detid, PixelFEDChannel ch);
+  // fill FEDerror25 info
+  void fillFEDerror25(int detid, PixelFEDChannel ch);
 
-  std::map<int, std::vector<int>> getStuckTBMsRocs();
+  std::map<int, std::vector<int>> getFEDerror25Rocs();
 
   // determine detector average nhits and RMS
   void digiOccupancy();

--- a/CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h
@@ -25,9 +25,9 @@ public:
   void addModule(int detid, SiPixelModuleStatus a);
 
   // fill hit in double idc in ROC roc into module detid
-  void fillDIGI(int detid, int roc, int idc);
+  void fillDIGI(int detid, int roc);
   // fill stuck TBM info
-  void fillStuckTBM(int detid, PixelFEDChannel ch, std::time_t time);
+  void fillStuckTBM(int detid, PixelFEDChannel ch);
 
   std::map<int, std::vector<int>> getStuckTBMsRocs();
 
@@ -54,8 +54,6 @@ public:
   std::pair<int,int> getRunRange() {return std::make_pair(fRun0,fRun1);}
   void setLSRange(int ls0, int ls1)  {fLS0 = ls0; fLS1 = ls1;}
   std::pair<int,int> getLSRange() {return std::make_pair(fLS0,fLS1);}
-  void setRefTime(std::time_t refTime0, std::time_t refTime1) {fTime0 = refTime0; fTime1 = refTime1;}
-  std::pair<std::time_t,std::time_t> getRefTime() {return std::make_pair(fTime0,fTime1);}
 
   // total processed events
   void setNevents(unsigned long int N){ fNevents = N; }
@@ -63,12 +61,10 @@ public:
 
   void resetDetectorStatus() { fModules.clear(); fDetAverage=0; fDetSigma=0; fDetHits=0; fNevents=0;
                                fRun0 = 99999999; fRun1 = 0; fLS0 = 99999999; fLS1 = 0; 
-                               fTime0 = 0; fTime1 = 0;
                              }
 
   // combine detector status
   void updateDetectorStatus(SiPixelDetectorStatus newData);
-  SiPixelDetectorStatus combineDetectorStatus(SiPixelDetectorStatus newData);
 
   // detector status
   std::map<int, SiPixelModuleStatus> getDetectorStatus(){ return fModules; }
@@ -83,9 +79,6 @@ public:
   // first and last run seen in this instance (likely to be the same number!)
   int fRun0, fRun1;
 
-  // being and end time stamp
-  std::time_t fTime0, fTime1;
-  
   // number of events processed
   unsigned long int fNevents;
 

--- a/CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h
@@ -32,9 +32,9 @@ public:
   std::map<int, std::vector<int>> getFEDerror25Rocs();
 
   // determine detector average nhits and RMS
-  void digiOccupancy();
-  double perRocDigiOcc(){ digiOccupancy(); return fDetAverage; }
-  double perRocDigiOccVar(){ digiOccupancy(); return fDetSigma; }
+  double perRocDigiOcc();
+  double perRocDigiOccVar();
+
   unsigned long int digiOccDET(){ return fDetHits; }
 
   // number of modules in detector
@@ -59,7 +59,7 @@ public:
   void setNevents(unsigned long int N){ fNevents = N; }
   unsigned long int getNevents(){ return fNevents; }
 
-  void resetDetectorStatus() { fModules.clear(); fDetAverage=0; fDetSigma=0; fDetHits=0; fNevents=0;
+  void resetDetectorStatus() { fModules.clear(); fDetHits=0; fNevents=0;
                                fRun0 = 99999999; fRun1 = 0; fLS0 = 99999999; fLS1 = 0; 
                              }
 
@@ -75,15 +75,11 @@ public:
 
   // first and last lumisection seen in this instance
   int fLS0, fLS1;
-
-  // first and last run seen in this instance (likely to be the same number!)
+  // first and last run seen in this instance (should be the same number!)
   int fRun0, fRun1;
 
   // number of events processed
   unsigned long int fNevents;
-
-  // average (per module) number of hits over entire detector
-  double fDetAverage, fDetSigma;
 
   // total hits in detector
   unsigned long int fDetHits;

--- a/CalibTracker/SiPixelQuality/interface/SiPixelModuleStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelModuleStatus.h
@@ -21,8 +21,8 @@ public:
   /// fill with online coordinates (nhit > 1)
   void updateDIGI(int iroc, unsigned int nhit);
 
-  /// fill stuck TBM
-  void fillStuckTBM( PixelFEDChannel ch );
+  /// fill FEDerror25
+  void fillFEDerror25( PixelFEDChannel ch );
 
   /// return ROC status (= hits on ROC iroc)
   unsigned int digiOccROC(int iroc);

--- a/CalibTracker/SiPixelQuality/interface/SiPixelModuleStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelModuleStatus.h
@@ -16,22 +16,19 @@ public:
   ~SiPixelModuleStatus();
 
   /// fill with online coordinates
-  void fillDIGI(int iroc, int idc);
+  void fillDIGI(int iroc);
 
   /// fill with online coordinates (nhit > 1)
-  void updateDIGI(int iroc, int idc, unsigned long nhit);
+  void updateDIGI(int iroc, unsigned int nhit);
 
   /// fill stuck TBM
-  void fillStuckTBM( PixelFEDChannel ch, std::time_t time );
-
-  /// return DC status of a ROC (=hits on DC idc on ROC iroc)
-  unsigned long int digiOccDC(int iroc, int idc);
+  void fillStuckTBM( PixelFEDChannel ch );
 
   /// return ROC status (= hits on ROC iroc)
-  unsigned long int digiOccROC(int iroc);
+  unsigned int digiOccROC(int iroc);
 
   /// return module status (= hits on module)
-  unsigned long int digiOccMOD();
+  unsigned int digiOccMOD();
 
   /// get a ROC
   SiPixelRocStatus* getRoc(int i);
@@ -47,7 +44,7 @@ public:
   double perRocDigiOccVar();
 
   /// combine new data to update(topup) module status
-  void updateModuleDIGI(int roc, int dc, unsigned long int nhits);
+  void updateModuleDIGI(int roc, unsigned int nhits);
   void updateModuleStatus(SiPixelModuleStatus newData);
 
 private:

--- a/CalibTracker/SiPixelQuality/interface/SiPixelModuleStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelModuleStatus.h
@@ -39,7 +39,6 @@ public:
   void   setNrocs(int iroc);
 
   /// calculate (averaged over this module's ROCs) mean hit number and its sigma
-  void digiOccupancy();
   double perRocDigiOcc();
   double perRocDigiOccVar();
 
@@ -50,7 +49,6 @@ public:
 private:
 
   int fDetid, fNrocs;
-  double fModAverage, fModSigma;
   std::vector<SiPixelRocStatus> fRocs;
 
 };

--- a/CalibTracker/SiPixelQuality/interface/SiPixelRocStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelRocStatus.h
@@ -1,8 +1,6 @@
 #ifndef SIPIXELROCSTATUS_h
 #define SIPIXELROCSTATUS_h
 
-#include <ctime>
-
 // ----------------------------------------------------------------------
 class SiPixelRocStatus {
 public:

--- a/CalibTracker/SiPixelQuality/interface/SiPixelRocStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelRocStatus.h
@@ -8,35 +8,20 @@ class SiPixelRocStatus {
 public:
   SiPixelRocStatus();
   ~SiPixelRocStatus();
-  void fillDIGI(int idc);
-  void updateDIGI(int idc, unsigned long int hits);
-
-  void fillStuckTBM(unsigned int fed, unsigned int link, std::time_t time);
-  void updateStuckTBM(unsigned int fed, unsigned int link, std::time_t time, unsigned long int freq);
+  void fillDIGI();
+  void updateDIGI(unsigned int hits);
+  void fillStuckTBM();
 
   // stuckTBM
   bool isStuckTBM(){ return isStuckTBM_; }
-  unsigned int getBadFed(){ return badFed_; }
-  unsigned int getBadLink(){ return badLink_; }
-  std::time_t getStartBadTime(){ return startBadTime_; }
-  unsigned long int getBadFreq(){ return badFreq_; }
 
   // occpancy
-  unsigned long int digiOccDC(int idc);
-  unsigned long int digiOccROC();
-
-  int nDC(){ return nDC_;}
-   
+  unsigned int digiOccROC();
 
 private:
-  const int nDC_ = 26;
-  unsigned long int fDC[26];
 
+  unsigned int fDC;
   bool isStuckTBM_;
-  unsigned int badFed_;
-  unsigned int badLink_;
-  std::time_t startBadTime_;
-  unsigned long int badFreq_;
  
 };
 

--- a/CalibTracker/SiPixelQuality/interface/SiPixelRocStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelRocStatus.h
@@ -10,10 +10,10 @@ public:
   ~SiPixelRocStatus();
   void fillDIGI();
   void updateDIGI(unsigned int hits);
-  void fillStuckTBM();
+  void fillFEDerror25();
 
   // stuckTBM
-  bool isStuckTBM(){ return isStuckTBM_; }
+  bool isFEDerror25(){ return isFEDerror25_; }
 
   // occpancy
   unsigned int digiOccROC();
@@ -21,7 +21,7 @@ public:
 private:
 
   unsigned int fDC;
-  bool isStuckTBM_;
+  bool isFEDerror25_;
  
 };
 

--- a/CalibTracker/SiPixelQuality/interface/SiPixelStatusManager.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelStatusManager.h
@@ -15,6 +15,8 @@
 #include <map>
 #include <utility>
 #include <iostream>
+#include <algorithm>    // std::sort
+#include <vector>       // std::vector
 
 //Data format
 #include "CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h"
@@ -29,22 +31,22 @@ class SiPixelStatusManager {
   void reset();   
   void readLumi(const edm::LuminosityBlock&);   
 
-  void createPayloads(){
-      createFEDerror25();
-      createBadComponents();
-  }
+  void createPayloads();
 
   const std::map<edm::LuminosityBlockNumber_t,SiPixelDetectorStatus>& getBadComponents(){return siPixelStatusMap_; } 
   const std::map<edm::LuminosityBlockNumber_t,std::map<int, std::vector<int>> >& getFEDerror25Rocs(){return FEDerror25Map_;}
 
   typedef std::map<edm::LuminosityBlockNumber_t,SiPixelDetectorStatus>::iterator siPixelStatusMap_iterator;
   typedef std::map<edm::LuminosityBlockNumber_t,std::map<int, std::vector<int>> >::iterator FEDerror25Map_iterator;
+  typedef std::vector<SiPixelDetectorStatus>::iterator siPixelStatusVtr_iterator;
 
  private:
 
+  static bool rankByLumi(SiPixelDetectorStatus status1, SiPixelDetectorStatus status2);
   void createFEDerror25();
   void createBadComponents();
 
+  std::vector<SiPixelDetectorStatus> siPixelStatusVtr_;
   std::map<edm::LuminosityBlockNumber_t, SiPixelDetectorStatus> siPixelStatusMap_;
   std::map<edm::LuminosityBlockNumber_t, std::map<int, std::vector<int>> > FEDerror25Map_;
 

--- a/CalibTracker/SiPixelQuality/interface/SiPixelStatusManager.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelStatusManager.h
@@ -29,24 +29,24 @@ class SiPixelStatusManager {
   void reset();   
   void readLumi(const edm::LuminosityBlock&);   
 
-  void createStuckTBMs();
-  void createBadComponents();
-
   void createPayloads(){
-      createStuckTBMs();
+      createFEDerror25();
       createBadComponents();
   }
 
   const std::map<edm::LuminosityBlockNumber_t,SiPixelDetectorStatus>& getBadComponents(){return siPixelStatusMap_; } 
-  const std::map<edm::LuminosityBlockNumber_t,std::map<int, std::vector<int>> >& getStuckTBMsRocs(){return stuckTBMsMap_;}
+  const std::map<edm::LuminosityBlockNumber_t,std::map<int, std::vector<int>> >& getFEDerror25Rocs(){return FEDerror25Map_;}
 
   typedef std::map<edm::LuminosityBlockNumber_t,SiPixelDetectorStatus>::iterator siPixelStatusMap_iterator;
-  typedef std::map<edm::LuminosityBlockNumber_t,std::map<int, std::vector<int>> >::iterator stuckTBMsMap_iterator;
+  typedef std::map<edm::LuminosityBlockNumber_t,std::map<int, std::vector<int>> >::iterator FEDerror25Map_iterator;
 
  private:
 
+  void createFEDerror25();
+  void createBadComponents();
+
   std::map<edm::LuminosityBlockNumber_t, SiPixelDetectorStatus> siPixelStatusMap_;
-  std::map<edm::LuminosityBlockNumber_t, std::map<int, std::vector<int>> > stuckTBMsMap_;
+  std::map<edm::LuminosityBlockNumber_t, std::map<int, std::vector<int>> > FEDerror25Map_;
 
   std::string outputBase_;
   int aveDigiOcc_;

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
@@ -44,16 +44,14 @@ using namespace edm;
 //--------------------------------------------------------------------------------------------------
 SiPixelStatusHarvester::SiPixelStatusHarvester(const edm::ParameterSet& iConfig) :
   outputBase_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<std::string>("outputBase")),
-  aveDigiOcc_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<int>("aveDigiOcc", 20000)),
+  aveDigiOcc_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<int>("aveDigiOcc")),
   nLumi_(iConfig.getParameter<edm::ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<int>("resetEveryNLumi")),
   moduleName_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<std::string>("moduleName")),
   label_(iConfig.getParameter<ParameterSet>("SiPixelStatusManagerParameters").getUntrackedParameter<std::string>("label")),
-  siPixelStatusManager_(iConfig, consumesCollector()) {  
+  siPixelStatusManager_(iConfig, consumesCollector()){  
 
+  debug_ = iConfig.getUntrackedParameter<bool>("debug");
   recordName_ = iConfig.getUntrackedParameter<std::string>("recordName", "SiPixelQualityFromDbRcd");
-  debug_ = iConfig.getUntrackedParameter<bool>("debug",false);
-  dumpTxt_ = iConfig.getUntrackedParameter<bool>("dumpTxt",false);
-  outTxtFileName_ = iConfig.getUntrackedParameter<std::string>("txtFileName");
   
 }
 
@@ -100,6 +98,11 @@ void SiPixelStatusHarvester::endRun(const edm::Run& iRun, const edm::EventSetup&
         siPixelQualityPermBad->addDisabledModule(badComponentList[i]);
     }
 
+    // IOV for final payloads. FEDerror25 and pcl
+    std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t> finalIOV;
+    std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t> fedError25IOV;
+    std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t> pclIOV;
+
     // stuckTBM tag from FED error 25 with permanent component removed
     for(SiPixelStatusManager::FEDerror25Map_iterator it=FEDerror25Map.begin(); it!=FEDerror25Map.end();it++){
 
@@ -143,35 +146,37 @@ void SiPixelStatusHarvester::endRun(const edm::Run& iRun, const edm::EventSetup&
                BadModule.BadRocs = badrocs;
                siPixelQuality->addDisabledModule(BadModule);
              }
-          }
 
-          if (poolDbService->isNewTagRequest(recordName_+"_stuckTBM") ) {
-              edm::LogInfo("SiPixelStatusHarvester")
-                 << "new tag requested for stuckTBM" << std::endl;
-              poolDbService->writeOne<SiPixelQuality>(siPixelQuality, thisIOV, recordName_+"_stuckTBM");
-          }
-          else {
-             edm::LogInfo("SiPixelStatusHarvester")
-                << "no new tag requested, appending IOV for stuckTBM" << std::endl;
-              poolDbService->writeOne<SiPixelQuality>(siPixelQuality, thisIOV, recordName_+"_stuckTBM");
-          }
+          } // loop over modules
+
+          finalIOV[it->first] = it->first;
+          fedError25IOV[it->first] = it->first;
+
+          poolDbService->writeOne<SiPixelQuality>(siPixelQuality, thisIOV, recordName_+"_stuckTBM");
 
     }
 
-    // Payload for PCL combines permanent bad/stuckTBM/other
+    // IOV for PCL combines permanent bad/stuckTBM/other
     for(SiPixelStatusManager::siPixelStatusMap_iterator it=siPixelStatusMap.begin(); it!=siPixelStatusMap.end();it++){
+        finalIOV[it->first] = it->first;
+        pclIOV[it->first] = it->first;
+    }
+
+    // loop over final IOV
+    std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t>::iterator itIOV;
+    for(itIOV=finalIOV.begin();itIOV!=finalIOV.end();itIOV++){
 
           cond::Time_t thisIOV = 1;
+          edm::LuminosityBlockID lu(iRun.id().run(),itIOV->first);
+          thisIOV = (cond::Time_t)(lu.value());
 
-          if (outputBase_ == "runbased") {
-               thisIOV = (cond::Time_t) iRun.id().run();
-          }
-          else if (outputBase_ == "nLumibased" || outputBase_ == "dynamicLumibased" ) {
-             edm::LuminosityBlockID lu(iRun.id().run(),it->first);
-             thisIOV = (cond::Time_t)(lu.value());
-          }
+          edm::LuminosityBlockNumber_t lumiStuckTBMs = SiPixelStatusHarvester::stepIOV(itIOV->first,fedError25IOV);
+          edm::LuminosityBlockNumber_t lumiPCL = SiPixelStatusHarvester::stepIOV(itIOV->first,pclIOV);
 
-          SiPixelDetectorStatus tmpSiPixelStatus = it->second;
+          // get badROC list due to FEDerror25 = stuckTBM + permanent bad components
+          std::map<int, std::vector<int> > tmpFEDerror25 = FEDerror25Map[lumiStuckTBMs];
+          // get SiPixelDetectorStatus
+          SiPixelDetectorStatus tmpSiPixelStatus = siPixelStatusMap[lumiPCL];
           double DetAverage = tmpSiPixelStatus.perRocDigiOcc();
 
           // For the IOV of which the statistics is too low, for e.g., a cosmic run
@@ -197,19 +202,14 @@ void SiPixelStatusHarvester::endRun(const edm::Run& iRun, const edm::EventSetup&
           // create the DB object
           // payload including all : PCL = permanent bad + other + stuckTBM
           SiPixelQuality *siPixelQualityPCL = new SiPixelQuality();
-          // payload for prompt reco : permanent bad + other sources of bad components
           SiPixelQuality *siPixelQualityPrompt = new SiPixelQuality();
-          // payload for : other sources of bad components
           SiPixelQuality *siPixelQualityOther = new SiPixelQuality();
-
-          // get badROC list due to FEDerror25 = stuckTBM + permanent bad components
-          std::map<int, std::vector<int> > tmpFEDerror25 = tmpSiPixelStatus.getFEDerror25Rocs();
 
           std::map<int, SiPixelModuleStatus> detectorStatus = tmpSiPixelStatus.getDetectorStatus();
           std::map<int, SiPixelModuleStatus>::iterator itModEnd = detectorStatus.end();
           for (std::map<int, SiPixelModuleStatus>::iterator itMod = detectorStatus.begin(); itMod != itModEnd; ++itMod) {
 
-               // create the bad module list
+               // create the bad module list for PCL, prompt and other
                SiPixelQuality::disabledModuleType BadModulePCL, BadModulePrompt, BadModuleOther;
 
                int detid = itMod->first;
@@ -234,89 +234,73 @@ void SiPixelStatusHarvester::endRun(const edm::Run& iRun, const edm::EventSetup&
                    // Bad ROC are from low DIGI Occ ROCs
                    if(rocOccupancy<1.e-4*DetAverage){
 
+                     //PCL bad roc list
                      BadRocListPCL.push_back(uint32_t(iroc));
+                     //FEDerror25 list
                      std::vector<int>::iterator it = std::find(listFEDerror25.begin(), listFEDerror25.end(),iroc);
 
-                     // from prompt =  permanent bad + other
+                     // from prompt = PCL bad - stuckTBM =  PCL bad - FEDerror25 + permanent bad
                      if(it==listFEDerror25.end() || badPixelInfo_->IsRocBad(detid, iroc)) 
-                     // if permanent or not stuck TBM( this is to say either in the FEDerror25 list or permanent bdd)
-                       BadRocListPrompt.push_back(uint32_t(iroc));
+                        // if not FEDerror25 or permanent bad
+                        BadRocListPrompt.push_back(uint32_t(iroc));
 
-                     // other source of bad components
+                     // other source of bad components = prompt - permanent bad = PCL bad - FEDerror25
+                     // or to be safe, say not FEDerro25 and not permanent bad
                      if(it==listFEDerror25.end() && !(badPixelInfo_->IsRocBad(detid, iroc))) 
-                     // if not permanent and not stuck TBM( this is to say either in the FEDerror25 list or permanent bdd)
-                       BadRocListOther.push_back(uint32_t(iroc));                     
-                    
+                        // if not permanent and not stuck TBM
+                        BadRocListOther.push_back(uint32_t(iroc)); 
+
                    }
-               }
+
+               } // loop over ROCs
 
                if(BadRocListPCL.size()==16) BadModulePCL.errorType = 0;
                if(BadRocListPrompt.size()==16) BadModulePrompt.errorType = 0;
                if(BadRocListOther.size()==16) BadModuleOther.errorType = 0;
 
+               // pcl
                short badrocsPCL = 0;
                for(std::vector<uint32_t>::iterator iterPCL = BadRocListPCL.begin(); iterPCL != BadRocListPCL.end(); ++iterPCL){
                    badrocsPCL +=  1 << *iterPCL; // 1 << *iter = 2^{*iter} using bitwise shift 
                } 
-               // fill the badmodule only if there is(are) bad ROC(s) in it
                if(badrocsPCL!=0){
                  BadModulePCL.BadRocs = badrocsPCL;
                  siPixelQualityPCL->addDisabledModule(BadModulePCL);
                }
 
+               // prompt
                short badrocsPrompt = 0;
                for(std::vector<uint32_t>::iterator iterPrompt = BadRocListPrompt.begin(); iterPrompt != BadRocListPrompt.end(); ++iterPrompt){
                    badrocsPrompt +=  1 << *iterPrompt; // 1 << *iter = 2^{*iter} using bitwise shift
                }
-               // fill the badmodule only if there is(are) bad ROC(s) in it
                if(badrocsPrompt!=0){
                  BadModulePrompt.BadRocs = badrocsPrompt;
                  siPixelQualityPrompt->addDisabledModule(BadModulePrompt);
                }
 
-               short badrocsOther = 0;
+               // other
+               short badrocsOther= 0;
                for(std::vector<uint32_t>::iterator iterOther = BadRocListOther.begin(); iterOther != BadRocListOther.end(); ++iterOther){
                    badrocsOther +=  1 << *iterOther; // 1 << *iter = 2^{*iter} using bitwise shift
                }
-               // fill the badmodule only if there is(are) bad ROC(s) in it
                if(badrocsOther!=0){
                  BadModuleOther.BadRocs = badrocsOther;
                  siPixelQualityOther->addDisabledModule(BadModuleOther);
                }
-
+     
          } // end module loop
+ 
+         //PCL
+         if(debug_==true) // only produce the tag for all sources of bad components for debugging reason
+             poolDbService->writeOne<SiPixelQuality>(siPixelQualityPCL, thisIOV, recordName_+"_PCL");
 
-         if(debug_) // only produce the tag for all sources of bad components for debugging reason
-	     poolDbService->writeOne<SiPixelQuality>(siPixelQualityPCL, thisIOV, recordName_+"_PCL");
+         // prompt
+         poolDbService->writeOne<SiPixelQuality>(siPixelQualityPrompt, thisIOV, recordName_+"_prompt");
 
-         if (poolDbService->isNewTagRequest(recordName_+"_prompt")) {
-             edm::LogInfo("SiPixelStatusHarvester")
-                 << "new tag requested for prompt" << std::endl;
-             poolDbService->writeOne<SiPixelQuality>(siPixelQualityPrompt, thisIOV, recordName_+"_prompt");
-         }
-         else {
-            edm::LogInfo("SiPixelStatusHarvester")
-               << "no new tag requested, appending IOV for prompt" << std::endl;
-             poolDbService->writeOne<SiPixelQuality>(siPixelQualityPrompt, thisIOV, recordName_+"_prompt");
-         }
+         // other
+         poolDbService->writeOne<SiPixelQuality>(siPixelQualityOther, thisIOV, recordName_+"_other");
 
-         if (poolDbService->isNewTagRequest(recordName_+"_other")) {
-             edm::LogInfo("SiPixelStatusHarvester")
-                 << "new tag requested for other" << std::endl;
-             poolDbService->writeOne<SiPixelQuality>(siPixelQualityOther, thisIOV, recordName_+"_other");
-         }
-         else {
-            edm::LogInfo("SiPixelStatusHarvester")
-               << "no new tag requested, appending IOV for other" << std::endl;
-             poolDbService->writeOne<SiPixelQuality>(siPixelQualityOther, thisIOV, recordName_+"_other");
-         }
-
-         if (dumpTxt_){ // text dump for the DIGI occuancy for all pixels in all ROCs for the pixle detector
-            std::string outTxt = Form("%s_Run%d_Lumi%d_SiPixelStatus.txt", outTxtFileName_.c_str(), iRun.id().run(),it->first);
-            tmpSiPixelStatus.dumpToFile(outTxt); 
-         }
-
-     }// loop over IOV-structured Map (payloads)
+     }// loop over IOV
 
      // Add a dummy IOV starting from last lumisection+1 to close the tag for the run
      if(outputBase_ == "nLumibased" || outputBase_ == "dynamicLumibased"){
@@ -343,7 +327,6 @@ void SiPixelStatusHarvester::beginLuminosityBlock(const edm::LuminosityBlock& iL
 //--------------------------------------------------------------------------------------------------
 void SiPixelStatusHarvester::endLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iEVentSetup) {
 
-  std::cout<<"lumi "<<iLumi.luminosityBlock()<<std::endl;
   siPixelStatusManager_.readLumi(iLumi);
   // update endLumiBlock_ by current lumi block
   if(endLumiBlock_<iLumi.luminosityBlock())
@@ -351,5 +334,30 @@ void SiPixelStatusHarvester::endLuminosityBlock(const edm::LuminosityBlock& iLum
 
 }
 
+// step function for IOV
+edm::LuminosityBlockNumber_t SiPixelStatusHarvester::stepIOV(edm::LuminosityBlockNumber_t pin, std::map<edm::LuminosityBlockNumber_t,edm::LuminosityBlockNumber_t> IOV){
+
+   std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t>::iterator itIOV;
+   for(itIOV=IOV.begin();itIOV!=IOV.end();itIOV++){
+       std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t>::iterator nextItIOV;
+       nextItIOV = itIOV; nextItIOV++;
+
+       if(nextItIOV!=IOV.end()){ 
+          if(pin>=itIOV->first && pin<nextItIOV->first){
+             return itIOV->first;
+          }
+       }
+       else{
+          if(pin>=itIOV->first){
+             return itIOV->first;
+          }
+       }
+
+   }
+
+   // return the firstIOV in case all above fail
+   return (IOV.begin())->first;
+   
+}
 
 DEFINE_FWK_MODULE(SiPixelStatusHarvester);

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
@@ -30,7 +30,6 @@ class SiPixelStatusHarvester : public edm::EDAnalyzer {
  protected:
 
  private:
-  bool debug_;
   // Parameters
   std::string outputBase_;
   int aveDigiOcc_;
@@ -39,6 +38,8 @@ class SiPixelStatusHarvester : public edm::EDAnalyzer {
   std::string label_;  
   // harvest helper classs that setup the IOV structure
   SiPixelStatusManager siPixelStatusManager_;
+  // debug mode
+  bool debug_;
   // for DB output naming
   std::string recordName_;
 
@@ -48,9 +49,8 @@ class SiPixelStatusHarvester : public edm::EDAnalyzer {
   // last lumi section of the SiPixeDetectorStatus data
   edm::LuminosityBlockNumber_t endLumiBlock_;
 
-  // only for debugging
-  bool dumpTxt_;
-  std::string outTxtFileName_;
+  // "step function" for IOV
+  edm::LuminosityBlockNumber_t stepIOV(edm::LuminosityBlockNumber_t pin, std::map<edm::LuminosityBlockNumber_t,edm::LuminosityBlockNumber_t> IOV);
 
 };
 

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
@@ -28,7 +28,7 @@
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
-// "FED error 25" - stuck TBM
+// "FED error 25"
 #include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 
 // CMSSW CondFormats
@@ -213,7 +213,7 @@ void SiPixelStatusProducer::accumulate(edm::Event const& iEvent, const edm::Even
   } // 
   //////////////////////////////////////////////////////////////////////
 
-  // the error given by FED due to stuck TBM
+  // FEDerror25 per-ROC per-event
   edm::Handle<PixelFEDChannelCollection> pixelFEDChannelCollectionHandle;
 
   // look over different resouces of takens
@@ -228,7 +228,7 @@ void SiPixelStatusProducer::accumulate(edm::Event const& iEvent, const edm::Even
 
                 DetId detId = disabledChannels.detId();
                 int detid = detId.rawId();
-                fDet.fillStuckTBM(detid,ch);
+                fDet.fillFEDerror25(detid,ch);
 
             } // loop over different PixelFED in a PixelFED vector (different channel for a given module)
 

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
@@ -42,8 +42,6 @@ class SiPixelStatusProducer : public edm::one::EDProducer<edm::EndLuminosityBloc
   int beginRun_;
   int endRun_;
 
-  std::time_t refTime_[2];
-
   // condition watchers
   // CablingMaps
   edm::ESWatcher<SiPixelFedCablingMapRcd> siPixelFedCablingMapWatcher_;
@@ -58,7 +56,6 @@ class SiPixelStatusProducer : public edm::one::EDProducer<edm::EndLuminosityBloc
 
   // SiPixel offline<->online conversion
   // -- map (for each detid) of the map from offline col/row to the online roc/col/row
-  bool monitorOnDoubleColumn_; // whether to use CablingMap to get the roc/ pixel local coordinate
   SiPixelCoordinates coord_;
 
   // ROC size (number of row, number of columns for each det id)
@@ -71,8 +68,6 @@ class SiPixelStatusProducer : public edm::one::EDProducer<edm::EndLuminosityBloc
   std::map<int, std::map<int,int> >fRocIds;
 
   // Producer inputs / controls
-  int                                                     fVerbose;
-  std::string                                             fFileName;
   edm::InputTag                                           fPixelClusterLabel_;
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>>  fSiPixelClusterToken_;
   std::vector<edm::EDGetTokenT<PixelFEDChannelCollection> > theBadPixelFEDChannelsTokens_;

--- a/CalibTracker/SiPixelQuality/python/SiPixelStatusHarvester_cfi.py
+++ b/CalibTracker/SiPixelQuality/python/SiPixelStatusHarvester_cfi.py
@@ -10,9 +10,7 @@ siPixelStatusHarvester = cms.EDAnalyzer("SiPixelStatusHarvester",
         label      = cms.untracked.string("siPixelStatus"),
     ),
     debug = cms.untracked.bool(False),
-    recordName   = cms.untracked.string("SiPixelQualityFromDbRcd"),
-    dumpTxt            = cms.untracked.bool(False),
-    txtFileName        = cms.untracked.string("SiPixelBadComponent"),
+    recordName   = cms.untracked.string("SiPixelQualityFromDbRcd")
 
 )
 

--- a/CalibTracker/SiPixelQuality/python/SiPixelStatusProducer_cfi.py
+++ b/CalibTracker/SiPixelQuality/python/SiPixelStatusProducer_cfi.py
@@ -4,7 +4,6 @@ siPixelStatusProducer = cms.EDProducer("SiPixelStatusProducer",
     SiPixelStatusProducerParameters = cms.PSet(
         badPixelFEDChannelCollections = cms.VInputTag(cms.InputTag('siPixelDigis')),
         pixelClusterLabel = cms.untracked.InputTag("siPixelClusters::RECO"),
-        monitorOnDoubleColumn = cms.untracked.bool(False),
         resetEveryNLumi = cms.untracked.int32( 1 )
     )
 )

--- a/CalibTracker/SiPixelQuality/src/SiPixelDetectorStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelDetectorStatus.cc
@@ -139,16 +139,16 @@ void SiPixelDetectorStatus::fillDIGI(int detid, int roc) {
 }
 
 // ----------------------------------------------------------------------
-void SiPixelDetectorStatus::fillStuckTBM(int detid,PixelFEDChannel ch){
+void SiPixelDetectorStatus::fillFEDerror25(int detid,PixelFEDChannel ch){
 
    if (fModules.find(detid) != fModules.end()){
-        fModules[detid].fillStuckTBM(ch);
+        fModules[detid].fillFEDerror25(ch);
    }
 
 }
 
-// stuck TBM effected ROCs in for each module
-std::map<int, std::vector<int>> SiPixelDetectorStatus::getStuckTBMsRocs(){
+// FEDerror25 effected ROCs in for each module
+std::map<int, std::vector<int>> SiPixelDetectorStatus::getFEDerror25Rocs(){
 
     std::map<int, std::vector<int>> badRocLists_;
 
@@ -156,13 +156,13 @@ std::map<int, std::vector<int>> SiPixelDetectorStatus::getStuckTBMsRocs(){
     for (std::map<int, SiPixelModuleStatus>::iterator itMod = begin(); itMod != itModEnd; ++itMod) {
 
          int detid = itMod->first;
-         // stuck TBM effected ROCs in a given module
+         // FEDerror25 effected ROCs in a given module
          std::vector<int> list;
          SiPixelModuleStatus modStatus = itMod->second;
          for (int iroc = 0; iroc < modStatus.nrocs(); ++iroc) {
 
               SiPixelRocStatus* roc = modStatus.getRoc(iroc);
-              if(roc->isStuckTBM()){
+              if(roc->isFEDerror25()){
                  list.push_back(iroc);
               }
               badRocLists_[detid]=list;

--- a/CalibTracker/SiPixelQuality/src/SiPixelDetectorStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelDetectorStatus.cc
@@ -9,15 +9,11 @@
 #include <TH1.h>
 
 #include "CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-using namespace std;
-
 
 // ----------------------------------------------------------------------
-SiPixelDetectorStatus::SiPixelDetectorStatus(): fLS0(99999999), fLS1(0), fRun0(99999999), fRun1(0), fDetHits(0) {
+SiPixelDetectorStatus::SiPixelDetectorStatus(): fLS0(99999999), fLS1(0), fRun0(99999999), fRun1(0) {
 
-  fDetAverage = fDetSigma = 0.;
+  fDetHits = 0;
   fNevents = 0;
 
 }
@@ -31,41 +27,41 @@ SiPixelDetectorStatus::~SiPixelDetectorStatus() {
 // ----------------------------------------------------------------------
 void SiPixelDetectorStatus::readFromFile(std::string filename) {
 
-  ifstream INS;
-  string sline;
+  std::ifstream INS;
+  std::string sline;
   INS.open(filename.c_str());
 
   int oldDetId(-1);
   int detid(0), roc(0), hits(0), nroc(0);
   SiPixelModuleStatus *pMod(nullptr);
   bool readOK(false);
-  while (getline(INS, sline)) {
+  while (std::getline(INS, sline)) {
 
-    if (string::npos != sline.find("# SiPixelDetectorStatus START")) {
+    if (std::string::npos != sline.find("# SiPixelDetectorStatus START")) {
       readOK = true;
       continue;
     }
     if (!readOK) continue;
 
-    if (string::npos != sline.find("# SiPixelDetectorStatus END")) {
+    if (std::string::npos != sline.find("# SiPixelDetectorStatus END")) {
       pMod->setNrocs(nroc+1);
       break;
     }
 
-    if (sline.find("# SiPixelDetectorStatus for LS") != string::npos) {
-      sscanf(sline.c_str(), "# SiPixelDetectorStatus for LS  %d .. %d", &fLS0, &fLS1);
+    if (sline.find("# SiPixelDetectorStatus for LS") != std::string::npos) {
+      std::sscanf(sline.c_str(), "# SiPixelDetectorStatus for LS  %d .. %d", &fLS0, &fLS1);
       continue;
     }
-    if (sline.find("# SiPixelDetectorStatus for run") != string::npos) {
-      sscanf(sline.c_str(), "# SiPixelDetectorStatus for run %d .. %d", &fRun0, &fRun1);
+    if (sline.find("# SiPixelDetectorStatus for run") != std::string::npos) {
+      std::sscanf(sline.c_str(), "# SiPixelDetectorStatus for run %d .. %d", &fRun0, &fRun1);
       continue;
     }
-    if (sline.find("# SiPixelDetectorStatus total hits = ") != string::npos) {
-      sscanf(sline.c_str(), "# SiPixelDetectorStatus total hits = %ld", &fDetHits);
+    if (sline.find("# SiPixelDetectorStatus total hits = ") != std::string::npos) {
+      std::sscanf(sline.c_str(), "# SiPixelDetectorStatus total hits = %ld", &fDetHits);
       continue;
     }
 
-    sscanf(sline.c_str(), "%d %d %d", &detid, &roc, &hits);
+    std::sscanf(sline.c_str(), "%d %d %d", &detid, &roc, &hits);
     if (roc > nroc) nroc = roc;
     if (detid != oldDetId) {
       if (pMod) {
@@ -95,20 +91,20 @@ void SiPixelDetectorStatus::readFromFile(std::string filename) {
 // ----------------------------------------------------------------------
 void SiPixelDetectorStatus::dumpToFile(std::string filename) {
 
-  ofstream OD(filename.c_str());
-  OD << "# SiPixelDetectorStatus START" << endl;
-  OD << "# SiPixelDetectorStatus for LS  " << fLS0 << " .. " << fLS1 << endl;
-  OD << "# SiPixelDetectorStatus for run " << fRun0 << " .. " << fRun1 << endl;
-  OD << "# SiPixelDetectorStatus total hits = " << fDetHits << endl;
-  map<int, SiPixelModuleStatus>::iterator itEnd = end();
-  for (map<int, SiPixelModuleStatus>::iterator it = begin(); it != itEnd; ++it) {
+  std::ofstream OD(filename.c_str());
+  OD << "# SiPixelDetectorStatus START" << std::endl;
+  OD << "# SiPixelDetectorStatus for LS  " << fLS0 << " .. " << fLS1 << std::endl;
+  OD << "# SiPixelDetectorStatus for run " << fRun0 << " .. " << fRun1 << std::endl;
+  OD << "# SiPixelDetectorStatus total hits = " << fDetHits << std::endl;
+
+  for (std::map<int, SiPixelModuleStatus>::iterator it = SiPixelDetectorStatus::begin(); it != SiPixelDetectorStatus::end(); ++it) {
     for (int iroc = 0; iroc < it->second.nrocs(); ++iroc) {
       for (int idc = 0; idc < 26; ++idc) {
-	OD << Form("%10d %2d %3d", it->first, iroc, int(it->second.getRoc(iroc)->digiOccROC())) << endl;
+	OD << Form("%10d %2d %3d", it->first, iroc, int(it->second.getRoc(iroc)->digiOccROC())) << std::endl;
       }
     }
   }
-  OD << "# SiPixelDetectorStatus END" << endl;
+  OD << "# SiPixelDetectorStatus END" << std::endl;
   OD.close();
 
 }
@@ -118,14 +114,14 @@ void SiPixelDetectorStatus::dumpToFile(std::string filename) {
 void SiPixelDetectorStatus::addModule(int detid, int nrocs) {
 
      SiPixelModuleStatus a(detid, nrocs);
-     fModules.insert(make_pair(detid, a));
+     fModules.insert(std::make_pair(detid, a));
 
 }
 
 // ----------------------------------------------------------------------
 void SiPixelDetectorStatus::addModule(int detid, SiPixelModuleStatus a) {
 
-     fModules.insert(make_pair(detid, a));
+     fModules.insert(std::make_pair(detid, a));
 
 }
 
@@ -152,9 +148,8 @@ std::map<int, std::vector<int>> SiPixelDetectorStatus::getFEDerror25Rocs(){
 
     std::map<int, std::vector<int>> badRocLists_;
 
-    std::map<int, SiPixelModuleStatus>::iterator itModEnd = end();
-    for (std::map<int, SiPixelModuleStatus>::iterator itMod = begin(); itMod != itModEnd; ++itMod) {
-
+    for(std::map<int, SiPixelModuleStatus>::iterator itMod = SiPixelDetectorStatus::begin(); itMod != SiPixelDetectorStatus::end(); ++itMod)
+    {
          int detid = itMod->first;
          // FEDerror25 effected ROCs in a given module
          std::vector<int> list;
@@ -219,42 +214,47 @@ bool SiPixelDetectorStatus::findModule(int detid) {
 }
 
 // ----------------------------------------------------------------------
-void SiPixelDetectorStatus::digiOccupancy() {
+double SiPixelDetectorStatus::perRocDigiOcc() {
 
-  fDetAverage = fDetSigma = 0;
-  unsigned long int ave(0), sig(0);
+  unsigned long int ave(0);
   int nrocs(0);
-  map<int, SiPixelModuleStatus>::iterator itEnd = end();
-  for (map<int, SiPixelModuleStatus>::iterator it = begin(); it != itEnd; ++it) {
+  for (std::map<int, SiPixelModuleStatus>::iterator it = SiPixelDetectorStatus::begin(); it != SiPixelDetectorStatus::end(); ++it) {
     unsigned long int inc = it->second.digiOccMOD();
     ave   += inc;
     nrocs += it->second.nrocs();
   }
-  fDetAverage = (1.0*ave)/nrocs;
+  return (1.0*ave)/nrocs;
 
-  for (map<int, SiPixelModuleStatus>::iterator it = begin(); it != itEnd; ++it) {
+}
+
+double SiPixelDetectorStatus::perRocDigiOccVar(){
+
+  double fDetAverage = SiPixelDetectorStatus::perRocDigiOcc();
+
+  double sig = 0.0;
+  int nrocs(0);
+  for(std::map<int, SiPixelModuleStatus>::iterator it = SiPixelDetectorStatus::begin(); it != SiPixelDetectorStatus::end(); ++it) {
     unsigned long int inc = it->second.digiOccMOD();
     sig += (fDetAverage - inc) * (fDetAverage - inc);
+    nrocs += it->second.nrocs();
   }
 
-  fDetSigma   = sig/(nrocs - 1);
-  fDetSigma   = TMath::Sqrt(fDetSigma);
-
+  double fDetSigma   = sig/(nrocs - 1);
+  return TMath::Sqrt(fDetSigma);
 }
 
 // combine status from different data (coming from different run/lumi)
 void SiPixelDetectorStatus::updateDetectorStatus(SiPixelDetectorStatus newData){
 
   // loop over new data status
-  std::map<int, SiPixelModuleStatus>::iterator itEnd = newData.end();
-  for (map<int, SiPixelModuleStatus>::iterator it = newData.begin(); it != itEnd; ++it) {
+  for(std::map<int, SiPixelModuleStatus>::iterator it = newData.begin(); it != newData.end(); ++it) {
        
        int detid = it->first;
        if(fModules.find(detid) != fModules.end()){// if the detid is in the module lists
           fModules[detid].updateModuleStatus( *(newData.getModule(detid)) );
        }
        else{
-          fModules.insert(make_pair(detid, *(newData.getModule(detid))));
+          fModules.insert(std::make_pair(detid, *(newData.getModule(detid))));
        }
 
   }

--- a/CalibTracker/SiPixelQuality/src/SiPixelModuleStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelModuleStatus.cc
@@ -44,12 +44,12 @@ void SiPixelModuleStatus::updateDIGI(int iroc, unsigned int nhit) {
 }
 
 // ----------------------------------------------------------------------
-void SiPixelModuleStatus::fillStuckTBM( PixelFEDChannel ch){
+void SiPixelModuleStatus::fillFEDerror25( PixelFEDChannel ch){
 
      int roc_first = int(ch.roc_first); int roc_last = int(ch.roc_last);
      for (int iroc = 0; iroc < fNrocs; iroc++){
           if(iroc>=roc_first && iroc<=roc_last){
-             fRocs[iroc].fillStuckTBM();
+             fRocs[iroc].fillFEDerror25();
           }
      }
 
@@ -160,10 +160,10 @@ void SiPixelModuleStatus::updateModuleStatus(SiPixelModuleStatus newData) {
         for (int iroc = 0; iroc < fNrocs; ++iroc) {
              //update occupancy
              fRocs[iroc].updateDIGI(newData.digiOccROC(iroc));
-             //update stuckTBM
+             //update FEDerror25
              SiPixelRocStatus* rocStatus = newData.getRoc(iroc);
-             if(rocStatus->isStuckTBM()){
-                 fRocs[iroc].fillStuckTBM();
+             if(rocStatus->isFEDerror25()){
+                 fRocs[iroc].fillFEDerror25();
              }
         }
         

--- a/CalibTracker/SiPixelQuality/src/SiPixelModuleStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelModuleStatus.cc
@@ -28,62 +28,50 @@ SiPixelModuleStatus::~SiPixelModuleStatus() {};
 
 
 // ----------------------------------------------------------------------
-void SiPixelModuleStatus::fillDIGI(int iroc, int idc) {
+void SiPixelModuleStatus::fillDIGI(int iroc) {
 
   if (iroc < fNrocs) 
-     fRocs[iroc].fillDIGI(idc);
+     fRocs[iroc].fillDIGI();
 
 }
 
 // ----------------------------------------------------------------------
-void SiPixelModuleStatus::updateDIGI(int iroc, int idc, unsigned long int nhit) {
+void SiPixelModuleStatus::updateDIGI(int iroc, unsigned int nhit) {
 
   if (iroc < fNrocs) 
-     fRocs[iroc].updateDIGI(idc, nhit);
+     fRocs[iroc].updateDIGI(nhit);
 
 }
 
 // ----------------------------------------------------------------------
-void SiPixelModuleStatus::fillStuckTBM( PixelFEDChannel ch, std::time_t time ){
+void SiPixelModuleStatus::fillStuckTBM( PixelFEDChannel ch){
 
-     int fed = int(ch.fed);
-     int link = int(ch.link);
      int roc_first = int(ch.roc_first); int roc_last = int(ch.roc_last);
      for (int iroc = 0; iroc < fNrocs; iroc++){
           if(iroc>=roc_first && iroc<=roc_last){
-             fRocs[iroc].fillStuckTBM(fed,link,time);
+             fRocs[iroc].fillStuckTBM();
           }
      }
 
 }
 
 // ----------------------------------------------------------------------
-unsigned long int SiPixelModuleStatus::digiOccDC(int iroc, int idc) {
-
-  return (iroc < fNrocs ? fRocs[iroc].digiOccDC(idc) : -1);
-
-}
-
-
-// ----------------------------------------------------------------------
-unsigned long int SiPixelModuleStatus::digiOccROC(int iroc) {
+unsigned int SiPixelModuleStatus::digiOccROC(int iroc) {
 
   return (iroc < fNrocs ? fRocs[iroc].digiOccROC() : -1);
 
 }
 
-
 // ----------------------------------------------------------------------
-unsigned long int SiPixelModuleStatus::digiOccMOD() {
+unsigned int SiPixelModuleStatus::digiOccMOD() {
 
-  unsigned long int count(0);
+  unsigned int count(0);
   for (int iroc = 0; iroc < fNrocs; ++iroc) {
     count += digiOccROC(iroc);
   }
   return count;
 
 }
-
 
 // ----------------------------------------------------------------------
 int SiPixelModuleStatus::detid() {
@@ -92,22 +80,27 @@ int SiPixelModuleStatus::detid() {
 
 }
 
-
 // ----------------------------------------------------------------------
 int SiPixelModuleStatus::nrocs() {
+
   return fNrocs;
+
 }
 
 // ----------------------------------------------------------------------
 void SiPixelModuleStatus::setNrocs(int iroc) {
+
   fNrocs = iroc;
+
 }
 
 
 // ----------------------------------------------------------------------
 double SiPixelModuleStatus::perRocDigiOcc() {
+
   digiOccupancy();
   return fModAverage;
+
 }
 
 
@@ -116,21 +109,22 @@ double SiPixelModuleStatus::perRocDigiOccVar() {
 
   digiOccupancy();
   return fModSigma;
+
 }
 
 // ----------------------------------------------------------------------
 void SiPixelModuleStatus::digiOccupancy() {
 
   fModAverage = fModSigma = 0.;
-  unsigned long int ave(0.), sig(0.);
+  unsigned int ave(0), sig(0);
   for (int iroc = 0; iroc < fNrocs; ++iroc) {
-    unsigned long int inc = digiOccROC(iroc);
+    unsigned int inc = digiOccROC(iroc);
     ave += inc;
   }
   fModAverage = (1.0*ave)/fNrocs;
 
   for (int iroc = 0; iroc < fNrocs; ++iroc) {
-    unsigned long int inc = digiOccROC(iroc);
+    unsigned int inc = digiOccROC(iroc);
     sig += (fModAverage-inc)*(fModAverage-inc);
   }
 
@@ -139,16 +133,19 @@ void SiPixelModuleStatus::digiOccupancy() {
 
 }
 
-
 // ----------------------------------------------------------------------
 // Be careful : return the address not the value of ROC status
 SiPixelRocStatus* SiPixelModuleStatus::getRoc(int i) {
+
   return &fRocs[i];
+
 }
 
 // ----------------------------------------------------------------------
-void SiPixelModuleStatus::updateModuleDIGI(int iroc, int idc, unsigned long int nhits) {
-     fRocs[iroc].updateDIGI(idc,nhits);
+void SiPixelModuleStatus::updateModuleDIGI(int iroc, unsigned int nhits) {
+
+     fRocs[iroc].updateDIGI(nhits);
+
 }
 
 void SiPixelModuleStatus::updateModuleStatus(SiPixelModuleStatus newData) {
@@ -161,15 +158,12 @@ void SiPixelModuleStatus::updateModuleStatus(SiPixelModuleStatus newData) {
      if(isSameModule){
 
         for (int iroc = 0; iroc < fNrocs; ++iroc) {
-             int nDC = fRocs[iroc].nDC();
              //update occupancy
-             for(int idc = 0; idc < nDC; ++idc) {
-                 fRocs[iroc].updateDIGI(idc,newData.digiOccDC(iroc,idc));
-             }
+             fRocs[iroc].updateDIGI(newData.digiOccROC(iroc));
              //update stuckTBM
              SiPixelRocStatus* rocStatus = newData.getRoc(iroc);
              if(rocStatus->isStuckTBM()){
-                 fRocs[iroc].updateStuckTBM(rocStatus->getBadFed(), rocStatus->getBadLink(),rocStatus->getStartBadTime(), rocStatus->getBadFreq());
+                 fRocs[iroc].fillStuckTBM();
              }
         }
         

--- a/CalibTracker/SiPixelQuality/src/SiPixelModuleStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelModuleStatus.cc
@@ -8,8 +8,6 @@
 
 #include "CalibTracker/SiPixelQuality/interface/SiPixelModuleStatus.h"
 
-using namespace std;
-
 // ----------------------------------------------------------------------
 SiPixelModuleStatus::SiPixelModuleStatus(int detId, int nrocs): fDetid(detId), fNrocs(nrocs) {
 
@@ -17,8 +15,6 @@ SiPixelModuleStatus::SiPixelModuleStatus(int detId, int nrocs): fDetid(detId), f
     SiPixelRocStatus a;
     fRocs.push_back(a);
   }
-
-  fModAverage = fModSigma = 0.;
 
 };
 
@@ -94,42 +90,30 @@ void SiPixelModuleStatus::setNrocs(int iroc) {
 
 }
 
-
 // ----------------------------------------------------------------------
 double SiPixelModuleStatus::perRocDigiOcc() {
 
-  digiOccupancy();
-  return fModAverage;
-
-}
-
-
-// ----------------------------------------------------------------------
-double SiPixelModuleStatus::perRocDigiOccVar() {
-
-  digiOccupancy();
-  return fModSigma;
-
-}
-
-// ----------------------------------------------------------------------
-void SiPixelModuleStatus::digiOccupancy() {
-
-  fModAverage = fModSigma = 0.;
   unsigned int ave(0), sig(0);
   for (int iroc = 0; iroc < fNrocs; ++iroc) {
     unsigned int inc = digiOccROC(iroc);
     ave += inc;
   }
-  fModAverage = (1.0*ave)/fNrocs;
+  return (1.0*ave)/fNrocs;
 
+}
+
+double SiPixelModuleStatus::perRocDigiOccVar() {
+
+  double fModAverage = SiPixelModuleStatus::perRocDigiOcc();
+
+  double sig = 1.0;
   for (int iroc = 0; iroc < fNrocs; ++iroc) {
     unsigned int inc = digiOccROC(iroc);
     sig += (fModAverage-inc)*(fModAverage-inc);
   }
 
-  fModSigma   = sig/(fNrocs-1);
-  fModSigma   = TMath::Sqrt(fModSigma);
+  double fModSigma   = sig/(fNrocs-1);
+  return TMath::Sqrt(fModSigma);
 
 }
 

--- a/CalibTracker/SiPixelQuality/src/SiPixelRocStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelRocStatus.cc
@@ -9,15 +9,8 @@ using namespace std;
 
 // ----------------------------------------------------------------------
 SiPixelRocStatus::SiPixelRocStatus() {
-
-  for (int i = 0; i < nDC_; ++i) {
-       fDC[i] = 0;
-  }
+  fDC = 0;
   isStuckTBM_ = false;
-  badFed_ = -1;
-  badLink_ = -1;
-  startBadTime_ = -1;
-  badFreq_ = 0;
 }
 
 
@@ -27,54 +20,29 @@ SiPixelRocStatus::~SiPixelRocStatus() {
 }
 
 // ----------------------------------------------------------------------
-void SiPixelRocStatus::fillDIGI(int idc) {
+void SiPixelRocStatus::fillDIGI() {
 
-  if (idc<nDC_) fDC[idc]++;
-
-}
-
-// ----------------------------------------------------------------------
-void SiPixelRocStatus::updateDIGI(int idc, unsigned long int hits) {
-
-  if (idc<nDC_) fDC[idc] += hits;
+  fDC++;
 
 }
 
 // ----------------------------------------------------------------------
-void SiPixelRocStatus::fillStuckTBM(unsigned int fed, unsigned int link, std::time_t time){
+void SiPixelRocStatus::updateDIGI(unsigned int hits) {
+
+  fDC += hits;
+
+}
+
+// ----------------------------------------------------------------------
+void SiPixelRocStatus::fillStuckTBM(){
 
      isStuckTBM_ = true;
-     if(badFreq_==0){
-        startBadTime_ = time;
-     }
-     badFed_ = fed; badLink_ = link;
-     badFreq_ = badFreq_ + 1;
-}
-
-void SiPixelRocStatus::updateStuckTBM(unsigned int fed, unsigned int link, std::time_t time, unsigned long int freq){
-
-     isStuckTBM_ = true;
-     if(badFreq_==0){
-        startBadTime_ = time;
-     }
-     badFed_ = fed; badLink_ = link;
-     badFreq_ = badFreq_ + freq;
-}
-
-// ----------------------------------------------------------------------
-unsigned long int SiPixelRocStatus::digiOccDC(int idc) {
-
-  return (idc<nDC_?fDC[idc]:-1);
 
 }
 
 // ----------------------------------------------------------------------
-unsigned long int SiPixelRocStatus::digiOccROC() {
+unsigned int SiPixelRocStatus::digiOccROC() {
 
-  unsigned long int count(0) ;
-  for (int idc = 0; idc < nDC_; ++idc) {
-    count += fDC[idc];
-  }
-  return count;
+  return fDC;
+
 }
-

--- a/CalibTracker/SiPixelQuality/src/SiPixelRocStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelRocStatus.cc
@@ -10,7 +10,7 @@ using namespace std;
 // ----------------------------------------------------------------------
 SiPixelRocStatus::SiPixelRocStatus() {
   fDC = 0;
-  isStuckTBM_ = false;
+  isFEDerror25_ = false;
 }
 
 
@@ -34,9 +34,9 @@ void SiPixelRocStatus::updateDIGI(unsigned int hits) {
 }
 
 // ----------------------------------------------------------------------
-void SiPixelRocStatus::fillStuckTBM(){
+void SiPixelRocStatus::fillFEDerror25(){
 
-     isStuckTBM_ = true;
+     isFEDerror25_ = true;
 
 }
 

--- a/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
@@ -248,15 +248,16 @@ void SiPixelStatusManager::createStuckTBMs(){
             // if the badroc list differs for any detid, update the payload
             if(tmpBadRocLists[detid]!=(stuckTBMsMap_[previousLumi])[detid]){
                sameAsLastIOV = false;
-               return;
+               break; // jump out of the loop once a new payload is found
             }       
         }
 
         if(sameAsLastIOV==false){
             //only write new IOV when this Lumi is not equal to the previous one
-
             stuckTBMsMap_[tmpLumi] = tmpBadRocLists; 
+            // and reset
             previousLumi = tmpLumi;
+            sameAsLastIOV = true;
 
         }
 

--- a/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
@@ -221,13 +221,13 @@ void SiPixelStatusManager::createBadComponents(){
 }
 
 
-void SiPixelStatusManager::createStuckTBMs(){
+void SiPixelStatusManager::createFEDerror25(){
 
     // initialize the first IOV and SiPixelDetector status (in the first IOV)
     siPixelStatusMap_iterator firstStatus = siPixelStatusMap_.begin();
     LuminosityBlockNumber_t   firstLumi = firstStatus->first;
-    SiPixelDetectorStatus     firstStuckTBMs = firstStatus->second;
-    stuckTBMsMap_[firstLumi] = firstStuckTBMs.getStuckTBMsRocs();   
+    SiPixelDetectorStatus     firstFEDerror25 = firstStatus->second;
+    FEDerror25Map_[firstLumi] = firstFEDerror25.getFEDerror25Rocs();   
 
     siPixelStatusMap_iterator lastStatus     = siPixelStatusMap_.end();
 
@@ -238,15 +238,15 @@ void SiPixelStatusManager::createStuckTBMs(){
     for (siPixelStatusMap_iterator it = secondStatus; it != lastStatus; it++) {
        
         LuminosityBlockNumber_t tmpLumi = it->first;
-        SiPixelDetectorStatus tmpStuckTBMs = it->second;
-        std::map<int,std::vector<int> >tmpBadRocLists = tmpStuckTBMs.getStuckTBMsRocs();
+        SiPixelDetectorStatus tmpFEDerror25 = it->second;
+        std::map<int,std::vector<int> >tmpBadRocLists = tmpFEDerror25.getFEDerror25Rocs();
 
-        std::map<int, SiPixelModuleStatus>::iterator itModEnd = tmpStuckTBMs.end();
-        for (std::map<int, SiPixelModuleStatus>::iterator itMod = tmpStuckTBMs.begin(); itMod != itModEnd; ++itMod) 
+        std::map<int, SiPixelModuleStatus>::iterator itModEnd = tmpFEDerror25.end();
+        for (std::map<int, SiPixelModuleStatus>::iterator itMod = tmpFEDerror25.begin(); itMod != itModEnd; ++itMod) 
         {
             int detid = itMod->first;
             // if the badroc list differs for any detid, update the payload
-            if(tmpBadRocLists[detid]!=(stuckTBMsMap_[previousLumi])[detid]){
+            if(tmpBadRocLists[detid]!=(FEDerror25Map_[previousLumi])[detid]){
                sameAsLastIOV = false;
                break; // jump out of the loop once a new payload is found
             }       
@@ -254,7 +254,7 @@ void SiPixelStatusManager::createStuckTBMs(){
 
         if(sameAsLastIOV==false){
             //only write new IOV when this Lumi is not equal to the previous one
-            stuckTBMsMap_[tmpLumi] = tmpBadRocLists; 
+            FEDerror25Map_[tmpLumi] = tmpBadRocLists; 
             // and reset
             previousLumi = tmpLumi;
             sameAsLastIOV = true;

--- a/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
@@ -46,6 +46,24 @@ SiPixelStatusManager::~SiPixelStatusManager(){
 //--------------------------------------------------------------------------------------------------
 void SiPixelStatusManager::reset(){
      siPixelStatusMap_.clear();
+     siPixelStatusVtr_.clear();
+}
+
+//--------------------------------------------------------------------------------------------------
+bool SiPixelStatusManager::rankByLumi(SiPixelDetectorStatus status1,SiPixelDetectorStatus status2) 
+{ return (status1.getLSRange().first < status2.getLSRange().first); }
+
+
+void SiPixelStatusManager::createPayloads(){
+   // sort the vector according to lumi
+   std::sort(siPixelStatusVtr_.begin(), siPixelStatusVtr_.end(), SiPixelStatusManager::rankByLumi);
+   
+   // create FEDerror25 ROCs and bad ROCs from PCL
+   SiPixelStatusManager::createFEDerror25();
+   SiPixelStatusManager::createBadComponents();
+     
+   // realse the cost of siPixelStatusVtr_ since it is not needed anymore
+   siPixelStatusVtr_.clear();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -55,26 +73,25 @@ void SiPixelStatusManager::readLumi(const LuminosityBlock& iLumi){
   iLumi.getByToken(siPixelStatusToken_, siPixelStatusHandle);
 
   if(siPixelStatusHandle.isValid()) { // check the product
-    siPixelStatusMap_[iLumi.luminosityBlock()] = *siPixelStatusHandle;
+    SiPixelDetectorStatus tmpStatus = (*siPixelStatusHandle);
+    if(tmpStatus.digiOccDET()>0){ // only put in SiPixelDetectorStatus with non zero digi (pixel hit)
+      siPixelStatusVtr_.push_back(tmpStatus);
+    }
   }
   else {
-    LogInfo("SiPixelStatusManager")
-        << "Lumi: " << iLumi.luminosityBlock() << std::endl;
-    LogInfo("SiPixelStatusManager")
-        << " SiPixelDetectorStatus is not valid!" << std::endl;
+       edm::LogWarning("SiPixelStatusManager")
+        << " SiPixelDetectorStatus is not valid for run "<<iLumi.run()<<" lumi "<<iLumi.luminosityBlock()<< std::endl;
   }
 
 }
 
-
-
 //--------------------------------------------------------------------------------------------------
 void SiPixelStatusManager::createBadComponents(){
 
-  siPixelStatusMap_iterator firstStatus    = siPixelStatusMap_.begin();
-  siPixelStatusMap_iterator lastStatus     = siPixelStatusMap_.end();
+  siPixelStatusVtr_iterator firstStatus    = siPixelStatusVtr_.begin();
+  siPixelStatusVtr_iterator lastStatus     = siPixelStatusVtr_.end();
 
-  std::map<LuminosityBlockNumber_t,SiPixelDetectorStatus> tmpSiPixelStatusMap_;
+  siPixelStatusMap_.clear();
 
   if(outputBase_ == "nLumibased" && nLumi_>1){ // doesn't work for nLumi_=1 cos any integer can be completely divided by 1
 
@@ -84,41 +101,42 @@ void SiPixelStatusManager::createBadComponents(){
 
     LuminosityBlockNumber_t tmpLumi;
     SiPixelDetectorStatus tmpSiPixelStatus;
-    for (siPixelStatusMap_iterator it = firstStatus; it != lastStatus; it++) {
-  
+    for (siPixelStatusVtr_iterator it = firstStatus; it != lastStatus; it++) {
+
         // this is the begining of an IOV
         if(iterationLumi%nLumi_==0){
-           tmpLumi = it->first;
-           tmpSiPixelStatus = it->second; 
+           tmpLumi = edm::LuminosityBlockNumber_t(it->getLSRange().first);
+           tmpSiPixelStatus = (*it); 
 	}
 
         // keep update detector status up to nLumi_ lumi sections
         if(iterationLumi%nLumi_>0){
-          tmpSiPixelStatus.updateDetectorStatus(it->second);
+          tmpSiPixelStatus.updateDetectorStatus((*it));
+          tmpSiPixelStatus.setLSRange(int(tmpLumi), (*it).getLSRange().second);
         }
 
-        siPixelStatusMap_iterator currentIt = it;
-        siPixelStatusMap_iterator nextIt = (++currentIt);
+        siPixelStatusVtr_iterator currentIt = it;
+        siPixelStatusVtr_iterator nextIt = (++currentIt);
         // wirte out if current lumi is the last lumi-section in the IOV
         if(iterationLumi%nLumi_==nLumi_-1 || nextIt==lastStatus) 
         {
              // fill it into a new map (with IOV structured)
-             tmpSiPixelStatusMap_[tmpLumi] = tmpSiPixelStatus;
+             siPixelStatusMap_[tmpLumi] = tmpSiPixelStatus;
         }
 
         iterationLumi=iterationLumi+1;
     }
 
     // check whether there is not enough number of Lumi in the last IOV
-    // (only when siPixelStatusMap_.size() > nLumi_ or equivalently tmpSiPixelStatusMap_.size()>1
+    // (only when siPixelStatusVtr_.size() > nLumi_ or equivalently current siPixelStatusMap_.size()>1
     //            (otherwise there will be only one IOV, and not previous IOV before the last IOV)
     //            and the number of lumi can not be completely divided by the nLumi_.
     //                (then the number of lumis in the last IOV is equal to the residual, which is less than nLumi_)
     // if it is, combine last IOV with the IOV before it
-    if(siPixelStatusMap_.size()%nLumi_!=0 && tmpSiPixelStatusMap_.size()>1){
+    if(siPixelStatusVtr_.size()%nLumi_!=0 && siPixelStatusMap_.size()>1){
 
        // start from the iterator of the end of std::map
-       siPixelStatusMap_iterator iterEnd = tmpSiPixelStatusMap_.end();
+       siPixelStatusMap_iterator iterEnd = siPixelStatusMap_.end();
        // the last IOV
        siPixelStatusMap_iterator iterLastIOV = std::prev(iterEnd);
        // the IOV before the last IOV
@@ -126,43 +144,43 @@ void SiPixelStatusManager::createBadComponents(){
 
        // combine the last IOV data to the IOV before the last IOV
        (iterBeforeLastIOV->second).updateDetectorStatus(iterLastIOV->second);
+       (iterBeforeLastIOV->second).setLSRange((iterBeforeLastIOV->second).getLSRange().first, (iterLastIOV->second).getLSRange().second);
+
        // delete the last IOV, so the IOV before the last IOV becomes the new last IOV
-       tmpSiPixelStatusMap_.erase(iterLastIOV);
+       siPixelStatusMap_.erase(iterLastIOV);
 
     }
-
-    siPixelStatusMap_.clear();
-    siPixelStatusMap_ = tmpSiPixelStatusMap_;
 
   }
   else if(outputBase_ == "dynamicLumibased"){
 
     double aveDigiOcc = 1.0*aveDigiOcc_;
   
-    LuminosityBlockNumber_t tmpLumi;
+    edm::LuminosityBlockNumber_t tmpLumi;
     SiPixelDetectorStatus tmpSiPixelStatus;
     bool isNewIOV = true;
 
     int counter = 0;
-    for (siPixelStatusMap_iterator it = firstStatus; it != lastStatus; it++) {
+    for (siPixelStatusVtr_iterator it = firstStatus; it != lastStatus; it++) {
 
          if(isNewIOV){ // if it is new IOV, init with the current data
-               tmpLumi = it->first;
-               tmpSiPixelStatus = it->second;
+               tmpLumi = edm::LuminosityBlockNumber_t(it->getLSRange().first);
+               tmpSiPixelStatus = (*it);
          }
          else{ // if it is not new IOV, append current data
-               tmpSiPixelStatus.updateDetectorStatus(it->second);
+               tmpSiPixelStatus.updateDetectorStatus((*it));
+               tmpSiPixelStatus.setLSRange(int(tmpLumi),(*it).getLSRange().second);
          }
 
          // if reaching the end of data, write the last IOV to the map whatsoevec
-         siPixelStatusMap_iterator currentIt = it;
-         siPixelStatusMap_iterator nextIt = (++currentIt);
+         siPixelStatusVtr_iterator currentIt = it;
+         siPixelStatusVtr_iterator nextIt = (++currentIt);
          if(tmpSiPixelStatus.perRocDigiOcc()<aveDigiOcc && nextIt!=lastStatus){
             isNewIOV = false; // if digi occ is not enough, next data will not belong to new IOV
          }
          else{ // if (accunumated) digi occ is enough, write the data to the map
            isNewIOV = true;
-           tmpSiPixelStatusMap_[tmpLumi]=tmpSiPixelStatus;
+           siPixelStatusMap_[tmpLumi]=tmpSiPixelStatus;
            // so next loop is the begining of a new IOV
          }
          counter++;
@@ -172,10 +190,10 @@ void SiPixelStatusManager::createBadComponents(){
    // check whether last IOV has enough statistics
    // (ONLY when there are more than oneIOV(otherwise there is NO previous IOV before the last IOV) )
    // if not, combine with previous IOV
-   if(tmpSiPixelStatusMap_.size()>1){
+   if(siPixelStatusMap_.size()>1){
 
       // start from the end iterator of the std::map
-      siPixelStatusMap_iterator iterEnd = tmpSiPixelStatusMap_.end();
+      siPixelStatusMap_iterator iterEnd = siPixelStatusMap_.end();
       // the last IOV
       siPixelStatusMap_iterator iterLastIOV = std::prev(iterEnd);
       // if the statistics of the last IOV is not enough
@@ -184,30 +202,25 @@ void SiPixelStatusManager::createBadComponents(){
          siPixelStatusMap_iterator iterBeforeLastIOV = std::prev(iterLastIOV);
          // combine the last IOV data to the IOV before the last IOV
          (iterBeforeLastIOV->second).updateDetectorStatus(iterLastIOV->second);
+         (iterBeforeLastIOV->second).setLSRange((iterBeforeLastIOV->second).getLSRange().first, (iterLastIOV->second).getLSRange().second);
          // erase the last IOV, so the IOV before the last IOV becomes the new last IOV
-         tmpSiPixelStatusMap_.erase(iterLastIOV);
+         siPixelStatusMap_.erase(iterLastIOV);
       }
  
    }
 
-   siPixelStatusMap_.clear();
-   siPixelStatusMap_ = tmpSiPixelStatusMap_;
-
   }
-  else if(outputBase_ == "runbased" || ( (int(siPixelStatusMap_.size()) <= nLumi_ && outputBase_ == "nLumibased")) ){
+  else if(outputBase_ == "runbased" || ( (int(siPixelStatusVtr_.size()) <= nLumi_ && outputBase_ == "nLumibased")) ){
 
-    siPixelStatusMap_iterator firstStatus    = siPixelStatusMap_.begin();
-    siPixelStatusMap_iterator lastStatus     = siPixelStatusMap_.end();
+    edm::LuminosityBlockNumber_t tmpLumi = edm::LuminosityBlockNumber_t(firstStatus->getLSRange().first);
+    SiPixelDetectorStatus tmpSiPixelStatus = (*firstStatus);
 
-    LuminosityBlockNumber_t tmpLumi = firstStatus->first;
-    SiPixelDetectorStatus tmpSiPixelStatus = firstStatus->second;
-
-    siPixelStatusMap_iterator nextStatus = ++siPixelStatusMap_.begin();
-    for (siPixelStatusMap_iterator it = nextStatus; it != lastStatus; it++) {
-          tmpSiPixelStatus.updateDetectorStatus(it->second);
+    siPixelStatusVtr_iterator nextStatus = ++siPixelStatusVtr_.begin();
+    for (siPixelStatusVtr_iterator it = nextStatus; it != lastStatus; it++) {
+          tmpSiPixelStatus.updateDetectorStatus((*it));
+          tmpSiPixelStatus.setLSRange(int(tmpLumi),(*it).getLSRange().second); 
     }
 
-    siPixelStatusMap_.clear();
     siPixelStatusMap_[tmpLumi] = tmpSiPixelStatus;
 
   }
@@ -224,21 +237,23 @@ void SiPixelStatusManager::createBadComponents(){
 void SiPixelStatusManager::createFEDerror25(){
 
     // initialize the first IOV and SiPixelDetector status (in the first IOV)
-    siPixelStatusMap_iterator firstStatus = siPixelStatusMap_.begin();
-    LuminosityBlockNumber_t   firstLumi = firstStatus->first;
-    SiPixelDetectorStatus     firstFEDerror25 = firstStatus->second;
+    siPixelStatusVtr_iterator firstStatus = siPixelStatusVtr_.begin();
+    edm::LuminosityBlockNumber_t  firstLumi = edm::LuminosityBlockNumber_t(firstStatus->getLSRange().first);
+    SiPixelDetectorStatus  firstFEDerror25 = (*firstStatus);
     FEDerror25Map_[firstLumi] = firstFEDerror25.getFEDerror25Rocs();   
 
-    siPixelStatusMap_iterator lastStatus     = siPixelStatusMap_.end();
+    siPixelStatusVtr_iterator lastStatus = siPixelStatusVtr_.end();
 
     ///////////
     bool sameAsLastIOV = true;
-    LuminosityBlockNumber_t previousLumi = firstLumi;
-    siPixelStatusMap_iterator secondStatus = ++siPixelStatusMap_.begin();
-    for (siPixelStatusMap_iterator it = secondStatus; it != lastStatus; it++) {
-       
-        LuminosityBlockNumber_t tmpLumi = it->first;
-        SiPixelDetectorStatus tmpFEDerror25 = it->second;
+    edm::LuminosityBlockNumber_t previousLumi = firstLumi;
+
+    siPixelStatusVtr_iterator secondStatus = ++siPixelStatusVtr_.begin();
+    for (siPixelStatusVtr_iterator it = secondStatus; it != lastStatus; it++) {
+        // init for each lumi section (iterator)
+        edm::LuminosityBlockNumber_t tmpLumi = edm::LuminosityBlockNumber_t(it->getLSRange().first);
+        SiPixelDetectorStatus tmpFEDerror25 = (*it);
+
         std::map<int,std::vector<int> >tmpBadRocLists = tmpFEDerror25.getFEDerror25Rocs();
 
         std::map<int, SiPixelModuleStatus>::iterator itModEnd = tmpFEDerror25.end();

--- a/CalibTracker/SiPixelQuality/src/classes_def.xml
+++ b/CalibTracker/SiPixelQuality/src/classes_def.xml
@@ -1,6 +1,6 @@
 <lcgdict>
-   <class name="SiPixelRocStatus" ClassVersion="7">
-    <version ClassVersion="7" checksum="4239451"/>
+   <class name="SiPixelRocStatus" ClassVersion="8">
+    <version ClassVersion="8" checksum="4171659340"/>
    </class>
    <class name="std::vector<SiPixelRocStatus>"/>
    <class name="SiPixelModuleStatus" ClassVersion="6">

--- a/CalibTracker/SiPixelQuality/src/classes_def.xml
+++ b/CalibTracker/SiPixelQuality/src/classes_def.xml
@@ -1,6 +1,6 @@
 <lcgdict>
-   <class name="SiPixelRocStatus" ClassVersion="6">
-    <version ClassVersion="6" checksum="507006949"/>
+   <class name="SiPixelRocStatus" ClassVersion="7">
+    <version ClassVersion="7" checksum="4239451"/>
    </class>
    <class name="std::vector<SiPixelRocStatus>"/>
    <class name="SiPixelModuleStatus" ClassVersion="6">
@@ -8,8 +8,8 @@
    </class>
    <class name="std::pair<int, SiPixelModuleStatus>"/>
    <class name="std::map<int, SiPixelModuleStatus>"/>
-   <class name="SiPixelDetectorStatus" ClassVersion="7">
-    <version ClassVersion="7" checksum="2530897911"/>
+   <class name="SiPixelDetectorStatus" ClassVersion="8">
+    <version ClassVersion="8" checksum="4205231572"/>
    </class>
    <class name="edm::Wrapper<SiPixelDetectorStatus>"/>
 </lcgdict>

--- a/CalibTracker/SiPixelQuality/src/classes_def.xml
+++ b/CalibTracker/SiPixelQuality/src/classes_def.xml
@@ -3,13 +3,13 @@
     <version ClassVersion="8" checksum="4171659340"/>
    </class>
    <class name="std::vector<SiPixelRocStatus>"/>
-   <class name="SiPixelModuleStatus" ClassVersion="6">
-    <version ClassVersion="6" checksum="1775077559"/>
+   <class name="SiPixelModuleStatus" ClassVersion="7">
+    <version ClassVersion="7" checksum="4251883507"/>
    </class>
    <class name="std::pair<int, SiPixelModuleStatus>"/>
    <class name="std::map<int, SiPixelModuleStatus>"/>
-   <class name="SiPixelDetectorStatus" ClassVersion="8">
-    <version ClassVersion="8" checksum="4205231572"/>
+   <class name="SiPixelDetectorStatus" ClassVersion="9">
+    <version ClassVersion="9" checksum="525778380"/>
    </class>
    <class name="edm::Wrapper<SiPixelDetectorStatus>"/>
 </lcgdict>

--- a/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
+++ b/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
@@ -165,6 +165,14 @@ ALCAHARVESTSiPixelQuality_dbOutput = cms.VPSet(cms.PSet(record = cms.string('SiP
                                                         )
                                                )
 
+if ALCAHARVESTSiPixelQuality.debug == cms.untracked.bool(True) :
+   ALCAHARVESTSiPixelQuality_dbOutput.append(
+       cms.PSet(record = cms.string('SiPixelQualityFromDbRcd_PCL'),
+                tag = cms.string('SiPixelQualityFromDbRcd_PCL'),
+                timetype = cms.untracked.string('lumiid')
+                )
+   )
+
 # define all the paths
 BeamSpotByRun  = cms.Path(ALCAHARVESTBeamSpotByRun)
 BeamSpotByLumi = cms.Path(ALCAHARVESTBeamSpotByLumi)


### PR DESCRIPTION
The PR is to bug fix and mitigate the memory cost of the SiPixelQuality PCL.

The members of SiPixeDetectorStatus that are not needed to determine the pixel quality is reduced so the memory cost can be mitigated in the harvester;
change the "stuckTBM" in the SiPixeDetectorStatus ot "FEDerror25" to avoid confusing;
fix the bug that no new payload of stuckTBM will be appended;
split the payloads generated by PCL for pixel digi occupancy analysis accordingly when the stuckTBM payload varies in the original IOV generated by PCL.