### PR TITLE
[GCC 8][Calibration] Fix build error const corr for comp operator

### DIFF
--- a/Calibration/HcalCalibAlgos/test/DiJetAnalyzer.h
+++ b/Calibration/HcalCalibAlgos/test/DiJetAnalyzer.h
@@ -168,7 +168,7 @@ class DiJetAnalyzer : public edm::EDAnalyzer {
   int getEtaPhi(const HcalDetId id);
 
   struct JetCorretPairComp {
-    inline bool operator() ( const JetCorretPair& a, const JetCorretPair& b) {
+    inline bool operator() ( const JetCorretPair& a, const JetCorretPair& b) const {
       return (a.jet()->pt()*a.scale()) > (b.jet()->pt()*b.scale());
     }
   };

--- a/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.h
+++ b/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.h
@@ -310,13 +310,13 @@ private:
   }
 
   struct PFJetCorretPairComp {
-    inline bool operator() ( const PFJetCorretPair& a, const PFJetCorretPair& b) {
+    inline bool operator() ( const PFJetCorretPair& a, const PFJetCorretPair& b) const {
       return (a.jet()->pt()*a.scale()) > (b.jet()->pt()*b.scale());
     }
   };
 
   struct PhotonPairComp {
-    inline bool operator() ( const PhotonPair& a, const PhotonPair& b) {
+    inline bool operator() ( const PhotonPair& a, const PhotonPair& b) const {
       return ( (a.photon()->pt()) > (b.photon()->pt()) );
     }
   };


### PR DESCRIPTION
This fixes this error: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc810/CMSSW_10_2_X_2018-05-22-2300/Calibration/HcalCalibAlgos 
following this instructions: https://gcc.gnu.org/gcc-8/porting_to.html 