### PR TITLE
[GCC 8][RecoLocalMuon] Fix build error

### DIFF
--- a/RecoLocalMuon/CSCSegment/test/CSCSegmentVisualise.cc
+++ b/RecoLocalMuon/CSCSegment/test/CSCSegmentVisualise.cc
@@ -153,7 +153,7 @@ void CSCSegmentVisualise::analyze(const edm::Event& event, const edm::EventSetup
     ymin = ymin - 5.;
     ymax = ymax + 5.;
 
-    char a[4];
+    char a[14];
     char evt[10];
 
     sprintf(evt, "Event %d", ievt);


### PR DESCRIPTION
Fix build error: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc810/CMSSW_10_2_X_2018-05-22-2300/RecoLocalMuon/CSCSegment 