### PR TITLE
HCALDQM: Require HB/HE for QIE11 and HF for QIE10

### DIFF
--- a/DQM/HcalTasks/plugins/DigiPhase1Task.cc
+++ b/DQM/HcalTasks/plugins/DigiPhase1Task.cc
@@ -333,10 +333,14 @@ DigiPhase1Task::DigiPhase1Task(edm::ParameterSet const& ps):
 		if (rawid==0) 
 		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
 		HcalElectronicsId const& eid(rawid);
-		if (did.subdet()==HcalBarrel)
+		if (did.subdet()==HcalBarrel) {
 			rawidHBValid = did.rawId();
-		else if (did.subdet()==HcalEndcap) 
+		} else if (did.subdet()==HcalEndcap) {
 			rawidHEValid = did.rawId();
+		} else {
+			// Skip non-HB or HE detids
+			continue;
+		}
 
 		//  filter out channels that are masked out
 		if (_xQuality.exists(did)) 
@@ -556,8 +560,12 @@ DigiPhase1Task::DigiPhase1Task(edm::ParameterSet const& ps):
 		if (rawid==0) 
 		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
 		HcalElectronicsId const& eid(rawid);
-		if (did.subdet()==HcalForward)
+		if (did.subdet()==HcalForward) {
 			rawidValid = did.rawId();
+		} else {
+			// Skip non-HF detids
+			continue;
+		}
 
 		//  filter out channels that are masked out
 		if (_xQuality.exists(did)) 


### PR DESCRIPTION
This PR addresses https://github.com/cms-sw/cmssw/issues/23259. DigiPhase1Task is crashing due to calibration DetIds in the QIE10/11 digi collections (the DetIds are not in the emap, so histograms are not created for them). 

It's not entirely obvious to me why this crash is only occurring now, but this fix should have no impact on the intended behavior of the module (which is no longer used, anyways).