### PR TITLE
[10.2.X] Fix SiStrip payload inspector classes 

### DIFF
--- a/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
@@ -47,8 +47,7 @@ namespace {
   class SiStripLatencyTest : public cond::payloadInspector::Histogram1D<SiStripLatency> {
     
   public:
-    SiStripLatencyTest() : cond::payloadInspector::Histogram1D<SiStripLatency>("SiStripLatency values",
-									       "SiStripLatency values", 5,0.0,5.0){
+    SiStripLatencyTest() : cond::payloadInspector::Histogram1D<SiStripLatency>("SiStripLatency values","SiStripLatency values", 5,0.0,5.0){
       Base::setSingleIov( true );
     }
     
@@ -56,7 +55,6 @@ namespace {
       for ( auto const & iov: iovs) {
 	std::shared_ptr<SiStripLatency> payload = Base::fetchPayload( std::get<1>(iov) );
 	if( payload.get() ){
-	  
 	  std::vector<SiStripLatency::Latency> lat = payload->allLatencyAndModes();
 	  fillWithValue(lat.size());
 	} 

--- a/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
@@ -48,7 +48,7 @@ namespace {
     
   public:
     SiStripLatencyTest() : cond::payloadInspector::Histogram1D<SiStripLatency>("SiStripLatency values",
-										 "SiStripLatency values", 5,0.0,5.0){
+									       "SiStripLatency values", 5,0.0,5.0){
       Base::setSingleIov( true );
     }
     
@@ -56,14 +56,10 @@ namespace {
       for ( auto const & iov: iovs) {
 	std::shared_ptr<SiStripLatency> payload = Base::fetchPayload( std::get<1>(iov) );
 	if( payload.get() ){
-	 
+	  
 	  std::vector<SiStripLatency::Latency> lat = payload->allLatencyAndModes();
-
-	  for (const auto & l : lat) {
-
-	    fillWithValue(1.);
-	  } 
-	}
+	  fillWithValue(lat.size());
+	} 
       }
       return true;
     }// fill

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -1317,10 +1317,6 @@ PAYLOAD_INSPECTOR_MODULE(SiStripNoises){
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMax_RatioWithPreviousIOV3sigmaTrackerMap);
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMean_RatioWithPreviousIOV3sigmaTrackerMap);
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseRms_RatioWithPreviousIOV3sigmaTrackerMap);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseComparatorMeanByRegion); 
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseComparatorMinByRegion);  
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseComparatorMaxByRegion);  
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseComparatorRMSByRegion);  
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseLinearity);
   PAYLOAD_INSPECTOR_CLASS(TIBNoiseHistory);
   PAYLOAD_INSPECTOR_CLASS(TOBNoiseHistory);

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -79,6 +79,10 @@ int main(int argc, char** argv) {
   histo9.process(connectionString, tag, runTimeType, start, end);
   std::cout <<histo9.data()<<std::endl;
 
+  SiStripNoiseComparatorMeanByRegion histoCompareMeanByRegion;
+  histoCompareMeanByRegion.process(connectionString, tag, runTimeType, start, start);
+  std::cout <<histoCompareMeanByRegion.data()<<std::endl;
+
   // Pedestals
 
   tag   = "SiStripPedestals_v2_prompt";


### PR DESCRIPTION
Greetings,
this PR fixes two issues introduced unintentionally in https://github.com/cms-sw/cmssw/pull/23316:

1. removes the warning in compilation in `CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc`
2. removes the duplication in the registration of the `SiStripNoiseComparator*ByRegion` classes that is triggering a python warning when invoking the `getPayloadData.py` script:

```shell
$ getPayloadData.py --plugin pluginSiStripNoises_PayloadInspector --plot plot_SiStripNoiseMaxByRegion --tag SiStripNoise_v2_prompt --time_type Run --iovs '{"start_iov": "303420", "end_iov": "303420"}' --db Prod --test ;                                                                                                                                                                      /cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc630/external/python/2.7.11-omkpbe2/lib/python2.7/importlib/__init__.py:37: RuntimeWarning: to-Python converter for (anonymous namespace)::SiStripNoiseComparatorByRegion<(SiStripPI::estimator)2> already registered; second conversion method ignored.
  __import__(name)
/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc630/external/python/2.7.11-omkpbe2/lib/python2.7/importlib/__init__.py:37: RuntimeWarning: to-Python converter for (anonymous namespace)::SiStripNoiseComparatorByRegion<(SiStripPI::estimator)0> already registered; second conversion method ignored.
  __import__(name)
/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc630/external/python/2.7.11-omkpbe2/lib/python2.7/importlib/__init__.py:37: RuntimeWarning: to-Python converter for (anonymous namespace)::SiStripNoiseComparatorByRegion<(SiStripPI::estimator)1> already registered; second conversion method ignored.
  __import__(name)
/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc630/external/python/2.7.11-omkpbe2/lib/python2.7/importlib/__init__.py:37: RuntimeWarning: to-Python converter for (anonymous namespace)::SiStripNoiseComparatorByRegion<(SiStripPI::estimator)3> already registered; second conversion method ignored.
  __import__(name)
```

I also include a test for the class that is giving python registration issues.
@jpriscia FYI
