### PR TITLE
CPPF emulator @maseguracern, Max 2 clusters per chamber

### DIFF
--- a/L1Trigger/L1TMuonCPPF/BuildFile.xml
+++ b/L1Trigger/L1TMuonCPPF/BuildFile.xml
@@ -1,0 +1,33 @@
+<export>
+  <lib name="1"/>
+</export>
+
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="DataFormats/L1TMuon"/>
+<use name="L1Trigger/L1TMuon"/>
+<use name="root"/>
+
+<use name="FWCore/PluginManager"/>
+
+<use name="DataFormats/Common"/>
+<use name="DataFormats/DetId"/>
+<use name="DataFormats/MuonDetId"/>
+<use name="DataFormats/RPCDigi"/>
+<use name="DataFormats/RPCRecHit"/>
+<use name="DataFormats/TrackingRecHit"/>
+
+<use name="CondFormats/RPCObjects"/>
+<use name="CondFormats/DataRecord"/>
+
+<use name="Geometry/Records"/>
+<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/RPCGeometry"/>
+<use name="TrackingTools/TrackRefitter"/>
+
+<use name="RecoMuon/DetLayers"/>
+
+<use name="FWCore/Utilities"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/Concurrency"/>
+<use name="L1Trigger/L1TMuonEndCap"/>

--- a/L1Trigger/L1TMuonCPPF/README.md
+++ b/L1Trigger/L1TMuonCPPF/README.md
@@ -1,0 +1,50 @@
+# CPPFDigis Emulator
+
+This is the first version of the CPPF emulator. we use the RPC Digitization and 
+reconstruction as intermedate steps. 
+Under test you can find two examples, one unpacking 2017F RAW Data (cppf_emulator_RAW.py)
+and another one using generated MC events (cppf_emulator_MC.py). 
+The output of the unpacker is an edm branch named emulatorCppfDigis, following
+the CPPFDigi dataformat already committed in CMSSW_10_1_X.
+
+# Out of the box instructions
+
+```
+ssh -XY username@lxplus.cern.ch
+#setenv SCRAM_ARCH slc6_amd64_gcc630 
+#(or export SCRAM_ARCH=slc6_amd64_gcc630)
+cmsrel CMSSW_10_1_X_2018-04-03-1100
+cd CMSSW_10_1_X_2018-04-03-1100/src
+cmsenv
+```
+
+```
+git cms-init
+git fetch maseguracern
+#git cms-merge-topic -u maseguracern:CPPF_Emulator_V2
+git cms-merge-topic -u maseguracern:maseguracern/DQM_CPPF
+#scram b clean 
+scram b -j6
+```
+
+## Run the code (check the input)
+```
+cd L1Trigger/L1TMuonCPPF
+cmsRun test/cppf_emulator_RAW.py (Generate Tree CPPF_Digis)
+cmsRun test/Generator_DQM_CPPF.py (Create DQM-plots for before step)
+cmsRun test/cppf_emulator_RAW_DQM_Plots.py (Whole sequence)
+```
+
+## Setup your Github space (In case you haven't)
+```
+git remote add YourGitHubName git@github.com:YourGitHubName/cmssw.git
+git fetch YourGitHubName
+git checkout -b YourBranchName
+```
+
+## Modifying files
+```
+git add <Modified files>
+git commit -m "Commit message"
+git push my-cmssw YourBranchName
+```

--- a/L1Trigger/L1TMuonCPPF/interface/EmulateCPPF.h
+++ b/L1Trigger/L1TMuonCPPF/interface/EmulateCPPF.h
@@ -1,0 +1,36 @@
+#ifndef L1Trigger_L1TMuonCPPF_EmulateCPPF_h
+#define L1Trigger_L1TMuonCPPF_EmulateCPPF_h
+
+#include "L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h"
+
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+
+class EmulateCPPF {
+  
+ public:
+  explicit EmulateCPPF(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iConsumes);
+  ~EmulateCPPF();
+  
+  void process(
+	       // Input
+	       const edm::Event& iEvent, const edm::EventSetup& iSetup,
+	       // Output
+	       l1t::CPPFDigiCollection& cppf_recHit
+	       );
+  
+  
+ private:
+  
+  // For now, treat CPPF as single board
+  // In the future, may want to treat the 4 CPPF boards in each endcap as separate entities
+  std::array<RecHitProcessor, 1> recHit_processors_;
+  
+  const edm::EDGetToken recHitToken_;
+  enum class CppfSource { File, EventSetup } cppfSource_;
+  std::vector<RecHitProcessor::CppfItem> CppfVec_1;
+  int MaxClusterSize_; 
+}; // End class EmulateCPPF
+
+#endif // #define L1Trigger_L1TMuonCPPF_EmulateCPPF_h

--- a/L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h
+++ b/L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h
@@ -1,0 +1,82 @@
+#ifndef L1Trigger_L1TMuonCPPF_RecHitProcessor_h
+#define L1Trigger_L1TMuonCPPF_RecHitProcessor_h
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "Geometry/RPCGeometry/interface/RPCRoll.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+
+#include "DataFormats/MuonDetId/interface/RPCDetId.h"
+#include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
+#include "DataFormats/L1TMuon/interface/CPPFDigi.h"
+
+#include "CondFormats/RPCObjects/interface/RPCMaskedStrips.h"
+#include "CondFormats/RPCObjects/interface/RPCDeadStrips.h"
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "L1Trigger/L1TMuonEndCap/interface/TrackTools.h"
+
+#include<boost/cstdint.hpp>
+#include<vector>
+#include<iostream>
+#include<sstream>
+#include<string> 
+#include<memory>
+#include<utility>
+#include <algorithm>
+#include <map>
+
+class RecHitProcessor {
+ public:
+  explicit RecHitProcessor();
+  ~RecHitProcessor();
+  
+  struct CppfItem {
+    
+    int lb;
+    int rawId;
+    int strip;
+    int lbchannel;
+    int halfchannel;
+    int int_phi;
+    int int_theta;
+    COND_SERIALIZABLE;
+  };
+  
+  std::vector<CppfItem> const & getCppfVec() const {return CppfVec;}
+  std::vector<CppfItem> CppfVec; 
+  
+  
+  void processLook(
+		   // Input
+		   const edm::Event& iEvent,
+		   const edm::EventSetup& iSetup,
+		   const edm::EDGetToken& recHitToken,
+		   std::vector<RecHitProcessor::CppfItem>& CppfVec1, 
+		   // Output
+		   l1t::CPPFDigiCollection& cppfDigis,
+		   const int MaxClusterSize
+		   ) const;
+  
+  void process(
+	       // Input
+	       const edm::Event& iEvent,
+	       const edm::EventSetup& iSetup,
+	       const edm::EDGetToken& recHitToken,
+	       // Output
+	       l1t::CPPFDigiCollection& cppfDigis
+	       ) const;
+  
+  void print(int a, int b, float c, float d) const {std::cout << a << " " << b << " " << c << " " << d << std::endl;};
+  
+  COND_SERIALIZABLE;
+  
+ private:
+  
+};
+
+#endif /* #define L1Trigger_L1TMuonCPPF_RecHitProcessor_h */

