### PR TITLE
[GCC 8][EventFilter] Fix build error

### DIFF
--- a/EventFilter/CSCRawToDigi/plugins/CSCDCCUnpacker.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDCCUnpacker.cc
@@ -772,7 +772,7 @@ void CSCDCCUnpacker::visual_raw(int hl,int id, int run, int event,bool fedshort,
   // Bufers
   int word_lines=hl/4;
   char tempbuf[80];
-  char tempbuf1[80];
+  char tempbuf1[130];
   char tempbuf_short[17];
   char sign1[]="  --->| ";
 


### PR DESCRIPTION
Fix build errors: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc810/CMSSW_10_2_X_2018-05-22-2300/EventFilter/CSCRawToDigi