### PR TITLE
Full workflow for HGCal v9

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C4_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C4_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2_cff import Phase2
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+
+Phase2C4 = cms.ModifierChain(Phase2, phase2_hgcalV9)
+

--- a/Configuration/Eras/python/Era_Phase2C4_timing_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C4_timing_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C4_cff import Phase2C4
+from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
+
+Phase2C4_timing = cms.ModifierChain(Phase2C4, phase2_timing)
+

--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -17,8 +17,9 @@ numWFIB = [20034.0,20034.1,20034.11] #2023D17 w/ special tracking and timing wor
 numWFIB.extend([20261.97]) # 2023D17 premixing stage1 (NuGun+PU)
 numWFIB.extend([20234.99]) # 2023D17 premixing combined stage1+stage2 (ttbar+PU)
 numWFIB.extend([20434.0]) #2023D19 (already has timing)
-numWFIB.extend([21234.0,21234.11]) #2023D21  
-numWFIB.extend([21634.0]) #2023D22  
-numWFIB.extend([22034.0]) #2023D23  
+numWFIB.extend([21234.0,21234.11]) #2023D21
+numWFIB.extend([21634.0]) #2023D22
+numWFIB.extend([22034.0]) #2023D23
+numWFIB.extend([24034.0]) #2023D28
 for numWF in numWFIB:
     workflows[numWF] = _upgrade_workflows[numWF]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2461,6 +2461,7 @@ defaultDataSets['2023D24']=''
 defaultDataSets['2023D25']=''
 defaultDataSets['2023D26']=''
 defaultDataSets['2023D27']=''
+defaultDataSets['2023D28']=''
 
 keys=defaultDataSets.keys()
 for key in keys:

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -15,7 +15,7 @@ def makeStepNameSim(key,frag,step,suffix):
 def makeStepName(key,frag,step,suffix):
    return step+suffix+'_'+key
 
-neutronKeys = ['2023D17','2023D19','2023D21','2023D22','2023D23','2023D24','2023D25','2023D26','2023D27']
+neutronKeys = ['2023D17','2023D19','2023D21','2023D22','2023D23','2023D24','2023D25','2023D26','2023D27','2023D28']
 neutronFrags = ['ZMM_14','MinBias_14TeV']
 
 #just define all of them

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -38,6 +38,8 @@ upgradeKeys[2023] = [
     '2023D26PU',
     '2023D27',
     '2023D27PU',
+    '2023D28',
+    '2023D28PU',
 ]
 
 # pre-generation of WF numbers
@@ -314,7 +316,14 @@ upgradeProperties[2023] = {
         'GT' : 'auto:phase2_realistic',
         'Era' : 'Phase2',
         'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
-     }
+     },
+    '2023D28' : {
+        'Geom' : 'Extended2023D28',
+        'HLTmenu': '@fake2',
+        'GT' : 'auto:phase2_realistic',
+        'Era' : 'Phase2C4',
+        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+     },
 }
 
 