--- a/L1Trigger/L1TMuonCPPF/plugins/BuildFile.xml
+++ b/L1Trigger/L1TMuonCPPF/plugins/BuildFile.xml
@@ -1,0 +1,4 @@
+<library file="*.cc" name="L1TriggerL1TMuonCPPFPlugins">
+  <use name="L1Trigger/L1TMuonCPPF"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/L1Trigger/L1TMuonCPPF/plugins/L1TMuonCPPFDigiProducer.cc
+++ b/L1Trigger/L1TMuonCPPF/plugins/L1TMuonCPPFDigiProducer.cc
@@ -1,0 +1,41 @@
+// Emulator that takes RPC hits and produces CPPFDigis to send to EMTF
+// Author Alejandro Segura -- Universidad de los Andes
+
+#include "L1TMuonCPPFDigiProducer.h"
+
+
+L1TMuonCPPFDigiProducer::L1TMuonCPPFDigiProducer(const edm::ParameterSet& iConfig) :
+  cppf_emulator_(std::make_unique<EmulateCPPF>(iConfig, consumesCollector()))
+  //cppf_emulator_(new EmulateCPPF(iConfig, consumesCollector()))
+{
+  // produces<l1t::CPPFDigiCollection>("rpcDigi");
+  produces<l1t::CPPFDigiCollection>("recHit");
+}
+
+L1TMuonCPPFDigiProducer::~L1TMuonCPPFDigiProducer() {
+}
+
+void L1TMuonCPPFDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+    
+  // Create pointers to the collections which will store the cppfDigis 
+  // auto cppf_rpcDigi = std::make_unique<l1t::CPPFDigiCollection>();
+  auto cppf_recHit  = std::make_unique<l1t::CPPFDigiCollection>();
+
+  // Main CPPF emulation process: emulates CPPF output from RPCDigi or RecHit inputs
+  // From src/EmulateCPPF.cc
+  // cppf_emulator_->process(iEvent, iSetup, *cppf_rpcDigi, *cppf_recHit);
+  cppf_emulator_->process(iEvent, iSetup, *cppf_recHit);
+
+  // Fill the output collections
+  // iEvent.put(std::move(cppf_rpcDigi), "rpcDigi");
+  iEvent.put(std::move(cppf_recHit),  "recHit");
+}
+
+void L1TMuonCPPFDigiProducer::beginStream(edm::StreamID iID) {
+}
+
+void L1TMuonCPPFDigiProducer::endStream(){
+}
+
+// Define this as a plug-in
+DEFINE_FWK_MODULE(L1TMuonCPPFDigiProducer);

--- a/L1Trigger/L1TMuonCPPF/plugins/L1TMuonCPPFDigiProducer.h
+++ b/L1Trigger/L1TMuonCPPF/plugins/L1TMuonCPPFDigiProducer.h
@@ -1,0 +1,66 @@
+// Emulator that takes RPC hits and produces CPPFDigis to send to EMTF
+// Author Alejandro Segura -- Universidad de los Andes
+
+#ifndef L1Trigger_L1TMuonCPPF_L1TMuonCPPFDigiProducer_h
+#define L1Trigger_L1TMuonCPPF_L1TMuonCPPFDigiProducer_h
+
+#include "L1Trigger/L1TMuonCPPF/interface/EmulateCPPF.h"
+
+// System include files
+#include <memory>
+
+// User include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+//#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+// Other includes (all needed? - AWB 27.07.17)
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
+#include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
+
+#include "CondFormats/RPCObjects/interface/RPCDeadStrips.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "DataFormats/MuonDetId/interface/RPCDetId.h"
+#include "DataFormats/L1TMuon/interface/CPPFDigi.h"
+
+#include "Geometry/RPCGeometry/interface/RPCRoll.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+
+#include "L1Trigger/L1TMuonEndCap/interface/PrimitiveConversion.h"
+#include "L1Trigger/L1TMuonEndCap/interface/SectorProcessorLUT.h"
+
+#include <Geometry/Records/interface/MuonGeometryRecord.h>
+
+#include <cassert>
+#include <string>
+#include <fstream>
+#include "TVector3.h"
+
+// Class declaration
+class L1TMuonCPPFDigiProducer : public edm::stream::EDProducer<> {
+  
+ public:
+  explicit L1TMuonCPPFDigiProducer(const edm::ParameterSet&);
+  ~L1TMuonCPPFDigiProducer() override;
+
+ private:
+  
+  void beginStream(edm::StreamID) override;
+  void endStream() override;
+  void produce(edm::Event& event, const edm::EventSetup& setup) override;
+  
+ private:
+  std::unique_ptr<EmulateCPPF> cppf_emulator_;
+       
+};
+
+#endif /* #define L1Trigger_L1TMuonCPPF_L1TMuonCPPFDigiProducer_h */

--- a/L1Trigger/L1TMuonCPPF/python/cppf_dqm_cfi.py
+++ b/L1Trigger/L1TMuonCPPF/python/cppf_dqm_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+DQM_CPPF = cms.EDAnalyzer('DQM_CPPF',
+                      cppfdigiLabel = cms.InputTag("emulatorCppfDigis","recHit")                  
+)

--- a/L1Trigger/L1TMuonCPPF/python/emulatorCppfDigis_cfi.py
+++ b/L1Trigger/L1TMuonCPPF/python/emulatorCppfDigis_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+emulatorCppfDigis = cms.EDProducer("L1TMuonCPPFDigiProducer",
+                                   
+                                   ## Input collection
+                                   recHitLabel = cms.InputTag("rpcRecHits"),
+				   MaxClusterSize = cms.int32(3),
+                                   #  cppfSource = cms.string('Geo'), #'File' for Look up table and 'Geo' for CMSSW Geometry 
+                                   cppfSource = cms.string('File'), #'File' for Look up table and 'Geo' for CMSSW Geometry 
+                                   
+                                   cppfvecfile = cms.FileInPath('L1Trigger/L1TMuon/data/cppf/angleScale_RPC_CPPFmerged.txt')                     
+                                   #    cppfvecfile = cms.FileInPath('L1Trigger/L1TMuon/data/cppf/angleScale_RPC_CPPFn1.txt')                    
+                                   #    cppfvecfile = cms.FileInPath('L1Trigger/L1TMuon/data/cppf/angleScale_RPC_CPPFn2.txt')                    
+                                   #    cppfvecfile = cms.FileInPath('L1Trigger/L1TMuon/data/cppf/angleScale_RPC_CPPFn3.txt')                    
+                                   #    cppfvecfile = cms.FileInPath('L1Trigger/L1TMuon/data/cppf/angleScale_RPC_CPPFn4.txt')                    
+                                   #    cppfvecfile = cms.FileInPath('L1Trigger/L1TMuon/data/cppf/angleScale_RPC_CPPFp1.txt')                    
+                                   #    cppfvecfile = cms.FileInPath('L1Trigger/L1TMuon/data/cppf/angleScale_RPC_CPPFp2.txt')                    
+                                   #    cppfvecfile = cms.FileInPath('L1Trigger/L1TMuon/data/cppf/angleScale_RPC_CPPFp3.txt')                   
+                                   #    cppfvecfile = cms.FileInPath('L1Trigger/L1TMuon/data/cppf/angleScale_RPC_CPPFp4.txt')                    
+                                   )
+

