### PR TITLE
Fix automated pixel pair mitigation to include "Fed25" information (10_1_X)

### DIFF
--- a/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaFinder.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaFinder.cc
@@ -503,7 +503,7 @@ PixelInactiveAreaFinder::PixelInactiveAreaFinder(const edm::ParameterSet& iConfi
 
 void PixelInactiveAreaFinder::fillDescriptions(edm::ParameterSetDescription& desc) {
   desc.add<std::vector<edm::InputTag>>("inactivePixelDetectorLabels", std::vector<edm::InputTag>{{edm::InputTag("siPixelDigis")}})->setComment("One or more DetIdCollections of modules to mask on the fly for a given event");
-  desc.add<std::vector<edm::InputTag>>("badPixelFEDChannelCollectionLabels", std::vector<edm::InputTag>())->setComment("One or more PixelFEDChannelCollections of modules+ROCs to mask on the fly for a given event");
+  desc.add<std::vector<edm::InputTag>>("badPixelFEDChannelCollectionLabels", std::vector<edm::InputTag>{{edm::InputTag("siPixelDigis")}})->setComment("One or more PixelFEDChannelCollections of modules+ROCs to mask on the fly for a given event");
   desc.add<bool>("ignoreSingleFPixPanelModules", false);
 
   desc.addUntracked<bool>("debug", false);


### PR DESCRIPTION
Backport of #23052. Original description

> The investigation of https://hypernews.cern.ch/HyperNews/CMS/get/recoTracking/1760.html lead to finding that the "Fed25" ("stuck TBM") information is not currently used in the automated pixel pair mitigation (an oversight in #21630?). This PR fixes the configuration to read the information.
> 
> Tested in 10_1_0, expecting changes (=more pixelPair tracks) in workflows processing data containing "Fed25" errors.

@VinInn 