### PR TITLE
Update SiStrip Miscalibration Tools [10.2.X]

### DIFF
--- a/CondTools/SiStrip/README.md
+++ b/CondTools/SiStrip/README.md
@@ -5,3 +5,11 @@
   - To run: 
     - `cmsRun test/SiStripApvGainReader_cfg.py inputFiles=sqlite_input  tag=my_tag runN=run_in_IOV`
     - `readSiStripApvGain.py  inputFiles=sqlite_input  tag=my_tag runN=run_in_IOV`
+
+- _SiStripChannelGainFromDBMiscalibrator_: reads APV gains (either G1 or G2) from DB and applies hierarchically a scale factor and/or gaussian smearing for each APV gain, down to the individual layer or disk level
+  - To run: 
+    - `cmsRun test/SiStripChannelGainFromDBMiscalibrator_cfg.py globalTag=<inputGT> runNumber=<inputIOV>`
+  
+- _SiStripNoisesFromDBMiscalibrator_: reads Noise from DB and applies hierarchically a scale factor and/or gaussian smearing for each APV gain, down to the individual layer or disk level
+  - To run: 
+    - `cmsRun test/SiStripNoiseFromDBMiscalibrator_cfg.py globalTag=<inputGT> runNumber=<inputIOV>`

--- a/CondTools/SiStrip/interface/SiStripMiscalibrateHelper.h
+++ b/CondTools/SiStrip/interface/SiStripMiscalibrateHelper.h
@@ -1,0 +1,79 @@
+#ifndef CONDTOOLS_SISTRIP_SISTRIPMISCALIBRATEHELPER
+#define CONDTOOLS_SISTRIP_SISTRIPMISCALIBRATEHELPER
+
+#include <numeric>
+#include "CommonTools/TrackerMap/interface/TrackerMap.h"
+#include "CondFormats/SiStripObjects/interface/SiStripSummary.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h" 
+
+namespace SiStripMiscalibrate {
+
+  /*-----------------
+  / Auxilliary class to store averages and std. deviations
+  /------------------*/
+  class Entry{
+  public:
+    Entry():
+      entries(0),
+      sum(0),
+      sq_sum(0){}
+
+    double mean() {return sum / entries;}
+    double std_dev() {
+      double tmean = mean();
+      return (sq_sum - entries*tmean*tmean)>0 ? sqrt((sq_sum - entries*tmean*tmean)/(entries-1)) : 0.;
+    }
+    double mean_rms() { return std_dev()/sqrt(entries); }
+
+    void add(double val){
+      entries++;
+      sum += val;
+      sq_sum += val*val;
+    }
+
+    void reset() {
+      entries = 0;
+      sum = 0;
+      sq_sum = 0;
+    }
+  private:
+    long int entries;
+    double sum, sq_sum;
+  };
+
+  /*-----------------
+  / Auxilliary struct to store scale & smear factors
+  /------------------*/
+  struct Smearings{
+    Smearings(){
+      m_doScale = false;
+      m_doSmear = false;
+      m_scaleFactor = 1.;
+      m_smearFactor = 0.;
+    }
+    ~Smearings(){}
+    
+    void setSmearing(bool doScale,bool doSmear,double the_scaleFactor,double the_smearFactor){
+      m_doScale = doScale;
+      m_doSmear = doSmear;
+      m_scaleFactor = the_scaleFactor;
+      m_smearFactor = the_smearFactor;
+    }
+    
+    bool m_doScale;
+    bool m_doSmear;
+    double m_scaleFactor;
+    double m_smearFactor;
+  };
+
+  /*-----------------
+  / Methods used in the miscalibration tools
+  /------------------*/
+  
+  std::pair<float,float> getTruncatedRange(const TrackerMap* theMap);  
+  sistripsummary::TrackerRegion getRegionFromString(std::string region);
+  std::vector<sistripsummary::TrackerRegion> getRegionsFromDetId(const TrackerTopology* m_trackerTopo,DetId detid);
+
+};
+
+#endif

--- a/CondTools/SiStrip/plugins/BuildFile.xml
+++ b/CondTools/SiStrip/plugins/BuildFile.xml
@@ -10,6 +10,7 @@
 <use   name="CalibTracker/Records"/>
 <use   name="CondCore/DBOutputService"/>
 <use   name="CondFormats/SiStripObjects"/>
+<use   name="CondCore/SiStripPlugins"/>
 <use   name="CalibFormats/SiStripObjects"/>
 <use   name="DataFormats/SiStripDetId"/>
 <use   name="CalibTracker/SiStripCommon"/>

--- a/CondTools/SiStrip/plugins/SiStripChannelGainFromDBMiscalibrator.cc
+++ b/CondTools/SiStrip/plugins/SiStripChannelGainFromDBMiscalibrator.cc
@@ -24,58 +24,29 @@
 
 // user include files
 #include "CLHEP/Random/RandGauss.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
-#include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
-#include "CondFormats/DataRecord/interface/SiStripApvGainRcd.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
 #include "CalibTracker/Records/interface/SiStripGainRcd.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h" 
-#include "Geometry/Records/interface/TrackerTopologyRcd.h" 
 #include "CommonTools/TrackerMap/interface/TrackerMap.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h" 
-#include "DataFormats/SiStripDetId/interface/SiStripDetId.h" 
+#include "CondFormats/DataRecord/interface/SiStripApvGainRcd.h"
+#include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
 #include "CondFormats/SiStripObjects/interface/SiStripSummary.h"
-
+#include "CondTools/SiStrip/interface/SiStripMiscalibrateHelper.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h" 
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h" 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h" 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h" 
 //
 // class declaration
 //
