### PR TITLE
Fixed sprintf buffer length problems

### DIFF
--- a/DataFormats/Scalers/src/BeamSpotOnline.cc
+++ b/DataFormats/Scalers/src/BeamSpotOnline.cc
@@ -75,7 +75,8 @@ BeamSpotOnline::~BeamSpotOnline() { }
 std::ostream& operator<<(std::ostream& s, const BeamSpotOnline& c) 
 {
   char zeit[128];
-  char line[128];
+  constexpr size_t kLineBufferSize = 157;
+  char line[kLineBufferSize];
   struct tm * hora;
 
   s << "BeamSpotOnline    Version: " << c.version() << 
@@ -84,28 +85,34 @@ std::ostream& operator<<(std::ostream& s, const BeamSpotOnline& c)
   timespec ts = c.collectionTime();
   hora = gmtime(&ts.tv_sec);
   strftime(zeit, sizeof(zeit), "%Y.%m.%d %H:%M:%S", hora);
-  sprintf(line, " CollectionTime: %s.%9.9d", zeit, 
-	  (int)ts.tv_nsec);
+  snprintf(line, kLineBufferSize,
+           " CollectionTime: %s.%9.9d", zeit, 
+           (int)ts.tv_nsec);
   s << line << std::endl;
 
-  sprintf(line, " TrigType: %d   EventID: %d    BunchNumber: %d", 
-	  c.trigType(), c.eventID(), c.bunchNumber());
+  snprintf(line, kLineBufferSize,
+           " TrigType: %d   EventID: %d    BunchNumber: %d", 
+           c.trigType(), c.eventID(), c.bunchNumber());
   s << line << std::endl;
 
-  sprintf(line,"    x: %e +/- %e   width: %e +/- %e",
-	  c.x(), c.err_x(), c.width_x(), c.err_width_x());
+  snprintf(line, kLineBufferSize,
+           "    x: %e +/- %e   width: %e +/- %e",
+           c.x(), c.err_x(), c.width_x(), c.err_width_x());
   s << line << std::endl;
 
-  sprintf(line,"    y: %e +/- %e   width: %e +/- %e",
-	  c.y(), c.err_y(), c.width_y(), c.err_width_y());
+  snprintf(line, kLineBufferSize,
+           "    y: %e +/- %e   width: %e +/- %e",
+           c.y(), c.err_y(), c.width_y(), c.err_width_y());
   s << line << std::endl;
 
-  sprintf(line,"    z: %e +/- %e   sigma: %e +/- %e",
-	  c.z(), c.err_z(), c.sigma_z(), c.err_sigma_z());
+  snprintf(line, kLineBufferSize,
+           "    z: %e +/- %e   sigma: %e +/- %e",
+           c.z(), c.err_z(), c.sigma_z(), c.err_sigma_z());
   s << line << std::endl;
 
-  sprintf(line," dxdy: %e +/- %e    dydz: %e +/- %e",
-	  c.dxdz(), c.err_dxdz(), c.dydz(), c.err_dydz());
+  snprintf(line, kLineBufferSize,
+           " dxdy: %e +/- %e    dydz: %e +/- %e",
+           c.dxdz(), c.err_dxdz(), c.dydz(), c.err_dydz());
   s << line << std::endl;
   return s;
 }

