### PR TITLE
dedicated DQM on displacedStandAlone muons

### DIFF
--- a/DQMOffline/Trigger/plugins/DiDispStaMuonMonitor.cc
+++ b/DQMOffline/Trigger/plugins/DiDispStaMuonMonitor.cc
@@ -1,0 +1,390 @@
+#include "DQMOffline/Trigger/plugins/DiDispStaMuonMonitor.h"
+
+// -----------------------------
+//  constructors and destructor
+// -----------------------------
+
+DiDispStaMuonMonitor::DiDispStaMuonMonitor( const edm::ParameterSet& iConfig ) :
+  folderName_             ( iConfig.getParameter<std::string>("FolderName") )
+  , muonToken_             ( consumes<reco::TrackCollection>       (iConfig.getParameter<edm::InputTag>("muons")     ) )
+  , muonPt_variable_binning_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("muonPtBinning") )
+  , muonPt_binning_          ( getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("muonPtPSet")    ) )
+  , muonEta_binning_          ( getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("muonEtaPSet")    ) )
+  , muonPhi_binning_          ( getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("muonPhiPSet")    ) )
+  , muonDxy_binning_          ( getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("muonDxyPSet")    ) )
+  , ls_binning_           ( getHistoPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("lsPSet")     ) )
+  , num_genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("numGenericTriggerEventPSet"),consumesCollector(), *this))
+  , den_genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("denGenericTriggerEventPSet"),consumesCollector(), *this))
+  //, muonSelection_ ( iConfig.getParameter<std::string>("muonSelection") )
+  , muonSelectionGeneral_ ( iConfig.getParameter<edm::ParameterSet>("muonSelection").getParameter<std::string>("general") )
+  , muonSelectionPt_ ( iConfig.getParameter<edm::ParameterSet>("muonSelection").getParameter<std::string>("pt") )
+  , muonSelectionDxy_ ( iConfig.getParameter<edm::ParameterSet>("muonSelection").getParameter<std::string>("dxy") )
+  , nmuons_     ( iConfig.getParameter<unsigned int>("nmuons" )     )
+{
+
+  muonPtME_.numerator   = nullptr;
+  muonPtME_.denominator = nullptr;
+  muonPtME_variableBinning_.numerator   = nullptr;
+  muonPtME_variableBinning_.denominator = nullptr;
+  muonPtVsLS_.numerator   = nullptr;
+  muonPtVsLS_.denominator   = nullptr;
+  muonEtaME_.numerator   = nullptr;
+  muonEtaME_.denominator = nullptr;
+  muonPhiME_.numerator   = nullptr;
+  muonPhiME_.denominator = nullptr;
+  muonDxyME_.numerator   = nullptr;
+  muonDxyME_.denominator = nullptr;
+
+
+  subMuonPtME_.numerator   = nullptr;
+  subMuonPtME_.denominator = nullptr;
+  subMuonPtME_variableBinning_.numerator   = nullptr;
+  subMuonPtME_variableBinning_.denominator = nullptr;
+  subMuonEtaME_.numerator   = nullptr;
+  subMuonEtaME_.denominator = nullptr;
+  subMuonPhiME_.numerator   = nullptr;
+  subMuonPhiME_.denominator = nullptr;
+  subMuonDxyME_.numerator   = nullptr;
+  subMuonDxyME_.denominator = nullptr;
+
+
+}
+
+DiDispStaMuonMonitor::~DiDispStaMuonMonitor() = default;
+
+DiDispStaMuonMonitor::MEbinning DiDispStaMuonMonitor::getHistoPSet(const edm::ParameterSet & pset)
+{
+  return MEbinning{
+    pset.getParameter<unsigned int>("nbins"),
+      pset.getParameter<double>("xmin"),
+      pset.getParameter<double>("xmax"),
+      };
+}
+
+DiDispStaMuonMonitor::MEbinning DiDispStaMuonMonitor::getHistoLSPSet(const edm::ParameterSet & pset)
+{
+  return MEbinning{
+    pset.getParameter<unsigned int>("nbins"),
+      0.,
+      double(pset.getParameter<unsigned int>("nbins"))
+      };
+}
+
+void DiDispStaMuonMonitor::setTitle(DiDispStaMuonME& me, const std::string& titleX, const std::string& titleY, bool bookDen)
+{
+  me.numerator->setAxisTitle(titleX,1);
+  me.numerator->setAxisTitle(titleY,2);
+  if(bookDen) {
+    me.denominator->setAxisTitle(titleX,1);
+    me.denominator->setAxisTitle(titleY,2);
+  }
+
+}
+
+void DiDispStaMuonMonitor::bookME(DQMStore::IBooker &ibooker, DiDispStaMuonME& me, const std::string& histname, const std::string& histtitle, int nbins, double min, double max)
+{
+  me.numerator   = ibooker.book1D(histname+"_numerator",   histtitle+" (numerator)",   nbins, min, max);
+  me.denominator = ibooker.book1D(histname+"_denominator", histtitle+" (denominator)", nbins, min, max);
+}
+void DiDispStaMuonMonitor::bookME(DQMStore::IBooker &ibooker, DiDispStaMuonME& me, const std::string& histname, const std::string& histtitle, const std::vector<double>& binning)
+{
+  int nbins = binning.size()-1;
+  std::vector<float> fbinning(binning.begin(),binning.end());
+  float* arr = &fbinning[0];
+  me.numerator   = ibooker.book1D(histname+"_numerator",   histtitle+" (numerator)",   nbins, arr);
+  me.denominator = ibooker.book1D(histname+"_denominator", histtitle+" (denominator)", nbins, arr);
+}
+void DiDispStaMuonMonitor::bookME(DQMStore::IBooker &ibooker, DiDispStaMuonME& me, const std::string& histname, const std::string& histtitle, int nbinsX, double xmin, double xmax, double ymin, double ymax, bool bookDen)
+{
+  me.numerator   = ibooker.bookProfile(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, xmin, xmax, ymin, ymax);
+  if(bookDen) me.denominator = ibooker.bookProfile(histname+"_denominator", histtitle+" (denominator)", nbinsX, xmin, xmax, ymin, ymax);
+}
+void DiDispStaMuonMonitor::bookME(DQMStore::IBooker &ibooker, DiDispStaMuonME& me, const std::string& histname, const std::string& histtitle, int nbinsX, double xmin, double xmax, int nbinsY, double ymin, double ymax)
+{
+  me.numerator   = ibooker.book2D(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, xmin, xmax, nbinsY, ymin, ymax);
+  me.denominator = ibooker.book2D(histname+"_denominator", histtitle+" (denominator)", nbinsX, xmin, xmax, nbinsY, ymin, ymax);
+}
+void DiDispStaMuonMonitor::bookME(DQMStore::IBooker &ibooker, DiDispStaMuonME& me, const std::string& histname, const std::string& histtitle, const std::vector<double>& binningX, const std::vector<double>& binningY)
+{
+  int nbinsX = binningX.size()-1;
+  std::vector<float> fbinningX(binningX.begin(),binningX.end());
+  float* arrX = &fbinningX[0];
+  int nbinsY = binningY.size()-1;
+  std::vector<float> fbinningY(binningY.begin(),binningY.end());
+  float* arrY = &fbinningY[0];
+
+  me.numerator   = ibooker.book2D(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, arrX, nbinsY, arrY);
+  me.denominator = ibooker.book2D(histname+"_denominator", histtitle+" (denominator)", nbinsX, arrX, nbinsY, arrY);
+}
+
+void DiDispStaMuonMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
+				 edm::Run const        & iRun,
+				 edm::EventSetup const & iSetup)
+{
+
+  std::string histname, histtitle;
+  bool bookDen;
+
+  std::string currentFolder = folderName_ ;
+  ibooker.setCurrentFolder(currentFolder);
+
+  histname = "muonPt"; histtitle = "muonPt";
+  bookDen = true;
+  bookME(ibooker,muonPtME_,histname,histtitle,muonPt_binning_.nbins,muonPt_binning_.xmin, muonPt_binning_.xmax);
+  setTitle(muonPtME_,"DisplacedStandAlone Muon p_{T} [GeV]","Events / [GeV]", bookDen);
+
+  histname = "muonPt_variable"; histtitle = "muonPt";
+  bookDen = true;
+  bookME(ibooker,muonPtME_variableBinning_,histname,histtitle,muonPt_variable_binning_);
+  setTitle(muonPtME_variableBinning_,"DisplacedStandAlone Muon p_{T} [GeV]","Events / [GeV]", bookDen);
+
+  histname = "muonPtVsLS"; histtitle = "muonPt vs LS";
+  bookDen = true;
+  bookME(ibooker,muonPtVsLS_,histname,histtitle,ls_binning_.nbins, ls_binning_.xmin, ls_binning_.xmax,muonPt_binning_.xmin, muonPt_binning_.xmax, bookDen);
+  setTitle(muonPtVsLS_,"LS","DisplacedStandAlone Muon p_{T} [GeV]", bookDen);
+
+  histname = "muonEta"; histtitle = "muonEta";
+  bookDen = true;
+  bookME(ibooker,muonEtaME_,histname,histtitle,muonEta_binning_.nbins,muonEta_binning_.xmin, muonEta_binning_.xmax);
+  setTitle(muonEtaME_,"DisplacedStandAlone Muon #eta","Events", bookDen);
+
+  histname = "muonPhi"; histtitle = "muonPhi";
+  bookDen = true;
+  bookME(ibooker,muonPhiME_,histname,histtitle,muonPhi_binning_.nbins,muonPhi_binning_.xmin, muonPhi_binning_.xmax);
+  setTitle(muonPhiME_,"DisplacedStandAlone Muon #phi","Events", bookDen);
+
+  histname = "muonDxy"; histtitle = "muonDxy";
+  bookDen = true;
+  bookME(ibooker,muonDxyME_,histname,histtitle,muonDxy_binning_.nbins,muonDxy_binning_.xmin, muonDxy_binning_.xmax);
+  setTitle(muonDxyME_,"DisplacedStandAlone Muon #dxy","Events", bookDen);
+
+
+  //-----------------------
+  //                      |
+  //-----------------------
+
+  if (nmuons_>1) {
+    histname = "subMuonPt"; histtitle = "subMuonPt";
+    bookDen = true;
+    bookME(ibooker,subMuonPtME_,histname,histtitle,muonPt_binning_.nbins,muonPt_binning_.xmin, muonPt_binning_.xmax);
+    setTitle(subMuonPtME_,"Subleading DisplacedStandAlone Muon p_{T} [GeV]","Events / [GeV]", bookDen);
+
+    histname = "subMuonPt_variable"; histtitle = "subMuonPt";
+    bookDen = true;
+    bookME(ibooker,subMuonPtME_variableBinning_,histname,histtitle,muonPt_variable_binning_);
+    setTitle(subMuonPtME_variableBinning_,"Subleading DisplacedStandAlone Muon p_{T} [GeV]","Events / [GeV]", bookDen);
+
+    histname = "subMuonEta"; histtitle = "subMuonEta";
+    bookDen = true;
+    bookME(ibooker,subMuonEtaME_,histname,histtitle,muonEta_binning_.nbins,muonEta_binning_.xmin, muonEta_binning_.xmax);
+    setTitle(subMuonEtaME_,"Subleading DisplacedStandAlone Muon #eta","Events", bookDen);
+
+    histname = "subMuonPhi"; histtitle = "subMuonPhi";
+    bookDen = true;
+    bookME(ibooker,subMuonPhiME_,histname,histtitle,muonPhi_binning_.nbins,muonPhi_binning_.xmin, muonPhi_binning_.xmax);
+    setTitle(subMuonPhiME_,"Subleading DisplacedStandAlone Muon #phi","Events", bookDen);
+
+    histname = "subMuonDxy"; histtitle = "subMuonDxy";
+    bookDen = true;
+    bookME(ibooker,subMuonDxyME_,histname,histtitle,muonDxy_binning_.nbins,muonDxy_binning_.xmin, muonDxy_binning_.xmax);
+    setTitle(subMuonDxyME_,"Subleading DisplacedStandAlone Muon #dxy","Events", bookDen);
+
+  }
+
+
+  // Initialize the GenericTriggerEventFlag
+  if ( num_genTriggerEventFlag_ && num_genTriggerEventFlag_->on() ) num_genTriggerEventFlag_->initRun( iRun, iSetup );
+  if ( den_genTriggerEventFlag_ && den_genTriggerEventFlag_->on() ) den_genTriggerEventFlag_->initRun( iRun, iSetup );
+
+}
+
+void DiDispStaMuonMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)  {
+
+  // Filter out events if Trigger Filtering is requested
+  if (den_genTriggerEventFlag_->on() && ! den_genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
+
+  int ls = iEvent.id().luminosityBlock();
+
+
+  edm::Handle<reco::TrackCollection> DSAHandle;
+  iEvent.getByToken( muonToken_, DSAHandle );
+  if ((unsigned int)(DSAHandle->size()) < nmuons_ ) return;
+  std::vector<edm::Ptr<reco::Track>> dsaMuonPtrs_{};// = DSAHandle->ptrs();
+  for (size_t i(0); i!=DSAHandle->size(); ++i) {
+    dsaMuonPtrs_.emplace_back(DSAHandle, i);
+  }
+  std::vector<edm::Ptr<reco::Track>> muons{}, muonsCutOnPt{}, muonsCutOnDxy{}, muonsCutOnPtAndDxy{};
+  //std::vector<reco::Track> muons;
+  //for ( auto const & m : *DSAHandle ) {
+  //  if ( muonSelectionGeneral_( m ) ) muons.push_back(m);
+  //}
+  std::copy_if(dsaMuonPtrs_.begin(), dsaMuonPtrs_.end(), back_inserter(muons), [this](const edm::Ptr<reco::Track>& m){ return muonSelectionGeneral_(*m); });
+  if ((unsigned int)(muons.size()) < nmuons_ ) return;
+  std::copy_if(muons.begin(), muons.end(), back_inserter(muonsCutOnPt), [this](const edm::Ptr<reco::Track>& m){ return muonSelectionPt_(*m); });
+  std::copy_if(muons.begin(), muons.end(), back_inserter(muonsCutOnDxy), [this](const edm::Ptr<reco::Track>& m){ return muonSelectionDxy_(*m); });
+  std::copy_if(muons.begin(), muons.end(), back_inserter(muonsCutOnPtAndDxy), [this](const edm::Ptr<reco::Track>& m){ return muonSelectionPt_(*m) && muonSelectionDxy_(*m); });
+  //double muonPt = -999;
+  //double muonEta = -999;
+  //double muonPhi = -999;
+  //double muonDxy = -999;
+
+  // filling histograms (denominator)
+  if(!muons.empty()){
+    if(!muonsCutOnDxy.empty()) { // pt has cut on dxy
+        muonPtME_.denominator->Fill( muonsCutOnDxy[0]->pt() );
+        muonPtME_variableBinning_.denominator->Fill( muonsCutOnDxy[0]->pt() );
+        muonPtVsLS_.denominator->Fill( ls, muonsCutOnDxy[0]->pt() );
+    }
+    if(!muonsCutOnPtAndDxy.empty()) { // eta, phi have cut on pt and dxy
+        muonEtaME_.denominator->Fill( muonsCutOnPtAndDxy[0]->eta() );
+        muonPhiME_.denominator->Fill( muonsCutOnPtAndDxy[0]->phi() );
+    }
+    if(!muonsCutOnPt.empty()){ // dxy has cut on pt
+        muonDxyME_.denominator->Fill( muonsCutOnPt[0]->dxy() );
+    }
+  }
+
+  //muonPtME_.denominator -> Fill(muonPt);
+  //muonPtME_variableBinning_.denominator -> Fill(muonPt);
+  //muonEtaME_.denominator -> Fill(muonEta);
+  //muonPhiME_.denominator -> Fill(muonPhi);
+  //muonDxyME_.denominator -> Fill(muonDxy);
+  //muonPtVsLS_.denominator-> Fill(ls, muonPt);
+
+  /*if (nmuons_>1) {
+    subMuonPtME_.denominator  -> Fill(muons[1].pt());
+    subMuonPtME_variableBinning_.denominator -> Fill(muons[1].pt());
+    subMuonEtaME_.denominator -> Fill(muons[1].eta());
+    subMuonPhiME_.denominator -> Fill(muons[1].phi()); 
+    subMuonDxyME_.denominator -> Fill(muons[1].dxy()); 
+  }*/
+  if(muonsCutOnDxy.size() > 1) { // pt has cut on dxy
+      subMuonPtME_.denominator->Fill( muonsCutOnDxy[1]->pt() );
+      subMuonPtME_variableBinning_.denominator->Fill( muonsCutOnDxy[1]->pt() );
+  }
+  if(muonsCutOnPtAndDxy.size() > 1) { // eta, phi have cut on pt and dxy
+      subMuonEtaME_.denominator->Fill( muonsCutOnPtAndDxy[1]->eta() );
+      subMuonPhiME_.denominator->Fill( muonsCutOnPtAndDxy[1]->phi() );
+  }
+  if(muonsCutOnPt.size() > 1){ // dxy has cut on pt
+      subMuonDxyME_.denominator->Fill( muonsCutOnPt[1]->dxy() );
+  }
+
+
+  // filling histograms (numerator)
+  /*if (num_genTriggerEventFlag_->on() && ! num_genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
+  muonPtME_.numerator -> Fill(muonPt);
+  muonPtME_variableBinning_.numerator -> Fill(muonPt);
+  muonPtVsLS_.numerator -> Fill(ls, muonPt);
+  muonEtaME_.numerator -> Fill(muonEta);
+  muonPhiME_.numerator -> Fill(muonPhi);
+  muonDxyME_.numerator -> Fill(muonDxy);
+
+  if (nmuons_>1) {
+    subMuonPtME_.numerator  -> Fill(muons[1].pt());
+    subMuonPtME_variableBinning_.numerator -> Fill(muons[1].pt());
+    subMuonEtaME_.numerator -> Fill(muons[1].eta());
+    subMuonPhiME_.numerator -> Fill(muons[1].phi()); 
+    subMuonDxyME_.numerator -> Fill(muons[1].dxy()); 
+  }*/
+  
+  if(!muons.empty()){
+    if(!muonsCutOnDxy.empty()) { // pt has cut on dxy
+        muonPtME_.numerator->Fill( muonsCutOnDxy[0]->pt() );
+        muonPtME_variableBinning_.numerator->Fill( muonsCutOnDxy[0]->pt() );
+        muonPtVsLS_.numerator->Fill( ls, muonsCutOnDxy[0]->pt() );
+    }
+    if(!muonsCutOnPtAndDxy.empty()) { // eta, phi have cut on pt and dxy
+        muonEtaME_.numerator->Fill( muonsCutOnPtAndDxy[0]->eta() );
+        muonPhiME_.numerator->Fill( muonsCutOnPtAndDxy[0]->phi() );
+    }
+    if(!muonsCutOnPt.empty()){ // dxy has cut on pt
+        muonDxyME_.numerator->Fill( muonsCutOnPt[0]->dxy() );
+    }
+  }
+
+  if(muonsCutOnDxy.size() > 1) { // pt has cut on dxy
+      subMuonPtME_.numerator->Fill( muonsCutOnDxy[1]->pt() );
+      subMuonPtME_variableBinning_.numerator->Fill( muonsCutOnDxy[1]->pt() );
+  }
+  if(muonsCutOnPtAndDxy.size() > 1) { // eta, phi have cut on pt and dxy
+      subMuonEtaME_.numerator->Fill( muonsCutOnPtAndDxy[1]->eta() );
+      subMuonPhiME_.numerator->Fill( muonsCutOnPtAndDxy[1]->phi() );
+  }
+  if(muonsCutOnPt.size() > 1){ // dxy has cut on pt
+      subMuonDxyME_.numerator->Fill( muonsCutOnPt[1]->dxy() );
+  }
+
+
+
+}
+
+void DiDispStaMuonMonitor::fillHistoPSetDescription(edm::ParameterSetDescription & pset)
+{
+  pset.add<unsigned int>   ( "nbins", 200);
+  pset.add<double>( "xmin", -0.5 );
+  pset.add<double>( "xmax", 19999.5 );
+}
+
+void DiDispStaMuonMonitor::fillHistoLSPSetDescription(edm::ParameterSetDescription & pset)
+{
+  pset.add<unsigned int>   ( "nbins", 2000);
+}
+
+void DiDispStaMuonMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>  ( "FolderName", "HLT/EXO/DiDispStaMuon" );
+
+  desc.add<edm::InputTag>( "muons",    edm::InputTag("displacedStandAloneMuons") );
+  desc.add<unsigned int>("nmuons",     2);
+
+  edm::ParameterSetDescription muonSelection;
+  muonSelection.add<std::string>("general", "pt > 0");
+  muonSelection.add<std::string>("pt", "");
+  muonSelection.add<std::string>("dxy", "pt > 0");
+  desc.add<edm::ParameterSetDescription>("muonSelection", muonSelection);
+
+  edm::ParameterSetDescription genericTriggerEventPSet;
+  genericTriggerEventPSet.add<bool>("andOr");
+  genericTriggerEventPSet.add<edm::InputTag>("dcsInputTag", edm::InputTag("scalersRawToDigi") );
+  genericTriggerEventPSet.add<std::vector<int> >("dcsPartitions",{});
+  genericTriggerEventPSet.add<bool>("andOrDcs", false);
+  genericTriggerEventPSet.add<bool>("errorReplyDcs", true);
+  genericTriggerEventPSet.add<std::string>("dbLabel","");
+  genericTriggerEventPSet.add<bool>("andOrHlt", true);
+  genericTriggerEventPSet.add<edm::InputTag>("hltInputTag", edm::InputTag("TriggerResults::HLT") );
+  genericTriggerEventPSet.add<std::vector<std::string> >("hltPaths",{});
+  genericTriggerEventPSet.add<std::string>("hltDBKey","");
+  genericTriggerEventPSet.add<bool>("errorReplyHlt",false);
+  genericTriggerEventPSet.add<unsigned int>("verbosityLevel",1);
+
+  desc.add<edm::ParameterSetDescription>("numGenericTriggerEventPSet", genericTriggerEventPSet);
+  desc.add<edm::ParameterSetDescription>("denGenericTriggerEventPSet", genericTriggerEventPSet);
+
+  edm::ParameterSetDescription histoPSet;
+  edm::ParameterSetDescription muonPtPSet;
+  edm::ParameterSetDescription muonEtaPSet;
+  edm::ParameterSetDescription muonPhiPSet;
+  edm::ParameterSetDescription muonDxyPSet;
+  edm::ParameterSetDescription lsPSet;
+  fillHistoPSetDescription(muonPtPSet);
+  fillHistoPSetDescription(muonEtaPSet);
+  fillHistoPSetDescription(muonPhiPSet);
+  fillHistoPSetDescription(muonDxyPSet);
+  fillHistoPSetDescription(lsPSet);
+  histoPSet.add<edm::ParameterSetDescription>("muonPtPSet", muonPtPSet);
+  histoPSet.add<edm::ParameterSetDescription>("muonEtaPSet", muonEtaPSet);
+  histoPSet.add<edm::ParameterSetDescription>("muonPhiPSet", muonPhiPSet);
+  histoPSet.add<edm::ParameterSetDescription>("muonDxyPSet", muonDxyPSet);
+  histoPSet.add<edm::ParameterSetDescription>("lsPSet", lsPSet);
+  std::vector<double> bins = {0.,20.,40.,60.,80.,90.,100.,110.,120.,130.,140.,150.,160.,170.,180.,190.,200.,220.,240.,260.,280.,300.,350.,400.,450.,1000.};
+  histoPSet.add<std::vector<double> >("muonPtBinning", bins);
+
+  desc.add<edm::ParameterSetDescription>("histoPSet",histoPSet);
+
+  descriptions.add("DiDispStaMuonMonitoring", desc);
+}
+
+// Define this as a plug-in
+DEFINE_FWK_MODULE(DiDispStaMuonMonitor);

