### PR TITLE
Changes to ECAL TTF4 DQM plots (for CMSSW master)

### DIFF
--- a/DQM/EcalMonitorClient/interface/TrigPrimClient.h
+++ b/DQM/EcalMonitorClient/interface/TrigPrimClient.h
@@ -17,6 +17,7 @@ namespace ecaldqm
 
     int minEntries_;
     float errorFractionThreshold_;
+    float TTF4MaskingAlarmThreshold_;
   };
 
 }

--- a/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
@@ -5,7 +5,7 @@ from DQM.EcalMonitorTasks.OccupancyTask_cfi import ecalOccupancyTask
 
 minEntries = 3
 errorFractionThreshold = 0.1
-TTF4MaskingAlarmThreshold = 0.05
+TTF4MaskingAlarmThreshold = 0.1
 
 ecalTrigPrimClient = cms.untracked.PSet(
     params = cms.untracked.PSet(
@@ -56,6 +56,13 @@ ecalTrigPrimClient = cms.untracked.PSet(
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('TriggerTower'),
             description = cms.untracked.string('Summarizes whether a TT was masked in the TPGRecords, or had an instance of TT Flag=4.<br/>GRAY: Masked, no TTF4,<br/>BLACK: Masked, with TTF4,<br/>BLUE: Not Masked, with TTF4.')
+        ),
+        TrendTTF4Flags = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/TrigPrimClient %(prefix)s number of TTs with TTF4 set'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of the total number of TTs in this partition with TTF4 flag set.')
         )
     )
 )

--- a/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
@@ -5,11 +5,13 @@ from DQM.EcalMonitorTasks.OccupancyTask_cfi import ecalOccupancyTask
 
 minEntries = 3
 errorFractionThreshold = 0.1
+TTF4MaskingAlarmThreshold = 0.05
 
 ecalTrigPrimClient = cms.untracked.PSet(
     params = cms.untracked.PSet(
         minEntries = cms.untracked.int32(minEntries),
-        errorFractionThreshold = cms.untracked.double(errorFractionThreshold)
+        errorFractionThreshold = cms.untracked.double(errorFractionThreshold),
+        TTF4MaskingAlarmThreshold = cms.untracked.double(TTF4MaskingAlarmThreshold)
     ),
     sources = cms.untracked.PSet(
         EtEmulError = ecalTrigPrimTask.MEs.EtEmulError,
@@ -36,7 +38,7 @@ ecalTrigPrimClient = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('TriggerTower'),
-            description = cms.untracked.string('Summary of emulator matching quality. A tower is red if the number of events with Et emulation error is greater than ' + str(errorFractionThreshold) + ' of total events. Towers with entries less than ' + str(minEntries) + ' are not considered.')
+            description = cms.untracked.string('Summary of emulator matching quality. A tower is red if the number of events with Et emulation error is greater than ' + str(errorFractionThreshold) + ' of total events. Towers with entries less than ' + str(minEntries) + ' are not considered. Also, an entire SuperModule can show red if its (data) Trigger Primitive digi occupancy is less than 5sigma of the overall SuperModule mean, or if more than 80% of its Trigger Towers are showing any number of TT Flag-Readout Mismatch errors. Finally, if the fraction of towers in a SuperModule that are permanently masked or have TTF4 flag set is greater than ' + str(TTF4MaskingAlarmThreshold) + ', then the entire supermodule shows red.')
         ),
         TimingSummary = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sSummaryClient/%(prefix)sTTT%(suffix)s Trigger Primitives Timing summary'),

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -14,7 +14,8 @@ namespace ecaldqm
   TrigPrimClient::TrigPrimClient() :
     DQWorkerClient(),
     minEntries_(0),
-    errorFractionThreshold_(0.)
+    errorFractionThreshold_(0.),
+    TTF4MaskingAlarmThreshold_(0.)
   {
     qualitySummaries_.insert("EmulQualitySummary");
   }
@@ -24,6 +25,7 @@ namespace ecaldqm
   {
     minEntries_ = _params.getUntrackedParameter<int>("minEntries");
     errorFractionThreshold_ = _params.getUntrackedParameter<double>("errorFractionThreshold");
+    TTF4MaskingAlarmThreshold_ = _params.getUntrackedParameter<double>("TTF4MaskingAlarmThreshold");
   }
 
   void
@@ -92,12 +94,15 @@ namespace ecaldqm
     MESet& meTTF4vMask(MEs_.at("TTF4vMask"));
     MESet const& sTTFlags4(sources_.at("TTFlags4"));
     MESet const& sTTMaskMapAll(sources_.at("TTMaskMapAll"));
-    
+
+    std::vector<float> nWithTTF4(nDCC, 0.); // counters to keep track of number of towers in a DCC that have TTF4 flag set
     // Loop over all TTs
     for(unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++) {
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
+      unsigned iDCC( dccId(ttid)-1 );
       bool isMasked( sTTMaskMapAll.getBinContent(ttid) > 0. );
       bool hasTTF4( sTTFlags4.getBinContent(ttid) > 0. );
+      if (hasTTF4) nWithTTF4[iDCC]++;
       if ( isMasked ) { 
         if ( hasTTF4 )
           meTTF4vMask.setBinContent( ttid,12 ); // Masked, has TTF4
@@ -109,7 +114,7 @@ namespace ecaldqm
       }   
     } // TT loop 
 
-    // Quality check: set an entire FED to BAD if an "entire" FED shows any DCC-SRP flag mismatch errors
+    // Quality check: set an entire FED to BAD if a more than 80% of the TTs in that FED show any DCC-SRP flag mismatch errors
     // Fill flag mismatch statistics
     std::vector<float> nTTs(nDCC,0.);
     std::vector<float> nTTFMismath(nDCC,0.);
@@ -121,12 +126,13 @@ namespace ecaldqm
           nTTFMismath[iDCC]++;
       nTTs[iDCC]++;
     }
