### PR TITLE
Properly handle trigger caches when we jump backwards in the file

### DIFF
--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -52,6 +52,7 @@ namespace edm {
     trainNow_(false),
     switchOverEntry_(-1),
     rawTriggerSwitchOverEntry_(-1),
+    performedSwitchOver_{false},
     learningEntries_(learningEntries),
     cacheSize_(cacheSize),
     treeAutoFlush_(0),
@@ -219,7 +220,7 @@ namespace edm {
           rawTreeCache_->FillBuffer();
         }
       }
-      if(performedSwitchOver_) {
+      if(performedSwitchOver_ and triggerTreeCache_) {
         //We are using the triggerTreeCache_ not the rawTriggerTreeCache_.
         //The triggerTreeCache was originally told to start from an entry further in the file.
         triggerTreeCache_->SetEntryRange(theEntryNumber, tree_->GetEntries());


### PR DESCRIPTION
The triggerCaches have specific starting points in their SetRange
calls. If the job jumps backwards in the file then we need to
reset their starting point.
This was found by a new error message in ROOT 6.14.