--- a/L1Trigger/L1TMuonCPPF/src/EmulateCPPF.cc
+++ b/L1Trigger/L1TMuonCPPF/src/EmulateCPPF.cc
@@ -1,0 +1,88 @@
+
+#include "L1Trigger/L1TMuonCPPF/interface/EmulateCPPF.h"
+#include "CondFormats/RPCObjects/interface/RPCMaskedStrips.h"
+#include "CondFormats/RPCObjects/interface/RPCDeadStrips.h"
+#include <string>
+#include <fstream>
+
+EmulateCPPF::EmulateCPPF(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iConsumes) :
+  // rpcDigi_processors_(),
+  recHit_processors_(),
+  // rpcDigiToken_( iConsumes.consumes<RPCTag::digi_collection>(iConfig.getParameter<edm::InputTag>("recHitLabel")) ),
+  recHitToken_(iConsumes.consumes<RPCRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitLabel"))),
+  cppfSource_(CppfSource::EventSetup),
+  MaxClusterSize_(0)
+{
+   MaxClusterSize_ = iConfig.getParameter<int>("MaxClusterSize");
+  
+  const std::string cppfSource = iConfig.getParameter<std::string>("cppfSource");
+  //Look up table
+  if (cppfSource == "File"){
+    cppfSource_ = CppfSource::File;
+    edm::FileInPath fp = iConfig.getParameter<edm::FileInPath>("cppfvecfile");
+    std::ifstream inputFile(fp.fullPath().c_str(), std::ios::in);
+    if ( !inputFile ) {
+    throw cms::Exception("No LUT") << "Error: CPPF look up table file cannot not be opened";
+      exit(1);
+    }
+    while ( inputFile.good() ) {
+      RecHitProcessor::CppfItem Item;
+      inputFile >> Item.rawId >> Item.strip >> Item.lb >> Item.halfchannel >> Item.int_phi >> Item.int_theta;
+      if ( inputFile.good() ) CppfVec_1.push_back(Item);
+    }
+    inputFile.close();
+  }
+  
+  //RPC Geometry	
+  else if (cppfSource == "Geo") {
+    cppfSource_ = CppfSource::EventSetup;
+  }
+  //Error for wrong input
+  else {
+    throw cms::Exception("Invalid option") << "Error: Specify in python/emulatorCppfDigis_cfi 'File' for look up  table or 'Geo' for RPC Geometry";
+    exit(1); 
+  }
+  
+}
+
+EmulateCPPF::~EmulateCPPF() {
+}
+
+void EmulateCPPF::process(
+			  const edm::Event& iEvent, const edm::EventSetup& iSetup,
+			  // l1t::CPPFDigiCollection& cppf_rpcDigi,
+			  l1t::CPPFDigiCollection& cppf_recHit
+			  ) {
+  
+  if( cppfSource_ == CppfSource::File ){
+    //Using the look up table to fill the information
+    cppf_recHit.clear();
+    for (auto& recHit_processor : recHit_processors_) {
+      recHit_processor.processLook( iEvent, iSetup, recHitToken_, CppfVec_1, cppf_recHit, MaxClusterSize_);
+    //  recHit_processors_.at(recHit_processor).processLook( iEvent, iSetup, recHitToken_, CppfVec_1, cppf_recHit );
+    }
+  }
+  else if (cppfSource_ == CppfSource::EventSetup) {
+    // Clear output collections
+    // cppf_rpcDigi.clear();
+    cppf_recHit.clear();
+    
+    // // Get the RPCDigis from the event
+    // edm::Handle<RPCTag::digi_collection> rpcDigis;
+    // iEvent.getByToken(rpcDigiToken_, rpcDigis);
+    
+    // _________________________________________________________________________________
+    // Run the CPPF clusterization+coordinate conversion algo on RPCDigis and RecHits
+    
+    // For now, treat CPPF as single board
+    // In the future, may want to treat the 4 CPPF boards in each endcap as separate entities
+    
+    // for (unsigned int iBoard = 0; iBoard < rpcDigi_processors_.size(); iBoard++) {
+    // rpcDigi_processors_.at(iBoard).process( iSetup, rpcDigis, cppf_rpcDigi );
+    // }
+    for (auto& recHit_processor : recHit_processors_) {
+      recHit_processor.process( iEvent, iSetup, recHitToken_, cppf_recHit );
+      //recHit_processors_.at(recHit_processor).process( iEvent, iSetup, recHitToken_, cppf_recHit );
+    } 
+  }
+} // End void EmulateCPPF::process()					   

--- a/L1Trigger/L1TMuonCPPF/src/RecHitProcessor.cc
+++ b/L1Trigger/L1TMuonCPPF/src/RecHitProcessor.cc
@@ -1,0 +1,525 @@
+#include "L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h"
+
+RecHitProcessor::RecHitProcessor() {
+}
+
+RecHitProcessor::~RecHitProcessor() {
+}
+
+void RecHitProcessor::processLook(
+				  const edm::Event& iEvent,
+				  const edm::EventSetup& iSetup,
+				  const edm::EDGetToken& recHitToken,
+				  std::vector<RecHitProcessor::CppfItem>& CppfVec1,
+				  l1t::CPPFDigiCollection& cppfDigis,
+				  const int MaxClusterSize
+				  ) const {
+  
+  edm::Handle<RPCRecHitCollection> recHits;
+  iEvent.getByToken(recHitToken, recHits);
+  
+  edm::ESHandle<RPCGeometry> rpcGeom;
+  iSetup.get<MuonGeometryRecord>().get(rpcGeom);
+  
+  
+  std::map <std::pair<int, int>, int> chamber_repetitions;
+  chamber_repetitions.clear();
+  // The loop is over the detector container in the rpc geometry collection. We are interested in the RPDdetID (inside of RPCChamber vectors), specifically, the RPCrechits. to assignment the CPPFDigis.
+  for ( TrackingGeometry::DetContainer::const_iterator iDet = rpcGeom->dets().begin(); iDet < rpcGeom->dets().end(); iDet++ ) {
+    
+    //  we do a cast over the class RPCChamber to obtain the RPCroll vectors, inside of them, the RPCRechits are found. in other words, the method ->rolls() does not exist for other kind of vector within DetContainer and we can not obtain the rpcrechits in a suitable way. 
+    if (dynamic_cast<const RPCChamber*>( *iDet ) == nullptr ) continue;
+    
+    auto chamb = dynamic_cast<const RPCChamber* >( *iDet ); 
+    
+    std::vector<const RPCRoll*> rolls = (chamb->rolls());
+    
+    // Loop over rolls in the chamber
+    for(auto& iRoll : rolls){
+      
+      RPCDetId rpcId = (*iRoll).id();	
+      
+      
+      
+      typedef std::pair<RPCRecHitCollection::const_iterator, RPCRecHitCollection::const_iterator> rangeRecHits;
+      rangeRecHits recHitCollection =  recHits->get(rpcId);
+      
+      //Loop over the RPC digis
+      for (RPCRecHitCollection::const_iterator rechit_it = recHitCollection.first; rechit_it != recHitCollection.second; rechit_it++) {	
+	//const RPCDetId& rpcId = rechit_it->rpcId();
+	
+	int rawId = rpcId.rawId();
+	int station = rpcId.station();
+        int ring = rpcId.ring();
+	int Bx = rechit_it->BunchX(); 
+	int isValid = rechit_it->isValid();
+	int firststrip = rechit_it->firstClusterStrip();
+	int clustersize = rechit_it->clusterSize();
+	LocalPoint lPos = rechit_it->localPosition();
+	const RPCRoll* roll = rpcGeom->roll(rpcId);
+	const BoundPlane& rollSurface = roll->surface();
+	GlobalPoint gPos = rollSurface.toGlobal(lPos);
+	float global_theta = emtf::rad_to_deg(gPos.theta().value());
+	float global_phi   = emtf::rad_to_deg(gPos.phi().value());
+	//::::::::::::::::::::::::::::
+	//Establish the average position of the rechit    
+	int rechitstrip = firststrip;
+	
+        if(clustersize > 2) {
+	  int medium = 0;
+	  if (clustersize % 2 == 0) medium = 0.5*(clustersize); 
+	  else medium = 0.5*(clustersize-1);
+	  rechitstrip += medium; 
+	} 
+	
+	if(clustersize > MaxClusterSize) continue;	
+	//This is just for test CPPFDigis with the RPC Geometry, It must be "true" in the normal runs 
+	bool Geo = true;
+	////:::::::::::::::::::::::::::::::::::::::::::::::::
+	//Set the EMTF Sector 	
+	int EMTFsector1 = 0;	
+	int EMTFsector2 = 0;
+	
+        //Chamber ID
+        int nsub = 6;
+        (ring == 1 && station > 1) ? nsub = 3 : nsub = 6;
+        int chamberID = rpcId.subsector() + nsub * ( rpcId.sector() - 1);
+	
+	
+	//sector 1
+	if ((global_phi > 15.) && (global_phi <= 16.3)) {
+	  EMTFsector1 = 1;
+	  EMTFsector2 = 6;
+	}
+	else if ((global_phi > 16.3) && (global_phi <= 53.)) {
+	  EMTFsector1 = 1;
+	  EMTFsector2 = 0;
+	}
+	else if ((global_phi > 53.) && (global_phi <= 75.)) {
+	  EMTFsector1 = 1;
+	  EMTFsector2 = 2;
+	}
+	//sector 2 
+	else if ((global_phi > 75.) && (global_phi <= 76.3)) {
+	  EMTFsector1 = 1;
+	  EMTFsector2 = 2;
+	}
+	else if ((global_phi > 76.3) && (global_phi <= 113.)) {
+	  EMTFsector1 = 2;
+	  EMTFsector2 = 0;
+	}
+	else if ((global_phi > 113.) && (global_phi <= 135.)) {
+	  EMTFsector1 = 2;
+	  EMTFsector2 = 3;
+	}
+	//sector 3
+	//less than 180
+	else if ((global_phi > 135.) && (global_phi <= 136.3)) {
+	  EMTFsector1 = 2;
+	  EMTFsector2 = 3;
+	}
+	else if ((global_phi > 136.3) && (global_phi <= 173.)) {
+	  EMTFsector1 = 3;
+	  EMTFsector2 = 0;
+	}
+	else if ((global_phi > 173.) && (global_phi <= 180.)) {
+	  EMTFsector1 = 3;
+	  EMTFsector2 = 4;
+	}
+	//Greater than -180
+	else if ((global_phi < -165.) && (global_phi >= -180.)) {
+	  EMTFsector1 = 3;
+	  EMTFsector2 = 4;
+	}
+	//Fourth sector
+	else if ((global_phi > -165.) && (global_phi <= -163.7)) {
+	  EMTFsector1 = 3;
+	  EMTFsector2 = 4;
+	}
+	else if ((global_phi > -163.7) && (global_phi <= -127.)) {
+	  EMTFsector1 = 4;
+	  EMTFsector2 = 0;
+	}
+	else if ((global_phi > -127.) && (global_phi <= -105.)) {
+	  EMTFsector1 = 4;
+	  EMTFsector2 = 5;
+	}
+	//fifth sector
+	else if ((global_phi > -105.) && (global_phi <= -103.7)) {
+	  EMTFsector1 = 4;
+	  EMTFsector2 = 5;
+	}
+	else if ((global_phi > -103.7) && (global_phi <= -67.)) {
+	  EMTFsector1 = 5;
+	  EMTFsector2 = 0;
+	}
+	else if ((global_phi > -67.) && (global_phi <= -45.)) {
+	  EMTFsector1 = 5;
+	  EMTFsector2 = 6;
+	} 
+	//sixth sector
+	else if ((global_phi > -45.) && (global_phi <= -43.7)) {
+	  EMTFsector1 = 5;
+	  EMTFsector2 = 6;
+	} 
+	else if ((global_phi > -43.7) && (global_phi <= -7.)) {
+	  EMTFsector1 = 6;
+	  EMTFsector2 = 0;
+	}
+	else if ((global_phi > -7.) && (global_phi <= 15.)) {
+	  EMTFsector1 = 6;
+	  EMTFsector2 = 1;
+	} 
+	
+	
+	// std::vector<RecHitProcessor::CppfItem>::iterator it;
+	// for(it = CppfVec1.begin(); it != CppfVec1.end(); it++){
+	//	if( (*it).rawId == rawId) if(Geo_true) std::cout << (*it).rawId << "rawid" << rawId << std::endl;
+	//	}
+	//Loop over the look up table    
+	double EMTFLink1 = 0.;
+	double EMTFLink2 = 0.;
+	
+        std::vector<RecHitProcessor::CppfItem>::iterator cppf1;
+        std::vector<RecHitProcessor::CppfItem>::iterator cppf;
+        for(cppf1 = CppfVec1.begin(); cppf1 != CppfVec1.end(); cppf1++){
+	  
+          
+	  
+	  //Condition to save the CPPFDigi
+	  if(((*cppf1).rawId == rawId) && ((*cppf1).strip == rechitstrip)){
+	    
+	    int old_strip = (*cppf1).strip;
+            int before = 0;
+	    int after = 0;
+	    
+            if(cppf1 != CppfVec1.begin())	    
+	      before = (*(cppf1-2)).strip;
+	    
+	    else if (cppf1 == CppfVec1.begin())
+	      before = (*cppf1).strip;
+	    
+            if(cppf1 != CppfVec1.end())
+	      after = (*(cppf1+2)).strip;
+	    
+            else if (cppf1 == CppfVec1.end())
+	      after = (*cppf1).strip;	
+	    
+	    cppf = cppf1;
+	    
+	    if(clustersize == 2){
+	      
+	      if(firststrip == 1){
+		if(before < after) cppf=(cppf1-1);
+                else if (before > after) cppf=(cppf1+1); 
+	      }
+	      else if(firststrip > 1){
+		if(before < after) cppf=(cppf1+1);
+		else if (before > after) cppf=(cppf1-1);
+	      }
+	      
+	    }
+	    //Information for save cluster (2) per chamber
+            std::pair<int, int> temporal;
+	    temporal = std::make_pair (station, chamberID);
+            
+	    
+            std::map<std::pair<int, int>, int>::iterator it; 
+            it = chamber_repetitions.find(temporal);
+	    
+              //  std::cout << "Current event " << temporal.first << "," << temporal.second << std::endl;
+	    
+	    if(it == chamber_repetitions.end()){
+	      chamber_repetitions[temporal] = 1;
+	    }
+	    else if((it != chamber_repetitions.end()) && (chamber_repetitions[temporal] == 1)){
+	      chamber_repetitions[temporal] = 2;  
+	    }
+	    else if((it != chamber_repetitions.end()) && (chamber_repetitions[temporal] == 2)){
+	      continue;
+	    }
+	    
+	    //  for(std::map<std::pair<int, int>, int>::iterator it = chamber_repetitions.begin() ; it != chamber_repetitions.end(); it++){
+	    //     std::pair<int, int> temp = it->first;
+	    //     std::cout << temp.first << "," << temp.second << " Repetitions: " << it->second <<std::endl;
+	    //     }
+	    
+	    //Using the RPCGeometry	
+	    if(Geo){
+	      std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(rpcId, Bx , (*cppf).int_phi, (*cppf).int_theta, isValid, (*cppf).lb, (*cppf).halfchannel, EMTFsector1, EMTFLink1, old_strip, clustersize, global_phi, global_theta));
+	      std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(rpcId, Bx , (*cppf).int_phi, (*cppf).int_theta, isValid, (*cppf).lb, (*cppf).halfchannel, EMTFsector2, EMTFLink2, old_strip, clustersize, global_phi, global_theta));
+	      
+	      if ((EMTFsector1 > 0) && (EMTFsector2 == 0)){
+		cppfDigis.push_back(*MainVariables1.get());
+	      } 
+	      else if ((EMTFsector1 > 0) && (EMTFsector2 > 0)){
+		cppfDigis.push_back(*MainVariables1.get());
+		cppfDigis.push_back(*MainVariables2.get());
+	      }
+	      else if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
+		continue; 
+	      } 
+	    } //Geo is true
+	    else {
+	      global_phi = 0.;
+	      global_theta = 0.;
+	      std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(rpcId, Bx , (*cppf).int_phi, (*cppf).int_theta, isValid, (*cppf).lb, (*cppf).halfchannel, EMTFsector1, EMTFLink1, old_strip, clustersize, global_phi, global_theta));
+	      std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(rpcId, Bx , (*cppf).int_phi, (*cppf).int_theta, isValid, (*cppf).lb, (*cppf).halfchannel, EMTFsector2, EMTFLink2, old_strip, clustersize, global_phi, global_theta));
+	      if ((EMTFsector1 > 0) && (EMTFsector2 == 0)){
+		cppfDigis.push_back(*MainVariables1.get());
+	      } 
+	      else if ((EMTFsector1 > 0) && (EMTFsector2 > 0)){
+		cppfDigis.push_back(*MainVariables1.get());
+		cppfDigis.push_back(*MainVariables2.get());
+	      }
+	      else if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
+		continue;
+	      } 
+	    }
+	  } //Condition to save the CPPFDigi 
+	} //Loop over the LUTVector
+      } //Loop over the recHits
+    } // End loop: for (std::vector<const RPCRoll*>::const_iterator r = rolls.begin(); r != rolls.end(); ++r)
+  } // End loop: for (TrackingGeometry::DetContainer::const_iterator iDet = rpcGeom->dets().begin(); iDet < rpcGeom->dets().end(); iDet++)  
+  
+}
+
+
+void RecHitProcessor::process(
+			      const edm::Event& iEvent,
+			      const edm::EventSetup& iSetup,
+			      const edm::EDGetToken& recHitToken,
+			      l1t::CPPFDigiCollection& cppfDigis
+			      ) const {
+  
+  // Get the RPC Geometry
+  edm::ESHandle<RPCGeometry> rpcGeom;
+  iSetup.get<MuonGeometryRecord>().get(rpcGeom);
+  
+  // Get the RecHits from the event
+  edm::Handle<RPCRecHitCollection> recHits;
+  iEvent.getByToken(recHitToken, recHits);
+  
+ 
+  std::map <std::pair<int, int>, int> chamber_repetitions;
+  chamber_repetitions.clear();
+  // The loop is over the detector container in the rpc geometry collection. We are interested in the RPDdetID (inside of RPCChamber vectors), specifically, the RPCrechits. to assignment the CPPFDigis.
+  for ( TrackingGeometry::DetContainer::const_iterator iDet = rpcGeom->dets().begin(); iDet < rpcGeom->dets().end(); iDet++ ) {
+    
+    //  we do a cast over the class RPCChamber to obtain the RPCroll vectors, inside of them, the RPCRechits are found. in other words, the method ->rolls() does not exist for other kind of vector within DetContainer and we can not obtain the rpcrechits in a suitable way.   
+    if (dynamic_cast<const RPCChamber*>( *iDet ) == nullptr ) continue;
+    
+    auto chamb = dynamic_cast<const RPCChamber* >( *iDet ); 
+    std::vector<const RPCRoll*> rolls = (chamb->rolls());
+    
+    // Loop over rolls in the chamber
+    for(auto& iRoll : rolls){
+      
+      RPCDetId rpcId = (*iRoll).id();	
+      
+      typedef std::pair<RPCRecHitCollection::const_iterator, RPCRecHitCollection::const_iterator> rangeRecHits;
+      rangeRecHits recHitCollection =  recHits->get(rpcId);
+      
+      
+      for (RPCRecHitCollection::const_iterator rechit_it = recHitCollection.first; rechit_it != recHitCollection.second; rechit_it++) {	  
+	
+        //const RPCDetId& rpcId = rechit_it->rpcId();
+	int station = rpcId.station();
+        int ring = rpcId.ring();
+        int region = rpcId.region();
+        int Bx = rechit_it->BunchX(); 
+        int isValid = rechit_it->isValid();
+        int firststrip = rechit_it->firstClusterStrip();
+        int clustersize = rechit_it->clusterSize();
+        LocalPoint lPos = rechit_it->localPosition();
+        const RPCRoll* roll = rpcGeom->roll(rpcId);
+        const BoundPlane& rollSurface = roll->surface();
+        GlobalPoint gPos = rollSurface.toGlobal(lPos);
+        float global_theta = emtf::rad_to_deg(gPos.theta().value());
+        float global_phi   = emtf::rad_to_deg(gPos.phi().value());
+        //Endcap region only
+	
+        if (region != 0) {
+	  
+	  int int_theta = (region == -1 ? 180. * 32. / 36.5 : 0.)
+	    + (float)region * global_theta * 32. / 36.5   
+	    - 8.5 * 32 / 36.5;
+	  
+	  if(region == 1) {
+	    if(global_theta < 8.5) int_theta = 0;
+	    if(global_theta > 45.) int_theta = 31;
+	  } 
+	  else if(region == -1) {
+	    if(global_theta < 135.) int_theta = 31;
+	    if(global_theta > 171.5) int_theta = 0;
+	  } 
+	  //Chamber ID
+	  int nsub = 6;
+	  (ring == 1 && station > 1) ? nsub = 3 : nsub = 6;
+	  int chamberID = rpcId.subsector() + nsub * ( rpcId.sector() - 1);
+	  
+	  //Local EMTF
+	  double local_phi = 0.;
+	  int EMTFsector1 = 0;
+	  int EMTFsector2 = 0;
+	  
+	  //sector 1
+	  if ((global_phi > 15.) && (global_phi <= 16.3)) {
+	    local_phi = global_phi-15.;
+	    EMTFsector1 = 1;
+	    EMTFsector2 = 6;
+	  }
+	  else if ((global_phi > 16.3) && (global_phi <= 53.)) {
+	    local_phi = global_phi-15.;
+	    EMTFsector1 = 1;
+	    EMTFsector2 = 0;
+	  }
+	  else if ((global_phi > 53.) && (global_phi <= 75.)) {
+	    local_phi = global_phi-15.;
+	    EMTFsector1 = 1;
+	    EMTFsector2 = 2;
+	  }
+	  //sector 2 
+	  else if ((global_phi > 75.) && (global_phi <= 76.3)) {
+	    local_phi = global_phi-15.;
+	    EMTFsector1 = 1;
+	    EMTFsector2 = 2;
+	  }
+	  else if ((global_phi > 76.3) && (global_phi <= 113.)) {
+	    local_phi = global_phi-75.;
+	    EMTFsector1 = 2;
+	    EMTFsector2 = 0;
+	  }
+	  else if ((global_phi > 113.) && (global_phi <= 135.)) {
+	    local_phi = global_phi-75.;
+	    EMTFsector1 = 2;
+	    EMTFsector2 = 3;
+	  }
+	  //sector 3
+	  //less than 180
+	  else if ((global_phi > 135.) && (global_phi <= 136.3)) {
+	    local_phi = global_phi-75.;
+	    EMTFsector1 = 2;
+	    EMTFsector2 = 3;
+	  }
+	  else if ((global_phi > 136.3) && (global_phi <= 173.)) {
+	    local_phi = global_phi-135.;
+	    EMTFsector1 = 3;
+	    EMTFsector2 = 0;
+	  }
+	  else if ((global_phi > 173.) && (global_phi <= 180.)) {
+	    local_phi = global_phi-135.;
+	    EMTFsector1 = 3;
+	    EMTFsector2 = 4;
+	  }
+	  //Greater than -180
+	  else if ((global_phi < -165.) && (global_phi >= -180.)) {
+	    local_phi = global_phi+225.;
+	    EMTFsector1 = 3;
+	    EMTFsector2 = 4;
+	  }
+	  //Fourth sector
+	  else if ((global_phi > -165.) && (global_phi <= -163.7)) {
+	    local_phi = global_phi+225.;
+	    EMTFsector1 = 3;
+	    EMTFsector2 = 4;
+	  }
+	  else if ((global_phi > -163.7) && (global_phi <= -127.)) {
+	    local_phi = global_phi+165.;
+	    EMTFsector1 = 4;
+	    EMTFsector2 = 0;
+	  }
+	  else if ((global_phi > -127.) && (global_phi <= -105.)) {
+	    local_phi = global_phi+165.;
+	    EMTFsector1 = 4;
+	    EMTFsector2 = 5;
+	  }
+	  //fifth sector
+	  else if ((global_phi > -105.) && (global_phi <= -103.7)) {
+	    local_phi = global_phi+165.;
+	    EMTFsector1 = 4;
+	    EMTFsector2 = 5;
+	  }
+	  else if ((global_phi > -103.7) && (global_phi <= -67.)) {
+	    local_phi = global_phi+105.;
+	    EMTFsector1 = 5;
+	    EMTFsector2 = 0;
+	  }
+	  else if ((global_phi > -67.) && (global_phi <= -45.)) {
+	    local_phi = global_phi+105.;
+	    EMTFsector1 = 5;
+	    EMTFsector2 = 6;
+	  } 
+	  //sixth sector
+	  else if ((global_phi > -45.) && (global_phi <= -43.7)) {
+	    local_phi = global_phi+105.;
+	    EMTFsector1 = 5;
+	    EMTFsector2 = 6;
+	  } 
+	  else if ((global_phi > -43.7) && (global_phi <= -7.)) {
+	    local_phi = global_phi+45.;
+	    EMTFsector1 = 6;
+	    EMTFsector2 = 0;
+	  }
+	  else if ((global_phi > -7.) && (global_phi <= 15.)) {
+	    local_phi = global_phi+45.;
+	    EMTFsector1 = 6;
+	    EMTFsector2 = 1;
+	  } 
+	  
+	  int int_phi = int((local_phi + 22.0 )*15. + .5); 
+	  
+	  double EMTFLink1 = 0.;
+	  double EMTFLink2 = 0.;
+          double lb = 0.;
+	  double halfchannel = 0.;
+	  
+	  //Invalid hit
+	  if (isValid == 0) int_phi = 2047;	 
+	  //Right integers range
+	  assert(0 <= int_phi && int_phi < 1250);
+	  assert(0 <= int_theta && int_theta < 32);
+	  
+	  //Information for save cluster (2) per chamber
+	  std::pair<int, int> temporal;
+	  temporal = std::make_pair (station, chamberID);
+          
+	  
+	  std::map<std::pair<int, int>, int>::iterator it; 
+	  it = chamber_repetitions.find(temporal);
+	  
+	  if(it == chamber_repetitions.end()){
+	    chamber_repetitions[temporal] = 1;
+	  }
+	  else if((it != chamber_repetitions.end()) && (chamber_repetitions[temporal] == 1)){
+	    chamber_repetitions[temporal] = 2;  
+	  }
+	  else if((it != chamber_repetitions.end()) && (chamber_repetitions[temporal] == 2)){
+	    continue;
+	  }
+	  
+	  std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(rpcId, Bx , int_phi, int_theta, isValid, lb, halfchannel, EMTFsector1, EMTFLink1, firststrip, clustersize, global_phi, global_theta));
+	  std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(rpcId, Bx , int_phi, int_theta, isValid, lb, halfchannel, EMTFsector2, EMTFLink2, firststrip, clustersize, global_phi, global_theta));
+	  if(int_theta == 31) continue;
+          if ((EMTFsector1 > 0) && (EMTFsector2 == 0)){
+	    cppfDigis.push_back(*MainVariables1.get());
+	  } 
+          if ((EMTFsector1 > 0) && (EMTFsector2 > 0)){
+	    cppfDigis.push_back(*MainVariables1.get());
+	    cppfDigis.push_back(*MainVariables2.get());
+	  }
+	  if ((EMTFsector1 == 0) && (EMTFsector2 == 0)){
+	    continue;
+	  } 
+        } // No barrel rechits	
+	
+      } // End loop: for (RPCRecHitCollection::const_iterator recHit = recHitCollection.first; recHit != recHitCollection.second; recHit++)
+      
+    } // End loop: for (std::vector<const RPCRoll*>::const_iterator r = rolls.begin(); r != rolls.end(); ++r)
+  } // End loop: for (TrackingGeometry::DetContainer::const_iterator iDet = rpcGeom->dets().begin(); iDet < rpcGeom->dets().end(); iDet++)
+} // End function: void RecHitProcessor::process()
+
+
+  
+
+

