### PR TITLE
Add DQM module to make uGT data/emulator comparisons (backport)

### DIFF
--- a/DQM/L1TMonitor/interface/L1TdeStage2uGT.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2uGT.h
@@ -1,0 +1,82 @@
+#ifndef L1TdeStage2uGT_H
+#define L1TdeStage2uGT_H
+
+// system include files
+#include <memory>
+#include <string>
+#include <array>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+// #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+
+#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
+// #include "DataFormats/Provenance/interface/EventAuxiliary.h"
+
+#include "CondFormats/RunInfo/interface/RunInfo.h"
+#include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
+
+#include "L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h"
+
+#include "FWCore/Utilities/interface/RegexMatch.h"
+#include <boost/foreach.hpp>
+
+using namespace l1t;
+
+class L1TdeStage2uGT : public DQMEDAnalyzer {
+  public:
+    L1TdeStage2uGT(const edm::ParameterSet& ps);
+    ~L1TdeStage2uGT() override;
+  
+  protected:
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+    void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run&, const edm::EventSetup&) override;
+    void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+    void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+  
+  private:
+    // Input and config info 
+    edm::InputTag dataLabel_;
+    edm::EDGetTokenT<GlobalAlgBlkBxCollection> dataSource_;
+    edm::InputTag emulLabel_;
+    edm::EDGetTokenT<GlobalAlgBlkBxCollection> emulSource_;
+    std::vector<std::string>  triggerBlackList_;
+    int numBx_;
+    std::string histFolder_;
+    L1TGlobalUtil* gtUtil_;
+    int numLS_;
+    uint m_currentLumi;
+
+    int firstBx, lastBx;
+
+    std::map<std::string, MonitorElement*> m_HistNamesInitial, m_HistNamesFinal, m_SummaryHistograms;
+    MonitorElement* initDecisionMismatches_vs_LS;
+    MonitorElement* finalDecisionMismatches_vs_LS;
+    MonitorElement* m_normalizationHisto;
+
+    enum SummaryColumn {
+      NInitalMismatchDataNoEmul,
+      NInitalMismatchEmulNoData,
+      NFinalMismatchDataNoEmul,
+      NFinalMismatchEmulNoData,
+      NSummaryColumns,
+    };
+
+    void  fillHist(const std::map<std::string, MonitorElement*>&, const std::string&, const Double_t& , const Double_t&);
+};
+
+#endif

--- a/DQM/L1TMonitor/plugins/SealModule.cc
+++ b/DQM/L1TMonitor/plugins/SealModule.cc
@@ -121,3 +121,6 @@ DEFINE_FWK_MODULE(L1TStage2uGTCaloLayer2Comp);
 
 #include "DQM/L1TMonitor/interface/L1TdeStage2CaloLayer2.h"
 DEFINE_FWK_MODULE(L1TdeStage2CaloLayer2);
+
+#include <DQM/L1TMonitor/interface/L1TdeStage2uGT.h>
+DEFINE_FWK_MODULE(L1TdeStage2uGT);

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -53,7 +53,7 @@ from L1Trigger.L1TGlobal.simGtStage2Digis_cfi import simGtStage2Digis
 from L1Trigger.L1TGlobal.simGtExtFakeProd_cfi import simGtExtFakeProd
 
 valGtStage2Digis = simGtStage2Digis.clone()
-valGtStage2Digis.ExtInputTag = cms.InputTag("simGtExtFakeProd")
+valGtStage2Digis.ExtInputTag = cms.InputTag("gtStage2Digis")
 valGtStage2Digis.MuonInputTag = cms.InputTag("gtStage2Digis", "Muon")
 valGtStage2Digis.EGammaInputTag = cms.InputTag("gtStage2Digis", "EGamma")
 valGtStage2Digis.TauInputTag = cms.InputTag("gtStage2Digis", "Tau")
@@ -61,6 +61,10 @@ valGtStage2Digis.JetInputTag = cms.InputTag("gtStage2Digis", "Jet")
 valGtStage2Digis.EtSumInputTag = cms.InputTag("gtStage2Digis", "EtSum")
 valGtStage2Digis.AlgorithmTriggersUnmasked = cms.bool(False)
 valGtStage2Digis.AlgorithmTriggersUnprescaled = cms.bool(False)