--- a/DQMOffline/Trigger/plugins/DiDispStaMuonMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiDispStaMuonMonitor.h
@@ -86,6 +86,7 @@ private:
   MEbinning           ls_binning_;
 
   DiDispStaMuonME muonPtME_;
+  DiDispStaMuonME muonPtNoDxyCutME_;
   DiDispStaMuonME muonPtME_variableBinning_;
   DiDispStaMuonME muonPtVsLS_;
   DiDispStaMuonME muonEtaME_;

--- a/DQMOffline/Trigger/plugins/DiDispStaMuonMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiDispStaMuonMonitor.h
@@ -1,0 +1,110 @@
+#ifndef DQMOFFLINE_TRIGGER_DIDISPSTAMUONMONITOR_H
+#define DQMOFFLINE_TRIGGER_DIDISPSTAMUONMONITOR_H
+
+
+#include <string>
+#include <vector>
+#include <map>
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include "DQM/TrackingMonitor/interface/GetLumi.h"
+
+#include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+//DataFormats
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+class GenericTriggerEventFlag;
+
+
+//
+// class declaration
+//
+
+class DiDispStaMuonMonitor : public DQMEDAnalyzer 
+{
+public:
+  DiDispStaMuonMonitor( const edm::ParameterSet& );
+  ~DiDispStaMuonMonitor() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillHistoPSetDescription(edm::ParameterSetDescription & pset);
+  static void fillHistoLSPSetDescription(edm::ParameterSetDescription & pset);
+
+  struct DiDispStaMuonME {
+    MonitorElement* numerator;
+    MonitorElement* denominator;
+  };
+
+protected:
+
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void bookME(DQMStore::IBooker &, DiDispStaMuonME& me, const std::string& histname, const std::string& histtitle, int nbins, double xmin, double xmax);
+  void bookME(DQMStore::IBooker &, DiDispStaMuonME& me, const std::string& histname, const std::string& histtitle, const std::vector<double>& binningX);
+  void bookME(DQMStore::IBooker &, DiDispStaMuonME& me, const std::string& histname, const std::string& histtitle, int nbinsX, double xmin, double xmax, double ymin, double ymax, bool bookDen);
+  void bookME(DQMStore::IBooker &, DiDispStaMuonME& me, const std::string& histname, const std::string& histtitle, int nbinsX, double xmin, double xmax, int nbinsY, double ymin, double ymax);
+  void bookME(DQMStore::IBooker &, DiDispStaMuonME& me, const std::string& histname, const std::string& histtitle, const std::vector<double>& binningX, const std::vector<double>& binningY);
+  void setTitle(DiDispStaMuonME& me, const std::string& titleX, const std::string& titleY, bool bookDen);
+
+  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
+
+private:  
+  struct MEbinning {
+    unsigned int nbins;
+    double xmin;
+    double xmax;
+  };
+
+  static MEbinning getHistoPSet    (const edm::ParameterSet & pset);
+  static MEbinning getHistoLSPSet  (const edm::ParameterSet & pset);
+
+  std::string folderName_;
+  std::string histoSuffix_;
+
+  edm::EDGetTokenT<reco::TrackCollection>        muonToken_;
+
+  std::vector<double> muonPt_variable_binning_;
+  MEbinning           muonPt_binning_;
+  MEbinning           muonEta_binning_;
+  MEbinning           muonPhi_binning_;
+  MEbinning           muonDxy_binning_;
+  MEbinning           ls_binning_;
+
+  DiDispStaMuonME muonPtME_;
+  DiDispStaMuonME muonPtME_variableBinning_;
+  DiDispStaMuonME muonPtVsLS_;
+  DiDispStaMuonME muonEtaME_;
+  DiDispStaMuonME muonPhiME_;
+  DiDispStaMuonME muonDxyME_;
+  DiDispStaMuonME subMuonPtME_;
+  DiDispStaMuonME subMuonPtME_variableBinning_;
+  DiDispStaMuonME subMuonEtaME_;
+  DiDispStaMuonME subMuonPhiME_;
+  DiDispStaMuonME subMuonDxyME_;
+
+  std::unique_ptr<GenericTriggerEventFlag> num_genTriggerEventFlag_;
+  std::unique_ptr<GenericTriggerEventFlag> den_genTriggerEventFlag_;
+
+  StringCutObjectSelector<reco::Track,true>        muonSelectionGeneral_;
+  StringCutObjectSelector<reco::Track,true>        muonSelectionPt_;
+  StringCutObjectSelector<reco::Track,true>        muonSelectionDxy_;
+  unsigned int nmuons_;
+
+};
+
+#endif //DQMOFFLINE_TRIGGER_DIDISPSTAMUONMONITOR_H

