### PR TITLE
SiPixelQuality harvester fix for segmenation fault for CMSSW_10_2_X

### DIFF
--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
@@ -229,7 +229,7 @@ void SiPixelStatusHarvester::endRun(const edm::Run& iRun, const edm::EventSetup&
 
                for (int iroc = 0; iroc < modStatus.nrocs(); ++iroc) {
 
-                   unsigned long int rocOccupancy = modStatus.digiOccROC(iroc);
+                   unsigned int rocOccupancy = modStatus.digiOccROC(iroc);
 
                    // Bad ROC are from low DIGI Occ ROCs
                    if(rocOccupancy<1.e-4*DetAverage){

--- a/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
@@ -53,8 +53,9 @@ void SiPixelStatusManager::reset(){
 bool SiPixelStatusManager::rankByLumi(SiPixelDetectorStatus status1,SiPixelDetectorStatus status2) 
 { return (status1.getLSRange().first < status2.getLSRange().first); }
 
-
 void SiPixelStatusManager::createPayloads(){
+  if(siPixelStatusVtr_.size()>0){ //only create std::map payloads when the number of non-zero DIGI lumi sections is greater than ZERO otherwise segmentation fault
+
    // sort the vector according to lumi
    std::sort(siPixelStatusVtr_.begin(), siPixelStatusVtr_.end(), SiPixelStatusManager::rankByLumi);
    
@@ -64,6 +65,9 @@ void SiPixelStatusManager::createPayloads(){
      
    // realse the cost of siPixelStatusVtr_ since it is not needed anymore
    siPixelStatusVtr_.clear();
+
+  }
+
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
@@ -54,7 +54,7 @@ bool SiPixelStatusManager::rankByLumi(SiPixelDetectorStatus status1,SiPixelDetec
 { return (status1.getLSRange().first < status2.getLSRange().first); }
 
 void SiPixelStatusManager::createPayloads(){
-  if(siPixelStatusVtr_.size()>0){ //only create std::map payloads when the number of non-zero DIGI lumi sections is greater than ZERO otherwise segmentation fault
+  if(!siPixelStatusVtr_.empty()){ //only create std::map payloads when the number of non-zero DIGI lumi sections is greater than ZERO otherwise segmentation fault
 
    // sort the vector according to lumi
    std::sort(siPixelStatusVtr_.begin(), siPixelStatusVtr_.end(), SiPixelStatusManager::rankByLumi);


### PR DESCRIPTION
Hello,
  the PR is to protect the SiPixelQuality harvester from the segmentation fault when the data are full of zero pixel DIGI lumi sections (the length of the vector for SiPixelDectectorStatus is zero). This could happen for in the cosmic runs.

Sincerely,
Tongguang Cheng