+valGtStage2Digis.EmulateBxInEvent = cms.int32(5)
+valGtStage2Digis.PrescaleSet = cms.uint32(7)
+valGtStage2Digis.GetPrescaleColumnFromData = cms.bool(True)
+valGtStage2Digis.AlgoBlkInputTag = cms.InputTag("gtStage2Digis")
 
 Stage2L1HardwareValidation = cms.Sequence(
     valCaloStage2Layer1Digis +
@@ -101,6 +105,7 @@ from DQM.L1TMonitor.L1TdeStage2uGMT_cff import *
 
 # uGT
 from DQM.L1TMonitor.L1TStage2uGTEmul_cfi import *
+from DQM.L1TMonitor.L1TdeStage2uGT_cfi import *
 
 #-------------------------------------------------
 # Stage2 Emulator and Emulator DQM Sequences
@@ -111,6 +116,7 @@ l1tStage2EmulatorOnlineDQM = cms.Sequence(
     l1tdeStage2Omtf +
     l1tdeStage2EmtfOnlineDQMSeq +
     l1tStage2uGMTEmulatorOnlineDQMSeq +
+    l1tdeStage2uGT +
     l1tStage2uGtEmul
 )
 

--- a/DQM/L1TMonitor/python/L1TdeStage2uGT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGT_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tdeStage2uGT = DQMEDAnalyzer('L1TdeStage2uGT',
+    dataSource = cms.InputTag("gtStage2Digis"),
+    emulSource = cms.InputTag("valGtStage2Digis"),
+    triggerBlackList = cms.vstring("L1_IsolatedBunch","L1_FirstBunchInTrain","L1_FirstBunchAfterTrain","*3BX","L1_CDC*"),
+    numBxToMonitor = cms.int32(5),
+    histFolder = cms.string('L1TEMU/L1TdeStage2uGT')
+)

--- a/DQM/L1TMonitor/src/L1TdeStage2uGT.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2uGT.cc
@@ -1,0 +1,290 @@
+/*
+ * \file L1TdeStage2uGT.cc
+ *
+ * L. Apanasevich <Leonard.Apanasevich@cern.ch>
+ */
+
+#include "DQM/L1TMonitor/interface/L1TdeStage2uGT.h"
+
+L1TdeStage2uGT::L1TdeStage2uGT(const edm::ParameterSet & ps) :
+  dataLabel_(ps.getParameter<edm::InputTag>("dataSource")),
+  dataSource_(consumes<GlobalAlgBlkBxCollection>(dataLabel_)),
+  emulLabel_(ps.getParameter<edm::InputTag>("emulSource")),
+  emulSource_(consumes<GlobalAlgBlkBxCollection>(emulLabel_)),
+  triggerBlackList_(ps.getParameter<std::vector<std::string> >("triggerBlackList")),
+  numBx_(ps.getParameter<int>("numBxToMonitor")),
+  histFolder_(ps.getParameter<std::string>("histFolder")),
+  gtUtil_(new l1t::L1TGlobalUtil(ps, consumesCollector(), *this, ps.getParameter<edm::InputTag>("dataSource"), ps.getParameter<edm::InputTag>("dataSource"))),
+  numLS_(2000),
+  m_currentLumi(0)
+{
+
+  if (numBx_ >5 ) numBx_ = 5;
+  if ( ( numBx_ > 0 ) && ( ( numBx_ % 2 ) == 0 )) {
+    numBx_ = numBx_ - 1;
+    
+    edm::LogWarning("L1TdeStage2uGT")
+      << "\nWARNING: Number of bunch crossing to be emulated rounded to: "
+      << numBx_ << "\n         The number must be an odd number!\n"
+      << std::endl;
+  }
+  firstBx = (numBx_ + 1)/2 - numBx_;
+  lastBx = (numBx_ + 1)/2 - 1;		   
+
+  edm::LogInfo("L1TdeStage2uGT") << "Number of bunches crossings monitored: " << numBx_ 
+	    << "\t" << "Min BX= " << firstBx << "\t" << "Max BX= " << lastBx << std::endl;
+
+}
+
+L1TdeStage2uGT::~L1TdeStage2uGT()
+{
+}
+
+void L1TdeStage2uGT::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& evtSetup)
+{
+}
+
+void L1TdeStage2uGT::analyze(const edm::Event & event, const edm::EventSetup & es)
+{
+   edm::Handle<GlobalAlgBlkBxCollection> dataCollection;
+   event.getByToken(dataSource_, dataCollection);
+   edm::Handle<GlobalAlgBlkBxCollection> emulCollection;
+   event.getByToken(emulSource_, emulCollection);
+
+   if (!dataCollection.isValid()) {
+     edm::LogError("L1TdeStage2uGT") << "Cannot find unpacked uGT readout record.";
+     return;
+   }
+   if (!emulCollection.isValid()) {
+     edm::LogError("L1TdeStage2uGT") << "Cannot find emulated uGT readout record.";
+     return;
+   }
+
+   // Only using gtUtil to find prescale factors and mapping of bits to names, so only call gtUtil_ at lumi boundaries.
+   if (m_currentLumi != event.luminosityBlock()){
+     m_currentLumi=event.luminosityBlock();
+     gtUtil_->retrieveL1(event,es,dataSource_);
+   }
+
+   // Get standard event parameters 
+   int lumi = event.luminosityBlock();
+   if (lumi > numLS_) lumi=numLS_;
+
+   // int bx = event.bunchCrossing();
+
+   // check that the requested range of BX's is consistent with the BX's in the emulated and unpacked collections
+   if (emulCollection->getFirstBX() > firstBx) firstBx = emulCollection->getFirstBX();
+   if (emulCollection->getLastBX() < lastBx) lastBx = emulCollection->getLastBX();
+
+   if (dataCollection->getFirstBX() > firstBx) firstBx = dataCollection->getFirstBX();
+   if (dataCollection->getLastBX() < lastBx) lastBx = dataCollection->getLastBX();
+
+   m_normalizationHisto -> Fill(float(NInitalMismatchDataNoEmul));
+   m_normalizationHisto -> Fill(float(NInitalMismatchEmulNoData));
+   m_normalizationHisto -> Fill(float(NFinalMismatchDataNoEmul));
+   m_normalizationHisto -> Fill(float(NFinalMismatchEmulNoData));
+
+   for (int ibx = firstBx; ibx <= lastBx; ++ibx) {
+
+     ostringstream bxt;
+     if (ibx==0){
+       bxt << "CentralBX";
+     }else{
+       bxt << "BX" << ibx;
+     }
+     std::string hname, hsummary;
+     float wt;
+
+     hsummary="dataEmulSummary_" + bxt.str();
+
+     std::vector<GlobalAlgBlk>::const_iterator it_data, it_emul;
+     for (it_data = dataCollection->begin(ibx), it_emul = emulCollection->begin(ibx); 
+	  it_data != dataCollection->end(ibx) && it_emul != emulCollection->end(ibx); 
+	  ++it_data, ++it_emul) {
+
+
+       // Fills algorithm bits histograms
+       int numAlgs= it_data->getAlgoDecisionInitial().size();
+       for(int algoBit = 0; algoBit < numAlgs; ++algoBit) {
+
+	 string algoName = "xxx";
+	 bool found=gtUtil_->getAlgNameFromBit(algoBit,algoName);
+	 if (not found) continue;
+
+	 // skip bits which emulator does not handle (only skiped for bx !=0)
+	 bool isBlackListed(false);
+	 BOOST_FOREACH(const std::string & pattern, triggerBlackList_) {
+	   //std::cout << pattern << std::endl;
+	   if (edm::is_glob(pattern)) {
+	     std::regex regexp(edm::glob2reg(pattern));
+	     if (regex_match (algoName.c_str(),regexp)) isBlackListed = true;
+	   } else {
+	     if (algoName == pattern) isBlackListed = true;
+	   }
+	 }
+	 if (ibx !=0 && isBlackListed) continue;	 
+
+	 // Check initial decisions
+	 if(it_data->getAlgoDecisionInitial(algoBit) != it_emul->getAlgoDecisionInitial(algoBit)) {
+
+	   if (it_data->getAlgoDecisionInitial(algoBit)){
+	     hname = "DataNoEmul_" + bxt.str();
+	     fillHist(m_SummaryHistograms, hsummary, float(NInitalMismatchDataNoEmul),1.);
+	     wt=1;
+	   }else{
+	     hname = "EmulatorNoData_" + bxt.str();
+	     fillHist(m_SummaryHistograms, hsummary, float(NInitalMismatchEmulNoData),1.);
+	     wt=-1;
+	   }
+	   fillHist(m_HistNamesInitial, hname, float(algoBit),1.);
+	   initDecisionMismatches_vs_LS->Fill(float(lumi),wt);
+
+	 }
+
+	 // Check final decisions
+	 if(it_data->getAlgoDecisionFinal(algoBit) != it_emul->getAlgoDecisionFinal(algoBit)) {
+	   bool unprescaled=true;
+	   // check the prescale factor
+	   int prescale = -999;
+	   bool dummy=gtUtil_->getPrescaleByBit(algoBit,prescale);
+	   if (not dummy) 
+	     edm::LogWarning("L1TdeStage2uGT") << "Could not find prescale value for algobit: " << algoBit << std::endl;
+
+	   if (prescale != 1) unprescaled=false;
+
+	   if (unprescaled) {
+
+	     if (it_data->getAlgoDecisionFinal(algoBit)){
+	       hname = "DataNoEmul_" + bxt.str();
+	       fillHist(m_SummaryHistograms, hsummary, float(NFinalMismatchDataNoEmul),1.);
+	       wt=1;
+	     }else{
+	       hname = "EmulatorNoData_" + bxt.str();
+	       fillHist(m_SummaryHistograms, hsummary, float(NFinalMismatchEmulNoData),1.);
+	       wt=-1;
+	     }
+	     fillHist(m_HistNamesFinal, hname, float(algoBit),1.);
+	     finalDecisionMismatches_vs_LS->Fill(float(lumi), wt);
+	   }
+	 }
+
+       }// end loop over algoBits
+     }// end loop over globalalgblk vector
+   }// endof loop over BX collections
+
+}
+
+void L1TdeStage2uGT::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {}
+
+void L1TdeStage2uGT::endLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup&) {}
+
+void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run& run , const edm::EventSetup& es) 
+{
+  gtUtil_->retrieveL1Setup(es);
+
+  auto const& prescales = gtUtil_->prescales();
+  int nbins = prescales.size(); // dummy values for now; update later when gtutils function is called
+  double xmin = -0.5;
+  double xmax = nbins-0.5;
+
+  string hname, htitle;
+
+  int ibx = (numBx_ + 1)/2 - numBx_;
+  for ( int i = 0; i < numBx_; i++) {
+
+    ostringstream bxn,bxt;
+
+    if (ibx==0){
+      bxt << "CentralBX";
+      bxn << " Central BX ";
+    }else{
+      bxt << "BX" << ibx;
+      bxn<< " BX " << ibx;
+    }
+    ibx++;
+
+    ibooker.setCurrentFolder(histFolder_);
+    hname = "dataEmulSummary_" + bxt.str();
+    htitle  = "uGT Data/Emulator Mismatches --" + bxn.str();
+    m_SummaryHistograms[hname] = ibooker.book1D(hname, htitle, NSummaryColumns, 0., double(NSummaryColumns));
+    m_SummaryHistograms[hname]->getTH1F()->GetYaxis()->SetTitle("Events");
+    m_SummaryHistograms[hname]->getTH1F()->GetXaxis()->SetBinLabel(1+NInitalMismatchDataNoEmul, "Data, NoEmul -- Initial Decisions");
+    m_SummaryHistograms[hname]->getTH1F()->GetXaxis()->SetBinLabel(1+NInitalMismatchEmulNoData, "Emulator, No Data -- Initial Decisions");
+    m_SummaryHistograms[hname]->getTH1F()->GetXaxis()->SetBinLabel(1+NFinalMismatchDataNoEmul, "Data, NoEmul -- Final Decisions");
+    m_SummaryHistograms[hname]->getTH1F()->GetXaxis()->SetBinLabel(1+NFinalMismatchEmulNoData, "Emulator, No Data -- Final Decisions");
+
+    if (i == 0){
+      hname="normalizationHisto";
+      htitle="Normalization histogram for uGT Data/Emulator Mismatches ratios";
+      m_normalizationHisto = ibooker.book1D(hname, htitle, NSummaryColumns, 0., double(NSummaryColumns));
+      m_normalizationHisto->getTH1F()->GetYaxis()->SetTitle("Events");
+      m_normalizationHisto->getTH1F()->GetXaxis()->SetBinLabel(1+NInitalMismatchDataNoEmul, "Data, NoEmul -- Initial Decisions");
+      m_normalizationHisto->getTH1F()->GetXaxis()->SetBinLabel(1+NInitalMismatchEmulNoData, "Emulator, No Data -- Initial Decisions");
+      m_normalizationHisto->getTH1F()->GetXaxis()->SetBinLabel(1+NFinalMismatchDataNoEmul, "Data, NoEmul -- Final Decisions");
+      m_normalizationHisto->getTH1F()->GetXaxis()->SetBinLabel(1+NFinalMismatchEmulNoData, "Emulator, No Data -- Final Decisions");
+    }
+
+    // book initial decisions histograms
+    ibooker.setCurrentFolder(histFolder_+"/InitialDecisionMismatches");
+    initDecisionMismatches_vs_LS = ibooker.book1D("initialDecisionMismatches_vs_LS", "uGT initial decision mismatches vs Luminosity Segment", numLS_, 0., double(numLS_));
+    initDecisionMismatches_vs_LS->getTH1F()->GetYaxis()->SetTitle("Events with Initial Decision Mismatch");
+    initDecisionMismatches_vs_LS->getTH1F()->GetXaxis()->SetTitle("Luminosity Segment");
+
+    hname = "DataNoEmul_" + bxt.str();
+    htitle  = "uGT data-emul mismatch -- Data fired but not Emulator --" + bxn.str();
+    m_HistNamesInitial[hname] = ibooker.book1D(hname, htitle, nbins, xmin, xmax);
+
+    hname = "EmulatorNoData_" + bxt.str();
+    htitle  = "uGT data-emul mismatch -- Emulator fired but not Data --" + bxn.str();
+    m_HistNamesInitial[hname] = ibooker.book1D(hname, htitle, nbins, xmin, xmax);
+
+
+    // book final decisions histograms
+    ibooker.setCurrentFolder(histFolder_+"/FinalDecisionMismatches");
+    finalDecisionMismatches_vs_LS = ibooker.book1D("finalDecisionMismatches_vs_LS", "uGT final decision mismatches vs Luminosity Segment", numLS_, 0., double(numLS_));
+    finalDecisionMismatches_vs_LS->getTH1F()->GetYaxis()->SetTitle("Events with Final Decision Mismatch");
+    finalDecisionMismatches_vs_LS->getTH1F()->GetXaxis()->SetTitle("Luminosity Segment");
+
+    hname = "DataNoEmul_" + bxt.str();
+    htitle  = "uGT data-emul mismatch -- Data fired but not Emulator --" + bxn.str();
+    m_HistNamesFinal[hname] = ibooker.book1D(hname, htitle, nbins, xmin, xmax);
+
+    hname = "EmulatorNoData_" + bxt.str();
+    htitle  = "uGT data-emul mismatch -- Emulator fired but not Data --" + bxn.str();
+    m_HistNamesFinal[hname] = ibooker.book1D(hname, htitle, nbins, xmin, xmax);
+
+  }
+
+  // Set some histogram attributes
+  for (std::map<std::string,MonitorElement*>::iterator it = m_HistNamesInitial.begin(); it != m_HistNamesInitial.end(); ++it) {
+    // for (unsigned int i = 0; i < prescales.size(); i++) {
+    //   auto const& name = prescales.at(i).first;    
+    //   if (name != "NULL")
+    // 	(*it).second->getTH1F()->GetXaxis()->SetBinLabel(1+i, name.c_str());
+    // }
+    (*it).second->getTH1F()->GetXaxis()->SetTitle("Trigger Bit");
+    (*it).second->getTH1F()->GetYaxis()->SetTitle("Events with Initial Decision Mismatch");
+  }
+
+  for (std::map<std::string,MonitorElement*>::iterator it = m_HistNamesFinal.begin(); it != m_HistNamesFinal.end(); ++it) {
+    // for (unsigned int i = 0; i < prescales.size(); i++) {
+    //   auto const& name = prescales.at(i).first;    
+    //   if (name != "NULL")
+    // 	(*it).second->getTH1F()->GetXaxis()->SetBinLabel(1+i, name.c_str());
+    // }
+    (*it).second->getTH1F()->GetXaxis()->SetTitle("Trigger Bit (Unprescaled)");
+    (*it).second->getTH1F()->GetYaxis()->SetTitle("Events with Final Decision Mismatch");
+  }
+
+
+}
+
+void L1TdeStage2uGT::fillHist(const std::map<std::string, MonitorElement*>& m_HistNames, const std::string& histName, const Double_t& value, const Double_t& wt=1.){
+
+  std::map<std::string, MonitorElement*>::const_iterator hid = m_HistNames.find(histName);
+
+  if (hid==m_HistNames.end())
+    edm::LogWarning("L1TdeStage2uGT") << "%fillHist -- Could not find histogram with name: " << histName << std::endl;
+  else
+    hid->second->Fill(value,wt);
+}

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -35,6 +35,8 @@ from DQM.L1TMonitorClient.L1TStage2EMTFEmulatorClient_cff import *
 # L1 emulator event info DQM client 
 from DQM.L1TMonitorClient.L1TStage2EmulatorEventInfoClient_cfi import *
 
