### PR TITLE
[L1T][DQMOffline] CaloJets -> PFJets for L1T Offline DQM

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
@@ -33,8 +33,8 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-// CaloJets
-#include "DataFormats/JetReco/interface/CaloJet.h"
+// PFJets
+#include "DataFormats/JetReco/interface/PFJet.h"
 
 // Calo MET
 #include "DataFormats/METReco/interface/CaloMET.h"
@@ -112,7 +112,7 @@ private:
   math::XYZPoint PVPoint_;
 
   //variables from config file
-  edm::EDGetTokenT<reco::CaloJetCollection> theCaloJetCollection_;
+  edm::EDGetTokenT<reco::PFJetCollection> thePFJetCollection_;
   edm::EDGetTokenT<reco::CaloMETCollection> thecaloMETCollection_;
   edm::EDGetTokenT<reco::CaloMETCollection> thecaloETMHFCollection_;
   edm::EDGetTokenT<reco::VertexCollection> thePVCollection_;
@@ -193,17 +193,17 @@ private:
 
 
   // jet reco vs L1
-  MonitorElement* h_L1JetETvsCaloJetET_HB_;
-  MonitorElement* h_L1JetETvsCaloJetET_HE_;
-  MonitorElement* h_L1JetETvsCaloJetET_HF_;
-  MonitorElement* h_L1JetETvsCaloJetET_HB_HE_;
+  MonitorElement* h_L1JetETvsPFJetET_HB_;
+  MonitorElement* h_L1JetETvsPFJetET_HE_;
+  MonitorElement* h_L1JetETvsPFJetET_HF_;
+  MonitorElement* h_L1JetETvsPFJetET_HB_HE_;
 
-  MonitorElement* h_L1JetPhivsCaloJetPhi_HB_;
-  MonitorElement* h_L1JetPhivsCaloJetPhi_HE_;
-  MonitorElement* h_L1JetPhivsCaloJetPhi_HF_;
-  MonitorElement* h_L1JetPhivsCaloJetPhi_HB_HE_;
+  MonitorElement* h_L1JetPhivsPFJetPhi_HB_;
+  MonitorElement* h_L1JetPhivsPFJetPhi_HE_;
+  MonitorElement* h_L1JetPhivsPFJetPhi_HF_;
+  MonitorElement* h_L1JetPhivsPFJetPhi_HB_HE_;
 
-  MonitorElement* h_L1JetEtavsCaloJetEta_;
+  MonitorElement* h_L1JetEtavsPFJetEta_;
 
   // jet resolutions
   MonitorElement* h_resolutionJetET_HB_;

--- a/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
@@ -41,11 +41,53 @@ httEfficiencyBins.extend(list(xrange(200, 400, 20)))
 httEfficiencyBins.extend(list(xrange(400, 500, 50)))
 httEfficiencyBins.extend(list(xrange(500, 601, 10)))
 
