### PR TITLE
Backport fixes for simulation of long lived exotics 

### DIFF
--- a/SimG4Core/CustomPhysics/interface/CustomParticleFactory.h
+++ b/SimG4Core/CustomPhysics/interface/CustomParticleFactory.h
@@ -1,34 +1,37 @@
-#ifndef CustomParticleFactory_h
-#define CustomParticleFactory_h 1
+#ifndef SimG4Core_CustomPhysics_CustomParticleFactory_h
+#define SimG4Core_CustomPhysics_CustomParticleFactory_h 1
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "SimG4Core/CustomPhysics/interface/CustomParticle.h"
+#include "G4Threading.hh"
 #include <vector>
 #include <string>
+#include <fstream>
 
 class G4DecayTable;
-// ######################################################################
-// ###                          CustomParticle                                ###
-// ######################################################################
+class G4ParticleDefinition;
 
 class CustomParticleFactory {
 
- public:
-  static void loadCustomParticles(const std::string & filePath);
-  static const std::vector<G4ParticleDefinition *>& GetCustomParticles();
+public:
 
- private:
+  explicit CustomParticleFactory();
+  ~CustomParticleFactory();
 
-  static void addCustomParticle(int pdgCode, double mass, const std::string & name );
-  static void getMassTable(std::ifstream *configFile);
-  static G4DecayTable* getDecayTable(std::ifstream *configFile, int pdgId);
-  static G4DecayTable* getAntiDecayTable(int pdgId, G4DecayTable *theDecayTable);
+  void loadCustomParticles(const std::string & filePath);
+  const std::vector<G4ParticleDefinition *>& GetCustomParticles();
+
+private:
+
+  void addCustomParticle(int pdgCode, double mass, const std::string & name );
+  void getMassTable(std::ifstream *configFile);
+  G4DecayTable* getDecayTable(std::ifstream *configFile, int pdgId);
+  G4DecayTable* getAntiDecayTable(int pdgId, G4DecayTable *theDecayTable);
+  std::string ToLower(std::string str);  
 
   static bool loaded;
   static std::vector<G4ParticleDefinition *> m_particles;
-
-  static std::string ToLower(std::string str);  
+#ifdef G4MULTITHREADED
+  static G4Mutex customParticleFactoryMutex;
+#endif
   
 };
 

--- a/SimG4Core/CustomPhysics/interface/CustomPhysicsList.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPhysicsList.h
@@ -1,30 +1,28 @@
-#ifndef SimG4Core_CustomPhysicsList_H
-#define SimG4Core_CustomPhysicsList_H
+#ifndef SimG4Core_CustomPhysics_CustomPhysicsList_H
+#define SimG4Core_CustomPhysics_CustomPhysicsList_H
 
-#include "SimG4Core/CustomPhysics/interface/HadronicProcessHelper.hh"
+#include "FWCore/ParameterSet/interface/ParameterSet.h" 
+#include "G4VPhysicsConstructor.hh"
 
 #include <string>
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
-#include "G4VPhysicsConstructor.hh"
-
 class G4ProcessHelper;