+## uGT emulator client
+from DQM.L1TMonitorClient.L1TStage2uGTEmulatorClient_cff import *
 
 #
 # define sequences 
@@ -48,7 +50,8 @@ l1TStage2EmulatorClients = cms.Sequence(
                       + l1tStage2BMTFEmulatorClient
                       + l1tStage2OMTFEmulatorClient
                       + l1tStage2EMTFEmulatorClient
-                      + l1tStage2EmulatorEventInfoClient 
+                      + l1tStage2EmulatorEventInfoClient
+                      + l1tStage2uGTEmulatorClient
                         )
 
 l1tStage2EmulatorMonitorClient = cms.Sequence(

--- a/DQM/L1TMonitorClient/python/L1TStage2uGTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGTEmulatorClient_cff.py
@@ -1,0 +1,72 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQM.L1TMonitor.L1TdeStage2uGMT_cff import ignoreBins
+
+# directories
+ugmtEmuDqmDir = "L1TEMU/L1TdeStage2uGT"
+
+
+BX            = 'CentralBX'
+errHistNumStr = 'dataEmulSummary_' + BX
+errHistDenStr = 'normalizationHisto'
+ratioHistStr  = 'dataEmulMismatchRatio_' + BX
+
+l1tStage2uGTEmulatorCompRatioClientBX0 = DQMEDHarvester("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string(ugmtEmuDqmDir),
+    inputNum = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistNumStr),
+    inputDen = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistDenStr),
+    ratioName = cms.untracked.string(ratioHistStr),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGT emulator and data'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+l1tStage2uGTEmulatorCompRatioClientBXP1 = l1tStage2uGTEmulatorCompRatioClientBX0.clone()
+l1tStage2uGTEmulatorCompRatioClientBXP2 = l1tStage2uGTEmulatorCompRatioClientBX0.clone()
+l1tStage2uGTEmulatorCompRatioClientBXM1 = l1tStage2uGTEmulatorCompRatioClientBX0.clone()
+l1tStage2uGTEmulatorCompRatioClientBXM2 = l1tStage2uGTEmulatorCompRatioClientBX0.clone()
+
+
+BX            = 'BX1'
+errHistNumStr = 'dataEmulSummary_' + BX
+errHistDenStr = 'normalizationHisto'
+ratioHistStr  = 'dataEmulMismatchRatio_' + BX
+l1tStage2uGTEmulatorCompRatioClientBXP1.inputNum  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistNumStr)
+l1tStage2uGTEmulatorCompRatioClientBXP1.inputDen  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistDenStr)
+l1tStage2uGTEmulatorCompRatioClientBXP1.ratioName = cms.untracked.string(ratioHistStr)
+
+BX            = 'BX2'
+errHistNumStr = 'dataEmulSummary_' + BX
+errHistDenStr = 'normalizationHisto'
+ratioHistStr  = 'dataEmulMismatchRatio_' + BX
+l1tStage2uGTEmulatorCompRatioClientBXP2.inputNum  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistNumStr)
+l1tStage2uGTEmulatorCompRatioClientBXP2.inputDen  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistDenStr)
+l1tStage2uGTEmulatorCompRatioClientBXP2.ratioName = cms.untracked.string(ratioHistStr)
+
+BX            = 'BX-1'
+errHistNumStr = 'dataEmulSummary_' + BX
+errHistDenStr = 'normalizationHisto'
+ratioHistStr  = 'dataEmulMismatchRatio_' + BX
+l1tStage2uGTEmulatorCompRatioClientBXM1.inputNum  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistNumStr)
+l1tStage2uGTEmulatorCompRatioClientBXM1.inputDen  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistDenStr)
+l1tStage2uGTEmulatorCompRatioClientBXM1.ratioName = cms.untracked.string(ratioHistStr)
+
+BX            = 'BX-2'
+errHistNumStr = 'dataEmulSummary_' + BX
+errHistDenStr = 'normalizationHisto'
+ratioHistStr  = 'dataEmulMismatchRatio_' + BX
+l1tStage2uGTEmulatorCompRatioClientBXM2.inputNum  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistNumStr)
+l1tStage2uGTEmulatorCompRatioClientBXM2.inputDen  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistDenStr)
+l1tStage2uGTEmulatorCompRatioClientBXM2.ratioName = cms.untracked.string(ratioHistStr)
+
+# uGT
+
+# sequences
+l1tStage2uGTEmulatorClient = cms.Sequence(
+    l1tStage2uGTEmulatorCompRatioClientBX0 +
+    l1tStage2uGTEmulatorCompRatioClientBXP1 +
+    l1tStage2uGTEmulatorCompRatioClientBXP2 +
+    l1tStage2uGTEmulatorCompRatioClientBXM1 +
+    l1tStage2uGTEmulatorCompRatioClientBXM2
+)
+

