### PR TITLE
set SERIAL on histogram fits to restore deterministic fits

### DIFF
--- a/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
+++ b/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
@@ -945,7 +945,7 @@ void DQMGenericClient::limitedFit(MonitorElement * srcME, MonitorElement * meanM
       double x1,x2;
       fitFcn->GetRange(x1,x2);
 
-      histoY->Fit(fitFcn,"QR0","",x1,x2);
+      histoY->Fit(fitFcn,"QR0 SERIAL","",x1,x2);
 
 //      histoY->Fit(fitFcn->GetName(),"RME");
       double *par = fitFcn->GetParameters();

--- a/DQMServices/ClientConfig/src/FitSlicesYTool.cc
+++ b/DQMServices/ClientConfig/src/FitSlicesYTool.cc
@@ -11,7 +11,7 @@ FitSlicesYTool::FitSlicesYTool(MonitorElement* me)
   TH1::AddDirectory(true);
   // ... create your hists
   TH2F * h = me->getTH2F();
-  h->FitSlicesY();
+  h->FitSlicesY(nullptr, 0, -1, 0, "QNR SERIAL");
   string name(h->GetName());
   h0 = (TH1*)gDirectory->Get((name+"_0").c_str());
   h1 = (TH1*)gDirectory->Get((name+"_1").c_str());

--- a/RecoHI/HiTracking/plugins/HIPixelMedianVtxProducer.cc
+++ b/RecoHI/HiTracking/plugins/HIPixelMedianVtxProducer.cc
@@ -161,7 +161,7 @@ void HIPixelMedianVtxProducer::produce
   f1.SetParLimits(2,0.001,0.05);
   f1.SetParLimits(3,0.0,0.005*tracks.size());
     
-  histo.Fit(&f1,"QN");
+  histo.Fit(&f1,"QN SERIAL");
     
   LogTrace("MinBiasTracking")
     << "  [vertex position] fitted    = "


### PR DESCRIPTION
In ROOT 6.12 with IMT enabled, the chi2 calculation for fits is chunked based on the number of cpus, changing the order of calculations.  In some (possibly pathological) cases this can change the results, causing problems for the automated comparisons used for pull requests.  This PR sets the SERIAL option on several fits to restore the deterministic ordering from prior to ROOT 6.12.  Details are in issue #23105 and see also previous history in PR #22227