### PR TITLE
Clean up the HGC validation folder structure

### DIFF
--- a/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
@@ -124,7 +124,7 @@ void HGCGeometryValidation::bookHistograms(DQMStore::IBooker& iB,
                                            edm::Run const&, 
                                            edm::EventSetup const&) {
 
-  iB.setCurrentFolder("HGCalSimHitsV/Geometry");
+  iB.setCurrentFolder("HGCAL/HGCalSimHitsV/Geometry");
 
   //initiating histograms
   heeTotEdepStep = iB.book1D("heeTotEdepStep","",100,0,100);

--- a/Validation/HGCalValidation/plugins/HGCalDigiClient.cc
+++ b/Validation/HGCalValidation/plugins/HGCalDigiClient.cc
@@ -78,7 +78,7 @@ void HGCalDigiClient::runClient_(DQMStore::IBooker &ib, DQMStore::IGetter &ig) {
     for (unsigned int j=0; j<fullSubDirPath.size(); j++) {
       if (verbosity_) 
 	edm::LogVerbatim("HGCalValidation") << "fullSubPath: " << fullSubDirPath.at(j);
-      std::string nameDirectory = "HGCalDigiV/"+nameDetector_;
+      std::string nameDirectory = "HGCAL/HGCalDigisV/"+nameDetector_;
       if (strcmp(fullSubDirPath.at(j).c_str(), nameDirectory.c_str()) == 0) {
         hgcalMEs = ig.getContents(fullSubDirPath.at(j));
         if (verbosity_) 

--- a/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
@@ -345,7 +345,7 @@ void HGCalDigiValidation::dqmBeginRun(const edm::Run&,
   
   if (verbosity_>0) 
     edm::LogVerbatim("HGCalValidation") << "current DQM directory:  "
-					<< "HGCalDigiV/" << nameDetector_ 
+					<< "HGCAL/HGCalDigisV/" << nameDetector_ 
 					<< "  layer = "<< layers_;
 }  
 
@@ -353,7 +353,7 @@ void HGCalDigiValidation::bookHistograms(DQMStore::IBooker& iB,
 					 edm::Run const&, 
 					 edm::EventSetup const&) {
   
-  iB.setCurrentFolder("HGCalDigiV/"+nameDetector_);
+  iB.setCurrentFolder("HGCAL/HGCalDigisV/"+nameDetector_);
 
   std::ostringstream histoname;
   for (int ilayer = 0; ilayer < layers_; ilayer++ ) {

--- a/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
@@ -165,7 +165,7 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent,
 	ntot++; nused++;
 	HGCalDetId detId     = it.id();
 	int        layer     = detId.layer();
-	HGCSample  hgcSample = it.sample(SampleIndx_);
+	const HGCSample&  hgcSample = it.sample(SampleIndx_);
 	uint16_t   gain      = hgcSample.toa();
 	uint16_t   adc       = hgcSample.data();
 	double     charge    = adc*gain;
@@ -191,7 +191,7 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent,
 	ntot++; nused++;
 	HGCalDetId detId     = it.id();
 	int        layer     = detId.layer();
-	HGCSample  hgcSample = it.sample(SampleIndx_);
+	const HGCSample&  hgcSample = it.sample(SampleIndx_);
 	uint16_t   gain      = hgcSample.toa();
 	uint16_t   adc       = hgcSample.data();
 	double     charge    = adc*gain;
@@ -216,7 +216,7 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent,
 	ntot++; nused++;
 	HcalDetId  detId     = it.id();
 	int        layer     = detId.depth();
-	HGCSample  hgcSample = it.sample(SampleIndx_);
+	const HGCSample&  hgcSample = it.sample(SampleIndx_);
 	uint16_t   gain      = hgcSample.toa();
 	uint16_t   adc       = hgcSample.data();
 	double     charge    = adc*gain;

--- a/Validation/HGCalValidation/plugins/HGCalHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitValidation.cc
@@ -156,7 +156,7 @@ void HGCalHitValidation::bookHistograms(DQMStore::IBooker& iB,
 					edm::Run const&, 
 					edm::EventSetup const&) {
 
-  iB.setCurrentFolder("HGCalSimHitsV/HitValidation");
+  iB.setCurrentFolder("HGCAL/HGCalSimHitsV/HitValidation");
 
   //initiating histograms
   heedzVsZ     = iB.book2D("heedzVsZ","",7200,-360,360,100,-0.1,0.1);

--- a/Validation/HGCalValidation/plugins/HGCalRecHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalRecHitValidation.cc
@@ -289,7 +289,7 @@ void HGCalRecHitValidation::bookHistograms(DQMStore::IBooker& iB,
 					   edm::Run const&, 
 					   edm::EventSetup const&) {
 
-  iB.setCurrentFolder("HGCalRecHitsV/"+nameDetector_);
+  iB.setCurrentFolder("HGCAL/HGCalRecHitsV/"+nameDetector_);
   std::ostringstream histoname;
   for (unsigned int ilayer = 0; ilayer < layers_; ilayer++ ) {
     histoname.str(""); histoname << "HitOccupancy_Plus_layer_" << ilayer;

--- a/Validation/HGCalValidation/plugins/HGCalRecHitsClient.cc
+++ b/Validation/HGCalValidation/plugins/HGCalRecHitsClient.cc
@@ -84,7 +84,7 @@ void HGCalRecHitsClient::runClient_(DQMStore::IBooker &ib, DQMStore::IGetter &ig
       if (verbosity_>1) 
 	edm::LogVerbatim("HGCalValidation") << "fullSubPath: " 
 					    << fullSubDirPath.at(j);
-      std::string nameDirectory = "HGCalRecHitsV/"+nameDetector_;
+      std::string nameDirectory = "HGCAL/HGCalRecHitsV/"+nameDetector_;
       if (strcmp(fullSubDirPath.at(j).c_str(), nameDirectory.c_str()) == 0) {
         hgcalMEs = ig.getContents(fullSubDirPath.at(j));
         if (verbosity_>1) 

--- a/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
@@ -430,7 +430,7 @@ void HGCalSimHitValidation::bookHistograms(DQMStore::IBooker& iB,
 					   edm::Run const&, 
 					   edm::EventSetup const&) {
 
-  iB.setCurrentFolder("HGCalSimHitsV/"+nameDetector_);
+  iB.setCurrentFolder("HGCAL/HGCalSimHitsV/"+nameDetector_);
     
   std::ostringstream histoname;
   for (unsigned int ilayer = 0; ilayer < layers_; ilayer++ ) {

--- a/Validation/HGCalValidation/plugins/HGCalSimHitsClient.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitsClient.cc
@@ -91,7 +91,7 @@ void HGCalSimHitsClient::runClient_(DQMStore::IBooker &ib, DQMStore::IGetter &ig
       if (verbosity_>0) 
 	edm::LogVerbatim("HGCalValidation") << "fullSubPath: " 
 					    << fullSubDirPath.at(j);
-      std::string nameDirectory = "HGCalSimHitsV/"+nameDetector_;
+      std::string nameDirectory = "HGCAL/HGCalSimHitsV/"+nameDetector_;
 
       if (strcmp(fullSubDirPath.at(j).c_str(), nameDirectory.c_str()) == 0) {
         hgcalMEs = ig.getContents(fullSubDirPath.at(j));


### PR DESCRIPTION
Put HGCAL simhits, digis, and rechits validation folders under the folder HGCAL for clean-up purpose.