@@ -338,6 +347,8 @@ upgradeProperties[2023]['2023D26PU'] = deepcopy(upgradeProperties[2023]['2023D26
 upgradeProperties[2023]['2023D26PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullTriggerPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
 upgradeProperties[2023]['2023D27PU'] = deepcopy(upgradeProperties[2023]['2023D27'])
 upgradeProperties[2023]['2023D27PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullTriggerPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
+upgradeProperties[2023]['2023D28PU'] = deepcopy(upgradeProperties[2023]['2023D28'])
+upgradeProperties[2023]['2023D28PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullTriggerPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
 
 
 from  Configuration.PyReleaseValidation.relval_steps import Kby

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -31,7 +31,10 @@ class Eras (object):
                  'Phase2',
                  'Phase2_timing',
                  'Phase2_timing_layer',
-                 'Phase2_timing_layer_new']
+                 'Phase2_timing_layer_new',
+				 'Phase2C4',
+				 'Phase2C4_timing',
+		]
 
         internalUseMods = ['run2_common', 'run2_25ns_specific',
                            'run2_50ns_specific', 'run2_HI_specific',
@@ -43,7 +46,7 @@ class Eras (object):
                            'phase1Pixel', 'run3_GEM', 'run2_GEM_2017',
                            'run2_CSC_2018',
                            'phase2_common', 'phase2_tracker',
-                           'phase2_hgcal', 'phase2_muon', 'phase2_timing',
+                           'phase2_hgcal', 'phase2_muon', 'phase2_timing', 'phase2_hgcalV9',
                            'phase2_timing_layer','phase2_timing_layer_new','phase2_hcal',
                            'trackingLowPU', 'trackingPhase1', 'ctpps_2016', 'trackingPhase2PU140','highBetaStar_2018',
                            'tracker_apv_vfp30_2016', 'run2_miniAOD_80XLegacy','run2_miniAOD_94XFall17', 'run2_nanoAOD_92X',

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -32,9 +32,9 @@ class Eras (object):
                  'Phase2_timing',
                  'Phase2_timing_layer',
                  'Phase2_timing_layer_new',
-				 'Phase2C4',
-				 'Phase2C4_timing',
-		]
+                 'Phase2C4',
+                 'Phase2C4_timing',
+        ]
 
         internalUseMods = ['run2_common', 'run2_25ns_specific',
                            'run2_50ns_specific', 'run2_HI_specific',

--- a/Geometry/HGCalCommonData/src/HGCalParametersFromDD.cc
+++ b/Geometry/HGCalCommonData/src/HGCalParametersFromDD.cc
@@ -173,20 +173,20 @@ bool HGCalParametersFromDD::build(const DDCompactView* cpv,
       geom->loadSpecParsHexagon8(fv, php);
       //Load Geometry parameters
       geom->loadGeometryHexagon8(fv, php, 1);
-      //Load wafer positions
-      geom->loadWaferHexagon8(php);
       //Set complete fill mode
       php.defineFull_ = false;
+      //Load wafer positions
+      geom->loadWaferHexagon8(php);
     } else if (php.mode_ == HGCalGeometryMode::Hexagon8Full) {
       //Load the SpecPars
       php.firstLayer_ = 1;
       geom->loadSpecParsHexagon8(fv, php);
       //Load Geometry parameters
       geom->loadGeometryHexagon8(fv, php, 1);
-      //Load wafer positions
-      geom->loadWaferHexagon8(php);
       //Set complete fill mode
       php.defineFull_ = true;
+      //Load wafer positions
+      geom->loadWaferHexagon8(php);
     } else if (php.mode_ == HGCalGeometryMode::Trapezoid) {
       //Load maximum eta & top level
       php.etaMinBH_        = getDDDValue("etaMinBH", sv);

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -62,7 +62,8 @@ _phase2_siml1emulator = SimL1Emulator.copy()
 _phase2_siml1emulator += hgcalTriggerPrimitives
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toReplaceWith( SimL1Emulator , _phase2_siml1emulator )
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+(phase2_hgcal & ~phase2_hgcalV9).toReplaceWith( SimL1Emulator , _phase2_siml1emulator )
 
 # If PreMixing, don't run these modules during first step
 # TODO: Do we actually need anything from here run in stage1?

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -50,6 +50,10 @@ namespace {
     const auto v = position - origin;
     return energy*std::sqrt(v.perp2()/v.mag2());
   }
+
+  inline bool isHGCalDet(DetId::Detector thedet){
+    return (thedet == DetId::Forward || thedet == DetId::Hcal || thedet == DetId::HGCalEE || thedet == DetId::HGCalHSi || thedet == DetId::HGCalHSc);
+  }
 }
 
 GEDPhotonProducer::RecoStepInfo::RecoStepInfo(const std::string& step):
@@ -510,7 +514,7 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     //    const reco::SuperCluster* pClus=&(*scRef);
     iSC++;
     
-    int thedet = scRef->seed()->hitsAndFractions()[0].first.det();
+    DetId::Detector thedet = scRef->seed()->hitsAndFractions()[0].first.det();
     int subdet = scRef->seed()->hitsAndFractions()[0].first.subdetId();
     if (subdet==EcalBarrel) { 
       preselCutValues = preselCutValuesBarrel_;
@@ -522,13 +526,13 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
       hits = ecalEndcapHits;
       flags_ = flagsexclEE_;
       severitiesexcl_ = severitiesexclEE_;
-    } else if ( thedet == DetId::Forward || thedet == DetId::Hcal)  {
+    } else if ( isHGCalDet(thedet) ) {
       preselCutValues = preselCutValuesEndcap_;
       hits = nullptr;
       flags_ = flagsexclEE_;
       severitiesexcl_ = severitiesexclEE_;
     } else {
-      edm::LogWarning("")<<"GEDPhotonProducer: do not know if it is a barrel or endcap SuperCluster" << thedet << ' ' << subdet; 
+      edm::LogWarning("")<<"GEDPhotonProducer: do not know if it is a barrel or endcap SuperCluster: " << thedet << ' ' << subdet; 
     }
 
     
@@ -612,7 +616,7 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     // Calculate fiducial flags and isolation variable. Blocked are filled from the isolationCalculator
     reco::Photon::FiducialFlags fiducialFlags;
     reco::Photon::IsolationVariables isolVarR03, isolVarR04;
-    if( thedet != DetId::Forward && thedet != DetId::Hcal) {
+    if( !isHGCalDet(thedet) ) {
       thePhotonIsolationCalculator_->calculate( &newCandidate,evt,es,fiducialFlags,isolVarR04, isolVarR03);
     }
     newCandidate.setFiducialVolumeFlags( fiducialFlags );
@@ -713,7 +717,7 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     /// plus values from regressions     and store them in the Photon
     // Photon candidate takes by default (set in photons_cfi.py) 
     // a 4-momentum derived from the ecal photon-specific corrections. 
-    if( thedet != DetId::Forward && thedet != DetId::Hcal) {
+    if( !isHGCalDet(thedet) ) {
       thePhotonEnergyCorrector_->calculate(evt, newCandidate, subdet, vertexCollection, es);
       if ( candidateP4type_ == "fromEcalEnergy") {
 	newCandidate.setP4( newCandidate.p4(reco::Photon::ecal_photons) );
@@ -808,13 +812,13 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     reco::PhotonRef phoRef(reco::PhotonRef(photonHandle, lSC));
     reco::SuperClusterRef parentSCRef = phoRef->parentSuperCluster();
     reco::SuperClusterRef scRef=phoRef->superCluster();
-    int thedet = scRef->seed()->hitsAndFractions()[0].first.det();
+    DetId::Detector thedet = scRef->seed()->hitsAndFractions()[0].first.det();
     int subdet = scRef->seed()->hitsAndFractions()[0].first.subdetId();
     if (subdet==EcalBarrel) { 
       preselCutValues = preselCutValuesBarrel_;
     } else if (subdet==EcalEndcap)  { 
       preselCutValues = preselCutValuesEndcap_;
-    } else if ( thedet == DetId::Forward || thedet == DetId::Hcal) {
+    } else if (isHGCalDet(thedet)) {
       preselCutValues = preselCutValuesEndcap_;
     } else {
       edm::LogWarning("")<<"GEDPhotonProducer: do not know if it is a barrel or endcap SuperCluster" << thedet << ' ' << subdet; 

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
@@ -164,8 +164,6 @@ private:
 // last layer per subdetector
 static const unsigned int lastLayerEE = 28;
 static const unsigned int lastLayerFH = 40;
-// maximum number of wafers per Layer: 666 (V7), 794 (V8)
-static const unsigned int maxNumberOfWafersPerLayer = 796;
 
 // The two parameters used to identify clusters
 std::vector<double> vecDeltas;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -8,6 +8,7 @@
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 
 class CaloGeometry;
+class CaloSubdetectorGeometry;
 class DetId;
 
 namespace edm {
@@ -23,6 +24,7 @@ namespace hgcal {
 
     void getEvent(const edm::Event&);
     void getEventSetup(const edm::EventSetup&);
+    const CaloSubdetectorGeometry* getSubdetectorGeometry( const DetId& id ) const;
 
     GlobalPoint getPosition(const DetId& id) const;
     // zside returns +/- 1

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -18,7 +18,7 @@ namespace edm {
 namespace hgcal {
   class RecHitTools {
   public:
-    RecHitTools() : geom_(nullptr), mode_(0), fhOffset_(0), bhOffset_(0) {}
+    RecHitTools() : geom_(nullptr), fhOffset_(0), bhOffset_(0) {}
     ~RecHitTools() {}
 
     void getEvent(const edm::Event&);
@@ -54,10 +54,8 @@ namespace hgcal {
     unsigned int lastLayerEE() const {return fhOffset_;}
     unsigned int lastLayerFH() const {return bhOffset_;}
     unsigned int maxNumberOfWafersPerLayer() const {return maxNumberOfWafersPerLayer_;}
-    void         setMode(int mode) { mode_ = mode;}
   private:
     const CaloGeometry* geom_;
-    int                 mode_;
     unsigned int        fhOffset_, bhOffset_, maxNumberOfWafersPerLayer_;
   };
 }

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -19,7 +19,7 @@ namespace edm {
 namespace hgcal {
   class RecHitTools {
   public:
-    RecHitTools() : geom_(nullptr), fhOffset_(0), bhOffset_(0) {}
+    RecHitTools() : geom_(nullptr), fhOffset_(0), bhOffset_(0), geometryType_(0) {}
     ~RecHitTools() {}
 
     void getEvent(const edm::Event&);
@@ -27,6 +27,7 @@ namespace hgcal {
     const CaloSubdetectorGeometry* getSubdetectorGeometry( const DetId& id ) const;
 
     GlobalPoint getPosition(const DetId& id) const;
+    GlobalPoint getPositionLayer(unsigned layer) const;
     // zside returns +/- 1
     int zside(const DetId& id) const;
 
@@ -60,6 +61,7 @@ namespace hgcal {
   private:
     const CaloGeometry* geom_;
     unsigned int        fhOffset_, bhOffset_, maxNumberOfWafersPerLayer_;
+    int geometryType_;
   };
 }
 

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -30,6 +30,7 @@ namespace hgcal {
 
     std::float_t getSiThickness(const DetId&) const;
     std::float_t getRadiusToSide(const DetId&) const;
+    int getSiThickIndex(const DetId&) const;
 
     unsigned int getLayer(DetId::Detector type) const;
     unsigned int getLayer(ForwardSubdetector type) const;

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -615,17 +615,12 @@ void HGCalImagingAlgo::computeThreshold() {
 
   if (initialized)
     return; // only need to calculate thresholds once
-  const std::vector<DetId> &listee(rhtools_.getGeometry()->getValidDetIds(
-      DetId::Forward, ForwardSubdetector::HGCEE));
-  const std::vector<DetId> &listfh(rhtools_.getGeometry()->getValidDetIds(
-      DetId::Forward, ForwardSubdetector::HGCHEF));
 
   std::vector<double> dummy;
   const unsigned maxNumberOfThickIndices = 3;
   dummy.resize(maxNumberOfThickIndices, 0);
   thresholds.resize(maxlayer, dummy);
   v_sigmaNoise.resize(maxlayer, dummy);
-  int previouswafer = -999;
 
   for (unsigned ilayer = 1; ilayer <= maxlayer; ++ilayer) {
     for (unsigned ithick = 0; ithick < maxNumberOfThickIndices; ++ithick) {

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -36,10 +36,10 @@ void HGCalImagingAlgo::populate(const HGCRecHitCollection &hits) {
         thickness = rhtools_.getSiThickness(detid);
       double storedThreshold =
           thresholds[layer - 1]
-                    [layer <= lastLayerFH ? rhtools_.getWafer(detid) : 0];
+                    [layer <= lastLayerFH ? rhtools_.getSiThickIndex(detid) : 0];
       sigmaNoise =
           v_sigmaNoise[layer - 1]
-                      [layer <= lastLayerFH ? rhtools_.getWafer(detid) : 0];
+                      [layer <= lastLayerFH ? rhtools_.getSiThickIndex(detid) : 0];
 
       if (hgrh.energy() < storedThreshold)
         continue; // this sets the ZS threshold at ecut times the sigma noise
@@ -621,39 +621,19 @@ void HGCalImagingAlgo::computeThreshold() {
       DetId::Forward, ForwardSubdetector::HGCHEF));
 
   std::vector<double> dummy;
-  dummy.resize(maxNumberOfWafersPerLayer, 0);
+  const unsigned maxNumberOfThickIndices = 3;
+  dummy.resize(maxNumberOfThickIndices, 0);
   thresholds.resize(maxlayer, dummy);
   v_sigmaNoise.resize(maxlayer, dummy);
   int previouswafer = -999;
 
-  for (unsigned icalo = 0; icalo < 2; ++icalo) {
-    const std::vector<DetId> &listDetId(icalo == 0 ? listee : listfh);
-
-    for (auto &detid : listDetId) {
-      int wafer = rhtools_.getWafer(detid);
-      if (wafer == previouswafer)
-        continue;
-      previouswafer = wafer;
-      // no need to do it twice
-      if (rhtools_.zside(detid) < 0)
-        continue;
-      int layer = rhtools_.getLayerWithOffset(detid);
-      float thickness = rhtools_.getSiThickness(detid);
-      int thickIndex = -1;
-      if (thickness > 99. && thickness < 101.)
-        thickIndex = 0;
-      else if (thickness > 199. && thickness < 201.)
-        thickIndex = 1;
-      else if (thickness > 299. && thickness < 301.)
-        thickIndex = 2;
-      else
-        assert(thickIndex > 0 &&
-               "ERROR - silicon thickness has a nonsensical value");
+  for (unsigned ilayer = 1; ilayer <= maxlayer; ++ilayer) {
+    for (unsigned ithick = 0; ithick < maxNumberOfThickIndices; ++ithick) {
       float sigmaNoise =
-          0.001f * fcPerEle * nonAgedNoises[thickIndex] * dEdXweights[layer] /
-          (fcPerMip[thickIndex] * thicknessCorrection[thickIndex]);
-      thresholds[layer - 1][wafer] = sigmaNoise * ecut;
-      v_sigmaNoise[layer - 1][wafer] = sigmaNoise;
+          0.001f * fcPerEle * nonAgedNoises[ithick] * dEdXweights[ilayer] /
+          (fcPerMip[ithick] * thicknessCorrection[ithick]);
+      thresholds[ilayer - 1][ithick] = sigmaNoise * ecut;
+      v_sigmaNoise[ilayer - 1][ithick] = sigmaNoise;
     }
   }
 

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -86,6 +86,7 @@ void RecHitTools::getEventSetup(const edm::EventSetup& es) {
   auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::HGCalEE,ForwardSubdetector::ForwardEmpty));
   //check if it's the new geometry
   if(geomEE) {
+    geometryType_ = 1;
     fhOffset_ = (geomEE->topology().dddConstants()).layers(true);
     wmaxEE    = (geomEE->topology().dddConstants()).waferCount(0);
     auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::HGCalHSi,ForwardSubdetector::ForwardEmpty));
@@ -93,6 +94,7 @@ void RecHitTools::getEventSetup(const edm::EventSetup& es) {
     wmaxFH    = (geomFH->topology().dddConstants()).waferCount(0);
   }
   else {
+    geometryType_ = 0;
     geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
     fhOffset_ = (geomEE->topology().dddConstants()).layers(true);
     wmaxEE    = 1 + (geomEE->topology().dddConstants()).waferMax();
@@ -123,6 +125,20 @@ GlobalPoint RecHitTools::getPosition(const DetId& id) const {
   return position;
 }
 
+GlobalPoint RecHitTools::getPositionLayer(unsigned layer) const {
+  DetId id(0);
+  if(geometryType_==0){
+    if (layer <= fhOffset_) id = HGCalDetId(ForwardSubdetector::HGCEE, 1, layer, 1, 50, 1);
+    else if (layer <= bhOffset_) id = HGCalDetId(ForwardSubdetector::HGCHEF, 1, layer - fhOffset_, 1, 50, 1);
+    else  id = HcalDetId(HcalSubdetector::HcalEndcap, 50, 100, layer - bhOffset_);
+  }
+  else {
+    if (layer <= fhOffset_) id = HGCSiliconDetId(DetId::HGCalEE, 1, 0, layer, 0, 0, 0, 0);
+    else if (layer <= bhOffset_) id = HGCSiliconDetId(DetId::HGCalHSi, 1, 0, layer - fhOffset_, 0, 0, 0, 0);
+    else  id = HGCScintillatorDetId(0, layer - bhOffset_, 1, 0);
+  }
+  return getPosition(id);
+}
 
 int RecHitTools::zside(const DetId& id) const {
   int zside = 0;

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -151,6 +151,24 @@ std::float_t RecHitTools::getSiThickness(const DetId& id) const {
   return thick;
 }
 
+int RecHitTools::getSiThickIndex(const DetId& id) const {
+  int thickIndex = -1;
+  if (id.det() == DetId::Forward) {
+    float thickness = getSiThickness(id);
+    if (thickness > 99. && thickness < 101.)
+      thickIndex = 0;
+    else if (thickness > 199. && thickness < 201.)
+      thickIndex = 1;
+    else if (thickness > 299. && thickness < 301.)
+      thickIndex = 2;
+    else
+      assert(thickIndex > 0 && "ERROR - silicon thickness has a nonsensical value");
+  } else if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
+    thickIndex = HGCSiliconDetId(id).type();
+  }
+  return thickIndex;
+}
+
 std::float_t RecHitTools::getRadiusToSide(const DetId& id) const {
   auto geom = geom_->getSubdetectorGeometry(id);
   check_geom(geom);
@@ -265,16 +283,11 @@ unsigned int RecHitTools::getWafer(const DetId& id) const {
   unsigned int wafer = std::numeric_limits<unsigned int>::max();
   if (id.det() == DetId::Forward) {
     wafer = HGCalDetId(id).wafer();
-  } else if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
-    wafer = HGCSiliconDetId(id).wafer();
-  } else if (id.det() == DetId::HGCalHSc) {
-    wafer = HGCScintillatorDetId(id).wafer();
   }
   else {
     edm::LogError("getWafer::InvalidSiliconDetid")
       << "det id: " << std::hex << id.rawId() << std::dec << ":" 
       << id.det() << " is not HGCal silicon!";
-    return std::numeric_limits<unsigned int>::max();
   }
   return wafer;
 }
@@ -283,16 +296,11 @@ unsigned int RecHitTools::getCell(const DetId& id) const {
   unsigned int cell = std::numeric_limits<unsigned int>::max();
   if (id.det() == DetId::Forward) {
     cell = HGCalDetId(id).cell();
-  } else if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
-    cell = HGCSiliconDetId(id).cell();
-  } else if (id.det() == DetId::HGCalHSc) {
-    cell = HGCScintillatorDetId(id).cell();
   }
   else {
     edm::LogError("getCell::InvalidSiliconDetid")
       << "det id: " << std::hex << id.rawId() << std::dec << ":" 
       << id.det() << " is not HGCal silicon!";
-    return std::numeric_limits<unsigned int>::max();
   }
   return cell;
 }

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -262,39 +262,53 @@ unsigned int RecHitTools::getLayerWithOffset(const DetId& id) const {
 }
 
 unsigned int RecHitTools::getWafer(const DetId& id) const {
-  if( id.det() != DetId::Forward ) {
+  unsigned int wafer = std::numeric_limits<unsigned int>::max();
+  if (id.det() == DetId::Forward) {
+    wafer = HGCalDetId(id).wafer();
+  } else if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
+    wafer = HGCSiliconDetId(id).wafer();
+  } else if (id.det() == DetId::HGCalHSc) {
+    wafer = HGCScintillatorDetId(id).wafer();
+  }
+  else {
     edm::LogError("getWafer::InvalidSiliconDetid")
       << "det id: " << std::hex << id.rawId() << std::dec << ":" 
       << id.det() << " is not HGCal silicon!";
     return std::numeric_limits<unsigned int>::max();
   }
-  const HGCalDetId hid(id);
-  unsigned int wafer = hid.wafer();
   return wafer;
 }
 
 unsigned int RecHitTools::getCell(const DetId& id) const {
-  if( id.det() != DetId::Forward ) {
+  unsigned int cell = std::numeric_limits<unsigned int>::max();
+  if (id.det() == DetId::Forward) {
+    cell = HGCalDetId(id).cell();
+  } else if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
+    cell = HGCSiliconDetId(id).cell();
+  } else if (id.det() == DetId::HGCalHSc) {
+    cell = HGCScintillatorDetId(id).cell();
+  }
+  else {
     edm::LogError("getCell::InvalidSiliconDetid")
       << "det id: " << std::hex << id.rawId() << std::dec << ":" 
       << id.det() << " is not HGCal silicon!";
     return std::numeric_limits<unsigned int>::max();
   }
-  const HGCalDetId hid(id);
-  unsigned int cell = hid.cell();
   return cell;
 }
 
 bool RecHitTools::isHalfCell(const DetId& id) const {
-  if( id.det() != DetId::Forward ) {
-    return false;
+  bool ishalf = false;
+  if (id.det() == DetId::Forward) {
+    HGCalDetId hid(id);
+    auto geom = geom_->getSubdetectorGeometry(hid);
+    check_geom(geom);
+    auto ddd = get_ddd(geom,hid);
+    const int waferType = ddd->waferTypeT(hid.waferType());
+    return ddd->isHalfCell(waferType,hid.cell());
   }
-  auto geom = geom_->getSubdetectorGeometry(id);
-  check_geom(geom);
-  const HGCalDetId hid(id);
-  auto ddd = get_ddd(geom,hid);
-  const int waferType = ddd->waferTypeT(hid.waferType());
-  return ddd->isHalfCell(waferType,hid.cell());
+  //new geometry is always false
+  return ishalf;
 }
 
 float RecHitTools::getEta(const GlobalPoint& position, const float& vertex_z) const {

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -83,20 +83,22 @@ void RecHitTools::getEventSetup(const edm::EventSetup& es) {
 
   geom_ = geom.product();
   unsigned int wmaxEE(0), wmaxFH(0);
-  if (mode_ == 0) {
-    auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
-    fhOffset_ = (geomEE->topology().dddConstants()).layers(true);
-    wmaxEE    = 1 + (geomEE->topology().dddConstants()).waferMax();
-    auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
-    bhOffset_ = fhOffset_ + (geomFH->topology().dddConstants()).layers(true);
-    wmaxFH    = 1 + (geomFH->topology().dddConstants()).waferMax();
-  } else {
-    auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::HGCalEE,ForwardSubdetector::ForwardEmpty));
+  auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::HGCalEE,ForwardSubdetector::ForwardEmpty));
+  //check if it's the new geometry
+  if(geomEE) {
     fhOffset_ = (geomEE->topology().dddConstants()).layers(true);
     wmaxEE    = (geomEE->topology().dddConstants()).waferCount(0);
     auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::HGCalHSi,ForwardSubdetector::ForwardEmpty));
     bhOffset_ = fhOffset_;
     wmaxFH    = (geomFH->topology().dddConstants()).waferCount(0);
+  }
+  else {
+    geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
+    fhOffset_ = (geomEE->topology().dddConstants()).layers(true);
+    wmaxEE    = 1 + (geomEE->topology().dddConstants()).waferMax();
+    auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
+    bhOffset_ = fhOffset_ + (geomFH->topology().dddConstants()).layers(true);
+    wmaxFH    = 1 + (geomFH->topology().dddConstants()).waferMax();
   }
   maxNumberOfWafersPerLayer_ = std::max(wmaxEE,wmaxFH);
 }

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -103,9 +103,16 @@ void RecHitTools::getEventSetup(const edm::EventSetup& es) {
   maxNumberOfWafersPerLayer_ = std::max(wmaxEE,wmaxFH);
 }
 
-GlobalPoint RecHitTools::getPosition(const DetId& id) const {
-  auto geom = geom_->getSubdetectorGeometry(id);
+const CaloSubdetectorGeometry* RecHitTools::getSubdetectorGeometry( const DetId& id ) const {
+  DetId::Detector det = id.det();
+  int subdet = (det == DetId::HGCalEE || det == DetId::HGCalHSi || det == DetId::HGCalHSc) ? ForwardSubdetector::ForwardEmpty : id.subdetId();
+  auto geom = geom_->getSubdetectorGeometry(det,subdet);
   check_geom(geom);
+  return geom;
+}
+
+GlobalPoint RecHitTools::getPosition(const DetId& id) const {
+  auto geom = getSubdetectorGeometry(id);
   GlobalPoint position;
   if (id.det() == DetId::Hcal) {
     position = geom->getGeometry(id)->getPosition();
@@ -132,8 +139,7 @@ int RecHitTools::zside(const DetId& id) const {
 }
 
 std::float_t RecHitTools::getSiThickness(const DetId& id) const {
-  auto geom = geom_->getSubdetectorGeometry(id);
-  check_geom(geom);
+  auto geom = getSubdetectorGeometry(id);
   std::float_t thick(0.37);
   if (id.det() == DetId::Forward) {
     const HGCalDetId hid(id);
@@ -170,8 +176,7 @@ int RecHitTools::getSiThickIndex(const DetId& id) const {
 }
 
 std::float_t RecHitTools::getRadiusToSide(const DetId& id) const {
-  auto geom = geom_->getSubdetectorGeometry(id);
-  check_geom(geom);
+  auto geom = getSubdetectorGeometry(id);
   std::float_t size(std::numeric_limits<std::float_t>::max());
   if (id.det() == DetId::Forward) {
     const HGCalDetId hid(id);
@@ -309,8 +314,7 @@ bool RecHitTools::isHalfCell(const DetId& id) const {
   bool ishalf = false;
   if (id.det() == DetId::Forward) {
     HGCalDetId hid(id);
-    auto geom = geom_->getSubdetectorGeometry(hid);
-    check_geom(geom);
+    auto geom = getSubdetectorGeometry(hid);
     auto ddd = get_ddd(geom,hid);
     const int waferType = ddd->waferTypeT(hid.waferType());
     return ddd->isHalfCell(waferType,hid.cell());

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -126,11 +126,14 @@ GlobalPoint RecHitTools::getPosition(const DetId& id) const {
 }
 
 GlobalPoint RecHitTools::getPositionLayer(unsigned layer) const {
+  const int hgcal_default_wafer = 50;
+  const int hcal_default_ieta = 50;
+  const int hcal_default_iphi = 100;
   DetId id(0);
   if(geometryType_==0){
-    if (layer <= fhOffset_) id = HGCalDetId(ForwardSubdetector::HGCEE, 1, layer, 1, 50, 1);
-    else if (layer <= bhOffset_) id = HGCalDetId(ForwardSubdetector::HGCHEF, 1, layer - fhOffset_, 1, 50, 1);
-    else  id = HcalDetId(HcalSubdetector::HcalEndcap, 50, 100, layer - bhOffset_);
+    if (layer <= fhOffset_) id = HGCalDetId(ForwardSubdetector::HGCEE, 1, layer, 1, hgcal_default_wafer, 1);
+    else if (layer <= bhOffset_) id = HGCalDetId(ForwardSubdetector::HGCHEF, 1, layer - fhOffset_, 1, hgcal_default_wafer, 1);
+    else  id = HcalDetId(HcalSubdetector::HcalEndcap, hcal_default_ieta, hcal_default_iphi, layer - bhOffset_);
   }
   else {
     if (layer <= fhOffset_) id = HGCSiliconDetId(DetId::HGCalEE, 1, 0, layer, 0, 0, 0, 0);

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerBaseClass.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalUncalibRecHitWorkerBaseClass.h
@@ -29,6 +29,9 @@ class HGCalUncalibRecHitWorkerBaseClass {
 
                 // run HGC-BH things
                 virtual bool run3(const edm::Event& evt, const HGCBHDigiCollection::const_iterator & digi, HGChebUncalibratedRecHitCollection & result) = 0;
+
+                // run HGC-BH things (new geom)
+                virtual bool run4(const edm::Event& evt, const HGCHEDigiCollection::const_iterator & digi, HGChebUncalibratedRecHitCollection & result) = 0;
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitProducer.h
@@ -22,11 +22,14 @@ class HGCalUncalibRecHitProducer : public edm::stream::EDProducer<> {
   
   const edm::EDGetTokenT<HGCEEDigiCollection> eeDigiCollection_; // collection of HGCEE digis
   const edm::EDGetTokenT<HGCHEDigiCollection> hefDigiCollection_; // collection of HGCHEF digis
-  const edm::EDGetTokenT<HGCBHDigiCollection> hebDigiCollection_; // collection of HGCHEB digis
+  edm::EDGetTokenT<HGCBHDigiCollection> hebDigiCollectionOld_; // collection of HGCHEB digis
+  edm::EDGetTokenT<HGCHEDigiCollection> hebDigiCollectionNew_; // collection of HGCHEB digis
   
   const std::string eeHitCollection_; // instance name of HGCEE collection of hits
   const std::string hefHitCollection_; // instance name of HGCHEF collection of hits
   const std::string hebHitCollection_; // instance name of HGCHEB collection of hits
+
+  int geometryType_;
   
   std::unique_ptr<HGCalUncalibRecHitWorkerBaseClass> worker_;
 };

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
@@ -67,7 +67,8 @@ HGCalUncalibRecHitWorkerWeights::HGCalUncalibRecHitWorkerWeights(const edm::Para
   const edm::ParameterSet& heb_cfg = ps.getParameterSet("HGCHEBConfig");
   configureIt(ee_cfg,uncalibMaker_ee_);
   configureIt(hef_cfg,uncalibMaker_hef_);
-  configureIt(heb_cfg,uncalibMaker_heb_);
+  configureIt(heb_cfg,uncalibMaker_heb_old_);
+  configureIt(heb_cfg,uncalibMaker_heb_new_);
 }
 
 void
@@ -83,7 +84,8 @@ HGCalUncalibRecHitWorkerWeights::set(const edm::EventSetup& es)
     es.get<IdealGeometryRecord>().get("HGCalHESiliconSensitive",hgchefGeoHandle) ; 
     uncalibMaker_hef_.setGeometry(hgchefGeoHandle.product());
   }  
-  uncalibMaker_heb_.setGeometry(nullptr);  
+  uncalibMaker_heb_old_.setGeometry(nullptr);  
+  uncalibMaker_heb_new_.setGeometry(nullptr);  
 }
 
 
@@ -110,7 +112,16 @@ HGCalUncalibRecHitWorkerWeights::run3( const edm::Event & evt,
 				       const HGCBHDigiCollection::const_iterator & itdg,
 				       HGChebUncalibratedRecHitCollection & result )
 {
-  result.push_back(uncalibMaker_heb_.makeRecHit(*itdg));
+  result.push_back(uncalibMaker_heb_old_.makeRecHit(*itdg));
+  return true;
+}
+
+bool
+HGCalUncalibRecHitWorkerWeights::run4( const edm::Event & evt,
+				       const HGCHEDigiCollection::const_iterator & itdg,
+				       HGChebUncalibratedRecHitCollection & result )
+{
+  result.push_back(uncalibMaker_heb_new_.makeRecHit(*itdg));
   return true;
 }
 

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.h
@@ -32,12 +32,14 @@ class HGCalUncalibRecHitWorkerWeights : public HGCalUncalibRecHitWorkerBaseClass
   bool run1(const edm::Event& evt, const HGCEEDigiCollection::const_iterator & digi, HGCeeUncalibratedRecHitCollection & result) override;
   bool run2(const edm::Event& evt, const HGCHEDigiCollection::const_iterator & digi, HGChefUncalibratedRecHitCollection & result) override;
   bool run3(const edm::Event& evt, const HGCBHDigiCollection::const_iterator & digi, HGChebUncalibratedRecHitCollection & result) override;
+  bool run4(const edm::Event& evt, const HGCHEDigiCollection::const_iterator & digi, HGChebUncalibratedRecHitCollection & result) override;
 
  protected:
     
   HGCalUncalibRecHitRecWeightsAlgo<HGCEEDataFrame> uncalibMaker_ee_;
   HGCalUncalibRecHitRecWeightsAlgo<HGCHEDataFrame> uncalibMaker_hef_;
-  HGCalUncalibRecHitRecWeightsAlgo<HGCBHDataFrame> uncalibMaker_heb_;
+  HGCalUncalibRecHitRecWeightsAlgo<HGCBHDataFrame> uncalibMaker_heb_old_;
+  HGCalUncalibRecHitRecWeightsAlgo<HGCHEDataFrame> uncalibMaker_heb_new_;
 
 };
 

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
@@ -45,6 +45,7 @@ HGCalUncalibRecHit = cms.EDProducer(
         fCPerMIP      = cms.vdouble(1.0,1.0,1.0) #dummy values, it's scintillator
         ),
 
+    geometryType = cms.uint32(0),
     algo = cms.string("HGCalUncalibRecHitWorkerWeights")
 )
 
@@ -54,3 +55,6 @@ premix_stage2.toModify(HGCalUncalibRecHit,
     HGCHEFdigiCollection = 'mixData:HGCDigisHEfront',
     HGCHEBdigiCollection = 'mixData:HGCDigisHEback',
 )
+
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+phase2_hgcalV9.toModify(HGCalUncalibRecHit, geometryType = cms.uint32(1))

--- a/RecoParticleFlow/PFClusterProducer/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/BuildFile.xml
@@ -6,7 +6,9 @@
 <use   name="DataFormats/ParticleFlowReco"/>
 <use   name="Geometry/HGCalGeometry"/>
 <use   name="RecoLocalCalo/HcalRecAlgos"/>
+<use   name="DataFormats/DetId"/>
 <use   name="DataFormats/HcalDetId"/>
+<use   name="DataFormats/ForwardDetId"/>
 <use   name="RecoEcal/EgammaCoreTools"/>
 <use   name="RecoParticleFlow/PFClusterTools"/>
 <use   name="Calibration/Tools"/>

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
@@ -22,7 +22,7 @@
 
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
-template <typename DET,PFLayer::Layer Layer,unsigned subdet>
+template <typename DET,PFLayer::Layer Layer,DetId::Detector det,unsigned subdet>
   class PFHGCalRecHitCreator :  public  PFRecHitCreatorBase {
 
  public:  
@@ -54,8 +54,10 @@ template <typename DET,PFLayer::Layer Layer,unsigned subdet>
       for (const auto & hgrh : rechits) {
 		const DET detid(hgrh.detid());
 	
-	if( subdet != detid.subdetId() ) {
+	if( det != detid.det() or (subdet != 0 and subdet != detid.subdetId() ) ) {
 	  throw cms::Exception("IncorrectHGCSubdetector")
+	    << "det expected: " << det 
+	    << " det gotten: " << detid.det() << " ; "
 	    << "subdet expected: " << subdet 
 	    << " subdet gotten: " << detid.subdetId() << std::endl;
 	}
@@ -63,7 +65,7 @@ template <typename DET,PFLayer::Layer Layer,unsigned subdet>
 	double energy = hgrh.energy();
 	double time = hgrh.time();	
 	
-	auto thisCell = geom->getSubdetectorGeometry(detid.det(),detid.subdetId())->getGeometry(detid);
+	auto thisCell = geom->getSubdetectorGeometry(det,subdet)->getGeometry(detid);
 
 	// find rechit geometry
 	if(!thisCell) {
@@ -110,11 +112,18 @@ template <typename DET,PFLayer::Layer Layer,unsigned subdet>
   hgcal::RecHitTools recHitTools_;
 };
 
+#include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
 
-typedef PFHGCalRecHitCreator<HGCalDetId,PFLayer::HGCAL,HGCEE> PFHGCEERecHitCreator;
-typedef PFHGCalRecHitCreator<HGCalDetId,PFLayer::HGCAL,HGCHEF> PFHGCHEFRecHitCreator;
-typedef PFHGCalRecHitCreator<HcalDetId ,PFLayer::HGCAL,HcalEndcap> PFHGCHEBRecHitCreator;
+typedef PFHGCalRecHitCreator<HGCalDetId,PFLayer::HGCAL,DetId::Forward,HGCEE> PFHGCEERecHitCreator;
+typedef PFHGCalRecHitCreator<HGCalDetId,PFLayer::HGCAL,DetId::Forward,HGCHEF> PFHGCHEFRecHitCreator;
+typedef PFHGCalRecHitCreator<HcalDetId ,PFLayer::HGCAL,DetId::Hcal,HcalEndcap> PFHGCHEBRecHitCreator;
+
+typedef PFHGCalRecHitCreator<HGCSiliconDetId     ,PFLayer::HGCAL,DetId::HGCalEE ,ForwardEmpty> PFHGCalEERecHitCreator;
+typedef PFHGCalRecHitCreator<HGCSiliconDetId     ,PFLayer::HGCAL,DetId::HGCalHSi,ForwardEmpty> PFHGCalHSiRecHitCreator;
+typedef PFHGCalRecHitCreator<HGCScintillatorDetId,PFLayer::HGCAL,DetId::HGCalHSc,ForwardEmpty> PFHGCalHScRecHitCreator;
 
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/RecHitCreators.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/RecHitCreators.cc
@@ -27,4 +27,7 @@ DEFINE_EDM_PLUGIN(PFRecHitFactory, PFPSRecHitCreator, "PFPSRecHitCreator");
 DEFINE_EDM_PLUGIN(PFRecHitFactory, PFHGCEERecHitCreator, "PFHGCEERecHitCreator");
 DEFINE_EDM_PLUGIN(PFRecHitFactory, PFHGCHEFRecHitCreator, "PFHGCHEFRecHitCreator");
 DEFINE_EDM_PLUGIN(PFRecHitFactory, PFHGCHEBRecHitCreator, "PFHGCHEBRecHitCreator");
+DEFINE_EDM_PLUGIN(PFRecHitFactory, PFHGCalEERecHitCreator, "PFHGCalEERecHitCreator");
+DEFINE_EDM_PLUGIN(PFRecHitFactory, PFHGCalHSiRecHitCreator, "PFHGCalHSiRecHitCreator");
+DEFINE_EDM_PLUGIN(PFRecHitFactory, PFHGCalHScRecHitCreator, "PFHGCalHScRecHitCreator");
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -67,7 +67,13 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
     const SimClusterCollection& simClusters = *simClusterH_;
     auto const& hits = *input;
     RealisticHitToClusterAssociator realisticAssociator;
-    const int numberOfLayers = rhtools_.getLayer(ForwardSubdetector::ForwardEmpty);
+    int geometryType = 0;
+    DetId testid(hits.size()>0 ? hits[0].detId() : 0);
+    if(DetId(hits[0].detId()).det()==DetId::HGCalEE or 
+       DetId(hits[0].detId()).det()==DetId::HGCalHSi or 
+       DetId(hits[0].detId()).det()==DetId::HGCalHSc)
+    { geometryType = 1; }
+    const int numberOfLayers = geometryType==0 ? rhtools_.getLayer(ForwardSubdetector::ForwardEmpty) : rhtools_.getLayer(DetId::Forward);
     realisticAssociator.init(hits.size(), simClusters.size(), numberOfLayers + 1);
     // for quick indexing back to hit energy
     std::unordered_map < uint32_t, size_t > detIdToIndex(hits.size());

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -66,9 +66,9 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
 {
     const SimClusterCollection& simClusters = *simClusterH_;
     auto const& hits = *input;
+    if(hits.empty()) return;
     RealisticHitToClusterAssociator realisticAssociator;
     int geometryType = 0;
-    DetId testid(!hits.empty() ? hits[0].detId() : 0);
     if(DetId(hits[0].detId()).det()==DetId::HGCalEE or 
        DetId(hits[0].detId()).det()==DetId::HGCalHSi or 
        DetId(hits[0].detId()).det()==DetId::HGCalHSc)

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -68,7 +68,7 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
     auto const& hits = *input;
     RealisticHitToClusterAssociator realisticAssociator;
     int geometryType = 0;
-    DetId testid(hits.size()>0 ? hits[0].detId() : 0);
+    DetId testid(!hits.empty() ? hits[0].detId() : 0);
     if(DetId(hits[0].detId()).det()==DetId::HGCalEE or 
        DetId(hits[0].detId()).det()==DetId::HGCalHSi or 
        DetId(hits[0].detId()).det()==DetId::HGCalHSc)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cfi.py
@@ -58,3 +58,12 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
            )
     )          
 )
+
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+phase2_hgcalV9.toModify(particleFlowRecHitHGC,
+    producers = {
+        0 : dict(name = cms.string("PFHGCalEERecHitCreator")),
+        1 : dict(name = cms.string("PFHGCalHSiRecHitCreator")),
+        2 : dict(name = cms.string("PFHGCalHScRecHitCreator")),
+    }
+)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cfi.py
@@ -62,8 +62,8 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 phase2_hgcalV9.toModify(particleFlowRecHitHGC,
     producers = {
-        0 : dict(name = cms.string("PFHGCalEERecHitCreator")),
-        1 : dict(name = cms.string("PFHGCalHSiRecHitCreator")),
-        2 : dict(name = cms.string("PFHGCalHScRecHitCreator")),
+        0 : dict(name = "PFHGCalEERecHitCreator"),
+        1 : dict(name = "PFHGCalHSiRecHitCreator"),
+        2 : dict(name = "PFHGCalHScRecHitCreator"),
     }
 )

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
@@ -26,6 +26,10 @@
 class PCaloHit;
 class PileUpEventPrincipal;
 
+//typedefs
+typedef HGCHEbackDigitizer<HGCBHDataFrame> HGCHEbackDigitizerOld;
+typedef HGCHEbackDigitizer<HGCHEDataFrame> HGCHEbackDigitizerNew;
+
 class HGCDigitizer
 {
 public:
@@ -74,6 +78,7 @@ public:
   bool producesHEbackDigis()   { 
     return ((mySubDet_==ForwardSubdetector::HGCHEB)||(myDet_==DetId::HGCalHSc)); }
   std::string digiCollection() { return digiCollection_; }
+  int geometryType() { return geometryType_; }
 
   /**
       @short actions at the start/end of run
@@ -111,7 +116,8 @@ private :
 
   //digitizers
   std::unique_ptr<HGCEEDigitizer>      theHGCEEDigitizer_;
-  std::unique_ptr<HGCHEbackDigitizer>  theHGCHEbackDigitizer_;
+  std::unique_ptr<HGCHEbackDigitizerOld>  theHGCHEbackDigitizerOld_;
+  std::unique_ptr<HGCHEbackDigitizerNew>  theHGCHEbackDigitizerNew_;
   std::unique_ptr<HGCHEfrontDigitizer> theHGCHEfrontDigitizer_;
   
   //geometries

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCHEbackDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCHEbackDigitizer.h
@@ -4,12 +4,15 @@
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 
-class HGCHEbackDigitizer : public HGCDigitizerBase<HGCBHDataFrame>
+template <class DFr>
+class HGCHEbackDigitizer : public HGCDigitizerBase<DFr>
 {
  public:
 
+  typedef edm::SortedCollection<DFr> DColl;
+
   HGCHEbackDigitizer(const edm::ParameterSet& ps);
-  void runDigitizer(std::unique_ptr<HGCBHDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData,
+  void runDigitizer(std::unique_ptr<DColl> &digiColl,hgc::HGCSimHitDataAccumulator &simData,
 		    const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
 		    uint32_t digitizationType, CLHEP::HepRandomEngine* engine) override;
   ~HGCHEbackDigitizer() override;
@@ -19,7 +22,7 @@ class HGCHEbackDigitizer : public HGCDigitizerBase<HGCBHDataFrame>
   //calice-like digitization parameters
   float keV2MIP_, noise_MIP_;
   float nPEperMIP_, nTotalPE_, xTalk_, sdPixels_;
-  void runCaliceLikeDigitizer(std::unique_ptr<HGCBHDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData, 
+  void runCaliceLikeDigitizer(std::unique_ptr<DColl> &digiColl,hgc::HGCSimHitDataAccumulator &simData, 
 			      const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
 			      CLHEP::HepRandomEngine* engine);
 };

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
@@ -20,8 +20,10 @@ HGCDigiProducer::HGCDigiProducer(edm::ParameterSet const& pset, edm::ProducerBas
       mixMod.produces<HGCEEDigiCollection>(theDigitizer_.digiCollection());
     if( theDigitizer_.producesHEfrontDigis() )
       mixMod.produces<HGCHEDigiCollection>(theDigitizer_.digiCollection());
-    if( theDigitizer_.producesHEbackDigis() )
+    if( theDigitizer_.producesHEbackDigis() and theDigitizer_.geometryType()==0 )
       mixMod.produces<HGCBHDigiCollection>(theDigitizer_.digiCollection());
+    if( theDigitizer_.producesHEbackDigis() and theDigitizer_.geometryType()==1 )
+      mixMod.produces<HGCHEDigiCollection>(theDigitizer_.digiCollection());
   }
 }
 

--- a/SimCalorimetry/HGCalSimProducers/plugins/PreMixingHGCalWorker.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/PreMixingHGCalWorker.cc
@@ -50,8 +50,11 @@ PreMixingHGCalWorker::PreMixingHGCalWorker(const edm::ParameterSet& ps, edm::Pro
   if(digitizer_.producesHEfrontDigis()) {
     producer.produces<HGCHEDigiCollection>(digitizer_.digiCollection());
   }
-  if(digitizer_.producesHEbackDigis()) {
+  if(digitizer_.producesHEbackDigis() and digitizer_.geometryType()==0) {
     producer.produces<HGCBHDigiCollection>(digitizer_.digiCollection());
+  }
+  if(digitizer_.producesHEbackDigis() and digitizer_.geometryType()==1) {
+    producer.produces<HGCHEDigiCollection>(digitizer_.digiCollection());
   }
 }
 

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -221,4 +221,5 @@ phase2_hgcalV9.toModify( hgchefrontDigitizer,
 )
 phase2_hgcalV9.toModify( hgchebackDigitizer,
       geometryType      = cms.uint32(1),
+      hitCollection = cms.string("HGCHitsHEback"),
 )

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -3,43 +3,7 @@
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 
 using namespace hgc_digi;
-
-namespace {
-  void addCellMetadata(HGCCellInfo& info,
-		       const HcalGeometry* geom,
-		       const DetId& detid ) {
-    //base time samples for each DetId, initialized to 0
-    info.size = 1.0;
-    info.thickness = 1.0;
-  }
-
-  void addCellMetadata(HGCCellInfo& info,
-		       const HGCalGeometry* geom,
-		       const DetId& detid ) {
-    const auto& dddConst = geom->topology().dddConstants();
-    bool isHalf = (((dddConst.geomMode() == HGCalGeometryMode::Hexagon) ||
-		    (dddConst.geomMode() == HGCalGeometryMode::HexagonFull)) ?
-		   dddConst.isHalfCell(HGCalDetId(detid).wafer(),HGCalDetId(detid).cell()) :
-		   false);
-    //base time samples for each DetId, initialized to 0
-    info.size = (isHalf ? 0.5 : 1.0);
-    info.thickness = dddConst.waferType(detid);
-  }
-
-  void addCellMetadata(HGCCellInfo& info,
-		       const CaloSubdetectorGeometry* geom,
-		       const DetId& detid ) {
-    if( DetId::Hcal == detid.det() ) {
-      const HcalGeometry* hc = static_cast<const HcalGeometry*>(geom);
-      addCellMetadata(info,hc,detid);
-    } else {
-      const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
-      addCellMetadata(info,hg,detid);
-    }
-  }
-
-}
-
+using namespace hgc_digi_utils;
 
 template<class DFr>
 HGCDigitizerBase<DFr>::HGCDigitizerBase(const edm::ParameterSet& ps) {

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
@@ -12,11 +12,12 @@ using namespace hgc_digi;
 using namespace hgc_digi_utils;
 
 //
-HGCHEbackDigitizer::HGCHEbackDigitizer(const edm::ParameterSet &ps) : HGCDigitizerBase(ps)
+template <class DFr>
+HGCHEbackDigitizer<DFr>::HGCHEbackDigitizer(const edm::ParameterSet &ps) : HGCDigitizerBase<DFr>(ps)
 {
   edm::ParameterSet cfg = ps.getParameter<edm::ParameterSet>("digiCfg");
   keV2MIP_   = cfg.getParameter<double>("keV2MIP");
-  keV2fC_    = 1.0; //keV2MIP_; // hack for HEB
+  this->keV2fC_    = 1.0; //keV2MIP_; // hack for HEB
   noise_MIP_ = cfg.getParameter<edm::ParameterSet>("noise_MIP").getParameter<double>("value");
   nPEperMIP_ = cfg.getParameter<double>("nPEperMIP");
   nTotalPE_  = cfg.getParameter<double>("nTotalPE");
@@ -25,7 +26,8 @@ HGCHEbackDigitizer::HGCHEbackDigitizer(const edm::ParameterSet &ps) : HGCDigitiz
 }
 
 //
-void HGCHEbackDigitizer::runDigitizer(std::unique_ptr<HGCBHDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,
+template <class DFr>
+void HGCHEbackDigitizer<DFr>::runDigitizer(std::unique_ptr<HGCHEbackDigitizer::DColl> &digiColl,HGCSimHitDataAccumulator &simData,
 				      const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
 				      uint32_t digitizationType, CLHEP::HepRandomEngine* engine)
 {
@@ -33,7 +35,8 @@ void HGCHEbackDigitizer::runDigitizer(std::unique_ptr<HGCBHDigiCollection> &digi
 }
 
 //
-void HGCHEbackDigitizer::runCaliceLikeDigitizer(std::unique_ptr<HGCBHDigiCollection> &digiColl,HGCSimHitDataAccumulator &simData,
+template <class DFr>
+void HGCHEbackDigitizer<DFr>::runCaliceLikeDigitizer(std::unique_ptr<HGCHEbackDigitizer::DColl> &digiColl,HGCSimHitDataAccumulator &simData,
 						const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
 						CLHEP::HepRandomEngine* engine)
 {
@@ -86,16 +89,20 @@ void HGCHEbackDigitizer::runCaliceLikeDigitizer(std::unique_ptr<HGCBHDigiCollect
 	}
 
       //init a new data frame and run shaper
-      HGCBHDataFrame newDataFrame( id );
-      myFEelectronics_->runTrivialShaper( newDataFrame, chargeColl, 1 );
+      DFr newDataFrame( id );
+      this->myFEelectronics_->runTrivialShaper( newDataFrame, chargeColl, 1 );
 
       //prepare the output
-      updateOutput(digiColl,newDataFrame);
+      this->updateOutput(digiColl,newDataFrame);
     }
 }
 
 //
-HGCHEbackDigitizer::~HGCHEbackDigitizer()
+template <class DFr>
+HGCHEbackDigitizer<DFr>::~HGCHEbackDigitizer()
 {
 }
 
+//explicit instantiations
+template class HGCHEbackDigitizer<HGCBHDataFrame>;
+template class HGCHEbackDigitizer<HGCHEDataFrame>;

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
@@ -9,42 +9,7 @@
 #include "vdt/vdtMath.h"
 
 using namespace hgc_digi;
-
-namespace {
-  void addCellMetadata(HGCCellInfo& info,
-		       const HcalGeometry* geom,
-		       const DetId& detid ) {
-    //base time samples for each DetId, initialized to 0
-    info.size = 1.0;
-    info.thickness = 1.0;
-  }
-
-  void addCellMetadata(HGCCellInfo& info,
-		       const HGCalGeometry* geom,
-		       const DetId& detid ) {
-    const auto& dddConst = geom->topology().dddConstants();
-    bool isHalf = (((dddConst.geomMode() == HGCalGeometryMode::Hexagon) ||
-		    (dddConst.geomMode() == HGCalGeometryMode::HexagonFull)) ?
-		   dddConst.isHalfCell(HGCalDetId(detid).wafer(),HGCalDetId(detid).cell()) :
-		   false);
-    //base time samples for each DetId, initialized to 0
-    info.size = (isHalf ? 0.5 : 1.0);
-    info.thickness = dddConst.waferType(detid);
-  }
-
-  void addCellMetadata(HGCCellInfo& info,
-		       const CaloSubdetectorGeometry* geom,
-		       const DetId& detid ) {
-    if( DetId::Hcal == detid.det() ) {
-      const HcalGeometry* hc = static_cast<const HcalGeometry*>(geom);
-      addCellMetadata(info,hc,detid);
-    } else {
-      const HGCalGeometry* hg = static_cast<const HGCalGeometry*>(geom);
-      addCellMetadata(info,hg,detid);
-    }
-  }
-
-}
+using namespace hgc_digi_utils;
 
 //
 HGCHEbackDigitizer::HGCHEbackDigitizer(const edm::ParameterSet &ps) : HGCDigitizerBase(ps)

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -140,7 +140,7 @@ G4bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
   } else { 
     if(aStep->GetTotalEnergyDeposit() > 0.0) { 
       G4TouchableHistory* touch =(G4TouchableHistory*)(theTrack->GetTouchable());
-      edm::LogWarning("CaloSim") << "CaloSD::ProcessHits: unitID= " << unitID
+      edm::LogInfo("CaloSim") << "CaloSD::ProcessHits: unitID= " << unitID
 				 << " currUnit=   " << currentID.unitID()
 				 << " Detector: " << GetName()
 				 << " trackID= " << theTrack->GetTrackID() 

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -561,7 +561,6 @@ void HCalSD::update(const BeginOfJob * job) {
 }
 
 void HCalSD::initRun() {
-  edm::LogWarning("HcalSim") << "InitRun for HFFFFF ";
   if (showerLibrary.get()) showerLibrary.get()->initRun(nullptr, hcalConstants);
   if (showerParam.get())   showerParam.get()->initRun(hcalConstants);
   if (hfshower.get())      hfshower.get()->initRun(hcalConstants);

--- a/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
@@ -206,8 +206,6 @@ class CaloTruthAccumulator : public DigiAccumulatorMixMod {
   const HcalDDDRecConstants* hcddd_ = nullptr;
   OutputCollections output_;
   calo_particles m_caloParticles;
-  //geometry type (0 pre-TDR; 1 TDR)
-  int geometryType_;
 };
 
 /* Graph utility functions */
@@ -378,8 +376,7 @@ CaloTruthAccumulator::CaloTruthAccumulator(const edm::ParameterSet& config,
       hepMCproductLabel_(config.getParameter<edm::InputTag>("HepMCProductLabel")),
       minEnergy_(config.getParameter<double>("MinEnergy")),
       maxPseudoRapidity_(config.getParameter<double>("MaxPseudoRapidity")),
-      premixStage1_(config.getParameter<bool>("premixStage1")),
-      geometryType_(config.getParameter<uint32_t>("geometryType"))
+      premixStage1_(config.getParameter<bool>("premixStage1"))
 {
   mixMod.produces<SimClusterCollection>("MergedCaloTruth");
   mixMod.produces<CaloParticleCollection>("MergedCaloTruth");
@@ -415,15 +412,16 @@ void CaloTruthAccumulator::beginLuminosityBlock(edm::LuminosityBlock const& iLum
   const HGCalGeometry *eegeom = nullptr, *fhgeom = nullptr, *bhgeomnew = nullptr;
   const HcalGeometry* bhgeom = nullptr;
 
-  if(geometryType_==0){
+  eegeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalEE,ForwardSubdetector::ForwardEmpty));
+  //check if it's the new geometry
+  if(eegeom){
+    fhgeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalHSi,ForwardSubdetector::ForwardEmpty));
+    bhgeomnew = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalHSc,ForwardSubdetector::ForwardEmpty));
+  }
+  else {
     eegeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCEE));
     fhgeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCHEF));
     bhgeom = static_cast<const HcalGeometry*>(geom->getSubdetectorGeometry(DetId::Hcal, HcalEndcap));
-  }
-  else {
-    eegeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalEE,ForwardSubdetector::ForwardEmpty));
-    fhgeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalHSi,ForwardSubdetector::ForwardEmpty));
-    bhgeomnew = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalHSc,ForwardSubdetector::ForwardEmpty));
   }
   hgtopo_[0] = &(eegeom->topology());
   hgtopo_[1] = &(fhgeom->topology());

--- a/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
@@ -201,11 +201,13 @@ class CaloTruthAccumulator : public DigiAccumulatorMixMod {
   };
 
  private:
-  const HGCalTopology* hgtopo_[2];
-  const HGCalDDDConstants* hgddd_[2];
-  const HcalDDDRecConstants* hcddd_;
+  const HGCalTopology* hgtopo_[3] = {nullptr,nullptr,nullptr};
+  const HGCalDDDConstants* hgddd_[3] = {nullptr,nullptr,nullptr};
+  const HcalDDDRecConstants* hcddd_ = nullptr;
   OutputCollections output_;
   calo_particles m_caloParticles;
+  //geometry type (0 pre-TDR; 1 TDR)
+  int geometryType_;
 };
 
 /* Graph utility functions */
@@ -376,7 +378,9 @@ CaloTruthAccumulator::CaloTruthAccumulator(const edm::ParameterSet& config,
       hepMCproductLabel_(config.getParameter<edm::InputTag>("HepMCProductLabel")),
       minEnergy_(config.getParameter<double>("MinEnergy")),
       maxPseudoRapidity_(config.getParameter<double>("MaxPseudoRapidity")),
-      premixStage1_(config.getParameter<bool>("premixStage1")) {
+      premixStage1_(config.getParameter<bool>("premixStage1")),
+      geometryType_(config.getParameter<uint32_t>("geometryType"))
+{
   mixMod.produces<SimClusterCollection>("MergedCaloTruth");
   mixMod.produces<CaloParticleCollection>("MergedCaloTruth");
   if(premixStage1_) {
@@ -408,21 +412,28 @@ void CaloTruthAccumulator::beginLuminosityBlock(edm::LuminosityBlock const& iLum
                                                          const edm::EventSetup& iSetup) {
   edm::ESHandle<CaloGeometry> geom;
   iSetup.get<CaloGeometryRecord>().get(geom);
-  const HGCalGeometry *eegeom, *fhgeom;
-  const HcalGeometry* bhgeom;
+  const HGCalGeometry *eegeom = nullptr, *fhgeom = nullptr, *bhgeomnew = nullptr;
+  const HcalGeometry* bhgeom = nullptr;
 
-  eegeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCEE));
-  fhgeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCHEF));
-  bhgeom = static_cast<const HcalGeometry*>(geom->getSubdetectorGeometry(DetId::Hcal, HcalEndcap));
-
+  if(geometryType_==0){
+    eegeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCEE));
+    fhgeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCHEF));
+    bhgeom = static_cast<const HcalGeometry*>(geom->getSubdetectorGeometry(DetId::Hcal, HcalEndcap));
+  }
+  else {
+    eegeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalEE,ForwardSubdetector::ForwardEmpty));
+    fhgeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalHSi,ForwardSubdetector::ForwardEmpty));
+    bhgeomnew = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalHSc,ForwardSubdetector::ForwardEmpty));
+  }
   hgtopo_[0] = &(eegeom->topology());
   hgtopo_[1] = &(fhgeom->topology());
+  if(bhgeomnew) hgtopo_[2] = &(bhgeomnew->topology());
 
-  for (unsigned i = 0; i < 2; ++i) {
-    hgddd_[i] = &(hgtopo_[i]->dddConstants());
+  for (unsigned i = 0; i < 3; ++i) {
+    if(hgtopo_[i]) hgddd_[i] = &(hgtopo_[i]->dddConstants());
   }
 
-  hcddd_ = bhgeom->topology().dddConstants();
+  if(bhgeom) hcddd_ = bhgeom->topology().dddConstants();
 }
 
 void CaloTruthAccumulator::initializeEvent(edm::Event const& event,

--- a/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
@@ -206,6 +206,8 @@ class CaloTruthAccumulator : public DigiAccumulatorMixMod {
   const HcalDDDRecConstants* hcddd_ = nullptr;
   OutputCollections output_;
   calo_particles m_caloParticles;
+  //geometry type (0 pre-TDR; 1 TDR)
+  int geometryType_;
 };
 
 /* Graph utility functions */
@@ -376,7 +378,8 @@ CaloTruthAccumulator::CaloTruthAccumulator(const edm::ParameterSet& config,
       hepMCproductLabel_(config.getParameter<edm::InputTag>("HepMCProductLabel")),
       minEnergy_(config.getParameter<double>("MinEnergy")),
       maxPseudoRapidity_(config.getParameter<double>("MaxPseudoRapidity")),
-      premixStage1_(config.getParameter<bool>("premixStage1"))
+      premixStage1_(config.getParameter<bool>("premixStage1")),
+      geometryType_(-1)
 {
   mixMod.produces<SimClusterCollection>("MergedCaloTruth");
   mixMod.produces<CaloParticleCollection>("MergedCaloTruth");
@@ -415,10 +418,12 @@ void CaloTruthAccumulator::beginLuminosityBlock(edm::LuminosityBlock const& iLum
   eegeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalEE,ForwardSubdetector::ForwardEmpty));
   //check if it's the new geometry
   if(eegeom){
+    geometryType_ = 1;
     fhgeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalHSi,ForwardSubdetector::ForwardEmpty));
     bhgeomnew = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalHSc,ForwardSubdetector::ForwardEmpty));
   }
   else {
+    geometryType_ = 0;
     eegeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCEE));
     fhgeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCHEF));
     bhgeom = static_cast<const HcalGeometry*>(geom->getSubdetectorGeometry(DetId::Hcal, HcalEndcap));
