### PR TITLE
Convert L1TStage2Layer2Constants variables to be const

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TStage2Layer2Constants.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TStage2Layer2Constants.cc
@@ -1,16 +1,16 @@
 
 #include "L1TStage2Layer2Constants.h"
 
-int l1t::stage2::layer2::fedId = 1360;
+const int l1t::stage2::layer2::fedId = 1360;
 
-unsigned int l1t::stage2::layer2::mp::offsetBoardId = 0x2210;
+const unsigned int l1t::stage2::layer2::mp::offsetBoardId = 0x2210;
 
-unsigned int l1t::stage2::layer2::mp::nInputFramePerBX = 40;
-unsigned int l1t::stage2::layer2::mp::nOutputFramePerBX = 8;
+const unsigned int l1t::stage2::layer2::mp::nInputFramePerBX = 40;
+const unsigned int l1t::stage2::layer2::mp::nOutputFramePerBX = 8;
 
-unsigned int l1t::stage2::layer2::demux::nOutputFramePerBX = 6;
-unsigned int l1t::stage2::layer2::demux::nEGPerLink    = 6;
-unsigned int l1t::stage2::layer2::demux::nTauPerLink   = 6;
-unsigned int l1t::stage2::layer2::demux::nJetPerLink   = 6;
-unsigned int l1t::stage2::layer2::demux::nEtSumPerLink = 4;
-unsigned int l1t::stage2::layer2::demux::amcSlotNum    = 12;
+const unsigned int l1t::stage2::layer2::demux::nOutputFramePerBX = 6;
+const unsigned int l1t::stage2::layer2::demux::nEGPerLink    = 6;
+const unsigned int l1t::stage2::layer2::demux::nTauPerLink   = 6;
+const unsigned int l1t::stage2::layer2::demux::nJetPerLink   = 6;
+const unsigned int l1t::stage2::layer2::demux::nEtSumPerLink = 4;
+const unsigned int l1t::stage2::layer2::demux::amcSlotNum    = 12;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TStage2Layer2Constants.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TStage2Layer2Constants.h
@@ -8,27 +8,27 @@ namespace l1t {
 
     namespace layer2 {
 
-      extern signed int fedId;
+      extern const signed int fedId;
 
       namespace mp {
 
-	extern unsigned int offsetBoardId;
+	extern const unsigned int offsetBoardId;
 
-	extern unsigned int nInputFramePerBX;
-	extern unsigned int nOutputFramePerBX;
+	extern const unsigned int nInputFramePerBX;
+	extern const unsigned int nOutputFramePerBX;
 
       }
 
       namespace demux {
       
-	extern unsigned int nOutputFramePerBX;
+	extern const unsigned int nOutputFramePerBX;
 	
-	extern unsigned int nEGPerLink;
-	extern unsigned int nTauPerLink;
-	extern unsigned int nJetPerLink;
-	extern unsigned int nEtSumPerLink;
+	extern const unsigned int nEGPerLink;
+	extern const unsigned int nTauPerLink;
+	extern const unsigned int nJetPerLink;
+	extern const unsigned int nEtSumPerLink;
 
-	extern unsigned int amcSlotNum;
+	extern const unsigned int amcSlotNum;
       
       }
 


### PR DESCRIPTION
The globally accessible variables in L1TStage2Layer2Constants need
to be const since they are being used by stream modules.