### PR TITLE
Minor cleanups to avoid clang warnings

### DIFF
--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -60,7 +60,7 @@ namespace edm {
   public:
     typedef ProductRegistryHelper::TypeLabelList TypeLabelList;
     ProducerBase ();
-    ~ProducerBase() override;
+    ~ProducerBase() noexcept(false) override;
  
     /// used by the fwk to register list of products
     std::function<void(BranchDescription const&)> registrationCallback() const;

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1118,7 +1118,7 @@ namespace edm {
     
     auto status= std::make_shared<LuminosityBlockProcessingStatus>(this, preallocations_.numberOfStreams(), iRunResource) ;
 
-    auto lumiWork = [this, iHolder, iSync, status](edm::LimitedTaskQueue::Resumer iResumer) mutable {
+    auto lumiWork = [this, iHolder, status](edm::LimitedTaskQueue::Resumer iResumer) mutable {
       if(iHolder.taskHasFailed()) { return; }
 
       status->setResumer(std::move(iResumer));

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -30,7 +30,8 @@ namespace {
 }
 
 namespace edm {
-struct LuminosityBlockPrincipal {
+class LuminosityBlockPrincipal {
+public:
   LuminosityBlockPrincipal(int iRun,int iLumi): run_(iRun),lumi_(iLumi){}
   int run_;
   int lumi_;


### PR DESCRIPTION
-Removed an unused parameter in a lambda
-Switched a struct to be a class to be consistent with other headers
-Delcared noexcept(false) to be consistent between header and source file