### PR TITLE
Fix noise in dqmMemoryStats [10_1_X]

### DIFF
--- a/DQMServices/FileIO/scripts/dqmMemoryStats.py
+++ b/DQMServices/FileIO/scripts/dqmMemoryStats.py
@@ -38,7 +38,9 @@ class HistogramAnalyzer(object):
             self._all[fn] = HistogramEntry(t, bin_size, bin_count, extra, total_bytes)
         else:
             t = str(type(obj))
-            bin_count, bin_size, extra = 0, 0, len(str(obj)) + len(fn)
+            #bin_count, bin_size, extra = 0, 0, len(str(obj)) + len(fn)
+            # assume constant size for strings
+            bin_count, bin_size, extra = 0, 0, 10 + len(fn)
             total_bytes = bin_count * bin_size + extra
 
             self._all[fn] = HistogramEntry(t, bin_size, bin_count, extra, total_bytes)


### PR DESCRIPTION
Backport of #22925, which works well with the new cms-bot code.

This should also clean up the comparisons on 10_1, e. g. there:
https://github.com/cms-sw/cmssw/pull/22972#issuecomment-386075507