### PR TITLE
Constrain HE TP depth sums to use only 11 bits

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -376,8 +376,10 @@ HcalTriggerPrimitiveAlgo::analyze2017(IntegerCaloSamples& samples, HcalTriggerPr
 	//add up value * scale factor
 	// In addition, divide by two in the 10 degree phi segmentation region
 	// to mimic 5 degree segmentation for the trigger
-	if(ids.size()==2) algosumvalue += int(samples[ibin+i] * 0.5 * weights_[i]);
-	else algosumvalue += int(samples[ibin+i] * weights_[i]);
+	unsigned int sample = samples[ibin+i];
+	if(sample>QIE11_MAX_LINEARIZATION_ET) sample = QIE11_MAX_LINEARIZATION_ET;
+	if(ids.size()==2) algosumvalue += int(sample * 0.5 * weights_[i]);
+	else algosumvalue += int(sample * weights_[i]);
       }
       if (algosumvalue<0) sum[ibin]=0;            // low-side
                                                   //high-side


### PR DESCRIPTION
Quick summary: 

This PR fixes an edge case in the emulation of HCAL TPs in the upgraded HE. Potentially these changes could have an effect on 2018 MC workflows in the PR comparison tests, but likely statistics are too low in these tests to see an effect.

Detailed summary:

TP ET mismatches have been seen in the TP correlation plot of the online DQM: 

http://cmsonline.cern.ch/cms-elog/1038548

The mismatches only occur for TPs from the 10-degree segmentation region of HE. In this region, the physical segmentation of HE is 10 degrees but, for the convenience of the trigger, the uHTR divides the energy into two TPs to mimic 5-degree segmentation. The computation of TPs proceeds as follows:

input (linearization) LUT -> summing of depths -> (divide-by-two) -> summing of time slices -> compression LUT

where the divide-by-two is only relevant in the 10-degree segmentation region. 

The firmware has the following widths:

- input LUT 8->10 bits
- summing of depths 10->11 bits
- summing of timeslices 11->11 bits
- compression 11->8 bits

The emulation uses the same LSB as the uHTR in the summing of the depths, but currently does not constrain the sum to be less than the firmware's 11-bit maximum of 0x7FF. This results in the emulated TP ET being larger than the data TP ET. In the 5-degree segmentation region, this would automatically result in a saturated TP. In contrast, in the 10-degree segmentation region, the divide-by-two reduces the ET so that it may fall in the region 64 < ET < 128 GeV, which does not necessarily result in a saturated TP after the sum of the two samples.

Constraining the depth sum to only 11 bits in the emulation resolves the discrepancies, as shown in the table below. These plots use run 315420 of the JetHT dataset. Though the HcalNZS dataset is normally used for TP emulation tests to avoid spurious mismatches between data and emulation as a result of zero suppression, the statistics are too low for this comparison because of the additional prescale of 4096 for NZS events. In these plots, the variable "soi" indicates the compressed ET in the sample of interest, and is equal to 2*ET with the current compression scheme. The features in abs(ieta)=21-28 disappear. There are additional mismatches at abs(ieta)=15-16 for reasons associated with zero-suppression, which are purely an artifact of using zero-suppressed data in the TP emulation, and are not relevant for this PR.

Before change | After change 
-------------- | --------------
![soi_emul_vs_soi_run315420_before_fix](https://user-images.githubusercontent.com/6534323/39543632-65e18bf2-4e11-11e8-9c91-d82eca9635f5.png) | ![soi_emul_vs_soi_run315420](https://user-images.githubusercontent.com/6534323/39543643-6cd62080-4e11-11e8-906b-f49c2ec11aa7.png)
![et_vs_ieta_run315420_before_fix](https://user-images.githubusercontent.com/6534323/39543671-78d6bdf4-4e11-11e8-94db-3936dac59fb5.png) | ![et_vs_ieta_run315420](https://user-images.githubusercontent.com/6534323/39543688-839c0866-4e11-11e8-8594-7ee5e96f1f1a.png)





