### PR TITLE
DQM Phase2: Added a zoomed pT efficiency plot for the L1 tracks

### DIFF
--- a/DQM/SiOuterTracker/python/OuterTrackerMonitorTTCluster_cfi.py
+++ b/DQM/SiOuterTracker/python/OuterTrackerMonitorTTCluster_cfi.py
@@ -9,15 +9,15 @@ OuterTrackerMonitorTTCluster = DQMEDAnalyzer('OuterTrackerMonitorTTCluster',
 
 # Number of clusters per layer
     TH1TTCluster_Barrel = cms.PSet(
-        Nbinsx = cms.int32(6),
-        xmax = cms.double(6.5),
+        Nbinsx = cms.int32(7),
+        xmax = cms.double(7.5),
         xmin = cms.double(0.5)
         ),
 
 # Number of clusters per disc
     TH1TTCluster_ECDiscs = cms.PSet(
-        Nbinsx = cms.int32(5),
-        xmax = cms.double(5.5),
+        Nbinsx = cms.int32(6),
+        xmax = cms.double(6.5),
         xmin = cms.double(0.5)
         ),
 

--- a/DQM/SiOuterTracker/python/OuterTrackerMonitorTTStub_cfi.py
+++ b/DQM/SiOuterTracker/python/OuterTrackerMonitorTTStub_cfi.py
@@ -50,16 +50,16 @@ OuterTrackerMonitorTTStub = DQMEDAnalyzer('OuterTrackerMonitorTTStub',
 
 #TTStub Barrel Layers
     TH1TTStub_Layers = cms.PSet(
-        Nbinsx = cms.int32(6),
+        Nbinsx = cms.int32(7),
         xmin = cms.double(0.5),
-        xmax = cms.double(6.5)
+        xmax = cms.double(7.5)
         ),
 
 #TTStub EC Discs
     TH1TTStub_Discs = cms.PSet(
-        Nbinsx = cms.int32(5),
+        Nbinsx = cms.int32(6),
         xmin = cms.double(0.5),
-        xmax = cms.double(5.5)
+        xmax = cms.double(6.5)
         ),
 
 #TTStub EC Rings

--- a/Validation/SiOuterTrackerV/interface/OuterTrackerMonitorTrackingParticles.h
+++ b/Validation/SiOuterTrackerV/interface/OuterTrackerMonitorTrackingParticles.h
@@ -45,11 +45,13 @@ public:
 
   // pT and eta for efficiency plots
   MonitorElement* tp_pt = nullptr;  // denominator
+  MonitorElement* tp_pt_zoom = nullptr;  // denominator
   MonitorElement* tp_eta = nullptr; // denominator
   MonitorElement* tp_d0 = nullptr; // denominator
   MonitorElement* tp_VtxR = nullptr; // denominator (also known as vxy)
   MonitorElement* tp_VtxZ = nullptr; // denominator
   MonitorElement* match_tp_pt = nullptr; // numerator
+  MonitorElement* match_tp_pt_zoom = nullptr; // numerator
   MonitorElement* match_tp_eta = nullptr; // numerator
   MonitorElement* match_tp_d0 = nullptr; // numerator
   MonitorElement* match_tp_VtxR = nullptr; // numerator (also known as vxy)

--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
@@ -326,7 +326,10 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
     }
 
     // To make efficiency plots where the denominator has NO stub cuts
-    if (VtxR < 1.0) tp_pt->Fill(tmp_tp_pt); // pT efficiency has no cut on pT, but includes VtxR cut
+    if (VtxR < 1.0) {
+      tp_pt->Fill(tmp_tp_pt); // pT efficiency has no cut on pT, but includes VtxR cut
+      if(tmp_tp_pt>0 && tmp_tp_pt<=10)tp_pt_zoom->Fill(tmp_tp_pt); // pT efficiency has no cut on pT, but includes VtxR cut
+    }
     if (tmp_tp_pt < TP_minPt) continue;
     tp_VtxR->Fill(tmp_tp_VtxR); // VtxR efficiency has no cut on VtxR
     if (VtxR > 1.0) continue;
@@ -431,12 +434,12 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
   } // End loop over tracking particles
 
   for (unsigned j=0;j<trkParts_eta.size();j++) { //Over all TPs
-    double eta =  trkParts_eta[j];
-    double pt = trkParts_pt[j];
-    double VtxR = trkParts_VtxR[j];
-    double d0 = trkParts_d0[j];
-    double VtxZ = trkParts_VtxZ[j];
-    double eventId = trkParts_eventId[j];
+    float eta =  trkParts_eta[j];
+    float pt = trkParts_pt[j];
+    float VtxR = trkParts_VtxR[j];
+    float d0 = trkParts_d0[j];
+    float VtxZ = trkParts_VtxZ[j];
+    float eventId = trkParts_eventId[j];
 
     // cut on event ID (eventid=0 means the TP is from the primary interaction, so *not* selecting only eventid=0 means including stuff from pileup)
     if (TP_select_eventid == 0 && eventId != 0) continue;
@@ -457,6 +460,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
 
     // fill matched track histograms (if passes all criteria)
     match_tp_pt->Fill(pt);
+    if(pt>0 && pt<=10)match_tp_pt_zoom->Fill(pt);
     match_tp_eta->Fill(eta);
     match_tp_d0->Fill(d0);
     match_tp_VtxR->Fill(VtxR);
@@ -469,18 +473,18 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
     res_eta->Fill(matchTrk_eta[j] - trkParts_eta[j]);
 
     // Eta and pT histograms for resolution
-    double pt_res = (matchTrk_pt[j] - trkParts_pt[j])/trkParts_pt[j];
-    double eta_res = matchTrk_eta[j] - trkParts_eta[j];
-    double phi_res = matchTrk_phi[j] - trkParts_phi[j];
-    double VtxZ_res = matchTrk_VtxZ[j] - trkParts_VtxZ[j];
-    double d0_res = matchTrk_d0[j] - trkParts_d0[j];
+    float pt_res = (matchTrk_pt[j] - trkParts_pt[j])/trkParts_pt[j];
+    float eta_res = matchTrk_eta[j] - trkParts_eta[j];
+    float phi_res = matchTrk_phi[j] - trkParts_phi[j];
+    float VtxZ_res = matchTrk_VtxZ[j] - trkParts_VtxZ[j];
+    float d0_res = matchTrk_d0[j] - trkParts_d0[j];
 
-    double tP_eta = trkParts_eta[j];
-    double tP_pt = trkParts_pt[j];
+    float tP_eta = trkParts_eta[j];
+    float tP_pt = trkParts_pt[j];
 
     // Fill resolution plots for different abs(eta) bins:
     // (0, 0.7), (0.7, 1.0), (1.0, 1.2), (1.2, 1.6), (1.6, 2.0), (2.0, 2.4)
-    if (abs(tP_eta) >= 0  && abs(tP_eta) < 0.7){
+    if (fabs(tP_eta) >= 0  && fabs(tP_eta) < 0.7){
       reseta_eta0to0p7->Fill(eta_res);
       resphi_eta0to0p7->Fill(phi_res);
       resVtxZ_eta0to0p7->Fill(VtxZ_res);
@@ -489,7 +493,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
       else if (tP_pt >= 3  && tP_pt < 8) respt_eta0to0p7_pt3to8->Fill(pt_res);
       else if (tP_pt >= 8) respt_eta0to0p7_pt8toInf->Fill(pt_res);
     }
-    else if (abs(tP_eta) >= 0.7 && abs(tP_eta) < 1.0){
+    else if (fabs(tP_eta) >= 0.7 && fabs(tP_eta) < 1.0){
       reseta_eta0p7to1->Fill(eta_res);
       resphi_eta0p7to1->Fill(phi_res);
       resVtxZ_eta0p7to1->Fill(VtxZ_res);
@@ -498,7 +502,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
       else if (tP_pt >= 3  && tP_pt < 8) respt_eta0p7to1_pt3to8->Fill(pt_res);
       else if (tP_pt >= 8) respt_eta0p7to1_pt8toInf->Fill(pt_res);
     }
-    else if (abs(tP_eta) >= 1.0 && abs(tP_eta) < 1.2){
+    else if (fabs(tP_eta) >= 1.0 && fabs(tP_eta) < 1.2){
       reseta_eta1to1p2->Fill(eta_res);
       resphi_eta1to1p2->Fill(phi_res);
       resVtxZ_eta1to1p2->Fill(VtxZ_res);
@@ -507,7 +511,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
       else if (tP_pt >= 3  && tP_pt < 8) respt_eta1to1p2_pt3to8->Fill(pt_res);
       else if (tP_pt >= 8) respt_eta1to1p2_pt8toInf->Fill(pt_res);
     }
-    else if (abs(tP_eta) >= 1.2 && abs(tP_eta) < 1.6){
+    else if (fabs(tP_eta) >= 1.2 && fabs(tP_eta) < 1.6){
       reseta_eta1p2to1p6->Fill(eta_res);
       resphi_eta1p2to1p6->Fill(phi_res);
       resVtxZ_eta1p2to1p6->Fill(VtxZ_res);
@@ -516,7 +520,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
       else if (tP_pt >= 3  && tP_pt < 8) respt_eta1p2to1p6_pt3to8->Fill(pt_res);
       else if (tP_pt >= 8) respt_eta1p2to1p6_pt8toInf->Fill(pt_res);
     }
-    else if (abs(tP_eta) >= 1.6 && abs(tP_eta) < 2.0){
+    else if (fabs(tP_eta) >= 1.6 && fabs(tP_eta) < 2.0){
       reseta_eta1p6to2->Fill(eta_res);
       resphi_eta1p6to2->Fill(phi_res);
       resVtxZ_eta1p6to2->Fill(VtxZ_res);
@@ -525,7 +529,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
       else if (tP_pt >= 3  && tP_pt < 8) respt_eta1p6to2_pt3to8->Fill(pt_res);
       else if (tP_pt >= 8) respt_eta1p6to2_pt8toInf->Fill(pt_res);
     }
-    else if (abs(tP_eta) >= 2.0 && abs(tP_eta) <= 2.4){
+    else if (fabs(tP_eta) >= 2.0 && fabs(tP_eta) <= 2.4){
       reseta_eta2to2p4->Fill(eta_res);
       resphi_eta2to2p4->Fill(phi_res);
       resVtxZ_eta2to2p4->Fill(VtxZ_res);
@@ -645,6 +649,25 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(DQMStore::IBooker &iBo
       psEffic_pt.getParameter<double>("xmax"));
   match_tp_pt->setAxisTitle("p_{T} [GeV]", 1);
   match_tp_pt->setAxisTitle("# matched tracking particles", 2);
+
+  //pT zoom (0-10 GeV)
+  edm::ParameterSet psEffic_pt_zoom =  conf_.getParameter<edm::ParameterSet>("TH1Effic_pt_zoom");
+  HistoName = "tp_pt_zoom";
+  tp_pt_zoom = iBooker.book1D(HistoName, HistoName,
+      psEffic_pt_zoom.getParameter<int32_t>("Nbinsx"),
+      psEffic_pt_zoom.getParameter<double>("xmin"),
+      psEffic_pt_zoom.getParameter<double>("xmax"));
+  tp_pt_zoom->setAxisTitle("p_{T} [GeV]", 1);
+  tp_pt_zoom->setAxisTitle("# tracking particles", 2);
+
+  //Matched pT zoom (0-10 GeV)
+  HistoName = "match_tp_pt_zoom";
+  match_tp_pt_zoom = iBooker.book1D(HistoName, HistoName,
+      psEffic_pt_zoom.getParameter<int32_t>("Nbinsx"),
+      psEffic_pt_zoom.getParameter<double>("xmin"),
+      psEffic_pt_zoom.getParameter<double>("xmax"));
+  match_tp_pt_zoom->setAxisTitle("p_{T} [GeV]", 1);
+  match_tp_pt_zoom->setAxisTitle("# matched tracking particles", 2);
 
   //eta
   edm::ParameterSet psEffic_eta =  conf_.getParameter<edm::ParameterSet>("TH1Effic_eta");

--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
@@ -167,12 +167,12 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
           for (auto it: *trackingParticleHandle){ // Loop over TPs
             counter++;
             float allowedRes = 0.001;
-            if (fabs(it.vx()-x)>allowedRes) continue;
-            if (fabs(it.vy()-y)>allowedRes) continue;
-            if (fabs(it.vz()-z)>allowedRes) continue;
-            if (fabs(it.px()-px)>allowedRes) continue;
-            if (fabs(it.py()-py)>allowedRes) continue;
-            if (fabs(it.pz()-pz)>allowedRes) continue;
+            if (std::fabs(it.vx()-x)>allowedRes) continue;
+            if (std::fabs(it.vy()-y)>allowedRes) continue;
+            if (std::fabs(it.vz()-z)>allowedRes) continue;
+            if (std::fabs(it.px()-px)>allowedRes) continue;
+            if (std::fabs(it.py()-py)>allowedRes) continue;
+            if (std::fabs(it.pz()-pz)>allowedRes) continue;
 
             idx=counter;
           }
@@ -233,7 +233,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
     double trkParts_nLayers = v_tp_nLayers[j]; // the number of layers hit for each tracking particle
 
     // Fill the 1D distribution plots for tracking particles, to monitor change in stub definition
-    if (fabs(trkParts_eta)<2.4 && trkParts_pt>2 && trkParts_nLayers>=4) {
+    if (std::fabs(trkParts_eta)<2.4 && trkParts_pt>2 && trkParts_nLayers>=4) {
       // Fill 1D distributions
       trackParts_Pt ->Fill(trkParts_pt);
       trackParts_Eta->Fill(trkParts_eta);
@@ -316,8 +316,8 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
     // ----------------------------------------------------------------------------------------------
     // look for L1 tracks matched to the tracking particle
     if (tmp_eventid > 0) continue; //only care about tracking particles from the primary interaction
-    if (fabs(tmp_tp_eta) > TP_maxEta) continue;
-    if (fabs(tmp_tp_VtxZ) > TP_maxVtxZ) continue;
+    if (std::fabs(tmp_tp_eta) > TP_maxEta) continue;
+    if (std::fabs(tmp_tp_VtxZ) > TP_maxVtxZ) continue;
 
     // ----------------------------------------------------------------------------------------------
     // only consider TPs with >= X stubs (configurable option)
@@ -365,9 +365,9 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
       int match_id = 999;
 
       edm::Ptr< TrackingParticle > my_tp = MCTruthTTTrackHandle->findTrackingParticlePtr(thisTrack);
-      dmatch_pt  = fabs(my_tp->p4().pt() - tmp_tp_pt);
-      dmatch_eta = fabs(my_tp->p4().eta() - tmp_tp_eta);
-      dmatch_phi = fabs(my_tp->p4().phi() - tmp_tp_phi);
+      dmatch_pt  = std::fabs(my_tp->p4().pt() - tmp_tp_pt);
+      dmatch_eta = std::fabs(my_tp->p4().eta() - tmp_tp_eta);
+      dmatch_phi = std::fabs(my_tp->p4().phi() - tmp_tp_phi);
       match_id = my_tp->pdgId();
       float tmp_trk_chi2dof = (thisTrack->getChi2(L1Tk_nPar)) / (2*tmp_trk_nstub - L1Tk_nPar);
 
@@ -446,7 +446,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
     if (VtxR > 1) continue;
     if (pt < 2) continue;
     if (pt > TP_maxPt) continue;
-    if (fabs(eta) > TP_maxEta) continue;
+    if (std::fabs(eta) > TP_maxEta) continue;
     if (trkParts_nMatch[j] < 1) continue; // was the tracking particle matched to a L1 track?
     if (matchTrk_nStub[j] < L1Tk_minNStub) continue;     // use only tracks with min X stubs
 
@@ -484,7 +484,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
 
     // Fill resolution plots for different abs(eta) bins:
     // (0, 0.7), (0.7, 1.0), (1.0, 1.2), (1.2, 1.6), (1.6, 2.0), (2.0, 2.4)
-    if (fabs(tP_eta) >= 0  && fabs(tP_eta) < 0.7){
+    if (std::fabs(tP_eta) >= 0  && std::fabs(tP_eta) < 0.7){
       reseta_eta0to0p7->Fill(eta_res);
       resphi_eta0to0p7->Fill(phi_res);
       resVtxZ_eta0to0p7->Fill(VtxZ_res);
@@ -493,7 +493,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
       else if (tP_pt >= 3  && tP_pt < 8) respt_eta0to0p7_pt3to8->Fill(pt_res);
       else if (tP_pt >= 8) respt_eta0to0p7_pt8toInf->Fill(pt_res);
     }
-    else if (fabs(tP_eta) >= 0.7 && fabs(tP_eta) < 1.0){
+    else if (std::fabs(tP_eta) >= 0.7 && std::fabs(tP_eta) < 1.0){
       reseta_eta0p7to1->Fill(eta_res);
       resphi_eta0p7to1->Fill(phi_res);
       resVtxZ_eta0p7to1->Fill(VtxZ_res);
@@ -502,7 +502,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
       else if (tP_pt >= 3  && tP_pt < 8) respt_eta0p7to1_pt3to8->Fill(pt_res);
       else if (tP_pt >= 8) respt_eta0p7to1_pt8toInf->Fill(pt_res);
     }
-    else if (fabs(tP_eta) >= 1.0 && fabs(tP_eta) < 1.2){
+    else if (std::fabs(tP_eta) >= 1.0 && std::fabs(tP_eta) < 1.2){
       reseta_eta1to1p2->Fill(eta_res);
       resphi_eta1to1p2->Fill(phi_res);
       resVtxZ_eta1to1p2->Fill(VtxZ_res);
@@ -511,7 +511,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
       else if (tP_pt >= 3  && tP_pt < 8) respt_eta1to1p2_pt3to8->Fill(pt_res);
       else if (tP_pt >= 8) respt_eta1to1p2_pt8toInf->Fill(pt_res);
     }
-    else if (fabs(tP_eta) >= 1.2 && fabs(tP_eta) < 1.6){
+    else if (std::fabs(tP_eta) >= 1.2 && std::fabs(tP_eta) < 1.6){
       reseta_eta1p2to1p6->Fill(eta_res);
       resphi_eta1p2to1p6->Fill(phi_res);
       resVtxZ_eta1p2to1p6->Fill(VtxZ_res);
@@ -520,7 +520,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
       else if (tP_pt >= 3  && tP_pt < 8) respt_eta1p2to1p6_pt3to8->Fill(pt_res);
       else if (tP_pt >= 8) respt_eta1p2to1p6_pt8toInf->Fill(pt_res);
     }
-    else if (fabs(tP_eta) >= 1.6 && fabs(tP_eta) < 2.0){
+    else if (std::fabs(tP_eta) >= 1.6 && std::fabs(tP_eta) < 2.0){
       reseta_eta1p6to2->Fill(eta_res);
       resphi_eta1p6to2->Fill(phi_res);
       resVtxZ_eta1p6to2->Fill(VtxZ_res);
@@ -529,7 +529,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event& iEvent, con
       else if (tP_pt >= 3  && tP_pt < 8) respt_eta1p6to2_pt3to8->Fill(pt_res);
       else if (tP_pt >= 8) respt_eta1p6to2_pt8toInf->Fill(pt_res);
     }
-    else if (fabs(tP_eta) >= 2.0 && fabs(tP_eta) <= 2.4){
+    else if (std::fabs(tP_eta) >= 2.0 && std::fabs(tP_eta) <= 2.4){
       reseta_eta2to2p4->Fill(eta_res);
       resphi_eta2to2p4->Fill(phi_res);
       resVtxZ_eta2to2p4->Fill(VtxZ_res);
@@ -1177,7 +1177,7 @@ int OuterTrackerMonitorTrackingParticles::Layer(const float R_, const float Z_) 
   const float zMin[sectionNum]={0.,125.,145.,165.,200.,240.};
   int layer=-1;
   for (int i=5;i>=0;--i){
-    if(fabs(Z_)>=zMin[i]){
+    if(std::fabs(Z_)>=zMin[i]){
       layer=5+i;
       break;
     }

--- a/Validation/SiOuterTrackerV/python/OuterTrackerMonitorTrackingParticles_cfi.py
+++ b/Validation/SiOuterTrackerV/python/OuterTrackerMonitorTrackingParticles_cfi.py
@@ -70,6 +70,13 @@ OuterTrackerMonitorTrackingParticles = DQMEDAnalyzer('OuterTrackerMonitorTrackin
         xmin = cms.double(0)
         ),
 
+# tracking particles vs pT (for efficiency)
+    TH1Effic_pt_zoom = cms.PSet(
+        Nbinsx = cms.int32(50),
+        xmax = cms.double(10),
+        xmin = cms.double(0)
+        ),
+
 # tracking particles vs eta (for efficiency)
     TH1Effic_eta = cms.PSet(
         Nbinsx = cms.int32(50),

--- a/Validation/SiOuterTrackerV/src/OuterTrackerMCHarvester.cc
+++ b/Validation/SiOuterTrackerV/src/OuterTrackerMCHarvester.cc
@@ -44,6 +44,8 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::I
 		MonitorElement *meD_eta = dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_eta");
 		MonitorElement *meN_pt = dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_pt");
 		MonitorElement *meD_pt = dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_pt");
+		MonitorElement *meN_pt_zoom = dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_pt_zoom");
+		MonitorElement *meD_pt_zoom = dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_pt_zoom");
 		MonitorElement *meN_d0 = dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_d0");
 		MonitorElement *meD_d0 = dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_d0");
 		MonitorElement *meN_VtxR = dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_VtxR");
@@ -151,6 +153,33 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::I
 			me_effic_pt->getTH1F()->SetStats(false);
 		} //if ME found
 		else {edm::LogWarning("DataNotFound") << "Monitor elements for pT efficiency cannot be found!\n";}
+
+		if (meN_pt_zoom && meD_pt_zoom) {
+			// Get the numerator and denominator histograms
+			TH1F *numerator2_zoom = meN_pt_zoom->getTH1F();
+			numerator2_zoom->Sumw2();
+			TH1F *denominator2_zoom = meD_pt_zoom->getTH1F();
+			denominator2_zoom->Sumw2();
+
+			// Set the current directory
+			dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalEfficiency");
+
+			// Book the new histogram to contain the results
+			MonitorElement *me_effic_pt_zoom =
+			ibooker.book1D("PtEfficiency_zoom","p_{T} efficiency",
+			numerator2_zoom->GetNbinsX(),
+			numerator2_zoom->GetXaxis()->GetXmin(),
+			numerator2_zoom->GetXaxis()->GetXmax());
+
+			// Calculate the efficiency
+			me_effic_pt_zoom->getTH1F()->Divide(numerator2_zoom, denominator2_zoom, 1., 1., "B");
+			me_effic_pt_zoom->getTH1F()->GetXaxis()->SetTitle("Tracking particle p_{T} [GeV]");
+			me_effic_pt_zoom->getTH1F()->GetYaxis()->SetTitle("Efficiency");
+			me_effic_pt_zoom->getTH1F()->SetMaximum(1.0);
+			me_effic_pt_zoom->getTH1F()->SetMinimum(0.0);
+			me_effic_pt_zoom->getTH1F()->SetStats(false);
+		} //if ME found
+		else {edm::LogWarning("DataNotFound") << "Monitor elements for zoom pT efficiency cannot be found!\n";}
 
 		if (meN_d0 && meD_d0) {
 			// Get the numerator and denominator histograms


### PR DESCRIPTION
Hello all,
My proposed changes to the SiOuterTracker for DQM:
Add a zoomed pT (0-10 GeV) efficiency plot for the L1 tracks
Modified the axis range for NStubs and NClusters
Changed abs->fabs