### PR TITLE
Cache the mapping from type_info to TypeWithDict for use in ObjectWithDict::dynamicType()

### DIFF
--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -51,6 +51,7 @@ private:
   long property_;
 public:
   static TypeWithDict byName(std::string const& name);
+  static TypeWithDict byTypeInfo(std::type_info const& ti);
 private:
   static TypeWithDict byName(std::string const& name, long property);
 public:

--- a/FWCore/Utilities/src/ObjectWithDict.cc
+++ b/FWCore/Utilities/src/ObjectWithDict.cc
@@ -58,7 +58,7 @@ namespace edm {
     }
     // Use a dirty trick, force the typeid() operator
     // to consult the virtual table stored at address_.
-    return TypeWithDict(typeid(*(DummyVT*)address_));
+    return TypeWithDict::byTypeInfo(typeid(*(DummyVT*)address_));
   }
 
   ObjectWithDict

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -33,18 +33,18 @@
 namespace edm {
 
   namespace {
-    typedef tbb::concurrent_unordered_map<std::string, TypeWithDict> Map;
+    using Map = tbb::concurrent_unordered_map<std::string, TypeWithDict>;
     Map typeMap;
-    typedef tbb::concurrent_unordered_map<std::string, FunctionWithDict> FunctionMap;
+    using FunctionMap = tbb::concurrent_unordered_map<std::string, FunctionWithDict>;
     FunctionMap functionMap;
 
-    struct Hasher {
+    struct TypeIndexHash {
       std::size_t operator()(std::type_index ti) const {
         return ti.hash_code();
       }
     };
  
-    typedef tbb::concurrent_unordered_map<std::type_index, TypeWithDict, Hasher> TypeIndexMap;
+    using TypeIndexMap = tbb::concurrent_unordered_map<std::type_index, TypeWithDict, TypeIndexHash>;
     TypeIndexMap typeIndexMap;
   }
    static

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <ostream>
 #include <typeinfo>
+#include <typeindex>
 
 #include <cxxabi.h>
 
@@ -36,6 +37,15 @@ namespace edm {
     Map typeMap;
     typedef tbb::concurrent_unordered_map<std::string, FunctionWithDict> FunctionMap;
     FunctionMap functionMap;
+
+    struct Hasher {
+      std::size_t operator()(std::type_index ti) const {
+        return ti.hash_code();
+      }
+    };
+ 
+    typedef tbb::concurrent_unordered_map<std::type_index, TypeWithDict, Hasher> TypeIndexMap;
+    TypeIndexMap typeIndexMap;
   }
    static
    void throwTypeException(std::string const& function, std::string const& typeName) {
@@ -53,6 +63,19 @@ namespace edm {
          << "Also, if this class has any transient members,\n"
          << "you need to specify them in classes_def.xml.";
 
+   }
+
+   TypeWithDict
+   TypeWithDict::byTypeInfo(std::type_info const& ti) {
+     // This is a public static function.
+     auto index = std::type_index(ti);
+     auto const& item = typeIndexMap.find(index);
+     if(item != typeIndexMap.end()) {
+        return item->second;
+     }
+     TypeWithDict theType(ti, 0L);
+     typeIndexMap.insert(std::make_pair(index, theType));
+     return theType;
    }
 
   TypeWithDict


### PR DESCRIPTION
In "lazy" evaluation mode (which @Dr15Jones wishes people wouldn't use), the expression evaluator calls `ObjectWithDict::dynamicType()` on every evaluation to check for virtual function overrides.  That call creates a new `TypeWithDict` for the real type of the variable using its `std::type_info` and `TClass::GetClass()`.  `GetClass()` traverses the ROOT global class list, taking at least a read lock on the list, leading to stack traces like this:

```
#11 0x00007fefeb52120a in ROOT::TReadLockGuard::TReadLockGuard (this=0x7fefb4738c20, mutex=0x7fefcf9619e0) at include/TVirtualRWMutex.h:107
#12 0x00007fefeacb1efc in TClass::GetClass (typeinfo=..., load=true) at core/meta/src/TClass.cxx:3111
#13 0x00007fefeba1886c in edm::TypeWithDict::TypeWithDict(std::type_info const&, long) () from libFWCoreUtilities.so
#14 0x00007fefeb9f5ee0 in edm::ObjectWithDict::dynamicType() const () from libFWCoreUtilities.so
#15 0x00007fefcc05aa0f in reco::parser::LazyInvoker::invokeLast(edm::ObjectWithDict const&, std::vector<edm::ObjectWithDict, std::allocator<edm::ObjectWithDict> >&) const () from libCommonToolsUtils.so
#16 0x00007fefcc03cfe7 in reco::parser::ExpressionLazyVar::value(edm::ObjectWithDict const&) const () from libCommonToolsUtils.so
#17 0x00007fefcc05dd19 in reco::parser::BinarySelector::operator()(edm::ObjectWithDict const&) const () from libCommonToolsUtils.so
```

In random stack samples and in the profiling tool "vtune", these calls are one of the leading causes of ROOT lock contention in a standard RAW2DIGI,L1Reco,RECO,EI,PAT job.  This PR adds a map from `std::type_index` to `TypeWithDict`, which is used to cache the results of these lookups.  A new function `TypeWithDict::byTypeInfo()` populates and interrogates the map.

Currently only `ObjectWithDict::dynamicType()` has been modified to use this cache.  While other uses of the `TypeWithDict` constructors could be modified to use this, in practice this PR plus #23058 are, in my test workflow, sufficient to eliminate all per-event calls to `GetClass` due to `TypeWithDict` construction.

By removing potential lock contention for "lazy" uses of the cut parser, this PR improves the throughput and efficiency of my 24-core RECO  test job by a modest but consistent 3%.