### PR TITLE
keep event content for HLT DeepCSV - Calo and PF

### DIFF
--- a/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
@@ -122,6 +122,8 @@ HLTDebugRAW   = cms.PSet(
         'keep *_hltCleanedHiCorrectedIslandBarrelSuperClustersHI_*_*',
         'keep *_hltCombinedSecondaryVertexBJetTagsCalo_*_*',
         'keep *_hltCombinedSecondaryVertexBJetTagsPF_*_*',
+        'keep *_hltDeepCombinedSecondaryVertexBJetTagsCalo_*_*',
+        'keep *_hltDeepCombinedSecondaryVertexBJetTagsPF_*_*',
         'keep *_hltConvPFTausTightIsoTrackFindingIsolation_*_*',
         'keep *_hltConvPFTausTightIsoTrackFinding_*_*',
         'keep *_hltConvPFTausTightIsoTrackPt5Isolation_*_*',


### PR DESCRIPTION
Keep event content for DeepCSV (crucial for HLT release validation after removal of paths with CSVv2)