### PR TITLE
HCALDQM: Update DigiTask for 2018 HE (10_1_X backport)

### DIFF
--- a/DQM/HcalCommon/interface/Constants.h
+++ b/DQM/HcalCommon/interface/Constants.h
@@ -180,7 +180,6 @@ namespace hcaldqm
 		int const HF = 4;
 		int const SUBDET_NUM = 4;
 		int const TPSUBDET_NUM = 2;
-		int const DIGISIZE[SUBDET_NUM] = {10, 10, 10, 3};
 		std::string const SUBDET_NAME[SUBDET_NUM]={"HB", "HE", "HO", "HF"};
 		std::string const SUBDETPM_NAME[2*SUBDET_NUM] = { "HBM", "HBP",
 			"HEM", "HEP", "HOM", "HOP", "HFM", "HFP"};

--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -77,10 +77,10 @@ namespace hcaldqm
 			{ffC_1000,"fC (QIE8)"},
 			{ffC_3000,"fC (QIE8)"},
 			{ffC_10000,"fC (QIE8)"},
-			{fQIE8fC_1000_50,"fC (QIE8)"},
-			{fQIE10fC_2000,"fC (QIE10/11)"},
-			{fQIE10fC_10000,"fC (QIE10/11)"},
-			{fQIE10fC_400000,"fC (QIE10/11)"},
+			{fQIE8fC_1000_50,"fC"},
+			{fQIE10fC_2000,"fC"},
+			{fQIE10fC_10000,"fC"},
+			{fQIE10fC_400000,"fC"},
 			{ffC_generic_10000,"fC (QIE8/10/11)"},
 			{ffC_generic_400000,"fC (QIE8/10/11)"},			
 			{fTiming_TS,"Timing"},
@@ -112,7 +112,7 @@ namespace hcaldqm
 			{fTime_ns_250,"Time (ns)"},
 			{fDualAnodeAsymmetry, "(q_{1}-q_{2})/(q_{1}+q_{2})"},
 			{fTimingRatio, "q_{SOI+1}/q_{SOI}"},
