### PR TITLE
Workaround for extra empty bins in MultiTrackValidator histograms with bin labels

### DIFF
--- a/DQMServices/Core/interface/ConcurrentMonitorElement.h
+++ b/DQMServices/Core/interface/ConcurrentMonitorElement.h
@@ -141,6 +141,11 @@ public:
     me_->getTH1()->Sumw2();
   }
 
+  void disableAlphanumeric()
+  {
+    me_->getTH1()->GetXaxis()->SetNoAlphanumeric(false);
+    me_->getTH1()->GetYaxis()->SetNoAlphanumeric(false);
+  }
 };
 
 #endif // DQMServices_Core_ConcurrentMonitorElement_h

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -220,6 +220,7 @@ void MultiTrackValidator::bookHistograms(DQMStore::ConcurrentBooker& ibook, edm:
     for(size_t i=0; i<label.size(); ++i) {
       me.setBinLabel(i+1, label[i].label());
     }
+    me.disableAlphanumeric();
     return me;
   };
 

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -257,11 +257,11 @@ void MultiTrackValidator::bookHistograms(DQMStore::ConcurrentBooker& ibook, edm:
       ibook.cd();
       InputTag algo = label[www];
       string dirName=dirName_;
-      if (algo.process()!="")
+      if (!algo.process().empty())
         dirName+=algo.process()+"_";
-      if(algo.label()!="")
+      if(!algo.label().empty())
         dirName+=algo.label()+"_";
-      if(algo.instance()!="")
+      if(!algo.instance().empty())
         dirName+=algo.instance()+"_";
       if (dirName.find("Tracks")<dirName.length()){
         dirName.replace(dirName.find("Tracks"),6,"");

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -59,12 +59,14 @@ namespace {
     for(size_t i=0; i<labels.size(); ++i) {
       h.setBinLabel(i+1, labels[i]);
     }
+    h.disableAlphanumeric();
   }
 
   void setBinLabelsAlgo(ConcurrentMonitorElement& h, int axis=1) {
     for(size_t i=0; i<reco::TrackBase::algoSize; ++i) {
       h.setBinLabel(i+1, reco::TrackBase::algoName(static_cast<reco::TrackBase::TrackAlgorithm>(i)), axis);
     }
+    h.disableAlphanumeric();
   }
 
   void fillMVAHistos(const std::vector<ConcurrentMonitorElement>& h_mva,
@@ -470,6 +472,7 @@ void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::ConcurrentBooker& 
   histograms.h_algo.push_back( ibook.book1D("h_algo","Tracks by algo",reco::TrackBase::algoSize, 0., double(reco::TrackBase::algoSize) ) );
   for (size_t ibin=0; ibin<reco::TrackBase::algoSize-1; ibin++)
     histograms.h_algo.back().setBinLabel(ibin+1,reco::TrackBase::algoNames[ibin]);
+  histograms.h_algo.back().disableAlphanumeric();
 
   /// these are needed to calculate efficiency during the harvesting for the automated validation
   histograms.h_recoeta.push_back( ibook.book1D("num_reco_eta","N of reco track vs eta",nintEta,minEta,maxEta) );


### PR DESCRIPTION
This PR addresses a problem described in
https://hypernews.cern.ch/HyperNews/CMS/get/dqmDevel/2401.html
i.e. with `ConcurrentMonitorElement` histograms with all bins having a label, additional empty bins appear in a multiple of the number of bins that should exist. As a workaround (I won't call it a fix as the actual origin is not really understood)
* `disableAlphanumeric()` method is added to `ConcurrentMonitorElement()`
  * Calling `TAxis::SetNoAlphanumeric()`
* the `ConcurrentMonitorElement::disableAlphanumeric()` is called in MultiTrackValidator for all histograms with bin labels

following
https://hypernews.cern.ch/HyperNews/CMS/get/dqmDevel/2401/2/1/2/1/1/1/1.html


Tested in CMSSW_10_1_0_pre2, expecting non-labeled empty bins to disappear from MTV histograms with bin labels.

@hajohajo @VinInn 