### PR TITLE
Update to uGT and CaloLayer2 unpackers to fill object collections from 6 uGT boards

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloCollections.h
@@ -22,22 +22,22 @@ namespace l1t {
                jets_(new JetBxCollection()),
                taus_(new TauBxCollection()),
                mp_etsums_(new EtSumBxCollection()),
-	       mp_jets_(new JetBxCollection()),
-		 mp_egammas_(new EGammaBxCollection()),
-	       mp_taus_(new TauBxCollection()) {};
+               mp_jets_(new JetBxCollection()),
+               mp_egammas_(new EGammaBxCollection()),
+               mp_taus_(new TauBxCollection()) {};
 
             ~CaloCollections() override;
 
             inline CaloTowerBxCollection* getTowers() { return towers_.get(); };
-            inline EGammaBxCollection* getEGammas() override { return egammas_.get(); };
-            inline EtSumBxCollection* getEtSums() override { return etsums_.get(); };
-            inline JetBxCollection* getJets() override { return jets_.get(); };
-            inline TauBxCollection* getTaus() override { return taus_.get(); };
+            inline EGammaBxCollection* getEGammas(const unsigned int copy) override { return egammas_.get(); };
+            inline EtSumBxCollection*  getEtSums( const unsigned int copy) override { return etsums_.get(); };
+            inline JetBxCollection*    getJets(   const unsigned int copy) override { return jets_.get(); };
+            inline TauBxCollection*    getTaus(   const unsigned int copy) override { return taus_.get(); };
 
-            inline EtSumBxCollection* getMPEtSums() { return mp_etsums_.get(); };
-            inline JetBxCollection* getMPJets() { return mp_jets_.get(); };
-	    inline EGammaBxCollection* getMPEGammas() { return mp_egammas_.get(); };
-	    inline TauBxCollection* getMPTaus() { return mp_taus_.get(); };
+            inline EtSumBxCollection*  getMPEtSums() {  return mp_etsums_.get(); };
+            inline JetBxCollection*    getMPJets() {    return mp_jets_.get(); };
+            inline EGammaBxCollection* getMPEGammas() { return mp_egammas_.get(); };
+            inline TauBxCollection*    getMPTaus() {    return mp_taus_.get(); };
 
          private:
             std::unique_ptr<CaloTowerBxCollection> towers_;
@@ -48,8 +48,8 @@ namespace l1t {
 
             std::unique_ptr<EtSumBxCollection> mp_etsums_;
             std::unique_ptr<JetBxCollection> mp_jets_;
-	    std::unique_ptr<EGammaBxCollection> mp_egammas_;
-	    std::unique_ptr<TauBxCollection> mp_taus_;
+            std::unique_ptr<EGammaBxCollection> mp_egammas_;
+            std::unique_ptr<TauBxCollection> mp_taus_;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EGammaUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EGammaUnpacker.cc
@@ -10,6 +10,10 @@
 
 namespace l1t {
 namespace stage2 {
+   EGammaUnpacker::EGammaUnpacker() : EGammaCopy_(0)
+   {
+   }
+
    bool
    EGammaUnpacker::unpack(const Block& block, UnpackerCollections *coll)
    {
@@ -29,7 +33,7 @@ namespace stage2 {
        lastBX = ceil((double)nBX/2.)-1;
      }
 
-     auto res_ = static_cast<L1TObjectCollections*>(coll)->getEGammas();
+     auto res_ = static_cast<L1TObjectCollections*>(coll)->getEGammas(EGammaCopy_);
      res_->setBXRange(firstBX, lastBX);
 
      LogDebug("L1T") << "nBX = " << nBX << " first BX = " << firstBX << " lastBX = " << lastBX;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EGammaUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EGammaUnpacker.h
@@ -15,7 +15,6 @@ namespace l1t {
             inline void setEGammaCopy(const unsigned int copy) { EGammaCopy_ = copy; };
 
          private:
-            EGammaBxCollection* res_;
             unsigned int EGammaCopy_;
       };
    }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EGammaUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EGammaUnpacker.h
@@ -7,7 +7,16 @@ namespace l1t {
    namespace stage2 {
       class EGammaUnpacker : public Unpacker {
          public:
+            EGammaUnpacker();
+            ~EGammaUnpacker() override {};
+
             bool unpack(const Block& block, UnpackerCollections *coll) override;
+
+            inline void setEGammaCopy(const unsigned int copy) { EGammaCopy_ = copy; };
+
+         private:
+            EGammaBxCollection* res_;
+            unsigned int EGammaCopy_;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.cc
@@ -10,6 +10,10 @@
 
 namespace l1t {
 namespace stage2 {
+   EtSumUnpacker::EtSumUnpacker() : EtSumCopy_(0)
+   {
+   }
+
    bool
    EtSumUnpacker::unpack(const Block& block, UnpackerCollections *coll)
    {
@@ -30,7 +34,7 @@ namespace stage2 {
        lastBX = ceil((double)nBX/2.)-1;
      }
 
-     auto res_ = static_cast<L1TObjectCollections*>(coll)->getEtSums();
+     auto res_ = static_cast<L1TObjectCollections*>(coll)->getEtSums(EtSumCopy_);
      res_->setBXRange(firstBX, lastBX);
 
      LogDebug("L1T") << "nBX = " << nBX << " first BX = " << firstBX << " lastBX = " << lastBX;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.h
@@ -15,7 +15,6 @@ namespace l1t {
             inline void setEtSumCopy(const unsigned int copy) { EtSumCopy_ = copy; };
 
          private:
-            EtSumBxCollection* res_;
             unsigned int EtSumCopy_;
       };
    }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.h
@@ -7,7 +7,16 @@ namespace l1t {
    namespace stage2 {
       class EtSumUnpacker : public Unpacker {
          public:
+            EtSumUnpacker();
+            ~EtSumUnpacker() override {};
+
             bool unpack(const Block& block, UnpackerCollections *coll) override;
+
+            inline void setEtSumCopy(const unsigned int copy) { EtSumCopy_ = copy; };
+
+         private:
+            EtSumBxCollection* res_;
+            unsigned int EtSumCopy_;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.cc
@@ -7,14 +7,22 @@ namespace l1t {
       GTCollections::~GTCollections()
       {
 
-        event_.put(std::move(muons_), "Muon");
-	event_.put(std::move(egammas_), "EGamma");
-	event_.put(std::move(etsums_), "EtSum");
-	event_.put(std::move(jets_), "Jet");
-	event_.put(std::move(taus_), "Tau");
-	
-	event_.put(std::move(algBlk_));
-	event_.put(std::move(extBlk_)); 
+        event_.put(std::move(muons_[0]),   "Muon");
+        event_.put(std::move(egammas_[0]), "EGamma");
+        event_.put(std::move(etsums_[0]),  "EtSum");
+        event_.put(std::move(jets_[0]),    "Jet");
+        event_.put(std::move(taus_[0]),    "Tau");
+
+        for (int i=1; i<6; ++i) {
+           event_.put(std::move(muons_[i]),   "Muon"   + std::to_string(i+1));
+           event_.put(std::move(egammas_[i]), "EGamma" + std::to_string(i+1));
+           event_.put(std::move(etsums_[i]),  "EtSum"  + std::to_string(i+1));
+           event_.put(std::move(jets_[i]),    "Jet"    + std::to_string(i+1));
+           event_.put(std::move(taus_[i]),    "Tau"    + std::to_string(i+1));
+        }
+        
+        event_.put(std::move(algBlk_));
+        event_.put(std::move(extBlk_)); 
 
       }
    }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.h
@@ -19,11 +19,6 @@ namespace l1t {
          public:
             GTCollections(edm::Event& e) :
                L1TObjectCollections(e),
-		       //muons_(),
-		       //egammas_(),
-		       //etsums_(),
-		       //jets_(),
-		       //taus_(),
 		       algBlk_(new GlobalAlgBlkBxCollection()),
 		       extBlk_(new GlobalExtBlkBxCollection())  
             {

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.h
@@ -18,38 +18,44 @@ namespace l1t {
       class GTCollections : public L1TObjectCollections {
          public:
             GTCollections(edm::Event& e) :
-                 L1TObjectCollections(e),
-		 muons_(new MuonBxCollection()),
-		 egammas_(new EGammaBxCollection()),
-		 etsums_(new EtSumBxCollection()),
-		 jets_(new JetBxCollection()),
-		 taus_(new TauBxCollection()),
-		 algBlk_(new GlobalAlgBlkBxCollection()),
-		 extBlk_(new GlobalExtBlkBxCollection())  {};
+               L1TObjectCollections(e),
+		       //muons_(),
+		       //egammas_(),
+		       //etsums_(),
+		       //jets_(),
+		       //taus_(),
+		       algBlk_(new GlobalAlgBlkBxCollection()),
+		       extBlk_(new GlobalExtBlkBxCollection())  
+            {
+               std::generate(muons_.begin(),   muons_.end(),   []{ return std::make_unique<MuonBxCollection>(); });
+               std::generate(egammas_.begin(), egammas_.end(), []{ return std::make_unique<EGammaBxCollection>(); });
+               std::generate(etsums_.begin(),  etsums_.end(),  []{ return std::make_unique<EtSumBxCollection>(); });
+               std::generate(jets_.begin(),    jets_.end(),    []{ return std::make_unique<JetBxCollection>(); });
+               std::generate(taus_.begin(),    taus_.end(),    []{ return std::make_unique<TauBxCollection>(); });
+            };
 
             ~GTCollections() override;
             
-	    inline MuonBxCollection* getMuons(const unsigned int copy) override { return muons_.get(); };
-	    inline EGammaBxCollection* getEGammas() override { return egammas_.get(); };
-            inline EtSumBxCollection* getEtSums() override { return etsums_.get(); };
-            inline JetBxCollection* getJets() override { return jets_.get(); };
-            inline TauBxCollection* getTaus() override { return taus_.get(); };
+            inline MuonBxCollection*   getMuons(  const unsigned int copy) override { return muons_[copy].get(); };
+            inline EGammaBxCollection* getEGammas(const unsigned int copy) override { return egammas_[copy].get(); };
+            inline EtSumBxCollection*  getEtSums( const unsigned int copy) override { return etsums_[copy].get(); };
+            inline JetBxCollection*    getJets(   const unsigned int copy) override { return jets_[copy].get(); };
+            inline TauBxCollection*    getTaus(   const unsigned int copy) override { return taus_[copy].get(); };
 
             inline GlobalAlgBlkBxCollection* getAlgs() { return algBlk_.get(); };
             inline GlobalExtBlkBxCollection* getExts() { return extBlk_.get(); };
 
 
          private:
-	    
-	    std::unique_ptr<MuonBxCollection> muons_;
-	    std::unique_ptr<EGammaBxCollection> egammas_;
-	    std::unique_ptr<EtSumBxCollection> etsums_;
-	    std::unique_ptr<JetBxCollection> jets_;
-	    std::unique_ptr<TauBxCollection> taus_;
+        
+            std::array<std::unique_ptr<MuonBxCollection>,   6 > muons_;
+            std::array<std::unique_ptr<EGammaBxCollection>, 6 > egammas_;
+            std::array<std::unique_ptr<EtSumBxCollection>,  6 > etsums_;
+            std::array<std::unique_ptr<JetBxCollection>,    6 > jets_;
+            std::array<std::unique_ptr<TauBxCollection>,    6 > taus_;
 
             std::unique_ptr<GlobalAlgBlkBxCollection> algBlk_;
             std::unique_ptr<GlobalExtBlkBxCollection> extBlk_;
-
 
       };
    }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
@@ -119,11 +119,9 @@ namespace l1t {
             res[14] = jet_unp;
             res[16] = tau_unp;
             res[18] = tau_unp;
-
             res[20] = etsum_unp;
 
-            //only unpack first uGT board for the inputs (single copy)
-            if(amc == 1) { 
+            if(amc == 1) { // only unpack first uGT board for the external signal inputs (single copy)
                 res[24] = ext_unp;
                 //res[22] = empty link no data
                 res[26] = ext_unp;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
@@ -5,6 +5,10 @@
 #include "EventFilter/L1TRawToDigi/plugins/UnpackerFactory.h"
 
 #include "EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h"
+#include "EventFilter/L1TRawToDigi/plugins/implementations_stage2/EGammaUnpacker.h"
+#include "EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.h"
+#include "EventFilter/L1TRawToDigi/plugins/implementations_stage2/JetUnpacker.h"
+#include "EventFilter/L1TRawToDigi/plugins/implementations_stage2/TauUnpacker.h"
 
 #include "GTSetup.h"
 
@@ -62,6 +66,13 @@ namespace l1t {
          prod.produces<TauBxCollection>("Tau");
          prod.produces<GlobalAlgBlkBxCollection>();
          prod.produces<GlobalExtBlkBxCollection>();
+         for (int i=2; i<7; ++i) { // Collections from boards 2-6
+            prod.produces<MuonBxCollection>(  "Muon"   + std::to_string(i));
+            prod.produces<EGammaBxCollection>("EGamma" + std::to_string(i));
+            prod.produces<EtSumBxCollection>( "EtSum"  + std::to_string(i));
+            prod.produces<JetBxCollection>(   "Jet"    + std::to_string(i));
+            prod.produces<TauBxCollection>(   "Tau"    + std::to_string(i));
+         }
 
       }
 
@@ -75,40 +86,49 @@ namespace l1t {
       GTSetup::getUnpackers(int fed, int board, int amc, unsigned int fw)
       {
 
-         auto muon_unp = static_pointer_cast<l1t::stage2::MuonUnpacker>(UnpackerFactory::get()->make("stage2::MuonUnpacker"));
-         auto egamma_unp = UnpackerFactory::get()->make("stage2::EGammaUnpacker");
-         auto etsum_unp = UnpackerFactory::get()->make("stage2::EtSumUnpacker");
-         auto jet_unp = UnpackerFactory::get()->make("stage2::JetUnpacker");
-         auto tau_unp = UnpackerFactory::get()->make("stage2::TauUnpacker");
+         auto muon_unp =   static_pointer_cast<l1t::stage2::MuonUnpacker>(UnpackerFactory::get()->make("stage2::MuonUnpacker"));
+         auto egamma_unp = static_pointer_cast<l1t::stage2::EGammaUnpacker>(UnpackerFactory::get()->make("stage2::EGammaUnpacker"));
+         auto etsum_unp =  static_pointer_cast<l1t::stage2::EtSumUnpacker>(UnpackerFactory::get()->make("stage2::EtSumUnpacker"));
+         auto jet_unp =    static_pointer_cast<l1t::stage2::JetUnpacker>(UnpackerFactory::get()->make("stage2::JetUnpacker"));
+         auto tau_unp =    static_pointer_cast<l1t::stage2::TauUnpacker>(UnpackerFactory::get()->make("stage2::TauUnpacker"));
+
          auto alg_unp = UnpackerFactory::get()->make("stage2::GlobalAlgBlkUnpacker");
          auto ext_unp = UnpackerFactory::get()->make("stage2::GlobalExtBlkUnpacker");
 
          muon_unp->setAlgoVersion(fw);
          muon_unp->setFedNumber(fed);
+         
+         muon_unp->setMuonCopy(amc-1);
+         egamma_unp->setEGammaCopy(amc-1);
+         etsum_unp->setEtSumCopy(amc-1);
+         jet_unp->setJetCopy(amc-1);
+         tau_unp->setTauCopy(amc-1);
 
          UnpackerMap res;
 
          if (fed == 1404) {
 
+            // From the rx buffers         
+            res[0]  = muon_unp;
+            res[2]  = muon_unp;
+            res[4]  = muon_unp;
+            res[6]  = muon_unp;
+            res[8]  = egamma_unp;
+            res[10] = egamma_unp;
+            res[12] = jet_unp;
+            res[14] = jet_unp;
+            res[16] = tau_unp;
+            res[18] = tau_unp;
+
+            res[20] = etsum_unp;
+
             //only unpack first uGT board for the inputs (single copy)
             if(amc == 1) { 
-               // From the rx buffers         
-               res[0]  = muon_unp;
-               res[2]  = muon_unp;
-               res[4]  = muon_unp;
-               res[6]  = muon_unp;
-               res[8]  = egamma_unp;
-               res[10] = egamma_unp;
-               res[12] = jet_unp;
-               res[14] = jet_unp;
-               res[16] = tau_unp;
-               res[18] = tau_unp;
-               res[20] = etsum_unp;
-               res[24] = ext_unp;
-               //res[22] = empty link no data
-               res[26] = ext_unp;
-               res[28] = ext_unp;
-               res[30] = ext_unp;
+                res[24] = ext_unp;
+                //res[22] = empty link no data
+                res[26] = ext_unp;
+                res[28] = ext_unp;
+                res[30] = ext_unp;
             }
 
             //From tx buffers

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/JetUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/JetUnpacker.cc
@@ -10,6 +10,10 @@
 
 namespace l1t {
 namespace stage2 {
+   JetUnpacker::JetUnpacker() : JetCopy_(0)
+   {
+   }
+
    bool
    JetUnpacker::unpack(const Block& block, UnpackerCollections *coll)
    {
@@ -29,7 +33,7 @@ namespace stage2 {
        lastBX = ceil((double)nBX/2.)-1;
      }
 
-     auto res_ = static_cast<L1TObjectCollections*>(coll)->getJets();
+     auto res_ = static_cast<L1TObjectCollections*>(coll)->getJets(JetCopy_);
      res_->setBXRange(firstBX, lastBX);
 
      LogDebug("L1T") << "nBX = " << nBX << " first BX = " << firstBX << " lastBX = " << lastBX;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/JetUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/JetUnpacker.h
@@ -15,7 +15,6 @@ namespace l1t {
             inline void setJetCopy(const unsigned int copy) { JetCopy_ = copy; };
 
          private:
-            JetBxCollection* res_;
             unsigned int JetCopy_;
       };
    }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/JetUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/JetUnpacker.h
@@ -7,7 +7,16 @@ namespace l1t {
    namespace stage2 {
       class JetUnpacker : public Unpacker {
          public:
+            JetUnpacker();
+            ~JetUnpacker() override {};
+
             bool unpack(const Block& block, UnpackerCollections *coll) override;
+
+            inline void setJetCopy(const unsigned int copy) { JetCopy_ = copy; };
+
+         private:
+            JetBxCollection* res_;
+            unsigned int JetCopy_;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TObjectCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TObjectCollections.h
@@ -15,13 +15,13 @@ namespace l1t {
        public:
          L1TObjectCollections(edm::Event& e) :
            UnpackerCollections(e) { };
-	 ~L1TObjectCollections() override ;
+         ~L1TObjectCollections() override ;
 
-         virtual MuonBxCollection* getMuons(const unsigned int copy) { return  nullptr;}
-	 virtual EGammaBxCollection* getEGammas() { return nullptr;} //= 0;
-	 virtual EtSumBxCollection* getEtSums() { return nullptr;}
-	 virtual JetBxCollection* getJets() {return nullptr; }
-	 virtual TauBxCollection* getTaus() {return nullptr; }
+         virtual MuonBxCollection*   getMuons(  const unsigned int copy) { return  nullptr;}
+         virtual EGammaBxCollection* getEGammas(const unsigned int copy) { return  nullptr;} //= 0;
+         virtual EtSumBxCollection*  getEtSums( const unsigned int copy) { return  nullptr;}
+         virtual JetBxCollection*    getJets(   const unsigned int copy) { return  nullptr;}
+         virtual TauBxCollection*    getTaus(   const unsigned int copy) { return  nullptr;}
 	 
       };
    }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/TauUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/TauUnpacker.cc
@@ -10,6 +10,10 @@
 
 namespace l1t {
 namespace stage2 {
+   TauUnpacker::TauUnpacker() : TauCopy_(0)
+   {
+   }
+
    bool
    TauUnpacker::unpack(const Block& block, UnpackerCollections *coll)
    {
@@ -29,7 +33,7 @@ namespace stage2 {
        lastBX = ceil((double)nBX/2.)-1;
      }
 
-     auto res_ = static_cast<L1TObjectCollections*>(coll)->getTaus();
+     auto res_ = static_cast<L1TObjectCollections*>(coll)->getTaus(TauCopy_);
      res_->setBXRange(firstBX, lastBX);
 
      LogDebug("L1T") << "nBX = " << nBX << " first BX = " << firstBX << " lastBX = " << lastBX;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/TauUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/TauUnpacker.h
@@ -15,7 +15,6 @@ namespace l1t {
             inline void setTauCopy(const unsigned int copy) { TauCopy_ = copy; };
 
          private:
-            TauBxCollection* res_;
             unsigned int TauCopy_;
       };
    }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/TauUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/TauUnpacker.h
@@ -7,7 +7,16 @@ namespace l1t {
    namespace stage2 {
       class TauUnpacker : public Unpacker {
          public:
+            TauUnpacker();
+            ~TauUnpacker() override {};
+
             bool unpack(const Block& block, UnpackerCollections *coll) override;
+
+            inline void setTauCopy(const unsigned int copy) { TauCopy_ = copy; };
+
+         private:
+            TauBxCollection* res_;
+            unsigned int TauCopy_;
       };
    }
 }


### PR DESCRIPTION
The readout record of the uGT has been updated to read-out data from all 6 boards for validation (fat) events only. This data is then to be compared using a L1T DQM module, to ensure that all 6 boards receive the same information. This is summarised in the following JIRA ticket: https://its.cern.ch/jira/browse/CMSLITDPG-329

The changes in the code allow for the unpacking of this additional data, which is filled into new BX collections that are appended by an index ranging from 2-6, corresponding to the board number. The following CaloLayer2 unpackers have been modified: EGamma, EtSum, Jet, Tau. The changes are analogous to the existing modification of the Muon unpacker, where one defines a 'copy' to be filled, which corresponds to the board number. This copy number is initialised to 0, which refers to the existing collection for the first board. 

The GTSetup, as well as the CaloCollections, GTCollections and L1TObjectCollections had to be updated to synchronise with these changes.

It is important to ensure that these changes have no effect on the original unpacked collections, as well as do not cause any issues downstream. The code has been tested on Run2018A data and a basic comparisons of single hwPt distributions indicate that there are no differences and that the new collections are correctly filled. However, this does not serve as a complete validation of the code. The results of these tests are attached together with the JIRA ticket in the form of slides.

Therefore, I would kindly request for the experts to proceed with validating this code further.

Backport of this PR to 10_1_X: https://github.com/cms-sw/cmssw/pull/23628