-			{fQIE10fC_100000Coarse,"fC (QIE10/11)"},
+			{fQIE10fC_100000Coarse,"fC"},
 			{fBadTDC, "TDC"},
 		};
 		const std::map<ValueQuantityType, double> min_value = {

--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -261,7 +261,7 @@ namespace hcaldqm
 			{fQIE10fC_2000,100},
 			{fQIE10fC_10000,500},
 			{fQIE8fC_1000_50,50},
-			{fTime_ns_250,250},
+			{fTime_ns_250,100},
 			{fADC_256,256},
 			{ffC_generic_10000,10000},
 			{ffC_generic_400000,10000},	

--- a/DQM/HcalTasks/interface/DigiRunSummary.h
+++ b/DQM/HcalTasks/interface/DigiRunSummary.h
@@ -3,6 +3,7 @@
 
 #include "DQM/HcalCommon/interface/DQClient.h"
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
 namespace hcaldqm
 {
@@ -37,6 +38,8 @@ namespace hcaldqm
 
 			ContainerXXX<uint32_t> _xDead, _xDigiSize, _xUniHF,
 				_xUni, _xNChs, _xNChsNominal;
+
+			std::map<HcalSubdetector, uint32_t> _refDigiSize;
 
 			//	flag enum
 			enum DigiLSFlag

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -44,15 +44,15 @@ class DigiTask : public hcaldqm::DQTask
 		void _resetMonitors(hcaldqm::UpdateFreq) override;
 
 		edm::InputTag		_tagHBHE;
-		edm::InputTag		_tagHEP17;
+		edm::InputTag		_tagHE;
 		edm::InputTag		_tagHO;
 		edm::InputTag		_tagHF;
 		edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-		edm::EDGetTokenT<QIE11DigiCollection> _tokHEP17;
+		edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
 		edm::EDGetTokenT<HODigiCollection>	 _tokHO;
 		edm::EDGetTokenT<QIE10DigiCollection>	_tokHF;
 
-		double _cutSumQ_HBHE, _cutSumQ_HEP17, _cutSumQ_HO, _cutSumQ_HF;
+		double _cutSumQ_HBHE, _cutSumQ_HE, _cutSumQ_HO, _cutSumQ_HF;
 		double _thresh_unihf;
 
 		//	flag vector
@@ -79,8 +79,8 @@ class DigiTask : public hcaldqm::DQTask
 		hcaldqm::filter::HashFilter _filter_VME;
 		hcaldqm::filter::HashFilter _filter_uTCA;
 		hcaldqm::filter::HashFilter _filter_FEDHF;
-		hcaldqm::filter::HashFilter _filter_HF;
-		hcaldqm::filter::HashFilter _filter_notHF;
+		hcaldqm::filter::HashFilter _filter_QIE1011;
+		hcaldqm::filter::HashFilter _filter_QIE8;
 		hcaldqm::filter::HashFilter _filter_HEP17;
 
 		/* hcaldqm::Containers */
@@ -93,17 +93,17 @@ class DigiTask : public hcaldqm::DQTask
 		hcaldqm::ContainerProf1D _cSumQvsBX_SubdetPM;	// online only!
 
 		// ADC, fC for HF (QIE10 has different ADC/fC)
-		hcaldqm::Container1D _cADC_SubdetPM_HF;
-		hcaldqm::Container1D _cfC_SubdetPM_HF;
-		hcaldqm::Container1D _cSumQ_SubdetPM_HF;
-		hcaldqm::ContainerProf1D _cSumQvsLS_SubdetPM_HF;
-		hcaldqm::ContainerProf1D _cSumQvsBX_SubdetPM_HF;	// online only!
+		hcaldqm::Container1D _cADC_SubdetPM_QIE1011;
+		hcaldqm::Container1D _cfC_SubdetPM_QIE1011;
+		hcaldqm::Container1D _cSumQ_SubdetPM_QIE1011;
+		hcaldqm::ContainerProf1D _cSumQvsLS_SubdetPM_QIE1011;
+		hcaldqm::ContainerProf1D _cSumQvsBX_SubdetPM_QIE1011;	// online only!
 
 		
 		//	Shape - just filling - not summary!
 		hcaldqm::Container1D _cShapeCut_FED;
 		hcaldqm::Container2D _cADCvsTS_SubdetPM;
-		hcaldqm::Container2D _cADCvsTS_SubdetPM_HF;
+		hcaldqm::Container2D _cADCvsTS_SubdetPM_QIE1011;
 
 		//	Timing
 		//	just filling - no summary!
@@ -143,7 +143,7 @@ class DigiTask : public hcaldqm::DQTask
 		hcaldqm::Container2D _cOccupancyCut_depth;
 		hcaldqm::Container1D _cOccupancyCutvsiphi_SubdetPM; // online only
 		hcaldqm::Container1D _cOccupancyCutvsieta_Subdet;	// online only
-		hcaldqm::Container2D _cOccupancyCutvsSlotvsLS_HFPM; // online only
+		//hcaldqm::Container2D _cOccupancyCutvsSlotvsLS_HFPM; // online only
 		hcaldqm::Container2D _cOccupancyCutvsiphivsLS_SubdetPM; // online only
 
 		//	Occupancy w/o and w/ a Cut vs BX and vs LS
@@ -167,14 +167,14 @@ class DigiTask : public hcaldqm::DQTask
 		hcaldqm::Container1D _cLETDCTime_SubdetPM;
 
 		// Bad TDC histograms
-		hcaldqm::Container1D _cBadTDCValues_SubdetPM_HF;
-		hcaldqm::Container1D _cBadTDCvsBX_SubdetPM_HF;
-		hcaldqm::Container1D _cBadTDCvsLS_SubdetPM_HF;
+		hcaldqm::Container1D _cBadTDCValues_SubdetPM;
+		hcaldqm::Container1D _cBadTDCvsBX_SubdetPM;
+		hcaldqm::Container1D _cBadTDCvsLS_SubdetPM;
 		hcaldqm::Container2D _cBadTDCCount_depth;
 
-		hcaldqm::Container1D _cBadTDCValues_SubdetPM_HEP17;
-		hcaldqm::Container1D _cBadTDCvsBX_SubdetPM_HEP17;
-		hcaldqm::Container1D _cBadTDCvsLS_SubdetPM_HEP17;
+		hcaldqm::Container1D _cBadTDCValues;
+		hcaldqm::Container1D _cBadTDCvsBX;
+		hcaldqm::Container1D _cBadTDCvsLS;
 
 		//	#events counters
 		MonitorElement *meNumEvents1LS; // to transfer the #events to harvesting

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -69,6 +69,8 @@ class DigiTask : public hcaldqm::DQTask
 		//	hashes/FED vectors
 		std::vector<uint32_t> _vhashFEDs;
 
+		std::map<HcalSubdetector, int> _refDigiSize;
+
 		//	emap
 		hcaldqm::electronicsmap::ElectronicsMap _ehashmap; // online only
 		hcaldqm::electronicsmap::ElectronicsMap _dhashmap;

--- a/DQM/HcalTasks/interface/LEDTask.h
+++ b/DQM/HcalTasks/interface/LEDTask.h
@@ -45,7 +45,7 @@ class LEDTask : public hcaldqm::DQTask
 
 		//	tags and tokens
 		edm::InputTag	_tagHBHE;
-		edm::InputTag	_tagHEP17;
+		edm::InputTag	_tagHE;
 		edm::InputTag	_tagHO;
 		edm::InputTag	_tagHF;
 		edm::InputTag	_tagTrigger;

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -50,7 +50,7 @@ class LaserTask : public hcaldqm::DQTask
 
 		//	tags and tokens
 		edm::InputTag	_tagHBHE;
-		edm::InputTag	_tagHEP17;
+		edm::InputTag	_tagHE;
 		edm::InputTag	_tagHO;
 		edm::InputTag	_tagHF;
 		edm::InputTag	_taguMN;

--- a/DQM/HcalTasks/interface/PedestalTask.h
+++ b/DQM/HcalTasks/interface/PedestalTask.h
@@ -42,7 +42,7 @@ class PedestalTask : public hcaldqm::DQTask
 
 		//	tags and tokens
 		edm::InputTag	_tagHBHE;
-		edm::InputTag	_tagHEP17;
+		edm::InputTag	_tagHE;
 		edm::InputTag	_tagHO;
 		edm::InputTag	_tagHF;
 		edm::InputTag	_tagTrigger;

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -727,13 +727,20 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		//	Explicit check on the DetIds present in the Collection
 		HcalDetId const& did = digi.detid();
 		uint32_t rawid = _ehashmap.lookup(did);
-		if (rawid==0) 
-		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
+		if (rawid==0) {
+			meUnknownIds1LS->Fill(1);
+			_unknownIdsPresent=true;
+			continue;
+		}
 		HcalElectronicsId const& eid(rawid);
-		if (did.subdet()==HcalBarrel) // Note: since this is HE, we obviously expect did.subdet() always to be HcalEndcap, but QIE11DigiCollection may someday expand.
+		if (did.subdet() != HcalEndcap) {
+			continue;
+		}
+		if (did.subdet()==HcalBarrel) { // Note: since this is HE, we obviously expect did.subdet() always to be HcalEndcap, but QIE11DigiCollection will have HB for Run 3.
 			rawidHBValid = did.rawId();
-		else if (did.subdet()==HcalEndcap) 
+		} else if (did.subdet()==HcalEndcap) {
 			rawidHEValid = did.rawId();
+		}
 
 		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
 		double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -9,7 +9,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 {
 	_tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE",
 		edm::InputTag("hcalDigis"));
-	_tagHEP17 = ps.getUntrackedParameter<edm::InputTag>("tagHEP17",
+	_tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE",
 		edm::InputTag("hcalDigis"));
 	_tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
 		edm::InputTag("hcalDigis"));
@@ -17,12 +17,12 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		edm::InputTag("hcalDigis"));
 
 	_tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-	_tokHEP17 = consumes<QIE11DigiCollection>(_tagHEP17);
+	_tokHE = consumes<QIE11DigiCollection>(_tagHE);
 	_tokHO = consumes<HODigiCollection>(_tagHO);
 	_tokHF = consumes<QIE10DigiCollection>(_tagHF);
 
 	_cutSumQ_HBHE = ps.getUntrackedParameter<double>("cutSumQ_HBHE", 20);
-	_cutSumQ_HEP17 = ps.getUntrackedParameter<double>("cutSumQ_HEP17", 20);
+	_cutSumQ_HE = ps.getUntrackedParameter<double>("cutSumQ_HE", 20);
 	_cutSumQ_HO = ps.getUntrackedParameter<double>("cutSumQ_HO", 20);
 	_cutSumQ_HF = ps.getUntrackedParameter<double>("cutSumQ_HF", 20);
 	_thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf", 0.2);
@@ -63,20 +63,14 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
 		vuTCA);
 
