### PR TITLE
reduce cases of LogWarnings with InvalidHelix category in Pixel/Strip ClusterShape compatibility checks

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeSeedComparitor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeSeedComparitor.cc
@@ -89,7 +89,9 @@ PixelClusterShapeSeedComparitor::compatible(const SeedingHitSet  &hits,
 { 
     if (!filterAtHelixStage_) return true;
 
-    if(!helix.isValid()) edm::LogWarning("InvalidHelix") << "PixelClusterShapeSeedComparitor helix is not valid, result is bad";
+    if(!helix.isValid() //check still if it's a straight line, which are OK
+       && !helix.circle().isLine())//complain if it's not even a straight line
+      edm::LogWarning("InvalidHelix") << "PixelClusterShapeSeedComparitor helix is not valid, result is bad";
 
     float xc = helix.circle().x0(), yc = helix.circle().y0();
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
@@ -369,7 +369,9 @@ bool StripSubClusterShapeSeedFilter::compatible
 { 
    if (!filterAtHelixStage_) return true;
 
-   if (!helix.isValid()) edm::LogWarning("InvalidHelix") << "PixelClusterShapeSeedComparitor helix is not valid, result is bad";
+   if (!helix.isValid() //check still if it's a straight line, which are OK
+       && !helix.circle().isLine())//complain if it's not even a straight line
+     edm::LogWarning("InvalidHelix") << "StripSubClusterShapeSeedFilter helix is not valid, result is bad";
 
     float xc = helix.circle().x0(), yc = helix.circle().y0();
 

--- a/RecoTracker/TkSeedGenerator/interface/FastCircle.h
+++ b/RecoTracker/TkSeedGenerator/interface/FastCircle.h
@@ -54,6 +54,8 @@ public:
   double rho() const {return theRho;}
   
   bool isValid() const {return theValid;}
+
+  bool isLine() const {return theIsLine;}
   
   // parameters of the straight line 
   // (if circle is invalid only these are available) 
@@ -84,6 +86,7 @@ private:
   double theC;
   
   bool theValid;
+  bool theIsLine;
   
   void createCircleParameters() dso_hidden;
    

--- a/RecoTracker/TkSeedGenerator/src/FastCircle.cc
+++ b/RecoTracker/TkSeedGenerator/src/FastCircle.cc
@@ -14,7 +14,8 @@ FastCircle::FastCircle(const GlobalPoint& outerHit,
   theN1(0.),
   theN2(0.),
   theC(0.),
-  theValid(true) {
+  theValid(true),
+  theIsLine(false) {
 
   createCircleParameters();
   
@@ -34,7 +35,8 @@ FastCircle::FastCircle(const GlobalPoint& outerHit,
   theN1(0.),
   theN2(0.),
   theC(0.),
-  theValid(true) {
+  theValid(true),
+  theIsLine(false) {
 
   createCircleParameters();
   
@@ -89,6 +91,7 @@ void FastCircle::createCircleParameters() {
     // numeric limit
     // circle is more a straight line...
     theValid = false;
+    theIsLine = true;
     return;
   }
 


### PR DESCRIPTION
InvalidHelix is one of the leading LogWarnings in current pp processing.
It turns out that a large fraction (all?) of the warnings corresponds to the reference helix considered "invalid" because it was reduced to a straight line. This is actually a valid input.

FastCircle::isLine method is added to make the simple test.

There is no change to the physics results of the algorithms. A LogWarning is simply not issued anymore in the case that appears to already have a correct behavior.
