### PR TITLE
Removal of unused DT DQM Online plots and LS label fixing

### DIFF
--- a/DQM/DTMonitorModule/python/dt_dqm_sourceclient_common_cff.py
+++ b/DQM/DTMonitorModule/python/dt_dqm_sourceclient_common_cff.py
@@ -69,7 +69,8 @@ from DQM.DTMonitorModule.dtTriggerBaseTask_cfi import *
 from DQM.DTMonitorModule.dtTriggerLutTask_cfi import *
 from DQM.DTMonitorClient.dtLocalTriggerTest_cfi import *
 from DQM.DTMonitorClient.dtTriggerLutTest_cfi import *
-
+triggerTest.hwSources = cms.untracked.vstring('TM')
+dtTriggerBaseMonitor.processDDU = False
 # scaler task
 from DQM.DTMonitorModule.dtScalerInfoTask_cfi import *
 
@@ -109,6 +110,7 @@ dtTPmonitor.inTimeHitsUpperBound = 0
 from DQM.DTMonitorModule.dtTriggerTask_TP_cfi import *
 from DQM.DTMonitorClient.dtLocalTriggerTest_TP_cfi import *
 dtTPTriggerTest.hwSources = cms.untracked.vstring('TM')
+dtTPTriggerMonitor.process_ddu = cms.untracked.bool(False)
 
 unpackers = cms.Sequence(dtunpacker + twinMuxStage2Digis + scalersRawToDigi)
 

--- a/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
@@ -172,6 +172,9 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker & ibooker, const int fedM
   hFEDEntry = ibooker.book1D("FEDEntries","# entries per DT FED",nFED,fedMin,fedMax+1);
   
   if(checkUros){
+
+  if(mode == 3 || mode ==1) return; //Avoid duplication of Info in FEDIntegrity_EvF
+
   string histoType = "ROSSummary";
   for (int wheel=-2;wheel<3;++wheel){
     string wheel_s = to_string(wheel);

--- a/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
@@ -173,7 +173,12 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker & ibooker, const int fedM
   
   if(checkUros){
 
-  if(mode == 3 || mode ==1) return; //Avoid duplication of Info in FEDIntegrity_EvF
+  if(mode == 3 || mode ==1) {
+	//Booked for completion in general CMS FED test. Not filled
+        hFEDFatal = ibooker.book1D("FEDFatal","# fatal errors DT FED",nFED,fedMin,fedMax+1); //No available in uROS
+        hFEDNonFatal = ibooker.book1D("FEDNonFatal","# NON fatal errors DT FED",nFED,fedMin,fedMax+1); //No available in uROS
+        return; //Avoid duplication of Info in FEDIntegrity_EvF
+        }
 
   string histoType = "ROSSummary";
   for (int wheel=-2;wheel<3;++wheel){
@@ -1875,7 +1880,9 @@ void DTDataIntegrityTask::analyze(const edm::Event& e, const edm::EventSetup& c)
 	continue;
 	}
     processFED(fedData, fed);
-    
+
+    if(mode == 3 || mode ==1) continue; //Not needed for FEDIntegrity_EvF 
+
     for(int slot=1; slot<=DOCESLOTS; ++slot)
     {
         urosData = fedData.getuROS(slot);

--- a/DQM/DTMonitorModule/src/DTTimeEvolutionHisto.cc
+++ b/DQM/DTMonitorModule/src/DTTimeEvolutionHisto.cc
@@ -170,7 +170,7 @@ void DTTimeEvolutionHisto::updateTimeSlot(int ls, int nEventsInLS) {
       if(nEventsInLastTimeSlot.size() > 1)
 	binLabel << "-" << lastLSinTimeSlot;
 
-      if(lastLSinTimeSlot%(3*(int)theLSPrescale==0)) 
+      if(lastLSinTimeSlot%(3*(int)theLSPrescale)==0)
 	histo->setBinLabel(nBookedBins,binLabel.str(),1);
 
       // reset the counters for the time slot

--- a/DQM/DTMonitorModule/src/DTTimeEvolutionHisto.cc
+++ b/DQM/DTMonitorModule/src/DTTimeEvolutionHisto.cc
@@ -170,7 +170,7 @@ void DTTimeEvolutionHisto::updateTimeSlot(int ls, int nEventsInLS) {
       if(nEventsInLastTimeSlot.size() > 1)
 	binLabel << "-" << lastLSinTimeSlot;
 
-      if(lastLSinTimeSlot%(3*(int)theLSPrescale)==0)
+      //if(lastLSinTimeSlot%(3*(int)theLSPrescale)==0)
 	histo->setBinLabel(nBookedBins,binLabel.str(),1);
 
       // reset the counters for the time slot

--- a/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
@@ -95,7 +95,6 @@ if (process.runType.getRunType() == process.runType.cosmic_run):
 #----------------------------
 
 if (process.runType.getRunType() == process.runType.hi_run):
-    process.dtunpacker.fedbyType = cms.bool(False)
     process.twinMuxStage2Digis.DTTM7_FED_Source = cms.InputTag("rawDataRepacker")
     process.dtunpacker.inputLabel = cms.InputTag("rawDataRepacker")
     process.gtDigis.DaqGtInputTag = cms.InputTag("rawDataRepacker")

--- a/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
@@ -79,7 +79,6 @@ if (process.runType.getRunType() == process.runType.cosmic_run):
 #----------------------------
 
 if (process.runType.getRunType() == process.runType.hi_run):
-    process.dtunpacker.fedbyType = cms.bool(False)
     process.twinMuxStage2Digis.DTTM7_FED_Source = cms.InputTag("rawDataRepacker")
     process.dtunpacker.inputLabel = cms.InputTag("rawDataRepacker")
     process.gtDigis.DaqGtInputTag = cms.InputTag("rawDataRepacker")

--- a/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
@@ -66,6 +66,7 @@ process.DTDataIntegrityTask.processingMode = 'SM'
 path = 'DT/%s/' % folder_name
 process.DTDataIntegrityTask.fedIntegrityFolder = path
 process.DTDataIntegrityTask.checkUros = True
+process.DTDataIntegrityTask.dtFEDlabel     = 'dtunpacker'
 # RPC sequence:
 process.load('EventFilter.RPCRawToDigi.rpcUnpacker_cfi')
 process.load('DQM.RPCMonitorClient.RPCFEDIntegrity_cfi')


### PR DESCRIPTION
- Remove unused folder 04-LocalTrigger-DDU in Online DQM
- Fix and remove no longer valid plots on DT / FEDIntegrity_EvF in Online DQM
- Fix LS labels in AverageEventLenght plots vs LS in Online DQM