### PR TITLE
Made comparitor methods in LinTrackCache const

### DIFF
--- a/RecoVertex/MultiVertexFit/interface/LinTrackCache.h
+++ b/RecoVertex/MultiVertexFit/interface/LinTrackCache.h
@@ -12,12 +12,12 @@ class LinTrackCache
 private:
   struct Comparer
   {
-    bool operator() ( const GlobalPoint &, const GlobalPoint & );
+    bool operator() ( const GlobalPoint &, const GlobalPoint & ) const;
   };
 
   struct Vicinity
   {
-    bool operator() ( const GlobalPoint &, const GlobalPoint & );
+    bool operator() ( const GlobalPoint &, const GlobalPoint & ) const;
   };
 
 public:

--- a/RecoVertex/MultiVertexFit/src/LinTrackCache.cc
+++ b/RecoVertex/MultiVertexFit/src/LinTrackCache.cc
@@ -32,7 +32,8 @@ LinTrackCache::RefCountedLinearizedTrackState LinTrackCache::linTrack
   return lTrData;
 }
 
-bool LinTrackCache::Comparer::operator() ( const GlobalPoint & left,                                               const GlobalPoint & right ) const
+bool LinTrackCache::Comparer::operator() ( const GlobalPoint & left,
+                                           const GlobalPoint & right ) const
 {
   // if theyre closer than 1 micron, they're
   // indistinguishable, i.e. the same

--- a/RecoVertex/MultiVertexFit/src/LinTrackCache.cc
+++ b/RecoVertex/MultiVertexFit/src/LinTrackCache.cc
@@ -32,7 +32,7 @@ LinTrackCache::RefCountedLinearizedTrackState LinTrackCache::linTrack
   return lTrData;
 }
 
-bool LinTrackCache::Comparer::operator() ( const GlobalPoint & left,                                               const GlobalPoint & right )
+bool LinTrackCache::Comparer::operator() ( const GlobalPoint & left,                                               const GlobalPoint & right ) const
 {
   // if theyre closer than 1 micron, they're
   // indistinguishable, i.e. the same
@@ -50,7 +50,7 @@ bool LinTrackCache::Comparer::operator() ( const GlobalPoint & left,            
 }
 
 bool LinTrackCache::Vicinity::operator() ( const GlobalPoint & p1,
-                                           const GlobalPoint & p2 )
+                                           const GlobalPoint & p2 ) const
 {
   if ( (p1 - p2).mag() < maxRelinDistance() )
   {


### PR DESCRIPTION
gcc 8 requires that comparitors used by std::maps have const
methods.