### PR TITLE
Use GBRForest in PATMuonProducer

### DIFF
--- a/PhysicsTools/PatAlgos/interface/MuonMvaEstimator.h
+++ b/PhysicsTools/PatAlgos/interface/MuonMvaEstimator.h
@@ -1,46 +1,56 @@
 #ifndef __PhysicsTools_PatAlgos_MuonMvaEstimator__
 #define __PhysicsTools_PatAlgos_MuonMvaEstimator__
-#include "DataFormats/MuonReco/interface/Muon.h"
-#include "DataFormats/PatCandidates/interface/Muon.h"
+
 #include "DataFormats/BTauReco/interface/JetTag.h"
-#include "TMVA/Reader.h"
+
+#include <memory>
+#include <string>
+
+class GBRForest;
+
+namespace pat {
+  class Muon;
+}
 
 namespace reco {
   class JetCorrector;
+  class Vertex;
 }
+
 namespace pat {
   class MuonMvaEstimator{
   public:
-    MuonMvaEstimator();
-    void initialize(std::string weightsfile, 
-		    float dRmax);
-    void computeMva(const pat::Muon& imuon,
-		    const reco::Vertex& vertex,
-		    const reco::JetTagCollection& bTags,
-		    const reco::JetCorrector* correctorL1=nullptr,
-		    const reco::JetCorrector* correctorL1L2L3Res=nullptr);
-    float mva() const {return mva_;}
-    float jetPtRatio() const {return jetPtRatio_;}
-    float jetPtRel() const {return jetPtRel_;}
+
+    MuonMvaEstimator(const std::string& weightsfile, float dRmax);
+
+    ~MuonMvaEstimator();
+
+    float computeMva(const pat::Muon& imuon,
+                     const reco::Vertex& vertex,
+                     const reco::JetTagCollection& bTags,
+                     float& jetPtRatio,
+                     float& jetPtRel,
+                     const reco::JetCorrector* correctorL1=nullptr,
+                     const reco::JetCorrector* correctorL1L2L3Res=nullptr) const;
+
   private:
-    TMVA::Reader tmvaReader_;
-    bool initialized_;
-    float mva_;
+
+    std::unique_ptr<const GBRForest> gbrForest_;
     float dRmax_;
-    
+
     /// MVA VAriables
-    float pt_;
-    float eta_;
-    float jetNDauCharged_;
-    float miniRelIsoCharged_;
-    float miniRelIsoNeutral_;
-    float jetPtRel_;
-    float jetPtRatio_;
-    float jetBTagCSV_;
-    float sip_;
-    float log_abs_dxyBS_; 
-    float log_abs_dzPV_;            
-    float segmentCompatibility_;
+    float pt_ = 0.0;
+    float eta_ = 0.0;
+    float jetNDauCharged_ = 0.0;
+    float miniRelIsoCharged_ = 0.0;
+    float miniRelIsoNeutral_ = 0.0;
+    float jetPtRel_ = 0.0;
+    float jetPtRatio_ = 0.0;
+    float jetBTagCSV_ = 0.0;
+    float sip_ = 0.0;
+    float log_abs_dxyBS_ = 0.0;
+    float log_abs_dzPV_ = 0.0;
+    float segmentCompatibility_ = 0.0;
   };
 }
 #endif

--- a/PhysicsTools/PatAlgos/interface/SoftMuonMvaEstimator.h
+++ b/PhysicsTools/PatAlgos/interface/SoftMuonMvaEstimator.h
@@ -1,43 +1,50 @@
 #ifndef __PhysicsTools_PatAlgos_SoftMuonMvaEstimator__
 #define __PhysicsTools_PatAlgos_SoftMuonMvaEstimator__
