### PR TITLE
Allow exception to be set early in a waiting task

### DIFF
--- a/FWCore/Concurrency/interface/WaitingTaskHolder.h
+++ b/FWCore/Concurrency/interface/WaitingTaskHolder.h
@@ -65,6 +65,18 @@ namespace edm {
     // ---------- static member functions --------------------
     
     // ---------- member functions ---------------------------
+    
+    /** Use in the case where you need to inform the parent task of a
+     failure before some other child task which may be run later reports
+     a different, but related failure. You must later call doneWaiting
+     in the same thread passing the same exceptoin.
+     */
+    void presetTaskAsFailed(std::exception_ptr iExcept) {
+      if(iExcept) {
+        m_task->dependentTaskFailed(iExcept);
+      }
+    }
+    
     void doneWaiting(std::exception_ptr iExcept) {
       if(iExcept) {
         m_task->dependentTaskFailed(iExcept);

--- a/FWCore/Concurrency/interface/WaitingTaskList.h
+++ b/FWCore/Concurrency/interface/WaitingTaskList.h
@@ -113,6 +113,13 @@ namespace edm {
       
       // ---------- member functions ---------------------------
       
+      /** Use in the case where you need to inform the parent task of a
+       failure before some other child task which may be run later reports
+       a different, but related failure. You must later call doneWaiting
+       with same exception later in the same thread.
+       */
+      void presetTaskAsFailed(std::exception_ptr iExcept);
+
       ///Adds task to the waiting list
       /**If doneWaiting() has already been called then the added task will immediately be spawned.
        * If that is not the case then the task will be held until doneWaiting() is called and will

--- a/FWCore/Concurrency/src/WaitingTaskList.cc
+++ b/FWCore/Concurrency/src/WaitingTaskList.cc
@@ -129,6 +129,21 @@ WaitingTaskList::add(WaitingTask* iTask) {
 }
 
 void
+WaitingTaskList::presetTaskAsFailed(std::exception_ptr iExcept) {
+  if(iExcept and m_waiting) {
+    WaitNode* node = m_head.load();
+    while(node) {
+      WaitNode* next;
+      while(node == (next=node->nextNode())) {
+        hardware_pause();
+      }
+      node->m_task->dependentTaskFailed(iExcept);
+      node = next;
+    }
+  }
+}
+
+void
 WaitingTaskList::announce()
 {
   //Need a temporary storage since one of these tasks could

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -261,6 +261,11 @@ namespace edm {
       } catch(...) {
         shouldContinue = false;
         finalException = std::current_exception();
+        //set the exception early to avoid case where another Path is waiting
+        // on a module in this Path and not running the module will lead to a
+        // different but related exception in the other Path. We want this
+        // Paths exception to be the one that gets reported.
+        waitingTasks_.presetTaskAsFailed(finalException);
       }
     }
     if(stopProcessingEvent_ and *stopProcessingEvent_) {


### PR DESCRIPTION
This avoids problems when one task is dependent upon the results of another task and the other task takes a long time to deal with the repercusions of the original exception. This may cause the dependent task to have an exception which is reported first, rather than the progenitor exception.