### PR TITLE
[10.1.X] Fix for ALCARECOSiStripCalMinBiasTrackingDQM as discussed on PR #23498

### DIFF
--- a/DQMOffline/CalibTracker/python/ALCARECOSiStripCalMinBiasDQM_cff.py
+++ b/DQMOffline/CalibTracker/python/ALCARECOSiStripCalMinBiasDQM_cff.py
@@ -13,6 +13,7 @@ ALCARECOSiStripCalMinBiasTrackingDQM = DQM.TrackingMonitor.TrackingMonitor_cfi.T
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
+    MeasurementState = "default",
 # margins and settings
     TkSizeBin = 71,
     TkSizeMin = -0.5,


### PR DESCRIPTION
backport of #23523
as a reminder this is needed, because without this change, once the MC AlCaReco TriggerBits for the `SiStripCalMinBias` ALCARECO producer are activated (as it is done e.g. in #23498) the module `ALCARECOSiStripCalMinBiasTrackingDQM` will fail with: 
```
----- Begin Fatal Exception 06-Jun-2018 00:47:08 CEST-----------------------
An exception of category 'NoRecord' occurred while
[0] Processing Event run: 1 lumi: 1 event: 1 stream: 0
[1] Running path 'pathALCARECOSiStripCalMinBias'
[2] Calling method for module TrackingMonitor/'ALCARECOSiStripCalMinBiasTrackingDQM'
Exception Message:
No "TransientTrackRecord" record found in the EventSetup.n
Please add an ESSource or ESProducer that delivers such a record.
----- End Fatal Exception -------------------------------------------------
```
In turn the activation of the of the Trigger Bits is needed to be able to generate a sample of `SiStripCalMinBias` events to derive the G2 calibration for the physics MC in 10.2.X.