### PR TITLE
avoid repeating computations when initializing HcalPulseShapes

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseShape.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseShape.h
@@ -9,7 +9,6 @@ public:
   HcalPulseShape(const std::vector<double>&,unsigned);
   void setNBin(int n);
   void setShapeBin(int i, float f);
-  float getTpeak() const { return tpeak_; }
   float operator()(double time) const;
   float at(double time) const;
   float integrate(double tmin, double tmax) const;
@@ -17,7 +16,6 @@ public:
 private:
   std::vector<float> shape_;
   int nbin_;
-  float tpeak_;
 };
 
 #endif

--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseShape.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseShape.h
@@ -6,6 +6,7 @@
 class HcalPulseShape {
 public:
   HcalPulseShape();
+  HcalPulseShape(const std::vector<double>&,unsigned);
   void setNBin(int n);
   void setShapeBin(int i, float f);
   float getTpeak() const { return tpeak_; }

--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
@@ -65,19 +65,47 @@ public:
     }
     return result;
   }
+  static std::vector<double> normalize(std::vector<double> nt, unsigned nbin){
+    //skip first bin, always 0
+    double norm = 0.;
+    for (unsigned int j = 1; j <= nbin; ++j) {
+      norm += (nt[j]>0) ? nt[j] : 0.;
+    }
+
+    double normInv=1./norm;
+    for (unsigned int j = 1; j <= nbin; ++j) {
+      nt[j] *= normInv;
+    }
+
+    return nt;
+  }
+  static std::vector<double> normalizeShift(std::vector<double> nt, unsigned nbin, int shift){
+    //skip first bin, always 0
+    double norm = 0.;
+    for (unsigned int j = std::max(1,-1*shift); j<=nbin; j++) {
+      norm += std::max(0., nt[j-shift]);
+    }
+    double normInv=1./norm;
+    std::vector<double> nt2(nbin,0);
+    for ( int j = 1; j<=(int)nbin; j++) {
+      if ( j-shift>=0 ) {
+        nt2[j] = nt[j-shift]*normInv;
+      }
+    }
+    return nt2;
+  }
 
 private:
   void computeHPDShape(float, float, float, float, float ,
                        float, float, float, Shape&);
   void computeHFShape();
   void computeSiPMShapeHO();
-  void computeSiPMShapeHE203();
-  void computeSiPMShapeHE206();
+  const HcalPulseShape& computeSiPMShapeHE203();
+  const HcalPulseShape& computeSiPMShapeHE206();
   void computeSiPMShapeData2017();
   void computeSiPMShapeData2018();
   Shape hpdShape_, hfShape_, siPMShapeHO_;
-  Shape siPMShapeMC2017_, siPMShapeData2017_;
-  Shape siPMShapeMC2018_, siPMShapeData2018_;
+  Shape siPMShapeData2017_, siPMShapeData2018_;
   Shape hpdShape_v2, hpdShapeMC_v2;
   Shape hpdShape_v3, hpdShapeMC_v3;
   Shape hpdBV30Shape_v2, hpdBV30ShapeMC_v2;

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseShape.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseShape.cc
@@ -5,6 +5,14 @@ HcalPulseShape::HcalPulseShape() {
   tpeak_=0;
 }
 
