### PR TITLE
Changed set to vector in PFDisplacedVertexSeed

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexSeed.h
+++ b/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexSeed.h
@@ -4,7 +4,7 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-#include <set>
+#include <vector>
 #include <iostream>
 
 
@@ -29,25 +29,15 @@ namespace reco {
 
   public:
 
-    /// -------- Useful Types -------- ///
-
-    typedef std::set< reco::TrackBaseRef >::iterator IEset;
-
-    /// A function necessary to use a set format to store the tracks Refs.
-    /// The set is the most appropriate in that case to avoid the double counting 
-    /// of the tracks durring the build up procedure.
-    /// The position of the tracks in the Collection
-    /// is used as a classification parameter.
-    struct Compare{
-      bool operator()(const TrackBaseRef& s1, const TrackBaseRef& s2) const
-      {return s1.key() < s2.key();}
-    };
-
     /// Default constructor
     PFDisplacedVertexSeed();
 
     /// Add a track Reference to the current Seed
+    /// If the track reference is already in the collection, it is ignored
     void addElement(TrackBaseRef);
+
+    /// Reserve space for elements
+    void reserveElements(size_t);
 
     /// Add a track Ref to the Seed and recalculate the seedPoint with a new dcaPoint
     /// A weight different from 1 may be assign to the new DCA point 
@@ -60,8 +50,8 @@ namespace reco {
     /// Check if it is a new Seed
     bool isEmpty() const {return (elements_.empty());}
 
-    /// \return set of references to tracks 
-    const std::set < TrackBaseRef, Compare >& elements() const 
+    /// \return vector of unique references to tracks 
+    const std::vector <TrackBaseRef>& elements() const 
       {return elements_;}
 
     const double nTracks() const {return elements_.size();}
@@ -84,7 +74,7 @@ namespace reco {
     /// --------- MEMBERS ---------- ///
 
     /// Set of tracks refs associated to the seed
-    std::set < TrackBaseRef , Compare >     elements_;
+    std::vector< TrackBaseRef>     elements_;
     /// Seed point which indicated the approximative position of the vertex.
     GlobalPoint                   seedPoint_;
     /// Total weight of the points used to calculate the seed point. 

--- a/DataFormats/ParticleFlowReco/test/BuildFile.xml
+++ b/DataFormats/ParticleFlowReco/test/BuildFile.xml
@@ -1,0 +1,6 @@
+<environment>
+  <bin file="test_catch2_*.cc" name="TestDataFormatsParticleFlowRecoCatch">
+    <use name="DataFormats/ParticleFlowReco"/>
+    <use name="catch2"/>
+  </bin>
+</environment>

--- a/DataFormats/ParticleFlowReco/test/test_catch2_PFDisplacedVertexSeed.cc
+++ b/DataFormats/ParticleFlowReco/test/test_catch2_PFDisplacedVertexSeed.cc
@@ -1,0 +1,104 @@
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexSeed.h"
+
+#include "catch.hpp"
+
+static constexpr auto s_tag = "[PFDisplacedVertexSeed]";
+TEST_CASE("Check adding elements", s_tag) {
+  reco::PFDisplacedVertexSeed seed;
+
+  REQUIRE(seed.elements().empty());
+
+  SECTION("updateSeedPoint") {
+
+    //empty tracks are fine
+    std::vector<reco::Track> tracks(5);
+    
+    seed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks,1)) );
+    REQUIRE(seed.elements().size() == 2);
+    REQUIRE(seed.nTracks() == 2);
+
+    seed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks,1)) );
+    REQUIRE(seed.elements().size() == 2);
+    REQUIRE(seed.nTracks() == 2);
+
+    seed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks,2)) );
+    REQUIRE(seed.elements().size() == 3);
+    REQUIRE(seed.nTracks() == 3);
+
+    seed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks,3)),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks,4)) );
+    REQUIRE(seed.elements().size() == 5);
+    REQUIRE(seed.nTracks() == 5);
+
+  }
+  
+  SECTION("addElement") {
+    //empty tracks are fine
+    std::vector<reco::Track> tracks(3);
+    
+    seed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks,1)) );
+    REQUIRE(seed.elements().size() == 2);
+    REQUIRE(seed.nTracks() == 2);
+
+    seed.addElement(reco::TrackBaseRef(reco::TrackRef(&tracks,0)));
+    REQUIRE(seed.elements().size() == 2);
+    REQUIRE(seed.nTracks() == 2);
+
+    seed.addElement(reco::TrackBaseRef(reco::TrackRef(&tracks,2)));
+    REQUIRE(seed.elements().size() == 3);
+    REQUIRE(seed.nTracks() == 3);
+
+  }
+  SECTION("mergeWith") {
+    std::vector<reco::Track> tracks(5);
+    
+    seed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks,1)) );
+
+
+    SECTION("completely overlapping seeds") {
+      reco::PFDisplacedVertexSeed otherSeed;
+      otherSeed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
+                                       reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
+                                       reco::TrackBaseRef(reco::TrackRef(&tracks,1)) );
+
+      seed.mergeWith(otherSeed);
+      REQUIRE(seed.elements().size() == 2);
+    }
+
+    SECTION("partially overlapping seeds") {
+      reco::PFDisplacedVertexSeed otherSeed;
+      otherSeed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
+                                       reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
+                                       reco::TrackBaseRef(reco::TrackRef(&tracks,2)) );
+
+      seed.mergeWith(otherSeed);
+      REQUIRE(seed.elements().size() == 3);
+    }
+
+    SECTION("non overlapping seeds") {
+      REQUIRE(seed.elements().size()==2);
+      reco::PFDisplacedVertexSeed otherSeed;
+      otherSeed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
+                                       reco::TrackBaseRef(reco::TrackRef(&tracks,3)),
+                                       reco::TrackBaseRef(reco::TrackRef(&tracks,2)) );
+      REQUIRE(otherSeed.elements().size() == 2);
+
+      seed.mergeWith(otherSeed);
+      REQUIRE(seed.elements().size() == 4);
+    }
+
+  }
+}
+

