### PR TITLE
Minor cleanup and interface changes

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -258,7 +258,7 @@ protected:
    //---------------------------------------------------------------------------
    //  Geometrical services to subclasses.
    //---------------------------------------------------------------------------
-private:
+protected:
    void computeAnglesFromDetPosition( DetParam const & theDetParam, ClusterParam & theClusterParam ) const;
    
    void computeAnglesFromTrajectory ( DetParam const & theDetParam, ClusterParam & theClusterParam,

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackBuilder.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackBuilder.cc
@@ -23,6 +23,7 @@ using namespace reco;
 template <class T> T inline sqr( T t) {return t*t;}
 
 namespace {
+  __attribute__((unused))
   std::string print(
 		    const Measurement1D & pt,
 		    const Measurement1D & phi,
@@ -33,28 +34,30 @@ namespace {
 		    int   charge)
   {
     ostringstream str;
-    str <<"\t pt: "  << pt.value() <<"+/-"<<pt.error()  
-        <<"\t phi: " << phi.value() <<"+/-"<<phi.error()
-        <<"\t cot: " << cotTheta.value() <<"+/-"<<cotTheta.error()
-        <<"\t tip: " << tip.value() <<"+/-"<<tip.error()
-        <<"\t zip: " << zip.value() <<"+/-"<<zip.error()
+    str <<"\t pt: "  << pt.value() <<"+/-"<< pt.error()
+        <<"\t phi: " << phi.value() <<"+/-"<< phi.error()
+        <<"\t cot: " << cotTheta.value() <<"+/-"<< cotTheta.error()
+        <<"\t tip: " << tip.value() <<"+/-"<< tip.error()
+        <<"\t zip: " << zip.value() <<"+/-"<< zip.error()
+        <<"\t chi2: " << chi2
         <<"\t charge: " << charge;
     return str.str();
   }
 
+  __attribute__((unused))
   std::string print(const reco::Track & track, const GlobalPoint & origin)
   {
-    
+
     math::XYZPoint bs(origin.x(), origin.y(), origin.z());
-    
+
     Measurement1D phi( track.phi(), track.phiError());
-    
+
     float theta = track.theta();
     float cosTheta = cos(theta);
     float sinTheta = sin(theta);
     float errLambda2 = sqr( track.lambdaError() );
     Measurement1D cotTheta(cosTheta/sinTheta, sqrt(errLambda2)/sqr(sinTheta));
-    
+
     float pt_v = track.pt();
     float errInvP2 = sqr(track.qoverpError());
     float covIPtTheta = track.covariance(TrackBase::i_qoverp, TrackBase::i_lambda);
@@ -63,21 +66,22 @@ namespace {
 			  + 2*(cosTheta/pt_v)*covIPtTheta
 			  ) / sqr(sinTheta);
     Measurement1D pt(pt_v, sqr(pt_v)*sqrt(errInvPt2));
-    
+
     Measurement1D tip(track.dxy(bs), track.d0Error());
-    
+
     Measurement1D zip(track.dz(bs), track.dzError());
-    
-    return print(pt, phi, cotTheta, tip, zip, track.chi2(),  track.charge());
+
+    return print(pt, phi, cotTheta, tip, zip, track.chi2(), track.charge());
   }
-  
-  std::string print(const  BasicTrajectoryStateOnSurface & state)
+
+  __attribute__((unused))
+  std::string print(const BasicTrajectoryStateOnSurface & state)
   {
     // TrajectoryStateOnSurface state(bstate);
     float pt_v = state.globalMomentum().perp();
     float phi_v = state.globalMomentum().phi();
     float theta_v = state.globalMomentum().theta();
-    
+
     CurvilinearTrajectoryError curv = state.curvilinearError();
     float errPhi2 = curv.matrix()(3,3);
     float errLambda2 = curv.matrix()(2,2);
@@ -92,16 +96,16 @@ namespace {
     Measurement1D pt(pt_v, sqr(pt_v) * sqrt(errInvPt2));
     Measurement1D phi(phi_v, sqrt(errPhi2) );
     Measurement1D cotTheta(cosTheta/sinTheta, errCotTheta);
-    
+
     float zip_v = state.globalPosition().z();
     float zip_e = sqrt( state.localError().matrix()(4,4));
     Measurement1D zip(zip_v, zip_e);
-    
-    float tip_v  = state.localPosition().x(); 
+
+    float tip_v  = state.localPosition().x();
     int tip_sign = (state.localMomentum().y()*cotTheta.value() > 0) ? -1 : 1;
     float tip_e  = sqrt( state.localError().matrix()(3,3) );
     Measurement1D tip( tip_sign*tip_v, tip_e);
-    
+
     return print(pt, phi, cotTheta, tip, zip, 0., state.charge());
   }
 
@@ -109,21 +113,21 @@ namespace {
   inline void checkState(const  BasicTrajectoryStateOnSurface & bstate, const MagneticField* mf, const GlobalPoint & origin)
   {
     TrajectoryStateOnSurface state(bstate.clone());
-    
-    LogTrace("")<<" *** PixelTrackBuilder::checkState: ";
-    LogTrace("")<<"INPUT,  ROTATION" << endl<<state.surface().rotation();
-    LogTrace("")<<"INPUT,  TSOS:"<<endl<<state;
-    
+
+    LogTrace("") << " *** PixelTrackBuilder::checkState: ";
+    LogTrace("") << "INPUT,  ROTATION" << '\n' << state.surface().rotation();
+    LogTrace("") << "INPUT,  TSOS:"<< '\n' << state;
+
     TransverseImpactPointExtrapolator tipe(mf);
     TrajectoryStateOnSurface test= tipe.extrapolate(state, origin);
-    LogTrace("")<<"CHECK-1 ROTATION" << endl<<"\n"<<test.surface().rotation();
-    LogTrace("")<<"CHECK-1 TSOS" << endl<<test;
-    
+    LogTrace("") << "CHECK-1 ROTATION" << '\n' << test.surface().rotation();
+    LogTrace("") << "CHECK-1 TSOS" << '\n' << test;
+
     TSCPBuilderNoMaterial tscpBuilder;
     TrajectoryStateClosestToPoint tscp =
       tscpBuilder(*(state.freeState()), origin);
     const FreeTrajectoryState& fs = tscp.theState();
-    LogTrace("")<<"CHECK-2 FTS: " << fs;
+    LogTrace("") << "CHECK-2 FTS: " << fs;
   }
 
 }
@@ -131,19 +135,19 @@ namespace {
 
 reco::Track * PixelTrackBuilder::build(
       const Measurement1D & pt,
-      const Measurement1D & phi, 
+      const Measurement1D & phi,
       const Measurement1D & cotTheta,
-      const Measurement1D & tip,  
+      const Measurement1D & tip,
       const Measurement1D & zip,
       float chi2,
       int   charge,
       const std::vector<const TrackingRecHit* >& hits,
       const MagneticField * mf,
-      const GlobalPoint   & origin) const 
+      const GlobalPoint   & origin) const
 {
 
   LogDebug("PixelTrackBuilder::build");
-  LogTrace("")<<"reconstructed TRIPLET kinematics:\n"<<print(pt,phi,cotTheta,tip,zip,chi2,charge);
+  LogTrace("") << "Reconstructed triplet kinematics: " << print(pt,phi,cotTheta,tip,zip,chi2,charge);
 
   double sinTheta = 1/std::sqrt(1+sqr(cotTheta.value()));
   double cosTheta = cotTheta.value()*sinTheta;
@@ -167,7 +171,7 @@ reco::Track * PixelTrackBuilder::build(
     LocalVector(0., -tipSign*pt.value()*cotTheta.value(), pt.value()),
     charge);
 
-  
+
   float sp = std::sin(phi.value());
   float cp = std::cos(phi.value());
   Surface::RotationType rot(
@@ -176,15 +180,15 @@ reco::Track * PixelTrackBuilder::build(
 			    cp        ,  sp        ,           0);
 
   // BTSOS hold Surface in a shared pointer and  will be autodeleted when BTSOS goes out of scope...
-  // to avoid memory churn we allocate it locally and just avoid it be deleted by refcount... 
+  // to avoid memory churn we allocate it locally and just avoid it be deleted by refcount...
   Plane impPointPlane(origin, rot);
   // (twice just to be sure!)
   impPointPlane.addReference(); impPointPlane.addReference();
-  // use Base (to avoid a useless new) 
+  // use Base (to avoid a useless new)
   BasicTrajectoryStateOnSurface impactPointState( lpar , error, impPointPlane, mf);
-  
+
   //checkState(impactPointState,mf);
-  LogTrace("")<<"constructed TSOS :\n"<<print(impactPointState);
+  LogTrace("") << "constructed TSOS:\n" << print(impactPointState);
 
   int ndof = 2*hits.size()-5;
   GlobalPoint vv = impactPointState.globalPosition();
@@ -192,11 +196,9 @@ reco::Track * PixelTrackBuilder::build(
   GlobalVector pp = impactPointState.globalMomentum();
   math::XYZVector mom( pp.x(), pp.y(), pp.z() );
 
-  reco::Track * track = new reco::Track( chi2, ndof, pos, mom, 
+  reco::Track * track = new reco::Track( chi2, ndof, pos, mom,
         impactPointState.charge(), impactPointState.curvilinearError());
 
-  LogTrace("") <<"RECONSTRUCTED TRACK (0,0,0):\n"<< print(*track,GlobalPoint(0,0,0))<<std::endl;
-  LogTrace("") <<"RECONSTRUCTED TRACK "<<origin<<"\n"<< print(*track,origin)<<std::endl;
 
   return track;
 }


### PR DESCRIPTION
Minor cleanup of `PixelTrackBuilder`:
  - replace `std::cout` with `LogTrace`;
  - mark debugging functions as possibly unused.

Relax interface constraints to allow inheritance from `PixelCPEBase`