### PR TITLE
[L1T][DQMOffline] Minor adjustments to Jets & energy sums plots

### DIFF
--- a/DQMOffline/L1Trigger/python/L1TCommon.py
+++ b/DQMOffline/L1Trigger/python/L1TCommon.py
@@ -1,0 +1,15 @@
+def generateEfficiencyStrings(variables, plots):
+    stringTemplate = "{plot} " + \
+        "'{var} efficiency; Offline E_{{T}}^{{miss}} (GeV); {var} efficiency'" + \
+        " {num_path} {den_path}"
+    for variable, thresholds in variables.iteritems():
+        for plot in plots[variable]:
+            for threshold in thresholds:
+                plotName = '{0}_threshold_{1}'.format(plot, threshold)
+                varName = plot.replace('efficiency', '')
+                yield stringTemplate.format(
+                    var=varName,
+                    plot=plotName,
+                    num_path='efficiency_raw/' + plotName + '_Num',
+                    den_path='efficiency_raw/' + plotName + '_Den',
+                )

--- a/DQMOffline/L1Trigger/python/L1TEtSumEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumEfficiency_cfi.py
@@ -15,58 +15,29 @@ plots = {
     'htt': ['efficiencyHTT'],
 }
 
-allEfficiencyPlots = []
-add_plot = allEfficiencyPlots.append
-for variable, thresholds in variables.iteritems():
-    for plot in plots[variable]:
-        for threshold in thresholds:
-            plotName = '{0}_threshold_{1}'.format(plot, threshold)
-            add_plot(plotName)
+from DQMOffline.L1Trigger.L1TCommon import generateEfficiencyStrings
 
