### PR TITLE
Add unit test of PathStatusFilter using TestProcessor

### DIFF
--- a/FWCore/Modules/test/testPathStatusFilter_cfg.py
+++ b/FWCore/Modules/test/testPathStatusFilter_cfg.py
@@ -1,3 +1,7 @@
+# Tests the PathStatusFilter module
+# Note many of the tests that were originally here
+# were moved to test_catch2_PathStatusFilter.cc.
+
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PROD")
@@ -12,15 +16,7 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source("EmptySource")
 
 # This is the expression in ModuloEventIDFilter "iEvent.id().event() % n_ == offset_"
-process.allPass = cms.EDFilter("ModuloEventIDFilter",
-    modulo = cms.uint32(1),
-    offset = cms.uint32(0)
-)
 
-process.allFail = cms.EDFilter("ModuloEventIDFilter",
-    modulo = cms.uint32(1),
-    offset = cms.uint32(0)
-)
 # pass 2, 4, 6, 8 ...
 process.mod2 = cms.EDFilter("ModuloEventIDFilter",
     modulo = cms.uint32(2),
@@ -51,9 +47,8 @@ process.mod20 = cms.EDFilter("ModuloEventIDFilter",
     offset = cms.uint32(0)
 )
 
-process.pathAllPass = cms.Path(process.allPass)
-process.pathAllFail = cms.Path(process.allFail)
 process.pathPassOdd = cms.Path(process.passOdd)
+
 process.pathMod2 = cms.Path(process.mod2)
 process.pathMod3 = cms.Path(process.mod3)
 process.pathMod5 = cms.Path(process.mod5)
@@ -80,81 +75,6 @@ process.sewer1 = cms.OutputModule("SewerModule",
     )
 )
 
-# test 'and'
-process.pathStatusFilter2 = cms.EDFilter('PathStatusFilter',
-  logicalExpression = cms.string('pathMod2 and pathMod5'),
-  verbose = cms.untracked.bool(False)
-)
-process.testpath2 = cms.Path(process.pathStatusFilter2)
-
-process.sewer2 = cms.OutputModule("SewerModule",
-    shouldPass = cms.int32(2),
-    name = cms.string('for_testpath2'),
-    SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('testpath2')
-    )
-)
-
-# test 'or'
-process.pathStatusFilter3 = cms.EDFilter('PathStatusFilter',
-  logicalExpression = cms.string('pathMod2 or pathMod5'),
-  verbose = cms.untracked.bool(False)
-)
-process.testpath3 = cms.Path(process.pathStatusFilter3)
-
-process.sewer3 = cms.OutputModule("SewerModule",
-    shouldPass = cms.int32(12),
-    name = cms.string('for_testpath3'),
-    SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('testpath3')
-    )
-)
-
-# test 'not'
-process.pathStatusFilter4 = cms.EDFilter('PathStatusFilter',
-  logicalExpression = cms.string('not pathMod5'),
-  verbose = cms.untracked.bool(False)
-)
-process.testpath4 = cms.Path(process.pathStatusFilter4)
-
-process.sewer4 = cms.OutputModule("SewerModule",
-    shouldPass = cms.int32(16),
-    name = cms.string('for_testpath4'),
-    SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('testpath4')
-    )
-)
-
-# test precedence
-process.pathStatusFilter5 = cms.EDFilter('PathStatusFilter',
-  logicalExpression = cms.string('pathMod2 or pathMod3 and pathMod5'),
-  verbose = cms.untracked.bool(False)
-)
-process.testpath5 = cms.Path(process.pathStatusFilter5)
-
-process.sewer5 = cms.OutputModule("SewerModule",
-    shouldPass = cms.int32(11),
-    name = cms.string('for_testpath5'),
-    SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('testpath5')
-    )
-)
-
-# test parentheses
-process.pathStatusFilter6 = cms.EDFilter('PathStatusFilter',
-  logicalExpression = cms.string('(pathMod2 or pathMod3) and pathMod5'),
-  verbose = cms.untracked.bool(False)
-)
-process.testpath6 = cms.Path(process.pathStatusFilter6)
-
-process.sewer6 = cms.OutputModule("SewerModule",
-    shouldPass = cms.int32(3),
-    name = cms.string('for_testpath6'),
-    SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('testpath6')
-    )
-)
-
 # test extra space between pathnames and operators
 process.pathStatusFilter7 = cms.EDFilter('PathStatusFilter',
   logicalExpression = cms.string("\t    pathMod2   \t and \t  pathMod3 \t and \t not(pathMod5)and not not not pathMod7 or(pathMod15)and  not (  pathMod20 or(pathPassOdd)) \t   "),
@@ -170,78 +90,4 @@ process.sewer7 = cms.OutputModule("SewerModule",
     )
 )
 
