### PR TITLE
SiStripMonitorCluster & SiStripMonitorDigi - Fix the FED digi/cluster plots ranges and error

### DIFF
--- a/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
+++ b/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
@@ -312,9 +312,9 @@ SiStripMonitorCluster = DQMEDAnalyzer('SiStripMonitorCluster',
         ),
 
      TProfNClustersFED = cms.PSet(
-         Nbinsx          = cms.int32(500),
-         xmax           = cms.double(500),
-         xmin           = cms.double(0),
+         Nbinsx          = cms.int32(440),
+         xmax           = cms.double(489.5),
+         xmin           = cms.double(49.5),
          Nbinsy = cms.int32(200),
          ymin = cms.double(-0.5),
          ymax = cms.double(199999.5),

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -709,7 +709,7 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es,
             FEDCluster.getParameter<double>("xmax"),
             FEDCluster.getParameter<int32_t>("Nbinsy"),
             FEDCluster.getParameter<double>("ymin"),
-            FEDCluster.getParameter<double>("ymax"));
+            FEDCluster.getParameter<double>("ymax"),"");
         NumberOfFEDClus->setAxisTitle("FED ID", 1);
         NumberOfFEDClus->setAxisTitle("Mean # of Cluster in FED", 2);
       }

--- a/DQM/SiStripMonitorDigi/python/SiStripMonitorDigi_cfi.py
+++ b/DQM/SiStripMonitorDigi/python/SiStripMonitorDigi_cfi.py
@@ -132,9 +132,9 @@ SiStripMonitorDigi = DQMEDAnalyzer('SiStripMonitorDigi',
     ),
 
     TProfNDigisFED = cms.PSet(
-        Nbinsx          = cms.int32(460),
-        xmax           = cms.double(460),
-        xmin           = cms.double(0),
+        Nbinsx          = cms.int32(440),
+        xmax           = cms.double(489.5),
+        xmin           = cms.double(49.5),
         Nbinsy = cms.int32(200),
         ymin = cms.double(-0.5),
         ymax = cms.double(199999.5),

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -518,7 +518,7 @@ void SiStripMonitorDigi::createMEs(DQMStore::IBooker & ibooker , const edm::Even
                                        FEDDigi.getParameter<double>("xmax"),
                                        FEDDigi.getParameter<int32_t>("Nbinsy"),
                                        FEDDigi.getParameter<double>("ymin"),
-                                       FEDDigi.getParameter<double>("ymax"));
+                                       FEDDigi.getParameter<double>("ymax"),"");
       NumberOfFEDDigis->setAxisTitle("FED ID",1);
       NumberOfFEDDigis->setAxisTitle("Mean # of Digis in FED",2);
     }


### PR DESCRIPTION
Fix ranges in the x-axis and errors for NumberOfClustersinFED_v_FEDID and NumberOfDigisinFED_v_FEDID 