-
-namespace ApvGain {
-  struct GainSmearings{
-    GainSmearings(){
-      m_doScale = false;
-      m_doSmear = false;
-      m_scaleFactor = 1.;
-      m_smearFactor = 0.;
-    }
-    ~GainSmearings(){}
-    
-    void setSmearing(bool doScale,bool doSmear,double the_scaleFactor,double the_smearFactor){
-      m_doScale = doScale;
-      m_doSmear = doSmear;
-      m_scaleFactor = the_scaleFactor;
-      m_smearFactor = the_smearFactor;
-    }
-    
-    bool m_doScale;
-    bool m_doSmear;
-    double m_scaleFactor;
-    double m_smearFactor;
-  };
-
-}
 
 class SiStripChannelGainFromDBMiscalibrator : public edm::one::EDAnalyzer<>  {
    public:
@@ -88,18 +59,19 @@ class SiStripChannelGainFromDBMiscalibrator : public edm::one::EDAnalyzer<>  {
       virtual void beginJob() override;
       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
       std::unique_ptr<SiStripApvGain> getNewObject(const std::map<std::pair<uint32_t,int>,float>& theMap);
-      sistripsummary::TrackerRegion getRegionFromString(std::string region);
-      std::vector<sistripsummary::TrackerRegion> getRegionsFromDetId(const TrackerTopology* tTopo,DetId detid);
       virtual void endJob() override;
 
       // ----------member data ---------------------------
       const std::string m_Record;  
       const uint32_t m_gainType;
+      const bool m_saveMaps;
       const std::vector<edm::ParameterSet> m_parameters;
 
       std::unique_ptr<TrackerMap> scale_map;
       std::unique_ptr<TrackerMap> smear_map;
       std::unique_ptr<TrackerMap> ratio_map;
+      std::unique_ptr<TrackerMap> old_payload_map;
+      std::unique_ptr<TrackerMap> new_payload_map;
 
 };
 
@@ -109,21 +81,33 @@ class SiStripChannelGainFromDBMiscalibrator : public edm::one::EDAnalyzer<>  {
 SiStripChannelGainFromDBMiscalibrator::SiStripChannelGainFromDBMiscalibrator(const edm::ParameterSet& iConfig):
   m_Record{iConfig.getUntrackedParameter<std::string> ("record" , "SiStripApvGainRcd")},
   m_gainType{iConfig.getUntrackedParameter<uint32_t>("gainType",1)},
+  m_saveMaps{iConfig.getUntrackedParameter<bool>("saveMaps",true)},
   m_parameters{iConfig.getParameter<std::vector<edm::ParameterSet> >("params")}
 {
    //now do what ever initialization is needed
   
+  std::string ss_gain = (m_gainType > 0) ? "G2" : "G1";
+
   scale_map = std::unique_ptr<TrackerMap>(new TrackerMap("scale"));
-  scale_map->setTitle("Scale factor module by module");
+  scale_map->setTitle("Scale factor averaged by module");
   scale_map->setPalette(1);
 
   smear_map =std::unique_ptr<TrackerMap>(new TrackerMap("smear"));
-  smear_map->setTitle("Smear factor module by module");
+  smear_map->setTitle("Smear factor averaged by module");
   smear_map->setPalette(1);
 
   ratio_map = std::unique_ptr<TrackerMap>(new TrackerMap("ratio"));
-  ratio_map->setTitle("Average by module of the payload ratio (new/old)");
+  ratio_map->setTitle("Average by module of the "+ss_gain+" Gain payload ratio (new/old)");
   ratio_map->setPalette(1);
+
+  new_payload_map =std::unique_ptr<TrackerMap>(new TrackerMap("new_payload"));
+  new_payload_map->setTitle("Tracker Map of Modified "+ss_gain+" Gain payload averaged by module");
+  new_payload_map->setPalette(1);
+  
+  old_payload_map =std::unique_ptr<TrackerMap>(new TrackerMap("old_payload"));
+  old_payload_map->setTitle("Tracker Map of Starting "+ss_gain+" Gain Payload averaged by module");
+  old_payload_map->setPalette(1);
+
 }
 
 
@@ -157,19 +141,19 @@ SiStripChannelGainFromDBMiscalibrator::analyze(const edm::Event& iEvent, const e
      }
    }
 
-   std::map<sistripsummary::TrackerRegion,ApvGain::GainSmearings> mapOfSmearings;
+   std::map<sistripsummary::TrackerRegion,SiStripMiscalibrate::Smearings> mapOfSmearings;
 
    for(auto& thePSet : m_parameters){
      
      const std::string partition(thePSet.getParameter<std::string>("partition"));
-     sistripsummary::TrackerRegion region = this->getRegionFromString(partition);
+     sistripsummary::TrackerRegion region = SiStripMiscalibrate::getRegionFromString(partition);
      
      bool    m_doScale(thePSet.getParameter<bool>("doScale"));
      bool    m_doSmear(thePSet.getParameter<bool>("doSmear"));
      double  m_scaleFactor(thePSet.getParameter<double>("scaleFactor"));
      double  m_smearFactor(thePSet.getParameter<double>("smearFactor"));
      
-     ApvGain::GainSmearings params = ApvGain::GainSmearings();
+     SiStripMiscalibrate::Smearings params = SiStripMiscalibrate::Smearings();
      params.setSmearing(m_doScale,m_doSmear,m_scaleFactor,m_smearFactor);
      mapOfSmearings[region]=params;
    }
@@ -178,7 +162,7 @@ SiStripChannelGainFromDBMiscalibrator::analyze(const edm::Event& iEvent, const e
    edm::ESHandle<SiStripGain> SiStripApvGain_;
    iSetup.get<SiStripGainRcd>().get(SiStripApvGain_);
 
-   std::map<std::pair<uint32_t,int>,float> theMap;
+   std::map<std::pair<uint32_t,int>,float> theMap,oldPayloadMap;
    
    std::vector<uint32_t> detid;
    SiStripApvGain_->getDetIds(detid);
@@ -186,12 +170,12 @@ SiStripChannelGainFromDBMiscalibrator::analyze(const edm::Event& iEvent, const e
      SiStripApvGain::Range range=SiStripApvGain_->getRange(d,m_gainType);
      float nAPV=0;
 
-     auto regions = getRegionsFromDetId(tTopo,d); 
+     auto regions = SiStripMiscalibrate::getRegionsFromDetId(tTopo,d); 
 
      // sort by largest to smallest
      std::sort(regions.rbegin(), regions.rend());
      
-     ApvGain::GainSmearings params = ApvGain::GainSmearings();
+     SiStripMiscalibrate::Smearings params = SiStripMiscalibrate::Smearings();
      
      for (unsigned int j=0; j<regions.size();j++){
        bool checkRegion = (mapOfSmearings.count(regions[j]) != 0);
@@ -206,10 +190,15 @@ SiStripChannelGainFromDBMiscalibrator::analyze(const edm::Event& iEvent, const e
        }
      }
      
+     scale_map->fill(d,params.m_scaleFactor);
+     smear_map->fill(d,params.m_smearFactor);
+
      for(int it=0;it<range.second-range.first;it++){
        nAPV+=1;
        float Gain=SiStripApvGain_->getApvGain(it,range);
        std::pair<uint32_t,int> index = std::make_pair(d,nAPV);
+
+       oldPayloadMap[index]=Gain;
        
        if(params.m_doScale){
 	 Gain*=params.m_scaleFactor;
@@ -227,6 +216,37 @@ SiStripChannelGainFromDBMiscalibrator::analyze(const edm::Event& iEvent, const e
 
    std::unique_ptr<SiStripApvGain> theAPVGains = this->getNewObject(theMap);
 
+   // make the payload ratio map
+   uint32_t cachedId(0);
+   SiStripMiscalibrate::Entry gain_ratio;
+   SiStripMiscalibrate::Entry o_gain;
+   SiStripMiscalibrate::Entry n_gain;
+   for(const auto &element : theMap){
+
+     uint32_t DetId  = element.first.first;
+     int      nAPV   = element.first.second;
+     float new_gain = element.second;
+     float old_gain = oldPayloadMap[std::make_pair(DetId,nAPV)];
+     
+     // flush the counters
+     if(cachedId!=0 && DetId!=cachedId){
+       ratio_map->fill(cachedId,gain_ratio.mean());
+       old_payload_map->fill(cachedId,o_gain.mean());
+       new_payload_map->fill(cachedId,n_gain.mean());
+
+       //auto test = new_payload_map.get()->smoduleMap;
+
+       gain_ratio.reset();
+       o_gain.reset();
+       n_gain.reset();
+     } 
+     
+     cachedId=DetId;
+     gain_ratio.add(new_gain/old_gain);
+     o_gain.add(old_gain);
+     n_gain.add(new_gain);
+   }
+
    // write out the APVGains record
    edm::Service<cond::service::PoolDBOutputService> poolDbService;
   
@@ -236,7 +256,6 @@ SiStripChannelGainFromDBMiscalibrator::analyze(const edm::Event& iEvent, const e
      throw std::runtime_error("PoolDBService required.");
  
 }
-
 
 // ------------ method called once each job just before starting event loop  ------------
 void 
@@ -248,6 +267,29 @@ SiStripChannelGainFromDBMiscalibrator::beginJob()
 void 
 SiStripChannelGainFromDBMiscalibrator::endJob() 
 {
+  if(m_saveMaps){
+
+    std::string ss_gain = (m_gainType > 0) ? "G2" : "G1";
+
+    scale_map->save(true,0,0,ss_gain+"_gain_scale_map.pdf");
+    scale_map->save(true,0,0,ss_gain+"_gain_scale_map.png"); 
+			             
+    smear_map->save(true,0,0,ss_gain+"_gain_smear_map.pdf");
+    smear_map->save(true,0,0,ss_gain+"_gain_smear_map.png"); 
+			             
+    ratio_map->save(true,0,0,ss_gain+"_gain_ratio_map.pdf");
+    ratio_map->save(true,0,0,ss_gain+"_gain_ratio_map.png"); 
+
+    auto range = SiStripMiscalibrate::getTruncatedRange(old_payload_map.get());
+
+    old_payload_map->save(true,range.first,range.second,"starting_"+ss_gain+"_gain_payload_map.pdf");
+    old_payload_map->save(true,range.first,range.second,"starting_"+ss_gain+"_gain_payload_map.png");
+                   		             	      
+    range = SiStripMiscalibrate::getTruncatedRange(new_payload_map.get());
+
+    new_payload_map->save(true,range.first,range.second,"new_"+ss_gain+"_gain_payload_map.pdf");
+    new_payload_map->save(true,range.first,range.second,"new_"+ss_gain+"_gain_payload_map.png");
+  }
 }
 
 //********************************************************************************//
@@ -271,9 +313,9 @@ SiStripChannelGainFromDBMiscalibrator::getNewObject(const std::map<std::pair<uin
     theSiStripVector.push_back(element.second);
     
     edm::LogInfo("SiStripChannelGainFromDBMiscalibrator")<<" DetId: "<<DetId 
-						 <<" APV:   "<<element.first.second
-						 <<" Gain:  "<<element.second
-						 <<std::endl;
+							 <<" APV:   "<<element.first.second
+							 <<" Gain:  "<<element.second
+							 <<std::endl;
   }
   
   if(!theSiStripVector.empty()){
@@ -306,121 +348,13 @@ SiStripChannelGainFromDBMiscalibrator::fillDescriptions(edm::ConfigurationDescri
 
   desc.addUntracked<std::string>("record","SiStripApvGainRcd");
   desc.addUntracked<unsigned int>("gainType",1);
+  desc.addUntracked<bool>("saveMaps",true);
 
   descriptions.add("scaleAndSmearSiStripGains", desc);
 
 }
 
 /*--------------------------------------------------------------------*/
-sistripsummary::TrackerRegion SiStripChannelGainFromDBMiscalibrator::getRegionFromString(std::string region)
-/*--------------------------------------------------------------------*/
-{
-  if(region.find("Tracker")!=std::string::npos){
-    return sistripsummary::TRACKER ;
-  } else if(region.find("TIB")!=std::string::npos){
-    if (region=="TIB_1") return sistripsummary::TIB_1;
-    else if (region=="TIB_2") return sistripsummary::TIB_2;
-    else if (region=="TIB_3") return sistripsummary::TIB_3;
-    else if (region=="TIB_4") return sistripsummary::TIB_4;
-    else return sistripsummary::TIB ;
-  } else if(region.find("TOB")!=std::string::npos){ 
-    if (region=="TOB_1") return sistripsummary::TOB_1;
-    else if (region=="TOB_2") return sistripsummary::TOB_2;
-    else if (region=="TOB_3") return sistripsummary::TOB_3;
-    else if (region=="TOB_4") return sistripsummary::TOB_4;
-    else if (region=="TOB_5") return sistripsummary::TOB_5;
-    else if (region=="TOB_6") return sistripsummary::TOB_6;
-    else return sistripsummary::TOB ;
-  } else if(region.find("TID")!=std::string::npos){
-    if(region.find("TIDM")!=std::string::npos){
-      if (region=="TIDM_1") return sistripsummary::TIDM_1;
-      else if (region=="TIDM_2") return sistripsummary::TIDM_2;
-      else if (region=="TIDM_3") return sistripsummary::TIDM_3;
-      else return sistripsummary::TIDM;
-    } else if(region.find("TIDP")!=std::string::npos){
-      if (region=="TIDP_1") return sistripsummary::TIDP_1;
-      else if (region=="TIDP_2") return sistripsummary::TIDP_2;
-      else if (region=="TIDP_3") return sistripsummary::TIDP_3;
-      else return sistripsummary::TIDP;
-    } else return sistripsummary::TID ;
-  } else if(region.find("TEC")!=std::string::npos) {
-    if(region.find("TECM")!=std::string::npos){
-      if (region=="TECM_1") return sistripsummary::TECM_1;
-      else if (region=="TECM_2") return sistripsummary::TECM_2;
-      else if (region=="TECM_3") return sistripsummary::TECM_3;
-      else if (region=="TECM_4") return sistripsummary::TECM_4;
-      else if (region=="TECM_5") return sistripsummary::TECM_5;
-      else if (region=="TECM_6") return sistripsummary::TECM_6;
-      else if (region=="TECM_7") return sistripsummary::TECM_7;
-      else if (region=="TECM_8") return sistripsummary::TECM_8;
-      else if (region=="TECM_9") return sistripsummary::TECM_9;
-      else return sistripsummary::TECM;
-    } else if(region.find("TECP")!=std::string::npos){
-      if (region=="TECP_1") return sistripsummary::TECP_1;
-      else if (region=="TECP_2") return sistripsummary::TECP_2;
-      else if (region=="TECP_3") return sistripsummary::TECP_3;
-      else if (region=="TECP_4") return sistripsummary::TECP_4;
-      else if (region=="TECP_5") return sistripsummary::TECP_5;
-      else if (region=="TECP_6") return sistripsummary::TECP_6;
-      else if (region=="TECP_7") return sistripsummary::TECP_7;
-      else if (region=="TECP_8") return sistripsummary::TECP_8;
-      else if (region=="TECP_9") return sistripsummary::TECP_9;
-      else return sistripsummary::TECP;
-    } else return sistripsummary::TEC ;
-  } else {
-    edm::LogError("LogicError") << "Unknown partition: " << region;
-    throw cms::Exception("Invalid Partition passed"); 
-  }  
-}
-
-/*--------------------------------------------------------------------*/
-std::vector<sistripsummary::TrackerRegion> SiStripChannelGainFromDBMiscalibrator::getRegionsFromDetId(const TrackerTopology* m_trackerTopo,DetId detid)
-/*--------------------------------------------------------------------*/      
-{
-  int layer    = 0;
-  int side     = 0;
-  int subdet   = 0;
-  int detCode  = 0;
-
-  std::vector<sistripsummary::TrackerRegion> ret;
-
-  switch (detid.subdetId()) {
-  case StripSubdetector::TIB:
-    layer = m_trackerTopo->tibLayer(detid);
-    subdet = 1;
-    break;
-  case StripSubdetector::TOB:
-    layer = m_trackerTopo->tobLayer(detid);
-    subdet = 2;
-    break;
-  case StripSubdetector::TID:
-    // is this module in TID+ or TID-?
-    layer = m_trackerTopo->tidWheel(detid);
-    side  = m_trackerTopo->tidSide(detid);
-    subdet = 3*10+side;
-    break;
-  case StripSubdetector::TEC:
-    // is this module in TEC+ or TEC-?
-    layer = m_trackerTopo->tecWheel(detid);
-    side  = m_trackerTopo->tecSide(detid);
-    subdet = 4*10+side;
-    break;
-  }
-  
-  detCode = (subdet*10)+layer;
-  
-  ret.push_back(static_cast<sistripsummary::TrackerRegion>(detCode));
-
-  if(subdet/10 > 0) {
-    ret.push_back(static_cast<sistripsummary::TrackerRegion>(subdet/10));
-  }
-
-  ret.push_back(static_cast<sistripsummary::TrackerRegion>(subdet));
-  ret.push_back(sistripsummary::TRACKER);
-
-  return ret;
-}
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(SiStripChannelGainFromDBMiscalibrator);

--- a/CondTools/SiStrip/plugins/SiStripChannelGainFromDBMiscalibrator.cc
+++ b/CondTools/SiStrip/plugins/SiStripChannelGainFromDBMiscalibrator.cc
@@ -51,15 +51,15 @@
 class SiStripChannelGainFromDBMiscalibrator : public edm::one::EDAnalyzer<>  {
    public:
       explicit SiStripChannelGainFromDBMiscalibrator(const edm::ParameterSet&);
-      ~SiStripChannelGainFromDBMiscalibrator();
+      ~SiStripChannelGainFromDBMiscalibrator() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void beginJob() override;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
       std::unique_ptr<SiStripApvGain> getNewObject(const std::map<std::pair<uint32_t,int>,float>& theMap);
-      virtual void endJob() override;
+      void endJob() override;
 
       // ----------member data ---------------------------
       const std::string m_Record;  

--- a/CondTools/SiStrip/plugins/SiStripMiscalibrateHelper.cc
+++ b/CondTools/SiStrip/plugins/SiStripMiscalibrateHelper.cc
@@ -1,0 +1,136 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CondFormats/SiStripObjects/interface/SiStripSummary.h"
+#include "CommonTools/TrackerMap/interface/TmModule.h"
+#include "CondTools/SiStrip/interface/SiStripMiscalibrateHelper.h"
+#include "CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h"
+
+/*--------------------------------------------------------------------*/
+sistripsummary::TrackerRegion SiStripMiscalibrate::getRegionFromString(std::string region)
+/*--------------------------------------------------------------------*/
+{
+  std::map<std::string,sistripsummary::TrackerRegion> mapping = {
+    {"Tracker",sistripsummary::TRACKER},
+    {"TIB"    ,sistripsummary::TIB   },
+    {"TIB_1"  ,sistripsummary::TIB_1 },
+    {"TIB_2"  ,sistripsummary::TIB_2 },
+    {"TIB_3"  ,sistripsummary::TIB_3 },
+    {"TIB_4"  ,sistripsummary::TIB_4 },
+    {"TID"    ,sistripsummary::TID   },
+    {"TIDP"   ,sistripsummary::TIDP  },
+    {"TIDP_1" ,sistripsummary::TIDP_1},
+    {"TIDP_2" ,sistripsummary::TIDP_2},
+    {"TIDP_3" ,sistripsummary::TIDP_3},
+    {"TIDM"   ,sistripsummary::TIDM  },
+    {"TIDM_1" ,sistripsummary::TIDM_1},
+    {"TIDM_2" ,sistripsummary::TIDM_2},
+    {"TIDM_3" ,sistripsummary::TIDM_3},
+    {"TOB"    ,sistripsummary::TOB   },
+    {"TOB_1"  ,sistripsummary::TOB_1 },
+    {"TOB_2"  ,sistripsummary::TOB_2 },
+    {"TOB_3"  ,sistripsummary::TOB_3 },
+    {"TOB_4"  ,sistripsummary::TOB_4 },
+    {"TOB_5"  ,sistripsummary::TOB_5 },
+    {"TOB_6"  ,sistripsummary::TOB_6 },
+    {"TEC"    ,sistripsummary::TEC   },
+    {"TECP"   ,sistripsummary::TECP  },
+    {"TECP_1" ,sistripsummary::TECP_1},
+    {"TECP_2" ,sistripsummary::TECP_2},
+    {"TECP_3" ,sistripsummary::TECP_3},
+    {"TECP_4" ,sistripsummary::TECP_4},
+    {"TECP_5" ,sistripsummary::TECP_5},
+    {"TECP_6" ,sistripsummary::TECP_6},
+    {"TECP_7" ,sistripsummary::TECP_7},
+    {"TECP_8" ,sistripsummary::TECP_8},
+    {"TECP_9" ,sistripsummary::TECP_9},
+    {"TECM"   ,sistripsummary::TECM  },
+    {"TECM_1" ,sistripsummary::TECM_1},
+    {"TECM_2" ,sistripsummary::TECM_2},
+    {"TECM_3" ,sistripsummary::TECM_3},
+    {"TECM_4" ,sistripsummary::TECM_4},
+    {"TECM_5" ,sistripsummary::TECM_5},
+    {"TECM_6" ,sistripsummary::TECM_6},
+    {"TECM_7" ,sistripsummary::TECM_7},
+    {"TECM_8" ,sistripsummary::TECM_8},
+    {"TECM_9" ,sistripsummary::TECM_9}
+  };
+  
+  if (mapping.find(region) == mapping.end() ){
+    edm::LogError("SiStripMiscalibrate") << "@SUB=analyze" << "Unknown partition: " << region;
+    throw cms::Exception("Invalid Partition passed"); 
+  } else {
+    return mapping[region];
+  }
+}
+
+/*--------------------------------------------------------------------*/
+std::vector<sistripsummary::TrackerRegion> SiStripMiscalibrate::getRegionsFromDetId(const TrackerTopology* m_trackerTopo,DetId detid)
+/*--------------------------------------------------------------------*/      
+{
+  int layer    = 0;
+  int side     = 0;
+  int subdet   = 0;
+  int detCode  = 0;
+
+  std::vector<sistripsummary::TrackerRegion> ret;
+
+  switch (detid.subdetId()) {
+  case StripSubdetector::TIB:
+    layer = m_trackerTopo->tibLayer(detid);
+    subdet = 1;
+    break;
+  case StripSubdetector::TOB:
+    layer = m_trackerTopo->tobLayer(detid);
+    subdet = 2;
+    break;
+  case StripSubdetector::TID:
+    // is this module in TID+ or TID-?
+    layer = m_trackerTopo->tidWheel(detid);
+    side  = m_trackerTopo->tidSide(detid);
+    subdet = 3*10+side;
+    break;
+  case StripSubdetector::TEC:
+    // is this module in TEC+ or TEC-?
+    layer = m_trackerTopo->tecWheel(detid);
+    side  = m_trackerTopo->tecSide(detid);
+    subdet = 4*10+side;
+    break;
+  }
+  
+  detCode = (subdet*10)+layer;
+  
+  ret.push_back(static_cast<sistripsummary::TrackerRegion>(detCode));
+
+  if(subdet/10 > 0) {
+    ret.push_back(static_cast<sistripsummary::TrackerRegion>(subdet/10));
+  }
+
+  ret.push_back(static_cast<sistripsummary::TrackerRegion>(subdet));
+  ret.push_back(sistripsummary::TRACKER);
+
+  return ret;
+}
+
+/*--------------------------------------------------------------------*/
+std::pair<float,float> SiStripMiscalibrate::getTruncatedRange(const TrackerMap* theMap){
+/*--------------------------------------------------------------------*/  
+
+  // ------------ trim the tracker map  ------------
+
+  auto map = theMap->smoduleMap;
+  std::map<unsigned int,float> info_per_detid;
+  for (int layer=1; layer < 44; layer++){
+    for (int ring=theMap->firstRing[layer-1]; ring < theMap->ntotRing[layer-1]+theMap->firstRing[layer-1];ring++){
+      for (int module=1;module<200;module++) {
+	int key=layer*100000+ring*1000+module;
+	TmModule* mod = map[key];
+	if(mod !=nullptr && !mod->notInUse()  && mod->count>0){
+	  info_per_detid[key]=mod->value;
+	}
+      } // loop on modules
+    } // loop on ring
+  } // loop on layers
+  
+  auto range = SiStripPI::getTheRange(info_per_detid,2);
+  return range;
+  
+}

--- a/CondTools/SiStrip/plugins/SiStripNoisesFromDBMiscalibrator.cc
+++ b/CondTools/SiStrip/plugins/SiStripNoisesFromDBMiscalibrator.cc
@@ -1,0 +1,625 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/SiStrip
+// Class:      SiStripNoisesFromDBMiscalibrator
+// 
+/**\class SiStripNoisesFromDBMiscalibrator SiStripNoisesFromDBMiscalibrator.cc CondTools/SiStrip/plugins/SiStripNoisesFromDBMiscalibrator.cc
+
+ Description: Class to miscalibrate a SiStrip Noise payload from Database
+
+ Implementation:
+     Read a SiStrip Noise payload from DB (either central DB or sqlite file) and apply a miscalibration (either an offset / gaussian smearing or both)
+     returns a local sqlite file with the same since of the original payload
+*/
+//
+// Original Author:  Marco Musich
+//         Created:  Tue, 03 Oct 2017 12:57:34 GMT
+//
+//
+
+// system include files
+#include <memory>
+#include <iostream>
+#include <fstream>
+
+// user include files
+#include "CLHEP/Random/RandGauss.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+#include "CommonTools/TrackerMap/interface/TrackerMap.h"
+#include "CommonTools/TrackerMap/interface/TmModule.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h"
+#include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "CondFormats/SiStripObjects/interface/SiStripSummary.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h" 
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h" 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h" 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h" 
+
+//
+// class declaration
+//
+
+namespace SiStripNoise {
+  
+  class Entry{
+  public:
+    Entry():
+      entries(0),
+      sum(0),
+      sq_sum(0){}
+
+    double mean() {return sum / entries;}
+    double std_dev() {
+      double tmean = mean();
+      return (sq_sum - entries*tmean*tmean)>0 ? sqrt((sq_sum - entries*tmean*tmean)/(entries-1)) : 0.;
+    }
+    double mean_rms() { return std_dev()/sqrt(entries); }
+
+    void add(double val){
+      entries++;
+      sum += val;
+      sq_sum += val*val;
+    }
+
+    void reset() {
+      entries = 0;
+      sum = 0;
+      sq_sum = 0;
+    }
+  private:
+    long int entries;
+    double sum, sq_sum;
+  };
+
+  struct NoiseSmearings{
+    NoiseSmearings(){
+      m_doScale = false;
+      m_doSmear = false;
+      m_scaleFactor = 1.;
+      m_smearFactor = 0.;
+    }
+    ~NoiseSmearings(){}
+    
+    void setSmearing(bool doScale,bool doSmear,double the_scaleFactor,double the_smearFactor){
+      m_doScale = doScale;
+      m_doSmear = doSmear;
+      m_scaleFactor = the_scaleFactor;
+      m_smearFactor = the_smearFactor;
+    }
+    
+    bool m_doScale;
+    bool m_doSmear;
+    double m_scaleFactor;
+    double m_smearFactor;
+  };
+
+}
+
+class SiStripNoisesFromDBMiscalibrator : public edm::one::EDAnalyzer<>  {
+   public:
+      explicit SiStripNoisesFromDBMiscalibrator(const edm::ParameterSet&);
+      ~SiStripNoisesFromDBMiscalibrator();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginJob() override;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      std::unique_ptr<SiStripNoises> getNewObject(const std::map<std::pair<uint32_t,int>,float>& theMap);
+      std::unique_ptr<SiStripNoises> getNewObject_withDefaults(const std::map<std::pair<uint32_t,int>,float>& theMap,const float theDefault);
+      sistripsummary::TrackerRegion getRegionFromString(std::string region);
+      std::vector<sistripsummary::TrackerRegion> getRegionsFromDetId(const TrackerTopology* tTopo,DetId detid);
+  
+      std::pair<float,float> getTruncatedRange(const TrackerMap* theMap);
+
+      virtual void endJob() override;
+
+      // ----------member data ---------------------------
+      const bool m_fillDefaults;
+      const bool m_saveMaps;
+      const std::vector<edm::ParameterSet> m_parameters;
+      edm::FileInPath fp_;
+
+      std::unique_ptr<TrackerMap> scale_map;
+      std::unique_ptr<TrackerMap> smear_map;
+      std::unique_ptr<TrackerMap> ratio_map;
+      std::unique_ptr<TrackerMap> old_payload_map;
+      std::unique_ptr<TrackerMap> new_payload_map;
+      std::unique_ptr<TrackerMap> missing_map;
+};
+
+//
+// constructors and destructor
+//
+SiStripNoisesFromDBMiscalibrator::SiStripNoisesFromDBMiscalibrator(const edm::ParameterSet& iConfig):
+  m_fillDefaults{iConfig.getUntrackedParameter<bool>("fillDefaults",false)},
+  m_saveMaps{iConfig.getUntrackedParameter<bool>("saveMaps",true)},
+  m_parameters{iConfig.getParameter<std::vector<edm::ParameterSet> >("params")},
+  fp_{iConfig.getUntrackedParameter<edm::FileInPath>("file",edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"))}
+{
+   //now do what ever initialization is needed
+
+  scale_map = std::unique_ptr<TrackerMap>(new TrackerMap("scale"));
+  scale_map->setTitle("Tracker Map of Scale factor module by module");
+  scale_map->setPalette(1);
+
+  smear_map =std::unique_ptr<TrackerMap>(new TrackerMap("smear"));
+  smear_map->setTitle("Tracker Map of Smear factor module by module");
+  smear_map->setPalette(1);
+
+  old_payload_map =std::unique_ptr<TrackerMap>(new TrackerMap("old_payload"));
+  old_payload_map->setTitle("Tracker Map of Starting Payload Noise module by module");
+  old_payload_map->setPalette(1);
+
+  new_payload_map =std::unique_ptr<TrackerMap>(new TrackerMap("new_payload"));
+  new_payload_map->setTitle("Tracker Map of Modified Payload Noise module by module");
+  new_payload_map->setPalette(1);
+
+  ratio_map = std::unique_ptr<TrackerMap>(new TrackerMap("ratio"));
+  ratio_map->setTitle("Tracker Map of Average by module of the payload ratio (new/old)");
+  ratio_map->setPalette(1);
+
+  if(m_fillDefaults){
+    missing_map = std::unique_ptr<TrackerMap>(new TrackerMap("uncabled"));
+    missing_map->setTitle("Tracker Map of uncabled modules");
+    missing_map->setPalette(1);
+  }
+
+}
+
+
+SiStripNoisesFromDBMiscalibrator::~SiStripNoisesFromDBMiscalibrator()
+{
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+SiStripNoisesFromDBMiscalibrator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+   edm::ESHandle<TrackerTopology> tTopoHandle;
+   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+   const auto* const tTopo = tTopoHandle.product();
+
+   std::vector<std::string> partitions;
+
+   // fill the list of partitions 
+   for(auto& thePSet : m_parameters){
+     const std::string partition(thePSet.getParameter<std::string>("partition"));
+     // only if it is not yet in the list
+     if(std::find(partitions.begin(), partitions.end(), partition) == partitions.end()) {
+       partitions.push_back(partition);
+     }
+   }
+
+   std::map<sistripsummary::TrackerRegion,SiStripNoise::NoiseSmearings> mapOfSmearings;
+
+   for(auto& thePSet : m_parameters){
+     
+     const std::string partition(thePSet.getParameter<std::string>("partition"));
+     sistripsummary::TrackerRegion region = this->getRegionFromString(partition);
+     
+     bool    m_doScale(thePSet.getParameter<bool>("doScale"));
+     bool    m_doSmear(thePSet.getParameter<bool>("doSmear"));
+     double  m_scaleFactor(thePSet.getParameter<double>("scaleFactor"));
+     double  m_smearFactor(thePSet.getParameter<double>("smearFactor"));
+     
+     SiStripNoise::NoiseSmearings params = SiStripNoise::NoiseSmearings();
+     params.setSmearing(m_doScale,m_doSmear,m_scaleFactor,m_smearFactor);
+     mapOfSmearings[region]=params;
+   }
+   
+   edm::ESHandle<SiStripNoises> SiStripNoise_;
+   iSetup.get<SiStripNoisesRcd>().get(SiStripNoise_);
+
+   std::map<std::pair<uint32_t,int>,float> theMap, oldPayloadMap;
+   
+   std::vector<uint32_t> detid;
+   SiStripNoise_->getDetIds(detid);
+   for (const auto & d : detid) {
+     SiStripNoises::Range range=SiStripNoise_->getRange(d);
+
+     auto regions = getRegionsFromDetId(tTopo,d); 
+
+     // sort by largest to smallest
+     std::sort(regions.rbegin(), regions.rend());
+     
+     SiStripNoise::NoiseSmearings params = SiStripNoise::NoiseSmearings();
+     
+     for (unsigned int j=0; j<regions.size();j++){
+       bool checkRegion = (mapOfSmearings.count(regions[j]) != 0);
+
+       if(!checkRegion) {
+	 // if the subdetector is not in the list and there's no indication for the whole tracker, just use the default 
+	 // i.e. no change
+	 continue;
+       } else {
+	 params = mapOfSmearings[regions[j]];
+	 break;
+       }
+     }
+
+     scale_map->fill(d,params.m_scaleFactor);
+     smear_map->fill(d,params.m_smearFactor);
+
+     int nStrips=0;
+     for( int it=0; it < (range.second-range.first)*8/9; ++it ){
+       auto noise=SiStripNoise_->getNoise(it,range);
+       std::pair<uint32_t,int> index = std::make_pair(d,nStrips);
+
+       oldPayloadMap[index]=noise;
+
+       if(params.m_doScale){
+	 noise*=params.m_scaleFactor;
+       }
+       
+       if(params.m_doSmear){
+	 float smearedNoise = CLHEP::RandGauss::shoot(noise,params.m_smearFactor); 
+	 noise=smearedNoise;
+       }
+
+       theMap[index]=noise;
+      
+       nStrips+=1;
+ 
+     } // loop over APVs
+   } // loop over DetIds
+
+   std::unique_ptr<SiStripNoises> theSiStripNoises;
+   if(!m_fillDefaults){
+     theSiStripNoises = this->getNewObject(theMap);
+   } else {
+     theSiStripNoises = this->getNewObject_withDefaults(theMap,-1.);
+   }
+
+   // make the payload ratio map
+   uint32_t cachedId(0);
+   SiStripNoise::Entry noise_ratio;
+   SiStripNoise::Entry o_noise;
+   SiStripNoise::Entry n_noise;
+   for(const auto &element : theMap){
+
+     uint32_t DetId  = element.first.first;
+     int      nstrip = element.first.second;
+     float new_noise = element.second;
+     float old_noise = oldPayloadMap[std::make_pair(DetId,nstrip)];
+     
+     // flush the counters
+     if(cachedId!=0 && DetId!=cachedId){
+       ratio_map->fill(cachedId,noise_ratio.mean());
+       old_payload_map->fill(cachedId,o_noise.mean());
+       new_payload_map->fill(cachedId,n_noise.mean());
+
+       //auto test = new_payload_map.get()->smoduleMap;
+
+       noise_ratio.reset();
+       o_noise.reset();
+       n_noise.reset();
+     } 
+     
+     cachedId=DetId;
+     noise_ratio.add(new_noise/old_noise);
+     o_noise.add(old_noise);
+     n_noise.add(new_noise);
+   }
+
+   // write out the SiStripNoises record
+   edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  
+   if( poolDbService.isAvailable() )
+     poolDbService->writeOne(theSiStripNoises.get(),poolDbService->currentTime(),"SiStripNoisesRcd");
+   else
+     throw std::runtime_error("PoolDBService required.");
+ 
+}
+
+// ------------ trim the tracker map  ------------
+std::pair<float,float> 
+SiStripNoisesFromDBMiscalibrator::getTruncatedRange(const TrackerMap* theMap){
+
+  auto map = theMap->smoduleMap;
+  std::map<unsigned int,float> info_per_detid;
+  for (int layer=1; layer < 44; layer++){
+    for (int ring=theMap->firstRing[layer-1]; ring < theMap->ntotRing[layer-1]+theMap->firstRing[layer-1];ring++){
+      for (int module=1;module<200;module++) {
+        int key=layer*100000+ring*1000+module;
+        TmModule* mod = map[key];
+        if(mod !=nullptr && !mod->notInUse()  && mod->count>0){
+          info_per_detid[key]=mod->value;
+        }
+      } // loop on modules
+    } // loop on ring
+  } // loop on layers
+
+  auto range = SiStripPI::getTheRange(info_per_detid,2);
+  return range;
+  
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+SiStripNoisesFromDBMiscalibrator::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+SiStripNoisesFromDBMiscalibrator::endJob() 
+{
+
+  if(m_saveMaps){
+    scale_map->save(true,0,0,"scale_map.pdf");
+    scale_map->save(true,0,0,"scale_map.png"); 
+			             
+    smear_map->save(true,0,0,"smear_map.pdf");
+    smear_map->save(true,0,0,"smear_map.png"); 
+			             
+    ratio_map->save(true,0,0,"ratio_map.pdf");
+    ratio_map->save(true,0,0,"ratio_map.png"); 
+
+    auto range = this->getTruncatedRange(old_payload_map.get());
+
+    old_payload_map->save(true,range.first,range.second,"starting_payload_map.pdf");
+    old_payload_map->save(true,range.first,range.second,"starting_payload_map.png");
+                   		             	      
+    range = this->getTruncatedRange(new_payload_map.get());
+
+    new_payload_map->save(true,range.first,range.second,"new_payload_map.pdf");
+    new_payload_map->save(true,range.first,range.second,"new_payload_map.png");
+
+    if(m_fillDefaults){
+      missing_map->save(true,0,0,"missing_map.pdf");
+      missing_map->save(true,0,0,"missing_map.png");
+    }
+  }
+}
+
+//********************************************************************************//
+std::unique_ptr<SiStripNoises>
+SiStripNoisesFromDBMiscalibrator::getNewObject_withDefaults(const std::map<std::pair<uint32_t,int>,float>& theMap,const float theDefault) 
+{
+  std::unique_ptr<SiStripNoises> obj = std::unique_ptr<SiStripNoises>(new SiStripNoises());
+  
+  SiStripDetInfoFileReader reader(fp_.fullPath());
+  const std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >& DetInfos  = reader.getAllData();
+
+  std::vector<uint32_t> missingDetIds;
+
+  for(std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >::const_iterator it = DetInfos.begin(); it != DetInfos.end(); it++){    
+    //Generate Noise for det detid
+    bool isMissing(false);
+    SiStripNoises::InputVector theSiStripVector;
+    for(int t_strip=0;t_strip<128*it->second.nApvs; ++t_strip){
+    
+      std::pair<uint32_t,int> index = std::make_pair(it->first, t_strip) ;
+    
+      if ( theMap.find(index) == theMap.end() ) {
+
+	LogDebug("SiStripNoisesFromDBMiscalibrator") << "detid " << it->first << " \t"
+						     << " strip " << t_strip << " \t"
+						     << " not found" << std::endl; 	    
+	
+	isMissing = true;
+	obj->setData(theDefault,theSiStripVector);
+
+      } else {
+
+	float noise = theMap.at(index);
+	obj->setData(noise,theSiStripVector);
+
+      }
+    }    
+     
+    if(isMissing) missingDetIds.push_back(it->first);
+ 
+    if ( ! obj->put(it->first,theSiStripVector) ) {
+      edm::LogError("SiStripNoisesFromDBMiscalibrator")<<"[SiStripNoisesFromDBMiscalibrator::analyze] detid already exists"<<std::endl;
+    }
+  }
+
+  if(missingDetIds.size()!=0){
+    // open output file
+    std::stringstream name; 
+    name << "missing_modules.txt";
+    std::ofstream* ofile = new std::ofstream(name.str(), std::ofstream::trunc); 
+    if ( !ofile->is_open() ) throw "cannot open output file!"; 
+    for(const auto &missing : missingDetIds){
+      edm::LogVerbatim("SiStripNoisesFromDBMiscalibrator") << missing << "  " << 1 << std::endl;
+      (*ofile) << missing << " " << 1 << std::endl; 
+      missing_map->fill(missing,1);
+    }
+
+    ofile->close();
+    delete ofile;
+
+  }
+
+  return obj;
+}
+
+
+//********************************************************************************//
+std::unique_ptr<SiStripNoises>
+SiStripNoisesFromDBMiscalibrator::getNewObject(const std::map<std::pair<uint32_t,int>,float>& theMap) 
+{
+  std::unique_ptr<SiStripNoises> obj = std::unique_ptr<SiStripNoises>(new SiStripNoises());
+  
+  uint32_t PreviousDetId = 0; 
+  SiStripNoises::InputVector theSiStripVector;
+  for(const auto &element : theMap){
+
+    uint32_t DetId = element.first.first;
+    float noise    = element.second;
+
+    if(DetId != PreviousDetId){    
+      if(!theSiStripVector.empty()){
+
+	if ( ! obj->put(PreviousDetId,theSiStripVector) ) {
+	  edm::LogError("SiStripNoisesFromDBMiscalibrator")<<"[SiStripNoisesFromDBMiscalibrator::analyze] detid already exists"<<std::endl;
+	}
+      }
+      
+      theSiStripVector.clear();
+      PreviousDetId = DetId;
+    }
+    obj->setData(noise,theSiStripVector);
+  }
+  return obj;
+}
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+SiStripNoisesFromDBMiscalibrator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  
+  desc.setComment("Creates rescaled / smeared SiStrip Noise payload."
+                  "PoolDBOutputService must be set up for 'SiSiStripNoisesRcd'.");
+  
+  edm::ParameterSetDescription descScaler;
+  descScaler.setComment("ParameterSet specifying the Strip tracker partition to be scaled / smeared "
+                        "by a given factor.");
+
+  descScaler.add<std::string>("partition", "Tracker");
+  descScaler.add<bool>("doScale",true);
+  descScaler.add<bool>("doSmear",true);
+  descScaler.add<double>("scaleFactor", 1.0);
+  descScaler.add<double>("smearFactor", 1.0);
+  desc.addVPSet("params", descScaler, std::vector<edm::ParameterSet>(1));
+
+  desc.addUntracked<bool>("fillDefaults",false);
+  desc.addUntracked<bool>("saveMaps",true);
+
+  descriptions.add("scaleAndSmearSiStripNoises", desc);
+
+}
+
+/*--------------------------------------------------------------------*/
+sistripsummary::TrackerRegion SiStripNoisesFromDBMiscalibrator::getRegionFromString(std::string region)
+/*--------------------------------------------------------------------*/
+{
+  std::map<std::string,sistripsummary::TrackerRegion> mapping = {
+    {"Tracker",sistripsummary::TRACKER},
+    {"TIB"    ,sistripsummary::TIB   },
+    {"TIB_1"  ,sistripsummary::TIB_1 },
+    {"TIB_2"  ,sistripsummary::TIB_2 },
+    {"TIB_3"  ,sistripsummary::TIB_3 },
+    {"TIB_4"  ,sistripsummary::TIB_4 },
+    {"TID"    ,sistripsummary::TID   },
+    {"TIDP"   ,sistripsummary::TIDP  },
+    {"TIDP_1" ,sistripsummary::TIDP_1},
+    {"TIDP_2" ,sistripsummary::TIDP_2},
+    {"TIDP_3" ,sistripsummary::TIDP_3},
+    {"TIDM"   ,sistripsummary::TIDM  },
+    {"TIDM_1" ,sistripsummary::TIDM_1},
+    {"TIDM_2" ,sistripsummary::TIDM_2},
+    {"TIDM_3" ,sistripsummary::TIDM_3},
+    {"TOB"    ,sistripsummary::TOB   },
+    {"TOB_1"  ,sistripsummary::TOB_1 },
+    {"TOB_2"  ,sistripsummary::TOB_2 },
+    {"TOB_3"  ,sistripsummary::TOB_3 },
+    {"TOB_4"  ,sistripsummary::TOB_4 },
+    {"TOB_5"  ,sistripsummary::TOB_5 },
+    {"TOB_6"  ,sistripsummary::TOB_6 },
+    {"TEC"    ,sistripsummary::TEC   },
+    {"TECP"   ,sistripsummary::TECP  },
+    {"TECP_1" ,sistripsummary::TECP_1},
+    {"TECP_2" ,sistripsummary::TECP_2},
+    {"TECP_3" ,sistripsummary::TECP_3},
+    {"TECP_4" ,sistripsummary::TECP_4},
+    {"TECP_5" ,sistripsummary::TECP_5},
+    {"TECP_6" ,sistripsummary::TECP_6},
+    {"TECP_7" ,sistripsummary::TECP_7},
+    {"TECP_8" ,sistripsummary::TECP_8},
+    {"TECP_9" ,sistripsummary::TECP_9},
+    {"TECM"   ,sistripsummary::TECM  },
+    {"TECM_1" ,sistripsummary::TECM_1},
+    {"TECM_2" ,sistripsummary::TECM_2},
+    {"TECM_3" ,sistripsummary::TECM_3},
+    {"TECM_4" ,sistripsummary::TECM_4},
+    {"TECM_5" ,sistripsummary::TECM_5},
+    {"TECM_6" ,sistripsummary::TECM_6},
+    {"TECM_7" ,sistripsummary::TECM_7},
+    {"TECM_8" ,sistripsummary::TECM_8},
+    {"TECM_9" ,sistripsummary::TECM_9}
+  };
+  
+  if (mapping.find(region) == mapping.end() ){
+    edm::LogError("SiStripNoisesFromDBMiscalibrator") << "@SUB=analyze" << "Unknown partition: " << region;
+    throw cms::Exception("Invalid Partition passed"); 
+  } else {
+    return mapping[region];
+  }
+}
+
+/*--------------------------------------------------------------------*/
+std::vector<sistripsummary::TrackerRegion> SiStripNoisesFromDBMiscalibrator::getRegionsFromDetId(const TrackerTopology* m_trackerTopo,DetId detid)
+/*--------------------------------------------------------------------*/      
+{
+  int layer    = 0;
+  int side     = 0;
+  int subdet   = 0;
+  int detCode  = 0;
+
+  std::vector<sistripsummary::TrackerRegion> ret;
+
+  switch (detid.subdetId()) {
+  case StripSubdetector::TIB:
+    layer = m_trackerTopo->tibLayer(detid);
+    subdet = 1;
+    break;
+  case StripSubdetector::TOB:
+    layer = m_trackerTopo->tobLayer(detid);
+    subdet = 2;
+    break;
+  case StripSubdetector::TID:
+    // is this module in TID+ or TID-?
+    layer = m_trackerTopo->tidWheel(detid);
+    side  = m_trackerTopo->tidSide(detid);
+    subdet = 3*10+side;
+    break;
+  case StripSubdetector::TEC:
+    // is this module in TEC+ or TEC-?
+    layer = m_trackerTopo->tecWheel(detid);
+    side  = m_trackerTopo->tecSide(detid);
+    subdet = 4*10+side;
+    break;
+  }
+  
+  detCode = (subdet*10)+layer;
+  
+  ret.push_back(static_cast<sistripsummary::TrackerRegion>(detCode));
+
+  if(subdet/10 > 0) {
+    ret.push_back(static_cast<sistripsummary::TrackerRegion>(subdet/10));
+  }
+
+  ret.push_back(static_cast<sistripsummary::TrackerRegion>(subdet));
+  ret.push_back(sistripsummary::TRACKER);
+
+  return ret;
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SiStripNoisesFromDBMiscalibrator);
+
+
+
+     

--- a/CondTools/SiStrip/plugins/SiStripNoisesFromDBMiscalibrator.cc
+++ b/CondTools/SiStrip/plugins/SiStripNoisesFromDBMiscalibrator.cc
@@ -51,16 +51,16 @@
 class SiStripNoisesFromDBMiscalibrator : public edm::one::EDAnalyzer<>  {
    public:
       explicit SiStripNoisesFromDBMiscalibrator(const edm::ParameterSet&);
-      ~SiStripNoisesFromDBMiscalibrator();
+      ~SiStripNoisesFromDBMiscalibrator() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void beginJob() override;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
       std::unique_ptr<SiStripNoises> getNewObject(const std::map<std::pair<uint32_t,int>,float>& theMap);
       std::unique_ptr<SiStripNoises> getNewObject_withDefaults(const std::map<std::pair<uint32_t,int>,float>& theMap,const float theDefault); 
-      virtual void endJob() override;
+      void endJob() override;
 
       // ----------member data ---------------------------
       const bool m_fillDefaults;
@@ -348,7 +348,7 @@ SiStripNoisesFromDBMiscalibrator::getNewObject_withDefaults(const std::map<std::
     }
   }
 
-  if(missingDetIds.size()!=0){
+  if(!missingDetIds.empty()){
     // open output file
     std::stringstream name; 
     name << "missing_modules.txt";

--- a/CondTools/SiStrip/python/MiscalibrationSettings_cff.py
+++ b/CondTools/SiStrip/python/MiscalibrationSettings_cff.py
@@ -1,0 +1,261 @@
+import FWCore.ParameterSet.Config as cms
+import copy
+
+# Layer: Layer.TIB1 ratio of ratios: 1.02533166915
+# Layer: Layer.TIB2 ratio of ratios: 1.01521093183
+# Layer: Layer.TIB3 ratio of ratios: 1.01552419364
+# Layer: Layer.TIB4 ratio of ratios: 0.95224779507
+# Layer: Layer.TOB1 ratio of ratios: 1.01219411074
+# Layer: Layer.TOB2 ratio of ratios: 1.00835168635
+# Layer: Layer.TOB3 ratio of ratios: 0.996159099354
+# Layer: Layer.TOB4 ratio of ratios: 0.997676926445
+# Layer: Layer.TOB5 ratio of ratios: 0.993886888572
+# Layer: Layer.TOB6 ratio of ratios: 0.997490411188
+# Layer: Layer.TIDP1 ratio of ratios: 1.0314881072
+# Layer: Layer.TIDP2 ratio of ratios: 1.02853114088
+# Layer: Layer.TIDP3 ratio of ratios: 1.0518768914
+# Layer: Layer.TIDM1 ratio of ratios: 1.03421675878
+# Layer: Layer.TIDM2 ratio of ratios: 1.04546785025
+# Layer: Layer.TIDM3 ratio of ratios: 1.0311586591
+# Layer: Layer.TECP1 ratio of ratios: 1.04989866792
+# Layer: Layer.TECP2 ratio of ratios: 1.03711260343
+# Layer: Layer.TECP3 ratio of ratios: 1.04297992451
+# Layer: Layer.TECP4 ratio of ratios: 1.04669045804
+# Layer: Layer.TECP5 ratio of ratios: 1.03838249025
+# Layer: Layer.TECP6 ratio of ratios: 1.04727471357
+# Layer: Layer.TECP7 ratio of ratios: 1.03632636024
+# Layer: Layer.TECP8 ratio of ratios: 1.04860504406
+# Layer: Layer.TECP9 ratio of ratios: 1.03398568113
+# Layer: Layer.TECM1 ratio of ratios: 1.04750199121
+# Layer: Layer.TECM2 ratio of ratios: 1.03771633506
+# Layer: Layer.TECM3 ratio of ratios: 1.0409554129
+# Layer: Layer.TECM4 ratio of ratios: 1.03630204118
+# Layer: Layer.TECM5 ratio of ratios: 1.0417988699
+# Layer: Layer.TECM6 ratio of ratios: 1.03864754217
+# Layer: Layer.TECM7 ratio of ratios: 1.03868976393
+# Layer: Layer.TECM8 ratio of ratios: 1.03942709841
+# Layer: Layer.TECM9 ratio of ratios: 1.03678940814
+
+byLayer = cms.VPSet(
+
+    ################## TIB ##################
+
+    cms.PSet(partition = cms.string("TIB_1"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.02533166915),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIB_2"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.01521093183),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIB_3"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.01552419364),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIB_4"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(0.95224779507),
+             smearFactor = cms.double(0.0)
+             ),
+
+    ################## TOB ##################
+
+    cms.PSet(partition = cms.string("TOB_1"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.01219411074),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TOB_2"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.00835168635),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TOB_3"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(0.996159099354),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TOB_4"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(0.997676926445),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TOB_5"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(0.993886888572),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TOB_6"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(0.997490411188),
+             smearFactor = cms.double(0.0)
+             ),
+
+    ################## TID Plus ##################
+
+    cms.PSet(partition = cms.string("TIDP_1"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.0314881072),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIDP_2"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.02853114088),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIDP_3"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.0518768914),
+             smearFactor = cms.double(0.0)
+             ),
+
+    ################## TID Minus ##################
+
+    cms.PSet(partition = cms.string("TIDM_1"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03421675878),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIDM_2"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04546785025),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIDM_3"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.0311586591),
+             smearFactor = cms.double(0.0)
+             ),
+    
+    ################## TEC plus ##################
+
+    cms.PSet(partition = cms.string("TECP_1"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04989866792),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_2"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03711260343),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_3"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04297992451),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_4"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04669045804),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_5"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03838249025),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_6"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04727471357),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_7"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03632636024),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_8"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04860504406),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_9"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03398568113),
+             smearFactor = cms.double(0.0)
+             ),
+
+    ################## TEC Minus ##################
+    cms.PSet(partition = cms.string("TECM_1"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04750199121),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_2"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03771633506),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_3"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.0409554129),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_4"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03630204118),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_5"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.0417988699),
+             smearFactor = cms.double(0.0)
+             ),    
+    cms.PSet(partition = cms.string("TECM_6"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03864754217),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_7"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.0386897639),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_8"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03942709841),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_9"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03678940814),
+             smearFactor = cms.double(0.0)
+             )
+    ) 

--- a/CondTools/SiStrip/test/SiStripBadModuleByHandBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripBadModuleByHandBuilder_cfg.py
@@ -23,7 +23,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     DBParameters = cms.PSet(
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
-    timetype = cms.string('runnumber'),
+    timetype = cms.untracked.string('runnumber'),
     connect = cms.string('sqlite_file:dbfile.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripBadStrip'),
@@ -31,7 +31,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     ))
 )
 
