### PR TITLE
SiStrip Commissioning Updates

### DIFF
--- a/CondFormats/SiStripObjects/interface/DaqScopeModeAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/DaqScopeModeAnalysis.h
@@ -24,50 +24,143 @@ class DaqScopeModeAnalysis : public CommissioningAnalysis {
   ~DaqScopeModeAnalysis() override {;}
 
   friend class DaqScopeModeAlgorithm;
+
+  /** Identifies if analysis is valid or not. */
+  bool isValid() const override;
+  /** Identifies if tick mark is found or not. */
+  bool foundTickMark() const;
+  /** FED frame-finding threshold [ADC] (returns 65535 if invalid). */
+  uint16_t frameFindingThreshold() const; 
+      
+  // Pedestal, noise and raw noise (128-strip vector per APV)
+  inline const VVFloat& peds() const;
+  inline const VVFloat& noise() const;
+  inline const VVFloat& raw() const;
+
+  // Dead and noisy strips (vector per APV)
+  inline const VVInt& dead() const; 
+  inline const VVInt& noisy() const;
+
+  // Mean and rms spread (value per APV)
+  inline const VFloat& pedsMean() const;
+  inline const VFloat& pedsSpread() const;
+  inline const VFloat& noiseMean() const;
+  inline const VFloat& noiseSpread() const;
+  inline const VFloat& rawMean() const;
+  inline const VFloat& rawSpread() const;
+
+  // Max and min values (value per APV)
+  inline const VFloat& pedsMax() const;
+  inline const VFloat& pedsMin() const; 
+  inline const VFloat& noiseMax() const;
+  inline const VFloat& noiseMin() const;
+  inline const VFloat& rawMax() const;
+  inline const VFloat& rawMin() const;
+     
+  /** Height of tick mark [ADC]. */
+  inline const float& height() const;
+  /** Baseline level of tick mark [ADC]. */
+  inline const float& base() const; 
+  /** Level of tick mark top [ADC]. */
+  inline const float& peak() const; 
+
+  /** Prints analysis results. */
+  void print( std::stringstream&, uint32_t apv_number = 0 ) override;  
+
+  /** Adds error codes for analysis (overrides private base). */ 
+  inline void addErrorCode( const std::string& error ) override;
+
+  /** Overrides base method. */
+  void summary( std::stringstream& ) const override;
   
-  inline const float& entries() const;
-
-  inline const float& mean() const; 
-
-  inline const float& median() const; 
-
-  inline const float& mode() const; 
-
-  inline const float& rms() const; 
-
-  inline const float& min() const; 
-
-  inline const float& max() const; 
-  
-  void print( std::stringstream&, uint32_t not_used = 0 ) override;
-  
+  /** Resets analysis member data. */
   void reset() override;
+  
+  /** Threshold defining minimum tick mark height [ADC]. */
+  static const float tickMarkHeightThreshold_;
+  
+  /** Threshold for FED frame finding (fraction of tick height). */
+  static const float frameFindingThreshold_;
   
  private:
   
-  float entries_;
-
-  float mean_;
-
-  float median_;
-
-  float mode_;
-
-  float rms_;
-
-  float min_;
-
-  float max_;
+  /** Height of tick mark [ADC]. */
+  float height_;
+  /** Baseline level of tick mark [ADC]. */
+  float base_;
+  /** Level of tick mark top [ADC]. */
+  float peak_;  
   
+  /** Peds values. */
+  VVFloat peds_;
+  /** Noise values. */
+  VVFloat noise_;
+  /** Raw noise values. */
+  VVFloat raw_;
+
+  /** Dead strips. */
+  VVInt dead_; 
+  /** Noisy strips. */
+  VVInt noisy_;
+
+  /** Mean peds value. */
+  VFloat pedsMean_;
+  /** Rms spread in peds. */
+  VFloat pedsSpread_;
+  /** Mean noise value. */
+  VFloat noiseMean_;
+  /** Rms spread in noise. */
+  VFloat noiseSpread_;
+  /** Mean raw noise value. */
+  VFloat rawMean_;
+  /** Rms spread in raw noise. */
+  VFloat rawSpread_;
+
+  /** Max peds value. */
+  VFloat pedsMax_;
+  /** Min peds value. */
+  VFloat pedsMin_; 
+
+  /** Max noise value. */
+  VFloat noiseMax_;
+  /** Min noise value. */
+  VFloat noiseMin_;
+  /** Max raw noise value. */
+  VFloat rawMax_;
+  /** Min raw noise value. */
+  VFloat rawMin_;  
+  // true if legacy histogram naming is used
+  bool legacy_;
+
+
 };
 
-const float& DaqScopeModeAnalysis::entries() const { return entries_; }
-const float& DaqScopeModeAnalysis::mean() const { return mean_; }
-const float& DaqScopeModeAnalysis::median() const { return median_; }
-const float& DaqScopeModeAnalysis::mode() const { return mode_; }
-const float& DaqScopeModeAnalysis::rms() const { return rms_; }
-const float& DaqScopeModeAnalysis::min() const { return min_; }
-const float& DaqScopeModeAnalysis::max() const { return max_; }
+const DaqScopeModeAnalysis::VVFloat& DaqScopeModeAnalysis::peds() const { return peds_; }
+const DaqScopeModeAnalysis::VVFloat& DaqScopeModeAnalysis::noise() const { return noise_; }
+const DaqScopeModeAnalysis::VVFloat& DaqScopeModeAnalysis::raw() const { return raw_; }
+
+const DaqScopeModeAnalysis::VVInt& DaqScopeModeAnalysis::dead() const { return dead_; } 
+const DaqScopeModeAnalysis::VVInt& DaqScopeModeAnalysis::noisy() const { return noisy_; }
+
+const DaqScopeModeAnalysis::VFloat& DaqScopeModeAnalysis::pedsMean() const { return pedsMean_; }
+const DaqScopeModeAnalysis::VFloat& DaqScopeModeAnalysis::pedsSpread() const { return pedsSpread_; }
+const DaqScopeModeAnalysis::VFloat& DaqScopeModeAnalysis::noiseMean() const { return noiseMean_; }
+const DaqScopeModeAnalysis::VFloat& DaqScopeModeAnalysis::noiseSpread() const { return noiseSpread_; }
+const DaqScopeModeAnalysis::VFloat& DaqScopeModeAnalysis::rawMean() const { return rawMean_; }
+const DaqScopeModeAnalysis::VFloat& DaqScopeModeAnalysis::rawSpread() const { return rawSpread_; }
+
+const DaqScopeModeAnalysis::VFloat& DaqScopeModeAnalysis::pedsMax() const { return pedsMax_; }
+const DaqScopeModeAnalysis::VFloat& DaqScopeModeAnalysis::pedsMin() const { return pedsMin_; } 
+const DaqScopeModeAnalysis::VFloat& DaqScopeModeAnalysis::noiseMax() const { return noiseMax_; }
+const DaqScopeModeAnalysis::VFloat& DaqScopeModeAnalysis::noiseMin() const { return noiseMin_; }
+const DaqScopeModeAnalysis::VFloat& DaqScopeModeAnalysis::rawMax() const { return rawMax_; }
+const DaqScopeModeAnalysis::VFloat& DaqScopeModeAnalysis::rawMin() const { return rawMin_; }
+
+const float& DaqScopeModeAnalysis::height() const { return height_; }
+const float& DaqScopeModeAnalysis::base() const { return base_; }
+const float& DaqScopeModeAnalysis::peak() const { return peak_; }
+void DaqScopeModeAnalysis::addErrorCode( const std::string& error ) { CommissioningAnalysis::addErrorCode(error) ;}
+
 
 #endif // CondFormats_SiStripObjects_DaqScopeModeAnalysis_H
 

--- a/CondFormats/SiStripObjects/src/DaqScopeModeAnalysis.cc
+++ b/CondFormats/SiStripObjects/src/DaqScopeModeAnalysis.cc
@@ -8,50 +8,315 @@
 
 using namespace sistrip;
 
+const float DaqScopeModeAnalysis::tickMarkHeightThreshold_ = 50.; // [ADC]
+const float DaqScopeModeAnalysis::frameFindingThreshold_ = (2./3.); // fraction of tick mark height
+
 // ----------------------------------------------------------------------------
 // 
 DaqScopeModeAnalysis::DaqScopeModeAnalysis( const uint32_t& key ) 
   : CommissioningAnalysis(key,"DaqScopeModeAnalysis"),
-    entries_(sistrip::invalid_), 
-    mean_(sistrip::invalid_), 
-    median_(sistrip::invalid_), 
-    mode_(sistrip::invalid_), 
-    rms_(sistrip::invalid_), 
-    min_(sistrip::invalid_), 
-    max_(sistrip::invalid_)
-{;}
+    height_(1.*sistrip::invalid_),
+    base_(1.*sistrip::invalid_), 
+    peak_(1.*sistrip::invalid_),
+    peds_(2,VFloat(128,sistrip::invalid_)), 
+    noise_(2,VFloat(128,sistrip::invalid_)), 
+    raw_(2,VFloat(128,sistrip::invalid_)), 
+    dead_(2,VInt(0,sistrip::invalid_)), 
+    noisy_(2,VInt(0,sistrip::invalid_)),
+    pedsMean_(2,sistrip::invalid_), 
+    pedsSpread_(2,sistrip::invalid_), 
+    noiseMean_(2,sistrip::invalid_), 
+    noiseSpread_(2,sistrip::invalid_), 
+    rawMean_(2,sistrip::invalid_), 
+    rawSpread_(2,sistrip::invalid_), 
+    pedsMax_(2,sistrip::invalid_), 
+    pedsMin_(2,sistrip::invalid_), 
+    noiseMax_(2,sistrip::invalid_), 
+    noiseMin_(2,sistrip::invalid_),
+    rawMax_(2,sistrip::invalid_), 
+    rawMin_(2,sistrip::invalid_)
+{
+  dead_[0].reserve(256); dead_[1].reserve(256); 
+  noisy_[0].reserve(256); noisy_[1].reserve(256);
+}
 
 // ----------------------------------------------------------------------------
 // 
 DaqScopeModeAnalysis::DaqScopeModeAnalysis() 
   : CommissioningAnalysis("DaqScopeModeAnalysis"),
-    entries_(sistrip::invalid_), 
-    mean_(sistrip::invalid_), 
-    median_(sistrip::invalid_), 
-    mode_(sistrip::invalid_), 
-    rms_(sistrip::invalid_), 
-    min_(sistrip::invalid_), 
-    max_(sistrip::invalid_)
-{;}
-
-// ----------------------------------------------------------------------------
-// 
-void DaqScopeModeAnalysis::reset() {
-  entries_ = 1. * sistrip::invalid_; 
-  mean_ = 1.*sistrip::invalid_; 
-  median_ = 1.*sistrip::invalid_; 
-  mode_ = 1.*sistrip::invalid_; 
-  rms_ = 1.*sistrip::invalid_; 
-  min_ = 1.*sistrip::invalid_; 
-  max_ = 1.*sistrip::invalid_; 
+    height_(1.*sistrip::invalid_),
+    base_(1.*sistrip::invalid_), 
+    peak_(1.*sistrip::invalid_),
+    peds_(2,VFloat(128,sistrip::invalid_)), 
+    noise_(2,VFloat(128,sistrip::invalid_)), 
+    raw_(2,VFloat(128,sistrip::invalid_)), 
+    dead_(2,VInt(0,sistrip::invalid_)), 
+    noisy_(2,VInt(0,sistrip::invalid_)),
+    pedsMean_(2,sistrip::invalid_), 
+    pedsSpread_(2,sistrip::invalid_), 
+    noiseMean_(2,sistrip::invalid_), 
+    noiseSpread_(2,sistrip::invalid_), 
+    rawMean_(2,sistrip::invalid_), 
+    rawSpread_(2,sistrip::invalid_), 
+    pedsMax_(2,sistrip::invalid_), 
+    pedsMin_(2,sistrip::invalid_), 
+    noiseMax_(2,sistrip::invalid_), 
+    noiseMin_(2,sistrip::invalid_),
+    rawMax_(2,sistrip::invalid_), 
+    rawMin_(2,sistrip::invalid_)
+{
+  dead_[0].reserve(256); dead_[1].reserve(256); 
+  noisy_[0].reserve(256); noisy_[1].reserve(256);
 }
 
 // ----------------------------------------------------------------------------
 // 
-void DaqScopeModeAnalysis::print( std::stringstream& ss, uint32_t not_used ) { 
+void DaqScopeModeAnalysis::reset() {
+  height_ = 1.*sistrip::invalid_;
+  base_ = 1.*sistrip::invalid_;
+  peak_ = 1.*sistrip::invalid_; 
+  
+  peds_        = VVFloat(2,VFloat(128,sistrip::invalid_)); 
+  noise_       = VVFloat(2,VFloat(128,sistrip::invalid_)); 
+  raw_         = VVFloat(2,VFloat(128,sistrip::invalid_));
+  dead_        = VVInt(2,VInt(0,sistrip::invalid_)); 
+  noisy_       = VVInt(2,VInt(0,sistrip::invalid_));
+  pedsMean_    = VFloat(2,sistrip::invalid_); 
+  pedsSpread_  = VFloat(2,sistrip::invalid_); 
+  noiseMean_   = VFloat(2,sistrip::invalid_); 
+  noiseSpread_ = VFloat(2,sistrip::invalid_); 
+  rawMean_     = VFloat(2,sistrip::invalid_);
+  rawSpread_   = VFloat(2,sistrip::invalid_);
+  pedsMax_     = VFloat(2,sistrip::invalid_); 
+  pedsMin_     = VFloat(2,sistrip::invalid_); 
+  noiseMax_    = VFloat(2,sistrip::invalid_); 
+  noiseMin_    = VFloat(2,sistrip::invalid_);
+  rawMax_      = VFloat(2,sistrip::invalid_);
+  rawMin_      = VFloat(2,sistrip::invalid_);
+  dead_[0].reserve(256); 
+  dead_[1].reserve(256); 
+  noisy_[0].reserve(256); 
+  noisy_[1].reserve(256);
+}
+
+
+// ----------------------------------------------------------------------------
+// 
+uint16_t DaqScopeModeAnalysis::frameFindingThreshold() const { 
+  if ( ( getErrorCodes().empty() || getErrorCodes()[0] == "TickMarkRecovered" ) &&
+       base_   < sistrip::valid_ && 
+       peak_   < sistrip::valid_ && 
+       height_ < sistrip::valid_  &&
+       height_ > tickMarkHeightThreshold_ ) { 
+    return ( ( static_cast<uint16_t>( base_ + 
+				      height_ * 
+				      DaqScopeModeAnalysis::frameFindingThreshold_ ) / 32 ) * 32 );
+  } else { return sistrip::invalid_; }
+}
+
+// ----------------------------------------------------------------------------
+// 
+bool DaqScopeModeAnalysis::foundTickMark() const {
+  return ( ( getErrorCodes().empty() || getErrorCodes()[0] == "TickMarkRecovered") &&
+	   base_   < sistrip::valid_ &&
+	   peak_   < sistrip::valid_ &&
+	   height_ < sistrip::valid_ &&
+	   frameFindingThreshold() < sistrip::valid_ );
+} 
+
+// ----------------------------------------------------------------------------
+// 
+bool DaqScopeModeAnalysis::isValid() const {
+  return ( ( getErrorCodes().empty() || getErrorCodes()[0] == "TickMarkRecovered" ) &&
+	   base_   < sistrip::valid_ &&
+	   peak_   < sistrip::valid_ &&
+	   height_ < sistrip::valid_ &&
+	   frameFindingThreshold() < sistrip::valid_ &&
+	   pedsMean_[0] < sistrip::maximum_ &&
+	   pedsMean_[1] < sistrip::maximum_ &&
+	   pedsSpread_[0] < sistrip::maximum_ &&
+	   pedsSpread_[1] < sistrip::maximum_ &&
+	   noiseMean_[0] < sistrip::maximum_ &&
+	   noiseMean_[1] < sistrip::maximum_ &&
+	   noiseSpread_[0] < sistrip::maximum_ &&
+	   noiseSpread_[1] < sistrip::maximum_ &&
+	   rawMean_[0] < sistrip::maximum_ &&
+	   rawMean_[1] < sistrip::maximum_ &&
+	   rawSpread_[0] < sistrip::maximum_ &&
+	   rawSpread_[1] < sistrip::maximum_ &&
+	   pedsMax_[0] < sistrip::maximum_ &&
+	   pedsMax_[1] < sistrip::maximum_ &&
+	   pedsMin_[0] < sistrip::maximum_ &&
+	   pedsMin_[1] < sistrip::maximum_ &&
+	   noiseMax_[0] < sistrip::maximum_ &&
+	   noiseMax_[1] < sistrip::maximum_ &&
+	   noiseMin_[0] < sistrip::maximum_ &&
+	   noiseMin_[1] < sistrip::maximum_ &&
+	   rawMax_[0] < sistrip::maximum_ &&
+	   rawMax_[1] < sistrip::maximum_ &&
+	   rawMin_[0] < sistrip::maximum_ &&
+	   rawMin_[1] < sistrip::maximum_ );
+}
+
+// ----------------------------------------------------------------------------
+// 
+void DaqScopeModeAnalysis::print( std::stringstream& ss, uint32_t iapv ) { 
+
+
+  if ( iapv == 1 || iapv == 2 ) { iapv--; }
+  else { iapv = 0; }
+
   header( ss );
-  ss << " Number of entries   : " << entries_ << "\n" 
-     << " Mean +/- rms [adc]  : " << mean_ << " +/- " << rms_ << "\n"
-     << " Median / mode [adc] : " << median_ << " / " << mode_ << "\n" 
-     << " Min / max [adc]     : " << min_ << " / " << max_ << "\n";
+  ss <<  std::fixed << std::setprecision(2)
+     << " Tick mark bottom (baseline)       [ADC] : " << base_ << std::endl 
+     << " Tick mark top                     [ADC] : " << peak_ << std::endl 
+     << " Tick mark height                  [ADC] : " << height_ << std::endl
+     << " Frame finding threshold           [ADC] : " << frameFindingThreshold() << std::endl
+     << std::boolalpha 
+     << " Tick mark found                         : " << foundTickMark()  << std::endl
+     << " isValid                                 : " << isValid()  << std::endl;
+    
+  if ( peds_[iapv].size()  < 128 ||
+       noise_[iapv].size() < 128 ||
+       raw_[iapv].size()   < 128 ) { 
+    
+    edm::LogWarning(mlCommissioning_)
+      << "[" << myName() << "::" << __func__ << "]"
+      << " Unexpected number of pedestal/noise values: " 
+      << peds_[iapv].size() << ", " 
+      << noise_[iapv].size() << ", " 
+      << raw_[iapv].size();
+    return;      
+  }
+  
+  ss << " Monitorables for APV number     : " << iapv;
+  if ( iapv == 0 ) { ss << " (first of pair)"; }
+  else if ( iapv == 1 ) { ss << " (second of pair)"; } 
+  ss << std::endl;
+  ss << std::fixed << std::setprecision(2);
+  ss << " Example peds/noise for strips   : "
+     << "     0,     31,     63,    127" << std::endl
+     << "  Peds                     [ADC] : " 
+     << std::setw(6) << peds_[iapv][0] << ", " 
+     << std::setw(6) << peds_[iapv][31] << ", " 
+     << std::setw(6) << peds_[iapv][63] << ", " 
+     << std::setw(6) << peds_[iapv][127] << std::endl
+     << "  Noise                    [ADC] : " 
+     << std::setw(6) << noise_[iapv][0] << ", " 
+     << std::setw(6) << noise_[iapv][31] << ", " 
+     << std::setw(6) << noise_[iapv][63] << ", " 
+     << std::setw(6) << noise_[iapv][127] << std::endl
+     << "  Raw noise                [ADC] : " 
+     << std::setw(6) << raw_[iapv][0] << ", " 
+     << std::setw(6) << raw_[iapv][31] << ", " 
+     << std::setw(6) << raw_[iapv][63] << ", " 
+     << std::setw(6) << raw_[iapv][127] << std::endl
+     << " Dead strips (<5s)       [strip] : (" << dead_[iapv].size() << " in total) ";
+  for ( uint16_t ii = 0; ii < dead_[iapv].size(); ii++ ) { 
+    ss << dead_[iapv][ii] << " "; }
+  
+  ss << std::endl;
+  ss << " Noisy strips (>5s)      [strip] : (" << noisy_[iapv].size() << " in total) ";
+  for ( uint16_t ii = 0; ii < noisy_[iapv].size(); ii++ ) { 
+    ss << noisy_[iapv][ii] << " "; 
+  } 
+  ss << std::endl;
+  ss << " Mean peds +/- spread      [ADC] : " << pedsMean_[iapv] << " +/- " << pedsSpread_[iapv] << std::endl 
+     << " Min/Max pedestal          [ADC] : " << pedsMin_[iapv] << " <-> " << pedsMax_[iapv] << std::endl
+     << " Mean noise +/- spread     [ADC] : " << noiseMean_[iapv] << " +/- " << noiseSpread_[iapv] << std::endl 
+     << " Min/Max noise             [ADC] : " << noiseMin_[iapv] << " <-> " << noiseMax_[iapv] << std::endl
+     << " Mean raw noise +/- spread [ADC] : " << rawMean_[iapv] << " +/- " << rawSpread_[iapv] << std::endl 
+     << " Min/Max raw noise         [ADC] : " << rawMin_[iapv] << " <-> " << rawMax_[iapv] << std::endl
+     << " Normalised noise                : " << "(yet to be implemented...)" << std::endl
+     << std::boolalpha 
+     << " isValid                         : " << isValid()  << std::endl
+     << std::noboolalpha
+     << " Error codes (found "
+     << std::setw(2) << std::setfill(' ') << getErrorCodes().size() 
+     << ")          : ";
+  if ( getErrorCodes().empty() ) { ss << "(none)"; }
+  else { 
+    VString::const_iterator istr = getErrorCodes().begin();
+    VString::const_iterator jstr = getErrorCodes().end();
+    for ( ; istr != jstr; ++istr ) { ss << *istr << " "; }
+  }
+  ss << std::endl;    
+}
+
+
+
+// ----------------------------------------------------------------------------
+// 
+void DaqScopeModeAnalysis::summary( std::stringstream& ss ) const { 
+  
+  SiStripFecKey fec_key( fecKey() );
+  SiStripFedKey fed_key( fedKey() );
+  
+  sistrip::RunType type = SiStripEnumsAndStrings::runType( myName() );
+
+  std::stringstream extra1,extra2,extra3,extra4;
+  extra1 << sistrip::extrainfo::pedestals_; 
+  extra2 << sistrip::extrainfo::rawNoise_; 
+  extra3 << sistrip::extrainfo::commonMode_;
+  extra4 << sistrip::extrainfo::scopeModeFrame_;
+  
+  std::string title1 = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
+					  type,
+					  sistrip::FED_KEY, 
+					  fed_key.key(),
+					  sistrip::LLD_CHAN, 
+					  fec_key.lldChan(),
+					  extra1.str() ).title();
+  std::string title2 = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
+					  type,
+					  sistrip::FED_KEY, 
+					  fed_key.key(),
+					  sistrip::LLD_CHAN, 
+					  fec_key.lldChan(),
+					  extra2.str() ).title();
+  std::string title3 = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
+					  type,
+					  sistrip::FED_KEY, 
+					  fed_key.key(),
+					  sistrip::APV, 
+					  SiStripFecKey::i2cAddr( fec_key.lldChan(), true ),
+					  extra3.str() ).title();
+  std::string title4 = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
+					  type,
+					  sistrip::FED_KEY, 
+					  fed_key.key(),
+					  sistrip::APV, 
+					  SiStripFecKey::i2cAddr( fec_key.lldChan(), false ),
+					  extra3.str() ).title();
+
+  std::string title5 = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
+					  type,
+					  sistrip::FED_KEY, 
+					  fed_key.key(),
+					  sistrip::LLD_CHAN, 
+					  SiStripFecKey::i2cAddr( fec_key.lldChan()),
+					  extra4.str() ).title();
+  
+  ss << " Summary"
+     << ":"
+     << ( isValid() ? "Valid" : "Invalid" )
+     << ":"
+     << sistrip::controlView_ << ":"
+     << fec_key.fecCrate() << "/" 
+     << fec_key.fecSlot() << "/" 
+     << fec_key.fecRing() << "/" 
+     << fec_key.ccuAddr() << "/" 
+     << fec_key.ccuChan() 
+     << ":"
+     << sistrip::dqmRoot_ << sistrip::dir_ 
+     << "Collate" << sistrip::dir_ 
+     << SiStripFecKey( fec_key.fecCrate(),
+		       fec_key.fecSlot(), 
+		       fec_key.fecRing(), 
+		       fec_key.ccuAddr(), 
+		       fec_key.ccuChan() ).path()
+     << ":"
+     << title1 << ";" << title2 << ";" << title3 << ";" << title4 << ";" << title5 
+     << std::endl;
+  
 }