-# test empty string for expression
-process.pathStatusFilter8 = cms.EDFilter('PathStatusFilter',
-  logicalExpression = cms.string(""),
-  verbose = cms.untracked.bool(False)
-)
-process.testpath8 = cms.Path(process.pathStatusFilter8)
-
-process.sewer8 = cms.OutputModule("SewerModule",
-    shouldPass = cms.int32(20),
-    name = cms.string('for_testpath8'),
-    SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('testpath8')
-    )
-)
-
-# test single character pathname
-process.a = cms.Path(process.allPass)
-process.pathStatusFilter9 = cms.EDFilter('PathStatusFilter',
-  logicalExpression = cms.string("a"),
-  verbose = cms.untracked.bool(False)
-)
-process.testpath9 = cms.Path(process.pathStatusFilter9)
-
-process.sewer9 = cms.OutputModule("SewerModule",
-    shouldPass = cms.int32(20),
-    name = cms.string('for_testpath9'),
-    SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('testpath9')
-    )
-)
-
-# test pathnames containing an operator name and duplicate pathnames
-process.nota = cms.Path(process.allPass)
-process.anot = cms.Path(process.allPass)
-process.pathStatusFilter10 = cms.EDFilter('PathStatusFilter',
-  logicalExpression = cms.string("nota and nota and anot"),
-  verbose = cms.untracked.bool(False)
-)
-process.testpath10 = cms.Path(process.pathStatusFilter10)
-
-process.sewer10 = cms.OutputModule("SewerModule",
-    shouldPass = cms.int32(20),
-    name = cms.string('for_testpath10'),
-    SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('testpath10')
-    )
-)
-
-# test multiple parentheses and 'not's
-process.pathStatusFilter11 = cms.EDFilter('PathStatusFilter',
-  logicalExpression = cms.string('not not not (((not(not(((((not not pathMod2))) or pathMod3))) and pathMod5)))'),
-  verbose = cms.untracked.bool(False)
-)
-process.testpath11 = cms.Path(process.pathStatusFilter11)
-
-process.sewer11 = cms.OutputModule("SewerModule",
-    shouldPass = cms.int32(17),
-    name = cms.string('for_testpath11'),
-    SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('testpath11')
-    )
-)
-
-process.endpath = cms.EndPath(process.sewer1 *
-                              process.sewer2 *
-                              process.sewer3 *
-                              process.sewer4 *
-                              process.sewer5 *
-                              process.sewer6 *
-                              process.sewer7 *
-                              process.sewer8 *
-                              process.sewer9 *
-                              process.sewer10 *
-                              process.sewer11
-)
+process.endpath = cms.EndPath(process.sewer1 * process.sewer7)