-process.prod = cms.EDFilter("SiStripBadModuleByHandBuilder",
+process.prod = cms.EDAnalyzer("SiStripBadModuleByHandBuilder",
     BadModuleList = cms.untracked.vuint32(470178036, 470178032, 470178024),
     Record = cms.string('SiStripBadStrip'),
     SinceAppendMode = cms.bool(True),
@@ -41,9 +41,9 @@ process.prod = cms.EDFilter("SiStripBadModuleByHandBuilder",
     file = cms.untracked.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat')
 )
 
-process.print = cms.OutputModule("AsciiOutputModule")
+process.pprint = cms.OutputModule("AsciiOutputModule")
 
 process.p = cms.Path(process.prod)
-process.ep = cms.EndPath(process.print)
+process.ep = cms.EndPath(process.pprint)
 
 

--- a/CondTools/SiStrip/test/SiStripChannelGainFromDBMiscalibrator_cfg.py
+++ b/CondTools/SiStrip/test/SiStripChannelGainFromDBMiscalibrator_cfg.py
@@ -8,7 +8,7 @@ process = cms.Process("Demo")
 options = VarParsing.VarParsing("analysis")
 
 options.register ('globalTag',
-                  "92X_dataRun2_Prompt_v8",
+                  "auto:run2_data",
                   VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "GlobalTag")
@@ -26,7 +26,7 @@ options.parseArguments()
 ## MessageLogger
 ##
 process.load('FWCore.MessageService.MessageLogger_cfi')   
-process.MessageLogger.categories.append("SmearSiStripChannelGainFromDB")  
+process.MessageLogger.categories.append("SiStripChannelGainFromDBMiscalibrator")  
 process.MessageLogger.destinations = cms.untracked.vstring("cout")
 process.MessageLogger.cout = cms.untracked.PSet(
     threshold = cms.untracked.string("WARNING"),
@@ -34,7 +34,7 @@ process.MessageLogger.cout = cms.untracked.PSet(
     FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
                                    reportEvery = cms.untracked.int32(1000)
                                    ),                                                      
-    SmearSiStripChannelGainFromDB  = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+    SiStripChannelGainFromDBMiscalibrator  = cms.untracked.PSet( limit = cms.untracked.int32(-1))
     )
 process.MessageLogger.statistics.append('cout') 
 
@@ -43,6 +43,11 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag,options.globalTag, '')
 
+print "Using Global Tag:", process.GlobalTag.globaltag._value
+
+##
+## Empty Source
+##
 process.source = cms.Source("EmptySource",
                             firstRun = cms.untracked.uint32(options.runNumber),
                             numberEventsInRun = cms.untracked.uint32(1),
@@ -134,7 +139,8 @@ subsets =  cms.VPSet(
 # process.demo = cms.EDAnalyzer('SiStripChannelGainFromDBMiscalibrator',
 #                               record = cms.untracked.string("SiStripApvGainRcd"),
 #                               gainType = cms.untracked.uint32(1), #0 for G1, 1 for G2
-#                               params = subsets # as a cms.VPset
+#                               params = subsets, # as a cms.VPset
+#                               saveMaps = cms.bool(True)      
 #                               )
 
 process.load("CondTools.SiStrip.scaleAndSmearSiStripGains_cfi")
@@ -149,7 +155,7 @@ process.load("CondCore.CondDB.CondDB_cfi")
 ##
 ## Output database (in this case local sqlite file)
 ##
-process.CondDB.connect = 'sqlite_file:modifiedGains_'+options.globalTag+'_IOV_'+str(options.runNumber)+".db"
+process.CondDB.connect = 'sqlite_file:modifiedGains_'+ process.GlobalTag.globaltag._value+'_IOV_'+str(options.runNumber)+".db"
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDB,
                                           timetype = cms.untracked.string('runnumber'),

--- a/CondTools/SiStrip/test/SiStripNoiseBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripNoiseBuilder_cfg.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ICALIB")
+process.MessageLogger = cms.Service("MessageLogger",
+                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('INFO')),
+                                    destinations = cms.untracked.vstring('cout')
+                                    )
+
+process.source = cms.Source("EmptyIOVSource",
+                            firstValue = cms.uint64(1),
+                            lastValue = cms.uint64(1),
+                            timetype = cms.string('runnumber'),
+                            interval = cms.uint64(1)
+                            )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+                                          DBParameters = cms.PSet(authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')),
+                                          timetype = cms.untracked.string('runnumber'),
+                                          connect = cms.string('sqlite_file:dbfile.db'),
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('SiStripNoisesRcd'),
+                                                                     tag = cms.string('SiStripNoise_test')
+                                                                     )
+                                                            )
+                                          )
+
+process.prod = cms.EDAnalyzer("SiStripNoisesBuilder",
+                              printDebug = cms.untracked.uint32(1),
+                              file = cms.untracked.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat')
+                              )
+
+#process.print = cms.OutputModule("AsciiOutputModule")
+
+process.p = cms.Path(process.prod)
+#process.ep = cms.EndPath(process.print)
+
+

