### PR TITLE
Fix of dtTriggerSyncTask configuration

### DIFF
--- a/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
@@ -29,7 +29,7 @@ dtTriggerSynchMonitor = DQMEDAnalyzer('DTLocalTriggerSynchTask',
 )
 
 from Configuration.Eras.Modifier_run2_DT_2018_cff import run2_DT_2018
-run2_DT_2018.toModify(dtTriggerSynchMonitor,processDDU = cms.untracked.bool(False))
+run2_DT_2018.toModify(dtTriggerSynchMonitor,processDDU = False)
 
 
 


### PR DESCRIPTION
Fix of the configuration problem reported in https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1875/1/1.html introduced in #23071 (and #23072 for 101X). See https://github.com/cms-sw/cmssw/pull/23072#pullrequestreview-117445545

Tested (in CMSSW_10_1_3) using Configuration/DataProcessing:

python RunExpressProcessing.py --scenario ppEra_Run2_2018 --lfn /store/t0streamer/Data/Express/000/315/322/run315322_ls1364_streamExpress_StorageManager.dat --global-tag 101X_dataRun2_Express_v7 --fevt --dqmio --alcarecos=DtCalib

manually modifying the output configuration

process.maxEvents = cms.untracked.PSet(
    input = cms.untracked.int32(-1)
)
process.source = cms.Source("NewEventStreamFileReader",
    fileNames = cms.untracked.vstring('/store/t0streamer/Data/Express/000/315/322/run315322_ls1364_streamExpress_StorageManager.dat')
)
process.options = cms.untracked.PSet(
    numberOfStreams = cms.untracked.uint32(0),
    numberOfThreads = cms.untracked.uint32(8)
)

to get the correct source. The file is processed correctly and the ALCARECO output file is produced. The produced output configuration is:

process.dtTriggerSynchMonitor = cms.EDProducer("DTLocalTriggerSynchTask",
    DDUInputTag = cms.InputTag("muonDTDigis"),
    SEGInputTag = cms.InputTag("dt4DSegmentsNoWire"),
    TMInputTag = cms.InputTag("dttfDigis"),
    angleRange = cms.double(30.0),
    baseDir = cms.string('AlCaReco/DtCalibSynch/02-Synchronization'),
    bxTimeInterval = cms.double(25),
    minHitsPhi = cms.int32(7),
    nBXHigh = cms.int32(3),
    nBXLow = cms.int32(-2),
    processDDU = cms.untracked.bool(False),
    rangeWithinBX = cms.bool(False),
    staticBooking = cms.untracked.bool(True),
    tTrigMode = cms.string('DTTTrigSyncFromDB'),
    tTrigModeConfig = cms.PSet(
        debug = cms.untracked.bool(False),
        doT0Correction = cms.bool(False),
        doTOFCorrection = cms.bool(False),
        doWirePropCorrection = cms.bool(False),
        tTrigLabel = cms.string(''),
        tofCorrType = cms.int32(0),
        vPropWire = cms.double(24.4),
        wirePropCorrType = cms.int32(0)
    )
)


