### PR TITLE
 Remove OOT photons from 2018 heavy-ion (AA) era 

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/patCandidates_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/patCandidates_cff.py
@@ -32,3 +32,7 @@ patCandidatesTask = cms.Task(
     makePatMETsTask
 )
 patCandidates = cms.Sequence(patCandidateSummary, patCandidatesTask)
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toReplaceWith(patCandidatesTask, patCandidatesTask.copyAndExclude([makePatOOTPhotonsTask]))
+pp_on_AA_2018.toModify(patCandidateSummary.candidates, func = lambda list: list.remove(cms.InputTag("patOOTPhotons")) )

--- a/PhysicsTools/PatAlgos/python/selectionLayer1/selectedPatCandidates_cff.py
+++ b/PhysicsTools/PatAlgos/python/selectionLayer1/selectedPatCandidates_cff.py
@@ -31,3 +31,7 @@ selectedPatCandidatesTask = cms.Task(
 )
 
 selectedPatCandidates = cms.Sequence(selectedPatCandidateSummary, selectedPatCandidatesTask)
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toReplaceWith(selectedPatCandidatesTask, selectedPatCandidatesTask.copyAndExclude([selectedPatOOTPhotons]))
+pp_on_AA_2018.toModify(selectedPatCandidateSummary.candidates, func = lambda list: list.remove(cms.InputTag("selectedPatOOTPhotons")) )

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -53,3 +53,6 @@ slimmingTask = cms.Task(
     bunchSpacingProducer,
     oniaPhotonCandidates
 )
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toReplaceWith(slimmingTask, slimmingTask.copyAndExclude([slimmedOOTPhotons]))

--- a/RecoEcal/EgammaClusterProducers/python/reducedRecHitsSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/reducedRecHitsSequence_cff.py
@@ -141,11 +141,11 @@ reducedEcalRecHitsES = cms.EDProducer("ReducedESRecHitCollectionProducer",
                                         cms.InputTag("interestingEcalDetIdPFES"),
                                         cms.InputTag("interestingEcalDetIdRefinedES"), 
                                         cms.InputTag("interestingEcalDetIdOOTPFES"),
-                                      ),
+                                        ),
                                       interestingDetIdsNotToClean = cms.VInputTag(
-                                          cms.InputTag("interestingGedEgammaIsoESDetId"),
-                                          cms.InputTag("interestingOotEgammaIsoESDetId"),
-                                      )
+                                        cms.InputTag("interestingGedEgammaIsoESDetId"),
+                                        cms.InputTag("interestingOotEgammaIsoESDetId"),
+                                        )
 )
 
 #selected digis
