### PR TITLE
[L1T][DQMOffline] Added PFMetNoMu to L1T Offline DQM

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
@@ -71,6 +71,7 @@ public:
     L1HTT,
     OfflineMET,
     OfflineETMHF,
+    OfflinePFMetNoMu,
     OfflineMHT,
     OfflineETT,
     OfflineHTT,
@@ -115,6 +116,7 @@ private:
   edm::EDGetTokenT<reco::PFJetCollection> thePFJetCollection_;
   edm::EDGetTokenT<reco::CaloMETCollection> thecaloMETCollection_;
   edm::EDGetTokenT<reco::CaloMETCollection> thecaloETMHFCollection_;
+  edm::EDGetTokenT<reco::PFMETCollection> thePFMETNoMuCollection_;
   edm::EDGetTokenT<reco::VertexCollection> thePVCollection_;
   edm::EDGetTokenT<reco::BeamSpot> theBSCollection_;
   edm::EDGetTokenT<trigger::TriggerEvent> triggerInputTag_;
@@ -160,33 +162,39 @@ private:
   // energy sums reco vs L1
   MonitorElement* h_L1METvsCaloMET_;
   MonitorElement* h_L1ETMHFvsCaloETMHF_;
+  MonitorElement* h_L1METvsPFMetNoMu_;
   MonitorElement* h_L1MHTvsRecoMHT_;
   MonitorElement* h_L1METTvsCaloETT_;
   MonitorElement* h_L1HTTvsRecoHTT_;
 
   MonitorElement* h_L1METPhivsCaloMETPhi_;
   MonitorElement* h_L1ETMHFPhivsCaloETMHFPhi_;
+  MonitorElement* h_L1METPhivsPFMetNoMuPhi_;
   MonitorElement* h_L1MHTPhivsRecoMHTPhi_;
 
   // energy sum resolutions
   MonitorElement* h_resolutionMET_;
   MonitorElement* h_resolutionETMHF_;
+  MonitorElement* h_resolutionPFMetNoMu_;
   MonitorElement* h_resolutionMHT_;
   MonitorElement* h_resolutionETT_;
   MonitorElement* h_resolutionHTT_;
   MonitorElement* h_resolutionMETPhi_;
   MonitorElement* h_resolutionETMHFPhi_;
+  MonitorElement* h_resolutionPFMetNoMuPhi_;
   MonitorElement* h_resolutionMHTPhi_;
 
   // energy sum turn ons
   std::map<double, MonitorElement*> h_efficiencyMET_pass_;
   std::map<double, MonitorElement*> h_efficiencyETMHF_pass_;
+  std::map<double, MonitorElement*> h_efficiencyPFMetNoMu_pass_;
   std::map<double, MonitorElement*> h_efficiencyMHT_pass_;
   std::map<double, MonitorElement*> h_efficiencyETT_pass_;
   std::map<double, MonitorElement*> h_efficiencyHTT_pass_;
 
   std::map<double, MonitorElement*> h_efficiencyMET_total_;
   std::map<double, MonitorElement*> h_efficiencyETMHF_total_;
+  std::map<double, MonitorElement*> h_efficiencyPFMetNoMu_total_;
   std::map<double, MonitorElement*> h_efficiencyMHT_total_;
   std::map<double, MonitorElement*> h_efficiencyETT_total_;
   std::map<double, MonitorElement*> h_efficiencyHTT_total_;

