### PR TITLE
 reduce max count of HcalUnpacker::printInvalidDataMessage to 1 (per stream)

### DIFF
--- a/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
@@ -45,7 +45,7 @@ public:
   /// for normal data
   HcalUnpacker(int sourceIdOffset, int beg, int end) : sourceIdOffset_(sourceIdOffset), startSample_(beg), endSample_(end), expectedOrbitMessageTime_(-1), mode_(0), nPrinted_ (0){ }
   /// For histograms, no begin and end
-  HcalUnpacker(int sourceIdOffset) : sourceIdOffset_(sourceIdOffset), startSample_(-1), endSample_(-1),  expectedOrbitMessageTime_(-1), mode_(0) { }
+  HcalUnpacker(int sourceIdOffset) : sourceIdOffset_(sourceIdOffset), startSample_(-1), endSample_(-1),  expectedOrbitMessageTime_(-1), mode_(0), nPrinted_ (0){ }
   void setExpectedOrbitMessageTime(int time) { expectedOrbitMessageTime_=time; }
   void unpack(const FEDRawData& raw, const HcalElectronicsMap& emap, std::vector<HcalHistogramDigi>& histoDigis);
   void unpack(const FEDRawData& raw, const HcalElectronicsMap& emap, Collections& conts, HcalUnpackerReport& report, bool silent=false);

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -939,7 +939,7 @@ void HcalUnpacker::printInvalidDataMessage( const std::string &coll_type, int de
 
   nPrinted_++;
 
-  int limit = 2;//print up to limit-1 messages
+  constexpr int limit = 2;//print up to limit-1 messages
   if( nPrinted_ >= limit ) {
 
       if( nPrinted_ == limit ) edm::LogInfo("Invalid Data") << "Suppressing further error messages";

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -939,10 +939,10 @@ void HcalUnpacker::printInvalidDataMessage( const std::string &coll_type, int de
 
   nPrinted_++;
 
-  int limit = 20;
+  int limit = 2;//print up to limit-1 messages
   if( nPrinted_ >= limit ) {
 
-      if( nPrinted_ == limit ) edm::LogWarning("Invalid Data") << "Suppressing further error messages" << std::endl;
+      if( nPrinted_ == limit ) edm::LogInfo("Invalid Data") << "Suppressing further error messages";
       
       return;
   }
@@ -963,6 +963,6 @@ void HcalUnpacker::printInvalidDataMessage( const std::string &coll_type, int de
               << conflict_ns << ") \nprocess.hcalDigis.save" << coll_type << "DataTags = cms.untracked.vstring( \"MYDATA\" )" ;
   }
 
-  edm::LogWarning("Invalid Data") << message.str() << std::endl;
+  edm::LogWarning("Invalid Data") << message.str();
 }
 


### PR DESCRIPTION
This is a partial followup to #22706, simply reducing the number of repeated messages .

Less trivial changes are still expected to avoid making this message in the first place for data that is not supposed to be unpacked.

