### PR TITLE
Fix the length of the string buffer to accommodate the "new format" of the HCAL DetId

### DIFF
--- a/DQM/HcalCommon/src/HashFunctions.cc
+++ b/DQM/HcalCommon/src/HashFunctions.cc
@@ -250,8 +250,8 @@ namespace hcaldqm
 
 		std::string name_HFPMiphi(HcalDetId const& did)
 		{
-			char name[10];
-			sprintf(name, "HF%siphi%d", did.ieta()>0 ? "P" : "M", did.iphi());
+			char name[12];
+			snprintf(name, sizeof(name), "HF%ciphi%d", did.ieta()>0 ? 'P' : 'M', did.iphi());
 			return std::string(name);
 		}
 


### PR DESCRIPTION
Reported by GCC 7 `-Werror=format-overflow`:
```c++
src/DQM/HcalCommon/src/HashFunctions.cc: In function 'std::__cxx11::string hcaldqm::hashfunctions::name_HFPMiphi(const HcalDetId&)':
src/DQM/HcalCommon/src/HashFunctions.cc:251:15: error: '%d' directive writing between 1 and 4 bytes into a region of size 3 [-Werror=format-overflow=]
   std::string name_HFPMiphi(HcalDetId const& did)
               ^~~~~~~~~~~~~
src/DQM/HcalCommon/src/HashFunctions.cc:251:15: note: directive argument in the range [0, 1023]
src/DQM/HcalCommon/src/HashFunctions.cc:254:11: note: 'sprintf' output between 9 and 12 bytes into a destination of size 10
    sprintf(name, "HF%siphi%d", did.ieta()>0 ? "P" : "M", did.iphi());
    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```