### PR TITLE
[10.2.X] Bug fixed in SiStripBadComponentInfo

### DIFF
--- a/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.cc
@@ -223,9 +223,9 @@ void SiStripBadComponentInfo::fillBadComponentMaps(int xbin,int component,SiStri
   }
   if (BC.BadFibers){ 
     int ntot = std::bitset<16>(BC.BadFibers&0x7).count();
-    float val = (mapBadStrip.find(index)!=mapBadStrip.end()) ? mapBadStrip.at(index) : 0.; 
+    float val = (mapBadFiber.find(index)!=mapBadFiber.end()) ? mapBadFiber.at(index) : 0.; 
     val+= ntot;
-    mapBadStrip[index]=val;
+    mapBadFiber[index]=val;
   }   
 }
 void SiStripBadComponentInfo::createSummary(MonitorElement* me,const std::map<std::pair<int,int>,float >& map) {

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
@@ -25,18 +25,23 @@ from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
 siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
 siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
 
-from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
-siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
-       cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
-       cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
-       cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
-       cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
-       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
-       cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
-       )
-siStripQualityESProducer.ReduceGranularity = cms.bool(False)
-siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
-siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
+from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import siStripQualityESProducer 
+mergedSiStripQualityProducer = siStripQualityESProducer.clone(
+    #names and desigantions
+    ListOfRecordToMerge = cms.VPSet(
+        cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
+        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
+        cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
+        cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
+        cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
+        cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
+        )
+    )
+
+mergedSiStripQualityProducer.ReduceGranularity = cms.bool(False)
+mergedSiStripQualityProducer.ThresholdForReducedGranularity = cms.double(0.3)
+mergedSiStripQualityProducer.appendToDataLabel = 'MergedBadComponent'
+
 
 siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
     StripQualityLabel = cms.string('MergedBadComponent')

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
@@ -36,18 +36,22 @@ from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
 siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
 siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
 
-from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
-siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
-       cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
-       cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
-       cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
-       cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
-       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
-       cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
-       )
-siStripQualityESProducer.ReduceGranularity = cms.bool(False)
-siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
-siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
+from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import siStripQualityESProducer 
+mergedSiStripQualityProducer = siStripQualityESProducer.clone(
+    #names and desigantions
+    ListOfRecordToMerge = cms.VPSet(
+        cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
+        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
+        cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
+        cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
+        cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
+        cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
+        )
+    )
+
+mergedSiStripQualityProducer.ReduceGranularity = cms.bool(False)
+mergedSiStripQualityProducer.ThresholdForReducedGranularity = cms.double(0.3)
+mergedSiStripQualityProducer.appendToDataLabel = 'MergedBadComponent'
 
 siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
     StripQualityLabel = cms.string('MergedBadComponent')

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
@@ -41,23 +41,26 @@ from CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi import*
 siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
 siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(False)
 
-from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
-siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
-       cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
-       cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
-       cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
-       cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
-       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
-       cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
-       )
-siStripQualityESProducer.ReduceGranularity = cms.bool(False)
-siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
-siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
+from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import siStripQualityESProducer 
+mergedSiStripQualityProducer = siStripQualityESProducer.clone(
+    #names and desigantions
+    ListOfRecordToMerge = cms.VPSet(
+        cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')), # DCS information
+        cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
+        cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
+        cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
+        cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')), # BadChannel list from FED erroes              
+        cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
+        )
+    )
+
+mergedSiStripQualityProducer.ReduceGranularity = cms.bool(False)
+mergedSiStripQualityProducer.ThresholdForReducedGranularity = cms.double(0.3)
+mergedSiStripQualityProducer.appendToDataLabel = 'MergedBadComponent'
 
 siStripBadComponentInfo = cms.EDProducer("SiStripBadComponentInfo",
-    StripQualityLabel = cms.string('MergedBadComponent')
-)
-
+                                         StripQualityLabel = cms.string('MergedBadComponent')
+                                         )
 
 # Sequence
 SiStripOfflineDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser*siStripBadComponentInfo)


### PR DESCRIPTION
Greetings,
this PR implements a bug-fix in SiStripBadComponentInfo.cc where the bad fiber histogram never got filled (same a proposed in  #23491).
In addition for what concerns the addition of bad components from FED errors, this PR is implements a fix via cloning the `siStripQualityESProducer` and then modifying the attributes instead of just changing the attributes from the imported module.
Tested against the regular workflow (non-DQM based) and found perfect agreement.
@suchandradutta  @fioriNTU @jandrea @arossi83