### PR TITLE
Fixes to  L3 Muon OI SeedGenerator (TSGForOI) for improved efficiency

### DIFF
--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -188,7 +188,7 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
       if (useBoth) {
         layerCount = 0;
         numSeedsMade = 0;
-        hittlessSeedsMade = 0;
+        hitlessSeedsMade = 0;
         for (auto it=tecPositive.rbegin(); it!=tecPositive.rend(); ++it) {
           LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount << endl;
           findSeedsOnLayer(tTopo, **it, outerTkStateOutside,  *(propagatorOpposite.get()), *(propagatorOpposite.get()), l2,
@@ -202,7 +202,7 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
       layerCount = 0;
       for (auto it=tecNegative.rbegin(); it!=tecNegative.rend(); ++it) {
         LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount << endl;
-        ffindSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
+        findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
                          estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
 	    }
       if (useBoth) {

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -33,6 +33,10 @@ TSGForOI::TSGForOI(const edm::ParameterSet & iConfig) :
   pT3_(iConfig.getParameter<double>("pT3")),
   eta1_(iConfig.getParameter<double>("eta1")),
   eta2_(iConfig.getParameter<double>("eta2")),
+  eta3_(iConfig.getParameter<double>("eta3")),
+  eta4_(iConfig.getParameter<double>("eta4")),
+  eta5_(iConfig.getParameter<double>("eta5")),
+  eta6_(iConfig.getParameter<double>("eta6")),
   SF1_(iConfig.getParameter<double>("SF1")),
   SF2_(iConfig.getParameter<double>("SF2")),
   SF3_(iConfig.getParameter<double>("SF3")),
@@ -157,8 +161,8 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
     if (std::abs(l2->eta()) < maxEtaForTOB_) {
       layerCount = 0;
       for (auto it=tob.rbegin(); it!=tob.rend(); ++it) {	// this runs from outermost to innermost TOB layer
-        LogTrace("TSGForOI") << "TSGForOI::produce: looping in TOB layer " << layerCount << endl;
-        findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
+	    LogTrace("TSGForOI") << "TSGForOI::produce: looping in TOB layer " << layerCount << endl;
+	    findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
                          estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
       }
       if (useBoth) {
@@ -170,30 +174,30 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
           findSeedsOnLayer(tTopo, **it, outerTkStateOutside,  *(propagatorOpposite.get()), *(propagatorOpposite.get()), l2,
                            estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
         }
-      }
+	  }
     }
     // Reset Number of seeds if in overlap region
     if (std::abs(l2->eta())>minEtaForTEC_ && std::abs(l2->eta())<maxEtaForTOB_){
-      numSeedsMade = 0;
+       numSeedsMade = 0;
     }
 
     // ENDCAP+
     if (l2->eta() > minEtaForTEC_) {
-      layerCount = 0;
+       layerCount = 0;
       for (auto it=tecPositive.rbegin(); it!=tecPositive.rend(); ++it) {
-	      LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount << endl;
-	      findSeedsOnLayer(tTopo, **it, tsosAtIP, *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
+	    LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount << endl;
+	    findSeedsOnLayer(tTopo, **it, tsosAtIP, *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
                          estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
-	    }
-      if (useBoth) {
+	  }
+	  if (useBoth) {
         layerCount = 0;
-        numSeedsMade = 0;
+	numSeedsMade = 0;
         hitlessSeedsMade = 0;
         for (auto it=tecPositive.rbegin(); it!=tecPositive.rend(); ++it) {
           LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount << endl;
           findSeedsOnLayer(tTopo, **it, outerTkStateOutside,  *(propagatorOpposite.get()), *(propagatorOpposite.get()), l2,
                            estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
-		    }
+		}
       }
     }
 
@@ -201,19 +205,19 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
     if (l2->eta() < -minEtaForTEC_) {
       layerCount = 0;
       for (auto it=tecNegative.rbegin(); it!=tecNegative.rend(); ++it) {
-        LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount << endl;
-        findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
+	    LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount << endl;
+	    findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
                          estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
-	    }
-      if (useBoth) {
+	  }
+	  if (useBoth) {
         layerCount = 0;
-        numSeedsMade = 0;
+	numSeedsMade = 0;
         hitlessSeedsMade = 0;
         for (auto it=tecNegative.rbegin(); it!=tecNegative.rend(); ++it) {
           LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount << endl;
           findSeedsOnLayer(tTopo, **it, outerTkStateOutside,  *(propagatorOpposite.get()), *(propagatorOpposite.get()), l2,
                            estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
-		    }
+		}
       }
     }
 
@@ -234,19 +238,19 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
 // Create seeds on a given layer (TOB or TEC)
 //
 void TSGForOI::findSeedsOnLayer(
-       const TrackerTopology* tTopo,
-       const GeometricSearchDet& layer,
-       const TrajectoryStateOnSurface& tsosAtIP,
-       const Propagator& propagatorAlong,
-       const Propagator& propagatorOpposite,
-       const reco::TrackRef l2,
-       edm::ESHandle<Chi2MeasurementEstimatorBase>& estimatorH,
-       edm::Handle<MeasurementTrackerEvent>& measurementTrackerH,
-       unsigned int& numSeedsMade,
-       unsigned int& hitlessSeedsMade,
-       unsigned int& numOfMaxSeeds,
-       unsigned int& layerCount,
-       std::unique_ptr<std::vector<TrajectorySeed> >& out) const {
+				const TrackerTopology* tTopo,
+				const GeometricSearchDet& layer,
+				const TrajectoryStateOnSurface& tsosAtIP,
+				const Propagator& propagatorAlong,
+				const Propagator& propagatorOpposite,
+				const reco::TrackRef l2,
+				edm::ESHandle<Chi2MeasurementEstimatorBase>& estimatorH,
+				edm::Handle<MeasurementTrackerEvent>& measurementTrackerH,
+				unsigned int& numSeedsMade,
+                unsigned int& hitlessSeedsMade,
+				unsigned int& numOfMaxSeeds,
+				unsigned int& layerCount,
+				std::unique_ptr<std::vector<TrajectorySeed> >& out) const {
   
   if (numSeedsMade > numOfMaxSeeds) return;
   LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: numSeedsMade = " << numSeedsMade << " , layerCount = " <<  layerCount << endl;
@@ -284,7 +288,7 @@ void TSGForOI::findSeedsOnLayer(
 
   // Hits
   if (layerCount > numOfLayersToTry_) return;
-  LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: Start Hits" <<endl;  
+  LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: Start Hits" << endl;
   if (makeSeedsFromHits(tTopo, layer, tsosAtIP, *out, propagatorAlong, *measurementTrackerH, estimatorH, numSeedsMade, errorSFHits, l2->eta())) ++layerCount;
 
 }
@@ -293,31 +297,43 @@ void TSGForOI::findSeedsOnLayer(
 //
 // Calculate the dynamic error SF by analysing the L2
 //
-double TSGForOI::calculateSFFromL2(const reco::TrackRef track) const{
+double TSGForOI::calculateSFFromL2(const reco::TrackRef track) const {
 
   double theSF = 1.0;
   //	L2 direction vs pT blowup - as was previously done:
   //	Split into 4 pT ranges: <pT1_, pT1_<pT2_, pT2_<pT3_, <pT4_: 13,30,70
-  //	Split into 2 eta ranges for the middle two pT ranges: 1.0,1.4
+  //	Split into different eta ranges depending in pT
+
+
   double abseta = std::abs(track->eta());
   if (track->pt() <= pT1_) theSF = SF1_;
   if (track->pt() > pT1_ && track->pt() <= pT2_) {
-    if (abseta <= eta1_) theSF = SF3_;
-    if (abseta > eta1_ && abseta <= eta2_) theSF = SF2_;
-    if (abseta > eta2_) theSF = SF3_;
+    if (abseta <= eta3_) theSF = SF3_;
+    if (abseta > eta3_ && abseta <= eta6_) theSF = SF2_;
+    if (abseta > eta6_) theSF = SF3_;
   }
   if (track->pt() > pT2_ && track->pt() <= pT3_) {
     if (abseta <= eta1_) theSF = SF6_;
-    if (abseta > eta1_ && abseta <= eta2_) theSF = SF4_;
-    if (abseta > eta2_) theSF = SF5_;
+    if (abseta > eta1_  && abseta <= eta2_) theSF = SF4_;
+    if (abseta > eta2_  && abseta <= eta3_) theSF = SF6_;
+    if (abseta > eta3_ && abseta <= eta4_) theSF = SF1_;
+    if (abseta > eta4_ && abseta<= eta5_) theSF=SF1_;
+    if (abseta > eta5_ ) theSF = SF5_;
   }
-  if (track->pt() > pT3_) theSF = SF5_;
+
+  if (track->pt() > pT3_) {
+    if (abseta <= eta3_) theSF = SF5_;
+    if (abseta > eta3_ && abseta <= eta4_) theSF = SF4_;
+    if (abseta > eta4_ && abseta <=eta5_) theSF=SF4_;
+    if (abseta > eta5_ ) theSF = SF5_;
+  }
 
   LogTrace(theCategory) << "TSGForOI::calculateSFFromL2: SF has been calculated as: " << theSF;
 
   return theSF;
     
 }
+
 
 
 //
@@ -361,19 +377,17 @@ int TSGForOI::makeSeedsFromHits(
   unsigned int found = 0;
   std::sort(meas.begin(), meas.end(), TrajMeasLessEstim());
 
-
-
   for (std::vector<TrajectoryMeasurement>::const_iterator it=meas.begin(); it!=meas.end(); ++it) {
     TrajectoryStateOnSurface updatedTSOS = updator_->update(it->forwardPredictedState(), *it->recHit());
     LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: TSOS for TM " << found << endl;
     if (not updatedTSOS.isValid()) continue;
 
     // Check if it is a Stereo TEC dets
-    if (useStereoLayersInTEC_ && (fabs(l2Eta) > 1.1 && fabs(l2Eta) < 2.0)) {
+    if (useStereoLayersInTEC_ && ((fabs(l2Eta) > 1.1 && fabs(l2Eta) < 2.0) || (fabs(l2Eta) > 2.15 && fabs(l2Eta) < 2.4))) {
       DetId detid = ((*it).recHit()->hit())->geographicalId();
       if (detid.subdetId() == StripSubdetector::TEC && !tTopo->tecIsStereo(detid.rawId())) break;  // try another layer
     }
-    
+
     edm::OwnVector<TrackingRecHit> seedHits;
     seedHits.push_back(*it->recHit()->hit());
     PTrajectoryStateOnDet const& pstate = trajectoryStateTransform::persistentState(updatedTSOS, it->recHit()->geographicalId().rawId());
@@ -439,8 +453,12 @@ void TSGForOI::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   desc.add<double>("pT1",13.0);
   desc.add<double>("pT2",30.0);
   desc.add<double>("pT3",70.0);
-  desc.add<double>("eta1",1.0);
-  desc.add<double>("eta2",1.4);
+  desc.add<double>("eta1",0.2);
+  desc.add<double>("eta2",0.3);
+  desc.add<double>("eta3",1.0);
+  desc.add<double>("eta4",1.2);  
+  desc.add<double>("eta5",1.6);
+  desc.add<double>("eta6",1.4);
   desc.add<double>("SF1",3.0);
   desc.add<double>("SF2",4.0);
   desc.add<double>("SF3",5.0);
@@ -449,7 +467,7 @@ void TSGForOI::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   desc.add<double>("SF6",2.0);
   desc.add<double>("tsosDiff1",0.2);
   desc.add<double>("tsosDiff2",0.02);
-  desc.add<std::string>("propagatorName","PropagatorWithMaterialParabolicMf");
+  desc.add<std::string>("propagatorName","PropagatorWithMaterial");
   descriptions.add("TSGForOI",desc);
 
 }

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -38,6 +38,7 @@ TSGForOI::TSGForOI(const edm::ParameterSet & iConfig) :
   SF3_(iConfig.getParameter<double>("SF3")),
   SF4_(iConfig.getParameter<double>("SF4")),
   SF5_(iConfig.getParameter<double>("SF5")),
+  SF6_(iConfig.getParameter<double>("SF6")),
   tsosDiff1_(iConfig.getParameter<double>("tsosDiff1")),
   tsosDiff2_(iConfig.getParameter<double>("tsosDiff2")),
   propagatorName_(iConfig.getParameter<std::string>("propagatorName")), 
@@ -156,8 +157,8 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
     if (std::abs(l2->eta()) < maxEtaForTOB_) {
       layerCount = 0;
       for (auto it=tob.rbegin(); it!=tob.rend(); ++it) {	// this runs from outermost to innermost TOB layer
-	    LogTrace("TSGForOI") << "TSGForOI::produce: looping in TOB layer " << layerCount << endl;
-	    findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
+        LogTrace("TSGForOI") << "TSGForOI::produce: looping in TOB layer " << layerCount << endl;
+        findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
                          estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
       }
       if (useBoth) {
@@ -169,7 +170,7 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
           findSeedsOnLayer(tTopo, **it, outerTkStateOutside,  *(propagatorOpposite.get()), *(propagatorOpposite.get()), l2,
                            estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
         }
-	  }
+      }
     }
     // Reset Number of seeds if in overlap region
     if (std::abs(l2->eta())>minEtaForTEC_ && std::abs(l2->eta())<maxEtaForTOB_){
@@ -180,19 +181,19 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
     if (l2->eta() > minEtaForTEC_) {
       layerCount = 0;
       for (auto it=tecPositive.rbegin(); it!=tecPositive.rend(); ++it) {
-	    LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount << endl;
-	    findSeedsOnLayer(tTopo, **it, tsosAtIP, *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
+	      LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount << endl;
+	      findSeedsOnLayer(tTopo, **it, tsosAtIP, *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
                          estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
-	  }
-	  if (useBoth) {
+	    }
+      if (useBoth) {
         layerCount = 0;
-		numSeedsMade = 0;
-        hitlessSeedsMade = 0;
+        numSeedsMade = 0;
+        hittlessSeedsMade = 0;
         for (auto it=tecPositive.rbegin(); it!=tecPositive.rend(); ++it) {
           LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount << endl;
           findSeedsOnLayer(tTopo, **it, outerTkStateOutside,  *(propagatorOpposite.get()), *(propagatorOpposite.get()), l2,
                            estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
-		}
+		    }
       }
     }
 
@@ -200,19 +201,19 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
     if (l2->eta() < -minEtaForTEC_) {
       layerCount = 0;
       for (auto it=tecNegative.rbegin(); it!=tecNegative.rend(); ++it) {
-	    LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount << endl;
-	    findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
+        LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount << endl;
+        ffindSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
                          estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
-	  }
-	  if (useBoth) {
+	    }
+      if (useBoth) {
         layerCount = 0;
-		numSeedsMade = 0;
+        numSeedsMade = 0;
         hitlessSeedsMade = 0;
         for (auto it=tecNegative.rbegin(); it!=tecNegative.rend(); ++it) {
           LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount << endl;
           findSeedsOnLayer(tTopo, **it, outerTkStateOutside,  *(propagatorOpposite.get()), *(propagatorOpposite.get()), l2,
                            estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
-		}
+		    }
       }
     }
 
@@ -233,19 +234,19 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
 // Create seeds on a given layer (TOB or TEC)
 //
 void TSGForOI::findSeedsOnLayer(
-				const TrackerTopology* tTopo,
-				const GeometricSearchDet& layer,
-				const TrajectoryStateOnSurface& tsosAtIP,
-				const Propagator& propagatorAlong,
-				const Propagator& propagatorOpposite,
-				const reco::TrackRef l2,
-				edm::ESHandle<Chi2MeasurementEstimatorBase>& estimatorH,
-				edm::Handle<MeasurementTrackerEvent>& measurementTrackerH,
-				unsigned int& numSeedsMade,
-                unsigned int& hitlessSeedsMade,
-				unsigned int& numOfMaxSeeds,
-				unsigned int& layerCount,
-				std::unique_ptr<std::vector<TrajectorySeed> >& out) const {
+       const TrackerTopology* tTopo,
+       const GeometricSearchDet& layer,
+       const TrajectoryStateOnSurface& tsosAtIP,
+       const Propagator& propagatorAlong,
+       const Propagator& propagatorOpposite,
+       const reco::TrackRef l2,
+       edm::ESHandle<Chi2MeasurementEstimatorBase>& estimatorH,
+       edm::Handle<MeasurementTrackerEvent>& measurementTrackerH,
+       unsigned int& numSeedsMade,
+       unsigned int& hitlessSeedsMade,
+       unsigned int& numOfMaxSeeds,
+       unsigned int& layerCount,
+       std::unique_ptr<std::vector<TrajectorySeed> >& out) const {
   
   if (numSeedsMade > numOfMaxSeeds) return;
   LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: numSeedsMade = " << numSeedsMade << " , layerCount = " <<  layerCount << endl;
@@ -276,7 +277,6 @@ void TSGForOI::findSeedsOnLayer(
         TrajectorySeed::recHitContainer rHC;
         out->push_back(TrajectorySeed(ptsod,rHC,oppositeToMomentum));
         LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: TSOD (Hitless) done " << endl;
-        numSeedsMade++;
         hitlessSeedsMade++;
       }
     }
@@ -285,7 +285,7 @@ void TSGForOI::findSeedsOnLayer(
   // Hits
   if (layerCount > numOfLayersToTry_) return;
   LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: Start Hits" <<endl;  
-  if (makeSeedsFromHits(tTopo, layer, tsosAtIP, *out, propagatorAlong, *measurementTrackerH, estimatorH, numSeedsMade, errorSFHits, l2->eta()))  ++layerCount; 
+  if (makeSeedsFromHits(tTopo, layer, tsosAtIP, *out, propagatorAlong, *measurementTrackerH, estimatorH, numSeedsMade, errorSFHits, l2->eta())) ++layerCount;
 
 }
 
@@ -306,8 +306,8 @@ double TSGForOI::calculateSFFromL2(const reco::TrackRef track) const{
     if (abseta > eta1_ && abseta <= eta2_) theSF = SF2_;
     if (abseta > eta2_) theSF = SF3_;
   }
-  if (track->pt() > pT2_ && track->pt() <= pT3_){
-    if (abseta <= eta1_) theSF = SF5_;
+  if (track->pt() > pT2_ && track->pt() <= pT3_) {
+    if (abseta <= eta1_) theSF = SF6_;
     if (abseta > eta1_ && abseta <= eta2_) theSF = SF4_;
     if (abseta > eta2_) theSF = SF5_;
   }
@@ -360,17 +360,18 @@ int TSGForOI::makeSeedsFromHits(
   LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: Update TSOS using TMs after sorting, then create Trajectory Seed, number of TM = " << meas.size() << endl;
   unsigned int found = 0;
   std::sort(meas.begin(), meas.end(), TrajMeasLessEstim());
+
+
+
   for (std::vector<TrajectoryMeasurement>::const_iterator it=meas.begin(); it!=meas.end(); ++it) {
     TrajectoryStateOnSurface updatedTSOS = updator_->update(it->forwardPredictedState(), *it->recHit());
     LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: TSOS for TM " << found << endl;
     if (not updatedTSOS.isValid()) continue;
 
-    // Check if it is a Stereo TEC Layer
-    if (useStereoLayersInTEC_ && (fabs(l2Eta) > 0.8 && fabs(l2Eta) < 1.6)) {
+    // Check if it is a Stereo TEC dets
+    if (useStereoLayersInTEC_ && (fabs(l2Eta) > 1.1 && fabs(l2Eta) < 2.0)) {
       DetId detid = ((*it).recHit()->hit())->geographicalId();
-      if (detid.subdetId() == StripSubdetector::TEC) {
-		if (!tTopo->tecIsStereo(detid.rawId())) break;  // try another layer
-      }
+      if (detid.subdetId() == StripSubdetector::TEC && !tTopo->tecIsStereo(detid.rawId())) break;  // try another layer
     }
     
     edm::OwnVector<TrackingRecHit> seedHits;
@@ -445,6 +446,7 @@ void TSGForOI::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   desc.add<double>("SF3",5.0);
   desc.add<double>("SF4",7.0);
   desc.add<double>("SF5",10.0);
+  desc.add<double>("SF6",2.0);
   desc.add<double>("tsosDiff1",0.2);
   desc.add<double>("tsosDiff2",0.02);
   desc.add<std::string>("propagatorName","PropagatorWithMaterial");

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -7,6 +7,7 @@
 #include "RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/Math/interface/deltaR.h"
+
 #include <memory>
 
 using namespace edm;
@@ -26,8 +27,7 @@ TSGForOI::TSGForOI(const edm::ParameterSet & iConfig) :
   maxEtaForTOB_(iConfig.getParameter<double>("maxEtaForTOB")),
   useHitLessSeeds_(iConfig.getParameter<bool>("UseHitLessSeeds")),
   useStereoLayersInTEC_(iConfig.getParameter<bool>("UseStereoLayersInTEC")),
-  updator_(new KFUpdator()),
-  measurementTrackerTag_(consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent"))),
+  updator_(new KFUpdator()), measurementTrackerTag_(consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent"))),
   pT1_(iConfig.getParameter<double>("pT1")),
   pT2_(iConfig.getParameter<double>("pT2")),
   pT3_(iConfig.getParameter<double>("pT3")),
@@ -47,22 +47,28 @@ TSGForOI::TSGForOI(const edm::ParameterSet & iConfig) :
 }
 
 
-TSGForOI::~TSGForOI(){
+TSGForOI::~TSGForOI() {
+
 }
 
 
+//
+// Produce seeds
+//
 void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-  /// Init variables
+    
+  using namespace std;
+    
+  // Initialize variables
   unsigned int numOfMaxSeeds = numOfMaxSeedsParam_;
-  unsigned int numSeedsMade=0;
-  bool analysedL2 = false;
+  unsigned int numSeedsMade = 0;
   unsigned int layerCount = 0;
+  unsigned int hitlessSeedsMade = 0;
 
-
-  /// Surface used to make a TSOS at the PCA to the beamline
+  // Surface used to make a TSOS at the PCA to the beamline
   Plane::PlanePointer dummyPlane = Plane::build(Plane::PositionType(), Plane::RotationType());
 
-  /// Read ESHandles
+  // Read ESHandles
   edm::Handle<MeasurementTrackerEvent>          measurementTrackerH;
   edm::ESHandle<Chi2MeasurementEstimatorBase>   estimatorH;
   edm::ESHandle<MagneticField>                  magfieldH;
@@ -79,14 +85,14 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
   iSetup.get<TrackingComponentsRecord>().get(estimatorName_,estimatorH);
   iEvent.getByToken(measurementTrackerTag_, measurementTrackerH);
 
-  /// Read L2 track collection
+  // Read L2 track collection
   edm::Handle<reco::TrackCollection> l2TrackCol;
   iEvent.getByToken(src_, l2TrackCol);
 
-  //	The product:
+  // The product
   std::unique_ptr<std::vector<TrajectorySeed> > result(new std::vector<TrajectorySeed>());
 
-  //	Get vector of Detector layers once:
+  // Get vector of Detector layers
   std::vector<BarrelDetLayer const*> const& tob = measurementTrackerH->geometricSearchTracker()->tobLayers();
   std::vector<ForwardDetLayer const*> const& tecPositive = tmpTkGeometryH->isThere(GeomDetEnumerators::P2OTEC) ? 
                                                                 measurementTrackerH->geometricSearchTracker()->posTidLayers() : 
@@ -98,143 +104,150 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
   iSetup.get<TrackerTopologyRcd>().get(tTopo_handle);
   const TrackerTopology* tTopo = tTopo_handle.product();
 
-  //	Get the suitable propagators: 
+  // Get suitable propagators
   std::unique_ptr<Propagator> propagatorAlong = SetPropagationDirection(*propagatorAlongH,alongMomentum);
   std::unique_ptr<Propagator> propagatorOpposite = SetPropagationDirection(*propagatorOppositeH,oppositeToMomentum);
 
-  edm::ESHandle<Propagator> SmartOpposite;
+  // Stepping Helix Propagator for propogation from uon system to tracker
   edm::ESHandle<Propagator> SHPOpposite;
-  iSetup.get<TrackingComponentsRecord>().get("hltESPSmartPropagatorAnyOpposite", SmartOpposite);
   iSetup.get<TrackingComponentsRecord>().get("hltESPSteppingHelixPropagatorOpposite", SHPOpposite);
 
-  //	Loop over the L2's and make seeds for all of them:
+  // Loop over the L2's and make seeds for all of them
   LogTrace(theCategory) << "TSGForOI::produce: Number of L2's: " << l2TrackCol->size();
-  for (unsigned int l2TrackColIndex(0);l2TrackColIndex!=l2TrackCol->size();++l2TrackColIndex){
+  for (unsigned int l2TrackColIndex(0); l2TrackColIndex!=l2TrackCol->size(); ++l2TrackColIndex) {
+
     const reco::TrackRef l2(l2TrackCol, l2TrackColIndex);
+
+    // Container of Seeds
     std::unique_ptr<std::vector<TrajectorySeed> > out(new std::vector<TrajectorySeed>());
     LogTrace("TSGForOI") << "TSGForOI::produce: L2 muon pT, eta, phi --> " << l2->pt() << " , " << l2->eta() << " , " << l2->phi() << endl;
-    
+ 
     FreeTrajectoryState fts = trajectoryStateTransform::initialFreeState(*l2, magfieldH.product());
+
     dummyPlane->move(fts.position() - dummyPlane->position());
     TrajectoryStateOnSurface tsosAtIP = TrajectoryStateOnSurface(fts, *dummyPlane);
     LogTrace("TSGForOI") << "TSGForOI::produce: Created TSOSatIP: " << tsosAtIP << std::endl;
     
-    // get the TSOS on the innermost layer of the L2. 
+    // Get the TSOS on the innermost layer of the L2
     TrajectoryStateOnSurface tsosAtMuonSystem = trajectoryStateTransform::innerStateOnSurface(*l2, *geometryH, magfieldH.product());
     LogTrace("TSGForOI") << "TSGForOI::produce: Created TSOSatMuonSystem: " << tsosAtMuonSystem <<endl;
     
     LogTrace("TSGForOI") << "TSGForOI::produce: Check the error of the L2 parameter and use hit seeds if big errors" << endl;
+
     StateOnTrackerBound fromInside(propagatorAlong.get());
     TrajectoryStateOnSurface outerTkStateInside = fromInside(fts);
-      
+
     StateOnTrackerBound fromOutside(&*SHPOpposite);
     TrajectoryStateOnSurface outerTkStateOutside = fromOutside(tsosAtMuonSystem);
 
-      // for now only checking if the two positions (using updated and not-updated) agree withing certain extent, 
-      // will probably have to design something fancier for the future. 
-     bool useBoth = false;
-
-     if(outerTkStateInside.isValid() && outerTkStateOutside.isValid()) {
-
+    // Check if the two positions (using updated and not-updated TSOS) agree withing certain extent.
+    // If both TSOSs agree, use only the one at vertex, as it uses more information. If they do not agree, search for seeds based on both.
+    bool useBoth = false;
+    if (outerTkStateInside.isValid() && outerTkStateOutside.isValid()) {
       auto dist1 = match_Chi2(outerTkStateInside,outerTkStateOutside);
-
       auto dist2 = deltaR(outerTkStateInside.globalMomentum(),outerTkStateOutside.globalMomentum());
-
       if (dist1 > tsosDiff1_ || dist2 > tsosDiff2_) useBoth = true;
+    }
 
-      }
+    numSeedsMade = 0;
+    hitlessSeedsMade = 0;
 
-    numSeedsMade=0;
-    analysedL2 = false;
-
-    // if both TSOSs agree, use only the one at vertex, as it uses more information. If they do not agree, search for seed based on both
-
-    //		BARREL
+    // BARREL
     if (std::abs(l2->eta()) < maxEtaForTOB_) {
       layerCount = 0;
-      for (auto it=tob.rbegin(); it!=tob.rend(); ++it) {	//This goes from outermost to innermost layer
-	LogTrace("TSGForOI") << "TSGForOI::produce: looping in TOB layer " << layerCount << endl; 
-	findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, 
-			 estimatorH, measurementTrackerH, numSeedsMade, numOfMaxSeeds, layerCount, analysedL2, out);
+      for (auto it=tob.rbegin(); it!=tob.rend(); ++it) {	// this runs from outermost to innermost TOB layer
+	    LogTrace("TSGForOI") << "TSGForOI::produce: looping in TOB layer " << layerCount << endl;
+	    findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
+                         estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
       }
-      if (useBoth){
-	      numSeedsMade=0;
-	      for (auto it=tob.rbegin(); it!=tob.rend(); ++it) {	//This goes from outermost to innermost layer
-			LogTrace("TSGForOI") << "TSGForOI::produce: looping in TOB layer " << layerCount << endl; 
-			findSeedsOnLayer(tTopo, **it, outerTkStateOutside,  *(propagatorOpposite.get()), *(propagatorOpposite.get()), l2, 
-			 estimatorH, measurementTrackerH, numSeedsMade, numOfMaxSeeds, layerCount, analysedL2, out);
-      		}
-	}
+      if (useBoth) {
+        layerCount = 0;
+        numSeedsMade = 0;
+        hitlessSeedsMade = 0;
+        for (auto it=tob.rbegin(); it!=tob.rend(); ++it) {	//This goes from outermost to innermost layer
+          LogTrace("TSGForOI") << "TSGForOI::produce: looping in TOB layer " << layerCount << endl;
+          findSeedsOnLayer(tTopo, **it, outerTkStateOutside,  *(propagatorOpposite.get()), *(propagatorOpposite.get()), l2,
+                           estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
+        }
+	  }
     }
-    //		Reset Number of seeds if in overlap region:
-
+    // Reset Number of seeds if in overlap region
     if (std::abs(l2->eta())>minEtaForTEC_ && std::abs(l2->eta())<maxEtaForTOB_){
-      numSeedsMade=0;
+      numSeedsMade = 0;
     }
 
-    //		ENDCAP+
+    // ENDCAP+
     if (l2->eta() > minEtaForTEC_) {
       layerCount = 0;
       for (auto it=tecPositive.rbegin(); it!=tecPositive.rend(); ++it) {
-	LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount << endl; 
-	findSeedsOnLayer(tTopo, **it, tsosAtIP, *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, 
-			 estimatorH, measurementTrackerH, numSeedsMade, numOfMaxSeeds, layerCount, analysedL2, out);
-	}
-	if (useBoth){
-		numSeedsMade=0;
-      		for (auto it=tecPositive.rbegin(); it!=tecPositive.rend(); ++it) {
-			LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount << endl; 
-			findSeedsOnLayer(tTopo, **it, outerTkStateOutside,  *(propagatorOpposite.get()), *(propagatorOpposite.get()), l2, 
-			 estimatorH, measurementTrackerH, numSeedsMade, numOfMaxSeeds, layerCount, analysedL2, out);
+	    LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount << endl;
+	    findSeedsOnLayer(tTopo, **it, tsosAtIP, *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
+                         estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
+	  }
+	  if (useBoth) {
+        layerCount = 0;
+		numSeedsMade = 0;
+        hitlessSeedsMade = 0;
+        for (auto it=tecPositive.rbegin(); it!=tecPositive.rend(); ++it) {
+          LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount << endl;
+          findSeedsOnLayer(tTopo, **it, outerTkStateOutside,  *(propagatorOpposite.get()), *(propagatorOpposite.get()), l2,
+                           estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
 		}
-     	}
+      }
     }
 
-    //		ENDCAP-
+    // ENDCAP-
     if (l2->eta() < -minEtaForTEC_) {
       layerCount = 0;
       for (auto it=tecNegative.rbegin(); it!=tecNegative.rend(); ++it) {
-	LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount << endl; 
-	findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, 
-			 estimatorH, measurementTrackerH, numSeedsMade, numOfMaxSeeds, layerCount, analysedL2, out);
-	}
-	if (useBoth){
-		numSeedsMade=0;
-	      	for (auto it=tecNegative.rbegin(); it!=tecNegative.rend(); ++it) {
-			LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount << endl; 
-			findSeedsOnLayer(tTopo, **it,outerTkStateOutside,  *(propagatorOpposite.get()), *(propagatorOpposite.get()), l2, 
-			 estimatorH, measurementTrackerH, numSeedsMade, numOfMaxSeeds, layerCount, analysedL2, out);
+	    LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount << endl;
+	    findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2,
+                         estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
+	  }
+	  if (useBoth) {
+        layerCount = 0;
+		numSeedsMade = 0;
+        hitlessSeedsMade = 0;
+        for (auto it=tecNegative.rbegin(); it!=tecNegative.rend(); ++it) {
+          LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount << endl;
+          findSeedsOnLayer(tTopo, **it, outerTkStateOutside,  *(propagatorOpposite.get()), *(propagatorOpposite.get()), l2,
+                           estimatorH, measurementTrackerH, numSeedsMade, hitlessSeedsMade, numOfMaxSeeds, layerCount, out);
 		}
-      	}
+      }
     }
 
-    
-
-    for (std::vector<TrajectorySeed>::iterator it=out->begin(); it!=out->end(); ++it){
+    for (std::vector<TrajectorySeed>::iterator it=out->begin(); it!=out->end(); ++it) {
       result->push_back(*it);
     }
-  } //L2Collection
+
+  } // L2Collection
+  
   edm::LogInfo(theCategory) << "TSGForOI::produce: number of seeds made: " << result->size();
 
   iEvent.put(std::move(result));
+
 }
 
+
+//
+// Create seeds on a given layer (TOB or TEC)
+//
 void TSGForOI::findSeedsOnLayer(
 				const TrackerTopology* tTopo,
-				const GeometricSearchDet &layer,
-				const TrajectoryStateOnSurface &tsosAtIP,
+				const GeometricSearchDet& layer,
+				const TrajectoryStateOnSurface& tsosAtIP,
 				const Propagator& propagatorAlong,
 				const Propagator& propagatorOpposite,
 				const reco::TrackRef l2,
 				edm::ESHandle<Chi2MeasurementEstimatorBase>& estimatorH,
 				edm::Handle<MeasurementTrackerEvent>& measurementTrackerH,
 				unsigned int& numSeedsMade,
+                unsigned int& hitlessSeedsMade,
 				unsigned int& numOfMaxSeeds,
 				unsigned int& layerCount,
-				bool& analysedL2,
-				std::unique_ptr<std::vector<TrajectorySeed> >& out)  const{
+				std::unique_ptr<std::vector<TrajectorySeed> >& out) const {
   
-  if (numSeedsMade>numOfMaxSeeds) return;
+  if (numSeedsMade > numOfMaxSeeds) return;
   LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: numSeedsMade = " << numSeedsMade << " , layerCount = " <<  layerCount << endl;
   
   double errorSFHits=1.0;
@@ -242,104 +255,108 @@ void TSGForOI::findSeedsOnLayer(
   if (!adjustErrorsDynamicallyForHits_) errorSFHits = fixedErrorRescalingForHits_;
   else                                  errorSFHits = calculateSFFromL2(l2);
   if (!adjustErrorsDynamicallyForHitless_) errorSFHitless = fixedErrorRescalingForHitless_;
+  else                                  errorSFHitless = calculateSFFromL2(l2);
 
-  // Hitless:  TO Be discarded from here at some point. 
-  if (useHitLessSeeds_) {
+  // create hitless seeds
+  // create one hitless seed per L2 on  on each layer
+  if ( useHitLessSeeds_ ) {
     LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: Start hitless" << endl;
     std::vector< GeometricSearchDet::DetWithState > dets;
     layer.compatibleDetsV(tsosAtIP, propagatorAlong, *estimatorH, dets);
-    if (!dets.empty()) {  
+    if (!dets.empty()) {
       auto const& detOnLayer = dets.front().first;
       auto const& tsosOnLayer = dets.front().second;
       LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: tsosOnLayer " << tsosOnLayer << endl;
-      if (!tsosOnLayer.isValid()){
-	edm::LogInfo(theCategory) << "ERROR!: Hitless TSOS is not valid!";
+      if (!tsosOnLayer.isValid()) {
+        edm::LogInfo(theCategory) << "ERROR!: Hitless TSOS is not valid!";
       }
-      else{
-	// calculate SF from L2 (only once -- if needed)
-	if (!analysedL2 && adjustErrorsDynamicallyForHitless_) {
-	  errorSFHitless=calculateSFFromL2(l2);
-	  analysedL2=true;
-	}
-	
-	dets.front().second.rescaleError(errorSFHitless);
-	PTrajectoryStateOnDet const& ptsod = trajectoryStateTransform::persistentState(tsosOnLayer,detOnLayer->geographicalId().rawId());
-	TrajectorySeed::recHitContainer rHC;
-	out->push_back(TrajectorySeed(ptsod,rHC,oppositeToMomentum));
-	LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: TSOD (Hitless) done " << endl;
+      else {
+        dets.front().second.rescaleError(errorSFHitless);
+        PTrajectoryStateOnDet const& ptsod = trajectoryStateTransform::persistentState(tsosOnLayer,detOnLayer->geographicalId().rawId());
+        TrajectorySeed::recHitContainer rHC;
+        out->push_back(TrajectorySeed(ptsod,rHC,oppositeToMomentum));
+        LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: TSOD (Hitless) done " << endl;
         numSeedsMade++;
+        hitlessSeedsMade++;
       }
     }
   }
 
-  // Hits:
-  if (layerCount>numOfLayersToTry_) return;
+  // Hits
+  if (layerCount > numOfLayersToTry_) return;
   LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: Start Hits" <<endl;  
   if (makeSeedsFromHits(tTopo, layer, tsosAtIP, *out, propagatorAlong, *measurementTrackerH, estimatorH, numSeedsMade, errorSFHits, l2->eta()))  ++layerCount; 
+
 }
 
+
+//
+// Calculate the dynamic error SF by analysing the L2
+//
 double TSGForOI::calculateSFFromL2(const reco::TrackRef track) const{
 
-  double theSF=1.0;
+  double theSF = 1.0;
   //	L2 direction vs pT blowup - as was previously done:
   //	Split into 4 pT ranges: <pT1_, pT1_<pT2_, pT2_<pT3_, <pT4_: 13,30,70
   //	Split into 2 eta ranges for the middle two pT ranges: 1.0,1.4
   double abseta = std::abs(track->eta());
-  if (track->pt()<=pT1_) theSF=SF1_;
-  if (track->pt()>pT1_ && track->pt()<=pT2_){
-    if (abseta<=eta1_) theSF=SF3_;
-    if (abseta>eta1_ && abseta<=eta2_) theSF=SF2_;
-    if (abseta>eta2_) theSF=SF3_;
+  if (track->pt() <= pT1_) theSF = SF1_;
+  if (track->pt() > pT1_ && track->pt() <= pT2_) {
+    if (abseta <= eta1_) theSF = SF3_;
+    if (abseta > eta1_ && abseta <= eta2_) theSF = SF2_;
+    if (abseta > eta2_) theSF = SF3_;
   }
-  if (track->pt()>pT2_ && track->pt()<=pT3_){
-    if (abseta<=eta1_) theSF=SF5_;
-    if (abseta>eta1_ && abseta<=eta2_) theSF=SF4_;
-    if (abseta>eta2_) theSF=SF5_;
+  if (track->pt() > pT2_ && track->pt() <= pT3_){
+    if (abseta <= eta1_) theSF = SF5_;
+    if (abseta > eta1_ && abseta <= eta2_) theSF = SF4_;
+    if (abseta > eta2_) theSF = SF5_;
   }
-  if (track->pt()>pT3_) theSF=SF5_;
+  if (track->pt() > pT3_) theSF = SF5_;
 
   LogTrace(theCategory) << "TSGForOI::calculateSFFromL2: SF has been calculated as: " << theSF;
+
   return theSF;
+    
 }
 
 
+//
+// Find hits on layers and create seeds from updated TSOS
+//
 int TSGForOI::makeSeedsFromHits(
 				const TrackerTopology* tTopo,
-				const GeometricSearchDet &layer,
-				const TrajectoryStateOnSurface &tsosAtIP,
-				std::vector<TrajectorySeed> &out,
+				const GeometricSearchDet& layer,
+				const TrajectoryStateOnSurface& tsosAtIP,
+				std::vector<TrajectorySeed>& out,
 				const Propagator& propagatorAlong,
-				const MeasurementTrackerEvent &measurementTracker,
+				const MeasurementTrackerEvent& measurementTracker,
 				edm::ESHandle<Chi2MeasurementEstimatorBase>& estimatorH,
 				unsigned int& numSeedsMade,
 				const double errorSF,
-				const double l2Eta)  const{
+				const double l2Eta) const {
 
-  //		Error Rescaling:
+  // Error Rescaling
   TrajectoryStateOnSurface onLayer(tsosAtIP);
   onLayer.rescaleError(errorSF);    
 
   std::vector< GeometricSearchDet::DetWithState > dets;
   layer.compatibleDetsV(onLayer, propagatorAlong, *estimatorH, dets);
-  
-  //	Find Measurements on each DetWithState:
+
+  // Find Measurements on each DetWithState
   LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: find measurements on each detWithState  " << dets.size() << endl;
   std::vector<TrajectoryMeasurement> meas;
   for (std::vector<GeometricSearchDet::DetWithState>::iterator it=dets.begin(); it!=dets.end(); ++it) {
     MeasurementDetWithData det = measurementTracker.idToDet(it->first->geographicalId());
-    if (det.isNull()) {
-      continue;
-    }
-    if (!it->second.isValid()) continue;	//Skip if TSOS is not valid
+    if (det.isNull()) continue;
+    if (!it->second.isValid()) continue;	// Skip if TSOS is not valid
 
-    std::vector < TrajectoryMeasurement > mymeas = det.fastMeasurements(it->second, onLayer, propagatorAlong, *estimatorH);	//Second TSOS is not used
+    std::vector < TrajectoryMeasurement > mymeas = det.fastMeasurements(it->second, onLayer, propagatorAlong, *estimatorH);	// Second TSOS is not used
     for (std::vector<TrajectoryMeasurement>::const_iterator it2 = mymeas.begin(), ed2 = mymeas.end(); it2 != ed2; ++it2) {
-      if (it2->recHit()->isValid()) meas.push_back(*it2);	//Only save those which are valid
+      if (it2->recHit()->isValid()) meas.push_back(*it2);	// Only save those which are valid
     }
   }
   
-  
-  //	Update TSOS using TMs after sorting, then create Trajectory Seed and put into vector:
+  // Update TSOS using TMs after sorting, then create Trajectory Seed and put into vector
   LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: Update TSOS using TMs after sorting, then create Trajectory Seed, number of TM = " << meas.size() << endl;
   unsigned int found = 0;
   std::sort(meas.begin(), meas.end(), TrajMeasLessEstim());
@@ -348,8 +365,8 @@ int TSGForOI::makeSeedsFromHits(
     LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: TSOS for TM " << found << endl;
     if (not updatedTSOS.isValid()) continue;
 
-    // CHECK if is StereoLayer: 
-    if (useStereoLayersInTEC_ && (fabs(l2Eta) > 0.8 && fabs(l2Eta) < 1.6)) { 
+    // Check if it is a Stereo TEC Layer
+    if (useStereoLayersInTEC_ && (fabs(l2Eta) > 0.8 && fabs(l2Eta) < 1.6)) {
       DetId detid = ((*it).recHit()->hit())->geographicalId();
       if (detid.subdetId() == StripSubdetector::TEC) {
 		if (!tTopo->tecIsStereo(detid.rawId())) break;  // try another layer
@@ -366,14 +383,17 @@ int TSGForOI::makeSeedsFromHits(
     numSeedsMade++;
     if (found == numOfHitsToTry_) break;
   }
-  return found;
-}
-//
-//// calculate Chi^2 of two trajectory states
-////
 
+  return found;
+
+}
+
+
+//
+// calculate Chi^2 of two trajectory states
+//
 double TSGForOI::match_Chi2(const TrajectoryStateOnSurface& tsos1,
-                  const TrajectoryStateOnSurface& tsos2) const{
+                            const TrajectoryStateOnSurface& tsos2) const {
 
   if ( !tsos1.isValid() || !tsos2.isValid() ) return -1.;
 
@@ -394,7 +414,11 @@ double TSGForOI::match_Chi2(const TrajectoryStateOnSurface& tsos1,
 }
 
 
+//
+//
+//
 void TSGForOI::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src",edm::InputTag("hltL2Muons","UpdatedAtVtx"));
   desc.add<int>("layersToTry",1);
@@ -425,6 +449,7 @@ void TSGForOI::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   desc.add<double>("tsosDiff2",0.02);
   desc.add<std::string>("propagatorName","PropagatorWithMaterial");
   descriptions.add("TSGForOI",desc);
+
 }
 
 DEFINE_FWK_MODULE(TSGForOI);

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -449,7 +449,7 @@ void TSGForOI::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   desc.add<double>("SF6",2.0);
   desc.add<double>("tsosDiff1",0.2);
   desc.add<double>("tsosDiff2",0.02);
-  desc.add<std::string>("propagatorName","PropagatorWithMaterial");
+  desc.add<std::string>("propagatorName","PropagatorWithMaterialParabolicMf");
   descriptions.add("TSGForOI",desc);
 
 }

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
@@ -29,10 +29,7 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/GeomPropagators/interface/StateOnTrackerBound.h"
-
-
-
-
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 class TSGForOI : public edm::global::EDProducer<> {
     
@@ -65,7 +62,7 @@ class TSGForOI : public edm::global::EDProducer<> {
     const bool adjustErrorsDynamicallyForHits_;
     const bool adjustErrorsDynamicallyForHitless_;
 
-  	/// Estimator used to find dets and TrajectoryMeasurements
+    /// Estimator used to find dets and TrajectoryMeasurements
     const std::string estimatorName_;
 
     /// Minimum eta value to activate searching in the TEC
@@ -88,7 +85,7 @@ class TSGForOI : public edm::global::EDProducer<> {
 
     /// pT, eta ranges and scale factor values
     const double pT1_,pT2_,pT3_;
-    const double eta1_,eta2_;
+    const double eta1_,eta2_,eta3_,eta4_,eta5_,eta6_;
     const double SF1_,SF2_,SF3_,SF4_,SF5_,SF6_;
 
     /// Distance of L2 TSOSs before and after updated with vertex
@@ -101,35 +98,35 @@ class TSGForOI : public edm::global::EDProducer<> {
 
     /// Find seeds on a given layer
     void findSeedsOnLayer(
-                const TrackerTopology* tTopo,
-                const GeometricSearchDet& layer,
-                const TrajectoryStateOnSurface& tsosAtIP,
-                const Propagator& propagatorAlong,
-                const Propagator& propagatorOpposite,
-                const reco::TrackRef l2,
-                edm::ESHandle<Chi2MeasurementEstimatorBase>& estimator,
-                edm::Handle<MeasurementTrackerEvent>& measurementTrackerH,
-                unsigned int& numSeedsMade,
-                unsigned int& hitlessSeedsMade,
-                unsigned int& numOfMaxSeeds,
-                unsigned int& layerCount,
-                std::unique_ptr<std::vector<TrajectorySeed> >& out) const;
+        const TrackerTopology* tTopo,
+        const GeometricSearchDet& layer,
+        const TrajectoryStateOnSurface& tsosAtIP,
+        const Propagator& propagatorAlong,
+        const Propagator& propagatorOpposite,
+        const reco::TrackRef l2,
+        edm::ESHandle<Chi2MeasurementEstimatorBase>& estimator,
+        edm::Handle<MeasurementTrackerEvent>& measurementTrackerH,
+        unsigned int& numSeedsMade,
+        unsigned int& hitlessSeedsMade,
+        unsigned int& numOfMaxSeeds,
+        unsigned int& layerCount,
+        std::unique_ptr<std::vector<TrajectorySeed> >& out) const;
 
     /// Calculate the dynamic error SF by analysing the L2
     double calculateSFFromL2(const reco::TrackRef track) const;
 
     /// Find hits on layers and create seeds from updated TSOS
     int makeSeedsFromHits(
-                const TrackerTopology* tTopo,
-                const GeometricSearchDet& layer,
-                const TrajectoryStateOnSurface& tsosAtIP,
-                std::vector<TrajectorySeed>& out,
-                const Propagator& propagatorAlong,
-                const MeasurementTrackerEvent& measurementTracker,
-                edm::ESHandle<Chi2MeasurementEstimatorBase>& estimator,
-                unsigned int& numSeedsMade,
-                const double errorSF,
-                const double l2Eta) const;
+        const TrackerTopology* tTopo,
+        const GeometricSearchDet& layer,
+        const TrajectoryStateOnSurface& tsosAtIP,
+        std::vector<TrajectorySeed>& out,
+        const Propagator& propagatorAlong,
+        const MeasurementTrackerEvent& measurementTracker,
+        edm::ESHandle<Chi2MeasurementEstimatorBase>& estimator,
+        unsigned int& numSeedsMade,
+        const double errorSF,
+        const double l2Eta) const;
 
     /// Find compatability between two TSOSs
     double match_Chi2(const TrajectoryStateOnSurface& tsos1,

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
@@ -31,31 +31,35 @@
 #include "TrackingTools/GeomPropagators/interface/StateOnTrackerBound.h"
 
 class TSGForOI : public edm::global::EDProducer<> {
-public:
-	explicit TSGForOI(const edm::ParameterSet & iConfig);
-	~TSGForOI() override;
-	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-	void produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
-private:
-	/// Labels for input collections
-	const edm::EDGetTokenT<reco::TrackCollection> src_;
+    
+  public:
+    
+    explicit TSGForOI(const edm::ParameterSet & iConfig);
+    ~TSGForOI() override;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+    void produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
-	/// Maximum number of seeds for each L2
-	const unsigned int numOfMaxSeedsParam_;
+  private:
+    
+    /// Labels for input collections
+    const edm::EDGetTokenT<reco::TrackCollection> src_;
 
-	/// How many layers to try
-	const unsigned int numOfLayersToTry_;
+    /// Maximum number of seeds for each L2
+    const unsigned int numOfMaxSeedsParam_;
 
-	/// How many hits to try per layer
-	const unsigned int numOfHitsToTry_;
+    /// How many layers to try
+    const unsigned int numOfLayersToTry_;
 
-	/// How much to rescale errors from the L2 (fixed error vs pT, eta)
-	const double fixedErrorRescalingForHits_;
-	const double fixedErrorRescalingForHitless_;
+    /// How many hits to try per layer
+    const unsigned int numOfHitsToTry_;
 
-	/// Whether or not to use an automatically calculated scale-factor value
-	const bool adjustErrorsDynamicallyForHits_;
-	const bool adjustErrorsDynamicallyForHitless_;
+    /// Rescale L2 parameter uncertainties (fixed error vs pT, eta)
+    const double fixedErrorRescalingForHits_;
+    const double fixedErrorRescalingForHitless_;
+
+    /// Whether or not to use an automatically calculated scale-factor value
+    const bool adjustErrorsDynamicallyForHits_;
+    const bool adjustErrorsDynamicallyForHitless_;
 
 	/// Estimator used to find dets and TrajectoryMeasurements
 	const std::string estimatorName_;
@@ -83,50 +87,49 @@ private:
 	const double eta1_,eta2_;
 	const double SF1_,SF2_,SF3_,SF4_,SF5_;
 
-	/// Distance of TSOSs to trigger using hits or not
-	const double tsosDiff1_;
-
-        const double tsosDiff2_;
+	/// Distance of L2 TSOSs before and after updated with vertex
+    const double tsosDiff1_;
+    const double tsosDiff2_;
 
 	/// Counters and flags for the implementation
 	const std::string propagatorName_;
 	const std::string theCategory;
 
-	/// Function to find seeds on a given layer
+	/// Find seeds on a given layer
 	void findSeedsOnLayer(
 				const TrackerTopology* tTopo,
-				const GeometricSearchDet &layer,
-				const TrajectoryStateOnSurface &tsosAtIP,
+				const GeometricSearchDet& layer,
+				const TrajectoryStateOnSurface& tsosAtIP,
 				const Propagator& propagatorAlong,
 				const Propagator& propagatorOpposite,
 				const reco::TrackRef l2,
 				edm::ESHandle<Chi2MeasurementEstimatorBase>& estimator_,
 				edm::Handle<MeasurementTrackerEvent>& measurementTrackerH,
 				unsigned int& numSeedsMade,
+                unsigned int& hitlessSeedsMade,
 				unsigned int& numOfMaxSeeds,
 				unsigned int& layerCount,
-				bool& analysedL2,
 				std::unique_ptr<std::vector<TrajectorySeed> >& out) const;
 
-	/// Function used to calculate the dynamic error SF by analysing the L2
+	/// Calculate the dynamic error SF by analysing the L2
 	double calculateSFFromL2(const reco::TrackRef track) const;
 
-	/// Function to find hits on layers and create seeds from updated TSOS
+	/// Find hits on layers and create seeds from updated TSOS
 	int makeSeedsFromHits(
 				const TrackerTopology* tTopo,
-				const GeometricSearchDet &layer,
-				const TrajectoryStateOnSurface &tsosAtIP,
-				std::vector<TrajectorySeed> &out,
+				const GeometricSearchDet& layer,
+				const TrajectoryStateOnSurface& tsosAtIP,
+				std::vector<TrajectorySeed>& out,
 				const Propagator& propagatorAlong,
-				const MeasurementTrackerEvent &measurementTracker,
+				const MeasurementTrackerEvent& measurementTracker,
 				edm::ESHandle<Chi2MeasurementEstimatorBase>& estimator_,
 				unsigned int& numSeedsMade,
 				const double errorSF,
 				const double l2Eta) const;
 
-        //Find compatability between two TSOSs
-        double match_Chi2(const TrajectoryStateOnSurface& tsos1,
-        		  const TrajectoryStateOnSurface& tsos2) const;
+    /// Find compatability between two TSOSs
+    double match_Chi2(const TrajectoryStateOnSurface& tsos1,
+                      const TrajectoryStateOnSurface& tsos2) const;
                                           
 };
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
@@ -30,6 +30,10 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/GeomPropagators/interface/StateOnTrackerBound.h"
 
+
+
+
+
 class TSGForOI : public edm::global::EDProducer<> {
     
   public:
@@ -61,71 +65,71 @@ class TSGForOI : public edm::global::EDProducer<> {
     const bool adjustErrorsDynamicallyForHits_;
     const bool adjustErrorsDynamicallyForHitless_;
 
-	/// Estimator used to find dets and TrajectoryMeasurements
-	const std::string estimatorName_;
+  	/// Estimator used to find dets and TrajectoryMeasurements
+    const std::string estimatorName_;
 
-	/// Minimum eta value to activate searching in the TEC
-	const double minEtaForTEC_;
+    /// Minimum eta value to activate searching in the TEC
+    const double minEtaForTEC_;
 
-	/// Maximum eta value to activate searching in the TOB
-	const double maxEtaForTOB_;
+    /// Maximum eta value to activate searching in the TOB
+    const double maxEtaForTOB_;
 
-	/// Switch ON  (True) : use additional hits for seeds depending on the L2 properties (ignores numOfMaxSeeds_) 
-	/// Switch OFF (False): the numOfMaxSeeds_ defines if we will use hitless (numOfMaxSeeds_==1) or hitless+hits (numOfMaxSeeds_>1) 
-	const bool useHitLessSeeds_;
+    /// Switch ON  (True) : use additional hits for seeds depending on the L2 properties (ignores numOfMaxSeeds_) 
+    /// Switch OFF (False): the numOfMaxSeeds_ defines if we will use hitless (numOfMaxSeeds_==1) or hitless+hits (numOfMaxSeeds_>1) 
+    const bool useHitLessSeeds_;
 
-	/// Switch ON to use Stereo layers instead of using every layer in TEC.
-	const bool useStereoLayersInTEC_;
+    /// Switch ON to use Stereo layers instead of using every layer in TEC.
+    const bool useStereoLayersInTEC_;
 
-	/// KFUpdator defined in constructor
-	const std::unique_ptr<TrajectoryStateUpdator> updator_;
+    /// KFUpdator defined in constructor
+    const std::unique_ptr<TrajectoryStateUpdator> updator_;
 
-	const edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerTag_;
+    const edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerTag_;
 
-	/// pT, eta ranges and scale factor values
-	const double pT1_,pT2_,pT3_;
-	const double eta1_,eta2_;
-	const double SF1_,SF2_,SF3_,SF4_,SF5_;
+    /// pT, eta ranges and scale factor values
+    const double pT1_,pT2_,pT3_;
+    const double eta1_,eta2_;
+    const double SF1_,SF2_,SF3_,SF4_,SF5_,SF6_;
 
-	/// Distance of L2 TSOSs before and after updated with vertex
+    /// Distance of L2 TSOSs before and after updated with vertex
     const double tsosDiff1_;
     const double tsosDiff2_;
 
-	/// Counters and flags for the implementation
-	const std::string propagatorName_;
-	const std::string theCategory;
+    /// Counters and flags for the implementation
+    const std::string propagatorName_;
+    const std::string theCategory;
 
-	/// Find seeds on a given layer
-	void findSeedsOnLayer(
-				const TrackerTopology* tTopo,
-				const GeometricSearchDet& layer,
-				const TrajectoryStateOnSurface& tsosAtIP,
-				const Propagator& propagatorAlong,
-				const Propagator& propagatorOpposite,
-				const reco::TrackRef l2,
-				edm::ESHandle<Chi2MeasurementEstimatorBase>& estimator_,
-				edm::Handle<MeasurementTrackerEvent>& measurementTrackerH,
-				unsigned int& numSeedsMade,
+    /// Find seeds on a given layer
+    void findSeedsOnLayer(
+                const TrackerTopology* tTopo,
+                const GeometricSearchDet& layer,
+                const TrajectoryStateOnSurface& tsosAtIP,
+                const Propagator& propagatorAlong,
+                const Propagator& propagatorOpposite,
+                const reco::TrackRef l2,
+                edm::ESHandle<Chi2MeasurementEstimatorBase>& estimator,
+                edm::Handle<MeasurementTrackerEvent>& measurementTrackerH,
+                unsigned int& numSeedsMade,
                 unsigned int& hitlessSeedsMade,
-				unsigned int& numOfMaxSeeds,
-				unsigned int& layerCount,
-				std::unique_ptr<std::vector<TrajectorySeed> >& out) const;
+                unsigned int& numOfMaxSeeds,
+                unsigned int& layerCount,
+                std::unique_ptr<std::vector<TrajectorySeed> >& out) const;
 
-	/// Calculate the dynamic error SF by analysing the L2
-	double calculateSFFromL2(const reco::TrackRef track) const;
+    /// Calculate the dynamic error SF by analysing the L2
+    double calculateSFFromL2(const reco::TrackRef track) const;
 
-	/// Find hits on layers and create seeds from updated TSOS
-	int makeSeedsFromHits(
-				const TrackerTopology* tTopo,
-				const GeometricSearchDet& layer,
-				const TrajectoryStateOnSurface& tsosAtIP,
-				std::vector<TrajectorySeed>& out,
-				const Propagator& propagatorAlong,
-				const MeasurementTrackerEvent& measurementTracker,
-				edm::ESHandle<Chi2MeasurementEstimatorBase>& estimator_,
-				unsigned int& numSeedsMade,
-				const double errorSF,
-				const double l2Eta) const;
+    /// Find hits on layers and create seeds from updated TSOS
+    int makeSeedsFromHits(
+                const TrackerTopology* tTopo,
+                const GeometricSearchDet& layer,
+                const TrajectoryStateOnSurface& tsosAtIP,
+                std::vector<TrajectorySeed>& out,
+                const Propagator& propagatorAlong,
+                const MeasurementTrackerEvent& measurementTracker,
+                edm::ESHandle<Chi2MeasurementEstimatorBase>& estimator,
+                unsigned int& numSeedsMade,
+                const double errorSF,
+                const double l2Eta) const;
 
     /// Find compatability between two TSOSs
     double match_Chi2(const TrajectoryStateOnSurface& tsos1,

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
@@ -84,7 +84,9 @@ private:
 	const double SF1_,SF2_,SF3_,SF4_,SF5_;
 
 	/// Distance of TSOSs to trigger using hits or not
-	const double tsosDiff_;
+	const double tsosDiff1_;
+
+        const double tsosDiff2_;
 
 	/// Counters and flags for the implementation
 	const std::string propagatorName_;


### PR DESCRIPTION
- The fixes added is supposed to enhance the L3 Outside-in reconstruction efficiency up to 3-4% depending on eta region 
    -  link to slides in HLT meeting : https://indico.cern.ch/event/724303/contributions/2979159/attachments/1638779/2615747/OI_improvementsPurdue_24thApril2018.pdf

- Currently OI starts from L2 muons with
    - Trajectory State on Surface (TSOS) in innermost Muon station (1)
    - TSOS at vertex after updating the parameters with vertex information (2) 
- Fix-I
    - Check compatibility between (1) and (2)
        - 5 parameter Chi2 and DeltaR(OuterTrakerStateInside,OuterTrackerStateOutside) 
        - If the two TSOS are too far apart use both states to start seed generation
   - To use (1)
       - first propagate from muon system to outer tracker surface using SteppingHelixPropagator,
       -  then use 'PropagatorWithMaterialParabolicMf' to propagate to TOB and TEC layers.  (In the previous version 'PropagatorWithMaterial' was used for both propagation steps.)
- Fix-II
   - Seeds are created on the outermost 2 layers:
      - The layer counter was not properly initialized before we proceed to step (2)
      - Has been fixed, initialized to 0 before layers are found for generating seeds using
TSOS at muon station
      - Scale factors have been optimized for different rapidity ranges:
           - Smaller scale factor in Barrel and Larger in the Endcap Use more eta bins 

- Fix-III
  - Optimize eta range where hits on stereo TEC dets are used to build seeds
    -  Before: If the L2 muon is 0.8-1.6
        - Create seeds using the stereo modules
        - Skip the modules without stereo hits
    - Now: 
       - Range is optimized to: (1.1 to 2.0 ) and (2.15 to 2.4)

