### PR TITLE
Simplify caching of CLHEP::HepRandomEngine in digitizers

### DIFF
--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
@@ -164,16 +164,10 @@ void CastorDigiProducer::checkGeometry(const edm::EventSetup & eventSetup) {
 }
 
 CLHEP::HepRandomEngine* CastorDigiProducer::randomEngine(edm::StreamID const& streamID) {
-  unsigned int index = streamID.value();
-  if(index >= randomEngines_.size()) {
-    randomEngines_.resize(index + 1, nullptr);
-  }
-  CLHEP::HepRandomEngine* ptr = randomEngines_[index];
-  if(!ptr) {
+  if(!randomEngine_) {
     edm::Service<edm::RandomNumberGenerator> rng;
-    ptr = &rng->getEngine(streamID);
-    randomEngines_[index] = ptr;
+    randomEngine_ = &rng->getEngine(streamID);
   }
-  return ptr;
+  return randomEngine_;
 }
 

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
@@ -73,13 +73,17 @@ CastorDigiProducer::~CastorDigiProducer() {
   delete theHitCorrection;
 }
 
-void CastorDigiProducer::initializeEvent(edm::Event const&, edm::EventSetup const& eventSetup) {
+void CastorDigiProducer::initializeEvent(edm::Event const& event, edm::EventSetup const& eventSetup) {
   // get the appropriate gains, noises, & widths for this event
   edm::ESHandle<CastorDbService> conditions;
   eventSetup.get<CastorDbRecord>().get(conditions);
   theAmplifier->setDbService(conditions.product());
   theCoderFactory->setDbService(conditions.product());
   theParameterMap->setDbService(conditions.product());
+
+  // Cache random number engine
+  edm::Service<edm::RandomNumberGenerator> rng;
+  randomEngine_ = &rng->getEngine(event.streamID());
 
   edm::LogInfo("CastorDigiProducer") << "checking the geometry...";
 
@@ -91,13 +95,13 @@ void CastorDigiProducer::initializeEvent(edm::Event const&, edm::EventSetup cons
   theCastorDigitizer->initializeHits();
 }
 
-void CastorDigiProducer::accumulateCaloHits(std::vector<PCaloHit> const& hcalHits, int bunchCrossing, CLHEP::HepRandomEngine* engine) {
+void CastorDigiProducer::accumulateCaloHits(std::vector<PCaloHit> const& hcalHits, int bunchCrossing) {
   //fillFakeHits();
 
   if(theHitCorrection != nullptr) {
     theHitCorrection->fillChargeSums(hcalHits);
   }
-  theCastorDigitizer->add(hcalHits, bunchCrossing, engine);
+  theCastorDigitizer->add(hcalHits, bunchCrossing, randomEngine_);
 }
 
 void CastorDigiProducer::accumulate(edm::Event const& e, edm::EventSetup const&) {
@@ -105,7 +109,7 @@ void CastorDigiProducer::accumulate(edm::Event const& e, edm::EventSetup const&)
   edm::Handle<std::vector<PCaloHit> > castorHandle;
   e.getByLabel(theHitsProducerTag, castorHandle);
 
-  accumulateCaloHits(*castorHandle.product(), 0, randomEngine(e.streamID()));
+  accumulateCaloHits(*castorHandle.product(), 0);
 }
 
 void CastorDigiProducer::accumulate(PileUpEventPrincipal const& e, edm::EventSetup const&, edm::StreamID const& streamID) {
@@ -113,7 +117,7 @@ void CastorDigiProducer::accumulate(PileUpEventPrincipal const& e, edm::EventSet
   edm::Handle<std::vector<PCaloHit> > castorHandle;
   e.getByLabel(theHitsProducerTag, castorHandle);
 
-  accumulateCaloHits(*castorHandle.product(), e.bunchCrossing(), randomEngine(streamID));
+  accumulateCaloHits(*castorHandle.product(), e.bunchCrossing());
 }
 
 void CastorDigiProducer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSetup) {
@@ -122,12 +126,14 @@ void CastorDigiProducer::finalizeEvent(edm::Event& e, const edm::EventSetup& eve
   std::unique_ptr<CastorDigiCollection> castorResult(new CastorDigiCollection());
 
   // Step C: Invoke the algorithm, getting back outputs.
-  theCastorDigitizer->run(*castorResult, randomEngine(e.streamID()));
+  theCastorDigitizer->run(*castorResult, randomEngine_);
 
   edm::LogInfo("CastorDigiProducer") << "HCAL/Castor digis   : " << castorResult->size();
 
   // Step D: Put outputs into event
   e.put(std::move(castorResult));
+
+  randomEngine_ = nullptr; // to prevent access outside event
 }
 
 
@@ -162,12 +168,3 @@ void CastorDigiProducer::checkGeometry(const edm::EventSetup & eventSetup) {
   //std::cout<<"CastorDigiProducer::CheckGeometry number of cells: "<<castorCells.size()<<std::endl;
   theCastorDigitizer->setDetIds(castorCells);
 }
-
-CLHEP::HepRandomEngine* CastorDigiProducer::randomEngine(edm::StreamID const& streamID) {
-  if(!randomEngine_) {
-    edm::Service<edm::RandomNumberGenerator> rng;
-    randomEngine_ = &rng->getEngine(streamID);
-  }
-  return randomEngine_;
-}
-

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
@@ -81,7 +81,7 @@ private:
 
   std::vector<PCaloHit> theCastorHits;
 
-  std::vector<CLHEP::HepRandomEngine*> randomEngines_;
+  CLHEP::HepRandomEngine* randomEngine_ = nullptr;
 };
 
 #endif

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
@@ -46,7 +46,7 @@ public:
 private:
   
 
-  void accumulateCaloHits(std::vector<PCaloHit> const&, int bunchCrossing, CLHEP::HepRandomEngine*);
+  void accumulateCaloHits(std::vector<PCaloHit> const&, int bunchCrossing);
 
   /// fills the vectors for each subdetector
   void sortHits(const edm::PCaloHitContainer & hits);
@@ -57,8 +57,6 @@ private:
   void checkGeometry(const edm::EventSetup& eventSetup);
 
   edm::InputTag theHitsProducerTag;
-
-  CLHEP::HepRandomEngine* randomEngine(edm::StreamID const& streamID);
 
   /** Reconstruction algorithm*/
   typedef CaloTDigitizer<CastorDigitizerTraits> CastorDigitizer;

--- a/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
@@ -78,15 +78,13 @@ class EcalDigiProducer : public DigiAccumulatorMixMod {
       virtual void cacheEEDigis( const EEDigiCollection* eeDigiPtr ) const { }
 
       typedef edm::Handle<std::vector<PCaloHit> > HitsHandle;
-      void accumulateCaloHits(HitsHandle const& ebHandle, HitsHandle const& eeHandle, HitsHandle const& esHandle, int bunchCrossing, CLHEP::HepRandomEngine*);
+      void accumulateCaloHits(HitsHandle const& ebHandle, HitsHandle const& eeHandle, HitsHandle const& esHandle, int bunchCrossing);
 
       void checkGeometry(const edm::EventSetup& eventSetup) ;
 
       void updateGeometry() ;
 
       void checkCalibrations(const edm::Event& event, const edm::EventSetup& eventSetup) ;
-
-      CLHEP::HepRandomEngine* randomEngine(edm::StreamID const& streamID);
 
       const APDShape m_APDShape ;
       const EBShape  m_EBShape  ;

--- a/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
@@ -148,7 +148,7 @@ class EcalDigiProducer : public DigiAccumulatorMixMod {
       std::array< std::unique_ptr<CorrelatedNoisifier<EcalCorrMatrix> >, 3 > m_EBCorrNoise ;
       std::array< std::unique_ptr<CorrelatedNoisifier<EcalCorrMatrix> >, 3 > m_EECorrNoise ;
 
-      std::vector<CLHEP::HepRandomEngine*> randomEngines_;
+      CLHEP::HepRandomEngine* randomEngine_ = nullptr;
 };
 
 #endif 

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -629,17 +629,11 @@ EcalDigiProducer::updateGeometry()
 }
 
 CLHEP::HepRandomEngine* EcalDigiProducer::randomEngine(edm::StreamID const& streamID) {
-  unsigned int index = streamID.value();
-  if(index >= randomEngines_.size()) {
-    randomEngines_.resize(index + 1, nullptr);
-  }
-  CLHEP::HepRandomEngine* ptr = randomEngines_[index];
-  if(!ptr) {
+  if(!randomEngine_) {
     edm::Service<edm::RandomNumberGenerator> rng;
-    ptr = &rng->getEngine(streamID);
-    randomEngines_[index] = ptr;
+    randomEngine_ = &rng->getEngine(streamID);
   }
-  return ptr;
+  return randomEngine_;
 }
 
 void EcalDigiProducer::setEBNoiseSignalGenerator(EcalBaseSignalGenerator * noiseGenerator) {

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -293,6 +293,9 @@ EcalDigiProducer::~EcalDigiProducer()
 
 void
 EcalDigiProducer::initializeEvent(edm::Event const& event, edm::EventSetup const& eventSetup) {
+  edm::Service<edm::RandomNumberGenerator> rng;
+  randomEngine_ = &rng->getEngine(event.streamID());
+
    checkGeometry( eventSetup );
    checkCalibrations( event, eventSetup );
    if( m_doEB ) {
@@ -314,24 +317,24 @@ EcalDigiProducer::initializeEvent(edm::Event const& event, edm::EventSetup const
 }
 
 void
-EcalDigiProducer::accumulateCaloHits(HitsHandle const& ebHandle, HitsHandle const& eeHandle, HitsHandle const& esHandle, int bunchCrossing, CLHEP::HepRandomEngine* engine) {
+EcalDigiProducer::accumulateCaloHits(HitsHandle const& ebHandle, HitsHandle const& eeHandle, HitsHandle const& esHandle, int bunchCrossing) {
   if(m_doEB && ebHandle.isValid()) {
-    m_BarrelDigitizer->add(*ebHandle.product(), bunchCrossing, engine);
+    m_BarrelDigitizer->add(*ebHandle.product(), bunchCrossing, randomEngine_);
 
     if(m_apdSeparateDigi) {
-      m_APDDigitizer->add(*ebHandle.product(), bunchCrossing, engine);
+      m_APDDigitizer->add(*ebHandle.product(), bunchCrossing, randomEngine_);
     }
   }
 
   if(m_doEE && eeHandle.isValid()) {
-    m_EndcapDigitizer->add(*eeHandle.product(), bunchCrossing, engine);
+    m_EndcapDigitizer->add(*eeHandle.product(), bunchCrossing, randomEngine_);
   }
 
   if(m_doES && esHandle.isValid()) {
     if(m_doFastES) {
-      m_ESDigitizer->add(*esHandle.product(), bunchCrossing, engine);
+      m_ESDigitizer->add(*esHandle.product(), bunchCrossing, randomEngine_);
     } else {
-      m_ESOldDigitizer->add(*esHandle.product(), bunchCrossing, engine);
+      m_ESOldDigitizer->add(*esHandle.product(), bunchCrossing, randomEngine_);
     }
   }
 }
@@ -357,7 +360,7 @@ EcalDigiProducer::accumulate(edm::Event const& e, edm::EventSetup const& eventSe
     e.getByLabel(esTag, esHandle);
   }
 
-  accumulateCaloHits(ebHandle, eeHandle, esHandle, 0, randomEngine(e.streamID()));
+  accumulateCaloHits(ebHandle, eeHandle, esHandle, 0);
 }
 
 void
@@ -381,7 +384,7 @@ EcalDigiProducer::accumulate(PileUpEventPrincipal const& e, edm::EventSetup cons
     e.getByLabel(esTag, esHandle);
   }
 
-  accumulateCaloHits(ebHandle, eeHandle, esHandle, e.bunchCrossing(), randomEngine(streamID));
+  accumulateCaloHits(ebHandle, eeHandle, esHandle, e.bunchCrossing());
 }
 
 void 
@@ -396,27 +399,27 @@ EcalDigiProducer::finalizeEvent(edm::Event& event, edm::EventSetup const& eventS
    // run the algorithm
 
    if( m_doEB ) {
-     m_BarrelDigitizer->run( *barrelResult, randomEngine(event.streamID()) ) ;
+     m_BarrelDigitizer->run( *barrelResult, randomEngine_ ) ;
      cacheEBDigis( &*barrelResult ) ;
      
      edm::LogInfo("DigiInfo") << "EB Digis: " << barrelResult->size() ;
      
      if( m_apdSeparateDigi ) {
-       m_APDDigitizer->run( *apdResult, randomEngine(event.streamID()) ) ;
+       m_APDDigitizer->run( *apdResult, randomEngine_ ) ;
        edm::LogInfo("DigiInfo") << "APD Digis: " << apdResult->size() ;
      }
    }
 
    if( m_doEE ) {
-     m_EndcapDigitizer->run( *endcapResult, randomEngine(event.streamID()) ) ;
+     m_EndcapDigitizer->run( *endcapResult, randomEngine_ ) ;
      edm::LogInfo("EcalDigi") << "EE Digis: " << endcapResult->size() ;
      cacheEEDigis( &*endcapResult ) ;
    }
    if( m_doES ) {
      if(m_doFastES) {
-       m_ESDigitizer->run( *preshowerResult, randomEngine(event.streamID()) ) ;
+       m_ESDigitizer->run( *preshowerResult, randomEngine_ ) ;
      } else {
-       m_ESOldDigitizer->run( *preshowerResult, randomEngine(event.streamID()) ) ;
+       m_ESOldDigitizer->run( *preshowerResult, randomEngine_ ) ;
      }
      edm::LogInfo("EcalDigi") << "ES Digis: " << preshowerResult->size();
    }
@@ -430,6 +433,8 @@ EcalDigiProducer::finalizeEvent(edm::Event& event, edm::EventSetup const& eventS
    event.put(std::move(barrelResult),    m_EBdigiCollection ) ;
    event.put(std::move(endcapResult),    m_EEdigiCollection ) ;
    event.put(std::move(preshowerResult), m_ESdigiCollection ) ;
+
+   randomEngine_ = nullptr; // to prevent access outside event
 }
 
 void
@@ -626,14 +631,6 @@ EcalDigiProducer::updateGeometry()
 	 m_ESDigitizer->setDetIds( *theESDets ) ; 
    }
   }
-}
-
-CLHEP::HepRandomEngine* EcalDigiProducer::randomEngine(edm::StreamID const& streamID) {
-  if(!randomEngine_) {
-    edm::Service<edm::RandomNumberGenerator> rng;
-    randomEngine_ = &rng->getEngine(streamID);
-  }
-  return randomEngine_;
 }
 
 void EcalDigiProducer::setEBNoiseSignalGenerator(EcalBaseSignalGenerator * noiseGenerator) {

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
@@ -28,24 +28,27 @@ HGCDigiProducer::HGCDigiProducer(edm::ParameterSet const& pset, edm::ConsumesCol
 //
 void HGCDigiProducer::initializeEvent(edm::Event const& event, edm::EventSetup const& es) 
 {
+  edm::Service<edm::RandomNumberGenerator> rng;
+  randomEngine_ = &rng->getEngine(event.streamID());
   theDigitizer_.initializeEvent(event, es);
 }
 
 //
 void HGCDigiProducer::finalizeEvent(edm::Event& event, edm::EventSetup const& es) 
 {
-  theDigitizer_.finalizeEvent(event, es, randomEngine(event.streamID()));
+  theDigitizer_.finalizeEvent(event, es, randomEngine_);
+  randomEngine_ = nullptr; // to precent access outside event
 }
 
 //
 void HGCDigiProducer::accumulate(edm::Event const& event, edm::EventSetup const& es) 
 {
-  theDigitizer_.accumulate(event, es, randomEngine(event.streamID()));
+  theDigitizer_.accumulate(event, es, randomEngine_);
 }
 
 void HGCDigiProducer::accumulate(PileUpEventPrincipal const& event, edm::EventSetup const& es, edm::StreamID const& streamID) 
 {
-  theDigitizer_.accumulate(event, es, randomEngine(streamID));
+  theDigitizer_.accumulate(event, es, randomEngine_);
 }
 
 //
@@ -58,14 +61,6 @@ void HGCDigiProducer::beginRun(edm::Run const&, edm::EventSetup const& es)
 void HGCDigiProducer::endRun(edm::Run const&, edm::EventSetup const&) 
 {
   theDigitizer_.endRun();
-}
-
-CLHEP::HepRandomEngine* HGCDigiProducer::randomEngine(edm::StreamID const& streamID) {
-  if(!randomEngine_) {
-    edm::Service<edm::RandomNumberGenerator> rng;
-    randomEngine_ = &rng->getEngine(streamID);
-  }
-  return randomEngine_;
 }
 
 DEFINE_DIGI_ACCUMULATOR(HGCDigiProducer);

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
@@ -61,17 +61,11 @@ void HGCDigiProducer::endRun(edm::Run const&, edm::EventSetup const&)
 }
 
 CLHEP::HepRandomEngine* HGCDigiProducer::randomEngine(edm::StreamID const& streamID) {
-  unsigned int index = streamID.value();
-  if(index >= randomEngines_.size()) {
-    randomEngines_.resize(index + 1, nullptr);
-  }
-  CLHEP::HepRandomEngine* ptr = randomEngines_[index];
-  if(!ptr) {
+  if(!randomEngine_) {
     edm::Service<edm::RandomNumberGenerator> rng;
-    ptr = &rng->getEngine(streamID);
-    randomEngines_[index] = ptr;
+    randomEngine_ = &rng->getEngine(streamID);
   }
-  return ptr;
+  return randomEngine_;
 }
 
 DEFINE_DIGI_ACCUMULATOR(HGCDigiProducer);

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.h
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.h
@@ -32,7 +32,6 @@ public:
   void endRun(edm::Run const&, edm::EventSetup const&) override;
   ~HGCDigiProducer() override = default;
 private:
-  CLHEP::HepRandomEngine* randomEngine(edm::StreamID const& streamID);
   //the digitizer
   HGCDigitizer theDigitizer_;
   CLHEP::HepRandomEngine* randomEngine_ = nullptr;

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.h
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.h
@@ -35,7 +35,7 @@ private:
   CLHEP::HepRandomEngine* randomEngine(edm::StreamID const& streamID);
   //the digitizer
   HGCDigitizer theDigitizer_;
-  std::vector<CLHEP::HepRandomEngine*> randomEngines_;
+  CLHEP::HepRandomEngine* randomEngine_ = nullptr;
 };
 
 #endif

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
@@ -38,9 +38,6 @@ public:
   void setQIE11NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator);
 
 private:
-
-  CLHEP::HepRandomEngine* randomEngine(edm::StreamID const& streamID);
-
   HcalDigitizer theDigitizer_;
 
   CLHEP::HepRandomEngine* randomEngine_ = nullptr;

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
@@ -43,7 +43,7 @@ private:
 
   HcalDigitizer theDigitizer_;
 
-  std::vector<CLHEP::HepRandomEngine*> randomEngines_;
+  CLHEP::HepRandomEngine* randomEngine_ = nullptr;
 };
 
 #endif

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
@@ -31,22 +31,25 @@ HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const& pset, edm::ConsumesC
 
 void
 HcalDigiProducer::initializeEvent(edm::Event const& event, edm::EventSetup const& es) {
+  edm::Service<edm::RandomNumberGenerator> rng;
+  randomEngine_ = &rng->getEngine(event.streamID());
   theDigitizer_.initializeEvent(event, es);
 }
 
 void
 HcalDigiProducer::finalizeEvent(edm::Event& event, edm::EventSetup const& es) {
-  theDigitizer_.finalizeEvent(event, es, randomEngine(event.streamID()));
+  theDigitizer_.finalizeEvent(event, es, randomEngine_);
+  randomEngine_ = nullptr; // to prevent access outside event
 }
 
 void
 HcalDigiProducer::accumulate(edm::Event const& event, edm::EventSetup const& es) {
-  theDigitizer_.accumulate(event, es, randomEngine(event.streamID()));
+  theDigitizer_.accumulate(event, es, randomEngine_);
 }
 
 void
 HcalDigiProducer::accumulate(PileUpEventPrincipal const& event, edm::EventSetup const& es, edm::StreamID const& streamID) {
-  theDigitizer_.accumulate(event, es, randomEngine(streamID));
+  theDigitizer_.accumulate(event, es, randomEngine_);
 }
 
 void
@@ -83,12 +86,4 @@ HcalDigiProducer::setQIE10NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGe
 void
 HcalDigiProducer::setQIE11NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGenerator) {
   theDigitizer_.setQIE11NoiseSignalGenerator(noiseGenerator);
-}
-
-CLHEP::HepRandomEngine* HcalDigiProducer::randomEngine(edm::StreamID const& streamID) {
-  if(!randomEngine_) {
-    edm::Service<edm::RandomNumberGenerator> rng;
-    randomEngine_ = &rng->getEngine(streamID);
-  }
-  return randomEngine_;
 }

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
@@ -86,15 +86,9 @@ HcalDigiProducer::setQIE11NoiseSignalGenerator(HcalBaseSignalGenerator * noiseGe
 }
 
 CLHEP::HepRandomEngine* HcalDigiProducer::randomEngine(edm::StreamID const& streamID) {
-  unsigned int index = streamID.value();
-  if(index >= randomEngines_.size()) {
-    randomEngines_.resize(index + 1, nullptr);
-  }
-  CLHEP::HepRandomEngine* ptr = randomEngines_[index];
-  if(!ptr) {
+  if(!randomEngine_) {
     edm::Service<edm::RandomNumberGenerator> rng;
-    ptr = &rng->getEngine(streamID);
-    randomEngines_[index] = ptr;
+    randomEngine_ = &rng->getEngine(streamID);
   }
-  return ptr;
+  return randomEngine_;
 }

--- a/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
+++ b/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
@@ -44,7 +44,7 @@ public:
   void finalizeEvent(edm::Event& e, edm::EventSetup const& c) override;
 
 private:
-  void accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const& hits, int bunchCrossing, CLHEP::HepRandomEngine*);
+  void accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const& hits, int bunchCrossing);
 
   /// fills the vectors for each subdetector
   void sortHits(const edm::PCaloHitContainer & hits);
@@ -55,8 +55,6 @@ private:
 
   void setPhaseShift(const DetId & detId);
 
-  CLHEP::HepRandomEngine* randomEngine(edm::StreamID const& streamID);
-  
   const HcalTimeSlew* hcalTimeSlew_delay_;
 
 private:

--- a/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
+++ b/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
@@ -96,7 +96,7 @@ private:
   bool   doPhaseShift;
   double tunePhaseShift;
 
-  std::vector<CLHEP::HepRandomEngine*> randomEngines_;
+  CLHEP::HepRandomEngine* randomEngine_ = nullptr;
 };
 
 #endif

--- a/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
+++ b/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
@@ -244,15 +244,9 @@ void HcalTBDigiProducer::setPhaseShift(const DetId & detId) {
 }
 
 CLHEP::HepRandomEngine* HcalTBDigiProducer::randomEngine(edm::StreamID const& streamID) {
-  unsigned int index = streamID.value();
-  if(index >= randomEngines_.size()) {
-    randomEngines_.resize(index + 1, nullptr);
-  }
-  CLHEP::HepRandomEngine* ptr = randomEngines_[index];
-  if(!ptr) {
+  if(!randomEngine_) {
     edm::Service<edm::RandomNumberGenerator> rng;
-    ptr = &rng->getEngine(streamID);
-    randomEngines_[index] = ptr;
+    randomEngine_ = &rng->getEngine(streamID);
   }
-  return ptr;
+  return randomEngine_;
 }

--- a/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
+++ b/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
@@ -99,6 +99,10 @@ void HcalTBDigiProducer::initializeEvent(edm::Event const& e, edm::EventSetup co
   // get the correct geometry
   checkGeometry(eventSetup);
 
+  // Cache random number engine
+  edm::Service<edm::RandomNumberGenerator> rng;
+  randomEngine_ = &rng->getEngine(e.streamID());
+
   theHBHEHits.clear();
   theHOHits.clear();
   if (doPhaseShift) {
@@ -123,15 +127,15 @@ void HcalTBDigiProducer::initializeEvent(edm::Event const& e, edm::EventSetup co
   theHODigitizer->initializeHits();
 }
 
-void HcalTBDigiProducer::accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const& hcalHandle, int bunchCrossing, CLHEP::HepRandomEngine* engine) {
+void HcalTBDigiProducer::accumulateCaloHits(edm::Handle<std::vector<PCaloHit> > const& hcalHandle, int bunchCrossing) {
 
   LogDebug("HcalSim") << "HcalTBDigiProducer::accumulate trying to get SimHit";
 
   if(hcalHandle.isValid()) {
     std::vector<PCaloHit> hits = *hcalHandle.product();
     LogDebug("HcalSim") << "HcalTBDigiProducer::accumulate Hits corrected";
-    theHBHEDigitizer->add(hits, bunchCrossing, engine);
-    theHODigitizer->add(hits, bunchCrossing, engine);
+    theHBHEDigitizer->add(hits, bunchCrossing, randomEngine_);
+    theHODigitizer->add(hits, bunchCrossing, randomEngine_);
   }
 }
 
@@ -142,7 +146,7 @@ void HcalTBDigiProducer::accumulate(edm::Event const& e, edm::EventSetup const&)
   edm::Handle<std::vector<PCaloHit> > hcalHandle;
   e.getByLabel(hcalTag, hcalHandle);
 
-  accumulateCaloHits(hcalHandle, 0, randomEngine(e.streamID()));
+  accumulateCaloHits(hcalHandle, 0);
 }
 
 void HcalTBDigiProducer::accumulate(PileUpEventPrincipal const& e, edm::EventSetup const&, edm::StreamID const& streamID) {
@@ -152,7 +156,7 @@ void HcalTBDigiProducer::accumulate(PileUpEventPrincipal const& e, edm::EventSet
   edm::Handle<std::vector<PCaloHit> > hcalHandle;
   e.getByLabel(hcalTag, hcalHandle);
 
-  accumulateCaloHits(hcalHandle, e.bunchCrossing(), randomEngine(streamID));
+  accumulateCaloHits(hcalHandle, e.bunchCrossing());
 }
 
 void HcalTBDigiProducer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSetup) {
@@ -161,9 +165,9 @@ void HcalTBDigiProducer::finalizeEvent(edm::Event& e, const edm::EventSetup& eve
   std::unique_ptr<HODigiCollection> hoResult(new HODigiCollection());
   LogDebug("HcalSim") << "HcalTBDigiProducer::produce Empty collection created";
   // Step C: Invoke the algorithm, getting back outputs.
-  theHBHEDigitizer->run(*hbheResult, randomEngine(e.streamID()));
+  theHBHEDigitizer->run(*hbheResult, randomEngine_);
   edm::LogInfo("HcalSim") << "HcalTBDigiProducer: HBHE digis : " << hbheResult->size();
-  theHODigitizer->run(*hoResult, randomEngine(e.streamID()));
+  theHODigitizer->run(*hoResult, randomEngine_);
   edm::LogInfo("HcalSim") << "HcalTBDigiProducer: HO digis   : " << hoResult->size();
 
   // Step D: Put outputs into event
@@ -171,6 +175,7 @@ void HcalTBDigiProducer::finalizeEvent(edm::Event& e, const edm::EventSetup& eve
   e.put(std::move(hbheResult), instance);
   e.put(std::move(hoResult), instance);
 
+  randomEngine_ = nullptr; // to prevent access outside event
 }
 
 void HcalTBDigiProducer::sortHits(const edm::PCaloHitContainer & hits) {
@@ -241,12 +246,4 @@ void HcalTBDigiProducer::setPhaseShift(const DetId & detId) {
       theHOResponse->setPhaseShift(passPhaseShift);
     }
   }
-}
-
-CLHEP::HepRandomEngine* HcalTBDigiProducer::randomEngine(edm::StreamID const& streamID) {
-  if(!randomEngine_) {
-    edm::Service<edm::RandomNumberGenerator> rng;
-    randomEngine_ = &rng->getEngine(streamID);
-  }
-  return randomEngine_;
 }

--- a/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.cc
+++ b/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.cc
@@ -76,15 +76,9 @@ void FTLDigiProducer::endRun(edm::Run const&, edm::EventSetup const&)
 }
 
 CLHEP::HepRandomEngine* FTLDigiProducer::randomEngine(edm::StreamID const& streamID) {
-  unsigned int index = streamID.value();
-  if(index >= randomEngines_.size()) {
-    randomEngines_.resize(index + 1, nullptr);
-  }
-  CLHEP::HepRandomEngine* ptr = randomEngines_[index];
-  if(!ptr) {
+  if(!randomEngine_) {
     edm::Service<edm::RandomNumberGenerator> rng;
-    ptr = &rng->getEngine(streamID);
-    randomEngines_[index] = ptr;
+    randomEngine_ = &rng->getEngine(streamID);
   }
-  return ptr;
+  return randomEngine_;
 }

--- a/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.cc
+++ b/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.cc
@@ -31,6 +31,8 @@ FTLDigiProducer::~FTLDigiProducer()
 //
 void FTLDigiProducer::initializeEvent(edm::Event const& event, edm::EventSetup const& es) 
 {
+  edm::Service<edm::RandomNumberGenerator> rng;
+  randomEngine_ = &rng->getEngine(event.streamID());
   for( auto& digitizer : theDigitizers_ ) {
     digitizer->initializeEvent(event, es);
   }
@@ -40,22 +42,23 @@ void FTLDigiProducer::initializeEvent(edm::Event const& event, edm::EventSetup c
 void FTLDigiProducer::finalizeEvent(edm::Event& event, edm::EventSetup const& es) 
 {
   for( auto& digitizer : theDigitizers_ ) {
-    digitizer->finalizeEvent(event, es, randomEngine(event.streamID()));
+    digitizer->finalizeEvent(event, es, randomEngine_);
   }
+  randomEngine_ = nullptr; // to prevent access outside event
 }
 
 //
 void FTLDigiProducer::accumulate(edm::Event const& event, edm::EventSetup const& es) 
 {
   for( auto& digitizer : theDigitizers_ ) {
-    digitizer->accumulate(event, es, randomEngine(event.streamID()));
+    digitizer->accumulate(event, es, randomEngine_);
   }
 }
 
 void FTLDigiProducer::accumulate(PileUpEventPrincipal const& event, edm::EventSetup const& es, edm::StreamID const& streamID) 
 {
   for( auto& digitizer : theDigitizers_ ) {
-    digitizer->accumulate(event, es, randomEngine(streamID));
+    digitizer->accumulate(event, es, randomEngine_);
   }
 }
 
@@ -73,12 +76,4 @@ void FTLDigiProducer::endRun(edm::Run const&, edm::EventSetup const&)
   for( auto& digitizer : theDigitizers_ ) {
     digitizer->endRun();
   }
-}
-
-CLHEP::HepRandomEngine* FTLDigiProducer::randomEngine(edm::StreamID const& streamID) {
-  if(!randomEngine_) {
-    edm::Service<edm::RandomNumberGenerator> rng;
-    randomEngine_ = &rng->getEngine(streamID);
-  }
-  return randomEngine_;
 }

--- a/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.h
+++ b/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.h
@@ -34,7 +34,6 @@ public:
   void endRun(edm::Run const&, edm::EventSetup const&) override;
   ~FTLDigiProducer() override;
 private:
-  CLHEP::HepRandomEngine* randomEngine(edm::StreamID const& streamID);
   //the digitizer
   std::vector<std::unique_ptr<FTLDigitizerBase> > theDigitizers_;
   CLHEP::HepRandomEngine* randomEngine_ = nullptr;

--- a/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.h
+++ b/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.h
@@ -37,7 +37,7 @@ private:
   CLHEP::HepRandomEngine* randomEngine(edm::StreamID const& streamID);
   //the digitizer
   std::vector<std::unique_ptr<FTLDigitizerBase> > theDigitizers_;
-  std::vector<CLHEP::HepRandomEngine*> randomEngines_;
+  CLHEP::HepRandomEngine* randomEngine_ = nullptr;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -70,11 +70,6 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-namespace CLHEP {
-  class HepRandomEngine;
-}
-
-
 //
 // constants, enums and typedefs
 //
@@ -135,7 +130,6 @@ namespace cms
   SiPixelDigitizer::accumulatePixelHits(edm::Handle<std::vector<PSimHit> > hSimHits,
 					size_t globalSimHitIndex,
 					const unsigned int tofBin,
-					CLHEP::HepRandomEngine* engine,
 					edm::EventSetup const& iSetup) {
     if(hSimHits.isValid()) {
        std::set<unsigned int> detIds;
@@ -157,7 +151,7 @@ namespace cms
              GlobalVector bfield = pSetup->inTesla(pixdet->surface().position());
              LogDebug ("PixelDigitizer ") << "B-field(T) at " << pixdet->surface().position() << "(cm): " 
                                           << pSetup->inTesla(pixdet->surface().position());
-             _pixeldigialgo->accumulateSimHits(it, itEnd, globalSimHitIndex, tofBin, pixdet, bfield, tTopo, engine);
+             _pixeldigialgo->accumulateSimHits(it, itEnd, globalSimHitIndex, tofBin, pixdet, bfield, tTopo, randomEngine_);
            }
          }
        }
@@ -176,6 +170,10 @@ namespace cms
     // indices used to create the digi-sim link (if configured to do so) rather than starting
     // from zero for each crossing.
     crossingSimHitIndexOffset_.clear();
+
+    // Cache random number engine
+    edm::Service<edm::RandomNumberGenerator> rng;
+    randomEngine_ = &rng->getEngine(e.streamID());
 
     _pixeldigialgo->initializeEvent();
     iSetup.get<TrackerDigiGeometryRecord>().get(geometryType, pDD);
@@ -213,7 +211,7 @@ namespace cms
       iEvent.getByLabel(tag, simHits);
       unsigned int tofBin = PixelDigiSimLink::LowTof;
       if ((*i).find(std::string("HighTof")) != std::string::npos) tofBin = PixelDigiSimLink::HighTof;
-      accumulatePixelHits(simHits, crossingSimHitIndexOffset_[tag.encode()], tofBin, randomEngine(iEvent.streamID()), iSetup);
+      accumulatePixelHits(simHits, crossingSimHitIndexOffset_[tag.encode()], tofBin, iSetup);
       // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
       // the global counter. Next time accumulateStripHits() is called it will count the sim hits
       // as though they were on the end of this collection.
@@ -233,7 +231,7 @@ namespace cms
       iEvent.getByLabel(tag, simHits);
       unsigned int tofBin = PixelDigiSimLink::LowTof;
       if ((*i).find(std::string("HighTof")) != std::string::npos) tofBin = PixelDigiSimLink::HighTof;
-      accumulatePixelHits(simHits, crossingSimHitIndexOffset_[tag.encode()], tofBin, randomEngine(streamID), iSetup);
+      accumulatePixelHits(simHits, crossingSimHitIndexOffset_[tag.encode()], tofBin, iSetup);
       // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
       // the global counter. Next time accumulateStripHits() is called it will count the sim hits
       // as though they were on the end of this collection.
@@ -246,10 +244,6 @@ namespace cms
   // ------------ method called to produce the data  ------------
   void
   SiPixelDigitizer::finalizeEvent(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
-    edm::Service<edm::RandomNumberGenerator> rng;
-    CLHEP::HepRandomEngine* engine = &rng->getEngine(iEvent.streamID());
-
     edm::ESHandle<TrackerTopology> tTopoHand;
     iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
     const TrackerTopology *tTopo=tTopoHand.product();
@@ -279,7 +273,7 @@ namespace cms
                                  collector.data,
                                  linkcollector.data,
 				 tTopo,
-                                 engine);
+                                 randomEngine_);
         if(!collector.data.empty()) {
           theDigiVector.push_back(std::move(collector));
         }
@@ -298,15 +292,8 @@ namespace cms
     // Step D: write output to file 
     iEvent.put(std::move(output));
     iEvent.put(std::move(outputlink));
-  }
 
-  CLHEP::HepRandomEngine* SiPixelDigitizer::randomEngine(edm::StreamID const& streamID) {
-    if(!randomEngine_) {
-      edm::Service<edm::RandomNumberGenerator> rng;
-      randomEngine_ = &rng->getEngine(streamID);
-    }
-    return randomEngine_;
+    randomEngine_ = nullptr; // to prevent access outside event
   }
-
 }// end namespace cms::
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -301,17 +301,11 @@ namespace cms
   }
 
   CLHEP::HepRandomEngine* SiPixelDigitizer::randomEngine(edm::StreamID const& streamID) {
-    unsigned int index = streamID.value();
-    if(index >= randomEngines_.size()) {
-      randomEngines_.resize(index + 1, nullptr);
-    }
-    CLHEP::HepRandomEngine* ptr = randomEngines_[index];
-    if(!ptr) {
+    if(!randomEngine_) {
       edm::Service<edm::RandomNumberGenerator> rng;
-      ptr = &rng->getEngine(streamID);
-      randomEngines_[index] = ptr;
+      randomEngine_ = &rng->getEngine(streamID);
     }
-    return ptr;
+    return randomEngine_;
   }
 
 }// end namespace cms::

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -95,7 +95,7 @@ namespace cms {
     edm::ESHandle<TrackerGeometry> pDD;
     edm::ESHandle<MagneticField> pSetup;
     std::map<unsigned int, PixelGeomDetUnit const *> detectorUnits;
-    std::vector<CLHEP::HepRandomEngine*> randomEngines_;
+    CLHEP::HepRandomEngine* randomEngine_ = nullptr;
 
     PileupMixingContent* PileupInfo_;
     

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -71,9 +71,7 @@ namespace cms {
     void accumulatePixelHits(edm::Handle<std::vector<PSimHit> >,
 			     size_t globalSimHitIndex,
 			     const unsigned int tofBin,
-			     CLHEP::HepRandomEngine*,
 			     edm::EventSetup const& c);
-    CLHEP::HepRandomEngine* randomEngine(edm::StreamID const& streamID);
 
     bool firstInitializeEvent_;
     bool firstFinalizeEvent_;

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -288,15 +288,9 @@ void SiStripDigitizer::finalizeEvent(edm::Event& iEvent, edm::EventSetup const& 
 }
 
 CLHEP::HepRandomEngine* SiStripDigitizer::randomEngine(edm::StreamID const& streamID) {
-  unsigned int index = streamID.value();
-  if(index >= randomEngines_.size()) {
-    randomEngines_.resize(index + 1, nullptr);
-  }
-  CLHEP::HepRandomEngine* ptr = randomEngines_[index];
-  if(!ptr) {
+  if(!randomEngine_) {
     edm::Service<edm::RandomNumberGenerator> rng;
-    ptr = &rng->getEngine(streamID);
-    randomEngines_[index] = ptr;
+    randomEngine_ = &rng->getEngine(streamID);
   }
-  return ptr;
+  return randomEngine_;
 }

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -95,7 +95,7 @@ SiStripDigitizer::~SiStripDigitizer() {
 }  
 
 void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hSimHits,
-					   const TrackerTopology *tTopo, size_t globalSimHitIndex, const unsigned int tofBin, CLHEP::HepRandomEngine* engine ) {
+					   const TrackerTopology *tTopo, size_t globalSimHitIndex, const unsigned int tofBin) {
   // globalSimHitIndex is the index the sim hit will have when it is put in a collection
   // of sim hits for all crossings. This is only used when creating digi-sim links if
   // configured to do so.
@@ -114,7 +114,7 @@ void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hS
 	  GlobalVector bfield = pSetup->inTesla(stripdet->surface().position());
 	  LogDebug ("Digitizer ") << "B-field(T) at " << stripdet->surface().position() << "(cm): "
 				  << pSetup->inTesla(stripdet->surface().position());
-	  theDigiAlgo->accumulateSimHits(it, itEnd, globalSimHitIndex, tofBin, stripdet, bfield, tTopo, engine);
+	  theDigiAlgo->accumulateSimHits(it, itEnd, globalSimHitIndex, tofBin, stripdet, bfield, tTopo, randomEngine_);
 	}
       }
     } // end of loop over sim hits
