### PR TITLE
OnlineDQM: Adjust uGMT quality tests CMSLITDPG-568

### DIFF
--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
@@ -64,8 +64,6 @@
       <TestName activate="true">uGMT_MuonPtRange</TestName>
   </LINK>
 
-  <!-- uGMT Muon Phi-Eta -->
-
 
   <!-- uGMT BMTF Quality Tests -->
 
@@ -118,8 +116,8 @@
   <QTEST name="uGMT_BMTFhwEtaSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.01</PARAM>
-    <PARAM name="warning">0.10</PARAM>
+    <PARAM name="error">0.00000001</PARAM>
+    <PARAM name="warning">0.01</PARAM>
   </QTEST>
 
   <QTEST name="uGMT_BMTFhwEtaMeanAt0">
@@ -144,11 +142,16 @@
   <!-- uGMT BMTF HW Sign -->
 
   <QTEST name="uGMT_BMTFhwSignUniform">
-    <TYPE>NoisyChannel</TYPE>	
-    <PARAM name="tolerance">0.3</PARAM>
-    <PARAM name="neighbours">2</PARAM>
-    <PARAM name="error">0.996</PARAM>
-    <PARAM name="warning">0.999</PARAM>
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.5</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">0.45</PARAM>
+    <PARAM name="xmax">0.55</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">100</PARAM>
   </QTEST>
 
   
@@ -221,8 +224,8 @@
   <QTEST name="uGMT_OMTFhwEtaSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.01</PARAM>
-    <PARAM name="warning">0.04</PARAM>
+    <PARAM name="error">0.00000001</PARAM>
+    <PARAM name="warning">0.01</PARAM>
   </QTEST>
 
   <QTEST name="uGMT_OMTFhwEtaMeanAt0">
@@ -261,11 +264,16 @@
   <!-- uGMT OMTF HW Sign -->
 
   <QTEST name="uGMT_OMTFhwSignUniform">
-    <TYPE>NoisyChannel</TYPE>	
-    <PARAM name="tolerance">0.3</PARAM>
-    <PARAM name="neighbours">2</PARAM>
-    <PARAM name="error">0.96</PARAM>
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.5</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">0.45</PARAM>
+    <PARAM name="xmax">0.55</PARAM>
+    <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">100</PARAM>
   </QTEST>
 
   
@@ -331,6 +339,26 @@
   <LINK name="*/L1TStage2uGMT/ugmtMuonPhiEmtf">
       <TestName activate="true">uGMT_EMTFMuonPhiSpectrum</TestName>
       <TestName activate="true">uGMT_EMTFMuonPhiMeanAt0</TestName>
+  </LINK>
+
+  <!-- uGMT EMTF HW Sign -->
+
+  <QTEST name="uGMT_EMTFhwSignUniform">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.5</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">0.45</PARAM>
+    <PARAM name="xmax">0.55</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">100</PARAM>
+  </QTEST>
+
+
+  <LINK name="*/L1TStage2uGMT/*/ugmtEMTFhwSign">
+      <TestName activate="true">uGMT_EMTFhwSignUniform</TestName>
   </LINK>
 
   <!-- uGMT Mismatch Summary QTest -->

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -256,6 +256,11 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
+                                QualityTestName = cms.string("uGMT_EMTFhwSignUniform"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFInput/ugmtEMTFhwSign"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
                                 QualityTestName = cms.string("BMTFvsuGMT_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)


### PR DESCRIPTION
Solves https://its.cern.ch/jira/browse/CMSLITDPG-568

Description: Adjust the uGMT quality tests associated to the hw sign and eta distribution of BMTF and OMTF inputs. Also add a uGMT QT for the EMTF hw sign.