--- a/L1Trigger/L1TMuonCPPF/test/BuildFile.xml
+++ b/L1Trigger/L1TMuonCPPF/test/BuildFile.xml
@@ -1,0 +1,34 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/PluginManager"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/Utilities"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/Concurrency"/>
+
+<use name="L1Trigger/L1TMuon"/>
+<use name="L1Trigger/L1TMuonEndCap"/>
+
+<use name="DataFormats/Common"/>
+<use name="DataFormats/DetId"/>
+<use name="DataFormats/MuonDetId"/>
+<use name="DataFormats/RPCDigi"/>
+<use name="DataFormats/RPCRecHit"/>
+<use name="DataFormats/L1TMuon" />
+<use name="DataFormats/TrackingRecHit"/>
+
+<use name="Geometry/Records"/>
+<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/RPCGeometry"/>
+<use name="CommonTools/UtilAlgos"/>
+
+<use name="CondFormats/RPCObjects"/>
+<use name="CondFormats/DataRecord"/>
+
+<use name="TrackingTools/TrackRefitter"/>
+<use name="RecoMuon/DetLayers"/>
+
+<use name="root"/>
+
+<library file="DQMCPPF.cc" name="DQMCPPF">
+<flags EDM_PLUGIN="1"/>
+</library>

--- a/L1Trigger/L1TMuonCPPF/test/DQMCPPF.cc
+++ b/L1Trigger/L1TMuonCPPF/test/DQMCPPF.cc
@@ -1,0 +1,148 @@
+#include "DQMCPPF.h"
+
+DQM_CPPF::DQM_CPPF(const edm::ParameterSet& iConfig) :
+  cppfDigiToken_(consumes<l1t::CPPFDigiCollection>(iConfig.getParameter<edm::InputTag>("cppfdigiLabel"))),
+  EMTF_sector(0),    
+  EMTF_subsector(0),
+  EMTF_bx(0) {
+}
+
+DQM_CPPF::~DQM_CPPF(){
+}
+
+void DQM_CPPF::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup){  
+  
+  //Get the CPPFDigi 
+  edm::Handle<l1t::CPPFDigiCollection> CppfDigis;
+  iEvent.getByToken(cppfDigiToken_, CppfDigis);
+  
+  //Fill the specific bin for each EMTF sector 
+  for(int i = 1; i < 7; i++ ){
+    EMTFsector1bins.push_back(i);
+    EMTFsector2bins.push_back(i+6);
+    EMTFsector3bins.push_back(i+12);
+    EMTFsector4bins.push_back(i+18);
+    EMTFsector5bins.push_back(i+24);
+    EMTFsector6bins.push_back(i+30);
+  }
+  //FIll the map for each EMTF sector 
+  fill_info[1] = EMTFsector1bins;
+  fill_info[2] = EMTFsector2bins;
+  fill_info[3] = EMTFsector3bins;
+  fill_info[4] = EMTFsector4bins;
+  fill_info[5] = EMTFsector5bins;
+  fill_info[6] = EMTFsector6bins;
+  
+  
+  for(auto& cppf_digis : *CppfDigis){
+    
+    RPCDetId rpcId = cppf_digis.rpcId();
+    int ring = rpcId.ring();
+    int station = rpcId.station();
+    int region = rpcId.region();
+    int subsector = rpcId.subsector();
+    
+    //Region -	
+    if(region == -1){
+      
+      //for Occupancy
+      EMTF_sector = cppf_digis.emtf_sector();
+      EMTF_subsector = fill_info[EMTF_sector][subsector-1];
+      
+      if((station == 4) && (ring == 3))
+	Occupancy_EMTFSector->Fill(EMTF_subsector, 1);
+      else if((station == 4) && (ring == 2))
+	Occupancy_EMTFSector->Fill(EMTF_subsector, 2);
+      else if((station == 3) && (ring == 3))
+	Occupancy_EMTFSector->Fill(EMTF_subsector, 3);
+      else if((station == 3) && (ring == 2))
+	Occupancy_EMTFSector->Fill(EMTF_subsector, 4);
+      else if((station == 2) && (ring == 2))
+	Occupancy_EMTFSector->Fill(EMTF_subsector, 5);
+      else if((station == 1) && (ring == 2))
+	Occupancy_EMTFSector->Fill(EMTF_subsector, 6);
+      
+      //for Track_Bx
+      EMTF_bx = cppf_digis.bx();  
+      if(EMTF_sector==1)
+	Track_Bx->Fill(6,EMTF_bx);
+      else if(EMTF_sector==2)
+	Track_Bx->Fill(5,EMTF_bx);
+      else if(EMTF_sector==3)
+	Track_Bx->Fill(4,EMTF_bx);
+      else if(EMTF_sector==4)
+	Track_Bx->Fill(3,EMTF_bx);
+      else if(EMTF_sector==5)
+	Track_Bx->Fill(2,EMTF_bx);
+      else if(EMTF_sector==6)
+	Track_Bx->Fill(1,EMTF_bx);
+    }
+
+    //Region +	
+    else if(region == 1){
+      
+      //for Occupancy
+      EMTF_sector = cppf_digis.emtf_sector();
+      EMTF_subsector = fill_info[EMTF_sector][subsector-1]; 
+      
+      if((station == 1) && (ring == 2)) 
+	Occupancy_EMTFSector->Fill(EMTF_subsector, 7);          
+      else if((station == 2) && (ring == 2))
+	Occupancy_EMTFSector->Fill(EMTF_subsector, 8);          
+      else if((station == 3) && (ring == 2))
+	Occupancy_EMTFSector->Fill(EMTF_subsector, 9);          
+      else if((station == 3) && (ring == 3))
+	Occupancy_EMTFSector->Fill(EMTF_subsector, 10);          
+      else if((station == 4) && (ring == 2))
+	Occupancy_EMTFSector->Fill(EMTF_subsector, 11);          
+      else if((station == 4) && (ring == 3))
+	Occupancy_EMTFSector->Fill(EMTF_subsector, 12);          
+
+      //for Track_Bx
+      EMTF_bx = cppf_digis.bx();
+      if(EMTF_sector==1)
+	Track_Bx->Fill(7,EMTF_bx);
+      else if(EMTF_sector==2)
+	Track_Bx->Fill(8,EMTF_bx);
+      else if(EMTF_sector==3)
+	Track_Bx->Fill(9,EMTF_bx);
+      else if(EMTF_sector==4)
+	Track_Bx->Fill(10,EMTF_bx);
+      else if(EMTF_sector==5)
+	Track_Bx->Fill(11,EMTF_bx);
+      else if(EMTF_sector==6)
+	Track_Bx->Fill(12,EMTF_bx);
+    }
+    
+    
+    //General hists    
+    
+    Phi_Integer->Fill(cppf_digis.phi_int());
+    Theta_Integer->Fill(cppf_digis.theta_int());
+    Phi_Global->Fill(cppf_digis.phi_glob()*TMath::Pi()/180.);
+    Theta_Global->Fill(cppf_digis.theta_glob()*TMath::Pi()/180.);
+    Phi_Global_Integer->Fill(cppf_digis.phi_glob(), cppf_digis.phi_int());
+    Theta_Global_Integer->Fill(cppf_digis.theta_glob(), cppf_digis.theta_int());
+    
+  } // loop over CPPFDigis
+  
+} //End class
+
+void DQM_CPPF::beginRun(const edm::Run& run, const edm::EventSetup& iSetup){
+  iSetup.get<MuonGeometryRecord>().get(rpcGeom);
+}
+
+void DQM_CPPF::beginJob(){
+  edm::Service<TFileService> fs;
+  Phi_Integer = fs->make<TH1D>("Phi_Integer", "Phi_Integer", 1240, 0., 1240.);
+  Theta_Integer = fs->make<TH1D>("Theta_Integer", "Theta_Integer", 32, 0., 32.);
+  Phi_Global = fs->make<TH1D>("Phi_Global", "Phi_Global", 72, -3.15, 3.15);
+  Theta_Global = fs->make<TH1D>("Theta_Global", "Theta_Global", 32, 0., 3.15);
+  Phi_Global_Integer = fs->make<TH2D>("Phi_Global_Integer", "Phi_Global_Integer", 360, -180, 180, 1240, 0.,1240.);
+  Theta_Global_Integer = fs->make<TH2D>("Theta_Global_Integer", "Theta_Global_Integer", 45, 0, 45, 32, 0.,32.);
+  Occupancy_EMTFSector = fs->make<TH2D>("Occupancy_EMTFSector", "Occupancy_EMTFSector", 36, 1., 37., 12, 1.,13.); 
+  Track_Bx = fs->make<TH2D>("Track_Bx","Track_Bx", 12, 1., 13., 7,-3.,4.);
+  return;
+}
+//define this as a plug-in
+DEFINE_FWK_MODULE(DQM_CPPF);