--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -259,6 +259,7 @@ private:
 
     bool m_firstEv;
     bool m_firstEvLumiSegment;
+    uint m_currentLumi;
 
 private:
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -51,6 +51,8 @@ void L1TGlobalProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<edm::InputTag> ("JetInputTag", edm::InputTag(""))->setComment("InputTag for Calo Trigger Jet (required parameter:  default value is invalid)");
   desc.add<edm::InputTag> ("EtSumInputTag", edm::InputTag(""))->setComment("InputTag for Calo Trigger EtSum (required parameter:  default value is invalid)");
   desc.add<edm::InputTag> ("ExtInputTag", edm::InputTag(""))->setComment("InputTag for external conditions (not required, but recommend to specify explicitly in config)");
+  desc.add<edm::InputTag> ("AlgoBlkInputTag", edm::InputTag("gtDigis"))->setComment("InputTag for unpacked Algblk (required only if GetPrescaleColumnFromData set to true)");
+  desc.add<bool> ("GetPrescaleColumnFromData",false)->setComment("Get prescale column from unpacked GlobalAlgBck. Otherwise use value specified in PrescaleSet");
   desc.add<bool> ("AlgorithmTriggersUnprescaled", false)->setComment("not required, but recommend to specify explicitly in config");
   desc.add<bool> ("AlgorithmTriggersUnmasked", false)->setComment("not required, but recommend to specify explicitly in config");
   // These parameters have well defined  default values and are not currently 
