### PR TITLE
Use FormulaEvaluator for JER

### DIFF
--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -578,6 +578,10 @@ namespace {
   const std::string k_TMath__Erf("TMath::Erf");
   const std::string k_erf("erf");
   const std::string k_TMath__Landau("TMath::Landau");
+  const std::string k_sqrt("sqrt");
+  const std::string k_TMath__Sqrt("TMath::Sqrt");
+  const std::string k_abs("abs");
+  const std::string k_TMath__Abs("TMath::Abs");
 
 
   EvaluatorInfo 
@@ -622,6 +626,30 @@ namespace {
 
     info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
                                      k_exp, [](double iArg)->double { return std::exp(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_sqrt, [](double iArg)->double { return std::sqrt(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_TMath__Sqrt, [](double iArg)->double { return std::sqrt(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_abs, [](double iArg)->double { return std::abs(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_TMath__Abs, [](double iArg)->double { return std::abs(iArg); } );
     if(info.evaluator.get() != nullptr) {
       return info;
     }

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -897,6 +897,40 @@ testFormulaEvaluator::checkFormulaEvaluator() {
     }
   }
 
+  //tests for JER
+  {
+    reco::FormulaEvaluator f("[0]+[1]*exp(-x/[2])");
+
+    std::vector<double> v = {0.006467,0.02519,77.08};
+    std::vector<double> x = {100.};
+
+    auto func = [&v](double x) { return v[0]+v[1]*std::exp(-x/v[2]); };
+
+    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0]) ) );
+  }
+
+  {
+    reco::FormulaEvaluator f("sqrt([0]*abs([0])/(x*x)+[1]*[1]*pow(x,[3])+[2]*[2])");
+
+    std::vector<double> v = {1.326,0.4209,0.02223,-0.6704};
+    std::vector<double> x = {100.};
+
+    auto func = [&v](double x) { return std::sqrt(v[0]*std::abs(v[0])/(x*x)+v[1]*v[1]*std::pow(x,v[3])+v[2]*v[2]); };
+
+    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0]) ) );
+  }
+
+  {
+    reco::FormulaEvaluator f("sqrt([0]*[0]/(x*x)+[1]*[1]/x+[2]*[2])");
+
+    std::vector<double> v = {2.3,0.20,0.009};
+    std::vector<double> x = {100.};
+
+    auto func = [&v](double x) { return std::sqrt(v[0]*v[0]/(x*x)+v[1]*v[1]/x+v[2]*v[2]); };
+
+    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0]) ) );
+  }
+
   {
     auto t = [] () {
       reco::FormulaEvaluator f("doesNotExist(2)");

--- a/CondFormats/JetMETObjects/interface/JetResolutionObject.h
+++ b/CondFormats/JetMETObjects/interface/JetResolutionObject.h
@@ -20,7 +20,11 @@
 #include <memory>
 #include <initializer_list>
 
+#ifndef STANDALONE
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+#else
 #include <TFormula.h>
+#endif
 
 enum class Variation {
     NOMINAL = 0,
@@ -186,10 +190,15 @@ namespace JME {
                         return m_formula_str;
                     }
 
+#ifndef STANDALONE
+                    const reco::FormulaEvaluator* getFormula() const {
+                        return m_formula.get();
+                    }
+#else
                     TFormula const * getFormula() const {
                         return m_formula.get();
                     }
-
+#endif
                     void init();
 
                 private:
@@ -197,8 +206,11 @@ namespace JME {
                     std::vector<std::string> m_variables_name;
                     std::string m_formula_str;
 
+#ifndef STANDALONE
+                    std::shared_ptr<reco::FormulaEvaluator> m_formula COND_TRANSIENT;
+#else
                     std::shared_ptr<TFormula> m_formula COND_TRANSIENT;
-
+#endif
                     std::vector<Binning> m_bins COND_TRANSIENT;
                     std::vector<Binning> m_variables COND_TRANSIENT;
 


### PR DESCRIPTION
Brief history lesson:
* #11584: custom (stateless, thread-safe and -efficient) `FormulaEvaluator` used for JECs
* #16283: static warning fixed in JER use of `TFormula`: required copying `TFormula` each time `JME::JetResolutionObject::evaluateFormula()` is called

It turns out copying `TFormula` objects is really slow. Using a stateless evaluator should be much faster.

I modified the `JetResolutionObject` to use `FormulaEvaluator` (preserving `TFormula` for the "standalone" case). I had to add support for `sqrt` and `abs` functions in the parser.

I tested this in my ntuple code and observed a 100x speedup in the `evaluateFormula()` function, with no changes in JER-related quantities in 5000 ttbar events.

Before:
```
            8.5  .........      45.81 / 399.31       edm::stream::EDProducerAdaptorBase::doEvent(edm::EventPrincipal const&, edm::EventSetup const&, edm::ActivityRegistry*, edm::ModuleCallingContext const*) [14]
[30]        8.5      45.81       0.00 / 45.81      @{pluginPhysicsToolsPatUtils_plugins.so+813138}
            8.4  .........      45.17 / 52.64        JME::JetResolutionObject::evaluateFormula(JME::JetResolutionObject::Record const&, JME::JetParameters const&) const [27]
            0.1  .........       0.64 / 0.76         JME::JetResolution::getResolution(JME::JetParameters const&) const [1106]
```

After:
```
            0.2  .........       0.88 / 329.62       edm::stream::EDProducerAdaptorBase::doEvent(edm::EventPrincipal const&, edm::EventSetup const&, edm::ActivityRegistry*, edm::ModuleCallingContext const*) [14]
[975]       0.2       0.88       0.00 / 0.88       @{pluginPhysicsToolsPatUtils_plugins.so+813138}
            0.1  .........       0.50 / 0.55         JME::JetResolution::getResolution(JME::JetParameters const&) const [1230]
            0.1  .........       0.37 / 0.40         JME::JetResolutionObject::evaluateFormula(JME::JetResolutionObject::Record const&, JME::JetParameters const&) const [1483]
```

This PR will be backported to 94X for analysis use.