### PR TITLE
test of tensorflow AOT

### DIFF
--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -21,3 +21,11 @@
     <use name="FWCore/Utilities" />
     <use name="PhysicsTools/TensorFlow" />
 </bin>
+
+
+<bin file="tfadd_t.cpp">
+  <flags DNN_NAME="test_graph_tfadd"/>
+  <use name="tensorflow-runtime"/>
+  <use name="tensorflow-xla_compiled_cpu_function"/> 
+</bin>
+

--- a/PhysicsTools/TensorFlow/test/test_graph_tfadd.config.pbtxt
+++ b/PhysicsTools/TensorFlow/test/test_graph_tfadd.config.pbtxt
@@ -1,0 +1,16 @@
+# Text form of tensorflow.tf2xla.Config proto.
+feed {
+  id { node_name: "x_const" }
+  shape {
+    dim { size: 1 }
+  }
+}
+feed {
+  id { node_name: "y_const" }
+  shape {
+    dim { size: 1 }
+  }
+}
+fetch {
+  id { node_name: "x_y_sum" }
+}

--- a/PhysicsTools/TensorFlow/test/test_graph_tfadd.pb
+++ b/PhysicsTools/TensorFlow/test/test_graph_tfadd.pb
@@ -1,0 +1,12 @@
+
+5
+x_constConst*
+dtype0*
+valueB:
+5
+y_constConst*
+dtype0*
+valueB:
+)
+x_y_sumAddx_consty_const*
+T0"

--- a/PhysicsTools/TensorFlow/test/tfadd_t.cpp
+++ b/PhysicsTools/TensorFlow/test/tfadd_t.cpp
@@ -1,0 +1,67 @@
+#include "PhysicsTools/TensorFlow/test/test_graph_tfadd/header.h"
+#include <cassert>
+#include <iostream>
+
+#define EXPECT_EQ(x,y) assert(x==y)
+#define	EXPECT_TRUE(x) assert(x)
+
+int main() {
+ using AddComp=test_graph_tfadd;
+ typedef int int32;
+ {
+
+  std::cout << "testing tf add " << std::endl;
+  AddComp add;
+  EXPECT_EQ(add.arg0_data(), add.args()[0]);
+  EXPECT_EQ(add.arg1_data(), add.args()[1]);
+
+  add.arg0() = 1;
+  add.arg1() = 2;
+  EXPECT_TRUE(add.Run());
+  EXPECT_EQ(add.error_msg(), "");
+  EXPECT_EQ(add.result0(), 3);
+  EXPECT_EQ(add.result0_data()[0], 3);
+  EXPECT_EQ(add.result0_data(), add.results()[0]);
+
+  add.arg0_data()[0] = 123;
+  add.arg1_data()[0] = 456;
+  EXPECT_TRUE(add.Run());
+  EXPECT_EQ(add.error_msg(), "");
+  EXPECT_EQ(add.result0(), 579);
+  EXPECT_EQ(add.result0_data()[0], 579);
+  EXPECT_EQ(add.result0_data(), add.results()[0]);
+
+  const AddComp& add_const = add;
+  EXPECT_EQ(add_const.error_msg(), "");
+  EXPECT_EQ(add_const.arg0(), 123);
+  EXPECT_EQ(add_const.arg0_data()[0], 123);
+  EXPECT_EQ(add_const.arg0_data(), add.args()[0]);
+  EXPECT_EQ(add_const.arg1(), 456);
+  EXPECT_EQ(add_const.arg1_data()[0], 456);
+  EXPECT_EQ(add_const.arg1_data(), add.args()[1]);
+  EXPECT_EQ(add_const.result0(), 579);
+  EXPECT_EQ(add_const.result0_data()[0], 579);
+  EXPECT_EQ(add_const.result0_data(), add_const.results()[0]);
+ }
+
+  // Run tests that use set_argN_data separately, to avoid accidentally re-using
+  // non-existent buffers.
+ {
+   std::cout << "testing tf add no input buffer" << std::endl;
+   AddComp add(AddComp::AllocMode::RESULTS_PROFILES_AND_TEMPS_ONLY);
+
+  int32 arg_x = 10;
+  int32 arg_y = 32;
+  add.set_arg0_data(&arg_x);
+  add.set_arg1_data(&arg_y);
+  EXPECT_EQ(add.arg0_data(), add.args()[0]);
+  EXPECT_EQ(add.arg1_data(), add.args()[1]);
+
+  EXPECT_TRUE(add.Run());
+  EXPECT_EQ(add.error_msg(), "");
+  EXPECT_EQ(add.result0(), 42);
+  EXPECT_EQ(add.result0_data()[0], 42);
+  EXPECT_EQ(add.result0_data(), add.results()[0]);
+ }
+
+}


### PR DESCRIPTION
testing the new SCRAM feature to generate AOT code given a model and config.

Not obvious to me where the .pb and config files should eventually be located
(they need to be shared at least by src/plugin and test directory in a package.)

In general there is no need to expose further the generated AOT as it is expected to be encapsulated in an algorithm or module


file and example copied from tensorflow/compile/aot/tests itself