### PR TITLE
Ecal pf rechit eta dependent 94x

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -63,6 +63,20 @@ def customiseFor20429(process):
         del producer.GBRForestFileName
     return process
 
+
+# to be able to run HLT with new ECAL code and default values
+def customiseFor22967(process):
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
+        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
+            module = getattr(process,hltParticleFlowRecHitECAL)
+            for producer in module.producers: 
+                if hasattr(producer,'qualityTests'):
+                    for qualityTest in producer.qualityTests:
+                        if hasattr(qualityTest,'thresholds'):
+                            qualityTest.applySelectionsToAllCrystals = cms.bool(False)                        
+    return process
+
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -74,5 +88,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     process = customiseFor19989(process)
     process = customiseFor20422(process)
     process = customiseFor20429(process)
+    process = customiseFor22967(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -64,28 +64,6 @@ def customiseFor20429(process):
     return process
 
 
-# 
-# Threshold 1-sigma backported from 10_0_X cmssw release from 2018 to perform tests on 2017 data/MC
-#
-
-def customiseForEcalTest(process):
-
-    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
-        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
-            module = getattr(process,hltParticleFlowRecHitECAL)
-
-            for producer in module.producers: 
-                if hasattr(producer,'srFlags'):
-                    producer.srFlags = cms.InputTag("")
-                if hasattr(producer,'qualityTests'):
-                    for qualityTest in producer.qualityTests:
-                        if hasattr(qualityTest,'thresholds'):
-                            qualityTest.applySelectionsToAllCrystals = cms.bool(True)
-                        
-    return process
-
-
-
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -63,6 +63,33 @@ def customiseFor20429(process):
         del producer.GBRForestFileName
     return process
 
+
+# 
+# The three different set of thresholds will be used to study
+# possible new thresholds of pfrechits and effects on high level objects
+# The values proposed (A, B, C) are driven by expected noise levels
+#
+
+
+# particleFlowRechitECAL new default value "false" flag to be added
+def customiseForEcalTest(process):
+
+    for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 
+        if hasattr(process,hltParticleFlowRecHitECAL):                                                 
+            module = getattr(process,hltParticleFlowRecHitECAL)
+
+            for producer in module.producers: 
+                if hasattr(producer,'srFlags'):
+                    producer.srFlags = cms.InputTag("")
+                if hasattr(producer,'qualityTests'):
+                    for qualityTest in producer.qualityTests:
+                        if hasattr(qualityTest,'thresholds'):
+                            qualityTest.applySelectionsToAllCrystals = cms.bool(True)
+                        
+    return process
+
+
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -63,7 +63,6 @@ def customiseFor20429(process):
         del producer.GBRForestFileName
     return process
 
-
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -65,13 +65,9 @@ def customiseFor20429(process):
 
 
 # 
-# The three different set of thresholds will be used to study
-# possible new thresholds of pfrechits and effects on high level objects
-# The values proposed (A, B, C) are driven by expected noise levels
+# Threshold 1-sigma backported from 10_0_X cmssw release from 2018 to perform tests on 2017 data/MC
 #
 
-
-# particleFlowRechitECAL new default value "false" flag to be added
 def customiseForEcalTest(process):
 
     for hltParticleFlowRecHitECAL in ['hltParticleFlowRecHitECALUnseeded', 'hltParticleFlowRecHitECALL1Seeded', 'hltParticleFlowRecHitECALForMuonsMF', 'hltParticleFlowRecHitECALForTkMuonsMF']: 

--- a/RecoParticleFlow/Configuration/python/customizePF.py
+++ b/RecoParticleFlow/Configuration/python/customizePF.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+#
+# customization function for ECAL PF-rechit thresholds
+# - ZS everywhere
+# - 1-sigma noise equivalent from 2018
+#
+def ecalNoSRPFCut1sigma(process):
+   import RecoParticleFlow.PFClusterProducer.particleFlowZeroSuppressionECAL_cff as _pfZS
+   if hasattr(process, "particleFlowRecHitECAL"):
+      process.particleFlowRecHitECAL.producers[0].srFlags = ""
+      process.particleFlowRecHitECAL.producers[1].srFlags = ""
+      process.particleFlowRecHitECAL.producers[0].qualityTests.thresholds = _pfZS._particle_flow_zero_suppression_ECAL_2018.thresholds
+      process.particleFlowRecHitECAL.producers[1].qualityTests.thresholds = _pfZS._particle_flow_zero_suppression_ECAL_2018.thresholds
+      process.particleFlowRecHitECAL.producers[0].qualityTests.applySelectionsToAllCrystals = cms.bool(True)
+      process.particleFlowRecHitECAL.producers[1].qualityTests.applySelectionsToAllCrystals = cms.bool(True)
+
+   return process

--- a/RecoParticleFlow/Configuration/python/customizePF.py
+++ b/RecoParticleFlow/Configuration/python/customizePF.py
@@ -10,8 +10,8 @@ def ecalNoSRPFCut1sigma(process):
    if hasattr(process, "particleFlowRecHitECAL"):
       process.particleFlowRecHitECAL.producers[0].srFlags = ""
       process.particleFlowRecHitECAL.producers[1].srFlags = ""
-      process.particleFlowRecHitECAL.producers[0].qualityTests[0].thresholds = _pfZS._particle_flow_zero_suppression_ECAL_2018.thresholds
-      process.particleFlowRecHitECAL.producers[1].qualityTests[0].thresholds = _pfZS._particle_flow_zero_suppression_ECAL_2018.thresholds
+      process.particleFlowRecHitECAL.producers[0].qualityTests[0].thresholds = _pfZS._particle_flow_zero_suppression_ECAL_2018_B.thresholds
+      process.particleFlowRecHitECAL.producers[1].qualityTests[0].thresholds = _pfZS._particle_flow_zero_suppression_ECAL_2018_B.thresholds
       process.particleFlowRecHitECAL.producers[0].qualityTests[0].applySelectionsToAllCrystals = cms.bool(True)
       process.particleFlowRecHitECAL.producers[1].qualityTests[0].applySelectionsToAllCrystals = cms.bool(True)
    return process

--- a/RecoParticleFlow/Configuration/python/customizePF.py
+++ b/RecoParticleFlow/Configuration/python/customizePF.py
@@ -10,9 +10,9 @@ def ecalNoSRPFCut1sigma(process):
    if hasattr(process, "particleFlowRecHitECAL"):
       process.particleFlowRecHitECAL.producers[0].srFlags = ""
       process.particleFlowRecHitECAL.producers[1].srFlags = ""
-      process.particleFlowRecHitECAL.producers[0].qualityTests.thresholds = _pfZS._particle_flow_zero_suppression_ECAL_2018.thresholds
-      process.particleFlowRecHitECAL.producers[1].qualityTests.thresholds = _pfZS._particle_flow_zero_suppression_ECAL_2018.thresholds
-      process.particleFlowRecHitECAL.producers[0].qualityTests.applySelectionsToAllCrystals = cms.bool(True)
-      process.particleFlowRecHitECAL.producers[1].qualityTests.applySelectionsToAllCrystals = cms.bool(True)
-
+      process.particleFlowRecHitECAL.producers[0].qualityTests[0].thresholds = _pfZS._particle_flow_zero_suppression_ECAL_2018.thresholds
+      process.particleFlowRecHitECAL.producers[1].qualityTests[0].thresholds = _pfZS._particle_flow_zero_suppression_ECAL_2018.thresholds
+      process.particleFlowRecHitECAL.producers[0].qualityTests[0].applySelectionsToAllCrystals = cms.bool(True)
+      process.particleFlowRecHitECAL.producers[1].qualityTests[0].applySelectionsToAllCrystals = cms.bool(True)
    return process
+

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -384,7 +384,8 @@ public:
 
   PFRecHitQTestECALMultiThreshold(const edm::ParameterSet& iConfig):
     PFRecHitQTestBase(iConfig),
-    thresholds_(iConfig.getParameter<std::vector<double> >("thresholds"))
+    thresholds_(iConfig.getParameter<std::vector<double> >("thresholds")),
+    applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals"))
   {
     if (thresholds_.size() != EcalRingCalibrationTools::N_RING_TOTAL)
       throw edm::Exception(edm::errors::Configuration, "ValueError")
@@ -403,7 +404,8 @@ public:
   }
 
   bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-    return fullReadOut or pass(hit);
+    if (applySelectionsToAllCrystals_) return pass(hit);
+    else return fullReadOut or pass(hit);
   }
   bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
     return true;
