### PR TITLE
Changes to ECAL TTF4 DQM plots (for P5 production)

### DIFF
--- a/DQM/EcalCommon/interface/MESetNonObject.h
+++ b/DQM/EcalCommon/interface/MESetNonObject.h
@@ -29,6 +29,8 @@ namespace ecaldqm
 
     double getBinContent(int, int = 0) const override;
 
+    double getFloatValue() const;
+
     double getBinError(int, int = 0) const override;
 
     double getBinEntries(int, int = 0) const override;

--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -726,11 +726,13 @@ namespace ecaldqm
         case kEB:
           xbin = 4 * ((iDCC - 9) % 18) + (isEBm ? towerid - 1 : 68 - towerid) % 4 + 1;
           ybin = (towerid - 1) / 4 * (isEBm ? -1 : 1) + (isEBm ? 18 : 17);
+          nbinsX = 72;
           break;
         case kSM:
         case kEBSM:
           xbin = (towerid - 1) / 4 + 1;
           ybin = (isEBm ? towerid - 1 : 68 - towerid) % 4 + 1;
+          nbinsX = 17;
           break;
         default:
           break;

--- a/DQM/EcalCommon/src/MESetNonObject.cc
+++ b/DQM/EcalCommon/src/MESetNonObject.cc
@@ -48,7 +48,7 @@ namespace ecaldqm
   MESetNonObject::clone(std::string const& _path/* = ""*/) const
   {
     std::string path(path_);
-    if(_path != "") path_ = _path;
+    if(!_path.empty()) path_ = _path;
     MESet* copy(new MESetNonObject(*this));
     path_ = path;
     return copy;
@@ -262,6 +262,13 @@ namespace ecaldqm
     if(mes_.empty() || !mes_[0]) return 0.;
 
     return mes_[0]->getBinContent(_bin);
+  }
+
+  double
+  MESetNonObject::getFloatValue() const
+  {
+    if(kind_ == MonitorElement::DQM_KIND_REAL) return mes_[0]->getFloatValue();
+    else return 0.;
   }
 
   double

--- a/DQM/EcalMonitorClient/interface/PresampleClient.h
+++ b/DQM/EcalMonitorClient/interface/PresampleClient.h
@@ -17,7 +17,8 @@ namespace ecaldqm
 
     int minChannelEntries_;
     float expectedMean_;
-    float toleranceMean_;
+    float toleranceLow_;
+    float toleranceHigh_;
     float toleranceRMS_;
     float toleranceRMSFwd_;
   };

--- a/DQM/EcalMonitorClient/interface/TrigPrimClient.h
+++ b/DQM/EcalMonitorClient/interface/TrigPrimClient.h
@@ -17,6 +17,7 @@ namespace ecaldqm
 
     int minEntries_;
     float errorFractionThreshold_;
+    float TTF4MaskingAlarmThreshold_;
   };
 
 }

--- a/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
@@ -5,7 +5,8 @@ from DQM.EcalMonitorClient.IntegrityClient_cfi import ecalIntegrityClient
 
 minChannelEntries = 6
 expectedMean = 200.0
-toleranceMean = 25.0
+toleranceLow = 25.0
+toleranceHigh = 40.0
 toleranceRMS = 3.0
 toleranceRMSFwd = 6.0
 
