### PR TITLE
Geant4 sensitive detectors revision 5 

### DIFF
--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -21,11 +21,12 @@
 #include "SimG4Core/Application/interface/SimTrackManager.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
+ 
 #include "G4VPhysicalVolume.hh"
 #include "G4Track.hh"
 #include "G4VGFlashSensitiveDetector.hh"
 
+#include <cstdint>
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -49,12 +50,12 @@ public:
   CaloSD(const std::string& aSDname, const DDCompactView & cpv,
          const SensitiveDetectorCatalog & clg,
          edm::ParameterSet const & p, const SimTrackManager*,
-	 float timeSlice=1., bool ignoreTkID=false);
+         float timeSlice=1., bool ignoreTkID=false);
   ~CaloSD() override;
-  bool     ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
-  bool     ProcessHits(G4GFlashSpot*aSpot,G4TouchableHistory*) override;
 
-  virtual double getEnergyDeposit(G4Step* step); 
+  G4bool   ProcessHits(G4Step * step, G4TouchableHistory *) override;
+  bool     ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) override;
+
   uint32_t setDetUnitId(const G4Step* step) override =0;
   
   void     Initialize(G4HCofThisEvent * HCE) override;
@@ -68,16 +69,19 @@ public:
 
 protected:
 
-  virtual G4bool   getStepInfo(G4Step* aStep);
-  G4ThreeVector    setToLocal(const G4ThreeVector&, const G4VTouchable*);
-  G4ThreeVector    setToGlobal(const G4ThreeVector&, const G4VTouchable*);
-  G4bool           hitExists();
-  G4bool           checkHit();
-  CaloG4Hit*       createNewHit();
-  void             updateHit(CaloG4Hit*);
-  void             resetForNewPrimary(const G4ThreeVector&, double);
-  double           getAttenuation(const G4Step* aStep, double birk1, double birk2,
-                                  double birk3);
+  virtual double getEnergyDeposit(const G4Step* step); 
+  virtual bool   getFromLibrary(const G4Step* step); 
+
+  G4ThreeVector  setToLocal(const G4ThreeVector&, const G4VTouchable*) const; 
+  G4ThreeVector  setToGlobal(const G4ThreeVector&, const G4VTouchable*) const; 
+
+  bool           hitExists(const G4Step*);
+  bool           checkHit();
+  CaloG4Hit*     createNewHit(const G4Step*);
+  void           updateHit(CaloG4Hit*);
+  void           resetForNewPrimary(const G4Step*);
+  double         getAttenuation(const G4Step* aStep, double birk1, double birk2,
+                                double birk3) const; 
 
   void     update(const BeginOfRun *) override;
   void     update(const BeginOfEvent *) override;
@@ -87,16 +91,27 @@ protected:
   virtual void     initRun();
   virtual bool     filterHit(CaloG4Hit*, double);
 
-  virtual int      getTrackID(const G4Track*);
+  virtual int      getTrackID(const G4Track*); 
+  virtual int      setTrackID(const G4Step*); 
   virtual uint16_t getDepth(const G4Step*);   
   double           getResponseWt(const G4Track*);
   int              getNumberOfHits();
+
+  inline void setParameterized(bool val) { isParameterized = val; }
+
+  inline void processHit(const G4Step* step) {
+    // check if it is in the same unit and timeslice as the previous one
+    if (currentID == previousID) {
+      updateHit(currentHit);
+    } else if (!checkHit()) {
+      currentHit = createNewHit(step);
+    }
+  }
 
 private:
 
   void             storeHit(CaloG4Hit*);
   bool             saveHit(CaloG4Hit*);
-  void             summarize();
   void             cleanHitCollection();
 
 protected:
@@ -106,51 +121,54 @@ protected:
   // One shower is made of several hits which differ by the
   // unit ID (crystal/fibre/scintillator) and the Time slice ID.
 
-  G4ThreeVector                   entrancePoint;
-  G4ThreeVector                   entranceLocal;
-  G4ThreeVector                   posGlobal;
+  G4ThreeVector                   entrancePoint; 
+  G4ThreeVector                   entranceLocal; 
+  G4ThreeVector                   posGlobal;    
   float                           incidentEnergy;
-  int                             primIDSaved; //  ID of the last saved primary
-
-  CaloHitID                       currentID, previousID; 
-  G4Track*                        theTrack;
-
-  G4StepPoint*                    preStepPoint; 
   float                           edepositEM, edepositHAD;
 
-  double                          energyCut, tmaxHit, eminHit, eminHitD;
-  int                             checkHits;
-  bool                            useMap;
+  CaloHitID                       currentID, previousID; 
 
-  const SimTrackManager*          m_trackManager;
+  double                          energyCut, tmaxHit, eminHit;
+
   CaloG4Hit*                      currentHit;
 
-  bool                            runInit;
-
-  bool                            corrTOFBeam, suppressHeavy;
-  double                          correctT;
+  bool                            suppressHeavy;
   double                          kmaxIon, kmaxNeutron, kmaxProton;
 
   bool                            forceSave;
 
 private:
 
-  float                           timeSlice;
-  bool                            ignoreTrackID;
-  CaloSlaveSD*                    slave;
-  int                             hcID;
+  const SimTrackManager*          m_trackManager;
+
+  std::unique_ptr<CaloSlaveSD>         slave;
+  std::unique_ptr<CaloMeanResponse>    meanResponse;
+
   CaloG4HitCollection*            theHC; 
-  std::map<CaloHitID,CaloG4Hit*>  hitMap;
 
-  std::map<int,TrackWithHistory*> tkMap;
-  CaloMeanResponse*               meanResponse;
+  bool                            ignoreTrackID;
+  bool                            isParameterized; 
+  bool                            useMap;
+  bool                            corrTOFBeam;
 
+  int                             hcID;
   int                             primAncestor;
   int                             cleanIndex;
+  int                             totalHits;
+  int                             primIDSaved; // ID of the last saved primary
+  int                             checkHits;
+
+  float                           timeSlice;
+  double                          eminHitD;
+  double                          correctT;
+
+  std::map<CaloHitID,CaloG4Hit*>  hitMap;
+  std::map<int,TrackWithHistory*> tkMap;
+
   std::vector<CaloG4Hit*>         reusehit;
   std::vector<CaloG4Hit*>         hitvec;
   std::vector<unsigned int>       selIndex;
-  int                             totalHits;
 
 };
 

--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -98,6 +98,7 @@ protected:
   int              getNumberOfHits();
 
   inline void setParameterized(bool val) { isParameterized = val; }
+  inline void setUseMap(bool val)        { useMap = val; }
 
   inline void processHit(const G4Step* step) {
     // check if it is in the same unit and timeslice as the previous one
@@ -107,6 +108,8 @@ protected:
       currentHit = createNewHit(step);
     }
   }
+
+  inline void setNumberCheckedHits(int val) { nCheckedHits = val; }
 
 private:
 
@@ -149,15 +152,15 @@ private:
 
   bool                            ignoreTrackID;
   bool                            isParameterized; 
-  bool                            useMap;
+  bool                            useMap;       // use map for comparison of ID
   bool                            corrTOFBeam;
 
   int                             hcID;
   int                             primAncestor;
   int                             cleanIndex;
   int                             totalHits;
-  int                             primIDSaved; // ID of the last saved primary
-  int                             checkHits;
+  int                             primIDSaved;  // ID of the last saved primary
+  int                             nCheckedHits; // number of last hits to compare ID
 
   float                           timeSlice;
   double                          eminHitD;

--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -32,32 +32,34 @@ class ECalSD : public CaloSD {
 public:    
 
   ECalSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
-	 edm::ParameterSet const & p, const SimTrackManager*);
+         edm::ParameterSet const & p, const SimTrackManager*);
   ~ECalSD() override;
-  double                    getEnergyDeposit(G4Step*) override;
-  virtual uint16_t          getRadiationLength(const G4Step *);
-  virtual uint16_t          getLayerIDForTimeSim(const G4Step *);
   uint32_t                  setDetUnitId(const G4Step*) override;
   void                      setNumberingScheme(EcalNumberingScheme*);
 
 protected:
 
+  double                    getEnergyDeposit(const G4Step*) override;
   int                       getTrackID(const G4Track*) override;
   uint16_t                  getDepth(const G4Step*) override;
 
 private:    
 
-  void                              initMap(const G4String&, const DDCompactView &);
-  double                            curve_LY(const G4Step*); 
-  double                            crystalLength(const G4LogicalVolume*);
-  double                            crystalDepth(const G4LogicalVolume*, const G4ThreeVector&);
-  void                              getBaseNumber(const G4Step*); 
-  double                            getBirkL3(const G4Step*);
-  std::vector<double>               getDDDArray(const std::string&,
-						const DDsvalues_type&);
-  std::vector<std::string>          getStringArray(const std::string&,
-						   const DDsvalues_type&);
+  void                      initMap(const G4String&, const DDCompactView &);
+  uint16_t                  getRadiationLength(const G4StepPoint* hitPoint, 
+                                               const G4LogicalVolume* lv);
+  uint16_t                  getLayerIDForTimeSim();
+  double                    curve_LY(const G4LogicalVolume*);  
 
+  void                      getBaseNumber(const G4Step*); 
+  double                    getBirkL3(const G4Step*);
+
+  std::vector<double>               getDDDArray(const std::string&,
+                                                const DDsvalues_type&);
+  std::vector<std::string>          getStringArray(const std::string&,
+                                                   const DDsvalues_type&);
+
+  // initialised before run
   bool                              isEB;
   bool                              isEE;
   EcalNumberingScheme *             numberingScheme;
@@ -71,6 +73,13 @@ private:
   EcalBaseNumber                    theBaseNumber;
   EnergyResolutionVsLumi            ageing;
   bool                              ageingWithSlopeLY;
+
+  // run time cache
+  G4ThreeVector                     currentLocalPoint;
+  double                            crystalLength;
+  double                            crystalDepth;
+  uint16_t                          depth;
+ 
 #ifdef plotDebug
   TH2F                             *g2L_[4];
 #endif

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -78,7 +78,6 @@ private:
   void                          getFromParam(const G4Step * step, bool& isKilled);
   void                          getHitPMT(const G4Step * step);
   void                          getHitFibreBundle(const G4Step * step, bool type);
-  //  int                           setTrackID(const G4Step * step);
   void                          readWeightFromFile(const std::string&);
   double                        layerWeight(int, const G4ThreeVector&, int, int);
   void                          plotProfile(const G4Step* step, const G4ThreeVector& pos, 

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -14,6 +14,7 @@
 #include "SimG4CMS/Calo/interface/HFShowerPMT.h"
 #include "SimG4CMS/Calo/interface/HFShowerFibreBundle.h"
 #include "SimG4CMS/Calo/interface/HcalNumberingScheme.h"
+#include "SimG4CMS/Calo/interface/HcalTestNS.h"
 #include "CondFormats/HcalObjects/interface/HBHEDarkening.h"
 #include "SimG4CMS/Calo/interface/HFDarkening.h"
 #include "DetectorDescription/Core/interface/DDsvalues.h"
@@ -24,7 +25,6 @@
 #include "G4String.hh"
 #include <map>
 #include <string>
-#include <TH1F.h>
 
 class DDCompactView;
 class DDFilteredView;
@@ -32,6 +32,7 @@ class G4LogicalVolume;
 class G4Material;
 class G4Step;
 class HcalTestNS;
+class TH1F;
 
 class HCalSD : public CaloSD, public Observer<const BeginOfJob *> {
 
@@ -39,19 +40,24 @@ public:
 
   HCalSD(const std::string& , const DDCompactView &, const SensitiveDetectorCatalog &,
          edm::ParameterSet const &, const SimTrackManager*);
-  ~HCalSD() override;
-  bool                  ProcessHits(G4Step * , G4TouchableHistory * ) override;
-  double                getEnergyDeposit(G4Step* ) override;
+  ~HCalSD() override = default;
   uint32_t              setDetUnitId(const G4Step* step) override;
   void                  setNumberingScheme(HcalNumberingScheme* );
 
 protected:
 
+  double                getEnergyDeposit(const G4Step*) override;
+  bool                  getFromLibrary(const G4Step*) override;
   void                  update(const BeginOfJob *) override;
   void                  initRun() override;
   bool                  filterHit(CaloG4Hit*, double) override;
 
 private:    
+
+  void                  fillLogVolumeVector(const std::string&, const std::string&, 
+					    const DDCompactView&,
+					    std::vector<const G4LogicalVolume*>&,
+					    std::vector<G4String>&);
 
   uint32_t                      setDetUnitId(int, const G4ThreeVector&, int, int);
   uint32_t                      setDetUnitId(HcalNumberingFromDDD::HcalID& tmp);
@@ -67,12 +73,12 @@ private:
   bool                          isItConicalBundle(const G4LogicalVolume*);
   bool                          isItScintillator(const G4Material*);
   bool                          isItinFidVolume (const G4ThreeVector&);
-  void                          getFromLibrary(G4Step * step, double weight);
-  void                          hitForFibre(const G4Step * step, double weight);
-  void                          getFromParam(G4Step * step, double weight);
+  void                          getFromHFLibrary(const G4Step * step, bool& isKilled);
+  void                          hitForFibre(const G4Step * step);
+  void                          getFromParam(const G4Step * step, bool& isKilled);
   void                          getHitPMT(const G4Step * step);
   void                          getHitFibreBundle(const G4Step * step, bool type);
-  int                           setTrackID(const G4Step * step);
+  //  int                           setTrackID(const G4Step * step);
   void                          readWeightFromFile(const std::string&);
   double                        layerWeight(int, const G4ThreeVector&, int, int);
   void                          plotProfile(const G4Step* step, const G4ThreeVector& pos, 
@@ -80,27 +86,30 @@ private:
   void                          plotHF(const G4ThreeVector& pos, bool emType);
   void                          modifyDepth(HcalNumberingFromDDD::HcalID& id);
 
+  std::unique_ptr<HcalNumberingFromDDD> numberingFromDDD;
+  std::unique_ptr<HcalNumberingScheme>  numberingScheme;
+  std::unique_ptr<HFShowerLibrary>      showerLibrary;
+  std::unique_ptr<HFShower>             hfshower;
+  std::unique_ptr<HFShowerParam>        showerParam;
+  std::unique_ptr<HFShowerPMT>          showerPMT;
+  std::unique_ptr<HFShowerFibreBundle>  showerBundle;
+
   HcalDDDSimConstants*          hcalConstants;
-  HcalNumberingFromDDD*         numberingFromDDD;
-  HcalNumberingScheme*          numberingScheme;
-  HFShowerLibrary *             showerLibrary;
-  HFShower *                    hfshower;
-  HFShowerParam *               showerParam;
-  HFShowerPMT *                 showerPMT;
-  HFShowerFibreBundle *         showerBundle;
-  bool                          agingFlagHB, agingFlagHE;
   const HBHEDarkening*          m_HBDarkening;
   const HBHEDarkening*          m_HEDarkening;
   std::unique_ptr<HFDarkening>  m_HFDarkening;
-  HcalTestNS *                  hcalTestNS_;
+  std::unique_ptr<HcalTestNS>   m_HcalTestNS;
+
+  bool                          isHF;
+  bool                          agingFlagHB, agingFlagHE;
   bool                          useBirk, useLayerWt, useFibreBundle, usePMTHit;
   bool                          testNumber, neutralDensity, testNS_;
   double                        birk1, birk2, birk3, betaThr;
   bool                          useHF, useShowerLibrary, useParam, applyFidCut;
-  bool                          isEM;
   double                        eminHitHB, eminHitHE, eminHitHO, eminHitHF;
   double                        deliveredLumi;
-  G4int                         depth_;
+  double                        weight_;
+  int                           depth_;
   std::vector<double>           gpar;
   std::vector<int>              hfLevels;
   std::vector<G4String>         hfNames, fibreNames, matNames;

--- a/SimG4CMS/Calo/interface/HFFibre.h
+++ b/SimG4CMS/Calo/interface/HFFibre.h
@@ -23,20 +23,20 @@ public:
   
   //Constructor and Destructor
   HFFibre(const std::string & name, const DDCompactView & cpv,
-	  edm::ParameterSet const & p);
-  ~HFFibre();
+          edm::ParameterSet const & p);
+  ~HFFibre() = default;
 
-  void                initRun(HcalDDDSimConstants*);
+  void                initRun(const HcalDDDSimConstants*);
   double              attLength(double lambda);
   double              tShift(const G4ThreeVector& point, int depth, 
-			     int fromEndAbs=0);
+                             int fromEndAbs=0);
   double              zShift(const G4ThreeVector& point, int depth, 
-			     int fromEndAbs=0);
+                             int fromEndAbs=0);
 
 protected:
 
   std::vector<double> getDDDArray(const std::string&, 
-				  const DDsvalues_type&, int&);
+                                  const DDsvalues_type&, int&);
 
 private:
 

--- a/SimG4CMS/Calo/interface/HFGflash.h
+++ b/SimG4CMS/Calo/interface/HFGflash.h
@@ -42,7 +42,7 @@ public:
     double              pez = 0.;
   };
 
-  std::vector<Hit> gfParameterization(G4Step * aStep, bool & ok, bool onlyLong=false);
+  std::vector<Hit> gfParameterization(const G4Step * aStep, bool onlyLong=false);
 
 private:    
 

--- a/SimG4CMS/Calo/interface/HFShower.h
+++ b/SimG4CMS/Calo/interface/HFShower.h
@@ -38,7 +38,7 @@ public:
     G4ThreeVector     position;
   };
 
-  void                initRun(G4ParticleTable *, HcalDDDSimConstants*);
+  void                initRun(const HcalDDDSimConstants*);
   std::vector<Hit>    getHits(const G4Step * aStep, double weight);
   std::vector<Hit>    getHits(const G4Step * aStep, bool forLibrary);
   std::vector<Hit>    getHits(const G4Step * aStep, bool forLibraryProducer, double zoffset);

--- a/SimG4CMS/Calo/interface/HFShowerFibreBundle.h
+++ b/SimG4CMS/Calo/interface/HFShowerFibreBundle.h
@@ -26,7 +26,7 @@ public:
   virtual ~HFShowerFibreBundle();
   double                getHits(const G4Step * aStep, bool type);
   double                getRadius();
-  void                  initRun(G4ParticleTable *, HcalDDDSimConstants*);
+  void                  initRun(const HcalDDDSimConstants*);
 
 private:    
 

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -12,7 +12,6 @@
 #include "SimDataFormats/CaloHit/interface/HFShowerPhoton.h"
 #include "DetectorDescription/Core/interface/DDsvalues.h"
 
-#include "G4ParticleTable.hh"
 #include "G4ThreeVector.hh"
  
 //ROOT
@@ -25,6 +24,7 @@
 
 class DDCompactView;    
 class G4Step;
+class G4ParticleTable;
 
 class HFShowerLibrary {
   
@@ -32,7 +32,7 @@ public:
   
   //Constructor and Destructor
   HFShowerLibrary(const std::string & name, const DDCompactView & cpv,
-		  edm::ParameterSet const & p);
+                  edm::ParameterSet const & p);
   ~HFShowerLibrary();
 
 public:
@@ -44,9 +44,9 @@ public:
     double                    time;
   };
 
-  void                initRun(G4ParticleTable *, HcalDDDSimConstants*);
-  std::vector<Hit>    getHits(G4Step * aStep, bool &ok, double weight, 
-			      bool onlyLong=false);
+  void                initRun(G4ParticleTable*, const HcalDDDSimConstants*);
+  std::vector<Hit>    getHits(const G4Step * aStep, bool &ok, double weight, 
+                              bool onlyLong=false);
   std::vector<Hit>    fillHits(const G4ThreeVector & p, const G4ThreeVector & v,
                                int parCode, double parEnergy, bool & ok,
                                double weight, double time, bool onlyLong=false);
@@ -59,7 +59,7 @@ protected:
   void                extrapolate(int, double);
   void                storePhoton(int j);
   std::vector<double> getDDDArray(const std::string&, const DDsvalues_type&,
-				  int&);
+                                  int&);
 
 private:
 

--- a/SimG4CMS/Calo/interface/HFShowerPMT.h
+++ b/SimG4CMS/Calo/interface/HFShowerPMT.h
@@ -26,7 +26,7 @@ public:
   virtual ~HFShowerPMT();
   double                getHits(const G4Step * aStep);
   double                getRadius();
-  void                  initRun(G4ParticleTable *, HcalDDDSimConstants*);
+  void                  initRun(const HcalDDDSimConstants*);
 
 private:    
 

--- a/SimG4CMS/Calo/interface/HFShowerParam.h
+++ b/SimG4CMS/Calo/interface/HFShowerParam.h
@@ -13,7 +13,6 @@
 #include "SimG4CMS/Calo/interface/HFFibre.h"
 #include "SimG4CMS/Calo/interface/HFGflash.h"
 
-#include "G4ParticleTable.hh"
 #include "G4ThreeVector.hh"
 
 class DDCompactView;
@@ -29,7 +28,7 @@ class HFShowerParam {
 public:    
 
   HFShowerParam(const std::string & name, const DDCompactView & cpv, 
-		edm::ParameterSet const & p);
+                edm::ParameterSet const & p);
   virtual ~HFShowerParam();
 
 public:    
@@ -42,8 +41,8 @@ public:
     double              edep;
   };
 
-  void                  initRun(G4ParticleTable *, HcalDDDSimConstants*);
-  std::vector<Hit>      getHits(G4Step * aStep, double weight);
+  void                  initRun(const HcalDDDSimConstants*);
+  std::vector<Hit>      getHits(const G4Step * aStep, double weight, bool& isKilled);
   
 private:    
 

--- a/SimG4CMS/Calo/interface/HGCSD.h
+++ b/SimG4CMS/Calo/interface/HGCSD.h
@@ -12,10 +12,7 @@
 #include "SimG4CMS/Calo/interface/HGCMouseBite.h"
 #include "DetectorDescription/Core/interface/DDsvalues.h"
 
-#include "G4String.hh"
-#include <map>
 #include <string>
-#include <TH1F.h>
 
 class DDCompactView;
 class DDFilteredView;
@@ -30,29 +27,26 @@ public:
   HGCSD(const std::string& , const DDCompactView &, const SensitiveDetectorCatalog &,
 	edm::ParameterSet const &, const SimTrackManager*);
   ~HGCSD() override;
-  bool                    ProcessHits(G4Step * , G4TouchableHistory * ) override;
-  double                  getEnergyDeposit(G4Step* ) override;
+
   uint32_t                setDetUnitId(const G4Step* step) override;
 
 protected:
 
+  double                  getEnergyDeposit(const G4Step* ) override;
   void                    update(const BeginOfJob *) override;
   void                    initRun() override;
   bool                    filterHit(CaloG4Hit*, double) override;
 
 private:    
 
-  uint32_t                        setDetUnitId(ForwardSubdetector&, int, int, 
-					       int, int, G4ThreeVector &);
-  bool                            isItinFidVolume (const G4ThreeVector&) {return true;}
-  int                             setTrackID(const G4Step * step);
+  uint32_t                setDetUnitId(ForwardSubdetector&, int, int, 
+				       int, int, G4ThreeVector &);
 
   std::string                     nameX;
 
   HGCalGeometryMode::GeometryMode m_mode;
   HGCNumberingScheme*             numberingScheme;
   HGCMouseBite*                   mouseBite_;
-  G4int                           mumPDG, mupPDG; 
   double                          eminHit;
   ForwardSubdetector              myFwdSubdet_;
   double                          slopeMin_;

--- a/SimG4CMS/Calo/interface/HGCSD.h
+++ b/SimG4CMS/Calo/interface/HGCSD.h
@@ -42,12 +42,12 @@ private:
   uint32_t                setDetUnitId(ForwardSubdetector&, int, int, 
 				       int, int, G4ThreeVector &);
 
-  std::string                     nameX;
+  std::string                     nameX_;
 
-  HGCalGeometryMode::GeometryMode m_mode;
-  HGCNumberingScheme*             numberingScheme;
+  HGCalGeometryMode::GeometryMode geom_mode_;
+  HGCNumberingScheme*             numberingScheme_;
   HGCMouseBite*                   mouseBite_;
-  double                          eminHit;
+  double                          eminHit_;
   ForwardSubdetector              myFwdSubdet_;
   double                          slopeMin_;
   int                             levelT_;

--- a/SimG4CMS/Calo/interface/HGCSD.h
+++ b/SimG4CMS/Calo/interface/HGCSD.h
@@ -41,6 +41,7 @@ private:
 
   uint32_t                setDetUnitId(ForwardSubdetector&, int, int, 
 				       int, int, G4ThreeVector &);
+  bool                    isItinFidVolume (const G4ThreeVector&) {return true;}
 
   std::string                     nameX_;
 

--- a/SimG4CMS/Calo/interface/HGCalSD.h
+++ b/SimG4CMS/Calo/interface/HGCalSD.h
@@ -22,14 +22,14 @@ class HGCalSD : public CaloSD, public Observer<const BeginOfJob *> {
 public:    
 
   HGCalSD(const std::string& , const DDCompactView &, const SensitiveDetectorCatalog &,
-	edm::ParameterSet const &, const SimTrackManager*);
+	  edm::ParameterSet const &, const SimTrackManager*);
   ~HGCalSD() override;
-  bool                    ProcessHits(G4Step * , G4TouchableHistory * ) override;
-  double                  getEnergyDeposit(G4Step* ) override;
+
   uint32_t                setDetUnitId(const G4Step* step) override;
 
 protected:
 
+  double                  getEnergyDeposit(const G4Step*) override;
   void                    update(const BeginOfJob *) override;
   void                    initRun() override;
   bool                    filterHit(CaloG4Hit*, double) override;
@@ -38,8 +38,6 @@ private:
 
   uint32_t                setDetUnitId(int, int, int, int, G4ThreeVector &);
   bool                    isItinFidVolume (const G4ThreeVector&) {return true;}
-  int                     setTrackID(const G4Step * step);
-
 
   HGCalNumberingScheme*           numberingScheme_;
   HGCMouseBite*                   mouseBite_;

--- a/SimG4CMS/Calo/interface/HGCalSD.h
+++ b/SimG4CMS/Calo/interface/HGCalSD.h
@@ -43,8 +43,7 @@ private:
   HGCMouseBite*                   mouseBite_;
   DetId::Detector                 mydet_;
   std::string                     nameX_;