--- a/L1Trigger/L1TMuonCPPF/test/DQMCPPF.h
+++ b/L1Trigger/L1TMuonCPPF/test/DQMCPPF.h
@@ -1,0 +1,79 @@
+#ifndef L1Trigger_DQMCPPF_h
+#define L1Trigger_DQMCPPF_h
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "Geometry/RPCGeometry/interface/RPCRoll.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+
+#include "DataFormats/MuonDetId/interface/RPCDetId.h"
+#include "DataFormats/L1TMuon/interface/CPPFDigi.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "CondFormats/RPCObjects/interface/RPCMaskedStrips.h"
+#include "CondFormats/RPCObjects/interface/RPCDeadStrips.h"
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "L1Trigger/L1TMuonEndCap/interface/TrackTools.h"
+
+#include<boost/cstdint.hpp>
+#include "TH1.h"
+#include "TH2.h"
+#include <memory>
+#include <iostream>
+#include <vector>
+#include "TLorentzVector.h"
+#include <ios>
+#include <map>
+
+
+class DQM_CPPF : public edm::EDAnalyzer {
+  
+ public:
+  explicit DQM_CPPF(const edm::ParameterSet&);
+  ~DQM_CPPF() override;
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  edm::ESHandle <RPCGeometry> rpcGeom;
+  
+ private:
+  
+  void beginJob() override;
+  const edm::EDGetTokenT<l1t::CPPFDigiCollection> cppfDigiToken_;
+
+  int EMTF_sector;
+  int EMTF_subsector;
+  int EMTF_bx;
+  
+  std::vector<int> EMTFsector1bins;
+  std::vector<int> EMTFsector2bins;
+  std::vector<int> EMTFsector3bins;
+  std::vector<int> EMTFsector4bins;
+  std::vector<int> EMTFsector5bins;
+  std::vector<int> EMTFsector6bins;
+  
+  std::map<int , std::vector<int>> fill_info;
+  
+  TH1D* Phi_Integer;
+  TH1D* Theta_Integer;
+  TH1D* Phi_Global;
+  TH1D* Theta_Global;
+  TH2D* Phi_Global_Integer;
+  TH2D* Theta_Global_Integer;
+  TH2D* Occupancy_EMTFSector;
+  TH2D* Track_Bx;
+};
+
+
+#endif
+

