### PR TITLE
don't create a new StringCutObjectSelector every event

### DIFF
--- a/HeavyFlavorAnalysis/Onia2MuMu/interface/OniaPhotonConversionProducer.h
+++ b/HeavyFlavorAnalysis/Onia2MuMu/interface/OniaPhotonConversionProducer.h
@@ -25,6 +25,7 @@
 #include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
 #include <vector>
 
@@ -74,7 +75,7 @@ class OniaPhotonConversionProducer : public edm::stream::EDProducer<> {
   std::vector<int>   convQuality_;
   
   std::string convSelectionCuts_;
-
+  std::unique_ptr<StringCutObjectSelector<reco::Conversion>> convSelection_;
 };
 
 #endif

--- a/HeavyFlavorAnalysis/Onia2MuMu/src/OniaPhotonConversionProducer.cc
+++ b/HeavyFlavorAnalysis/Onia2MuMu/src/OniaPhotonConversionProducer.cc
@@ -76,7 +76,7 @@ OniaPhotonConversionProducer:: OniaPhotonConversionProducer(const edm::Parameter
   convAlgo_ = StringToEnumValue<reco::Conversion::ConversionAlgorithm>(algo);
 
   std::vector<std::string> qual = ps.getParameter<std::vector<std::string> >("convQuality"); 
-  if( qual[0] != "" ) convQuality_ =StringToEnumValue<reco::Conversion::ConversionQuality>(qual);
+  if( !qual[0].empty() ) convQuality_ =StringToEnumValue<reco::Conversion::ConversionQuality>(qual);
 
   convSelectionCuts_ = ps.getParameter<std::string>("convSelection");
   convSelection_ = std::make_unique<StringCutObjectSelector<reco::Conversion>>(convSelectionCuts_);

--- a/HeavyFlavorAnalysis/Onia2MuMu/src/OniaPhotonConversionProducer.cc
+++ b/HeavyFlavorAnalysis/Onia2MuMu/src/OniaPhotonConversionProducer.cc
@@ -6,7 +6,6 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackBase.h"
 
-#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "CommonTools/Utils/interface/StringToEnumValue.h"
 #include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
 
@@ -80,6 +79,7 @@ OniaPhotonConversionProducer:: OniaPhotonConversionProducer(const edm::Parameter
   if( qual[0] != "" ) convQuality_ =StringToEnumValue<reco::Conversion::ConversionQuality>(qual);
 
   convSelectionCuts_ = ps.getParameter<std::string>("convSelection");
+  convSelection_ = std::make_unique<StringCutObjectSelector<reco::Conversion>>(convSelectionCuts_);
   produces<pat::CompositeCandidateCollection>("conversions");
 }
 
@@ -98,8 +98,6 @@ void OniaPhotonConversionProducer::produce(edm::Event& event, const edm::EventSe
   event.getByToken(pfCandidateCollectionToken_,pfcandidates);
 
   const reco::PFCandidateCollection pfphotons = selectPFPhotons(*pfcandidates);  
-
-  StringCutObjectSelector<reco::Conversion> *convSelection_ = new StringCutObjectSelector<reco::Conversion>(convSelectionCuts_);
 
   for(reco::ConversionCollection::const_iterator conv = pConv->begin(); conv != pConv->end(); ++conv){
 
@@ -175,8 +173,6 @@ void OniaPhotonConversionProducer::produce(edm::Event& event, const edm::EventSe
      }
   }
   event.put(std::move(patoutCollection),"conversions");
-
-  delete convSelection_;
 }
 
 int OniaPhotonConversionProducer::PackFlags(const reco::Conversion& conv, bool flagTkVtxCompatibility, 


### PR DESCRIPTION
OniaPhotonConversionProducer currently creates a new StringCutObjectSelector every event in the produce() method.  This is a relatively heavyweight operation that also has implications for scalability (because under the hood TClass::GetClass gets called, which acquires a ROOT global lock).  This PR moves the allocation of the StringCutObjectSelector to the constructor and improves the memory management.

No change to functionality.