### PR TITLE
[94X][Change GTs] 2016,2017 JES and JER 

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,13 +40,13 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v10',
+    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '94X_mc2017_realistic_v14',
+    'phase1_2017_realistic'    : '94X_mc2017_realistic_v15',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v10',
+    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v11',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v10',
+    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v11',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '94X_upgrade2018_design_IdealBS_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,19 +10,19 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '94X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '94X_mcRun2_design_v2',
+    'run2_design'       :   '94X_mcRun2_design_v4',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '94X_mcRun2_startup_v2',
+    'run2_mc_50ns'      :   '94X_mcRun2_startup_v3',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '94X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '94X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '94X_mcRun2cosmics_startup_deco_v2',
+    'run2_mc_cosmics'   :   '94X_mcRun2cosmics_startup_deco_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '93X_mcRun2_HeavyIon_v0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '94X_mcRun2_pA_v2',
+    'run2_mc_pa'        :   '94X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '94X_dataRun2_v7',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '94X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '94X_dataRun2_v7',
+    'run1_data'         :   '94X_dataRun2_v10',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '94X_dataRun2_v7',
+    'run2_data'         :   '94X_dataRun2_v10',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '94X_dataRun2_relval_v12',
+    'run2_data_relval'  :   '94X_dataRun2_relval_v14',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '94X_dataRun2_PromptLike_v9',
     # GlobalTag for Run1 HLT: it points to the online GT


### PR DESCRIPTION
## Offline Data
-  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2_design_v2/94X_mcRun2_design_v4
-  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_relval_v12/94X_dataRun2_relval_v14


## 2016 Simulation 
-  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_v7/94X_dataRun2_v10
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2_startup_v2/94X_mcRun2_startup_v3
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2_asymptotic_v2/94X_mcRun2_asymptotic_v3
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2cosmics_startup_deco_v2/94X_mcRun2cosmics_startup_deco_v3
-  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2_pA_v2/94X_mcRun2_pA_v3

## 2017 Simulation 
-  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017_design_IdealBS_v10/94X_mc2017_design_IdealBS_v11
-  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017_realistic_v14/94X_mc2017_realistic_v15
-  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017cosmics_realistic_deco_v10/94X_mc2017cosmics_realistic_deco_v11
-  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017cosmics_realistic_peak_v10/94X_mc2017cosmics_realistic_peak_v11