--- a/DQM/SiStripCommissioningAnalysis/interface/DaqScopeModeAlgorithm.h
+++ b/DQM/SiStripCommissioningAnalysis/interface/DaqScopeModeAlgorithm.h
@@ -19,33 +19,38 @@ class DaqScopeModeAlgorithm : public CommissioningAlgorithm {
   
   DaqScopeModeAlgorithm( const edm::ParameterSet & pset, DaqScopeModeAnalysis* const );
 
-  ~DaqScopeModeAlgorithm() override {;}
+  ~DaqScopeModeAlgorithm() override {;} 
   
-  inline const float& entries() const;
-  inline const float& mean() const; 
-  inline const float& median() const; 
-  inline const float& mode() const; 
-  inline const float& rms() const; 
-  inline const float& min() const; 
-  inline const float& max() const; 
-  
+  inline const Histo& hPeds() const;
+  inline const Histo& hNoise() const;
   inline const Histo& histo() const;
   
  private:
   
   DaqScopeModeAlgorithm() {;}
   
-  void extract( const std::vector<TH1*>& ) override;
+  void extract( const std::vector<TH1*>& );
 
-  void analyse() override;
+  void analyse();
   
  private:
   
   /** Histogram of scope mode data. */
   Histo histo_;
+  /** Pedestals and raw noise */
+  Histo hPeds_;
+  /** Residuals and noise */
+  Histo hNoise_;
+  
+  /** Analysis parameters */
+  float deadStripMax_;
+  float noisyStripMin_;
   
 };
+
 const DaqScopeModeAlgorithm::Histo& DaqScopeModeAlgorithm::histo() const { return histo_; }
+const DaqScopeModeAlgorithm::Histo& DaqScopeModeAlgorithm::hPeds() const { return hPeds_; }
+const DaqScopeModeAlgorithm::Histo& DaqScopeModeAlgorithm::hNoise() const { return hNoise_; }
 
 #endif // DQM_SiStripCommissioningAnalysis_DaqScopeModeAlgorithm_H
 

--- a/DQM/SiStripCommissioningAnalysis/interface/DaqScopeModeAlgorithm.h
+++ b/DQM/SiStripCommissioningAnalysis/interface/DaqScopeModeAlgorithm.h
@@ -29,9 +29,9 @@ class DaqScopeModeAlgorithm : public CommissioningAlgorithm {
   
   DaqScopeModeAlgorithm() {;}
   
-  void extract( const std::vector<TH1*>& );
+  void extract( const std::vector<TH1*>& ) override;
 
-  void analyse();
+  void analyse() override;
   
  private:
   

--- a/DQM/SiStripCommissioningAnalysis/src/DaqScopeModeAlgorithm.cc
+++ b/DQM/SiStripCommissioningAnalysis/src/DaqScopeModeAlgorithm.cc
@@ -4,6 +4,7 @@
 #include "DataFormats/SiStripCommon/interface/SiStripEnumsAndStrings.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "TH1.h"
+#include "TProfile.h"
 #include <iostream>
 #include <iomanip>
 #include <cmath>
@@ -14,7 +15,11 @@ using namespace sistrip;
 // 
 DaqScopeModeAlgorithm::DaqScopeModeAlgorithm( const edm::ParameterSet & pset, DaqScopeModeAnalysis* const anal ) 
   : CommissioningAlgorithm(anal),
-    histo_(nullptr,"")
+    histo_(nullptr,""),
+    hPeds_(nullptr,""),
+    hNoise_(nullptr,""),
+    deadStripMax_(pset.getParameter<double>("DeadStripMax")),
+    noisyStripMin_(pset.getParameter<double>("NoisyStripMin"))
 {;}
 
 // ----------------------------------------------------------------------------
@@ -29,7 +34,7 @@ void DaqScopeModeAlgorithm::extract( const std::vector<TH1*>& histos ) {
   }
 
   // Check
-  if ( histos.size() != 1 ) {
+  if ( histos.size() != 3 ) {
     anal()->addErrorCode(sistrip::numberOfHistos_);
   }
   
@@ -51,11 +56,28 @@ void DaqScopeModeAlgorithm::extract( const std::vector<TH1*>& histos ) {
     }
     
     // Extract timing histo
-    histo_.first = *ihis;
-    histo_.second = (*ihis)->GetName();
-    
-  }
-  
+    // Extract peds and noise histos (check for legacy names first!)
+    if ( title.extraInfo().find(sistrip::extrainfo::pedsAndRawNoise_) != std::string::npos ) {
+      hPeds_.first = *ihis;
+      hPeds_.second = (*ihis)->GetName();
+    } 
+    else if ( title.extraInfo().find(sistrip::extrainfo::pedsAndCmSubNoise_) != std::string::npos ) {
+      hNoise_.first = *ihis;
+      hNoise_.second = (*ihis)->GetName();
+    } else if ( title.extraInfo().find(sistrip::extrainfo::pedestals_) != std::string::npos ) {
+      hPeds_.first = *ihis;
+      hPeds_.second = (*ihis)->GetName();
+    } else if ( title.extraInfo().find(sistrip::extrainfo::noise_) != std::string::npos ) {
+      hNoise_.first = *ihis;
+      hNoise_.second = (*ihis)->GetName();
+    } else if ( title.extraInfo().find(sistrip::extrainfo::commonMode_) != std::string::npos ) {
+      //@@ something here for CM plots?
+    }
+    else if ( title.extraInfo().find(sistrip::extrainfo::scopeModeFrame_) != std::string::npos ) {
+      histo_.first = *ihis;
+      histo_.second = (*ihis)->GetName();
+    }
+  }  
 }
 
 // ----------------------------------------------------------------------------
@@ -78,48 +100,151 @@ void DaqScopeModeAlgorithm::analyse() {
     return; 
   }
 
+  // Analysis level wants all the informations --> it will work only on Spy-events
+  if ( !hPeds_.first ) {
+    anal->addErrorCode(sistrip::nullPtr_);
+    return;
+  }
+
+  if ( !hNoise_.first ) {
+    anal->addErrorCode(sistrip::nullPtr_);
+    return;
+  }
+
   if ( !histo_.first ) {
     anal->addErrorCode(sistrip::nullPtr_);
     return;
   }
 
-  // Some initialization
-  std::vector<float> median;
-  float max_value = -1. * sistrip::invalid_;
-  float max_contents = -1. * sistrip::invalid_;
-  float sum = 0.;
-  float sum2 = 0.;
-  
-  // Entries, min, mode
-  uint16_t nbins = static_cast<uint16_t>( histo_.first->GetNbinsX() );
-  for ( uint16_t ibin = 0; ibin < nbins; ibin++ ) {
-    float value = histo_.first->GetBinLowEdge(ibin+1) + histo_.first->GetBinWidth(ibin+1) / 2.;
-    float contents = histo_.first->GetBinContent(ibin+1);
-    //float errors = histo_.first->GetBinError(ibin+1);
-    if ( contents ) { 
-      if ( contents > max_contents ) { anal->mode_ = contents; max_contents = contents; }
-      if ( value > max_value ) { max_value = value; }
-      if ( value < anal->min_ ) { anal->min_ = value; }
-      sum += value * contents;
-      sum2 += value * contents* value * contents;
-      median.insert( median.end(), static_cast<uint32_t>(contents), value );
-    }
-    anal->entries_ += contents;
-  }
-  
-  // Max
-  if ( max_value > -1. * sistrip::maximum_ ) { anal->max_ = max_value; }
+  /// pedestal
+  TProfile* peds_histo  = dynamic_cast<TProfile*>(hPeds_.first);
+  TProfile* noise_histo = dynamic_cast<TProfile*>(hNoise_.first);
+  /// scope-mode profile
+  TProfile* scope_histo = dynamic_cast<TProfile*>(histo_.first);
 
-  // Median
-  sort( median.begin(), median.end() );
-  if ( !median.empty() ) { anal->median_ = median[ median.size()%2 ? median.size()/2 : median.size()/2 ]; }
-  
-  // Mean, rms
-  if ( anal->entries_ ) { 
-    sum /= static_cast<float>(anal->entries_);
-    sum2 /= static_cast<float>(anal->entries_);
-    anal->mean_ = sum;
-    if (  sum2 > sum*sum ) { anal->rms_ = sqrt( sum2 - sum*sum ); }
+  if ( !peds_histo ) {
+    anal->addErrorCode(sistrip::nullPtr_);
+    return;
   }
-  
+
+  if ( !noise_histo ) {
+    anal->addErrorCode(sistrip::nullPtr_);
+    return;
+  }
+
+  if ( !scope_histo ) {
+    anal->addErrorCode(sistrip::nullPtr_);
+    return;
+  }
+
+  if ( peds_histo->GetNbinsX() != 256 ) {
+    anal->addErrorCode(sistrip::numberOfBins_);
+    return;
+  }
+
+  if ( noise_histo->GetNbinsX() != 256 ) {
+    anal->addErrorCode(sistrip::numberOfBins_);
+    return;
+  }
+
+  if ( scope_histo->GetNbinsX() != 298 ) {
+    anal->addErrorCode(sistrip::numberOfBins_);
+    return;
+  }
+
+  // Calculate pedestals and noise
+  // Iterate through APVs 
+  for ( uint16_t iapv = 0; iapv < 2; iapv++ ) {
+    
+    // Used to calc mean and rms for peds and noise
+    float p_sum = 0., p_sum2 = 0., p_max = -1.*sistrip::invalid_, p_min = sistrip::invalid_;
+    float n_sum = 0., n_sum2 = 0., n_max = -1.*sistrip::invalid_, n_min = sistrip::invalid_;
+    float r_sum = 0., r_sum2 = 0., r_max = -1.*sistrip::invalid_, r_min = sistrip::invalid_;
+    
+    // Iterate through strips of APV
+    for ( uint16_t istr = 0; istr < 128; istr++ ) {      
+      uint16_t strip = iapv*128 + istr;
+      
+      // Pedestals and raw noise
+      if ( peds_histo ) {
+	if ( peds_histo->GetBinEntries(strip+1) ) {
+	  anal->peds_[iapv][istr] = peds_histo->GetBinContent(strip+1);
+	  p_sum  += anal->peds_[iapv][istr];
+	  p_sum2 += (anal->peds_[iapv][istr] * anal->peds_[iapv][istr]);
+	  if ( anal->peds_[iapv][istr] > p_max ) { p_max = anal->peds_[iapv][istr]; }
+	  if ( anal->peds_[iapv][istr] < p_min ) { p_min = anal->peds_[iapv][istr]; }
+
+	  anal->raw_[iapv][istr] = peds_histo->GetBinError(strip+1);
+	  r_sum  += anal->raw_[iapv][istr];
+	  r_sum2 += (anal->raw_[iapv][istr] * anal->raw_[iapv][istr]);
+	  if ( anal->raw_[iapv][istr] > r_max ) { r_max = anal->raw_[iapv][istr]; }
+	  if ( anal->raw_[iapv][istr] < r_min ) { r_min = anal->raw_[iapv][istr]; }
+	}
+      }
+      
+      // Noise
+      if ( noise_histo ) {
+	if ( noise_histo->GetBinEntries(strip+1) ) {
+	  anal->noise_[iapv][istr] = noise_histo->GetBinContent(strip+1);
+	  n_sum  += anal->noise_[iapv][istr];
+	  n_sum2 += (anal->noise_[iapv][istr] * anal->noise_[iapv][istr]);
+	  if ( anal->noise_[iapv][istr] > n_max ) { n_max = anal->noise_[iapv][istr]; }
+	  if ( anal->noise_[iapv][istr] < n_min ) { n_min = anal->noise_[iapv][istr]; }
+	}
+      }      
+    } // strip loop
+    
+    // Calc mean and rms for peds
+    if (!anal->peds_[iapv].empty()) { 
+      p_sum  /= static_cast<float>( anal->peds_[iapv].size() );
+      p_sum2 /= static_cast<float>( anal->peds_[iapv].size() );
+      anal->pedsMean_[iapv] = p_sum;
+      anal->pedsSpread_[iapv] = sqrt( fabs(p_sum2 - p_sum*p_sum) );
+    }
+    
+    // Calc mean and rms for noise
+    if ( !anal->noise_[iapv].empty() ) { 
+      n_sum /= static_cast<float>( anal->noise_[iapv].size() );
+      n_sum2 /= static_cast<float>( anal->noise_[iapv].size() );
+      anal->noiseMean_[iapv] = n_sum;
+      anal->noiseSpread_[iapv] = sqrt( fabs(n_sum2 - n_sum*n_sum) );
+    }
+
+    // Calc mean and rms for raw noise
+    if ( !anal->raw_[iapv].empty() ) { 
+      r_sum /= static_cast<float>( anal->raw_[iapv].size() );
+      r_sum2 /= static_cast<float>( anal->raw_[iapv].size() );
+      anal->rawMean_[iapv] = r_sum;
+      anal->rawSpread_[iapv] = sqrt( fabs(r_sum2 - r_sum*r_sum) );
+    }
+
+    // Set max and min values for peds, noise and raw noise
+    if ( p_max > -1.*sistrip::maximum_ ) { anal->pedsMax_[iapv] = p_max; }
+    if ( p_min < 1.*sistrip::maximum_ )  { anal->pedsMin_[iapv] = p_min; }
+    if ( n_max > -1.*sistrip::maximum_ ) { anal->noiseMax_[iapv] = n_max; }
+    if ( n_min < 1.*sistrip::maximum_ )  { anal->noiseMin_[iapv] = n_min; }
+    if ( r_max > -1.*sistrip::maximum_ ) { anal->rawMax_[iapv] = r_max; }
+    if ( r_min < 1.*sistrip::maximum_ )  { anal->rawMin_[iapv] = r_min; }
+
+    // Set dead and noisy strips
+    for ( uint16_t istr = 0; istr < 128; istr++ ) {
+      if ( anal->noiseMin_[iapv] > sistrip::maximum_ ||
+	   anal->noiseMax_[iapv] > sistrip::maximum_ ) { continue; }
+      if ( anal->noise_[iapv][istr] < ( anal->noiseMean_[iapv] - deadStripMax_ * anal->noiseSpread_[iapv] ) ) {
+	anal->dead_[iapv].push_back(istr);
+      } 
+      else if ( anal->noise_[iapv][istr] > ( anal->noiseMean_[iapv] + noisyStripMin_ * anal->noiseSpread_[iapv] ) ) {
+	anal->noisy_[iapv].push_back(istr);
+      }
+    }   
+  } // apv loop
+
+  //// Tick-Mark --> just store values and check if the height is significant
+  anal->peak_ = (scope_histo->GetBinContent(287)+scope_histo->GetBinContent(288))/2.; // trailing tickmark for each APV
+  anal->base_ = (scope_histo->GetBinContent(1)+scope_histo->GetBinContent(2)+scope_histo->GetBinContent(3)+scope_histo->GetBinContent(4)+scope_histo->GetBinContent(5))/5.;
+  anal->height_ = anal->peak_-anal->base_;
+  if ( anal->height_ < DaqScopeModeAnalysis::tickMarkHeightThreshold_ ) {
+    anal->addErrorCode(sistrip::smallTickMarkHeight_);
+    return; 
+  }    
 }

--- a/DQM/SiStripCommissioningClients/data/summary.xml
+++ b/DQM/SiStripCommissioningClients/data/summary.xml
@@ -95,52 +95,27 @@
 
 <RunType name="PedsFullNoise">
 
-<SummaryPlot monitorable="StripPedestals" presentation="Histo1D" level="SiStrip/ControlView"  granularity=""/>
-<SummaryPlot monitorable="StripPedestals" presentation="Profile1D" level="SiStrip/ControlView"  granularity="CcuChan"/>
-<SummaryPlot monitorable="StripPedestals" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
-
+<SummaryPlot monitorable="StripPedestals" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
 <SummaryPlot monitorable="StripNoise" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="StripNoise" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
-<SummaryPlot monitorable="StripNoise" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
-
-<SummaryPlot monitorable="NoiseMean" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NoiseRmsSpread" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
 <SummaryPlot monitorable="NoiseMin" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
 <SummaryPlot monitorable="NoiseMax" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
 
-<SummaryPlot monitorable="PedestalMean" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="PedestalRmsSpread" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="PedestalMax" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="PedestalMin" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-
 <SummaryPlot monitorable="NumOfDeadStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NumOfBadStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NumOfBadADProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NumOfBadKSProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NumOfBadJBProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NumOfBadChi2ProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NumOfBadShfitedStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NumOfBadLowNoiseStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NumOfBadLargeNoiseStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NumOfBadLargeNoiseSignificanceStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NumOfBadTailStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NumOfBadFitStatusStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NumOfBadDoublePeakStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NumOfNoisyStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
 
-<SummaryPlot monitorable="deadStripBit" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="badStripBit" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="adProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="ksProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="jbProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="chi2ProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="residualRMSStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="residualSigmaGausStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="noiseSignificanceStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="residualMeanStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="residualSkewnessStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="residualKurtosisStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="residualIntegralNsigmaStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="residualIntegralStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="StripPedestals" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="StripNoise" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+
+<SummaryPlot monitorable="StripPedestals" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="StripNoise" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+
+<SummaryPlot monitorable="StripNoiseKS" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
+<SummaryPlot monitorable="StripNoiseGaus" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
+<SummaryPlot monitorable="StripNoiseBin84" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
+<SummaryPlot monitorable="StripNoiseRMS" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
+<SummaryPlot monitorable="StripNoiseChi2" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
+<SummaryPlot monitorable="StripNoiseSignif" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
+<SummaryPlot monitorable="NoiseRmsSpread" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
 </RunType>
 
 <RunType name="Noise">
@@ -203,6 +178,30 @@
 
 <SummaryPlot monitorable="CalibrationTail" presentation="Profile1D" level="SiStrip/ControlView" granularity="Apv"/>
 <SummaryPlot monitorable="CalibrationRiseTime" presentation="Profile1D" level="SiStrip/ControlView" granularity="Apv"/>
+
+</RunType>
+
+<RunType name="DaqScopeMode">
+
+<SummaryPlot monitorable="StripPedestals" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="StripNoise" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NoiseMin" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NoiseMax" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+
+<SummaryPlot monitorable="NumOfDeadStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NumOfNoisyStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+
+<SummaryPlot monitorable="StripPedestals" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="StripNoise" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+
+<SummaryPlot monitorable="StripPedestals" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="StripNoise" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+
+<SummaryPlot monitorable="TickMarkHeight" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+
+<SummaryPlot monitorable="TickMarkHeight" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+
+<SummaryPlot monitorable="TickMarkHeight" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
 
 </RunType>
 

--- a/DQM/SiStripCommissioningClients/data/summary.xml
+++ b/DQM/SiStripCommissioningClients/data/summary.xml
@@ -96,26 +96,74 @@
 <RunType name="PedsFullNoise">
 
 <SummaryPlot monitorable="StripPedestals" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="StripNoise" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NoiseMin" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NoiseMax" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="StripNoise"     presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NoiseMin"       presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NoiseMax"       presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NoiseMean"      presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NoiseRmsSpread" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
 
 <SummaryPlot monitorable="NumOfDeadStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
-<SummaryPlot monitorable="NumOfNoisyStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NumOfBadStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NumOfBadADProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NumOfBadJBProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NumOfBadChi2ProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NumOfBadShfitedStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NumOfBadLowNoiseStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NumOfBadLargeNoiseStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NumOfBadLargeNoiseSignificanceStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NumOfBadTailStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NumOfBadFitStatusStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="NumOfBadDoublePeakStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+
+<SummaryPlot monitorable="badStripBit" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="deadStripBit" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="adProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="ksProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="jbProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="chi2ProbabStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="residualRMSStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="residualSigmaGausStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="noiseSignificanceStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="residualMeanStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="residualSkewnessStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="residualKurtosisStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="residualIntegralNsigmaStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
+<SummaryPlot monitorable="residualIntegralStrips" presentation="Histo1D" level="SiStrip/ControlView" granularity=""/>
 
 <SummaryPlot monitorable="StripPedestals" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
 <SummaryPlot monitorable="StripNoise" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="badStripBit" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="deadStripBit" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="adProbabStrips" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="ksProbabStrips" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="jbProbabStrips" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="chi2ProbabStrips" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualRMSStrips" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualSigmaGausStrips" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="noiseSignificanceStrips" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualMeanStrips" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualSkewnessStrips" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualKurtosisStrips" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualIntegralNsigmaStrips" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualIntegralStrips" presentation="Histo2DScatter" level="SiStrip/ControlView" granularity="CcuChan"/>
 
 <SummaryPlot monitorable="StripPedestals" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
 <SummaryPlot monitorable="StripNoise" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
-
-<SummaryPlot monitorable="StripNoiseKS" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
-<SummaryPlot monitorable="StripNoiseGaus" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
-<SummaryPlot monitorable="StripNoiseBin84" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
-<SummaryPlot monitorable="StripNoiseRMS" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
-<SummaryPlot monitorable="StripNoiseChi2" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
-<SummaryPlot monitorable="StripNoiseSignif" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
-<SummaryPlot monitorable="NoiseRmsSpread" presentation="Histo1D" level="SiStrip/ControlView" granularity="LldChannel"/>
+<SummaryPlot monitorable="deadStripBit" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="badStripBit" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="adProbabStrips" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="ksProbabStrips" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="jbProbabStrips" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="chi2ProbabStrips" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualRMSStrips" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualSigmaGausStrips" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="noiseSignificanceStrips" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualMeanStrips" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualSkewnessStrips" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualKurtosisStrips" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualIntegralNsigmaStrips" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+<SummaryPlot monitorable="residualIntegralStrips" presentation="Profile1D" level="SiStrip/ControlView" granularity="CcuChan"/>
+ 
 </RunType>
 
 <RunType name="Noise">

--- a/DQM/SiStripCommissioningClients/interface/CommissioningHistograms.h
+++ b/DQM/SiStripCommissioningClients/interface/CommissioningHistograms.h
@@ -102,8 +102,10 @@ class CommissioningHistograms {
   
   void remove( std::string pattern = "" ); 
   
+
   void save( std::string& filename,
-	     uint32_t run_number = 0 ); 
+             uint32_t run_number = 0,
+             std::string partitionName = "");
 
   // ---------- protected methods ----------
   

--- a/DQM/SiStripCommissioningClients/interface/DaqScopeModeHistograms.h
+++ b/DQM/SiStripCommissioningClients/interface/DaqScopeModeHistograms.h
@@ -2,37 +2,20 @@
 #define DQM_SiStripCommissioningClients_DaqScopeModeHistograms_H
 
 #include "DQM/SiStripCommissioningClients/interface/CommissioningHistograms.h"
-#include "DQM/SiStripCommissioningSummary/interface/DaqScopeModeSummaryFactory.h"
-#include "CondFormats/SiStripObjects/interface/DaqScopeModeAnalysis.h"
-
 
 class DQMStore;
 