-class G4Decay;
+class CustomParticleFactory;
 
 class CustomPhysicsList : public G4VPhysicsConstructor 
 {
 public:
-  CustomPhysicsList(std::string name, const edm::ParameterSet & p);
-  virtual ~CustomPhysicsList();
+  CustomPhysicsList(const std::string& name, const edm::ParameterSet & p, 
+		    bool useuni = false);
+  ~CustomPhysicsList() override;
 
-  virtual void ConstructParticle();
-  virtual void ConstructProcess();
+  void ConstructParticle() override;
+  void ConstructProcess() override;
 
 private:
 
-  static G4ThreadLocal G4Decay* fDecayProcess;
-  static G4ThreadLocal G4ProcessHelper* myHelper;
+  static G4ThreadLocal std::unique_ptr<G4ProcessHelper> myHelper;
+  std::unique_ptr<CustomParticleFactory> fParticleFactory;
 
   bool fHadronicInteraction;
 

--- a/SimG4Core/CustomPhysics/interface/CustomPhysicsList.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPhysicsList.h
@@ -12,8 +12,7 @@ class CustomParticleFactory;
 class CustomPhysicsList : public G4VPhysicsConstructor 
 {
 public:
-  CustomPhysicsList(const std::string& name, const edm::ParameterSet & p, 
-		    bool useuni = false);
+  CustomPhysicsList(const std::string& name, const edm::ParameterSet & p);
   ~CustomPhysicsList() override;
 
   void ConstructParticle() override;

--- a/SimG4Core/CustomPhysics/interface/CustomPhysicsListSS.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPhysicsListSS.h
@@ -1,30 +1,30 @@
-#ifndef SimG4Core_CustomPhysicsListSS_H
-#define SimG4Core_CustomPhysicsListSS_H
+#ifndef SimG4Core_CustomPhysics_CustomPhysicsListSS_H
+#define SimG4Core_CustomPhysics_CustomPhysicsListSS_H
 
-#include "SimG4Core/CustomPhysics/interface/HadronicProcessHelper.hh"
-
-#include <string>
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
+#include "FWCore/ParameterSet/interface/ParameterSet.h" 
 #include "G4VPhysicsConstructor.hh"
+#include <string>
 
 class G4ProcessHelper;
 class G4Decay;
+class CustomParticleFactory;
 
 class CustomPhysicsListSS : public G4VPhysicsConstructor 
 {
 public:
-  CustomPhysicsListSS(std::string name, const edm::ParameterSet & p);
-  virtual ~CustomPhysicsListSS();
+  CustomPhysicsListSS(const std::string& name, const edm::ParameterSet & p,
+		      bool useuni = false);
+  ~CustomPhysicsListSS() override;
 
-  virtual void ConstructParticle();
-  virtual void ConstructProcess();
+  void ConstructParticle() override;
+  void ConstructProcess() override;
 
 private:
 
-  static G4ThreadLocal G4Decay* fDecayProcess;
-  static G4ThreadLocal G4ProcessHelper* myHelper;
+  static G4ThreadLocal std::unique_ptr<G4Decay> fDecayProcess;
+  static G4ThreadLocal std::unique_ptr<G4ProcessHelper> myHelper;
+
+  std::unique_ptr<CustomParticleFactory> fParticleFactory;
 
   bool fHadronicInteraction;
 
@@ -32,7 +32,7 @@ private:
 
   std::string particleDefFilePath;
   std::string processDefFilePath;
-
+  double dfactor;
 };
  
 #endif

--- a/SimG4Core/CustomPhysics/interface/CustomPhysicsListSS.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPhysicsListSS.h
@@ -12,8 +12,7 @@ class CustomParticleFactory;
 class CustomPhysicsListSS : public G4VPhysicsConstructor 
 {
 public:
-  CustomPhysicsListSS(const std::string& name, const edm::ParameterSet & p,
-		      bool useuni = false);
+  CustomPhysicsListSS(const std::string& name, const edm::ParameterSet & p);
   ~CustomPhysicsListSS() override;
 
   void ConstructParticle() override;

--- a/SimG4Core/CustomPhysics/interface/G4ProcessHelper.h
+++ b/SimG4Core/CustomPhysics/interface/G4ProcessHelper.h
@@ -1,3 +1,6 @@
+#ifndef SimG4Core_CustomPhysics_G4ProcessHelper_H
+#define SimG4Core_CustomPhysics_G4ProcessHelper_H
+
 #include"globals.hh"
 #include"G4ParticleDefinition.hh"
 #include"G4DynamicParticle.hh"
@@ -15,6 +18,7 @@ typedef std::vector<ReactionProduct > ReactionProductList;
 typedef std::map<G4int , ReactionProductList> ReactionMap;
 
 class G4ParticleTable;
+class CustomParticleFactory;
 class HistoHelper;
 class TProfile;
 class TH1D;
@@ -23,9 +27,9 @@ class G4ProcessHelper {
 
 public:
 
-  static G4ProcessHelper* Instance();
+  G4ProcessHelper(const edm::ParameterSet & p, CustomParticleFactory* ptr);
 
-  G4ProcessHelper(const edm::ParameterSet & p);
+  ~G4ProcessHelper();
  
   G4bool ApplicabilityTester(const G4ParticleDefinition& aPart);
 
@@ -35,14 +39,10 @@ public:
   //Make sure the element is known (for n/p-decision)
   ReactionProduct GetFinalState(const G4Track& aTrack,G4ParticleDefinition*& aTarget);
 
-protected:
-
-  G4ProcessHelper(const G4ProcessHelper&);
-  G4ProcessHelper& operator= (const G4ProcessHelper&);
-
 private:
 
-  //static G4ProcessHelper* pinstance;
+  G4ProcessHelper(const G4ProcessHelper&) = delete;
+  G4ProcessHelper& operator= (const G4ProcessHelper&) = delete;
 
   G4double Regge(const double boost);
   G4double Pom(const double boost);
@@ -94,6 +94,7 @@ private:
   //Neutron-scattering processes
   ReactionMap nReactionMap;
 
+  CustomParticleFactory* fParticleFactory;
   G4ParticleTable* particleTable;
   HistoHelper* theHistoHelper;
   TProfile* h_xsec_lab;
@@ -103,3 +104,4 @@ private:
   TProfile* h_q_gamma;
 
 };
+#endif

--- a/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
+++ b/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
@@ -1,34 +1,44 @@
-#include <fstream>
-#include <iomanip>
-#include <iostream>
-#include <string>
-#include <vector>
-#include <sstream>
-#include <set>
-#include <locale>     
-
+#include "SimG4Core/CustomPhysics/interface/CustomParticleFactory.h"
 #include "SimG4Core/CustomPhysics/interface/CustomPDGParser.h"
 #include "SimG4Core/CustomPhysics/interface/CustomParticle.h"
-#include "SimG4Core/CustomPhysics/interface/CustomParticleFactory.h"
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include <G4ParticleTable.hh>
+#include "G4ParticleTable.hh"
 #include "G4DecayTable.hh"
-#include <G4PhaseSpaceDecayChannel.hh>
+#include "G4PhaseSpaceDecayChannel.hh"
 #include "G4ProcessManager.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4SystemOfUnits.hh"
 
-using namespace CLHEP;
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 
 bool CustomParticleFactory::loaded = false;
 std::vector<G4ParticleDefinition *> CustomParticleFactory::m_particles;
 
-void CustomParticleFactory::loadCustomParticles(const std::string & filePath){
-  if(loaded) return;
-  loaded = true;
+#ifdef G4MULTITHREADED
+G4Mutex CustomParticleFactory::customParticleFactoryMutex = G4MUTEX_INITIALIZER;
+#endif
 
+CustomParticleFactory::CustomParticleFactory()
+{}
+
+CustomParticleFactory::~CustomParticleFactory()
+{}
+
+void CustomParticleFactory::loadCustomParticles(const std::string & filePath){
+
+  if(loaded) { return; }
+#ifdef G4MULTITHREADED
+  G4MUTEXLOCK(&customParticleFactoryMutex);
+  if(loaded) { return; } 
+#endif
+
+  // loading once
+  loaded = true; 
   std::ifstream configFile(filePath.c_str());
 
   std::string line;
@@ -37,15 +47,16 @@ void CustomParticleFactory::loadCustomParticles(const std::string & filePath){
     << filePath; 
   // This should be compatible IMO to SLHA 
   G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
-  while(getline(configFile,line)){
-    line.erase(0, line.find_first_not_of(" \t"));         // Remove leading whitespace.
-    if (line.length()==0 || line.at(0) == '#') continue;  // Skip blank lines and comments.  
-    if (ToLower(line).find("block") < line.npos &&        // The mass table begins with a line containing "BLOCK MASS".  
+  while(getline(configFile, line)){
+    line.erase(0, line.find_first_not_of(" \t"));            // Remove leading whitespace.
+    if (line.length()==0 || line.at(0) == '#') { continue; } // Skip blank lines and comments.  
+    // The mass table begins with a line containing "BLOCK MASS"
+    if (ToLower(line).find("block") < line.npos &&        
 	ToLower(line).find("mass")  < line.npos) {
       edm::LogInfo("SimG4CoreCustomPhysics") <<"CustomParticleFactory: Retrieving mass table."; 
       getMassTable(&configFile);
     }
-    if(line.find("DECAY")<line.npos){
+    if(line.find("DECAY")<line.npos) {
       int pdgId;
       double width; 
       std::string tmpString;
@@ -53,27 +64,33 @@ void CustomParticleFactory::loadCustomParticles(const std::string & filePath){
       lineStream >> tmpString >> pdgId >> width; 
       // assume SLHA format, e.g.: DECAY  1000021  5.50675438E+00   # gluino decays
       edm::LogInfo("SimG4CoreCustomPhysics") 
-	<<"CustomParticleFactory: entry to G4DecayTable: pdgID, width " << pdgId << ",  " << width; 
+	<<"CustomParticleFactory: entry to G4DecayTable: pdgID, width " 
+	<< pdgId << ",  " << width; 
+      G4ParticleDefinition *aParticle = theParticleTable->FindParticle(pdgId);
+      if (!aParticle || width == 0.0) { continue; }    
       G4DecayTable* aDecayTable = getDecayTable(&configFile, pdgId);      
-      G4ParticleDefinition *aParticle     = theParticleTable->FindParticle(pdgId);
-      G4ParticleDefinition *aAntiParticle = theParticleTable->FindAntiParticle(pdgId);
-      if (!aParticle) continue;    
       aParticle->SetDecayTable(aDecayTable); 
       aParticle->SetPDGStable(false);
-      aParticle->SetPDGLifeTime(1.0/(width*GeV)*6.582122e-22*MeV*s);      
-      if(aAntiParticle && aAntiParticle->GetPDGEncoding()!=pdgId){	
+      aParticle->SetPDGLifeTime(1.0/(width*CLHEP::GeV)*6.582122e-22*CLHEP::MeV*CLHEP::s);      
+      G4ParticleDefinition *aAntiParticle = theParticleTable->FindAntiParticle(pdgId);
+      if(aAntiParticle && aAntiParticle->GetPDGEncoding() != pdgId){	
 	aAntiParticle->SetDecayTable(getAntiDecayTable(pdgId,aDecayTable)); 
 	aAntiParticle->SetPDGStable(false);
-	aAntiParticle->SetPDGLifeTime(1.0/(width*GeV)*6.582122e-22*MeV*s);
-      }         
+	aAntiParticle->SetPDGLifeTime(1.0/(width*CLHEP::GeV)*6.582122e-22*CLHEP::MeV*CLHEP::s);
+      }
     }
   }
+#ifdef G4MULTITHREADED
+  G4MUTEXUNLOCK(&customParticleFactoryMutex); 
+#endif
 }
 
-void CustomParticleFactory::addCustomParticle(int pdgCode, double mass, const std::string & name){
+void CustomParticleFactory::addCustomParticle(int pdgCode, double mass, 
+                                              const std::string & name){
   
-  if(abs(pdgCode)%100 <14 && abs(pdgCode) / 1000000 == 0){
-    edm::LogError("") << "Pdg code too low " << pdgCode << " "<<abs(pdgCode) / 1000000; 
+  if(std::abs(pdgCode)%100 <14 && std::abs(pdgCode)/1000000 == 0){
+    edm::LogError("CustomParticleFactory::addCustomParticle") 
+      << "Pdg code too low " << pdgCode << " "<<std::abs(pdgCode)/1000000; 
     return;
   }
     
@@ -83,32 +100,32 @@ void CustomParticleFactory::addCustomParticle(int pdgCode, double mass, const st
   G4double spectatormass = 0.0;
   G4ParticleDefinition* spectator = nullptr; 
   //////////////////////
-  if(CustomPDGParser::s_isRHadron(pdgCode)) pType = "rhadron";
-  if(CustomPDGParser::s_isSLepton(pdgCode)) pType = "sLepton";
-  if(CustomPDGParser::s_isMesonino(pdgCode)) pType = "mesonino";
-  if(CustomPDGParser::s_isSbaryon(pdgCode)) pType = "sbaryon";
+  if(CustomPDGParser::s_isRHadron(pdgCode)) { pType = "rhadron"; }
+  if(CustomPDGParser::s_isSLepton(pdgCode)) { pType = "sLepton"; }
+  if(CustomPDGParser::s_isMesonino(pdgCode)){ pType = "mesonino"; }
+  if(CustomPDGParser::s_isSbaryon(pdgCode)) { pType = "sbaryon"; }
  
-  double massGeV =mass*GeV;
-  double width = 0.0*MeV;
-  double charge = eplus* CustomPDGParser::s_charge(pdgCode);
+  double massGeV = mass*CLHEP::GeV;
+  double width   = 0.0;
+  double charge  = CLHEP::eplus* CustomPDGParser::s_charge(pdgCode);
   if (name.compare(0,4,"~HIP") == 0)
     {
       if ((name.compare(0,7,"~HIPbar") == 0))  {
 	std::string str = name.substr(7); 
-	charge=eplus*atoi(str.c_str())/3.;
+	charge=CLHEP::eplus*atoi(str.c_str())/3.;
       } else {
 	std::string str = name.substr(4); 
-	charge=eplus*atoi(str.c_str())*-1./3.;  
+	charge=-CLHEP::eplus*atoi(str.c_str())/3.;  
       }
     }
   if (name.compare(0,9,"anti_~HIP") == 0)
     {
       if ((name.compare(0,12,"anti_~HIPbar") == 0))  {
 	std::string str = name.substr (12); 
-	charge=eplus*atoi(str.c_str())*-1./3.;
+	charge=-CLHEP::eplus*atoi(str.c_str())/3.;
       } else {
 	std::string str = name.substr (9); 
-	charge=eplus*atoi(str.c_str())*1./3.;  
+	charge=CLHEP::eplus*atoi(str.c_str())/3.;  
       }
     }
   int spin =  (int)CustomPDGParser::s_spin(pdgCode)-1;
@@ -149,23 +166,21 @@ void CustomParticleFactory::addCustomParticle(int pdgCode, double mass, const st
     G4String cloudtype = pType+"cloud";
     spectator = theParticleTable->FindParticle(1000021);
     spectatormass = spectator->GetPDGMass();
-    G4double cloudmass = mass-spectatormass/GeV;
+    G4double cloudmass = massGeV - spectatormass;
     CustomParticle *tmpParticle  = new CustomParticle(
-						      cloudname,           cloudmass * GeV ,        0.0*MeV,  0 , 
-						      0,              +1,             0,          
-						      0,              0,             0,             
-						      cloudtype,               0,            +1, 0,
-						      true,            -1.0,          NULL );
+						      cloudname,  cloudmass,     0.0,  0, 
+						      0,              +1,        0,          
+						      0,               0,        0,             
+						      cloudtype,       0,       +1,    0,
+						      true,           -1.0,    nullptr );
     particle->SetCloud(tmpParticle);
     particle->SetSpectator(spectator);
     
     edm::LogInfo("SimG4CoreCustomPhysics")
-      <<"CustomParticleFactory: " <<name<<" being assigned "
-      <<particle->GetCloud()->GetParticleName()
-      <<" and "<<particle->GetSpectator()->GetParticleName() << "\n" 
-      <<"                        Masses: "<<particle->GetPDGMass()/GeV<<" Gev, "
-      <<particle->GetCloud()->GetPDGMass()/GeV<<" GeV and "
-      <<particle->GetSpectator()->GetPDGMass()/GeV<<" GeV."; 
+      <<"CustomParticleFactory: " <<name<<" being assigned spectator"
+      << spectator->GetParticleName() << " and cloud " <<cloudname << "\n" 
+      <<"                        Masses: "<<mass<<" Gev, "
+      <<spectatormass/CLHEP::GeV<<" GeV and "<<cloudmass/CLHEP::GeV<<" GeV."; 
   } else if(pType == "mesonino" || pType == "sbaryon") {
     int sign=1;
     if(pdgCode < 0 ) sign=-1;
@@ -183,29 +198,26 @@ void CustomParticleFactory::addCustomParticle(int pdgCode, double mass, const st
         edm::LogError("SimG4CoreCustomPhysics")<< "CustomParticleFactory: Cannot find spectator parton";
       }
     }
-    if(spectator) spectatormass = spectator->GetPDGMass();
-    G4double cloudmass = mass-spectatormass/GeV;
+    if(spectator) { spectatormass = spectator->GetPDGMass(); }
+    G4double cloudmass = massGeV - spectatormass;
     CustomParticle *tmpParticle  = new CustomParticle(
-                                                      cloudname,           cloudmass * GeV ,        0.0*MeV,  0 ,
-                                                      0,              +1,             0,
-                                                      0,              0,             0,
-                                                      cloudtype,               0,            +1, 0,
-                                                      true,            -1.0,          NULL );
+                                                      cloudname, cloudmass,    0.0,  0 ,
+                                                      0,              +1,      0,
+                                                      0,               0,      0,
+                                                      cloudtype,       0,     +1,     0,
+                                                      true,           -1.0,   nullptr);
     particle->SetCloud(tmpParticle);
     particle->SetSpectator(spectator);
 
     edm::LogInfo("SimG4CoreCustomPhysics")
-      <<"CustomParticleFactory: "<<name<<" being assigned "
-      <<particle->GetCloud()->GetParticleName()
-      <<" and "<<particle->GetSpectator()->GetParticleName() << "\n" 
-      <<"                        Masses: "
-      <<particle->GetPDGMass()/GeV<<" Gev, "
-      <<particle->GetCloud()->GetPDGMass()/GeV<<" GeV and "
-      <<particle->GetSpectator()->GetPDGMass()/GeV<<" GeV."; 
+      <<"CustomParticleFactory: " <<name<<" being assigned spectator"
+      << spectator->GetParticleName() << " and cloud " <<cloudname << "\n" 
+      <<"                        Masses: "<<mass<<" Gev, "
+      <<spectatormass/CLHEP::GeV<<" GeV and "<<cloudmass/CLHEP::GeV<<" GeV."; 
   }
   else{
-    particle->SetCloud(0);
-    particle->SetSpectator(0);
+    particle->SetCloud(nullptr);
+    particle->SetSpectator(nullptr);
   } 
   m_particles.push_back(particle);
 }
@@ -216,6 +228,8 @@ void  CustomParticleFactory::getMassTable(std::ifstream *configFile) {
   double mass;
   std::string name, tmp;
   std::string line;
+  G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
+
   // This should be compatible IMO to SLHA 
   while (getline(*configFile,line)) {
     line.erase(0, line.find_first_not_of(" \t"));         // remove leading whitespace
@@ -228,21 +242,25 @@ void  CustomParticleFactory::getMassTable(std::ifstream *configFile) {
     std::stringstream sstr(line);
     sstr >> pdgId >> mass >> tmp >> name;  // Assume SLHA format, e.g.: 1000001 5.68441109E+02 # ~d_L 
 
+    mass = std::max(mass, 0.0);
+    if(theParticleTable->FindParticle(pdgId)) { continue; }
+
     edm::LogInfo("SimG4CoreCustomPhysics") 
       <<"CustomParticleFactory: Calling addCustomParticle for pdgId: " << pdgId 
-      << ", mass " << mass << ", name " << name; 
-    addCustomParticle(pdgId, fabs(mass), name);
+      << ", mass " << mass << " GeV  " <<  name 
+      << ", isRHadron: " << CustomPDGParser::s_isRHadron(pdgId)    
+      << ", isstopHadron: " << CustomPDGParser::s_isstopHadron(pdgId); 
+    addCustomParticle(pdgId, mass, name);
+
     ////Find SM particle partner and check for the antiparticle.
     int pdgIdPartner = pdgId%100;
-    G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
     G4ParticleDefinition *aParticle = theParticleTable->FindParticle(pdgIdPartner);
     //Add antiparticles for SUSY particles only, not for rHadrons.
-    edm::LogInfo("SimG4CoreCustomPhysics") 
-      <<"CustomParticleFactory: Found aParticle = " << aParticle
-      << ", pdgId = " << pdgId
-      << ", pdgIdPartner = " << pdgIdPartner  
-      << ", CustomPDGParser::s_isRHadron(pdgId) = " << CustomPDGParser::s_isRHadron(pdgId)    
-      << ", CustomPDGParser::s_isstopHadron(pdgId) = " << CustomPDGParser::s_isstopHadron(pdgId); 
+    if(aParticle) {
+      edm::LogInfo("SimG4CoreCustomPhysics") 
+	<<"CustomParticleFactory: Found partner particle for " << " pdgId= " << pdgId
+	<< ", pdgIdPartner= " << pdgIdPartner << " " << aParticle->GetParticleName();
+    }
     
     if (aParticle && 
 	!CustomPDGParser::s_isRHadron(pdgId)    && 
@@ -255,22 +273,26 @@ void  CustomParticleFactory::getMassTable(std::ifstream *configFile) {
 	pdgId!=37){ 
       int sign = aParticle->GetAntiPDGEncoding()/pdgIdPartner;   
       edm::LogInfo("SimG4CoreCustomPhysics") 
-	<<"CustomParticleFactory: Found sign = " << sign 
-	<< ", aParticle->GetAntiPDGEncoding() " << aParticle->GetAntiPDGEncoding() 
-	<< ", pdgIdPartner = " << pdgIdPartner;   
-      if(abs(sign)!=1) {
+	<<"CustomParticleFactory: For " << aParticle->GetParticleName()
+	<<" pdg= " << pdgIdPartner 
+	<< ", GetAntiPDGEncoding() " << aParticle->GetAntiPDGEncoding() 
+	<< " sign= " << sign;
+
+      if(std::abs(sign)!=1) {
 	edm::LogInfo("SimG4CoreCustomPhysics")
-	  <<"CustomParticleFactory: sgn= "<<sign<<" a "
-	  <<aParticle->GetAntiPDGEncoding()<<" b "<<pdgIdPartner; 
+	  <<"CustomParticleFactory: sign= "<<sign<<" a: "
+	  <<aParticle->GetAntiPDGEncoding()<<" b: "<<pdgIdPartner; 
 	aParticle->DumpTable();
       }
       if(sign==-1 && pdgId!=25 && pdgId!=35 && pdgId!=36 && pdgId!=37 && pdgId!=1000039){
 	tmp = "anti_"+name;
-	edm::LogInfo("SimG4CoreCustomPhysics") 
-	  <<"CustomParticleFactory: Calling addCustomParticle for antiparticle with pdgId: " 
-	  << -pdgId << ", mass " << mass << ", name " << tmp; 
-	addCustomParticle(-pdgId, mass, tmp);
-	theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(-pdgId);
+	if(!theParticleTable->FindParticle(-pdgId)) {
+	  edm::LogInfo("SimG4CoreCustomPhysics") 
+	    <<"CustomParticleFactory: Calling addCustomParticle for antiparticle with pdgId: " 
+	    << -pdgId << ", mass " << mass << " GeV, name " << tmp; 
+	  addCustomParticle(-pdgId, mass, tmp);
+	  theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(-pdgId);
+	}
       }
       else theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(pdgId);      
     }
@@ -278,11 +300,13 @@ void  CustomParticleFactory::getMassTable(std::ifstream *configFile) {
     if(pdgId==1000039) theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(pdgId); // gravitino     
     if(pdgId==1000024 || pdgId==1000037 || pdgId==37) {   
       tmp = "anti_"+name;
-      edm::LogInfo("SimG4CoreCustomPhysics") 
-	<<"CustomParticleFactory: Calling addCustomParticle for antiparticle (2) with pdgId: " 
-	<< -pdgId << ", mass " << mass << ", name " << tmp; 
-      addCustomParticle(-pdgId, mass, tmp);
-      theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(-pdgId);
+      if(!theParticleTable->FindParticle(-pdgId)) {
+	edm::LogInfo("SimG4CoreCustomPhysics") 
+	  <<"CustomParticleFactory: Calling addCustomParticle for antiparticle (2) with pdgId: " 
+	  << -pdgId << ", mass " << mass << " GeV, name " << tmp; 
+	addCustomParticle(-pdgId, mass, tmp);
+	theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(-pdgId);
+      }
     }
   }
 }
@@ -291,9 +315,8 @@ G4DecayTable*  CustomParticleFactory::getDecayTable(std::ifstream *configFile, i
 
   double br;
   int nDaughters;
-  std::vector<int> pdg(4);
+  int pdg[4] = {0};
   std::string line;
-  std::vector<std::string> name(4);
 
   G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
 
@@ -307,17 +330,14 @@ G4DecayTable*  CustomParticleFactory::getDecayTable(std::ifstream *configFile, i
     if (line.at(0) == '#' && 
 	ToLower(line).find("br")  < line.npos &&
 	ToLower(line).find("nda") < line.npos) continue;  // skip a comment of the form:  # BR  NDA  ID1  ID2
-    if (line.at(0) == '#') {                              // other comments signal the end of the decay block  
+    if (line.at(0) == '#' || ToLower(line).find("block") < line.npos) {   
       edm::LogInfo("SimG4CoreCustomPhysics") <<"CustomParticleFactory: Finished the Decay Table "; 
       break;
     }
-    
-    pdg.clear();
-    name.clear();
 
     std::stringstream sstr(line);  
     sstr >> br >> nDaughters;  // assume SLHA format, e.g.:  1.49435135E-01  2  -15  16  # BR(H+ -> tau+ nu_tau)
-    edm::LogInfo("SimG4CoreCustomPhysics") 
+    LogDebug("SimG4CoreCustomPhysics") 
       <<"CustomParticleFactory: Branching Ratio: " << br << ", Number of Daughters: " << nDaughters; 
     if (nDaughters > 4) {
       edm::LogError("SimG4CoreCustomPhysics") 
@@ -325,9 +345,16 @@ G4DecayTable*  CustomParticleFactory::getDecayTable(std::ifstream *configFile, i
 	<< " for pdgId: " << pdgId; 
       break; 
     }
-    for(int i=0; i<nDaughters; i++) {
+    if (br <= 0.0) {
+      edm::LogError("SimG4CoreCustomPhysics") 
+	<<"CustomParticleFactory: Branching ratio is " << br  
+	<< " for pdgId: " << pdgId; 
+      break; 
+    }
+    std::string name[4] = {""};
+    for(int i=0; i<nDaughters; ++i) {
       sstr >> pdg[i];
-      edm::LogInfo("SimG4CoreCustomPhysics") <<"CustomParticleFactory: Daughter ID " << pdg[i]; 
+      LogDebug("SimG4CoreCustomPhysics") <<"CustomParticleFactory: Daughter ID " << pdg[i]; 
       const G4ParticleDefinition* part = theParticleTable->FindParticle(pdg[i]);
       if (!part) {
 	edm::LogWarning("SimG4CoreCustomPhysics")
@@ -338,21 +365,25 @@ G4DecayTable*  CustomParticleFactory::getDecayTable(std::ifstream *configFile, i
     }
     ////Set the G4 decay
     G4PhaseSpaceDecayChannel *aDecayChannel = new G4PhaseSpaceDecayChannel(parentName, br, nDaughters,
-									   name[0],name[1],name[2],name[3]);    
+									   name[0],name[1],name[2],name[3]);
     decaytable->Insert(aDecayChannel);  
+    edm::LogInfo("SimG4CoreCustomPhysics") <<"CustomParticleFactory: inserted decay channel "
+					   <<" for pdgID= " << pdgId << "  " << parentName
+					   <<" BR= " << br << " Daughters: " << name[0] 
+					   <<"  " << name[1]<< "  " << name[2]<< "  " << name[3]; 
   }
   return decaytable;
 }
 
 G4DecayTable*  CustomParticleFactory::getAntiDecayTable(int pdgId,  G4DecayTable *theDecayTable) {
 
-  std::vector<std::string> name(4);
+  std::string name[4] = {""};
   G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
 
   std::string parentName = theParticleTable->FindParticle(-pdgId)->GetParticleName();
   G4DecayTable *decaytable= new G4DecayTable();
 
-  for(int i=0;i<theDecayTable->entries();i++){
+  for(int i=0;i<theDecayTable->entries(); ++i){
     G4VDecayChannel *theDecayChannel = theDecayTable->GetDecayChannel(i); 
     int nd = std::min(4, theDecayChannel->GetNumberOfDaughters());
     for(int j=0; j<nd; ++j){
@@ -370,6 +401,11 @@ G4DecayTable*  CustomParticleFactory::getAntiDecayTable(int pdgId,  G4DecayTable
 				   theDecayChannel->GetBR(), nd,
 				   name[0],name[1],name[2],name[3]);  
     decaytable->Insert(aDecayChannel);
+    edm::LogInfo("SimG4CoreCustomPhysics") <<"CustomParticleFactory: inserted decay channel "
+					   <<" for pdgID= " << -pdgId << "  " << parentName
+					   <<" BR= " << theDecayChannel->GetBR() 
+					   << " Daughters: " << name[0] 
+					   <<"  " << name[1]<< "  " << name[2]<< "  " << name[3]; 
   }
   return decaytable;
 }

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -1,36 +1,43 @@
 #include "SimG4Core/CustomPhysics/interface/CustomPhysicsList.h"
 #include "SimG4Core/CustomPhysics/interface/CustomParticleFactory.h"
+#include "SimG4Core/CustomPhysics/interface/CustomParticle.h"
 #include "SimG4Core/CustomPhysics/interface/DummyChargeFlipProcess.h"
-#include "SimG4Core/CustomPhysics/interface/G4ProcessHelper.hh"
+#include "SimG4Core/CustomPhysics/interface/G4ProcessHelper.h"
 #include "SimG4Core/CustomPhysics/interface/CustomPDGParser.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "G4Decay.hh"
 #include "G4hMultipleScattering.hh"
 #include "G4hIonisation.hh"
 #include "G4ProcessManager.hh"
 
 #include "SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.hh"
-#include "SimG4Core/CustomPhysics/interface/ToyModelHadronicProcess.hh"
 #include "SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh"
 
 using namespace CLHEP;
 
-G4ThreadLocal G4Decay* CustomPhysicsList::fDecayProcess = nullptr;
-G4ThreadLocal G4ProcessHelper* CustomPhysicsList::myHelper = nullptr;
+G4ThreadLocal std::unique_ptr<G4ProcessHelper> CustomPhysicsList::myHelper;
 
-CustomPhysicsList::CustomPhysicsList(std::string name, const edm::ParameterSet & p)  
+CustomPhysicsList::CustomPhysicsList(const std::string& name, 
+				     const edm::ParameterSet & p, bool apinew)  
   :  G4VPhysicsConstructor(name) 
 {  
   myConfig = p;
-  dfactor = p.getParameter<double>("dark_factor");
+  if(apinew) {
+    dfactor = p.getParameter<double>("DarkMPFactor");
+    fHadronicInteraction = p.getParameter<bool>("RhadronPhysics");
+  } else {
+    // this is left for backward compatibility
+    dfactor = p.getParameter<double>("dark_factor");
+    fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
+  }
   edm::FileInPath fp = p.getParameter<edm::FileInPath>("particlesDef");
-  fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
-
   particleDefFilePath = fp.fullPath();
+  fParticleFactory.reset(new CustomParticleFactory());
+  myHelper.reset(nullptr);
+
   edm::LogInfo("SimG4CoreCustomPhysics") 
     << "CustomPhysicsList: Path for custom particle definition file: \n"
     <<particleDefFilePath << "\n" << "      dark_factor= " << dfactor;
@@ -40,8 +47,9 @@ CustomPhysicsList::~CustomPhysicsList() {
 }
  
 void CustomPhysicsList::ConstructParticle(){
-  G4cout << "===== CustomPhysicsList::ConstructParticle " << this << G4endl;
-  CustomParticleFactory::loadCustomParticles(particleDefFilePath);
+  edm::LogInfo("SimG4CoreCustomPhysics") 
+    << "===== CustomPhysicsList::ConstructParticle ";
+  fParticleFactory.get()->loadCustomParticles(particleDefFilePath);
 }
  
 void CustomPhysicsList::ConstructProcess() {
@@ -50,11 +58,9 @@ void CustomPhysicsList::ConstructProcess() {
     <<"CustomPhysicsList: adding CustomPhysics processes "
     << "for the list of particles";
 
-  fDecayProcess = new G4Decay();
-  
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
-  for(auto particle : CustomParticleFactory::GetCustomParticles()) {
+  for(auto particle : fParticleFactory.get()->GetCustomParticles()) {
     CustomParticle* cp = dynamic_cast<CustomParticle*>(particle);
     if(cp) {
       G4ProcessManager* pmanager = particle->GetProcessManager();
@@ -67,9 +73,6 @@ void CustomPhysicsList::ConstructProcess() {
 	  ph->RegisterProcess(new G4hMultipleScattering, particle);
 	  ph->RegisterProcess(new G4hIonisation, particle);
 	}
-	if(fDecayProcess->IsApplicable(*particle)) {
-	  ph->RegisterProcess(fDecayProcess, particle);
-	}
 	if(cp->GetCloud() && fHadronicInteraction && 
 	   CustomPDGParser::s_isRHadron(particle->GetPDGEncoding())) {
 	  edm::LogInfo("SimG4CoreCustomPhysics") 
@@ -77,8 +80,8 @@ void CustomPhysicsList::ConstructProcess() {
 	    <<" CloudMass= " <<cp->GetCloud()->GetPDGMass()/GeV
 	    <<" GeV; SpectatorMass= " << cp->GetSpectator()->GetPDGMass()/GeV<<" GeV.";
        
-          if(!myHelper) { myHelper = new G4ProcessHelper(myConfig); }
-	  pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper));
+          if(!myHelper.get()) { myHelper.reset(new G4ProcessHelper(myConfig, fParticleFactory.get())); }
+	  pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper.get()));
 	}
         if(particle->GetParticleType()=="darkpho"){
           CMSDarkPairProductionProcess * darkGamma = new CMSDarkPairProductionProcess(dfactor);

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -25,8 +25,8 @@ CustomPhysicsList::CustomPhysicsList(const std::string& name, const edm::Paramet
 {  
   myConfig = p;
   dfactor = p.getParameter<double>("dark_factor");
-  fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
   edm::FileInPath fp = p.getParameter<edm::FileInPath>("particlesDef");
+  fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
   particleDefFilePath = fp.fullPath();
   fParticleFactory.reset(new CustomParticleFactory());
   myHelper.reset(nullptr);

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -20,19 +20,12 @@ using namespace CLHEP;
 
 G4ThreadLocal std::unique_ptr<G4ProcessHelper> CustomPhysicsList::myHelper;
 
-CustomPhysicsList::CustomPhysicsList(const std::string& name, 
-				     const edm::ParameterSet & p, bool apinew)  
+CustomPhysicsList::CustomPhysicsList(const std::string& name, const edm::ParameterSet & p)
   :  G4VPhysicsConstructor(name) 
 {  
   myConfig = p;
-  if(apinew) {
-    dfactor = p.getParameter<double>("DarkMPFactor");
-    fHadronicInteraction = p.getParameter<bool>("RhadronPhysics");
-  } else {
-    // this is left for backward compatibility
-    dfactor = p.getParameter<double>("dark_factor");
-    fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
-  }
+  dfactor = p.getParameter<double>("dark_factor");
+  fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
   edm::FileInPath fp = p.getParameter<edm::FileInPath>("particlesDef");
   particleDefFilePath = fp.fullPath();
   fParticleFactory.reset(new CustomParticleFactory());

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
@@ -28,8 +28,8 @@ CustomPhysicsListSS::CustomPhysicsListSS(const std::string& name, const edm::Par
 {  
   myConfig = p;
   dfactor = p.getParameter<double>("dark_factor");
-  fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
   edm::FileInPath fp = p.getParameter<edm::FileInPath>("particlesDef");
+  fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
   particleDefFilePath = fp.fullPath();
   fParticleFactory.reset(new CustomParticleFactory());
   fDecayProcess.reset(nullptr);

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
@@ -1,7 +1,8 @@
 #include "SimG4Core/CustomPhysics/interface/CustomPhysicsListSS.h"
 #include "SimG4Core/CustomPhysics/interface/CustomParticleFactory.h"
+#include "SimG4Core/CustomPhysics/interface/CustomParticle.h"
 #include "SimG4Core/CustomPhysics/interface/DummyChargeFlipProcess.h"
-#include "SimG4Core/CustomPhysics/interface/G4ProcessHelper.hh"
+#include "SimG4Core/CustomPhysics/interface/G4ProcessHelper.h"
 #include "SimG4Core/CustomPhysics/interface/CustomPDGParser.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -15,42 +16,55 @@
 #include "G4ProcessManager.hh"
 
 #include "SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.hh"
-#include "SimG4Core/CustomPhysics/interface/ToyModelHadronicProcess.hh"
+#include "SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh"
 
 using namespace CLHEP;
 
-G4ThreadLocal G4Decay* CustomPhysicsListSS::fDecayProcess = nullptr;
-G4ThreadLocal G4ProcessHelper* CustomPhysicsListSS::myHelper = nullptr;
+G4ThreadLocal std::unique_ptr<G4Decay> CustomPhysicsListSS::fDecayProcess;
+G4ThreadLocal std::unique_ptr<G4ProcessHelper> CustomPhysicsListSS::myHelper;
  
-CustomPhysicsListSS::CustomPhysicsListSS(std::string name, const edm::ParameterSet& p)
+CustomPhysicsListSS::CustomPhysicsListSS(const std::string& name,
+					 const edm::ParameterSet & p, bool apinew)  
   :  G4VPhysicsConstructor(name) 
 {  
   myConfig = p;
+  if(apinew) {
+    dfactor = p.getParameter<double>("DarkMPFactor");
+    fHadronicInteraction = p.getParameter<bool>("RhadronPhysics");
+  } else {
+    // this is left for backward compatibility
+    dfactor = p.getParameter<double>("dark_factor");
+    fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
+  }
   edm::FileInPath fp = p.getParameter<edm::FileInPath>("particlesDef");
-  fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
   particleDefFilePath = fp.fullPath();
+  fParticleFactory.reset(new CustomParticleFactory());
+  fDecayProcess.reset(nullptr);
+  myHelper.reset(nullptr);
+
   edm::LogInfo("SimG4CoreCustomPhysics")
     <<"CustomPhysicsListSS: Path for custom particle definition file: \n" 
     <<particleDefFilePath;
-  myHelper = 0;  
 }
 
 CustomPhysicsListSS::~CustomPhysicsListSS() {
 }
  
 void CustomPhysicsListSS::ConstructParticle(){
-  CustomParticleFactory::loadCustomParticles(particleDefFilePath);     
+  edm::LogInfo("SimG4CoreCustomPhysicsSS") 
+    << "===== CustomPhysicsList::ConstructParticle ";
+  fParticleFactory.get()->loadCustomParticles(particleDefFilePath);
 }
  
 void CustomPhysicsListSS::ConstructProcess() {
 
-  edm::LogInfo("SimG4CoreCustomPhysics") 
+  edm::LogInfo("SimG4CoreCustomPhysicsSS") 
     <<"CustomPhysicsListSS: adding CustomPhysics processes";
 
-  fDecayProcess = new G4Decay();
+  fDecayProcess.reset(new G4Decay());
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
-  for(auto particle : CustomParticleFactory::GetCustomParticles()) {
+  for(auto particle : fParticleFactory.get()->GetCustomParticles()) {
 
     CustomParticle* cp = dynamic_cast<CustomParticle*>(particle);
     if(cp) {
@@ -64,8 +78,8 @@ void CustomPhysicsListSS::ConstructProcess() {
 	  ph->RegisterProcess(new G4hMultipleScattering, particle);
 	  ph->RegisterProcess(new G4hIonisation, particle);
 	}
-	if(fDecayProcess->IsApplicable(*particle)) {
-	  ph->RegisterProcess(fDecayProcess, particle);
+	if(fDecayProcess.get()->IsApplicable(*particle)) {
+	  ph->RegisterProcess(fDecayProcess.get(), particle);
 	}
 	if(cp->GetCloud() && fHadronicInteraction &&
 	   CustomPDGParser::s_isRHadron(particle->GetPDGEncoding())) {
@@ -74,9 +88,13 @@ void CustomPhysicsListSS::ConstructProcess() {
 	    <<" CloudMass= " <<cp->GetCloud()->GetPDGMass()/GeV
 	    <<" GeV; SpectatorMass= " << cp->GetSpectator()->GetPDGMass()/GeV <<" GeV.";
        
-	  if(!myHelper) { myHelper = new G4ProcessHelper(myConfig); }
-	  pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper));
+	  if(!myHelper.get()) { myHelper.reset(new G4ProcessHelper(myConfig, fParticleFactory.get())); }
+	  pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper.get()));
 	}
+        if(particle->GetParticleType()=="darkpho"){
+          CMSDarkPairProductionProcess * darkGamma = new CMSDarkPairProductionProcess(dfactor);
+          pmanager->AddDiscreteProcess(darkGamma);
+        }
       }
     }
   }

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
@@ -23,19 +23,12 @@ using namespace CLHEP;
 G4ThreadLocal std::unique_ptr<G4Decay> CustomPhysicsListSS::fDecayProcess;
 G4ThreadLocal std::unique_ptr<G4ProcessHelper> CustomPhysicsListSS::myHelper;
  
-CustomPhysicsListSS::CustomPhysicsListSS(const std::string& name,
-					 const edm::ParameterSet & p, bool apinew)  
+CustomPhysicsListSS::CustomPhysicsListSS(const std::string& name, const edm::ParameterSet & p)  
   :  G4VPhysicsConstructor(name) 
 {  
   myConfig = p;
-  if(apinew) {
-    dfactor = p.getParameter<double>("DarkMPFactor");
-    fHadronicInteraction = p.getParameter<bool>("RhadronPhysics");
-  } else {
-    // this is left for backward compatibility
-    dfactor = p.getParameter<double>("dark_factor");
-    fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
-  }
+  dfactor = p.getParameter<double>("dark_factor");
+  fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
   edm::FileInPath fp = p.getParameter<edm::FileInPath>("particlesDef");
   particleDefFilePath = fp.fullPath();
   fParticleFactory.reset(new CustomParticleFactory());

--- a/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
@@ -3,7 +3,7 @@
 #include "G4ParticleTable.hh"
 
 #include "SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.hh"
-#include "SimG4Core/CustomPhysics/interface/G4ProcessHelper.hh"
+#include "SimG4Core/CustomPhysics/interface/G4ProcessHelper.h"
 #include "SimG4Core/CustomPhysics/interface/Decay3Body.h"
 #include "SimG4Core/CustomPhysics/interface/CustomPDGParser.h"
 #include "SimG4Core/CustomPhysics/interface/CustomParticle.h"

--- a/SimG4Core/CustomPhysics/src/G4ProcessHelper.cc
+++ b/SimG4Core/CustomPhysics/src/G4ProcessHelper.cc
@@ -1,3 +1,12 @@
+#include "SimG4Core/CustomPhysics/interface/G4ProcessHelper.h"
+#include "SimG4Core/CustomPhysics/interface/CustomPDGParser.h"
+#include "SimG4Core/CustomPhysics/interface/CustomParticle.h"
+#include "SimG4Core/CustomPhysics/interface/CustomParticleFactory.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 #include"G4ParticleTable.hh" 
 #include "Randomize.hh"
 
@@ -5,18 +14,11 @@
 #include<fstream>
 #include <string>
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "SimG4Core/CustomPhysics/interface/G4ProcessHelper.hh"
-#include "SimG4Core/CustomPhysics/interface/CustomPDGParser.h"
-#include "SimG4Core/CustomPhysics/interface/CustomParticle.h"
-#include "SimG4Core/CustomPhysics/interface/CustomParticleFactory.h"
-
 using namespace CLHEP;
 
-G4ProcessHelper::G4ProcessHelper(const edm::ParameterSet & p){
+G4ProcessHelper::G4ProcessHelper(const edm::ParameterSet & p, 
+                                 CustomParticleFactory* ptr) {
+  fParticleFactory = ptr;
 
   particleTable = G4ParticleTable::GetParticleTable();
 
@@ -95,7 +97,7 @@ G4ProcessHelper::G4ProcessHelper(const edm::ParameterSet & p){
 
   process_stream.close();
 
-  for(auto part : CustomParticleFactory::GetCustomParticles()) {
+  for(auto part : fParticleFactory->GetCustomParticles()) {
     CustomParticle* particle = dynamic_cast<CustomParticle*>(part);
     if(particle) {
       edm::LogInfo("SimG4CoreCustomPhysics")
@@ -104,6 +106,9 @@ G4ProcessHelper::G4ProcessHelper(const edm::ParameterSet & p){
 	<<" isStable: "<<particle->GetPDGStable();
     }
   }
+}
+
+G4ProcessHelper::~G4ProcessHelper(){
 }
 
 G4bool G4ProcessHelper::ApplicabilityTester(const G4ParticleDefinition& aPart){
@@ -292,7 +297,7 @@ ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4Particle
   }
   //  edm::LogInfo("SimG4CoreCustomPhysics")<<"The size of the ReactionProductList is: "<<theReactionProductList.size()<<G4endl;
 
-  if (theReactionProductList.size()==0) G4Exception("G4ProcessHelper", "NoProcessPossible", FatalException,
+  if (theReactionProductList.empty()) G4Exception("G4ProcessHelper", "NoProcessPossible", FatalException,
 						    "GetFinalState: No process could be selected from the given list.");
 
   // For the Regge model no phase space considerations. We pick a process at random


### PR DESCRIPTION
This is a back-port of developments/fixes accumulated in 10_2 for simulation of long-lived exotic particles. This update is needed for the multi-threaded mode and for cases when long lived SUSY particle decay outside vacuum chamber. 

Some modifications triggered by code-checks are also back-ported. 

Mainstream production will not be affected.