### PR TITLE
HCALDQM: Add monitoring of LED and laser in global runs (10_2_X)

### DIFF
--- a/DQM/HcalCommon/interface/Constants.h
+++ b/DQM/HcalCommon/interface/Constants.h
@@ -321,7 +321,8 @@ namespace hcaldqm
 		 *	Orbit Gap Operations enum
 		 */
 		uint8_t const EVENTTYPE_PEDESTAL = 1;
-		uint8_t const EVENTTYPE_LASER = 14;
+		uint8_t const EVENTTYPE_LASER    = 14;
+		uint8_t const EVENTTYPE_LED      = 15;
 		enum OrbitGapType
 		{
 			tUnkown = -1,

--- a/DQM/HcalCommon/interface/Container1D.h
+++ b/DQM/HcalCommon/interface/Container1D.h
@@ -323,6 +323,9 @@ namespace hcaldqm
 			//	set lumi flags for all mes
 			virtual void setLumiFlag();
 
+			virtual void showOverflowX(bool showOverflow);
+			virtual void showOverflowY(bool showOverflow);
+
 		protected:
 			virtual void customize(MonitorElement*);
 

--- a/DQM/HcalCommon/interface/Container2D.h
+++ b/DQM/HcalCommon/interface/Container2D.h
@@ -173,6 +173,8 @@ namespace hcaldqm
 				HcalElectronicsMap const*, filter::HashFilter const&,
 				std::string subsystem="Hcal", std::string aux="") override;
 
+			void showOverflowZ(bool showOverflow);
+
 		protected:
 			Quantity	*_qz;
 

--- a/DQM/HcalCommon/interface/ContainerProf2D.h
+++ b/DQM/HcalCommon/interface/ContainerProf2D.h
@@ -54,6 +54,31 @@ namespace hcaldqm
 				HcalElectronicsMap const*, filter::HashFilter const&,
 				std::string subsystem="Hcal", std::string aux="") override;
 
+			void fill(HcalDetId const&) override ;
+			void fill(HcalDetId const&, int) override;
+			void fill(HcalDetId const&, double) override;
+			void fill(HcalDetId const&, int, double) override;
+			void fill(HcalDetId const&, int, int) override;
+			void fill(HcalDetId const&, double, double) override;
+
+			void fill(HcalElectronicsId const&) override;
+			void fill(HcalElectronicsId const&, int) override;
+			void fill(HcalElectronicsId const&, double) override;
+			void fill(HcalElectronicsId const&, int, double) override;
+			void fill(HcalElectronicsId const&, int, int) override;
+			void fill(HcalElectronicsId const&, double, double) override;
+
+			void fill(HcalTrigTowerDetId const&) override;
+			void fill(HcalTrigTowerDetId const&, int) override;
+			void fill(HcalTrigTowerDetId const&, double) override;
+			void fill(HcalTrigTowerDetId const&, int, int) override;
+			void fill(HcalTrigTowerDetId const&, int, double) override;
+			void fill(HcalTrigTowerDetId const&, double, double) override;
+
+			void fill(HcalDetId const&, double, double, double);
+			void fill(HcalElectronicsId const&, double, double, double);
+			void fill(HcalTrigTowerDetId const&, double, double, double);
+
 		protected:
 	};
 }

--- a/DQM/HcalCommon/interface/ContainerSingle1D.h
+++ b/DQM/HcalCommon/interface/ContainerSingle1D.h
@@ -101,6 +101,9 @@ namespace hcaldqm
 
 			virtual void extendAxisRange(int);
 
+			virtual void showOverflowX(bool showOverflow);
+			virtual void showOverflowY(bool showOverflow);
+
 		protected:
 			MonitorElement				*_me;
 			Quantity					*_qx;

--- a/DQM/HcalCommon/interface/ContainerSingle2D.h
+++ b/DQM/HcalCommon/interface/ContainerSingle2D.h
@@ -154,6 +154,8 @@ namespace hcaldqm
 
 			virtual void extendAxisRange(int);
 
+			void showOverflowZ(bool showOverflow);
+
 		protected:
 			MonitorElement					*_me;
 			Quantity						*_qx;

--- a/DQM/HcalCommon/interface/ContainerSingleProf2D.h
+++ b/DQM/HcalCommon/interface/ContainerSingleProf2D.h
@@ -50,30 +50,30 @@ namespace hcaldqm
 			void fill(double, double) override;
 			void fill(double, double, double) override;
 
-			virtual void fill(HcalDetId const&);
-			virtual void fill(HcalDetId const&, int);
-			virtual void fill(HcalDetId const&, double);
-			virtual void fill(HcalDetId const&, int, int);
-			virtual void fill(HcalDetId const&, int, double);
-			virtual void fill(HcalDetId const&, double, double);
+			void fill(HcalDetId const&) override;
+			void fill(HcalDetId const&, int) override;
+			void fill(HcalDetId const&, double) override;
+			void fill(HcalDetId const&, int, int) override;
+			void fill(HcalDetId const&, int, double) override;
+			void fill(HcalDetId const&, double, double) override;
 
-			virtual void fill(HcalElectronicsId const&);
-			virtual void fill(HcalElectronicsId const&, int);
-			virtual void fill(HcalElectronicsId const&, double);
-			virtual void fill(HcalElectronicsId const&, int, int);
-			virtual void fill(HcalElectronicsId const&, int, double);
-			virtual void fill(HcalElectronicsId const&, double, double);
+			void fill(HcalElectronicsId const&) override;
+			void fill(HcalElectronicsId const&, int) override;
+			void fill(HcalElectronicsId const&, double) override;
+			void fill(HcalElectronicsId const&, int, int) override;
+			void fill(HcalElectronicsId const&, int, double) override;
+			void fill(HcalElectronicsId const&, double, double) override;
 
-			virtual void fill(HcalDetId const&, HcalElectronicsId const&);
-			virtual void fill(HcalDetId const&, HcalElectronicsId const&, 
-				double);
+			void fill(HcalDetId const&, HcalElectronicsId const&) override;
+			void fill(HcalDetId const&, HcalElectronicsId const&, 
+				double) override;
 
-			virtual void fill(HcalTrigTowerDetId const&);
-			virtual void fill(HcalTrigTowerDetId const&, int);
-			virtual void fill(HcalTrigTowerDetId const&, double);
-			virtual void fill(HcalTrigTowerDetId const&, int, int);
-			virtual void fill(HcalTrigTowerDetId const&, int, double);
-			virtual void fill(HcalTrigTowerDetId const&, double, double);
+			void fill(HcalTrigTowerDetId const&) override;
+			void fill(HcalTrigTowerDetId const&, int) override;
+			void fill(HcalTrigTowerDetId const&, double) override;
+			void fill(HcalTrigTowerDetId const&, int, int) override;
+			void fill(HcalTrigTowerDetId const&, int, double) override;
+			void fill(HcalTrigTowerDetId const&, double, double) override;
 
 	};
 }

--- a/DQM/HcalCommon/interface/ContainerSingleProf2D.h
+++ b/DQM/HcalCommon/interface/ContainerSingleProf2D.h
@@ -40,6 +40,41 @@ namespace hcaldqm
 				std::string subsystem="Hcal", std::string aux="") override;
 			void book(DQMStore*,
 				std::string subsystem="Hcal", std::string aux="") override;
+
+			void fill(int, int) override;
+			void fill(int, double) override;
+			void fill(int, double, double) override;
+			void fill(int, int, int) override;
+			void fill(int, int, double) override;
+			void fill(double, int) override;
+			void fill(double, double) override;
+			void fill(double, double, double) override;
+
+			virtual void fill(HcalDetId const&);
+			virtual void fill(HcalDetId const&, int);
+			virtual void fill(HcalDetId const&, double);
+			virtual void fill(HcalDetId const&, int, int);
+			virtual void fill(HcalDetId const&, int, double);
+			virtual void fill(HcalDetId const&, double, double);
+
+			virtual void fill(HcalElectronicsId const&);
+			virtual void fill(HcalElectronicsId const&, int);
+			virtual void fill(HcalElectronicsId const&, double);
+			virtual void fill(HcalElectronicsId const&, int, int);
+			virtual void fill(HcalElectronicsId const&, int, double);
+			virtual void fill(HcalElectronicsId const&, double, double);
+
+			virtual void fill(HcalDetId const&, HcalElectronicsId const&);
+			virtual void fill(HcalDetId const&, HcalElectronicsId const&, 
+				double);
+
+			virtual void fill(HcalTrigTowerDetId const&);
+			virtual void fill(HcalTrigTowerDetId const&, int);
+			virtual void fill(HcalTrigTowerDetId const&, double);
+			virtual void fill(HcalTrigTowerDetId const&, int, int);
+			virtual void fill(HcalTrigTowerDetId const&, int, double);
+			virtual void fill(HcalTrigTowerDetId const&, double, double);
+
 	};
 }
 

--- a/DQM/HcalCommon/interface/ElectronicsMap.h
+++ b/DQM/HcalCommon/interface/ElectronicsMap.h
@@ -53,6 +53,7 @@ namespace hcaldqm
 				void initialize(HcalElectronicsMap const*, ElectronicsMapType,
 					filter::HashFilter const&);
 				uint32_t lookup(DetId const&);
+				uint32_t lookup(HcalDetId const&);
 				uint32_t lookup(HcalElectronicsId const&);
 
 				void print();

--- a/DQM/HcalCommon/interface/HashFunctions.h
+++ b/DQM/HcalCommon/interface/HashFunctions.h
@@ -32,7 +32,6 @@ namespace hcaldqm
 		uint32_t hash_HFPMiphi(HcalDetId const&);
 		uint32_t hash_HBHEPartition(HcalDetId const&);
 		uint32_t hash_DChannel(HcalDetId const&);