-  G4int                           mumPDG_, mupPDG_; 
-  HGCalGeometryMode::GeometryMode m_mode;
+  HGCalGeometryMode::GeometryMode geom_mode_;
   double                          eminHit_, slopeMin_, mouseBiteCut_;
   int                             levelT1_, levelT2_;
   bool                            storeAllG4Hits_, rejectMB_, waferRot_;

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -564,15 +564,10 @@ void CaloSD::initRun() {}
 
 int CaloSD::getTrackID(const G4Track* aTrack) {
 
-  int primaryID = 0;
   forceSave = false;
   TrackInformation* trkInfo=(TrackInformation *)(aTrack->GetUserInformation());
-  if (trkInfo) {
-    int id = trkInfo->getIDonCaloSurface();
-    if(id > 0) { primaryID = id; } 
-  } else {
-    primaryID = aTrack->GetTrackID();
-  }
+  int primaryID = (trkInfo) ? trkInfo->getIDonCaloSurface() : 0;
+  if(primaryID == 0) { primaryID = aTrack->GetTrackID(); }
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD::getTrackID for " << GetName() 
                           << " trackID= " << aTrack->GetTrackID()
@@ -585,10 +580,8 @@ int CaloSD::setTrackID(const G4Step* aStep) {
 
   auto const theTrack = aStep->GetTrack();
   TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
-  int primaryID = trkInfo->getIDonCaloSurface();
-  if (primaryID == 0) {
-    primaryID = theTrack->GetTrackID();
-  }
+  int primaryID = (trkInfo) ? trkInfo->getIDonCaloSurface() : 0;
+  if (primaryID == 0) { primaryID = theTrack->GetTrackID(); }
 
   if (primaryID != previousID.trackID()) {
     resetForNewPrimary(aStep);

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -27,10 +27,9 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
         edm::ParameterSet const & p, const SimTrackManager* manager,
         float timeSliceUnit, bool ignoreTkID) : 
   SensitiveCaloDetector(name, cpv, clg, p),
-  G4VGFlashSensitiveDetector(), theTrack(nullptr), preStepPoint(nullptr), eminHit(0), 
-  eminHitD(0), m_trackManager(manager), currentHit(nullptr), runInit(false),
-  timeSlice(timeSliceUnit), ignoreTrackID(ignoreTkID), hcID(-1), theHC(nullptr), 
-  meanResponse(nullptr) {
+  G4VGFlashSensitiveDetector(), eminHit(0.),currentHit(nullptr), 
+  m_trackManager(manager), theHC(nullptr), ignoreTrackID(ignoreTkID), hcID(-1), 
+  timeSlice(timeSliceUnit), eminHitD(0.) {
 
   //Parameters
   edm::ParameterSet m_CaloSD = p.getParameter<edm::ParameterSet>("CaloSD");
@@ -53,24 +52,32 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
   correctT     = beamZ/c_light/nanosecond;
 
   SetVerboseLevel(verbn);
+  meanResponse.reset(nullptr);
   for (unsigned int k=0; k<hcn.size(); ++k) {
-    if (name == (G4String)(hcn[k])) {
+    if (name == hcn[k]) {
       if (k < eminHits.size()) eminHit = eminHits[k]*MeV;
       if (k < eminHitX.size()) eminHitD= eminHitX[k]*MeV;
       if (k < tmaxHits.size()) tmaxHit = tmaxHits[k]*ns;
-      if (k < useResMap.size() && useResMap[k] > 0) meanResponse = new CaloMeanResponse(p);
-      break;
+      if (k < useResMap.size() && useResMap[k] > 0) {
+        meanResponse.reset(new CaloMeanResponse(p));
+        break;
+      }
     }
   }
-  slave      = new CaloSlaveSD(name);
+  slave.reset(new CaloSlaveSD(name));
+
   currentID  = CaloHitID(timeSlice, ignoreTrackID);
   previousID = CaloHitID(timeSlice, ignoreTrackID);
+  isParameterized = false;
   
-  primAncestor = 0;
-  cleanIndex = 0;
-  totalHits = 0;
-  forceSave = false;
+  entrancePoint.set(0.,0.,0.);
+  entranceLocal.set(0.,0.,0.);
+  posGlobal.set(0.,0.,0.);
+  incidentEnergy = edepositEM = edepositHAD = 0.f;
 
+  primAncestor = cleanIndex = totalHits = primIDSaved = 0;
+  forceSave = false;
+  
   edm::LogInfo("CaloSim") << "CaloSD: Minimum energy of track for saving it " 
                           << energyCut/GeV  << " GeV" << "\n"
                           << "        Use of HitID Map " << useMap << "\n"
@@ -81,99 +88,154 @@ CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
                           << "        Save hits recorded before " << tmaxHit
                           << " ns and if energy is above " << eminHit/MeV
                           << " MeV (for depth 0) or " << eminHitD/MeV
-                          << " MeV (for nonzero depths); Time Slice Unit " 
+                          << " MeV (for nonzero depths);\n"
+                          << "        Time Slice Unit " 
                           << timeSlice << " Ignore TrackID Flag " << ignoreTrackID;
 }
 
-CaloSD::~CaloSD() { 
-  delete slave; 
+CaloSD::~CaloSD()
+{
   delete theHC;
-  delete meanResponse;
 }
 
-bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
+G4bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
   
-  NaNTrap( aStep ) ;
-  
-  if (aStep == nullptr) {
-    return true;
-  } else {
-    if (getStepInfo(aStep)) {
-      if (hitExists() == false && edepositEM+edepositHAD>0.) 
-        currentHit = createNewHit();
+  NaNTrap( aStep );
+
+#ifdef DebugLog
+  edm::LogInfo("CaloSim") << "CaloSD::" << GetName()
+                          << " ID= " << aStep->GetTrack()->GetTrackID() 
+                          << " prID= " << aStep->GetTrack()->GetParentID() 
+                          << " Eprestep= " << aStep->GetPreStepPoint()->GetKineticEnergy()
+                          << " step= " << aStep->GetStepLength() << " Edep= " << aStep->GetTotalEnergyDeposit(); 
+#endif
+  // apply shower library or parameterisation
+  if(isParameterized) { 
+    if(getFromLibrary(aStep)) {
+
+      // for parameterized showers the primary track should be killed
+      aStep->GetTrack()->SetTrackStatus(fStopAndKill); 
+      auto tv  = aStep->GetSecondary();
+      auto vol = aStep->GetPreStepPoint()->GetPhysicalVolume();
+      for(auto & tk : *tv) {
+        if (tk->GetVolume() == vol) {
+          tk->SetTrackStatus(fStopAndKill);
+        }
+      }
+      return true;
     }
   }
-  return true;
+
+  // ignore steps without energy deposit
+  edepositEM = edepositHAD = 0.f;
+  unsigned int unitID = setDetUnitId(aStep);
+  auto const theTrack = aStep->GetTrack();   
+  uint16_t depth = getDepth(aStep);
+    
+  double   time  = theTrack->GetGlobalTime()/nanosecond;
+  int      primaryID = getTrackID(theTrack);
+  currentID.setID(unitID, time, primaryID, depth);
+
+  if(aStep->GetTotalEnergyDeposit() == 0.0) { 
+    //---VI: This code is for backward compatibility and should be removed 
+    hitExists(aStep);
+    //--- 
+    return false; 
+  }
+
+  double energy = getEnergyDeposit(aStep);
+  if(energy > 0.0) {
+    if(G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
+      edepositEM  = energy;
+    } else {
+      edepositHAD = energy;
+    }
+#ifdef DebugLog
+    G4TouchableHistory* touch =(G4TouchableHistory*)(theTrack->GetTouchable());
+    edm::LogInfo("CaloSim") << "CaloSD::" << GetName()
+                            << " PV:"   << touch->GetVolume(0)->GetName()
+                            << " PVid=" << touch->GetReplicaNumber(0)
+                            << " MVid=" << touch->GetReplicaNumber(1)
+                            << " Unit:" << std::hex << unitID << std::dec 
+                            << " Edep=" << edepositEM << " " << edepositHAD
+                            << " ID=" << theTrack->GetTrackID()
+                            << " pID=" << theTrack->GetParentID()
+                            << " E=" << theTrack->GetKineticEnergy()
+                            << " S=" << aStep->GetStepLength()
+                            << " " << theTrack->GetDefinition()->GetParticleName()
+                            << " currentID= " << currentID 
+                            << " previousID= " << previousID;
+#endif
+    if(!hitExists(aStep)) {
+      currentHit = createNewHit(aStep);
+    }
+    return true;
+  }
+  return false;
 } 
 
-bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) { 
+bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory * ) { 
 
-  if (aSpot != nullptr) {   
-    theTrack = const_cast<G4Track *>(aSpot->GetOriginatorTrack()->GetPrimaryTrack());
-    
-    if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
-      edepositEM  = aSpot->GetEnergySpot()->GetEnergy();
-      edepositHAD = 0.;
-    } else {
-      edepositEM  = 0.;
-      edepositHAD = 0.;
-    }
- 
-    if (edepositEM>0.) {
-      G4Step *      fFakeStep          = new G4Step();
-      preStepPoint                     = fFakeStep->GetPreStepPoint();
-      G4StepPoint * fFakePostStepPoint = fFakeStep->GetPostStepPoint();
-      preStepPoint->SetPosition(aSpot->GetPosition());
-      fFakePostStepPoint->SetPosition(aSpot->GetPosition());
+  edepositEM = edepositHAD = 0.f;
+  const G4Track* track = aSpot->GetOriginatorTrack()->GetPrimaryTrack();
+  if(!G4TrackToParticleID::isGammaElectronPositron(track)) { return false; }
+  double edep = aSpot->GetEnergySpot()->GetEnergy();
+  if (edep <= 0.0) { return false; }
+  edepositEM = edep;
+  G4Step fFakeStep;
+  G4StepPoint * fFakePreStepPoint  = fFakeStep.GetPreStepPoint();
+  G4StepPoint * fFakePostStepPoint = fFakeStep.GetPostStepPoint();
+  fFakePreStepPoint->SetPosition(aSpot->GetPosition());
+  fFakePostStepPoint->SetPosition(aSpot->GetPosition());
       
-      G4TouchableHandle fTouchableHandle   = aSpot->GetTouchableHandle();
-      preStepPoint->SetTouchableHandle(fTouchableHandle);
-      fFakeStep->SetTotalEnergyDeposit(aSpot->GetEnergySpot()->GetEnergy());
+  G4TouchableHandle fTouchableHandle = aSpot->GetTouchableHandle();
+  fFakePreStepPoint->SetTouchableHandle(fTouchableHandle);
+  fFakeStep.SetTotalEnergyDeposit(edep);
       
-      double       time   = 0;
-      unsigned int unitID = setDetUnitId(fFakeStep);
-      int          primaryID = getTrackID(theTrack);
-      uint16_t     depth = getDepth(fFakeStep);
+  unsigned int unitID = setDetUnitId(&fFakeStep);
 
-      if (unitID > 0) {
-        currentID.setID(unitID, time, primaryID, depth);
+  if (unitID > 0) {
+    double time   = 0;
+    int primaryID = getTrackID(track);
+    uint16_t depth = getDepth(&fFakeStep);
+    currentID.setID(unitID, time, primaryID, depth);
 #ifdef DebugLog
-        LogDebug("CaloSim") << "CaloSD:: GetSpotInfo for"
+    edm::LogInfo("CaloSim") << "CaloSD:: GetSpotInfo for"
                             << " Unit 0x" << std::hex << currentID.unitID() 
                             << std::dec << " Edeposit = " << edepositEM << " " 
                             << edepositHAD;
 #endif
-        // Update if in the same detector, time-slice and for same track   
-        if (currentID == previousID) {
-	  updateHit(currentHit);
-        } else {
-          posGlobal = aSpot->GetEnergySpot()->GetPosition();
-          // Reset entry point for new primary
-          if (currentID.trackID() != previousID.trackID()) {
-            entrancePoint  = aSpot->GetPosition();
-            entranceLocal  = aSpot->GetTouchableHandle()->GetHistory()->
-                                      GetTopTransform().TransformPoint(entrancePoint);
-            incidentEnergy = theTrack->GetKineticEnergy();
+    // Update if in the same detector, time-slice and for same track   
+    if (currentID == previousID) {
+      updateHit(currentHit);
+    } else {
+      posGlobal = aSpot->GetEnergySpot()->GetPosition();
+      // Reset entry point for new primary
+      if (currentID.trackID() != previousID.trackID()) {
+        entrancePoint = aSpot->GetPosition();
+        entranceLocal = aSpot->GetTouchableHandle()->GetHistory()->
+          GetTopTransform().TransformPoint(entrancePoint);
+        incidentEnergy = track->GetKineticEnergy();
 #ifdef DebugLog
-            LogDebug("CaloSim") << "CaloSD: Incident energy " 
-                                << incidentEnergy/GeV << " GeV and" 
-                                << " entrance point " << entrancePoint 
-                                << " (Global) " << entranceLocal << " (Local)";
+        LogDebug("CaloSim") << "CaloSD: Incident energy " 
+                            << incidentEnergy/GeV << " GeV and" 
+                            << " entrance point " << entrancePoint 
+                            << " (Global) " << entranceLocal << " (Local)";
 #endif
-          }
-
-          if (checkHit() == false) currentHit = createNewHit();
-        }
       }
-      delete  fFakeStep;
+      if (!checkHit()) { currentHit = createNewHit(&fFakeStep); }
     }
     return true;
-  } 
+  }
   return false;
 }                                   
 
-double CaloSD::getEnergyDeposit(G4Step* aStep) {
+double CaloSD::getEnergyDeposit(const G4Step* aStep) {
   return aStep->GetTotalEnergyDeposit();
+}
+
+bool CaloSD::getFromLibrary(const G4Step*) {
+  return false;
 }
 
 void CaloSD::Initialize(G4HCofThisEvent * HCE) { 
@@ -187,7 +249,9 @@ void CaloSD::Initialize(G4HCofThisEvent * HCE) {
   //------------------------------------------------------------
   theHC = new CaloG4HitCollection(GetName(), collectionName[0]);
   
-  if (hcID<0) hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
+  if (hcID<0) { 
+    hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]); 
+  }
   HCE->AddHitsCollection(hcID, theHC);
 }
 
@@ -200,7 +264,6 @@ void CaloSD::EndOfEvent(G4HCofThisEvent* ) {
   edm::LogInfo("CaloSim") << "CaloSD: EndofEvent entered with " << theHC->entries()
                           << " entries";
 #endif
-  //  TimeMe("CaloSD:sortAndMergeHits",false);
 }
 
 void CaloSD::clear() {} 
@@ -215,74 +278,19 @@ void CaloSD::PrintAll() {
 } 
 
 void CaloSD::fillHits(edm::PCaloHitContainer& cc, const std::string& hname) {
-  if (slave->name() == hname) { cc=slave->hits(); }
-  slave->Clean();
+  if (slave.get()->name() == hname) { cc=slave.get()->hits(); }
+  slave.get()->Clean();
 }
 
-bool CaloSD::getStepInfo(G4Step* aStep) {  
-
-  preStepPoint = aStep->GetPreStepPoint(); 
-  theTrack     = aStep->GetTrack();   
-  
-  double       time  = (aStep->GetPostStepPoint()->GetGlobalTime())/nanosecond;
-  unsigned int unitID= setDetUnitId(aStep);
-  uint16_t     depth = getDepth(aStep);
-  int          primaryID = getTrackID(theTrack);
-  
-  bool flag = (unitID > 0);
-  if (flag) {
-    currentID.setID(unitID, time, primaryID, depth);
-#ifdef DebugLog
-    G4TouchableHistory* touch =(G4TouchableHistory*)(theTrack->GetTouchable());
-    edm::LogInfo("CaloSim") << "CaloSD:: GetStepInfo for"
-			    << " PV "     << touch->GetVolume(0)->GetName()
-			    << " PVid = " << touch->GetReplicaNumber(0)
-			    << " MVid = " << touch->GetReplicaNumber(1)
-			    << " Unit   " << currentID.unitID() 
-			    << " Edeposit = " << edepositEM << " " << edepositHAD;
-  } else {
-    G4TouchableHistory* touch =(G4TouchableHistory*)(theTrack->GetTouchable());
-    edm::LogInfo("CaloSim") << "CaloSD:: GetStepInfo for"
-			    << " PV "     << touch->GetVolume(0)->GetName()
-			    << " PVid = " << touch->GetReplicaNumber(0)
-			    << " MVid = " << touch->GetReplicaNumber(1)
-			    << " Unit   " << std::hex << unitID << std::dec 
-			    << " Edeposit = " << edepositEM << " " << edepositHAD;
-#endif
-  }
-  
-  if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
-    edepositEM  = getEnergyDeposit(aStep);
-    edepositHAD = 0.;
-  } else {
-    edepositEM  = 0.;
-    edepositHAD = getEnergyDeposit(aStep);
-  }
-
-  return flag;
+G4ThreeVector CaloSD::setToLocal(const G4ThreeVector& global, const G4VTouchable* touch) const {
+  return touch->GetHistory()->GetTopTransform().TransformPoint(global);
 }
 
-G4ThreeVector CaloSD::setToLocal(const G4ThreeVector& global, const G4VTouchable* touch) {
-
-  G4ThreeVector localPoint = touch->GetHistory()->GetTopTransform().TransformPoint(global);
-  
-  return localPoint;  
+G4ThreeVector CaloSD::setToGlobal(const G4ThreeVector& local, const G4VTouchable* touch) const {
+  return touch->GetHistory()->GetTopTransform().Inverse().TransformPoint(local);
 }
 
-G4ThreeVector CaloSD::setToGlobal(const G4ThreeVector& local, const G4VTouchable* touch) {
-
-  G4ThreeVector globalPoint = touch->GetHistory()->GetTopTransform().Inverse().TransformPoint(local);
-  
-  return globalPoint;  
-}
-
-G4bool CaloSD::hitExists() {
-#ifdef DebugLog
-  if (currentID.trackID()<1)
-    edm::LogWarning("CaloSim") << "***** CaloSD error: primaryID = " 
-                               << currentID.trackID()
-                               << " maybe detector name changed";
-#endif  
+bool CaloSD::hitExists(const G4Step* aStep) {
   // Update if in the same detector, time-slice and for same track   
   if (currentID == previousID) {
     updateHit(currentHit);
@@ -290,14 +298,13 @@ G4bool CaloSD::hitExists() {
   }
   
   // Reset entry point for new primary
-  posGlobal = preStepPoint->GetPosition();
   if (currentID.trackID() != previousID.trackID()) { 
-    resetForNewPrimary(posGlobal, preStepPoint->GetKineticEnergy());
+    resetForNewPrimary(aStep);
   }
   return checkHit();
 }
 
-G4bool CaloSD::checkHit() {  
+bool CaloSD::checkHit() {  
   //look in the HitContainer whether a hit with the same ID already exists:
   bool       found = false;
   if (useMap) {
@@ -311,10 +318,11 @@ G4bool CaloSD::checkHit() {
     int  minhit= (theHC->entries()>checkHits ? theHC->entries()-checkHits : 0);
     int  maxhit= theHC->entries()-1;
     
-    for (int j=maxhit; j>minhit&&!found; --j) {
+    for (int j=maxhit; j>minhit; --j) {
       if ((*theHC)[j]->getID() == currentID) {
         currentHit = (*theHC)[j];
         found      = true;
+        break;
       }
     }          
   }
@@ -329,32 +337,28 @@ G4bool CaloSD::checkHit() {
 
 int CaloSD::getNumberOfHits() { return theHC->entries(); }
 
-CaloG4Hit* CaloSD::createNewHit() {
+CaloG4Hit* CaloSD::createNewHit(const G4Step* aStep) {
+
+  auto const theTrack = aStep->GetTrack();
 #ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD::CreateNewHit for"
-			  << " Unit " << currentID.unitID() 
-			  << " " << currentID.depth()
-			  << " Edeposit = " << edepositEM << " " << edepositHAD;
-  edm::LogInfo("CaloSim") << " primary "    << currentID.trackID()
-			  << " time slice " << currentID.timeSliceID()
-			  << " For Track  " << theTrack->GetTrackID()
-			  << " which is a " <<theTrack->GetDefinition()->GetParticleName()
-			  << " of energy "  << theTrack->GetKineticEnergy()/GeV
-			  << " " << theTrack->GetMomentum().mag()/GeV
-			  << " daughter of part. " << theTrack->GetParentID()
-			  << " and created by " ;
-  
-  if (theTrack->GetCreatorProcess()!=NULL)
-    edm::LogInfo("CaloSim") << theTrack->GetCreatorProcess()->GetProcessName();
-  else 
-    edm::LogInfo("CaloSim") << "NO process";
+  edm::LogInfo("CaloSim") << "CaloSD::CreateNewHit " << getNumberOfHits()
+                          << " for " << GetName()
+                          << " Unit:" << currentID.unitID() 
+                          << " " << currentID.depth()
+                          << " Edep= " << edepositEM << " " << edepositHAD
+                          << " primaryID= "    << currentID.trackID()
+                          << " timeSlice= " << currentID.timeSliceID()
+                          << " ID= " << theTrack->GetTrackID()
+                          << " " <<theTrack->GetDefinition()->GetParticleName()
+                          << " E(GeV)= "  << theTrack->GetKineticEnergy()/GeV
+                          << " parentID= " << theTrack->GetParentID();
 #endif  
   
   CaloG4Hit* aHit;
   if (!reusehit.empty()) {
     aHit = reusehit[0];
-    aHit->setEM(0.);
-    aHit->setHadr(0.);
+    aHit->setEM(0.f);
+    aHit->setHadr(0.f);
     reusehit.erase(reusehit.begin());
   } else {
     aHit = new CaloG4Hit;
@@ -372,82 +376,84 @@ CaloG4Hit* CaloSD::createNewHit() {
   if (currentID.trackID() == primIDSaved) { // The track is saved; nothing to be done
   } else if (currentID.trackID() == theTrack->GetTrackID()) {
     etrack= theTrack->GetKineticEnergy();
-    //edm::LogInfo("CaloSim") << "CaloSD: set save the track " << currentID.trackID()
-    //      << " etrack " << etrack << " eCut " << energyCut << " flag " << forceSave;
+#ifdef DebugLog
+    edm::LogInfo("CaloSim") << "CaloSD: set save the track " << currentID.trackID()
+                            << " etrack " << etrack << " eCut " << energyCut 
+                            << " force: " << forceSave 
+                            << " save: " << (etrack >= energyCut || forceSave);
+#endif
     if (etrack >= energyCut || forceSave) {
       TrackInformation* trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
       trkInfo->storeTrack(true);
       trkInfo->putInHistory();
-      //      trkInfo->setAncestor();
-#ifdef DebugLog
-      edm::LogInfo("CaloSim") << "CaloSD: set save the track " 
-			      << currentID.trackID() << " with Hit";
-#endif
     }
   } else {
     TrackWithHistory * trkh = tkMap[currentID.trackID()];
 #ifdef DebugLog
     edm::LogInfo("CaloSim") << "CaloSD : TrackwithHistory pointer for " 
-			    << currentID.trackID() << " is " << trkh;
+                            << currentID.trackID() << " is " << trkh;
 #endif
     if (trkh != nullptr) {
       etrack = sqrt(trkh->momentum().Mag2());
       if (etrack >= energyCut) {
         trkh->save();
 #ifdef DebugLog
-	edm::LogInfo("CaloSim") << "CaloSD: set save the track " 
-				<< currentID.trackID() << " with Hit";
+        edm::LogInfo("CaloSim") << "CaloSD: set save the track " 
+                                << currentID.trackID() << " with Hit";
 #endif
       }
     }
   }
   primIDSaved = currentID.trackID();
-  if (useMap) totalHits++;
+  if (useMap) ++totalHits;
   return aHit;
 }  
 
 void CaloSD::updateHit(CaloG4Hit* aHit) {
-  if (edepositEM+edepositHAD != 0) {
-    aHit->addEnergyDeposit(edepositEM,edepositHAD);
+
+  aHit->addEnergyDeposit(edepositEM,edepositHAD);
 #ifdef DebugLog
-    edm::LogInfo("CaloSim") << "CaloSD: Add energy deposit in " << currentID 
-			    << " em " << edepositEM/MeV << " hadronic " 
-			    << edepositHAD/MeV << " MeV"; 
+  edm::LogInfo("CaloSim") << "CaloSD:" << GetName() << " Add energy deposit in " 
+                          << currentID << " Edep_em(MeV)= " 
+                          << edepositEM << " Edep_had(MeV)= " << edepositHAD; 
 #endif
-  }
 
   // buffer for next steps:
   previousID = currentID;
 }
 
-void CaloSD::resetForNewPrimary(const G4ThreeVector& point, double energy) { 
-  entrancePoint  = point;
+void CaloSD::resetForNewPrimary(const G4Step* aStep) { 
+  auto const preStepPoint = aStep->GetPreStepPoint();
+  entrancePoint  = preStepPoint->GetPosition();
   entranceLocal  = setToLocal(entrancePoint, preStepPoint->GetTouchable());
-  incidentEnergy = energy;
+  incidentEnergy = preStepPoint->GetKineticEnergy();
 #ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD: Incident energy " << incidentEnergy/GeV 
-			  << " GeV and" << " entrance point " << entrancePoint 
-			  << " (Global) " << entranceLocal << " (Local)";
+  edm::LogInfo("CaloSim") 
+    << "CaloSD::resetForNewPrimary for " << GetName() 
+    << " ID= " << aStep->GetTrack()->GetTrackID()
+    << " Ein= " << incidentEnergy/GeV 
+    << " GeV and" << " entrance point global: " << entrancePoint 
+    << " local: " << entranceLocal;
 #endif
 }
 
-double CaloSD::getAttenuation(const G4Step* aStep, double birk1, double birk2, double birk3) {
+double CaloSD::getAttenuation(const G4Step* aStep, double birk1, double birk2, double birk3) const {
   double weight = 1.;
   double charge = aStep->GetPreStepPoint()->GetCharge();
+  double length = aStep->GetStepLength();
 
-  if (charge != 0. && aStep->GetStepLength() > 0) {
-    G4Material* mat = aStep->GetPreStepPoint()->GetMaterial();
-    double density = mat->GetDensity();
-    double dedx    = aStep->GetTotalEnergyDeposit()/aStep->GetStepLength();
+  if (charge != 0. && length > 0.) {
+    double density = aStep->GetPreStepPoint()->GetMaterial()->GetDensity();
+    double dedx    = aStep->GetTotalEnergyDeposit()/length;
     double rkb     = birk1/density;
     double c       = birk2*rkb*rkb;
     if (std::abs(charge) >= 2.) rkb /= birk3; // based on alpha particle data
     weight = 1./(1.+rkb*dedx+c*dedx*dedx);
 #ifdef DebugLog
     edm::LogInfo("CaloSim") << "CaloSD::getAttenuation in " << mat->GetName() 
-			    << " Charge " << charge << " dE/dx " << dedx 
-			    << " Birk Const " << rkb << ", " << c << " Weight = " 
-			    << weight << " dE " << aStep->GetTotalEnergyDeposit();
+                            << " Charge " << charge << " dE/dx " << dedx 
+                            << " Birk Const " << rkb << ", " << c << " Weight = " 
+                            << weight << " dE " << aStep->GetTotalEnergyDeposit();
 #endif
   }
   return weight;
@@ -455,13 +461,12 @@ double CaloSD::getAttenuation(const G4Step* aStep, double birk1, double birk2, d
 
 void CaloSD::update(const BeginOfRun *) {
   initRun();
-  runInit = true;
 } 
 
 void CaloSD::update(const BeginOfEvent *) {
 #ifdef DebugLog
   edm::LogInfo("CaloSim")  << "CaloSD: Dispatched BeginOfEvent for " 
-			   << GetName() << " !" ;
+                           << GetName() << " !" ;
 #endif
   clearHits();
 }
@@ -479,13 +484,13 @@ void CaloSD::update(const EndOfTrack * trk) {
         TrackWithHistory * trkH = (*trksForThisEvent)[it];
         if (trkH->trackID() == (unsigned int)(id)) tkMap[id] = trkH;
 #ifdef DebugLog
-	edm::LogInfo("CaloSim") << "CaloSD: get track " << it << " from "
-				<< "Container of size " << trksForThisEvent->size()
-				<< " with ID " << trkH->trackID();
+        edm::LogInfo("CaloSim") << "CaloSD: get track " << it << " from "
+                                << "Container of size " << trksForThisEvent->size()
+                                << " with ID " << trkH->trackID();
       } else {
-	edm::LogInfo("CaloSim") << "CaloSD: get track " << it << " from "
-				<< "Container of size " << trksForThisEvent->size()
-				<< " with no ID";
+        edm::LogInfo("CaloSim") << "CaloSD: get track " << it << " from "
+                                << "Container of size " << trksForThisEvent->size()
+                                << " with no ID";
 #endif
       }
     }
@@ -493,22 +498,55 @@ void CaloSD::update(const EndOfTrack * trk) {
 }
 
 void CaloSD::update(const ::EndOfEvent * ) {
-  int count = 0, wrong = 0;
-  bool ok;
-  
-  slave->ReserveMemory(theHC->entries());
 
+  slave.get()->ReserveMemory(theHC->entries());
+
+  int count(0);
+  int wrong(0);
+  double eEM(0.0); 
+  double eHAD(0.0); 
+  double eEM2(0.0); 
+  double eHAD2(0.0); 
+  double tt(0.0); 
+  double zloc(0.0); 
+  double zglob(0.0); 
+  double ee(0.0); 
+ 
   for (int i=0; i<theHC->entries(); ++i) {
-    ok = saveHit((*theHC)[i]);
+    if(!saveHit((*theHC)[i])) { ++wrong; }
     ++count;
-    if (!ok)  ++wrong;
+    double x = (*theHC)[i]->getEM();
+    eEM += x;
+    eEM2 += x*x;
+    x = (*theHC)[i]->getHadr();
+    eHAD += x;
+    eHAD2 += x*x;
+    tt += (*theHC)[i]->getTimeSlice();
+    ee += (*theHC)[i]->getIncidentEnergy();
+    zglob += std::abs((*theHC)[i]->getEntry().z());
+    zloc  += std::abs((*theHC)[i]->getEntryLocal().z());
   }
   
+  double norm = (count>0) ? 1.0/count : 0.0;  
+  eEM   *= norm;
+  eEM2  *= norm;
+  eHAD  *= norm;
+  eHAD2 *= norm;
+  eEM2   = std::sqrt(eEM2 - eEM*eEM);
+  eHAD2  = std::sqrt(eHAD2 - eHAD*eHAD);
+  tt    *= norm;
+  ee    *= norm;
+  zglob *= norm;
+  zloc  *= norm;
+ 
   edm::LogInfo("CaloSim") << "CaloSD: " << GetName() << " store " << count
-                          << " hits recorded with " << wrong 
+                          << " hits; " << wrong 
                           << " track IDs not given properly and "
-                          << totalHits-count << " hits not passing cuts";
-  summarize();
+                          << totalHits-count << " hits not passing cuts"
+			  << "\n EmeanEM= " << eEM << " ErmsEM= " << eEM2 
+			  << "\n EmeanHAD= " << eHAD << " ErmsHAD= " << eHAD2
+			  << " TimeMean= " << tt << " E0mean= " << ee 
+			  << " Zglob= " << zglob << " Zloc= " << zloc;
 
   tkMap.erase (tkMap.begin(), tkMap.end());
 }
@@ -521,34 +559,50 @@ void CaloSD::clearHits() {
   previousID.reset();
   primIDSaved = -99;
 #ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD: Clears hit vector for " << GetName() << " " << slave;
+  edm::LogInfo("CaloSim") << "CaloSD: Clears hit vector for " << GetName() 
+                          << " and initialise slave: " << slave;
 #endif
-  slave->Initialize();
-#ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD: Initialises slave SD for " << GetName();
-#endif
+  slave.get()->Initialize();
 }
 
 void CaloSD::initRun() {}
 
 int CaloSD::getTrackID(const G4Track* aTrack) {
+
   int primaryID = 0;
   forceSave = false;
   TrackInformation* trkInfo=(TrackInformation *)(aTrack->GetUserInformation());
   if (trkInfo) {
-    primaryID = trkInfo->getIDonCaloSurface(); 
-#ifdef DebugLog
-    edm::LogInfo("CaloSim") << "CaloSD: hit update from track Id on Calo Surface " 
-			    << trkInfo->getIDonCaloSurface();
-#endif   
+    int id = trkInfo->getIDonCaloSurface();
+    if(id > 0) { primaryID = id; } 
   } else {
     primaryID = aTrack->GetTrackID();
-#ifdef DebugLog
-    edm::LogWarning("CaloSim") << "CaloSD: Problem with primaryID **** set by "
-                               << "force to TkID **** " << primaryID << " in "
-                               << preStepPoint->GetTouchable()->GetVolume(0)->GetName();
-#endif
   }
+#ifdef DebugLog
+  edm::LogInfo("CaloSim") << "CaloSD::getTrackID for " << GetName() 
+                          << " trackID= " << aTrack->GetTrackID()
+                          << " primaryID= " << primaryID;
+#endif
+  return primaryID;
+}
+
+int CaloSD::setTrackID(const G4Step* aStep) {
+
+  auto const theTrack = aStep->GetTrack();
+  TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
+  int primaryID = trkInfo->getIDonCaloSurface();
+  if (primaryID == 0) {
+    primaryID = theTrack->GetTrackID();
+  }
+
+  if (primaryID != previousID.trackID()) {
+    resetForNewPrimary(aStep);
+  }
+#ifdef DebugLog
+  edm::LogInfo("CaloSim") << "CaloSD::setTrackID for " << GetName() 
+                          << " trackID= " << aStep->GetTrack()->GetTrackID()
+                          << " primaryID= " << primaryID;
+#endif
   return primaryID;
 }
 
@@ -558,25 +612,26 @@ bool CaloSD::filterHit(CaloG4Hit* hit, double time) {
   double emin(eminHit);
   if (hit->getDepth() > 0) emin = eminHitD;
 #ifdef DebugLog
-  edm::LogInfo("CaloSim") << "Depth " << hit->getDepth() << " Emin = " << emin 
-			  << " (" << eminHit << ", " << eminHitD << ")";
+  edm::LogInfo("CaloSim") << "CaloSD::filterHit(..) Depth " << hit->getDepth() 
+                          << " Emin = " << emin 
+                          << " (" << eminHit << ", " << eminHitD << ")";
 #endif   
   return ((time <= tmaxHit) && (hit->getEnergyDeposit() > emin));
 }
 
 double CaloSD::getResponseWt(const G4Track* aTrack) {
-  if (meanResponse) {
+  double wt = 1.0;
+  if (meanResponse.get()) {
     TrackInformation * trkInfo = (TrackInformation *)(aTrack->GetUserInformation());
-    return meanResponse->getWeight(trkInfo->genParticlePID(), trkInfo->genParticleP());
-  } else {
-    return 1;
+    wt = meanResponse.get()->getWeight(trkInfo->genParticlePID(), trkInfo->genParticleP());
   }
+  return wt;
 }
 
 void CaloSD::storeHit(CaloG4Hit* hit) {
   if (previousID.trackID()<0) return;
   if (hit == nullptr) {
-    edm::LogWarning("CaloSim") << "CaloSD: hit to be stored is NULL !!";
+    edm::LogWarning("CaloSim") << "CaloSD: hit to be stored is nullptr !!";
     return;
   }
   
@@ -592,35 +647,32 @@ bool CaloSD::saveHit(CaloG4Hit* aHit) {
     if (tkID == 0) {
       if (m_trackManager->trackExists(aHit->getTrackID())) tkID = (aHit->getTrackID());
       else {
-	ok = false;
+        ok = false;
       }
     }
   } else {
     tkID = aHit->getTrackID();
     ok = false;
   }
-  //  edm::LogInfo("CaloSim") << "CalosD: Track ID " << aHit->getTrackID() << " changed to " << tkID << " by SimTrackManager" << " Status " << ok;
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CalosD: Track ID " << aHit->getTrackID() 
-			  << " changed to " << tkID << " by SimTrackManager"
-			  << " Status " << ok;
+                          << " changed to " << tkID << " by SimTrackManager"
+                          << " Status " << ok;
 #endif
   double time = aHit->getTimeSlice();
   if (corrTOFBeam) time += correctT;
-  slave->processHits(aHit->getUnitID(), aHit->getEM()/GeV, 
-                     aHit->getHadr()/GeV, time, tkID, aHit->getDepth());
+  slave.get()->processHits(aHit->getUnitID(), aHit->getEM()/GeV, 
+                           aHit->getHadr()/GeV, time, tkID, aHit->getDepth());
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: Store Hit at " << std::hex 
-			  << aHit->getUnitID() << std::dec << " " 
-			  << aHit->getDepth() << " due to " << tkID 
-			  << " in time " << time << " of energy " 
-			  << aHit->getEM()/GeV << " GeV (EM) and " 
-			  << aHit->getHadr()/GeV << " GeV (Hadr)";
+                          << aHit->getUnitID() << std::dec << " " 
+                          << aHit->getDepth() << " due to " << tkID 
+                          << " in time " << time << " of energy " 
+                          << aHit->getEM()/GeV << " GeV (EM) and " 
+                          << aHit->getHadr()/GeV << " GeV (Hadr)";
 #endif
   return ok;
 }
-
-void CaloSD::summarize() {}
 
 void CaloSD::update(const BeginOfTrack * trk) {
   int primary = -1;
@@ -629,8 +681,8 @@ void CaloSD::update(const BeginOfTrack * trk) {
   
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "New track: isPrimary " << trkInfo->isPrimary() 
-			  << " primary ID = " << primary 
-			  << " primary ancestor ID " << primAncestor;
+                          << " primary ID = " << primary 
+                          << " primary ancestor ID " << primAncestor;
 #endif
   
   // update the information if a different primary track ID 
@@ -649,7 +701,8 @@ void CaloSD::cleanHitCollection() {
   std::vector<CaloG4Hit*>* theCollection = theHC->GetVector();
 
 #ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD: collection before merging, size = " << theHC->entries();
+  edm::LogInfo("CaloSim") << "CaloSD: collection before merging, size = " 
+                          << theHC->entries();
 #endif
   
   selIndex.reserve(theHC->entries()-cleanIndex);
@@ -661,7 +714,7 @@ void CaloSD::cleanHitCollection() {
     sort((hitvec.begin()+cleanIndex), hitvec.end(), CaloG4HitLess());
 #ifdef DebugLog
     edm::LogInfo("CaloSim") << "CaloSD::cleanHitCollection: sort hits in buffer "
-			    << "starting from element = " << cleanIndex;
+                            << "starting from element = " << cleanIndex;
     for (unsigned int i = 0; i<hitvec.size(); ++i) 
       edm::LogInfo("CaloSim") << i << " " << *hitvec[i];
 #endif
@@ -691,7 +744,7 @@ void CaloSD::cleanHitCollection() {
     hitvec.resize(cleanIndex+selIndex.size());
 #ifdef DebugLog
     edm::LogInfo("CaloSim") << "CaloSD::cleanHitCollection: remove the merged hits in buffer,"
-			    << " new size = " << hitvec.size();
+                            << " new size = " << hitvec.size();
     for (unsigned int i = 0; i<hitvec.size(); ++i) 
       edm::LogInfo("CaloSim") << i << " " << *hitvec[i];
 #endif
@@ -702,16 +755,12 @@ void CaloSD::cleanHitCollection() {
   }
 
 #ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD: collection after merging, size = " << theHC->entries();
-#endif
-
-  int addhit = 0;
-
-#ifdef DebugLog
-  edm::LogInfo("CaloSim") << "CaloSD: Size of reusehit after merge = " << reusehit.size();
-  edm::LogInfo("CaloSim") << "CaloSD: Starting hit selection from index = " << cleanIndex;
+  edm::LogInfo("CaloSim") << "CaloSD: collection after merging, size= " << theHC->entries()
+                          << " Size of reusehit= " << reusehit.size()
+                          << "\n      starting hit selection from index = " << cleanIndex;
 #endif
   
+  int addhit = 0;
   selIndex.reserve(theCollection->size()-cleanIndex);
   for (unsigned int i = cleanIndex; i<theCollection->size(); ++i) {   
     CaloG4Hit* aHit((*theCollection)[i]);
@@ -736,8 +785,8 @@ void CaloSD::cleanHitCollection() {
 
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: Size of reusehit after selection = " 
-			  << reusehit.size() << " Number of added hit = " 
-			  << addhit;
+                          << reusehit.size() << " Number of added hit = " 
+                          << addhit;
 #endif
   if (useMap) {
     if ( addhit>0 ) {
@@ -757,7 +806,7 @@ void CaloSD::cleanHitCollection() {
 
 #ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: hit collection after selection, size = "
-			  << theHC->entries();
+                          << theHC->entries();
   theHC->PrintAllHits();
 #endif
     

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -206,14 +206,13 @@ double ECalSD::getEnergyDeposit(const G4Step * aStep) {
   edep *= weight*wt1;
   // Russian Roulette
   double wt2 = theTrack->GetWeight();
-  //#ifdef EDM_ML_DEBUG
-  if(theTrack->GetTrackID() == 82946)
+  if(wt2 > 0.0) { edep *= wt2; }
+#ifdef EDM_ML_DEBUG
   edm::LogInfo("EcalSim") << lv->GetName()
                           << " Light Collection Efficiency " << weight << ":"
                           << wt1 << " wt2= " << wt2
                           << " Weighted Energy Deposit " << edep/MeV << " MeV";
-  //#endif
-  if(wt2 > 0.0) { edep *= wt2; }
+#endif
   return edep; 
 }
 

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -145,7 +145,9 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
                           << "\tDepth2 Name = " << depth2Name
                           << "\n\tstoreRL" << storeRL << ":" << scaleRL
                           << "\tstoreLayerTimeSim " << storeLayerTimeSim
-                          << "\n\ttime Granularity " << p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit") << " ns"; 
+                          << "\n\ttime Granularity " 
+                          << p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit") 
+                          << " ns"; 
   if (useWeight) initMap(name,cpv);
 #ifdef plotDebug
   edm::Service<TFileService> tfile;
@@ -167,95 +169,58 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
 }
 
 ECalSD::~ECalSD() {
-  if (numberingScheme) delete numberingScheme;
+  delete numberingScheme;
 }
 
-double ECalSD::getEnergyDeposit(G4Step * aStep) {
-  
-  if (aStep == nullptr) {
-    return 0;
-  } else {
-    preStepPoint = aStep->GetPreStepPoint();
-    theTrack     = aStep->GetTrack();
-    double wt2   = theTrack->GetWeight();
-    const G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
+double ECalSD::getEnergyDeposit(const G4Step * aStep) {
 
-    // take into account light collection curve for crystals
-    double weight = 1.;
-    if (suppressHeavy) {
-      TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
-      if (trkInfo) {
-        int pdg = theTrack->GetDefinition()->GetPDGEncoding();
-        if (!(trkInfo->isPrimary())) { // Only secondary particles
-          double ke = theTrack->GetKineticEnergy()/MeV;
-          if (((pdg/1000000000 == 1 && ((pdg/10000)%100) > 0 &&
-                ((pdg/10)%100) > 0)) && (ke<kmaxIon)) weight = 0;
-          if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
-          if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
-#ifdef EDM_ML_DEBUG
-          if (weight == 0) 
-            edm::LogInfo("EcalSim") << "Ignore Track " << theTrack->GetTrackID()
-                                    << " Type " << theTrack->GetDefinition()->GetParticleName()
-                                    << " Kinetic Energy " << ke << " MeV";
-#endif
-        }
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
+  const G4Track* theTrack = aStep->GetTrack();
+  double edep = aStep->GetTotalEnergyDeposit();
+
+  // take into account light collection curve for crystals
+  double weight = 1.;
+  if (suppressHeavy) {
+    TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
+    if (trkInfo) {
+      int pdg = theTrack->GetDefinition()->GetPDGEncoding();
+      if (!(trkInfo->isPrimary())) { // Only secondary particles
+        double ke = theTrack->GetKineticEnergy();
+        if (((pdg/1000000000 == 1 && ((pdg/10000)%100) > 0 &&
+              ((pdg/10)%100) > 0)) && (ke<kmaxIon)) weight = 0;
+        if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
+        if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
       }
     }
-    const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-    if (useWeight && !any(noWeight,lv)) {
-      weight *= curve_LY(aStep);
-      if (useBirk) {
-        if (useBirkL3) weight *= getBirkL3(aStep);
-        else           weight *= getAttenuation(aStep, birk1, birk2, birk3);
-      }
+  }
+  const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+  double wt1 = 1.0;
+  if (useWeight && !any(noWeight,lv)) {
+    weight *= curve_LY(lv);
+    if (useBirk) {
+      if (useBirkL3) weight *= getBirkL3(aStep);
+      else           weight *= getAttenuation(aStep, birk1, birk2, birk3);
     }
-    double wt1  = getResponseWt(theTrack);
-    double edep = aStep->GetTotalEnergyDeposit()*weight*wt1;
-    /*
-    if(wt2 != 1.0) { 
-      edm::LogInfo("EcalSim") << "ECalSD:: " << nameVolume
-                              <<" LightWeight= " <<weight << " wt1= " <<wt1
-                              << "  wt2= " << wt2 << "  "
-                              << " Weighted Energy Deposit " << edep/MeV
-                              << " MeV";
-      const G4VProcess* pr = theTrack->GetCreatorProcess();
-      if (pr) 
-        edm::LogInfo("EcalSim") << theTrack->GetDefinition()->GetParticleName()
-                                << " " << theTrack->GetKineticEnergy()
-                                << " Id=" << theTrack->GetTrackID()
-                                << " IdP=" << theTrack->GetParentID()
-                                << " from  " << pr->GetProcessName();
-      else
-        edm::LogInfo("EcalSim") << theTrack->GetDefinition()->GetParticleName()
-                                << " " << theTrack->GetKineticEnergy()
-                                << " Id=" << theTrack->GetTrackID()
-                                << " IdP=" << theTrack->GetParentID();
-    }
-    */
-    if(wt2 > 0.0) { edep *= wt2; }
-#ifdef EDM_ML_DEBUG
-    edm::LogInfo("EcalSim") << "ECalSD:: " << nameVolume
-                            << " Light Collection Efficiency " << weight << ":"
-                            << wt1 << " Weighted Energy Deposit " << edep/MeV 
-                            << " MeV";
-#endif
-    return edep;
-  } 
+    wt1 = getResponseWt(theTrack);
+  }
+  edep *= weight*wt1;
+  // Russian Roulette
+  double wt2 = theTrack->GetWeight();
+  //#ifdef EDM_ML_DEBUG
+  if(theTrack->GetTrackID() == 82946)
+  edm::LogInfo("EcalSim") << lv->GetName()
+                          << " Light Collection Efficiency " << weight << ":"
+                          << wt1 << " wt2= " << wt2
+                          << " Weighted Energy Deposit " << edep/MeV << " MeV";
+  //#endif
+  if(wt2 > 0.0) { edep *= wt2; }
+  return edep; 
 }
 
 int ECalSD::getTrackID(const G4Track* aTrack) {
 
   int  primaryID(0);
-  bool flag(false);
-  if (storeTrack) {
-    const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-    if (any(useDepth1,lv)) {
-      flag = true;
-    } else if (any(useDepth2,lv)) {
-      flag = true;
-    }
-  }
-  if (flag) {
+  if (storeTrack && depth > 0) {
     forceSave = true;
     primaryID = aTrack->GetTrackID();
   } else {
@@ -265,17 +230,25 @@ int ECalSD::getTrackID(const G4Track* aTrack) {
 }
 
 uint16_t ECalSD::getDepth(const G4Step * aStep) {
+
+  // this method should be called first at a step
   const G4StepPoint* hitPoint = aStep->GetPreStepPoint();
+  currentLocalPoint = setToLocal(hitPoint->GetPosition(), hitPoint->GetTouchable());
   const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-  uint16_t depth  = any(useDepth1,lv) ? 1 : (any(useDepth2,lv) ? 2 : 0);
+
+  auto ite = xtalLMap.find(lv);
+  crystalLength = (ite == xtalLMap.end()) ? 230.0 : std::abs(ite->second);
+  crystalDepth = (ite == xtalLMap.end()) 
+    ? 0.0 : (std::abs(0.5*(ite->second)+currentLocalPoint.z()));
+  depth = any(useDepth1,lv) ? 1 : (any(useDepth2,lv) ? 2 : 0);
+
   if (storeRL) {
-    auto ite        = xtalLMap.find(lv);
     uint16_t depth1 = (ite == xtalLMap.end()) ? 0 : (((ite->second) >= 0) ? 0 :
                                                      PCaloHit::kEcalDepthRefz);
-    uint16_t depth2 = getRadiationLength(aStep);
+    uint16_t depth2 = getRadiationLength(hitPoint, lv);
     depth          |= (((depth2&PCaloHit::kEcalDepthMask) << PCaloHit::kEcalDepthOffset) | depth1);
   } else if (storeLayerTimeSim) {
-    uint16_t depth2 = getLayerIDForTimeSim(aStep);
+    uint16_t depth2 = getLayerIDForTimeSim();
     depth          |= ((depth2&PCaloHit::kEcalDepthMask) << PCaloHit::kEcalDepthOffset);
   }
 #ifdef EDM_ML_DEBUG
@@ -286,63 +259,41 @@ uint16_t ECalSD::getDepth(const G4Step * aStep) {
   return depth;
 }
 
-uint16_t ECalSD::getRadiationLength(const G4Step * aStep) {
+uint16_t ECalSD::getRadiationLength(const G4StepPoint* hitPoint, const G4LogicalVolume* lv) {
   
   uint16_t thisX0 = 0;
-  if (aStep != nullptr) {
-    const G4StepPoint* hitPoint = aStep->GetPreStepPoint();
-    const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-#ifdef EDM_ML_DEBUG
-    edm::LogInfo("EcalSim") << lv->GetName() << " useWight " << useWeight;
-#endif
-    if (useWeight) {
-      const G4ThreeVector  localPoint = setToLocal(hitPoint->GetPosition(),
-                                                   hitPoint->GetTouchable());
-      double radl     = preStepPoint->GetMaterial()->GetRadlen();
-      double depth    = crystalDepth(lv,localPoint);
-      thisX0 = (uint16_t)floor(scaleRL*depth/radl);
+  if (useWeight) {
+    double radl = hitPoint->GetMaterial()->GetRadlen();
+    thisX0 = (uint16_t)floor(scaleRL*crystalDepth/radl);
 #ifdef plotDebug
-      std::string lvname = lv->GetName();
-      int k1 = (lvname.find("EFRY")!=std::string::npos) ? 2 : 0;
-      int k2 = (lvname.find("refl")!=std::string::npos) ? 1 : 0;
-      int kk = k1+k2;
-      double rz = (k1 == 0) ? (hitPoint->GetPosition()).rho() : 
-        std::abs((hitPoint->GetPosition()).z());
-      edm::LogVerbatim("EcalSim") << lvname << " # " << k1 << ":" << k2 << ":" 
-                                  << kk << " rz " << rz << " D " << thisX0;
-      g2L_[kk]->Fill(rz,thisX0);
+    const std::string& lvname = lv->GetName();
+    int k1 = (lvname.find("EFRY")!=std::string::npos) ? 2 : 0;
+    int k2 = (lvname.find("refl")!=std::string::npos) ? 1 : 0;
+    int kk = k1+k2;
+    double rz = (k1 == 0) ? (hitPoint->GetPosition()).rho() : 
+      std::abs((hitPoint->GetPosition()).z());
+    edm::LogVerbatim("EcalSim") << lvname << " # " << k1 << ":" << k2 << ":" 
+                                << kk << " rz " << rz << " D " << thisX0;
+    g2L_[kk]->Fill(rz,thisX0);
 #endif
 #ifdef EDM_ML_DEBUG
-      double crlength = crystalLength(lv);
-      edm::LogVerbatim("EcalSim") << lv->GetName() << " Global " 
-                                  << hitPoint->GetPosition() << ":" 
-                                  << (hitPoint->GetPosition()).rho() 
-                                  << " Local " << localPoint 
-                                  << " Crystal Length " << crlength 
-                                  << " Radl " << radl << " DetZ " << detz 
-                                  << " Index " << thisX0 
-                                  << " : " << getLayerIDForTimeSim(aStep);
+    edm::LogVerbatim("EcalSim") << lv->GetName() << " Global " 
+                                << hitPoint->GetPosition() << ":" 
+                                << (hitPoint->GetPosition()).rho() 
+                                << " Local " << localPoint 
+                                << " Crystal Length " << crlength 
+                                << " Radl " << radl << " DetZ " << detz 
+                                << " Index " << thisX0 
+                                << " : " << getLayerIDForTimeSim();
 #endif
-    } 
-  }
+  } 
   return thisX0;
 }
 
-uint16_t ECalSD::getLayerIDForTimeSim(const G4Step * aStep) 
+uint16_t ECalSD::getLayerIDForTimeSim() 
 {
-  float    layerSize = 1*cm; //layer size in cm
-  if (!isEB && !isEE)  return 0;
-
-  if (aStep != nullptr ) {
-    const G4StepPoint* hitPoint = aStep->GetPreStepPoint();
-    const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-    const G4ThreeVector  localPoint = setToLocal(hitPoint->GetPosition(),
-                                                 hitPoint->GetTouchable());
-    double detz     = crystalDepth(lv,localPoint);
-    if (detz<0) detz= 0;
-    return (int)detz/layerSize;
-  }
-  return 0;
+  const double invLayerSize = 0.1; //layer size in 1/mm
+  return (int)crystalDepth*invLayerSize;
 }
 
 uint32_t ECalSD::setDetUnitId(const G4Step * aStep) { 
@@ -434,7 +385,7 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
 #ifdef EDM_ML_DEBUG
           edm::LogInfo("EcalSim") << "ECalSD::initMap (for " << sd 
                                   << "): Solid " << lvname << " Shape " 
-                                  << DDSolidShapesName::name(sol.shape()) << " Parameter 0 = "
+                                  << sol.shape() << " Parameter 0 = "
                                   << paras[0] << " Logical Volume " << lv;
 #endif
           if (sol.shape() == DDSolidShape::ddtrap) {
@@ -482,58 +433,34 @@ void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
 #endif
 }
 
-double ECalSD::curve_LY(const G4Step* aStep) {
-
-  const G4LogicalVolume* lv = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+double ECalSD::curve_LY(const G4LogicalVolume* lv) {
 
   double weight = 1.;
-  const G4ThreeVector localPoint = setToLocal(preStepPoint->GetPosition(),
-                                              preStepPoint->GetTouchable());
-
-  double crlength = crystalLength(lv);
-  double depth    = crystalDepth(lv,localPoint);
-
   if (ageingWithSlopeLY) {
     //position along the crystal in mm from 0 to 230 (in EB)
-    if (depth >= -0.1 || depth <= crlength+0.1)
-      weight = ageing.calcLightCollectionEfficiencyWeighted(currentID.unitID(), depth/crlength);
+    if (crystalDepth >= -0.1 || crystalDepth <= crystalLength+0.1)
+      weight = ageing.calcLightCollectionEfficiencyWeighted(currentID.unitID(), 
+                                                            crystalDepth/crystalLength);
   } else {
-    double dapd = crlength - depth;
-    if (dapd >= -0.1 || dapd <= crlength+0.1) {
+    double dapd = crystalLength - crystalDepth;
+    if (dapd >= -0.1 || dapd <= crystalLength+0.1) {
       if (dapd <= 100.)
         weight = 1.0 + slopeLY - dapd * 0.01 * slopeLY;
     } else {
       edm::LogWarning("EcalSim") << "ECalSD: light coll curve : wrong distance "
                                  << "to APD " << dapd << " crlength = " 
-                                 << crlength <<" crystal name = " <<lv->GetName()
-                                 << " z of localPoint = " << localPoint.z() 
+                                 << crystalLength <<" crystal name = " <<lv->GetName()
+                                 << " z of localPoint = " << currentLocalPoint.z() 
                                  << " take weight = " << weight;
     }
   }
   return weight;
 }
 
-double ECalSD::crystalLength(const G4LogicalVolume* lv) {
-
-  auto ite = xtalLMap.find(lv);
-  double length = (ite == xtalLMap.end()) ? 230.0 : std::abs(ite->second);
-  return length;
-}
-
-double ECalSD::crystalDepth(const G4LogicalVolume* lv, 
-                            const G4ThreeVector& localPoint) {
-
-  auto ite = xtalLMap.find(lv);
-  double depth = (ite == xtalLMap.end()) ? 0 :
-    (std::abs(0.5*(ite->second)+localPoint.z()));
-//  (0.5*std::abs(ite->second)+localPoint.z());
-  return depth;
-}
-
 void ECalSD::getBaseNumber(const G4Step* aStep) {
 
   theBaseNumber.reset();
-  const G4VTouchable* touch = preStepPoint->GetTouchable();
+  const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   int theSize = touch->GetHistoryDepth()+1;
   if ( theBaseNumber.getCapacity() < theSize ) theBaseNumber.setSize(theSize);
   //Get name and copy numbers
@@ -552,6 +479,7 @@ void ECalSD::getBaseNumber(const G4Step* aStep) {
 double ECalSD::getBirkL3(const G4Step* aStep) {
 
   double weight = 1.;
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
   double charge = preStepPoint->GetCharge();
 
   if (charge != 0. && aStep->GetStepLength() > 0.) {
@@ -572,7 +500,6 @@ double ECalSD::getBirkL3(const G4Step* aStep) {
 #endif
   }
   return weight;
-
 }
 
 std::vector<double> ECalSD::getDDDArray(const std::string & str,

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -217,7 +217,6 @@ double ECalSD::getEnergyDeposit(const G4Step * aStep) {
 }
 
 int ECalSD::getTrackID(const G4Track* aTrack) {
-
   int  primaryID(0);
   if (storeTrack && depth > 0) {
     forceSave = true;

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -6,7 +6,6 @@
 #include "SimG4CMS/Calo/interface/HCalSD.h"
 #include "SimG4CMS/Calo/interface/HcalTestNumberingScheme.h"
 #include "SimG4CMS/Calo/interface/HFFibreFiducial.h"
-#include "SimG4CMS/Calo/interface/HcalTestNS.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
@@ -29,18 +28,22 @@
 #include "G4LogicalVolume.hh"
 #include "G4Step.hh"
 #include "G4Track.hh"
-#include "G4ParticleTable.hh"
-#include "G4VProcess.hh"
 
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
+#include "Randomize.hh"
 
 #include <iostream>
 #include <fstream>
 #include <iomanip>
+#include <sstream>
 
 //#define EDM_ML_DEBUG
 //#define plotDebug
+
+#ifdef plotDebug
+#include <TH1F.h>
+#endif
 
 HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
                const SensitiveDetectorCatalog & clg,
@@ -48,10 +51,18 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
   CaloSD(name, cpv, clg, p, manager,
          (float)(p.getParameter<edm::ParameterSet>("HCalSD").getParameter<double>("TimeSliceUnit")),
          p.getParameter<edm::ParameterSet>("HCalSD").getParameter<bool>("IgnoreTrackID")), 
-  hcalConstants(nullptr), numberingFromDDD(nullptr), numberingScheme(nullptr), 
-  showerLibrary(nullptr), hfshower(nullptr), showerParam(nullptr), showerPMT(nullptr), 
-  showerBundle(nullptr), m_HBDarkening(nullptr), m_HEDarkening(nullptr),
-  m_HFDarkening(nullptr), hcalTestNS_(nullptr), depth_(1) {
+  hcalConstants(nullptr), m_HBDarkening(nullptr), m_HEDarkening(nullptr), isHF(false),
+  weight_(1.0), depth_(1) {
+
+  numberingFromDDD.reset(nullptr); 
+  numberingScheme.reset(nullptr); 
+  showerLibrary.reset(nullptr); 
+  hfshower.reset(nullptr); 
+  showerParam.reset(nullptr);
+  showerPMT.reset(nullptr); 
+  showerBundle.reset(nullptr);
+  m_HFDarkening.reset(nullptr);
+  m_HcalTestNS.reset(nullptr);
 
   //static SimpleConfigurable<double> bk1(0.013, "HCalSD:BirkC1");
   //static SimpleConfigurable<double> bk2(0.0568,"HCalSD:BirkC2");
@@ -89,10 +100,7 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
 #ifdef EDM_ML_DEBUG
   LogDebug("HcalSim") << "***************************************************" 
                       << "\n"
-                      << "*                                                 *"
-                      << "\n"
                       << "* Constructing a HCalSD  with name " << name << "\n"
-                      << "*                                                 *"
                       << "\n"
                       << "***************************************************";
 #endif
@@ -112,31 +120,36 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
                           << "         Threshold for storing hits in HB: "
                           << eminHitHB << " HE: " << eminHitHE << " HO: "
                           << eminHitHO << " HF: " << eminHitHF << "\n"
-			  << "Delivered luminosity for Darkening " 
-			  << deliveredLumi << " Flag (HE) " << agingFlagHE
-              << " Flag (HB) " << agingFlagHB
-			  << " Flag (HF) " << agingFlagHF << "\n"
-			  << "Application of Fiducial Cut " << applyFidCut
-			  << "Flag for test number|neutral density filter "
-			  << testNumber << " " << neutralDensity;
+                          << "Delivered luminosity for Darkening " 
+                          << deliveredLumi << " Flag (HE) " << agingFlagHE
+                          << " Flag (HB) " << agingFlagHB
+                          << " Flag (HF) " << agingFlagHF << "\n"
+                          << "Application of Fiducial Cut " << applyFidCut
+                          << "Flag for test number|neutral density filter "
+                          << testNumber << " " << neutralDensity;
 
   HcalNumberingScheme* scheme;
-  if (testNumber || forTBH2) 
+  if (testNumber || forTBH2) {
     scheme = dynamic_cast<HcalNumberingScheme*>(new HcalTestNumberingScheme(forTBH2));
-  else 
+  } else { 
     scheme = new HcalNumberingScheme();
+  }
   setNumberingScheme(scheme);
 
+  // always call getFromLibrary() method to identify HF region
+  setParameterized(true);
+
   const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
-  std::vector<G4LogicalVolume *>::const_iterator lvcite;
+  //  std::vector<G4LogicalVolume *>::const_iterator lvcite;
   const G4LogicalVolume* lv;
   std::string attribute, value;
+
   if (useHF) {
     if (useParam) {
-      showerParam = new HFShowerParam(name, cpv, p);
+      showerParam.reset(new HFShowerParam(name, cpv, p));
     }  else {
-      if (useShowerLibrary) showerLibrary = new HFShowerLibrary(name, cpv, p);
-      hfshower  = new HFShower(name, cpv, p, 0);
+      if (useShowerLibrary) { showerLibrary.reset(new HFShowerLibrary(name, cpv, p)); }
+      hfshower.reset(new HFShower(name, cpv, p, 0));
     }
 
     // HF volume names
@@ -148,111 +161,34 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
     fv0.firstChild();
     DDsvalues_type sv0(fv0.mergedSpecifics());
     std::vector<double> temp =  getDDDArray("Levels",sv0);
-    edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute 
-                            << " = " << value << " has " << hfNames.size() 
-			    << " elements";
-    for (unsigned int i=0; i < hfNames.size(); ++i) {
+
+    unsigned int nhf = hfNames.size();
+    std::stringstream ss;
+    ss << "HCalSD: Names to be tested for " << attribute 
+       << " = " << value << " has " << nhf << " elements";
+    for (unsigned int i=0; i < nhf; ++i) {
       G4String namv = hfNames[i];
       lv            = nullptr;
-      for(lvcite=lvs->begin(); lvcite!=lvs->end(); lvcite++) 
-	if((*lvcite)->GetName()==namv) {
-	  lv = (*lvcite);
-	  break;
-	}
-      hfLV.push_back(lv);
-      int level = static_cast<int>(temp[i]);
-      hfLevels.push_back(level);
-      edm::LogInfo("HcalSim") << "HCalSD:  HF[" << i << "] = " << hfNames[i]
-                              << " LV " << hfLV[i] << " at level " 
-			      << hfLevels[i];
-    }
-  
-    // HF Fibre volume names
-    value     = "HFFibre";
-    DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
-    DDFilteredView fv1(cpv,filter1);
-    fibreNames = getNames(fv1);
-    edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute 
-                            << " = " << value << ":";
-    for (unsigned int i=0; i<fibreNames.size(); ++i) {
-      G4String namv = fibreNames[i];
-      lv            = nullptr;
-      for (lvcite = lvs->begin(); lvcite != lvs->end(); ++lvcite) {
-        if ((*lvcite)->GetName() == namv) {
-          lv = (*lvcite);
+      for(auto lvol : *lvs) {
+        if(lvol->GetName() == namv) {
+          lv = lvol;
           break;
         }
       }
-      fibreLV.push_back(lv);
-      edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << fibreNames[i]
-                              << " LV " << fibreLV[i];
+      hfLV.push_back(lv);
+      int level = static_cast<int>(temp[i]);
+      hfLevels.push_back(level);
+      ss << "\n        HF[" << i << "] = " << namv
+         << " LV " << hfLV[i] << " at level " << hfLevels[i];
     }
+    edm::LogInfo("HcalSim") << ss.str();
   
-    // HF PMT volume names
-    value     = "HFPMT";
-    DDSpecificsMatchesValueFilter filter3{DDValue(attribute,value,0)};
-    DDFilteredView fv3(cpv,filter3);
-    std::vector<G4String> pmtNames = getNames(fv3);
-    edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute 
-			    << " = " << value << " have " << pmtNames.size() 
-			    << " entries";
-    for (unsigned int i=0; i<pmtNames.size(); ++i)  {
-      G4String namv = pmtNames[i];
-      lv            = nullptr;
-      for (lvcite = lvs->begin(); lvcite != lvs->end(); ++lvcite) 
-        if ((*lvcite)->GetName() == namv) {
-	  lv = (*lvcite);
-	  break;
-	}
-      pmtLV.push_back(lv);
-      edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << pmtNames[i]
-                              << " LV " << pmtLV[i];
-    }
-    if (!pmtNames.empty()) showerPMT = new HFShowerPMT (name, cpv, p);
-  
-    // HF Fibre bundles
-    value     = "HFFibreBundleStraight";
-    DDSpecificsMatchesValueFilter filter4{DDValue(attribute,value,0)};
-    DDFilteredView fv4(cpv,filter4);
-    std::vector<G4String> fibreNames = getNames(fv4);
-    edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute
-                            << " = " << value << " have " << fibreNames.size()
-                            << " entries";
-    for (unsigned int i=0; i<fibreNames.size(); ++i) {
-      G4String namv = fibreNames[i];
-      lv            = nullptr;
-      for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) 
-        if ((*lvcite)->GetName() == namv) {
-	  lv = (*lvcite);
-	  break;
-	}
-      fibre1LV.push_back(lv);
-      edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << fibreNames[i]
-                              << " LV " << fibre1LV[i];
-    }
-
-    // Geometry parameters for HF
-    value     = "HFFibreBundleConical";
-    DDSpecificsMatchesValueFilter filter5{DDValue(attribute,value,0)};
-    DDFilteredView fv5(cpv,filter5);
-    fibreNames = getNames(fv5);
-    edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute
-			    << " = " << value << " have " << fibreNames.size() 
-			    << " entries";
-    for (unsigned int i=0; i<fibreNames.size(); ++i) {
-      G4String namv = fibreNames[i];
-      lv            = nullptr;
-      for (lvcite = lvs->begin(); lvcite != lvs->end(); ++lvcite) 
-	if ((*lvcite)->GetName() == namv) {
-	  lv = (*lvcite);
-	  break;
-	}
-      fibre2LV.push_back(lv);
-      edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << fibreNames[i]
-                              << " LV " << fibre2LV[i];
-    }
-    if (!fibre1LV.empty() || !fibre2LV.empty()) 
-      showerBundle = new HFShowerFibreBundle (name, cpv, p);
+    // HF Fibre volume names
+    fillLogVolumeVector(attribute, "HFFibre", cpv, fibreLV, fibreNames);
+    std::vector<G4String> tempNames;
+    fillLogVolumeVector(attribute, "HFPMT", cpv, pmtLV, tempNames);
+    fillLogVolumeVector(attribute, "HFFibreBundleStraight", cpv, fibre1LV, tempNames);
+    fillLogVolumeVector(attribute, "HFFibreBundleConical", cpv, fibre2LV, tempNames);
   }
 
   //Material list for HB/HE/HO sensitive detectors
@@ -291,20 +227,22 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
     dodet = fv2.next();
   }
 
+  std::stringstream sss;
+  for (unsigned int i=0; i<matNames.size(); ++i) {
+    if(i/10*10 == i) { sss << "\n"; }
+    sss << "  "  << matNames[i];
+  }
   edm::LogInfo("HcalSim") << "HCalSD: Material names for " << attribute 
-                          << " = " << name << ":";
-  for (unsigned int i=0; i<matNames.size(); ++i)
-    edm::LogInfo("HcalSim") << "HCalSD: (" << i << ") " << matNames[i]
-                            << " pointer " << materials[i];
+                          << " = " << name << ":" << sss.str();
 
-  isEM = false;
-  
-  if (useLayerWt) readWeightFromFile(file);
+  if (useLayerWt) { readWeightFromFile(file); }
 
-  for (int i=0;  i<9; ++i) hit_[i] = time_[i]= dist_[i] = nullptr;
+  for (int i=0;  i<9; ++i) { hit_[i] = time_[i]= dist_[i] = nullptr; }
   hzvem = hzvhad = nullptr;
 
-  if (agingFlagHF) m_HFDarkening.reset(new HFDarkening(m_HC.getParameter<edm::ParameterSet>("HFDarkeningParameterBlock")));
+  if (agingFlagHF) {
+    m_HFDarkening.reset(new HFDarkening(m_HC.getParameter<edm::ParameterSet>("HFDarkeningParameterBlock")));
+  }
 #ifdef plotDebug
   edm::Service<TFileService> tfile;
 
@@ -344,136 +282,160 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
 #endif
 }
 
-HCalSD::~HCalSD() { 
+void HCalSD::fillLogVolumeVector(const std::string& attribute, const std::string& value, 
+                                 const DDCompactView& cpv,
+                                 std::vector<const G4LogicalVolume*>& lvvec,
+                                 std::vector<G4String>& lvnames) {
 
-  if (numberingFromDDD) delete numberingFromDDD;
-  if (numberingScheme)  delete numberingScheme;
-  if (showerLibrary)    delete showerLibrary;
-  if (hfshower)         delete hfshower;
-  if (showerParam)      delete showerParam;
-  if (showerPMT)        delete showerPMT;
-  if (showerBundle)     delete showerBundle;
-  if (hcalTestNS_)      delete hcalTestNS_;
-}
+  const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
+  const G4LogicalVolume* lv;
 
-bool HCalSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute,value,0)};
+  DDFilteredView fv(cpv,filter);
+  lvnames = getNames(fv);
 
-  NaNTrap( aStep ) ;
-  
-  if (aStep == nullptr) {
-    return true;
-  } else {
-    depth_ = (aStep->GetPreStepPoint()->GetTouchable()->GetReplicaNumber(0))%10;
-    const G4LogicalVolume* lv =
-      aStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume();
-    isEM = (G4TrackToParticleID::isGammaElectronPositron(aStep->GetTrack())) ? true : false;
-    G4String nameVolume = lv->GetName();
-    if (isItHF(aStep)) {
-      double weight(1.0);
-      if (m_HFDarkening) {
-	G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
-	double r = hitPoint.perp()/CLHEP::cm;
-	double z = std::abs(hitPoint.z())/CLHEP::cm;
-	double dose_acquired = 0.;
-	if (z>=HFDarkening::lowZLimit && z <= HFDarkening::upperZLimit) {
-	  unsigned int hfZLayer = (int)((z - HFDarkening::lowZLimit)/5);
-	  if (hfZLayer >= HFDarkening::upperZLimit) hfZLayer = (HFDarkening::upperZLimit-1);
-	  float normalized_lumi = m_HFDarkening->int_lumi(deliveredLumi);
-	  for (int i = hfZLayer; i != HFDarkening::numberOfZLayers; ++i) {
-	    dose_acquired = m_HFDarkening->dose(i,r);
-	    weight *= m_HFDarkening->degradation(normalized_lumi*dose_acquired);
-	  }
-	}
-#ifdef EDM_ML_DEBUG
-	LogDebug("HcalSim") << "HCalSD: HFLumiDarkening at r = " << r 
-			    << ", z = " << z << " Dose " << dose_acquired 
-			    << " weight " << weight;
-#endif
-      }
-      if (useParam) {
-#ifdef EDM_ML_DEBUG
-        LogDebug("HcalSim") << "HCalSD: " << getNumberOfHits()
-			    << " hits from parametrization in " << nameVolume 
-			    << " for Track " << aStep->GetTrack()->GetTrackID()
-			    <<" (" << aStep->GetTrack()->GetDefinition()->GetParticleName() 
-			    <<")";
-#endif
-        getFromParam(aStep, weight);
-#ifdef EDM_ML_DEBUG
-        LogDebug("HcalSim") << "HCalSD: " << getNumberOfHits() 
-			    << " hits afterParamS*";
-#endif 
-      } else {
-	// shower library is applied only for gamma, e+- or stable hadrons
-	// muons are tracked via HF, hyperons does not interact
-        if (useShowerLibrary && !G4TrackToParticleID::isMuon(aStep->GetTrack())) {
-	  if(isEM || G4TrackToParticleID::isStableHadronIon(aStep->GetTrack())) {
-	    getFromLibrary(aStep, weight);
-	  }
-#ifdef EDM_ML_DEBUG
-          LogDebug("HcalSim") << "HCalSD: Starts shower library from " 
-                              << nameVolume << " for Track " 
-                              << aStep->GetTrack()->GetTrackID() << " ("
-                              << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-        } else if (isItFibre(lv)) {
-#ifdef EDM_ML_DEBUG
-          LogDebug("HcalSim") << "HCalSD: Hit at Fibre in " << nameVolume 
-                              << " for Track " 
-                              << aStep->GetTrack()->GetTrackID() <<" ("
-                              << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-          hitForFibre(aStep, weight);
-        }
-      }
-    } else if (isItPMT(lv)) {
-#ifdef EDM_ML_DEBUG
-      LogDebug("HcalSim") << "HCalSD: Hit from PMT parametrization from " 
-                          <<  nameVolume << " for Track " 
-                          << aStep->GetTrack()->GetTrackID() << " ("
-                          << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-      if (usePMTHit && showerPMT) getHitPMT(aStep);
-    } else if (isItStraightBundle(lv) || isItConicalBundle(lv)) {
-#ifdef EDM_ML_DEBUG
-      LogDebug("HcalSim") << "HCalSD: Hit from FibreBundle from "
-                          << nameVolume << " for Track " 
-                          << aStep->GetTrack()->GetTrackID() << " ("
-                          << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-      if (useFibreBundle && showerBundle) 
-	getHitFibreBundle(aStep, isItConicalBundle(lv));
-    } else {
-#ifdef EDM_ML_DEBUG
-      LogDebug("HcalSim") << "HCalSD: Hit from standard path from " 
-                          <<  nameVolume << " for Track " 
-                          << aStep->GetTrack()->GetTrackID() << " ("
-                          << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-      if (getStepInfo(aStep)) {
-#ifdef plotDebug
-        if (edepositEM+edepositHAD > 0)
-          plotProfile(aStep, aStep->GetPreStepPoint()->GetPosition(),
-                      edepositEM+edepositHAD,aStep->GetPostStepPoint()->GetGlobalTime(),0);
-#endif
-        if (hitExists() == false && edepositEM+edepositHAD>0.) currentHit = createNewHit();
+  unsigned int nvol = lvnames.size();
+  std::stringstream ss;
+  ss << "HCalSD: " << nvol << " names to be tested for " << attribute << " <" << value << ">:";
+  for (unsigned int i=0; i<nvol; ++i) {
+    G4String namv = lvnames[i];
+    lv = nullptr;
+    for (auto lvol : *lvs) {
+      if (lvol->GetName() == namv) {
+        lv = lvol;
+        break;
       }
     }
-    return true;
+    lvvec.push_back(lv);
+    if(i/10*10 == i) { ss << "\n"; }
+    ss << "  " << namv;
   }
+  edm::LogInfo("HcalSim") << ss.str();
+}
+
+bool HCalSD::getFromLibrary(const G4Step * aStep) {
+
+  auto const track = aStep->GetTrack();
+  depth_ = (aStep->GetPreStepPoint()->GetTouchable()->GetReplicaNumber(0))%10;
+  weight_= 1.0;
+  bool kill(false);
+  isHF = isItHF(aStep);
+  if(isHF) { 
+    if (m_HFDarkening) {
+      G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
+      const double invcm = 1./CLHEP::cm;
+      double r = hitPoint.perp()*invcm;
+      double z = std::abs(hitPoint.z())*invcm;
+      double dose_acquired = 0.;
+      if (z>=HFDarkening::lowZLimit && z <= HFDarkening::upperZLimit) {
+        unsigned int hfZLayer = (unsigned int)((z - HFDarkening::lowZLimit)/5);
+        if (hfZLayer >= HFDarkening::upperZLimit) hfZLayer = (HFDarkening::upperZLimit-1);
+        float normalized_lumi = m_HFDarkening->int_lumi(deliveredLumi);
+        for (int i = hfZLayer; i != HFDarkening::numberOfZLayers; ++i) {
+          dose_acquired = m_HFDarkening->dose(i,r);
+          weight_ *= m_HFDarkening->degradation(normalized_lumi*dose_acquired);
+        }
+      }
+#ifdef EDM_ML_DEBUG
+      edm::LogInfo("HcalSim") << "HCalSD::getFromLibrary: HFLumiDarkening at r= " 
+                              << r << ", z= " << z << " Dose= " << dose_acquired 
+                              << " weight= " << weight_;
+#endif
+    }
+
+    if (useParam) {
+      getFromParam(aStep, kill);
+#ifdef EDM_ML_DEBUG
+      G4String nameVolume = lv->GetName();
+      LogDebug("HcalSim") << "HCalSD: " << getNumberOfHits()
+                          << " hits from parametrization in " << nameVolume 
+                          << " for Track " << track->GetTrackID()
+                          <<" (" << track->GetDefinition()->GetParticleName() 
+                          <<")";
+#endif
+    } else if (useShowerLibrary && !G4TrackToParticleID::isMuon(track)) {
+      if(G4TrackToParticleID::isGammaElectronPositron(track) || 
+	 G4TrackToParticleID::isStableHadronIon(track) ) {
+#ifdef EDM_ML_DEBUG
+	auto nameVolume = 
+	  aStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetName();
+	edm::LogInfo("HcalSim") << "HCalSD: Starts shower library from " 
+				<< nameVolume << " for Track " 
+				<< track->GetTrackID() << " ("
+				<< track->GetDefinition()->GetParticleName() << ")";
+
+#endif
+	getFromHFLibrary(aStep, kill);
+      }
+    }
+  }
+#ifdef EDM_ML_DEBUG
+  edm::LogInfo("HcalSim") << "HCalSD::getFromLibrary ID= " 
+                          << track->GetTrackID() << " ("
+                          << track->GetDefinition()->GetParticleName() 
+                          << ") kill= " << kill << " weight= " << weight_ 
+                          << " depth= " << depth_ << " isHF: " << isHF;
+#endif
+  return kill;
 } 
 
-double HCalSD::getEnergyDeposit(G4Step* aStep) {
-  double destep = aStep->GetTotalEnergyDeposit();
-  double weight = 1;
-  theTrack = aStep->GetTrack();
+double HCalSD::getEnergyDeposit(const G4Step* aStep) {
+  double destep(0.0);
+  auto const lv = aStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume();
+  auto const theTrack = aStep->GetTrack();
+
+  if(isHF) {
+    if (useShowerLibrary && G4TrackToParticleID::isMuon(theTrack) && isItFibre(lv)) {
+#ifdef EDM_ML_DEBUG
+      edm::LogInfo("HcalSim") << "HCalSD: Hit at Fibre in LV " << lv->GetName() 
+                              << " for track " << aStep->GetTrack()->GetTrackID() <<" ("
+                              << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+#endif
+      hitForFibre(aStep);
+    }
+    return destep;
+  }
+
+  if (isItPMT(lv)) {
+    if(usePMTHit && showerPMT) { getHitPMT(aStep); }
+#ifdef EDM_ML_DEBUG
+    edm::LogInfo("HcalSim") << "HCalSD: Hit from PMT parametrization in LV " 
+                            <<  lv->GetName() << " for Track " 
+                            << aStep->GetTrack()->GetTrackID() << " ("
+                            << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+#endif
+    return destep;
+
+  } else if (isItStraightBundle(lv)) {
+    if(useFibreBundle && showerBundle) { getHitFibreBundle(aStep, false); }
+#ifdef EDM_ML_DEBUG
+    edm::LogInfo("HcalSim") << "HCalSD: Hit from straight FibreBundle in LV: "
+			    << lv->GetName() << " for track " 
+			    << aStep->GetTrack()->GetTrackID() << " ("
+			    << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+#endif
+    return destep;
+
+  } else if(isItConicalBundle(lv)) {
+    if(useFibreBundle && showerBundle) { getHitFibreBundle(aStep, true); }
+#ifdef EDM_ML_DEBUG
+    edm::LogInfo("HcalSim") << "HCalSD: Hit from conical FibreBundle PV: "
+			    << lv->GetName() << " for track " 
+			    << aStep->GetTrack()->GetTrackID() << " ("
+			    << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+#endif
+    return destep;
+  }
+
+  // normal hit
+  destep = aStep->GetTotalEnergyDeposit();
 
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   uint32_t detid = setDetUnitId(aStep);
   int det(0), ieta(0), phi(0), z(0), lay, depth(-1);
   if (testNumber) {
     HcalTestNumbering::unpackHcalIndex(detid,det,z,depth,ieta,phi,lay);
-    if (z==0) z = -1;
+    if (z==0) { z = -1; }
   } else {
     HcalDetId hcid(detid);
     det  = hcid.subdetId();
@@ -484,31 +446,31 @@ double HCalSD::getEnergyDeposit(G4Step* aStep) {
   lay   = (touch->GetReplicaNumber(0)/10)%100 + 1;
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("HcalSim") << "HCalSD: det: " << det << " ieta: "<< ieta 
-			  << " iphi: " << phi << " zside " << z << "  lay: " 
-			  << lay-2;
+                          << " iphi: " << phi << " zside " << z << "  lay: " 
+                          << lay-2;
 #endif 
   if (depth_==0 && (det==1 || det==2) && ((!testNumber) || neutralDensity))
-    weight = hcalConstants->getLayer0Wt(det,phi,z);
+    weight_ = hcalConstants->getLayer0Wt(det,phi,z);
   if (useLayerWt) {
     G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
-    weight = layerWeight(det+2, hitPoint, depth_, lay);
+    weight_ = layerWeight(det+2, hitPoint, depth_, lay);
   }
 
   if (m_HBDarkening && det == 1) {
-    float dweight = m_HBDarkening->degradation(deliveredLumi,ieta,lay);
-    weight *= dweight;
+    double dweight = m_HBDarkening->degradation(deliveredLumi,ieta,lay);
+    weight_ *= dweight;
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD:         >>> HB Lumi: " << deliveredLumi
-			    << "    coefficient = " << dweight;
+    edm::LogInfo("HcalSim") << "HCalSD: HB Lumi: " << deliveredLumi
+                            << " coefficient = " << dweight << " Weight= " << weight_;
 #endif  
   }
 
   if (m_HEDarkening && det == 2) {
-    float dweight = m_HEDarkening->degradation(deliveredLumi,ieta,lay);
-    weight *= dweight;
+    double dweight = m_HEDarkening->degradation(deliveredLumi,ieta,lay);
+    weight_ *= dweight;
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD:         >>> HE Lumi: " << deliveredLumi
-			    << "    coefficient = " << dweight;
+    edm::LogInfo("HcalSim") << "HCalSD: HB Lumi: " << deliveredLumi
+                            << " coefficient = " << dweight << " Weight= " << weight_;
 #endif  
   }
 
@@ -517,44 +479,34 @@ double HCalSD::getEnergyDeposit(G4Step* aStep) {
     if (trkInfo) {
       int pdg = theTrack->GetDefinition()->GetPDGEncoding();
       if (!(trkInfo->isPrimary())) {         // Only secondary particles
-        double ke = theTrack->GetKineticEnergy()/MeV;
+        double ke = theTrack->GetKineticEnergy();
         if ( pdg/1000000000 == 1 && (pdg/10000)%100 > 0 &&
-	     (pdg/10)%100 > 0    && ke <kmaxIon   ) weight = 0;
-        if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
-        if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
-#ifdef EDM_ML_DEBUG
-        if (weight == 0) 
-          edm::LogInfo("HcalSim") << "HCalSD:Ignore Track " 
-                                  << theTrack->GetTrackID() << " Type " 
-                                  << theTrack->GetDefinition()->GetParticleName()
-                                  << " Kinetic Energy " << ke << " MeV";
-#endif
+             (pdg/10)%100 > 0    && ke <kmaxIon   ) weight_ = 0;
+        if ((pdg == 2212) && (ke < kmaxProton))     weight_ = 0;
+        if ((pdg == 2112) && (ke < kmaxNeutron))    weight_ = 0;
       }
     }
   }
-#ifdef EDM_ML_DEBUG
-  double weight0 = weight;
-#endif
   if (useBirk) {
     const G4Material* mat = aStep->GetPreStepPoint()->GetMaterial();
-    if (isItScintillator(mat)) weight *= getAttenuation(aStep, birk1, birk2, birk3);
+    if (isItScintillator(mat)) weight_ *= getAttenuation(aStep, birk1, birk2, birk3);
   }
   double wt1 = getResponseWt(theTrack);
   double wt2 = theTrack->GetWeight();
-#ifdef EDM_ML_DEBUG
-  edm::LogInfo("HcalSim") << "HCalSD: Detector " << det+2 << " Depth " << depth_
-                          << " weight " << weight0 << " " << weight << " " << wt1 
-			  << " " << wt2; 
-#endif
-  double edep = weight*wt1*destep;
+  double edep = weight_*wt1*destep;
   if (wt2 > 0.0) { edep *= wt2; }
+#ifdef EDM_ML_DEBUG
+  edm::LogInfo("HcalSim") 
+    << "HCalSD: edep= " << edep << " Det: " << det+2 << " depth= " << depth_
+    << " weight= " << weight_ << " wt1= " << wt1 << " wt2= " << wt2; 
+#endif
   return edep;
 }
 
 uint32_t HCalSD::setDetUnitId(const G4Step * aStep) { 
 
-  const G4StepPoint* prePoint   = aStep->GetPreStepPoint(); 
-  const G4VTouchable* touch     = prePoint->GetTouchable();
+  auto const prePoint  = aStep->GetPreStepPoint(); 
+  auto const touch     = prePoint->GetTouchable();
   const G4ThreeVector& hitPoint = prePoint->GetPosition();
 
   int depth = (touch->GetReplicaNumber(0))%10 + 1;
@@ -567,8 +519,7 @@ uint32_t HCalSD::setDetUnitId(const G4Step * aStep) {
 void HCalSD::setNumberingScheme(HcalNumberingScheme * scheme) {
   if (scheme != nullptr) {
     edm::LogInfo("HcalSim") << "HCalSD: updates numbering scheme for " << GetName();
-    if (numberingScheme) delete numberingScheme;
-    numberingScheme = scheme;
+    numberingScheme.reset(scheme);
   }
 }
 
@@ -584,18 +535,18 @@ void HCalSD::update(const BeginOfJob * job) {
     throw cms::Exception("Unknown", "HCalSD") << "Cannot find HcalDDDSimConstant" << "\n";
   }
 
-  numberingFromDDD = new HcalNumberingFromDDD(hcalConstants);
-
-  edm::LogInfo("HcalSim") << "Maximum depth for HF " << hcalConstants->getMaxDepth(2);
+  numberingFromDDD.reset(new HcalNumberingFromDDD(hcalConstants));
 
   //Special Geometry parameters
-  gpar      = hcalConstants->getGparHF();
-  edm::LogInfo("HcalSim") << "HCalSD: " << gpar.size()<< " gpar (cm)";
-  for (unsigned int ig=0; ig<gpar.size(); ig++)
-    edm::LogInfo("HcalSim") << "HCalSD: gpar[" << ig << "] = "
-			    << gpar[ig]/cm << " cm";
+  gpar = hcalConstants->getGparHF();
+  std::stringstream sss;
+  for (unsigned int ig=0; ig<gpar.size(); ig++) {
+    sss << "\n         gpar[" << ig << "] = " << gpar[ig]/cm << " cm";
+  }
+  edm::LogInfo("HcalSim") << "Maximum depth for HF " << hcalConstants->getMaxDepth(2)
+                          << gpar.size()<< " gpar (cm)" << sss.str();
   //Test Hcal Numbering Scheme
-  if (testNS_) hcalTestNS_ = new HcalTestNS(es);
+  if (testNS_) m_HcalTestNS.reset(new HcalTestNS(es));
 
   if (agingFlagHB) {
     edm::ESHandle<HBHEDarkening> hdark;
@@ -610,12 +561,12 @@ void HCalSD::update(const BeginOfJob * job) {
 }
 
 void HCalSD::initRun() {
-  G4ParticleTable * theParticleTable = G4ParticleTable::GetParticleTable();
-  if (showerLibrary) showerLibrary->initRun(theParticleTable,hcalConstants);
-  if (showerParam)   showerParam->initRun(theParticleTable,hcalConstants);
-  if (hfshower)      hfshower->initRun(theParticleTable,hcalConstants);
-  if (showerPMT)     showerPMT->initRun(theParticleTable,hcalConstants);
-  if (showerBundle)  showerBundle->initRun(theParticleTable,hcalConstants);
+  edm::LogWarning("HcalSim") << "InitRun for HFFFFF ";
+  if (showerLibrary.get()) showerLibrary.get()->initRun(nullptr, hcalConstants);
+  if (showerParam.get())   showerParam.get()->initRun(hcalConstants);
+  if (hfshower.get())      hfshower.get()->initRun(hcalConstants);
+  if (showerPMT.get())     showerPMT.get()->initRun(hcalConstants);
+  if (showerBundle.get())  showerBundle.get()->initRun(hcalConstants);
 }
 
 bool HCalSD::filterHit(CaloG4Hit* aHit, double time) {
@@ -638,9 +589,9 @@ bool HCalSD::filterHit(CaloG4Hit* aHit, double time) {
 
 uint32_t HCalSD::setDetUnitId (int det, const G4ThreeVector& pos, int depth, int lay=1) { 
   uint32_t id = 0;
-  if (numberingFromDDD) {
+  if (numberingFromDDD.get()) {
     //get the ID's as eta, phi, depth, ... indices
-    HcalNumberingFromDDD::HcalID tmp = numberingFromDDD->unitID(det, pos, depth, lay);
+    HcalNumberingFromDDD::HcalID tmp = numberingFromDDD.get()->unitID(det, pos, depth, lay);
     id = setDetUnitId(tmp);
   }
   return id;
@@ -648,16 +599,16 @@ uint32_t HCalSD::setDetUnitId (int det, const G4ThreeVector& pos, int depth, int
 
 uint32_t HCalSD::setDetUnitId (HcalNumberingFromDDD::HcalID& tmp) { 
   modifyDepth(tmp);
-  uint32_t id = (numberingScheme) ? numberingScheme->getUnitID(tmp) : 0;
-  if ((!testNumber) && hcalTestNS_) {
-    bool ok = hcalTestNS_->compare(tmp,id);
+  uint32_t id = (numberingScheme.get()) ? numberingScheme.get()->getUnitID(tmp) : 0;
+  if ((!testNumber) && m_HcalTestNS.get()) {
+    bool ok = m_HcalTestNS.get()->compare(tmp,id);
     if (!ok)
       edm::LogWarning("HcalSim") << "Det ID from HCalSD " << HcalDetId(id) 
-				 << " " << std::hex << id << std::dec 
-				 << " does not match one from relabller for " 
-				 << tmp.subdet << ":" << tmp.etaR << ":"
-				 << tmp.phi << ":" << tmp.phis << ":" 
-				 << tmp.depth << ":" << tmp.lay << std::endl;
+                                 << " " << std::hex << id << std::dec 
+                                 << " does not match one from relabller for " 
+                                 << tmp.subdet << ":" << tmp.etaR << ":"
+                                 << tmp.phi << ":" << tmp.phis << ":" 
+                                 << tmp.depth << ":" << tmp.lay << std::endl;
   }
   return id;
 }
@@ -720,134 +671,110 @@ bool HCalSD::isItHF(const G4Step * aStep) {
 }
 
 bool HCalSD::isItHF (const G4String& name) {
-  std::vector<G4String>::const_iterator it = hfNames.begin();
-  for (; it != hfNames.end(); ++it) if (name == *it) return true;
+  for (auto nam : hfNames) if (name == nam) { return true; }
   return false;
 }
 
 bool HCalSD::isItFibre (const G4LogicalVolume* lv) {
-  std::vector<const G4LogicalVolume*>::const_iterator ite = fibreLV.begin();
-  for (; ite != fibreLV.end(); ++ite) if (lv == *ite) return true;
+  for (auto lvol : fibreLV) if (lv == lvol) { return true; }
   return false;
 }
 
 bool HCalSD::isItFibre (const G4String& name) {
-  std::vector<G4String>::const_iterator it = fibreNames.begin();
-  for (; it != fibreNames.end(); ++it) if (name == *it) return true;
+  for (auto nam : fibreNames) if (name == nam) { return true; }
   return false;
 }
 
 bool HCalSD::isItPMT (const G4LogicalVolume* lv) {
-  std::vector<const G4LogicalVolume*>::const_iterator ite = pmtLV.begin();
-  for (; ite != pmtLV.end(); ++ite) if (lv == *ite) return true;
+  for (auto lvol : pmtLV) if (lv == lvol) { return true; }
   return false;
 }
 
 bool HCalSD::isItStraightBundle (const G4LogicalVolume* lv) {
-  std::vector<const G4LogicalVolume*>::const_iterator ite = fibre1LV.begin();
-  for (; ite != fibre1LV.end(); ++ite) if (lv == *ite) return true;
+  for (auto lvol : fibre1LV) if (lv == lvol) { return true; }
   return false;
 }
 
 bool HCalSD::isItConicalBundle (const G4LogicalVolume* lv) {
-  std::vector<const G4LogicalVolume*>::const_iterator ite = fibre2LV.begin();
-  for (; ite != fibre2LV.end(); ++ite) if (lv == *ite) return true;
+  for (auto lvol : fibre2LV) if (lv == lvol) { return true; }
   return false;
 }
 
 bool HCalSD::isItScintillator (const G4Material* mat) {
-  std::vector<const G4Material*>::const_iterator ite = materials.begin();
-  for (; ite != materials.end(); ++ite) if (mat == *ite) return true;
+  for (auto amat : materials) if (amat == mat) { return true; }
   return false;
 }
 
 bool HCalSD::isItinFidVolume (const G4ThreeVector& hitPoint) {
   bool flag = true;
   if (applyFidCut) {
-    int npmt = HFFibreFiducial:: PMTNumber(hitPoint);
+    int npmt = HFFibreFiducial::PMTNumber(hitPoint);
 #ifdef EDM_ML_DEBUG
     edm::LogInfo("HcalSim") << "HCalSD::isItinFidVolume:#PMT= " << npmt 
-			    << " for hit point " << hitPoint;
+                            << " for hit point " << hitPoint;
 #endif
     if (npmt <= 0) flag = false;
   }
 #ifdef EDM_ML_DEBUG
     edm::LogInfo("HcalSim") << "HCalSD::isItinFidVolume: point " << hitPoint
-			    << " return flag " << flag;
+                            << " return flag " << flag;
 #endif
   return flag;
 }
 
-void HCalSD::getFromLibrary (G4Step* aStep, double weight) {
-  preStepPoint  = aStep->GetPreStepPoint(); 
-  theTrack = aStep->GetTrack();   
-  int det  = 5;
-  bool ok(false);
+void HCalSD::getFromHFLibrary (const G4Step* aStep, bool& isKilled) {
 
-  std::vector<HFShowerLibrary::Hit> hits = showerLibrary->getHits(aStep, ok, weight, false);
+  std::vector<HFShowerLibrary::Hit> hits = showerLibrary.get()->getHits(aStep, isKilled, weight_, false);
+  if(!isKilled || hits.empty()) { return; } 
 
-  if(!hits.empty()) {
-    double etrack    = preStepPoint->GetKineticEnergy();
-    int    primaryID = setTrackID(aStep);
+  int primaryID = setTrackID(aStep);
 
-    // Reset entry point for new primary
-    posGlobal = preStepPoint->GetPosition();
-    resetForNewPrimary(posGlobal, etrack);
+  // Reset entry point for new primary
+  resetForNewPrimary(aStep);
 
-    if (isEM) {
-      edepositEM  = 1.*GeV;
-      edepositHAD = 0.;
-    } else {
-      edepositEM  = 0.;
-      edepositHAD = 1.*GeV;
-    }
-#ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD::getFromLibrary " <<hits.size() 
-			    << " hits for " << GetName() << " of " << primaryID 
-			    << " with " << theTrack->GetDefinition()->GetParticleName() 
-			    << " of " << preStepPoint->GetKineticEnergy()/GeV << " GeV";
-#endif
-    for (unsigned int i=0; i<hits.size(); ++i) {
-      G4ThreeVector hitPoint = hits[i].position;
-      if (isItinFidVolume (hitPoint)) {
-	int depth              = hits[i].depth;
-	double time            = hits[i].time;
-	unsigned int unitID    = setDetUnitId(det, hitPoint, depth);
-	currentID.setID(unitID, time, primaryID, 0);
-#ifdef plotDebug
-	plotProfile(aStep, hitPoint, 1.0*GeV, time, depth);
-	plotHF(hitPoint,isEM);
-#endif
-   
-	// check if it is in the same unit and timeslice as the previous one
-	if (currentID == previousID) {
-	  updateHit(currentHit);
-	} else {
-	  if (!checkHit()) currentHit = createNewHit();
-	}
-      }
-    }
+  auto const theTrack = aStep->GetTrack();   
+  int det = 5;
+
+  if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
+    edepositEM  = 1.*GeV;
+    edepositHAD = 0.;
+  } else {
+    edepositEM  = 0.;
+    edepositHAD = 1.*GeV;
   }
-
-  //Now kill the current track
-  if (ok) {
-    theTrack->SetTrackStatus(fStopAndKill);
-    G4TrackVector tv = *(aStep->GetSecondary());
-    for (unsigned int kk=0; kk<tv.size(); ++kk)
-      if (tv[kk]->GetVolume() == preStepPoint->GetPhysicalVolume())
-        tv[kk]->SetTrackStatus(fStopAndKill);
+#ifdef EDM_ML_DEBUG
+  edm::LogInfo("HcalSim") << "HCalSD::getFromLibrary " <<hits.size() 
+                          << " hits for " << GetName() << " of " << primaryID 
+                          << " with " << theTrack->GetDefinition()->GetParticleName() 
+                          << " of " << aStep->GetPreStepPoint()->GetKineticEnergy()/GeV << " GeV";
+#endif
+  for (unsigned int i=0; i<hits.size(); ++i) {
+    G4ThreeVector hitPoint = hits[i].position;
+    if (isItinFidVolume (hitPoint)) {
+      int depth              = hits[i].depth;
+      double time            = hits[i].time;
+      unsigned int unitID    = setDetUnitId(det, hitPoint, depth);
+      currentID.setID(unitID, time, primaryID, 0);
+#ifdef plotDebug
+      plotProfile(aStep, hitPoint, 1.0*GeV, time, depth);
+      bool emType = G4TrackToParticleID::isGammaElectronPositron(parCode);
+      plotHF(hitPoint,emType);
+#endif
+      processHit(aStep);
+    }
   }
 }
 
-void HCalSD::hitForFibre (const G4Step* aStep, double weight) { // if not ParamShower
+void HCalSD::hitForFibre (const G4Step* aStep) { // if not ParamShower
 
-  const G4StepPoint* preStepPoint  = aStep->GetPreStepPoint();
+  std::vector<HFShower::Hit> hits = hfshower.get()->getHits(aStep, weight_);
+  if(hits.empty()) { return; }
+
+  auto const theTrack = aStep->GetTrack();
   int primaryID = setTrackID(aStep);
-
   int det   = 5;
-  std::vector<HFShower::Hit> hits = hfshower->getHits(aStep, weight);
 
-  if (isEM) {
+  if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
     edepositEM  = 1.*GeV;
     edepositHAD = 0.;
   } else {
@@ -857,81 +784,67 @@ void HCalSD::hitForFibre (const G4Step* aStep, double weight) { // if not ParamS
  
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("HcalSim") << "HCalSD::hitForFibre " << hits.size() 
-			  << " hits for " << GetName() << " of " << primaryID 
-			  << " with " << theTrack->GetDefinition()->GetParticleName() 
-			  << " of " << preStepPoint->GetKineticEnergy()/GeV 
-			  << " GeV in detector type " << det;
+                          << " hits for " << GetName() << " of " << primaryID 
+                          << " with " << theTrack->GetDefinition()->GetParticleName() 
+                          << " of " << preStepPoint->GetKineticEnergy()/GeV 
+                          << " GeV in detector type " << det;
 #endif
-  if (!hits.empty()) {
-    for (unsigned int i=0; i<hits.size(); ++i) {
-      G4ThreeVector hitPoint = hits[i].position;
-      if (isItinFidVolume (hitPoint)) {
-	int depth              = hits[i].depth;
-	double time            = hits[i].time;
-	unsigned int unitID = setDetUnitId(det, hitPoint, depth);
-	currentID.setID(unitID, time, primaryID, 0);
+
+  for (unsigned int i=0; i<hits.size(); ++i) {
+    G4ThreeVector hitPoint = hits[i].position;
+    if (isItinFidVolume (hitPoint)) {
+      int depth              = hits[i].depth;
+      double time            = hits[i].time;
+      unsigned int unitID = setDetUnitId(det, hitPoint, depth);
+      currentID.setID(unitID, time, primaryID, 0);
 #ifdef plotDebug
-	plotProfile(aStep, hitPoint, edepositEM, time, depth);
-	plotHF(hitPoint,isEM);
+      plotProfile(aStep, hitPoint, edepositEM, time, depth);
+      bool emType = (edepositEM > 0.) ? true : false;
+      plotHF(hitPoint,emType);
 #endif
-	// check if it is in the same unit and timeslice as the previous one
-	if (currentID == previousID) {
-	  updateHit(currentHit);
-	} else {
-	  posGlobal = preStepPoint->GetPosition();
-	  if (!checkHit()) currentHit = createNewHit();
-	}
-      }
+      processHit(aStep);
     }
   }
 }
 
-void HCalSD::getFromParam (G4Step* aStep, double weight) {
-  std::vector<HFShowerParam::Hit> hits = showerParam->getHits(aStep, weight);
-  int nHit = static_cast<int>(hits.size());
+void HCalSD::getFromParam (const G4Step* aStep, bool& isKilled) {
 
-  if (nHit > 0) {
-    const G4StepPoint* preStepPoint  = aStep->GetPreStepPoint();
-    int primaryID = setTrackID(aStep);
-   
-    int det   = 5;
+  std::vector<HFShowerParam::Hit> hits = showerParam.get()->getHits(aStep, weight_, isKilled);
+  if(!isKilled || hits.empty()) { return; }
+
+  int primaryID = setTrackID(aStep);   
+  int det   = 5;
+
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD::getFromParam " << nHit << " hits for " 
+  edm::LogInfo("HcalSim") << "HCalSD::getFromParam " << hits.size() << " hits for " 
                             << GetName() << " of " << primaryID << " with " 
                             <<  aStep->GetTrack()->GetDefinition()->GetParticleName()
                             << " of " << preStepPoint->GetKineticEnergy()/GeV 
                             << " GeV in detector type " << det;
 #endif
-    for (int i = 0; i<nHit; ++i) {
-      G4ThreeVector hitPoint = hits[i].position;
-      int depth              = hits[i].depth;
-      double time            = hits[i].time;
-      unsigned int unitID    = setDetUnitId(det, hitPoint, depth);
-      currentID.setID(unitID, time, primaryID, 0);
-      edepositEM             = hits[i].edep*GeV; 
-      edepositHAD            = 0.;
+  for (unsigned int i=0; i<hits.size(); ++i) {
+    G4ThreeVector hitPoint = hits[i].position;
+    int depth              = hits[i].depth;
+    double time            = hits[i].time;
+    unsigned int unitID    = setDetUnitId(det, hitPoint, depth);
+    currentID.setID(unitID, time, primaryID, 0);
+    edepositEM             = hits[i].edep*GeV; 
+    edepositHAD            = 0.;
 #ifdef plotDebug
-      plotProfile(aStep, hitPoint, edepositEM, time, depth);
+    plotProfile(aStep, hitPoint, edepositEM, time, depth);
 #endif
-
-      // check if it is in the same unit and timeslice as the previous one
-      if (currentID == previousID) {
-	updateHit(currentHit);
-      } else {
-        posGlobal = preStepPoint->GetPosition();
-        if (!checkHit()) currentHit = createNewHit();
-      }
-    }
+    processHit(aStep);
   }
 }
 
 void HCalSD::getHitPMT (const G4Step * aStep) {
 
-  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
-  const G4Track*     theTrack     = aStep->GetTrack();
+  auto const preStepPoint = aStep->GetPreStepPoint();
+  auto const theTrack     = aStep->GetTrack();
   double edep  = showerPMT->getHits(aStep);
 
-  if (edep >= 0) {
+  if (edep >= 0.) {
+    edep *= GeV;
     double etrack    = preStepPoint->GetKineticEnergy();
     int    primaryID = 0;
     if (etrack >= energyCut) {
@@ -941,9 +854,7 @@ void HCalSD::getHitPMT (const G4Step * aStep) {
       if (primaryID == 0) primaryID = theTrack->GetTrackID();
     }
     // Reset entry point for new primary
-    posGlobal = preStepPoint->GetPosition();
-    resetForNewPrimary(posGlobal, etrack);
-
+    resetForNewPrimary(aStep);
     //
     int    det      = static_cast<int>(HcalForward);
     const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
@@ -963,16 +874,16 @@ void HCalSD::getHitPMT (const G4Step * aStep) {
     double time = (aStep->GetPostStepPoint()->GetGlobalTime());
     uint32_t unitID = 0;
     if (numberingFromDDD) {
-      HcalNumberingFromDDD::HcalID tmp = numberingFromDDD->unitID(det,etaR,phi,
-								  depth,1);
+      HcalNumberingFromDDD::HcalID tmp = numberingFromDDD.get()->unitID(det,etaR,phi,
+                                                                  depth,1);
       unitID = setDetUnitId(tmp);
     }
     currentID.setID(unitID, time, primaryID, 1);
 
     edepositHAD = aStep->GetTotalEnergyDeposit();
-    edepositEM  =-edepositHAD + (edep*GeV);
+    edepositEM  =-edepositHAD + edep;
 #ifdef plotDebug
-    plotProfile(aStep, hitPoint, edep*GeV, time, depth);
+    plotProfile(aStep, hitPoint, edep, time, depth);
 #endif
 #ifdef EDM_ML_DEBUG
     double beta = preStepPoint->GetBeta();
@@ -983,21 +894,17 @@ void HCalSD::getHitPMT (const G4Step * aStep) {
                         << " GeV with velocity " << beta << " UnitID "
                         << std::hex << unitID << std::dec;
 #endif
-    // check if it is in the same unit and timeslice as the previous one
-    if      (currentID == previousID) {
-      updateHit(currentHit);
-    } else {
-      if (!checkHit()) currentHit = createNewHit();
-    }
+    processHit(aStep);
   }
 }
 
 void HCalSD::getHitFibreBundle (const G4Step* aStep, bool type) {
-  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
-  const G4Track*     theTrack     = aStep->GetTrack();
-  double edep  = showerBundle->getHits(aStep, type);
+  auto const preStepPoint = aStep->GetPreStepPoint();
+  auto const theTrack     = aStep->GetTrack();
+  double edep  = showerBundle.get()->getHits(aStep, type);
 
-  if (edep >= 0) {
+  if (edep >= 0.0) {
+    edep *= GeV;
     double etrack    = preStepPoint->GetKineticEnergy();
     int    primaryID = 0;
     if (etrack >= energyCut) {
@@ -1007,38 +914,36 @@ void HCalSD::getHitFibreBundle (const G4Step* aStep, bool type) {
       if (primaryID == 0) primaryID = theTrack->GetTrackID();
     }
     // Reset entry point for new primary
-    posGlobal = preStepPoint->GetPosition();
-    resetForNewPrimary(posGlobal, etrack);
-
+    resetForNewPrimary(aStep);
     //
     int    det      = static_cast<int>(HcalForward);
     const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
-    double rr       = (hitPoint.x()*hitPoint.x() + hitPoint.y()*hitPoint.y());
-    double phi      = (rr == 0. ? 0. :atan2(hitPoint.y(),hitPoint.x()));
+    double rr       = hitPoint.x()*hitPoint.x() + hitPoint.y()*hitPoint.y();
+    double phi      = rr == 0. ? 0. :atan2(hitPoint.y(),hitPoint.x());
     double etaR     = showerBundle->getRadius();
     int depth       = 1;
-    if (etaR < 0) {
+    if (etaR < 0.) {
       depth         = 2;
       etaR          =-etaR;
     }
-    if (hitPoint.z() < 0) etaR =-etaR;
+    if (hitPoint.z() < 0.) etaR =-etaR;
 #ifdef EDM_ML_DEBUG
     LogDebug("HcalSim") << "HCalSD::Hit for Detector " << det << " etaR "
-			<< etaR << " phi " << phi/deg << " depth " <<depth;
+                        << etaR << " phi " << phi/deg << " depth " <<depth;
 #endif
     double time = (aStep->GetPostStepPoint()->GetGlobalTime());
     uint32_t unitID = 0;
     if (numberingFromDDD) {
-      HcalNumberingFromDDD::HcalID tmp = numberingFromDDD->unitID(det,etaR,phi,depth,1);
+      HcalNumberingFromDDD::HcalID tmp = numberingFromDDD.get()->unitID(det,etaR,phi,depth,1);
       unitID = setDetUnitId(tmp);
     }
     if (type) currentID.setID(unitID, time, primaryID, 3);
     else      currentID.setID(unitID, time, primaryID, 2);
 
     edepositHAD = aStep->GetTotalEnergyDeposit();
-    edepositEM  =-edepositHAD + (edep*GeV);
+    edepositEM  =-edepositHAD + edep;
 #ifdef plotDebug
-    plotProfile(aStep, hitPoint, edep*GeV, time, depth);
+    plotProfile(aStep, hitPoint, edep, time, depth);
 #endif
 #ifdef EDM_ML_DEBUG
     double beta = preStepPoint->GetBeta();
@@ -1049,31 +954,8 @@ void HCalSD::getHitFibreBundle (const G4Step* aStep, bool type) {
                         << " GeV with velocity " << beta << " UnitID "
                         << std::hex << unitID << std::dec;
 #endif
-    // check if it is in the same unit and timeslice as the previous one
-    if (currentID == previousID) updateHit(currentHit);
-    else if (!checkHit()) currentHit = createNewHit();
+    processHit(aStep);
   } // non-zero energy deposit
-}
-
-int HCalSD::setTrackID (const G4Step* aStep) {
-  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
-  const G4Track* theTrack         = aStep->GetTrack();
-
-  double etrack = preStepPoint->GetKineticEnergy();
-  TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
-  int      primaryID = trkInfo->getIDonCaloSurface();
-  if (primaryID == 0) {
-#ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD: Problem with primaryID **** set by "
-			    << "force to TkID **** " <<theTrack->GetTrackID();
-#endif
-    primaryID = theTrack->GetTrackID();
-  }
-
-  if (primaryID != previousID.trackID())
-    resetForNewPrimary(preStepPoint->GetPosition(), etrack);
-
-  return primaryID;
 }
 
 void HCalSD::readWeightFromFile(const std::string& fName) {
@@ -1107,8 +989,8 @@ double HCalSD::layerWeight(int det, const G4ThreeVector& pos, int depth, int lay
   double wt = 1.;
   if (numberingFromDDD) {
     //get the ID's as eta, phi, depth, ... indices
-    HcalNumberingFromDDD::HcalID tmp = numberingFromDDD->unitID(det, pos, 
-								depth, lay);
+    HcalNumberingFromDDD::HcalID tmp = numberingFromDDD.get()->unitID(det, pos, 
+                                                                depth, lay);
     modifyDepth(tmp);
     uint32_t id = HcalTestNumbering::packHcalIndex(tmp.subdet, tmp.zside, 1,
                                                    tmp.etaR, tmp.phis,tmp.lay);
@@ -1129,7 +1011,7 @@ void HCalSD::plotProfile(const G4Step* aStep,const G4ThreeVector& global, double
 
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   static const G4String modName[8] = {"HEModule", "HVQF" , "HBModule", "MBAT",
-				      "MBBT"    , "MBBTC", "MBBT_R1P", "MBBT_R1M"};
+                                      "MBBT"    , "MBBTC", "MBBT_R1P", "MBBT_R1M"};
   G4ThreeVector local;
   bool found=false;
   double depth=-2000;
@@ -1141,14 +1023,14 @@ void HCalSD::plotProfile(const G4Step* aStep,const G4ThreeVector& global, double
 #endif
     for (unsigned int ii=0; ii<8; ++ii) {
       if (name == modName[ii]) {
-	found = true;
-	int dn = touch->GetHistoryDepth() - n;
-	local = touch->GetHistory()->GetTransform(dn).TransformPoint(global);
-	if      (ii == 0) {depth = local.z() - 4006.5; idx = 1;}
-	else if (ii == 1) {depth = local.z() + 825.0;  idx = 3;}
-	else if (ii == 2) {depth = local.x() - 1775.;  idx = 0;}
-	else              {depth = local.y() + 15.;    idx = 2;}
-	break;
+        found = true;
+        int dn = touch->GetHistoryDepth() - n;
+        local = touch->GetHistory()->GetTransform(dn).TransformPoint(global);
+        if      (ii == 0) {depth = local.z() - 4006.5; idx = 1;}
+        else if (ii == 1) {depth = local.z() + 825.0;  idx = 3;}
+        else if (ii == 2) {depth = local.x() - 1775.;  idx = 0;}
+        else              {depth = local.y() + 15.;    idx = 2;}
+        break;
       }
     }
     if (found) break;
@@ -1157,7 +1039,7 @@ void HCalSD::plotProfile(const G4Step* aStep,const G4ThreeVector& global, double
 #ifdef EDM_ML_DEBUG
   LogDebug("HcalSim") << "plotProfile Found " << found << " Global " << global
                       << " Local " << local << " depth " << depth << " ID " 
-		      << id << " EDEP " << edep << " Time " << time;
+                      << id << " EDEP " << edep << " Time " << time;
 #endif
   if (hit_[idx]  != nullptr) hit_[idx]->Fill(edep);
   if (time_[idx] != nullptr) time_[idx]->Fill(time,edep);
@@ -1185,11 +1067,10 @@ void HCalSD::modifyDepth(HcalNumberingFromDDD::HcalID& id) {
     int ieta = (id.zside == 0) ? -id.etaR : id.etaR;
     if (hcalConstants->maxHFDepth(ieta,id.phis) > 2) {
       if (id.depth <= 2) {
-	if (G4UniformRand() > 0.5) id.depth += 2;
+        if (G4UniformRand() > 0.5) id.depth += 2;
       }
     }
   } else if ((id.subdet == 1 || id.subdet ==2) && testNumber) {
-    if (depth_ == 0) id.depth = 1;
-    else             id.depth = 2;
+    id.depth = (depth_ == 0) ? 1 : 2;
   }
 }

--- a/SimG4CMS/Calo/src/HFFibre.cc
+++ b/SimG4CMS/Calo/src/HFFibre.cc
@@ -13,17 +13,18 @@
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include <iostream>
+#include <sstream>
 
 //#define DebugLog
 
 HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv, 
-		 edm::ParameterSet const & p) {
+                 edm::ParameterSet const & p) {
 
   edm::ParameterSet m_HF = p.getParameter<edm::ParameterSet>("HFShower");
   cFibre           = c_light*(m_HF.getParameter<double>("CFibre"));
   
   edm::LogInfo("HFShower") << "HFFibre:: Speed of light in fibre " << cFibre
-			   << " m/ns";
+                           << " m/ns";
 
   std::string attribute = "Volume"; 
   std::string value     = "HF";
@@ -37,10 +38,12 @@ HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv,
     // Attenuation length
     nBinAtt      = -1;
     attL         = getDDDArray("attl",sv,nBinAtt);
-    edm::LogInfo("HFShower") << "HFFibre: " << nBinAtt << " attL ";
-    for (int it=0; it<nBinAtt; it++) 
-      edm::LogInfo("HFShower") << "HFFibre: attL[" << it << "] = " 
-			       << attL[it]*cm << "(1/cm)";
+    std::stringstream ss1;
+    for (int it=0; it<nBinAtt; it++) {
+      if(it/10*10 == it) { ss1 << "\n"; }
+      ss1 << "  " << attL[it]*cm;
+    }
+    edm::LogInfo("HFShower") << "HFFibre: " << nBinAtt << " attL(1/cm): " << ss1.str();
 
     // Limits on Lambda
     int nb   = 2;
@@ -48,47 +51,47 @@ HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv,
     lambLim[0] = static_cast<int>(nvec[0]);
     lambLim[1] = static_cast<int>(nvec[1]);
     edm::LogInfo("HFShower") << "HFFibre: Limits on lambda " << lambLim[0]
-			     << " and " << lambLim[1];
+                             << " and " << lambLim[1];
 
     // Fibre Lengths
     nb       = 0;
     longFL   = getDDDArray("LongFL",sv,nb);
-    edm::LogInfo("HFShower") << "HFFibre: " << nb << " Long Fibre Length";
-    for (int it=0; it<nb; it++) 
-      edm::LogInfo("HFShower") << "HFFibre: longFL[" << it << "] = " 
-			       << longFL[it]/cm << " cm";
-    nb       = 0;
+    std::stringstream ss2;
+    for (int it=0; it<nb; it++) {
+      if(it/10*10 == it) { ss2 << "\n"; }
+      ss2 << "  " << longFL[it]/cm;
+    }
+    edm::LogInfo("HFShower") << "HFFibre: " << nb << " Long Fibre Length(cm):" << ss2.str();
+    nb = 0;
     shortFL   = getDDDArray("ShortFL",sv,nb);
-    edm::LogInfo("HFShower") << "HFFibre: " << nb << " Short Fibre Length";
-    for (int it=0; it<nb; it++) 
-      edm::LogInfo("HFShower") << "HFFibre: shortFL[" << it << "] = " 
-			       << shortFL[it]/cm << " cm";
+    std::stringstream ss3;
+    for (int it=0; it<nb; it++) {
+      if(it/10*10 == it) { ss3 << "\n"; }
+      ss3 << "  " << shortFL[it]/cm;
+    } 
+    edm::LogInfo("HFShower") << "HFFibre: " << nb << " Short Fibre Length(cm):" << ss3.str();
   } else {
     edm::LogError("HFShower") << "HFFibre: cannot get filtered "
-			      << " view for " << attribute << " matching "
-			      << name;
+                              << " view for " << attribute << " matching "
+                              << name;
     throw cms::Exception("Unknown", "HFFibre")
       << "cannot match " << attribute << " to " << name <<"\n";
   }
 }
 
-HFFibre::~HFFibre() {}
-
-void HFFibre::initRun(HcalDDDSimConstants* hcons) {
+void HFFibre::initRun(const HcalDDDSimConstants* hcons) {
 
   // Now geometry parameters
   gpar      = hcons->getGparHF();
-  edm::LogInfo("HFShower") << "HFFibre: " << gpar.size() <<" gpar (cm)";
-  for (unsigned int i=0; i<gpar.size(); i++)
-    edm::LogInfo("HFShower") << "HFFibre: gpar[" << i << "] = "
-                             << gpar[i]/cm << " cm";
-
   radius    = hcons->getRTableHF();
+
   nBinR     = (int)(radius.size());
-  edm::LogInfo("HFShower") << "HFFibre: " << radius.size() <<" rTable (cm)";
-  for (unsigned int i=0; i<radius.size(); i++)
-    edm::LogInfo("HFShower") << "HFFibre: radius[" << i << "] = "
-                             << radius[i]/cm << " cm";
+  std::stringstream sss;
+  for (int i=0; i<nBinR; ++i) {
+    if(i/10*10 == i) { sss << "\n"; }
+    sss << "  " << radius[i]/cm;
+  }
+  edm::LogInfo("HFShower") << "HFFibre: " << radius.size() <<" rTable(cm):" << sss.str();
 }
 
 double HFFibre::attLength(double lambda) {
@@ -103,8 +106,8 @@ double HFFibre::attLength(double lambda) {
   double att = attL[j];
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFFibre::attLength for Lambda " << lambda
-			   << " index " << i  << " " << j << " Att. Length " 
-			   << att;
+                           << " index " << i  << " " << j << " Att. Length " 
+                           << att;
 #endif
   return att;
 }
@@ -115,8 +118,8 @@ double HFFibre::tShift(const G4ThreeVector& point, int depth, int fromEndAbs) {
   double time   = zFibre/cFibre;
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFFibre::tShift for point " << point
-			   << " ( depth = " << depth <<", traversed length = " 
-			   << zFibre/cm  << " cm) = " << time/ns << " ns";
+                           << " ( depth = " << depth <<", traversed length = " 
+                           << zFibre/cm  << " cm) = " << time/ns << " ns";
 #endif
   return time;
 }
@@ -150,21 +153,21 @@ double HFFibre::zShift(const G4ThreeVector& point, int depth, int fromEndAbs) { 
 
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFFibre::zShift for point " << point
-			   << " (R = " << hR/cm << " cm, Index = " << ieta 
-			   << ", depth = " << depth << ", Fibre Length = " 
-			   << length/cm       << " cm = " << zFibre/cm  
-			   << " cm)";
+                           << " (R = " << hR/cm << " cm, Index = " << ieta 
+                           << ", depth = " << depth << ", Fibre Length = " 
+                           << length/cm       << " cm = " << zFibre/cm  
+                           << " cm)";
 #endif
   return zFibre;
 }
 
 std::vector<double> HFFibre::getDDDArray(const std::string & str, 
-					 const DDsvalues_type & sv, 
-					 int & nmin) {
+                                         const DDsvalues_type & sv, 
+                                         int & nmin) {
 
 #ifdef DebugLog
   LogDebug("HFShower") << "HFFibre:getDDDArray called for " << str 
-		       << " with nMin " << nmin;
+                       << " with nMin " << nmin;
 #endif
   DDValue value(str);
   if (DDfetch(&sv,value)) {
@@ -175,18 +178,18 @@ std::vector<double> HFFibre::getDDDArray(const std::string & str,
     int nval = fvec.size();
     if (nmin > 0) {
       if (nval < nmin) {
-	edm::LogError("HFShower") << "HFFibre : # of " << str << " bins " 
-				  << nval << " < " << nmin << " ==> illegal";
-	throw cms::Exception("Unknown", "HFFibre")
-	  << "nval < nmin for array " << str <<"\n";
+        edm::LogError("HFShower") << "HFFibre : # of " << str << " bins " 
+                                  << nval << " < " << nmin << " ==> illegal";
+        throw cms::Exception("Unknown", "HFFibre")
+          << "nval < nmin for array " << str <<"\n";
       }
     } else {
       if (nval < 1 && nmin != 0) {
-	edm::LogError("HFShower") << "HFFibre : # of " << str << " bins " 
-				  << nval << " < 1 ==> illegal (nmin=" 
-				  << nmin << ")";
-	throw cms::Exception("Unknown", "HFFibre")
-	  << "nval < 1 for array " << str <<"\n";
+        edm::LogError("HFShower") << "HFFibre : # of " << str << " bins " 
+                                  << nval << " < 1 ==> illegal (nmin=" 
+                                  << nmin << ")";
+        throw cms::Exception("Unknown", "HFFibre")
+          << "nval < 1 for array " << str <<"\n";
       }
     }
     nmin = nval;
@@ -195,7 +198,7 @@ std::vector<double> HFFibre::getDDDArray(const std::string & str,
     if (nmin != 0) {
       edm::LogError("HFShower") << "HFFibre : cannot get array " << str;
       throw cms::Exception("Unknown", "HFFibre")
-	<< "cannot get array " << str <<"\n";
+        << "cannot get array " << str <<"\n";
     } else {
       std::vector<double> fvec;
       return fvec;

--- a/SimG4CMS/Calo/src/HFFibreFiducial.cc
+++ b/SimG4CMS/Calo/src/HFFibreFiducial.cc
@@ -6,18 +6,21 @@
 
 #include<iostream>
 
+//#define DebugLog
+
 int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
 {
   double xv  = pe_effect.x();          // X in global system
   double yv  = pe_effect.y();          // Y in global system
-  double zv  = pe_effect.z();          // Z in global system
   double phi = atan2(yv, xv);          // In global system
   if (phi < 0.) phi+=CLHEP::pi;        // Just for security
   double dph = CLHEP::pi/18;           // 10 deg = a half sector width
   double sph = dph+dph;                // 20 deg = a sector width
   int   nphi = phi/dph;                // 10 deg sector #
+#ifdef DebugLog
   edm::LogInfo("HFShower") <<"HFFibreFiducial:***> P = " << pe_effect 
                            << ", phi = " << phi/CLHEP::deg;
+#endif
   if (nphi > 35) nphi=35;              // Just for security
   double xl=0.;                        // local sector coordinates (left/right)
   double yl=0.;                        // local sector coordinates (down/up)
@@ -46,12 +49,16 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
     double sinr= sin(phir);
     yl= xv*cosr+yv*sinr;
     xl= yv*cosr-xv*sinr;
+#ifdef DebugLog
     edm::LogInfo("HFShower") << "HFFibreFiducial: nr " << nr << " phi " << phir/CLHEP::deg;
+#endif
   }
   if (yl < 0) yl =-yl;
+#ifdef DebugLog
   edm::LogInfo("HFShower") << "HFFibreFiducial: Global Point " << pe_effect
                            << " nphi " << nphi << " Local Sector Coordinates (" 
                            << xl << ", " << yl << "), widget # " << nwid;
+#endif
   // Provides a PMT # for the (x,y) hit in the widget # nwid (M. Kosov, 11.2010)
   // Send comments/questions to Mikhail.Kossov@cern.ch
   // nwid = 1-18 for Forward HF, 19-36 for Backward HF (all equal now)
@@ -1517,7 +1524,9 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
     return 0;
   }
   int nx=static_cast<int>(fx);           // Cell number (starting from 0)
+#ifdef DebugLog
   double phis=atan2(xl, yl)/CLHEP::deg;
+  double zv  = pe_effect.z();          // Z in global system
   edm::LogInfo("HFShower") << "HFFibreFiducial::PMTNumber:X = " << xv 
       << ", Y = " << yv << ", Z = " << zv << ", fX = "
       << fx << "-> nX = " << nx << ", nY = " << ny 
@@ -1526,9 +1535,10 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
       << nwid << ", phi = " << phi/CLHEP::deg 
       << ", phis = " << phis << ", phir = "
       << phir/CLHEP::deg;
+#endif
   if (nx >= nSL[ny])
   {
-    edm::LogInfo("HFShower") << "-Warning-HFFibreFiducial::nx/ny (" << nx 
+    edm::LogInfo("HFShower") << "HFFibreFiducial::nx/ny (" << nx 
                              << "," << ny <<") " << " above limit " << nSL[ny];
     return 0;                           // ===> out of the acceptance
   }
@@ -1538,16 +1548,21 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
   int flag= code%10;
   int npmt= code/10;
   bool src= false;                       // by default: not a source-tube
+#ifdef DebugLog
   edm::LogInfo("HFShower") << "HFFibreFiducial::nx/ny (" << nx << ","
                            << ny << ") code/flag/npmt " <<  code << "/" << flag
                            << "/" << npmt;
+#endif
+
   if (!flag) return 0;                   // ===> no fiber in the cell
   else if (flag==1) npmt += 24;
   else if (flag==3 || flag==4) {
     src=true;
   }
+#ifdef DebugLog
   edm::LogInfo("HFShower") << "HFFibreFiducial::PMTNumber: src = " << src 
                            << ", npmt =" << npmt;
+#endif
   if (src) return -npmt;   // return the negative number for the source
   return npmt;
 } // End of PMTNumber

--- a/SimG4CMS/Calo/src/HFFibreFiducial.cc
+++ b/SimG4CMS/Calo/src/HFFibreFiducial.cc
@@ -67,20 +67,24 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
   static const int nWidM=36;
   if (nwid > nWidM || nwid <= 0)
   {
+#ifdef DebugLog
     edm::LogInfo("HFShower") << "-Warning-HFFibreFiducial::PMTNumber: "
                              << nwid << " == wrong widget number";
+#endif
     return 0;
   }
   static const double yMin= 13.1*CLHEP::cm; // start of the active area (Conv to mm?)
   static const double yMax=129.6*CLHEP::cm; // finish of the active area (Conv to mm?)
   if( yl < yMin || yl >= yMax )
   {
+#ifdef DebugLog
     edm::LogInfo("HFShower") << "-Warning-HFFibreFiducial::PMTNumber: Point "
                              << "with y = " << yl << " outside acceptance [" 
                              << yMin << ":" << yMax << "],  X = " << xv
                              << ", Y = " << yv << ", x = " << xl << ", nW = " 
                              << nwid << ", phi = " << phi/CLHEP::deg 
                              << ", phir = " << phir/CLHEP::deg;
+#endif
     return 0;                     // ===> out of the acceptance
   }
   bool left=true;                 // flag of the left part of the widget
@@ -93,9 +97,11 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
   static const double tg10=.17632698070847; // phi-angular acceptance of the widget
   if (r > tg10)
   {
+#ifdef DebugLog
     edm::LogInfo("HFShower") << "-Warning-HFFibreFiducial::PMTNumber: (x = "
                              << xl << ", y = " << yl << ", tg = " << r 
                              << ") out of the widget acceptance tg(10) " << tg10;
+#endif
     return 0;
   }
 
@@ -1519,8 +1525,10 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
   int ny=static_cast<int>((yl-yMin)/cellSize);   // Layer number (starting from 0)
   if (ny < 0 || ny >= nLay) // Sould never happen as was checked beforehand
   {
+#ifdef DebugLog
     edm::LogInfo("HFShower") << "-Warning-HFFibreFiducial::PMTNumber: "
                              << "check limits y = " << yl << ", nL=" << nLay;
+#endif
     return 0;
   }
   int nx=static_cast<int>(fx);           // Cell number (starting from 0)
@@ -1538,8 +1546,10 @@ int HFFibreFiducial::PMTNumber(const G4ThreeVector& pe_effect)
 #endif
   if (nx >= nSL[ny])
   {
+#ifdef DebugLog
     edm::LogInfo("HFShower") << "HFFibreFiducial::nx/ny (" << nx 
                              << "," << ny <<") " << " above limit " << nSL[ny];
+#endif
     return 0;                           // ===> out of the acceptance
   }
   int code=0;                           // a prototype

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -24,7 +24,7 @@
 #include<iostream>
 
 HFShower::HFShower(const std::string & name, const DDCompactView & cpv, 
-		   edm::ParameterSet const & p, int chk) : cherenkov(nullptr),
+                   edm::ParameterSet const & p, int chk) : cherenkov(nullptr),
                                                            fibre(nullptr),
                                                            chkFibre(chk) {
 
@@ -97,7 +97,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
       ok = false;
     } else if (npmt > 24) { // a short fibre
       if (zv > gpar[0]) {
-	depth = 2; 
+        depth = 2; 
       } else {
         ok = false;
       }
@@ -124,10 +124,10 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
 
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFShower::getHits: in " << name << " Z " 
-			   << zCoor << "(" << globalPos.z() << ") " << zFibre 
-			   << " Trans " << translation << " Time " << tSlice  
-			   << " " << time << "\n                  Direction " 
-			   << momentumDir << " Local " << localMom;
+                           << zCoor << "(" << globalPos.z() << ") " << zFibre 
+                           << " Trans " << translation << " Time " << tSlice  
+                           << " " << time << "\n                  Direction " 
+                           << momentumDir << " Local " << localMom;
 #endif 
   // Here npe should be 0 if there is no fiber (@@ M.K.)
   int npe = 1;
@@ -146,23 +146,23 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
       double r2  = G4UniformRand();
 #ifdef DebugLog
       edm::LogInfo("HFShower") << "HFShower::getHits: " << i << " attenuation "
-			       << r1 <<":" << exp(-p*zFibre) << " r2 " << r2 
-			       << ":" << probMax << " Survive: " 
-			       << (r1 <= exp(-p*zFibre) && r2 <= probMax);
+                               << r1 <<":" << exp(-p*zFibre) << " r2 " << r2 
+                               << ":" << probMax << " Survive: " 
+                               << (r1 <= exp(-p*zFibre) && r2 <= probMax);
 #endif
       if (applyFidCut || chkFibre < 0 || (r1 <= exp(-p*zFibre) && r2 <= probMax)) {
-	hit.depth      = depth;
-	hit.time       = tSlice+time;
-	if (!applyFidCut) {
-	  hit.wavelength = wavelength[i]; // Tmp
-	  hit.momentum   = momz[i]; // Tmp
-	} else {
-	  hit.wavelength = 300.; // Tmp
-	  hit.momentum   = 1.; // Tmp
-	}
-	hit.position   = globalPos;
-	hits.push_back(hit);
-	nHit++;
+        hit.depth      = depth;
+        hit.time       = tSlice+time;
+        if (!applyFidCut) {
+          hit.wavelength = wavelength[i]; // Tmp
+          hit.momentum   = momz[i]; // Tmp
+        } else {
+          hit.wavelength = 300.; // Tmp
+          hit.momentum   = 1.; // Tmp
+        }
+        hit.position   = globalPos;
+        hits.push_back(hit);
+        nHit++;
       }
     }
   }
@@ -171,17 +171,17 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
   edm::LogInfo("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
   for (int i=0; i<nHit; ++i)
     edm::LogInfo("HFShower") << "HFShower::Hit " << i << " WaveLength " 
-			     << hits[i].wavelength << " Time " << hits[i].time
-			     << " Momentum " << hits[i].momentum <<" Position "
-			     << hits[i].position;
+                             << hits[i].wavelength << " Time " << hits[i].time
+                             << " Momentum " << hits[i].momentum <<" Position "
+                             << hits[i].position;
 #endif
   return hits;
 
 } 
 
 std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
-					     bool forLibraryProducer,
-					     double zoffset) {
+                                             bool forLibraryProducer,
+                                             double zoffset) {
 
   std::vector<HFShower::Hit> hits;
   int    nHit    = 0;
@@ -232,7 +232,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
       ok = false;
     } else if (npmt > 24) { // a short fibre
       if (zv > gpar[0]) {
-	depth = 2; 
+        depth = 2; 
       } else {
         ok = false;
       }
@@ -259,10 +259,10 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
 
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFShower::getHits: in " << name << " Z " <<zCoor
-			   << "(" << globalPos.z() <<") " << zFibre <<" Trans "
-			   << translation << " Time " << tSlice  << " " << time
-			   << "\n                  Direction " << momentumDir 
-			   << " Local " << localMom;
+                           << "(" << globalPos.z() <<") " << zFibre <<" Trans "
+                           << translation << " Time " << tSlice  << " " << time
+                           << "\n                  Direction " << momentumDir 
+                           << " Local " << localMom;
 #endif 
   // Here npe should be 0 if there is no fiber (@@ M.K.)
   int npe = 1;
@@ -281,23 +281,23 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
       double r2  = G4UniformRand();
 #ifdef DebugLog
       edm::LogInfo("HFShower") << "HFShower::getHits: " << i << " attenuation "
-			       << r1 << ":" << exp(-p*zFibre) << " r2 " << r2 
-			       << ":" << probMax << " Survive: " 
-			       << (r1 <= exp(-p*zFibre) && r2 <= probMax);
+                               << r1 << ":" << exp(-p*zFibre) << " r2 " << r2 
+                               << ":" << probMax << " Survive: " 
+                               << (r1 <= exp(-p*zFibre) && r2 <= probMax);
 #endif
       if (applyFidCut || chkFibre < 0 || (r1 <= exp(-p*zFibre) && r2 <= probMax)) {
-	hit.depth      = depth;
-	hit.time       = tSlice+time;
-	if (!applyFidCut) {
-	  hit.wavelength = wavelength[i]; // Tmp
-	  hit.momentum   = momz[i]; // Tmp
-	} else {
-	  hit.wavelength = 300.; // Tmp
-	  hit.momentum   = 1.; // Tmp
-	}
-	hit.position   = globalPos;
-	hits.push_back(hit);
-	nHit++;
+        hit.depth      = depth;
+        hit.time       = tSlice+time;
+        if (!applyFidCut) {
+          hit.wavelength = wavelength[i]; // Tmp
+          hit.momentum   = momz[i]; // Tmp
+        } else {
+          hit.wavelength = 300.; // Tmp
+          hit.momentum   = 1.; // Tmp
+        }
+        hit.position   = globalPos;
+        hits.push_back(hit);
+        nHit++;
       }
     }
   }
@@ -306,9 +306,9 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep,
   edm::LogInfo("HFShower") << "HFShower::getHits: Number of Hits " << nHit;
   for (int i=0; i<nHit; ++i)
     edm::LogInfo("HFShower") << "HFShower::Hit " << i << " WaveLength " 
-			     << hits[i].wavelength << " Time " << hits[i].time
-			     << " Momentum " << hits[i].momentum <<" Position "
-			     << hits[i].position;
+                             << hits[i].wavelength << " Time " << hits[i].time
+                             << " Momentum " << hits[i].momentum <<" Position "
+                             << hits[i].position;
 #endif
   return hits;
 
@@ -363,7 +363,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, bool forLibra
       ok = false;
     } else if (npmt > 24) { // a short fibre
       if (zv > gpar[0]) {
-	depth = 2; 
+        depth = 2; 
       } else {
         ok = false;
       }
@@ -390,10 +390,10 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, bool forLibra
 
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFShower::getHits(SL): in " << name << " Z " 
-			   << zCoor << "(" << globalPos.z() << ") " << zFibre 
-			   << " Trans " << translation << " Time " << tSlice  
-			   << " " << time << "\n                  Direction " 
-			   << momentumDir << " Local " << localMom;
+                           << zCoor << "(" << globalPos.z() << ") " << zFibre 
+                           << " Trans " << translation << " Time " << tSlice  
+                           << " " << time << "\n                  Direction " 
+                           << momentumDir << " Local " << localMom;
 #endif
   // npe should be 0
   int npe = 0;
@@ -415,7 +415,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, bool forLibra
 
 std::vector<double> HFShower::getDDDArray(const std::string & str, 
                                           const DDsvalues_type & sv, 
-					  int & nmin) {
+                                          int & nmin) {
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShower:getDDDArray called for " << str 
                        << " with nMin " << nmin;
@@ -438,8 +438,7 @@ std::vector<double> HFShower::getDDDArray(const std::string & str,
       if (nval < 2) {
         edm::LogError("HFShower") << "HFShower : # of " << str << " bins " << nval
                                   << " < 2 ==> illegal" << " (nmin=" << nmin << ")";
-        throw cms::Exception("Unknown", "HFShower")
-	  << "nval < 2 for array " << str << "\n";
+        throw cms::Exception("Unknown", "HFShower") << "nval < 2 for array " << str;
       }
     }
     nmin = nval;
@@ -451,14 +450,9 @@ std::vector<double> HFShower::getDDDArray(const std::string & str,
   }
 }
 
-void HFShower::initRun(G4ParticleTable *, HcalDDDSimConstants* hcons) {
+void HFShower::initRun(const HcalDDDSimConstants* hcons) {
 
   //Special Geometry parameters
-  gpar      = hcons->getGparHF();
-  edm::LogInfo("HFShower") << "HFShower: " << gpar.size() << " gpar (cm)";
-  for (unsigned int ig=0; ig<gpar.size(); ig++)
-    edm::LogInfo("HFShower") << "HFShower: gpar[" << ig << "] = "
-                             << gpar[ig]/cm << " cm";
-
-  if (fibre) fibre->initRun(hcons);
+  gpar = hcons->getGparHF();
+  if (fibre) { fibre->initRun(hcons); }
 }

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -16,17 +16,18 @@
 #include "G4NavigationHistory.hh"
 #include "G4Step.hh"
 #include "G4Track.hh"
+#include "G4ParticleTable.hh"
 #include "Randomize.hh"
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
-#include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "CLHEP/Units/SystemOfUnits.h"
+#include "CLHEP/Units/PhysicalConstants.h"
 
 //#define DebugLog
 
 HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView & cpv,
-				 edm::ParameterSet const & p) : fibre(nullptr),hf(nullptr),
-								emBranch(nullptr),
-								hadBranch(nullptr),
-								npe(0) {
+                                 edm::ParameterSet const & p) : fibre(nullptr),hf(nullptr),
+                                                                emBranch(nullptr),
+                                                                hadBranch(nullptr),
+                                                                npe(0) {
   
 
   edm::ParameterSet m_HF  = p.getParameter<edm::ParameterSet>("HFShower");
@@ -50,15 +51,15 @@ HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView &
 
   if (!hf->IsOpen()) { 
     edm::LogError("HFShower") << "HFShowerLibrary: opening " << nTree 
-			      << " failed";
+                              << " failed";
     throw cms::Exception("Unknown", "HFShowerLibrary") 
       << "Opening of " << pTreeName << " fails\n";
   } else {
     edm::LogInfo("HFShower") << "HFShowerLibrary: opening " << nTree 
-			     << " successfully"; 
+                             << " successfully"; 
   }
 
-  newForm = (branchEvInfo == "");
+  newForm = (branchEvInfo.empty());
   TTree* event(nullptr);
   if (newForm) event = (TTree *) hf ->Get("HFSimHits");
   else         event = (TTree *) hf ->Get("Events");
@@ -72,26 +73,26 @@ HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView &
       loadEventInfo(evtInfo);
     } else {
       edm::LogError("HFShower") << "HFShowerLibrary: HFShowerLibrayEventInfo"
-				<< " Branch does not exist in Event";
+                                << " Branch does not exist in Event";
       throw cms::Exception("Unknown", "HFShowerLibrary")
-	<< "Event information absent\n";
+        << "Event information absent\n";
     }
   } else {
     edm::LogError("HFShower") << "HFShowerLibrary: Events Tree does not "
-			      << "exist";
+                              << "exist";
     throw cms::Exception("Unknown", "HFShowerLibrary")
       << "Events tree absent\n";
   }
   
-  edm::LogInfo("HFShower") << "HFShowerLibrary: Library " << libVers 
-			   << " ListVersion "	<< listVersion 
-			   << " Events Total " << totEvents << " and "
-			   << evtPerBin << " per bin";
-  edm::LogInfo("HFShower") << "HFShowerLibrary: Energies (GeV) with " 
-			   << nMomBin	<< " bins";
-  for (int i=0; i<nMomBin; i++)
-    edm::LogInfo("HFShower") << "HFShowerLibrary: pmom[" << i << "] = "
-			     << pmom[i]/GeV << " GeV";
+  std::stringstream ss;
+  ss << "HFShowerLibrary: Library " << libVers << " ListVersion " << listVersion 
+     << " Events Total " << totEvents << " and " << evtPerBin << " per bin\n";
+  ss << "HFShowerLibrary: Energies (GeV) with " << nMomBin << " bins\n";
+  for (int i=0; i<nMomBin; ++i) {
+    if(i/10*10 == i && i > 0) { ss << "\n"; }
+    ss << "  " << pmom[i]/CLHEP::GeV;
+  }
+  edm::LogInfo("HFShower") << ss.str();
 
   std::string nameBr = branchPre + emName + branchPost;
   emBranch         = event->GetBranch(nameBr.c_str());
@@ -105,18 +106,16 @@ HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView &
     v3version=true;
   }
   
-
-  edm::LogInfo("HFShower") << "HFShowerLibrary:Branch " << emName 
-			   << " has " << emBranch->GetEntries() 
-			   << " entries and Branch " << hadName 
-			   << " has " << hadBranch->GetEntries() 
-			   << " entries";
-  edm::LogInfo("HFShower") << "HFShowerLibrary::No packing information -"
-			   << " Assume x, y, z are not in packed form";
-
-  edm::LogInfo("HFShower") << "HFShowerLibrary: Maximum probability cut off " 
-			   << probMax << "  Back propagation of light prob. "
-                           << backProb ;
+  edm::LogInfo("HFShower") << " HFShowerLibrary:Branch " << emName 
+                           << " has " << emBranch->GetEntries() 
+                           << " entries and Branch " << hadName 
+                           << " has " << hadBranch->GetEntries() 
+                           << " entries"
+                           << "\n HFShowerLibrary::No packing information -"
+                           << " Assume x, y, z are not in packed form"
+                           << "\n Maximum probability cut off " 
+                           << probMax << "  Back propagation of light prob. "
+                           << backProb;
   
   fibre = new HFFibre(name, cpv, p);
   photo = new HFShowerPhotonCollection;
@@ -124,13 +123,11 @@ HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView &
 
 HFShowerLibrary::~HFShowerLibrary() {
   if (hf)     hf->Close();
-  if (fibre)  delete   fibre;
-  fibre  = nullptr;
-  if (photo)  delete photo;
+  delete fibre;
+  delete photo;
 }
 
-void HFShowerLibrary::initRun(G4ParticleTable * theParticleTable,
-			      HcalDDDSimConstants* hcons) {
+void HFShowerLibrary::initRun(G4ParticleTable*, const HcalDDDSimConstants* hcons) {
 
   if (fibre) fibre->initRun(hcons);
   
@@ -138,51 +135,46 @@ void HFShowerLibrary::initRun(G4ParticleTable * theParticleTable,
   std::vector<double> rTable = hcons->getRTableHF();
   rMin = rTable[0];
   rMax = rTable[rTable.size()-1];
-  edm::LogInfo("HFShower") << "HFShowerLibrary: rMIN " << rMin/cm 
-                           << " cm and rMax " << rMax/cm;
 
   //Delta phi
   std::vector<double> phibin   = hcons->getPhiTableHF();
   dphi       = phibin[0];
-  edm::LogInfo("HFShower") << "HFShowerLibrary: (Half) Phi Width of wedge " 
+  edm::LogInfo("HFShower") << "HFShowerLibrary: rMIN " << rMin/cm 
+                           << " cm and rMax " << rMax/cm
+                           << " (Half) Phi Width of wedge " 
                            << dphi/deg;
 
   //Special Geometry parameters
-  gpar      = hcons->getGparHF();
-  edm::LogInfo("HFShower") << "HFShowerLibrary: " <<gpar.size() <<" gpar (cm)";
-  for (unsigned int ig=0; ig<gpar.size(); ig++)
-    edm::LogInfo("HFShower") << "HFShowerLibrary: gpar[" << ig << "] = "
-                             << gpar[ig]/cm << " cm";
+  gpar = hcons->getGparHF();
 }
 
+std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(const G4Step * aStep,
+                                                           bool & isKilled,
+                                                           double weight,
+                                                           bool onlyLong) {
 
-std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(G4Step * aStep,
-							   bool & ok,
-							   double weight,
-							   bool onlyLong) {
-
-  const G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
-  const G4StepPoint * postStepPoint = aStep->GetPostStepPoint(); 
-  const G4Track *     track    = aStep->GetTrack();
+  auto const preStepPoint  = aStep->GetPreStepPoint(); 
+  auto const postStepPoint = aStep->GetPostStepPoint(); 
+  auto const track = aStep->GetTrack();
   // Get Z-direction 
-  const G4DynamicParticle *aParticle = track->GetDynamicParticle();
+  auto const aParticle = track->GetDynamicParticle();
   const G4ThreeVector& momDir = aParticle->GetMomentumDirection();
-
   const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
-  G4String      partType = track->GetDefinition()->GetParticleName();
-  int           parCode  = track->GetDefinition()->GetPDGEncoding();
+  int parCode   = track->GetDefinition()->GetPDGEncoding();
 
   // VI: for ions use internally pdg code of alpha in order to keep 
   // consistency with previous simulation
   if(track->GetDefinition()->IsGeneralIon()) { parCode = 1000020040; }
- 
 
 #ifdef DebugLog
-  G4ThreeVector localPos = preStepPoint->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPoint);
+  G4String      partType = track->GetDefinition()->GetParticleName();
+  const G4ThreeVector localPos = 
+    preStepPoint->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPoint);
   double zoff   = localPos.z() + 0.5*gpar[1];
-  //  if (zoff < 0) zoff = 0;
-  edm::LogInfo("HFShower") << "HFShowerLibrary: getHits " << partType
+
+  edm::LogInfo("HFShower") << "HFShowerLibrary::getHits " << partType
                            << " of energy " << pin/GeV << " GeV"
+                           << " weight= " << weight << " onlyLong: " << onlyLong
                            << "  dir.orts " << momDir.x() << ", " <<momDir.y()
                            << ", " << momDir.z() << "  Pos x,y,z = "
                            << hitPoint.x() << "," << hitPoint.y() << ","
@@ -192,13 +184,13 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(G4Step * aStep,
                            << "," << cos(momDir.theta());
 #endif
 
-  double tSlice = (postStepPoint->GetGlobalTime())/nanosecond;
+  double tSlice = (postStepPoint->GetGlobalTime())/CLHEP::nanosecond;
 
   // use kinetic energy for protons and ions
   double pin = (track->GetDefinition()->GetBaryonNumber() > 0) 
     ? preStepPoint->GetKineticEnergy() : preStepPoint->GetTotalEnergy();
 
-  return fillHits(hitPoint,momDir,parCode,pin,ok,weight,tSlice,onlyLong);
+  return fillHits(hitPoint,momDir,parCode,pin,isKilled,weight,tSlice,onlyLong);
 }
 
 std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector & hitPoint,
@@ -223,15 +215,14 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
   double zint   = hitPoint.z(); 
 
   // if particle moves from interaction point or "backwards (halo)
-  int backward = 0;
-  if (pz * zint < 0.) backward = 1;
+  bool backward = (pz * zint < 0.) ? true : false;
   
   double sphi   = sin(momDir.phi());
   double cphi   = cos(momDir.phi());
   double ctheta = cos(momDir.theta());
   double stheta = sin(momDir.theta());
 
-  if (isEM) {
+  if(isEM) {
     if (pin<pmom[nMomBin-1]) {
       interpolate(0, pin);
     } else {
@@ -247,19 +238,19 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
     
   int nHit = 0;
   HFShowerLibrary::Hit oneHit;
-  for (int i = 0; i < npe; i++) {
+  for (int i = 0; i < npe; ++i) {
     double zv = std::abs(pe[i].z()); // abs local z  
 #ifdef DebugLog
     edm::LogInfo("HFShower") << "HFShowerLibrary: Hit " << i << " " << pe[i] << " zv " << zv;
 #endif
     if (zv <= gpar[1] && pe[i].lambda() > 0 && 
-	(pe[i].z() >= 0 || (zv > gpar[0] && (!onlyLong)))) {
+        (pe[i].z() >= 0 || (zv > gpar[0] && (!onlyLong)))) {
       int depth = 1;
       if (onlyLong) {
-      } else if (backward == 0) {    // fully valid only for "front" particles
-	if (pe[i].z() < 0) depth = 2;// with "front"-simulated shower lib.
+      } else if (!backward) {        // fully valid only for "front" particles
+        if (pe[i].z() < 0) depth = 2;// with "front"-simulated shower lib.
       } else {                       // for "backward" particles - almost equal
-	double r = G4UniformRand();  // share between L and S fibers
+        double r = G4UniformRand();  // share between L and S fibers
         if (r > 0.5) depth = 2;
       } 
       
@@ -282,7 +273,7 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
       double r  = pos.perp();
       double p  = fibre->attLength(pe[i].lambda());
       double fi = pos.phi();
-      if (fi < 0) fi += twopi;
+      if (fi < 0) fi += CLHEP::twopi;
       int    isect = int(fi/dphi) + 1;
       isect        = (isect + 1) / 2;
       double dfi   = ((isect*2-1)*dphi - fi);
@@ -290,90 +281,88 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector 
       double dfir  = r * sin(dfi);
 #ifdef DebugLog
       edm::LogInfo("HFShower") << "HFShowerLibrary: Position shift " << xx 
-			       << ", " << yy << ", "  << zz << ": " << pos 
-			       << " R " << r << " Phi " << fi << " Section " 
-			       << isect << " R*Dfi " << dfir << " Dist " << zv;
+                               << ", " << yy << ", "  << zz << ": " << pos 
+                               << " R " << r << " Phi " << fi << " Section " 
+                               << isect << " R*Dfi " << dfir << " Dist " << zv;
 #endif
       zz           = std::abs(pos.z());
       double r1    = G4UniformRand();
       double r2    = G4UniformRand();
-      double r3    = -9999.;
-      if (backward)     r3    = G4UniformRand();
+      double r3    = backward ? G4UniformRand() : -9999.;
       if (!applyFidCut) dfir += gpar[5];
 
 #ifdef DebugLog
       edm::LogInfo("HFShower") << "HFShowerLibrary: rLimits " << rInside(r)
-			       << " attenuation " << r1 <<":" << exp(-p*zv) 
-			       << " r2 " << r2 << " r3 " << r3 << " rDfi "  
-			       << gpar[5] << " zz " 
-			       << zz << " zLim " << gpar[4] << ":" 
-			       << gpar[4]+gpar[1] << "\n"
-			       << "  rInside(r) :" << rInside(r) 
-			       << "  r1 <= exp(-p*zv) :" <<  (r1 <= exp(-p*zv))
-			       << "  r2 <= probMax :"    <<  (r2 <= probMax*weight)
-			       << "  r3 <= backProb :"   <<  (r3 <= backProb) 
-			       << "  dfir > gpar[5] :"   <<  (dfir > gpar[5])
-			       << "  zz >= gpar[4] :"    <<  (zz >= gpar[4])
-			       << "  zz <= gpar[4]+gpar[1] :" 
-			       << (zz <= gpar[4]+gpar[1]);   
+                               << " attenuation " << r1 <<":" << exp(-p*zv) 
+                               << " r2 " << r2 << " r3 " << r3 << " rDfi "  
+                               << gpar[5] << " zz " 
+                               << zz << " zLim " << gpar[4] << ":" 
+                               << gpar[4]+gpar[1] << "\n"
+                               << "  rInside(r) :" << rInside(r) 
+                               << "  r1 <= exp(-p*zv) :" <<  (r1 <= exp(-p*zv))
+                               << "  r2 <= probMax :"    <<  (r2 <= probMax*weight)
+                               << "  r3 <= backProb :"   <<  (r3 <= backProb) 
+                               << "  dfir > gpar[5] :"   <<  (dfir > gpar[5])
+                               << "  zz >= gpar[4] :"    <<  (zz >= gpar[4])
+                               << "  zz <= gpar[4]+gpar[1] :" 
+                               << (zz <= gpar[4]+gpar[1]);   
 #endif
       if (rInside(r) && r1 <= exp(-p*zv) && r2 <= probMax*weight && 
-	  dfir > gpar[5] && zz >= gpar[4] && zz <= gpar[4]+gpar[1] && 
-	  r3 <= backProb && (depth != 2 || zz >= gpar[4]+gpar[0])) {
-	oneHit.position = pos;
-	oneHit.depth    = depth;
-	oneHit.time     = (tSlice+(pe[i].t())+(fibre->tShift(lpos,depth,1)));
-	hit.push_back(oneHit);
+          dfir > gpar[5] && zz >= gpar[4] && zz <= gpar[4]+gpar[1] && 
+          r3 <= backProb && (depth != 2 || zz >= gpar[4]+gpar[0])) {
+        oneHit.position = pos;
+        oneHit.depth    = depth;
+        oneHit.time     = (tSlice+(pe[i].t())+(fibre->tShift(lpos,depth,1)));
+        hit.push_back(oneHit);
 #ifdef DebugLog
-	edm::LogInfo("HFShower") << "HFShowerLibrary: Final Hit " << nHit 
-				 <<" position " << (hit[nHit].position) 
-				 << " Depth " << (hit[nHit].depth) <<" Time " 
-				 << tSlice << ":" << pe[i].t() << ":" 
-				 << fibre->tShift(lpos,depth,1) << ":" 
-				 << (hit[nHit].time);
+        edm::LogInfo("HFShower") << "HFShowerLibrary: Final Hit " << nHit 
+                                 <<" position " << (hit[nHit].position) 
+                                 << " Depth " << (hit[nHit].depth) <<" Time " 
+                                 << tSlice << ":" << pe[i].t() << ":" 
+                                 << fibre->tShift(lpos,depth,1) << ":" 
+                                 << (hit[nHit].time);
 #endif
-	nHit++;
+        ++nHit;
       }
 #ifdef DebugLog
       else  LogDebug("HFShower") << "HFShowerLibrary: REJECTED !!!";
 #endif
       if (onlyLong && zz >= gpar[4]+gpar[0] && zz <= gpar[4]+gpar[1]) {
-	r1    = G4UniformRand();
-	r2    = G4UniformRand();
-	if (rInside(r) && r1 <= exp(-p*zv) && r2 <= probMax && dfir > gpar[5]){
-	  oneHit.position = pos;
-	  oneHit.depth    = 2;
-	  oneHit.time     = (tSlice+(pe[i].t())+(fibre->tShift(lpos,2,1)));
-	  hit.push_back(oneHit);
+        r1    = G4UniformRand();
+        r2    = G4UniformRand();
+        if (rInside(r) && r1 <= exp(-p*zv) && r2 <= probMax && dfir > gpar[5]){
+          oneHit.position = pos;
+          oneHit.depth    = 2;
+          oneHit.time     = (tSlice+(pe[i].t())+(fibre->tShift(lpos,2,1)));
+          hit.push_back(oneHit);
 #ifdef DebugLog
-	  edm::LogInfo("HFShower") << "HFShowerLibrary: Final Hit " << nHit 
-				   << " position " << (hit[nHit].position) 
-				   << " Depth " << (hit[nHit].depth) <<" Time "
-				   << tSlice << ":" << pe[i].t() << ":" 
-				   << fibre->tShift(lpos,2,1) << ":" 
-				   << (hit[nHit].time);
+          edm::LogInfo("HFShower") << "HFShowerLibrary: Final Hit " << nHit 
+                                   << " position " << (hit[nHit].position) 
+                                   << " Depth " << (hit[nHit].depth) <<" Time "
+                                   << tSlice << ":" << pe[i].t() << ":" 
+                                   << fibre->tShift(lpos,2,1) << ":" 
+                                   << (hit[nHit].time);
 #endif
-	  nHit++;
-	}
+          ++nHit;
+        }
       }
     }
   }
 
 #ifdef DebugLog
   edm::LogInfo("HFShower") << "HFShowerLibrary: Total Hits " << nHit
-			   << " out of " << npe << " PE";
+                           << " out of " << npe << " PE";
 #endif
-  if (nHit > npe && !onlyLong)
+  if (nHit > npe && !onlyLong) {
     edm::LogWarning("HFShower") << "HFShowerLibrary: Hit buffer " << npe 
-				<< " smaller than " << nHit << " Hits";
- return hit;
-
+                                << " smaller than " << nHit << " Hits";
+  }
+  return hit;
 }
 
 bool HFShowerLibrary::rInside(double r) {
 
-  if (r >= rMin && r <= rMax) return true;
-  else                        return false;
+  return (r >= rMin && r <= rMax);
 }
 
 void HFShowerLibrary::getRecord(int type, int record) {
@@ -384,19 +373,19 @@ void HFShowerLibrary::getRecord(int type, int record) {
   if (type > 0) {
     if (newForm) {
       if ( !v3version ) {
-	hadBranch->SetAddress(&photo);
-	hadBranch->GetEntry(nrc+totEvents);
+        hadBranch->SetAddress(&photo);
+        hadBranch->GetEntry(nrc+totEvents);
       }
       else{
-	std::vector<float> t;
-	std::vector<float> *tp=&t;
-	hadBranch->SetAddress(&tp);
-	hadBranch->GetEntry(nrc+totEvents);
-	unsigned int tSize=t.size()/5;
-	photo->reserve(tSize);
-	for ( unsigned int i=0; i<tSize; i++ ) {
-	  photo->push_back( HFShowerPhoton( t[i], t[1*tSize+i], t[2*tSize+i], t[3*tSize+i], t[4*tSize+i] ) );
-	}
+        std::vector<float> t;
+        std::vector<float> *tp=&t;
+        hadBranch->SetAddress(&tp);
+        hadBranch->GetEntry(nrc+totEvents);
+        unsigned int tSize=t.size()/5;
+        photo->reserve(tSize);
+        for ( unsigned int i=0; i<tSize; i++ ) {
+          photo->push_back( HFShowerPhoton( t[i], t[1*tSize+i], t[2*tSize+i], t[3*tSize+i], t[4*tSize+i] ) );
+        }
       }
     } else {
       hadBranch->SetAddress(&photon);
@@ -405,19 +394,19 @@ void HFShowerLibrary::getRecord(int type, int record) {
   } else {
     if (newForm) {
       if (!v3version) {
-	emBranch->SetAddress(&photo);
-	emBranch->GetEntry(nrc);
+        emBranch->SetAddress(&photo);
+        emBranch->GetEntry(nrc);
       }
       else{
-	std::vector<float> t;
-	std::vector<float> *tp=&t;
-	emBranch->SetAddress(&tp);
-	emBranch->GetEntry(nrc);
-	unsigned int tSize=t.size()/5;
-	photo->reserve(tSize);
-	for ( unsigned int i=0; i<tSize; i++ ) {
-	  photo->push_back( HFShowerPhoton( t[i], t[1*tSize+i], t[2*tSize+i], t[3*tSize+i], t[4*tSize+i] ) );
-	}
+        std::vector<float> t;
+        std::vector<float> *tp=&t;
+        emBranch->SetAddress(&tp);
+        emBranch->GetEntry(nrc);
+        unsigned int tSize=t.size()/5;
+        photo->reserve(tSize);
+        for ( unsigned int i=0; i<tSize; i++ ) {
+          photo->push_back( HFShowerPhoton( t[i], t[1*tSize+i], t[2*tSize+i], t[3*tSize+i], t[4*tSize+i] ) );
+        }
       }
     } else {
       emBranch->SetAddress(&photon);
@@ -427,8 +416,8 @@ void HFShowerLibrary::getRecord(int type, int record) {
 #ifdef DebugLog
   int nPhoton = (newForm) ? photo->size() : photon.size();
   LogDebug("HFShower") << "HFShowerLibrary::getRecord: Record " << record
-		       << " of type " << type << " with " << nPhoton 
-		       << " photons";
+                       << " of type " << type << " with " << nPhoton 
+                       << " photons";
   for (int j = 0; j < nPhoton; j++) 
     if (newForm) LogDebug("HFShower") << "Photon " << j << " " << photo->at(j);
     else         LogDebug("HFShower") << "Photon " << j << " " << photon[j];
@@ -442,8 +431,8 @@ void HFShowerLibrary::loadEventInfo(TBranch* branch) {
     branch->SetAddress(&eventInfoCollection);
     branch->GetEntry(0);
     edm::LogInfo("HFShower") << "HFShowerLibrary::loadEventInfo loads "
-			     << " EventInfo Collection of size "
-			     << eventInfoCollection.size() << " records";
+                             << " EventInfo Collection of size "
+                             << eventInfoCollection.size() << " records";
     totEvents   = eventInfoCollection[0].totalEvents();
     nMomBin     = eventInfoCollection[0].numberOfBins();
     evtPerBin   = eventInfoCollection[0].eventsPerBin();
@@ -452,7 +441,7 @@ void HFShowerLibrary::loadEventInfo(TBranch* branch) {
     pmom        = eventInfoCollection[0].energyBins();
   } else {
     edm::LogInfo("HFShower") << "HFShowerLibrary::loadEventInfo loads "
-			     << " EventInfo from hardwired numbers";
+                             << " EventInfo from hardwired numbers";
     nMomBin     = 16;
     evtPerBin   = 5000;
     totEvents   = nMomBin*evtPerBin;
@@ -468,8 +457,8 @@ void HFShowerLibrary::interpolate(int type, double pin) {
 
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerLibrary:: Interpolate for Energy " <<pin/GeV
-		       << " GeV with " << nMomBin << " momentum bins and " 
-		       << evtPerBin << " entries/bin -- total " << totEvents;
+                       << " GeV with " << nMomBin << " momentum bins and " 
+                       << evtPerBin << " entries/bin -- total " << totEvents;
 #endif
   int irc[2]={0,0};
   double w = 0.;
@@ -482,41 +471,41 @@ void HFShowerLibrary::interpolate(int type, double pin) {
   } else {
     for (int j=0; j<nMomBin-1; j++) {
       if (pin >= pmom[j] && pin < pmom[j+1]) {
-	w = (pin-pmom[j])/(pmom[j+1]-pmom[j]);
-	if (j == nMomBin-2) { 
-	  irc[1] = int(evtPerBin*0.5*r);
-	} else {
-	  irc[1] = int(evtPerBin*r);
-	}
-	irc[1] += (j+1)*evtPerBin + 1;
-	r = G4UniformRand();
-	irc[0] = int(evtPerBin*r) + 1 + j*evtPerBin;
-	if (irc[0]<0) {
-	  edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[0] = "
-				      << irc[0] << " now set to 0";
-	  irc[0] = 0;
-	} else if (irc[0] > totEvents) {
-	  edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[0] = "
-				      << irc[0] << " now set to "<< totEvents;
-	  irc[0] = totEvents;
-	}
+        w = (pin-pmom[j])/(pmom[j+1]-pmom[j]);
+        if (j == nMomBin-2) { 
+          irc[1] = int(evtPerBin*0.5*r);
+        } else {
+          irc[1] = int(evtPerBin*r);
+        }
+        irc[1] += (j+1)*evtPerBin + 1;
+        r = G4UniformRand();
+        irc[0] = int(evtPerBin*r) + 1 + j*evtPerBin;
+        if (irc[0]<0) {
+          edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[0] = "
+                                      << irc[0] << " now set to 0";
+          irc[0] = 0;
+        } else if (irc[0] > totEvents) {
+          edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[0] = "
+                                      << irc[0] << " now set to "<< totEvents;
+          irc[0] = totEvents;
+        }
       }
     }
   }
   if (irc[1]<1) {
     edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[1] = " 
-				<< irc[1] << " now set to 1";
+                                << irc[1] << " now set to 1";
     irc[1] = 1;
   } else if (irc[1] > totEvents) {
     edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[1] = " 
-				<< irc[1] << " now set to "<< totEvents;
+                                << irc[1] << " now set to "<< totEvents;
     irc[1] = totEvents;
   }
 
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerLibrary:: Select records " << irc[0] 
-		       << " and " << irc[1] << " with weights " << 1-w 
-		       << " and " << w;
+                       << " and " << irc[1] << " with weights " << 1-w 
+                       << " and " << w;
 #endif
   pe.clear(); 
   npe       = 0;
@@ -527,25 +516,25 @@ void HFShowerLibrary::interpolate(int type, double pin) {
       int nPhoton = (newForm) ? photo->size() : photon.size();
       npold      += nPhoton;
       for (int j=0; j<nPhoton; j++) {
-	r = G4UniformRand();
-	if ((ir==0 && r > w) || (ir > 0 && r < w)) {
-	  storePhoton (j);
-	}
+        r = G4UniformRand();
+        if ((ir==0 && r > w) || (ir > 0 && r < w)) {
+          storePhoton (j);
+        }
       }
     }
   }
 
   if ((npe > npold || (npold == 0 && irc[0] > 0)) && !(npe == 0 && npold == 0))
     edm::LogWarning("HFShower") << "HFShowerLibrary: Interpolation Warning =="
-				<< " records " << irc[0] << " and " << irc[1]
-				<< " gives a buffer of " << npold 
-				<< " photons and fills " << npe << " *****";
+                                << " records " << irc[0] << " and " << irc[1]
+                                << " gives a buffer of " << npold 
+                                << " photons and fills " << npe << " *****";
 #ifdef DebugLog
   else
     LogDebug("HFShower") << "HFShowerLibrary: Interpolation == records " 
-			 << irc[0] << " and " << irc[1] << " gives a "
-			 << "buffer of " << npold << " photons and fills "
-			 << npe << " PE";
+                         << irc[0] << " and " << irc[1] << " gives a "
+                         << "buffer of " << npold << " photons and fills "
+                         << npe << " PE";
   for (int j=0; j<npe; j++)
     LogDebug("HFShower") << "Photon " << j << " " << pe[j];
 #endif
@@ -558,9 +547,9 @@ void HFShowerLibrary::extrapolate(int type, double pin) {
   nrec++;
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerLibrary:: Extrapolate for Energy " << pin 
-		       << " GeV with " << nMomBin << " momentum bins and " 
-		       << evtPerBin << " entries/bin -- total " << totEvents 
-		       << " using " << nrec << " records";
+                       << " GeV with " << nMomBin << " momentum bins and " 
+                       << evtPerBin << " entries/bin -- total " << totEvents 
+                       << " using " << nrec << " records";
 #endif
   std::vector<int> irc(nrec);
 
@@ -569,17 +558,17 @@ void HFShowerLibrary::extrapolate(int type, double pin) {
     irc[ir] = int(evtPerBin*0.5*r) +(nMomBin-1)*evtPerBin + 1;
     if (irc[ir]<1) {
       edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[" << ir 
-				  << "] = " << irc[ir] << " now set to 1";
+                                  << "] = " << irc[ir] << " now set to 1";
       irc[ir] = 1;
     } else if (irc[ir] > totEvents) {
       edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[" << ir 
-				  << "] = " << irc[ir] << " now set to "
-				  << totEvents;
+                                  << "] = " << irc[ir] << " now set to "
+                                  << totEvents;
       irc[ir] = totEvents;
 #ifdef DebugLog
     } else {
       LogDebug("HFShower") << "HFShowerLibrary::Extrapolation use irc[" 
-			   << ir  << "] = " << irc[ir];
+                           << ir  << "] = " << irc[ir];
 #endif
     }
   }
@@ -593,14 +582,14 @@ void HFShowerLibrary::extrapolate(int type, double pin) {
       int nPhoton = (newForm) ? photo->size() : photon.size();
       npold      += nPhoton;
       for (int j=0; j<nPhoton; j++) {
-	double r = G4UniformRand();
-	if (ir != nrec-1 || r < w) {
-	  storePhoton (j);
-	}
+        double r = G4UniformRand();
+        if (ir != nrec-1 || r < w) {
+          storePhoton (j);
+        }
       }
 #ifdef DebugLog
       LogDebug("HFShower") << "HFShowerLibrary: Record [" << ir << "] = " 
-			   << irc[ir] << " npold = " << npold;
+                           << irc[ir] << " npold = " << npold;
 #endif
     }
   }
@@ -610,16 +599,16 @@ void HFShowerLibrary::extrapolate(int type, double pin) {
 
   if (npe > npold || npold == 0)
     edm::LogWarning("HFShower") << "HFShowerLibrary: Extrapolation Warning == "
-				<< nrec << " records " << irc[0] << ", " 
-				<< irc[1] << ", ... gives a buffer of " <<npold
-				<< " photons and fills " << npe 
-				<< " *****";
+                                << nrec << " records " << irc[0] << ", " 
+                                << irc[1] << ", ... gives a buffer of " <<npold
+                                << " photons and fills " << npe 
+                                << " *****";
 #ifdef DebugLog
   else
     LogDebug("HFShower") << "HFShowerLibrary: Extrapolation == " << nrec
-			 << " records " << irc[0] << ", " << irc[1] 
-			 << ", ... gives a buffer of " << npold 
-			 << " photons and fills " << npe << " PE";
+                         << " records " << irc[0] << ", " << irc[1] 
+                         << ", ... gives a buffer of " << npold 
+                         << " photons and fills " << npe << " PE";
   for (int j=0; j<npe; j++)
     LogDebug("HFShower") << "Photon " << j << " " << pe[j];
 #endif
@@ -631,18 +620,18 @@ void HFShowerLibrary::storePhoton(int j) {
   else         pe.push_back(photon[j]);
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerLibrary: storePhoton " << j << " npe " 
-		       << npe << " " << pe[npe];
+                       << npe << " " << pe[npe];
 #endif
   npe++;
 }
 
 std::vector<double> HFShowerLibrary::getDDDArray(const std::string & str, 
-						 const DDsvalues_type & sv, 
-						 int & nmin) {
+                                                 const DDsvalues_type & sv, 
+                                                 int & nmin) {
 
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerLibrary:getDDDArray called for " << str 
-		       << " with nMin " << nmin;
+                       << " with nMin " << nmin;
 #endif
   DDValue value(str);
   if (DDfetch(&sv,value)) {
@@ -653,19 +642,19 @@ std::vector<double> HFShowerLibrary::getDDDArray(const std::string & str,
     int nval = fvec.size();
     if (nmin > 0) {
       if (nval < nmin) {
-	edm::LogError("HFShower") << "HFShowerLibrary : # of " << str 
-				  << " bins " << nval << " < " << nmin 
-				  << " ==> illegal";
-	throw cms::Exception("Unknown", "HFShowerLibrary")
-	  << "nval < nmin for array " << str << "\n";
+        edm::LogError("HFShower") << "HFShowerLibrary : # of " << str 
+                                  << " bins " << nval << " < " << nmin 
+                                  << " ==> illegal";
+        throw cms::Exception("Unknown", "HFShowerLibrary")
+          << "nval < nmin for array " << str << "\n";
       }
     } else {
       if (nval < 2) {
-	edm::LogError("HFShower") << "HFShowerLibrary : # of " << str 
-				  << " bins " << nval << " < 2 ==> illegal"
-				  << " (nmin=" << nmin << ")";
-	throw cms::Exception("Unknown", "HFShowerLibrary")
-	  << "nval < 2 for array " << str << "\n";
+        edm::LogError("HFShower") << "HFShowerLibrary : # of " << str 
+                                  << " bins " << nval << " < 2 ==> illegal"
+                                  << " (nmin=" << nmin << ")";
+        throw cms::Exception("Unknown", "HFShowerLibrary")
+          << "nval < 2 for array " << str << "\n";
       }
     }
     nmin = nval;

--- a/SimG4CMS/Calo/src/HFShowerPMT.cc
+++ b/SimG4CMS/Calo/src/HFShowerPMT.cc
@@ -16,11 +16,12 @@
 #include "G4Track.hh"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include <sstream>
 
 //#define DebugLog
 
 HFShowerPMT::HFShowerPMT(const std::string & name, const DDCompactView & cpv,
-			 edm::ParameterSet const & p) : cherenkov(nullptr) {
+                         edm::ParameterSet const & p) : cherenkov(nullptr) {
 
   edm::ParameterSet m_HF  = p.getParameter<edm::ParameterSet>("HFShowerPMT");
   pePerGeV                = m_HF.getParameter<double>("PEPerGeVPMT");
@@ -38,7 +39,7 @@ HFShowerPMT::HFShowerPMT(const std::string & name, const DDCompactView & cpv,
       int index = static_cast<int>(neta[ii]);
       int ir=-1, ifib=-1;
       if (index >= 0) {
-	ir   = index/10; ifib = index%10;
+        ir   = index/10; ifib = index%10;
       }
       pmtR1.push_back(ir);
       pmtFib1.push_back(ifib);
@@ -48,23 +49,26 @@ HFShowerPMT::HFShowerPMT(const std::string & name, const DDCompactView & cpv,
       int index = static_cast<int>(neta[ii]);
       int ir=-1, ifib=-1;
       if (index >= 0) {
-	ir   = index/10; ifib = index%10;
+        ir   = index/10; ifib = index%10;
       }
       pmtR2.push_back(ir);
       pmtFib2.push_back(ifib);
     }
+#ifdef DebugLog
     edm::LogInfo("HFShower") << "HFShowerPMT: gets the Index matches for "
-			     << neta.size() << " PMTs";
-    for (unsigned int ii=0; ii<neta.size(); ii++) 
+                             << neta.size() << " PMTs";
+    for (unsigned int ii=0; ii<neta.size(); ii++) {
       edm::LogInfo("HFShower") << "HFShowerPMT: rIndexR[" << ii << "] = "
-			       << pmtR1[ii] << " fibreR[" << ii << "] = "
-			       << pmtFib1[ii] << " rIndexL[" << ii << "] = "
-			       << pmtR2[ii] << " fibreL[" << ii << "] = "
-			       << pmtFib2[ii];
+                               << pmtR1[ii] << " fibreR[" << ii << "] = "
+                               << pmtFib1[ii] << " rIndexL[" << ii << "] = "
+                               << pmtR2[ii] << " fibreL[" << ii << "] = "
+                               << pmtFib2[ii];
+    }
+#endif
   } else {
     edm::LogWarning("HFShower") << "HFShowerPMT: cannot get filtered "
-				<< " view for " << attribute << " matching "
-				<< value;
+                                << " view for " << attribute << " matching "
+                                << value;
   }
 
   cherenkov = new HFCherenkov(m_HF);
@@ -74,15 +78,17 @@ HFShowerPMT::~HFShowerPMT() {
   if (cherenkov) delete cherenkov;
 }
 
-void HFShowerPMT::initRun(G4ParticleTable *, HcalDDDSimConstants* hcons) {
+void HFShowerPMT::initRun(const HcalDDDSimConstants* hcons) {
 
   // Special Geometry parameters
-  rTable   = hcons->getRTableHF();
-  edm::LogInfo("HFShower") << "HFShowerPMT: " << rTable.size() 
-                           << " rTable (cm)";
-  for (unsigned int ig=0; ig<rTable.size(); ig++)
-    edm::LogInfo("HFShower") << "HFShowerPMT: rTable[" << ig << "] = "
-                             << rTable[ig]/cm << " cm";
+  rTable = hcons->getRTableHF();
+  std::stringstream sss;
+  for (unsigned int ig=0; ig<rTable.size(); ++ig) {
+    if(ig/10*10 == ig) { sss << "\n"; }
+    sss << "  " << rTable[ig]/cm;
+  }
+  edm::LogInfo("HFShowerPMT") << "HFShowerPMT: " << rTable.size() 
+                              << " rTable(cm):" << sss.str();
 }
 
 double HFShowerPMT::getHits(const G4Step * aStep) {
@@ -104,9 +110,9 @@ double HFShowerPMT::getHits(const G4Step * aStep) {
 #ifdef DebugLog
   double edep = aStep->GetTotalEnergyDeposit();
   LogDebug("HFShower") << "HFShowerPMT: Box " << boxNo << " PMT "
-		       << pmtNo << " Mapped Indices " << indexR << ", "
-		       << indexF << " Edeposit " << edep/MeV << " MeV; PE "
-		       << edep*pePerGeV/GeV;
+                       << pmtNo << " Mapped Indices " << indexR << ", "
+                       << indexF << " Edeposit " << edep/MeV << " MeV; PE "
+                       << edep*pePerGeV/GeV;
 #endif
 
   double photons = 0;
@@ -119,12 +125,12 @@ double HFShowerPMT::getHits(const G4Step * aStep) {
     G4ThreeVector localMom = preStepPoint->GetTouchable()->GetHistory()->
       GetTopTransform().TransformAxis(pDir);
     photons = cherenkov->computeNPEinPMT(particleDef, beta, localMom.x(),
-					 localMom.y(), localMom.z(), stepl);
+                                         localMom.y(), localMom.z(), stepl);
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerPMT::getHits: for particle " 
-		       << particleDef->GetParticleName() << " Step " << stepl
-		       << " Beta " << beta << " Direction " << pDir
-		       << " Local " << localMom << " p.e. " << photons;
+                       << particleDef->GetParticleName() << " Step " << stepl
+                       << " Beta " << beta << " Direction " << pDir
+                       << " Local " << localMom << " p.e. " << photons;
 #endif 
 
   }
@@ -139,18 +145,18 @@ double HFShowerPMT::getRadius() {
 #ifdef DebugLog
   else
     LogDebug("HFShower") << "HFShowerPMT::getRadius: R " << indexR
-			 << " F " << indexF;
+                         << " F " << indexF;
 #endif
   if (indexF == 2)  r =-r;
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerPMT: Radius (" << indexR << "/" << indexF 
-		       << ") " << r;
+                       << ") " << r;
 #endif
   return r;
 }
 
 std::vector<double> HFShowerPMT::getDDDArray(const std::string & str, 
-					     const DDsvalues_type & sv) {
+                                             const DDsvalues_type & sv) {
 
 #ifdef DebugLog
   LogDebug("HFShower") << "HFShowerPMT:getDDDArray called for " << str;
@@ -164,9 +170,9 @@ std::vector<double> HFShowerPMT::getDDDArray(const std::string & str,
     int nval = fvec.size();
     if (nval < 2) {
       edm::LogError("HFShower") << "HFShowerPMT: # of " << str 
-				<< " bins " << nval << " < 2 ==> illegal";
+                                << " bins " << nval << " < 2 ==> illegal";
       throw cms::Exception("Unknown", "HFShowerPMT")
-	<< "nval < 2 for array " << str << "\n";
+        << "nval < 2 for array " << str << "\n";
     }
 
     return fvec;

--- a/SimG4CMS/Calo/src/HGCSD.cc
+++ b/SimG4CMS/Calo/src/HGCSD.cc
@@ -170,7 +170,7 @@ uint32_t HGCSD::setDetUnitId(const G4Step * aStep) {
 			     << aStep->GetPreStepPoint()->GetMaterial()->GetRadlen();
 #endif
   // The following statement should be examined later before elimination
-  // VI: this is likely a check if media is vacuum - not needed
+  // VI: this is likely a check if media is vacuum - not needed 
   if (aStep->GetPreStepPoint()->GetMaterial()->GetRadlen() > 100000.) return 0;
   
   uint32_t id = setDetUnitId (subdet, layer, module, cell, iz, localpos);

--- a/SimG4CMS/Calo/src/HGCSD.cc
+++ b/SimG4CMS/Calo/src/HGCSD.cc
@@ -118,11 +118,11 @@ double HGCSD::getEnergyDeposit(const G4Step* aStep) {
   if (r < z*slopeMin_) { return 0.0; }
  
   double wt1    = getResponseWt(aStep->GetTrack());
-  double destep = wt1*aStep->GetTotalEnergyDeposit();
   double wt2    = aStep->GetTrack()->GetWeight();
-  if (wt2 > 0) { destep *= wt2; }
+  double destep = wt1*aStep->GetTotalEnergyDeposit();
+  if (wt2 > 0) destep *= wt2;
   return destep;
-} 
+}
 
 uint32_t HGCSD::setDetUnitId(const G4Step * aStep) { 
 

--- a/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
+++ b/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
@@ -23,12 +23,13 @@ public:
   DreamSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
   ~DreamSD() override {}
-  bool   ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
+  //  bool   ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
   uint32_t setDetUnitId(const G4Step*) override;
 
 protected:
 
-  G4bool getStepInfo(G4Step* aStep) override;
+  // G4bool getStepInfo(G4Step* aStep) override;
+  double getEnergyDeposit(const G4Step* ) override;
   void   initRun() override;
 
 private:    

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -27,8 +27,8 @@
 
 //________________________________________________________________________________________
 DreamSD::DreamSD(const std::string& name, const DDCompactView & cpv,
-		 const SensitiveDetectorCatalog & clg,
-		 edm::ParameterSet const & p, const SimTrackManager* manager) : 
+                 const SensitiveDetectorCatalog & clg,
+                 edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager) {
 
   edm::ParameterSet m_EC = p.getParameter<edm::ParameterSet>("ECalSD");
@@ -43,15 +43,15 @@ DreamSD::DreamSD(const std::string& name, const DDCompactView & cpv,
   chAngleIntegrals_.reset(nullptr);
   
   edm::LogInfo("EcalSim")  << "Constructing a DreamSD  with name " << GetName() << "\n"
-			   << "DreamSD:: Use of Birks law is set to      " 
-			   << useBirk << "  with three constants kB = "
-			   << birk1 << ", C1 = " << birk2 << ", C2 = " 
-			   << birk3 << "\n"
-			   << "          Slope for Light yield is set to "
-			   << slopeLY << "\n"
+                           << "DreamSD:: Use of Birks law is set to      " 
+                           << useBirk << "  with three constants kB = "
+                           << birk1 << ", C1 = " << birk2 << ", C2 = " 
+                           << birk3 << "\n"
+                           << "          Slope for Light yield is set to "
+                           << slopeLY << "\n"
                            << "          Parameterization of Cherenkov is set to " 
                            << doCherenkov_ << " and readout both sides is "
-			   << readBothSide_;
+                           << readBothSide_;
 
   initMap(name,cpv);
 
@@ -76,92 +76,23 @@ DreamSD::DreamSD(const std::string& name, const DDCompactView & cpv,
 }
 
 //________________________________________________________________________________________
-bool DreamSD::ProcessHits(G4Step * aStep, G4TouchableHistory *) {
-
-  if (aStep == nullptr) {
-    return true;
-  } else {
-    side = 1;
-    if (getStepInfo(aStep)) {
-      if (hitExists() == false && edepositEM+edepositHAD>0.)
-        currentHit = createNewHit();
-      if (readBothSide_) {
-	side = -1;
-	getStepInfo(aStep);
-	if (hitExists() == false && edepositEM+edepositHAD>0.)
-	  currentHit = createNewHit();
-      }
-    }
-  }
-  return true;
-}
-
-
-//________________________________________________________________________________________
-bool DreamSD::getStepInfo(G4Step* aStep) {
-
-  preStepPoint = aStep->GetPreStepPoint();
-  theTrack     = aStep->GetTrack();
-  G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
+double DreamSD::getEnergyDeposit(const G4Step* aStep) {
 
   // take into account light collection curve for crystals
-  double weight = 1.;
-  weight *= curve_LY(aStep, side);
+  double weight = curve_LY(aStep, side);
   if (useBirk)   weight *= getAttenuation(aStep, birk1, birk2, birk3);
-  edepositEM  = aStep->GetTotalEnergyDeposit() * weight;
-  LogDebug("EcalSim") << "DreamSD:: " << nameVolume << " Side " << side
-		      <<" Light Collection Efficiency " << weight 
-		      << " Weighted Energy Deposit " << edepositEM/MeV 
-		      << " MeV";
-  // Get cherenkov contribution
-  if ( doCherenkov_ ) {
-    edepositHAD = cherenkovDeposit_( aStep );
-  } else {
-    edepositHAD = 0;
-  }
+  double edep = aStep->GetTotalEnergyDeposit() * weight;
 
-  double       time  = (aStep->GetPostStepPoint()->GetGlobalTime())/nanosecond;
-  unsigned int unitID= setDetUnitId(aStep);
-  if (side < 0) unitID++;
-  TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
-  int      primaryID;
+  // Get Cerenkov contribution
+  if ( doCherenkov_ ) { edep += cherenkovDeposit_( aStep ); }
+  LogDebug("EcalSim") << "DreamSD:: " << aStep->GetPreStepPoint()->GetPhysicalVolume()->GetName() 
+                      << " Side " << side
+                      <<" Light Collection Efficiency " << weight 
+                      << " Weighted Energy Deposit " << edep/MeV 
+                      << " MeV";
 
-  if (trkInfo)
-    primaryID = trkInfo->getIDonCaloSurface();
-  else
-    primaryID = 0;
-
-  if (primaryID == 0) {
-    edm::LogWarning("EcalSim") << "CaloSD: Problem with primaryID **** set by "
-                               << "force to TkID **** "
-                               << theTrack->GetTrackID() << " in Volume "
-                               << preStepPoint->GetTouchable()->GetVolume(0)->GetName();
-    primaryID = theTrack->GetTrackID();
-  }
-
-  bool flag = (unitID > 0);
-  G4TouchableHistory* touch =(G4TouchableHistory*)(theTrack->GetTouchable());
-  if (flag) {
-    currentID.setID(unitID, time, primaryID, 0);
-
-    LogDebug("EcalSim") << "CaloSD:: GetStepInfo for"
-                        << " PV "     << touch->GetVolume(0)->GetName()
-                        << " PVid = " << touch->GetReplicaNumber(0)
-                        << " MVid = " << touch->GetReplicaNumber(1)
-                        << " Unit   " << currentID.unitID()
-                        << " Edeposit = " << edepositEM << " " << edepositHAD;
-  } else {
-    LogDebug("EcalSim") << "CaloSD:: GetStepInfo for"
-                        << " PV "     << touch->GetVolume(0)->GetName()
-                        << " PVid = " << touch->GetReplicaNumber(0)
-                        << " MVid = " << touch->GetReplicaNumber(1)
-                        << " Unit   " << std::hex << unitID << std::dec
-                        << " Edeposit = " << edepositEM << " " << edepositHAD;
-  }
-  return flag;
-
+  return edep;
 }
-
 
 //________________________________________________________________________________________
 void DreamSD::initRun() {
@@ -171,7 +102,7 @@ void DreamSD::initRun() {
   const G4LogicalVolume* lv = (ite->first);
   G4Material* material = lv->GetMaterial();
   edm::LogInfo("EcalSim") << "DreamSD::initRun: Initializes for material " 
-			  << material->GetName() << " in " << lv->GetName();
+                          << material->GetName() << " in " << lv->GetName();
   materialPropertiesTable = material->GetMaterialPropertiesTable();
   if ( !materialPropertiesTable ) {
     if ( !setPbWO2MaterialProperties_( material ) ) {
@@ -187,6 +118,8 @@ void DreamSD::initRun() {
 uint32_t DreamSD::setDetUnitId(const G4Step * aStep) { 
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   uint32_t id = (touch->GetReplicaNumber(1))*10 + (touch->GetReplicaNumber(0));
+  side = readBothSide_ ? -1 : 1;
+  if(side < 0) { ++id; }
   LogDebug("EcalSim") << "DreamSD:: ID " << id;
   return id;
 }
@@ -210,12 +143,12 @@ void DreamSD::initMap(const std::string& sd, const DDCompactView & cpv) {
     G4LogicalVolume* lv=nullptr;
     for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) 
       if ((*lvcite)->GetName() == name) {
-	lv = (*lvcite);
-	break;
+        lv = (*lvcite);
+        break;
       }
     LogDebug("EcalSim") << "DreamSD::initMap (for " << sd << "): Solid " 
-			<< name	<< " Shape " << sol.shape() <<" Parameter 0 = "
-			<< paras[0] << " Logical Volume " << lv;
+                        << name        << " Shape " << sol.shape() <<" Parameter 0 = "
+                        << paras[0] << " Logical Volume " << lv;
     double length = 0, width = 0;
     // Set length to be the largest size, width the smallest
     std::sort( paras.begin(), paras.end() );
@@ -225,14 +158,14 @@ void DreamSD::initMap(const std::string& sd, const DDCompactView & cpv) {
     dodet = fv.next();
   }
   LogDebug("EcalSim") << "DreamSD: Length Table for " << attribute << " = " 
-		      << sd << ":";   
+                      << sd << ":";   
   DimensionMap::const_iterator ite = xtalLMap.begin();
   int i=0;
   for (; ite != xtalLMap.end(); ite++, i++) {
     G4String name = "Unknown";
     if (ite->first != nullptr) name = (ite->first)->GetName();
     LogDebug("EcalSim") << " " << i << " " << ite->first << " " << name 
-			<< " L = " << ite->second.first
+                        << " L = " << ite->second.first
                         << " W = " << ite->second.second;
   }
 }
@@ -240,13 +173,13 @@ void DreamSD::initMap(const std::string& sd, const DDCompactView & cpv) {
 //________________________________________________________________________________________
 double DreamSD::curve_LY(const G4Step* aStep, int flag) {
 
-  const G4StepPoint*     stepPoint = aStep->GetPreStepPoint();
-  G4LogicalVolume* lv        = stepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+  auto const stepPoint = aStep->GetPreStepPoint();
+  auto const lv        = stepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
   G4String         nameVolume= lv->GetName();
 
   double weight = 1.;
   G4ThreeVector  localPoint = setToLocal(stepPoint->GetPosition(),
-					 stepPoint->GetTouchable());
+                                         stepPoint->GetTouchable());
   double crlength = crystalLength(lv);
   double localz   = localPoint.x();
   double dapd = 0.5 * crlength - flag*localz; // Distance from closest APD
@@ -255,16 +188,16 @@ double DreamSD::curve_LY(const G4Step* aStep, int flag) {
       weight = 1.0 + slopeLY - dapd * 0.01 * slopeLY;
   } else {
     edm::LogWarning("EcalSim") << "DreamSD: light coll curve : wrong distance "
-			       << "to APD " << dapd << " crlength = " 
-			       << crlength << " crystal name = " << nameVolume 
-			       << " z of localPoint = " << localz
-			       << " take weight = " << weight;
+                               << "to APD " << dapd << " crlength = " 
+                               << crlength << " crystal name = " << nameVolume 
+                               << " z of localPoint = " << localz
+                               << " take weight = " << weight;
   }
   LogDebug("EcalSim") << "DreamSD, light coll curve : " << dapd 
-		      << " crlength = " << crlength
-		      << " crystal name = " << nameVolume 
-		      << " z of localPoint = " << localz
-		      << " take weight = " << weight;
+                      << " crlength = " << crlength
+                      << " crystal name = " << nameVolume 
+                      << " z of localPoint = " << localz
+                      << " take weight = " << weight;
   return weight;
 }
 
@@ -364,13 +297,13 @@ double DreamSD::cherenkovDeposit_(const G4Step* aStep ) {
 
     // sample a momentum (not sure why this is needed!)
     do {
-      randomNumber = G4UniformRand();	
+      randomNumber = G4UniformRand();        
       sampledMomentum = Pmin + randomNumber * dp; 
       sampledRI = Rindex->Value(sampledMomentum);
       cosTheta = BetaInverse / sampledRI;  
       
       sin2Theta = (1.0 - cosTheta)*(1.0 + cosTheta);
-      randomNumber = G4UniformRand();	
+      randomNumber = G4UniformRand();        
       
     } while (randomNumber*maxSin2 > sin2Theta);
 
@@ -425,9 +358,9 @@ double DreamSD::cherenkovDeposit_(const G4Step* aStep ) {
 // Returns number of photons produced per GEANT-unit (millimeter) in the current medium. 
 // From G4Cerenkov.cc
 double DreamSD::getAverageNumberOfPhotons_( const double charge,
-					    const double beta,
-					    const G4Material* aMaterial,
-					    const G4MaterialPropertyVector* Rindex )
+                                            const double beta,
+                                            const G4Material* aMaterial,
+                                            const G4MaterialPropertyVector* Rindex )
 {
   const G4double rFact = 369.81/(eV * cm);
 
@@ -436,8 +369,8 @@ double DreamSD::getAverageNumberOfPhotons_( const double charge,
   double BetaInverse = 1./beta;
 
   // Vectors used in computation of Cerenkov Angle Integral:
-  // 	- Refraction Indices for the current material
-  //	- new G4PhysicsOrderedFreeVector allocated to hold CAI's
+  //         - Refraction Indices for the current material
+  //        - new G4PhysicsOrderedFreeVector allocated to hold CAI's
  
   // Min and Max photon momenta 
   int Rlength = Rindex->GetVectorLength() - 1; 
@@ -445,7 +378,7 @@ double DreamSD::getAverageNumberOfPhotons_( const double charge,
   double Pmax = Rindex->Energy(Rlength);
 
   // Min and Max Refraction Indices 
-  double nMin = (*Rindex)[0];	
+  double nMin = (*Rindex)[0];        
   double nMax = (*Rindex)[Rlength];
 
   // Max Cerenkov Angle Integral 
@@ -458,7 +391,7 @@ double DreamSD::getAverageNumberOfPhotons_( const double charge,
 
   // otherwise if n(Pmin) >= 1/Beta -- photons generated  
   else if (nMin > BetaInverse) {
-    dp = Pmax - Pmin;	
+    dp = Pmax - Pmin;        
     ge = CAImax; 
   } 
   // If n(Pmin) < 1/Beta, and n(Pmax) >= 1/Beta, then
@@ -559,8 +492,8 @@ bool DreamSD::setPbWO2MaterialProperties_( G4Material* aMaterial ) {
 // - configurable reflection probability if not straight to APD;
 // - APD response function
 double DreamSD::getPhotonEnergyDeposit_( const G4ThreeVector& p, 
-					 const G4ThreeVector& x,
-					 const G4Step* aStep )
+                                         const G4ThreeVector& x,
+                                         const G4Step* aStep )
 {
 
   double energy = 0;

--- a/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
+++ b/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
@@ -12,7 +12,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "G4String.hh"
+//#include "G4String.hh"
 #include <map>
 
 class EcalBaseNumber;
@@ -24,9 +24,11 @@ public:
   EcalTBH4BeamSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 		 edm::ParameterSet const &, const SimTrackManager*);
   ~EcalTBH4BeamSD() override;
-  double getEnergyDeposit(G4Step*) override;
   uint32_t setDetUnitId(const G4Step* step) override;
   void setNumberingScheme(EcalNumberingScheme* scheme);
+
+ protected:
+  double getEnergyDeposit(const G4Step*) override;
 
 private:    
 

--- a/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
+++ b/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
@@ -50,23 +50,17 @@ EcalTBH4BeamSD::~EcalTBH4BeamSD() {
   if (numberingScheme) delete numberingScheme;
 }
 
-double EcalTBH4BeamSD::getEnergyDeposit(G4Step * aStep) {
+double EcalTBH4BeamSD::getEnergyDeposit(const G4Step * aStep) {
   
-  if (aStep == nullptr) {
-    return 0;
-  } else {
-    preStepPoint        = aStep->GetPreStepPoint();
-    G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
-
-    // take into account light collection curve for crystals
-    double weight = 1.;
-    if (useBirk)   weight *= getAttenuation(aStep, birk1, birk2, birk3);
-    double edep   = aStep->GetTotalEnergyDeposit() * weight;
-    LogDebug("EcalTBSim") << "EcalTBH4BeamSD:: " << nameVolume
+  // take into account light collection curve for crystals
+  double weight = 1.;
+  if (useBirk)   weight *= getAttenuation(aStep, birk1, birk2, birk3);
+  double edep   = aStep->GetTotalEnergyDeposit() * weight;
+  LogDebug("EcalTBSim") << "EcalTBH4BeamSD:: " 
+			<< aStep->GetPreStepPoint()->GetPhysicalVolume()->GetName()
 			<<" Light Collection Efficiency " << weight 
 			<< " Weighted Energy Deposit " << edep/MeV << " MeV";
-    return edep;
-  } 
+  return edep;
 }
 
 uint32_t EcalTBH4BeamSD::setDetUnitId(const G4Step * aStep) { 

--- a/SimG4CMS/Forward/interface/CastorSD.h
+++ b/SimG4CMS/Forward/interface/CastorSD.h
@@ -32,17 +32,20 @@ class CastorSD : public CaloSD {
 public:    
 
   CastorSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog & clg,
-	   edm::ParameterSet const &, const SimTrackManager*);
+           edm::ParameterSet const &, const SimTrackManager*);
   ~CastorSD() override;
-  double   getEnergyDeposit(G4Step* ) override;
   uint32_t setDetUnitId(const G4Step* step) override;
   void     setNumberingScheme(CastorNumberingScheme* scheme);
 
+protected:
+
+  double   getEnergyDeposit(const G4Step*) override;
+  bool     getFromLibrary(const G4Step*) override;
+  void     initRun() override;
+
 private:
 
-  void                    getFromLibrary(G4Step*);
-  int                     setTrackID(G4Step*);
-  uint32_t                rotateUnitID(uint32_t, G4Track*, const CastorShowerEvent&);
+  uint32_t                rotateUnitID(uint32_t, const G4Track*, const CastorShowerEvent&);
   CastorNumberingScheme * numberingScheme;
   CastorShowerLibrary *   showerLibrary;
   G4LogicalVolume         *lvC3EF, *lvC3HF, *lvC4EF, *lvC4HF;
@@ -50,12 +53,7 @@ private:
   
   bool                    useShowerLibrary;
   double                  energyThresholdSL; 
-  double		  non_compensation_factor;
-
-protected:
-
-  void            initRun() override;
-
+  double                  non_compensation_factor;
 };
 
 #endif // CastorSD_h

--- a/SimG4CMS/Forward/interface/CastorShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/CastorShowerLibrary.h
@@ -40,7 +40,7 @@ public:
 public:
 
   void                initParticleTable(G4ParticleTable *);
-  CastorShowerEvent   getShowerHits(G4Step*, bool&);
+  CastorShowerEvent   getShowerHits(const G4Step*, bool&);
   int                 FindEnergyBin(double);
   int                 FindEtaBin(double);
   int                 FindPhiBin(double);
@@ -70,6 +70,10 @@ private:
   
   std::vector<double> pmom;
 
+  int                 emPDG, epPDG, gammaPDG;
+  int                 pi0PDG, etaPDG, nuePDG, numuPDG, nutauPDG;
+  int                 anuePDG, anumuPDG, anutauPDG, geantinoPDG;
+  int                 mumPDG, mupPDG;
 // new variables (bins in eta and phi)
   unsigned int        nBinsE, nBinsEta, nBinsPhi;
   unsigned int        nEvtPerBinE, nEvtPerBinEta, nEvtPerBinPhi;

--- a/SimG4CMS/Forward/interface/ZdcSD.h
+++ b/SimG4CMS/Forward/interface/ZdcSD.h
@@ -9,34 +9,34 @@
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 #include "SimG4CMS/Forward/interface/ZdcShowerLibrary.h"
 #include "SimG4CMS/Forward/interface/ZdcNumberingScheme.h"
-#undef debug
 
 class ZdcSD : public CaloSD {
 
 public:    
   ZdcSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
-	edm::ParameterSet const &,const SimTrackManager*);
+        edm::ParameterSet const &,const SimTrackManager*);
  
-  ~ZdcSD() override;
-  bool ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
+  ~ZdcSD() override = default;
+
   uint32_t setDetUnitId(const G4Step* step) override;
-  double getEnergyDeposit(const G4Step*, edm::ParameterSet const &);
  
   void setNumberingScheme(ZdcNumberingScheme* scheme);
-  void getFromLibrary(G4Step * step);
  
 protected:
-  void initRun() override;
+
+  double getEnergyDeposit(const G4Step*) override;
+  bool   getFromLibrary(const G4Step*) override;
+  void   initRun() override;
+
 private:    
 
   int verbosity;
   bool  useShowerLibrary,useShowerHits; 
-  int   setTrackID(G4Step * step);
   double thFibDir;
   double zdcHitEnergyCut;
-  ZdcShowerLibrary *    showerLibrary;
-  ZdcNumberingScheme * numberingScheme;
 
+  std::unique_ptr<ZdcShowerLibrary>   showerLibrary;
+  std::unique_ptr<ZdcNumberingScheme> numberingScheme;
   std::vector<ZdcShowerLibrary::Hit> hits;
 
 };

--- a/SimG4CMS/Forward/interface/ZdcShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/ZdcShowerLibrary.h
@@ -43,7 +43,7 @@ public:
 
 
   void                        initRun(G4ParticleTable * theParticleTable);
-  std::vector<Hit>&           getHits(G4Step * aStep, bool & ok);
+  std::vector<Hit>&           getHits(const G4Step * aStep, bool & ok);
   int                         getEnergyFromLibrary(const G4ThreeVector& posHit, const G4ThreeVector& momDir, double energy,
                                                    G4int parCode,HcalZDCDetId::Section section, bool side, int channel);
   int                         photonFluctuation(double eav, double esig,double edis);

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -29,9 +29,9 @@
 //#define debugLog
 
 CastorSD::CastorSD(const std::string& name, const DDCompactView & cpv,
-		   const SensitiveDetectorCatalog & clg,
-		   edm::ParameterSet const & p, 
-		   const SimTrackManager* manager) : 
+                   const SensitiveDetectorCatalog & clg,
+                   edm::ParameterSet const & p, 
+                   const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager), numberingScheme(nullptr), lvC3EF(nullptr),
   lvC3HF(nullptr), lvC4EF(nullptr), lvC4HF(nullptr), lvCAST(nullptr) {
   
@@ -39,44 +39,42 @@ CastorSD::CastorSD(const std::string& name, const DDCompactView & cpv,
   useShowerLibrary  = m_CastorSD.getParameter<bool>("useShowerLibrary");
   energyThresholdSL = m_CastorSD.getParameter<double>("minEnergyInGeVforUsingSLibrary");
   energyThresholdSL = energyThresholdSL*GeV;   //  Convert GeV => MeV 
-	  
+          
   non_compensation_factor = m_CastorSD.getParameter<double>("nonCompensationFactor");
   
-  if (useShowerLibrary) showerLibrary = new CastorShowerLibrary(name, p);
-  
+  if (useShowerLibrary) {
+    showerLibrary = new CastorShowerLibrary(name, p);
+    setParameterized(true);
+  }
   setNumberingScheme(new CastorNumberingScheme());
   
   edm::LogInfo("ForwardSim") 
-    << "***************************************************\n"
-    << "*                                                 *\n" 
+    << "********************************************************\n"
     << "* Constructing a CastorSD  with name " << GetName() << "\n"
-    << "*                                                 *\n"
-    << "***************************************************";
+    << "* Using Castor Shower Library: " << useShowerLibrary << "\n"
+    << "********************************************************";
     
   const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
-  std::vector<G4LogicalVolume*>::const_iterator lvcite;
-  for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) {
-    if (strcmp(((*lvcite)->GetName()).c_str(),"C3EF") == 0) lvC3EF = (*lvcite);
-    if (strcmp(((*lvcite)->GetName()).c_str(),"C3HF") == 0) lvC3HF = (*lvcite);
-    if (strcmp(((*lvcite)->GetName()).c_str(),"C4EF") == 0) lvC4EF = (*lvcite);
-    if (strcmp(((*lvcite)->GetName()).c_str(),"C4HF") == 0) lvC4HF = (*lvcite);
-    if (strcmp(((*lvcite)->GetName()).c_str(),"CAST") == 0) lvCAST = (*lvcite);
-    if (lvC3EF != nullptr && lvC3HF != nullptr && lvC4EF != nullptr && lvC4HF != nullptr && lvCAST != nullptr) break;
+  for (auto lv : *lvs) {
+    if (strcmp((lv->GetName()).c_str(),"C3EF") == 0) { lvC3EF = lv; }
+    if (strcmp((lv->GetName()).c_str(),"C3HF") == 0) { lvC3HF = lv; }
+    if (strcmp((lv->GetName()).c_str(),"C4EF") == 0) { lvC4EF = lv; }
+    if (strcmp((lv->GetName()).c_str(),"C4HF") == 0) { lvC4HF = lv; }
+    if (strcmp((lv->GetName()).c_str(),"CAST") == 0) { lvCAST = lv; }
+    if (lvC3EF != nullptr && lvC3HF != nullptr && lvC4EF != nullptr && 
+        lvC4HF != nullptr && lvCAST != nullptr) { break; }
   }
   edm::LogInfo("ForwardSim") << "CastorSD:: LogicalVolume pointers\n"
-			     << lvC3EF << " for C3EF; " << lvC3HF 
-			     << " for C3HF; " << lvC4EF << " for C4EF; " 
-			     << lvC4HF << " for C4HF; " 
-			     << lvCAST << " for CAST. " << std::endl;
-
-  //  if(useShowerLibrary) edm::LogInfo("ForwardSim") << "\n Using Castor Shower Library \n";
-
+                             << lvC3EF << " for C3EF; " << lvC3HF 
+                             << " for C3HF; " << lvC4EF << " for C4EF; " 
+                             << lvC4HF << " for C4HF; " 
+                             << lvCAST << " for CAST. ";
 }
 
 //=============================================================================================
 
 CastorSD::~CastorSD() {
-  if (useShowerLibrary) delete showerLibrary;
+  delete showerLibrary;
 }
 
 //=============================================================================================
@@ -85,139 +83,55 @@ void CastorSD::initRun(){
   if (useShowerLibrary) {
     G4ParticleTable * theParticleTable = G4ParticleTable::GetParticleTable();
     showerLibrary->initParticleTable(theParticleTable);
-    edm::LogInfo("ForwardSim") << "CastorSD::initRun: Using Castor Shower Library \n";
   }
 }
 
 //=============================================================================================
 
-double CastorSD::getEnergyDeposit(G4Step * aStep) {
+double CastorSD::getEnergyDeposit(const G4Step * aStep) {
   
   double NCherPhot = 0.;
 
   // Get theTrack 
-  G4Track* theTrack = aStep->GetTrack();
+  auto const theTrack = aStep->GetTrack();
 
   // preStepPoint information *********************************************
-  
-  G4StepPoint*       preStepPoint = aStep->GetPreStepPoint();
-  G4VPhysicalVolume* currentPV    = preStepPoint->GetPhysicalVolume();
-  G4LogicalVolume*   currentLV    = currentPV->GetLogicalVolume();
+  auto const preStepPoint = aStep->GetPreStepPoint();
+  auto const currentPV    = preStepPoint->GetPhysicalVolume();
+  auto const currentLV    = currentPV->GetLogicalVolume();
 
 #ifdef debugLog
-  G4String           name   = currentPV->GetName();
-  std::string        nameVolume;
-  nameVolume.assign(name,0,4);
-
-  G4SteppingControl  stepControlFlag = aStep->GetControlFlag();
-  if (aStep->IsFirstStepInVolume()) 
-    LogDebug("ForwardSim") << "CastorSD::getEnergyDeposit:"
-			   << "\n IsFirstStepInVolume " ; 
+  edm::LogInfo("ForwardSim") << "CastorSD::getEnergyDeposit:"
+                             << "\n CurrentStepNumber , TrackID , ParentID, Particle , VertexPosition ,"
+                             << " LogicalVolumeAtVertex , PV, Time"
+                             << "\n  TRACKINFO: " 
+                             << theTrack->GetCurrentStepNumber() 
+                             << " , " 
+                             << theTrack->GetTrackID() 
+                             << " , " 
+                             << theTrack->GetParentID() 
+                             << " , "
+                             << theTrack->GetDefinition()->GetParticleName() 
+                             << " , "
+                             << theTrack->GetVertexPosition() 
+                             << " , "
+                             << theTrack->GetLogicalVolumeAtVertex()->GetName() 
+                             << " , "
+                             << currentPV->GetName()
+                             << " , " 
+                             << theTrack->GetGlobalTime();
 #endif
 
-    
-    
-#ifdef debugLog
-  if (useShowerLibrary && currentLV==lvCAST) {
-    LogDebug("ForwardSim") << "CastorSD::getEnergyDeposit:"
-			   << "\n TrackID , ParentID , ParticleName ,"
-			   << " eta , phi , z , time ,"
-			   << " K , E , Mom " 
-			   << "\n  TRACKINFO: " 
-			   << theTrack->GetTrackID() 
-			   << " , " 
-			   << theTrack->GetParentID() 
-			   << " , "
-			   << theTrack->GetDefinition()->GetParticleName() 
-			   << " , "
-			   << theTrack->GetPosition().eta() 
-			   << " , "
-			   << theTrack->GetPosition().phi() 
-			   << " , "
-			   << theTrack->GetPosition().z() 
-			   << " , "
-			   << theTrack->GetGlobalTime() 
-			   << " , "
-			   << theTrack->GetKineticEnergy() 
-			   << " , "
-			   << theTrack->GetTotalEnergy() 
-			   << " , "
-			   << theTrack->GetMomentum().mag() ;
-    if(theTrack->GetTrackID() != 1) 
-      LogDebug("ForwardSim") << "CastorSD::getEnergyDeposit:"
-			     << "\n CurrentStepNumber , TrackID , Particle , VertexPosition ,"
-			     << " LogicalVolumeAtVertex , CreatorProcess"
-			     << "\n  TRACKINFO2: " 
-			     << theTrack->GetCurrentStepNumber() 
-			     << " , " 
-			     << theTrack->GetTrackID() 
-			     << " , "
-			     << theTrack->GetDefinition()->GetParticleName() 
-			     << " , "
-			     << theTrack->GetVertexPosition() 
-			     << " , "
-			     << theTrack->GetLogicalVolumeAtVertex()->GetName() 
-			     << " , " 
-			     << theTrack->GetCreatorProcess()->GetProcessName() ;
-  } // end of if(useShowerLibrary)
-#endif
-  
   // if particle moves from interaction point or "backwards (halo)
-  bool backward = false;
-  const G4ThreeVector&  hitPoint = preStepPoint->GetPosition();	
   const G4ThreeVector&  hit_mom  = preStepPoint->GetMomentumDirection();
+  const G4ThreeVector&  hitPoint = preStepPoint->GetPosition();        
   double zint = hitPoint.z();
-  double pz   = hit_mom.z();
   
-  // Check if theTrack moves backward 
-  if (pz * zint < 0.) backward = true;
-  
-  // Check that theTrack is above the energy threshold to use Shower Library 
-  bool aboveThreshold = false;
-  if(theTrack->GetKineticEnergy() > energyThresholdSL) aboveThreshold = true;
-    
   // Check if theTrack is a muon (if so, DO NOT use Shower Library) 
   G4int parCode = theTrack->GetDefinition()->GetPDGEncoding();
-  bool isEM = G4TrackToParticleID::isGammaElectronPositron(parCode);
   bool isHad = G4TrackToParticleID::isStableHadronIon(theTrack);
-  
-  // angle condition
-  double theta_max = M_PI - 3.1305; // angle in radians corresponding to -5.2 eta
-  double R_mom=sqrt(hit_mom.x()*hit_mom.x() + hit_mom.y()*hit_mom.y());
-  double theta = atan2(R_mom,std::abs(pz));
-  bool angleok = false;
-  if ( theta < theta_max) angleok = true;
-  
-  // OkToUse
-  double R = sqrt(hitPoint.x()*hitPoint.x() + hitPoint.y()*hitPoint.y());
-  bool dot = false;
-  if ( zint < -14450. && R < 45.) dot = true;
-  bool inRange = true;
-  if ( zint < -14700. || R > 193.) inRange = false;
-  bool OkToUse = false;
-  if ( inRange && !dot) OkToUse = true;
-  
-  bool particleWithinShowerLibrary = aboveThreshold && (isEM || isHad)
-    && (!backward) && OkToUse && angleok && currentLV == lvCAST;
-  
-  if (useShowerLibrary && particleWithinShowerLibrary) {
-    // Use Castor shower library if energy is above threshold, is not a muon 
-    // and is not moving backward 
-    getFromLibrary(aStep);
-    
-#ifdef debugLog
-    LogDebug("ForwardSim") << " Current logical volume is " << nameVolume ;
-#endif
-    
-    // track is killed in getFromLibrary...
 
-    return 0.0;
-  }
-  
-
-  // Full - Simulation starts here
-
-  double meanNCherPhot = 0.0;
+  double meanNCherPhot=0;
   G4double charge = preStepPoint->GetCharge();
   // VI: no Cerenkov light from neutrals
   if(0.0 == charge) { return meanNCherPhot; }
@@ -233,43 +147,11 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   if (!trkInfo.hasCastorHit()) {
     trkInfo.setCastorHitPID(parCode);
   }
-  
-  G4double           stepl    = aStep->GetStepLength()/cm;
-  
-#ifdef debugLog
-  // postStepPoint information *********************************************
-  G4StepPoint* postStepPoint= aStep->GetPostStepPoint();   
-  G4VPhysicalVolume* postPV= postStepPoint->GetPhysicalVolume();
-  
-  G4String           postname   = postPV->GetName();
-  std::string        postnameVolume;
-  postnameVolume.assign(postname,0,4);
-  
-  G4ThreeVector   vert_mom = theTrack->GetVertexMomentumDirection();
-  
-  G4ThreeVector  localPoint = theTrack->GetTouchable()->GetHistory()->
-    GetTopTransform().TransformPoint(hitPoint);
-  
-  G4String       particleType = theTrack->GetDefinition()->GetParticleName();
-  
-  // calculations...       *************************************************
-  double phi = -100.;
-  if (vert_mom.x() != 0) phi = atan2(vert_mom.y(),vert_mom.x()); 
-  if (phi < 0.) phi += twopi;
-  
-  
-  double costheta =vert_mom.z()/sqrt(vert_mom.x()*vert_mom.x()+
-				     vert_mom.y()*vert_mom.y()+
-				     vert_mom.z()*vert_mom.z());
-  double theta = acos(std::min(std::max(costheta,double(-1.)),double(1.)));
-  double eta = -log(tan(theta/2));
-  G4int          primaryID    = theTrack->GetTrackID();
-  double edep   = aStep->GetTotalEnergyDeposit();
-#endif
-  
-  // *************************************************
-  
-  
+  G4double stepl = aStep->GetStepLength()/cm;
+
+  //int castorHitPID = trkInfo.hasCastorHit() ? std::abs(trkInfo.getCastorHitPID())
+  //  : std::abs(parCode);
+
   // *************************************************
   // take into account light collection curve for plate
   //      double weight = curve_Castor(nameVolume, preStepPoint);
@@ -279,21 +161,28 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   
   // *************************************************
   /*    comments for sensitive volumes:      
-	C001 ...-... CP06,CBU1 ...-...CALM --- > fibres and bundle 
-	for first release of CASTOR
-	CASF  --- > quartz plate  for first and second releases of CASTOR  
-	GF2Q, GFNQ, GR2Q, GRNQ 
-	for tests with my own test geometry of HF (on ask of Gavrilov)
-	C3TF, C4TF - for third release of CASTOR
+        C001 ...-... CP06,CBU1 ...-...CALM --- > fibres and bundle 
+        for first release of CASTOR
+        CASF  --- > quartz plate  for first and second releases of CASTOR  
+        GF2Q, GFNQ, GR2Q, GRNQ 
+        for tests with my own test geometry of HF (on ask of Gavrilov)
+        C3TF, C4TF - for third release of CASTOR
   */  
+#ifdef debugLog
+  edm::LogInfo("ForwardSim") << "CastorSD::getEnergyDeposit: for ID=" 
+                             << theTrack->GetTrackID() << " LV: " << currentLV->GetName() 
+                             << " isHad:" << isHad << " pdg=" << parCode 
+                             << " castorPID=" << trkInfo.getCastorHitPID()
+                             << " sl= " << stepl << " Edep= " << aStep->GetTotalEnergyDeposit(); 
+#endif
   if (currentLV == lvC3EF || currentLV == lvC4EF || currentLV == lvC3HF ||
       currentLV == lvC4HF) {
     
-    double nMedium = 1.4925;
+    const double nMedium = 1.4925;
     //     double photEnSpectrDL = (1./400.nm-1./700.nm)*10000000.cm/nm; /* cm-1  */
     //     double photEnSpectrDL = 10714.285714;
     
-    double photEnSpectrDE = 1.24;    /* see below   */
+    const double photEnSpectrDE = 1.24;    /* see below   */
     /*     E = 2pi*(1./137.)*(eV*cm/370.)/lambda  =     */
     /*       = 12.389184*(eV*cm)/lambda                 */
     /*     Emax = 12.389184*(eV*cm)/400nm*10-7cm/nm  = 3.01 eV     */
@@ -302,28 +191,28 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
     /*   */
     /* default for Castor nameVolume  == "CASF" or (C3TF & C4TF)  */
     
-    double thFullRefl = 23.;  /* 23.dergee */
-    double thFullReflRad = thFullRefl*pi/180.;
+    const double thFullRefl = 23.;  /* 23.dergee */
+    const double thFullReflRad = thFullRefl*pi/180.;
     
     /* default for Castor nameVolume  == "CASF" or (C3TF & C4TF)  */
-    double thFibDir = 45.;  /* .dergee */
+    const double thFibDir = 45.;  /* .dergee */
     /* for test HF geometry volumes:   
        if(nameVolume == "GF2Q" || nameVolume == "GFNQ" ||
        nameVolume == "GR2Q" || nameVolume == "GRNQ")
        thFibDir = 0.0; // .dergee
     */
-    double thFibDirRad = thFibDir*pi/180.;
+    const double thFibDirRad = thFibDir*pi/180.;
     
     // theta of charged particle in LabRF(hit momentum direction):
     double costh =hit_mom.z()/sqrt(hit_mom.x()*hit_mom.x()+
-				   hit_mom.y()*hit_mom.y()+
-				   hit_mom.z()*hit_mom.z());
+                                   hit_mom.y()*hit_mom.y()+
+                                   hit_mom.z()*hit_mom.z());
     if (zint < 0) costh = -costh;
     double th = acos(std::min(std::max(costh,double(-1.)),double(1.)));
     
     // just in case (can do bot use):
     if (th < 0.) th += twopi;
-        
+    
     // theta of cone with Cherenkov photons w.r.t.direction of charged part.:
     double costhcher =1./(nMedium*beta);
     double thcher = acos(std::min(std::max(costhcher,double(-1.)),double(1.)));
@@ -335,134 +224,69 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
     double d = std::abs(tan(th)-tan(thFibDirRad));   
     
     double a = tan(thFibDirRad)+tan(std::abs(thFibDirRad-thFullReflRad));   
-    double r = tan(th)+tan(fabs(th-thcher));   
+    double r = tan(th)+tan(std::abs(th-thcher));       
     
     // define losses d_qz in cone of full reflection inside quartz direction
     double d_qz;
 #ifdef debugLog
-    double variant;
+    int variant(0);
 #endif
     if(DelFibPart > (thFullReflRad + thcher) ) {
       d_qz = 0.; 
-#ifdef debugLog
-      variant=0.;
-#endif
     }
-    // if(d > (r+a) ) {d_qz = 0.; variant=0.;}
     else {
       if((th + thcher) < (thFibDirRad+thFullReflRad) && 
-	 (th - thcher) > (thFibDirRad-thFullReflRad)) {
-	d_qz = 1.; 
+         (th - thcher) > (thFibDirRad-thFullReflRad)) {
+        d_qz = 1.; 
 #ifdef debugLog
-	variant=1.;
+        variant=1;
 #endif
       }
-      // if((DelFibPart + thcher) < thFullReflRad ) {d_qz = 1.; variant=1.;}
-      // if((d+r) < a ) {d_qz = 1.; variant=1.;}
       else {
-	if((thFibDirRad + thFullReflRad) < (th + thcher) && 
-	   (thFibDirRad - thFullReflRad) > (th - thcher) ) {
-	  // if((thcher - DelFibPart ) > thFullReflRad ) 
-	  // if((r-d ) > a ) 
-	  d_qz = 0.; 
+        if((thFibDirRad + thFullReflRad) < (th + thcher) && 
+           (thFibDirRad - thFullReflRad) > (th - thcher) ) {
+          d_qz = 0.; 
 #ifdef debugLog
-	  variant=2.;
+          variant=2;
 #endif
-	} else {
-	  // if((thcher + DelFibPart ) > thFullReflRad && 
-	  //    thcher < (DelFibPart+thFullReflRad) ) 
-	  //      {
+        } else {
 #ifdef debugLog
-	  variant=3.;
-#endif
-	  
-	  // use crossed length of circles(cone projection)
-	  // dC1/dC2 : 
-	  double arg_arcos = 0.;
-	  double tan_arcos = 2.*a*d;
-	  if(tan_arcos != 0.) arg_arcos =(r*r-a*a-d*d)/tan_arcos; 
-	  arg_arcos = std::abs(arg_arcos);
-	  double th_arcos = acos(std::min(std::max(arg_arcos,double(-1.)),double(1.)));
-	  d_qz = std::abs(th_arcos/pi/2.);	  
-	}
+          variant=3;
+#endif          
+          // use crossed length of circles(cone projection)
+          // dC1/dC2 : 
+          double arg_arcos = 0.;
+          double tan_arcos = 2.*a*d;
+          if(tan_arcos != 0.) arg_arcos =(r*r-a*a-d*d)/tan_arcos; 
+          arg_arcos = std::abs(arg_arcos);
+          double th_arcos = acos(std::min(std::max(arg_arcos,-1.),1.));
+          d_qz = std::abs(th_arcos/CLHEP::twopi);
+        }
       }
     }
+        
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     
-      meanNCherPhot = 370.*charge*charge*
-	( 1. - 1./(nMedium*nMedium*beta*beta) )*
-	photEnSpectrDE*stepl;
+    meanNCherPhot = 370.*charge*charge*
+      ( 1. - 1./(nMedium*nMedium*beta*beta) )*photEnSpectrDE*stepl;
       
-      const double scale = (isHad ? non_compensation_factor : 1.0);
-      G4int poissNCherPhot = (G4int) G4Poisson(meanNCherPhot * scale);
+    double scale = isHad ? non_compensation_factor : 1.0;
+
+    int poissNCherPhot = std::max(0, (int)G4Poisson(meanNCherPhot * scale));
       
-      if(poissNCherPhot < 0) poissNCherPhot = 0;
-      
-      double effPMTandTransport = 0.19;
-      double ReflPower = 0.1;
-      double proba = d_qz + (1-d_qz)*ReflPower;
-      NCherPhot = poissNCherPhot*effPMTandTransport*proba*0.307;
-      
-      
+    const double effPMTandTransport = 0.19;
+    const double ReflPower = 0.1;
+    double proba = d_qz + (1-d_qz)*ReflPower;
+    NCherPhot = poissNCherPhot*effPMTandTransport*proba*0.307;
 #ifdef debugLog
-      double thgrad = th*180./pi;
-      double thchergrad = thcher*180./pi;
-      double DelFibPartgrad = DelFibPart*180./pi;
-      LogDebug("ForwardSim") << " ==============================> start all "
-			     << "information:<========= \n" << " =====> for "
-			     << "test:<===  \n" << " variant = " << variant  
-			     << "\n thgrad = " << thgrad  << "\n thchergrad "
-			     << "= " << thchergrad  << "\n DelFibPartgrad = "
-			     << DelFibPartgrad << "\n d_qz = " << d_qz  
-			     << "\n =====> Start Step Information <===  \n"
-			     << " ===> calo preStepPoint info <===  \n" 
-			     << " hitPoint = " << hitPoint  << "\n"
-			     << " hitMom = " << hit_mom  << "\n"
-			     << " stepControlFlag = " << stepControlFlag 
-	// << "\n curprocess = " << curprocess << "\n"
-	// << " nameProcess = " << nameProcess 
-			     << "\n charge = " << charge << "\n"
-			     << " beta = " << beta << "\n"
-			     << " bThreshold = " << bThreshold << "\n"
-			     << " thgrad =" << thgrad << "\n"
-			     << " effPMTandTransport=" << effPMTandTransport 
-	// << "\n volume = " << name 
-			     << "\n nameVolume = " << nameVolume << "\n"
-			     << " nMedium = " << nMedium << "\n"
-	//  << " rad length = " << rad << "\n"
-	//  << " material = " << mat << "\n"
-			     << " stepl = " << stepl << "\n"
-			     << " photEnSpectrDE = " << photEnSpectrDE <<"\n"
-			     << " edep = " << edep << "\n"
-			     << " ===> calo theTrack info <=== " << "\n"
-			     << " particleType = " << particleType << "\n"
-			     << " primaryID = " << primaryID << "\n"
-			     << " entot= " << theTrack->GetTotalEnergy() << "\n"
-			     << " vert_eta= " << eta  << "\n"
-			     << " vert_phi= " << phi << "\n"
-			     << " vert_mom= " << vert_mom  << "\n"
-			     << " ===> calo hit preStepPointinfo <=== "<<"\n"
-			     << " local point = " << localPoint << "\n"
-			     << " ==============================> final info"
-			     << ":  <=== \n" 
-			     << " meanNCherPhot = " << meanNCherPhot << "\n"
-			     << " poissNCherPhot = " << poissNCherPhot <<"\n"
-			     << " NCherPhot = " << NCherPhot;
-#endif 
-      
-  }
-    
-  
-#ifdef debugLog
-  LogDebug("ForwardSim") << "CastorSD:: " << nameVolume 
-    //      << " Light Collection Efficiency " << weight
-			 << " Weighted Energy Deposit " << edep/MeV 
-			 << " MeV\n";
+      edm::LogInfo("ForwardSim") << " Nph= " << NCherPhot << " Np= " << poissNCherPhot
+                                 << " eff= " << effPMTandTransport << " pb= " << proba
+                                 << " Nmean= " << meanNCherPhot
+                                 << " q=" << charge << " beta=" << beta 
+                                 << " nMedium= " << nMedium << " sl= " << stepl
+                                 << " Nde=" << photEnSpectrDE;
 #endif
-  // Temporary member for testing purpose only...
-  // unit_id = setDetUnitId(aStep);
-  // if(NCherPhot != 0) std::cout << "\n  UnitID = " << unit_id << "  ;  NCherPhot = " << NCherPhot ;
-  
+  }
   return NCherPhot;
 }
 
@@ -478,39 +302,15 @@ void CastorSD::setNumberingScheme(CastorNumberingScheme* scheme) {
 
   if (scheme != nullptr) {
     edm::LogInfo("ForwardSim") << "CastorSD: updates numbering scheme for " 
-			       << GetName();
-    if (numberingScheme) delete numberingScheme;
+                               << GetName();
+    delete numberingScheme;
     numberingScheme = scheme;
   }
 }
 
 //=======================================================================================
 
-int CastorSD::setTrackID (G4Step* aStep) {
-
-  theTrack     = aStep->GetTrack();
-
-  TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
-  int      primaryID = trkInfo->getIDonCaloSurface();
-  if (primaryID == 0) {
-#ifdef debugLog
-    edm::LogWarning("ForwardSim") << "CastorSD: Problem with primaryID **** set by force "
-				  << "to TkID **** " << theTrack->GetTrackID();
-#endif
-    primaryID = theTrack->GetTrackID();
-  }
-
-  if (primaryID != previousID.trackID()) {
-    double etrack = preStepPoint->GetKineticEnergy();
-    resetForNewPrimary(preStepPoint->GetPosition(), etrack);
-  }
-
-  return primaryID;
-}
-
-//=======================================================================================
-
-uint32_t CastorSD::rotateUnitID(uint32_t unitID, G4Track* track, const CastorShowerEvent& shower) {
+uint32_t CastorSD::rotateUnitID(uint32_t unitID, const G4Track* track, const CastorShowerEvent& shower) {
 // ==============================================================
 //
 //   o   Exploit Castor phi symmetry to return newUnitID for  
@@ -534,17 +334,11 @@ uint32_t CastorSD::rotateUnitID(uint32_t unitID, G4Track* track, const CastorSho
   uint32_t         sec = ( ( unitID>>4 ) & 0xF ) ;
   uint32_t  complement = ( unitID & 0xFFFFFF0F ) ;
   
-  // edm::LogInfo("ForwardSim") << "\n CastorSD::rotateUnitID:  " 
-  //                            << "\n      unitID = " << unitID 
-  //                            << "\n         sec = " << sec 
-  //                            << "\n  complement = " << complement ; 
-  
   // Get 'track' z:
   double   trackZ = track->GetPosition().z();
   
   int aux ;
   int dSec = 2*(trackOctSector - showerOctSector) ;
-  // if(trackZ<0)  // Good for revision 1.8 of CastorNumberingScheme
   if(trackZ>0)  // Good for revision 1.9 of CastorNumberingScheme
   {
     int sec1 = sec-dSec;
@@ -564,8 +358,8 @@ uint32_t CastorSD::rotateUnitID(uint32_t unitID, G4Track* track, const CastorSho
 #ifdef debugLog
   if(newUnitID != unitID) {
     LogDebug("ForwardSim") << "\n CastorSD::rotateUnitID:  " 
-			   << "\n     unitID = " << unitID 
-			   << "\n  newUnitID = " << newUnitID ; 
+                           << "\n     unitID = " << unitID 
+                           << "\n  newUnitID = " << newUnitID ; 
   }
 #endif
   
@@ -575,81 +369,155 @@ uint32_t CastorSD::rotateUnitID(uint32_t unitID, G4Track* track, const CastorSho
 
 //=======================================================================================
 
-void CastorSD::getFromLibrary (G4Step* aStep) {
+bool CastorSD::getFromLibrary(const G4Step* aStep) {
 
 /////////////////////////////////////////////////////////////////////
 //
 //   Method to get hits from the Shower Library
-//
-//   CastorShowerEvent hits returned by getShowerHits are used to  
-//   replace the full simulation of the shower from theTrack
 //    
 //   "updateHit" save the Hits to a CaloG4Hit container
 //
 /////////////////////////////////////////////////////////////////////
 
-  preStepPoint  = aStep->GetPreStepPoint(); 
-  theTrack      = aStep->GetTrack();   
-  bool ok;
-  
-  // ****    Call method to retrieve hits from the ShowerLibrary   ****
-  CastorShowerEvent hits = showerLibrary->getShowerHits(aStep, ok);
+  auto const theTrack = aStep->GetTrack();
+  auto parCode = theTrack->GetDefinition()->GetPDGEncoding();
 
-  double etrack    = preStepPoint->GetKineticEnergy();
-  int    primaryID = setTrackID(aStep);
-  // int    primaryID = theTrack->GetTrackID();
-
-  // Reset entry point for new primary
-  posGlobal = preStepPoint->GetPosition();
-  resetForNewPrimary(posGlobal, etrack);
-
-  // Check whether track is EM or HAD
-  bool isEM , isHAD ;
-  if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
-    isEM = true ; isHAD = false;
-  } else {
-    isEM = false; isHAD = true ;
+  // remember primary particle hitting the CASTOR detector    
+  TrackInformationExtractor TIextractor;
+  TrackInformation& trkInfo = TIextractor(theTrack);
+  if (!trkInfo.hasCastorHit()) {
+    trkInfo.setCastorHitPID(parCode);
   }
 
+  if (!useShowerLibrary) { return false; }
+
+  // preStepPoint information *********************************************
+  
+  auto const preStepPoint = aStep->GetPreStepPoint();
+  auto const currentPV    = preStepPoint->GetPhysicalVolume();
+  auto const currentLV    = currentPV->GetLogicalVolume();
+
 #ifdef debugLog
-  //  edm::LogInfo("ForwardSim") << "\n CastorSD::getFromLibrary:  " 
-  LogDebug("ForwardSim") << "\n CastorSD::getFromLibrary:  " 
-			 << hits.getNhit() << " hits for " << GetName() << " from " 
-			 << theTrack->GetDefinition()->GetParticleName() << " of "
-			 << preStepPoint->GetKineticEnergy()/GeV << " GeV and trackID " 
-			 << theTrack->GetTrackID()  ;
+    edm::LogInfo("ForwardSim") << "CastorSD::getFromLibrary: for ID=" << theTrack->GetTrackID() 
+                               << " parentID= " << theTrack->GetParentID() << " " 
+                               << theTrack->GetDefinition()->GetParticleName() 
+                               << " LV: " << currentLV->GetName() << " PV: " << currentPV->GetName()
+                               << "\n eta= " << theTrack->GetPosition().eta() 
+                               << " phi= " << theTrack->GetPosition().phi()
+                               << " z(cm)= " << theTrack->GetPosition().z()/cm 
+                               << " time(ns)= " << theTrack->GetGlobalTime() 
+                               << " E(GeV)= " << theTrack->GetTotalEnergy()/GeV;
+  
+#endif
+  
+  const G4ThreeVector&  hitPoint = preStepPoint->GetPosition();        
+  const G4ThreeVector&  hit_mom  = preStepPoint->GetMomentumDirection();
+  double zint = hitPoint.z();
+  double pz   = hit_mom.z();
+  
+  // Check if theTrack moves backward 
+  bool backward = (pz * zint < 0.) ? true : false;
+  
+  // Check that theTrack is above the energy threshold to use Shower Library 
+  bool aboveThreshold = (theTrack->GetKineticEnergy() > energyThresholdSL) 
+    ? true : false;
+    
+  // Check if theTrack is a muon (if so, DO NOT use Shower Library) 
+  bool isEM = G4TrackToParticleID::isGammaElectronPositron(parCode);
+  bool isHad = G4TrackToParticleID::isStableHadronIon(theTrack);
+  
+  // angle condition
+  double theta_max = M_PI - 3.1305; // angle in radians corresponding to -5.2 eta
+  double R_mom=sqrt(hit_mom.x()*hit_mom.x() + hit_mom.y()*hit_mom.y());
+  double theta = atan2(R_mom,std::abs(pz));
+  bool angleok = (theta < theta_max) ? true : false;
+  
+  // OkToUse
+  double R = sqrt(hitPoint.x()*hitPoint.x() + hitPoint.y()*hitPoint.y());
+  bool dot = (zint < -14450. && R < 45.) ? true : false;
+  bool inRange = (zint < -14700. || R > 193.) ? false : true;
+  //bool OkToUse = (inRange && !dot) ? true : false;
+  
+  bool particleWithinShowerLibrary = aboveThreshold && (isEM || isHad)
+    && (!backward) && inRange && !dot && angleok && currentLV == lvCAST;
+
+#ifdef debugLog
+  edm::LogInfo("ForwardSim") << "CastorSD::getFromLibrary: ID= " << theTrack->GetTrackID()
+                             << " E>E0 " << aboveThreshold
+                             << " isEM " << isEM << " isHad " << isHad 
+			     << " backword " << backward
+                             << " Ok " << (inRange && !dot) << " angle " << angleok << " LV: " 
+                             << currentLV->GetName() << "  " << (currentLV == lvCAST) 
+                             << " " << particleWithinShowerLibrary 
+                             << " Edep= " << aStep->GetTotalEnergyDeposit();
+#endif
+
+  // Use Castor shower library if energy is above threshold, is not a muon 
+  // and is not moving backward 
+  if (!particleWithinShowerLibrary) {
+    //---VI: This code is for backward compatibility and should be removed 
+
+    if (currentLV == lvC3EF || currentLV == lvC4EF || currentLV == lvC3HF ||
+        currentLV == lvC4HF) {
+      G4double edep     = aStep->GetTotalEnergyDeposit();
+      G4double beta     = preStepPoint->GetBeta();
+      G4double charge   = preStepPoint->GetCharge();
+      double bThreshold = 0.67;
+      if(edep == 0.0 && charge != 0.0 && beta > bThreshold) { 
+        G4Poisson(0.0); 
+      }
+    }
+    //---
+    return false;
+  }
+  
+  // ****    Call method to retrieve hits from the ShowerLibrary   ****
+  // always kill primary
+  bool isKilled(true);
+  CastorShowerEvent hits = showerLibrary->getShowerHits(aStep, isKilled);
+  
+  //---VI:
+  //if(!isKilled) { return false; }
+  
+  int primaryID = setTrackID(aStep);
+
+  // Reset entry point for new primary
+  resetForNewPrimary(aStep);
+
+#ifdef debugLog
+  edm::LogInfo("ForwardSim") 
+    << "CastorSD::getFromLibrary:  " 
+    << hits.getNhit() << " hits for " << GetName() << " from " 
+    << theTrack->GetDefinition()->GetParticleName() << " of "
+    << preStepPoint->GetKineticEnergy()/GeV << " GeV and trackID " 
+    << theTrack->GetTrackID() << " isHad: " << isHad;
 #endif
 
   // Scale to correct energy
   double E_track = preStepPoint->GetTotalEnergy() ;
-  double E_SLhit = hits.getPrimE() * GeV ;
+  double E_SLhit = hits.getPrimE() * CLHEP::GeV ;
   double scale = E_track/E_SLhit ;
-	
+
   //Non compensation 
-  if (isHAD){
+  if (isHad){
     scale *= non_compensation_factor; // if hadronic extend the scale with the non-compensation factor
   }
-	
   //  Loop over hits retrieved from the library
-  for (unsigned int i=0; i<hits.getNhit(); i++) {
+  for (unsigned int i=0; i<hits.getNhit(); ++i) {
     
     // Get nPhotoElectrons and set edepositEM / edepositHAD accordingly
-    double nPhotoElectrons    = hits.getNphotons(i);
-    // Apply scaling
-      nPhotoElectrons *= scale ;
+    double nPhotoElectrons = hits.getNphotons(i)*scale;
+
     if(isEM)  {
-       // edepositEM  = nPhotoElectrons*GeV; 
        edepositEM  = nPhotoElectrons; 
        edepositHAD = 0.;                 
-    } else if(isHAD) {
+    } else {
        edepositEM  = 0.;                  
        edepositHAD = nPhotoElectrons;
-       // edepositHAD = nPhotoElectrons*GeV;
     }
     
     // Get hit position and time
     double                time = hits.getTime(i);
-    //    math::XYZPoint    position = hits.getHitPosition(i);
     
     // Get hit detID
     unsigned int        unitID = hits.getDetID(i);
@@ -659,41 +527,8 @@ void CastorSD::getFromLibrary (G4Step* aStep) {
     // the 'hits' retrieved from shower library   
     unsigned int rotatedUnitID = rotateUnitID(unitID , theTrack , hits);
     currentID.setID(rotatedUnitID, time, primaryID, 0);
-    // currentID.setID(unitID, time, primaryID, 0);
-   
-    // check if it is in the same unit and timeslice as the previous one
-    if (currentID == previousID) {
-      updateHit(currentHit);
-    } else {
-      if (!checkHit()) currentHit = createNewHit();
-    }
+    processHit(aStep);
   }  //  End of loop over hits
-
-  //Now kill the current track
-  if (ok) {
-    theTrack->SetTrackStatus(fStopAndKill);
-#ifdef debugLog
-    LogDebug("ForwardSim") << "CastorSD::getFromLibrary:"
-			   << "\n \"theTrack\" with TrackID() = " 
-			   << theTrack->GetTrackID() 
-			   << " and with energy " 
-			   << theTrack->GetTotalEnergy()
-			   << " has been set to be killed" ;
-#endif
-    G4TrackVector tv = *(aStep->GetSecondary());
-    for (unsigned int kk=0; kk<tv.size(); kk++) {
-      if (tv[kk]->GetVolume() == preStepPoint->GetPhysicalVolume()) {
-	tv[kk]->SetTrackStatus(fStopAndKill);
-#ifdef debugLog
-	LogDebug("ForwardSim") << "CastorSD::getFromLibrary:"
-			       << "\n tv[" << kk << "]->GetTrackID() = " 
-			       << tv[kk]->GetTrackID() 
-			       << " with energy " 
-			       << tv[kk]->GetTotalEnergy()
-			       << " has been set to be killed" ;
-#endif
-      }
-    }
-  }
+  return isKilled;
 }
 

--- a/SimG4CMS/Forward/src/CastorShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/CastorShowerLibrary.cc
@@ -8,16 +8,16 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "SimG4CMS/Forward/interface/CastorShowerLibrary.h"
-#include "FWCore/Utilities/interface/Exception.h"
 #include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #include "G4VPhysicalVolume.hh"
 #include "G4Step.hh"
 #include "G4Track.hh"
 #include "G4ParticleTable.hh"
 #include "Randomize.hh"
-#include "G4PhysicalConstants.hh"
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include "CLHEP/Units/PhysicalConstants.h"
+#include "CLHEP/Units/SystemOfUnits.h"
 
 //#define DebugLog
 
@@ -123,9 +123,6 @@ void CastorShowerLibrary::loadEventInfo(TBranchObject* branch) {
   // Initialize shower library general parameters
 
   totEvents   = eventInfo->Energy.getNEvts();
-//  nMomBin     = eventInfo->Energy.getNBins();
-//  evtPerBin   = eventInfo->Energy.getNEvtPerBin();
-//  pmom        = eventInfo->Energy.getBin();
   nBinsE        = eventInfo->Energy.getNBins();
   nEvtPerBinE   = eventInfo->Energy.getNEvtPerBin();
   SLenergies    = eventInfo->Energy.getBin();
@@ -137,7 +134,7 @@ void CastorShowerLibrary::loadEventInfo(TBranchObject* branch) {
   SLphis        = eventInfo->Phi.getBin();
   
   // Convert from GeV to MeV
-  for (unsigned int i=0; i<SLenergies.size(); i++) SLenergies[i] *= GeV;
+  for (unsigned int i=0; i<SLenergies.size(); i++) { SLenergies[i] *= CLHEP::GeV; }
   
   edm::LogInfo("CastorShower") << " CastorShowerLibrary::loadEventInfo : " 
 			       << "\n \n Total number of events     :  " << totEvents 
@@ -150,7 +147,7 @@ void CastorShowerLibrary::loadEventInfo(TBranchObject* branch) {
   
   for (unsigned int i=0; i<nBinsE; i++)
      edm::LogInfo("CastorShower") << "CastorShowerLibrary: SLenergies[" << i << "] = "
-			          << SLenergies[i]/GeV << " GeV";
+			          << SLenergies[i]/CLHEP::GeV << " GeV";
   for (unsigned int i=0; i<nBinsEta; i++)
      edm::LogInfo("CastorShower") << "CastorShowerLibrary: SLetas[" << i << "] = "
 			          << SLetas[i];
@@ -161,19 +158,17 @@ void CastorShowerLibrary::loadEventInfo(TBranchObject* branch) {
 
 //=============================================================================================
 
-void CastorShowerLibrary::initParticleTable(G4ParticleTable *) {
+void CastorShowerLibrary::initParticleTable(G4ParticleTable * theParticleTable) {
 }
-
 
 //=============================================================================================
 
-CastorShowerEvent CastorShowerLibrary::getShowerHits(G4Step * aStep, bool & ok) {
+CastorShowerEvent CastorShowerLibrary::getShowerHits(const G4Step * aStep, bool & ok) {
 
   G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
   G4Track *     track         = aStep->GetTrack();
 
   const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
-  G4String      partType = track->GetDefinition()->GetParticleName();
 
   CastorShowerEvent hit;
   hit.Clear();
@@ -190,7 +185,7 @@ CastorShowerEvent CastorShowerLibrary::getShowerHits(G4Step * aStep, bool & ok) 
   double R=sqrt(hitPoint.x()*hitPoint.x() + hitPoint.y()*hitPoint.y());
   double theta = atan2(R,std::abs(zint));
   double phiin = atan2(hitPoint.y(),hitPoint.x());
-  double etain = -std::log(std::tan((pi-theta)*0.5));
+  double etain = -std::log(std::tan((CLHEP::pi-theta)*0.5));
 
   // Replace "interpolation/extrapolation" by new method "select" that just randomly 
   // selects a record from the appropriate energy bin and fills its content to  
@@ -198,23 +193,12 @@ CastorShowerEvent CastorShowerLibrary::getShowerHits(G4Step * aStep, bool & ok) 
   
   if (isEM) {
     select(0, pin, etain, phiin);
-    // if (pin<SLenergies[nBinsE-1]) {
-    //   interpolate(0, pin);
-    // } else {
-    //   extrapolate(0, pin);
-    // }
   } else {
     select(1, pin, etain, phiin);
-    // if (pin<SLenergies[nBinsE-1]) {
-    //   interpolate(1, pin);
-    // } else {
-    //   extrapolate(1, pin);
-    // }
   }
     
   hit = (*showerEvent);
   return hit;
-
 }
 
 //=============================================================================================
@@ -277,39 +261,6 @@ void CastorShowerLibrary::select(int type, double pin, double etain, double phii
   // Randomly select a record from the right energy bin in the library, 
   // based on track momentum (pin) 
    
-  //   pin < SLenergies[MIN]
-/*
-  if (pin<SLenergies[0]) {
-     edm::LogWarning("CastorShower") << "CastorShowerLibrary: Warning, pin = " << pin 
-                                     << " less than minimum SLenergies " << SLenergies[0] << " in library." 
-                                     << " For the moment, selecting hit from the first bin" ;
-     irec = int(nEvtPerBinE*r) + 1;
-  //   pin > SLenergies[MAX]
-  } else if (pin>SLenergies[nBinsE]) {
-
-// This part needs rethinking because the last element of SLenergies is no longer the upper limit of the bins
-    edm::LogWarning("CastorShower") << "CastorShowerLibrary: Warning, pin = " << pin 
-                                    << " greater than maximum SLenergies " << SLenergies[nBinsE] << " in library." 
-                                    << " For the moment, selecting hit from the last bin";
-    irec = (nBinsE-1)*nEvtPerBinE + int(evtPerBin*r) + 1;
-  //   SLenergies[MIN] < pin < SLenergies[MAX]
-  } else {
-     for (unsigned int j=0; j<nBinsE; j++) {
-        if (pin >= SLenergies[j] && pin < SLenergies[j+1]) {
-	   irec = j*evtPerBin + int(evtPerBin*r) + 1 ;
-	   if (irec<0) {
-	      edm::LogWarning("CastorShower") << "CastorShowerLibrary:: Illegal irec = "
-				              << irec << " now set to 0";
-	      irec = 0;
-	   } else if (irec > totEvents) {
-	      edm::LogWarning("CastorShower") << "CastorShowerLibrary:: Illegal irec = "
-				              << irec << " now set to "<< totEvents;
-	      irec = totEvents;
-	   }
-        }
-     }
-  }
-*/
   int ienergy = FindEnergyBin(pin);
   int ieta    = FindEtaBin(etain);
 #ifdef DebugLog
@@ -318,13 +269,13 @@ void CastorShowerLibrary::select(int type, double pin, double etain, double phii
 #endif
 
   int iphi;
-  double phiMin = 0. ;
-  double phiMax = M_PI/4 ;     // 45 * (pi/180)  rad 
+  const double phiMin = 0.;
+  const double phiMax = M_PI/4.;     // 45 * (pi/180)  rad 
   if(phiin < phiMin) phiin = phiin + M_PI ;
   if(phiin >= phiMin && phiin < phiMax) {
      iphi = FindPhiBin(phiin) ;
   } else {
-     double remainder = fmod(phiin , M_PI/4) ;
+     double remainder = fmod(phiin, phiMax) ;
      phiin = phiMin + remainder ;
      iphi = FindPhiBin(phiin) ;
   }

--- a/SimG4CMS/Forward/src/ZdcSD.cc
+++ b/SimG4CMS/Forward/src/ZdcSD.cc
@@ -21,19 +21,18 @@
 #include "G4Poisson.hh"
 
 ZdcSD::ZdcSD(const std::string& name, const DDCompactView & cpv,
-	     const SensitiveDetectorCatalog & clg,
-	     edm::ParameterSet const & p,const SimTrackManager* manager) : 
-  CaloSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
+             const SensitiveDetectorCatalog & clg,
+             edm::ParameterSet const & p,const SimTrackManager* manager) : 
+  CaloSD(name, cpv, clg, p, manager){
   edm::ParameterSet m_ZdcSD = p.getParameter<edm::ParameterSet>("ZdcSD");
   useShowerLibrary = m_ZdcSD.getParameter<bool>("UseShowerLibrary");
   useShowerHits    = m_ZdcSD.getParameter<bool>("UseShowerHits");
   zdcHitEnergyCut  = m_ZdcSD.getParameter<double>("ZdcHitEnergyCut")*GeV;
+  thFibDir   = m_ZdcSD.getParameter<double>("FiberDirection");
   verbosity  = m_ZdcSD.getParameter<int>("Verbosity");
   int verbn  = verbosity/10;
   verbosity %= 10;
-  ZdcNumberingScheme* scheme;
-  scheme = new ZdcNumberingScheme(verbn);
-  setNumberingScheme(scheme);
+  setNumberingScheme(new ZdcNumberingScheme(verbn));
   
   edm::LogInfo("ForwardSim")
     << "***************************************************\n"
@@ -46,7 +45,7 @@ ZdcSD::ZdcSD(const std::string& name, const DDCompactView & cpv,
      << "\nUse of shower library is set to " 
      << useShowerLibrary 
      << "\nUse of Shower hits method is set to "
-     << useShowerHits; 			
+     << useShowerHits;                         
  
   edm::LogInfo("ForwardSim")
      << "\nEnergy Threshold Cut set to " 
@@ -54,87 +53,51 @@ ZdcSD::ZdcSD(const std::string& name, const DDCompactView & cpv,
      <<" (GeV)";
   
   if(useShowerLibrary){
-    showerLibrary = new ZdcShowerLibrary(name, cpv, p);
+    showerLibrary.reset(new ZdcShowerLibrary(name, cpv, p));
+    setParameterized(true);
+  } else {
+    showerLibrary.reset(nullptr);
   }
-}
-
-ZdcSD::~ZdcSD() {
-  
-  if(numberingScheme) delete numberingScheme;
-  if(showerLibrary)delete showerLibrary;
-
-  edm::LogInfo("ForwardSim") 
-    <<"end of ZdcSD\n";
 }
 
 void ZdcSD::initRun(){
   if(useShowerLibrary){
     G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
-    showerLibrary->initRun(theParticleTable); 
+    showerLibrary.get()->initRun(theParticleTable); 
   }
   hits.clear();  
 }
 
-bool ZdcSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
-
-  NaNTrap( aStep ) ;
-
-  if (aStep == nullptr) {
-    return true;
-  } else {
-    if(useShowerLibrary){
-      getFromLibrary(aStep);
-    }
-    if(useShowerHits){
-      if (getStepInfo(aStep)) {
-	if (hitExists() == false && edepositEM+edepositHAD>0.)
-	  currentHit = CaloSD::createNewHit();
-      }
-    }
-  }
-  return true;
-}
-
-void ZdcSD::getFromLibrary (G4Step* aStep) {
+bool ZdcSD::getFromLibrary (const G4Step* aStep) {
   bool ok = true;
 
-  preStepPoint  = aStep->GetPreStepPoint(); 
-  theTrack      = aStep->GetTrack();   
+  auto const preStepPoint  = aStep->GetPreStepPoint(); 
+  auto const theTrack = aStep->GetTrack();   
 
-  double etrack    = preStepPoint->GetKineticEnergy();
+  double etrack = preStepPoint->GetKineticEnergy();
   int primaryID = setTrackID(aStep);  
 
   hits.clear();
-
-  /*
-    if (etrack >= zdcHitEnergyCut) {
-    primaryID    = theTrack->GetTrackID();
-    } else {
-    primaryID    = theTrack->GetParentID();
-    if (primaryID == 0) primaryID = theTrack->GetTrackID();
-    }
-  */
     
   // Reset entry point for new primary
-  posGlobal = preStepPoint->GetPosition();
-  resetForNewPrimary(posGlobal, etrack);
+  resetForNewPrimary(aStep);
 
   if (etrack >= zdcHitEnergyCut){
     // create hits only if above threshold
 
     LogDebug("ForwardSim")
-      //std::cout
       <<"----------------New track------------------------------\n"
       <<"Incident EnergyTrack: "<<etrack<< " MeV \n"
       <<"Zdc Cut Energy for Hits: "<<zdcHitEnergyCut<<" MeV \n"
       << "ZdcSD::getFromLibrary " <<hits.size() <<" hits for "
       << GetName() << " of " << primaryID << " with " 
       << theTrack->GetDefinition()->GetParticleName() << " of " 
-      << preStepPoint->GetKineticEnergy()<< " MeV\n"; 
+      << etrack<< " MeV\n"; 
     
-    hits.swap(showerLibrary->getHits(aStep, ok));    
+    hits.swap(showerLibrary.get()->getHits(aStep, ok));    
   }
  
+  incidentEnergy= etrack;
   entrancePoint = preStepPoint->GetPosition();
   for (unsigned int i=0; i<hits.size(); i++) {
     posGlobal           = hits[i].position;
@@ -143,68 +106,35 @@ void ZdcSD::getFromLibrary (G4Step* aStep) {
     unsigned int unitID = hits[i].detID;
     edepositHAD         = hits[i].DeHad;
     edepositEM          = hits[i].DeEM;
-    currentID.setID(unitID, time, primaryID);
-      
-    // check if it is in the same unit and timeslice as the previous on    
-    if (currentID == previousID) {
-      updateHit(currentHit);	
-    } else {
-      currentHit = createNewHit();
-    }
-      
-    //  currentHit->setPosition(hitPoint.x(),hitPoint.y(),hitPoint.z());
-    //  currentHit->setEM(eEM);
-    //   currentHit->setHadr(eHAD);
-    currentHit->setIncidentEnergy(etrack);
-    //  currentHit->setEntryLocal(hitEntry.x(),hitEntry.y(),hitEntry.z());
+    currentID.setID(unitID, time, primaryID, 0);
+    processHit(aStep);
       
     LogDebug("ForwardSim") << "ZdcSD: Final Hit number:"<<i<<"-->"
-			   <<"New HitID: "<<currentHit->getUnitID()
-			   <<" New Hit trackID: "<<currentHit->getTrackID()
-			   <<" New EM Energy: "<<currentHit->getEM()/GeV
-			   <<" New HAD Energy: "<<currentHit->getHadr()/GeV
-			   <<" New HitEntryPoint: "<<currentHit->getEntryLocal()
-			   <<" New IncidentEnergy: "<<currentHit->getIncidentEnergy()/GeV
-			   <<" New HitPosition: "<<posGlobal;
+                           <<"New HitID: "<<currentHit->getUnitID()
+                           <<" New Hit trackID: "<<currentHit->getTrackID()
+                           <<" New EM Energy: "<<currentHit->getEM()/GeV
+                           <<" New HAD Energy: "<<currentHit->getHadr()/GeV
+                           <<" New HitEntryPoint: "<<currentHit->getEntryLocal()
+                           <<" New IncidentEnergy: "<<currentHit->getIncidentEnergy()/GeV
+                           <<" New HitPosition: "<<posGlobal;
   }
-  
-  //Now kill the current track
-  if (ok) {
-    theTrack->SetTrackStatus(fStopAndKill);
-    G4TrackVector tv = *(aStep->GetSecondary());
-    for (unsigned int kk=0; kk<tv.size(); kk++) {
-      if (tv[kk]->GetVolume() == preStepPoint->GetPhysicalVolume())
-	tv[kk]->SetTrackStatus(fStopAndKill);
-    }
-  }
+  return ok;
 }
 
-double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p ) {
+double ZdcSD::getEnergyDeposit(const G4Step * aStep) {
 
-  float NCherPhot = 0.;
-  //std::cout<<"I go through here"<<std::endl;
+    double NCherPhot = 0.;
 
-  if (aStep == nullptr) {
-    LogDebug("ForwardSim") << "ZdcSD::  getEnergyDeposit: aStep is NULL!";
-    return 0;
-  } else {
     // preStepPoint information
-    G4SteppingControl  stepControlFlag = aStep->GetControlFlag();
     G4StepPoint*       preStepPoint = aStep->GetPreStepPoint();
     G4VPhysicalVolume* currentPV    = preStepPoint->GetPhysicalVolume();
     const G4String&           nameVolume   = currentPV->GetName();
 
-    const G4ThreeVector&      hitPoint = preStepPoint->GetPosition();	
+    const G4ThreeVector&      hitPoint = preStepPoint->GetPosition();        
     const G4ThreeVector&      hit_mom = preStepPoint->GetMomentumDirection();
     G4double           stepL = aStep->GetStepLength()/cm;
     G4double           beta     = preStepPoint->GetBeta();
     G4double           charge   = preStepPoint->GetCharge();
-
-    // G4VProcess*        curprocess   = preStepPoint->GetProcessDefinedStep();
-    // G4String           namePr   = preStepPoint->GetProcessDefinedStep()->GetProcessName();
-    // G4LogicalVolume*   lv    = currentPV->GetLogicalVolume();
-    // G4Material*        mat   = lv->GetMaterial();
-    // G4double           rad   = mat->GetRadlen();
 
     // postStepPoint information
     G4StepPoint* postStepPoint = aStep->GetPostStepPoint();   
@@ -214,15 +144,13 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p
     // theTrack information
     G4Track* theTrack = aStep->GetTrack();   
     G4String particleType = theTrack->GetDefinition()->GetParticleName();
-    G4int primaryID = theTrack->GetTrackID();
-    G4double entot = theTrack->GetTotalEnergy();
     const G4ThreeVector& vert_mom = theTrack->GetVertexMomentumDirection();
     G4ThreeVector localPoint = theTrack->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPoint);
 
     // calculations
     float costheta = vert_mom.z()/sqrt(vert_mom.x()*vert_mom.x()+
-				       vert_mom.y()*vert_mom.y()+
-				       vert_mom.z()*vert_mom.z());
+                                       vert_mom.y()*vert_mom.y()+
+                                       vert_mom.z()*vert_mom.z());
     float theta = acos(std::min(std::max(costheta,float(-1.)),float(1.)));
     float eta = -log(tan(theta/2));
     float phi = -100.;
@@ -237,8 +165,8 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p
       << "  preStepPoint: " << nameVolume << "," << stepL << "," << stepE 
       << "," << beta << "," << charge << "\n"
       << "  postStepPoint: " << postnameVolume << "," << costheta << "," 
-      << theta << "," << eta << "," << phi << "," << particleType << "," 
-      << primaryID;
+      << theta << "," << eta << "," << phi << "," << particleType << " id= " 
+      << theTrack->GetTrackID() << " Etot(GeV)= " << theTrack->GetTotalEnergy()/GeV;
 
     float bThreshold = 0.67;
     if ((beta > bThreshold) && (charge != 0) && (nameVolume == "ZDC_EMFiber" || nameVolume == "ZDC_HadFiber")) {
@@ -260,9 +188,6 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p
       float thFullRefl = 23.;
       float thFullReflRad = thFullRefl*pi/180.;
 
-      edm::ParameterSet m_ZdcSD = p.getParameter<edm::ParameterSet>("ZdcSD");
-      thFibDir  = m_ZdcSD.getParameter<double>("FiberDirection");
-      //float thFibDir = 90.;
       float thFibDirRad = thFibDir*pi/180.;
 
       // at which theta the point is located:
@@ -270,8 +195,8 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p
 
       // theta of charged particle in LabRF(hit momentum direction):
       float costh = hit_mom.z()/sqrt(hit_mom.x()*hit_mom.x()+
-				     hit_mom.y()*hit_mom.y()+
-				     hit_mom.z()*hit_mom.z());
+                                     hit_mom.y()*hit_mom.y()+
+                                     hit_mom.z()*hit_mom.z());
       float th = acos(std::min(std::max(costh,float(-1.)),float(1.)));
       // just in case (can do both standard ranges of phi):
       if (th < 0.) th += twopi;
@@ -292,7 +217,7 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p
       float r = tan(th)+tan(fabs(th-thcher));   
       
       // std::cout.testOut << "  d=|tan(" << th << ")-tan(" << thFibDirRad << ")| "
-      //	      << "=|" << tan(th) << "-" << tan(thFibDirRad) << "| = " << d;
+      //              << "=|" << tan(th) << "-" << tan(thFibDirRad) << "| = " << d;
       // std::cout.testOut << "  a=tan(" << thFibDirRad << ")=" << tan(thFibDirRad) 
       //              << " + tan(|" << thFibDirRad << " - " << thFullReflRad << "|)="
       //              << tan(fabs(thFibDirRad-thFullReflRad)) << " = " << a;
@@ -308,75 +233,69 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p
         variant = 0.; d_qz = 0.;
       } else {
         // if ((DelFibPart + thcher) < thFullReflRad )  [(d+r) < a]
-	if ((th + thcher) < (thFibDirRad+thFullReflRad) && (th - thcher) > (thFibDirRad-thFullReflRad) ) {
-	  variant = 1.; d_qz = 1.;
-	} else {
+        if ((th + thcher) < (thFibDirRad+thFullReflRad) && (th - thcher) > (thFibDirRad-thFullReflRad) ) {
+          variant = 1.; d_qz = 1.;
+        } else {
           // if ((thcher - DelFibPart ) > thFullReflRad )  [(r-d) > a]
-	  if ((thFibDirRad + thFullReflRad) < (th + thcher) && (thFibDirRad - thFullReflRad) > (th - thcher) ) {
+          if ((thFibDirRad + thFullReflRad) < (th + thcher) && (thFibDirRad - thFullReflRad) > (th - thcher) ) {
             variant = 2.; d_qz = 0.;
-	  } else {
-            // if ((thcher + DelFibPart ) > thFullReflRad && thcher < (DelFibPart+thFullReflRad) ) {  [(r+d) > a && (r-d) < a)]
+          } else {
             variant = 3.; // d_qz is calculated below
 
             // use crossed length of circles(cone projection) - dC1/dC2 : 
-	    float arg_arcos = 0.;
-	    float tan_arcos = 2.*a*d;
-	    if (tan_arcos != 0.) arg_arcos =(r*r-a*a-d*d)/tan_arcos; 
+            float arg_arcos = 0.;
+            float tan_arcos = 2.*a*d;
+            if (tan_arcos != 0.) arg_arcos =(r*r-a*a-d*d)/tan_arcos; 
             // std::cout.testOut << "  d_qz: " << r << "," << a << "," << d << " " << tan_arcos << " " << arg_arcos;
-	    arg_arcos = fabs(arg_arcos);
+            arg_arcos = fabs(arg_arcos);
             // std::cout.testOut << "," << arg_arcos;
-	    float th_arcos = acos(std::min(std::max(arg_arcos,float(-1.)),float(1.)));
+            float th_arcos = acos(std::min(std::max(arg_arcos,float(-1.)),float(1.)));
             // std::cout.testOut << " " << th_arcos;
-	    d_qz = th_arcos/pi/2.;
+            d_qz = th_arcos/pi/2.;
             // std::cout.testOut << " " << d_qz;
-	    d_qz = fabs(d_qz);
+            d_qz = fabs(d_qz);
             // std::cout.testOut << "," << d_qz;
-	  }
-	}
+          }
+        }
       }
-
-      //  std::cout<< std::endl;
-
       double meanNCherPhot = 0.;
       G4int poissNCherPhot = 0;
       if (d_qz > 0) {
-	meanNCherPhot = 370.*charge*charge*( 1. - 1./(nMedium*nMedium*beta*beta) ) * photEnSpectrDE * stepL;
+        meanNCherPhot = 370.*charge*charge*( 1. - 1./(nMedium*nMedium*beta*beta) ) * photEnSpectrDE * stepL;
 
-	// dLamdX:  meanNCherPhot = (2.*pi/137.)*charge*charge* 
-	//                          ( 1. - 1./(nMedium*nMedium*beta*beta) ) * photEnSpectrDL * stepL;
-	poissNCherPhot = (G4int) G4Poisson(meanNCherPhot);
+        // dLamdX:  meanNCherPhot = (2.*pi/137.)*charge*charge* 
+        //                          ( 1. - 1./(nMedium*nMedium*beta*beta) ) * photEnSpectrDL * stepL;
+        poissNCherPhot = (G4int) G4Poisson(meanNCherPhot);
 
-	if (poissNCherPhot < 0) poissNCherPhot = 0; 
+        if (poissNCherPhot < 0) poissNCherPhot = 0; 
 
-	// NCherPhot = meanNCherPhot;
-	NCherPhot = poissNCherPhot * effPMTandTransport * d_qz;
+        // NCherPhot = meanNCherPhot;
+        NCherPhot = poissNCherPhot * effPMTandTransport * d_qz;
       }
 
       LogDebug("ForwardSim") 
-	<< "ZdcSD::  getEnergyDeposit:  gED: "
-	<< stepE
-	<< "," << costh
-	<< "," << th
-	<< "," << costhcher
-	<< "," << thcher
-	<< "," << DelFibPart
-	<< "," << d
-	<< "," << a
-	<< "," << r
-	<< "," << hitPoint
-	<< "," << hit_mom
-	<< "," << stepControlFlag
-	<< "," << entot
-	<< "," << vert_mom
-	<< "," << localPoint
-	<< "," << charge
-	<< "," << beta
-	<< "," << stepL
-	<< "," << d_qz
-	<< "," << variant
-	<< "," << meanNCherPhot
-	<< "," << poissNCherPhot
-	<< "," << NCherPhot;
+        << "ZdcSD::  getEnergyDeposit:  gED: "
+        << stepE
+        << "," << costh
+        << "," << th
+        << "," << costhcher
+        << "," << thcher
+        << "," << DelFibPart
+        << "," << d
+        << "," << a
+        << "," << r
+        << "," << hitPoint
+        << "," << hit_mom
+        << "," << vert_mom
+        << "," << localPoint
+        << "," << charge
+        << "," << beta
+        << "," << stepL
+        << "," << d_qz
+        << "," << variant
+        << "," << meanNCherPhot
+        << "," << poissNCherPhot
+        << "," << NCherPhot;
       // --constants-----------------
       // << "," << photEnSpectrDE
       // << "," << nMedium
@@ -395,45 +314,26 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep, edm::ParameterSet const & p
       // determine failure mode: beta, charge, and/or nameVolume
       if (beta <= bThreshold)
         LogDebug("ForwardSim") 
-	  << "ZdcSD::  getEnergyDeposit: fail beta=" << beta;
+          << "ZdcSD::  getEnergyDeposit: fail beta=" << beta;
       if (charge == 0)
         LogDebug("ForwardSim") 
-	  << "ZdcSD::  getEnergyDeposit: fail charge=0";
+          << "ZdcSD::  getEnergyDeposit: fail charge=0";
       if ( !(nameVolume == "ZDC_EMFiber" || nameVolume == "ZDC_HadFiber") )
         LogDebug("ForwardSim") 
-	  << "ZdcSD::  getEnergyDeposit: fail nv=" << nameVolume;
+          << "ZdcSD::  getEnergyDeposit: fail nv=" << nameVolume;
     }
 
-    return NCherPhot;
-  } 
+    return NCherPhot; 
 }
 
 uint32_t ZdcSD::setDetUnitId(const G4Step* aStep) {
-  return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
+  return (numberingScheme.get() == nullptr ? 0 : numberingScheme.get()->getUnitID(aStep));
 }
 
 void ZdcSD::setNumberingScheme(ZdcNumberingScheme* scheme) {
   if (scheme != nullptr) {
     edm::LogInfo("ForwardSim") << "ZdcSD: updates numbering scheme for " 
-			       << GetName();
-    if (numberingScheme) delete numberingScheme;
-    numberingScheme = scheme;
+                               << GetName();
+    numberingScheme.reset(scheme);
   }
-}
-
-int ZdcSD::setTrackID (G4Step* aStep) {
-  theTrack     = aStep->GetTrack();
-  double etrack = preStepPoint->GetKineticEnergy();
-  TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
-  int primaryID = trkInfo->getIDonCaloSurface();
-  if (primaryID == 0) {
-#ifdef DebugLog
-    LogDebug("ZdcSD") << "ZdcSD: Problem with primaryID **** set by force "
-			<< "to TkID **** " << theTrack->GetTrackID();
-#endif
-    primaryID = theTrack->GetTrackID();
-    }
-  if (primaryID != previousID.trackID())
-      resetForNewPrimary(preStepPoint->GetPosition(), etrack); 
-  return primaryID;
 }

--- a/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
@@ -53,7 +53,7 @@ void ZdcShowerLibrary::initRun(G4ParticleTable *theParticleTable){
 		       << anutauPDG;
 }
 
-std::vector<ZdcShowerLibrary::Hit> & ZdcShowerLibrary::getHits(G4Step * aStep, bool & ok) {
+std::vector<ZdcShowerLibrary::Hit> & ZdcShowerLibrary::getHits(const G4Step * aStep, bool & ok) {
 
   G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
   G4StepPoint * postStepPoint = aStep->GetPostStepPoint(); 

--- a/SimG4CMS/HGCalTestBeam/interface/AHCalSD.h
+++ b/SimG4CMS/HGCalTestBeam/interface/AHCalSD.h
@@ -3,7 +3,6 @@
 
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 
-#include "G4String.hh"
 #include <map>
 #include <string>
 
@@ -15,13 +14,13 @@ public:
 
   AHCalSD(const std::string& , const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
-  ~AHCalSD() override;
-  double                getEnergyDeposit(G4Step* ) override;
+  ~AHCalSD() override = default;
   uint32_t              setDetUnitId(const G4Step* step) override;
   bool                  unpackIndex(const uint32_t & idx, int & row, 
 				    int& col, int& depth);
 protected:
 
+  double                getEnergyDeposit(const G4Step*) override;
   bool                  filterHit(CaloG4Hit*, double) override;
 
 private:    

--- a/SimG4CMS/HGCalTestBeam/interface/HGCalTB16SD01.h
+++ b/SimG4CMS/HGCalTestBeam/interface/HGCalTB16SD01.h
@@ -8,8 +8,6 @@
 
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 
-#include "G4String.hh"
-
 #include <string>
 
 class DDCompactView;
@@ -23,12 +21,15 @@ public:
   HGCalTB16SD01(const std::string& , const DDCompactView &, 
 		const SensitiveDetectorCatalog &, edm::ParameterSet const &, 
 		const SimTrackManager*);
-  ~HGCalTB16SD01() override;
-  double   getEnergyDeposit(G4Step* ) override;
+  ~HGCalTB16SD01() override = default;
   uint32_t setDetUnitId(const G4Step* step) override;
   static uint32_t  packIndex(int det, int lay, int x, int y);
   static void      unpackIndex(const uint32_t & idx, int& det, int& lay,
 			       int& x, int& y);
+
+protected:
+
+  double           getEnergyDeposit(const G4Step*) override;
 
 private:    
   void             initialize(const G4StepPoint* point);

--- a/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
@@ -38,9 +38,7 @@ AHCalSD::AHCalSD(const std::string& name, const DDCompactView & cpv,
                           << eminHit << std::endl;
 }
 
-AHCalSD::~AHCalSD() { }
-
-double AHCalSD::getEnergyDeposit(G4Step* aStep) {
+double AHCalSD::getEnergyDeposit(const G4Step* aStep) {
 
   double destep = aStep->GetTotalEnergyDeposit();
   double wt2    = aStep->GetTrack()->GetWeight();
@@ -59,7 +57,7 @@ double AHCalSD::getEnergyDeposit(G4Step* aStep) {
 
 uint32_t AHCalSD::setDetUnitId(const G4Step * aStep) { 
 
-  G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
 
   int depth = (touch->GetReplicaNumber(1));

--- a/SimG4CMS/HGCalTestBeam/src/HGCalTB16SD01.cc
+++ b/SimG4CMS/HGCalTestBeam/src/HGCalTB16SD01.cc
@@ -42,11 +42,9 @@ HGCalTB16SD01::HGCalTB16SD01(const std::string& name, const DDCompactView & cpv,
 			 << ", C1 = " << birk2_ << ", C2 = " << birk3_;
 }
 
-HGCalTB16SD01::~HGCalTB16SD01() {}
+double HGCalTB16SD01::getEnergyDeposit(const G4Step* aStep) {
 
-double HGCalTB16SD01::getEnergyDeposit(G4Step* aStep) {
-
-  G4StepPoint* point = aStep->GetPreStepPoint();
+  auto const point = aStep->GetPreStepPoint();
   if (initialize_) initialize(point);
   double destep = aStep->GetTotalEnergyDeposit();
   double wt2    = aStep->GetTrack()->GetWeight();
@@ -65,9 +63,8 @@ double HGCalTB16SD01::getEnergyDeposit(G4Step* aStep) {
 
 uint32_t HGCalTB16SD01::setDetUnitId(const G4Step * aStep) { 
 
-  G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
-  G4String name             = preStepPoint->GetPhysicalVolume()->GetName();
 
   int det(1), x(0), y(0);
   int lay = (touch->GetReplicaNumber(0));

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
@@ -32,15 +32,18 @@ public:
   HcalTB02SD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	     edm::ParameterSet const &, const SimTrackManager*);
   ~HcalTB02SD() override;
-  double getEnergyDeposit(G4Step*) override;
   uint32_t setDetUnitId(const G4Step* step) override;
   void setNumberingScheme(HcalTB02NumberingScheme* scheme);
+
+protected:
+
+  double getEnergyDeposit(const G4Step*) override;
 
 private:    
 
   void   initMap(const std::string&, const DDCompactView &);
-  double curve_LY(G4String& , G4StepPoint* ); 
-  double crystalLength(G4String);
+  double curve_LY(const G4String& , const G4StepPoint* ); 
+  double crystalLength(const G4String&);
 
 private:    
 

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
@@ -25,8 +25,11 @@ public:
                  const SensitiveDetectorCatalog &,
 		 edm::ParameterSet const &, const SimTrackManager*);
   ~HcalTB06BeamSD() override;
-  double getEnergyDeposit(G4Step* ) override;
   uint32_t setDetUnitId(const G4Step* step) override;
+
+protected:
+
+  double getEnergyDeposit(const G4Step*) override;
 
 private:    
 

--- a/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
@@ -84,13 +84,13 @@ HcalTB02SD::~HcalTB02SD() {
 // member functions
 //
  
-double HcalTB02SD::getEnergyDeposit(G4Step * aStep) {
+double HcalTB02SD::getEnergyDeposit(const G4Step * aStep) {
   
   if (aStep == nullptr) {
     return 0;
   } else {
-    preStepPoint        = aStep->GetPreStepPoint();
-    G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
+    auto const preStepPoint = aStep->GetPreStepPoint();
+    auto const & nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
 
     // take into account light collection curve for crystals
     double weight = 1.;
@@ -148,7 +148,7 @@ void HcalTB02SD::initMap(const std::string& sd, const DDCompactView & cpv) {
   }
 }
 
-double HcalTB02SD::curve_LY(G4String& nameVolume, G4StepPoint* stepPoint) {
+double HcalTB02SD::curve_LY(const G4String& nameVolume, const G4StepPoint* stepPoint) {
 
   double weight = 1.;
   G4ThreeVector  localPoint = setToLocal(stepPoint->GetPosition(),
@@ -173,7 +173,7 @@ double HcalTB02SD::curve_LY(G4String& nameVolume, G4StepPoint* stepPoint) {
   return weight;
 }
 
-double HcalTB02SD::crystalLength(G4String name) {
+double HcalTB02SD::crystalLength(const G4String& name) {
 
   double length = 230.;
   std::map<G4String,double>::const_iterator it = lengthMap.find(name);

--- a/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
@@ -93,7 +93,7 @@ HcalTB06BeamSD::HcalTB06BeamSD(const std::string& name, const DDCompactView & cp
 
 HcalTB06BeamSD::~HcalTB06BeamSD() {}
 
-double HcalTB06BeamSD::getEnergyDeposit(G4Step* aStep) {
+double HcalTB06BeamSD::getEnergyDeposit(const G4Step* aStep) {
 
   double destep = aStep->GetTotalEnergyDeposit();
   double weight = 1;

--- a/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
@@ -115,7 +115,7 @@ void FiberSD::update(const BeginOfJob * job) {
   es->get<HcalSimNumberingRecord>().get(hdc);
   if (hdc.isValid()) {
     HcalDDDSimConstants *hcalConstants = (HcalDDDSimConstants*)(&(*hdc));
-    theShower->initRun(nullptr, hcalConstants);
+    theShower->initRun(hcalConstants);
   } else {
     edm::LogError("HcalSim") << "HCalSD : Cannot find HcalDDDSimConstant";
     throw cms::Exception("Unknown", "HCalSD") << "Cannot find HcalDDDSimConstant" << "\n";


### PR DESCRIPTION
This PR is made instead of #21964. 
Geant4 calorimeter sensitive detectors are updated:

1.     In the base class CaloSD Geant4 interface ProcessHits(..) is implemented. In the 
        derived classes two main methods for sub-detectors : getFromLibrary(..) and 
        getEnergyDeposit(.. ) allow implementation of shower libraries/parametrisation 
        or detailed simulation 
2.     Removed duplicated codes from sub-detector classes and use base class CaloSD methods 
3.     use const G4Step* pointer in protected and private interfaces, use const pointers and 
        references for all other objects, where possible
4.     use std::unique_ptr, auto, and other C++11 features where possible
5.     reduce number of protected class members and reduced number of type conversions
6.     optimized ECalSD run time methods - perform only one search over map of logical 
        volumes instead of doing this in each method
7.     remove usage of G4ParticleTable at initialisation use instead static utility
8.     optimised LogInfo and LogDebug - verbose output is substantially smaller but keeping
        similar information
9.     removed old commented lines
10.   applied corrections suggested by @kpedro88 and @VinInn to previous PRs

Correctness of this PR means identical results for all WFs.