### PR TITLE
Fixing bug in default values for EgammaHLTGsfTrackVarProducer : 10_2_X

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
@@ -144,8 +144,8 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
       missingHitsValue = 0;
       validHitsValue = 100;
       chi2Value = 0;
-      oneOverESuperMinusOneOverPValue = 1;
-      oneOverESeedMinusOneOverPValue = 1;
+      oneOverESuperMinusOneOverPValue = 0;
+      oneOverESeedMinusOneOverPValue = 0;
     }else{
       for(size_t trkNr=0;trkNr<gsfTracks.size();trkNr++){
       


### PR DESCRIPTION
This PR fixes a bug in the default values of EgammaHLTGsfTrackVarProducer which incorrectly sets 1/E-1/p default values to 1 rather than 0. This is now fixed.

This PR is needed rather urgently to relax the electron cuts for startup for the HLT. Can we slip it into CMSSW_10_1_1?
@Martin-Grunewald 