### PR TITLE
Fix reading of input parameters for PixelTrackFilter for 90m beta star run

### DIFF
--- a/HLTrigger/special/plugins/HLTPixelTrackFilter.cc
+++ b/HLTrigger/special/plugins/HLTPixelTrackFilter.cc
@@ -71,7 +71,6 @@ bool HLTPixelTrackFilter::filter(edm::Event& event, const edm::EventSetup& iSetu
   event.getByToken(inputToken_, trackColl);
 
   unsigned int numTracks = trackColl->size();
-  std::cout << numTracks << std::endl;
   LogDebug("") << "Number of tracks accepted: " << numTracks;
   bool accept = (numTracks >= min_pixelTracks_);
   if(max_pixelTracks_ > 0)

--- a/HLTrigger/special/plugins/HLTPixelTrackFilter.cc
+++ b/HLTrigger/special/plugins/HLTPixelTrackFilter.cc
@@ -38,8 +38,8 @@ private:
 
 HLTPixelTrackFilter::HLTPixelTrackFilter(const edm::ParameterSet& config):
   inputTag_     (config.getParameter<edm::InputTag>("pixelTracks")),
-  min_pixelTracks_ (config.getParameter<unsigned int>("maxPixelTracks")),
-  max_pixelTracks_ (config.getParameter<unsigned int>("minPixelTracks"))
+  min_pixelTracks_ (config.getParameter<unsigned int>("minPixelTracks")),
+  max_pixelTracks_ (config.getParameter<unsigned int>("maxPixelTracks"))
 {
   inputToken_ = consumes< reco::TrackCollection >(inputTag_);
   LogDebug("") << "Using the " << inputTag_ << " input collection";
@@ -71,6 +71,7 @@ bool HLTPixelTrackFilter::filter(edm::Event& event, const edm::EventSetup& iSetu
   event.getByToken(inputToken_, trackColl);
 
   unsigned int numTracks = trackColl->size();
+  std::cout << numTracks << std::endl;
   LogDebug("") << "Number of tracks accepted: " << numTracks;
   bool accept = (numTracks >= min_pixelTracks_);
   if(max_pixelTracks_ > 0)


### PR DESCRIPTION
Fixing a stupid mistake I made where the minimum and maximum number of tracks was assigned to the wrong variables when reading the configuration. 