### PR TITLE
try to solve mg5 /tmp problem from ExternalLHEProducer

### DIFF
--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
@@ -65,6 +65,10 @@ mkdir lheevent; cd lheevent
 #untar the tarball directly from cvmfs
 tar -xaf ${path} 
 
+# If TMPDIR is unset, set it to the condor scratch area if present
+# and fallback to /tmp
+export TMPDIR=${TMPDIR:-${_CONDOR_SCRATCH_DIR:-/tmp}}
+
 #generate events
 ./runcmsgrid.sh $nevt $rnum $ncpu ${@:5}
 


### PR DESCRIPTION
In production (and gridpack creation) when using condor infrastructure 
some failures have been observed which are related to the use of `/tmp`
by MG5_aMC when the `$TMPDIR` environment variable is not set.
A solution has been provided by @khurtado (https://github.com/cms-sw/genproductions/issues/1534#issuecomment-346390101)
and is used for new gridpacks.
However, so far, existing gridpacks had been patched one by one.
Different MG5_aMC versions require different patches, making the operation cumbersome.
Discussing with @fabiocos and @vlimant it comes out that CMSSW doesn't touch this environment variable, 
so one can effectively set the $TMPDIR upstream in the ExternalLHEProducer before the gridpack runs.
It has been cross-checked that the call of `cmsenv` doesn't overwrite the `$TMPDIR` variable

@kdlong, @agrohsje, @efeyazgan, @perrozzi

[1]
```
-bash-4.1$ cmsenv
-bash-4.1$ echo $TMPDIR
/tmp/pippo
-bash-4.1$ export TMPDIR=/ciao
-bash-4.1$ echo $TMPDIR
/ciao
-bash-4.1$ cmsenv
-bash-4.1$ echo $TMPDIR
/ciao
```