-from DQMOffline.L1Trigger.L1TEfficiencyHarvesting_cfi import l1tEfficiencyHarvesting
-l1tEtSumEfficiency = l1tEfficiencyHarvesting.clone(
-    plotCfgs=cms.untracked.VPSet(
-        cms.untracked.PSet(
-            numeratorDir=cms.untracked.string("L1T/L1TObjects/L1TEtSum/L1TriggerVsReco/efficiency_raw"),
-            outputDir=cms.untracked.string("L1T/L1TObjects/L1TEtSum/L1TriggerVsReco"),
-            numeratorSuffix=cms.untracked.string("_Num"),
-            denominatorSuffix=cms.untracked.string("_Den"),
-            plots=cms.untracked.vstring(allEfficiencyPlots)
-        ),
-    )
+efficiencyStrings = list(generateEfficiencyStrings(variables, plots))
+
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+l1tEtSumEfficiency = DQMEDHarvester(
+    "DQMGenericClient",
+    commands=cms.vstring(),
+    resolution=cms.vstring(),
+    subDirs=cms.untracked.vstring('L1T/L1TObjects/L1TEtSum/L1TriggerVsReco'),
+    efficiency=cms.vstring(),
+    efficiencyProfile=cms.untracked.vstring(efficiencyStrings),
 )
 
-l1tEtSumEmuEfficiency = l1tEfficiencyHarvesting.clone(
-    plotCfgs=cms.untracked.VPSet(
-        cms.untracked.PSet(
-            numeratorDir=cms.untracked.string("L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco/efficiency_raw"),
-            outputDir=cms.untracked.string("L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco"),
-            numeratorSuffix=cms.untracked.string("_Num"),
-            denominatorSuffix=cms.untracked.string("_Den"),
-            plots=cms.untracked.vstring(allEfficiencyPlots)
-        ),
-    )
+l1tEtSumEmuEfficiency = l1tEtSumEfficiency.clone(
+    subDirs=cms.untracked.vstring(
+        'L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco'),
 )
 
 # modifications for the pp reference run
 variables_HI = variables
-
-allEfficiencyPlots_HI = []
-add_plot = allEfficiencyPlots_HI.append
-for variable, thresholds in variables_HI.iteritems():
-    for plot in plots[variable]:
-        for threshold in thresholds:
-            plotName = '{0}_threshold_{1}'.format(plot, threshold)
-            add_plot(plotName)
+efficiencyStrings_HI = list(generateEfficiencyStrings(variables_HI, plots))
 
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
-ppRef_2017.toModify(l1tEtSumEfficiency,
-    plotCfgs = {
-        0:dict(plots = allEfficiencyPlots_HI),
-    }
-)
-ppRef_2017.toModify(l1tEtSumEmuEfficiency,
-    plotCfgs = {
-        0:dict(plots = allEfficiencyPlots_HI),
-    }
-)
+ppRef_2017.toModify(l1tEtSumEfficiency, efficiency=efficiencyStrings_HI)
+ppRef_2017.toModify(l1tEtSumEmuEfficiency, efficiency=efficiencyStrings_HI)

--- a/DQMOffline/L1Trigger/python/L1TEtSumEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumEfficiency_cfi.py
@@ -39,5 +39,5 @@ variables_HI = variables
 efficiencyStrings_HI = list(generateEfficiencyStrings(variables_HI, plots))
 
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
-ppRef_2017.toModify(l1tEtSumEfficiency, efficiency=efficiencyStrings_HI)
-ppRef_2017.toModify(l1tEtSumEmuEfficiency, efficiency=efficiencyStrings_HI)
+ppRef_2017.toModify(l1tEtSumEfficiency, efficiencyProfile=efficiencyStrings_HI)
+ppRef_2017.toModify(l1tEtSumEmuEfficiency, efficiencyProfile=efficiencyStrings_HI)

--- a/DQMOffline/L1Trigger/python/L1TJetEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TJetEfficiency_cfi.py
@@ -11,59 +11,30 @@ plots = {
         "efficiencyJetEt_HB_HE"],
 }
 
-allEfficiencyPlots = []
-add_plot = allEfficiencyPlots.append
-for variable, thresholds in variables.iteritems():
-    for plot in plots[variable]:
-        for threshold in thresholds:
-            plotName = '{0}_threshold_{1}'.format(plot, threshold)
-            add_plot(plotName)
+from DQMOffline.L1Trigger.L1TCommon import generateEfficiencyStrings
+efficiencyStrings = list(generateEfficiencyStrings(variables, plots))
 
-from DQMOffline.L1Trigger.L1TEfficiencyHarvesting_cfi import l1tEfficiencyHarvesting
-l1tJetEfficiency = l1tEfficiencyHarvesting.clone(
-    plotCfgs=cms.untracked.VPSet(
-        cms.untracked.PSet(
-            numeratorDir=cms.untracked.string("L1T/L1TObjects/L1TJet/L1TriggerVsReco/efficiency_raw"),
-            outputDir=cms.untracked.string("L1T/L1TObjects/L1TJet/L1TriggerVsReco"),
-            numeratorSuffix=cms.untracked.string("_Num"),
-            denominatorSuffix=cms.untracked.string("_Den"),
-            plots=cms.untracked.vstring(allEfficiencyPlots)
-        ),
-    )
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+l1tJetEfficiency = DQMEDHarvester(
+    "DQMGenericClient",
+    commands=cms.vstring(),
+    resolution=cms.vstring(),
+    subDirs=cms.untracked.vstring('L1T/L1TObjects/L1TJet/L1TriggerVsReco'),
+    efficiency=cms.vstring(),
+    efficiencyProfile=cms.untracked.vstring(efficiencyStrings),
 )
 
-l1tJetEmuEfficiency = l1tEfficiencyHarvesting.clone(
-    plotCfgs=cms.untracked.VPSet(
-        cms.untracked.PSet(
-            numeratorDir=cms.untracked.string("L1TEMU/L1TObjects/L1TJet/L1TriggerVsReco/efficiency_raw"),
-            outputDir=cms.untracked.string("L1TEMU/L1TObjects/L1TJet/L1TriggerVsReco"),
-            numeratorSuffix=cms.untracked.string("_Num"),
-            denominatorSuffix=cms.untracked.string("_Den"),
-            plots=cms.untracked.vstring(allEfficiencyPlots)
-        ),
-    )
+l1tJetEmuEfficiency = l1tJetEfficiency.clone(
+    subDirs=cms.untracked.vstring(
+        'L1TEMU/L1TObjects/L1TJet/L1TriggerVsReco'),
 )
 
 # modifications for the pp reference run
 variables_HI = variables
 variables_HI['jet'] = L1TStep1.jetEfficiencyThresholds_HI
 
-allEfficiencyPlots_HI = []
-add_plot = allEfficiencyPlots_HI.append
-for variable, thresholds in variables_HI.iteritems():
-    for plot in plots[variable]:
-        for threshold in thresholds:
-            plotName = '{0}_threshold_{1}'.format(plot, threshold)
-            add_plot(plotName)
+efficiencyStrings_HI = list(generateEfficiencyStrings(variables_HI, plots))
 
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
-ppRef_2017.toModify(l1tJetEfficiency,
-    plotCfgs = {
-        0:dict(plots = allEfficiencyPlots_HI),
-    }
-)
-ppRef_2017.toModify(l1tJetEmuEfficiency,
-    plotCfgs = {
-        0:dict(plots = allEfficiencyPlots_HI),
-    }
-)
+ppRef_2017.toModify(l1tJetEfficiency, efficiency=efficiencyStrings_HI)
+ppRef_2017.toModify(l1tJetEmuEfficiency, efficiency=efficiencyStrings_HI)

--- a/DQMOffline/L1Trigger/python/L1TJetEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TJetEfficiency_cfi.py
@@ -36,5 +36,5 @@ variables_HI['jet'] = L1TStep1.jetEfficiencyThresholds_HI
 efficiencyStrings_HI = list(generateEfficiencyStrings(variables_HI, plots))
 
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
-ppRef_2017.toModify(l1tJetEfficiency, efficiency=efficiencyStrings_HI)
-ppRef_2017.toModify(l1tJetEmuEfficiency, efficiency=efficiencyStrings_HI)
+ppRef_2017.toModify(l1tJetEfficiency, efficiencyProfile=efficiencyStrings_HI)
+ppRef_2017.toModify(l1tJetEmuEfficiency, efficiencyProfile=efficiencyStrings_HI)

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -297,7 +297,12 @@ void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsig
   fillWithinLimits(h_resolutionPFMetNoMu_, resolutionPFMetNoMu);
   fillWithinLimits(h_resolutionMHT_, resolutionMHT);
   fillWithinLimits(h_resolutionETT_, resolutionETT);
-  fillWithinLimits(h_resolutionHTT_, resolutionHTT);
+  if (resolutionMHT < outOfBounds){
+    fillWithinLimits(h_resolutionMHT_, resolutionMHT);
+  }
+  if(resolutionHTT < outOfBounds){
+    fillWithinLimits(h_resolutionHTT_, resolutionHTT);
+  }
 
   fillWithinLimits(h_resolutionMETPhi_, resolutionMETPhi);
   fillWithinLimits(h_resolutionETMHFPhi_, resolutionETMHFPhi);
@@ -576,26 +581,24 @@ void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker
 
   // energy sum resolutions
   h_resolutionMET_ = ibooker.book1D("resolutionMET",
-      "MET resolution; (L1 E_{T}^{miss} - Offline E_{T}^{miss})/Offline E_{T}^{miss}; events", 50, -1, 1.5);
+      "MET resolution; (L1 E_{T}^{miss} - Offline E_{T}^{miss})/Offline E_{T}^{miss}; events", 70, -1.0, 2.5);
   h_resolutionETMHF_ = ibooker.book1D("resolutionETMHF",
-      "MET resolution (HF); (L1 E_{T}^{miss} - Offline E_{T}^{miss})/Offline E_{T}^{miss} (HF); events", 50, -1, 1.5);
+      "MET resolution (HF); (L1 E_{T}^{miss} - Offline E_{T}^{miss})/Offline E_{T}^{miss} (HF); events", 70, -1.0, 2.5);
   h_resolutionPFMetNoMu_ = ibooker.book1D("resolutionPFMetNoMu",
-          "PFMetNoMu resolution; (L1 E_{T}^{miss} - Offline E_{T}^{miss})/Offline E_{T}^{miss} (PFMetNoMu); events", 50, -1, 1.5);
-  h_resolutionMHT_ = ibooker.book1D("resolutionMHT", "MHT resolution; (L1 MHT - reco MHT)/reco MHT; events", 50, -1,
-      1.5);
-  h_resolutionETT_ = ibooker.book1D("resolutionETT", "ETT resolution; (L1 ETT - calo ETT)/calo ETT; events", 50, -1,
-      1.5);
+          "PFMetNoMu resolution; (L1 E_{T}^{miss} - Offline E_{T}^{miss})/Offline E_{T}^{miss} (PFMetNoMu); events", 70, -1.0, 2.5);
+  h_resolutionMHT_ = ibooker.book1D("resolutionMHT", "MHT resolution; (L1 MHT - reco MHT)/reco MHT; events", 70, -1.0, 2.5);
+  h_resolutionETT_ = ibooker.book1D("resolutionETT", "ETT resolution; (L1 ETT - calo ETT)/calo ETT; events", 70, -1.0, 2.5);
   h_resolutionHTT_ = ibooker.book1D("resolutionHTT",
-      "HTT resolution; (L1 Total H_{T} - Offline Total H_{T})/Offline Total H_{T}; events", 50, -1, 1.5);
+      "HTT resolution; (L1 Total H_{T} - Offline Total H_{T})/Offline Total H_{T}; events", 70, -1.0, 2.5);
 
   h_resolutionMETPhi_ = ibooker.book1D("resolutionMETPhi",
-      "MET #phi resolution; (L1 E_{T}^{miss} #phi - reco MET #phi)/reco MET #phi; events", 120, -0.3, 0.3);
+      "MET #phi resolution; (L1 E_{T}^{miss} #phi - reco MET #phi)/reco MET #phi; events", 200, -1, 1);
   h_resolutionETMHFPhi_ = ibooker.book1D("resolutionETMHFPhi",
-      "MET #phi resolution (HF); (L1 E_{T}^{miss} #phi - reco MET #phi)/reco MET #phi (HF); events", 120, -0.3, 0.3);
+      "MET #phi resolution (HF); (L1 E_{T}^{miss} #phi - reco MET #phi)/reco MET #phi (HF); events", 200, -1, 1);
   h_resolutionPFMetNoMuPhi_ = ibooker.book1D("resolutionPFMetNoMuPhi",
-      "MET #phi resolution (PFMetNoMu); (L1 E_{T}^{miss} #phi - reco MET #phi)/reco MET #phi (PFMetNoMu); events", 120, -0.3, 0.3);
+      "MET #phi resolution (PFMetNoMu); (L1 E_{T}^{miss} #phi - reco MET #phi)/reco MET #phi (PFMetNoMu); events", 200, -1, 1);
   h_resolutionMHTPhi_ = ibooker.book1D("resolutionMHTPhi",
-      "MET #phi resolution; (L1 MHT #phi - reco MHT #phi)/reco MHT #phi; events", 120, -0.3, 0.3);
+      "MET #phi resolution; (L1 MHT #phi - reco MHT #phi)/reco MHT #phi; events",  200, -1, 1);
 
   // energy sum turn ons
   ibooker.setCurrentFolder(efficiencyFolderEtSum_);

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -592,13 +592,13 @@ void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker
       "HTT resolution; (L1 Total H_{T} - Offline Total H_{T})/Offline Total H_{T}; events", 70, -1.0, 2.5);
 
   h_resolutionMETPhi_ = ibooker.book1D("resolutionMETPhi",
-      "MET #phi resolution; (L1 E_{T}^{miss} #phi - reco MET #phi)/reco MET #phi; events", 200, -1, 1);
+      "MET #phi resolution; (L1 E_{T}^{miss} #phi - reco MET #phi); events", 200, -1, 1);
   h_resolutionETMHFPhi_ = ibooker.book1D("resolutionETMHFPhi",
-      "MET #phi resolution (HF); (L1 E_{T}^{miss} #phi - reco MET #phi)/reco MET #phi (HF); events", 200, -1, 1);
+      "MET #phi resolution (HF); (L1 E_{T}^{miss} #phi - reco MET #phi) (HF); events", 200, -1, 1);
   h_resolutionPFMetNoMuPhi_ = ibooker.book1D("resolutionPFMetNoMuPhi",
-      "MET #phi resolution (PFMetNoMu); (L1 E_{T}^{miss} #phi - reco MET #phi)/reco MET #phi (PFMetNoMu); events", 200, -1, 1);
+      "MET #phi resolution (PFMetNoMu); (L1 E_{T}^{miss} #phi - reco MET #phi) (PFMetNoMu); events", 200, -1, 1);
   h_resolutionMHTPhi_ = ibooker.book1D("resolutionMHTPhi",
-      "MET #phi resolution; (L1 MHT #phi - reco MHT #phi)/reco MHT #phi; events",  200, -1, 1);
+      "MET #phi resolution; (L1 MHT #phi - reco MHT #phi); events",  200, -1, 1);
 
   // energy sum turn ons
   ibooker.setCurrentFolder(efficiencyFolderEtSum_);
