### PR TITLE
Fix GeneratorInterfaceCascadeInterface plugin name

### DIFF
--- a/GeneratorInterface/CascadeInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/CascadeInterface/plugins/BuildFile.xml
@@ -5,7 +5,7 @@
 <architecture name="osx">
 <use   name="pydata"/>
 </architecture>
-<library   file="Cascade2GeneratorFilter.cc,Cascade2Hadronizer.cc" name="GeneratorInterfaceCascadeInterface">
+<library   file="Cascade2GeneratorFilter.cc,Cascade2Hadronizer.cc" name="GeneratorInterfaceCascadeInterfacePlugin">
 <use   name="GeneratorInterface/PartonShowerVeto"/>
 <use   name="GeneratorInterface/ExternalDecays"/>
 <use   name="heppdt"/>


### PR DESCRIPTION
So that it does not clash with package's default library name