### PR TITLE
Bug fix for static pulse shapes

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
@@ -86,7 +86,7 @@ public:
       norm += std::max(0., nt[j-shift]);
     }
     double normInv=1./norm;
-    std::vector<double> nt2(nbin,0);
+    std::vector<double> nt2(nt.size(),0);
     for ( int j = 1; j<=(int)nbin; j++) {
       if ( j-shift>=0 ) {
         nt2[j] = nt[j-shift]*normInv;


### PR DESCRIPTION
This PR corrects an error in reimplementing the pulse shape calculation from #22921. The intermediate vector should be initialized to the size of the input vector, not the output vector (the convolution produces a vector of size 2n-1). This caused an invalid write.