### PR TITLE
Add a flag to prevent storage of LHEXMLStringProduct

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEAsciiDumper.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEAsciiDumper.cc
@@ -42,6 +42,8 @@ private:
   edm::InputTag lheProduct_;
   std::string   lheFileName_;
 
+  edm::EDGetTokenT<LHEXMLStringProduct> LHEAsciiToken_;
+
   // ----------member data ---------------------------
   
 };
@@ -50,6 +52,8 @@ ExternalLHEAsciiDumper::ExternalLHEAsciiDumper(const edm::ParameterSet& ps):
   lheProduct_( ps.getParameter<edm::InputTag>("lheProduct") ),
   lheFileName_( ps.getParameter<std::string>("lheFileName") )
 {
+  
+  LHEAsciiToken_ = consumes <LHEXMLStringProduct,edm::InRun> (edm::InputTag(lheProduct_));
   
   return;
   
@@ -70,7 +74,7 @@ void
 ExternalLHEAsciiDumper::endRun(edm::Run const& iRun, edm::EventSetup const&) {
 
   edm::Handle< LHEXMLStringProduct > LHEAscii;
-  iRun.getByLabel(lheProduct_,LHEAscii);
+  iRun.getByToken(LHEAsciiToken_,LHEAscii);
   
   const std::vector<std::string>& lheOutputs = LHEAscii->getStrings();
 

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEAsciiDumper.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEAsciiDumper.cc
@@ -91,7 +91,7 @@ ExternalLHEAsciiDumper::endRun(edm::Run const& iRun, edm::EventSetup const&) {
     else {
       std::stringstream fname;
       fname << basename << "_" << iout ;
-      if (extension != "")
+      if (!extension.empty())
         fname << "." << extension;
       outfile.open (fname.str().c_str(), std::ofstream::out | std::ofstream::app);
     }
@@ -107,7 +107,7 @@ ExternalLHEAsciiDumper::endRun(edm::Run const& iRun, edm::EventSetup const&) {
     else {
       std::stringstream fname;
       fname << basename << "_" << iout ;
-      if (extension != "")
+      if (!extension.empty())
         fname << "." << extension;
       outfile.open (fname.str().c_str(), std::ofstream::out | std::ofstream::app);
     }

--- a/GeneratorInterface/LHEInterface/python/ExternalLHEProducer_cfi.py
+++ b/GeneratorInterface/LHEInterface/python/ExternalLHEProducer_cfi.py
@@ -5,6 +5,7 @@ externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     outputFile = cms.string("W1Jet_7TeV_madgraph_final.lhe"),
     numberOfParameters = cms.uint32(10),
     args = cms.vstring('slc5_ia32_gcc434/madgraph/V5_1.3.27/test','W1Jet_7TeV_madgraph','false','true','wjets','5','20','false','0','99'),
-    nEvents = cms.untracked.uint32(100)                                    
+    nEvents = cms.untracked.uint32(100),
+    storeXML = cms.untracked.bool(False)                                 
 )
 


### PR DESCRIPTION
LHEXMLStringProduct is no more really used in production, and it is creating memory issues keeping on hold production in 93X. This PR adds a boolean flag as untracked parameter to activate/deactivate the storage of the xml output into the product, setting the default to "false" (i.e. do not store).

With the opportunity I fixed also the ExternalLHEAsciiDumper analyzer that was supposed to extract the xml file out of the edm root output, and that was no more working.

Both the "false" and "true" option have been tested in wf 512 (10 events), with a visible reduction of the final file size (84kB vs 112kB), and when the option was true the dumper was used to extract the xml file (216 kB after de-compression), proving that is again functional.