@@ -180,3 +180,49 @@ phase2_common.toReplaceWith( reducedEcalRecHitsTask , _phase2_reducedEcalRecHits
 _fastSim_reducedEcalRecHitsTask = reducedEcalRecHitsTask.copyAndExclude(seldigisTask)
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith( reducedEcalRecHitsTask, _fastSim_reducedEcalRecHitsTask)
+
+_pp_on_AA_reducedEcalRecHitsTask = reducedEcalRecHitsTask.copy()
+_pp_on_AA_reducedEcalRecHitsTask.remove(interestingEcalDetIdOOTPFEB)
+_pp_on_AA_reducedEcalRecHitsTask.remove(interestingEcalDetIdOOTPFEE)
+_pp_on_AA_reducedEcalRecHitsTask.remove(interestingEcalDetIdOOTPFES)
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toReplaceWith(reducedEcalRecHitsTask, _pp_on_AA_reducedEcalRecHitsTask)
+
+_pp_on_AA_interestingDetIdsEB  = cms.VInputTag(
+    cms.InputTag("interestingEcalDetIdEB"),
+    cms.InputTag("interestingEcalDetIdEBU"),
+    cms.InputTag("interestingEcalDetIdPFEB"),
+    cms.InputTag("interestingEcalDetIdRefinedEB"),
+    cms.InputTag("interestingGedEleIsoDetIdEB"),
+    cms.InputTag("interestingGedGamIsoDetIdEB"),
+    cms.InputTag("interestingGamIsoDetIdEB"),
+    cms.InputTag("muonEcalDetIds"),
+    cms.InputTag("interestingTrackEcalDetIds")
+    )
+_pp_on_AA_interestingDetIdsEE  = cms.VInputTag(
+    cms.InputTag("interestingEcalDetIdEE"),
+    cms.InputTag("interestingEcalDetIdPFEE"),
+    cms.InputTag("interestingEcalDetIdRefinedEE"),
+    cms.InputTag("interestingGedEleIsoDetIdEE"),
+    cms.InputTag("interestingGedGamIsoDetIdEE"),
+    cms.InputTag("interestingGamIsoDetIdEE"),
+    cms.InputTag("muonEcalDetIds"),
+    cms.InputTag("interestingTrackEcalDetIds")
+    )
+_pp_on_AA_interestingDetIdsES  = cms.VInputTag(cms.InputTag("interestingEcalDetIdPFES"),cms.InputTag("interestingEcalDetIdRefinedES"))
+_pp_on_AA_interestingDetIdsNotToClean  = cms.VInputTag(cms.InputTag("interestingGedEgammaIsoESDetId"))
+
+pp_on_AA_2018.toModify(
+    reducedEcalRecHitsEB,
+    interestingDetIdCollections = _pp_on_AA_interestingDetIdsEB,
+    )
+pp_on_AA_2018.toModify(
+    reducedEcalRecHitsEE,
+    interestingDetIdCollections = _pp_on_AA_interestingDetIdsEE,
+    )
+pp_on_AA_2018.toModify(
+    reducedEcalRecHitsES,
+    interestingDetIds = _pp_on_AA_interestingDetIdsES,
+    interestingDetIdsNotToClean =  _pp_on_AA_interestingDetIdsNotToClean
+    )

--- a/RecoEcal/EgammaClusterProducers/python/reducedRecHitsSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/reducedRecHitsSequence_cff.py
@@ -141,11 +141,11 @@ reducedEcalRecHitsES = cms.EDProducer("ReducedESRecHitCollectionProducer",
                                         cms.InputTag("interestingEcalDetIdPFES"),
                                         cms.InputTag("interestingEcalDetIdRefinedES"), 
                                         cms.InputTag("interestingEcalDetIdOOTPFES"),
-                                        ),
+                                      ),
                                       interestingDetIdsNotToClean = cms.VInputTag(
                                         cms.InputTag("interestingGedEgammaIsoESDetId"),
                                         cms.InputTag("interestingOotEgammaIsoESDetId"),
-                                        )
+                                      )
 )
 
 #selected digis
@@ -189,40 +189,9 @@ _pp_on_AA_reducedEcalRecHitsTask.remove(interestingEcalDetIdOOTPFES)
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toReplaceWith(reducedEcalRecHitsTask, _pp_on_AA_reducedEcalRecHitsTask)
 