--- a/FWCore/Modules/test/test_catch2_PathStatusFilter.cc
+++ b/FWCore/Modules/test/test_catch2_PathStatusFilter.cc
@@ -1,0 +1,557 @@
+#include "catch.hpp"
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "DataFormats/Common/interface/PathStatus.h"
+
+#include <memory>
+#include <utility>
+
+static constexpr auto s_tag = "[PathStatusFilter]";
+
+TEST_CASE("Standard checks of PathStatusFilter", s_tag) {
+  const std::string baseConfig{
+R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+process.toTest = cms.EDFilter("PathStatusFilter")
+process.moduleToTest(process.toTest)
+)_"
+  };
+
+  SECTION("module constructor") {
+    edm::test::TestProcessor::Config config{ baseConfig };
+    REQUIRE_NOTHROW(edm::test::TestProcessor(config));
+  }
+
+  SECTION("No event data, empty expression") {
+    edm::test::TestProcessor::Config config{ baseConfig };
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.test());
+
+    auto event = tester.test();
+    REQUIRE(event.modulePassed());
+  }
+
+  SECTION("Only a single path in expression") {
+    std::string fullConfig = baseConfig +
+                             R"_(process.toTest.logicalExpression = cms.string("pathname")
+                             )_";
+    edm::test::TestProcessor::Config testConfig{ fullConfig };
+    auto token = testConfig.produces<edm::PathStatus>("pathname");
+    edm::test::TestProcessor tester(testConfig);
+    auto event = tester.test(std::make_pair(token,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)));
+    REQUIRE(event.modulePassed());
+
+    event = tester.test(std::make_pair(token,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)));
+    REQUIRE(!event.modulePassed());
+
+    REQUIRE_THROWS(tester.test());
+  }
+
+  SECTION("test the operator 'and'") {
+    std::string fullConfig = baseConfig +
+                             R"_(process.toTest.logicalExpression = cms.string("path1 and path2")
+                             )_";
+    edm::test::TestProcessor::Config testConfig{ fullConfig };
+    auto token1 = testConfig.produces<edm::PathStatus>("path1");
+    auto token2 = testConfig.produces<edm::PathStatus>("path2");
+    edm::test::TestProcessor tester(testConfig);
+    auto event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(!event.modulePassed());
+  }
+
+  SECTION("test the operator 'or'") {
+    std::string fullConfig = baseConfig +
+                             R"_(process.toTest.logicalExpression = cms.string("path1 or path2")
+                             )_";
+    edm::test::TestProcessor::Config testConfig{ fullConfig };
+    auto token1 = testConfig.produces<edm::PathStatus>("path1");
+    auto token2 = testConfig.produces<edm::PathStatus>("path2");
+    edm::test::TestProcessor tester(testConfig);
+    auto event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(!event.modulePassed());
+  }
+
+  SECTION("test operator 'not'") {
+    std::string fullConfig = baseConfig +
+                             R"_(process.toTest.logicalExpression = cms.string("not pathname")
+                             )_";
+    edm::test::TestProcessor::Config testConfig{ fullConfig };
+    auto token = testConfig.produces<edm::PathStatus>("pathname");
+    edm::test::TestProcessor tester(testConfig);
+    auto event = tester.test(std::make_pair(token,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)));
+    REQUIRE(!event.modulePassed());
+
+    event = tester.test(std::make_pair(token,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)));
+    REQUIRE(event.modulePassed());
+  }
+
+  SECTION("test precedence") {
+    std::string fullConfig = baseConfig +
+                             R"_(process.toTest.logicalExpression = cms.string("path1 or path2 and path3")
+                             )_";
+    edm::test::TestProcessor::Config testConfig{ fullConfig };
+    auto token1 = testConfig.produces<edm::PathStatus>("path1");
+    auto token2 = testConfig.produces<edm::PathStatus>("path2");
+    auto token3 = testConfig.produces<edm::PathStatus>("path3");
+    edm::test::TestProcessor tester(testConfig);
+    auto event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(!event.modulePassed());
+  }
+  SECTION("test parenthesis") {
+    std::string fullConfig = baseConfig +
+                             R"_(process.toTest.logicalExpression = cms.string("(path1 or path2) and path3")
+                             )_";
+    edm::test::TestProcessor::Config testConfig{ fullConfig };
+    auto token1 = testConfig.produces<edm::PathStatus>("path1");
+    auto token2 = testConfig.produces<edm::PathStatus>("path2");
+    auto token3 = testConfig.produces<edm::PathStatus>("path3");
+    edm::test::TestProcessor tester(testConfig);
+    auto event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(!event.modulePassed());
+  }
+
+  SECTION("test extra space between pathnames and operators") {
+    std::string fullConfig = baseConfig +
+                             R"_(process.toTest.logicalExpression = cms.string("\t    path1   \t and \t  path2 \t and \t not(path3)and not not not path4 or(path5)and  not (  path6 or(path7)) \t   ")
+                             )_";
+    edm::test::TestProcessor::Config testConfig{ fullConfig };
+    auto token1 = testConfig.produces<edm::PathStatus>("path1");
+    auto token2 = testConfig.produces<edm::PathStatus>("path2");
+    auto token3 = testConfig.produces<edm::PathStatus>("path3");
+    auto token4 = testConfig.produces<edm::PathStatus>("path4");
+    auto token5 = testConfig.produces<edm::PathStatus>("path5");
+    auto token6 = testConfig.produces<edm::PathStatus>("path6");
+    auto token7 = testConfig.produces<edm::PathStatus>("path7");
+    edm::test::TestProcessor tester(testConfig);
+    auto event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token4,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token5,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token6,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token7,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token4,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token5,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token6,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token7,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token4,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token5,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token6,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token7,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token4,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token5,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token6,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token7,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token4,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token5,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token6,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token7,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token4,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token5,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token6,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token7,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token4,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token5,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token6,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token7,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token4,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token5,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token6,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token7,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail))
+    );
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token4,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token5,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token6,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                             std::make_pair(token7,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass))
+    );
+    REQUIRE(!event.modulePassed());
+  }
+
+  SECTION("test single character pathname") {
+    std::string fullConfig = baseConfig +
+                             R"_(process.toTest.logicalExpression = cms.string("a")
+                             )_";
+    edm::test::TestProcessor::Config testConfig{ fullConfig };
+    auto token = testConfig.produces<edm::PathStatus>("a");
+    edm::test::TestProcessor tester(testConfig);
+    auto event = tester.test(std::make_pair(token,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)));
+    REQUIRE(event.modulePassed());
+
+    event = tester.test(std::make_pair(token,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)));
+    REQUIRE(!event.modulePassed());
+  }
+
+  SECTION("test pathnames containing an operator name and duplicate pathnames") {
+    std::string fullConfig = baseConfig +
+                             R"_(process.toTest.logicalExpression = cms.string("nota and nota and anot")
+                             )_";
+    edm::test::TestProcessor::Config testConfig{ fullConfig };
+    auto token1 = testConfig.produces<edm::PathStatus>("nota");
+    auto token2 = testConfig.produces<edm::PathStatus>("anot");
+    edm::test::TestProcessor tester(testConfig);
+    auto event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)));
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)));
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass)));
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)));
+    REQUIRE(!event.modulePassed());
+  }
+
+  SECTION("test multiple parentheses and 'not's") {
+    std::string fullConfig = baseConfig +
+                             R"_(process.toTest.logicalExpression = cms.string("not not not (((not(not(((((not not path1))) or path2))) and path3)))")
+                             )_";
+    edm::test::TestProcessor::Config testConfig{ fullConfig };
+    auto token1 = testConfig.produces<edm::PathStatus>("path1");
+    auto token2 = testConfig.produces<edm::PathStatus>("path2");
+    auto token3 = testConfig.produces<edm::PathStatus>("path3");
+    edm::test::TestProcessor tester(testConfig);
+    auto event = tester.test(std::make_pair(token1,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token2,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                             std::make_pair(token3,
+                                            std::make_unique<edm::PathStatus>(edm::hlt::Pass)));
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                        std::make_pair(token3,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)));
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token3,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass)));
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token3,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)));
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                        std::make_pair(token3,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass)));
+    REQUIRE(!event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass)),
+                        std::make_pair(token3,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)));
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token3,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Pass)));
+    REQUIRE(event.modulePassed());
+    event = tester.test(std::make_pair(token1,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token2,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)),
+                        std::make_pair(token3,
+                                       std::make_unique<edm::PathStatus>(edm::hlt::Fail)));
+    REQUIRE(event.modulePassed());
+  }
+}