@@ -708,20 +708,20 @@ void L1TStage2CaloLayer2Offline::bookJetHistos(DQMStore::IBooker & ibooker)
       "jet ET resolution (HB+HE); (L1 Jet E_{T} - Offline Jet E_{T})/Offline Jet E_{T}; events", 50, -1, 1.5);
 
   h_resolutionJetPhi_HB_ = ibooker.book1D("resolutionJetPhi_HB",
-      "#phi_{jet} resolution (HB); (#phi_{jet}^{L1} - #phi_{jet}^{offline})/#phi_{jet}^{offline}; events", 120, -0.3,
+      "#phi_{jet} resolution (HB); (#phi_{jet}^{L1} - #phi_{jet}^{offline}); events", 120, -0.3,
       0.3);
   h_resolutionJetPhi_HE_ = ibooker.book1D("resolutionJetPhi_HE",
-      "jet #phi resolution (HE); (#phi_{jet}^{L1} - #phi_{jet}^{offline})/#phi_{jet}^{offline}; events", 120, -0.3,
+      "jet #phi resolution (HE); (#phi_{jet}^{L1} - #phi_{jet}^{offline}); events", 120, -0.3,
       0.3);
   h_resolutionJetPhi_HF_ = ibooker.book1D("resolutionJetPhi_HF",
-      "jet #phi resolution (HF); (#phi_{jet}^{L1} - #phi_{jet}^{offline})/#phi_{jet}^{offline}; events", 120, -0.3,
+      "jet #phi resolution (HF); (#phi_{jet}^{L1} - #phi_{jet}^{offline}); events", 120, -0.3,
       0.3);
   h_resolutionJetPhi_HB_HE_ = ibooker.book1D("resolutionJetPhi_HB_HE",
-      "jet #phi resolution (HB+HE); (#phi_{jet}^{L1} - #phi_{jet}^{offline})/#phi_{jet}^{offline}; events", 120, -0.3,
+      "jet #phi resolution (HB+HE); (#phi_{jet}^{L1} - #phi_{jet}^{offline}); events", 120, -0.3,
       0.3);
 
   h_resolutionJetEta_ = ibooker.book1D("resolutionJetEta",
-      "jet #eta resolution  (HB); (L1 Jet #eta - Offline Jet #eta)/Offline Jet #eta; events", 120, -0.3, 0.3);
+      "jet #eta resolution  (HB); (L1 Jet #eta - Offline Jet #eta); events", 120, -0.3, 0.3);
 
   // jet turn-ons
   ibooker.setCurrentFolder(efficiencyFolderJet_);

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -375,6 +375,7 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
       minDeltaR = currentDeltaR;
       closestL1Jet = *jet;
       foundMatch = true;
