### PR TITLE
Add 9_4_9_cand1 content on top of 9_4_X as a patch

### DIFF
--- a/CommonTools/ParticleFlow/plugins/BuildFile.xml
+++ b/CommonTools/ParticleFlow/plugins/BuildFile.xml
@@ -14,4 +14,6 @@
   <use   name="JetMETCorrections/Objects"/>
   <use   name="CommonTools/Utils"/>
   <use   name="CommonTools/ParticleFlow"/>
+  <use   name="CalibFormats/HcalObjects"/>
+  <use   name="Geometry/HcalTowerAlgo"/>
 </library>

--- a/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
+++ b/CommonTools/ParticleFlow/plugins/PFCandidateRecalibrator.cc
@@ -1,0 +1,354 @@
+/// Take:
+//    - a PF candidate collection (which uses bugged HCAL respcorrs)
+//    - respCorrs values from fixed GT and bugged GT
+//  Produce:
+//    - a new PFCandidate collection containing the recalibrated PFCandidates in HF and where the neutral had pointing to problematic cells are removed
+//    - a second PFCandidate collection with just those discarded hadrons
+//    - a ValueMap<reco::PFCandidateRef> that maps the old to the new, and vice-versa
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/Framework/interface/Event.h"
+
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Common/interface/Association.h"
+#include <iostream>
+
+
+struct HEChannel { 
+  float eta; float phi; float ratio;
+  HEChannel(float eta, float phi, float ratio): 
+    eta(eta),
+    phi(phi),
+    ratio(ratio)
+  {}
+};
+struct HFChannel { 
+  int ieta; int iphi; int depth; float ratio;
+  HFChannel(int ieta, int iphi, int depth, float ratio): 
+    ieta(ieta),
+    iphi(iphi),
+    depth(depth),
+    ratio(ratio)
+  {}  
+};
+
+
+class PFCandidateRecalibrator : public edm::stream::EDProducer<> {
+    public:
+        PFCandidateRecalibrator(const edm::ParameterSet&);
+        ~PFCandidateRecalibrator() override {};
+
+        static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    private:
+        void beginRun(const edm::Run& iRun, edm::EventSetup const& iSetup) override;
+        void endRun(const edm::Run& iRun, edm::EventSetup const& iSetup) override;
+        void produce(edm::Event&, const edm::EventSetup&) override;
+
+        edm::ESWatcher<HcalRecNumberingRecord> hcalDbWatcher_;
+        edm::ESWatcher<HcalRespCorrsRcd> hcalRCWatcher_;
+  
+        edm::EDGetTokenT<reco::PFCandidateCollection> pfcandidates_;
+
+        std::vector<HEChannel> badChHE_;
+        std::vector<HFChannel> badChHF_;
+
+        float shortFibreThr_;
+        float longFibreThr_;
+};
+
+PFCandidateRecalibrator::PFCandidateRecalibrator(const edm::ParameterSet &iConfig) :
+  pfcandidates_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfcandidates"))),
+  shortFibreThr_(iConfig.getParameter<double>("shortFibreThr")),
+  longFibreThr_(iConfig.getParameter<double>("longFibreThr"))
+{
+    produces<reco::PFCandidateCollection>();
+    produces<reco::PFCandidateCollection>("discarded");
+    produces<edm::ValueMap<reco::PFCandidateRef>>();
+}
+
+void PFCandidateRecalibrator::beginRun(const edm::Run &iRun, const edm::EventSetup &iSetup)
+{
+    if (hcalDbWatcher_.check(iSetup) || hcalRCWatcher_.check(iSetup))
+      {
+	//Get Calib Constants from current GT
+	edm::ESHandle<HcalDbService> gtCond;
+	iSetup.get<HcalDbRecord>().get(gtCond);
+	
+	//Get Calib Constants from bugged tag
+	edm::ESHandle<HcalTopology> htopo;
+	iSetup.get<HcalRecNumberingRecord>().get(htopo);
+	const HcalTopology* theHBHETopology = htopo.product();
+	
+	edm::ESHandle<HcalRespCorrs> buggedCond;
+	iSetup.get<HcalRespCorrsRcd>().get("bugged", buggedCond);
+	HcalRespCorrs buggedRespCorrs(*buggedCond.product());
+	buggedRespCorrs.setTopo(theHBHETopology);
+	
+	//access calogeometry
+	edm::ESHandle<CaloGeometry> calogeom;
+	iSetup.get<CaloGeometryRecord>().get(calogeom);
+	const CaloGeometry* cgeo = calogeom.product();
+	const HcalGeometry* hgeom = static_cast<const HcalGeometry*>(cgeo->getSubdetectorGeometry(DetId::Hcal,HcalForward));
+
+	//reset the bad channel containers
+	badChHE_.clear();
+	badChHF_.clear();
+	
+	//fill bad cells HE (use eta, phi)
+	const std::vector<DetId>& cellsHE = hgeom->getValidDetIds(DetId::Detector::Hcal, HcalEndcap);
+	for( auto id : cellsHE)
+	  {
+	    float currentRespCorr = gtCond->getHcalRespCorr(id)->getValue();
+	    float buggedRespCorr = buggedRespCorrs.getValues(id)->getValue();
+	    if (buggedRespCorr == 0.)
+	      continue;
+
+	    float ratio = currentRespCorr/buggedRespCorr;
+	    if( std::abs(ratio - 1.f) > 0.001 )
+	      {
+		GlobalPoint pos = hgeom->getPosition(id);
+		badChHE_.push_back(HEChannel(pos.eta(),pos.phi(),ratio));
+	      }
+	  }
+	
+	//fill bad cells HF (use ieta, iphi)
+	auto const& cellsHF = hgeom->getValidDetIds(DetId::Detector::Hcal, HcalForward);
+	for( auto id : cellsHF)
+	  {
+	    float currentRespCorr = gtCond->getHcalRespCorr(id)->getValue();
+	    float buggedRespCorr = buggedRespCorrs.getValues(id)->getValue();
+	    if (buggedRespCorr == 0.)
+	      continue;
+
+	    float ratio = currentRespCorr/buggedRespCorr;
+	    if( std::abs(ratio - 1.f) > 0.001 )
+	      {
+		HcalDetId dummyId(id);
+		badChHF_.push_back(HFChannel(dummyId.ieta(), dummyId.iphi(), dummyId.depth(), ratio));
+	      }
+	  }
+      }
+}
+
+void PFCandidateRecalibrator::endRun(const edm::Run &iRun, const edm::EventSetup &iSetup)
+{
+}
+
+void PFCandidateRecalibrator::produce(edm::Event &iEvent, const edm::EventSetup &iSetup)
+{
+    //access calogeometry
+    edm::ESHandle<CaloGeometry> calogeom;
+    iSetup.get<CaloGeometryRecord>().get(calogeom);
+    const CaloGeometry* cgeo = calogeom.product();
+    const HcalGeometry* hgeom = static_cast<const HcalGeometry*>(cgeo->getSubdetectorGeometry(DetId::Hcal,HcalForward));
+ 
+    //access PFCandidates
+    edm::Handle<reco::PFCandidateCollection> pfcandidates;
+    iEvent.getByToken(pfcandidates_, pfcandidates);
+
+    int nPfCand = pfcandidates->size();
+    std::unique_ptr<reco::PFCandidateCollection> copy(new reco::PFCandidateCollection());
+    std::unique_ptr<reco::PFCandidateCollection> discarded(new reco::PFCandidateCollection());
+    copy->reserve(nPfCand);
+    std::vector<int> oldToNew(nPfCand), newToOld, badToOld; 
+    newToOld.reserve(nPfCand);
+
+    LogDebug("PFCandidateRecalibrator") << "NEW EV:";
+
+    //loop over PFCandidates
+    int i = -1;
+    for (const reco::PFCandidate &pf : *pfcandidates) 
+      {
+	++i;
+	float absEta = std::abs(pf.eta());
+
+	//deal with HE
+	if( pf.particleId() == reco::PFCandidate::ParticleType::h0 && 
+	    !badChHE_.empty() &&  //don't touch if no miscalibration is found
+	    absEta > 1.4  && absEta < 3.)
+	  {
+	    bool toKill = false;
+	    for(auto const& badIt: badChHE_)
+	      if( reco::deltaR2(pf.eta(), pf.phi(), badIt.eta, badIt.phi) < 0.07 )
+		toKill = true;
+	    
+	    
+	    if(toKill)
+	      {
+		discarded->push_back(pf);
+		oldToNew[i] = (-discarded->size());
+		badToOld.push_back(i);
+		continue;
+	      }
+	    else
+	      {
+		copy->push_back(pf);
+		oldToNew[i] = (copy->size());
+		newToOld.push_back(i);
+	      }
+	  }
+	//deal with HF
+	else if( (pf.particleId() == reco::PFCandidate::ParticleType::h_HF || pf.particleId() == reco::PFCandidate::ParticleType::egamma_HF) &&
+		 !badChHF_.empty() &&  //don't touch if no miscalibration is found
+		 absEta >= 3.)
+	  {
+	    const math::XYZPointF& ecalPoint = pf.positionAtECALEntrance();
+	    GlobalPoint ecalGPoint(ecalPoint.X(),ecalPoint.Y(),ecalPoint.Z());
+	    HcalDetId closestDetId(hgeom->getClosestCell(ecalGPoint));
+	    
+	    if(closestDetId.subdet() == HcalForward)
+	      {
+		HcalDetId hDetId(closestDetId.subdet(),closestDetId.ieta(),closestDetId.iphi(),1); //depth1
+		
+		//raw*calEnergy() is the same as *calEnergy() - no corrections are done for HF
+		float longE  = pf.rawEcalEnergy() + pf.rawHcalEnergy()/2.;  //depth1
+		float shortE = pf.rawHcalEnergy()/2.;                       //depth2
+		
+		float ecalEnergy = pf.rawEcalEnergy();
+		float hcalEnergy = pf.rawHcalEnergy();
+		float totEnergy = ecalEnergy + hcalEnergy;
+		float totEnergyOrig = totEnergy;
+		
+		bool toKill = false;
+			
+		for(auto const& badIt: badChHF_)
+		  {
+		    if ( hDetId.ieta() == badIt.ieta &&
+			 hDetId.iphi() == badIt.iphi )
+		      {
+			LogDebug("PFCandidateRecalibrator") << "==> orig en (tot,H,E): " 
+							    << pf.energy() << " " << pf.rawHcalEnergy() << " " << pf.rawEcalEnergy();
+			if(badIt.depth == 1) //depth1
+			  {
+			    longE *= badIt.ratio;
+			    ecalEnergy = ((longE - shortE) > 0.) ? (longE - shortE) : 0.;
+			    totEnergy = ecalEnergy + hcalEnergy;
+			  }
+			else //depth2
+			  {
+			    shortE *= badIt.ratio;
+			    hcalEnergy = 2*shortE;
+			    ecalEnergy = ((longE - shortE) > 0.) ? (longE - shortE) : 0.;
+			    totEnergy = ecalEnergy + hcalEnergy;
+			  }
+			//kill candidate if goes below thr
+			if((pf.particleId() == reco::PFCandidate::ParticleType::h_HF && shortE < shortFibreThr_) ||
+			   (pf.particleId() == reco::PFCandidate::ParticleType::egamma_HF && longE < longFibreThr_))
+			  toKill = true;
+
+			LogDebug("PFCandidateRecalibrator") << "====> ieta,iphi,depth: " 
+							    << badIt.ieta << " " << badIt.iphi << " " << badIt.depth << " corr: " << badIt.ratio;
+			LogDebug("PFCandidateRecalibrator") << "====> recal en (tot,H,E): " 
+							    << totEnergy << " " << hcalEnergy << " " << ecalEnergy;
+
+		      }
+		  }
+		
+		if(toKill)
+		  {
+		    discarded->push_back(pf);
+		    oldToNew[i] = (-discarded->size());
+		    badToOld.push_back(i);
+
+		    LogDebug("PFCandidateRecalibrator") << "==> KILLED ";
+		  }
+		else
+		  {
+		    copy->push_back(pf);
+		    oldToNew[i] = (copy->size());
+		    newToOld.push_back(i);
+		    
+		    copy->back().setHcalEnergy(hcalEnergy, hcalEnergy);
+		    copy->back().setEcalEnergy(ecalEnergy, ecalEnergy);
+
+		    float scalingFactor = totEnergy/totEnergyOrig;
+		    math::XYZTLorentzVector recalibP4 = pf.p4() * scalingFactor;
+		    copy->back().setP4( recalibP4 );
+
+		    LogDebug("PFCandidateRecalibrator") << "====> stored en (tot,H,E): " 
+							<< copy->back().energy() << " " << copy->back().hcalEnergy() << " " << copy->back().ecalEnergy();
+		  }
+	      }
+	    else
+	      {
+		copy->push_back(pf);
+		oldToNew[i] = (copy->size());
+		newToOld.push_back(i);
+	      }
+	  }
+	else
+	  {
+	    copy->push_back(pf);
+	    oldToNew[i] = (copy->size());
+	    newToOld.push_back(i);
+	  }
+      }
+
+    // Now we put things in the event
+    edm::OrphanHandle<reco::PFCandidateCollection> newpf = iEvent.put(std::move(copy));
+    edm::OrphanHandle<reco::PFCandidateCollection> badpf = iEvent.put(std::move(discarded), "discarded");
+
+    std::unique_ptr<edm::ValueMap<reco::PFCandidateRef>> pf2pf(new edm::ValueMap<reco::PFCandidateRef>());
+    edm::ValueMap<reco::PFCandidateRef>::Filler filler(*pf2pf);
+    std::vector<reco::PFCandidateRef> refs; refs.reserve(nPfCand);
+
+    // old to new
+    for (auto iOldToNew : oldToNew){
+      if (iOldToNew > 0) {
+	refs.push_back(reco::PFCandidateRef(newpf, iOldToNew-1));
+      } else {
+	refs.push_back(reco::PFCandidateRef(badpf,-iOldToNew-1));
+      }
+    }
+    filler.insert(pfcandidates, refs.begin(), refs.end());
+    // new good to old
+    refs.clear();
+    for (int i : newToOld) {
+      refs.push_back(reco::PFCandidateRef(pfcandidates,i));
+    }
+    filler.insert(newpf, refs.begin(), refs.end());
+    // new bad to old
+    refs.clear();
+    for (int i : badToOld) {
+      refs.push_back(reco::PFCandidateRef(pfcandidates,i));
+    }
+    filler.insert(badpf, refs.begin(), refs.end());
+    // done
+    filler.fill();
+    iEvent.put(std::move(pf2pf));
+}
+
+void
+PFCandidateRecalibrator::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("pfcandidates", edm::InputTag("particleFlow"));
+  desc.add<double>("shortFibreThr", 1.4);
+  desc.add<double>("longFibreThr", 1.4);
+
+  descriptions.add("pfCandidateRecalibrator", desc);
+
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PFCandidateRecalibrator);

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,25 +10,25 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '94X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '94X_mcRun2_design_v2',
+    'run2_design'       :   '94X_mcRun2_design_v4',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '94X_mcRun2_startup_v2',
+    'run2_mc_50ns'      :   '94X_mcRun2_startup_v3',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '94X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '94X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '94X_mcRun2cosmics_startup_deco_v2',
+    'run2_mc_cosmics'   :   '94X_mcRun2cosmics_startup_deco_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '93X_mcRun2_HeavyIon_v0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '94X_mcRun2_pA_v2',
+    'run2_mc_pa'        :   '94X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '94X_dataRun2_v6',
+    'run1_data'         :   '94X_dataRun2_v10',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '94X_dataRun2_v6',
+    'run2_data'         :   '94X_dataRun2_v10',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '94X_dataRun2_relval_v11',
+    'run2_data_relval'  :   '94X_dataRun2_relval_v14',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '94X_dataRun2_PromptLike_v9',
     # GlobalTag for Run1 HLT: it points to the online GT
