### PR TITLE
Use FormulaEvaluator for JER [94X]

### DIFF
--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -297,6 +297,11 @@ namespace {
         fullExpression.evaluator.reset();
       }
 
+      if(fullExpression.evaluator == nullptr) {
+        //we had a parsing problem
+        return fullExpression;
+      }
+
       //Now to handle precedence
       auto topNode = fullExpression.top;
       auto binaryEval = dynamic_cast<reco::formula::BinaryOperatorEvaluatorBase*>(fullExpression.evaluator.get());

--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -573,6 +573,10 @@ namespace {
   const std::string k_TMath__Erf("TMath::Erf");
   const std::string k_erf("erf");
   const std::string k_TMath__Landau("TMath::Landau");
+  const std::string k_sqrt("sqrt");
+  const std::string k_TMath__Sqrt("TMath::Sqrt");
+  const std::string k_abs("abs");
+  const std::string k_TMath__Abs("TMath::Abs");
 
 
   EvaluatorInfo 
@@ -617,6 +621,30 @@ namespace {
 
     info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
                                      k_exp, [](double iArg)->double { return std::exp(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_sqrt, [](double iArg)->double { return std::sqrt(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_TMath__Sqrt, [](double iArg)->double { return std::sqrt(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_abs, [](double iArg)->double { return std::abs(iArg); } );
+    if(info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(iBegin, iEnd, m_expressionFinder,
+                                     k_TMath__Abs, [](double iArg)->double { return std::abs(iArg); } );
     if(info.evaluator.get() != nullptr) {
       return info;
     }

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -895,4 +895,38 @@ testFormulaEvaluator::checkFormulaEvaluator() {
     }
   }
 
+  //tests for JER
+  {
+    reco::FormulaEvaluator f("[0]+[1]*exp(-x/[2])");
+
+    std::vector<double> v = {0.006467,0.02519,77.08};
+    std::vector<double> x = {100.};
+
+    auto func = [&v](double x) { return v[0]+v[1]*std::exp(-x/v[2]); };
+
+    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0]) ) );
+  }
+
+  {
+    reco::FormulaEvaluator f("sqrt([0]*abs([0])/(x*x)+[1]*[1]*pow(x,[3])+[2]*[2])");
+
+    std::vector<double> v = {1.326,0.4209,0.02223,-0.6704};
+    std::vector<double> x = {100.};
+
+    auto func = [&v](double x) { return std::sqrt(v[0]*std::abs(v[0])/(x*x)+v[1]*v[1]*std::pow(x,v[3])+v[2]*v[2]); };
+
+    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0]) ) );
+  }
+
+  {
+    reco::FormulaEvaluator f("sqrt([0]*[0]/(x*x)+[1]*[1]/x+[2]*[2])");
+
+    std::vector<double> v = {2.3,0.20,0.009};
+    std::vector<double> x = {100.};
+
+    auto func = [&v](double x) { return std::sqrt(v[0]*v[0]/(x*x)+v[1]*v[1]/x+v[2]*v[2]); };
+
+    CPPUNIT_ASSERT( compare( f.evaluate(x,v), func(x[0]) ) );
+  }
+
 }

--- a/CondFormats/JetMETObjects/interface/JetResolutionObject.h
+++ b/CondFormats/JetMETObjects/interface/JetResolutionObject.h
@@ -20,7 +20,11 @@
 #include <memory>
 #include <initializer_list>
 
+#ifndef STANDALONE
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+#else
 #include <TFormula.h>
+#endif
 
 enum class Variation {
     NOMINAL = 0,
@@ -186,10 +190,15 @@ namespace JME {
                         return m_formula_str;
                     }
 
+#ifndef STANDALONE
+                    const reco::FormulaEvaluator* getFormula() const {
+                        return m_formula.get();
+                    }
+#else
                     TFormula const * getFormula() const {
                         return m_formula.get();
                     }
-
+#endif
                     void init();
 
                 private:
@@ -197,8 +206,11 @@ namespace JME {
                     std::vector<std::string> m_variables_name;
                     std::string m_formula_str;
 
+#ifndef STANDALONE
+                    std::shared_ptr<reco::FormulaEvaluator> m_formula COND_TRANSIENT;
+#else
                     std::shared_ptr<TFormula> m_formula COND_TRANSIENT;
-
+#endif
                     std::vector<Binning> m_bins COND_TRANSIENT;
                     std::vector<Binning> m_variables COND_TRANSIENT;
 


### PR DESCRIPTION
backport of #23106

also includes a patch from #22354 to prevent segfaults

intended to speed up analysis; no changes were observed in my private tests, so I think it can go to the main branch rather than the analysis branch.