### PR TITLE
DQMStore preparations for concurrent booking - phase 2

### DIFF
--- a/DQMServices/Core/interface/DQMNet.h
+++ b/DQMServices/Core/interface/DQMNet.h
@@ -23,58 +23,58 @@
 class DQMNet
 {
 public:
-  static const uint32_t DQM_PROP_TYPE_MASK	 = 0x000000ff;
-  static const uint32_t DQM_PROP_TYPE_SCALAR	 = 0x0000000f;
-  static const uint32_t DQM_PROP_TYPE_INVALID	 = 0x00000000;
-  static const uint32_t DQM_PROP_TYPE_INT	 = 0x00000001;
-  static const uint32_t DQM_PROP_TYPE_REAL	 = 0x00000002;
-  static const uint32_t DQM_PROP_TYPE_STRING	 = 0x00000003;
-  static const uint32_t DQM_PROP_TYPE_TH1F	 = 0x00000010;
-  static const uint32_t DQM_PROP_TYPE_TH1S	 = 0x00000011;
-  static const uint32_t DQM_PROP_TYPE_TH1D	 = 0x00000012;
-  static const uint32_t DQM_PROP_TYPE_TH2F	 = 0x00000020;
-  static const uint32_t DQM_PROP_TYPE_TH2S	 = 0x00000021;
-  static const uint32_t DQM_PROP_TYPE_TH2D	 = 0x00000022;
-  static const uint32_t DQM_PROP_TYPE_TH3F	 = 0x00000030;
-  static const uint32_t DQM_PROP_TYPE_TH3S	 = 0x00000031;
-  static const uint32_t DQM_PROP_TYPE_TH3D	 = 0x00000032;
-  static const uint32_t DQM_PROP_TYPE_TPROF	 = 0x00000040;
-  static const uint32_t DQM_PROP_TYPE_TPROF2D	 = 0x00000041;
-  static const uint32_t DQM_PROP_TYPE_DATABLOB	 = 0x00000050;
-  
-  static const uint32_t DQM_PROP_REPORT_MASK	 = 0x00000f00;
-  static const uint32_t DQM_PROP_REPORT_CLEAR	 = 0x00000000;
-  static const uint32_t DQM_PROP_REPORT_ERROR	 = 0x00000100;
-  static const uint32_t DQM_PROP_REPORT_WARN	 = 0x00000200;
-  static const uint32_t DQM_PROP_REPORT_OTHER	 = 0x00000400;
-  static const uint32_t DQM_PROP_REPORT_ALARM	 = (DQM_PROP_REPORT_ERROR
-						    | DQM_PROP_REPORT_WARN
-						    | DQM_PROP_REPORT_OTHER);
+  static const uint32_t DQM_PROP_TYPE_MASK       = 0x000000ff;
+  static const uint32_t DQM_PROP_TYPE_SCALAR     = 0x0000000f;
+  static const uint32_t DQM_PROP_TYPE_INVALID    = 0x00000000;
+  static const uint32_t DQM_PROP_TYPE_INT        = 0x00000001;
+  static const uint32_t DQM_PROP_TYPE_REAL       = 0x00000002;
+  static const uint32_t DQM_PROP_TYPE_STRING     = 0x00000003;
+  static const uint32_t DQM_PROP_TYPE_TH1F       = 0x00000010;
+  static const uint32_t DQM_PROP_TYPE_TH1S       = 0x00000011;
+  static const uint32_t DQM_PROP_TYPE_TH1D       = 0x00000012;
+  static const uint32_t DQM_PROP_TYPE_TH2F       = 0x00000020;
+  static const uint32_t DQM_PROP_TYPE_TH2S       = 0x00000021;
+  static const uint32_t DQM_PROP_TYPE_TH2D       = 0x00000022;
+  static const uint32_t DQM_PROP_TYPE_TH3F       = 0x00000030;
+  static const uint32_t DQM_PROP_TYPE_TH3S       = 0x00000031;
+  static const uint32_t DQM_PROP_TYPE_TH3D       = 0x00000032;
+  static const uint32_t DQM_PROP_TYPE_TPROF      = 0x00000040;
+  static const uint32_t DQM_PROP_TYPE_TPROF2D    = 0x00000041;
+  static const uint32_t DQM_PROP_TYPE_DATABLOB   = 0x00000050;
 
-  static const uint32_t DQM_PROP_HAS_REFERENCE	 = 0x00001000;
-  static const uint32_t DQM_PROP_TAGGED		 = 0x00002000;
-  static const uint32_t DQM_PROP_ACCUMULATE	 = 0x00004000;
-  static const uint32_t DQM_PROP_RESET		 = 0x00008000;
+  static const uint32_t DQM_PROP_REPORT_MASK     = 0x00000f00;
+  static const uint32_t DQM_PROP_REPORT_CLEAR    = 0x00000000;
+  static const uint32_t DQM_PROP_REPORT_ERROR    = 0x00000100;
+  static const uint32_t DQM_PROP_REPORT_WARN     = 0x00000200;
+  static const uint32_t DQM_PROP_REPORT_OTHER    = 0x00000400;
+  static const uint32_t DQM_PROP_REPORT_ALARM    = (DQM_PROP_REPORT_ERROR
+                                                    | DQM_PROP_REPORT_WARN
+                                                    | DQM_PROP_REPORT_OTHER);
 
-  static const uint32_t DQM_PROP_NEW		 = 0x00010000;
-  static const uint32_t DQM_PROP_RECEIVED	 = 0x00020000;
-  static const uint32_t DQM_PROP_LUMI		 = 0x00040000;
-  static const uint32_t DQM_PROP_DEAD		 = 0x00080000;
-  static const uint32_t DQM_PROP_STALE		 = 0x00100000;
+  static const uint32_t DQM_PROP_HAS_REFERENCE   = 0x00001000;
+  static const uint32_t DQM_PROP_TAGGED          = 0x00002000;
+  static const uint32_t DQM_PROP_ACCUMULATE      = 0x00004000;
+  static const uint32_t DQM_PROP_RESET           = 0x00008000;
+
+  static const uint32_t DQM_PROP_NEW             = 0x00010000;
+  static const uint32_t DQM_PROP_RECEIVED        = 0x00020000;
+  static const uint32_t DQM_PROP_LUMI            = 0x00040000;
+  static const uint32_t DQM_PROP_DEAD            = 0x00080000;
+  static const uint32_t DQM_PROP_STALE           = 0x00100000;
   static const uint32_t DQM_PROP_EFFICIENCY_PLOT = 0x00200000;
   static const uint32_t DQM_PROP_MARKTODELETE    = 0x01000000;
 
-  static const uint32_t DQM_MSG_HELLO		 = 0;
-  static const uint32_t DQM_MSG_UPDATE_ME	 = 1;
-  static const uint32_t DQM_MSG_LIST_OBJECTS	 = 2;
-  static const uint32_t DQM_MSG_GET_OBJECT	 = 3;
+  static const uint32_t DQM_MSG_HELLO            = 0;
+  static const uint32_t DQM_MSG_UPDATE_ME        = 1;
+  static const uint32_t DQM_MSG_LIST_OBJECTS     = 2;
+  static const uint32_t DQM_MSG_GET_OBJECT       = 3;
 
-  static const uint32_t DQM_REPLY_LIST_BEGIN	 = 101;
-  static const uint32_t DQM_REPLY_LIST_END	 = 102;
-  static const uint32_t DQM_REPLY_NONE		 = 103;
-  static const uint32_t DQM_REPLY_OBJECT	 = 104;
+  static const uint32_t DQM_REPLY_LIST_BEGIN     = 101;
+  static const uint32_t DQM_REPLY_LIST_END       = 102;
+  static const uint32_t DQM_REPLY_NONE           = 103;
+  static const uint32_t DQM_REPLY_OBJECT         = 104;
 
-  static const uint32_t MAX_PEER_WAITREQS	 = 128;
+  static const uint32_t MAX_PEER_WAITREQS        = 128;
 
   struct Peer;
   struct QValue;
@@ -87,115 +87,142 @@ public:
 
   struct QValue
   {
-    int			code;
-    float		qtresult;
-    std::string		message;
-    std::string		qtname;
-    std::string		algorithm;
+    int                 code;
+    float               qtresult;
+    std::string         message;
+    std::string         qtname;
+    std::string         algorithm;
   };
 
-  struct CoreObject
-  {
-    uint32_t		flags;
-    uint32_t 		tag;
-    uint64_t		version;
+  struct KeyObject {
+    KeyObject(std::string const* dir,
+              std::string name)
+      : KeyObject{dir, move(name), 0, 0, 0}
+    {}
+
+    KeyObject(std::string const* dir,
+              std::string name,
+              uint32_t const r,
+              uint32_t const l,
+              uint32_t const modId) :
+      run{r}, lumi{l}, streamId{}, moduleId{modId}, dirname{dir}, objname{move(name)}
+    {}
+    KeyObject() = default;
+
     uint32_t            run;
     uint32_t            lumi;
     uint32_t            streamId;
     uint32_t            moduleId;
-    const std::string	*dirname;
-    std::string		objname;
-    QReports		qreports;
+    const std::string   *dirname;
+    std::string         objname;
+
+    bool operator<(KeyObject const& b) const
+    {
+      if (run == b.run) {
+        if (lumi == b.lumi) {
+          if (streamId == b.streamId) {
+            if (moduleId == b.moduleId) {
+              if (*dirname == *b.dirname) {
+                return objname < b.objname;
+              }
+              return *dirname < *b.dirname;
+            }
+            return moduleId < b.moduleId;
+          }
+          return streamId < b.streamId;
+        }
+        return lumi < b.lumi;
+      }
+      return run < b.run;
+    }
+
   };
-  
+
+
+
+  struct CoreObject : KeyObject
+  {
+    uint32_t            flags;
+    uint32_t            tag;
+    uint64_t            version;
+    QReports            qreports;
+  };
+
   struct Object : CoreObject
   {
-    uint64_t		hash;
-    uint64_t		lastreq;
-    DataBlob		rawdata;
-    std::string		scalar;
-    std::string		qdata;
+    uint64_t            hash;
+    uint64_t            lastreq;
+    DataBlob            rawdata;
+    std::string         scalar;
+    std::string         qdata;
   };
 
   struct Bucket
   {
-    Bucket		*next;
-    DataBlob		data;
+    Bucket              *next;
+    DataBlob            data;
   };
 
   struct WaitObject
   {
-    lat::Time		time;
-    std::string		name;
-    std::string		info;
-    Peer		*peer;
+    lat::Time           time;
+    std::string         name;
+    std::string         info;
+    Peer                *peer;
   };
 
   struct AutoPeer;
   struct Peer
   {
-    std::string		peeraddr;
-    lat::Socket		*socket;
-    DataBlob		incoming;
-    Bucket		*sendq;
-    size_t		sendpos;
+    std::string         peeraddr;
+    lat::Socket         *socket;
+    DataBlob            incoming;
+    Bucket              *sendq;
+    size_t              sendpos;
 
-    unsigned		mask;
-    bool		source;
-    bool		update;
-    bool		updated;
-    size_t		updates;
-    size_t		waiting;
-    AutoPeer		*automatic;
+    unsigned            mask;
+    bool                source;
+    bool                update;
+    bool                updated;
+    size_t              updates;
+    size_t              waiting;
+    AutoPeer            *automatic;
   };
 
   struct AutoPeer
   {
-    Peer		*peer;
-    lat::Time		next;
-    std::string		host;
-    int			port;
-    bool		update;
+    Peer                *peer;
+    lat::Time           next;
+    std::string         host;
+    int                 port;
+    bool                update;
   };
 
   DQMNet(const std::string &appname = "");
   virtual ~DQMNet();
 
-  void			debug(bool doit);
-  void			delay(int delay);
-  void			startLocalServer(int port);
-  void			startLocalServer(const char *path);
-  void			staleObjectWaitLimit(lat::TimeSpan time);
-  void			updateToCollector(const std::string &host, int port);
-  void			listenToCollector(const std::string &host, int port);
-  void			shutdown();
-  void			lock();
-  void			unlock();
+  void                  debug(bool doit);
+  void                  delay(int delay);
+  void                  startLocalServer(int port);
+  void                  startLocalServer(const char *path);
+  void                  staleObjectWaitLimit(lat::TimeSpan time);
+  void                  updateToCollector(const std::string &host, int port);
+  void                  listenToCollector(const std::string &host, int port);
+  void                  shutdown();
+  void                  lock();
+  void                  unlock();
 
-  void			start();
-  void			run();
+  void                  start();
+  void                  run();
 
-  void			sendLocalChanges();
+  void                  sendLocalChanges();
 
   static bool setOrder(const CoreObject &a, const CoreObject &b)
-    {
-      if (a.run == b.run) {
-        if (a.lumi == b.lumi) {
-          if (a.streamId == b.streamId) {
-            if (a.moduleId == b.moduleId) {
-              if (*a.dirname == *b.dirname) {
-                return a.objname < b.objname;
-              }
-              return *a.dirname < *b.dirname;
-            }
-            return a.moduleId < b.moduleId;
-          }
-          return a.streamId < b.streamId;
-        }
-        return a.lumi < b.lumi;
-      }
-      return a.run < b.run;
-    }
+  {
+    KeyObject const& ka = a;
+    KeyObject const& kb = b;
+    return ka < kb;
+  }
 
   struct HashOp
   {
@@ -234,7 +261,7 @@ public:
         a ^= c; a -= dqmhashrot(c,4);  \
         b ^= a; b -= dqmhashrot(a,14); \
         c ^= b; c -= dqmhashrot(b,24); }
- 
+
       uint32_t a, b, c;
       a = b = c = 0xdeadbeef + (uint32_t) keylen;
       const auto *k = (const unsigned char *) key;
@@ -285,71 +312,71 @@ public:
 #     undef dqmhashfinal
     }
 
-  static void		packQualityData(std::string &into, const QReports &qr);
-  static void		unpackQualityData(QReports &qr, uint32_t &flags, const char *from);
+  static void           packQualityData(std::string &into, const QReports &qr);
+  static void           unpackQualityData(QReports &qr, uint32_t &flags, const char *from);
 
 protected:
-  std::ostream &	logme();
-  static void		copydata(Bucket *b, const void *data, size_t len);
-  virtual void		sendObjectToPeer(Bucket *msg, Object &o, bool data);
+  std::ostream &        logme();
+  static void           copydata(Bucket *b, const void *data, size_t len);
+  virtual void          sendObjectToPeer(Bucket *msg, Object &o, bool data);
 
-  virtual bool		shouldStop();
-  void			waitForData(Peer *p, const std::string &name, const std::string &info, Peer *owner);
-  virtual void		releaseFromWait(Bucket *msg, WaitObject &w, Object *o);
-  virtual bool		onMessage(Bucket *msg, Peer *p, unsigned char *data, size_t len);
+  virtual bool          shouldStop();
+  void                  waitForData(Peer *p, const std::string &name, const std::string &info, Peer *owner);
+  virtual void          releaseFromWait(Bucket *msg, WaitObject &w, Object *o);
+  virtual bool          onMessage(Bucket *msg, Peer *p, unsigned char *data, size_t len);
 
-  // bool			reconstructObject(Object &o);
-  // bool			reinstateObject(DQMStore *store, Object &o);
-  virtual Object *	findObject(Peer *p, const std::string &name, Peer **owner = nullptr) = 0;
-  virtual Object *	makeObject(Peer *p, const std::string &name) = 0;
-  virtual void		markObjectsDead(Peer *p) = 0;
-  virtual void		purgeDeadObjects(Peer *p) = 0;
+  // bool                       reconstructObject(Object &o);
+  // bool                       reinstateObject(DQMStore *store, Object &o);
+  virtual Object *      findObject(Peer *p, const std::string &name, Peer **owner = nullptr) = 0;
+  virtual Object *      makeObject(Peer *p, const std::string &name) = 0;
+  virtual void          markObjectsDead(Peer *p) = 0;
+  virtual void          purgeDeadObjects(Peer *p) = 0;
 
-  virtual Peer *	getPeer(lat::Socket *s) = 0;
-  virtual Peer *	createPeer(lat::Socket *s) = 0;
-  virtual void		removePeer(Peer *p, lat::Socket *s) = 0;
-  virtual void		sendObjectListToPeer(Bucket *msg, bool all, bool clear) = 0;
-  virtual void		sendObjectListToPeers(bool all) = 0;
+  virtual Peer *        getPeer(lat::Socket *s) = 0;
+  virtual Peer *        createPeer(lat::Socket *s) = 0;
+  virtual void          removePeer(Peer *p, lat::Socket *s) = 0;
+  virtual void          sendObjectListToPeer(Bucket *msg, bool all, bool clear) = 0;
+  virtual void          sendObjectListToPeers(bool all) = 0;
 
-  void			updateMask(Peer *p);
-  virtual void		updatePeerMasks() = 0;
-  static void		discard(Bucket *&b);
+  void                  updateMask(Peer *p);
+  virtual void          updatePeerMasks() = 0;
+  static void           discard(Bucket *&b);
 
-  bool			debug_;
-  pthread_mutex_t	lock_;
+  bool                  debug_;
+  pthread_mutex_t       lock_;
 
 private:
-  void			losePeer(const char *reason,
-				 Peer *peer,
-				 lat::IOSelectEvent *event,
-				 lat::Error *err = nullptr);
-  void			requestObjectData(Peer *p, const char *name, size_t len);
-  void			releaseFromWait(WaitList::iterator i, Object *o);
-  void			releaseWaiters(const std::string &name, Object *o);
+  void                  losePeer(const char *reason,
+                                 Peer *peer,
+                                 lat::IOSelectEvent *event,
+                                 lat::Error *err = nullptr);
+  void                  requestObjectData(Peer *p, const char *name, size_t len);
+  void                  releaseFromWait(WaitList::iterator i, Object *o);
+  void                  releaseWaiters(const std::string &name, Object *o);
 
-  bool			onPeerData(lat::IOSelectEvent *ev, Peer *p);
-  bool			onPeerConnect(lat::IOSelectEvent *ev);
-  bool			onLocalNotify(lat::IOSelectEvent *ev);
+  bool                  onPeerData(lat::IOSelectEvent *ev, Peer *p);
+  bool                  onPeerConnect(lat::IOSelectEvent *ev);
+  bool                  onLocalNotify(lat::IOSelectEvent *ev);
 
-  std::string		appname_;
-  int			pid_;
+  std::string           appname_;
+  int                   pid_;
 
-  lat::IOSelector	sel_;
-  lat::Socket		*server_;
-  lat::Pipe		wakeup_;
-  lat::Time		version_;
+  lat::IOSelector       sel_;
+  lat::Socket           *server_;
+  lat::Pipe             wakeup_;
+  lat::Time             version_;
 
-  AutoPeer		upstream_;
-  AutoPeer		downstream_;
-  WaitList		waiting_;
+  AutoPeer              upstream_;
+  AutoPeer              downstream_;
+  WaitList              waiting_;
 
-  pthread_t		communicate_;
-  sig_atomic_t		shutdown_;
+  pthread_t             communicate_;
+  sig_atomic_t          shutdown_;
 
-  int			delay_;
-  lat::TimeSpan		waitStale_;
-  lat::TimeSpan		waitMax_;
-  bool			flush_;
+  int                   delay_;
+  lat::TimeSpan         waitStale_;
+  lat::TimeSpan         waitMax_;
+  bool                  flush_;
 
 public:
   // copying is not available
@@ -376,7 +403,7 @@ public:
   DQMImplNet(const std::string &appname = "")
     : DQMNet(appname)
     {}
-  
+
   ~DQMImplNet() override
     = default;
 
@@ -396,31 +423,31 @@ protected:
       typename ObjectMap::iterator pos;
       typename PeerMap::iterator i, e;
       if (owner)
-	*owner = nullptr;
+        *owner = nullptr;
       if (p)
       {
-	auto *ip = static_cast<ImplPeer *>(p);
-	pos = ip->objs.find(proto);
-	if (pos == ip->objs.end())
-	  return nullptr;
-	else
-	{
-	  if (owner) *owner = ip;
-	  return const_cast<ObjType *>(&*pos);
-	}
+        auto *ip = static_cast<ImplPeer *>(p);
+        pos = ip->objs.find(proto);
+        if (pos == ip->objs.end())
+          return nullptr;
+        else
+        {
+          if (owner) *owner = ip;
+          return const_cast<ObjType *>(&*pos);
+        }
       }
       else
       {
-	for (i = peers_.begin(), e = peers_.end(); i != e; ++i)
-	{
-	  pos = i->second.objs.find(proto);
-	  if (pos != i->second.objs.end())
-	  {
-	    if (owner) *owner = &i->second;
-	    return const_cast<ObjType *>(&*pos);
-	  }
-	}
-	return nullptr;
+        for (i = peers_.begin(), e = peers_.end(); i != e; ++i)
+        {
+          pos = i->second.objs.find(proto);
+          if (pos != i->second.objs.end())
+          {
+            if (owner) *owner = &i->second;
+            return const_cast<ObjType *>(&*pos);
+          }
+        }
+        return nullptr;
       }
     }
 
@@ -453,15 +480,15 @@ protected:
   markObjectsDead(Peer *p) override
     {
       uint64_t minreq
-	= (lat::Time::current()
-	  - lat::TimeSpan(0, 0, 5 /* minutes */, 0, 0)).ns();
+        = (lat::Time::current()
+          - lat::TimeSpan(0, 0, 5 /* minutes */, 0, 0)).ns();
       auto *ip = static_cast<ImplPeer *>(p);
       typename ObjectMap::iterator i, e;
       for (i = ip->objs.begin(), e = ip->objs.end(); i != e; ++i)
       {
-	if (i->lastreq && i->lastreq < minreq)
-	  const_cast<ObjType &>(*i).lastreq = 0;
-	const_cast<ObjType &>(*i).flags |= DQM_PROP_DEAD;
+        if (i->lastreq && i->lastreq < minreq)
+          const_cast<ObjType &>(*i).lastreq = 0;
+        const_cast<ObjType &>(*i).flags |= DQM_PROP_DEAD;
       }
     }
 
@@ -473,10 +500,10 @@ protected:
       typename ObjectMap::iterator i, e;
       for (i = ip->objs.begin(), e = ip->objs.end(); i != e; )
       {
-	if (i->flags & DQM_PROP_DEAD)
-	  ip->objs.erase(i++);
-	else
-	  ++i;
+        if (i->flags & DQM_PROP_DEAD)
+          ip->objs.erase(i++);
+        else
+          ++i;
       }
     }
 
@@ -513,14 +540,14 @@ protected:
 
       typename ObjectMap::iterator i, e;
       for (i = ip->objs.begin(), e = ip->objs.end(); i != e; )
-	ip->objs.erase(i++);
-    
+        ip->objs.erase(i++);
+
       peers_.erase(s);
 
       // If we removed a peer with objects, our list of objects
       // has changed and we need to update downstream peers.
       if (needflush)
-	sendLocalChanges();
+        sendLocalChanges();
     }
 
   /// Send all objects to a peer and optionally mark sent objects old.
@@ -532,11 +559,11 @@ protected:
       size_t size = 0;
       size_t numobjs = 0;
       for (pi = peers_.begin(), pe = peers_.end(); pi != pe; ++pi)
-	for (oi = pi->second.objs.begin(), oe = pi->second.objs.end(); oi != oe; ++oi, ++numobjs)
-	  if (all || (oi->flags & DQM_PROP_NEW))
-	    size += 9*sizeof(uint32_t) + oi->dirname->size()
-		    + oi->objname.size() + 1 + oi->scalar.size() + oi->qdata.size()
-		    + (oi->lastreq > 0 ? oi->rawdata.size() : 0);
+        for (oi = pi->second.objs.begin(), oe = pi->second.objs.end(); oi != oe; ++oi, ++numobjs)
+          if (all || (oi->flags & DQM_PROP_NEW))
+            size += 9*sizeof(uint32_t) + oi->dirname->size()
+                    + oi->objname.size() + 1 + oi->scalar.size() + oi->qdata.size()
+                    + (oi->lastreq > 0 ? oi->rawdata.size() : 0);
 
       msg->data.reserve(msg->data.size() + size + 8 * sizeof(uint32_t));
 
@@ -549,14 +576,14 @@ protected:
       copydata(msg, &words[0], sizeof(words));
 
       for (pi = peers_.begin(), pe = peers_.end(); pi != pe; ++pi)
-	for (oi = pi->second.objs.begin(), oe = pi->second.objs.end(); oi != oe; ++oi)
-	  if (all || (oi->flags & DQM_PROP_NEW))
-	  {
-	    sendObjectToPeer(msg, const_cast<ObjType &>(*oi), oi->lastreq > 0);
-	    if (clear)
-	      const_cast<ObjType &>(*oi).flags &= ~DQM_PROP_NEW;
-	    ++nupdates;
-	  }
+        for (oi = pi->second.objs.begin(), oe = pi->second.objs.end(); oi != oe; ++oi)
+          if (all || (oi->flags & DQM_PROP_NEW))
+          {
+            sendObjectToPeer(msg, const_cast<ObjType &>(*oi), oi->lastreq > 0);
+            if (clear)
+              const_cast<ObjType &>(*oi).flags &= ~DQM_PROP_NEW;
+            ++nupdates;
+          }
 
       words[1] = DQM_REPLY_LIST_END;
       words[2] = nupdates;
@@ -570,29 +597,29 @@ protected:
       typename ObjectMap::iterator oi, oe;
       for (i = peers_.begin(), e = peers_.end(); i != e; ++i)
       {
-	ImplPeer &p = i->second;
-	if (! p.update)
-	  continue;
+        ImplPeer &p = i->second;
+        if (! p.update)
+          continue;
 
-	if (debug_)
-	  logme()
-	    << "DEBUG: notifying " << p.peeraddr << std::endl;
+        if (debug_)
+          logme()
+            << "DEBUG: notifying " << p.peeraddr << std::endl;
 
-	Bucket msg;
+        Bucket msg;
         msg.next = nullptr;
-	sendObjectListToPeer(&msg, !p.updated || all, true);
+        sendObjectListToPeer(&msg, !p.updated || all, true);
 
-	if (! msg.data.empty())
-	{
-	  Bucket **prev = &p.sendq;
-	  while (*prev)
-	    prev = &(*prev)->next;
+        if (! msg.data.empty())
+        {
+          Bucket **prev = &p.sendq;
+          while (*prev)
+            prev = &(*prev)->next;
 
-	  *prev = new Bucket;
-	  (*prev)->next = nullptr;
-	  (*prev)->data.swap(msg.data);
-	}
-	p.updated = true;
+          *prev = new Bucket;
+          (*prev)->next = nullptr;
+          (*prev)->data.swap(msg.data);
+        }
+        p.updated = true;
       }
     }
 
@@ -601,25 +628,25 @@ protected:
     {
       typename PeerMap::iterator i, e;
       for (i = peers_.begin(), e = peers_.end(); i != e; )
-	updateMask(&(i++)->second);
+        updateMask(&(i++)->second);
     }
 
 protected:
-  PeerMap		peers_;
+  PeerMap               peers_;
 };
-  
+
 
 class DQMBasicNet : public DQMImplNet<DQMNet::Object>
 {
 public:
   DQMBasicNet(const std::string &appname = "");
 
-  void			reserveLocalSpace(uint32_t size);
-  void			updateLocalObject(Object &o);
-  bool			removeLocalExcept(const std::set<std::string> &known);
+  void                  reserveLocalSpace(uint32_t size);
+  void                  updateLocalObject(Object &o);
+  bool                  removeLocalExcept(const std::set<std::string> &known);
 
 private:
-  ImplPeer		*local_;
+  ImplPeer              *local_;
 };
 
 

