### PR TITLE
suppress a to-do reminder in PFEGammaAlgo.cc from LogWarning to LogInfo

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1527,7 +1527,7 @@ initializeProtoCands(std::list<PFEGammaAlgo::ProtoEGObject>& egobjs) {
 	   thefront.lateBrem = roToMerge->lateBrem;
 	 } else if ( thefront.electronSeed.isNonnull() && 
 		     roToMerge->electronSeed.isNonnull()) {
-	   LOGWARN("PFEGammaAlgo::mergeROsByAnyLink")
+	   LOGDRESSED("PFEGammaAlgo::mergeROsByAnyLink")
 	     << "Need to implement proper merging of two gsf candidates!"
 	     << std::endl;
 	 }


### PR DESCRIPTION
backport of #23217 

I'm downgrading the severity of the message "Need to implement proper merging of two gsf candidates!" and put it on the list of reco issues in #23216

this is another PR in a series of cleanup of logError/logWarning in the prompt reco jobs (based on tests in run 315420)
