### PR TITLE
[gcc8] Replaced use of sprintf with efficient use of LogTrace

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -951,13 +951,14 @@ bool CSCAnodeLCTProcessor::patternDetection(const int key_wire) {
       else if ((sz % 2) == 1) first_bx_corrected[key_wire] = *(++im);
       else first_bx_corrected[key_wire] = ((*im) + (*(++im)))/2;
 
+#if defined(EDM_ML_DEBUG)
       if (infoV > 1) {
-        char bxs[300]="";
-        for (im = mset_for_median.begin(); im != mset_for_median.end(); im++)
-          sprintf(bxs,"%s %d", bxs, *im);
-        LogTrace("CSCAnodeLCTProcessor")
-          <<"bx="<<first_bx[key_wire]<<" bx_cor="<< first_bx_corrected[key_wire]<<"  bxset="<<bxs;
+        auto lt = LogTrace("CSCAnodeLCTProcessor") <<"bx="<<first_bx[key_wire]<<" bx_cor="<< first_bx_corrected[key_wire]<<"  bxset=";
+        for (im = mset_for_median.begin(); im != mset_for_median.end(); im++) {
+          lt<<" "<<*im;
+        }
       }
+#endif
     }
 
     if (temp_quality >= pattern_thresh[i_pattern]) {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -2495,15 +2495,17 @@ bool CSCCathodeLCTProcessor::ptnFinding(
           else if ((sz % 2) == 1) first_bx_corrected[key_hstrip] = *(++im);
           else first_bx_corrected[key_hstrip] = ((*im) + (*(++im)))/2;
 
+#if defined(EDM_ML_DEBUG)
+          //LogTrace only ever prints if EDM_ML_DEBUG is defined
           if (infoV > 1) {
-            char bxs[300]="";
-            for (im = mset_for_median.begin(); im != mset_for_median.end(); im++)
-              sprintf(bxs,"%s %d", bxs, *im);
-            LogTrace("CSCCathodeLCTProcessor")
-              <<"bx="<<bx_time<<" bx_cor="<< first_bx_corrected[key_hstrip]<<"  bxset="<<bxs;
+            auto lt = LogTrace("CSCCathodeLCTProcessor")
+              <<"bx="<<bx_time<<" bx_cor="<< first_bx_corrected[key_hstrip]<<"  bxset=";
+            for (im = mset_for_median.begin(); im != mset_for_median.end(); im++) {
+              lt<<" "<<*im;
+            }
           }
+#endif
         }
-
 	// Do not loop over the other (worse) patterns if max. numbers of
 	// hits is found.
 	if (nhits[key_hstrip] == CSCConstants::NUM_LAYERS) break;


### PR DESCRIPTION
The code was using sprintf to fill a char array which was only
being passed to LogTrace. gcc 8 gave an error that the buffer being
passed to sprintf was insufficient to guarantee that there would be
no memory overwrites. Switching to just using LogTrace directly
and adding a conditional compilation avoids the possible overwrite
and should improve performance.