### PR TITLE
HCAL MAHI Code optimization to reduce CPU consuming

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
@@ -11,8 +11,8 @@ typedef Eigen::Matrix<double,Eigen::Dynamic,1,0,MaxSVSize,1> SampleVector;
 typedef Eigen::Matrix<double,Eigen::Dynamic,1,0,MaxPVSize,1> PulseVector;
 typedef Eigen::Matrix<int,Eigen::Dynamic,1,0,MaxPVSize,1> BXVector;
 
-typedef Eigen::Matrix<double,MaxFSVSize,1> FullSampleVector;
-typedef Eigen::Matrix<double,MaxFSVSize,MaxFSVSize> FullSampleMatrix;
+typedef Eigen::Matrix<double,Eigen::Dynamic,1,0,MaxFSVSize,1> FullSampleVector;
+typedef Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,0,MaxFSVSize,MaxFSVSize> FullSampleMatrix;
 
 typedef Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,0,MaxSVSize,MaxSVSize> SampleMatrix;
 typedef Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,0,MaxPVSize,MaxPVSize> PulseMatrix;

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -21,6 +21,7 @@ struct MahiNnlsWorkspace {
   unsigned int tsOffset;
   unsigned int fullTSOffset;
   int bxOffset;
+  int maxoffset;
   double dt;
 
   //holds active bunch crossings
@@ -66,7 +67,6 @@ struct MahiNnlsWorkspace {
   unsigned int nP;
   PulseVector ampVec;
 
-  PulseVector errVec;
   PulseVector ampvecpermtest;
 
   SamplePulseMatrix invcovp;
@@ -75,8 +75,6 @@ struct MahiNnlsWorkspace {
   PulseVector updateWork; // w (vector)
 
   SampleDecompLLT covDecomp;
-  SampleMatrix covDecompLinv;
-  PulseMatrix topleft_work;
   PulseDecompLDLT pulseDecomp;
 
 };


### PR DESCRIPTION
1). Set FullSampleMatrix/FullSampleVector to be dynamic so that it works for different bx and TS configurations and also allocates space only for the minimum needed.
2). Move part of the initialization (in "resetWorkspace()") to the main body, serving as the same purpose as elaborated in 1).
3). Code Cleanup: Removed some unused variables and repeated sentences.

Testing results:
1>. Same reconstruction results.
[Mahi_CPUSpeed.pdf](https://github.com/cms-sw/cmssw/files/2095745/Mahi_CPUSpeed.pdf)

2>. "MahiFit::phase1Apply" CPU consuming reduces ~18% from igprof report.
Two igprof.res files (one for the old one for the new) are put: https://www.dropbox.com/sh/nyjv61mfn29mupt/AAB8Ge1XsKndxHaI7rtIaHgEa?dl=0