### PR TITLE
Update TriggerIdLoose definition to recover the efficiency in low-pT (backport to 10_1_X)

### DIFF
--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -847,7 +847,7 @@ bool muon::isLooseTriggerMuon(const reco::Muon& muon){
   bool layer_requirements = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 &&
     muon.innerTrack()->hitPattern().pixelLayersWithMeasurement() > 0;
   bool global_requirements = (not muon.isGlobalMuon()) or muon.globalTrack()->normalizedChi2()<20;
-  bool match_requirements = (muon.expectedNnumberOfMatchedStations()<2) or (muon.numberOfMatchedStations()>1);
+  bool match_requirements = (muon.expectedNnumberOfMatchedStations()<2) or (muon.numberOfMatchedStations()>1) or (muon.pt()<8);
   return layer_requirements and global_requirements and match_requirements;
 }
 


### PR DESCRIPTION
Backport of #23124 
> This PR updates the muon station requirement in TriggerIdLoose to recover the efficiency of low-pT (a few GeV) muons.
Backport is needed.