### PR TITLE
Renamed likely macro to avoid name collision

### DIFF
--- a/CondFormats/SiPixelObjects/src/SiPixelFrameConverter.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFrameConverter.cc
@@ -28,7 +28,7 @@ PixelROC const * SiPixelFrameConverter::toRoc(int link, int roc) const {
                                static_cast<unsigned int>(link),
                                static_cast<unsigned int>(roc)}; 
   const PixelROC * rocp = (theFed) ? theTree->findItemInFed(path, theFed) : theMap->findItem(path);
-  if unlikely(!rocp){
+  if UNLIKELY(!rocp){
     stringstream stm;
     stm << "Map shows no fed="<<theFedId
         <<", link="<< link

--- a/DataFormats/Phase2ITPixelCluster/interface/Phase2ITPixelCluster.h
+++ b/DataFormats/Phase2ITPixelCluster/interface/Phase2ITPixelCluster.h
@@ -192,7 +192,7 @@ public:
   
   /// mostly to be compatible for <610 
   void verifyVersion() const {
-    if unlikely( thePixelRow<MAXPOS && thePixelCol<MAXPOS)
+    if UNLIKELY( thePixelRow<MAXPOS && thePixelCol<MAXPOS)
 		 const_cast<Phase2ITPixelCluster*>(this)->computeMax();
   }
   

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -124,6 +124,7 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
+#include "FWCore/Utilities/interface/Likely.h"
 
 #include <utility>
 #include <algorithm>
@@ -505,7 +506,7 @@ template<typename I>
 bool HitPattern::appendHits(const I &begin, const I &end, const TrackerTopology& ttopo)
 {
     for (I hit = begin; hit != end; hit++) {
-      if unlikely((!appendHit(*hit, ttopo))) {
+      if UNLIKELY((!appendHit(*hit, ttopo))) {
             return false;
         }
     }
@@ -515,7 +516,7 @@ bool HitPattern::appendHits(const I &begin, const I &end, const TrackerTopology&
 inline uint16_t HitPattern::getHitPattern(HitCategory category, int position) const
 {
     std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
-    if unlikely((position < 0 || (position + range.first) >= range.second)) {
+    if UNLIKELY((position < 0 || (position + range.first) >= range.second)) {
         return HitPattern::EMPTY_PATTERN;
     }
 
@@ -563,7 +564,7 @@ inline int HitPattern::countTypedHits(HitCategory category, filterType typeFilte
 
 inline bool HitPattern::pixelHitFilter(uint16_t pattern)
 {
-    if unlikely(!trackerHitFilter(pattern)) {
+    if UNLIKELY(!trackerHitFilter(pattern)) {
         return false;
     }
 
@@ -574,7 +575,7 @@ inline bool HitPattern::pixelHitFilter(uint16_t pattern)
 
 inline bool HitPattern::pixelBarrelHitFilter(uint16_t pattern)
 {
-    if unlikely(!trackerHitFilter(pattern)) {
+    if UNLIKELY(!trackerHitFilter(pattern)) {
         return false;
     }
 
@@ -584,7 +585,7 @@ inline bool HitPattern::pixelBarrelHitFilter(uint16_t pattern)
 
 inline bool HitPattern::pixelEndcapHitFilter(uint16_t pattern)
 {
-    if unlikely(!trackerHitFilter(pattern)) {
+    if UNLIKELY(!trackerHitFilter(pattern)) {
         return false;
     }
 
@@ -600,7 +601,7 @@ inline bool HitPattern::stripHitFilter(uint16_t pattern)
 
 inline bool HitPattern::stripSubdetectorHitFilter(uint16_t pattern, StripSubdetector::SubDetector substructure)
 {
-    if unlikely(!trackerHitFilter(pattern)) {
+    if UNLIKELY(!trackerHitFilter(pattern)) {
         return false;
     }
 
@@ -629,7 +630,7 @@ inline bool HitPattern::stripTECHitFilter(uint16_t pattern)
 
 inline bool HitPattern::muonDTHitFilter(uint16_t pattern)
 {
-    if unlikely(!muonHitFilter(pattern)) {
+    if UNLIKELY(!muonHitFilter(pattern)) {
         return false;
     }
 
@@ -639,7 +640,7 @@ inline bool HitPattern::muonDTHitFilter(uint16_t pattern)
 
 inline bool HitPattern::muonCSCHitFilter(uint16_t pattern)
 {
-    if unlikely(!muonHitFilter(pattern)) {
+    if UNLIKELY(!muonHitFilter(pattern)) {
         return false;
     }
 
@@ -649,7 +650,7 @@ inline bool HitPattern::muonCSCHitFilter(uint16_t pattern)
 
 inline bool HitPattern::muonRPCHitFilter(uint16_t pattern)
 {
-    if unlikely(!muonHitFilter(pattern)) {
+    if UNLIKELY(!muonHitFilter(pattern)) {
         return false;
     }
 
@@ -659,7 +660,7 @@ inline bool HitPattern::muonRPCHitFilter(uint16_t pattern)
 
 inline bool HitPattern::muonGEMHitFilter(uint16_t pattern)
 { 
-    if  unlikely(!muonHitFilter(pattern)) {
+    if  UNLIKELY(!muonHitFilter(pattern)) {
          return false;
     }
 
@@ -668,7 +669,7 @@ inline bool HitPattern::muonGEMHitFilter(uint16_t pattern)
 }
 
 inline bool HitPattern::muonME0HitFilter(uint16_t pattern) { 
-  if  unlikely(!muonHitFilter(pattern)) return false;
+  if  UNLIKELY(!muonHitFilter(pattern)) return false;
   uint16_t substructure = getSubStructure(pattern);
   return (substructure == (uint16_t) MuonSubdetId::ME0);
 }
@@ -681,7 +682,7 @@ inline bool HitPattern::trackerHitFilter(uint16_t pattern)
 
 inline bool HitPattern::muonHitFilter(uint16_t pattern)
 {
-    if unlikely(pattern == HitPattern::EMPTY_PATTERN) {
+    if UNLIKELY(pattern == HitPattern::EMPTY_PATTERN) {
         return false;
     }
 
@@ -690,7 +691,7 @@ inline bool HitPattern::muonHitFilter(uint16_t pattern)
 
 inline uint32_t HitPattern::getSubStructure(uint16_t pattern)
 {
-    if unlikely(pattern == HitPattern::EMPTY_PATTERN) {
+    if UNLIKELY(pattern == HitPattern::EMPTY_PATTERN) {
         return NULL_RETURN;
     }
 
@@ -704,7 +705,7 @@ inline uint32_t HitPattern::getLayer(uint16_t pattern)
 
 inline uint32_t HitPattern::getSubSubStructure(uint16_t pattern)
 {
-    if unlikely(pattern == HitPattern::EMPTY_PATTERN) {
+    if UNLIKELY(pattern == HitPattern::EMPTY_PATTERN) {
         return NULL_RETURN;
     }
 
@@ -713,7 +714,7 @@ inline uint32_t HitPattern::getSubSubStructure(uint16_t pattern)
 
 inline uint32_t HitPattern::getSubDetector(uint16_t pattern)
 {
-    if unlikely(pattern == HitPattern::EMPTY_PATTERN) {
+    if UNLIKELY(pattern == HitPattern::EMPTY_PATTERN) {
         return NULL_RETURN;
     }
 
@@ -723,7 +724,7 @@ inline uint32_t HitPattern::getSubDetector(uint16_t pattern)
 
 inline uint32_t HitPattern::getSide(uint16_t pattern)
 {
-    if unlikely(pattern == HitPattern::EMPTY_PATTERN) {
+    if UNLIKELY(pattern == HitPattern::EMPTY_PATTERN) {
         return NULL_RETURN;
     }
 
@@ -732,7 +733,7 @@ inline uint32_t HitPattern::getSide(uint16_t pattern)
 
 inline uint32_t HitPattern::getHitType(uint16_t pattern)
 {
-    if unlikely(pattern == HitPattern::EMPTY_PATTERN) {
+    if UNLIKELY(pattern == HitPattern::EMPTY_PATTERN) {
         return NULL_RETURN;
     }
 
@@ -759,7 +760,7 @@ inline uint16_t HitPattern::getRPCLayer(uint16_t pattern)
     uint16_t subSubStructure = getSubSubStructure(pattern);
     uint16_t stat = subSubStructure >> 2;
 
-    if likely(stat <= 1) {
+    if LIKELY(stat <= 1) {
         return ((subSubStructure >> 1) & 1) + 1;
     }
 

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -8,6 +8,8 @@
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
+#include "FWCore/Utilities/interface/Likely.h"
+
 
 #include<bitset>
 
@@ -192,7 +194,7 @@ bool HitPattern::appendHit(const TrackingRecHit &hit, const TrackerTopology& tto
 bool HitPattern::appendHit(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo)
 {
     //if HitPattern is full, journey ends no matter what.
-    if unlikely((hitCount == HitPattern::MaxHits)) {
+    if UNLIKELY((hitCount == HitPattern::MaxHits)) {
         return false;
     }
 
@@ -204,7 +206,7 @@ bool HitPattern::appendHit(const DetId &id, TrackingRecHit::Type hitType, const 
 bool HitPattern::appendHit(const uint16_t pattern, TrackingRecHit::Type hitType)
 {
     //if HitPattern is full, journey ends no matter what.
-    if unlikely((hitCount == HitPattern::MaxHits)) {
+    if UNLIKELY((hitCount == HitPattern::MaxHits)) {
         return false;
     }
 
@@ -217,7 +219,7 @@ bool HitPattern::appendHit(const uint16_t pattern, TrackingRecHit::Type hitType)
         // 0 != beginT || 0 != endT => we already have hits of T type
         // so we already have hits of T in the vector and we don't want to
         // mess them with T' hits.
-        if unlikely(((hitCount != endTrackHits) && (0 != beginTrackHits || 0 != endTrackHits))) {
+        if UNLIKELY(((hitCount != endTrackHits) && (0 != beginTrackHits || 0 != endTrackHits))) {
             cms::Exception("HitPattern")
                     << "TRACK_HITS"
                     << " were stored on this object before hits of some other category were inserted "
@@ -231,7 +233,7 @@ bool HitPattern::appendHit(const uint16_t pattern, TrackingRecHit::Type hitType)
         break;
     case TrackingRecHit::inactive_inner:
     case TrackingRecHit::missing_inner:
-        if unlikely(((hitCount != endInner) && (0 != beginInner || 0 != endInner))) {
+        if UNLIKELY(((hitCount != endInner) && (0 != beginInner || 0 != endInner))) {
             cms::Exception("HitPattern")
                     << "MISSING_INNER_HITS"
                     << " were stored on this object before hits of some other category were inserted "
@@ -245,7 +247,7 @@ bool HitPattern::appendHit(const uint16_t pattern, TrackingRecHit::Type hitType)
         break;
     case TrackingRecHit::inactive_outer:
     case TrackingRecHit::missing_outer:
-        if unlikely(((hitCount != endOuter) && (0 != beginOuter || 0 != endOuter))) {
+        if UNLIKELY(((hitCount != endOuter) && (0 != beginOuter || 0 != endOuter))) {
             cms::Exception("HitPattern")
                     << "MISSING_OUTER_HITS"
                     << " were stored on this object before hits of some other category were inserted "
@@ -268,11 +270,11 @@ bool HitPattern::appendTrackerHit(uint16_t subdet, uint16_t layer, uint16_t ster
 
 bool HitPattern::appendMuonHit(const DetId& id, TrackingRecHit::Type hitType) {
     //if HitPattern is full, journey ends no matter what.
-    if unlikely((hitCount == HitPattern::MaxHits)) {
+    if UNLIKELY((hitCount == HitPattern::MaxHits)) {
         return false;
     }
 
-    if unlikely(id.det() != DetId::Muon) {
+    if UNLIKELY(id.det() != DetId::Muon) {
         throw cms::Exception("HitPattern") << "Got DetId from det " << id.det() << " that is not Muon in appendMuonHit(), which should only be used for muon hits in the HitPattern IO rule";
     }
 
@@ -283,7 +285,7 @@ bool HitPattern::appendMuonHit(const DetId& id, TrackingRecHit::Type hitType) {
 
 uint16_t HitPattern::getHitPatternByAbsoluteIndex(int position) const
 {
-    if unlikely((position < 0 || position >= hitCount)) {
+    if UNLIKELY((position < 0 || position >= hitCount)) {
         return HitPattern::EMPTY_PATTERN;
     }
     /*
@@ -502,7 +504,7 @@ int HitPattern::pixelLayersWithMeasurement() const {
    std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
    for (int i = range.first; i < range.second; ++i) {
      auto pattern = getHitPatternByAbsoluteIndex(i);
-     if unlikely(!trackerHitFilter(pattern)) continue;
+     if UNLIKELY(!trackerHitFilter(pattern)) continue;
      if (pattern>minStripWord) continue;
      uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
      if (hitType != HIT_TYPE::VALID) continue;
@@ -521,7 +523,7 @@ int HitPattern::trackerLayersWithMeasurement() const {
    std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
    for (int i = range.first; i < range.second; ++i) {
      auto pattern = getHitPatternByAbsoluteIndex(i);
-     if unlikely(!trackerHitFilter(pattern)) continue;
+     if UNLIKELY(!trackerHitFilter(pattern)) continue;
      uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
      if (hitType != HIT_TYPE::VALID) continue;
      pattern = (pattern-minTrackerWord) >> LayerOffset;
@@ -538,7 +540,7 @@ int HitPattern::trackerLayersWithoutMeasurement(HitCategory category) const {
    std::pair<uint8_t, uint8_t> range = getCategoryIndexRange(category);
    for (int i = range.first; i < range.second; ++i) {
      auto pattern = getHitPatternByAbsoluteIndex(i);
-     if unlikely(!trackerHitFilter(pattern)) continue;
+     if UNLIKELY(!trackerHitFilter(pattern)) continue;
      uint16_t hitType = (pattern >> HitTypeOffset) & HitTypeMask;
      pattern = (pattern-minTrackerWord) >> LayerOffset;
      // assert(pattern<128);
@@ -1015,7 +1017,7 @@ bool HitPattern::insertTrackHit(const uint16_t pattern)
     // empty index.
     // unlikely, because it will happen only when inserting
     // the first hit of this type
-    if unlikely((0 == beginTrackHits && 0 == endTrackHits)) {
+    if UNLIKELY((0 == beginTrackHits && 0 == endTrackHits)) {
         beginTrackHits = hitCount;
         // before the first hit of this type is inserted, there are no hits
         endTrackHits = beginTrackHits;
@@ -1029,7 +1031,7 @@ bool HitPattern::insertTrackHit(const uint16_t pattern)
 
 bool HitPattern::insertExpectedInnerHit(const uint16_t pattern)
 {
-    if unlikely((0 == beginInner && 0 == endInner)) {
+    if UNLIKELY((0 == beginInner && 0 == endInner)) {
         beginInner = hitCount;
         endInner = beginInner;
     }
@@ -1042,7 +1044,7 @@ bool HitPattern::insertExpectedInnerHit(const uint16_t pattern)
 
 bool HitPattern::insertExpectedOuterHit(const uint16_t pattern)
 {
-    if unlikely((0 == beginOuter && 0 == endOuter)) {
+    if UNLIKELY((0 == beginOuter && 0 == endOuter)) {
         beginOuter = hitCount;
         endOuter = beginOuter;
     }

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -118,7 +118,7 @@ void CTPPSPixelDataFormatter::interpretRawData(  bool& errorsInEvent, int fedId,
     LogTrace("")<<"DATA: " <<  print(*word);
 
     auto ww = *word;
-    if unlikely(ww==0) { m_WordCounter--; continue;}
+    if UNLIKELY(ww==0) { m_WordCounter--; continue;}
     int nlink = (ww >> m_LINK_shift) & m_LINK_mask; 
     int nroc  = (ww >> m_ROC_shift) & m_ROC_mask;
 
@@ -148,7 +148,7 @@ void CTPPSPixelDataFormatter::interpretRawData(  bool& errorsInEvent, int fedId,
     if ( (nlink!=link) | (nroc!=roc) ) {  // new roc
       link = nlink; roc=nroc;
 
-      skipROC = likely((roc-1)<maxRocIndex) ? false : !m_ErrorCheck.checkROC(errorsInEvent, fedId, iD,  ww, errors); 
+      skipROC = LIKELY((roc-1)<maxRocIndex) ? false : !m_ErrorCheck.checkROC(errorsInEvent, fedId, iD,  ww, errors); 
       if (skipROC) continue;
 
       auto rawId = rocp.rawId();

--- a/EventFilter/CTPPSRawToDigi/src/RPixErrorChecker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RPixErrorChecker.cc
@@ -81,7 +81,7 @@ bool RPixErrorChecker::checkTrailer(bool& errorsInEvent, int fedId, unsigned int
 bool RPixErrorChecker::checkROC(bool& errorsInEvent, int fedId, uint32_t iD, const Word32& errorWord,  Errors& errors) const
 {
   int errorType = (errorWord >> ROC_shift) & ERROR_mask;
-  if likely(errorType<25) return true;
+  if LIKELY(errorType<25) return true;
 
   switch (errorType) {
   case(25) : {

--- a/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
+++ b/EventFilter/SiPixelRawToDigi/src/ErrorChecker.cc
@@ -116,7 +116,7 @@ bool ErrorChecker::checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameCo
 			    const SiPixelFedCabling* theCablingTree, Word32& errorWord, Errors& errors)
 {
   int errorType = (errorWord >> ROC_shift) & ERROR_mask;
-  if likely(errorType<25) return true;
+  if LIKELY(errorType<25) return true;
 
  switch (errorType) {
     case(25) : {

--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -175,7 +175,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
     LogTrace("")<<"DATA: " <<  print(*word);
 
     auto ww = *word;
-    if unlikely(ww==0) { theWordCounter--; continue;}
+    if UNLIKELY(ww==0) { theWordCounter--; continue;}
     int nlink = (ww >> LINK_shift) & LINK_mask; 
     int nroc  = (ww >> ROC_shift) & ROC_mask;
 
@@ -183,10 +183,10 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 
     if ( (nlink!=link) | (nroc!=roc) ) {  // new roc
       link = nlink; roc=nroc;
-      skipROC = likely(roc<maxROCIndex) ? false : !errorcheck.checkROC(errorsInEvent, fedId, &converter, theCablingTree, ww, errors);
+      skipROC = LIKELY(roc<maxROCIndex) ? false : !errorcheck.checkROC(errorsInEvent, fedId, &converter, theCablingTree, ww, errors);
       if (skipROC) continue;
       rocp = converter.toRoc(link,roc);
-      if unlikely(!rocp) {
+      if UNLIKELY(!rocp) {
 	errorsInEvent = true;
 	errorcheck.conversionError(fedId, &converter, 2, ww, errors);
 	skipROC=true;
@@ -213,7 +213,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
     }
 
     // skip is roc to be skipped ot invalid
-    if unlikely(skipROC || !rocp) continue;
+    if UNLIKELY(skipROC || !rocp) continue;
     
     int adc  = (ww >> ADC_shift) & ADC_mask;
     std::unique_ptr<LocalPixel> local;
@@ -227,7 +227,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 
       LocalPixel::RocRowCol localCR = { row, col }; // build pixel
       //if(DANEK)cout<<localCR.rocCol<<" "<<localCR.rocRow<<endl;
-      if unlikely(!localCR.valid()) {
+      if UNLIKELY(!localCR.valid()) {
 	  LogDebug("PixelDataFormatter::interpretRawData") 
 	    << "status #3";
 	  errorsInEvent = true;
@@ -246,7 +246,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
       LocalPixel::DcolPxid localDP = { dcol, pxid };
       //if(DANEK) cout<<localDP.dcol<<" "<<localDP.pxid<<endl;
 
-      if unlikely(!localDP.valid()) {
+      if UNLIKELY(!localDP.valid()) {
 	  LogDebug("PixelDataFormatter::interpretRawData") 
 	    << "status #3";
 	  errorsInEvent = true;

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
@@ -97,7 +97,7 @@ namespace sistrip {
     uint16_t offsetBeginningOfChannel = 0;
     for (uint16_t i = 0; i < FEDCH_PER_FED; i++) {
       //if FE unit is not enabled then skip rest of FE unit adding NULL pointers
-      if unlikely( !(fePresent(i/FEDCH_PER_FEUNIT) && feEnabled(i/FEDCH_PER_FEUNIT)) ) {
+      if UNLIKELY( !(fePresent(i/FEDCH_PER_FEUNIT) && feEnabled(i/FEDCH_PER_FEUNIT)) ) {
 	channels_.insert(channels_.end(),uint16_t(FEDCH_PER_FEUNIT),FEDChannel(payloadPointer_,0,0));
 	i += FEDCH_PER_FEUNIT-1;
 	validChannels_ += FEDCH_PER_FEUNIT;
@@ -105,7 +105,7 @@ namespace sistrip {
       }
       //if FE unit is enabled
       //check that channel length bytes fit into buffer
-      if unlikely(offsetBeginningOfChannel+1 >= payloadLength_) {
+      if UNLIKELY(offsetBeginningOfChannel+1 >= payloadLength_) {
 	std::ostringstream ss;
         SiStripFedKey key(0,i/FEDCH_PER_FEUNIT,i%FEDCH_PER_FEUNIT);
         ss << "Channel " << uint16_t(i) << " (FE unit " << key.feUnit() << " channel " << key.feChan() << " according to external numbering scheme)" 
@@ -120,7 +120,7 @@ namespace sistrip {
       uint16_t channelLength = channels_.back().length();
 
       //check that the channel length is long enough to contain the header
-      if unlikely(channelLength < minLength) {
+      if UNLIKELY(channelLength < minLength) {
         SiStripFedKey key(0,i/FEDCH_PER_FEUNIT,i%FEDCH_PER_FEUNIT);
         std::ostringstream ss;
         ss << "Channel " << uint16_t(i) << " (FE unit " << key.feUnit() << " channel " << key.feChan() << " according to external numbering scheme)"
@@ -130,7 +130,7 @@ namespace sistrip {
            << "Min length is " << uint16_t(minLength) << ". ";
         throw cms::Exception("FEDBuffer") << ss.str();
       }
-      if unlikely(offsetBeginningOfChannel+channelLength > payloadLength_) {
+      if UNLIKELY(offsetBeginningOfChannel+channelLength > payloadLength_) {
         SiStripFedKey key(0,i/FEDCH_PER_FEUNIT,i%FEDCH_PER_FEUNIT);
 	std::ostringstream ss;
         ss << "Channel " << uint16_t(i) << " (FE unit " << key.feUnit() << " channel " << key.feChan() << " according to external numbering scheme)" 

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -545,7 +545,7 @@ namespace evf{
   {
     //make sure that all path names are retrieved before allowing ministate to change
     //hack: assume memory is synchronized after ~50 events seen by each stream
-    if (unlikely(eventCountForPathInit_[sc.streamID()]<50) && false==collectedPathList_[sc.streamID()]->load(std::memory_order_acquire))
+    if (UNLIKELY(eventCountForPathInit_[sc.streamID()]<50) && false==collectedPathList_[sc.streamID()]->load(std::memory_order_acquire))
     {
       //protection between stream threads, as well as the service monitoring thread
       std::lock_guard<std::mutex> lock(fmt_.monlock_);

--- a/FWCore/Concurrency/src/SerialTaskQueue.cc
+++ b/FWCore/Concurrency/src/SerialTaskQueue.cc
@@ -56,7 +56,7 @@ SerialTaskQueue::pushTask(TaskBase* iTask) {
 tbb::task* 
 SerialTaskQueue::pushAndGetNextTask(TaskBase* iTask) {
   tbb::task* returnValue{nullptr};
-  if likely(nullptr!=iTask) {
+  if LIKELY(nullptr!=iTask) {
     m_tasks.push(iTask);
     returnValue = pickNextTask();
   }
@@ -74,9 +74,9 @@ SerialTaskQueue::TaskBase*
 SerialTaskQueue::pickNextTask() {
   
   bool expect = false;
-  if likely(0 == m_pauseCount and m_taskChosen.compare_exchange_strong(expect,true)) {
+  if LIKELY(0 == m_pauseCount and m_taskChosen.compare_exchange_strong(expect,true)) {
     TaskBase* t=nullptr;
-    if likely(m_tasks.try_pop(t)) {
+    if LIKELY(m_tasks.try_pop(t)) {
       return t;
     }
     //no task was actually pulled
@@ -99,8 +99,8 @@ SerialTaskQueue::pickNextTask() {
 
 void SerialTaskQueue::pushAndWait(tbb::empty_task* iWait, TaskBase* iTask) {
    auto nextTask = pushAndGetNextTask(iTask);
-   if likely(nullptr != nextTask) {
-     if likely(nextTask == iTask) {
+   if LIKELY(nullptr != nextTask) {
+     if LIKELY(nextTask == iTask) {
         //spawn and wait for all requires the task to have its parent set
         iWait->spawn_and_wait_for_all(*nextTask);
      } else {

--- a/FWCore/Concurrency/src/WaitingTaskList.cc
+++ b/FWCore/Concurrency/src/WaitingTaskList.cc
@@ -96,7 +96,7 @@ void
 WaitingTaskList::add(WaitingTask* iTask) {
   iTask->increment_ref_count();
   if(!m_waiting) {
-    if(unlikely(bool(m_exceptionPtr))) {
+    if(UNLIKELY(bool(m_exceptionPtr))) {
       iTask->dependentTaskFailed(m_exceptionPtr);
     }
     if(0==iTask->decrement_ref_count()) {
@@ -145,7 +145,7 @@ WaitingTaskList::announce()
       hardware_pause();
     }
     auto t = n->m_task;
-    if(unlikely(bool(m_exceptionPtr))) {
+    if(UNLIKELY(bool(m_exceptionPtr))) {
       t->dependentTaskFailed(m_exceptionPtr);
     }
     if(0==t->decrement_ref_count()){

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -39,6 +39,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/Likely.h"
 
 #include <memory>
 #include <string>
@@ -393,7 +394,7 @@ namespace edm {
   template<typename PROD>
   OrphanHandle<PROD>
   Event::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
-    if(unlikely(product.get() == nullptr)) {                // null pointer is illegal
+    if(UNLIKELY(product.get() == nullptr)) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, productInstanceName);
     }
@@ -406,11 +407,11 @@ namespace edm {
   template<typename PROD>
   OrphanHandle<PROD>
   Event::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
-    if(unlikely(product.get() == 0)) {                // null pointer is illegal
+    if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
     }
-    if(unlikely(token.isUninitialized())) {
+    if(UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
     return putImpl(token.index(),std::move(product));
@@ -419,14 +420,14 @@ namespace edm {
   template<typename PROD>
   OrphanHandle<PROD>
   Event::put(EDPutToken token, std::unique_ptr<PROD> product) {
-    if(unlikely(product.get() == 0)) {                // null pointer is illegal
+    if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
     }
-    if(unlikely(token.isUninitialized())) {
+    if(UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
-    if(unlikely(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+    if(UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
       principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
     }
 
@@ -449,7 +450,7 @@ namespace edm {
   RefProd<PROD>
   Event::getRefBeforePut(EDPutTokenT<PROD> token)
   {
-    if(unlikely(token.isUninitialized())) {
+    if(UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
    return RefProd<PROD>(provRecorder_.getProductID(token.index()),
@@ -460,10 +461,10 @@ namespace edm {
   RefProd<PROD>
   Event::getRefBeforePut(EDPutToken token)
   {
-    if(unlikely(token.isUninitialized())) {
+    if(UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
-    if(unlikely(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+    if(UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
       principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
     }
     return RefProd<PROD>(provRecorder_.getProductID(token.index()),

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -27,6 +27,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/Likely.h"
 
 #include <memory>
 #include <string>
@@ -193,7 +194,7 @@ namespace edm {
   template <typename PROD>
   void
   LuminosityBlock::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
-    if(unlikely(product.get() == nullptr)) {                // null pointer is illegal
+    if(UNLIKELY(product.get() == nullptr)) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID, productInstanceName);
     }
@@ -205,11 +206,11 @@ namespace edm {
   template<typename PROD>
   void
   LuminosityBlock::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
-    if(unlikely(product.get() == 0)) {                // null pointer is illegal
+    if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
     }
-    if(unlikely(token.isUninitialized())) {
+    if(UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
     putImpl(token.index(),std::move(product));
@@ -218,14 +219,14 @@ namespace edm {
   template<typename PROD>
   void
   LuminosityBlock::put(EDPutToken token, std::unique_ptr<PROD> product) {
-    if(unlikely(product.get() == 0)) {                // null pointer is illegal
+    if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
     }
-    if(unlikely(token.isUninitialized())) {
+    if(UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
-    if(unlikely(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+    if(UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
       principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
     }
     

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -25,6 +25,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Utilities/interface/EDPutToken.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
+#include "FWCore/Utilities/interface/Likely.h"
 
 #include <memory>
 #include <string>
@@ -204,7 +205,7 @@ namespace edm {
   template <typename PROD>
   void
   Run::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
-    if(unlikely(product.get() == nullptr)) {                // null pointer is illegal
+    if(UNLIKELY(product.get() == nullptr)) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID, productInstanceName);
     }
@@ -216,11 +217,11 @@ namespace edm {
   template<typename PROD>
   void
   Run::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
-    if(unlikely(product.get() == 0)) {                // null pointer is illegal
+    if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
     }
-    if(unlikely(token.isUninitialized())) {
+    if(UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
     putImpl(token.index(),std::move(product));
@@ -229,14 +230,14 @@ namespace edm {
   template<typename PROD>
   void
   Run::put(EDPutToken token, std::unique_ptr<PROD> product) {
-    if(unlikely(product.get() == 0)) {                // null pointer is illegal
+    if(UNLIKELY(product.get() == 0)) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
     }
-    if(unlikely(token.isUninitialized())) {
+    if(UNLIKELY(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
-    if(unlikely(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+    if(UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
       principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
     }
     

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -203,12 +203,12 @@ EDConsumerBase::updateLookup(BranchType iBranchType,
 ProductResolverIndexAndSkipBit
 EDConsumerBase::indexFrom(EDGetToken iToken, BranchType iBranch, TypeID const& iType) const
 {
-  if(unlikely(iToken.index()>=m_tokenInfo.size())) {
+  if(UNLIKELY(iToken.index()>=m_tokenInfo.size())) {
     throwBadToken(iType,iToken);
   }
   const auto& info = m_tokenInfo.get<kLookupInfo>(iToken.index());
-  if (likely(iBranch == info.m_branchType)) {
-    if (likely(iType == info.m_type)) {
+  if (LIKELY(iBranch == info.m_branchType)) {
+    if (LIKELY(iType == info.m_type)) {
       return info.m_index;
     } else {
       throwTypeMismatch(iType, iToken);

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -17,6 +17,7 @@
 #include "FWCore/Utilities/interface/ProductResolverIndex.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/WrappedClassName.h"
+#include "FWCore/Utilities/interface/Likely.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -602,7 +603,7 @@ namespace edm {
 
     assert(results.empty());
 
-    if(unlikely(consumer and (not consumer->registeredToConsumeMany(typeID,branchType())))) {
+    if(UNLIKELY(consumer and (not consumer->registeredToConsumeMany(typeID,branchType())))) {
       failedToRegisterConsumesMany(typeID);
     }
 
@@ -729,7 +730,7 @@ namespace edm {
       }
       inputTag.tryToCacheIndex(index, typeID, branchType(), &productRegistry());
     }
-    if(unlikely( consumer and (not consumer->registeredToConsume(index, skipCurrentProcess, branchType())))) {
+    if(UNLIKELY( consumer and (not consumer->registeredToConsume(index, skipCurrentProcess, branchType())))) {
       failedToRegisterConsumes(kindOfType,typeID,inputTag.label(),inputTag.instance(),
                                appendCurrentProcessIfAlias(inputTag.process(), processConfiguration_->processName()));
     }
@@ -767,7 +768,7 @@ namespace edm {
       return nullptr;
     }
     
-    if(unlikely( consumer and (not consumer->registeredToConsume(index, false, branchType())))) {
+    if(UNLIKELY( consumer and (not consumer->registeredToConsume(index, false, branchType())))) {
       failedToRegisterConsumes(kindOfType,typeID,label,instance,process);
     }
     

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/Principal.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
+#include "FWCore/Utilities/interface/Likely.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
 #include "DataFormats/Common/interface/FunctorHandleExceptionFactory.h"
@@ -196,9 +197,9 @@ namespace edm {
     ProductResolverIndexAndSkipBit indexAndBit = consumer_->indexFrom(token,branchType(),id);
     ProductResolverIndex index = indexAndBit.productResolverIndex();
     bool skipCurrentProcess = indexAndBit.skipCurrentProcess();
-    if( unlikely(index == ProductResolverIndexInvalid)) {
+    if( UNLIKELY(index == ProductResolverIndexInvalid)) {
       return makeFailToGetException(kindOfType,id,token);
-    } else if( unlikely(index == ProductResolverIndexAmbiguous)) {
+    } else if( UNLIKELY(index == ProductResolverIndexAmbiguous)) {
       // This deals with ambiguities where the process is specified
       throwAmbiguousException(id, token);
     }
@@ -279,7 +280,7 @@ namespace edm {
                                             std::string const& productInstanceName) const {
     ProductResolverIndexHelper const& productResolverIndexHelper = principal_.productLookup();
     ProductResolverIndex index = productResolverIndexHelper.index(PRODUCT_TYPE, type, md_.moduleLabel().c_str(),productInstanceName.c_str(), md_.processName().c_str());
-    if(unlikely(index == ProductResolverIndexInvalid)) {
+    if(UNLIKELY(index == ProductResolverIndexInvalid)) {
       throwUnregisteredPutException(type, productInstanceName);
     }
     ProductResolverBase const*  phb = principal_.getProductResolverByIndex(index);
@@ -307,7 +308,7 @@ namespace edm {
 
   Transition
   PrincipalGetAdapter::transition() const {
-    if(likely(principal().branchType() == InEvent)) {
+    if(LIKELY(principal().branchType() == InEvent)) {
       return Transition::Event;
     }
     if(principal().branchType() == InRun) {

--- a/FWCore/Utilities/interface/Likely.h
+++ b/FWCore/Utilities/interface/Likely.h
@@ -5,20 +5,20 @@
 #if GCC_PREREQUISITE(3,0,0)
 
 #if defined(NO_LIKELY)
-#define likely(x) (x)
-#define unlikely(x) (x)   
+#define LIKELY(x) (x)
+#define UNLIKELY(x) (x)   
 #elif defined(REVERSE_LIKELY)
-#define unlikely(x) (__builtin_expect(x, true))
-#define likely(x) (__builtin_expect(x, false))
+#define UNLIKELY(x) (__builtin_expect(x, true))
+#define LIKELY(x) (__builtin_expect(x, false))
 #else
-#define likely(x) (__builtin_expect(x, true))
-#define unlikely(x) (__builtin_expect(x, false))
+#define LIKELY(x) (__builtin_expect(x, true))
+#define UNLIKELY(x) (__builtin_expect(x, false))
 #endif
 
 #else
 #define NO_LIKELY
-#define likely(x) (x)  
-#define unlikely(x) (x)
+#define LIKELY(x) (x)  
+#define UNLIKELY(x) (x)
 #endif
 
 #endif

--- a/FWCore/Utilities/test/likely_t.cpp
+++ b/FWCore/Utilities/test/likely_t.cpp
@@ -6,16 +6,16 @@
 namespace {
   bool test(int n) {
     bool ret=true;
-    if (likely(n>1)) ret&=true; 
+    if (LIKELY(n>1)) ret&=true; 
     else
       ret=false;
     
-    if (unlikely(n>1)) ret&=true;
+    if (UNLIKELY(n>1)) ret&=true;
     else
       ret =false;
 
-    ret &=likely(n>1);
-    ret &=unlikely(n>1);
+    ret &=LIKELY(n>1);
+    ret &=UNLIKELY(n>1);
     return ret;
   }
 }

--- a/Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h
@@ -121,7 +121,7 @@ public:
   } 
 
   bool isItBigPixelInY( const int iybin ) const override {
-      if unlikely( m_upgradeGeometry ) return false;
+      if UNLIKELY( m_upgradeGeometry ) return false;
       else {
 	int iybin0 = iybin%52;
  	return(( iybin0 == 0 ) | ( iybin0 == 51 ));

--- a/Geometry/TrackerGeometryBuilder/src/RectangularPixelTopology.cc
+++ b/Geometry/TrackerGeometryBuilder/src/RectangularPixelTopology.cc
@@ -220,7 +220,7 @@ RectangularPixelTopology::localX( const float mpx ) const
   float fractionX = mpx - float(binoffx); // find the fraction 
   float local_pitchx = m_pitchx;   // defaultpitch
 
-  if unlikely( m_upgradeGeometry ) {
+  if UNLIKELY( m_upgradeGeometry ) {
 #ifdef EDM_ML_DEBUG
     if( binoffx > m_ROWS_PER_ROC * m_ROCS_X ) // too large
     {
@@ -276,7 +276,7 @@ RectangularPixelTopology::localY( const float mpy ) const
   float fractionY = mpy - float(binoffy); // find the fraction 
   float local_pitchy = m_pitchy;   // defaultpitch
 
-  if unlikely( m_upgradeGeometry ){
+  if UNLIKELY( m_upgradeGeometry ){
  #ifdef EDM_ML_DEBUG
    if( binoffy > m_ROCS_Y * m_COLS_PER_ROC )   // too large
       {
@@ -335,7 +335,7 @@ RectangularPixelTopology::measurementError( const LocalPoint& lp,
   float pitchy=m_pitchy;
   float pitchx=m_pitchx;
 
-  if likely( !m_upgradeGeometry ) {    
+  if LIKELY( !m_upgradeGeometry ) {    
       int iybin = int( (lp.y() - m_yoffset)/m_pitchy );   //get bin for equal picth 
       int iybin0 = iybin%54;  //This is just to avoid many ifs by using the periodicy
       //quasi bins 0,1,52,53 fall into larger pixels  

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -1060,7 +1060,7 @@ void CaloTowersCreationAlgo::convert(const CaloTowerDetId& id, const MetaTower& 
     
     
     // insert in collection (remove and return if below threshold)
-    if unlikely ( (towerP4[3]==0) & (E_outer>0)  ) {
+    if UNLIKELY ( (towerP4[3]==0) & (E_outer>0)  ) {
         float val = theHOIsUsed ? 0 : 1E-9; // to keep backwards compatibility for theHOIsUsed == true
         collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, CaloTower::PolarLorentzVector(val,hadPoint.eta(), hadPoint.phi(),0),  emPoint, hadPoint); 
     } else {

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -321,7 +321,7 @@ PixelCPEClusterRepair::callTempReco2D( DetParam const & theDetParam,
    // ******************************************************************
    
    //--- Check exit status
-   if unlikely( theClusterParam.ierr != 0 )
+   if UNLIKELY( theClusterParam.ierr != 0 )
    {
       LogDebug("PixelCPEClusterRepair::localPosition") <<
       "reconstruction failed with error " << theClusterParam.ierr << "\n";
@@ -441,7 +441,7 @@ PixelCPEClusterRepair::callTempReco3D( DetParam const & theDetParam,
    // ******************************************************************
    
    //--- Check exit status
-   if unlikely( theClusterParam.ierr2 != 0 )
+   if UNLIKELY( theClusterParam.ierr2 != 0 )
    {
       LogDebug("PixelCPEClusterRepair::localPosition") <<
       "3D reconstruction failed with error " << theClusterParam.ierr2 << "\n";
@@ -502,11 +502,11 @@ PixelCPEClusterRepair::localError(DetParam const & theDetParam,  ClusterParam & 
    float xerr = 0.0f, yerr = 0.0f;
 
    //--- Check status of both template calls.
-   if unlikely ( (theClusterParam.ierr !=0) || (theClusterParam.ierr2 !=0) ) {
+   if UNLIKELY ( (theClusterParam.ierr !=0) || (theClusterParam.ierr2 !=0) ) {
      // If reconstruction fails the hit position is calculated from cluster center of gravity
      // corrected in x by average Lorentz drift. Assign huge errors.
      //
-     if unlikely (!GeomDetEnumerators::isTrackerPixel(theDetParam.thePart))
+     if UNLIKELY (!GeomDetEnumerators::isTrackerPixel(theDetParam.thePart))
        throw cms::Exception("PixelCPEClusterRepair::localPosition :")
 	 << "A non-pixel detector type in here?";
      

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -615,7 +615,7 @@ PixelCPEGeneric::localError(DetParam const & theDetParam,  ClusterParam & theClu
          <<sizex<<" "<<sizey<<endl;
    }
    
-   if likely(UseErrorsFromTemplates_ ) {
+   if LIKELY(UseErrorsFromTemplates_ ) {
       //
       // Use template errors
       //cout << "Track angles are known. We can use either errors from templates or the error parameterization from DB." << endl;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -257,7 +257,7 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
    // ******************************************************************
    
    // Check exit status
-   if unlikely( theClusterParam.ierr != 0 )
+   if UNLIKELY( theClusterParam.ierr != 0 )
    {
       LogDebug("PixelCPETemplateReco::localPosition") <<
       "reconstruction failed with error " << theClusterParam.ierr << "\n";
@@ -286,7 +286,7 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
          theClusterParam.templYrec_ = theDetParam.theTopol->localY( theClusterParam.theCluster->y() );
       }
    }
-   else if unlikely( UseClusterSplitter_ && theClusterParam.templQbin_ == 0 )
+   else if UNLIKELY( UseClusterSplitter_ && theClusterParam.templQbin_ == 0 )
    {
       cout << " PixelCPETemplateReco : We should never be here !!!!!!!!!!!!!!!!!!!!!!" << endl;
       cout << "                 (int)UseClusterSplitter_ = " << (int)UseClusterSplitter_ << endl;

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -51,7 +51,7 @@ namespace {
     const FEDRawData& rawData = rawColl.FEDData(fedId);
     
     // Check on FEDRawData pointer
-    if unlikely( !rawData.data() ) {
+    if UNLIKELY( !rawData.data() ) {
 	if (edm::isDebugEnabled()) {
 	  edm::LogWarning(sistrip::mlRawToCluster_)
 	    << "[ClustersFromRawProducer::" 
@@ -64,7 +64,7 @@ namespace {
       }	
     
     // Check on FEDRawData size
-    if unlikely( !rawData.size() ) {
+    if UNLIKELY( !rawData.size() ) {
 	if (edm::isDebugEnabled()) {
 	  edm::LogWarning(sistrip::mlRawToCluster_)
 	    << "[ClustersFromRawProducer::" 
@@ -78,7 +78,7 @@ namespace {
     // construct FEDBuffer
     try {
       buffer.reset(new sistrip::FEDBuffer(rawData.data(),rawData.size()));
-      if unlikely(!buffer->doChecks(false)) throw cms::Exception("FEDBuffer") << "FED Buffer check fails for FED ID" << fedId << ".";
+      if UNLIKELY(!buffer->doChecks(false)) throw cms::Exception("FEDBuffer") << "FED Buffer check fails for FED ID" << fedId << ".";
     }
     catch (const cms::Exception& e) { 
       if (edm::isDebugEnabled()) {
@@ -311,12 +311,12 @@ try { // edmNew::CapacityExaustedException
 
   // Loop over apv-pairs of det
   for (auto const conn : clusterizer.currentConnection(det)) {
-    if unlikely(!conn) continue;
+    if UNLIKELY(!conn) continue;
     
     const uint16_t fedId = conn->fedId();
     
     // If fed id is null or connection is invalid continue
-    if unlikely( !fedId || !conn->isConnected() ) { continue; }    
+    if UNLIKELY( !fedId || !conn->isConnected() ) { continue; }    
     
 
     // If Fed hasnt already been initialised, extract data and initialise
@@ -333,7 +333,7 @@ try { // edmNew::CapacityExaustedException
     // check channel
     const uint8_t fedCh = conn->fedCh();
     
-    if unlikely(!buffer->channelGood(fedCh,doAPVEmulatorCheck)) {
+    if UNLIKELY(!buffer->channelGood(fedCh,doAPVEmulatorCheck)) {
 	if (edm::isDebugEnabled()) {
 	  std::ostringstream ss;
 	  ss << "Problem unpacking channel " << fedCh << " on FED " << fedId;
@@ -349,7 +349,7 @@ try { // edmNew::CapacityExaustedException
     const sistrip::FEDReadoutMode mode = buffer->readoutMode();
     
     
-    if likely(mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_LITE10 || mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_LITE8) { 
+    if LIKELY(mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_LITE10 || mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_LITE8) { 
 	
 	try {
 	  // create unpacker

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
@@ -38,7 +38,7 @@ float StripCPEfromTrackAngle::stripErrorSquared(const unsigned N, const float uP
 
 
 float StripCPEfromTrackAngle::legacyStripErrorSquared(const unsigned N, const float uProj) const {
-  if unlikely( (float(N)-uProj) > 3.5f )
+  if UNLIKELY( (float(N)-uProj) > 3.5f )
     return float(N*N)/12.f;
   else {
     static constexpr float P1=-0.339;

--- a/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
@@ -304,12 +304,12 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
       auto const & hit = (*recHitCollection)[ih];
       auto hits = MuonTrackLoader::unpackHit(hit);
       for (auto hh : hits) {
-          if unlikely(!track.appendHitPattern(*hh, ttopo)) break;
+          if UNLIKELY(!track.appendHitPattern(*hh, ttopo)) break;
       }
  
       if(theUpdatingAtVtx && updateResult.first){
         for (auto hh : hits) {
-              if unlikely(!updateResult.second.appendHitPattern(*hh, ttopo)) break;
+              if UNLIKELY(!updateResult.second.appendHitPattern(*hh, ttopo)) break;
         }
       }
     }
@@ -630,12 +630,12 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
       auto const & hit = (*recHitCollection)[ih];
       auto hits = MuonTrackLoader::unpackHit(hit);
       for (auto hh : hits) {
-          if unlikely(!track.appendHitPattern(*hh, ttopo)) break;
+          if UNLIKELY(!track.appendHitPattern(*hh, ttopo)) break;
       }
  
       if(theUpdatingAtVtx && updateResult.first){
         for (auto hh : hits) {
-              if unlikely(!updateResult.second.appendHitPattern(*hh, ttopo)) break;
+              if UNLIKELY(!updateResult.second.appendHitPattern(*hh, ttopo)) break;
         }
       }
     }

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -72,7 +72,7 @@ calculateAndSetPositionActual(reco::PFCluster& cluster) const {
     const auto rh_rawenergy = rhf.energy;
     const auto rh_energy = rh_rawenergy * rh_fraction;   
 #ifdef PF_DEBUG
-    if unlikely( edm::isNotFinite(rh_energy) ) {
+    if UNLIKELY( edm::isNotFinite(rh_energy) ) {
       throw cms::Exception("PFClusterAlgo")
 	<<"rechit " << refhit.detId() << " has a NaN energy... " 
 	<< "The input of the particle flow clustering seems to be corrupted.";

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -136,7 +136,7 @@ std::unique_ptr<reco::Track> PixelFitterByHelixProjections::run(
   float curvature = circle.curvature();
 
   if ((curvature > 1.e-4)&&
-	(likely(PixelRecoUtilities::fieldInInvGev(*theES)>0.01))) {
+	(LIKELY(PixelRecoUtilities::fieldInInvGev(*theES)>0.01))) {
     float invPt = PixelRecoUtilities::inversePt( circle.curvature(), *theES);
     valPt = (invPt > 1.e-4f) ? 1.f/invPt : 1.e4f;
     CircleFromThreePoints::Vector2D center = circle.center();

--- a/RecoPixelVertexing/PixelTriplets/src/ThirdHitPredictionFromCircle.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/ThirdHitPredictionFromCircle.cc
@@ -50,7 +50,7 @@ ThirdHitPredictionFromCircle::ThirdHitPredictionFromCircle(
 float ThirdHitPredictionFromCircle::phi(float curvature, float radius) const
 {
   float phi;
-  if (unlikely(std::abs(curvature) < float(1.0e-5))) {
+  if (UNLIKELY(std::abs(curvature) < float(1.0e-5))) {
     float cos = (center * axis) / radius;
     phi = axis.phi() - clamped_acos(cos);
   } else {
@@ -68,7 +68,7 @@ float ThirdHitPredictionFromCircle::phi(float curvature, float radius) const
 
 float ThirdHitPredictionFromCircle::angle(float curvature, float radius) const
 {
-  if (unlikely(std::abs(curvature) < float(1.0e-5))) {
+  if (UNLIKELY(std::abs(curvature) < float(1.0e-5))) {
     float sin = (center * axis) / radius;
     return sin / clamped_sqrt(1 - sqr(sin));
   } else {
@@ -119,11 +119,11 @@ ThirdHitPredictionFromCircle::curvature(double transverseIP) const
   constexpr double SMALL = 1.0e-23;
   constexpr double LARGE = 1.0e23;
 
-  if (unlikely(tmp4 - tmp5 < 1.0e-15)) {
+  if (UNLIKELY(tmp4 - tmp5 < 1.0e-15)) {
     u1 = -SMALL;
     u2 = +SMALL;
   } else {
-    if (unlikely(std::abs(tmp2) < 1.0e-15)) {
+    if (UNLIKELY(std::abs(tmp2) < 1.0e-15)) {
       // the denominator is zero
       // this means that one of the tracks will be straight
       // and the other can be computed from the limit of the equation
@@ -134,7 +134,7 @@ ThirdHitPredictionFromCircle::curvature(double transverseIP) const
         std::swap(u1, u2);
     } else {
       double tmp6 = (tmp4 - tmp5) * (tmp4 + tmp5);
-      if (unlikely(tmp6 < 1.0e-15)) {
+      if (UNLIKELY(tmp6 < 1.0e-15)) {
         u1 = -SMALL;
         u2 = +SMALL;
       } else {
@@ -180,7 +180,7 @@ double ThirdHitPredictionFromCircle::curvature(const Vector2D &p2) const
 double ThirdHitPredictionFromCircle::transverseIP(const Vector2D &p2) const
 {
   double invDist = invCenterOnAxis(p2);
-  if (unlikely(std::abs(invDist) < 1.0e-5))
+  if (UNLIKELY(std::abs(invDist) < 1.0e-5))
     return std::abs(p2 * axis);
   else {
     double dist = 1.0 / invDist;
@@ -225,7 +225,7 @@ double ThirdHitPredictionFromCircle::HelixRZ::maxCurvature(
 {
   constexpr double maxAngle = M_PI;
   double halfAngle = (0.5 * maxAngle) * (z2 - z1) / (z3 - z1);
-  if (unlikely(halfAngle <= 0.0))
+  if (UNLIKELY(halfAngle <= 0.0))
     return 0.0;
 
   return std::sin(halfAngle) / circle->delta;
@@ -234,7 +234,7 @@ double ThirdHitPredictionFromCircle::HelixRZ::maxCurvature(
 
 ThirdHitPredictionFromCircle::HelixRZ::Scalar
 ThirdHitPredictionFromCircle::HelixRZ::zAtR(Scalar r) const {
-  if (unlikely(std::abs(curvature) < 1.0e-5)) {
+  if (UNLIKELY(std::abs(curvature) < 1.0e-5)) {
      Scalar tip = circle->axis * circle->p1;
      Scalar lip = circle->axis.y() * circle->p1.x() -
                   circle->axis.x() * circle->p1.y();
@@ -265,10 +265,10 @@ ThirdHitPredictionFromCircle::HelixRZ::zAtR(Scalar r) const {
 
 ThirdHitPredictionFromCircle::HelixRZ::Scalar
 ThirdHitPredictionFromCircle::HelixRZ::rAtZ(Scalar z) const {
-  if (unlikely(std::abs(dzdu) < 1.0e-5))
+  if (UNLIKELY(std::abs(dzdu) < 1.0e-5))
     return 99999.0;
 
-  if (unlikely(std::abs(curvature) < 1.0e-5)) {
+  if (UNLIKELY(std::abs(curvature) < 1.0e-5)) {
     Scalar tip = circle->axis * circle->p1;
     Scalar lip = circle->axis.y() * circle->p1.x() -
                  circle->axis.x() * circle->p1.y();
@@ -280,7 +280,7 @@ ThirdHitPredictionFromCircle::HelixRZ::rAtZ(Scalar z) const {
 
   float phi =  curvature * (z - z1) / dzdu;
 
-  if (unlikely(std::abs(phi) > 2. * M_PI)) {
+  if (UNLIKELY(std::abs(phi) > 2. * M_PI)) {
     // with a helix we can get problems here - this is used to get the limits
     // however, if phi gets large, we get into the regions where we loop back
     // to smaller r's.  The question is - do we care about these tracks?

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -500,7 +500,7 @@ GroupedCkfTrajectoryBuilder::advanceOneLayer (const TrajectorySeed& seed,
     TSOS stateToUse = stateAndLayers.first;
     
     double dPhiCacheForLoopersReconstruction(0);
-    if unlikely(!traj.empty() && (*il)==traj.lastLayer()){
+    if UNLIKELY(!traj.empty() && (*il)==traj.lastLayer()){
 	
 	if(maxPt2ForLooperReconstruction>0){
 	  // ------ For loopers reconstruction
@@ -861,7 +861,7 @@ GroupedCkfTrajectoryBuilder::rebuildSeedingRegion(const TrajectorySeed&seed,
     //
 
     auto && reFitted = backwardFit(*it,nSeed,fitter,seedHits);
-    if unlikely( !reFitted.isValid() ) {
+    if UNLIKELY( !reFitted.isValid() ) {
 	rebuiltTrajectories.push_back(std::move(*it));
 	LogDebug("CkfPattern")<< "RebuildSeedingRegion skipped as backward fit failed";
 	//			    << "after reFitted.size() " << reFitted.size();
@@ -1036,7 +1036,7 @@ GroupedCkfTrajectoryBuilder::backwardFit (TempTrajectory& candidate, unsigned in
   unsigned int nHitMin = std::max(candidate.foundHits()-nSeed,theMinNrOfHitsForRebuild);
   //  unsigned int nHitMin = oldMeasurements.size()-nSeed;
   // we want to rebuild only if the number of VALID measurements excluding the seed measurements is higher than the cut
-  if unlikely(nHitMin<theMinNrOfHitsForRebuild) return TempTrajectory();
+  if UNLIKELY(nHitMin<theMinNrOfHitsForRebuild) return TempTrajectory();
 
   LogDebug("CkfPattern")/* << "nHitMin " << nHitMin*/ <<"Sizes: " << candidate.measurements().size() << " / ";
   //
@@ -1060,7 +1060,7 @@ GroupedCkfTrajectoryBuilder::backwardFit (TempTrajectory& candidate, unsigned in
       //
       // count valid / 2D hits
       //
-      if likely( hit->isValid() ) {
+      if LIKELY( hit->isValid() ) {
 	  nHit++;
 	  //if ( hit.isMatched() ||
 	  //     hit.det().detUnits().front()->type().module()==pixel )
@@ -1079,7 +1079,7 @@ GroupedCkfTrajectoryBuilder::backwardFit (TempTrajectory& candidate, unsigned in
   //
   // Fit only if required number of valid hits can be used
   //
-  if unlikely( nHit<nHitMin ) return TempTrajectory();
+  if UNLIKELY( nHit<nHitMin ) return TempTrajectory();
 
   //
   // Do the backward fit (important: start from scaled, not random cov. matrix!)
@@ -1090,7 +1090,7 @@ GroupedCkfTrajectoryBuilder::backwardFit (TempTrajectory& candidate, unsigned in
   //TrajectoryContainer bwdFitted(fitter.fit(fwdTraj.seed(),fwdTraj.recHits(),firstTsos));
   Trajectory && bwdFitted = fitter.fitOne(TrajectorySeed(PTrajectoryStateOnDet(), TrajectorySeed::recHitContainer(), oppositeDirection(candidate.direction())),
 					  fwdTraj.recHits(),firstTsos);
-  if unlikely(!bwdFitted.isValid()) return TempTrajectory();
+  if UNLIKELY(!bwdFitted.isValid()) return TempTrajectory();
 
 
   LogDebug("CkfPattern")<<"Obtained bwdFitted trajectory with measurement size " << bwdFitted.measurements().size();

--- a/RecoTracker/CkfPattern/plugins/TrajectorySegmentBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/TrajectorySegmentBuilder.cc
@@ -104,10 +104,10 @@ TrajectorySegmentBuilder::segments (const TSOS startingState)
   for (auto const & gr : measGroups) {
     ++ngrp;
     int nhit(0);
-    for ( auto const & m : gr.measurements()) if likely( m.recHitR().isValid() )  nhit++;
+    for ( auto const & m : gr.measurements()) if LIKELY( m.recHitR().isValid() )  nhit++;
     
     if ( nhit>1 )  ncomb *= nhit;
-    if unlikely( ncomb>MAXCOMB ) {
+    if UNLIKELY( ncomb>MAXCOMB ) {
 	edm::LogInfo("TrajectorySegmentBuilder") << " found " << measGroups.size() 
 						 << " groups and more than " << static_cast<unsigned int>(MAXCOMB)
 						 << " combinations - limiting to "
@@ -120,7 +120,7 @@ TrajectorySegmentBuilder::segments (const TSOS startingState)
       }
   }  
   //   cout << "Groups / combinations = " << measGroups.size() << " " << ncomb << endl;
-  if unlikely( truncate && ngrp>0 )  measGroups.resize(ngrp-1);
+  if UNLIKELY( truncate && ngrp>0 )  measGroups.resize(ngrp-1);
 
 #endif
 
@@ -179,7 +179,7 @@ TrajectorySegmentBuilder::segments (const TSOS startingState)
   TempTrajectoryContainer && candidates = 
     addGroup(startingTrajectory,measGroups.begin(),measGroups.end());
 
-  if unlikely(theDbgFlg) cout << "TSB: back with " << candidates.size() << " candidates" << endl;
+  if UNLIKELY(theDbgFlg) cout << "TSB: back with " << candidates.size() << " candidates" << endl;
 
   //
   // add invalid hit - try to get first detector hit by the extrapolation
@@ -187,7 +187,7 @@ TrajectorySegmentBuilder::segments (const TSOS startingState)
 
   updateWithInvalidHit(startingTrajectory,measGroups,candidates);
 
-  if unlikely(theDbgFlg) cout << "TSB: " << candidates.size() << " candidates after invalid hit" << endl;
+  if UNLIKELY(theDbgFlg) cout << "TSB: " << candidates.size() << " candidates after invalid hit" << endl;
 
   statCount.incr(measGroups.size(), candidates.size(), theLockedHits.size());
 
@@ -234,13 +234,13 @@ TrajectorySegmentBuilder::addGroup (TempTrajectory const & traj,
   vector<TempTrajectory> ret;
   if ( begin==end ) {
     //std::cout << "TrajectorySegmentBuilder::addGroup" << " traj.empty()=" << traj.empty() << "EMPTY" << std::endl;
-    if unlikely(theDbgFlg) cout << "TSB::addGroup : no groups left" << endl;
+    if UNLIKELY(theDbgFlg) cout << "TSB::addGroup : no groups left" << endl;
     if ( !traj.empty() )
       ret.push_back(traj);
     return ret;
   }
   
-  if unlikely(theDbgFlg) cout << "TSB::addGroup : traj.size() = " << traj.measurements().size()
+  if UNLIKELY(theDbgFlg) cout << "TSB::addGroup : traj.size() = " << traj.measurements().size()
 			      << " first group at " << &(*begin)
 	       //        << " nr. of candidates = " << candidates.size() 
 			      << endl;
@@ -254,7 +254,7 @@ TrajectorySegmentBuilder::addGroup (TempTrajectory const & traj,
     } else {
       updateCandidates(traj,begin->measurements(),updatedTrajectories);
     }
-    if unlikely(theDbgFlg) cout << "TSB::addGroup : updating with first group - "
+    if UNLIKELY(theDbgFlg) cout << "TSB::addGroup : updating with first group - "
 				<< updatedTrajectories.size() << " trajectories" << endl;
   }
   else {
@@ -267,7 +267,7 @@ TrajectorySegmentBuilder::addGroup (TempTrajectory const & traj,
       updateCandidates(traj,std::move(meas),
 		       updatedTrajectories);
     }
-    if unlikely(theDbgFlg) cout << "TSB::addGroup : updating"
+    if UNLIKELY(theDbgFlg) cout << "TSB::addGroup : updating"
 				<< updatedTrajectories.size() << " trajectories-1" << endl;
     } 
   }
@@ -279,16 +279,16 @@ TrajectorySegmentBuilder::addGroup (TempTrajectory const & traj,
   if (begin+1 != end) {
     ret.reserve(4); // a good upper bound
     for (auto const & ut : updatedTrajectories) {
-      if unlikely(theDbgFlg) cout << "TSB::addGroup : trying to extend candidate at "
+      if UNLIKELY(theDbgFlg) cout << "TSB::addGroup : trying to extend candidate at "
 				  << &ut << " size " << ut.measurements().size() << endl;
       vector<TempTrajectory> && finalTrajectories = addGroup(ut,begin+1,end);
-      if unlikely(theDbgFlg) cout << "TSB::addGroup : " << finalTrajectories.size()
+      if UNLIKELY(theDbgFlg) cout << "TSB::addGroup : " << finalTrajectories.size()
 				  << " finalised candidates before cleaning" << endl;
       //B.M. to be ported later
       // V.I. only mark invalidate
       cleanCandidates(finalTrajectories);
       
-      if unlikely(theDbgFlg) {
+      if UNLIKELY(theDbgFlg) {
 	  int ntf=0; for ( auto const & t : finalTrajectories) if (t.isValid()) ++ntf;
 	  cout << "TSB::addGroup : got " << ntf
 	       << " finalised candidates" << endl;
@@ -353,7 +353,7 @@ TrajectorySegmentBuilder::redoMeasurements (const TempTrajectory& traj,
   //
   // loop over all dets
   //
-  if unlikely(theDbgFlg) cout << "TSB::redoMeasurements : nr. of measurements / group =";
+  if UNLIKELY(theDbgFlg) cout << "TSB::redoMeasurements : nr. of measurements / group =";
 
   tracking::TempMeasurements tmps;
 
@@ -364,7 +364,7 @@ TrajectorySegmentBuilder::redoMeasurements (const TempTrajectory& traj,
 						 traj.lastMeasurement().updatedState(),
 						 theGeomPropagator,theEstimator);
     
-    if unlikely(theDbgFlg && !compat.first) std::cout << " 0";
+    if UNLIKELY(theDbgFlg && !compat.first) std::cout << " 0";
 
     if(!compat.first) continue;
 
@@ -374,12 +374,12 @@ TrajectorySegmentBuilder::redoMeasurements (const TempTrajectory& traj,
       for (std::size_t i=0; i!=tmps.size(); ++i)
 	result.emplace_back(compat.second,std::move(tmps.hits[i]),tmps.distances[i],&theLayer);
 
-    if unlikely(theDbgFlg) std::cout << " " << tmps.size();
+    if UNLIKELY(theDbgFlg) std::cout << " " << tmps.size();
     tmps.clear();
     
   }
 
-  if unlikely(theDbgFlg) cout << endl;  
+  if UNLIKELY(theDbgFlg) cout << endl;  
 
   std::sort( result.begin(), result.end(), TrajMeasLessEstim());
 
@@ -415,7 +415,7 @@ TrajectorySegmentBuilder::updateWithInvalidHit (TempTrajectory& traj,
 	    // add the hit
             candidates.push_back(traj); 
             updateTrajectory(candidates.back(), *im);
-	    if unlikely( theDbgFlg ) cout << "TrajectorySegmentBuilder::updateWithInvalidHit "
+	    if UNLIKELY( theDbgFlg ) cout << "TrajectorySegmentBuilder::updateWithInvalidHit "
 				  << "added inactive hit" << endl;
 	    return;
 	  }
@@ -435,7 +435,7 @@ TrajectorySegmentBuilder::updateWithInvalidHit (TempTrajectory& traj,
       for ( auto im=measurements.rbegin(); im!=measurements.rend(); ++im ) {
 	// only use invalid hits
 	auto const & hit = im->recHitR();
-	if likely( hit.isValid() )  continue;
+	if LIKELY( hit.isValid() )  continue;
 
 	// check, if the extrapolation traverses the Det
 	auto const & predState = im->predictedState();
@@ -448,11 +448,11 @@ TrajectorySegmentBuilder::updateWithInvalidHit (TempTrajectory& traj,
 	}
       }
     }
-    if unlikely( theDbgFlg && iteration==0 ) cout << "TrajectorySegmentBuilder::updateWithInvalidHit: "
+    if UNLIKELY( theDbgFlg && iteration==0 ) cout << "TrajectorySegmentBuilder::updateWithInvalidHit: "
 				    << " did not find invalid hit on 1st iteration" << endl;
   }
 
-  if unlikely( theDbgFlg)
+  if UNLIKELY( theDbgFlg)
 	       cout << "TrajectorySegmentBuilder::updateWithInvalidHit: "
 		    << " did not find invalid hit" << endl;
 }
@@ -469,9 +469,9 @@ TrajectorySegmentBuilder::unlockedMeasurements (const vector<TM>& measurements) 
 
   for ( auto const & m : measurements) {
     auto const & testHit = m.recHitR();
-    if unlikely( !testHit.isValid() )  continue;
+    if UNLIKELY( !testHit.isValid() )  continue;
     bool found(false);
-    if likely( theLockHits ) {
+    if LIKELY( theLockHits ) {
       for ( auto const & h : theLockedHits) {
 	if ( h->hit()->sharesInput(testHit.hit(), TrackingRecHit::all) ) {
 	  found = true;
@@ -479,7 +479,7 @@ TrajectorySegmentBuilder::unlockedMeasurements (const vector<TM>& measurements) 
 	}
       }
     }
-    if likely( !found )  result.push_back(m);
+    if LIKELY( !found )  result.push_back(m);
   }
   return result;
 }

--- a/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
@@ -89,7 +89,7 @@ BaseCkfTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed,  TempTraj
       TSOS innerState   = backwardPropagator(seed)->propagate(outerState,hitGeomDet->surface());
 
       // try to recover if propagation failed
-      if unlikely(!innerState.isValid())
+      if UNLIKELY(!innerState.isValid())
         innerState =
           trajectoryStateTransform::transientState(pState, &(hitGeomDet->surface()),
                                                             forwardPropagator(seed)->magneticField());
@@ -123,7 +123,7 @@ createStartingTrajectory( const TrajectorySeed& seed) const
 
 bool BaseCkfTrajectoryBuilder::toBeContinued (TempTrajectory& traj, bool inOut) const
 {
-  if unlikely(traj.measurements().size() > 400) {
+  if UNLIKELY(traj.measurements().size() > 400) {
     edm::LogError("BaseCkfTrajectoryBuilder_InfiniteLoop");
     LogTrace("BaseCkfTrajectoryBuilder_InfiniteLoop") << 
               "Cropping Track After 400 Measurements:\n" <<

--- a/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
@@ -348,7 +348,7 @@ CkfTrajectoryBuilder::findCompatibleMeasurements(const TrajectorySeed&seed,
 
     TSOS stateToUse = stateAndLayers.first;
     //Added protection before asking for the lastLayer on the trajectory
-    if unlikely (!traj.empty() && (*il)==traj.lastLayer()) {
+    if UNLIKELY (!traj.empty() && (*il)==traj.lastLayer()) {
 	LogDebug("CkfPattern")<<" self propagating in findCompatibleMeasurements.\n from: \n"<<stateToUse;
 	//self navigation case
 	// go to a middle point first

--- a/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.cc
@@ -60,7 +60,7 @@ PhotonConversionTrajectorySeedProducerFromSingleLegAlgo::find(const edm::Event &
   edm::ESHandle<MagneticField> handleMagField;
   setup.get<IdealMagneticFieldRecord>().get(handleMagField);
   magField = handleMagField.product();
-  if (unlikely(magField->inTesla(GlobalPoint(0.,0.,0.)).z()<0.01)){seedCollection= nullptr;  return;}
+  if (UNLIKELY(magField->inTesla(GlobalPoint(0.,0.,0.)).z()<0.01)){seedCollection= nullptr;  return;}
 
   _IdealHelixParameters.setMagnField(magField);
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionMerger.cc
@@ -194,7 +194,7 @@ namespace {
 	  for (auto it = track.recHitsBegin();  it != track.recHitsEnd(); ++it) {
 	    auto const & hit = *(*it);
 	    auto id = hit.rawId() ;
-	    if likely(hit.isValid()) { rhv.emplace_back(id,&hit); std::push_heap(rhv.begin(),rhv.end(),compById); }
+	    if LIKELY(hit.isValid()) { rhv.emplace_back(id,&hit); std::push_heap(rhv.begin(),rhv.end(),compById); }
 	  }
 	  std::sort_heap(rhv.begin(),rhv.end(),compById);
 	  

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -459,13 +459,13 @@ TrackListMerger::~TrackListMerger() { }
 	const TrackingRecHit* hit = (*it);
 	unsigned int id = hit->rawId() ;
 	if(hit->geographicalId().subdetId()>2)  id &= (~3); // mask mono/stereo in strips...
-	if likely(hit->isValid()) { rh1[i].emplace_back(id,hit); std::push_heap(rh1[i].begin(),rh1[i].end(),compById); }
+	if LIKELY(hit->isValid()) { rh1[i].emplace_back(id,hit); std::push_heap(rh1[i].begin(),rh1[i].end(),compById); }
       }
       std::sort_heap(rh1[i].begin(),rh1[i].end(),compById);
     }
 
     //DL here
-    if likely(ngood>1 && collsSize>1)
+    if LIKELY(ngood>1 && collsSize>1)
     for ( unsigned int ltm=0; ltm<listsToMerge_.size(); ltm++) {
       int saveSelected[rSize];
       bool notActive[collsSize];
@@ -522,7 +522,7 @@ TrackListMerger::~TrackListMerger() { }
 	  int noverlap=0;
 	  int firstoverlap=0;
 	  // check first hit  (should use REAL first hit?)
-	  if unlikely(allowFirstHitShare_ && rh1[k1][0].first==rh1[k2][0].first ) {
+	  if UNLIKELY(allowFirstHitShare_ && rh1[k1][0].first==rh1[k2][0].first ) {
 	      const TrackingRecHit*  it = rh1[k1][0].second;
 	      const TrackingRecHit*  jt = rh1[k2][0].second;
 	      if (share(it,jt,epsilon_)) firstoverlap=1;

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -220,7 +220,7 @@ TrackListMerger::TrackListMerger(edm::ParameterSet const& conf) {
   indivShareFrac_=conf.getParameter<std::vector<double> >("indivShareFrac");
   std::string qualityStr = conf.getParameter<std::string>("newQuality");
   
-  if (qualityStr != "") {
+  if (!qualityStr.empty()) {
     qualityToSet_ = reco::TrackBase::qualityByName(conf.getParameter<std::string>("newQuality"));
   }
   else

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -104,7 +104,7 @@ TkGluedMeasurementDet::recHits( const TrajectoryStateOnSurface& ts, const Measur
 bool TkGluedMeasurementDet::recHits(SimpleHitContainer & result,  
 				    const TrajectoryStateOnSurface& stateOnThisDet, 
 				    const MeasurementEstimator& est, const MeasurementTrackerEvent & data) const {
-  if unlikely((!theMonoDet->isActive(data)) && (!theStereoDet->isActive(data))) return false;
+  if UNLIKELY((!theMonoDet->isActive(data)) && (!theStereoDet->isActive(data))) return false;
   auto oldSize = result.size();
   HitCollectorForSimpleHits collector( &fastGeomDet(), theMatcher, theCPE, stateOnThisDet, est, result);
   collectRecHits(stateOnThisDet, data, collector);
@@ -121,7 +121,7 @@ bool TkGluedMeasurementDet::measurements( const TrajectoryStateOnSurface& stateO
                                           const MeasurementTrackerEvent & data,
 					  TempMeasurements & result) const {
   
-  if unlikely((!theMonoDet->isActive(data)) && (!theStereoDet->isActive(data))) {
+  if UNLIKELY((!theMonoDet->isActive(data)) && (!theStereoDet->isActive(data))) {
        //     LogDebug("TkStripMeasurementDet") << " DetID " << geomDet().geographicalId().rawId() << " (glued) fully inactive";
        result.add(theInactiveHit, 0.F);
        return true;

--- a/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.cc
@@ -39,7 +39,7 @@ bool TkPhase2OTMeasurementDet::measurements( const TrajectoryStateOnSurface& sta
 bool TkPhase2OTMeasurementDet::recHits( const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
                                         RecHitContainer & result, std::vector<float> & diffs) const {
 
-  if unlikely( (!isActive(data)) || isEmpty(data.phase2OTData()) ) return false;
+  if UNLIKELY( (!isActive(data)) || isEmpty(data.phase2OTData()) ) return false;
 
   auto oldSize = result.size();
 

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
@@ -24,7 +24,7 @@ TkStripMeasurementDet::TkStripMeasurementDet( const GeomDet* gdet, StMeasurement
 
 // fast check if the det contains any useful cluster
 bool TkStripMeasurementDet::empty(const MeasurementTrackerEvent & data) const {
-  if unlikely( (!isActive(data)) || isEmpty(data.stripData())) return true;
+  if UNLIKELY( (!isActive(data)) || isEmpty(data.stripData())) return true;
 
     const detset & detSet = data.stripData().detSet(index()); 
     for ( auto ci = detSet.begin(); ci != detSet.end(); ++ ci ) {
@@ -41,7 +41,7 @@ TkStripMeasurementDet::RecHitContainer
 TkStripMeasurementDet::recHits( const TrajectoryStateOnSurface& ts, const MeasurementTrackerEvent & data) const
 {
   RecHitContainer result;
-  if unlikely( (!isActive(data)) || isEmpty(data.stripData())) return result;
+  if UNLIKELY( (!isActive(data)) || isEmpty(data.stripData())) return result;
     const detset & detSet = data.stripData().detSet(index()); 
     result.reserve(detSet.size());
     for ( new_const_iterator ci = detSet.begin(); ci != detSet.end(); ++ ci ) {
@@ -61,7 +61,7 @@ TkStripMeasurementDet::recHits( const TrajectoryStateOnSurface& ts, const Measur
 bool TkStripMeasurementDet::recHits(SimpleHitContainer & result,  
 				    const TrajectoryStateOnSurface& stateOnThisDet, 
 				    const MeasurementEstimator& est, const MeasurementTrackerEvent & data) const {
-  if unlikely( (!isActive(data)) || isEmpty(data.stripData())) return false;
+  if UNLIKELY( (!isActive(data)) || isEmpty(data.stripData())) return false;
   auto oldSize = result.size();
   
   int utraj =  specificGeomDet().specificTopology().measurementPosition( stateOnThisDet.localPosition()).x();
@@ -101,7 +101,7 @@ bool TkStripMeasurementDet::recHits(SimpleHitContainer & result,
 bool TkStripMeasurementDet::simpleRecHits( const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator& est, 
 					   const MeasurementTrackerEvent & data,
 					   std::vector<SiStripRecHit2D> &result) const  {
-  if unlikely( (!isActive(data)) || isEmpty(data.stripData())) return false;
+  if UNLIKELY( (!isActive(data)) || isEmpty(data.stripData())) return false;
 
   auto oldSize = result.size();
 
@@ -135,7 +135,7 @@ bool TkStripMeasurementDet::simpleRecHits( const TrajectoryStateOnSurface& state
 bool
 TkStripMeasurementDet::recHits( const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator& est, const MeasurementTrackerEvent & data, 
 				RecHitContainer & result, std::vector<float> & diffs ) const {
-  if unlikely( (!isActive(data)) || isEmpty(data.stripData())) return false;
+  if UNLIKELY( (!isActive(data)) || isEmpty(data.stripData())) return false;
 
   auto oldSize = result.size();
   auto const & cpepar = cpe()->getAlgoParam(specificGeomDet(),stateOnThisDet.localParameters());

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -89,7 +89,7 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
   // FIXME  clean this and optimize the rest of the code once understood and validated
   if (true) { // collector.filter()) {
     emptyMono = theMonoDet->empty(data);
-    if likely(!emptyMono) {
+    if LIKELY(!emptyMono) {
         // mono does require "projection" for precise estimate
 	TrajectoryStateOnSurface mts = fastProp(ts,geomDet().surface(),theMonoDet->geomDet().surface());
 	theMonoDet->simpleRecHits(mts,collector.estimator(),data,monoHits);
@@ -105,7 +105,7 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
   // stereo requires "projection" for precision and change in coordinates
   if (collector.filter()) {
     emptyStereo = theStereoDet->empty(data);
-    if likely(!emptyStereo) {
+    if LIKELY(!emptyStereo) {
 	TrajectoryStateOnSurface pts = fastProp(ts,geomDet().surface(),theStereoDet->geomDet().surface());
 	theStereoDet->simpleRecHits(pts,collector.estimator(),data,stereoHits);
 	// print("stereo", pts,ts);
@@ -123,15 +123,15 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
     stat(mh,sh,mf,sf);
   }
 
-  if unlikely( emptyMono &  emptyStereo) return;
+  if UNLIKELY( emptyMono &  emptyStereo) return;
 
-  if unlikely(emptyStereo) {
+  if UNLIKELY(emptyStereo) {
       // make mono TTRHs and project them
       projectOnGluedDet( collector, monoHits, glbDir);
       return;
     }
   
-  if unlikely( emptyMono ) {
+  if UNLIKELY( emptyMono ) {
       // make stereo TTRHs and project them
     projectOnGluedDet( collector, stereoHits, glbDir);
     return;

--- a/RecoTracker/TkDetLayers/src/TkDetUtil.cc
+++ b/RecoTracker/TkDetLayers/src/TkDetUtil.cc
@@ -27,7 +27,7 @@ namespace tkDetUtil {
     LocalPoint start = ts.localPosition();
     //     std::cout << "plane z " << plane.normalVector() << std::endl;
     float dphi=0;
-    if likely(std::abs(1.f-std::abs(plane.normalVector().z()))<tolerance) {
+    if LIKELY(std::abs(1.f-std::abs(plane.normalVector().z()))<tolerance) {
       auto ori = plane.toLocal(GlobalPoint(0.,0.,0.));
       auto xc = std::abs(start.x() - ori.x());
       auto yc = std::abs(start.y() - ori.y());

--- a/RecoTracker/TkMSParametrization/src/MSLayer.cc
+++ b/RecoTracker/TkMSParametrization/src/MSLayer.cc
@@ -136,7 +136,7 @@ float MSLayer::distance2(const PixelRecoPointRZ & point) const
 //----------------------------------------------------------------------
 float MSLayer::x0(float cotTheta) const
 {
-  if likely(theX0Data.hasX0) {
+  if LIKELY(theX0Data.hasX0) {
     float OverSinTheta = std::sqrt(1.f+cotTheta*cotTheta);
     return (theFace==barrel) ? theX0Data.x0*OverSinTheta :
                                theX0Data.x0*OverSinTheta/std::abs(cotTheta);
@@ -151,7 +151,7 @@ float MSLayer::x0(float cotTheta) const
 //----------------------------------------------------------------------
 float MSLayer::sumX0D(float cotTheta) const
 {
-if likely(theX0Data.hasX0) {
+if LIKELY(theX0Data.hasX0) {
     switch(theFace) {
     case barrel:  
       return theX0Data.sumX0D

--- a/RecoTracker/TkNavigation/plugins/SimpleBarrelNavigableLayer.cc
+++ b/RecoTracker/TkNavigation/plugins/SimpleBarrelNavigableLayer.cc
@@ -125,7 +125,7 @@ SimpleBarrelNavigableLayer::nextLayers( const FreeTrajectoryState& fts,
 			      (!(momentum.z() > 0) &&  (dir == alongMomentum) )   );
 
 
-  if likely( dirOppositeXORisInOutTrackBarrel &&  dirOppositeXORisInOutTrackFWD) {
+  if LIKELY( dirOppositeXORisInOutTrackBarrel &&  dirOppositeXORisInOutTrackFWD) {
       if ( signZmomentumXORdir   ) {
 	wellInside( ftsWithoutErrors, dir, theNegOuterLayers, result);
       }
@@ -163,7 +163,7 @@ SimpleBarrelNavigableLayer::nextLayers( const FreeTrajectoryState& fts,
   LogDebug("SimpleBarrelNavigableLayer") << "goingIntoTheBarrel: " << goingIntoTheBarrel;
 
 
-  if unlikely(theSelfSearch && result.empty()){
+  if UNLIKELY(theSelfSearch && result.empty()){
     if (!goingIntoTheBarrel){     
       LogDebug("SimpleBarrelNavigableLayer")<<" state is not going toward the center of the barrel. not adding self search.";}
     else{

--- a/RecoTracker/TkNavigation/plugins/SimpleForwardNavigableLayer.cc
+++ b/RecoTracker/TkNavigation/plugins/SimpleForwardNavigableLayer.cc
@@ -95,7 +95,7 @@ SimpleForwardNavigableLayer::nextLayers( const FreeTrajectoryState& fts,
   bool dirOppositeXORisInOutTrackFWD = ( !(dir == oppositeToMomentum) && isInOutTrackFWD) || ( (dir == oppositeToMomentum) && !isInOutTrackFWD);
   //bool dirOppositeXORisInOutTrack = ( !(dir == oppositeToMomentum) && isInOutTrack) || ( (dir == oppositeToMomentum) && !isInOutTrack);
 
-  if likely( dirOppositeXORisInOutTrackFWD && dirOppositeXORisInOutTrackBarrel ) { //standard tracks
+  if LIKELY( dirOppositeXORisInOutTrackFWD && dirOppositeXORisInOutTrackBarrel ) { //standard tracks
     wellInside(ftsWithoutErrors, dir, theOuterLayers, result);
   }
   else if (!dirOppositeXORisInOutTrackFWD && !dirOppositeXORisInOutTrackBarrel){ // !dirOppositeXORisInOutTrack

--- a/RecoTracker/TkNavigation/plugins/SimpleNavigableLayer.cc
+++ b/RecoTracker/TkNavigation/plugins/SimpleNavigableLayer.cc
@@ -23,7 +23,7 @@ TrajectoryStateOnSurface SimpleNavigableLayer::crossingState(const FreeTrajector
   FreeTrajectoryState const & dest = *propState.freeState();
   GlobalPoint middlePoint = dest.position();
   const float toCloseToEachOther2 = 1e-4*1e-4;
-  if unlikely( (middlePoint-initialPoint).mag2() < toCloseToEachOther2){
+  if UNLIKELY( (middlePoint-initialPoint).mag2() < toCloseToEachOther2){
     LogDebug("SimpleNavigableLayer")<<"initial state and PCA are identical. Things are bound to fail. Do not add the link.";
     return TrajectoryStateOnSurface();
   }
@@ -51,7 +51,7 @@ TrajectoryStateOnSurface SimpleNavigableLayer::crossingState(const FreeTrajector
   LogDebug("SimpleNavigableLayer")<<"second propagation("<< dir <<") to: \n"
 				  <<dest2;
   double finalDot = (middlePoint - initialPoint).basicVector().dot((finalPoint-middlePoint).basicVector());
-  if unlikely(finalDot<0){ // check that before and after are in different side.
+  if UNLIKELY(finalDot<0){ // check that before and after are in different side.
     LogDebug("SimpleNavigableLayer")<<"switch side back: ABORT.";
     return TrajectoryStateOnSurface();
   }

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc
@@ -120,7 +120,7 @@ bool SeedFromConsecutiveHitsCreator::initialKinematic(GlobalTrajectoryParameters
     kine = GlobalTrajectoryParameters(vertexPos, initMomentum, 1, &*bfield);
   } 
 
-  if unlikely(isBOFF && (theBOFFMomentum > 0)) {
+  if UNLIKELY(isBOFF && (theBOFFMomentum > 0)) {
       kine = GlobalTrajectoryParameters(kine.position(),
 					kine.momentum().unit() * theBOFFMomentum,
 					kine.charge(),

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsTripletOnlyCreator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsTripletOnlyCreator.cc
@@ -24,7 +24,7 @@ bool SeedFromConsecutiveHitsTripletOnlyCreator::initialKinematic(GlobalTrajector
     SeedingHitSet::ConstRecHitPointer tth3 = hits[2];
     FastHelix helix(tth3->globalPosition(), tth2->globalPosition(), tth1->globalPosition(), nomField, &*bfield, tth1->globalPosition());
     kine = helix.stateAtVertex();
-    if unlikely(isBOFF && (theBOFFMomentum > 0)) {
+    if UNLIKELY(isBOFF && (theBOFFMomentum > 0)) {
       kine = GlobalTrajectoryParameters(kine.position(),
 					kine.momentum().unit() * theBOFFMomentum,
 					kine.charge(),
@@ -44,7 +44,7 @@ bool SeedFromConsecutiveHitsTripletOnlyCreator::initialKinematic(GlobalTrajector
     kine = GlobalTrajectoryParameters(vertexPos, initMomentum, 1, &*bfield);
   } 
 
-  if unlikely(isBOFF && (theBOFFMomentum > 0)) {
+  if UNLIKELY(isBOFF && (theBOFFMomentum > 0)) {
       kine = GlobalTrajectoryParameters(kine.position(),
 					kine.momentum().unit() * theBOFFMomentum,
 					kine.charge(),

--- a/RecoTracker/TkSeedingLayers/src/HitExtractorSTRP.cc
+++ b/RecoTracker/TkSeedingLayers/src/HitExtractorSTRP.cc
@@ -55,7 +55,7 @@ bool HitExtractorSTRP::skipThis(DetId id, OmniClusterRef const& clus,
 
   if (maskCluster && (stripClusterMask->mask(clus.key())) ) return true;
 
-  if unlikely(minGoodCharge<=0) return false;
+  if UNLIKELY(minGoodCharge<=0) return false;
   return siStripClusterTools::chargePerCM(id,*clus.cluster_strip()) <= minGoodCharge;
 }
 

--- a/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
@@ -41,7 +41,7 @@ GlobalTrackingRegion::checkRZ(const DetLayer* layer,
   bool isBarrel = layer->isBarrel();
   bool isPixel = (layer->subDetector() == PixelBarrel || layer->subDetector() == PixelEndcap);
   
-  if unlikely(!outerlayer) {
+  if UNLIKELY(!outerlayer) {
         GlobalPoint ohit =  outerHit->globalPosition();
         lr = std::sqrt( sqr(ohit.x()-origin().x())+sqr(ohit.y()-origin().y()) );
 	gz = ohit.z();
@@ -60,7 +60,7 @@ GlobalTrackingRegion::checkRZ(const DetLayer* layer,
       PixelRecoPointRZ(-originRBound(), origin().z()-originZBound())
     : PixelRecoPointRZ( originRBound(), origin().z()-originZBound()); 
 
-  if unlikely((!thePrecise) &&(isPixel )) {
+  if UNLIKELY((!thePrecise) &&(isPixel )) {
     auto VcotMin = PixelRecoLineRZ( vtxR, outerred).cotLine();
     auto VcotMax = PixelRecoLineRZ( vtxL, outerred).cotLine();
     return new HitEtaCheck(isBarrel, outerred, VcotMax, VcotMin);
@@ -92,7 +92,7 @@ GlobalTrackingRegion::checkRZ(const DetLayer* layer,
   HitRZConstraint rzConstraint(leftLine, rightLine);
 
 
-  if unlikely(theUseMS) {
+  if UNLIKELY(theUseMS) {
     MultipleScatteringParametrisation iSigma(layer,iSetup);
     PixelRecoPointRZ vtxMean(0.,origin().z());
 

--- a/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
@@ -98,7 +98,7 @@ TrackProducerAlgorithm<reco::Track>::buildTrack (const TrajectoryFitter * theFit
       
   //perform the fit: the result's size is 1 if it succeded, 0 if fails
   Trajectory && trajTmp = theFitter->fitOne(seed, hits, theTSOS,(nLoops>0) ? TrajectoryFitter::looper : TrajectoryFitter::standard);
-  if unlikely(!trajTmp.isValid()) {
+  if UNLIKELY(!trajTmp.isValid()) {
      DPRINT("TrackFitters") << "fit failed " << algo_ << ": " <<  hits.size() <<'|' << int(nLoops) << ' ' << std::endl; 
      return false;
   }
@@ -124,7 +124,7 @@ TrackProducerAlgorithm<reco::Track>::buildTrack (const TrajectoryFitter * theFit
   }
   
   ndof -= 5.f;
-  if unlikely(std::abs(theTSOS.magneticField()->nominalValue())<DBL_MIN) ++ndof;  // same as -4
+  if UNLIKELY(std::abs(theTSOS.magneticField()->nominalValue())<DBL_MIN) ++ndof;  // same as -4
  
 
 #if defined(VI_DEBUG) || defined(EDM_ML_DEBUG)
@@ -173,7 +173,7 @@ for (auto const & tm : theTraj->measurements()) {
     }
   }
 
-  if unlikely(!stateForProjectionToBeamLineOnSurface.isValid()){
+  if UNLIKELY(!stateForProjectionToBeamLineOnSurface.isValid()){
     edm::LogError("CannotPropagateToBeamLine")<<"the state on the closest measurement isnot valid. skipping track.";
     delete theTraj;
     return false;
@@ -196,7 +196,7 @@ for (auto const & tm : theTraj->measurements()) {
   }
 
   
-  if unlikely(!tscbl.isValid()) {
+  if UNLIKELY(!tscbl.isValid()) {
     delete theTraj;
     return false;
   }
@@ -248,7 +248,7 @@ TrackProducerAlgorithm<reco::GsfTrack>::buildTrack (const TrajectoryFitter * the
   PropagationDirection seedDir = seed.direction();
   
   Trajectory && trajTmp = theFitter->fitOne(seed, hits, theTSOS,(nLoops>0) ? TrajectoryFitter::looper: TrajectoryFitter::standard);
-  if unlikely(!trajTmp.isValid()) return false;
+  if UNLIKELY(!trajTmp.isValid()) return false;
   
   
   auto theTraj = new Trajectory( std::move(trajTmp) );
@@ -290,7 +290,7 @@ TrackProducerAlgorithm<reco::GsfTrack>::buildTrack (const TrajectoryFitter * the
   }
   
   ndof = ndof - 5;
-  if unlikely(std::abs(theTSOS.magneticField()->nominalValue())<DBL_MIN) ++ndof;  // same as -4
+  if UNLIKELY(std::abs(theTSOS.magneticField()->nominalValue())<DBL_MIN) ++ndof;  // same as -4
   
   
   //if geometricInnerState_ is false the state for projection to beam line is the state attached to the first hit: to be used for loopers
@@ -307,7 +307,7 @@ TrackProducerAlgorithm<reco::GsfTrack>::buildTrack (const TrajectoryFitter * the
     }
   }
 
-  if unlikely(!stateForProjectionToBeamLineOnSurface.isValid()){
+  if UNLIKELY(!stateForProjectionToBeamLineOnSurface.isValid()){
       edm::LogError("CannotPropagateToBeamLine")<<"the state on the closest measurement isnot valid. skipping track.";
       delete theTraj;
       return false;
@@ -330,7 +330,7 @@ TrackProducerAlgorithm<reco::GsfTrack>::buildTrack (const TrajectoryFitter * the
   }  
 
   
-  if unlikely(tscbl.isValid()==false) {
+  if UNLIKELY(tscbl.isValid()==false) {
       delete theTraj;
       return false;
     }

--- a/RecoVertex/VertexTools/interface/PerigeeLinearizedTrackState.h
+++ b/RecoVertex/VertexTools/interface/PerigeeLinearizedTrackState.h
@@ -191,7 +191,7 @@ private:
 inline
 const AlgebraicVector5 & PerigeeLinearizedTrackState::constantTerm() const
 {
-  if unlikely(!jacobiansAvailable) computeJacobians();
+  if UNLIKELY(!jacobiansAvailable) computeJacobians();
   return theConstantTerm;
 }
 
@@ -201,7 +201,7 @@ const AlgebraicVector5 & PerigeeLinearizedTrackState::constantTerm() const
 inline
 const AlgebraicMatrix53 & PerigeeLinearizedTrackState::positionJacobian() const
 {
-  if unlikely(!jacobiansAvailable) computeJacobians();
+  if UNLIKELY(!jacobiansAvailable) computeJacobians();
   return thePositionJacobian;
 }
 
@@ -211,7 +211,7 @@ const AlgebraicMatrix53 & PerigeeLinearizedTrackState::positionJacobian() const
 inline
 const AlgebraicMatrix53 & PerigeeLinearizedTrackState::momentumJacobian() const
 {
-  if unlikely(!jacobiansAvailable) computeJacobians();
+  if UNLIKELY(!jacobiansAvailable) computeJacobians();
   return theMomentumJacobian;
 }
 
@@ -220,7 +220,7 @@ const AlgebraicMatrix53 & PerigeeLinearizedTrackState::momentumJacobian() const
 inline
 const AlgebraicVector5 & PerigeeLinearizedTrackState::parametersFromExpansion() const
 {
-  if unlikely(!jacobiansAvailable) computeJacobians();
+  if UNLIKELY(!jacobiansAvailable) computeJacobians();
   return theExpandedParams;
 }
 
@@ -231,7 +231,7 @@ const AlgebraicVector5 & PerigeeLinearizedTrackState::parametersFromExpansion() 
 inline
 const TrajectoryStateClosestToPoint & PerigeeLinearizedTrackState::predictedState() const
 {
-  if unlikely(!jacobiansAvailable) computeJacobians();
+  if UNLIKELY(!jacobiansAvailable) computeJacobians();
   return thePredState;
 }
 
@@ -239,7 +239,7 @@ const TrajectoryStateClosestToPoint & PerigeeLinearizedTrackState::predictedStat
 inline
 bool PerigeeLinearizedTrackState::hasError() const
 {
-  if unlikely(!jacobiansAvailable) computeJacobians();
+  if UNLIKELY(!jacobiansAvailable) computeJacobians();
   return thePredState.hasError();
 }
 
@@ -253,7 +253,7 @@ AlgebraicVector5 PerigeeLinearizedTrackState::predictedStateParameters() const
 inline
 AlgebraicVector3 PerigeeLinearizedTrackState::predictedStateMomentumParameters() const
 {
-  if unlikely(!jacobiansAvailable) computeJacobians();
+  if UNLIKELY(!jacobiansAvailable) computeJacobians();
   auto v= thePredState.perigeeParameters().vector();
   return AlgebraicVector3(v[0],v[1],v[2]);
 
@@ -262,7 +262,7 @@ AlgebraicVector3 PerigeeLinearizedTrackState::predictedStateMomentumParameters()
 inline
 AlgebraicSymMatrix55 PerigeeLinearizedTrackState::predictedStateWeight(int & error) const
 {
-  if unlikely(!jacobiansAvailable) computeJacobians();
+  if UNLIKELY(!jacobiansAvailable) computeJacobians();
   if (!thePredState.isValid()) {
     error = 1;
     return AlgebraicSymMatrix55();
@@ -273,22 +273,22 @@ AlgebraicSymMatrix55 PerigeeLinearizedTrackState::predictedStateWeight(int & err
 inline
 AlgebraicSymMatrix55 PerigeeLinearizedTrackState::predictedStateError() const
 {
-  if unlikely(!jacobiansAvailable) computeJacobians();
+  if UNLIKELY(!jacobiansAvailable) computeJacobians();
   return thePredState.perigeeError().covarianceMatrix();
 } 
 
 inline
 AlgebraicSymMatrix33 PerigeeLinearizedTrackState::predictedStateMomentumError() const
 {
-  if unlikely(!jacobiansAvailable) computeJacobians();
+  if UNLIKELY(!jacobiansAvailable) computeJacobians();
   return thePredState.perigeeError().covarianceMatrix().Sub<AlgebraicSymMatrix33>(0,2);
 } 
 
 inline
 bool PerigeeLinearizedTrackState::isValid() const
 {
-  if unlikely(!theTSOS.isValid()) return false;
-  if unlikely(!jacobiansAvailable) computeJacobians();
+  if UNLIKELY(!theTSOS.isValid()) return false;
+  if UNLIKELY(!jacobiansAvailable) computeJacobians();
   return jacobiansAvailable;
 }
 

--- a/RecoVertex/VertexTools/src/PerigeeLinearizedTrackState.cc
+++ b/RecoVertex/VertexTools/src/PerigeeLinearizedTrackState.cc
@@ -12,7 +12,7 @@ void PerigeeLinearizedTrackState::computeJacobians() const
   GlobalPoint paramPt(theLinPoint);
   
   thePredState = builder(theTSOS, paramPt); 
-  if unlikely(!thePredState.isValid()) return;
+  if UNLIKELY(!thePredState.isValid()) return;
   
   double field =  theTrack.field()->inInverseGeV(thePredState.theState().position()).z();
   

--- a/TrackPropagation/RungeKutta/src/AnalyticalErrorPropagation.h
+++ b/TrackPropagation/RungeKutta/src/AnalyticalErrorPropagation.h
@@ -2,6 +2,7 @@
 #define AnalyticalErrorPropagation_H
 
 #include "FWCore/Utilities/interface/Visibility.h"
+#include "FWCore/Utilities/interface/Likely.h"
 #include "TrackingTools/AnalyticalJacobians/interface/AnalyticalCurvilinearJacobian.h"
 #include "TrackingTools/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
@@ -16,7 +17,7 @@ analyticalErrorPropagation( const FreeTrajectoryState& startingState,
 		const Surface& surface, SurfaceSideDefinition::SurfaceSide side,
 		const GlobalTrajectoryParameters& destParameters, 
 		const double& s) {
-    if unlikely(!startingState.hasError()) 
+    if UNLIKELY(!startingState.hasError()) 
        // return state without errors
       return std::pair<TrajectoryStateOnSurface,double>(TrajectoryStateOnSurface(destParameters,surface,side),s);
 

--- a/TrackPropagation/RungeKutta/src/RKLocalFieldProvider.cc
+++ b/TrackPropagation/RungeKutta/src/RKLocalFieldProvider.cc
@@ -1,6 +1,7 @@
 #include "RKLocalFieldProvider.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/VolumeGeometry/interface/MagVolume.h"
+#include "FWCore/Utilities/interface/Likely.h"
 
 RKLocalFieldProvider::RKLocalFieldProvider( const MagVolume& vol) :
   theVolume( vol), theFrame(vol), transform_(false) {}
@@ -10,7 +11,7 @@ RKLocalFieldProvider::RKLocalFieldProvider( const MagVolume& vol, const Frame& f
 
 RKLocalFieldProvider::Vector RKLocalFieldProvider::inTesla( const LocalPoint& lp) const 
 {
-  if unlikely(transform_) {
+  if UNLIKELY(transform_) {
       LocalPoint vlp( theVolume.toLocal( theFrame.toGlobal( lp)));
       return theFrame.toLocal( theVolume.toGlobal( theVolume.fieldInTesla( vlp))).basicVector();
     }

--- a/TrackPropagation/RungeKutta/src/RKPropagatorInS.cc
+++ b/TrackPropagation/RungeKutta/src/RKPropagatorInS.cc
@@ -28,7 +28,7 @@ RKPropagatorInS::propagateWithPath(const FreeTrajectoryState& fts,
 				   const Plane& plane) const
 {
   GlobalParametersWithPath gp =  propagateParametersOnPlane( fts, plane);
-  if unlikely(!gp) return TsosWP(TrajectoryStateOnSurface(),0.);
+  if UNLIKELY(!gp) return TsosWP(TrajectoryStateOnSurface(),0.);
 
   SurfaceSideDefinition::SurfaceSide side = PropagationDirectionFromPath()(gp.s(),propagationDirection())==alongMomentum 
     ? SurfaceSideDefinition::beforeSurface : SurfaceSideDefinition::afterSurface;
@@ -39,7 +39,7 @@ std::pair< TrajectoryStateOnSurface, double>
 RKPropagatorInS::propagateWithPath (const FreeTrajectoryState& fts, const Cylinder& cyl) const
 {
   GlobalParametersWithPath gp =  propagateParametersOnCylinder( fts, cyl);
-  if  unlikely(!gp) return TsosWP(TrajectoryStateOnSurface(),0.);
+  if  UNLIKELY(!gp) return TsosWP(TrajectoryStateOnSurface(),0.);
 
   SurfaceSideDefinition::SurfaceSide side = PropagationDirectionFromPath()(gp.s(),propagationDirection())==alongMomentum 
     ? SurfaceSideDefinition::beforeSurface : SurfaceSideDefinition::afterSurface;
@@ -61,7 +61,7 @@ RKPropagatorInS::propagateParametersOnPlane( const FreeTrajectoryState& ts,
   // Straight line approximation? |rho|<1.e-10 equivalent to ~ 1um 
   // difference in transversal position at 10m.
   //
-  if  unlikely( fabs(rho)<1.e-10 ) {
+  if  UNLIKELY( fabs(rho)<1.e-10 ) {
     //
     // Instantiate auxiliary object for finding intersection.
     // Frame-independant point and vector are created explicitely to 
@@ -70,7 +70,7 @@ RKPropagatorInS::propagateParametersOnPlane( const FreeTrajectoryState& ts,
     //
     LogDebug("RKPropagatorInS")<<" startZ = "<<startZ;
 
-    if unlikely(fabs(startZ) < 1e-5){  
+    if UNLIKELY(fabs(startZ) < 1e-5){  
       LogDebug("RKPropagatorInS")<< "Propagation is not performed: state is already on final surface.";
       GlobalTrajectoryParameters res( gpos, gmom, ts.charge(), 
 				      theVolume);
@@ -84,7 +84,7 @@ RKPropagatorInS::propagateParametersOnPlane( const FreeTrajectoryState& ts,
     // get solution
     //
     std::pair<bool,double> propResult = planeCrossing.pathLength(plane);
-    if likely( propResult.first && theVolume !=nullptr) {
+    if LIKELY( propResult.first && theVolume !=nullptr) {
       double s = propResult.second;
       // point (reconverted to GlobalPoint)
       GlobalPoint x (planeCrossing.position(s));
@@ -141,7 +141,7 @@ RKPropagatorInS::propagateParametersOnPlane( const FreeTrajectoryState& ts,
     std::pair<bool,double> path = pathLength( plane, startState.position(), 
 					      startState.momentum(), 
 					      (double) ts.charge(), currentDirection);
-    if  unlikely(!path.first) { 
+    if  UNLIKELY(!path.first) { 
       LogDebug("RKPropagatorInS")  << "RKPropagatorInS: Path length calculation to plane failed!" 
 				   << "...distance to plane " << plane.localZ( globalPosition(startState.position()))
 				   << "...Local starting position in volume " << startState.position() 
@@ -155,7 +155,7 @@ RKPropagatorInS::propagateParametersOnPlane( const FreeTrajectoryState& ts,
    
 
     double sstep = path.second;
-    if  unlikely( std::abs(sstep) < eps) {
+    if  UNLIKELY( std::abs(sstep) < eps) {
       LogDebug("RKPropagatorInS")  << "On-surface accuracy not reached, but pathLength calculation says we are there! "
 		 << "path " << path.second << " distance to plane is " << startZ ;
       GlobalTrajectoryParameters res( gtpFromVolumeLocal( startState, ts.charge()));
@@ -203,7 +203,7 @@ RKPropagatorInS::propagateParametersOnCylinder( const FreeTrajectoryState& ts,
   
   
   const GlobalPoint& sp = cyl.position();
-  if unlikely(sp.x()!=0. || sp.y()!=0.) {
+  if UNLIKELY(sp.x()!=0. || sp.y()!=0.) {
       throw PropagationException("Cannot propagate to an arbitrary cylinder");
     }
   
@@ -222,7 +222,7 @@ RKPropagatorInS::propagateParametersOnCylinder( const FreeTrajectoryState& ts,
   // Straight line approximation? |rho|<1.e-10 equivalent to ~ 1um 
   // difference in transversal position at 10m.
   //
-  if  unlikely( fabs(rho)<1.e-10 ) {
+  if  UNLIKELY( fabs(rho)<1.e-10 ) {
       //
       // Instantiate auxiliary object for finding intersection.
       // Frame-independant point and vector are created explicitely to 
@@ -236,7 +236,7 @@ RKPropagatorInS::propagateParametersOnCylinder( const FreeTrajectoryState& ts,
       // get solution
       //
       std::pair<bool,double> propResult = cylCrossing.pathLength(cyl);
-      if  likely( propResult.first && theVolume !=nullptr) {
+      if  LIKELY( propResult.first && theVolume !=nullptr) {
 	  double s = propResult.second;
 	  // point (reconverted to GlobalPoint)
 	  GlobalPoint x (cylCrossing.position(s));
@@ -271,7 +271,7 @@ RKPropagatorInS::propagateParametersOnCylinder( const FreeTrajectoryState& ts,
 					     currentDirection, eps);
     
     std::pair<bool,double> path = pathLength.pathLength( cyl);
-    if  unlikely(!path.first) { 
+    if  UNLIKELY(!path.first) { 
 	LogDebug("RKPropagatorInS")  << "RKPropagatorInS: Path length calculation to cylinder failed!" 
 				     << "Radius " << cyl.radius() << " pos.perp() " << LocalPoint(startState.position()).perp() ;
 	return GlobalParametersWithPath();
@@ -285,7 +285,7 @@ RKPropagatorInS::propagateParametersOnCylinder( const FreeTrajectoryState& ts,
     
     
     double sstep = path.second;
-    if  unlikely( std::abs(sstep) < eps) {
+    if  UNLIKELY( std::abs(sstep) < eps) {
 	LogDebug("RKPropagatorInS")  << "accuracy not reached, but pathLength calculation says we are there! "
 				     << path.second ;
 	

--- a/TrackingTools/DetLayers/src/BarrelDetLayer.cc
+++ b/TrackingTools/DetLayers/src/BarrelDetLayer.cc
@@ -75,12 +75,12 @@ BarrelDetLayer::compatible( const TrajectoryStateOnSurface& ts,
 			    const Propagator& prop, 
 			    const MeasurementEstimator&) const
 {
-  if unlikely(theCylinder == nullptr)  edm::LogError("DetLayers") 
+  if UNLIKELY(theCylinder == nullptr)  edm::LogError("DetLayers") 
     << "ERROR: BarrelDetLayer::compatible() is used before the layer surface is initialized" ;
   // throw an exception? which one?
 
   TrajectoryStateOnSurface myState = prop.propagate( ts, specificSurface());
-  if unlikely(!myState.isValid()) return make_pair( false, myState);
+  if UNLIKELY(!myState.isValid()) return make_pair( false, myState);
   
 
   // check z assuming symmetric bounds around position().z()

--- a/TrackingTools/DetLayers/src/ForwardDetLayer.cc
+++ b/TrackingTools/DetLayers/src/ForwardDetLayer.cc
@@ -105,12 +105,12 @@ ForwardDetLayer::compatible( const TrajectoryStateOnSurface& ts,
 			     const Propagator& prop, 
 			     const MeasurementEstimator&) const
 {
-  if unlikely(theDisk == nullptr)  edm::LogError("DetLayers") 
+  if UNLIKELY(theDisk == nullptr)  edm::LogError("DetLayers") 
     << "ERROR: BarrelDetLayer::compatible() is used before the layer surface is initialized" ;
   // throw an exception? which one?
 
   TrajectoryStateOnSurface myState = prop.propagate( ts, specificSurface());
-  if unlikely( !myState.isValid()) return make_pair( false, myState);
+  if UNLIKELY( !myState.isValid()) return make_pair( false, myState);
 
 
   // check z;  (are we sure?????)

--- a/TrackingTools/DetLayers/src/GeomDetCompatibilityChecker.cc
+++ b/TrackingTools/DetLayers/src/GeomDetCompatibilityChecker.cc
@@ -70,13 +70,13 @@ GeomDetCompatibilityChecker::isCompatible(const GeomDet* theDet,
     bool isIn = false;
     float sagitta=99999999;
     bool close = false;
-  if likely(sagCut>0) {
+  if LIKELY(sagCut>0) {
     // linear approximation
     auto const & plane = theDet->specificSurface();
     StraightLinePlaneCrossing crossing(tsos.globalPosition().basicVector(),tsos.globalMomentum().basicVector(), prop.propagationDirection());
     auto path = crossing.pathLength(plane);
     isIn = path.first;
-    if  unlikely(!path.first) stat.ns1++;
+    if  UNLIKELY(!path.first) stat.ns1++;
     else {
       auto gpos =  GlobalPoint(crossing.position(path.second));
       auto tpath2 = (gpos-tsos.globalPosition()).perp2();
@@ -100,7 +100,7 @@ GeomDetCompatibilityChecker::isCompatible(const GeomDet* theDet,
 
   // precise propagation
   TrajectoryStateOnSurface && propSt = prop.propagate( tsos, theDet->specificSurface());
-  if unlikely ( !propSt.isValid()) { stat.nf1++; return std::make_pair( false, std::move(propSt));}
+  if UNLIKELY ( !propSt.isValid()) { stat.nf1++; return std::make_pair( false, std::move(propSt));}
 
 
   auto es = est.estimate( propSt, theDet->specificSurface());

--- a/TrackingTools/DetLayers/src/GeometricSearchDet.cc
+++ b/TrackingTools/DetLayers/src/GeometricSearchDet.cc
@@ -11,7 +11,7 @@ GeometricSearchDet::compatibleDetsV( const TrajectoryStateOnSurface& startingSta
 				     const MeasurementEstimator& est,
 				     std::vector<DetWithState>& result) const {
   
-  if unlikely(!hasGroups()) edm::LogError("DetLayers") << "At the moment not a real implementation" ;
+  if UNLIKELY(!hasGroups()) edm::LogError("DetLayers") << "At the moment not a real implementation" ;
 
 
   // standard implementation of compatibleDets() for class which have 

--- a/TrackingTools/GeomPropagators/interface/HelixForwardPlaneCrossing.h
+++ b/TrackingTools/GeomPropagators/interface/HelixForwardPlaneCrossing.h
@@ -4,6 +4,7 @@
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 #include "TrackingTools/GeomPropagators/interface/HelixPlaneCrossing.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
+#include "FWCore/Utilities/interface/Likely.h"
 #include <limits>
 
 /** Calculates intersections of a helix with planes perpendicular to the z-axis.
@@ -27,7 +28,7 @@ public:
     //
     // Protect against p_z=0 and calculate path length
     //
-    if unlikely( std::abs(theCosTheta)<std::numeric_limits<float>::min()  )  return std::pair<bool,double>(false,0);
+    if UNLIKELY( std::abs(theCosTheta)<std::numeric_limits<float>::min()  )  return std::pair<bool,double>(false,0);
     
     double dS = (plane.position().z()-theZ0) / theCosTheta;
     

--- a/TrackingTools/GeomPropagators/src/AnalyticalPropagator.cc
+++ b/TrackingTools/GeomPropagators/src/AnalyticalPropagator.cc
@@ -17,6 +17,7 @@
 #include "TrackingTools/GeomPropagators/interface/PropagationExceptions.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Likely.h"
 
 #include <cmath>
 
@@ -35,13 +36,13 @@ AnalyticalPropagator::propagateWithPath(const FreeTrajectoryState& fts,
   double s;
   
   // check if already on plane
-  if likely (plane.localZclamped(fts.position()) !=0)  {
+  if LIKELY (plane.localZclamped(fts.position()) !=0)  {
       // propagate
       bool parametersOK = this->propagateParametersOnPlane(fts, plane, x, p, s);
       // check status and deltaPhi limit
       float dphi2 = float(s)*rho;
       dphi2 = dphi2*dphi2*fts.momentum().perp2();
-      if unlikely( !parametersOK || dphi2>theMaxDPhi2*fts.momentum().mag2() )  return TsosWP(TrajectoryStateOnSurface(),0.);
+      if UNLIKELY( !parametersOK || dphi2>theMaxDPhi2*fts.momentum().mag2() )  return TsosWP(TrajectoryStateOnSurface(),0.);
     }
   else {
     LogDebug("AnalyticalPropagator")<<"not going anywhere. Already on surface.\n"
@@ -56,7 +57,7 @@ AnalyticalPropagator::propagateWithPath(const FreeTrajectoryState& fts,
   // Compute propagated state and check change in curvature
   //
   GlobalTrajectoryParameters gtp(x,p,fts.charge(),theField);
-  if unlikely(std::abs(gtp.transverseCurvature()-rho)>theMaxDBzRatio*std::abs(rho) ) 
+  if UNLIKELY(std::abs(gtp.transverseCurvature()-rho)>theMaxDBzRatio*std::abs(rho) ) 
     return TsosWP(TrajectoryStateOnSurface(),0.);
   //
   // construct TrajectoryStateOnSurface
@@ -81,12 +82,12 @@ AnalyticalPropagator::propagateWithPath(const FreeTrajectoryState& fts,
   // check status and deltaPhi limit
   float dphi2 = s*rho;
   dphi2 = dphi2*dphi2*fts.momentum().perp2();
-  if unlikely( !parametersOK || dphi2>theMaxDPhi2*fts.momentum().mag2() )  return TsosWP(TrajectoryStateOnSurface(),0.);
+  if UNLIKELY( !parametersOK || dphi2>theMaxDPhi2*fts.momentum().mag2() )  return TsosWP(TrajectoryStateOnSurface(),0.);
   //
   // Compute propagated state and check change in curvature
   //
   GlobalTrajectoryParameters gtp(x,p,fts.charge(),theField);
-  if unlikely( std::abs(gtp.transverseCurvature()-rho)>theMaxDBzRatio*std::abs(rho) ) 
+  if UNLIKELY( std::abs(gtp.transverseCurvature()-rho)>theMaxDBzRatio*std::abs(rho) ) 
     return TsosWP(TrajectoryStateOnSurface(),0.);
   //
   // create result TSOS on TangentPlane (local parameters & errors are better defined)
@@ -146,7 +147,7 @@ bool AnalyticalPropagator::propagateParametersOnCylinder(
 {
 
   GlobalPoint const & sp = cylinder.position();
-  if unlikely(sp.x()!=0. || sp.y()!=0.) {
+  if UNLIKELY(sp.x()!=0. || sp.y()!=0.) {
     throw PropagationException("Cannot propagate to an arbitrary cylinder");
   }
   // preset output
@@ -159,7 +160,7 @@ bool AnalyticalPropagator::propagateParametersOnCylinder(
   // Straight line approximation? |rho|<1.e-10 equivalent to ~ 1um 
   // difference in transversal position at 10m.
   //
-  if unlikely( std::abs(rho)<1.e-10f )
+  if UNLIKELY( std::abs(rho)<1.e-10f )
     return propagateWithLineCrossing(fts.position(),p,cylinder,x,s);
   //
   // Helix case
@@ -173,7 +174,7 @@ bool AnalyticalPropagator::propagateParametersOnCylinder(
   //
   HelixBarrelCylinderCrossing cylinderCrossing(fts.position(),fts.momentum(),rho,
 					       propagationDirection(),cylinder);
-  if unlikely( !cylinderCrossing.hasSolution() )  return false;
+  if UNLIKELY( !cylinderCrossing.hasSolution() )  return false;
   // path length
   s = cylinderCrossing.pathLength();
   // point
@@ -200,7 +201,7 @@ AnalyticalPropagator::propagateParametersOnPlane(const FreeTrajectoryState& fts,
   // Straight line approximation? |rho|<1.e-10 equivalent to ~ 1um 
   // difference in transversal position at 10m.
   //
-  if unlikely( std::abs(rho)<1.e-10f )
+  if UNLIKELY( std::abs(rho)<1.e-10f )
     return propagateWithLineCrossing(fts.position(),p,plane,x,s);
   //
   // Helix case 
@@ -213,7 +214,7 @@ AnalyticalPropagator::propagateParametersOnPlane(const FreeTrajectoryState& fts,
   //
   HelixPlaneCrossing::PositionType helixPos(x);
   HelixPlaneCrossing::DirectionType helixDir(p);
-  if likely(isOldPropagationType) {
+  if LIKELY(isOldPropagationType) {
       OptimalHelixPlaneCrossing planeCrossing(plane,helixPos,helixDir,rho,propagationDirection());
       return propagateWithHelixCrossing(*planeCrossing,plane,fts.momentum().mag(),x,p,s);
     }
@@ -408,7 +409,7 @@ AnalyticalPropagator::propagateWithHelixCrossing (HelixPlaneCrossing& planeCross
 						  double& s) const {
   // get solution
   std::pair<bool,double> propResult = planeCrossing.pathLength(plane);
-  if unlikely( !propResult.first )  return false;
+  if UNLIKELY( !propResult.first )  return false;
 
   s = propResult.second;
   x = GlobalPoint(planeCrossing.position(s));

--- a/TrackingTools/GeomPropagators/src/HelixArbitraryPlaneCrossing.cc
+++ b/TrackingTools/GeomPropagators/src/HelixArbitraryPlaneCrossing.cc
@@ -85,7 +85,7 @@ HelixArbitraryPlaneCrossing::pathLength(const Plane& plane) {
   double dSTotal;
   // Use existing 2nd order object at first pass
   std::tie(notFail,dSTotal) = theQuadraticCrossingFromStart.pathLength(plane);
-  if unlikely(!notFail) return std::make_pair(notFail,dSTotal);
+  if UNLIKELY(!notFail) return std::make_pair(notFail,dSTotal);
   auto  xnew = positionInDouble(dSTotal);
 
   auto propDir = thePropDir;
@@ -93,7 +93,7 @@ HelixArbitraryPlaneCrossing::pathLength(const Plane& plane) {
   if ( propDir == anyDirection ) {
       propDir = newDir;
   }  else {
-     if unlikely( newDir!=propDir )  return std::pair<bool,double>(false,0);
+     if UNLIKELY( newDir!=propDir )  return std::pair<bool,double>(false,0);
   }
  
 
@@ -105,7 +105,7 @@ HelixArbitraryPlaneCrossing::pathLength(const Plane& plane) {
     //
     // return empty solution vector if no convergence after maxIterations iterations
     //
-    if unlikely( --iteration == 0 ) {
+    if UNLIKELY( --iteration == 0 ) {
       LogDebug("HelixArbitraryPlaneCrossing") << "pathLength : no convergence";
       return std::pair<bool,double>(false,0);
     }
@@ -122,7 +122,7 @@ HelixArbitraryPlaneCrossing::pathLength(const Plane& plane) {
     auto  deltaS2 = quadraticCrossing.pathLength(plane);
    
      
-    if unlikely( !deltaS2.first )  return deltaS2;
+    if UNLIKELY( !deltaS2.first )  return deltaS2;
     //
     // Calculate and sort total pathlength (max. 2 solutions)
     //
@@ -132,7 +132,7 @@ HelixArbitraryPlaneCrossing::pathLength(const Plane& plane) {
       propDir = newDir;
     }
     else {
-      if unlikely( newDir!=propDir )  return std::pair<bool,double>(false,0);
+      if UNLIKELY( newDir!=propDir )  return std::pair<bool,double>(false,0);
     }
     //
     // Step forward by dSTotal.
@@ -163,7 +163,7 @@ HelixArbitraryPlaneCrossing::positionInDouble (double s) const {
   //
   // Calculate delta phi (if not already available)
   //
-  if unlikely( s!=theCachedS ) {
+  if UNLIKELY( s!=theCachedS ) {
     theCachedS = s;
     theCachedDPhi = theCachedS*theRho*theSinTheta;
     vdt::fast_sincos(theCachedDPhi,theCachedSDPhi,theCachedCDPhi);
@@ -210,7 +210,7 @@ HelixArbitraryPlaneCrossing::directionInDouble (double s) const {
   //
   // Calculate delta phi (if not already available)
   //
-  if unlikely( s!=theCachedS ) {  // very very unlikely!
+  if UNLIKELY( s!=theCachedS ) {  // very very unlikely!
     theCachedS = s;
     theCachedDPhi = theCachedS*theRho*theSinTheta;
     vdt::fast_sincos(theCachedDPhi,theCachedSDPhi,theCachedCDPhi);

--- a/TrackingTools/GeomPropagators/src/HelixArbitraryPlaneCrossing2Order.cc
+++ b/TrackingTools/GeomPropagators/src/HelixArbitraryPlaneCrossing2Order.cc
@@ -60,7 +60,7 @@ HelixArbitraryPlaneCrossing2Order::pathLength(const Plane& plane) {
   //   curvature, forward plane or direction perp. to plane)
   //
   double dS1,dS2;
-  if likely( std::abs(ceq1)>FLT_MIN ) {
+  if LIKELY( std::abs(ceq1)>FLT_MIN ) {
     double deq1 = ceq2*ceq2;
     double deq2 = ceq1*ceq3;
     if ( std::abs(deq1)<FLT_MIN || std::abs(deq2/deq1)>1.e-6 ) {
@@ -68,7 +68,7 @@ HelixArbitraryPlaneCrossing2Order::pathLength(const Plane& plane) {
       // Standard solution for quadratic equations
       //
       double deq = deq1+2*deq2;
-      if unlikely( deq<0. )  return std::pair<bool,double>(false,0);
+      if UNLIKELY( deq<0. )  return std::pair<bool,double>(false,0);
       double ceq =  ceq2+std::copysign(std::sqrt(deq),ceq2);
       dS1 = (ceq/ceq1)*theSinThetaI;
       dS2 = -2.*(ceq3/ceq)*theSinThetaI;

--- a/TrackingTools/GsfTools/src/BasicMultiTrajectoryState.cc
+++ b/TrackingTools/GsfTools/src/BasicMultiTrajectoryState.cc
@@ -10,24 +10,24 @@ BasicMultiTrajectoryState::BasicMultiTrajectoryState( const std::vector<TSOS>& t
  
   // only accept planes!!
   const BoundPlane* bp = dynamic_cast<const BoundPlane*>(&tsvec.begin()->surface());
-  if unlikely( bp==nullptr )
+  if UNLIKELY( bp==nullptr )
 	       throw cms::Exception("LogicError") << "MultiTrajectoryState constructed on cylinder";
    
   for (auto i=tsvec.begin(); i!=tsvec.end(); i++) {
-    if unlikely(!i->isValid()) {
+    if UNLIKELY(!i->isValid()) {
       throw cms::Exception("LogicError") << "MultiTrajectoryState constructed with invalid state";
     }
-    if unlikely(i->hasError() != tsvec.front().hasError()) {
+    if UNLIKELY(i->hasError() != tsvec.front().hasError()) {
       throw cms::Exception("LogicError") << "MultiTrajectoryState mixes states with and without errors";
     }
-    if unlikely( &i->surface() != &tsvec.front().surface()) {
+    if UNLIKELY( &i->surface() != &tsvec.front().surface()) {
       throw cms::Exception("LogicError") << "MultiTrajectoryState mixes states with different surfaces";
     }
-    if unlikely( i->surfaceSide() != tsvec.front().surfaceSide()) {
+    if UNLIKELY( i->surfaceSide() != tsvec.front().surfaceSide()) {
       throw cms::Exception("LogicError") 
 	<< "MultiTrajectoryState mixes states defined before and after material";
     }
-    if unlikely( i->localParameters().pzSign()*tsvec.front().localParameters().pzSign()<0. ) {
+    if UNLIKELY( i->localParameters().pzSign()*tsvec.front().localParameters().pzSign()<0. ) {
       throw cms::Exception("LogicError") 
 	<< "MultiTrajectoryState mixes states with different signs of local p_z";
     }
@@ -41,7 +41,7 @@ BasicMultiTrajectoryState::BasicMultiTrajectoryState( const std::vector<TSOS>& t
 
 void BasicMultiTrajectoryState::rescaleError(double factor) {
 
-  if unlikely(theStates.empty()) {
+  if UNLIKELY(theStates.empty()) {
     edm::LogError("BasicMultiTrajectoryState") << "Trying to rescale errors of empty MultiTrajectoryState!";
     return;
   }
@@ -54,7 +54,7 @@ void
 BasicMultiTrajectoryState::combine()  {
   const std::vector<TrajectoryStateOnSurface>& tsos = theStates;
 
-  if unlikely(tsos.empty()) {
+  if UNLIKELY(tsos.empty()) {
     edm::LogError("MultiTrajectoryStateCombiner") 
       << "Trying to collapse empty set of trajectory states!";
     return;
@@ -63,14 +63,14 @@ BasicMultiTrajectoryState::combine()  {
   double pzSign = tsos.front().localParameters().pzSign();
   for (std::vector<TrajectoryStateOnSurface>::const_iterator it = tsos.begin(); 
        it != tsos.end(); it++) {
-    if unlikely(it->localParameters().pzSign() != pzSign) {
+    if UNLIKELY(it->localParameters().pzSign() != pzSign) {
       edm::LogError("MultiTrajectoryStateCombiner") 
 	<< "Trying to collapse trajectory states with different signs on p_z!";
       return;
     }
   }
   
-  if unlikely(tsos.size() == 1) {
+  if UNLIKELY(tsos.size() == 1) {
     BasicTrajectoryState::update(tsos.front().weight(),
                                  tsos.front().localParameters(), 
 				 tsos.front().localError(), 

--- a/TrackingTools/MaterialEffects/src/MultipleScatteringUpdator.cc
+++ b/TrackingTools/MaterialEffects/src/MultipleScatteringUpdator.cc
@@ -24,7 +24,7 @@ void MultipleScatteringUpdator::compute (const TrajectoryStateOnSurface& TSoS,
   // Now get information on medium
   //
   const MediumProperties& mp = surface.mediumProperties();
-  if unlikely(mp.radLen()==0) return;
+  if UNLIKELY(mp.radLen()==0) return;
 
   // Momentum vector
   LocalVector d = TSoS.localMomentum();

--- a/TrackingTools/MaterialEffects/src/PropagatorWithMaterial.cc
+++ b/TrackingTools/MaterialEffects/src/PropagatorWithMaterial.cc
@@ -36,7 +36,7 @@ PropagatorWithMaterial::propagateWithPath (const FreeTrajectoryState& fts,
       bool updateOk = theMEUpdator->updateStateInPlace(newTsosWP.first,
                                                        PropagationDirectionFromPath()(newTsosWP.second,
                                                                                       propagationDirection()));
-      if unlikely(!updateOk) newTsosWP.first = TrajectoryStateOnSurface();
+      if UNLIKELY(!updateOk) newTsosWP.first = TrajectoryStateOnSurface();
   }
   return newTsosWP;
 }
@@ -49,7 +49,7 @@ PropagatorWithMaterial::propagateWithPath (const FreeTrajectoryState& fts,
       bool updateOk = theMEUpdator->updateStateInPlace(newTsosWP.first,
                                                        PropagationDirectionFromPath()(newTsosWP.second,
                                                                                       propagationDirection()));
-      if unlikely(!updateOk) newTsosWP.first = TrajectoryStateOnSurface();
+      if UNLIKELY(!updateOk) newTsosWP.first = TrajectoryStateOnSurface();
   }
   return newTsosWP;
 }
@@ -64,21 +64,21 @@ PropagatorWithMaterial::propagateWithPath (const TrajectoryStateOnSurface& tsos,
   TsosWP newTsosWP(tsos,0.);
   if ( materialAtSource() ) {
     bool updateOk = theMEUpdator->updateStateInPlace(newTsosWP.first,propagationDirection());
-    if unlikely(!updateOk) newTsosWP.first = TrajectoryStateOnSurface();
+    if UNLIKELY(!updateOk) newTsosWP.first = TrajectoryStateOnSurface();
   }
-  if unlikely( !newTsosWP.first.isValid() )  return newTsosWP;
+  if UNLIKELY( !newTsosWP.first.isValid() )  return newTsosWP;
   //
   // geometrical propagation
   //
   newTsosWP = theGeometricalPropagator->propagateWithPath(newTsosWP.first,plane);
-  if unlikely( !newTsosWP.first.isValid() || materialAtSource() )  return newTsosWP;
+  if UNLIKELY( !newTsosWP.first.isValid() || materialAtSource() )  return newTsosWP;
   //
   // add material at destination surface, if requested
   //
   bool updateOk = theMEUpdator->updateStateInPlace(newTsosWP.first,
                                                    PropagationDirectionFromPath()(newTsosWP.second,
                                                                                   propagationDirection()));
-  if unlikely(!updateOk) newTsosWP.first = TrajectoryStateOnSurface();
+  if UNLIKELY(!updateOk) newTsosWP.first = TrajectoryStateOnSurface();
   return newTsosWP;
 }
 
@@ -91,21 +91,21 @@ PropagatorWithMaterial::propagateWithPath (const TrajectoryStateOnSurface& tsos,
   TsosWP newTsosWP(tsos,0.);
   if ( materialAtSource() ) {
     bool updateOk = theMEUpdator->updateStateInPlace(newTsosWP.first,propagationDirection());
-    if unlikely(!updateOk) newTsosWP.first = TrajectoryStateOnSurface();
+    if UNLIKELY(!updateOk) newTsosWP.first = TrajectoryStateOnSurface();
   }
-  if unlikely( !newTsosWP.first.isValid() )  return newTsosWP;
+  if UNLIKELY( !newTsosWP.first.isValid() )  return newTsosWP;
   //
   // geometrical propagation
   //
   newTsosWP = theGeometricalPropagator->propagateWithPath(newTsosWP.first,cylinder);
-  if unlikely( !(newTsosWP.first).isValid() || materialAtSource() )  return newTsosWP;
+  if UNLIKELY( !(newTsosWP.first).isValid() || materialAtSource() )  return newTsosWP;
   //
   // add material at destination surface, if requested
   //
   bool updateOk = theMEUpdator->updateStateInPlace(newTsosWP.first,
                                                    PropagationDirectionFromPath()(newTsosWP.second,
                                                                                   propagationDirection()));
-  if unlikely(!updateOk) newTsosWP.first = TrajectoryStateOnSurface();
+  if UNLIKELY(!updateOk) newTsosWP.first = TrajectoryStateOnSurface();
   return newTsosWP;
 }
 
@@ -116,7 +116,7 @@ void PropagatorWithMaterial::setPropagationDirection (PropagationDirection dir) 
 
 bool
 PropagatorWithMaterial::materialAtSource() const {
-  if unlikely( (propagationDirection()==anyDirection) &&  (theMaterialLocation!=atDestination) )
+  if UNLIKELY( (propagationDirection()==anyDirection) &&  (theMaterialLocation!=atDestination) )
 	       throw cms::Exception("TrackingTools/MaterialEffects",
 				    "PropagatorWithMaterial: propagation direction = anyDirection is incompatible with adding of material at source");
 

--- a/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
+++ b/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
@@ -55,7 +55,7 @@ namespace {
 
     for ( auto const & ds : compatDets) {
       MeasurementDetWithData mdet = theDetSystem->idToDet(ds.first->geographicalId(), *theData);
-      if unlikely(mdet.isNull()) {
+      if UNLIKELY(mdet.isNull()) {
 	throw MeasurementDetException( "MeasurementDet not found");
       }
       

--- a/TrackingTools/PatternTools/src/TempTrajectory.cc
+++ b/TrackingTools/PatternTools/src/TempTrajectory.cc
@@ -121,7 +121,7 @@ void TempTrajectory::check() const {
 
 bool TempTrajectory::lost( const TrackingRecHit& hit)
 {
-  if  likely(hit.isValid()) return false;
+  if  LIKELY(hit.isValid()) return false;
 
   //     // A DetLayer is always inactive in this logic.
   //     // The DetLayer is the Det of an invalid RecHit only if no DetUnit 

--- a/TrackingTools/TrackFitters/src/KFTrajectoryFitter.cc
+++ b/TrackingTools/TrackFitters/src/KFTrajectoryFitter.cc
@@ -36,7 +36,7 @@ Trajectory KFTrajectoryFitter::fitOne(const TrajectorySeed& aSeed,
   if(hits.empty()) return Trajectory();
 
 
-  if unlikely(aSeed.direction() == anyDirection)
+  if UNLIKELY(aSeed.direction() == anyDirection)
     throw cms::Exception("KFTrajectoryFitter","TrajectorySeed::direction() requested but not set");
 
   std::unique_ptr<Propagator> p_cloned = SetPropagationDirection(*thePropagator,
@@ -70,9 +70,9 @@ Trajectory KFTrajectoryFitter::fitOne(const TrajectorySeed& aSeed,
 
     const TransientTrackingRecHit & hit = (*ihit);
 
-    // if unlikely(hit.det() == nullptr) continue;
+    // if UNLIKELY(hit.det() == nullptr) continue;
 
-    if unlikely( (!hit.isValid()) && hit.surface() == nullptr) {
+    if UNLIKELY( (!hit.isValid()) && hit.surface() == nullptr) {
        LogDebug("TrackFitters")<< " Error: invalid hit with no GeomDet attached .... skipping";
       continue;
     }
@@ -83,7 +83,7 @@ Trajectory KFTrajectoryFitter::fitOne(const TrajectorySeed& aSeed,
       predTsos = p_cloned->propagate( currTsos, *(hit.surface()) );
 
 
-    if unlikely(!predTsos.isValid()) {
+    if UNLIKELY(!predTsos.isValid()) {
       LogDebug("TrackFitters")
 	<< "SOMETHING WRONG !" << "\n"
 	<< "KFTrajectoryFitter: predicted tsos not valid!\n"
@@ -101,7 +101,7 @@ Trajectory KFTrajectoryFitter::fitOne(const TrajectorySeed& aSeed,
     }
 
 
-    if likely(hit.isValid()) {
+    if LIKELY(hit.isValid()) {
         assert( (hit.geographicalId()!=0U) | !hit.canImproveWithTrack() ) ;
        	assert(hit.surface()!=nullptr);
 	//update
@@ -114,7 +114,7 @@ Trajectory KFTrajectoryFitter::fitOne(const TrajectorySeed& aSeed,
        	assert( (preciseHit->geographicalId()!=0U)  | (!preciseHit->canImproveWithTrack()) );
        	assert(preciseHit->surface()!=nullptr);
 
-	if unlikely(!preciseHit->isValid()){
+	if UNLIKELY(!preciseHit->isValid()){
 	    LogTrace("TrackFitters") << "THE Precise HIT IS NOT VALID: using currTsos = predTsos" << "\n";
 	    currTsos = predTsos;
 	    myTraj.push(TM(predTsos, ihit,0,theGeometry->idToLayer((ihit)->geographicalId()) ));
@@ -132,7 +132,7 @@ Trajectory KFTrajectoryFitter::fitOne(const TrajectorySeed& aSeed,
                ) ) 
             || edm::isNotFinite(currTsos.localParameters().qbp()) 
             || !currTsos.localError().posDef();
-	  if unlikely(badState){
+	  if UNLIKELY(badState){
 	    if (!currTsos.isValid()) {
 	      edm::LogError("FailedUpdate") <<"updating with the hit failed. Not updating the trajectory with the hit";
 

--- a/TrackingTools/TrackFitters/src/KFTrajectorySmoother.cc
+++ b/TrackingTools/TrackFitters/src/KFTrajectorySmoother.cc
@@ -54,7 +54,7 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
 
   do {
     auto hitSize = avtm.rend()-start;
-    if unlikely( hitSize < minHits_ ) {
+    if UNLIKELY( hitSize < minHits_ ) {
       LogDebug("TrackFitters") << " killing trajectory" << "\n";
       return Trajectory();
     }
@@ -73,8 +73,8 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
     TransientTrackingRecHit::ConstRecHitPointer hit = itm->recHit();
 
     //check surface just for safety: should never be ==0 because they are skipped in the fitter 
-    // if unlikely(hit->det() == nullptr) continue;
-    if unlikely( hit->surface()==nullptr ) {
+    // if UNLIKELY(hit->det() == nullptr) continue;
+    if UNLIKELY( hit->surface()==nullptr ) {
 	LogDebug("TrackFitters") << " Error: invalid hit with no GeomDet attached .... skipping";
 	continue;
       }
@@ -83,7 +83,7 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
     if (itm != start)//no propagation needed for first smoothed (==last fitted) hit 
       predTsos = usePropagator->propagate( currTsos, *(hit->surface()) );
 
-    if unlikely(!predTsos.isValid()) {
+    if UNLIKELY(!predTsos.isValid()) {
       LogDebug("TrackFitters") << "KFTrajectorySmoother: predicted tsos not valid!";
       LogDebug("TrackFitters") << " retry with last hit removed" << "\n";
       LogDebug("TrackFitters")
@@ -113,7 +113,7 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
       else if (hitCounter == 1) combTsos = predTsos;
       else combTsos = combiner(predTsos, itm->forwardPredictedState());
       
-      if unlikely(!combTsos.isValid()) {
+      if UNLIKELY(!combTsos.isValid()) {
 	  LogDebug("TrackFitters") << 
 	    "KFTrajectorySmoother: combined tsos not valid!\n" <<
 	    "pred Tsos pos: " << predTsos.globalPosition() << "\n" <<
@@ -135,7 +135,7 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
 
         dump(*hit,hitCounter,"TrackFitters");
 
-      if unlikely(!preciseHit->isValid()){
+      if UNLIKELY(!preciseHit->isValid()){
 	  LogTrace("TrackFitters") << "THE Precise HIT IS NOT VALID: using currTsos = predTsos" << "\n";
 	  currTsos = predTsos;
 	  myTraj.push(TM(predTsos, hit, 0, theGeometry->idToLayer(hit->geographicalId()) ));
@@ -144,7 +144,7 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
 	
 	//update backward predicted tsos with the hit
 	currTsos = updator()->update(predTsos, *preciseHit);
-        if unlikely(!currTsos.isValid()) {
+        if UNLIKELY(!currTsos.isValid()) {
 	    currTsos = predTsos;
 	    edm::LogWarning("KFSmoother_UpdateFailed") << 
 	      "Failed updating state with hit. Rolling back to non-updated state.\n" <<
@@ -161,7 +161,7 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
 	else if (hitCounter == 1) smooTsos = currTsos;
 	else smooTsos = combiner(itm->forwardPredictedState(), currTsos); 
 	
-	if unlikely(!smooTsos.isValid()) {
+	if UNLIKELY(!smooTsos.isValid()) {
 	    LogDebug("TrackFitters") << "KFTrajectorySmoother: smoothed tsos not valid!";
             start++;
             retry = true;
@@ -212,7 +212,7 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
       else if (hitCounter == 1) combTsos = predTsos;
       else combTsos = combiner(predTsos, itm->forwardPredictedState());
       
-      if unlikely(!combTsos.isValid()) {
+      if UNLIKELY(!combTsos.isValid()) {
     	LogDebug("TrackFitters") << 
     	  "KFTrajectorySmoother: combined tsos not valid!";
         return Trajectory();

--- a/TrackingTools/TrajectoryParametrization/interface/PerigeeTrajectoryError.h
+++ b/TrackingTools/TrajectoryParametrization/interface/PerigeeTrajectoryError.h
@@ -41,7 +41,7 @@ public:
    */
   const AlgebraicSymMatrix55 &weightMatrix(int & error) const
   {
-    if unlikely(!weightIsAvailable) calculateWeightMatrix();
+    if UNLIKELY(!weightIsAvailable) calculateWeightMatrix();
     error = inverseError;
     return thePerigeeWeight;
   }

--- a/TrackingTools/TrajectoryParametrization/src/LocalTrajectoryError.cc
+++ b/TrackingTools/TrajectoryParametrization/src/LocalTrajectoryError.cc
@@ -16,7 +16,7 @@ LocalTrajectoryError( float dx, float dy, float dxdir, float dydir,
 }
 
 const AlgebraicSymMatrix55 & LocalTrajectoryError::weightMatrix() const {
-  if unlikely(theWeightMatrixPtr.get() == nullptr) {
+  if UNLIKELY(theWeightMatrixPtr.get() == nullptr) {
     theWeightMatrixPtr.reset(new AlgebraicSymMatrix55());
     invertPosDefMatrix(theCovarianceMatrix,*theWeightMatrixPtr);
   }

--- a/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
+++ b/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
@@ -21,6 +21,7 @@
 #include "DataFormats/GeometryCommonDetAlgo/interface/DeepCopyPointer.h"
 #include "DataFormats/GeometrySurface/interface/Surface.h"
 #include "TrackingTools/TrajectoryParametrization/interface/TrajectoryStateExceptions.h"
+#include "FWCore/Utilities/interface/Likely.h"
 
 /// vvv DEBUG
 // #include <iostream>
@@ -225,14 +226,14 @@ public:
   }
 
   const CartesianTrajectoryError cartesianError() const {
-    if unlikely(!hasError()) {
+    if UNLIKELY(!hasError()) {
 	missingError(" accesing cartesian error.");
 	return CartesianTrajectoryError();
       }
     return freeTrajectoryState(true)->cartesianError();
   }
   const CurvilinearTrajectoryError& curvilinearError() const {
-    if unlikely(!hasError()) {
+    if UNLIKELY(!hasError()) {
 	missingError(" accesing curvilinearerror.");
 	static const CurvilinearTrajectoryError crap;
 	return crap;
@@ -243,7 +244,7 @@ public:
 
 
   FreeTrajectoryState const* freeTrajectoryState(bool withErrors=true) const {
-    if unlikely(!isValid()) notValid();
+    if UNLIKELY(!isValid()) notValid();
     if(withErrors && hasError()) { // this is the right thing
       checkCurvilinError();
     }
@@ -255,8 +256,8 @@ public:
 
 // access local parameters/errors
   const LocalTrajectoryParameters& localParameters() const {
-    if unlikely(!isValid()) notValid();
-    if unlikely(!theLocalParametersValid)
+    if UNLIKELY(!isValid()) notValid();
+    if UNLIKELY(!theLocalParametersValid)
       createLocalParameters();
     return theLocalParameters;
   }
@@ -271,11 +272,11 @@ public:
   }
 
   const LocalTrajectoryError& localError() const {
-    if unlikely(!hasError()) {
+    if UNLIKELY(!hasError()) {
 	missingError(" accessing local error.");
 	return theLocalError;
       }
-    if unlikely(theLocalError.invalid()) createLocalError();
+    if UNLIKELY(theLocalError.invalid()) createLocalError();
     return theLocalError;
   }
 

--- a/TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h
+++ b/TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h
@@ -112,14 +112,14 @@ public:
 
 
   CartesianTrajectoryError cartesianError() const {
-    if unlikely(!hasError()) missingError();
+    if UNLIKELY(!hasError()) missingError();
     CartesianTrajectoryError aCartesianError;
     createCartesianError(aCartesianError);
     return aCartesianError;
   }
 
   const CurvilinearTrajectoryError& curvilinearError() const {
-    if  unlikely(!hasError()) missingError();
+    if  UNLIKELY(!hasError()) missingError();
     return theCurvilinearError;
   }
 

--- a/TrackingTools/TrajectoryState/interface/ProxyBase11.h
+++ b/TrackingTools/TrajectoryState/interface/ProxyBase11.h
@@ -67,7 +67,7 @@ public:
 
   void check() const {
 #ifdef TR_DEBUG
-    if  unlikely(!theData) std::cout << "dead proxyBase11 " << references() << std::endl;
+    if  UNLIKELY(!theData) std::cout << "dead proxyBase11 " << references() << std::endl;
 #endif
   }
 

--- a/TrackingTools/TrajectoryState/src/BasicTrajectoryState.cc
+++ b/TrackingTools/TrajectoryState/src/BasicTrajectoryState.cc
@@ -100,14 +100,14 @@ void BasicTrajectoryState::notValid() {
 
 namespace {
   void verifyLocalErr(LocalTrajectoryError const & err, const FreeTrajectoryState & state ) {
-     if unlikely(!err.posDef())
+     if UNLIKELY(!err.posDef())
                  edm::LogWarning("BasicTrajectoryState") << "local error not pos-def\n"
                                                         <<  err.matrix()
                                                          << "\npos/mom/mf " << state.position() << ' ' << state.momentum()
                                                           <<  ' ' << state.parameters().magneticFieldInTesla();
   }
   void verifyCurvErr(CurvilinearTrajectoryError const & err, const FreeTrajectoryState & state ) {
-     if unlikely(!err.posDef())
+     if UNLIKELY(!err.posDef())
                  edm::LogWarning("BasicTrajectoryState") << "curv error not pos-def\n" 
                                                         <<  err.matrix()
                                                          << "\npos/mom/mf " << state.position() << ' ' << state.momentum()
@@ -131,9 +131,9 @@ void BasicTrajectoryState::missingError(char const * where) const{
 
 
 void BasicTrajectoryState::checkCurvilinError() const {
-  if likely(theFreeState.hasCurvilinearError()) return;
+  if LIKELY(theFreeState.hasCurvilinearError()) return;
 
-  if unlikely(!theLocalParametersValid) createLocalParameters();
+  if UNLIKELY(!theLocalParametersValid) createLocalParameters();
   
   JacobianLocalToCurvilinear loc2Curv(surface(), localParameters(), globalParameters(), *magneticField());
   const AlgebraicMatrix55& jac = loc2Curv.jacobian();
@@ -160,7 +160,7 @@ void BasicTrajectoryState::createLocalParameters() const {
 }
 
 void BasicTrajectoryState::createLocalError() const {
-  if likely(theFreeState.hasCurvilinearError())
+  if LIKELY(theFreeState.hasCurvilinearError())
     createLocalErrorFromCurvilinearError();
   else theLocalError = InvalidError();
 }
@@ -248,13 +248,13 @@ BasicTrajectoryState::update( const LocalTrajectoryParameters& p,
 
 void 
 BasicTrajectoryState::rescaleError(double factor) {
-  if unlikely(!hasError()) missingError(" trying to rescale");    
+  if UNLIKELY(!hasError()) missingError(" trying to rescale");    
   theFreeState.rescaleError(factor);
   
   if (theLocalError.valid()){
     //do it by hand if the free state is not around.
     bool zeroField = (magneticField()->nominalValue()==0);
-    if unlikely(zeroField){
+    if UNLIKELY(zeroField){
       AlgebraicSymMatrix55 errors=theLocalError.matrix();
       //scale the 0 indexed covariance by the square root of the factor
       for (unsigned int i=1;i!=5;++i)      errors(i,0)*=factor;

--- a/TrackingTools/TrajectoryState/src/FreeTrajectoryState.cc
+++ b/TrackingTools/TrajectoryState/src/FreeTrajectoryState.cc
@@ -6,6 +6,8 @@
 
 #include "MagneticField/Engine/interface/MagneticField.h"
 
+#include "FWCore/Utilities/interface/Likely.h"
+
 #include <cmath>
 #include<sstream>
 
@@ -48,9 +50,9 @@ void FreeTrajectoryState::createCurvilinearError(CartesianTrajectoryError const&
 
 
 void FreeTrajectoryState::rescaleError(double factor) {
-  if unlikely(!hasError()) return;
+  if UNLIKELY(!hasError()) return;
   bool zeroField = (parameters().magneticField().nominalValue()==0);  
-  if unlikely(zeroField)  theCurvilinearError.zeroFieldScaling(factor*factor);
+  if UNLIKELY(zeroField)  theCurvilinearError.zeroFieldScaling(factor*factor);
   else theCurvilinearError *= (factor*factor);
 }
 

--- a/TrackingTools/TransientTrack/src/TransientTrackFromFTS.cc
+++ b/TrackingTools/TransientTrack/src/TransientTrackFromFTS.cc
@@ -89,13 +89,13 @@ void TransientTrackFromFTS::setBeamSpot(const BeamSpot& beamSpot)
 
 TrajectoryStateOnSurface TransientTrackFromFTS::impactPointState() const
 {
-  if unlikely(!initialTSOSAvailable) calculateTSOSAtVertex();
+  if UNLIKELY(!initialTSOSAvailable) calculateTSOSAtVertex();
   return initialTSOS;
 }
 
 TrajectoryStateClosestToPoint TransientTrackFromFTS::impactPointTSCP() const
 {
-  if unlikely(!initialTSCPAvailable) {
+  if UNLIKELY(!initialTSCPAvailable) {
     initialTSCP = builder(initialFTS, initialFTS.position());
     initialTSCPAvailable = true;
   }
@@ -131,7 +131,7 @@ TransientTrackFromFTS::stateOnSurface(const GlobalPoint & point) const
 
 const Track & TransientTrackFromFTS::track() const
 {
-  if unlikely(!trackAvailable) {
+  if UNLIKELY(!trackAvailable) {
     GlobalPoint v = initialFTS.position();
     math::XYZPoint  pos( v.x(), v.y(), v.z() );
     GlobalVector p = initialFTS.momentum();
@@ -146,7 +146,7 @@ const Track & TransientTrackFromFTS::track() const
 
 TrajectoryStateClosestToBeamLine TransientTrackFromFTS::stateAtBeamLine() const
 {
-  if unlikely(!blStateAvailable) {
+  if UNLIKELY(!blStateAvailable) {
     TSCBLBuilderNoMaterial blsBuilder;
     trajectoryStateClosestToBeamLine = blsBuilder(initialFTS, theBeamSpot);
     blStateAvailable = true;

--- a/Utilities/XrdAdaptor/src/XrdFile.cc
+++ b/Utilities/XrdAdaptor/src/XrdFile.cc
@@ -328,10 +328,10 @@ IOSize
 XrdFile::readv (IOPosBuffer *into, IOSize n)
 {
   // A trivial vector read - unlikely, considering ROOT data format.
-  if (unlikely(n == 0)) {
+  if (UNLIKELY(n == 0)) {
     return 0;
   }
-  if (unlikely(n == 1)) {
+  if (UNLIKELY(n == 1)) {
     return read(into[0].data(), into[0].size(), into[0].offset());
   }
 

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -10,6 +10,7 @@
 
 #include "FWCore/Utilities/interface/CPUTimer.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/Likely.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
@@ -262,7 +263,7 @@ RequestManager::updateCurrentServer()
     // NOTE: we use memory_order_relaxed here, meaning that we may actually miss
     // a pending update.  *However*, since we call this for every read, we'll get it
     // eventually.
-    if (likely(!m_serverToAdvertise.load(std::memory_order_relaxed))) {return;}
+    if (LIKELY(!m_serverToAdvertise.load(std::memory_order_relaxed))) {return;}
     std::string *hostname_ptr;
     if ((hostname_ptr = m_serverToAdvertise.exchange(nullptr)))
     {


### PR DESCRIPTION
The likely and unlikely macros were renamed to LIKELY and
UNLIKELY to avoid name collisions with a function in boost.
Using all capital letters is the C family standard for naming
macros so best to follow convention.