### PR TITLE
HLT DQM online fix

### DIFF
--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -22,6 +22,12 @@ process.dqmSaver.tag = 'HLT'
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.GlobalTrackingGeometryESProducer = cms.ESProducer( "GlobalTrackingGeometryESProducer" ) # for muon hlt dqm
+process.ClusterShapeHitFilterESProducer = cms.ESProducer( "ClusterShapeHitFilterESProducer",
+    ComponentName = cms.string( "ClusterShapeHitFilter" ),
+    PixelShapeFileL1 = cms.string( "RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase1_loose.par" ),
+    clusterChargeCut = cms.PSet(  refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
+    PixelShapeFile = cms.string( "RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase1_noL1.par" )
+)
 #SiStrip Local Reco
 process.load("CalibTracker.SiStripCommon.TkDetMap_cff")
 

--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -22,6 +22,7 @@ process.dqmSaver.tag = 'HLT'
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.GlobalTrackingGeometryESProducer = cms.ESProducer( "GlobalTrackingGeometryESProducer" ) # for muon hlt dqm
+process.HLTSiStripClusterChargeCutNone = cms.PSet(  value = cms.double( -1.0 ) )
 process.ClusterShapeHitFilterESProducer = cms.ESProducer( "ClusterShapeHitFilterESProducer",
     ComponentName = cms.string( "ClusterShapeHitFilter" ),
     PixelShapeFileL1 = cms.string( "RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase1_loose.par" ),


### PR DESCRIPTION
This should fix the HLT DQM online error:

More details about the bug as  reported in @threus 's e-mail:
{code}
----- Begin Fatal Exception 08-Apr-2018 06:07:27 CEST-----------------------
An exception of category 'NoProxyException' occurred while
   [0] Processing  Event run: 313555 lumi: 10 event: 162318 stream: 0
   [1] Running path 'hlt4vector'
   [2] Calling method for module SiPixelPhase1TrackClusters/'hltSiPixelPhase1TrackClustersAnalyzer'
Exception Message:
No data of type "ClusterShapeHitFilter" with label "ClusterShapeHitFilter" in record "CkfComponentsRecord"
 Please add an ESSource or ESProducer to your job which can deliver this data.
----- End Fatal Exception -------------------------------------------------
{code}

The full log file can be found on DQM^2 (needs tunnel to p5 network):
http://fu-c2f11-15-01:9215/utils/show_log/dqm-source-state-run503533-hostfu-c2f11-15-01-pid057210

The DQM^2 is a monitoring tool for online DQM, including streams and DQM subsystem clients (also needs tunnel to p5):
http://fu-c2f11-11-01.cms:9215/static/index.html

From there, click on the blue fu-xxx button, in the dropdown menu click enable on playback_c2f11, then at the bottom of the page click the show button of Known cmssw jobs. One of them is “hlt”, in red. When you hover the mouse over it, at the far right is the “full log” button, which brings you to the exact same log as the first link above.

101X backport: #22902