### PR TITLE
ignore MemoryCheck in LogError skims

### DIFF
--- a/FWCore/Modules/python/logErrorFilter_cfi.py
+++ b/FWCore/Modules/python/logErrorFilter_cfi.py
@@ -5,7 +5,7 @@ logErrorFilter = cms.EDFilter("LogErrorFilter",
                               atLeastOneError = cms.bool(True),
                               atLeastOneWarning = cms.bool(True),
                               useThresholdsPerKind = cms.bool(False),
-                              avoidCategories = cms.vstring()
+                              avoidCategories = cms.vstring('MemoryCheck')
                               )
 
 logErrorSkimFilter = cms.EDFilter("LogErrorFilter",
@@ -15,6 +15,6 @@ logErrorSkimFilter = cms.EDFilter("LogErrorFilter",
                               useThresholdsPerKind = cms.bool(True),
                               maxErrorKindsPerLumi = cms.uint32(1),    
                               maxWarningKindsPerLumi = cms.uint32(1),    
-                              avoidCategories = cms.vstring()
+                              avoidCategories = cms.vstring('MemoryCheck', 'HLTObjectsMonitor')
                               )
 

--- a/FWCore/Modules/python/logErrorFilter_cfi.py
+++ b/FWCore/Modules/python/logErrorFilter_cfi.py
@@ -15,6 +15,6 @@ logErrorSkimFilter = cms.EDFilter("LogErrorFilter",
                               useThresholdsPerKind = cms.bool(True),
                               maxErrorKindsPerLumi = cms.uint32(1),    
                               maxWarningKindsPerLumi = cms.uint32(1),    
-                              avoidCategories = cms.vstring('MemoryCheck', 'HLTObjectsMonitor')
+                              avoidCategories = cms.vstring('MemoryCheck')
                               )
 


### PR DESCRIPTION
backport of #23153 

LogError skim is currently flooded by the MemoryCheck and less significantly by HLTObjectsMonitor LogWarning categories.
This PR should skip both during LogError RAW-RECO skimming and skip MemoryCheck for the LogErrorMonitor skim .

