### PR TITLE
EvtGen access in multiple Pythia guns

### DIFF
--- a/GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h
+++ b/GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h
@@ -51,6 +51,7 @@ namespace gen {
     
     void setRandomEngine(CLHEP::HepRandomEngine* v) { p8SetRandomEngine(v); }
     std::vector<std::string> const& sharedResources() const { return p8SharedResources; }
+	void evtGenDecay();
 
   protected:        
     // (some of) PGun parameters

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -4,10 +4,6 @@
 
 #include "GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h"
 
-// EvtGen plugin
-//
-#include "Pythia8Plugins/EvtGen.h"
-
 namespace gen {
 
 class Py8EGun : public Py8GunBase {
@@ -104,8 +100,7 @@ bool Py8EGun::generatePartonsAndHadronize()
    }
    
    if ( !fMasterGen->next() ) return false;
-   
-   if (evtgenDecays.get()) evtgenDecays->decay();
+   evtGenDecay();
 
    event().reset(new HepMC::GenEvent);
    return toHepMC.fill_next_event( fMasterGen->event, event().get() );

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
@@ -106,6 +106,7 @@ bool Py8PtGun::generatePartonsAndHadronize()
    }
    
    if ( !fMasterGen->next() ) return false;
+   evtGenDecay();
    
    event().reset(new HepMC::GenEvent);
    return toHepMC.fill_next_event( fMasterGen->event, event().get() );

--- a/GeneratorInterface/Pythia8Interface/src/Py8GunBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8GunBase.cc
@@ -161,4 +161,9 @@ void Py8GunBase::statistics()
 
 }
 
+void Py8GunBase::evtGenDecay()
+{
+  if (evtgenDecays.get()) evtgenDecays->decay();
+}
+
 }


### PR DESCRIPTION
Trying to add the statement `if (evtgenDecays.get()) evtgenDecays->decay();` in `Py8PtGun` (previously only in `Py8EGun`) caused an ODR violation since `Pythia8Plugins/EvtGen.h` is header-only and not inline.

To get around this, that statement is wrapped in a function of the base class, so none of the derived classes have to include the `EvtGen.h` header directly.

Once approved, this PR will be backported to all active MC releases: 101X, 93X, 71X.

attn: @alberto-sanchez