### PR TITLE
Made comparison functions const

### DIFF
--- a/CondFormats/HcalObjects/interface/HcalDcsMap.h
+++ b/CondFormats/HcalObjects/interface/HcalDcsMap.h
@@ -130,31 +130,31 @@ class HcalDcsMap {
 namespace HcalDcsMapAddons {
   class LessById {
    public:
-    bool operator () (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) {
+    bool operator () (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) const {
       return a->mId < b->mId;
     }
-    bool operator () (const HcalDcsMap::Item& a, const HcalDcsMap::Item& b) {
+    bool operator () (const HcalDcsMap::Item& a, const HcalDcsMap::Item& b) const {
       return a.mId < b.mId;
     }
-    bool equal (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) {
+    bool equal (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) const {
       return a->mId == b->mId;
     }
-    bool good (const HcalDcsMap::Item& a) {
+    bool good (const HcalDcsMap::Item& a) const {
       return a.mDcsId;
     }
   };
   class LessByDcsId {
    public:
-    bool operator () (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) {
+    bool operator () (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) const {
       return a->mDcsId < b->mDcsId;
     }
-    bool operator () (const HcalDcsMap::Item& a, const HcalDcsMap::Item& b) {
+    bool operator () (const HcalDcsMap::Item& a, const HcalDcsMap::Item& b) const {
       return a.mDcsId < b.mDcsId;
     }
-    bool equal (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) {
+    bool equal (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) const {
       return a->mDcsId == b->mDcsId;
     }
-    bool good (const HcalDcsMap::Item& a) {
+    bool good (const HcalDcsMap::Item& a) const {
       return a.mDcsId;
     }
   };

--- a/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
+++ b/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
@@ -82,10 +82,10 @@ protected:
 namespace HcalFrontEndMapAddons {
   class LessById {
    public: 
-    bool operator () (const HcalFrontEndMap::PrecisionItem* a, const HcalFrontEndMap::PrecisionItem* b) {return a->mId < b->mId;}
-    bool operator () (const HcalFrontEndMap::PrecisionItem& a, const HcalFrontEndMap::PrecisionItem& b) {return a.mId < b.mId;}
-    bool equal (const HcalFrontEndMap::PrecisionItem* a, const HcalFrontEndMap::PrecisionItem* b) {return a->mId == b->mId;}
-    bool good (const HcalFrontEndMap::PrecisionItem& a) {return a.mId;}
+    bool operator () (const HcalFrontEndMap::PrecisionItem* a, const HcalFrontEndMap::PrecisionItem* b) const {return a->mId < b->mId;}
+    bool operator () (const HcalFrontEndMap::PrecisionItem& a, const HcalFrontEndMap::PrecisionItem& b) const {return a.mId < b.mId;}
+    bool equal (const HcalFrontEndMap::PrecisionItem* a, const HcalFrontEndMap::PrecisionItem* b) const {return a->mId == b->mId;}
+    bool good (const HcalFrontEndMap::PrecisionItem& a) const {return a.mId;}
   };
   class Helper {
    public:

--- a/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
+++ b/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
@@ -87,10 +87,10 @@ protected:
 namespace HcalSiPMCharacteristicsAddons {
   class LessByType {
    public: 
-    bool operator () (const HcalSiPMCharacteristics::PrecisionItem* a, const HcalSiPMCharacteristics::PrecisionItem* b) {return a->type_ < b->type_;}
-    bool operator () (const HcalSiPMCharacteristics::PrecisionItem& a, const HcalSiPMCharacteristics::PrecisionItem& b) {return a.type_ < b.type_;}
-    bool equal (const HcalSiPMCharacteristics::PrecisionItem* a, const HcalSiPMCharacteristics::PrecisionItem* b) {return a->type_ == b->type_;}
-    bool good (const HcalSiPMCharacteristics::PrecisionItem& a) {return a.type_;}
+    bool operator () (const HcalSiPMCharacteristics::PrecisionItem* a, const HcalSiPMCharacteristics::PrecisionItem* b) const {return a->type_ < b->type_;}
+    bool operator () (const HcalSiPMCharacteristics::PrecisionItem& a, const HcalSiPMCharacteristics::PrecisionItem& b) const {return a.type_ < b.type_;}
+    bool equal (const HcalSiPMCharacteristics::PrecisionItem* a, const HcalSiPMCharacteristics::PrecisionItem* b) const {return a->type_ == b->type_;}
+    bool good (const HcalSiPMCharacteristics::PrecisionItem& a) const {return a.type_;}
   };
   class Helper {
    public:


### PR DESCRIPTION
gcc8 requires that comparison functions used in sorted std containers
must be const.