### PR TITLE
[10.2.X] Cleanup CondTools/SiStrip BuildFile

### DIFF
--- a/CondTools/SiStrip/plugins/BuildFile.xml
+++ b/CondTools/SiStrip/plugins/BuildFile.xml
@@ -10,7 +10,6 @@
 <use   name="CalibTracker/Records"/>
 <use   name="CondCore/DBOutputService"/>
 <use   name="CondFormats/SiStripObjects"/>
-<use   name="CondCore/SiStripPlugins"/>
 <use   name="CalibFormats/SiStripObjects"/>
 <use   name="DataFormats/SiStripDetId"/>
 <use   name="CalibTracker/SiStripCommon"/>


### PR DESCRIPTION
CondCore/SiStripPlugins generates an edm plugin, so one can not depend on it. This shoudl fix the SCRAM warning 
```
****WARNING: Invalid tool CondCore/SiStripPlugins. Please fix src/CondTools/SiStrip/plugins/BuildFile.xml file.
```