### PR TITLE
New timing cuts for ECAL (for CMSSW master)

### DIFF
--- a/DQM/EcalMonitorClient/python/TimingClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TimingClient_cfi.py
@@ -3,16 +3,16 @@ import FWCore.ParameterSet.Config as cms
 from DQM.EcalMonitorTasks.TimingTask_cfi import ecalTimingTask
 from DQM.EcalMonitorClient.IntegrityClient_cfi import ecalIntegrityClient
 
-minChannelEntries = 5
-minTowerEntries = 15
+minChannelEntries = 1
+minTowerEntries = 3
 toleranceMean = 2.
 toleranceRMS = 6.
-minChannelEntriesFwd = 40
-minTowerEntriesFwd = 160
+minChannelEntriesFwd = 8
+minTowerEntriesFwd = 24
 toleranceMeanFwd = 6.
 toleranceRMSFwd = 12.
 tailPopulThreshold = 0.4
-timeWindow = 25. 
+timeWindow = 25.
 
 ecalTimingClient = cms.untracked.PSet(
     params = cms.untracked.PSet(

--- a/DQM/EcalMonitorTasks/interface/TimingTask.h
+++ b/DQM/EcalMonitorTasks/interface/TimingTask.h
@@ -31,7 +31,9 @@ namespace ecaldqm {
     float chi2ThresholdEE_;
     float energyThresholdEB_;
     float energyThresholdEE_;
+    float energyThresholdEEFwd_;
     float timingVsBXThreshold_;
+    float timeErrorThreshold_;
 
     MESet* meTimeMapByLS;
   };

--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -28,9 +28,11 @@ for i in range(50) :
 
 chi2ThresholdEE = 50.
 chi2ThresholdEB = 16.
-energyThresholdEE = 3.
-energyThresholdEB = 1.
-timingVsBXThreshold = 2.02
+energyThresholdEE = 4.6
+energyThresholdEEFwd = 6.7
+energyThresholdEB = 2.02
+timingVsBXThreshold = energyThresholdEB
+timeErrorThreshold = 3.
 timeWindow = 12.5
 summaryTimeWindow = 7.
 
@@ -41,8 +43,10 @@ ecalTimingTask = cms.untracked.PSet(
         chi2ThresholdEE = cms.untracked.double(chi2ThresholdEE),
         chi2ThresholdEB = cms.untracked.double(chi2ThresholdEB),
         energyThresholdEE = cms.untracked.double(energyThresholdEE),
+        energyThresholdEEFwd = cms.untracked.double(energyThresholdEEFwd),
         energyThresholdEB = cms.untracked.double(energyThresholdEB),
-        timingVsBXThreshold = cms.untracked.double(timingVsBXThreshold)
+        timingVsBXThreshold = cms.untracked.double(timingVsBXThreshold),
+        timeErrorThreshold = cms.untracked.double(timeErrorThreshold)
     ),
     MEs = cms.untracked.PSet(
         TimeMap = cms.untracked.PSet(


### PR DESCRIPTION
The cuts on rechits included in the ECAL timing plots were out of date. Especially in the forward region, most of the rechits passing the cuts were pure noise and created a few false alarms. This commit introduces these changes:

(1) Update thresholds on rechit energy for rechits to be included in the timing plots.

(2) Introduce cut on timing error to match offline processing.

(3) Implement separate energy thresholds for forward region in EE.

Link to backport for CMSSW online/offline production: #23284 