### PR TITLE
Minor changes to HcalNoiseRBX for gcc8 compilation

### DIFF
--- a/DataFormats/METReco/interface/HcalNoiseRBX.h
+++ b/DataFormats/METReco/interface/HcalNoiseRBX.h
@@ -42,7 +42,7 @@ namespace reco {
     HcalNoiseRBX();
     
     // destructor
-    virtual ~HcalNoiseRBX();
+    ~HcalNoiseRBX();
 
     //
     // Detector ID accessors
@@ -97,7 +97,7 @@ namespace reco {
     
     // helper function to get the unique calotowers
     struct twrcomp {
-      inline bool operator() ( const CaloTower & t1, const CaloTower & t2 ) {
+      inline bool operator() ( const CaloTower & t1, const CaloTower & t2 ) const {
 	return t1.id() < t2.id();
       }
     };


### PR DESCRIPTION
Made comparison operator for std::set be a const function.
Removed virtual on destructor since there are no other virtual
methods and no class inherits from this class.