--- a/DataFormats/Scalers/src/DcsStatus.cc
+++ b/DataFormats/Scalers/src/DcsStatus.cc
@@ -102,8 +102,10 @@ DcsStatus::~DcsStatus() { }
 /// Pretty-print operator for DcsStatus
 std::ostream& operator<<(std::ostream& s, const DcsStatus& c) 
 {
-  char zeit[128];
-  char line[128];
+  constexpr size_t kZeitBufferSize = 128;
+  char zeit[kZeitBufferSize];
+  constexpr size_t kLineBufferSize = 157;
+  char line[kLineBufferSize];
   struct tm * hora;
 
   s << "DcsStatus    Version: " << c.version() << 
@@ -111,31 +113,31 @@ std::ostream& operator<<(std::ostream& s, const DcsStatus& c)
 
   timespec ts = c.collectionTime();
   hora = gmtime(&ts.tv_sec);
-  strftime(zeit, sizeof(zeit), "%Y.%m.%d %H:%M:%S", hora);
-  sprintf(line, " CollectionTime: %s.%9.9d", zeit, 
+  strftime(zeit, kZeitBufferSize, "%Y.%m.%d %H:%M:%S", hora);
+  snprintf(line, kLineBufferSize, " CollectionTime: %s.%9.9d", zeit, 
 	  (int)ts.tv_nsec);
   s << line << std::endl;
 
-  sprintf(line, " TrigType: %d   EventID: %d    BunchNumber: %d", 
+  snprintf(line, kLineBufferSize, " TrigType: %d   EventID: %d    BunchNumber: %d", 
 	  c.trigType(), c.eventID(), c.bunchNumber());
   s << line << std::endl;
 
-  sprintf(line," MagnetCurrent: %e    MagnetTemperature: %e", 
+  snprintf(line, kLineBufferSize, " MagnetCurrent: %e    MagnetTemperature: %e", 
 	  c.magnetCurrent(), c.magnetTemperature());
   s << line << std::endl;
 
-  sprintf(line," Ready: %d  0x%8.8X", c.ready(), c.ready());
+  snprintf(line,kLineBufferSize," Ready: %d  0x%8.8X", c.ready(), c.ready());
   s << line << std::endl;
 
   for ( int i=0; i<DcsStatus::nPartitions; i++)
   {
     if ( c.ready(DcsStatus::partitionList[i]))
     {
-      sprintf(line,"  %2d %6s: READY", i, DcsStatus::partitionName[i]);
+      snprintf(line,kLineBufferSize,"  %2d %6s: READY", i, DcsStatus::partitionName[i]);
     }
     else
     {
-      sprintf(line,"  %2d %6s: NOT READY", i, DcsStatus::partitionName[i]);
+      snprintf(line,kLineBufferSize,"  %2d %6s: NOT READY", i, DcsStatus::partitionName[i]);
     }
   s << line << std::endl;
   }

--- a/DataFormats/Scalers/src/L1TriggerScalers.cc
+++ b/DataFormats/Scalers/src/L1TriggerScalers.cc
@@ -110,7 +110,8 @@ std::ostream& operator<<(std::ostream& s,L1TriggerScalers const &c)
 {
   s << "L1TriggerScalers    Version:" << c.version() <<
     "   SourceID: " << c.sourceID() << std::endl;
-  char line[128];
+  constexpr size_t kLineBufferSize = 164;
+  char line[kLineBufferSize];
   char zeitHeaven[128];
   char zeitHell[128];
   char zeitLimbo[128];
@@ -125,74 +126,74 @@ std::ostream& operator<<(std::ostream& s,L1TriggerScalers const &c)
   timespec secondsToHeaven = c.collectionTimeSummary();
   horaHeaven = gmtime(&secondsToHeaven.tv_sec);
   strftime(zeitHeaven, sizeof(zeitHeaven), "%Y.%m.%d %H:%M:%S", horaHeaven);
-  sprintf(line, " CollectionTimeSummary: %s.%9.9d" , 
+  snprintf(line, kLineBufferSize, " CollectionTimeSummary: %s.%9.9d" , 
 	  zeitHeaven, (int)secondsToHeaven.tv_nsec);
   s << line << std::endl;
 
   timespec secondsToHell= c.collectionTimeSpecial();
   horaHell = gmtime(&secondsToHell.tv_sec);
   strftime(zeitHell, sizeof(zeitHell), "%Y.%m.%d %H:%M:%S", horaHell);
-  sprintf(line, " CollectionTimeSpecial: %s.%9.9d" , 
+  snprintf(line, kLineBufferSize, " CollectionTimeSpecial: %s.%9.9d" , 
 	  zeitHell, (int)secondsToHell.tv_nsec);
   s << line << std::endl;
 
   timespec secondsToLimbo= c.collectionTimeDetails();
   horaLimbo = gmtime(&secondsToLimbo.tv_sec);
   strftime(zeitLimbo, sizeof(zeitLimbo), "%Y.%m.%d %H:%M:%S", horaLimbo);
-  sprintf(line, " CollectionTimeDetails: %s.%9.9d" , 
+  snprintf(line, kLineBufferSize, " CollectionTimeDetails: %s.%9.9d" , 
 	  zeitLimbo, (int)secondsToLimbo.tv_nsec);
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " LuminositySection: %15d  BunchCrossingErrors:      %15d",
 	  c.luminositySection(), c.bunchCrossingErrors());
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " TriggerNumber:     %15d  EventNumber:              %15d",
 	  c.triggerNumber(), c.eventNumber());
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " TriggersDistributed:    %10d  TriggersGenerated:        %15d",
 	  c.finalTriggersDistributed(), 
 	  c.finalTriggersGenerated());
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " TriggersInvalidBC: %15d  CalibrationTriggers:      %15d",
 	  c.finalTriggersInvalidBC(), c.calibrationTriggers());
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " TestTriggers:      %15d  RandomTriggers:           %15d",
 	  c.totalTestTriggers(), c.randomTriggers());
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " DeadTime:          %15d  DeadTimeActiveTimeSlot:   %15ld",
 	  c.numberResets(), (long int)c.deadTime());
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " DeadTimeActive:    %15ld  DeadTimeActiveCalibration:%15ld",
 	  (long int)c.deadTimeActive(), 
 	  (long int)c.deadTimeActiveCalibration());
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " LostTriggers:      %15ld  DeadTimeActivePartition:  %15ld",
 	  (long int)c.lostFinalTriggers(), 
 	  (long int)c.deadTimeActivePartition());
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " LostTriggersActive:%15ld  DeadTimeActiveThrottle:   %15ld",
 	  (long int)c.lostFinalTriggersActive(),
 	  (long int)c.deadTimeActiveThrottle());
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " NumberResets:      %15d  DeadTimeActivePrivate:    %15ld",
 	  c.numberResets(),
 	  (long int)c.deadTimeActivePrivate());
