### PR TITLE
Fixing Default Values of EgammaHLTGsfTrackVarProducer to be only used if there is a track found : 101X

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTGsfTrackVarProducer.cc
@@ -134,10 +134,13 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::Event& iEvent, const edm::EventS
     float oneOverESuperMinusOneOverPValue=999999;
     float oneOverESeedMinusOneOverPValue=999999;
     
-    if(static_cast<int>(gsfTracks.size())>=upperTrackNrToRemoveCut_ || 
-       static_cast<int>(gsfTracks.size())<=lowerTrackNrToRemoveCut_ ||
-       (isBarrel && useDefaultValuesForBarrel_) ||
-       (!isBarrel && useDefaultValuesForEndcap_)){
+    const int nrTracks = gsfTracks.size();
+    const bool rmCutsDueToNrTracks = nrTracks <= lowerTrackNrToRemoveCut_ ||
+                                     nrTracks >= upperTrackNrToRemoveCut_;
+    //to use the default values, we require at least one track...
+    const bool useDefaultValues = isBarrel ? useDefaultValuesForBarrel_ && nrTracks>=1 : useDefaultValuesForEndcap_ && nrTracks>=1;
+
+    if(rmCutsDueToNrTracks || useDefaultValues){
       dEtaInValue=0;
       dEtaSeedInValue=0;
       dPhiInValue=0;


### PR DESCRIPTION
10_1_X flavour of https://github.com/cms-sw/cmssw/pull/22987

This is an rather urgently needed fix for data taking and TSG would like it as a patch release. 

