### PR TITLE
Fix compilation warnings (ClassDef macro)

### DIFF
--- a/PhysicsTools/KinFitter/interface/TFitConstraintEp.h
+++ b/PhysicsTools/KinFitter/interface/TFitConstraintEp.h
@@ -56,7 +56,7 @@ private:
   Double_t _constraint;                   // Value of constraint
   TFitConstraintEp::component _component; // 4vector component to be constrained
 
-  ClassDef(TFitConstraintEp, 0)
+  ClassDefOverride(TFitConstraintEp, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitConstraintM.h
+++ b/PhysicsTools/KinFitter/interface/TFitConstraintM.h
@@ -53,7 +53,7 @@ protected :
 
 private :
 
-  ClassDef(TFitConstraintM, 0)
+  ClassDefOverride(TFitConstraintM, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitConstraintMGaus.h
+++ b/PhysicsTools/KinFitter/interface/TFitConstraintMGaus.h
@@ -39,7 +39,7 @@ protected :
 
 private :
 
-  ClassDef(TFitConstraintMGaus, 0)
+  ClassDefOverride(TFitConstraintMGaus, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleCart.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleCart.h
@@ -35,7 +35,7 @@ protected :
 
 private:
 
-  ClassDef(TFitParticleCart, 0)
+  ClassDefOverride(TFitParticleCart, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleECart.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleECart.h
@@ -35,7 +35,7 @@ protected :
 
 private:
 
-  ClassDef(TFitParticleECart, 0)
+  ClassDefOverride(TFitParticleECart, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleEMomDev.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleEMomDev.h
@@ -37,7 +37,7 @@ protected :
 
 private:
 
-  ClassDef(TFitParticleEMomDev, 0)
+  ClassDefOverride(TFitParticleEMomDev, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleEScaledMomDev.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleEScaledMomDev.h
@@ -32,7 +32,7 @@ protected :
 
 private :
 
-  ClassDef(TFitParticleEScaledMomDev, 0)
+  ClassDefOverride(TFitParticleEScaledMomDev, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleESpher.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleESpher.h
@@ -35,7 +35,7 @@ protected :
 
 private:
 
-  ClassDef(TFitParticleESpher, 0)
+  ClassDefOverride(TFitParticleESpher, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleEtEtaPhi.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleEtEtaPhi.h
@@ -35,7 +35,7 @@ protected :
 
 private:
 
-  ClassDef(TFitParticleEtEtaPhi, 0)
+  ClassDefOverride(TFitParticleEtEtaPhi, 0)
 };
 
 

--- a/PhysicsTools/KinFitter/interface/TFitParticleEtThetaPhi.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleEtThetaPhi.h
@@ -35,7 +35,7 @@ protected :
 
 private:
 
-  ClassDef(TFitParticleEtThetaPhi, 0)
+  ClassDefOverride(TFitParticleEtThetaPhi, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleMCCart.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleMCCart.h
@@ -34,7 +34,7 @@ protected :
 
 private:
 
-  ClassDef(TFitParticleMCCart, 0)
+  ClassDefOverride(TFitParticleMCCart, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleMCMomDev.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleMCMomDev.h
@@ -35,7 +35,7 @@ protected :
 
 private:
 
-  ClassDef(TFitParticleMCMomDev, 0)
+  ClassDefOverride(TFitParticleMCMomDev, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleMCPInvSpher.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleMCPInvSpher.h
@@ -34,7 +34,7 @@ protected :
 
 private:
 
-  ClassDef(TFitParticleMCPInvSpher, 0)
+  ClassDefOverride(TFitParticleMCPInvSpher, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleMCSpher.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleMCSpher.h
@@ -34,7 +34,7 @@ protected :
 
 private:
 
-  ClassDef(TFitParticleMCSpher, 0)
+  ClassDefOverride(TFitParticleMCSpher, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleMomDev.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleMomDev.h
@@ -37,7 +37,7 @@ protected :
 
 private:
 
-  ClassDef(TFitParticleMomDev, 0)
+  ClassDefOverride(TFitParticleMomDev, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TFitParticleSpher.h
+++ b/PhysicsTools/KinFitter/interface/TFitParticleSpher.h
@@ -35,7 +35,7 @@ protected :
 
 private:
 
-  ClassDef(TFitParticleSpher, 0)
+  ClassDefOverride(TFitParticleSpher, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TKinFitter.h
+++ b/PhysicsTools/KinFitter/interface/TKinFitter.h
@@ -148,7 +148,7 @@ private :
   Int_t _status;        // Status of the last fit;_
   Int_t _nbIter;        // number of iteration performed in the fit
 
-  ClassDef(TKinFitter, 0)
+  ClassDefOverride(TKinFitter, 0)
 };
 
 #endif

--- a/PhysicsTools/KinFitter/interface/TSLToyGen.h
+++ b/PhysicsTools/KinFitter/interface/TSLToyGen.h
@@ -92,7 +92,7 @@ private :
   Bool_t _withMPDGCons;
   Bool_t _doCheckConstraintsTruth;
 
-  ClassDef(TSLToyGen, 0)
+  ClassDefOverride(TSLToyGen, 0)
 };
 
 #endif


### PR DESCRIPTION
This is a fix for https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc630/CMSSW_10_2_X_2018-04-05-2300/PhysicsTools/KinFitter warnings