### PR TITLE
fixes in assignment of SimTracks/SimVertices

### DIFF
--- a/FastSimulation/Calorimetry/src/CalorimetryManager.cc
+++ b/FastSimulation/Calorimetry/src/CalorimetryManager.cc
@@ -1333,10 +1333,10 @@ void CalorimetryManager::harvestMuonSimTracks(edm::SimTrackContainer &c) const
 {
   c.reserve(int(0.2*muonSimTracks.size()+0.2*savedMuonSimTracks.size()+0.5));
   for(const auto & track : muonSimTracks){
-    if(track.momentum().perp2() > 1.0 && fabs(track.momentum().eta()) < 3.0)  c.push_back(track);
+    if(track.momentum().perp2() > 1.0 && fabs(track.momentum().eta()) < 3.0 && track.isGlobal())  c.push_back(track);
   }
   for(const auto & track : savedMuonSimTracks){
-    if(track.momentum().perp2() > 1.0 && fabs(track.momentum().eta()) < 3.0)  c.push_back(track);
+    if(track.momentum().perp2() > 1.0 && fabs(track.momentum().eta()) < 3.0 && track.isGlobal())  c.push_back(track);
   }
   c.shrink_to_fit();
 }

--- a/FastSimulation/Event/interface/FSimTrack.h
+++ b/FastSimulation/Event/interface/FSimTrack.h
@@ -149,6 +149,12 @@ class FSimTrack : public SimTrack {
   /// The particle at HCAL exir
   inline const RawParticle& hoEntrance() const { return HO_Entrance; }
 
+  /// particle did not decay before more detectors (useful for newProducer)
+  inline bool isGlobal() const { return isGlobal_; }
+
+  /// particle did not decay before more detectors (useful for newProducer)
+  inline void setGlobal() { isGlobal_ = true; }
+
   /// Set origin vertex
   inline void setOriginVertex(const SimVertex& v) { vertex_ = v; } 
 
@@ -246,6 +252,8 @@ class FSimTrack : public SimTrack {
   XYZTLorentzVector momentum_;
 
   double properDecayTime; // The proper decay time  (default is -1)
+
+  bool isGlobal_; // needed for interfacing the new particle propagator with the old muon sim hit code
 
 };
 

--- a/FastSimulation/Event/src/FSimTrack.cc
+++ b/FastSimulation/Event/src/FSimTrack.cc
@@ -33,8 +33,8 @@ FSimTrack::FSimTrack(int ipart, const math::XYZTLorentzVector& p, int iv, int ig
   SimTrack(ipart, p, iv, ig, math::XYZVectorD(tkp.X(), tkp.Y(), tkp.Z()),  tkm), vertex_(tkv),
   mom_(nullptr), id_(id), charge_(charge), endv_(-1),
   layer1(0), layer2(0), ecal(0), hcal(0), vfcal(0), hcalexit(0), hoentr(0), prop(false),
-  closestDaughterId_(-1), info_(nullptr), momentum_(tkm),
-  properDecayTime(-1)
+  closestDaughterId_(-1), info_(nullptr), momentum_(p),
+  properDecayTime(-1), isGlobal_(false)
   {
     setTrackId(id);
   }

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -87,6 +87,9 @@ namespace fastsim {
         //! Returns the position of a given SimVertex. Needed for interfacing the code with the old calorimetry.
         const SimVertex getSimVertex(unsigned i) { return simVertices_->at(i); }
 
+        //! Returns a given SimTrack. Needed for interfacing the code with the old calorimetry.
+        const SimTrack getSimTrack(unsigned i) { return simTracks_->at(i); }
+
         //! Necessary to add an end vertex to a particle.
         /*!
             Needed if particle is no longer propagated for some reason (e.g. remaining energy below threshold) and no
@@ -121,6 +124,13 @@ namespace fastsim {
             Tries to get some basic information about the status of the particle from the GenEvent and does some first rejection cuts based on them.
         */
         std::unique_ptr<Particle> nextGenParticle();
+
+        //! Set lifetime and charge of a particle
+        /*!
+            Set lifetime and charge of a particle according to its pdgId, typically used for secondaries produced in an interaction
+            \param particle A generic particle.
+        */
+        void setParticleData(std::unique_ptr<fastsim::Particle> & particle);
 
         // data members
         const HepMC::GenEvent * const genEvent_;  //!< The GenEvent 

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -125,13 +125,6 @@ namespace fastsim {
         */
         std::unique_ptr<Particle> nextGenParticle();
 
-        //! Set lifetime and charge of a particle
-        /*!
-            Set lifetime and charge of a particle according to its pdgId, typically used for secondaries produced in an interaction
-            \param particle A generic particle.
-        */
-        void setParticleData(std::unique_ptr<fastsim::Particle> & particle);
-
         // data members
         const HepMC::GenEvent * const genEvent_;  //!< The GenEvent 
         HepMC::GenEvent::particle_const_iterator genParticleIterator_;  //!< Iterator to keep track on which GenParticles where already considered.

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
@@ -402,7 +402,15 @@ FastSimProducer::endStream()
 FSimTrack
 FastSimProducer::createFSimTrack(fastsim::Particle* particle, fastsim::ParticleManager* particleManager)
 {
-    FSimTrack myFSimTrack(particle->pdgId(), particle->momentum(), particle->simVertexIndex(), particle->genParticleIndex(), particle->simTrackIndex(), particle->charge(), particle->position(), particle->momentum(), particleManager->getSimVertex(particle->simVertexIndex()));
+    FSimTrack myFSimTrack(particle->pdgId(),
+        particleManager->getSimTrack(particle->simTrackIndex()).momentum(),
+        particle->simVertexIndex(),
+        particle->genParticleIndex(),
+        particle->simTrackIndex(),
+        particle->charge(),
+        particle->position(),
+        particle->momentum(),
+        particleManager->getSimVertex(particle->simVertexIndex()));
 
     // move the particle through the caloLayers
     fastsim::LayerNavigator caloLayerNavigator(caloGeometry_);
@@ -455,6 +463,7 @@ FastSimProducer::createFSimTrack(fastsim::Particle* particle, fastsim::ParticleM
             // not necessary to continue propagation
             if(caloLayer->getCaloType() == fastsim::SimplifiedGeometry::VFCAL)
             {
+                myFSimTrack.setGlobal();
                 caloLayer = nullptr;
                 break;
             }
@@ -528,6 +537,7 @@ FastSimProducer::createFSimTrack(fastsim::Particle* particle, fastsim::ParticleM
         // Particle reached end of detector
         if(caloLayer->getCaloType() == fastsim::SimplifiedGeometry::VFCAL)
         {
+            myFSimTrack.setGlobal();
             caloLayer = nullptr;
             break;
         }

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/TrackerSimHitProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/TrackerSimHitProducer.cc
@@ -205,7 +205,8 @@ void fastsim::TrackerSimHitProducer::interact(Particle & particle,const Simplifi
                                 particle.position().z()-particle.momentum().z()/particle.momentum().P()*10.);
 
     // FastSim: cheat tracking -> assign hits to closest charged daughter if particle decays
-    int pdgId = particle.getMotherDeltaR() == -1 ? particle.pdgId() : particle.getMotherPdgId();
+    int pdgId = particle.pdgId();
+    int simTrackId = particle.getMotherSimTrackIndex() >=0 ? particle.getMotherSimTrackIndex() : particle.simTrackIndex();
 
     // loop over the compatible detectors
     for (const auto & detectorWithState : compatibleDetectors)
@@ -216,7 +217,7 @@ void fastsim::TrackerSimHitProducer::interact(Particle & particle,const Simplifi
         // if the detector has no components
         if(detector.isLeaf())
         {
-            std::pair<double, PSimHit*> hitPair = createHitOnDetector(particleState, pdgId, layer.getThickness(particle.position()), energyDeposit, particle.simTrackIndex(), detector, positionOutside);
+            std::pair<double, PSimHit*> hitPair = createHitOnDetector(particleState, pdgId, layer.getThickness(particle.position()), energyDeposit, simTrackId, detector, positionOutside);
             if(hitPair.second){
                 distAndHits.insert(distAndHits.end(), hitPair);
             }
@@ -226,7 +227,7 @@ void fastsim::TrackerSimHitProducer::interact(Particle & particle,const Simplifi
             // if the detector has components
             for(const auto component : detector.components())
             {
-                std::pair<double, PSimHit*> hitPair = createHitOnDetector(particleState, pdgId,layer.getThickness(particle.position()), energyDeposit, particle.simTrackIndex(), *component, positionOutside);            
+                std::pair<double, PSimHit*> hitPair = createHitOnDetector(particleState, pdgId,layer.getThickness(particle.position()), energyDeposit, simTrackId, *component, positionOutside);            
                 if(hitPair.second){
                     distAndHits.insert(distAndHits.end(), hitPair);
                 }

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -215,21 +215,12 @@ unsigned fastsim::ParticleManager::addSimVertex(
 
 unsigned fastsim::ParticleManager::addSimTrack(const fastsim::Particle * particle)
 {
-    int simTrackIndex;
-    // Again: FastSim cheat tracking -> continue track of mother
-    if(particle->getMotherDeltaR() != -1){
-        simTrackIndex = particle->getMotherSimTrackIndex();
-    }
-    // or create new SimTrack
-    else
-    {
-        simTrackIndex = simTracks_->size();
-        simTracks_->emplace_back(particle->pdgId(),
-                    particle->momentum(),
-                    particle->simVertexIndex(),
-                    particle->genParticleIndex());
-        simTracks_->back().setTrackId(simTrackIndex);
-    }
+    int simTrackIndex = simTracks_->size();
+    simTracks_->emplace_back(particle->pdgId(),
+                particle->momentum(),
+                particle->simVertexIndex(),
+                particle->genParticleIndex());
+    simTracks_->back().setTrackId(simTrackIndex);
     return simTrackIndex;
 }
 
@@ -286,10 +277,17 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
             newParticle->setRemainingProperLifeTimeC(labFrameLifeTime / newParticle->gamma() * fastsim::Constants::speedOfLight);
         }
 
-        // TODO: The products of a b-decay should point to that vertex and not to the primary vertex!
-        // Seems like this information has to be taken from the genEvent. How to do this? Is this really neccessary?
-        // See FBaseSimEvent::fill(..)
-        newParticle->setSimVertexIndex(0);
+        // Find production vertex if it already exists. Otherwise create new vertex
+        // Possible to recreate the whole GenEvent using SimTracks/SimVertices (see FBaseSimEvent::fill(..))
+        bool foundVtx = false;
+        for(const auto& simVtx : *simVertices_){
+            if(std::abs(simVtx.position().x() - newParticle->position().x()) < 1E-3 && std::abs(simVtx.position().y() - newParticle->position().y()) < 1E-3 && std::abs(simVtx.position().z() - newParticle->position().z()) < 1E-3){
+                newParticle->setSimVertexIndex(simVtx.vertexId());
+                foundVtx = true;
+                break;
+            }
+        }        
+        if(!foundVtx) newParticle->setSimVertexIndex(addSimVertex(newParticle->position(), -1));
 
         // iterator/index has to be increased in case of return (is not done by the loop then)
         ++genParticleIterator_; ++genParticleIndex_;


### PR DESCRIPTION
Two issues in the muon validation were observed for the new FastSim ParticlePropagator:
1) Significant amount of fake standalone muons with low pt
2) Increase of residuals/pulls for global muons

Both issues have been fixed and the muon efficiency distributions behave as expected.