@@ -40,13 +40,13 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v10',
+    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '94X_mc2017_realistic_v14',
+    'phase1_2017_realistic'    : '94X_mc2017_realistic_v15',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v10',
+    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v11',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v10',
+    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v11',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '94X_upgrade2018_design_IdealBS_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1960,12 +1960,15 @@ steps['REMINIAOD_data2016'] = merge([{'-s' : 'PAT,DQM:@miniAODDQM',
                                       '--data' : '',
                                       '--scenario' : 'pp',
                                       '--eventcontent' : 'MINIAOD,DQM',
-                                      '--datatier' : 'MINIAOD,DQMIO'
+                                      '--datatier' : 'MINIAOD,DQMIO',
+                                      '--customise_unsch' : 'PhysicsTools/PatAlgos/slimming/customizeMiniAOD_HcalFixLegacy2016.customizeAll'
                                       },stepMiniAODDefaults])
 
 steps['REMINIAOD_data2016_HIPM'] = merge([{'--era' : 'Run2_2016_HIPM,run2_miniAOD_80XLegacy'},steps['REMINIAOD_data2016']])
 
-steps['REMINIAOD_data2017'] = merge([{'--era' : 'Run2_2017,run2_miniAOD_94XFall17'},steps['REMINIAOD_data2016']])
+stepReMiniAODData17 = merge([{'--era' : 'Run2_2017,run2_miniAOD_94XFall17'},steps['REMINIAOD_data2016']])
+stepReMiniAODData17 = remove(stepReMiniAODData17,'--customise_unsch')
+steps['REMINIAOD_data2017'] = stepReMiniAODData17
 
 # Not sure whether the customisations are in the dict as "--customise" or "--era" so try to
 # remove both. Currently premixing uses "--customise" and everything else uses "--era".

