### PR TITLE
Make sure the GlobalAlgBlk is not empty before accessing member data

### DIFF
--- a/DQM/L1TMonitor/src/L1TStage2uGTCaloLayer2Comp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGTCaloLayer2Comp.cc
@@ -344,9 +344,10 @@ bool L1TStage2uGTCaloLayer2Comp::compareSums(
   l1t::EtSumBxCollection::const_iterator calol2It = calol2Col->begin();
   l1t::EtSumBxCollection::const_iterator uGTIt = uGTCol->begin();
 
-  // if the calol2 or ugt collections  have different size, mark the event as
-  // bad (this should never occur in normal running)
-  if ((calol2Col->size() != uGTCol->size())) {
+  // if either calol2 or ugt collections are empty, or they have different
+  // size, mark the event as bad (this should never occur in normal running)
+  if (calol2Col->size() == 0 || uGTCol->size() == 0 ||
+      (calol2Col->size() != uGTCol->size())) {
     comparisonNum->Fill(EVENTBADSUMCOL);
     return false;
   }

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -410,7 +410,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 	edm::Handle<BXVector<GlobalAlgBlk>> m_uGtAlgBlk;
 	iEvent.getByToken(m_algoblkInputToken, m_uGtAlgBlk);
 
-	if(m_uGtAlgBlk.isValid()) {
+	if(m_uGtAlgBlk.isValid() && !m_uGtAlgBlk->isEmpty(0)) {
 	  std::vector<GlobalAlgBlk>::const_iterator algBlk = m_uGtAlgBlk->begin(0);
 	  m_prescaleSet=static_cast<unsigned int>(algBlk->getPreScColumn());
 	}else{


### PR DESCRIPTION
Add a check that the GlobalAlgBlk is not empty when trying to get the prescale column number from the unpacked data