--- a/L1Trigger/L1TMuonCPPF/test/Generator_DQM_CPPF.py
+++ b/L1Trigger/L1TMuonCPPF/test/Generator_DQM_CPPF.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+import subprocess
+#import FWCore.Utilities.FileUtils as FileUtils
+
+process = cms.Process("DQMPlots")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = 'INFO'
+process.MessageLogger.categories.append('DQMPlots')
+process.MessageLogger.cerr.INFO = cms.untracked.PSet(
+	limit = cms.untracked.int32(-1)
+)
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.Geometry.GeometryExtended2016_cff')
+process.load('Configuration.Geometry.GeometryExtended2016Reco_cff')
+
+
+
+readFiles = cms.untracked.vstring()
+process.source = cms.Source("PoolSource",
+        fileNames = readFiles,
+)
+in_dir_name = './'
+readFiles.extend( cms.untracked.vstring('file:'+in_dir_name+'test_cppf_emulator.root') )
+
+
+process.load('L1Trigger.L1TMuonCPPF.cppf_dqm_cfi')
+process.TFileService = cms.Service("TFileService",
+	fileName = cms.string("DQM_CPPF.root")
+)
+process.p = cms.Path(process.DQM_CPPF)
+
+

--- a/L1Trigger/L1TMuonCPPF/test/cppf_emulator_MC.py
+++ b/L1Trigger/L1TMuonCPPF/test/cppf_emulator_MC.py
@@ -1,0 +1,137 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: SingleMuPt10_pythia8_cfi.py -s GEN,SIM,DIGI --pileup=NoPileUp --geometry DB --conditions=auto:run1_mc --eventcontent FEVTDEBUGHLT --no_exec -n 30
+import FWCore.ParameterSet.Config as cms
+import datetime
+import random
+
+process = cms.Process('DIGI')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+#process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+#process.load('Configuration.Geometry.GeometryDB_cff')
+#process.load('Configuration.StandardSequences.GeometryExtended_cff')
+process.load('Configuration.Geometry.GeometryExtended2016_cff')
+process.load('Configuration.Geometry.GeometryExtended2016Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.load('RecoLocalMuon.RPCRecHit.rpcRecHits_cfi')
+from RecoLocalMuon.RPCRecHit.rpcRecHits_cfi import *
+
+process.load('L1Trigger.L1TMuonCPPF.emulatorCppfDigis_cfi')
+from L1Trigger.L1TMuonCPPF.emulatorCppfDigis_cfi import *
+
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(1)
+process.MessageLogger = cms.Service("MessageLogger")
+process.maxEvents = cms.untracked.PSet(
+	input = cms.untracked.int32(300)
+	)
+
+
+# Input source
+process.source = cms.Source("EmptySource"
+			    )
+process.options = cms.untracked.PSet(
+	)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+	annotation = cms.untracked.string('SingleMuPt10_pythia8_cfi.py nevts:100'),
+	name = cms.untracked.string('Applications'),
+	version = cms.untracked.string('$Revision: 1.19 $')
+	)
+
+# Output definition
+
+process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
+					      SelectEvents = cms.untracked.PSet(
+		SelectEvents = cms.vstring('generation_step')
+		),
+					      dataset = cms.untracked.PSet(
+		dataTier = cms.untracked.string(''),
+		filterName = cms.untracked.string('')
+		),
+					      eventAutoFlushCompressedSize = cms.untracked.int32(10485760),
+					      fileName = cms.untracked.string('SingleMuPt10_pythia8_cfi_py_GEN_SIM_DIGI.root'),
+					      outputCommands = cms.untracked.vstring('drop *',"keep *_emulatorMuonRPCDigis_*_*", "keep *_emulatorCppfDigis_*_*", 
+										     "keep *_rpcRecHits_*_*", "keep *_genParticles_*_*"),
+					      #outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
+					      splitLevel = cms.untracked.int32(0)
+					      )
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+
+
+from IOMC.RandomEngine.RandomServiceHelper import  RandomNumberServiceHelper
+randHelper =  RandomNumberServiceHelper(process.RandomNumberGeneratorService)
+randHelper.populate()
+
+process.RandomNumberGeneratorService.saveFileName =  cms.untracked.string("RandomEngineState.log")
+
+
+process.generator = cms.EDFilter("Pythia8PtGun",
+				 PGunParameters = cms.PSet(
+		AddAntiParticle = cms.bool(True),
+		MaxEta = cms.double(1.6),
+		MaxPhi = cms.double(3.14159265359),
+		MaxPt = cms.double(30.1),
+		MinEta = cms.double(1.2),
+		MinPhi = cms.double(-3.14159265359),
+		MinPt = cms.double(1.1),
+		ParticleID = cms.vint32(-13)
+		),
+				 PythiaParameters = cms.PSet(
+		parameterSets = cms.vstring()
+		),
+				 Verbosity = cms.untracked.int32(0),
+				 firstRun = cms.untracked.uint32(1),
+				 psethack = cms.string('single mu pt 10')
+				 )
+
+process.rpcRecHits.rpcDigiLabel = 'simMuonRPCDigis'
+process.emulatorCppfDigis.recHitLabel = 'rpcRecHits'
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.digitisation_step = cms.Path(process.pdigi)
+process.rpcrechits_step = cms.Path(process.rpcRecHits)
+process.emulatorCppfDigis_step = cms.Path(process.emulatorCppfDigis)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
+
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.digitisation_step,process.rpcrechits_step,process.emulatorCppfDigis_step,process.endjob_step,process.FEVTDEBUGHLToutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path)._seq = process.generator * getattr(process,path)._seq 
+	
+	
+	# Customisation from command line
+	# Add early deletion of temporary data products to reduce peak memory need
+	from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+	process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/L1Trigger/L1TMuonCPPF/test/cppf_emulator_RAW.py
+++ b/L1Trigger/L1TMuonCPPF/test/cppf_emulator_RAW.py
@@ -1,0 +1,99 @@
+
+import FWCore.ParameterSet.Config as cms
+import datetime
+import random
+
+process = cms.Process('DIGI')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+#process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+#process.load('Configuration.Geometry.GeometryDB_cff')
+#process.load('Configuration.StandardSequences.GeometryExtended_cff')
+process.load('Configuration.Geometry.GeometryExtended2016_cff')
+process.load('Configuration.Geometry.GeometryExtended2016Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.load("EventFilter.RPCRawToDigi.rpcUnpacker_cfi")
+import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
+muonRPCDigis = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone()
+muonRPCDigis.InputLabel = 'rawDataCollector'
+
+process.load('RecoLocalMuon.RPCRecHit.rpcRecHits_cfi')
+from RecoLocalMuon.RPCRecHit.rpcRecHits_cfi import *
+
+process.load('L1Trigger.L1TMuonCPPF.emulatorCppfDigis_cfi')
+from L1Trigger.L1TMuonCPPF.emulatorCppfDigis_cfi import *
+
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(1)
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+
+# Input source
+process.source = cms.Source(
+    'PoolSource',fileNames = cms.untracked.vstring ('/store/data/Run2017F/SingleMuon/RAW/v1/000/306/125/00000/4EDD5765-B3C0-E711-B906-02163E01A2D5.root')
+    )
+
+process.options = cms.untracked.PSet(
+    )
+
+process.treeOut = cms.OutputModule("PoolOutputModule",
+                                   fileName = cms.untracked.string('test_cppf_emulator.root'),
+                                   outputCommands = cms.untracked.vstring('drop *',
+                                                                          "keep *_rpcunpacker_*_*", 
+                                                                          "keep *_emulatorCppfDigis_*_*",
+                                                                          "keep *_rpcRecHits_*_*"
+                                                                          #"keep *"
+                                                                          )
+                                   )
+
+
+# Additional output definition
+
+# Other statements
+
+# process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+
+
+process.rpcunpacker.InputLabel = 'rawDataCollector'
+process.rpcRecHits.rpcDigiLabel = 'rpcunpacker'
+process.emulatorCppfDigis.recHitLabel = 'rpcRecHits'
+
+# Path and EndPath definitions
+process.path_step =  cms.Path(process.rpcunpacker)
+process.rpcrechits_step = cms.Path(process.rpcRecHits)
+process.emulatorCppfDigis_step = cms.Path(process.emulatorCppfDigis)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.treeOut_step = cms.EndPath(process.treeOut)
+
+
+
+# Schedule definition
+process.schedule = cms.Schedule(
+    process.path_step,
+    process.rpcrechits_step,
+    process.emulatorCppfDigis_step,
+    process.endjob_step,
+    process.treeOut_step )
+
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# Customisation from command line
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/L1Trigger/L1TMuonCPPF/test/cppf_emulator_RAW_DQM_Plots.py
+++ b/L1Trigger/L1TMuonCPPF/test/cppf_emulator_RAW_DQM_Plots.py
@@ -1,0 +1,109 @@
+
+import FWCore.ParameterSet.Config as cms
+import datetime
+import random
+
+process = cms.Process('DIGI')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+#process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+#process.load('Configuration.Geometry.GeometryDB_cff')
+#process.load('Configuration.StandardSequences.GeometryExtended_cff')
+process.load('Configuration.Geometry.GeometryExtended2016_cff')
+process.load('Configuration.Geometry.GeometryExtended2016Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.load("EventFilter.RPCRawToDigi.rpcUnpacker_cfi")
+import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
+muonRPCDigis = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone()
+muonRPCDigis.InputLabel = 'rawDataCollector'
+
+process.load('RecoLocalMuon.RPCRecHit.rpcRecHits_cfi')
+from RecoLocalMuon.RPCRecHit.rpcRecHits_cfi import *
+
+process.load('L1Trigger.L1TMuonCPPF.emulatorCppfDigis_cfi')
+from L1Trigger.L1TMuonCPPF.emulatorCppfDigis_cfi import *
+
+process.load('L1Trigger.L1TMuonCPPF.cppf_dqm_cfi')
+from L1Trigger.L1TMuonCPPF.cppf_dqm_cfi import *
+
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(1)
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+
+# Input source
+process.source = cms.Source(
+    'PoolSource',fileNames = cms.untracked.vstring ('/store/data/Run2017F/SingleMuon/RAW/v1/000/306/125/00000/4EDD5765-B3C0-E711-B906-02163E01A2D5.root')
+    )
+
+process.options = cms.untracked.PSet(
+    )
+
+process.treeOut = cms.OutputModule("PoolOutputModule",
+                                   fileName = cms.untracked.string('test_cppf_emulator.root'),
+                                   outputCommands = cms.untracked.vstring('drop *',
+                                                                          "keep *_rpcunpacker_*_*", 
+                                                                          "keep *_emulatorCppfDigis_*_*",
+                                                                          "keep *_rpcRecHits_*_*"
+                                                                          #"keep *"
+                                                                          )
+                                   )
+
+
+# Additional output definition
+
+# Other statements
+
+# process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.TFileService = cms.Service("TFileService",
+	fileName = cms.string("DQM_CPPF.root")
+)
+
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+
+
+process.rpcunpacker.InputLabel = 'rawDataCollector'
+process.rpcRecHits.rpcDigiLabel = 'rpcunpacker'
+process.emulatorCppfDigis.recHitLabel = 'rpcRecHits'
+
+# Path and EndPath definitions
+process.path_step =  cms.Path(process.rpcunpacker)
+process.rpcrechits_step = cms.Path(process.rpcRecHits)
+process.emulatorCppfDigis_step = cms.Path(process.emulatorCppfDigis)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.treeOut_step = cms.EndPath(process.treeOut)
+process.plot = cms.Path(process.DQM_CPPF)
+
+
+# Schedule definition
+process.schedule = cms.Schedule(
+    process.path_step,
+    process.rpcrechits_step,
+    process.emulatorCppfDigis_step,
+    process.endjob_step,
+    process.treeOut_step,
+    process.plot 
+		)
+
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# Customisation from command line
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion


### PR DESCRIPTION
This is the first version of the CPPF emulator. we use the RPC Digitization and
reconstruction as intermediate steps.
Under test you can find two examples, one unpacking 2017F RAW Data (cppf_emulator_RAW.py)
and another one using generated MC events (cppf_emulator_MC.py).
The output of the unpacker is an edm branch named emulatorCppfDigis, following
the CPPFDigi dataformat already committed in CMSSW_10_1_X.

one improvement was performed: 
Save maximum 2 CPPFDigis per RPC chamber (hardware performance suggested by the hardware experts).
one analyzer in the folder test as an example was included .

 @abrinke1 @camilocarrillo @jhgoh @mileva


