### PR TITLE
[10.2.X] MC conditions for 2018

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,27 +2,27 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '101X_mcRun1_design_v4',
+    'run1_design'       :   '102X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '101X_mcRun1_realistic_v4',
+    'run1_mc'           :   '102X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '101X_mcRun1_HeavyIon_v4',
+    'run1_mc_hi'        :   '102X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '101X_mcRun1_pA_v4',
+    'run1_mc_pa'        :   '102X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '102X_mcRun2_design_v1',
+    'run2_design'       :   '102X_mcRun2_design_v2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '102X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '102X_mcRun2_startup_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '102X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '102X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '102X_mcRun2cosmics_startup_deco_v1',
+    'run2_mc_cosmics'   :   '102X_mcRun2cosmics_startup_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '102X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'        :   '102X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '102X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '102X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '102X_dataRun2_v3',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,25 +40,25 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '102X_mc2017_design_IdealBS_v1',
+    'phase1_2017_design'       :  '102X_mc2017_design_IdealBS_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '102X_mc2017_realistic_v1',
+    'phase1_2017_realistic'    : '102X_mc2017_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '102X_mc2017cosmics_realistic_deco_v1',
+    'phase1_2017_cosmics'      : '102X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '102X_mc2017cosmics_realistic_peak_v1',
+    'phase1_2017_cosmics_peak' : '102X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '102X_upgrade2018_design_v1',
+    'phase1_2018_design'       : '102X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v1',
+    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '102X_postLS2_design_v1', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '102X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'       : '102X_postLS2_realistic_v1', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'       : '102X_postLS2_realistic_v2', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '102X_upgrade2023_realistic_v1'
+    'phase2_realistic'         : '102X_upgrade2023_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
# Summary of changes in Global Tags

## RunI simulation

   * **RunI Heavy Ions scenario** : [101X_mcRun1_HeavyIon_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_HeavyIon_v4) as [102X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun1_HeavyIon_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun1_HeavyIon_v4/102X_mcRun1_HeavyIon_v1):
      * AlCaRecoHLTpaths

   * **RunI Ideal scenario** : [101X_mcRun1_design_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_design_v4) as [102X_mcRun1_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun1_design_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun1_design_v4/102X_mcRun1_design_v1):
      * AlCaRecoHLTpaths

   * **RunI Proton-Lead scenario** : [101X_mcRun1_pA_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_pA_v4) as [102X_mcRun1_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun1_pA_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun1_pA_v4/102X_mcRun1_pA_v1):
      * AlCaRecoHLTpaths

   * **RunI Realistic scenario** : [101X_mcRun1_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/101X_mcRun1_realistic_v4) as [102X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun1_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_mcRun1_realistic_v4/102X_mcRun1_realistic_v1):
      * AlCaRecoHLTpaths

## RunII simulation

   * **RunII Asymptotic scenario** : [102X_mcRun2_asymptotic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_asymptotic_v2) as [102X_mcRun2_asymptotic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_asymptotic_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mcRun2_asymptotic_v2/102X_mcRun2_asymptotic_v3):
      * AlCaRecoHLTpaths

   * **RunII CRAFT scenario** : [102X_mcRun2cosmics_startup_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2cosmics_startup_deco_v1) as [102X_mcRun2cosmics_startup_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2cosmics_startup_deco_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mcRun2cosmics_startup_deco_v1/102X_mcRun2cosmics_startup_deco_v2):
      * AlCaRecoHLTpaths

   * **RunII Heavy Ions scenario** : [102X_mcRun2_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_HeavyIon_v1) as [102X_mcRun2_HeavyIon_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mcRun2_HeavyIon_v1/102X_mcRun2_HeavyIon_v2):
      * AlCaRecoHLTpaths

   * **RunII Ideal scenario** : [102X_mcRun2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_design_v1) as [102X_mcRun2_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_design_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mcRun2_design_v1/102X_mcRun2_design_v2):
      * AlCaRecoHLTpaths

   * **RunII Proton-Lead scenario** : [102X_mcRun2_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_pA_v1) as [102X_mcRun2_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_pA_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mcRun2_pA_v1/102X_mcRun2_pA_v2):
      * AlCaRecoHLTpaths

   * **RunII Startup scenario** : [102X_mcRun2_startup_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_startup_v1) as [102X_mcRun2_startup_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mcRun2_startup_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mcRun2_startup_v1/102X_mcRun2_startup_v2):
      * AlCaRecoHLTpaths

