### PR TITLE
electron reco modifications for 2018 heavy ion era

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
@@ -82,4 +82,4 @@ ecalDrivenElectronSeedsParameters = cms.PSet(
 )
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-pp_on_AA_2018.toModify(ecalDrivenElectronSeedsParameters, SCEtCut = cms.double(15.0))
+pp_on_AA_2018.toModify(ecalDrivenElectronSeedsParameters, SCEtCut = 15.0)

--- a/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
@@ -81,3 +81,5 @@ ecalDrivenElectronSeedsParameters = cms.PSet(
     
 )
 
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(ecalDrivenElectronSeedsParameters, SCEtCut = cms.double(15.0))

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -169,5 +169,5 @@ gedGsfElectronsTmp = cms.EDProducer("GEDGsfElectronProducer",
 )
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-pp_on_AA_2018.toModify(gedGsfElectronsTmp, minSCEtBarrel = cms.double(15.0))
-pp_on_AA_2018.toModify(gedGsfElectronsTmp, minSCEtEndcaps = cms.double(15.0))
+pp_on_AA_2018.toModify(gedGsfElectronsTmp, minSCEtBarrel = 15.0)
+pp_on_AA_2018.toModify(gedGsfElectronsTmp, minSCEtEndcaps = 15.0)

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -168,5 +168,6 @@ gedGsfElectronsTmp = cms.EDProducer("GEDGsfElectronProducer",
                                  ),
 )
 
-
-
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(gedGsfElectronsTmp, minSCEtBarrel = cms.double(15.0))
+pp_on_AA_2018.toModify(gedGsfElectronsTmp, minSCEtEndcaps = cms.double(15.0))

--- a/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
@@ -166,6 +166,9 @@ ecalDrivenGsfElectrons = cms.EDProducer("GsfElectronEcalDrivenProducer",
 
 )
 
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(ecalDrivenGsfElectrons, minSCEtBarrel = cms.double(15.0))
+pp_on_AA_2018.toModify(ecalDrivenGsfElectrons, minSCEtEndcaps = cms.double(15.0))
 
 #==============================================================================
 # Final producer of persistent gsf electrons

--- a/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
@@ -167,8 +167,8 @@ ecalDrivenGsfElectrons = cms.EDProducer("GsfElectronEcalDrivenProducer",
 )
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-pp_on_AA_2018.toModify(ecalDrivenGsfElectrons, minSCEtBarrel = cms.double(15.0))
-pp_on_AA_2018.toModify(ecalDrivenGsfElectrons, minSCEtEndcaps = cms.double(15.0))
+pp_on_AA_2018.toModify(ecalDrivenGsfElectrons, minSCEtBarrel = 15.0)
+pp_on_AA_2018.toModify(ecalDrivenGsfElectrons, minSCEtEndcaps = 15.0)
 
 #==============================================================================
 # Final producer of persistent gsf electrons

--- a/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
+++ b/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
@@ -22,10 +22,11 @@ ElectronSeedMerger::ElectronSeedMerger(const ParameterSet& iConfig):
  conf_(iConfig)
 {
   LogInfo("ElectronSeedMerger")<<"Electron SeedMerger  started  ";
-  
 
   ecalSeedToken_ = consumes<ElectronSeedCollection>(iConfig.getParameter<InputTag>("EcalBasedSeeds"));
-  tkSeedToken_ = consumes<ElectronSeedCollection>(iConfig.getParameter<InputTag>("TkBasedSeeds"));
+  edm::InputTag tkSeedLabel_ = iConfig.getParameter<InputTag>("TkBasedSeeds");
+  if (!tkSeedLabel_.label().empty())
+    tkSeedToken_ = consumes<ElectronSeedCollection>(tkSeedLabel_);
    
   produces<ElectronSeedCollection>();
 
@@ -58,8 +59,11 @@ ElectronSeedMerger::produce(Event& iEvent, const EventSetup& iSetup)
   ElectronSeedCollection ESeed = *(EcalBasedSeeds.product());
 
   Handle<ElectronSeedCollection> TkBasedSeeds;
-  iEvent.getByToken(tkSeedToken_,TkBasedSeeds);
-  ElectronSeedCollection TSeed = *(TkBasedSeeds.product());
+  ElectronSeedCollection TSeed;
+  if (!tkSeedToken_.isUninitialized()) {
+    iEvent.getByToken(tkSeedToken_,TkBasedSeeds);
+    TSeed = *(TkBasedSeeds.product());
+  }
 
 
   //VECTOR FOR MATCHED SEEDS

--- a/RecoParticleFlow/PFTracking/python/mergedElectronSeeds_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/mergedElectronSeeds_cfi.py
@@ -7,7 +7,7 @@ electronMergedSeeds =cms.EDProducer("ElectronSeedMerger",
     )
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-pp_on_AA_2018.toModify(electronMergedSeeds, TkBasedSeeds = cms.InputTag(''))
+pp_on_AA_2018.toModify(electronMergedSeeds, TkBasedSeeds = '')
 
 electronMergedSeedsFromMultiCl = electronMergedSeeds.clone(
   EcalBasedSeeds = 'ecalDrivenElectronSeedsFromMultiCl'

--- a/RecoParticleFlow/PFTracking/python/mergedElectronSeeds_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/mergedElectronSeeds_cfi.py
@@ -6,6 +6,9 @@ electronMergedSeeds =cms.EDProducer("ElectronSeedMerger",
      TkBasedSeeds  = cms.InputTag("trackerDrivenElectronSeeds:SeedsForGsf")
     )
 
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(electronMergedSeeds, TkBasedSeeds = cms.InputTag(''))
+
 electronMergedSeedsFromMultiCl = electronMergedSeeds.clone(
   EcalBasedSeeds = 'ecalDrivenElectronSeedsFromMultiCl'
 )

--- a/TrackingTools/GsfTracking/python/GsfElectronTracking_cff.py
+++ b/TrackingTools/GsfTracking/python/GsfElectronTracking_cff.py
@@ -10,6 +10,9 @@ _electronSeedsTaskFromMultiCl = electronSeedsTask.copy()
 _electronSeedsTaskFromMultiCl.add(cms.Task(ecalDrivenElectronSeedsFromMultiCl,electronMergedSeedsFromMultiCl))
 _electronSeedsFromMultiCl = cms.Sequence(_electronSeedsTaskFromMultiCl)
 
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toReplaceWith(electronSeedsTask, electronSeedsTask.copyAndExclude([trackerDrivenElectronSeeds]))
+
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toReplaceWith(
   electronSeedsTask, _electronSeedsTaskFromMultiCl )


### PR DESCRIPTION
this PR includes the following modifications to electron reconstruction for the 2018 heavy ion era:
- raise supercluster energy thresholds
- removal of tracker-driven electrons

these changes affect mainly very low-pt electrons, and are in line with the (old) custom heavy ion reconstruction sequence.

@mandrenguyen 