### PR TITLE
Remove check for empty sum collection in CALOL2-uGT comparison 10_1_X

### DIFF
--- a/DQM/L1TMonitor/src/L1TStage2uGTCaloLayer2Comp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGTCaloLayer2Comp.cc
@@ -346,8 +346,7 @@ bool L1TStage2uGTCaloLayer2Comp::compareSums(
 
   // if either calol2 or ugt collections are empty, or they have different
   // size, mark the event as bad (this should never occur in normal running)
-  if (calol2Col->size() == 0 || uGTCol->size() == 0 ||
-      (calol2Col->size() != uGTCol->size())) {
+  if ((calol2Col->size() != uGTCol->size())) {
     comparisonNum->Fill(EVENTBADSUMCOL);
     return false;
   }

--- a/DQM/L1TMonitor/src/L1TStage2uGTCaloLayer2Comp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGTCaloLayer2Comp.cc
@@ -344,8 +344,8 @@ bool L1TStage2uGTCaloLayer2Comp::compareSums(
   l1t::EtSumBxCollection::const_iterator calol2It = calol2Col->begin();
   l1t::EtSumBxCollection::const_iterator uGTIt = uGTCol->begin();
 
-  // if either calol2 or ugt collections are empty, or they have different
-  // size, mark the event as bad (this should never occur in normal running)
+  // if the calol2 or ugt collections  have different size, mark the event as
+  // bad (this should never occur in normal running)
   if ((calol2Col->size() != uGTCol->size())) {
     comparisonNum->Fill(EVENTBADSUMCOL);
     return false;


### PR DESCRIPTION
PR addresses a false alarm that the DQM comparison plot located under

L1T / L1TStage2uGT / calol2ouput_vs_uGTinput / errorSummaryNum

10_1_x backport of #22878 