### PR TITLE
LogWarning->LogInfo in HLTObjectsMonitor for "objects have different ID" check

### DIFF
--- a/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
+++ b/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
@@ -503,7 +503,7 @@ HLTObjectsMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 		plot.q1q2ME.first->Fill(q1q2);
 
 		if ( abs(id) != abs(id2) )
-		  edm::LogWarning ("HLTObjectsMonitor") << plot.pathNAME << " " << plot.moduleNAME << " objects have different ID !?!" << abs(id) << " and " << abs(id2);
+		  edm::LogInfo ("HLTObjectsMonitor") << plot.pathNAME << " " << plot.moduleNAME << " objects have different ID !?!" << abs(id) << " and " << abs(id2);
 
 		if( (id+id2 ) == 0 ) {   // check di-object system charge and flavor
 		  


### PR DESCRIPTION

Warnings like
```
%MSG-w HLTObjectsMonitor:  HLTObjectsMonitor:hltObjectsMonitor4all  02-May-2018 17:24:34 UTC Run: 315420 Event: 180590874
HLT_PFHT1050 hltPFHT1050Jet30 objects have different ID !?!89 and 0
```
represent about 60% of all LogWarnings (excluding the MemoryCheck "warnings") in recent data taking (numbers derived from run 315420 LS 1711 - 1719 in JetHT PD).
It looks like cross-triggers (HLTHtMhtFilter in this case) normally produce different object types. A normal behavior can not be used to issue a LogWarning.



