### PR TITLE
Backport of #22935 to 93X (Add a flag to prevent storage of LHEXMLStringProduct)

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEAsciiDumper.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEAsciiDumper.cc
@@ -42,6 +42,8 @@ private:
   edm::InputTag lheProduct_;
   std::string   lheFileName_;
 
+  edm::EDGetTokenT<LHEXMLStringProduct> LHEAsciiToken_;
+
   // ----------member data ---------------------------
   
 };
@@ -50,6 +52,8 @@ ExternalLHEAsciiDumper::ExternalLHEAsciiDumper(const edm::ParameterSet& ps):
   lheProduct_( ps.getParameter<edm::InputTag>("lheProduct") ),
   lheFileName_( ps.getParameter<std::string>("lheFileName") )
 {
+
+  LHEAsciiToken_ = consumes <LHEXMLStringProduct,edm::InRun> (edm::InputTag(lheProduct_));
   
   return;
   
@@ -70,7 +74,7 @@ void
 ExternalLHEAsciiDumper::endRun(edm::Run const& iRun, edm::EventSetup const&) {
 
   edm::Handle< LHEXMLStringProduct > LHEAscii;
-  iRun.getByLabel(lheProduct_,LHEAscii);
+  iRun.getByToken(LHEAsciiToken_,LHEAscii);
   
   const std::vector<std::string>& lheOutputs = LHEAscii->getStrings();
 
@@ -87,7 +91,7 @@ ExternalLHEAsciiDumper::endRun(edm::Run const& iRun, edm::EventSetup const&) {
     else {
       std::stringstream fname;
       fname << basename << "_" << iout ;
-      if (extension != "")
+      if (!extension.empty())
         fname << "." << extension;
       outfile.open (fname.str().c_str(), std::ofstream::out | std::ofstream::app);
     }
@@ -103,7 +107,7 @@ ExternalLHEAsciiDumper::endRun(edm::Run const& iRun, edm::EventSetup const&) {
     else {
       std::stringstream fname;
       fname << basename << "_" << iout ;
-      if (extension != "")
+      if (!extension.empty())
         fname << "." << extension;
       outfile.open (fname.str().c_str(), std::ofstream::out | std::ofstream::app);
     }

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -93,6 +93,7 @@ private:
   std::vector<std::string> args_;
   uint32_t npars_;
   uint32_t nEvents_;
+  bool storeXML_;
   unsigned int nThreads_{1};
   std::string outputContents_;
 
@@ -133,7 +134,8 @@ ExternalLHEProducer::ExternalLHEProducer(const edm::ParameterSet& iConfig) :
   outputFile_(iConfig.getParameter<std::string>("outputFile")),
   args_(iConfig.getParameter<std::vector<std::string> >("args")),
   npars_(iConfig.getParameter<uint32_t>("numberOfParameters")),
-  nEvents_(iConfig.getUntrackedParameter<uint32_t>("nEvents"))
+  nEvents_(iConfig.getUntrackedParameter<uint32_t>("nEvents")),
+  storeXML_(iConfig.getUntrackedParameter<bool>("storeXML"))
 {
   if (npars_ != args_.size())
     throw cms::Exception("ExternalLHEProducer") << "Problem with configuration: " << args_.size() << " script arguments given, expected " << npars_;
@@ -256,17 +258,21 @@ ExternalLHEProducer::beginRunProduce(edm::Run& run, edm::EventSetup const& es)
 
   executeScript();
   
+
   //fill LHEXMLProduct (streaming read directly into compressed buffer to save memory)
   std::unique_ptr<LHEXMLStringProduct> p(new LHEXMLStringProduct);
-  std::ifstream instream(outputFile_);
-  if (!instream) {
-    throw cms::Exception("OutputOpenError") << "Unable to open script output file " << outputFile_ << ".";
-  }  
-  instream.seekg (0, instream.end);
-  int insize = instream.tellg();
-  instream.seekg (0, instream.beg);  
-  p->fillCompressedContent(instream, 0.25*insize);
-  instream.close();
+
+  //store the XML file only if explictly requested
+  if (storeXML_) {  std::ifstream instream(outputFile_);
+    if (!instream) {
+      throw cms::Exception("OutputOpenError") << "Unable to open script output file " << outputFile_ << ".";
+    }  
+    instream.seekg (0, instream.end);
+    int insize = instream.tellg();
+    instream.seekg (0, instream.beg);  
+    p->fillCompressedContent(instream, 0.25*insize);
+    instream.close();
+  }
   run.put(std::move(p), "LHEScriptOutput");
 
   // LHE C++ classes translation
@@ -499,6 +505,7 @@ ExternalLHEProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<std::vector<std::string> >("args");
   desc.add<uint32_t>("numberOfParameters");
   desc.addUntracked<uint32_t>("nEvents");
+  desc.addUntracked<bool>("storeXML", false);
 
   descriptions.addDefault(desc);
 }

--- a/GeneratorInterface/LHEInterface/python/ExternalLHEProducer_cfi.py
+++ b/GeneratorInterface/LHEInterface/python/ExternalLHEProducer_cfi.py
@@ -5,6 +5,7 @@ externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     outputFile = cms.string("W1Jet_7TeV_madgraph_final.lhe"),
     numberOfParameters = cms.uint32(10),
     args = cms.vstring('slc5_ia32_gcc434/madgraph/V5_1.3.27/test','W1Jet_7TeV_madgraph','false','true','wjets','5','20','false','0','99'),
-    nEvents = cms.untracked.uint32(100)                                    
+    nEvents = cms.untracked.uint32(100),
+    storeXML = cms.untracked.bool(False)                                    
 )
 


### PR DESCRIPTION
LHEXMLStringProduct is no more really used in production, and it is creating memory issues keeping on hold production in 93X. This PR adds a boolean flag as untracked parameter to activate/deactivate the storage of the xml output into the product, setting the default to "false" (i.e. do not store).

With the opportunity I fixed also the ExternalLHEAsciiDumper analyzer that was supposed to extract the xml file out of the edm root output, and that was no more working.

Both the "false" and "true" option have been tested in wf 512 (10 events), with a visible reduction of the final file size (84kB vs 112kB), and when the option was true the dumper was used to extract the xml file (216 kB after de-compression), proving that is again functional.

Tested in master (10_2_X), wf 512.0 not functional in 9_3_8.

Backport of #22935 (only changes in that PR, rest of the package left unchanged)