### PR TITLE
DataFormats/FWLite: Update test.cppunit.cpp and RefTest.sh to look for root files in current directory.

### DIFF
--- a/DataFormats/FWLite/test/RefTest.sh
+++ b/DataFormats/FWLite/test/RefTest.sh
@@ -3,7 +3,6 @@
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
-pushd ${LOCAL_TMP_DIR}
 
 rm -f goodDataFormatsFWLite.root good2DataFormatsFWLite.root emptyDataFormatsFWLite.root
 rm -f other_onlyDataFormatsFWLite.root good_delta5DataFormatsFWLite.root
@@ -20,5 +19,4 @@ cmsRun ${LOCAL_TEST_DIR}/PartialEventTest_cfg.py || die "cmsRun PartialEventTest
 echo RefTestCopyDrop_cfg.py
 cmsRun ${LOCAL_TEST_DIR}/RefTestCopyDrop_cfg.py || die "cmsRun RefTestCopyDrop_cfg.py" $?
 
-popd
 exit 0

--- a/DataFormats/FWLite/test/test.cppunit.cpp
+++ b/DataFormats/FWLite/test/test.cppunit.cpp
@@ -59,9 +59,7 @@ public:
       FWLiteEnabler::enable();
       sWasRun_ = true;
     }
-    tmpdir = "tmp/";
-    tmpdir += getenv("SCRAM_ARCH");
-    tmpdir += "/";
+    tmpdir = "./";
   }
   void tearDown(){ }
 


### PR DESCRIPTION
This allows this test to work under ctest.