### PR TITLE
Timing hgcal realistic sim pf

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
@@ -1,0 +1,119 @@
+// user include files
+#include <TH1F.h>
+#include <vector>
+
+
+// functions to select the hits to compute the time of a given cluster
+// start with the only hits with timing information
+// average among the hits contained in the chosen time interval
+
+// N.B. time is corrected wrt vtx-calorimeter distance 
+// with straight line and light speed hypothesis
+// for charged tracks or heavy particles (longer track length or beta < 1) 
+// need to correct the offset at analysis level
+
+
+
+//time-interval based on the smallest one containing a minimum fraction of hits
+float highestDensityFraction(std::vector<float>& hitTimes, float fractionToKeep=0.68 /*fraction between 0 and 1*/, float timeWidthBy=0.5){
+
+  std::sort(hitTimes.begin(), hitTimes.end());
+  int totSize = hitTimes.size();
+
+  int num = 0.;
+  float sum = 0.;
+
+  float minTimeDiff = 999.;
+  int startTimeBin = 0;
+  
+  int startBin = 0;
+  int endBin = totSize;
+  
+  for(int ij=0; ij<int(totSize*(1.-fractionToKeep)); ++ij){
+    float localDiff = fabs(hitTimes.at(ij) - hitTimes.at(int(ij+totSize*fractionToKeep)));
+    if(localDiff < minTimeDiff){
+      minTimeDiff = localDiff;
+      startTimeBin = ij;
+    }
+  }
+
+  // further adjust time width around the chosen one based on the hits density
+  // proved to improve the resolution: get as many hits as possible provided they are close in time
+  startBin = startTimeBin;
+  endBin = int(startBin+totSize*fractionToKeep);
+  float HalfTimeDiff = std::abs(hitTimes.at(startBin) - hitTimes.at(endBin)) * timeWidthBy;
+
+  for(int ij=0; ij<startBin; ++ij){  
+    if(hitTimes.at(ij) > (hitTimes.at(startBin) - HalfTimeDiff) ){
+      for(int kl=ij; kl<totSize; ++kl){   
+	if(hitTimes.at(kl) < (hitTimes.at(endBin) + HalfTimeDiff) ){	 	  
+	  sum += hitTimes.at(kl); 
+	  ++num;
+	}
+	else  break;                                                                                                                                                                                                          }
+      break;
+    }                                                                                                                                                                                                          
+  }
+  
+  if(num == 0) return -99.;  
+  return sum/num;
+}
+
+
+
+//time-interval based on that ~210ps wide and with the highest number of hits
+float fixSizeHighestDensity(std::vector<float>& t, float deltaT=0.210 /*time window in ns*/, float timeWidthBy=0.5){
+
+  float tolerance = 0.05f;
+  std::sort(t.begin(), t.end());
+  auto start = t.begin();
+  int max_elements = 0;
+  int start_el = 0;
+  int end_el = 0;
+  float timeW = 0.f;
+
+  while (start != t.end()) {
+    const auto startRef = *start;
+    int c = count_if(start, t.end(), [&](float el) {
+	return el - startRef <= deltaT + tolerance;
+      });
+    if (c > max_elements) {
+      max_elements = c;
+      auto last_el = find_if_not(start, t.end(), [&](float el) {
+	  return el - startRef <= deltaT + tolerance;
+	});
+      auto val = *(--last_el);
+      if (std::abs(deltaT - (val - startRef)) < tolerance) {
+        tolerance = std::abs(deltaT - (val - startRef));
+      }
+      start_el = distance(t.begin(), start);
+      end_el = distance(t.begin(), last_el);
+      timeW = val - startRef;
+    }
+    ++start;
+  }
+
+  // further adjust time width around the chosen one based on the hits density
+  // proved to improve the resolution: get as many hits as possible provided they are close in time
+  float HalfTimeDiff = timeW * timeWidthBy;
+
+  float sum = 0.;
+  int num = 0;
+  int totSize = t.size();
+
+  for(int ij=0; ij<=start_el; ++ij){
+    if(t.at(ij) > (t.at(start_el) - HalfTimeDiff) ){
+      for(int kl=ij; kl<totSize; ++kl){
+        if(t.at(kl) < (t.at(end_el) + HalfTimeDiff) ){
+          sum += t.at(kl);
+          ++num;
+        }
+        else  break;
+      }
+      break;
+    }
+  }
+
+  if(num == 0) return -99.;
+  return sum/num;
+}

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
@@ -103,7 +103,7 @@ namespace hgcalSimClusterTime {
     // proved to improve the resolution: get as many hits as possible provided they are close in time
 
     int startBin = startTimeBin;
-    int endBin = int(startBin+totToKeep);
+    int endBin = startBin+totToKeep;
     float HalfTimeDiff = std::abs(hitTimes[startBin] - hitTimes[endBin]) * timeWidthBy;
 
     for(int ij=0; ij<startBin; ++ij){

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
@@ -1,3 +1,6 @@
+#ifndef ComputeClusterTime_h
+#define ComputeClusterTime_h
+
 // user include files
 #include <vector>
 
@@ -13,110 +16,118 @@
 
 
 
-//time-interval based on the smallest one containing a minimum fraction of hits
-float highestDensityFraction(std::vector<float>& hitTimes, float fractionToKeep=0.68 /*fraction between 0 and 1*/, float timeWidthBy=0.5){
+namespace hgcalSimClusterTime {
 
-  std::sort(hitTimes.begin(), hitTimes.end());
-  int totSize = hitTimes.size();
+  //time-interval based on that ~210ps wide and with the highest number of hits
+  float fixSizeHighestDensity(std::vector<float>& t, float deltaT=0.210 /*time window in ns*/, float timeWidthBy=0.5){
 
-  int num = 0.;
-  float sum = 0.;
+    float tolerance = 0.05f;
+    std::sort(t.begin(), t.end());
 
-  float minTimeDiff = 999.;
-  int startTimeBin = 0;
-  
-  int startBin = 0;
-  int endBin = totSize;
+    int max_elements = 0;
+    int start_el = 0;
+    int end_el = 0;
+    float timeW = 0.f;
 
-  int totToKeep = int(totSize*fractionToKeep);
-  int maxStart = totSize - totToKeep;
-
-  for(int ij=0; ij<maxStart; ++ij){
-    float localDiff = fabs(hitTimes[ij] - hitTimes[int(ij+totToKeep)]);
-    if(localDiff < minTimeDiff){
-      minTimeDiff = localDiff;
-      startTimeBin = ij;
-    }
-  }
-
-  // further adjust time width around the chosen one based on the hits density
-  // proved to improve the resolution: get as many hits as possible provided they are close in time
-  startBin = startTimeBin;
-  endBin = int(startBin+totSize*fractionToKeep);
-  float HalfTimeDiff = std::abs(hitTimes[startBin] - hitTimes[endBin]) * timeWidthBy;
-
-  for(int ij=0; ij<startBin; ++ij){
-    if(hitTimes[ij] > (hitTimes[startBin] - HalfTimeDiff) ){
-      for(int kl=ij; kl<totSize; ++kl){
-        if(hitTimes[kl] < (hitTimes[endBin] + HalfTimeDiff) ){
-	  sum += hitTimes[kl];
-	  ++num;
-	}
-	else  break;
-      }
-      break;
-    }
-  }
-  
-  if(num == 0) return -99.;  
-  return sum/num;
-}
-
-
-
-//time-interval based on that ~210ps wide and with the highest number of hits
-float fixSizeHighestDensity(std::vector<float>& t, float deltaT=0.210 /*time window in ns*/, float timeWidthBy=0.5){
-
-  float tolerance = 0.05f;
-  std::sort(t.begin(), t.end());
-  auto start = t.begin();
-  int max_elements = 0;
-  int start_el = 0;
-  int end_el = 0;
-  float timeW = 0.f;
-
-  while (start != t.end()) {
-    const auto startRef = *start;
-    int c = count_if(start, t.end(), [&](float el) {
-	return el - startRef <= deltaT + tolerance;
-      });
-    if (c > max_elements) {
-      max_elements = c;
-      auto last_el = find_if_not(start, t.end(), [&](float el) {
+    for(auto start = t.begin(); start != t.end(); ++start) {
+      const auto startRef = *start;
+      int c = count_if(start, t.end(), [&](float el) {
 	  return el - startRef <= deltaT + tolerance;
 	});
-      auto val = *(--last_el);
+      if (c > max_elements) {
+	max_elements = c;
+	auto last_el = find_if_not(start, t.end(), [&](float el) {
+	    return el - startRef <= deltaT + tolerance;
+	  });
+	auto val = *(--last_el);
       if (std::abs(deltaT - (val - startRef)) < tolerance) {
         tolerance = std::abs(deltaT - (val - startRef));
       }
       start_el = distance(t.begin(), start);
       end_el = distance(t.begin(), last_el);
       timeW = val - startRef;
-    }
-    ++start;
-  }
-
-  // further adjust time width around the chosen one based on the hits density
-  // proved to improve the resolution: get as many hits as possible provided they are close in time
-  float HalfTimeDiff = timeW * timeWidthBy;
-
-  float sum = 0.;
-  int num = 0;
-  int totSize = t.size();
-
-  for(int ij=0; ij<=start_el; ++ij){
-    if(t[ij] > (t[start_el] - HalfTimeDiff) ){
-      for(int kl=ij; kl<totSize; ++kl){
-        if(t[kl] < (t[end_el] + HalfTimeDiff) ){
-          sum += t[kl];
-          ++num;
-        }
-        else  break;
       }
-      break;
     }
+
+    // further adjust time width around the chosen one based on the hits density
+    // proved to improve the resolution: get as many hits as possible provided they are close in time
+    float HalfTimeDiff = timeW * timeWidthBy;
+
+    float sum = 0.;
+    int num = 0;
+    int totSize = t.size();
+
+    for(int ij=0; ij<=start_el; ++ij){
+      if(t[ij] > (t[start_el] - HalfTimeDiff) ){
+	for(int kl=ij; kl<totSize; ++kl){
+	  if(t[kl] < (t[end_el] + HalfTimeDiff) ){
+	    sum += t[kl];
+	    ++num;
+	  }
+	  else  break;
+      }
+	break;
+      }
+    }
+
+    if(num == 0) return -99.;
+    return sum/num;
   }
 
-  if(num == 0) return -99.;
-  return sum/num;
+
+
+  //useful for future developments - baseline for 0PU
+  /*
+  //time-interval based on the smallest one containing a minimum fraction of hits
+  // vector with time values of the hit; fraction between 0 and 1; how much furher enlarge the selected time window
+  float highestDensityFraction(std::vector<float>& hitTimes, float fractionToKeep=0.68, float timeWidthBy=0.5){
+
+    std::sort(hitTimes.begin(), hitTimes.end());
+    int totSize = hitTimes.size();
+
+    int num = 0.;
+    float sum = 0.;
+
+    float minTimeDiff = 999.;
+    int startTimeBin = 0;
+
+    int startBin = 0;
+    int endBin = totSize;
+
+    int totToKeep = int(totSize*fractionToKeep);
+    int maxStart = totSize - totToKeep;
+
+    for(int ij=0; ij<maxStart; ++ij){
+      float localDiff = fabs(hitTimes[ij] - hitTimes[int(ij+totToKeep)]);
+      if(localDiff < minTimeDiff){
+	minTimeDiff = localDiff;
+	startTimeBin = ij;
+      }
+    }
+
+    // further adjust time width around the chosen one based on the hits density
+    // proved to improve the resolution: get as many hits as possible provided they are close in time
+    startBin = startTimeBin;
+    endBin = int(startBin+totSize*fractionToKeep);
+    float HalfTimeDiff = std::abs(hitTimes[startBin] - hitTimes[endBin]) * timeWidthBy;
+
+    for(int ij=0; ij<startBin; ++ij){
+      if(hitTimes[ij] > (hitTimes[startBin] - HalfTimeDiff) ){
+	for(int kl=ij; kl<totSize; ++kl){
+	  if(hitTimes[kl] < (hitTimes[endBin] + HalfTimeDiff) ){
+	    sum += hitTimes[kl];
+	    ++num;
+	  }
+	  else  break;
+	}
+	break;
+      }
+    }
+
+    if(num == 0) return -99.;
+    return sum/num;
+  }
+  */
 }
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
@@ -16,7 +16,7 @@
 
 
 
-namespace hgcalSimClusterTime {
+namespace hgcalsimclustertime {
 
   //time-interval based on that ~210ps wide and with the highest number of hits
   float fixSizeHighestDensity(std::vector<float>& t, float deltaT=0.210 /*time window in ns*/, float timeWidthBy=0.5){

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
@@ -1,5 +1,4 @@
 // user include files
-#include <TH1F.h>
 #include <vector>
 
 
@@ -28,9 +27,12 @@ float highestDensityFraction(std::vector<float>& hitTimes, float fractionToKeep=
   
   int startBin = 0;
   int endBin = totSize;
-  
-  for(int ij=0; ij<int(totSize*(1.-fractionToKeep)); ++ij){
-    float localDiff = fabs(hitTimes.at(ij) - hitTimes.at(int(ij+totSize*fractionToKeep)));
+
+  int totToKeep = int(totSize*fractionToKeep);
+  int maxStart = totSize - totToKeep;
+
+  for(int ij=0; ij<maxStart; ++ij){
+    float localDiff = fabs(hitTimes[ij] - hitTimes[int(ij+totToKeep)]);
     if(localDiff < minTimeDiff){
       minTimeDiff = localDiff;
       startTimeBin = ij;
@@ -41,18 +43,19 @@ float highestDensityFraction(std::vector<float>& hitTimes, float fractionToKeep=
   // proved to improve the resolution: get as many hits as possible provided they are close in time
   startBin = startTimeBin;
   endBin = int(startBin+totSize*fractionToKeep);
-  float HalfTimeDiff = std::abs(hitTimes.at(startBin) - hitTimes.at(endBin)) * timeWidthBy;
+  float HalfTimeDiff = std::abs(hitTimes[startBin] - hitTimes[endBin]) * timeWidthBy;
 
-  for(int ij=0; ij<startBin; ++ij){  
-    if(hitTimes.at(ij) > (hitTimes.at(startBin) - HalfTimeDiff) ){
-      for(int kl=ij; kl<totSize; ++kl){   
-	if(hitTimes.at(kl) < (hitTimes.at(endBin) + HalfTimeDiff) ){	 	  
-	  sum += hitTimes.at(kl); 
+  for(int ij=0; ij<startBin; ++ij){
+    if(hitTimes[ij] > (hitTimes[startBin] - HalfTimeDiff) ){
+      for(int kl=ij; kl<totSize; ++kl){
+        if(hitTimes[kl] < (hitTimes[endBin] + HalfTimeDiff) ){
+	  sum += hitTimes[kl];
 	  ++num;
 	}
-	else  break;                                                                                                                                                                                                          }
+	else  break;
+      }
       break;
-    }                                                                                                                                                                                                          
+    }
   }
   
   if(num == 0) return -99.;  
@@ -102,10 +105,10 @@ float fixSizeHighestDensity(std::vector<float>& t, float deltaT=0.210 /*time win
   int totSize = t.size();
 
   for(int ij=0; ij<=start_el; ++ij){
-    if(t.at(ij) > (t.at(start_el) - HalfTimeDiff) ){
+    if(t[ij] > (t[start_el] - HalfTimeDiff) ){
       for(int kl=ij; kl<totSize; ++kl){
-        if(t.at(kl) < (t.at(end_el) + HalfTimeDiff) ){
-          sum += t.at(kl);
+        if(t[kl] < (t[end_el] + HalfTimeDiff) ){
+          sum += t[kl];
           ++num;
         }
         else  break;

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
@@ -1,5 +1,5 @@
-#ifndef ComputeClusterTime_h
-#define ComputeClusterTime_h
+#ifndef RecoParticleFlow_PFClusterProducer_ComputeClusterTime_h
+#define RecoParticleFlow_PFClusterProducer_ComputeClusterTime_h
 
 // user include files
 #include <vector>
@@ -40,19 +40,19 @@ namespace hgcalSimClusterTime {
 	    return el - startRef <= deltaT + tolerance;
 	  });
 	auto val = *(--last_el);
-      if (std::abs(deltaT - (val - startRef)) < tolerance) {
-        tolerance = std::abs(deltaT - (val - startRef));
-      }
-      start_el = distance(t.begin(), start);
-      end_el = distance(t.begin(), last_el);
-      timeW = val - startRef;
+	if (std::abs(deltaT - (val - startRef)) < tolerance) {
+	  tolerance = std::abs(deltaT - (val - startRef));
+	}
+	start_el = distance(t.begin(), start);
+	end_el = distance(t.begin(), last_el);
+	timeW = val - startRef;
       }
     }
 
     // further adjust time width around the chosen one based on the hits density
     // proved to improve the resolution: get as many hits as possible provided they are close in time
-    float HalfTimeDiff = timeW * timeWidthBy;
 
+    float HalfTimeDiff = timeW * timeWidthBy;
     float sum = 0.;
     int num = 0;
     int totSize = t.size();
@@ -65,7 +65,7 @@ namespace hgcalSimClusterTime {
 	    ++num;
 	  }
 	  else  break;
-      }
+	}
 	break;
       }
     }
@@ -73,7 +73,6 @@ namespace hgcalSimClusterTime {
     if(num == 0) return -99.;
     return sum/num;
   }
-
 
 
   //useful for future developments - baseline for 0PU
@@ -84,15 +83,10 @@ namespace hgcalSimClusterTime {
 
     std::sort(hitTimes.begin(), hitTimes.end());
     int totSize = hitTimes.size();
-
     int num = 0.;
     float sum = 0.;
-
     float minTimeDiff = 999.;
     int startTimeBin = 0;
-
-    int startBin = 0;
-    int endBin = totSize;
 
     int totToKeep = int(totSize*fractionToKeep);
     int maxStart = totSize - totToKeep;
@@ -107,8 +101,9 @@ namespace hgcalSimClusterTime {
 
     // further adjust time width around the chosen one based on the hits density
     // proved to improve the resolution: get as many hits as possible provided they are close in time
-    startBin = startTimeBin;
-    endBin = int(startBin+totSize*fractionToKeep);
+
+    int startBin = startTimeBin;
+    int endBin = int(startBin+totToKeep);
     float HalfTimeDiff = std::abs(hitTimes[startBin] - hitTimes[endBin]) * timeWidthBy;
 
     for(int ij=0; ij<startBin; ++ij){

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -10,9 +10,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
-#include "RealisticHitToClusterAssociator.h"
-#include "ComputeClusterTime.h"
-#include "RealisticCluster.h"
+#include "RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticHitToClusterAssociator.h"
+#include "RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h"
+#include "RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticCluster.h"
 
 #ifdef PFLOW_DEBUG
 #define LOGVERB(x) edm::LogVerbatim(x)

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -169,7 +169,7 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
                 }
             }
 	    //assign time if minimum number of hits
-	    if(timeHits.size() >= minNHitsforTiming_) timeRealisticSC = hgcalSimClusterTime::fixSizeHighestDensity(timeHits);
+	    if(timeHits.size() >= minNHitsforTiming_) timeRealisticSC = hgcalsimclustertime::fixSizeHighestDensity(timeHits);
 	}
         if (!back.hitsAndFractions().empty())
         {

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -11,6 +11,8 @@
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "RealisticHitToClusterAssociator.h"
+#include "ComputeClusterTime.h"
+#include "RealisticCluster.h"
 
 #ifdef PFLOW_DEBUG
 #define LOGVERB(x) edm::LogVerbatim(x)
@@ -116,6 +118,7 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
         reco::PFCluster& back = output.back();
         edm::Ref < std::vector<reco::PFRecHit> > seed;
         float energyCorrection = 1.f;
+        float timeRealisticSC = -99.;
         if (realisticClusters[ic].isVisible())
         {
             int pdgId = simClusters[ic].pdgId();
@@ -139,6 +142,8 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
                 }
 
             }
+	    std::vector<float> timeHits;
+	    timeHits.clear();
             const auto& hitsIdsAndFractions = realisticClusters[ic].hitsIdsAndFractions();
             for (const auto& idAndF : hitsIdsAndFractions)
             {
@@ -153,14 +158,26 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
                         highest_energy = hit_energy;
                         seed = ref;
                     }
+                    //select hits good for timing
+                    if(ref->time() > -1. ){
+		      int rhLayer = rhtools_.getLayerWithOffset(ref->detId());
+		      std::array<float,3> scPosition = realisticClusters[ic].getCenterOfGravity(rhLayer);
+		      float distanceSquared = std::pow((ref->position().x() - scPosition[0]),2) + std::pow((ref->position().y() - scPosition[1]),2);
+		      if(distanceSquared < maxDforTimingSquared_){
+			timeHits.push_back(ref->time() - timeOffset_);
+		      }
+		    }
                 }
             }
-        }
+	    //assign time if minimum number of hits
+	    if(timeHits.size() >= minNHitsforTiming_) timeRealisticSC = fixSizeHighestDensity(timeHits);
+	}
         if (!back.hitsAndFractions().empty())
         {
             back.setSeed(seed->detId());
             back.setEnergy(realisticClusters[ic].getEnergy());
             back.setCorrectedEnergy(energyCorrection*realisticClusters[ic].getEnergy()); //applying energy correction
+	    back.setTime(timeRealisticSC);
         }
         else
         {

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -143,7 +143,6 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
 
             }
 	    std::vector<float> timeHits;
-	    timeHits.clear();
             const auto& hitsIdsAndFractions = realisticClusters[ic].hitsIdsAndFractions();
             for (const auto& idAndF : hitsIdsAndFractions)
             {
@@ -170,7 +169,7 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
                 }
             }
 	    //assign time if minimum number of hits
-	    if(timeHits.size() >= minNHitsforTiming_) timeRealisticSC = fixSizeHighestDensity(timeHits);
+	    if(timeHits.size() >= minNHitsforTiming_) timeRealisticSC = hgcalSimClusterTime::fixSizeHighestDensity(timeHits);
 	}
         if (!back.hitsAndFractions().empty())
         {

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -111,6 +111,9 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
 
     const auto& realisticClusters = realisticAssociator.realisticClusters();
     unsigned int nClusters = realisticClusters.size();
+    float bin_norm = 1. / (calibMaxEta_ - calibMinEta_);
+    float egamma_bin_norm = egammaCalib_.size() * bin_norm;
+    float hadron_bin_norm = hadronCalib_.size() * bin_norm;
     for (unsigned ic = 0; ic < nClusters; ++ic)
     {
         float highest_energy = 0.0f;
@@ -128,16 +131,13 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
                 if ((isEGamma(pdgId) or isPi0(pdgId)) and !egammaCalib_.empty())
                 {
                     unsigned int etabin = std::floor(
-                            ((abseta - calibMinEta_) * egammaCalib_.size())
-                                    / (calibMaxEta_ - calibMinEta_));
-
+                            ((abseta - calibMinEta_) * egamma_bin_norm));
                     energyCorrection = egammaCalib_[etabin];
                 }
                 else if (isHadron(pdgId) and !(isPi0(pdgId)) and !hadronCalib_.empty()) // this function is expensive.. should we treat as hadron everything which is not egamma?
                 {
                     unsigned int etabin = std::floor(
-                            ((abseta - calibMinEta_) * hadronCalib_.size())
-                                    / (calibMaxEta_ - calibMinEta_));
+                            ((abseta - calibMinEta_) * hadron_bin_norm));
                     energyCorrection = hadronCalib_[etabin];
                 }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
@@ -20,6 +20,9 @@ class RealisticSimClusterMapper : public InitialClusteringStepBase {
     exclusiveFraction_(conf.getParameter<double>("exclusiveFraction")),
     maxDistanceFilter_(conf.getParameter<bool>("maxDistanceFilter")),
     maxDistance_(conf.getParameter<double>("maxDistance")),
+    maxDforTimingSquared_(conf.getParameter<double>("maxDforTimingSquared")),
+    timeOffset_(conf.getParameter<double>("timeOffset")),
+    minNHitsforTiming_(conf.getParameter<unsigned int>("minNHitsforTiming")),
     useMCFractionsForExclEnergy_(conf.getParameter<bool>("useMCFractionsForExclEnergy")),
     calibMinEta_(conf.getParameter<double>("calibMinEta")),
     calibMaxEta_(conf.getParameter<double>("calibMaxEta"))
@@ -47,6 +50,9 @@ class RealisticSimClusterMapper : public InitialClusteringStepBase {
   const float exclusiveFraction_ = 0.7f;
   const bool maxDistanceFilter_ = false;
   const float maxDistance_ = 10.f;
+  const float maxDforTimingSquared_ = 4.0f;
+  const float timeOffset_;
+  const unsigned int minNHitsforTiming_ = 3;
   const bool useMCFractionsForExclEnergy_ = false;
   const float calibMinEta_ = 1.4;
   const float calibMaxEta_ = 3.0;

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from RecoParticleFlow.PFClusterProducer.particleFlowRealisticSimClusterHGCCalibrations_cfi import *
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import *
 #### PF CLUSTER HGCal ####
 
 #cleaning (none for now)
@@ -20,6 +21,9 @@ _simClusterMapper_HGCal = cms.PSet(
     maxDistanceFilter = cms.bool(True),
     #filtering out hits outside a cylinder of 10cm radius, built around the center of gravity per each layer
     maxDistance =  cms.double(10.0),
+    maxDforTimingSquared = cms.double(4.0),
+    timeOffset = hgceeDigitizer.tofDelay,
+    minNHitsforTiming = cms.uint32(3),
     useMCFractionsForExclEnergy = cms.bool(False),    
     thresholdsByDetector = cms.VPSet(
     ),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
@@ -24,13 +24,13 @@ _simClusterMapper_HGCal = cms.PSet(
     maxDforTimingSquared = cms.double(4.0),
     timeOffset = hgceeDigitizer.tofDelay,
     minNHitsforTiming = cms.uint32(3),
-    useMCFractionsForExclEnergy = cms.bool(False),    
+    useMCFractionsForExclEnergy = cms.bool(False),
     thresholdsByDetector = cms.VPSet(
     ),
     hadronCalib = hadronCorrections,
-    egammaCalib = egammaCorrections, 
-    calibMinEta = minEtaCorrection, 
-    calibMaxEta = maxEtaCorrection,                                   
+    egammaCalib = egammaCorrections,
+    calibMinEta = minEtaCorrection,
+    calibMaxEta = maxEtaCorrection,
     simClusterSrc = cms.InputTag("mix:MergedCaloTruth")
 )
 
@@ -38,7 +38,8 @@ _simClusterMapper_HGCal = cms.PSet(
 #position calculations
 _positionCalcPCA_HGCal = cms.PSet(
         algoName = cms.string("Cluster3DPCACalculator"),
-        minFractionInCalc = cms.double(1e-9)
+        minFractionInCalc = cms.double(1e-9),
+        updateTiming = cms.bool(False)
 )
 
 _hgcalMultiClusterMapper_HGCal = cms.PSet(


### PR DESCRIPTION
Introduce timing for realistic sim clusters, in HGCAL only.
Use algorithm optimized for TDR studies.
N.B. time is referred to the start of the BX, it is corrected for tof in the hypothesis of neutral and light particle: for longer track length and beta < 1 need offset correction at the analysis level

The timing for the hits in HGCAL is enabled in the PR #21957





Please refer to #22758 for the original PR and discussion therein.
#22758 can be closed.