### PR TITLE
L1T DQM Retire unneeded caloLayer2 data-emulator ratio plots

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2CaloLayer2Emul_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2CaloLayer2Emul_cfi.py
@@ -6,6 +6,6 @@ l1tStage2CaloLayer2Emul = DQMEDAnalyzer('L1TStage2CaloLayer2',
                 stage2CaloLayer2EGammaSource = cms.InputTag("valCaloStage2Layer2Digis"),
                 stage2CaloLayer2TauSource = cms.InputTag("valCaloStage2Layer2Digis"),
                 stage2CaloLayer2EtSumSource = cms.InputTag("valCaloStage2Layer2Digis"),
-                monitorDir = cms.untracked.string("L1TEMU/L1TStage2CaloLayer2/L1TStage2CaloLayer2EMU")
+                monitorDir = cms.untracked.string("L1TEMU/L1TStage2CaloLayer2")
 )
                                      

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -88,7 +88,6 @@ from DQM.L1TMonitor.L1TdeStage2CaloLayer1_cfi import *
 
 # CaloLayer2
 from DQM.L1TMonitor.L1TdeStage2CaloLayer2_cfi import *
-from DQM.L1TMonitor.L1TStage2CaloLayer2_cfi import *
 from DQM.L1TMonitor.L1TStage2CaloLayer2Emul_cfi import *
 
 # BMTF
@@ -123,10 +122,7 @@ l1tStage2EmulatorOnlineDQM = cms.Sequence(
 # sequence to run only for validation events
 l1tStage2EmulatorOnlineDQMValidationEvents = cms.Sequence(
     l1tdeStage2CaloLayer1 +
-    # We process both layer2 and layer2emu in same sourceclient
-    # to be able to divide them in the MonitorClient
     l1tdeStage2CaloLayer2 +
-    l1tStage2CaloLayer2 +
     l1tStage2CaloLayer2Emul
 )
 

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -17,7 +17,6 @@ import FWCore.ParameterSet.Config as cms
 from DQM.L1TMonitorClient.L1TStage2EmulatorQualityTests_cff import *
 
 # Calo trigger layer2 client
-from DQM.L1TMonitorClient.L1TStage2CaloLayer2DEClient_cfi import *
 from DQM.L1TMonitorClient.L1TStage2CaloLayer2DEClientSummary_cfi import *
 
 # uGMT emulator client
@@ -44,8 +43,7 @@ from DQM.L1TMonitorClient.L1TStage2uGTEmulatorClient_cff import *
 
 # L1T monitor client sequence (system clients and quality tests)
 l1TStage2EmulatorClients = cms.Sequence(
-                        l1tStage2CaloLayer2DEClient
-		      + l1tStage2CaloLayer2DEClientSummary
+		        l1tStage2CaloLayer2DEClientSummary
                       + l1tStage2uGMTEmulatorClient
                       + l1tStage2BMTFEmulatorClient
                       + l1tStage2OMTFEmulatorClient


### PR DESCRIPTION
The caloLayer2 data over emulator ratio plots are not needed anymore since there re now dedicated event by event comparison plots for the data vs. emulator agreement checks.

The running of the caloLayer2 DQM module in the emulator client also results in a race condition in the DQMGUI where the histograms produced by the l1tstage2 client race against the ones from the l1tstage2emulator client. Since the later have much less events as they only run in fat events, only the ones from the l1tstage2 client are desired. With the removal of the ratio plots the l1tstage2emulator version of the histograms are not needed anymore and could be removed.