### PR TITLE
Fix noise in dqmMemoryStats

### DIFF
--- a/DQMServices/FileIO/scripts/dqmMemoryStats.py
+++ b/DQMServices/FileIO/scripts/dqmMemoryStats.py
@@ -38,7 +38,9 @@ class HistogramAnalyzer(object):
             self._all[fn] = HistogramEntry(t, bin_size, bin_count, extra, total_bytes)
         else:
             t = str(type(obj))
-            bin_count, bin_size, extra = 0, 0, len(str(obj)) + len(fn)
+            #bin_count, bin_size, extra = 0, 0, len(str(obj)) + len(fn)
+            # assume constant size for strings
+            bin_count, bin_size, extra = 0, 0, 10 + len(fn)
             total_bytes = bin_count * bin_size + extra
 
             self._all[fn] = HistogramEntry(t, bin_size, bin_count, extra, total_bytes)


### PR DESCRIPTION
Assume constant size for strings in dqmMemoryStats.

This should prevent the noise in PR comparisons (`DQMHistoSizes`) where nothing changed, except for the release name.

Note that this will not be effective when testing this PR, cms-bot appears to use the base IB version of the script. 

A PR to cms-bot improving the ouptut in general will come soon. 