@@ -13,7 +14,8 @@ ecalPresampleClient = cms.untracked.PSet(
     params = cms.untracked.PSet(
         minChannelEntries = cms.untracked.int32(minChannelEntries),
         expectedMean = cms.untracked.double(expectedMean),
-        toleranceMean = cms.untracked.double(toleranceMean),
+        toleranceLow = cms.untracked.double(toleranceLow),
+        toleranceHigh = cms.untracked.double(toleranceHigh),
         toleranceRMS = cms.untracked.double(toleranceRMS),
         toleranceRMSFwd = cms.untracked.double(toleranceRMSFwd)
     ),
@@ -84,14 +86,14 @@ ecalPresampleClient = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('Crystal'),
-            description = cms.untracked.string('Summary of the presample data quality. A channel is red if presample mean is off by ' + str(toleranceMean) + ' from ' + str(expectedMean) + ' or RMS is greater than ' + str(toleranceRMS) + '. RMS threshold is ' + str(toleranceRMSFwd) + ' in the forward region (|eta| > 2.1). Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')
+            description = cms.untracked.string('Summary of the presample data quality. A channel is red if presample mean is outside the range (' + str(expectedMean - toleranceLow) + ', ' + str(expectedMean + toleranceHigh) + '), or RMS is greater than ' + str(toleranceRMS) + '. RMS threshold is ' + str(toleranceRMSFwd) + ' in the forward region (|eta| > 2.1). Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')
         ),
         Quality = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sPedestalOnlineClient/%(prefix)sPOT pedestal quality G12 %(sm)s'),
             kind = cms.untracked.string('TH2F'),
             otype = cms.untracked.string('SM'),
             btype = cms.untracked.string('Crystal'),
-            description = cms.untracked.string('Summary of the presample data quality. A channel is red if presample mean is off by ' + str(toleranceMean) + ' from ' + str(expectedMean) + ' or RMS is greater than ' + str(toleranceRMS) + '. RMS threshold is ' + str(toleranceRMSFwd) + ' in the forward region (|eta| > 2.1). Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')            
+            description = cms.untracked.string('Summary of the presample data quality. A channel is red if presample mean is outside the range (' + str(expectedMean - toleranceLow) + ', ' + str(expectedMean + toleranceHigh) + '), or RMS is greater than ' + str(toleranceRMS) + '. RMS threshold is ' + str(toleranceRMSFwd) + ' in the forward region (|eta| > 2.1). Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')
         ),
         ErrorsSummary = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sSummaryClient/%(prefix)sPOT pedestal quality errors summary G12'),

--- a/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
@@ -17,6 +17,7 @@ ecalTrigPrimClient = cms.untracked.PSet(
         TTFlags4 = ecalTrigPrimTask.MEs.TTFlags4,
         TTMaskMapAll = ecalTrigPrimTask.MEs.TTMaskMapAll,
         TTFMismatch = ecalTrigPrimTask.MEs.TTFMismatch,
+        LHCStatusByLumi = ecalTrigPrimTask.MEs.LHCStatusByLumi,
         TPDigiThrAll = ecalOccupancyTask.MEs.TPDigiThrAll
     ),
     MEs = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
@@ -5,7 +5,7 @@ from DQM.EcalMonitorTasks.OccupancyTask_cfi import ecalOccupancyTask
 
 minEntries = 3
 errorFractionThreshold = 0.1
-TTF4MaskingAlarmThreshold = 0.05
+TTF4MaskingAlarmThreshold = 0.1
 
 ecalTrigPrimClient = cms.untracked.PSet(
     params = cms.untracked.PSet(
@@ -56,6 +56,13 @@ ecalTrigPrimClient = cms.untracked.PSet(
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('TriggerTower'),
             description = cms.untracked.string('Summarizes whether a TT was masked in the TPGRecords, or had an instance of TT Flag=4.<br/>GRAY: Masked, no TTF4,<br/>BLACK: Masked, with TTF4,<br/>BLUE: Not Masked, with TTF4.')
+        ),
+        TrendTTF4Flags = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/TrigPrimClient %(prefix)s number of TTs with TTF4 set'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of the total number of TTs in this partition with TTF4 flag set.')
         )
     )
 )

--- a/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
@@ -5,11 +5,13 @@ from DQM.EcalMonitorTasks.OccupancyTask_cfi import ecalOccupancyTask
 
 minEntries = 3
 errorFractionThreshold = 0.1
