### PR TITLE
Adding dedicated CaloLayer2 shifter plots

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer2.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer2.h
@@ -44,6 +44,7 @@ class L1TStage2CaloLayer2 : public DQMEDAnalyzer {
   bool verbose_;
 
   MonitorElement* stage2CaloLayer2CenJetEtEtaPhi_;
+  MonitorElement* stage2CaloLayer2CenJetEtEtaPhi_shift_;
   MonitorElement* stage2CaloLayer2CenJetEta_;
   MonitorElement* stage2CaloLayer2CenJetPhi_;
   MonitorElement* stage2CaloLayer2CenJetRank_;
@@ -52,6 +53,7 @@ class L1TStage2CaloLayer2 : public DQMEDAnalyzer {
   MonitorElement* stage2CaloLayer2CenJetQual_;
 
   MonitorElement* stage2CaloLayer2ForJetEtEtaPhi_;
+  MonitorElement* stage2CaloLayer2ForJetEtEtaPhi_shift_;
   MonitorElement* stage2CaloLayer2ForJetEta_;
   MonitorElement* stage2CaloLayer2ForJetPhi_;
   MonitorElement* stage2CaloLayer2ForJetRank_;
@@ -62,6 +64,7 @@ class L1TStage2CaloLayer2 : public DQMEDAnalyzer {
   MonitorElement* stage2CaloLayer2EGIso_;
 
   MonitorElement* stage2CaloLayer2IsoEGEtEtaPhi_;
+  MonitorElement* stage2CaloLayer2IsoEGEtEtaPhi_shift_;
   MonitorElement* stage2CaloLayer2IsoEGEta_;
   MonitorElement* stage2CaloLayer2IsoEGPhi_;
   MonitorElement* stage2CaloLayer2IsoEGRank_;
@@ -70,6 +73,7 @@ class L1TStage2CaloLayer2 : public DQMEDAnalyzer {
   MonitorElement* stage2CaloLayer2IsoEGQual_;
 
   MonitorElement* stage2CaloLayer2NonIsoEGEtEtaPhi_;
+  MonitorElement* stage2CaloLayer2NonIsoEGEtEtaPhi_shift_;
   MonitorElement* stage2CaloLayer2NonIsoEGEta_;
   MonitorElement* stage2CaloLayer2NonIsoEGPhi_;
   MonitorElement* stage2CaloLayer2NonIsoEGRank_;
@@ -80,6 +84,7 @@ class L1TStage2CaloLayer2 : public DQMEDAnalyzer {
   MonitorElement* stage2CaloLayer2TauIso_;
 
   MonitorElement* stage2CaloLayer2IsoTauEtEtaPhi_;
+  MonitorElement* stage2CaloLayer2IsoTauEtEtaPhi_shift_;
   MonitorElement* stage2CaloLayer2IsoTauEta_;
   MonitorElement* stage2CaloLayer2IsoTauPhi_;
   MonitorElement* stage2CaloLayer2IsoTauRank_;
@@ -88,6 +93,7 @@ class L1TStage2CaloLayer2 : public DQMEDAnalyzer {
   MonitorElement* stage2CaloLayer2IsoTauQual_;
 
   MonitorElement* stage2CaloLayer2TauEtEtaPhi_;
+  MonitorElement* stage2CaloLayer2TauEtEtaPhi_shift_;
   MonitorElement* stage2CaloLayer2TauEta_;
   MonitorElement* stage2CaloLayer2TauPhi_;
   MonitorElement* stage2CaloLayer2TauRank_;

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer2.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer2.cc
@@ -121,12 +121,12 @@ void L1TStage2CaloLayer2::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
  
   //Shifter
   ibooker.setCurrentFolder(monitorDir_+"/shifter");
-  stage2CaloLayer2CenJetEtEtaPhi_shift_ = ibooker.book2D("CenJetsEtEtaPhi_shift", "CENTRAL JET E_{T} ETA PHI; Jet i#eta; Jet i#phi", 229, -65, 65, 144, -0.5, 143.5); 	
-  stage2CaloLayer2ForJetEtEtaPhi_shift_ = ibooker.book2D("ForJetsEtEtaPhi_shift", "FORWARD JET E_{T} ETA PHI; Jet i#eta; Jet i#phi", 229, -114.5, 114.5, 144, -0.5, 143.5);
-  stage2CaloLayer2IsoEGEtEtaPhi_shift_ = ibooker.book2D("IsoEGsEtEtaPhi_shift", "ISO EG E_{T} ETA PHI; i#eta; i#phi", 229, -114.5, 114.5, 144, -0.5, 143.5);
-  stage2CaloLayer2NonIsoEGEtEtaPhi_shift_ = ibooker.book2D("NonIsoEGsEtEtaPhi_shift", "NonISO EG E_{T} ETA PHI; i#eta; i#phi", 229, -114.5, 114.5, 144, -0.5, 143.5);	
-  stage2CaloLayer2IsoTauEtEtaPhi_shift_ = ibooker.book2D("IsoTausEtEtaPhi_shift", "ISO Tau E_{T} ETA PHI; i#eta; i#phi", 229, -114.5, 114.5, 144, -0.5, 143.5);
-  stage2CaloLayer2TauEtEtaPhi_shift_ = ibooker.book2D("TausEtEtaPhi_shift", "Tau E_{T} ETA PHI; i#eta; i#phi", 229, -114.5, 114.5, 144, -0.5, 143.5);
+  stage2CaloLayer2CenJetEtEtaPhi_shift_ = ibooker.book2D("CenJetsEtEtaPhi_shift", "CENTRAL JET E_{T} ETA PHI; Jet i#eta; Jet i#phi", 68, -68, 68, 144, -0.5, 143.5); 	
+  stage2CaloLayer2ForJetEtEtaPhi_shift_ = ibooker.book2D("ForJetsEtEtaPhi_shift", "FORWARD JET E_{T} ETA PHI; Jet i#eta; Jet i#phi", 115, -115, 115, 144, -0.5, 143.5);
+  stage2CaloLayer2IsoEGEtEtaPhi_shift_ = ibooker.book2D("IsoEGsEtEtaPhi_shift", "ISO EG E_{T} ETA PHI; i#eta; i#phi", 60, -60, 60, 72, -0.5, 143.5);
+  stage2CaloLayer2NonIsoEGEtEtaPhi_shift_ = ibooker.book2D("NonIsoEGsEtEtaPhi_shift", "NonISO EG E_{T} ETA PHI; i#eta; i#phi", 60, -60, 60, 72, -0.5, 143.5);	
+  stage2CaloLayer2IsoTauEtEtaPhi_shift_ = ibooker.book2D("IsoTausEtEtaPhi_shift", "ISO Tau E_{T} ETA PHI; i#eta; i#phi", 60, -60, 60, 72, -0.5, 143.5);
+  stage2CaloLayer2TauEtEtaPhi_shift_ = ibooker.book2D("TausEtEtaPhi_shift", "Tau E_{T} ETA PHI; i#eta; i#phi", 60, -60, 60, 72, -0.5, 143.5);
   
 }
 

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer2.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer2.cc
@@ -118,6 +118,16 @@ void L1TStage2CaloLayer2::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
   timingStage2CaloLayer2IsoTauBxOcc_ = stage2CaloLayer2TauBxOcc_;
   timingStage2CaloLayer2TauBxOcc_ = stage2CaloLayer2EtSumBxOcc_;
   timingStage2CaloLayer2EtSumBxOcc_ = stage2CaloLayer2EtSumBxOcc_;
+ 
+  //Shifter
+  ibooker.setCurrentFolder(monitorDir_+"/shifter");
+  stage2CaloLayer2CenJetEtEtaPhi_shift_ = ibooker.book2D("CenJetsEtEtaPhi_shift", "CENTRAL JET E_{T} ETA PHI; Jet i#eta; Jet i#phi", 229, -65, 65, 144, -0.5, 143.5); 	
+  stage2CaloLayer2ForJetEtEtaPhi_shift_ = ibooker.book2D("ForJetsEtEtaPhi_shift", "FORWARD JET E_{T} ETA PHI; Jet i#eta; Jet i#phi", 229, -114.5, 114.5, 144, -0.5, 143.5);
+  stage2CaloLayer2IsoEGEtEtaPhi_shift_ = ibooker.book2D("IsoEGsEtEtaPhi_shift", "ISO EG E_{T} ETA PHI; i#eta; i#phi", 229, -114.5, 114.5, 144, -0.5, 143.5);
+  stage2CaloLayer2NonIsoEGEtEtaPhi_shift_ = ibooker.book2D("NonIsoEGsEtEtaPhi_shift", "NonISO EG E_{T} ETA PHI; i#eta; i#phi", 229, -114.5, 114.5, 144, -0.5, 143.5);	
+  stage2CaloLayer2IsoTauEtEtaPhi_shift_ = ibooker.book2D("IsoTausEtEtaPhi_shift", "ISO Tau E_{T} ETA PHI; i#eta; i#phi", 229, -114.5, 114.5, 144, -0.5, 143.5);
+  stage2CaloLayer2TauEtEtaPhi_shift_ = ibooker.book2D("TausEtEtaPhi_shift", "Tau E_{T} ETA PHI; i#eta; i#phi", 229, -114.5, 114.5, 144, -0.5, 143.5);
+  
 }
 
 void L1TStage2CaloLayer2::analyze(const edm::Event & e, const edm::EventSetup & c)
@@ -139,6 +149,7 @@ void L1TStage2CaloLayer2::analyze(const edm::Event & e, const edm::EventSetup & 
 	  stage2CaloLayer2ForJetRank_->Fill(itJet->hwPt());
 	  if (itJet->hwPt() !=0 ){
 	    stage2CaloLayer2ForJetEtEtaPhi_->Fill(itJet->hwEta(), itJet->hwPhi(), itJet->hwPt());
+	    stage2CaloLayer2ForJetEtEtaPhi_shift_->Fill(itJet->hwEta(), itJet->hwPhi(), itJet->hwPt());
 	    stage2CaloLayer2ForJetOcc_->Fill(itJet->hwEta(), itJet->hwPhi());
             stage2CaloLayer2ForJetPhi_->Fill(itJet->hwPhi());
             stage2CaloLayer2ForJetEta_->Fill(itJet->hwEta());
@@ -152,6 +163,7 @@ void L1TStage2CaloLayer2::analyze(const edm::Event & e, const edm::EventSetup & 
 	  stage2CaloLayer2CenJetRank_->Fill(itJet->hwPt());
 	  if (itJet->hwPt() !=0 ){
 	    stage2CaloLayer2CenJetEtEtaPhi_->Fill(itJet->hwEta(), itJet->hwPhi(), itJet->hwPt());
+	    stage2CaloLayer2CenJetEtEtaPhi_shift_->Fill(itJet->hwEta(), itJet->hwPhi(), itJet->hwPt());
 	    stage2CaloLayer2CenJetOcc_->Fill(itJet->hwEta(), itJet->hwPhi());
             stage2CaloLayer2CenJetPhi_->Fill(itJet->hwPhi());
             stage2CaloLayer2CenJetEta_->Fill(itJet->hwEta());
@@ -175,6 +187,7 @@ void L1TStage2CaloLayer2::analyze(const edm::Event & e, const edm::EventSetup & 
 	  stage2CaloLayer2IsoEGRank_->Fill(itEG->hwPt());
 	  if(itEG->hwPt() !=0 ){
 	    stage2CaloLayer2IsoEGEtEtaPhi_->Fill(itEG->hwEta(), itEG->hwPhi(), itEG->hwPt());
+	    stage2CaloLayer2IsoEGEtEtaPhi_shift_->Fill(itEG->hwEta(), itEG->hwPhi(), itEG->hwPt());
 	    stage2CaloLayer2IsoEGOcc_->Fill(itEG->hwEta(), itEG->hwPhi());
             stage2CaloLayer2IsoEGPhi_->Fill(itEG->hwPhi());
             stage2CaloLayer2IsoEGEta_->Fill(itEG->hwEta());
@@ -189,7 +202,8 @@ void L1TStage2CaloLayer2::analyze(const edm::Event & e, const edm::EventSetup & 
 	  stage2CaloLayer2NonIsoEGRank_->Fill(itEG->hwPt());
 	  if(itEG->hwPt() !=0 ){
 	    stage2CaloLayer2NonIsoEGEtEtaPhi_->Fill(itEG->hwEta(), itEG->hwPhi(), itEG->hwPt());
-	    stage2CaloLayer2NonIsoEGOcc_->Fill(itEG->hwEta(), itEG->hwPhi());
+	    stage2CaloLayer2NonIsoEGEtEtaPhi_shift_->Fill(itEG->hwEta(), itEG->hwPhi(), itEG->hwPt());
+            stage2CaloLayer2NonIsoEGOcc_->Fill(itEG->hwEta(), itEG->hwPhi());
             stage2CaloLayer2NonIsoEGPhi_->Fill(itEG->hwPhi());
             stage2CaloLayer2NonIsoEGEta_->Fill(itEG->hwEta());
             stage2CaloLayer2NonIsoEGQual_->Fill(itEG->hwQual());
@@ -212,6 +226,7 @@ void L1TStage2CaloLayer2::analyze(const edm::Event & e, const edm::EventSetup & 
 	  stage2CaloLayer2IsoTauRank_->Fill(itTau->hwPt());
 	  if(itTau->hwPt() !=0 ){
 	    stage2CaloLayer2IsoTauEtEtaPhi_->Fill(itTau->hwEta(), itTau->hwPhi(), itTau->hwPt());
+	    stage2CaloLayer2IsoTauEtEtaPhi_shift_->Fill(itTau->hwEta(), itTau->hwPhi(), itTau->hwPt());
 	    stage2CaloLayer2IsoTauOcc_->Fill(itTau->hwEta(), itTau->hwPhi());
             stage2CaloLayer2IsoTauPhi_->Fill(itTau->hwPhi());
             stage2CaloLayer2IsoTauEta_->Fill(itTau->hwEta());
@@ -226,6 +241,7 @@ void L1TStage2CaloLayer2::analyze(const edm::Event & e, const edm::EventSetup & 
 	  stage2CaloLayer2TauRank_->Fill(itTau->hwPt());
 	  if(itTau->hwPt() !=0 ){
 	    stage2CaloLayer2TauEtEtaPhi_->Fill(itTau->hwEta(), itTau->hwPhi(), itTau->hwPt());
+            stage2CaloLayer2TauEtEtaPhi_shift_->Fill(itTau->hwEta(), itTau->hwPhi(), itTau->hwPt());
 	    stage2CaloLayer2TauOcc_->Fill(itTau->hwEta(), itTau->hwPhi());
             stage2CaloLayer2TauPhi_->Fill(itTau->hwPhi());
             stage2CaloLayer2TauEta_->Fill(itTau->hwEta());

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer2.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer2.cc
@@ -121,10 +121,10 @@ void L1TStage2CaloLayer2::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
  
   //Shifter
   ibooker.setCurrentFolder(monitorDir_+"/shifter");
-  stage2CaloLayer2CenJetEtEtaPhi_shift_ = ibooker.book2D("CenJetsEtEtaPhi_shift", "CENTRAL JET E_{T} ETA PHI; Jet i#eta; Jet i#phi", 68, -68, 68, 144, -0.5, 143.5); 	
-  stage2CaloLayer2ForJetEtEtaPhi_shift_ = ibooker.book2D("ForJetsEtEtaPhi_shift", "FORWARD JET E_{T} ETA PHI; Jet i#eta; Jet i#phi", 115, -115, 115, 144, -0.5, 143.5);
-  stage2CaloLayer2IsoEGEtEtaPhi_shift_ = ibooker.book2D("IsoEGsEtEtaPhi_shift", "ISO EG E_{T} ETA PHI; i#eta; i#phi", 60, -60, 60, 72, -0.5, 143.5);
-  stage2CaloLayer2NonIsoEGEtEtaPhi_shift_ = ibooker.book2D("NonIsoEGsEtEtaPhi_shift", "NonISO EG E_{T} ETA PHI; i#eta; i#phi", 60, -60, 60, 72, -0.5, 143.5);	
+  stage2CaloLayer2CenJetEtEtaPhi_shift_ = ibooker.book2D("CenJetsEtEtaPhi_shift", "CENTRAL JET E_{T} ETA PHI; Jet i#eta; Jet i#phi", 68, -68, 68, 72, -0.5, 143.5); 	
+  stage2CaloLayer2ForJetEtEtaPhi_shift_ = ibooker.book2D("ForJetsEtEtaPhi_shift", "FORWARD JET E_{T} ETA PHI; Jet i#eta; Jet i#phi", 58, -116, 116, 72, -0.5, 143.5);
+  stage2CaloLayer2IsoEGEtEtaPhi_shift_ = ibooker.book2D("IsoEGsEtEtaPhi_shift", "ISO EG E_{T} ETA PHI; i#eta; i#phi", 70, -70, 70, 72, -0.5, 143.5);
+  stage2CaloLayer2NonIsoEGEtEtaPhi_shift_ = ibooker.book2D("NonIsoEGsEtEtaPhi_shift", "NonISO EG E_{T} ETA PHI; i#eta; i#phi", 70, -70, 70, 72, -0.5, 143.5);	
   stage2CaloLayer2IsoTauEtEtaPhi_shift_ = ibooker.book2D("IsoTausEtEtaPhi_shift", "ISO Tau E_{T} ETA PHI; i#eta; i#phi", 60, -60, 60, 72, -0.5, 143.5);
   stage2CaloLayer2TauEtEtaPhi_shift_ = ibooker.book2D("TausEtEtaPhi_shift", "Tau E_{T} ETA PHI; i#eta; i#phi", 60, -60, 60, 72, -0.5, 143.5);
   

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer2.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer2.cc
@@ -122,7 +122,7 @@ void L1TStage2CaloLayer2::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
   //Shifter
   ibooker.setCurrentFolder(monitorDir_+"/shifter");
   stage2CaloLayer2CenJetEtEtaPhi_shift_ = ibooker.book2D("CenJetsEtEtaPhi_shift", "CENTRAL JET E_{T} ETA PHI; Jet i#eta; Jet i#phi", 68, -68, 68, 72, -0.5, 143.5); 	
-  stage2CaloLayer2ForJetEtEtaPhi_shift_ = ibooker.book2D("ForJetsEtEtaPhi_shift", "FORWARD JET E_{T} ETA PHI; Jet i#eta; Jet i#phi", 58, -116, 116, 72, -0.5, 143.5);
+  stage2CaloLayer2ForJetEtEtaPhi_shift_ = ibooker.book2D("ForJetsEtEtaPhi_shift", "FORWARD JET E_{T} ETA PHI; Jet i#eta; Jet i#phi", 58, -116, 116, 36, -0.5, 143.5);
   stage2CaloLayer2IsoEGEtEtaPhi_shift_ = ibooker.book2D("IsoEGsEtEtaPhi_shift", "ISO EG E_{T} ETA PHI; i#eta; i#phi", 70, -70, 70, 72, -0.5, 143.5);
   stage2CaloLayer2NonIsoEGEtEtaPhi_shift_ = ibooker.book2D("NonIsoEGsEtEtaPhi_shift", "NonISO EG E_{T} ETA PHI; i#eta; i#phi", 70, -70, 70, 72, -0.5, 143.5);	
   stage2CaloLayer2IsoTauEtEtaPhi_shift_ = ibooker.book2D("IsoTausEtEtaPhi_shift", "ISO Tau E_{T} ETA PHI; i#eta; i#phi", 60, -60, 60, 72, -0.5, 143.5);


### PR DESCRIPTION
Change requested in: https://its.cern.ch/jira/browse/CMSLITDPG-480
The online shifter plots 02-07 needed some work to make them more comprehensible for shifters and other non-experts (the old/expert plots are saved in the same location, while the new plots are placed under a new "shifter" folder).