### PR TITLE
[10.2.X] cleanup HLTrigger/HLTanalyzers BuildFile

### DIFF
--- a/HLTrigger/HLTanalyzers/plugins/BuildFile.xml
+++ b/HLTrigger/HLTanalyzers/plugins/BuildFile.xml
@@ -16,7 +16,6 @@
 <use name="DataFormats/L1TGlobal"/>
 <use name="DataFormats/Luminosity"/>
 <use name="DataFormats/METReco"/>
-<use name="DataFormats/MuonData"/>
 <use name="DataFormats/RPCDigi"/>
 <use name="DataFormats/SiPixelDigi"/>
 <use name="DataFormats/SiStripDigi"/>


### PR DESCRIPTION
DataFormats/MuonData package does not contain any BuildFile, so one should not depend on such packages. This should fix the SCRAM warning
```
****WARNING: Invalid tool DataFormats/MuonData. Please fix src/HLTrigger/HLTanalyzers/plugins/BuildFile.xml file.
```