### PR TITLE
remove unnecessary import of particleFlowZeroSuppressionECAL in particleFlowRecHitECAL_cfi

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -1,6 +1,5 @@
 
 import FWCore.ParameterSet.Config as cms
-from RecoParticleFlow.PFClusterProducer.particleFlowZeroSuppressionECAL_cff import *
 
 #until we are actually clustering across the EB/EE boundary
 #it is faster to cluster EB and EE as separate


### PR DESCRIPTION
after switching to PFRecHitQTestDBThreshold, the import of particleFlowZeroSuppressionECAL is no longer necessary

