### PR TITLE
[10.2.X] Cleanup PhysicsTools/PythonAnalysis BuildFile

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -1,8 +1,4 @@
 <use name="py2-histogrammar"/>
-<use name="py2-matplotlib"/>
-<use name="py2-root_numpy"/>
-<use name="py2-pandas"/>
-<use name="py2-pippkgs"/>
 <use name="rootpy"/>
 
 <test name="testHistogrammar" command="testHistogrammar.py"/>


### PR DESCRIPTION
There are no tool files for these packages, so this PR shoudl fix the SCRAM warnings
```
****WARNING: Invalid tool py2-matplotlib. Please fix src/PhysicsTools/PythonAnalysis/test/BuildFile.xml file.
****WARNING: Invalid tool tmp/slc6_amd64_gcc630/cache/bf/src/PhysicsTools/PythonAnalysis/test/BuildFile_USE_ERR+=py2-pandas. Please fix src/PhysicsTools/PythonAnalysis/test/BuildFile.xml file.
****WARNING: Invalid tool tmp/slc6_amd64_gcc630/cache/bf/src/PhysicsTools/PythonAnalysis/test/BuildFile_USE_ERR+=py2-pippkgs. Please fix src/PhysicsTools/PythonAnalysis/test/BuildFile.xml file.
****WARNING: Invalid tool tmp/slc6_amd64_gcc630/cache/bf/src/PhysicsTools/PythonAnalysis/test/BuildFile_USE_ERR+=py2-root_numpy. Please fix src/PhysicsTools/PythonAnalysis/test/BuildFile.xml file.
```