### PR TITLE
Fixing bug in default values for EgammaHLTGsfTrackVarProducer : 10_1_X

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
@@ -144,8 +144,8 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
       missingHitsValue = 0;
       validHitsValue = 100;
       chi2Value = 0;
-      oneOverESuperMinusOneOverPValue = 1;
-      oneOverESeedMinusOneOverPValue = 1;
+      oneOverESuperMinusOneOverPValue = 0;
+      oneOverESeedMinusOneOverPValue = 0;
     }else{
       for(size_t trkNr=0;trkNr<gsfTracks.size();trkNr++){
       


### PR DESCRIPTION
Backport https://github.com/cms-sw/cmssw/pull/22863 which is needed for data taking.

Without it, we'll need to disable all the endcap ecal-track match cuts by hand which we manage to mess up every year. Currently when we set it to the default values, we cause all the 1/E-1/p filters to fail due to an improperly set default value by me. 

Best,
Sam