### PR TITLE
Fix HLT DQM online application (102X)

### DIFF
--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("DQM")
+from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
+process = cms.Process("DQM", run2_HECollapse_2018)
 # for live online DQM in P5
 process.load("DQM.Integration.config.inputsource_cfi")
 # used in the old input source


### PR DESCRIPTION
This PR fixes the crash of HLT DQM online application due to a seg fault in hcalOnlineMonitoringSequence.
The reason was that HLT uses collapsed HCAL digis and offline uses uncollapsed HCAL digis.
(Thanks @deguio  for the fix)
