### PR TITLE
Change puppi weight compression

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -255,8 +255,17 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     auto puppiMatched = find_if( lCandidates.begin(), lCandidates.end(), [&val]( fastjet::PseudoJet const & i ){ return i.user_index() == val; } );
     if ( puppiMatched != lCandidates.end() ) {
       pVec.SetPxPyPzE(puppiMatched->px(),puppiMatched->py(),puppiMatched->pz(),puppiMatched->E());
+      if(fClonePackedCands && (!fUseExistingWeights)) {
+        if(fPuppiForLeptons)
+          pCand->setPuppiWeight(pCand->puppiWeight(),lWeights[puppiMatched-lCandidates.begin()]);
+        else
+          pCand->setPuppiWeight(lWeights[puppiMatched-lCandidates.begin()],pCand->puppiWeightNoLep());
+      }
     } else {
       pVec.SetPxPyPzE( 0, 0, 0, 0);
+      if(fClonePackedCands && (!fUseExistingWeights)) {
+        pCand->setPuppiWeight(0,0);
+      }
     }
     puppiP4s.push_back( pVec );
 

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -710,7 +710,7 @@ namespace pat {
     void packBoth() { pack(false); packVtx(false); delete p4_.exchange(nullptr); delete p4c_.exchange(nullptr); delete vertex_.exchange(nullptr); unpack(); unpackVtx(); } // do it this way, so that we don't loose precision on the angles before computing dxy,dz
     void unpackTrk() const ;
 
-    int8_t packedPuppiweight_;
+    uint8_t packedPuppiweight_;
     int8_t packedPuppiweightNoLepDiff_; // storing the DIFFERENCE of (all - "no lep") for compression optimization
     uint8_t rawCaloFraction_;
     int8_t hcalFraction_;

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -354,13 +354,13 @@ bool pat::PackedCandidate::massConstraint() const {return false;}
 // puppiweight
 void pat::PackedCandidate::setPuppiWeight(float p, float p_nolep) {
   // Set both weights at once to avoid misconfigured weights if called in the wrong order
-  packedPuppiweight_ = pack8logClosed((p-0.5)*2,-2,0,64);
-  packedPuppiweightNoLepDiff_ = pack8logClosed((p_nolep-0.5)*2,-2,0,64) - packedPuppiweight_;
+  packedPuppiweight_ = std::numeric_limits<uint8_t>::max()*p;
+  packedPuppiweightNoLepDiff_ = std::numeric_limits<int8_t>::max()*(p_nolep-p);
 }
 
-float pat::PackedCandidate::puppiWeight() const { return unpack8logClosed(packedPuppiweight_,-2,0,64)/2. + 0.5;}
+float pat::PackedCandidate::puppiWeight() const { return 1.f*packedPuppiweight_/std::numeric_limits<uint8_t>::max();}
 
-float pat::PackedCandidate::puppiWeightNoLep() const { return unpack8logClosed(packedPuppiweightNoLepDiff_+packedPuppiweight_,-2,0,64)/2. + 0.5;}
+float pat::PackedCandidate::puppiWeightNoLep() const { return 1.f*packedPuppiweightNoLepDiff_/std::numeric_limits<int8_t>::max() + 1.f*packedPuppiweight_/std::numeric_limits<uint8_t>::max();}
 
 void pat::PackedCandidate::setRawCaloFraction(float p) {
   if(100*p>std::numeric_limits<uint8_t>::max())

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -322,7 +322,8 @@
   <class name="pat::PackedCandidate::PackedCovariance" ClassVersion="3">
    <version ClassVersion="3" checksum="3320406063"/>
   </class>
-  <class name="pat::PackedCandidate" ClassVersion="32">
+  <class name="pat::PackedCandidate" ClassVersion="33">
+   <version ClassVersion="33" checksum="1092680546"/>
    <version ClassVersion="32" checksum="926869123"/>
    <version ClassVersion="31" checksum="1248040002"/>
    <version ClassVersion="30" checksum="3338823671"/>
@@ -392,7 +393,18 @@
             packedCovariance_.dphidphi = onfile.packedCovarianceDphiDphi_;
    ]]>
    </ioread>
-
+  <ioread sourceClass="pat::PackedCandidate" source="int8_t packedPuppiweight_" version="[-32]" targetClass="pat::PackedCandidate"
+   target="packedPuppiweight_" include="DataFormats/Math/interface/liblogintpack.h">
+   <![CDATA[
+            packedPuppiweight_ = std::numeric_limits<uint8_t>::max()*(logintpack::unpack8logClosed(onfile.packedPuppiweight_,-2,0,64)/2. + 0.5);
+   ]]>
+   </ioread>
+  <ioread sourceClass="pat::PackedCandidate" source="int8_t packedPuppiweightNoLepDiff_; int8_t packedPuppiweight_" version="[-32]" targetClass="pat::PackedCandidate"
+   target="packedPuppiweightNoLepDiff_" include="DataFormats/Math/interface/liblogintpack.h">
+   <![CDATA[
+            packedPuppiweightNoLepDiff_ = std::numeric_limits<int8_t>::max()*(logintpack::unpack8logClosed(onfile.packedPuppiweightNoLepDiff_+onfile.packedPuppiweight_,-2,0,64)/2. - logintpack::unpack8logClosed(onfile.packedPuppiweight_,-2,0,64)/2.);
+   ]]>
+   </ioread>
 
 
   <class name="pat::PackedGenParticle" ClassVersion="12">


### PR DESCRIPTION
Adresses issue #23366.

The puppi weight is stored with linear instead of log scale compression to 8 bits.

The new compression scheme has improved precision for weights around 0.5, while is was at 10% level before (see https://github.com/cms-sw/cmssw/files/2045014/weight_not_charged_data_MC.pdf)

The iorules allow to read files created with older releases within the precision of the old an new compression schemes.

The size increase was check with 1000 ttbar events with patMiniAOD_standard_cfg.
before this commit
patPackedCandidates_packedPFCandidates__PAT. 136489 20525

after this commit
patPackedCandidates_packedPFCandidates__PAT. 136489 20540.4

In addition, the puppi weight is now set for packed candidates created by the PUPPI algorithm, when cloning the packed candidates from MiniAOD.