-	// Filters for HEP17 and HF, aka QIE10/11
-	std::vector<uint32_t> vhashHF; 
-	vhashHF.push_back(hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalForward, 29,1,1)));
-	_filter_HF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fSubdet,
-		vhashHF);
-	_filter_notHF.initialize(filter::fFilter, hcaldqm::hashfunctions::fSubdet,
-		vhashHF);
-
-	std::vector<uint32_t> vhashHEP17;
-	vhashHEP17.push_back(HcalDetId(HcalEndcap, 1, 63, 1));
-	vhashHEP17.push_back(HcalDetId(HcalEndcap, 1, 64, 1));
-	vhashHEP17.push_back(HcalDetId(HcalEndcap, 1, 65, 1));
-	vhashHEP17.push_back(HcalDetId(HcalEndcap, 1, 66, 1));
-	_filter_HEP17.initialize(filter::fPreserver, hcaldqm::hashfunctions::fSubdetPMiphi, vhashHEP17);
+	// Filters for QIE8 vs QIE10/11
+	std::vector<uint32_t> vhashQIE1011; 
+	vhashQIE1011.push_back(hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalEndcap, 20,1,1)));
+	vhashQIE1011.push_back(hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalForward, 29,1,1)));
+	_filter_QIE1011.initialize(filter::fPreserver, hcaldqm::hashfunctions::fSubdet,
+		vhashQIE1011);
+	_filter_QIE8.initialize(filter::fFilter, hcaldqm::hashfunctions::fSubdet,
+		vhashQIE1011);
 
 	//	INITIALIZE FIRST
 	_cADC_SubdetPM.initialize(_name, "ADC", hcaldqm::hashfunctions::fSubdetPM,
@@ -97,16 +91,16 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		new hcaldqm::quantity::LumiSection(_maxLS),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),0);
 
