### PR TITLE
10_1_X Backport of #23349, add DataProcessing configurations for 2018 high beta star scenario

### DIFF
--- a/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2018_highBetaStar.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2018_highBetaStar.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""
+_hcalnzsEra_Run2_2018_highBetaStar_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Impl.hcalnzs import hcalnzs
+from Configuration.Eras.Era_Run2_2018_highBetaStar_cff import Run2_2018_highBetaStar
+
+class hcalnzsEra_Run2_2018_highBetaStar(hcalnzs):
+    def __init__(self):
+        hcalnzs.__init__(self)
+        self.recoSeq=':reconstruction_HcalNZS'
+        self.cbSc='pp'
+        self.addEI=True
+        self.eras = Run2_2018_highBetaStar
+        #keep post-era parts the same as in the default 2018 era
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+    """
+    _hcalnzsEra_Run2_2018_highBetaStar_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2, 2018 hcal nzs workflow in highBetaStar data taking
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2018_highBetaStar.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2018_highBetaStar.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2018_highBetaStar_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run2_2018_highBetaStar_cff import Run2_2018_highBetaStar
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run2_2018_highBetaStar(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.addEI=True
+        self.eras=Run2_2018_highBetaStar
+        #keep post-era parts the same as in the default 2018 era
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+    """
+    _ppEra_Run2_2018_highBetaStar_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2 2018 highBetaStar data taking
+
+    """

--- a/Configuration/DataProcessing/python/Impl/trackingOnlyEra_Run2_2018_highBetaStar.py
+++ b/Configuration/DataProcessing/python/Impl/trackingOnlyEra_Run2_2018_highBetaStar.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""
+_trackingOnlyEra_Run2_2018_highBetaStar
+
+Scenario supporting proton collisions and tracking only reconstruction for HP beamspot
+
+"""
+
+import os
+import sys
+
+from   Configuration.DataProcessing.Impl.trackingOnly import trackingOnly
+import FWCore.ParameterSet.Config as cms
+from   Configuration.Eras.Era_Run2_2018_highBetaStar_cff import Run2_2018_highBetaStar
+
+from   Configuration.DataProcessing.Impl.pp import pp
+
+class trackingOnlyEra_Run2_2018_highBetaStar(trackingOnly):
+    def __init__(self):
+        trackingOnly.__init__(self)
+        # tracking only RECO is sufficient, to run high performance BS at PCL;
+        # some dedicated customization are required, though: customisePostEra_Run2_2018_trackingOnly
+        self.recoSeq=':reconstruction_trackingOnly'
+        self.cbSc='pp'
+        self.addEI=False
+        self.eras=Run2_2018_highBetaStar
+        #keep post-era parts the same as in the default 2018 era
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018_express_trackingOnly' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018' ]
+
+    """
+    _trackingOnlyEra_Run2_2018_highBetaStar
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2, 2018 high performance beamspot in highBetaStar data taking
+
+    """

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmicsEra_Run2_2016" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "cosmicsEra_Run2_2018" "ppEra_Run2_2018")
+declare -a arr=("cosmicsEra_Run2_2016" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "cosmicsEra_Run2_2018" "ppEra_Run2_2018" "ppEra_Run2_2018_highBetaStar")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
@@ -22,20 +22,20 @@ do
 done
 
 
-declare -a arr=("cosmicsEra_Run2_2016" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzsEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "cosmicsEra_Run2_2017" "hcalnzsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018")
+declare -a arr=("cosmicsEra_Run2_2016" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzsEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "cosmicsEra_Run2_2017" "hcalnzsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_highBetaStar")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
 done
 
-declare -a arr=("cosmicsEra_Run2_2016" "AlCaLumiPixels" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "ppEra_Run2_2018")
+declare -a arr=("cosmicsEra_Run2_2016" "AlCaLumiPixels" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017" "cosmicsEra_Run2_2018" "ppEra_Run2_2018" "ppEra_Run2_2018_highBetaStar")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
      runTest "${LOCAL_TEST_DIR}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
 done
 
-declare -a arr=("ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2018")
+declare -a arr=("ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2018" "ppEra_Run2_2018_highBetaStar")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
@@ -50,7 +50,7 @@ runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario AlCaLumiPixels --g
 runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario AlCaLumiPixels --lfn=/store/whatever --global-tag GLOBALTAG --skims AlCaPCCRandom,PromptCalibProdLumiPCC"
 runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario AlCaLumiPixels --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --alcapromptdataset=PromptCalibProdLumiPCC"
 
-declare -a arr=("trackingOnlyEra_Run2_2017" "trackingOnlyEra_Run2_2018")
+declare -a arr=("trackingOnlyEra_Run2_2017" "trackingOnlyEra_Run2_2018" "trackingOnlyEra_Run2_2018_highBetaStar")
 for scenario in "${arr[@]}"
 do
     runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG  --lfn /store/whatever  --alcarecos=TkAlMinBias+PromptCalibProdBeamSpotHP"


### PR DESCRIPTION
add pp, hcalnzs, and trackingOnly scenarios for Era_Run2_2018_highBetaStar.

Only pp is really necessary. I still added the hcalnzs and trackingOnly, just in case.

From @slava77 implementation in master, backport of #23349