### PR TITLE
process only 20 plugins per process for AARCH64

### DIFF
--- a/FWCore/PluginManager/bin/refresh.cc
+++ b/FWCore/PluginManager/bin/refresh.cc
@@ -37,6 +37,8 @@ using namespace edmplugin;
 // memory usage low as well.
 #ifdef __APPLE__
 #define PER_PROCESS_DSO 20
+#elif defined(__aarch64__)
+#define PER_PROCESS_DSO 20
 #else
 #define PER_PROCESS_DSO 2000
 #endif


### PR DESCRIPTION
This PR is to avoid AARCH64 crashes we are seeing when updated to Root 6.12. 

[a]
```
@@@@ Refreshing Plugins:edmPluginRefresh
@@@@ Refreshing Plugins:edmPluginRefresh
>> All python modules compiled
Caught exception An exception of category 'PluginLibraryLoadError' occurred.
Exception Message:
unable to load lib/slc7_aarch64_gcc700/pluginFireworksCaloPlugins.so because /lib64/libGL.so.1: cannot allocate memory in static TLS block
 will ignore pluginFireworksCaloPlugins.so and continue.

 *** Break *** segmentation violation
```