### PR TITLE
Remove positional arguments from PSet.clone()

### DIFF
--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -657,7 +657,7 @@ class PSet(_ParameterTypeBase,_Parameterizable,_ConfigureComponent,_Labelable):
         return config
     def dumpPython(self, options=PrintOptions()):
         return self.pythonTypeName()+"(\n"+_Parameterizable.dumpPython(self, options)+options.indentation()+")"
-    def clone(self, *args, **params):
+    def clone(self, **params):
         myparams = self.parameters_()
         _modifyParametersFromDict(myparams, params, self._Parameterizable__raiseBadSetAttr)
         returnValue = PSet(**myparams)
@@ -1416,6 +1416,10 @@ if __name__ == "__main__":
             self.assertEqual(p4.b.b.value(), 5)
             self.assertEqual(p4.a.b.value(), 1)
             self.assertEqual(p4.ui.value(), 2)
+            # couple of cases of "weird" arguments
+            self.assertRaises(TypeError, p4.clone, dict(b = None))
+            self.assertRaises(TypeError, p4.clone, [])
+            self.assertRaises(TypeError, p4.clone, 42)
         def testVPSet(self):
             p1 = VPSet(PSet(anInt = int32(1)), PSet(anInt=int32(2)))
             self.assertEqual(len(p1),2)


### PR DESCRIPTION
There was a bug in #23363 (already fixed in the PR) using a pattern `FooPSet.clone(dict(foo = dict(...)))` to clone a `PSet`. Because of the leading `dict` the clone was not modified, and it took a while to realize the cause. A simple way to detect this kind of bug would be to forbid positional arguments to `PSet.clone()` (as in this PR). I am not aware of any use cases for them (and e.g. `Modifier.toModify()` does not allow positional arguments, except for customizing with a function).

The error message from python is
```
TypeError: clone() takes exactly 1 argument (2 given)
```
which may be a bit difficult to interpret. Alternatively we could keep the positional arguments and raise our own Exception with an easier-to-understand message if any positional arguments are given.

Tested in CMSSW_10_2_X_2018-06-10-2300, no changes expected.

@Dr15Jones 