### PR TITLE
Remove unused variable causing compiler warning

### DIFF
--- a/CalibTracker/SiPixelQuality/src/SiPixelModuleStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelModuleStatus.cc
@@ -93,7 +93,7 @@ void SiPixelModuleStatus::setNrocs(int iroc) {
 // ----------------------------------------------------------------------
 double SiPixelModuleStatus::perRocDigiOcc() {
 
-  unsigned int ave(0), sig(0);
+  unsigned int ave(0);
   for (int iroc = 0; iroc < fNrocs; ++iroc) {
     unsigned int inc = digiOccROC(iroc);
     ave += inc;


### PR DESCRIPTION
Trivial fix for compiler warning due to an unused variable, backport of #22984