### PR TITLE
Add 2D plots for the comparison between data and emulator for L1TObjects - L1T&Online DQM - cmssw102X

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
@@ -43,6 +43,7 @@ class L1TStage2MuonComp : public DQMEDAnalyzer {
   std::string summaryTitle;
   std::vector<int> ignoreBin;
   bool verbose;
+  bool enable2DComp; // Default value is false. Set to true in the configuration file for enabling 2D eta-phi histograms
 
   MonitorElement* summary;
   MonitorElement* errorSummaryNum;
@@ -60,6 +61,7 @@ class L1TStage2MuonComp : public DQMEDAnalyzer {
   MonitorElement* muColl1hwQual;
   MonitorElement* muColl1hwIso;
   MonitorElement* muColl1Index;
+  MonitorElement* muColl1EtaPhimap; // This histogram will be filled only if enable2DComp is true 
 
   MonitorElement* muColl2BxRange;
   MonitorElement* muColl2nMu;
@@ -73,7 +75,8 @@ class L1TStage2MuonComp : public DQMEDAnalyzer {
   MonitorElement* muColl2hwQual;
   MonitorElement* muColl2hwIso;
   MonitorElement* muColl2Index;
-
+  MonitorElement* muColl2EtaPhimap; // This histogram will be filled only if enable2DComp is true
+ 
 };
 
 #endif

--- a/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer2.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer2.h
@@ -279,6 +279,8 @@ class L1TdeStage2CaloLayer2 : public DQMEDAnalyzer {
   MonitorElement * jetEtEmul;
   MonitorElement * jetEtaEmul;
   MonitorElement * jetPhiEmul;
+  MonitorElement * jet2DEtaPhiData; // This histogram will be filled only if enable2DComp is true 
+  MonitorElement * jet2DEtaPhiEmul; // This histogram will be filled only if enable2DComp is true  
 
   // histograms to store the properties of mismatched non-isolated e/g
   MonitorElement * egEtData;
@@ -287,7 +289,9 @@ class L1TdeStage2CaloLayer2 : public DQMEDAnalyzer {
   MonitorElement * egEtEmul;
   MonitorElement * egEtaEmul;
   MonitorElement * egPhiEmul;
-
+  MonitorElement * eg2DEtaPhiData; // This histogram will be filled only if enable2DComp is true
+  MonitorElement * eg2DEtaPhiEmul; // This histogram will be filled only if enable2DComp is true
+  
   // histograms to store the properties of mismatched isolated e/g
   MonitorElement * isoEgEtData;
   MonitorElement * isoEgEtaData;
@@ -295,7 +299,9 @@ class L1TdeStage2CaloLayer2 : public DQMEDAnalyzer {
   MonitorElement * isoEgEtEmul;
   MonitorElement * isoEgEtaEmul;
   MonitorElement * isoEgPhiEmul;
-
+  MonitorElement * isoEg2DEtaPhiData; // This histogram will be filled only if enable2DComp is true
+  MonitorElement * isoEg2DEtaPhiEmul; // This histogram will be filled only if enable2DComp is true
+  
   // histograms to store the properties of mismatched non-isolated taus
   MonitorElement * tauEtData;
   MonitorElement * tauEtaData;
@@ -303,6 +309,8 @@ class L1TdeStage2CaloLayer2 : public DQMEDAnalyzer {
   MonitorElement * tauEtEmul;
   MonitorElement * tauEtaEmul;
   MonitorElement * tauPhiEmul;
+  MonitorElement * tau2DEtaPhiData; // This histogram will be filled only if enable2DComp is true 
+  MonitorElement * tau2DEtaPhiEmul; // This histogram will be filled only if enable2DComp is true
 
   // histograms to store the properties of mismatched isolated taus
   MonitorElement * isoTauEtData;
@@ -311,7 +319,9 @@ class L1TdeStage2CaloLayer2 : public DQMEDAnalyzer {
   MonitorElement * isoTauEtEmul;
   MonitorElement * isoTauEtaEmul;
   MonitorElement * isoTauPhiEmul;
-
+  MonitorElement * isoTau2DEtaPhiData; // This histogram will be filled only if enable2DComp is true
+  MonitorElement * isoTau2DEtaPhiEmul; // This histogram will be filled only if enable2DComp is true
+  
   // histograms for mismatched ett sums
   MonitorElement * ettData;
   MonitorElement * ettEmul;
@@ -361,6 +371,7 @@ class L1TdeStage2CaloLayer2 : public DQMEDAnalyzer {
   MonitorElement * towCountEmul;
 
   bool verbose;
+  bool enable2DComp; // Default value is false. Set to true in the configuration file for enabling 2D eta-phi histograms
 
   // use only bx = 0 since it only contains RAW data (needed for emulator)
   const unsigned int currBx = 0;

--- a/DQM/L1TMonitor/python/L1TdeStage2CaloLayer2_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2CaloLayer2_cfi.py
@@ -11,5 +11,5 @@ l1tdeStage2CaloLayer2 = DQMEDAnalyzer('L1TdeStage2CaloLayer2',
     calol2EtSumCollectionData = cms.InputTag("caloStage2Digis", "EtSum"),
     calol2EtSumCollectionEmul = cms.InputTag("valCaloStage2Layer2Digis"),
     monitorDir = cms.untracked.string("L1TEMU/L1TStage2CaloLayer2/L1TdeStage2CaloLayer2"),
-    enable2DComp = cms.untracked.bool(False) # When true eta-phi comparison plots are also produced
+    enable2DComp = cms.untracked.bool(True) # When true eta-phi comparison plots are also produced
 )

--- a/DQM/L1TMonitor/python/L1TdeStage2CaloLayer2_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2CaloLayer2_cfi.py
@@ -10,5 +10,6 @@ l1tdeStage2CaloLayer2 = DQMEDAnalyzer('L1TdeStage2CaloLayer2',
     calol2TauCollectionEmul = cms.InputTag("valCaloStage2Layer2Digis"),
     calol2EtSumCollectionData = cms.InputTag("caloStage2Digis", "EtSum"),
     calol2EtSumCollectionEmul = cms.InputTag("valCaloStage2Layer2Digis"),
-    monitorDir = cms.untracked.string("L1TEMU/L1TStage2CaloLayer2/L1TdeStage2CaloLayer2")
+    monitorDir = cms.untracked.string("L1TEMU/L1TStage2CaloLayer2/L1TdeStage2CaloLayer2"),
+    enable2DComp = cms.untracked.bool(False) # When true eta-phi comparison plots are also produced
 )

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -72,7 +72,7 @@ l1tdeStage2uGMT = DQMEDAnalyzer(
     muonCollection2Title = cms.untracked.string("uGMT emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT emulator muons"),
     verbose = cms.untracked.bool(False),
-    enable2DComp = cms.untracked.bool(False), # When true eta-phi comparison plots are also produced 
+    enable2DComp = cms.untracked.bool(True), # When true eta-phi comparison plots are also produced 
 )
 
 # compares the unpacked uGMT intermediate muon collection to the emulated uGMT intermediate muon collection

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -72,6 +72,7 @@ l1tdeStage2uGMT = DQMEDAnalyzer(
     muonCollection2Title = cms.untracked.string("uGMT emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT emulator muons"),
     verbose = cms.untracked.bool(False),
+    enable2DComp = cms.untracked.bool(False), # When true eta-phi comparison plots are also produced 
 )
 
 # compares the unpacked uGMT intermediate muon collection to the emulated uGMT intermediate muon collection

--- a/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
@@ -9,7 +9,8 @@ L1TStage2MuonComp::L1TStage2MuonComp(const edm::ParameterSet& ps)
       muonColl2Title(ps.getUntrackedParameter<std::string>("muonCollection2Title")),
       summaryTitle(ps.getUntrackedParameter<std::string>("summaryTitle")),
       ignoreBin(ps.getUntrackedParameter<std::vector<int>>("ignoreBin")),
-      verbose(ps.getUntrackedParameter<bool>("verbose"))
+      verbose(ps.getUntrackedParameter<bool>("verbose")),  
+      enable2DComp(ps.getUntrackedParameter<bool>("enable2DComp"))  // When true eta-phi comparison plots are also produced 
 {
   // First include all bins
   for (unsigned int i = 1; i <= RIDX; i++) {
@@ -35,6 +36,7 @@ void L1TStage2MuonComp::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.addUntracked<std::string>("summaryTitle", "Summary")->setComment("Title of summary histogram.");
   desc.addUntracked<std::vector<int>>("ignoreBin", std::vector<int>())->setComment("List of bins to ignore");
   desc.addUntracked<bool>("verbose", false);
+  desc.addUntracked<bool>("enable2DComp", false);
   descriptions.add("l1tStage2MuonComp", desc);
 }
 
@@ -124,6 +126,13 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   muColl1hwIso->setAxisTitle("Hardware isolation", 1);
   muColl1Index = ibooker.book1D("muIndexColl1", (muonColl1Title+" mismatching Input muon index").c_str(), 108, -0.5, 107.5);
   muColl1Index->setAxisTitle("Index", 1);
+  
+  // if enable2DComp variable is True, book also the eta-phi map
+  if(enable2DComp){
+    muColl1EtaPhimap = ibooker.book2D("muEtaPhimapColl1", (muonColl1Title+" mismatching muon #eta-#phi map").c_str(),25,-2.5,2.5,25,-3.2,3.2);
+    muColl1EtaPhimap->setAxisTitle("#eta", 1);
+    muColl1EtaPhimap->setAxisTitle("#phi", 2);
+  }
 
   muColl2BxRange = ibooker.book1D("muBxRangeColl2", (muonColl2Title+" mismatching BX range").c_str(), 5, -2.5, 2.5);
   muColl2BxRange->setAxisTitle("BX range", 1);
@@ -149,6 +158,13 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   muColl2hwIso->setAxisTitle("Hardware isolation", 1);
   muColl2Index = ibooker.book1D("muIndexColl2", (muonColl2Title+" mismatching Input muon index").c_str(), 108, -0.5, 107.5);
   muColl2Index->setAxisTitle("Index", 1);
+ 
+  // if enable2DdeMu variable is True, book also the eta-phi map
+  if(enable2DComp){
+    muColl2EtaPhimap = ibooker.book2D("muEtaPhimapColl2", (muonColl2Title+" mismatching muon #eta-#phi map").c_str(),25,-2.5,2.5,25,-3.2,3.2);
+    muColl2EtaPhimap->setAxisTitle("#eta", 1);
+    muColl2EtaPhimap->setAxisTitle("#phi", 2);
+  }
 }
 
 void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
@@ -205,6 +221,7 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
           muColl1hwQual->Fill(muonIt1->hwQual());
           muColl1hwIso->Fill(muonIt1->hwIso());
           muColl1Index->Fill(muonIt1->tfMuonIndex());
+          if(enable2DComp) muColl1EtaPhimap->Fill(muonIt1->eta(),muonIt1->phi());
         }
       } else {
         muonIt2 = muonBxColl2->begin(iBx) + muonBxColl1->size(iBx);
@@ -218,7 +235,8 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
           muColl2hwChargeValid->Fill(muonIt2->hwChargeValid());
           muColl2hwQual->Fill(muonIt2->hwQual());
           muColl2hwIso->Fill(muonIt2->hwIso());
-          muColl2Index->Fill(muonIt2->tfMuonIndex());
+          muColl2Index->Fill(muonIt2->tfMuonIndex()); 
+          if(enable2DComp) muColl2EtaPhimap->Fill(muonIt2->eta(), muonIt2->phi()); 
         }
       }
     } else {
@@ -332,6 +350,7 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
         muColl1hwQual->Fill(muonIt1->hwQual());
         muColl1hwIso->Fill(muonIt1->hwIso());
         muColl1Index->Fill(muonIt1->tfMuonIndex());
+        if(enable2DComp) muColl1EtaPhimap->Fill(muonIt1->eta(),muonIt1->phi());
 
         muColl2hwPt->Fill(muonIt2->hwPt());
         muColl2hwEta->Fill(muonIt2->hwEta());
@@ -343,7 +362,10 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
         muColl2hwQual->Fill(muonIt2->hwQual());
         muColl2hwIso->Fill(muonIt2->hwIso());
         muColl2Index->Fill(muonIt2->tfMuonIndex());
-      } else {
+        if(enable2DComp) muColl2EtaPhimap->Fill(muonIt2->eta(),muonIt2->phi());
+      
+      }
+      else {
         summary->Fill(MUONGOOD);
       }
 

--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer2.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer2.cc
@@ -26,7 +26,8 @@ L1TdeStage2CaloLayer2::L1TdeStage2CaloLayer2 (const edm::ParameterSet& ps)
     calol2EtSumCollectionEmul(consumes <l1t::EtSumBxCollection>(
 				ps.getParameter<edm::InputTag>(
 				  "calol2EtSumCollectionEmul"))),
-    verbose(ps.getUntrackedParameter<bool> ("verbose", false))
+    verbose(ps.getUntrackedParameter<bool> ("verbose", false)),
+    enable2DComp(ps.getUntrackedParameter<bool> ("enable2DComp", false)) // When true eta-phi comparison plots are also produced
 {}
 
 void L1TdeStage2CaloLayer2::bookHistograms(
@@ -49,9 +50,21 @@ void L1TdeStage2CaloLayer2::bookHistograms(
 			      227, -113.5, 113.5);
   jetPhiEmul = ibooker.book1D("Problematic Emul Jet iPhi", "Jet i#phi",
 			      288, -0.5, 143.5);
+  //if enable2DComp is true book also 2D eta-phi plots
+  if(enable2DComp){
+    jet2DEtaPhiData = ibooker.book2D("Problematic Data Jet Eta - Phi","Jet #eta - #phi map",
+                                      50,-5.,5.,25,-3.2,3.2);
+    jet2DEtaPhiData->setAxisTitle("#eta", 1);
+    jet2DEtaPhiData->setAxisTitle("#phi", 2);
+
+    jet2DEtaPhiEmul = ibooker.book2D("Problematic Emul Jet Eta - Phi","Jet #eta - #phi map",
+                                      50,-5.,5.,25,-3.2,3.2);
+    jet2DEtaPhiEmul->setAxisTitle("#eta", 1);
+    jet2DEtaPhiEmul->setAxisTitle("#phi", 2);
+  }
 
   // DQM directory to store histograms with problematic e/gs
-  ibooker.setCurrentFolder(monitorDir + "/Problematic EG candidtes");
+  ibooker.setCurrentFolder(monitorDir + "/Problematic EG candidates");
 
   egEtData = ibooker.book1D("Problematic Data Eg iEt", "Eg iE_{T}",
 			    1400, 0, 1399);
@@ -65,7 +78,18 @@ void L1TdeStage2CaloLayer2::bookHistograms(
 			     227, -113.5, 113.5);
   egPhiEmul = ibooker.book1D("Problematic Emul Eg iPhi", "Eg i#phi",
 			     288, -0.5, 143.5);
+  //if enable2DComp is true book also 2D eta-phi plots
+  if(enable2DComp){
+    eg2DEtaPhiData = ibooker.book2D("Problematic Data Eg Eta - Phi","Eg #eta - #phi map",
+                                      30,-3.,3.,25,-3.2,3.2);
+    eg2DEtaPhiData->setAxisTitle("#eta", 1);
+    eg2DEtaPhiData->setAxisTitle("#phi", 2);
 
+    eg2DEtaPhiEmul = ibooker.book2D("Problematic Emul Eg Eta - Phi","Eg #eta - #phi map",
+                                      30,-3.,3.,25,-3.2,3.2);
+    eg2DEtaPhiEmul->setAxisTitle("#eta", 1);
+    eg2DEtaPhiEmul->setAxisTitle("#phi", 2);
+  }
   isoEgEtData = ibooker.book1D("Problematic Isolated Data Eg iEt",
 			       "Iso Eg iE_{T}", 1400, 0, 1399);
   isoEgEtaData = ibooker.book1D("Problematic Isolated Data Eg iEta",
@@ -78,9 +102,20 @@ void L1TdeStage2CaloLayer2::bookHistograms(
 				"Iso Eg i#eta", 227, -113.5, 113.5);
   isoEgPhiEmul = ibooker.book1D("Problematic Isolated Emul Eg iPhi",
 				"Iso Eg i#phi", 288, -0.5, 143.5);
+  // enable2DComp is true book also 2D eta-phi plots
+  if(enable2DComp){
+    isoEg2DEtaPhiData = ibooker.book2D("Problematic Isolated Data Eg Eta - Phi","Iso Eg #eta - #phi map",
+                                      30,-3.,3.,25,-3.2,3.2);
+    isoEg2DEtaPhiData->setAxisTitle("#eta", 1);
+    isoEg2DEtaPhiData->setAxisTitle("#phi", 2);
 
+    isoEg2DEtaPhiEmul = ibooker.book2D("Problematic Isolated Emul Eg Eta - Phi","Iso Eg #eta - #phi map",
+                                      30,-3.,3.,25,-3.2,3.2);
+    isoEg2DEtaPhiEmul->setAxisTitle("#eta", 1);
+    isoEg2DEtaPhiEmul->setAxisTitle("#phi", 2);
+  }
   // DQM directory to store histograms with problematic taus
-  ibooker.setCurrentFolder(monitorDir + "/Problematic Tau candidtes");
+  ibooker.setCurrentFolder(monitorDir + "/Problematic Tau candidates");
 
   tauEtData = ibooker.book1D("Problematic Data Tau iEt", "Tau iE_{T}",
 			     1400, 0, 1399);
@@ -94,7 +129,18 @@ void L1TdeStage2CaloLayer2::bookHistograms(
 			      227, -113.5, 113.5);
   tauPhiEmul = ibooker.book1D("Problematic Emul Tau iPhi", "Tau i#phi",
 			      288, -0.5, 143.5);
+  // enable2DComp is true book also 2D eta-phi plots
+  if(enable2DComp){
+    tau2DEtaPhiData = ibooker.book2D("Problematic Data Tau Eta - Phi","Tau #eta - #phi map",
+                                      30,-3.,3.,25,-3.2,3.2);
+    tau2DEtaPhiData->setAxisTitle("#eta", 1);
+    tau2DEtaPhiData->setAxisTitle("#phi", 2);
 
+    tau2DEtaPhiEmul = ibooker.book2D("Problematic Emul Tau Eta - Phi","Tau #eta - #phi map",
+                                      30,-3.,3.,25,-3.2,3.2);
+    tau2DEtaPhiEmul->setAxisTitle("#eta", 1);
+    tau2DEtaPhiEmul->setAxisTitle("#phi", 2);
+  }
   isoTauEtData = ibooker.book1D("Problematic Isolated Data Tau iEt",
 				"Iso Tau iE_{T}", 1400, 0, 1399);
   isoTauEtaData = ibooker.book1D("Problematic Isolated Data Tau iEta",
@@ -107,7 +153,18 @@ void L1TdeStage2CaloLayer2::bookHistograms(
 				 "Iso Tau i#eta", 227, -113.5, 113.5);
   isoTauPhiEmul = ibooker.book1D("Problematic Isolated Emul Tau iPhi",
 				 "Iso Tau i#phi", 288, -0.5, 143.5);
+  // enable2DComp is true book also 2D eta-phi plots
+  if(enable2DComp){
+    isoTau2DEtaPhiData = ibooker.book2D("Problematic Isolated Data Tau Eta - Phi","Iso Tau #eta - #phi map",
+                                      30,-3.,3.,25,-3.2,3.2);
+    isoTau2DEtaPhiData->setAxisTitle("#eta", 1);
+    isoTau2DEtaPhiData->setAxisTitle("#phi", 2);
 
+    isoTau2DEtaPhiEmul = ibooker.book2D("Problematic Isolated Emul Tau Eta - Phi","Iso Tau #eta - #phi map",
+                                      30,-3.,3.,25,-3.2,3.2);
+    isoTau2DEtaPhiEmul->setAxisTitle("#eta", 1);
+    isoTau2DEtaPhiEmul->setAxisTitle("#phi", 2);
+  }
   // DQM directory to store histograms with problematic sums
   ibooker.setCurrentFolder(monitorDir + "/Problematic Sums");
 
@@ -406,6 +463,7 @@ bool L1TdeStage2CaloLayer2::compareJets(
 	jetEtData->Fill(dataIt->hwPt());
 	jetEtaData->Fill(dataIt->hwEta());
 	jetPhiData->Fill(dataIt->hwPhi());
+        if(enable2DComp) jet2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
 
 	++dataIt;
 
@@ -421,7 +479,8 @@ bool L1TdeStage2CaloLayer2::compareJets(
 
 	jetEtEmul->Fill(emulIt->hwPt());
 	jetEtaEmul->Fill(emulIt->hwEta());
-	jetPhiEmul->Fill(emulIt->hwPhi());
+	jetPhiEmul->Fill(emulIt->hwPhi()); 
+        if(enable2DComp) jet2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
 
 	++emulIt;
 
@@ -434,7 +493,7 @@ bool L1TdeStage2CaloLayer2::compareJets(
 	jetEtEmul->Fill(dataIt->hwPt());
 	jetEtaEmul->Fill(dataIt->hwEta());
 	jetPhiEmul->Fill(dataIt->hwPhi());
-
+         
 	++dataIt;
 
 	if (dataIt == dataCol->end(currBx))
@@ -483,10 +542,12 @@ bool L1TdeStage2CaloLayer2::compareJets(
 	jetEtData->Fill(dataIt->hwPt());
 	jetEtaData->Fill(dataIt->hwEta());
 	jetPhiData->Fill(dataIt->hwPhi());
+        if(enable2DComp) jet2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
 
 	jetEtEmul->Fill(emulIt->hwPt());
 	jetEtaEmul->Fill(emulIt->hwEta());
 	jetPhiEmul->Fill(emulIt->hwPhi());
+        if(enable2DComp) jet2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
 
 	if (verbose) {
 	  edm::LogInfo("L1TdeStage2CaloLayer2") << "--- jet ---"<< std::endl;
@@ -561,11 +622,13 @@ bool L1TdeStage2CaloLayer2::compareEGs(
 	if (dataIt->hwIso()) {
 	  isoEgEtData->Fill(dataIt->hwPt());
 	  isoEgEtaData->Fill(dataIt->hwEta());
-	  isoEgPhiData->Fill(dataIt->hwPhi());
+	  isoEgPhiData->Fill(dataIt->hwPhi());  
+          if(enable2DComp) isoEg2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
 	} else {
 	  egEtData->Fill(dataIt->hwPt());
 	  egEtaData->Fill(dataIt->hwEta());
 	  egPhiData->Fill(dataIt->hwPhi());
+          if(enable2DComp) eg2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
 	}
 
 	++dataIt;
@@ -583,10 +646,12 @@ bool L1TdeStage2CaloLayer2::compareEGs(
 	  isoEgEtEmul->Fill(emulIt->hwPt());
 	  isoEgEtaEmul->Fill(emulIt->hwEta());
 	  isoEgPhiEmul->Fill(emulIt->hwPhi());
+          if(enable2DComp) isoEg2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());    
 	} else {
 	  egEtEmul->Fill(emulIt->hwPt());
 	  egEtaEmul->Fill(emulIt->hwEta());
 	  egPhiEmul->Fill(emulIt->hwPhi());
+          if(enable2DComp) eg2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi()); 
 	}
 
 	++emulIt;
@@ -644,18 +709,22 @@ bool L1TdeStage2CaloLayer2::compareEGs(
 	  isoEgEtData->Fill(dataIt->hwPt());
 	  isoEgEtaData->Fill(dataIt->hwEta());
 	  isoEgPhiData->Fill(dataIt->hwPhi());
+          if(enable2DComp) isoEg2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
 
 	  isoEgEtEmul->Fill(emulIt->hwPt());
 	  isoEgEtaEmul->Fill(emulIt->hwEta());
 	  isoEgPhiEmul->Fill(emulIt->hwPhi());
+          if(enable2DComp) isoEg2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
 	} else {
 	  egEtData->Fill(dataIt->hwPt());
 	  egEtaData->Fill(dataIt->hwEta());
 	  egPhiData->Fill(dataIt->hwPhi());
+          if(enable2DComp) eg2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
 
 	  egEtEmul->Fill(emulIt->hwPt());
 	  egEtaEmul->Fill(emulIt->hwEta());
 	  egPhiEmul->Fill(emulIt->hwPhi());
+          if(enable2DComp) eg2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
 	}
 
 	if (verbose) {
@@ -746,11 +815,13 @@ bool L1TdeStage2CaloLayer2::compareTaus(
 	if (dataIt->hwIso()) {
 	  isoTauEtData->Fill(dataIt->hwPt());
 	  isoTauEtaData->Fill(dataIt->hwEta());
-	  isoTauPhiData->Fill(dataIt->hwPhi());
+	  isoTauPhiData->Fill(dataIt->hwPhi()); 
+          if(enable2DComp) isoTau2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
 	} else {
 	  tauEtData->Fill(dataIt->hwPt());
 	  tauEtaData->Fill(dataIt->hwEta());
 	  tauPhiData->Fill(dataIt->hwPhi());
+          if(enable2DComp) tau2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
 	}
 
 	++dataIt;
@@ -771,10 +842,13 @@ bool L1TdeStage2CaloLayer2::compareTaus(
 	  isoTauEtEmul->Fill(emulIt->hwPt());
 	  isoTauEtaEmul->Fill(emulIt->hwEta());
 	  isoTauPhiEmul->Fill(emulIt->hwPhi());
+          if(enable2DComp) isoTau2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
+          
 	} else {
 	  tauEtEmul->Fill(emulIt->hwPt());
 	  tauEtaEmul->Fill(emulIt->hwEta());
 	  tauPhiEmul->Fill(emulIt->hwPhi());
+          if(enable2DComp) tau2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
 	}
 
 	++emulIt;
@@ -831,19 +905,23 @@ bool L1TdeStage2CaloLayer2::compareTaus(
 	  isoTauEtData->Fill(dataIt->hwPt());
 	  isoTauEtaData->Fill(dataIt->hwEta());
 	  isoTauPhiData->Fill(dataIt->hwPhi());
+          if(enable2DComp) isoTau2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
 
 	  isoTauEtEmul->Fill(emulIt->hwPt());
 	  isoTauEtaEmul->Fill(emulIt->hwEta());
 	  isoTauPhiEmul->Fill(emulIt->hwPhi());
+          if(enable2DComp) isoTau2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
 
 	} else {
 	  tauEtData->Fill(dataIt->hwPt());
 	  tauEtaData->Fill(dataIt->hwEta());
 	  tauPhiData->Fill(dataIt->hwPhi());
+          if(enable2DComp) tau2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
 
 	  tauEtEmul->Fill(emulIt->hwPt());
 	  tauEtaEmul->Fill(emulIt->hwEta());
 	  tauPhiEmul->Fill(emulIt->hwPhi());
+          if(enable2DComp) tau2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
 	}
 
 	if (verbose) {


### PR DESCRIPTION
This PR applies the changes that have been discussed in https://its.cern.ch/jira/browse/CMSLITDPG-166

It introduces a new boolean parameter enable2DComp in:
DQM/L1TMonitor/python/L1TStage2uGMT_cff.py 
and
DQM/L1TMonitor/python/L1TdeStage2CaloLayer2_cfi.py

which can be set to True for drawing 2D eta-phi mismatch plots for the comparison of two collections of L1TOblects.

When enable2DComp=True in DQM/L1TMonitor/python/L1TStage2uGMT_cff.py then 2D plots will be produced for Muon Collections and when enable2DComp=True in DQM/L1TMonitor/python/L1TdeStage2CaloLayer2_cfi.py then 2D plots will be produced for Jet, EGs and Tau collections.