### PR TITLE
Remove low weight PUPPI particles

### DIFF
--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -259,11 +259,11 @@ std::vector<double> const & PuppiContainer::puppiWeights() {
             LogDebug("PuppiWeightError") << "====> Weight is nan : " << pWeight << " : pt " << fRecoParticles[i0].pt << " -- eta : " << fRecoParticles[i0].eta << " -- Value" << fVals[i0] << " -- id :  " << fRecoParticles[i0].id << " --  NAlgos: " << lNAlgos << std::endl;
         }
         //Basic Cuts
-        if(pWeight                         < fPuppiWeightCut) pWeight = 0;  //==> Elminate the low Weight stuff
         if(pWeight*fPFParticles[i0].pt()   < fPuppiAlgo[pPupId].neutralPt(fNPV) && fRecoParticles[i0].id == 0 ) pWeight = 0;  //threshold cut on the neutral Pt
+        if((fPtMax>0) && (fRecoParticles[i0].id == 0)) pWeight=min(max(pWeight,fPFParticles[i0].pt()/fPtMax),1.);
+        if(pWeight                         < fPuppiWeightCut) pWeight = 0;  //==> Elminate the low Weight stuff
         if(fInvert) pWeight = 1.-pWeight;
         //std::cout << "fRecoParticles[i0].pt = " <<  fRecoParticles[i0].pt << ", fRecoParticles[i0].charge = " << fRecoParticles[i0].charge << ", fRecoParticles[i0].id = " << fRecoParticles[i0].id << ", weight = " << pWeight << std::endl;
-        if((fPtMax>0) && (fRecoParticles[i0].id == 0)) pWeight=min(max(pWeight,fPFParticles[i0].pt()/fPtMax),1.);
 
         fWeights .push_back(pWeight);
         fAlphaMed.push_back(fPuppiAlgo[pPupId].median());


### PR DESCRIPTION
This is a followup to #19587. While #19587 achieves the intended physics behavior, it unnecessarily kept particles below the PUPPI weight threshold. By changing the order of the applied cuts, those are removed.
The expected behavior is a reduction of the number of jet constituents for PUPPI jets in MiniAOD, all of them with weight <1% such that the physics performance, i.e. puppi jet momenta do not change signficantly.
The MiniAOD size is reduced (200 ttbar events without PU) as follows:

before
patJets_slimmedJetsPuppi__PAT. 15985.9 2209.08
patJets_slimmedJetsAK8__PAT. 6065.2 1313.88

after
patJets_slimmedJetsPuppi__PAT. 15393.1 2140.67
patJets_slimmedJetsAK8__PAT. 5996.57 1303.97