### PR TITLE
Significant reduction of memory footprint for 2D templates, etc.

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplateReco2D.cc (Version 2.55)
+//  SiPixelTemplateReco2D.cc (Version 2.60)
 //  Updated to work with the 2D template generation code
 //  2.10 - Add y-lorentz drift to estimate starting point [for FPix]
 //  2.10 - Remove >1 pixel requirement
@@ -8,6 +8,9 @@
 //  2.50 - Add variable cluster shifting to make the position parameter space more symmetric,
 //         also fix potential problems with variable size input clusters and double pixel flags
 //  2.55 - Fix another double pixel flag problem and a small pseudopixel problem in the edgegflagy = 3 case.
+//  2.60 - Modify the algorithm to return the point with the best chi2 from the starting point scan when
+//         the iterative procedure does not converge [eg 1 pixel clusters]
+
 //
 //
 //  Created by Morris Swartz on 7/13/17.

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h
@@ -1,11 +1,12 @@
 //
-//  SiPixelTemplateReco2D.cc (Version 2.20)
+//  SiPixelTemplateReco2D.cc (Version 2.50)
 //  Updated to work with the 2D template generation code
 //  2.10 - Add y-lorentz drift to estimate starting point [for FPix]
 //  2.10 - Remove >1 pixel requirement
 //  2.20 - Fix major bug, change chi2 scan to 9x5 [YxX]
-
-
+//  2.30 - Allow one pixel clusters, improve cosmetics for increased style points from judges
+//  2.50 - Add variable cluster shifting to make the position parameter space more symmetric,
+//         also fix potential problems with variable size input clusters and double pixel flags
 //
 //
 //  Created by Morris Swartz on 7/13/17.

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco2D.h
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplateReco2D.cc (Version 2.50)
+//  SiPixelTemplateReco2D.cc (Version 2.55)
 //  Updated to work with the 2D template generation code
 //  2.10 - Add y-lorentz drift to estimate starting point [for FPix]
 //  2.10 - Remove >1 pixel requirement
@@ -7,6 +7,7 @@
 //  2.30 - Allow one pixel clusters, improve cosmetics for increased style points from judges
 //  2.50 - Add variable cluster shifting to make the position parameter space more symmetric,
 //         also fix potential problems with variable size input clusters and double pixel flags
