### PR TITLE
Make JetResolution class available from python

### DIFF
--- a/JetMETCorrections/Modules/src/classes.h
+++ b/JetMETCorrections/Modules/src/classes.h
@@ -1,0 +1,7 @@
+#include "JetMETCorrections/Modules/interface/JetResolution.h"
+
+namespace JetMETCorrections_Modules {
+    struct dictionary {
+        JME::JetResolution jr;
+    };
+}

--- a/JetMETCorrections/Modules/src/classes_def.xml
+++ b/JetMETCorrections/Modules/src/classes_def.xml
@@ -1,3 +1,4 @@
 <lcgdict>
-    <class name="JME::JetResolution" class_version="0"/>
+    <class name="JME::JetResolution" persistent="false"/>
 </lcgdict>
+

--- a/JetMETCorrections/Modules/src/classes_def.xml
+++ b/JetMETCorrections/Modules/src/classes_def.xml
@@ -1,0 +1,3 @@
+<lcgdict>
+    <class name="JME::JetResolution" class_version="0"/>
+</lcgdict>


### PR DESCRIPTION
Works like this in python:

    import ROOT
    res_obj = ROOT.JME.JetResolution('Spring16_25nsV10_MC_PtResolution_AK4PFchs.txt')
    jet_res = jet_pt * res_obj.getResolution(ROOT.JME.JetParameters().setRho(rho).setJetPt(jet_pt).setJetEta(jet_eta))