### PR TITLE
L1T DQM fix for ZS module

### DIFF
--- a/DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h
+++ b/DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h
@@ -60,6 +60,8 @@ class L1TMP7ZeroSupp : public DQMEDAnalyzer {
 
   int maxFedReadoutSize_;
 
+  bool checkOnlyCapIdsWithMasks_;
+
   std::string monitorDir_;
   bool verbose_;
 

--- a/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
+++ b/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
@@ -260,7 +260,6 @@ void L1TMP7ZeroSupp::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
         capIds_->Fill(blockCapId);
 
-        // fill the denominator histograms
         bool capIdDefined = false;
         if (zeroSuppValMap_.find(blockCapId) != zeroSuppValMap_.end()) {
           capIdDefined = true;
@@ -271,6 +270,7 @@ void L1TMP7ZeroSupp::analyze(const edm::Event& e, const edm::EventSetup& c) {
           continue;
         }
 
+        // fill the denominator histograms
         zeroSuppValMap_[maxMasks_]->Fill(BLOCKS);
         errorSummaryDenMap_[maxMasks_]->Fill(RBLKS);
         errorSummaryDenMap_[maxMasks_]->Fill(RBLKSFALSEPOS);

--- a/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
+++ b/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
@@ -16,14 +16,15 @@ L1TMP7ZeroSupp::L1TMP7ZeroSupp(const edm::ParameterSet& ps)
       zsFlagMask_(ps.getUntrackedParameter<int>("zsFlagMask")),
       dataInvFlagMask_(ps.getUntrackedParameter<int>("dataInvFlagMask")),
       maxFedReadoutSize_(ps.getUntrackedParameter<int>("maxFEDReadoutSize")),
+      checkOnlyCapIdsWithMasks_(ps.getUntrackedParameter<bool>("checkOnlyCapIdsWithMasks")),
       monitorDir_(ps.getUntrackedParameter<std::string>("monitorDir")),
       verbose_(ps.getUntrackedParameter<bool>("verbose"))
 {
-  std::vector<int> zeroMask(6, 0);
+  std::vector<int> onesMask(6, 0xffffffff);
   masks_.reserve(maxMasks_);
   for (unsigned int i = 0; i < maxMasks_; ++i) {
     std::string maskCapIdStr{"maskCapId"+std::to_string(i)};
-    masks_.push_back(ps.getUntrackedParameter<std::vector<int>>(maskCapIdStr, zeroMask));
+    masks_.push_back(ps.getUntrackedParameter<std::vector<int>>(maskCapIdStr, onesMask));
     // which masks are defined?
     if (ps.exists(maskCapIdStr)) {
       definedMaskCapIds_.push_back(i);
@@ -62,6 +63,7 @@ void L1TMP7ZeroSupp::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   for (unsigned int i = 0; i < maxMasks_; ++i) {
     desc.addOptionalUntracked<std::vector<int>>("maskCapId"+std::to_string(i))->setComment("ZS mask for caption id "+std::to_string(i)+".");
   }
+  desc.addUntracked<bool>("checkOnlyCapIdsWithMasks", true)->setComment("Check only blocks that have a CapId for which a mask is defined.");
   desc.addUntracked<std::string>("monitorDir", "")->setComment("Target directory in the DQM file. Will be created if not existing.");
   desc.addUntracked<bool>("verbose", false);
   descriptions.add("l1tMP7ZeroSupp", desc);
@@ -260,12 +262,20 @@ void L1TMP7ZeroSupp::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
         // fill the denominator histograms
         bool capIdDefined = false;
+        if (zeroSuppValMap_.find(blockCapId) != zeroSuppValMap_.end()) {
+          capIdDefined = true;
+        }
+
+        // Only check blocks with a CapId that has a defined ZS mask.
+        if (checkOnlyCapIdsWithMasks_ and not capIdDefined) {
+          continue;
+        }
+
         zeroSuppValMap_[maxMasks_]->Fill(BLOCKS);
         errorSummaryDenMap_[maxMasks_]->Fill(RBLKS);
         errorSummaryDenMap_[maxMasks_]->Fill(RBLKSFALSEPOS);
         errorSummaryDenMap_[maxMasks_]->Fill(RBLKSFALSENEG);
-        if (zeroSuppValMap_.find(blockCapId) != zeroSuppValMap_.end()) {
-          capIdDefined = true;
+        if (capIdDefined) {
           zeroSuppValMap_[blockCapId]->Fill(BLOCKS);
           errorSummaryDenMap_[blockCapId]->Fill(RBLKS);
           errorSummaryDenMap_[blockCapId]->Fill(RBLKSFALSEPOS);


### PR DESCRIPTION
Adds config parameter to select if blocks with CapIds for which no mask was defined should be checked.
To avoid mismatches if ZS is activated for some CapIds but not for others.