--- a/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
+++ b/PhysicsTools/PatAlgos/python/slimming/customizeMiniAOD_HcalFixLegacy2016.py
@@ -1,0 +1,105 @@
+import FWCore.ParameterSet.Config as cms
+
+from PhysicsTools.PatAlgos.tools.helpers import MassSearchReplaceAnyInputTagVisitor, addKeepStatement
+from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask
+
+def loadJetMETBTag(process):
+
+    task = getPatAlgosToolsTask(process)
+
+    import RecoParticleFlow.PFProducer.pfLinker_cff
+    process.particleFlowPtrs = RecoParticleFlow.PFProducer.pfLinker_cff.particleFlowPtrs.clone()
+    task.add(process.particleFlowPtrs)
+
+    process.load("CommonTools.ParticleFlow.pfNoPileUpIso_cff")
+    task.add(process.pfNoPileUpIsoTask)
+    process.load("CommonTools.ParticleFlow.ParticleSelectors.pfSortByType_cff")
+    task.add(process.pfSortByTypeTask)
+
+    import RecoJets.Configuration.RecoPFJets_cff
+    process.ak4PFJetsCHS = RecoJets.Configuration.RecoPFJets_cff.ak4PFJetsCHS.clone()
+    task.add(process.ak4PFJetsCHS)
+    # need also the non-CHS ones as they are used to seed taus
+    process.ak4PFJets = RecoJets.Configuration.RecoPFJets_cff.ak4PFJets.clone()
+    task.add(process.ak4PFJets)
+    process.ak8PFJetsCHS = RecoJets.Configuration.RecoPFJets_cff.ak8PFJetsCHS.clone()
+    task.add(process.ak8PFJetsCHS)
+
+    process.fixedGridRhoAll = RecoJets.Configuration.RecoPFJets_cff.fixedGridRhoAll.clone()
+    process.fixedGridRhoFastjetAll = RecoJets.Configuration.RecoPFJets_cff.fixedGridRhoFastjetAll.clone()
+    process.fixedGridRhoFastjetCentral = RecoJets.Configuration.RecoPFJets_cff.fixedGridRhoFastjetCentral.clone()
+    process.fixedGridRhoFastjetCentralChargedPileUp = RecoJets.Configuration.RecoPFJets_cff.fixedGridRhoFastjetCentralChargedPileUp.clone()
+    process.fixedGridRhoFastjetCentralNeutral = RecoJets.Configuration.RecoPFJets_cff.fixedGridRhoFastjetCentralNeutral.clone()
+    task.add( process.fixedGridRhoAll,
+              process.fixedGridRhoFastjetAll,
+              process.fixedGridRhoFastjetCentral,
+              process.fixedGridRhoFastjetCentralChargedPileUp,
+              process.fixedGridRhoFastjetCentralNeutral )
+
+    process.load("RecoJets.JetAssociationProducers.ak4JTA_cff")
+    task.add(process.ak4JetTracksAssociatorAtVertexPF)
+
+    process.load('RecoBTag.Configuration.RecoBTag_cff')
+    task.add(process.btaggingTask)
+
+    process.load("RecoMET.METProducers.PFMET_cfi")
+    task.add(process.pfMet)
+
+
+def cleanPfCandidates(process, verbose=False):
+    task = getPatAlgosToolsTask(process)
+
+    #add producer at the beginning of the schedule
+    process.load("CommonTools.ParticleFlow.pfCandidateRecalibrator_cfi")
+    task.add(process.pfCandidateRecalibrator)
+
+    replacePFCandidates = MassSearchReplaceAnyInputTagVisitor("particleFlow", "pfCandidateRecalibrator", verbose=verbose)
+    replacePFTmpPtrs = MassSearchReplaceAnyInputTagVisitor("particleFlowTmpPtrs", "particleFlowPtrs", verbose=verbose)
+    for everywhere in [ process.producers, process.filters, process.analyzers, process.psets, process.vpsets ]:
+        for name,obj in everywhere.iteritems():
+            if obj != process.pfCandidateRecalibrator:
+                replacePFCandidates.doIt(obj, name)
+                replacePFTmpPtrs.doIt(obj, name)
+
+
+    process.load("CommonTools.ParticleFlow.pfEGammaToCandidateRemapper_cfi")
+    task.add(process.pfEGammaToCandidateRemapper)
+    process.pfEGammaToCandidateRemapper.pf2pf = cms.InputTag("pfCandidateRecalibrator")
+    process.reducedEgamma.gsfElectronsPFValMap = cms.InputTag("pfEGammaToCandidateRemapper","electrons")
+    process.reducedEgamma.photonsPFValMap      = cms.InputTag("pfEGammaToCandidateRemapper","photons")
+
+
+def addDiscardedPFCandidates(process, inputCollection, verbose=False):
+
+    task = getPatAlgosToolsTask(process)
+
+    process.primaryVertexAssociationDiscardedCandidates = process.primaryVertexAssociation.clone(
+        particles = inputCollection,
+        )
+    task.add(process.primaryVertexAssociationDiscardedCandidates)
+
+    process.packedPFCandidatesDiscarded = process.packedPFCandidates.clone(
+        inputCollection = inputCollection,
+        PuppiNoLepSrc = cms.InputTag(""),
+        PuppiSrc = cms.InputTag(""),
+        secondaryVerticesForWhiteList = cms.VInputTag(),
+        vertexAssociator = cms.InputTag("primaryVertexAssociationDiscardedCandidates","original")
+        )
+    task.add(process.packedPFCandidatesDiscarded)
+
+    addKeepStatement(process, "keep patPackedCandidates_packedPFCandidates_*_*",
+                             ["keep patPackedCandidates_packedPFCandidatesDiscarded_*_*"],
+                              verbose=verbose)
+
+
+def customizeAll(process, verbose=False):
+
+    if verbose:
+        print "===>>> customizing the process for legacy rereco 2016"
+
+    loadJetMETBTag(process)
+
+    cleanPfCandidates(process, verbose)
+    addDiscardedPFCandidates(process, cms.InputTag("pfCandidateRecalibrator","discarded"), verbose=verbose)
+
+    return process

