### PR TITLE
Geant4 sensitive detectors clean-up 6

### DIFF
--- a/SimG4CMS/Calo/interface/CaloHitID.h
+++ b/SimG4CMS/Calo/interface/CaloHitID.h
@@ -5,7 +5,7 @@
 // HitID class for storing unique identifier of a Calorimetric Hit
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <iostream>
 
 class CaloHitID {

--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -26,9 +26,6 @@
 #include "G4Track.hh"
 #include "G4VGFlashSensitiveDetector.hh"
 
-#include <cstdint>
-#include <iostream>
-#include <fstream>
 #include <vector>
 #include <map>
 

--- a/SimG4CMS/Calo/interface/HcalNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HcalNumberingScheme.h
@@ -8,7 +8,7 @@
 #include "Geometry/CaloGeometry/interface/CaloNumberingScheme.h"
 #include "Geometry/HcalCommonData/interface/HcalNumberingFromDDD.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class HcalNumberingScheme : public CaloNumberingScheme {
 

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -20,6 +20,9 @@
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 
+#include <iostream>
+#include <fstream>
+
 //#define DebugLog
 
 CaloSD::CaloSD(const std::string& name, const DDCompactView & cpv,
@@ -402,7 +405,7 @@ CaloG4Hit* CaloSD::createNewHit(const G4Step* aStep) {
                             << " save: " << (etrack >= energyCut || forceSave);
 #endif
     if (etrack >= energyCut || forceSave) {
-      TrackInformation* trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
+      TrackInformation* trkInfo = cmsTrackInformation(theTrack);
       trkInfo->storeTrack(true);
       trkInfo->putInHistory();
     }
@@ -492,7 +495,7 @@ void CaloSD::update(const BeginOfEvent *) {
 
 void CaloSD::update(const EndOfTrack * trk) {
   int id = (*trk)()->GetTrackID();
-  TrackInformation *trkI =(TrackInformation *)((*trk)()->GetUserInformation());
+  TrackInformation *trkI = cmsTrackInformation((*trk)());
   int lastTrackID = -1;
   if (trkI) lastTrackID = trkI->getIDonCaloSurface();
   if (id == lastTrackID) {
@@ -591,7 +594,7 @@ int CaloSD::getTrackID(const G4Track* aTrack) {
 
   int primaryID = 0;
   forceSave = false;
-  TrackInformation* trkInfo=(TrackInformation *)(aTrack->GetUserInformation());
+  TrackInformation* trkInfo = cmsTrackInformation(aTrack);
   if (trkInfo) {
     primaryID = trkInfo->getIDonCaloSurface(); 
 #ifdef DebugLog
@@ -612,7 +615,7 @@ int CaloSD::getTrackID(const G4Track* aTrack) {
 int CaloSD::setTrackID(const G4Step* aStep) {
 
   auto const theTrack = aStep->GetTrack();
-  TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
+  TrackInformation * trkInfo = cmsTrackInformation(theTrack);
   int primaryID = trkInfo->getIDonCaloSurface();
   if (primaryID == 0) { primaryID = theTrack->GetTrackID(); }
 
@@ -643,7 +646,7 @@ bool CaloSD::filterHit(CaloG4Hit* hit, double time) {
 double CaloSD::getResponseWt(const G4Track* aTrack) {
   double wt = 1.0;
   if (meanResponse.get()) {
-    TrackInformation * trkInfo = (TrackInformation *)(aTrack->GetUserInformation());
+    TrackInformation * trkInfo = cmsTrackInformation(aTrack);
     wt = meanResponse.get()->getWeight(trkInfo->genParticlePID(), trkInfo->genParticleP());
   }
   return wt;
@@ -697,7 +700,7 @@ bool CaloSD::saveHit(CaloG4Hit* aHit) {
 
 void CaloSD::update(const BeginOfTrack * trk) {
   int primary = -1;
-  TrackInformation * trkInfo = (TrackInformation *)((*trk)()->GetUserInformation());
+  TrackInformation * trkInfo = cmsTrackInformation((*trk)());
   if ( trkInfo->isPrimary() ) primary = (*trk)()->GetTrackID();
   
 #ifdef DebugLog

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -561,7 +561,6 @@ void HCalSD::update(const BeginOfJob * job) {
 }
 
 void HCalSD::initRun() {
-  edm::LogWarning("HcalSim") << "InitRun for HFFFFF ";
   if (showerLibrary.get()) showerLibrary.get()->initRun(nullptr, hcalConstants);
   if (showerParam.get())   showerParam.get()->initRun(hcalConstants);
   if (hfshower.get())      hfshower.get()->initRun(hcalConstants);

--- a/SimG4CMS/Muon/BuildFile.xml
+++ b/SimG4CMS/Muon/BuildFile.xml
@@ -1,8 +1,9 @@
 <use   name="SimG4Core/SensitiveDetector"/>
 <use   name="SimG4Core/Notification"/>
+<use   name="SimG4Core/Physics"/>
+<use   name="SimDataFormats/SimHitMaker"/>
+<use   name="Geometry/MuonNumbering"/>
 <use   name="boost"/>
 <use   name="geant4core"/>
-<use   name="SimDataFormats/SimHitMaker"/>
-<use   name="SimG4Core/Application"/>
-<use   name="Geometry/MuonNumbering"/>
+<use   name="hepmc"/>
 <flags   EDM_PLUGIN="1"/>

--- a/SimG4CMS/Muon/interface/MuonFrameRotation.h
+++ b/SimG4CMS/Muon/interface/MuonFrameRotation.h
@@ -10,19 +10,16 @@
  * Make it base class of each detector FrameRotation  
  */
 
-#include "G4Step.hh"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 
-class MuonSubDetector;
-class DDCompactView;
+class G4Step;
 
 class MuonFrameRotation {
  public:
-  MuonFrameRotation( ) { };
-  virtual ~MuonFrameRotation(){};
-  virtual Local3DPoint transformPoint(const Local3DPoint &,const G4Step *) const = 0;
+  MuonFrameRotation() {};
+  virtual ~MuonFrameRotation() {};
+  virtual Local3DPoint transformPoint(const Local3DPoint &,const G4Step *) const;
 
- private:
 };
 
 #endif

--- a/SimG4CMS/Muon/interface/MuonGEMFrameRotation.h
+++ b/SimG4CMS/Muon/interface/MuonGEMFrameRotation.h
@@ -14,9 +14,8 @@
 #include "SimG4CMS/Muon/interface/MuonFrameRotation.h"
 #include "SimG4CMS/Muon/interface/MuonG4Numbering.h"
 
-#include "G4Step.hh"
-
 class MuonDDDConstants;
+class G4Step;
 
 class MuonGEMFrameRotation : public MuonFrameRotation {
 

--- a/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
+++ b/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
@@ -15,17 +15,10 @@
  * Add SimTracks selection
  */
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimG4Core/Notification/interface/Observer.h"
 #include "SimG4Core/Notification/interface/BeginOfEvent.h"
-#include "SimG4Core/Notification/interface/EndOfEvent.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
-
-#include "G4Step.hh"
-#include "G4StepPoint.hh"
-#include "G4Track.hh"
 
 #include <string>
 
@@ -36,22 +29,18 @@ class UpdatablePSimHit;
 class MuonSubDetector;
 class MuonG4Numbering;
 class SimHitPrinter;
-class TrackInformation;
-class G4Track;
+class G4Step;
 class G4ProcessTypeEnumerator;
-class G4TrackToParticleID;
 class SimTrackManager;
 
 class MuonSensitiveDetector : 
 public SensitiveTkDetector,
-public Observer<const BeginOfEvent*>,
-public Observer<const EndOfEvent*>
- {
-
- public:    
-  MuonSensitiveDetector(const std::string&, const DDCompactView &,
-			const SensitiveDetectorCatalog &, edm::ParameterSet const &,
-			const SimTrackManager*);
+public Observer<const BeginOfEvent*>
+{
+public:    
+  explicit MuonSensitiveDetector(const std::string&, const DDCompactView &,
+				 const SensitiveDetectorCatalog &, edm::ParameterSet const &,
+				 const SimTrackManager*);
   ~MuonSensitiveDetector() override;
   G4bool ProcessHits(G4Step *,G4TouchableHistory *) override;
   uint32_t setDetUnitId(const G4Step *) override;
@@ -60,58 +49,51 @@ public Observer<const EndOfEvent*>
   void fillHits(edm::PSimHitContainer&, const std::string&) override;
   void clearHits() override;
 
-  std::string type();
-
   const MuonSlaveSD* GetSlaveMuon() const {
     return slaveMuon; }
-  
- private:
+
+protected:
+
   void update(const BeginOfEvent *) override;
-  void update(const ::EndOfEvent *) override;
+  
+private:
 
-  Local3DPoint toOrcaRef(Local3DPoint in ,G4Step *);
-  Local3DPoint toOrcaUnits(const Local3DPoint&);
-  Global3DPoint toOrcaUnits(const Global3DPoint&);
+  inline Local3DPoint cmsUnits(const Local3DPoint& v)
+  { return Local3DPoint(v.x()*0.1, v.y()*0.1, v.z()*0.1); }
 
-  TrackInformation* getOrCreateTrackInformation( const G4Track* theTrack );
-
- private:
   MuonSlaveSD* slaveMuon;
   MuonSimHitNumberingScheme* numbering;
   MuonSubDetector* detector;
   MuonFrameRotation* theRotation;
   MuonG4Numbering* g4numbering;
 
-  void storeVolumeAndTrack(const G4Step *);
-  bool newHit(G4Step *);
-  void createHit(G4Step *);
-  void updateHit(G4Step *);
+  bool newHit(const G4Step *);
+  void createHit(const G4Step *);
+  void updateHit(const G4Step *);
   void saveHit();
   
   /**
    * Transform from local coordinates of a volume to local coordinates of a parent volume
-   * one or more levels up the volume hierarchy: e.g. levelsUp = 1 for immediate parent. <BR>
+   * one or more levels up the volume hierarchy: e.g. levelsUp = 1 for immediate parent.
    * This is done by moving from local_1 -> global -> local_2.
    */
-  Local3DPoint InitialStepPositionVsParent(G4Step * currentStep, G4int levelsUp);
-  Local3DPoint FinalStepPositionVsParent(G4Step * currentStep, G4int levelsUp);
+  Local3DPoint InitialStepPositionVsParent(const G4Step * currentStep, G4int levelsUp);
+  Local3DPoint FinalStepPositionVsParent(const G4Step * currentStep, G4int levelsUp);
 
-  G4VPhysicalVolume * thePV;
+  const G4VPhysicalVolume* thePV;
   UpdatablePSimHit* theHit;
-  uint32_t theDetUnitId; 
-  unsigned int theTrackID;
+  uint32_t theDetUnitId;
+  int theTrackID;
  
   bool printHits;
   SimHitPrinter* thePrinter;
-  Global3DPoint theGlobalEntry;
 
   //--- SimTracks cuts
-  double STenergyPersistentCut;
-  bool STallMuonsPersistent;
+  float ePersistentCutGeV;
+  bool  allMuonsPersistent;
 
   G4ProcessTypeEnumerator* theG4ProcessTypeEnumerator;
 
-  G4TrackToParticleID* myG4TrackToParticleID;
   const SimTrackManager* theManager;
 };
 

--- a/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
+++ b/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
@@ -83,6 +83,7 @@ private:
   const G4VPhysicalVolume* thePV;
   UpdatablePSimHit* theHit;
   uint32_t theDetUnitId;
+  uint32_t newDetUnitId;
   int theTrackID;
  
   bool printHits;

--- a/SimG4CMS/Muon/src/MuonEndcapFrameRotation.cc
+++ b/SimG4CMS/Muon/src/MuonEndcapFrameRotation.cc
@@ -1,22 +1,17 @@
 #include "SimG4CMS/Muon/interface/MuonEndcapFrameRotation.h"
+#include "SimG4Core/SensitiveDetector/interface/FrameRotation.h"
 
+#include "G4Step.hh"
 #include "G4StepPoint.hh"
 #include "G4TouchableHistory.hh"
 
-Local3DPoint MuonEndcapFrameRotation::transformPoint(const Local3DPoint & point,const G4Step * s=nullptr) const {
-  if (!s)
-    return Local3DPoint(0.,0.,0.);
+Local3DPoint MuonEndcapFrameRotation::transformPoint(const Local3DPoint& point,const G4Step* step) const {
       
-  const G4StepPoint * preStepPoint = s->GetPreStepPoint();
+  const G4StepPoint * preStepPoint = step->GetPreStepPoint();
   const G4TouchableHistory * theTouchable = (const G4TouchableHistory *)preStepPoint->GetTouchable();
   const G4ThreeVector& trans=theTouchable->GetTranslation();
   
-  if (trans.z()<0) {
-    //      return Local3DPoint(point.x(),-point.z(),point.y());
-    //      return Local3DPoint(-point.x(),point.z(),-point.y());
-    return Local3DPoint(-point.x(),-point.z(),-point.y());
-  } else {
-    //      return Local3DPoint(point.x(),point.z(),-point.y());
-    return Local3DPoint(point.x(),point.z(),-point.y());
-  }
+  return (trans.z()<0) 
+    ? Local3DPoint(-point.x(),-point.z(),-point.y())
+    : Local3DPoint(point.x(),point.z(),-point.y());
 } 

--- a/SimG4CMS/Muon/src/MuonFrameRotation.cc
+++ b/SimG4CMS/Muon/src/MuonFrameRotation.cc
@@ -1,0 +1,6 @@
+#include "SimG4CMS/Muon/interface/MuonFrameRotation.h"
+#include "G4Step.hh"
+
+Local3DPoint MuonFrameRotation::transformPoint(const Local3DPoint& point,const G4Step*) const {
+  return point;
+} 

--- a/SimG4CMS/Muon/src/MuonGEMFrameRotation.cc
+++ b/SimG4CMS/Muon/src/MuonGEMFrameRotation.cc
@@ -2,27 +2,20 @@
 #include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 
-#include "G4StepPoint.hh"
-#include "G4TouchableHistory.hh"
+#include "G4Step.hh"
 
-//#define LOCAL_DEBUG
-
-MuonGEMFrameRotation::MuonGEMFrameRotation(const MuonDDDConstants& muonConstants) : MuonFrameRotation::MuonFrameRotation() {
+MuonGEMFrameRotation::MuonGEMFrameRotation(const MuonDDDConstants& muonConstants) 
+  : MuonFrameRotation::MuonFrameRotation() {
   g4numbering     = new MuonG4Numbering(muonConstants);
   int theLevelPart= muonConstants.getValue("level");
   theSectorLevel  = muonConstants.getValue("mg_sector")/theLevelPart;
-#ifdef LOCAL_DEBUG
-  std::cout << "MuonGEMFrameRotation: theSectorLevel " << theSectorLevel 
-	    << std::endl;
-#endif
 }
 
 MuonGEMFrameRotation::~MuonGEMFrameRotation() {
   delete g4numbering;
 }
 
-Local3DPoint MuonGEMFrameRotation::transformPoint(const Local3DPoint & point,const G4Step * aStep=nullptr) const {
-  if (!aStep) return Local3DPoint(0.,0.,0.);  
-
+Local3DPoint MuonGEMFrameRotation::transformPoint(const Local3DPoint & point,const G4Step *) const {
+  //---VI: theSectorLevel and g4numbering are not used
   return Local3DPoint(point.x(),point.z(),-point.y());
 }

--- a/SimG4CMS/Muon/src/MuonME0FrameRotation.cc
+++ b/SimG4CMS/Muon/src/MuonME0FrameRotation.cc
@@ -3,29 +3,23 @@
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "G4StepPoint.hh"
-#include "G4TouchableHistory.hh"
+#include "G4Step.hh"
 
-//#define LOCAL_DEBUG
-
-MuonME0FrameRotation::MuonME0FrameRotation(const MuonDDDConstants& muonConstants) : MuonFrameRotation::MuonFrameRotation() {
+MuonME0FrameRotation::MuonME0FrameRotation(const MuonDDDConstants& muonConstants) 
+  : MuonFrameRotation::MuonFrameRotation() {
   g4numbering     = new MuonG4Numbering(muonConstants);
   int theLevelPart= muonConstants.getValue("level");
   theSectorLevel  = muonConstants.getValue("mg_sector")/theLevelPart;
-#ifdef LOCAL_DEBUG
-  std::cout << "MuonME0FrameRotation: theSectorLevel " << theSectorLevel 
-	    << std::endl;
-#endif
-  edm::LogVerbatim("MuonME0FrameRotation")<<"MuonME0FrameRotation: theSectorLevel " << theSectorLevel;
+  edm::LogVerbatim("MuonME0FrameRotation")
+    <<"MuonME0FrameRotation: theSectorLevel " << theSectorLevel;
 }
 
 MuonME0FrameRotation::~MuonME0FrameRotation() {
   delete g4numbering;
 }
 
-Local3DPoint MuonME0FrameRotation::transformPoint(const Local3DPoint & point,const G4Step * aStep=nullptr) const {
-  if (!aStep) return Local3DPoint(0.,0.,0.);  
-
-  edm::LogVerbatim("MuonME0FrameRotation")<<"MuonME0FrameRotation transformPoint :: Local3DPoint (" <<point.x()<<","<<point.z()<<","<<-point.y()<<")" ;
+Local3DPoint 
+MuonME0FrameRotation::transformPoint(const Local3DPoint& point,const G4Step *) const {
+  //---VI: sector level and g4numbering are not used
   return Local3DPoint(point.x(),point.z(),-point.y());
 }

--- a/SimG4CMS/Muon/src/MuonRPCFrameRotation.cc
+++ b/SimG4CMS/Muon/src/MuonRPCFrameRotation.cc
@@ -3,8 +3,7 @@
 #include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 
-#include "G4StepPoint.hh"
-#include "G4TouchableHistory.hh"
+#include "G4Step.hh"
 
 MuonRPCFrameRotation::MuonRPCFrameRotation(const MuonDDDConstants& muonConstants) : 
 MuonFrameRotation::MuonFrameRotation() {
@@ -17,16 +16,11 @@ MuonRPCFrameRotation::~MuonRPCFrameRotation(){
   delete g4numbering;
 }
 
-Local3DPoint MuonRPCFrameRotation::transformPoint(const Local3DPoint & point,const G4Step * aStep=nullptr) const {
-  if (!aStep)
-    return Local3DPoint(0.,0.,0.);  
-
+Local3DPoint 
+MuonRPCFrameRotation::transformPoint(const Local3DPoint& point,const G4Step* aStep) const {
   //check if endcap
   MuonBaseNumber num = g4numbering->PhysicalVolumeToBaseNumber(aStep);
   bool endcap_muon = (num.getSuperNo(theRegion)!=1);
-  if (endcap_muon){
-    return Local3DPoint(point.x(),point.z(),-point.y());
-  } else {
-    return point; 
-  }
+  return (endcap_muon) ? Local3DPoint(point.x(),point.z(),-point.y())
+    : Local3DPoint(point.x(),point.y(),point.z());
 }

--- a/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
@@ -7,10 +7,9 @@
 #include "Geometry/MuonNumbering/interface/MuonSubDetector.h"
 #include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
 
-#include "DataFormats/GeometryVector/interface/LocalVector.h"
-
 #include "SimG4CMS/Muon/interface/SimHitPrinter.h"
 #include "SimDataFormats/TrackingHit/interface/UpdatablePSimHit.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
 #include "SimG4CMS/Muon/interface/MuonG4Numbering.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
@@ -20,14 +19,18 @@
 #include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
 #include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
 
-#include "G4SDManager.hh"
 #include "G4VProcess.hh"
 #include "G4EventManager.hh"
 #include "G4SystemOfUnits.hh"
+#include "G4Step.hh"
+#include "G4StepPoint.hh"
+#include "G4Track.hh"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <iostream>
+
+//#define DebugLog
 
 MuonSensitiveDetector::MuonSensitiveDetector(const std::string& name, 
 					     const DDCompactView & cpv,
@@ -38,40 +41,35 @@ MuonSensitiveDetector::MuonSensitiveDetector(const std::string& name,
     thePV(nullptr), theHit(nullptr), theDetUnitId(0), theTrackID(0), theManager(manager)
 {
   edm::ParameterSet m_MuonSD = p.getParameter<edm::ParameterSet>("MuonSD");
-  STenergyPersistentCut = m_MuonSD.getParameter<double>("EnergyThresholdForPersistency");//Default 1. GeV
-  STallMuonsPersistent = m_MuonSD.getParameter<bool>("AllMuonsPersistent");
+  ePersistentCutGeV = m_MuonSD.getParameter<double>("EnergyThresholdForPersistency");//Default 1. GeV
+  allMuonsPersistent = m_MuonSD.getParameter<bool>("AllMuonsPersistent");
   printHits  = m_MuonSD.getParameter<bool>("PrintHits");
   
   //
   // Here simply create 1 MuonSlaveSD for the moment
   //  
-  
-  LogDebug("MuonSimDebug") << "create MuonSubDetector "<<name<<std::endl;
-
+  LogDebug("MuonSimDebug") << "create MuonSubDetector "<<name;
   detector = new MuonSubDetector(name);
 
-  LogDebug("MuonSimDebug") << "create MuonFrameRotation"<<std::endl;
-
- //The constants take time to calculate and are needed by many helpers
- MuonDDDConstants constants(cpv);
- if (detector->isEndcap()) {
-   //    cout << "MuonFrameRotation create MuonEndcapFrameRotation"<<endl;
+  //The constants take time to calculate and are needed by many helpers
+  MuonDDDConstants constants(cpv);
+  G4String sdet = "unknown";
+  if (detector->isEndcap()) {
     theRotation=new MuonEndcapFrameRotation();
+    sdet = "Endcap";
   } else if (detector->isRPC()) {
-    //    cout << "MuonFrameRotation create MuonRPCFrameRotation"<<endl;
     theRotation=new MuonRPCFrameRotation( constants );
+    sdet = "RPC";
   } else if (detector->isGEM()) {
-    //    cout << "MuonFrameRotation create MuonGEMFrameRotation"<<endl;
     theRotation=new MuonGEMFrameRotation( constants );
+    sdet = "GEM";
   } else if (detector->isME0()) {
-    //    cout << "MuonFrameRotation create MuonME0FrameRotation"<<endl;
     theRotation=new MuonME0FrameRotation( constants );
-  }  else {
-    theRotation = nullptr;
+    sdet = "ME0";
+  } else {
+    theRotation = new MuonFrameRotation();
   }
-  LogDebug("MuonSimDebug") << "create MuonSlaveSD"<<std::endl;
   slaveMuon  = new MuonSlaveSD(detector,theManager);
-  LogDebug("MuonSimDebug") << "create MuonSimHitNumberingScheme"<<std::endl;
   numbering  = new MuonSimHitNumberingScheme(detector, constants);
   g4numbering = new MuonG4Numbering(constants);
   
@@ -79,13 +77,12 @@ MuonSensitiveDetector::MuonSensitiveDetector(const std::string& name,
     thePrinter = new SimHitPrinter("HitPositionOSCAR.dat");
   }
 
-
-  edm::LogInfo("MuonSimDebug") << "  EnergyThresholdForPersistency " 
-			       << STenergyPersistentCut << " AllMuonsPersistent " 
-			       <<  STallMuonsPersistent;
+  edm::LogVerbatim("MuonSensitiveDetector") 
+    << " of type " << sdet << " <" << GetName() 
+    << "> EnergyThresholdForPersistency(GeV) " << ePersistentCutGeV/CLHEP::GeV 
+    << " allMuonsPersistent: " << allMuonsPersistent;
     
   theG4ProcessTypeEnumerator = new G4ProcessTypeEnumerator;
-  myG4TrackToParticleID = new G4TrackToParticleID;
 }
 
 MuonSensitiveDetector::~MuonSensitiveDetector() { 
@@ -94,40 +91,32 @@ MuonSensitiveDetector::~MuonSensitiveDetector() {
   delete slaveMuon;
   delete theRotation;
   delete detector;
-
   delete theG4ProcessTypeEnumerator;
-  
-  delete myG4TrackToParticleID;
 }
 
 void MuonSensitiveDetector::update(const BeginOfEvent * i){
   clearHits();
-
   //----- Initialize variables to check if two steps belong to same hit
   thePV = nullptr;
   theDetUnitId = 0;
   theTrackID = 0;
-
 }
-
-void MuonSensitiveDetector::update(const  ::EndOfEvent *)
-{}
-
 
 void MuonSensitiveDetector::clearHits()
 {
-  LogDebug("MuonSimDebug") << "MuonSensitiveDetector::clearHits"<<std::endl;
+  LogDebug("MuonSimDebug") << "MuonSensitiveDetector::clearHits";
   slaveMuon->Initialize();
 }
 
 bool MuonSensitiveDetector::ProcessHits(G4Step * aStep, G4TouchableHistory * ROhist)
 {
-  LogDebug("MuonSimDebug") <<" MuonSensitiveDetector::ProcessHits "<<InitialStepPosition(aStep,WorldCoordinates)<<std::endl;
-
- // TimeMe t1( theHitTimer, false);
+  LogDebug("MuonSimDebug") <<" MuonSensitiveDetector::ProcessHits "
+			   <<InitialStepPosition(aStep,WorldCoordinates);
 
   if (aStep->GetTotalEnergyDeposit()>0.){
     // do not count neutrals that are killed by User Limits MinEKine
+    //---VI: this is incorrect, neutral particle, like neutron may have local
+    //       energy deposit, which potentially may make a hit
     if( aStep->GetTrack()->GetDynamicParticle()->GetCharge() != 0 ){
   
       if (newHit(aStep)) {
@@ -135,23 +124,18 @@ bool MuonSensitiveDetector::ProcessHits(G4Step * aStep, G4TouchableHistory * ROh
 	createHit(aStep);
       } else {
 	updateHit(aStep);
-      }    
-      return true;
-    } else {
-      storeVolumeAndTrack(aStep);
-      return false;
+      } 
     }
   }
-  return false;
+  return true;
 }
 
 uint32_t MuonSensitiveDetector::setDetUnitId(const G4Step * aStep)
 { 
-  //  G4VPhysicalVolume * pv = aStep->GetPreStepPoint()->GetPhysicalVolume();
   MuonBaseNumber num = g4numbering->PhysicalVolumeToBaseNumber(aStep);
 
+#ifdef DebugLog
   std::stringstream MuonBaseNumber; 
-  // LogDebug :: Print MuonBaseNumber
   MuonBaseNumber << "MuonNumbering :: number of levels = "<<num.getLevels()<<std::endl;
   MuonBaseNumber << "Level \t SuperNo \t BaseNo"<<std::endl;
   for (int level=1;level<=num.getLevels();level++) {
@@ -161,248 +145,169 @@ uint32_t MuonSensitiveDetector::setDetUnitId(const G4Step * aStep)
   std::string MuonBaseNumbr = MuonBaseNumber.str();
 
   LogDebug("MuonSimDebug") <<"MuonSensitiveDetector::setDetUnitId :: "<<MuonBaseNumbr;
-  LogDebug("MuonSimDebug") <<"MuonSensitiveDetector::setDetUnitId :: MuonDetUnitId = "<<(numbering->baseNumberToUnitNumber(num));
+  LogDebug("MuonSimDebug") <<"MuonSensitiveDetector::setDetUnitId :: MuonDetUnitId = "
+			   <<(numbering->baseNumberToUnitNumber(num));
+#endif
   return numbering->baseNumberToUnitNumber(num);
 }
 
+bool MuonSensitiveDetector::newHit(const G4Step * aStep){
 
-Local3DPoint MuonSensitiveDetector::toOrcaRef(Local3DPoint in ,G4Step * step){
-  if (theRotation !=nullptr ) {
-    return theRotation->transformPoint(in,step);
-  }
-  return (in);
+  return (!theHit || (aStep->GetTrack()->GetTrackID() != theTrackID) 
+	  || (aStep->GetPreStepPoint()->GetPhysicalVolume() != thePV) 
+	  || (setDetUnitId(aStep) !=  theDetUnitId));
 }
 
-Local3DPoint MuonSensitiveDetector::toOrcaUnits(const Local3DPoint& in){
-  return Local3DPoint(in.x()/cm,in.y()/cm,in.z()/cm);
-}
-
-Global3DPoint MuonSensitiveDetector::toOrcaUnits(const Global3DPoint& in){
-  return Global3DPoint(in.x()/cm,in.y()/cm,in.z()/cm);
-}
-
-void MuonSensitiveDetector::storeVolumeAndTrack(const G4Step * aStep) {
-  G4VPhysicalVolume* pv = aStep->GetPreStepPoint()->GetPhysicalVolume();
-  G4Track * t  = aStep->GetTrack();
-  thePV=pv;
-  theTrackID=t->GetTrackID();
-}
-
-bool MuonSensitiveDetector::newHit(G4Step * aStep){
-  
-  G4VPhysicalVolume* pv = aStep->GetPreStepPoint()->GetPhysicalVolume();
-  G4Track * t  = aStep->GetTrack();
-  uint32_t currentUnitId=setDetUnitId(aStep);
-  LogDebug("MuonSimDebug") <<"MuonSensitiveDetector::newHit :: currentUnitId = "<<currentUnitId;
-  unsigned int currentTrackID=t->GetTrackID();
-  //unsigned int currentEventID=G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
-  bool changed=((pv!=thePV) || 
-		(currentUnitId!=theDetUnitId) || 
-		(currentTrackID!=theTrackID));
-  return changed;
-}
-
-void MuonSensitiveDetector::createHit(G4Step * aStep){
-
-  G4Track * theTrack  = aStep->GetTrack(); 
+void MuonSensitiveDetector::createHit(const G4Step * aStep){
 
   Local3DPoint theEntryPoint;
   Local3DPoint theExitPoint;
 
   if (detector->isBarrel()) {
-    theEntryPoint= toOrcaUnits(toOrcaRef(InitialStepPositionVsParent(aStep,1),aStep)); // 1 level up
-    theExitPoint= toOrcaUnits(toOrcaRef(FinalStepPositionVsParent(aStep,1),aStep));  
+    // 1 levels up
+    theEntryPoint = cmsUnits(theRotation->transformPoint(InitialStepPositionVsParent(aStep,1),aStep));
+    theExitPoint  = cmsUnits(theRotation->transformPoint(FinalStepPositionVsParent(aStep,1),aStep));
   } else if (detector->isEndcap()) {
     // save local z at current level
-    theEntryPoint= toOrcaUnits(toOrcaRef(InitialStepPosition(aStep,LocalCoordinates),aStep));
-    theExitPoint= toOrcaUnits(toOrcaRef(FinalStepPosition(aStep,LocalCoordinates),aStep));
-    float zentry = theEntryPoint.z();
-    float zexit = theExitPoint.z();
-    Local3DPoint tempEntryPoint= toOrcaUnits(toOrcaRef(InitialStepPositionVsParent(aStep,4),aStep)); // 4 levels up
-    Local3DPoint tempExitPoint= toOrcaUnits(toOrcaRef(FinalStepPositionVsParent(aStep,4),aStep));
+    theEntryPoint = theRotation->transformPoint(InitialStepPosition(aStep,LocalCoordinates),aStep);
+    theExitPoint  = theRotation->transformPoint(FinalStepPosition(aStep,LocalCoordinates),aStep);
+    float zentry  = theEntryPoint.z();
+    float zexit   = theExitPoint.z();
+    // 4 levels up
+    Local3DPoint tempEntry = theRotation->transformPoint(InitialStepPositionVsParent(aStep,4),aStep);
+    Local3DPoint tempExit  = theRotation->transformPoint(FinalStepPositionVsParent(aStep,4),aStep);
     // reset local z from z wrt deep-parent volume to z wrt low-level volume
-    theEntryPoint = Local3DPoint( tempEntryPoint.x(), tempEntryPoint.y(), zentry );
-    theExitPoint  = Local3DPoint( tempExitPoint.x(), tempExitPoint.y(), zexit );
+    theEntryPoint = cmsUnits(Local3DPoint( tempEntry.x(), tempEntry.y(), zentry ));
+    theExitPoint  = cmsUnits(Local3DPoint( tempExit.x(),  tempExit.y(),  zexit ));
   } else {
-    theEntryPoint= toOrcaUnits(toOrcaRef(InitialStepPosition(aStep,LocalCoordinates),aStep));
-    theExitPoint= toOrcaUnits(toOrcaRef(FinalStepPosition(aStep,LocalCoordinates),aStep)); 
+    theEntryPoint = cmsUnits(theRotation->transformPoint(InitialStepPosition(aStep,LocalCoordinates),aStep));
+    theExitPoint  = cmsUnits(theRotation->transformPoint(FinalStepPosition(aStep,LocalCoordinates),aStep)); 
   }
 
-  float thePabs             = aStep->GetPreStepPoint()->GetMomentum().mag()/GeV;
-  float theTof              = aStep->GetPreStepPoint()->GetGlobalTime()/nanosecond;
-  float theEnergyLoss       = aStep->GetTotalEnergyDeposit()/GeV;
-  //  int theParticleType     = theTrack->GetDefinition()->GetPDGEncoding();
-  int theParticleType     = myG4TrackToParticleID->particleID(theTrack);
-  G4ThreeVector gmd  = aStep->GetPreStepPoint()->GetMomentumDirection();
-  G4ThreeVector lmd = ((const G4TouchableHistory *)(aStep->GetPreStepPoint()->GetTouchable()))->GetHistory()
-    ->GetTopTransform().TransformAxis(gmd);
-  Local3DPoint lnmd = toOrcaRef(ConvertToLocal3DPoint(lmd),aStep);
+  const G4Track* theTrack = aStep->GetTrack(); 
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint();
+
+  float thePabs       = preStepPoint->GetMomentum().mag()/CLHEP::GeV;
+  float theTof        = preStepPoint->GetGlobalTime()/CLHEP::nanosecond;
+  float theEnergyLoss = aStep->GetTotalEnergyDeposit()/CLHEP::GeV;
+  int theParticleType = G4TrackToParticleID::particleID(theTrack);
+
+  theDetUnitId = setDetUnitId(aStep);
+  thePV = preStepPoint->GetPhysicalVolume();
+  theTrackID = theTrack->GetTrackID();
+
+  // convert momentum direction it to local frame
+  const G4ThreeVector& gmd  = preStepPoint->GetMomentumDirection();
+  G4ThreeVector lmd = ((G4TouchableHistory *)(preStepPoint->GetTouchable()))->GetHistory()
+      ->GetTopTransform().TransformAxis(gmd);
+  Local3DPoint lnmd = ConvertToLocal3DPoint(lmd);
+  lnmd = theRotation->transformPoint(lnmd, aStep);
   float theThetaAtEntry = lnmd.theta();
   float thePhiAtEntry = lnmd.phi();
 
-  storeVolumeAndTrack( aStep );
-  theDetUnitId              = setDetUnitId(aStep);
-
-  Global3DPoint theGlobalPos;
-  if (printHits) {   
-    Local3DPoint theGlobalHelp = InitialStepPosition(aStep,WorldCoordinates);
-    theGlobalEntry = toOrcaUnits(Global3DPoint (theGlobalHelp.x(),theGlobalHelp.y(),theGlobalHelp.z()));
-
-    G4StepPoint * preStepPoint = aStep->GetPreStepPoint();
-    const G4TouchableHistory * theTouchable=(const G4TouchableHistory *)
-                                            (preStepPoint->GetTouchable());
-    theGlobalHelp=ConvertToLocal3DPoint(theTouchable->GetTranslation());
-    theGlobalPos = toOrcaUnits(Global3DPoint (theGlobalHelp.x(),theGlobalHelp.y(),theGlobalHelp.z()));
-    //    const G4RotationMatrix * theGlobalRot = theTouchable->GetRotation();
-  }
-  
-  LogDebug("MuonSimDebug") << "MuonSensitiveDetector::createHit UpdatablePSimHit"<<std::endl;
-
   theHit = new UpdatablePSimHit(theEntryPoint,theExitPoint,thePabs,theTof,
-                  theEnergyLoss,theParticleType,theDetUnitId,
-                  theTrackID,theThetaAtEntry,thePhiAtEntry,
-                  theG4ProcessTypeEnumerator->processId(theTrack->GetCreatorProcess()));
+				theEnergyLoss,theParticleType,theDetUnitId,
+				theTrackID,theThetaAtEntry,thePhiAtEntry,
+				theG4ProcessTypeEnumerator->processId(theTrack->GetCreatorProcess()));
 
-
-  LogDebug("MuonSimDebug") <<"=== NEW ==================> ELOSS   = "<<theEnergyLoss<<" "
-       <<thePV->GetLogicalVolume()->GetName()<<std::endl;
-  const G4VProcess* p = aStep->GetPostStepPoint()->GetProcessDefinedStep();
-  const G4VProcess* p2 = aStep->GetPreStepPoint()->GetProcessDefinedStep();
-  if (p)
-    LogDebug("MuonSimDebug") <<" POST PROCESS = "<<p->GetProcessName()<<std::endl;
-  if (p2)
-    LogDebug("MuonSimDebug") <<" PRE  PROCESS = "<<p2->GetProcessName()<<std::endl;
-  LogDebug("MuonSimDebug") << "newhit theta " << theThetaAtEntry<<std::endl;
-  LogDebug("MuonSimDebug") << "newhit phi   " << thePhiAtEntry<<std::endl;
-  LogDebug("MuonSimDebug") << "newhit pabs  " << thePabs<<std::endl;
-  LogDebug("MuonSimDebug") << "newhit tof   " << theTof<<std::endl;
-  LogDebug("MuonSimDebug") << "newhit track " << theTrackID<<std::endl;
-  LogDebug("MuonSimDebug") << "newhit entry " << theEntryPoint<<std::endl;
-  LogDebug("MuonSimDebug") << "newhit exit  " << theExitPoint<<std::endl;
-  LogDebug("MuonSimDebug") << "newhit eloss " << theEnergyLoss << std::endl;
-  LogDebug("MuonSimDebug") << "newhit detid " << theDetUnitId<<std::endl;
-  LogDebug("MuonSimDebug") << "newhit delta " << (theExitPoint-theEntryPoint)<<std::endl;
-  LogDebug("MuonSimDebug") << "newhit deltu " << (theExitPoint-theEntryPoint).unit();
-  LogDebug("MuonSimDebug") << " " << (theExitPoint-theEntryPoint).mag()<<std::endl;
-  LogDebug("MuonSimDebug") << "newhit glob  " << theGlobalEntry<<std::endl;
-  LogDebug("MuonSimDebug") << "newhit dpos  " << theGlobalPos<<std::endl;
-  LogDebug("MuonSimDebug") << "newhit drot  " << std::endl;
-  //  theGlobalRot->print(LogDebug("MuonSimDebug"));
-
-
-  //
-  //----- SimTracks: Make it persistent?
-  //
-  int thePID = theTrack->GetDefinition()->GetPDGEncoding();
-  LogDebug("MuonSimDebug") << " checking simtrack " << thePID << " " << thePabs << " STenergyPersistentCut " << STenergyPersistentCut << std::endl;
-
-  if( thePabs*GeV > STenergyPersistentCut 
-      || ( abs(thePID) == 13 && STallMuonsPersistent ) ){
-    TrackInformation* info = getOrCreateTrackInformation(theTrack);
-    LogDebug("MuonSimDebug") <<" track leaving hit in muons made selected for persistency"<<std::endl;
-
+  // Make track persistent
+  int thePID = std::abs(theTrack->GetDefinition()->GetPDGEncoding());
+  //---VI - in parameters cut in energy is declared but applied to momentum
+  if(thePabs > ePersistentCutGeV || ( thePID == 13 && allMuonsPersistent ) ){
+    TrackInformation* info = cmsTrackInformation(theTrack);
     info->storeTrack(true);
   }
-     
+
+#ifdef DebugLog
+  edm::LogVerbatim("MuonSimDebug") <<"=== NEW Muon hit for "<< GetName() 
+				   << " Edep(GeV)= " << theEnergyLoss
+				   <<" " <<thePV->GetLogicalVolume()->GetName();
+  const G4VProcess* p = aStep->GetPostStepPoint()->GetProcessDefinedStep();
+  const G4VProcess* p2 = preStepPoint->GetProcessDefinedStep();
+  G4String sss = "";
+  if (p) sss += " POST PROCESS: " + p->GetProcessName();
+  if (p2)sss += ";  PRE  PROCESS: " + p2->GetProcessName();
+  if("" != sss) edm::LogVerbatim("MuonSimDebug") << sss;
+  edm::LogVerbatim("MuonSimDebug") << " theta= " << theThetaAtEntry
+				   << " phi= " << thePhiAtEntry
+				   << " Pabs(GeV/c)  " << thePabs
+				   << " Eloss(GeV)= " << theEnergyLoss
+				   << " Tof(ns)=  " << theTof
+				   << " trackID= " << theTrackID
+				   << " detID= " << theDetUnitId
+				   << "\n Local:  entry " << theEntryPoint 
+				   << " exit " << theExitPoint
+				   << " delta " << (theExitPoint-theEntryPoint)
+				   << "\n Global: entry " << preStepPoint->GetPosition() 
+				   << " exit " << aStep->GetPostStepPoint()->GetPosition();
+#endif
 }
 
-void MuonSensitiveDetector::updateHit(G4Step * aStep){
-  //  float thePabs             = aStep->GetPreStepPoint()->GetMomentum().mag()/GeV;
-  //  Local3DPoint theEntryPoint= InitialStepPosition(aStep,LocalCoordinates);  
-
+void MuonSensitiveDetector::updateHit(const G4Step * aStep){
 
   Local3DPoint theExitPoint;
 
   if (detector->isBarrel()) {
-    theExitPoint= toOrcaUnits(toOrcaRef(FinalStepPositionVsParent(aStep,1),aStep));  
+    theExitPoint = cmsUnits(theRotation->transformPoint(FinalStepPositionVsParent(aStep,1),aStep));  
   } else if (detector->isEndcap()) {
     // save local z at current level
-    theExitPoint= toOrcaUnits(toOrcaRef(FinalStepPosition(aStep,LocalCoordinates),aStep));
-    float zexit = theExitPoint.z();
-    Local3DPoint tempExitPoint= toOrcaUnits(toOrcaRef(FinalStepPositionVsParent(aStep,4),aStep));
-    theExitPoint  = Local3DPoint( tempExitPoint.x(), tempExitPoint.y(), zexit );
+    theExitPoint = theRotation->transformPoint(FinalStepPosition(aStep,LocalCoordinates),aStep);
+    float zexit  = theExitPoint.z();
+    Local3DPoint tempExitPoint = theRotation->transformPoint(FinalStepPositionVsParent(aStep,4),aStep);
+    theExitPoint = cmsUnits(Local3DPoint( tempExitPoint.x(), tempExitPoint.y(), zexit));
   } else {
-    theExitPoint= toOrcaUnits(toOrcaRef(FinalStepPosition(aStep,LocalCoordinates),aStep)); 
+    theExitPoint = cmsUnits(theRotation->transformPoint(FinalStepPosition(aStep,LocalCoordinates),aStep)); 
   }
 
-  float theEnergyLoss = aStep->GetTotalEnergyDeposit()/GeV;  
-
-  if( theHit == nullptr ){ 
-    std::cerr << "!!ERRROR in MuonSensitiveDetector::updateHit. It is called when there is no hit " << std::endl;
-  }
+  float theEnergyLoss = aStep->GetTotalEnergyDeposit()/CLHEP::GeV;  
 
   theHit->updateExitPoint(theExitPoint);
   theHit->addEnergyLoss(theEnergyLoss);
 
-  LogDebug("MuonSimDebug") <<"=== UPDATE ===============> ELOSS   = "<<theEnergyLoss<<" "
-       <<thePV->GetLogicalVolume()->GetName()<<std::endl;
+#ifdef DebugLog
+  edm::LogVerbatim("MuonSimDebug") <<"=== NEW Update muon hit for "<< GetName() 
+				   << " Edep(GeV)= " << theEnergyLoss
+				   <<" " <<thePV->GetLogicalVolume()->GetName();
   const G4VProcess* p = aStep->GetPostStepPoint()->GetProcessDefinedStep();
-  const G4VProcess* p2 = aStep->GetPreStepPoint()->GetProcessDefinedStep();
-  if (p)
-    LogDebug("MuonSimDebug") <<" POST PROCESS = "<<p->GetProcessName()<<std::endl;
-  if (p2)
-    LogDebug("MuonSimDebug") <<" PRE  PROCESS = "<<p2->GetProcessName()<<std::endl;
-  LogDebug("MuonSimDebug") << "updhit exit  " << theExitPoint<<std::endl;
-  LogDebug("MuonSimDebug") << "updhit eloss " << theHit->energyLoss() <<std::endl;
-  LogDebug("MuonSimDebug") << "updhit detid " << theDetUnitId<<std::endl;
-  LogDebug("MuonSimDebug") << "updhit delta " << (theExitPoint-theHit->entryPoint())<<std::endl;
-  LogDebug("MuonSimDebug") << "updhit deltu " << (theExitPoint-theHit->entryPoint()).unit();
-  LogDebug("MuonSimDebug") << " " << (theExitPoint-theHit->entryPoint()).mag()<<std::endl; 
-
+  const G4VProcess* p2 = preStepPoint->GetProcessDefinedStep();
+  G4String sss = "";
+  if (p) sss += " POST PROCESS: " + p->GetProcessName();
+  if (p2)sss += ";  PRE  PROCESS: " + p2->GetProcessName();
+  if("" != sss) edm::LogVerbatim("MuonSimDebug") << sss;
+  edm::LogVerbatim("MuonSimDebug") << " delEloss(GeV)= " << theEnergyLoss
+				   << " Tof(ns)=  " << theTof
+				   << " trackID= " << theTrackID
+				   << " detID= " << theDetUnitId
+				   << " exit " << theExitPoint;
+#endif
 }
 
 void MuonSensitiveDetector::saveHit(){
-
   if (theHit) {
     if (printHits) {
       thePrinter->startNewSimHit(detector->name());
       thePrinter->printId(theHit->detUnitId());
-      //      thePrinter->printTrack(theHit->trackId());
-      //thePrinter->printPabs(theHit->pabs());
-      //thePrinter->printEloss(theHit->energyLoss());
       thePrinter->printLocal(theHit->entryPoint(),theHit->exitPoint());
-      thePrinter->printGlobal(theGlobalEntry);
     }
+    // hit is included into hit collection
     slaveMuon->processHits(*theHit);
-    // seems the hit does not want to be deleted
-    // done by the hit collection?
     delete theHit;
-    theHit = nullptr; //set it to 0, because you are checking that is 0
-  }
-
-}
-
-TrackInformation* MuonSensitiveDetector::getOrCreateTrackInformation( const G4Track* gTrack)
-{
-  G4VUserTrackInformation* temp = gTrack->GetUserInformation();
-  if (temp == nullptr){
-    std::cerr <<" ERROR: no G4VUserTrackInformation available"<<std::endl;
-    abort();
-  }else{
-    TrackInformation* info = dynamic_cast<TrackInformation*>(temp);
-    if (info ==nullptr){
-      std::cerr <<" ERROR: TkSimTrackSelection: the UserInformation does not appear to be a TrackInformation"<<std::endl;
-      abort();
-    }
-    return info;
+    theHit = nullptr;
   }
 }
 
 void MuonSensitiveDetector::EndOfEvent(G4HCofThisEvent*)
 {
-//  TimeMe t("MuonSensitiveDetector::EndOfEvent", false);
- // LogDebug("MuonSimDebug") << "MuonSensitiveDetector::EndOfEvent saving last hit en event " << std::endl;
   saveHit();
 }
-
 
 void MuonSensitiveDetector::fillHits(edm::PSimHitContainer& cc, const std::string& hname){
   if (slaveMuon->name() == hname) { cc=slaveMuon->hits(); }
 }
 
-Local3DPoint MuonSensitiveDetector::InitialStepPositionVsParent(G4Step * currentStep, G4int levelsUp) {
+Local3DPoint MuonSensitiveDetector::InitialStepPositionVsParent(const G4Step * currentStep, G4int levelsUp) {
   
-  G4StepPoint * preStepPoint = currentStep->GetPreStepPoint();
+  const G4StepPoint * preStepPoint = currentStep->GetPreStepPoint();
   const G4ThreeVector& globalCoordinates = preStepPoint->GetPosition();
   
   const G4TouchableHistory * theTouchable=(const G4TouchableHistory *)
@@ -415,10 +320,10 @@ Local3DPoint MuonSensitiveDetector::InitialStepPositionVsParent(G4Step * current
   return ConvertToLocal3DPoint(localCoordinates); 
 }
  
-Local3DPoint MuonSensitiveDetector::FinalStepPositionVsParent(G4Step * currentStep, G4int levelsUp) {
+Local3DPoint MuonSensitiveDetector::FinalStepPositionVsParent(const G4Step* currentStep, G4int levelsUp) {
   
-  G4StepPoint * postStepPoint = currentStep->GetPostStepPoint();
-  G4StepPoint * preStepPoint  = currentStep->GetPreStepPoint();
+  const G4StepPoint * postStepPoint = currentStep->GetPostStepPoint();
+  const G4StepPoint * preStepPoint  = currentStep->GetPreStepPoint();
   const G4ThreeVector& globalCoordinates = postStepPoint->GetPosition();
     
   const G4TouchableHistory * theTouchable = (const G4TouchableHistory *)

--- a/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
@@ -41,7 +41,7 @@ MuonSensitiveDetector::MuonSensitiveDetector(const std::string& name,
     thePV(nullptr), theHit(nullptr), theDetUnitId(0), theTrackID(0), theManager(manager)
 {
   edm::ParameterSet m_MuonSD = p.getParameter<edm::ParameterSet>("MuonSD");
-  ePersistentCutGeV = m_MuonSD.getParameter<double>("EnergyThresholdForPersistency");//Default 1. GeV
+  ePersistentCutGeV = m_MuonSD.getParameter<double>("EnergyThresholdForPersistency")/CLHEP::GeV;//Default 1. GeV
   allMuonsPersistent = m_MuonSD.getParameter<bool>("AllMuonsPersistent");
   printHits  = m_MuonSD.getParameter<bool>("PrintHits");
   
@@ -125,6 +125,9 @@ bool MuonSensitiveDetector::ProcessHits(G4Step * aStep, G4TouchableHistory * ROh
       } else {
 	updateHit(aStep);
       } 
+    } else {
+      thePV = aStep->GetPreStepPoint()->GetPhysicalVolume();
+      theTrackID = aStep->GetTrack()->GetTrackID();
     }
   }
   return true;
@@ -154,8 +157,7 @@ uint32_t MuonSensitiveDetector::setDetUnitId(const G4Step * aStep)
 bool MuonSensitiveDetector::newHit(const G4Step * aStep){
 
   return (!theHit || (aStep->GetTrack()->GetTrackID() != theTrackID) 
-	  || (aStep->GetPreStepPoint()->GetPhysicalVolume() != thePV) 
-	  || (setDetUnitId(aStep) !=  theDetUnitId));
+	  || (aStep->GetPreStepPoint()->GetPhysicalVolume() != thePV));
 }
 
 void MuonSensitiveDetector::createHit(const G4Step * aStep){

--- a/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
+++ b/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
@@ -51,11 +51,12 @@ private:
     bool newHit   (const G4Step *);
     bool closeHit (const G4Step *);
 
+protected:
     void update(const BeginOfEvent *) override;
     void update(const BeginOfTrack *) override;
     void update(const BeginOfJob *) override;
 
-    Local3DPoint RotateAndScale(const Local3DPoint&);
+private:
 
     // data members initialised before run
     const SimTrackManager* theManager;

--- a/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
+++ b/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
@@ -56,7 +56,6 @@ private:
     void update(const BeginOfJob *) override;
 
     Local3DPoint RotateAndScale(const Local3DPoint&);
-    TrackInformation* getTrackInformation(const G4Track *);
 
     // data members initialised before run
     const SimTrackManager* theManager;

--- a/SimG4CMS/Tracker/src/FakeFrameRotation.cc
+++ b/SimG4CMS/Tracker/src/FakeFrameRotation.cc
@@ -1,5 +1,4 @@
 #include "SimG4CMS/Tracker/interface/FakeFrameRotation.h"
-#include "G4SystemOfUnits.hh"
 
 Local3DPoint FakeFrameRotation::transformPoint(const Local3DPoint & point,const G4VPhysicalVolume*) const {
   return Local3DPoint(point.x()*invcm,point.z()*invcm,-point.y()*invcm);

--- a/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
+++ b/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
@@ -308,13 +308,13 @@ void TkAccumulatingSensitiveDetector::updateHit(const G4Step * aStep)
     mySimHit->addEnergyLoss(theEnergyLoss);
     if (printHits) {
       globalExitPoint = ConvertToLocal3DPoint(aStep->GetPostStepPoint()->GetPosition());
-    }
-    LogDebug("TrackerSimDebug")
+      LogDebug("TrackerSimDebug")
       << " updateHit: for " << aStep->GetTrack()->GetDefinition()->GetParticleName()
       << " trackID= " << aStep->GetTrack()->GetTrackID() << " deltaEloss= " << theEnergyLoss
       << "\n Updated PSimHit: " << mySimHit->detUnitId() << " " << mySimHit->trackId()
       << " " << mySimHit->energyLoss() << " " << mySimHit->entryPoint() 
       << " " << mySimHit->exitPoint();
+    }
 }
 
 bool TkAccumulatingSensitiveDetector::newHit(const G4Step * aStep)

--- a/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
+++ b/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
@@ -134,10 +134,10 @@ void TkAccumulatingSensitiveDetector::update(const BeginOfTrack *bot){
 
 #ifdef DUMPPROCESSES
   if (gTrack->GetCreatorProcess()) {
-    edm::LogInfo("TrackerSimInfo")<<" -> PROCESS CREATOR : "
+    edm::LogVerbatim("TrackerSimInfo")<<" -> PROCESS CREATOR : "
 				  <<gTrack->GetCreatorProcess()->GetProcessName();
   } else {
-    edm::LogInfo("TrackerSimInfo") <<" -> No Creator process";
+    edm::LogVerbatim("TrackerSimInfo") <<" -> No Creator process";
   }
 #endif
 
@@ -154,23 +154,24 @@ void TkAccumulatingSensitiveDetector::update(const BeginOfTrack *bot){
   //
   // Check if in Tracker Volume
   //
-  if (pos.x()*pos.x() + pos.y()*pos.y() < rTracker2 && std::abs(pos.z()) < zTracker){
+  if (pos.x()*pos.x() + pos.y()*pos.y() < rTracker2 
+      && std::abs(pos.z()) < zTracker){
     //
     // inside the Tracker
     //
+    TrackInformation* info = nullptr;
     if (gTrack->GetKineticEnergy() > energyCut){
-      TrackInformation* info = getTrackInformation(gTrack);
+      info = cmsTrackInformation(gTrack);
       info->storeTrack(true);
     }
     //
     // Save History?
     //
     if (gTrack->GetKineticEnergy() > energyHistoryCut){
-      TrackInformation* info = getTrackInformation(gTrack);
+      if(!info) { info = cmsTrackInformation(gTrack); }
       info->putInHistory();
-      //LogDebug("TrackerSimDebug")<<" POINTER "<<info;
-      // <<" track inside the tracker selected for HISTORY";
-      // <<"Track ID (history track)= "<<gTrack->GetTrackID();
+      LogDebug("TrackerSimDebug")<<" Track inside the tracker selected for HISTORY"
+				 <<" Track ID= "<<gTrack->GetTrackID();
     }    
   }
 }
@@ -247,34 +248,18 @@ void TkAccumulatingSensitiveDetector::createHit(const G4Step * aStep)
     // otherwise, get to the mother
     unsigned int theTrackIDInsideTheSimHit=theTrackID;
     
-    G4VUserTrackInformation * info = theTrack->GetUserInformation();
-    if (info == nullptr) {
-      edm::LogWarning("TkAccumulatingSensitiveDetector::createHit") 
-	<< " no UserTrackInformation available for trackID= " << theTrackID;
-      throw cms::Exception("TkAccumulatingSensitiveDetector::createHit")
-	<< " cannot handle hits for tracking in " << GetName();
+    const TrackInformation* temp = cmsTrackInformation(theTrack);
+    if (!temp->storeTrack()) {
+      // Go to the mother!
+      theTrackIDInsideTheSimHit = theTrack->GetParentID();
+      LogDebug("TrackerSimDebug")
+	<< " TkAccumulatingSensitiveDetector::createHit(): setting the TrackID from "
+	<< theTrackIDInsideTheSimHit
+	<< " to the mother one " << theTrackIDInsideTheSimHit << " " << theEnergyLoss;
     } else {
-      TrackInformation * temp = dynamic_cast<TrackInformation* >(info);
-      if (temp ==nullptr) {
-	edm::LogWarning("TkAccumulatingSensitiveDetector::createHit") 
-	  << " G4VUserTrackInformation is not a TrackInformation for trackID= " 
-	  << theTrackID;
-	throw cms::Exception("TkAccumulatingSensitiveDetector::createHit")
-	  << " cannot handle hits for tracking in " << GetName();
-      } else {
-	if (temp->storeTrack() == false) {
-	  // Go to the mother!
-	  theTrackIDInsideTheSimHit = theTrack->GetParentID();
-	  LogDebug("TrackerSimDebug")
-	    << " TkAccumulatingSensitiveDetector::createHit(): setting the TrackID from "
-	    << theTrackIDInsideTheSimHit
-	    << " to the mother one " << theTrackIDInsideTheSimHit << " " << theEnergyLoss;
-	} else {
-	  LogDebug("TrackerSimDebug")
-	    << " TkAccumulatingSensitiveDetector:createHit(): leaving the current TrackID " 
-	    << theTrackIDInsideTheSimHit;
-	}
-      }
+      LogDebug("TrackerSimDebug")
+	<< " TkAccumulatingSensitiveDetector:createHit(): leaving the current TrackID " 
+	<< theTrackIDInsideTheSimHit;
     }
         
     const G4ThreeVector& gmd  = preStepPoint->GetMomentumDirection();
@@ -298,9 +283,9 @@ void TkAccumulatingSensitiveDetector::createHit(const G4Step * aStep)
       globalEntryPoint = ConvertToLocal3DPoint(preStepPoint->GetPosition());
       globalExitPoint  = ConvertToLocal3DPoint(aStep->GetPostStepPoint()->GetPosition());
       // in CMS unit (GeV)
-      px  = preStepPoint->GetMomentum().x()/GeV;
-      py  = preStepPoint->GetMomentum().y()/GeV;
-      pz  = preStepPoint->GetMomentum().z()/GeV;
+      px  = preStepPoint->GetMomentum().x()/CLHEP::GeV;
+      py  = preStepPoint->GetMomentum().y()/CLHEP::GeV;
+      pz  = preStepPoint->GetMomentum().z()/CLHEP::GeV;
       oldVolume = preStepPoint->GetPhysicalVolume();
       pname = theTrack->GetDefinition()->GetParticleName();
       LogDebug("TrackerSimDebug")<< " Created PSimHit: " << pname
@@ -391,30 +376,6 @@ void TkAccumulatingSensitiveDetector::clearHits()
 {
   slaveLowTof.get()->Initialize();
   slaveHighTof.get()->Initialize();
-}
-
-TrackInformation* TkAccumulatingSensitiveDetector::getTrackInformation(const G4Track* gTrack){
-  TrackInformation* info = nullptr;
-  G4VUserTrackInformation* temp = gTrack->GetUserInformation();
-  if (temp == nullptr){
-    edm::LogWarning("TkAccumulatingSensitiveDetector::getTrackInformation") 
-      <<" ERROR: no G4VUserTrackInformation available for track " 
-      << gTrack->GetTrackID() << " Ekin(MeV)= " << gTrack->GetKineticEnergy()
-      << "  " << gTrack->GetDefinition()->GetParticleName();
-    throw cms::Exception("TkAccumulatingSensitiveDetector::getTrackInformation")
-      << " cannot handle hits for tracking in " << GetName();
-  }else{
-    info = dynamic_cast<TrackInformation*>(temp);
-    if (info == nullptr){
-      edm::LogWarning("TkAccumulatingSensitiveDetector::getTrackInformation") 
-	<< " G4VUserTrackInformation is not a TrackInformation for " 
-	<<"TrackID= " << gTrack->GetTrackID() << " Ekin(MeV)= " << gTrack->GetKineticEnergy()
-	<< "  " << gTrack->GetDefinition()->GetParticleName();
-      throw cms::Exception("TkAccumulatingSensitiveDetector::getTrackInformation")
-	<< " cannot handle hits for tracking in " << GetName();
-    }
-  }
-  return info;
 }
 
 void TkAccumulatingSensitiveDetector::fillHits(edm::PSimHitContainer& cc, const std::string& hname){

--- a/SimG4CMS/Tracker/src/TrackerFrameRotation.cc
+++ b/SimG4CMS/Tracker/src/TrackerFrameRotation.cc
@@ -1,5 +1,4 @@
 #include "SimG4CMS/Tracker/interface/TrackerFrameRotation.h"
-#include "G4SystemOfUnits.hh"
 
 Local3DPoint TrackerFrameRotation::transformPoint(const Local3DPoint & point,const G4VPhysicalVolume*) const {
   return Local3DPoint(point.x()*invcm,point.y()*invcm,point.z()*invcm);

--- a/SimG4Core/SensitiveDetector/BuildFile.xml
+++ b/SimG4Core/SensitiveDetector/BuildFile.xml
@@ -2,6 +2,7 @@
   <lib   name="1"/>
 </export>
 <use   name="SimG4Core/Geometry"/>
+<use   name="SimG4Core/Notification"/>
 <use   name="boost"/>
 <use   name="geant4core"/>
 <use   name="sigcpp"/>

--- a/SimG4Core/SensitiveDetector/interface/FrameRotation.h
+++ b/SimG4Core/SensitiveDetector/interface/FrameRotation.h
@@ -9,10 +9,12 @@ class FrameRotation
 {
 public:
 
-    static constexpr double invcm = 0.1; // from Geant4 unit of coordinates to CMS
+  // from Geant4 unit of coordinates to CMS
+  static constexpr double invcm = 0.1;
 
-    virtual ~FrameRotation() = default;
-    virtual Local3DPoint transformPoint(const Local3DPoint &,const G4VPhysicalVolume *v=nullptr) const = 0;
+  virtual ~FrameRotation() = default;
+
+  virtual Local3DPoint transformPoint(const Local3DPoint &,const G4VPhysicalVolume *v=nullptr) const = 0;
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -4,13 +4,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
-//#include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
+#include "SimG4Core/Notification/interface/TrackInformation.h"
 
 #include "G4VSensitiveDetector.hh"
 
 #include <string>
+#include <cstdint>
 
+class G4Track;
 class G4Step;
 class G4HCofThisEvent;
 class G4TouchableHistory;
@@ -22,7 +24,7 @@ class SensitiveDetector : public G4VSensitiveDetector
 public:
   explicit SensitiveDetector(const std::string & iname, 
                              const DDCompactView & cpv,
-			     const SensitiveDetectorCatalog & ,
+			     const SensitiveDetectorCatalog &,
 			     edm::ParameterSet const & p);
   ~SensitiveDetector() override;
 
@@ -37,6 +39,7 @@ public:
  
 protected:
 
+  // generic geometry methods, all coordinates in mm
   enum coordinates {WorldCoordinates, LocalCoordinates};
   Local3DPoint InitialStepPosition(const G4Step * step, coordinates) const;
   Local3DPoint FinalStepPosition(const G4Step * step, coordinates) const;
@@ -49,6 +52,8 @@ protected:
   
   void setNames(const std::vector<std::string>&);
   void NaNTrap(const G4Step* step ) const;
+
+  TrackInformation* cmsTrackInformation(const G4Track* aTrack);
     
 private:
 


### PR DESCRIPTION
This PR includes clean-ups for muon Geant4 sensitive detectors and additional modifications in the base class, tracker and calo sensitive detectors:

1) TrackInformation object access is implemented in the base class and it is used in Calo, Tracker, Muon derived classes (removed multiple implementations of the same code)
2) Fixed dependences between these packages - removed circular dependence between SimG4CMS/SimMuon and SimG4Core/Application, added few really needed dependencies
3) Unified transformation from Geant4 space coordinates to CMS coordinates in muon and and tracker 
4) Use "#include cstdint" instead of boost
5) In MuonSensitiveDetector there were computations needed only for debug printout, these computations are protected by #ifdef 
6) Use LogVerbatim and LogDebug where possible, removed abort() and cerr, use cms exceptions instead
7) Use const pointers to Geant4 objects
8) clean up Observer interface - make update() methods protected
9) removed unnecessary methods, header, unreasonable comments, old commented lines and add new comments

Correctness of this PR means no change of the results.
 