### PR TITLE
produce dqm plots also for low stat runs

### DIFF
--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
@@ -123,13 +123,10 @@ void ECALpedestalPCLHarvester::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::
         enough_stat=true;
     }
 
+       
+    dqmPlots(pedestals, ibooker_);
+
     
-    if(enough_stat){
-
-        dqmPlots(pedestals, ibooker_);
-
-    }
-
     // check if there are large variations wrt exisiting pedstals
 
     if (checkAnomalies_){


### PR DESCRIPTION
remove an unwanted feature by which dqm plots are not generated for low stat runs