--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -97,3 +97,6 @@ from RecoEgamma.EgammaPhotonProducers.reducedEgamma_tools import calibrateReduce
 from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
 modifyReducedEGammaRun2MiniAOD9XFall17_ = run2_miniAOD_94XFall17.makeProcessModifier(calibrateReducedEgamma)
 
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+modifyReducedEGammaRun2MiniAOD8XLegacy_ = run2_miniAOD_80XLegacy.makeProcessModifier(calibrateReducedEgamma)
+

--- a/RecoEgamma/EgammaTools/plugins/EG8XObjectUpdateModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EG8XObjectUpdateModifier.cc
@@ -1,0 +1,134 @@
+#include "CommonTools/CandAlgos/interface/ModifyObjectValueBase.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/ESHandle.h" 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "Geometry/CaloTopology/interface/CaloTopology.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
+#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+
+#include <vdt/vdtMath.h>
+
+//this modifier fills variables where not present in CMSSW_8X 
+//use case is when reading older 80X samples in newer releases, aka legacy
+
+class EG8XObjectUpdateModifier : public ModifyObjectValueBase {
+public:
+  EG8XObjectUpdateModifier(const edm::ParameterSet& conf);
+  ~EG8XObjectUpdateModifier() override{}
+  
+  void setEvent(const edm::Event&) final;
+  void setEventContent(const edm::EventSetup&) final;
+  void setConsumes(edm::ConsumesCollector&) final;
+  
+  void modifyObject(reco::GsfElectron& ele) const final;
+  void modifyObject(reco::Photon& pho) const final;
+  
+  void modifyObject(pat::Electron& ele) const final{return modifyObject(static_cast<reco::GsfElectron&>(ele));}
+  void modifyObject(pat::Photon& pho) const final{return modifyObject(static_cast<reco::Photon&>(pho));}
+  
+private:
+  std::pair<int,bool> getSaturationInfo(const reco::SuperCluster& superClus)const;
+  
+  edm::ESHandle<CaloTopology> caloTopoHandle_;
+  edm::Handle<EcalRecHitCollection> ecalRecHitsEBHandle_;
+  edm::Handle<EcalRecHitCollection> ecalRecHitsEEHandle_;
+  edm::EDGetTokenT<EcalRecHitCollection> ecalRecHitsEBToken_;
+  edm::EDGetTokenT<EcalRecHitCollection> ecalRecHitsEEToken_;
+  edm::InputTag ecalRecHitsEBTag_;
+  edm::InputTag ecalRecHitsEETag_;
+  
+};
+
+EG8XObjectUpdateModifier::EG8XObjectUpdateModifier(const edm::ParameterSet& conf):
+  ModifyObjectValueBase(conf),
+  ecalRecHitsEBTag_(conf.getParameter<edm::InputTag>("ecalRecHitsEB")),
+  ecalRecHitsEETag_(conf.getParameter<edm::InputTag>("ecalRecHitsEE"))
+{
+  
+
+}
+
+void EG8XObjectUpdateModifier::setConsumes(edm::ConsumesCollector& cc)
+{
+  ecalRecHitsEBToken_ = cc.consumes<EcalRecHitCollection>(ecalRecHitsEBTag_);
+  ecalRecHitsEEToken_ = cc.consumes<EcalRecHitCollection>(ecalRecHitsEETag_);
+}
+
+void EG8XObjectUpdateModifier::setEvent(const edm::Event& iEvent)
+{
+  iEvent.getByToken(ecalRecHitsEBToken_,ecalRecHitsEBHandle_);
+  iEvent.getByToken(ecalRecHitsEEToken_,ecalRecHitsEEHandle_);
+}
+
+void EG8XObjectUpdateModifier::setEventContent(const edm::EventSetup& iSetup)
+{
+  iSetup.get<CaloTopologyRecord>().get(caloTopoHandle_);
+}
+
+
+void EG8XObjectUpdateModifier::modifyObject(reco::GsfElectron& ele)const
+{
+
+  const reco::CaloCluster& seedClus = *(ele.superCluster()->seed());
+  const EcalRecHitCollection* ecalRecHits = ele.isEB() ? &*ecalRecHitsEBHandle_ : &*ecalRecHitsEEHandle_;
+  const auto* caloTopo = caloTopoHandle_.product();
+
+  auto full5x5ShowerShapes = ele.full5x5_showerShape();  
+  full5x5ShowerShapes.e2x5Left   = noZS::EcalClusterTools::e2x5Left  (seedClus,ecalRecHits,caloTopo);
+  full5x5ShowerShapes.e2x5Right  = noZS::EcalClusterTools::e2x5Right (seedClus,ecalRecHits,caloTopo);
+  full5x5ShowerShapes.e2x5Top    = noZS::EcalClusterTools::e2x5Top   (seedClus,ecalRecHits,caloTopo);
+  full5x5ShowerShapes.e2x5Bottom = noZS::EcalClusterTools::e2x5Bottom(seedClus,ecalRecHits,caloTopo);
+  ele.full5x5_setShowerShape(full5x5ShowerShapes);
+  
+  auto showerShapes = ele.showerShape();  
+  showerShapes.e2x5Left   = EcalClusterTools::e2x5Left  (seedClus,ecalRecHits,caloTopo);
+  showerShapes.e2x5Right  = EcalClusterTools::e2x5Right (seedClus,ecalRecHits,caloTopo);
+  showerShapes.e2x5Top    = EcalClusterTools::e2x5Top   (seedClus,ecalRecHits,caloTopo);
+  showerShapes.e2x5Bottom = EcalClusterTools::e2x5Bottom(seedClus,ecalRecHits,caloTopo);
+  ele.setShowerShape(showerShapes);
+
+  reco::GsfElectron::SaturationInfo eleSatInfo;
+  auto satInfo = getSaturationInfo(*ele.superCluster());
+  eleSatInfo.nSaturatedXtals = satInfo.first;
+  eleSatInfo.isSeedSaturated = satInfo.second;
+  ele.setSaturationInfo(eleSatInfo);
+}
+
+void EG8XObjectUpdateModifier::modifyObject(reco::Photon& pho)const
+{
+  reco::Photon::SaturationInfo phoSatInfo;
+  auto satInfo = getSaturationInfo(*pho.superCluster());
+  phoSatInfo.nSaturatedXtals = satInfo.first;
+  phoSatInfo.isSeedSaturated = satInfo.second;
+  pho.setSaturationInfo(phoSatInfo);
+}
+
+
+std::pair<int,bool> EG8XObjectUpdateModifier::getSaturationInfo(const reco::SuperCluster& superClus)const
+{
+  bool isEB = superClus.seed()->seed().subdetId()==EcalBarrel;
+  const auto& ecalRecHits = isEB ? *ecalRecHitsEBHandle_ : *ecalRecHitsEEHandle_;
+
+  int nrSatCrys = 0;
+  bool seedSaturated = false;
+  const auto& hitsAndFractions = superClus.seed()->hitsAndFractions();
+  for(const auto& hitFractionPair : hitsAndFractions) {    
+    auto ecalRecHitIt = ecalRecHits.find(hitFractionPair.first);
+    if(ecalRecHitIt != ecalRecHits.end() && 
+       ecalRecHitIt->checkFlag(EcalRecHit::Flags::kSaturated)){
+      nrSatCrys++;
+      if(hitFractionPair.first == superClus.seed()->seed()) seedSaturated = true;
+    }
+  }
+  return {nrSatCrys,seedSaturated};
+}
+  
+DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
+		  EG8XObjectUpdateModifier,
+		  "EG8XObjectUpdateModifier");