+HcalPulseShape::HcalPulseShape(const std::vector<double>& shape, unsigned nbin) :
+  shape_(shape.begin(),shape.begin()+nbin),
+  nbin_(nbin)
+{
+  tpeak_ = 0;
+}
+
+
 void HcalPulseShape::setNBin(int n) {
   nbin_=n;
   shape_=std::vector<float>(n,0.0f);

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseShape.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseShape.cc
@@ -2,14 +2,12 @@
 
 HcalPulseShape::HcalPulseShape() {
   nbin_=0;
-  tpeak_=0;
 }
 
 HcalPulseShape::HcalPulseShape(const std::vector<double>& shape, unsigned nbin) :
   shape_(shape.begin(),shape.begin()+nbin),
   nbin_(nbin)
 {
-  tpeak_ = 0;
 }
 
 

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
@@ -381,7 +381,7 @@ void HcalPulseShapes::computeSiPMShapeHO()
 const HcalPulseShape& HcalPulseShapes::computeSiPMShapeHE203()
 {
   //numerical convolution of SiPM pulse + WLS fiber shape
-  static HcalPulseShape siPMShapeMC2017(normalize(convolve(nBinsSiPM_,analyticPulseShapeSiPMHE,Y11203),nBinsSiPM_),nBinsSiPM_);
+  static const HcalPulseShape siPMShapeMC2017(normalize(convolve(nBinsSiPM_,analyticPulseShapeSiPMHE,Y11203),nBinsSiPM_),nBinsSiPM_);
   return siPMShapeMC2017;
 }
 
@@ -389,7 +389,7 @@ const HcalPulseShape& HcalPulseShapes::computeSiPMShapeHE206()
 {
   //numerical convolution of SiPM pulse + WLS fiber shape
   //shift: aligning 206 phase closer to 205 in order to have good reco agreement
-  static HcalPulseShape siPMShapeMC2018(normalizeShift(convolve(nBinsSiPM_,analyticPulseShapeSiPMHE,Y11206),nBinsSiPM_,-2),nBinsSiPM_);
+  static const HcalPulseShape siPMShapeMC2018(normalizeShift(convolve(nBinsSiPM_,analyticPulseShapeSiPMHE,Y11206),nBinsSiPM_,-2),nBinsSiPM_);
   return siPMShapeMC2018;
 }
 

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
@@ -77,16 +77,14 @@ Reco  MC
 
   computeHFShape();
   computeSiPMShapeHO();
-  computeSiPMShapeHE203();
-  computeSiPMShapeHE206();
   computeSiPMShapeData2017();
   computeSiPMShapeData2018();
 
   theShapes[201] = &siPMShapeHO_;
   theShapes[202] = theShapes[201];
-  theShapes[203] = &siPMShapeMC2017_;
+  theShapes[203] = &(computeSiPMShapeHE203());
   theShapes[205] = &siPMShapeData2017_;
-  theShapes[206] = &siPMShapeMC2018_;
+  theShapes[206] = &(computeSiPMShapeHE206());
   theShapes[207] = &siPMShapeData2018_;
   theShapes[301] = &hfShape_;
   //theShapes[401] = new CaloCachedShapeIntegrator(&theZDCShape);
@@ -380,50 +378,19 @@ void HcalPulseShapes::computeSiPMShapeHO()
   }
 }
 
-void HcalPulseShapes::computeSiPMShapeHE203()
+const HcalPulseShape& HcalPulseShapes::computeSiPMShapeHE203()
 {
   //numerical convolution of SiPM pulse + WLS fiber shape
-  std::vector<double> nt = convolve(nBinsSiPM_,analyticPulseShapeSiPMHE,Y11203);
-
-  siPMShapeMC2017_.setNBin(nBinsSiPM_);
-
-  //skip first bin, always 0
-  double norm = 0.;
-  for (unsigned int j = 1; j <= nBinsSiPM_; ++j) {
-    norm += (nt[j]>0) ? nt[j] : 0.;
-  }
-
-  for (unsigned int j = 1; j <= nBinsSiPM_; ++j) {
-    nt[j] /= norm;
-    siPMShapeMC2017_.setShapeBin(j,nt[j]);
-  }
+  static HcalPulseShape siPMShapeMC2017(normalize(convolve(nBinsSiPM_,analyticPulseShapeSiPMHE,Y11203),nBinsSiPM_),nBinsSiPM_);
+  return siPMShapeMC2017;
 }
 
-void HcalPulseShapes::computeSiPMShapeHE206()
+const HcalPulseShape& HcalPulseShapes::computeSiPMShapeHE206()
 {
   //numerical convolution of SiPM pulse + WLS fiber shape
-  std::vector<double> nt = convolve(nBinsSiPM_,analyticPulseShapeSiPMHE,Y11206);
-
-  siPMShapeMC2018_.setNBin(nBinsSiPM_);
-
-  //Aligning 206 phase closer to 205 in order to have good reco agreement
-  int shift = -2;
-
-  //skip first bin, always 0
-  double norm = 0.;
-  for (unsigned int j = std::max(1,-1*shift); j<=nBinsSiPM_; j++) {
-    norm += std::max(0., nt[j-shift]);
-  }
-  double normInv=1./norm;
-  for ( int j = 1; j<=nBinsSiPM_; j++) {
-    if ( j-shift>=0 ) {
-      nt[j-shift]*=normInv;
-      siPMShapeMC2018_.setShapeBin(j,nt[j-shift]);
-    }
-    else{
-      siPMShapeMC2018_.setShapeBin(j,0);
-    }
-  }
+  //shift: aligning 206 phase closer to 205 in order to have good reco agreement
+  static HcalPulseShape siPMShapeMC2018(normalizeShift(convolve(nBinsSiPM_,analyticPulseShapeSiPMHE,Y11206),nBinsSiPM_,-2),nBinsSiPM_);
+  return siPMShapeMC2018;
 }
 
 const HcalPulseShapes::Shape &


### PR DESCRIPTION
Resolves #22913, though better code design (e.g. ESProduct) would be preferable for long-term maintainability. I also made a few very minor optimizations and cleanups while making the major change (using magic statics).

attn: @abdoulline @wddgit @Dr15Jones @slava77 