### PR TITLE
DD Generic Singleton Pattern

### DIFF
--- a/DetectorDescription/DDCMS/interface/DDSingleton.h
+++ b/DetectorDescription/DDCMS/interface/DDSingleton.h
@@ -1,6 +1,8 @@
 #ifndef DETECTOR_DESCRIPTION_DD_SINGLETON_H
 #define DETECTOR_DESCRIPTION_DD_SINGLETON_H
 
+#include <memory>
+
 namespace cms {
 
   template< typename T, typename CONTEXT >
@@ -15,7 +17,7 @@ namespace cms {
   protected:
     DDSingleton() {
       static bool static_init __attribute__(( unused )) = []()->bool {
-	m_instance = new T;
+	m_instance = std::make_shared<T>();
 	return true;
       }();
     }
@@ -28,11 +30,11 @@ namespace cms {
     }
     
   private:
-    static T *m_instance;
+    static std::shared_ptr<T> m_instance;
   };
 }
 
 template < typename T, typename CONTEXT >
-  T *cms::DDSingleton< T, CONTEXT >::m_instance;
+  std::shared_ptr<T> cms::DDSingleton< T, CONTEXT >::m_instance;
   
 #endif

--- a/DetectorDescription/DDCMS/interface/DDSingleton.h
+++ b/DetectorDescription/DDCMS/interface/DDSingleton.h
@@ -9,10 +9,19 @@ namespace cms {
     class DDSingleton
   {
   public:
-    T* operator->() { return m_instance; }
+    T* operator->() { return m_instance.get(); }
     const T* operator->() const { return m_instance; }
     T& operator*() { return *m_instance; }
     const T& operator*() const { return *m_instance; }
+
+    static T *getInstance()
+    {
+      static bool static_init __attribute__(( unused )) = []()->bool {
+	m_instance = std::make_unique<T>();
+	return true;
+      }();
+      return m_instance.get();
+    }
     
   protected:
     DDSingleton() {

--- a/DetectorDescription/DDCMS/interface/DDSingleton.h
+++ b/DetectorDescription/DDCMS/interface/DDSingleton.h
@@ -17,7 +17,7 @@ namespace cms {
   protected:
     DDSingleton() {
       static bool static_init __attribute__(( unused )) = []()->bool {
-	m_instance = std::make_shared<T>();
+	m_instance = std::make_unique<T>();
 	return true;
       }();
     }
@@ -30,11 +30,11 @@ namespace cms {
     }
     
   private:
-    static std::shared_ptr<T> m_instance;
+    static std::unique_ptr<T> m_instance;
   };
 }
 
 template < typename T, typename CONTEXT >
-  std::shared_ptr<T> cms::DDSingleton< T, CONTEXT >::m_instance;
+  std::unique_ptr<T> cms::DDSingleton< T, CONTEXT >::m_instance;
   
 #endif

--- a/DetectorDescription/DDCMS/interface/DDSingleton.h
+++ b/DetectorDescription/DDCMS/interface/DDSingleton.h
@@ -1,0 +1,38 @@
+#ifndef DETECTOR_DESCRIPTION_DD_SINGLETON_H
+#define DETECTOR_DESCRIPTION_DD_SINGLETON_H
+
+namespace cms {
+
+  template< typename T, typename CONTEXT >
+    class DDSingleton
+  {
+  public:
+    T* operator->() { return m_instance; }
+    const T* operator->() const { return m_instance; }
+    T& operator*() { return *m_instance; }
+    const T& operator*() const { return *m_instance; }
+    
+  protected:
+    DDSingleton() {
+      static bool static_init __attribute__(( unused )) = []()->bool {
+	m_instance = new T;
+	return true;
+      }();
+    }
+
+    DDSingleton( int ) {
+      static bool static_init __attribute__(( unused )) = []()->bool {
+	m_instance = CONTEXT::init();
+	return true;
+      }();
+    }
+    
+  private:
+    static T *m_instance;
+  };
+}
+
+template < typename T, typename CONTEXT >
+  T *cms::DDSingleton< T, CONTEXT >::m_instance;
+  
+#endif

--- a/DetectorDescription/DDCMS/test/BuildFile.xml
+++ b/DetectorDescription/DDCMS/test/BuildFile.xml
@@ -1,2 +1,3 @@
 <use   name="cppunit"/>
 <bin   name="testDDUnits" file="DDUnits.cppunit.cc,testRunner.cpp"/>
+<bin   name="testSingleton" file="DDSingleton.cppunit.cc,testRunner.cpp"/>

--- a/DetectorDescription/DDCMS/test/BuildFile.xml
+++ b/DetectorDescription/DDCMS/test/BuildFile.xml
@@ -3,3 +3,6 @@
 <bin   name="testDDSingleton" file="DDSingleton.cppunit.cc,testRunner.cpp"/>
 <bin   name="testSingleton" file="testDDSingleton.cpp"/>
 <bin   name="testSingletonInit" file="testDDSingletonInit.cpp"/>
+<bin   name="testSingletonBenchmark" file="testDDSingletonBenchmark.cpp">
+  <flags CXXFLAGS="-DBENCHMARK_ON"/>
+</bin>

--- a/DetectorDescription/DDCMS/test/BuildFile.xml
+++ b/DetectorDescription/DDCMS/test/BuildFile.xml
@@ -1,3 +1,5 @@
 <use   name="cppunit"/>
 <bin   name="testDDUnits" file="DDUnits.cppunit.cc,testRunner.cpp"/>
-<bin   name="testSingleton" file="DDSingleton.cppunit.cc,testRunner.cpp"/>
+<bin   name="testDDSingleton" file="DDSingleton.cppunit.cc,testRunner.cpp"/>
+<bin   name="testSingleton" file="testDDSingleton.cpp"/>
+<bin   name="testSingletonInit" file="testDDSingletonInit.cpp"/>

--- a/DetectorDescription/DDCMS/test/DDSingleton.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDSingleton.cppunit.cc
@@ -1,0 +1,45 @@
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "DetectorDescription/DDCMS/interface/DDSingleton.h"
+
+#include "cppunit/TestAssert.h"
+#include "cppunit/TestFixture.h"
+
+#include <string>
+
+struct MyDDSingleton : public cms::DDSingleton<std::string, MyDDSingleton> {};
+
+class testDDSingleton : public CppUnit::TestFixture {
+  
+  CPPUNIT_TEST_SUITE( testDDSingleton );
+  CPPUNIT_TEST( testEquality );
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  void setUp() override{}
+  void tearDown() override {}
+  void testEquality();
+
+private:
+  MyDDSingleton m_singleton1;  
+  MyDDSingleton m_singleton2;
+};
+
+void
+testDDSingleton::testEquality()
+{
+  *m_singleton1 = "\"Hello\"";
+  std::cout << "\n"
+	    << *m_singleton1 << " is the same as "
+	    << *m_singleton2 << "\n";
+  CPPUNIT_ASSERT( *m_singleton1 == *m_singleton2 );
+
+  *m_singleton2 = "\"World!\"";
+  std::cout << "\n"
+	    << *m_singleton1 << " is the same as "
+	    << *m_singleton2 << "\n";
+  CPPUNIT_ASSERT( *m_singleton1 == *m_singleton2 );
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION( testDDSingleton );

--- a/DetectorDescription/DDCMS/test/testDDSingleton.cpp
+++ b/DetectorDescription/DDCMS/test/testDDSingleton.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <string>
+
+#include "DetectorDescription/DDCMS/interface/DDSingleton.h"
+
+using namespace std;
+
+struct StrDDSingleton : public cms::DDSingleton< string, StrDDSingleton> {};
+
+class TestClass
+{
+public:
+
+  void test()
+  {
+    *m_singleton = "Hello world";
+  }
+
+  friend ostream &operator << ( ostream &o, const TestClass &t )
+  {
+    o << *t.m_singleton;
+    return o;
+  }
+
+private:
+
+  StrDDSingleton m_singleton;
+};
+
+int main(int argc, char *argv[])
+{
+  TestClass tst;
+  for (int i = 0; i < 100000; ++i)
+    tst.test();
+  cout << tst << endl;
+  return 0;
+}

--- a/DetectorDescription/DDCMS/test/testDDSingletonBenchmark.cpp
+++ b/DetectorDescription/DDCMS/test/testDDSingletonBenchmark.cpp
@@ -1,0 +1,121 @@
+#include "DetectorDescription/DDCMS/interface/DDSingleton.h"
+
+#include <iostream>
+#include <string>
+#include <chrono>
+
+using namespace std;
+using namespace cms;
+
+struct StrSingleton : public DDSingleton<string, StrSingleton> {};
+struct StrSingletonTwo : public DDSingleton<string, StrSingletonTwo>
+{
+  StrSingletonTwo() : DDSingleton(1) {}
+  static std::unique_ptr<string> init() { return std::make_unique<string>( "Initialized" ); }
+};
+
+class TestClass
+{
+public:
+  TestClass() : m_strVal("Hello World")
+  {}
+
+  void test1( int i )
+  {
+    StrSingleton::getInstance()->assign( std::to_string( i ));
+  }
+
+  void test2( int i )
+  {
+    m_str->assign( std::to_string( i ));
+  }
+
+  void test3( int i )
+  {
+    m_strVal.assign( std::to_string( i ));
+  }
+  
+  void test4( int i )
+  {
+    *m_str = std::to_string( i );
+  }
+  
+  void test5( int i )
+  {
+    m_str2->assign( std::to_string( i ));
+  }
+  
+  void test6( int i )
+  {
+    *m_str2 = std::to_string( i );
+  }
+
+private:
+  string m_strVal;
+  StrSingleton m_str;
+  StrSingleton m_str2;
+};
+
+class BenchmarkGrd
+{
+public:
+  BenchmarkGrd( const std::string &name )
+    : m_start( std::chrono::high_resolution_clock::now()),
+      m_name( name )
+  {}
+  
+  ~BenchmarkGrd()
+  {
+    std::chrono::duration< double, std::milli > diff = std::chrono::high_resolution_clock::now() - m_start;
+    std::cout << "Benchmark '" << m_name << "' took " << diff.count() << " millis\n";
+  }
+  
+private:
+  std::chrono::time_point<std::chrono::high_resolution_clock> m_start;
+  std::string m_name;
+};
+
+#ifdef BENCHMARK_ON
+#   define BENCHMARK_START(X) {BenchmarkGrd(#X)
+#   define BENCHMARK_END }
+#else
+#   define BENCHMARK_START(X)
+#   define BENCHMARK_END
+#endif
+
+int main( int argc, char *argv[])
+{
+  TestClass tst;
+  
+  BENCHMARK_START( test1 );
+  for( int i = 0; i < 1000000; ++i )
+    tst.test1( i );
+  BENCHMARK_END;
+  
+  BENCHMARK_START( test2 );
+  for( int i = 0; i < 1000000; ++i )
+    tst.test2( i );
+  BENCHMARK_END;
+  
+  BENCHMARK_START( test3 );
+  for( int i = 0; i < 1000000; ++i )
+    tst.test3( i );
+  BENCHMARK_END;
+  
+  BENCHMARK_START( test4 );
+  for( int i = 0; i < 1000000; ++i )
+    tst.test4( i );
+  BENCHMARK_END;
+  
+  BENCHMARK_START( test5 );
+  for( int i = 0; i < 1000000; ++i )
+    tst.test5( i );
+  BENCHMARK_END;
+  
+  BENCHMARK_START( test6 );
+  for( int i = 0; i < 1000000; ++i )
+    tst.test6( i );
+  BENCHMARK_END;
+  
+  return 0;
+}

--- a/DetectorDescription/DDCMS/test/testDDSingletonInit.cpp
+++ b/DetectorDescription/DDCMS/test/testDDSingletonInit.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <string>
+
+#include "DetectorDescription/DDCMS/interface/DDSingleton.h"
+
+using namespace std;
+using namespace cms;
+
+struct StrSingleton : public DDSingleton<string, StrSingleton>
+{
+  StrSingleton() : DDSingleton(1) {}
+  static std::unique_ptr<string> init() { return std::make_unique<string>( "Initialized" ); }
+};
+
+int main( int argc, char *argv[] )
+{
+  StrSingleton strSingleton;
+  
+  cout << *strSingleton << endl;
+  
+  *strSingleton = "Hello";
+  
+  cout << *strSingleton << endl;
+  return 0;
+}


### PR DESCRIPTION
* Simple to reuse the same implementation across all singletons use cases
* More than a single singleton can be constructed for the same type
* A singleton can be applied to any type which one can construct, not necessarily with a default constructor
* Defer the singleton initialization until the first use
* The singleton initialization is thread safe:
    * Only a single thread will initialize the singleton
    * All the threads will use the same initialized instance
* Using  the singleton is as fast as direct pointer access
* Add unit test and a couple of tests for valgrind

```
$ valgrind --leak-check=full --show-leak-kinds=all ../../../test/slc6_amd64_gcc630/testSingleton
==16045== Memcheck, a memory error detector
==16045== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==16045== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==16045== Command: ../../../test/slc6_amd64_gcc630/testSingleton
==16045== 
Hello world
==16045== 
==16045== HEAP SUMMARY:
==16045==     in use at exit: 0 bytes in 0 blocks
==16045==   total heap usage: 2 allocs, 2 frees, 72,736 bytes allocated
==16045== 
==16045== All heap blocks were freed -- no leaks are possible
==16045== 
==16045== For counts of detected and suppressed errors, rerun with: -v
==16045== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 4 from 4)

```
```
$ valgrind --leak-check=full --show-leak-kinds=all ../../../test/slc6_amd64_gcc630/testSingletonInit 
==2464== Memcheck, a memory error detector
==2464== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2464== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==2464== Command: ../../../test/slc6_amd64_gcc630/testSingletonInit
==2464== 
Initialized
Hello
==2464== 
==2464== HEAP SUMMARY:
==2464==     in use at exit: 0 bytes in 0 blocks
==2464==   total heap usage: 2 allocs, 2 frees, 72,736 bytes allocated
==2464== 
==2464== All heap blocks were freed -- no leaks are possible
==2464== 
==2464== For counts of detected and suppressed errors, rerun with: -v
==2464== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 4 from 4)
```
Note, test1 uses getInstance():
```
Package DetectorDescription/DDCMS: Running test testSingletonBenchmark
 
===== Test "testSingletonBenchmark" ====
Benchmark 'test1' took 0.000699 millis
Benchmark 'test2' took 0.001109 millis
Benchmark 'test3' took 0.001125 millis
Benchmark 'test4' took 0.000953 millis
Benchmark 'test5' took 0.000975 millis
Benchmark 'test6' took 0.001117 millis

---> test testSingletonBenchmark succeeded
```