### PR TITLE
The use of the innerTrack is now protected with an if, also a cout ha…

### DIFF
--- a/DQMOffline/Muon/src/EfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/EfficiencyAnalyzer.cc
@@ -270,10 +270,11 @@ void EfficiencyAnalyzer::analyze(const edm::Event & iEvent,const edm::EventSetup
       h_allProbes_pt->Fill(muon2->pt());
       h_allProbes_eta->Fill(muon2->eta());
       h_allProbes_phi->Fill(muon2->phi());
-      h_allProbes_inner_pt->Fill(muon2->innerTrack()->innerMomentum().Rho());
-      h_allProbes_inner_eta->Fill(muon2->innerTrack()->innerPosition().Eta());
-      h_allProbes_inner_phi->Fill(muon2->innerTrack()->innerPosition().Phi());
-      
+      if(muon2->innerTrack().isNonnull()) {
+          h_allProbes_inner_pt->Fill(muon2->innerTrack()->innerMomentum().Rho());
+          h_allProbes_inner_eta->Fill(muon2->innerTrack()->innerPosition().Eta());
+          h_allProbes_inner_phi->Fill(muon2->innerTrack()->innerPosition().Phi());
+      }
       if (isMB)               h_allProbes_EB_pt->Fill(muon2->pt());
       if (isME)               h_allProbes_EE_pt->Fill(muon2->pt());
       if(muon2->pt() > 20 ) h_allProbes_hp_eta->Fill(muon2->eta());
@@ -288,9 +289,11 @@ void EfficiencyAnalyzer::analyze(const edm::Event & iEvent,const edm::EventSetup
       h_passProbes_ID_pt->Fill(muon2->pt());
       h_passProbes_ID_eta->Fill(muon2->eta());
       h_passProbes_ID_phi->Fill(muon2->phi());
-      h_passProbes_ID_inner_pt->Fill(muon2->innerTrack()->innerMomentum().Rho());
-      h_passProbes_ID_inner_eta->Fill(muon2->innerTrack()->innerPosition().Eta());
-      h_passProbes_ID_inner_phi->Fill(muon2->innerTrack()->innerPosition().Phi());
+      if(muon2->innerTrack().isNonnull()) {
+          h_passProbes_ID_inner_pt->Fill(muon2->innerTrack()->innerMomentum().Rho());
+          h_passProbes_ID_inner_eta->Fill(muon2->innerTrack()->innerPosition().Eta());
+          h_passProbes_ID_inner_phi->Fill(muon2->innerTrack()->innerPosition().Phi());
+      } 
       
       if (isMB) h_passProbes_ID_EB_pt->Fill(muon2->pt());
       if (isME) h_passProbes_ID_EE_pt->Fill(muon2->pt());

--- a/DQMOffline/Muon/src/EfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/EfficiencyAnalyzer.cc
@@ -270,7 +270,7 @@ void EfficiencyAnalyzer::analyze(const edm::Event & iEvent,const edm::EventSetup
       h_allProbes_pt->Fill(muon2->pt());
       h_allProbes_eta->Fill(muon2->eta());
       h_allProbes_phi->Fill(muon2->phi());
-      if(muon2->innerTrack().isNonnull()) {
+      if(muon2->innerTrack()->extra().isAvailable()) {
           h_allProbes_inner_pt->Fill(muon2->innerTrack()->innerMomentum().Rho());
           h_allProbes_inner_eta->Fill(muon2->innerTrack()->innerPosition().Eta());
           h_allProbes_inner_phi->Fill(muon2->innerTrack()->innerPosition().Phi());
@@ -289,7 +289,7 @@ void EfficiencyAnalyzer::analyze(const edm::Event & iEvent,const edm::EventSetup
       h_passProbes_ID_pt->Fill(muon2->pt());
       h_passProbes_ID_eta->Fill(muon2->eta());
       h_passProbes_ID_phi->Fill(muon2->phi());
-      if(muon2->innerTrack().isNonnull()) {
+      if(muon2->innerTrack()->extra().isAvailable()) {
           h_passProbes_ID_inner_pt->Fill(muon2->innerTrack()->innerMomentum().Rho());
           h_passProbes_ID_inner_eta->Fill(muon2->innerTrack()->innerPosition().Eta());
           h_passProbes_ID_inner_phi->Fill(muon2->innerTrack()->innerPosition().Phi());

--- a/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
@@ -455,10 +455,10 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
          if (pvIndex > -1) {
 	   refPoint = vertex->at(pvIndex).position();
          } else {
-	   if (&(*beamSpot)==NULL) {
+	   if(beamSpot.isValid()) {
 	     refPoint = beamSpot->position();
 	   } else {
-	     cout << "ERROR: No beam sport found!" << endl;
+	     edm::LogInfo("MuonRecoAnalyzer") << "ERROR: No beam sport found!" << endl;
 	   }
          }
       }


### PR DESCRIPTION
This PR corrects an issue discussed here:

https://github.com/cms-sw/cmssw/pull/22456#discussion_r182422868

In particular it corrects three things:

The innerTrack is tested to be "isnonNull()" before being used, otherwise the code is not executed.

The logic of the beamspot spotted before is now corrected to uses beamSpot().isValid()

One remaining cout has been replaced by a edm::Log

