### PR TITLE
Fix parameter update in era customization for DtCalib DQM [10_1_X]

### DIFF
--- a/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
@@ -29,7 +29,7 @@ dtTriggerSynchMonitor = DQMEDAnalyzer('DTLocalTriggerSynchTask',
 )
 
 from Configuration.Eras.Modifier_run2_DT_2018_cff import run2_DT_2018
-run2_DT_2018.toModify(dtTriggerSynchMonitor,processDDU = cms.bool(False))
+run2_DT_2018.toModify(dtTriggerSynchMonitor,processDDU = False)
 
 
 


### PR DESCRIPTION
This is a trivial fix for the issue reported in the [thread of PR 23072](https://github.com/cms-sw/cmssw/pull/23072#pullrequestreview-117445545).
The parameter in the era customization must be untracked, or, better, without type specs. 

The change was tested injecting "by hand" the module into the DT offline DQM sequence for workflows 10009.0 and 10809.0.