+TTF4MaskingAlarmThreshold = 0.05
 
 ecalTrigPrimClient = cms.untracked.PSet(
     params = cms.untracked.PSet(
         minEntries = cms.untracked.int32(minEntries),
-        errorFractionThreshold = cms.untracked.double(errorFractionThreshold)
+        errorFractionThreshold = cms.untracked.double(errorFractionThreshold),
+        TTF4MaskingAlarmThreshold = cms.untracked.double(TTF4MaskingAlarmThreshold)
     ),
     sources = cms.untracked.PSet(
         EtEmulError = ecalTrigPrimTask.MEs.EtEmulError,
@@ -36,7 +38,7 @@ ecalTrigPrimClient = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('TriggerTower'),
-            description = cms.untracked.string('Summary of emulator matching quality. A tower is red if the number of events with Et emulation error is greater than ' + str(errorFractionThreshold) + ' of total events. Towers with entries less than ' + str(minEntries) + ' are not considered.')
+            description = cms.untracked.string('Summary of emulator matching quality. A tower is red if the number of events with Et emulation error is greater than ' + str(errorFractionThreshold) + ' of total events. Towers with entries less than ' + str(minEntries) + ' are not considered. Also, an entire SuperModule can show red if its (data) Trigger Primitive digi occupancy is less than 5sigma of the overall SuperModule mean, or if more than 80% of its Trigger Towers are showing any number of TT Flag-Readout Mismatch errors. Finally, if the fraction of towers in a SuperModule that are permanently masked or have TTF4 flag set is greater than ' + str(TTF4MaskingAlarmThreshold) + ', then the entire supermodule shows red.')
         ),
         TimingSummary = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sSummaryClient/%(prefix)sTTT%(suffix)s Trigger Primitives Timing summary'),

--- a/DQM/EcalMonitorClient/src/PresampleClient.cc
+++ b/DQM/EcalMonitorClient/src/PresampleClient.cc
@@ -15,7 +15,8 @@ namespace ecaldqm
     DQWorkerClient(),
     minChannelEntries_(0),
     expectedMean_(0.),
-    toleranceMean_(0.),
+    toleranceLow_(0.),
+    toleranceHigh_(0.),
     toleranceRMS_(0.),
     toleranceRMSFwd_(0.)
   {
@@ -28,7 +29,8 @@ namespace ecaldqm
   {
     minChannelEntries_ = _params.getUntrackedParameter<int>("minChannelEntries");
     expectedMean_ = _params.getUntrackedParameter<double>("expectedMean");
-    toleranceMean_ = _params.getUntrackedParameter<double>("toleranceMean");
+    toleranceLow_ = _params.getUntrackedParameter<double>("toleranceLow");
+    toleranceHigh_ = _params.getUntrackedParameter<double>("toleranceHigh");
     toleranceRMS_ = _params.getUntrackedParameter<double>("toleranceRMS");
     toleranceRMSFwd_ = _params.getUntrackedParameter<double>("toleranceRMSFwd");
   }
@@ -93,7 +95,7 @@ namespace ecaldqm
       meRMSMap.setBinContent(id, rms);
       meRMSMapAllByLumi.setBinContent(id, rmsLS);
 
-      if(std::abs(mean - expectedMean_) > toleranceMean_ || rms > rmsThresh){
+      if(((mean > expectedMean_ + toleranceHigh_) || (mean < expectedMean_ - toleranceLow_)) || rms > rmsThresh){
         qItr->setBinContent(doMask ? kMBad : kBad);
         meQualitySummary.setBinContent(id, doMask ? kMBad : kBad);
         if(!doMask) meErrorsSummary.fill(id);

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -14,7 +14,8 @@ namespace ecaldqm
   TrigPrimClient::TrigPrimClient() :
     DQWorkerClient(),
     minEntries_(0),
-    errorFractionThreshold_(0.)
+    errorFractionThreshold_(0.),
+    TTF4MaskingAlarmThreshold_(0.)
   {
     qualitySummaries_.insert("EmulQualitySummary");
   }
@@ -24,6 +25,7 @@ namespace ecaldqm
   {
     minEntries_ = _params.getUntrackedParameter<int>("minEntries");
     errorFractionThreshold_ = _params.getUntrackedParameter<double>("errorFractionThreshold");
+    TTF4MaskingAlarmThreshold_ = _params.getUntrackedParameter<double>("TTF4MaskingAlarmThreshold");
   }
 
   void
@@ -92,12 +94,15 @@ namespace ecaldqm
     MESet& meTTF4vMask(MEs_.at("TTF4vMask"));
     MESet const& sTTFlags4(sources_.at("TTFlags4"));
     MESet const& sTTMaskMapAll(sources_.at("TTMaskMapAll"));
-    
+
+    std::vector<float> nWithTTF4(nDCC, 0.); // counters to keep track of number of towers in a DCC that have TTF4 flag set
     // Loop over all TTs
     for(unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++) {
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
+      unsigned iDCC( dccId(ttid)-1 );
       bool isMasked( sTTMaskMapAll.getBinContent(ttid) > 0. );
       bool hasTTF4( sTTFlags4.getBinContent(ttid) > 0. );
+      if (hasTTF4) nWithTTF4[iDCC]++;
       if ( isMasked ) { 
         if ( hasTTF4 )
           meTTF4vMask.setBinContent( ttid,12 ); // Masked, has TTF4
@@ -109,7 +114,7 @@ namespace ecaldqm
       }   
     } // TT loop 
 
-    // Quality check: set an entire FED to BAD if an "entire" FED shows any DCC-SRP flag mismatch errors
+    // Quality check: set an entire FED to BAD if a more than 80% of the TTs in that FED show any DCC-SRP flag mismatch errors
     // Fill flag mismatch statistics
     std::vector<float> nTTs(nDCC,0.);
     std::vector<float> nTTFMismath(nDCC,0.);
@@ -121,12 +126,13 @@ namespace ecaldqm
           nTTFMismath[iDCC]++;
       nTTs[iDCC]++;
     }
-    // Analyze flag mismatch statistics
+    // Analyze flag mismatch statistics and TTF4 fraction statistics
     for ( unsigned iTT(0); iTT < EcalTrigTowerDetId::kSizeForDenseIndexing; iTT++ ) {
       EcalTrigTowerDetId ttid(EcalTrigTowerDetId::detIdFromDenseIndex(iTT));
       unsigned iDCC( dccId(ttid)-1 );
-      if ( nTTFMismath[iDCC] > 0.8*nTTs[iDCC] ) // "entire" => 80%
+      if ( nTTFMismath[iDCC] > 0.8*nTTs[iDCC] || nWithTTF4[iDCC] > TTF4MaskingAlarmThreshold_*nTTs[iDCC]) {
         meEmulQualitySummary.setBinContent( ttid, meEmulQualitySummary.maskMatches(ttid, mask, statusManager_) ? kMBad : kBad );
+      }
     }
 
     // Quality check: set entire FED to BAD if its occupancy begins to vanish

--- a/DQM/EcalMonitorTasks/BuildFile.xml
+++ b/DQM/EcalMonitorTasks/BuildFile.xml
@@ -7,6 +7,7 @@
 <use   name="DataFormats/EcalRecHit"/>
 <use   name="DataFormats/EgammaReco"/>
 <use   name="DataFormats/Math"/>
+<use   name="DataFormats/TCDS"/>
 <use   name="DataFormats/L1GlobalTrigger"/>
 <use   name="DataFormats/L1GlobalMuonTrigger"/>
 <use   name="FWCore/Framework"/>

--- a/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
+++ b/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
@@ -4,8 +4,12 @@
 #include "DQWorkerTask.h"
 
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+#include "DataFormats/TCDS/interface/TCDSRecord.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGStripStatus.h"
@@ -28,6 +32,8 @@ namespace ecaldqm {
     void runOnRealTPs(EcalTrigPrimDigiCollection const&);
     void runOnEmulTPs(EcalTrigPrimDigiCollection const&);
     template<typename DigiCollection> void runOnDigis(DigiCollection const&);
+
+    void setTokens(edm::ConsumesCollector&) override;
 
     enum Constants {
       nBXBins = 15
@@ -52,6 +58,10 @@ namespace ecaldqm {
 
     edm::ESHandle<EcalTPGTowerStatus> TTStatusRcd;
     edm::ESHandle<EcalTPGStripStatus> StripStatusRcd;
+
+    edm::InputTag lhcStatusInfoCollectionTag_;
+    edm::EDGetTokenT<TCDSRecord> lhcStatusInfoRecordToken_;
+    bool lhcStatusSet_;
 
   };
 

--- a/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
@@ -23,7 +23,8 @@ ecalTrigPrimTask = cms.untracked.PSet(
     params = cms.untracked.PSet(
         #    HLTMuonPath = cms.untracked.string('HLT_Mu5_v*'),
         #    HLTCaloPath = cms.untracked.string('HLT_SingleJet*'),
-        runOnEmul = cms.untracked.bool(True)
+        runOnEmul = cms.untracked.bool(True),
+        lhcStatusInfoCollectionTag = cms.untracked.InputTag("tcdsDigis","tcdsRecord")
     ),
     MEs = cms.untracked.PSet(
         LowIntMap = cms.untracked.PSet(
@@ -268,6 +269,13 @@ ecalTrigPrimTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT Real vs Emulated TP Et%(suffix)s'),
             description = cms.untracked.string('Real data VS emulated TP Et (in-time)')
+        ),
+        LHCStatusByLumi = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/LHC status by lumi'),
+            kind = cms.untracked.string('REAL'),
+            otype = cms.untracked.string('None'),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('LHC Status in this lumisection. The convention for the value is the same as in the plot Info/LhcInfo/beamMode')
         )
     )
 )

--- a/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
+++ b/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
@@ -1,6 +1,7 @@
 #include "../interface/PNDiodeTask.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace ecaldqm {
 
@@ -59,7 +60,12 @@ namespace ecaldqm {
     }
 
     std::for_each(_ids.begin(), _ids.end(), [&](EcalElectronicsIdCollection::value_type const& id){
-        set->fill(EcalElectronicsId(id.dccId(), id.towerId(), 1, id.xtalId()));
+        if (id.towerId() == 69) {
+          edm::LogWarning("EcalDQM") << "PNDiodeTask::runOnErrors : one of the ids in the electronics ID collection is unphysical in lumi number " << timestamp_.iLumi << ", event number " << timestamp_.iEvt; // Added March 2018 because some events have this unphysical tower ID and cause the ECAL calibration application to crash.
+        }
+        else {
+          set->fill(EcalElectronicsId(id.dccId(), id.towerId(), 1, id.xtalId()));
+        }
       });
   }
 

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -258,15 +258,16 @@ namespace ecaldqm
       }
 
       // Fill TT Flag MEs
-      float ttF( tpItr->ttFlag() );
-      meTTFlags.fill( ttid, ttF );
-      meTTFlagsVsEt.fill(ttid, et, ttF);
+      // float ttF( tpItr->ttFlag() );
+      int ttF( tpItr->ttFlag() );
+      meTTFlags.fill( ttid, 1.0*ttF );
+      meTTFlagsVsEt.fill(ttid, et, 1.0*ttF);
       // Monitor occupancy of TTF=4
       // which contains info about TT auto-masking
-      if ( ttF == 4. )
+      if ( ttF >= 4 )
         meTTFlags4.fill( ttid );
 
-      if((interest == 1 || interest == 3) && towerReadouts_[ttid.rawId()] != getTrigTowerMap()->constituentsOf(ttid).size())
+      if((ttF == 1 || ttF == 3) && towerReadouts_[ttid.rawId()] != getTrigTowerMap()->constituentsOf(ttid).size())
         meTTFMismatch.fill(ttid);
     }
 
@@ -345,8 +346,9 @@ namespace ecaldqm
 
         if(realEt > 0){
 
-          int interest(realItr->ttFlag() & 0x3);
-          if((interest == 1 || interest == 3) && towerReadouts_[ttid.rawId()] == getTrigTowerMap()->constituentsOf(ttid).size()){
+          // int interest(realItr->ttFlag() & 0x3);
+          int ttF(realItr->ttFlag());
+          if((ttF == 1 || ttF == 3) && towerReadouts_[ttid.rawId()] == getTrigTowerMap()->constituentsOf(ttid).size()){
 
             if(et != realEt) match = false;
             if(tpItr->fineGrain() != realItr->fineGrain()) matchFG = false;

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -258,7 +258,6 @@ namespace ecaldqm
       }
 
       // Fill TT Flag MEs
-      // float ttF( tpItr->ttFlag() );
       int ttF( tpItr->ttFlag() );
       meTTFlags.fill( ttid, 1.0*ttF );
       meTTFlagsVsEt.fill(ttid, et, 1.0*ttF);
@@ -346,7 +345,6 @@ namespace ecaldqm
 
         if(realEt > 0){
 
-          // int interest(realItr->ttFlag() & 0x3);
           int ttF(realItr->ttFlag());
           if((ttF == 1 || ttF == 3) && towerReadouts_[ttid.rawId()] == getTrigTowerMap()->constituentsOf(ttid).size()){
 

--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -1,5 +1,6 @@
 ### AUTO-GENERATED CMSRUN CONFIGURATION FOR ECAL DQM ###
 import FWCore.ParameterSet.Config as cms
+from EventFilter.Utilities.tcdsRawToDigi_cfi import * # To monitor LHC status, e.g. to mask trigger primitives quality alarm during Cosmics
 
 process = cms.Process("process")
 
@@ -92,6 +93,9 @@ process.GlobalTag.toGet = cms.VPSet(cms.PSet(
 
 process.preScaler.prescaleFactor = 1
 
+process.tcdsDigis = tcdsRawToDigi.clone()
+process.tcdsDigis.InputLabel = cms.InputTag("rawDataCollector")
+
 process.DQMStore.referenceFileName = "/dqmdata/dqm/reference/ecal_reference.root"
 
 process.dqmEnv.subSystemFolder = cms.untracked.string('Ecal')
@@ -122,7 +126,7 @@ process.hybridClusteringSequence = cms.Sequence(process.cleanedHybridSuperCluste
 
 ### Paths ###
 
-process.ecalMonitorPath = cms.Path(process.preScaler+process.ecalPreRecoSequence+process.ecalPhysicsFilter+process.ecalRecoSequence+process.ecalMonitorTask)
+process.ecalMonitorPath = cms.Path(process.preScaler+process.ecalPreRecoSequence+process.ecalPhysicsFilter+process.ecalRecoSequence+process.tcdsDigis+process.ecalMonitorTask)
 process.ecalClientPath = cms.Path(process.preScaler+process.ecalPreRecoSequence+process.ecalPhysicsFilter+process.ecalMonitorClient)
 
 process.dqmEndPath = cms.EndPath(process.dqmEnv)


### PR DESCRIPTION
This PR builds on top of changes that have already been introduced previously to CMSSW master to avoid conflicts with merging. This PR is a backport of [PR#23087](https://github.com/cms-sw/cmssw/pull/23087) to CMSSW master.

The new changes introduced are:
(1) Added alarm to trigger primitives quality summary plot -- the plot now turns RED when the fraction of towers in a given SM that have TTF4 flag set is greater than a threshold fraction which is currently set to 0.1.

(2) Added trend plots for the total number of towers in EB and EE with TTF4 flag set.

(3) COKE in the endcaps can mask on the strip level, not just the tower level; the ttFlag container now has meaningful values above 4 for situations where not all strip in a tower are masked. This requires the following changes to the DQM code:
    (3.1) TTF4 occupancy now counts all towers with ttF >= 4, not just ttF == 4
    (3.2) Flag mismatch for low interest, medium interest regions: only perform check if ttF == 1 or ttF == 3
    (3.3) For data/emulator comparisons, ignore towers with ttF > 4