--- a/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cff.py
@@ -11,12 +11,10 @@ hltDiDispStaMuonCosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstri
 hltDispStaMuon23Monitoring = hltDiDispStaMuonMonitoring.clone()
 hltDispStaMuon23Monitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/singlePpSeed23/')
 hltDispStaMuon23Monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_L2Mu23NoVtx_2Cha_v*") #HLT_ZeroBias_v*
-hltDispStaMuon23Monitoring.nmuons = cms.uint32(1)
 
 hltDispStaMuon23CosmicMonitoring = hltDiDispStaMuonMonitoring.clone()
 hltDispStaMuon23CosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/singleCosmicSeed23/')
 hltDispStaMuon23CosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_L2Mu23NoVtx_2Cha_CosmicSeed_v*") #HLT_ZeroBias_v*
-hltDispStaMuon23CosmicMonitoring.nmuons = cms.uint32(1)
 
 ## Backup trigger
 hltDiDispStaMuon25Monitoring = hltDiDispStaMuonMonitoring.clone()

--- a/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cff.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.DiDispStaMuonMonitor_cfi import hltDiDispStaMuonMonitoring
+
+
+hltDiDispStaMuonCosmicMonitoring = hltDiDispStaMuonMonitoring.clone()
+hltDiDispStaMuonCosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/cosmicSeed/')
+hltDiDispStaMuonCosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v*") #HLT_ZeroBias_v*
+
+## Efficiency trigger
+hltDispStaMuon23Monitoring = hltDiDispStaMuonMonitoring.clone()
+hltDispStaMuon23Monitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/singlePpSeed23/')
+hltDispStaMuon23Monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_L2Mu23NoVtx_2Cha_v*") #HLT_ZeroBias_v*
+hltDispStaMuon23Monitoring.nmuons = cms.uint32(1)
+
+hltDispStaMuon23CosmicMonitoring = hltDiDispStaMuonMonitoring.clone()
+hltDispStaMuon23CosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/singleCosmicSeed23/')
+hltDispStaMuon23CosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_L2Mu23NoVtx_2Cha_CosmicSeed_v*") #HLT_ZeroBias_v*
+hltDispStaMuon23CosmicMonitoring.nmuons = cms.uint32(1)
+
+## Backup trigger
+hltDiDispStaMuon25Monitoring = hltDiDispStaMuonMonitoring.clone()
+hltDiDispStaMuon25Monitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/ppSeed25/')
+hltDiDispStaMuon25Monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu25NoVtx_2Cha_v*") #HLT_ZeroBias_v*
+
+hltDiDispStaMuon25CosmicMonitoring = hltDiDispStaMuonMonitoring.clone()
+hltDiDispStaMuon25CosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/cosmicSeed25/')
+hltDiDispStaMuon25CosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu25NoVtx_2Cha_CosmicSeed_v*") #HLT_ZeroBias_v*
+
+hltDiDispStaMuon30Monitoring = hltDiDispStaMuonMonitoring.clone()
+hltDiDispStaMuon30Monitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/ppSeed30Eta2p4/')
+hltDiDispStaMuon30Monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu30NoVtx_2Cha_Eta2p4_v*") #HLT_ZeroBias_v*
+
+hltDiDispStaMuon30CosmicMonitoring = hltDiDispStaMuonMonitoring.clone()
+hltDiDispStaMuon30CosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/cosmicSeed30Eta2p4/')
+hltDiDispStaMuon30CosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu30NoVtx_2Cha_CosmicSeed_Eta2p4_v*") #HLT_ZeroBias_v*
+
+
+exoHLTdispStaMuonMonitoring = cms.Sequence(
+    hltDiDispStaMuonMonitoring
+    + hltDiDispStaMuonCosmicMonitoring
+    + hltDispStaMuon23Monitoring
+    + hltDispStaMuon23CosmicMonitoring
+    + hltDiDispStaMuon25Monitoring
+    + hltDiDispStaMuon25CosmicMonitoring
+    + hltDiDispStaMuon30Monitoring
+    + hltDiDispStaMuon30CosmicMonitoring
+)