-	_cADC_SubdetPM_HF.initialize(_name, "ADC", hcaldqm::hashfunctions::fSubdetPM,
+	_cADC_SubdetPM_QIE1011.initialize(_name, "ADC", hcaldqm::hashfunctions::fSubdetPM,
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cfC_SubdetPM_HF.initialize(_name, "fC", hcaldqm::hashfunctions::fSubdetPM,
+	_cfC_SubdetPM_QIE1011.initialize(_name, "fC", hcaldqm::hashfunctions::fSubdetPM,
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_10000),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cSumQ_SubdetPM_HF.initialize(_name, "SumQ", hcaldqm::hashfunctions::fSubdetPM,
+	_cSumQ_SubdetPM_QIE1011.initialize(_name, "SumQ", hcaldqm::hashfunctions::fSubdetPM,
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_10000),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-	_cSumQvsLS_SubdetPM_HF.initialize(_name, "SumQvsLS",
+	_cSumQvsLS_SubdetPM_QIE1011.initialize(_name, "SumQvsLS",
 		hcaldqm::hashfunctions::fSubdetPM,
 		new hcaldqm::quantity::LumiSection(_maxLS),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_10000),0);
@@ -157,11 +151,12 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_128),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cADCvsTS_SubdetPM_HF.initialize(_name, "ADCvsTS",
+	_cADCvsTS_SubdetPM_QIE1011.initialize(_name, "ADCvsTS",
 		hcaldqm::hashfunctions::fSubdetPM,
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+
 	_cLETDCTimevsADC_SubdetPM.initialize(_name, "LETDCTimevsADC",
 		hcaldqm::hashfunctions::fSubdetPM,
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
@@ -181,15 +176,16 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		hcaldqm::hashfunctions::fSubdetPM,
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cBadTDCValues_SubdetPM_HF.initialize(_name, "BadTDCValues", 
+
+	_cBadTDCValues_SubdetPM.initialize(_name, "BadTDCValues", 
 		hcaldqm::hashfunctions::fSubdetPM,
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBadTDC),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cBadTDCvsBX_SubdetPM_HF.initialize(_name, "BadTDCvsBX", 
+	_cBadTDCvsBX_SubdetPM.initialize(_name, "BadTDCvsBX", 
 		hcaldqm::hashfunctions::fSubdetPM, 
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cBadTDCvsLS_SubdetPM_HF.initialize(_name, "BadTDCvsLS", 
+	_cBadTDCvsLS_SubdetPM.initialize(_name, "BadTDCvsLS", 
 		hcaldqm::hashfunctions::fSubdetPM, 
 		new hcaldqm::quantity::LumiSection(_maxLS),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
@@ -198,18 +194,6 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
 		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	_cBadTDCValues_SubdetPM_HEP17.initialize(_name, "BadTDCValues", 
-		hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBadTDC),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cBadTDCvsBX_SubdetPM_HEP17.initialize(_name, "BadTDCvsBX", 
-		hcaldqm::hashfunctions::fSubdetPM, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cBadTDCvsLS_SubdetPM_HEP17.initialize(_name, "BadTDCvsLS", 
-		hcaldqm::hashfunctions::fSubdetPM, 
-		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
 
 	if (_ptype == fOnline || _ptype == fLocal) {
 		_cOccupancy_Crate.initialize(_name,
@@ -236,7 +220,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			hcaldqm::hashfunctions::fSubdetPM,
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),0);
-		_cSumQvsBX_SubdetPM_HF.initialize(_name, "SumQvsBX",
+		_cSumQvsBX_SubdetPM_QIE1011.initialize(_name, "SumQvsBX",
 			hcaldqm::hashfunctions::fSubdetPM,
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_10000),0);
@@ -428,18 +412,18 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	char cutstr2[200];
 	sprintf(cutstr2, "_SumQHF%d", int(_cutSumQ_HF));
 
-	_cADC_SubdetPM.book(ib, _emap, _filter_notHF, _subsystem);
-	_cADC_SubdetPM_HF.book(ib, _emap, _filter_HF, _subsystem);
-	_cfC_SubdetPM.book(ib, _emap, _filter_notHF, _subsystem);
-	_cfC_SubdetPM_HF.book(ib, _emap, _filter_HF, _subsystem);
-	_cSumQ_SubdetPM.book(ib, _emap, _filter_notHF, _subsystem);
-	_cSumQ_SubdetPM_HF.book(ib, _emap, _filter_HF, _subsystem);
+	_cADC_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
+	_cADC_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
+	_cfC_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
+	_cfC_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
+	_cSumQ_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
+	_cSumQ_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
 	_cSumQ_depth.book(ib, _emap, _subsystem);
-	_cSumQvsLS_SubdetPM.book(ib, _emap, _filter_notHF, _subsystem);
-	_cSumQvsLS_SubdetPM_HF.book(ib, _emap, _filter_HF, _subsystem);
+	_cSumQvsLS_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
+	_cSumQvsLS_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
 	_cDigiSize_Crate.book(ib, _emap, _subsystem);
-	_cADCvsTS_SubdetPM.book(ib, _emap, _filter_notHF, _subsystem);
-	_cADCvsTS_SubdetPM_HF.book(ib, _emap, _filter_HF, _subsystem);
+	_cADCvsTS_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
+	_cADCvsTS_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
 
 	if (_ptype != fOffline) { // hidefed2crate
 		_cShapeCut_FED.book(ib, _emap, _subsystem);
@@ -467,17 +451,15 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_cOccupancy_depth.book(ib, _emap, _subsystem);
 	_cOccupancyCut_depth.book(ib, _emap, _subsystem);
 
-	_cLETDCTimevsADC_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
-	_cLETDCvsADC_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
-	_cLETDCvsTS_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
-	_cLETDCTime_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
-	_cBadTDCValues_SubdetPM_HF.book(ib, _emap, _filter_HF, _subsystem);
-	_cBadTDCvsBX_SubdetPM_HF.book(ib, _emap, _filter_HF, _subsystem);
-	_cBadTDCvsLS_SubdetPM_HF.book(ib, _emap, _filter_HF, _subsystem);
-	_cBadTDCCount_depth.book(ib, _emap, _filter_HF, _subsystem);
-	_cBadTDCValues_SubdetPM_HEP17.book(ib, _emap, _filter_HEP17, _subsystem);
-	_cBadTDCvsBX_SubdetPM_HEP17.book(ib, _emap, _filter_HEP17, _subsystem);
-	_cBadTDCvsLS_SubdetPM_HEP17.book(ib, _emap, _filter_HEP17, _subsystem);
+	_cLETDCTimevsADC_SubdetPM.book(ib, _emap, _subsystem);
+	_cLETDCvsADC_SubdetPM.book(ib, _emap, _subsystem);
+	_cLETDCvsTS_SubdetPM.book(ib, _emap, _subsystem);
+	_cLETDCTime_SubdetPM.book(ib, _emap, _subsystem);
+
+	_cBadTDCValues_SubdetPM.book(ib, _emap, _subsystem);
+	_cBadTDCvsBX_SubdetPM.book(ib, _emap, _subsystem);
+	_cBadTDCvsLS_SubdetPM.book(ib, _emap, _subsystem);
+	_cBadTDCCount_depth.book(ib, _emap, _subsystem);
 
 	//	BOOK HISTOGRAMS that are only for Online
 	_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
@@ -491,8 +473,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	if (_ptype==fOnline)
 	{
 		_cQ2Q12CutvsLS_FEDHF.book(ib, _emap, _filter_FEDHF, _subsystem);
-		_cSumQvsBX_SubdetPM.book(ib, _emap, _filter_notHF, _subsystem);
-		_cSumQvsBX_SubdetPM_HF.book(ib, _emap, _filter_HF, _subsystem);
+		_cSumQvsBX_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
+		_cSumQvsBX_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
 		_cDigiSizevsLS_FED.book(ib, _emap, _subsystem);
 		_cTimingCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
 		_cTimingCutvsieta_Subdet.book(ib, _emap, _subsystem);
@@ -502,7 +484,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		_cOccupancyvsieta_Subdet.book(ib, _emap, _subsystem);
 		_cOccupancyCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
 		_cOccupancyCutvsieta_Subdet.book(ib, _emap, _subsystem);
-//		_cOccupancyCutvsSlotvsLS_HFPM.book(ib, _emap, _filter_HF, _subsystem);
+//		_cOccupancyCutvsSlotvsLS_HFPM.book(ib, _emap, _filter_QIE1011, _subsystem);
 		_cOccupancyCutvsiphivsLS_SubdetPM.book(ib, _emap, _subsystem);
 		_cSummaryvsLS_FED.book(ib, _emap, _subsystem);
 		_cSummaryvsLS.book(ib, _subsystem);
@@ -583,16 +565,16 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	edm::EventSetup const&)
 {
 	edm::Handle<HBHEDigiCollection>     chbhe;
-	edm::Handle<QIE11DigiCollection>     chep17;
+	edm::Handle<QIE11DigiCollection>     che_qie11;
 	edm::Handle<HODigiCollection>       cho;
 	edm::Handle<QIE10DigiCollection>       chf;
 
 	if (!e.getByToken(_tokHBHE, chbhe))
 		_logger.dqmthrow("Collection HBHEDigiCollection isn't available"
 			+ _tagHBHE.label() + " " + _tagHBHE.instance());
-	if (!e.getByToken(_tokHEP17, chep17))
-		_logger.dqmthrow("Collection HEP17DigiCollection isn't available"
-			+ _tagHEP17.label() + " " + _tagHEP17.instance());
+	if (!e.getByToken(_tokHE, che_qie11))
+		_logger.dqmthrow("Collection QIE11DigiCollection isn't available"
+			+ _tagHE.label() + " " + _tagHE.instance());
 	if (!e.getByToken(_tokHO, cho))
 		_logger.dqmthrow("Collection HODigiCollection isn't available"
 			+ _tagHO.label() + " " + _tagHO.instance());
@@ -733,15 +715,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		did.subdet()==HcalBarrel?numChs++:numChsHE++;
 	}
 
-	// HEP17 collection
-	// The following are filled w.r.t. HBHE digis
-	// - All eta-phi maps
-	// - Occupancy in electronics coordinates
-	// - Digi size
-	// 
-	// The following are not filled:
-	// - ADC, fC, sumQ, timing. These are different for QIE11 vs. QIE8. Find them in QIE11Task instead.
-	for (QIE11DigiCollection::const_iterator it=chep17->begin(); it!=chep17->end();
+	// HE QIE11 collection
+	for (QIE11DigiCollection::const_iterator it=che_qie11->begin(); it!=che_qie11->end();
 		++it)
 	{
 		const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
@@ -752,12 +727,11 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		if (rawid==0) 
 		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
 		HcalElectronicsId const& eid(rawid);
-		if (did.subdet()==HcalBarrel) // Note: since this is HEP17, we obviously expect did.subdet() always to be HcalEndcap, but QIE11DigiCollection may someday expand.
+		if (did.subdet()==HcalBarrel) // Note: since this is HE, we obviously expect did.subdet() always to be HcalEndcap, but QIE11DigiCollection may someday expand.
 			rawidHBValid = did.rawId();
 		else if (did.subdet()==HcalEndcap) 
 			rawidHEValid = did.rawId();
 
-		//double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(digi, 2.5, 0, digi.samples()-1);
 		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
 		double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
 
@@ -771,7 +745,12 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 				continue;
 		}
 
+		_cSumQ_SubdetPM.fill(did, sumQ);
 		_cOccupancy_depth.fill(did);
+		if (_ptype == fOnline || _ptype == fLocal) {
+			_cOccupancy_Crate.fill(eid);
+			_cOccupancy_CrateSlot.fill(eid);
+		}
 		if (_ptype==fOnline)
 		{
 			_cDigiSizevsLS_FED.fill(eid, _currentLS, digi.samples());
@@ -801,27 +780,49 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			}
 		}
 		for (int i=0; i<digi.samples(); i++) {
-			if (!_filter_HEP17.filter(did)) {
-				// Bad TDC values: 50-61 should never happen in QIE10 or QIE11, but we are seeing some in 2017 data.
-				if ((50 <= digi[i].tdc()) && (digi[i].tdc() <= 61)) {
-					_cBadTDCValues_SubdetPM_HEP17.fill(did, digi[i].tdc());
-					_cBadTDCvsBX_SubdetPM_HEP17.fill(did, bx);
-					_cBadTDCvsLS_SubdetPM_HEP17.fill(did, _currentLS);
-					_cBadTDCCount_depth.fill(did);
-				}
+			double q = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, digi, i);
+			_cADC_SubdetPM_QIE1011.fill(did, digi[i].adc());
+			_cfC_SubdetPM_QIE1011.fill(did, q);
+			_cLETDCvsADC_SubdetPM.fill(did, digi[i].adc(), digi[i].tdc());
+			_cLETDCvsTS_SubdetPM.fill(did, (int)i, digi[i].tdc());
+			if (digi[i].tdc() <50) {
+				double time = i*25. + (digi[i].tdc() / 2.);
+				_cLETDCTime_SubdetPM.fill(did, time);
+				_cLETDCTimevsADC_SubdetPM.fill(did, digi[i].adc(), time);
 			}
+			// Bad TDC values: 50-61 should never happen in QIE10 or QIE11, but we saw some in 2017 data.
+			if ((50 <= digi[i].tdc()) && (digi[i].tdc() <= 61)) {
+				_cBadTDCValues_SubdetPM.fill(did, digi[i].tdc());
+				_cBadTDCvsBX_SubdetPM.fill(did, bx);
+				_cBadTDCvsLS_SubdetPM.fill(did, _currentLS);
+				_cBadTDCCount_depth.fill(did);
+			}
+			if (_ptype != fOffline) { // hidefed2crate
+				_cADCvsTS_SubdetPM_QIE1011.fill(did, i, q);
+				if (sumQ>_cutSumQ_HE) {
+					_cShapeCut_FED.fill(eid, i, q);
+				}
+			}			
 		}
 
-		if (sumQ>_cutSumQ_HEP17)
+		if (sumQ>_cutSumQ_HE)
 		{
 			//double timing = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
 			double timing = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
-
-			_cOccupancyCut_depth.fill(did);
+			_cTimingCut_SubdetPM.fill(did, timing);
 			_cTimingCut_depth.fill(did, timing);
+			_cOccupancyCut_depth.fill(did);
+			_cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
+			if (_ptype != fOffline) { // hidefed2crate
+				_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+			}
 			_cSumQ_depth.fill(did, sumQ);
+			_cSumQvsLS_SubdetPM_QIE1011.fill(did, _currentLS, sumQ);
 			if (_ptype==fOnline)
 			{
+				_cSumQvsBX_SubdetPM_QIE1011.fill(did, bx, sumQ);
+				_cTimingCutvsiphi_SubdetPM.fill(did, timing);
+				_cTimingCutvsieta_Subdet.fill(did, timing);
 				_cOccupancyCutvsiphi_SubdetPM.fill(did);
 				_cOccupancyCutvsieta_Subdet.fill(did);
 				_cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
@@ -829,11 +830,15 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			if (_ptype != fOffline) { // hidefed2crate
 				if (eid.isVMEid())
 				{
+					_cTimingCut_FEDVME.fill(eid, timing);
+					_cTimingCut_ElectronicsVME.fill(eid, timing);
 					_cOccupancyCut_FEDVME.fill(eid);
 					_cOccupancyCut_ElectronicsVME.fill(eid);
 				}
 				else 
 				{
+					_cTimingCut_FEDuTCA.fill(eid, timing);
+					_cTimingCut_ElectronicsuTCA.fill(eid, timing);
 					_cOccupancyCut_FEDuTCA.fill(eid);
 					_cOccupancyCut_ElectronicsuTCA.fill(eid);
 				}
@@ -1038,9 +1043,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 					cs.isBitSet(HcalChannelStatus::HcalCellDead))
 					continue;
 			}
-			if (!_filter_HF.filter(did)) {
-				_cSumQ_SubdetPM_HF.fill(did, sumQ);
-			}
+			//if (!_filter_QIE1011.filter(did)) {
+			_cSumQ_SubdetPM_QIE1011.fill(did, sumQ);
+			//}
 			_cOccupancy_depth.fill(did);
 			if (_ptype==fOnline)
 			{
@@ -1075,31 +1080,30 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			for (int i=0; i<digi.samples(); i++)
 			{
 				double q = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i);
-				if (!_filter_HF.filter(did)) {
-					_cADC_SubdetPM_HF.fill(did, digi[i].adc());
-					_cfC_SubdetPM_HF.fill(did, q);
-					_cLETDCvsADC_SubdetPM.fill(did, digi[i].adc(), digi[i].le_tdc());
-					_cLETDCvsTS_SubdetPM.fill(did, (int)i, digi[i].le_tdc());
-					if (digi[i].le_tdc() <50) {
-						double time = i*25. + (digi[i].le_tdc() / 2.);
-						_cLETDCTime_SubdetPM.fill(did, time);
-						_cLETDCTimevsADC_SubdetPM.fill(did, digi[i].adc(), time);
-					}
-
-					// Bad TDC values: 50-61 should never happen in QIE10 or QIE11, but we are seeing some in 2017 data.
-					if ((50 <= digi[i].le_tdc()) && (digi[i].le_tdc() <= 61)) {
-						_cBadTDCValues_SubdetPM_HF.fill(did, digi[i].le_tdc());
-						_cBadTDCvsBX_SubdetPM_HF.fill(did, bx);
-						_cBadTDCvsLS_SubdetPM_HF.fill(did, _currentLS);
-						_cBadTDCCount_depth.fill(did);
-					}
+				//if (!_filter_QIE1011.filter(did)) {
+				_cADC_SubdetPM_QIE1011.fill(did, digi[i].adc());
+				_cfC_SubdetPM_QIE1011.fill(did, q);
+				_cLETDCvsADC_SubdetPM.fill(did, digi[i].adc(), digi[i].le_tdc());
+				_cLETDCvsTS_SubdetPM.fill(did, (int)i, digi[i].le_tdc());
+				if (digi[i].le_tdc() <50) {
+					double time = i*25. + (digi[i].le_tdc() / 2.);
+					_cLETDCTime_SubdetPM.fill(did, time);
+					_cLETDCTimevsADC_SubdetPM.fill(did, digi[i].adc(), time);
 				}
 
+				// Bad TDC values: 50-61 should never happen in QIE10 or QIE11, but we are seeing some in 2017 data.
+				if ((50 <= digi[i].le_tdc()) && (digi[i].le_tdc() <= 61)) {
+					_cBadTDCValues_SubdetPM.fill(did, digi[i].le_tdc());
+					_cBadTDCvsBX_SubdetPM.fill(did, bx);
+					_cBadTDCvsLS_SubdetPM.fill(did, _currentLS);
+					_cBadTDCCount_depth.fill(did);
+				}
 				if (_ptype != fOffline) { // hidefed2crate
-					_cADCvsTS_SubdetPM_HF.fill(did, (int)i, q);
+					_cADCvsTS_SubdetPM_QIE1011.fill(did, (int)i, q);
 					if (sumQ>_cutSumQ_HF)
 						_cShapeCut_FED.fill(eid, (int)i, q);
 				}
+				//}
 			}
 
 			if (sumQ>_cutSumQ_HF)
@@ -1110,14 +1114,17 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 				double q2 = hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, 2);
 				double q2q12 = q2/(q1+q2);
 				_cSumQ_depth.fill(did, sumQ);
-				if (!_filter_HF.filter(did)) {
-					_cSumQvsLS_SubdetPM_HF.fill(did, _currentLS, sumQ);
-				}
+				//if (!_filter_QIE1011.filter(did)) {
+				_cSumQvsLS_SubdetPM_QIE1011.fill(did, _currentLS, sumQ);
+				//}
+				_cTimingCut_SubdetPM.fill(did, timing);
+				_cTimingCut_depth.fill(did, timing);
+				_cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
 				if (_ptype==fOnline)
 				{
-					if (!_filter_HF.filter(did)) {
-						_cSumQvsBX_SubdetPM_HF.fill(did, bx, sumQ);
-					}
+					//if (!_filter_QIE1011.filter(did)) {
+					_cSumQvsBX_SubdetPM_QIE1011.fill(did, bx, sumQ);
+					//}
 					_cTimingCutvsiphi_SubdetPM.fill(did, timing);
 					_cTimingCutvsieta_Subdet.fill(did, timing);
 					_cOccupancyCutvsiphi_SubdetPM.fill(did);
@@ -1126,9 +1133,6 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	//				_cOccupancyCutvsSlotvsLS_HFPM.fill(did, _currentLS);
 					_xUniHF.get(eid)++;
 				}
-				_cTimingCut_SubdetPM.fill(did, timing);
-				_cTimingCut_depth.fill(did, timing);
-				_cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
 				if (_ptype != fOffline) { // hidefed2crate
 					_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
 				}

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -602,6 +602,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	{
 		//	Explicit check on the DetIds present in the Collection
 		HcalDetId const& did = it->id();
+		if (did.subdet() != HcalBarrel) {
+			continue;
+		}
 		uint32_t rawid = _ehashmap.lookup(did);
 		if (rawid==0) 
 		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -745,7 +745,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 				continue;
 		}
 
-		_cSumQ_SubdetPM.fill(did, sumQ);
+		_cSumQ_SubdetPM_QIE1011.fill(did, sumQ);
 		_cOccupancy_depth.fill(did);
 		if (_ptype == fOnline || _ptype == fLocal) {
 			_cOccupancy_Crate.fill(eid);

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -34,6 +34,13 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_vflags[fUnknownIds]=hcaldqm::flag::Flag("UnknownIds");
 
 	_qie10InConditions = ps.getUntrackedParameter<bool>("qie10InConditions", true);
+
+	// Get reference digi sizes. Convert from unsigned to signed int, because <digi>::size()/samples() return ints for some reason.
+	std::vector<uint32_t> vrefDigiSize = ps.getUntrackedParameter<std::vector<uint32_t>>("refDigiSize");
+	_refDigiSize[HcalBarrel]  = (int)vrefDigiSize[0];
+	_refDigiSize[HcalEndcap]  = (int)vrefDigiSize[1];
+	_refDigiSize[HcalOuter]   = (int)vrefDigiSize[2];
+	_refDigiSize[HcalForward] = (int)vrefDigiSize[3];
 }
 
 /* virtual */ void DigiTask::bookHistograms(DQMStore::IBooker& ib,
@@ -645,7 +652,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		if (_ptype==fOnline)
 		{
 			_cDigiSizevsLS_FED.fill(eid, _currentLS, it->size());
-			it->size()!=constants::DIGISIZE[did.subdet()-1]?
+			it->size()!=_refDigiSize[did.subdet()]?
 				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
 			_cOccupancyvsiphi_SubdetPM.fill(did);
 			_cOccupancyvsieta_Subdet.fill(did);
@@ -768,7 +775,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		if (_ptype==fOnline)
 		{
 			_cDigiSizevsLS_FED.fill(eid, _currentLS, digi.samples());
-			digi.samples()!=constants::DIGISIZE[did.subdet()-1]?
+			digi.samples()!=_refDigiSize[did.subdet()]?
 				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
 			_cOccupancyvsiphi_SubdetPM.fill(did);
 			_cOccupancyvsieta_Subdet.fill(did);
@@ -895,7 +902,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		if (_ptype==fOnline)
 		{
 			_cDigiSizevsLS_FED.fill(eid, _currentLS, it->size());
-			it->size()!=constants::DIGISIZE[did.subdet()-1]?
+			it->size()!=_refDigiSize[did.subdet()]?
 				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
 			_cOccupancyvsiphi_SubdetPM.fill(did);
 			_cOccupancyvsieta_Subdet.fill(did);
@@ -1039,7 +1046,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			{
 				_xNChs.get(eid)++;
 				_cDigiSizevsLS_FED.fill(eid, _currentLS, digi.samples());
-				digi.samples()!=constants::DIGISIZE[did.subdet()-1]?
+				digi.samples()!=_refDigiSize[did.subdet()]?
 					_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
 				_cOccupancyvsiphi_SubdetPM.fill(did);
 				_cOccupancyvsieta_Subdet.fill(did);

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -10,7 +10,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 	//	tags
 	_tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE",
 		edm::InputTag("hcalDigis"));
-	_tagHEP17 = ps.getUntrackedParameter<edm::InputTag>("tagHEP17",
+	_tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE",
 		edm::InputTag("hcalDigis"));
 	_tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
 		edm::InputTag("hcalDigis"));
@@ -19,7 +19,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 	_tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger",
 		edm::InputTag("tbunpacker"));
 	_tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-	_tokHEP17 = consumes<QIE11DigiCollection>(_tagHEP17);
+	_tokHEP17 = consumes<QIE11DigiCollection>(_tagHE);
 	_tokHO = consumes<HODigiCollection>(_tagHO);
 	_tokHF = consumes<QIE10DigiCollection>(_tagHF);
 	_tokTrigger = consumes<HcalTBTriggerData>(_tagTrigger);
@@ -306,7 +306,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 			+ _tagHF.label() + " " + _tagHF.instance());
 	if (!e.getByToken(_tokHEP17, chep17))
 		_logger.dqmthrow("Collection QIE11DigiCollection isn't available "
-			+ _tagHEP17.label() + " " + _tagHEP17.instance());
+			+ _tagHE.label() + " " + _tagHE.instance());
 
 //	int currentEvent = e.eventAuxiliary().id().event();
 

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -12,7 +12,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 	//	tags
 	_tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE",
 		edm::InputTag("hcalDigis"));
-	_tagHEP17 = ps.getUntrackedParameter<edm::InputTag>("tagHEP17",
+	_tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE",
 		edm::InputTag("hcalDigis"));
 	_tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
 		edm::InputTag("hcalDigis"));
@@ -21,7 +21,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 	_taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN",
 		edm::InputTag("hcalDigis"));
 	_tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-	_tokHEP17 = consumes<QIE11DigiCollection>(_tagHEP17);
+	_tokHEP17 = consumes<QIE11DigiCollection>(_tagHE);
 	_tokHO = consumes<HODigiCollection>(_tagHO);
 	_tokHF = consumes<QIE10DigiCollection>(_tagHF);
 	_tokuMN = consumes<HcalUMNioDigi>(_taguMN);
@@ -350,7 +350,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 			+ _tagHBHE.label() + " " + _tagHBHE.instance());
 	if (!e.getByToken(_tokHEP17, chep17))
 		_logger.dqmthrow("Collection QIE11DigiCollection isn't available "
-			+ _tagHEP17.label() + " " + _tagHEP17.instance());
+			+ _tagHE.label() + " " + _tagHE.instance());
 	if (!e.getByToken(_tokHO, cho))
 		_logger.dqmthrow("Collection HODigiCollection isn't available "
 			+ _tagHO.label() + " " + _tagHO.instance());

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -66,7 +66,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 	//	INITIALIZE
 	_cSignalMean_Subdet.initialize(_name, "SignalMean",
 		hcaldqm::hashfunctions::fSubdet, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_100000Coarse),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 	_cSignalRMS_Subdet.initialize(_name, "SignalRMS",
 		hcaldqm::hashfunctions::fSubdet, 
@@ -91,12 +91,12 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 			hcaldqm::hashfunctions::fFED,
 			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
 			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),0);
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_100000Coarse),0);
 		_cSignalMean_FEDuTCA.initialize(_name, "SignalMean",
 			hcaldqm::hashfunctions::fFED,
 			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
 			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),0);
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_100000Coarse),0);
 		_cSignalRMS_FEDVME.initialize(_name, "SignalRMS",
 			hcaldqm::hashfunctions::fFED,
 			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
@@ -162,7 +162,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 		hcaldqm::hashfunctions::fdepth, 
 		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
 		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_3000),0);
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_100000Coarse),0);
 	_cSignalRMS_depth.initialize(_name, "SignalRMS",
 		hcaldqm::hashfunctions::fdepth, 
 		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta), 
@@ -293,11 +293,6 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 		HcalDetId did = HcalDetId(it->rawId());
 		HcalElectronicsId eid(_ehashmap.lookup(*it));
 		int n = _xEntries.get(did);
-		double msig = _xSignalSum.get(did)/n; 
-		double mtim = _xTimingSum.get(did)/n;
-		double rsig = sqrt(_xSignalSum2.get(did)/n-msig*msig);
-		double rtim = sqrt(_xTimingSum2.get(did)/n-mtim*mtim);
-
 		//	channels missing or low signal
 		if (n==0)
 		{
@@ -310,6 +305,12 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 			}
 			continue;
 		}
