### PR TITLE
Fix premix setting in MatrixInjector

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -361,7 +361,7 @@ class MatrixInjector(object):
                                     processStrPrefix='PU25ns_'
                                 elif   (  s[2][index].split()[  s[2][index].split().index('--pileup')+1 ]  ).find('50ns')  > 0 :
                                     processStrPrefix='PU50ns_'
-                            if 'premix_stage2' in s[2][index] : # take care of pu overlay done with DIGI mixing of premixed events
+                            if 'premix_stage2' in s[2][index] and '--pileup_input' in s[2][index]: # take care of pu overlay done with DIGI mixing of premixed events
                                 if s[2][index].split()[ s[2][index].split().index('--pileup_input')+1  ].find('25ns')  > 0 :
                                     processStrPrefix='PUpmx25ns_'
                                 elif s[2][index].split()[ s[2][index].split().index('--pileup_input')+1  ].find('50ns')  > 0 :


### PR DESCRIPTION
@zhenhu observed a failure when submitting relvals for 10_2_0_pre2. #22583 added the `premix_stage2` modifier to the RECO step in premixed workflows. However, the `--pileup_input` argument is not provided for the RECO step, so this led to an issue in the `MatrixInjector`.

This PR has a simple proposed fix (tested by @zhenhu).

attn: @makortel 