### PR TITLE
Fix of dtTriggerSyncTask configuration, 101X backport

### DIFF
--- a/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
@@ -29,7 +29,7 @@ dtTriggerSynchMonitor = DQMEDAnalyzer('DTLocalTriggerSynchTask',
 )
 
 from Configuration.Eras.Modifier_run2_DT_2018_cff import run2_DT_2018
-run2_DT_2018.toModify(dtTriggerSynchMonitor,processDDU = cms.bool(False))
+run2_DT_2018.toModify(dtTriggerSynchMonitor,processDDU = False)
 
 
 


### PR DESCRIPTION
Backport of #23144, fixing the configuration problem in dtTriggerSyncTask (DTMonitorModule). See the discussion in master for validation.