--- a/CondTools/SiStrip/test/SiStripNoiseFromDBMiscalibrator_cfg.py
+++ b/CondTools/SiStrip/test/SiStripNoiseFromDBMiscalibrator_cfg.py
@@ -1,0 +1,472 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("Demo")
+
+#prepare options
+
+options = VarParsing.VarParsing("analysis")
+
+options.register ('globalTag',
+                  "100X_dataRun2_Express_v2",
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "GlobalTag")
+
+options.register ('runNumber',
+                  306054,
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.int,           # string, int, or float
+                  "run number")
+
+options.parseArguments()
+
+
+##
+## MessageLogger
+##
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.categories.append("SiStripNoisesFromDBMiscalibrator")  
+process.MessageLogger.destinations = cms.untracked.vstring("cout")
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    SiStripNoisesFromDBMiscalibrator = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+    )
+process.MessageLogger.statistics.append('cout') 
+
+process.load("Configuration.Geometry.GeometryRecoDB_cff") # Ideal geometry and interface 
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag,options.globalTag, '')
+
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(options.runNumber),
+                            numberEventsInRun = cms.untracked.uint32(1),
+                            )
+
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
+
+##
+## Example smearing configurations
+##
+
+# Layer: Layer.TIB1 ratio of ratios: 1.02533166915
+# Layer: Layer.TIB2 ratio of ratios: 1.01521093183
+# Layer: Layer.TIB3 ratio of ratios: 1.01552419364
+# Layer: Layer.TIB4 ratio of ratios: 0.95224779507
+# Layer: Layer.TOB1 ratio of ratios: 1.01219411074
+# Layer: Layer.TOB2 ratio of ratios: 1.00835168635
+# Layer: Layer.TOB3 ratio of ratios: 0.996159099354
+# Layer: Layer.TOB4 ratio of ratios: 0.997676926445
+# Layer: Layer.TOB5 ratio of ratios: 0.993886888572
+# Layer: Layer.TOB6 ratio of ratios: 0.997490411188
+# Layer: Layer.TIDP1 ratio of ratios: 1.0314881072
+# Layer: Layer.TIDP2 ratio of ratios: 1.02853114088
+# Layer: Layer.TIDP3 ratio of ratios: 1.0518768914
+# Layer: Layer.TIDM1 ratio of ratios: 1.03421675878
+# Layer: Layer.TIDM2 ratio of ratios: 1.04546785025
+# Layer: Layer.TIDM3 ratio of ratios: 1.0311586591
+# Layer: Layer.TECP1 ratio of ratios: 1.04989866792
+# Layer: Layer.TECP2 ratio of ratios: 1.03711260343
+# Layer: Layer.TECP3 ratio of ratios: 1.04297992451
+# Layer: Layer.TECP4 ratio of ratios: 1.04669045804
+# Layer: Layer.TECP5 ratio of ratios: 1.03838249025
+# Layer: Layer.TECP6 ratio of ratios: 1.04727471357
+# Layer: Layer.TECP7 ratio of ratios: 1.03632636024
+# Layer: Layer.TECP8 ratio of ratios: 1.04860504406
+# Layer: Layer.TECP9 ratio of ratios: 1.03398568113
+# Layer: Layer.TECM1 ratio of ratios: 1.04750199121
+# Layer: Layer.TECM2 ratio of ratios: 1.03771633506
+# Layer: Layer.TECM3 ratio of ratios: 1.0409554129
+# Layer: Layer.TECM4 ratio of ratios: 1.03630204118
+# Layer: Layer.TECM5 ratio of ratios: 1.0417988699
+# Layer: Layer.TECM6 ratio of ratios: 1.03864754217
+# Layer: Layer.TECM7 ratio of ratios: 1.03868976393
+# Layer: Layer.TECM8 ratio of ratios: 1.03942709841
+# Layer: Layer.TECM9 ratio of ratios: 1.03678940814
+
+byLayer = cms.VPSet(
+
+    ################## TIB ##################
+
+    cms.PSet(partition = cms.string("TIB_1"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.02533166915),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIB_2"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.01521093183),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIB_3"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.01552419364),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIB_4"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(0.95224779507),
+             smearFactor = cms.double(0.0)
+             ),
+
+    ################## TOB ##################
+
+    cms.PSet(partition = cms.string("TOB_1"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.01219411074),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TOB_2"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.00835168635),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TOB_3"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(0.996159099354),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TOB_4"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(0.997676926445),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TOB_5"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(0.993886888572),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TOB_6"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(0.997490411188),
+             smearFactor = cms.double(0.0)
+             ),
+
+    ################## TID Plus ##################
+
+    cms.PSet(partition = cms.string("TIDP_1"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.0314881072),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIDP_2"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.02853114088),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIDP_3"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.0518768914),
+             smearFactor = cms.double(0.0)
+             ),
+
+    ################## TID Minus ##################
+
+    cms.PSet(partition = cms.string("TIDM_1"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03421675878),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIDM_2"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04546785025),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TIDM_3"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.0311586591),
+             smearFactor = cms.double(0.0)
+             ),
+    
+    ################## TEC plus ##################
+
+    cms.PSet(partition = cms.string("TECP_1"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04989866792),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_2"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03711260343),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_3"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04297992451),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_4"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04669045804),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_5"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03838249025),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_6"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04727471357),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_7"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03632636024),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_8"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04860504406),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECP_9"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03398568113),
+             smearFactor = cms.double(0.0)
+             ),
+
+    ################## TEC Minus ##################
+    cms.PSet(partition = cms.string("TECM_1"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.04750199121),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_2"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03771633506),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_3"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.0409554129),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_4"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03630204118),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_5"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.0417988699),
+             smearFactor = cms.double(0.0)
+             ),    
+    cms.PSet(partition = cms.string("TECM_6"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03864754217),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_7"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.0386897639),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_8"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03942709841),
+             smearFactor = cms.double(0.0)
+             ),
+    cms.PSet(partition = cms.string("TECM_9"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.03678940814),
+             smearFactor = cms.double(0.0)
+             )
+    ) 
+
+
+########### Noise ##########
+# TEC: new = 5.985 old = 5.684  => ratio: 1.052
+# TOB: new = 6.628 old = 6.647  => ratio: 0.997
+# TIB: new = 5.491 old = 5.392  => ratio: 1.018
+# TID: new = 5.259 old = 5.080  => ratio: 1.035
+
+##
+## separately partition by partition
+##
+byPartition = cms.VPSet(
+    cms.PSet(partition = cms.string("TEC"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.2),
+             smearFactor = cms.double(0.04)
+             ),
+    cms.PSet(partition = cms.string("TOB"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(0.94),
+             smearFactor = cms.double(0.03)
+             ),
+    cms.PSet(partition = cms.string("TIB"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(1.1),
+             smearFactor = cms.double(0.02)
+             ),
+    cms.PSet(partition = cms.string("TID"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(False),
+             scaleFactor = cms.double(0.22),
+             smearFactor = cms.double(0.01)
+             )
+    )
+
+##
+## whole Strip tracker
+##
+
+wholeTracker = cms.VPSet(
+    cms.PSet(partition = cms.string("Tracker"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(1.00),
+             smearFactor = cms.double(0.00)
+             )
+    )
+
+byLayer2 = cms.VPSet(
+
+    ################## TIB ##################
+
+    cms.PSet(partition = cms.string("TIB_1"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(1),
+             smearFactor = cms.double(0.1)
+             ),
+    cms.PSet(partition = cms.string("TIB_2"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(2),
+             smearFactor = cms.double(0.25)
+             ),
+    cms.PSet(partition = cms.string("TIB_3"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(3),
+             smearFactor = cms.double(0.2)
+             ),
+    cms.PSet(partition = cms.string("TIB_4"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(4),
+             smearFactor = cms.double(0.01)
+             )
+    )
+
+subsets =  cms.VPSet(
+    cms.PSet(partition = cms.string("Tracker"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(0.65),
+             smearFactor = cms.double(0.05)
+             ),
+    cms.PSet(partition = cms.string("TEC"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(1.15),
+             smearFactor = cms.double(0.02)
+             ),
+    cms.PSet(partition = cms.string("TECP"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(1.35),
+             smearFactor = cms.double(0.02)
+             ),
+    cms.PSet(partition = cms.string("TECP_9"),
+             doScale   = cms.bool(True),
+             doSmear   = cms.bool(True),
+             scaleFactor = cms.double(1.55),
+             smearFactor = cms.double(0.02)
+             )
+    )
+
+
+autoparams=[]
+listOfLayers=["TIB_1","TIB_2","TIB_3","TIB_4","TOB_1","TOB_2","TOB_3","TOB_4","TOB_5","TOB_6","TIDM_1","TIDM_2","TIDM_3","TECM_1","TECM_2","TECM_3","TECM_4","TECM_5","TECM_6","TECM_7","TECM_8","TECM_9","TIDP_1","TIDP_2","TIDP_3","TECP_1","TECP_2","TECP_3","TECP_4","TECP_5","TECP_6","TECP_7","TECP_8","TECP_9"]
+
+for i,ll in enumerate(listOfLayers):
+    autoparams.append(
+        cms.PSet(
+            partition = cms.string(ll),
+            doScale   = cms.bool(True),
+            doSmear   = cms.bool(True),
+            scaleFactor = cms.double(i*0.1),
+            smearFactor = cms.double((len(listOfLayers)-i)*0.01)
+            )
+        )
+
+
+# process.demo = cms.EDAnalyzer('SiStripChannelGainFromDBMiscalibrator',
+#                               record = cms.untracked.string("SiStripApvGainRcd"),
+#                               gainType = cms.untracked.uint32(1), #0 for G1, 1 for G2
+#                               params = subsets # as a cms.VPset
+#                               )
+
+process.load("CondTools.SiStrip.scaleAndSmearSiStripNoises_cfi")
+#process.scaleAndSmearSiStripNoises.params  = wholeTracker  # as a cms.VPset
+#process.scaleAndSmearSiStripNoises.params  = byPartition   # as a cms.VPset
+#process.scaleAndSmearSiStripNoises.params = subsets        # as a cms.VPset
+#process.scaleAndSmearSiStripNoises.params = byLayer2       # as a cms.VPset
+process.scaleAndSmearSiStripNoises.params  = autoparams
+process.scaleAndSmearSiStripNoises.fillDefaults = True     # to fill uncabled DetIds with default
+
+##
+## Database output service
+##
+process.load("CondCore.CondDB.CondDB_cfi")
+
+##
+## Output database (in this case local sqlite file)
+##
+process.CondDB.connect = 'sqlite_file:modifiedNoise_'+options.globalTag+'_IOV_'+str(options.runNumber)+".db"
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          process.CondDB,
+                                          timetype = cms.untracked.string('runnumber'),
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('SiStripNoisesRcd'),
+                                                                     tag = cms.string('modifiedNoise')
+                                                                     )
+                                                            )
+                                          )
+
+process.p = cms.Path(process.scaleAndSmearSiStripNoises)

--- a/CondTools/SiStrip/test/SiStripNoiseFromDBMiscalibrator_cfg.py
+++ b/CondTools/SiStrip/test/SiStripNoiseFromDBMiscalibrator_cfg.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
+import copy 
 
 process = cms.Process("Demo")
 
@@ -8,7 +9,7 @@ process = cms.Process("Demo")
 options = VarParsing.VarParsing("analysis")
 
 options.register ('globalTag',
-                  "100X_dataRun2_Express_v2",
+                  "auto:run2_data",
                   VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "GlobalTag")
@@ -43,6 +44,11 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag,options.globalTag, '')
 
+print "Using Global Tag:", process.GlobalTag.globaltag._value
+
+##
+## Empty Source
+##
 process.source = cms.Source("EmptySource",
                             firstRun = cms.untracked.uint32(options.runNumber),
                             numberEventsInRun = cms.untracked.uint32(1),
@@ -54,266 +60,6 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 ##
 ## Example smearing configurations
 ##
-
-# Layer: Layer.TIB1 ratio of ratios: 1.02533166915
-# Layer: Layer.TIB2 ratio of ratios: 1.01521093183
-# Layer: Layer.TIB3 ratio of ratios: 1.01552419364
-# Layer: Layer.TIB4 ratio of ratios: 0.95224779507
-# Layer: Layer.TOB1 ratio of ratios: 1.01219411074
-# Layer: Layer.TOB2 ratio of ratios: 1.00835168635
-# Layer: Layer.TOB3 ratio of ratios: 0.996159099354
-# Layer: Layer.TOB4 ratio of ratios: 0.997676926445
-# Layer: Layer.TOB5 ratio of ratios: 0.993886888572
-# Layer: Layer.TOB6 ratio of ratios: 0.997490411188
-# Layer: Layer.TIDP1 ratio of ratios: 1.0314881072
-# Layer: Layer.TIDP2 ratio of ratios: 1.02853114088
-# Layer: Layer.TIDP3 ratio of ratios: 1.0518768914
-# Layer: Layer.TIDM1 ratio of ratios: 1.03421675878
-# Layer: Layer.TIDM2 ratio of ratios: 1.04546785025
-# Layer: Layer.TIDM3 ratio of ratios: 1.0311586591
-# Layer: Layer.TECP1 ratio of ratios: 1.04989866792
-# Layer: Layer.TECP2 ratio of ratios: 1.03711260343
-# Layer: Layer.TECP3 ratio of ratios: 1.04297992451
-# Layer: Layer.TECP4 ratio of ratios: 1.04669045804
-# Layer: Layer.TECP5 ratio of ratios: 1.03838249025
-# Layer: Layer.TECP6 ratio of ratios: 1.04727471357
-# Layer: Layer.TECP7 ratio of ratios: 1.03632636024
-# Layer: Layer.TECP8 ratio of ratios: 1.04860504406
-# Layer: Layer.TECP9 ratio of ratios: 1.03398568113
-# Layer: Layer.TECM1 ratio of ratios: 1.04750199121
-# Layer: Layer.TECM2 ratio of ratios: 1.03771633506
-# Layer: Layer.TECM3 ratio of ratios: 1.0409554129
-# Layer: Layer.TECM4 ratio of ratios: 1.03630204118
-# Layer: Layer.TECM5 ratio of ratios: 1.0417988699
-# Layer: Layer.TECM6 ratio of ratios: 1.03864754217
-# Layer: Layer.TECM7 ratio of ratios: 1.03868976393
-# Layer: Layer.TECM8 ratio of ratios: 1.03942709841
-# Layer: Layer.TECM9 ratio of ratios: 1.03678940814
-
-byLayer = cms.VPSet(
-
-    ################## TIB ##################
-
-    cms.PSet(partition = cms.string("TIB_1"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.02533166915),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TIB_2"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.01521093183),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TIB_3"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.01552419364),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TIB_4"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(0.95224779507),
-             smearFactor = cms.double(0.0)
-             ),
-
-    ################## TOB ##################
-
-    cms.PSet(partition = cms.string("TOB_1"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.01219411074),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TOB_2"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.00835168635),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TOB_3"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(0.996159099354),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TOB_4"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(0.997676926445),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TOB_5"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(0.993886888572),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TOB_6"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(0.997490411188),
-             smearFactor = cms.double(0.0)
-             ),
-
-    ################## TID Plus ##################
-
-    cms.PSet(partition = cms.string("TIDP_1"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.0314881072),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TIDP_2"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.02853114088),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TIDP_3"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.0518768914),
-             smearFactor = cms.double(0.0)
-             ),
-
-    ################## TID Minus ##################
-
-    cms.PSet(partition = cms.string("TIDM_1"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.03421675878),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TIDM_2"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.04546785025),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TIDM_3"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.0311586591),
-             smearFactor = cms.double(0.0)
-             ),
-    
-    ################## TEC plus ##################
-
-    cms.PSet(partition = cms.string("TECP_1"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.04989866792),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECP_2"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.03711260343),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECP_3"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.04297992451),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECP_4"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.04669045804),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECP_5"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.03838249025),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECP_6"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.04727471357),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECP_7"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.03632636024),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECP_8"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.04860504406),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECP_9"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.03398568113),
-             smearFactor = cms.double(0.0)
-             ),
-
-    ################## TEC Minus ##################
-    cms.PSet(partition = cms.string("TECM_1"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.04750199121),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECM_2"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.03771633506),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECM_3"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.0409554129),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECM_4"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.03630204118),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECM_5"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.0417988699),
-             smearFactor = cms.double(0.0)
-             ),    
-    cms.PSet(partition = cms.string("TECM_6"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.03864754217),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECM_7"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.0386897639),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECM_8"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.03942709841),
-             smearFactor = cms.double(0.0)
-             ),
-    cms.PSet(partition = cms.string("TECM_9"),
-             doScale   = cms.bool(True),
-             doSmear   = cms.bool(False),
-             scaleFactor = cms.double(1.03678940814),
-             smearFactor = cms.double(0.0)
-             )
-    ) 
-
 
 ########### Noise ##########
 # TEC: new = 5.985 old = 5.684  => ratio: 1.052