--- a/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cff.py
@@ -4,33 +4,33 @@ from DQMOffline.Trigger.DiDispStaMuonMonitor_cfi import hltDiDispStaMuonMonitori
 
 
 hltDiDispStaMuonCosmicMonitoring = hltDiDispStaMuonMonitoring.clone()
-hltDiDispStaMuonCosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/cosmicSeed/')
+hltDiDispStaMuonCosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/DoubleL2Mu23NoVtx_2Cha_CosmicSeed/')
 hltDiDispStaMuonCosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v*") #HLT_ZeroBias_v*
 
 ## Efficiency trigger
 hltDispStaMuon23Monitoring = hltDiDispStaMuonMonitoring.clone()
-hltDispStaMuon23Monitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/singlePpSeed23/')
+hltDispStaMuon23Monitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/L2Mu23NoVtx_2Cha/')
 hltDispStaMuon23Monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_L2Mu23NoVtx_2Cha_v*") #HLT_ZeroBias_v*
 
 hltDispStaMuon23CosmicMonitoring = hltDiDispStaMuonMonitoring.clone()
-hltDispStaMuon23CosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/singleCosmicSeed23/')
+hltDispStaMuon23CosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/L2Mu23NoVtx_2Cha_CosmicSeed/')
 hltDispStaMuon23CosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_L2Mu23NoVtx_2Cha_CosmicSeed_v*") #HLT_ZeroBias_v*
 
 ## Backup trigger
 hltDiDispStaMuon25Monitoring = hltDiDispStaMuonMonitoring.clone()