+# from https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVRun2017
+centralJetSelection = [
+    'abs(eta) <= 2.7',
+    'neutralHadronEnergyFraction < 0.9',
+    'neutralEmEnergyFraction < 0.9',
+    'numberOfDaughters > 1',
+    'muonEnergyFraction < 0.8'
+]
+withinTrackerSelection = centralJetSelection[:]
+withinTrackerSelection += [
+    'abs(eta) <= 2.4',
+    'chargedHadronEnergyFraction > 0',
+    'chargedMultiplicity > 0',
+    'chargedEmEnergyFraction < 0.8'
+]
+forwardJetSelection = [
+    'abs(eta) > 2.7',
+    'abs(eta) <= 3.0',
+    'neutralEmEnergyFraction > 0.02',
+    'neutralEmEnergyFraction < 0.99',
+    'neutralMultiplicity > 2'
+]
+veryForwardJetSelection = [
+    'abs(eta) > 3.0',
+    'neutralEmEnergyFraction < 0.99',
+    'neutralHadronEnergyFraction > 0.02',
+    'neutralMultiplicity > 10'
+]
+centralJetSelection = ' && '.join(centralJetSelection)
+withinTrackerSelection = ' && '.join(withinTrackerSelection)
+forwardJetSelection = ' && '.join(forwardJetSelection)
+veryForwardJetSelection = ' && '.join(veryForwardJetSelection)
+completeSelection = 'et > 30 && (' + ' || '.join([centralJetSelection, withinTrackerSelection,
+                                       forwardJetSelection, veryForwardJetSelection]) + ')'
+
+goodPFJetsForL1T = cms.EDFilter(
+    "PFJetSelector",
+    src=cms.InputTag("ak4PFJetsCHS"),
+    cut=cms.string(completeSelection),
+    filter=cms.bool(True),
+)
+
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 l1tEtSumJetOfflineDQM = DQMEDAnalyzer(
     "L1TStage2CaloLayer2Offline",
     electronCollection=cms.InputTag("gedGsfElectrons"),
-    caloJetCollection=cms.InputTag("ak4CaloJets"),
+    pfJetCollection=cms.InputTag("goodPFJetsForL1T"),
     caloMETCollection=cms.InputTag("caloMetBE"),
     # MET collection including HF
     caloETMHFCollection=cms.InputTag("caloMet"),
@@ -120,6 +162,6 @@ l1tEtSumJetOfflineDQMEmu = l1tEtSumJetOfflineDQM.clone(
     stage2CaloLayer2JetSource=cms.InputTag("simCaloStage2Digis"),
     stage2CaloLayer2EtSumSource=cms.InputTag("simCaloStage2Digis"),
 
-    histFolderEtSum = cms.string('L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco'),
-    histFolderJet = cms.string('L1TEMU/L1TObjects/L1TJet/L1TriggerVsReco'),
+    histFolderEtSum=cms.string('L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco'),
+    histFolderJet=cms.string('L1TEMU/L1TObjects/L1TJet/L1TriggerVsReco'),
 )

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -21,8 +21,8 @@ const std::map<std::string, unsigned int> L1TStage2CaloLayer2Offline::PlotConfig
 // -------------------------------------- Constructor --------------------------------------------
 //
 L1TStage2CaloLayer2Offline::L1TStage2CaloLayer2Offline(const edm::ParameterSet& ps) :
-        theCaloJetCollection_(
-            consumes < reco::CaloJetCollection > (ps.getParameter < edm::InputTag > ("caloJetCollection"))),
+        thePFJetCollection_(
+            consumes < reco::PFJetCollection > (ps.getParameter < edm::InputTag > ("pfJetCollection"))),
         thecaloMETCollection_(
             consumes < reco::CaloMETCollection > (ps.getParameter < edm::InputTag > ("caloMETCollection"))),
         thecaloETMHFCollection_(
@@ -145,8 +145,8 @@ void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsig
   edm::Handle<l1t::EtSumBxCollection> l1EtSums;
   e.getByToken(stage2CaloLayer2EtSumToken_, l1EtSums);
 
-  edm::Handle<reco::CaloJetCollection> caloJets;
-  e.getByToken(theCaloJetCollection_, caloJets);
+  edm::Handle<reco::PFJetCollection> pfJets;
+  e.getByToken(thePFJetCollection_, pfJets);
 
   edm::Handle<reco::CaloMETCollection> caloMETs;
   e.getByToken(thecaloMETCollection_, caloMETs);
@@ -154,8 +154,8 @@ void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsig
   edm::Handle<reco::CaloMETCollection> caloETMHFs;
   e.getByToken(thecaloETMHFCollection_, caloETMHFs);
 
-  if (!caloJets.isValid()) {
-    edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: calo jets " << std::endl;
+  if (!pfJets.isValid()) {
+    edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: PF jets " << std::endl;
     return;
   }
   if (!caloMETs.isValid()) {
@@ -221,7 +221,7 @@ void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsig
 
   TVector2 mht(0., 0.);
 
-  for (auto jet = caloJets->begin(); jet != caloJets->end(); ++jet) {
+  for (auto jet = pfJets->begin(); jet != pfJets->end(); ++jet) {
     double et = jet->et();
     if (et < 30) {
       continue;
@@ -320,11 +320,11 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
   edm::Handle<l1t::JetBxCollection> l1Jets;
   e.getByToken(stage2CaloLayer2JetToken_, l1Jets);
 
-  edm::Handle<reco::CaloJetCollection> caloJets;
-  e.getByToken(theCaloJetCollection_, caloJets);
+  edm::Handle<reco::PFJetCollection> pfJets;
+  e.getByToken(thePFJetCollection_, pfJets);
 
-  if (!caloJets.isValid()) {
-    edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: calo jets " << std::endl;
+  if (!pfJets.isValid()) {
+    edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: PF jets " << std::endl;
     return;
   }
   if (!l1Jets.isValid()) {
@@ -332,12 +332,12 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
     return;
   }
 
-  if (caloJets->empty()) {
-    LogDebug("L1TStage2CaloLayer2Offline") << "no calo jets found" << std::endl;
+  if (pfJets->empty()) {
+    LogDebug("L1TStage2CaloLayer2Offline") << "no PF jets found" << std::endl;
     return;
   }
 
-  auto leadingRecoJet = caloJets->front();
+  auto leadingRecoJet = pfJets->front();
 
   // find corresponding L1 jet
   double minDeltaR = 0.3;
@@ -392,42 +392,42 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
   }
 
   // eta
-  fill2DWithinLimits(h_L1JetEtavsCaloJetEta_, recoEta, l1Eta);
+  fill2DWithinLimits(h_L1JetEtavsPFJetEta_, recoEta, l1Eta);
   fillWithinLimits(h_resolutionJetEta_, resolutionEta);
 
   if (std::abs(recoEta) <= 1.479) { // barrel
     // et
-    fill2DWithinLimits(h_L1JetETvsCaloJetET_HB_, recoEt, l1Et);
-    fill2DWithinLimits(h_L1JetETvsCaloJetET_HB_HE_, recoEt, l1Et);
+    fill2DWithinLimits(h_L1JetETvsPFJetET_HB_, recoEt, l1Et);
+    fill2DWithinLimits(h_L1JetETvsPFJetET_HB_HE_, recoEt, l1Et);
     //resolution
     fillWithinLimits(h_resolutionJetET_HB_, resolutionEt);
     fillWithinLimits(h_resolutionJetET_HB_HE_, resolutionEt);
     // phi
-    fill2DWithinLimits(h_L1JetPhivsCaloJetPhi_HB_, recoPhi, l1Phi);
-    fill2DWithinLimits(h_L1JetPhivsCaloJetPhi_HB_HE_, recoPhi, l1Phi);
+    fill2DWithinLimits(h_L1JetPhivsPFJetPhi_HB_, recoPhi, l1Phi);
+    fill2DWithinLimits(h_L1JetPhivsPFJetPhi_HB_HE_, recoPhi, l1Phi);
     // resolution
     fillWithinLimits(h_resolutionJetPhi_HB_, resolutionPhi);
     fillWithinLimits(h_resolutionJetPhi_HB_HE_, resolutionPhi);
   } else if (std::abs(recoEta) <= 3.0) { // end-cap
     // et
-    fill2DWithinLimits(h_L1JetETvsCaloJetET_HE_, recoEt, l1Et);
-    fill2DWithinLimits(h_L1JetETvsCaloJetET_HB_HE_, recoEt, l1Et);
+    fill2DWithinLimits(h_L1JetETvsPFJetET_HE_, recoEt, l1Et);
+    fill2DWithinLimits(h_L1JetETvsPFJetET_HB_HE_, recoEt, l1Et);
     //resolution
     fillWithinLimits(h_resolutionJetET_HE_, resolutionEt);
     fillWithinLimits(h_resolutionJetET_HB_HE_, resolutionEt);
     // phi
-    fill2DWithinLimits(h_L1JetPhivsCaloJetPhi_HE_, recoPhi, l1Phi);
-    fill2DWithinLimits(h_L1JetPhivsCaloJetPhi_HB_HE_, recoPhi, l1Phi);
+    fill2DWithinLimits(h_L1JetPhivsPFJetPhi_HE_, recoPhi, l1Phi);
+    fill2DWithinLimits(h_L1JetPhivsPFJetPhi_HB_HE_, recoPhi, l1Phi);
     // resolution
     fillWithinLimits(h_resolutionJetPhi_HE_, resolutionPhi);
     fillWithinLimits(h_resolutionJetPhi_HB_HE_, resolutionPhi);
   } else { // forward jets
     // et
-    fill2DWithinLimits(h_L1JetETvsCaloJetET_HF_, recoEt, l1Et);
+    fill2DWithinLimits(h_L1JetETvsPFJetET_HF_, recoEt, l1Et);
     // resolution
     fillWithinLimits(h_resolutionJetET_HF_, resolutionEt);
     // phi
-    fill2DWithinLimits(h_L1JetPhivsCaloJetPhi_HF_, recoPhi, l1Phi);
+    fill2DWithinLimits(h_L1JetPhivsPFJetPhi_HF_, recoPhi, l1Phi);
     // resolution
     fillWithinLimits(h_resolutionJetPhi_HF_, resolutionPhi);
   }
@@ -620,38 +620,38 @@ void L1TStage2CaloLayer2Offline::bookJetHistos(DQMStore::IBooker & ibooker)
       "Offline Jet E_{T}; Offline Jet E_{T} (GeV); events", 500, 0, 5e3);
   // jet reco vs L1
   dqmoffline::l1t::HistDefinition templateETvsET = histDefinitions_[PlotConfig::ETvsET];
-  h_L1JetETvsCaloJetET_HB_ = ibooker.book2D("L1JetETvsCaloJetET_HB",
+  h_L1JetETvsPFJetET_HB_ = ibooker.book2D("L1JetETvsPFJetET_HB",
       "L1 Jet E_{T} vs Offline Jet E_{T} (HB); Offline Jet E_{T} (GeV); L1 Jet E_{T} (GeV)",
       templateETvsET.nbinsX, &templateETvsET.binsX[0], templateETvsET.nbinsY, &templateETvsET.binsY[0]);
-  h_L1JetETvsCaloJetET_HE_ = ibooker.book2D("L1JetETvsCaloJetET_HE",
+  h_L1JetETvsPFJetET_HE_ = ibooker.book2D("L1JetETvsPFJetET_HE",
       "L1 Jet E_{T} vs Offline Jet E_{T} (HE); Offline Jet E_{T} (GeV); L1 Jet E_{T} (GeV)",
       templateETvsET.nbinsX, &templateETvsET.binsX[0], templateETvsET.nbinsY, &templateETvsET.binsY[0]);
-  h_L1JetETvsCaloJetET_HF_ = ibooker.book2D("L1JetETvsCaloJetET_HF",
+  h_L1JetETvsPFJetET_HF_ = ibooker.book2D("L1JetETvsPFJetET_HF",
       "L1 Jet E_{T} vs Offline Jet E_{T} (HF); Offline Jet E_{T} (GeV); L1 Jet E_{T} (GeV)",
       templateETvsET.nbinsX, &templateETvsET.binsX[0], templateETvsET.nbinsY, &templateETvsET.binsY[0]);
-  h_L1JetETvsCaloJetET_HB_HE_ = ibooker.book2D("L1JetETvsCaloJetET_HB_HE",
+  h_L1JetETvsPFJetET_HB_HE_ = ibooker.book2D("L1JetETvsPFJetET_HB_HE",
       "L1 Jet E_{T} vs Offline Jet E_{T} (HB+HE); Offline Jet E_{T} (GeV); L1 Jet E_{T} (GeV)",
       templateETvsET.nbinsX, &templateETvsET.binsX[0], templateETvsET.nbinsY, &templateETvsET.binsY[0]);
 
   dqmoffline::l1t::HistDefinition templatePHIvsPHI = histDefinitions_[PlotConfig::PHIvsPHI];
-  h_L1JetPhivsCaloJetPhi_HB_ = ibooker.book2D("L1JetPhivsCaloJetPhi_HB",
+  h_L1JetPhivsPFJetPhi_HB_ = ibooker.book2D("L1JetPhivsPFJetPhi_HB",
       "#phi_{jet}^{L1} vs #phi_{jet}^{offline} (HB); #phi_{jet}^{offline}; #phi_{jet}^{L1}",
       templatePHIvsPHI.nbinsX, templatePHIvsPHI.xmin, templatePHIvsPHI.xmax,
       templatePHIvsPHI.nbinsY, templatePHIvsPHI.ymin, templatePHIvsPHI.ymax);
-  h_L1JetPhivsCaloJetPhi_HE_ = ibooker.book2D("L1JetPhivsCaloJetPhi_HE",
+  h_L1JetPhivsPFJetPhi_HE_ = ibooker.book2D("L1JetPhivsPFJetPhi_HE",
       "#phi_{jet}^{L1} vs #phi_{jet}^{offline} (HE); #phi_{jet}^{offline}; #phi_{jet}^{L1}",
       templatePHIvsPHI.nbinsX, templatePHIvsPHI.xmin, templatePHIvsPHI.xmax,
       templatePHIvsPHI.nbinsY, templatePHIvsPHI.ymin, templatePHIvsPHI.ymax);
-  h_L1JetPhivsCaloJetPhi_HF_ = ibooker.book2D("L1JetPhivsCaloJetPhi_HF",
+  h_L1JetPhivsPFJetPhi_HF_ = ibooker.book2D("L1JetPhivsPFJetPhi_HF",
       "#phi_{jet}^{L1} vs #phi_{jet}^{offline} (HF); #phi_{jet}^{offline}; #phi_{jet}^{L1}",
       templatePHIvsPHI.nbinsX, templatePHIvsPHI.xmin, templatePHIvsPHI.xmax,
       templatePHIvsPHI.nbinsY, templatePHIvsPHI.ymin, templatePHIvsPHI.ymax);
-  h_L1JetPhivsCaloJetPhi_HB_HE_ = ibooker.book2D("L1JetPhivsCaloJetPhi_HB_HE",
+  h_L1JetPhivsPFJetPhi_HB_HE_ = ibooker.book2D("L1JetPhivsPFJetPhi_HB_HE",
       "#phi_{jet}^{L1} vs #phi_{jet}^{offline} (HB+HE); #phi_{jet}^{offline}; #phi_{jet}^{L1}",
       templatePHIvsPHI.nbinsX, templatePHIvsPHI.xmin, templatePHIvsPHI.xmax,
       templatePHIvsPHI.nbinsY, templatePHIvsPHI.ymin, templatePHIvsPHI.ymax);
 
-  h_L1JetEtavsCaloJetEta_ = ibooker.book2D("L1JetEtavsCaloJetEta_HB",
+  h_L1JetEtavsPFJetEta_ = ibooker.book2D("L1JetEtavsPFJetEta_HB",
       "L1 Jet #eta vs Offline Jet #eta; Offline Jet #eta; L1 Jet #eta", 100, -10, 10, 100, -10, 10);
 
   // jet resolutions

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
@@ -102,6 +102,7 @@ if os.environ.get('DEBUG', False):
     )
 
 process.dqmoffline_step = cms.Path(
+    process.goodPFJetsForL1T *
     process.l1tEtSumJetOfflineDQMEmu +
     process.l1tEtSumJetOfflineDQM +
     process.l1tEGammaOfflineDQM +

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
@@ -30,8 +30,8 @@ process.load('DQMServices.Examples.test.DQMExample_GenericClient_cfi')
 process.load('DQMServices.Examples.test.DQMExample_qTester_cfi')
 
 # L1T
-process.load('DQMOffline.L1Trigger.L1TStage2CaloLayer2Efficiency_cfi')
-process.load('DQMOffline.L1Trigger.L1TStage2CaloLayer2Diff_cfi')
+process.load('DQMOffline.L1Trigger.L1TEtSumEfficiency_cfi')
+process.load('DQMOffline.L1Trigger.L1TEtSumDiff_cfi')
 process.load('DQMOffline.L1Trigger.L1TEGammaEfficiency_cfi')
 process.load('DQMOffline.L1Trigger.L1TEGammaDiff_cfi')
 process.load('DQMOffline.L1Trigger.L1TTauEfficiency_cfi')
@@ -58,14 +58,14 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')  # for MC
 # Path and EndPath definitions
 process.myHarvesting = cms.Path(process.DQMExampleStep2)
 process.myEff = cms.Path(
-    process.l1tStage2CaloLayer2Efficiency *
-    process.l1tStage2CaloLayer2EmuEfficiency *
-    process.l1tStage2CaloLayer2EmuDiff +
+    process.l1tEtSumEfficiency *
+    process.l1tEtSumEmuEfficiency *
+    process.l1tEtSumEmuDiff +
     process.l1tEGammaEfficiency *
     process.l1tEGammaEmuEfficiency *
     process.l1tEGammaEmuDiff +
     process.l1tTauEfficiency *
-    process.l1tTauEmuEfficiency * 
+    process.l1tTauEmuEfficiency *
     process.l1tTauEmuDiff
 )
 process.myTest = cms.Path(process.DQMExample_qTester)


### PR DESCRIPTION
The second part of https://its.cern.ch/jira/browse/CMSLITDPG-588.
Replaces `caloJets` with `pfJets` (with `TightLepVeto` as per https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVRun2017).

Part 3 (PFMetNoMu) and Part 4 (minor fixes) will follow shortly.