+
+		double msig = _xSignalSum.get(did)/n; 
+		double mtim = _xTimingSum.get(did)/n;
+		double rsig = sqrt(_xSignalSum2.get(did)/n-msig*msig);
+		double rtim = sqrt(_xTimingSum2.get(did)/n-mtim*mtim);
+
 		_cSignalMean_Subdet.fill(did, msig);
 		_cSignalMean_depth.fill(did, msig);
 		_cSignalRMS_Subdet.fill(did, rsig);

--- a/DQM/HcalTasks/plugins/PedestalTask.cc
+++ b/DQM/HcalTasks/plugins/PedestalTask.cc
@@ -9,7 +9,7 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps):
 	//	tags
 	_tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE",
 		edm::InputTag("hcalDigis"));
-	_tagHEP17 = ps.getUntrackedParameter<edm::InputTag>("tagHEP17",
+	_tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE",
 		edm::InputTag("hcalDigis"));
 	_tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
 		edm::InputTag("hcalDigis"));
@@ -20,7 +20,7 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps):
 	_taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN",
 		edm::InputTag("hcalDigis"));
 	_tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-	_tokHEP17 = consumes<QIE11DigiCollection>(_tagHEP17);
+	_tokHEP17 = consumes<QIE11DigiCollection>(_tagHE);
 	_tokHO = consumes<HODigiCollection>(_tagHO);
 	_tokHF = consumes<QIE10DigiCollection>(_tagHF);
 	_tokTrigger = consumes<HcalTBTriggerData>(_tagTrigger);