## Upgrade

   * **PhaseII realistic scenario** : [102X_upgrade2023_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_upgrade2023_realistic_v1) as [102X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_upgrade2023_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2023_realistic_v1/102X_upgrade2023_realistic_v2):
      * EcalChannelStatus CTPPS_Geometry AlCaRecoHLTpaths

   * **PhaseI 2018 cosmics scenario** : [102X_upgrade2018cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_upgrade2018cosmics_realistic_deco_v1) as [102X_upgrade2018cosmics_realistic_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_upgrade2018cosmics_realistic_deco_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018cosmics_realistic_deco_v1/102X_upgrade2018cosmics_realistic_deco_v2):
      * EcalChannelStatus CTPPS_Geometry_2018 AlCaRecoHLTpaths HcalChannelQuality HcalGainsHcalPedestals HcalPedestalWidthsHcalSiPMParameters

   * **PhaseI 2018 design scenario** : [102X_upgrade2018_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_upgrade2018_design_v1) as [102X_upgrade2018_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_upgrade2018_design_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018_design_v1/102X_upgrade2018_design_v2):
      * EcalChannelStatus CTPPS_Geometry_2018 AlCaRecoHLTpaths HcalChannelQuality HcalGainsHcalPedestals HcalPedestalWidthsHcalSiPMParameters

   * **PhaseI 2018 realistic scenario** : [102X_upgrade2018_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_upgrade2018_realistic_v1) as [102X_upgrade2018_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_upgrade2018_realistic_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018_realistic_v1/102X_upgrade2018_realistic_v3):
      * EcalChannelStatus CTPPS_Geometry_2018 AlCaRecoHLTpaths HcalChannelQuality HcalGainsHcalPedestals HcalPedestalWidthsHcalSiPMParameters

## 2017_MC

   * **PhaseI 2017 cosmics peak scenario** : [102X_mc2017cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mc2017cosmics_realistic_deco_v1) as [102X_mc2017cosmics_realistic_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mc2017cosmics_realistic_deco_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mc2017cosmics_realistic_deco_v1/102X_mc2017cosmics_realistic_deco_v2):
      * AlCaRecoHLTpaths ExtendedDetailedCavern2017Plan1

   * **PhaseI 2017 cosmics scenario** : [102X_mc2017cosmics_realistic_peak_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mc2017cosmics_realistic_peak_v1) as [102X_mc2017cosmics_realistic_peak_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mc2017cosmics_realistic_peak_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mc2017cosmics_realistic_peak_v1/102X_mc2017cosmics_realistic_peak_v2):
      * AlCaRecoHLTpaths ExtendedDetailedCavern2017Plan1

   * **PhaseI 2017 design scenario** : [102X_mc2017_design_IdealBS_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mc2017_design_IdealBS_v1) as [102X_mc2017_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mc2017_design_IdealBS_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mc2017_design_IdealBS_v1/102X_mc2017_design_IdealBS_v2):
      * AlCaRecoHLTpaths ExtendedDetailedCavern2017Plan1

   * **PhaseI 2017 realistic scenario** : [102X_mc2017_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mc2017_realistic_v1) as [102X_mc2017_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_mc2017_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mc2017_realistic_v1/102X_mc2017_realistic_v2):
      * AlCaRecoHLTpaths ExtendedDetailedCavern2017Plan1

# Notes
. Due to a broken paths in the DQM code this PR will fail if not tested with #23523 