### PR TITLE
Remove unused simTrackHits parameter from some L1 track trigger code

### DIFF
--- a/L1Trigger/TrackTrigger/python/TTCluster_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTCluster_cfi.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 TTClustersFromPhase2TrackerDigis = cms.EDProducer("TTClusterBuilder_Phase2TrackerDigi_",
     rawHits = cms.VInputTag(cms.InputTag("mix","Tracker")),
-    simTrackHits = cms.InputTag("g4SimHits"),
     ADCThreshold = cms.uint32(30),
     storeLocalCoord = cms.bool(True), # if True, local coordinates (row and col)
                                       # of each hit are stored in the cluster object

--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
@@ -55,13 +55,11 @@ class TTClusterAssociator : public edm::stream::EDProducer<>
   private:
     /// Data members
     edm::Handle< edm::DetSetVector< PixelDigiSimLink > >   thePixelDigiSimLinkHandle;
-    edm::Handle< edm::SimTrackContainer >                  theSimTrackHandle;
     edm::Handle< std::vector< TrackingParticle > >         TrackingParticleHandle;
 
     std::vector< edm::InputTag > TTClustersInputTags;
 
     edm::EDGetTokenT< edm::DetSetVector< PixelDigiSimLink > >              digisimLinkToken;
-    edm::EDGetTokenT< edm::SimTrackContainer >                             simTrackToken;
     edm::EDGetTokenT< std::vector< TrackingParticle > >                    tpToken;
     //std::vector< edm::EDGetTokenT< edm::DetSetVector< TTCluster< T > > > > TTClustersTokens;
     std::vector<edm::EDGetTokenT< edmNew::DetSetVector< TTCluster< T > > > > TTClustersTokens;
@@ -92,7 +90,6 @@ class TTClusterAssociator : public edm::stream::EDProducer<>
 template< typename T >
 TTClusterAssociator< T >::TTClusterAssociator( const edm::ParameterSet& iConfig )
 {
-  simTrackToken = consumes< edm::SimTrackContainer >(iConfig.getParameter< edm::InputTag >( "simTrackHits" ));
   digisimLinkToken = consumes< edm::DetSetVector< PixelDigiSimLink > >(iConfig.getParameter< edm::InputTag >( "digiSimLinks" ));
   tpToken = consumes< std::vector< TrackingParticle >  >(iConfig.getParameter< edm::InputTag >( "trackingParts" ));
 

--- a/SimTracker/TrackTriggerAssociation/python/TTClusterAssociation_cfi.py
+++ b/SimTracker/TrackTriggerAssociation/python/TTClusterAssociation_cfi.py
@@ -4,7 +4,6 @@ TTClusterAssociatorFromPixelDigis = cms.EDProducer("TTClusterAssociator_Phase2Tr
     TTClusters = cms.VInputTag( cms.InputTag("TTClustersFromPhase2TrackerDigis", "ClusterInclusive"),
                                 cms.InputTag("TTStubsFromPhase2TrackerDigis", "ClusterAccepted"),
     ),
-    simTrackHits = cms.InputTag( "g4SimHits" ),
     digiSimLinks = cms.InputTag( "mix","Tracker" ), 
     trackingParts= cms.InputTag( "mix","MergedTrackTruth" )
 )


### PR DESCRIPTION
This PR suggests to remove `simTrackHits` parameter from two places in L1 track trigger code where I found them confusing and not used. (confusion arose from the need to understand whether these modules actually need `g4SimHits` or not in the context of pileup mixing)

Tested in CMSSW_10_1_0, no changes expected.