### PR TITLE
CTPPS: updated DQM for 2018 data taking (10_1_X)

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -215,7 +215,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 // Values for all constants
 const double    CTPPSDiamondDQMSource::SEC_PER_LUMI_SECTION = 23.31;
 const int       CTPPSDiamondDQMSource::CHANNEL_OF_VFAT_CLOCK = 30;
-const double    CTPPSDiamondDQMSource::DISPLAY_RESOLUTION_FOR_HITS_MM = 0.01;
+const double    CTPPSDiamondDQMSource::DISPLAY_RESOLUTION_FOR_HITS_MM = 0.1;
 const double    CTPPSDiamondDQMSource::INV_DISPLAY_RESOLUTION_FOR_HITS_MM = 1./DISPLAY_RESOLUTION_FOR_HITS_MM;
 const double    CTPPSDiamondDQMSource::HPTDC_BIN_WIDTH_NS = 25./1024;
 const int       CTPPSDiamondDQMSource::CTPPS_NUM_OF_ARMS = 2;
@@ -834,8 +834,8 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         if ( pixId.station() != CTPPS_PIXEL_STATION_ID || pixId.rp() != CTPPS_FAR_RP_ID ) continue;
         for ( const auto& lt : ds ) {
           if ( lt.isValid() && pixId.arm() == detId_pot.arm() ) {
-            if ( rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.getOOTIndex() - centralOOT_ + 1 < (int) potPlots_[detId_pot].pixelTomographyAll.size() && rechit.getOOTIndex() - centralOOT_ + 1  >= 0 )
-              potPlots_[detId_pot].pixelTomographyAll.at( rechit.getOOTIndex() - centralOOT_ + 1  )->Fill( lt.getX0() - horizontalShiftBwDiamondPixels_ + 25*detId.plane(), lt.getY0() );
+            if ( rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.getOOTIndex() - centralOOT_ < (int) potPlots_[detId_pot].pixelTomographyAll.size() && rechit.getOOTIndex() - centralOOT_  >= 0 )
+              potPlots_[detId_pot].pixelTomographyAll.at( rechit.getOOTIndex() - centralOOT_  )->Fill( lt.getX0() - horizontalShiftBwDiamondPixels_ + 25*detId.plane(), lt.getY0() );
           }
         }
       }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -415,14 +415,9 @@ CTPPSDiamondDQMSource::dqmBeginRun( const edm::Run& iRun, const edm::EventSetup&
   
   // Rough alignement of pixel detector for diamond thomography
   const CTPPSPixelDetId pixid(0, CTPPS_PIXEL_STATION_ID, CTPPS_FAR_RP_ID, 0);
-  try {
+  if ( iRun.run()>300000 ) {    //Pixel installed
     det = geom->getSensor( pixid );
     horizontalShiftBwDiamondPixels_ = det->translation().x() - det->params().at( 0 ) - horizontalShiftOfDiamond_ - 3;
-  }
-  catch (...)
-  {
-    // Pixel not yet installed... tomography will be empty
-    horizontalShiftBwDiamondPixels_ = 0;
   }
 }
 

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -24,7 +24,6 @@
 #include "DataFormats/CTPPSDigi/interface/TotemVFATStatus.h"
 #include "DataFormats/CTPPSDigi/interface/TotemFEDInfo.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/CTPPSReco/interface/TotemRPLocalTrack.h"
 
 #include "DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h"
 #include "DataFormats/CTPPSDigi/interface/CTPPSDiamondDigi.h"
@@ -90,7 +89,6 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     static const int CTPPS_FED_ID_56;
 
     edm::EDGetTokenT< edm::DetSetVector<TotemVFATStatus> > tokenStatus_;
-    edm::EDGetTokenT< edm::DetSetVector<TotemRPLocalTrack> > tokenLocalTrack_;
     edm::EDGetTokenT< edm::DetSetVector<CTPPSPixelLocalTrack> > tokenPixelTrack_;
     edm::EDGetTokenT< edm::DetSetVector<CTPPSDiamondDigi> > tokenDigi_;
     edm::EDGetTokenT< edm::DetSetVector<CTPPSDiamondRecHit> > tokenDiamondHit_;
@@ -375,7 +373,6 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
 
 CTPPSDiamondDQMSource::CTPPSDiamondDQMSource( const edm::ParameterSet& ps ) :
   tokenStatus_      ( consumes< edm::DetSetVector<TotemVFATStatus> >       ( ps.getParameter<edm::InputTag>( "tagStatus" ) ) ),
-  tokenLocalTrack_  ( consumes< edm::DetSetVector<TotemRPLocalTrack> >     ( ps.getParameter<edm::InputTag>( "tagLocalTrack" ) ) ),
   tokenPixelTrack_  ( consumes< edm::DetSetVector<CTPPSPixelLocalTrack> >     ( ps.getParameter<edm::InputTag>( "tagPixelLocalTracks" ) ) ),
   tokenDigi_        ( consumes< edm::DetSetVector<CTPPSDiamondDigi> >      ( ps.getParameter<edm::InputTag>( "tagDigi" ) ) ),
   tokenDiamondHit_  ( consumes< edm::DetSetVector<CTPPSDiamondRecHit> >    ( ps.getParameter<edm::InputTag>( "tagDiamondRecHits" ) ) ),
@@ -418,8 +415,15 @@ CTPPSDiamondDQMSource::dqmBeginRun( const edm::Run& iRun, const edm::EventSetup&
   
   // Rough alignement of pixel detector for diamond thomography
   const CTPPSPixelDetId pixid(0, CTPPS_PIXEL_STATION_ID, CTPPS_FAR_RP_ID, 0);
-  det = geom->getSensor( pixid );
-  horizontalShiftBwDiamondPixels_ = det->translation().x() - det->params().at( 0 ) - horizontalShiftOfDiamond_ - 3;
+  try {
+    det = geom->getSensor( pixid );
+    horizontalShiftBwDiamondPixels_ = det->translation().x() - det->params().at( 0 ) - horizontalShiftOfDiamond_ - 3;
+  }
+  catch (...)
+  {
+    // Pixel not yet installed... tomography will be empty
+    horizontalShiftBwDiamondPixels_ = 0;
+  }
 }
 
 
@@ -465,9 +469,6 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   // get event data
   edm::Handle< edm::DetSetVector<TotemVFATStatus> > diamondVFATStatus;
   event.getByToken( tokenStatus_, diamondVFATStatus );
-
-  edm::Handle< edm::DetSetVector<TotemRPLocalTrack> > stripTracks;
-  event.getByToken( tokenLocalTrack_, stripTracks );
   
   edm::Handle< edm::DetSetVector<CTPPSPixelLocalTrack> > pixelTracks;
   event.getByToken( tokenPixelTrack_, pixelTracks );
@@ -513,7 +514,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   // Correlation Plots
   //------------------------------
 
-  for ( const auto& ds1 : *stripTracks ) {
+  for ( const auto& ds1 : *pixelTracks ) {
     for ( const auto& tr1 : ds1 ) {
       if ( ! tr1.isValid() )  continue;
 
@@ -524,7 +525,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       if (stNum1 != 0 || ( rpNum1 != 2 && rpNum1 != 3 ) )  continue;
       unsigned int idx1 = arm1*3 + rpNum1-2;
 
-      for ( const auto& ds2 : *stripTracks ) {
+      for ( const auto& ds2 : *pixelTracks ) {
         for ( const auto& tr2 : ds2 ) {
           if ( ! tr2.isValid() )  continue;
 

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -8,10 +8,9 @@ ctppsDiamondDQMSource = DQMEDAnalyzer('CTPPSDiamondDQMSource',
     tagDiamondRecHits = cms.InputTag("ctppsDiamondRecHits"),
     tagDiamondLocalTracks = cms.InputTag("ctppsDiamondLocalTracks"),
     tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
+    tagPixelLocalTracks = cms.InputTag("ctppsPixelLocalTracks"),
     
     excludeMultipleHits = cms.bool(True),
-    minimumStripAngleForTomography = cms.double(0),
-    maximumStripAngleForTomography = cms.double(1),
 
     offsetsOOT = cms.VPSet( # cut on the OOT bin for physics hits
         # 2016, after TS2

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -7,7 +7,6 @@ ctppsDiamondDQMSource = DQMEDAnalyzer('CTPPSDiamondDQMSource',
     tagFEDInfo = cms.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
     tagDiamondRecHits = cms.InputTag("ctppsDiamondRecHits"),
     tagDiamondLocalTracks = cms.InputTag("ctppsDiamondLocalTracks"),
-    tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
     tagPixelLocalTracks = cms.InputTag("ctppsPixelLocalTracks"),
     
     excludeMultipleHits = cms.bool(True),

--- a/DQM/CTPPS/test/diamond_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/diamond_dqm_test_cfg.py
@@ -14,6 +14,12 @@ process.MessageLogger = cms.Service("MessageLogger",
         threshold = cms.untracked.string('WARNING')
     )
 )
+    
+    # import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 # load DQM framework
 process.load("DQM.Integration.config.environment_cfi")
@@ -23,14 +29,52 @@ process.dqmSaver.path = ""
 process.dqmSaver.tag = "CTPPS"
 
 # raw data source
-process.source = cms.Source("NewEventStreamFileReader",
-  fileNames = cms.untracked.vstring(
-    #'file:/afs/cern.ch/user/j/jkaspar/public/run273062_ls0001-2_stream.root'
-    #'/store/t0streamer/Data/Physics/000/294/737/run294737_ls0011_streamPhysics_StorageManager.dat',
-    '/store/t0streamer/Minidaq/A/000/295/626/run295626_ls0001_streamA_StorageManager.dat',
-  )
+process.source = cms.Source("PoolSource",
+    # replace 'myfile.root',',' with the source file you want to use
+    fileNames = cms.untracked.vstring(
+    *(
+           '/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/02448DBC-0A77-E711-8240-02163E01A2ED.root',
+#'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/106FE4C4-0D77-E711-8785-02163E01373C.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/469D8C89-1477-E711-A6A4-02163E01190C.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/4C729FDF-0C77-E711-A078-02163E014548.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/664E5FE8-0C77-E711-917D-02163E01469B.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/6A5C61DE-0C77-E711-A08C-02163E013720.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/6A76D2EC-0E77-E711-8903-02163E01A7A5.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/82937E4A-0C77-E711-8725-02163E01421E.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/8A8595B1-1177-E711-B1E8-02163E014761.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/A2BDBF69-1677-E711-83E2-02163E01A4ED.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/A4F9404C-0B77-E711-ADB0-02163E0134D7.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/A615970E-1177-E711-9AA8-02163E0139D9.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/ACBCD4BB-0F77-E711-9AB2-02163E014342.root',
+'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/C2D92F59-0C77-E711-B3AD-02163E01A5B4.root',
+#'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/E041BD4B-0B77-E711-A90A-02163E012140.root',
+
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/1E2FB550-5190-E711-8010-02163E01A731.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/ECE07B13-5C90-E711-AA7C-02163E011DDC.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/AABBE824-5990-E711-BE37-02163E0144E2.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/562C1C92-5A90-E711-904D-02163E01A2C7.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/D23D5509-6390-E711-B82E-02163E014785.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/88377025-5990-E711-8E26-02163E01A4E6.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/FE7699DC-5990-E711-8DF5-02163E011D9E.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/600BB493-5A90-E711-84EE-02163E01A1EB.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/AA6E5A99-6090-E711-B9AA-02163E012B3A.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/F45AD155-5B90-E711-8ACE-02163E019C49.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/909B3BB3-5C90-E711-8649-02163E01A1EB.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/ACC8407D-5890-E711-A88A-02163E0134FB.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/A4DF7114-5E90-E711-9BD7-02163E011D9E.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/9EF2EBDC-5990-E711-BC87-02163E0138EC.root',
+#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/DE7748D6-5C90-E711-A008-02163E011B3C.root',
+
+     )
+    ),
+    #inputCommands = cms.untracked.vstring(
+       #'drop CTPPSPixelCluseredmDetSetVector_ctppsPixelClusters__RECO'
+    #)
 )
 
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_hlt_relval', '')
 
 # raw-to-digi conversion
 process.load("EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff")
@@ -45,19 +89,23 @@ process.load('RecoCTPPS.TotemRPLocal.ctppsDiamondRecHits_cfi')
 # local tracks fitter
 process.load('RecoCTPPS.TotemRPLocal.ctppsDiamondLocalTracks_cfi')
 
+# pixel
+process.load('RecoCTPPS.PixelLocal.ctppsPixelLocalTracks_cfi')
 
 # CTPPS DQM modules
 process.load("DQM.CTPPS.ctppsDQM_cff")
 process.ctppsDiamondDQMSource.excludeMultipleHits = cms.bool(True);
 
 process.path = cms.Path(
-    process.ctppsRawToDigi *
+    #process.ctppsRawToDigi *
     process.recoCTPPS *
-    process.ctppsDiamondRawToDigi *
+    #process.ctppsDiamondRawToDigi *
     process.ctppsDiamondRecHits *
     process.ctppsDiamondLocalTracks *
+    process.ctppsPixelLocalTracks *
     process.ctppsDQM
-)
+    )
+
 
 process.end_path = cms.EndPath(
     process.dqmEnv +

--- a/DQM/CTPPS/test/diamond_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/diamond_dqm_test_cfg.py
@@ -30,46 +30,12 @@ process.dqmSaver.tag = "CTPPS"
 
 # raw data source
 process.source = cms.Source("PoolSource",
-    # replace 'myfile.root',',' with the source file you want to use
+    # replace '*.root',',' with the source file you want to use
     fileNames = cms.untracked.vstring(
     *(
-           '/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/02448DBC-0A77-E711-8240-02163E01A2ED.root',
-#'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/106FE4C4-0D77-E711-8785-02163E01373C.root',
 '/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/469D8C89-1477-E711-A6A4-02163E01190C.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/4C729FDF-0C77-E711-A078-02163E014548.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/664E5FE8-0C77-E711-917D-02163E01469B.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/6A5C61DE-0C77-E711-A08C-02163E013720.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/6A76D2EC-0E77-E711-8903-02163E01A7A5.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/82937E4A-0C77-E711-8725-02163E01421E.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/8A8595B1-1177-E711-B1E8-02163E014761.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/A2BDBF69-1677-E711-83E2-02163E01A4ED.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/A4F9404C-0B77-E711-ADB0-02163E0134D7.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/A615970E-1177-E711-9AA8-02163E0139D9.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/ACBCD4BB-0F77-E711-9AB2-02163E014342.root',
-'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/C2D92F59-0C77-E711-B3AD-02163E01A5B4.root',
-#'/store/data/Run2017C/ZeroBias/AOD/PromptReco-v2/000/300/088/00000/E041BD4B-0B77-E711-A90A-02163E012140.root',
-
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/1E2FB550-5190-E711-8010-02163E01A731.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/ECE07B13-5C90-E711-AA7C-02163E011DDC.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/AABBE824-5990-E711-BE37-02163E0144E2.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/562C1C92-5A90-E711-904D-02163E01A2C7.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/D23D5509-6390-E711-B82E-02163E014785.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/88377025-5990-E711-8E26-02163E01A4E6.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/FE7699DC-5990-E711-8DF5-02163E011D9E.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/600BB493-5A90-E711-84EE-02163E01A1EB.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/AA6E5A99-6090-E711-B9AA-02163E012B3A.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/F45AD155-5B90-E711-8ACE-02163E019C49.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/909B3BB3-5C90-E711-8649-02163E01A1EB.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/ACC8407D-5890-E711-A88A-02163E0134FB.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/A4DF7114-5E90-E711-9BD7-02163E011D9E.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/9EF2EBDC-5990-E711-BC87-02163E0138EC.root',
-#'/store/data/Run2017D/ZeroBias/AOD/PromptReco-v1/000/302/159/00000/DE7748D6-5C90-E711-A008-02163E011B3C.root',
-
      )
     ),
-    #inputCommands = cms.untracked.vstring(
-       #'drop CTPPSPixelCluseredmDetSetVector_ctppsPixelClusters__RECO'
-    #)
 )
 
 

--- a/DQM/CTPPS/test/diamond_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/diamond_dqm_test_cfg.py
@@ -49,7 +49,6 @@ process.load("EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff")
 process.load("RecoCTPPS.Configuration.recoCTPPS_cff")
 
 # rechits production
-process.load('Geometry.VeryForwardGeometry.geometryRP_cfi')
 process.load('RecoCTPPS.TotemRPLocal.ctppsDiamondRecHits_cfi')
 
 # local tracks fitter


### PR DESCRIPTION
backport of #22447

This PR updates the DQM:
* Tomography is now using pixel detectors instead of strip (not installed anymore)
* Efficiency of diamond channels wrt to other diamonds and wrt to pixel detectors
* Increased flexibility of hitmaps: the horizontal position of diamond (`horizontalShiftOfDiamond_`) is retrieved from the geometry and this value is subtracted such that the hitmaps are always starting from x=0. In a similar way, the offset with pixel detectors is used to properly display the tomography.
* Updated tests to cope with #22264
