### PR TITLE
[10.2.X] Build cuda based tests only for amd64

### DIFF
--- a/DataFormats/HcalDetId/test/BuildFile.xml
+++ b/DataFormats/HcalDetId/test/BuildFile.xml
@@ -1,4 +1,6 @@
+<architecture match="_amd64_">
 <bin name="test_hcal_detid" file="test_hcal_detid.cu">
     <use name="DataFormats/DetId"/>
     <use name="DataFormats/HcalDetId"/>
 </bin>
+</architecture>

--- a/DataFormats/HcalDigi/test/BuildFile.xml
+++ b/DataFormats/HcalDigi/test/BuildFile.xml
@@ -5,9 +5,11 @@
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/ParameterSet"/>
 </library>
+<architecture match="_amd64_">
 <bin name="test_hcal_digi" file="test_hcal_digi.cu">
     <use name="DataFormats/DetId"/>
     <use name="DataFormats/HcalDetId"/>
     <use name="DataFormats/HcalDigi"/>
     <use name="DataFormats/Common"/>
 </bin>
+</architecture>


### PR DESCRIPTION
This test failed for aarch64 as we do not have cuda for aarch64