### PR TITLE
improving dynamic inefficiency monitoring (Rebase of #23061)

### DIFF
--- a/DQM/SiPixelPhase1Common/python/SiPixelPhase1Clusters_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/SiPixelPhase1Clusters_cfi.py
@@ -92,7 +92,7 @@ SiPixelPhase1ClustersSizeY = DefaultHistoDigiCluster.clone(
 SiPixelPhase1ClustersNClusters = DefaultHistoDigiCluster.clone(
   name = "clusters",
   title = "Clusters",
-  range_min = 0, range_max = 30, range_nbins = 60,
+  range_min = 0, range_max = 100, range_nbins = 25,
   xlabel = "clusters",
   dimensions = 0,
 
@@ -226,7 +226,7 @@ SiPixelPhase1ClustersReadoutCharge = DefaultHistoReadout.clone(
 SiPixelPhase1ClustersReadoutNClusters = DefaultHistoReadout.clone(
   name = "clusters",
   title = "Clusters",
-  range_min = 0, range_max = 30, range_nbins = 30,
+  range_min = 0, range_max = 100, range_nbins = 25,
   xlabel = "clusters",
   dimensions = 0,
   specs = VPSet(

--- a/DQM/SiPixelPhase1Common/python/SiPixelPhase1DeadFEDChannels_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/SiPixelPhase1DeadFEDChannels_cfi.py
@@ -10,7 +10,6 @@ topFolderName = DefaultHisto.topFolderName.value() +"/FED",
   name = "Dead Channels",
   title = "Dead Channels",
   xlabel = "dead channels",
-  #range_min = 1199.5, range_max = 1338.5, range_nbins = 139,
   range_min = 0, range_max = 1000, range_nbins = 100,
   dimensions = 0,
   specs = VPSet(
@@ -27,7 +26,7 @@ topFolderName = DefaultHisto.topFolderName.value() +"/FED",
                    .groupBy("FED","EXTEND_X")
                    .groupBy("","EXTEND_Y")
                    .save(), #average dead channels per event and FED per LumiBlock 
-    Specification().groupBy("LumiBlock/Event")
+    Specification().groupBy("PXAll/Event")
                    .reduce("COUNT")
                    .groupBy("LumiBlock") #average number of dead channels per Lumisection
                    .reduce("MEAN")
@@ -83,7 +82,6 @@ topFolderName = DefaultHisto.topFolderName.value() +"/FED",
   name = "Dead Channels per ROC",
   title = "Dead Channels per ROC",
   xlabel = "dead channels per ROC",
-  #range_min = 1199.5, range_max = 1338.5, range_nbins = 139,
   range_min = 0, range_max = 1000, range_nbins = 100,
   dimensions = 0,
   specs = VPSet(

--- a/DQM/SiPixelPhase1Common/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/SiPixelPhase1Digis_cfi.py
@@ -26,8 +26,8 @@ SiPixelPhase1DigisNdigis = DefaultHistoDigiCluster.clone(
   title = "Digis",
   xlabel = "digis",
   range_min = 0,
-  range_max = 200,
-  range_nbins = 100,
+  range_max = 300,
+  range_nbins = 50,
   dimensions = 0, # this is a count
 
   specs = VPSet(
@@ -38,11 +38,11 @@ SiPixelPhase1DigisNdigis = DefaultHistoDigiCluster.clone(
     Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
                              .reduce("COUNT")    
                              .groupBy("PXBarrel/PXLayer")
-                             .save(nbins=100, xmin=0, xmax=20000),
+                             .save(nbins=100, xmin=0, xmax=40000),
     Specification().groupBy("PXForward/PXDisk/Event")
                              .reduce("COUNT")    
                              .groupBy("PXForward/PXDisk/")
-                             .save(nbins=100, xmin=0, xmax=10000),
+                             .save(nbins=100, xmin=0, xmax=20000),
   )
 )
 

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
@@ -45,6 +45,7 @@ enum {
   ON_TRACK_POSITIONB,
   ON_TRACK_POSITIONF,
   DIGIS_HITMAP_ON_TRACK,
+  ON_TRACK_NDIGIS,
 
   NTRACKS,
   NTRACKS_INVOLUME,
@@ -246,6 +247,7 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
       for (int i = 0; i < cluster.size(); i++){
           SiPixelCluster::Pixel const & vecipxl = cluster.pixel(i);
           histo[DIGIS_HITMAP_ON_TRACK].fill(id, &iEvent, vecipxl.y, vecipxl.x);
+	  histo[ON_TRACK_NDIGIS].fill(id, &iEvent);
       }
 
       histo[ON_TRACK_NCLUSTERS].fill(id, &iEvent);
@@ -287,6 +289,7 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
   }
 
   histo[ON_TRACK_NCLUSTERS].executePerEventHarvesting(&iEvent);
+  histo[ON_TRACK_NDIGIS].executePerEventHarvesting(&iEvent);
 }
 
 } // namespace

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackClusters_cfi.py
@@ -299,8 +299,35 @@ SiPixelPhase1DigisHitmapOnTrack = DefaultHistoTrack.clone(
                             .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row", "EXTEND_X")
                             .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName", "EXTEND_Y")
                             .save(),
+    StandardSpecificationOccupancy,
   )
 )
+
+SiPixelPhase1DigisNdigisOnTrack = DefaultHistoTrack.clone(
+  name = "digis on-track", # 'Count of' added automatically
+  title = "Digis on-track",
+  xlabel = "digis (on-track)",
+  range_min = 0,
+  range_max = 300,
+  range_nbins = 50,
+  dimensions = 0, # this is a count
+
+  specs = VPSet(
+    StandardSpecificationTrend_Num,
+    StandardSpecification2DProfile_Num,
+	
+    Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
+                             .reduce("COUNT")    
+                             .groupBy("PXBarrel/PXLayer")
+                             .save(nbins=100, xmin=0, xmax=40000),
+    Specification().groupBy("PXForward/PXDisk/Event")
+                             .reduce("COUNT")    
+                             .groupBy("PXForward/PXDisk/")
+                             .save(nbins=100, xmin=0, xmax=20000),
+  )
+)
+
+
 
 SiPixelPhase1TrackClustersNTracks = DefaultHistoTrack.clone(
   name = "ntracks",
@@ -469,6 +496,7 @@ SiPixelPhase1TrackClustersConf = cms.VPSet(
   SiPixelPhase1TrackClustersOnTrackPositionB,
   SiPixelPhase1TrackClustersOnTrackPositionF,
   SiPixelPhase1DigisHitmapOnTrack,
+  SiPixelPhase1DigisNdigisOnTrack,
 
   SiPixelPhase1TrackClustersNTracks,
   SiPixelPhase1TrackClustersNTracksInVolume,


### PR DESCRIPTION
This PR include plots to monitor the distribution of on track pixels in space (with ROC maps) and in time (with Lumisection trends). It improve the monitoring of dynamic inefficiency in the Pixel detector.

Also few ranges have been adapted to 2018 running

(Rebase of #23061 which is now closed)