### PR TITLE
Fix hot HCAL channels in legacy 2016

### DIFF
--- a/CommonTools/ParticleFlow/plugins/BuildFile.xml
+++ b/CommonTools/ParticleFlow/plugins/BuildFile.xml
@@ -14,4 +14,5 @@
   <use   name="JetMETCorrections/Objects"/>
   <use   name="CommonTools/Utils"/>
   <use   name="CommonTools/ParticleFlow"/>
+  <use   name="CalibFormats/HcalObjects"/>
 </library>

--- a/CommonTools/ParticleFlow/plugins/BuildFile.xml
+++ b/CommonTools/ParticleFlow/plugins/BuildFile.xml
@@ -15,4 +15,5 @@
   <use   name="CommonTools/Utils"/>
   <use   name="CommonTools/ParticleFlow"/>
   <use   name="CalibFormats/HcalObjects"/>
+  <use   name="Geometry/HcalTowerAlgo"/>
 </library>

--- a/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
+++ b/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
@@ -176,7 +176,7 @@ void PFCandidateRecalibrator::produce(edm::Event &iEvent, const edm::EventSetup 
 	//deal with HF
 	else if(fabs(pf.eta()) > 3.)
 	  {
-	    math::XYZPointF ecalPoint = pf.positionAtECALEntrance();
+	    const math::XYZPointF& ecalPoint = pf.positionAtECALEntrance();
 	    GlobalPoint ecalGPoint(ecalPoint.X(),ecalPoint.Y(),ecalPoint.Z());
 	    HcalDetId closestDetId(hgeom->getClosestCell(ecalGPoint));
 	    

--- a/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
+++ b/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
@@ -1,0 +1,130 @@
+/// Take:
+//    - a PF candidate collection (which uses bugged HCAL respcorrs)
+//    - respCorrs values from fixed GT and bugged GT
+//  Produce:
+//    - a new PFCandidate collection containing the recalibrated PFCandidates in HF and where the neutral had pointing to problematic cells are removed
+//    - a second PFCandidate collection with just those discarded hadrons
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/Framework/interface/Event.h"
+
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Common/interface/Association.h"
+#include <iostream>
+
+class PFCandidateRecalibrator : public edm::global::EDProducer<> {
+    public:
+        PFCandidateRecalibrator(const edm::ParameterSet&);
+        ~PFCandidateRecalibrator() override {};
+
+        void produce(edm::StreamID iID, edm::Event&, const edm::EventSetup&) const override;
+
+    private:
+        edm::EDGetTokenT<std::vector<reco::PFCandidate> > pfcandidates_;
+};
+
+PFCandidateRecalibrator::PFCandidateRecalibrator(const edm::ParameterSet &iConfig) :
+    pfcandidates_(consumes<std::vector<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("pfcandidates")))
+{
+    produces<std::vector<reco::PFCandidate>>();
+    produces<std::vector<reco::PFCandidate>>("discarded");
+}
+
+void PFCandidateRecalibrator::produce(edm::StreamID iID, edm::Event &iEvent, const edm::EventSetup &iSetup) const
+{
+    //Get Calib Constants from current GT
+    edm::ESHandle<HcalDbService> GTCond;
+    iSetup.get<HcalDbRecord>().get(GTCond);
+
+    //Get Calib Constants from bugged tag
+    edm::ESHandle<HcalTopology> htopo;
+    iSetup.get<HcalRecNumberingRecord>().get(htopo);
+    const HcalTopology* theHBHETopology = htopo.product();
+    
+    edm::ESHandle<HcalRespCorrs> buggedCond;
+    iSetup.get<HcalRespCorrsRcd>().get("bugged", buggedCond);
+    HcalRespCorrs* buggedRespCorrs = new HcalRespCorrs(*buggedCond.product());
+    buggedRespCorrs->setTopo(theHBHETopology);
+
+    //access calogeometry
+    edm::ESHandle<CaloGeometry> calogeom;
+    iSetup.get<CaloGeometryRecord>().get(calogeom);
+    const CaloGeometry* cgeo = calogeom.product();
+    HcalGeometry* hgeom = (HcalGeometry*)(cgeo->getSubdetectorGeometry(DetId::Hcal,HcalForward));
+    
+    //access PFCandidates
+    edm::Handle<std::vector<reco::PFCandidate>> pfcandidates;
+    iEvent.getByToken(pfcandidates_, pfcandidates);
+
+    int n = pfcandidates->size();
+    std::unique_ptr<std::vector<reco::PFCandidate>> copy(new std::vector<reco::PFCandidate>());
+    std::unique_ptr<std::vector<reco::PFCandidate>> discarded(new std::vector<reco::PFCandidate>());
+    copy->reserve(n); 
+
+    for (const reco::PFCandidate &pf : *pfcandidates) 
+      {
+	math::XYZPointF ecalPoint = pf.positionAtECALEntrance();
+	GlobalPoint ecalGPoint(ecalPoint.X(),ecalPoint.Y(),ecalPoint.Z());
+	DetId closestDetId(hgeom->getClosestCell(ecalGPoint));
+	
+	//make sure we are in hcal
+	if(closestDetId.det() != 4)
+	  continue;
+
+	//make sure we are in HE or HF
+        HcalDetId hDetId(closestDetId.rawId());
+	if(hDetId.subdet() != 2 && hDetId.subdet() != 4)
+	  continue;
+	
+	//access the calib values
+	const HcalRespCorr* GTrespcorr = GTCond->getHcalRespCorr(hDetId);
+	float currentRespCorr = GTrespcorr->getValue();
+	float buggedRespCorr = buggedRespCorrs->getValues(hDetId)->getValue();
+	float scalingFactor = currentRespCorr/buggedRespCorr;
+
+	//if same calib then don't do anything
+	if (scalingFactor == 1)
+	  {
+	    copy->push_back(pf);
+	    continue;
+	  }
+
+	//kill pfCandidate if neutral and HE
+	else if (hDetId.subdet() == 2 && pf.particleId() == 5)
+	  {
+	    discarded->push_back(pf);
+	    continue;
+	  }
+
+	//recalibrate pfCandidate if HF
+	else if (hDetId.subdet() == 4)
+	  {
+	    reco::PFCandidate recalibCand(pf);
+	    recalibCand.setHcalEnergy(pf.rawHcalEnergy() * scalingFactor,
+				      pf.hcalEnergy() * scalingFactor);
+	    copy->push_back(pf);
+	  }
+      }
+
+    // Now we put things in the event
+    edm::OrphanHandle<std::vector<reco::PFCandidate>> newpf = iEvent.put(std::move(copy));
+    edm::OrphanHandle<std::vector<reco::PFCandidate>> badpf = iEvent.put(std::move(discarded), "discarded");
+}
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PFCandidateRecalibrator);

