### PR TITLE
Disable [[cms::...]] attributes while building with nvcc

### DIFF
--- a/FWCore/Utilities/interface/thread_safety_macros.h
+++ b/FWCore/Utilities/interface/thread_safety_macros.h
@@ -1,6 +1,6 @@
 #ifndef FWCore_Utilites_thread_safe_macros_h 
 #define FWCore_Utilites_thread_safe_macros_h 
-#if ! defined __ROOTCLING__ && ! defined __INTEL_COMPILER
+#if ! defined __ROOTCLING__ && ! defined __INTEL_COMPILER && ! defined __NVCC__
 #define CMS_THREAD_SAFE [[cms::thread_safe]]
 #define CMS_THREAD_GUARD(_var_) [[cms::thread_guard(#_var_)]]
 #else 


### PR DESCRIPTION
Compiling with nvcc/cicc prints multiple messages like

> warning: attribute namespace "cms" is unrecognized

As those attributes are only used by the clang static checker, we can safely disable them when compiling with nvcc/cicc.