--- a/DataFormats/ParticleFlowReco/test/test_catch2_main.cc
+++ b/DataFormats/ParticleFlowReco/test/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -234,18 +234,16 @@ PFDisplacedVertexFinder::fitVertexFromSeed(const PFDisplacedVertexSeed& displace
 
   // ---- Prepare transient track list ----
 
-  set < TrackBaseRef, PFDisplacedVertexSeed::Compare > const& tracksToFit = displacedVertexSeed.elements();
+  auto const& tracksToFit = displacedVertexSeed.elements();
   const GlobalPoint& seedPoint = displacedVertexSeed.seedPoint();
 
   vector<TransientTrack> transTracks;
   vector<TransientTrack> transTracksRaw;
   vector<TrackBaseRef> transTracksRef;
-  vector<TrackBaseRef> transTracksRefRaw;
 
   transTracks.reserve(tracksToFit.size());
   transTracksRaw.reserve(tracksToFit.size());
   transTracksRef.reserve(tracksToFit.size());
-  transTracksRefRaw.reserve(tracksToFit.size());
 
 
 
@@ -278,7 +276,6 @@ PFDisplacedVertexFinder::fitVertexFromSeed(const PFDisplacedVertexSeed& displace
   for(auto const& ie : tracksToFit){
     TransientTrack tmpTk( *(ie.get()), magField_, globTkGeomHandle_);
     transTracksRaw.emplace_back( tmpTk );
-    transTracksRefRaw.push_back( ie );
     bool nonIt = PFTrackAlgoTools::nonIterative((ie)->algo());
     bool step45 = PFTrackAlgoTools::step45((ie)->algo());
     bool highQ = PFTrackAlgoTools::highQuality((ie)->algo());   
@@ -416,7 +413,7 @@ PFDisplacedVertexFinder::fitVertexFromSeed(const PFDisplacedVertexSeed& displace
 
     if (theVertexAdaptiveRaw.trackWeight(transTracksRaw[i]) > minAdaptWeight_){
 
-      PFTrackHitFullInfo pattern = hitPattern_.analyze(tkerTopo_, tkerGeom_, transTracksRefRaw[i], theVertexAdaptiveRaw);
+      PFTrackHitFullInfo pattern = hitPattern_.analyze(tkerTopo_, tkerGeom_, tracksToFit[i], theVertexAdaptiveRaw);
 
       PFDisplacedVertex::VertexTrackType vertexTrackType = getVertexTrackType(pattern);
 
@@ -426,7 +423,7 @@ PFDisplacedVertexFinder::fitVertexFromSeed(const PFDisplacedVertexSeed& displace
 
 	if (bGoodTrack){
 	  transTracks.push_back(transTracksRaw[i]);
-	  transTracksRef.push_back(transTracksRefRaw[i]);
+	  transTracksRef.push_back(tracksToFit[i]);
 	} else {
 	  if (debug_)
 	    cout << "Track rejected nChi2 = " << transTracksRaw[i].track().normalizedChi2()
@@ -528,7 +525,7 @@ PFDisplacedVertexFinder::fitVertexFromSeed(const PFDisplacedVertexSeed& displace
   // -----------------------------------------------//
   
 
-  displacedVertex = (PFDisplacedVertex) theRecoVtx;
+  displacedVertex = theRecoVtx;
   displacedVertex.removeTracks();
   
   for(unsigned i = 0; i < transTracks.size();i++) {

--- a/RecoParticleFlow/PFTracking/test/BuildFile.xml
+++ b/RecoParticleFlow/PFTracking/test/BuildFile.xml
@@ -7,3 +7,7 @@
 <library   file="PreIdAnalyzer.cc" name="PreIdAnalyzer">
   <flags   EDM_PLUGIN="1"/>
 </library>
+  <bin file="test_catch2_*.cc" name="TestRecoParticleFlowPFTrackingTP">
+    <use name="FWCore/TestProcessor"/>
+    <use name="catch2"/>
+  </bin>

--- a/RecoParticleFlow/PFTracking/test/test_catch2_PFDisplacedVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/test/test_catch2_PFDisplacedVertexProducer.cc
@@ -1,0 +1,67 @@
+#include "catch.hpp"
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h"
+
+
+static constexpr auto s_tag = "[PFDisplacedVertexProducer]";
+
+TEST_CASE("Standard checks of PFDisplacedVertexProducer", s_tag) {
+  const std::string baseConfig{
+R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+from RecoParticleFlow.PFTracking.particleFlowDisplacedVertex_cfi import particleFlowDisplacedVertex
+process.toTest = particleFlowDisplacedVertex
+process.moduleToTest(process.toTest)
+)_"
+  };
+
+  const std::string fullConfig{
+R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+process.load("MagneticField.Engine.uniformMagneticField_cfi")
+process.load("Configuration.Geometry.GeometryExtended2018Reco_cff")
+process.add_(cms.ESProducer("TrackerParametersESModule"))
+process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
+
+
+from RecoParticleFlow.PFTracking.particleFlowDisplacedVertex_cfi import particleFlowDisplacedVertex
+process.toTest = particleFlowDisplacedVertex
+process.moduleToTest(process.toTest)
+)_"
+  };
+  
+  edm::test::TestProcessor::Config config{ baseConfig };  
+  SECTION("base configuration is OK") {
+    REQUIRE_NOTHROW(edm::test::TestProcessor(config));
+  }
+  
+  SECTION("No event data") {
+    edm::test::TestProcessor::Config config{ fullConfig };  
+    edm::test::TestProcessor tester(config);
+    
+    //The module ignores missing data products
+    REQUIRE(tester.test().get<reco::PFDisplacedVertexCollection>()->empty());
+  }
+  
+  SECTION("beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+    
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+    
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+
+  SECTION("LuminosityBlock with no Events") {
+    edm::test::TestProcessor tester(config);
+    
+    REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  }
+
+}
+
+//Add additional TEST_CASEs to exercise the modules capabilities

--- a/RecoParticleFlow/PFTracking/test/test_catch2_main.cc
+++ b/RecoParticleFlow/PFTracking/test/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"


### PR DESCRIPTION
A vector should reduce memory and most likely speed up the use of PFDisplacedVertexSeed.

Added unit tests for the code I touched.