### PR TITLE
Clean up QuickTrackAssociatorByHits configuration

### DIFF
--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsProducer.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsProducer.cc
@@ -80,7 +80,6 @@ class QuickTrackAssociatorByHitsProducer : public edm::global::EDProducer<> {
 // constructors and destructor
 //
 QuickTrackAssociatorByHitsProducer::QuickTrackAssociatorByHitsProducer(const edm::ParameterSet& iConfig):
-  trackerHitAssociatorConfig_(makeHitAssociatorParameters(iConfig), consumesCollector()),
   qualitySimToReco_( iConfig.getParameter<double>( "Quality_SimToReco" ) ),
   puritySimToReco_( iConfig.getParameter<double>( "Purity_SimToReco" ) ),
   pixelHitWeight_( iConfig.getParameter<double>( "PixelHitWeight" ) ),
@@ -122,6 +121,9 @@ QuickTrackAssociatorByHitsProducer::QuickTrackAssociatorByHitsProducer(const edm
 
   if(useClusterTPAssociation_) {
     cluster2TPToken_ = consumes<ClusterTPAssociation>(iConfig.getParameter < edm::InputTag > ("cluster2TPSrc"));
+  }
+  else {
+    trackerHitAssociatorConfig_ = TrackerHitAssociator::Config(makeHitAssociatorParameters(iConfig), consumesCollector());
   }
 
 }

--- a/SimTracker/TrackAssociatorProducers/python/quickTrackAssociatorByHits_cfi.py
+++ b/SimTracker/TrackAssociatorProducers/python/quickTrackAssociatorByHits_cfi.py
@@ -23,15 +23,8 @@ fastSim.toModify(quickTrackAssociatorByHits,
     useClusterTPAssociation = False
 )
 
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify( 
-    quickTrackAssociatorByHits,
-    pixelSimLinkSrc = cms.InputTag("simSiPixelDigis","Pixel"),
-    stripSimLinkSrc = cms.InputTag("simSiPixelDigis","Tracker")
-)
-
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(quickTrackAssociatorByHits,
+(fastSim & premix_stage2).toModify(quickTrackAssociatorByHits,
     pixelSimLinkSrc = "mixData:PixelDigiSimLink",
     stripSimLinkSrc = "mixData:StripDigiSimLink",
 )

--- a/SimTracker/TrackAssociatorProducers/python/quickTrackAssociatorByHits_cfi.py
+++ b/SimTracker/TrackAssociatorProducers/python/quickTrackAssociatorByHits_cfi.py
@@ -8,19 +8,17 @@ quickTrackAssociatorByHits = cms.EDProducer("QuickTrackAssociatorByHitsProducer"
 	Purity_SimToReco = cms.double(0.75),
 	ThreeHitTracksAreSpecial = cms.bool(True),
         PixelHitWeight = cms.double(1.0),
-	associatePixel = cms.bool(True),
-	associateStrip = cms.bool(True),
-        pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
-        stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
         useClusterTPAssociation = cms.bool(True),
         cluster2TPSrc = cms.InputTag("tpClusterProducer")
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(quickTrackAssociatorByHits,
-    associateStrip = False,
-    associatePixel = False,
-    useClusterTPAssociation = False
+    useClusterTPAssociation = False,
+    associateStrip = cms.bool(False),
+    associatePixel = cms.bool(False),
+    pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
+    stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
 )
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2

--- a/SimTracker/TrackAssociatorProducers/python/quickTrackAssociatorByHits_cfi.py
+++ b/SimTracker/TrackAssociatorProducers/python/quickTrackAssociatorByHits_cfi.py
@@ -12,14 +12,19 @@ quickTrackAssociatorByHits = cms.EDProducer("QuickTrackAssociatorByHitsProducer"
         cluster2TPSrc = cms.InputTag("tpClusterProducer")
 )
 
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(quickTrackAssociatorByHits,
+quickTrackAssociatorByHitsTrackerHitAssociator = quickTrackAssociatorByHits.clone(
     useClusterTPAssociation = False,
-    associateStrip = cms.bool(False),
-    associatePixel = cms.bool(False),
+    associateStrip = cms.bool(True),
+    associatePixel = cms.bool(True),
     pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
     stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
 )
+
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toReplaceWith(quickTrackAssociatorByHits, quickTrackAssociatorByHitsTrackerHitAssociator.clone(
+    associateStrip = False,
+    associatePixel = False,
+))
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 (fastSim & premix_stage2).toModify(quickTrackAssociatorByHits,

--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -56,6 +56,7 @@ class TrackerHitAssociator {
   
  public:
   struct Config {
+    Config() {}
     Config(const edm::ParameterSet& conf, edm::ConsumesCollector && iC);
     Config(edm::ConsumesCollector && iC);
     bool doPixel_, doStrip_, useOTph2_, doTrackAssoc_, assocHitbySimTrack_;

--- a/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
+++ b/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
@@ -2,9 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 # track associator settings
 import SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi
-trackAssociatorByHitsRecoDenom = SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi.quickTrackAssociatorByHits.clone(
-    useClusterTPAssociation = False # to do the track<->TP association with TrackerHitAssociator
-)
+# to do the track<->TP association with TrackerHitAssociator
+trackAssociatorByHitsRecoDenom = SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi.quickTrackAssociatorByHitsTrackerHitAssociator.clone()
 from SimGeneral.TrackingAnalysis.trackingParticleNumberOfLayersProducer_cff import *
 
 # reco track quality cuts


### PR DESCRIPTION
This PR suggests the following modifications to the configuration of `QuickTrackAssociatorByHits` (making the use of `TrackerHitAssociator` even more specific to FastSim, and apparently for HI as well)
* Read configuration parameters specific to 'TrackerHitAssociator` only if `useClusterTPAssociation` is `False`
* Remove configuration parameters specific to `TrackerHitAssociator` from the default configuration, and add them only for FastSim

The motivation is to 
* avoid (unnecessary) customizations e.g. for premixing
* reduce possible confusion in the `QuickTrackAssociatorByHits` configuration, especially for "are the DigiSimLinks read by the module or not"

Tested in CMSSW_10_2_X_2018-04-12-2300, no changes expected.

@VinInn @mtosi @jalimena @hajohajo 