### PR TITLE
Make legacy and uROS DT packer naming consistent for InputTag cfg parameter [10_1_X] 

### DIFF
--- a/EventFilter/DTRawToDigi/plugins/DTuROSDigiToRaw.cc
+++ b/EventFilter/DTRawToDigi/plugins/DTuROSDigiToRaw.cc
@@ -28,7 +28,7 @@ DTuROSDigiToRaw::DTuROSDigiToRaw(const edm::ParameterSet& pset) :  eventNum(0) {
 
   produces<FEDRawDataCollection>();
 
-  DTDigiInputTag_ = pset.getParameter<edm::InputTag>("DTDigi_Source");
+  DTDigiInputTag_ = pset.getParameter<edm::InputTag>("digiColl");
 
   debug_ = pset.getUntrackedParameter<bool>("debug", false);
 

--- a/EventFilter/DTRawToDigi/python/dturospacker_cfi.py
+++ b/EventFilter/DTRawToDigi/python/dturospacker_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 dturospacker = cms.EDProducer("DTuROSDigiToRaw",
-                                DTDigi_Source = cms.InputTag("simMuonDTDigis"),
+                                digiColl = cms.InputTag("simMuonDTDigis"),
                                 debug = cms.untracked.bool(True),
                              )


### PR DESCRIPTION
Backport of [PR # 23091](https://github.com/cms-sw/cmssw/pull/23091)