### PR TITLE
[GCC 8.1] Fixed const correctness for operator()

### DIFF
--- a/CondFormats/HcalObjects/interface/HcalDcsMap.h
+++ b/CondFormats/HcalObjects/interface/HcalDcsMap.h
@@ -130,31 +130,31 @@ class HcalDcsMap {
 namespace HcalDcsMapAddons {
   class LessById {
    public:
-    bool operator () (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) {
+    bool operator () (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) const {
       return a->mId < b->mId;
     }
-    bool operator () (const HcalDcsMap::Item& a, const HcalDcsMap::Item& b) {
+    bool operator () (const HcalDcsMap::Item& a, const HcalDcsMap::Item& b) const {
       return a.mId < b.mId;
     }
-    bool equal (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) {
+    bool equal (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) const {
       return a->mId == b->mId;
     }
-    bool good (const HcalDcsMap::Item& a) {
+    bool good (const HcalDcsMap::Item& a) const {
       return a.mDcsId;
     }
   };
   class LessByDcsId {
    public:
-    bool operator () (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) {
+    bool operator () (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) const {
       return a->mDcsId < b->mDcsId;
     }
-    bool operator () (const HcalDcsMap::Item& a, const HcalDcsMap::Item& b) {
+    bool operator () (const HcalDcsMap::Item& a, const HcalDcsMap::Item& b) const {
       return a.mDcsId < b.mDcsId;
     }
-    bool equal (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) {
+    bool equal (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) const {
       return a->mDcsId == b->mDcsId;
     }
-    bool good (const HcalDcsMap::Item& a) {
+    bool good (const HcalDcsMap::Item& a) const {
       return a.mDcsId;
     }
   };

--- a/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
+++ b/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
@@ -82,10 +82,10 @@ protected:
 namespace HcalFrontEndMapAddons {
   class LessById {
    public: 
-    bool operator () (const HcalFrontEndMap::PrecisionItem* a, const HcalFrontEndMap::PrecisionItem* b) {return a->mId < b->mId;}
-    bool operator () (const HcalFrontEndMap::PrecisionItem& a, const HcalFrontEndMap::PrecisionItem& b) {return a.mId < b.mId;}
-    bool equal (const HcalFrontEndMap::PrecisionItem* a, const HcalFrontEndMap::PrecisionItem* b) {return a->mId == b->mId;}
-    bool good (const HcalFrontEndMap::PrecisionItem& a) {return a.mId;}
+    bool operator () (const HcalFrontEndMap::PrecisionItem* a, const HcalFrontEndMap::PrecisionItem* b) const {return a->mId < b->mId;}
+    bool operator () (const HcalFrontEndMap::PrecisionItem& a, const HcalFrontEndMap::PrecisionItem& b) const {return a.mId < b.mId;}
+    bool equal (const HcalFrontEndMap::PrecisionItem* a, const HcalFrontEndMap::PrecisionItem* b) const {return a->mId == b->mId;}
+    bool good (const HcalFrontEndMap::PrecisionItem& a) const {return a.mId;}
   };
   class Helper {
    public:

--- a/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
+++ b/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
@@ -87,10 +87,10 @@ protected:
 namespace HcalSiPMCharacteristicsAddons {
   class LessByType {
    public: 
-    bool operator () (const HcalSiPMCharacteristics::PrecisionItem* a, const HcalSiPMCharacteristics::PrecisionItem* b) {return a->type_ < b->type_;}
-    bool operator () (const HcalSiPMCharacteristics::PrecisionItem& a, const HcalSiPMCharacteristics::PrecisionItem& b) {return a.type_ < b.type_;}
-    bool equal (const HcalSiPMCharacteristics::PrecisionItem* a, const HcalSiPMCharacteristics::PrecisionItem* b) {return a->type_ == b->type_;}
-    bool good (const HcalSiPMCharacteristics::PrecisionItem& a) {return a.type_;}
+    bool operator () (const HcalSiPMCharacteristics::PrecisionItem* a, const HcalSiPMCharacteristics::PrecisionItem* b) const {return a->type_ < b->type_;}
+    bool operator () (const HcalSiPMCharacteristics::PrecisionItem& a, const HcalSiPMCharacteristics::PrecisionItem& b) const {return a.type_ < b.type_;}
+    bool equal (const HcalSiPMCharacteristics::PrecisionItem* a, const HcalSiPMCharacteristics::PrecisionItem* b) const {return a->type_ == b->type_;}
+    bool good (const HcalSiPMCharacteristics::PrecisionItem& a) const {return a.type_;}
   };
   class Helper {
    public:


### PR DESCRIPTION
To avoid GCC 8 build errors like
```
../c++/8.1.1/bits/stl_tree.h: In instantiation of 'class std::_Rb_tree<HcalDcsMap::Item, HcalDcsMap::Item, std::_Identity<HcalDcsMap::Item>, HcalDcsMapAddons::LessByDcsId, std::allocator<HcalDcsMap::Item> >':
.../c++/8.1.1/bits/stl_set.h:133:17:   required from 'class std::set<HcalDcsMap::Item, HcalDcsMapAddons::LessByDcsId>'
.../CMSSW_10_2_X_2018-05-16-1100/src/CondFormats/HcalObjects/interface/HcalDcsMap.h:171:44:   required from here
  /build/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc810/external/gcc/8.1.0/include/c++/8.1.1/bits/stl_tree.h:457:21: error: static assertion failed: comparison object must be invocable as const
        static_assert(is_invocable_v<const _Compare&, const _Key&, const _Key&>,
```