### PR TITLE
Add copy constructor to edmNew::DetSetVector

### DIFF
--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -440,19 +440,13 @@ namespace edmNew {
       // delete content if T is pointer...
     }
 
+    // default or delete is the same...
+    DetSetVector& operator=(const DetSetVector&) = delete;
     // Implement copy constructor because of a (possibly temporary)
     // need in heterogeneous framework prototyping. In general this
     // class is still supposed to be non-copyable, so to prevent
     // accidental copying the assignment operator is left deleted.
-    DetSetVector(const DetSetVector& rh):
-      DetSetVectorTrans(rh),
-      m_subdetId(rh.m_subdetId),
-      m_ids(rh.m_ids),
-      m_data(rh.m_data)
-    {}
-
-    // default or delete is the same...
-    DetSetVector& operator=(const DetSetVector&) = delete;
+    DetSetVector(const DetSetVector&) = default;
     DetSetVector(DetSetVector&&) = default;
     DetSetVector& operator=(DetSetVector&&) = default;
 

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -70,9 +70,10 @@ namespace edmNew {
 #endif
       }
 
-      DetSetVectorTrans(DetSetVectorTrans&& rh) { // can't be default because of atomics
+      DetSetVectorTrans(DetSetVectorTrans&& rh): // can't be default because of atomics
+        m_filling(false) {
         // better no one is filling...
-        assert(m_filling==false); assert(rh.m_filling==false);
+        assert(rh.m_filling==false);
         m_getter = std::move(rh.m_getter);
 #ifdef DSVN_USE_ATOMIC
         m_dataSize.store(rh.m_dataSize.exchange(m_dataSize.load()));

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -57,7 +57,19 @@ namespace edmNew {
 
       DetSetVectorTrans(): m_filling(false), m_dataSize(0){}
       DetSetVectorTrans& operator=(const DetSetVectorTrans&) = delete;
-      DetSetVectorTrans(const DetSetVectorTrans&) = delete;
+
+      DetSetVectorTrans(const DetSetVectorTrans& rh): // can't be default because of atomics
+        m_filling(false) {
+        // better no one is filling...
+        assert(rh.m_filling==false);
+        m_getter = rh.m_getter;
+#ifdef DSVN_USE_ATOMIC
+        m_dataSize.store(rh.m_dataSize.load());
+#else
+        m_dataSize = rh.m_dataSize;
+#endif
+      }
+
       DetSetVectorTrans(DetSetVectorTrans&& rh) { // can't be default because of atomics
         // better no one is filling...
         assert(m_filling==false); assert(rh.m_filling==false);
@@ -427,9 +439,19 @@ namespace edmNew {
       // delete content if T is pointer...
     }
 
+    // Implement copy constructor because of a (possibly temporary)
+    // need in heterogeneous framework prototyping. In general this
+    // class is still supposed to be non-copyable, so to prevent
+    // accidental copying the assignment operator is left deleted.
+    DetSetVector(const DetSetVector& rh):
+      DetSetVectorTrans(rh),
+      m_subdetId(rh.m_subdetId),
+      m_ids(rh.m_ids),
+      m_data(rh.m_data)
+    {}
+
     // default or delete is the same...
     DetSetVector& operator=(const DetSetVector&) = delete;
-    DetSetVector(const DetSetVector&) = delete;
     DetSetVector(DetSetVector&&) = default;
     DetSetVector& operator=(DetSetVector&&) = default;
 

--- a/DataFormats/Common/test/DetSetNew_t.cpp
+++ b/DataFormats/Common/test/DetSetNew_t.cpp
@@ -125,6 +125,12 @@ void TestDetSet::default_ctor() {
   CPPUNIT_ASSERT(detsets.subdetId()==4);
   CPPUNIT_ASSERT(detsets.size()==0);
   CPPUNIT_ASSERT(detsets.dataSize()==0);
+
+  // test copy
+  DSTV detsets4(detsets);
+  CPPUNIT_ASSERT(detsets4.subdetId()==4);
+  CPPUNIT_ASSERT(detsets4.size()==0);
+  CPPUNIT_ASSERT(detsets4.dataSize()==0);
 }
 
 void TestDetSet::inserting() {
@@ -143,11 +149,19 @@ void TestDetSet::inserting() {
 
     std::copy(sv.begin(),sv.begin()+n,df.begin());
 
+    DSTV detsets2(detsets);
+    CPPUNIT_ASSERT(detsets2.size()==n);
+    CPPUNIT_ASSERT(detsets2.dataSize()==ntot);
+    CPPUNIT_ASSERT(detsets2.detsetSize(n-1)==n);
+
     std::vector<DST::data_type> v1(n);
     std::vector<DST::data_type> v2(n);
+    std::vector<DST::data_type> v3(n);
     std::copy(detsets.m_data.begin()+ntot-n,detsets.m_data.begin()+ntot,v2.begin());
+    std::copy(detsets2.m_data.begin()+ntot-n,detsets2.m_data.begin()+ntot,v3.begin());
     std::copy(sv.begin(),sv.begin()+n,v1.begin());
     CPPUNIT_ASSERT(v1==v2);
+    CPPUNIT_ASSERT(v1==v3);
   }
 
   // test error conditions
@@ -216,6 +230,12 @@ void TestDetSet::filling() {
  CPPUNIT_ASSERT(detsets.exists(30));
 
  {
+   DSTV detsets2(detsets);
+   CPPUNIT_ASSERT(detsets2.size()==5);
+   CPPUNIT_ASSERT(detsets2.exists(30));
+ }
+
+ {
    unsigned int cs = detsets.dataSize();
    FF ff1(detsets, 31);
    ff1.resize(4);
@@ -232,10 +252,22 @@ void TestDetSet::filling() {
  CPPUNIT_ASSERT(!detsets.exists(31));
  { FF ff1(detsets, 32,true); }
  CPPUNIT_ASSERT(detsets.size()==6);
+
+ DSTV detsets2(detsets);
+ CPPUNIT_ASSERT(detsets2.size()==6);
+
  detsets.clean();
  CPPUNIT_ASSERT(detsets.size()==4);
  CPPUNIT_ASSERT(!detsets.exists(30));
  CPPUNIT_ASSERT(!detsets.exists(32));
+
+ CPPUNIT_ASSERT(detsets2.size()==6);
+ CPPUNIT_ASSERT(detsets2.exists(30));
+ CPPUNIT_ASSERT(detsets2.exists(32));
+ detsets2.clean();
+ CPPUNIT_ASSERT(detsets2.size()==4);
+ CPPUNIT_ASSERT(!detsets2.exists(30));
+ CPPUNIT_ASSERT(!detsets2.exists(32));
 
   // test error conditions
   try {
@@ -601,6 +633,9 @@ void TestDetSet::onDemand() {
   DSTV detsets3;
   detsets3 = std::move(detsets2);
   CPPUNIT_ASSERT(detsets3.onDemand());
+
+  DSTV detsets4(detsets3);
+  CPPUNIT_ASSERT(detsets4.onDemand());
 }
 
 void TestDetSet::toRangeMap() {

--- a/DataFormats/Common/test/DetSetNew_t.cpp
+++ b/DataFormats/Common/test/DetSetNew_t.cpp
@@ -125,9 +125,13 @@ void TestDetSet::default_ctor() {
   CPPUNIT_ASSERT(detsets.subdetId()==4);
   CPPUNIT_ASSERT(detsets.size()==0);
   CPPUNIT_ASSERT(detsets.dataSize()==0);
+  DSTV detsets5(std::move(detsets));
+  CPPUNIT_ASSERT(detsets5.subdetId()==4);
+  CPPUNIT_ASSERT(detsets5.size()==0);
+  CPPUNIT_ASSERT(detsets5.dataSize()==0);
 
   // test copy
-  DSTV detsets4(detsets);
+  DSTV detsets4(detsets5);
   CPPUNIT_ASSERT(detsets4.subdetId()==4);
   CPPUNIT_ASSERT(detsets4.size()==0);
   CPPUNIT_ASSERT(detsets4.dataSize()==0);
@@ -633,8 +637,10 @@ void TestDetSet::onDemand() {
   DSTV detsets3;
   detsets3 = std::move(detsets2);
   CPPUNIT_ASSERT(detsets3.onDemand());
+  DSTV detsets5(std::move(detsets3));
+  CPPUNIT_ASSERT(detsets5.onDemand());
 
-  DSTV detsets4(detsets3);
+  DSTV detsets4(detsets5);
   CPPUNIT_ASSERT(detsets4.onDemand());
 }
 


### PR DESCRIPTION
This PR adds a ~~way to make copy of~~ copy constructor to `edmNew::DetSetVector`. Such a functionality is needed in the GPU pixel tracking work. Because the change implies recompiling ~half of the universe, I submit it here already now so that we could benefit getting it to a CMSSW pre-release (thus avoiding the aforementioned private recompilation).

~~The "copying" is implemented as the following pattern~~
~~`edmNew::DetSetVector<T> copy;`~~
~~`copy.replaceFrom(original);`~~
~~to allow putting the the `copy` to an `std::unique_ptr<T>`, and still keeping the copy constructor and assignment operator disabled (to prevent accidental copies).~~

Tested in 10_2_0_pre3, no changes expected.

@fwyzard @felicepantaleo @VinInn 