### PR TITLE
Specify upgrade digi collections for HCAL TP emulation in offline DQM

### DIFF
--- a/L1Trigger/Configuration/python/ValL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/ValL1Emulator_cff.py
@@ -23,6 +23,7 @@ from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
 valHcalTriggerPrimitiveDigis = SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cfi.simHcalTriggerPrimitiveDigis.clone()
 #
 valHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(cms.InputTag('hcalDigis'),cms.InputTag('hcalDigis'))
+valHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(cms.InputTag('hcalDigis'),cms.InputTag('hcalDigis'))
 #
 # do not generate new LUTs when running on data, read them from DB
 HcalTPGCoderULUT.LUTGenerationMode = cms.bool(False)


### PR DESCRIPTION
The HCAL offline DQM runs on the HcalNZS stream, which contains events for which no zero suppression is applied to the HCAL raw data; such events are needed for validating the HCAL trigger primitive (TP) generation. This PR corrects the behavior of the TP emulation in the HCAL offline DQM. Currently the InputTags for digis in the upgraded portion of the HCAL (HE and HF) are not specified. This results in all of the emulated TPs being set to zero (table below, left column). After the change (right column), the emulated TPs are nonzero and good agreement is seen between data and emulated TPs. The setup for the tests can be found below [1], where in the "after" case this PR is merged as well.

Subdetector | Before changes | After changes
-- | ------------------ | -----------
HBHE | [ETCorr_HBHE_beforefix.pdf](https://github.com/cms-sw/cmssw/files/1938800/ETCorr_HBHE_beforefix.pdf) |  [ETCorr_HBHE_afterfix.pdf](https://github.com/cms-sw/cmssw/files/1938805/ETCorr_HBHE_afterfix.pdf)
HF | [ETCorr_HF_beforefix.pdf](https://github.com/cms-sw/cmssw/files/1938806/ETCorr_HF_beforefix.pdf) | [ETCorr_HF_afterfix.pdf](https://github.com/cms-sw/cmssw/files/1938808/ETCorr_HF_afterfix.pdf)



[1]
```
cmsrel CMSSW_10_2_0_pre1
cd CMSSW_10_2_0_pre1/src
cmsenv
git cms-addpkg Configuration/DataProcessing
scram b -j4
python $CMSSW_BASE/src/Configuration/DataProcessing/test/RunPromptReco.py --scenario hcalnzsEra_Run2_2018 --dqmSeq @common+@hcal --reco --dqmio --global-tag 101X_dataRun2_Prompt_v9 --lfn=file:/eos/cms/store/data/Commissioning2018/HcalNZS/RAW/v1/000/314/473/00000/5C2FF0C0-3742-E811-810B-FA163ED9F81E.root
cmsRun -e RunPromptRecoCfg.py
DQMIO2histo.py -in output_inDQMIO.root -o histos.root
```