### PR TITLE
GBRForestTools seraches for gzipped weight file if raw file not found

### DIFF
--- a/RecoEgamma/EgammaTools/interface/GBRForestTools.h
+++ b/RecoEgamma/EgammaTools/interface/GBRForestTools.h
@@ -30,6 +30,10 @@ class GBRForestTools
     static std::unique_ptr<const GBRForest> createGBRForest(const std::string &weightFile);
     static std::unique_ptr<const GBRForest> createGBRForest(const edm::FileInPath &weightFile);
 
+    // Overloaded versions which are taking string vectors by reference to strore the variable names in
+    static std::unique_ptr<const GBRForest> createGBRForest(const std::string &weightFile, std::vector<std::string> &varNames);
+    static std::unique_ptr<const GBRForest> createGBRForest(const edm::FileInPath &weightFile, std::vector<std::string> &varNames);
+
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/GBRForestTools.h
+++ b/RecoEgamma/EgammaTools/interface/GBRForestTools.h
@@ -22,6 +22,9 @@
 
 #include "CommonTools/Utils/interface/TMVAZipReader.h"
 
+#include "FWCore/Utilities/interface/EDMException.h"
+
+
 class GBRForestTools
 {
   public:

--- a/RecoEgamma/EgammaTools/src/GBRForestTools.cc
+++ b/RecoEgamma/EgammaTools/src/GBRForestTools.cc
@@ -34,18 +34,22 @@ namespace {
 // anything else.
 std::unique_ptr<const GBRForest> GBRForestTools::createGBRForest(const std::string &weightFile,
                                                                  std::vector<std::string> &varNames){
-  try {
-      edm::FileInPath weightFileEdm(weightFile + ".gz");
-      return GBRForestTools::createGBRForest(weightFileEdm, varNames);
-  } catch (...) {
-      try {
-          edm::FileInPath weightFileEdm(weightFile + ".gzip");
-          return GBRForestTools::createGBRForest(weightFileEdm, varNames);
-      } catch (...) {
-          edm::FileInPath weightFileEdm(weightFile);
-          return GBRForestTools::createGBRForest(weightFileEdm, varNames);
-      }
-  }
+
+   std::string gzipExtensions[3] = {"gz", "gzip"};
+
+   for(const std::string &gzipExt : gzipExtensions) {
+     try {
+         edm::FileInPath weightFileEdm(weightFile + "." + gzipExt);
+         return GBRForestTools::createGBRForest(weightFileEdm, varNames);
+     } catch (edm::Exception& e) {
+         if (e.category() == "FileInPathError") continue;
+         else throw e;
+     }
+   }
+
+   edm::FileInPath weightFileEdm(weightFile);
+   return GBRForestTools::createGBRForest(weightFileEdm, varNames);
+
 }
 
 // Creates a pointer to new GBRForest corresponding to a TMVA weights file

--- a/RecoEgamma/EgammaTools/src/GBRForestTools.cc
+++ b/RecoEgamma/EgammaTools/src/GBRForestTools.cc
@@ -11,7 +11,7 @@ namespace {
     int found = 0;
     for (unsigned int i=0 ; i<nth ; ++i) {
         std::size_t pos = haystack.find(needle, found);
-        if (pos == std::string::npos) return -1; 
+        if (pos == std::string::npos) return -1;
         else found = pos+1;
     }
     return found;
@@ -27,13 +27,30 @@ namespace {
 
 };
 
-std::unique_ptr<const GBRForest> GBRForestTools::createGBRForest(const std::string &weightFile){
-  edm::FileInPath weightFileEdm(weightFile);
-  return GBRForestTools::createGBRForest(weightFileEdm);
+// Creates a pointer to new GBRForest corresponding to a TMVA weights file,
+// given a file path as string.  When the file is not found, also the same name
+// appended with ".gz" and ".gzip" is tried.  This allows the maintainters of
+// the data repositories to gzip weight files a posteriori without changing
+// anything else.
+std::unique_ptr<const GBRForest> GBRForestTools::createGBRForest(const std::string &weightFile,
+                                                                 std::vector<std::string> &varNames){
+  try {
+      edm::FileInPath weightFileEdm(weightFile + ".gz");
+      return GBRForestTools::createGBRForest(weightFileEdm, varNames);
+  } catch (...) {
+      try {
+          edm::FileInPath weightFileEdm(weightFile + ".gzip");
+          return GBRForestTools::createGBRForest(weightFileEdm, varNames);
+      } catch (...) {
+          edm::FileInPath weightFileEdm(weightFile);
+          return GBRForestTools::createGBRForest(weightFileEdm, varNames);
+      }
+  }
 }
 
 // Creates a pointer to new GBRForest corresponding to a TMVA weights file
-std::unique_ptr<const GBRForest> GBRForestTools::createGBRForest(const edm::FileInPath &weightFile){
+std::unique_ptr<const GBRForest> GBRForestTools::createGBRForest(const edm::FileInPath &weightFile,
+                                                                 std::vector<std::string> &varNames){
 
   std::string method;
 
@@ -43,7 +60,7 @@ std::unique_ptr<const GBRForest> GBRForestTools::createGBRForest(const edm::File
   std::vector<float> dumbVars;
   std::vector<float> dumbSpecs;
 
-  std::vector<std::string> varNames;
+  varNames.clear();
   std::vector<std::string> specNames;
 
   std::string line;
@@ -134,4 +151,14 @@ std::unique_ptr<const GBRForest> GBRForestTools::createGBRForest(const edm::File
   delete mvaReader;
 
   return gbrForest;
+}
+
+std::unique_ptr<const GBRForest> GBRForestTools::createGBRForest(const std::string &weightFile){
+  std::vector<std::string> varNames;
+  return GBRForestTools::createGBRForest(weightFile);
+}
+
+std::unique_ptr<const GBRForest> GBRForestTools::createGBRForest(const edm::FileInPath &weightFile){
+    std::vector<std::string> varNames;
+    return GBRForestTools::createGBRForest(weightFile, varNames);
 }


### PR DESCRIPTION
This goes together with https://github.com/cms-data/RecoEgamma-ElectronIdentification/pull/9.

* GBRForestTools seraches for gzipped weight file if raw file not found, allows us to gzip weight files a posteriori in cms-data

* Added versions of createGBRForest() that take string vectors by reference to strore the variable names in (will be used by other PR by egamma to come in the future)