### PR TITLE
decouple EventContent_cff load from general purpose use of Merge.py

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -64,6 +64,7 @@ def mergeProcess(*inputFiles, **options):
     if newDQMIO:
         outMod = OutputModule("DQMRootOutputModule")
     elif mergeNANO:
+        import Configuration.EventContent.EventContent_cff
         outMod = OutputModule("NanoAODOutputModule",Configuration.EventContent.EventContent_cff.NANOAODEventContent.clone())
     else:
         outMod = OutputModule("PoolOutputModule")

--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -10,7 +10,6 @@ standard processing
 
 from FWCore.ParameterSet.Config import Process, EndPath
 from FWCore.ParameterSet.Modules import OutputModule, Source, Service
-from Configuration.EventContent.EventContent_cff import NANOAODEventContent
 import FWCore.ParameterSet.Types as CfgTypes
 
 
@@ -65,7 +64,7 @@ def mergeProcess(*inputFiles, **options):
     if newDQMIO:
         outMod = OutputModule("DQMRootOutputModule")
     elif mergeNANO:
-        outMod = OutputModule("NanoAODOutputModule",NANOAODEventContent.clone())
+        outMod = OutputModule("NanoAODOutputModule",Configuration.EventContent.EventContent_cff.NANOAODEventContent.clone())
     else:
         outMod = OutputModule("PoolOutputModule")
 

--- a/Configuration/DataProcessing/test/RunMerge.py
+++ b/Configuration/DataProcessing/test/RunMerge.py
@@ -51,7 +51,7 @@ class RunMerge:
 
 
 if __name__ == '__main__':
-    valid = ["input-files=", "output-file=", "output-lfn=", "dqmroot" ]
+    valid = ["input-files=", "output-file=", "output-lfn=", "dqmroot", "mergeNANO" ]
              
     usage = """RunMerge.py <options>"""
     try:
@@ -75,6 +75,7 @@ if __name__ == '__main__':
             merger.outputLFN = arg
         if opt == "--dqmroot" :
             merger.newDQMIO = True
-        
+        if  opt == "--mergeNANO" :
+            merger.mergeNANO = True
 
     merger()

--- a/Configuration/DataProcessing/test/RunMerge.py
+++ b/Configuration/DataProcessing/test/RunMerge.py
@@ -35,7 +35,8 @@ class RunMerge:
                 process_name = self.processName,
                 output_file = self.outputFile,
                 output_lfn = self.outputLFN,
-                newDQMIO = self.newDQMIO)
+                newDQMIO = self.newDQMIO,
+                mergeNANO = self.mergeNANO)
         except Exception as ex:
             msg = "Error creating process for Merge:\n"
             msg += str(ex)


### PR DESCRIPTION
This should resolve #22933 
The immediate problem is for Configuration/DataProcessing/python/Scenario.py, which defines the T0 config driver for production workflows:
- the Merge.py is needed for file merging functionality of the Scenario.py
- the EventContent_cff has to be also loaded for RECO or similar workflows and is normally supposed to be loaded only after the cms.Process object with a relevant era is created (done in the ConfigBuilder.py)
- In the current state the EventContent_cff is loaded in Merge.py for RECO and similar workflows before  cms.Process object is defined. This is a bug.

This fix simply restricts loading of the EventContent_cff in the Merge.py only in merging context for NANO AOD purposes.

Tests:
``` python $CMSSW_BASE/src/Configuration/DataProcessing/test/RunMerge.py  --input-files file:a.root --output-file file:b.root --mergeNANO```
and then config dump to see that the result is as expected. The RunMerge is also made aware of mergeNANO.

```python $CMSSW_BASE/src/Configuration/DataProcessing/test/RunPromptReco.py --scenario ppEra_Run2_2017_pp_on_XeXe --reco --aod --miniaod --dqmio --global-tag 92X_dataRun2_Express_v7 --lfn=file:raw.root```
and then dump to see that _hiCentrality name  actually shows up in the keep statements