--- a/RecoEgamma/EgammaTools/plugins/EGEtScaleSysModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGEtScaleSysModifier.cc
@@ -1,0 +1,216 @@
+#include "CommonTools/CandAlgos/interface/ModifyObjectValueBase.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "RecoEgamma/EgammaTools/interface/EpCombinationTool.h"
+#include "RecoEgamma/EgammaTools/interface/EGEnergySysIndex.h"
+
+#include <vdt/vdtMath.h>
+
+//in the legacy re-reco we came across an Et scale issue, specifically an inflection at 45 GeV
+//it is problematic to address in the normal scale and smearing code therefore 
+//this patch modifies the e/gamma object to "patch in" this additional systematic
+//Questions:
+//1 ) Why dont we add this to the overall scale systematic?
+//Well we could but the whole point of this is to get a proper template which can be evolved
+//correctly. The issue is not that the current systematic doesnt cover this systematic on a
+//per bin basis, it does, the problem is the sign flips at 45 GeV so its fine if you use 
+//only eles/phos > 45 or <45 GeV but the template cant simultaneously cover the entire spectrum
+//and you'll get a nasty constrained fit. 
+//And if you care about these sort of things (and you probably should), you shouldnt be using 
+//the overall systematic anyways but its seperate parts
+//
+//2 ) Why dont you do it inside the standard class
+//We could but we're rather hoping to solve this issue more cleanly in the future
+//but we would hold up the reminiAOD too long to do so so this is just to get something
+//which should be fine for 90% of analyses in the miniAOD. So this is a temporary fix 
+//which we hope to rip out soon (if you're reading this in 2024 because we're still doing it 
+//this way, all I can say is sorry, we thought it would go away soon! )
+
+
+class EGEtScaleSysModifier : public ModifyObjectValueBase {
+public:
+  EGEtScaleSysModifier(const edm::ParameterSet& conf);
+  ~EGEtScaleSysModifier() override{}
+  
+  void setEvent(const edm::Event&) final;
+  void setEventContent(const edm::EventSetup&) final;
+  void setConsumes(edm::ConsumesCollector&) final;
+  
+  void modifyObject(pat::Electron& ele) const final;
+  void modifyObject(pat::Photon& pho) const final;
+  
+private:  
+  std::pair<float,float> calCombinedMom(reco::GsfElectron& ele,const float scale,
+					const float smear)const;
+  void setEcalEnergy(reco::GsfElectron& ele,const float scale,const float smear)const;
+
+  class UncertFuncBase {
+  public:
+    UncertFuncBase(){}
+    virtual ~UncertFuncBase(){}
+    virtual float val(const float et)const=0;
+  };
+  
+  //defines two uncertaintes, one Et<X and one Et>Y
+  //for X<Et<Y, it linearly extrapolates betwen the two values
+  class UncertFuncV1 : public UncertFuncBase {
+  public:
+    UncertFuncV1(const edm::ParameterSet& conf):
+      lowEt_(conf.getParameter<double>("lowEt")),highEt_(conf.getParameter<double>("highEt")),
+      lowEtUncert_(conf.getParameter<double>("lowEtUncert")),
+      highEtUncert_(conf.getParameter<double>("highEtUncert")),
+      dEt_(highEt_-lowEt_),
+      dUncert_(highEtUncert_ - lowEtUncert_)
+    {
+      if(highEt_<=lowEt_) throw cms::Exception("ConfigError") <<" highEt "<<highEt_<<" is not higher than lowEt "<<lowEt_;
+    }
+    ~UncertFuncV1() override{}
+   
+    float val(const float et)const override{
+      if(et<=lowEt_) return lowEtUncert_;
+      else if(et>=highEt_) return highEtUncert_;
+      else{
+	return (et-lowEt_)*dUncert_/dEt_+lowEtUncert_;
+      }
+    }
+  private:
+    float lowEt_;
+    float highEt_;
+    float lowEtUncert_;
+    float highEtUncert_;
+    float dEt_;
+    float dUncert_;
+  };
+    
+  EpCombinationTool epCombTool_;
+  std::unique_ptr<UncertFuncBase> uncertFunc_;
+};
+
+EGEtScaleSysModifier::EGEtScaleSysModifier(const edm::ParameterSet& conf):
+  ModifyObjectValueBase(conf),
+  epCombTool_(conf.getParameter<edm::ParameterSet>("epCombConfig"))
+{
+  const edm::ParameterSet funcPSet = conf.getParameter<edm::ParameterSet>("uncertFunc");
+  const std::string& funcName = funcPSet.getParameter<std::string>("name");
+  if(funcName == "UncertFuncV1"){
+    uncertFunc_ = std::make_unique<UncertFuncV1>(funcPSet);
+  }else{
+    throw cms::Exception("ConfigError") <<"Error constructing EGEtScaleSysModifier, function name "<<funcName<<" not valid";
+  } 
+
+}
+
+void EGEtScaleSysModifier::setConsumes(edm::ConsumesCollector& cc)
+{
+
+}
+
+void EGEtScaleSysModifier::setEvent(const edm::Event& iEvent)
+{
+
+}
+
+void EGEtScaleSysModifier::setEventContent(const edm::EventSetup& iSetup)
+{
+  epCombTool_.setEventContent(iSetup);
+}
+
+
+void EGEtScaleSysModifier::modifyObject(pat::Electron& ele)const
+{
+  auto getVal = [](const pat::Electron& ele,EGEnergySysIndex::Index valIndex){
+    return ele.userFloat(EGEnergySysIndex::name(valIndex));
+  };
+  //so ele.energy() may be either pre or post corrections, we have no idea
+  //so we explicity access the pre and post correction ecal energies
+  //we need the pre corrected to properly do the e/p combination
+  //we need the post corrected to get et uncertainty
+  const float ecalEnergyPostCorr = getVal(ele,EGEnergySysIndex::kEcalPostCorr); 
+  const float ecalEnergyPreCorr = getVal(ele,EGEnergySysIndex::kEcalPreCorr);
+  const float ecalEnergyErrPreCorr = getVal(ele,EGEnergySysIndex::kEcalErrPreCorr);
+
+  //the et cut is in terms of ecal et using the track angle and post corr ecal energy
+  const float etUncert = uncertFunc_->val(ele.et()/ele.energy()*ecalEnergyPostCorr); 
+  const float smear = getVal(ele,EGEnergySysIndex::kSmearValue);
+  const float corr = getVal(ele,EGEnergySysIndex::kScaleValue);
+
+  //get the values we have to reset back to
+  const float oldEcalEnergy = ele.ecalEnergy();
+  const float oldEcalEnergyErr = ele.ecalEnergyError();
+  const auto oldP4 = ele.p4();
+  const float oldP4Err = ele.p4Error(reco::GsfElectron::P4_COMBINATION);
+  const float oldTrkMomErr = ele.trackMomentumError();
+  
+  ele.setCorrectedEcalEnergy(ecalEnergyPreCorr);
+  ele.setCorrectedEcalEnergyError(ecalEnergyErrPreCorr);
+  
+  const float energyEtUncertUp = calCombinedMom(ele,corr+etUncert,smear).first;
+  const float energyEtUncertDn = calCombinedMom(ele,corr-etUncert,smear).first;
+
+  //reset it back to how it was
+  ele.setCorrectedEcalEnergy(oldEcalEnergy);
+  ele.setCorrectedEcalEnergyError(oldEcalEnergyErr);
+  ele.correctMomentum(oldP4,oldTrkMomErr,oldP4Err);
+  
+  ele.addUserFloat("energyScaleEtUp",energyEtUncertUp);
+  ele.addUserFloat("energyScaleEtDown",energyEtUncertDn);
+						
+}
+
+void EGEtScaleSysModifier::modifyObject(pat::Photon& pho)const
+{
+  auto getVal = [](const pat::Photon& pho,EGEnergySysIndex::Index valIndex){
+    return pho.userFloat(EGEnergySysIndex::name(valIndex));
+  };
+  //so pho.energy() may be either pre or post corrections, we have no idea
+  //so we explicity access the pre and post correction ecal energies
+  //post corr for the et value for the systematic, pre corr to apply them
+  const float ecalEnergyPostCorr = getVal(pho,EGEnergySysIndex::kEcalPostCorr); 
+  const float ecalEnergyPreCorr = getVal(pho,EGEnergySysIndex::kEcalPreCorr);
+
+  //the et cut is in terms of post corr ecal energy
+  const float etUncert = uncertFunc_->val(pho.et()/pho.energy()*ecalEnergyPostCorr);
+  const float corr = getVal(pho,EGEnergySysIndex::kScaleValue);
+
+  const float energyEtUncertUp = ecalEnergyPreCorr*(corr+etUncert);
+  const float energyEtUncertDn = ecalEnergyPreCorr*(corr-etUncert);
+
+  pho.addUserFloat("energyScaleEtUp",energyEtUncertUp);
+  pho.addUserFloat("energyScaleEtDown",energyEtUncertDn);
+ 
+}
+
+std::pair<float,float> EGEtScaleSysModifier::calCombinedMom(reco::GsfElectron& ele,
+							    const float scale,
+							    const float smear)const
+{ 
+  const float oldEcalEnergy = ele.ecalEnergy();
+  const float oldEcalEnergyErr = ele.ecalEnergyError();
+  const auto oldP4 = ele.p4();
+  const float oldP4Err = ele.p4Error(reco::GsfElectron::P4_COMBINATION);
+  const float oldTrkMomErr = ele.trackMomentumError();
+  
+  setEcalEnergy(ele,scale,smear);
+  const auto& combinedMomentum = epCombTool_.combine(ele);
+  ele.setCorrectedEcalEnergy(oldEcalEnergy);
+  ele.setCorrectedEcalEnergyError(oldEcalEnergyErr);
+  ele.correctMomentum(oldP4,oldTrkMomErr,oldP4Err);
+
+
+  return combinedMomentum;
+}
+
+void EGEtScaleSysModifier::setEcalEnergy(reco::GsfElectron& ele,
+					 const float scale,
+					 const float smear)const
+{
+  const float oldEcalEnergy = ele.ecalEnergy();
+  const float oldEcalEnergyErr = ele.ecalEnergyError();
+  ele.setCorrectedEcalEnergy( oldEcalEnergy*scale );
+  ele.setCorrectedEcalEnergyError(std::hypot( oldEcalEnergyErr*scale, oldEcalEnergy*smear*scale ) );
+}
+
+  
+  
+DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
+		  EGEtScaleSysModifier,
+		  "EGEtScaleSysModifier");

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -1,12 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 
+_correctionFile2016Legacy = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Legacy2016_07Aug2017_FineEtaR9_v3_ele_unc"
+_correctionFile2017Nov17 = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_17Nov2017_v1_ele_unc"
+
 calibratedEgammaSettings = cms.PSet(minEtToCalibrate = cms.double(5.0),
                                     semiDeterministic = cms.bool(True),
-                                    correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_17Nov2017_v1_ele_unc"),
+                                    correctionFile = cms.string(_correctionFile2017Nov17),
                                     recHitCollectionEB = cms.InputTag('reducedEcalRecHitsEB'),
                                     recHitCollectionEE = cms.InputTag('reducedEcalRecHitsEE'),
                                     produceCalibratedObjs = cms.bool(True)
                                     )
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+run2_miniAOD_80XLegacy.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016Legacy)
+
 calibratedEgammaPatSettings = calibratedEgammaSettings.clone(
     recHitCollectionEB = cms.InputTag('reducedEgamma','reducedEBRecHits'),
     recHitCollectionEE = cms.InputTag('reducedEgamma','reducedEERecHits')
@@ -63,3 +69,6 @@ calibratedPatPhotons = cms.EDProducer("CalibratedPatPhotonProducer",
 
 def prefixName(prefix,name):
     return prefix+name[0].upper()+name[1:]
+
+
+

--- a/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
+++ b/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
@@ -129,10 +129,46 @@ import RecoEgamma.EgammaTools.calibratedPhotonProducerTRecoPhoton_cfi
 for valueMapName in RecoEgamma.EgammaTools.calibratedPhotonProducerTRecoPhoton_cfi.calibratedPhotonProducerTRecoPhoton.valueMapsStored:
     setattr(reducedEgammaEnergyScaleAndSmearingModifier.photon_config,valueMapName,cms.InputTag("reducedEgamma",prefixName("calibPho",valueMapName)))
 
+#############################################################
+# 8X to 9X modifiers (fills in variables new to 9X w.r.t 8X)
+#############################################################
+egamma8XObjectUpdateModifier = cms.PSet(
+    modifierName  = cms.string('EG8XObjectUpdateModifier'),
+    ecalRecHitsEB = cms.InputTag("reducedEgamma","reducedEBRecHits"),
+    ecalRecHitsEE = cms.InputTag("reducedEgamma","reducedEERecHits"),
+)
+
+#############################################################
+# 8X legacy needs an extra Et scale systematic
+# due to an inflection around 45 GeV which is handled as a
+# patch on top of the standard scale and smearing systematics
+#############################################################
+from RecoEgamma.EgammaTools.calibratedEgammas_cff import ecalTrkCombinationRegression
+egamma8XLegacyEtScaleSysModifier = cms.PSet(
+    modifierName = cms.string('EGEtScaleSysModifier'),
+    epCombConfig = ecalTrkCombinationRegression,
+    uncertFunc = cms.PSet(
+        name = cms.string("UncertFuncV1"),
+        lowEt = cms.double(43.5),
+        highEt = cms.double(46.5),
+        lowEtUncert = cms.double(0.002),
+        highEtUncert = cms.double(-0.002)
+        )
+    )
 
 def appendReducedEgammaEnergyScaleAndSmearingModifier(modifiers):
     modifiers.append(reducedEgammaEnergyScaleAndSmearingModifier)
 
+def prependEgamma8XObjectUpdateModifier(modifiers):
+    modifiers.insert(0,egamma8XObjectUpdateModifier)
+
+def appendEgamma8XLegacyAppendableModifiers (modifiers):
+    modifiers.append(reducedEgammaEnergyScaleAndSmearingModifier)
+    modifiers.append(egamma8XLegacyEtScaleSysModifier)
+
 from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
 run2_miniAOD_94XFall17.toModify(egamma_modifications,appendReducedEgammaEnergyScaleAndSmearingModifier)
    
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+run2_miniAOD_80XLegacy.toModify(egamma_modifications,appendEgamma8XLegacyAppendableModifiers)
+run2_miniAOD_80XLegacy.toModify(egamma_modifications,prependEgamma8XObjectUpdateModifier)

--- a/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
@@ -183,10 +183,18 @@ std::pair<float,float> ElectronEnergyCalibrator::calCombinedMom(reco::GsfElectro
 { 
   const float oldEcalEnergy = ele.ecalEnergy();
   const float oldEcalEnergyErr = ele.ecalEnergyError();
+
+  const auto oldP4 = ele.p4();
+  const float oldP4Err = ele.p4Error(reco::GsfElectron::P4_COMBINATION);
+  const float oldTrkMomErr = ele.trackMomentumError();
+ 
   setEcalEnergy(ele,scale,smear);
   const auto& combinedMomentum = epCombinationTool_->combine(ele);
+  
   ele.setCorrectedEcalEnergy(oldEcalEnergy);
   ele.setCorrectedEcalEnergyError(oldEcalEnergyErr);
+  ele.correctMomentum(oldP4,oldTrkMomErr,oldP4Err);
+  
   return combinedMomentum;
 }
 						      

--- a/RecoEgamma/EgammaTools/src/EnergyScaleCorrection.cc
+++ b/RecoEgamma/EgammaTools/src/EnergyScaleCorrection.cc
@@ -8,6 +8,7 @@
 #include <iomanip>
 #include <algorithm>
 
+
 EnergyScaleCorrection::EnergyScaleCorrection(const std::string& correctionFileName, unsigned int genSeed):
   smearingType_(ECALELF)
 {
@@ -359,7 +360,21 @@ EnergyScaleCorrection::CorrectionCategory::CorrectionCategory(const std::string&
     r9Min_ = -1;
     r9Max_ = 0.94;
   };	
-  
+  // R9 region
+  p1 = category.find("-R9");
+  p2 = p1 + 1;
+  if(p1 != std::string::npos) {
+    p1 = category.find("_", p1);
+    p2 = category.find("_", p1 + 1);
+    r9Min_ = std::stof(category.substr(p1 + 1, p2 - p1 - 1));
+    // If there is one value, just set lower bound
+    if (p2 != std::string::npos) {
+      p1 = p2;
+      p2 = category.find("-", p1);
+      r9Max_ = std::stof(category.substr(p1 + 1, p2 - p1 - 1));
+      if(r9Max_>=1.0) r9Max_ = std::numeric_limits<float>::max();
+    }
+  }
   //------------------------------
   p1 = category.find("gainEle_");      // Position of first character
   if(p1 != std::string::npos) {


### PR DESCRIPTION
The content of this PR is equivalent to #23474 , but instead of doing a simple "git checkout CMSSW_9_4_X ; git merge CMSSW_9_4_MAOD_X" it is obtained by applying on top of CMSSW_9_4_X the result of the "git diff CMSSW_9_4_X..CMSSW_9_4_MAOD_X". 

The result of "git diff --name-only fc-MAODbackport..CMSSW_9_4_MAOD_X" is empty.

In this way the synchronisation of the 94X and 9_4_MAOD_X code happens without jeopardising the commit history (affected by forward ports). For the detailed history of the commits the 9_4_MAOD_X branch can be checked