### PR TITLE
First version of phase2 premixing

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -579,6 +579,7 @@ phase2_common.toModify(PREMIXEventContent, outputCommands = PREMIXEventContent.o
         'keep *_*_GEMStripDigiSimLink_*',
         # ME0
         'keep *_simMuonME0Digis_*_*',
+        'keep *_mix_g4SimHitsMuonME0Hits_*',
         'keep *_*_ME0DigiSimLink_*',
         'keep *_*_ME0StripDigiSimLink_*',
         # CaloParticles

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -575,8 +575,12 @@ phase2_common.toModify(PREMIXEventContent, outputCommands = PREMIXEventContent.o
         'keep *_simMuonRPCDigis_*_*',
         # GEM
         'keep *_simMuonGEMDigis_*_*',
+        'keep *_*_GEMDigiSimLink_*',
+        'keep *_*_GEMStripDigiSimLink_*',
         # ME0
         'keep *_simMuonME0Digis_*_*',
+        'keep *_*_ME0DigiSimLink_*',
+        'keep *_*_ME0StripDigiSimLink_*',
         # CaloParticles
         'keep *_mix_MergedCaloTruth_*',
 ])
@@ -754,6 +758,13 @@ from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 (premix_stage2 & phase2_tracker).toModify(FEVTDEBUGHLTEventContent, outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
     'keep *_*_Phase2OTDigiSimLink_*'
+])
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+(premix_stage2 & phase2_muon).toModify(FEVTDEBUGHLTEventContent, outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
+    'keep *_*_GEMDigiSimLink_*',
+    'keep *_*_GEMStripDigiSimLink_*',
+    'keep *_*_ME0DigiSimLink_*',
+    'keep *_*_ME0StripDigiSimLink_*',
 ])
 
 REPACKRAWSIMEventContent.outputCommands.extend(['drop FEDRawDataCollection_source_*_*',

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -552,6 +552,7 @@ from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(PREMIXEventContent, outputCommands = PREMIXEventContent.outputCommands+[
         # Tracker
         'keep Phase2TrackerDigiedmDetSetVector_mix_*_*',
+        'keep *_*_Phase2OTDigiSimLink_*',
         'keep *_simSiPixelDigis_*_*', # covers digis and digiSimLinks
         # MTD
         # ???
@@ -749,6 +750,12 @@ RECODEBUGEventContent.outputCommands.extend(RECOSIMEventContent.outputCommands)
 RECODEBUGEventContent.outputCommands.extend(SimGeneralFEVTDEBUG.outputCommands)
 RECODEBUGEventContent.outputCommands.extend(SimTrackerDEBUG.outputCommands)
 
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+(premix_stage2 & phase2_tracker).toModify(FEVTDEBUGHLTEventContent, outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
+    'keep *_*_Phase2OTDigiSimLink_*'
+])
+
 REPACKRAWSIMEventContent.outputCommands.extend(['drop FEDRawDataCollection_source_*_*',
                                                 'drop FEDRawDataCollection_rawDataCollector_*_*'])
 REPACKRAWEventContent.outputCommands.extend(['drop FEDRawDataCollection_source_*_*',
@@ -896,7 +903,6 @@ for _entry in [MINIAODEventContent, MINIAODSIMEventContent]:
     fastSim.toModify(_entry, outputCommands = _entry.outputCommands + fastSimEC.dropPatTrigger)
 
 
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 for _entry in [FEVTDEBUGEventContent,FEVTDEBUGHLTEventContent,FEVTEventContent]:
     phase2_tracker.toModify(_entry, outputCommands = _entry.outputCommands + [
         'keep Phase2TrackerDigiedmDetSetVector_mix_*_*',

--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -14,7 +14,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 
 #2023 WFs to run in IB (TTbar, TTbar+Timing)
 numWFIB = [20034.0,20034.1,20034.11] #2023D17 w/ special tracking and timing workflows
-numWFIB.extend([20261.98]) # 2023D17 premixing stage1 (NuGun+PU)
+numWFIB.extend([20261.97]) # 2023D17 premixing stage1 (NuGun+PU)
 numWFIB.extend([20434.0]) #2023D19 (already has timing)
 numWFIB.extend([21234.0,21234.11]) #2023D21  
 numWFIB.extend([21634.0]) #2023D22  

--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -15,6 +15,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #2023 WFs to run in IB (TTbar, TTbar+Timing)
 numWFIB = [20034.0,20034.1,20034.11] #2023D17 w/ special tracking and timing workflows
 numWFIB.extend([20261.97]) # 2023D17 premixing stage1 (NuGun+PU)
+numWFIB.extend([20234.99]) # 2023D17 premixing combined stage1+stage2 (ttbar+PU)
 numWFIB.extend([20434.0]) #2023D19 (already has timing)
 numWFIB.extend([21234.0,21234.11]) #2023D21  
 numWFIB.extend([21634.0]) #2023D22  

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2631,7 +2631,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
             if "GenSim" in step:
                 stepName = step + upgradeSteps['baseline']['suffix']
                 stepNamePmx = step.replace('GenSim', 'Premix') + 'PU' + upgradeSteps['Premix']['suffix']
-                d = merge([{'-s'            : 'GEN,SIM,DIGI:pdigi_valid,L1',
+                d = merge([{'-s'            : 'GEN,SIM,DIGI:pdigi_valid',
                             '--datatier'    : 'PREMIX',
                             '--eventcontent': 'PREMIX',
                             '--procModifiers': 'premix_stage1',

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2655,9 +2655,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                     if "Digi" in step:
                         tmpsteps = []
                         for s in d["-s"].split(","):
-                            if "L1TrackTrigger" in s: # TODO: ignore TrackTrigger for now
-                                continue
-
                             if s == "DIGI" or "DIGI:" in s:
                                 tmpsteps.extend([s, "DATAMIX"])
                             else:

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2432,6 +2432,7 @@ for stepType in upgradeSteps.keys():
         upgradeStepDict[stepName]={}
         stepNamePmx = step+'PUPRMX'+upgradeSteps[stepType]['suffix']
         upgradeStepDict[stepNamePmx]={}
+        upgradeStepDict[stepNamePmx+'Combined']={}
 
 # just make all combinations - yes, some will be nonsense.. but then these are not used unless specified above
 # collapse upgradeKeys using list comprehension
@@ -2669,6 +2670,9 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                         else:
                             d["--procModifiers"] = "premix_stage2"
                     upgradeStepDict[stepNamePUpmx][k] = d
+                    # For combined stage1+stage2
+                    if "Digi" in step:
+                        upgradeStepDict[stepNamePUpmx+"Combined"][k] = merge([digiPremixLocalPileup, d])
 
 for step in upgradeStepDict.keys():
     # we need to do this for each fragment

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -53,7 +53,9 @@ for year in upgradeKeys:
                         if not s in upgradeSteps[stepType]['PU']:
                             continue
                         s = s + 'PU' # later processing requires to have PU here
-                        stepList[stepType].append(stepMaker(key,frag[:-4],s,upgradeSteps[stepType]['suffix']))
+                        # Hardcode nu gun fragment below in order to use it for combined stage1+stage2
+                        # Anyway all other fragments are irrelevant for premixing stage1
+                        stepList[stepType].append(stepMaker(key,"SingleNuE10_cf",s,upgradeSteps[stepType]['suffix']))
                     elif (stepType is not 'baseline') and ( ('PU' in step and step.replace('PU','') in upgradeSteps[stepType]['PU']) or (step in upgradeSteps[stepType]['steps']) ):
                         stepList[stepType].append(stepMaker(key,frag[:-4],step,upgradeSteps[stepType]['suffix']))
                     else:
@@ -99,5 +101,12 @@ for year in upgradeKeys:
                         s = s.replace("PU", "PUPRMX", 1)
                     slist.append(s)
                 workflows[numWF+premixS2_offset] = [upgradeDatasetFromFragment[frag], slist]
+
+                # Combined stage1+stage2
+                workflows[numWF+premixS1S2_offset] = [upgradeDatasetFromFragment[frag], # Signal fragment
+                                                      [slist[0]] +                      # Start with signal generation
+                                                      stepList['Premix'] +              # Premixing stage1
+                                                      [slist[1].replace("PUPRMX", "PUPRMXCombined")] + # Premixing stage2, customized for the combined (defined in relval_steps.py)
+                                                      slist[2:]]                        # Remaining standard steps
 
             numWF+=1

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -181,6 +181,8 @@ upgradeSteps['Premix'] = {
 }
 # Premix stage2 is derived from baseline+PU in relval_upgrade.py
 premixS2_offset = 0.98
+# Premix combined stage1+stage2 is derived for Premix+PU and baseline+PU in relval_upgrade.py
+premixS1S2_offset = 0.99
 
 upgradeProperties = {}
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -177,10 +177,10 @@ upgradeSteps['Premix'] = {
         'PremixHLBeamSpotFull14',
     ],
     'suffix': '_Premix',
-    'offset': 0.98,
+    'offset': 0.97,
 }
 # Premix stage2 is derived from baseline+PU in relval_upgrade.py
-premixS2_offset = 0.99
+premixS2_offset = 0.98
 
 upgradeProperties = {}
 

--- a/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
@@ -57,6 +57,14 @@ hcalDigiSequenceDM = cms.Sequence(DMHcalTriggerPrimitiveDigis+DMHcalDigis*DMHcal
 
 postDMDigi = cms.Sequence(ecalDigiSequenceDM+hcalDigiSequenceDM)
 
+# GEM and ME0 have additional digi sequences
+from SimMuon.GEMDigitizer.muonGEMDigi_cff import muonGEMDigiDM
+from SimMuon.GEMDigitizer.muonME0Digi_cff import muonME0DigiDM
+_phase2_postDMDigi = postDMDigi.copy()
+_phase2_postDMDigi += (muonGEMDigiDM+muonME0DigiDM)
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+phase2_muon.toReplaceWith(postDMDigi, _phase2_postDMDigi)
+
 # disable adding noise to HCAL cells with no MC signal
 #mixData.doEmpty = False
 

--- a/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
@@ -14,6 +14,7 @@ from SimGeneral.PreMixingModule.mixOne_premix_on_sim_cfi import *
 # clone these sequences:
 
 DMEcalTriggerPrimitiveDigis = simEcalTriggerPrimitiveDigis.clone()
+DMEcalEBTriggerPrimitiveDigis = simEcalEBTriggerPrimitiveDigis.clone()
 DMEcalDigis = simEcalDigis.clone()
 DMEcalPreshowerDigis = simEcalPreshowerDigis.clone()
 
@@ -21,6 +22,8 @@ DMEcalPreshowerDigis = simEcalPreshowerDigis.clone()
 DMEcalTriggerPrimitiveDigis.Label = cms.string('mixData')
 DMEcalTriggerPrimitiveDigis.InstanceEB = cms.string('')
 DMEcalTriggerPrimitiveDigis.InstanceEE = cms.string('')
+#
+DMEcalEBTriggerPrimitiveDigis.barrelEcalDigis = 'mixData'
 #
 DMEcalDigis.digiProducer = cms.string('mixData')
 DMEcalDigis.EBdigiCollection = cms.string('')
@@ -31,6 +34,10 @@ DMEcalPreshowerDigis.digiProducer = cms.string('mixData')
 #DMEcalPreshowerDigis.ESdigiCollection = cms.string('ESDigiCollectionDM')
 
 ecalDigiSequenceDM = cms.Sequence(DMEcalTriggerPrimitiveDigis*DMEcalDigis*DMEcalPreshowerDigis)
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+_phase2_ecalDigiSequenceDM = ecalDigiSequenceDM.copy()
+_phase2_ecalDigiSequenceDM.insert(0,DMEcalEBTriggerPrimitiveDigis)
+phase2_common.toReplaceWith(ecalDigiSequenceDM, _phase2_ecalDigiSequenceDM)
 
 # same for Hcal:
 

--- a/Configuration/StandardSequences/python/DigiDM_cff.py
+++ b/Configuration/StandardSequences/python/DigiDM_cff.py
@@ -33,6 +33,7 @@ simMuonRPCDigis.Noise = False
 # remove unnecessary modules from 'pdigi' sequence - run after DataMixing
 # standard mixing module now makes unsuppressed digis for calorimeter
 pdigi.remove(simEcalTriggerPrimitiveDigis)
+pdigi.remove(simEcalEBTriggerPrimitiveDigis) # phase2
 pdigi.remove(simEcalDigis)  # does zero suppression
 pdigi.remove(simEcalPreshowerDigis)  # does zero suppression
 pdigi.remove(simHcalDigis)

--- a/Configuration/StandardSequences/python/SimL1EmulatorDM_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorDM_cff.py
@@ -12,6 +12,9 @@ simRpcTechTrigDigis.RPCDigiLabel = 'mixData'
 #
 simHcalTechTrigDigis.ttpDigiCollection = "DMHcalTTPDigis"
 #
+hgcalTriggerPrimitiveDigiProducer.eeDigis.setModuleLabel("mixData")
+hgcalTriggerPrimitiveDigiProducer.fhDigis.setModuleLabel("mixData")
+hgcalTriggerPrimitiveDigiProducer.bhDigis.setModuleLabel("mixData")
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 if not stage2L1Trigger.isChosen():

--- a/DQM/HcalTasks/python/OfflineSourceSequence_pp.py
+++ b/DQM/HcalTasks/python/OfflineSourceSequence_pp.py
@@ -42,3 +42,10 @@ phase2_hcal.toModify(digiPhase1Task,
     tagHO = cms.untracked.InputTag("simHcalDigis"),
     tagHF = cms.untracked.InputTag("simHcalDigis","HFQIE10DigiCollection")
 )
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+(premix_stage2 & phase2_hcal).toModify(digiPhase1Task,
+    tagHBHE = "DMHcalDigis:HBHEQIE11DigiCollection",
+    tagHO = "DMHcalDigis",
+    tagHF = "DMHcalDigis:HFQIE10DigiCollection"
+)

--- a/DataFormats/HGCDigi/interface/PHGCSimAccumulator.h
+++ b/DataFormats/HGCDigi/interface/PHGCSimAccumulator.h
@@ -69,10 +69,16 @@ public:
     data_.shrink_to_fit();
   }
 
+  /**
+   * Adds data for a given detId, energyIndex, and sampleIndex.
+   *
+   * It is the caller's responsibility to ensure that energyIndex,
+   * sampleIndex, and data fit in the space reserved for them in the
+   * Data bitfield above.
+   */
   void emplace_back(unsigned int detId, unsigned short energyIndex, unsigned short sampleIndex, unsigned short data) {
     assert( (detId >> DetId::kSubdetOffset) == detSubdetId_ );
 
-    // TODO: add checks
     if(detIdSize_.empty() || detIdSize_.back().detIdDetails() != (detId & DetIdSize::detIdMask)) {
       detIdSize_.emplace_back(detId);
     }

--- a/DataFormats/HGCDigi/interface/PHGCSimAccumulator.h
+++ b/DataFormats/HGCDigi/interface/PHGCSimAccumulator.h
@@ -1,0 +1,156 @@
+#ifndef DataFormats_HGCDigi_PHGCSimAccumulator_h
+#define DataFormats_HGCDigi_PHGCSimAccumulator_h
+
+#include "DataFormats/DetId/interface/DetId.h"
+
+#include <vector>
+#include <cassert>
+
+class PHGCSimAccumulator {
+public:
+  // These two structs are public only because of dictionary generation
+  class DetIdSize {
+  public:
+    // Use top 27 bits to hold the details of the DetId
+    constexpr static unsigned detIdOffset = 5;
+    constexpr static unsigned detIdMask = 0x7ffffff;
+    // Use the last 5 bits to index 2x15 elements
+    constexpr static unsigned sizeOffset = 27;
+    constexpr static unsigned sizeMask = 0x1f;
+    // With this arrangement increasing the size component is faster
+
+    DetIdSize(): detIdSize_(0) {}
+    DetIdSize(unsigned int detId): detIdSize_(detId << detIdOffset) {}
+
+    void increaseSize() {
+      assert(size()+1 < 1<<detIdOffset);
+      ++detIdSize_;
+    }
+
+    unsigned int detIdDetails() const { return detIdSize_ >> detIdOffset; }
+    unsigned int size() const { return detIdSize_ & sizeMask; }
+
+  private:
+    unsigned int detIdSize_;
+  };
+  class Data {
+  public:
+    constexpr static unsigned energyOffset = 15;
+    constexpr static unsigned energyMask = 0x1;
+    constexpr static unsigned sampleOffset = 11;
+    constexpr static unsigned sampleMask = 0xf;
+    constexpr static unsigned dataOffset = 0;
+    constexpr static unsigned dataMask = 0x7ff;
+
+    Data(): data_(0) {}
+    Data(unsigned short ei, unsigned short si, unsigned short d):
+      data_((ei << energyOffset) | (si << sampleOffset) | d)
+    {}
+
+    unsigned int energyIndex() const { return data_ >> energyOffset; }
+    unsigned int sampleIndex() const { return (data_ >> sampleOffset) & sampleMask; }
+    unsigned int data() const { return data_ & dataMask; }
+
+  private:
+    unsigned short data_;
+  };
+
+  PHGCSimAccumulator() = default;
+  PHGCSimAccumulator(unsigned int detId): detSubdetId_(detId >> DetId::kSubdetOffset) {}
+  ~PHGCSimAccumulator() = default;
+
+  void reserve(size_t size) {
+    detIdSize_.reserve(size);
+    data_.reserve(size);
+  }
+
+  void shrink_to_fit() {
+    detIdSize_.shrink_to_fit();
+    data_.shrink_to_fit();
+  }
+
+  void emplace_back(unsigned int detId, unsigned short energyIndex, unsigned short sampleIndex, unsigned short data) {
+    assert( (detId >> DetId::kSubdetOffset) == detSubdetId_ );
+
+    // TODO: add checks
+    if(detIdSize_.empty() || detIdSize_.back().detIdDetails() != (detId & DetIdSize::detIdMask)) {
+      detIdSize_.emplace_back(detId);
+    }
+    data_.emplace_back(energyIndex, sampleIndex, data);
+    detIdSize_.back().increaseSize();
+  }
+
+  class TmpElem {
+  public:
+    TmpElem(unsigned int detId, Data data): detId_(detId), data_(data) {}
+
+    unsigned int detId() const { return detId_; }
+    unsigned short energyIndex() const { return data_.energyIndex(); }
+    unsigned short sampleIndex() const { return data_.sampleIndex(); }
+    unsigned short data() const { return data_.data(); }
+  private:
+    unsigned int detId_;
+    Data data_;
+  };
+
+  class const_iterator {
+  public:
+    // begin
+    const_iterator(const PHGCSimAccumulator *acc):
+      acc_(acc), iDet_(0), iData_(0),
+      endData_(acc->detIdSize_.empty() ? 0 : acc->detIdSize_.front().size())
+    {}
+
+    // end
+    const_iterator(const PHGCSimAccumulator *acc, unsigned int detSize, unsigned int dataSize):
+      acc_(acc), iDet_(detSize), iData_(dataSize), endData_(0)
+    {}
+
+    bool operator==(const const_iterator& other) const {
+      return iDet_ == other.iDet_ && iData_ == other.iData_;
+    }
+    bool operator!=(const const_iterator& other) const {
+      return !operator==(other);
+    }
+    const_iterator& operator++() {
+      ++iData_;
+      if(iData_ == endData_) {
+        ++iDet_;
+        endData_ += (iDet_ == acc_->detIdSize_.size()) ? 0 : acc_->detIdSize_[iDet_].size();
+      }
+      return *this;
+    }
+    const_iterator operator++(int) {
+      auto tmp = *this;
+      ++(*this);
+      return tmp;
+    }
+    TmpElem operator*() {
+      return TmpElem((acc_->detSubdetId_ << DetId::kSubdetOffset) | acc_->detIdSize_[iDet_].detIdDetails(),
+                     acc_->data_[iData_]);
+    }
+
+  private:
+    const PHGCSimAccumulator *acc_;
+    unsigned int iDet_;
+    unsigned int iData_;
+    unsigned int endData_;
+  };
+
+  TmpElem back() const {
+    return TmpElem((detSubdetId_ << DetId::kSubdetOffset) | detIdSize_.back().detIdDetails(),
+                   data_.back());
+  }
+
+  const_iterator cbegin() const { return const_iterator(this); }
+  const_iterator begin() const { return cbegin(); }
+  const_iterator cend() const { return const_iterator(this, detIdSize_.size(), data_.size()); }
+  const_iterator end() const { return cend(); }
+
+private:
+  std::vector<DetIdSize> detIdSize_;
+  std::vector<Data> data_;
+  unsigned short detSubdetId_ = 0;
+};
+
+#endif

--- a/DataFormats/HGCDigi/src/classes.h
+++ b/DataFormats/HGCDigi/src/classes.h
@@ -1,5 +1,6 @@
 #include <vector>
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
+#include "DataFormats/HGCDigi/interface/PHGCSimAccumulator.h"
 
 namespace DataFormats_HGCDigi {
   struct dictionary {
@@ -33,6 +34,14 @@ namespace DataFormats_HGCDigi {
     edm::Wrapper< edm::SortedCollection< HGCDataFrame<HGCHEDetId,HGCSample> > > prodHGCHEDataFrames;
     HGCHEDigiCollection dcHGCHE;
     edm::Wrapper<HGCHEDigiCollection> wdcHGCHE;
+
+    // Sim cell accumulator (for premixing)
+    PHGCSimAccumulator saHGC;
+    PHGCSimAccumulator::Data saHGCdata;
+    PHGCSimAccumulator::DetIdSize saHGCdis;
+    std::vector<PHGCSimAccumulator::Data> vsaHGCdata;
+    std::vector<PHGCSimAccumulator::DetIdSize> vsaHGCdis;
+    edm::Wrapper<PHGCSimAccumulator> wsaHGC;
   };
 }
 

--- a/DataFormats/HGCDigi/src/classes_def.xml
+++ b/DataFormats/HGCDigi/src/classes_def.xml
@@ -27,4 +27,11 @@
    <class name="edm::SortedCollection<HGCDataFrame<HGCHEDetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<HGCHEDetId,HGCSample> > >"/>
    <class name="edm::Wrapper<edm::SortedCollection<HGCDataFrame<HGCHEDetId,HGCSample>,edm::StrictWeakOrdering<HGCDataFrame<HGCHEDetId,HGCSample> > > >" />
    <class name="edm::Wrapper<HGCHEDigiCollection>"/>
+
+   <class name="PHGCSimAccumulator"/>
+   <class name="PHGCSimAccumulator::Data"/>
+   <class name="PHGCSimAccumulator::DetIdSize"/>
+   <class name="std::vector<PHGCSimAccumulator::Data>"/>
+   <class name="std::vector<PHGCSimAccumulator::DetIdSize>"/>
+   <class name="edm::Wrapper<PHGCSimAccumulator>"/>
 </lcgdict>

--- a/DataFormats/WrappedStdDictionaries/src/classes.h
+++ b/DataFormats/WrappedStdDictionaries/src/classes.h
@@ -33,6 +33,7 @@ namespace DataFormats_WrappedStdDictionaries {
   edm::Wrapper<std::vector<std::pair<std::basic_string<char>,float> > > dummy16_0;
   edm::Wrapper<std::vector<std::pair<unsigned int,double> > > dummy16_1;
   edm::Wrapper<std::vector<std::pair<int,int>>> dummy16_2;
+  edm::Wrapper<std::vector<std::pair<unsigned int,float> > > dummy16_3;
 
   edm::Wrapper<std::list<int> > dummy17;
 

--- a/DataFormats/WrappedStdDictionaries/src/classes_def.xml
+++ b/DataFormats/WrappedStdDictionaries/src/classes_def.xml
@@ -47,6 +47,7 @@
  <class name="edm::Wrapper<std::vector<unsigned long long> >"/>
  <class name="edm::Wrapper<std::vector<unsigned short> >"/>
  <class name="edm::Wrapper<std::vector<std::pair<int,int>>>"/>
+ <class name="edm::Wrapper<std::vector<std::pair<unsigned int,float>>>"/>
  <class name="edm::Wrapper<unsigned char>"/>
  <class name="edm::Wrapper<unsigned int>"/>
  <class name="edm::Wrapper<unsigned long>"/>

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -65,9 +65,13 @@ from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toReplaceWith( SimL1Emulator , _phase2_siml1emulator )
 
 # If PreMixing, don't run these modules during first step
+# TODO: Do we actually need anything from here run in stage1?
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 premix_stage1.toReplaceWith(SimL1Emulator, SimL1Emulator.copyAndExclude([
     SimL1TCalorimeter,
     SimL1TechnicalTriggers,
     SimL1TGlobal
+]))
+(premix_stage1 & phase2_hgcal).toReplaceWith(SimL1Emulator, SimL1Emulator.copyAndExclude([
+    hgcalTriggerPrimitives
 ]))

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -72,6 +72,3 @@ premix_stage1.toReplaceWith(SimL1Emulator, SimL1Emulator.copyAndExclude([
     SimL1TechnicalTriggers,
     SimL1TGlobal
 ]))
-(premix_stage1 & phase2_hgcal).toReplaceWith(SimL1Emulator, SimL1Emulator.copyAndExclude([
-    hgcalTriggerPrimitives
-]))

--- a/L1Trigger/TrackTrigger/python/TTCluster_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTCluster_cfi.py
@@ -7,3 +7,5 @@ TTClustersFromPhase2TrackerDigis = cms.EDProducer("TTClusterBuilder_Phase2Tracke
                                       # of each hit are stored in the cluster object
 )
 
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(TTClustersFromPhase2TrackerDigis, rawHits = ["mixData:Tracker"])

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
@@ -47,3 +47,10 @@ HGCalUncalibRecHit = cms.EDProducer(
 
     algo = cms.string("HGCalUncalibRecHitWorkerWeights")
 )
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(HGCalUncalibRecHit,
+    HGCEEdigiCollection = 'mixData:HGCDigisEE',
+    HGCHEFdigiCollection = 'mixData:HGCDigisHEfront',
+    HGCHEBdigiCollection = 'mixData:HGCDigisHEback',
+)

--- a/RecoLocalMuon/RPCRecHit/python/rpcRecHits_cfi.py
+++ b/RecoLocalMuon/RPCRecHit/python/rpcRecHits_cfi.py
@@ -1,3 +1,4 @@
+
 import FWCore.ParameterSet.Config as cms
 
 rpcRecHits = cms.EDProducer("RPCRecHitProducer",
@@ -15,3 +16,7 @@ rpcRecHits = cms.EDProducer("RPCRecHitProducer",
 #disabling DIGI2RAW,RAW2DIGI chain for Phase2
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify(rpcRecHits, rpcDigiLabel = cms.InputTag('simMuonRPCDigis'))
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+(premix_stage2 & phase2_muon).toModify(rpcRecHits,
+    rpcDigiLabel = "mixData"
+)

--- a/RecoLocalTracker/SiPhase2Clusterizer/python/phase2TrackerClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPhase2Clusterizer/python/phase2TrackerClusterizer_cfi.py
@@ -7,5 +7,6 @@ siPhase2Clusters = cms.EDProducer('Phase2TrackerClusterizer',
     maxNumberClusters = cms.uint32(0)
 )
 
-
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(siPhase2Clusters, src = "mixData:Tracker")
 

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -48,3 +48,7 @@ phase2_tracker.toModify(siPixelClusters, # FIXME
   MissCalibrate = False,
   ElectronPerADCGain = cms.double(600.) # it can be changed to something else (e.g. 135e) if needed
 )
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+(premix_stage2 & phase2_tracker).toModify(siPixelClusters,
+    src = "mixData:Pixel"
+)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
@@ -33,6 +33,8 @@ _simClusterMapper_HGCal = cms.PSet(
     calibMaxEta = maxEtaCorrection,
     simClusterSrc = cms.InputTag("mix:MergedCaloTruth")
 )
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(_simClusterMapper_HGCal, simClusterSrc = "mixData:MergedCaloTruth")
 
 
 #position calculations

--- a/RecoParticleFlow/PFProducer/python/simPFProducer_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/simPFProducer_cfi.py
@@ -24,3 +24,8 @@ phase2_timing.toModify(
     gsfTrackTimeValueMap = cms.InputTag("gsfTrackTimeValueMapProducer:electronGsfTracksConfigurableFlatResolutionModel"),
     gsfTrackTimeErrorMap = cms.InputTag("gsfTrackTimeValueMapProducer:electronGsfTracksConfigurableFlatResolutionModelResolution"),
 )
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(simPFProducer,
+    trackingParticleSrc = "mixData:MergedTrackTruth"
+)

--- a/RecoParticleFlow/PFProducer/python/simPFProducer_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/simPFProducer_cfi.py
@@ -27,5 +27,7 @@ phase2_timing.toModify(
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(simPFProducer,
-    trackingParticleSrc = "mixData:MergedTrackTruth"
+    trackingParticleSrc = "mixData:MergedTrackTruth",
+    caloParticlesSrc = "mixData:MergedCaloTruth",
+    simClusterTruthSrc = "mixData:MergedCaloTruth",
 )

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -36,6 +36,9 @@ from Configuration.Eras.Modifier_run2_common_cff import run2_common
 run2_common.toModify( SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )
 run2_common.toModify( SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )
 
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+phase2_hcal.toModify(SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_DMHcalDigis_*_*') )
+
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_timing.toModify(SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_mix_EETimeDigi_*') )
 phase2_timing.toModify(SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_mix_EBTimeDigi_*') )

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
@@ -12,6 +12,7 @@
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCHEfrontDigitizer.h"
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCHEbackDigitizer.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
+#include "DataFormats/HGCDigi/interface/PHGCSimAccumulator.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
@@ -55,6 +56,8 @@ public:
   void accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& c, CLHEP::HepRandomEngine* hre);
   template<typename GEOM>
   void accumulate(edm::Handle<edm::PCaloHitContainer> const &hits, int bxCrossing,const GEOM *geom, CLHEP::HepRandomEngine* hre);
+  // for premixing
+  void accumulate(const PHGCSimAccumulator& simAccumulator);
 
   /**
      @short actions at the start/end of event
@@ -82,6 +85,14 @@ private :
 
   //digitization type (it's up to the specializations to decide it's meaning)
   int digitizationType_;
+
+  // if true, we're running mixing in premixing stage1 and have to produce the output differently
+  bool premixStage1_;
+
+  // Minimum charge threshold for premixing stage1
+  double premixStage1MinCharge_;
+  // Maximum charge for packing in premixing stage1
+  double premixStage1MaxCharge_;
 
   //handle sim hits
   int maxSimHitsAccTime_;

--- a/SimCalorimetry/HGCalSimProducers/plugins/BuildFile.xml
+++ b/SimCalorimetry/HGCalSimProducers/plugins/BuildFile.xml
@@ -11,6 +11,7 @@
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/HepMCCandidate"/>
 <use name="SimGeneral/MixingModule"/>
+<use name="SimGeneral/PreMixingModule"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="SimCalorimetry/HGCalSimProducers"/>
 <use name="geant4core"/>

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
@@ -12,12 +12,17 @@ HGCDigiProducer::HGCDigiProducer(edm::ParameterSet const& pset, edm::ProducerBas
                                  edm::ConsumesCollector& iC) :
   HGCDigiProducer(pset, iC)
 {
-  if( theDigitizer_.producesEEDigis()     )
-    mixMod.produces<HGCEEDigiCollection>(theDigitizer_.digiCollection());
-  if( theDigitizer_.producesHEfrontDigis() )
-    mixMod.produces<HGCHEDigiCollection>(theDigitizer_.digiCollection());
-  if( theDigitizer_.producesHEbackDigis() )
-    mixMod.produces<HGCBHDigiCollection>(theDigitizer_.digiCollection());
+  if(pset.getParameter<bool>("premixStage1")) {
+    mixMod.produces<PHGCSimAccumulator>(theDigitizer_.digiCollection());
+  }
+  else {
+    if( theDigitizer_.producesEEDigis()     )
+      mixMod.produces<HGCEEDigiCollection>(theDigitizer_.digiCollection());
+    if( theDigitizer_.producesHEfrontDigis() )
+      mixMod.produces<HGCHEDigiCollection>(theDigitizer_.digiCollection());
+    if( theDigitizer_.producesHEbackDigis() )
+      mixMod.produces<HGCBHDigiCollection>(theDigitizer_.digiCollection());
+  }
 }
 
 HGCDigiProducer::HGCDigiProducer(edm::ParameterSet const& pset, edm::ConsumesCollector& iC) :

--- a/SimCalorimetry/HGCalSimProducers/plugins/PreMixingHGCalWorker.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/PreMixingHGCalWorker.cc
@@ -1,0 +1,83 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/HGCDigi/interface/PHGCSimAccumulator.h"
+#include "SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h"
+
+#include "SimGeneral/PreMixingModule/interface/PreMixingWorker.h"
+#include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
+
+class PreMixingHGCalWorker: public PreMixingWorker {
+public:
+  PreMixingHGCalWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
+  ~PreMixingHGCalWorker() override = default;
+
+  PreMixingHGCalWorker(const PreMixingHGCalWorker&) = delete;
+  PreMixingHGCalWorker& operator=(const PreMixingHGCalWorker&) = delete;
+
+  void beginRun(const edm::Run& run, const edm::EventSetup& ES) override;
+  void endRun() override;
+  void initializeEvent(const edm::Event &e, const edm::EventSetup& ES) override {}
+  void addSignals(const edm::Event &e, const edm::EventSetup& ES) override;
+  void addPileups(const PileUpEventPrincipal&, const edm::EventSetup& ES) override;
+  void put(edm::Event &e,const edm::EventSetup& ES, std::vector<PileupSummaryInfo> const& ps, int bs) override;
+
+private:
+  edm::EDGetTokenT<PHGCSimAccumulator> signalToken_;
+
+  edm::InputTag pileInputTag_;
+
+  HGCDigitizer digitizer_;
+};
+
+PreMixingHGCalWorker::PreMixingHGCalWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC):
+  signalToken_(iC.consumes<PHGCSimAccumulator>(ps.getParameter<edm::InputTag>("digiTagSig"))),
+  pileInputTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
+  digitizer_(ps, iC)
+{
+  if(digitizer_.producesEEDigis()) {
+    producer.produces<HGCEEDigiCollection>(digitizer_.digiCollection());
+  }
+  if(digitizer_.producesHEfrontDigis()) {
+    producer.produces<HGCHEDigiCollection>(digitizer_.digiCollection());
+  }
+  if(digitizer_.producesHEbackDigis()) {
+    producer.produces<HGCBHDigiCollection>(digitizer_.digiCollection());
+  }
+}
+
+void PreMixingHGCalWorker::beginRun(const edm::Run& run, const edm::EventSetup& ES) {
+  digitizer_.beginRun(ES);
+}
+
+void PreMixingHGCalWorker::endRun() {
+  digitizer_.endRun();
+}
+
+void PreMixingHGCalWorker::addSignals(const edm::Event &e,const edm::EventSetup& ES) {
+  edm::Handle<PHGCSimAccumulator> handle;
+  e.getByToken(signalToken_, handle);
+  digitizer_.accumulate(*handle);
+}
+
+void PreMixingHGCalWorker::addPileups(const PileUpEventPrincipal& pep, const edm::EventSetup& ES) {
+  edm::Handle<PHGCSimAccumulator> handle;
+  pep.getByLabel(pileInputTag_, handle);
+  digitizer_.accumulate(*handle);
+}
+
+void PreMixingHGCalWorker::put(edm::Event &e,const edm::EventSetup& ES, std::vector<PileupSummaryInfo> const& ps, int bs) {
+  edm::Service<edm::RandomNumberGenerator> rng;
+  digitizer_.finalizeEvent(e, ES, &rng->getEngine(e.streamID()));
+}
+
+DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingHGCalWorker, "PreMixingHGCalWorker");

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -34,6 +34,9 @@ hgceeDigitizer = cms.PSet(
     tofDelay          = cms.double(5),
     digitizationType  = cms.uint32(0),
     makeDigiSimLinks  = cms.bool(False),
+    premixStage1      = cms.bool(False),
+    premixStage1MinCharge = cms.double(0),
+    premixStage1MaxCharge = cms.double(1e6),
     useAllChannels    = cms.bool(True),
     verbosity         = cms.untracked.uint32(0),
     digiCfg = cms.PSet(
@@ -95,6 +98,9 @@ hgchefrontDigitizer = cms.PSet(
     tofDelay          = cms.double(5),
     digitizationType  = cms.uint32(0),
     makeDigiSimLinks  = cms.bool(False),
+    premixStage1      = cms.bool(False),
+    premixStage1MinCharge = cms.double(0),
+    premixStage1MaxCharge = cms.double(1e6),
     useAllChannels    = cms.bool(True),
     verbosity         = cms.untracked.uint32(0),
     digiCfg = cms.PSet(
@@ -155,6 +161,9 @@ hgchebackDigitizer = cms.PSet(
     tofDelay          = cms.double(1),
     digitizationType  = cms.uint32(1),
     makeDigiSimLinks  = cms.bool(False),
+    premixStage1      = cms.bool(False),
+    premixStage1MinCharge = cms.double(0),
+    premixStage1MaxCharge = cms.double(1e6),
     useAllChannels    = cms.bool(True),
     verbosity         = cms.untracked.uint32(0),
     digiCfg = cms.PSet(
@@ -178,6 +187,9 @@ hgchebackDigitizer = cms.PSet(
             )
         )
     )
+from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
+for _m in [hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer]:
+    premix_stage1.toModify(_m, premixStage1 = True)
 
 #function to set noise to aged HGCal
 endOfLifeCCEs = [0.5, 0.5, 0.7]

--- a/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
+++ b/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
@@ -74,7 +74,9 @@ public:
     const SimClusterRefVector& simClusters() const { return simClusters_; }
     // Only for clusters from the signal vertex
     const std::vector<SimTrack>& g4Tracks() const { return g4Tracks_; }
-    
+
+    void clearSimClusters() { simClusters_.clear(); }
+
     /// @brief Electric charge. Note this is taken from the first SimTrack only.
     float charge() const { return g4Tracks_[0].charge(); }
     /// Gives charge in unit of quark charge (should be 3 times "charge()")

--- a/SimDataFormats/CrossingFrame/interface/CrossingFrame.h
+++ b/SimDataFormats/CrossingFrame/interface/CrossingFrame.h
@@ -91,10 +91,10 @@ class CrossingFrame
   std::string getSubDet() const { return subdet_;}
   unsigned int getPileupFileNr() const {return pileupFileNr_;}
   edm::EventID getIdFirstPileup() const {return idFirstPileup_;}
-  std::vector<unsigned int> getPileupOffsetsBcr() const {return pileupOffsetsBcr_;}   
-  std::vector< std::vector<unsigned int> > getPileupOffsetsSource() const {return pileupOffsetsSource_;} //one per source
-  std::vector<const T *> getPileups() const {return pileups_;}
-  std::vector<const T *> getSignal() const {return signals_;}
+  const std::vector<unsigned int>& getPileupOffsetsBcr() const {return pileupOffsetsBcr_;}
+  const std::vector< std::vector<unsigned int> >& getPileupOffsetsSource() const {return pileupOffsetsSource_;} //one per source
+  const std::vector<const T *>& getPileups() const {return pileups_;}
+  const std::vector<const T *>& getSignal() const {return signals_;}
   
   
   void getSignal(typename std::vector<const T *>::const_iterator &first,typename std::vector<const T*>::const_iterator &last) const {

--- a/SimDataFormats/CrossingFrame/interface/PCrossingFrame.h
+++ b/SimDataFormats/CrossingFrame/interface/PCrossingFrame.h
@@ -21,13 +21,17 @@ class PCrossingFrame
 
   PCrossingFrame(){}
   PCrossingFrame(const CrossingFrame<T>& cf);
-  PCrossingFrame(const PCrossingFrame<T> &pcf){};
 
   ~PCrossingFrame() {;}
   
   // getters for data members of PCrossingFrame
   edm::EventID getEventID() const {return Pid_;}
-  std::vector<const T *> getPileups() const {return PCFpileups_;}
+  std::vector<const T *> getPileups() const {
+    std::vector<const T *> ret;
+    ret.reserve(PCFpileups_.size());
+    for(const auto& p: PCFpileups_) ret.emplace_back(&p);
+    return ret;
+  }
   int getBunchSpace() const {return PbunchSpace_;}
   unsigned int getMaxNbSources() const {return PmaxNbSources_; }
   std::string getSubDet() const { return PCFsubdet_;}
@@ -44,8 +48,8 @@ class PCrossingFrame
   edm::EventID Pid_;
   int firstPCrossing_;
   int lastPCrossing_;
-  std::vector<const T * > PCFpileups_;
-  std::vector<const T * > PCFsignals_;
+  std::vector<T> PCFpileups_;
+  std::vector<T> PCFsignals_;
   std::string PCFsubdet_;
   unsigned int PCFpileupFileNr_;
   edm::EventID PCFidFirstPileup_;
@@ -63,8 +67,18 @@ PCrossingFrame<T>::PCrossingFrame(const CrossingFrame<T>& cf)
  Pid_ = cf.getEventID();
  firstPCrossing_ = cf.getBunchRange().first;
  lastPCrossing_ = cf.getBunchRange().second;
- PCFpileups_ = cf.getPileups();
- PCFsignals_ = cf.getSignal();
+
+ const auto pileups = cf.getPileups();
+ PCFpileups_.reserve(pileups.size());
+ for(const auto& ptr: pileups) {
+   PCFpileups_.emplace_back(*ptr);
+ }
+ const auto signal = cf.getSignal();
+ PCFsignals_.reserve(signal.size());
+ for(const auto& ptr: signal) {
+   PCFsignals_.emplace_back(*ptr);
+ }
+
  PCFsubdet_ = cf.getSubDet();
  PCFpileupFileNr_ = cf.getPileupFileNr();
  PCFidFirstPileup_ = cf.getIdFirstPileup();

--- a/SimDataFormats/CrossingFrame/interface/PCrossingFrame.h
+++ b/SimDataFormats/CrossingFrame/interface/PCrossingFrame.h
@@ -72,12 +72,12 @@ PCrossingFrame<T>::PCrossingFrame(const CrossingFrame<T>& cf)
  firstPCrossing_ = cf.getBunchRange().first;
  lastPCrossing_ = cf.getBunchRange().second;
 
- const auto pileups = cf.getPileups();
+ const auto& pileups = cf.getPileups();
  PCFpileups_.reserve(pileups.size());
  for(const auto& ptr: pileups) {
    PCFpileups_.emplace_back(*ptr);
  }
- const auto signal = cf.getSignal();
+ const auto& signal = cf.getSignal();
  PCFsignals_.reserve(signal.size());
  for(const auto& ptr: signal) {
    PCFsignals_.emplace_back(*ptr);

--- a/SimDataFormats/CrossingFrame/interface/PCrossingFrame.h
+++ b/SimDataFormats/CrossingFrame/interface/PCrossingFrame.h
@@ -24,8 +24,12 @@ class PCrossingFrame
 
   ~PCrossingFrame() {;}
   
+  void setAllExceptSignalFrom(const PCrossingFrame<T>& cf);
+
   // getters for data members of PCrossingFrame
   edm::EventID getEventID() const {return Pid_;}
+  const std::vector<T>& getSignals() const { return PCFsignals_; }
+  const std::vector<T>& getPileupRefs() const { return PCFpileups_; }
   std::vector<const T *> getPileups() const {
     std::vector<const T *> ret;
     ret.reserve(PCFpileups_.size());
@@ -85,5 +89,23 @@ PCrossingFrame<T>::PCrossingFrame(const CrossingFrame<T>& cf)
  PCFpileupOffsetsBcr_ = cf.getPileupOffsetsBcr();
  PCFpileupOffsetsSource_ = cf.getPileupOffsetsSource();
 }
+
+template <typename T>
+void PCrossingFrame<T>::setAllExceptSignalFrom(const PCrossingFrame<T>& cf) {
+  // TODO: reduce copy-paste
+ PmaxNbSources_= cf.getMaxNbSources();
+ PbunchSpace_ = cf.getBunchSpace();
+ firstPCrossing_ = cf.getBunchRange().first;
+ lastPCrossing_ = cf.getBunchRange().second;
+
+ PCFpileups_ = cf.getPileupRefs();
+
+ PCFsubdet_ = cf.getSubDet();
+ PCFpileupFileNr_ = cf.getPileupFileNr();
+ PCFidFirstPileup_ = cf.getIdFirstPileup();
+ PCFpileupOffsetsBcr_ = cf.getPileupOffsetsBcr();
+ PCFpileupOffsetsSource_ = cf.getPileupOffsetsSource();
+}
+
 
 #endif 

--- a/SimDataFormats/CrossingFrame/interface/PCrossingFrame.h
+++ b/SimDataFormats/CrossingFrame/interface/PCrossingFrame.h
@@ -37,8 +37,8 @@ class PCrossingFrame
   std::string getSubDet() const { return PCFsubdet_;}
   unsigned int getPileupFileNr() const {return PCFpileupFileNr_;}
   edm::EventID getIdFirstPileup() const {return PCFidFirstPileup_;}
-  std::vector<unsigned int> getPileupOffsetsBcr() const {return PCFpileupOffsetsBcr_;}   
-  std::vector< std::vector<unsigned int> > getPileupOffsetsSource() const {return PCFpileupOffsetsSource_;} //one per source
+  const std::vector<unsigned int>& getPileupOffsetsBcr() const {return PCFpileupOffsetsBcr_;}
+  const std::vector< std::vector<unsigned int> >& getPileupOffsetsSource() const {return PCFpileupOffsetsSource_;} //one per source
   std::pair<int,int> getBunchRange() const {return std::pair<int,int>(firstPCrossing_,lastPCrossing_);}
 	
 

--- a/SimGeneral/CaloAnalysis/plugins/BuildFile.xml
+++ b/SimGeneral/CaloAnalysis/plugins/BuildFile.xml
@@ -19,6 +19,7 @@
 <use   name="SimTracker/Common"/>
 <use   name="DataFormats/HepMCCandidate"/>
 <use   name="SimGeneral/MixingModule"/>
+<use   name="SimGeneral/PreMixingModule"/>
 <use   name="SimDataFormats/CaloTest"/>
 <use   name="DataFormats/ForwardDetId"/>
 <use   name="DataFormats/HcalDetId"/>

--- a/SimGeneral/CaloAnalysis/plugins/PreMixingCaloParticleWorker.cc
+++ b/SimGeneral/CaloAnalysis/plugins/PreMixingCaloParticleWorker.cc
@@ -1,0 +1,145 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
+
+#include "SimGeneral/PreMixingModule/interface/PreMixingWorker.h"
+#include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
+
+class PreMixingCaloParticleWorker: public PreMixingWorker {
+public:
+  PreMixingCaloParticleWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector && iC);
+  ~PreMixingCaloParticleWorker() override = default;
+
+  void initializeEvent(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
+  void addSignals(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
+  void addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& iSetup) override;
+  void put(edm::Event& iEvent, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bunchSpacing) override;
+
+private:
+  using EnergyMap = std::vector<std::pair<unsigned, float> >;
+
+  void add(const SimClusterCollection& clusters, const CaloParticleCollection& particles, const EnergyMap& energyMap);
+
+  edm::EDGetTokenT<SimClusterCollection> sigClusterToken_;
+  edm::EDGetTokenT<CaloParticleCollection> sigParticleToken_;
+  edm::EDGetTokenT<EnergyMap> sigEnergyToken_;
+
+  edm::InputTag particlePileInputTag_;
+  std::string particleCollectionDM_;
+
+  std::unordered_map<unsigned, float> totalEnergy_;
+
+  std::unique_ptr<SimClusterCollection> newClusters_;
+  std::unique_ptr<CaloParticleCollection> newParticles_;
+  SimClusterRefProd clusterRef_;
+};
+
+PreMixingCaloParticleWorker::PreMixingCaloParticleWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector && iC):
+  sigClusterToken_(iC.consumes<SimClusterCollection>(ps.getParameter<edm::InputTag>("labelSig"))),
+  sigParticleToken_(iC.consumes<CaloParticleCollection>(ps.getParameter<edm::InputTag>("labelSig"))),
+  sigEnergyToken_(iC.consumes<EnergyMap>(ps.getParameter<edm::InputTag>("labelSig"))),
+  particlePileInputTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
+  particleCollectionDM_(ps.getParameter<std::string>("collectionDM"))
+{
+  producer.produces<SimClusterCollection>(particleCollectionDM_);
+  producer.produces<CaloParticleCollection>(particleCollectionDM_);
+}
+
+void PreMixingCaloParticleWorker::initializeEvent(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
+  newClusters_ = std::make_unique<SimClusterCollection>();
+  newParticles_ = std::make_unique<CaloParticleCollection>();
+
+  // need RefProds in order to re-key the CaloParticle->SimCluster refs
+  // TODO: try to remove const_cast, requires making Event non-const in BMixingModule::initializeEvent
+  clusterRef_ = const_cast<edm::Event&>(iEvent).getRefBeforePut<SimClusterCollection>(particleCollectionDM_);
+}
+
+void PreMixingCaloParticleWorker::addSignals(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
+  edm::Handle<SimClusterCollection> clusters;
+  iEvent.getByToken(sigClusterToken_, clusters);
+
+  edm::Handle<CaloParticleCollection> particles;
+  iEvent.getByToken(sigParticleToken_, particles);
+
+  edm::Handle<EnergyMap> energy;
+  iEvent.getByToken(sigEnergyToken_, energy);
+
+  if(clusters.isValid() && particles.isValid() && energy.isValid()) {
+    add(*clusters, *particles, *energy);
+  }
+}
+
+void PreMixingCaloParticleWorker::addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& iSetup) {
+  edm::Handle<SimClusterCollection> clusters;
+  pep.getByLabel(particlePileInputTag_, clusters);
+
+  edm::Handle<CaloParticleCollection> particles;
+  pep.getByLabel(particlePileInputTag_, particles);
+
+  edm::Handle<EnergyMap> energy;
+  pep.getByLabel(particlePileInputTag_, energy);
+
+  if(clusters.isValid() && particles.isValid() && energy.isValid()) {
+    add(*clusters, *particles, *energy);
+  }
+}
+
+void PreMixingCaloParticleWorker::add(const SimClusterCollection& clusters, const CaloParticleCollection& particles, const EnergyMap& energy) {
+  const size_t startingIndex = newClusters_->size();
+
+  // Copy SimClusters
+  newClusters_->reserve(newClusters_->size() + clusters.size());
+  std::copy(clusters.begin(), clusters.end(), std::back_inserter(*newClusters_));
+
+  // Copy CaloParticles
+  newParticles_->reserve(newParticles_->size() + particles.size());
+  for(const auto& p: particles) {
+    newParticles_->push_back(p);
+    auto& particle = newParticles_->back();
+
+    // re-key the refs to SimClusters
+    particle.clearSimClusters();
+    for(const auto& ref: p.simClusters()) {
+      particle.addSimCluster(SimClusterRef(clusterRef_, startingIndex + ref.index()));
+    }
+  }
+
+  // Add energies
+  for(const auto elem: energy) {
+    totalEnergy_[elem.first] += elem.second;
+  }
+}
+
+void PreMixingCaloParticleWorker::put(edm::Event& iEvent, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bunchSpacing) {
+  for (auto& sc : *newClusters_) {
+    auto hitsAndEnergies = sc.hits_and_fractions();
+    sc.clearHitsAndFractions();
+    for (auto& hAndE : hitsAndEnergies) {
+      const float totalenergy = totalEnergy_[hAndE.first];
+      float fraction = 0.;
+      if (totalenergy > 0)
+        fraction = hAndE.second / totalenergy;
+      else
+        edm::LogWarning("PreMixingParticleWorker") << "TotalSimEnergy for hit " << hAndE.first
+                                                   << " is 0! The fraction for this hit cannot be computed.";
+      sc.addRecHitAndFraction(hAndE.first, fraction);
+    }
+  }
+
+  // clear memory
+  std::unordered_map<unsigned, float>{}.swap(totalEnergy_);
+
+  iEvent.put(std::move(newClusters_), particleCollectionDM_);
+  iEvent.put(std::move(newParticles_), particleCollectionDM_);
+}
+
+DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingCaloParticleWorker, "PreMixingCaloParticleWorker");

--- a/SimGeneral/Configuration/python/SimGeneral_EventContent_cff.py
+++ b/SimGeneral/Configuration/python/SimGeneral_EventContent_cff.py
@@ -31,18 +31,17 @@ SimGeneralAOD = cms.PSet(
 
 # mods for HGCAL
 _phase2_hgc_extraCommands = cms.PSet( # using PSet in order to customize with Modifier
-    digis = cms.vstring('keep *_mix_HGCDigisEE_*', 'keep *_mix_HGCDigisHEfront_*', 'keep *_mix_HGCDigisHEback_*'),
-    truth = cms.vstring('keep *_mix_MergedCaloTruth_*'),
+    v = cms.vstring('keep *_mix_HGCDigisEE_*', 'keep *_mix_HGCDigisHEfront_*', 'keep *_mix_HGCDigisHEback_*', 'keep *_mix_MergedCaloTruth_*'),
 )
 # For phase2 premixing switch the sim digi collections to the ones including pileup
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(_phase2_hgc_extraCommands,
-    digis = ['keep *_mixData_HGCDigisEE_*', 'keep *_mixData_HGCDigisHEfront_*', 'keep *_mixData_HGCDigisHEback_*']
+    v = ['keep *_mixData_HGCDigisEE_*', 'keep *_mixData_HGCDigisHEfront_*', 'keep *_mixData_HGCDigisHEback_*', 'keep *_mixData_MergedCaloTruth_*']
 )
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toModify( SimGeneralRAW, outputCommands = SimGeneralRAW.outputCommands + _phase2_hgc_extraCommands.digis + _phase2_hgc_extraCommands.truth )
-phase2_hgcal.toModify( SimGeneralFEVTDEBUG, outputCommands = SimGeneralFEVTDEBUG.outputCommands + _phase2_hgc_extraCommands.digis + _phase2_hgc_extraCommands.truth )
-phase2_hgcal.toModify( SimGeneralRECO, outputCommands = SimGeneralRECO.outputCommands + _phase2_hgc_extraCommands.digis + _phase2_hgc_extraCommands.truth )
+phase2_hgcal.toModify( SimGeneralRAW, outputCommands = SimGeneralRAW.outputCommands + _phase2_hgc_extraCommands.v )
+phase2_hgcal.toModify( SimGeneralFEVTDEBUG, outputCommands = SimGeneralFEVTDEBUG.outputCommands + _phase2_hgc_extraCommands.v )
+phase2_hgcal.toModify( SimGeneralRECO, outputCommands = SimGeneralRECO.outputCommands + _phase2_hgc_extraCommands.v )
 
 _phase2_timing_extraCommands = [ 'keep *_mix_FTLBarrel_*','keep *_mix_FTLEndcap_*','keep *_mix_InitialVertices_*' ]
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing

--- a/SimGeneral/Configuration/python/SimGeneral_EventContent_cff.py
+++ b/SimGeneral/Configuration/python/SimGeneral_EventContent_cff.py
@@ -30,12 +30,19 @@ SimGeneralAOD = cms.PSet(
 )
 
 # mods for HGCAL
-_phase2_hgc_extraCommands = [ 'keep *_mix_HGCDigisEE_*', 'keep *_mix_HGCDigisHEfront_*', 'keep *_mix_HGCDigisHEback_*', 
-                              'keep *_mix_MergedCaloTruth_*' ]
+_phase2_hgc_extraCommands = cms.PSet( # using PSet in order to customize with Modifier
+    digis = cms.vstring('keep *_mix_HGCDigisEE_*', 'keep *_mix_HGCDigisHEfront_*', 'keep *_mix_HGCDigisHEback_*'),
+    truth = cms.vstring('keep *_mix_MergedCaloTruth_*'),
+)
+# For phase2 premixing switch the sim digi collections to the ones including pileup
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(_phase2_hgc_extraCommands,
+    digis = ['keep *_mixData_HGCDigisEE_*', 'keep *_mixData_HGCDigisHEfront_*', 'keep *_mixData_HGCDigisHEback_*']
+)
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toModify( SimGeneralRAW, outputCommands = SimGeneralRAW.outputCommands + _phase2_hgc_extraCommands )
-phase2_hgcal.toModify( SimGeneralFEVTDEBUG, outputCommands = SimGeneralFEVTDEBUG.outputCommands + _phase2_hgc_extraCommands )
-phase2_hgcal.toModify( SimGeneralRECO, outputCommands = SimGeneralRECO.outputCommands + _phase2_hgc_extraCommands )
+phase2_hgcal.toModify( SimGeneralRAW, outputCommands = SimGeneralRAW.outputCommands + _phase2_hgc_extraCommands.digis + _phase2_hgc_extraCommands.truth )
+phase2_hgcal.toModify( SimGeneralFEVTDEBUG, outputCommands = SimGeneralFEVTDEBUG.outputCommands + _phase2_hgc_extraCommands.digis + _phase2_hgc_extraCommands.truth )
+phase2_hgcal.toModify( SimGeneralRECO, outputCommands = SimGeneralRECO.outputCommands + _phase2_hgc_extraCommands.digis + _phase2_hgc_extraCommands.truth )
 
 _phase2_timing_extraCommands = [ 'keep *_mix_FTLBarrel_*','keep *_mix_FTLEndcap_*','keep *_mix_InitialVertices_*' ]
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -181,6 +181,8 @@ namespace edm {
             std::vector<std::string> subdets=pset.getParameter<std::vector<std::string> >("subdets");
             std::vector<std::string> crossingFrames=pset.getUntrackedParameter<std::vector<std::string> >("crossingFrames", std::vector<std::string>());
             sort_all(crossingFrames);
+            std::vector<std::string> pcrossingFrames=pset.getUntrackedParameter<std::vector<std::string> >("pcrossingFrames", std::vector<std::string>());
+            sort_all(pcrossingFrames);
             for (unsigned int ii=0;ii<subdets.size();++ii) {
               InputTag tag;
               if (tags.size()==1) tag=tags[0];
@@ -190,8 +192,12 @@ namespace edm {
               branchesActivate(TypeID(typeid(std::vector<PSimHit>)).friendlyClassName(),subdets[ii],tag,label);
               adjustersObjects_.push_back(new Adjuster<std::vector<PSimHit> >(tag, consumesCollector(),wrapLongTimes_));
               if(binary_search_all(crossingFrames, tag.instance())) {
-                workersObjects_.push_back(new MixingWorker<PSimHit>(minBunch_,maxBunch_,bunchSpace_,subdets[ii],label,labelCF,maxNbSources_,tag,tagCF));
+                bool makePCrossingFrame = binary_search_all(pcrossingFrames, tag.instance());
+                workersObjects_.push_back(new MixingWorker<PSimHit>(minBunch_,maxBunch_,bunchSpace_,subdets[ii],label,labelCF,maxNbSources_,tag,tagCF, makePCrossingFrame));
                 produces<CrossingFrame<PSimHit> >(label);
+                if(makePCrossingFrame) {
+                  produces<PCrossingFrame<PSimHit> >(label);
+                }
                 consumes<std::vector<PSimHit> >(tag);
               }
 

--- a/SimGeneral/MixingModule/plugins/MixingWorker.h
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.h
@@ -51,6 +51,7 @@ namespace edm
         label_(std::string(" ")),
         labelCF_(std::string(" ")),
         maxNbSources_(5),
+        makePCrossingFrame_(false),
 	tag_(),
 	tagSignal_(),
         allTags_(),
@@ -62,7 +63,7 @@ namespace edm
       MixingWorker(int minBunch,int maxBunch, int bunchSpace,
 		   std::string subdet,std::string label,
 		   std::string labelCF,int maxNbSources, InputTag& tag,
-		   InputTag& tagCF):
+		   InputTag& tagCF, bool makePCrossingFrame=false):
 	MixingWorkerBase(),
 	minBunch_(minBunch),
 	maxBunch_(maxBunch),
@@ -71,6 +72,7 @@ namespace edm
 	label_(label),
 	labelCF_(labelCF),
 	maxNbSources_(maxNbSources),
+	makePCrossingFrame_(makePCrossingFrame),
 	tag_(tag),
 	tagSignal_(tagCF),
         allTags_(),
@@ -92,6 +94,7 @@ namespace edm
 	label_(label),
 	labelCF_(labelCF),
 	maxNbSources_(maxNbSources),
+	makePCrossingFrame_(false),
 	tag_(tag),
 	tagSignal_(tagCF),
         allTags_(tags),
@@ -152,6 +155,9 @@ namespace edm
       void setTof() override;
 
       void put(edm::Event &e) override {	
+        if(makePCrossingFrame_) {
+          e.put(std::make_unique<PCrossingFrame<T> >(*crFrame_), label_);
+        }
 	e.put(std::move(crFrame_),label_);
 	LogDebug("MixingModule") <<" CF was put for type "<<typeid(T).name()<<" with "<<label_;
       }
@@ -168,6 +174,7 @@ namespace edm
       std::string const label_;
       std::string const labelCF_;
       unsigned int const maxNbSources_;
+      bool const makePCrossingFrame_;
       InputTag tag_;
       InputTag tagSignal_;
       std::vector<InputTag> allTags_; // for HepMCProduct

--- a/SimGeneral/MixingModule/plugins/MixingWorker.h
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.h
@@ -54,8 +54,7 @@ namespace edm
 	tag_(),
 	tagSignal_(),
         allTags_(),
-        crFrame_(nullptr),
-        secSourceCF_(nullptr)
+        crFrame_(nullptr)
         {
 	}
 
@@ -75,8 +74,7 @@ namespace edm
 	tag_(tag),
 	tagSignal_(tagCF),
         allTags_(),
-        crFrame_(nullptr),
-        secSourceCF_(nullptr)
+        crFrame_(nullptr)
 	{
 	}
 
@@ -97,8 +95,7 @@ namespace edm
 	tag_(tag),
 	tagSignal_(tagCF),
         allTags_(tags),
-        crFrame_(nullptr),
-        secSourceCF_(nullptr)
+        crFrame_(nullptr)
 	{
 	}
 
@@ -133,7 +130,7 @@ namespace edm
       
       
       void createnewEDProduct() override{        
-          crFrame_=new CrossingFrame<T>(minBunch_,maxBunch_,bunchSpace_,subdet_,maxNbSources_);
+        crFrame_ = std::make_unique<CrossingFrame<T> >(minBunch_,maxBunch_,bunchSpace_,subdet_,maxNbSources_);
       }
            
       void addSignals(const edm::Event &e) override{
@@ -155,8 +152,7 @@ namespace edm
       void setTof() override;
 
       void put(edm::Event &e) override {	
-        std::unique_ptr<CrossingFrame<T> > pOut(crFrame_);
-	e.put(std::move(pOut),label_);
+	e.put(std::move(crFrame_),label_);
 	LogDebug("MixingModule") <<" CF was put for type "<<typeid(T).name()<<" with "<<label_;
       }
 
@@ -176,8 +172,7 @@ namespace edm
       InputTag tagSignal_;
       std::vector<InputTag> allTags_; // for HepMCProduct
 
-      CrossingFrame<T> * crFrame_;
-      PCrossingFrame<T> * secSourceCF_;
+      std::unique_ptr<CrossingFrame<T> > crFrame_;
     };
 
   template <typename T>

--- a/SimGeneral/MixingModule/python/caloTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/caloTruthProducer_cfi.py
@@ -8,6 +8,7 @@ caloParticles = cms.PSet(
 #	alwaysAddAncestors = cms.bool(True),
         MinEnergy = cms.double(0.5),
         MaxPseudoRapidity = cms.double(5.0),
+        premixStage1 = cms.bool(False),
 	maximumPreviousBunchCrossing = cms.uint32(0),
 	maximumSubsequentBunchCrossing = cms.uint32(0),
 	simHitCollections = cms.PSet(
@@ -32,3 +33,6 @@ caloParticles = cms.PSet(
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(caloParticles, cms.PSet()) # don't allow this to run in fastsim
+
+from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
+premix_stage1.toModify(caloParticles, premixStage1 = True)

--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -87,7 +87,8 @@ theDigitizersValid = cms.PSet(theDigitizers)
 theDigitizers.mergedtruth.select.signalOnlyTP = True
 
 phase2_hgcal.toModify( theDigitizersValid,
-                       calotruth = cms.PSet( caloParticles ) )
+                       calotruth = cms.PSet( caloParticles ) ) # Doesn't HGCal need these also without validation?
+(premix_stage2 & phase2_hgcal).toModify(theDigitizersValid, calotruth = dict(premixStage1 = True))
 
 
 phase2_timing.toModify( theDigitizersValid.mergedtruth,

--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -76,9 +76,12 @@ phase2_timing_layer.toModify( theDigitizers,
 premix_stage2.toModify(theDigitizers,
     ecal = None,
     hcal = None,
-    # TODO: what to do with hgcal?
 )
-
+(premix_stage2 & phase2_hgcal).toModify(theDigitizers,
+    hgceeDigitizer = dict(premixStage1 = True),
+    hgchebackDigitizer = dict(premixStage1 = True),
+    hgchefrontDigitizer = dict(premixStage1 = True),
+)
 
 theDigitizersValid = cms.PSet(theDigitizers)
 theDigitizers.mergedtruth.select.signalOnlyTP = True

--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -99,11 +99,8 @@ def _customizePremixStage1(mod):
     # To avoid this if-else structure we'd need an "_InverseModifier"
     # to customize pixel/strip for everything else than fastSim.
     if hasattr(mod, "pixel"):
-        if hasattr(mod.pixel, "PixelDigitizerAlgorithm"):
-            mod.pixel.PixelDigitizerAlgorithm.makeDigiSimLinks = True
-            mod.pixel.PSPDigitizerAlgorithm.makeDigiSimLinks = True
-            mod.pixel.PSSDigitizerAlgorithm.makeDigiSimLinks = True
-            mod.pixel.SSDigitizerAlgorithm.makeDigiSimLinks = True
+        if hasattr(mod.pixel, "AlgorithmCommon"):
+            mod.pixel.AlgorithmCommon.makeDigiSimLinks = True
         else:
             mod.pixel.makeDigiSimLinks = True
     if hasattr(mod, "strip"):

--- a/SimGeneral/MixingModule/python/mixObjects_cfi.py
+++ b/SimGeneral/MixingModule/python/mixObjects_cfi.py
@@ -47,6 +47,7 @@ mixSimHits = cms.PSet(
     #    'TotemHitsRP',
     #    'TotemHitsT1',
     #    'TotemHitsT2Gem')
+    pcrossingFrames = cms.untracked.vstring()
 )
 
 # fastsim customs
@@ -98,6 +99,7 @@ fastSim.toModify(mixCaloHits,
                'EcalHitsES',
                'HcalHits']
 )
+
 
 mixSimTracks = cms.PSet(
     makeCrossingFrame = cms.untracked.bool(False),
@@ -235,6 +237,12 @@ phase2_muon.toModify( theMixObjects,
         input = theMixObjects.mixSH.input + [ cms.InputTag("g4SimHits","MuonME0Hits") ],
         subdets = theMixObjects.mixSH.subdets + [ 'MuonME0Hits' ],
         crossingFrames = theMixObjects.mixSH.crossingFrames + [ 'MuonME0Hits' ]
+    )
+)
+from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
+(premix_stage1 & phase2_muon).toModify(theMixObjects,
+    mixSH = dict(
+        pcrossingFrames = theMixObjects.mixSH.pcrossingFrames + [ 'MuonME0Hits' ]
     )
 )
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -13,15 +13,18 @@ premix_stage1.toModify(pixelDigitizer, makeDigiSimLinks = False)
 
 # Customize here instead of SiPixelSimBlock as the latter is imported
 # also to DataMixer configuration, and the original version is needed
-# there. Customize before phase2_tracker because this customization
-# applies only to phase0/1 pixel, and at the moment it is unclear what
-# needs to be done for phase2 tracker in premixing stage2.
+# there in stage2. Customize before phase2_tracker because this
+# customization applies only to phase0/1 pixel.
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(pixelDigitizer,
     AddPixelInefficiency = False # will be added in DataMixer
 )
 
-from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import phase2TrackerDigitizer as _phase2TrackerDigitizer
+from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import phase2TrackerDigitizer as _phase2TrackerDigitizer, _premixStage1ModifyDict
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toReplaceWith(pixelDigitizer, _phase2TrackerDigitizer)
+phase2_tracker.toReplaceWith(pixelDigitizer, _phase2TrackerDigitizer.clone()) # have to clone here in order to not change the original with further customizations
 
+# Customize here instead of phase2TrackerDigitizer as the latter is
+# imported also to DataMixer configuration, and the original version
+# is needed there in stage2.
+(premix_stage2 & phase2_tracker).toModify(pixelDigitizer, **_premixStage1ModifyDict)

--- a/SimGeneral/PreMixingModule/interface/PreMixingWorker.h
+++ b/SimGeneral/PreMixingModule/interface/PreMixingWorker.h
@@ -17,6 +17,7 @@ public:
   virtual ~PreMixingWorker() = default;
 
   virtual void beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {}
+  virtual void endRun() {}
   virtual void beginLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const& iSetup) {}
   virtual void initializeBunchCrossing(edm::Event const& iEvent, edm::EventSetup const& iSetup, int bunchCrossing) {}
   virtual void finalizeBunchCrossing(edm::Event& iEvent, edm::EventSetup const& iSetup, int bunchCrossing) {}

--- a/SimGeneral/PreMixingModule/plugins/PreMixingCrossingFrameWorker.cc
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingCrossingFrameWorker.cc
@@ -1,0 +1,88 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventPrincipal.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
+#include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
+
+#include "SimGeneral/PreMixingModule/interface/PreMixingWorker.h"
+#include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
+
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/PCrossingFrame.h"
+
+namespace edm {
+  template <typename T>
+  class PreMixingCrossingFrameWorker: public PreMixingWorker {
+  public:
+    PreMixingCrossingFrameWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
+    ~PreMixingCrossingFrameWorker() override = default;
+
+    void initializeEvent(edm::Event const& iEvent, edm::EventSetup const& iSetup) override {}
+    void addSignals(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
+    void addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& iSetup) override;
+    void put(edm::Event& iEvent, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bunchSpacing) override;
+
+  private:
+    edm::EDGetTokenT<CrossingFrame<T> > signalToken_;
+    edm::InputTag pileupTag_;
+    std::string collectionDM_; // secondary name to be given to new digis
+
+    std::unique_ptr<PCrossingFrame<T> > merged_;
+  };
+
+  template <typename T>
+  PreMixingCrossingFrameWorker<T>::PreMixingCrossingFrameWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC):
+    signalToken_(iC.consumes<CrossingFrame<T> >(ps.getParameter<edm::InputTag>("labelSig"))),
+    pileupTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
+    collectionDM_(ps.getParameter<std::string>("collectionDM"))
+  {
+    producer.produces<PCrossingFrame<T> >(collectionDM_); // TODO: this is needed only to store the pointed-to objects, do we really need it?
+    producer.produces<CrossingFrame<T> >(collectionDM_);
+  }
+
+  template <typename T>
+  void PreMixingCrossingFrameWorker<T>::addSignals(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
+    edm::Handle<CrossingFrame<T> > hcf;
+    iEvent.getByToken(signalToken_, hcf);
+
+    const auto& cf = *hcf;
+    if(!cf.getPileups().empty()) {
+      throw cms::Exception("LogicError") << "Got CrossingFrame from signal with pileup content?";
+    }
+
+    merged_ = std::make_unique<PCrossingFrame<T> >(cf); // for signal we just copy
+  }
+
+  template <typename T>
+  void PreMixingCrossingFrameWorker<T>::addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& iSetup) {
+    edm::Handle<PCrossingFrame<T> > hcf;
+    pep.getByLabel(pileupTag_, hcf);
+
+    const auto& cf = *hcf;
+    if(!cf.getSignals().empty()) {
+      throw cms::Exception("LogicError") << "Got PCrossingFrame from pileup with signal content?";
+    }
+
+    merged_->setAllExceptSignalFrom(cf);
+  }
+
+  template <typename T>
+    void PreMixingCrossingFrameWorker<T>::put(edm::Event& iEvent, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bunchSpacing) {
+    auto orphanHandle = iEvent.put(std::move(merged_), collectionDM_);
+    const auto& pcf = *orphanHandle;
+
+    const auto bx = pcf.getBunchRange();
+    auto cf = std::make_unique<CrossingFrame<T> >(bx.first, bx.second, pcf.getBunchSpace(), pcf.getSubDet(), pcf.getMaxNbSources());
+    cf->addSignals(&(pcf.getSignals()), pcf.getEventID());
+    cf->setPileups(pcf.getPileups());
+    iEvent.put(std::move(cf), collectionDM_);
+  }
+}
+
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+namespace edm {
+  using PreMixingCrossingFramePSimHitWorker = PreMixingCrossingFrameWorker<PSimHit>;
+}
+
+DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, edm::PreMixingCrossingFramePSimHitWorker, "PreMixingCrossingFramePSimHitWorker");

--- a/SimGeneral/PreMixingModule/plugins/PreMixingModule.cc
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingModule.cc
@@ -111,6 +111,9 @@ namespace edm {
   }
 
   void PreMixingModule::endRun(edm::Run const& run, const edm::EventSetup& ES) { 
+    for(auto& w: workers_) {
+      w->endRun();
+    }
     BMixingModule::endRun( run, ES);
   }
 

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -345,6 +345,13 @@ phase2_hgcal.toModify(mixData,
             digiTagSig = cms.InputTag("mix", "HGCDigisHEback"),
             pileInputTag = cms.InputTag("mix", "HGCDigisHEback"),
         ),
+        caloTruth = cms.PSet(
+            workerType = cms.string("PreMixingCaloParticleWorker"),
+            #
+            labelSig = cms.InputTag("mix", "MergedCaloTruth"),
+            pileInputTag = cms.InputTag("mix", "MergedCaloTruth"),
+            collectionDM = cms.string("MergedCaloTruth"),
+        )
     )
 )
 

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -256,6 +256,7 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 from Configuration.Eras.Modifier_phase2_ecal_cff import phase2_ecal
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_common.toModify(mixData, input = dict(producers = [])) # we use digis directly, no need for raw2digi producers
 
 # Tracker
@@ -295,3 +296,17 @@ phase2_hcal.toModify(mixData,
 )
 
 # TODO: Add HGCAL, but needs code first
+
+# Muon
+phase2_muon.toModify(mixData,
+    workers = dict(
+        dt = dict(pileInputTag = "simMuonDTDigis"),
+        rpc = dict(pileInputTag = "simMuonRPCDigis"),
+        csc = dict(
+            strip = dict(pileInputTag = "simMuonCSCDigis:MuonCSCStripDigi"),
+            wire = dict(pileInputTag = "simMuonCSCDigis:MuonCSCWireDigi"),
+            comparator = dict(pileInputTag = "simMuonCSCDigis:MuonCSCComparatorDigi"),
+        )
+    )
+)
+# TODO: Add GEM and ME0, but needs code first

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -11,6 +11,7 @@ from SimCalorimetry.HcalSimProducers.hcalUnsuppressedDigis_cfi import hcalSimBlo
 from SimGeneral.MixingModule.SiStripSimParameters_cfi import SiStripSimBlock
 from SimGeneral.MixingModule.SiPixelSimParameters_cfi import SiPixelSimBlock
 from SimGeneral.MixingModule.ecalDigitizer_cfi import ecalDigitizer
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchebackDigitizer, hgchefrontDigitizer
 
 import EventFilter.EcalRawToDigi.EcalUnpackerData_cfi
 import EventFilter.ESRawToDigi.esRawToDigi_cfi
@@ -307,7 +308,34 @@ phase2_hcal.toModify(mixData,
     )
 )
 
-# TODO: Add HGCAL, but needs code first
+phase2_hgcal.toModify(mixData,
+    workers = dict(
+        hgcee = cms.PSet(
+            hgceeDigitizer,
+            #
+            workerType = cms.string("PreMixingHGCalWorker"),
+            #
+            digiTagSig = cms.InputTag("mix", "HGCDigisEE"),
+            pileInputTag = cms.InputTag("mix", "HGCDigisEE"),
+        ),
+        hgchefront = cms.PSet(
+            hgchefrontDigitizer,
+            #
+            workerType = cms.string("PreMixingHGCalWorker"),
+            #
+            digiTagSig = cms.InputTag("mix", "HGCDigisHEfront"),
+            pileInputTag = cms.InputTag("mix", "HGCDigisHEfront"),
+        ),
+        hgcheback = cms.PSet(
+            hgchebackDigitizer,
+            #
+            workerType = cms.string("PreMixingHGCalWorker"),
+            #
+            digiTagSig = cms.InputTag("mix", "HGCDigisHEback"),
+            pileInputTag = cms.InputTag("mix", "HGCDigisHEback"),
+        ),
+    )
+)
 
 # Muon
 phase2_muon.toModify(mixData,

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -10,6 +10,7 @@ import FWCore.ParameterSet.Config as cms
 from SimCalorimetry.HcalSimProducers.hcalUnsuppressedDigis_cfi import hcalSimBlock
 from SimGeneral.MixingModule.SiStripSimParameters_cfi import SiStripSimBlock
 from SimGeneral.MixingModule.SiPixelSimParameters_cfi import SiPixelSimBlock
+from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import phase2TrackerDigitizer, _premixStage1ModifyDict as _phase2TrackerPremixStage1ModifyDict
 from SimGeneral.MixingModule.ecalDigitizer_cfi import ecalDigitizer
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchebackDigitizer, hgchefrontDigitizer
 
@@ -266,8 +267,18 @@ phase2_tracker.toModify(mixData,
         # Disable SiStrip
         strip = None,
         stripSimLink = None,
-        # Add Phase2 OT digiSimLink
-        # TODO: Add digis, but needs code first
+        # Replace pixel with Phase2 tracker
+        pixel = cms.PSet(
+            phase2TrackerDigitizer,
+            #
+            workerType = cms.string("PreMixingPhase2TrackerWorker"),
+            #
+            pixelLabelSig = cms.InputTag("simSiPixelDigis:Pixel"),
+            pixelPileInputTag = cms.InputTag("simSiPixelDigis:Pixel"),
+            trackerLabelSig = cms.InputTag("simSiPixelDigis:Tracker"),
+            trackerPileInputTag = cms.InputTag("simSiPixelDigis:Tracker"),
+            premixStage1ElectronPerAdc = cms.double(_phase2TrackerPremixStage1ModifyDict["PixelDigitizerAlgorithm"]["ElectronPerAdc"])
+        ),
         pixelSimLink = dict(
             labelSig = "simSiPixelDigis:Pixel",
             pileInputTag = "simSiPixelDigis:Pixel",

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -318,7 +318,48 @@ phase2_muon.toModify(mixData,
             strip = dict(pileInputTag = "simMuonCSCDigis:MuonCSCStripDigi"),
             wire = dict(pileInputTag = "simMuonCSCDigis:MuonCSCWireDigi"),
             comparator = dict(pileInputTag = "simMuonCSCDigis:MuonCSCComparatorDigi"),
-        )
+        ),
+        gem = cms.PSet(
+            workerType = cms.string("PreMixingGEMWorker"),
+            #
+            digiTagSig = cms.InputTag("simMuonGEMDigis"),
+            pileInputTag = cms.InputTag("simMuonGEMDigis",""),
+            collectionDM = cms.string(''),
+        ),
+        me0 = cms.PSet(
+            workerType = cms.string("PreMixingME0Worker"),
+            #
+            digiTagSig = cms.InputTag("simMuonME0Digis"),
+            pileInputTag = cms.InputTag("simMuonME0Digis",""),
+            collectionDM = cms.string(''),
+        ),
+        gemSimLink = cms.PSet(
+            workerType = cms.string("PreMixingGEMDigiSimLinkWorker"),
+            #
+            labelSig = cms.InputTag("simMuonGEMDigis"),
+            pileInputTag = cms.InputTag("simMuonGEMDigis"),
+            collectionDM = cms.string('GEMDigiSimLink'),
+        ),
+        gemStripSimLink = cms.PSet(
+            workerType = cms.string("PreMixingStripDigiSimLinkWorker"),
+            #
+            labelSig = cms.InputTag("simMuonGEMDigis"),
+            pileInputTag = cms.InputTag("simMuonGEMDigis"),
+            collectionDM = cms.string('GEMStripDigiSimLink'),
+        ),
+        me0SimLink = cms.PSet(
+            workerType = cms.string("PreMixingME0DigiSimLinkWorker"),
+            #
+            labelSig = cms.InputTag("simMuonMe0Digis"),
+            pileInputTag = cms.InputTag("simMuonME0Digis"),
+            collectionDM = cms.string('ME0DigiSimLink'),
+        ),
+        me0StripSimLink = cms.PSet(
+            workerType = cms.string("PreMixingStripDigiSimLinkWorker"),
+            #
+            labelSig = cms.InputTag("simMuonME0Digis"),
+            pileInputTag = cms.InputTag("simMuonME0Digis"),
+            collectionDM = cms.string('ME0StripDigiSimLink'),
+        ),
     )
 )
-# TODO: Add GEM and ME0, but needs code first

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -253,6 +253,8 @@ fastSim.toModify(mixData,
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+from Configuration.Eras.Modifier_phase2_ecal_cff import phase2_ecal
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_common.toModify(mixData, input = dict(producers = [])) # we use digis directly, no need for raw2digi producers
 
 # Tracker
@@ -264,3 +266,15 @@ phase2_tracker.toModify(mixData,
         stripSimLink = None,
     ),
 )
+
+# ECAL
+phase2_ecal.toModify(mixData,
+    workers = dict(
+        ecal = dict(
+            doES = False,
+            EBPileInputTag = "simEcalDigis:ebDigis",
+            EEPileInputTag = "simEcalDigis:eeDigis",
+        )
+    )
+)
+phase2_hgcal.toModify(mixData, workers=dict(ecal=dict(doEE=False)))

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -250,3 +250,17 @@ fastSim.toModify(mixData,
         )
     ),
 )
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_common.toModify(mixData, input = dict(producers = [])) # we use digis directly, no need for raw2digi producers
+
+# Tracker
+# TODO: Add phase2 OT, but needs code first
+phase2_tracker.toModify(mixData,
+    workers = dict(
+        # Disable SiStrip
+        strip = None,
+        stripSimLink = None,
+    ),
+)

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -254,6 +254,7 @@ fastSim.toModify(mixData,
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 from Configuration.Eras.Modifier_phase2_ecal_cff import phase2_ecal
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_common.toModify(mixData, input = dict(producers = [])) # we use digis directly, no need for raw2digi producers
 
@@ -278,3 +279,19 @@ phase2_ecal.toModify(mixData,
     )
 )
 phase2_hgcal.toModify(mixData, workers=dict(ecal=dict(doEE=False)))
+
+# HCAL
+phase2_hcal.toModify(mixData,
+    workers = dict(
+        hcal = dict(
+            HBHEPileInputTag = "simHcalDigis",
+            HOPileInputTag = "simHcalDigis",
+            HFPileInputTag = "simHcalDigis",
+            QIE10PileInputTag = "simHcalDigis:HFQIE10DigiCollection",
+            QIE11PileInputTag = "simHcalDigis:HBHEQIE11DigiCollection",
+            ZDCPileInputTag = "simHcalUnsuppressedDigis",
+        )
+    )
+)
+
+# TODO: Add HGCAL, but needs code first

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -260,12 +260,24 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_common.toModify(mixData, input = dict(producers = [])) # we use digis directly, no need for raw2digi producers
 
 # Tracker
-# TODO: Add phase2 OT, but needs code first
 phase2_tracker.toModify(mixData,
     workers = dict(
         # Disable SiStrip
         strip = None,
         stripSimLink = None,
+        # Add Phase2 OT digiSimLink
+        # TODO: Add digis, but needs code first
+        pixelSimLink = dict(
+            labelSig = "simSiPixelDigis:Pixel",
+            pileInputTag = "simSiPixelDigis:Pixel",
+        ),
+        phase2OTSimLink = cms.PSet(
+            workerType = cms.string("PreMixingPixelDigiSimLinkWorker"),
+            #
+            labelSig = cms.InputTag("simSiPixelDigis:Tracker"),
+            pileInputTag = cms.InputTag("simSiPixelDigis:Tracker"),
+            collectionDM = cms.string("Phase2OTDigiSimLink"),
+        ),
     ),
 )
 

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -379,6 +379,13 @@ phase2_muon.toModify(mixData,
             pileInputTag = cms.InputTag("simMuonME0Digis",""),
             collectionDM = cms.string(''),
         ),
+        me0SimHit = cms.PSet(
+            workerType = cms.string("PreMixingCrossingFramePSimHitWorker"),
+            #
+            labelSig = cms.InputTag("mix", "g4SimHitsMuonME0Hits"),
+            pileInputTag = cms.InputTag("mix", "g4SimHitsMuonME0Hits"),
+            collectionDM = cms.string("g4SimHitsMuonME0Hits"),
+        ),
         gemSimLink = cms.PSet(
             workerType = cms.string("PreMixingGEMDigiSimLinkWorker"),
             #

--- a/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
@@ -93,7 +93,6 @@ run3_GEM.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCom
 run3_GEM.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
 run3_GEM.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
 
-
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonME0PseudoDigis_*_*',
                                                                                             'keep *_simMuonME0PseudoReDigis_*_*',
@@ -102,3 +101,11 @@ phase2_muon.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.output
                                                                                             'keep *_simMuonME0PadDigiClusters_*_*'] )
 phase2_muon.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )
 phase2_muon.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )
+
+# For phase2 premixing switch the sim digi collections to the ones including pileup
+(premix_stage2 & phase2_muon).toModify(SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + [
+    'drop *_simMuonGEMDigis_*_*',
+    'keep GEMDetIdGEMDigiMuonDigiCollection_mixData_*_*',
+    'drop *_simMuonME0Digis_*_*',
+    'keep ME0DetIdME0DigiMuonDigiCollection_mixData_*_*',
+])

--- a/SimMuon/GEMDigitizer/plugins/BuildFile.xml
+++ b/SimMuon/GEMDigitizer/plugins/BuildFile.xml
@@ -10,6 +10,7 @@
   <use name="DataFormats/GeometryVector"/>
   <use name="Geometry/Records"/>
   <use name="CondFormats/DataRecord"/>
+  <use name="SimGeneral/PreMixingModule"/>
 
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/SimMuon/GEMDigitizer/plugins/PreMixingGEMDigiSimLinkWorkers.cc
+++ b/SimMuon/GEMDigitizer/plugins/PreMixingGEMDigiSimLinkWorkers.cc
@@ -1,0 +1,12 @@
+#include "SimGeneral/PreMixingModule/interface/PreMixingDigiSimLinkWorker.h"
+#include "SimDataFormats/GEMDigiSimLink/interface/GEMDigiSimLink.h"
+#include "SimDataFormats/GEMDigiSimLink/interface/ME0DigiSimLink.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+
+using PreMixingGEMDigiSimLinkWorker = PreMixingDigiSimLinkWorker<edm::DetSetVector<GEMDigiSimLink> >;
+using PreMixingME0DigiSimLinkWorker = PreMixingDigiSimLinkWorker<edm::DetSetVector<ME0DigiSimLink> >;
+
+// register plugins
+#include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
+DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingGEMDigiSimLinkWorker , "PreMixingGEMDigiSimLinkWorker");
+DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingME0DigiSimLinkWorker , "PreMixingME0DigiSimLinkWorker");

--- a/SimMuon/GEMDigitizer/plugins/PreMixingGEMWorkers.cc
+++ b/SimMuon/GEMDigitizer/plugins/PreMixingGEMWorkers.cc
@@ -1,0 +1,10 @@
+#include "SimGeneral/PreMixingModule/interface/PreMixingMuonWorker.h"
+#include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
+#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/ME0DigiCollection.h"
+
+using PreMixingGEMWorker = PreMixingMuonWorker<GEMDigiCollection>;
+using PreMixingME0Worker = PreMixingMuonWorker<ME0DigiCollection>;
+
+DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingGEMWorker, "PreMixingGEMWorker");
+DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingME0Worker, "PreMixingME0Worker");

--- a/SimMuon/GEMDigitizer/python/muonGEMDigi_cff.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMDigi_cff.py
@@ -5,3 +5,10 @@ from SimMuon.GEMDigitizer.muonGEMPadDigis_cfi import *
 from SimMuon.GEMDigitizer.muonGEMPadDigiClusters_cfi import *
 
 muonGEMDigi = cms.Sequence(simMuonGEMDigis*simMuonGEMPadDigis*simMuonGEMPadDigiClusters)
+
+# In phase2 premixing we use simMuonGEMDigis for the overlay, and the rest are run after that
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+(premix_stage2 & phase2_muon).toReplaceWith(muonGEMDigi, cms.Sequence(simMuonGEMDigis))
+
+muonGEMDigiDM = cms.Sequence(simMuonGEMPadDigis*simMuonGEMPadDigiClusters)

--- a/SimMuon/GEMDigitizer/python/muonGEMPadDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMPadDigis_cfi.py
@@ -4,3 +4,7 @@ import FWCore.ParameterSet.Config as cms
 simMuonGEMPadDigis = cms.EDProducer("GEMPadDigiProducer",
     InputCollection = cms.InputTag('simMuonGEMDigis'),
 )
+
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+(premix_stage2 & phase2_muon).toModify(simMuonGEMPadDigis, InputCollection = "mixData")

--- a/SimMuon/GEMDigitizer/python/muonME0Digi_cff.py
+++ b/SimMuon/GEMDigitizer/python/muonME0Digi_cff.py
@@ -11,3 +11,9 @@ muonME0RealDigi = cms.Sequence(simMuonME0Digis * simMuonME0PadDigis + simMuonME0
 muonME0PseudoDigi = cms.Sequence(simMuonME0PseudoDigis * simMuonME0PseudoReDigis)
 
 muonME0Digi = cms.Sequence(muonME0RealDigi * muonME0PseudoDigi)
+
+# In premixing we use simMuonME0Digis for the overlay, and the rest are run after that
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toReplaceWith(muonME0Digi, cms.Sequence(simMuonME0Digis))
+
+muonME0DigiDM = cms.Sequence(simMuonME0PadDigis + simMuonME0PadDigiClusters + muonME0PseudoDigi)

--- a/SimMuon/GEMDigitizer/python/muonME0PseudoDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0PseudoDigis_cfi.py
@@ -28,6 +28,9 @@ me0PseudoDigiCommonParameters = cms.PSet(
     mixLabel = cms.string('mix')
 )
 
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(me0PseudoDigiCommonParameters, mixLabel = "mixData")
+
 # Module to create simulated ME0 Pre Reco digis.
 simMuonME0PseudoDigis = cms.EDProducer("ME0DigiPreRecoProducer",
     me0PseudoDigiCommonParameters

--- a/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
+++ b/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
@@ -123,6 +123,7 @@ premix_stage2.toModify(muonAssociatorByHitsCommonParameters,
     RPCdigisimlinkTag = "mixData:RPCDigiSimLink",
     pixelSimLinkSrc = "mixData:PixelDigiSimLink",
     stripSimLinkSrc = "mixData:StripDigiSimLink",
+    phase2TrackerSimLinkSrc = "mixData:Phase2OTDigiSimLink",
 )
   
 muonAssociatorByHits = cms.EDProducer("MuonAssociatorEDProducer",

--- a/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
+++ b/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
@@ -124,6 +124,7 @@ premix_stage2.toModify(muonAssociatorByHitsCommonParameters,
     pixelSimLinkSrc = "mixData:PixelDigiSimLink",
     stripSimLinkSrc = "mixData:StripDigiSimLink",
     phase2TrackerSimLinkSrc = "mixData:Phase2OTDigiSimLink",
+    GEMdigisimlinkTag = "mixData:GEMStripDigiSimLink",
 )
   
 muonAssociatorByHits = cms.EDProducer("MuonAssociatorEDProducer",

--- a/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
+++ b/SimTracker/Configuration/python/SimTracker_EventContent_cff.py
@@ -18,6 +18,14 @@ SimTrackerFEVTDEBUG = cms.PSet(
         'keep *_TTStubAssociatorFromPixelDigis_*_*')
 
 )
+# For phase2 premixing switch the sim digi collections to the ones including pileup
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+(premix_stage2 & phase2_tracker).toModify(SimTrackerFEVTDEBUG, outputCommands = SimTrackerFEVTDEBUG.outputCommands + [
+    'drop *_simSiPixelDigis_*_*',
+    'keep *_mixData_Pixel_*',
+    'keep *_mixData_Tracker_*',
+])
 
 SimTrackerDEBUG = cms.PSet(
     outputCommands = cms.untracked.vstring(

--- a/SimTracker/SiPhase2Digitizer/plugins/BuildFile.xml
+++ b/SimTracker/SiPhase2Digitizer/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="SimTracker/SiPhase2Digitizer"/>
-<library   file="Phase2TrackerDigitizer.cc PSPDigitizerAlgorithm.cc Phase2TrackerDigitizerAlgorithm.cc PixelDigitizerAlgorithm.cc PSSDigitizerAlgorithm.cc SSDigitizerAlgorithm.cc" name="SimTrackerSiPhase2DigitizerPlugins">
+<library   file="*.cc" name="SimTrackerSiPhase2DigitizerPlugins">
+  <use name="SimGeneral/PreMixingModule"/>
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
@@ -83,12 +83,15 @@ namespace cms
     trackerContainers_(iConfig.getParameter<std::vector<std::string> >("ROUList")),
     geometryType_(iConfig.getParameter<std::string>("GeometryType")),
     isOuterTrackerReadoutAnalog(iConfig.getParameter<bool>("isOTreadoutAnalog")),
-    premixStage1_(iConfig.getParameter<bool>("premixStage1"))
+    premixStage1_(iConfig.getParameter<bool>("premixStage1")),
+    makeDigiSimLinks_(iConfig.getParameter<edm::ParameterSet>("AlgorithmCommon").getUntrackedParameter<bool>("makeDigiSimLinks"))
   {
     //edm::LogInfo("Phase2TrackerDigitizer") << "Initialize Digitizer Algorithms";
     const std::string alias1("simSiPixelDigis"); 
     mixMod.produces<edm::DetSetVector<PixelDigi> >("Pixel").setBranchAlias(alias1);
-    mixMod.produces<edm::DetSetVector<PixelDigiSimLink> >("Pixel").setBranchAlias(alias1);
+    if(makeDigiSimLinks_) {
+      mixMod.produces<edm::DetSetVector<PixelDigiSimLink> >("Pixel").setBranchAlias(alias1);
+    }
 
     if(!iConfig.getParameter<bool>("isOTreadoutAnalog")) {
       const std::string alias2("simSiTrackerDigis");
@@ -100,7 +103,9 @@ namespace cms
       else {
         mixMod.produces<edm::DetSetVector<Phase2TrackerDigi> >("Tracker").setBranchAlias(alias2);
       }
-      mixMod.produces<edm::DetSetVector<PixelDigiSimLink> >("Tracker").setBranchAlias(alias2);
+      if(makeDigiSimLinks_) {
+        mixMod.produces<edm::DetSetVector<PixelDigiSimLink> >("Tracker").setBranchAlias(alias2);
+      }
     }
     // creating algorithm objects and pushing them into the map
     algomap_[AlgorithmType::InnerPixel] = std::make_unique<PixelDigitizerAlgorithm>(iConfig);
@@ -317,7 +322,9 @@ namespace cms
     
     // Step D: write output to file 
     iEvent.put(std::move(output), "Pixel");
-    iEvent.put(std::move(outputlink), "Pixel");
+    if(makeDigiSimLinks_) {
+      iEvent.put(std::move(outputlink), "Pixel");
+    }
   }
 }
 namespace {
@@ -373,7 +380,9 @@ namespace cms {
     
     // Step D: write output to file 
     iEvent.put(std::move(output), "Tracker");
-    iEvent.put(std::move(outputlink), "Tracker");
+    if(makeDigiSimLinks_) {
+      iEvent.put(std::move(outputlink), "Tracker");
+    }
   }
 }
 

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
@@ -82,17 +82,26 @@ namespace cms
     hitsProducer_(iConfig.getParameter<std::string>("hitsProducer")),
     trackerContainers_(iConfig.getParameter<std::vector<std::string> >("ROUList")),
     geometryType_(iConfig.getParameter<std::string>("GeometryType")),
-    isOuterTrackerReadoutAnalog(iConfig.getParameter<bool>("isOTreadoutAnalog"))
+    isOuterTrackerReadoutAnalog(iConfig.getParameter<bool>("isOTreadoutAnalog")),
+    premixStage1_(iConfig.getParameter<bool>("premixStage1"))
   {
     //edm::LogInfo("Phase2TrackerDigitizer") << "Initialize Digitizer Algorithms";
     const std::string alias1("simSiPixelDigis"); 
     mixMod.produces<edm::DetSetVector<PixelDigi> >("Pixel").setBranchAlias(alias1);
     mixMod.produces<edm::DetSetVector<PixelDigiSimLink> >("Pixel").setBranchAlias(alias1);
 
-    const std::string alias2("simSiTrackerDigis"); 
-    mixMod.produces<edm::DetSetVector<Phase2TrackerDigi> >("Tracker").setBranchAlias(alias2);
-    mixMod.produces<edm::DetSetVector<PixelDigiSimLink> >("Tracker").setBranchAlias(alias2);
-
+    if(!iConfig.getParameter<bool>("isOTreadoutAnalog")) {
+      const std::string alias2("simSiTrackerDigis");
+      if(premixStage1_) {
+        // Premixing exploits the ADC field of PixelDigi to store the collected charge
+        // But we still want everything else to be treated like for Phase2TrackerDigi
+        mixMod.produces<edm::DetSetVector<PixelDigi> >("Tracker").setBranchAlias(alias2);
+      }
+      else {
+        mixMod.produces<edm::DetSetVector<Phase2TrackerDigi> >("Tracker").setBranchAlias(alias2);
+      }
+      mixMod.produces<edm::DetSetVector<PixelDigiSimLink> >("Tracker").setBranchAlias(alias2);
+    }
     // creating algorithm objects and pushing them into the map
     algomap_[AlgorithmType::InnerPixel] = std::make_unique<PixelDigitizerAlgorithm>(iConfig);
     algomap_[AlgorithmType::PixelinPS]  = std::make_unique<PSPDigitizerAlgorithm>(iConfig);
@@ -206,11 +215,27 @@ namespace cms
       if (simHits.isValid()) crossingSimHitIndexOffset_[tag.encode()] += simHits->size();
      }
   }
+
+  // For premixing
+  void Phase2TrackerDigitizer::loadAccumulator(const std::map<unsigned int, std::map<int, float> >& accumulator) {
+    for(const auto& detMap: accumulator) {
+      AlgorithmType algoType = getAlgoType(detMap.first);
+      auto& algo = *(algomap_.at(algoType));
+      algo.loadAccumulator(detMap.first, detMap.second);
+    }
+  }
+
   void Phase2TrackerDigitizer::finalizeEvent(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     //Decide if we want analog readout for Outer Tracker.
     addPixelCollection(iEvent, iSetup, isOuterTrackerReadoutAnalog);
-    if(!isOuterTrackerReadoutAnalog)
-      addOuterTrackerCollection(iEvent, iSetup);
+    if(!isOuterTrackerReadoutAnalog) {
+      if(premixStage1_) {
+        addOuterTrackerCollection<PixelDigi>(iEvent, iSetup);
+      }
+      else {
+        addOuterTrackerCollection<Phase2TrackerDigi>(iEvent, iSetup);
+      }
+    }
   }
   Phase2TrackerDigitizer::AlgorithmType Phase2TrackerDigitizer::getAlgoType(unsigned int detId_raw) {
     DetId detId(detId_raw); 
@@ -294,9 +319,26 @@ namespace cms
     iEvent.put(std::move(output), "Pixel");
     iEvent.put(std::move(outputlink), "Pixel");
   }
+}
+namespace {
+  void addToCollector(edm::DetSet<PixelDigi>& collector, const int channel, const DigitizerUtility::DigiSimInfo& info) {
+    // For premixing stage1 the channel must be decoded with PixelDigi
+    // so that when the row and column are inserted to PixelDigi the
+    // coded channel stays the same (so that it can then be decoded
+    // with Phase2TrackerDigi in stage2).
+    std::pair<int,int> ip = PixelDigi::channelToPixel(channel);
+    collector.data.emplace_back(ip.first, ip.second, info.sig_tot);
+  }
+  void addToCollector(edm::DetSet<Phase2TrackerDigi>& collector, const int channel, const DigitizerUtility::DigiSimInfo& info) {
+    std::pair<int,int> ip = Phase2TrackerDigi::channelToPixel(channel);
+    collector.data.emplace_back(ip.first, ip.second, info.ot_bit);
+  }
+}
+namespace cms {
+  template <typename DigiType>
   void Phase2TrackerDigitizer::addOuterTrackerCollection(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     const TrackerTopology* tTopo = tTopoHand.product();
-    std::vector<edm::DetSet<Phase2TrackerDigi> > digiVector;
+    std::vector<edm::DetSet<DigiType> > digiVector;
     std::vector<edm::DetSet<PixelDigiSimLink> > digiLinkVector;
     for (auto const & det_u : pDD_->detUnits()) {
       DetId detId_raw = DetId(det_u->geographicalId().rawId());
@@ -307,13 +349,12 @@ namespace cms
       std::map<int, DigitizerUtility::DigiSimInfo> digi_map;
       algomap_[algotype]->digitize(dynamic_cast<const Phase2TrackerGeomDetUnit*>(det_u),
 				   digi_map, tTopo);
-      edm::DetSet<Phase2TrackerDigi> collector(det_u->geographicalId().rawId());
+      edm::DetSet<DigiType> collector(det_u->geographicalId().rawId());
       edm::DetSet<PixelDigiSimLink> linkcollector(det_u->geographicalId().rawId());
       
       for (auto const & digi_p : digi_map) {
 	DigitizerUtility::DigiSimInfo info = digi_p.second;  
-	std::pair<int,int> ip = Phase2TrackerDigi::channelToPixel(digi_p.first);
-	collector.data.emplace_back(ip.first, ip.second, info.ot_bit);
+        addToCollector(collector, digi_p.first, info);
         for (auto const & sim_p : info.simInfoList) {
 
 	  linkcollector.data.emplace_back(digi_p.first, sim_p.second->trackId(), sim_p.second->hitIndex(), sim_p.second->tofBin(), sim_p.second->eventId(), sim_p.first);
@@ -325,8 +366,8 @@ namespace cms
     } 
     
     // Step C: create collection with the cache vector of DetSet 
-    std::unique_ptr<edm::DetSetVector<Phase2TrackerDigi> >
-      output(new edm::DetSetVector<Phase2TrackerDigi>(digiVector));
+    std::unique_ptr<edm::DetSetVector<DigiType> >
+      output(new edm::DetSetVector<DigiType>(digiVector));
     std::unique_ptr<edm::DetSetVector<PixelDigiSimLink> >
       outputlink(new edm::DetSetVector<PixelDigiSimLink>(digiLinkVector));
     

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
@@ -64,7 +64,8 @@ namespace cms
     template <class T>
     void accumulate_local(T const& iEvent, edm::EventSetup const& iSetup);
 
-  
+    // For premixing
+    void loadAccumulator(const std::map<unsigned int, std::map<int, float> >& accumulator);
   private:
     using vstring = std::vector<std::string> ;
 
@@ -82,6 +83,9 @@ namespace cms
 			     size_t globalSimHitIndex,
 			     const unsigned int tofBin);   
     void addPixelCollection(edm::Event& iEvent, const edm::EventSetup& iSetup, const bool ot_analog);
+
+    // Templated for premixing
+    template <typename DigiType>
     void addOuterTrackerCollection(edm::Event& iEvent, const edm::EventSetup& iSetup);
    
 
@@ -106,6 +110,7 @@ namespace cms
     edm::ESHandle<TrackerTopology> tTopoHand;
     edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
     const bool isOuterTrackerReadoutAnalog; 
+    const bool premixStage1_;
     // cache for detector types
     ModuleTypeCache moduleTypeCache_;
     

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
@@ -111,6 +111,7 @@ namespace cms
     edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher;
     const bool isOuterTrackerReadoutAnalog; 
     const bool premixStage1_;
+    const bool makeDigiSimLinks_;
     // cache for detector types
     ModuleTypeCache moduleTypeCache_;
     

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -59,7 +59,7 @@ using namespace sipixelobjects;
 Phase2TrackerDigitizerAlgorithm::Phase2TrackerDigitizerAlgorithm(const edm::ParameterSet& conf_common, 
 								 const edm::ParameterSet& conf_specific):
   _signal(),
-  makeDigiSimLinks_(conf_specific.getUntrackedParameter<bool>("makeDigiSimLinks", true)),
+  makeDigiSimLinks_(conf_common.getUntrackedParameter<bool>("makeDigiSimLinks", true)),
   use_ineff_from_db_(conf_specific.getParameter<bool>("Inefficiency_DB")),
   use_module_killing_(conf_specific.getParameter<bool>("KillModules")), // boolean to kill or not modules
   use_deadmodule_DB_(conf_specific.getParameter<bool>("DeadModules_DB")), // boolean to access dead modules from DB

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -911,6 +911,20 @@ void Phase2TrackerDigitizerAlgorithm::module_killing_DB(uint32_t detID) {
     }
   }
 }
+
+// For premixing
+void Phase2TrackerDigitizerAlgorithm::loadAccumulator(unsigned int detId, const std::map<int, float>& accumulator) {
+  auto& theSignal = _signal[detId];
+  // the input channel is always with PixelDigi definition
+  // if needed, that has to be converted to Phase2TrackerDigi convention
+  for(const auto& elem: accumulator) {
+    auto inserted = theSignal.emplace(elem.first, DigitizerUtility::Amplitude(elem.second, nullptr));
+    if(!inserted.second) {
+      throw cms::Exception("LogicError") << "Signal was already set for DetId " << detId;
+    }
+  }
+}
+
 void Phase2TrackerDigitizerAlgorithm::digitize(const Phase2TrackerGeomDetUnit* pixdet,
 	std::map<int, DigitizerUtility::DigiSimInfo> & digi_map,
 	     const TrackerTopology* tTopo) 

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
@@ -61,6 +61,8 @@ class Phase2TrackerDigitizerAlgorithm  {
 		       std::map<int, DigitizerUtility::DigiSimInfo>& digi_map,
 		       const TrackerTopology* tTopo);
 
+  // For premixing
+  void loadAccumulator(unsigned int detId, const std::map<int, float>& accumulator);
  protected:
   // Accessing Lorentz angle from DB:
   edm::ESHandle<SiPixelLorentzAngle> SiPixelLorentzAngle_;

--- a/SimTracker/SiPhase2Digitizer/plugins/PreMixingPhase2TrackerWorker.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PreMixingPhase2TrackerWorker.cc
@@ -1,0 +1,104 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSet.h"
+
+#include "SimGeneral/PreMixingModule/interface/PreMixingWorker.h"
+#include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
+
+#include "Phase2TrackerDigitizer.h"
+#include "Phase2TrackerDigitizerAlgorithm.h"
+
+class PreMixingPhase2TrackerWorker: public PreMixingWorker {
+public:
+  PreMixingPhase2TrackerWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
+  ~PreMixingPhase2TrackerWorker() override = default;
+
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& es) override;
+
+  void initializeEvent(edm::Event const& e, edm::EventSetup const& es) override;
+  void addSignals(edm::Event const& e, edm::EventSetup const& es) override;
+  void addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& es) override;
+  void put(edm::Event &e, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bs) override;
+
+private:
+  void accumulate(const edm::DetSetVector<PixelDigi>& digis);
+
+  cms::Phase2TrackerDigitizer digitizer_;
+
+  edm::EDGetTokenT<edm::DetSetVector<PixelDigi> > pixelSignalToken_;
+  edm::EDGetTokenT<edm::DetSetVector<PixelDigi> > trackerSignalToken_;
+  edm::InputTag pixelPileupLabel_;
+  edm::InputTag trackerPileupLabel_;
+  float electronPerAdc_;
+
+  // Maybe map of maps is not that bad for this add once, update once,
+  // read once workflow?
+  using SignalMap = std::map<unsigned int, std::map<int, float>>; // (channel, charge)
+  SignalMap accumulator_;
+};
+
+
+PreMixingPhase2TrackerWorker::PreMixingPhase2TrackerWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC):
+  digitizer_(ps, producer, iC),
+  pixelSignalToken_(iC.consumes<edm::DetSetVector<PixelDigi> >(ps.getParameter<edm::InputTag>("pixelLabelSig"))),
+  trackerSignalToken_(iC.consumes<edm::DetSetVector<PixelDigi> >(ps.getParameter<edm::InputTag>("trackerLabelSig"))),
+  pixelPileupLabel_(ps.getParameter<edm::InputTag>("pixelPileInputTag")),
+  trackerPileupLabel_(ps.getParameter<edm::InputTag>("trackerPileInputTag")),
+  electronPerAdc_(ps.getParameter<double>("premixStage1ElectronPerAdc"))
+{}
+
+void PreMixingPhase2TrackerWorker::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& es) {
+  digitizer_.beginLuminosityBlock(lumi, es);
+}
+
+void PreMixingPhase2TrackerWorker::initializeEvent(edm::Event const& e, edm::EventSetup const& es) {
+  digitizer_.initializeEvent(e, es);
+}
+
+void PreMixingPhase2TrackerWorker::addSignals(edm::Event const& e, edm::EventSetup const& es) {
+  edm::Handle<edm::DetSetVector<PixelDigi> > hdigis;
+  e.getByToken(pixelSignalToken_, hdigis);
+  accumulate(*hdigis);
+
+  e.getByToken(trackerSignalToken_, hdigis);
+  accumulate(*hdigis);
+}
+
+void PreMixingPhase2TrackerWorker::addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& es) {
+  edm::Handle<edm::DetSetVector<PixelDigi> > hdigis;
+  pep.getByLabel(pixelPileupLabel_, hdigis);
+  accumulate(*hdigis);
+
+  pep.getByLabel(trackerPileupLabel_, hdigis);
+  accumulate(*hdigis);
+}
+
+void PreMixingPhase2TrackerWorker::accumulate(const edm::DetSetVector<PixelDigi>& digis) {
+  for(const auto& detset: digis) {
+    auto& accDet = accumulator_[detset.detId()];
+    for(const auto& digi: detset) {
+      // note: according to C++ standard operator[] does
+      // value-initializiation, which for float means initial value of 0
+      auto& acc = accDet[digi.channel()];
+      acc += digi.adc()*electronPerAdc_;
+    }
+  }
+}
+
+void PreMixingPhase2TrackerWorker::put(edm::Event &e, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bs) {
+  digitizer_.loadAccumulator(accumulator_);
+  digitizer_.finalizeEvent(e, iSetup);
+  decltype(accumulator_){}.swap(accumulator_); // release memory
+}
+
+DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, PreMixingPhase2TrackerWorker, "PreMixingPhase2TrackerWorker");

--- a/SimTracker/SiPhase2Digitizer/python/Phase2TrackerValidateDigi_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/Phase2TrackerValidateDigi_cfi.py
@@ -112,3 +112,9 @@ digiValid = DQMEDAnalyzer('Phase2TrackerValidateDigi',
         ymax   = cms.double(50.)
     )
 )
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(digiValid,
+    OuterTrackerDigiSimLinkSource = "mixData:Phase2OTDigiSimLink",
+    InnerPixelDigiSimLinkSource = "mixData:PixelDigiSimLink",
+)

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -14,12 +14,12 @@ phase2TrackerDigitizer = cms.PSet(
 # Common for Algos
     premixStage1 = cms.bool(False),
     AlgorithmCommon = cms.PSet(
-      DeltaProductionCut = cms.double(0.03)
+      DeltaProductionCut = cms.double(0.03),
+      makeDigiSimLinks = cms.untracked.bool(True),
     ),
 # Specific parameters
 #Pixel Digitizer Algorithm
     PixelDigitizerAlgorithm = cms.PSet(
-      makeDigiSimLinks = cms.untracked.bool(True),
       ElectronPerAdc = cms.double(600.0),
       ReadoutNoiseInElec = cms.double(0.0),
       ThresholdInElectrons_Barrel = cms.double(1200.0),
@@ -57,7 +57,6 @@ phase2TrackerDigitizer = cms.PSet(
     ),
 #Pixel in PS Module
     PSPDigitizerAlgorithm = cms.PSet(
-      makeDigiSimLinks = cms.untracked.bool(True),
       ElectronPerAdc = cms.double(135.0),
       ReadoutNoiseInElec = cms.double(200.0),#D.B.:Fill readout noise, including all readout chain, relevant for smearing
       ThresholdInElectrons_Barrel = cms.double(6300.), #(0.4 MIP = 0.4 * 16000 e)
@@ -95,7 +94,6 @@ phase2TrackerDigitizer = cms.PSet(
     ),
 #Strip in PS module
     PSSDigitizerAlgorithm = cms.PSet(
-      makeDigiSimLinks = cms.untracked.bool(True),
       ElectronPerAdc = cms.double(135.0),
 #D.B.:the noise should be a function of strip capacitance, roughly: ReadoutNoiseInElec=500+(64*Cdet[pF]) ~= 500+(64*1.5[cm])
       ReadoutNoiseInElec = cms.double(700.0),#D.B.:Fill readout noise, including all readout chain, relevant for smearing
@@ -134,7 +132,6 @@ phase2TrackerDigitizer = cms.PSet(
     ),
 #Two Strip Module
     SSDigitizerAlgorithm = cms.PSet(
-      makeDigiSimLinks = cms.untracked.bool(True),
       ElectronPerAdc = cms.double(135.0),
 #D.B.:the noise should be a function of strip capacitance, roughly: ReadoutNoiseInElec=500+(64*Cdet[pF]) ~= 500+(64*1.5[cm])
       ReadoutNoiseInElec = cms.double(1000.0),#D.B.:Fill readout noise, including all readout chain, relevant for smearing

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -12,6 +12,7 @@ phase2TrackerDigitizer = cms.PSet(
     GeometryType = cms.string('idealForDigi'),
     isOTreadoutAnalog = cms.bool(False),#set this to true if you want analog readout for OT
 # Common for Algos
+    premixStage1 = cms.bool(False),
     AlgorithmCommon = cms.PSet(
       DeltaProductionCut = cms.double(0.03)
     ),
@@ -172,27 +173,43 @@ phase2TrackerDigitizer = cms.PSet(
     )
 )
 
-# TODO: values are copied from phase0/1 pixel configuration, they can be wrong
+# For premixing stage1
+# - add noise as by default
+# - do not add noisy pixels (to be done in stage2)
+# - do not apply inefficiency (to be done in stage2)
+# - disable threshold smearing
+#
+# For inner pixel
+# - extend the dynamic range of ADCs
+#
+# For outer tracker
+# - force analog readout to get the ADCs
+#
+# NOTE: It is currently assumed that all sub-digitizers have the same ElectronPerAdc.
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
-premix_stage1.toModify(phase2TrackerDigitizer,
+_premixStage1ModifyDict = dict(
+    premixStage1 = True,
     PixelDigitizerAlgorithm = dict(
-        AddNoise = True,
         AddNoisyPixels = False,
-        makeDigiSimLinks = False,
+        AddInefficiency = False,
+        AddThresholdSmearing = False,
+        ElectronPerAdc = phase2TrackerDigitizer.PSPDigitizerAlgorithm.ElectronPerAdc.value(),
+        AdcFullScale = phase2TrackerDigitizer.PSPDigitizerAlgorithm.AdcFullScale.value(),
     ),
     PSPDigitizerAlgorithm = dict(
-        AddNoise = True,
         AddNoisyPixels = False,
-        makeDigiSimLinks = False,
+        AddInefficiency = False,
+        AddThresholdSmearing = False,
     ),
     PSSDigitizerAlgorithm = dict(
-        AddNoise = True,
         AddNoisyPixels = False,
-        makeDigiSimLinks = False,
+        AddInefficiency = False,
+        AddThresholdSmearing = False,
     ),
     SSDigitizerAlgorithm = dict(
-        AddNoise = True,
         AddNoisyPixels = False,
-        makeDigiSimLinks = False,
+        AddInefficiency = False,
+        AddThresholdSmearing = False,
     ),
 )
+premix_stage1.toModify(phase2TrackerDigitizer, **_premixStage1ModifyDict)

--- a/SimTracker/TrackTriggerAssociation/python/TTClusterAssociation_cfi.py
+++ b/SimTracker/TrackTriggerAssociation/python/TTClusterAssociation_cfi.py
@@ -8,3 +8,8 @@ TTClusterAssociatorFromPixelDigis = cms.EDProducer("TTClusterAssociator_Phase2Tr
     trackingParts= cms.InputTag( "mix","MergedTrackTruth" )
 )
 
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(TTClusterAssociatorFromPixelDigis,
+    digiSimLinks = "mixData:Tracker",
+    trackingParts = "mixData:MergedTrackTruth",
+)

--- a/SimTracker/TrackerHitAssociation/python/tpClusterProducer_cfi.py
+++ b/SimTracker/TrackerHitAssociation/python/tpClusterProducer_cfi.py
@@ -16,4 +16,5 @@ premix_stage2.toModify(tpClusterProducer,
     trackingParticleSrc = "mixData:MergedTrackTruth",
     pixelSimLinkSrc = "mixData:PixelDigiSimLink",
     stripSimLinkSrc = "mixData:StripDigiSimLink",
+    phase2OTSimLinkSrc = "mixData:Phase2OTDigiSimLink",
 )

--- a/Validation/HGCalValidation/plugins/CaloParticleValidation.cc
+++ b/Validation/HGCalValidation/plugins/CaloParticleValidation.cc
@@ -264,7 +264,7 @@ CaloParticleValidation::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<edm::InputTag>("recHitsEE", edm::InputTag("HGCalRecHit","HGCEERecHits"));
   desc.add<edm::InputTag>("recHitsFH", edm::InputTag("HGCalRecHit","HGCHEFRecHits"));
   desc.add<edm::InputTag>("recHitsBH", edm::InputTag("HGCalRecHit","HGCHEBRecHits"));
-  descriptions.add("caloparticlevalidation", desc);
+  descriptions.add("caloparticlevalidationDefault", desc);
 }
 
 //define this as a plug-in

--- a/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
@@ -165,7 +165,7 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent,
 	ntot++; nused++;
 	HGCalDetId detId     = it.id();
 	int        layer     = detId.layer();
-	HGCSample  hgcSample = it.sample(SampleIndx_);
+	const HGCSample&  hgcSample = it.sample(SampleIndx_);
 	uint16_t   gain      = hgcSample.toa();
 	uint16_t   adc       = hgcSample.data();
 	double     charge    = adc*gain;
@@ -191,7 +191,7 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent,
 	ntot++; nused++;
 	HGCalDetId detId     = it.id();
 	int        layer     = detId.layer();
-	HGCSample  hgcSample = it.sample(SampleIndx_);
+	const HGCSample&  hgcSample = it.sample(SampleIndx_);
 	uint16_t   gain      = hgcSample.toa();
 	uint16_t   adc       = hgcSample.data();
 	double     charge    = adc*gain;
@@ -216,7 +216,7 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent,
 	ntot++; nused++;
 	HcalDetId  detId     = it.id();
 	int        layer     = detId.depth();
-	HGCSample  hgcSample = it.sample(SampleIndx_);
+	const HGCSample&  hgcSample = it.sample(SampleIndx_);
 	uint16_t   gain      = hgcSample.toa();
 	uint16_t   adc       = hgcSample.data();
 	double     charge    = adc*gain;

--- a/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
@@ -124,7 +124,7 @@ void HGCalDigiValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<bool>("ifHCAL",false);
   desc.addUntracked<int>("Verbosity",0);
   desc.addUntracked<int>("SampleIndx",0);
-  descriptions.add("hgcalDigiValidationEE",desc);
+  descriptions.add("hgcalDigiValidationEEDefault",desc);
 }
 
 void HGCalDigiValidation::analyze(const edm::Event& iEvent, 

--- a/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
@@ -386,7 +386,7 @@ void HGCalHitCalibration::fillDescriptions(
   desc.add<edm::InputTag>("hgcalMultiClusters", edm::InputTag("particleFlowClusterHGCalFromMultiCl"));
   desc.add<edm::InputTag>("electrons", edm::InputTag("ecalDrivenGsfElectronsFromMultiCl"));
   desc.add<edm::InputTag>("photons", edm::InputTag("photonsFromMultiCl"));
-  descriptions.add("hgcalHitCalibration", desc);
+  descriptions.add("hgcalHitCalibrationDefault", desc);
 }
 
 // define this as a plug-in

--- a/Validation/HGCalValidation/plugins/HGCalShowerSeparation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalShowerSeparation.cc
@@ -327,7 +327,7 @@ void HGCalShowerSeparation::fillDescriptions(
   desc.add<edm::InputTag>("recHitsEE", edm::InputTag("HGCalRecHit", "HGCEERecHits"));
   desc.add<edm::InputTag>("recHitsFH", edm::InputTag("HGCalRecHit", "HGCHEFRecHits"));
   desc.add<edm::InputTag>("recHitsBH", edm::InputTag("HGCalRecHit", "HGCHEBRecHits"));
-  descriptions.add("hgcalShowerSeparation", desc);
+  descriptions.add("hgcalShowerSeparationDefault", desc);
 }
 
 // define this as a plug-in

--- a/Validation/HGCalValidation/python/caloparticlevalidation_cfi.py
+++ b/Validation/HGCalValidation/python/caloparticlevalidation_cfi.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.HGCalValidation.caloparticlevalidationDefault_cfi import caloparticlevalidationDefault as _caloparticlevalidationDefault
+caloparticlevalidation = _caloparticlevalidationDefault.clone()
+
+# TODO: The following would be needed to use the signal+pileup
+# CaloParticles for premixing. However, the code uses SimVertices, and
+# - we don't propagate pileup SimVertices (actually we don't do that even in classical mixing?)
+# - the code will either produce garbage or throw an exception
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(caloparticlevalidation,
+    caloParticles = "mixData:MergedCaloTruth"
+)

--- a/Validation/HGCalValidation/python/digiValidation_cff.py
+++ b/Validation/HGCalValidation/python/digiValidation_cff.py
@@ -9,3 +9,7 @@ hgcalDigiValidationHEF = hgcalDigiValidationEE.clone(
 hgcalDigiValidationHEB = hgcalDigiValidationEE.clone(
     DetectorName = cms.string("HCal"),
     DigiSource   = cms.InputTag("mix","HGCDigisHEback"))
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(hgcalDigiValidationHEF, DigiSource = "mixData:HGCDigisHEfront")
+premix_stage2.toModify(hgcalDigiValidationHEB, DigiSource = "mixData:HGCDigisHEback")

--- a/Validation/HGCalValidation/python/hgcalDigiValidationEE_cfi.py
+++ b/Validation/HGCalValidation/python/hgcalDigiValidationEE_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+from Validation.HGCalValidation.hgcalDigiValidationEEDefault_cfi import hgcalDigiValidationEEDefault as _hgcalDigiValidationEEDefault
+hgcalDigiValidationEE = _hgcalDigiValidationEEDefault.clone()
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(hgcalDigiValidationEE, DigiSource = "mixData:HGCDigisEE")

--- a/Validation/HGCalValidation/python/hgcalHitCalibration_cfi.py
+++ b/Validation/HGCalValidation/python/hgcalHitCalibration_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.HGCalValidation.hgcalHitCalibrationDefault_cfi import hgcalHitCalibrationDefault as _hgcalHitCalibrationDefault
+hgcalHitCalibration = _hgcalHitCalibrationDefault.clone()
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(hgcalHitCalibration, caloParticles = "mixData:MergedCaloTruth")

--- a/Validation/HGCalValidation/python/hgcalShowerSeparation_cfi.py
+++ b/Validation/HGCalValidation/python/hgcalShowerSeparation_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.HGCalValidation.hgcalShowerSeparationDefault_cfi import hgcalShowerSeparationDefault as _hgcalShowerSeparationDefault
+hgcalShowerSeparation = _hgcalShowerSeparationDefault.clone()
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(hgcalShowerSeparation, caloParticles = "mixData:MergedCaloTruth")

--- a/Validation/MuonGEMDigis/python/MuonGEMDigis_cff.py
+++ b/Validation/MuonGEMDigis/python/MuonGEMDigis_cff.py
@@ -52,6 +52,11 @@ gemDigiTrackValidation = DQMEDAnalyzer('GEMDigiTrackMatch',
   detailPlot = cms.bool(False), 
 )
 
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+(premix_stage2 & phase2_muon).toModify(gemStripValidation, stripLabel = "mixData")
+(premix_stage2 & phase2_muon).toModify(gemDigiTrackValidation, gemDigiInput = "mixData")
+
 gemGeometryChecker = DQMEDAnalyzer('GEMCheckGeometry',
   detailPlot = cms.bool(False), 
 )

--- a/Validation/SiOuterTrackerV/python/OuterTrackerMonitorTrackingParticles_cfi.py
+++ b/Validation/SiOuterTrackerV/python/OuterTrackerMonitorTrackingParticles_cfi.py
@@ -133,3 +133,6 @@ OuterTrackerMonitorTrackingParticles = DQMEDAnalyzer('OuterTrackerMonitorTrackin
         xmin = cms.double(-0.05)
         ),
 )
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(OuterTrackerMonitorTrackingParticles, trackingParticleToken = "mixData:MergedTrackTruth")


### PR DESCRIPTION
This PR adds premixing for phase2 D17 geometry detectors as described in these O&C week slides
https://indico.cern.ch/event/711343/#54-phase-2-premixing-status

As a summary the changes include
* Customization of ECAL, HCAL, DT, CSC, RPC premixing for phase2
* `PreMixingPhase2TrackerWorker` for phase2 tracker premixing
   * Both inner and outer tracker are treated like pixel is treated in phase0/1 premixing
   * In the standard digitizer changed the `makeDigiSimLinks` to be a single parameter to control the behaviour of all sub-digitizers instead of sub-digitizer specific parameters
* `PreMixingHGCalWorker` for HGCal premixing
   * The state of the digi accumulator is stored
* `PreMixingCaloParticleWorker` for CaloParticles and SimClusters
   * Similar to `PreMixingTrackingParticleWorker`
   * SimClusters need an additional "DetId->total sim enery" map to calculate the fractions
* `PreMixingGEMWorker` and `PreMixingME0Worker` for GEM and ME0
   * Mixing the digis as with other muon detectors
   * May change in the future (to SimHits, see next point)
* `PreMixingCrossingFramePSimHitWorker` to mix `PCrossingFrame<PSimHit>` (from pileup) and `CrossingFrame<PSimHit>` (from signal)
   * to mix SimHits for ME0 pseudo digis (used for L1)
* Disable L1 from premixing stage1 (not needed)
* Some cleanup in `MixingWorker`, `CrossingFrame<T>`, and `PCrossingFrame<T>`
* Combined stage1+stage2 workflow, which is now also enabled in standard matrix
  * For this the existing stage1 and stage2 workflow numbers were decreased (.98->.97, 0.99->0.98)

There is still work to do (I'd be surprised if there were no bugs), but I believe integrating the first complete version has value (getting it reviewed, tested etc).

Tested in CMSSW_10_2_X_2018-04-23-2300 (rebased on top of CMSSW_10_2_X_2018-05-09-2300), no changes expected in existing workflows.

@kpedro88 @mdhildreth 