### PR TITLE
Reduced ES alcareco size 

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalESAlign_Output_cff.py
+++ b/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalESAlign_Output_cff.py
@@ -6,9 +6,7 @@ OutALCARECOEcalESAlign_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOEcalESAlign')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep ESDCCHeaderBlocksSorted_ecalPreshowerDigis_*_*',
         'keep ESDigiCollection_ecalPreshowerDigis_*_*',
-        'keep ESKCHIPBlocksSorted_ecalPreshowerDigis_*_*',
         'keep SiPixelClusteredmNewDetSetVector_ecalAlCaESAlignTrackReducer_*_*',
         'keep SiStripClusteredmNewDetSetVector_ecalAlCaESAlignTrackReducer_*_*',
         'keep TrackingRecHitsOwned_ecalAlCaESAlignTrackReducer_*_*',


### PR DESCRIPTION
This PR is to remove two unused collections from the output of the EcalESAlign Alcareco.
Once integrated in 10.2.x, we would like to back-port it to 10.1.x as well, as per A.Kumar's request 