### PR TITLE
[RFC] Define a Phase2_tracker_postTDR era for development purposes

### DIFF
--- a/Configuration/Eras/python/Era_Phase2_tracker_postTDR_cff.py
+++ b/Configuration/Eras/python/Era_Phase2_tracker_postTDR_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2_cff import Phase2
+from Configuration.Eras.Modifier_phase2_tracker_postTDR_cff import phase2_tracker_postTDR
+
+Phase2_tracker_postTDR = cms.ModifierChain(Phase2, phase2_tracker_postTDR)
+

--- a/Configuration/Eras/python/Modifier_phase2_tracker_postTDR_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_tracker_postTDR_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_tracker_postTDR =  cms.Modifier()
+

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -29,7 +29,8 @@ class Eras (object):
                  'Run3',
                  'Phase2',
                  'Phase2_timing',
-                 'Phase2_timing_layer']
+                 'Phase2_timing_layer',
+                 'Phase2_tracker_postTDR']
 
         internalUseMods = ['run2_common', 'run2_25ns_specific',
                            'run2_50ns_specific', 'run2_HI_specific',
@@ -40,7 +41,7 @@ class Eras (object):
                            'run3_HB', 'run3_common',
                            'phase1Pixel', 'run3_GEM', 'run2_GEM_2017',
                            'run2_CSC_2018',
-                           'phase2_common', 'phase2_tracker',
+                           'phase2_common', 'phase2_tracker', 'phase2_tracker_postTDR',
                            'phase2_hgcal', 'phase2_muon', 'phase2_timing',
                            'phase2_timing_layer','phase2_hcal',
                            'trackingLowPU', 'trackingPhase1', 'ctpps_2016', 'trackingPhase2PU140',

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -72,3 +72,16 @@ phase2_tracker.toModify(PixelCPEGenericESProducer,
   Upgrade = cms.bool(True)
 )
 
+
+from Configuration.Eras.Modifier_phase2_tracker_postTDR_cff import phase2_tracker_postTDR
+phase2_tracker_postTDR.toModify(PixelCPEGenericESProducer, 
+  useLAWidthFromDB = False,
+  UseErrorsFromTemplates = False,
+  LoadTemplatesFromDB = False,
+  TruncatePixelCharge = False,
+  IrradiationBiasCorrection = False,
+  DoCosmics = False,
+  Upgrade = cms.bool(True),
+  lAOffset = cms.double(0.0459)
+)
+

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -26,11 +26,6 @@ from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import phase2Tracke
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toReplaceWith(pixelDigitizer, _phase2TrackerDigitizer)
 
-# tracker phase2 post-TDR
-from Configuration.StandardSequences.Eras import eras
-eras.phase2_tracker_postTDR.toModify(_phase2TrackerDigitizer, PixelDigitizerAlgorithm  = dict(TanLorentzAnglePerTesla_Barrel = 0.0459))
-eras.phase2_tracker_postTDR.toModify(_phase2TrackerDigitizer, PixelDigitizerAlgorithm  = dict(TanLorentzAnglePerTesla_Endcap = 0.0459))
-
 from Configuration.Eras.Modifier_phase2_tracker_postTDR_cff import phase2_tracker_postTDR
 phase2_tracker_postTDR.toReplaceWith(pixelDigitizer, _phase2TrackerDigitizer)
 

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -22,6 +22,15 @@ premix_stage2.toModify(pixelDigitizer,
 )
 
 from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import phase2TrackerDigitizer as _phase2TrackerDigitizer
+
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toReplaceWith(pixelDigitizer, _phase2TrackerDigitizer)
+
+# tracker phase2 post-TDR
+from Configuration.StandardSequences.Eras import eras
+eras.phase2_tracker_postTDR.toModify(_phase2TrackerDigitizer, PixelDigitizerAlgorithm  = dict(TanLorentzAnglePerTesla_Barrel = 0.0459))
+eras.phase2_tracker_postTDR.toModify(_phase2TrackerDigitizer, PixelDigitizerAlgorithm  = dict(TanLorentzAnglePerTesla_Endcap = 0.0459))
+
+from Configuration.Eras.Modifier_phase2_tracker_postTDR_cff import phase2_tracker_postTDR
+phase2_tracker_postTDR.toReplaceWith(pixelDigitizer, _phase2TrackerDigitizer)
 

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -172,6 +172,15 @@ phase2TrackerDigitizer = cms.PSet(
     )
 )
 
+# tracker phase2 post-TDR
+from Configuration.StandardSequences.Eras import eras
+eras.phase2_tracker_postTDR.toModify(phase2TrackerDigitizer, 
+                                     PixelDigitizerAlgorithm  = dict(
+        TanLorentzAnglePerTesla_Barrel = 0.0459,
+        TanLorentzAnglePerTesla_Endcap = 0.0459
+        )
+)
+
 # TODO: values are copied from phase0/1 pixel configuration, they can be wrong
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 premix_stage1.toModify(phase2TrackerDigitizer,


### PR DESCRIPTION
In the context of the Tracker studies for phase2, we are investigating configurations of the digitizer(s) and of the local reco with parameters reflecting the evolution in the design of the detector hardware post-TDR.
The values of these parameters are not final yet but nevertheless we would like to have them in release as we would need to validate them on RelVal samples.
In order to keep in the same CMSSW release the TDR and the post-TDR settings, I would propose to introduce a "Tracker post-TDR" era. 
This PR enables to activate this post-TDR era from the cmsDriver command line option
'--era Phase2_tracker_postTDR' 
but I have not created the corresponding workflows yet.
Thanks in advance for the feedback on the strategy and on the way I have implemented.
Ernesto 

@kpedro88 @slava77: this it not for integration, only for discussion.
@pmaksim1 @boudoul FYI