### PR TITLE
Marking DetId member functions as constexpr

### DIFF
--- a/DataFormats/DetId/interface/DetId.h
+++ b/DataFormats/DetId/interface/DetId.h
@@ -27,47 +27,47 @@ public:
 		 VeryForward=7, HGCalEE=8, HGCalHSi=9, HGCalHSc=10,
 		 HGCalTrigger=11};
   /// Create an empty or null id (also for persistence)
-  DetId()  : id_(0) { }
+  constexpr DetId()  : id_(0) { }
   /// Create an id from a raw number
-  DetId(uint32_t id) : id_(id) { }
+  constexpr DetId(uint32_t id) : id_(id) { }
   /// Create an id, filling the detector and subdetector fields as specified
-  DetId(Detector det, int subdet)  {
-    id_=((det&kDetMask)<<kDetOffset)|((subdet&kSubdetMask)<<kSubdetOffset);
-  }
+  constexpr DetId(Detector det, int subdet) 
+    : id_(((det&kDetMask)<<kDetOffset)|((subdet&kSubdetMask)<<kSubdetOffset))
+  {}
 
   /// get the detector field from this detid
-  Detector det() const { return Detector((id_>>kDetOffset)&kDetMask); }
+  constexpr Detector det() const { return Detector((id_>>kDetOffset)&kDetMask); }
   /// get the contents of the subdetector field (not cast into any detector's numbering enum)
-  int subdetId() const { return ((id_>>kSubdetOffset)&kSubdetMask); }
+  constexpr int subdetId() const { return ((id_>>kSubdetOffset)&kSubdetMask); }
 
-  uint32_t operator()() const { return id_; }
-  operator uint32_t() const { return id_; }
+  constexpr uint32_t operator()() const { return id_; }
+  constexpr operator uint32_t() const { return id_; }
 
   /// get the raw id 
-  uint32_t rawId() const { return id_; }
+  constexpr uint32_t rawId() const { return id_; }
   /// is this a null id ?
-  bool null() const { return id_==0; }
+  constexpr bool null() const { return id_==0; }
   
   /// equality
-  bool operator==(DetId id) const { return id_==id.id_; }
+  constexpr bool operator==(DetId id) const { return id_==id.id_; }
   /// inequality
-  bool operator!=(DetId id) const { return id_!=id.id_; }
+  constexpr bool operator!=(DetId id) const { return id_!=id.id_; }
   /// comparison
-  bool operator<(DetId id) const { return id_<id.id_; }
+  constexpr bool operator<(DetId id) const { return id_<id.id_; }
 
 protected:
   uint32_t id_;
 };
 
 /// equality
-inline bool operator==(uint32_t i, DetId id)  { return i==id(); }
-inline bool operator==(DetId id, uint32_t i)  { return i==id(); }
+constexpr inline bool operator==(uint32_t i, DetId id)  { return i==id(); }
+constexpr inline bool operator==(DetId id, uint32_t i)  { return i==id(); }
 /// inequality
-inline bool operator!=(uint32_t i, DetId id)  { return i!=id(); }
-inline bool operator!=(DetId id, uint32_t i) { return i!=id(); }
+constexpr inline bool operator!=(uint32_t i, DetId id)  { return i!=id(); }
+constexpr inline bool operator!=(DetId id, uint32_t i) { return i!=id(); }
 /// comparison
-inline bool operator<(uint32_t i, DetId id) { return i<id(); }
-inline bool operator<(DetId id, uint32_t i) { return id()<i; }
+constexpr inline bool operator<(uint32_t i, DetId id) { return i<id(); }
+constexpr inline bool operator<(DetId id, uint32_t i) { return id()<i; }
 
 
 //std::ostream& operator<<(std::ostream& s, const DetId& id);

--- a/DataFormats/DetId/test/BuildFile.xml
+++ b/DataFormats/DetId/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<bin name="test_detid" file="test_detid.cu">
+    <use name="DataFormats/DetId"/>
+    <use name="cuda"/>
+</bin>

--- a/DataFormats/DetId/test/test_detid.cu
+++ b/DataFormats/DetId/test/test_detid.cu
@@ -1,0 +1,37 @@
+#include <cuda_runtime.h>
+#include <cuda.h>
+
+#include <iostream>
+#include <assert.h>
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+
+__global__ void test_gen_detid(DetId* id, int const rawid) {
+    DetId did{rawid};
+    *id = did;
+}
+
+void test_detid() {
+    // test det ids
+    DetId h_id, h_id_test{100};
+    DetId h_test0{1};
+    DetId *d_id;
+
+    cudaMalloc((void**)&d_id, sizeof(DetId));
+    cudaMemcpy(d_id, &h_id, sizeof(DetId), cudaMemcpyHostToDevice);
+    test_gen_detid<<<1,1>>>(d_id, 100);
+    cudaMemcpy(&h_id, d_id, sizeof(DetId), cudaMemcpyDeviceToHost);
+    
+    assert(h_id_test == h_id);
+    assert(h_id != h_test0);
+}
+
+int main(int argc, char** argv) {
+    int nDevices;
+    cudaGetDeviceCount(&nDevices);
+    std::cout << "nDevices = " << nDevices << std::endl;
+
+    // test det id functionality
+    if (nDevices > 0)
+        test_detid();
+}


### PR DESCRIPTION
- marking DetId member functions constexpr 
- makes them directly available on the cuda device w/o using __device__ __host__ 
- added simple tests

just fyi @makortel , @fwyzard 