### PR TITLE
Changes to CalibFormats/SiPixelObjects to fix gcc 8 compiler errors

### DIFF
--- a/CalibFormats/SiPixelObjects/interface/PixelTimeFormatter.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelTimeFormatter.h
@@ -58,14 +58,16 @@ namespace pos{
     //---------------------------------------------------------------------------------
     static std::string getTime(void) 
     {
-      char theDate[20] ;
+      constexpr size_t kBufferLength = 72;
+      char theDate[kBufferLength] ;
       struct tm *thisTime;
       time_t aclock;
       std::string date ;
       time( &aclock );		  
       thisTime = localtime( &aclock ); 
        
-      sprintf(theDate,
+      snprintf(theDate,
+               kBufferLength,
 	      "%d-%02d-%02d %02d:%02d:%02d", thisTime->tm_year+1900,
 	      thisTime->tm_mon+1,
 	      thisTime->tm_mday,
@@ -90,11 +92,13 @@ namespace pos{
     //---------------------------------------------------------------------------------
     static std::string getmSecTime(void) 
     {
-      char theDate[20] ;
+      constexpr size_t kBufferSize = 20;
+      char theDate[kBufferSize] ;
       struct timeval msecTime;
       gettimeofday(&msecTime, (struct timezone *)nullptr) ;
       
-      sprintf(theDate,
+      snprintf(theDate,
+               kBufferSize,
 	      "%d-%d", 
 	      (unsigned int)msecTime.tv_sec,
 	      (unsigned int)msecTime.tv_usec ); 

--- a/CalibFormats/SiPixelObjects/src/PixelROCMaskBits.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelROCMaskBits.cc
@@ -23,23 +23,16 @@ PixelROCMaskBits::PixelROCMaskBits(){
 void PixelROCMaskBits::setROCMaskBits(PixelROCName& rocid ,std::string bits)
 {
   std::string mthn = "[PixelROCMaskBits::setROCMaskBits()]\t\t\t    " ;
-try
-  {
-    rocid_=rocid;
-    char cpt[520] ;
-    bits.copy( cpt , 520);
-    for(unsigned int i = 0 ; i < bits.size(); i++)
-      {
-	bits_[i] = (unsigned char)cpt[i];
-	//      std::cout<< "bits_[" << i << "]\t" << bits_[i] <<std::endl;
-	//      std::cout<<rocid_<<std::endl;
-	//      std::cout.flags(std::ios::hex)
-      }
-  }
- catch(std::bad_cast)
-   {
-     std::cout << __LINE__ << "]\t" << mthn << "Error casting variable." << std::endl;
-   }
+  rocid_=rocid;
+  char cpt[520] ;
+  bits.copy( cpt , 520);
+  for(unsigned int i = 0 ; i < bits.size(); i++)
+    {
+      bits_[i] = static_cast<unsigned char>(cpt[i]);
+      //      std::cout<< "bits_[" << i << "]\t" << bits_[i] <<std::endl;
+      //      std::cout<<rocid_<<std::endl;
+      //      std::cout.flags(std::ios::hex)
+    }
 }
 /**********************End Modification******************************/
 

--- a/CalibFormats/SiPixelObjects/src/PixelROCTrimBits.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelROCTrimBits.cc
@@ -22,17 +22,11 @@ PixelROCTrimBits::PixelROCTrimBits()
 void PixelROCTrimBits::setROCTrimBits(PixelROCName rocid , std::string bits)
 {
 
-try{
   rocid_=rocid;
   char cpt[2080] ;
   bits.copy( cpt , 2080);
   for(unsigned int i = 0 ; i < bits.size(); i++)
-        bits_[i] = (unsigned char)cpt[i];
-}catch(std::bad_cast){
-
-std::cout << "Error casting variable." << std::endl;
-
-}	
+    bits_[i] = static_cast<unsigned char>(cpt[i]);
   
 }
 //End of part modified


### PR DESCRIPTION
This avoids potential buffer problems with calls to sprintf as well as removed unnecessary try {} catch block.