### PR TITLE
Reduced ES alcareco size

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalESAlign_Output_cff.py
+++ b/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalESAlign_Output_cff.py
@@ -6,9 +6,7 @@ OutALCARECOEcalESAlign_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOEcalESAlign')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep ESDCCHeaderBlocksSorted_ecalPreshowerDigis_*_*',
         'keep ESDigiCollection_ecalPreshowerDigis_*_*',
-        'keep ESKCHIPBlocksSorted_ecalPreshowerDigis_*_*',
         'keep SiPixelClusteredmNewDetSetVector_ecalAlCaESAlignTrackReducer_*_*',
         'keep SiStripClusteredmNewDetSetVector_ecalAlCaESAlignTrackReducer_*_*',
         'keep TrackingRecHitsOwned_ecalAlCaESAlignTrackReducer_*_*',


### PR DESCRIPTION
This PR is a backport of #23265 to 10.1.x
Unused collections are removed from the event content of ALCARECOEcalESAlign, to reduce
the event size.