### PR TITLE
remove eventAutoFlushCompressedSize in eventdisplay

### DIFF
--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -74,7 +74,6 @@ del process._Process__outputmodules["FEVToutput"]
 
 process.FEVToutput = cms.OutputModule("JsonWritingTimeoutPoolOutputModule",
     splitLevel = oldo.splitLevel,
-    eventAutoFlushCompressedSize = oldo.eventAutoFlushCompressedSize,
     outputCommands = oldo.outputCommands,
     fileName = oldo.fileName,
     dataset = oldo.dataset,

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -74,7 +74,6 @@ del process._Process__outputmodules["FEVToutput"]
 
 process.FEVToutput = cms.OutputModule("JsonWritingTimeoutPoolOutputModule",
     splitLevel = oldo.splitLevel,
-    eventAutoFlushCompressedSize = oldo.eventAutoFlushCompressedSize,
     outputCommands = oldo.outputCommands,
     fileName = oldo.fileName,
     dataset = oldo.dataset,


### PR DESCRIPTION
removes eventAutoFlushCompressedSize in eventdisplay DQM client which causes crash