-_pp_on_AA_interestingDetIdsEB  = cms.VInputTag(
-    cms.InputTag("interestingEcalDetIdEB"),
-    cms.InputTag("interestingEcalDetIdEBU"),
-    cms.InputTag("interestingEcalDetIdPFEB"),
-    cms.InputTag("interestingEcalDetIdRefinedEB"),
-    cms.InputTag("interestingGedEleIsoDetIdEB"),
-    cms.InputTag("interestingGedGamIsoDetIdEB"),
-    cms.InputTag("interestingGamIsoDetIdEB"),
-    cms.InputTag("muonEcalDetIds"),
-    cms.InputTag("interestingTrackEcalDetIds")
-    )
-_pp_on_AA_interestingDetIdsEE  = cms.VInputTag(
-    cms.InputTag("interestingEcalDetIdEE"),
-    cms.InputTag("interestingEcalDetIdPFEE"),
-    cms.InputTag("interestingEcalDetIdRefinedEE"),
-    cms.InputTag("interestingGedEleIsoDetIdEE"),
-    cms.InputTag("interestingGedGamIsoDetIdEE"),
-    cms.InputTag("interestingGamIsoDetIdEE"),
-    cms.InputTag("muonEcalDetIds"),
-    cms.InputTag("interestingTrackEcalDetIds")
-    )
-_pp_on_AA_interestingDetIdsES  = cms.VInputTag(cms.InputTag("interestingEcalDetIdPFES"),cms.InputTag("interestingEcalDetIdRefinedES"))
-_pp_on_AA_interestingDetIdsNotToClean  = cms.VInputTag(cms.InputTag("interestingGedEgammaIsoESDetId"))
-
-pp_on_AA_2018.toModify(
-    reducedEcalRecHitsEB,
-    interestingDetIdCollections = _pp_on_AA_interestingDetIdsEB,
-    )
-pp_on_AA_2018.toModify(
-    reducedEcalRecHitsEE,
-    interestingDetIdCollections = _pp_on_AA_interestingDetIdsEE,
-    )
-pp_on_AA_2018.toModify(
-    reducedEcalRecHitsES,
-    interestingDetIds = _pp_on_AA_interestingDetIdsES,
-    interestingDetIdsNotToClean =  _pp_on_AA_interestingDetIdsNotToClean
-    )
+pp_on_AA_2018.toModify(reducedEcalRecHitsEB.interestingDetIdCollections, func = lambda list: list.remove(cms.InputTag("interestingEcalDetIdOOTPFEB")) )
+pp_on_AA_2018.toModify(reducedEcalRecHitsEB.interestingDetIdCollections, func = lambda list: list.remove(cms.InputTag("interestingOotGamIsoDetIdEB")) )
+pp_on_AA_2018.toModify(reducedEcalRecHitsEE.interestingDetIdCollections, func = lambda list: list.remove(cms.InputTag("interestingEcalDetIdOOTPFEE")) )
+pp_on_AA_2018.toModify(reducedEcalRecHitsEE.interestingDetIdCollections, func = lambda list: list.remove(cms.InputTag("interestingOotGamIsoDetIdEE")) )
+pp_on_AA_2018.toModify(reducedEcalRecHitsES.interestingDetIds, func = lambda list: list.remove(cms.InputTag("interestingEcalDetIdOOTPFES")) )
+pp_on_AA_2018.toModify(reducedEcalRecHitsES.interestingDetIdsNotToClean, func = lambda list: list.remove(cms.InputTag("interestingOotEgammaIsoESDetId")) )

--- a/RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoDetIdsSequence_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoDetIdsSequence_cff.py
@@ -122,3 +122,12 @@ interestingEgammaIsoDetIdsTask = cms.Task(
     interestingOotEgammaIsoESDetId
 )
 interestingEgammaIsoDetIds = cms.Sequence(interestingEgammaIsoDetIdsTask)
+
+_pp_on_AA_interestingEgammaIsoDetIdsTask = interestingEgammaIsoDetIdsTask.copy()
+_pp_on_AA_interestingEgammaIsoDetIdsTask.remove(interestingOotGamIsoDetIdEB)
+_pp_on_AA_interestingEgammaIsoDetIdsTask.remove(interestingOotGamIsoDetIdEE)
+_pp_on_AA_interestingEgammaIsoDetIdsTask.remove(interestingOotEgammaIsoHCALDetId)
+_pp_on_AA_interestingEgammaIsoDetIdsTask.remove(interestingOotEgammaIsoESDetId)
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toReplaceWith(interestingEgammaIsoDetIdsTask, _pp_on_AA_interestingEgammaIsoDetIdsTask)