+//  2.55 - Fix another double pixel flag problem and a small pseudopixel problem in the edgegflagy = 3 case.
 //
 //
 //  Created by Morris Swartz on 7/13/17.

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -107,8 +107,8 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const & conf,
 //-----------------------------------------------------------------------------
 PixelCPEClusterRepair::~PixelCPEClusterRepair()
 {
-   for(auto x : thePixelTemp_) x.destroy();
-   // Note: this is not needed for Template 2D
+   for (auto x : thePixelTemp_)   x.destroy();
+   for (auto x : thePixelTemp2D_) x.destroy();
 }
 
 PixelCPEBase::ClusterParam* PixelCPEClusterRepair::createClusterParam(const SiPixelCluster & cl) const

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -2818,7 +2818,7 @@ void SiPixelTemplate::temperrors(int id, float cotalpha, float cotbeta, int qBin
    // Interpolate the absolute value of cot(beta)
    
    acotb = fabs((double)cotbeta);
-   cotb = cotbeta;
+   // cotb = cotbeta;   // &&& check with Morris, we reassign it below.
    
    // for some cosmics, the ususal gymnastics are incorrect
    
@@ -3005,7 +3005,7 @@ void SiPixelTemplate::qbin_dist(int id, float cotalpha, float cotbeta, float qbi
    // Interpolate the absolute value of cot(beta)
    
    acotb = fabs((double)cotbeta);
-   cotb = cotbeta;
+   // cotb = cotbeta;   // &&& check with Morris, we reassign it below.
    
    
    // for some cosmics, the ususal gymnastics are incorrect

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate2D.cc
@@ -64,7 +64,6 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2
    // Add template stored in external file numbered filenum to theTemplateStore
    
    // Local variables
-   char c;
    const int code_version={21};
    
    //  Create a filename for this run
@@ -101,9 +100,10 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2
       SiPixelTemplateStore2D theCurrentTemp;
       
       // Read-in a header string first and print it
+      char c;
       for (int i=0; (c=in_file.get()) != '\n'; ++i) {
          if(i < 79) {theCurrentTemp.head.title[i] = c;}
-         if(i > 78) {theCurrentTemp.head.title[79] ='\0';}
+         else       {theCurrentTemp.head.title[79] ='\0';}
       }
       LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
       
@@ -827,7 +827,6 @@ bool SiPixelTemplate2D::interpolate(int id, float cotalpha, float cotbeta, float
 
 void SiPixelTemplate2D::sideload(SiPixelTemplateEntry2D* entry, int iDtype, float locBx, float locBz, float lorwdy, float lorwdx, float q50, float fbin[3], float xsize, float ysize, float zsize)
 {
-   
    // Set class variables to the input parameters
    
    entry00_ = entry;
@@ -951,7 +950,7 @@ bool SiPixelTemplate2D::xytemp(float xhit, float yhit, bool ydouble[BYM2], bool 
    int pixx, pixy, k0, k1, l0, l1, deltax, deltay, iflipy, jflipx, imin, imax, jmin, jmax;
    int m, n;
    float dx, dy, ddx, ddy, adx, ady;
-//   const float deltaxy[2] = {8.33f, 12.5f};
+   //   const float deltaxy[2] = {8.33f, 12.5f};
    const float deltaxy[2] = {16.67f, 25.0f};
    
    // Check to see if interpolation is valid
@@ -1087,7 +1086,7 @@ bool SiPixelTemplate2D::xytemp(float xhit, float yhit, bool ydouble[BYM2], bool 
                dpdx2d[k][i][j] = 0.f;
             }
          }
-     }
+      }
       
       // First do shifted +x template
       
@@ -1481,7 +1480,6 @@ bool SiPixelTemplate2D::xytemp(int id, float cotalpha, float cotbeta, float xhit
    // Interpolate for a new set of track angles
    
    if(SiPixelTemplate2D::interpolate(id, cotalpha, cotbeta, locBz, locBx)) {
-      
       return SiPixelTemplate2D::xytemp(xhit, yhit, yd, xd, template2d, derivatives, dpdx2d, QTemplate);
    } else {
       return false;
@@ -1519,27 +1517,27 @@ void SiPixelTemplate2D::xysigma2(float qpixel, int index, float& xysig2)
    
    // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis
    
-			if(qpixel < sxymax_) {
-            sigi = qpixel;
-            qscale = 1.f;
-         } else {
-            sigi = sxymax_;
-            qscale = qpixel/sxymax_;
-         }
-			sigi2 = sigi*sigi; sigi3 = sigi2*sigi; sigi4 = sigi3*sigi;
-			if(index <= T2HYP1) {
-            err00 = xypary0x0_[0][0]+xypary0x0_[0][1]*sigi+xypary0x0_[0][2]*sigi2+xypary0x0_[0][3]*sigi3+xypary0x0_[0][4]*sigi4;
-            err2 = err00
-            +adcota_*(xypary0x1_[0][0]+xypary0x1_[0][1]*sigi+xypary0x1_[0][2]*sigi2+xypary0x1_[0][3]*sigi3+xypary0x1_[0][4]*sigi4 - err00)
-            +adcotb_*(xypary1x0_[0][0]+xypary1x0_[0][1]*sigi+xypary1x0_[0][2]*sigi2+xypary1x0_[0][3]*sigi3+xypary1x0_[0][4]*sigi4 - err00);
-         } else {
-            err00 = xypary0x0_[1][0]+xypary0x0_[1][1]*sigi+xypary0x0_[1][2]*sigi2+xypary0x0_[1][3]*sigi3+xypary0x0_[1][4]*sigi4;
-            err2 = err00
-            +adcota_*(xypary0x1_[1][0]+xypary0x1_[1][1]*sigi+xypary0x1_[1][2]*sigi2+xypary0x1_[1][3]*sigi3+xypary0x1_[1][4]*sigi4 - err00)
-            +adcotb_*(xypary1x0_[1][0]+xypary1x0_[1][1]*sigi+xypary1x0_[1][2]*sigi2+xypary1x0_[1][3]*sigi3+xypary1x0_[1][4]*sigi4 - err00);
-         }
-			xysig2 =qscale*err2;
-			if(xysig2 <= 0.f) {xysig2 = s50_*s50_;}
+   if(qpixel < sxymax_) {
+      sigi = qpixel;
+      qscale = 1.f;
+   } else {
+      sigi = sxymax_;
+      qscale = qpixel/sxymax_;
+   }
+   sigi2 = sigi*sigi; sigi3 = sigi2*sigi; sigi4 = sigi3*sigi;
+   if(index <= T2HYP1) {
+      err00 = xypary0x0_[0][0]+xypary0x0_[0][1]*sigi+xypary0x0_[0][2]*sigi2+xypary0x0_[0][3]*sigi3+xypary0x0_[0][4]*sigi4;
+      err2 = err00
+	+adcota_*(xypary0x1_[0][0]+xypary0x1_[0][1]*sigi+xypary0x1_[0][2]*sigi2+xypary0x1_[0][3]*sigi3+xypary0x1_[0][4]*sigi4 - err00)
+	+adcotb_*(xypary1x0_[0][0]+xypary1x0_[0][1]*sigi+xypary1x0_[0][2]*sigi2+xypary1x0_[0][3]*sigi3+xypary1x0_[0][4]*sigi4 - err00);
+   } else {
+      err00 = xypary0x0_[1][0]+xypary0x0_[1][1]*sigi+xypary0x0_[1][2]*sigi2+xypary0x0_[1][3]*sigi3+xypary0x0_[1][4]*sigi4;
+      err2 = err00
+	+adcota_*(xypary0x1_[1][0]+xypary0x1_[1][1]*sigi+xypary0x1_[1][2]*sigi2+xypary0x1_[1][3]*sigi3+xypary0x1_[1][4]*sigi4 - err00)
+	+adcotb_*(xypary1x0_[1][0]+xypary1x0_[1][1]*sigi+xypary1x0_[1][2]*sigi2+xypary1x0_[1][3]*sigi3+xypary1x0_[1][4]*sigi4 - err00);
+   }
+   xysig2 =qscale*err2;
+   if(xysig2 <= 0.f) {xysig2 = s50_*s50_;}
    
    return;
    

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate2D.cc
@@ -159,7 +159,12 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector< SiPixelTemplateStore2
             in_file >> theCurrentTemp.entry[iy][jx].runnum >> theCurrentTemp.entry[iy][jx].costrk[0]
             >> theCurrentTemp.entry[iy][jx].costrk[1] >> theCurrentTemp.entry[iy][jx].costrk[2];
             
-            if(in_file.fail()) {LOGERROR("SiPixelTemplate2D") << "Error reading file 1, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL; return false;}
+            if(in_file.fail()) {
+	      LOGERROR("SiPixelTemplate2D") << "Error reading file 1, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+	      delete theCurrentTemp.entry[0];
+	      delete theCurrentTemp.entry;
+	      return false;
+	    }
             
             // Calculate cot(alpha) and cot(beta) for this entry
             

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplateReco2D.cc (Version 2.50)
+//  SiPixelTemplateReco2D.cc (Version 2.55)
 //  Updated to work with the 2D template generation code
 //  Include all bells and whistles for edge clusters
 //  2.10 - Add y-lorentz drift to estimate starting point [for FPix]
@@ -8,6 +8,7 @@
 //  2.30 - Allow one pixel clusters, improve cosmetics for increased style points from judges
 //  2.50 - Add variable cluster shifting to make the position parameter space more symmetric,
 //         also fix potential problems with variable size input clusters and double pixel flags
+//  2.55 - Fix another double pixel flag problem and a small pseudopixel problem in the edgegflagy = 3 case.
 //
 //
 //
@@ -322,7 +323,7 @@ int SiPixelTemplateReco2D::PixelTempReco3D(int id, float cotalpha, float cotbeta
    
    float chi2min[2], xerr2[2], yerr2[2];
    float x2D0[2], y2D0[2], qtfrac0[2];
-   int ipass, niter0[2];
+   int ipass, tpixel, niter0[2];
    
    for(ipass = 0; ipass < npass; ++ipass) {
       
@@ -332,11 +333,17 @@ int SiPixelTemplateReco2D::PixelTempReco3D(int id, float cotalpha, float cotbeta
          
          imisshigh = -1;
          imisslow = imax+1;
+// erase pseudo pixels from previous pass
+         for(int k=npixel; k<tpixel; ++k) {         
+            int j = indexxy[0][k];
+            int i = indexxy[1][k];
+            clusxy[j][i] = 0.f;
+         }
       }
       
       // Next, add pseudo pixels around the periphery of the cluster
       
-      int tpixel = npixel;
+      tpixel = npixel;
       for(int k=0; k<npixel; ++k) {
          int j = indexxy[0][k];
          int i = indexxy[1][k];
@@ -437,7 +444,7 @@ int SiPixelTemplateReco2D::PixelTempReco3D(int id, float cotalpha, float cotbeta
             chi2 = 0.f;
             qactive = 0.f;
             for(int j=0; j<BXM2; ++j) {for(int i=0; i<BYM2; ++i) {template2d[j][i] = 0.f;}}
-            templ2D.xytemp(xtry, ytry, ydouble, xdouble, template2d, false, dpdx2d, qtemplate);
+            templ2D.xytemp(xtry, ytry, yd, xd, template2d, false, dpdx2d, qtemplate);
             for(int k=0; k<tpixel; ++k) {
                int jpix = indexxy[0][k];
                int ipix = indexxy[1][k];


### PR DESCRIPTION
1) reduction of memory footprint of 2D templates.  Average reduction is about a factor of 3.  This was the main homework from #20950.
2) additionally, there are bug fixes in 3D reconstruction (used by ClusterRepair).
3) cosmetic fixes in SiPixelTemplate*2D.{hh,cc}.  (Cosmetic fixes in other files coming separately.)

Tests:
- TrackingValidation RunTheMatrix workflow (TTBar 2018_realistic) and it worked fine
- Pixeltree running on data with Tamas's GT worked too. 
- runTheMatrix.py -e -n -l 136.831 (on data) with the tag that Tamas gave to us also runs fine.

As discussed previously, the plan is to have a separate FastSim PR and then another SiPixelRecHits + SiPixelDigitizer + pixel FastSim PR which involves moving templates + miscellanea to another package.  So I'd like to defer all cosmetics to that PR.  (But you can still give me suggestions :)

@perrotta @slava77 @fabiocos @makortel @tvami @tsusa @OzAmram @cmantill @schuetzepaul 