### PR TITLE
Modifications to tracking in pp_on_AA_2018 era to improve timing

### DIFF
--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -250,15 +250,6 @@ photonConvTrajSeedFromSingleLeg.primaryVerticesTag = cms.InputTag('firstStepPrim
 from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
 trackingLowPU.toModify(photonConvTrajSeedFromSingleLeg, primaryVerticesTag   = "pixelVertices")
 
-from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
-from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toModify(photonConvTrajSeedFromSingleLeg,
-               RegionFactoryPSet = dict(RegionPSet = dict(ptMin = 999999.0,
-                                                          originRadius = 0,
-                                                          originHalfLength = 0)
-                                        )
-               )
     
 # TRACKER DATA CONTROL
 

--- a/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cfi.py
+++ b/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cfi.py
@@ -69,10 +69,21 @@ peripheralPbPb.toModify(photonConvTrajSeedFromSingleLeg,
                         )
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toModify(photonConvTrajSeedFromSingleLeg,
+(pp_on_XeXe_2017 | pp_on_AA_2018 ).toModify(photonConvTrajSeedFromSingleLeg,
                              ClusterCheckPSet = dict(MaxNumberOfPixelClusters = 100000,
                                                      cut = "strip < 1000000 && pixel < 100000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + strip/2.)"
                                                      ),
                              OrderedHitsFactoryPSet = dict(maxElement = 100000)
                              )
+from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
+(pp_on_XeXe_2017 | pp_on_AA_2018 ).toModify(photonConvTrajSeedFromSingleLeg,
+               RegionFactoryPSet = dict(ComponentName = 'GlobalTrackingRegionWithVerticesProducer',
+                                        RegionPSet = _globalTrackingRegionWithVertices.RegionPSet.clone(
+                                                          originRadius = 0,
+                                                          originRScaling4BigEvts = True,
+                                                          minOriginR = 0,
+                                                          scalingStartNPix = 0,
+                                                          scalingEndNPix = 1#essentially turn off immediately 
+                                                         ),
+                                        )
+               )

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -36,12 +36,11 @@ trackingPhase2PU140.toReplaceWith(detachedQuadStepTrackingRegions, _globalTracki
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toReplaceWith(detachedQuadStepTrackingRegions, 
-                    _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                fixedError = 3.75,
-                ptMin = 0.8,
-                originRadius = 1.5
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(detachedQuadStepTrackingRegions, 
+                _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
+                    fixedError = 3.75,
+                    ptMin = 0.9,
+                    originRadius = 1.5
                 )
                                                                       )
 )

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -51,12 +51,11 @@ trackingPhase1.toModify(detachedTripletStepTrackingRegions, RegionPSet = dict(pt
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toReplaceWith(detachedTripletStepTrackingRegions, 
-                    _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                fixedError = 3.0,
-                ptMin = 0.8,
-                originRadius = 1.5
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(detachedTripletStepTrackingRegions, 
+                _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
+                    fixedError = 2.5,
+                    ptMin = 0.9,
+                    originRadius = 1.5
                 )
                                                                       )
 )

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -66,12 +66,11 @@ trackingPhase2PU140.toModify(highPtTripletStepTrackingRegions, RegionPSet = dict
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toReplaceWith(highPtTripletStepTrackingRegions, 
-                    _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                fixedError = 0.2,
-                ptMin = 0.6,
-                originRadius = 0.02
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(highPtTripletStepTrackingRegions, 
+                _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
+                    fixedError = 0.2,
+                    ptMin = 0.7,
+                    originRadius = 0.02
                 )
                                                                       )
 )

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -141,6 +141,10 @@ firstStepPrimaryVerticesPreSplitting = _offlinePrimaryVertices.clone()
 firstStepPrimaryVerticesPreSplitting.TrackLabel = cms.InputTag("initialStepTracksPreSplitting")
 firstStepPrimaryVerticesPreSplitting.vertexCollections = [_offlinePrimaryVertices.vertexCollections[0].clone()]
 
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(firstStepPrimaryVerticesPreSplitting, TkFilterParameters = dict(trackQuality = "any"))
+
 #Jet Core emulation to identify jet-tracks
 from RecoTracker.IterativeTracking.InitialStep_cff import initialStepTrackRefsForJets, caloTowerForTrk, ak4CaloJetsForTrk
 from RecoTracker.IterativeTracking.JetCoreRegionalStep_cff import jetsForCoreTracking

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -243,6 +243,11 @@ from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlineP
 firstStepPrimaryVerticesUnsorted = _offlinePrimaryVertices.clone()
 firstStepPrimaryVerticesUnsorted.TrackLabel = cms.InputTag("initialStepTracks")
 firstStepPrimaryVerticesUnsorted.vertexCollections = [_offlinePrimaryVertices.vertexCollections[0].clone()]
+
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(firstStepPrimaryVerticesUnsorted, TkFilterParameters = dict(trackQuality = "any"))
+
 # we need a replacment for the firstStepPrimaryVerticesUnsorted
 # that includes tracker information of signal and pile up
 # after mixing there is no such thing as initialStepTracks,

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -28,12 +28,11 @@ trackingPhase2PU140.toModify(lowPtQuadStepTrackingRegions, RegionPSet = dict(ptM
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toReplaceWith(lowPtQuadStepTrackingRegions, 
-                    _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                fixedError = 0.5,
-                ptMin = 0.25,
-                originRadius = 0.02
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(lowPtQuadStepTrackingRegions, 
+                _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
+                    fixedError = 0.5,
+                    ptMin = 0.3,
+                    originRadius = 0.02
                 )
                                                             )
 )

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -60,12 +60,11 @@ trackingPhase2PU140.toModify(lowPtTripletStepTrackingRegions, RegionPSet = dict(
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toReplaceWith(lowPtTripletStepTrackingRegions, 
-                    _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                fixedError = 0.2,
-                ptMin = 0.25,
-                originRadius = 0.02
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(lowPtTripletStepTrackingRegions, 
+                _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
+                    useFixedError = False,
+                    ptMin = 0.3,
+                    originRadius = 0.02
                 )
                                                                       )
 )

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -93,15 +93,21 @@ mixedTripletStepTrackingRegionsA = _mixedTripletStepTrackingRegionsCommon.clone(
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toReplaceWith(mixedTripletStepTrackingRegionsA, 
-                    _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                fixedError = 3.75,
-                ptMin = 0.4,
-                originRadius = 1.5
+_mixedTripletStepTrackingRegionsCommon_pp_on_HI = _globalTrackingRegionWithVertices.clone(
+                RegionPSet=dict(
+                    fixedError = 3.75,
+                    ptMin = 0.4,
+                    originRadius = 1.5,
+                    originRScaling4BigEvts = True,
+                    ptMinScaling4BigEvts= True,
+                    minOriginR = 0.,
+                    maxPtMin = 0.7,
+                    scalingStartNPix = 20000,
+                    scalingEndNPix = 35000
                 )
-                                                                      )
 )
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(mixedTripletStepTrackingRegionsA,_mixedTripletStepTrackingRegionsCommon_pp_on_HI)
+
 
 # seeding
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import ClusterShapeHitFilterESProducer as _ClusterShapeHitFilterESProducer
@@ -172,14 +178,12 @@ trackingPhase1.toModify(mixedTripletStepSeedLayersB, layerList = ['BPix3+BPix4+T
 
 # TrackingRegion
 mixedTripletStepTrackingRegionsB = _mixedTripletStepTrackingRegionsCommon.clone(RegionPSet = dict(ptMin=0.6, originHalfLength=10.0))
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toReplaceWith(mixedTripletStepTrackingRegionsB, 
-                    _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                fixedError = 2.5,
-                ptMin = 0.6,
-                originRadius = 1.5
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(mixedTripletStepTrackingRegionsB, 
+                _mixedTripletStepTrackingRegionsCommon_pp_on_HI.clone(RegionPSet=dict(
+                    fixedError = 2.5,
+                    ptMin = 0.6,
                 )
-                                                                      )
+           )
 )
 highBetaStar_2018.toReplaceWith(mixedTripletStepTrackingRegionsB, _mixedTripletStepTrackingRegionsCommon.clone())
 

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -116,15 +116,16 @@ trackingLowPU.toModify(pixelLessStepTrackingRegions, RegionPSet = dict(
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toReplaceWith(pixelLessStepTrackingRegions, 
-                    _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                fixedError = 3.0,
-                ptMin = 2.0,
-                originRadius = 1.0
+from RecoTracker.IterativeTracking.MixedTripletStep_cff import _mixedTripletStepTrackingRegionsCommon_pp_on_HI
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(pixelLessStepTrackingRegions, 
+                _mixedTripletStepTrackingRegionsCommon_pp_on_HI.clone(RegionPSet=dict(
+                    ptMinScaling4BigEvts= False,
+                    fixedError = 3.0,
+                    ptMin = 2.0,
+                    originRadius = 1.0
                 )                                                                      )
 )
+
 
 # seeding
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import ClusterShapeHitFilterESProducer as _ClusterShapeHitFilterESProducer

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -165,6 +165,21 @@ highBetaStar_2018.toModify(pixelPairStepTrackingRegionsSeedLayersB,RegionPSet = 
      ptMin = 0.05,
      originRadius = 0.2,
 ))
+#include commented lines from above in pp_on_XY eras; global seeds (A) are not used in this era b/c timing
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(pixelPairStepTrackingRegionsSeedLayersB, layerList = [
+      "BPix1+BPix2", "BPix1+BPix3", "BPix1+BPix4", "BPix2+BPix3", "BPix2+BPix4","BPix3+BPix4",
+      "BPix1+FPix1_pos"    , "BPix1+FPix1_neg",
+      "BPix1+FPix2_pos"    , "BPix1+FPix2_neg",
+      "BPix1+FPix3_pos"    , "BPix1+FPix3_neg",
+      "BPix2+FPix1_pos"    , "BPix2+FPix1_neg",
+      "BPix2+FPix2_pos"    , "BPix2+FPix2_neg",
+      "BPix3+FPix1_pos"    , "BPix3+FPix1_neg",
+      "FPix1_pos+FPix2_pos", "FPix1_neg+FPix2_neg",
+      "FPix1_pos+FPix3_pos", "FPix1_neg+FPix3_neg",
+      "FPix2_pos+FPix3_pos", "FPix2_neg+FPix3_neg" 
+   ])
 
 pixelPairStepHitDoubletsB = pixelPairStepHitDoublets.clone(
     seedingLayers = "",
@@ -181,6 +196,8 @@ _pixelPairStepSeedsMerged = _globalCombinedSeeds.clone(
 )
 (trackingPhase1 & ~fastSim).toReplaceWith(pixelPairStepSeeds, _pixelPairStepSeedsMerged)
 
+#only use region B for pp_on_XY era for timing reasons
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(pixelPairStepSeeds, pixelPairStepSeedsB)
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
@@ -405,11 +422,15 @@ trackingLowPU.toReplaceWith(PixelPairStepTask, _PixelPairStepTask_LowPU_Phase2PU
 trackingPhase2PU140.toReplaceWith(PixelPairStepTask, _PixelPairStepTask_LowPU_Phase2PU140)
 
 _PixelPairStepTask_Phase1 = PixelPairStepTask.copy()
+_PixelPairStepTask_pp_on_AA = PixelPairStepTask.copy()
 _PixelPairStepTask_Phase1.replace(pixelPairStepSeeds,cms.Task(
                               pixelPairStepSeedsA ,
                               pixelPairStepTrackingRegionsSeedLayersB,pixelPairStepHitDoubletsB,pixelPairStepSeedsB,
                               pixelPairStepSeeds))
 trackingPhase1.toReplaceWith(PixelPairStepTask, _PixelPairStepTask_Phase1)
+
+_PixelPairStepTask_pp_on_AA.replace(pixelPairStepHitDoublets, cms.Task(pixelPairStepTrackingRegionsSeedLayersB,pixelPairStepHitDoubletsB))
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(PixelPairStepTask, _PixelPairStepTask_pp_on_AA)
 
 #fastSim
 import FastSimulation.Tracking.FastTrackerRecHitMaskProducer_cfi

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -49,13 +49,13 @@ tobTecStepTrackingRegionsTripl = _globalTrackingRegionFromBeamSpotFixedZ.clone(R
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toReplaceWith(tobTecStepTrackingRegionsTripl, 
-                    _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                fixedError = 5.0,
-                ptMin = 2.0,
-                originRadius = 3.5
+from RecoTracker.IterativeTracking.MixedTripletStep_cff import _mixedTripletStepTrackingRegionsCommon_pp_on_HI
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(tobTecStepTrackingRegionsTripl, 
+                _mixedTripletStepTrackingRegionsCommon_pp_on_HI.clone(RegionPSet=dict(
+                    ptMinScaling4BigEvts= False,
+                    fixedError = 5.0,
+                    ptMin = 2.0,
+                    originRadius = 3.5
                 )                                                                      )
 )
 
@@ -143,15 +143,15 @@ tobTecStepTrackingRegionsPair = _globalTrackingRegionFromBeamSpotFixedZ.clone(Re
     originRadius = 6.0,
 ))
 
-from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toReplaceWith(tobTecStepTrackingRegionsPair, 
-                    _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
-                fixedError = 7.5,
-                ptMin = 2.0,
-                originRadius = 6.0
+(pp_on_XeXe_2017 | pp_on_AA_2018).toReplaceWith(tobTecStepTrackingRegionsPair, 
+                _mixedTripletStepTrackingRegionsCommon_pp_on_HI.clone(RegionPSet=dict(
+                    ptMinScaling4BigEvts= False,
+                    fixedError = 7.5,
+                    ptMin = 2.0,
+                    originRadius = 6.0
                 )                                                                      )
 )
+
 
 # Pair seeds
 tobTecStepHitDoubletsPair = _hitPairEDProducer.clone(

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -61,9 +61,13 @@ phase2_tracker.toModify(offlinePrimaryVertices,
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
-    e.toModify(offlinePrimaryVertices,
-               TkFilterParameters = dict(maxD0Significance = 3.0),
+(pp_on_XeXe_2017 | pp_on_AA_2018).toModify(offlinePrimaryVertices,
+               TkFilterParameters = dict(
+                   maxD0Significance = 2.0,
+                   minPixelLayersWithHits=3,
+                   minPt = 0.7,
+                   trackQuality = "highPurity"
+               ),
                TkClusParameters = cms.PSet(
             algorithm = cms.string("gap"),
             TkGapClusParameters = cms.PSet(


### PR DESCRIPTION
This PR makes several changes to the tracking and vertexing sequences in the pp_on_AA_2018 era to be used for PbPb data this year, with the goal of speeding up the reconstruction.  The major changes are as follows:

1) Added a filter on the tracks input to offlinePrimaryVertices
2) Improved the timing of the ConversionStep by giving it an empty tracking region collection instead of a point-like tracking region
3) Various tweaks to the tracking region parameters in most tracking iterations
4) Scaling the size of tracking regions as a function of detector occupancy for the mixed/tobtec/pixelless steps (similar strategy to PR #21930)

The difference in tracking efficiency is fairly small, and the high-pt fake rate also goes down as can be seen by comparing the red lines in slide 6 in this presentation [1].  The reconstruction also runs about 15% faster, from slide 4.

[1] https://indico.cern.ch/event/734653/contributions/3029929/attachments/1662113/2663273/Dener_Tracking_June1.pdf

@mandrenguyen 