### PR TITLE
Allow use of HCAL digi collections without instance labels in HcalRealisticZS

### DIFF
--- a/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
@@ -9,6 +9,7 @@ import FWCore.ParameterSet.Config as cms
 
 simHcalDigis = cms.EDProducer("HcalRealisticZS",
     digiLabel = cms.string("simHcalUnsuppressedDigis"),
+    useInstanceLabels = cms.bool(True),
     markAndPass = cms.bool(False),
     HBlevel = cms.int32(8),
     HElevel = cms.int32(9),

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
@@ -13,13 +13,16 @@ HcalRealisticZS::HcalRealisticZS(edm::ParameterSet const& conf):
   inputLabel_(conf.getParameter<std::string>("digiLabel")) {
 
   bool markAndPass=conf.getParameter<bool>("markAndPass");
+  bool useInstanceLabels=conf.getParameter<bool>("useInstanceLabels");
 
   // register for data access
   tok_hbhe_ = consumes<HBHEDigiCollection>(edm::InputTag(inputLabel_));
   tok_ho_ = consumes<HODigiCollection>(edm::InputTag(inputLabel_));
   tok_hf_ = consumes<HFDigiCollection>(edm::InputTag(inputLabel_));
-  tok_hfQIE10_ = consumes<QIE10DigiCollection>(edm::InputTag(inputLabel_, "HFQIE10DigiCollection"));
-  tok_hbheQIE11_ = consumes<QIE11DigiCollection>(edm::InputTag(inputLabel_, "HBHEQIE11DigiCollection"));
+  tok_hfQIE10_ = consumes<QIE10DigiCollection>(edm::InputTag(inputLabel_,
+							     useInstanceLabels ? "HFQIE10DigiCollection" : "" ));
+  tok_hbheQIE11_ = consumes<QIE11DigiCollection>(edm::InputTag(inputLabel_,
+							       useInstanceLabels ? "HBHEQIE11DigiCollection" : ""));
 
 
   std::vector<int> tmp = conf.getParameter<std::vector<int> >("HBregion");


### PR DESCRIPTION
The code that implements the HCAL zero suppression currently has hard-coded instance labels that are appropriate for use on simulated data. For studies of the behavior of the zero suppression algorithm, it is useful to run the same code on non-zero-suppressed real data. In the case of real data, however, there are no such instance labels. This PR introduces a configuration parameter that allows for disabling instance labels in the InputTags for the digi collections so that HcalRealisticZS can be configured properly in this case.

As the default behavior is unchanged, no changes are expected in any standard workflow.