### PR TITLE
Add move constructor and assignment operator to edm::HepMCProduct

### DIFF
--- a/SimDataFormats/GeneratorProducts/interface/HepMCProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/HepMCProduct.h
@@ -43,6 +43,8 @@ namespace edm {
 
 		HepMCProduct(HepMCProduct const &orig);
 		HepMCProduct &operator = (HepMCProduct const &other);
+		HepMCProduct(HepMCProduct&& orig);
+		HepMCProduct &operator=(HepMCProduct&& other);
 		void swap(HepMCProduct &other);
 
 	    private:

--- a/SimDataFormats/GeneratorProducts/src/HepMCProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/HepMCProduct.cc
@@ -171,3 +171,13 @@ HepMCProduct::operator=(HepMCProduct const& other) {
   swap(temp);
   return *this;
 } 
+
+// move, needed explicitly as we have raw pointer...
+HepMCProduct::HepMCProduct(HepMCProduct&& other):
+  evt_(nullptr) {
+  swap(other);
+}
+HepMCProduct& HepMCProduct::operator=(HepMCProduct&& other) {
+  swap(other);
+  return *this;
+}


### PR DESCRIPTION
While debugging a strange segfault with valgrind I noticed `emd::HepMCProduct` needs an explicit move constructor and assignment operator (after #22069) as the compiler-generated ones may leave the pointer member (`evt_`) valid for the moved-from object leading to double-delete (as both objects think owning it). This PR adds the move operators and makes sure each `evt_` is deleted exactly once when moving objects.

Tested in CMSSW_10_2_X_2018-04-12-2300, in principle expecting no changes but cannot fully exclude them.

@Dr15Jones 