### PR TITLE
Strip hit eff update 10_2_x

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
@@ -67,6 +67,9 @@ class HitEff : public edm::EDAnalyzer {
   bool addCommonMode_;
   bool cutOnTracks_;
   unsigned int trackMultiplicityCut_;
+  bool useFirstMeas_;
+  bool useLastMeas_;
+  bool useAllHitsFromTracksWithMissingHits_;  
   
   const edm::EDGetTokenT< reco::TrackCollection > combinatorialTracks_token_;
   const edm::EDGetTokenT< std::vector<Trajectory> > trajectories_token_;

--- a/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
@@ -17,6 +17,7 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "TrackingTools/TrackFitters/interface/KFTrajectoryFitter.h"
 #include "TrackingTools/TrackFitters/interface/KFTrajectorySmoother.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h" 
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
@@ -73,6 +74,7 @@ class HitEff : public edm::EDAnalyzer {
   
   const edm::EDGetTokenT< reco::TrackCollection > combinatorialTracks_token_;
   const edm::EDGetTokenT< std::vector<Trajectory> > trajectories_token_;
+  const edm::EDGetTokenT< TrajTrackAssociationCollection > trajTrackAsso_token_;
   const edm::EDGetTokenT< edmNew::DetSetVector<SiStripCluster> > clusters_token_;
   const edm::EDGetTokenT<DetIdCollection> digis_token_;
   const edm::EDGetTokenT<MeasurementTrackerEvent> trackerEvent_token_;
@@ -95,6 +97,7 @@ class HitEff : public edm::EDAnalyzer {
   unsigned int ModIsBad; unsigned int Id; unsigned int SiStripQualBad; bool withinAcceptance;
   int nHits, nLostHits; 
   float p, pT, chi2;
+  bool highPurity;
   unsigned int trajHitValid, run, event, bunchx;
   float timeDT, timeDTErr;
   int timeDTDOF;

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -1041,9 +1041,9 @@ void SiStripHitEffFromCalibTree::makeTKMap(bool autoTagging=false) {
           //Fill the bad list with empty results for every module
           tkmapbad->fillc((*ih).first,255,255,255);
     	}
-    	/*if(myden < nModsMin ) {
+    	if(myden < nModsMin ) {
           cout << "Layer " << i <<" ("<< GetLayerName(i) << ")  module " << (*ih).first << " layer " << i << " is under occupancy at " << myden << endl;
-    	}*/
+    	}
       }
 	  
 	}

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -304,7 +304,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
     // Get event infos
     bool foundEventInfos=false;
     try {
-      CalibTreeFile->cd("testTree");
+      CalibTreeFile->cd("eventInfo");
     }
     catch(exception& e) {
       cout << "No event infos tree" << endl;

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -416,8 +416,8 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
 	  // if no special tree with event infos, they may be stored in the hit eff tree
 	  if(!foundEventInfos){
 		bx = (unsigned int)BunchLf->GetValue();
-		if(InstLumiLf!=0) instLumi = InstLumiLf->GetValue(); // branch not filled by default
-		if(PULf!=0) PU = PULf->GetValue(); // branch not filled by default
+		if(InstLumiLf!=nullptr) instLumi = InstLumiLf->GetValue(); // branch not filled by default
+		if(PULf!=nullptr) PU = PULf->GetValue(); // branch not filled by default
 	  }
 	  int CM = -100;
 	  if(_useCM) CM = CMLf->GetValue();

--- a/CalibTracker/SiStripHitEfficiency/python/SiStripHitEff_cff.py
+++ b/CalibTracker/SiStripHitEfficiency/python/SiStripHitEff_cff.py
@@ -21,7 +21,12 @@ anEff = cms.EDAnalyzer("HitEff",
                        # do not cut on the total number of tracks
                        cutOnTracks = cms.untracked.bool(True),
                        # compatibility
-                       trackMultiplicity = cms.untracked.uint32(100)
+                       trackMultiplicity = cms.untracked.uint32(100),
+                       # use or not first and last measurement of a trajectory (biases), default is false
+                       useFirstMeas = cms.untracked.bool(False),
+                       useLastMeas = cms.untracked.bool(False),
+                       # use or not all hits when some missing hits in the trajectory (bias), default is false
+                       useAllHitsFromTracksWithMissingHits = cms.untracked.bool(False)
                        )
 
 hiteff = cms.Sequence( anEff )

--- a/CalibTracker/SiStripHitEfficiency/test/SiStripHitEff_template.py
+++ b/CalibTracker/SiStripHitEfficiency/test/SiStripHitEff_template.py
@@ -30,6 +30,7 @@ process.SiStripHitEff = cms.EDFilter("SiStripHitEffFromCalibTree",
     ClusterMatchingMethod  = cms.untracked.int32(4),     # default 0  case0,1,2,3,4
     ClusterTrajDist   = cms.untracked.double(64),   # default 64
     StripsApvEdge     = cms.untracked.double(10),   # default 10  
+    UseOnlyHighPurityTracks = cms.untracked.bool(True), # default True
     SpaceBetweenTrains = cms.untracked.int32(25),   # default 25
     UseCommonMode     = cms.untracked.bool(False),  # default False
     ShowEndcapSides   = cms.untracked.bool(True),  # default True

--- a/CalibTracker/SiStripHitEfficiency/test/SiStripHitEff_template.py
+++ b/CalibTracker/SiStripHitEfficiency/test/SiStripHitEff_template.py
@@ -18,7 +18,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1))
 
 process.SiStripHitEff = cms.EDFilter("SiStripHitEffFromCalibTree",
     CalibTreeFilenames = cms.untracked.vstring('root://cms-xrd-global.cern.ch//newfilelocation'),
-    Threshold         = cms.double(0.1),
+    Threshold         = cms.double(0.2),
     nModsMin          = cms.int32(25),
     doSummary         = cms.int32(0),
     #ResXSig           = cms.untracked.double(5),
@@ -27,6 +27,7 @@ process.SiStripHitEff = cms.EDFilter("SiStripHitEffFromCalibTree",
     Record            = cms.string('SiStripBadStrip'),
     doStoreOnDB       = cms.bool(True),
     BadModulesFile    = cms.untracked.string("BadModules_input.txt"),   # default "" no input
+    AutoIneffModTagging = cms.untracked.bool(True),   # default true, automatic limit for each layer to identify inefficient modules
     ClusterMatchingMethod  = cms.untracked.int32(4),     # default 0  case0,1,2,3,4
     ClusterTrajDist   = cms.untracked.double(64),   # default 64
     StripsApvEdge     = cms.untracked.double(10),   # default 10  


### PR DESCRIPTION
Update of the CalibTracker/SiStripHitEfficiency package used for measuring hit efficiency.
Mainly new selections added and update of tree format.