### PR TITLE
Backport of #23015 to 101X, DQMOffline/Muon fixes

### DIFF
--- a/DQMOffline/Muon/src/EfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/EfficiencyAnalyzer.cc
@@ -270,9 +270,11 @@ void EfficiencyAnalyzer::analyze(const edm::Event & iEvent,const edm::EventSetup
       h_allProbes_pt->Fill(muon2->pt());
       h_allProbes_eta->Fill(muon2->eta());
       h_allProbes_phi->Fill(muon2->phi());
-      h_allProbes_inner_pt->Fill(muon2->innerTrack()->innerMomentum().Rho());
-      h_allProbes_inner_eta->Fill(muon2->innerTrack()->innerPosition().Eta());
-      h_allProbes_inner_phi->Fill(muon2->innerTrack()->innerPosition().Phi());
+      if(muon2->innerTrack()->extra().isAvailable()) {
+        h_allProbes_inner_pt->Fill(muon2->innerTrack()->innerMomentum().Rho());
+        h_allProbes_inner_eta->Fill(muon2->innerTrack()->innerPosition().Eta());
+        h_allProbes_inner_phi->Fill(muon2->innerTrack()->innerPosition().Phi());
+      }
       
       if (isMB)               h_allProbes_EB_pt->Fill(muon2->pt());
       if (isME)               h_allProbes_EE_pt->Fill(muon2->pt());
@@ -288,9 +290,11 @@ void EfficiencyAnalyzer::analyze(const edm::Event & iEvent,const edm::EventSetup
       h_passProbes_ID_pt->Fill(muon2->pt());
       h_passProbes_ID_eta->Fill(muon2->eta());
       h_passProbes_ID_phi->Fill(muon2->phi());
-      h_passProbes_ID_inner_pt->Fill(muon2->innerTrack()->innerMomentum().Rho());
-      h_passProbes_ID_inner_eta->Fill(muon2->innerTrack()->innerPosition().Eta());
-      h_passProbes_ID_inner_phi->Fill(muon2->innerTrack()->innerPosition().Phi());
+      if(muon2->innerTrack()->extra().isAvailable()) {
+        h_passProbes_ID_inner_pt->Fill(muon2->innerTrack()->innerMomentum().Rho());
+        h_passProbes_ID_inner_eta->Fill(muon2->innerTrack()->innerPosition().Eta());
+        h_passProbes_ID_inner_phi->Fill(muon2->innerTrack()->innerPosition().Phi());
+      } 
       
       if (isMB) h_passProbes_ID_EB_pt->Fill(muon2->pt());
       if (isME) h_passProbes_ID_EE_pt->Fill(muon2->pt());

--- a/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
@@ -451,16 +451,16 @@ void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       int pvIndex = 0;   
       math::XYZPoint refPoint;
       if(doMVA) {
-         pvIndex = getPv(iTrack.index(), &(*vertex)); //HFDumpUtitilies
-         if (pvIndex > -1) {
-	   refPoint = vertex->at(pvIndex).position();
-         } else {
-	   if (&(*beamSpot)==NULL) {
-	     refPoint = beamSpot->position();
-	   } else {
-	     cout << "ERROR: No beam sport found!" << endl;
-	   }
-         }
+        pvIndex = getPv(iTrack.index(), &(*vertex)); //HFDumpUtitilies
+        if (pvIndex > -1) {
+          refPoint = vertex->at(pvIndex).position();
+        } else {
+          if(beamSpot.isValid()) {
+            refPoint = beamSpot->position();
+          } else {
+            edm::LogInfo("MuonRecoAnalyzer") << "ERROR: No beam sport found!" << endl;
+          }
+        }
       }
       ptSoftMuonMVA->Fill(iTrack->eta());
       deltaRSoftMuonMVA->Fill(getDeltaR(*iTrack,*oTrack));


### PR DESCRIPTION
Backport of #23015, to address part of the issue #23439 observed during the preparation of the RE-RECO of 2018A for runs affected by T0 deletion.