@@ -364,7 +110,11 @@ wholeTracker = cms.VPSet(
              )
     )
 
-byLayer2 = cms.VPSet(
+##
+## by Layer only one partition
+##
+
+byLayerOnlyTIB = cms.VPSet(
 
     ################## TIB ##################
 
@@ -394,6 +144,10 @@ byLayer2 = cms.VPSet(
              )
     )
 
+##
+## hierarchies
+##
+
 subsets =  cms.VPSet(
     cms.PSet(partition = cms.string("Tracker"),
              doScale   = cms.bool(True),
@@ -421,7 +175,9 @@ subsets =  cms.VPSet(
              )
     )
 
-
+#
+# just a silly example
+#
 autoparams=[]
 listOfLayers=["TIB_1","TIB_2","TIB_3","TIB_4","TOB_1","TOB_2","TOB_3","TOB_4","TOB_5","TOB_6","TIDM_1","TIDM_2","TIDM_3","TECM_1","TECM_2","TECM_3","TECM_4","TECM_5","TECM_6","TECM_7","TECM_8","TECM_9","TIDP_1","TIDP_2","TIDP_3","TECP_1","TECP_2","TECP_3","TECP_4","TECP_5","TECP_6","TECP_7","TECP_8","TECP_9"]
 
@@ -436,20 +192,27 @@ for i,ll in enumerate(listOfLayers):
             )
         )
 