--- a/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
@@ -145,7 +145,7 @@ class ReducedEGProducer : public edm::stream::EDProducer<> {
 
  //tokens for input collections
  const edm::EDGetTokenT<reco::PhotonCollection> photonT_;
- const edm::EDGetTokenT<reco::PhotonCollection> ootPhotonT_;
+ edm::EDGetTokenT<reco::PhotonCollection> ootPhotonT_;
  const edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectronT_;
  const edm::EDGetTokenT<reco::GsfTrackCollection> gsfTrackT_;
  const edm::EDGetTokenT<reco::ConversionCollection> conversionT_;

--- a/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
@@ -145,7 +145,6 @@ class ReducedEGProducer : public edm::stream::EDProducer<> {
 
  //tokens for input collections
  const edm::EDGetTokenT<reco::PhotonCollection> photonT_;
- const bool                                   doOotPhotons_;
  const edm::EDGetTokenT<reco::PhotonCollection> ootPhotonT_;
  const edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectronT_;
  const edm::EDGetTokenT<reco::GsfTrackCollection> gsfTrackT_;

--- a/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
@@ -145,6 +145,7 @@ class ReducedEGProducer : public edm::stream::EDProducer<> {
 
  //tokens for input collections
  const edm::EDGetTokenT<reco::PhotonCollection> photonT_;
+ const bool                                   doOotPhotons_;
  const edm::EDGetTokenT<reco::PhotonCollection> ootPhotonT_;
  const edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectronT_;
  const edm::EDGetTokenT<reco::GsfTrackCollection> gsfTrackT_;

--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -109,3 +109,5 @@ from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_
 modifyReducedEGammaRun2MiniAOD9XFall17_ = run2_miniAOD_94XFall17.makeProcessModifier(calibrateReducedEgamma)
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 modifyReducedEGammaRun2MiniAOD8XLegacy_ = run2_miniAOD_80XLegacy.makeProcessModifier(calibrateReducedEgamma)
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify( reducedEgamma, ootPhotons = cms.InputTag("") )

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -46,7 +46,6 @@
 
 ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config) :
   photonT_(consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("photons"))),
-  ootPhotonT_(consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("ootPhotons"))),
   gsfElectronT_(consumes<reco::GsfElectronCollection>(config.getParameter<edm::InputTag>("gsfElectrons"))),
   gsfTrackT_(consumes<reco::GsfTrackCollection>(config.getParameter<edm::InputTag>("gsfTracks"))),
   conversionT_(consumes<reco::ConversionCollection>(config.getParameter<edm::InputTag>("conversions"))),
@@ -98,6 +97,10 @@ ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config) :
   slimRelinkGsfElectronSel_(config.getParameter<std::string>("slimRelinkGsfElectrons")),
   relinkGsfElectronSel_(config.getParameter<std::string>("relinkGsfElectrons"))
 {  
+
+  const edm::InputTag& aTag = config.getParameter<edm::InputTag>("ootPhotons");
+  if (not aTag.label().empty()) ootPhotonT_ = consumes<reco::PhotonCollection>(aTag);  
+  
   const std::vector<edm::InputTag>& photonidinputs = 
     config.getParameter<std::vector<edm::InputTag> >("photonIDSources");
   for (const edm::InputTag &tag : photonidinputs) {

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -572,10 +572,8 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     }
   }
 
-  if(!ootPhotonT_.isUninitialized()) {
-    theEvent.put(std::move(ebRecHits),outEBRecHits_);
-    theEvent.put(std::move(eeRecHits),outEERecHits_);
-  }
+  theEvent.put(std::move(ebRecHits),outEBRecHits_);
+  theEvent.put(std::move(eeRecHits),outEERecHits_);
 
   if (doPreshowerEcalHits_) { 
     for (const EcalRecHit &rechit : *preshowerHitHandle) {

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -47,9 +47,7 @@
 ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config) :
   photonT_(consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("photons"))),
   doOotPhotons_(!config.getParameter<edm::InputTag>("ootPhotons").label().empty()),
-  //doOotPhotons_(config.getParameter<bool>("doOotPhotons")),
   ootPhotonT_(doOotPhotons_ ? consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("ootPhotons")) : edm::EDGetTokenT<reco::PhotonCollection>()),
