### PR TITLE
Fix Herwig7 LHE file reading

### DIFF
--- a/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
+++ b/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
@@ -1,5 +1,6 @@
 #include <memory>
 #include <sstream>
+#include <fstream>
 
 #include <HepMC/GenEvent.h>
 #include <HepMC/IO_BaseClass.h>
@@ -58,16 +59,19 @@ class Herwig7Hadronizer : public Herwig7Interface, public gen::BaseHadronizer {
 	
 	boost::shared_ptr<lhef::LHEProxy> proxy_;
 	const std::string		handlerDirectory_;
+	edm::ParameterSet 	paramSettings;
+	const std::string runFileName;
 };
 
 Herwig7Hadronizer::Herwig7Hadronizer(const edm::ParameterSet &pset) :
 	Herwig7Interface(pset),
 	BaseHadronizer(pset),
 	eventsToPrint(pset.getUntrackedParameter<unsigned int>("eventsToPrint", 0)),
-	handlerDirectory_(pset.getParameter<std::string>("eventHandlers"))
+	handlerDirectory_(pset.getParameter<std::string>("eventHandlers")),
+	runFileName(pset.getParameter<std::string>("run"))
 {  
 	initRepository(pset);
-
+	paramSettings = pset;
 }
 
 Herwig7Hadronizer::~Herwig7Hadronizer()
@@ -76,6 +80,11 @@ Herwig7Hadronizer::~Herwig7Hadronizer()
 
 bool Herwig7Hadronizer::initializeForInternalPartons()
 {
+	std::ifstream runFile(runFileName+".run");
+	if (runFile.fail()) //required for showering of LHE files
+	{
+		initRepository(paramSettings);
+	}
 	if (!initGenerator())
 	{
 		edm::LogInfo("Generator|Herwig7Hadronizer") << "No run step for Herwig chosen. Program will be aborted.";

--- a/GeneratorInterface/Herwig7Interface/python/Herwig7_Dummy_ReadLHE_GEN_SIM.py
+++ b/GeneratorInterface/Herwig7Interface/python/Herwig7_Dummy_ReadLHE_GEN_SIM.py
@@ -1,18 +1,25 @@
 import FWCore.ParameterSet.Config as cms
 
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/2017/13TeV/madgraph/V5_2.4.2/BulkGraviton_hh_GF_HH_narrow_M1000/v1/BulkGraviton_hh_GF_HH_narrow_M1000_slc6_amd64_gcc481_CMSSW_7_1_30_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
 generator = cms.EDFilter("Herwig7GeneratorFilter",
-    run = cms.string('InterfaceMatchboxTest'),
+    run = cms.string('LHEinRun'),
     repository = cms.string('${HERWIGPATH}/HerwigDefaults.rpo'),
     dataLocation = cms.string('${HERWIGPATH:-6}'),
     generatorModule = cms.string('/Herwig/Generators/EventGenerator'),
     eventHandlers = cms.string('/Herwig/EventHandlers'),
     configFiles = cms.vstring(),
     crossSection = cms.untracked.double(-1),
-    parameterSets = cms.vstring(),
+    parameterSets = cms.vstring("Matchbox"),
     filterEfficiency = cms.untracked.double(1.0),
-    Matchbox = cms.vstring( 'read LHE.in',
-        'set LesHouchesReader:FileName ${CMSSW_BASE}/src/cmsgrid_final.lhe.gz'
-        )
+    Matchbox = cms.vstring('read LHE.in'),
+    runModeList = cms.untracked.string('read,run')
 )
 
 ProductionFilterSequence = cms.Sequence(generator)

--- a/GeneratorInterface/Herwig7Interface/test/LHE.in
+++ b/GeneratorInterface/Herwig7Interface/test/LHE.in
@@ -53,7 +53,7 @@ set /Herwig/Partons/PPExtractor:SecondPDF /Herwig/Partons/LHAPDF
 # create the reader and set cuts
 create ThePEG::LesHouchesFileReader LesHouchesReader
 # the file can be compressed (gziped,bziped)
-set LesHouchesReader:FileName cmsgrid_final.lhe.gz
+set LesHouchesReader:FileName cmsgrid_final.lhe
 set LesHouchesReader:AllowedToReOpen No
 set LesHouchesReader:InitPDFs 0
 set LesHouchesReader:Cuts /Herwig/Cuts/NoCuts


### PR DESCRIPTION
Dear @all,
This is a fix, which enables Herwig7 to be run in LHEGEN production with an external gridpack. Herwig7 is used to shower the events.
Kind regards,
Andrej