--- a/FWCore/TestProcessor/interface/TestProcessor.h
+++ b/FWCore/TestProcessor/interface/TestProcessor.h
@@ -205,13 +205,13 @@ This simulates a problem happening early in the job which causes processing not 
   template< typename T, typename... U>
   edm::test::Event testImpl(std::pair<edm::EDPutTokenT<T>,std::unique_ptr<T>>&& iPut, U&&... iArgs) {
     put(std::move(iPut));
-    return testImpl(std::forward(iArgs)...);
+    return testImpl(std::forward<U>(iArgs)...);
   }
 
   template<typename T, typename... U>
   edm::test::Event testImpl(std::pair<edm::test::ESPutTokenT<T>,std::unique_ptr<T>>&& iPut, U&&... iArgs) {
     put(std::move(iPut));
-    return testImpl(std::forward(iArgs)...);
+    return testImpl(std::forward<U>(iArgs)...);
   }
 
   template< typename T>

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -204,6 +204,12 @@ TestProcessor::~TestProcessor() noexcept(false) {
   
 void
 TestProcessor::put(unsigned int index, std::unique_ptr<WrapperBase> iWrapper) {
+  if (index >= dataProducts_.size()) {
+    throw cms::Exception("LogicError")
+      << "Products must be declared to the TestProcessor::Config object\n"
+         "with a call to the function \'produces\' BEFORE passing the\n"
+         "TestProcessor::Config object to the TestProcessor constructor";
+  }
   dataProducts_[index].second = std::move(iWrapper);
 }
 


### PR DESCRIPTION
Also includes a bug fix in TestProcessor needed for this test
to work and also a minor improvement in TestProcessor which
will detect a kind of coding error and print a useful message instead
of allowing a seg fault. This should not affect anything other than unit
tests.