-
-# process.demo = cms.EDAnalyzer('SiStripChannelGainFromDBMiscalibrator',
-#                               record = cms.untracked.string("SiStripApvGainRcd"),
-#                               gainType = cms.untracked.uint32(1), #0 for G1, 1 for G2
-#                               params = subsets # as a cms.VPset
+# process.demo = cms.EDAnalyzer('SiStripNoisesFromDBMiscalibrator',
+#                               params = subsets, # as a cms.VPset
+#                               fillDefaults = cms.bool(False),
+#                               saveMaps = cms.bool(True)      
 #                               )
 
+
+##
+## Impot the thresholds configuration
+##
+import CondTools.SiStrip.MiscalibrationSettings_cff as Settings
+eachLayer = copy.deepcopy(Settings.byLayer)
+
 process.load("CondTools.SiStrip.scaleAndSmearSiStripNoises_cfi")
-#process.scaleAndSmearSiStripNoises.params  = wholeTracker  # as a cms.VPset
-#process.scaleAndSmearSiStripNoises.params  = byPartition   # as a cms.VPset
-#process.scaleAndSmearSiStripNoises.params = subsets        # as a cms.VPset
-#process.scaleAndSmearSiStripNoises.params = byLayer2       # as a cms.VPset
+#process.scaleAndSmearSiStripNoises.params  = eachLayer      # as a cms.VPset
+#process.scaleAndSmearSiStripNoises.params  = wholeTracker   # as a cms.VPset
+#process.scaleAndSmearSiStripNoises.params  = byPartition    # as a cms.VPset
+#process.scaleAndSmearSiStripNoises.params  = subsets        # as a cms.VPset
+#process.scaleAndSmearSiStripNoises.params  = byLayerOnlyTIB # as a cms.VPset
 process.scaleAndSmearSiStripNoises.params  = autoparams
