### PR TITLE
Small bug fix in hltGetConfiguration (102X)

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -682,9 +682,9 @@ if 'GlobalTag' in %%(dict)s:
       else:
         # drop all output EndPaths but the Scouting ones, and drop the RatesMonitoring and DQMHistograms
         paths.append( "-*Output" )
-        paths.append( "Scouting*Output" )
         paths.append( "-RatesMonitoring")
         paths.append( "-DQMHistograms")
+        if self.config.fragment: paths.append( "Scouting*Output" )
 
     elif self.config.output in ('dqm', 'minimal', 'full'):
       if self.config.paths:
@@ -693,8 +693,8 @@ if 'GlobalTag' in %%(dict)s:
       else:
         # drop all output EndPaths but the Scouting ones, and drop the RatesMonitoring
         paths.append( "-*Output" )
-        paths.append( "Scouting*Output" )
         paths.append( "-RatesMonitoring")
+        if self.config.fragment: paths.append( "Scouting*Output" )
 
     else:
       if self.config.paths:


### PR DESCRIPTION
Issue: scouting EndPaths are included in the HLT configuration even when `hltGetConfiguration --no-output` is used. This is a side effect of #21297 .
Solution: add Scouting EndPaths only when `--cff` option is used (this is needed to add Scouting objects in MC production, see #21297)

101 backport: #22945