### PR TITLE
isolate TTree::Fill so IMT doesn't steal long running CMS tasks

### DIFF
--- a/IOPool/Output/src/RootOutputTree.cc
+++ b/IOPool/Output/src/RootOutputTree.cc
@@ -22,6 +22,8 @@
 
 #include <limits>
 
+#include "tbb/task_arena.h"
+
 namespace edm {
 
     /**
@@ -319,7 +321,9 @@ namespace edm {
       fillTTree(producedBranches_);
       fillTTree(unclonedReadBranches_);
     } else {
-      tree_->Fill();
+      // Isolate the fill operation so that IMT doesn't grab other large tasks
+      // that could lead to PoolOutputModule stalling
+      tbb::this_task_arena::isolate( [&]{ tree_->Fill(); } );
     }
   }
 


### PR DESCRIPTION
In a CMSSW job with many threads, a small number of output branches, and ROOT IMT enabled, the parallel IMT compression can run out of its own tasks to run.  That can lead to the PoolOutputModule thread stealing a CMSSW task, potentially a long running one (like G4 simulation),  leading to lengthy PoolOutputModule stalls.  This has been observed to cause significant performance degradation and excessive stalls for GEN-SIM jobs with 24 or more threads.  This was observed by @slava77 in scaling tests with 32 threads.

This PR wraps the primary PoolOutputModule call to TTree::Fill inside a TBB this_task_arena::isolate() context that restricts the current thread to only execute tasks created by it or its children, preventing stealing of other CMSSW tasks.