+      break;
     }
 
   }

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
@@ -32,6 +32,8 @@ process.load('DQMServices.Examples.test.DQMExample_qTester_cfi')
 # L1T
 process.load('DQMOffline.L1Trigger.L1TEtSumEfficiency_cfi')
 process.load('DQMOffline.L1Trigger.L1TEtSumDiff_cfi')
+process.load('DQMOffline.L1Trigger.L1TJetEfficiency_cfi')
+process.load('DQMOffline.L1Trigger.L1TJetDiff_cfi')
 process.load('DQMOffline.L1Trigger.L1TEGammaEfficiency_cfi')
 process.load('DQMOffline.L1Trigger.L1TEGammaDiff_cfi')
 process.load('DQMOffline.L1Trigger.L1TTauEfficiency_cfi')
@@ -61,6 +63,9 @@ process.myEff = cms.Path(
     process.l1tEtSumEfficiency *
     process.l1tEtSumEmuEfficiency *
     process.l1tEtSumEmuDiff +
+    process.l1tJetEfficiency *
+    process.l1tJetEmuEfficiency *
+    process.l1tJetEmuDiff +
     process.l1tEGammaEfficiency *
     process.l1tEGammaEmuEfficiency *
     process.l1tEGammaEmuDiff +


### PR DESCRIPTION
The 4th and final part of https://its.cern.ch/jira/browse/CMSLITDPG-588.
It implements:
 - fixed jet matching (in case of two jets with exactly the same dR)
 - TProfile handling for comparison harvester
 - increased ranges for &phi; resolution plots (energy sums)
 - label fixes
 - using `DQMGenericClient` for efficiency harvesting