### PR TITLE
[GCC 8][DPGAnalysis] Fix build error

### DIFF
--- a/DPGAnalysis/SiStripTools/bin/SOF_profiles.cc
+++ b/DPGAnalysis/SiStripTools/bin/SOF_profiles.cc
@@ -23,7 +23,7 @@ TCanvas* printSOF(TFile* file, const int run, const int firstLS,const int zoom) 
   TH1F* evtdcson = nullptr;
   TH1F* evtnostrip = nullptr;
 
-  char dname[400];
+  char dname[422];
 
   sprintf(dname,"ssqhistory/%s",rname);
   if(file->cd(dname)) { badmod = (TProfile*)gDirectory->Get("badmodrun_HVDCS");  }


### PR DESCRIPTION
Fix build error: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc810/CMSSW_10_2_X_2018-05-22-2300/DPGAnalysis/SiStripTools