-		uint32_t hash_RBX(HcalDetId const&);
 
 		/**
 		 *	by ElectronicsId
@@ -71,7 +70,6 @@ namespace hcaldqm
 		std::string name_HFPMiphi(HcalDetId const&);
 		std::string name_HBHEPartition(HcalDetId const&);
 		std::string name_DChannel(HcalDetId const&);
-		std::string name_RBX(HcalDetId const&);
 
 		uint32_t hash_Subdet(std::string const&);
 		uint32_t hash_Subdetiphi(std::string const&);
@@ -85,7 +83,6 @@ namespace hcaldqm
 		uint32_t hash_HFPMiphi(std::string const&);
 		uint32_t hash_HBHEPartition(std::string const&);
 		uint32_t hash_DChannel(std::string const&);
-		uint32_t hash_RBX(std::string const&);
 
 		std::string name_FED(HcalElectronicsId const&);
 		std::string name_FEDSpigot(HcalElectronicsId const&);
@@ -127,44 +124,39 @@ namespace hcaldqm
 
 		enum HashType
 		{
-			fSubdet=0,
-			fSubdetiphi=1,
-			fSubdetieta=2,
-			fSubdetdepth=3,
-			fSubdetPM=4,
-			fSubdetPMiphi=5,
-			fiphi=6,
-			fieta=7,
-			fdepth=8,
-			fHFPMiphi=9,
-			fHBHEPartition=10,
-			fDChannel=11,
-			fRBX=12,
-
-			nHashType_did=13,
-
-			fFED=14,
-			fFEDSpigot=15,
-			fFEDSlot=16,
-			fCrate=17,
-			fCrateSpigot=18,
-			fCrateSlot=19,
-			fFiber=20,
-			fFiberFiberCh=21,
-			fFiberCh=22,
-			fElectronics=23,
-			fEChannel=24,
-
-			nHashType_eid=25,
-
-			fTTSubdet=26,
-			fTTSubdetPM=27,
-			fTTSubdetPMiphi=28,
-			fTTSubdetieta=29,
-			fTTdepth=30,
-			fTChannel=31,
-
-			nHashType_tid=32,
+			fSubdet = 0,
+			fSubdetiphi = 1,
+			fSubdetieta = 2,
+			fSubdetdepth = 3,
+			fSubdetPM = 4,
+			fSubdetPMiphi = 5,
+			fiphi = 6,
+			fieta = 7,
+			fdepth = 8,
+			fHFPMiphi = 9,
+			fHBHEPartition = 10,
+			fDChannel = 11,
+			nHashType_did = 12,
+			fFED = 13,
+			fFEDSpigot = 14,
+			fFEDSlot = 15,
+			fCrate = 16,
+			fCrateSpigot = 17,
+			fCrateSlot = 18,
+			fFiber = 19,
+			fFiberFiberCh = 20,
+			fFiberCh = 21,
+			fElectronics = 22,
+			fEChannel = 23, 
+			nHashType_eid = 24,
+			fTTSubdet = 25,
+			fTTSubdetPM = 26,
+			fTTSubdetPMiphi = 27,
+			fTTSubdetieta = 28,
+			fTTdepth = 29,
+			fTChannel = 30,
+			nHashType_tid = 31,
+			nHashType = 32
 		};
 		typedef uint32_t (*hash_function_did)(HcalDetId const&);
 		typedef uint32_t (*hash_function_eid)(HcalElectronicsId const&);
@@ -172,109 +164,52 @@ namespace hcaldqm
 		typedef std::string (*name_function_did)(HcalDetId const&);
 		typedef std::string (*name_function_eid)(HcalElectronicsId const&);
 		typedef std::string (*name_function_tid)(HcalTrigTowerDetId const&);
-		const std::map<HashType, hash_function_did> hash_did = {
-			{fSubdet,hash_Subdet}, 
-			{fSubdetiphi,hash_Subdetiphi}, 
-			{fSubdetieta,hash_Subdetieta}, 
-			{fSubdetdepth,hash_Subdetdepth}, 
-			{fSubdetPM,hash_SubdetPM}, 
-			{fSubdetPMiphi,hash_SubdetPMiphi},
-			{fiphi,hash_iphi}, 
-			{fieta,hash_ieta}, 
-			{fdepth,hash_depth}, 
-			{fHFPMiphi,hash_HFPMiphi}, 
-			{fHBHEPartition,hash_HBHEPartition}, 
-			{fDChannel,hash_DChannel}, 
-			{fRBX,hash_RBX},
+		hash_function_did const hash_did[nHashType_did] = {
+			hash_Subdet, hash_Subdetiphi, hash_Subdetieta, 
+			hash_Subdetdepth, hash_SubdetPM, hash_SubdetPMiphi,
+			hash_iphi, hash_ieta, hash_depth, hash_HFPMiphi, 
+			hash_HBHEPartition, hash_DChannel
 		};
-		const std::map<HashType, hash_function_eid> hash_eid = {
-			{fFED,hash_FED}, 
-			{fFEDSpigot,hash_FEDSpigot}, 
-			{fFEDSlot,hash_FEDSlot}, 
-			{fCrate,hash_Crate}, 
-			{fCrateSpigot,hash_CrateSpigot}, 
-			{fCrateSlot,hash_CrateSlot},
-			{fFiber,hash_Fiber}, 
-			{fFiberFiberCh,hash_FiberFiberCh}, 
-			{fFiberCh,hash_FiberCh},
-			{fElectronics,hash_Electronics}, 
-			{fEChannel,hash_EChannel},
+		hash_function_eid const hash_eid[nHashType_eid-nHashType_did-1] = {
+			hash_FED, hash_FEDSpigot, hash_FEDSlot, 
+			hash_Crate, hash_CrateSpigot, hash_CrateSlot,
+			hash_Fiber, hash_FiberFiberCh, hash_FiberCh,
+			hash_Electronics, hash_EChannel
 		};
-		const std::map<HashType, hash_function_tid> hash_tid = {
-			{fTTSubdet,hash_TTSubdet}, 
-			{fTTSubdetPM,hash_TTSubdetPM}, 
-			{fTTSubdetPMiphi, hash_TTSubdetPMiphi}, 
-			{fTTSubdetieta,hash_TTSubdetieta}, 
-			{fTTdepth,hash_TTdepth}, 
-			{fTChannel,hash_TChannel},
+		hash_function_tid const hash_tid[nHashType_tid-nHashType_eid-1] = {
+			hash_TTSubdet, hash_TTSubdetPM, hash_TTSubdetPMiphi, 
+			hash_TTSubdetieta, hash_TTdepth, hash_TChannel
 		};
-		const std::map<HashType, name_function_did> name_did = {
-			{fSubdet,name_Subdet}, 
-			{fSubdetiphi,name_Subdetiphi}, 
-			{fSubdetieta, name_Subdetieta}, 
-			{fSubdetdepth, name_Subdetdepth}, 
-			{fSubdetPM, name_SubdetPM}, 
-			{fSubdetPMiphi, name_SubdetPMiphi},
-			{fiphi, name_iphi}, 
-			{fieta, name_ieta}, 
-			{fdepth, name_depth}, 
-			{fHFPMiphi, name_HFPMiphi}, 
-			{fHBHEPartition, name_HBHEPartition}, 
-			{fDChannel, name_DChannel},
-			{fRBX, name_RBX}
+		name_function_did const name_did[nHashType_did] = {
+			name_Subdet, name_Subdetiphi, name_Subdetieta, 
+			name_Subdetdepth, name_SubdetPM, name_SubdetPMiphi,
+			name_iphi, name_ieta, name_depth, name_HFPMiphi, 
+			name_HBHEPartition, name_DChannel
 		};
-		const std::map<HashType, name_function_eid> name_eid = {
-			{fFED,name_FED}, 
-			{fFEDSpigot,name_FEDSpigot}, 
-			{fFEDSlot,name_FEDSlot},
-			{fCrate,name_Crate}, 
-			{fCrateSpigot,name_CrateSpigot}, 
-			{fCrateSlot,name_CrateSlot},
-			{fFiber,name_Fiber}, 
-			{fFiberFiberCh,name_FiberFiberCh}, 
-			{fFiberCh,name_FiberCh},
-			{fElectronics,name_Electronics}, 
-			{fEChannel,name_EChannel}
+		name_function_eid const name_eid[nHashType_eid-nHashType_did-1] = {
+			name_FED, name_FEDSpigot, name_FEDSlot,
+			name_Crate, name_CrateSpigot, name_CrateSlot,
+			name_Fiber, name_FiberFiberCh, name_FiberCh,
+			name_Electronics, name_EChannel
 		};
-		const std::map<HashType, name_function_tid> name_tid = {
-			{fTTSubdet, name_TTSubdet}, 
-			{fTTSubdetPM, name_TTSubdetPM}, 
-			{fTTSubdetPMiphi, name_TTSubdetPMiphi},
-			{fTTSubdetieta, name_TTSubdetieta}, 
-			{fTTdepth, name_TTdepth}, 
-			{fTChannel, name_TChannel},
+		name_function_tid const name_tid[nHashType_tid-nHashType_eid-1] = {
+			name_TTSubdet, name_TTSubdetPM, name_TTSubdetPMiphi,
+			name_TTSubdetieta, name_TTdepth, name_TChannel
 		};
-		const std::map<HashType, std::string> hash_names = {
-			{fSubdet,"Subdet"}, 
-			{fSubdetiphi,"Subdetiphi"}, 
-			{fSubdetieta,"Subdetieta"}, 
-			{fSubdetdepth,"Subdetdepth"},
-			{fSubdetPM,"SubdetPM"}, 
-			{fSubdetPMiphi,"SubdetPMiphi"}, 
-			{fiphi,"iphi"}, 
-			{fieta,"ieta"}, 
-			{fdepth,"depth"},
-			{fHFPMiphi,"HFPMiphi"}, 
-			{fHBHEPartition,"HBHEPartition"}, 
-			{fRBX,"RBX"},
-			{fDChannel,"DChannel"},
-			{fFED,"FED"}, 
-			{fFEDSpigot,"FEDSpigot"}, 
-			{fFEDSlot,"FEDSlot"},
-			{fCrate,"Crate"}, 
-			{fCrateSpigot,"CrateSpigot"}, 
-			{fCrateSlot,"CrateSlot"},
-			{fFiber,"Fiber"}, 
-			{fFiberFiberCh,"FiberFiberCh"}, 
-			{fFiberCh,"FiberCh"},
-			{fElectronics,"Electronics"}, 
-			{fEChannel,"EChannel"},
-			{fTTSubdet,"TTSubdet"}, 
-			{fTTSubdetPM,"TTSubdetPM"}, 
-			{fTTSubdetPMiphi,"TTSubdetPMiphi"},
-			{fTTSubdetieta,"TTSubdetieta"}, 
-			{fTTdepth,"TTdepth"}, 
-			{fTChannel,"TChannel"},
+		int const nhashes = nHashType_did + (nHashType_eid-nHashType_did-1) + 
+			(nHashType_tid-nHashType_eid-1);
+		std::string const hash_names[nhashes] = {
+			"Subdet", "Subdetiphi", "Subdetieta", "Subdetdepth",
+			"SubdetPM", "SubdetPMiphi", "iphi", "ieta", "depth",
+			"HFPMiphi", "HBHEPartition", "DChannel",
+
+			"FED", "FEDSpigot", "FEDSlot",
+			"Crate", "CrateSpigot", "CrateSlot",
+			"Fiber", "FiberFiberCh", "FiberCh",
+			"Electronics", "EChannel",
+
+			"TTSubdet", "TTSubdetPM", "TTSubdetPMiphi",
+			"TTSubdetieta", "TTdepth", "TChannel"
 		};
 	}
 }

--- a/DQM/HcalCommon/interface/HashFunctions.h
+++ b/DQM/HcalCommon/interface/HashFunctions.h
@@ -32,6 +32,7 @@ namespace hcaldqm
 		uint32_t hash_HFPMiphi(HcalDetId const&);
 		uint32_t hash_HBHEPartition(HcalDetId const&);
 		uint32_t hash_DChannel(HcalDetId const&);
+		uint32_t hash_RBX(HcalDetId const&);
 
 		/**
 		 *	by ElectronicsId
@@ -70,6 +71,7 @@ namespace hcaldqm
 		std::string name_HFPMiphi(HcalDetId const&);
 		std::string name_HBHEPartition(HcalDetId const&);
 		std::string name_DChannel(HcalDetId const&);
+		std::string name_RBX(HcalDetId const&);
 
 		uint32_t hash_Subdet(std::string const&);
 		uint32_t hash_Subdetiphi(std::string const&);
@@ -83,6 +85,7 @@ namespace hcaldqm
 		uint32_t hash_HFPMiphi(std::string const&);
 		uint32_t hash_HBHEPartition(std::string const&);
 		uint32_t hash_DChannel(std::string const&);
+		uint32_t hash_RBX(std::string const&);
 
 		std::string name_FED(HcalElectronicsId const&);
 		std::string name_FEDSpigot(HcalElectronicsId const&);
@@ -124,39 +127,44 @@ namespace hcaldqm
 
 		enum HashType
 		{
-			fSubdet = 0,
-			fSubdetiphi = 1,
-			fSubdetieta = 2,
-			fSubdetdepth = 3,
-			fSubdetPM = 4,
-			fSubdetPMiphi = 5,
-			fiphi = 6,
-			fieta = 7,
-			fdepth = 8,
-			fHFPMiphi = 9,
-			fHBHEPartition = 10,
-			fDChannel = 11,
-			nHashType_did = 12,
-			fFED = 13,
-			fFEDSpigot = 14,
-			fFEDSlot = 15,
-			fCrate = 16,
-			fCrateSpigot = 17,
-			fCrateSlot = 18,
-			fFiber = 19,
-			fFiberFiberCh = 20,
-			fFiberCh = 21,
-			fElectronics = 22,
-			fEChannel = 23, 
-			nHashType_eid = 24,
-			fTTSubdet = 25,
-			fTTSubdetPM = 26,
-			fTTSubdetPMiphi = 27,
-			fTTSubdetieta = 28,
-			fTTdepth = 29,
-			fTChannel = 30,
-			nHashType_tid = 31,
-			nHashType = 32
+			fSubdet=0,
+			fSubdetiphi=1,
+			fSubdetieta=2,
+			fSubdetdepth=3,
+			fSubdetPM=4,
+			fSubdetPMiphi=5,
+			fiphi=6,
+			fieta=7,
+			fdepth=8,
+			fHFPMiphi=9,
+			fHBHEPartition=10,
+			fDChannel=11,
+			fRBX=12,
+
+			nHashType_did=13,
+
+			fFED=14,
+			fFEDSpigot=15,
+			fFEDSlot=16,
+			fCrate=17,
+			fCrateSpigot=18,
+			fCrateSlot=19,
+			fFiber=20,
+			fFiberFiberCh=21,
+			fFiberCh=22,
+			fElectronics=23,
+			fEChannel=24,
+
+			nHashType_eid=25,
+
+			fTTSubdet=26,
+			fTTSubdetPM=27,
+			fTTSubdetPMiphi=28,
+			fTTSubdetieta=29,
+			fTTdepth=30,
+			fTChannel=31,
+
+			nHashType_tid=32,
 		};
 		typedef uint32_t (*hash_function_did)(HcalDetId const&);
 		typedef uint32_t (*hash_function_eid)(HcalElectronicsId const&);
@@ -164,52 +172,109 @@ namespace hcaldqm
 		typedef std::string (*name_function_did)(HcalDetId const&);
 		typedef std::string (*name_function_eid)(HcalElectronicsId const&);
 		typedef std::string (*name_function_tid)(HcalTrigTowerDetId const&);
-		hash_function_did const hash_did[nHashType_did] = {
-			hash_Subdet, hash_Subdetiphi, hash_Subdetieta, 
-			hash_Subdetdepth, hash_SubdetPM, hash_SubdetPMiphi,
-			hash_iphi, hash_ieta, hash_depth, hash_HFPMiphi, 
-			hash_HBHEPartition, hash_DChannel
+		const std::map<HashType, hash_function_did> hash_did = {
+			{fSubdet,hash_Subdet}, 
+			{fSubdetiphi,hash_Subdetiphi}, 
+			{fSubdetieta,hash_Subdetieta}, 
+			{fSubdetdepth,hash_Subdetdepth}, 
+			{fSubdetPM,hash_SubdetPM}, 
+			{fSubdetPMiphi,hash_SubdetPMiphi},
+			{fiphi,hash_iphi}, 
+			{fieta,hash_ieta}, 
+			{fdepth,hash_depth}, 
+			{fHFPMiphi,hash_HFPMiphi}, 
+			{fHBHEPartition,hash_HBHEPartition}, 
+			{fDChannel,hash_DChannel}, 
+			{fRBX,hash_RBX},
 		};
-		hash_function_eid const hash_eid[nHashType_eid-nHashType_did-1] = {
-			hash_FED, hash_FEDSpigot, hash_FEDSlot, 
-			hash_Crate, hash_CrateSpigot, hash_CrateSlot,
-			hash_Fiber, hash_FiberFiberCh, hash_FiberCh,
-			hash_Electronics, hash_EChannel
+		const std::map<HashType, hash_function_eid> hash_eid = {
+			{fFED,hash_FED}, 
+			{fFEDSpigot,hash_FEDSpigot}, 
+			{fFEDSlot,hash_FEDSlot}, 
+			{fCrate,hash_Crate}, 
+			{fCrateSpigot,hash_CrateSpigot}, 
+			{fCrateSlot,hash_CrateSlot},
+			{fFiber,hash_Fiber}, 
+			{fFiberFiberCh,hash_FiberFiberCh}, 
+			{fFiberCh,hash_FiberCh},
+			{fElectronics,hash_Electronics}, 
+			{fEChannel,hash_EChannel},
 		};
-		hash_function_tid const hash_tid[nHashType_tid-nHashType_eid-1] = {
-			hash_TTSubdet, hash_TTSubdetPM, hash_TTSubdetPMiphi, 
-			hash_TTSubdetieta, hash_TTdepth, hash_TChannel
+		const std::map<HashType, hash_function_tid> hash_tid = {
+			{fTTSubdet,hash_TTSubdet}, 
+			{fTTSubdetPM,hash_TTSubdetPM}, 
+			{fTTSubdetPMiphi, hash_TTSubdetPMiphi}, 
+			{fTTSubdetieta,hash_TTSubdetieta}, 
+			{fTTdepth,hash_TTdepth}, 
+			{fTChannel,hash_TChannel},
 		};
-		name_function_did const name_did[nHashType_did] = {
-			name_Subdet, name_Subdetiphi, name_Subdetieta, 
-			name_Subdetdepth, name_SubdetPM, name_SubdetPMiphi,
-			name_iphi, name_ieta, name_depth, name_HFPMiphi, 
-			name_HBHEPartition, name_DChannel
+		const std::map<HashType, name_function_did> name_did = {
+			{fSubdet,name_Subdet}, 
+			{fSubdetiphi,name_Subdetiphi}, 
+			{fSubdetieta, name_Subdetieta}, 
+			{fSubdetdepth, name_Subdetdepth}, 
+			{fSubdetPM, name_SubdetPM}, 
+			{fSubdetPMiphi, name_SubdetPMiphi},
+			{fiphi, name_iphi}, 
+			{fieta, name_ieta}, 
+			{fdepth, name_depth}, 
+			{fHFPMiphi, name_HFPMiphi}, 
+			{fHBHEPartition, name_HBHEPartition}, 
+			{fDChannel, name_DChannel},
+			{fRBX, name_RBX}
 		};
-		name_function_eid const name_eid[nHashType_eid-nHashType_did-1] = {
-			name_FED, name_FEDSpigot, name_FEDSlot,
-			name_Crate, name_CrateSpigot, name_CrateSlot,
-			name_Fiber, name_FiberFiberCh, name_FiberCh,
-			name_Electronics, name_EChannel
+		const std::map<HashType, name_function_eid> name_eid = {
+			{fFED,name_FED}, 
+			{fFEDSpigot,name_FEDSpigot}, 
+			{fFEDSlot,name_FEDSlot},
+			{fCrate,name_Crate}, 
+			{fCrateSpigot,name_CrateSpigot}, 
+			{fCrateSlot,name_CrateSlot},
+			{fFiber,name_Fiber}, 
+			{fFiberFiberCh,name_FiberFiberCh}, 
+			{fFiberCh,name_FiberCh},
+			{fElectronics,name_Electronics}, 
+			{fEChannel,name_EChannel}
 		};
-		name_function_tid const name_tid[nHashType_tid-nHashType_eid-1] = {
-			name_TTSubdet, name_TTSubdetPM, name_TTSubdetPMiphi,
-			name_TTSubdetieta, name_TTdepth, name_TChannel
+		const std::map<HashType, name_function_tid> name_tid = {
+			{fTTSubdet, name_TTSubdet}, 
+			{fTTSubdetPM, name_TTSubdetPM}, 
+			{fTTSubdetPMiphi, name_TTSubdetPMiphi},
+			{fTTSubdetieta, name_TTSubdetieta}, 
+			{fTTdepth, name_TTdepth}, 
+			{fTChannel, name_TChannel},
 		};
-		int const nhashes = nHashType_did + (nHashType_eid-nHashType_did-1) + 
-			(nHashType_tid-nHashType_eid-1);
-		std::string const hash_names[nhashes] = {
-			"Subdet", "Subdetiphi", "Subdetieta", "Subdetdepth",
-			"SubdetPM", "SubdetPMiphi", "iphi", "ieta", "depth",
-			"HFPMiphi", "HBHEPartition", "DChannel",
-
-			"FED", "FEDSpigot", "FEDSlot",
-			"Crate", "CrateSpigot", "CrateSlot",
-			"Fiber", "FiberFiberCh", "FiberCh",
-			"Electronics", "EChannel",
-
-			"TTSubdet", "TTSubdetPM", "TTSubdetPMiphi",
-			"TTSubdetieta", "TTdepth", "TChannel"
+		const std::map<HashType, std::string> hash_names = {
+			{fSubdet,"Subdet"}, 
+			{fSubdetiphi,"Subdetiphi"}, 
+			{fSubdetieta,"Subdetieta"}, 
+			{fSubdetdepth,"Subdetdepth"},
+			{fSubdetPM,"SubdetPM"}, 
+			{fSubdetPMiphi,"SubdetPMiphi"}, 
+			{fiphi,"iphi"}, 
+			{fieta,"ieta"}, 
+			{fdepth,"depth"},
+			{fHFPMiphi,"HFPMiphi"}, 
+			{fHBHEPartition,"HBHEPartition"}, 
+			{fRBX,"RBX"},
+			{fDChannel,"DChannel"},
+			{fFED,"FED"}, 
+			{fFEDSpigot,"FEDSpigot"}, 
+			{fFEDSlot,"FEDSlot"},
+			{fCrate,"Crate"}, 
+			{fCrateSpigot,"CrateSpigot"}, 
+			{fCrateSlot,"CrateSlot"},
+			{fFiber,"Fiber"}, 
+			{fFiberFiberCh,"FiberFiberCh"}, 
+			{fFiberCh,"FiberCh"},
+			{fElectronics,"Electronics"}, 
+			{fEChannel,"EChannel"},
+			{fTTSubdet,"TTSubdet"}, 
+			{fTTSubdetPM,"TTSubdetPM"}, 
+			{fTTSubdetPMiphi,"TTSubdetPMiphi"},
+			{fTTSubdetieta,"TTSubdetieta"}, 
+			{fTTdepth,"TTdepth"}, 
+			{fTChannel,"TChannel"},
 		};
 	}
 }

--- a/DQM/HcalCommon/interface/HashMapper.h
+++ b/DQM/HcalCommon/interface/HashMapper.h
@@ -11,7 +11,6 @@
 
 #include "DQM/HcalCommon/interface/Mapper.h"
 #include "DQM/HcalCommon/interface/HashFunctions.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace hcaldqm
 {
@@ -33,38 +32,24 @@ namespace hcaldqm
 				//	get hash
 				using Mapper::getHash;
 				uint32_t getHash(HcalDetId const& did) const override
-				{
-					return (hash_did.at(_htype))(did);
-				}
+				{return hash_did[_htype](did);}
 				uint32_t getHash(HcalElectronicsId const& eid) const override
-				{
-					return (hash_eid.at(_htype))(eid);
-				}
+				{return hash_eid[_htype-nHashType_did-1](eid);}
 				uint32_t getHash(HcalTrigTowerDetId const& tid) const override
-				{
-					return (hash_tid.at(_htype))(tid);
-				}
+				{return hash_tid[_htype-nHashType_eid-1](tid);}
 
 				//	get name of the hashed element
 				using Mapper::getName;
 				std::string getName(HcalDetId const &did) const override
-				{
-					return hashfunctions::name_did.at(_htype)(did);
-				}
+				{return hashfunctions::name_did[_htype](did);}
 				std::string getName(HcalElectronicsId const& eid) const override
-				{
-					return hashfunctions::name_eid.at(_htype)(eid);
-				}
+				{return hashfunctions::name_eid[_htype-nHashType_did-1](eid);}
 				std::string getName(HcalTrigTowerDetId const& tid) const override
-				{
-					return hashfunctions::name_tid.at(_htype)(tid);
-				}
+				{return hashfunctions::name_tid[_htype-nHashType_eid-1](tid);}
 
 				//	get the Hash Type Name
 				virtual std::string getHashTypeName() const
-				{
-					return hash_names.at(_htype);
-				}
+				{return hash_names[this->getLinearHashType(_htype)];}
 				virtual HashType getHashType() const
 				{return _htype;}
 

--- a/DQM/HcalCommon/interface/HashMapper.h
+++ b/DQM/HcalCommon/interface/HashMapper.h
@@ -11,6 +11,7 @@
 
 #include "DQM/HcalCommon/interface/Mapper.h"
 #include "DQM/HcalCommon/interface/HashFunctions.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace hcaldqm
 {
@@ -32,24 +33,38 @@ namespace hcaldqm
 				//	get hash
 				using Mapper::getHash;
 				uint32_t getHash(HcalDetId const& did) const override
-				{return hash_did[_htype](did);}
+				{
+					return (hash_did.at(_htype))(did);
+				}
 				uint32_t getHash(HcalElectronicsId const& eid) const override
-				{return hash_eid[_htype-nHashType_did-1](eid);}
+				{
+					return (hash_eid.at(_htype))(eid);
+				}
 				uint32_t getHash(HcalTrigTowerDetId const& tid) const override
-				{return hash_tid[_htype-nHashType_eid-1](tid);}
+				{
+					return (hash_tid.at(_htype))(tid);
+				}
 
 				//	get name of the hashed element
 				using Mapper::getName;
 				std::string getName(HcalDetId const &did) const override
-				{return hashfunctions::name_did[_htype](did);}
+				{
+					return hashfunctions::name_did.at(_htype)(did);
+				}
 				std::string getName(HcalElectronicsId const& eid) const override
-				{return hashfunctions::name_eid[_htype-nHashType_did-1](eid);}
+				{
+					return hashfunctions::name_eid.at(_htype)(eid);
+				}
 				std::string getName(HcalTrigTowerDetId const& tid) const override
-				{return hashfunctions::name_tid[_htype-nHashType_eid-1](tid);}
+				{
+					return hashfunctions::name_tid.at(_htype)(tid);
+				}
 
 				//	get the Hash Type Name
 				virtual std::string getHashTypeName() const
-				{return hash_names[this->getLinearHashType(_htype)];}
+				{
+					return hash_names.at(_htype);
+				}
 				virtual HashType getHashType() const
 				{return _htype;}
 

--- a/DQM/HcalCommon/interface/Quantity.h
+++ b/DQM/HcalCommon/interface/Quantity.h
@@ -36,10 +36,10 @@ namespace hcaldqm
 		class Quantity
 		{
 			public:
-				Quantity() : _name("Quantity"), _isLog(false)
+				Quantity() : _name("Quantity"), _isLog(false), _showOverflow(false)
 				{}
 				Quantity(std::string const& name, bool isLog) : 
-					_name(name), _isLog(isLog)
+					_name(name), _isLog(isLog), _showOverflow(false)
 				{}
 				virtual ~Quantity() {}
 
@@ -82,10 +82,13 @@ namespace hcaldqm
 				virtual void setMin(double) {}
 				virtual void setNbins(int) {}
 
+				virtual void showOverflow(bool showOverflow) {_showOverflow = showOverflow;}
+
 			protected:
 				std::string		_name;
 				bool			_isLog;
 				AxisType		_axistype;
+				bool _showOverflow;
 		};
 	}
 }

--- a/DQM/HcalCommon/interface/Utilities.h
+++ b/DQM/HcalCommon/interface/Utilities.h
@@ -43,7 +43,7 @@ namespace hcaldqm
 		double aveTSDB(const edm::ESHandle<HcalDbService>& conditions, const CaloSamples& calo_samples, const HcalDetId did, const Digi& digi, unsigned int i_start, unsigned int i_end) {
 			double sumQ = 0;
 			double sumQT = 0;
-			for (unsigned int i = i_start; i <+ i_end; ++i) {
+			for (unsigned int i = i_start; i <= i_end; ++i) {
 				double q = adc2fCDBMinusPedestal(conditions, calo_samples, did, digi, i);
 				sumQ += q;
 				sumQT += (i+1)*q;
@@ -54,7 +54,7 @@ namespace hcaldqm
 		template<class Digi>
 		double sumQDB(const edm::ESHandle<HcalDbService>& conditions, const CaloSamples& calo_samples, const HcalDetId did, const Digi& digi, unsigned int i_start, unsigned int i_end) {
 			double sumQ = 0;
-			for (unsigned int i = i_start; i <+ i_end; ++i) {
+			for (unsigned int i = i_start; i <= i_end; ++i) {
 				sumQ += adc2fCDBMinusPedestal(conditions, calo_samples, did, digi, i);
 			}
 			return sumQ;

--- a/DQM/HcalCommon/interface/Utilities.h
+++ b/DQM/HcalCommon/interface/Utilities.h
@@ -194,6 +194,8 @@ namespace hcaldqm
 		 *	Orbit Gap Related
 		 */	
 		std::string ogtype2string(OrbitGapType type);
