### PR TITLE
[94XminiAOD][updated GT] Change HcalRespCorrs and updated BS

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '94X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '94X_dataRun2_v6',
+    'run1_data'         :   '94X_dataRun2_v7',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '94X_dataRun2_v6',
+    'run2_data'         :   '94X_dataRun2_v7',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '94X_dataRun2_relval_v11',
+    'run2_data_relval'  :   '94X_dataRun2_relval_v12',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '94X_dataRun2_PromptLike_v9',
     # GlobalTag for Run1 HLT: it points to the online GT


### PR DESCRIPTION
# Updated GTs [94X]
1) 94X_dataRun2_v6 -> 94X_dataRun2_v7
-  HcalRespCorrs_v6.5_offline
-  BeamSpotObjects_LumiBased_v4_offline
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_v6/94X_dataRun2_v7

2) 94X_dataRun2_relval_v11 -> 94X_dataRun2_relval_v12
-  HcalRespCorrs_v6.5_offline
-  BeamSpotObjects_LumiBased_v4_offline
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_relval_v11/94X_dataRun2_relval_v12