### PR TITLE
Switch the order of HARVESTING and ALCA steps for upgrade workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2501,7 +2501,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                     '--geometry' : geom,
                                     '--scenario' : 'pp',
                                     '--filetype':'DQM',
-				    '--filein':'file:step3_inDQM.root'
                                     }
 
     upgradeStepDict['HARVESTFullGlobal'][k] = merge([{'-s': 'HARVESTING:@phase2Validation+@phase2+@miniAODValidation+@miniAODDQM'}, upgradeStepDict['HARVESTFull'][k]])
@@ -2511,7 +2510,8 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--datatier':'ALCARECO',
                                       '-n':'10',
                                       '--eventcontent':'ALCARECO',
-                                      '--geometry' : geom
+                                      '--geometry' : geom,
+                                      '--filein':'file:step3.root'
                                       }
 
     upgradeStepDict['FastSim'][k]={'-s':'GEN,SIM,RECO,VALIDATION',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -190,7 +190,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2017_realistic',
         'HLTmenu': '@relval2017',
         'Era' : 'Run2_2017',
-        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','ALCAFull','HARVESTFull'],
+        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull','ALCAFull'],
     },
     '2017Design' : {
         'Geom' : 'DB:Extended',
@@ -205,7 +205,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2018_realistic',
         'HLTmenu': '@relval2018',
         'Era' : 'Run2_2018',
-        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','ALCAFull','HARVESTFull'],
+        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull','ALCAFull'],
     },
     '2018Design' : {
         'Geom' : 'DB:Extended',
@@ -220,7 +220,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2019_realistic',
         'HLTmenu': '@relval2017',
         'Era' : 'Run3',
-        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','ALCAFull','HARVESTFull'],
+        'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull','ALCAFull'],
     },
     '2019Design' : {
         'Geom' : 'Extended2019',


### PR DESCRIPTION
This PR suggests to switch the order of HARVESTING and ALCA steps for the ugprade workflows (2017-18 in practice) as they are in the non-upgrade MC workflows (making them tiny bit more consistent)

Essentially the hardcoded `--filein step3` is moved from HARVESTING to ALCA step. While it does not really add anything for workflows with both HARVESTING and ALCA, it does add flexibility to workflows without ALCA (like all 2023 ones) by not fixing the RECO+DQM+VALIDATION step to be number 3. This feature will be needed for combined premixing stage1+stage2 workflow (where RECO will be step 4).

Tested in CMSSW_10_2_X_2018-04-12-2300, no changes expected.