### PR TITLE
Fixing Default Values of EgammaHLTGsfTrackVarProducer to be only used if there is a track found : 102X

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
@@ -134,10 +134,13 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
     float oneOverESuperMinusOneOverPValue=999999;
     float oneOverESeedMinusOneOverPValue=999999;
     
-    if(static_cast<int>(gsfTracks.size())>=upperTrackNrToRemoveCut_ || 
-       static_cast<int>(gsfTracks.size())<=lowerTrackNrToRemoveCut_ ||
-       (isBarrel && useDefaultValuesForBarrel_) ||
-       (!isBarrel && useDefaultValuesForEndcap_)){
+    const int nrTracks = gsfTracks.size();
+    const bool rmCutsDueToNrTracks = nrTracks <= lowerTrackNrToRemoveCut_ ||
+                                     nrTracks >= upperTrackNrToRemoveCut_;
+    //to use the default values, we require at least one track...
+    const bool useDefaultValues = isBarrel ? useDefaultValuesForBarrel_ && nrTracks>=1 : useDefaultValuesForEndcap_ && nrTracks>=1;
+
+    if(rmCutsDueToNrTracks || useDefaultValues){
       dEtaInValue=0;
       dEtaSeedInValue=0;
       dPhiInValue=0;


### PR DESCRIPTION
Dear All,
First appologies for this bug, I didnt catch it in my testing which was only apparent on MuEG events due to how the DZ filters work differently for those paths.

When setting the default values for a track, we didnt check if a track was actually found. So even if there was no GsfTrack, good "auto" pass values were written. This unfortunately causes the mu-electron DZ filters to crash they dont check they actually find an electron.

This fix makes the default values only be written if the electron actually has a track. So no trackless electrons can now pass through to the DZ filters. 

Best,
Sam