### PR TITLE
Make legacy and uROS DT packer naming consistent for InputTag cfg parameter [10_2_X]

### DIFF
--- a/EventFilter/DTRawToDigi/plugins/DTuROSDigiToRaw.cc
+++ b/EventFilter/DTRawToDigi/plugins/DTuROSDigiToRaw.cc
@@ -28,7 +28,7 @@ DTuROSDigiToRaw::DTuROSDigiToRaw(const edm::ParameterSet& pset) :  eventNum(0) {
 
   produces<FEDRawDataCollection>();
 
-  DTDigiInputTag_ = pset.getParameter<edm::InputTag>("DTDigi_Source");
+  DTDigiInputTag_ = pset.getParameter<edm::InputTag>("digiColl");
 
   debug_ = pset.getUntrackedParameter<bool>("debug", false);
 

--- a/EventFilter/DTRawToDigi/python/dturospacker_cfi.py
+++ b/EventFilter/DTRawToDigi/python/dturospacker_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 dturospacker = cms.EDProducer("DTuROSDigiToRaw",
-                                DTDigi_Source = cms.InputTag("simMuonDTDigis"),
+                                digiColl = cms.InputTag("simMuonDTDigis"),
                                 debug = cms.untracked.bool(True),
                              )


### PR DESCRIPTION
This PR makes the legacy and uROS packer input tag cfg parameter names consistent.

It is expected to have impact on premixing workflows as it makes [this line](https://github.com/cms-sw/cmssw/blob/29202e1ff747c480d7cbdf5fb13555ce00c1a3bf/Configuration/StandardSequences/python/DigiToRawDM_cff.py#L28) work in the expected way.

It should be addressing (at the bare minimum a fraction of) the issues observed in 102X/101X for muons for premixing.