### PR TITLE
Make CondFormats/HcalObjects compatible with boost 1.64

### DIFF
--- a/CondFormats/HcalObjects/interface/HFPhase1PMTData.h
+++ b/CondFormats/HcalObjects/interface/HFPhase1PMTData.h
@@ -4,8 +4,12 @@
 #include "boost/serialization/access.hpp"
 #include "boost/serialization/version.hpp"
 #include "boost/serialization/shared_ptr.hpp"
+#include "boost/version.hpp"
+#if BOOST_VERSION < 106400
 #include "boost/serialization/array.hpp"
-
+#else
+#include "boost/serialization/boost_array.hpp"
+#endif
 #include "CondFormats/HcalObjects/interface/AbsHcalFunctor.h"
 
 class HFPhase1PMTData

--- a/CondFormats/HcalObjects/interface/HcalItemArrayColl.h
+++ b/CondFormats/HcalObjects/interface/HcalItemArrayColl.h
@@ -9,7 +9,12 @@
 #include "boost/serialization/version.hpp"
 #include "boost/serialization/shared_ptr.hpp"
 #include "boost/serialization/vector.hpp"
+#include "boost/version.hpp"
+#if BOOST_VERSION < 106400
 #include "boost/serialization/array.hpp"
+#else
+#include "boost/serialization/boost_array.hpp"
+#endif
 
 //
 // This collection manages arrays of pointers and references.


### PR DESCRIPTION
In boost 1.64 the serialization code that handles boost::array was
removed from array.hpp and put into boost_array.hpp.