-hltDiDispStaMuon25Monitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/ppSeed25/')
+hltDiDispStaMuon25Monitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/DoubleL2Mu25NoVtx_2Cha/')
 hltDiDispStaMuon25Monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu25NoVtx_2Cha_v*") #HLT_ZeroBias_v*
 
 hltDiDispStaMuon25CosmicMonitoring = hltDiDispStaMuonMonitoring.clone()
-hltDiDispStaMuon25CosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/cosmicSeed25/')
+hltDiDispStaMuon25CosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/DoubleL2Mu25NoVtx_2Cha_CosmicSeed/')
 hltDiDispStaMuon25CosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu25NoVtx_2Cha_CosmicSeed_v*") #HLT_ZeroBias_v*
 
 hltDiDispStaMuon30Monitoring = hltDiDispStaMuonMonitoring.clone()
-hltDiDispStaMuon30Monitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/ppSeed30Eta2p4/')
+hltDiDispStaMuon30Monitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/DoubleL2Mu30NoVtx_2Cha_Eta2p4/')
 hltDiDispStaMuon30Monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu30NoVtx_2Cha_Eta2p4_v*") #HLT_ZeroBias_v*
 
 hltDiDispStaMuon30CosmicMonitoring = hltDiDispStaMuonMonitoring.clone()
-hltDiDispStaMuon30CosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/cosmicSeed30Eta2p4/')
+hltDiDispStaMuon30CosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/DoubleL2Mu30NoVtx_2Cha_CosmicSeed_Eta2p4/')
 hltDiDispStaMuon30CosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu30NoVtx_2Cha_CosmicSeed_Eta2p4_v*") #HLT_ZeroBias_v*
 
 

--- a/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cfi.py
@@ -34,24 +34,24 @@ hltDiDispStaMuonMonitoring.muons     = cms.InputTag("displacedStandAloneMuons")
 hltDiDispStaMuonMonitoring.nmuons     = cms.uint32(2)
 
 hltDiDispStaMuonMonitoring.muonSelection = cms.PSet(
-    general = cms.string("hitPattern.muonStationsWithValidHits() > 1"),
+    general = cms.string("hitPattern.numberOfValidMuonHits > 16 && pt > 0 && normalizedChi2 < 10 "),
+    #general = cms.string("hitPattern.muonStationsWithValidHits > 1 && pt > 5 && normalizedChi2 < 10"),
     pt      = cms.string("pt > 2 "),
-    dxy     = cms.string("dxy > 5"),
+    dxy     = cms.string("dxy > 5 "),
     )
 
 hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
 #hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("ExoDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !                                                                                                           
 hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND 
-hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::reHLT" )
+hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
 hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_v*") # HLT_ZeroBias_v*
 hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
 
 hltDiDispStaMuonMonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
+hltDiDispStaMuonMonitoring.denGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND 
 hltDiDispStaMuonMonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
 hltDiDispStaMuonMonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
 hltDiDispStaMuonMonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
 hltDiDispStaMuonMonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
 hltDiDispStaMuonMonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
-
-#hltDiDispStaMuonMonitoring.muonSelection = cms.string("hitPattern.muonStationsWithValidHits() > 1")

--- a/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cfi.py
@@ -26,8 +26,8 @@ hltDiDispStaMuonMonitoring.histoPSet.muonPhiPSet = cms.PSet(
     )
 hltDiDispStaMuonMonitoring.histoPSet.muonDxyPSet = cms.PSet(
     nbins = cms.uint32(50),
-    xmin  = cms.double(-50.),
-    xmax  = cms.double(50.),
+    xmin  = cms.double(-120.),
+    xmax  = cms.double(120.),
     )
 
 hltDiDispStaMuonMonitoring.muons     = cms.InputTag("displacedStandAloneMuons")
@@ -35,8 +35,8 @@ hltDiDispStaMuonMonitoring.nmuons     = cms.uint32(2)
 
 hltDiDispStaMuonMonitoring.muonSelection = cms.PSet(
     general = cms.string("hitPattern.muonStationsWithValidHits() > 1"),
-    pt      = cms.string("pt() > 2 && pt() < 200"),
-    dxy     = cms.string("dxy() > 5"),
+    pt      = cms.string("pt > 2 "),
+    dxy     = cms.string("dxy > 5"),
     )
 
 hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )

--- a/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cfi.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.DiDispStaMuonMonitoring_cfi import DiDispStaMuonMonitoring
+
+hltDiDispStaMuonMonitoring = DiDispStaMuonMonitoring.clone()
+hltDiDispStaMuonMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/ppSeed/')
+hltDiDispStaMuonMonitoring.histoPSet.lsPSet = cms.PSet(
+  nbins = cms.uint32 ( 250 ),
+  xmin  = cms.double(    0.),
+  xmax  = cms.double( 2500.),
+)
+hltDiDispStaMuonMonitoring.histoPSet.muonPtPSet = cms.PSet(
+    nbins = cms.uint32(100),
+    xmin  = cms.double(-0.5),
+    xmax  = cms.double(999.5),
+    )
+hltDiDispStaMuonMonitoring.histoPSet.muonEtaPSet = cms.PSet(
+    nbins = cms.uint32(100),
+    xmin  = cms.double(-5.),
+    xmax  = cms.double(5.),
+    )
+hltDiDispStaMuonMonitoring.histoPSet.muonPhiPSet = cms.PSet(
+    nbins = cms.uint32(64),
+    xmin  = cms.double(-3.2),
+    xmax  = cms.double(3.2),
+    )
+hltDiDispStaMuonMonitoring.histoPSet.muonDxyPSet = cms.PSet(
+    nbins = cms.uint32(50),
+    xmin  = cms.double(-50.),
+    xmax  = cms.double(50.),
+    )
+
+hltDiDispStaMuonMonitoring.muons     = cms.InputTag("displacedStandAloneMuons")
+hltDiDispStaMuonMonitoring.nmuons     = cms.uint32(2)
+
+hltDiDispStaMuonMonitoring.muonSelection = cms.PSet(
+    general = cms.string("hitPattern.muonStationsWithValidHits() > 1"),
+    pt      = cms.string("pt() > 2 && pt() < 200"),
+    dxy     = cms.string("dxy() > 5"),
+    )
+
+hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
+#hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("ExoDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !                                                                                                           
+hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND 
+hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
+hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_v*") # HLT_ZeroBias_v*
+hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
+hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+
+hltDiDispStaMuonMonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
+hltDiDispStaMuonMonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
+hltDiDispStaMuonMonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
+hltDiDispStaMuonMonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
+hltDiDispStaMuonMonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
+hltDiDispStaMuonMonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+
+#hltDiDispStaMuonMonitoring.muonSelection = cms.string("hitPattern.muonStationsWithValidHits() > 1")

--- a/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cfi.py
@@ -3,31 +3,31 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.DiDispStaMuonMonitoring_cfi import DiDispStaMuonMonitoring
 
 hltDiDispStaMuonMonitoring = DiDispStaMuonMonitoring.clone()
-hltDiDispStaMuonMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/ppSeed/')
+hltDiDispStaMuonMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/DoubleL2Mu23NoVtx_2Cha/')
 hltDiDispStaMuonMonitoring.histoPSet.lsPSet = cms.PSet(
   nbins = cms.uint32 ( 250 ),
   xmin  = cms.double(    0.),
   xmax  = cms.double( 2500.),
 )
 hltDiDispStaMuonMonitoring.histoPSet.muonPtPSet = cms.PSet(
-    nbins = cms.uint32(100),
+    nbins = cms.uint32(25),
     xmin  = cms.double(-0.5),
-    xmax  = cms.double(999.5),
+    xmax  = cms.double(99.5),
     )
 hltDiDispStaMuonMonitoring.histoPSet.muonEtaPSet = cms.PSet(
-    nbins = cms.uint32(100),
-    xmin  = cms.double(-5.),
-    xmax  = cms.double(5.),
+    nbins = cms.uint32(24),
+    xmin  = cms.double(-2.4),
+    xmax  = cms.double(2.4),
     )
 hltDiDispStaMuonMonitoring.histoPSet.muonPhiPSet = cms.PSet(
-    nbins = cms.uint32(64),
+    nbins = cms.uint32(24),
     xmin  = cms.double(-3.2),
     xmax  = cms.double(3.2),
     )
 hltDiDispStaMuonMonitoring.histoPSet.muonDxyPSet = cms.PSet(
-    nbins = cms.uint32(50),
-    xmin  = cms.double(-120.),
-    xmax  = cms.double(120.),
+    nbins = cms.uint32(25),
+    xmin  = cms.double(-60.),
+    xmax  = cms.double(60.),
     )
 
 hltDiDispStaMuonMonitoring.muons     = cms.InputTag("displacedStandAloneMuons")
@@ -42,7 +42,7 @@ hltDiDispStaMuonMonitoring.muonSelection = cms.PSet(
 hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
 #hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("ExoDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !                                                                                                           
 hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND 
-hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
+hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::reHLT" )
 hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_v*") # HLT_ZeroBias_v*
 hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
 hltDiDispStaMuonMonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)

--- a/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
@@ -220,6 +220,7 @@ DisplacedJet_jetRatioHemHep17 = DQMEDHarvester("DQMGenericClient",
 
 exoticaClient = cms.Sequence(
     NoBPTXEfficiency
+  + DiDispStaMuonEfficiency
   + photonEfficiency
   + photonVBF_jetMETEfficiency
   + DisplacedJet_htEfficiency

--- a/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
@@ -78,6 +78,7 @@ DiDispStaMuonEfficiency = DQMEDHarvester("DQMGenericClient",
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
         "effic_muonPt          'Muon pt turnON; DisplacedStandAlone Muon p_{T} [GeV]; Efficiency'     muonPt_numerator          muonPt_denominator",
+        "effic_muonPtNoDxyCut  'Muon pt turnON; DisplacedStandAlone Muon p_{T} [GeV]; Efficiency'     muonPtNoDxyCut_numerator  muonPtNoDxyCut_denominator",
         "effic_muonPt_variable 'Muon pt turnON; DisplacedStandAlone Muon p_{T} [GeV]; Efficiency'     muonPt_variable_numerator muonPt_variable_denominator",
         "effic_muonEta          'Muon eta eff; DisplacedStandAlone Muon #eta; Efficiency'     muonEta_numerator          muonEta_denominator",
         "effic_muonPhi          'Muon phi eff; DisplacedStandAlone Muon #phi; Efficiency'     muonPhi_numerator          muonPhi_denominator",

--- a/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
@@ -72,6 +72,23 @@ NoBPTXEfficiency = DQMEDHarvester("DQMGenericClient",
     ),
 )
 
+DiDispStaMuonEfficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/EXO/DiDispStaMuon/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_muonPt          'Muon pt turnON; DisplacedStandAlone Muon p_{T} [GeV]; Efficiency'     muonPt_numerator          muonPt_denominator",
+        "effic_muonPt_variable 'Muon pt turnON; DisplacedStandAlone Muon p_{T} [GeV]; Efficiency'     muonPt_variable_numerator muonPt_variable_denominator",
+        "effic_muonEta          'Muon eta eff; DisplacedStandAlone Muon #eta; Efficiency'     muonEta_numerator          muonEta_denominator",
+        "effic_muonPhi          'Muon phi eff; DisplacedStandAlone Muon #phi; Efficiency'     muonPhi_numerator          muonPhi_denominator",
+        "effic_muonDxy          'Muon dxy eff; DisplacedStandAlone Muon #dxy; Efficiency'     muonDxy_numerator          muonDxy_denominator",
+    ),
+    efficiencyProfile = cms.untracked.vstring(
+        "effic_muon_vs_LS 'Muon pt efficiency vs LS; LS; Muon p_{T} Efficiency' muonVsLS_numerator muonVsLS_denominator",
+    ),
+)
+
+
 METplusTrackEfficiency = DQMEDHarvester("DQMGenericClient",
     subDirs = cms.untracked.vstring("HLT/EXO/MET/MET105_IsoTrk50/", "HLT/EXO/MET/MET120_IsoTrk50/"),
     verbose = cms.untracked.uint32(0), # Set to 2 for all messages

--- a/DQMOffline/Trigger/python/ExoticaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_cff.py
@@ -7,10 +7,12 @@ from DQMOffline.Trigger.HTMonitor_cff import *
 from DQMOffline.Trigger.METplusTrackMonitor_cff import *
 from DQMOffline.Trigger.MuonMonitor_cff import *
 from DQMOffline.Trigger.DisplacedJet_Monitor_cff import *
+from DQMOffline.Trigger.DiDispStaMuonMonitor_cff import *
 
 exoticaMonitorHLT = cms.Sequence(
     exoHLTMETmonitoring
   + exoHLTNoBPTXmonitoring
+  + exoHLTdispStaMuonMonitoring
 )
 
 


### PR DESCRIPTION
This is a DQM for EXO Double L2 muon trigger reported in JIRA:
https://its.cern.ch/jira/browse/CMSHLT-1727

It's monitoring on **displacedStandAlone** collections instead of **muons**, which serves better for this trigger.

It's monitoring on leading muon's pt(w/ and w/o dxy cut), ptVSLs, pt_variable, eta, phi, dxy,
and subleading muon's pt (w/ dxy cut), pt_variable, eta, phi, dxy.

It's also creating efficiency plots on leading muon's monitorables with DQMEDHarvester.