-process.scaleAndSmearSiStripNoises.fillDefaults = True     # to fill uncabled DetIds with default
+process.scaleAndSmearSiStripNoises.fillDefaults = False     # to fill uncabled DetIds with default
 
 ##
 ## Database output service
@@ -459,7 +222,7 @@ process.load("CondCore.CondDB.CondDB_cfi")
 ##
 ## Output database (in this case local sqlite file)
 ##
-process.CondDB.connect = 'sqlite_file:modifiedNoise_'+options.globalTag+'_IOV_'+str(options.runNumber)+".db"
+process.CondDB.connect = 'sqlite_file:modifiedNoise_'+ process.GlobalTag.globaltag._value+'_IOV_'+str(options.runNumber)+".db"
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDB,
                                           timetype = cms.untracked.string('runnumber'),


### PR DESCRIPTION
Greetings,
this PR is meant to update/ add tools used for the creation of Strip conditions for simulation, starting from existing payloads in database.
   * `SiStripChannelGainFromDBMiscalibrator`: reads APV gains (either G1 or G2) from DB and applies hierarchically a scale factor and/or gaussian smearing for each APV gain, down to the individual layer or disk level. 
   * `SiStripNoisesFromDBMiscalibrator` : reads Noise from DB and applies hierarchically a scale factor and/or gaussian smearing for each APV gain, down to the individual layer or disk level.

Code has been refactored to avoid duplication, moving common methods to an helper file; in addition the configuration and existing documentation have been updated.