### PR TITLE
Have FileWriteError be an edm::Exception

### DIFF
--- a/FWCore/Utilities/interface/EDMException.h
+++ b/FWCore/Utilities/interface/EDMException.h
@@ -62,6 +62,8 @@ namespace edm {
        ExceededResourceVSize = 8030,
        ExceededResourceRSS = 8031,
        ExceededResourceTime = 8032,
+
+       FileWriteError = 8033,
       
        EventGenerationFailure = 8501,
 

--- a/FWCore/Utilities/src/EDMException.cc
+++ b/FWCore/Utilities/src/EDMException.cc
@@ -41,6 +41,7 @@ namespace edm {
       FILLENTRY(ExceededResourceVSize),
       FILLENTRY(ExceededResourceRSS),
       FILLENTRY(ExceededResourceTime),
+      FILLENTRY(FileWriteError),
       FILLENTRY(EventGenerationFailure),
       FILLENTRY(CaughtSignal)
     };

--- a/Utilities/DCacheAdaptor/src/DCacheFile.cc
+++ b/Utilities/DCacheAdaptor/src/DCacheFile.cc
@@ -242,7 +242,7 @@ DCacheFile::write (const void *from, IOSize n)
     dc_errno = 0;
     ssize_t s = dc_write (m_fd, (const char *) from + done, n - done);
     if (s == -1) {
-      cms::Exception ex("FileWriteError");
+      edm::Exception ex(edm::errors::FileWriteError);
       ex << "dc_write(name='" << m_name << "', n=" << (n-done)
          << ") failed with error '" << dc_strerror(dc_errno)
          << "' (dc_errno=" << dc_errno << ")";

--- a/Utilities/DavixAdaptor/src/DavixFile.cc
+++ b/Utilities/DavixAdaptor/src/DavixFile.cc
@@ -343,7 +343,7 @@ IOSize DavixFile::read(void *into, IOSize n) {
 }
 
 IOSize DavixFile::write(const void *from, IOSize n) {
-  cms::Exception ex("FileWriteError");
+  edm::Exception ex(edm::errors::FileWriteError);
   ex << "DavixFile::write(name='" << m_name << "') not implemented";
   ex.addContext("Calling DavixFile::write()");
   throw ex;

--- a/Utilities/StorageFactory/src/UnixFile.cc
+++ b/Utilities/StorageFactory/src/UnixFile.cc
@@ -87,7 +87,7 @@ File::write (const void *from, IOSize n, IOOffset pos)
   while (s == -1 && errno == EINTR);
 
   if (s == -1)
-    throwStorageError("FileWriteError", "Calling File::write()", "pwrite()", errno);
+    throwStorageError(edm::errors::FileWriteError, "Calling File::write()", "pwrite()", errno);
 
   if (m_flags & OpenUnbuffered)
     // FIXME: Exception handling?

--- a/Utilities/StorageFactory/src/UnixIOChannel.cc
+++ b/Utilities/StorageFactory/src/UnixIOChannel.cc
@@ -64,7 +64,7 @@ IOChannel::write (const void *from, IOSize n)
   while (s == -1 && errno == EINTR);
 
   if (s == -1 && errno != EWOULDBLOCK)
-    throwStorageError ("FileWriteError", "Calling IOChannel::write()", "write()", errno);
+    throwStorageError (edm::errors::FileWriteError, "Calling IOChannel::write()", "write()", errno);
 
   return s >= 0 ? s : 0;
 }
@@ -95,7 +95,7 @@ IOChannel::writev (const IOBuffer *from, IOSize buffers)
 
   // If it was serious error, throw it.
   if (n == -1)
-    throwStorageError ("FileWriteError", "Calling IOChannel::writev()", "writev()", errno);
+    throwStorageError (edm::errors::FileWriteError, "Calling IOChannel::writev()", "writev()", errno);
 
   // Return the number of bytes actually written.
   return n;

--- a/Utilities/XrdAdaptor/src/XrdFile.cc
+++ b/Utilities/XrdAdaptor/src/XrdFile.cc
@@ -475,7 +475,7 @@ IOSize
 XrdFile::write (const void *from, IOSize n)
 {
   if (n > 0x7fffffff) {
-    cms::Exception ex("FileWriteError");
+    edm::Exception ex(edm::errors::FileWriteError);
     ex << "XrdFile::write(name='" << m_name << "', n=" << n
        << ") too many bytes, limit is 0x7fffffff";
     ex.addContext("Calling XrdFile::write()");
@@ -486,7 +486,7 @@ XrdFile::write (const void *from, IOSize n)
 
   XrdCl::XRootDStatus s = file->Write(m_offset, n, from);
   if (!s.IsOK()) {
-    cms::Exception ex("FileWriteError");
+    edm::Exception ex(edm::errors::FileWriteError);
     ex << "XrdFile::write(name='" << m_name << "', n=" << n
        << ") failed with error '" << s.ToStr()
        << "' (errno=" << s.errNo << ", code=" << s.code << ")";
@@ -506,7 +506,7 @@ IOSize
 XrdFile::write (const void *from, IOSize n, IOOffset pos)
 {
   if (n > 0x7fffffff) {
-    cms::Exception ex("FileWriteError");
+    edm::Exception ex(edm::errors::FileWriteError);
     ex << "XrdFile::write(name='" << m_name << "', n=" << n
        << ") too many bytes, limit is 0x7fffffff";
     ex.addContext("Calling XrdFile::write()");
@@ -517,7 +517,7 @@ XrdFile::write (const void *from, IOSize n, IOOffset pos)
 
   XrdCl::XRootDStatus s = file->Write(pos, n, from);
   if (!s.IsOK()) {
-    cms::Exception ex("FileWriteError");
+    edm::Exception ex(edm::errors::FileWriteError);
     ex << "XrdFile::write(name='" << m_name << "', n=" << n
        << ") failed with error '" << s.ToStr()
        << "' (errno=" << s.errNo << ", code=" << s.code << ")";


### PR DESCRIPTION
By using an edm::Exception instead of a cms::Exception, cmsRun will return a unique error code.
This was requested by the CRAB team.