### PR TITLE
update VtxSmearingScenario for 10_2_X MC production

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -57,6 +57,7 @@ VtxSmeared = {
     'Realistic100ns13TeVCollisionBetaStar90m' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic100ns13TeVCollisionBetaStar90m_cfi',
     'Realistic100ns13TeVCollisionBetaStar90mLowBunches' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic100ns13TeVCollisionBetaStar90mLowBunches_cfi',
     'Realistic25ns13TeVEarly2017Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVEarly2017Collision_cfi',
+    'Realistic25ns13TeVEarly2018Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVEarly2018Collision_cfi',
 
 }
 VtxSmearedDefaultKey='Realistic50ns13TeVCollision'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -594,6 +594,34 @@ Realistic5TeVppCollision2017VtxSmearingParameters = cms.PSet(
     Z0 = cms.double(0.619)
 )
 
+# From 2018B 3.8T data
+# BS parameters extracted from run 316199, fill 6675 (from StreamExpressAlignment, HP BS):
+# X0         =  0.09676  [cm]
+# Y0         = -0.06245  [cm]
+# Z0         = -0.292    [cm]
+# sigmaZ0    =  3.5      [cm] => mean sigmaZ0 in this run is 3.2676
+# BeamWidthX 0.0008050
+# BeamWidthY 0.0006238
+#
+# From LHC calculator, emittance is 1.634e-8 cm
+# https://lpc.web.cern.ch/lpc/lumi2.html
+#
+# BPIX absolute position (from https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod):
+# X = 0.0859918 cm
+# Y = -0.104172 cm
+# Z = -0.327748 cm
+Realistic25ns13TeVEarly2018CollisionVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(30.0),
+    Emittance = cms.double(1.634e-8),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(3.5),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.0107682),
+    Y0 = cms.double(0.041722 ),
+    Z0 = cms.double(0.035748 )
+)
+
 # Test HF offset
 ShiftedCollision2015VtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic25ns13TeVEarly2018Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic25ns13TeVEarly2018Collision_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Realistic25ns13TeVEarly2018CollisionVtxSmearingParameters,
+    VtxSmearedCommon
+)


### PR DESCRIPTION
Update the VtxSmearingScenario parameters for 10_2_X MC production using early 2018 data:
- BeamSpot parameters extracted from run 316199 (fill 6675)
- BPix barycenter from Payload Inspector (https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod)