### PR TITLE
Bug fixed in SiStripBadComponentInfo

### DIFF
--- a/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.cc
@@ -223,9 +223,9 @@ void SiStripBadComponentInfo::fillBadComponentMaps(int xbin,int component,SiStri
   }
   if (BC.BadFibers){ 
     int ntot = std::bitset<16>(BC.BadFibers&0x7).count();
-    float val = (mapBadStrip.find(index)!=mapBadStrip.end()) ? mapBadStrip.at(index) : 0.; 
+    float val = (mapBadFiber.find(index)!=mapBadFiber.end()) ? mapBadFiber.at(index) : 0.; 
     val+= ntot;
-    mapBadStrip[index]=val;
+    mapBadFiber[index]=val;
   }   
 }
 void SiStripBadComponentInfo::createSummary(MonitorElement* me,const std::map<std::pair<int,int>,float >& map) {

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
@@ -21,9 +21,9 @@ siStripQTester = cms.EDAnalyzer("QualityTester",
     getQualityTestsFromFile = cms.untracked.bool(True)
 )
 
-from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
-siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
-siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
+#from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
+#siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
+#siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
 
 from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
 siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
@@ -31,7 +31,7 @@ siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
        cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
        cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
-       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
+#       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
        cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
        )
 siStripQualityESProducer.ReduceGranularity = cms.bool(False)

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
@@ -32,9 +32,9 @@ siStripQTesterHI = cms.EDAnalyzer("QualityTester",
     getQualityTestsFromFile = cms.untracked.bool(True)
 )
 
-from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
-siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
-siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
+#from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
+#siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
+#siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
 
 from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
 siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
@@ -42,7 +42,7 @@ siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
        cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
        cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
-       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
+#       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
        cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
        )
 siStripQualityESProducer.ReduceGranularity = cms.bool(False)

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
@@ -37,9 +37,9 @@ siStripQTester = cms.EDAnalyzer("QualityTester",
     getQualityTestsFromFile = cms.untracked.bool(True)
 )
 
-from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
-siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
-siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
+#from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
+#siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
+#siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
 
 from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
 siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
@@ -47,7 +47,7 @@ siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
        cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
        cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
-       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
+#       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
        cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
        )
 siStripQualityESProducer.ReduceGranularity = cms.bool(False)


### PR DESCRIPTION
Bug fixed in SiStripBadComponentInfo.cc where bad fiber histogram never git filled; Commented out the addition of BadChannels from FED errors as SiStripESProducer is not working in Harvesting step for the time being Once the issue is solved we shall put it back
@mmusich @fioriNTU @jandrea 