### PR TITLE
[GCC 8][L1Trigger] Fix build error

### DIFF
--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTLutWriter.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTLutWriter.cc
@@ -255,7 +255,7 @@ L1RCTLutWriter::writeRcLutFile(unsigned short card)
 
   // don't mess yet with name
   char filename[256];
-  char command[64];
+  char command[264];
   if (card != 6)
     {
       int card2 = card + 1;
@@ -367,7 +367,7 @@ L1RCTLutWriter::writeEicLutFile(unsigned short card)
 {
   // try timestamp
   char filename[256];
-  char command[64];
+  char command[264];
   if (card != 6)
     {
       int card2 = card + 1;
@@ -413,7 +413,7 @@ void
 L1RCTLutWriter::writeJscLutFile()
 {
   char filename[256];
-  char command[64];
+  char command[264];
   sprintf(filename, "JSC-%s.dat", keyName_.c_str() );
 
   // open file; if it already existed, delete existing content


### PR DESCRIPTION
Increase char size to pass build error : https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc810/CMSSW_10_2_X_2018-05-22-2300/L1Trigger/RegionalCaloTrigger