### PR TITLE
Tracker alignment - fix incorrect assumption in data file names

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
@@ -859,8 +859,8 @@ class Dataset(object):
             error = "does not start with /store"
         elif parts[2] in ["mc", "relval"]:
             result = 1
-        elif parts[-2] != "00000" or not parts[-1].endswith(".root"):
-            error = "does not end with 00000/something.root"
+        elif not parts[-1].endswith(".root"):
+            error = "does not end with something.root"
         elif len(parts) != 12:
             error = "should be exactly 11 slashes counting the first one"
         else:


### PR DESCRIPTION
This is a simple fix to the run filter for alignment validation data files.  This is applied on top of the lumi filter, but doesn't involve opening and closing files or DAS, so it's quick.  It's been failing for files that end in /00001/....root.