### PR TITLE
fixes for AddOn Test Failures

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/interface/StraightTrajectory.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/StraightTrajectory.h
@@ -25,6 +25,12 @@ namespace fastsim
         */
         StraightTrajectory(const Particle & particle) : Trajectory(particle) {;}
 
+        //! Use Copy Constructor.
+        /*
+            \param trajectory StraightTrajectory does not have any special attribues so it can be copied right away
+        */
+        StraightTrajectory(const Trajectory & trajectory) : Trajectory(trajectory) {;}
+
         //! Check if an intersection of the trajectory with a barrel layer exists.
         /*!
             There is always an intersection between a straight line and a barrel layer unless the trajectory is parallel to z axis. In this case, the particle is not propagated anyways since it will not hit any detector material.

--- a/FastSimulation/SimplifiedGeometryPropagator/src/HelixTrajectory.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/HelixTrajectory.cc
@@ -147,7 +147,8 @@ double fastsim::HelixTrajectory::nextCrossingTimeC(const BarrelSimplifiedGeometr
     if(std::abs(layer.getRadius() - getRadParticle(phi1)) > 1.0e-2 
         || std::abs(layer.getRadius() - getRadParticle(phi2)) > 1.0e-2)
     {
-        return ((StraightTrajectory*) this)->nextCrossingTimeC(layer, onLayer);
+        StraightTrajectory traj(*((Trajectory*) this));
+        return traj.nextCrossingTimeC(layer, onLayer);
     }
 
     // if the particle is already on the layer, we need to make sure the 2nd solution is picked.

--- a/FastSimulation/SimplifiedGeometryPropagator/src/HelixTrajectory.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/HelixTrajectory.cc
@@ -147,7 +147,7 @@ double fastsim::HelixTrajectory::nextCrossingTimeC(const BarrelSimplifiedGeometr
     if(std::abs(layer.getRadius() - getRadParticle(phi1)) > 1.0e-2 
         || std::abs(layer.getRadius() - getRadParticle(phi2)) > 1.0e-2)
     {
-        StraightTrajectory traj(*((Trajectory*) this));
+        StraightTrajectory traj(*this);
         return traj.nextCrossingTimeC(layer, onLayer);
     }
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -91,7 +91,10 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextParticle(const 
         const HepPDT::ParticleData * particleData = particleDataTable_->particle(HepPDT::ParticleID(particle->pdgId()));
         if(!particleData)
         {
-            throw cms::Exception("fastsim::ParticleManager") << "unknown pdg id: " << particle->pdgId() << std::endl;
+            // in very few events the Decayer (pythia) produces high mass resonances that are for some reason not present in the table (even though they should technically be)
+            // they have short lifetimes, so decay them right away (charge and lifetime cannot be taken from table)
+            particle->setRemainingProperLifeTimeC(0.);
+            particle->setCharge(0.);
         }
 
         // set lifetime


### PR DESCRIPTION
Adressed two issues discussed in https://github.com/cms-sw/cmssw/issues/22721 that could lead to rare failures in case of large production samples.

-> Cast in HelixTrajectory did not work, so now explicitly included CopyConstructor
-> HepPDT::ParticleData does not contain information about some high mass resonances that are sometimes produced by the pythia decayer even though they should be according to [2]. They have short lifetimes so decay them again right away.

[2] http://pdg.lbl.gov/2007/reviews/montecarlorpp.pdf

