### PR TITLE
ged photon modifications for pp_on_AA_2018 era

### DIFF
--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -154,3 +154,8 @@ particleFlowSuperClusterECALMustache = cms.EDProducer(
 
 #define the default clustering type
 particleFlowSuperClusterECAL = particleFlowSuperClusterECALMustache.clone()
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(particleFlowSuperClusterECAL, useDynamicDPhiWindow = False
+pp_on_AA_2018.toModify(particleFlowSuperClusterECAL, phiwidth_SuperClusterBarrel = 0.20
+pp_on_AA_2018.toModify(particleFlowSuperClusterECAL, phiwidth_SuperClusterEndcap = 0.20

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -156,6 +156,6 @@ particleFlowSuperClusterECALMustache = cms.EDProducer(
 particleFlowSuperClusterECAL = particleFlowSuperClusterECALMustache.clone()
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-pp_on_AA_2018.toModify(particleFlowSuperClusterECAL, useDynamicDPhiWindow = False
-pp_on_AA_2018.toModify(particleFlowSuperClusterECAL, phiwidth_SuperClusterBarrel = 0.20
-pp_on_AA_2018.toModify(particleFlowSuperClusterECAL, phiwidth_SuperClusterEndcap = 0.20
+pp_on_AA_2018.toModify(particleFlowSuperClusterECAL, useDynamicDPhiWindow = False)
+pp_on_AA_2018.toModify(particleFlowSuperClusterECAL, phiwidth_SuperClusterBarrel = 0.20)
+pp_on_AA_2018.toModify(particleFlowSuperClusterECAL, phiwidth_SuperClusterEndcap = 0.20)


### PR DESCRIPTION
this PR aims to improve ged photon reconstruction performance in heavy ion collisions with the following changes:
- set upper bound for supercluster phi widths
- set supercluster phi widths to 0.2

some slides on the performance can be found at [[1]] and [[2]].

@ttrk @mandrenguyen 

[1]: https://indico.cern.ch/event/697575/contributions/2925147/attachments/1612442/2561934/180307_photonRecoPerformance_GED_phiWidth_HI.pdf
[2]: https://twiki.cern.ch/twiki/pub/CMS/HiEgamma2018/180530_photonReco_10Xreco_default_vs_mod.pdf