### PR TITLE
Add flag to configure production of DDU-based trigger synch plots [10_2_X]

### DIFF
--- a/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
@@ -7,7 +7,7 @@ dtTriggerSynchMonitor = DQMEDAnalyzer('DTLocalTriggerSynchTask',
     TMInputTag    = cms.InputTag('dttfDigis'),
     DDUInputTag    = cms.InputTag('muonDTDigis'),
     SEGInputTag    = cms.InputTag('dt4DSegments'),
-    processDDU     = cms.bool(True),
+    processDDU     = cms.untracked.bool(True),
     bxTimeInterval = cms.double(25),
     rangeWithinBX  = cms.bool(True),
     nBXHigh        = cms.int32(0),
@@ -29,7 +29,7 @@ dtTriggerSynchMonitor = DQMEDAnalyzer('DTLocalTriggerSynchTask',
 )
 
 from Configuration.Eras.Modifier_run2_DT_2018_cff import run2_DT_2018
-run2_DT_2018.toModify(dtTriggerSynchMonitor,processDDU = cms.bool(False))
+run2_DT_2018.toModify(dtTriggerSynchMonitor,processDDU = cms.untracked.bool(False))
 
 
 

--- a/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
@@ -7,6 +7,7 @@ dtTriggerSynchMonitor = DQMEDAnalyzer('DTLocalTriggerSynchTask',
     TMInputTag    = cms.InputTag('dttfDigis'),
     DDUInputTag    = cms.InputTag('muonDTDigis'),
     SEGInputTag    = cms.InputTag('dt4DSegments'),
+    processDDU     = cms.bool(True),
     bxTimeInterval = cms.double(25),
     rangeWithinBX  = cms.bool(True),
     nBXHigh        = cms.int32(0),
@@ -26,5 +27,9 @@ dtTriggerSynchMonitor = DQMEDAnalyzer('DTLocalTriggerSynchTask',
     ),
     tTrigMode = cms.string('DTTTrigSyncFromDB')
 )
+
+from Configuration.Eras.Modifier_run2_DT_2018_cff import run2_DT_2018
+run2_DT_2018.toModify(dtTriggerSynchMonitor,processDDU = cms.bool(False))
+
 
 

--- a/DQM/DTMonitorModule/src/DTLocalTriggerSynchTask.h
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerSynchTask.h
@@ -90,6 +90,7 @@ class DTLocalTriggerSynchTask: public DQMEDAnalyzer{
 
   float bxTime;
   bool rangeInBX;
+  bool processDDU;
   int nBXLow;
   int nBXHigh;
   float angleRange;


### PR DESCRIPTION
This PR is intended to fix the T0 issue related to pathALCARECODtCalib reported in [this HN thread](https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1862/1.html).

What it does is making the production of a few plots (hence the access to some products) configurable and disables them in the 2018 era.