### PR TITLE
Prioritize exception from Paths

### DIFF
--- a/FWCore/Concurrency/interface/WaitingTask.h
+++ b/FWCore/Concurrency/interface/WaitingTask.h
@@ -77,7 +77,7 @@ namespace edm {
   template<typename F>
   class FunctorWaitingTask : public WaitingTask {
   public:
-    explicit FunctorWaitingTask( F f): func_(f) {}
+    explicit FunctorWaitingTask( F f): func_(std::move(f)) {}
     
     task* execute() override {
       func_(exceptionPtr());
@@ -90,7 +90,7 @@ namespace edm {
   
   template< typename ALLOC, typename F>
   FunctorWaitingTask<F>* make_waiting_task( ALLOC&& iAlloc, F f) {
-    return new (iAlloc) FunctorWaitingTask<F>(f);
+    return new (iAlloc) FunctorWaitingTask<F>(std::move(f));
   }
   
 }

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -295,7 +295,7 @@ namespace edm {
 
     void resetAll();
 
-    void finishedPaths(std::exception_ptr, WaitingTaskHolder,
+    void finishedPaths(std::atomic<std::exception_ptr*>&, WaitingTaskHolder,
                        EventPrincipal& ep, EventSetup const& es);
     std::exception_ptr finishProcessOneEvent(std::exception_ptr);
     


### PR DESCRIPTION
When multiple exceptions occur when processing an Event, prioritize the exception originating from a Path over those from EndPaths or Accumulators. 

This comes from diagnosing failures coming in the gcc 8 IBs where an exception originating in a Path ultimately leads to missing data which triggers a different exception when running accumulators.