### PR TITLE
Use SiStripDetInfoFileReader as an edm::Service in fake ES producers

### DIFF
--- a/CalibTracker/SiStripESProducers/plugins/fake/Phase2TrackerCablingCfgESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/Phase2TrackerCablingCfgESSource.cc
@@ -2,7 +2,6 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripFecCabling.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripModule.h"
 #include "CalibTracker/Records/interface/SiStripHashedDetIdRcd.h"
-#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 #include "CalibTracker/SiStripCommon/interface/SiStripFedIdListReader.h"
 #include "CondFormats/SiStripObjects/interface/FedChannelConnection.h"
 #include "CondFormats/SiStripObjects/interface/Phase2TrackerCabling.h"

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainBuilderFromTag.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainBuilderFromTag.cc
@@ -12,7 +12,6 @@
 #include "SiStripFakeAPVParameters.h"
 
 SiStripApvGainBuilderFromTag::SiStripApvGainBuilderFromTag( const edm::ParameterSet& iConfig ):
-  fp_(iConfig.getUntrackedParameter<edm::FileInPath>("file",edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"))),
   printdebug_(iConfig.getUntrackedParameter<uint32_t>("printDebug",1)),
   pset_(iConfig)
 {}
@@ -47,10 +46,9 @@ void SiStripApvGainBuilderFromTag::analyze(const edm::Event& evt, const edm::Eve
   // Prepare the new object
   SiStripApvGain* obj = new SiStripApvGain();
 
-  SiStripDetInfoFileReader reader(fp_.fullPath());
-
+  const edm::Service<SiStripDetInfoFileReader> reader;
   uint32_t count = 0;
-  const std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >& DetInfos = reader.getAllData();
+  const std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >& DetInfos = reader->getAllData();
   for(std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >::const_iterator it = DetInfos.begin(); it != DetInfos.end(); it++) {
 
     // Find if this DetId is in the input tag and if so how many are the Apvs for which it contains information

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainBuilderFromTag.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainBuilderFromTag.h
@@ -50,7 +50,6 @@ class SiStripApvGainBuilderFromTag : public edm::EDAnalyzer
    */
   void fillSubDetParameter(std::map<int, std::vector<double> > & mapToFill, const std::vector<double> & v, const int subDet, const unsigned short layers) const;
 
-  edm::FileInPath fp_;
   bool printdebug_;
   edm::ParameterSet pset_;
 };

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainFakeESSource.cc
@@ -37,7 +37,6 @@ private:
   double m_meanGain;
   double m_sigmaGain;
   double m_minimumPosValue;
-  edm::FileInPath m_file;
   uint32_t m_printDebug;
 };
 
@@ -54,7 +53,6 @@ SiStripApvGainFakeESSource::SiStripApvGainFakeESSource(const edm::ParameterSet& 
   m_meanGain = iConfig.getParameter<double>("MeanGain");
   m_sigmaGain = iConfig.getParameter<double>("SigmaGain");
   m_minimumPosValue = iConfig.getParameter<double>("MinPositiveGain");
-  m_file = iConfig.getParameter<edm::FileInPath>("file");
   m_printDebug = iConfig.getUntrackedParameter<uint32_t>("printDebug", 5);
 }
 
@@ -73,10 +71,9 @@ SiStripApvGainFakeESSource::produce(const SiStripApvGainRcd& iRecord)
 
   auto apvGain = std::make_unique<SiStripApvGain>();
 
-  SiStripDetInfoFileReader reader{m_file.fullPath()};
-
+  const edm::Service<SiStripDetInfoFileReader> reader;
   uint32_t count{0};
-  for ( const auto& elm : reader.getAllData() ) {
+  for ( const auto& elm : reader->getAllData() ) {
     std::vector<float> theSiStripVector;
     for ( unsigned short j=0; j < elm.second.nApvs; ++j ){
       float gainValue;

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripBackPlaneCorrectionFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripBackPlaneCorrectionFakeESSource.cc
@@ -34,7 +34,6 @@ public:
 
 private:
   std::vector<double> m_valuePerModuleGeometry;
-  edm::FileInPath m_file;
 };
 
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -48,7 +47,6 @@ SiStripBackPlaneCorrectionFakeESSource::SiStripBackPlaneCorrectionFakeESSource(c
   findingRecord<SiStripBackPlaneCorrectionRcd>();
 
   m_valuePerModuleGeometry = iConfig.getParameter<std::vector<double>>("BackPlaneCorrection_PerModuleGeometry");
-  m_file = iConfig.getParameter<edm::FileInPath>("file");
 }
 
 SiStripBackPlaneCorrectionFakeESSource::~SiStripBackPlaneCorrectionFakeESSource() {}
@@ -69,9 +67,8 @@ SiStripBackPlaneCorrectionFakeESSource::produce(const SiStripBackPlaneCorrection
 
   auto backPlaneCorrection = std::make_unique<SiStripBackPlaneCorrection>();
 
-  SiStripDetInfoFileReader reader{m_file.fullPath()};
-
-  for ( const auto& detId : reader.getAllDetIds() ) {
+  const edm::Service<SiStripDetInfoFileReader> reader;
+  for ( const auto& detId : reader->getAllDetIds() ) {
     unsigned int moduleGeometry = tTopo->moduleGeometry(DetId(detId))-1;
     if ( moduleGeometry > m_valuePerModuleGeometry.size() ) {
       edm::LogError("SiStripBackPlaneCorrectionGenerator") << " BackPlaneCorrection_PerModuleGeometry only contains " << m_valuePerModuleGeometry.size() << "elements and module is out of range";

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripBadModuleConfigurableFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripBadModuleConfigurableFakeESSource.cc
@@ -36,7 +36,6 @@ public:
 private:
   using Parameters = std::vector<edm::ParameterSet>;
   Parameters m_badComponentList;
-  edm::FileInPath m_file;
   bool m_printDebug;
 
   std::vector<uint32_t> selectDetectors(const TrackerTopology* tTopo, const std::vector<uint32_t>& detIds) const;
@@ -53,7 +52,6 @@ SiStripBadModuleConfigurableFakeESSource::SiStripBadModuleConfigurableFakeESSour
   findingRecord<SiStripBadModuleRcd>();
 
   m_badComponentList = iConfig.getUntrackedParameter<Parameters>("BadComponentList");
-  m_file = iConfig.getParameter<edm::FileInPath>("file");
   m_printDebug = iConfig.getUntrackedParameter<bool>("printDebug", false);
 }
 
@@ -75,9 +73,8 @@ SiStripBadModuleConfigurableFakeESSource::produce(const SiStripBadModuleRcd& iRe
 
   auto quality = std::make_unique<SiStripQuality>();
 
-  SiStripDetInfoFileReader reader{m_file.fullPath()};
-
-  std::vector<uint32_t> selDetIds{selectDetectors(tTopo.product(), reader.getAllDetIds())};
+  const edm::Service<SiStripDetInfoFileReader> reader;
+  std::vector<uint32_t> selDetIds{selectDetectors(tTopo.product(), reader->getAllDetIds())};
   edm::LogInfo("SiStripQualityConfigurableFakeESSource")<<"[produce] number of selected dets to be removed " << selDetIds.size() <<std::endl;
 
   std::stringstream ss;
@@ -85,7 +82,7 @@ SiStripBadModuleConfigurableFakeESSource::produce(const SiStripBadModuleRcd& iRe
     SiStripQuality::InputVector theSiStripVector;
 
     unsigned short firstBadStrip{0};
-    unsigned short NconsecutiveBadStrips = reader.getNumberOfApvsAndStripLength(selId).first * 128;
+    unsigned short NconsecutiveBadStrips = reader->getNumberOfApvsAndStripLength(selId).first * 128;
     unsigned int theBadStripRange{quality->encode(firstBadStrip,NconsecutiveBadStrips)};
 
     if (m_printDebug) {

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripBaseDelayFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripBaseDelayFakeESSource.cc
@@ -35,7 +35,6 @@ public:
 private:
   uint16_t m_coarseDelay;
   uint16_t m_fineDelay;
-  edm::FileInPath m_file;
 };
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -48,7 +47,6 @@ SiStripBaseDelayFakeESSource::SiStripBaseDelayFakeESSource(const edm::ParameterS
 
   m_coarseDelay = iConfig.getParameter<uint32_t>("CoarseDelay");
   m_fineDelay = iConfig.getParameter<uint32_t>("FineDelay");
-  m_file = iConfig.getParameter<edm::FileInPath>("file");
 }
 
 SiStripBaseDelayFakeESSource::~SiStripBaseDelayFakeESSource() {}
@@ -66,13 +64,12 @@ SiStripBaseDelayFakeESSource::produce(const SiStripBaseDelayRcd& iRecord)
 
   auto baseDelay = std::make_unique<SiStripBaseDelay>();
 
-  SiStripDetInfoFileReader reader{m_file.fullPath()};
-
-  const auto& detInfos = reader.getAllData();
+  const edm::Service<SiStripDetInfoFileReader> reader;
+  const auto& detInfos = reader->getAllData();
   if ( detInfos.empty() ) {
     edm::LogError("SiStripBaseDelayGenerator") << "Error: detInfo map is empty.";
   }
-  for ( const auto& elm : reader.getAllData() ) {
+  for ( const auto& elm : reader->getAllData() ) {
     baseDelay->put(elm.first, m_coarseDelay, m_fineDelay);
   }
 

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripConfObjectFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripConfObjectFakeESSource.cc
@@ -34,7 +34,6 @@ public:
 
 private:
   std::vector<edm::ParameterSet> m_parameters;
-  edm::FileInPath m_file;
 };
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -45,7 +44,6 @@ SiStripConfObjectFakeESSource::SiStripConfObjectFakeESSource(const edm::Paramete
   findingRecord<SiStripConfObjectRcd>();
 
   m_parameters = iConfig.getParameter<std::vector<edm::ParameterSet>>("Parameters");
-  m_file = iConfig.getParameter<edm::FileInPath>("file");
 }
 
 SiStripConfObjectFakeESSource::~SiStripConfObjectFakeESSource() {}

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripFedCablingFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripFedCablingFakeESSource.cc
@@ -17,7 +17,6 @@ using namespace sistrip;
 //
 SiStripFedCablingFakeESSource::SiStripFedCablingFakeESSource( const edm::ParameterSet& pset )
   : SiStripFedCablingESProducer( pset ),
-    detIds_( pset.getParameter<edm::FileInPath>("DetIdsFile") ),
     fedIds_( pset.getParameter<edm::FileInPath>("FedIdsFile") ),
     pset_(pset)
 {
@@ -47,10 +46,10 @@ SiStripFedCabling* SiStripFedCablingFakeESSource::make( const SiStripFedCablingR
   SiStripFecCabling* fec_cabling = new SiStripFecCabling();
   
   // Read DetId list from file
-  SiStripDetInfoFileReader Detreader( detIds_.fullPath() );
+  const edm::Service<SiStripDetInfoFileReader> Detreader;
   typedef std::vector<uint32_t>  Dets;
   
-  Dets dets = Detreader.getAllDetIds();
+  Dets dets = Detreader->getAllDetIds();
   
   // Read FedId list from file
   typedef std::vector<uint16_t> Feds;
@@ -63,7 +62,7 @@ SiStripFedCabling* SiStripFedCablingFakeESSource::make( const SiStripFedCablingR
   Dets::const_iterator idet = dets.begin();
   Dets::const_iterator jdet = dets.end();
   for ( ; idet != jdet; ++idet ) {
-    uint16_t npairs =  Detreader.getNumberOfApvsAndStripLength(*idet).first / 2;
+    uint16_t npairs =  Detreader->getNumberOfApvsAndStripLength(*idet).first / 2;
     for ( uint16_t ipair = 0; ipair < npairs; ++ipair ) {
       uint16_t addr = 0;
       if      ( npairs == 2 && ipair == 0 ) { addr = 32; }

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripFedCablingFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripFedCablingFakeESSource.h
@@ -32,9 +32,6 @@ class SiStripFedCablingFakeESSource : public SiStripFedCablingESProducer, public
   /** Builds cabling map based on ascii files. */
   SiStripFedCabling* make( const SiStripFedCablingRcd& ) override; 
 
-  /** Location of ascii file containing DetIds. */
-  edm::FileInPath detIds_;
-
   /** Location of ascii file containing FedIds. */
   edm::FileInPath fedIds_;
   edm::ParameterSet pset_;

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripHashedDetIdFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripHashedDetIdFakeESSource.cc
@@ -12,8 +12,7 @@ using namespace sistrip;
 // -----------------------------------------------------------------------------
 //
 SiStripHashedDetIdFakeESSource::SiStripHashedDetIdFakeESSource( const edm::ParameterSet& pset )
-  : SiStripHashedDetIdESProducer( pset ),
-    detIds_( pset.getParameter<edm::FileInPath>("DetIdsFile") )
+  : SiStripHashedDetIdESProducer( pset )
 {
   findingRecord<SiStripHashedDetIdRcd>();
   edm::LogVerbatim("HashedDetId") 
@@ -37,7 +36,8 @@ SiStripHashedDetId* SiStripHashedDetIdFakeESSource::make( const SiStripHashedDet
     << " Building \"fake\" hashed DetId map from ascii file";
   
   typedef std::map<uint32_t,SiStripDetInfoFileReader::DetInfo>  Dets;
-  Dets det_info = SiStripDetInfoFileReader( detIds_.fullPath() ).getAllData();
+  const edm::Service<SiStripDetInfoFileReader> reader;
+  Dets det_info = reader->getAllData();
   
   std::vector<uint32_t> dets;
   dets.reserve(16000);

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripHashedDetIdFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripHashedDetIdFakeESSource.h
@@ -32,9 +32,6 @@ class SiStripHashedDetIdFakeESSource : public SiStripHashedDetIdESProducer, publ
   /** Builds hashed DetId map based on ascii file. */
   SiStripHashedDetId* make( const SiStripHashedDetIdRcd& ) override; 
   
-  /** Location of ascii file containing DetIds. */
-  edm::FileInPath detIds_;
-  
 };
 
 #endif // CalibTracker_SiStripESProducers_SiStripHashedDetIdFakeESSource_H

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripLatencyFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripLatencyFakeESSource.cc
@@ -35,7 +35,6 @@ public:
 private:
   uint32_t m_latency;
   uint32_t m_mode;
-  edm::FileInPath m_file;
 };
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -48,7 +47,6 @@ SiStripLatencyFakeESSource::SiStripLatencyFakeESSource(const edm::ParameterSet& 
 
   m_latency = iConfig.getParameter<uint32_t>("latency");
   m_mode = iConfig.getParameter<uint32_t>("mode");
-  m_file = iConfig.getParameter<edm::FileInPath>("file");
 }
 
 SiStripLatencyFakeESSource::~SiStripLatencyFakeESSource() {}
@@ -66,8 +64,8 @@ SiStripLatencyFakeESSource::produce(const SiStripLatencyRcd& iRecord)
 
   auto latency = std::make_unique<SiStripLatency>();
 
-  SiStripDetInfoFileReader reader{m_file.fullPath()};
-  const auto& detInfos = reader.getAllData();
+  const edm::Service<SiStripDetInfoFileReader> reader;
+  const auto& detInfos = reader->getAllData();
   // Take the last detId. Since the map is sorted it will be the biggest value
   if ( ! detInfos.empty() ) {
     // Set the apv number as 6, the highest possible

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripLorentzAngleFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripLorentzAngleFakeESSource.cc
@@ -60,8 +60,6 @@ private:
   double m_TOBmeanPerCentError;
   double m_TIBmeanStdDev;
   double m_TOBmeanStdDev;
-
-  edm::FileInPath m_file;
 };
 
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -149,8 +147,6 @@ SiStripLorentzAngleFakeESSource::SiStripLorentzAngleFakeESSource(const edm::Para
   m_TOBmeanPerCentError = std::accumulate(m_TOB_PerCent_Errs.begin(), m_TOB_PerCent_Errs.end(), 0.)/double(m_TOB_PerCent_Errs.size());
   m_TIBmeanStdDev = (m_TIBmeanPerCentError/100)*m_TIBmeanValueMin;
   m_TOBmeanStdDev = (m_TOBmeanPerCentError/100)*m_TOBmeanValueMin;
-
-  m_file = iConfig.getParameter<edm::FileInPath>("file");
 }
 
 SiStripLorentzAngleFakeESSource::~SiStripLorentzAngleFakeESSource() {}
@@ -171,9 +167,8 @@ SiStripLorentzAngleFakeESSource::produce(const SiStripLorentzAngleRcd& iRecord)
 
   auto lorentzAngle = std::make_unique<SiStripLorentzAngle>();
 
-  SiStripDetInfoFileReader reader{m_file.fullPath()};
-
-  for ( const auto& detId : reader.getAllDetIds() ) {
+  const edm::Service<SiStripDetInfoFileReader> reader;
+  for ( const auto& detId : reader->getAllDetIds() ) {
     const DetId detectorId = DetId(detId);
     const int subDet = detectorId.subdetId();
 

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoiseNormalizedWithApvGainBuilder.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoiseNormalizedWithApvGainBuilder.cc
@@ -11,7 +11,6 @@
 #include <algorithm>
 
 SiStripNoiseNormalizedWithApvGainBuilder::SiStripNoiseNormalizedWithApvGainBuilder( const edm::ParameterSet& iConfig ):
-  fp_(iConfig.getUntrackedParameter<edm::FileInPath>("file",edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"))),
   printdebug_(iConfig.getUntrackedParameter<uint32_t>("printDebug",1)),
   pset_(iConfig),
   electronsPerADC_(0.),
@@ -36,9 +35,6 @@ void SiStripNoiseNormalizedWithApvGainBuilder::analyze(const edm::Event& evt, co
   // Prepare the new object
   SiStripNoises* obj = new SiStripNoises();
 
-  SiStripDetInfoFileReader reader(fp_.fullPath());
-
-
 
   stripLengthMode_ = pset_.getParameter<bool>("StripLengthMode");
   
@@ -54,8 +50,9 @@ void SiStripNoiseNormalizedWithApvGainBuilder::analyze(const edm::Event& evt, co
 
   printDebug_ = pset_.getUntrackedParameter<uint32_t>("printDebug", 5);
 
+  const edm::Service<SiStripDetInfoFileReader> reader;
   unsigned int count = 0;
-  const std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >& DetInfos = reader.getAllData();
+  const std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >& DetInfos = reader->getAllData();
   for(std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >::const_iterator it = DetInfos.begin(); it != DetInfos.end(); it++) {
 
     // Find if this DetId is in the input tag and if so how many are the Apvs for which it contains information

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoisesFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoisesFakeESSource.cc
@@ -41,7 +41,6 @@ private:
   double m_noisePar0;
   SiStripFakeAPVParameters m_noisePar1;
   SiStripFakeAPVParameters m_noisePar2;
-  edm::FileInPath m_file;
   uint32_t m_printDebug;
 };
 
@@ -78,7 +77,6 @@ SiStripNoisesFakeESSource::SiStripNoisesFakeESSource(const edm::ParameterSet& iC
     m_noisePar2 = SiStripFakeAPVParameters(iConfig, "NoiseStripLengthQuote");
   }
 
-  m_file = iConfig.getParameter<edm::FileInPath>("file");
   m_printDebug = iConfig.getUntrackedParameter<uint32_t>("printDebug", 5);
 }
 
@@ -100,10 +98,9 @@ SiStripNoisesFakeESSource::produce(const SiStripNoisesRcd& iRecord)
 
   auto noises = std::make_unique<SiStripNoises>();
 
-  SiStripDetInfoFileReader reader{m_file.fullPath()};
-
+  const edm::Service<SiStripDetInfoFileReader> reader;
   uint32_t count{0};
-  for ( const auto& elm : reader.getAllData() ) {
+  for ( const auto& elm : reader->getAllData() ) {
     //Generate Noises for det detid
     SiStripNoises::InputVector theSiStripVector;
     SiStripFakeAPVParameters::index sl = SiStripFakeAPVParameters::getIndex(tTopo.product(), elm.first);

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripPedestalsFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripPedestalsFakeESSource.cc
@@ -34,7 +34,6 @@ public:
 
 private:
   uint32_t m_pedestalValue;
-  edm::FileInPath m_file;
   uint32_t m_printDebug;
 };
 
@@ -47,7 +46,6 @@ SiStripPedestalsFakeESSource::SiStripPedestalsFakeESSource(const edm::ParameterS
   findingRecord<SiStripPedestalsRcd>();
 
   m_pedestalValue = iConfig.getParameter<uint32_t>("PedestalValue");
-  m_file = iConfig.getParameter<edm::FileInPath>("file");
   m_printDebug = iConfig.getUntrackedParameter<uint32_t>("printDebug", 5);
 }
 
@@ -66,10 +64,9 @@ SiStripPedestalsFakeESSource::produce(const SiStripPedestalsRcd& iRecord)
 
   auto pedestals = std::make_unique<SiStripPedestals>();
 
-  SiStripDetInfoFileReader reader{m_file.fullPath()};
-
+  const edm::Service<SiStripDetInfoFileReader> reader;
   uint32_t count{0};
-  for ( const auto& elm : reader.getAllData() ) {
+  for ( const auto& elm : reader->getAllData() ) {
     //Generate Noises for det detid
     SiStripPedestals::InputVector theSiStripVector;
     for ( unsigned short j{0}; j < 128*elm.second.nApvs; ++j ) {

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripThresholdFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripThresholdFakeESSource.cc
@@ -36,7 +36,6 @@ private:
   float m_lTh;
   float m_hTh;
   float m_cTh;
-  edm::FileInPath m_file;
 };
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -50,7 +49,6 @@ SiStripThresholdFakeESSource::SiStripThresholdFakeESSource(const edm::ParameterS
   m_lTh = iConfig.getParameter<double>("LowTh");
   m_hTh = iConfig.getParameter<double>("HighTh");
   m_cTh = iConfig.getParameter<double>("ClusTh");
-  m_file = iConfig.getParameter<edm::FileInPath>("file");
 }
 
 SiStripThresholdFakeESSource::~SiStripThresholdFakeESSource() {}
@@ -68,9 +66,8 @@ SiStripThresholdFakeESSource::produce(const SiStripThresholdRcd& iRecord)
 
   auto threshold = std::make_unique<SiStripThreshold>();
 
-  SiStripDetInfoFileReader reader{m_file.fullPath()};
-
-  for ( const auto& elm : reader.getAllData() ) {
+  const edm::Service<SiStripDetInfoFileReader> reader;
+  for ( const auto& elm : reader->getAllData() ) {
     //Generate Thresholds for det detid
     SiStripThreshold::Container theSiStripVector;
     uint16_t strip=0;

--- a/CalibTracker/SiStripESProducers/python/SiStripHashedDetIdFakeESProducer_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/SiStripHashedDetIdFakeESProducer_cfi.py
@@ -1,7 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 
-SiStripHashedDetIdFakeESProducer = cms.ESSource("SiStripHashedDetIdFakeESProducer",
-    DetIds = cms.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat')
-)
-
-
+SiStripHashedDetIdFakeESProducer = cms.ESSource("SiStripHashedDetIdFakeESProducer")

--- a/CalibTracker/SiStripESProducers/python/SiStripQualityConfigurableFakeESSource_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/SiStripQualityConfigurableFakeESSource_cfi.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 siStripQualityConfigurableFakeESSource = cms.ESSource("SiStripQualityConfigurableFakeESSource",
     printDebug = cms.untracked.bool(False),
     appendToDataLabel = cms.string(''),
-    file = cms.untracked.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'),
     BadComponentList = cms.untracked.VPSet(cms.PSet(
         SubDet = cms.string('TIB'),  
         layer = cms.uint32(0),        ## SELECTION: layer = 1..4, 0(ALL)		    

--- a/CalibTracker/SiStripESProducers/python/fake/SiStripApvGainFakeESSource_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/fake/SiStripApvGainFakeESSource_cfi.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 siStripApvGainFakeESSource = cms.ESSource("SiStripApvGainFakeESSource",
                                           appendToDataLabel = cms.string(''),
-                                          file      = cms.FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"),
                                           genMode   = cms.string("default"),
                                           MeanGain  =cms.double(1.0),
                                           SigmaGain =cms.double(0.0),

--- a/CalibTracker/SiStripESProducers/python/fake/SiStripBackPlaneCorrectionFakeESSource_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/fake/SiStripBackPlaneCorrectionFakeESSource_cfi.py
@@ -3,6 +3,5 @@ import FWCore.ParameterSet.Config as cms
 siStripBackPlaneCorrectionFakeESSource = cms.ESSource("SiStripBackPlaneCorrectionFakeESSource",
         appendToDataLabel = cms.string(''),
         #BackPlaneCorrection values for each module geometry: IB1, IB2, OB1, OB2, W1A, W1B, W2A, W2B, W3A, W3B, W4, W5, W6, W7
-        BackPlaneCorrection_PerModuleGeometry = cms.vdouble(0.034, 0.034, 0.05, 0.05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
-        file = cms.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat')
+        BackPlaneCorrection_PerModuleGeometry = cms.vdouble(0.034, 0.034, 0.05, 0.05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
     )

--- a/CalibTracker/SiStripESProducers/python/fake/SiStripBadModuleConfigurableFakeESSource_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/fake/SiStripBadModuleConfigurableFakeESSource_cfi.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 siStripBadModuleConfigurableFakeESSource = cms.ESSource("SiStripBadModuleConfigurableFakeESSource",
         appendToDataLabel = cms.string(''),
         printDebug = cms.untracked.bool(False),
-        file = cms.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'),
         BadComponentList = cms.untracked.VPSet(
                 cms.PSet(
                 SubDet = cms.string('TIB'),  

--- a/CalibTracker/SiStripESProducers/python/fake/SiStripBaseDelayFakeESSource_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/fake/SiStripBaseDelayFakeESSource_cfi.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 
 siStripBaseDelayFakeESSource = cms.ESSource("SiStripBaseDelayFakeESSource",
 					    appendToDataLabel = cms.string(''),
-                                            file = cms.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'),
                                             CoarseDelay = cms.uint32(0),
                                             FineDelay = cms.uint32(0)
 					   )

--- a/CalibTracker/SiStripESProducers/python/fake/SiStripFedCablingFakeESSource_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/fake/SiStripFedCablingFakeESSource_cfi.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 siStripFedCabling = cms.ESSource("SiStripFedCablingFakeESSource",
                                  FedIdsFile       = cms.FileInPath('CalibTracker/SiStripCommon/data/SiStripFedIdList.dat'),
-                                 DetIdsFile       = cms.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'),
                                  PopulateAllFeds  = cms.bool(False)
                                  )
 

--- a/CalibTracker/SiStripESProducers/python/fake/SiStripLatencyFakeESSource_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/fake/SiStripLatencyFakeESSource_cfi.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 
 siStripLatencyFakeESSource = cms.ESSource("SiStripLatencyFakeESSource",
                                          appendToDataLabel = cms.string(''),
-                                         file = cms.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'),
                                          latency = cms.uint32(1),
                                          mode = cms.uint32(37)
                                          )

--- a/CalibTracker/SiStripESProducers/python/fake/SiStripLorentzAngleFakeESSource_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/fake/SiStripLorentzAngleFakeESSource_cfi.py
@@ -18,6 +18,4 @@ siStripLorentzAngleFakeESSource = cms.ESSource("SiStripLorentzAngleFakeESSource"
        TOB_EstimatedValuesMax = cms.vdouble(0.021, 0.021, 0.021, 0.021, 0.021, 0.021),
        # TOB errors
        TOB_PerCent_Errs       = cms.vdouble(0.,    0.,    0.,    0.,    0.,    0.),
-       
-       file = cms.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'),         
    )

--- a/CalibTracker/SiStripESProducers/python/fake/SiStripNoisesFakeESSource_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/fake/SiStripNoisesFakeESSource_cfi.py
@@ -4,7 +4,6 @@ siStripNoisesFakeESSource = cms.ESSource("SiStripNoisesFakeESSource",
         appendToDataLabel = cms.string(''),
 
         printDebug = cms.untracked.uint32(5),
-        file = cms.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'),
 
         StripLengthMode = cms.bool(True),
 

--- a/CalibTracker/SiStripESProducers/python/fake/SiStripPedestalsFakeESSource_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/fake/SiStripPedestalsFakeESSource_cfi.py
@@ -4,6 +4,5 @@ siStripPedestalsFakeESSource = cms.ESSource("SiStripPedestalsFakeESSource",
                                             appendToDataLabel = cms.string(''),
                                             #
                                             printDebug = cms.untracked.uint32(5),
-                                            PedestalsValue = cms.uint32(30),
-                                            file = cms.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'),
+                                            PedestalsValue = cms.uint32(30)
                                             )

--- a/CalibTracker/SiStripESProducers/python/fake/SiStripThresholdFakeESSource_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/fake/SiStripThresholdFakeESSource_cfi.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 siStripThresholdFakeESSource = cms.ESSource("SiStripThresholdFakeESSource",
                                             appendToDataLabel = cms.string(''),
-                                            file   = cms.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'),
                                             HighTh = cms.double(5.0),
                                             LowTh  = cms.double(2.0),
                                             ClusTh = cms.double(0.0)

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripApvGain_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripApvGain_cfg.py
@@ -23,6 +23,7 @@ process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32(1)
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripApvGainFakeESSource_cfi")
 process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripApvGainDummyDBWriter_cfi")
 from CalibTracker.SiStripESProducers.fake.SiStripApvGainFakeESSource_cfi import siStripApvGainFakeESSource

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBackPlaneCorrection_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBackPlaneCorrection_cfg.py
@@ -25,6 +25,7 @@ process.source = cms.Source("EmptySource",
 
 process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripBackPlaneCorrectionFakeESSource_cfi")
 process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripBackPlaneCorrectionDummyDBWriter_cfi")
 

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBadModule_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBadModule_cfg.py
@@ -23,6 +23,7 @@ process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32(1)
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripBadModuleFakeESSource_cfi")
 process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripBadModuleDummyDBWriter_cfi")
 

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBaseDelay_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBaseDelay_cfg.py
@@ -24,6 +24,7 @@ process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32(1),
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripBaseDelayFakeESSource_cfi")
 process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripBaseDelayDummyDBWriter_cfi")
 

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripClusterThreshold_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripClusterThreshold_cfg.py
@@ -23,6 +23,7 @@ process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32(1)
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripThresholdFakeESSource_cfi")
 process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripThresholdDummyDBWriter_cfi")
 from CalibTracker.SiStripESProducers.fake.SiStripThresholdFakeESSource_cfi import siStripThresholdFakeESSource

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripFedCabling_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripFedCabling_cfg.py
@@ -23,6 +23,7 @@ process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32(1)
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripFedCablingFakeESSource_cfi")
 process.siStripFedCabling.PopulateAllFeds=cms.bool(False)
 process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripFedCablingDummyDBWriter_cfi")

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripLatency_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripLatency_cfg.py
@@ -24,6 +24,7 @@ process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32(1),
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripLatencyFakeESSource_cfi")
 process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripLatencyDummyDBWriter_cfi")
 

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripLorentzAngle_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripLorentzAngle_cfg.py
@@ -25,6 +25,7 @@ process.source = cms.Source("EmptySource",
 
 process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripLorentzAngleFakeESSource_cfi")
 process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripLorentzAngleDummyDBWriter_cfi")
 

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripNoises_DecMode_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripNoises_DecMode_cfg.py
@@ -23,6 +23,7 @@ process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32(1)
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripNoisesFakeESSource_cfi")
 process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripNoisesDummyDBWriter_cfi")
 

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripNoises_PeakMode_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripNoises_PeakMode_cfg.py
@@ -23,6 +23,7 @@ process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32(1)
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripNoisesFakeESSource_cfi")
 process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripNoisesDummyDBWriter_cfi")
 

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripNoises_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripNoises_cfg.py
@@ -23,6 +23,7 @@ process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32(1)
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripNoisesFakeESSource_cfi")
 process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripNoisesDummyDBWriter_cfi")
 

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripPedestals_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripPedestals_cfg.py
@@ -23,6 +23,7 @@ process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32(1)
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripPedestalsFakeESSource_cfi")
 process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripPedestalsDummyDBWriter_cfi")
 

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripThreshold_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripThreshold_cfg.py
@@ -23,6 +23,7 @@ process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32(1)
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripThresholdFakeESSource_cfi")
 process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripThresholdDummyDBWriter_cfi")
 

--- a/CalibTracker/SiStripESProducers/test/python/SiStripBadComponentBuilder_byHand_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/SiStripBadComponentBuilder_byHand_cfg.py
@@ -22,6 +22,7 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 #Populate ES
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripBadModuleConfigurableFakeESSource_cfi")
 from CalibTracker.SiStripESProducers.fake.SiStripBadModuleConfigurableFakeESSource_cfi import siStripBadModuleConfigurableFakeESSource
 siStripBadModuleConfigurableFakeESSource.BadComponentList = cms.untracked.VPSet(   cms.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/SiStripNoiseNormalizedWithApvGainBuilder_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/SiStripNoiseNormalizedWithApvGainBuilder_cfg.py
@@ -45,10 +45,10 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     ))
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 from SimTracker.SiStripDigitizer.SiStripDigi_cfi import *
 process.prod = cms.EDFilter("SiStripNoiseNormalizedWithApvGainBuilder",
                             printDebug = cms.untracked.uint32(5),
-                            file = cms.untracked.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'),
                                                                           
                             StripLengthMode = cms.bool(True),
 

--- a/CalibTracker/SiStripESProducers/test/python/siStripBackPlaneCorrectionDepDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripBackPlaneCorrectionDepDummyPrinter_cfg.py
@@ -46,6 +46,7 @@ process.poolDBESSource = cms.ESSource("PoolDBESSource",
     )
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 #Latency producer
 process.load("CalibTracker.SiStripESProducers.fake.SiStripLatencyFakeESSource_cfi")
 from CalibTracker.SiStripESProducers.fake.SiStripLatencyFakeESSource_cfi import siStripLatencyFakeESSource

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTIB_firstIOV_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTIB_firstIOV_cfg.py
@@ -21,6 +21,7 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 #Populate ES
 process.load("CalibTracker.SiStripESProducers.fake.SiStripBadModuleConfigurableFakeESSource_cfi")
 from CalibTracker.SiStripESProducers.fake.SiStripBadModuleConfigurableFakeESSource_cfi import siStripBadModuleConfigurableFakeESSource

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTIB_secondIOV_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTIB_secondIOV_cfg.py
@@ -22,6 +22,7 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 #Populate ES
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripBadModuleConfigurableFakeESSource_cfi")
 from CalibTracker.SiStripESProducers.fake.SiStripBadModuleConfigurableFakeESSource_cfi import siStripBadModuleConfigurableFakeESSource
 siStripBadModuleConfigurableFakeESSource.BadComponentList = cms.untracked.VPSet(   cms.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTID_firstIOV_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTID_firstIOV_cfg.py
@@ -22,6 +22,7 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 #Populate ES
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripBadModuleConfigurableFakeESSource_cfi")
 from CalibTracker.SiStripESProducers.fake.SiStripBadModuleConfigurableFakeESSource_cfi import siStripBadModuleConfigurableFakeESSource
 siStripBadModuleConfigurableFakeESSource.BadComponentList = cms.untracked.VPSet(   cms.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTID_secondIOV_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTID_secondIOV_cfg.py
@@ -22,6 +22,7 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 #Populate ES
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripBadModuleConfigurableFakeESSource_cfi")
 from CalibTracker.SiStripESProducers.fake.SiStripBadModuleConfigurableFakeESSource_cfi import siStripBadModuleConfigurableFakeESSource
 siStripBadModuleConfigurableFakeESSource.BadComponentList = cms.untracked.VPSet(   cms.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripQualityESProducer_fromBadModuleConfigurableFakeESSource_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripQualityESProducer_fromBadModuleConfigurableFakeESSource_cfg.py
@@ -24,6 +24,7 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(100)
 )
 
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 process.load("CalibTracker.SiStripESProducers.fake.SiStripBadModuleConfigurableFakeESSource_cfi")
 
 process.load("CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi")


### PR DESCRIPTION
Minor change, suggested by @venturia and @avartak , in how the "fake" conditions producer access the DetId list from SiStripDetInfoFileReader: from reading it in every one of them to using `edm::Service` ([SiStripDetInfoFileReader](https://github.com/cms-sw/cmssw/blob/master/CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h) is thread safe, see the [services review twiki](https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedServicesReview#SiStripDetInfoFileReader)).
This avoids passing the file name to all fake producers used in a config, e.g. in the cosmic rack tracking setup.

CC: @mmusich @echabert @alesaggio @vidalm @OlivierBondu 