### PR TITLE
Magnetic Field: Remove Dependency on DDSolidShape

### DIFF
--- a/MagneticField/GeomBuilder/src/MagGeoBuilderFromDDD.cc
+++ b/MagneticField/GeomBuilder/src/MagGeoBuilderFromDDD.cc
@@ -490,7 +490,6 @@ void MagGeoBuilderFromDDD::buildMagVolumes(const handles & volumes, map<string, 
     const GloballyPositioned<float> * gpos = (*vol)->placement();
     (*vol)->magVolume = new MagVolume6Faces(gpos->position(),
 					    gpos->rotation(),
-					    (*vol)->shape(),
 					    (*vol)->sides(),
 					    mp, sf);
 
@@ -579,7 +578,6 @@ void MagGeoBuilderFromDDD::buildInterpolator(const volumeHandle * vol, map<strin
     // Check that all grid points of the interpolator are inside the volume.
       const MagVolume6Faces tempVolume(vol->placement()->position(),
 				 vol->placement()->rotation(),
-				 vol->shape(),
 				 vol->sides(), 
 				 interpolators[vol->magFile]);
 

--- a/MagneticField/VolumeGeometry/interface/MagCylinder.h
+++ b/MagneticField/VolumeGeometry/interface/MagCylinder.h
@@ -17,7 +17,7 @@ class MagCylinder : public MagVolume {
 public:
 
   MagCylinder( const PositionType& pos, const RotationType& rot, 
-	       DDSolidShape shape, const std::vector<VolumeSide>& faces,
+	       const std::vector<VolumeSide>& faces,
 	       const MagneticFieldProvider<float> * mfp);
 
   bool inside( const GlobalPoint& gp, double tolerance=0.) const override;

--- a/MagneticField/VolumeGeometry/interface/MagVolume.h
+++ b/MagneticField/VolumeGeometry/interface/MagVolume.h
@@ -2,7 +2,6 @@
 #define MagVolume_H
 
 #include "DataFormats/GeometrySurface/interface/GloballyPositioned.h"
-#include "DetectorDescription/Core/interface/DDSolidShapes.h"
 #include "MagneticField/VolumeGeometry/interface/VolumeSide.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 
@@ -21,14 +20,12 @@ public:
   typedef GloballyPositioned<float>::GlobalVector   GlobalVector;
 
   MagVolume( const PositionType& pos, const RotationType& rot, 
-	     DDSolidShape shape, const MagneticFieldProvider<float> * mfp,
+	     const MagneticFieldProvider<float> * mfp,
 	     double sf=1.) :
-    Base(pos,rot), MagneticField(), theShape(shape), theProvider(mfp), 
+    Base(pos,rot), MagneticField(), theProvider(mfp), 
     theProviderOwned(false), theScalingFactor(sf), isIronFlag(false) {}
 
   ~MagVolume() override;
-
-  DDSolidShape shapeType() const {return theShape;}
 
   LocalVector fieldInTesla( const LocalPoint& lp) const;
   GlobalVector fieldInTesla( const GlobalPoint& lp) const;
@@ -54,7 +51,6 @@ public:
 
 private:
 
-  DDSolidShape theShape;
   const MagneticFieldProvider<float> * theProvider;
   bool theProviderOwned;
   double theScalingFactor;

--- a/MagneticField/VolumeGeometry/interface/MagVolume6Faces.h
+++ b/MagneticField/VolumeGeometry/interface/MagVolume6Faces.h
@@ -17,10 +17,6 @@
 
 #include <vector>
 
-//-- FIXME
-#include <string>
-//--
-
 template <class T>
 class MagneticFieldProvider;
 
@@ -28,7 +24,7 @@ class MagVolume6Faces : public MagVolume {
 public:
 
   MagVolume6Faces( const PositionType& pos, const RotationType& rot, 
-		   DDSolidShape shape, const std::vector<VolumeSide>& faces,
+		   const std::vector<VolumeSide>& faces,
 		   const MagneticFieldProvider<float> * mfp,
 		   double sf=1.);
 

--- a/MagneticField/VolumeGeometry/src/MagCylinder.cc
+++ b/MagneticField/VolumeGeometry/src/MagCylinder.cc
@@ -1,16 +1,12 @@
-// 
-//#include "Utilities/Configuration/interface/Architecture.h"
-
 #include "MagneticField/VolumeGeometry/interface/MagCylinder.h"
 #include "MagneticField/VolumeGeometry/interface/MagExceptions.h"
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 
 MagCylinder::MagCylinder( const PositionType& pos,
 			  const RotationType& rot, 
-			  DDSolidShape shape,
 			  const std::vector<VolumeSide>& faces,
 			  const MagneticFieldProvider<float> * mfp)
-  : MagVolume(pos,rot,shape,mfp), theFaces(faces), theZmin(0.), theZmax(0.), theInnerR(0.), theOuterR(0.)
+  : MagVolume(pos,rot,mfp), theFaces(faces), theZmin(0.), theZmax(0.), theInnerR(0.), theOuterR(0.)
 {
   using SurfaceOrientation::GlobalFace;
 

--- a/MagneticField/VolumeGeometry/src/MagVolume6Faces.cc
+++ b/MagneticField/VolumeGeometry/src/MagVolume6Faces.cc
@@ -2,11 +2,10 @@
 
 MagVolume6Faces::MagVolume6Faces( const PositionType& pos,
 				  const RotationType& rot, 
-				  DDSolidShape shape,
 				  const std::vector<VolumeSide>& faces,
 				  const MagneticFieldProvider<float> * mfp,
 				  double sf)
-  : MagVolume(pos,rot,shape,mfp,sf),  volumeNo(0), copyno(0), theFaces(faces)
+  : MagVolume(pos,rot,mfp,sf),  volumeNo(0), copyno(0), theFaces(faces)
 {}
 
 bool MagVolume6Faces::inside( const GlobalPoint& gp, double tolerance) const 

--- a/TrackPropagation/RungeKutta/interface/defaultRKPropagator.h
+++ b/TrackPropagation/RungeKutta/interface/defaultRKPropagator.h
@@ -30,8 +30,8 @@ namespace defaultRKPropagator {
   class RKMagVolume final : public MagVolume {
   public:
     RKMagVolume( const PositionType& pos, const RotationType& rot, 
-		 DDSolidShape shape, const MagneticFieldProvider<float> * mfp) :
-      MagVolume( pos, rot, shape, mfp) {}
+		 const MagneticFieldProvider<float> * mfp) :
+      MagVolume( pos, rot, mfp) {}
     
     bool inside( const GlobalPoint& gp, double tolerance=0.) const override {return true;}
     
@@ -45,7 +45,7 @@ namespace defaultRKPropagator {
   struct Product {
     explicit Product(const MagneticField* field,PropagationDirection dir = alongMomentum, double tolerance = 5.e-5) : 
       mpf(field), 
-      volume(MagVolume::PositionType(0,0,0), MagVolume::RotationType(),ddshapeless, &mpf),
+      volume(MagVolume::PositionType(0,0,0), MagVolume::RotationType(), &mpf),
       propagator(volume, dir, tolerance){}
     TrivialFieldProvider mpf;
     RKMagVolume volume;

--- a/TrackPropagation/SteppingHelixPropagator/src/SteppingHelixPropagator.cc
+++ b/TrackPropagation/SteppingHelixPropagator/src/SteppingHelixPropagator.cc
@@ -1959,7 +1959,7 @@ SteppingHelixPropagator::refToMagVolume(const SteppingHelixPropagator::StateInfo
   double curP = sv.p3.mag();
 
   if (debug_){
-    LogTrace(metname)<<std::setprecision(17)<<std::setw(20)<<std::scientific<<"Trying volume "<<DDSolidShapesName::name(cVol->shapeType())
+    LogTrace(metname)<<std::setprecision(17)<<std::setw(20)<<std::scientific<<"Trying volume "
 		     <<" with "<<cVolFaces.size()<<" faces"<<std::endl;
   }
 


### PR DESCRIPTION
* DDSolidShape doesn't seem to be used. The MagVolume's private shape member was set to ddshapeless

@slava77 - either the shape information is not needed and this PR is ok, or we should find a common place for the following include file to avoid Reco dependency on DD: https://github.com/cms-sw/cmssw/pull/22986/files#diff-f77fc1bddc05bdfec90ad6e66289ca1c 