### PR TITLE
Fix missing headers in Geometry/HcalCommonData to test boost 1.67

### DIFF
--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -5,6 +5,7 @@
 
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include <cmath>
 
 //#define EDM_ML_DEBUG
 

--- a/Geometry/HcalCommonData/src/HcalDDDSimConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDSimConstants.cc
@@ -5,6 +5,7 @@
 
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include <cmath>
 
 //#define EDM_ML_DEBUG
 


### PR DESCRIPTION
Fixes missing headers needed for this test https://github.com/cms-sw/cmsdist/pull/4004 