-#include "DataFormats/MuonReco/interface/Muon.h"
-#include "DataFormats/PatCandidates/interface/Muon.h"
-#include "TMVA/Reader.h"
+
+#include <memory>
+#include <string>
+
+class GBRForest;
 
 namespace pat {
-class SoftMuonMvaEstimator{
-public:
-  SoftMuonMvaEstimator();
-  void initialize(std::string weightsfile);
-  void computeMva(const pat::Muon& imuon);
-  float mva() const {return mva_;}
+  class Muon;
+}
+
+namespace pat {
+  class SoftMuonMvaEstimator{
+  public:
+
+    SoftMuonMvaEstimator(const std::string& weightsfile);
+
+    ~SoftMuonMvaEstimator();
+
+    float computeMva(const pat::Muon& imuon) const;
+
   private:
-  TMVA::Reader tmvaReader_;
-  bool initialized_;
-  float mva_;
 
-  // MVA Spectator
-  float pID_;
-  float pt_;
-  float eta_;
-  float momID_;
-  float dummy_;
+    std::unique_ptr<const GBRForest> gbrForest_;
 
-  // MVA VAriables
-  float segmentCompatibility_;
-  float chi2LocalMomentum_;
-  float chi2LocalPosition_;
-  float glbTrackProbability_;
-  float iValidFraction_;
-  float layersWithMeasurement_;
-  float trkKink_;
-  float log2PlusGlbKink_;
-  float timeAtIpInOutErr_;
-  float outerChi2_;
-  float innerChi2_;
-  float trkRelChi2_;
-  float vMuonHitComb_;
-  float qProd_;
+    // MVA VAriables
+    float segmentCompatibility_ = 0.0;
+    float chi2LocalMomentum_ = 0.0;
+    float chi2LocalPosition_ = 0.0;
+    float glbTrackProbability_ = 0.0;
+    float iValidFraction_ = 0.0;
+    float layersWithMeasurement_ = 0.0;
+    float trkKink_ = 0.0;
+    float log2PlusGlbKink_ = 0.0;
+    float timeAtIpInOutErr_ = 0.0;
+    float outerChi2_ = 0.0;
+    float innerChi2_ = 0.0;
+    float trkRelChi2_ = 0.0;
+    float vMuonHitComb_ = 0.0;
+    float qProd_ = 0.0;
+
+    // MVA Spectator
+    float pID_ = 0.0;
+    float pt_ = 0.0;
+    float eta_ = 0.0;
+    float momID_ = 0.0;
 
   };
 }

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -36,18 +36,44 @@
 #include "PhysicsTools/PatAlgos/interface/SoftMuonMvaEstimator.h"
 
 namespace pat {
+
+  class PATMuonHeavyObjectCache {
+  public:
+
+    PATMuonHeavyObjectCache(const edm::ParameterSet&);
+
+    std::unique_ptr<const pat::MuonMvaEstimator> const& muonMvaEstimator() const {
+      return muonMvaEstimator_;
+    }
+
+    std::unique_ptr<const pat::SoftMuonMvaEstimator> const& softMuonMvaEstimator() const {
+      return softMuonMvaEstimator_;
+    }
+
+  private:
+    std::unique_ptr<const pat::MuonMvaEstimator> muonMvaEstimator_;
+    std::unique_ptr<const pat::SoftMuonMvaEstimator> softMuonMvaEstimator_;
+  };
+
   /// foward declarations
   class TrackerIsolationPt;
   class CaloIsolationEnergy;
 
   /// class definition
-  class PATMuonProducer : public edm::stream::EDProducer<> {
+  class PATMuonProducer : public edm::stream::EDProducer<edm::GlobalCache<PATMuonHeavyObjectCache>> {
 
   public:
     /// default constructir
-    explicit PATMuonProducer(const edm::ParameterSet & iConfig);
+    explicit PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavyObjectCache const*);
     /// default destructur
     ~PATMuonProducer() override;
+
+    static std::unique_ptr<PATMuonHeavyObjectCache> initializeGlobalCache(const edm::ParameterSet& iConfig) {
+      return std::make_unique<PATMuonHeavyObjectCache>(iConfig);
+    }
+
+    static void globalEndJob(PATMuonHeavyObjectCache*) { }
+
     /// everything that needs to be done during the event loop
     void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
     /// description of config file parameters
@@ -168,16 +194,11 @@ namespace pat {
     bool computeMuonMVA_;
     bool computeSoftMuonMVA_;
     bool recomputeBasicSelectors_;
-    double mvaDrMax_;
     bool mvaUseJec_;
     edm::EDGetTokenT<reco::JetTagCollection> mvaBTagCollectionTag_;
     edm::EDGetTokenT<reco::JetCorrector> mvaL1Corrector_;
     edm::EDGetTokenT<reco::JetCorrector> mvaL1L2L3ResCorrector_;
     edm::EDGetTokenT<double> rho_;
-    pat::MuonMvaEstimator mvaEstimator_;
-    std::string mvaTrainingFile_;
-    pat::SoftMuonMvaEstimator softMvaEstimator_;
-    std::string softMvaTrainingFile_;
     
     /// --- tools ---
     /// comparator for pt ordering


### PR DESCRIPTION
This PR was motivated by an igprof performance profile where we were looking for initialization times for modules that were proportional to the number of streams and significant. It was about the fourth highest and the higher ones were recently fixed also. The intent is that this should not change results. I tested by printing the mva values calculated with and without this change in runTheMatrix test 10824.0 and they were identical. I also verified it removes the scaling with number of streams with igprof.