### PR TITLE
Bug fix in IndexIntoFileItrImpl::firstEventEntryThisLumi

### DIFF
--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -1281,10 +1281,10 @@ namespace edm {
     long long saveIndexToEvent = indexToEvent();
     long long saveNEvents = nEvents();
 
-    for(int i = 1; indexToLumi() - i > 0; ++i) {
-      if(getRunOrLumiEntryType(indexToLumi_ - i) == kRun) break;
-      if(!isSameLumi(indexToLumi(), indexToLumi() - i)) break;
-      indexToLumi_ = indexToLumi_ - i;
+    while (indexToLumi() - 1 > 0) {
+      if(getRunOrLumiEntryType(indexToLumi() - 1) == kRun) break;
+      if(!isSameLumi(indexToLumi(), indexToLumi() - 1)) break;
+      --indexToLumi_;
     }
     initializeLumi();
 

--- a/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
@@ -267,6 +267,9 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
     if (i == 12) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 6);
 
     if (i == 0) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+    if (i == 1) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+    if (i == 2) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
+    if (i == 3) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
     if (i == 10) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 4);
     if (i == 12) CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
   }
@@ -370,6 +373,9 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
     if (i == 12) CPPUNIT_ASSERT(iterNum.firstEventEntryThisRun() == 6);
 
     if (i == 0) CPPUNIT_ASSERT(iterNum.firstEventEntryThisLumi() == 3);
+    if (i == 1) CPPUNIT_ASSERT(iterNum.firstEventEntryThisLumi() == 3);
+    if (i == 2) CPPUNIT_ASSERT(iterNum.firstEventEntryThisLumi() == 3);
+    if (i == 3) CPPUNIT_ASSERT(iterNum.firstEventEntryThisLumi() == 3);
     if (i == 10) CPPUNIT_ASSERT(iterNum.firstEventEntryThisLumi() == 5);
     if (i == 12) CPPUNIT_ASSERT(iterNum.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
   }


### PR DESCRIPTION
As far as I know no one has ever hit this bug.
An extremely unusual set of circumstances needs
to exist to hit it. First the function is only
called when the LuminosityBlockAuxiliary has an
invalid beginTime and the Framework is trying to
fix it by getting the time from the first event
in that lumi. The bug might cause it to get the
wrong event and there is a remote chance this event
could be from the wrong run. But for the wrong
event to be selected, the lumi has to be fragmented
over multiple lumi entries in the lumi TTree and
that only happens after after a lumi was split over
multiple files and then merged together in a noncontiguous
order. It can also happen running in a mode using
multiple concurrent luminosity blocks.