@@ -97,15 +99,19 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet) :
 
             m_verbosity(parSet.getUntrackedParameter<int>("Verbosity")),
 	    m_printL1Menu(parSet.getUntrackedParameter<bool>("PrintL1Menu")),
-            m_isDebugEnabled(edm::isDebugEnabled())
+            m_isDebugEnabled(edm::isDebugEnabled()),
+	    m_getPrescaleColumnFromData(parSet.getParameter<bool>("GetPrescaleColumnFromData")),
+	    m_algoblkInputTag(parSet.getParameter<edm::InputTag>("AlgoBlkInputTag"))
 {
 
-  m_egInputToken = consumes <BXVector<EGamma> > (m_egInputTag);
-  m_tauInputToken = consumes <BXVector<Tau> > (m_tauInputTag);
-  m_jetInputToken = consumes <BXVector<Jet> > (m_jetInputTag);
-  m_sumInputToken = consumes <BXVector<EtSum> > (m_sumInputTag);
-  m_muInputToken = consumes <BXVector<Muon> > (m_muInputTag);
-  m_extInputToken = consumes <BXVector<GlobalExtBlk> > (m_extInputTag);
+    m_egInputToken = consumes <BXVector<EGamma> > (m_egInputTag);
+    m_tauInputToken = consumes <BXVector<Tau> > (m_tauInputTag);
+    m_jetInputToken = consumes <BXVector<Jet> > (m_jetInputTag);
+    m_sumInputToken = consumes <BXVector<EtSum> > (m_sumInputTag);
+    m_muInputToken = consumes <BXVector<Muon> > (m_muInputTag);
+    m_extInputToken = consumes <BXVector<GlobalExtBlk> > (m_extInputTag);
+    if (m_getPrescaleColumnFromData) 
+      m_algoblkInputToken = consumes <BXVector<GlobalAlgBlk> > (m_algoblkInputTag);
 
     if (m_verbosity) {
 
@@ -222,6 +228,7 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet) :
 
     m_l1GtTmVetoAlgoCacheID = 0ULL;
 
+    m_currentLumi = 0;
 
     // Set default, initial, dummy prescale factor table
     std::vector<std::vector<int> > temp_prescaleTable;
@@ -395,6 +402,21 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 	m_triggerMaskVetoAlgoTrig = &(m_l1GtPrescalesVetoes->triggerMaskVeto());
 
 	m_l1GtPfAlgoCacheID = l1GtPfAlgoCacheID;
+      }
+      if (m_getPrescaleColumnFromData && (m_currentLumi != iEvent.luminosityBlock()) ){ // get prescale column from unpacked data
+
+	m_currentLumi=iEvent.luminosityBlock();
+
+	edm::Handle<BXVector<GlobalAlgBlk>> m_uGtAlgBlk;
+	iEvent.getByToken(m_algoblkInputToken, m_uGtAlgBlk);
+
+	if(m_uGtAlgBlk.isValid()) {
+	  std::vector<GlobalAlgBlk>::const_iterator algBlk = m_uGtAlgBlk->begin(0);
+	  m_prescaleSet=static_cast<unsigned int>(algBlk->getPreScColumn());
+	}else{
+	  m_prescaleSet=1;
+	  edm::LogError("L1TGlobalProduce") << "Could not find valid algo block. Setting prescale column to 1" << std::endl;
+	}
       }
     }
     else{

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -410,7 +410,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 	edm::Handle<BXVector<GlobalAlgBlk>> m_uGtAlgBlk;
 	iEvent.getByToken(m_algoblkInputToken, m_uGtAlgBlk);
 
-	if(m_uGtAlgBlk.isValid()) {
+	if(m_uGtAlgBlk.isValid() && !m_uGtAlgBlk->isEmpty(0)) {
 	  std::vector<GlobalAlgBlk>::const_iterator algBlk = m_uGtAlgBlk->begin(0);
 	  m_prescaleSet=static_cast<unsigned int>(algBlk->getPreScColumn());
 	}else{

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -99,6 +99,8 @@ private:
     /// CSV file for prescales
     std::string m_prescalesFile;
 
+    uint m_currentLumi;
+
     /// trigger masks & veto masks
     const L1GtTriggerMask* m_l1GtTmAlgo;
     unsigned long long m_l1GtTmAlgoCacheID;
@@ -173,7 +175,11 @@ private:
     int m_verbosity;
     bool m_printL1Menu;
     bool m_isDebugEnabled;
-    
+
+    bool m_getPrescaleColumnFromData;    
+    edm::InputTag m_algoblkInputTag;
+    edm::EDGetToken m_algoblkInputToken;
+
 
 };
 

--- a/L1Trigger/L1TGlobal/python/simGtStage2Digis_cfi.py
+++ b/L1Trigger/L1TGlobal/python/simGtStage2Digis_cfi.py
@@ -16,6 +16,8 @@ simGtStage2Digis = cms.EDProducer("L1TGlobalProducer",
     EtSumInputTag = cms.InputTag("simCaloStage2Digis"),
     AlgorithmTriggersUnmasked = cms.bool(True),    
     AlgorithmTriggersUnprescaled = cms.bool(True),
+    GetPrescaleColumnFromData = cms.bool(False),
+    AlgoBlkInputTag = cms.InputTag("gtStage2Digis")
     # deprecated in Mike's version of producer:                              
     #ProduceL1GtDaqRecord = cms.bool(True),
     #GmtInputTag = cms.InputTag("gtInput"),

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -67,6 +67,7 @@ l1t::GlobalBoard::GlobalBoard() :
     m_candL1External( new BXVector<const GlobalExtBlk*>),
     m_firstEv(true),
     m_firstEvLumiSegment(true),
+    m_currentLumi(0),
     m_isDebugEnabled(edm::isDebugEnabled())
 {
 
@@ -957,10 +958,11 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
 	m_prescaleCounterAlgoTrig.push_back(prescaleFactorsAlgoTrig);
       }
       m_firstEv = false;
+      m_currentLumi=iEvent.luminosityBlock();
     }
 
-    // TODO FIXME find the beginning of the luminosity segment
-    if( m_firstEvLumiSegment ){
+    // update and clear prescales at the beginning of the luminosity segment
+    if( m_firstEvLumiSegment || m_currentLumi != iEvent.luminosityBlock() ){
 
       m_prescaleCounterAlgoTrig.clear();
       for( int iBxInEvent = 0; iBxInEvent <= totalBxInEvent; ++iBxInEvent ){
@@ -968,6 +970,7 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
       }
 
       m_firstEvLumiSegment = false;
+      m_currentLumi=iEvent.luminosityBlock();
     }
 
     // Copy Algorithm bits to Prescaled word 


### PR DESCRIPTION
Backport of #22907 and #22961 

This PR add a new DQM module to make uGT data/emulator comparisons and also add option to use prescale column from unpacked GlobalAlgBlk in emulator (#22907). Also adds a check that the GlobalAlgBlk is not empty when trying to get the prescale column number from the unpacked data (#22961).