### PR TITLE
modernized Validation/DTRecHits

### DIFF
--- a/Validation/DTRecHits/interface/DTHitQualityUtils.h
+++ b/Validation/DTRecHits/interface/DTHitQualityUtils.h
@@ -1,5 +1,5 @@
-#ifndef DTHitQualityUtils_H
-#define DTHitQualityUtils_H
+#ifndef Validation_DTRecHits_DTHitQualityUtils_h
+#define Validation_DTRecHits_DTHitQualityUtils_h
 
 /** \class DTHitQualityUtils
  *  
@@ -16,46 +16,35 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 #include <map>
+#include <atomic>
 
 class PSimHit;
 class DTGeometry;
 
-class DTHitQualityUtils {
-public:
-
-  /// Constructor
-  DTHitQualityUtils();
-
-
-  /// Destructor
-  virtual ~DTHitQualityUtils();
+namespace DTHitQualityUtils {
 
   /// Operations
   /// Create a map between the SimHits in a chamber and the corrisponding MuBarWireId
-  static std::map<DTWireId, edm::PSimHitContainer > mapSimHitsPerWire(const edm::PSimHitContainer& simhits) ;
+  std::map<DTWireId, edm::PSimHitContainer > mapSimHitsPerWire(const edm::PSimHitContainer& simhits) ;
   /// Create a map between the Mu SimHits and corresponding MuBarWireId ;
-  static  std::map<DTWireId, const PSimHit*> mapMuSimHitsPerWire(const std::map<DTWireId, edm::PSimHitContainer>& simHitWireMap) ;
+  std::map<DTWireId, const PSimHit*> mapMuSimHitsPerWire(const std::map<DTWireId, edm::PSimHitContainer>& simHitWireMap) ;
   /// Select the SimHit from a muon in a vector of SimHits
-  static const PSimHit* findMuSimHit(const edm::PSimHitContainer& hits); 
+  const PSimHit* findMuSimHit(const edm::PSimHitContainer& hits); 
   /// Find Innermost and outermost SimHit from Mu in a SL (they identify a simulated segment)
-  static std::pair<const PSimHit*, const PSimHit*> findMuSimSegment(const std::map<DTWireId, const PSimHit*>& mapWireAndMuSimHit) ;
+  std::pair<const PSimHit*, const PSimHit*> findMuSimSegment(const std::map<DTWireId, const PSimHit*>& mapWireAndMuSimHit) ;
   /// Find direction and position of a segment (in local RF) from outer and inner mu SimHit in the RF of object Det
-  static std::pair<LocalVector, LocalPoint> findMuSimSegmentDirAndPos(const std::pair<const PSimHit*, const PSimHit*>& inAndOutSimHit, 
+  std::pair<LocalVector, LocalPoint> findMuSimSegmentDirAndPos(const std::pair<const PSimHit*, const PSimHit*>& inAndOutSimHit, 
 								      const DetId detId, const DTGeometry *muonGeom);
   /// Find the angles from a segment direction:
   /// atan(dx/dz) = "phi"   angle in the chamber RF
   /// atan(dy/dz) = "theta" angle in the chamber RF (note: this has opposite sign in the SLZ RF!)
-  static std::pair<double, double> findSegmentAlphaAndBeta(const LocalVector& direction);
+  std::pair<double, double> findSegmentAlphaAndBeta(const LocalVector& direction);
 
   // Set the verbosity level
-  static bool debug; 
+  extern std::atomic<bool> debug; 
 
   //Find angle error
-  static double sigmaAngle(double Angle, double sigma2TanAngle);
+  double sigmaAngle(double Angle, double sigma2TanAngle);
 
-protected:
-
-private:
-
-};
+}
 #endif

--- a/Validation/DTRecHits/plugins/DTSegment4DQuality.cc
+++ b/Validation/DTRecHits/plugins/DTSegment4DQuality.cc
@@ -47,7 +47,7 @@ struct Histograms {
 // simmetrized one.
 // Set mirrorMinusWheels to avoid this.
 namespace {
-  bool mirrorMinusWheels = true;
+  constexpr bool mirrorMinusWheels = true;
 }
 
 // Constructor

--- a/Validation/DTRecHits/src/DTHitQualityUtils.cc
+++ b/Validation/DTRecHits/src/DTHitQualityUtils.cc
@@ -17,17 +17,7 @@
 using namespace std;
 using namespace edm;
 
-bool DTHitQualityUtils::debug;
-
-// Constructor
-DTHitQualityUtils::DTHitQualityUtils(){
-  //DTHitQualityUtils::setDebug(debug);
-}
-
-// Destructor
-DTHitQualityUtils::~DTHitQualityUtils(){
-}
-
+std::atomic<bool> DTHitQualityUtils::debug{false};
 
 // Return a map between simhits of a layer,superlayer or chamber and the wireId of their cell
 map<DTWireId, PSimHitContainer >


### PR DESCRIPTION
DTHitQualityUtils was a class with only static members. This was
changed to be a namespace instead.
Converted global 'debug' variable to atomic.

Changed anonymous namespace global variable to be constexpr to avoid thread-safety issues.