### PR TITLE
Hcal phase1 fastsim updates

### DIFF
--- a/FastSimulation/Calorimetry/src/CalorimetryManager.cc
+++ b/FastSimulation/Calorimetry/src/CalorimetryManager.cc
@@ -1236,12 +1236,12 @@ void CalorimetryManager::updateHCAL(const std::map<CaloHitID,float>& hitMap, int
       else if (hdetid.subdetId()== HcalForward){
         if(useShowerLibrary) {
           if(useCorrectionSL) {
-             if(hdetid.depth()== 1) energy *= hfcorrEm[hdetid.ietaAbs()-ietaShiftHF_];
-             if(hdetid.depth()== 2) energy *= hfcorrHad[hdetid.ietaAbs()-ietaShiftHF_];
+             if(hdetid.depth()== 1 or hdetid.depth()==3) energy *= hfcorrEm[hdetid.ietaAbs()-ietaShiftHF_];
+             if(hdetid.depth()== 2 or hdetid.depth()==4) energy *= hfcorrHad[hdetid.ietaAbs()-ietaShiftHF_];
           }
         } else {
-          if(hdetid.depth()== 1) energy *= samplingHF_[0];
-          if(hdetid.depth()== 2) energy *= samplingHF_[1];
+          if(hdetid.depth()== 1 or hdetid.depth()==3) energy *= samplingHF_[0];
+          if(hdetid.depth()== 2 or hdetid.depth()==4) energy *= samplingHF_[1];
           time = timeShiftHF_[hdetid.ietaAbs()-ietaShiftHF_];
         } 
       }

--- a/FastSimulation/Calorimetry/src/CalorimetryManager.cc
+++ b/FastSimulation/Calorimetry/src/CalorimetryManager.cc
@@ -1226,28 +1226,28 @@ void CalorimetryManager::updateHCAL(const std::map<CaloHitID,float>& hitMap, int
     if(HcalDigitizer_){
       HcalDetId hdetid = HcalDetId(mapitr->first.unitID());
       if (hdetid.subdetId()== HcalBarrel){
-	energy /= samplingHBHE_[hdetid.ietaAbs()-1]; //re-convert to GeV
-	time = timeShiftHB_[hdetid.ietaAbs()-ietaShiftHB_];
+        energy /= samplingHBHE_[hdetid.ietaAbs()-1]; //re-convert to GeV
+        time = timeShiftHB_[hdetid.ietaAbs()-ietaShiftHB_];
       }
       else if (hdetid.subdetId()== HcalEndcap){
-	energy /= samplingHBHE_[hdetid.ietaAbs()-1]; //re-convert to GeV
-	time = timeShiftHE_[hdetid.ietaAbs()-ietaShiftHE_];
+        energy /= samplingHBHE_[hdetid.ietaAbs()-1]; //re-convert to GeV
+        time = timeShiftHE_[hdetid.ietaAbs()-ietaShiftHE_];
       }
       else if (hdetid.subdetId()== HcalForward){
         if(useShowerLibrary) {
- 	  if(useCorrectionSL) {
+          if(useCorrectionSL) {
              if(hdetid.depth()== 1) energy *= hfcorrEm[hdetid.ietaAbs()-ietaShiftHF_];
              if(hdetid.depth()== 2) energy *= hfcorrHad[hdetid.ietaAbs()-ietaShiftHF_];
           }
-	} else {
-	  if(hdetid.depth()== 1) energy *= samplingHF_[0];
-	  if(hdetid.depth()== 2) energy *= samplingHF_[1];
+        } else {
+          if(hdetid.depth()== 1) energy *= samplingHF_[0];
+          if(hdetid.depth()== 2) energy *= samplingHF_[1];
           time = timeShiftHF_[hdetid.ietaAbs()-ietaShiftHF_];
-	} 
+        } 
       }
       else if (hdetid.subdetId()== HcalOuter){
-	energy /= samplingHO_[hdetid.ietaAbs()-1];
-	time = timeShiftHO_[hdetid.ietaAbs()-ietaShiftHO_];
+        energy /= samplingHO_[hdetid.ietaAbs()-1];
+        time = timeShiftHO_[hdetid.ietaAbs()-ietaShiftHO_];
       }
     }	
     

--- a/FastSimulation/ShowerDevelopment/interface/FastHFShowerLibrary.h
+++ b/FastSimulation/ShowerDevelopment/interface/FastHFShowerLibrary.h
@@ -50,7 +50,7 @@ public:
 
   void       const    initHFShowerLibrary(const edm::EventSetup& );
   void                recoHFShowerLibrary(const FSimTrack &myTrack);
-  void                modifyDepth(uint32_t &id);
+  void                modifyDepth(HcalNumberingFromDDD::HcalID& id);
   const std::map<CaloHitID,float>& getHitsMap() { return hitMap; };
 
   void  SetRandom(const RandomEngineAndDistribution *);

--- a/FastSimulation/ShowerDevelopment/src/FastHFShowerLibrary.cc
+++ b/FastSimulation/ShowerDevelopment/src/FastHFShowerLibrary.cc
@@ -123,6 +123,7 @@ void FastHFShowerLibrary::recoHFShowerLibrary(const FSimTrack& myTrack) {
       int lay = 1;
       uint32_t id = 0;
       HcalNumberingFromDDD::HcalID tmp = numberingFromDDD->unitID(det, pos, depth, lay);
+      modifyDepth(tmp);
       id = numberingScheme.getUnitID(tmp);
 
       CaloHitID current_id(id,time,myTrack.id());
@@ -138,16 +139,12 @@ void FastHFShowerLibrary::recoHFShowerLibrary(const FSimTrack& myTrack) {
 
 }
 
-void FastHFShowerLibrary::modifyDepth(uint32_t &id) {
-
-  HcalDetId hid(id);
-  if (hid.subdet() == HcalForward) {
-    int eta = hid.ieta();
-    int phi = hid.iphi();
-    if (hcalConstants->maxHFDepth(eta,phi) > 2) {
-      if (hid.depth() <= 2) {
-	int dep = (G4UniformRand() > 0.5) ? (2+hid.depth()) : hid.depth();
-	id = HcalDetId(HcalForward,eta,phi,dep).rawId();
+void FastHFShowerLibrary::modifyDepth(HcalNumberingFromDDD::HcalID& id) {
+  if (id.subdet == HcalForward) {
+    int ieta = (id.zside == 0) ? -id.etaR : id.etaR;
+    if (hcalConstants->maxHFDepth(ieta,id.phis) > 2) {
+      if (id.depth <= 2) {
+        if (G4UniformRand() > 0.5) id.depth += 2;
       }
     }
   }

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -57,8 +57,9 @@ premix_stage1.toModify(hcalSimBlock,
     HcalPreMixStage1 = True,
 )
 
+# test numbering not used in fastsim
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
-run2_HCAL_2017.toModify( hcalSimBlock, TestNumbering = cms.bool(True) )
+(run2_HCAL_2017 & ~fastSim).toModify( hcalSimBlock, TestNumbering = cms.bool(True) )
 
 # remove HE processing for phase 2, completely put in HGCal land
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal

--- a/Validation/HcalDigis/python/HLTHcalDigisParam_cfi.py
+++ b/Validation/HcalDigis/python/HLTHcalDigisParam_cfi.py
@@ -17,7 +17,8 @@ hltHCALdigisAnalyzer.TestNumber   = cms.bool(False)
 hltHCALdigisAnalyzer.hep17        = cms.bool(False)
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
-run2_HCAL_2017.toModify(hltHCALdigisAnalyzer,
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+(run2_HCAL_2017 & ~fastSim).toModify(hltHCALdigisAnalyzer,
     TestNumber    = cms.bool(True)
 )
 

--- a/Validation/HcalDigis/python/HcalDigisParam_cfi.py
+++ b/Validation/HcalDigis/python/HcalDigisParam_cfi.py
@@ -24,7 +24,7 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(hcaldigisAnalyzer, simHits = "fastSimProducer:HcalHits")
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
-run2_HCAL_2017.toModify(hcaldigisAnalyzer,
+(run2_HCAL_2017 & ~fastSim).toModify(hcaldigisAnalyzer,
     TestNumber    = cms.bool(True)
 )
 

--- a/Validation/HcalHits/python/HcalSimHitStudy_cfi.py
+++ b/Validation/HcalHits/python/HcalSimHitStudy_cfi.py
@@ -15,7 +15,7 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify( hcalSimHitStudy, ModuleLabel = cms.untracked.string('fastSimProducer') )
     
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
-run2_HCAL_2017.toModify( hcalSimHitStudy, TestNumber = cms.bool(True) )
+(run2_HCAL_2017 & ~fastSim).toModify( hcalSimHitStudy, TestNumber = cms.bool(True) )
 
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
 run2_HEPlan1_2017.toModify( hcalSimHitStudy, hep17 = cms.bool(True) )

--- a/Validation/HcalHits/python/HcalSimHitsValidation_cfi.py
+++ b/Validation/HcalHits/python/HcalSimHitsValidation_cfi.py
@@ -11,7 +11,7 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(    HcalSimHitsAnalyser, ModuleLabel = cms.untracked.string("fastSimProducer") )
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
-run2_HCAL_2017.toModify( HcalSimHitsAnalyser, TestNumber = cms.untracked.bool(True) )
+(run2_HCAL_2017 & ~fastSim).toModify( HcalSimHitsAnalyser, TestNumber = cms.untracked.bool(True) )
 
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal 
 phase2_hcal.toModify( HcalSimHitsAnalyser, EEHitCollection = cms.untracked.string("") )

--- a/Validation/HcalHits/python/SimHitsValidationHcal_cfi.py
+++ b/Validation/HcalHits/python/SimHitsValidationHcal_cfi.py
@@ -12,4 +12,4 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify( simHitsValidationHcal, ModuleLabel = cms.string("fastSimProducer") )
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
-run2_HCAL_2017.toModify( simHitsValidationHcal, TestNumber = cms.bool(True) )
+(run2_HCAL_2017 & ~fastSim).toModify( simHitsValidationHcal, TestNumber = cms.bool(True) )

--- a/Validation/HcalRecHits/python/HLTHcalRecHitParam_cfi.py
+++ b/Validation/HcalRecHits/python/HLTHcalRecHitParam_cfi.py
@@ -24,9 +24,11 @@ hltHCALNoiseRates.minRBXEnergy = cms.untracked.double(20.0)
 hltHCALNoiseRates.minHitEnergy = cms.untracked.double(1.5)
 hltHCALNoiseRates.noiselabel   = cms.InputTag('hcalnoise')
 
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toModify( hltHCALRecoAnalyzer, SimHitCollectionLabel = cms.untracked.InputTag("fastSimProducer","HcalHits") )
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
-run2_HCAL_2017.toModify( hltHCALRecoAnalyzer, TestNumber = cms.bool(True) )
+(run2_HCAL_2017 & ~fastSim).toModify( hltHCALRecoAnalyzer, TestNumber = cms.bool(True) )
 
 #from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 #phase2_hcal.toModify(hcalRecoAnalyzer, mc = cms.untracked.string('no') )

--- a/Validation/HcalRecHits/python/HcalRecHitParam_cfi.py
+++ b/Validation/HcalRecHits/python/HcalRecHitParam_cfi.py
@@ -28,8 +28,8 @@ hcalNoiseRates = DQMEDAnalyzer('NoiseRates',
     noiselabel   = cms.InputTag('hcalnoise')
 )
 
-from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
-run2_HCAL_2017.toModify( hcalRecoAnalyzer, TestNumber = cms.bool(True) )
-
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify( hcalRecoAnalyzer, SimHitCollectionLabel = cms.untracked.InputTag("fastSimProducer","HcalHits") )
+
+from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
+(run2_HCAL_2017 & ~fastSim).toModify( hcalRecoAnalyzer, TestNumber = cms.bool(True) )


### PR DESCRIPTION
* HF dual anode splitting:
  * introduced in https://github.com/cms-sw/cmssw/commit/12e98bd14c38e0dbeab5d976dcd67260912bae4e
  * (accidentally?) removed in https://github.com/cms-sw/cmssw/commit/f3ad3409d666dfed66dcbd0b55ca9446aec1a7c7
  * reimplemented here in a different place (to split each PE from the shower library instead of the final hit at the end, perhaps more statistically accurate)
  * extend corrections to HF depths 3, 4
* HE depth segmentation:
  * Fastsim already uses CMS database geometry by default
  * Fullsim uses TestNumbering setting to save hits per layer from 2017 onward - fastsim doesn't do this (no need, we don't store/reuse SIM info from fastsim)
  * remove TestNumbering-related settings from digitization and validation

I confirmed by looking at `hfprereco` and `hbheprereco` collections that the appropriate depths are seen in the 2017 configuration with these changes, using a recipe provided by @ssekmen.

attn: @bsunanda 