### PR TITLE
EMTF unpacker bug-fix for Cosmics RelVals failure

### DIFF
--- a/EventFilter/L1TRawToDigi/interface/Unpacker.h
+++ b/EventFilter/L1TRawToDigi/interface/Unpacker.h
@@ -12,6 +12,13 @@ namespace l1t {
       public:
          virtual bool unpack(const Block& block, UnpackerCollections *coll) = 0;
          virtual ~Unpacker() = default;
+      
+         // Modeled on plugins/implementations_stage2/MuonUnpacker.h
+         inline unsigned int getAlgoVersion() { return algoVersion_; };
+         inline void setAlgoVersion(const unsigned int version) { algoVersion_ = version; };
+      
+      private:
+         unsigned int algoVersion_;
    };
 }
 

--- a/EventFilter/L1TRawToDigi/interface/Unpacker.h
+++ b/EventFilter/L1TRawToDigi/interface/Unpacker.h
@@ -10,8 +10,10 @@ namespace l1t {
 
    class Unpacker {
       public:
-         virtual bool unpack(const Block& block, UnpackerCollections *coll) = 0;
+         Unpacker() : algoVersion_(0) {};
          virtual ~Unpacker() = default;
+         virtual bool unpack(const Block& block, UnpackerCollections *coll) = 0;
+
       
          // Modeled on plugins/implementations_stage2/MuonUnpacker.h
          inline unsigned int getAlgoVersion() { return algoVersion_; };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
@@ -65,15 +65,17 @@ namespace l1t {
       }
 
       // Converts station, CSC_ID, sector, subsector, and neighbor from the ME output
-      std::vector<int> convert_ME_location(int _station, int _csc_ID, int _sector) {
+      std::vector<int> convert_ME_location(int _station, int _csc_ID, int _sector, bool _csc_ID_shift = false) {
 	int new_sector = _sector;
-	int new_csc_ID = _csc_ID; // Before FW update on 05.05.16, shift by +1 from 0,1,2... convention to 1,2,3...
+	int new_csc_ID = _csc_ID;
+	if (_csc_ID_shift) new_csc_ID += 1; // Before FW update on 05.05.16, shift by +1 from 0,1,2... convention to 1,2,3...
 	if      (_station == 0) { int arr[] = {       1, new_csc_ID, new_sector,  1, 0}; std::vector<int> vec(arr, arr+5); return vec; }
 	else if (_station == 1) { int arr[] = {       1, new_csc_ID, new_sector,  2, 0}; std::vector<int> vec(arr, arr+5); return vec; }
 	else if (_station <= 4) { int arr[] = {_station, new_csc_ID, new_sector, -1, 0}; std::vector<int> vec(arr, arr+5); return vec; }
-	else if (_station == 5) new_sector = (_sector != 1) ? _sector-1 : 6;
+	else if (_station == 5) new_sector = (_sector != 1) ? _sector-1 : 6; // Indicates neighbor chamber, don't return yet
 	else { int arr[] = {_station, _csc_ID, _sector, -99, -99}; std::vector<int> vec(arr, arr+5); return vec; }
 	
+	// Mapping for chambers from neighboring sector
 	if      (new_csc_ID == 1) { int arr[] = {1, 3, new_sector,  2, 1}; std::vector<int> vec(arr, arr+5); return vec; }
 	else if (new_csc_ID == 2) { int arr[] = {1, 6, new_sector,  2, 1}; std::vector<int> vec(arr, arr+5); return vec; }
 	else if (new_csc_ID == 3) { int arr[] = {1, 9, new_sector,  2, 1}; std::vector<int> vec(arr, arr+5); return vec; }
@@ -150,13 +152,22 @@ namespace l1t {
 	// ME_.set_dataword     ( uint64_t dataword);
 
 	// Convert specially-encoded ME quantities
-	std::vector<int> conv_vals = convert_ME_location( ME_.Station(), ME_.CSC_ID(), 
-							  (res->at(iOut)).PtrEventHeader()->Sector() );
+	bool csc_ID_shift = (getAlgoVersion() <= 8348); // For FW versions <= 28.04.2016, shift by +1 from 0,1,2... convention to 1,2,3...
+							// Computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
+	std::vector<int> conv_vals = convert_ME_location( ME_.Station(), ME_.CSC_ID(), (res->at(iOut)).PtrEventHeader()->Sector(), csc_ID_shift );
+
 	Hit_.set_station   ( conv_vals.at(0) );
 	Hit_.set_csc_ID    ( conv_vals.at(1) );
 	Hit_.set_sector    ( conv_vals.at(2) );
 	Hit_.set_subsector ( conv_vals.at(3) );
 	Hit_.set_neighbor  ( conv_vals.at(4) );
+	      
+       if (Hit_.Station() < 1 || Hit_.Station() > 4) edm::LogWarning("L1T|EMTF") << "EMTF unpacked LCT station = " << Hit_.Station()
+                                                                                 << ", outside proper [1, 4] range" << std::endl;
+       if (Hit_.CSC_ID()  < 1 || Hit_.CSC_ID()  > 9) edm::LogWarning("L1T|EMTF") << "EMTF unpacked LCT CSC ID = " << Hit_.CSC_ID()
+                                                                                 << ", outside proper [1, 9] range" << std::endl;
+       if (Hit_.Sector()  < 1 || Hit_.Sector()  > 6) edm::LogWarning("L1T|EMTF") << "EMTF unpacked LCT sector = " << Hit_.Sector()
+                                                                                 << ", outside proper [1, 6] range" << std::endl;
 
 	// Fill the EMTFHit
 	ImportME( Hit_, ME_, (res->at(iOut)).PtrEventHeader()->Endcap(), (res->at(iOut)).PtrEventHeader()->Sector() );

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
@@ -68,11 +68,13 @@ namespace l1t {
 
          auto emtf_headers_unp   = UnpackerFactory::get()->make("stage2::emtf::HeadersBlockUnpacker");  // Unpack "AMC data header" and "Event Record Header"
          auto emtf_counters_unp  = UnpackerFactory::get()->make("stage2::emtf::CountersBlockUnpacker"); // Unpack "Block of Counters"
-         auto emtf_me_unp       = UnpackerFactory::get()->make("stage2::emtf::MEBlockUnpacker");      // Unpack "ME Data Record"
-         auto emtf_rpc_unp      = UnpackerFactory::get()->make("stage2::emtf::RPCBlockUnpacker");     // // Unpack "RPC Data Record"
-         auto emtf_sp_unp       = UnpackerFactory::get()->make("stage2::emtf::SPBlockUnpacker");      // Unpack "SP Output Data Record"
+         auto emtf_me_unp       = UnpackerFactory::get()->make("stage2::emtf::MEBlockUnpacker");        // Unpack "ME Data Record"
+         auto emtf_rpc_unp      = UnpackerFactory::get()->make("stage2::emtf::RPCBlockUnpacker");       // Unpack "RPC Data Record"
+         auto emtf_sp_unp       = UnpackerFactory::get()->make("stage2::emtf::SPBlockUnpacker");        // Unpack "SP Output Data Record"
          auto emtf_trailers_unp  = UnpackerFactory::get()->make("stage2::emtf::TrailersBlockUnpacker"); // Unpack "Event Record Trailer"
 
+         emtf_me_unp->setAlgoVersion(fw); // Currently only the CSC LCT unpacking needs the firmware version, can add others as needed - AWB 09.04.18
+         
          // Index of res is block->header().getID(), matching block_patterns_ in src/Block.cc
          res[511] = emtf_headers_unp;
          res[2]   = emtf_counters_unp;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.cc
@@ -9,7 +9,7 @@
 
 namespace l1t {
    namespace stage2 {
-      IntermediateMuonUnpacker::IntermediateMuonUnpacker() : res1_(nullptr), res2_(nullptr), algoVersion_(0), coll1Cnt_(0)
+      IntermediateMuonUnpacker::IntermediateMuonUnpacker() : res1_(nullptr), res2_(nullptr), coll1Cnt_(0)
       {
       }
 
@@ -126,7 +126,7 @@ namespace l1t {
                // The intermediate muons of the uGMT (FED number 1402) do not
                // have coordinates estimated at the vertex in the RAW data.
                // The corresponding bits are set to zero.
-               MuonRawDigiTranslator::fillMuon(mu, raw_data_00_31, raw_data_32_63, 1402, algoVersion_);
+               MuonRawDigiTranslator::fillMuon(mu, raw_data_00_31, raw_data_32_63, 1402, getAlgoVersion());
 
                LogDebug("L1T") << "Mu" << nWord/2 << ": eta " << mu.hwEta() << " phi " << mu.hwPhi() << " pT " << mu.hwPt() << " iso " << mu.hwIso() << " qual " << mu.hwQual() << " charge " << mu.hwCharge() << " charge valid " << mu.hwChargeValid();
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.h
@@ -12,16 +12,12 @@ namespace l1t {
 
             bool unpack(const Block& block, UnpackerCollections *coll) override;
 
-            inline unsigned int getAlgoVersion() { return algoVersion_; };
-            inline void setAlgoVersion(const unsigned int version) { algoVersion_ = version; };
-
          private:
             static constexpr unsigned nWords_ = 6; // every link transmits 6 words (3 muons) per bx
             static constexpr unsigned bxzs_enable_shift_ = 1;
 
             MuonBxCollection* res1_;
             MuonBxCollection* res2_;
-            unsigned int algoVersion_;
             unsigned int coll1Cnt_;
 
             void unpackBx(int bx, const std::vector<uint32_t>& payload, unsigned int startIdx=0);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -9,7 +9,7 @@
 
 namespace l1t {
    namespace stage2 {
-      MuonUnpacker::MuonUnpacker() : res_(nullptr), algoVersion_(0), muonCopy_(0)
+      MuonUnpacker::MuonUnpacker() : res_(nullptr), muonCopy_(0)
       {
       }
 
@@ -74,7 +74,7 @@ namespace l1t {
 
                Muon mu;
                    
-               MuonRawDigiTranslator::fillMuon(mu, raw_data_00_31, raw_data_32_63, fed_, algoVersion_);
+               MuonRawDigiTranslator::fillMuon(mu, raw_data_00_31, raw_data_32_63, fed_, getAlgoVersion());
 
                LogDebug("L1T") << "Mu" << nWord/2 << ": eta " << mu.hwEta() << " phi " << mu.hwPhi() << " pT " << mu.hwPt() << " iso " << mu.hwIso() << " qual " << mu.hwQual() << " charge " << mu.hwCharge() << " charge valid " << mu.hwChargeValid();
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
@@ -14,11 +14,9 @@ namespace l1t {
 
             bool unpack(const Block& block, UnpackerCollections *coll) override;
 
-            inline unsigned int getAlgoVersion() { return algoVersion_; };
             inline int getFedNumber() { return fed_; };
             inline unsigned int getMuonCopy() { return muonCopy_; };
 
-            inline void setAlgoVersion(const unsigned int version) { algoVersion_ = version; };
             inline void setFedNumber(const int fed) { fed_ = fed; };
             inline void setMuonCopy(const unsigned int copy) { muonCopy_ = copy; };
 
@@ -27,7 +25,6 @@ namespace l1t {
             static constexpr unsigned bxzs_enable_shift_ = 1;
 
             MuonBxCollection* res_;
-            unsigned int algoVersion_;
             int fed_;
             unsigned int muonCopy_;
 

--- a/EventFilter/L1TRawToDigi/src/Block.cc
+++ b/EventFilter/L1TRawToDigi/src/Block.cc
@@ -130,7 +130,7 @@ namespace l1t {
     if (end16 - data16 < header_size + counter_size + trailer_size) {
       edm::LogError("L1T") << "MTF7 payload smaller than allowed!";
       data_ = end_;
-    } else if (
+    } else if ( // Check bits for EMTF Event Record Header
 	       ((data16[0] >> 12) != 0x9) || ((data16[1] >> 12) != 0x9) ||
 	       ((data16[2] >> 12) != 0x9) || ((data16[3] >> 12) != 0x9) ||
 	       ((data16[4] >> 12) != 0xA) || ((data16[5] >> 12) != 0xA) ||
@@ -139,15 +139,31 @@ namespace l1t {
 	       ((data16[10] >> 11) != 0) || ((data16[11] >> 11) != 0)) {
          edm::LogError("L1T") << "MTF7 payload has invalid header!";
          data_ = end_;
-    } else if (
+    } else if ( // Check bits for EMTF MPC Link Errors
 	       ((data16[12] >> 15) != 0) || ((data16[13] >> 15) != 1) ||
 	       ((data16[14] >> 15) != 0) || ((data16[15] >> 15) != 0)) {
       edm::LogError("L1T") << "MTF7 payload has invalid counter block!";
       data_ = end_;
-    } else if (
-	       false) {
-      // TODO: check trailer
     }
+
+    // Check bits for EMTF Event Record Trailer, get firmware version
+    algo_ = 0; // Firmware version
+    for (int i = 4; i < 1590; i++) { // Start after Counters block, up to 108 ME / 84 RPC / 3 SP blocks per BX, 8 BX
+      if ( ((data16[4*i+0] >> 12) == 0xF) && ((data16[4*i+1] >> 12) == 0xF) &&
+          ((data16[4*i+2] >> 12) == 0xF) && ((data16[4*i+3] >> 12) == 0xF) &&
+          ((data16[4*i+4] >> 12) == 0xE) && ((data16[4*i+5] >> 12) == 0xE) &&
+          ((data16[4*i+6] >> 12) == 0xE) && ((data16[4*i+7] >> 12) == 0xE) ) { // Indicators for the Trailer block
+       algo_  = (((data16[4*i+2] >> 4) & 0x3F) << 9); // Year  (6 bits)
+       algo_ |= (((data16[4*i+2] >> 0) & 0x0F) << 5); // Month (4 bits)
+       algo_ |= (((data16[4*i+4] >> 0) & 0x1F) << 0); // Day   (5 bits)
+       break;
+      }
+    }
+    if (algo_ == 0) {
+      edm::LogError("L1T") << "MTF7 payload has no valid EMTF firmware version!";
+      data_ = end_;
+    }
+  
   }
 
   int


### PR DESCRIPTION
Incorporate EMTF firmware version into the unpacking to write out the correct LCTs.
Fixes error which was appearing in EMTF emulator due to corrupt inputs when running over early 2016 Cosmics data.  Of interest to Zhen Hu (anyone know his gitHub name?) and others.  @rekovic , @thomreis , @jiafulow please take a look.
Best, Andrew

Update: incorporated into PR #23136 
Unpacked L1 trigger unit-test still needed