### PR TITLE
SiStripEventSummary fixes for special runs in local-DAQ

### DIFF
--- a/DataFormats/SiStripCommon/src/SiStripEventSummary.cc
+++ b/DataFormats/SiStripCommon/src/SiStripEventSummary.cc
@@ -222,6 +222,8 @@ void SiStripEventSummary::commissioningInfo( const uint32_t& daq1,
     params_[0] = (daq2>>8)&0xFF; // latency
     params_[1] = (daq2>>4)&0x0F; // cal_chan
     params_[2] = (daq2>>0)&0x0F; // cal_sel
+    params_[3] = (daq2>>16)&0xFF; // isha
+    params_[4] = (daq2>>24);      // vfs
   } else if ( runType_ == sistrip::OPTO_SCAN ) { 
     params_[0] = (daq2>>8)&0xFF; // opto gain
     params_[1] = (daq2>>0)&0xFF; // opto bias

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -1121,7 +1121,10 @@ namespace sistrip {
   }
 
   void RawToDigiUnpacker::updateEventSummary( const sistrip::FEDBuffer& fed, SiStripEventSummary& summary ) {
-  
+
+    summary.event(fed.daqHeader().l1ID());
+    summary.bx(fed.daqHeader().bxID());
+
     // Retrieve contents of DAQ registers
 
     sistrip::FEDDAQEventType readout_mode = fed.daqEventType(); 


### PR DESCRIPTION
From @rgerosa . Neither of the changes should affect normal data taking (UseDaqRegister is False then)

- store event and bx id from the DAQ header (if UseDaqRegister; otherwise updateEventSummary is not called). This is needed to get those from the SiStripEventSummary in special runs without "trigger FED"
- store ISHA and VFS parameters for calibration scans

CC: @OlivierBondu @alesaggio @vidalm 