### PR TITLE
[12X][change GT] 2018 realistic

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -50,7 +50,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '102X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
# SUMMARY
One GT changed: 102X_upgrade2018_realistic_v2
.  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018_realistic_v1/102X_upgrade2018_realistic_v2

# Note
. This change is needed for the sample production to derive the G2 calibration for MC in 10.2.X
. Due to a broken paths in the DQM code this PR will fail
. This need to be fixed, because a new release with the updated AlCaReco Trigger bit is needed in order to generate the samples  to derive the G2 calibration for MC in 10.2.X