### PR TITLE
Muon reco modification for 2018 heavy ion era

### DIFF
--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -92,4 +92,5 @@ muonEcalDetIds = cms.EDProducer("InterestingEcalDetIdProducer",
                                 inputCollection = cms.InputTag("muons1stStep")
 )
 
-
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(muons1stStep, minPt = 0.8)


### PR DESCRIPTION
this PR includes pt threshold in muons1stStep module for the 2018 heavy ion era.
- change the minPt from 0.5 to  0.8 same as HI setup.
The modification affects timing reduction in reconstruction with HI custom