+
+		int getRBX(uint32_t iphi);
 	}
 }
 

--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -64,6 +64,7 @@ namespace hcaldqm
 			fBadTDC = 49,
 			fRBX = 50,
 			fTimingDiff_ns = 51,
+			ffC_1000000 = 52,
 		};
 		const std::map<ValueQuantityType, std::string> name_value = {
 			{fN,"N"},
@@ -118,6 +119,7 @@ namespace hcaldqm
 			{fBadTDC, "TDC"},
 			{fRBX, "RBX"},
 			{fTimingDiff_ns, "#Delta timing [ns]"},
+			{ffC_1000000, "fC"}
 		};
 		const std::map<ValueQuantityType, double> min_value = {
 			{fN,-0.05},
@@ -172,6 +174,7 @@ namespace hcaldqm
 			{fBadTDC,49.5},
 			{fRBX, 0.5},
 			{fTimingDiff_ns, -125.},
+			{ffC_1000000,0.}
 		};
 		const std::map<ValueQuantityType, double> max_value = {
 			{fN,1000},
@@ -226,6 +229,7 @@ namespace hcaldqm
 			{fBadTDC,61.5},
 			{fRBX, 18.5},
 			{fTimingDiff_ns, 125.},
+			{ffC_1000000,1.e6},
 		};
 		const std::map<ValueQuantityType, int> nbins_value = {
 			{fN,200},
@@ -279,6 +283,7 @@ namespace hcaldqm
 			{fBadTDC,12},
 			{fRBX, 18},
 			{fTimingDiff_ns, 40},
+			{ffC_1000000,1000},
 		};
 		class ValueQuantity : public Quantity
 		{

--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -233,7 +233,7 @@ namespace hcaldqm
 			{fRBX, 18.5},
 			{fTimingDiff_ns, 125.},
 			{ffC_1000000,1.e6},
-			{fTime_ns_250, 249.5},
+			{fTime_ns_250_coarse, 249.5},
 		};
 		const std::map<ValueQuantityType, int> nbins_value = {
 			{fN,200},

--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -62,6 +62,8 @@ namespace hcaldqm
 			fTimingRatio = 47,
 			fQIE10fC_100000Coarse = 48,
 			fBadTDC = 49,
+			fRBX = 50,
+			fTimingDiff_ns = 51,
 		};
 		const std::map<ValueQuantityType, std::string> name_value = {
 			{fN,"N"},
@@ -114,6 +116,8 @@ namespace hcaldqm
 			{fTimingRatio, "q_{SOI+1}/q_{SOI}"},
 			{fQIE10fC_100000Coarse,"fC"},
 			{fBadTDC, "TDC"},
+			{fRBX, "RBX"},
+			{fTimingDiff_ns, "#Delta timing [ns]"},
 		};
 		const std::map<ValueQuantityType, double> min_value = {
 			{fN,-0.05},
@@ -127,7 +131,7 @@ namespace hcaldqm
 			{ffC_1000,0},
 			{ffC_3000,0},
 			{fTiming_TS,-0.5},
-			{fTiming_TS200,0},
+			{fTiming_TS200,-0.5},
 			{fLS,0.5},
 			{fEt_256,0},
 			{fEt_128,0},
@@ -166,6 +170,8 @@ namespace hcaldqm
 			{fTimingRatio,0.},	
 			{fQIE10fC_100000Coarse,0},
 			{fBadTDC,49.5},
+			{fRBX, 0.5},
+			{fTimingDiff_ns, -125.},
 		};
 		const std::map<ValueQuantityType, double> max_value = {
 			{fN,1000},
@@ -218,6 +224,8 @@ namespace hcaldqm
 			{fTimingRatio,2.5},	
 			{fQIE10fC_100000Coarse,100000},
 			{fBadTDC,61.5},
+			{fRBX, 18.5},
+			{fTimingDiff_ns, 125.},
 		};
 		const std::map<ValueQuantityType, int> nbins_value = {
 			{fN,200},
@@ -268,7 +276,9 @@ namespace hcaldqm
 			{fDualAnodeAsymmetry,40},
 			{fTimingRatio,50},
 			{fQIE10fC_100000Coarse,1000},
-			{fBadTDC,12}
+			{fBadTDC,12},
+			{fRBX, 18},
+			{fTimingDiff_ns, 40},
 		};
 		class ValueQuantity : public Quantity
 		{
@@ -366,6 +376,36 @@ namespace hcaldqm
 
 			protected:
 				int _n;
+		};
+
+		/**
+		 * Coarse LumiSection axis. Specify binning (default=10 LS)
+		 */
+		class LumiSectionCoarse : public ValueQuantity
+		{
+			public:
+				LumiSectionCoarse() : ValueQuantity(fLS), _n(4000), _binning(10)
+				{}
+				LumiSectionCoarse(int n, int binning) : ValueQuantity(fLS), 
+					_n(n), _binning(binning) 
+				{}
+				~LumiSectionCoarse() override {}
+				
+				LumiSectionCoarse* makeCopy() override
+				{return new LumiSectionCoarse(_n, _binning);}
+
+				std::string name() override {return "LS";}
+				int nbins() override {return (_n + _binning - 1) / _binning;}
+				double min() override {return 1;}
+				double max() override {return _n+1;}
+				int getValue(int l) override {return l;}
+				uint32_t getBin(int l) override 
+				{return (l + _binning - 1) / _binning;}
+				void setMax(double x) override {_n=x;}
+
+			protected:
+				int _n;
+				int _binning;
 		};
 
 		class RunNumber : public ValueQuantity

--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -272,7 +272,7 @@ namespace hcaldqm
 			{fBX,3601},
 			{fEnergy_1TeV,200},
 			{fState,flag::nState},
-			{fQIE10fC_400000,4000},
+			{fQIE10fC_400000,1000},
 			{fDataSize,100},
 			{fQIE10fC_2000,100},
 			{fQIE10fC_10000,500},

--- a/DQM/HcalCommon/src/Container1D.cc
+++ b/DQM/HcalCommon/src/Container1D.cc
@@ -603,10 +603,10 @@ namespace hcaldqm
 		//	if loaded and not stripped, then 
 		//	prepend/subsystem/Run summary/taskname/...
 		_logger.debug(_hashmap.getHashTypeName());
-		std::string path = (prepend==""?prepend:prepend+"/")+
+		std::string path = (prepend.empty()?prepend:prepend+"/")+
 			subsystem+"/"+(mode==DQMStore::KeepRunDirs?"Run summary/":"")
 			+_folder+"/"+_qname+
-			(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName();
+			(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName();
 		_logger.debug("FULLPATH::"+path);
 
 		if (_hashmap.isDHash())
@@ -686,10 +686,10 @@ namespace hcaldqm
 		//	if loaded and not stripped, then 
 		//	prepend/subsystem/Run summary/taskname/...
 		_logger.debug(_hashmap.getHashTypeName());
-		std::string path = (prepend==""?prepend:prepend+"/")+
+		std::string path = (prepend.empty()?prepend:prepend+"/")+
 			subsystem+"/"+(mode==DQMStore::KeepRunDirs?"Run summary/":"")
 			+_folder+"/"+_qname+
-			(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName();
+			(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName();
 		_logger.debug("FULLPATH::"+path);
 
 		if (_hashmap.isDHash())
@@ -783,7 +783,7 @@ namespace hcaldqm
 		_logger.debug(_hashmap.getHashTypeName());
 		std::string path = 
 			subsystem+"/"+_folder+"/"+_qname+
-			(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName();
+			(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName();
 		_logger.debug("FULLPATH::"+path);
 
 		if (_hashmap.isDHash())
@@ -869,7 +869,7 @@ namespace hcaldqm
 		_logger.debug(_hashmap.getHashTypeName());
 		std::string path = 
 			subsystem+"/"+_folder+"/"+_qname+
-			(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName();
+			(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName();
 		_logger.debug("FULLPATH::"+path);
 
 		if (_hashmap.isDHash())
@@ -961,7 +961,7 @@ namespace hcaldqm
 		//	full path to where all the plots are living
 		//	subsystem/taskname/QxvsQy_auxilary/HashType
 		ib.setCurrentFolder(subsystem+"/"+_folder+"/"+_qname+
-			(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
+			(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
 		_logger.debug(_hashmap.getHashTypeName());
 		if (_hashmap.isDHash())
 		{
@@ -1051,7 +1051,7 @@ namespace hcaldqm
 		//	full path to where all the plots are living
 		//	subsystem/taskname/QxvsQy_auxilary/HashType
 		ib.setCurrentFolder(subsystem+"/"+_folder+"/"+_qname+
-			(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
+			(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
 		_logger.debug(_hashmap.getHashTypeName());
 
 		if (_hashmap.isDHash())
@@ -1146,7 +1146,7 @@ namespace hcaldqm
 		//	full path to where all the plots are living
 		//	subsystem/taskname/QxvsQy_auxilary/HashType
 		store->setCurrentFolder(subsystem+"/"+_folder+"/"+_qname+
-			(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
+			(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
 		_logger.debug(_hashmap.getHashTypeName());
 		if (_hashmap.isDHash())
 		{
@@ -1234,7 +1234,7 @@ namespace hcaldqm
 		//	full path to where all the plots are living
 		//	subsystem/taskname/QxvsQy_auxilary/HashType
 		store->setCurrentFolder(subsystem+"/"+_folder+"/"+_qname+
-			(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
+			(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
 		_logger.debug(_hashmap.getHashTypeName());
 		if (_hashmap.isDHash())
 		{

--- a/DQM/HcalCommon/src/Container1D.cc
+++ b/DQM/HcalCommon/src/Container1D.cc
@@ -1364,6 +1364,15 @@ namespace hcaldqm
 			pair.second->setLumiFlag();
 		}
 	}
+	
+	void Container1D::showOverflowX(bool showOverflow) {
+		_qx->showOverflow(showOverflow);
+	}
+
+	void Container1D::showOverflowY(bool showOverflow) {
+		_qy->showOverflow(showOverflow);
+	}
+
 }
 
 

--- a/DQM/HcalCommon/src/Container2D.cc
+++ b/DQM/HcalCommon/src/Container2D.cc
@@ -900,7 +900,7 @@ namespace hcaldqm
 		//	full path as in Container1D.cc
 		//
 		ib.setCurrentFolder(subsystem+"/"+_folder+"/"+_qname+
-			(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
+			(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
 		if (_hashmap.isDHash())
 		{
 			//	for Detector Hashes
@@ -982,7 +982,7 @@ namespace hcaldqm
 		//	full path as in Container1D.cc
 		//
 		ib.setCurrentFolder(subsystem+"/"+_folder+"/"+_qname+
-			(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
+			(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
 		if (_hashmap.isDHash())
 		{
 			//	for Detector Hashes
@@ -1070,7 +1070,7 @@ namespace hcaldqm
 		//	full path as in Container1D.cc
 		//
 		store->setCurrentFolder(subsystem+"/"+_folder+"/"+_qname+
-			(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
+			(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
 		if (_hashmap.isDHash())
 		{
 			//	for Detector Hashes
@@ -1152,7 +1152,7 @@ namespace hcaldqm
 		//	full path as in Container1D.cc
 		//
 		store->setCurrentFolder(subsystem+"/"+_folder+"/"+_qname+
-			(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
+			(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
 		if (_hashmap.isDHash())
 		{
 			//	for Detector Hashes

--- a/DQM/HcalCommon/src/Container2D.cc
+++ b/DQM/HcalCommon/src/Container2D.cc
@@ -1252,6 +1252,11 @@ namespace hcaldqm
 			me->setBinLabel(i+1, ylabels[i], 2);
 		}
 	}
+
+	void Container2D::showOverflowZ(bool showOverflow) {
+		_qz->showOverflow(showOverflow);
+	}
 }
+
 
 

--- a/DQM/HcalCommon/src/ContainerProf2D.cc
+++ b/DQM/HcalCommon/src/ContainerProf2D.cc
@@ -55,7 +55,7 @@ namespace hcaldqm
 		//	full path as in Container1D.cc
 		//
 		ib.setCurrentFolder(subsystem+"/"+_folder+"/"+_qname
-			+(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
+			+(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
 		if (_hashmap.isDHash())
 		{
 			//	for Detector Hashes
@@ -140,7 +140,7 @@ namespace hcaldqm
 		//	full path as in Container1D.cc
 		//
 		ib.setCurrentFolder(subsystem+"/"+_folder+"/"+_qname
-			+(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
+			+(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
 		if (_hashmap.isDHash())
 		{
 			//	for Detector Hashes
@@ -231,7 +231,7 @@ namespace hcaldqm
 		//	full path as in Container1D.cc
 		//
 		store->setCurrentFolder(subsystem+"/"+_folder+"/"+_qname
-			+(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
+			+(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
 		if (_hashmap.isDHash())
 		{
 			//	for Detector Hashes
@@ -316,7 +316,7 @@ namespace hcaldqm
 		//	full path as in Container1D.cc
 		//
 		store->setCurrentFolder(subsystem+"/"+_folder+"/"+_qname
-			+(aux==""?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
+			+(aux.empty()?aux:"_"+aux)+"/"+_hashmap.getHashTypeName());
 		if (_hashmap.isDHash())
 		{
 			//	for Detector Hashes

--- a/DQM/HcalCommon/src/ContainerProf2D.cc
+++ b/DQM/HcalCommon/src/ContainerProf2D.cc
@@ -399,4 +399,248 @@ namespace hcaldqm
 			}
 		}
 	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalDetId const& did)
+	{
+		_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+			_qy->getValue(did));
+	}
+
+	//	HcalDetId based
+	/* virtual */ void ContainerProf2D::fill(HcalDetId const& did, int x)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+				_qy->getValue(did), x);
+		else if (_qx->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+				_qy->getValue(x));
+		else if (_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalDetId const& did, double x)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+				_qy->getValue(did), x);
+		else if (_qx->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+				_qy->getValue(x));
+		else if (_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalDetId const& did, 
+		int x, double y)
+	{
+		if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did), 
+				_qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did), y);
+		else if (!_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(y));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalDetId const& did, 
+		int x, int y)
+	{
+		if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did), 
+				_qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did), y);
+		else if (!_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(y));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalDetId const& did, 
+		double x, double y)
+	{
+		if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did), 
+				_qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did), y);
+		else if (!_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(y));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalElectronicsId const& did)
+	{
+		_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+			_qy->getValue(did));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalElectronicsId const& did, int x)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+				_qy->getValue(did), x);
+		else if (_qx->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+				_qy->getValue(x));
+		else if (_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalElectronicsId const& did, double x)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+				_qy->getValue(did), x);
+		else if (_qx->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+				_qy->getValue(x));
+		else if (_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalElectronicsId const& did, 
+		int x, double y)
+	{
+		if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did), 
+				_qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did), y);
+		else if (!_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(y));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalElectronicsId const& did, 
+		int x, int y)
+	{
+		if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did), 
+				_qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did), y);
+		else if (!_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(y));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalElectronicsId const& did, 
+		double x, double y)
+	{
+		if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did), 
+				_qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did), y);
+		else if (!_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(y));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalTrigTowerDetId const& did)
+	{
+		_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+			_qy->getValue(did));
+	}
+
+	//	HcalDetId based
+	/* virtual */ void ContainerProf2D::fill(HcalTrigTowerDetId const& did, int x)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+				_qy->getValue(did), x);
+		else if (_qx->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+				_qy->getValue(x));
+		else if (_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalTrigTowerDetId const& did, 
+		double x)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+				_qy->getValue(did), x);
+		else if (_qx->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did),
+				_qy->getValue(x));
+		else if (_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalTrigTowerDetId const& did, 
+		int x, double y)
+	{
+		if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did), 
+				_qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did), y);
+		else if (!_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(y));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalTrigTowerDetId const& did, 
+		int x, int y)
+	{
+		if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did), 
+				_qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did), y);
+		else if (!_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(y));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalTrigTowerDetId const& did, 
+		double x, double y)
+	{
+		if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(did), 
+				_qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(did), y);
+		else if (!_qx->isCoordinate() && !_qy->isCoordinate())
+			_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), 
+				_qy->getValue(y));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalDetId const& did, 
+		double x, double y, double z)
+	{
+		_mes[_hashmap.getHash(did)]->Fill(_qx->getValue(x), _qy->getValue(y), _qz->getValue(z));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalElectronicsId const& eid, 
+		double x, double y, double z)
+	{
+		_mes[_hashmap.getHash(eid)]->Fill(_qx->getValue(x), _qy->getValue(y), _qz->getValue(z));
+	}
+
+	/* virtual */ void ContainerProf2D::fill(HcalTrigTowerDetId const& tid, 
+		double x, double y, double z)
+	{
+		_mes[_hashmap.getHash(tid)]->Fill(_qx->getValue(x), _qy->getValue(y), _qz->getValue(z));
+	}
+
 }

--- a/DQM/HcalCommon/src/ContainerSingle1D.cc
+++ b/DQM/HcalCommon/src/ContainerSingle1D.cc
@@ -69,8 +69,8 @@ namespace hcaldqm
 		 std::string subsystem, std::string aux)
 	{
 		ib.setCurrentFolder(subsystem+"/"+_folder+"/"+_qname);
-		_me = ib.book1D(_qname+(aux==""?aux:"_"+aux), 
-			_qname+(aux==""?aux:" "+aux),
+		_me = ib.book1D(_qname+(aux.empty()?aux:"_"+aux), 
+			_qname+(aux.empty()?aux:" "+aux),
 			_qx->nbins(), _qx->min(), _qx->max());
 		customize();
 	}
@@ -79,8 +79,8 @@ namespace hcaldqm
 		 std::string subsystem, std::string aux)
 	{
 		store->setCurrentFolder(subsystem+"/"+_folder+"/"+_qname);
-		_me = store->book1D(_qname+(aux==""?aux:"_"+aux), 
-			_qname+(aux==""?aux:" "+aux),
+		_me = store->book1D(_qname+(aux.empty()?aux:"_"+aux), 
+			_qname+(aux.empty()?aux:" "+aux),
 			_qx->nbins(), _qx->min(), _qx->max());
 		customize();
 	}

--- a/DQM/HcalCommon/src/ContainerSingle1D.cc
+++ b/DQM/HcalCommon/src/ContainerSingle1D.cc
@@ -304,6 +304,15 @@ namespace hcaldqm
 			_qx->setMax(x);
 		}
 	}
+
+	void ContainerSingle1D::showOverflowX(bool showOverflow) {
+		_qx->showOverflow(showOverflow);
+	}
+
+	void ContainerSingle1D::showOverflowY(bool showOverflow) {
+		_qy->showOverflow(showOverflow);
+	}
+
 }
 
 

--- a/DQM/HcalCommon/src/ContainerSingle2D.cc
+++ b/DQM/HcalCommon/src/ContainerSingle2D.cc
@@ -704,5 +704,8 @@ namespace hcaldqm
 			_qx->setMax(x);
 		}
 	}
-}
 
