### PR TITLE
Improve RootHandlers

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <vector>
 #include <string>
+#include <array>
 
 // WORKAROUND: At CERN, execv is replaced with a non-async-signal safe
 // version.  This can break our stack trace printer.  Avoid this by
@@ -149,11 +150,12 @@ namespace {
 
   bool s_ignoreEverything = false;
 
-  bool find_if_string(const std::string& search, const std::vector<std::string>& substrs){
-    return (find_if(substrs.begin(), substrs.end(), [&search](const std::string& s) -> bool { return (search.find(s) != std::string::npos); }) != substrs.end());
+  template<std::size_t SIZE>
+  bool find_if_string(const std::string& search, const std::array<const char* const,SIZE>& substrs){
+    return (std::find_if(substrs.begin(), substrs.end(), [&search](const char* const s) -> bool { return (search.find(s) != std::string::npos); }) != substrs.end());
   }
 
-  const std::vector<std::string> in_message{
+  constexpr std::array<const char* const,8> in_message{{
     "no dictionary for class",
     "already in TClassTable",
     "matrix not positive definite",
@@ -162,22 +164,22 @@ namespace {
     "Announced number of args different from the real number of argument passed", // Always printed if gDebug>0 - regardless of whether warning message is real.
     "nbins is <=0 - set to nbins = 1",
     "nbinsy is <=0 - set to nbinsy = 1"
-  };
+  }};
 
-  const std::vector<std::string> in_location{
+  constexpr std::array<const char* const,6> in_location{{
     "Fit",
     "TDecompChol::Solve",
     "THistPainter::PaintInit",
     "TUnixSystem::SetDisplay",
     "TGClient::GetFontByName",
     "Inverter::Dinv"
-  };
+  }};
 
-  const std::vector<std::string> in_message_print{
+  constexpr std::array<const char* const,3> in_message_print{{
     "number of iterations was insufficient",
     "bad integrand behavior",
     "integral is divergent, or slowly convergent"
-  };
+  }};
 
   void RootErrorHandlerImpl(int level, char const* location, char const* message) {
 

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -153,6 +153,32 @@ namespace {
     return (find_if(substrs.begin(), substrs.end(), [&search](const std::string& s) -> bool { return (search.find(s) != std::string::npos); }) != substrs.end());
   }
 
+  const std::vector<std::string> in_message{
+    "no dictionary for class",
+    "already in TClassTable",
+    "matrix not positive definite",
+    "not a TStreamerInfo object",
+    "Problems declaring payload",
+    "Announced number of args different from the real number of argument passed", // Always printed if gDebug>0 - regardless of whether warning message is real.
+    "nbins is <=0 - set to nbins = 1",
+    "nbinsy is <=0 - set to nbinsy = 1"
+  };
+
+  const std::vector<std::string> in_location{
+    "Fit",
+    "TDecompChol::Solve",
+    "THistPainter::PaintInit",
+    "TUnixSystem::SetDisplay",
+    "TGClient::GetFontByName",
+    "Inverter::Dinv"
+  };
+
+  const std::vector<std::string> in_message_print{
+    "number of iterations was insufficient",
+    "bad integrand behavior",
+    "integral is divergent, or slowly convergent"
+  };
+
   void RootErrorHandlerImpl(int level, char const* location, char const* message) {
 
   bool die = false;
@@ -227,26 +253,6 @@ namespace {
 
   // Intercept some messages and downgrade the severity
 
-      std::vector<std::string> in_message = {
-        "no dictionary for class",
-        "already in TClassTable",
-        "matrix not positive definite",
-        "not a TStreamerInfo object",
-        "Problems declaring payload",
-        "Announced number of args different from the real number of argument passed", // Always printed if gDebug>0 - regardless of whether warning message is real.
-        "nbins is <=0 - set to nbins = 1",
-        "nbinsy is <=0 - set to nbinsy = 1"
-      };
-
-      std::vector<std::string> in_location = {
-        "Fit",
-        "TDecompChol::Solve",
-        "THistPainter::PaintInit",
-        "TUnixSystem::SetDisplay",
-        "TGClient::GetFontByName",
-        "Inverter::Dinv"
-      };
-
       if (find_if_string(el_message,in_message) ||
           find_if_string(el_location,in_location) ||
           (level < kError and (el_location.find("CINTTypedefBuilder::Setup")!= std::string::npos) and (el_message.find("possible entries are in use!") != std::string::npos)))
@@ -256,11 +262,6 @@ namespace {
 
       // These are a special case because we do not want them to
       // be fatal, but we do want an error to print.
-      std::vector<std::string> in_message_print = {
-        "number of iterations was insufficient",
-        "bad integrand behavior",
-        "integral is divergent, or slowly convergent"
-      };
       bool alreadyPrinted = false;
       if (find_if_string(el_message,in_message_print))
       {

--- a/FWCore/Utilities/interface/RootHandlers.h
+++ b/FWCore/Utilities/interface/RootHandlers.h
@@ -5,10 +5,19 @@
 namespace edm {
   class EventProcessor;
   class RootHandlers {
+  public:
+    enum class SeverityLevel {
+      kInfo,
+      kWarning,
+      kError,
+      kSysError,
+      kFatal
+    };
+
   private:
     struct WarningSentry {
-      WarningSentry(RootHandlers* iHandler): m_handler(iHandler){
-        m_handler->ignoreWarnings_();
+      WarningSentry(RootHandlers* iHandler, SeverityLevel level): m_handler(iHandler){
+        m_handler->ignoreWarnings_(level);
       };
       ~WarningSentry() {
         m_handler->enableWarnings_();
@@ -19,12 +28,11 @@ namespace edm {
     friend class edm::EventProcessor;
 
   public:
-    RootHandlers () {}
     virtual ~RootHandlers () {}
 
     template<typename F>
-    void ignoreWarningsWhileDoing(F iFunc) {
-      WarningSentry sentry(this);
+    void ignoreWarningsWhileDoing(F iFunc, SeverityLevel level=SeverityLevel::kWarning) {
+      WarningSentry sentry(this,level);
       iFunc();
     }
     
@@ -32,7 +40,7 @@ namespace edm {
     virtual void willBeUsingThreads() = 0;
     
     virtual void enableWarnings_() = 0;
-    virtual void ignoreWarnings_() = 0;
+    virtual void ignoreWarnings_(SeverityLevel level) = 0;
   };
 }  // end of namespace edm
 


### PR DESCRIPTION
Two changes:
1. Technical modification to reduce code duplication and make it easier to add specific messages to be downgraded.
2. Moderate refactoring to allow the use of `ignoreWarningsWhileDoing()` with any severity level (not just `kWarning`).

These changes were inspired by issues I found while integrating GeantV with CMSSW.