-class DaqScopeModeHistograms : public CommissioningHistograms {
+class DaqScopeModeHistograms : public virtual CommissioningHistograms {
 
  public:
   
   DaqScopeModeHistograms( const edm::ParameterSet& pset, DQMStore* );
-  ~DaqScopeModeHistograms() override;
+  virtual ~DaqScopeModeHistograms();
   
-  typedef SummaryHistogramFactory<DaqScopeModeAnalysis> Factory;
-  
-  /** */
-  void histoAnalysis( bool debug ) override;
+  void histoAnalysis( bool debug );
 
-  /** */
-  void createSummaryHisto( const sistrip::Monitorable&,
-			   const sistrip::Presentation&,
-			   const std::string& top_level_dir,
-			   const sistrip::Granularity& ) override;
-  
- protected: 
-  
-  std::map<uint32_t,DaqScopeModeAnalysis> data_;
-  
-  std::auto_ptr<Factory> factory_;
-  
+  void printAnalyses(); // override
+
 };
 
 #endif // DQM_SiStripCommissioningClients_DaqScopeModeHistograms_H
-

--- a/DQM/SiStripCommissioningClients/interface/DaqScopeModeHistograms.h
+++ b/DQM/SiStripCommissioningClients/interface/DaqScopeModeHistograms.h
@@ -10,11 +10,11 @@ class DaqScopeModeHistograms : public virtual CommissioningHistograms {
  public:
   
   DaqScopeModeHistograms( const edm::ParameterSet& pset, DQMStore* );
-  virtual ~DaqScopeModeHistograms();
+  ~DaqScopeModeHistograms() override;
   
-  void histoAnalysis( bool debug );
+  void histoAnalysis( bool debug ) override;
 
-  void printAnalyses(); // override
+  void printAnalyses() override; // override
 
 };
 

--- a/DQM/SiStripCommissioningClients/interface/SiStripCommissioningOfflineClient.h
+++ b/DQM/SiStripCommissioningClients/interface/SiStripCommissioningOfflineClient.h
@@ -41,7 +41,7 @@ class SiStripCommissioningOfflineClient : public edm::EDAnalyzer {
 
   virtual void createHistos( const edm::ParameterSet&, const edm::EventSetup& );
   virtual void uploadToConfigDb() {;}
-  virtual void setInputFiles( std::vector<std::string>&, const std::string, uint32_t, bool );
+  virtual void setInputFiles( std::vector<std::string>&, const std::string, const std::string, uint32_t, bool );
   
  protected:
 
@@ -80,6 +80,9 @@ class SiStripCommissioningOfflineClient : public edm::EDAnalyzer {
   
   /** Run number. */
   uint32_t runNumber_;
+
+  /** Partition Name */
+  std::string partitionName_ ;
 
   /** */
   typedef std::vector<TH1*> Histos;

--- a/DQM/SiStripCommissioningClients/src/CommissioningHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/CommissioningHistograms.cc
@@ -680,7 +680,8 @@ void CommissioningHistograms::remove( std::string pattern ) {
 // -----------------------------------------------------------------------------
 /** */
 void CommissioningHistograms::save( std::string& path,
-				    uint32_t run_number ) {
+				    uint32_t run_number,
+				    std::string partitionName) {
   
   // Construct path and filename
   std::stringstream ss; 
@@ -702,12 +703,17 @@ void CommissioningHistograms::save( std::string& path,
     // Add directory path 
     if ( !dir.empty() ) { ss << dir << "/"; }
     else { ss << "/tmp/"; }
-    
-    // Add filename with run number and ".root" extension
-    ss << sistrip::dqmClientFileName_ << "_" 
-       << std::setfill('0') << std::setw(8) << run_number
-       << ".root";
-    
+
+    // Add filename with run number and ".root" extension                                                                                                                                       
+    if(partitionName.empty())
+      ss << sistrip::dqmClientFileName_ << "_"
+         << std::setfill('0') << std::setw(8) << run_number
+         << ".root";
+    else
+      ss << sistrip::dqmClientFileName_ << "_" << partitionName << "_"
+         << std::setfill('0') << std::setw(8) << run_number
+         << ".root";
+        
   }
   
   // Save file with appropriate filename

--- a/DQM/SiStripCommissioningClients/src/DaqScopeModeHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/DaqScopeModeHistograms.cc
@@ -2,6 +2,7 @@
 #include "CondFormats/SiStripObjects/interface/DaqScopeModeAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "DataFormats/SiStripCommon/interface/SiStripEnumsAndStrings.h"
+#include "DQM/SiStripCommissioningSummary/interface/DaqScopeModeSummaryFactory.h"
 #include "DQM/SiStripCommissioningAnalysis/interface/DaqScopeModeAlgorithm.h"
 #include "DQM/SiStripCommissioningSummary/interface/SummaryGenerator.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -18,94 +19,118 @@ DaqScopeModeHistograms::DaqScopeModeHistograms( const edm::ParameterSet& pset,
                                                 DQMStore* bei ) 
   : CommissioningHistograms( pset.getParameter<edm::ParameterSet>("DaqScopeModeParameters"),
                              bei,
-                             sistrip::DAQ_SCOPE_MODE ),
-    factory_( new Factory )
+                             sistrip::DAQ_SCOPE_MODE )
 {
-  cout << endl // LogTrace(mlDqmClient_) 
-       << "[DaqScopeModeHistograms::" << __func__ << "]"
-       << " Constructing object...";
+
+  factory_ = auto_ptr<DaqScopeModeSummaryFactory>( new DaqScopeModeSummaryFactory );
+  LogTrace(mlDqmClient_)
+    << "[DaqScopeModeHistograms::" << __func__ << "]"
+    << " Constructing object...";
+
 }
 
 // -----------------------------------------------------------------------------
 /** */
 DaqScopeModeHistograms::~DaqScopeModeHistograms() {
-  cout << endl // LogTrace(mlDqmClient_) 
-       << "[DaqScopeModeHistograms::" << __func__ << "]"
-       << " Constructing object...";
+  LogTrace(mlDqmClient_)
+    << "[DaqScopeModeHistograms::" << __func__ << "]"
+    << " Destructing object...";
 }
 
 // -----------------------------------------------------------------------------	 
 /** */	 
 void DaqScopeModeHistograms::histoAnalysis( bool debug ) {
 
-  // Clear std::map holding analysis objects
-  data_.clear();
+  LogTrace(mlDqmClient_)
+    << "[DaqScopeModeHistograms::" << __func__ << "]";
+
+  // Some initialisation                                                                                                                                                                            
+  uint16_t valid = 0;
+  HistosMap::const_iterator iter;
+  Analyses::iterator ianal;
+  std::map<std::string,uint16_t> errors;
+
+  // Clear map holding analysis objects                                                                                                                                                   
+  for ( ianal = data().begin(); ianal != data().end(); ianal++ ) {
+    if ( ianal->second ) { delete ianal->second; }
+  }
+  data().clear();
+
+  // Iterate through map containing histograms                                                                                                                                                        
+  for ( iter = histos().begin();
+        iter != histos().end(); iter++ ) {
+    
+    // Check vector of histos is not empty                                                                                                                                                            
+    if ( iter->second.empty() ) {
+      edm::LogWarning(mlDqmClient_)
+        << "[DaqScopeModeHistograms::" << __func__ << "]"
+        << " Zero histograms found!";
+      continue;
+    }
+    
+    // Retrieve pointers to profile histos                                                                                                                                                             
+    std::vector<TH1*> profs;
+    Histos::const_iterator ihis = iter->second.begin();
+    for ( ; ihis != iter->second.end(); ihis++ ) {
+      TProfile* prof = ExtractTObject<TProfile>().extract( (*ihis)->me_ );
+      if ( prof ) 
+	profs.push_back(prof);
+    }
+
+    // Perform histo analysis                                                                                                                                                                          
+    DaqScopeModeAnalysis* anal = new DaqScopeModeAnalysis( iter->first );
+    DaqScopeModeAlgorithm algo( this->pset(), anal );
+    algo.analysis( profs );
+    data()[iter->first] = anal;
   
-//   // Iterate through std::map containing std::vectors of profile histograms
-//   CollationsMap::const_iterator iter = collations().begin();
-//   for ( ; iter != collations().end(); iter++ ) {
-    
-//     // Check std::vector of histos is not empty (should be 1 histo)
-//     if ( iter->second.empty() ) {
-//       edm::LogWarning(mlDqmClient_) 
-// 	<< "[DaqScopeModeHistograms::" << __func__ << "]"
-// 	<< " Zero collation histograms found!";
-//       continue;
-//     }
-    
-//     // Retrieve pointers to profile histos for this FED channel 
-//     std::vector<TH1*> histos;
-//     Collations::const_iterator ihis = iter->second.begin(); 
-//     for ( ; ihis != iter->second.end(); ihis++ ) {
-//       TH1F* his = ExtractTObject<TH1F>().extract( ihis->second->getMonitorElement() );
-//       if ( his ) { histos.push_back(his); }
-//     } 
-    
-//     // Perform histo analysis
-//     DaqScopeModeAnalysis anal( iter->first );
-//     DaqScopeModeAlgorithm algo( &anal );
-//     algo.analysis( histos );
-//     data_[iter->first] = anal; 
-//     if ( debug ) {
-//       std::stringstream ss;
-//       anal.print( ss ); 
-//       cout << ss.str() << endl;
-//     }
-    
-//   }
+    if ( anal->isValid() ) { valid++; }
+    if ( !anal->getErrorCodes().empty() ) {
+      errors[anal->getErrorCodes()[0]]++;
+    }
+  }
   
-//   cout << endl // LogTrace(mlDqmClient_) 
-//        << "[DaqScopeModeHistograms::" << __func__ << "]"
-//        << " Analyzed histograms for " 
-//        << collations().size() 
-//        << " FED channels";
-  
+  if ( !histos().empty() ) {
+    edm::LogVerbatim(mlDqmClient_)
+      << "[DaqScopeModeHistograms::" << __func__ << "]"
+      << " Analyzed histograms for " << histos().size()
+      << " FED channels, of which " << valid
+      << " (" << 100 * valid / histos().size()
+      << "%) are valid.";      
+    if ( !errors.empty() ) {	
+      uint16_t count = 0;
+      std::stringstream ss;
+      ss << std::endl;
+      std::map<std::string,uint16_t>::const_iterator ii;
+      for ( ii = errors.begin(); ii != errors.end(); ++ii ) {
+	ss << " " << ii->first << ": " << ii->second << std::endl;
+	count += ii->second;
+      }
+      edm::LogWarning(mlDqmClient_)
+	<< "[DaqScopeModeHistograms::" << __func__ << "]"
+	<< " Found " << count << " errors ("
+	<< 100 * count / histos().size() << "%): "
+	<< ss.str();
+    }      
+  } else {
+    edm::LogWarning(mlDqmClient_)
+      << "[DaqScopeModeHistograms::" << __func__ << "]"
+      << " No histograms to analyze!";
+  }
 }
 
-// -----------------------------------------------------------------------------
-/** */
-void DaqScopeModeHistograms::createSummaryHisto( const sistrip::Monitorable& histo, 
-						 const sistrip::Presentation& type, 
-						 const std::string& directory,
-						 const sistrip::Granularity& gran ) {
-  cout << endl // LogTrace(mlDqmClient_)
-       << "[DaqScopeModeHistograms::" << __func__ << "]";
-  
-  // Check view 
-  sistrip::View view = SiStripEnumsAndStrings::view(directory);
-  if ( view == sistrip::UNKNOWN_VIEW ) { return; }
-
-  // Analyze histograms
-  histoAnalysis( false );
-
-  // Extract data to be histogrammed
-  factory_->init( histo, type, view, directory, gran );
-  uint32_t xbins = factory_->extract( data_ );
-
-  // Create summary histogram (if it doesn't already exist)
-  TH1* summary = histogram( histo, type, view, directory, xbins );
-
-  // Fill histogram with data
-  factory_->fill( *summary );
-  
+// -----------------------------------------------------------------------------                                                                                                              
+void DaqScopeModeHistograms::printAnalyses() {
+  Analyses::iterator ianal = data().begin();
+  Analyses::iterator janal = data().end();
+  for ( ; ianal != janal; ++ianal ) {
+    if ( ianal->second ) {
+      std::stringstream ss;
+      ianal->second->print( ss, 1 );
+      ianal->second->print( ss, 2 );
+      if ( ianal->second->isValid() ) { LogTrace(mlDqmClient_) << ss.str();
+      }
+      else { edm::LogWarning(mlDqmClient_) << ss.str(); }
+    }
+  }
 }
+

--- a/DQM/SiStripCommissioningClients/src/PedsFullNoiseHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/PedsFullNoiseHistograms.cc
@@ -56,6 +56,8 @@ void PedsFullNoiseHistograms::histoAnalysis( bool debug ) {
   data().clear();
 
   // Iterate through map containing histograms
+  long int ichannel = 0;
+  long int nchannel = histos().size();
   for ( iter = histos().begin(); 
 	iter != histos().end(); iter++ ) {
 
@@ -81,6 +83,12 @@ void PedsFullNoiseHistograms::histoAnalysis( bool debug ) {
       if ( his2D ) { 
 	hists.push_back(his2D); }
     }
+
+    if(ichannel % 100 == 0)
+      edm::LogVerbatim(mlDqmClient_)
+	<< "[PedsFullNoiseHistograms::" << __func__ << "]"
+	<< " Analyzing channel " << ichannel << " out of "<<nchannel;
+    ichannel++;
 
     // Perform histo analysis
     PedsFullNoiseAnalysis * anal = new PedsFullNoiseAnalysis( iter->first );

--- a/DQM/SiStripCommissioningClients/src/SiStripCommissioningOfflineClient.cc
+++ b/DQM/SiStripCommissioningClients/src/SiStripCommissioningOfflineClient.cc
@@ -57,7 +57,7 @@ SiStripCommissioningOfflineClient::SiStripCommissioningOfflineClient( const edm:
     << " Constructing object...";
   setInputFiles( inputFiles_,
 		 pset.getUntrackedParameter<std::string>( "FilePath" ),
-		 pset.getParameter<std::string>("PartitionName"),
+		 pset.existsAs<std::string>("PartitionName") ? pset.getParameter<std::string>("PartitionName") : "",
 		 pset.getUntrackedParameter<uint32_t>("RunNumber"), 
 		 collateHistos_ );
 }

--- a/DQM/SiStripCommissioningClients/src/SiStripCommissioningOfflineClient.cc
+++ b/DQM/SiStripCommissioningClients/src/SiStripCommissioningOfflineClient.cc
@@ -14,6 +14,7 @@
 #include "DQM/SiStripCommissioningClients/interface/NoiseHistograms.h"
 #include "DQM/SiStripCommissioningClients/interface/SamplingHistograms.h"
 #include "DQM/SiStripCommissioningClients/interface/CalibrationHistograms.h"
+#include "DQM/SiStripCommissioningClients/interface/DaqScopeModeHistograms.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -46,6 +47,7 @@ SiStripCommissioningOfflineClient::SiStripCommissioningOfflineClient( const edm:
     uploadToDb_( false ), 
     runType_(sistrip::UNKNOWN_RUN_TYPE),
     runNumber_(0),
+    partitionName_(pset.existsAs<std::string>("PartitionName") ? pset.getParameter<std::string>("PartitionName") : ""),
     map_(),
     plots_(),
     parameters_(pset)
@@ -55,6 +57,7 @@ SiStripCommissioningOfflineClient::SiStripCommissioningOfflineClient( const edm:
     << " Constructing object...";
   setInputFiles( inputFiles_,
 		 pset.getUntrackedParameter<std::string>( "FilePath" ),
+		 pset.getParameter<std::string>("PartitionName"),
 		 pset.getUntrackedParameter<uint32_t>("RunNumber"), 
 		 collateHistos_ );
 }
@@ -333,7 +336,12 @@ void SiStripCommissioningOfflineClient::beginRun( const edm::Run& run, const edm
   // Save client root file
   if ( histos_ ) {
     bool save = parameters_.getUntrackedParameter<bool>( "SaveClientFile", true );
-    if ( save ) { histos_->save( outputFileName_, runNumber_ ); }
+    if ( save ) { 
+      if(runType_ != sistrip::DAQ_SCOPE_MODE)
+	histos_->save( outputFileName_, runNumber_ ); 
+      else
+	histos_->save( outputFileName_, runNumber_, partitionName_); 
+    }
     else {
       edm::LogVerbatim(mlDqmClient_)
 	<< "[SiStripCommissioningOfflineClient::" << __func__ << "]"
@@ -411,6 +419,7 @@ void SiStripCommissioningOfflineClient::createHistos( const edm::ParameterSet& p
 	    runType_ == sistrip::CALIBRATION_DECO ||
 	    runType_ == sistrip::CALIBRATION_SCAN ||
 	    runType_ == sistrip::CALIBRATION_SCAN_DECO) { histos_ = new CalibrationHistograms( pset, bei_,runType_ ); }
+  else if ( runType_ == sistrip::DAQ_SCOPE_MODE)        { histos_ = new DaqScopeModeHistograms( pset, bei_);}
   else if ( runType_ == sistrip::UNDEFINED_RUN_TYPE   ) { 
     histos_ = nullptr; 
     edm::LogError(mlDqmClient_)
@@ -431,6 +440,7 @@ void SiStripCommissioningOfflineClient::createHistos( const edm::ParameterSet& p
 // 
 void SiStripCommissioningOfflineClient::setInputFiles( std::vector<std::string>& files,
 						       const std::string path,
+						       const std::string partitionName,
 						       uint32_t run_number, 
 						       bool collate_histos ) {
 
@@ -462,8 +472,13 @@ void SiStripCommissioningOfflineClient::setInputFiles( std::vector<std::string>&
     bool goodName = ( fileName.find(nameStr) != std::string::npos );
     bool goodRun  = ( fileName.find(runStr) != std::string::npos );
     bool rootFile = ( fileName.find(".root") != std::string::npos );
+    bool goodPartition = true;
+    if(not partitionName.empty()){
+      goodPartition = ( fileName.find(partitionName) != std::string::npos );
+    }
+
     //bool rootFile = ( fileName.rfind(".root",5) == fileName.size()-5 );
-    if ( goodName && goodRun && rootFile ) {
+    if ( goodName && goodRun && rootFile && goodPartition ){
       std::string entry = path;
       entry += "/";
       entry += fileName;

--- a/DQM/SiStripCommissioningDbClients/interface/DaqScopeModeHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/DaqScopeModeHistosUsingDb.h
@@ -1,0 +1,41 @@
+#ifndef DQM_SiStripCommissioningClients_DaqScopeModeHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_DaqScopeModeHistosUsingD_H
+
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+#include "DQM/SiStripCommissioningClients/interface/DaqScopeModeHistograms.h"
+
+class DaqScopeModeHistosUsingDb : public CommissioningHistosUsingDb, public DaqScopeModeHistograms {
+  
+ public:
+  
+  DaqScopeModeHistosUsingDb( const edm::ParameterSet & pset,
+			     DQMStore*,
+			     SiStripConfigDb* const );
+  
+  ~DaqScopeModeHistosUsingDb() override;
+  
+  void uploadConfigurations() override;
+  
+ private:
+
+
+  void update( SiStripConfigDb::FedDescriptionsRange ); 
+  void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis ) override;
+
+  // parameters for pedestal measurement
+  float highThreshold_;
+  float lowThreshold_;
+  bool  disableBadStrips_;
+  bool  keepStripsDisabled_;
+
+  // selective upload
+  bool  allowSelectiveUpload_;    
+  // switch for uploading the pll thresholds                                                                                                                                                           
+  bool skipPedestalUpdate_;
+  // switch for uploading the frame finding thresholds                                                                                                                                                 
+  bool skipTickUpdate_;
+ 
+};
+
+#endif // DQM_SiStripCommissioningClients_DaqScopeModeHistosUsingDb_H
+

--- a/DQM/SiStripCommissioningDbClients/plugins/SiStripCommissioningOfflineDbClient.cc
+++ b/DQM/SiStripCommissioningDbClients/plugins/SiStripCommissioningOfflineDbClient.cc
@@ -11,6 +11,7 @@
 #include "DQM/SiStripCommissioningDbClients/interface/PedsOnlyHistosUsingDb.h"
 #include "DQM/SiStripCommissioningDbClients/interface/NoiseHistosUsingDb.h"
 #include "DQM/SiStripCommissioningDbClients/interface/PedsFullNoiseHistosUsingDb.h"
+#include "DQM/SiStripCommissioningDbClients/interface/DaqScopeModeHistosUsingDb.h"
 #include "DQM/SiStripCommissioningDbClients/interface/LatencyHistosUsingDb.h"
 #include "DQM/SiStripCommissioningDbClients/interface/FineDelayHistosUsingDb.h"
 #include "DQM/SiStripCommissioningDbClients/interface/CalibrationHistosUsingDb.h"
@@ -109,6 +110,7 @@ void SiStripCommissioningOfflineDbClient::createHistos( const edm::ParameterSet&
             runType_ == sistrip::CALIBRATION_SCAN ||
             runType_ == sistrip::CALIBRATION_SCAN_DECO)
                                                 { histos_ = new CalibrationHistosUsingDb( pset, bei_, db, runType_ ); }
+  else if ( runType_ == sistrip::DAQ_SCOPE_MODE) {histos_ = new DaqScopeModeHistosUsingDb( pset, bei_, db);}
   else if ( runType_ == sistrip::UNDEFINED_RUN_TYPE ) { 
     histos_ = nullptr; 
     edm::LogError(mlDqmClient_)

--- a/DQM/SiStripCommissioningDbClients/python/OfflineDbClient_cff.py
+++ b/DQM/SiStripCommissioningDbClients/python/OfflineDbClient_cff.py
@@ -17,7 +17,16 @@ db_client = cms.EDAnalyzer("SiStripCommissioningOfflineDbClient",
     TargetDelay = cms.int32(-1)       # -1: latest tick (old default), otherwise target delay for all ticks' rising edge
   ),
   CalibrationParameters    = cms.PSet(),
-  DaqScopeModeParameters   = cms.PSet(),
+  DaqScopeModeParameters   = cms.PSet(
+        HighThreshold       = cms.double(5),
+        LowThreshold        = cms.double(2),
+        DisableBadStrips    = cms.bool(False),
+        DeadStripMax        = cms.double(10),
+        NoisyStripMin       = cms.double(10),
+        KeepsStripsDisabled = cms.bool(False),
+        SkipPedestalUpdate  = cms.bool(False),
+        SkipTickUpdate  = cms.bool(False)
+        ),
   FastFedCablingParameters = cms.PSet(),
   FedCablingParameters     = cms.PSet(),
   FedTimingParameters      = cms.PSet(),

--- a/DQM/SiStripCommissioningDbClients/python/SiStripCommissioningClient_cfg.py
+++ b/DQM/SiStripCommissioningDbClients/python/SiStripCommissioningClient_cfg.py
@@ -1,0 +1,69 @@
+import FWCore.ParameterSet.Config as cms
+import os,sys,getopt,glob,cx_Oracle,subprocess
+
+conn_str = os.path.expandvars("$CONFDB")
+conn     = cx_Oracle.connect(conn_str)
+e        = conn.cursor()
+e.execute('select RUNMODE from run where runnumber = RUNNUMBER')
+runmode = e.fetchall()
+runtype = -1;
+for result in runmode:
+    runtype = int(result[0]);
+conn.close()
+
+process = cms.Process("SiStripCommissioningOfflineDbClient")
+
+process.load("DQM.SiStripCommon.MessageLogger_cfi")
+
+process.load("DQM.SiStripCommon.DaqMonitorROOTBackEnd_cfi")
+
+process.load("OnlineDB.SiStripConfigDb.SiStripConfigDb_cfi")
+process.SiStripConfigDb.UsingDb = True                                            # true means use database (not xml files)
+process.SiStripConfigDb.ConfDb  = 'overwritten/by@confdb'                         # database connection account ( or use CONFDB env. var.)
+process.SiStripConfigDb.Partitions.PrimaryPartition.PartitionName = 'DBPART'      # database partition (or use ENV_CMS_TK_PARTITION env. var.)
+process.SiStripConfigDb.Partitions.PrimaryPartition.RunNumber     = RUNNUMBER     # specify run number ("0" means use major/minor versions, which are by default set to "current state")
+process.SiStripConfigDb.TNS_ADMIN = '/etc'                                        # location of tnsnames.ora, needed at P5, not in TAC
+#process.SiStripConfigDb.Partitions.PrimaryPartition.ForceCurrentState = cms.untracked.bool(True)
+
+process.source = cms.Source("EmptySource") 
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(2) ) 
+
+process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
+process.load("Geometry.TrackerNumberingBuilder.trackerTopology_cfi")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+
+process.load("DQM.SiStripCommissioningDbClients.OfflineDbClient_cff")
+process.db_client.FilePath         = cms.untracked.string('DATALOCATION')
+process.db_client.RunNumber        = cms.untracked.uint32(RUNNUMBER)
+process.db_client.UseClientFile    = cms.untracked.bool(CLIENTFLAG)
+process.db_client.UploadHwConfig   = cms.untracked.bool(DBUPDATE)
+process.db_client.UploadAnalyses   = cms.untracked.bool(ANALUPDATE)
+process.db_client.DisableDevices   = cms.untracked.bool(DISABLEDEVICES)
+process.db_client.DisableBadStrips = cms.untracked.bool(DISABLEBADSTRIPS)
+process.db_client.SaveClientFile   = cms.untracked.bool(SAVECLIENTFILE)
+
+if runtype == 15: ## only needed for spy-channel
+    process.db_client.PartitionName    = cms.string("DBPART")
+
+process.db_client.ApvTimingParameters.SkipFecUpdate = cms.bool(True)
+process.db_client.ApvTimingParameters.SkipFedUpdate = cms.bool(False)
+#process.db_client.ApvTimingParameters.TargetDelay = cms.int32(725)
+process.db_client.ApvTimingParameters.TargetDelay = cms.int32(-1)
+
+process.db_client.OptoScanParameters.SkipGainUpdate = cms.bool(False)
+
+process.db_client.PedestalsParameters.KeepStripsDisabled = cms.bool(True)
+
+process.db_client.DaqScopeModeParameters.DisableBadStrips =  cms.bool(False)
+process.db_client.DaqScopeModeParameters.KeepStripsDisabled = cms.bool(True)
+process.db_client.DaqScopeModeParameters.SkipPedestalUpdate = cms.bool(False)
+process.db_client.DaqScopeModeParameters.SkipTickUpdate = cms.bool(False)
+
+### Bad strip analysis options                                                                                                                                                                         
+process.db_client.PedsFullNoiseParameters.DisableBadStrips   = cms.bool(True) ## if True the code loops over the dead and bad strips identified and will disable them                                  
+process.db_client.PedsFullNoiseParameters.KeepStripsDisabled = cms.bool(True) ## if True, strips that have been already disabled will be kept disabled                                                 
+process.db_client.PedsFullNoiseParameters.UploadOnlyStripBadChannelBit = cms.bool(True) ## if True, only the disable flag will be changed, peds and noise cloned from the previous FED version         
+process.db_client.PedsFullNoiseParameters.SkipEmptyStrips    =  cms.bool(True) ## if True, empty strips (dead) are skipped --> to avoid to flag bad stuff not powered ON                               
+process.db_client.PedsFullNoiseParameters.UploadPedsFullNoiseDBTable  =  cms.bool(False) ## if True, also the pedsfullnoise analysis tables is uploaded                                                
+
+process.p = cms.Path(process.db_client)

--- a/DQM/SiStripCommissioningDbClients/src/CommissioningHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/CommissioningHistosUsingDb.cc
@@ -276,33 +276,13 @@ void CommissioningHistosUsingDb::createAnalyses( SiStripConfigDb::AnalysisDescri
     << " Creating AnalysisDescriptions...";
 
   desc.clear();
-  
-//   uint16_t size = 0;
-//   std::stringstream ss;
-//   ss << "[CommissioningHistosUsingDb::" << __func__ << "]"
-//      << " Analysis descriptions:" << std::endl;
 
   Analyses::iterator ianal = data().begin();
   Analyses::iterator janal = data().end();
   for ( ; ianal != janal; ++ianal ) { 
-
     // create analysis description
-    create( desc, ianal ); 
-    
-//     // debug
-//     if ( ianal->second ) {
-//       if ( desc.size()/2 > size ) { // print every 2nd description
-// 	size = desc.size()/2;
-// 	ianal->second->print(ss); 
-// 	ss << (*(desc.end()-2))->toString();
-// 	ss << (*(desc.end()-1))->toString();
-// 	ss << std::endl;
-//       }
-//     }
-
+    create( desc, ianal );     
   }
-
-//   LogTrace(mlDqmClient_) << ss.str(); 
   
 }
 

--- a/DQM/SiStripCommissioningDbClients/src/DaqScopeModeHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/DaqScopeModeHistosUsingDb.cc
@@ -1,0 +1,409 @@
+#include "DQM/SiStripCommissioningDbClients/interface/DaqScopeModeHistosUsingDb.h"
+#include "CondFormats/SiStripObjects/interface/DaqScopeModeAnalysis.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFedKey.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+DaqScopeModeHistosUsingDb::DaqScopeModeHistosUsingDb( const edm::ParameterSet & pset,
+						      DQMStore* bei,
+						      SiStripConfigDb* const db ) 
+  : CommissioningHistograms( pset.getParameter<edm::ParameterSet>("DaqScopeModeParameters"),
+                             bei,
+                             sistrip::DAQ_SCOPE_MODE ),
+    CommissioningHistosUsingDb( db,
+                                sistrip::DAQ_SCOPE_MODE ),
+    DaqScopeModeHistograms(pset.getParameter<edm::ParameterSet>("DaqScopeModeParameters"),
+    			   bei )
+{
+
+  LogTrace(mlDqmClient_) 
+    << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+    << " Constructing object...";
+  highThreshold_ = this->pset().getParameter<double>("HighThreshold");
+  lowThreshold_ = this->pset().getParameter<double>("LowThreshold");
+  LogTrace(mlDqmClient_)
+    << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+    << " Set FED zero suppression high/low threshold to "
+    << highThreshold_ << "/" << lowThreshold_;
+  disableBadStrips_   = this->pset().getParameter<bool>("DisableBadStrips");
+  keepStripsDisabled_ = this->pset().getParameter<bool>("KeepStripsDisabled");
+  LogTrace(mlDqmClient_)
+    << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+    << " Disabling strips: " << disableBadStrips_
+    << " ; keeping previously disabled strips: " << keepStripsDisabled_;
+  allowSelectiveUpload_ = this->pset().existsAs<bool>("doSelectiveUpload")?this->pset().getParameter<bool>("doSelectiveUpload"):false;
+  LogTrace(mlDqmClient_)
+    << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+    << " Selective upload of modules set to : " << allowSelectiveUpload_;
+
+  skipPedestalUpdate_ =  this->pset().existsAs<bool>("SkipPedestalUpdate")?this->pset().getParameter<bool>("SkipPedestalUpdate"):false;
+  skipTickUpdate_     =  this->pset().existsAs<bool>("SkipTickUpdate")?this->pset().getParameter<bool>("SkipTickUpdate"):false;
+  LogTrace(mlDqmClient_)
+    << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+    << " Perform pedestal upload set to : " <<skipPedestalUpdate_;
+  LogTrace(mlDqmClient_)
+    << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+    << " Perform tick-mark upload set to : " <<skipTickUpdate_;
+}
+
+// -----------------------------------------------------------------------------
+DaqScopeModeHistosUsingDb::~DaqScopeModeHistosUsingDb() {
+  LogTrace(mlDqmClient_) 
+    << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+void DaqScopeModeHistosUsingDb::uploadConfigurations() {
+  LogTrace(mlDqmClient_) 
+    << "[DaqScopeModeHistosUsingDb::" << __func__ << "]";
+
+  if ( !db() ) {
+    edm::LogError(mlDqmClient_) 
+      << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Aborting upload...";
+    return;
+  }
+  
+  // Update FED descriptions with new peds/noise values as well as tick-marks (no PLL delays, for these ones please use the Timing run
+  SiStripConfigDb::FedDescriptionsRange feds = db()->getFedDescriptions();
+  update( feds );
+
+  if ( doUploadConf() ) { 
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+      << " Uploading FED information to DB...";
+    db()->uploadFedDescriptions();
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+      << " Completed database upload of " << feds.size() 
+      << " FED descriptions!";
+  } else {
+    edm::LogWarning(mlDqmClient_) 
+      << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+      << " No FED values will be uploaded to DB...";
+  }
+}
+
+// -----------------------------------------------------------------------------
+void DaqScopeModeHistosUsingDb::update( SiStripConfigDb::FedDescriptionsRange feds ) {
+  // Retrieve FED ids from cabling                                                                                                                                                                    
+  auto ids = cabling()->fedIds();
+
+  // Iterate through feds and update fed descriptions
+  uint16_t updated_peds  = 0;
+  uint16_t updated_ticks = 0;
+  SiStripConfigDb::FedDescriptionsV::const_iterator ifed;
+  for ( ifed = feds.begin(); ifed != feds.end(); ifed++ ) {
+
+    // If FED id not found in list (from cabling), then continue                                                                                                                                  
+    if ( find( ids.begin(), ids.end(), (*ifed)->getFedId() ) == ids.end() ) { continue; }
+    
+    for ( uint16_t ichan = 0; ichan < sistrip::FEDCH_PER_FED; ichan++ ) {
+
+      // Build FED and FEC keys
+      const FedChannelConnection& conn = cabling()->fedConnection( (*ifed)->getFedId(), ichan );
+
+      if ( conn.fecCrate() == sistrip::invalid_ ||
+           conn.fecSlot() == sistrip::invalid_ ||
+           conn.fecRing() == sistrip::invalid_ ||
+           conn.ccuAddr() == sistrip::invalid_ ||
+           conn.ccuChan() == sistrip::invalid_ ||
+           conn.lldChannel() == sistrip::invalid_ ) { continue; }
+      
+      SiStripFedKey fed_key( conn.fedId(), 
+                             SiStripFedKey::feUnit( conn.fedCh() ),
+                             SiStripFedKey::feChan( conn.fedCh() ) );
+
+      SiStripFecKey fec_key( conn.fecCrate(), 
+                             conn.fecSlot(), 
+                             conn.fecRing(), 
+                             conn.ccuAddr(), 
+                             conn.ccuChan(), 
+                             conn.lldChannel() );
+
+      // Locate appropriate analysis object 
+      Analyses::const_iterator iter = data(allowSelectiveUpload_).find( fec_key.key() );
+
+      if ( iter != data(allowSelectiveUpload_).end() ) {
+
+         // Check if analysis is valid
+         if ( !iter->second->isValid() ) { 
+           continue; 
+         }
+	 
+         DaqScopeModeAnalysis* anal = dynamic_cast<DaqScopeModeAnalysis*>( iter->second );
+         if ( !anal ) { 
+           edm::LogError(mlDqmClient_)
+             << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+             << " NULL pointer to analysis object!";
+           continue; 
+         }
+	 
+	 /// Pedestal and noise uploads
+	 if(not skipPedestalUpdate_){	   
+
+	   // Determine the pedestal shift to apply
+	   uint32_t pedshift = 127;
+	   for ( uint16_t iapv = 0; iapv < sistrip::APVS_PER_FEDCH; iapv++ ) {
+	     uint32_t pedmin = (uint32_t) anal->pedsMin()[iapv];
+	     pedshift = pedmin < pedshift ? pedmin : pedshift;
+	     std::stringstream ss;
+	     ss << "iapv: " << iapv << " pedsMin()[iapv]: " << anal->pedsMin()[iapv] << " pedmin: " << pedmin << " pedshift: " << pedshift;	  
+	     edm::LogWarning(mlDqmClient_) << ss.str();
+	   }
+	   
+	   // Iterate through APVs and strips
+	   for ( uint16_t iapv = 0; iapv < sistrip::APVS_PER_FEDCH; iapv++ ) {
+	     for ( uint16_t istr = 0; istr < anal->peds()[iapv].size(); istr++ ) { 
+
+	       // Patch added by R.B. (I'm back! ;-), requested by J.F. and S.L. (04/11/2010)
+	       if ( anal->peds()[iapv][istr] < 1. ) { //@@ ie, zero
+		 edm::LogWarning(mlDqmClient_) 
+		   << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+		   << " Skipping ZERO pedestal value (ie, NO UPLOAD TO DB!) for FedKey/Id/Ch: " 
+		   << hex << setw(8) << setfill('0') << fed_key.key() << dec << "/"
+		   << (*ifed)->getFedId() << "/"
+		   << ichan
+		   << " and device with FEC/slot/ring/CCU/LLD " 
+		   << fec_key.fecCrate() << "/"
+		   << fec_key.fecSlot() << "/"
+		   << fec_key.fecRing() << "/"
+		   << fec_key.ccuAddr() << "/"
+		   << fec_key.ccuChan() << "/"
+		   << fec_key.channel();
+		 continue; //@@ do not upload
+	       }
+	       
+	       // get the information on the strip as it was on the db
+	       Fed9U::Fed9UAddress addr( ichan, iapv, istr );
+	       Fed9U::Fed9UStripDescription temp = (*ifed)->getFedStrips().getStrip( addr );
+
+	       // determine whether we need to disable the strip
+	       bool disableStrip = false;
+	       if ( keepStripsDisabled_ ) {
+		 disableStrip = temp.getDisable();
+	       } 
+	       else if (disableBadStrips_) {
+		 DaqScopeModeAnalysis::VInt dead = anal->dead()[iapv];
+		 if ( find( dead.begin(), dead.end(), istr ) != dead.end() ) disableStrip = true;
+		 DaqScopeModeAnalysis::VInt noisy = anal->noisy()[iapv];
+		 if ( find( noisy.begin(), noisy.end(), istr ) != noisy.end() ) disableStrip = true;
+	       }
+
+	       Fed9U::Fed9UStripDescription data( static_cast<uint32_t>( anal->peds()[iapv][istr]-pedshift ),
+						  highThreshold_,
+						  lowThreshold_,
+						  anal->noise()[iapv][istr],
+						  disableStrip);
+
+	       std::stringstream ss;
+	       if ( data.getDisable() && edm::isDebugEnabled() ) {
+		 ss << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+		    << " Disabling strip in Fed9UStripDescription object..." << std::endl
+		    << " for FED id/channel and APV/strip : "
+		    << fed_key.fedId() << "/"
+		    << fed_key.fedChannel() << " "
+		    << iapv << "/"
+		    << istr << std::endl 
+		    << " and crate/FEC/ring/CCU/module    : "
+		    << fec_key.fecCrate() << "/"
+		    << fec_key.fecSlot() << "/"
+		    << fec_key.fecRing() << "/"
+		    << fec_key.ccuAddr() << "/"
+		    << fec_key.ccuChan() << std::endl 
+		    << " from ped/noise/high/low/disable  : "
+		    << static_cast<uint16_t>( temp.getPedestal() ) << "/" 
+		    << static_cast<uint16_t>( temp.getHighThreshold() ) << "/" 
+		    << static_cast<uint16_t>( temp.getLowThreshold() ) << "/" 
+		    << static_cast<uint16_t>( temp.getNoise() ) << "/" 
+		    << static_cast<uint16_t>( temp.getDisable() ) << std::endl;
+	       }
+	       
+	       // update strip inf
+	       (*ifed)->getFedStrips().setStrip( addr, data );
+
+	       if ( data.getDisable() && edm::isDebugEnabled() ) {
+		 ss << " to ped/noise/high/low/disable    : "
+		    << static_cast<uint16_t>( data.getPedestal() ) << "/" 
+		    << static_cast<uint16_t>( data.getHighThreshold() ) << "/" 
+		    << static_cast<uint16_t>( data.getLowThreshold() ) << "/" 
+		    << static_cast<uint16_t>( data.getNoise() ) << "/" 
+		    << static_cast<uint16_t>( data.getDisable() ) << std::endl;
+		 LogTrace(mlDqmClient_) << ss.str();
+	       }
+	     } // end loop on strips
+	   } // end loop on apvs
+	   updated_peds++;
+	 }
+	 
+	 // if one wants to update the frame finding threhsolds
+	 if(not skipTickUpdate_){
+	   
+	   // Update frame finding threshold                                                                                                                                                      
+	   Fed9U::Fed9UAddress addr( ichan );
+	   uint16_t old_threshold = static_cast<uint16_t>( (*ifed)->getFrameThreshold( addr ) );
+	   if(anal->isValid()) {
+	     (*ifed)->setFrameThreshold( addr, anal->frameFindingThreshold() );
+	     updated_ticks++;
+	   }
+	   uint16_t new_threshold = static_cast<uint16_t>( (*ifed)->getFrameThreshold( addr ) );
+
+	   std::stringstream ss;
+	   ss << "LLD channel : old frame threshold "<<old_threshold<<" new frame threshold "<<new_threshold<<std::endl;
+	   edm::LogWarning(mlDqmClient_) << ss.str();
+       
+	   // Debug                                                                                                                                                                                   
+	   ss.clear();
+	   ss << "[DaqScopeModeHistosUsingDb::" << __func__ << "]";
+	   if ( anal->isValid() ) {
+	     ss << " Updating the frame-finding threshold"
+		<< " from " << old_threshold
+		<< " to " << new_threshold
+		<< " using tick mark base/peak/height "
+		<< anal->base() << "/"
+		<< anal->peak() << "/"
+		<< anal->height();
+	   } else {
+	     ss << " Cannot update the frame-finding threshold"
+		<< " from " << old_threshold
+		<< " to a new value using invalid analysis ";
+	   }
+	   ss << " for crate/FEC/ring/CCU/module/LLD "
+	      << fec_key.fecCrate() << "/"
+	      << fec_key.fecSlot() << "/"
+	      << fec_key.fecRing() << "/"
+	      << fec_key.ccuAddr() << "/"
+	      << fec_key.ccuChan()
+	      << fec_key.channel()
+	      << " and FED id/ch "
+	      << fed_key.fedId() << "/"
+	      << fed_key.fedChannel();
+	   anal->print(ss);
+	   LogTrace(mlDqmClient_) << ss.str();                                                                                                                                                  
+	 }
+      }
+      else{
+	if ( deviceIsPresent(fec_key) ) {
+	  edm::LogWarning(mlDqmClient_) 
+	    << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+	    << " Unable to find pedestals/noise for FedKey/Id/Ch: " 
+	    << hex << setw(8) << setfill('0') << fed_key.key() << dec << "/"
+	    << (*ifed)->getFedId() << "/"
+	    << ichan
+	    << " and device with FEC/slot/ring/CCU/LLD " 
+	    << fec_key.fecCrate() << "/"
+	    << fec_key.fecSlot() << "/"
+	    << fec_key.fecRing() << "/"
+	    << fec_key.ccuAddr() << "/"
+	    << fec_key.ccuChan() << "/"
+	    << fec_key.channel();
+	}	
+      }
+    }
+   }
+
+  edm::LogVerbatim(mlDqmClient_) 
+    << "[DaqScopeModeHistosUsingDb::" << __func__ << "]"
+    << " Updated FED parameters for pedestal/noise " 
+    << updated_peds << " channels" 
+    << " Updated FED parameters for frame finding thresholds " 
+    << updated_ticks << " channels";
+}
+
+// -----------------------------------------------------------------------------
+void DaqScopeModeHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& desc,
+					Analysis analysis ) {
+
+  DaqScopeModeAnalysis* anal = dynamic_cast<DaqScopeModeAnalysis*>( analysis->second );
+  if ( !anal ) { return; }
+  
+  SiStripFecKey fec_key( anal->fecKey() );
+  SiStripFedKey fed_key( anal->fedKey() );
+  
+  for ( uint16_t iapv = 0; iapv < 2; ++iapv ) {
+    
+    // Create description for the pedestal table
+    PedestalsAnalysisDescription* peds_tmp;
+    peds_tmp = new PedestalsAnalysisDescription( 
+      anal->dead()[iapv],
+      anal->noisy()[iapv],
+      anal->pedsMean()[iapv],
+      anal->pedsSpread()[iapv],
+      anal->noiseMean()[iapv],
+      anal->noiseSpread()[iapv],
+      anal->rawMean()[iapv],
+      anal->rawSpread()[iapv],
+      anal->pedsMax()[iapv], 
+      anal->pedsMin()[iapv], 
+      anal->noiseMax()[iapv],
+      anal->noiseMin()[iapv],
+      anal->rawMax()[iapv],
+      anal->rawMin()[iapv],
+      fec_key.fecCrate(),
+      fec_key.fecSlot(),
+      fec_key.fecRing(),
+      fec_key.ccuAddr(),
+      fec_key.ccuChan(),
+      SiStripFecKey::i2cAddr( fec_key.lldChan(), !iapv ), 
+      db()->dbParams().partitions().begin()->second.partitionName(),
+      db()->dbParams().partitions().begin()->second.runNumber(),
+      anal->isValid(),
+      "",
+      fed_key.fedId(),
+      fed_key.feUnit(),
+      fed_key.feChan(),
+      fed_key.fedApv()
+    );
+    
+
+    // Add comments
+    typedef std::vector<std::string> Strings;
+    Strings errors = anal->getErrorCodes();
+    Strings::const_iterator istr = errors.begin();
+    Strings::const_iterator jstr = errors.end();
+    for ( ; istr != jstr; ++istr ) { peds_tmp->addComments( *istr ); }
+
+    // Store description
+    desc.push_back( peds_tmp );
+
+    // Create description                                                                                                                                                                           
+    TimingAnalysisDescription* timing_tmp;
+    timing_tmp = new TimingAnalysisDescription( 
+        -1.,
+	-1.,
+        -1.,
+        anal->height(),
+        anal->base(),
+        anal->peak(),
+        anal->frameFindingThreshold(),
+        -1.,
+        DaqScopeModeAnalysis::tickMarkHeightThreshold_,
+        true, //@@ APV timing analysis (not FED timing)                                                                                                             
+        fec_key.fecCrate(),
+        fec_key.fecSlot(),
+        fec_key.fecRing(),
+        fec_key.ccuAddr(),
+        fec_key.ccuChan(),
+        SiStripFecKey::i2cAddr( fec_key.lldChan(), !iapv ),
+        db()->dbParams().partitions().begin()->second.partitionName(),
+        db()->dbParams().partitions().begin()->second.runNumber(),
+        anal->isValid(),
+	"",
+        fed_key.fedId(),
+        fed_key.feUnit(),
+        fed_key.feChan(),
+        fed_key.fedApv() );
+    
+    istr = errors.begin();
+    jstr = errors.end();
+    for ( ; istr != jstr; ++istr ) { timing_tmp->addComments( *istr ); }
+    desc.push_back(timing_tmp);    
+  }
+}

--- a/DQM/SiStripCommissioningDbClients/src/DaqScopeModeHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/DaqScopeModeHistosUsingDb.cc
@@ -361,7 +361,6 @@ void DaqScopeModeHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& 
       fed_key.feChan(),
       fed_key.fedApv()
     );
-    
 
     // Add comments
     typedef std::vector<std::string> Strings;
@@ -400,7 +399,7 @@ void DaqScopeModeHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& 
         fed_key.feUnit(),
         fed_key.feChan(),
         fed_key.fedApv() );
-    
+
     istr = errors.begin();
     jstr = errors.end();
     for ( ; istr != jstr; ++istr ) { timing_tmp->addComments( *istr ); }

--- a/DQM/SiStripCommissioningDbClients/src/PedestalsHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/PedestalsHistosUsingDb.cc
@@ -152,7 +152,7 @@ void PedestalsHistosUsingDb::update( SiStripConfigDb::FedDescriptionsRange feds 
             Fed9U::Fed9UStripDescription temp = (*ifed)->getFedStrips().getStrip( addr );
 
 
-	    if ( anal->peds()[iapv][istr] < 1.e-6 ) { //@@ ie, zero
+	    if ( anal->peds()[iapv][istr] < 1.) { //@@ ie, zero
 	      edm::LogWarning(mlDqmClient_) 
 		<< "[PedestalsHistosUsingDb::" << __func__ << "]"
 		<< " Skipping ZERO pedestal value (ie, NO UPLOAD TO DB!) for FedKey/Id/Ch: " 

--- a/DQM/SiStripCommissioningSources/interface/CalibrationScanTask.h
+++ b/DQM/SiStripCommissioningSources/interface/CalibrationScanTask.h
@@ -14,27 +14,23 @@ class CalibrationScanTask : public CommissioningTask {
   CalibrationScanTask( DQMStore*, const FedChannelConnection&, const sistrip::RunType&, 
                        const char* filename, uint32_t run, const edm::EventSetup& setup );
   ~CalibrationScanTask() override;
+  void setCurrentFolder(const std::string &);
   
  private:
 
   void book() override;
-  void fill( const SiStripEventSummary&,
-		     const edm::DetSet<SiStripRawDigi>& ) override;
+  void fill( const SiStripEventSummary&,const edm::DetSet<SiStripRawDigi>& ) override;
   void update() override;
-  void checkAndSave(const uint16_t& isha, const uint16_t& vfs );
-  void directory( std::stringstream&, uint32_t run_number = 0 );
   
-  sistrip::RunType runType_;
-  
-  HistoSet calib1_, calib2_;
+  sistrip::RunType runType_;  
+  std::map<std::string,HistoSet> calib1_, calib2_;
 
   uint16_t nBins_;
-  uint16_t lastISHA_,lastVFS_, lastCalchan_;
-  std::string filename_;
+  uint32_t lastISHA_,lastVFS_, lastCalChan_, lastCalSel_, lastLatency_;  
   std::vector<uint16_t> ped;
+  std::string extrainfo_;
+  std::string directory_;
   uint32_t run_;
-  MonitorElement *ishaElement_, *vfsElement_, *calchanElement_;
-
 };
 
 #endif // DQM_SiStripCommissioningSources_CalibrationScanTask_h

--- a/DQM/SiStripCommissioningSources/interface/CalibrationTask.h
+++ b/DQM/SiStripCommissioningSources/interface/CalibrationTask.h
@@ -14,6 +14,7 @@ class CalibrationTask : public CommissioningTask {
   CalibrationTask( DQMStore*, const FedChannelConnection&, const sistrip::RunType&, 
                    const char* filename, uint32_t run, const edm::EventSetup& setup );
   ~CalibrationTask() override;
+  void setCurrentFolder(const std::string &);
   
  private:
 
@@ -21,20 +22,18 @@ class CalibrationTask : public CommissioningTask {
   void fill( const SiStripEventSummary&,
 		     const edm::DetSet<SiStripRawDigi>& ) override;
   void update() override;
-  void checkAndSave(const uint16_t&);
-  void directory( std::stringstream&,
-                  uint32_t run_number = 0 );
 
   sistrip::RunType runType_;
   
-  std::vector<HistoSet> calib_;
+  std::map<std::string,std::vector<HistoSet>> calib1_; // first  APV --> one key for each calChan
+  std::map<std::string,std::vector<HistoSet>> calib2_; // second APV --> one key for each calChan
 
   uint16_t nBins_;
-  uint16_t lastCalChan_;
-  std::string filename_;
-  std::vector<uint16_t> ped;
+  uint16_t lastCalChan_, lastCalSel_, lastLatency_;
+  std::string extrainfo_;
+  std::string directory_;
   uint32_t run_;
-  MonitorElement* calchanElement_;
+  std::vector<uint16_t> ped;
 };
 
 #endif // DQM_SiStripCommissioningSources_CalibrationTask_h

--- a/DQM/SiStripCommissioningSources/interface/CommissioningTask.h
+++ b/DQM/SiStripCommissioningSources/interface/CommissioningTask.h
@@ -69,6 +69,11 @@ class CommissioningTask {
   /** Fills HistoSet cache. */
   void fillHistograms( const SiStripEventSummary&, 
 		       const edm::DetSet<SiStripRawDigi>& );
+
+  /** Fills HistoSet cache. */
+  void fillHistograms( const SiStripEventSummary&,
+                       const edm::DetSet<SiStripRawDigi>&,
+                       const edm::DetSet<SiStripRawDigi>&);
   
   /** Fill HistoSet cache for FED cabling (special case). */
   void fillHistograms( const SiStripEventSummary&, 
@@ -137,6 +142,10 @@ class CommissioningTask {
 
   virtual void fill( const SiStripEventSummary&,
 		     const edm::DetSet<SiStripRawDigi>& );
+
+  virtual void fill( const SiStripEventSummary&,
+		     const edm::DetSet<SiStripRawDigi>&,
+                     const edm::DetSet<SiStripRawDigi>&);
 
   virtual void fill( const SiStripEventSummary&, 
 		     const uint16_t& fed_id,

--- a/DQM/SiStripCommissioningSources/interface/DaqScopeModeTask.h
+++ b/DQM/SiStripCommissioningSources/interface/DaqScopeModeTask.h
@@ -12,19 +12,19 @@ class DaqScopeModeTask : public CommissioningTask {
  public:
   
   DaqScopeModeTask( DQMStore*, const FedChannelConnection&, const edm::ParameterSet & );
-  virtual ~DaqScopeModeTask();
+  ~DaqScopeModeTask() override;
   
  private:
 
-  virtual void book();
-  virtual void fill( const SiStripEventSummary&,
-		     const edm::DetSet<SiStripRawDigi>& );
+  void book() override;
+  void fill( const SiStripEventSummary&,
+		     const edm::DetSet<SiStripRawDigi>& ) override;
 
-  virtual void fill( const SiStripEventSummary&,
+  void fill( const SiStripEventSummary&,
 		     const edm::DetSet<SiStripRawDigi>&,
-		     const edm::DetSet<SiStripRawDigi>&);
+		     const edm::DetSet<SiStripRawDigi>&) override;
 
-  virtual void update();
+  void update() override;
 
   // scope mode frame for each channel
   HistoSet scopeFrame_;

--- a/DQM/SiStripCommissioningSources/interface/DaqScopeModeTask.h
+++ b/DQM/SiStripCommissioningSources/interface/DaqScopeModeTask.h
@@ -2,6 +2,7 @@
 #define DQM_SiStripCommissioningSources_DaqScopeModeTask_h
 
 #include "DQM/SiStripCommissioningSources/interface/CommissioningTask.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 /**
    @class DaqScopeModeTask
@@ -10,20 +11,33 @@ class DaqScopeModeTask : public CommissioningTask {
 
  public:
   
-  DaqScopeModeTask( DQMStore*, const FedChannelConnection& );
-  ~DaqScopeModeTask() override;
+  DaqScopeModeTask( DQMStore*, const FedChannelConnection&, const edm::ParameterSet & );
+  virtual ~DaqScopeModeTask();
   
  private:
 
-  void book() override;
-  void fill( const SiStripEventSummary&,
-		     const edm::DetSet<SiStripRawDigi>& ) override;
-  void update() override;
-  
-  HistoSet scope_;
+  virtual void book();
+  virtual void fill( const SiStripEventSummary&,
+		     const edm::DetSet<SiStripRawDigi>& );
+
+  virtual void fill( const SiStripEventSummary&,
+		     const edm::DetSet<SiStripRawDigi>&,
+		     const edm::DetSet<SiStripRawDigi>&);
+
+  virtual void update();
+
+  // scope mode frame for each channel
+  HistoSet scopeFrame_;
+
+  // Pedestal and common mode
+  std::vector<HistoSet> peds_;
+  std::vector<HistoSet> cm_;
 
   uint16_t nBins_;
+  uint16_t nBinsSpy_;
 
+  /// parameters useful for the spy
+  edm::ParameterSet parameters_;
 };
 
 #endif // DQM_SiStripCommissioningSources_DaqScopeModeTask_h

--- a/DQM/SiStripCommissioningSources/interface/SiStripCommissioningSource.h
+++ b/DQM/SiStripCommissioningSources/interface/SiStripCommissioningSource.h
@@ -73,7 +73,7 @@ class SiStripCommissioningSource : public edm::EDAnalyzer {
   /** */
   void fillHistos( const SiStripEventSummary* const,
 		   const edm::DetSetVector<SiStripRawDigi>&,
-		   const edm::DetSetVector<SiStripRawDigi>& = edm::DetSetVector<SiStripRawDigi>());
+		   const edm::DetSetVector<SiStripRawDigi>* = nullptr);
   
   /** */
   void remove();

--- a/DQM/SiStripCommissioningSources/interface/SiStripCommissioningSource.h
+++ b/DQM/SiStripCommissioningSources/interface/SiStripCommissioningSource.h
@@ -72,7 +72,8 @@ class SiStripCommissioningSource : public edm::EDAnalyzer {
 
   /** */
   void fillHistos( const SiStripEventSummary* const,
-		   const edm::DetSetVector<SiStripRawDigi>& );
+		   const edm::DetSetVector<SiStripRawDigi>&,
+		   const edm::DetSetVector<SiStripRawDigi>& = edm::DetSetVector<SiStripRawDigi>());
   
   /** */
   void remove();
@@ -101,9 +102,11 @@ class SiStripCommissioningSource : public edm::EDAnalyzer {
   edm::EDGetTokenT<edm::DetSetVector<SiStripRawDigi> > digiVirginRawToken_;
   edm::EDGetTokenT<edm::DetSetVector<SiStripRawDigi> > digiScopeModeToken_;
   edm::EDGetTokenT<edm::DetSetVector<SiStripRawDigi> > digiFineDelaySelectionToken_;
+  edm::EDGetTokenT<edm::DetSetVector<SiStripRawDigi> > digiReorderedToken_;
 
   /** Name of digi input module. */
   std::string inputModuleLabel_;
+  std::string inputModuleLabelAlt_;
   std::string inputModuleLabelSummary_;
 
   /** Filename of output root file containing source histos. */
@@ -111,9 +114,15 @@ class SiStripCommissioningSource : public edm::EDAnalyzer {
 
   /** Run number used for naming of root file. */
   uint32_t run_;
+  
+  /** to be used in the output file */
+  std::string partitionName_;
 
   /** Record of time used to calculate event rate. */
   int32_t time_;
+  
+  /** to mark whether a DAQ_SCOPE run is from spy */
+  bool isSpy_;
 
   // ---------- Histogram-related ----------
 

--- a/DQM/SiStripCommissioningSources/python/SiStripCommissioningSource_FromEDM_cfg.py
+++ b/DQM/SiStripCommissioningSources/python/SiStripCommissioningSource_FromEDM_cfg.py
@@ -1,0 +1,123 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+import glob
+import os
+import os,sys,getopt,glob,cx_Oracle,subprocess
+
+cmsswbase = os.path.expandvars("$CMSSW_BASE/")
+inputPath = '/raid/fff'
+
+conn_str = os.path.expandvars("$CONFDB")
+conn     = cx_Oracle.connect(conn_str)
+e        = conn.cursor()
+e.execute('select RUNMODE from run where runnumber = RUNNUMBER')
+runmode = e.fetchall()
+runtype = -1;
+for result in runmode:
+    runtype = int(result[0]);
+conn.close()
+
+process = cms.Process("SRCEDM")
+
+process.load("DQM.SiStripCommon.MessageLogger_cfi")
+process.load("DQM.SiStripCommon.DaqMonitorROOTBackEnd_cfi")
+
+process.load("OnlineDB.SiStripConfigDb.SiStripConfigDb_cfi")
+process.SiStripConfigDb.UsingDb = True                    
+process.SiStripConfigDb.ConfDb = 'user/password@account'
+process.SiStripConfigDb.Partitions.PrimaryPartition.PartitionName = 'DBPART'
+process.SiStripConfigDb.Partitions.PrimaryPartition.RunNumber     = RUNNUMBER
+process.SiStripConfigDb.TNS_ADMIN = '/etc'
+
+process.SiStripCondObjBuilderFromDb = cms.Service("SiStripCondObjBuilderFromDb")
+process.SiStripCondObjBuilderFromDb.UseFEC = cms.untracked.bool(True)
+process.SiStripCondObjBuilderFromDb.UseFED = cms.untracked.bool(True)
+
+process.FedCablingFromConfigDb = cms.ESSource("SiStripFedCablingBuilderFromDb",
+    CablingSource = cms.untracked.string('UNDEFINED')  
+)
+
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.PedestalsFromConfigDb = cms.ESSource("SiStripPedestalsBuilderFromDb")
+process.NoiseFromConfigDb = cms.ESSource("SiStripNoiseBuilderFromDb")
+process.sistripconn = cms.ESProducer("SiStripConnectivity")
+
+process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
+process.load("Geometry.TrackerNumberingBuilder.trackerTopology_cfi")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+
+process.FastMonitoringService = cms.Service("FastMonitoringService",
+        sleepTime = cms.untracked.int32(1),
+        microstateDefPath = cms.untracked.string( cmsswbase+'/src/EventFilter/Utilities/plugins/microstatedef.jsd'),
+        fastMicrostateDefPath = cms.untracked.string( cmsswbase+'/src/EventFilter/Utilities/plugins/microstatedeffast.jsd'),
+        fastName = cms.untracked.string( 'fastmoni' ),
+        slowName = cms.untracked.string( 'slowmoni' )
+)
+
+process.EvFDaqDirector = cms.Service("EvFDaqDirector",
+        runNumber = cms.untracked.uint32(RUNNUMBER),
+        buBaseDir = cms.untracked.string(inputPath),
+        directorIsBu = cms.untracked.bool(False),
+        testModeNoBuilderUnit = cms.untracked.bool(False)
+)
+
+infilename = "file:"+inputPath+"/runRUNNUMBER/runRUNNUMBER.root"
+process.source = cms.Source("PoolSource",
+        fileNames = cms.untracked.vstring(infilename)
+)
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+### for run types != from DAQ SCOPE Modes                                                                                                                                                              
+if runtype != 15:
+    process.load("EventFilter.SiStripRawToDigi.FedChannelDigis_cfi")
+    process.FedChannelDigis.UnpackBadChannels = cms.bool(True)
+    process.FedChannelDigis.DoAPVEmulatorCheck = cms.bool(True)
+    process.FedChannelDigis.LegacyUnpacker = cms.bool(False)
+    process.FedChannelDigis.ProductLabel = cms.InputTag("rawDataCollector")
+else:
+    process.load('DQM.SiStripMonitorHardware.SiStripSpyUnpacker_cfi')
+    process.load('DQM.SiStripMonitorHardware.SiStripSpyDigiConverter_cfi')
+    process.load('DQM.SiStripMonitorHardware.SiStripSpyEventSummaryProducer_cfi')
+    ## * Scope digi settings                                                                                                                                                                          
+    process.SiStripSpyUnpacker.FEDIDs = cms.vuint32()                   #use a subset of FEDs or leave empty for all.                                                                                  
+    process.SiStripSpyUnpacker.InputProductLabel = cms.InputTag('rawDataCollector')
+    process.SiStripSpyUnpacker.AllowIncompleteEvents = True
+    process.SiStripSpyUnpacker.StoreCounters = True
+    process.SiStripSpyUnpacker.StoreScopeRawDigis = cms.bool(True)      # Note - needs to be True for use in other modules.                                                                            
+    ## * Module digi settings                                                                                                                                                                         
+    process.SiStripSpyDigiConverter.InputProductLabel = cms.InputTag('SiStripSpyUnpacker','ScopeRawDigis')
+    process.SiStripSpyDigiConverter.StorePayloadDigis = True
+    process.SiStripSpyDigiConverter.StoreReorderedDigis = True
+    process.SiStripSpyDigiConverter.StoreModuleDigis = True
+    process.SiStripSpyDigiConverter.StoreAPVAddress = True
+    process.SiStripSpyDigiConverter.MinDigiRange = 100
+    process.SiStripSpyDigiConverter.MaxDigiRange = 1024
+    process.SiStripSpyDigiConverter.MinZeroLight = 0
+    process.SiStripSpyDigiConverter.MaxZeroLight = 1024
+    process.SiStripSpyDigiConverter.MinTickHeight = 0
+    process.SiStripSpyDigiConverter.MaxTickHeight = 1024
+    process.SiStripSpyDigiConverter.ExpectedPositionOfFirstHeaderBit = 0
+    process.SiStripSpyDigiConverter.DiscardDigisWithWrongAPVAddress = False
+    process.SiStripSpyEventSummary.RawDataTag = cms.InputTag('rawDataCollector')
+
+
+process.load("DQM.SiStripCommissioningSources.CommissioningHistos_cfi")
+process.CommissioningHistos.CommissioningTask = 'UNDEFINED'
+process.CommissioningHistos.PedsFullNoiseParameters.NrEvToSkipAtStart = 100
+process.CommissioningHistos.PedsFullNoiseParameters.NrEvForPeds       = 3000
+process.CommissioningHistos.PedsFullNoiseParameters.FillNoiseProfile  = True
+
+if runtype != 15:
+    process.p = cms.Path(process.FedChannelDigis*process.CommissioningHistos)
+else:
+
+    process.SiStripSpyEventSummary.RunType = cms.uint32(runtype)
+    process.CommissioningHistos.InputModuleLabel = 'SiStripSpyDigiConverter'  # output label from spy converter                                                                                        
+    process.CommissioningHistos.InputModuleLabelAlt = cms.string('SiStripSpyUnpacker')
+    process.CommissioningHistos.SummaryInputModuleLabel = 'SiStripSpyEventSummary'
+    process.CommissioningHistos.isSpy = cms.bool(True)
+    process.CommissioningHistos.PartitionName = cms.string('DBPART')
+
+    process.p = cms.Path(process.SiStripSpyUnpacker*process.SiStripSpyDigiConverter*process.SiStripSpyEventSummary*process.CommissioningHistos)
+

--- a/DQM/SiStripCommissioningSources/python/SiStripCommissioningSource_FromRAW_cfg.py
+++ b/DQM/SiStripCommissioningSources/python/SiStripCommissioningSource_FromRAW_cfg.py
@@ -1,0 +1,146 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+import glob
+import os
+import os,sys,getopt,glob,cx_Oracle,subprocess
+
+cmsswbase = os.path.expandvars("$CMSSW_BASE/")
+inputPath = '/raid/fff'
+
+##### to understand the run type by means of connecting the the CONFDB
+conn_str = os.path.expandvars("$CONFDB")
+conn     = cx_Oracle.connect(conn_str)
+e        = conn.cursor()
+e.execute('select RUNMODE from run where runnumber = RUNNUMBER')
+runmode = e.fetchall()
+runtype = -1;
+for result in runmode:
+    runtype = int(result[0]);
+conn.close()
+
+
+process = cms.Process("SRC")
+
+process.load("DQM.SiStripCommon.MessageLogger_cfi")
+
+process.load("DQM.SiStripCommon.DaqMonitorROOTBackEnd_cfi")
+
+process.load("OnlineDB.SiStripConfigDb.SiStripConfigDb_cfi")
+process.SiStripConfigDb.UsingDb = True                    
+process.SiStripConfigDb.ConfDb = 'user/password@account'
+process.SiStripConfigDb.Partitions.PrimaryPartition.PartitionName = 'DBPART'
+process.SiStripConfigDb.Partitions.PrimaryPartition.RunNumber     = RUNNUMBER
+process.SiStripConfigDb.TNS_ADMIN = '/etc'
+
+process.SiStripCondObjBuilderFromDb = cms.Service("SiStripCondObjBuilderFromDb")
+process.SiStripCondObjBuilderFromDb.UseFEC = cms.untracked.bool(True)
+process.SiStripCondObjBuilderFromDb.UseFED = cms.untracked.bool(True)
+
+process.FedCablingFromConfigDb = cms.ESSource("SiStripFedCablingBuilderFromDb",
+    CablingSource = cms.untracked.string('UNDEFINED')  
+)
+process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+
+process.PedestalsFromConfigDb = cms.ESSource("SiStripPedestalsBuilderFromDb")
+process.NoiseFromConfigDb = cms.ESSource("SiStripNoiseBuilderFromDb")
+process.sistripconn = cms.ESProducer("SiStripConnectivity")
+
+process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
+process.load("Geometry.TrackerNumberingBuilder.trackerTopology_cfi")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+
+process.FastMonitoringService = cms.Service("FastMonitoringService",
+        sleepTime = cms.untracked.int32(1),
+        microstateDefPath = cms.untracked.string( cmsswbase+'/src/EventFilter/Utilities/plugins/microstatedef.jsd'),
+        fastMicrostateDefPath = cms.untracked.string( cmsswbase+'/src/EventFilter/Utilities/plugins/microstatedeffast.jsd'),
+        fastName = cms.untracked.string( 'fastmoni' ),
+        slowName = cms.untracked.string( 'slowmoni' )
+)
+
+process.EvFDaqDirector = cms.Service("EvFDaqDirector",
+        runNumber = cms.untracked.uint32(RUNNUMBER),
+        buBaseDir = cms.untracked.string(inputPath),
+        directorIsBu = cms.untracked.bool(False),
+        testModeNoBuilderUnit = cms.untracked.bool(False)
+)
+
+process.source = cms.Source("FedRawDataInputSource",
+        runNumber = cms.untracked.uint32(RUNNUMBER),
+        getLSFromFilename = cms.untracked.bool(True),
+        testModeNoBuilderUnit = cms.untracked.bool(False),
+        verifyAdler32 = cms.untracked.bool(True),
+        verifyChecksum = cms.untracked.bool(True),
+        useL1EventID = cms.untracked.bool(True),
+        eventChunkSize = cms.untracked.uint32(16),
+        numBuffers = cms.untracked.uint32(2),
+        eventChunkBlock = cms.untracked.uint32(1),
+        fileListMode = cms.untracked.bool(True),
+        fileNames = cms.untracked.vstring()
+)
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+### for run types != from DAQ SCOPE Modes
+if runtype != 15:
+    process.load("EventFilter.SiStripRawToDigi.FedChannelDigis_cfi")
+    process.FedChannelDigis.UnpackBadChannels = cms.bool(True)
+    process.FedChannelDigis.DoAPVEmulatorCheck = cms.bool(True)
+    process.FedChannelDigis.LegacyUnpacker = cms.bool(False)
+    process.FedChannelDigis.ProductLabel = cms.InputTag("rawDataCollector")
+else:
+    process.load('DQM.SiStripMonitorHardware.SiStripSpyUnpacker_cfi')
+    process.load('DQM.SiStripMonitorHardware.SiStripSpyDigiConverter_cfi')
+    process.load('DQM.SiStripMonitorHardware.SiStripSpyEventSummaryProducer_cfi')    
+    ## * Scope digi settings                                                                                                                                                                     
+    process.SiStripSpyUnpacker.FEDIDs = cms.vuint32()                   #use a subset of FEDs or leave empty for all.                                                                                  
+    process.SiStripSpyUnpacker.InputProductLabel = cms.InputTag('rawDataCollector')
+    process.SiStripSpyUnpacker.AllowIncompleteEvents = True
+    process.SiStripSpyUnpacker.StoreCounters = True
+    process.SiStripSpyUnpacker.StoreScopeRawDigis = cms.bool(True)      # Note - needs to be True for use in other modules.                                                                       
+    ## * Module digi settings                                                                                                                                                                         
+    process.SiStripSpyDigiConverter.InputProductLabel = cms.InputTag('SiStripSpyUnpacker','ScopeRawDigis')
+    process.SiStripSpyDigiConverter.StorePayloadDigis = True
+    process.SiStripSpyDigiConverter.StoreReorderedDigis = True
+    process.SiStripSpyDigiConverter.StoreModuleDigis = True
+    process.SiStripSpyDigiConverter.StoreAPVAddress = True
+    process.SiStripSpyDigiConverter.MinDigiRange = 100
+    process.SiStripSpyDigiConverter.MaxDigiRange = 1024
+    process.SiStripSpyDigiConverter.MinZeroLight = 0
+    process.SiStripSpyDigiConverter.MaxZeroLight = 1024
+    process.SiStripSpyDigiConverter.MinTickHeight = 0
+    process.SiStripSpyDigiConverter.MaxTickHeight = 1024
+    process.SiStripSpyDigiConverter.ExpectedPositionOfFirstHeaderBit = 0
+    process.SiStripSpyDigiConverter.DiscardDigisWithWrongAPVAddress = False
+    process.SiStripSpyEventSummary.RawDataTag = cms.InputTag('rawDataCollector')
+
+process.load("DQM.SiStripCommissioningSources.CommissioningHistos_cfi")
+process.CommissioningHistos.CommissioningTask = 'UNDEFINED'
+process.CommissioningHistos.PedsFullNoiseParameters.NrEvToSkipAtStart = 100
+process.CommissioningHistos.PedsFullNoiseParameters.NrEvForPeds       = 3000
+process.CommissioningHistos.PedsFullNoiseParameters.FillNoiseProfile  = True
+
+outfilename = inputPath+"/run"+"RUNNUMBER"+"/run"+"RUNNUMBER"+".root"
+process.out = cms.OutputModule("PoolOutputModule",
+  fileName = cms.untracked.string(outfilename),
+  outputCommands = cms.untracked.vstring("drop *", "keep FEDRawDataCollection_*_*_*")
+)
+
+if runtype != 15:
+    process.p = cms.Path(process.FedChannelDigis*process.CommissioningHistos)
+else:
+    
+    process.SiStripSpyEventSummary.RunType = cms.uint32(runtype)
+    process.CommissioningHistos.InputModuleLabel = 'SiStripSpyDigiConverter'  # output label from spy converter                                                                                        
+    process.CommissioningHistos.InputModuleLabelAlt = cms.string('SiStripSpyUnpacker')
+    process.CommissioningHistos.SummaryInputModuleLabel = 'SiStripSpyEventSummary'
+    process.CommissioningHistos.isSpy = cms.bool(True)
+    process.CommissioningHistos.PartitionName = cms.string('DBPART')
+
+    process.p = cms.Path(process.SiStripSpyUnpacker*process.SiStripSpyDigiConverter*process.SiStripSpyEventSummary*process.CommissioningHistos)
+
+process.e = cms.EndPath(process.out)
+
+fnames = glob.glob(inputPath+"/run"+"RUNNUMBER"+"/*ls00*.raw")
+for f in fnames :
+        process.source.fileNames.extend(cms.untracked.vstring('file:'+f))
+

--- a/DQM/SiStripCommissioningSources/src/CalibrationScanTask.cc
+++ b/DQM/SiStripCommissioningSources/src/CalibrationScanTask.cc
@@ -12,7 +12,7 @@
 #include <sys/unistd.h>
 #include <sys/socket.h>
 #include <netdb.h>
-#include <stdio.h>
+#include <cstdio>
 #include <fstream>
 
 // -----------------------------------------------------------------------------

--- a/DQM/SiStripCommissioningSources/src/CalibrationScanTask.cc
+++ b/DQM/SiStripCommissioningSources/src/CalibrationScanTask.cc
@@ -12,24 +12,32 @@
 #include <sys/unistd.h>
 #include <sys/socket.h>
 #include <netdb.h>
-#include <cstdio>
+#include <stdio.h>
 #include <fstream>
 
 // -----------------------------------------------------------------------------
 //
 CalibrationScanTask::CalibrationScanTask( DQMStore* dqm,
-			      const FedChannelConnection& conn,
-			      const sistrip::RunType& rtype,
-			      const char* filename,
-			      uint32_t run,
-                              const edm::EventSetup& setup ) :
+					  const FedChannelConnection& conn,
+					  const sistrip::RunType& rtype,
+					  const char* filename,
+					  uint32_t run,
+					  const edm::EventSetup& setup ) :
   CommissioningTask( dqm, conn, "CalibrationScanTask" ),
   runType_(rtype),
-  calib1_(),calib2_(),
-  nBins_(65),lastISHA_(1000),lastVFS_(1000),lastCalchan_(1000),
-  filename_(filename),
+  nBins_(64),
+  lastISHA_(1000),
+  lastVFS_(1000),
+  lastCalChan_(1000),
+  lastCalSel_(1000),
+  lastLatency_(1000),
+  extrainfo_(),
   run_(run)
 {
+
+  if(runType_ == sistrip::CALIBRATION) nBins_ = 64;
+  else if(runType_ == sistrip::CALIBRATION_DECO) nBins_ = 80;
+
   LogDebug("Commissioning") << "[CalibrationScanTask::CalibrationScanTask] Constructing object...";
   // load the pedestals
   edm::ESHandle<SiStripPedestals> pedestalsHandle;
@@ -57,239 +65,101 @@ CalibrationScanTask::~CalibrationScanTask() {
 // -----------------------------------------------------------------------------
 //
 void CalibrationScanTask::book() {
-  LogDebug("Commissioning") << "[CalibrationScanTask::book]";
 
-  // construct the histo titles and book two histograms: one per APV
-  std::string title1 = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
-					 runType_, 
-  					 sistrip::DET_KEY, 
-					 connection().detId(),
-					 sistrip::APV, 
-					 connection().i2cAddr(0) ).title(); 
-  calib1_.histo( dqm()->book1D( title1, title1, nBins_, 0, 203.125) );
-  calib1_.isProfile_=false;
-  calib1_.vNumOfEntries_.resize(nBins_,0);
-  std::string title2 = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
-					 runType_, 
-  					 sistrip::DET_KEY, 
-					 connection().detId(),
-					 sistrip::APV, 
-					 connection().i2cAddr(1) ).title(); 
-  calib2_.histo( dqm()->book1D( title2, title2, nBins_, 0, 203.125) );
-  calib2_.isProfile_=false;
-  calib2_.vNumOfEntries_.resize(nBins_,0);
+  if(calib1_.find(extrainfo_) == calib1_.end()){
 
-  // book the isha, vfs values
-  std::string pwd = dqm()->pwd();
-  std::string rootDir = pwd.substr(0,pwd.find(std::string(sistrip::root_) + "/")+(sizeof(sistrip::root_) - 1));
-  dqm()->setCurrentFolder( rootDir );
-  std::vector<std::string> existingMEs = dqm()->getMEs();
-  if(find(existingMEs.begin(),existingMEs.end(),"isha")!=existingMEs.end()) {
-    ishaElement_ = dqm()->get(dqm()->pwd()+"/isha");
-  } else {
-    ishaElement_ = dqm()->bookInt("isha");
+    // construct the histo titles and book two histograms: one per APV
+    std::string title = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
+					   runType_, 
+					   sistrip::FED_KEY, 
+					   fedKey(),
+					   sistrip::APV, 
+					   connection().i2cAddr(0),
+					   extrainfo_).title(); 
+    
+    dqm()->setCurrentFolder(directory_);    
+    calib1_[extrainfo_] = HistoSet();
+    if(runType_ == sistrip::CALIBRATION_SCAN) // each latency point is 25ns, each calSel is 25/8 --> 64 points = 8 calsel + 8 latency                                                                 
+      calib1_[extrainfo_].histo( dqm()->book1D( title, title, nBins_, 0, 200));
+    else if(runType_ == sistrip::CALIBRATION_SCAN_DECO) // each latency point is 25ns, each calSel is 25/8 --> 80 points = 8 calsel + 10 latency                                                      
+      calib1_[extrainfo_].histo( dqm()->book1D( title, title, nBins_, 0, 250));
+    calib1_[extrainfo_].isProfile_ = false;
+    calib1_[extrainfo_].vNumOfEntries_.resize(nBins_,0);
   }
-  if(find(existingMEs.begin(),existingMEs.end(),"isha")!=existingMEs.end()) {
-    vfsElement_ = dqm()->get(dqm()->pwd()+"/vfs");  
-  } else {
-    vfsElement_ = dqm()->bookInt("vfs");
+
+  if(calib2_.find(extrainfo_) == calib2_.end()){
+
+    std::string title = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
+					   runType_, 
+					   sistrip::FED_KEY, 
+					   fedKey(),
+					   sistrip::APV, 
+					   connection().i2cAddr(1),
+					   extrainfo_).title(); 
+            
+    dqm()->setCurrentFolder(directory_);    
+    calib2_[extrainfo_] = HistoSet();
+    if(runType_ == sistrip::CALIBRATION_SCAN) // each latency point is 25ns, each calSel is 25/8 --> 64 points = 8 calsel + 8 latency                                                                  
+       calib2_[extrainfo_].histo( dqm()->book1D( title, title, nBins_, 0, 200));
+    else if(runType_ == sistrip::CALIBRATION_SCAN_DECO) // each latency point is 25ns, each calSel is 25/8 --> 80 points = 8 calsel + 10 latency                                                       
+      calib2_[extrainfo_].histo( dqm()->book1D( title, title, nBins_, 0, 250));
+    calib2_[extrainfo_].isProfile_=false;
+    calib2_[extrainfo_].vNumOfEntries_.resize(nBins_,0);
   }
-  if(find(existingMEs.begin(),existingMEs.end(),"calchan")!=existingMEs.end()) {
-    calchanElement_ = dqm()->get(dqm()->pwd()+"/calchan");
-  } else {
-    calchanElement_ = dqm()->bookInt("calchan");
-  }
-  
-  LogDebug("Commissioning") << "[CalibrationScanTask::book] done";
-  
 }
 
 // -----------------------------------------------------------------------------
 //
 void CalibrationScanTask::fill( const SiStripEventSummary& summary,
-			    const edm::DetSet<SiStripRawDigi>& digis ) {
-  //LogDebug("Commissioning") << "[CalibrationScanTask::fill]: isha/vfs = " << summary.isha() << "/" << summary.vfs();
-  //Check if ISHA/VFS changed. In that case, save, reset histo, change title, and continue
-  checkAndSave(summary.isha(),summary.vfs());
+				const edm::DetSet<SiStripRawDigi>& digis ) {
+  
+
+  if(lastISHA_ != summary.isha() or lastVFS_ != summary.vfs()){ // triggered only when there is a change in isha and vfs
+    lastISHA_    = summary.isha();
+    lastVFS_     = summary.vfs();
+    lastCalSel_  = summary.calSel();
+    lastLatency_ = summary.latency();
+    lastCalChan_ = summary.calChan();    
+    extrainfo_ = "isha_"+std::to_string(lastISHA_)+"_vfs_"+std::to_string(lastVFS_);
+    book(); // book histograms and load the right one
+  }
+  else{
+    lastISHA_    = summary.isha();
+    lastVFS_     = summary.vfs();
+    lastCalSel_  = summary.calSel();
+    lastLatency_ = summary.latency();
+    lastCalChan_ = summary.calChan();
+    extrainfo_ = "isha_"+std::to_string(lastISHA_)+"_vfs_"+std::to_string(lastVFS_);
+  }
+
   // retrieve the delay from the EventSummary
-  int bin = (100-summary.latency())*8+(7-summary.calSel());
-  // loop on the strips to fill the histogram
-  // digis are obtained for an APV pair. 
-  // strips 0->127  : calib1_
-  // strips 128->255: calib2_
+  int bin = 0;
+  if(runType_ == sistrip::CALIBRATION_SCAN) bin = (100-summary.latency())*8+(7-summary.calSel());
+  else if(runType_ == sistrip::CALIBRATION_SCAN_DECO) bin = (102-summary.latency())*8+(7-summary.calSel());
+  // digis are obtained for an APV pair.strips 0->127  : calib1_ strips 128->255: calib2_
   // then, only some strips are fired at a time.
   // We use calChan to know that
-  int isub,ical = summary.calChan();
-  isub = ical<4 ? ical+4 : ical-4;
-  lastCalchan_ = ical;
+  int isub = lastCalChan_<4 ? lastCalChan_+4 : lastCalChan_-4;
   for (int k=0;k<16;++k)  {
     // all strips of the APV are merged in 
-    updateHistoSet( calib1_,bin,digis.data[ical+k*8].adc()-ped[ical+k*8]-(digis.data[isub+k*8].adc()-ped[isub+k*8]));
-    updateHistoSet( calib2_,bin,digis.data[128+ical+k*8].adc()-ped[128+ical+k*8]-(digis.data[128+isub+k*8].adc()-ped[128+isub+k*8]));
-  }
+    updateHistoSet(calib1_[extrainfo_],bin,digis.data[lastCalChan_+k*8].adc()-ped[lastCalChan_+k*8]-(digis.data[isub+k*8].adc()-ped[isub+k*8]));
+    updateHistoSet(calib2_[extrainfo_],bin,digis.data[128+lastCalChan_+k*8].adc()-ped[128+lastCalChan_+k*8]-(digis.data[128+isub+k*8].adc()-ped[128+isub+k*8]));
+  } 
   update(); //TODO: temporary: find a better solution later
 }
 
 // -----------------------------------------------------------------------------
 //
 void CalibrationScanTask::update() {
-  // LogDebug("Commissioning") << "[CalibrationScanTask::update]"; // huge output
-  updateHistoSet( calib1_ );
-  updateHistoSet( calib2_ );
+  
+  LogDebug("Commissioning") << "[CalibrationScanTask::update]"; // huge output  
+  for(auto element : calib1_)
+    updateHistoSet(element.second);
+  for(auto element : calib2_)
+    updateHistoSet(element.second);
 }
 
-// -----------------------------------------------------------------------------
-//
-void CalibrationScanTask::checkAndSave(const uint16_t& isha, const uint16_t& vfs ) {
-  //for the first time
-  if(lastISHA_==1000 && lastVFS_==1000) {
-    lastISHA_ = isha;
-    lastVFS_  = vfs;
-  }
-
-  // set the calchan value in the correspond string
-  ishaElement_->Fill(lastISHA_);
-  vfsElement_->Fill(lastVFS_);
-  calchanElement_->Fill(lastCalchan_);
-
-  // check if ISHA/VFS has changed
-  // in that case, save the histograms, reset them, change the title and continue
-  if(lastISHA_!=isha || lastVFS_!=vfs) {
-
-    // set histograms before saving
-    update(); //TODO: we must do this for all tasks, otherwise only the first is updated.
-    
-    // change the title
-    std::stringstream complement;
-    complement << "ISHA" << isha << "_VFS" << vfs;
-    std::string title1 = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
-			 		    runType_, 
-  					    sistrip::DET_KEY, 
-				 	    connection().detId(),
-					    sistrip::APV, 
-					    connection().i2cAddr(0),
-					    complement.str() ).title(); 
-    calib1_.histo()->setTitle(title1);
-
-    std::string title2 = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
-			 		    runType_, 
-  					    sistrip::DET_KEY, 
-				 	    connection().detId(),
-					    sistrip::APV, 
-					    connection().i2cAddr(1),
-					    complement.str() ).title(); 
-    calib2_.histo()->setTitle(title2);
-
-    // Strip filename of ".root" extension
-    std::string name;
-    if ( filename_.find(".root",0) == std::string::npos ) { name = filename_; }
-    else { name = filename_.substr( 0, filename_.find(".root",0) ); }
-  
-    // Retrieve SCRATCH directory
-    std::string scratch = "SCRATCH"; //@@ remove trailing slash!!!
-    std::string dir = "";
-    if ( getenv(scratch.c_str()) != nullptr ) {
-      dir = getenv(scratch.c_str());
-    }
-  
-    // Save file with appropriate filename 
-    std::stringstream ss;
-    if ( !dir.empty() ) { ss << dir << "/"; }
-    else { ss << "/tmp/"; }
-    ss << name << "_";
-    directory(ss,run_); // Add filename with run number, host ip, pid and .root extension
-    ss << "_ISHA" << lastISHA_ << "_VFS" << lastVFS_; // Add ISHA and VFS values
-    ss << "_000"; // Add FU instance number (fake)
-    ss << ".root"; // Append ".root" extension
-    if ( !filename_.empty() ) {
-      if(std::ifstream(ss.str().c_str(),std::ifstream::in).fail()) { //save only once. Skip if the file already exist
-        dqm()->save( ss.str() ); 
-        LogTrace("DQMsource")
-          << "[SiStripCommissioningSource::" << __func__ << "]"
-          << " Saved all histograms to file \""
-          << ss.str() << "\"";
-      } else {
-        LogTrace("DQMsource")
-	  << "[SiStripCommissioningSource::" << __func__ << "]"
-	  << " Skipping creation of file \""
-	  << ss.str() << "\" that already exists" ;
-      }
-    } else {
-      edm::LogWarning("DQMsource")
-        << "[SiStripCommissioningSource::" << __func__ << "]"
-        << " NULL value for filename! No root file saved!";
-    }
-  
-    // reset
-    calib1_.vNumOfEntries_.clear();
-    calib1_.vNumOfEntries_.resize(nBins_,0);
-    calib2_.vNumOfEntries_.clear();
-    calib2_.vNumOfEntries_.resize(nBins_,0);
-  
-    // set new parameter values
-    lastISHA_=isha;
-    lastVFS_=vfs;
-    // set the calchan value in the correspond string
-    ishaElement_->Fill(lastISHA_);
-    vfsElement_->Fill(lastVFS_);
-    calchanElement_->Fill(lastCalchan_);
-  }
+void CalibrationScanTask::setCurrentFolder(const std::string & dir){
+  directory_ = dir;
 }
 
-// -----------------------------------------------------------------------------
-// 
-void CalibrationScanTask::directory( std::stringstream& dir,
-					    uint32_t run_number ) {
-
-  // Get details about host
-  char hn[256];
-  gethostname( hn, sizeof(hn) );
-  struct hostent* he;
-  he = gethostbyname(hn);
-
-  // Extract host name and ip
-  std::string host_name;
-  std::string host_ip;
-  if ( he ) { 
-    host_name = std::string(he->h_name);
-    host_ip = std::string( inet_ntoa( *(struct in_addr*)(he->h_addr) ) );
-  } else {
-    host_name = "unknown.cern.ch";
-    host_ip = "255.255.255.255";
-  }
-
-  // Reformat IP address
-  std::string::size_type pos = 0;
-  std::stringstream ip;
-  //for ( uint16_t ii = 0; ii < 4; ++ii ) {
-  while ( pos != std::string::npos ) {
-    std::string::size_type tmp = host_ip.find(".",pos);
-    if ( tmp != std::string::npos ) {
-      ip << std::setw(3)
-	 << std::setfill('0')
-	 << host_ip.substr( pos, tmp-pos ) 
-	 << ".";
-      pos = tmp+1; // skip the delimiter "."
-    } else {
-      ip << std::setw(3)
-	 << std::setfill('0')
-	 << host_ip.substr( pos );
-      pos = std::string::npos;
-    }
-  }
-  
-  // Get pid
-  pid_t pid = getpid();
-
-  // Construct string
-  dir << std::setw(8) 
-      << std::setfill('0') 
-      << run_number
-      << "_" 
-      << ip.str()
-      << "_"
-      << std::setw(5) 
-      << std::setfill('0') 
-      << pid;
-
-}

--- a/DQM/SiStripCommissioningSources/src/CalibrationTask.cc
+++ b/DQM/SiStripCommissioningSources/src/CalibrationTask.cc
@@ -12,7 +12,7 @@
 #include <sys/unistd.h>
 #include <sys/socket.h>
 #include <netdb.h>
-#include <stdio.h>
+#include <cstdio>
 #include <fstream>
 
 // -----------------------------------------------------------------------------

--- a/DQM/SiStripCommissioningSources/src/CalibrationTask.cc
+++ b/DQM/SiStripCommissioningSources/src/CalibrationTask.cc
@@ -12,7 +12,7 @@
 #include <sys/unistd.h>
 #include <sys/socket.h>
 #include <netdb.h>
-#include <cstdio>
+#include <stdio.h>
 #include <fstream>
 
 // -----------------------------------------------------------------------------
@@ -25,10 +25,17 @@ CalibrationTask::CalibrationTask( DQMStore* dqm,
 			      const edm::EventSetup& setup) :
   CommissioningTask( dqm, conn, "CalibrationTask" ),
   runType_(rtype),
-  nBins_(65),lastCalChan_(8),
-  filename_(filename),
+  nBins_(64),
+  lastCalChan_(1000),
+  lastCalSel_(1000),
+  lastLatency_(1000),
+  extrainfo_(),
   run_(run)
 {
+
+  if(runType_ == sistrip::CALIBRATION) nBins_ = 64;
+  else if(runType_ == sistrip::CALIBRATION_DECO) nBins_ = 80;
+
   LogDebug("Commissioning") << "[CalibrationTask::CalibrationTask] Constructing object...";
   // load the pedestals
   edm::ESHandle<SiStripPedestals> pedestalsHandle;
@@ -56,63 +63,88 @@ CalibrationTask::~CalibrationTask() {
 void CalibrationTask::book() {
   LogDebug("Commissioning") << "[CalibrationTask::book]";
 
-  // book 32 histograms, one for each strip in a calibration group on 2 APVs
-  calib_.resize(32);
-  for(int apv=0;apv<2;++apv) {
-    for(int i=0;i<16;++i) {
+  // book 16 histograms, one for each strip in a calibration group --> APV1
+  if(calib1_.find(extrainfo_) == calib1_.end()){  
+    dqm()->setCurrentFolder(directory_);      
+    calib1_[extrainfo_].resize(16);
+    for(int i = 0; i < 16; ++i) {
+      std::string postfix = extrainfo_+"_istrip_"+std::to_string(i);
       std::string title = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
-                                             runType_, 
-                                             sistrip::DET_KEY, 
-                                             connection().detId(),
-                                             sistrip::APV, 
-                                             connection().i2cAddr(apv) ).title(); 
-      std::stringstream complement;
-      complement << "_" << i ;
-      title += complement.str();			
-      calib_[apv*16+i].histo( dqm()->book1D( title, title, nBins_, 0, 203.125) );
-      calib_[apv*16+i].isProfile_=false;
-      calib_[apv*16+i].vNumOfEntries_.resize(nBins_,0);
+					     runType_, 
+					     sistrip::FED_KEY, 
+					     fedKey(),
+					     sistrip::APV, 
+					     connection().i2cAddr(0),
+					     postfix).title(); 
+
+      if(runType_ == sistrip::CALIBRATION) // each latency point is 25ns, each calSel is 25/8 --> 64 points = 8 calsel + 8 latency
+	calib1_[extrainfo_][i].histo( dqm()->book1D( title, title, nBins_, 0, 200));
+      else if(runType_ == sistrip::CALIBRATION_DECO) // each latency point is 25ns, each calSel is 25/8 --> 80 points = 8 calsel + 10 latency
+	calib1_[extrainfo_][i].histo( dqm()->book1D( title, title, nBins_, 0, 250));
+      calib1_[extrainfo_][i].isProfile_ = false;
+      calib1_[extrainfo_][i].vNumOfEntries_.resize(nBins_,0);      
     }
   }
 
-  // book the calchan values
-  std::string pwd = dqm()->pwd();
-  std::string rootDir = pwd.substr(0,pwd.find(std::string(sistrip::root_) + "/")+(sizeof(sistrip::root_) - 1));
-  dqm()->setCurrentFolder( rootDir );
-  std::vector<std::string> existingMEs = dqm()->getMEs();
-  if(find(existingMEs.begin(),existingMEs.end(),"calchan")!=existingMEs.end()) {
-    calchanElement_ = dqm()->get(dqm()->pwd()+"/calchan");
-  } else {
-    calchanElement_ = dqm()->bookInt("calchan");
-  }
-  dqm()->setCurrentFolder(pwd);
-  
-  LogDebug("Commissioning") << "[CalibrationTask::book] done";
-  
+  // book 16 histograms, one for each strip in a calibration group --> APV2
+  if(calib2_.find(extrainfo_) == calib2_.end()){  
+
+    dqm()->setCurrentFolder(directory_);    
+    calib2_[extrainfo_].resize(16);    
+    for(int i = 0; i < 16; ++i) {      
+      std::string postfix = extrainfo_+"_istrip_"+std::to_string(i);
+      std::string title = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
+					     runType_, 
+					     sistrip::FED_KEY, 
+					     fedKey(),
+					     sistrip::APV, 
+					     connection().i2cAddr(1),
+					     postfix).title(); 
+
+      if(runType_ == sistrip::CALIBRATION) // each latency point is 25ns, each calSel is 25/8 --> 64 points = 8 calsel + 8 latency                                                                     
+        calib2_[extrainfo_][i].histo( dqm()->book1D( title, title, nBins_, 0, 200));
+      else if(runType_ == sistrip::CALIBRATION_DECO) // each latency point is 25ns, each calSel is 25/8 --> 80 points = 8 calsel + 10 latency                                                          
+        calib2_[extrainfo_][i].histo( dqm()->book1D( title, title, nBins_, 0, 250));
+      
+      calib2_[extrainfo_][i].isProfile_ = false;
+      calib2_[extrainfo_][i].vNumOfEntries_.resize(nBins_,0);      
+    }
+  }    
 }
 
 // -----------------------------------------------------------------------------
 //
 void CalibrationTask::fill( const SiStripEventSummary& summary,
 			    const edm::DetSet<SiStripRawDigi>& digis ) {
+
   LogDebug("Commissioning") << "[CalibrationTask::fill]";
+
+  if(lastCalChan_ != summary.calChan()){ // change in the calChan value
+    lastCalChan_ = summary.calChan();
+    lastLatency_ = summary.latency();
+    lastCalSel_  = summary.calSel();
+    extrainfo_   = "calChan_"+std::to_string(lastCalChan_);
+    book(); // book histograms and load the right one                                                                                                                                                  
+  }
+  else{
+    lastCalChan_ = summary.calChan();
+    lastLatency_ = summary.latency();
+    lastCalSel_  = summary.calSel();
+    extrainfo_   = "calChan_"+std::to_string(lastCalChan_);
+  }
+
   // Check if CalChan changed. In that case, save, reset histo, change title, and continue
-  int isub,ical = summary.calChan();
-  isub = ical<4 ? ical+4 : ical-4;
-  checkAndSave(ical);
-  // retrieve the delay from the EventSummary
+  int isub = lastCalChan_<4 ? lastCalChan_+4 : lastCalChan_-4;
   int bin = 0;
-  if(runType_ == sistrip::CALIBRATION)
-    bin = (100-summary.latency())*8+(7-summary.calSel());
-  else if(runType_ == sistrip::CALIBRATION_DECO)
-    bin = (102-summary.latency())*8+(7-summary.calSel());
-  // Fill the histograms.
-  // data-ped -(data-ped)_isub
+
+  if(runType_ == sistrip::CALIBRATION) bin = (100-summary.latency())*8+(7-summary.calSel());
+  else if(runType_ == sistrip::CALIBRATION_DECO) bin = (102-summary.latency())*8+(7-summary.calSel());
+
+  // Fill the histograms data-ped -(data-ped)_isub
   // the second term corresponds to the common mode substraction, looking at a strip far away.
-  for (int apv=0; apv<2; ++apv) {
-    for (int k=0;k<16;++k)  {
-      updateHistoSet( calib_[apv*16+k],bin,digis.data[apv*128+ical+k*8].adc()-ped[apv*128+ical+k*8]-(digis.data[apv*128+isub+k*8].adc()-ped[apv*128+isub+k*8]));
-    }
+  for (int k=0;k<16;++k)  {
+    updateHistoSet(calib1_[extrainfo_][k],bin,digis.data[lastCalChan_+k*8].adc()-ped[lastCalChan_+k*8]-(digis.data[isub+k*8].adc()-ped[isub+k*8]));
+    updateHistoSet(calib2_[extrainfo_][k],bin,digis.data[128+lastCalChan_+k*8].adc()-ped[128+lastCalChan_+k*8]-(digis.data[128+isub+k*8].adc()-ped[128+isub+k*8]));
   }
   update(); //TODO: temporary: find a better solution later
 }
@@ -120,151 +152,21 @@ void CalibrationTask::fill( const SiStripEventSummary& summary,
 // -----------------------------------------------------------------------------
 //
 void CalibrationTask::update() {
-  // LogDebug("Commissioning") << "[CalibrationTask::update]"; // huge output
-  for(std::vector<HistoSet>::iterator it=calib_.begin();it<calib_.end();++it) {
-    updateHistoSet( *it );
+
+  LogDebug("Commissioning") << "[CalibrationTask::update]"; // huge output                                                                                                                         
+
+  for(auto element : calib1_){ // all pulse for different calChan
+    for(auto vecelement : element.second) // all strips in a calCan
+      updateHistoSet(vecelement);
   }
+
+  for(auto element : calib2_){ // all pulse for different calChan
+    for(auto vecelement : element.second) // all strips in a calCan
+      updateHistoSet(vecelement);
+  }
+
 }
 
-// -----------------------------------------------------------------------------
-//
-void CalibrationTask::checkAndSave(const uint16_t& calchan) {
-  //for the first time
-  if(lastCalChan_==8) {
-    // set new parameter value
-    lastCalChan_ = calchan;
-    calchanElement_->Fill(lastCalChan_);
-    return;
-  }
-
-  //check if CDRV register (ical) has changed
-  // in that case, save the histograms, reset them, change the title and continue
-  if(calchan!=lastCalChan_) {
-    
-    // set histograms before saving
-    update(); //TODO: we must do this for all tasks, otherwise only the first is updated.
-
-    // change the title
-    for(int apv=0;apv<2;++apv) {
-      for(int i=0;i<16;++i) {
-        std::stringstream complement;
-        complement << "STRIP_" << (apv*128+lastCalChan_+i*8) ;
-        std::string title = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
-                                               runType_, 
-                                               sistrip::DET_KEY, 
-                                               connection().detId(),
-                                               sistrip::APV, 
-                                               connection().i2cAddr(apv),
-                                               complement.str() ).title(); 
-        calib_[apv*16+i].histo()->setTitle(title);
-	calib_[apv*16+i].histo()->setAxisTitle(title);
-      }
-    }
-
-    // Strip filename of ".root" extension
-    std::string name;
-    if ( filename_.find(".root",0) == std::string::npos ) { name = filename_; }
-    else { name = filename_.substr( 0, filename_.find(".root",0) ); }
-  
-    // Retrieve SCRATCH directory
-    std::string scratch = "SCRATCH"; //@@ remove trailing slash!!!
-    std::string dir = "";
-    if ( getenv(scratch.c_str()) != nullptr ) {
-      dir = getenv(scratch.c_str());
-    }
-  
-    // Save file with appropriate filename 
-    std::stringstream ss;
-    if ( !dir.empty() ) { ss << dir << "/"; }
-    else { ss << "/tmp/"; }
-    ss << name << "_";
-    directory(ss,run_); // Add filename with run number, host ip, pid and .root extension
-    ss << "_CALCHAN" << lastCalChan_; // Add CalChan value
-    ss << "_000"; // Add FU instance number (fake)
-    ss << ".root"; // Append ".root" extension
-    if ( !filename_.empty() ) {
-      if(std::ifstream(ss.str().c_str(),std::ifstream::in).fail()) { //save only once. Skip if the file already exist
-        dqm()->save( ss.str() ); 
-        LogTrace("DQMsource")
-          << "[SiStripCommissioningSource::" << __func__ << "]"
-          << " Saved all histograms to file \""
-          << ss.str() << "\"";
-      } else {
-        LogTrace("DQMsource")
-          << "[SiStripCommissioningSource::" << __func__ << "]"
-          << " Skipping creation of file \""
-          << ss.str() << "\" that already exists" ;
-      }
-    } else {
-      edm::LogWarning("DQMsource")
-        << "[SiStripCommissioningSource::" << __func__ << "]"
-        << " NULL value for filename! No root file saved!";
-    }
-  
-    // reset
-    for(std::vector<HistoSet>::iterator it=calib_.begin();it<calib_.end();++it) {
-      it->vNumOfEntries_.clear();
-      it->vNumOfEntries_.resize(nBins_,0);
-    }
-    // set new parameter values
-    lastCalChan_ = calchan;
-    calchanElement_->Fill(lastCalChan_);
-  }
-}
-
-// -----------------------------------------------------------------------------
-// 
-void CalibrationTask::directory( std::stringstream& dir,
-					    uint32_t run_number ) {
-
-  // Get details about host
-  char hn[256];
-  gethostname( hn, sizeof(hn) );
-  struct hostent* he;
-  he = gethostbyname(hn);
-
-  // Extract host name and ip
-  std::string host_name;
-  std::string host_ip;
-  if ( he ) { 
-    host_name = std::string(he->h_name);
-    host_ip = std::string( inet_ntoa( *(struct in_addr*)(he->h_addr) ) );
-  } else {
-    host_name = "unknown.cern.ch";
-    host_ip = "255.255.255.255";
-  }
-
-  // Reformat IP address
-  std::string::size_type pos = 0;
-  std::stringstream ip;
-  //for ( uint16_t ii = 0; ii < 4; ++ii ) {
-  while ( pos != std::string::npos ) {
-    std::string::size_type tmp = host_ip.find(".",pos);
-    if ( tmp != std::string::npos ) {
-      ip << std::setw(3)
-	 << std::setfill('0')
-	 << host_ip.substr( pos, tmp-pos ) 
-	 << ".";
-      pos = tmp+1; // skip the delimiter "."
-    } else {
-      ip << std::setw(3)
-	 << std::setfill('0')
-	 << host_ip.substr( pos );
-      pos = std::string::npos;
-    }
-  }
-  
-  // Get pid
-  pid_t pid = getpid();
-
-  // Construct string
-  dir << std::setw(8) 
-      << std::setfill('0') 
-      << run_number
-      << "_" 
-      << ip.str()
-      << "_"
-      << std::setw(5) 
-      << std::setfill('0') 
-      << pid;
+void CalibrationTask::setCurrentFolder(const std::string & dir){
+  directory_ = dir;
 }

--- a/DQM/SiStripCommissioningSources/src/CommissioningTask.cc
+++ b/DQM/SiStripCommissioningSources/src/CommissioningTask.cc
@@ -156,6 +156,16 @@ void CommissioningTask::fill( const SiStripEventSummary& summary,
     << " No derived implementation exists!";
 }
 
+// -----------------------------------------------------------------------------                                                                                                                  
+//                                                                                                                                                                                                   
+void CommissioningTask::fill( const SiStripEventSummary& summary,
+                              const edm::DetSet<SiStripRawDigi>& digis,
+                              const edm::DetSet<SiStripRawDigi>& digisAlt) {
+  edm::LogWarning(mlDqmSource_)
+    << "[CommissioningTask::" << __func__ << "]"
+    << " No derived implementation exists!";
+}
+
 // -----------------------------------------------------------------------------
 //
 void CommissioningTask::fill( const SiStripEventSummary& summary,
@@ -195,8 +205,26 @@ void CommissioningTask::fillHistograms( const SiStripEventSummary& summary,
   fill( summary, digis ); 
   if ( updateFreq_ && !(fillCntr_%updateFreq_) ) { 
     update(); 
+  }  
+}
+
+// -----------------------------------------------------------------------------                                                                                                                
+//                                                                                                                                                                                                      
+void CommissioningTask::fillHistograms( const SiStripEventSummary& summary,
+                                        const edm::DetSet<SiStripRawDigi>& digis,
+                                        const edm::DetSet<SiStripRawDigi>& digisAlt
+                                        ) {
+  if ( !booked_ ) {
+    edm::LogWarning(mlDqmSource_)
+      << "[CommissioningTask::" << __func__ << "]"
+      << " Attempting to fill histos that haven't been booked yet!";
+    return;
   }
-  
+  fillCntr_++;
+  fill( summary, digis, digisAlt );
+  if ( updateFreq_ && !(fillCntr_%updateFreq_) ) {
+    update();
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/DQM/SiStripCommissioningSources/src/CommissioningTask.cc
+++ b/DQM/SiStripCommissioningSources/src/CommissioningTask.cc
@@ -195,11 +195,16 @@ void CommissioningTask::bookHistograms() {
 //
 void CommissioningTask::fillHistograms( const SiStripEventSummary& summary,
 					const edm::DetSet<SiStripRawDigi>& digis ) {
-  if ( !booked_ ) {
-    edm::LogWarning(mlDqmSource_)
-      << "[CommissioningTask::" << __func__ << "]"
-      << " Attempting to fill histos that haven't been booked yet!";
-    return;
+  if(summary.runType() != sistrip::CALIBRATION_SCAN and
+     summary.runType() != sistrip::CALIBRATION_SCAN_DECO and
+     summary.runType() != sistrip::CALIBRATION and
+     summary.runType() != sistrip::CALIBRATION_DECO){
+    if ( !booked_ ) {
+      edm::LogWarning(mlDqmSource_)
+	<< "[CommissioningTask::" << __func__ << "]"
+	<< " Attempting to fill histos that haven't been booked yet!";
+      return;
+    }
   }
   fillCntr_++;
   fill( summary, digis ); 

--- a/DQM/SiStripCommissioningSources/src/DaqScopeModeTask.cc
+++ b/DQM/SiStripCommissioningSources/src/DaqScopeModeTask.cc
@@ -163,100 +163,46 @@ void DaqScopeModeTask::fill( const SiStripEventSummary& summary,
     }
   }
   else{
-    // fill the pedestal histograms as done in the pedestal task
-    // Check number of digis                                                                                                                                                                       
+    // fill the pedestal histograms as done in the pedestal task                                                                                                                                     
+    // Check number of digis                                                                                                                                                                          
     uint16_t nbins = peds_[0].vNumOfEntries_.size();
     if ( digis.data.size() < nbins ) { nbins = digis.data.size(); }
 
     uint16_t napvs = nbins / 128;
     std::vector<uint32_t> cm; cm.resize(napvs,0);
 
-    // Calc common mode for both APVs                                                                                                                                                               
+    // Calc common mode for both APVs                                                                                                                                                                 
     std::vector<uint16_t> adc;
     for ( uint16_t iapv = 0; iapv < napvs; iapv++ ) {
       adc.clear(); adc.reserve(128);
 
       for ( uint16_t ibin = 0; ibin < 128; ibin++ ) {
-	if ( (iapv*128)+ibin < nbins ) { 
-	  if(digis.data[(iapv*128)+ibin].adc() < 1024) // check good values
-	    adc.push_back( digis.data[(iapv*128)+ibin].adc() );  
-	  else{
-	    if((iapv*128)+ibin == 0 or (iapv*128)+ibin == 128){ // saturated channels --> fix them by hand to the neighbours
-	      for(int istrip = 1; istrip < 128; istrip++){
-		if(digis.data[(iapv*128)+istrip].adc() < 1024){
-		  adc.push_back( digis.data[(iapv*128)+istrip].adc() );
-		  break;
-		}
-	      }		
-	    }
-	    else if((iapv*128)+ibin == 127 or (iapv*128)+ibin == 255){ // find the first strip with non crazy measurement
-	      for(int istrip = 1; istrip < 128; istrip--){
-		if(digis.data[(iapv*128)-istrip].adc() < 1024){
-		  adc.push_back( digis.data[(iapv*128)-istrip].adc() );
-		  break;
-		}
-	      }		
-	    }
-	    else{
-	      for(int istrip = ibin; istrip < 128; istrip++){
-		if(digis.data[(iapv*128)-istrip].adc() < 1024 and digis.data[(iapv*128)+istrip].adc() < 1024){
-		  adc.push_back((digis.data[(iapv*128)-istrip].adc()+digis.data[(iapv*128)+istrip].adc())/2);
-		  break;
-		}
-	      }	    	    
-	    }
-	  }	
-	}
+        if ( (iapv*128)+ibin < nbins ) {
+	  adc.push_back( digis.data[(iapv*128)+ibin].adc() );
+        }
       }
-    
+
       sort( adc.begin(), adc.end() );
       uint16_t index = adc.size()%2 ? adc.size()/2 : adc.size()/2-1;
       if ( !adc.empty() ) { cm[iapv] = static_cast<uint32_t>( adc[index] ); }
     }
-    
     for ( uint16_t ibin = 0; ibin < nbins; ibin++ ) {
       float digiVal = digis.data[ibin].adc();
-      if(digiVal > 1024){
-	if(ibin == 0 or ibin == 128){
-	  for(int istrip = 1; istrip < 128; istrip++){	    
-	    if(digis.data[ibin+istrip].adc() < 1024){
-	      digiVal = digis.data[ibin+istrip].adc();
-	      break;
-	    }
-	  }		
-	}
-	else if(ibin == 127 or ibin == 255){ // find the first strip with non crazy measurement
-	  for(int istrip = 1; istrip < 128; istrip--){
-	    if(digis.data[ibin-istrip].adc() < 1024){
-	      digiVal = digis.data[ibin-istrip].adc();
-	      break;
-	    }
-	  }
-	}			
-	else{
-	  for(int istrip = ibin; istrip < nbins; istrip++){
-	    if(digis.data[ibin-istrip].adc() < 1024 and digis.data[ibin+istrip].adc() < 1024){
-	      digiVal = (digis.data[ibin-istrip].adc()+digis.data[ibin+istrip].adc())/2;
-	      break;
-	    }
-	  }
-	}
-      }
-      updateHistoSet( peds_[0], ibin, digiVal ); // peds and raw noise                                                                                                                  
+      updateHistoSet( peds_[0], ibin, digiVal ); // peds and raw noise                                                                                                                                
       float diff = digiVal - static_cast<float>( cm[ibin/128] );
-      updateHistoSet( peds_[1], ibin, diff ); // residuals and real noise                            
-
+      updateHistoSet( peds_[1], ibin, diff ); // residuals and real noise                                                                                                                             
     }
-    
+
     if ( cm.size() < cm_.size() ) {
       edm::LogWarning(mlDqmSource_)
-	<< "[PedestalsTask::" << __func__ << "]"
-	<< " Fewer CM values than expected: " << cm.size();
+        << "[PedestalsTask::" << __func__ << "]"
+        << " Fewer CM values than expected: " << cm.size();
     }
 
     updateHistoSet( cm_[0], cm[0] );
     updateHistoSet( cm_[1], cm[1] );
-  }  
+  }
+
 }
 
 // -----------------------------------------------------------------------------
@@ -286,9 +232,8 @@ void DaqScopeModeTask::fill( const SiStripEventSummary& summary,
     }
   }
   else{
-  
-    // fill the pedestal histograms as done in the pedestal task
-    // Check number of digis                                                                                                                                                                       
+    // fill the pedestal histograms as done in the pedestal task                                                                                                                                      
+    // Check number of digis                                                                                                                                                                         
     uint16_t nbins = peds_[0].vNumOfEntries_.size();
     if ( digis.data.size() < nbins ) { nbins = digis.data.size(); }
 
@@ -299,93 +244,38 @@ void DaqScopeModeTask::fill( const SiStripEventSummary& summary,
     std::vector<uint16_t> adc;
     for ( uint16_t iapv = 0; iapv < napvs; iapv++ ) {
       adc.clear(); adc.reserve(128);
-
       for ( uint16_t ibin = 0; ibin < 128; ibin++ ) {
-	if ( (iapv*128)+ibin < nbins ) { 
-	  if(digis.data[(iapv*128)+ibin].adc() < 1024) // check good values
-	    adc.push_back( digis.data[(iapv*128)+ibin].adc() );  
-	  else{
-	    if((iapv*128)+ibin == 0 or (iapv*128)+ibin == 128){ // saturated channels --> fix them by hand to the neighbours
-	      for(int istrip = 1; istrip < 128; istrip++){
-		if(digis.data[(iapv*128)+istrip].adc() < 1024){
-		  adc.push_back( digis.data[(iapv*128)+istrip].adc() );
-		  break;
-		}
-	      }		
-	    }
-	    else if((iapv*128)+ibin == 127 or (iapv*128)+ibin == 255){ // find the first strip with non crazy measurement
-	      for(int istrip = 1; istrip < 128; istrip--){
-		if(digis.data[(iapv*128)-istrip].adc() < 1024){
-		  adc.push_back( digis.data[(iapv*128)-istrip].adc() );
-		  break;
-		}
-	      }		
-	    }
-	    else{
-	      for(int istrip = ibin; istrip < 128; istrip++){
-		if(digis.data[(iapv*128)-istrip].adc() < 1024 and digis.data[(iapv*128)+istrip].adc() < 1024){
-		  adc.push_back((digis.data[(iapv*128)-istrip].adc()+digis.data[(iapv*128)+istrip].adc())/2);
-		  break;
-		}
-	      }	    	    
-	    }
-	  }	
-	}
+        if ( (iapv*128)+ibin < nbins ) {
+	  adc.push_back( digis.data[(iapv*128)+ibin].adc() );
+        }
       }
-    
       sort( adc.begin(), adc.end() );
       uint16_t index = adc.size()%2 ? adc.size()/2 : adc.size()/2-1;
       if ( !adc.empty() ) { cm[iapv] = static_cast<uint32_t>( adc[index] ); }
     }
-    
-    /// Calculate pedestal
+
+    /// Calculate pedestal                                                                                                                                                                            
     for ( uint16_t ibin = 0; ibin < nbins; ibin++ ) {
       float digiVal = digis.data[ibin].adc();
-      if(digiVal > 1024){
-	if(ibin == 0 or ibin == 128){
-	  for(int istrip = 1; istrip < 128; istrip++){	    
-	    if(digis.data[ibin+istrip].adc() < 1024){
-	      digiVal = digis.data[ibin+istrip].adc();
-	      break;
-	    }
-	  }		
-	}
-	else if(ibin == 127 or ibin == 255){ // find the first strip with non crazy measurement
-	  for(int istrip = 1; istrip < 128; istrip--){
-	    if(digis.data[ibin-istrip].adc() < 1024){
-	      digiVal = digis.data[ibin-istrip].adc();
-	      break;
-	    }
-	  }
-	}			
-	else{
-	  for(int istrip = ibin; istrip < nbins; istrip++){
-	    if(digis.data[ibin-istrip].adc() < 1024 and digis.data[ibin+istrip].adc() < 1024){
-	      digiVal = (digis.data[ibin-istrip].adc()+digis.data[ibin+istrip].adc())/2;
-	      break;
-	    }
-	  }
-	}
-      }
-      updateHistoSet( peds_[0], ibin, digiVal ); // peds and raw noise                                                                                                                  
+      updateHistoSet( peds_[0], ibin, digiVal ); // peds and raw noise                                                                                                                                
       float diff = digiVal - static_cast<float>( cm[ibin/128] );
-      updateHistoSet( peds_[1], ibin, diff ); // residuals and real noise                            
+      updateHistoSet( peds_[1], ibin, diff ); // residuals and real noise                                                                                                                             
     }
-    
+
     if ( cm.size() < cm_.size() ) {
       edm::LogWarning(mlDqmSource_)
-	<< "[PedestalsTask::" << __func__ << "]"
-	<< " Fewer CM values than expected: " << cm.size();
+        << "[PedestalsTask::" << __func__ << "]"
+        << " Fewer CM values than expected: " << cm.size();
     }
 
     updateHistoSet( cm_[0], cm[0] );
     updateHistoSet( cm_[1], cm[1] );
-    
+
     uint16_t bins = digisAlt.data.size() < nBinsSpy_ ? digisAlt.data.size() : nBinsSpy_;
     for ( uint16_t ibin = 0; ibin < bins; ibin++ ) {
-      updateHistoSet( scopeFrame_, ibin, digisAlt.data[ibin].adc() ); 
-    }    
-  }      
+      updateHistoSet( scopeFrame_, ibin, digisAlt.data[ibin].adc() );
+    }
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -412,10 +302,8 @@ void DaqScopeModeTask::update() {
       float error = 0; // sqrt(entries) / entries;                                                                                                                                                
       UpdateTProfile::setBinContent( histo, ii+1, entries, noise, error );      
     }
-
     updateHistoSet( cm_[0] );
     updateHistoSet( cm_[1] );
-
     updateHistoSet( scopeFrame_ );
 
   }

--- a/DQM/SiStripCommissioningSources/src/DaqScopeModeTask.cc
+++ b/DQM/SiStripCommissioningSources/src/DaqScopeModeTask.cc
@@ -3,16 +3,21 @@
 #include "DataFormats/SiStripCommon/interface/SiStripHistoTitle.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQM/SiStripCommon/interface/ExtractTObject.h"
+#include "DQM/SiStripCommon/interface/UpdateTProfile.h"
 
 using namespace sistrip;
 
 // -----------------------------------------------------------------------------
 //
 DaqScopeModeTask::DaqScopeModeTask( DQMStore* dqm,
-				    const FedChannelConnection& conn ) :
+				    const FedChannelConnection& conn,
+				    const edm::ParameterSet & pset) :
   CommissioningTask( dqm, conn, "DaqScopeModeTask" ),
-  scope_(),
-  nBins_(256) //@@ number of strips per FED channel
+  scopeFrame_(),
+  nBins_(256), //@@ number of strips per FED channel
+  nBinsSpy_(298), //@@ in case of spy events includes header and trailing tick
+  parameters_(pset)
 {}
 
 // -----------------------------------------------------------------------------
@@ -24,22 +29,111 @@ DaqScopeModeTask::~DaqScopeModeTask() {
 //
 void DaqScopeModeTask::book() {
   LogTrace(mlDqmSource_) << "[CommissioningTask::" << __func__ << "]";
-  
-  std::string title = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
-					 sistrip::DAQ_SCOPE_MODE, 
-					 sistrip::FED_KEY, 
-					 fedKey(),
-					 sistrip::LLD_CHAN, 
-					 connection().lldChannel() ).title();
 
-  scope_.histo( dqm()->book1D( title, title, 
-			       nBins_, -0.5, nBins_-0.5 ) );
-		
-  scope_.vNumOfEntries_.resize(nBins_,0);
-  scope_.vSumOfContents_.resize(nBins_,0);
-  scope_.vSumOfSquares_.resize(nBins_,0);
-  scope_.isProfile_ = false; 
-  
+  std::string title;
+  if(not (parameters_.existsAs<bool>("isSpy") and parameters_.getParameter<bool>("isSpy"))){
+
+    //// Scope mode histograms
+    title = SiStripHistoTitle( sistrip::EXPERT_HISTO, 
+			       sistrip::DAQ_SCOPE_MODE, 
+			       sistrip::FED_KEY, 
+			       fedKey(),
+			       sistrip::LLD_CHAN, 
+			       connection().lldChannel(),
+			       sistrip::extrainfo::scopeModeFrame_).title();
+    
+    scopeFrame_.histo( dqm()->book1D( title, title, 
+				      nBins_, -0.5, nBins_-0.5 ) );
+    
+    scopeFrame_.vNumOfEntries_.resize(nBins_,0);
+    scopeFrame_.vSumOfContents_.resize(nBins_,0);
+    scopeFrame_.vSumOfSquares_.resize(nBins_,0);
+    scopeFrame_.isProfile_ = false; 
+  }
+  else{ // use spy run to measure pedestal and tick height
+    
+    std::string extra_info;
+    peds_.resize(2);
+    extra_info = sistrip::extrainfo::pedestals_;
+
+    peds_[0].isProfile_ = true;
+    title = SiStripHistoTitle( sistrip::EXPERT_HISTO,
+			       sistrip::DAQ_SCOPE_MODE,
+			       sistrip::FED_KEY,
+			       fedKey(),
+			       sistrip::LLD_CHAN,
+			       connection().lldChannel(),
+			       extra_info ).title();
+
+    peds_[0].histo( dqm()->bookProfile( title, title,
+					nBins_, -0.5,nBins_*1.-0.5,
+					1025, 0., 1025. ) );
+
+    peds_[0].vNumOfEntries_.resize(nBins_,0);
+    peds_[0].vSumOfContents_.resize(nBins_,0);
+    peds_[0].vSumOfSquares_.resize(nBins_,0);
+    
+    // Noise histogram                                                                                                                                                                                
+    extra_info = sistrip::extrainfo::noise_;
+    peds_[1].isProfile_ = true;
+
+    title = SiStripHistoTitle( sistrip::EXPERT_HISTO,
+			       sistrip::DAQ_SCOPE_MODE,
+			       sistrip::FED_KEY,
+			       fedKey(),
+			       sistrip::LLD_CHAN,
+			       connection().lldChannel(),
+			       extra_info ).title();
+
+    peds_[1].histo( dqm()->bookProfile( title, title,
+					nBins_, -0.5, nBins_*1.-0.5,
+					1025, 0., 1025. ) );
+
+    peds_[1].vNumOfEntries_.resize(nBins_,0);
+    peds_[1].vSumOfContents_.resize(nBins_,0);
+    peds_[1].vSumOfSquares_.resize(nBins_,0);
+    
+    // Common mode histograms                                                                                                                                                                    
+    cm_.resize(2);
+    int nbins = 1024;
+
+    for ( uint16_t iapv = 0; iapv < 2; iapv++ ) {
+      title = SiStripHistoTitle( sistrip::EXPERT_HISTO,
+				 sistrip::DAQ_SCOPE_MODE,
+				 sistrip::FED_KEY,
+				 fedKey(),
+				 sistrip::APV,
+				 connection().i2cAddr(iapv),
+				 sistrip::extrainfo::commonMode_ ).title();
+      
+      cm_[iapv].histo( dqm()->book1D( title, title, nbins, -0.5, nbins*1.-0.5 ) );
+      cm_[iapv].isProfile_ = false;
+
+      cm_[iapv].vNumOfEntries_.resize(nbins,0);
+      cm_[iapv].vNumOfEntries_.resize(nbins,0);      
+    }
+
+
+    //// Scope mode histograms                                                                                                                                                                         
+    title = SiStripHistoTitle( sistrip::EXPERT_HISTO,
+                               sistrip::DAQ_SCOPE_MODE,
+                               sistrip::FED_KEY,
+                               fedKey(),
+                               sistrip::LLD_CHAN,
+                               connection().lldChannel(),
+			       sistrip::extrainfo::scopeModeFrame_).title();
+
+    scopeFrame_.histo( dqm()->bookProfile( title, title,
+					   nBinsSpy_, -0.5, nBinsSpy_*1.-0.5,
+					   1025, 0., 1025. ) );
+
+    scopeFrame_.vNumOfEntries_.resize(nBinsSpy_,0);
+    scopeFrame_.vSumOfContents_.resize(nBinsSpy_,0);
+    scopeFrame_.vSumOfSquares_.resize(nBinsSpy_,0);
+    scopeFrame_.isProfile_ = true;
+    
+
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -48,8 +142,10 @@ void DaqScopeModeTask::fill( const SiStripEventSummary& summary,
 			     const edm::DetSet<SiStripRawDigi>& digis ) {
   
   // Only fill every 'N' events 
-  if ( !updateFreq() || fillCntr()%updateFreq() ) { return; }
-  
+  if(not (parameters_.existsAs<bool>("isSpy") and parameters_.getParameter<bool>("isSpy"))){
+    if ( !updateFreq() || fillCntr()%updateFreq() ) { return; }
+  }
+
   if ( digis.data.size() != nBins_ ) { //@@ check scope mode length?  
     edm::LogWarning(mlDqmSource_)
       << "[DaqScopeModeTask::" << __func__ << "]"
@@ -58,18 +154,271 @@ void DaqScopeModeTask::fill( const SiStripEventSummary& summary,
       << ") wrt number of histogram bins ("
       << nBins_ << ")!";
   }
-  
-  uint16_t bins = digis.data.size() < nBins_ ? digis.data.size() : nBins_;
-  for ( uint16_t ibin = 0; ibin < bins; ibin++ ) {
-      updateHistoSet( scope_, ibin, digis.data[ibin].adc() ); 
+
+ 
+  if(not (parameters_.existsAs<bool>("isSpy") and parameters_.getParameter<bool>("isSpy"))){
+    uint16_t bins = digis.data.size() < nBins_ ? digis.data.size() : nBins_;
+    for ( uint16_t ibin = 0; ibin < bins; ibin++ ) {
+      updateHistoSet( scopeFrame_, ibin, digis.data[ibin].adc() ); 
+    }
   }
+  else{
+    // fill the pedestal histograms as done in the pedestal task
+    // Check number of digis                                                                                                                                                                       
+    uint16_t nbins = peds_[0].vNumOfEntries_.size();
+    if ( digis.data.size() < nbins ) { nbins = digis.data.size(); }
+
+    uint16_t napvs = nbins / 128;
+    std::vector<uint32_t> cm; cm.resize(napvs,0);
+
+    // Calc common mode for both APVs                                                                                                                                                               
+    std::vector<uint16_t> adc;
+    for ( uint16_t iapv = 0; iapv < napvs; iapv++ ) {
+      adc.clear(); adc.reserve(128);
+
+      for ( uint16_t ibin = 0; ibin < 128; ibin++ ) {
+	if ( (iapv*128)+ibin < nbins ) { 
+	  if(digis.data[(iapv*128)+ibin].adc() < 1024) // check good values
+	    adc.push_back( digis.data[(iapv*128)+ibin].adc() );  
+	  else{
+	    if((iapv*128)+ibin == 0 or (iapv*128)+ibin == 128){ // saturated channels --> fix them by hand to the neighbours
+	      for(int istrip = 1; istrip < 128; istrip++){
+		if(digis.data[(iapv*128)+istrip].adc() < 1024){
+		  adc.push_back( digis.data[(iapv*128)+istrip].adc() );
+		  break;
+		}
+	      }		
+	    }
+	    else if((iapv*128)+ibin == 127 or (iapv*128)+ibin == 255){ // find the first strip with non crazy measurement
+	      for(int istrip = 1; istrip < 128; istrip--){
+		if(digis.data[(iapv*128)-istrip].adc() < 1024){
+		  adc.push_back( digis.data[(iapv*128)-istrip].adc() );
+		  break;
+		}
+	      }		
+	    }
+	    else{
+	      for(int istrip = ibin; istrip < 128; istrip++){
+		if(digis.data[(iapv*128)-istrip].adc() < 1024 and digis.data[(iapv*128)+istrip].adc() < 1024){
+		  adc.push_back((digis.data[(iapv*128)-istrip].adc()+digis.data[(iapv*128)+istrip].adc())/2);
+		  break;
+		}
+	      }	    	    
+	    }
+	  }	
+	}
+      }
+    
+      sort( adc.begin(), adc.end() );
+      uint16_t index = adc.size()%2 ? adc.size()/2 : adc.size()/2-1;
+      if ( !adc.empty() ) { cm[iapv] = static_cast<uint32_t>( adc[index] ); }
+    }
+    
+    for ( uint16_t ibin = 0; ibin < nbins; ibin++ ) {
+      float digiVal = digis.data[ibin].adc();
+      if(digiVal > 1024){
+	if(ibin == 0 or ibin == 128){
+	  for(int istrip = 1; istrip < 128; istrip++){	    
+	    if(digis.data[ibin+istrip].adc() < 1024){
+	      digiVal = digis.data[ibin+istrip].adc();
+	      break;
+	    }
+	  }		
+	}
+	else if(ibin == 127 or ibin == 255){ // find the first strip with non crazy measurement
+	  for(int istrip = 1; istrip < 128; istrip--){
+	    if(digis.data[ibin-istrip].adc() < 1024){
+	      digiVal = digis.data[ibin-istrip].adc();
+	      break;
+	    }
+	  }
+	}			
+	else{
+	  for(int istrip = ibin; istrip < nbins; istrip++){
+	    if(digis.data[ibin-istrip].adc() < 1024 and digis.data[ibin+istrip].adc() < 1024){
+	      digiVal = (digis.data[ibin-istrip].adc()+digis.data[ibin+istrip].adc())/2;
+	      break;
+	    }
+	  }
+	}
+      }
+      updateHistoSet( peds_[0], ibin, digiVal ); // peds and raw noise                                                                                                                  
+      float diff = digiVal - static_cast<float>( cm[ibin/128] );
+      updateHistoSet( peds_[1], ibin, diff ); // residuals and real noise                            
+
+    }
+    
+    if ( cm.size() < cm_.size() ) {
+      edm::LogWarning(mlDqmSource_)
+	<< "[PedestalsTask::" << __func__ << "]"
+	<< " Fewer CM values than expected: " << cm.size();
+    }
+
+    updateHistoSet( cm_[0], cm[0] );
+    updateHistoSet( cm_[1], cm[1] );
+  }  
+}
+
+// -----------------------------------------------------------------------------
+//
+void DaqScopeModeTask::fill( const SiStripEventSummary& summary,
+			     const edm::DetSet<SiStripRawDigi>& digis,
+			     const edm::DetSet<SiStripRawDigi>& digisAlt) {
   
+  // Only fill every 'N' events 
+  if(not (parameters_.existsAs<bool>("isSpy") and parameters_.getParameter<bool>("isSpy"))){
+    if ( !updateFreq() || fillCntr()%updateFreq() ) { return; }
+  }
+
+  if ( digis.data.size() != nBins_ ) { //@@ check scope mode length?  
+    edm::LogWarning(mlDqmSource_)
+      << "[DaqScopeModeTask::" << __func__ << "]"
+      << " Unexpected number of digis (" 
+      << digis.data.size()
+      << ") wrt number of histogram bins ("
+      << nBins_ << ")!";
+  }
+
+  if(not (parameters_.existsAs<bool>("isSpy") and parameters_.getParameter<bool>("isSpy"))){
+    uint16_t bins = digis.data.size() < nBins_ ? digis.data.size() : nBins_;
+    for ( uint16_t ibin = 0; ibin < bins; ibin++ ) {
+      updateHistoSet( scopeFrame_, ibin, digis.data[ibin].adc() ); 
+    }
+  }
+  else{
+  
+    // fill the pedestal histograms as done in the pedestal task
+    // Check number of digis                                                                                                                                                                       
+    uint16_t nbins = peds_[0].vNumOfEntries_.size();
+    if ( digis.data.size() < nbins ) { nbins = digis.data.size(); }
+
+    uint16_t napvs = nbins / 128;
+    std::vector<uint32_t> cm; cm.resize(napvs,0);
+
+    // Calc common mode for both APVs                                                                                                                                                               
+    std::vector<uint16_t> adc;
+    for ( uint16_t iapv = 0; iapv < napvs; iapv++ ) {
+      adc.clear(); adc.reserve(128);
+
+      for ( uint16_t ibin = 0; ibin < 128; ibin++ ) {
+	if ( (iapv*128)+ibin < nbins ) { 
+	  if(digis.data[(iapv*128)+ibin].adc() < 1024) // check good values
+	    adc.push_back( digis.data[(iapv*128)+ibin].adc() );  
+	  else{
+	    if((iapv*128)+ibin == 0 or (iapv*128)+ibin == 128){ // saturated channels --> fix them by hand to the neighbours
+	      for(int istrip = 1; istrip < 128; istrip++){
+		if(digis.data[(iapv*128)+istrip].adc() < 1024){
+		  adc.push_back( digis.data[(iapv*128)+istrip].adc() );
+		  break;
+		}
+	      }		
+	    }
+	    else if((iapv*128)+ibin == 127 or (iapv*128)+ibin == 255){ // find the first strip with non crazy measurement
+	      for(int istrip = 1; istrip < 128; istrip--){
+		if(digis.data[(iapv*128)-istrip].adc() < 1024){
+		  adc.push_back( digis.data[(iapv*128)-istrip].adc() );
+		  break;
+		}
+	      }		
+	    }
+	    else{
+	      for(int istrip = ibin; istrip < 128; istrip++){
+		if(digis.data[(iapv*128)-istrip].adc() < 1024 and digis.data[(iapv*128)+istrip].adc() < 1024){
+		  adc.push_back((digis.data[(iapv*128)-istrip].adc()+digis.data[(iapv*128)+istrip].adc())/2);
+		  break;
+		}
+	      }	    	    
+	    }
+	  }	
+	}
+      }
+    
+      sort( adc.begin(), adc.end() );
+      uint16_t index = adc.size()%2 ? adc.size()/2 : adc.size()/2-1;
+      if ( !adc.empty() ) { cm[iapv] = static_cast<uint32_t>( adc[index] ); }
+    }
+    
+    /// Calculate pedestal
+    for ( uint16_t ibin = 0; ibin < nbins; ibin++ ) {
+      float digiVal = digis.data[ibin].adc();
+      if(digiVal > 1024){
+	if(ibin == 0 or ibin == 128){
+	  for(int istrip = 1; istrip < 128; istrip++){	    
+	    if(digis.data[ibin+istrip].adc() < 1024){
+	      digiVal = digis.data[ibin+istrip].adc();
+	      break;
+	    }
+	  }		
+	}
+	else if(ibin == 127 or ibin == 255){ // find the first strip with non crazy measurement
+	  for(int istrip = 1; istrip < 128; istrip--){
+	    if(digis.data[ibin-istrip].adc() < 1024){
+	      digiVal = digis.data[ibin-istrip].adc();
+	      break;
+	    }
+	  }
+	}			
+	else{
+	  for(int istrip = ibin; istrip < nbins; istrip++){
+	    if(digis.data[ibin-istrip].adc() < 1024 and digis.data[ibin+istrip].adc() < 1024){
+	      digiVal = (digis.data[ibin-istrip].adc()+digis.data[ibin+istrip].adc())/2;
+	      break;
+	    }
+	  }
+	}
+      }
+      updateHistoSet( peds_[0], ibin, digiVal ); // peds and raw noise                                                                                                                  
+      float diff = digiVal - static_cast<float>( cm[ibin/128] );
+      updateHistoSet( peds_[1], ibin, diff ); // residuals and real noise                            
+    }
+    
+    if ( cm.size() < cm_.size() ) {
+      edm::LogWarning(mlDqmSource_)
+	<< "[PedestalsTask::" << __func__ << "]"
+	<< " Fewer CM values than expected: " << cm.size();
+    }
+
+    updateHistoSet( cm_[0], cm[0] );
+    updateHistoSet( cm_[1], cm[1] );
+    
+    uint16_t bins = digisAlt.data.size() < nBinsSpy_ ? digisAlt.data.size() : nBinsSpy_;
+    for ( uint16_t ibin = 0; ibin < bins; ibin++ ) {
+      updateHistoSet( scopeFrame_, ibin, digisAlt.data[ibin].adc() ); 
+    }    
+  }      
 }
 
 // -----------------------------------------------------------------------------
 //
 void DaqScopeModeTask::update() {
-  updateHistoSet( scope_ );
+
+  if(not (parameters_.existsAs<bool>("isSpy") and parameters_.getParameter<bool>("isSpy")))
+    updateHistoSet( scopeFrame_ );
+  else{
+    
+    updateHistoSet( peds_[0] );   
+    TProfile* histo = ExtractTObject<TProfile>().extract( peds_[1].histo() );
+    for ( uint16_t ii = 0; ii < peds_[1].vNumOfEntries_.size(); ++ii ) {
+
+      float mean    = 0.;
+      float spread  = 0.;
+      float entries = peds_[1].vNumOfEntries_[ii];
+      if ( entries > 0. ) {
+	mean   = peds_[1].vSumOfContents_[ii] / entries;
+	spread = sqrt( peds_[1].vSumOfSquares_[ii] / entries - mean * mean );
+      }
+      
+      float noise = spread;
+      float error = 0; // sqrt(entries) / entries;                                                                                                                                                
+      UpdateTProfile::setBinContent( histo, ii+1, entries, noise, error );      
+    }
+
+    updateHistoSet( cm_[0] );
+    updateHistoSet( cm_[1] );
+
+    updateHistoSet( scopeFrame_ );
+
+  }
 }
 
 

--- a/DQM/SiStripCommissioningSources/src/SiStripCommissioningSource.cc
+++ b/DQM/SiStripCommissioningSources/src/SiStripCommissioningSource.cc
@@ -104,7 +104,7 @@ SiStripCommissioningSource::~SiStripCommissioningSource() {
 DQMStore* const SiStripCommissioningSource::dqm( std::string method ) const {
   if ( !dqm_ ) { 
     std::stringstream ss;
-    if ( method != "" ) { ss << "[SiStripCommissioningSource::" << method << "]" << std::endl; }
+    if ( !method.empty() ) { ss << "[SiStripCommissioningSource::" << method << "]" << std::endl; }
     else { ss << "[SiStripCommissioningSource]" << std::endl; }
     ss << " NULL pointer to DQMStore";
     edm::LogWarning(mlDqmSource_) << ss.str();

--- a/DQM/SiStripCommissioningSources/src/SiStripCommissioningSource.cc
+++ b/DQM/SiStripCommissioningSources/src/SiStripCommissioningSource.cc
@@ -1087,17 +1087,22 @@ void SiStripCommissioningSource::createTasks( sistrip::RunType run_type, const e
           }
 
           // Check if fed_key is found and, if so, book histos and set update freq
+
+          // Check if fed_key is found and, if so, book histos and set update freq                                                                                                                      
           if ( tasks_[iconn->fedId()][iconn->fedCh()] ) {
             tasks_[iconn->fedId()][iconn->fedCh()]->eventSetup( &setup );
-            tasks_[iconn->fedId()][iconn->fedCh()]->bookHistograms(); 
-            tasks_[iconn->fedId()][iconn->fedCh()]->updateFreq( updateFreq_ ); 
+            if(task_ != sistrip::CALIBRATION_SCAN and task_ != sistrip::CALIBRATION_SCAN_DECO and
+	       task_ != sistrip::CALIBRATION and task_ != sistrip::CALIBRATION_DECO)
+              tasks_[iconn->fedId()][iconn->fedCh()]->bookHistograms();
+
+            else{
+              if(task_ == sistrip::CALIBRATION_SCAN or task_ == sistrip::CALIBRATION_SCAN_DECO)
+                static_cast<CalibrationScanTask*>(tasks_[iconn->fedId()][iconn->fedCh()])->setCurrentFolder(dir.str());
+              else if(task_ == sistrip::CALIBRATION or task_ == sistrip::CALIBRATION_DECO)
+                static_cast<CalibrationTask*>(tasks_[iconn->fedId()][iconn->fedCh()])->setCurrentFolder(dir.str());
+            }
+            tasks_[iconn->fedId()][iconn->fedCh()]->updateFreq( updateFreq_ );
             booked++;
-            //std::stringstream ss;
-            //ss << "[SiStripCommissioningSource::" << __func__ << "]"
-            //<< " Booking histograms for '" << tasks_[iconn->fedId()][iconn->fedCh()]->myName()
-            //<< "' object with key 0x" << std::hex << std::setfill('0') << std::setw(8) << fed_key.key() << std::dec
-            //<< " in directory " << dir.str();
-            //LogTrace(mlDqmSource_) << ss.str();
           } else {
             std::stringstream ss;
             ss << "[SiStripCommissioningSource::" << __func__ << "]"

--- a/DQM/SiStripCommissioningSummary/interface/DaqScopeModeSummaryFactory.h
+++ b/DQM/SiStripCommissioningSummary/interface/DaqScopeModeSummaryFactory.h
@@ -1,37 +1,15 @@
 #ifndef DQM_SiStripCommissioningSummary_DaqScopeModeSummaryFactory_H
 #define DQM_SiStripCommissioningSummary_DaqScopeModeSummaryFactory_H
 
-#include "DQM/SiStripCommissioningSummary/interface/SummaryHistogramFactory.h"
-#include "CondFormats/SiStripObjects/interface/DaqScopeModeAnalysis.h"
+#include "DQM/SiStripCommissioningSummary/interface/CommissioningSummaryFactory.h"
 
-class SummaryGenerator;
-
-template<>
-class SummaryHistogramFactory<DaqScopeModeAnalysis> {
+class DaqScopeModeSummaryFactory : public SummaryPlotFactory<CommissioningAnalysis*> {
   
- public:
+ protected:
   
-  SummaryHistogramFactory();
-  ~SummaryHistogramFactory();
-
-  void init( const sistrip::Monitorable&, 
-	     const sistrip::Presentation&,
-	     const sistrip::View&, 
-	     const std::string& top_level_dir, 
-	     const sistrip::Granularity& );
+  void extract( Iterator );
   
-  uint32_t extract( const std::map<uint32_t,DaqScopeModeAnalysis>& data );
-  
-  void fill( TH1& summary_histo );
-  
- private:
-  
-  sistrip::Monitorable mon_;
-  sistrip::Presentation pres_;
-  sistrip::View view_;
-  std::string level_;
-  sistrip::Granularity gran_;
-  SummaryGenerator* generator_;
+  void format();
   
 };
 

--- a/DQM/SiStripCommissioningSummary/interface/DaqScopeModeSummaryFactory.h
+++ b/DQM/SiStripCommissioningSummary/interface/DaqScopeModeSummaryFactory.h
@@ -7,9 +7,9 @@ class DaqScopeModeSummaryFactory : public SummaryPlotFactory<CommissioningAnalys
   
  protected:
   
-  void extract( Iterator );
+  void extract( Iterator ) override;
   
-  void format();
+  void format() override;
   
 };
 

--- a/DQM/SiStripCommissioningSummary/src/PedsFullNoiseSummaryFactory.cc
+++ b/DQM/SiStripCommissioningSummary/src/PedsFullNoiseSummaryFactory.cc
@@ -466,6 +466,8 @@ void PedsFullNoiseSummaryFactory::format() {
   }
   else if( mon_ == sistrip::NUM_OF_BAD_LOW_NOISE) {
   }
+  else if( mon_ == sistrip::NUM_OF_BAD_LARGE_NOISE) {
+  }
   else if( mon_ == sistrip::NUM_OF_BAD_LARGE_SIGNIF) {
   }
   else if( mon_ == sistrip::NUM_OF_BAD_FIT_STATUS) {

--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyUnpacker.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyUnpacker.h
@@ -51,7 +51,7 @@ namespace sistrip {
       private:
         // Configuration
         const bool allowIncompleteEvents_;
-        
+
     }; // end of SpyUnpacker class.
   
 } // end of sistrip namespace.

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyDigiConverter.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyDigiConverter.cc
@@ -156,7 +156,8 @@ namespace sistrip {
       const DetSetRawDigis::const_iterator payloadBegin = iDigi+aHeaderBitVec[lCh]+24;
       const DetSetRawDigis::const_iterator payloadEnd = payloadBegin + STRIPS_PER_FEDCH;
               
-              
+      if(payloadEnd-iDigi >= endOfChannel-iDigi) continue; // few-cases where this is possible, i.e. nothing above frame-threhsold                                                                
+
       // Copy data into output collection
       // Create new detSet with same key (in this case it is the fedKey, not detId)
       outputData.push_back( DetSetRawDigis((*lIter)->detId()) );
@@ -227,7 +228,7 @@ namespace sistrip {
 	if (iConn->detId() == sistrip::invalid32_) continue;
                 
 	// Find the data from the input collection
-	const uint32_t fedIndex = SiStripFedKey::fedIndex(iConn->fedId(),iConn->fedCh());
+	const uint32_t fedIndex = ( ( iConn->detId()  & sistrip::invalid_ ) << 16 ) | ( iConn->fedCh() & sistrip::invalid_ ) ;
 	const DSVRawDigis::const_iterator iDetSet = inputPhysicalOrderChannelDigis->find(fedIndex);
 	if (iDetSet == inputPhysicalOrderChannelDigis->end()) {
 	  // NOTE: It will display this warning if channel hasn't been unpacked...

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
@@ -302,7 +302,7 @@ namespace sistrip {
       outputL1ACounters[fedId] = (*inputL1ACounters)[fedId];
       outputAPVAddresses[fedId] = (*inputAPVAddresses)[fedId];
       for (uint8_t chan = 0; chan < FEDCH_PER_FED; ++chan) {
-        uint32_t fedIndex = SiStripFedKey::fedIndex(fedId,chan);
+        uint32_t fedIndex = ( ( fedId & sistrip::invalid_ ) << 16 ) | ( chan & sistrip::invalid_ ) ;;
         if (inputScopeDigis) {
           edm::DetSetVector<SiStripRawDigi>::const_iterator iScopeDigis = inputScopeDigis->find(fedIndex);
           if (iScopeDigis != inputScopeDigis->end()) {

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
@@ -187,8 +187,9 @@ namespace sistrip {
 	  }
 	  continue;
 	}
-	//determine key from cabling
-	const uint32_t key = SiStripFedKey::fedIndex(lFedId,chan);
+
+	//determine key from cabling	
+	const uint32_t key = ( ( lFedId & sistrip::invalid_ ) << 16 ) | ( chan & sistrip::invalid_ );
 
 	// Start a new channel in the filler
 	dsvFiller.newChannel(key);

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUnpackerModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUnpackerModule.cc
@@ -72,8 +72,7 @@ namespace sistrip {
         const bool allowIncompleteEvents_;  //!< Allow inconsistent (by event count, APV address) event storage.
         const bool storeCounters_;          //!< True = store L1ID and TotalEventCount by FED key.
         const bool storeScopeRawDigis_;           //!< True = store the scope mode raw digis.
-
-        // Unpacking
+      // Unpacking
         SpyUnpacker* unpacker_;      //!<
     
       //utilities for cabling etc...

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUtilities.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUtilities.cc
@@ -151,14 +151,11 @@ namespace sistrip {
       if (val==0)     numzeroes++;
       if (val==0x3FF) numsats++;
       lFrame.baseline += val;
-//       std::cout<<"val : "<<val<<std::endl;
     }
 
     if (!channelDigis.empty()) lFrame.baseline = lFrame.baseline/channelDigis.size();
     lFrame.digitalLow = min;
     lFrame.digitalHigh = max;
-//    std::cout<<"lFrame.digitalLow : "<<lFrame.digitalLow<<std::endl;
-//    std::cout<<"lFrame.digitalHigh : "<<lFrame.digitalHigh<<std::endl;    
 
     const uint16_t threshold = static_cast<uint16_t>( (2.0 * static_cast<double>(max-min)) / 3.0 );
 

--- a/DataFormats/SiStripCommon/interface/ConstantsForDqm.h
+++ b/DataFormats/SiStripCommon/interface/ConstantsForDqm.h
@@ -58,6 +58,9 @@ namespace sistrip {
 
     static const char clusterCharge_[]     = "ClusterCharge";
     static const char occupancy_[]         = "Occupancy";
+
+    // ---------- DaqScopeMode -----
+    static const char scopeModeFrame_[] = "DaqScopeFrame";
     
   }
   

--- a/OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h
+++ b/OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h
@@ -96,6 +96,7 @@ class SiStripConfigDb {
   friend class LatencyHistosUsingDb;
   friend class FineDelayHistosUsingDb;
   friend class CalibrationHistosUsingDb;
+  friend class DaqScopeModeHistosUsingDb;
 
   // Utility and tests
   friend class SiStripPartition;


### PR DESCRIPTION
This pull request includes several updates for:

1) New workflow (DaqScopeMode task) developed to use SiStrip spy-data to measure pedestal, noise and tick-mark height.
2) Updates for calibration-scan and calibration-run source steps due to the migration to a new SiStrip local-DAQ infrastructure.
3) Bug fix in the condition upload for the SiStrip online bad-strip analysis, plus fix in the analysis summary plot generation.

None of the proposed changes should affect the production workflow.