### PR TITLE
[L1T][DQMOffline] Fixes for L1T jet DQMOffline

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
@@ -106,6 +106,7 @@ private:
 
   void fillEnergySums(edm::Event const& e, const unsigned int nVertex);
   void fillJets(edm::Event const& e, const unsigned int nVertex);
+  void fillJetEfficiencies(const double & recoEt, const double & l1Et, const double & recoEta);
 
   bool doesNotOverlapWithHLTObjects(const l1t::Jet & jet) const;
 

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -251,13 +251,13 @@ void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsig
   double outOfBounds = 9999;
 
   double resolutionMET = recoMET > 0 ? (l1MET - recoMET) / recoMET : outOfBounds;
-  double resolutionMETPhi = std::abs(recoMETPhi) > 0 ? (l1METPhi - recoMETPhi) / recoMETPhi : outOfBounds;
+  double resolutionMETPhi = reco::deltaPhi(l1METPhi, recoMETPhi);
 
   double resolutionETMHF = recoETMHF > 0 ? (l1ETMHF - recoETMHF) / recoETMHF : outOfBounds;
-  double resolutionETMHFPhi = std::abs(recoETMHFPhi) > 0 ? (l1ETMHFPhi - recoETMHFPhi) / recoETMHFPhi : outOfBounds;
+  double resolutionETMHFPhi = reco::deltaPhi(l1ETMHFPhi, recoETMHFPhi);
 
   double resolutionMHT = recoMHT > 0 ? (l1MHT - recoMHT) / recoMHT : outOfBounds;
-  double resolutionMHTPhi = std::abs(recoMHTPhi) > 0 ? (l1MHTPhi - recoMHTPhi) / recoMHTPhi : outOfBounds;
+  double resolutionMHTPhi = reco::deltaPhi(l1MHTPhi, recoMHTPhi);
 
   double resolutionETT = recoETT > 0 ? (l1ETT - recoETT) / recoETT : outOfBounds;
   double resolutionHTT = recoHTT > 0 ? (l1HTT - recoHTT) / recoHTT : outOfBounds;
@@ -380,19 +380,21 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
   double recoEta = leadingRecoJet.eta();
   double recoPhi = leadingRecoJet.phi();
 
-  double l1Et = foundMatch ? closestL1Jet.et() : 0;
-  double l1Eta = foundMatch ? closestL1Jet.eta() : 9999;
-  double l1Phi = foundMatch ? closestL1Jet.phi() : 9999;
-
-  // if no reco value, relative resolution does not make sense -> sort to overflow
   double outOfBounds = 9999;
+  double l1Et = foundMatch ? closestL1Jet.et() : 0;
+  double l1Eta = foundMatch ? closestL1Jet.eta() : outOfBounds;
+  double l1Phi = foundMatch ? closestL1Jet.phi() : outOfBounds;
+
   double resolutionEt = recoEt > 0 ? (l1Et - recoEt) / recoEt : outOfBounds;
   double resolutionEta = l1Eta - recoEta;
-  double resolutionPhi = l1Phi - recoPhi;
+  double resolutionPhi = l1Phi < outOfBounds ? reco::deltaPhi(l1Phi, recoPhi) : outOfBounds;
 
   using namespace dqmoffline::l1t;
   // fill efficiencies regardless of matched jet found
   fillJetEfficiencies(recoEt, l1Et, recoEta);
