### PR TITLE
[101X][change Metadata] Adding PCC + TrackAlign PCL not consumed by Prompt

### DIFF
--- a/CondFormats/Common/test/LumiCorrections_prep.json
+++ b/CondFormats/Common/test/LumiCorrections_prep.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "LumiPCC_Corrections_prep_prompt": {}
+    }, 
+    "inputTag": "LumiPCCCorrections_pcl", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for PCC"
+}

--- a/CondFormats/Common/test/LumiCorrections_prod.json
+++ b/CondFormats/Common/test/LumiCorrections_prod.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
+    "destinationTags": {
+        "LumiPCC_Corrections_prompt": {}
+    }, 
+    "inputTag": "LumiPCCCorrections_pcl", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for PCC"
+}

--- a/CondFormats/Common/test/ProduceDropBoxMetadata.py
+++ b/CondFormats/Common/test/ProduceDropBoxMetadata.py
@@ -66,6 +66,10 @@ SiPixelAliRcd_prep_str = encodeJsonInString("SiPixelAliRcd_prep.json")
 EcalPedestalsRcd_prod_str = encodeJsonInString("EcalPedestal_prod.json")
 EcalPedestalsRcd_prep_str = encodeJsonInString("EcalPedestal_prep.json")
 
+#LumiCorrectionsRcd
+LumiCorrectionsRcd_prod_str = encodeJsonInString("LumiCorrections_prod.json")
+LumiCorrectionsRcd_prep_str = encodeJsonInString("LumiCorrections_prep.json")
+
 # given a set of .json files in the current dir, ProduceDropBoxMetadata produces a sqlite containign the payload with the prod/and/prep metadata
 process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                   # set to True if you want to write out a sqlite.db translating the json's into a payload
@@ -136,13 +140,19 @@ process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                                                prodMetaData        = cms.untracked.string(EcalPedestalsRcd_prod_str),
                                                                prepMetaData        = cms.untracked.string(EcalPedestalsRcd_prep_str),
                                                                ),
+                                                      cms.PSet(record              = cms.untracked.string('LumiCorrectionsRcd'),
+                                                               Source              = cms.untracked.string("AlcaHarvesting"),
+                                                               FileClass           = cms.untracked.string("ALCA"),
+                                                               prodMetaData        = cms.untracked.string(LumiCorrectionsRcd_prod_str),
+                                                               prepMetaData        = cms.untracked.string(LumiCorrectionsRcd_prep_str),
+                                                               ),
                                                       ),
                                   # this boolean will read the content of whichever payload is available and print its content to stoutput
                                   # set this to false if you write out a sqlite.db translating the json's into a payload
                                   read = cms.untracked.bool(False),
 
                                   # toRead lists of record naemes to be sought inside the DropBoxMetadataRcd payload avaialble to the ProduceDropBoxMetadata; for instance, if write is True, you're reading back the metadata you've just entered in the payload from the .json files
-                                  toRead = cms.untracked.vstring('BeamSpotObjectsRcdByRun','BeamSpotObjectsRcdByLumi','BeamSpotObjectsRcdHPByLumi','BeamSpotObjectsRcdHPByRun','SiStripBadStripRcd','SiStripApvGainRcd','TrackerAlignmentRcd','SiStripApvGainRcdAfterAbortGap','SiStripApvGainRcdAAG','EcalPedestalsRcd') # same strings as fType
+                                  toRead = cms.untracked.vstring('BeamSpotObjectsRcdByRun','BeamSpotObjectsRcdByLumi','BeamSpotObjectsRcdHPByLumi','BeamSpotObjectsRcdHPByRun','SiStripBadStripRcd','SiStripApvGainRcd','TrackerAlignmentRcd','SiStripApvGainRcdAfterAbortGap','SiStripApvGainRcdAAG','EcalPedestalsRcd',"LumiCorrectionsRcd")# same strings as fType
                                   )
 
 process.p = cms.Path(process.mywriter)
@@ -150,7 +160,7 @@ process.p = cms.Path(process.mywriter)
 if process.mywriter.write:
 
     from CondCore.CondDB.CondDB_cfi import CondDB
-    CondDB.connect = "sqlite_file:DropBoxMetadata_addHPbyRun_addAAGmulti.db"
+    CondDB.connect = "sqlite_file:DropBoxMetadata_addLumiCorrections_TrackerAlignmentPCLoff.db"
 
     process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                               CondDB,

--- a/CondFormats/Common/test/SiPixelAliRcd_prod.json
+++ b/CondFormats/Common/test/SiPixelAliRcd_prod.json
@@ -2,9 +2,9 @@
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
         "SiPixelAli_PCL_v0_hlt": {}, 
-        "TrackerAlignment_PCL_byRun_v2_express": {}
+        "TrackerAlignment_PCL_byRun_v1_express": {}
     }, 
     "inputTag": "SiPixelAli_pcl", 
     "since": null, 
-    "userText": "T0 PCL Upload for SiPixel Ali - moved to the tag consumed by prompt. (prod)"
+    "userText": "T0 PCL Upload for SiPixel Ali - changed to v1 to not be consumed by prompt. (prod). To be consumed change v1 to v2."
 }


### PR DESCRIPTION
This PR has no effect on any workflow.
This PR keeps track on the script that produce the latest IOV of the metadata TAG:
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/DropBoxMetadata_v5.1_express
(not yet appened to the offical tag)
The test single IOV is in:
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prep/tags/DropBoxMetadata_PCC_TrackAlnoPCC_v1