### PR TITLE
Added likelihood fit to BeamPixel DQM application

### DIFF
--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
@@ -1224,7 +1224,7 @@ void Vx3DHLTAnalyzer::endLuminosityBlock (const LuminosityBlock& lumiBlock, cons
 	    }
 	}
       myGaussFit->SetRange(minXfit - (maxXfit-minXfit)/2.,maxXfit + (maxXfit-minXfit)/2.);
-      Vx_X_Fit->getTH1()->Fit(myGaussFit,"QR");
+      Vx_X_Fit->getTH1()->Fit(myGaussFit,"QRL");
 
       myGaussFit->SetParameter(0, Vx_Y_Fit->getTH1()->GetMaximum());
       myGaussFit->SetParameter(1, Vx_Y_Fit->getTH1()->GetMean());
@@ -1248,7 +1248,7 @@ void Vx3DHLTAnalyzer::endLuminosityBlock (const LuminosityBlock& lumiBlock, cons
 	    }
 	}
       myGaussFit->SetRange(minXfit - (maxXfit-minXfit)/2.,maxXfit + (maxXfit-minXfit)/2.);
-      Vx_Y_Fit->getTH1()->Fit(myGaussFit,"QR");
+      Vx_Y_Fit->getTH1()->Fit(myGaussFit,"QRL");
 
       myGaussFit->SetParameter(0, Vx_Z_Fit->getTH1()->GetMaximum());
       myGaussFit->SetParameter(1, Vx_Z_Fit->getTH1()->GetMean());
@@ -1272,7 +1272,7 @@ void Vx3DHLTAnalyzer::endLuminosityBlock (const LuminosityBlock& lumiBlock, cons
 	    }
 	}
       myGaussFit->SetRange(minXfit - (maxXfit-minXfit)/2.,maxXfit + (maxXfit-minXfit)/2.);
-      Vx_Z_Fit->getTH1()->Fit(myGaussFit,"QR");
+      Vx_Z_Fit->getTH1()->Fit(myGaussFit,"QRL");
 
       delete myGaussFit;
     }

--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
@@ -3,7 +3,7 @@
   \Display Beam-spot monitor entirely based on pixel detector information
            the monitoring is based on a 3D fit to the vertex cloud
   \Author Mauro Dinardo
-  \Version $ Revision: 3.6 $
+  \Version $ Revision: 3.5 $
   \Date $ Date: 2010/23/02 13:15:00 $
 */
 

--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
@@ -3,7 +3,7 @@
   \Display Beam-spot monitor entirely based on pixel detector information
            the monitoring is based on a 3D fit to the vertex cloud
   \Author Mauro Dinardo
-  \Version $ Revision: 3.5 $
+  \Version $ Revision: 3.6 $
   \Date $ Date: 2010/23/02 13:15:00 $
 */
 


### PR DESCRIPTION
I've added a likelihood fit for histograms fitted with a Gaussian.
Before they were fitted with a chi2 method but since there might be empty bins, likelihood is more appropriate.