@@ -203,7 +204,8 @@ std::ostream& operator<<(std::ostream& s,L1TriggerScalers const &c)
   int length = triggers.size() / 4;
   for ( int i=0; i<length; i++)
   {
-    sprintf(line," %3.3d: %10d    %3.3d: %10d    %3.3d: %10d    %3.3d: %10d",
+    snprintf(line, kLineBufferSize,
+             " %3.3d: %10d    %3.3d: %10d    %3.3d: %10d    %3.3d: %10d",
 	    i,              triggers[i], 
 	    (i+length),     triggers[i+length], 
 	    (i+(length*2)), triggers[i+(length*2)], 
@@ -216,7 +218,8 @@ std::ostream& operator<<(std::ostream& s,L1TriggerScalers const &c)
   length = testTriggers.size() / 4;
   for ( int i=0; i<length; i++)
   {
-    sprintf(line," %3.3d: %10d    %3.3d: %10d    %3.3d: %10d    %3.3d: %10d",
+    snprintf(line, kLineBufferSize,
+             " %3.3d: %10d    %3.3d: %10d    %3.3d: %10d    %3.3d: %10d",
 	    i,              testTriggers[i], 
 	    (i+length),     testTriggers[i+length], 
 	    (i+(length*2)), testTriggers[i+(length*2)], 

--- a/DataFormats/Scalers/src/Level1TriggerRates.cc
+++ b/DataFormats/Scalers/src/Level1TriggerRates.cc
@@ -164,7 +164,8 @@ void Level1TriggerRates::computeRates(Level1TriggerScalers const& t1,
 /// Pretty-print operator for Level1TriggerRates
 std::ostream& operator<<(std::ostream& s, const Level1TriggerRates& c) 
 {
-  char line[128];
+  constexpr size_t kLineBufferSize = 164;
+  char line[kLineBufferSize];
   char zeitHeaven[128];
   struct tm * horaHeaven;
 
@@ -183,82 +184,99 @@ std::ostream& operator<<(std::ostream& s, const Level1TriggerRates& c)
   struct timespec secondsToHeaven = c.collectionTime();
   horaHeaven = gmtime(&secondsToHeaven.tv_sec);
   strftime(zeitHeaven, sizeof(zeitHeaven), "%Y.%m.%d %H:%M:%S", horaHeaven);
-  sprintf(line, " CollectionTime:        %s.%9.9d" , 
-	  zeitHeaven, (int)secondsToHeaven.tv_nsec);
+  snprintf(line, kLineBufferSize, " CollectionTime:        %s.%9.9d" , 
+           zeitHeaven, (int)secondsToHeaven.tv_nsec);
   s << line << std::endl;
   
-  sprintf(line, " GtTriggersRate:                              %22.3f Hz",
-	  c.gtTriggersRate());
+  snprintf(line, kLineBufferSize, 
+           " GtTriggersRate:                              %22.3f Hz",
+           c.gtTriggersRate());
   s << line << std::endl;
   
-  sprintf(line, " GtEventsRate:                                %22.3f Hz",
-	  c.gtEventsRate());
+  snprintf(line, kLineBufferSize,
+           " GtEventsRate:                                %22.3f Hz",
+           c.gtEventsRate());
   s << line << std::endl;
 
   secondsToHeaven = c.collectionTimeLumiSeg();
   horaHeaven = gmtime(&secondsToHeaven.tv_sec);
   strftime(zeitHeaven, sizeof(zeitHeaven), "%Y.%m.%d %H:%M:%S", horaHeaven);
-  sprintf(line, " CollectionTimeLumiSeg: %s.%9.9d" , 
+  snprintf(line, kLineBufferSize, " CollectionTimeLumiSeg: %s.%9.9d" , 
 	  zeitHeaven, (int)secondsToHeaven.tv_nsec);
   s << line << std::endl;
   
-  sprintf(line, " TriggersPhysicsGeneratedFDLRate:             %22.3f Hz",
-	  c.triggersPhysicsGeneratedFDLRate());
+  snprintf(line, kLineBufferSize,
+           " TriggersPhysicsGeneratedFDLRate:             %22.3f Hz",
+           c.triggersPhysicsGeneratedFDLRate());
   s << line << std::endl;
 
-  sprintf(line, " TriggersPhysicsLostRate:                     %22.3f Hz",
-	  c.triggersPhysicsLostRate());
+  snprintf(line, kLineBufferSize,
+           " TriggersPhysicsLostRate:                     %22.3f Hz",
+           c.triggersPhysicsLostRate());
   s << line << std::endl;
 
-  sprintf(line, " TriggersPhysicsLostBeamActiveRate:           %22.3f Hz",
-	  c.triggersPhysicsLostBeamActiveRate());
+  snprintf(line, kLineBufferSize,
+           " TriggersPhysicsLostBeamActiveRate:           %22.3f Hz",
+           c.triggersPhysicsLostBeamActiveRate());
   s << line << std::endl;
 
-  sprintf(line, " TriggersPhysicsLostBeamInactiveRate:         %22.3f Hz",
+  snprintf(line, kLineBufferSize,
+          " TriggersPhysicsLostBeamInactiveRate:         %22.3f Hz",
 	  c.triggersPhysicsLostBeamInactiveRate());
   s << line << std::endl;
 
-  sprintf(line, " L1AsPhysicsRate:                             %22.3f Hz",
+  snprintf(line, kLineBufferSize,
+          " L1AsPhysicsRate:                             %22.3f Hz",
 	  c.l1AsPhysicsRate());
   s << line << std::endl;
 
-  sprintf(line, " L1AsRandomRate:                              %22.3f Hz",
-	  c.l1AsRandomRate());
+  snprintf(line, kLineBufferSize, 
+           " L1AsRandomRate:                              %22.3f Hz",
+           c.l1AsRandomRate());
   s << line << std::endl;
 
-  sprintf(line, " L1AsTestRate:                                %22.3f Hz",
-	  c.l1AsTestRate());
+  snprintf(line, kLineBufferSize,
+           " L1AsTestRate:                                %22.3f Hz",
+           c.l1AsTestRate());
   s << line << std::endl;
 
-  sprintf(line, " L1AsCalibrationRate:                         %22.3f Hz",
-	  c.l1AsCalibrationRate());
+  snprintf(line, kLineBufferSize,
+           " L1AsCalibrationRate:                         %22.3f Hz",
+           c.l1AsCalibrationRate());
   s << line << std::endl;
 
-  sprintf(line, " DeadtimePercent:                             %22.3f %%",
-	  c.deadtimePercent());
+  snprintf(line, kLineBufferSize,
+           " DeadtimePercent:                             %22.3f %%",
+           c.deadtimePercent());
   s << line << std::endl;
 
-  sprintf(line, " DeadtimeBeamActivePercent:                   %22.3f %%",
-	  c.deadtimeBeamActivePercent());
+  snprintf(line, kLineBufferSize,
+           " DeadtimeBeamActivePercent:                   %22.3f %%",
+           c.deadtimeBeamActivePercent());
   s << line << std::endl;
 
-  sprintf(line, " DeadtimeBeamActiveTriggerRulesPercent:       %22.3f %%",
-	  c.deadtimeBeamActiveTriggerRulesPercent());
+  snprintf(line, kLineBufferSize,
+           " DeadtimeBeamActiveTriggerRulesPercent:       %22.3f %%",
+           c.deadtimeBeamActiveTriggerRulesPercent());
   s << line << std::endl;
 
-  sprintf(line, " DeadtimeBeamActiveCalibrationPercent:        %22.3f %%",
-	  c.deadtimeBeamActiveCalibrationPercent());
+  snprintf(line, kLineBufferSize,
+           " DeadtimeBeamActiveCalibrationPercent:        %22.3f %%",
+           c.deadtimeBeamActiveCalibrationPercent());
   s << line << std::endl;
 
-  sprintf(line, " DeadtimeBeamActivePrivateOrbitPercent:       %22.3f %%",
-	  c.deadtimeBeamActivePrivateOrbitPercent());
+  snprintf(line, kLineBufferSize,
+           " DeadtimeBeamActivePrivateOrbitPercent:       %22.3f %%",
+           c.deadtimeBeamActivePrivateOrbitPercent());
   s << line << std::endl;
 
-  sprintf(line, " DeadtimeBeamActivePartitionControllerPercent:%22.3f %%",
-	  c.deadtimeBeamActivePartitionControllerPercent());
+  snprintf(line, kLineBufferSize,
+           " DeadtimeBeamActivePartitionControllerPercent:%22.3f %%",
+           c.deadtimeBeamActivePartitionControllerPercent());
   s << line << std::endl;
 
-  sprintf(line, " DeadtimeBeamActiveTimeSlotPercent:           %22.3f %%",
+  snprintf(line, kLineBufferSize, 
+          " DeadtimeBeamActiveTimeSlotPercent:           %22.3f %%",
 	  c.deadtimeBeamActiveTimeSlotPercent());
   s << line << std::endl;
 
@@ -267,12 +285,12 @@ std::ostream& operator<<(std::ostream& s, const Level1TriggerRates& c)
   int length = gtAlgoCountsRate.size() / 4;
   for ( int i=0; i<length; i++)
   {
-    sprintf(line,
-	    " %3.3d: %12.3f  %3.3d: %12.3f  %3.3d: %12.3f  %3.3d: %12.3f",
-	    i,              gtAlgoCountsRate[i], 
-	    (i+length),     gtAlgoCountsRate[i+length], 
-	    (i+(length*2)), gtAlgoCountsRate[i+(length*2)], 
-	    (i+(length*3)), gtAlgoCountsRate[i+(length*3)]);
+    snprintf(line, kLineBufferSize,
+             " %3.3d: %12.3f  %3.3d: %12.3f  %3.3d: %12.3f  %3.3d: %12.3f",
+             i,              gtAlgoCountsRate[i], 
+             (i+length),     gtAlgoCountsRate[i+length], 
+             (i+(length*2)), gtAlgoCountsRate[i+(length*2)], 
+             (i+(length*3)), gtAlgoCountsRate[i+(length*3)]);
     s << line << std::endl;
   }
 
@@ -281,12 +299,12 @@ std::ostream& operator<<(std::ostream& s, const Level1TriggerRates& c)
   length = gtTechCountsRate.size() / 4;
   for ( int i=0; i<length; i++)
   {
-    sprintf(line,
-	    " %3.3d: %12.3f  %3.3d: %12.3f  %3.3d: %12.3f  %3.3d: %12.3f",
-	    i,              gtTechCountsRate[i], 
-	    (i+length),     gtTechCountsRate[i+length], 
-	    (i+(length*2)), gtTechCountsRate[i+(length*2)], 
-	    (i+(length*3)), gtTechCountsRate[i+(length*3)]);
+    snprintf(line, kLineBufferSize,
+             " %3.3d: %12.3f  %3.3d: %12.3f  %3.3d: %12.3f  %3.3d: %12.3f",
+             i,              gtTechCountsRate[i], 
+             (i+length),     gtTechCountsRate[i+length], 
+             (i+(length*2)), gtTechCountsRate[i+(length*2)], 
+             (i+(length*3)), gtTechCountsRate[i+(length*3)]);
     s << line << std::endl;
   }
   return s;

--- a/DataFormats/Scalers/src/Level1TriggerScalers.cc
+++ b/DataFormats/Scalers/src/Level1TriggerScalers.cc
@@ -221,128 +221,129 @@ std::ostream& operator<<(std::ostream& s,Level1TriggerScalers const &c)
 {
   s << "Level1TriggerScalers    Version:" << c.version() <<
     "   SourceID: " << c.sourceID() << std::endl;
-  char line[128];
+  constexpr size_t kLineBufferSize = 164;
+  char line[kLineBufferSize];
   char zeitHeaven[128];
   struct tm * horaHeaven;
 
-  sprintf(line, " TrigType: %d   EventID: %d    BunchNumber: %d", 
+  snprintf(line, kLineBufferSize, " TrigType: %d   EventID: %d    BunchNumber: %d", 
 	  c.trigType(), c.eventID(), c.bunchNumber());
   s << line << std::endl;
 
   struct timespec secondsToHeaven = c.collectionTime();
   horaHeaven = gmtime(&secondsToHeaven.tv_sec);
   strftime(zeitHeaven, sizeof(zeitHeaven), "%Y.%m.%d %H:%M:%S", horaHeaven);
-  sprintf(line, " CollectionTime:        %s.%9.9d" , 
+  snprintf(line, kLineBufferSize, " CollectionTime:        %s.%9.9d" , 
 	  zeitHeaven, (int)secondsToHeaven.tv_nsec);
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " LumiSegmentNr:        %10u   LumiSegmentOrbits:     %10u",
 	  c.lumiSegmentNr(), c.lumiSegmentOrbits());
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " LumiSegmentNrLumiSeg: %10u   OrbitNr:               %10u ",
 	  c.lumiSegmentNrLumiSeg(),  c.orbitNr());
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " GtResets:             %10u   BunchCrossingErrors:   %10u",
 	  c.gtResets(), c.bunchCrossingErrors());
   s << line << std::endl;
 
-  sprintf(line,
+  snprintf(line, kLineBufferSize,
 	  " PrescaleIndexAlgo:    %10d   PrescaleIndexTech:     %10d",
 	  c.prescaleIndexAlgo(), c.prescaleIndexTech());
   s << line << std::endl;
 
-  sprintf(line, " GtTriggers:                      %20llu %22.3f Hz", 
+  snprintf(line, kLineBufferSize, " GtTriggers:                      %20llu %22.3f Hz", 
 	  c.gtTriggers(), c.gtTriggersRate());
   s << line << std::endl;
 
-  sprintf(line, " GtEvents:                        %20llu %22.3f Hz", 
+  snprintf(line, kLineBufferSize, " GtEvents:                        %20llu %22.3f Hz", 
 	  c.gtEvents(), c.gtEventsRate());
   s << line << std::endl;
 
   secondsToHeaven = c.collectionTimeLumiSeg();
   horaHeaven = gmtime(&secondsToHeaven.tv_sec);
   strftime(zeitHeaven, sizeof(zeitHeaven), "%Y.%m.%d %H:%M:%S", horaHeaven);
-  sprintf(line, " CollectionTimeLumiSeg: %s.%9.9d" , 
+  snprintf(line, kLineBufferSize, " CollectionTimeLumiSeg: %s.%9.9d" , 
 	  zeitHeaven, (int)secondsToHeaven.tv_nsec);
   s << line << std::endl;
 
 
-  sprintf(line, " TriggersPhysicsGeneratedFDL:     %20llu %22.3f Hz",
+  snprintf(line, kLineBufferSize, " TriggersPhysicsGeneratedFDL:     %20llu %22.3f Hz",
 	  c.triggersPhysicsGeneratedFDL(),
 	  Level1TriggerScalers::rateLS(c.triggersPhysicsGeneratedFDL()));
   s << line << std::endl;
 
-  sprintf(line, " TriggersPhysicsLost:             %20llu %22.3f Hz",
+  snprintf(line, kLineBufferSize, " TriggersPhysicsLost:             %20llu %22.3f Hz",
 	  c.triggersPhysicsLost(),
 	  Level1TriggerScalers::rateLS(c.triggersPhysicsLost()));
   s << line << std::endl;
 
-  sprintf(line, " TriggersPhysicsLostBeamActive:   %20llu %22.3f Hz",
+  snprintf(line, kLineBufferSize, " TriggersPhysicsLostBeamActive:   %20llu %22.3f Hz",
 	  c.triggersPhysicsLostBeamActive(),
 	  Level1TriggerScalers::rateLS(c.triggersPhysicsLostBeamActive()));
   s << line << std::endl;
 
-  sprintf(line, " TriggersPhysicsLostBeamInactive: %20llu %22.3f Hz",
+  snprintf(line, kLineBufferSize, " TriggersPhysicsLostBeamInactive: %20llu %22.3f Hz",
 	  c.triggersPhysicsLostBeamInactive(),
 	  Level1TriggerScalers::rateLS(c.triggersPhysicsLostBeamInactive()));
   s << line << std::endl;
 
-  sprintf(line, " L1AsPhysics:                     %20llu %22.3f Hz",
+  snprintf(line, kLineBufferSize, " L1AsPhysics:                     %20llu %22.3f Hz",
 	  c.l1AsPhysics(),
 	  Level1TriggerScalers::rateLS(c.l1AsPhysics()));
   s << line << std::endl;
 
-  sprintf(line, " L1AsRandom:                      %20llu %22.3f Hz",
+  snprintf(line, kLineBufferSize, " L1AsRandom:                      %20llu %22.3f Hz",
 	  c.l1AsRandom(),
 	  Level1TriggerScalers::rateLS(c.l1AsRandom()));
   s << line << std::endl;
 
-  sprintf(line, " L1AsTest:                        %20llu %22.3f Hz",
+  snprintf(line, kLineBufferSize, " L1AsTest:                        %20llu %22.3f Hz",
 	  c.l1AsTest(),
 	  Level1TriggerScalers::rateLS(c.l1AsTest()));
   s << line << std::endl;
 
-  sprintf(line, " L1AsCalibration:                 %20llu %22.3f Hz",
+  snprintf(line, kLineBufferSize, " L1AsCalibration:                 %20llu %22.3f Hz",
 	  c.l1AsCalibration(),
 	  Level1TriggerScalers::rateLS(c.l1AsCalibration()));
   s << line << std::endl;
 
-  sprintf(line, " Deadtime:                             %20llu %17.3f%%",
+  snprintf(line, kLineBufferSize, " Deadtime:                             %20llu %17.3f%%",
 	  c.deadtime(),
 	  Level1TriggerScalers::percentLS(c.deadtime()));
   s << line << std::endl;
 
-  sprintf(line, " DeadtimeBeamActive:                   %20llu %17.3f%%",
+  snprintf(line, kLineBufferSize, " DeadtimeBeamActive:                   %20llu %17.3f%%",
 	  c.deadtimeBeamActive(),
 	  Level1TriggerScalers::percentLSActive(c.deadtimeBeamActive()));
   s << line << std::endl;
 
-  sprintf(line, " DeadtimeBeamActiveTriggerRules:       %20llu %17.3f%%",
+  snprintf(line, kLineBufferSize, " DeadtimeBeamActiveTriggerRules:       %20llu %17.3f%%",
 	  c.deadtimeBeamActiveTriggerRules(),
 	  Level1TriggerScalers::percentLSActive(c.deadtimeBeamActiveTriggerRules()));
   s << line << std::endl;
 
-  sprintf(line, " DeadtimeBeamActiveCalibration:        %20llu %17.3f%%",
+  snprintf(line, kLineBufferSize, " DeadtimeBeamActiveCalibration:        %20llu %17.3f%%",
 	  c.deadtimeBeamActiveCalibration(),
 	  Level1TriggerScalers::percentLSActive(c.deadtimeBeamActiveCalibration()));
   s << line << std::endl;
 
-  sprintf(line, " DeadtimeBeamActivePrivateOrbit:       %20llu %17.3f%%",
+  snprintf(line, kLineBufferSize, " DeadtimeBeamActivePrivateOrbit:       %20llu %17.3f%%",
 	  c.deadtimeBeamActivePrivateOrbit(),
 	  Level1TriggerScalers::percentLSActive(c.deadtimeBeamActivePrivateOrbit()));
   s << line << std::endl;
 
-  sprintf(line, " DeadtimeBeamActivePartitionController:%20llu %17.3f%%",
+  snprintf(line, kLineBufferSize, " DeadtimeBeamActivePartitionController:%20llu %17.3f%%",
 	  c.deadtimeBeamActivePartitionController(),
 	  Level1TriggerScalers::percentLSActive(c.deadtimeBeamActivePartitionController()));
   s << line << std::endl;
 
-  sprintf(line, " DeadtimeBeamActiveTimeSlot:           %20llu %17.3f%%",
+  snprintf(line, kLineBufferSize, " DeadtimeBeamActiveTimeSlot:           %20llu %17.3f%%",
 	  c.deadtimeBeamActiveTimeSlot(),
 	  Level1TriggerScalers::percentLSActive(c.deadtimeBeamActiveTimeSlot()));
   s << line << std::endl;
@@ -352,7 +353,7 @@ std::ostream& operator<<(std::ostream& s,Level1TriggerScalers const &c)
   int length = gtAlgoCounts.size() / 4;
   for ( int i=0; i<length; i++)
   {
-    sprintf(line," %3.3d: %10u    %3.3d: %10u    %3.3d: %10u    %3.3d: %10u",
+    snprintf(line, kLineBufferSize," %3.3d: %10u    %3.3d: %10u    %3.3d: %10u    %3.3d: %10u",
 	    i,              gtAlgoCounts[i], 
 	    (i+length),     gtAlgoCounts[i+length], 
 	    (i+(length*2)), gtAlgoCounts[i+(length*2)], 
@@ -365,7 +366,7 @@ std::ostream& operator<<(std::ostream& s,Level1TriggerScalers const &c)
   length = gtTechCounts.size() / 4;
   for ( int i=0; i<length; i++)
   {
-    sprintf(line," %3.3d: %10u    %3.3d: %10u    %3.3d: %10u    %3.3d: %10u",
+    snprintf(line, kLineBufferSize," %3.3d: %10u    %3.3d: %10u    %3.3d: %10u    %3.3d: %10u",
 	    i,              gtTechCounts[i], 
 	    (i+length),     gtTechCounts[i+length], 
 	    (i+(length*2)), gtTechCounts[i+(length*2)], 
@@ -375,27 +376,27 @@ std::ostream& operator<<(std::ostream& s,Level1TriggerScalers const &c)
 
   if ( c.version() >= 5 )
   {
-    sprintf(line," LastOrbitCounter0:  %10u  0x%8.8X", c.lastOrbitCounter0(),
+    snprintf(line, kLineBufferSize," LastOrbitCounter0:  %10u  0x%8.8X", c.lastOrbitCounter0(),
 	    c.lastOrbitCounter0()); 
     s << line << std::endl;
     
-    sprintf(line," LastTestEnable:     %10u  0x%8.8X", c.lastTestEnable(),
+    snprintf(line, kLineBufferSize," LastTestEnable:     %10u  0x%8.8X", c.lastTestEnable(),
 	    c.lastTestEnable()); 
     s << line << std::endl;
     
-    sprintf(line," LastResync:         %10u  0x%8.8X", c.lastResync(),
+    snprintf(line, kLineBufferSize," LastResync:         %10u  0x%8.8X", c.lastResync(),
 	    c.lastResync()); 
     s << line << std::endl;
     
-    sprintf(line," LastStart:          %10u  0x%8.8X", c.lastStart(),
+    snprintf(line, kLineBufferSize," LastStart:          %10u  0x%8.8X", c.lastStart(),
 	    c.lastStart()); 
     s << line << std::endl;
     
-    sprintf(line," LastEventCounter0:  %10u  0x%8.8X", c.lastEventCounter0(),
+    snprintf(line, kLineBufferSize," LastEventCounter0:  %10u  0x%8.8X", c.lastEventCounter0(),
 	    c.lastEventCounter0()); 
     s << line << std::endl;
     
-    sprintf(line," LastHardReset:      %10u  0x%8.8X", c.lastHardReset(),
+    snprintf(line, kLineBufferSize," LastHardReset:      %10u  0x%8.8X", c.lastHardReset(),
 	    c.lastHardReset()); 
     s << line << std::endl;
   }

--- a/DataFormats/Scalers/src/LumiScalers.cc
+++ b/DataFormats/Scalers/src/LumiScalers.cc
@@ -142,7 +142,8 @@ LumiScalers::~LumiScalers() { }
 std::ostream& operator<<(std::ostream& s, const LumiScalers& c) 
 {
   char zeit[128];
-  char line[128];
+  constexpr size_t kLineBufferSize = 157;
+  char line[kLineBufferSize];
   struct tm * hora;
 
   s << "LumiScalers    Version: " << c.version() << 
@@ -151,48 +152,48 @@ std::ostream& operator<<(std::ostream& s, const LumiScalers& c)
   timespec ts = c.collectionTime();
   hora = gmtime(&ts.tv_sec);
   strftime(zeit, sizeof(zeit), "%Y.%m.%d %H:%M:%S", hora);
-  sprintf(line, " CollectionTime: %s.%9.9d", zeit, 
+  snprintf(line, kLineBufferSize, " CollectionTime: %s.%9.9d", zeit, 
 	  (int)ts.tv_nsec);
   s << line << std::endl;
 
-  sprintf(line, " TrigType: %d   EventID: %d    BunchNumber: %d", 
+  snprintf(line, kLineBufferSize, " TrigType: %d   EventID: %d    BunchNumber: %d", 
 	  c.trigType(), c.eventID(), c.bunchNumber());
   s << line << std::endl;
 
-  sprintf(line," SectionNumber: %10d   StartOrbit: %10d  NumOrbits: %10d",
+  snprintf(line, kLineBufferSize," SectionNumber: %10d   StartOrbit: %10d  NumOrbits: %10d",
 	  c.sectionNumber(), c.startOrbit(), c.numOrbits());
   s << line << std::endl;
 
-  sprintf(line," Normalization: %e  DeadTimeNormalization: %e",
+  snprintf(line, kLineBufferSize," Normalization: %e  DeadTimeNormalization: %e",
 	  c.normalization(), c.deadTimeNormalization());
   s << line << std::endl;
 
   // Integrated Luminosity
 
-  sprintf(line," LumiFill:            %e   LumiRun:            %e", 
+  snprintf(line, kLineBufferSize," LumiFill:            %e   LumiRun:            %e", 
 	  c.lumiFill(), c.lumiRun());
   s << line << std::endl;
-  sprintf(line," LiveLumiFill:        %e   LiveLumiRun:        %e", 
+  snprintf(line, kLineBufferSize," LiveLumiFill:        %e   LiveLumiRun:        %e", 
 	  c.liveLumiFill(), c.liveLumiRun());
   s << line << std::endl;
 
-  sprintf(line," LumiETFill:          %e   LumiETRun:          %e", 
+  snprintf(line, kLineBufferSize," LumiETFill:          %e   LumiETRun:          %e", 
 	  c.lumiFill(), c.lumiRun());
   s << line << std::endl;
 
-  sprintf(line," LiveLumiETFill:      %e   LiveLumETiRun:      %e", 
+  snprintf(line, kLineBufferSize," LiveLumiETFill:      %e   LiveLumETiRun:      %e", 
 	  c.liveLumiETFill(), c.liveLumiETRun());
   s << line << std::endl;
 
   int length = c.instantOccLumi().size();
   for (int i=0; i<length; i++)
   {
-    sprintf(line,
+    snprintf(line, kLineBufferSize,
 	       " LumiOccFill[%d]:      %e   LumiOccRun[%d]:      %e", 
 	    i, c.lumiOccFill()[i], i, c.lumiOccRun()[i]);
     s << line << std::endl;
 
-    sprintf(line,
+    snprintf(line, kLineBufferSize,
 	       " LiveLumiOccFill[%d]:  %e   LiveLumiOccRun[%d]:  %e", 
 	    i, c.liveLumiOccFill()[i], i, c.liveLumiOccRun()[i]);
     s << line << std::endl;
@@ -200,29 +201,29 @@ std::ostream& operator<<(std::ostream& s, const LumiScalers& c)
 
   // Instantaneous Luminosity
 
-  sprintf(line," InstantLumi:       %e  Err: %e  Qlty: %d",
+  snprintf(line, kLineBufferSize," InstantLumi:       %e  Err: %e  Qlty: %d",
 	  c.instantLumi(), c.instantLumiErr(), c.instantLumiQlty());
   s << line << std::endl;
 
-  sprintf(line," InstantETLumi:     %e  Err: %e  Qlty: %d",
+  snprintf(line, kLineBufferSize," InstantETLumi:     %e  Err: %e  Qlty: %d",
 	  c.instantETLumi(), c.instantETLumiErr(), c.instantETLumiQlty());
   s << line << std::endl;
 
   for (int i=0; i<length; i++)
   {
-    sprintf(line," InstantOccLumi[%d]: %e  Err: %e  Qlty: %d",
+    snprintf(line, kLineBufferSize," InstantOccLumi[%d]: %e  Err: %e  Qlty: %d",
 	    i, c.instantOccLumi()[i], c.instantOccLumiErr()[i], 
 	    c.instantOccLumiQlty()[i]);
     s << line << std::endl;
-    sprintf(line,"      LumiNoise[%d]: %e", i, c.lumiNoise()[i]);
+    snprintf(line, kLineBufferSize,"      LumiNoise[%d]: %e", i, c.lumiNoise()[i]);
     s << line << std::endl;
   }
 
-  sprintf(line," Pileup: %f       PileupRMS: %f", 
+  snprintf(line, kLineBufferSize," Pileup: %f       PileupRMS: %f", 
 	  c.pileup(), c.pileupRMS());
   s << line << std::endl;
 
-  sprintf(line," BunchLumi: %f    Spare: %f", 
+  snprintf(line, kLineBufferSize," BunchLumi: %f    Spare: %f", 
 	   c.bunchLumi(), c.spare());
   s << line << std::endl;
 


### PR DESCRIPTION
gcc 8 was issuing errors for the uses of sprintf where the buffer
was not long enough to contain the full range of integral values.
This change increased the buffer size to match what the compiler
found as the maximum theoretical size and changed to using
snprintf.