--- a/DQMServices/Core/interface/DQMNet.h
+++ b/DQMServices/Core/interface/DQMNet.h
@@ -95,16 +95,11 @@ public:
   };
 
   struct KeyObject {
-    KeyObject(std::string const* dir,
-              std::string name)
-      : KeyObject{dir, move(name), 0, 0, 0}
-    {}
-
-    KeyObject(std::string const* dir,
-              std::string name,
-              uint32_t const r,
+    KeyObject(uint32_t const r,
               uint32_t const l,
-              uint32_t const modId) :
+              uint32_t const modId,
+              std::string const* dir,
+              std::string name) :
       run{r}, lumi{l}, streamId{}, moduleId{modId}, dirname{dir}, objname{move(name)}
     {}
     KeyObject() = default;

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -46,302 +46,192 @@ class TH3F;
 class TProfile;
 class TProfile2D;
 class TNamed;
+class TString;
 
 
 /** Implements RegEx patterns which occur often in a high-performant
     mattern. For all other expressions, the full RegEx engine is used.
     Note: this class can only be used for lat::Regexp::Wildcard-like
     patterns.  */
-class fastmatch
-{
- private:
+class fastmatch {
   enum MatchingHeuristicEnum { UseFull, OneStarStart, OneStarEnd, TwoStar };
 
- public:
-  fastmatch (std::string  _fastString);
+public:
+  fastmatch(std::string fastString);
 
-  bool match (std::string const& s) const;
+  bool match(std::string const& s) const;
 
- private:
+private:
   // checks if two strings are equal, starting at the back of the strings
-  bool compare_strings_reverse (std::string const& pattern,
-                                std::string const& input) const;
+  bool compare_strings_reverse(std::string const& pattern,
+                               std::string const& input) const;
   // checks if two strings are equal, starting at the front of the strings
-  bool compare_strings (std::string const& pattern,
-                        std::string const& input) const;
+  bool compare_strings(std::string const& pattern,
+                       std::string const& input) const;
 
   std::unique_ptr<lat::Regexp> regexp_{nullptr};
   std::string fastString_;
   MatchingHeuristicEnum matching_;
 };
 
-class DQMStore
-{
- public:
-  enum SaveReferenceTag
-  {
+
+class DQMStore {
+public:
+  enum SaveReferenceTag {
     SaveWithoutReference,
     SaveWithReference,
     SaveWithReferenceForQTest
   };
-  enum OpenRunDirs
-  {
+  enum OpenRunDirs {
     KeepRunDirs,
     StripRunDirs
   };
 
-  class IBooker
-  {
-   public:
-    friend class DQMStore;
-
-    // for the supported syntaxes, see the declarations of DQMStore::bookString
-    template <typename... Args>
-    MonitorElement * bookString(Args && ... args) {
-      return owner_->bookString(std::forward<Args>(args)...);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::bookInt
-    template <typename... Args>
-    MonitorElement * bookInt(Args && ... args) {
-      return owner_->bookInt(std::forward<Args>(args)...);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::bookFloat
-    template <typename... Args>
-    MonitorElement * bookFloat(Args && ... args) {
-      return owner_->bookFloat(std::forward<Args>(args)...);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::book1D
-    template <typename... Args>
-    MonitorElement * book1D(Args && ... args) {
-      return owner_->book1D(std::forward<Args>(args)...);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::book1S
-    template <typename... Args>
-    MonitorElement * book1S(Args && ... args) {
-      return owner_->book1S(std::forward<Args>(args)...);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::book1DD
-    template <typename... Args>
-    MonitorElement * book1DD(Args && ... args) {
-      return owner_->book1DD(std::forward<Args>(args)...);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::book2D
-    template <typename... Args>
-    MonitorElement * book2D(Args && ... args) {
-      return owner_->book2D(std::forward<Args>(args)...);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::book2S
-    template <typename... Args>
-    MonitorElement * book2S(Args && ... args) {
-      return owner_->book2S(std::forward<Args>(args)...);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::book2DD
-    template <typename... Args>
-    MonitorElement * book2DD(Args && ... args) {
-      return owner_->book2DD(std::forward<Args>(args)...);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::book3D
-    template <typename... Args>
-    MonitorElement * book3D(Args && ... args) {
-      return owner_->book3D(std::forward<Args>(args)...);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::bookProfile
-    template <typename... Args>
-    MonitorElement * bookProfile(Args && ... args) {
-      return owner_->bookProfile(std::forward<Args>(args)...);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::bookProfile2D
-    template <typename... Args>
-    MonitorElement * bookProfile2D(Args && ... args) {
-      return owner_->bookProfile2D(std::forward<Args>(args)...);
-    }
-
-    void cd();
-    void cd(const std::string &dir);
-    void setCurrentFolder(const std::string &fullpath);
-    void goUp();
-    const std::string & pwd();
-    void tag(MonitorElement *, unsigned int);
-    void tagContents(const std::string &, unsigned int);
-
-   private:
-    explicit IBooker(DQMStore * store):owner_(nullptr) {
-      assert(store);
-      owner_ = store;
-    }
-
-   public:
-    IBooker() = delete;
-    IBooker(const IBooker&) = delete;
-
-   private:
-    // Embedded classes do not natively own a pointer to the embedding
-    // class. We therefore need to store a pointer to the main
-    // DQMStore instance (owner_).
-    DQMStore * owner_;
-  };  // IBooker
-
-  class ConcurrentBooker : public IBooker
-  {
+  class IBooker {
   public:
     friend class DQMStore;
 
-    // for the supported syntaxes, see the declarations of DQMStore::bookString
-    template <typename... Args>
-    ConcurrentMonitorElement bookString(Args && ... args) {
-      MonitorElement* me = IBooker::bookString(std::forward<Args>(args)...);
-      return ConcurrentMonitorElement(me);
+#define IBOOKER_FUNCTION_WITH_SUFFIX(funcname)                          \
+    template <typename... Args>                                         \
+    MonitorElement* book##funcname(Args&&... args)                      \
+    {                                                                   \
+      return owner_->book##funcname(std::forward<Args>(args)...);       \
     }
 
-    // for the supported syntaxes, see the declarations of DQMStore::bookInt
-    template <typename... Args>
-    ConcurrentMonitorElement bookInt(Args && ... args) {
-      MonitorElement* me = IBooker::bookInt(std::forward<Args>(args)...);
-      return ConcurrentMonitorElement(me);
-    }
+    // For the supported interface, see the DQMStore function that
+    // starts with "book" and ends with the supplied suffix.  For
+    // example, giving an argument of "String" generates a function
+    // that interfaces with DQMStore::bookString.
+    IBOOKER_FUNCTION_WITH_SUFFIX(String);
+    IBOOKER_FUNCTION_WITH_SUFFIX(Int);
+    IBOOKER_FUNCTION_WITH_SUFFIX(Float);
+    IBOOKER_FUNCTION_WITH_SUFFIX(1D);
+    IBOOKER_FUNCTION_WITH_SUFFIX(1S);
+    IBOOKER_FUNCTION_WITH_SUFFIX(1DD);
+    IBOOKER_FUNCTION_WITH_SUFFIX(2D);
+    IBOOKER_FUNCTION_WITH_SUFFIX(2S);
+    IBOOKER_FUNCTION_WITH_SUFFIX(2DD);
+    IBOOKER_FUNCTION_WITH_SUFFIX(3D);
+    IBOOKER_FUNCTION_WITH_SUFFIX(Profile);
+    IBOOKER_FUNCTION_WITH_SUFFIX(Profile2D);
 
-    // for the supported syntaxes, see the declarations of DQMStore::bookFloat
-    template <typename... Args>
-    ConcurrentMonitorElement bookFloat(Args && ... args) {
-      MonitorElement* me = IBooker::bookFloat(std::forward<Args>(args)...);
-      return ConcurrentMonitorElement(me);
-    }
+#undef IBOOKER_FUNCTION_WITH_SUFFIX
 
-    // for the supported syntaxes, see the declarations of DQMStore::book1D
-    template <typename... Args>
-    ConcurrentMonitorElement book1D(Args && ... args) {
-      MonitorElement* me = IBooker::book1D(std::forward<Args>(args)...);
-      return ConcurrentMonitorElement(me);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::book1S
-    template <typename... Args>
-    ConcurrentMonitorElement book1S(Args && ... args) {
-      MonitorElement* me = IBooker::book1S(std::forward<Args>(args)...);
-      return ConcurrentMonitorElement(me);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::book1DD
-    template <typename... Args>
-    ConcurrentMonitorElement book1DD(Args && ... args) {
-      MonitorElement* me = IBooker::book1DD(std::forward<Args>(args)...);
-      return ConcurrentMonitorElement(me);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::book2D
-    template <typename... Args>
-    ConcurrentMonitorElement book2D(Args && ... args) {
-      MonitorElement* me = IBooker::book2D(std::forward<Args>(args)...);
-      return ConcurrentMonitorElement(me);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::book2S
-    template <typename... Args>
-    ConcurrentMonitorElement book2S(Args && ... args) {
-      MonitorElement* me = IBooker::book2S(std::forward<Args>(args)...);
-      return ConcurrentMonitorElement(me);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::book2DD
-    template <typename... Args>
-    ConcurrentMonitorElement book2DD(Args && ... args) {
-      MonitorElement* me = IBooker::book2DD(std::forward<Args>(args)...);
-      return ConcurrentMonitorElement(me);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::book3D
-    template <typename... Args>
-    ConcurrentMonitorElement book3D(Args && ... args) {
-      MonitorElement* me = IBooker::book3D(std::forward<Args>(args)...);
-      return ConcurrentMonitorElement(me);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::bookProfile
-    template <typename... Args>
-    ConcurrentMonitorElement bookProfile(Args && ... args) {
-      MonitorElement* me = IBooker::bookProfile(std::forward<Args>(args)...);
-      return ConcurrentMonitorElement(me);
-    }
-
-    // for the supported syntaxes, see the declarations of DQMStore::bookProfile2D
-    template <typename... Args>
-    ConcurrentMonitorElement bookProfile2D(Args && ... args) {
-      MonitorElement* me = IBooker::bookProfile2D(std::forward<Args>(args)...);
-      return ConcurrentMonitorElement(me);
-    }
+    void cd();
+    void cd(std::string const& dir);
+    void setCurrentFolder(std::string const& fullpath);
+    void goUp();
+    std::string const& pwd();
+    void tag(MonitorElement*, unsigned int);
+    void tagContents(std::string const&, unsigned int);
 
   private:
-    explicit ConcurrentBooker(DQMStore * store) :
-      IBooker(store)
-    { }
+    explicit IBooker(DQMStore* store) noexcept : owner_{store}
+    {
+      assert(store);
+    }
+
+    IBooker() = delete;
+    IBooker(IBooker const&) = delete;
+
+    // Embedded classes do not natively own a pointer to the embedding
+    // class. We therefore need to store a pointer to the main
+    // DQMStore instance (owner_).
+    DQMStore* owner_;
+  };  // IBooker
+
+  class ConcurrentBooker : public IBooker {
+  public:
+    friend class DQMStore;
+
+#define CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(funcname)                 \
+    template <typename... Args>                                         \
+    ConcurrentMonitorElement book##funcname(Args&&... args)             \
+    {                                                                   \
+      MonitorElement* me = IBooker::book##funcname(std::forward<Args>(args)...); \
+      return ConcurrentMonitorElement(me);                              \
+    }
+
+    // For the supported interface, see the DQMStore function that
+    // starts with "book" and ends with the supplied suffix.  For
+    // example, giving an argument of "String" generates a function
+    // that interfaces with DQMStore::bookString.
+    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(String);
+    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(Int);
+    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(Float);
+    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(1D);
+    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(1S);
+    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(1DD);
+    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(2D);
+    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(2S);
+    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(2DD);
+    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(3D);
+    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(Profile);
+    CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX(Profile2D);
+
+#undef CONCURRENTBOOKER_FUNCTION_WITH_SUFFIX
+
+  private:
+    explicit ConcurrentBooker(DQMStore* store) noexcept :
+      IBooker{store}
+    {}
 
     ConcurrentBooker() = delete;
     ConcurrentBooker(ConcurrentBooker const&) = delete;
     ConcurrentBooker(ConcurrentBooker &&) = delete;
-    ConcurrentBooker& operator= (ConcurrentBooker const&) = delete;
-    ConcurrentBooker& operator= (ConcurrentBooker &&) = delete;
+    ConcurrentBooker& operator=(ConcurrentBooker const&) = delete;
+    ConcurrentBooker& operator=(ConcurrentBooker &&) = delete;
 
     ~ConcurrentBooker() = default;
   };
 
-  class IGetter
-  {
-   public:
+  class IGetter {
+  public:
     friend class DQMStore;
 
     // for the supported syntaxes, see the declarations of DQMStore::getContents
     template <typename... Args>
-    std::vector<MonitorElement *> getContents(Args && ... args) {
+    std::vector<MonitorElement*> getContents(Args&&... args)
+    {
       return owner_->getContents(std::forward<Args>(args)...);
     }
-    // for the supported syntaxes, see the declarations of DQMStore::removeElements
+
+    // for the supported syntaxes, see the declarations of DQMStore::removeElement
     template <typename... Args>
-      void removeElement(Args && ... args) {
+    void removeElement(Args&&... args)
+    {
       return owner_->removeElement(std::forward<Args>(args)...);
     }
 
-    std::vector<MonitorElement*>  getAllContents(const std::string &path,
+    std::vector<MonitorElement*> getAllContents(std::string const& path,
                                                  uint32_t runNumber = 0,
                                                  uint32_t lumi = 0);
-    MonitorElement * get(const std::string &path);
+    MonitorElement* get(std::string const& path);
 
     // same as get, throws an exception if histogram not found
-    MonitorElement * getElement(const std::string &path);
+    MonitorElement* getElement(std::string const& path);
 
     std::vector<std::string> getSubdirs();
     std::vector<std::string> getMEs();
-    bool containsAnyMonitorable(const std::string &path);
-    bool dirExists(const std::string &path);
+    bool containsAnyMonitorable(std::string const& path);
+    bool dirExists(std::string const& path);
     void cd();
-    void cd(const std::string &dir);
-    void setCurrentFolder(const std::string &fullpath);
+    void cd(std::string const& dir);
+    void setCurrentFolder(std::string const& fullpath);
 
-   private:
-    explicit IGetter(DQMStore * store):owner_(nullptr) {
+  private:
+    explicit IGetter(DQMStore* store) noexcept : owner_{store}
+    {
       assert(store);
-      owner_ = store;
     }
 
-   public:
     IGetter() = delete;
-    IGetter(const IGetter&) = delete;
+    IGetter(IGetter const&) = delete;
 
-   private:
     // Embedded classes do not natively own a pointer to the embedding
     // class. We therefore need to store a pointer to the main
     // DQMStore instance (owner_).
-    DQMStore * owner_;
+    DQMStore* owner_;
   }; //IGetter
 
   // Template function to be used inside each DQM Modules' lambda
@@ -352,7 +242,8 @@ class DQMStore
   // into the DQMStore via a public API. The central mutex is acquired
   // *before* invoking and automatically released upon returns.
   template <typename iFunc>
-  void bookTransaction(iFunc f, uint32_t run, uint32_t moduleId) {
+  void bookTransaction(iFunc f, uint32_t run, uint32_t moduleId)
+  {
     std::lock_guard<std::mutex> guard(book_mutex_);
     /* Set the run number and module id only if multithreading is enabled */
     if (enableMultiThread_) {
@@ -372,7 +263,8 @@ class DQMStore
   // Similar function used to book "global" histograms via the
   // ConcurrentMonitorElement interface.
   template <typename iFunc>
-  void bookConcurrentTransaction(iFunc f, uint32_t run) {
+  void bookConcurrentTransaction(iFunc f, uint32_t run)
+  {
     std::lock_guard<std::mutex> guard(book_mutex_);
     /* Set the run_ member only if enableMultiThread is enabled */
     if (enableMultiThread_) {
@@ -387,13 +279,14 @@ class DQMStore
     }
   }
 
-  // Signature needed in the harvesting where the booking is done
-  // in the endJob. No handles to the run there. Two arguments ensure
-  // the capability of booking and getting. The method relies on the
-  // initialization of run, stream and module ID to 0. The mutex
-  // is not needed.
+  // Signature needed in the harvesting where the booking is done in
+  // the endJob. No handles to the run there. Two arguments ensure the
+  // capability of booking and getting. The method relies on the
+  // initialization of run, stream and module ID to 0. The mutex is
+  // not needed.
   template <typename iFunc>
-  void meBookerGetter(iFunc f) {
+  void meBookerGetter(iFunc f)
+  {
     IBooker booker{this};
     IGetter getter{this};
     f(booker, getter);
@@ -401,340 +294,236 @@ class DQMStore
 
   //-------------------------------------------------------------------------
   // ---------------------- Constructors ------------------------------------
-  DQMStore(const edm::ParameterSet &pset, edm::ActivityRegistry&);
-  DQMStore(const edm::ParameterSet &pset);
+  DQMStore(edm::ParameterSet const& pset, edm::ActivityRegistry&);
+  DQMStore(edm::ParameterSet const& pset);
   ~DQMStore();
 
   //-------------------------------------------------------------------------
-  void                          setVerbose(unsigned level);
+  void setVerbose(unsigned level);
 
   // ---------------------- public navigation -------------------------------
-  const std::string &           pwd() const;
-  void                          cd();
-  void                          cd(const std::string &subdir);
-  void                          setCurrentFolder(const std::string &fullpath);
-  void                          goUp();
+  std::string const& pwd() const;
+  void cd();
+  void cd(std::string const& subdir);
+  void setCurrentFolder(std::string const& fullpath);
+  void goUp();
 
-  bool                          dirExists(const std::string &path) const;
+  bool dirExists(std::string const& path) const;
 
   //-------------------------------------------------------------------------
   // ---------------------- public ME booking -------------------------------
-
-  MonitorElement *              bookInt      (const char *name);
-  MonitorElement *              bookInt      (const std::string &name);
-
-  MonitorElement *              bookFloat    (const char *name);
-  MonitorElement *              bookFloat    (const std::string &name);
-
-  MonitorElement *              bookString   (const char *name,
-                                              const char *value);
-  MonitorElement *              bookString   (const std::string &name,
-                                              const std::string &value);
-
-  MonitorElement *              book1D       (const char *name,
-                                              const char *title,
-                                              int nchX, double lowX, double highX);
-  MonitorElement *              book1D       (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, double lowX, double highX);
-  MonitorElement *              book1D       (const char *name,
-                                              const char *title,
-                                              int nchX, const float *xbinsize);
-  MonitorElement *              book1D       (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, const float *xbinsize);
-  MonitorElement *              book1D       (const char *name, TH1F *h);
-  MonitorElement *              book1D       (const std::string &name, TH1F *h);
-
-  MonitorElement *              book1S       (const char *name,
-                                              const char *title,
-                                              int nchX, double lowX, double highX);
-  MonitorElement *              book1S       (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, double lowX, double highX);
-  MonitorElement *              book1S       (const char *name,
-                                              const char *title,
-                                              int nchX, const float *xbinsize);
-  MonitorElement *              book1S       (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, const float *xbinsize);
-  MonitorElement *              book1S       (const char *name, TH1S *h);
-  MonitorElement *              book1S       (const std::string &name, TH1S *h);
-
-  MonitorElement *              book1DD       (const char *name,
-                                               const char *title,
-                                               int nchX, double lowX, double highX);
-  MonitorElement *              book1DD       (const std::string &name,
-                                               const std::string &title,
-                                               int nchX, double lowX, double highX);
-  MonitorElement *              book1DD       (const char *name,
-                                               const char *title,
-                                               int nchX, const float *xbinsize);
-  MonitorElement *              book1DD       (const std::string &name,
-                                               const std::string &title,
-                                               int nchX, const float *xbinsize);
-  MonitorElement *              book1DD       (const char *name, TH1D *h);
-  MonitorElement *              book1DD       (const std::string &name, TH1D *h);
-
-  MonitorElement *              book2D       (const char *name,
-                                              const char *title,
-                                              int nchX, double lowX, double highX,
-                                              int nchY, double lowY, double highY);
-  MonitorElement *              book2D       (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, double lowX, double highX,
-                                              int nchY, double lowY, double highY);
-  MonitorElement *              book2D       (const char *name,
-                                              const char *title,
-                                              int nchX, const float *xbinsize,
-                                              int nchY, const float *ybinsize);
-  MonitorElement *              book2D       (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, const float *xbinsize,
-                                              int nchY, const float *ybinsize);
-  MonitorElement *              book2D       (const char *name, TH2F *h);
-  MonitorElement *              book2D       (const std::string &name, TH2F *h);
-
-  MonitorElement *              book2S       (const char *name,
-                                              const char *title,
-                                              int nchX, double lowX, double highX,
-                                              int nchY, double lowY, double highY);
-  MonitorElement *              book2S       (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, double lowX, double highX,
-                                              int nchY, double lowY, double highY);
-  MonitorElement *              book2S       (const char *name,
-                                              const char *title,
-                                              int nchX, const float *xbinsize,
-                                              int nchY, const float *ybinsize);
-  MonitorElement *              book2S       (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, const float *xbinsize,
-                                              int nchY, const float *ybinsize);
-  MonitorElement *              book2S       (const char *name, TH2S *h);
-  MonitorElement *              book2S       (const std::string &name, TH2S *h);
-
-  MonitorElement *              book2DD       (const char *name,
-                                               const char *title,
-                                               int nchX, double lowX, double highX,
-                                               int nchY, double lowY, double highY);
-  MonitorElement *              book2DD       (const std::string &name,
-                                               const std::string &title,
-                                               int nchX, double lowX, double highX,
-                                               int nchY, double lowY, double highY);
-  MonitorElement *              book2DD       (const char *name,
-                                               const char *title,
-                                               int nchX, const float *xbinsize,
-                                               int nchY, const float *ybinsize);
-  MonitorElement *              book2DD       (const std::string &name,
-                                               const std::string &title,
-                                               int nchX, const float *xbinsize,
-                                               int nchY, const float *ybinsize);
-  MonitorElement *              book2DD       (const char *name, TH2D *h);
-  MonitorElement *              book2DD       (const std::string &name, TH2D *h);
-
-  MonitorElement *              book3D       (const char *name,
-                                              const char *title,
-                                              int nchX, double lowX, double highX,
-                                              int nchY, double lowY, double highY,
-                                              int nchZ, double lowZ, double highZ);
-  MonitorElement *              book3D       (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, double lowX, double highX,
-                                              int nchY, double lowY, double highY,
-                                              int nchZ, double lowZ, double highZ);
-  MonitorElement *              book3D       (const char *name, TH3F *h);
-  MonitorElement *              book3D       (const std::string &name, TH3F *h);
-
-  MonitorElement *              bookProfile  (const char *name,
-                                              const char *title,
-                                              int nchX, double lowX, double highX,
-                                              int nchY, double lowY, double highY,
-                                              const char *option = "s");
-  MonitorElement *              bookProfile  (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, double lowX, double highX,
-                                              int nchY, double lowY, double highY,
-                                              const char *option = "s");
-  MonitorElement *              bookProfile  (const char *name,
-                                              const char *title,
-                                              int nchX, double lowX, double highX,
-                                              double lowY, double highY,
-                                              const char *option = "s");
-  MonitorElement *              bookProfile  (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, double lowX, double highX,
-                                              double lowY, double highY,
-                                              const char *option = "s");
-  MonitorElement *              bookProfile  (const char *name,
-                                              const char *title,
-                                              int nchX, const double *xbinsize,
-                                              int nchY, double lowY, double highY,
-                                              const char *option = "s");
-  MonitorElement *              bookProfile  (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, const double *xbinsize,
-                                              int nchY, double lowY, double highY,
-                                              const char *option = "s");
-  MonitorElement *              bookProfile  (const char *name,
-                                              const char *title,
-                                              int nchX, const double *xbinsize,
-                                              double lowY, double highY,
-                                              const char *option = "s");
-  MonitorElement *              bookProfile  (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, const double *xbinsize,
-                                              double lowY, double highY,
-                                              const char *option = "s");
-  MonitorElement *              bookProfile  (const char *name, TProfile *h);
-  MonitorElement *              bookProfile  (const std::string &name, TProfile *h);
-
-  MonitorElement *              bookProfile2D(const char *name,
-                                              const char *title,
-                                              int nchX, double lowX, double highX,
-                                              int nchY, double lowY, double highY,
-                                              int nchZ, double lowZ, double highZ,
-                                              const char *option = "s");
-  MonitorElement *              bookProfile2D(const std::string &name,
-                                              const std::string &title,
-                                              int nchX, double lowX, double highX,
-                                              int nchY, double lowY, double highY,
-                                              int nchZ, double lowZ, double highZ,
-                                              const char *option = "s");
-  MonitorElement *              bookProfile2D(const char *name,
-                                              const char *title,
-                                              int nchX, double lowX, double highX,
-                                              int nchY, double lowY, double highY,
-                                              double lowZ, double highZ,
-                                              const char *option = "s");
-  MonitorElement *              bookProfile2D(const std::string &name,
-                                              const std::string &title,
-                                              int nchX, double lowX, double highX,
-                                              int nchY, double lowY, double highY,
-                                              double lowZ, double highZ,
-                                              const char *option = "s");
-  MonitorElement *              bookProfile2D(const char *name, TProfile2D *h);
-  MonitorElement *              bookProfile2D(const std::string &name, TProfile2D *h);
+  MonitorElement* bookInt(TString const& name);
+  MonitorElement* bookFloat(TString const& name);
+  MonitorElement* bookString(TString const& name,
+                             TString const& value);
+  MonitorElement* book1D(TString const& name,
+                         TString const& title,
+                         int nchX, double lowX, double highX);
+  MonitorElement* book1D(TString const& name,
+                         TString const& title,
+                         int nchX, float const* xbinsize);
+  MonitorElement* book1D(TString const& name, TH1F* h);
+  MonitorElement* book1S(TString const& name,
+                         TString const& title,
+                         int nchX, double lowX, double highX);
+  MonitorElement* book1S(TString const& name,
+                         TString const& title,
+                         int nchX, float const* xbinsize);
+  MonitorElement* book1S(TString const& name, TH1S* h);
+  MonitorElement* book1DD(TString const& name,
+                          TString const& title,
+                          int nchX, double lowX, double highX);
+  MonitorElement* book1DD(TString const& name,
+                          TString const& title,
+                          int nchX, float const* xbinsize);
+  MonitorElement* book1DD(TString const& name, TH1D* h);
+  MonitorElement* book2D(TString const& name,
+                         TString const& title,
+                         int nchX, double lowX, double highX,
+                         int nchY, double lowY, double highY);
+  MonitorElement* book2D(TString const& name,
+                         TString const& title,
+                         int nchX, float const* xbinsize,
+                         int nchY, float const* ybinsize);
+  MonitorElement* book2D(TString const& name, TH2F* h);
+  MonitorElement* book2S(TString const& name,
+                         TString const& title,
+                         int nchX, double lowX, double highX,
+                         int nchY, double lowY, double highY);
+  MonitorElement* book2S(TString const& name,
+                         TString const& title,
+                         int nchX, float const* xbinsize,
+                         int nchY, float const* ybinsize);
+  MonitorElement* book2S(TString const& name, TH2S* h);
+  MonitorElement* book2DD(TString const& name,
+                          TString const& title,
+                          int nchX, double lowX, double highX,
+                          int nchY, double lowY, double highY);
+  MonitorElement* book2DD(TString const& name,
+                          TString const& title,
+                          int nchX, float const* xbinsize,
+                          int nchY, float const* ybinsize);
+  MonitorElement* book2DD(TString const& name, TH2D* h);
+  MonitorElement* book3D(TString const& name,
+                         TString const& title,
+                         int nchX, double lowX, double highX,
+                         int nchY, double lowY, double highY,
+                         int nchZ, double lowZ, double highZ);
+  MonitorElement* book3D(TString const& name, TH3F* h);
+  MonitorElement* bookProfile(TString const& name,
+                              TString const& title,
+                              int nchX, double lowX, double highX,
+                              int nchY, double lowY, double highY,
+                              char const* option = "s");
+  MonitorElement* bookProfile(TString const& name,
+                              TString const& title,
+                              int nchX, double lowX, double highX,
+                              double lowY, double highY,
+                              char const* option = "s");
+  MonitorElement* bookProfile(TString const& name,
+                              TString const& title,
+                              int nchX, double const* xbinsize,
+                              int nchY, double lowY, double highY,
+                              char const* option = "s");
+  MonitorElement* bookProfile(TString const& name,
+                              TString const& title,
+                              int nchX, double const* xbinsize,
+                              double lowY, double highY,
+                              char const* option = "s");
+  MonitorElement* bookProfile(TString const& name, TProfile* h);
+  MonitorElement* bookProfile2D(TString const& name,
+                                TString const& title,
+                                int nchX, double lowX, double highX,
+                                int nchY, double lowY, double highY,
+                                int nchZ, double lowZ, double highZ,
+                                char const* option = "s");
+  MonitorElement* bookProfile2D(TString const& name,
+                                TString const& title,
+                                int nchX, double lowX, double highX,
+                                int nchY, double lowY, double highY,
+                                double lowZ, double highZ,
+                                char const* option = "s");
+  MonitorElement* bookProfile2D(TString const& name, TProfile2D* h);
 
   //-------------------------------------------------------------------------
   // ---------------------- public tagging ----------------------------------
-  void                          tag(MonitorElement *me, unsigned int myTag);
-  void                          tag(const std::string &path, unsigned int myTag);
-  void                          tagContents(const std::string &path, unsigned int myTag);
-  void                          tagAllContents(const std::string &path, unsigned int myTag);
+  void tag(MonitorElement* me, unsigned int myTag);
+  void tag(std::string const& path, unsigned int myTag);
+  void tagContents(std::string const& path, unsigned int myTag);
+  void tagAllContents(std::string const& path, unsigned int myTag);
 
   //-------------------------------------------------------------------------
   // ---------------------- public ME getters -------------------------------
-  std::vector<std::string>      getSubdirs() const;
-  std::vector<std::string>      getMEs() const;
-  bool                          containsAnyMonitorable(const std::string &path) const;
+  std::vector<std::string> getSubdirs() const;
+  std::vector<std::string> getMEs() const;
+  bool containsAnyMonitorable(std::string const& path) const;
 
-  MonitorElement *              get(const std::string &path) const;
-  std::vector<MonitorElement *> get(unsigned int tag) const;
-  std::vector<MonitorElement *> getContents(const std::string &path) const;
-  std::vector<MonitorElement *> getContents(const std::string &path, unsigned int tag) const;
-  void                          getContents(std::vector<std::string> &into, bool showContents = true) const;
+  MonitorElement* get(std::string const& path) const;
+  std::vector<MonitorElement*> get(unsigned int tag) const;
+  std::vector<MonitorElement*> getContents(std::string const& path) const;
+  std::vector<MonitorElement*> getContents(std::string const& path, unsigned int tag) const;
+  void getContents(std::vector<std::string> &into, bool showContents = true) const;
 
   // ---------------------- softReset methods -------------------------------
-  void                          softReset(MonitorElement *me);
-  void                          disableSoftReset(MonitorElement *me);
+  void softReset(MonitorElement* me);
+  void disableSoftReset(MonitorElement* me);
 
   // ---------------------- Public deleting ---------------------------------
-  void                          rmdir(const std::string &fullpath);
-  void                          removeContents();
-  void                          removeContents(const std::string &dir);
-  void                          removeElement(const std::string &name);
-  void                          removeElement(const std::string &dir, const std::string &name, bool warning = true);
+  void rmdir(std::string const& fullpath);
+  void removeContents();
+  void removeContents(std::string const& dir);
+  void removeElement(std::string const& name);
+  void removeElement(std::string const& dir, std::string const& name, bool warning = true);
 
   // ------------------------------------------------------------------------
   // ---------------------- public I/O --------------------------------------
-  void                          save(const std::string &filename,
-                                     const std::string &path = "",
-                                     const std::string &pattern = "",
-                                     const std::string &rewrite = "",
-                                     const uint32_t run = 0,
-                                     const uint32_t lumi = 0,
-                                     SaveReferenceTag ref = SaveWithReference,
-                                     int minStatus = dqm::qstatus::STATUS_OK,
-                                     const std::string &fileupdate = "RECREATE");
-  void                          savePB(const std::string &filename,
-                                       const std::string &path = "",
-                                       const uint32_t run = 0,
-                                       const uint32_t lumi = 0);
-  bool                          open(const std::string &filename,
-                                     bool overwrite = false,
-                                     const std::string &path ="",
-                                     const std::string &prepend = "",
-                                     OpenRunDirs stripdirs = KeepRunDirs,
-                                     bool fileMustExist = true);
-  bool                          load(const std::string &filename,
-                                     OpenRunDirs stripdirs = StripRunDirs,
-                                     bool fileMustExist = true);
-  bool                          mtEnabled() { return enableMultiThread_; };
+  void save(std::string const& filename,
+            std::string const& path = "",
+            std::string const& pattern = "",
+            std::string const& rewrite = "",
+            uint32_t run = 0,
+            uint32_t lumi = 0,
+            SaveReferenceTag ref = SaveWithReference,
+            int minStatus = dqm::qstatus::STATUS_OK,
+            std::string const& fileupdate = "RECREATE");
+  void savePB(std::string const& filename,
+              std::string const& path = "",
+              uint32_t run = 0,
+              uint32_t lumi = 0);
+  bool open(std::string const& filename,
+            bool overwrite = false,
+            std::string const& path ="",
+            std::string const& prepend = "",
+            OpenRunDirs stripdirs = KeepRunDirs,
+            bool fileMustExist = true);
+  bool load(std::string const& filename,
+            OpenRunDirs stripdirs = StripRunDirs,
+            bool fileMustExist = true);
+  bool mtEnabled() { return enableMultiThread_; };
 
 
- public:
+public:
   // -------------------------------------------------------------------------
   // ---------------------- Public print methods -----------------------------
-  void                          showDirStructure() const;
+  void showDirStructure() const;
 
   // ---------------------- Public check options -----------------------------
-  bool                          isCollate() const;
+  bool isCollate() const;
 
   // -------------------------------------------------------------------------
   // ---------------------- Quality Test methods -----------------------------
-  QCriterion *                  getQCriterion(const std::string &qtname) const;
-  QCriterion *                  createQTest(const std::string &algoname, const std::string &qtname);
-  void                          useQTest(const std::string &dir, const std::string &qtname);
-  int                           useQTestByMatch(const std::string &pattern, const std::string &qtname);
-  void                          runQTests();
-  int                           getStatus(const std::string &path = "") const;
-  void                          scaleElements();
+  QCriterion* getQCriterion(std::string const& qtname) const;
+  QCriterion* createQTest(std::string const& algoname, std::string const& qtname);
+  void useQTest(std::string const& dir, std::string const& qtname);
+  int useQTestByMatch(std::string const& pattern, std::string const& qtname);
+  void runQTests();
+  int getStatus(std::string const& path = "") const;
+  void scaleElements();
 
- private:
+private:
   // ---------------- Navigation -----------------------
-  bool                          cdInto(const std::string &path) const;
+  bool cdInto(std::string const& path) const;
 
   // ------------------- Reference ME -------------------------------
-  bool                          isCollateME(MonitorElement *me) const;
+  bool isCollateME(MonitorElement* me) const;
 
   // ------------------- Private "getters" ------------------------------
-  bool                          readFilePB(const std::string &filename,
-                                           bool overwrite = false,
-                                           const std::string &path ="",
-                                           const std::string &prepend = "",
-                                           OpenRunDirs stripdirs = StripRunDirs,
-                                           bool fileMustExist = true);
-  bool                          readFile(const std::string &filename,
-                                         bool overwrite = false,
-                                         const std::string &path ="",
-                                         const std::string &prepend = "",
-                                         OpenRunDirs stripdirs = StripRunDirs,
-                                         bool fileMustExist = true);
-  void                          makeDirectory(const std::string &path);
-  unsigned int                  readDirectory(TFile *file,
-                                              bool overwrite,
-                                              const std::string &path,
-                                              const std::string &prepend,
-                                              const std::string &curdir,
-                                              OpenRunDirs stripdirs);
+  bool readFilePB(std::string const& filename,
+                  bool overwrite = false,
+                  std::string const& path ="",
+                  std::string const& prepend = "",
+                  OpenRunDirs stripdirs = StripRunDirs,
+                  bool fileMustExist = true);
+  bool readFile(std::string const& filename,
+                bool overwrite = false,
+                std::string const& path ="",
+                std::string const& prepend = "",
+                OpenRunDirs stripdirs = StripRunDirs,
+                bool fileMustExist = true);
+  void makeDirectory(std::string const& path);
+  unsigned int readDirectory(TFile* file,
+                             bool overwrite,
+                             std::string const& path,
+                             std::string const& prepend,
+                             std::string const& curdir,
+                             OpenRunDirs stripdirs);
 
-  MonitorElement *              findObject(const uint32_t run,
-                                           const uint32_t lumi,
-                                           const uint32_t moduleId,
-                                           const std::string &dir,
-                                           const std::string &name) const;
+  MonitorElement* findObject(uint32_t run,
+                             uint32_t lumi,
+                             uint32_t moduleId,
+                             std::string const& dir,
+                             std::string const& name) const;
 
-  void                          get_info(const  dqmstorepb::ROOTFilePB_Histo &,
-                                         std::string & dirname,
-                                         std::string & objname,
-                                         TObject ** obj);
+  void get_info(dqmstorepb::ROOTFilePB_Histo const&,
+                std::string& dirname,
+                std::string& objname,
+                TObject** obj);
 
- public:
-  std::vector<MonitorElement*>  getAllContents(const std::string &path,
-                                               uint32_t runNumber = 0,
-                                               uint32_t lumi = 0) const;
-  std::vector<MonitorElement*>  getMatchingContents(const std::string &pattern, lat::Regexp::Syntax syntaxType = lat::Regexp::Wildcard) const;
+public:
+  std::vector<MonitorElement*> getAllContents(std::string const& path,
+                                              uint32_t runNumber = 0,
+                                              uint32_t lumi = 0) const;
+  std::vector<MonitorElement*> getMatchingContents(std::string const& pattern, lat::Regexp::Syntax syntaxType = lat::Regexp::Wildcard) const;
 
   // lumisection based histograms manipulations
   void cloneLumiHistograms(uint32_t run, uint32_t lumi, uint32_t moduleId);
@@ -742,56 +531,56 @@ class DQMStore
 
   void deleteUnusedLumiHistograms(uint32_t run, uint32_t lumi);
 
- private:
+private:
   // ---------------- Miscellaneous -----------------------------
-  void        initializeFrom(const edm::ParameterSet&);
-  void        reset();
-  void        forceReset();
-  void        postGlobalBeginLumi(const edm::GlobalContext&);
+  void initializeFrom(const edm::ParameterSet&);
+  void reset();
+  void forceReset();
+  void postGlobalBeginLumi(const edm::GlobalContext&);
 
-  bool        extract(TObject *obj, const std::string &dir, bool overwrite, bool collateHistograms);
-  TObject *   extractNextObject(TBufferFile&) const;
+  bool extract(TObject* obj, std::string const& dir, bool overwrite, bool collateHistograms);
+  TObject* extractNextObject(TBufferFile&) const;
 
   // ---------------------- Booking ------------------------------------
-  MonitorElement *              initialise(MonitorElement *me, const std::string &path);
-  MonitorElement *              book_(const std::string &dir,
-                                      const std::string &name,
-                                      const char *context);
+  MonitorElement* initialise(MonitorElement* me, std::string const& path);
+  MonitorElement* book_(std::string const& dir,
+                        std::string const& name,
+                        char const* context);
   template <class HISTO, class COLLATE>
-  MonitorElement *              book_(const std::string &dir,
-                                      const std::string &name,
-                                      const char *context,
-                                      int kind, HISTO *h, COLLATE collate);
+  MonitorElement* book_(std::string const& dir,
+                        std::string const& name,
+                        char const* context,
+                        int kind, HISTO* h, COLLATE collate);
 
-  MonitorElement *              bookInt_(const std::string &dir, const std::string &name);
-  MonitorElement *              bookFloat_(const std::string &dir, const std::string &name);
-  MonitorElement *              bookString_(const std::string &dir, const std::string &name, const std::string &value);
-  MonitorElement *              book1D_(const std::string &dir, const std::string &name, TH1F *h);
-  MonitorElement *              book1S_(const std::string &dir, const std::string &name, TH1S *h);
-  MonitorElement *              book1DD_(const std::string &dir, const std::string &name, TH1D *h);
-  MonitorElement *              book2D_(const std::string &dir, const std::string &name, TH2F *h);
-  MonitorElement *              book2S_(const std::string &dir, const std::string &name, TH2S *h);
-  MonitorElement *              book2DD_(const std::string &dir, const std::string &name, TH2D *h);
-  MonitorElement *              book3D_(const std::string &dir, const std::string &name, TH3F *h);
-  MonitorElement *              bookProfile_(const std::string &dir, const std::string &name, TProfile *h);
-  MonitorElement *              bookProfile2D_(const std::string &dir, const std::string &name, TProfile2D *h);
+  MonitorElement* bookInt_(std::string const& dir, std::string const& name);
+  MonitorElement* bookFloat_(std::string const& dir, std::string const& name);
+  MonitorElement* bookString_(std::string const& dir, std::string const& name, std::string const& value);
+  MonitorElement* book1D_(std::string const& dir, std::string const& name, TH1F* h);
+  MonitorElement* book1S_(std::string const& dir, std::string const& name, TH1S* h);
+  MonitorElement* book1DD_(std::string const& dir, std::string const& name, TH1D* h);
+  MonitorElement* book2D_(std::string const& dir, std::string const& name, TH2F* h);
+  MonitorElement* book2S_(std::string const& dir, std::string const& name, TH2S* h);
+  MonitorElement* book2DD_(std::string const& dir, std::string const& name, TH2D* h);
+  MonitorElement* book3D_(std::string const& dir, std::string const& name, TH3F* h);
+  MonitorElement* bookProfile_(std::string const& dir, std::string const& name, TProfile* h);
+  MonitorElement* bookProfile2D_(std::string const& dir, std::string const& name, TProfile2D* h);
 
-  static bool                   checkBinningMatches(MonitorElement *me, TH1 *h, unsigned verbose);
+  static bool checkBinningMatches(MonitorElement* me, TH1* h, unsigned verbose);
 
-  static void                   collate1D(MonitorElement *me, TH1F *h, unsigned verbose);
-  static void                   collate1S(MonitorElement *me, TH1S *h, unsigned verbose);
-  static void                   collate1DD(MonitorElement *me, TH1D *h, unsigned verbose);
-  static void                   collate2D(MonitorElement *me, TH2F *h, unsigned verbose);
-  static void                   collate2S(MonitorElement *me, TH2S *h, unsigned verbose);
-  static void                   collate2DD(MonitorElement *me, TH2D *h, unsigned verbose);
-  static void                   collate3D(MonitorElement *me, TH3F *h, unsigned verbose);
-  static void                   collateProfile(MonitorElement *me, TProfile *h, unsigned verbose);
-  static void                   collateProfile2D(MonitorElement *me, TProfile2D *h, unsigned verbose);
+  static void collate1D(MonitorElement* me, TH1F* h, unsigned verbose);
+  static void collate1S(MonitorElement* me, TH1S* h, unsigned verbose);
+  static void collate1DD(MonitorElement* me, TH1D* h, unsigned verbose);
+  static void collate2D(MonitorElement* me, TH2F* h, unsigned verbose);
+  static void collate2S(MonitorElement* me, TH2S* h, unsigned verbose);
+  static void collate2DD(MonitorElement* me, TH2D* h, unsigned verbose);
+  static void collate3D(MonitorElement* me, TH3F* h, unsigned verbose);
+  static void collateProfile(MonitorElement* me, TProfile* h, unsigned verbose);
+  static void collateProfile2D(MonitorElement* me, TProfile2D* h, unsigned verbose);
 
   // --- Operations on MEs that are normally reset at end of monitoring cycle ---
-  void                          setAccumulate(MonitorElement *me, bool flag);
+  void setAccumulate(MonitorElement* me, bool flag);
 
-  void print_trace(const std::string &dir, const std::string &name);
+  void print_trace(std::string const& dir, std::string const& name);
 
   // ----------------------- Unavailable ---------------------------------------
   DQMStore(DQMStore const&) = delete;
@@ -799,59 +588,55 @@ class DQMStore
 
   //-------------------------------------------------------------------------------
   //-------------------------------------------------------------------------------
-  using QTestSpec             = std::pair<fastmatch *, QCriterion *>;
-  using QTestSpecs            = std::list<QTestSpec>;
-  using KeyObject             = DQMNet::KeyObject;
-  using MEMap                 = std::map<KeyObject, MonitorElement>;
-  using QCMap                 = std::map<std::string, QCriterion *>;
-  using QAMap                 = std::map<std::string, QCriterion *(*)(const std::string &)>;
+  using QTestSpec = std::pair<fastmatch*, QCriterion*>;
+  using QTestSpecs = std::list<QTestSpec>;
+  using KeyObject = DQMNet::KeyObject;
+  using MEMap = std::map<KeyObject, MonitorElement>;
+  using QCMap = std::map<std::string, QCriterion*>;
+  using QAMap = std::map<std::string, QCriterion* (*)(std::string const&)>;
 
 
   // ------------------------ private I/O helpers ------------------------------
-  void                          saveMonitorElementToPB(
-                                    MonitorElement const& me,
-                                    dqmstorepb::ROOTFilePB & file);
-  void                          saveMonitorElementRangeToPB(
-                                    std::string const& dir,
-                                    unsigned int run,
-                                    MEMap::const_iterator begin,
-                                    MEMap::const_iterator end,
-                                    dqmstorepb::ROOTFilePB & file,
-                                    unsigned int & counter);
-  void                          saveMonitorElementToROOT(
-                                    MonitorElement const& me,
-                                    TFile & file);
-  void                          saveMonitorElementRangeToROOT(
-                                    std::string const& dir,
-                                    std::string const& refpath,
-                                    SaveReferenceTag ref,
-                                    int minStatus,
-                                    unsigned int run,
-                                    MEMap::const_iterator begin,
-                                    MEMap::const_iterator end,
-                                    TFile & file,
-                                    unsigned int & counter);
+  void saveMonitorElementToPB(MonitorElement const& me,
+                              dqmstorepb::ROOTFilePB& file);
+  void saveMonitorElementRangeToPB(std::string const& dir,
+                                   unsigned int run,
+                                   MEMap::const_iterator begin,
+                                   MEMap::const_iterator end,
+                                   dqmstorepb::ROOTFilePB& file,
+                                   unsigned int& counter);
+  void saveMonitorElementToROOT(MonitorElement const& me,
+                                TFile& file);
+  void saveMonitorElementRangeToROOT(std::string const& dir,
+                                     std::string const& refpath,
+                                     SaveReferenceTag ref,
+                                     int minStatus,
+                                     unsigned int run,
+                                     MEMap::const_iterator begin,
+                                     MEMap::const_iterator end,
+                                     TFile& file,
+                                     unsigned int& counter);
 
-  unsigned                      verbose_{1};
-  unsigned                      verboseQT_{1};
-  bool                          reset_{false};
-  double                        scaleFlag_;
-  bool                          collateHistograms_{false};
-  bool                          enableMultiThread_{false};
-  bool                          LSbasedMode_;
-  bool                          forceResetOnBeginLumi_{false};
-  std::string                   readSelectedDirectory_{};
-  uint32_t                      run_{};
-  uint32_t                      moduleId_{};
+  unsigned verbose_{1};
+  unsigned verboseQT_{1};
+  bool reset_{false};
+  double scaleFlag_;
+  bool collateHistograms_{false};
+  bool enableMultiThread_{false};
+  bool LSbasedMode_;
+  bool forceResetOnBeginLumi_{false};
+  std::string readSelectedDirectory_{};
+  uint32_t run_{};
+  uint32_t moduleId_{};
   std::unique_ptr<std::ostream> stream_{nullptr};
 
-  std::string                   pwd_{};
-  MEMap                         data_;
-  std::set<std::string>         dirs_;
+  std::string pwd_{};
+  MEMap data_;
+  std::set<std::string> dirs_;
 
-  QCMap                         qtests_;
-  QAMap                         qalgos_;
-  QTestSpecs                    qtestspecs_;
+  QCMap qtests_;
+  QAMap qalgos_;
+  QTestSpecs qtestspecs_;
 
   std::mutex book_mutex_;
 

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -719,11 +719,11 @@ class DQMStore
                                               const std::string &curdir,
                                               OpenRunDirs stripdirs);
 
-  MonitorElement *              findObject(const std::string &dir,
-                                           const std::string &name,
-                                           const uint32_t run = 0,
-                                           const uint32_t lumi = 0,
-                                           const uint32_t moduleId = 0) const;
+  MonitorElement *              findObject(const uint32_t run,
+                                           const uint32_t lumi,
+                                           const uint32_t moduleId,
+                                           const std::string &dir,
+                                           const std::string &name) const;
 
   void                          get_info(const  dqmstorepb::ROOTFilePB_Histo &,
                                          std::string & dirname,

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -801,7 +801,8 @@ class DQMStore
   //-------------------------------------------------------------------------------
   using QTestSpec             = std::pair<fastmatch *, QCriterion *>;
   using QTestSpecs            = std::list<QTestSpec>;
-  using MEMap                 = std::set<MonitorElement>;
+  using KeyObject             = DQMNet::KeyObject;
+  using MEMap                 = std::map<KeyObject, MonitorElement>;
   using QCMap                 = std::map<std::string, QCriterion *>;
   using QAMap                 = std::map<std::string, QCriterion *(*)(const std::string &)>;
 

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -204,8 +204,8 @@ public:
     }
 
     std::vector<MonitorElement*> getAllContents(std::string const& path,
-                                                 uint32_t runNumber = 0,
-                                                 uint32_t lumi = 0);
+                                                uint32_t runNumber = 0,
+                                                uint32_t lumi = 0);
     MonitorElement* get(std::string const& path);
 
     // same as get, throws an exception if histogram not found

--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -30,9 +30,6 @@
 
 class QCriterion;
 
-// tag for a special constructor, see below
-struct MonitorElementNoCloneTag {};
-
 /** The base class for all MonitorElements (ME) */
 class MonitorElement
 {
@@ -85,9 +82,8 @@ public:
   MonitorElement();
   MonitorElement(const std::string *path, const std::string &name);
   MonitorElement(const std::string *path, const std::string &name, uint32_t run, uint32_t moduleId);
-  MonitorElement(const MonitorElement &, MonitorElementNoCloneTag);
   MonitorElement(const MonitorElement &);
-  MonitorElement(MonitorElement &&);
+  MonitorElement(MonitorElement &&) = default;
   MonitorElement &operator=(const MonitorElement &) = delete;
   MonitorElement &operator=(MonitorElement &&) = delete;
   ~MonitorElement();

--- a/DQMServices/Core/src/DQMService.cc
+++ b/DQMServices/Core/src/DQMService.cc
@@ -36,7 +36,7 @@ DQMService::DQMService(const edm::ParameterSet &pset, edm::ActivityRegistry &ar)
   ar.watchPostEvent(this, &DQMService::flush);
   ar.watchPostStreamEndLumi(this, &DQMService::flush);
 
-  std::string host = pset.getUntrackedParameter<std::string>("collectorHost", ""); 
+  std::string host = pset.getUntrackedParameter<std::string>("collectorHost", "");
   int port = pset.getUntrackedParameter<int>("collectorPort", 9090);
   bool verbose = pset.getUntrackedParameter<bool>("verbose", false);
   publishFrequency_ = pset.getUntrackedParameter<double>("publishFrequency", publishFrequency_);
@@ -56,17 +56,17 @@ DQMService::DQMService(const edm::ParameterSet &pset, edm::ActivityRegistry &ar)
     {
       filter_ = new lat::Regexp(filter);
       if (! filter_->valid())
-	throw cms::Exception("DQMService")
-	  << "Invalid 'filter' parameter value '" << filter << "':"
-	  << " bad regular expression syntax at character "
-	  << filter_->errorOffset() << ": " << filter_->errorMessage();
+        throw cms::Exception("DQMService")
+          << "Invalid 'filter' parameter value '" << filter << "':"
+          << " bad regular expression syntax at character "
+          << filter_->errorOffset() << ": " << filter_->errorMessage();
       filter_->study();
     }
     catch (lat::Error &e)
     {
       throw cms::Exception("DQMService")
-	<< "Invalid regular expression 'filter' parameter value '"
-	<< filter << "': " << e.explain();
+        << "Invalid regular expression 'filter' parameter value '"
+        << filter << "': " << e.explain();
     }
   }
 }
@@ -103,7 +103,7 @@ void DQMService::flushStandalone()
     net_->reserveLocalSpace(store_->data_.size());
     for (i = store_->data_.begin(), e = store_->data_.end(); i != e; ++i)
     {
-      const MonitorElement &me = *i;
+      const MonitorElement &me = i->second;
       fullpath.clear();
       fullpath += *me.data_.dirname;
       if (! me.data_.dirname->empty())
@@ -111,11 +111,11 @@ void DQMService::flushStandalone()
       fullpath += me.data_.objname;
 
       if (filter_ && filter_->search(fullpath) < 0)
-	continue;
+        continue;
 
       seen.insert(fullpath);
       if (! me.wasUpdated())
-	continue;
+        continue;
 
       o.lastreq = 0;
       o.hash = DQMNet::dqmhash(fullpath.c_str(), fullpath.size());
@@ -134,22 +134,22 @@ void DQMService::flushStandalone()
       case MonitorElement::DQM_KIND_INT:
       case MonitorElement::DQM_KIND_REAL:
       case MonitorElement::DQM_KIND_STRING:
-	me.packScalarData(o.scalar, "");
-	break;
+        me.packScalarData(o.scalar, "");
+        break;
 
       default:
-	{
+        {
           TBufferFile buffer(TBufferFile::kWrite);
           buffer.WriteObject(me.object_);
           if (me.reference_)
-	    buffer.WriteObject(me.reference_);
+            buffer.WriteObject(me.reference_);
           else
-	    buffer.WriteObjectAny(nullptr, nullptr);
+            buffer.WriteObjectAny(nullptr, nullptr);
           o.rawdata.resize(buffer.Length());
           memcpy(&o.rawdata[0], buffer.Buffer(), buffer.Length());
           DQMNet::packQualityData(o.qdata, me.data_.qreports);
-	  break;
-	}
+          break;
+        }
       }
 
       // Update.

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -138,7 +138,7 @@ namespace {
 } // anonymous namespace
 
 /////////////////////////////////////////////////////////////
-fastmatch::fastmatch (std::string fastString) :
+fastmatch::fastmatch(std::string fastString) :
   fastString_{move(fastString)}, matching_{UseFull}
 {
   try {
@@ -299,12 +299,14 @@ DQMStore::IGetter::getAllContents(std::string const& path,
   return owner_->getAllContents(path, run, lumi);
 }
 
-MonitorElement*  DQMStore::IGetter::get(std::string const& path)
+MonitorElement*
+DQMStore::IGetter::get(std::string const& path)
 {
   return owner_->get(path);
 }
 
-MonitorElement*  DQMStore::IGetter::getElement(std::string const& path)
+MonitorElement*
+DQMStore::IGetter::getElement(std::string const& path)
 {
   MonitorElement* ptr = this->get(path);
   if (ptr == nullptr) {
@@ -319,37 +321,44 @@ MonitorElement*  DQMStore::IGetter::getElement(std::string const& path)
   return ptr;
 }
 
-std::vector<std::string> DQMStore::IGetter::getSubdirs()
+std::vector<std::string>
+DQMStore::IGetter::getSubdirs()
 {
   return owner_->getSubdirs();
 }
 
-std::vector<std::string> DQMStore::IGetter::getMEs()
+std::vector<std::string>
+DQMStore::IGetter::getMEs()
 {
   return owner_->getMEs();
 }
 
-bool DQMStore::IGetter::containsAnyMonitorable(std::string const& path)
+bool
+DQMStore::IGetter::containsAnyMonitorable(std::string const& path)
 {
   return owner_->containsAnyMonitorable(path);
 }
 
-bool DQMStore::IGetter::dirExists(std::string const& path)
+bool
+DQMStore::IGetter::dirExists(std::string const& path)
 {
   return owner_->dirExists(path);
 }
 
-void DQMStore::IGetter::cd()
+void
+DQMStore::IGetter::cd()
 {
   owner_->cd();
 }
 
-void DQMStore::IGetter::cd(std::string const& dir)
+void
+DQMStore::IGetter::cd(std::string const& dir)
 {
   owner_->cd(dir);
 }
 
-void DQMStore::IGetter::setCurrentFolder(std::string const& fullpath)
+void
+DQMStore::IGetter::setCurrentFolder(std::string const& fullpath)
 {
   owner_->setCurrentFolder(fullpath);
 }
@@ -622,6 +631,265 @@ DQMStore::dirExists(std::string const& path) const
   return dirs_.count(path) > 0;
 }
 
+//====================================================
+// Global-histogram booking
+MonitorElement*
+DQMStore::bookInt(char_string const& name)
+{
+  return bookInt(0, 0, pwd_, name);
+}
+
+MonitorElement*
+DQMStore::bookFloat(char_string const& name)
+{
+  return bookFloat(0, 0, pwd_, name);
+}
+
+MonitorElement*
+DQMStore::bookString(char_string const& name,
+                     char_string const& value)
+{
+  return bookString(0, 0, pwd_, name, value);
+}
+
+MonitorElement*
+DQMStore::book1D(char_string const& name,
+                 char_string const& title,
+                 int const nchX, double const lowX, double const highX)
+{
+  return book1D(0, 0,  pwd_, name, title, nchX, lowX, highX);
+}
+
+MonitorElement*
+DQMStore::book1D(char_string const& name,
+                 char_string const& title,
+                 int const nchX, float const* xbinsize)
+{
+  return book1D(0, 0,  pwd_, name, title, nchX, xbinsize);
+}
+
+MonitorElement*
+DQMStore::book1D(char_string const& name, TH1F* h)
+{
+  return book1D(0, 0, pwd_, name, h);
+}
+
+MonitorElement*
+DQMStore::book1S(char_string const& name,
+                 char_string const& title,
+                 int const nchX, double const lowX, double const highX)
+{
+  return book1S(0, 0,  pwd_, name, title, nchX, lowX, highX);
+}
+
+MonitorElement*
+DQMStore::book1S(char_string const& name,
+                 char_string const& title,
+                 int const nchX, float const* xbinsize)
+{
+  return book1S(0, 0,  pwd_, name, title, nchX, xbinsize);
+}
+
+MonitorElement*
+DQMStore::book1S(char_string const& name, TH1S* h)
+{
+  return book1S(0, 0, pwd_, name, h);
+}
+
+MonitorElement*
+DQMStore::book1DD(char_string const& name,
+                  char_string const& title,
+                  int const nchX, double const lowX, double const highX)
+{
+  return book1DD(0, 0,  pwd_, name, title, nchX, lowX, highX);
+}
+
+MonitorElement*
+DQMStore::book1DD(char_string const& name,
+                  char_string const& title,
+                  int const nchX, float const* xbinsize)
+{
+  return book1DD(0, 0,  pwd_, name, title, nchX, xbinsize);
+}
+
+MonitorElement*
+DQMStore::book1DD(char_string const& name, TH1D* h)
+{
+  return book1DD(0, 0, pwd_, name, h);
+}
+
+MonitorElement*
+DQMStore::book2D(char_string const& name,
+                 char_string const& title,
+                 int const nchX, double const lowX, double const highX,
+                 int const nchY, double const lowY, double const highY)
+{
+  return book2D(0, 0,  pwd_, name, title, nchX, lowX, highX, nchY, lowY, highY);
+}
+
+MonitorElement*
+DQMStore::book2D(char_string const& name,
+                 char_string const& title,
+                 int const nchX, float const* xbinsize,
+                 int const nchY, float const* ybinsize)
+{
+  return book2D(0, 0,  pwd_, name, title, nchX, xbinsize, nchY, ybinsize);
+}
+
+MonitorElement*
+DQMStore::book2D(char_string const& name, TH2F* h)
+{
+  return book2D(0, 0, pwd_, name, h);
+}
+
+MonitorElement*
+DQMStore::book2S(char_string const& name,
+                 char_string const& title,
+                 int const nchX, double const lowX, double const highX,
+                 int const nchY, double const lowY, double const highY)
+{
+  return book2S(0, 0,  pwd_, name, title, nchX, lowX, highX, nchY, lowY, highY);
+}
+
+MonitorElement*
+DQMStore::book2S(char_string const& name,
+                 char_string const& title,
+                 int const nchX, float const* xbinsize,
+                 int const nchY, float const* ybinsize)
+{
+  return book2S(0, 0,  pwd_, name, title, nchX, xbinsize, nchY, ybinsize);
+}
+
+MonitorElement*
+DQMStore::book2S(char_string const& name, TH2S* h)
+{
+  return book2S(0, 0, pwd_, name, h);
+}
+
+MonitorElement*
+DQMStore::book2DD(char_string const& name,
+                  char_string const& title,
+                  int const nchX, double const lowX, double const highX,
+                  int const nchY, double const lowY, double const highY)
+{
+  return book2DD(0, 0,  pwd_, name, title, nchX, lowX, highX, nchY, lowY, highY);
+}
+
+MonitorElement*
+DQMStore::book2DD(char_string const& name,
+                  char_string const& title,
+                  int const nchX, float const* xbinsize,
+                  int const nchY, float const* ybinsize)
+{
+  return book2DD(0, 0,  pwd_, name, title, nchX, xbinsize, nchY, ybinsize);
+}
+
+MonitorElement*
+DQMStore::book2DD(char_string const& name, TH2D* h)
+{
+  return book2DD(0, 0, pwd_, name, h);
+}
+
+MonitorElement*
+DQMStore::book3D(char_string const& name,
+                 char_string const& title,
+                 int const nchX, double const lowX, double const highX,
+                 int const nchY, double const lowY, double const highY,
+                 int const nchZ, double const lowZ, double const highZ)
+{
+  return book3D(0, 0,  pwd_, name, title,
+                nchX, lowX, highX,
+                nchY, lowY, highY,
+                nchZ, lowZ, highZ);
+}
+
+MonitorElement*
+DQMStore::book3D(char_string const& name, TH3F* h)
+{
+  return book3D(0, 0, pwd_, name, h);
+}
+
+MonitorElement*
+DQMStore::bookProfile(char_string const& name,
+                      char_string const& title,
+                      int const nchX, double const lowX, double const highX,
+                      int const nchY, double const lowY, double const highY,
+                      char const* option)
+{
+  return bookProfile(0, 0,  pwd_, name, title, nchX, lowX, highX, nchY, lowY, highY, option);
+}
+
+MonitorElement*
+DQMStore::bookProfile(char_string const& name,
+                      char_string const& title,
+                      int const nchX, double const lowX, double const highX,
+                      double const lowY, double const highY,
+                      char const* option)
+{
+  return bookProfile(0, 0,  pwd_, name, title, nchX, lowX, highX, lowY, highY, option);
+}
+
+MonitorElement*
+DQMStore::bookProfile(char_string const& name,
+                      char_string const& title,
+                      int const nchX, double const* xbinsize,
+                      int const nchY, double const lowY, double const highY,
+                      char const* option)
+{
+  return bookProfile(0, 0,  pwd_, name, title, nchX, xbinsize, nchY, lowY, highY, option);
+}
+
+MonitorElement*
+DQMStore::bookProfile(char_string const& name,
+                      char_string const& title,
+                      int const nchX, double const* xbinsize,
+                      double const lowY, double const highY,
+                      char const* option)
+{
+  return bookProfile(0, 0,  pwd_, name, title, nchX, xbinsize, lowY, highY, option);
+}
+
+MonitorElement*
+DQMStore::bookProfile(char_string const& name, TProfile* h)
+{
+  return bookProfile(0, 0, pwd_, name, h);
+}
+
+MonitorElement*
+DQMStore::bookProfile2D(char_string const& name,
+                        char_string const& title,
+                        int const nchX, double const lowX, double const highX,
+                        int const nchY, double const lowY, double const highY,
+                        int const nchZ, double const lowZ, double const highZ,
+                        char const* option)
+{
+  return bookProfile2D(0, 0,  pwd_, name, title,
+                       nchX, lowX, highX,
+                       nchY, lowY, highY,
+                       nchZ, lowZ, highZ, option);
+}
+
+MonitorElement*
+DQMStore::bookProfile2D(char_string const& name,
+                        char_string const& title,
+                        int const nchX, double const lowX, double const highX,
+                        int const nchY, double const lowY, double const highY,
+                        double const lowZ, double const highZ,
+                        char const* option)
+{
+  return bookProfile2D(0, 0,  pwd_, name, title,
+                       nchX, lowX, highX,
+                       nchY, lowY, highY,
+                       lowZ, highZ, option);
+}
+
+MonitorElement*
+DQMStore::bookProfile2D(char_string const& name, TProfile2D* h)
+{
+  return bookProfile2D(0, 0, pwd_, name, h);
+}
+
+
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
@@ -747,15 +1015,14 @@ DQMStore::bookInt_(uint32_t const run, uint32_t const moduleId, std::string cons
     }
   }
 
-  return book_(run, moduleId, dir, name, "bookInt")
-    ->initialise(MonitorElement::DQM_KIND_INT);
+  return book_(run, moduleId, dir, name, "bookInt")->initialise(MonitorElement::DQM_KIND_INT);
 }
 
 /// Book int.
 MonitorElement*
-DQMStore::bookInt(uint32_t const run, uint32_t const moduleId, TString const& name)
+DQMStore::bookInt(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name)
 {
-  return bookInt_(run, moduleId, pwd_, name.Data());
+  return bookInt_(run, moduleId, dir, name);
 }
 
 // -------------------------------------------------------------------
@@ -772,18 +1039,17 @@ DQMStore::bookFloat_(uint32_t const run,
       return me;
     }
   }
-
-  return book_(run, moduleId, dir, name, "bookFloat")
-    ->initialise(MonitorElement::DQM_KIND_REAL);
+  return book_(run, moduleId, dir, name, "bookFloat")->initialise(MonitorElement::DQM_KIND_REAL);
 }
 
 /// Book float.
 MonitorElement*
 DQMStore::bookFloat(uint32_t const run,
                     uint32_t const moduleId,
-                    TString const& name)
+                    std::string const& dir,
+                    char_string const& name)
 {
-  return bookFloat_(run, moduleId, pwd_, name.Data());
+  return bookFloat_(run, moduleId, dir, name);
 }
 
 // -------------------------------------------------------------------
@@ -799,16 +1065,14 @@ DQMStore::bookString_(uint32_t const run,
     if (MonitorElement* me = findObject(run, 0, moduleId, dir, name))
       return me;
   }
-
-  return book_(run, moduleId, dir, name, "bookString")
-    ->initialise(MonitorElement::DQM_KIND_STRING, value);
+  return book_(run, moduleId, dir, name, "bookString")->initialise(MonitorElement::DQM_KIND_STRING, value);
 }
 
 /// Book string.
 MonitorElement*
-DQMStore::bookString(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& value)
+DQMStore::bookString(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& value)
 {
-  return bookString_(run, moduleId, pwd_, name.Data(), value.Data());
+  return bookString_(run, moduleId, dir, name, value);
 }
 
 // -------------------------------------------------------------------
@@ -835,55 +1099,70 @@ DQMStore::book1DD_(uint32_t const run, uint32_t const moduleId, std::string cons
 
 /// Book 1D histogram.
 MonitorElement*
-DQMStore::book1D(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::book1D(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                  int const nchX, double const lowX, double const highX)
 {
-  return book1D_(run, moduleId, pwd_, name.Data(), new TH1F(name, title, nchX, lowX, highX));
+  return book1D_(run, moduleId, dir, name, new TH1F(name, title, nchX, lowX, highX));
 }
 
 /// Book 1S histogram.
 MonitorElement*
-DQMStore::book1S(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::book1S(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                  int const nchX, double const lowX, double const highX)
 {
-  return book1S_(run, moduleId, pwd_, name.Data(), new TH1S(name, title, nchX, lowX, highX));
+  return book1S_(run, moduleId, dir, name, new TH1S(name, title, nchX, lowX, highX));
 }
 
 /// Book 1S histogram.
 MonitorElement*
-DQMStore::book1DD(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::book1S(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
+                 int const nchX, const float* xbinsize)
+{
+  return book1S_(run, moduleId, dir, name, new TH1S(name, title, nchX, xbinsize));
+}
+
+/// Book 1DD histogram.
+MonitorElement*
+DQMStore::book1DD(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                   int const nchX, double const lowX, double const highX)
 {
-  return book1DD_(run, moduleId, pwd_, name.Data(), new TH1D(name, title, nchX, lowX, highX));
+  return book1DD_(run, moduleId, dir, name, new TH1D(name, title, nchX, lowX, highX));
+}
+
+MonitorElement*
+DQMStore::book1DD(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
+                  int const nchX, float const* xbinsize)
+{
+  return book1DD_(run, moduleId, dir, name, new TH1D(name, title, nchX, xbinsize));
 }
 
 /// Book 1D variable bin histogram.
 MonitorElement*
-DQMStore::book1D(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::book1D(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                  int const nchX, const float* xbinsize)
 {
-  return book1D_(run, moduleId, pwd_, name.Data(), new TH1F(name, title, nchX, xbinsize));
+  return book1D_(run, moduleId, dir, name, new TH1F(name, title, nchX, xbinsize));
 }
 
 /// Book 1D histogram by cloning an existing histogram.
 MonitorElement*
-DQMStore::book1D(uint32_t const run, uint32_t const moduleId, TString const& name, TH1F* source)
+DQMStore::book1D(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, TH1F* source)
 {
-  return book1D_(run, moduleId, pwd_, name.Data(), static_cast<TH1F*>(source->Clone(name)));
+  return book1D_(run, moduleId, dir, name, static_cast<TH1F*>(source->Clone(name)));
 }
 
 /// Book 1S histogram by cloning an existing histogram.
 MonitorElement*
-DQMStore::book1S(uint32_t const run, uint32_t const moduleId, TString const& name, TH1S* source)
+DQMStore::book1S(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, TH1S* source)
 {
-  return book1S_(run, moduleId, pwd_, name.Data(), static_cast<TH1S*>(source->Clone(name)));
+  return book1S_(run, moduleId, dir, name, static_cast<TH1S*>(source->Clone(name)));
 }
 
 /// Book 1D double histogram by cloning an existing histogram.
 MonitorElement*
-DQMStore::book1DD(uint32_t const run, uint32_t const moduleId, TString const& name, TH1D* source)
+DQMStore::book1DD(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, TH1D* source)
 {
-  return book1DD_(run, moduleId, pwd_, name.Data(), static_cast<TH1D*>(source->Clone(name)));
+  return book1DD_(run, moduleId, dir, name, static_cast<TH1D*>(source->Clone(name)));
 }
 
 // -------------------------------------------------------------------
@@ -910,74 +1189,83 @@ DQMStore::book2DD_(uint32_t const run, uint32_t const moduleId, std::string cons
 
 /// Book 2D histogram.
 MonitorElement*
-DQMStore::book2D(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::book2D(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                  int const nchX, double const lowX, double const highX,
                  int const nchY, double const lowY, double const highY)
 {
-  return book2D_(run, moduleId, pwd_, name.Data(), new TH2F(name, title,
-                                                            nchX, lowX, highX,
-                                                            nchY, lowY, highY));
+  return book2D_(run, moduleId, dir, name, new TH2F(name, title,
+                                                    nchX, lowX, highX,
+                                                    nchY, lowY, highY));
 }
 
 /// Book 2S histogram.
 MonitorElement*
-DQMStore::book2S(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::book2S(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                  int const nchX, double const lowX, double const highX,
                  int const nchY, double const lowY, double const highY)
 {
-  return book2S_(run, moduleId, pwd_, name.Data(), new TH2S(name, title,
-                                                            nchX, lowX, highX,
-                                                            nchY, lowY, highY));
+  return book2S_(run, moduleId, dir, name, new TH2S(name, title,
+                                                    nchX, lowX, highX,
+                                                    nchY, lowY, highY));
 }
 
-/// Book 2S histogram.
+/// Book 2D histogram.
 MonitorElement*
-DQMStore::book2DD(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::book2DD(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                   int const nchX, double const lowX, double const highX,
                   int const nchY, double const lowY, double const highY)
 {
-  return book2DD_(run, moduleId, pwd_, name.Data(), new TH2D(name, title,
-                                                             nchX, lowX, highX,
-                                                             nchY, lowY, highY));
+  return book2DD_(run, moduleId, dir, name, new TH2D(name, title,
+                                                     nchX, lowX, highX,
+                                                     nchY, lowY, highY));
 }
 
 /// Book 2D variable bin histogram.
 MonitorElement*
-DQMStore::book2D(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::book2DD(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
+                  int const nchX, float const* xbinsize, int const nchY, float const* ybinsize)
+{
+  return book2DD_(run, moduleId, dir, name, new TH2D(name, title,
+                                                     nchX, xbinsize, nchY, ybinsize));
+}
+
+/// Book 2D variable bin histogram.
+MonitorElement*
+DQMStore::book2D(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                  int const nchX, const float* xbinsize, int const nchY, const float* ybinsize)
 {
-  return book2D_(run, moduleId, pwd_, name.Data(), new TH2F(name, title,
-                                                            nchX, xbinsize, nchY, ybinsize));
+  return book2D_(run, moduleId, dir, name, new TH2F(name, title,
+                                                    nchX, xbinsize, nchY, ybinsize));
 }
 
 /// Book 2S variable bin histogram.
 MonitorElement*
-DQMStore::book2S(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::book2S(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                  int const nchX, const float* xbinsize, int const nchY, const float* ybinsize)
 {
-  return book2S_(run, moduleId, pwd_, name.Data(), new TH2S(name, title,
-                                                            nchX, xbinsize, nchY, ybinsize));
+  return book2S_(run, moduleId, dir, name, new TH2S(name, title,
+                                                    nchX, xbinsize, nchY, ybinsize));
 }
 
 /// Book 2D histogram by cloning an existing histogram.
 MonitorElement*
-DQMStore::book2D(uint32_t const run, uint32_t const moduleId, TString const& name, TH2F* source)
+DQMStore::book2D(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, TH2F* source)
 {
-  return book2D_(run, moduleId, pwd_, name.Data(), static_cast<TH2F*>(source->Clone(name)));
+  return book2D_(run, moduleId, dir, name, static_cast<TH2F*>(source->Clone(name)));
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement*
-DQMStore::book2S(uint32_t const run, uint32_t const moduleId, TString const& name, TH2S* source)
+DQMStore::book2S(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, TH2S* source)
 {
-  return book2S_(run, moduleId, pwd_, name.Data(), static_cast<TH2S*>(source->Clone(name)));
+  return book2S_(run, moduleId, dir, name, static_cast<TH2S*>(source->Clone(name)));
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement*
-DQMStore::book2DD(uint32_t const run, uint32_t const moduleId, TString const& name, TH2D* source)
+DQMStore::book2DD(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, TH2D* source)
 {
-  return book2DD_(run, moduleId, pwd_, name.Data(), static_cast<TH2D*>(source->Clone(name)));
+  return book2DD_(run, moduleId, dir, name, static_cast<TH2D*>(source->Clone(name)));
 }
 
 // -------------------------------------------------------------------
@@ -990,22 +1278,22 @@ DQMStore::book3D_(uint32_t const run, uint32_t const moduleId, std::string const
 
 /// Book 3D histogram.
 MonitorElement*
-DQMStore::book3D(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::book3D(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                  int const nchX, double const lowX, double const highX,
                  int const nchY, double const lowY, double const highY,
                  int const nchZ, double const lowZ, double const highZ)
 {
-  return book3D_(run, moduleId, pwd_, name.Data(), new TH3F(name, title,
-                                                            nchX, lowX, highX,
-                                                            nchY, lowY, highY,
-                                                            nchZ, lowZ, highZ));
+  return book3D_(run, moduleId, dir, name, new TH3F(name, title,
+                                                    nchX, lowX, highX,
+                                                    nchY, lowY, highY,
+                                                    nchZ, lowZ, highZ));
 }
 
 /// Book 3D histogram by cloning an existing histogram.
 MonitorElement*
-DQMStore::book3D(uint32_t const run, uint32_t const moduleId, TString const& name, TH3F* source)
+DQMStore::book3D(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, TH3F* source)
 {
-  return book3D_(run, moduleId, pwd_, name.Data(), static_cast<TH3F*>(source->Clone(name)));
+  return book3D_(run, moduleId, dir, name, static_cast<TH3F*>(source->Clone(name)));
 }
 
 // -------------------------------------------------------------------
@@ -1022,67 +1310,67 @@ DQMStore::bookProfile_(uint32_t const run, uint32_t const moduleId, std::string 
 /// TProfile::BuildOptions).  The number of channels in Y is
 /// disregarded in a profile plot.
 MonitorElement*
-DQMStore::bookProfile(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::bookProfile(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                       int const nchX, double const lowX, double const highX,
                       int /* nchY */, double const lowY, double const highY,
                       char const* option /* = "s" */)
 {
-  return bookProfile_(run, moduleId, pwd_, name.Data(), new TProfile(name, title,
-                                                                     nchX, lowX, highX,
-                                                                     lowY, highY,
-                                                                     option));
+  return bookProfile_(run, moduleId, dir, name, new TProfile(name, title,
+                                                             nchX, lowX, highX,
+                                                             lowY, highY,
+                                                             option));
 }
 
 /// Book profile.  Option is one of: " ", "s" (default), "i", "G" (see
 /// TProfile::BuildOptions).  The number of channels in Y is
 /// disregarded in a profile plot.
 MonitorElement*
-DQMStore::bookProfile(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::bookProfile(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                       int const nchX, double const lowX, double const highX,
                       double const lowY, double const highY,
                       char const* option /* = "s" */)
 {
-  return bookProfile_(run, moduleId, pwd_, name.Data(), new TProfile(name, title,
-                                                                     nchX, lowX, highX,
-                                                                     lowY, highY,
-                                                                     option));
+  return bookProfile_(run, moduleId, dir, name, new TProfile(name, title,
+                                                             nchX, lowX, highX,
+                                                             lowY, highY,
+                                                             option));
 }
 
 /// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
 /// TProfile::BuildOptions).  The number of channels in Y is
 /// disregarded in a profile plot.
 MonitorElement*
-DQMStore::bookProfile(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::bookProfile(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                       int const nchX, double const* xbinsize,
                       int /* nchY */, double const lowY, double const highY,
                       char const* option /* = "s" */)
 {
-  return bookProfile_(run, moduleId, pwd_, name.Data(), new TProfile(name, title,
-                                                                     nchX, xbinsize,
-                                                                     lowY, highY,
-                                                                     option));
+  return bookProfile_(run, moduleId, dir, name, new TProfile(name, title,
+                                                             nchX, xbinsize,
+                                                             lowY, highY,
+                                                             option));
 }
 
 /// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
 /// TProfile::BuildOptions).  The number of channels in Y is
 /// disregarded in a profile plot.
 MonitorElement*
-DQMStore::bookProfile(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::bookProfile(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                       int const nchX, double const* xbinsize,
                       double const lowY, double const highY,
                       char const* option /* = "s" */)
 {
-  return bookProfile_(run, moduleId, pwd_, name.Data(), new TProfile(name, title,
-                                                                     nchX, xbinsize,
-                                                                     lowY, highY,
-                                                                     option));
+  return bookProfile_(run, moduleId, dir, name, new TProfile(name, title,
+                                                             nchX, xbinsize,
+                                                             lowY, highY,
+                                                             option));
 }
 
 /// Book TProfile by cloning an existing profile.
 MonitorElement*
-DQMStore::bookProfile(uint32_t const run, uint32_t const moduleId, TString const& name, TProfile* source)
+DQMStore::bookProfile(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, TProfile* source)
 {
-  return bookProfile_(run, moduleId, pwd_, name.Data(), static_cast<TProfile*>(source->Clone(name)));
+  return bookProfile_(run, moduleId, dir, name, static_cast<TProfile*>(source->Clone(name)));
 }
 
 // -------------------------------------------------------------------
@@ -1099,41 +1387,41 @@ DQMStore::bookProfile2D_(uint32_t const run, uint32_t const moduleId, std::strin
 /// (see TProfile2D::BuildOptions).  The number of channels in Z is
 /// disregarded in a 2-D profile.
 MonitorElement*
-DQMStore::bookProfile2D(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::bookProfile2D(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                         int const nchX, double const lowX, double const highX,
                         int const nchY, double const lowY, double const highY,
                         int /* nchZ */, double const lowZ, double const highZ,
                         char const* option /* = "s" */)
 {
-  return bookProfile2D_(run, moduleId, pwd_, name.Data(), new TProfile2D(name, title,
-                                                                         nchX, lowX, highX,
-                                                                         nchY, lowY, highY,
-                                                                         lowZ, highZ,
-                                                                         option));
+  return bookProfile2D_(run, moduleId, dir, name, new TProfile2D(name, title,
+                                                                 nchX, lowX, highX,
+                                                                 nchY, lowY, highY,
+                                                                 lowZ, highZ,
+                                                                 option));
 }
 
 /// Book 2-D profile.  Option is one of: " ", "s" (default), "i", "G"
 /// (see TProfile2D::BuildOptions).  The number of channels in Z is
 /// disregarded in a 2-D profile.
 MonitorElement*
-DQMStore::bookProfile2D(uint32_t const run, uint32_t const moduleId, TString const& name, TString const& title,
+DQMStore::bookProfile2D(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, char_string const& title,
                         int const nchX, double const lowX, double const highX,
                         int const nchY, double const lowY, double const highY,
                         double const lowZ, double const highZ,
                         char const* option /* = "s" */)
 {
-  return bookProfile2D_(run, moduleId, pwd_, name.Data(), new TProfile2D(name, title,
-                                                                         nchX, lowX, highX,
-                                                                         nchY, lowY, highY,
-                                                                         lowZ, highZ,
-                                                                         option));
+  return bookProfile2D_(run, moduleId, dir, name, new TProfile2D(name, title,
+                                                                 nchX, lowX, highX,
+                                                                 nchY, lowY, highY,
+                                                                 lowZ, highZ,
+                                                                 option));
 }
 
 /// Book TProfile2D by cloning an existing profile.
 MonitorElement*
-DQMStore::bookProfile2D(uint32_t const run, uint32_t const moduleId, TString const& name, TProfile2D* source)
+DQMStore::bookProfile2D(uint32_t const run, uint32_t const moduleId, std::string const& dir, char_string const& name, TProfile2D* source)
 {
-  return bookProfile2D_(run, moduleId, pwd_, name.Data(), static_cast<TProfile2D*>(source->Clone(name)));
+  return bookProfile2D_(run, moduleId, dir, name, static_cast<TProfile2D*>(source->Clone(name)));
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -16,14 +16,14 @@
 #include "TClass.h"
 #include "TSystem.h"
 #include "TBufferFile.h"
-#include <iterator>
-#include <cerrno>
 #include <boost/algorithm/string.hpp>
 #include <boost/range/iterator_range_core.hpp>
 
+#include <iterator>
+#include <cerrno>
+#include <exception>
 #include <fstream>
 #include <sstream>
-#include <exception>
 #include <utility>
 
 /** @var DQMStore::verbose_
@@ -34,9 +34,9 @@
 
 /** @var DQMStore::reset_
 
-Flag used to print out a warning when calling quality tests.
-twice without having called reset() in between; to be reset in
-DQMOldReceiver::runQualityTests.  */
+    Flag used to print out a warning when calling quality tests.
+    twice without having called reset() in between; to be reset in
+    DQMOldReceiver::runQualityTests.  */
 
 /** @var DQMStore::collateHistograms_ */
 
@@ -56,25 +56,25 @@ namespace {
 
   //////////////////////////////////////////////////////////////////////
   /// name of global monitoring folder (containing all sources subdirectories)
-  const std::string s_monitorDirName = "DQMData";
-  const std::string s_referenceDirName = "Reference";
-  const std::string s_collateDirName = "Collate";
-  const std::string s_safe = "/ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-+=_()# ";
+  std::string const s_monitorDirName{"DQMData"};
+  std::string const s_referenceDirName{"Reference"};
+  std::string const s_collateDirName{"Collate"};
+  std::string const s_safe{"/ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-+=_()# "};
 
-  const lat::Regexp s_rxmeval ("^<(.*)>(i|f|s|e|t|qr)=(.*)</\\1>$");
-  const lat::Regexp s_rxmeqr1 ("^st:(\\d+):([-+e.\\d]+):([^:]*):(.*)$");
-  const lat::Regexp s_rxmeqr2 ("^st\\.(\\d+)\\.(.*)$");
-  const lat::Regexp s_rxtrace ("(.*)\\((.*)\\+0x.*\\).*");
-  const lat::Regexp s_rxself  ("^[^()]*DQMStore::.*");
-  const lat::Regexp s_rxpbfile (".*\\.pb$");
+  lat::Regexp const s_rxmeval{"^<(.*)>(i|f|s|e|t|qr)=(.*)</\\1>$"};
+  lat::Regexp const s_rxmeqr1{"^st:(\\d+):([-+e.\\d]+):([^:]*):(.*)$"};
+  lat::Regexp const s_rxmeqr2{"^st\\.(\\d+)\\.(.*)$"};
+  lat::Regexp const s_rxtrace{"(.*)\\((.*)\\+0x.*\\).*"};
+  lat::Regexp const s_rxself{"^[^()]*DQMStore::.*"};
+  lat::Regexp const s_rxpbfile{".*\\.pb$"};
 
-  const std::string empty_str{};
+  std::string const empty_str{};
 
   //////////////////////////////////////////////////////////////////////
   /// Check whether the @a path is a subdirectory of @a ofdir.  Returns
   /// true both for an exact match and any nested subdirectory.
   bool
-  isSubdirectory(const std::string &ofdir, const std::string &path)
+  isSubdirectory(std::string const& ofdir, std::string const& path)
   {
     return (ofdir.empty()
             || (path.size() >= ofdir.size()
@@ -84,7 +84,7 @@ namespace {
   }
 
   void
-  cleanTrailingSlashes(const std::string &path, std::string &clean, const std::string *&cleaned)
+  cleanTrailingSlashes(std::string const& path, std::string& clean, std::string const*& cleaned)
   {
     clean.clear();
     cleaned = &path;
@@ -93,19 +93,17 @@ namespace {
     for ( ; len > 0 && path[len-1] == '/'; --len)
       ;
 
-    if (len != path.size())
-    {
+    if (len != path.size()) {
       clean = path.substr(0, len);
       cleaned = &clean;
     }
   }
 
   void
-  splitPath(std::string &dir, std::string &name, const std::string &path)
+  splitPath(std::string& dir, std::string& name, std::string const& path)
   {
     size_t slash = path.rfind('/');
-    if (slash != std::string::npos)
-    {
+    if (slash != std::string::npos) {
       dir.append(path, 0, slash);
       name.append(path, slash+1, std::string::npos);
     }
@@ -114,7 +112,7 @@ namespace {
   }
 
   void
-  mergePath(std::string &path, const std::string &dir, const std::string &name)
+  mergePath(std::string& path, std::string const& dir, std::string const& name)
   {
     path.reserve(dir.size() + name.size() + 2);
     path += dir;
@@ -124,28 +122,30 @@ namespace {
   }
 
   template <class T>
-  QCriterion *
-  makeQCriterion(const std::string &qtname)
-  { return new T(qtname); }
+  QCriterion*
+  makeQCriterion(std::string const& qtname)
+  {
+    return new T{qtname};
+  }
 
   template <class T>
   void
-  initQCriterion(std::map<std::string, QCriterion *(*)(const std::string &)> &m)
-  { m[T::getAlgoName()] = &makeQCriterion<T>; }
+  initQCriterion(std::map<std::string, QCriterion* (*)(std::string const&)>& m)
+  {
+    m[T::getAlgoName()] = &makeQCriterion<T>;
+  }
 
 } // anonymous namespace
 
 /////////////////////////////////////////////////////////////
-fastmatch::fastmatch (std::string  _fastString) :
-  fastString_ (std::move(_fastString)),  matching_ (UseFull)
+fastmatch::fastmatch (std::string fastString) :
+  fastString_{move(fastString)}, matching_{UseFull}
 {
-  try
-  {
+  try {
     regexp_ = std::make_unique<lat::Regexp>(fastString_, 0, lat::Regexp::Wildcard);
     regexp_->study();
   }
-  catch (lat::Error &e)
-  {
+  catch (lat::Error &e) {
     raiseDQMError("DQMStore", "Invalid wildcard pattern '%s' in quality"
                   " test specification", fastString_.c_str());
   }
@@ -153,8 +153,7 @@ fastmatch::fastmatch (std::string  _fastString) :
   // count stars ( "*" )
   size_t starCount = 0;
   int pos = -1;
-  while (true)
-  {
+  while (true) {
     pos = fastString_.find('*', pos + 1 );
     if ((size_t)pos == std::string::npos)
       break;
@@ -166,24 +165,20 @@ fastmatch::fastmatch (std::string  _fastString) :
       (fastString_.find(']') != std::string::npos)  ||
       (fastString_.find('?') != std::string::npos)  ||
       (fastString_.find('\\') != std::string::npos) ||
-      (starCount > 2))
-  {
+      (starCount > 2)) {
     // no fast version can be used
     return;
   }
 
   // match for pattern "*MyString" and "MyString*"
-  if (starCount == 1)
-  {
-    if (boost::algorithm::starts_with(fastString_, "*"))
-    {
+  if (starCount == 1) {
+    if (boost::algorithm::starts_with(fastString_, "*")) {
       matching_ = OneStarStart;
       fastString_.erase(0,1);
       return;
     }
 
-    if (boost::algorithm::ends_with(fastString_, "*"))
-    {
+    if (boost::algorithm::ends_with(fastString_, "*")) {
       matching_ = OneStarEnd;
       fastString_.erase(fastString_.length()-1,1);
       return;
@@ -191,11 +186,9 @@ fastmatch::fastmatch (std::string  _fastString) :
   }
 
   // match for pattern "*MyString*"
-  if (starCount == 2)
-  {
+  if (starCount == 2) {
     if (boost::algorithm::starts_with(fastString_, "*") &&
-        boost::algorithm::ends_with(fastString_, "*"))
-    {
+        boost::algorithm::ends_with(fastString_, "*")) {
       matching_ = TwoStar;
       fastString_.erase(0,1);
       fastString_.erase(fastString_.size() - 1, 1);
@@ -216,8 +209,7 @@ bool fastmatch::compare_strings_reverse(std::string const& pattern,
   auto rit_pattern = pattern.crbegin();
   auto rit_input = input.crbegin();
 
-  for (; rit_pattern < pattern.rend(); ++rit_pattern, ++rit_input)
-  {
+  for (; rit_pattern < pattern.rend(); ++rit_pattern, ++rit_input) {
     if (*rit_pattern != *rit_input)
       // found a difference, fail
       return false;
@@ -237,8 +229,7 @@ bool fastmatch::compare_strings(std::string const& pattern,
   auto rit_pattern = pattern.cbegin();
   auto rit_input = input.cbegin();
 
-  for (; rit_pattern < pattern.end(); ++rit_pattern, ++rit_input)
-  {
+  for (; rit_pattern < pattern.end(); ++rit_pattern, ++rit_input) {
     if (*rit_pattern != *rit_input)
       // found a difference, fail
       return false;
@@ -248,8 +239,7 @@ bool fastmatch::compare_strings(std::string const& pattern,
 
 bool fastmatch::match(std::string const& s) const
 {
-  switch (matching_)
-  {
+  switch (matching_) {
   case OneStarStart:
     return compare_strings_reverse(fastString_, s);
 
@@ -265,90 +255,107 @@ bool fastmatch::match(std::string const& s) const
 }
 
 //IBooker methods
-void DQMStore::IBooker::cd() {
+void DQMStore::IBooker::cd()
+{
   owner_->cd();
 }
 
-void DQMStore::IBooker::cd(const std::string &dir) {
+void DQMStore::IBooker::cd(std::string const& dir)
+{
   owner_->cd(dir);
 }
 
-void DQMStore::IBooker::setCurrentFolder(const std::string &fullpath) {
+void DQMStore::IBooker::setCurrentFolder(std::string const& fullpath)
+{
   owner_->setCurrentFolder(fullpath);
 }
 
-void DQMStore::IBooker::goUp() {
+void DQMStore::IBooker::goUp()
+{
   owner_->goUp();
 }
 
-const std::string & DQMStore::IBooker::pwd() {
+std::string const& DQMStore::IBooker::pwd()
+{
   return owner_->pwd();
 }
 
-void DQMStore::IBooker::tag(MonitorElement *me, unsigned int tag) {
+void DQMStore::IBooker::tag(MonitorElement* me, unsigned int const tag)
+{
   owner_->tag(me, tag);
 }
 
-void DQMStore::IBooker::tagContents(const std::string &path, unsigned int myTag) {
+void DQMStore::IBooker::tagContents(std::string const& path, unsigned int const myTag)
+{
   owner_->tagContents(path, myTag);
 }
 
 //IGetter methods
 std::vector<MonitorElement*>
-DQMStore::IGetter::getAllContents(const std::string &path,
-                                  uint32_t run  /* = 0 */,
-                                  uint32_t lumi /* = 0 */) {
+DQMStore::IGetter::getAllContents(std::string const& path,
+                                  uint32_t const run  /* = 0 */,
+                                  uint32_t const lumi /* = 0 */)
+{
   return owner_->getAllContents(path, run, lumi);
 }
 
-MonitorElement * DQMStore::IGetter::get(const std::string &path) {
+MonitorElement*  DQMStore::IGetter::get(std::string const& path)
+{
   return owner_->get(path);
 }
 
-MonitorElement * DQMStore::IGetter::getElement(const std::string &path) {
-    MonitorElement *ptr = this->get(path);
-    if (ptr == nullptr) {
-      std::stringstream msg;
-      msg << "DQM object not found";
+MonitorElement*  DQMStore::IGetter::getElement(std::string const& path)
+{
+  MonitorElement* ptr = this->get(path);
+  if (ptr == nullptr) {
+    std::stringstream msg;
+    msg << "DQM object not found";
 
-      msg << ": " << path;
+    msg << ": " << path;
 
-      // can't use cms::Exception inside DQMStore
-      throw std::out_of_range(msg.str());
-    }
-    return ptr;
+    // can't use cms::Exception inside DQMStore
+    throw std::out_of_range(msg.str());
+  }
+  return ptr;
 }
 
-std::vector<std::string> DQMStore::IGetter::getSubdirs() {
+std::vector<std::string> DQMStore::IGetter::getSubdirs()
+{
   return owner_->getSubdirs();
 }
 
-std::vector<std::string> DQMStore::IGetter::getMEs() {
+std::vector<std::string> DQMStore::IGetter::getMEs()
+{
   return owner_->getMEs();
 }
 
-bool DQMStore::IGetter::containsAnyMonitorable(const std::string &path) {
+bool DQMStore::IGetter::containsAnyMonitorable(std::string const& path)
+{
   return owner_->containsAnyMonitorable(path);
 }
 
-bool DQMStore::IGetter::dirExists(const std::string &path) {
+bool DQMStore::IGetter::dirExists(std::string const& path)
+{
   return owner_->dirExists(path);
 }
 
-void DQMStore::IGetter::cd() {
+void DQMStore::IGetter::cd()
+{
   owner_->cd();
 }
 
-void DQMStore::IGetter::cd(const std::string &dir) {
+void DQMStore::IGetter::cd(std::string const& dir)
+{
   owner_->cd(dir);
 }
 
-void DQMStore::IGetter::setCurrentFolder(const std::string &fullpath) {
+void DQMStore::IGetter::setCurrentFolder(std::string const& fullpath)
+{
   owner_->setCurrentFolder(fullpath);
 }
 
 //////////////////////////////////////////////////////////////////////
-DQMStore::DQMStore(const edm::ParameterSet &pset, edm::ActivityRegistry& ar)
+DQMStore::DQMStore(edm::ParameterSet const& pset, edm::ActivityRegistry& ar)
   : DQMStore{pset}
 {
   ar.preallocateSignal_.connect([this](edm::service::SystemBounds const& iBounds) {
@@ -366,22 +373,23 @@ DQMStore::DQMStore(const edm::ParameterSet &pset, edm::ActivityRegistry& ar)
   ar.watchPostGlobalBeginLumi(this, &DQMStore::postGlobalBeginLumi);
 }
 
-DQMStore::DQMStore(const edm::ParameterSet &pset)
+DQMStore::DQMStore(edm::ParameterSet const& pset)
 {
   initializeFrom(pset);
 }
 
 DQMStore::~DQMStore()
 {
-  for (auto & qtest : qtests_)
+  for (auto& qtest : qtests_)
     delete qtest.second;
 
-  for (auto & qtestspec : qtestspecs_)
+  for (auto& qtestspec : qtestspecs_)
     delete qtestspec.first;
 }
 
 void
-DQMStore::initializeFrom(const edm::ParameterSet& pset) {
+DQMStore::initializeFrom(edm::ParameterSet const& pset)
+{
   makeDirectory("");
   reset();
 
@@ -403,12 +411,11 @@ DQMStore::initializeFrom(const edm::ParameterSet& pset) {
     std::cout << "DQMStore: MultiThread option is enabled\n";
 
   LSbasedMode_ = pset.getUntrackedParameter<bool>("LSbasedMode", false);
-   if (LSbasedMode_)
-     std::cout << "DQMStore: LSbasedMode option is enabled\n";
+  if (LSbasedMode_)
+    std::cout << "DQMStore: LSbasedMode option is enabled\n";
 
   std::string ref = pset.getUntrackedParameter<std::string>("referenceFileName", "");
-  if (! ref.empty())
-  {
+  if (! ref.empty()) {
     std::cout << "DQMStore: using reference file '" << ref << "'\n";
     readFile(ref, true, "", s_referenceDirName, StripRunDirs, false);
   }
@@ -434,16 +441,16 @@ DQMStore::initializeFrom(const edm::ParameterSet& pset) {
 }
 
 /* Generic method to do a backtrace and print it to stdout. It is
- customised to properly get the routine that called the booking of the
- histograms, which, following the usual stack, is at position 4. The
- name of the calling function is properly demangled and the original
- shared library including this function is also printed. For a more
- detailed explanation of the routines involved, see here:
- http://www.gnu.org/software/libc/manual/html_node/Backtraces.html
- http://gcc.gnu.org/onlinedocs/libstdc++/manual/ext_demangling.html.*/
+   customised to properly get the routine that called the booking of the
+   histograms, which, following the usual stack, is at position 4. The
+   name of the calling function is properly demangled and the original
+   shared library including this function is also printed. For a more
+   detailed explanation of the routines involved, see here:
+   http://www.gnu.org/software/libc/manual/html_node/Backtraces.html
+   http://gcc.gnu.org/onlinedocs/libstdc++/manual/ext_demangling.html.*/
 
 void
-DQMStore::print_trace (const std::string &dir, const std::string &name)
+DQMStore::print_trace(std::string const& dir, std::string const& name)
 {
   // the access to the member stream_ is implicitely protected against
   // concurrency problems because the print_trace method is always called behind
@@ -451,18 +458,18 @@ DQMStore::print_trace (const std::string &dir, const std::string &name)
   if (!stream_)
     stream_ = std::make_unique<std::ofstream>("histogramBookingBT.log");
 
-  void *array[10];
+  void* array[10];
   size_t size;
-  char **strings;
-  int r=0;
+  char** strings;
+  int r = 0;
   lat::RegexpMatch m;
   m.reset();
 
-  size = backtrace (array, 10);
-  strings = backtrace_symbols (array, size);
+  size = backtrace(array, 10);
+  strings = backtrace_symbols(array, size);
 
   size_t level = 1;
-  char * demangled = nullptr;
+  char* demangled = nullptr;
   for (; level < size; ++level) {
     if (!s_rxtrace.match(strings[level], 0, 0, &m)) continue;
     demangled = abi::__cxa_demangle(m.matchString(strings[level], 2).c_str(), nullptr, nullptr, &r);
@@ -474,29 +481,27 @@ DQMStore::print_trace (const std::string &dir, const std::string &name)
 
   if (demangled != nullptr) {
     *stream_ << "\"" << dir << "/"
-           << name << "\" "
-           << (r ? m.matchString(strings[level], 2) : demangled) << " "
-           << m.matchString(strings[level], 1) << "\n";
+             << name << "\" "
+             << (r ? m.matchString(strings[level], 2) : demangled) << " "
+             << m.matchString(strings[level], 1) << "\n";
     free(demangled);
   } else {
     *stream_ << "Skipping "<< dir << "/" << name
-           << " with stack size " << size << "\n";
+             << " with stack size " << size << "\n";
   }
 
   /* In this case print the full stack trace, up to main or to the
    * maximum stack size, i.e. 10. */
-  if (verbose_ > 4 || demangled == nullptr)
-  {
+  if (verbose_ > 4 || demangled == nullptr) {
     size_t i;
     m.reset();
 
     for (i = 0; i < size; ++i)
-      if (s_rxtrace.match(strings[i], 0, 0, &m))
-      {
-        char * demangled = abi::__cxa_demangle(m.matchString(strings[i], 2).c_str(), nullptr, nullptr, &r);
+      if (s_rxtrace.match(strings[i], 0, 0, &m)) {
+        char* demangled = abi::__cxa_demangle(m.matchString(strings[i], 2).c_str(), nullptr, nullptr, &r);
         *stream_ << "\t\t" << i << "/" << size << " "
-               << (r ? m.matchString(strings[i], 2) : demangled) << " "
-               << m.matchString(strings[i], 1) << std::endl;
+                 << (r ? m.matchString(strings[i], 2) : demangled) << " "
+                 << m.matchString(strings[i], 1) << std::endl;
         free (demangled);
       }
   }
@@ -509,27 +514,31 @@ DQMStore::print_trace (const std::string &dir, const std::string &name)
 /// set verbose level (0 turns all non-error messages off)
 void
 DQMStore::setVerbose(unsigned /* level */)
-{ return; }
+{}
 
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
 /// return pathname of current directory
-const std::string &
+std::string const&
 DQMStore::pwd() const
-{ return pwd_; }
+{
+  return pwd_;
+}
 
 /// go to top directory (ie. root)
 void
 DQMStore::cd()
-{ setCurrentFolder(""); }
+{
+  setCurrentFolder("");
+}
 
 /// cd to subdirectory (if there)
 void
-DQMStore::cd(const std::string &subdir)
+DQMStore::cd(std::string const& subdir)
 {
   std::string clean;
-  const std::string *cleaned = nullptr;
+  std::string const* cleaned = nullptr;
   cleanTrailingSlashes(subdir, clean, cleaned);
 
   if (! dirExists(*cleaned))
@@ -544,10 +553,10 @@ DQMStore::cd(const std::string &subdir)
 /// before booking;
 /// commands book1D (etc) & removeElement(name) imply elements in this directory!;
 void
-DQMStore::setCurrentFolder(const std::string &fullpath)
+DQMStore::setCurrentFolder(std::string const& fullpath)
 {
   std::string clean;
-  const std::string *cleaned = nullptr;
+  std::string const* cleaned = nullptr;
   cleanTrailingSlashes(fullpath, clean, cleaned);
   makeDirectory(*cleaned);
   pwd_ = *cleaned;
@@ -568,7 +577,7 @@ DQMStore::goUp()
 /// get folder corresponding to inpath wrt to root (create subdirs if
 /// necessary)
 void
-DQMStore::makeDirectory(const std::string &path)
+DQMStore::makeDirectory(std::string const& path)
 {
   std::string prev;
   std::string subdir;
@@ -579,8 +588,7 @@ DQMStore::makeDirectory(const std::string &path)
   size_t prevname = 0;
   size_t slash = 0;
 
-  while (true)
-  {
+  while (true) {
     // Create this subdirectory component.
     subdir.clear();
     subdir.append(path, 0, slash);
@@ -609,17 +617,22 @@ DQMStore::makeDirectory(const std::string &path)
 
 /// true if directory exists
 bool
-DQMStore::dirExists(const std::string &path) const
-{ return dirs_.count(path) > 0; }
+DQMStore::dirExists(std::string const& path) const
+{
+  return dirs_.count(path) > 0;
+}
 
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
 template <class HISTO, class COLLATE>
-MonitorElement *
-DQMStore::book_(const std::string &dir, const std::string &name,
-                const char *context, int kind,
-                HISTO *h, COLLATE collate)
+MonitorElement*
+DQMStore::book_(std::string const& dir,
+                std::string const& name,
+                char const* context,
+                int const kind,
+                HISTO* h,
+                COLLATE collate)
 {
   assert(name.find('/') == std::string::npos);
   if (verbose_ > 3)
@@ -631,17 +644,14 @@ DQMStore::book_(const std::string &dir, const std::string &name,
   h->SetDirectory(nullptr);
 
   // Check if the request monitor element already exists.
-  MonitorElement *me = findObject(run_, 0, moduleId_, dir, name);
-  if (me)
-  {
-    if (collateHistograms_)
-    {
+  MonitorElement* me = findObject(run_, 0, moduleId_, dir, name);
+  if (me) {
+    if (collateHistograms_) {
       collate(me, h, verbose_);
       delete h;
       return me;
     }
-    else
-    {
+    else {
       if (verbose_ > 1)
         std::cout << "DQMStore: "
                   << context << ": monitor element '"
@@ -652,8 +662,7 @@ DQMStore::book_(const std::string &dir, const std::string &name,
       return me;
     }
   }
-  else
-  {
+  else {
     // Create and initialise core object.
     assert(dirs_.count(dir));
     KeyObject key{&*dirs_.find(dir), name, run_, 0, moduleId_};
@@ -662,8 +671,7 @@ DQMStore::book_(const std::string &dir, const std::string &name,
     me = it->second.initialise((MonitorElement::Kind)kind, h);
 
     // Initialise quality test information.
-    for (auto const& q : qtestspecs_)
-    {
+    for (auto const& q : qtestspecs_) {
       if (q.first->match(path))
         me->addQReport(q.second);
     }
@@ -691,20 +699,18 @@ DQMStore::book_(const std::string &dir, const std::string &name,
   }
 }
 
-MonitorElement *
-DQMStore::book_(const std::string &dir,
-                const std::string &name,
-                const char *context)
+MonitorElement*
+DQMStore::book_(std::string const& dir,
+                std::string const& name,
+                char const* context)
 {
   assert(name.find('/') == std::string::npos);
   if (verbose_ > 3)
     print_trace(dir, name);
 
   // Check if the request monitor element already exists.
-  if (MonitorElement *me = findObject(run_, 0, moduleId_, dir, name))
-  {
-    if (verbose_ > 1)
-    {
+  if (MonitorElement* me = findObject(run_, 0, moduleId_, dir, name)) {
+    if (verbose_ > 1) {
       std::string path;
       mergePath(path, dir, name);
 
@@ -715,8 +721,7 @@ DQMStore::book_(const std::string &dir,
     me->Reset();
     return me;
   }
-  else
-  {
+  else {
     // Create it and return for initialisation.
     assert(dirs_.count(dir));
     KeyObject key{&*dirs_.find(dir), name, run_, 0, moduleId_};
@@ -728,13 +733,11 @@ DQMStore::book_(const std::string &dir,
 
 // -------------------------------------------------------------------
 /// Book int.
-MonitorElement *
-DQMStore::bookInt_(const std::string &dir, const std::string &name)
+MonitorElement*
+DQMStore::bookInt_(std::string const& dir, std::string const& name)
 {
-  if (collateHistograms_)
-  {
-    if (MonitorElement *me = findObject(run_, 0, moduleId_, dir, name))
-    {
+  if (collateHistograms_) {
+    if (MonitorElement* me = findObject(run_, 0, moduleId_, dir, name)) {
       me->Fill(0);
       return me;
     }
@@ -745,26 +748,19 @@ DQMStore::bookInt_(const std::string &dir, const std::string &name)
 }
 
 /// Book int.
-MonitorElement *
-DQMStore::bookInt(const char *name)
-{ return bookInt_(pwd_, name); }
-
-/// Book int.
-MonitorElement *
-DQMStore::bookInt(const std::string &name)
+MonitorElement*
+DQMStore::bookInt(TString const& name)
 {
-  return bookInt_(pwd_, name);
+  return bookInt_(pwd_, name.Data());
 }
 
 // -------------------------------------------------------------------
 /// Book float.
-MonitorElement *
-DQMStore::bookFloat_(const std::string &dir, const std::string &name)
+MonitorElement*
+DQMStore::bookFloat_(std::string const& dir, std::string const& name)
 {
-  if (collateHistograms_)
-  {
-    if (MonitorElement *me = findObject(run_, 0, moduleId_, dir, name))
-    {
+  if (collateHistograms_) {
+    if (MonitorElement* me = findObject(run_, 0, moduleId_, dir, name)) {
       me->Fill(0.);
       return me;
     }
@@ -775,27 +771,21 @@ DQMStore::bookFloat_(const std::string &dir, const std::string &name)
 }
 
 /// Book float.
-MonitorElement *
-DQMStore::bookFloat(const char *name)
-{ return bookFloat_(pwd_, name); }
-
-/// Book float.
-MonitorElement *
-DQMStore::bookFloat(const std::string &name)
+MonitorElement*
+DQMStore::bookFloat(TString const& name)
 {
-  return bookFloat_(pwd_, name);
+  return bookFloat_(pwd_, name.Data());
 }
 
 // -------------------------------------------------------------------
 /// Book string.
-MonitorElement *
-DQMStore::bookString_(const std::string &dir,
-                      const std::string &name,
-                      const std::string &value)
+MonitorElement*
+DQMStore::bookString_(std::string const& dir,
+                      std::string const& name,
+                      std::string const& value)
 {
-  if (collateHistograms_)
-  {
-    if (MonitorElement *me = findObject(run_, 0, moduleId_, dir, name))
+  if (collateHistograms_) {
+    if (MonitorElement* me = findObject(run_, 0, moduleId_, dir, name))
       return me;
   }
 
@@ -804,364 +794,213 @@ DQMStore::bookString_(const std::string &dir,
 }
 
 /// Book string.
-MonitorElement *
-DQMStore::bookString(const char *name, const char *value)
-{ return bookString_(pwd_, name, value); }
-
-/// Book string.
-MonitorElement *
-DQMStore::bookString(const std::string &name, const std::string &value)
+MonitorElement*
+DQMStore::bookString(TString const& name, TString const& value)
 {
-  return bookString_(pwd_, name, value);
+  return bookString_(pwd_, name.Data(), value.Data());
 }
 
 // -------------------------------------------------------------------
 /// Book 1D histogram based on TH1F.
-MonitorElement *
-DQMStore::book1D_(const std::string &dir, const std::string &name, TH1F *h)
+MonitorElement*
+DQMStore::book1D_(std::string const& dir, std::string const& name, TH1F* h)
 {
   return book_(dir, name, "book1D", MonitorElement::DQM_KIND_TH1F, h, collate1D);
 }
 
 /// Book 1D histogram based on TH1S.
-MonitorElement *
-DQMStore::book1S_(const std::string &dir, const std::string &name, TH1S *h)
+MonitorElement*
+DQMStore::book1S_(std::string const& dir, std::string const& name, TH1S* h)
 {
   return book_(dir, name, "book1S", MonitorElement::DQM_KIND_TH1S, h, collate1S);
 }
 
 /// Book 1D histogram based on TH1D.
-MonitorElement *
-DQMStore::book1DD_(const std::string &dir, const std::string &name, TH1D *h)
+MonitorElement*
+DQMStore::book1DD_(std::string const& dir, std::string const& name, TH1D* h)
 {
   return book_(dir, name, "book1DD", MonitorElement::DQM_KIND_TH1D, h, collate1DD);
 }
 
 /// Book 1D histogram.
-MonitorElement *
-DQMStore::book1D(const char *name, const char *title,
-                 int nchX, double lowX, double highX)
+MonitorElement*
+DQMStore::book1D(TString const& name, TString const& title,
+                 int const nchX, double const lowX, double const highX)
 {
-  return book1D_(pwd_, name, new TH1F(name, title, nchX, lowX, highX));
-}
-
-/// Book 1D histogram.
-MonitorElement *
-DQMStore::book1D(const std::string &name, const std::string &title,
-                 int nchX, double lowX, double highX)
-{
-  return book1D_(pwd_, name, new TH1F(name.c_str(), title.c_str(), nchX, lowX, highX));
+  return book1D_(pwd_, name.Data(), new TH1F(name, title, nchX, lowX, highX));
 }
 
 /// Book 1S histogram.
-MonitorElement *
-DQMStore::book1S(const char *name, const char *title,
-                 int nchX, double lowX, double highX)
+MonitorElement*
+DQMStore::book1S(TString const& name, TString const& title,
+                 int const nchX, double const lowX, double const highX)
 {
-  return book1S_(pwd_, name, new TH1S(name, title, nchX, lowX, highX));
+  return book1S_(pwd_, name.Data(), new TH1S(name, title, nchX, lowX, highX));
 }
 
 /// Book 1S histogram.
-MonitorElement *
-DQMStore::book1S(const std::string &name, const std::string &title,
-                 int nchX, double lowX, double highX)
+MonitorElement*
+DQMStore::book1DD(TString const& name, TString const& title,
+                  int const nchX, double const lowX, double const highX)
 {
-  return book1S_(pwd_, name, new TH1S(name.c_str(), title.c_str(), nchX, lowX, highX));
-}
-
-/// Book 1S histogram.
-MonitorElement *
-DQMStore::book1DD(const char *name, const char *title,
-                  int nchX, double lowX, double highX)
-{
-  return book1DD_(pwd_, name, new TH1D(name, title, nchX, lowX, highX));
-}
-
-/// Book 1S histogram.
-MonitorElement *
-DQMStore::book1DD(const std::string &name, const std::string &title,
-                  int nchX, double lowX, double highX)
-{
-  return book1DD_(pwd_, name, new TH1D(name.c_str(), title.c_str(), nchX, lowX, highX));
+  return book1DD_(pwd_, name.Data(), new TH1D(name, title, nchX, lowX, highX));
 }
 
 /// Book 1D variable bin histogram.
-MonitorElement *
-DQMStore::book1D(const char *name, const char *title,
-                 int nchX, const float *xbinsize)
+MonitorElement*
+DQMStore::book1D(TString const& name, TString const& title,
+                 int const nchX, const float* xbinsize)
 {
-  return book1D_(pwd_, name, new TH1F(name, title, nchX, xbinsize));
-}
-
-/// Book 1D variable bin histogram.
-MonitorElement *
-DQMStore::book1D(const std::string &name, const std::string &title,
-                 int nchX, const float *xbinsize)
-{
-  return book1D_(pwd_, name, new TH1F(name.c_str(), title.c_str(), nchX, xbinsize));
+  return book1D_(pwd_, name.Data(), new TH1F(name, title, nchX, xbinsize));
 }
 
 /// Book 1D histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book1D(const char *name, TH1F *source)
+MonitorElement*
+DQMStore::book1D(TString const& name, TH1F* source)
 {
-  return book1D_(pwd_, name, static_cast<TH1F *>(source->Clone(name)));
-}
-
-/// Book 1D histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book1D(const std::string &name, TH1F *source)
-{
-  return book1D_(pwd_, name, static_cast<TH1F *>(source->Clone(name.c_str())));
+  return book1D_(pwd_, name.Data(), static_cast<TH1F*>(source->Clone(name)));
 }
 
 /// Book 1S histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book1S(const char *name, TH1S *source)
+MonitorElement*
+DQMStore::book1S(TString const& name, TH1S* source)
 {
-  return book1S_(pwd_, name, static_cast<TH1S *>(source->Clone(name)));
-}
-
-/// Book 1S histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book1S(const std::string &name, TH1S *source)
-{
-  return book1S_(pwd_, name, static_cast<TH1S *>(source->Clone(name.c_str())));
+  return book1S_(pwd_, name.Data(), static_cast<TH1S*>(source->Clone(name)));
 }
 
 /// Book 1D double histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book1DD(const char *name, TH1D *source)
+MonitorElement*
+DQMStore::book1DD(TString const& name, TH1D* source)
 {
-  return book1DD_(pwd_, name, static_cast<TH1D *>(source->Clone(name)));
-}
-
-/// Book 1D double histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book1DD(const std::string &name, TH1D *source)
-{
-  return book1DD_(pwd_, name, static_cast<TH1D *>(source->Clone(name.c_str())));
+  return book1DD_(pwd_, name.Data(), static_cast<TH1D*>(source->Clone(name)));
 }
 
 // -------------------------------------------------------------------
 /// Book 2D histogram based on TH2F.
-MonitorElement *
-DQMStore::book2D_(const std::string &dir, const std::string &name, TH2F *h)
+MonitorElement*
+DQMStore::book2D_(std::string const& dir, std::string const& name, TH2F* h)
 {
   return book_(dir, name, "book2D", MonitorElement::DQM_KIND_TH2F, h, collate2D);
 }
 
 /// Book 2D histogram based on TH2S.
-MonitorElement *
-DQMStore::book2S_(const std::string &dir, const std::string &name, TH2S *h)
+MonitorElement*
+DQMStore::book2S_(std::string const& dir, std::string const& name, TH2S* h)
 {
   return book_(dir, name, "book2S", MonitorElement::DQM_KIND_TH2S, h, collate2S);
 }
 
 /// Book 2D histogram based on TH2D.
-MonitorElement *
-DQMStore::book2DD_(const std::string &dir, const std::string &name, TH2D *h)
+MonitorElement*
+DQMStore::book2DD_(std::string const& dir, std::string const& name, TH2D* h)
 {
   return book_(dir, name, "book2DD", MonitorElement::DQM_KIND_TH2D, h, collate2DD);
 }
 
 /// Book 2D histogram.
-MonitorElement *
-DQMStore::book2D(const char *name, const char *title,
-                 int nchX, double lowX, double highX,
-                 int nchY, double lowY, double highY)
+MonitorElement*
+DQMStore::book2D(TString const& name, TString const& title,
+                 int const nchX, double const lowX, double const highX,
+                 int const nchY, double const lowY, double const highY)
 {
-  return book2D_(pwd_, name, new TH2F(name, title,
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY));
-}
-
-/// Book 2D histogram.
-MonitorElement *
-DQMStore::book2D(const std::string &name, const std::string &title,
-                 int nchX, double lowX, double highX,
-                 int nchY, double lowY, double highY)
-{
-  return book2D_(pwd_, name, new TH2F(name.c_str(), title.c_str(),
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY));
+  return book2D_(pwd_, name.Data(), new TH2F(name, title,
+                                             nchX, lowX, highX,
+                                             nchY, lowY, highY));
 }
 
 /// Book 2S histogram.
-MonitorElement *
-DQMStore::book2S(const char *name, const char *title,
-                 int nchX, double lowX, double highX,
-                 int nchY, double lowY, double highY)
+MonitorElement*
+DQMStore::book2S(TString const& name, TString const& title,
+                 int const nchX, double const lowX, double const highX,
+                 int const nchY, double const lowY, double const highY)
 {
-  return book2S_(pwd_, name, new TH2S(name, title,
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY));
+  return book2S_(pwd_, name.Data(), new TH2S(name, title,
+                                             nchX, lowX, highX,
+                                             nchY, lowY, highY));
 }
 
 /// Book 2S histogram.
-MonitorElement *
-DQMStore::book2S(const std::string &name, const std::string &title,
-                 int nchX, double lowX, double highX,
-                 int nchY, double lowY, double highY)
+MonitorElement*
+DQMStore::book2DD(TString const& name, TString const& title,
+                  int const nchX, double const lowX, double const highX,
+                  int const nchY, double const lowY, double const highY)
 {
-  return book2S_(pwd_, name, new TH2S(name.c_str(), title.c_str(),
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY));
-}
-
-/// Book 2D double histogram.
-MonitorElement *
-DQMStore::book2DD(const char *name, const char *title,
-                  int nchX, double lowX, double highX,
-                  int nchY, double lowY, double highY)
-{
-  return book2DD_(pwd_, name, new TH2D(name, title,
-                                      nchX, lowX, highX,
-                                      nchY, lowY, highY));
-}
-
-/// Book 2S histogram.
-MonitorElement *
-DQMStore::book2DD(const std::string &name, const std::string &title,
-                  int nchX, double lowX, double highX,
-                  int nchY, double lowY, double highY)
-{
-  return book2DD_(pwd_, name, new TH2D(name.c_str(), title.c_str(),
-                                      nchX, lowX, highX,
-                                      nchY, lowY, highY));
+  return book2DD_(pwd_, name.Data(), new TH2D(name, title,
+                                              nchX, lowX, highX,
+                                              nchY, lowY, highY));
 }
 
 /// Book 2D variable bin histogram.
-MonitorElement *
-DQMStore::book2D(const char *name, const char *title,
-                 int nchX, const float *xbinsize, int nchY, const float *ybinsize)
+MonitorElement*
+DQMStore::book2D(TString const& name, TString const& title,
+                 int const nchX, const float* xbinsize, int const nchY, const float* ybinsize)
 {
-  return book2D_(pwd_, name, new TH2F(name, title,
-                                     nchX, xbinsize, nchY, ybinsize));
-}
-
-/// Book 2D variable bin histogram.
-MonitorElement *
-DQMStore::book2D(const std::string &name, const std::string &title,
-                 int nchX, const float *xbinsize, int nchY, const float *ybinsize)
-{
-  return book2D_(pwd_, name, new TH2F(name.c_str(), title.c_str(),
-                                     nchX, xbinsize, nchY, ybinsize));
+  return book2D_(pwd_, name.Data(), new TH2F(name, title,
+                                             nchX, xbinsize, nchY, ybinsize));
 }
 
 /// Book 2S variable bin histogram.
-MonitorElement *
-DQMStore::book2S(const char *name, const char *title,
-                 int nchX, const float *xbinsize, int nchY, const float *ybinsize)
+MonitorElement*
+DQMStore::book2S(TString const& name, TString const& title,
+                 int const nchX, const float* xbinsize, int const nchY, const float* ybinsize)
 {
-
-  return book2S_(pwd_, name, new TH2S(name, title,
-                                     nchX, xbinsize, nchY, ybinsize));
-}
-
-/// Book 2S variable bin histogram.
-MonitorElement *
-DQMStore::book2S(const std::string &name, const std::string &title,
-                 int nchX, const float *xbinsize, int nchY, const float *ybinsize)
-{
-  return book2S_(pwd_, name, new TH2S(name.c_str(), title.c_str(),
-                                     nchX, xbinsize, nchY, ybinsize));
+  return book2S_(pwd_, name.Data(), new TH2S(name, title,
+                                             nchX, xbinsize, nchY, ybinsize));
 }
 
 /// Book 2D histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book2D(const char *name, TH2F *source)
+MonitorElement*
+DQMStore::book2D(TString const& name, TH2F* source)
 {
-  return book2D_(pwd_, name, static_cast<TH2F *>(source->Clone(name)));
-}
-
-/// Book 2D histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book2D(const std::string &name, TH2F *source)
-{
-  return book2D_(pwd_, name, static_cast<TH2F *>(source->Clone(name.c_str())));
+  return book2D_(pwd_, name.Data(), static_cast<TH2F*>(source->Clone(name)));
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book2S(const char *name, TH2S *source)
+MonitorElement*
+DQMStore::book2S(TString const& name, TH2S* source)
 {
-  return book2S_(pwd_, name, static_cast<TH2S *>(source->Clone(name)));
+  return book2S_(pwd_, name.Data(), static_cast<TH2S*>(source->Clone(name)));
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book2S(const std::string &name, TH2S *source)
+MonitorElement*
+DQMStore::book2DD(TString const& name, TH2D* source)
 {
-  return book2S_(pwd_, name, static_cast<TH2S *>(source->Clone(name.c_str())));
-}
-
-/// Book 2DS histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book2DD(const char *name, TH2D *source)
-{
-  return book2DD_(pwd_, name, static_cast<TH2D *>(source->Clone(name)));
-}
-
-/// Book 2DS histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book2DD(const std::string &name, TH2D *source)
-{
-  return book2DD_(pwd_, name, static_cast<TH2D *>(source->Clone(name.c_str())));
+  return book2DD_(pwd_, name.Data(), static_cast<TH2D*>(source->Clone(name)));
 }
 
 // -------------------------------------------------------------------
 /// Book 3D histogram based on TH3F.
-MonitorElement *
-DQMStore::book3D_(const std::string &dir, const std::string &name, TH3F *h)
+MonitorElement*
+DQMStore::book3D_(std::string const& dir, std::string const& name, TH3F* h)
 {
   return book_(dir, name, "book3D", MonitorElement::DQM_KIND_TH3F, h, collate3D);
 }
 
 /// Book 3D histogram.
-MonitorElement *
-DQMStore::book3D(const char *name, const char *title,
-                 int nchX, double lowX, double highX,
-                 int nchY, double lowY, double highY,
-                 int nchZ, double lowZ, double highZ)
+MonitorElement*
+DQMStore::book3D(TString const& name, TString const& title,
+                 int const nchX, double const lowX, double const highX,
+                 int const nchY, double const lowY, double const highY,
+                 int const nchZ, double const lowZ, double const highZ)
 {
-  return book3D_(pwd_, name, new TH3F(name, title,
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY,
-                                     nchZ, lowZ, highZ));
-}
-
-/// Book 3D histogram.
-MonitorElement *
-DQMStore::book3D(const std::string &name, const std::string &title,
-                 int nchX, double lowX, double highX,
-                 int nchY, double lowY, double highY,
-                 int nchZ, double lowZ, double highZ)
-{
-  return book3D_(pwd_, name, new TH3F(name.c_str(), title.c_str(),
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY,
-                                     nchZ, lowZ, highZ));
+  return book3D_(pwd_, name.Data(), new TH3F(name, title,
+                                             nchX, lowX, highX,
+                                             nchY, lowY, highY,
+                                             nchZ, lowZ, highZ));
 }
 
 /// Book 3D histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book3D(const char *name, TH3F *source)
+MonitorElement*
+DQMStore::book3D(TString const& name, TH3F* source)
 {
-  return book3D_(pwd_, name, static_cast<TH3F *>(source->Clone(name)));
-}
-
-/// Book 3D histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book3D(const std::string &name, TH3F *source)
-{
-  return book3D_(pwd_, name, static_cast<TH3F *>(source->Clone(name.c_str())));
+  return book3D_(pwd_, name.Data(), static_cast<TH3F*>(source->Clone(name)));
 }
 
 // -------------------------------------------------------------------
 /// Book profile histogram based on TProfile.
-MonitorElement *
-DQMStore::bookProfile_(const std::string &dir, const std::string &name, TProfile *h)
+MonitorElement*
+DQMStore::bookProfile_(std::string const& dir, std::string const& name, TProfile* h)
 {
   return book_(dir, name, "bookProfile",
                MonitorElement::DQM_KIND_TPROFILE,
@@ -1171,141 +1010,74 @@ DQMStore::bookProfile_(const std::string &dir, const std::string &name, TProfile
 /// Book profile.  Option is one of: " ", "s" (default), "i", "G" (see
 /// TProfile::BuildOptions).  The number of channels in Y is
 /// disregarded in a profile plot.
-MonitorElement *
-DQMStore::bookProfile(const char *name, const char *title,
-                      int nchX, double lowX, double highX,
-                      int /* nchY */, double lowY, double highY,
-                      const char *option /* = "s" */)
+MonitorElement*
+DQMStore::bookProfile(TString const& name, TString const& title,
+                      int const nchX, double const lowX, double const highX,
+                      int /* nchY */, double const lowY, double const highY,
+                      char const* option /* = "s" */)
 {
-  return bookProfile_(pwd_, name, new TProfile(name, title,
-                                              nchX, lowX, highX,
-                                              lowY, highY,
-                                              option));
+  return bookProfile_(pwd_, name.Data(), new TProfile(name, title,
+                                                      nchX, lowX, highX,
+                                                      lowY, highY,
+                                                      option));
 }
 
 /// Book profile.  Option is one of: " ", "s" (default), "i", "G" (see
 /// TProfile::BuildOptions).  The number of channels in Y is
 /// disregarded in a profile plot.
-MonitorElement *
-DQMStore::bookProfile(const std::string &name, const std::string &title,
-                      int nchX, double lowX, double highX,
-                      int /* nchY */, double lowY, double highY,
-                      const char *option /* = "s" */)
+MonitorElement*
+DQMStore::bookProfile(TString const& name, TString const& title,
+                      int const nchX, double const lowX, double const highX,
+                      double const lowY, double const highY,
+                      char const* option /* = "s" */)
 {
-  return bookProfile_(pwd_, name, new TProfile(name.c_str(), title.c_str(),
-                                              nchX, lowX, highX,
-                                              lowY, highY,
-                                              option));
-}
-
-/// Book profile.  Option is one of: " ", "s" (default), "i", "G" (see
-/// TProfile::BuildOptions).  The number of channels in Y is
-/// disregarded in a profile plot.
-MonitorElement *
-DQMStore::bookProfile(const char *name, const char *title,
-                      int nchX, double lowX, double highX,
-                      double lowY, double highY,
-                      const char *option /* = "s" */)
-{
-  return bookProfile_(pwd_, name, new TProfile(name, title,
-                                              nchX, lowX, highX,
-                                              lowY, highY,
-                                              option));
-}
-
-/// Book profile.  Option is one of: " ", "s" (default), "i", "G" (see
-/// TProfile::BuildOptions).  The number of channels in Y is
-/// disregarded in a profile plot.
-MonitorElement *
-DQMStore::bookProfile(const std::string &name, const std::string &title,
-                      int nchX, double lowX, double highX,
-                      double lowY, double highY,
-                      const char *option /* = "s" */)
-{
-  return bookProfile_(pwd_, name, new TProfile(name.c_str(), title.c_str(),
-                                              nchX, lowX, highX,
-                                              lowY, highY,
-                                              option));
+  return bookProfile_(pwd_, name.Data(), new TProfile(name, title,
+                                                      nchX, lowX, highX,
+                                                      lowY, highY,
+                                                      option));
 }
 
 /// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
 /// TProfile::BuildOptions).  The number of channels in Y is
 /// disregarded in a profile plot.
-MonitorElement *
-DQMStore::bookProfile(const char *name, const char *title,
-                      int nchX, const double *xbinsize,
-                      int /* nchY */, double lowY, double highY,
-                      const char *option /* = "s" */)
+MonitorElement*
+DQMStore::bookProfile(TString const& name, TString const& title,
+                      int const nchX, double const* xbinsize,
+                      int /* nchY */, double const lowY, double const highY,
+                      char const* option /* = "s" */)
 {
-  return bookProfile_(pwd_, name, new TProfile(name, title,
-                                              nchX, xbinsize,
-                                              lowY, highY,
-                                              option));
+  return bookProfile_(pwd_, name.Data(), new TProfile(name, title,
+                                                      nchX, xbinsize,
+                                                      lowY, highY,
+                                                      option));
 }
 
 /// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
 /// TProfile::BuildOptions).  The number of channels in Y is
 /// disregarded in a profile plot.
-MonitorElement *
-DQMStore::bookProfile(const std::string &name, const std::string &title,
-                      int nchX, const double *xbinsize,
-                      int /* nchY */, double lowY, double highY,
-                      const char *option /* = "s" */)
+MonitorElement*
+DQMStore::bookProfile(TString const& name, TString const& title,
+                      int const nchX, double const* xbinsize,
+                      double const lowY, double const highY,
+                      char const* option /* = "s" */)
 {
-  return bookProfile_(pwd_, name, new TProfile(name.c_str(), title.c_str(),
-                                              nchX, xbinsize,
-                                              lowY, highY,
-                                              option));
-}
-
-/// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
-/// TProfile::BuildOptions).  The number of channels in Y is
-/// disregarded in a profile plot.
-MonitorElement *
-DQMStore::bookProfile(const char *name, const char *title,
-                      int nchX, const double *xbinsize,
-                      double lowY, double highY,
-                      const char *option /* = "s" */)
-{
-  return bookProfile_(pwd_, name, new TProfile(name, title,
-                                              nchX, xbinsize,
-                                              lowY, highY,
-                                              option));
-}
-
-/// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
-/// TProfile::BuildOptions).  The number of channels in Y is
-/// disregarded in a profile plot.
-MonitorElement *
-DQMStore::bookProfile(const std::string &name, const std::string &title,
-                      int nchX, const double *xbinsize,
-                      double lowY, double highY,
-                      const char *option /* = "s" */)
-{
-  return bookProfile_(pwd_, name, new TProfile(name.c_str(), title.c_str(),
-                                              nchX, xbinsize,
-                                              lowY, highY,
-                                              option));
+  return bookProfile_(pwd_, name.Data(), new TProfile(name, title,
+                                                      nchX, xbinsize,
+                                                      lowY, highY,
+                                                      option));
 }
 
 /// Book TProfile by cloning an existing profile.
-MonitorElement *
-DQMStore::bookProfile(const char *name, TProfile *source)
+MonitorElement*
+DQMStore::bookProfile(TString const& name, TProfile* source)
 {
-  return bookProfile_(pwd_, name, static_cast<TProfile *>(source->Clone(name)));
-}
-
-/// Book TProfile by cloning an existing profile.
-MonitorElement *
-DQMStore::bookProfile(const std::string &name, TProfile *source)
-{
-  return bookProfile_(pwd_, name, static_cast<TProfile *>(source->Clone(name.c_str())));
+  return bookProfile_(pwd_, name.Data(), static_cast<TProfile*>(source->Clone(name)));
 }
 
 // -------------------------------------------------------------------
 /// Book 2D profile histogram based on TProfile2D.
-MonitorElement *
-DQMStore::bookProfile2D_(const std::string &dir, const std::string &name, TProfile2D *h)
+MonitorElement*
+DQMStore::bookProfile2D_(std::string const& dir, std::string const& name, TProfile2D* h)
 {
   return book_(dir, name, "bookProfile2D",
                MonitorElement::DQM_KIND_TPROFILE2D,
@@ -1315,90 +1087,49 @@ DQMStore::bookProfile2D_(const std::string &dir, const std::string &name, TProfi
 /// Book 2-D profile.  Option is one of: " ", "s" (default), "i", "G"
 /// (see TProfile2D::BuildOptions).  The number of channels in Z is
 /// disregarded in a 2-D profile.
-MonitorElement *
-DQMStore::bookProfile2D(const char *name, const char *title,
-                        int nchX, double lowX, double highX,
-                        int nchY, double lowY, double highY,
-                        int /* nchZ */, double lowZ, double highZ,
-                        const char *option /* = "s" */)
+MonitorElement*
+DQMStore::bookProfile2D(TString const& name, TString const& title,
+                        int const nchX, double const lowX, double const highX,
+                        int const nchY, double const lowY, double const highY,
+                        int /* nchZ */, double const lowZ, double const highZ,
+                        char const* option /* = "s" */)
 {
-  return bookProfile2D_(pwd_, name, new TProfile2D(name, title,
-                                                  nchX, lowX, highX,
-                                                  nchY, lowY, highY,
-                                                  lowZ, highZ,
-                                                  option));
+  return bookProfile2D_(pwd_, name.Data(), new TProfile2D(name, title,
+                                                          nchX, lowX, highX,
+                                                          nchY, lowY, highY,
+                                                          lowZ, highZ,
+                                                          option));
 }
 
 /// Book 2-D profile.  Option is one of: " ", "s" (default), "i", "G"
 /// (see TProfile2D::BuildOptions).  The number of channels in Z is
 /// disregarded in a 2-D profile.
-MonitorElement *
-DQMStore::bookProfile2D(const std::string &name, const std::string &title,
-                        int nchX, double lowX, double highX,
-                        int nchY, double lowY, double highY,
-                        int /* nchZ */, double lowZ, double highZ,
-                        const char *option /* = "s" */)
+MonitorElement*
+DQMStore::bookProfile2D(TString const& name, TString const& title,
+                        int const nchX, double const lowX, double const highX,
+                        int const nchY, double const lowY, double const highY,
+                        double const lowZ, double const highZ,
+                        char const* option /* = "s" */)
 {
-  return bookProfile2D_(pwd_, name, new TProfile2D(name.c_str(), title.c_str(),
-                                                  nchX, lowX, highX,
-                                                  nchY, lowY, highY,
-                                                  lowZ, highZ,
-                                                  option));
-}
-
-/// Book 2-D profile.  Option is one of: " ", "s" (default), "i", "G"
-/// (see TProfile2D::BuildOptions).  The number of channels in Z is
-/// disregarded in a 2-D profile.
-MonitorElement *
-DQMStore::bookProfile2D(const char *name, const char *title,
-                        int nchX, double lowX, double highX,
-                        int nchY, double lowY, double highY,
-                        double lowZ, double highZ,
-                        const char *option /* = "s" */)
-{
-  return bookProfile2D_(pwd_, name, new TProfile2D(name, title,
-                                                  nchX, lowX, highX,
-                                                  nchY, lowY, highY,
-                                                  lowZ, highZ,
-                                                  option));
-}
-
-/// Book 2-D profile.  Option is one of: " ", "s" (default), "i", "G"
-/// (see TProfile2D::BuildOptions).  The number of channels in Z is
-/// disregarded in a 2-D profile.
-MonitorElement *
-DQMStore::bookProfile2D(const std::string &name, const std::string &title,
-                        int nchX, double lowX, double highX,
-                        int nchY, double lowY, double highY,
-                        double lowZ, double highZ,
-                        const char *option /* = "s" */)
-{
-  return bookProfile2D_(pwd_, name, new TProfile2D(name.c_str(), title.c_str(),
-                                                  nchX, lowX, highX,
-                                                  nchY, lowY, highY,
-                                                  lowZ, highZ,
-                                                  option));
+  return bookProfile2D_(pwd_, name.Data(), new TProfile2D(name, title,
+                                                          nchX, lowX, highX,
+                                                          nchY, lowY, highY,
+                                                          lowZ, highZ,
+                                                          option));
 }
 
 /// Book TProfile2D by cloning an existing profile.
-MonitorElement *
-DQMStore::bookProfile2D(const char *name, TProfile2D *source)
+MonitorElement*
+DQMStore::bookProfile2D(TString const& name, TProfile2D* source)
 {
-  return bookProfile2D_(pwd_, name, static_cast<TProfile2D *>(source->Clone(name)));
-}
-
-/// Book TProfile2D by cloning an existing profile.
-MonitorElement *
-DQMStore::bookProfile2D(const std::string &name, TProfile2D *source)
-{
-  return bookProfile2D_(pwd_, name, static_cast<TProfile2D *>(source->Clone(name.c_str())));
+  return bookProfile2D_(pwd_, name.Data(), static_cast<TProfile2D*>(source->Clone(name)));
 }
 
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
 bool
-DQMStore::checkBinningMatches(MonitorElement *me, TH1 *h, unsigned verbose)
+DQMStore::checkBinningMatches(MonitorElement* me, TH1* h, unsigned const verbose)
 {
   if (me->getTH1()->GetNbinsX() != h->GetNbinsX()
       || me->getTH1()->GetNbinsY() != h->GetNbinsY()
@@ -1411,8 +1142,7 @@ DQMStore::checkBinningMatches(MonitorElement *me, TH1 *h, unsigned verbose)
       || me->getTH1()->GetZaxis()->GetXmax() != h->GetZaxis()->GetXmax()
       || !MonitorElement::CheckBinLabels((TAxis*)me->getTH1()->GetXaxis(),(TAxis*)h->GetXaxis())
       || !MonitorElement::CheckBinLabels((TAxis*)me->getTH1()->GetYaxis(),(TAxis*)h->GetYaxis())
-      || !MonitorElement::CheckBinLabels((TAxis*)me->getTH1()->GetZaxis(),(TAxis*)h->GetZaxis()) )
-  {
+      || !MonitorElement::CheckBinLabels((TAxis*)me->getTH1()->GetZaxis(),(TAxis*)h->GetZaxis())) {
     if(verbose > 0)
       std::cout << "*** DQMStore: WARNING:"
                 << "checkBinningMatches: different binning - cannot add object '"
@@ -1425,70 +1155,68 @@ DQMStore::checkBinningMatches(MonitorElement *me, TH1 *h, unsigned verbose)
 }
 
 void
-DQMStore::collate1D(MonitorElement *me, TH1F *h, unsigned verbose)
+DQMStore::collate1D(MonitorElement* me, TH1F* h, unsigned const verbose)
 {
   if (checkBinningMatches(me,h,verbose))
     me->getTH1F()->Add(h);
 }
 
 void
-DQMStore::collate1S(MonitorElement *me, TH1S *h, unsigned verbose)
+DQMStore::collate1S(MonitorElement* me, TH1S* h, unsigned const verbose)
 {
   if (checkBinningMatches(me,h,verbose))
     me->getTH1S()->Add(h);
 }
 
 void
-DQMStore::collate1DD(MonitorElement *me, TH1D *h, unsigned verbose)
+DQMStore::collate1DD(MonitorElement* me, TH1D* h, unsigned const verbose)
 {
   if (checkBinningMatches(me,h,verbose))
     me->getTH1D()->Add(h);
 }
 
 void
-DQMStore::collate2D(MonitorElement *me, TH2F *h, unsigned verbose)
+DQMStore::collate2D(MonitorElement* me, TH2F* h, unsigned const verbose)
 {
   if (checkBinningMatches(me,h,verbose))
     me->getTH2F()->Add(h);
 }
 
 void
-DQMStore::collate2S(MonitorElement *me, TH2S *h, unsigned verbose)
+DQMStore::collate2S(MonitorElement* me, TH2S* h, unsigned const verbose)
 {
   if (checkBinningMatches(me,h,verbose))
     me->getTH2S()->Add(h);
 }
 
 void
-DQMStore::collate2DD(MonitorElement *me, TH2D *h, unsigned verbose)
+DQMStore::collate2DD(MonitorElement* me, TH2D* h, unsigned const verbose)
 {
   if (checkBinningMatches(me,h,verbose))
     me->getTH2D()->Add(h);
 }
 
 void
-DQMStore::collate3D(MonitorElement *me, TH3F *h, unsigned verbose)
+DQMStore::collate3D(MonitorElement* me, TH3F* h, unsigned const verbose)
 {
   if (checkBinningMatches(me,h,verbose))
     me->getTH3F()->Add(h);
 }
 
 void
-DQMStore::collateProfile(MonitorElement *me, TProfile *h, unsigned verbose)
+DQMStore::collateProfile(MonitorElement* me, TProfile* h, unsigned const verbose)
 {
-  if (checkBinningMatches(me,h,verbose))
-  {
-    TProfile *meh = me->getTProfile();
+  if (checkBinningMatches(me,h,verbose)) {
+    TProfile* meh = me->getTProfile();
     me->addProfiles(h, meh, meh, 1, 1);
   }
 }
 
 void
-DQMStore::collateProfile2D(MonitorElement *me, TProfile2D *h, unsigned verbose)
+DQMStore::collateProfile2D(MonitorElement* me, TProfile2D* h, unsigned const verbose)
 {
-  if (checkBinningMatches(me,h,verbose))
-  {
-    TProfile2D *meh = me->getTProfile2D();
+  if (checkBinningMatches(me,h,verbose)) {
+    TProfile2D* meh = me->getTProfile2D();
     me->addProfiles(h, meh, meh, 1, 1);
   }
 }
@@ -1498,7 +1226,7 @@ DQMStore::collateProfile2D(MonitorElement *me, TProfile2D *h, unsigned verbose)
 //////////////////////////////////////////////////////////////////////
 /// tag ME as <myTag> (myTag > 0)
 void
-DQMStore::tag(MonitorElement *me, unsigned int myTag)
+DQMStore::tag(MonitorElement* me, unsigned int const myTag)
 {
   if (! myTag)
     raiseDQMError("DQMStore", "Attempt to tag monitor element '%s'"
@@ -1513,13 +1241,13 @@ DQMStore::tag(MonitorElement *me, unsigned int myTag)
 
 /// tag ME specified by full pathname (e.g. "my/long/dir/my_histo")
 void
-DQMStore::tag(const std::string &path, unsigned int myTag)
+DQMStore::tag(std::string const& path, unsigned int const myTag)
 {
   std::string dir;
   std::string name;
   splitPath(dir, name, path);
 
-  if (MonitorElement *me = findObject(0, 0, 0, dir, name))
+  if (MonitorElement* me = findObject(0, 0, 0, dir, name))
     tag(me, myTag);
   else
     raiseDQMError("DQMStore", "Attempt to tag non-existent monitor element"
@@ -1529,7 +1257,7 @@ DQMStore::tag(const std::string &path, unsigned int myTag)
 
 /// tag all children of folder (does NOT include subfolders)
 void
-DQMStore::tagContents(const std::string &path, unsigned int myTag)
+DQMStore::tagContents(std::string const& path, unsigned int const myTag)
 {
   KeyObject const proto{&path, empty_str};
   auto e = data_.end();
@@ -1541,18 +1269,17 @@ DQMStore::tagContents(const std::string &path, unsigned int myTag)
 /// tag all children of folder, including all subfolders and their children;
 /// path must be an exact path name
 void
-DQMStore::tagAllContents(const std::string &path, unsigned int myTag)
+DQMStore::tagAllContents(std::string const& path, unsigned int const myTag)
 {
   std::string clean;
-  const std::string *cleaned = nullptr;
+  std::string const* cleaned = nullptr;
   cleanTrailingSlashes(path, clean, cleaned);
   KeyObject const proto{cleaned, empty_str};
 
   // FIXME: WILDCARDS? Old one supported them, but nobody seemed to use them.
   auto e = data_.end();
   auto i = data_.lower_bound(proto);
-  while (i != e && isSubdirectory(*cleaned, *i->second.data_.dirname))
-  {
+  while (i != e && isSubdirectory(*cleaned, *i->second.data_.dirname)) {
     tag(&i->second, myTag);
     ++i;
   }
@@ -1602,7 +1329,7 @@ DQMStore::getMEs() const
 /// true if directory (or any subfolder at any level below it) contains
 /// at least one monitorable element
 bool
-DQMStore::containsAnyMonitorable(const std::string &path) const
+DQMStore::containsAnyMonitorable(std::string const& path) const
 {
   KeyObject const proto{&path, empty_str};
   auto e = data_.end();
@@ -1611,8 +1338,8 @@ DQMStore::containsAnyMonitorable(const std::string &path) const
 }
 
 /// get ME from full pathname (e.g. "my/long/dir/my_histo")
-MonitorElement *
-DQMStore::get(const std::string &path) const
+MonitorElement*
+DQMStore::get(std::string const& path) const
 {
   std::string dir;
   std::string name;
@@ -1624,31 +1351,31 @@ DQMStore::get(const std::string &path) const
 }
 
 /// get all MonitorElements tagged as <tag>
-std::vector<MonitorElement *>
-DQMStore::get(unsigned int tag) const
+std::vector<MonitorElement*>
+DQMStore::get(unsigned int const tag) const
 {
   // FIXME: Use reverse map [tag -> path] / [tag -> dir]?
-  std::vector<MonitorElement *> result;
+  std::vector<MonitorElement*> result;
   for (auto const& pr : data_)
-  {
-    auto const& me = pr.second;
-    if ((me.data_.flags & DQMNet::DQM_PROP_TAGGED) && me.data_.tag == tag)
-      result.push_back(const_cast<MonitorElement *>(&me));
-  }
+    {
+      auto const& me = pr.second;
+      if ((me.data_.flags & DQMNet::DQM_PROP_TAGGED) && me.data_.tag == tag)
+        result.push_back(const_cast<MonitorElement*>(&me));
+    }
   return result;
 }
 
 /// get vector with all children of folder
 /// (does NOT include contents of subfolders)
-std::vector<MonitorElement *>
-DQMStore::getContents(const std::string &path) const
+std::vector<MonitorElement*>
+DQMStore::getContents(std::string const& path) const
 {
   std::string clean;
-  const std::string *cleaned = nullptr;
+  std::string const* cleaned = nullptr;
   cleanTrailingSlashes(path, clean, cleaned);
   KeyObject const proto{cleaned, empty_str};
 
-  std::vector<MonitorElement *> result;
+  std::vector<MonitorElement*> result;
   auto e = data_.end();
   auto i = data_.lower_bound(proto);
   for ( ; i != e && isSubdirectory(*cleaned, *i->second.data_.dirname); ++i)
@@ -1659,15 +1386,15 @@ DQMStore::getContents(const std::string &path) const
 }
 
 /// same as above for tagged MonitorElements
-std::vector<MonitorElement *>
-DQMStore::getContents(const std::string &path, unsigned int tag) const
+std::vector<MonitorElement*>
+DQMStore::getContents(std::string const& path, unsigned int const tag) const
 {
   std::string clean;
-  const std::string *cleaned = nullptr;
+  std::string const* cleaned = nullptr;
   cleanTrailingSlashes(path, clean, cleaned);
   KeyObject const proto{cleaned, empty_str};
 
-  std::vector<MonitorElement *> result;
+  std::vector<MonitorElement*> result;
   auto e = data_.end();
   auto i = data_.lower_bound(proto);
   for ( ; i != e && isSubdirectory(*cleaned, *i->second.data_.dirname); ++i)
@@ -1684,7 +1411,7 @@ DQMStore::getContents(const std::string &path, unsigned int tag) const
 /// if showContents = false, change form to <dir pathname>:
 /// (useful for subscription requests; meant to imply "all contents")
 void
-DQMStore::getContents(std::vector<std::string> &into, bool showContents /* = true */) const
+DQMStore::getContents(std::vector<std::string>& into, bool const showContents /* = true */) const
 {
   std::vector<std::string> result;
   result.reserve(dirs_.size());
@@ -1735,12 +1462,12 @@ DQMStore::getContents(std::vector<std::string> &into, bool showContents /* = tru
 
 /// get MonitorElement <name> in directory <dir>
 /// (null if MonitorElement does not exist)
-MonitorElement *
-DQMStore::findObject(const uint32_t run,
-                     const uint32_t lumi,
-                     const uint32_t moduleId,
-                     const std::string &dir,
-                     const std::string &name) const
+MonitorElement*
+DQMStore::findObject(uint32_t const run,
+                     uint32_t const lumi,
+                     uint32_t const moduleId,
+                     std::string const& dir,
+                     std::string const& name) const
 {
   if (dir.find_first_not_of(s_safe) != std::string::npos)
     raiseDQMError("DQMStore", "Monitor element path name '%s' uses"
@@ -1758,17 +1485,17 @@ DQMStore::findObject(const uint32_t run,
 /// get vector with children of folder, including all subfolders + their children;
 /// must use an exact pathname
 std::vector<MonitorElement*>
-DQMStore::getAllContents(const std::string &path,
-                         uint32_t run  /* = 0 */,
-                         uint32_t lumi /* = 0 */) const
+DQMStore::getAllContents(std::string const& path,
+                         uint32_t const run  /* = 0 */,
+                         uint32_t const lumi /* = 0 */) const
 {
   std::string clean;
-  const std::string *cleaned = nullptr;
+  std::string const* cleaned = nullptr;
   cleanTrailingSlashes(path, clean, cleaned);
 
   KeyObject const proto{cleaned, empty_str, run, lumi, 0};
 
-  std::vector<MonitorElement *> result;
+  std::vector<MonitorElement*> result;
   auto e = data_.end();
   auto i = data_.lower_bound(proto);
   for ( ; i != e && isSubdirectory(*cleaned, *i->second.data_.dirname); ++i) {
@@ -1789,17 +1516,16 @@ DQMStore::getAllContents(const std::string &path,
     result.push_back(const_cast<MonitorElement*>(&me));
   }
 
-  if (enableMultiThread_)
-    {
-      //save legacy modules when running MT
-      i = data_.begin();
-      for ( ; i != e && isSubdirectory(*cleaned, *i->second.data_.dirname); ++i) {
-        auto const& me = i->second;
-        if (me.data_.run != 0 or me.data_.moduleId != 0)
-          break;
-        result.push_back(const_cast<MonitorElement*>(&me));
-      }
+  if (enableMultiThread_) {
+    //save legacy modules when running MT
+    i = data_.begin();
+    for ( ; i != e && isSubdirectory(*cleaned, *i->second.data_.dirname); ++i) {
+      auto const& me = i->second;
+      if (me.data_.run != 0 or me.data_.moduleId != 0)
+        break;
+      result.push_back(const_cast<MonitorElement*>(&me));
     }
+  }
 
   return result;
 }
@@ -1807,29 +1533,26 @@ DQMStore::getAllContents(const std::string &path,
 /// get vector with children of folder, including all subfolders + their children;
 /// matches names against a wildcard pattern matched against the full ME path
 std::vector<MonitorElement*>
-DQMStore::getMatchingContents(const std::string &pattern, lat::Regexp::Syntax syntaxType /* = Wildcard */) const
+DQMStore::getMatchingContents(std::string const& pattern, lat::Regexp::Syntax const syntaxType /* = Wildcard */) const
 {
   lat::Regexp rx;
-  try
-  {
+  try {
     rx = lat::Regexp(pattern, 0, syntaxType);
     rx.study();
   }
-  catch (lat::Error &e)
-  {
+  catch (lat::Error& e) {
     raiseDQMError("DQMStore", "Invalid regular expression '%s': %s",
                   pattern.c_str(), e.explain().c_str());
   }
 
   std::string path;
-  std::vector<MonitorElement *> result;
-  for (auto const& pr : data_)
-  {
+  std::vector<MonitorElement*> result;
+  for (auto const& pr : data_) {
     auto const& me = pr.second;
     path.clear();
     mergePath(path, *me.data_.dirname, me.data_.objname);
     if (rx.match(path))
-      result.push_back(const_cast<MonitorElement *>(&me));
+      result.push_back(const_cast<MonitorElement*>(&me));
   }
 
   return result;
@@ -1844,11 +1567,9 @@ DQMStore::getMatchingContents(const std::string &pattern, lat::Regexp::Syntax sy
 void
 DQMStore::reset()
 {
-  for (auto& pr : data_)
-  {
+  for (auto& pr : data_) {
     auto& me = pr.second;
-    if (me.wasUpdated())
-    {
+    if (me.wasUpdated()) {
       if (me.resetMe())
         me.Reset();
       me.resetUpdate();
@@ -1866,8 +1587,7 @@ DQMStore::reset()
 void
 DQMStore::forceReset()
 {
-  for (auto& pr : data_)
-  {
+  for (auto& pr : data_) {
     auto& me = pr.second;
     if (forceResetOnBeginLumi_ && (me.getLumiFlag() == false))
       continue;
@@ -1887,7 +1607,7 @@ DQMStore::forceReset()
  * they can be reused.
  */
 void
-DQMStore::postGlobalBeginLumi(const edm::GlobalContext &gc)
+DQMStore::postGlobalBeginLumi(edm::GlobalContext const& gc)
 {
   auto const& lumiblock = gc.luminosityBlockID();
   uint32_t run = lumiblock.run();
@@ -1919,7 +1639,7 @@ DQMStore::postGlobalBeginLumi(const edm::GlobalContext &gc)
  */
 
 void
-DQMStore::cloneLumiHistograms(uint32_t run, uint32_t lumi, uint32_t moduleId)
+DQMStore::cloneLumiHistograms(uint32_t const run, uint32_t const lumi, uint32_t const moduleId)
 {
   if (verbose_ > 1) {
     std::cout << "DQMStore::cloneLumiHistograms - Preparing lumi histograms for run: "
@@ -1957,7 +1677,7 @@ DQMStore::cloneLumiHistograms(uint32_t run, uint32_t lumi, uint32_t moduleId)
  */
 
 void
-DQMStore::cloneRunHistograms(uint32_t run, uint32_t moduleId)
+DQMStore::cloneRunHistograms(uint32_t const run, uint32_t const moduleId)
 {
   if (verbose_ > 1) {
     std::cout << "DQMStore::cloneRunHistograms - Preparing run histograms for run: "
@@ -1996,7 +1716,7 @@ DQMStore::cloneRunHistograms(uint32_t run, uint32_t moduleId)
  * deleted after the last globalEndLuminosityBlock.
  */
 void
-DQMStore::deleteUnusedLumiHistograms(uint32_t run, uint32_t lumi)
+DQMStore::deleteUnusedLumiHistograms(uint32_t const run, uint32_t const lumi)
 {
   if (!enableMultiThread_)
     return;
@@ -2037,129 +1757,117 @@ DQMStore::deleteUnusedLumiHistograms(uint32_t run, uint32_t lumi)
 /// extract object (TH1F, TH2F, ...) from <to>; return success flag
 /// flag fromRemoteNode indicating if ME arrived from different node
 bool
-DQMStore::extract(TObject *obj, const std::string &dir,
-  bool overwrite, bool collateHistograms)
+DQMStore::extract(TObject* obj,
+                  std::string const& dir,
+                  bool const overwrite,
+                  bool const collateHistograms)
 {
   // NB: Profile histograms inherit from TH*D, checking order matters.
   MonitorElement *refcheck = nullptr;
-  if (auto *h = dynamic_cast<TProfile *>(obj))
-  {
-    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
+  if (auto* h = dynamic_cast<TProfile*>(obj)) {
+    MonitorElement* me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
-      me = bookProfile_(dir, h->GetName(), (TProfile *) h->Clone());
+      me = bookProfile_(dir, h->GetName(), (TProfile*) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collateProfile(me, h, verbose_);
     refcheck = me;
   }
-  else if (auto *h = dynamic_cast<TProfile2D *>(obj))
-  {
-    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
+  else if (auto* h = dynamic_cast<TProfile2D*>(obj)) {
+    MonitorElement* me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
-      me = bookProfile2D_(dir, h->GetName(), (TProfile2D *) h->Clone());
+      me = bookProfile2D_(dir, h->GetName(), (TProfile2D*) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collateProfile2D(me, h, verbose_);
     refcheck = me;
   }
-  else if (auto *h = dynamic_cast<TH1F *>(obj))
-  {
-    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
+  else if (auto* h = dynamic_cast<TH1F*>(obj)) {
+    MonitorElement* me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
-      me = book1D_(dir, h->GetName(), (TH1F *) h->Clone());
+      me = book1D_(dir, h->GetName(), (TH1F*) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate1D(me, h, verbose_);
     refcheck = me;
   }
-  else if (auto *h = dynamic_cast<TH1S *>(obj))
-  {
-    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
+  else if (auto* h = dynamic_cast<TH1S*>(obj)) {
+    MonitorElement* me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
-      me = book1S_(dir, h->GetName(), (TH1S *) h->Clone());
+      me = book1S_(dir, h->GetName(), (TH1S*) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate1S(me, h, verbose_);
     refcheck = me;
   }
-  else if (auto *h = dynamic_cast<TH1D *>(obj))
-  {
-    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
+  else if (auto* h = dynamic_cast<TH1D*>(obj)) {
+    MonitorElement* me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
-      me = book1DD_(dir, h->GetName(), (TH1D *) h->Clone());
+      me = book1DD_(dir, h->GetName(), (TH1D*) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate1DD(me, h, verbose_);
     refcheck = me;
   }
-  else if (auto *h = dynamic_cast<TH2F *>(obj))
-  {
-    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
+  else if (auto* h = dynamic_cast<TH2F*>(obj)) {
+    MonitorElement* me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
-      me = book2D_(dir, h->GetName(), (TH2F *) h->Clone());
+      me = book2D_(dir, h->GetName(), (TH2F*) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate2D(me, h, verbose_);
     refcheck = me;
   }
-  else if (auto *h = dynamic_cast<TH2S *>(obj))
-  {
-    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
+  else if (auto* h = dynamic_cast<TH2S*>(obj)) {
+    MonitorElement* me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
-      me = book2S_(dir, h->GetName(), (TH2S *) h->Clone());
+      me = book2S_(dir, h->GetName(), (TH2S*) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate2S(me, h, verbose_);
     refcheck = me;
   }
-  else if (auto *h = dynamic_cast<TH2D *>(obj))
-  {
-    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
+  else if (auto* h = dynamic_cast<TH2D*>(obj)) {
+    MonitorElement* me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
-      me = book2DD_(dir, h->GetName(), (TH2D *) h->Clone());
+      me = book2DD_(dir, h->GetName(), (TH2D*) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate2DD(me, h, verbose_);
     refcheck = me;
   }
-  else if (auto *h = dynamic_cast<TH3F *>(obj))
-  {
-    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
+  else if (auto* h = dynamic_cast<TH3F*>(obj)) {
+    MonitorElement* me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
-      me = book3D_(dir, h->GetName(), (TH3F *) h->Clone());
+      me = book3D_(dir, h->GetName(), (TH3F*) h->Clone());
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate3D(me, h, verbose_);
     refcheck = me;
   }
-  else if (dynamic_cast<TObjString *>(obj))
-  {
+  else if (dynamic_cast<TObjString*>(obj)) {
     lat::RegexpMatch m;
-    if (! s_rxmeval.match(obj->GetName(), 0, 0, &m))
-    {
-      if (strstr(obj->GetName(), "CMSSW"))
-      {
+    if (! s_rxmeval.match(obj->GetName(), 0, 0, &m)) {
+      if (strstr(obj->GetName(), "CMSSW")) {
         if (verbose_)
           std::cout << "Input file version: " << obj->GetName() << std::endl;
         return true;
       }
-      else if (strstr(obj->GetName(), "DQMPATCH"))
-      {
+      else if (strstr(obj->GetName(), "DQMPATCH")) {
         if (verbose_)
           std::cout << "DQM patch version: " << obj->GetName() << std::endl;
         return true;
       }
-      else
-      {
+      else {
         std::cout << "*** DQMStore: WARNING: cannot extract object '"
                   << obj->GetName() << "' of type '"
                   << obj->IsA()->GetName() << "'\n";
@@ -2171,37 +1879,30 @@ DQMStore::extract(TObject *obj, const std::string &dir,
     std::string kind = m.matchString(obj->GetName(), 2);
     std::string value = m.matchString(obj->GetName(), 3);
 
-    if (kind == "i")
-    {
-      MonitorElement *me = findObject(0, 0, 0, dir, label);
-      if (! me || overwrite)
-      {
+    if (kind == "i") {
+      MonitorElement* me = findObject(0, 0, 0, dir, label);
+      if (! me || overwrite) {
         if (! me) me = bookInt_(dir, label);
         me->Fill(atoll(value.c_str()));
       }
     }
-    else if (kind == "f")
-    {
-      MonitorElement *me = findObject(0, 0, 0, dir, label);
-      if (! me || overwrite)
-      {
+    else if (kind == "f") {
+      MonitorElement* me = findObject(0, 0, 0, dir, label);
+      if (! me || overwrite) {
         if (! me) me = bookFloat_(dir, label);
         me->Fill(atof(value.c_str()));
       }
     }
-    else if (kind == "s")
-    {
-      MonitorElement *me = findObject(0, 0, 0, dir, label);
+    else if (kind == "s") {
+      MonitorElement* me = findObject(0, 0, 0, dir, label);
       if (! me)
         me = bookString_(dir, label, value);
       else if (overwrite)
         me->Fill(value);
     }
-    else if (kind == "e")
-    {
-      MonitorElement *me = findObject(0, 0, 0, dir, label);
-      if (! me)
-      {
+    else if (kind == "e") {
+      MonitorElement* me = findObject(0, 0, 0, dir, label);
+      if (! me) {
         std::cout << "*** DQMStore: WARNING: no monitor element '"
                   << label << "' in directory '"
                   << dir << "' to be marked as efficiency plot.\n";
@@ -2209,21 +1910,18 @@ DQMStore::extract(TObject *obj, const std::string &dir,
       }
       me->setEfficiencyFlag();
     }
-    else if (kind == "t")
-    {
-      MonitorElement *me = findObject(0, 0, 0, dir, label);
-      if (! me)
-      {
+    else if (kind == "t") {
+      MonitorElement* me = findObject(0, 0, 0, dir, label);
+      if (! me) {
         std::cout << "*** DQMStore: WARNING: no monitor element '"
                   << label << "' in directory '"
                   << dir << "' for a tag\n";
         return false;
       }
       errno = 0;
-      char *endp = nullptr;
+      char* endp = nullptr;
       unsigned long val = strtoul(value.c_str(), &endp, 10);
-      if ((val == 0 && errno) || *endp || val > ~uint32_t(0))
-      {
+      if ((val == 0 && errno) || *endp || val > ~uint32_t(0)) {
         std::cout << "*** DQMStore: WARNING: cannot restore tag '"
                   << value << "' for monitor element '"
                   << label << "' in directory '"
@@ -2232,14 +1930,11 @@ DQMStore::extract(TObject *obj, const std::string &dir,
       }
       tag(me, val);
     }
-    else if (kind == "qr")
-    {
+    else if (kind == "qr") {
       // Handle qreports, but skip them while reading in references.
-      if (! isSubdirectory(s_referenceDirName, dir))
-      {
+      if (! isSubdirectory(s_referenceDirName, dir)) {
         size_t dot = label.find('.');
-        if (dot == std::string::npos)
-        {
+        if (dot == std::string::npos) {
           std::cout << "*** DQMStore: WARNING: quality report label in '" << label
                     << "' is missing a '.' and cannot be extracted\n";
           return false;
@@ -2250,32 +1945,28 @@ DQMStore::extract(TObject *obj, const std::string &dir,
 
         m.reset();
         DQMNet::QValue qv;
-        if (s_rxmeqr1.match(value, 0, 0, &m))
-        {
+        if (s_rxmeqr1.match(value, 0, 0, &m)) {
           qv.code = atoi(m.matchString(value, 1).c_str());
           qv.qtresult = strtod(m.matchString(value, 2).c_str(), nullptr);
           qv.message = m.matchString(value, 4);
           qv.qtname = qrname;
           qv.algorithm = m.matchString(value, 3);
         }
-        else if (s_rxmeqr2.match(value, 0, 0, &m))
-        {
+        else if (s_rxmeqr2.match(value, 0, 0, &m)) {
           qv.code = atoi(m.matchString(value, 1).c_str());
           qv.qtresult = 0; // unavailable in old format
           qv.message = m.matchString(value, 2);
           qv.qtname = qrname;
           // qv.algorithm unavailable in old format
         }
-        else
-        {
+        else {
           std::cout << "*** DQMStore: WARNING: quality test value '"
                     << value << "' is incorrectly formatted\n";
           return false;
         }
 
-        MonitorElement *me = findObject(0, 0, 0, dir, mename);
-        if (! me)
-        {
+        MonitorElement* me = findObject(0, 0, 0, dir, mename);
+        if (! me) {
           std::cout << "*** DQMStore: WARNING: no monitor element '"
                     << mename << "' in directory '"
                     << dir << "' for quality test '"
@@ -2286,16 +1977,14 @@ DQMStore::extract(TObject *obj, const std::string &dir,
         me->addQReport(qv, /* FIXME: getQTest(qv.qtname)? */ nullptr);
       }
     }
-    else
-    {
+    else {
       std::cout << "*** DQMStore: WARNING: cannot extract object '"
                 << obj->GetName() << "' of type '"
                 << obj->IsA()->GetName() << "'\n";
       return false;
     }
   }
-  else if (auto *n = dynamic_cast<TNamed *>(obj))
-  {
+  else if (auto* n = dynamic_cast<TNamed*>(obj)) {
     // For old DQM data.
     std::string s;
     s.reserve(6 + strlen(n->GetTitle()) + 2*strlen(n->GetName()));
@@ -2305,8 +1994,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
     TObjString os(s.c_str());
     return extract(&os, dir, overwrite, collateHistograms_);
   }
-  else
-  {
+  else {
     std::cout << "*** DQMStore: WARNING: cannot extract object '"
               << obj->GetName() << "' of type '" << obj->IsA()->GetName()
               << "' and with title '" << obj->GetTitle() << "'\n";
@@ -2316,11 +2004,9 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   // If we just read in a reference MonitorElement, and there is a
   // MonitorElement with the same name, link the two together.
   // The other direction is handled by the book() method.
-  if (refcheck && isSubdirectory(s_referenceDirName, dir))
-  {
+  if (refcheck && isSubdirectory(s_referenceDirName, dir)) {
     std::string mdir(dir, s_referenceDirName.size()+1, std::string::npos);
-    if (MonitorElement *master = findObject(0, 0, 0, mdir, obj->GetName()))
-    {
+    if (MonitorElement* master = findObject(0, 0, 0, mdir, obj->GetName())) {
       // We have extracted a MonitorElement, and it's located in the reference
       // dir. Then we find the corresponding MonitorElement in the
       // non-reference dir and assign the object_ of the reference
@@ -2338,7 +2024,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
 /// cd into directory (create first if it doesn't exist);
 /// returns success flag
 bool
-DQMStore::cdInto(const std::string &path) const
+DQMStore::cdInto(std::string const& path) const
 {
   assert(! path.empty());
 
@@ -2348,13 +2034,12 @@ DQMStore::cdInto(const std::string &path) const
   if (end == std::string::npos)
     end = path.size();
 
-  while (true)
-  {
+  while (true) {
     // Check if this subdirectory component exists.  If yes, make sure
     // it is actually a subdirectory.  Otherwise create or cd into it.
     std::string part(path, start, end-start);
-    TObject *o = gDirectory->Get(part.c_str());
-    if (o && ! dynamic_cast<TDirectory *>(o))
+    TObject* o = gDirectory->Get(part.c_str());
+    if (o && ! dynamic_cast<TDirectory*>(o))
       raiseDQMError("DQMStore", "Attempt to create directory '%s' in a file"
                     " fails because the part '%s' already exists and is not"
                     " directory", path.c_str(), part.c_str());
@@ -2381,9 +2066,8 @@ DQMStore::cdInto(const std::string &path) const
 }
 
 void
-DQMStore::saveMonitorElementToROOT(
-    MonitorElement const& me,
-    TFile & file)
+DQMStore::saveMonitorElementToROOT(MonitorElement const& me,
+                                   TFile& file)
 {
   // Save the object.
   if (me.kind() < MonitorElement::DQM_KIND_TH1F) {
@@ -2393,8 +2077,7 @@ DQMStore::saveMonitorElementToROOT(
   }
 
   // Save quality reports if this is not in reference section.
-  if (not isSubdirectory(s_referenceDirName, *me.data_.dirname))
-  {
+  if (not isSubdirectory(s_referenceDirName, *me.data_.dirname)) {
     for (auto const& report: me.data_.qreports) {
       TObjString(me.qualityTagString(report).c_str()).Write();
     }
@@ -2412,19 +2095,17 @@ DQMStore::saveMonitorElementToROOT(
 }
 
 void
-DQMStore::saveMonitorElementRangeToROOT(
-    std::string const& dir,
-    std::string const& refpath,
-    SaveReferenceTag ref,
-    int minStatus,
-    unsigned int run,
-    MEMap::const_iterator begin,
-    MEMap::const_iterator end,
-    TFile & file,
-    unsigned int & counter)
+DQMStore::saveMonitorElementRangeToROOT(std::string const& dir,
+                                        std::string const& refpath,
+                                        SaveReferenceTag const ref,
+                                        int const minStatus,
+                                        unsigned int const run,
+                                        MEMap::const_iterator const begin,
+                                        MEMap::const_iterator const end,
+                                        TFile& file,
+                                        unsigned int& counter)
 {
-  for (auto const& pr: boost::make_iterator_range(begin, end))
-  {
+  for (auto const& pr: boost::make_iterator_range(begin, end)) {
     auto const& me = pr.second;
     if (not isSubdirectory(dir, *me.data_.dirname))
       break;
@@ -2453,27 +2134,24 @@ DQMStore::saveMonitorElementRangeToROOT(
     // 3) Save only references for monitor elements with qtests.
     // The latter two are affected by "path" sub-tree selection,
     // i.e. references are saved only in the selected tree part.
-    if (isSubdirectory(refpath, *me.data_.dirname))
-    {
+    if (isSubdirectory(refpath, *me.data_.dirname)) {
       if (ref == SaveWithoutReference)
         // Skip the reference entirely.
         continue;
       else if (ref == SaveWithReference)
         // Save all references regardless of qtests.
         ;
-      else if (ref == SaveWithReferenceForQTest)
-      {
+      else if (ref == SaveWithReferenceForQTest) {
         // Save only references for monitor elements with qtests
         // with an optional cut on minimum quality test result.
         int status = -1;
         std::string mname(me.getFullname(), s_referenceDirName.size()+1, std::string::npos);
-        MonitorElement *master = get(mname);
+        MonitorElement* master = get(mname);
         if (master)
           for (auto const& qreport : master->data_.qreports)
             status = std::max(status, qreport.code);
 
-        if (not master or status < minStatus)
-        {
+        if (not master or status < minStatus) {
           if (verbose_ > 1)
             std::cout << "DQMStore::save: skipping monitor element '"
                       << me.data_.objname << "' while saving, status is "
@@ -2498,25 +2176,24 @@ DQMStore::saveMonitorElementRangeToROOT(
 /// save directory with monitoring objects into protobuf file <filename>;
 /// if directory="", save full monitoring structure
 void
-DQMStore::save(const std::string &filename,
-               const std::string &path /* = "" */,
-               const std::string &pattern /* = "" */,
-               const std::string &rewrite /* = "" */,
-               const uint32_t run /* = 0 */,
-               const uint32_t lumi /* = 0 */,
-               SaveReferenceTag ref /* = SaveWithReference */,
-               int minStatus /* = dqm::qstatus::STATUS_OK */,
-               const std::string &fileupdate /* = RECREATE */)
+DQMStore::save(std::string const& filename,
+               std::string const& path /* = "" */,
+               std::string const& pattern /* = "" */,
+               std::string const& rewrite /* = "" */,
+               uint32_t const run /* = 0 */,
+               uint32_t const lumi /* = 0 */,
+               SaveReferenceTag const ref /* = SaveWithReference */,
+               int const minStatus /* = dqm::qstatus::STATUS_OK */,
+               std::string const& fileupdate /* = RECREATE */)
 {
   // TFile flushes to disk with fsync() on every TDirectory written to
   // the file.  This makes DQM file saving painfully slow, and
   // ironically makes it _more_ likely the file saving gets
   // interrupted and corrupts the file.  The utility class below
   // simply ignores the flush synchronisation.
-  class TFileNoSync : public TFile
-  {
+  class TFileNoSync : public TFile {
   public:
-    TFileNoSync(const char *file, const char *opt) : TFile(file, opt) {}
+    TFileNoSync(char const* file, char const* opt) : TFile{file, opt} {}
     Int_t SysSync(Int_t) override { return 0; }
   };
 
@@ -2545,15 +2222,13 @@ DQMStore::save(const std::string &filename,
   std::string refpath;
   refpath.reserve(s_referenceDirName.size() + path.size() + 2);
   refpath += s_referenceDirName;
-  if (not path.empty())
-  {
+  if (not path.empty()) {
     refpath += '/';
     refpath += path;
   }
 
   // Loop over the directory structure.
-  for (auto const& dir: dirs_)
-  {
+  for (auto const& dir: dirs_) {
     // Check if we should process this directory.  We process the
     // requested part of the object tree, including references.
     if (not path.empty()
@@ -2609,9 +2284,8 @@ DQMStore::save(const std::string &filename,
 }
 
 void
-DQMStore::saveMonitorElementToPB(
-    MonitorElement const& me,
-    dqmstorepb::ROOTFilePB & file)
+DQMStore::saveMonitorElementToPB(MonitorElement const& me,
+                                 dqmstorepb::ROOTFilePB& file)
 {
   // Save the object.
   TBufferFile buffer(TBufferFile::kWrite);
@@ -2625,7 +2299,7 @@ DQMStore::saveMonitorElementToPB(
   histo.set_full_pathname(*me.data_.dirname + '/' + me.data_.objname);
   histo.set_flags(me.data_.flags);
   histo.set_size(buffer.Length());
-  histo.set_streamed_histo((const void*)buffer.Buffer(), buffer.Length());
+  histo.set_streamed_histo((void const*)buffer.Buffer(), buffer.Length());
 
   // Save quality reports if this is not in reference section.
   // XXX not supported by protobuf files.
@@ -2638,16 +2312,14 @@ DQMStore::saveMonitorElementToPB(
 }
 
 void
-DQMStore::saveMonitorElementRangeToPB(
-    std::string const& dir,
-    unsigned int run,
-    MEMap::const_iterator begin,
-    MEMap::const_iterator end,
-    dqmstorepb::ROOTFilePB & file,
-    unsigned int & counter)
+DQMStore::saveMonitorElementRangeToPB(std::string const& dir,
+                                      unsigned int const run,
+                                      MEMap::const_iterator const begin,
+                                      MEMap::const_iterator const end,
+                                      dqmstorepb::ROOTFilePB& file,
+                                      unsigned int& counter)
 {
-  for (auto const& pr: boost::make_iterator_range(begin, end))
-  {
+  for (auto const& pr: boost::make_iterator_range(begin, end)) {
     auto const& me = pr.second;
     if (not isSubdirectory(dir, *me.data_.dirname))
       break;
@@ -2687,10 +2359,10 @@ DQMStore::saveMonitorElementRangeToPB(
 /// save directory with monitoring objects into protobuf file <filename>;
 /// if directory="", save full monitoring structure
 void
-DQMStore::savePB(const std::string &filename,
-                 const std::string &path /* = "" */,
-                 const uint32_t run /* = 0 */,
-                 const uint32_t lumi /* = 0 */)
+DQMStore::savePB(std::string const& filename,
+                 std::string const& path /* = "" */,
+                 uint32_t const run /* = 0 */,
+                 uint32_t const lumi /* = 0 */)
 {
   using google::protobuf::io::FileOutputStream;
   using google::protobuf::io::GzipOutputStream;
@@ -2707,8 +2379,7 @@ DQMStore::savePB(const std::string &filename,
   dqmstorepb::ROOTFilePB dqmstore_message;
 
   // Loop over the directory structure.
-  for (auto const& dir: dirs_)
-  {
+  for (auto const& dir: dirs_) {
     // Check if we should process this directory.  We process the
     // requested part of the object tree, including references.
     if (not path.empty()
@@ -2772,12 +2443,12 @@ DQMStore::savePB(const std::string &filename,
 /// read ROOT objects from file <file> in directory <onlypath>;
 /// return total # of ROOT objects read
 unsigned int
-DQMStore::readDirectory(TFile *file,
-                        bool overwrite,
-                        const std::string &onlypath,
-                        const std::string &prepend,
-                        const std::string &curdir,
-                        OpenRunDirs stripdirs)
+DQMStore::readDirectory(TFile* file,
+                        bool const overwrite,
+                        std::string const& onlypath,
+                        std::string const& prepend,
+                        std::string const& curdir,
+                        OpenRunDirs const stripdirs)
 {
   unsigned int ntot = 0;
   unsigned int count = 0;
@@ -2789,8 +2460,7 @@ DQMStore::readDirectory(TFile *file,
   // Figure out current directory name, but strip out the top
   // directory into which we dump everything.
   std::string dirpart = curdir;
-  if (dirpart.compare(0, s_monitorDirName.size(), s_monitorDirName) == 0)
-  {
+  if (dirpart.compare(0, s_monitorDirName.size(), s_monitorDirName) == 0) {
     if (dirpart.size() == s_monitorDirName.size())
       dirpart.clear();
     else if (dirpart[s_monitorDirName.size()] == '/')
@@ -2802,15 +2472,13 @@ DQMStore::readDirectory(TFile *file,
 
   if (prepend == s_collateDirName ||
       prepend == s_referenceDirName ||
-      stripdirs == StripRunDirs )
-  {
+      stripdirs == StripRunDirs ) {
     // Remove Run # and RunSummary dirs
     // first look for Run summary,
     // if that is found and erased, also erase Run dir
     size_t slash = dirpart.find('/');
     size_t pos = dirpart.find("/Run summary");
-    if (slash != std::string::npos && pos !=std::string::npos)
-    {
+    if (slash != std::string::npos && pos !=std::string::npos) {
       dirpart.erase(pos,12);
 
       pos = dirpart.find("Run ");
@@ -2823,8 +2491,7 @@ DQMStore::readDirectory(TFile *file,
   // If we are prepending, add it to the directory name,
   // and suppress reading of already existing reference histograms
   if (prepend == s_collateDirName ||
-      prepend == s_referenceDirName)
-  {
+      prepend == s_referenceDirName) {
     size_t slash = dirpart.find('/');
     // If we are reading reference, skip previous reference.
     if (slash == std::string::npos   // skip if Reference is toplevel folder, i.e. no slash
@@ -2848,8 +2515,7 @@ DQMStore::readDirectory(TFile *file,
     else
       dirpart = prepend + '/' + dirpart;
   }
-  else if (! prepend.empty())
-  {
+  else if (! prepend.empty()) {
     if (dirpart.empty())
       dirpart = prepend;
     else
@@ -2860,45 +2526,41 @@ DQMStore::readDirectory(TFile *file,
   // Post-pone string object handling to happen after other
   // objects have been read in so we are guaranteed to have
   // histograms by the time we read in quality tests and tags.
-  TKey *key;
+  TKey* key;
   TIter next (gDirectory->GetListOfKeys());
-  std::list<TObject *> delayed;
-  while ((key = (TKey *) next()))
-  {
-    std::unique_ptr<TObject> obj(key->ReadObj());
-    if (dynamic_cast<TDirectory *>(obj.get()))
+  std::list<TObject*> delayed;
+  while ((key = (TKey*) next()))
     {
-      std::string subdir;
-      subdir.reserve(curdir.size() + strlen(obj->GetName()) + 2);
-      subdir += curdir;
-      if (! curdir.empty())
-        subdir += '/';
-      subdir += obj->GetName();
+      std::unique_ptr<TObject> obj(key->ReadObj());
+      if (dynamic_cast<TDirectory*>(obj.get())) {
+        std::string subdir;
+        subdir.reserve(curdir.size() + strlen(obj->GetName()) + 2);
+        subdir += curdir;
+        if (! curdir.empty())
+          subdir += '/';
+        subdir += obj->GetName();
 
-      ntot += readDirectory(file, overwrite, onlypath, prepend, subdir, stripdirs);
-    }
-    else if (skip)
-      ;
-    else if (dynamic_cast<TObjString *>(obj.get()))
-    {
-      delayed.push_back(obj.release());
-    }
-    else
-    {
-      if (verbose_ > 2)
-        std::cout << "DQMStore: reading object '" << obj->GetName()
-                  << "' of type '" << obj->IsA()->GetName()
-                  << "' from '" << file->GetName()
-                  << "' into '" << dirpart << "'\n";
+        ntot += readDirectory(file, overwrite, onlypath, prepend, subdir, stripdirs);
+      }
+      else if (skip)
+        ;
+      else if (dynamic_cast<TObjString*>(obj.get())) {
+        delayed.push_back(obj.release());
+      }
+      else {
+        if (verbose_ > 2)
+          std::cout << "DQMStore: reading object '" << obj->GetName()
+                    << "' of type '" << obj->IsA()->GetName()
+                    << "' from '" << file->GetName()
+                    << "' into '" << dirpart << "'\n";
 
-      makeDirectory(dirpart);
-      if (extract(obj.get(), dirpart, overwrite, collateHistograms_))
-        ++count;
+        makeDirectory(dirpart);
+        if (extract(obj.get(), dirpart, overwrite, collateHistograms_))
+          ++count;
+      }
     }
-  }
 
-  while (! delayed.empty())
-  {
+  while (! delayed.empty()) {
     if (verbose_ > 2)
       std::cout << "DQMStore: reading object '" << delayed.front()->GetName()
                 << "' of type '" << delayed.front()->IsA()->GetName()
@@ -2927,12 +2589,12 @@ DQMStore::readDirectory(TFile *file,
 /// note: by default this method keeps the dir structure as in file
 /// and does not update monitor element references!
 bool
-DQMStore::open(const std::string &filename,
-               bool overwrite /* = false */,
-               const std::string &onlypath /* ="" */,
-               const std::string &prepend /* ="" */,
-               OpenRunDirs stripdirs /* =KeepRunDirs */,
-               bool fileMustExist /* =true */)
+DQMStore::open(std::string const& filename,
+               bool const overwrite /* = false */,
+               std::string const& onlypath /* ="" */,
+               std::string const& prepend /* ="" */,
+               OpenRunDirs const stripdirs /* =KeepRunDirs */,
+               bool const fileMustExist /* =true */)
 {
   return readFile(filename,overwrite,onlypath,prepend,stripdirs,fileMustExist);
 }
@@ -2942,20 +2604,20 @@ DQMStore::open(const std::string &filename,
 /// set DQMStore.collateHistograms to true to sum several files
 /// note: by default this method strips off run dir structure
 bool
-DQMStore::load(const std::string &filename,
-               OpenRunDirs stripdirs /* =StripRunDirs */,
-               bool fileMustExist /* =true */)
+DQMStore::load(std::string const& filename,
+               OpenRunDirs const stripdirs /* =StripRunDirs */,
+               bool const fileMustExist /* =true */)
 {
   bool overwrite = true;
   if (collateHistograms_) overwrite = false;
   if (verbose_)
-  {
-    std::cout << "DQMStore::load: reading from file '" << filename << "'\n";
-    if (collateHistograms_)
-      std::cout << "DQMStore::load: in collate mode   " << "\n";
-    else
-      std::cout << "DQMStore::load: in overwrite mode   " << "\n";
-  }
+    {
+      std::cout << "DQMStore::load: reading from file '" << filename << "'\n";
+      if (collateHistograms_)
+        std::cout << "DQMStore::load: in collate mode   " << "\n";
+      else
+        std::cout << "DQMStore::load: in overwrite mode   " << "\n";
+    }
 
   if (!s_rxpbfile.match(filename, 0, 0))
     return readFile(filename, overwrite, "", "", stripdirs, fileMustExist);
@@ -2969,12 +2631,12 @@ DQMStore::load(const std::string &filename,
 /// if prepend !="", prepend string to path
 /// if StripRunDirs is set the run and run summary folders are erased.
 bool
-DQMStore::readFile(const std::string &filename,
-                   bool overwrite /* = false */,
-                   const std::string &onlypath /* ="" */,
-                   const std::string &prepend /* ="" */,
-                   OpenRunDirs stripdirs /* =StripRunDirs */,
-                   bool fileMustExist /* =true */)
+DQMStore::readFile(std::string const& filename,
+                   bool const overwrite /* = false */,
+                   std::string const& onlypath /* ="" */,
+                   std::string const& prepend /* ="" */,
+                   OpenRunDirs const stripdirs /* =StripRunDirs */,
+                   bool const fileMustExist /* =true */)
 {
 
   if (verbose_)
@@ -2982,21 +2644,18 @@ DQMStore::readFile(const std::string &filename,
 
   std::unique_ptr<TFile> f;
 
-  try
-  {
+  try {
     f.reset(TFile::Open(filename.c_str()));
     if (! f.get() || f->IsZombie())
       raiseDQMError("DQMStore", "Failed to open file '%s'", filename.c_str());
   }
-  catch (std::exception &)
-  {
+  catch (std::exception &) {
     if (fileMustExist)
       throw;
-    else
-    {
-    if (verbose_)
-      std::cout << "DQMStore::readFile: file '" << filename << "' does not exist, continuing\n";
-    return false;
+    else {
+      if (verbose_)
+        std::cout << "DQMStore::readFile: file '" << filename << "' does not exist, continuing\n";
+      return false;
     }
   }
 
@@ -3007,8 +2666,7 @@ DQMStore::readFile(const std::string &filename,
     pr.second.updateQReportStats();
   }
 
-  if (verbose_)
-  {
+  if (verbose_) {
     std::cout << "DQMStore::open: successfully read " << n
               << " objects from file '" << filename << "'";
     if (! onlypath.empty())
@@ -3021,21 +2679,22 @@ DQMStore::readFile(const std::string &filename,
 }
 
 /** Extract the next serialised ROOT object from @a buf. Returns null
-if there are no more objects in the buffer, or a null pointer was
-serialised at this location. */
-inline TObject * DQMStore::extractNextObject(TBufferFile &buf) const {
+    if there are no more objects in the buffer, or a null pointer was
+    serialised at this location. */
+inline TObject* DQMStore::extractNextObject(TBufferFile& buf) const
+{
   if (buf.Length() == buf.BufferSize())
     return nullptr;
   buf.InitMap();
-  void *ptr = buf.ReadObjectAny(nullptr);
-  return reinterpret_cast<TObject *>(ptr);
+  void* ptr = buf.ReadObjectAny(nullptr);
+  return reinterpret_cast<TObject*>(ptr);
 }
 
-void DQMStore::get_info(const dqmstorepb::ROOTFilePB::Histo &h,
-                        std::string &dirname,
-                        std::string &objname,
-                        TObject ** obj) {
-
+void DQMStore::get_info(dqmstorepb::ROOTFilePB::Histo const& h,
+                        std::string& dirname,
+                        std::string& objname,
+                        TObject** obj)
+{
   size_t slash = h.full_pathname().rfind('/');
   size_t dirpos = (slash == std::string::npos ? 0 : slash);
   size_t namepos = (slash == std::string::npos ? 0 : slash+1);
@@ -3052,12 +2711,12 @@ void DQMStore::get_info(const dqmstorepb::ROOTFilePB::Histo &h,
 }
 
 bool
-DQMStore::readFilePB(const std::string &filename,
-                     bool overwrite /* = false */,
-                     const std::string &onlypath /* ="" */,
-                     const std::string &prepend /* ="" */,
-                     OpenRunDirs stripdirs /* =StripRunDirs */,
-                     bool fileMustExist /* =true */)
+DQMStore::readFilePB(std::string const& filename,
+                     bool const overwrite /* = false */,
+                     std::string const& onlypath /* ="" */,
+                     std::string const& prepend /* ="" */,
+                     OpenRunDirs const stripdirs /* =StripRunDirs */,
+                     bool const fileMustExist /* =true */)
 {
   using google::protobuf::io::FileInputStream;
   using google::protobuf::io::FileOutputStream;
@@ -3094,25 +2753,24 @@ DQMStore::readFilePB(const std::string &filename,
     std::string path;
     std::string objname;
 
-    TObject *obj = nullptr;
-    const dqmstorepb::ROOTFilePB::Histo &h = dqmstore_message.histo(i);
+    TObject* obj = nullptr;
+    dqmstorepb::ROOTFilePB::Histo const& h = dqmstore_message.histo(i);
     get_info(h, path, objname, &obj);
 
     setCurrentFolder(path);
-    if (obj)
-    {
+    if (obj) {
       /* Before calling the extract() check if histogram exists:
        * if it does - flags for the given monitor are already set (and merged)
        * else - set the flags after the histogram is created.
        */
-      MonitorElement *me = findObject(0, 0, 0, path, objname);
+      MonitorElement* me = findObject(0, 0, 0, path, objname);
 
       /* Run histograms should be collated and not overwritten,
        * Lumi histograms should be overwritten (and collate flag is not checked)
        */
       bool overwrite = h.flags() & DQMNet::DQM_PROP_LUMI;
       bool collate = !(h.flags() & DQMNet::DQM_PROP_LUMI);
-      extract(static_cast<TObject *>(obj), path, overwrite, collate);
+      extract(static_cast<TObject*>(obj), path, overwrite, collate);
 
       if (me == nullptr) {
         me = findObject(0, 0, 0, path, objname);
@@ -3133,10 +2791,10 @@ DQMStore::readFilePB(const std::string &filename,
 /// delete directory and all contents;
 /// delete directory (all contents + subfolders);
 void
-DQMStore::rmdir(const std::string &path)
+DQMStore::rmdir(std::string const& path)
 {
   std::string clean;
-  const std::string *cleaned = nullptr;
+  std::string const* cleaned = nullptr;
   cleanTrailingSlashes(path, clean, cleaned);
   KeyObject const proto{cleaned, empty_str};
 
@@ -3153,7 +2811,7 @@ DQMStore::rmdir(const std::string &path)
 
 /// remove all monitoring elements from directory;
 void
-DQMStore::removeContents(const std::string &dir)
+DQMStore::removeContents(std::string const& dir)
 {
   KeyObject const proto{&dir, empty_str};
   auto e = data_.end();
@@ -3175,7 +2833,7 @@ DQMStore::removeContents()
 /// erase monitoring element in current directory
 /// (opposite of book1D,2D,etc. action);
 void
-DQMStore::removeElement(const std::string &name)
+DQMStore::removeElement(std::string const& name)
 {
   removeElement(pwd_, name);
 }
@@ -3183,7 +2841,7 @@ DQMStore::removeElement(const std::string &name)
 /// remove monitoring element from directory;
 /// if warning = true, print message if element does not exist
 void
-DQMStore::removeElement(const std::string &dir, const std::string &name, bool warning /* = true */)
+DQMStore::removeElement(std::string const& dir, std::string const& name, bool const warning /* = true */)
 {
   KeyObject const proto{&dir, name};
   auto pos = data_.find(proto);
@@ -3200,8 +2858,8 @@ DQMStore::removeElement(const std::string &dir, const std::string &name, bool wa
 //////////////////////////////////////////////////////////////////////
 /// get QCriterion corresponding to <qtname>
 /// (null pointer if QCriterion does not exist)
-QCriterion *
-DQMStore::getQCriterion(const std::string &qtname) const
+QCriterion*
+DQMStore::getQCriterion(std::string const& qtname) const
 {
   auto i = qtests_.find(qtname);
   auto e = qtests_.end();
@@ -3211,8 +2869,8 @@ DQMStore::getQCriterion(const std::string &qtname) const
 /// create quality test with unique name <qtname> (analogous to ME name);
 /// quality test can then be attached to ME with useQTest method
 /// (<algo_name> must match one of known algorithms)
-QCriterion *
-DQMStore::createQTest(const std::string &algoname, const std::string &qtname)
+QCriterion*
+DQMStore::createQTest(std::string const& algoname, std::string const& qtname)
 {
   if (qtests_.count(qtname))
     raiseDQMError("DQMStore", "Attempt to create duplicate quality test '%s'",
@@ -3223,7 +2881,7 @@ DQMStore::createQTest(const std::string &algoname, const std::string &qtname)
     raiseDQMError("DQMStore", "Cannot create a quality test using unknown"
                   " algorithm '%s'", algoname.c_str());
 
-  QCriterion *qc = i->second(qtname);
+  QCriterion* qc = i->second(qtname);
   qc->setVerbose(verboseQT_);
 
   qtests_[qtname] = qc;
@@ -3233,11 +2891,11 @@ DQMStore::createQTest(const std::string &algoname, const std::string &qtname)
 /// attach quality test <qtname> to directory contents
 /// (need exact pathname without wildcards, e.g. A/B/C);
 void
-DQMStore::useQTest(const std::string &dir, const std::string &qtname)
+DQMStore::useQTest(std::string const& dir, std::string const& qtname)
 {
   // Clean the path
   std::string clean;
-  const std::string *cleaned = nullptr;
+  std::string const* cleaned = nullptr;
   cleanTrailingSlashes(dir, clean, cleaned);
 
   // Validate the path.
@@ -3251,14 +2909,14 @@ DQMStore::useQTest(const std::string &dir, const std::string &qtname)
 
 /// attach quality test <qc> to monitor elements matching <pattern>.
 int
-DQMStore::useQTestByMatch(const std::string &pattern, const std::string &qtname)
+DQMStore::useQTestByMatch(std::string const& pattern, std::string const& qtname)
 {
-  QCriterion *qc = getQCriterion(qtname);
+  QCriterion* qc = getQCriterion(qtname);
   if (! qc)
     raiseDQMError("DQMStore", "Cannot apply non-existent quality test '%s'",
                   qtname.c_str());
 
-  auto * fm = new fastmatch( pattern );
+  auto* fm = new fastmatch(pattern);
 
   // Record the test for future reference.
   QTestSpec qts(fm, qc);
@@ -3267,13 +2925,11 @@ DQMStore::useQTestByMatch(const std::string &pattern, const std::string &qtname)
   // Apply the quality test.
   std::string path;
   int cases = 0;
-  for (auto& pr : data_)
-  {
+  for (auto& pr : data_) {
     auto& me = pr.second;
     path.clear();
     mergePath(path, *me.data_.dirname, me.data_.objname);
-    if (fm->match(path))
-    {
+    if (fm->match(path)) {
       ++cases;
       me.addQReport(qts.second);
     }
@@ -3306,15 +2962,14 @@ DQMStore::runQTests()
 /// returns most sever error, where ERROR > WARNING > OTHER > STATUS_OK;
 /// see Core/interface/QTestStatus.h for details on "OTHER"
 int
-DQMStore::getStatus(const std::string &path /* = "" */) const
+DQMStore::getStatus(std::string const& path /* = "" */) const
 {
   std::string clean;
-  const std::string *cleaned = nullptr;
+  std::string const* cleaned = nullptr;
   cleanTrailingSlashes(path, clean, cleaned);
 
   int status = dqm::qstatus::STATUS_OK;
-  for (auto const& pr : data_)
-  {
+  for (auto const& pr : data_) {
     auto const& me = pr.second;
     if (! cleaned->empty() && ! isSubdirectory(*cleaned, *me.data_.dirname))
       continue;
@@ -3336,7 +2991,7 @@ DQMStore::getStatus(const std::string &path /* = "" */) const
 /// reset contents (does not erase contents permanently)
 /// (makes copy of current contents; will be subtracted from future contents)
 void
-DQMStore::softReset(MonitorElement *me)
+DQMStore::softReset(MonitorElement* me)
 {
   if (me)
     me->softReset();
@@ -3344,7 +2999,7 @@ DQMStore::softReset(MonitorElement *me)
 
 // reverts action of softReset
 void
-DQMStore::disableSoftReset(MonitorElement *me)
+DQMStore::disableSoftReset(MonitorElement* me)
 {
   if (me)
     me->disableSoftReset();
@@ -3353,7 +3008,7 @@ DQMStore::disableSoftReset(MonitorElement *me)
 /// if true, will accumulate ME contents (over many periods)
 /// until method is called with flag = false again
 void
-DQMStore::setAccumulate(MonitorElement *me, bool flag)
+DQMStore::setAccumulate(MonitorElement* me, bool const flag)
 {
   if (me)
     me->setAccumulate(flag);
@@ -3392,8 +3047,11 @@ DQMStore::isCollate() const
 //////////////////////////////////////////////////////////////////////
 // check if the monitor element is in auto-collation folder
 bool
-DQMStore::isCollateME(MonitorElement *me) const
-{ return me && isSubdirectory(s_collateDirName, *me->data_.dirname); }
+DQMStore::isCollateME(MonitorElement* me) const
+{
+  return me && isSubdirectory(s_collateDirName, *me->data_.dirname);
+}
+
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
@@ -3409,68 +3067,66 @@ DQMStore::scaleElements()
   int events = 1;
   if (dirExists("Info/EventInfo")) {
     if ( scaleFlag_ == -1.0) {
-      MonitorElement * scale_me = get("Info/EventInfo/ScaleFactor");
+      MonitorElement*  scale_me = get("Info/EventInfo/ScaleFactor");
       if (scale_me && scale_me->kind()==MonitorElement::DQM_KIND_REAL) factor = scale_me->getFloatValue();
     }
-    MonitorElement * event_me = get("Info/EventInfo/processedEvents");
+    MonitorElement*  event_me = get("Info/EventInfo/processedEvents");
     if (event_me && event_me->kind()==MonitorElement::DQM_KIND_INT) events = event_me->getIntValue();
   }
   factor = factor/(events*1.0);
 
-  for (auto& pr : data_)
-  {
+  for (auto& pr : data_) {
     auto& me = pr.second;
-    switch (me.kind())
+    switch (me.kind()) {
+    case MonitorElement::DQM_KIND_TH1F:
       {
-      case MonitorElement::DQM_KIND_TH1F:
-        {
-          me.getTH1F()->Scale(factor);
-          break;
-        }
-      case MonitorElement::DQM_KIND_TH1S:
-        {
-          me.getTH1S()->Scale(factor);
-          break;
-        }
-      case MonitorElement::DQM_KIND_TH1D:
-        {
-          me.getTH1D()->Scale(factor);
-          break;
-        }
-      case MonitorElement::DQM_KIND_TH2F:
-        {
-          me.getTH2F()->Scale(factor);
-          break;
-        }
-      case MonitorElement::DQM_KIND_TH2S:
-        {
-          me.getTH2S()->Scale(factor);
-          break;
-        }
-      case MonitorElement::DQM_KIND_TH2D:
-        {
-          me.getTH2D()->Scale(factor);
-          break;
-        }
-      case MonitorElement::DQM_KIND_TH3F:
-        {
-          me.getTH3F()->Scale(factor);
-          break;
-        }
-      case MonitorElement::DQM_KIND_TPROFILE:
-        {
-          me.getTProfile()->Scale(factor);
-          break;
-        }
-      case MonitorElement::DQM_KIND_TPROFILE2D:
-        {
-          me.getTProfile2D()->Scale(factor);
-          break;
-        }
-      default:
-        if (verbose_ > 0)
-          std::cout << " The DQM object '" << me.getFullname() << "' is not scalable object " << std::endl;
-        continue;
+        me.getTH1F()->Scale(factor);
+        break;
       }
+    case MonitorElement::DQM_KIND_TH1S:
+      {
+        me.getTH1S()->Scale(factor);
+        break;
+      }
+    case MonitorElement::DQM_KIND_TH1D:
+      {
+        me.getTH1D()->Scale(factor);
+        break;
+      }
+    case MonitorElement::DQM_KIND_TH2F:
+      {
+        me.getTH2F()->Scale(factor);
+        break;
+      }
+    case MonitorElement::DQM_KIND_TH2S:
+      {
+        me.getTH2S()->Scale(factor);
+        break;
+      }
+    case MonitorElement::DQM_KIND_TH2D:
+      {
+        me.getTH2D()->Scale(factor);
+        break;
+      }
+    case MonitorElement::DQM_KIND_TH3F:
+      {
+        me.getTH3F()->Scale(factor);
+        break;
+      }
+    case MonitorElement::DQM_KIND_TPROFILE:
+      {
+        me.getTProfile()->Scale(factor);
+        break;
+      }
+    case MonitorElement::DQM_KIND_TPROFILE2D:
+      {
+        me.getTProfile2D()->Scale(factor);
+        break;
+      }
+    default:
+      if (verbose_ > 0)
+        std::cout << " The DQM object '" << me.getFullname() << "' is not scalable object " << std::endl;
+      continue;
+    }
   }
 }

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -586,7 +586,7 @@ DQMStore::makeDirectory(const std::string &path)
     subdir.append(path, 0, slash);
     name.clear();
     name.append(subdir, prevname, std::string::npos);
-    if (! prev.empty() && findObject(prev, name))
+    if (! prev.empty() && findObject(0, 0, 0, prev, name))
       raiseDQMError("DQMStore", "Attempt to create subdirectory '%s'"
                     " which already exists as a monitor element",
                     subdir.c_str());
@@ -631,7 +631,7 @@ DQMStore::book_(const std::string &dir, const std::string &name,
   h->SetDirectory(nullptr);
 
   // Check if the request monitor element already exists.
-  MonitorElement *me = findObject(dir, name, run_, 0, moduleId_);
+  MonitorElement *me = findObject(run_, 0, moduleId_, dir, name);
   if (me)
   {
     if (collateHistograms_)
@@ -676,7 +676,7 @@ DQMStore::book_(const std::string &dir, const std::string &name,
     refdir += s_referenceDirName;
     refdir += '/';
     refdir += dir;
-    MonitorElement* referenceME = findObject(refdir, name);
+    MonitorElement* referenceME = findObject(0, 0, 0, refdir, name);
     if (referenceME) {
       // We have booked a new MonitorElement with a specific dir and name.
       // Then, if we can find the corresponding MonitorElement in the reference
@@ -701,7 +701,7 @@ DQMStore::book_(const std::string &dir,
     print_trace(dir, name);
 
   // Check if the request monitor element already exists.
-  if (MonitorElement *me = findObject(dir, name, run_, 0, moduleId_))
+  if (MonitorElement *me = findObject(run_, 0, moduleId_, dir, name))
   {
     if (verbose_ > 1)
     {
@@ -733,7 +733,7 @@ DQMStore::bookInt_(const std::string &dir, const std::string &name)
 {
   if (collateHistograms_)
   {
-    if (MonitorElement *me = findObject(dir, name, run_, 0, moduleId_))
+    if (MonitorElement *me = findObject(run_, 0, moduleId_, dir, name))
     {
       me->Fill(0);
       return me;
@@ -763,7 +763,7 @@ DQMStore::bookFloat_(const std::string &dir, const std::string &name)
 {
   if (collateHistograms_)
   {
-    if (MonitorElement *me = findObject(dir, name, run_, 0, moduleId_))
+    if (MonitorElement *me = findObject(run_, 0, moduleId_, dir, name))
     {
       me->Fill(0.);
       return me;
@@ -795,7 +795,7 @@ DQMStore::bookString_(const std::string &dir,
 {
   if (collateHistograms_)
   {
-    if (MonitorElement *me = findObject(dir, name, run_, 0, moduleId_))
+    if (MonitorElement *me = findObject(run_, 0, moduleId_, dir, name))
       return me;
   }
 
@@ -1519,7 +1519,7 @@ DQMStore::tag(const std::string &path, unsigned int myTag)
   std::string name;
   splitPath(dir, name, path);
 
-  if (MonitorElement *me = findObject(dir, name))
+  if (MonitorElement *me = findObject(0, 0, 0, dir, name))
     tag(me, myTag);
   else
     raiseDQMError("DQMStore", "Attempt to tag non-existent monitor element"
@@ -1736,11 +1736,11 @@ DQMStore::getContents(std::vector<std::string> &into, bool showContents /* = tru
 /// get MonitorElement <name> in directory <dir>
 /// (null if MonitorElement does not exist)
 MonitorElement *
-DQMStore::findObject(const std::string &dir,
-                     const std::string &name,
-                     const uint32_t run /* = 0 */,
-                     const uint32_t lumi /* = 0 */,
-                     const uint32_t moduleId /* = 0 */) const
+DQMStore::findObject(const uint32_t run,
+                     const uint32_t lumi,
+                     const uint32_t moduleId,
+                     const std::string &dir,
+                     const std::string &name) const
 {
   if (dir.find_first_not_of(s_safe) != std::string::npos)
     raiseDQMError("DQMStore", "Monitor element path name '%s' uses"
@@ -2044,7 +2044,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   MonitorElement *refcheck = nullptr;
   if (auto *h = dynamic_cast<TProfile *>(obj))
   {
-    MonitorElement *me = findObject(dir, h->GetName());
+    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
       me = bookProfile_(dir, h->GetName(), (TProfile *) h->Clone());
     else if (overwrite)
@@ -2055,7 +2055,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   }
   else if (auto *h = dynamic_cast<TProfile2D *>(obj))
   {
-    MonitorElement *me = findObject(dir, h->GetName());
+    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
       me = bookProfile2D_(dir, h->GetName(), (TProfile2D *) h->Clone());
     else if (overwrite)
@@ -2066,7 +2066,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   }
   else if (auto *h = dynamic_cast<TH1F *>(obj))
   {
-    MonitorElement *me = findObject(dir, h->GetName());
+    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
       me = book1D_(dir, h->GetName(), (TH1F *) h->Clone());
     else if (overwrite)
@@ -2077,7 +2077,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   }
   else if (auto *h = dynamic_cast<TH1S *>(obj))
   {
-    MonitorElement *me = findObject(dir, h->GetName());
+    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
       me = book1S_(dir, h->GetName(), (TH1S *) h->Clone());
     else if (overwrite)
@@ -2088,7 +2088,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   }
   else if (auto *h = dynamic_cast<TH1D *>(obj))
   {
-    MonitorElement *me = findObject(dir, h->GetName());
+    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
       me = book1DD_(dir, h->GetName(), (TH1D *) h->Clone());
     else if (overwrite)
@@ -2099,7 +2099,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   }
   else if (auto *h = dynamic_cast<TH2F *>(obj))
   {
-    MonitorElement *me = findObject(dir, h->GetName());
+    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
       me = book2D_(dir, h->GetName(), (TH2F *) h->Clone());
     else if (overwrite)
@@ -2110,7 +2110,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   }
   else if (auto *h = dynamic_cast<TH2S *>(obj))
   {
-    MonitorElement *me = findObject(dir, h->GetName());
+    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
       me = book2S_(dir, h->GetName(), (TH2S *) h->Clone());
     else if (overwrite)
@@ -2121,7 +2121,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   }
   else if (auto *h = dynamic_cast<TH2D *>(obj))
   {
-    MonitorElement *me = findObject(dir, h->GetName());
+    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
       me = book2DD_(dir, h->GetName(), (TH2D *) h->Clone());
     else if (overwrite)
@@ -2132,7 +2132,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   }
   else if (auto *h = dynamic_cast<TH3F *>(obj))
   {
-    MonitorElement *me = findObject(dir, h->GetName());
+    MonitorElement *me = findObject(0, 0, 0, dir, h->GetName());
     if (! me)
       me = book3D_(dir, h->GetName(), (TH3F *) h->Clone());
     else if (overwrite)
@@ -2173,7 +2173,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
 
     if (kind == "i")
     {
-      MonitorElement *me = findObject(dir, label);
+      MonitorElement *me = findObject(0, 0, 0, dir, label);
       if (! me || overwrite)
       {
         if (! me) me = bookInt_(dir, label);
@@ -2182,7 +2182,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
     }
     else if (kind == "f")
     {
-      MonitorElement *me = findObject(dir, label);
+      MonitorElement *me = findObject(0, 0, 0, dir, label);
       if (! me || overwrite)
       {
         if (! me) me = bookFloat_(dir, label);
@@ -2191,7 +2191,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
     }
     else if (kind == "s")
     {
-      MonitorElement *me = findObject(dir, label);
+      MonitorElement *me = findObject(0, 0, 0, dir, label);
       if (! me)
         me = bookString_(dir, label, value);
       else if (overwrite)
@@ -2199,7 +2199,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
     }
     else if (kind == "e")
     {
-      MonitorElement *me = findObject(dir, label);
+      MonitorElement *me = findObject(0, 0, 0, dir, label);
       if (! me)
       {
         std::cout << "*** DQMStore: WARNING: no monitor element '"
@@ -2211,7 +2211,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
     }
     else if (kind == "t")
     {
-      MonitorElement *me = findObject(dir, label);
+      MonitorElement *me = findObject(0, 0, 0, dir, label);
       if (! me)
       {
         std::cout << "*** DQMStore: WARNING: no monitor element '"
@@ -2273,7 +2273,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
           return false;
         }
 
-        MonitorElement *me = findObject(dir, mename);
+        MonitorElement *me = findObject(0, 0, 0, dir, mename);
         if (! me)
         {
           std::cout << "*** DQMStore: WARNING: no monitor element '"
@@ -2319,7 +2319,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   if (refcheck && isSubdirectory(s_referenceDirName, dir))
   {
     std::string mdir(dir, s_referenceDirName.size()+1, std::string::npos);
-    if (MonitorElement *master = findObject(mdir, obj->GetName()))
+    if (MonitorElement *master = findObject(0, 0, 0, mdir, obj->GetName()))
     {
       // We have extracted a MonitorElement, and it's located in the reference
       // dir. Then we find the corresponding MonitorElement in the
@@ -3105,7 +3105,7 @@ DQMStore::readFilePB(const std::string &filename,
        * if it does - flags for the given monitor are already set (and merged)
        * else - set the flags after the histogram is created.
        */
-      MonitorElement *me = findObject(path, objname);
+      MonitorElement *me = findObject(0, 0, 0, path, objname);
 
       /* Run histograms should be collated and not overwritten,
        * Lumi histograms should be overwritten (and collate flag is not checked)
@@ -3115,7 +3115,7 @@ DQMStore::readFilePB(const std::string &filename,
       extract(static_cast<TObject *>(obj), path, overwrite, collate);
 
       if (me == nullptr) {
-        me = findObject(path, objname);
+        me = findObject(0, 0, 0, path, objname);
         me->data_.flags = h.flags();
       }
 

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -205,7 +205,7 @@ MonitorElement::MonitorElement(const std::string *path,
   scalar_.real = 0;
 }
 
-MonitorElement::MonitorElement(const MonitorElement &x, MonitorElementNoCloneTag)
+MonitorElement::MonitorElement(const MonitorElement &x)
   : data_(x.data_),
     scalar_(x.scalar_),
     object_(nullptr),
@@ -213,26 +213,11 @@ MonitorElement::MonitorElement(const MonitorElement &x, MonitorElementNoCloneTag
     refvalue_(nullptr),
     qreports_(x.qreports_)
 {
-}
-
-MonitorElement::MonitorElement(const MonitorElement &x)
-  : MonitorElement::MonitorElement(x, MonitorElementNoCloneTag())
-{
   if (x.object_)
-    object_ = static_cast<TH1 *>(x.object_->Clone());
+    object_ = static_cast<TH1*>(x.object_->Clone());
 
   if (x.refvalue_)
-    refvalue_ = static_cast<TH1 *>(x.refvalue_->Clone());
-}
-
-MonitorElement::MonitorElement(MonitorElement &&o)
-  : MonitorElement::MonitorElement(o, MonitorElementNoCloneTag())
-{
-  object_ = o.object_;
-  refvalue_ = o.refvalue_;
-
-  o.object_ = nullptr;
-  o.refvalue_ = nullptr;
+    refvalue_ = static_cast<TH1*>(x.refvalue_->Clone());
 }
 
 MonitorElement::~MonitorElement()
@@ -249,7 +234,7 @@ MonitorElement::CheckBinLabels(const TAxis* a1, const TAxis * a2)
   // check that axis have same labels
   THashList *l1 = (const_cast<TAxis*>(a1))->GetLabels();
   THashList *l2 = (const_cast<TAxis*>(a2))->GetLabels();
-  
+
   if (!l1 && !l2 )
     return true;
   if (!l1 ||  !l2 ) {


### PR DESCRIPTION
This PR includes many changes to the `DQMStore`, built off of PR #22614 .  I have made the following changes:

- `DQMStore` no longer has global `run_` and `moduleId_` data members.  The run and module-ID numbers are now owned by the `IBooker` transactional object.
- Any per-run/module histograms are booked via the `IBooker`.   To retain backwards compatibility, **I have made the assumption that all direct uses of the `DQMStore::book*` functions are intended to book global histograms.  If this assumption is incorrect, please show me the counterexamples.**
- The container for storing `MonitorElement`s is no longer an `std::set` but an `std::map`.  To allow for concurrent booking, this will need to change to a concurrent unordered map.  That will be the next stage.
- The duplication of `std::string const&/char const*` booking-function overloads has been replaced by a single set of functions that takes a `char_string const&` argument.  The `char_string` class has implicit constructors allowing the conversions from `char const*`, `std::string`, and `TString` types.  This cuts down drastically on the overload set.  Ideally, in C++17, we could use `std::string_view` instead--but that may be a change for another time.

With all of the above changes, and given the assumption I make about raw usage of `DQMStore::book*`, I believe there are no breaking changes.  At least, none of my local builds (including many dependent packages) have exposed any.

The next phase for concurrent booking will involve removing the global `DQMStore::pwd_` data member and introducing a proxy class to ensure synchronization of the directory between `IBooker` and `IGetter` instances.