-    // Analyze flag mismatch statistics
+    // Analyze flag mismatch statistics and TTF4 fraction statistics
     for ( unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++ ) {
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
       unsigned iDCC( dccId(ttid)-1 );
-      if ( nTTFMismath[iDCC] > 0.8*nTTs[iDCC] ) // "entire" => 80%
+      if ( nTTFMismath[iDCC] > 0.8*nTTs[iDCC] || nWithTTF4[iDCC] > TTF4MaskingAlarmThreshold_*nTTs[iDCC]) {
         meEmulQualitySummary.setBinContent( ttid, meEmulQualitySummary.maskMatches(ttid, mask, statusManager_) ? kMBad : kBad );
+      }
     }
 
     // Quality check: set entire FED to BAD if its occupancy begins to vanish

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -258,15 +258,16 @@ namespace ecaldqm
       }
 
       // Fill TT Flag MEs
-      float ttF( tpItr->ttFlag() );
-      meTTFlags.fill( ttid, ttF );
-      meTTFlagsVsEt.fill(ttid, et, ttF);
+      // float ttF( tpItr->ttFlag() );
+      int ttF( tpItr->ttFlag() );
+      meTTFlags.fill( ttid, 1.0*ttF );
+      meTTFlagsVsEt.fill(ttid, et, 1.0*ttF);
       // Monitor occupancy of TTF=4
       // which contains info about TT auto-masking
-      if ( ttF == 4. )
+      if ( ttF >= 4 )
         meTTFlags4.fill( ttid );
 
-      if((interest == 1 || interest == 3) && towerReadouts_[ttid.rawId()] != getTrigTowerMap()->constituentsOf(ttid).size())
+      if((ttF == 1 || ttF == 3) && towerReadouts_[ttid.rawId()] != getTrigTowerMap()->constituentsOf(ttid).size())
         meTTFMismatch.fill(ttid);
     }
 
@@ -345,8 +346,9 @@ namespace ecaldqm
 
         if(realEt > 0){
 
-          int interest(realItr->ttFlag() & 0x3);
-          if((interest == 1 || interest == 3) && towerReadouts_[ttid.rawId()] == getTrigTowerMap()->constituentsOf(ttid).size()){
+          // int interest(realItr->ttFlag() & 0x3);
+          int ttF(realItr->ttFlag());
+          if((ttF == 1 || ttF == 3) && towerReadouts_[ttid.rawId()] == getTrigTowerMap()->constituentsOf(ttid).size()){
 
             if(et != realEt) match = false;
             if(tpItr->fineGrain() != realItr->fineGrain()) matchFG = false;

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -258,7 +258,6 @@ namespace ecaldqm
       }
 
       // Fill TT Flag MEs
-      // float ttF( tpItr->ttFlag() );
       int ttF( tpItr->ttFlag() );
       meTTFlags.fill( ttid, 1.0*ttF );
       meTTFlagsVsEt.fill(ttid, et, 1.0*ttF);
@@ -346,7 +345,6 @@ namespace ecaldqm
 
         if(realEt > 0){
 
-          // int interest(realItr->ttFlag() & 0x3);
           int ttF(realItr->ttFlag());
           if((ttF == 1 || ttF == 3) && towerReadouts_[ttid.rawId()] == getTrigTowerMap()->constituentsOf(ttid).size()){
 


### PR DESCRIPTION
This PR is also meant to be deployed in production at P5. Corresponding PR to 10_1_X: [PR#23088](https://github.com/cms-sw/cmssw/pull/23088)

Changes introduced:

(1) Added alarm to trigger primitives quality summary plot -- the plot now turns RED when the fraction of towers in a given SM that have TTF4 flag set is greater than a threshold fraction which is currently set to 0.1.

(2) Added trend plots for the total number of towers in EB and EE with TTF4 flag set.

(3) COKE in the endcaps can mask on the strip level, not just the tower level; the ttFlag container now has meaningful values above 4 for situations where not all strip in a tower are masked. This requires the following changes to the DQM code:
    (3.1) TTF4 occupancy now counts all towers with ttF >= 4, not just ttF == 4
    (3.2) Flag mismatch for low interest, medium interest regions: only perform check if ttF == 1 or ttF == 3
    (3.3) For data/emulator comparisons, ignore towers with ttF > 4