@@ -137,7 +137,7 @@ void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hS
       if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
 
       iEvent.getByLabel(tag, simHits);
-      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], tofBin, randomEngine(iEvent.streamID()));
+      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], tofBin);
       // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
       // the global counter. Next time accumulateStripHits() is called it will count the sim hits
       // as though they were on the end of this collection.
@@ -165,7 +165,7 @@ void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hS
       if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof; 
 
       iEvent.getByLabel(tag, simHits);
-      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], tofBin, randomEngine(streamID));
+      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], tofBin);
       // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
       // the global counter. Next time accumulateStripHits() is called it will count the sim hits
       // as though they were on the end of this collection.
@@ -189,6 +189,10 @@ void SiStripDigitizer::initializeEvent(edm::Event const& iEvent, edm::EventSetup
     iSetup.get<SiStripDetCablingRcd>().get(detCabling);
     detCabling->addConnected(theDetIdList);
   }
+
+  // Cache random number engine
+  edm::Service<edm::RandomNumberGenerator> rng;
+  randomEngine_ = &rng->getEngine(iEvent.streamID());
 
   theDigiAlgo->initializeEvent(iSetup);
 
@@ -244,7 +248,7 @@ void SiStripDigitizer::finalizeEvent(edm::Event& iEvent, edm::EventSetup const& 
       edm::DetSet<SiStripRawDigi> collectorRaw(iu->geographicalId().rawId());
       edm::DetSet<StripDigiSimLink> collectorLink(iu->geographicalId().rawId());
       theDigiAlgo->digitize(collectorZS,collectorRaw,collectorLink,sgd,
-                            gainHandle,thresholdHandle,noiseHandle,pedestalHandle,theAffectedAPVvector,randomEngine(iEvent.streamID()));
+                            gainHandle,thresholdHandle,noiseHandle,pedestalHandle,theAffectedAPVvector,randomEngine_);
       if(zeroSuppression){
         if(!collectorZS.data.empty()){
           theDigiVector.push_back(collectorZS);
@@ -285,12 +289,5 @@ void SiStripDigitizer::finalizeEvent(edm::Event& iEvent, edm::EventSetup const& 
     iEvent.put(std::move(output_processedraw), PRDigi);
     if( makeDigiSimLinks_ ) iEvent.put(std::move(pOutputDigiSimLink)); // The previous EDProducer didn't name this collection so I won't either
   }
-}
-
-CLHEP::HepRandomEngine* SiStripDigitizer::randomEngine(edm::StreamID const& streamID) {
-  if(!randomEngine_) {
-    edm::Service<edm::RandomNumberGenerator> rng;
-    randomEngine_ = &rng->getEngine(streamID);
-  }
-  return randomEngine_;
+  randomEngine_ = nullptr; // to prevent access outside event
 }

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -63,8 +63,7 @@ public:
 
   
 private:
-  void accumulateStripHits(edm::Handle<std::vector<PSimHit> >, const TrackerTopology *tTopo, size_t globalSimHitIndex, const unsigned int tofBin, CLHEP::HepRandomEngine*);
-  CLHEP::HepRandomEngine* randomEngine(edm::StreamID const& streamID);
+  void accumulateStripHits(edm::Handle<std::vector<PSimHit> >, const TrackerTopology *tTopo, size_t globalSimHitIndex, const unsigned int tofBin);
 
   typedef std::vector<std::string> vstring;
   typedef std::map<unsigned int, std::vector<std::pair<const PSimHit*, int> >,std::less<unsigned int> > simhit_map;

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -98,7 +98,7 @@ private:
   edm::ESHandle<TrackerGeometry> pDD;
   edm::ESHandle<MagneticField> pSetup;
   std::map<unsigned int, StripGeomDetUnit const *> detectorUnits;
-  std::vector<CLHEP::HepRandomEngine*> randomEngines_;
+  CLHEP::HepRandomEngine* randomEngine_ = nullptr;
   std::vector<std::pair<int,std::bitset<6>>> theAffectedAPVvector;
 
   PileupMixingContent* PileupInfo_;


### PR DESCRIPTION
The explicit stream-based caching was introduced in #2392 at the time the the MixingModule was still a "one" module. Now that the MixingModule is a stream producer, there is no need to do the caching explicitly (=vectors indexed by the stream ID). A simple member variable is enough, and it is safe because framework runs always the same instance of a stream module in a given stream.

The caching is further simplified to always set the cache variable in `initializeEvent()` and set it back to `nullptr` in `finalizeEvent()` (to prevent the use of the engine outside event, e.g. begin/end lumi/run).

Resolves #22712.

Tested in CMSSW_10_1_0 (rebased on top of CMSSW_10_2_X_2018-04-10-2300), no changes expected.

@wddgit @Dr15Jones 