### PR TITLE
Bugfix in pixel detector's cluster charge re-weighting

### DIFF
--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -2245,7 +2245,10 @@ bool SiPixelDigitizerAlgorithm::hitSignalReweight(const PSimHit& hit,
     ierr = PixelTempRewgt2D(IDden, IDden, pixrewgt);
   }
   if (ierr!=0){
-    LogInfo ("PixelDigitizer ") << "Cluster Charge Reweighting did not work properly.";
+#ifdef TP_DEBUG 
+    LogDebug ("PixelDigitizer ") << "Cluster Charge Reweighting did not work properly.";
+#endif
+    return false;
   }
   
   if(PrintClusters){
@@ -2336,7 +2339,10 @@ int SiPixelDigitizerAlgorithm::PixelTempRewgt2D(int id_in, int id_rewgt, array_2
 
   if(!templ2D.xytemp(id_in, cotalpha, cotbeta, xhit2D, yhit2D, ydouble, xdouble, xy_in)) {success = 1;}
   if(success != 0){
-    LogWarning ("Pixel Digitizer") << "No matching template found" << std::endl;
+#ifdef TP_DEBUG 
+    LogDebug("Pixel Digitizer") << "No matching template found" << std::endl;
+#endif
+    return 2;
   }
 
   if(PrintTemplates){


### PR DESCRIPTION
Following up on #22911 :
A bug in the re-weighting algorithm of the pixel digitizer was discovered causing the removal of a significant number of clusters. 
Technically spoken: If no matching 2D template was found for a cluster, it was removed (all charges set to 0) due to a missing return of the re-weighting function. This happens mainly for low pt tracks, since they have a higher possibility for very large incidence angles, not covered by the templates.

Solution: The re-weighting function returns with an error in case no matching template was found. This pulls the flag `reweighted` to `false`, causing the signal to be digitized without re-weighting (see [here](https://github.com/schuetzepaul/cmssw/blob/pixelClusterChargeReweightingBugfix/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc#L1311)). Therefore the signal is not fully correct in terms of radiation damage, but it's not lost.

As noted in #22911 the feature of charge re-weighting is still turned of by default. It can be used with the following lines in the configuration (switching on the Re-weighting and loading the templates via the GT candidate):
```
from SimGeneral.MixingModule.pixelDigitizer_cfi import *
process.mix.digitizers.pixel.UseReweighting = cms.bool(True)

from Configuration.AlCa.GlobalTag import GlobalTag
process.GlobalTag = GlobalTag(process.GlobalTag, '102X_upgrade2018_realistic_Candidate_2018_06_10_00_16_33', '')
```

The validation of the simulated data with this fix is ongoing.

Interested users: @tvami @tsusa @veszpv @pmaksim1 