### PR TITLE
Switched to std::unordered_map from boost::unordered_map

### DIFF
--- a/Fireworks/Core/src/FWGeometryTableManager.cc
+++ b/Fireworks/Core/src/FWGeometryTableManager.cc
@@ -272,7 +272,7 @@ void FWGeometryTableManager::loadGeometry(TGeoNode* iGeoTopNode, TObjArray* iVol
    m_levelOffset = 0;
 
    // set volume table for filters
-   boost::unordered_map<TGeoVolume*, Match>  pipi(iVolumes->GetSize());
+   Volumes_t  pipi(iVolumes->GetSize());
    m_volumes.swap(pipi);
    TIter next( iVolumes);
    TGeoVolume* v;

--- a/Fireworks/Core/src/FWGeometryTableManager.h
+++ b/Fireworks/Core/src/FWGeometryTableManager.h
@@ -20,7 +20,7 @@
 
 #include "Fireworks/Core/interface/FWGeometryTableManagerBase.h"
 #include <string>
-#include <boost/tr1/unordered_map.hpp>
+#include <unordered_map>
 
 class FWGeometryTableViewBase;
 class FWGeometryTableView;
@@ -46,11 +46,11 @@ public:
       bool m_childMatches;
       Match() : m_matches(false), m_childMatches(false) {}
 
-      bool accepted() { return m_matches || m_childMatches; }
+      bool accepted() const { return m_matches || m_childMatches; }
    };
 
 
-   typedef boost::unordered_map<TGeoVolume*, Match>  Volumes_t;
+   typedef std::unordered_map<TGeoVolume*, Match>  Volumes_t;
    typedef Volumes_t::iterator               Volumes_i; 
 
    FWGeometryTableManager(FWGeometryTableView*);


### PR DESCRIPTION
The boost::unordered_map header was moved so it was a good time to switch to the std version.