-  //if(doOotPhotons_) ootPhotonT_(consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("ootPhotons"))),
   gsfElectronT_(consumes<reco::GsfElectronCollection>(config.getParameter<edm::InputTag>("gsfElectrons"))),
   gsfTrackT_(consumes<reco::GsfTrackCollection>(config.getParameter<edm::InputTag>("gsfTracks"))),
   conversionT_(consumes<reco::ConversionCollection>(config.getParameter<edm::InputTag>("conversions"))),

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -397,7 +397,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     index = -1;
     for (const auto& ootPhoton : *ootPhotonHandle) {
       index++;
-
+      
       bool keep = keepOOTPhotonSel_(ootPhoton);
       if (!keep) continue;
 
@@ -592,13 +592,15 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   for (reco::SuperCluster &superCluster : *superClusters) {
     relinkCaloClusters(superCluster, ebeeClusterMap, esClusterMap, outEBEEClusterHandle, outESClusterHandle);
   }
-  if(!ootPhotonT_.isUninitialized()) {
-    //OOTCaloClusters
-    //put ootcalocluster output collections in event and get orphan handles to create ptrs
-    const edm::OrphanHandle<reco::CaloClusterCollection> &outOOTEBEEClusterHandle = theEvent.put(std::move(ootEbeeClusters),outOOTEBEEClusters_);
-    const edm::OrphanHandle<reco::CaloClusterCollection> &outOOTESClusterHandle = theEvent.put(std::move(ootEsClusters),outOOTESClusters_);;  
 
-    //Loop over OOTSuperClusters and relink OOTPhoton CaloClusters
+  //OOTCaloClusters
+  //put ootcalocluster output collections in event and get orphan handles to create ptrs
+  edm::OrphanHandle<reco::CaloClusterCollection> outOOTEBEEClusterHandle;
+  edm::OrphanHandle<reco::CaloClusterCollection> outOOTESClusterHandle;
+  //Loop over OOTSuperClusters and relink OOTPhoton CaloClusters
+  if(!ootPhotonT_.isUninitialized()) {
+    outOOTEBEEClusterHandle = theEvent.put(std::move(ootEbeeClusters),outOOTEBEEClusters_);
+    outOOTESClusterHandle = theEvent.put(std::move(ootEsClusters),outOOTESClusters_);  
     for (reco::SuperCluster &ootSuperCluster : *ootSuperClusters) {
       relinkCaloClusters(ootSuperCluster, ootEbeeClusterMap, ootEsClusterMap, outOOTEBEEClusterHandle, outOOTESClusterHandle);
     }
@@ -630,7 +632,8 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   }
 
   //put ootsuperclusters in the event
-  const edm::OrphanHandle<reco::SuperClusterCollection> &outOOTSuperClusterHandle = theEvent.put(std::move(ootSuperClusters),outOOTSuperClusters_);
+  edm::OrphanHandle<reco::SuperClusterCollection> outOOTSuperClusterHandle;
+  if(!ootPhotonT_.isUninitialized()) outOOTSuperClusterHandle = theEvent.put(std::move(ootSuperClusters),outOOTSuperClusters_);
   
   //Relink OOTPhoton SuperClusters
   for (reco::PhotonCore &ootPhotonCore : *ootPhotonCores) {
@@ -639,7 +642,8 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 
   //put photoncores and gsfelectroncores into the event
   const edm::OrphanHandle<reco::PhotonCoreCollection> &outPhotonCoreHandle = theEvent.put(std::move(photonCores),outPhotonCores_);
-  const edm::OrphanHandle<reco::PhotonCoreCollection> &outOOTPhotonCoreHandle = theEvent.put(std::move(ootPhotonCores),outOOTPhotonCores_);
+  edm::OrphanHandle<reco::PhotonCoreCollection> outOOTPhotonCoreHandle;
+  if(!ootPhotonT_.isUninitialized()) outOOTPhotonCoreHandle = theEvent.put(std::move(ootPhotonCores),outOOTPhotonCores_);
   const edm::OrphanHandle<reco::GsfElectronCoreCollection> &outgsfElectronCoreHandle = theEvent.put(std::move(gsfElectronCores),outGsfElectronCores_);
 
   //loop over photons, oot photons, and electrons and relink the cores
@@ -688,7 +692,8 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 
   //(finally) store the output photon and electron collections
   const edm::OrphanHandle<reco::PhotonCollection> &outPhotonHandle = theEvent.put(std::move(photons),outPhotons_);  
-  const edm::OrphanHandle<reco::PhotonCollection> &outOOTPhotonHandle = theEvent.put(std::move(ootPhotons),outOOTPhotons_);  
+  edm::OrphanHandle<reco::PhotonCollection> outOOTPhotonHandle;
+  if(!ootPhotonT_.isUninitialized()) outOOTPhotonHandle = theEvent.put(std::move(ootPhotons),outOOTPhotons_);  
   const edm::OrphanHandle<reco::GsfElectronCollection> &outGsfElectronHandle = theEvent.put(std::move(gsfElectrons),outGsfElectrons_);
   
   //still need to output relinked valuemaps

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -118,7 +118,7 @@ ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config) :
   for (const edm::InputTag &tag : photonpfclusterisoinputs) {
     photonFloatValueMapTs_.emplace_back(consumes<edm::ValueMap<float> >(tag));
   }  
-  std::cout<<" 1 "<<std::endl;
+
   const std::vector<edm::InputTag>&  ootphotonpfclusterisoinputs = 
     config.getParameter<std::vector<edm::InputTag> >("ootPhotonFloatValueMapSources");
   for (const edm::InputTag &tag : ootphotonpfclusterisoinputs) {
@@ -190,10 +190,10 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   
   edm::Handle<reco::PhotonCollection> photonHandle;
   theEvent.getByToken(photonT_, photonHandle);
-  std::cout<<" 2 "<<std::endl;
+
   edm::Handle<reco::PhotonCollection> ootPhotonHandle;
   if(doOotPhotons_)theEvent.getByToken(ootPhotonT_, ootPhotonHandle);
-  std::cout<<" 3 "<<std::endl;
+
   edm::Handle<reco::GsfElectronCollection> gsfElectronHandle;
   theEvent.getByToken(gsfElectronT_, gsfElectronHandle);  
 
@@ -238,7 +238,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   for (const auto& photonFloatValueMapT : photonFloatValueMapTs_) {
     theEvent.getByToken(photonFloatValueMapT,photonFloatValueMapHandles[index++]);
   }  
-  std::cout<<" 4 "<<std::endl;
+
   std::vector<edm::Handle<edm::ValueMap<float> > > ootPhotonFloatValueMapHandles(ootPhotonFloatValueMapTs_.size());
   if (doOotPhotons_){ 
     index = 0;
@@ -246,7 +246,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
       theEvent.getByToken(ootPhotonFloatValueMapT,ootPhotonFloatValueMapHandles[index++]);
     }  
   }
-  std::cout<<" 5 "<<std::endl;
+
   std::vector<edm::Handle<edm::ValueMap<float> > > gsfElectronFloatValueMapHandles(gsfElectronFloatValueMapTs_.size());
   index = 0;
   for (const auto& gsfElectronFloatValueMapT : gsfElectronFloatValueMapTs_) {
@@ -386,7 +386,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     const reco::ConversionRefVector &singleconvrefs = photon.conversionsOneLeg();
     linkConversions(singleconvrefs, *singleConversions, singleConversionMap);
   }
-  std::cout<<" 7, doOotPhotons_ "<<doOotPhotons_<<std::endl;
+
   //loop over oot photons and fill maps
   //special note1: since not PFCand --> no PF isolation, IDs (but we do have FloatValueMap!)
   //special note2: conversion sequence not run over bcs from oot phos, so skip relinking of oot phos
@@ -395,10 +395,10 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     index = -1;
     for (const auto& ootPhoton : *ootPhotonHandle) {
       index++;
-      std::cout<<" 8 "<<std::endl;
+
       bool keep = keepOOTPhotonSel_(ootPhoton);
       if (!keep) continue;
-      std::cout<<" 9 "<<std::endl;
+
       reco::PhotonRef ootPhotonref(ootPhotonHandle,index);
       
       ootPhotons->push_back(ootPhoton);
@@ -423,7 +423,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
       linkSuperCluster(ootSuperCluster, ootSuperClusterMap, *ootSuperClusters, relink, ootSuperClusterFullRelinkMap);
     }
   }
-  std::cout<<" 10 "<<std::endl;
+
   //loop over electrons and fill maps
   index = -1;
   for (const auto& gsfElectron : *gsfElectronHandle) {

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -46,7 +46,7 @@
 
 ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config) :
   photonT_(consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("photons"))),