@@ -677,7 +682,11 @@ void CaloTruthAccumulator::fillSimHits(
     for (auto const& simHit : *hSimHits) {
       DetId id(0);
       const uint32_t simId = simHit.id();
-      if (isHcal) {
+      if (geometryType_==1) {
+        //no test numbering in new geometry
+        id = simId;
+      }
+      else if (isHcal) {
         HcalDetId hid = HcalHitRelabeller::relabel(simId, hcddd_);
         if (hid.subdet() == HcalEndcap) id = hid;
       } else {

--- a/SimGeneral/MixingModule/python/caloTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/caloTruthProducer_cfi.py
@@ -29,7 +29,6 @@ caloParticles = cms.PSet(
 	genParticleCollection = cms.InputTag('genParticles'),
 	allowDifferentSimHitProcesses = cms.bool(False), # should be True for FastSim, False for FullSim
 	HepMCProductLabel = cms.InputTag('generatorSmeared'),
-    geometryType = cms.uint32(0),
 )
 
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
@@ -38,7 +37,6 @@ premix_stage1.toModify(caloParticles, premixStage1 = True)
 from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 phase2_hgcalV9.toModify(
     caloParticles,
-    geometryType = cms.uint32(1),
     simHitCollections = dict(hgc = {2 : cms.InputTag('g4SimHits','HGCHitsHEback')} ),
 )
 

--- a/SimGeneral/MixingModule/python/caloTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/caloTruthProducer_cfi.py
@@ -28,11 +28,19 @@ caloParticles = cms.PSet(
 	simVertexCollection = cms.InputTag('g4SimHits'),
 	genParticleCollection = cms.InputTag('genParticles'),
 	allowDifferentSimHitProcesses = cms.bool(False), # should be True for FastSim, False for FullSim
-	HepMCProductLabel = cms.InputTag('generatorSmeared')
+	HepMCProductLabel = cms.InputTag('generatorSmeared'),
+    geometryType = cms.uint32(0),
 )
 
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 premix_stage1.toModify(caloParticles, premixStage1 = True)
+
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+phase2_hgcalV9.toModify(
+    caloParticles,
+    geometryType = cms.uint32(1),
+    simHitCollections = dict(hgc = {2 : cms.InputTag('g4SimHits','HGCHitsHEback')} ),
+)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(caloParticles, cms.PSet()) # don't allow this to run in fastsim

--- a/Validation/HGCalValidation/plugins/HGCGeometryClient.cc
+++ b/Validation/HGCalValidation/plugins/HGCGeometryClient.cc
@@ -40,29 +40,29 @@ HGCalGeometryClient::~HGCalGeometryClient() { }
 void HGCalGeometryClient::dqmEndJob(DQMStore::IBooker &ib, DQMStore::IGetter &ig) {
   ig.setCurrentFolder("/"); 
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("HGCalValid") << "HGCalGeometry :: runClient" << std::endl;
+  edm::LogVerbatim("HGCalValid") << "HGCalGeometry :: runClient";
 #endif
   std::vector<MonitorElement*> hgcalMEs;
   std::vector<std::string> fullDirPath = ig.getSubdirs();
 
   for (unsigned int i=0; i<fullDirPath.size(); i++) {
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HGCalValid") << "HGCalGeometry::fullPath: " 
-			       << fullDirPath.at(i) << std::endl;
+    edm::LogVerbatim("HGCalValid") << "HGCalGeometry::fullPath: " 
+				   << fullDirPath.at(i);
 #endif
     ig.setCurrentFolder(fullDirPath.at(i));
     std::vector<std::string> fullSubDirPath = ig.getSubdirs();
 
     for (unsigned int j=0; j<fullSubDirPath.size(); j++) {
 #ifdef EDM_ML_DEBUG
-      edm::LogInfo("HGCalValid") << "HGCalGeometry:: fullSubPath: " 
-				 << fullSubDirPath.at(j) << std::endl;
+      edm::LogVerbatim("HGCalValid") << "HGCalGeometry:: fullSubPath: " 
+				     << fullSubDirPath.at(j);
 #endif
       if (strcmp(fullSubDirPath.at(j).c_str(), subDirectory_.c_str()) == 0) {
         hgcalMEs = ig.getContents(fullSubDirPath.at(j));
 #ifdef EDM_ML_DEBUG
-	edm::LogInfo("HGCalValid") << "HGCalGeometry:: hgcalMES size : " 
-				   << hgcalMEs.size() << std::endl;
+	edm::LogVerbatim("HGCalValid") << "HGCalGeometry:: hgcalMES size : " 
+				       << hgcalMEs.size();
 #endif
         if (!geometryEndjob(hgcalMEs)) 
           edm::LogWarning("HGCalValid") << "\nError in GeometryEndjob!";

--- a/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
@@ -9,6 +9,8 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -37,6 +39,8 @@
 #include "CLHEP/Geometry/Vector3D.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
+
+const double mmtocm = 0.1;
 
 class HGCGeometryValidation : public DQMEDAnalyzer {
 
@@ -104,7 +108,7 @@ void HGCGeometryValidation::dqmBeginRun(const edm::Run& iRun,
 	hgcGeometry_.push_back(nullptr);
       } else {
 	edm::LogWarning("HGCalValid") << "Cannot initiate HGCalGeometry for "
-				      << geometrySource_[i] << std::endl;
+				      << geometrySource_[i];
       }
     } else {
       edm::ESHandle<HGCalDDDConstants> hgcGeom;
@@ -113,7 +117,7 @@ void HGCGeometryValidation::dqmBeginRun(const edm::Run& iRun,
 	hgcGeometry_.push_back(hgcGeom.product());
       } else {
 	edm::LogWarning("HGCalValid") << "Cannot initiate HGCalGeometry for "
-				      << geometrySource_[i] << std::endl;
+				      << geometrySource_[i];
       }
     }
   }
@@ -223,69 +227,101 @@ void HGCGeometryValidation::analyze(const edm::Event &iEvent,
     hebTotEdepStep->Fill((double)infoLayer->hebTotEdep());
     
     //loop over all hits
-    for(unsigned int i=0; i<hitVtxX.size(); i++) {
+    for (unsigned int i=0; i<hitVtxX.size(); i++) {
 
-      if (hitDet.at(i) == (unsigned int)(DetId::Forward)) {
-	int subdet, zside, layer, wafer, celltype, cell;
-	HGCalTestNumbering::unpackHexagonIndex(hitIdx.at(i), subdet, zside, layer, wafer, celltype, cell);	
+      hitVtxX.at(i) = mmtocm*hitVtxX.at(i);
+      hitVtxY.at(i) = mmtocm*hitVtxY.at(i);
+      hitVtxZ.at(i) = mmtocm*hitVtxZ.at(i);
 
-	std::pair<float, float> xy;
-	std::pair<int,float> layerIdx;
-	double zp, xx, yx;
+      if ((hitDet.at(i) == (unsigned int)(DetId::Forward)) ||
+	  (hitDet.at(i) == (unsigned int)(DetId::HGCalEE)) ||
+	  (hitDet.at(i) == (unsigned int)(DetId::HGCalHSi)) ||
+	  (hitDet.at(i) == (unsigned int)(DetId::HGCalHSc))) {
+	double xx, yy;
+	int    dtype(0), layer(0), zside(1);
+	std::pair<float,float> xy;
+	if (hitDet.at(i) == (unsigned int)(DetId::Forward)) {
+	  int subdet, wafer, celltype, cell;
+	  HGCalTestNumbering::unpackHexagonIndex(hitIdx.at(i), subdet, zside, 
+						 layer, wafer, celltype,cell);
+	  dtype = (subdet==(int)(HGCEE)) ? 0 : 1; 
+	  xy = hgcGeometry_[dtype]->locateCell(cell,layer,wafer,true); //cm
+	} else if ((hitDet.at(i) == (unsigned int)(DetId::HGCalEE)) ||
+		   (hitDet.at(i) == (unsigned int)(DetId::HGCalHSi))) {
+	  HGCSiliconDetId id(hitIdx.at(i));
+	  dtype = (id.det() == DetId::HGCalEE) ? 0 : 1;
+	  layer = id.layer();
+	  zside = id.zside();
+	  xy    = hgcGeometry_[dtype]->locateCell(layer,id.waferU(),
+						  id.waferV(),id.cellU(),
+						  id.cellV(),true,true);
+	} else {
+	  HGCScintillatorDetId id(hitIdx.at(i));
+	  dtype = 2;
+	  layer = id.layer();
+	  zside = id.zside();
+	  xy    = hgcGeometry_[dtype]->locateCellTrap(layer,id.ietaAbs(),
+						      id.iphi(), true);
+	}
+	double zz = hgcGeometry_[dtype]->waferZ(layer,true); //cm 
+	if (zside < 0) zz = -zz;
+	xx = (zside<0) ? -xy.first : xy.first; 
+	yy = xy.second;
 
-	if (subdet==(int)(HGCEE)) {
-	  xy = hgcGeometry_[0]->locateCell(cell,layer,wafer,false); //mm
-	  zp = hgcGeometry_[0]->waferZ(layer,false); //cm 
-	  if (zside < 0) zp = -zp;
-	  xx = (zp<0) ? -xy.first/10 : xy.first/10; //mm
-	  yx = xy.second/10; //mm
-	  hitVtxX.at(i) = hitVtxX.at(i)/10;
-	  hitVtxY.at(i) = hitVtxY.at(i)/10;
-	  hitVtxZ.at(i) = hitVtxZ.at(i)/10;
-	  
-	  heedzVsZ->Fill(zp, (hitVtxZ.at(i)-zp));
-	  heedyVsY->Fill(yx, (hitVtxY.at(i)-yx));
+	if (dtype == 0) {
+
+	  heedzVsZ->Fill(zz, (hitVtxZ.at(i)-zz));
+	  heedyVsY->Fill(yy, (hitVtxY.at(i)-yy));
 	  heedxVsX->Fill(xx, (hitVtxX.at(i)-xx));
 	  
 	  heeXG4VsId->Fill(hitVtxX.at(i),xx);
-	  heeYG4VsId->Fill(hitVtxY.at(i),yx);
-	  heeZG4VsId->Fill(hitVtxZ.at(i),zp);
+	  heeYG4VsId->Fill(hitVtxY.at(i),yy);
+	  heeZG4VsId->Fill(hitVtxZ.at(i),zz);
 
-	  heedzVsLayer->Fill(layer,(hitVtxZ.at(i)-zp));
-	  heedyVsLayer->Fill(layer,(hitVtxY.at(i)-yx));
+	  heedzVsLayer->Fill(layer,(hitVtxZ.at(i)-zz));
+	  heedyVsLayer->Fill(layer,(hitVtxY.at(i)-yy));
 	  heedxVsLayer->Fill(layer,(hitVtxX.at(i)-xx));
 	  
 	  heedX->Fill((hitVtxX.at(i)-xx));
-	  heedZ->Fill((hitVtxZ.at(i)-zp));
-	  heedY->Fill((hitVtxY.at(i)-yx));
+	  heedZ->Fill((hitVtxZ.at(i)-zz));
+	  heedY->Fill((hitVtxY.at(i)-yy));
 
-	} else if (subdet==(int)(HGCHEF)) {
-
-	  xy = hgcGeometry_[1]->locateCell(cell,layer,wafer,false); //mm
-	  zp = hgcGeometry_[1]->waferZ(layer,false); //cm 
-	  if (zside < 0) zp = -zp;
-	  xx = (zp<0) ? -xy.first/10 : xy.first/10; //mm
-	  yx = xy.second/10; //mm
-	  hitVtxX.at(i) = hitVtxX.at(i)/10;
-	  hitVtxY.at(i) = hitVtxY.at(i)/10;
-	  hitVtxZ.at(i) = hitVtxZ.at(i)/10;
+	} else if (dtype == 1) {
 	  
-	  hefdzVsZ->Fill(zp, (hitVtxZ.at(i)-zp));
-	  hefdyVsY->Fill(yx, (hitVtxY.at(i)-yx));
+	  hefdzVsZ->Fill(zz, (hitVtxZ.at(i)-zz));
+	  hefdyVsY->Fill(yy, (hitVtxY.at(i)-yy));
 	  hefdxVsX->Fill(xx, (hitVtxX.at(i)-xx));
 	  
 	  hefXG4VsId->Fill(hitVtxX.at(i),xx);
-	  hefYG4VsId->Fill(hitVtxY.at(i),yx);
-	  hefZG4VsId->Fill(hitVtxZ.at(i),zp);
+	  hefYG4VsId->Fill(hitVtxY.at(i),yy);
+	  hefZG4VsId->Fill(hitVtxZ.at(i),zz);
 	  
-	  hefdzVsLayer->Fill(layer,(hitVtxZ.at(i)-zp));
-	  hefdyVsLayer->Fill(layer,(hitVtxY.at(i)-yx));
+	  hefdzVsLayer->Fill(layer,(hitVtxZ.at(i)-zz));
+	  hefdyVsLayer->Fill(layer,(hitVtxY.at(i)-yy));
 	  hefdxVsLayer->Fill(layer,(hitVtxX.at(i)-xx));
 	  
 	  hefdX->Fill((hitVtxX.at(i)-xx));
-	  hefdZ->Fill((hitVtxZ.at(i)-zp));
-	  hefdY->Fill((hitVtxY.at(i)-yx));
+	  hefdZ->Fill((hitVtxZ.at(i)-zz));
+	  hefdY->Fill((hitVtxY.at(i)-yy));
 	
+	} else {
+
+	  hebdzVsZ->Fill(zz, (hitVtxZ.at(i)-zz));
+	  hebdyVsY->Fill(yy, (hitVtxY.at(i)-yy));
+	  hebdxVsX->Fill(xx, (hitVtxX.at(i)-xx));
+
+	  hebXG4VsId->Fill(hitVtxX.at(i),xx);
+	  hebYG4VsId->Fill(hitVtxY.at(i),yy);
+	  hebZG4VsId->Fill(hitVtxZ.at(i),zz);
+
+	  hebdzVsLayer->Fill(layer,(hitVtxZ.at(i)-zz));
+	  hebdyVsLayer->Fill(layer,(hitVtxY.at(i)-yy));
+	  hebdxVsLayer->Fill(layer,(hitVtxX.at(i)-xx));
+
+	  hebdX->Fill((hitVtxX.at(i)-xx));
+	  hebdZ->Fill((hitVtxZ.at(i)-zz));
+	  hebdY->Fill((hitVtxY.at(i)-yy));
+
 	}
 	
       } else if (hitDet.at(i) == (unsigned int)(DetId::Hcal)) {
@@ -294,37 +330,33 @@ void HGCGeometryValidation::analyze(const edm::Event &iEvent,
 	HcalTestNumbering::unpackHcalIndex(hitIdx.at(i), subdet, zside, depth, eta, phi, lay);
 	HcalCellType::HcalCell cell = hcons_->cell(subdet, zside, lay, eta, phi);
 	
-	double zp = cell.rz/10; //mm --> cm
-	if (zside == 0) zp = -zp;
-	double rho = zp*tan(2.0*atan(exp(-cell.eta)));
-	double xp  = rho * cos(cell.phi); //cm
-	double yp  = rho * sin(cell.phi); //cm
+	double zz = mmtocm*cell.rz; //mm --> cm
+	if (zside == 0) zz = -zz;
+	double rho = zz*tan(2.0*atan(exp(-cell.eta)));
+	double xx  = rho * cos(cell.phi); //cm
+	double yy  = rho * sin(cell.phi); //cm
 
-	hitVtxX.at(i) = hitVtxX.at(i)/10;
-	hitVtxY.at(i) = hitVtxY.at(i)/10;
-	hitVtxZ.at(i) = hitVtxZ.at(i)/10;
+	hebdzVsZ->Fill(zz, (hitVtxZ.at(i)-zz));
+	hebdyVsY->Fill(yy, (hitVtxY.at(i)-yy));
+	hebdxVsX->Fill(xx, (hitVtxX.at(i)-xx));
 
-	hebdzVsZ->Fill(zp, (hitVtxZ.at(i)-zp));
-	hebdyVsY->Fill(yp, (hitVtxY.at(i)-yp));
-	hebdxVsX->Fill(xp, (hitVtxX.at(i)-xp));
+	hebXG4VsId->Fill(hitVtxX.at(i),xx);
+	hebYG4VsId->Fill(hitVtxY.at(i),yy);
+	hebZG4VsId->Fill(hitVtxZ.at(i),zz);
 
-	hebXG4VsId->Fill(hitVtxX.at(i),xp);
-	hebYG4VsId->Fill(hitVtxY.at(i),yp);
-	hebZG4VsId->Fill(hitVtxZ.at(i),zp);
+	hebdzVsLayer->Fill(lay,(hitVtxZ.at(i)-zz));
+	hebdyVsLayer->Fill(lay,(hitVtxY.at(i)-yy));
+	hebdxVsLayer->Fill(lay,(hitVtxX.at(i)-xx));
 
-	hebdzVsLayer->Fill(lay,(hitVtxZ.at(i)-zp));
-	hebdyVsLayer->Fill(lay,(hitVtxY.at(i)-yp));
-	hebdxVsLayer->Fill(lay,(hitVtxX.at(i)-xp));
-
-	hebdX->Fill((hitVtxX.at(i)-xp));
-	hebdZ->Fill((hitVtxZ.at(i)-zp));
-	hebdY->Fill((hitVtxY.at(i)-yp));
+	hebdX->Fill((hitVtxX.at(i)-xx));
+	hebdZ->Fill((hitVtxZ.at(i)-zz));
+	hebdY->Fill((hitVtxY.at(i)-yy));
       }
 
     }//end G4 hits
     
   } else {
-    edm::LogWarning("HGCalValid") << "No PHGCalInfo " << std::endl;
+    edm::LogVerbatim("HGCalValid") << "HGCGeometryValidation::No PHGCalInfo ";
   }
 
 }

--- a/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
@@ -112,7 +112,7 @@ HGCalDigiValidation::HGCalDigiValidation(const edm::ParameterSet& iConfig) :
   } else {
     throw cms::Exception("BadHGCDigiSource")
       << "HGCal DetectorName given as " << nameDetector_ << " must be: "
-      << "\"HGCalHESiliconSensitive\", \"HGCalHESiliconSensitive\", "
+      << "\"HGCalEESensitive\", \"HGCalHESiliconSensitive\", "
       << "\"HGCalHEScintillatorSensitive\", or \"HCal\"!"; 
   }  
 }

--- a/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
@@ -300,7 +300,7 @@ void HGCalDigiValidation::digiValidation(const T1& detId, const T2* geom,
   hinfo.z       =  global1.z();
   hinfo.adc     =  adc;
   hinfo.charge  =  charge; //charges[0];
-  hinfo.layer   =  layer;
+  hinfo.layer   =  std::min(layer,layers_);
   
   if (verbosity_>1) 
     edm::LogVerbatim("HGCalValidation") << "gx =  "  << hinfo.x
@@ -309,8 +309,8 @@ void HGCalDigiValidation::digiValidation(const T1& detId, const T2* geom,
   
   fillDigiInfo(hinfo);
 
-  if (global1.eta() > 0)  fillOccupancyMap(OccupancyMap_plus_, layer -1);
-  else                    fillOccupancyMap(OccupancyMap_minus_, layer -1);
+  if (global1.eta() > 0)  fillOccupancyMap(OccupancyMap_plus_, hinfo.layer -1);
+  else                    fillOccupancyMap(OccupancyMap_minus_, hinfo.layer -1);
   
 }
 

--- a/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalDigiValidation.cc
@@ -134,20 +134,25 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent,
   
   const HGCalGeometry* geom0(nullptr);
   const CaloGeometry*  geom1(nullptr);
+  int geomType(0);
   if (nameDetector_ == "HCal") {
     edm::ESHandle<CaloGeometry> geom;
     iSetup.get<CaloGeometryRecord>().get(geom);
     if (!geom.isValid()) 
-      edm::LogWarning("HGCalValidation") << "Cannot get valid HGCalGeometry "
-					 << "Object for " << nameDetector_;
+      edm::LogVerbatim("HGCalValidation") << "HGCalDigiValidation: Cannot get valid "
+					  << "HGCalGeometry Object for " << nameDetector_;
     geom1 = geom.product();
   } else {
     edm::ESHandle<HGCalGeometry> geom;
     iSetup.get<IdealGeometryRecord>().get(nameDetector_, geom);
     if (!geom.isValid()) 
-      edm::LogWarning("HGCalValidation") << "Cannot get valid HGCalGeometry "
-					 << "Object for " << nameDetector_;
+      edm::LogVerbatim("HGCalValidation") << "HGCalDigiValidation: Cannot get valid "
+					  << "HGCalGeometry Object for " << nameDetector_;
     geom0 = geom.product();
+    HGCalGeometryMode::GeometryMode mode = geom0->topology().geomMode();
+    if ((mode == HGCalGeometryMode::Hexagon8) ||
+	(mode == HGCalGeometryMode::Hexagon8Full)) geomType = 1;
+    else if (mode == HGCalGeometryMode::Trapezoid) geomType = 2;
   }
 
   unsigned int ntot(0), nused(0);
@@ -163,8 +168,9 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent,
       
       for (const auto & it: *(theHGCEEDigiContainers.product())) {
 	ntot++; nused++;
-	HGCalDetId detId     = it.id();
-	int        layer     = detId.layer();
+	DetId      detId     = it.id();
+	int        layer     = ((geomType == 0) ? HGCalDetId(detId).layer() :
+				HGCSiliconDetId(detId).layer());
 	const HGCSample&  hgcSample = it.sample(SampleIndx_);
 	uint16_t   gain      = hgcSample.toa();
 	uint16_t   adc       = hgcSample.data();
@@ -173,8 +179,8 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent,
       }
       fillDigiInfo();
     } else {
-      edm::LogWarning("HGCalValidation") << "DigiCollection handle does not "
-					 << "exist for HGCEE!!!";
+      edm::LogVerbatim("HGCalValidation") << "DigiCollection handle does not "
+					  << "exist for HGCEE!!!";
     }
   } else if ((nameDetector_ == "HGCalHESiliconSensitive") || 
 	     (nameDetector_ == "HGCalHEScintillatorSensitive")) {
@@ -189,8 +195,10 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent,
       
       for (const auto & it: *(theHGCHEDigiContainers.product())) {
 	ntot++; nused++;
-	HGCalDetId detId     = it.id();
-	int        layer     = detId.layer();
+	DetId      detId     = it.id();
+	int        layer     = ((geomType == 0) ? HGCalDetId(detId).layer() :
+				((geomType == 1) ? HGCSiliconDetId(detId).layer() :
+				 HGCScintillatorDetId(detId).layer()));
 	const HGCSample&  hgcSample = it.sample(SampleIndx_);
 	uint16_t   gain      = hgcSample.toa();
 	uint16_t   adc       = hgcSample.data();
@@ -199,8 +207,8 @@ void HGCalDigiValidation::analyze(const edm::Event& iEvent,
       }
       fillDigiInfo();
     } else {
-      edm::LogWarning("HGCalValidation") << "DigiCollection handle does not "
-					 << "exist for HGCFH!!!";
+      edm::LogVerbatim("HGCalValidation") << "DigiCollection handle does not "
+					  << "exist for HGCFH!!!";
     }
   } else if ((nameDetector_ == "HCal") && (!ifHCAL_)) {
     //HGCalBH
@@ -276,7 +284,9 @@ template<class T1, class T2>
 void HGCalDigiValidation::digiValidation(const T1& detId, const T2* geom, 
 					 int layer, uint16_t adc, double charge) {
   
-  if (verbosity_>1) edm::LogVerbatim("HGCalValidation") << detId;
+  if (verbosity_>1) edm::LogVerbatim("HGCalValidation") << std::hex 
+							<< detId.rawId()
+							<< std::dec;
   DetId id1 = DetId(detId.rawId());
   const GlobalPoint& global1 = geom->getPosition(id1);
   

--- a/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
@@ -162,7 +162,8 @@ void HGCalHitCalibration::fillWithRecHits(
       << " Subdet " << hitid.subdetId() << std::endl;
     return;
   }
-  if (hitid.det() != DetId::Forward) {
+  if ((hitid.det() != DetId::Forward) && (hitid.det() != DetId::HGCalEE) &&
+      (hitid.det() != DetId::HGCalHSi) && (hitid.det() != DetId::HGCalHSc)) {
     IfLogTrace(debug_ > 0, "HGCalHitCalibration")
       << ">>> Wrong type of detid " << std::hex << hitid.rawId() << std::dec
       << " Det " << hitid.det()
@@ -279,6 +280,9 @@ void HGCalHitCalibration::analyze(const edm::Event& iEvent,
           if ((hitid.det() == DetId::Forward &&
 	       (hitid.subdetId() == HGCEE || hitid.subdetId() == HGCHEF ||
 		hitid.subdetId() == HGCHEB)) ||
+	      (hitid.det() == DetId::HGCalEE) ||
+	      (hitid.det() == DetId::HGCalHSi) ||
+	      (hitid.det() == DetId::HGCalHSc) ||
 	      (hitid.det() == DetId::Hcal && hitid.subdetId() == HcalEndcap))
             fillWithRecHits(hitmap, hitid, hitlayer, it_haf.second, seedDet,
                             seedEnergy);
@@ -342,7 +346,8 @@ void HGCalHitCalibration::analyze(const edm::Event& iEvent,
 				      ele.end(),
 				      closest_fcn);
       if (closest != ele.end()
-	  && closest->superCluster()->seed()->seed().det() == DetId::Forward
+	  && (closest->superCluster()->seed()->seed().det() == DetId::Forward ||
+	      closest->superCluster()->seed()->seed().det() == DetId::HGCalEE)
 	  && reco::deltaR2(*closest, it_caloPart) < 0.01) {
 	seedDet = recHitTools_.getSiThickness(closest->superCluster()->seed()->seed());
 	if (hgcal_ele_EoP_CPene_calib_fraction_.count(seedDet)) {
@@ -359,7 +364,8 @@ void HGCalHitCalibration::analyze(const edm::Event& iEvent,
 				      photon.end(),
 				      closest_fcn);
       if (closest != photon.end()
-	  && closest->superCluster()->seed()->seed().det() == DetId::Forward
+	  && (closest->superCluster()->seed()->seed().det() == DetId::Forward ||
+	      closest->superCluster()->seed()->seed().det() == DetId::HGCalEE)
 	  && reco::deltaR2(*closest, it_caloPart) < 0.01) {
 	seedDet = recHitTools_.getSiThickness(closest->superCluster()->seed()->seed());
 	if (hgcal_photon_EoP_CPene_calib_fraction_.count(seedDet)) {

--- a/Validation/HGCalValidation/plugins/HGCalHitClient.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitClient.cc
@@ -42,29 +42,29 @@ HGCalHitClient::~HGCalHitClient() { }
 void HGCalHitClient::dqmEndJob(DQMStore::IBooker &ib, DQMStore::IGetter &ig) {
   ig.setCurrentFolder("/"); 
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("HGCalValid") << "HGCalHitValidation :: runClient" << std::endl;
+  edm::LogVerbatim("HGCalValid") << "HGCalHitValidation :: runClient";
 #endif
   std::vector<MonitorElement*> hgcalMEs;
   std::vector<std::string> fullDirPath = ig.getSubdirs();
 
   for (unsigned int i=0; i<fullDirPath.size(); i++) {
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HGCalValid") << "HGCalHitValidation::fullPath: " 
-			       << fullDirPath.at(i) << std::endl;
+    edm::LogVerbatim("HGCalValid") << "HGCalHitValidation::fullPath: " 
+				   << fullDirPath.at(i);
 #endif
     ig.setCurrentFolder(fullDirPath.at(i));
     std::vector<std::string> fullSubDirPath = ig.getSubdirs();
 
     for (unsigned int j=0; j<fullSubDirPath.size(); j++) {
 #ifdef EDM_ML_DEBUG
-      edm::LogInfo("HGCalValid") << "HGCalHitValidation:: fullSubPath: " 
-				 << fullSubDirPath.at(j) << std::endl;
+      edm::LogVerbatim("HGCalValid") << "HGCalHitValidation:: fullSubPath: " 
+				     << fullSubDirPath.at(j);
 #endif
       if (strcmp(fullSubDirPath.at(j).c_str(), subDirectory_.c_str()) == 0) {
         hgcalMEs = ig.getContents(fullSubDirPath.at(j));
 #ifdef EDM_ML_DEBUG
-	edm::LogInfo("HGCalValid") << "HGCalHitValidation:: hgcalMES size : " 
-				   << hgcalMEs.size() << std::endl;
+	edm::LogVerbatim("HGCalValid") << "HGCalHitValidation:: hgcalMES size : " 
+				       << hgcalMEs.size();
 #endif
         if (!geometryEndjob(hgcalMEs)) 
           edm::LogWarning("HGCalValid") << "\nError in HGcalHitEndjob!";

--- a/Validation/HGCalValidation/plugins/HGCalHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitValidation.cc
@@ -90,6 +90,7 @@ private:
   std::vector<std::string>              geometrySource_;
   std::vector<int>                      ietaExcludeBH_;
   bool                                  ifHCAL_;
+  bool                                  ifHCALsim_;
 
   edm::InputTag eeSimHitSource, fhSimHitSource, bhSimHitSource;
   edm::EDGetTokenT<std::vector<PCaloHit>> eeSimHitToken_;
@@ -127,6 +128,7 @@ HGCalHitValidation::HGCalHitValidation(const edm::ParameterSet &cfg) {
   fhRecHitToken_  = consumes<HGChefRecHitCollection>(cfg.getParameter<edm::InputTag>("fhRecHitSource"));
   ietaExcludeBH_  = cfg.getParameter<std::vector<int> >("ietaExcludeBH");
   ifHCAL_         = cfg.getParameter<bool>("ifHCAL");
+  ifHCALsim_      = cfg.getParameter<bool>("ifHCALsim");
   if (ifHCAL_) 
     bhRecHitTokenh_ = consumes<HBHERecHitCollection>(cfg.getParameter<edm::InputTag>("bhRecHitSource"));
   else
@@ -297,7 +299,7 @@ void HGCalHitValidation::analyze( const edm::Event &iEvent, const edm::EventSetu
   edm::Handle<std::vector<PCaloHit>> bhSimHits;
   iEvent.getByToken(bhSimHitToken_, bhSimHits);
   if (bhSimHits.isValid()) {
-   if(ifHCAL_){
+   if(ifHCALsim_){
     for (std::vector<PCaloHit>::const_iterator simHit = bhSimHits->begin();
 	 simHit != bhSimHits->end(); ++simHit) {
       int subdet, z, depth, eta, phi, lay;

--- a/Validation/HGCalValidation/plugins/HGCalHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitValidation.cc
@@ -265,11 +265,11 @@ void HGCalHitValidation::analyze( const edm::Event &iEvent, const edm::EventSetu
 				 << std::get<0>(itr->second) 
 				 << "; Position (" << std::get<1>(itr->second) 
 				 << ", " << std::get<2>(itr->second) <<", " 
-				 << std::get<3>(itr->second) << ")" <<std::endl;
+				 << std::get<3>(itr->second) << ")";
     }
 #endif
   } else {   
-    edm::LogWarning("HGCalValid") << "No EE SimHit Found " << std::endl;
+    edm::LogVerbatim("HGCalValid") << "No EE SimHit Found ";
   }
 
   //Accesing fh simhits
@@ -286,11 +286,11 @@ void HGCalHitValidation::analyze( const edm::Event &iEvent, const edm::EventSetu
 				 << std::get<0>(itr->second) << "; Position (" 
 				 << std::get<1>(itr->second) << ", "
 				 << std::get<2>(itr->second) <<", " 
-				 << std::get<3>(itr->second) << ")" <<std::endl;
+				 << std::get<3>(itr->second) << ")";
     }
 #endif
   } else {
-    edm::LogWarning("HGCalValid") << "No FH SimHit Found " << std::endl;
+    edm::LogVerbatim("HGCalValid") << "No FH SimHit Found ";
   }
 	
   //Accessing bh simhits
@@ -335,11 +335,11 @@ void HGCalHitValidation::analyze( const edm::Event &iEvent, const edm::EventSetu
 				 << std::get<0>(itr->second) << "; Position (" 
 				 << std::get<1>(itr->second) << ", "
 				 << std::get<2>(itr->second) <<", " 
-				 << std::get<3>(itr->second) << ")" <<std::endl;
+				 << std::get<3>(itr->second) << ")";
     }
 #endif
   } else {
-    edm::LogWarning("HGCalValid") << "No BH SimHit Found " << std::endl;
+    edm::LogVerbatim("HGCalValid") << "No BH SimHit Found ";
   }
 
   //accessing EE Rechit information
@@ -368,12 +368,12 @@ void HGCalHitValidation::analyze( const edm::Event &iEvent, const edm::EventSetu
 				   << std::get<2>(itr->second) << ", " 
 				   << std::get<3>(itr->second) << ") Rec (" 
 				   << energy << ", "  << xyz.x() << ", " 
-				   << xyz.y() << ", " << xyz.z() << ")\n";
+				   << xyz.y() << ", " << xyz.z() << ")";
 #endif
       }
     }
   } else {
-    edm::LogWarning("HGCalValid") << "No EE RecHit Found " << std::endl;
+    edm::LogVerbatim("HGCalValid") << "No EE RecHit Found ";
   }
 
   //accessing FH Rechit information
@@ -403,12 +403,12 @@ void HGCalHitValidation::analyze( const edm::Event &iEvent, const edm::EventSetu
 				   << std::get<2>(itr->second) << ", " 
 				   << std::get<3>(itr->second) << ") Rec (" 
 				   << energy << "," << xyz.x() << ", " 
-				   << xyz.y() << ", " << xyz.z() << ")\n";
+				   << xyz.y() << ", " << xyz.z() << ")";
 #endif
       }
     }
   } else {
-    edm::LogWarning("HGCalValid") << "No FH RecHit Found " << std::endl;
+    edm::LogVerbatim("HGCalValid") << "No FH RecHit Found ";
   }
 
 
@@ -420,7 +420,7 @@ void HGCalHitValidation::analyze( const edm::Event &iEvent, const edm::EventSetu
       const HBHERecHitCollection* theHits = (bhRecHit.product());
       analyzeHGCalRecHit(theHits, bhHitRefs);
     } else {
-      edm::LogWarning("HGCalValid") << "No BH RecHit Found " << std::endl;
+      edm::LogVerbatim("HGCalValid") << "No BH RecHit Found ";
     }
   } else {
     edm::Handle<HGChebRecHitCollection> bhRecHit;
@@ -429,7 +429,7 @@ void HGCalHitValidation::analyze( const edm::Event &iEvent, const edm::EventSetu
       const HGChebRecHitCollection* theHits = (bhRecHit.product());
       analyzeHGCalRecHit(theHits, bhHitRefs);
     } else {
-      edm::LogWarning("HGCalValid") << "No BH RecHit Found " << std::endl;
+      edm::LogVerbatim("HGCalValid") << "No BH RecHit Found ";
     }
   }
 }

--- a/Validation/HGCalValidation/plugins/HGCalHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitValidation.cc
@@ -297,6 +297,7 @@ void HGCalHitValidation::analyze( const edm::Event &iEvent, const edm::EventSetu
   edm::Handle<std::vector<PCaloHit>> bhSimHits;
   iEvent.getByToken(bhSimHitToken_, bhSimHits);
   if (bhSimHits.isValid()) {
+   if(ifHCAL_){
     for (std::vector<PCaloHit>::const_iterator simHit = bhSimHits->begin();
 	 simHit != bhSimHits->end(); ++simHit) {
       int subdet, z, depth, eta, phi, lay;
@@ -326,6 +327,10 @@ void HGCalHitValidation::analyze( const edm::Event &iEvent, const edm::EventSetu
 	}
       }
     }
+   }
+   else {
+    analyzeHGCalSimHit(bhSimHits, 2, hebEnSim, bhHitRefs);
+   }
 #ifdef EDM_ML_DEBUG
     for (std::map<unsigned int,HGCHitTuple>::iterator itr=bhHitRefs.begin();
 	 itr != bhHitRefs.end(); ++itr) {
@@ -473,7 +478,7 @@ void HGCalHitValidation::analyzeHGCalRecHit(T1 const & theHits,
 					    std::map<unsigned int, HGCHitTuple> const& hitRefs) {
   for (auto it = theHits->begin(); it!=theHits->end(); ++it) {
     DetId id = it->id();
-    if (id.subdetId() == (int)(HcalEndcap)) {
+    if (id.det() == DetId::Hcal and id.subdetId() == (int)(HcalEndcap)) {
       double energy = it->energy();
       hebEnRec->Fill(energy);
       GlobalPoint xyz = hcGeometry_->getGeometry(id)->getPosition();

--- a/Validation/HGCalValidation/plugins/HGCalRecHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalRecHitValidation.cc
@@ -236,7 +236,7 @@ void HGCalRecHitValidation::recHitValidation(DetId & detId, int layer,
   hinfo.x      = globalx;
   hinfo.y      = globaly;
   hinfo.z      = globalz;
-  hinfo.layer  = layer;
+  hinfo.layer  = std::min((unsigned)layer,layers_);
   hinfo.phi    = global.phi();
   hinfo.eta    = global.eta();
       
@@ -244,12 +244,12 @@ void HGCalRecHitValidation::recHitValidation(DetId & detId, int layer,
     edm::LogVerbatim("HGCalValidation") << "--------------------------   gx = "
 					<< globalx << " gy = "  << globaly   
 					<< " gz = " << globalz << " phi = " 
-					<< hinfo.phi << " eta = " << hinfo.eta;
+					<< hinfo.phi << " eta = " << hinfo.eta << " lay = " << hinfo.layer;
       
   fillHitsInfo(hinfo);
       
-  if (hinfo.eta > 0)  fillOccupancyMap(OccupancyMap_plus, layer -1);
-  else                fillOccupancyMap(OccupancyMap_minus, layer -1);
+  if (hinfo.eta > 0)  fillOccupancyMap(OccupancyMap_plus, hinfo.layer -1);
+  else                fillOccupancyMap(OccupancyMap_minus, hinfo.layer -1);
       
 }      
 

--- a/Validation/HGCalValidation/plugins/HGCalRecHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalRecHitValidation.cc
@@ -130,73 +130,88 @@ void HGCalRecHitValidation::analyze(const edm::Event& iEvent,
   if (nameDetector_ == "HCal") {
     edm::ESHandle<CaloGeometry> geom;
     iSetup.get<CaloGeometryRecord>().get(geom);
-    if (!geom.isValid()) 
-      edm::LogWarning("HGCalValidation") << "Cannot get valid HGCalGeometry "
-					 << "Object for " << nameDetector_;
-    const CaloGeometry* geom0 = geom.product();
+    if (!geom.isValid()) {
+      edm::LogVerbatim("HGCalValidation") << "Cannot get valid HGCalGeometry "
+					  << "Object for " << nameDetector_;
+    } else {
+      const CaloGeometry* geom0 = geom.product();
 
-    if (ifHCAL_) {
-      edm::Handle<HBHERecHitCollection> hbhecoll;
-      iEvent.getByToken(recHitSource_, hbhecoll);
-      if (hbhecoll.isValid()) {
-	if (verbosity_>0) 
-	  edm::LogVerbatim("HGCalValidation") << nameDetector_ << " with " 
-					      << hbhecoll->size() 
-					      << " element(s)";
-	for (const auto & it : *(hbhecoll.product())) {
-	  DetId detId = it.id();
-	  ntot++;
-	  if (detId.subdetId() == HcalEndcap) {
-	    nused++;
+      if (ifHCAL_) {
+	edm::Handle<HBHERecHitCollection> hbhecoll;
+	iEvent.getByToken(recHitSource_, hbhecoll);
+	if (hbhecoll.isValid()) {
+	  if (verbosity_>0) 
+	    edm::LogVerbatim("HGCalValidation") << nameDetector_ << " with " 
+						<< hbhecoll->size() 
+						<< " element(s)";
+	  for (const auto & it : *(hbhecoll.product())) {
+	    DetId detId = it.id();
+	    ntot++;
+	    if (detId.subdetId() == HcalEndcap) {
+	      nused++;
+	      int   layer = HcalDetId(detId).depth();
+	      recHitValidation(detId, layer, geom0, &it);
+	    }
+	  }
+	} else {
+	  ok = false;
+	  edm::LogVerbatim("HGCalValidation") << "HBHERecHitCollection Handle does not "
+					      << "exist !!!";
+	}
+      } else {
+	edm::Handle<HGChebRecHitCollection> hbhecoll;
+	iEvent.getByToken(recHitSource_, hbhecoll);
+	if (hbhecoll.isValid()) {
+	  if (verbosity_>0) 
+	    edm::LogVerbatim("HGCalValidation") << nameDetector_ << " with " 
+						<< hbhecoll->size() 
+						<< " element(s)";
+	  for (const auto & it : *(hbhecoll.product())) {
+	    DetId detId = it.id();
+	    ntot++; nused++;
 	    int   layer = HcalDetId(detId).depth();
 	    recHitValidation(detId, layer, geom0, &it);
 	  }
+	} else {
+	  ok = false;
+	  edm::LogVerbatim("HGCalValidation") << "HGChebRecHitCollection Handle does not "
+					      << "exist !!!";
 	}
-      } else {
-	ok = false;
-	edm::LogWarning("HGCalValidation") << "HBHERecHitCollection Handle does not exist !!!";
-      }
-    } else {
-      edm::Handle<HGChebRecHitCollection> hbhecoll;
-      iEvent.getByToken(recHitSource_, hbhecoll);
-      if (hbhecoll.isValid()) {
-	if (verbosity_>0) 
-	  edm::LogVerbatim("HGCalValidation") << nameDetector_ << " with " 
-					      << hbhecoll->size() 
-					      << " element(s)";
-	for (const auto & it : *(hbhecoll.product())) {
-	  DetId detId = it.id();
-	  ntot++; nused++;
-	  int   layer = HcalDetId(detId).depth();
-	  recHitValidation(detId, layer, geom0, &it);
-	}
-      } else {
-	ok = false;
-	edm::LogWarning("HGCalValidation") << "HGChebRecHitCollection Handle does not exist !!!";
       }
     }
   } else {
     edm::ESHandle<HGCalGeometry> geom;
     iSetup.get<IdealGeometryRecord>().get(nameDetector_, geom);
-    if (!geom.isValid()) edm::LogWarning("HGCalValidation") << "Cannot get valid HGCalGeometry Object for " << nameDetector_;
-    const HGCalGeometry* geom0 = geom.product();
-
-    edm::Handle<HGCRecHitCollection> theRecHitContainers;
-    iEvent.getByToken(recHitSource_, theRecHitContainers);
-    if (theRecHitContainers.isValid()) {
-      if (verbosity_>0) 
-	edm::LogVerbatim("HGCalValidation") << nameDetector_ << " with " 
-					    << theRecHitContainers->size()
-					    << " element(s)";
-      for (const auto &  it : *(theRecHitContainers.product())) {
-	ntot++; nused++;
-	DetId detId = it.id();
-	int layer   = HGCalDetId(detId).layer();
-	recHitValidation(detId, layer, geom0, &it);
-      }
+    if (!geom.isValid()) {
+      edm::LogVerbatim("HGCalValidation") << "Cannot get valid HGCalGeometry Object for "
+					   << nameDetector_;
     } else {
-      ok = false;
-      edm::LogWarning("HGCalValidation") << "HGCRecHitCollection Handle does not exist !!!";
+      const HGCalGeometry* geom0 = geom.product();
+      HGCalGeometryMode::GeometryMode mode = geom0->topology().geomMode();
+      int geomType = (((mode == HGCalGeometryMode::Hexagon8) ||
+		       (mode == HGCalGeometryMode::Hexagon8Full)) ? 1 :
+		      ((mode == HGCalGeometryMode::Trapezoid) ? 2 : 0));
+      
+      edm::Handle<HGCRecHitCollection> theRecHitContainers;
+      iEvent.getByToken(recHitSource_, theRecHitContainers);
+      if (theRecHitContainers.isValid()) {
+	if (verbosity_>0) 
+	  edm::LogVerbatim("HGCalValidation") << nameDetector_ << " with " 
+					      << theRecHitContainers->size()
+					      << " element(s)";
+	for (const auto &  it : *(theRecHitContainers.product())) {
+	  ntot++; nused++;
+	  DetId detId = it.id();
+	  int layer   = ((geomType == 0) ? HGCalDetId(detId).layer() :
+			 ((geomType == 1) ? HGCSiliconDetId(detId).layer() :
+			  HGCScintillatorDetId(detId).layer()));
+	  recHitValidation(detId, layer, geom0, &it);
+	}
+      } else {
+	ok = false;
+	edm::LogVerbatim("HGCalValidation") << "HGCRecHitCollection Handle does not "
+					    << "exist !!!";
+      }
     }
   }
   if (ok) fillHitsInfo();

--- a/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
@@ -8,6 +8,8 @@
 
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
 #include "DetectorDescription/Core/interface/DDCompactView.h"
@@ -61,10 +63,10 @@ public:
   struct hitsinfo{
     hitsinfo() {
       x=y=z=phi=eta=0.0;
-      cell=sector=layer=0;
+      cell=cell2=sector=sector2=type=layer=0;
     }
     double x, y, z, phi, eta;
-    int    cell, sector, layer;
+    int    cell, cell2, sector, sector2, type, layer;
   };
   
   
@@ -137,7 +139,7 @@ void HGCalSimHitValidation::analyze(const edm::Event& iEvent,
   edm::Handle<edm::HepMCProduct> evtMC;
   iEvent.getByToken(tok_hepMC_,evtMC); 
   if (!evtMC.isValid()) {
-    edm::LogWarning("HGCalValidation") << "no HepMCProduct found\n";
+    edm::LogVerbatim("HGCalValidation") << "no HepMCProduct found";
   } else { 
     const HepMC::GenEvent * myGenEvent = evtMC->GetEvent();
     unsigned int k(0);
@@ -192,8 +194,8 @@ void HGCalSimHitValidation::analyzeHits (std::vector<PCaloHit>& hits) {
     double energy      = hits[i].energy();
     double time        = hits[i].time();
     uint32_t id_       = hits[i].id();
-    int    cell, sector, subsector, layer, zside;
-    int    subdet(0);
+    int    cell, sector, subsector(0), layer, zside;
+    int    subdet(0), cell2(0), type(0);
     if (heRebuild_) {
       HcalDetId detId  = HcalDetId(id_);
       subdet           = detId.subdet();
@@ -203,21 +205,41 @@ void HGCalSimHitValidation::analyzeHits (std::vector<PCaloHit>& hits) {
       subsector        = 1;
       layer            = detId.depth();
       zside            = detId.zside();
+    } else if ((hgcons_->geomMode() == HGCalGeometryMode::Hexagon8) ||
+	       (hgcons_->geomMode() == HGCalGeometryMode::Hexagon8Full)) {
+      HGCSiliconDetId detId = HGCSiliconDetId(id_);
+      subdet           = ForwardEmpty;
+      cell             = detId.cellU();
+      cell2            = detId.cellV();
+      sector           = detId.waferU();
+      subsector        = detId.waferV();
+      type             = detId.type();
+      layer            = detId.layer();
+      zside            = detId.zside();
+    } else if (hgcons_->geomMode() == HGCalGeometryMode::Square) {
+      HGCalTestNumbering::unpackSquareIndex(id_, zside, layer, sector, subsector, cell);
+    } else if (hgcons_->geomMode() == HGCalGeometryMode::Trapezoid) {
+      HGCScintillatorDetId detId = HGCScintillatorDetId(id_);
+      subdet           = ForwardEmpty;
+      cell             = detId.ietaAbs();
+      sector           = detId.iphi();
+      subsector        = 1;
+      type             = detId.type();
+      layer            = detId.layer();
+      zside            = detId.zside();
     } else {
-      if (hgcons_->geomMode() == HGCalGeometryMode::Square) {
-	HGCalTestNumbering::unpackSquareIndex(id_, zside, layer, sector, subsector, cell);
-      } else {
-	HGCalTestNumbering::unpackHexagonIndex(id_, subdet, zside, layer, sector, subsector, cell);
-      }
+      HGCalTestNumbering::unpackHexagonIndex(id_, subdet, zside, layer, sector, type, cell);
     }
     nused++;
     if (verbosity_>1) 
       edm::LogVerbatim("HGCalValidation") << "Detector "     << nameDetector_
 					  << " zside = "     << zside
 					  << " sector|wafer = "   << sector
-					  << " subsector|type = " << subsector
+					  << ":" << subsector
+					  << " type = "      << type
 					  << " layer = "     << layer
-					  << " cell = "      << cell
+					  << " cell = "      << cell 
+					  << ":" << cell2
 					  << " energy = "    << energy
 					  << " energyem = "  << hits[i].energyEM()
 					  << " energyhad = " << hits[i].energyHad()
@@ -236,20 +258,26 @@ void HGCalSimHitValidation::analyzeHits (std::vector<PCaloHit>& hits) {
       gcoord = HepGeom::Point3D<float>(rz*cos(etaphi.second)/cosh(etaphi.first),
 				       rz*sin(etaphi.second)/cosh(etaphi.first),
 				       rz*tanh(etaphi.first));
+    } else if (hgcons_->geomMode() == HGCalGeometryMode::Square) {
+      std::pair<float,float> xy = hgcons_->locateCell(cell,layer,subsector,false);
+      const HepGeom::Point3D<float> lcoord(xy.first,xy.second,0);
+      int subs = (symmDet_ ? 0 : subsector);
+      id_      = HGCalTestNumbering::packSquareIndex(zside,layer,sector,subs,0);
+      gcoord   = (transMap_[id_]*lcoord);
     } else {
-      if (hgcons_->geomMode() == HGCalGeometryMode::Square) {
-	std::pair<float,float> xy = hgcons_->locateCell(cell,layer,subsector,false);
-	const HepGeom::Point3D<float> lcoord(xy.first,xy.second,0);
-	int subs = (symmDet_ ? 0 : subsector);
-	id_      = HGCalTestNumbering::packSquareIndex(zside,layer,sector,subs,0);
-	gcoord   = (transMap_[id_]*lcoord);
+      std::pair<float,float> xy;
+      if ((hgcons_->geomMode() == HGCalGeometryMode::Hexagon8) ||
+	  (hgcons_->geomMode() == HGCalGeometryMode::Hexagon8Full)) {
+	xy = hgcons_->locateCell(layer,sector,subsector,cell,cell2,false,true);
+      } else if (hgcons_->geomMode() == HGCalGeometryMode::Trapezoid) {
+	xy = hgcons_->locateCellTrap(layer,sector,cell,false);
       } else {
-	std::pair<float,float> xy = hgcons_->locateCell(cell,layer,sector,false);
-	double zp = hgcons_->waferZ(layer,false);
-	if (zside < 0) zp = -zp;
-	float  xp = (zp < 0) ? -xy.first : xy.first;
-	gcoord = HepGeom::Point3D<float>(xp,xy.second,zp);
+	xy = hgcons_->locateCell(cell,layer,sector,false);
       }
+      double zp = hgcons_->waferZ(layer,false);
+      if (zside < 0) zp = -zp;
+      float  xp = (zp < 0) ? -xy.first : xy.first;
+      gcoord = HepGeom::Point3D<float>(xp,xy.second,zp);
     }
     double tof = (gcoord.mag()*CLHEP::mm)/CLHEP::c_light; 
     if (verbosity_>1) 
@@ -268,7 +296,10 @@ void HGCalSimHitValidation::analyzeHits (std::vector<PCaloHit>& hits) {
       hinfo.y      = gcoord.y();
       hinfo.z      = gcoord.z();
       hinfo.sector = sector;
+      hinfo.sector2= subsector;
       hinfo.cell   = cell;
+      hinfo.cell2  = cell;
+      hinfo.type   = type;
       hinfo.layer  = layer;
       hinfo.phi    = gcoord.getPhi();
       hinfo.eta    = gcoord.getEta();
@@ -342,9 +373,11 @@ void HGCalSimHitValidation::fillHitsInfo(std::pair<hitsinfo,energysum> hits,
     if (verbosity_>0) 
       edm::LogVerbatim("HGCalValidation") << "Problematic Hit for " 
 					  << nameDetector_ << " at sector " 
-					  << hits.first.sector << " layer " 
+					  << hits.first.sector << ":"
+					  << hits.first.sector2 << " layer " 
 					  << hits.first.layer << " cell " 
-					  << hits.first.cell << " energy "
+					  << hits.first.cell << ":"
+					  << hits.first.cell2 << " energy "
 					  << hits.second.etotal;
   }
 }

--- a/Validation/HGCalValidation/python/digiValidation_cff.py
+++ b/Validation/HGCalValidation/python/digiValidation_cff.py
@@ -13,3 +13,6 @@ hgcalDigiValidationHEB = hgcalDigiValidationEE.clone(
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(hgcalDigiValidationHEF, DigiSource = "mixData:HGCDigisHEfront")
 premix_stage2.toModify(hgcalDigiValidationHEB, DigiSource = "mixData:HGCDigisHEback")
+
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+phase2_hgcalV9.toModify(hgcalDigiValidationHEB, DetectorName = cms.string("HGCalHEScintillatorSensitive"))

--- a/Validation/HGCalValidation/python/hgcGeometryValidationV6_cfi.py
+++ b/Validation/HGCalValidation/python/hgcGeometryValidationV6_cfi.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+from SimG4Core.Configuration.SimG4Core_cff import *
+
+g4SimHits.Watchers = cms.VPSet(cms.PSet(
+        SimG4HGCalValidation = cms.PSet(
+            Names = cms.vstring(
+                'HGCalEECell',  
+                'HGCalHECell',
+                'HEScintillator',
+                ),
+            Types = cms.vint32(1,1,2),
+            LabelLayerInfo = cms.string("HGCalInfoLayer"),
+            ),
+        type = cms.string('SimG4HGCalValidation')
+        )
+                               )
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+hgcGeomAnalysis = DQMEDAnalyzer('HGCGeometryValidation',
+                                 geometrySource = cms.untracked.vstring(
+        'HGCalEESensitive',
+        'HGCalHESiliconSensitive',
+        'Hcal'),
+                                 g4Source = cms.InputTag("g4SimHits","HGCalInfoLayer"),
+                                 )

--- a/Validation/HGCalValidation/python/hgcGeometryValidationV9_cfi.py
+++ b/Validation/HGCalValidation/python/hgcGeometryValidationV9_cfi.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+from SimG4Core.Configuration.SimG4Core_cff import *
+
+g4SimHits.Watchers = cms.VPSet(cms.PSet(
+        SimG4HGCalValidation = cms.PSet(
+            Names = cms.vstring(
+                'HGCalEESensitive',  
+                'HGCalHESiliconSensitive',
+                'HGCalHEScintillatorSensitive',
+                ),
+            Types = cms.vint32(1,1,1),
+            LabelLayerInfo = cms.string("HGCalInfoLayer"),
+            ),
+        type = cms.string('SimG4HGCalValidation')
+        )
+                               )
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+hgcGeomAnalysis = DQMEDAnalyzer('HGCGeometryValidation',
+                                 geometrySource = cms.untracked.vstring(
+        'HGCalEESensitive',
+        'HGCalHESiliconSensitive',
+        'HGCalHEScintillatorSensitive'),
+                                 g4Source = cms.InputTag("g4SimHits","HGCalInfoLayer"),
+                                 )

--- a/Validation/HGCalValidation/python/hgcalHitValidation_cfi.py
+++ b/Validation/HGCalValidation/python/hgcalHitValidation_cfi.py
@@ -10,7 +10,7 @@ hgcalHitValidation = DQMEDAnalyzer('HGCalHitValidation',
                                     bhSimHitSource = cms.InputTag("g4SimHits","HcalHits"),
                                     eeRecHitSource = cms.InputTag("HGCalRecHit","HGCEERecHits"),
                                     fhRecHitSource = cms.InputTag("HGCalRecHit","HGCHEFRecHits"),
-                                    bhRecHitSource = cms.InputTag("hbhereco"),
+								    bhRecHitSource = cms.InputTag("HGCalRecHit","HGCHEBRecHits"),
                                     ietaExcludeBH  = cms.vint32([]),
                                     ifHCAL         = cms.bool(True)
                                     )
@@ -24,6 +24,5 @@ from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 phase2_hgcalV9.toModify(hgcalHitValidation,
     bhSimHitSource = cms.InputTag("g4SimHits","HGCHitsHEback"),
     geometrySource = cms.untracked.vstring("HGCalEESensitive","HGCalHESiliconSensitive","HGCalHEScintillatorSensitive"),
-    bhRecHitSource = cms.InputTag("HGCalRecHit","HGCHEBRecHits"),
     ifHCAL         = cms.bool(False),
 )

--- a/Validation/HGCalValidation/python/hgcalHitValidation_cfi.py
+++ b/Validation/HGCalValidation/python/hgcalHitValidation_cfi.py
@@ -12,7 +12,8 @@ hgcalHitValidation = DQMEDAnalyzer('HGCalHitValidation',
                                     fhRecHitSource = cms.InputTag("HGCalRecHit","HGCHEFRecHits"),
 								    bhRecHitSource = cms.InputTag("HGCalRecHit","HGCHEBRecHits"),
                                     ietaExcludeBH  = cms.vint32([]),
-                                    ifHCAL         = cms.bool(True)
+                                    ifHCAL         = cms.bool(False),
+                                    ifHCALsim      = cms.bool(True),
                                     )
 
 from Validation.HGCalValidation.hgcalHitCalibration_cfi import hgcalHitCalibration
@@ -24,5 +25,5 @@ from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
 phase2_hgcalV9.toModify(hgcalHitValidation,
     bhSimHitSource = cms.InputTag("g4SimHits","HGCHitsHEback"),
     geometrySource = cms.untracked.vstring("HGCalEESensitive","HGCalHESiliconSensitive","HGCalHEScintillatorSensitive"),
-    ifHCAL         = cms.bool(False),
+    ifHCALsim      = cms.bool(False),
 )

--- a/Validation/HGCalValidation/python/hgcalHitValidation_cfi.py
+++ b/Validation/HGCalValidation/python/hgcalHitValidation_cfi.py
@@ -10,13 +10,20 @@ hgcalHitValidation = DQMEDAnalyzer('HGCalHitValidation',
                                     bhSimHitSource = cms.InputTag("g4SimHits","HcalHits"),
                                     eeRecHitSource = cms.InputTag("HGCalRecHit","HGCEERecHits"),
                                     fhRecHitSource = cms.InputTag("HGCalRecHit","HGCHEFRecHits"),
-                                    bhRecHitSource = cms.InputTag("HGCalRecHit","HGCHEBRecHits"),
-#                                    bhRecHitSource = cms.InputTag("hbhereco"),
+                                    bhRecHitSource = cms.InputTag("hbhereco"),
                                     ietaExcludeBH  = cms.vint32([]),
-                                    ifHCAL         = cms.bool(False)
+                                    ifHCAL         = cms.bool(True)
                                     )
 
 from Validation.HGCalValidation.hgcalHitCalibration_cfi import hgcalHitCalibration
 from Validation.HGCalValidation.caloparticlevalidation_cfi import caloparticlevalidation
 
 hgcalHitValidationSequence = cms.Sequence(hgcalHitValidation+hgcalHitCalibration+caloparticlevalidation)
+
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+phase2_hgcalV9.toModify(hgcalHitValidation,
+    bhSimHitSource = cms.InputTag("g4SimHits","HGCHitsHEback"),
+    geometrySource = cms.untracked.vstring("HGCalEESensitive","HGCalHESiliconSensitive","HGCalHEScintillatorSensitive"),
+    bhRecHitSource = cms.InputTag("HGCalRecHit","HGCHEBRecHits"),
+    ifHCAL         = cms.bool(False),
+)

--- a/Validation/HGCalValidation/python/rechitValidation_cff.py
+++ b/Validation/HGCalValidation/python/rechitValidation_cff.py
@@ -9,3 +9,7 @@ hgcalRecHitValidationHEF = hgcalRecHitValidationEE.clone(
 hgcalRecHitValidationHEB = hgcalRecHitValidationEE.clone(
     DetectorName  = cms.string("HCal"),
     RecHitSource  = cms.InputTag("HGCalRecHit", "HGCHEBRecHits"))
+
+from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+phase2_hgcalV9.toModify(hgcalRecHitValidationHEB, DetectorName = cms.string("HGCalHEScintillatorSensitive"));
+


### PR DESCRIPTION
This PR introduces a full workflow for the new HGCal geometry. There are corresponding new Eras, `Phase2C4` and `Phase2C4_timing`.

Numerous fixes in simulation, digitization, reconstruction, and validation were needed to make the workflow run to completion. In particular, the digi collection for HEB changes its type. The changes in DetId and geometry access had to be propagated to reconstruction in a number of places.

A few things that will need to be fixed later:
* L1T for HGCal is disabled. @jbsauvan you should revert 1efeb680e43e8cb6b9ddf6af9567cc9f92577285 once there is a trigger mapping for V9.
* @rovere I'm not 100% sure the layer z position is done correctly for the new geometry in the egamma algorithms (ebd8f4066dab207397afb80b31916163e33689f4).
* The layer offset for HEB (now that it is no longer HCAL but part of HGCal) needs to be handled in validation sequences. Right now, a simple hack is used to avoid out-of-range exceptions (e5bb5f9b177f232f66579109c4a5f294c7f8bbd5). I hope @bsunanda can figure out the right way to incorporate this.

I tested locally with 100 events in WF 24034.0, and it ran to completion without crashing or emitting unexpected warnings. A more thorough validation campaign will begin once this is approved (or even before).

This PR includes #23503.