+	void ContainerSingle2D::showOverflowZ(bool showOverflow) {
+		_qz->showOverflow(showOverflow);
+	}
+}

--- a/DQM/HcalCommon/src/ContainerSingle2D.cc
+++ b/DQM/HcalCommon/src/ContainerSingle2D.cc
@@ -82,8 +82,8 @@ namespace hcaldqm
 		 std::string subsystem, std::string aux)
 	{
 		ib.setCurrentFolder(subsystem+"/"+_folder+"/"+_qname);
-		_me = ib.book2D(_qname+(aux==""?aux:"_"+aux), 
-			_qname+(aux==""?aux:" "+aux),
+		_me = ib.book2D(_qname+(aux.empty()?aux:"_"+aux), 
+			_qname+(aux.empty()?aux:" "+aux),
 			_qx->nbins(), _qx->min(), _qx->max(),
 			_qy->nbins(), _qy->min(), _qy->max());
 		customize();
@@ -93,15 +93,15 @@ namespace hcaldqm
 		std::string subsystem, std::string aux)
 	{
 		_me = ig.get(subsystem+"/"+_folder+"/"+_qname+"/"+
-			_qname+(aux==""?aux:"_"+aux));
+			_qname+(aux.empty()?aux:"_"+aux));
 	}
 
 	/* virtual */ void ContainerSingle2D::book(DQMStore *store,
 		 std::string subsystem, std::string aux)
 	{
 		store->setCurrentFolder(subsystem+"/"+_folder+"/"+_qname);
-		_me = store->book2D(_qname+(aux==""?aux:"_"+aux), 
-			_qname+(aux==""?aux:" "+aux),
+		_me = store->book2D(_qname+(aux.empty()?aux:"_"+aux), 
+			_qname+(aux.empty()?aux:" "+aux),
 			_qx->nbins(), _qx->min(), _qx->max(),
 			_qy->nbins(), _qy->min(), _qy->max());
 		customize();

--- a/DQM/HcalCommon/src/ContainerSingleProf2D.cc
+++ b/DQM/HcalCommon/src/ContainerSingleProf2D.cc
@@ -62,6 +62,246 @@ namespace hcaldqm
 			_qz->min(), _qz->max());
 		customize();
 	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(int x, int y)
+	{
+		_me->Fill(_qx->getValue(x), _qy->getValue(y));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(int x, double y)
+	{
+		_me->Fill(_qx->getValue(x), _qy->getValue(y));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(int x, double y, double z)
+	{
+		_me->Fill(_qx->getValue(x), _qy->getValue(y), _qz->getValue(z));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(double x, int y)
+	{
+		_me->Fill(_qx->getValue(x), _qy->getValue(y));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(double x, double y)
+	{
+		_me->Fill(_qx->getValue(x), _qy->getValue(y));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(double x, double y, double z)
+	{
+		_me->Fill(_qx->getValue(x), _qy->getValue(y), _qz->getValue(z));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(int x, int y, double z)
+	{
+		_me->Fill(_qx->getValue(x), _qy->getValue(y), _qz->getValue(z));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(int x, int y, int z)
+	{
+		_me->Fill(_qx->getValue(x), _qy->getValue(y), _qz->getValue(z));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalDetId const& id)
+	{
+		_me->Fill(_qx->getValue(id), _qy->getValue(id));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalDetId const& id, double x)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x));
+		else if (_qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalDetId const& id, int x)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x));
+		else if (_qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalDetId const& id, double x,
+		double y)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id), y);
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalDetId const& id, int x,
+		int y)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id), y);
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalDetId const& id, int x,
+		double y)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id), y);
+	}
+	
+	/* virtual */ void ContainerSingleProf2D::fill(HcalElectronicsId const& id)
+	{
+		_me->Fill(_qx->getValue(id), _qy->getValue(id));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalElectronicsId const& id, 
+		double x)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x));
+		else if (_qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalElectronicsId const& id, 
+		int x)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x));
+		else if (_qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalElectronicsId const& id, 
+		double x,
+		double y)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id), y);
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalElectronicsId const& id, 
+		int x,
+		int y)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id), y);
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalElectronicsId const& id, 
+		int x,
+		double y)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id), y);
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalTrigTowerDetId const& id)
+	{
+		_me->Fill(_qx->getValue(id), _qy->getValue(id));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalTrigTowerDetId const& id, 
+		double x)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x));
+		else if (_qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalTrigTowerDetId const& id, 
+		int x)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x));
+		else if (_qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalTrigTowerDetId const& id, 
+		double x, double y)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id), y);
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalTrigTowerDetId const& id, 
+		int x, int y)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id), y);
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalTrigTowerDetId const& id, 
+		int x, double y)
+	{
+		if (_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(id), x);
+		else if (_qx->isCoordinate() && !_qy->isCoordinate())
+			_me->Fill(_qx->getValue(id), _qy->getValue(x), y);
+		else if (!_qx->isCoordinate() && _qy->isCoordinate())
+			_me->Fill(_qx->getValue(x), _qy->getValue(id), y);
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalDetId const& did,
+		HcalElectronicsId const& eid)
+	{
+		if (_qx->type()==fDetectorQuantity)
+			_me->Fill(_qx->getValue(did), _qy->getValue(eid));
+		else
+			_me->Fill(_qx->getValue(eid), _qy->getValue(did));
+	}
+
+	/* virtual */ void ContainerSingleProf2D::fill(HcalDetId const& did,
+		HcalElectronicsId const& eid, double x)
+	{
+		if (_qx->type()==fDetectorQuantity)
+			_me->Fill(_qx->getValue(did), _qy->getValue(eid), x);
+		else
+			_me->Fill(_qx->getValue(eid), _qy->getValue(did), x);
+	}
+
 }
 
 

