### PR TITLE
Update max number of LS in beamspot IOVs

### DIFF
--- a/Calibration/TkAlCaRecoProducers/src/AlcaBeamSpotManager.cc
+++ b/Calibration/TkAlCaRecoProducers/src/AlcaBeamSpotManager.cc
@@ -104,7 +104,7 @@ void AlcaBeamSpotManager::createWeightedPayloads(void){
     bool foundShift = false;
     long countlumi = 0;//Added
     string tmprun = "";//Added
-    long maxNlumis = 60;//Added
+    long maxNlumis = 20;//Added
 //    if weighted:
 //        maxNlumis = 999999999
 


### PR DESCRIPTION
Update the number of maximum consecutive lumi sections that can be included in a single beamspot IOV (if no drifts in the beamspot parameters are observed). 
Changed from 60 to 20 LS, in order to have a measurement approximately every 8 mins.
Finer measurements have been requested by Run Coordination to accomodate LHC needs.
This change has been discussed in the AlCa meeting
https://indico.cern.ch/event/727168/contributions/3014708/subcontributions/256002/attachments/1657135/2653254/expressAlignment_validation_reprise.pdf