### PR TITLE
L1T offline DQM changes for muon resolution plots - 101x

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
@@ -63,7 +63,7 @@ class MuonGmtPair;
 
 class L1TMuonDQMOffline : public DQMEDAnalyzer {
     public:
-        enum Control {kCtrlTagPt, kCtrlTagEta, kCtrlTagPhi, kCtrlProbePt, kCtrlProbeEta, kCtrlProbePhi, kCtrlTagProbeDr, kCtrlMuonGmtDeltaR, kCtrlNTightVsAll, kCtrlNProbesVsTight};
+        enum Control {kCtrlTagPt, kCtrlTagEta, kCtrlTagPhi, kCtrlProbePt, kCtrlProbeEta, kCtrlProbePhi, kCtrlTagProbeDr, kCtrlTagHltDr, kCtrlMuonGmtDeltaR, kCtrlNTightVsAll, kCtrlNProbesVsTight};
         enum EffType {kEffPt, kEffPhi, kEffEta, kEffVtx};
         enum ResType {kResPt, kRes1OverPt, kResQOverPt, kResPhi, kResEta, kResCh};
         enum EtaRegion {kEtaRegionAll, kEtaRegionBmtf, kEtaRegionOmtf, kEtaRegionEmtf, kEtaRegionOut};
@@ -86,7 +86,7 @@ class L1TMuonDQMOffline : public DQMEDAnalyzer {
         // Helper Functions
         const unsigned int getNVertices(edm::Handle<reco::VertexCollection> & vertex);
         const reco::Vertex getPrimaryVertex(edm::Handle<reco::VertexCollection> & vertex,edm::Handle<reco::BeamSpot> & beamSpot);
-        bool matchHlt(edm::Handle<trigger::TriggerEvent>  & triggerEvent, const reco::Muon * mu);
+        double matchHlt(edm::Handle<trigger::TriggerEvent>  & triggerEvent, const reco::Muon * mu);
 
         // Cut and Matching
         void getMuonGmtPairs(edm::Handle<l1t::MuonBxCollection> & gmtCands);

--- a/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
@@ -43,6 +43,7 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"

--- a/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
@@ -2,13 +2,16 @@ import FWCore.ParameterSet.Config as cms
 
 # define binning for efficiency plots
 # pt
-effVsPtBins = range(0, 50, 2)
+effVsPtBins = range(0, 30, 1)
+effVsPtBins += range(30, 50, 2)
 effVsPtBins += range(50, 70, 5)
 effVsPtBins += range(70, 100, 10)
 effVsPtBins += range(100, 200, 25)
 effVsPtBins += range(200, 300, 50)
 effVsPtBins += range(300, 500, 100)
-effVsPtBins.append(500)
+effVsPtBins += range(500, 700, 200)
+effVsPtBins += range(700, 1000, 300)
+effVsPtBins.append(1000)
 
 # phi
 nPhiBins = 34

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -91,8 +91,8 @@ L1TMuonDQMOffline::EtaRegion MuonGmtPair::etaRegion() const {
 
 double MuonGmtPair::getDeltaVar(const L1TMuonDQMOffline::ResType type) const {
     if (type == L1TMuonDQMOffline::kResPt)      return (gmtPt() - pt()) / pt();
-    if (type == L1TMuonDQMOffline::kRes1OverPt) return 1/gmtPt() - 1/pt();
-    if (type == L1TMuonDQMOffline::kResQOverPt) return gmtCharge()/gmtPt() - charge()/pt();
+    if (type == L1TMuonDQMOffline::kRes1OverPt) return (pt() - gmtPt()) / gmtPt(); // (1/gmtPt - 1/pt) / (1/pt)
+    if (type == L1TMuonDQMOffline::kResQOverPt) return (gmtCharge()*charge()*pt() - gmtPt()) / gmtPt(); // (gmtCharge/gmtPt - charge/pt) / (charge/pt) with gmtCharge/charge = gmtCharge*charge
     if (type == L1TMuonDQMOffline::kResPhi)     return reco::deltaPhi(gmtPhi(), phi());
     if (type == L1TMuonDQMOffline::kResEta)     return gmtEta() - eta();
     if (type == L1TMuonDQMOffline::kResCh)      return gmtCharge() - charge();
@@ -153,7 +153,7 @@ L1TMuonDQMOffline::L1TMuonDQMOffline(const ParameterSet & ps) :
     m_effStrings({ {kEffPt, "pt"}, {kEffPhi, "phi"}, {kEffEta, "eta"}, {kEffVtx, "vtx"} }),
     m_effLabelStrings({ {kEffPt, "p_{T} (GeV)"}, {kEffPhi, "#phi"}, {kEffEta, "#eta"}, {kEffVtx, "# vertices"} }),
     m_resStrings({ {kResPt, "pt"}, {kRes1OverPt, "1overpt"}, {kResQOverPt, "qoverpt"}, {kResPhi, "phi"}, {kResEta, "eta"}, {kResCh, "charge"} }),
-    m_resLabelStrings({ {kResPt, "(p_{T}^{L1} - p_{T}^{reco})/p_{T}^{reco}"}, {kRes1OverPt, "1/p_{T}^{L1} - 1/p_{T}^{reco}"}, {kResQOverPt, "q^{L1}/p_{T}^{L1} - q^{reco}/p_{T}^{reco}"}, {kResPhi, "#phi_{L1} - #phi_{reco}"}, {kResEta, "#eta_{L1} - #eta_{reco}"}, {kResCh, "charge^{L1} - charge^{reco}"} }),
+    m_resLabelStrings({ {kResPt, "(p_{T}^{L1} - p_{T}^{reco})/p_{T}^{reco}"}, {kRes1OverPt, "(p_{T}^{reco} - p_{T}^{L1})/p_{T}^{L1}"}, {kResQOverPt, "(q^{L1}*q^{reco}*p_{T}^{reco} - p_{T}^{L1})/p_{T}^{L1}"}, {kResPhi, "#phi_{L1} - #phi_{reco}"}, {kResEta, "#eta_{L1} - #eta_{reco}"}, {kResCh, "charge^{L1} - charge^{reco}"} }),
     m_etaStrings({ {kEtaRegionAll, "etaMin0_etaMax2p4"}, {kEtaRegionBmtf, "etaMin0_etaMax0p83"}, {kEtaRegionOmtf, "etaMin0p83_etaMax1p24"}, {kEtaRegionEmtf, "etaMin1p24_etaMax2p4"} }),
     m_qualStrings({ {kQualAll, "qualAll"}, {kQualOpen, "qualOpen"}, {kQualDouble, "qualDouble"}, {kQualSingle, "qualSingle"} }),
     m_verbose(ps.getUntrackedParameter<bool>("verbose")),
@@ -648,9 +648,9 @@ std::vector<float> L1TMuonDQMOffline::getHistBinsEff(EffType eff) {
 }
 
 std::tuple<int, double, double> L1TMuonDQMOffline::getHistBinsRes(ResType res){
-    if (res == kResPt)      return {100, -50., 50.};
-    if (res == kRes1OverPt) return {50, -0.05, 0.05};
-    if (res == kResQOverPt) return {50, -0.05, 0.05};
+    if (res == kResPt)      return {50, -2.5, 2.5};
+    if (res == kRes1OverPt) return {50, -2., 2.};
+    if (res == kResQOverPt) return {50, -2., 2.};
     if (res == kResPhi)     return {96, -0.2, 0.2};
     if (res == kResEta)     return {100, -0.1, 0.1};
     if (res == kResCh)      return {5, -2, 3};

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -90,10 +90,10 @@ L1TMuonDQMOffline::EtaRegion MuonGmtPair::etaRegion() const {
 }
 
 double MuonGmtPair::getDeltaVar(const L1TMuonDQMOffline::ResType type) const {
-    if (type == L1TMuonDQMOffline::kResPt)      return gmtPt() - pt();
+    if (type == L1TMuonDQMOffline::kResPt)      return (gmtPt() - pt()) / pt();
     if (type == L1TMuonDQMOffline::kRes1OverPt) return 1/gmtPt() - 1/pt();
     if (type == L1TMuonDQMOffline::kResQOverPt) return gmtCharge()/gmtPt() - charge()/pt();
-    if (type == L1TMuonDQMOffline::kResPhi)     return gmtPhi() - phi();
+    if (type == L1TMuonDQMOffline::kResPhi)     return reco::deltaPhi(gmtPhi(), phi());
     if (type == L1TMuonDQMOffline::kResEta)     return gmtEta() - eta();
     if (type == L1TMuonDQMOffline::kResCh)      return gmtCharge() - charge();
     return -999.;
@@ -153,7 +153,7 @@ L1TMuonDQMOffline::L1TMuonDQMOffline(const ParameterSet & ps) :
     m_effStrings({ {kEffPt, "pt"}, {kEffPhi, "phi"}, {kEffEta, "eta"}, {kEffVtx, "vtx"} }),
     m_effLabelStrings({ {kEffPt, "p_{T} (GeV)"}, {kEffPhi, "#phi"}, {kEffEta, "#eta"}, {kEffVtx, "# vertices"} }),
     m_resStrings({ {kResPt, "pt"}, {kRes1OverPt, "1overpt"}, {kResQOverPt, "qoverpt"}, {kResPhi, "phi"}, {kResEta, "eta"}, {kResCh, "charge"} }),
-    m_resLabelStrings({ {kResPt, "p_{T}^{L1} - p_{T}^{reco}"}, {kRes1OverPt, "1/p_{T}^{L1} - 1/p_{T}^{reco}"}, {kResQOverPt, "q^{L1}/p_{T}^{L1} - q^{reco}/p_{T}^{reco}"}, {kResPhi, "#phi_{L1} - #phi_{reco}"}, {kResEta, "#eta_{L1} - #eta_{reco}"}, {kResCh, "charge^{L1} - charge^{reco}"} }),
+    m_resLabelStrings({ {kResPt, "(p_{T}^{L1} - p_{T}^{reco})/p_{T}^{reco}"}, {kRes1OverPt, "1/p_{T}^{L1} - 1/p_{T}^{reco}"}, {kResQOverPt, "q^{L1}/p_{T}^{L1} - q^{reco}/p_{T}^{reco}"}, {kResPhi, "#phi_{L1} - #phi_{reco}"}, {kResEta, "#eta_{L1} - #eta_{reco}"}, {kResCh, "charge^{L1} - charge^{reco}"} }),
     m_etaStrings({ {kEtaRegionAll, "etaMin0_etaMax2p4"}, {kEtaRegionBmtf, "etaMin0_etaMax0p83"}, {kEtaRegionOmtf, "etaMin0p83_etaMax1p24"}, {kEtaRegionEmtf, "etaMin1p24_etaMax2p4"} }),
     m_qualStrings({ {kQualAll, "qualAll"}, {kQualOpen, "qualOpen"}, {kQualDouble, "qualDouble"}, {kQualSingle, "qualSingle"} }),
     m_verbose(ps.getUntrackedParameter<bool>("verbose")),

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -176,7 +176,7 @@ L1TMuonDQMOffline::L1TMuonDQMOffline(const ParameterSet & ps) :
     m_useAtVtxCoord(ps.getUntrackedParameter<bool>("useL1AtVtxCoord")),
     m_maxGmtMuonDR(0.3),
     m_minTagProbeDR(0.5),
-    m_maxHltMuonDR(0.3)
+    m_maxHltMuonDR(0.1)
 {
     if (m_verbose) cout << "[L1TMuonDQMOffline:] ____________ Storage initialization ____________ " << endl;
 


### PR DESCRIPTION
backport of #23279 

Some upgrades to the L1T offline DQM muon resolution histograms.

 - Proper delta phi calculation with wrap around at pi.
 - Relative pT residuals.