--- a/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
+++ b/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
@@ -119,8 +119,10 @@ void PFCandidateRecalibrator::beginRun(const edm::Run &iRun, const edm::EventSet
 	  {
 	    float currentRespCorr = gtCond->getHcalRespCorr(id)->getValue();
 	    float buggedRespCorr = buggedRespCorrs.getValues(id)->getValue();
+	    if (buggedRespCorr == 0.)
+	      continue;
+
 	    float ratio = currentRespCorr/buggedRespCorr;
-	    
 	    if( std::abs(ratio - 1.f) > 0.001 )
 	      {
 		GlobalPoint pos = hgeom->getPosition(id);
@@ -134,8 +136,10 @@ void PFCandidateRecalibrator::beginRun(const edm::Run &iRun, const edm::EventSet
 	  {
 	    float currentRespCorr = gtCond->getHcalRespCorr(id)->getValue();
 	    float buggedRespCorr = buggedRespCorrs.getValues(id)->getValue();
+	    if (buggedRespCorr == 0.)
+	      continue;
+
 	    float ratio = currentRespCorr/buggedRespCorr;
-	    
 	    if( std::abs(ratio - 1.f) > 0.001 )
 	      {
 		HcalDetId dummyId(id);
@@ -338,9 +342,11 @@ PFCandidateRecalibrator::fillDescriptions(edm::ConfigurationDescriptions& descri
 {
   edm::ParameterSetDescription desc;
 
-  desc.add<edm::InputTag>("pfcandidates");
+  desc.add<edm::InputTag>("pfcandidates", edm::InputTag("particleFlow"));
   desc.add<double>("shortFibreThr", 1.4);
   desc.add<double>("longFibreThr", 1.4);
+
+  descriptions.add("pfCandidateRecalibrator", desc);
 
 }
 

--- a/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
+++ b/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
@@ -177,7 +177,7 @@ void PFCandidateRecalibrator::produce(edm::Event &iEvent, const edm::EventSetup 
 
 	//deal with HE
 	if( pf.particleId() == reco::PFCandidate::ParticleType::h0 && 
-	    badChHE_.size() > 0 &&  //don't touch if no miscalibration is found
+	    !badChHE_.empty() &&  //don't touch if no miscalibration is found
 	    absEta > 1.4  && absEta < 3.)
 	  {
 	    bool toKill = false;
@@ -202,7 +202,7 @@ void PFCandidateRecalibrator::produce(edm::Event &iEvent, const edm::EventSetup 
 	  }
 	//deal with HF
 	else if( (pf.particleId() == reco::PFCandidate::ParticleType::h_HF || pf.particleId() == reco::PFCandidate::ParticleType::egamma_HF) &&
-		 badChHF_.size() > 0 &&  //don't touch if no miscalibration is found
+		 !badChHF_.empty() &&  //don't touch if no miscalibration is found
 		 absEta >= 3.)
 	  {
 	    const math::XYZPointF& ecalPoint = pf.positionAtECALEntrance();

--- a/CommonTools/ParticleFlow/python/pfCandidatesBadHadRecalibrated_cfi.py
+++ b/CommonTools/ParticleFlow/python/pfCandidatesBadHadRecalibrated_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+pfCandidatesBadHadRecalibrated = cms.EDProducer("PFCandidateRecalibrator",
+    pfcandidates = cms.InputTag("particleFlow")
+)

--- a/CommonTools/ParticleFlow/python/pfCandidatesBadHadRecalibrated_cfi.py
+++ b/CommonTools/ParticleFlow/python/pfCandidatesBadHadRecalibrated_cfi.py
@@ -1,7 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-pfCandidatesBadHadRecalibrated = cms.EDProducer("PFCandidateRecalibrator",
-                                                pfcandidates = cms.InputTag("particleFlow"),
-                                                shortFibreThr = cms.double(1.4),  #taking it from particleFlowClusterHF_cfi.py
-                                                longFibreThr = cms.double(1.4)    #taking it from particleFlowClusterHF_cfi.py
-                                                )

--- a/CommonTools/ParticleFlow/python/pfCandidatesBadHadRecalibrated_cfi.py
+++ b/CommonTools/ParticleFlow/python/pfCandidatesBadHadRecalibrated_cfi.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 pfCandidatesBadHadRecalibrated = cms.EDProducer("PFCandidateRecalibrator",
-    pfcandidates = cms.InputTag("particleFlow")
-)
+                                                pfcandidates = cms.InputTag("particleFlow"),
+                                                shortFibreThr = cms.double(1.4),  #taking it from particleFlowClusterHF_cfi.py
+                                                longFibreThr = cms.double(1.4)    #taking it from particleFlowClusterHF_cfi.py
+                                                )

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2274,7 +2274,9 @@ steps['REMINIAOD_data2016'] = merge([{'-s' : 'PAT,DQM:@miniAODDQM',
 
 steps['REMINIAOD_data2016_HIPM'] = merge([{'--era' : 'Run2_2016_HIPM,run2_miniAOD_80XLegacy'},steps['REMINIAOD_data2016']])
 
-steps['REMINIAOD_data2017'] = merge([{'--era' : 'Run2_2017,run2_miniAOD_94XFall17'},steps['REMINIAOD_data2016']])
+stepReMiniAODData17 = merge([{'--era' : 'Run2_2017,run2_miniAOD_94XFall17'},steps['REMINIAOD_data2016']])
+stepReMiniAODData17 = remove(stepReMiniAODData17,'--customise_unsch')
+steps['REMINIAOD_data2017'] = stepReMiniAODData17
 
 # Not sure whether the customisations are in the dict as "--customise" or "--era" so try to
 # remove both. Currently premixing uses "--customise" and everything else uses "--era".

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2268,7 +2268,8 @@ steps['REMINIAOD_data2016'] = merge([{'-s' : 'PAT,DQM:@miniAODDQM',
                                       '--data' : '',
                                       '--scenario' : 'pp',
                                       '--eventcontent' : 'MINIAOD,DQM',
-                                      '--datatier' : 'MINIAOD,DQMIO'
+                                      '--datatier' : 'MINIAOD,DQMIO',
+                                      '--customise_unsch' : 'PhysicsTools/PatAlgos/slimming/customizeMiniAOD_HcalFixLegacy2016.customizeAll'
                                       },stepMiniAODDefaults])
 
 steps['REMINIAOD_data2016_HIPM'] = merge([{'--era' : 'Run2_2016_HIPM,run2_miniAOD_80XLegacy'},steps['REMINIAOD_data2016']])

--- a/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
+++ b/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
@@ -69,32 +69,6 @@ def cleanPfCandidates(process, verbose=False):
     process.reducedEgamma.photonsPFValMap      = cms.InputTag("pfEGammaToCandidateRemapper","photons")
 
 
-    #add bugged conditions to GT for comparison
-    process.GlobalTag.toGet.append(cms.PSet(
-        record = cms.string("HcalRespCorrsRcd"),
-        label = cms.untracked.string("bugged"),
-        tag = cms.string("HcalRespCorrs_v6.3_offline")
-        )
-    )
-
-
-    #=== TMP FOR TESTING ONLY
-    #process.load("CondCore.DBCommon.CondDBSetup_cfi")
-    #process.es_pool = cms.ESSource("PoolDBESSource",
-    #                               process.CondDBSetup,
-    #                               timetype = cms.string('runnumber'),
-    #                               toGet = cms.VPSet(
-    #                                            cms.PSet(record = cms.string("HcalRespCorrsRcd"),
-    #                                            tag = cms.string("HcalRespCorrs_2016legacy_fixBadCalib")
-    #                                                     )
-    #                                            ),
-    #                               connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
-    #                               authenticationMethod = cms.untracked.uint32(0)
-    #                               )
-    #process.es_prefer_es_pool = cms.ESPrefer( "PoolDBESSource", "es_pool" )
-    #=== END - TMP FOR TESTING ONLY
-
-
 def addDiscardedPFCandidates(process, inputCollection, verbose=False):
 
     task = getPatAlgosToolsTask(process)
@@ -127,14 +101,5 @@ def customizeAll(process, verbose=False):
 
     cleanPfCandidates(process, verbose)
     addDiscardedPFCandidates(process, cms.InputTag("pfCandidatesBadHadRecalibrated","discarded"), verbose=verbose)
-
-    #=== TMP FOR TESTING ONLY
-    #addKeepStatement(process, "keep patPackedCandidates_packedPFCandidates_*_*",
-    #                         ["keep patPackedCandidates_packedPFCandidatesDiscarded_*_*",
-    #                          "keep *_particleFlow__*",
-    #                          "keep *_pfCandidatesBadHadRecalibrated__*"],
-    #                          verbose=verbose)
-    #=== END - TMP FOR TESTING ONLY
-
 
     return process

--- a/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
+++ b/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
@@ -15,10 +15,9 @@ def loadJetMETBTag(process):
     task.add(process.ak4PFJets)
     process.ak8PFJetsCHS = RecoJets.Configuration.RecoPFJets_cff.ak8PFJetsCHS.clone()
     task.add(process.ak8PFJetsCHS)
-    process.load("RecoMET.METProducers.PFMET_cfi")
-    task.add(process.pfMet)
     process.load("RecoJets.JetAssociationProducers.ak4JTA_cff")
     task.add(process.ak4JetTracksAssociatorAtVertexPF)
+
     process.load("RecoBTag.ImpactParameter.impactParameter_cff")
     task.add(process.impactParameterTask)
     process.load("RecoBTag.SecondaryVertex.secondaryVertex_cff")
@@ -33,6 +32,9 @@ def loadJetMETBTag(process):
     task.add(process.inclusiveVertexingTask)
     task.add(process.inclusiveCandidateVertexingTask)
     task.add(process.inclusiveCandidateVertexingCvsLTask)
+
+    process.load("RecoMET.METProducers.PFMET_cfi")
+    task.add(process.pfMet)
 
 
 def cleanPfCandidates(process, verbose=False):
@@ -60,7 +62,7 @@ def cleanPfCandidates(process, verbose=False):
     process.GlobalTag.toGet.append(cms.PSet(
         record = cms.string("HcalRespCorrsRcd"),
         label = cms.untracked.string("bugged"),
-        tag = cms.string("HcalRespCorrs_v6.3_offline") #to be replaced with proper bugged tag
+        tag = cms.string("HcalRespCorrs_v6.3_offline")
         )
     )
 
@@ -72,7 +74,7 @@ def cleanPfCandidates(process, verbose=False):
     #                               timetype = cms.string('runnumber'),
     #                               toGet = cms.VPSet(
     #                                            cms.PSet(record = cms.string("HcalRespCorrsRcd"),
-    #                                            tag = cms.string("HcalRespCorrs_2016legacy_fixBadCalib")  #based on HcalRespCorrs_v6.3_offline
+    #                                            tag = cms.string("HcalRespCorrs_2016legacy_fixBadCalib")
     #                                                     )
     #                                            ),
     #                               connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),

--- a/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
+++ b/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+from PhysicsTools.PatAlgos.tools.helpers import MassSearchReplaceAnyInputTagVisitor, addKeepStatement
+from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask
+
+def cleanPfCandidates(process, verbose=False):
+    task = getPatAlgosToolsTask(process)
+
+    #add producer at the beginning of the schedule
+    process.load("CommonTools.ParticleFlow.pfCandidatesBadHadRecalibrated_cfi")
+    task.add(process.pfCandidatesBadHadRecalibrated)
+
+    replacePFCandidates = MassSearchReplaceAnyInputTagVisitor("particleFlow", "pfCandidatesBadHadRecalibrated", verbose=verbose)
+    for everywhere in [ process.producers, process.filters, process.analyzers, process.psets, process.vpsets ]:
+        for name,obj in everywhere.iteritems():
+            if obj != process.pfCandidatesBadHadRecalibrated:
+                replacePFCandidates.doIt(obj, name)
+
+    #add bugged conditions to GT for comparison
+    process.GlobalTag.toGet.append(cms.PSet(
+        record = cms.string("HcalRespCorrsRcd"),
+        label = cms.untracked.string("bugged"),
+        tag = cms.string("HcalRespCorrs_v1.02_express") #to be replaced with proper tag name once available
+        )
+    )
+
+
+
+def customizeAll(process, verbose=False):
+    print "===>>> customizing the process for legacy rereco 2016"
+
+    cleanPfCandidates(process, verbose)
+
+    addKeepStatement(process,
+                     "keep *_pfCandidatesBadHadRecalibrated_*_*",
+                     ["keep *_pfCandidatesBadHadRecalibrated_discarded_*"],
+                     verbose=verbose)
+    
+
+    return process

--- a/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
+++ b/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
@@ -3,6 +3,35 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.helpers import MassSearchReplaceAnyInputTagVisitor, addKeepStatement
 from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask
 
+def loadJetMETBTag(process):
+
+    task = getPatAlgosToolsTask(process)
+
+    import RecoJets.Configuration.RecoPFJets_cff
+    process.ak4PFJetsCHS = RecoJets.Configuration.RecoPFJets_cff.ak4PFJetsCHS.clone()
+    task.add(process.ak4PFJetsCHS)
+    process.ak8PFJetsCHS = RecoJets.Configuration.RecoPFJets_cff.ak8PFJetsCHS.clone()
+    task.add(process.ak8PFJetsCHS)
+    process.load("RecoMET.METProducers.PFMET_cfi")
+    task.add(process.pfMet)
+    process.load("RecoBTag.ImpactParameter.impactParameter_cff")
+    task.add(process.impactParameterTask)
+    process.load("RecoBTag.SecondaryVertex.secondaryVertex_cff")
+    task.add(process.secondaryVertexTask)
+    process.load("RecoBTag.SoftLepton.softLepton_cff")
+    task.add(process.softLeptonTask)
+    process.load("RecoBTag.Combined.combinedMVA_cff")
+    task.add(process.combinedMVATask)
+    process.load("RecoBTag.Combined.deepFlavour_cff")
+    task.add(process.pfDeepFlavourTask)
+    process.load("RecoBTag.CTagging.cTagging_cff")
+    task.add(process.cTaggingTask)
+    process.load("RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff")
+    task.add(process.inclusiveVertexingTask)
+    task.add(process.inclusiveCandidateVertexingTask)
+    task.add(process.inclusiveCandidateVertexingCvsLTask)
+
+
 def cleanPfCandidates(process, verbose=False):
     task = getPatAlgosToolsTask(process)
 
@@ -16,6 +45,14 @@ def cleanPfCandidates(process, verbose=False):
             if obj != process.pfCandidatesBadHadRecalibrated:
                 replacePFCandidates.doIt(obj, name)
 
+
+    process.load("CommonTools.ParticleFlow.pfEGammaToCandidateRemapper_cfi")
+    task.add(process.pfEGammaToCandidateRemapper)
+    process.pfEGammaToCandidateRemapper.pf2pf = cms.InputTag("pfCandidatesBadHadRecalibrated")
+    process.reducedEgamma.gsfElectronsPFValMap = cms.InputTag("pfEGammaToCandidateRemapper","electrons")
+    process.reducedEgamma.photonsPFValMap      = cms.InputTag("pfEGammaToCandidateRemapper","photons")
+
+
     #add bugged conditions to GT for comparison
     process.GlobalTag.toGet.append(cms.PSet(
         record = cms.string("HcalRespCorrsRcd"),
@@ -24,17 +61,45 @@ def cleanPfCandidates(process, verbose=False):
         )
     )
 
+def addDiscardedPFCandidates(process, inputCollection, verbose=False):
+
+    task = getPatAlgosToolsTask(process)
+
+    process.primaryVertexAssociationDiscardedCandidates = process.primaryVertexAssociation.clone(
+        particles = inputCollection,
+        )
+    task.add(process.primaryVertexAssociationDiscardedCandidates)
+
+    process.packedPFCandidatesDiscarded = process.packedPFCandidates.clone(
+        inputCollection = inputCollection,
+        PuppiNoLepSrc = cms.InputTag(""),
+        PuppiSrc = cms.InputTag(""),
+        secondaryVerticesForWhiteList = cms.VInputTag(),
+        vertexAssociator = cms.InputTag("primaryVertexAssociationDiscardedCandidates","original")
+        )
+    task.add(process.packedPFCandidatesDiscarded)
+
+    addKeepStatement(process, "keep patPackedCandidates_packedPFCandidates_*_*",
+                             ["keep patPackedCandidates_packedPFCandidatesDiscarded_*_*"],
+                              verbose=verbose)
+    # Now make the mixed map for rekeying
+    from PhysicsTools.PatAlgos.slimming.packedPFCandidateRefMixer_cfi import packedPFCandidateRefMixer
+    process.oldPFCandToPackedOrDiscarded = packedPFCandidateRefMixer.clone(
+        pf2pf = cms.InputTag(inputCollection.moduleLabel),
+        pf2packed = cms.VInputTag(cms.InputTag("packedPFCandidates"), cms.InputTag("packedPFCandidatesDiscarded"))
+    )
+    task.add(process.oldPFCandToPackedOrDiscarded)
 
 
-def customizeAll(process, verbose=False):
-    print "===>>> customizing the process for legacy rereco 2016"
+def customizeAll(process, verbose=True): #change to false by default
+
+    if verbose:
+        print "===>>> customizing the process for legacy rereco 2016"
+
+    loadJetMETBTag(process)
 
     cleanPfCandidates(process, verbose)
+    addDiscardedPFCandidates(process, cms.InputTag("pfCandidatesBadHadRecalibrated","discarded"), verbose=verbose)
 
-    addKeepStatement(process,
-                     "keep *_pfCandidatesBadHadRecalibrated_*_*",
-                     ["keep *_pfCandidatesBadHadRecalibrated_discarded_*"],
-                     verbose=verbose)
-    
 
     return process

--- a/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
+++ b/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
@@ -50,21 +50,21 @@ def cleanPfCandidates(process, verbose=False):
     task = getPatAlgosToolsTask(process)
 
     #add producer at the beginning of the schedule
-    process.load("CommonTools.ParticleFlow.pfCandidatesBadHadRecalibrated_cfi")
-    task.add(process.pfCandidatesBadHadRecalibrated)
+    process.load("CommonTools.ParticleFlow.pfCandidateRecalibrator_cfi")
+    task.add(process.pfCandidateRecalibrator)
 
-    replacePFCandidates = MassSearchReplaceAnyInputTagVisitor("particleFlow", "pfCandidatesBadHadRecalibrated", verbose=verbose)
+    replacePFCandidates = MassSearchReplaceAnyInputTagVisitor("particleFlow", "pfCandidateRecalibrator", verbose=verbose)
     replacePFTmpPtrs = MassSearchReplaceAnyInputTagVisitor("particleFlowTmpPtrs", "particleFlowPtrs", verbose=verbose)
     for everywhere in [ process.producers, process.filters, process.analyzers, process.psets, process.vpsets ]:
         for name,obj in everywhere.iteritems():
-            if obj != process.pfCandidatesBadHadRecalibrated:
+            if obj != process.pfCandidateRecalibrator:
                 replacePFCandidates.doIt(obj, name)
                 replacePFTmpPtrs.doIt(obj, name)
 
 
     process.load("CommonTools.ParticleFlow.pfEGammaToCandidateRemapper_cfi")
     task.add(process.pfEGammaToCandidateRemapper)
-    process.pfEGammaToCandidateRemapper.pf2pf = cms.InputTag("pfCandidatesBadHadRecalibrated")
+    process.pfEGammaToCandidateRemapper.pf2pf = cms.InputTag("pfCandidateRecalibrator")
     process.reducedEgamma.gsfElectronsPFValMap = cms.InputTag("pfEGammaToCandidateRemapper","electrons")
     process.reducedEgamma.photonsPFValMap      = cms.InputTag("pfEGammaToCandidateRemapper","photons")
 
@@ -100,6 +100,6 @@ def customizeAll(process, verbose=False):
     loadJetMETBTag(process)
 
     cleanPfCandidates(process, verbose)
-    addDiscardedPFCandidates(process, cms.InputTag("pfCandidatesBadHadRecalibrated","discarded"), verbose=verbose)
+    addDiscardedPFCandidates(process, cms.InputTag("pfCandidateRecalibrator","discarded"), verbose=verbose)
 
     return process

--- a/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
+++ b/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
@@ -10,10 +10,15 @@ def loadJetMETBTag(process):
     import RecoJets.Configuration.RecoPFJets_cff
     process.ak4PFJetsCHS = RecoJets.Configuration.RecoPFJets_cff.ak4PFJetsCHS.clone()
     task.add(process.ak4PFJetsCHS)
+    # need also the non-CHS ones as they are used to seed taus
+    process.ak4PFJets = RecoJets.Configuration.RecoPFJets_cff.ak4PFJets.clone()
+    task.add(process.ak4PFJets)
     process.ak8PFJetsCHS = RecoJets.Configuration.RecoPFJets_cff.ak8PFJetsCHS.clone()
     task.add(process.ak8PFJetsCHS)
     process.load("RecoMET.METProducers.PFMET_cfi")
     task.add(process.pfMet)
+    process.load("RecoJets.JetAssociationProducers.ak4JTA_cff")
+    task.add(process.ak4JetTracksAssociatorAtVertexPF)
     process.load("RecoBTag.ImpactParameter.impactParameter_cff")
     task.add(process.impactParameterTask)
     process.load("RecoBTag.SecondaryVertex.secondaryVertex_cff")
@@ -22,8 +27,6 @@ def loadJetMETBTag(process):
     task.add(process.softLeptonTask)
     process.load("RecoBTag.Combined.combinedMVA_cff")
     task.add(process.combinedMVATask)
-    process.load("RecoBTag.Combined.deepFlavour_cff")
-    task.add(process.pfDeepFlavourTask)
     process.load("RecoBTag.CTagging.cTagging_cff")
     task.add(process.cTaggingTask)
     process.load("RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff")
@@ -57,9 +60,27 @@ def cleanPfCandidates(process, verbose=False):
     process.GlobalTag.toGet.append(cms.PSet(
         record = cms.string("HcalRespCorrsRcd"),
         label = cms.untracked.string("bugged"),
-        tag = cms.string("HcalRespCorrs_v1.02_express") #to be replaced with proper tag name once available
+        tag = cms.string("HcalRespCorrs_v6.3_offline") #to be replaced with proper bugged tag
         )
     )
+
+
+    #=== TMP FOR TESTING ONLY
+    #process.load("CondCore.DBCommon.CondDBSetup_cfi")
+    #process.es_pool = cms.ESSource("PoolDBESSource",
+    #                               process.CondDBSetup,
+    #                               timetype = cms.string('runnumber'),
+    #                               toGet = cms.VPSet(
+    #                                            cms.PSet(record = cms.string("HcalRespCorrsRcd"),
+    #                                            tag = cms.string("HcalRespCorrs_2016legacy_fixBadCalib")
+    #                                                     )
+    #                                            ),
+    #                               connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+    #                               authenticationMethod = cms.untracked.uint32(0)
+    #                               )
+    #process.es_prefer_es_pool = cms.ESPrefer( "PoolDBESSource", "es_pool" )
+    #=== END - TMP FOR TESTING ONLY
+
 
 def addDiscardedPFCandidates(process, inputCollection, verbose=False):
 
@@ -91,7 +112,7 @@ def addDiscardedPFCandidates(process, inputCollection, verbose=False):
     task.add(process.oldPFCandToPackedOrDiscarded)
 
 
-def customizeAll(process, verbose=True): #change to false by default
+def customizeAll(process, verbose=False):
 
     if verbose:
         print "===>>> customizing the process for legacy rereco 2016"

--- a/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
+++ b/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
@@ -72,7 +72,7 @@ def cleanPfCandidates(process, verbose=False):
     #                               timetype = cms.string('runnumber'),
     #                               toGet = cms.VPSet(
     #                                            cms.PSet(record = cms.string("HcalRespCorrsRcd"),
-    #                                            tag = cms.string("HcalRespCorrs_2016legacy_fixBadCalib")
+    #                                            tag = cms.string("HcalRespCorrs_2016legacy_fixBadCalib")  #based on HcalRespCorrs_v6.3_offline
     #                                                     )
     #                                            ),
     #                               connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
@@ -121,6 +121,14 @@ def customizeAll(process, verbose=False):
 
     cleanPfCandidates(process, verbose)
     addDiscardedPFCandidates(process, cms.InputTag("pfCandidatesBadHadRecalibrated","discarded"), verbose=verbose)
+
+    #=== TMP FOR TESTING ONLY
+    #addKeepStatement(process, "keep patPackedCandidates_packedPFCandidates_*_*",
+    #                         ["keep patPackedCandidates_packedPFCandidatesDiscarded_*_*",
+    #                          "keep *_particleFlow__*",
+    #                          "keep *_pfCandidatesBadHadRecalibrated__*"],
+    #                          verbose=verbose)
+    #=== END - TMP FOR TESTING ONLY
 
 
     return process


### PR DESCRIPTION
same content as in #22713

this development is relevant for the re-miniAODv2 of the 2016 legacy rereco that will happen in 94x.

for reference, here is the effect of the recipe on HE:
- left plot in slide 2 at: https://indico.cern.ch/event/713034/contributions/2936595/attachments/1617731/2571895/15Mar2018_Legacy_HCALfixV2.pdf
- slides up to 8 at: https://www.dropbox.com/s/g75uiiod37a7qvg/2018-03-04_MET-HCALfix_3rd_2016legacy.pdf?dl=0