--- a/DQMOffline/L1Trigger/python/L1TEtSumDiff_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumDiff_cfi.py
@@ -9,7 +9,7 @@ variables = {
 }
 
 plots = {
-    'met': ['efficiencyMET', 'efficiencyETMHF'],
+    'met': ['efficiencyMET', 'efficiencyETMHF', 'efficiencyPFMetNoMu'],
     'mht': ['efficiencyMHT'],
     'ett': ['efficiencyETT'],
     'htt': ['efficiencyHTT'],
@@ -26,13 +26,13 @@ for variable, thresholds in variables.iteritems():
 from DQMOffline.L1Trigger.L1TDiffHarvesting_cfi import l1tDiffHarvesting
 
 resolution_plots = [
-    "resolutionMET", "resolutionETMHF", "resolutionMHT", "resolutionETT",
-    "resolutionHTT", "resolutionMETPhi", "resolutionETMHFPhi",
+    "resolutionMET", "resolutionETMHF", "resolutionPFMetNoMu", "resolutionMHT", "resolutionETT",
+    "resolutionHTT", "resolutionMETPhi", "resolutionETMHFPhi", "resolutionPFMetNoMuPhi",
     "resolutionMHTPhi",
 ]
 plots2D = [
-    'L1METvsCaloMET', 'L1ETMHFvsCaloETMHF', 'L1MHTvsRecoMHT', 'L1ETTvsCaloETT',
-    'L1HTTvsRecoHTT', 'L1METPhivsCaloMETPhi', 'L1ETMHFPhivsCaloETMHFPhi',
+    'L1METvsCaloMET', 'L1ETMHFvsCaloETMHF', 'L1METvsPFMetNoMu', 'L1MHTvsRecoMHT', 'L1ETTvsCaloETT',
+    'L1HTTvsRecoHTT', 'L1METPhivsCaloMETPhi', 'L1METPhivsPFMetNoMuPhi', 'L1ETMHFPhivsCaloETMHFPhi',
     'L1MHTPhivsRecoMHTPhi',
 ]
 
@@ -44,8 +44,10 @@ allPlots.extend(plots2D)
 l1tEtSumEmuDiff = l1tDiffHarvesting.clone(
     plotCfgs=cms.untracked.VPSet(
         cms.untracked.PSet(  # EMU comparison
-            dir1=cms.untracked.string("L1T/L1TObjects/L1TEtSum/L1TriggerVsReco"),
-            dir2=cms.untracked.string("L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco"),
+            dir1=cms.untracked.string(
+                "L1T/L1TObjects/L1TEtSum/L1TriggerVsReco"),
+            dir2=cms.untracked.string(
+                "L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco"),
             outputDir=cms.untracked.string(
                 "L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco/Comparison"),
             plots=cms.untracked.vstring(allPlots)
@@ -70,7 +72,7 @@ allPlots_HI.extend(resolution_plots)
 allPlots_HI.extend(plots2D)
 
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
-ppRef_2017.toModify(l1tEtSumEmuDiff,
-    plotCfgs = {0:dict(plots = allPlots_HI)}
+ppRef_2017.toModify(
+    l1tEtSumEmuDiff,
+    plotCfgs={0: dict(plots=allPlots_HI)}
 )
-

--- a/DQMOffline/L1Trigger/python/L1TEtSumEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumEfficiency_cfi.py
@@ -9,7 +9,7 @@ variables = {
 }
 
 plots = {
-    'met': ['efficiencyMET', 'efficiencyETMHF'],
+    'met': ['efficiencyMET', 'efficiencyETMHF', 'efficiencyPFMetNoMu'],
     'mht': ['efficiencyMHT'],
     'ett': ['efficiencyETT'],
     'htt': ['efficiencyHTT'],

--- a/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
@@ -83,6 +83,13 @@ goodPFJetsForL1T = cms.EDFilter(
     filter=cms.bool(True),
 )
 
+from L1Trigger.L1TNtuples.L1TPFMetNoMuProducer_cfi import l1tPFMetNoMu
+
+l1tPFMetNoMuForDQM = l1tPFMetNoMu.clone(
+    pfMETCollection=cms.InputTag('pfMETT1'),
+    muonCollection=cms.InputTag('muons'),
+)
+
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 l1tEtSumJetOfflineDQM = DQMEDAnalyzer(
     "L1TStage2CaloLayer2Offline",
@@ -91,6 +98,7 @@ l1tEtSumJetOfflineDQM = DQMEDAnalyzer(
     caloMETCollection=cms.InputTag("caloMetBE"),
     # MET collection including HF
     caloETMHFCollection=cms.InputTag("caloMet"),
+    pfMETNoMuCollection=cms.InputTag('l1tPFMetNoMuForDQM'),
     conversionsCollection=cms.InputTag("allConversions"),
     PVCollection=cms.InputTag("offlinePrimaryVerticesWithBS"),
     beamSpotCollection=cms.InputTag("offlineBeamSpot"),

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -27,6 +27,7 @@ L1TStage2CaloLayer2Offline::L1TStage2CaloLayer2Offline(const edm::ParameterSet& 
             consumes < reco::CaloMETCollection > (ps.getParameter < edm::InputTag > ("caloMETCollection"))),
         thecaloETMHFCollection_(
             consumes < reco::CaloMETCollection > (ps.getParameter < edm::InputTag > ("caloETMHFCollection"))),
+        thePFMETNoMuCollection_(consumes < reco::PFMETCollection > (ps.getParameter < edm::InputTag > ("pfMETNoMuCollection"))),
         thePVCollection_(consumes < reco::VertexCollection > (ps.getParameter < edm::InputTag > ("PVCollection"))),
         theBSCollection_(consumes < reco::BeamSpot > (ps.getParameter < edm::InputTag > ("beamSpotCollection"))),
         triggerInputTag_(consumes < trigger::TriggerEvent > (ps.getParameter < edm::InputTag > ("triggerInputTag"))),
@@ -154,6 +155,9 @@ void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsig
   edm::Handle<reco::CaloMETCollection> caloETMHFs;
   e.getByToken(thecaloETMHFCollection_, caloETMHFs);
 
+  edm::Handle<reco::PFMETCollection> pfMETNoMus;
+  e.getByToken(thePFMETNoMuCollection_, pfMETNoMus);
+
   if (!pfJets.isValid()) {
     edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: PF jets " << std::endl;
     return;
@@ -164,6 +168,10 @@ void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsig
   }
   if (!caloETMHFs.isValid()) {
     edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: Offline E_{T}^{miss} (HF) " << std::endl;
+    return;
+  }
+  if (!pfMETNoMus.isValid()) {
+    edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: Offline PF E_{T}^{miss} No Mu" << std::endl;
     return;
   }
   if (!l1EtSums.isValid()) {
@@ -214,6 +222,8 @@ void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsig
   double recoMETPhi(caloMETs->front().phi());
   double recoETMHF(caloETMHFs->front().et());
   double recoETMHFPhi(caloETMHFs->front().phi());
+  double recoPFMetNoMu(pfMETNoMus->front().et());
+  double recoPFMetNoMuPhi(pfMETNoMus->front().phi());
   double recoMHT(0);
   double recoMHTPhi(0);
   double recoETT(caloMETs->front().sumEt());
@@ -247,6 +257,9 @@ void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsig
   double resolutionETMHF = recoETMHF > 0 ? (l1ETMHF - recoETMHF) / recoETMHF : outOfBounds;
   double resolutionETMHFPhi = reco::deltaPhi(l1ETMHFPhi, recoETMHFPhi);
 
+  double resolutionPFMetNoMu = recoETMHF > 0 ? (l1MET - recoPFMetNoMu) / recoPFMetNoMu : outOfBounds;
+  double resolutionPFMetNoMuPhi = reco::deltaPhi(l1METPhi, recoPFMetNoMuPhi);
+
   double resolutionMHT = recoMHT > 0 ? (l1MHT - recoMHT) / recoMHT : outOfBounds;
   double resolutionMHTPhi = reco::deltaPhi(l1MHTPhi, recoMHTPhi);
 
@@ -260,38 +273,46 @@ void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsig
   fillWithinLimits(h_controlPlots_[ControlPlots::L1MHT], l1MHT);
   fillWithinLimits(h_controlPlots_[ControlPlots::L1ETT], l1ETT);
   fillWithinLimits(h_controlPlots_[ControlPlots::L1HTT], l1HTT);
+  fillWithinLimits(h_controlPlots_[ControlPlots::OfflineMET], recoMET);
   fillWithinLimits(h_controlPlots_[ControlPlots::OfflineETMHF], recoETMHF);
+  fillWithinLimits(h_controlPlots_[ControlPlots::OfflinePFMetNoMu], recoPFMetNoMu);
   fillWithinLimits(h_controlPlots_[ControlPlots::OfflineMHT], recoMHT);
   fillWithinLimits(h_controlPlots_[ControlPlots::OfflineETT], recoETT);
   fillWithinLimits(h_controlPlots_[ControlPlots::OfflineHTT], recoHTT);
 
   fill2DWithinLimits(h_L1METvsCaloMET_, recoMET, l1MET);
   fill2DWithinLimits(h_L1ETMHFvsCaloETMHF_, recoETMHF, l1ETMHF);
+  fill2DWithinLimits(h_L1METvsPFMetNoMu_, recoPFMetNoMu, l1MET);
   fill2DWithinLimits(h_L1MHTvsRecoMHT_, recoMHT, l1MHT);
   fill2DWithinLimits(h_L1METTvsCaloETT_, recoETT, l1ETT);
   fill2DWithinLimits(h_L1HTTvsRecoHTT_, recoHTT, l1HTT);
 
   fill2DWithinLimits(h_L1METPhivsCaloMETPhi_, recoMETPhi, l1METPhi);
   fill2DWithinLimits(h_L1ETMHFPhivsCaloETMHFPhi_, recoETMHFPhi, l1ETMHFPhi);
+  fill2DWithinLimits(h_L1METPhivsPFMetNoMuPhi_, recoPFMetNoMuPhi, l1METPhi);
   fill2DWithinLimits(h_L1MHTPhivsRecoMHTPhi_, recoMHTPhi, l1MHTPhi);
 
   fillWithinLimits(h_resolutionMET_, resolutionMET);
   fillWithinLimits(h_resolutionETMHF_, resolutionETMHF);
+  fillWithinLimits(h_resolutionPFMetNoMu_, resolutionPFMetNoMu);
   fillWithinLimits(h_resolutionMHT_, resolutionMHT);
   fillWithinLimits(h_resolutionETT_, resolutionETT);
   fillWithinLimits(h_resolutionHTT_, resolutionHTT);
 
   fillWithinLimits(h_resolutionMETPhi_, resolutionMETPhi);
   fillWithinLimits(h_resolutionETMHFPhi_, resolutionETMHFPhi);
+  fillWithinLimits(h_resolutionPFMetNoMuPhi_, resolutionPFMetNoMuPhi);
   fillWithinLimits(h_resolutionMHTPhi_, resolutionMHTPhi);
 
   // efficiencies
   for (auto threshold : metEfficiencyThresholds_) {
     fillWithinLimits(h_efficiencyMET_total_[threshold], recoMET);
     fillWithinLimits(h_efficiencyETMHF_total_[threshold], recoETMHF);
+    fillWithinLimits(h_efficiencyPFMetNoMu_total_[threshold], recoPFMetNoMu);
     if (l1MET > threshold){
       fillWithinLimits(h_efficiencyMET_pass_[threshold], recoMET);
       fillWithinLimits(h_efficiencyETMHF_pass_[threshold], recoETMHF);
+      fillWithinLimits(h_efficiencyPFMetNoMu_pass_[threshold], recoPFMetNoMu);
     }
   }
 
@@ -506,6 +527,8 @@ void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker
       "Offline E_{T}^{miss}; Offline E_{T}^{miss} (GeV); events", 500, -0.5, 4999.5);
   h_controlPlots_[ControlPlots::OfflineETMHF] = ibooker.book1D("OfflineETMHF",
       "Offline E_{T}^{miss} (HF); Offline E_{T}^{miss} (HF) (GeV); events", 500, -0.5, 4999.5);
+  h_controlPlots_[ControlPlots::OfflinePFMetNoMu] = ibooker.book1D("OfflinePFMetNoMu",
+      "Offline E_{T}^{miss} (PFMetNoMu); Offline E_{T}^{miss} (PFMetNoMu) (GeV); events", 500, -0.5, 4999.5);
   h_controlPlots_[ControlPlots::OfflineMHT] = ibooker.book1D("OfflineMHT", "Offline MHT; Offline MHT (GeV); events",
       500, -0.5, 4999.5);
   h_controlPlots_[ControlPlots::OfflineETT] = ibooker.book1D("OfflineETT", "Offline ETT; Offline ETT (GeV); events",
@@ -521,6 +544,9 @@ void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker
   h_L1ETMHFvsCaloETMHF_ = ibooker.book2D("L1ETMHFvsCaloETMHF",
       "L1 E_{T}^{miss} vs Offline E_{T}^{miss} (HF);Offline E_{T}^{miss} (HF) (GeV);L1 E_{T}^{miss} (HF) (GeV)",
       templateETvsET.nbinsX, &templateETvsET.binsX[0], templateETvsET.nbinsY, &templateETvsET.binsY[0]);
+  h_L1METvsPFMetNoMu_ = ibooker.book2D("L1METvsPFMetNoMu",
+          "L1 E_{T}^{miss} vs Offline E_{T}^{miss} (PFMetNoMu);Offline E_{T}^{miss} (PFMetNoMu) (GeV);L1 E_{T}^{miss} (GeV)",
+          templateETvsET.nbinsX, &templateETvsET.binsX[0], templateETvsET.nbinsY, &templateETvsET.binsY[0]);
   h_L1MHTvsRecoMHT_ = ibooker.book2D("L1MHTvsRecoMHT", "L1 MHT vs reco MHT;reco MHT (GeV);L1 MHT (GeV)",
       templateETvsET.nbinsX, &templateETvsET.binsX[0], templateETvsET.nbinsY, &templateETvsET.binsY[0]);
   h_L1METTvsCaloETT_ = ibooker.book2D("L1ETTvsCaloETT", "L1 ETT vs calo ETT;calo ETT (GeV);L1 ETT (GeV)",
@@ -538,6 +564,10 @@ void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker
       "L1 E_{T}^{miss} #phi vs Offline E_{T}^{miss} (HF) #phi;Offline E_{T}^{miss} (HF) #phi;L1 E_{T}^{miss} #phi",
       templatePHIvsPHI.nbinsX, templatePHIvsPHI.xmin, templatePHIvsPHI.xmax,
       templatePHIvsPHI.nbinsY, templatePHIvsPHI.ymin, templatePHIvsPHI.ymax);
+  h_L1METPhivsPFMetNoMuPhi_ = ibooker.book2D("L1METPhivsPFMetNoMuPhi",
+      "L1 E_{T}^{miss} #phi vs Offline E_{T}^{miss} (PFMetNoMu) #phi;Offline E_{T}^{miss} (PFMetNoMu) #phi;L1 E_{T}^{miss} #phi",
+      templatePHIvsPHI.nbinsX, templatePHIvsPHI.xmin, templatePHIvsPHI.xmax,
+      templatePHIvsPHI.nbinsY, templatePHIvsPHI.ymin, templatePHIvsPHI.ymax);
   h_L1MHTPhivsRecoMHTPhi_ = ibooker.book2D("L1MHTPhivsRecoMHTPhi",
       "L1 MHT #phi vs reco MHT #phi;reco MHT #phi;L1 MHT #phi",
       templatePHIvsPHI.nbinsX, templatePHIvsPHI.xmin, templatePHIvsPHI.xmax,
@@ -548,6 +578,8 @@ void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker
       "MET resolution; (L1 E_{T}^{miss} - Offline E_{T}^{miss})/Offline E_{T}^{miss}; events", 50, -1, 1.5);
   h_resolutionETMHF_ = ibooker.book1D("resolutionETMHF",
       "MET resolution (HF); (L1 E_{T}^{miss} - Offline E_{T}^{miss})/Offline E_{T}^{miss} (HF); events", 50, -1, 1.5);
+  h_resolutionPFMetNoMu_ = ibooker.book1D("resolutionPFMetNoMu",
+          "PFMetNoMu resolution; (L1 E_{T}^{miss} - Offline E_{T}^{miss})/Offline E_{T}^{miss} (PFMetNoMu); events", 50, -1, 1.5);
   h_resolutionMHT_ = ibooker.book1D("resolutionMHT", "MHT resolution; (L1 MHT - reco MHT)/reco MHT; events", 50, -1,
       1.5);
   h_resolutionETT_ = ibooker.book1D("resolutionETT", "ETT resolution; (L1 ETT - calo ETT)/calo ETT; events", 50, -1,
@@ -557,8 +589,10 @@ void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker
 
   h_resolutionMETPhi_ = ibooker.book1D("resolutionMETPhi",
       "MET #phi resolution; (L1 E_{T}^{miss} #phi - reco MET #phi)/reco MET #phi; events", 120, -0.3, 0.3);
-  h_resolutionETMHFPhi_ = ibooker.book1D("resolutionEMTHFPhi",
+  h_resolutionETMHFPhi_ = ibooker.book1D("resolutionETMHFPhi",
       "MET #phi resolution (HF); (L1 E_{T}^{miss} #phi - reco MET #phi)/reco MET #phi (HF); events", 120, -0.3, 0.3);
+  h_resolutionPFMetNoMuPhi_ = ibooker.book1D("resolutionPFMetNoMuPhi",
+      "MET #phi resolution (PFMetNoMu); (L1 E_{T}^{miss} #phi - reco MET #phi)/reco MET #phi (PFMetNoMu); events", 120, -0.3, 0.3);
   h_resolutionMHTPhi_ = ibooker.book1D("resolutionMHTPhi",
       "MET #phi resolution; (L1 MHT #phi - reco MHT #phi)/reco MHT #phi; events", 120, -0.3, 0.3);
 
@@ -581,6 +615,11 @@ void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker
         "MET efficiency (numerator); Offline E_{T}^{miss} (GeV) (HF);", metBins.size() - 1, &(metBins[0]));
     h_efficiencyETMHF_total_[threshold] = ibooker.book1D("efficiencyETMHF_threshold_" + str_threshold + "_Den",
         "MET efficiency (denominator); Offline E_{T}^{miss} (GeV) (HF);", metBins.size() - 1, &(metBins[0]));
+
+    h_efficiencyPFMetNoMu_pass_[threshold] = ibooker.book1D("efficiencyPFMetNoMu_threshold_" + str_threshold + "_Num",
+        "MET efficiency (numerator); Offline E_{T}^{miss} (GeV) (PFMetNoMu);", metBins.size() - 1, &(metBins[0]));
+    h_efficiencyPFMetNoMu_total_[threshold] = ibooker.book1D("efficiencyPFMetNoMu_threshold_" + str_threshold + "_Den",
+        "MET efficiency (denominator); Offline E_{T}^{miss} (GeV) (PFMetNoMu);", metBins.size() - 1, &(metBins[0]));
   }
 
   for (auto threshold : mhtEfficiencyThresholds_) {

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
@@ -101,8 +101,13 @@ if os.environ.get('DEBUG', False):
         '*',
     )
 
+# pfMETT1 from https://github.com/cms-sw/cmssw/blob/master/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py#L109,
+# is difficult to set up, let's use pfMet for testing
+process.l1tPFMetNoMuForDQM.pfMETCollection = 'pfMet'
+
 process.dqmoffline_step = cms.Path(
     process.goodPFJetsForL1T *
+    process.l1tPFMetNoMuForDQM *
     process.l1tEtSumJetOfflineDQMEmu +
     process.l1tEtSumJetOfflineDQM +
     process.l1tEGammaOfflineDQM +

--- a/L1Trigger/L1TNtuples/interface/L1TPFMetNoMuProducer.h
+++ b/L1Trigger/L1TNtuples/interface/L1TPFMetNoMuProducer.h
@@ -1,0 +1,26 @@
+#ifndef L1TPFMetNoMuProducer_H
+#define L1TPFMetNoMuProducer_H
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/METReco/interface/PFMETCollection.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+
+class L1TPFMetNoMuProducer : public edm::stream::EDProducer<> {
+public:
+  explicit L1TPFMetNoMuProducer(const edm::ParameterSet &ps);
+
+
+private:
+  void produce(edm::Event &event, const edm::EventSetup &eventSetup);
+
+  const edm::EDGetTokenT<reco::PFMETCollection> thePFMETCollection_;
+  const edm::EDGetTokenT<reco::MuonCollection> theMuonCollection_;
+};
+#endif

--- a/L1Trigger/L1TNtuples/plugins/L1TPFMetNoMuProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1TPFMetNoMuProducer.cc
@@ -1,0 +1,60 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "L1Trigger/L1TNtuples/interface/L1TPFMetNoMuProducer.h"
+
+L1TPFMetNoMuProducer::L1TPFMetNoMuProducer(const edm::ParameterSet &ps)
+    : thePFMETCollection_(consumes<reco::PFMETCollection>(
+          ps.getParameter<edm::InputTag>("pfMETCollection"))),
+      theMuonCollection_(consumes<reco::MuonCollection>(
+          ps.getParameter<edm::InputTag>("muonCollection"))) {
+  produces<reco::PFMETCollection>();
+}
+
+void L1TPFMetNoMuProducer::produce(edm::Event &event,
+                                   const edm::EventSetup &eventSetup) {
+  edm::Handle<reco::PFMETCollection> pfMet;
+  event.getByToken(thePFMETCollection_, pfMet);
+
+  edm::Handle<reco::MuonCollection> muons;
+  event.getByToken(theMuonCollection_, muons);
+
+  if (!pfMet.isValid()) {
+    edm::LogWarning("L1TPFMetNoMuProducer")
+        << "invalid collection for pfMet" << std::endl;
+    return;
+  }
+  if (!muons.isValid()) {
+    edm::LogWarning("L1TPFMetNoMuProducer")
+        << "invalid collection for muons" << std::endl;
+    return;
+  }
+
+  reco::PFMET thePFMetNoMu = pfMet.product()->front();
+  double pfMetNoMuPx = thePFMetNoMu.px();
+  double pfMetNoMuPy = thePFMetNoMu.py();
+
+  double muPx(0.), muPy(0.);
+
+  for (auto muon = muons->begin(); muon != muons->end(); ++muon) {
+    if (muon->isPFMuon()) {
+      muPx += muon->px();
+      muPy += muon->py();
+    }
+  }
+
+  pfMetNoMuPx += muPx;
+  pfMetNoMuPy += muPy;
+  math::XYZTLorentzVector pfMetNoMuP4(pfMetNoMuPx, pfMetNoMuPy, 0,
+                                      hypot(pfMetNoMuPx, pfMetNoMuPy));
+
+  thePFMetNoMu.setP4(pfMetNoMuP4);
+
+  std::unique_ptr<reco::PFMETCollection> product(new reco::PFMETCollection);
+  product->emplace_back(thePFMetNoMu.getSpecific(), thePFMetNoMu.sumEt(),
+                        thePFMetNoMu.p4(), thePFMetNoMu.vertex());
+
+  event.put(std::move(product));
+}
+
+DEFINE_FWK_MODULE(L1TPFMetNoMuProducer);

--- a/L1Trigger/L1TNtuples/python/L1TPFMetNoMuProducer_cfi.py
+++ b/L1Trigger/L1TNtuples/python/L1TPFMetNoMuProducer_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+
+l1tPFMetNoMu = cms.EDProducer(
+    "L1TPFMetNoMuProducer",
+    pfMETCollection=cms.InputTag("pfMetT1"),
+    muonCollection=cms.InputTag("muons"),
+)


### PR DESCRIPTION
The third part of https://its.cern.ch/jira/browse/CMSLITDPG-588.
Adds `PFMetNoMu` as defined in https://github.com/cms-l1t-offline/cmssw/blob/l1t-integration-v97.28/L1Trigger/L1TNtuples/plugins/L1JetRecoTreeProducer.cc#L482
Example plots are shown in the jira issue.

However, instead of copying the code from the L1TNuples I added a producer, `L1TPFMetNoMuProducer`. This should provide a more clear separation between creating the objects and filling histograms. 

As for the PFJet issue (#23458 ) the new module dependency, `l1tPFMetNoMuForDQM`, should be picked up automagically by CMSSW unscheduled running.

Part 4 (minor fixes) will follow shortly.