+  // control plots
+  fillWithinLimits(h_controlPlots_[ControlPlots::L1JetET], l1Et);
+  fillWithinLimits(h_controlPlots_[ControlPlots::OfflineJetET], recoEt);
   // don't fill anything else if no matched L1 jet is found
   if (!foundMatch){
     return;
@@ -401,9 +403,6 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
   // eta
   fill2DWithinLimits(h_L1JetEtavsCaloJetEta_, recoEta, l1Eta);
   fillWithinLimits(h_resolutionJetEta_, resolutionEta);
-  // control plots
-  fillWithinLimits(h_controlPlots_[ControlPlots::L1JetET], l1Et);
-  fillWithinLimits(h_controlPlots_[ControlPlots::OfflineJetET], recoEt);
 
   if (std::abs(recoEta) <= 1.479) { // barrel
     // et

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -393,8 +393,8 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
   // if no reco value, relative resolution does not make sense -> sort to overflow
   double outOfBounds = 9999;
   double resolutionEt = recoEt > 0 ? (l1Et - recoEt) / recoEt : outOfBounds;
-  double resolutionEta = std::abs(recoEta) > 0 ? (l1Eta - recoEta) / recoEta : outOfBounds;
-  double resolutionPhi = std::abs(recoPhi) > 0 ? (l1Phi - recoPhi) / recoPhi : outOfBounds;
+  double resolutionEta = l1Eta - recoEta;
+  double resolutionPhi = l1Phi - recoPhi;
 
   using namespace dqmoffline::l1t;
   // eta

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -585,37 +585,37 @@ void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker
   for (auto threshold : metEfficiencyThresholds_) {
     std::string str_threshold = std::to_string(int(threshold));
     h_efficiencyMET_pass_[threshold] = ibooker.book1D("efficiencyMET_threshold_" + str_threshold + "_Num",
-        "MET efficiency (numerator); Offline E_{T}^{miss} (GeV); events", metBins.size() - 1, &(metBins[0]));
+        "MET efficiency (numerator); Offline E_{T}^{miss} (GeV);", metBins.size() - 1, &(metBins[0]));
     h_efficiencyMET_total_[threshold] = ibooker.book1D("efficiencyMET_threshold_" + str_threshold + "_Den",
-        "MET efficiency (denominator); Offline E_{T}^{miss} (GeV); events", metBins.size() - 1, &(metBins[0]));
+        "MET efficiency (denominator); Offline E_{T}^{miss} (GeV);", metBins.size() - 1, &(metBins[0]));
 
     h_efficiencyETMHF_pass_[threshold] = ibooker.book1D("efficiencyETMHF_threshold_" + str_threshold + "_Num",
-        "MET efficiency (numerator); Offline E_{T}^{miss} (GeV) (HF); events", metBins.size() - 1, &(metBins[0]));
+        "MET efficiency (numerator); Offline E_{T}^{miss} (GeV) (HF);", metBins.size() - 1, &(metBins[0]));
     h_efficiencyETMHF_total_[threshold] = ibooker.book1D("efficiencyETMHF_threshold_" + str_threshold + "_Den",
-        "MET efficiency (denominator); Offline E_{T}^{miss} (GeV) (HF); events", metBins.size() - 1, &(metBins[0]));
+        "MET efficiency (denominator); Offline E_{T}^{miss} (GeV) (HF);", metBins.size() - 1, &(metBins[0]));
   }
 
   for (auto threshold : mhtEfficiencyThresholds_) {
     std::string str_threshold = std::to_string(int(threshold));
     h_efficiencyMHT_pass_[threshold] = ibooker.book1D("efficiencyMHT_threshold_" + str_threshold + "_Num",
-        "MHT efficiency (numerator); Offline MHT (GeV); events", mhtBins.size() - 1, &(mhtBins[0]));
+        "MHT efficiency (numerator); Offline MHT (GeV);", mhtBins.size() - 1, &(mhtBins[0]));
     h_efficiencyMHT_total_[threshold] = ibooker.book1D("efficiencyMHT_threshold_" + str_threshold + "_Den",
-        "MHT efficiency (denominator); Offline MHT (GeV); events", mhtBins.size() - 1, &(mhtBins[0]));
+        "MHT efficiency (denominator); Offline MHT (GeV);", mhtBins.size() - 1, &(mhtBins[0]));
   }
 
   for (auto threshold : ettEfficiencyThresholds_) {
     std::string str_threshold = std::to_string(int(threshold));
     h_efficiencyETT_pass_[threshold] = ibooker.book1D("efficiencyETT_threshold_" + str_threshold + "_Num",
-        "ETT efficiency (numerator); Offline ETT (GeV); events", ettBins.size() - 1, &(ettBins[0]));
+        "ETT efficiency (numerator); Offline ETT (GeV);", ettBins.size() - 1, &(ettBins[0]));
     h_efficiencyETT_total_[threshold] = ibooker.book1D("efficiencyETT_threshold_" + str_threshold + "_Den",
-        "ETT efficiency (denominator); Offline ETT (GeV); events", ettBins.size() - 1, &(ettBins[0]));
+        "ETT efficiency (denominator); Offline ETT (GeV);", ettBins.size() - 1, &(ettBins[0]));
   }
   for (auto threshold : httEfficiencyThresholds_) {
     std::string str_threshold = std::to_string(int(threshold));
     h_efficiencyHTT_pass_[threshold] = ibooker.book1D("efficiencyHTT_threshold_" + str_threshold + "_Num",
-        "HTT efficiency (numerator); Offline Total H_{T} (GeV); events", httBins.size() - 1, &(httBins[0]));
+        "HTT efficiency (numerator); Offline Total H_{T} (GeV);", httBins.size() - 1, &(httBins[0]));
     h_efficiencyHTT_total_[threshold] = ibooker.book1D("efficiencyHTT_threshold_" + str_threshold + "_Den",
-        "HTT efficiency (denominator); Offline Total H_{T} (GeV); events", httBins.size() - 1, &(httBins[0]));
+        "HTT efficiency (denominator); Offline Total H_{T} (GeV);", httBins.size() - 1, &(httBins[0]));
   }
 
   ibooker.cd();

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -362,7 +362,7 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
   int bunchCrossing = 0;
   for (auto jet = l1Jets->begin(bunchCrossing); jet != l1Jets->end(bunchCrossing); ++jet) {
     double currentDeltaR = deltaR(jet->eta(), jet->phi(), leadingRecoJet.eta(), leadingRecoJet.phi());
-    if (currentDeltaR > minDeltaR) {
+    if (currentDeltaR >= minDeltaR) {
       continue;
     } else {
       minDeltaR = currentDeltaR;


### PR DESCRIPTION
Partly fixes https://its.cern.ch/jira/projects/CMSLITDPG/issues/CMSLITDPG-588

* Drop “events” y axis label for efficiency plots.
* Phi resolution plots should not show (phi-phi_offline)/phi_offline but phi-phi_offline only.
* Eta resolution plots should not show (eta-eta_offline)/eta_offline but eta-eta_offline only.
* fill the efficiencies even if no a matched jet is found. 
* `currentDeltaR > minDeltaR`&rarr; `currentDeltaR >= minDeltaR`