--- a/DQM/HcalCommon/src/ContainerSingleProf2D.cc
+++ b/DQM/HcalCommon/src/ContainerSingleProf2D.cc
@@ -43,8 +43,8 @@ namespace hcaldqm
 		std::string subsystem, std::string aux)
 	{
 		ib.setCurrentFolder(subsystem+"/"+_folder+"/"+_qname);
-		_me = ib.bookProfile2D(_qname+(aux==""?aux:"_"+aux), 
-			_qname+(aux==""?aux:" "+aux),
+		_me = ib.bookProfile2D(_qname+(aux.empty()?aux:"_"+aux), 
+			_qname+(aux.empty()?aux:" "+aux),
 			_qx->nbins(), _qx->min(), _qx->max(),
 			_qy->nbins(), _qy->min(), _qy->max(),
 			_qz->min(), _qz->max());
@@ -55,8 +55,8 @@ namespace hcaldqm
 		std::string subsystem, std::string aux)
 	{
 		store->setCurrentFolder(subsystem+"/"+_folder+"/"+_qname);
-		_me = store->bookProfile2D(_qname+(aux==""?aux:"_"+aux), 
-			_qname+(aux==""?aux:" "+aux),
+		_me = store->bookProfile2D(_qname+(aux.empty()?aux:"_"+aux), 
+			_qname+(aux.empty()?aux:" "+aux),
 			_qx->nbins(), _qx->min(), _qx->max(),
 			_qy->nbins(), _qy->min(), _qy->max(),
 			_qz->min(), _qz->max());

--- a/DQM/HcalCommon/src/ElectronicsMap.cc
+++ b/DQM/HcalCommon/src/ElectronicsMap.cc
@@ -20,7 +20,7 @@ namespace hcaldqm
 					for (std::vector<HcalElectronicsId>::const_iterator it=
 						eids.begin(); it!=eids.end(); ++it)
 					{
-						HcalGenericDetId did = HcalGenericDetId(
+						HcalDetId did = HcalDetId(
 							_emap->lookup(*it));
 						EMapType::iterator dit = _ids.find(did.rawId());
 						if (dit!=_ids.end())
@@ -56,7 +56,7 @@ namespace hcaldqm
 					for (std::vector<HcalElectronicsId>::const_iterator
 						it=eids.begin(); it!=eids.end(); ++it)
 					{
-						HcalGenericDetId did = HcalGenericDetId(_emap->lookup(*it));
+						HcalDetId did = HcalDetId(_emap->lookup(*it));
 						uint32_t hash = it->rawId();
 						EMapType::iterator eit = _ids.find(hash);
 						if (eit!=_ids.end())
@@ -107,7 +107,7 @@ namespace hcaldqm
 					for (std::vector<HcalElectronicsId>::const_iterator it=
 						eids.begin(); it!=eids.end(); ++it)
 					{
-						HcalGenericDetId did = HcalGenericDetId(
+						HcalDetId did = HcalDetId(
 							_emap->lookup(*it));
 						if (filter.filter(*it))
 							continue;
@@ -138,7 +138,7 @@ namespace hcaldqm
 					for (std::vector<HcalElectronicsId>::const_iterator it=
 						eids.begin(); it!=eids.end(); ++it)
 					{
-						HcalGenericDetId did = HcalGenericDetId(
+						HcalDetId did = HcalDetId(
 							_emap->lookup(*it));
 						uint32_t hash = hashfunctions::hash_EChannel(
 							*it);

--- a/DQM/HcalCommon/src/ElectronicsMap.cc
+++ b/DQM/HcalCommon/src/ElectronicsMap.cc
@@ -184,9 +184,11 @@ namespace hcaldqm
 
 		uint32_t ElectronicsMap::lookup(HcalDetId const &id)
 		{
+			// Turn the HcalDetId into a HcalGenericDetId to avoid newForm
 			uint32_t hash = (id.oldFormat() ? id.otherForm() : id.rawId());
+			HcalGenericDetId gdid(hash);
 			if (_etype==fHcalElectronicsMap)
-				return _emap->lookup(id).rawId();
+				return _emap->lookup(gdid).rawId();
 			else 
 			{
 				EMapType::iterator it = _ids.find(hash);

--- a/DQM/HcalCommon/src/ElectronicsMap.cc
+++ b/DQM/HcalCommon/src/ElectronicsMap.cc
@@ -20,7 +20,7 @@ namespace hcaldqm
 					for (std::vector<HcalElectronicsId>::const_iterator it=
 						eids.begin(); it!=eids.end(); ++it)
 					{
-						HcalDetId did = HcalDetId(
+						HcalGenericDetId did = HcalGenericDetId(
 							_emap->lookup(*it));
 						EMapType::iterator dit = _ids.find(did.rawId());
 						if (dit!=_ids.end())
@@ -56,7 +56,7 @@ namespace hcaldqm
 					for (std::vector<HcalElectronicsId>::const_iterator
 						it=eids.begin(); it!=eids.end(); ++it)
 					{
-						HcalDetId did = HcalDetId(_emap->lookup(*it));
+						HcalGenericDetId did = HcalGenericDetId(_emap->lookup(*it));
 						uint32_t hash = it->rawId();
 						EMapType::iterator eit = _ids.find(hash);
 						if (eit!=_ids.end())
@@ -107,7 +107,7 @@ namespace hcaldqm
 					for (std::vector<HcalElectronicsId>::const_iterator it=
 						eids.begin(); it!=eids.end(); ++it)
 					{
-						HcalDetId did = HcalDetId(
+						HcalGenericDetId did = HcalGenericDetId(
 							_emap->lookup(*it));
 						if (filter.filter(*it))
 							continue;
@@ -138,7 +138,7 @@ namespace hcaldqm
 					for (std::vector<HcalElectronicsId>::const_iterator it=
 						eids.begin(); it!=eids.end(); ++it)
 					{
-						HcalDetId did = HcalDetId(
+						HcalGenericDetId did = HcalGenericDetId(
 							_emap->lookup(*it));
 						uint32_t hash = hashfunctions::hash_EChannel(
 							*it);
@@ -168,10 +168,23 @@ namespace hcaldqm
 			}
 		}
 
-		//	2 funcs below are only for 1->1 mappings
+		//	3 funcs below are only for 1->1 mappings
 		uint32_t ElectronicsMap::lookup(DetId const &id)
 		{
 			uint32_t hash = id.rawId();
+			if (_etype==fHcalElectronicsMap)
+				return _emap->lookup(id).rawId();
+			else 
+			{
+				EMapType::iterator it = _ids.find(hash);
+				return it==_ids.end() ? 0 : it->second;
+			}
+			return 0;
+		}
+
+		uint32_t ElectronicsMap::lookup(HcalDetId const &id)
+		{
+			uint32_t hash = (id.oldFormat() ? id.otherForm() : id.rawId());
 			if (_etype==fHcalElectronicsMap)
 				return _emap->lookup(id).rawId();
 			else 

--- a/DQM/HcalCommon/src/HashFunctions.cc
+++ b/DQM/HcalCommon/src/HashFunctions.cc
@@ -89,14 +89,6 @@ namespace hcaldqm
 			return utilities::hash(did);
 		}
 
-		uint32_t hash_RBX(HcalDetId const& did)
-		{
-			// RBX = 4 iphis, starting from (71, 72, 1, 2)
-			int rbx = (((did.iphi() + 2) % 72) + 4 - 1) / 4;
-			int hash_iphi = rbx * 4 - 3; // RBX 1 = iphi 1
-			return utilities::hash(HcalDetId(did.subdet(), fabs(did.ieta()) / did.ieta(), hash_iphi, 1));
-		}
-
 		std::string name_Subdet(HcalDetId const& did)
 		{
 			return constants::SUBDET_NAME[did.subdet()-1];
@@ -311,21 +303,6 @@ namespace hcaldqm
 		{
 			return HcalDetId(HcalBarrel,1,1,1).rawId();
 		}
-
-		std::string name_RBX(HcalDetId const& did) {
-			char name[10];
-			std::string pm = (did.ieta() > 0 ? "P" : "M");
-			sprintf(name, "%s %s RBX %d", constants::SUBDET_NAME[did.subdet()-1].c_str(), pm.c_str(), hcaldqm::utilities::getRBX(did));
-			return std::string(name);
-		}
-
-		//	TODO: Make it work here
-		//	Not neccessary right now!
-		uint32_t hash_RBX(std::string const& name)
-		{
-			return HcalDetId(HcalBarrel,1,1,1).rawId();
-		}
-
 
 		/**
 		 *	by ElectronicsId

--- a/DQM/HcalCommon/src/HashFunctions.cc
+++ b/DQM/HcalCommon/src/HashFunctions.cc
@@ -89,6 +89,14 @@ namespace hcaldqm
 			return utilities::hash(did);
 		}
 
+		uint32_t hash_RBX(HcalDetId const& did)
+		{
+			// RBX = 4 iphis, starting from (71, 72, 1, 2)
+			int rbx = (((did.iphi() + 2) % 72) + 4 - 1) / 4;
+			int hash_iphi = rbx * 4 - 3; // RBX 1 = iphi 1
+			return utilities::hash(HcalDetId(did.subdet(), fabs(did.ieta()) / did.ieta(), hash_iphi, 1));
+		}
+
 		std::string name_Subdet(HcalDetId const& did)
 		{
 			return constants::SUBDET_NAME[did.subdet()-1];
@@ -303,6 +311,21 @@ namespace hcaldqm
 		{
 			return HcalDetId(HcalBarrel,1,1,1).rawId();
 		}
+
+		std::string name_RBX(HcalDetId const& did) {
+			char name[10];
+			std::string pm = (did.ieta() > 0 ? "P" : "M");
+			sprintf(name, "%s %s RBX %d", constants::SUBDET_NAME[did.subdet()-1].c_str(), pm.c_str(), hcaldqm::utilities::getRBX(did));
+			return std::string(name);
+		}
+
+		//	TODO: Make it work here
+		//	Not neccessary right now!
+		uint32_t hash_RBX(std::string const& name)
+		{
+			return HcalDetId(HcalBarrel,1,1,1).rawId();
+		}
+
 
 		/**
 		 *	by ElectronicsId

--- a/DQM/HcalCommon/src/Utilities.cc
+++ b/DQM/HcalCommon/src/Utilities.cc
@@ -247,6 +247,11 @@ namespace hcaldqm
 				default : return "Unknonw";
 			}
 		}
+
+		int getRBX(uint32_t iphi) {
+			return (((iphi + 2) % 72) + 4 - 1) / 4;
+		}
+
 	}
 }
 

--- a/DQM/HcalTasks/interface/DigiRunSummary.h
+++ b/DQM/HcalTasks/interface/DigiRunSummary.h
@@ -47,10 +47,11 @@ namespace hcaldqm
 				fDigiSize = 0,
 				fNChsHF=1,
 				fUnknownIds=2,
-				nLSFlags=3, // defines the boundary between lumi-based and run-based flags
-				fUniHF=4,
-				fDead=5,
-				nDigiFlag = 6
+				fLED=3,
+				nLSFlags=4, // defines the boundary between lumi-based and run-based flags
+				fUniHF=5,
+				fDead=6,
+				nDigiFlag = 7
 			};
 	};
 }

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -183,6 +183,8 @@ class DigiTask : public hcaldqm::DQTask
 		MonitorElement *meNumEvents1LS; // to transfer the #events to harvesting
 		MonitorElement *meUnknownIds1LS;
 		bool _unknownIdsPresent;
+		MonitorElement *_meLEDEventCount; // Count events with LED pin diode signal > threshold
+		double _thresh_led;
 
 		hcaldqm::Container2D _cSummaryvsLS_FED; // online only
 		hcaldqm::ContainerSingle2D _cSummaryvsLS; // online only

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -165,6 +165,7 @@ class DigiTask : public hcaldqm::DQTask
 		hcaldqm::Container2D _cLETDCvsADC_SubdetPM;
 		hcaldqm::Container2D _cLETDCvsTS_SubdetPM;
 		hcaldqm::Container1D _cLETDCTime_SubdetPM;
+		hcaldqm::ContainerProf2D _cLETDCTime_depth;
 
 		// Bad TDC histograms
 		hcaldqm::Container1D _cBadTDCValues_SubdetPM;

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -63,7 +63,8 @@ class DigiTask : public hcaldqm::DQTask
 			fUni = 1,
 			fNChsHF = 2,
 			fUnknownIds = 3,
-			nDigiFlag = 4
+			fLED=4,
+			nDigiFlag = 5
 		};
 
 		//	hashes/FED vectors
@@ -186,6 +187,7 @@ class DigiTask : public hcaldqm::DQTask
 		bool _unknownIdsPresent;
 		MonitorElement *_meLEDEventCount; // Count events with LED pin diode signal > threshold
 		double _thresh_led;
+		bool _ledSignalPresent;
 
 		hcaldqm::Container2D _cSummaryvsLS_FED; // online only
 		hcaldqm::ContainerSingle2D _cSummaryvsLS; // online only

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -176,6 +176,9 @@ class DigiTask : public hcaldqm::DQTask
 		hcaldqm::Container1D _cBadTDCvsBX;
 		hcaldqm::Container1D _cBadTDCvsLS;
 
+		// For monitoring LED misfires: ADC vs BX
+		MonitorElement* _meLEDMon;
+
 		//	#events counters
 		MonitorElement *meNumEvents1LS; // to transfer the #events to harvesting
 		MonitorElement *meUnknownIds1LS;

--- a/DQM/HcalTasks/interface/LEDTask.h
+++ b/DQM/HcalTasks/interface/LEDTask.h
@@ -108,6 +108,11 @@ class LEDTask : public hcaldqm::DQTask
 		hcaldqm::Container2D _cADCvsTS_SubdetPM;
 		hcaldqm::Container1D _cSumQ_SubdetPM;
 		hcaldqm::Container1D _cTDCTime_SubdetPM;
+		hcaldqm::ContainerProf2D _cTDCTime_depth;
+
+		// For monitoring LED firing: ADC vs BX
+		MonitorElement* _meLEDMon;
+		
 };
 
 #endif

--- a/DQM/HcalTasks/interface/LEDTask.h
+++ b/DQM/HcalTasks/interface/LEDTask.h
@@ -49,11 +49,13 @@ class LEDTask : public hcaldqm::DQTask
 		edm::InputTag	_tagHO;
 		edm::InputTag	_tagHF;
 		edm::InputTag	_tagTrigger;
+		edm::InputTag	_taguMN;
 		edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-		edm::EDGetTokenT<QIE11DigiCollection> _tokHEP17;
+		edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
 		edm::EDGetTokenT<HODigiCollection> _tokHO;
 		edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
 		edm::EDGetTokenT<HcalTBTriggerData> _tokTrigger;
+		edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
 		//	emap
 		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
@@ -62,7 +64,7 @@ class LEDTask : public hcaldqm::DQTask
 
 		//	Cuts
 		double _lowHBHE;
-		double _lowHEP17;
+		double _lowHE;
 		double _lowHO;
 		double _lowHF;
 
@@ -101,6 +103,11 @@ class LEDTask : public hcaldqm::DQTask
 		hcaldqm::Container2D		_cMissing_depth;
 		hcaldqm::Container2D		_cMissing_FEDVME;
 		hcaldqm::Container2D		_cMissing_FEDuTCA;
+
+		// For hcalcalib online LED
+		hcaldqm::Container2D _cADCvsTS_SubdetPM;
+		hcaldqm::Container1D _cSumQ_SubdetPM;
+		hcaldqm::Container1D _cTDCTime_SubdetPM;
 };
 
 #endif

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -138,8 +138,12 @@ class LaserTask : public hcaldqm::DQTask
 		int _laserMonTS0;
 		double _laserMonThreshold;
 
-		hcaldqm::ContainerSingleProf1D _cLaserMonSumQ_LS;
-		hcaldqm::ContainerSingleProf1D _cLaserMonTiming_LS;
+		hcaldqm::ContainerSingle1D _cLaserMonSumQ;
+		hcaldqm::ContainerSingle1D _cLaserMonTiming;
+		hcaldqm::ContainerSingleProf1D _cLaserMonSumQ_LS; // Online
+		hcaldqm::ContainerSingleProf1D _cLaserMonTiming_LS; // Online
+		hcaldqm::ContainerSingleProf1D _cLaserMonSumQ_Event; // Local
+		hcaldqm::ContainerSingleProf1D _cLaserMonTiming_Event; // Local
 		hcaldqm::Container2D _cTiming_DigivsLaserMon_SubdetPM;
 		hcaldqm::ContainerProf2D _cTimingDiffLS_SubdetPM;
 };

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -151,8 +151,8 @@ class LaserTask : public hcaldqm::DQTask
 		int _laserMonDigiOverlap;
 		int _laserMonTS0;
 		double _laserMonThreshold;
-		double _thresh_timingreflm_rms; // Threshold on timing (ref. lasermon) RMS to mark channel as bad
-		double _thresh_frac_timingreflmrms; // Flag threshold (BAD) on fraction of channels with bad timingreflm_rms
+		std::map<HcalSubdetector, std::pair<double, double>> _thresh_timingreflm; // Min and max timing (ref. lasermon)
+		double _thresh_frac_timingreflm; // Flag threshold (BAD) on fraction of channels with bad timing
 		double _thresh_min_lmsumq; // Threshold on minimum SumQ from lasermon, if laser is expected
 		int _xMissingLaserMon; // Counter for missing lasermon events
 

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -136,6 +136,7 @@ class LaserTask : public hcaldqm::DQTask
 		int _laserMonCBox;
 		int _laserMonDigiOverlap;
 		int _laserMonTS0;
+		double _laserMonThreshold;
 
 		hcaldqm::ContainerSingleProf1D _cLaserMonSumQ_LS;
 		hcaldqm::ContainerSingleProf1D _cLaserMonTiming_LS;

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -13,6 +13,8 @@
 #include "DQM/HcalCommon/interface/ContainerXXX.h"
 #include "DQM/HcalCommon/interface/Container1D.h"
 #include "DQM/HcalCommon/interface/Container2D.h"
+#include "DQM/HcalCommon/interface/ContainerSingle1D.h"
+#include "DQM/HcalCommon/interface/ContainerSingleProf1D.h"
 #include "DQM/HcalCommon/interface/ContainerSingle2D.h"
 #include "DQM/HcalCommon/interface/ContainerSingleProf2D.h"
 #include "DQM/HcalCommon/interface/ContainerProf1D.h"
@@ -47,6 +49,8 @@ class LaserTask : public hcaldqm::DQTask
 		void _resetMonitors(hcaldqm::UpdateFreq) override;
 		bool _isApplicable(edm::Event const&) override;
 		virtual void _dump();
+		void processLaserMon(edm::Handle<QIE10DigiCollection> &col, std::vector<int> &iLaserMonADC);
+
 
 		//	tags and tokens
 		edm::InputTag	_tagHBHE;
@@ -122,6 +126,21 @@ class LaserTask : public hcaldqm::DQTask
 		hcaldqm::Container2D		_cMissing_depth;
 		hcaldqm::Container2D		_cMissing_FEDVME;
 		hcaldqm::Container2D		_cMissing_FEDuTCA;
+
+		// Things for LASERMON
+		edm::InputTag _tagLaserMon;
+		edm::EDGetTokenT<QIE10DigiCollection> _tokLaserMon;
+
+		std::vector<int> _vLaserMonIPhi; // Laser mon digis are assigned to CBox=5, IEta=0, IPhi=[23-index] by the emap
+		int _laserMonIEta;
+		int _laserMonCBox;
+		int _laserMonDigiOverlap;
+		int _laserMonTS0;
+
+		hcaldqm::ContainerSingleProf1D _cLaserMonSumQ_LS;
+		hcaldqm::ContainerSingleProf1D _cLaserMonTiming_LS;
+		hcaldqm::Container2D _cTiming_DigivsLaserMon_SubdetPM;
+		hcaldqm::ContainerProf2D _cTimingDiffLS_SubdetPM;
 };
 
 #endif

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -55,7 +55,7 @@ class LaserTask : public hcaldqm::DQTask
 		edm::InputTag	_tagHF;
 		edm::InputTag	_taguMN;
 		edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-		edm::EDGetTokenT<QIE11DigiCollection> _tokHEP17;
+		edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
 		edm::EDGetTokenT<HODigiCollection> _tokHO;
 		edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
 		edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
@@ -68,7 +68,7 @@ class LaserTask : public hcaldqm::DQTask
 		//	Cuts and variables
 		int _nevents;
 		double _lowHBHE;
-		double _lowHEP17;
+		double _lowHE;
 		double _lowHO;
 		double _lowHF;
 		uint32_t _laserType;
@@ -83,6 +83,8 @@ class LaserTask : public hcaldqm::DQTask
 		//	1D
 		hcaldqm::Container1D		_cSignalMean_Subdet;
 		hcaldqm::Container1D		_cSignalRMS_Subdet;
+		hcaldqm::Container1D		_cSignalMeanQIE1011_Subdet;
+		hcaldqm::Container1D		_cSignalRMSQIE1011_Subdet;
 		hcaldqm::Container1D		_cTimingMean_Subdet;
 		hcaldqm::Container1D		_cTimingRMS_Subdet;
 
@@ -94,12 +96,16 @@ class LaserTask : public hcaldqm::DQTask
 		hcaldqm::ContainerProf1D _cSignalvsEvent_SubdetPM;
 		hcaldqm::ContainerProf1D _cTimingvsLS_SubdetPM;
 		hcaldqm::ContainerProf1D _cSignalvsLS_SubdetPM;
+		hcaldqm::ContainerProf1D _cSignalvsLSQIE1011_SubdetPM;
 		hcaldqm::ContainerProf1D _cTimingvsBX_SubdetPM;
 		hcaldqm::ContainerProf1D _cSignalvsBX_SubdetPM;
+		hcaldqm::ContainerProf1D _cSignalvsBXQIE1011_SubdetPM;
 
 		//	2D timing/signals
 		hcaldqm::ContainerProf2D		_cSignalMean_depth;
 		hcaldqm::ContainerProf2D		_cSignalRMS_depth;
+		hcaldqm::ContainerProf2D		_cSignalMeanQIE1011_depth;
+		hcaldqm::ContainerProf2D		_cSignalRMSQIE1011_depth;
 		hcaldqm::ContainerProf2D		_cTimingMean_depth;
 		hcaldqm::ContainerProf2D		_cTimingRMS_depth;
 

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -64,10 +64,19 @@ class LaserTask : public hcaldqm::DQTask
 		edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
 		edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
+		enum LaserFlag
+		{
+			fBadTiming = 0,
+			fMissingLaserMon = 1,
+			nLaserFlag = 2
+		};
+		std::vector<hcaldqm::flag::Flag> _vflags;
+
 		//	emap
 		hcaldqm::electronicsmap::ElectronicsMap _ehashmap;
 		hcaldqm::filter::HashFilter _filter_uTCA;
 		hcaldqm::filter::HashFilter _filter_VME;
+		std::vector<uint32_t> _vhashFEDs;
 
 		//	Cuts and variables
 		int _nevents;
@@ -83,6 +92,11 @@ class LaserTask : public hcaldqm::DQTask
 		hcaldqm::ContainerXXX<int> _xEntries;
 		hcaldqm::ContainerXXX<double> _xTimingSum;
 		hcaldqm::ContainerXXX<double> _xTimingSum2;
+		hcaldqm::ContainerXXX<double> _xTimingRefLMSum; // For computation of channel-by-channel mean timing w.r.t. lasermon
+		hcaldqm::ContainerXXX<double> _xTimingRefLMSum2;
+		hcaldqm::ContainerXXX<int> _xNBadTimingRefLM; // Count channels with bad timing
+		hcaldqm::ContainerXXX<int> _xNChs; // number of channels per FED as in emap
+
 
 		//	1D
 		hcaldqm::Container1D		_cSignalMean_Subdet;
@@ -137,6 +151,10 @@ class LaserTask : public hcaldqm::DQTask
 		int _laserMonDigiOverlap;
 		int _laserMonTS0;
 		double _laserMonThreshold;
+		double _thresh_timingreflm_rms; // Threshold on timing (ref. lasermon) RMS to mark channel as bad
+		double _thresh_frac_timingreflmrms; // Flag threshold (BAD) on fraction of channels with bad timingreflm_rms
+		double _thresh_min_lmsumq; // Threshold on minimum SumQ from lasermon, if laser is expected
+		int _xMissingLaserMon; // Counter for missing lasermon events
 
 		hcaldqm::ContainerSingle1D _cLaserMonSumQ;
 		hcaldqm::ContainerSingle1D _cLaserMonTiming;
@@ -146,6 +164,11 @@ class LaserTask : public hcaldqm::DQTask
 		hcaldqm::ContainerSingleProf1D _cLaserMonTiming_Event; // Local
 		hcaldqm::Container2D _cTiming_DigivsLaserMon_SubdetPM;
 		hcaldqm::ContainerProf2D _cTimingDiffLS_SubdetPM;
+		hcaldqm::ContainerProf2D _cTimingDiffEvent_SubdetPM;
+
+		//	Summaries
+		hcaldqm::Container2D _cSummaryvsLS_FED;
+		hcaldqm::ContainerSingle2D _cSummaryvsLS;
 };
 
 #endif

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -628,7 +628,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 				continue;
 		}
 
-		_cSumQ_SubdetPM.fill(did, sumQ);
+		_cSumQ_SubdetPM_QIE1011.fill(did, sumQ);
 		_cOccupancy_depth.fill(did);
 		if (_ptype == fOnline || _ptype == fLocal) {
 			_cOccupancy_Crate.fill(eid);

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -744,7 +744,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			if (did.subdet() == HcalOther) {
 				HcalOtherDetId hodid(digi.detid());
 				if (hodid.subdet() == HcalCalibration) {
-					if (did.depth() == 0) {
+					if (did.depth() == 10) {
 						for (int i=0; i<digi.samples(); i++) {
 							_meLEDMon->Fill(bx, digi[i].adc());
 						}

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -97,15 +97,15 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 	_cfC_SubdetPM_QIE1011.initialize(_name, "fC", hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_10000),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 	_cSumQ_SubdetPM_QIE1011.initialize(_name, "SumQ", hcaldqm::hashfunctions::fSubdetPM,
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_10000),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 	_cSumQvsLS_SubdetPM_QIE1011.initialize(_name, "SumQvsLS",
 		hcaldqm::hashfunctions::fSubdetPM,
 		new hcaldqm::quantity::LumiSection(_maxLS),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_10000),0);
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),0);
 
 	_cTimingCut_SubdetPM.initialize(_name, "TimingCut",
 		hcaldqm::hashfunctions::fSubdetPM,

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -674,7 +674,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			_cADC_SubdetPM.fill(did, it->sample(i).adc());
 			_cfC_SubdetPM.fill(did, it->sample(i).nominal_fC());
 			if (_ptype != fOffline) { // hidefed2crate
-				_cADCvsTS_SubdetPM.fill(did, i, it->sample(i).nominal_fC());
+				_cADCvsTS_SubdetPM.fill(did, i, it->sample(i).adc());
 				if (sumQ>_cutSumQ_HBHE) {
 					_cShapeCut_FED.fill(eid, i, it->sample(i).nominal_fC());
 				}
@@ -826,7 +826,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 				_cBadTDCCount_depth.fill(did);
 			}
 			if (_ptype != fOffline) { // hidefed2crate
-				_cADCvsTS_SubdetPM_QIE1011.fill(did, i, q);
+				_cADCvsTS_SubdetPM_QIE1011.fill(did, i, digi[i].adc());
 				if (sumQ>_cutSumQ_HE) {
 					_cShapeCut_FED.fill(eid, i, q);
 				}
@@ -967,7 +967,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			_cADC_SubdetPM.fill(did, it->sample(i).adc());
 			_cfC_SubdetPM.fill(did, it->sample(i).nominal_fC());
 			if (_ptype != fOffline) { // hidefed2crate
-				_cADCvsTS_SubdetPM.fill(did, i, it->sample(i).nominal_fC());
+				_cADCvsTS_SubdetPM.fill(did, i, it->sample(i).adc());
 				if (sumQ>_cutSumQ_HO)
 					_cShapeCut_FED.fill(eid, i, it->sample(i).nominal_fC());
 			}
@@ -1127,7 +1127,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 					_cBadTDCCount_depth.fill(did);
 				}
 				if (_ptype != fOffline) { // hidefed2crate
-					_cADCvsTS_SubdetPM_QIE1011.fill(did, (int)i, q);
+					_cADCvsTS_SubdetPM_QIE1011.fill(did, (int)i, digi[i].adc());
 					if (sumQ>_cutSumQ_HF)
 						_cShapeCut_FED.fill(eid, (int)i, q);
 				}

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -177,6 +177,11 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		hcaldqm::hashfunctions::fSubdetPM,
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+	_cLETDCTime_depth.initialize(_name, "LETDCTime",
+		hcaldqm::hashfunctions::fdepth,
+		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
 
 	_cBadTDCValues_SubdetPM.initialize(_name, "BadTDCValues", 
 		hcaldqm::hashfunctions::fSubdetPM,
@@ -456,6 +461,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_cLETDCvsADC_SubdetPM.book(ib, _emap, _subsystem);
 	_cLETDCvsTS_SubdetPM.book(ib, _emap, _subsystem);
 	_cLETDCTime_SubdetPM.book(ib, _emap, _subsystem);
+	_cLETDCTime_depth.book(ib, _emap, _subsystem);
 
 	_cBadTDCValues_SubdetPM.book(ib, _emap, _subsystem);
 	_cBadTDCvsBX_SubdetPM.book(ib, _emap, _subsystem);
@@ -827,6 +833,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 			if (digi[i].tdc() <50) {
 				double time = i*25. + (digi[i].tdc() / 2.);
 				_cLETDCTime_SubdetPM.fill(did, time);
+				_cLETDCTime_depth.fill(did, time);
 				_cLETDCTimevsADC_SubdetPM.fill(did, digi[i].adc(), time);
 			}
 			// Bad TDC values: 50-61 should never happen in QIE10 or QIE11, but we saw some in 2017 data.
@@ -1127,6 +1134,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 				if (digi[i].le_tdc() <50) {
 					double time = i*25. + (digi[i].le_tdc() / 2.);
 					_cLETDCTime_SubdetPM.fill(did, time);
+					_cLETDCTime_depth.fill(did, time);
 					_cLETDCTimevsADC_SubdetPM.fill(did, digi[i].adc(), time);
 				}
 

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -66,8 +66,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 
 	// Filters for QIE8 vs QIE10/11
 	std::vector<uint32_t> vhashQIE1011; 
-	vhashQIE1011.push_back(hcaldqm::hashfunctions::hash_did.at(hcaldqm::hashfunctions::fSubdet)(HcalDetId(HcalEndcap, 20,1,1)));
-	vhashQIE1011.push_back(hcaldqm::hashfunctions::hash_did.at(hcaldqm::hashfunctions::fSubdet)(HcalDetId(HcalForward, 29,1,1)));
+	vhashQIE1011.push_back(hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalEndcap, 20,1,1)));
+	vhashQIE1011.push_back(hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalForward, 29,1,1)));
 	_filter_QIE1011.initialize(filter::fPreserver, hcaldqm::hashfunctions::fSubdet,
 		vhashQIE1011);
 	_filter_QIE8.initialize(filter::fFilter, hcaldqm::hashfunctions::fSubdet,
@@ -644,7 +644,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 				continue;
 		}
 
-		_cSumQ_SubdetPM_QIE1011.fill(did, sumQ);
+		_cSumQ_SubdetPM.fill(did, sumQ);
 		_cOccupancy_depth.fill(did);
 		if (_ptype == fOnline || _ptype == fLocal) {
 			_cOccupancy_Crate.fill(eid);

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -160,7 +160,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_cLETDCTimevsADC_SubdetPM.initialize(_name, "LETDCTimevsADC",
 		hcaldqm::hashfunctions::fSubdetPM,
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250_coarse),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
 	_cLETDCvsADC_SubdetPM.initialize(_name, "LETDCvsADC",
 		hcaldqm::hashfunctions::fSubdetPM,

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -28,7 +28,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 	//	constants
 	_lowHBHE = ps.getUntrackedParameter<double>("lowHBHE",
 		20);
-	_lowHE = ps.getUntrackedParameter<double>("lowQIE11",
+	_lowHE = ps.getUntrackedParameter<double>("lowHE",
 		20);
 	_lowHO = ps.getUntrackedParameter<double>("lowHO",
 		20);

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -19,15 +19,16 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 	_tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger",
 		edm::InputTag("tbunpacker"));
 	_tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-	_tokHEP17 = consumes<QIE11DigiCollection>(_tagHE);
+	_tokHE = consumes<QIE11DigiCollection>(_tagHE);
 	_tokHO = consumes<HODigiCollection>(_tagHO);
 	_tokHF = consumes<QIE10DigiCollection>(_tagHF);
 	_tokTrigger = consumes<HcalTBTriggerData>(_tagTrigger);
+	_tokuMN = consumes<HcalUMNioDigi>(_taguMN);
 
 	//	constants
 	_lowHBHE = ps.getUntrackedParameter<double>("lowHBHE",
 		20);
-	_lowHEP17 = ps.getUntrackedParameter<double>("lowHEP17",
+	_lowHE = ps.getUntrackedParameter<double>("lowQIE11",
 		20);
 	_lowHO = ps.getUntrackedParameter<double>("lowHO",
 		20);
@@ -164,6 +165,23 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
 	}
+
+	// Plots for LED in global
+	if (_ptype == fOnline) {
+		_cADCvsTS_SubdetPM.initialize(_name, "ADCvsTS",
+			hcaldqm::hashfunctions::fSubdetPM,
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
+		_cSumQ_SubdetPM.initialize(_name, "SumQ", 
+			hcaldqm::hashfunctions::fSubdetPM,
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
+		_cTDCTime_SubdetPM.initialize(_name, "SumQ", 
+			hcaldqm::hashfunctions::fSubdetPM,
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
+	}
 	
 	//	initialize compact containers
 	_xSignalSum.initialize(hcaldqm::hashfunctions::fDChannel);
@@ -196,6 +214,12 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 		_cShapeCut_FEDSlot.book(ib, _emap, _subsystem);
 		_cMissing_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
 		_cMissing_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+	}
+	if (_ptype == fOnline) {
+
+		_cADCvsTS_SubdetPM.book(ib, _emap, _subsystem);
+		_cSumQ_SubdetPM.book(ib, _emap, _subsystem);
+		_cTDCTime_SubdetPM.book(ib, _emap, _subsystem);
 	}
 
 	_xSignalSum.book(_emap);
@@ -293,7 +317,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 	edm::Handle<HBHEDigiCollection>		chbhe;
 	edm::Handle<HODigiCollection>		cho;
 	edm::Handle<QIE10DigiCollection>		chf;
-	edm::Handle<QIE11DigiCollection>		chep17;
+	edm::Handle<QIE11DigiCollection>		che;
 
 	if (!e.getByToken(_tokHBHE, chbhe))
 		_logger.dqmthrow("Collection HBHEDigiCollection isn't available "
@@ -304,7 +328,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 	if (!e.getByToken(_tokHF, chf))
 		_logger.dqmthrow("Collection QIE10DigiCollection isn't available "
 			+ _tagHF.label() + " " + _tagHF.instance());
-	if (!e.getByToken(_tokHEP17, chep17))
+	if (!e.getByToken(_tokHE, che))
 		_logger.dqmthrow("Collection QIE11DigiCollection isn't available "
 			+ _tagHE.label() + " " + _tagHE.instance());
 
@@ -321,27 +345,33 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HBHEDataFrame>(_dbService, did, digi);
 		//double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(digi, 2.5, 0, digi.size()-1);
 		double sumQ = hcaldqm::utilities::sumQDB<HBHEDataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
-		if (sumQ<_lowHBHE)
-			continue;
+		if (sumQ >= _lowHBHE) {
+			//double aveTS = hcaldqm::utilities::aveTS<HBHEDataFrame>(digi, 2.5, 0,digi.size()-1);
+			double aveTS = hcaldqm::utilities::aveTSDB<HBHEDataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
 
-		//double aveTS = hcaldqm::utilities::aveTS<HBHEDataFrame>(digi, 2.5, 0,digi.size()-1);
-		double aveTS = hcaldqm::utilities::aveTSDB<HBHEDataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
+			_xSignalSum.get(did)+=sumQ;
+			_xSignalSum2.get(did)+=sumQ*sumQ;
+			_xTimingSum.get(did)+=aveTS;
+			_xTimingSum2.get(did)+=aveTS*aveTS;
+			_xEntries.get(did)++;
 
-		_xSignalSum.get(did)+=sumQ;
-		_xSignalSum2.get(did)+=sumQ*sumQ;
-		_xTimingSum.get(did)+=aveTS;
-		_xTimingSum2.get(did)+=aveTS*aveTS;
-		_xEntries.get(did)++;
+			if (_ptype == fLocal) { // hidefed2crate
+				for (int i=0; i<digi.size(); i++) {
+					//_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-2.5);
+					_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<HBHEDataFrame>(_dbService, digi_fC, did, digi, i));
+				}
+			}
 
-		if (_ptype != fOffline) { // hidefed2crate
-			for (int i=0; i<digi.size(); i++) {
-				//_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-2.5);
-				_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<HBHEDataFrame>(_dbService, digi_fC, did, digi, i));
+			if (_ptype == fOnline) {
+				for (int iTS = 0; iTS < digi.size(); ++iTS) {
+					_cADCvsTS_SubdetPM.fill(did, iTS, digi.sample(iTS).adc());					
+				}
+				_cSumQ_SubdetPM.fill(did, sumQ);
 			}
 		}
 	}
 
-	for (QIE11DigiCollection::const_iterator it=chep17->begin(); it!=chep17->end();
+	for (QIE11DigiCollection::const_iterator it=che->begin(); it!=che->end();
 		++it)
 	{
 		const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
@@ -362,24 +392,33 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
 		//double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(digi, 2.5, 0, digi.samples()-1);
 		double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
-		if (sumQ<_lowHEP17)
-			continue;
+		if (sumQ >= _lowHE) {
+			//double aveTS = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
+			double aveTS = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
 
-		//double aveTS = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
-		double aveTS = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
+			_xSignalSum.get(did)+=sumQ;
+			_xSignalSum2.get(did)+=sumQ*sumQ;
+			_xTimingSum.get(did)+=aveTS;
+			_xTimingSum2.get(did)+=aveTS*aveTS;
+			_xEntries.get(did)++;
 
-		_xSignalSum.get(did)+=sumQ;
-		_xSignalSum2.get(did)+=sumQ*sumQ;
-		_xTimingSum.get(did)+=aveTS;
-		_xTimingSum2.get(did)+=aveTS*aveTS;
-		_xEntries.get(did)++;
-
-		if (_ptype != fOffline) { // hidefed2crate
-			for (int i=0; i<digi.samples(); i++) {
-				//_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-2.5);
-				_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, digi, i));
+			if (_ptype == fLocal) { // hidefed2crate
+				for (int i=0; i<digi.samples(); i++) {
+					//_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-2.5);
+					_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, digi, i));
+				}
 			}
-		}
+			if (_ptype == fOnline) {
+				for (unsigned int iTS = 0; iTS < digi.size(); ++iTS) {
+					_cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc());					
+					if (digi[iTS].tdc() <50) {
+						double time = iTS*25. + (digi[iTS].tdc() / 2.);
+						_cTDCTime_SubdetPM.fill(did, time);
+					}
+				}
+				_cSumQ_SubdetPM.fill(did, sumQ);
+			}
+		}			
 	}
 	for (HODigiCollection::const_iterator it=cho->begin();
 		it!=cho->end(); ++it)
@@ -390,25 +429,31 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 		//double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(digi, 8.5, 0, digi.size()-1);
 		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HODataFrame>(_dbService, did, digi);
 		double sumQ = hcaldqm::utilities::sumQDB<HODataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
-		if (sumQ<_lowHO)
-			continue;
+		if (sumQ >= _lowHO) {
+			//double aveTS = hcaldqm::utilities::aveTS<HODataFrame>(digi, 8.5, 0, digi.size()-1);
+			double aveTS = hcaldqm::utilities::aveTSDB<HODataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
 
-		//double aveTS = hcaldqm::utilities::aveTS<HODataFrame>(digi, 8.5, 0, digi.size()-1);
-		double aveTS = hcaldqm::utilities::aveTSDB<HODataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
+			_xSignalSum.get(did)+=sumQ;
+			_xSignalSum2.get(did)+=sumQ*sumQ;
+			_xTimingSum.get(did)+=aveTS;
+			_xTimingSum2.get(did)+=aveTS*aveTS;
+			_xEntries.get(did)++;
 
-		_xSignalSum.get(did)+=sumQ;
-		_xSignalSum2.get(did)+=sumQ*sumQ;
-		_xTimingSum.get(did)+=aveTS;
-		_xTimingSum2.get(did)+=aveTS*aveTS;
-		_xEntries.get(did)++;
-
-		if (_ptype != fOffline) { // hidefed2crate
-			for (int i=0; i<digi.size(); i++) {
-				//_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-8.5);
-				_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<HODataFrame>(_dbService, digi_fC, did, digi, i));
+			if (_ptype == fLocal) { // hidefed2crate
+				for (int i=0; i<digi.size(); i++) {
+					//_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-8.5);
+					_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<HODataFrame>(_dbService, digi_fC, did, digi, i));
+				}
+			}
+			if (_ptype == fOnline) {
+				for (int iTS = 0; iTS < digi.size(); ++iTS) {
+					_cADCvsTS_SubdetPM.fill(did, iTS, digi.sample(iTS).adc());					
+				}
+				_cSumQ_SubdetPM.fill(did, sumQ);
 			}
 		}
 	}
+
 	for (QIE10DigiCollection::const_iterator it=chf->begin();
 		it!=chf->end(); ++it)
 	{
@@ -421,26 +466,35 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 		//double sumQ = hcaldqm::utilities::sumQ_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
 		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, digi);
 		double sumQ = hcaldqm::utilities::sumQDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
-		if (sumQ<_lowHF)
-			continue;
+		if (sumQ >= _lowHF) {
+			//double aveTS = hcaldqm::utilities::aveTS_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
+			double aveTS = hcaldqm::utilities::aveTSDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
 
-		//double aveTS = hcaldqm::utilities::aveTS_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
-		double aveTS = hcaldqm::utilities::aveTSDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
+			_xSignalSum.get(did)+=sumQ;
+			_xSignalSum2.get(did)+=sumQ*sumQ;
+			_xTimingSum.get(did)+=aveTS;
+			_xTimingSum2.get(did)+=aveTS*aveTS;
+			_xEntries.get(did)++;
 
-		_xSignalSum.get(did)+=sumQ;
-		_xSignalSum2.get(did)+=sumQ*sumQ;
-		_xTimingSum.get(did)+=aveTS;
-		_xTimingSum2.get(did)+=aveTS*aveTS;
-		_xEntries.get(did)++;
-
-		if (_ptype != fOffline) { // hidefed2crate
-			for (int i = 0; i < digi.samples(); ++i) {
-				// Note: this used to be digi.sample(i).nominal_fC() - 2.5, but this branch doesn't exist in QIE10DataFrame.
-				// Instead, use lookup table.
-				//_cShapeCut_FEDSlot.fill(eid, i, constants::adc2fC[digi[i].adc()]);
-				_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i));
+			if (_ptype == fLocal) { // hidefed2crate
+				for (int i = 0; i < digi.samples(); ++i) {
+					// Note: this used to be digi.sample(i).nominal_fC() - 2.5, but this branch doesn't exist in QIE10DataFrame.
+					// Instead, use lookup table.
+					//_cShapeCut_FEDSlot.fill(eid, i, constants::adc2fC[digi[i].adc()]);
+					_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i));
+				}
 			}
-		}
+			if (_ptype == fOnline) {
+				for (unsigned int iTS = 0; iTS < digi.size(); ++iTS) {
+					_cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc());					
+					if (digi[iTS].le_tdc() <50) {
+						double time = iTS*25. + (digi[iTS].le_tdc() / 2.);
+						_cTDCTime_SubdetPM.fill(did, time);
+					}
+				}
+				_cSumQ_SubdetPM.fill(did, sumQ);
+			}
+		}			
 	}
 
 	if (_ptype==fOnline && _evsTotal>0 &&
@@ -458,6 +512,14 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 			_logger.dqmthrow("Collection HcalTBTriggerData isn't available "
 				+ _tagTrigger.label() + " " + _tagTrigger.instance());
 		return ctrigger->wasLEDTrigger();
+	} else {
+		//	fOnline mode
+		edm::Handle<HcalUMNioDigi> cumn;
+		if (!e.getByToken(_tokuMN, cumn)) {
+			return false;
+		}
+		
+		return (cumn->eventType() == constants::EVENTTYPE_LED);
 	}
 
 	return false;

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -179,7 +179,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 			hcaldqm::hashfunctions::fSubdetPM,
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
-		_cTDCTime_SubdetPM.initialize(_name, "SumQ", 
+		_cTDCTime_SubdetPM.initialize(_name, "TDCTime", 
 			hcaldqm::hashfunctions::fSubdetPM,
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
@@ -411,7 +411,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 				}
 			}
 			if (_ptype == fOnline) {
-				for (unsigned int iTS = 0; iTS < digi.size(); ++iTS) {
+				for (int iTS = 0; iTS < digi.samples(); ++iTS) {
 					_cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc());					
 					if (digi[iTS].tdc() <50) {
 						double time = iTS*25. + (digi[iTS].tdc() / 2.);

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -394,7 +394,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 			if (did.subdet() == HcalOther) {
 				HcalOtherDetId hodid(digi.detid());
 				if (hodid.subdet() == HcalCalibration) {
-					if (did.depth() == 0) {
+					if (did.depth() == 10) {
 						for (int i=0; i<digi.samples(); i++) {
 							_meLEDMon->Fill(e.bunchCrossing(), digi[i].adc());
 						}

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -81,7 +81,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200), 
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 
-	if (_ptype != fOffline) { // hidefed2crate
+	if (_ptype == fLocal) { // hidefed2crate
 		_cSignalMean_FEDVME.initialize(_name, "SignalMean",
 			hcaldqm::hashfunctions::fFED,
 			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
@@ -214,7 +214,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 	_cTimingRMS_depth.book(ib, _emap, _subsystem);
 
 	_cMissing_depth.book(ib, _emap, _subsystem);
-	if (_ptype != fOffline) { // hidefed2crate
+	if (_ptype == fLocal) { // hidefed2crate
 		_cSignalMean_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
 		_cSignalMean_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
 		_cSignalRMS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
@@ -260,7 +260,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 	_cTimingMean_depth.reset();
 	_cTimingRMS_depth.reset();
 
-	if (_ptype != fOffline) { // hidefed2crate
+	if (_ptype == fLocal) { // hidefed2crate
 		_cSignalMean_FEDVME.reset();
 		_cSignalMean_FEDuTCA.reset();
 		_cSignalRMS_FEDVME.reset();
@@ -289,7 +289,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 		if (n==0)
 		{
 			_cMissing_depth.fill(did);
-			if (_ptype != fOffline) { // hidefed2crate
+			if (_ptype == fLocal) { // hidefed2crate
 				if (eid.isVMEid())
 					_cMissing_FEDVME.fill(eid);
 				else
@@ -305,7 +305,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 		_cTimingMean_depth.fill(did, mtim);
 		_cTimingRMS_Subdet.fill(did, rtim);
 		_cTimingRMS_depth.fill(did, rtim);
-		if (_ptype != fOffline) { // hidefed2crate
+		if (_ptype == fLocal) { // hidefed2crate
 			if (eid.isVMEid())
 			{
 				_cSignalMean_FEDVME.fill(eid, msig);

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -18,6 +18,8 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 		edm::InputTag("hcalDigis"));
 	_tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger",
 		edm::InputTag("tbunpacker"));
+	_taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN",
+		edm::InputTag("hcalDigis"));
 	_tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
 	_tokHE = consumes<QIE11DigiCollection>(_tagHE);
 	_tokHO = consumes<HODigiCollection>(_tagHO);

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -181,13 +181,13 @@ LEDTask::LEDTask(edm::ParameterSet const& ps):
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 		_cTDCTime_SubdetPM.initialize(_name, "TDCTime", 
 			hcaldqm::hashfunctions::fSubdetPM,
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 		_cTDCTime_depth.initialize(_name, "TDCTime", 
 			hcaldqm::hashfunctions::fdepth,
 			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
 			new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),			
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),0);
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),0);
 		// Manually book LED monitoring histogram, to get custom axis
 		ib.setCurrentFolder(_subsystem+"/"+_name);
 		_meLEDMon = ib.book2D("LED_ADCvsBX", "ADC vs BX", 99, -0.5, 3564-0.5, 64, -0.5, 255.5);

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -834,7 +834,7 @@ void LaserTask::processLaserMon(edm::Handle<QIE10DigiCollection> &col, std::vect
 		}		
 
 		// First digi: initialize the vectors to -1 (need to know the length of the digi)
-		if (iLaserMonADC.size() == 0) {
+		if (iLaserMonADC.empty()) {
 			int totalNSamples = (digi.samples() - _laserMonDigiOverlap) * _vLaserMonIPhi.size();
 			for (int i = 0; i < totalNSamples; ++i) {
 				iLaserMonADC.push_back(-1);

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -254,7 +254,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_100TS)
 			);
 			_cTimingDiffLS_SubdetPM.initialize(_name, "TimingDiff_DigiMinusLaserMon",
-				hcaldqm::hashfunctions::fSubdet,
+				hcaldqm::hashfunctions::fSubdetPM,
 				new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
 				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRBX),
 				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTimingDiff_ns), 0);
@@ -271,7 +271,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_100TS)
 			);
 			_cTimingDiffEvent_SubdetPM.initialize(_name, "TimingDiff_DigiMinusLaserMon",
-				hcaldqm::hashfunctions::fSubdet,
+				hcaldqm::hashfunctions::fSubdetPM,
 				new hcaldqm::quantity::EventNumber(_nevents),
 				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRBX),
 				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTimingDiff_ns), 0);

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -36,11 +36,11 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 	_lowHBHE = ps.getUntrackedParameter<double>("lowHBHE",
 		50);
 	_lowHE = ps.getUntrackedParameter<double>("lowHE",
-		100);
+		150);
 	_lowHO = ps.getUntrackedParameter<double>("lowHO",
-		20);
+		100);
 	_lowHF = ps.getUntrackedParameter<double>("lowHF",
-		20);
+		50);
 	_laserType = (uint32_t)ps.getUntrackedParameter<uint32_t>("laserType");
 
 	// Laser mon digi ordering list
@@ -53,10 +53,10 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 	_thresh_frac_timingreflm = ps.getUntrackedParameter<double>("_thresh_frac_timingreflm", 0.01);
 	_thresh_min_lmsumq = ps.getUntrackedParameter<double>("thresh_min_lmsumq", 50000.);
 
-	std::vector<double> vTimingRangeHB = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HB", std::vector<double>({-60, -10.}));
-	std::vector<double> vTimingRangeHE = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HE", std::vector<double>({-50., 0.}));
-	std::vector<double> vTimingRangeHO = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HO", std::vector<double>({-35., 15.}));
-	std::vector<double> vTimingRangeHF = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HF", std::vector<double>({-40., 10.}));
+	std::vector<double> vTimingRangeHB = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HB", std::vector<double>({-70, -10.}));
+	std::vector<double> vTimingRangeHE = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HE", std::vector<double>({-60., 0.}));
+	std::vector<double> vTimingRangeHO = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HO", std::vector<double>({-50., 20.}));
+	std::vector<double> vTimingRangeHF = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HF", std::vector<double>({-50., 20.}));
 	_thresh_timingreflm[HcalBarrel] = std::make_pair(vTimingRangeHB[0], vTimingRangeHB[1]);
 	_thresh_timingreflm[HcalEndcap] = std::make_pair(vTimingRangeHE[0], vTimingRangeHE[1]);
 	_thresh_timingreflm[HcalOuter] = std::make_pair(vTimingRangeHO[0], vTimingRangeHO[1]);
@@ -500,11 +500,16 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 			}
 			//	@cDAQ
 			if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHO(eid) || hcaldqm::utilities::isFEDHF(eid)) {
-				double frbadtimingreflm = double(_xNBadTimingRefLM.get(eid))/double(_xNChs.get(eid));
-				if (frbadtimingreflm > _thresh_frac_timingreflm) {
-					_vflags[fBadTiming]._state = hcaldqm::flag::fBAD;
+				int min_nchs = 10;
+				if (_xNChs.get(eid) < min_nchs) {
+					_vflags[fBadTiming]._state = hcaldqm::flag::fNA;
 				} else {
-					_vflags[fBadTiming]._state = hcaldqm::flag::fGOOD;
+					double frbadtimingreflm = double(_xNBadTimingRefLM.get(eid))/double(_xNChs.get(eid));
+					if (frbadtimingreflm > _thresh_frac_timingreflm) {
+						_vflags[fBadTiming]._state = hcaldqm::flag::fBAD;
+					} else {
+						_vflags[fBadTiming]._state = hcaldqm::flag::fGOOD;
+					}
 				}
 				if (_xMissingLaserMon) {
 					_vflags[fMissingLaserMon]._state = hcaldqm::flag::fBAD;

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -216,28 +216,57 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 	_xEntries.initialize(hcaldqm::hashfunctions::fDChannel);
 
 	// LaserMon containers
-	_cLaserMonSumQ_LS.initialize(_name, 
-		"LaserMonSumQ",
-		new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000000)
-	);
-	_cLaserMonTiming_LS.initialize(_name, 
-		"LaserMonTiming",
-		new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250)
-	);
+	if (_ptype == fOnline || _ptype == fLocal) {
+		_cLaserMonSumQ.initialize(_name, 
+			"LaserMonSumQ",
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000000),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+		_cLaserMonSumQ.showOverflowX(true);
 
-	_cTiming_DigivsLaserMon_SubdetPM.initialize(_name, "Timing_DigivsLaserMon", 
-		hcaldqm::hashfunctions::fSubdetPM, 
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+		_cLaserMonTiming.initialize(_name, 
+			"LaserMonTiming",
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+		_cLaserMonTiming.showOverflowX(true);
 
-	_cTimingDiffLS_SubdetPM.initialize(_name, "TimingDiff_DigiMinusLaserMon",
-		hcaldqm::hashfunctions::fSubdet,
-		new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRBX),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTimingDiff_ns), 0);
+		if (_ptype == fOnline) {
+			_cLaserMonSumQ_LS.initialize(_name, 
+				"LaserMonSumQ_LS",
+				new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
+				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000000)
+			);
+			_cLaserMonTiming_LS.initialize(_name, 
+				"LaserMonTiming_LS",
+				new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
+				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_100TS)
+			);
+		} else if (_ptype == fLocal) {
+			_cLaserMonSumQ_Event.initialize(_name, 
+				"LaserMonSumQ_Event",
+				new hcaldqm::quantity::EventNumber(_nevents),
+				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_1000000)
+			);
+			_cLaserMonTiming_Event.initialize(_name, 
+				"LaserMonTiming_Event",
+				new hcaldqm::quantity::EventNumber(_nevents),
+				new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_100TS)
+			);
+		}
+		_cTiming_DigivsLaserMon_SubdetPM.initialize(_name, "Timing_DigivsLaserMon", 
+			hcaldqm::hashfunctions::fSubdetPM, 
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250_coarse),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250_coarse),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+		_cTiming_DigivsLaserMon_SubdetPM.showOverflowX(true);
+		_cTiming_DigivsLaserMon_SubdetPM.showOverflowY(true);
+
+		_cTimingDiffLS_SubdetPM.initialize(_name, "TimingDiff_DigiMinusLaserMon",
+			hcaldqm::hashfunctions::fSubdet,
+			new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRBX),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTimingDiff_ns), 0);
+		_cTimingDiffLS_SubdetPM.showOverflowY(true);
+	}
 
 	//	BOOK
 	_cSignalMean_Subdet.book(ib, _emap, _subsystem);
@@ -288,10 +317,19 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 	_xTimingSum.book(_emap);
 	_xTimingSum2.book(_emap);
 
-	_cLaserMonSumQ_LS.book(ib, _subsystem);
-	_cLaserMonTiming_LS.book(ib, _subsystem);
-	_cTiming_DigivsLaserMon_SubdetPM.book(ib, _emap, _subsystem);
-	_cTimingDiffLS_SubdetPM.book(ib, _emap, _subsystem);
+	if (_ptype == fOnline || _ptype == fLocal) {
+		_cLaserMonSumQ.book(ib, _subsystem);
+		_cLaserMonTiming.book(ib, _subsystem);
+		if (_ptype == fOnline) {
+			_cLaserMonSumQ_LS.book(ib, _subsystem);
+			_cLaserMonTiming_LS.book(ib, _subsystem);
+		} else if (_ptype == fLocal) {
+			_cLaserMonSumQ_Event.book(ib, _subsystem);
+			_cLaserMonTiming_Event.book(ib, _subsystem);
+		}
+		_cTiming_DigivsLaserMon_SubdetPM.book(ib, _emap, _subsystem);
+		_cTimingDiffLS_SubdetPM.book(ib, _emap, _subsystem);
+	}
 
 	_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
 }
@@ -440,8 +478,16 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 	}
 
 	if (laserMonSumQ > _laserMonThreshold) {
-		_cLaserMonSumQ_LS.fill(_currentLS, laserMonSumQ);
-		_cLaserMonTiming_LS.fill(_currentLS, laserMonTiming);
+		_cLaserMonSumQ.fill(laserMonSumQ);
+		_cLaserMonTiming.fill(laserMonTiming);
+		if (_ptype == fOnline) {
+			_cLaserMonSumQ_LS.fill(_currentLS, laserMonSumQ);
+			_cLaserMonTiming_LS.fill(_currentLS, laserMonTiming);
+		} else if (_ptype == fLocal) {
+			int currentEvent = e.eventAuxiliary().id().event();
+			_cLaserMonSumQ_Event.fill(currentEvent, laserMonSumQ);
+			_cLaserMonTiming_Event.fill(currentEvent, laserMonTiming);
+		}
 	}
 
 	for (HBHEDigiCollection::const_iterator it=chbhe->begin();
@@ -487,7 +533,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 			_cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
 
 			double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
-			_cTiming_DigivsLaserMon_SubdetPM.fill(did, digiTimingSOI, laserMonTiming);
+			_cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
 			_cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), digiTimingSOI - laserMonTiming);
 		}
 	}
@@ -538,7 +584,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 			_cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
 
 			double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
-			_cTiming_DigivsLaserMon_SubdetPM.fill(did, digiTimingSOI, laserMonTiming);
+			_cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
 			_cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), digiTimingSOI - laserMonTiming);
 		}
 	}
@@ -585,7 +631,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 			_cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
 
 			double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
-			_cTiming_DigivsLaserMon_SubdetPM.fill(did, digiTimingSOI, laserMonTiming);
+			_cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
 			_cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), digiTimingSOI - laserMonTiming);
 		}
 	}
@@ -637,7 +683,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 			_cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
 
 			double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
-			_cTiming_DigivsLaserMon_SubdetPM.fill(did, digiTimingSOI, laserMonTiming);
+			_cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
 			_cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), digiTimingSOI - laserMonTiming);
 		}
 	}

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -53,10 +53,10 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 	_thresh_frac_timingreflm = ps.getUntrackedParameter<double>("_thresh_frac_timingreflm", 0.01);
 	_thresh_min_lmsumq = ps.getUntrackedParameter<double>("thresh_min_lmsumq", 50000.);
 
-	std::vector<double> vTimingRangeHB = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HB", std::vector<double>({-75., -25.}));
-	std::vector<double> vTimingRangeHE = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HE", std::vector<double>({-75., -25.}));
-	std::vector<double> vTimingRangeHO = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HO", std::vector<double>({-75., -25.}));
-	std::vector<double> vTimingRangeHF = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HF", std::vector<double>({-75., -25.}));
+	std::vector<double> vTimingRangeHB = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HB", std::vector<double>({-60, -10.}));
+	std::vector<double> vTimingRangeHE = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HE", std::vector<double>({-50., 0.}));
+	std::vector<double> vTimingRangeHO = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HO", std::vector<double>({-35., 15.}));
+	std::vector<double> vTimingRangeHF = ps.getUntrackedParameter<std::vector<double>>("thresh_timingreflm_HF", std::vector<double>({-40., 10.}));
 	_thresh_timingreflm[HcalBarrel] = std::make_pair(vTimingRangeHB[0], vTimingRangeHB[1]);
 	_thresh_timingreflm[HcalEndcap] = std::make_pair(vTimingRangeHE[0], vTimingRangeHE[1]);
 	_thresh_timingreflm[HcalOuter] = std::make_pair(vTimingRangeHO[0], vTimingRangeHO[1]);
@@ -479,7 +479,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 		//double timingreflm_rms = sqrt(_xTimingRefLMSum2.get(did) / n - timingreflm_mean * timingreflm_mean);
 
 		if ((timingreflm_mean < _thresh_timingreflm[did.subdet()].first) || (timingreflm_mean > _thresh_timingreflm[did.subdet()].second)) {
-			++_xNBadTimingRefLM.get(did);
+			_xNBadTimingRefLM.get(eid)++;
 		}		
 	}
 	if (_ptype != fOffline) { // hidefed2crate

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -443,12 +443,12 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 			continue;
 		}
 
-		++_xNChs.get(did);
+		_xNChs.get(eid)++;
 
-		double msig = 0.;//_xSignalSum.get(did)/n; 
-		double mtim = 0.;//_xTimingSum.get(did)/n;
-		double rsig = 0.;//sqrt(_xSignalSum2.get(did)/n-msig*msig);
-		double rtim = 0.;//sqrt(_xTimingSum2.get(did)/n-mtim*mtim);
+		double msig = _xSignalSum.get(did)/n; 
+		double mtim = _xTimingSum.get(did)/n;
+		double rsig = sqrt(_xSignalSum2.get(did)/n-msig*msig);
+		double rtim = sqrt(_xTimingSum2.get(did)/n-mtim*mtim);
 
 		_cSignalMean_Subdet.fill(did, msig);
 		_cSignalMean_depth.fill(did, msig);

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -111,7 +111,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fADC_128),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);
 
-	if (_ptype != fOffline) { // hidefed2crate
+	if (_ptype == fLocal) { // hidefed2crate
 		_cSignalMean_FEDVME.initialize(_name, "SignalMean",
 			hcaldqm::hashfunctions::fFED,
 			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
@@ -152,6 +152,16 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
 			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
 			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),0);
+		_cMissing_FEDVME.initialize(_name, "Missing",
+			hcaldqm::hashfunctions::fFED,
+			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
+			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
+		_cMissing_FEDuTCA.initialize(_name, "Missing",
+			hcaldqm::hashfunctions::fFED,
+			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
+			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
+			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
 
 		_cShapeCut_FEDSlot.initialize(_name, "Shape", 
 			hcaldqm::hashfunctions::fFEDSlot,
@@ -209,18 +219,6 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
 		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cMissing_FEDVME.initialize(_name, "Missing",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSpigot),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberVMEFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-		_cMissing_FEDuTCA.initialize(_name, "Missing",
-			hcaldqm::hashfunctions::fFED,
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
-			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fFiberuTCAFiberCh),
-			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-	}
 
 	
 	//	initialize compact containers
@@ -345,7 +343,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 		_cSignalvsBX_SubdetPM.book(ib, _emap, _subsystem);
 	}
 
-	if (_ptype != fOffline) { // hidefed2crate
+	if (_ptype == fLocal) { // hidefed2crate
 		_cSignalMean_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
 		_cSignalMean_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
 		_cSignalRMS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
@@ -354,15 +352,13 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 		_cTimingMean_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
 		_cTimingRMS_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
 		_cTimingRMS_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
+		_cMissing_FEDVME.book(ib, _emap, _filter_uTCA,_subsystem);
+		_cMissing_FEDuTCA.book(ib, _emap, _filter_VME,_subsystem);
+		_cShapeCut_FEDSlot.book(ib, _emap, _subsystem);
 	}
 	_cADC_SubdetPM.book(ib, _emap, _subsystem);
 
 	_cMissing_depth.book(ib, _emap,_subsystem);
-	if (_ptype != fOffline) { // hidefed2crate
-		_cShapeCut_FEDSlot.book(ib, _emap, _subsystem);
-		_cMissing_FEDVME.book(ib, _emap, _filter_uTCA,_subsystem);
-		_cMissing_FEDuTCA.book(ib, _emap, _filter_VME,_subsystem);
-	}
 
 	_xSignalSum.book(_emap);
 	_xSignalSum2.book(_emap);
@@ -410,7 +406,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 	_cTimingMean_depth.reset();
 	_cTimingRMS_depth.reset();
 
-	if (_ptype != fOffline) { // hidefed2crate
+	if (_ptype == fLocal) { // hidefed2crate
 		_cSignalMean_FEDVME.reset();
 		_cSignalMean_FEDuTCA.reset();
 		_cSignalRMS_FEDVME.reset();
@@ -419,7 +415,9 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 		_cTimingMean_FEDuTCA.reset();
 		_cTimingRMS_FEDVME.reset();
 		_cTimingRMS_FEDuTCA.reset();
-		_xNChs.reset();
+	}
+	if (_ptype != fOffline) {
+		_xNChs.reset();		
 	}
 
 	std::vector<HcalGenericDetId> dids = _emap->allPrecisionId();
@@ -434,7 +432,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 		//	channels missing or low signal
 		if (n == 0) {
 			_cMissing_depth.fill(did);
-			if (_ptype != fOffline) { // hidefed2crate
+			if (_ptype == fLocal) { // hidefed2crate
 				if (eid.isVMEid())
 					_cMissing_FEDVME.fill(eid);
 				else
@@ -458,7 +456,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 		_cTimingMean_depth.fill(did, mtim);
 		_cTimingRMS_Subdet.fill(did, rtim);
 		_cTimingRMS_depth.fill(did, rtim);
-		if (_ptype != fOffline) { // hidefed2crate
+		if (_ptype == fLocal) { // hidefed2crate
 			if (eid.isVMEid())
 			{
 				_cSignalMean_FEDVME.fill(eid, msig);
@@ -631,7 +629,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 
 		for (int i=0; i<digi.size(); i++)
 		{
-			if (_ptype != fOffline) { // hidefed2crate
+			if (_ptype == fLocal) { // hidefed2crate
 				_cShapeCut_FEDSlot.fill(eid, i, 
 					digi.sample(i).nominal_fC()-2.5);
 			}
@@ -686,7 +684,9 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 
 		for (int i=0; i<digi.samples(); i++)
 		{
-			_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, digi, i));
+			if (_ptype == fLocal) {
+				_cShapeCut_FEDSlot.fill(eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, digi, i));
+			}
 			_cADC_SubdetPM.fill(did, digi[i].adc());
 		}
 
@@ -733,7 +733,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 
 		for (int i=0; i<digi.size(); i++)
 		{
-			if (_ptype != fOffline) { // hidefed2crate
+			if (_ptype == fLocal) { // hidefed2crate
 				_cShapeCut_FEDSlot.fill(eid, i, 
 					digi.sample(i).nominal_fC()-8.5);
 			}
@@ -789,7 +789,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 
 		for (int i=0; i<digi.samples(); i++)
 		{
-			if (_ptype != fOffline) { // hidefed2crate
+			if (_ptype == fLocal) { // hidefed2crate
 				_cShapeCut_FEDSlot.fill(eid, (int)i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i));
 			}
 			_cADC_SubdetPM.fill(did, digi[i].adc());

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -1,4 +1,3 @@
-
 #include "DQM/HcalTasks/interface/LaserTask.h"
 
 using namespace hcaldqm;
@@ -21,7 +20,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 	_taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN",
 		edm::InputTag("hcalDigis"));
 	_tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-	_tokHEP17 = consumes<QIE11DigiCollection>(_tagHE);
+	_tokHE = consumes<QIE11DigiCollection>(_tagHE);
 	_tokHO = consumes<HODigiCollection>(_tagHO);
 	_tokHF = consumes<QIE10DigiCollection>(_tagHF);
 	_tokuMN = consumes<HcalUMNioDigi>(_taguMN);
@@ -29,7 +28,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 	//	constants
 	_lowHBHE = ps.getUntrackedParameter<double>("lowHBHE",
 		20);
-	_lowHEP17 = ps.getUntrackedParameter<double>("lowHEP17",
+	_lowHE = ps.getUntrackedParameter<double>("lowHE",
 		20);
 	_lowHO = ps.getUntrackedParameter<double>("lowHO",
 		20);
@@ -342,14 +341,14 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 	edm::EventSetup const& es)
 {
 	edm::Handle<HBHEDigiCollection>		chbhe;
-	edm::Handle<QIE11DigiCollection>		chep17;
+	edm::Handle<QIE11DigiCollection>		cHE;
 	edm::Handle<HODigiCollection>		cho;
 	edm::Handle<QIE10DigiCollection>		chf;
 
 	if (!e.getByToken(_tokHBHE, chbhe))
 		_logger.dqmthrow("Collection HBHEDigiCollection isn't available "
 			+ _tagHBHE.label() + " " + _tagHBHE.instance());
-	if (!e.getByToken(_tokHEP17, chep17))
+	if (!e.getByToken(_tokHE, cHE))
 		_logger.dqmthrow("Collection QIE11DigiCollection isn't available "
 			+ _tagHE.label() + " " + _tagHE.instance());
 	if (!e.getByToken(_tokHO, cho))
@@ -405,7 +404,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 			_cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
 		}
 	}
-	for (QIE11DigiCollection::const_iterator it=chep17->begin(); it!=chep17->end();
+	for (QIE11DigiCollection::const_iterator it=cHE->begin(); it!=cHE->end();
 		++it)
 	{
 		const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
@@ -419,7 +418,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps):
 		CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
 		//double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(digi, 2.5, 0, digi.samples()-1);
 		double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
-		if (sumQ<_lowHEP17)
+		if (sumQ<_lowHE)
 			continue;
 
 

--- a/DQM/HcalTasks/plugins/RecHitTask.cc
+++ b/DQM/HcalTasks/plugins/RecHitTask.cc
@@ -56,7 +56,7 @@ RecHitTask::RecHitTask(edm::ParameterSet const& ps):
 	_filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
 		vuTCA);
 	std::vector<uint32_t> vhashHF; 
-	vhashHF.push_back(hcaldqm::hashfunctions::hash_did.at(hcaldqm::hashfunctions::fSubdet)(HcalDetId(HcalForward, 29,1,1)));
+	vhashHF.push_back(hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalForward, 29,1,1)));
 
 	_filter_HF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fSubdet, vhashHF);
 

--- a/DQM/HcalTasks/plugins/RecHitTask.cc
+++ b/DQM/HcalTasks/plugins/RecHitTask.cc
@@ -56,7 +56,8 @@ RecHitTask::RecHitTask(edm::ParameterSet const& ps):
 	_filter_uTCA.initialize(filter::fFilter, hcaldqm::hashfunctions::fElectronics,
 		vuTCA);
 	std::vector<uint32_t> vhashHF; 
-	vhashHF.push_back(hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalForward, 29,1,1)));
+	vhashHF.push_back(hcaldqm::hashfunctions::hash_did.at(hcaldqm::hashfunctions::fSubdet)(HcalDetId(HcalForward, 29,1,1)));
+
 	_filter_HF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fSubdet, vhashHF);
 
 	//	INITIALIZE FIRST

--- a/DQM/HcalTasks/python/DigiTask.py
+++ b/DQM/HcalTasks/python/DigiTask.py
@@ -25,6 +25,7 @@ digiTask = DQMEDAnalyzer(
 
 	#	ratio thresholds
 	thresh_unifh = cms.untracked.double(0.2),
+	thresh_led = cms.untracked.double(20),
 
 	qie10InConditions = cms.untracked.bool(False),
 

--- a/DQM/HcalTasks/python/LaserTask.py
+++ b/DQM/HcalTasks/python/LaserTask.py
@@ -32,7 +32,10 @@ laserTask = DQMEDAnalyzer(
 	laserMonDigiOverlap = cms.untracked.int32(2), # digis have 6 TSes, but overlap by 2.
 	laserMonTS0 = cms.untracked.int32(65), # Timing is set so the peak is in TS 69.
 	laserMonThreshold = cms.untracked.double(1.e5),
-	thresh_timingreflm_rms = cms.untracked.double(5.),
-	thresh_frac_timingreflmrms = cms.untracked.double(0.01),
+	thresh_frac_timingreflm = cms.untracked.double(5.),
 	thresh_min_lmsumq = cms.untracked.double(50000.),
+	thresh_timingreflm_HB = cms.untracked.vdouble(-75., -25.),
+	thresh_timingreflm_HE = cms.untracked.vdouble(-75., -25.),
+	thresh_timingreflm_HO = cms.untracked.vdouble(-75., -25.),
+	thresh_timingreflm_HF = cms.untracked.vdouble(-75., -25.),
 )

--- a/DQM/HcalTasks/python/LaserTask.py
+++ b/DQM/HcalTasks/python/LaserTask.py
@@ -34,8 +34,8 @@ laserTask = DQMEDAnalyzer(
 	laserMonThreshold = cms.untracked.double(1.e5),
 	thresh_frac_timingreflm = cms.untracked.double(5.),
 	thresh_min_lmsumq = cms.untracked.double(50000.),
-	thresh_timingreflm_HB = cms.untracked.vdouble(-60., -10.),
-	thresh_timingreflm_HE = cms.untracked.vdouble(-50., 0.),
-	thresh_timingreflm_HO = cms.untracked.vdouble(-35., 15.),
-	thresh_timingreflm_HF = cms.untracked.vdouble(-40., 10.),
+	thresh_timingreflm_HB = cms.untracked.vdouble(-70., -10.),
+	thresh_timingreflm_HE = cms.untracked.vdouble(-60., 0.),
+	thresh_timingreflm_HO = cms.untracked.vdouble(-50., 20.),
+	thresh_timingreflm_HF = cms.untracked.vdouble(-50., 20.),
 )

--- a/DQM/HcalTasks/python/LaserTask.py
+++ b/DQM/HcalTasks/python/LaserTask.py
@@ -32,4 +32,7 @@ laserTask = DQMEDAnalyzer(
 	laserMonDigiOverlap = cms.untracked.int32(2), # digis have 6 TSes, but overlap by 2.
 	laserMonTS0 = cms.untracked.int32(65), # Timing is set so the peak is in TS 69.
 	laserMonThreshold = cms.untracked.double(1.e5),
+	thresh_timingreflm_rms = cms.untracked.double(5.),
+	thresh_frac_timingreflmrms = cms.untracked.double(0.01),
+	thresh_min_lmsumq = cms.untracked.double(50000.),
 )

--- a/DQM/HcalTasks/python/LaserTask.py
+++ b/DQM/HcalTasks/python/LaserTask.py
@@ -5,21 +5,30 @@ laserTask = DQMEDAnalyzer(
 	"LaserTask",
 	
 	#	standard parameters
-	name = cms.untracked.string("LaserTask"),
-	debug = cms.untracked.int32(0),
-	runkeyVal = cms.untracked.int32(0),
+	name       = cms.untracked.string("LaserTask"),
+	debug      = cms.untracked.int32(0),
+	runkeyVal  = cms.untracked.int32(0),
 	runkeyName = cms.untracked.string("pp_run"),
-	ptype = cms.untracked.int32(0),
-	mtype = cms.untracked.bool(True),
-	subsystem = cms.untracked.string("HcalCalib"),
+	ptype      = cms.untracked.int32(0),
+	mtype      = cms.untracked.bool(True),
+	subsystem  = cms.untracked.string("HcalCalib"),
 
 	#	tags
-	tagHBHE = cms.untracked.InputTag("hcalDigis"),
-	tagHO = cms.untracked.InputTag("hcalDigis"),
-	tagHF = cms.untracked.InputTag("hcalDigis"),
-    taguMN = cms.untracked.InputTag("hcalDigis"),
-	tagRaw = cms.untracked.InputTag('hltHcalCalibrationRaw'),
+	tagHBHE     = cms.untracked.InputTag("hcalDigis"),
+	tagHO       = cms.untracked.InputTag("hcalDigis"),
+	tagHF       = cms.untracked.InputTag("hcalDigis"),
+	taguMN      = cms.untracked.InputTag("hcalDigis"),
+	tagRaw      = cms.untracked.InputTag('hltHcalCalibrationRaw'),
+	tagLaserMon = cms.untracked.InputTag("LASERMON"),
+
 	laserType = cms.untracked.uint32(0),
 
-	nevents = cms.untracked.int32(10000)
+	nevents = cms.untracked.int32(10000),
+
+	# laser mon stuff
+	laserMonCBox = cms.untracked.int32(5),
+	laserMonIEta = cms.untracked.int32(0),
+	vLaserMonIPhi = cms.untracked.vint32(23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0),
+	laserMonDigiOverlap = cms.untracked.int32(2), # digis have 6 TSes, but overlap by 2.
+	laserMonTS0 = cms.untracked.int32(65), # Timing is set so the peak is in TS 69.
 )

--- a/DQM/HcalTasks/python/LaserTask.py
+++ b/DQM/HcalTasks/python/LaserTask.py
@@ -34,8 +34,8 @@ laserTask = DQMEDAnalyzer(
 	laserMonThreshold = cms.untracked.double(1.e5),
 	thresh_frac_timingreflm = cms.untracked.double(5.),
 	thresh_min_lmsumq = cms.untracked.double(50000.),
-	thresh_timingreflm_HB = cms.untracked.vdouble(-75., -25.),
-	thresh_timingreflm_HE = cms.untracked.vdouble(-75., -25.),
-	thresh_timingreflm_HO = cms.untracked.vdouble(-75., -25.),
-	thresh_timingreflm_HF = cms.untracked.vdouble(-75., -25.),
+	thresh_timingreflm_HB = cms.untracked.vdouble(-60., -10.),
+	thresh_timingreflm_HE = cms.untracked.vdouble(-50., 0.),
+	thresh_timingreflm_HO = cms.untracked.vdouble(-35., 15.),
+	thresh_timingreflm_HF = cms.untracked.vdouble(-40., 10.),
 )

--- a/DQM/HcalTasks/python/LaserTask.py
+++ b/DQM/HcalTasks/python/LaserTask.py
@@ -19,7 +19,7 @@ laserTask = DQMEDAnalyzer(
 	tagHF       = cms.untracked.InputTag("hcalDigis"),
 	taguMN      = cms.untracked.InputTag("hcalDigis"),
 	tagRaw      = cms.untracked.InputTag('hltHcalCalibrationRaw'),
-	tagLaserMon = cms.untracked.InputTag("LASERMON"),
+	tagLaserMon = cms.untracked.InputTag("hcalDigis:LASERMON"),
 
 	laserType = cms.untracked.uint32(0),
 
@@ -31,4 +31,5 @@ laserTask = DQMEDAnalyzer(
 	vLaserMonIPhi = cms.untracked.vint32(23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0),
 	laserMonDigiOverlap = cms.untracked.int32(2), # digis have 6 TSes, but overlap by 2.
 	laserMonTS0 = cms.untracked.int32(65), # Timing is set so the peak is in TS 69.
+	laserMonThreshold = cms.untracked.double(1.e5),
 )

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -116,6 +116,8 @@ namespace hcaldqm
 		int numEvents = meNumEvents->getBinContent(1);
 		bool unknownIdsPresent = ig.get(_subsystem+"/"
 			+_taskname+"/UnknownIds")->getBinContent(1)>0;
+		bool ledSignalPresent = ig.get(_subsystem+"/"
+			+_taskname+"/LEDEventCount")->getBinContent(1)>0;
 
 		//	book the Numer of Events - set axis extendable
 		if (!_booked)
@@ -158,6 +160,7 @@ namespace hcaldqm
 		vtmpflags[fDigiSize]=flag::Flag("DigiSize");
 		vtmpflags[fNChsHF]=flag::Flag("NChsHF");
 		vtmpflags[fUnknownIds]=flag::Flag("UnknownIds");
+		vtmpflags[fLED]=flag::Flag("LEDMisfire");
 		for (std::vector<uint32_t>::const_iterator it=_vhashCrates.begin();
 			it!=_vhashCrates.end(); ++it)
 		{
@@ -189,6 +192,11 @@ namespace hcaldqm
 			else
 				vtmpflags[fUnknownIds]._state = flag::fGOOD;
 
+			if (ledSignalPresent)
+				vtmpflags[fLED]._state = flag::fBAD;
+			else
+				vtmpflags[fLED]._state = flag::fGOOD;
+
 			// push all the flags for this crate
 			lssum._vflags.push_back(vtmpflags);
 		}
@@ -216,6 +224,7 @@ namespace hcaldqm
 		vflagsPerLS[fDigiSize]=flag::Flag("DigiSize");
 		vflagsPerLS[fNChsHF]=flag::Flag("NChsHF");
 		vflagsPerLS[fUnknownIds]=flag::Flag("UnknownIds");
+		vflagsPerLS[fLED]=flag::Flag("LEDMisfire");
 		vflagsPerRun[fDigiSize]=flag::Flag("DigiSize");
 		vflagsPerRun[fNChsHF]=flag::Flag("NChsHF");
 		vflagsPerRun[fUniHF-nLSFlags+1]=flag::Flag("UniSlotHF");

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -117,7 +117,7 @@ namespace hcaldqm
 		bool unknownIdsPresent = ig.get(_subsystem+"/"
 			+_taskname+"/UnknownIds")->getBinContent(1)>0;
 		bool ledSignalPresent = ig.get(_subsystem+"/"
-			+_taskname+"/LEDEventCount")->getBinContent(1)>0;
+			+_taskname+"/LED/LEDEventCount")->getBinContent(1)>0;
 
 		//	book the Numer of Events - set axis extendable
 		if (!_booked)

--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -104,6 +104,7 @@ process.hbhereco = process.hbheprereco.clone()
 process.load("DQM.HcalTasks.PedestalTask")
 process.load('DQM.HcalTasks.RawTask')
 process.load("DQM.HcalTasks.LaserTask")
+process.load("DQM.HcalTasks.LEDTask")
 process.load("DQM.HcalTasks.UMNioTask")
 process.load('DQM.HcalTasks.HcalOnlineHarvesting')
 process.load("DQM.HcalTasks.HFRaddamTask")
@@ -177,6 +178,8 @@ process.qie11Task_pedestal.tagQIE11 = cms.untracked.InputTag("hcalDigis")
 process.qie11Task_pedestal.subsystem = cms.untracked.string("HcalCalib")
 process.qie11Task_pedestal.eventType = cms.untracked.int32(1)
 
+process.ledTask.name = cms.untracked.string("LEDTask")
+
 #-------------------------------------
 #	Hcal DQM Tasks Sequence Definition
 #-------------------------------------
@@ -194,6 +197,7 @@ process.tasksSequence = cms.Sequence(
 		*process.umnioTask
 		*process.qie11Task_laser
 		*process.qie11Task_pedestal
+		*process.ledTask
 )
 
 process.harvestingSequence = cms.Sequence(


### PR DESCRIPTION
This PR adds monitoring of the calibration LED and laser firing into the abort gap in global runs. LEDTask is added to the hcalcalib application. Plots are added to LaserTask, LEDTask, and DigiTask, to monitor both the detector channels (e.g. timing) and the dedicated laser and LED monitoring channels (LaserMon PMT, and LED calibration channels). 

A few improvements to the HCAL DQM infrastructure are also included:
- Add option for folding in overflow bins.
- Have the TProfile containers implement their own fill methods, instead of just inheriting from TH1.
- The ElectronicsMap class accounts for the fact that HcalDetId sometimes changed the rawId ("newForm").
- Add coarse luminosity axis (e.g. 10 LS binning).
- Add RBX axis.
- Fix a few mistakes where the wrong quantity was being filled in plots.
 