@@ -428,6 +430,9 @@ protected:
   const std::vector<double> thresholds_;
   bool endcapGeometrySet_;
 
+  // apply selections to all crystals
+  bool applySelectionsToAllCrystals_;
+  
   bool pass(const reco::PFRecHit& hit){
 
     DetId detId(hit.detId());

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -20,7 +20,8 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
              qualityTests = cms.VPSet(
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECALMultiThreshold"),
-                  thresholds = particle_flow_zero_suppression_ECAL.thresholds
+                  thresholds = particle_flow_zero_suppression_ECAL.thresholds,
+                  applySelectionsToAllCrystals = cms.bool(True)
                   ),
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECAL"),
@@ -38,7 +39,8 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
             qualityTests = cms.VPSet(
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECALMultiThreshold"),
-                 thresholds = particle_flow_zero_suppression_ECAL.thresholds
+                 thresholds = particle_flow_zero_suppression_ECAL.thresholds,
+                 applySelectionsToAllCrystals = cms.bool(True)
                  ),
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECAL"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -16,12 +16,12 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
            cms.PSet(
              name = cms.string("PFEBRecHitCreator"),
              src  = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
-             srFlags = cms.InputTag(""),
+             srFlags = cms.InputTag("ecalDigis"),
              qualityTests = cms.VPSet(
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECALMultiThreshold"),
                   thresholds = particle_flow_zero_suppression_ECAL.thresholds,
-                  applySelectionsToAllCrystals = cms.bool(True)
+                  applySelectionsToAllCrystals = cms.bool(False)
                   ),
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECAL"),
@@ -35,12 +35,12 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
           cms.PSet(
             name = cms.string("PFEERecHitCreator"),
             src  = cms.InputTag("ecalRecHit","EcalRecHitsEE"),
-            srFlags = cms.InputTag(""),
+            srFlags = cms.InputTag("ecalDigis"),
             qualityTests = cms.VPSet(
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECALMultiThreshold"),
                  thresholds = particle_flow_zero_suppression_ECAL.thresholds,
-                 applySelectionsToAllCrystals = cms.bool(True)
+                 applySelectionsToAllCrystals = cms.bool(False)
                  ),
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECAL"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -16,7 +16,7 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
            cms.PSet(
              name = cms.string("PFEBRecHitCreator"),
              src  = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
-             srFlags = cms.InputTag("ecalDigis"),
+             srFlags = cms.InputTag(""),
              qualityTests = cms.VPSet(
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECALMultiThreshold"),
@@ -35,7 +35,7 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
           cms.PSet(
             name = cms.string("PFEERecHitCreator"),
             src  = cms.InputTag("ecalRecHit","EcalRecHitsEE"),
-            srFlags = cms.InputTag("ecalDigis"),
+            srFlags = cms.InputTag(""),
             qualityTests = cms.VPSet(
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECALMultiThreshold"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
@@ -4,11 +4,9 @@ pfZeroSuppressionThresholds_EB = [0.080]*170
 pfZeroSuppressionThresholds_EEminus = [0.300]*39
 pfZeroSuppressionThresholds_EEplus = pfZeroSuppressionThresholds_EEminus
 
-_pfZeroSuppressionThresholds_EB_2017 = [0.270]*170
-_pfZeroSuppressionThresholds_EEminus_2017 = [1.25023,   1.25033,   1.25047,   1.25068,   1.25097,   1.25139,   1.25199,   1.25286,   1.2541,   1.25587,  # rings 170-179 (EE-) / 209-218 (EE+) 
-                                             1.25842,   1.26207,   1.26729,   1.27479,   1.28553,   1.30092,   1.32299,   1.35462,   1.39995,  1.46493,  # rings 180-189 (EE-) / 219-228 (EE+)
-                                             1.55807,   1.69156,   1.88291,   2.15716,   2.55027,   3.11371,   3.92131,   5.07887,   6.73803,  9.11615,  # rings 190-199 (EE-) / 229-238 (EE+)
-                                             10,   10,   10,   10,   10,   10,   10,   10,   10 ]  # rings 200-208 (EE-) / 239-247 (EE+)
+
+_pfZeroSuppressionThresholds_EB_2017 = [0.140]*170
+_pfZeroSuppressionThresholds_EEminus_2017 = [0.11, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.17, 0.18, 0.18, 0.19, 0.19, 0.20, 0.22, 0.23, 0.25, 0.27, 0.29, 0.31, 0.34, 0.36, 0.39, 0.42, 0.45, 0.50, 0.57, 0.68, 0.84, 1.07, 1.40, 1.88, 2.55, 3.47, 4.73, 6.42, 8.65, 11.6, 15.4]  
 _pfZeroSuppressionThresholds_EEplus_2017 = _pfZeroSuppressionThresholds_EEminus_2017
 
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
@@ -4,7 +4,7 @@ pfZeroSuppressionThresholds_EB = [0.080]*170
 pfZeroSuppressionThresholds_EEminus = [0.300]*39
 pfZeroSuppressionThresholds_EEplus = pfZeroSuppressionThresholds_EEminus
 
-_pfZeroSuppressionThresholds_EB_2017 = [0.250]*170
+_pfZeroSuppressionThresholds_EB_2017 = [0.270]*170
 _pfZeroSuppressionThresholds_EEminus_2017 = [1.25023,   1.25033,   1.25047,   1.25068,   1.25097,   1.25139,   1.25199,   1.25286,   1.2541,   1.25587,  # rings 170-179 (EE-) / 209-218 (EE+) 
                                              1.25842,   1.26207,   1.26729,   1.27479,   1.28553,   1.30092,   1.32299,   1.35462,   1.39995,  1.46493,  # rings 180-189 (EE-) / 219-228 (EE+)
                                              1.55807,   1.69156,   1.88291,   2.15716,   2.55027,   3.11371,   3.92131,   5.07887,   6.73803,  9.11615,  # rings 190-199 (EE-) / 229-238 (EE+)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
@@ -5,9 +5,19 @@ pfZeroSuppressionThresholds_EEminus = [0.300]*39
 pfZeroSuppressionThresholds_EEplus = pfZeroSuppressionThresholds_EEminus
 
 
-_pfZeroSuppressionThresholds_EB_2017 = [0.140]*170
-_pfZeroSuppressionThresholds_EEminus_2017 = [0.11, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.17, 0.18, 0.18, 0.19, 0.19, 0.20, 0.22, 0.23, 0.25, 0.27, 0.29, 0.31, 0.34, 0.36, 0.39, 0.42, 0.45, 0.50, 0.57, 0.68, 0.84, 1.07, 1.40, 1.88, 2.55, 3.47, 4.73, 6.42, 8.65, 11.6, 15.4]  
+
+_pfZeroSuppressionThresholds_EB_2017 = [0.250]*170
+_pfZeroSuppressionThresholds_EEminus_2017 = [1.25023,   1.25033,   1.25047,   1.25068,   1.25097,   1.25139,   1.25199,   1.25286,   1.2541,   1.25587,  # rings 170-179 (EE-) / 209-218 (EE+) 
+                                             1.25842,   1.26207,   1.26729,   1.27479,   1.28553,   1.30092,   1.32299,   1.35462,   1.39995,  1.46493,  # rings 180-189 (EE-) / 219-228 (EE+)
+                                             1.55807,   1.69156,   1.88291,   2.15716,   2.55027,   3.11371,   3.92131,   5.07887,   6.73803,  9.11615,  # rings 190-199 (EE-) / 229-238 (EE+)
+                                             10,   10,   10,   10,   10,   10,   10,   10,   10 ]  # rings 200-208 (EE-) / 239-247 (EE+)
 _pfZeroSuppressionThresholds_EEplus_2017 = _pfZeroSuppressionThresholds_EEminus_2017
+
+
+
+_pfZeroSuppressionThresholds_EB_2018 = [0.140]*170
+_pfZeroSuppressionThresholds_EEminus_2018 = [0.11, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.17, 0.18, 0.18, 0.19, 0.19, 0.20, 0.22, 0.23, 0.25, 0.27, 0.29, 0.31, 0.34, 0.36, 0.39, 0.42, 0.45, 0.50, 0.57, 0.68, 0.84, 1.07, 1.40, 1.88, 2.55, 3.47, 4.73, 6.42, 8.65, 11.6, 15.4]  
+_pfZeroSuppressionThresholds_EEplus_2018 = _pfZeroSuppressionThresholds_EEminus_2018
 
 
 
@@ -18,6 +28,11 @@ particle_flow_zero_suppression_ECAL = cms.PSet(
 
 _particle_flow_zero_suppression_ECAL_2017 = cms.PSet(
     thresholds = cms.vdouble(_pfZeroSuppressionThresholds_EB_2017 + _pfZeroSuppressionThresholds_EEminus_2017 + _pfZeroSuppressionThresholds_EEplus_2017
+        )
+    )
+
+_particle_flow_zero_suppression_ECAL_2018 = cms.PSet(
+    thresholds = cms.vdouble(_pfZeroSuppressionThresholds_EB_2018 + _pfZeroSuppressionThresholds_EEminus_2018 + _pfZeroSuppressionThresholds_EEplus_2018
         )
     )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowZeroSuppressionECAL_cff.py
@@ -15,9 +15,9 @@ _pfZeroSuppressionThresholds_EEplus_2017 = _pfZeroSuppressionThresholds_EEminus_
 
 
 
-_pfZeroSuppressionThresholds_EB_2018 = [0.140]*170
-_pfZeroSuppressionThresholds_EEminus_2018 = [0.11, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.17, 0.18, 0.18, 0.19, 0.19, 0.20, 0.22, 0.23, 0.25, 0.27, 0.29, 0.31, 0.34, 0.36, 0.39, 0.42, 0.45, 0.50, 0.57, 0.68, 0.84, 1.07, 1.40, 1.88, 2.55, 3.47, 4.73, 6.42, 8.65, 11.6, 15.4]  
-_pfZeroSuppressionThresholds_EEplus_2018 = _pfZeroSuppressionThresholds_EEminus_2018
+_pfZeroSuppressionThresholds_EB_2018_B = [0.140]*170
+_pfZeroSuppressionThresholds_EEminus_2018_B = [0.11, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.17, 0.18, 0.18, 0.19, 0.19, 0.20, 0.22, 0.23, 0.25, 0.27, 0.29, 0.31, 0.34, 0.36, 0.39, 0.42, 0.45, 0.50, 0.57, 0.68, 0.84, 1.07, 1.40, 1.88, 2.55, 3.47, 4.73, 6.42, 8.65, 11.6, 15.4]  
+_pfZeroSuppressionThresholds_EEplus_2018_B = _pfZeroSuppressionThresholds_EEminus_2018_B
 
 
 
@@ -31,8 +31,8 @@ _particle_flow_zero_suppression_ECAL_2017 = cms.PSet(
         )
     )
 
-_particle_flow_zero_suppression_ECAL_2018 = cms.PSet(
-    thresholds = cms.vdouble(_pfZeroSuppressionThresholds_EB_2018 + _pfZeroSuppressionThresholds_EEminus_2018 + _pfZeroSuppressionThresholds_EEplus_2018
+_particle_flow_zero_suppression_ECAL_2018_B = cms.PSet(
+    thresholds = cms.vdouble(_pfZeroSuppressionThresholds_EB_2018_B + _pfZeroSuppressionThresholds_EEminus_2018_B + _pfZeroSuppressionThresholds_EEplus_2018_B
         )
     )
 


### PR DESCRIPTION
Implementation of eta depencent cuts on pf-rechits.
This is a test to check possible improvements for POGs.

The values correspond to 1-sigma noise after 30/fb in *2018*.