@@ -859,7 +859,7 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps):
 			+ _tagHF.label() + " " + _tagHF.instance());
 	if (!e.getByToken(_tokHEP17, chep17))
 		_logger.dqmthrow("Collection QIE11DigiCollection isn't available"
-			+ _tagHEP17.label() + " " + _tagHEP17.instance());
+			+ _tagHE.label() + " " + _tagHE.instance());
 
 	int nHB(0), nHE(0), nHO(0), nHF(0);
 	for (HBHEDigiCollection::const_iterator it=chbhe->begin();

--- a/DQM/HcalTasks/python/DigiTask.py
+++ b/DQM/HcalTasks/python/DigiTask.py
@@ -29,13 +29,13 @@ digiTask = DQMEDAnalyzer(
 	qie10InConditions = cms.untracked.bool(False),
 
 	# Reference digi sizes
-	refDigiSize = cms.untracked.vint32(10, 10, 10, 4), # HB, HE, HF, HO
+	refDigiSize = cms.untracked.vuint32(10, 10, 10, 4), # HB, HE, HF, HO
 )
 
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 run2_HF_2017.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
-run2_HF_2017.toModify(digiTask, refDigiSize=cms.untracked.vint32(10, 10, 10, 3))
+run2_HF_2017.toModify(digiTask, refDigiSize=cms.untracked.vuint32(10, 10, 10, 3))
 
 from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
 run2_HCAL_2018.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
-run2_HCAL_2018.toModify(digiTask, refDigiSize=cms.untracked.vint32(8, 8, 10, 3))
+run2_HCAL_2018.toModify(digiTask, refDigiSize=cms.untracked.vuint32(8, 8, 10, 3))

--- a/DQM/HcalTasks/python/DigiTask.py
+++ b/DQM/HcalTasks/python/DigiTask.py
@@ -36,6 +36,6 @@ from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 run2_HF_2017.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
 run2_HF_2017.toModify(digiTask, refDigiSize=cms.untracked.vint32(10, 10, 10, 3))
 
-from Configuration.StandardSequences.Eras import eras
-eras.Run2_2018.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
-eras.Run2_2018.toModify(digiTask, refDigiSize=cms.untracked.vint32(8, 8, 10, 3))
+from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+run2_HCAL_2018.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
+run2_HCAL_2018.toModify(digiTask, refDigiSize=cms.untracked.vint32(8, 8, 10, 3))

--- a/DQM/HcalTasks/python/DigiTask.py
+++ b/DQM/HcalTasks/python/DigiTask.py
@@ -29,7 +29,7 @@ digiTask = DQMEDAnalyzer(
 	qie10InConditions = cms.untracked.bool(False),
 
 	# Reference digi sizes
-	refDigiSize = cms.untracked.vuint32(10, 10, 10, 4), # HB, HE, HF, HO
+	refDigiSize = cms.untracked.vuint32(10, 10, 10, 4), # HB, HE, HO, HF
 )
 
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017

--- a/DQM/HcalTasks/python/DigiTask.py
+++ b/DQM/HcalTasks/python/DigiTask.py
@@ -27,7 +27,15 @@ digiTask = DQMEDAnalyzer(
 	thresh_unifh = cms.untracked.double(0.2),
 
 	qie10InConditions = cms.untracked.bool(False),
+
+	# Reference digi sizes
+	refDigiSize = cms.untracked.vint32(10, 10, 10, 4), # HB, HE, HF, HO
 )
 
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 run2_HF_2017.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
+run2_HF_2017.toModify(digiTask, refDigiSize=cms.untracked.vint32(10, 10, 10, 3))
+
+from Configuration.StandardSequences.Eras import eras
+eras.Run2_2018.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
+eras.Run2_2018.toModify(digiTask, refDigiSize=cms.untracked.vint32(8, 8, 10, 3))

--- a/DQM/HcalTasks/python/HcalOfflineHarvesting.py
+++ b/DQM/HcalTasks/python/HcalOfflineHarvesting.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQM.HcalTasks.DigiTask import digiTask
 
 hcalOfflineHarvesting = DQMEDHarvester(
 	"HcalOfflineHarvesting",
@@ -17,5 +18,6 @@ hcalOfflineHarvesting = DQMEDHarvester(
 	thresh_FGMsmRate_high = cms.untracked.double(0.2),
 	thresh_FGMsmRate_low = cms.untracked.double(0.1),
 	thresh_unihf = cms.untracked.double(0.2),
-	thresh_tcds = cms.untracked.double(1.5)
+	thresh_tcds = cms.untracked.double(1.5),
+	refDigiSize = digiTask.refDigiSize,
 )

--- a/DQM/HcalTasks/python/HcalOnlineHarvesting.py
+++ b/DQM/HcalTasks/python/HcalOnlineHarvesting.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
-from DQM.HcalTasks.DigiTask import DigiTask
+from DQM.HcalTasks.DigiTask import digiTask
 
 hcalOnlineHarvesting = DQMEDHarvester(
 	"HcalOnlineHarvesting",

--- a/DQM/HcalTasks/python/HcalOnlineHarvesting.py
+++ b/DQM/HcalTasks/python/HcalOnlineHarvesting.py
@@ -12,5 +12,5 @@ hcalOnlineHarvesting = DQMEDHarvester(
 	ptype = cms.untracked.int32(0),
 	mtype = cms.untracked.bool(True),
 	subsystem = cms.untracked.string("Hcal"),
-	refDigiSize = DigiTask.refDigiSize,
+	refDigiSize = digiTask.refDigiSize,
 )

--- a/DQM/HcalTasks/python/HcalOnlineHarvesting.py
+++ b/DQM/HcalTasks/python/HcalOnlineHarvesting.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQM.HcalTasks.DigiTask import DigiTask
 
 hcalOnlineHarvesting = DQMEDHarvester(
 	"HcalOnlineHarvesting",
@@ -11,4 +12,5 @@ hcalOnlineHarvesting = DQMEDHarvester(
 	ptype = cms.untracked.int32(0),
 	mtype = cms.untracked.bool(True),
 	subsystem = cms.untracked.string("Hcal"),
+	refDigiSize = DigiTask.refDigiSize,
 )

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -8,6 +8,12 @@ namespace hcaldqm
 	{
 		_thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf",
 			0.2);
+
+		std::vector<uint32_t> vrefDigiSize = ps.getUntrackedParameter<std::vector<uint32_t>>("refDigiSize");
+		_refDigiSize[HcalBarrel]  = vrefDigiSize[0];
+		_refDigiSize[HcalEndcap]  = vrefDigiSize[1];
+		_refDigiSize[HcalOuter]   = vrefDigiSize[2];
+		_refDigiSize[HcalForward] = vrefDigiSize[3];
 	}
 
 	/* virtual */ void DigiRunSummary::beginRun(edm::Run const& r,
@@ -140,7 +146,7 @@ namespace hcaldqm
 			_cOccupancy_depth.fill(did, cOccupancy_depth.getBinContent(did));
 			//	digi size
 			cDigiSize_Crate.getMean(eid)!=
-				constants::DIGISIZE[did.subdet()-1]?
+				_refDigiSize[did.subdet()]?
 				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;
 			cDigiSize_Crate.getRMS(eid)!=0?
 				_xDigiSize.get(eid)++:_xDigiSize.get(eid)+=0;

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -113,7 +113,7 @@ process.load('DQM.HcalTasks.TPTask')
 process.load('DQM.HcalTasks.RawTask')
 process.load('DQM.HcalTasks.NoCQTask')
 #process.load('DQM.HcalTasks.ZDCTask')
-process.load('DQM.HcalTasks.QIE11Task')
+#process.load('DQM.HcalTasks.QIE11Task') # 2018: integrate QIE11Task into DigiTask
 process.load('DQM.HcalTasks.HcalOnlineHarvesting')
 
 #-------------------------------------
@@ -149,9 +149,9 @@ process.tpTask.runkeyName = runTypeName
 #process.zdcTask.runkeyVal = runType
 #process.zdcTask.runkeyName = runTypeName
 #process.zdcTask.tagQIE10 = cms.untracked.InputTag("castorDigis")
-process.qie11Task.runkeyVal = runType
-process.qie11Task.runkeyName = runTypeName
-process.qie11Task.tagQIE11 = cms.untracked.InputTag("hcalDigis")
+#process.qie11Task.runkeyVal = runType
+#process.qie11Task.runkeyName = runTypeName
+#process.qie11Task.tagQIE11 = cms.untracked.InputTag("hcalDigis")
 
 #-------------------------------------
 #	Hcal DQM Tasks/Clients Sequences Definition
@@ -161,7 +161,7 @@ process.tasksPath = cms.Path(
 		+process.digiTask
 		+process.tpTask
 		+process.nocqTask
-		+process.qie11Task
+		#+process.qie11Task
 		#ZDC to be removed for 2017 pp running
 		#+process.zdcTask
 )


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/22724 to 10_1_X (the original PR was intended for 10_1_X, but was merged in 10_2_X).

Updates HCALDQM DigiTask for 2018 HE. A number of plots were not filled for HEP17 last year because it would have mixed QIE8 and QIE11 digis; QIE11-specific plots were created in QIE11Task. Now that HE==QIE11, I integrated the plots of interest from QIE11Task to DigiTask.

I also included one small bug fix for LaserTask: with the 2018 HE, the range for the laser signal has to be increased.

#22971 should be merged first. 
