### PR TITLE
L1 DQM - CaloL1 DQM updates

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -137,6 +137,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.caloStage1Digis.InputLabel = cms.InputTag("rawDataRepacker")
     process.caloStage2Digis.InputLabel = cms.InputTag("rawDataRepacker")
     process.simHcalTriggerPrimitiveDigis.InputTagFEDRaw = cms.InputTag("rawDataRepacker")
+    process.l1tdeStage2CaloLayer1.fedRawDataLabel = cms.InputTag("rawDataRepacker")
     process.gtStage2Digis.InputLabel = cms.InputTag("rawDataRepacker")
     process.selfFatEventFilter.rawInput = cms.InputTag("rawDataRepacker")
 

--- a/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
@@ -23,6 +23,9 @@
 
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "DataFormats/L1TCalorimeter/interface/CaloTower.h"
+
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
 using namespace l1t;
 
 class L1TdeStage2CaloLayer1 : public DQMEDAnalyzer {
@@ -45,6 +48,7 @@ class L1TdeStage2CaloLayer1 : public DQMEDAnalyzer {
     edm::InputTag emulLabel_;
     edm::EDGetTokenT<CaloTowerBxCollection> emulSource_;
     edm::EDGetTokenT<HcalTrigPrimDigiCollection> hcalTowers_;
+    edm::EDGetTokenT<FEDRawDataCollection> fedRawData_;
     std::string histFolder_;
     int tpFillThreshold_;
 

--- a/DQM/L1TMonitor/python/L1TdeStage2CaloLayer1_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2CaloLayer1_cfi.py
@@ -4,5 +4,6 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 l1tdeStage2CaloLayer1 = DQMEDAnalyzer('L1TdeStage2CaloLayer1',
     dataSource = cms.InputTag("caloStage2Digis", "CaloTower"),
     emulSource = cms.InputTag("valCaloStage2Layer1Digis"),
+    fedRawDataLabel  = cms.InputTag("rawDataCollector"),
     histFolder = cms.string('L1TEMU/L1TdeStage2CaloLayer1'),
 )

--- a/DQM/L1TMonitorClient/data/L1TStage2CaloLayer1QualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2CaloLayer1QualityTests.xml
@@ -5,7 +5,7 @@
       <PARAM name="warning">0.</PARAM>
       <PARAM name="error">1.</PARAM>
       <PARAM name="ymin">0.0</PARAM>
-      <PARAM name="ymax">150.0</PARAM>
+      <PARAM name="ymax">10.0</PARAM>
       <PARAM name="useEmptyBins">0</PARAM>
   </QTEST>
 
@@ -14,7 +14,7 @@
       <PARAM name="warning">0.</PARAM>
       <PARAM name="error">1.</PARAM>
       <PARAM name="ymin">0.0</PARAM>
-      <PARAM name="ymax">100.0</PARAM>
+      <PARAM name="ymax">10.0</PARAM>
       <PARAM name="useEmptyBins">0</PARAM>
   </QTEST>
 


### PR DESCRIPTION
* Prevents false error condition if CaloLayer1 or CaloLayer2 out of run
* Lowers link error and discrepancy thresholds for ECAL and HCAL link monitoring to 10