-  ootPhotonT_(!ootPhotonT_.isUninitialized() ? consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("ootPhotons")) : edm::EDGetTokenT<reco::PhotonCollection>()),
+  ootPhotonT_(consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("ootPhotons"))),
   gsfElectronT_(consumes<reco::GsfElectronCollection>(config.getParameter<edm::InputTag>("gsfElectrons"))),
   gsfTrackT_(consumes<reco::GsfTrackCollection>(config.getParameter<edm::InputTag>("gsfTracks"))),
   conversionT_(consumes<reco::ConversionCollection>(config.getParameter<edm::InputTag>("conversions"))),

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
@@ -12,9 +12,4 @@ reducedHcalRecHits = cms.EDProducer("HcalHitSelection",
                                     )
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-_pp_on_AA_interestingDetIds  = cms.VInputTag([cms.InputTag("interestingGedEgammaIsoHCALDetId")])
-
-pp_on_AA_2018.toModify(
-    reducedHcalRecHits,
-    interestingDetIds = _pp_on_AA_interestingDetIds
-    )
+pp_on_AA_2018.toModify(reducedHcalRecHits.interestingDetIds, func = lambda list: list.remove(cms.InputTag("interestingOotEgammaIsoHCALDetId")) )

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
@@ -10,3 +10,11 @@ reducedHcalRecHits = cms.EDProducer("HcalHitSelection",
                                          cms.InputTag("interestingOotEgammaIsoHCALDetId"),
                                          )
                                     )
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+_pp_on_AA_interestingDetIds  = cms.VInputTag([cms.InputTag("interestingGedEgammaIsoHCALDetId")])
+
+pp_on_AA_2018.toModify(
+    reducedHcalRecHits,
+    interestingDetIds = _pp_on_AA_interestingDetIds
+    )

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
@@ -56,3 +56,7 @@ egmElectronIsolationPileUpCITK.srcForIsolationCone = cms.InputTag("pfPileUpAllCh
 particleFlowEGammaFull = cms.Sequence(particleFlowEGamma*gedGsfElectronSequenceTmp*gedPhotonSequenceTmp*ootPhotonSequence)
 particleFlowEGammaFinal = cms.Sequence(particleBasedIsolationTmp*pfNoPileUpIsoSequence*pfNoPileUpCandidates*pfPileUpAllChargedParticles*\
 egmPhotonIsolationCITK*egmElectronIsolationCITK*egmElectronIsolationPileUpCITK*gedPhotonSequence*gedElectronPFIsoSequence)
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+for e in [pp_on_AA_2018]:
+  e.toReplaceWith(particleFlowEGammaFull, particleFlowEGammaFull.copyAndExclude([ootPhotonSequence]))

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
@@ -58,5 +58,4 @@ particleFlowEGammaFinal = cms.Sequence(particleBasedIsolationTmp*pfNoPileUpIsoSe
 egmPhotonIsolationCITK*egmElectronIsolationCITK*egmElectronIsolationPileUpCITK*gedPhotonSequence*gedElectronPFIsoSequence)
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-for e in [pp_on_AA_2018]:
-  e.toReplaceWith(particleFlowEGammaFull, particleFlowEGammaFull.copyAndExclude([ootPhotonSequence]))
+pp_on_AA_2018.toReplaceWith(particleFlowEGammaFull, particleFlowEGammaFull.copyAndExclude([ootPhotonSequence]))


### PR DESCRIPTION
OOT photons are not needed for reconstruction of PbPb events. 
This PR modifies the era "pp_on_AA_2018", which is intended for PbPb processing this year.
It was tested with wf 158.
