### PR TITLE
Backport of #23120. PUPPI jet ID

### DIFF
--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -256,11 +256,11 @@ std::vector<double> const & PuppiContainer::puppiWeights() {
             LogDebug("PuppiWeightError") << "====> Weight is nan : " << pWeight << " : pt " << fRecoParticles[i0].pt << " -- eta : " << fRecoParticles[i0].eta << " -- Value" << fVals[i0] << " -- id :  " << fRecoParticles[i0].id << " --  NAlgos: " << lNAlgos << std::endl;
         }
         //Basic Cuts
-        if(pWeight*fPFParticles[i0].pt()   < fPuppiAlgo[pPupId].neutralPt(fNPV) && fRecoParticles[i0].id == 0 ) pWeight = 0;  //threshold cut on the neutral Pt
-        if((fPtMax>0) && (fRecoParticles[i0].id == 0)) pWeight=min(max(pWeight,fPFParticles[i0].pt()/fPtMax),1.);
         if(pWeight                         < fPuppiWeightCut) pWeight = 0;  //==> Elminate the low Weight stuff
+        if(pWeight*fPFParticles[i0].pt()   < fPuppiAlgo[pPupId].neutralPt(fNPV) && fRecoParticles[i0].id == 0 ) pWeight = 0;  //threshold cut on the neutral Pt
         if(fInvert) pWeight = 1.-pWeight;
         //std::cout << "fRecoParticles[i0].pt = " <<  fRecoParticles[i0].pt << ", fRecoParticles[i0].charge = " << fRecoParticles[i0].charge << ", fRecoParticles[i0].id = " << fRecoParticles[i0].id << ", weight = " << pWeight << std::endl;
+        if((fPtMax>0) && (fRecoParticles[i0].id == 0)) pWeight=min(max(pWeight,fPFParticles[i0].pt()/fPtMax),1.);
 
         fWeights .push_back(pWeight);
         fAlphaMed.push_back(fPuppiAlgo[pPupId].median());

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -256,11 +256,11 @@ std::vector<double> const & PuppiContainer::puppiWeights() {
             LogDebug("PuppiWeightError") << "====> Weight is nan : " << pWeight << " : pt " << fRecoParticles[i0].pt << " -- eta : " << fRecoParticles[i0].eta << " -- Value" << fVals[i0] << " -- id :  " << fRecoParticles[i0].id << " --  NAlgos: " << lNAlgos << std::endl;
         }
         //Basic Cuts
-        if(pWeight                         < fPuppiWeightCut) pWeight = 0;  //==> Elminate the low Weight stuff
         if(pWeight*fPFParticles[i0].pt()   < fPuppiAlgo[pPupId].neutralPt(fNPV) && fRecoParticles[i0].id == 0 ) pWeight = 0;  //threshold cut on the neutral Pt
+        if((fPtMax>0) && (fRecoParticles[i0].id == 0)) pWeight=min(max(pWeight,fPFParticles[i0].pt()/fPtMax),1.);
+        if(pWeight                         < fPuppiWeightCut) pWeight = 0;  //==> Elminate the low Weight stuff
         if(fInvert) pWeight = 1.-pWeight;
         //std::cout << "fRecoParticles[i0].pt = " <<  fRecoParticles[i0].pt << ", fRecoParticles[i0].charge = " << fRecoParticles[i0].charge << ", fRecoParticles[i0].id = " << fRecoParticles[i0].id << ", weight = " << pWeight << std::endl;
-        if((fPtMax>0) && (fRecoParticles[i0].id == 0)) pWeight=min(max(pWeight,fPFParticles[i0].pt()/fPtMax),1.);
 
         fWeights .push_back(pWeight);
         fAlphaMed.push_back(fPuppiAlgo[pPupId].median());

--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -163,12 +163,20 @@ jetDQMAnalyzerAk4PFCHSCleanedMiniAOD=jetDQMAnalyzerAk4PFCleaned.clone(
 
 jetDQMAnalyzerAk8PFPUPPICleanedMiniAOD=jetDQMAnalyzerAk4PFCHSCleanedMiniAOD.clone(
     jetsrc = cms.InputTag("slimmedJetsAK8"),
+    #for PUPPI jets: TIGHT
+    JetIDQuality               = cms.string("TIGHT"),
+    #for PUPPI jets: WINTER17PUPPI from 9_4_X onwards
+    JetIDVersion               = cms.string("WINTER17PUPPI"),
     fillsubstructure =cms.bool(True),
 )
 
 jetDQMAnalyzerAk4PFCHSPuppiCleanedMiniAOD=jetDQMAnalyzerAk4PFCHSCleanedMiniAOD.clone(
     JetType = cms.string('miniaod'),#pf, calo or jpt
     jetsrc = cms.InputTag("slimmedJetsPuppi"),
+    #for PUPPI jets: TIGHT
+    JetIDQuality               = cms.string("TIGHT"),
+    #for PUPPI jets: WINTER17PUPPI from 9_4_X onwards
+    JetIDVersion               = cms.string("WINTER17PUPPI"),
 )
 
 jetDQMAnalyzerIC5CaloHIUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -2688,7 +2688,12 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
       
       mPhiVSEta = map_of_MEs[DirName+"/"+"PhiVSEta"]; if (mPhiVSEta && mPhiVSEta->getRootObject()) mPhiVSEta->Fill(correctedJet.eta(),correctedJet.phi());
       //if(!isJPTJet_){
-      mConstituents = map_of_MEs[DirName+"/"+"Constituents"]; if (mConstituents && mConstituents->getRootObject()) mConstituents->Fill (correctedJet.nConstituents());
+      float nConstituents=correctedJet.nConstituents();
+      if(isMiniAODJet_) {
+        if ((*patJets)[ijet].hasUserFloat("patPuppiJetSpecificProducer:puppiMultiplicity"))
+           nConstituents = (*patJets)[ijet].userFloat("patPuppiJetSpecificProducer:puppiMultiplicity");
+      }
+      mConstituents = map_of_MEs[DirName+"/"+"Constituents"]; if (mConstituents && mConstituents->getRootObject()) mConstituents->Fill (nConstituents);
       //}
       // Fill NPV profiles
       //--------------------------------------------------------------------
@@ -2696,28 +2701,28 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
       mEta_profile = map_of_MEs[DirName+"/"+"Eta_profile"]; if (mEta_profile && mEta_profile->getRootObject())  mEta_profile         ->Fill(numPV, correctedJet.eta());
       mPhi_profile = map_of_MEs[DirName+"/"+"Phi_profile"]; if (mPhi_profile && mPhi_profile->getRootObject())  mPhi_profile         ->Fill(numPV, correctedJet.phi());
       //if(!isJPTJet_){
-      mConstituents_profile = map_of_MEs[DirName+"/"+"Constituents_profile"]; if (mConstituents_profile && mConstituents_profile->getRootObject())  mConstituents_profile->Fill(numPV, correctedJet.nConstituents());
+      mConstituents_profile = map_of_MEs[DirName+"/"+"Constituents_profile"]; if (mConstituents_profile && mConstituents_profile->getRootObject())  mConstituents_profile->Fill(numPV, nConstituents);
       //}
       if (fabs(correctedJet.eta()) <= 1.3) {
 	mPt_Barrel = map_of_MEs[DirName+"/"+"Pt_Barrel"]; if (mPt_Barrel && mPt_Barrel->getRootObject()) mPt_Barrel->Fill (correctedJet.pt());
 	mPhi_Barrel = map_of_MEs[DirName+"/"+"Phi_Barrel"]; if (mPhi_Barrel && mPhi_Barrel->getRootObject()) mPhi_Barrel->Fill (correctedJet.phi());
 	//if (mE_Barrel)    mE_Barrel->Fill (correctedJet.energy());
 	//if(!isJPTJet_){
-	mConstituents_Barrel = map_of_MEs[DirName+"/"+"Constituents_Barrel"]; if (mConstituents_Barrel && mConstituents_Barrel->getRootObject()) mConstituents_Barrel->Fill(correctedJet.nConstituents());
+	mConstituents_Barrel = map_of_MEs[DirName+"/"+"Constituents_Barrel"]; if (mConstituents_Barrel && mConstituents_Barrel->getRootObject()) mConstituents_Barrel->Fill(nConstituents);
 	//}
       }else if (fabs(correctedJet.eta()) <= 3) {
 	mPt_EndCap = map_of_MEs[DirName+"/"+"Pt_EndCap"]; if (mPt_EndCap && mPt_EndCap->getRootObject()) mPt_EndCap->Fill (correctedJet.pt());
 	mPhi_EndCap = map_of_MEs[DirName+"/"+"Phi_EndCap"]; if (mPhi_EndCap && mPhi_EndCap->getRootObject())  mPhi_EndCap->Fill (correctedJet.phi());
 	//if (mE_EndCap)    mE_EndCap->Fill (correctedJet.energy());
 	//if(!isJPTJet_){
-	mConstituents_EndCap = map_of_MEs[DirName+"/"+"Constituents_EndCap"]; if (mConstituents_EndCap && mConstituents_EndCap->getRootObject())  mConstituents_EndCap->Fill(correctedJet.nConstituents());
+	mConstituents_EndCap = map_of_MEs[DirName+"/"+"Constituents_EndCap"]; if (mConstituents_EndCap && mConstituents_EndCap->getRootObject())  mConstituents_EndCap->Fill(nConstituents);
 	//}
       }else{
 	mPt_Forward = map_of_MEs[DirName+"/"+"Pt_Forward"]; if (mPt_Forward && mPt_Forward->getRootObject()) mPt_Forward->Fill (correctedJet.pt());
 	mPhi_Forward = map_of_MEs[DirName+"/"+"Phi_Forward"]; if (mPhi_Forward && mPhi_Forward->getRootObject()) mPhi_Forward->Fill (correctedJet.phi());
 	//if (mE_Forward)    mE_Forward->Fill (correctedJet.energy());
 	//if(!isJPTJet_){
-	mConstituents_Forward = map_of_MEs[DirName+"/"+"Constituents_Forward"]; if (mConstituents_Forward && mConstituents_Forward->getRootObject())   mConstituents_Forward->Fill(correctedJet.nConstituents());
+	mConstituents_Forward = map_of_MEs[DirName+"/"+"Constituents_Forward"]; if (mConstituents_Forward && mConstituents_Forward->getRootObject())   mConstituents_Forward->Fill(nConstituents);
 	//}
       }
     }// pass ID for corrected jets --> inclusive selection

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -152,6 +152,10 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
       pfjetidversion = PFJetIDSelectionFunctor::RUNIISTARTUP;
     }else if(JetIDVersion_== "WINTER16"){
       pfjetidversion = PFJetIDSelectionFunctor::WINTER16;
+    }else if(JetIDVersion_== "WINTER17"){
+      pfjetidversion = PFJetIDSelectionFunctor::WINTER17;
+    }else if(JetIDVersion_== "WINTER17PUPPI"){
+      pfjetidversion = PFJetIDSelectionFunctor::WINTER17PUPPI;
     }else{
       if (verbose_) std::cout<<"no valid PF JetID version given"<<std::endl;
     }

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -61,135 +61,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
    else if ( qualityStr == "TIGHTLEPVETO") quality_ = TIGHTLEPVETO;
    else quality_ = TIGHT;
 
-    push_back("CHF" );
-    push_back("NHF" );
-    if( (version_ != WINTER17 && version_!=WINTER17PUPPI) || quality_ != TIGHT ) push_back("CEF" );
-    push_back("NEF" );
-    push_back("NCH" );
-    push_back("nConstituents");
-    if(version_ == RUNIISTARTUP ){
-      push_back("NEF_FW");
-      push_back("nNeutrals_FW");
-    }
-    if(version_ == WINTER16 ){
-      push_back("NHF_EC");
-      push_back("NEF_EC");
-      push_back("nNeutrals_EC");
-      push_back("NEF_FW");
-      push_back("nNeutrals_FW");
-    }
-    if(version_ == WINTER17 ){
-      push_back("NEF_EC_L");
-      push_back("NEF_EC_U");
-      push_back("nNeutrals_EC");
-      push_back("NEF_FW");
-      push_back("NHF_FW");
-      push_back("nNeutrals_FW");
-      if (quality_ == TIGHTLEPVETO) push_back("MUF");
-    }
-    if(version_ == WINTER17PUPPI ){
-      push_back("NHF_EC");
-      push_back("NEF_FW");
-      push_back("NHF_FW");
-      push_back("nNeutrals_FW_L");
-      push_back("nNeutrals_FW_U");
-      if (quality_ == TIGHTLEPVETO) push_back("MUF");
-    }
- 
-
-    if( (version_ == WINTER17 || version_ == WINTER17PUPPI) && quality_ == LOOSE ){
-      edm::LogWarning("BadJetIDVersion") << "Winter17 JetID version does not support the LOOSE operating point -- defaulting to TIGHT";
-      quality_ = TIGHT;
-      }
-
-   if( (version_ != WINTER17 && version_ != WINTER17PUPPI) && quality_ ==  TIGHTLEPVETO){
-      edm::LogWarning("BadJetIDVersion") << "JetID version does not support the TIGHTLEPVETO operating point -- defaulting to TIGHT";
-      quality_ = TIGHT;
-      }
- 
-
-    // Set some default cuts for LOOSE, TIGHT
-    if ( quality_ == LOOSE ) {
-      set("CHF", 0.0);
-      set("NHF", 0.99);
-      set("CEF", 0.99);
-      set("NEF", 0.99);
-      set("NCH", 0);
-      set("nConstituents", 1);
-      if(version_ == RUNIISTARTUP){
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-      if(version_ == WINTER16){
-	set("NHF_EC",0.98);
-	set("NEF_EC",0.01);
-	set("nNeutrals_EC",2);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-
-
-    } else if ( quality_ == TIGHT ) {
-      set("CHF", 0.0);
-      set("NHF", 0.9);
-      if(version_ != WINTER17 && version_ != WINTER17PUPPI ) set("CEF", 0.99);
-      set("NEF", 0.9);
-      set("NCH", 0);
-      set("nConstituents", 1);
-      if(version_ == RUNIISTARTUP){
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-      if(version_ == WINTER16){
-	set("NHF_EC",0.98);
-	set("NEF_EC",0.01);
-	set("nNeutrals_EC",2);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-      if(version_ == WINTER17){
-	set("NEF_EC_L",0.02);
-	set("NEF_EC_U",0.99);
-	set("nNeutrals_EC",2);
-	set("NHF_FW",0.02);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-      if(version_ == WINTER17PUPPI){
-	set("NHF_EC",0.99);
-	set("NHF_FW",0.02);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW_L",2);
-	set("nNeutrals_FW_U",15);
-      }
-
-    }else if ( quality_ == TIGHTLEPVETO ) {
-      set("CHF", 0.0);
-      set("NHF", 0.9);
-      set("CEF", 0.8);
-      set("NEF", 0.9);
-      set("NCH", 0);
-      set("nConstituents", 1);
-      if(version_ == WINTER17){
-	set("NEF_EC_L",0.02);
-	set("NEF_EC_U",0.99);
-	set("nNeutrals_EC",2);
-	set("NHF_FW",0.02);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-        set("MUF", 0.8);
-      }
-      if(version_ == WINTER17PUPPI){
-	set("NHF_EC",0.99);
-	set("NHF_FW",0.02);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW_L",2);
-	set("nNeutrals_FW_H",15);
-        set("MUF", 0.8);
-      }
-
-    }
-
+   initCuts();
 
     // Now check the configuration to see if the user changed anything
     if ( params.exists("CHF") ) set("CHF", params.getParameter<double>("CHF") );
@@ -231,46 +103,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
     if ( params.exists("cutsToIgnore") )
       setIgnoredCuts( params.getParameter<std::vector<std::string> >("cutsToIgnore") );
 
-
-    indexNConstituents_ = index_type (&bits_, "nConstituents");
-    indexNEF_ = index_type (&bits_, "NEF");
-    indexNHF_ = index_type (&bits_, "NHF");
-    if((version_ != WINTER17 && version_ != WINTER17PUPPI) || quality_ != TIGHT ) indexCEF_ = index_type (&bits_, "CEF");
-
-    indexCHF_ = index_type (&bits_, "CHF");
-    indexNCH_ = index_type (&bits_, "NCH");
-    if(version_ == RUNIISTARTUP){
-      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
-      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
-    }
-    if(version_ == WINTER16){
-      indexNHF_EC_ = index_type (&bits_, "NHF_EC");
-      indexNEF_EC_ = index_type (&bits_, "NEF_EC");
-      indexNNeutrals_EC_ = index_type (&bits_, "nNeutrals_EC");
-      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
-      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
-    }
-    if(version_ == WINTER17){
-      indexNEF_EC_L_ = index_type (&bits_, "NEF_EC_L");
-      indexNEF_EC_U_ = index_type (&bits_, "NEF_EC_U");
-      indexNNeutrals_EC_ = index_type (&bits_, "nNeutrals_EC");
-      indexNHF_FW_ = index_type (&bits_, "NHF_FW");
-      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
-      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
-      if ( quality_ == TIGHTLEPVETO ) {indexMUF_ = index_type (&bits_, "MUF");}
-    }
-    if(version_ == WINTER17PUPPI){
-      indexNHF_EC_ = index_type (&bits_, "NHF_EC");
-      indexNHF_FW_ = index_type (&bits_, "NHF_FW");
-      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
-      indexNNeutrals_FW_L_ = index_type (&bits_, "nNeutrals_FW_L");
-      indexNNeutrals_FW_U_ = index_type (&bits_, "nNeutrals_FW_U");
-      if ( quality_ == TIGHTLEPVETO ) {indexMUF_ = index_type (&bits_, "MUF");}
-    }
-
-
-
-    retInternal_ = getBitTemplate();
+    initIndex();
 
   }
 
@@ -279,176 +112,8 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 			  Quality_t quality ) :
   version_(version), quality_(quality)
  {
-
-    push_back("CHF" );
-    push_back("NHF" );
-    if( (version_ != WINTER17 && version_!=WINTER17PUPPI) || quality_ != TIGHT ) push_back("CEF" );
-    push_back("NEF" );
-    push_back("NCH" );
-    push_back("nConstituents");
-    if(version_ == RUNIISTARTUP ){
-      push_back("NEF_FW");
-      push_back("nNeutrals_FW");
-    }
-    if(version_ == WINTER16 ){
-      push_back("NHF_EC");
-      push_back("NEF_EC");
-      push_back("nNeutrals_EC");
-      push_back("NEF_FW");
-      push_back("nNeutrals_FW");
-    }
-    if(version_ == WINTER17 ){
-      push_back("NEF_EC_L");
-      push_back("NEF_EC_U");
-      push_back("nNeutrals_EC");
-      push_back("NEF_FW");
-      push_back("NHF_FW");
-      push_back("nNeutrals_FW");
-      if (quality_ == TIGHTLEPVETO) push_back("MUF");
-    }
-    if(version_ == WINTER17PUPPI ){
-      push_back("NHF_EC");
-      push_back("NEF_FW");
-      push_back("NHF_FW");
-      push_back("nNeutrals_FW_L");
-      push_back("nNeutrals_FW_U");
-      if (quality_ == TIGHTLEPVETO) push_back("MUF");
-    }
- 
-
-    if( (version_ == WINTER17 || version_ == WINTER17PUPPI) && quality_ == LOOSE ){
-      edm::LogWarning("BadJetIDVersion") << "Winter17 JetID version does not support the LOOSE operating point -- defaulting to TIGHT";
-      quality_ = TIGHT;
-      }
-
-   if( (version_ != WINTER17 && version_ != WINTER17PUPPI) && quality_ ==  TIGHTLEPVETO){
-      edm::LogWarning("BadJetIDVersion") << "JetID version does not support the TIGHTLEPVETO operating point -- defaulting to TIGHT";
-      quality_ = TIGHT;
-      }
- 
-
-    // Set some default cuts for LOOSE, TIGHT
-    if ( quality_ == LOOSE ) {
-      set("CHF", 0.0);
-      set("NHF", 0.99);
-      set("CEF", 0.99);
-      set("NEF", 0.99);
-      set("NCH", 0);
-      set("nConstituents", 1);
-      if(version_ == RUNIISTARTUP){
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-      if(version_ == WINTER16){
-	set("NHF_EC",0.98);
-	set("NEF_EC",0.01);
-	set("nNeutrals_EC",2);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-
-
-    } else if ( quality_ == TIGHT ) {
-      set("CHF", 0.0);
-      set("NHF", 0.9);
-      if(version_ != WINTER17 && version_ != WINTER17PUPPI ) set("CEF", 0.99);
-      set("NEF", 0.9);
-      set("NCH", 0);
-      set("nConstituents", 1);
-      if(version_ == RUNIISTARTUP){
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-      if(version_ == WINTER16){
-	set("NHF_EC",0.98);
-	set("NEF_EC",0.01);
-	set("nNeutrals_EC",2);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-      if(version_ == WINTER17){
-	set("NEF_EC_L",0.02);
-	set("NEF_EC_U",0.99);
-	set("nNeutrals_EC",2);
-	set("NHF_FW",0.02);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-      }
-      if(version_ == WINTER17PUPPI){
-	set("NHF_EC",0.99);
-	set("NHF_FW",0.02);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW_L",2);
-	set("nNeutrals_FW_U",15);
-      }
-
-    }else if ( quality_ == TIGHTLEPVETO ) {
-      set("CHF", 0.0);
-      set("NHF", 0.9);
-      set("CEF", 0.8);
-      set("NEF", 0.9);
-      set("NCH", 0);
-      set("nConstituents", 1);
-      if(version_ == WINTER17){
-	set("NEF_EC_L",0.02);
-	set("NEF_EC_U",0.99);
-	set("nNeutrals_EC",2);
-	set("NHF_FW",0.02);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW",10);
-        set("MUF", 0.8);
-      }
-      if(version_ == WINTER17PUPPI){
-	set("NHF_EC",0.99);
-	set("NHF_FW",0.02);
-	set("NEF_FW",0.90);
-	set("nNeutrals_FW_L",2);
-	set("nNeutrals_FW_H",15);
-        set("MUF", 0.8);
-      }
-
-    }
-
-
-    indexNConstituents_ = index_type (&bits_, "nConstituents");
-    indexNEF_ = index_type (&bits_, "NEF");
-    indexNHF_ = index_type (&bits_, "NHF");
-    if((version_ != WINTER17 && version_ != WINTER17PUPPI) || quality_ != TIGHT ) indexCEF_ = index_type (&bits_, "CEF");
-
-    indexCHF_ = index_type (&bits_, "CHF");
-    indexNCH_ = index_type (&bits_, "NCH");
-    if(version_ == RUNIISTARTUP){
-      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
-      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
-    }
-    if(version_ == WINTER16){
-      indexNHF_EC_ = index_type (&bits_, "NHF_EC");
-      indexNEF_EC_ = index_type (&bits_, "NEF_EC");
-      indexNNeutrals_EC_ = index_type (&bits_, "nNeutrals_EC");
-      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
-      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
-    }
-    if(version_ == WINTER17){
-      indexNEF_EC_L_ = index_type (&bits_, "NEF_EC_L");
-      indexNEF_EC_U_ = index_type (&bits_, "NEF_EC_U");
-      indexNNeutrals_EC_ = index_type (&bits_, "nNeutrals_EC");
-      indexNHF_FW_ = index_type (&bits_, "NHF_FW");
-      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
-      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
-      if ( quality_ == TIGHTLEPVETO ) {indexMUF_ = index_type (&bits_, "MUF");}
-    }
-    if(version_ == WINTER17PUPPI){
-      indexNHF_EC_ = index_type (&bits_, "NHF_EC");
-      indexNHF_FW_ = index_type (&bits_, "NHF_FW");
-      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
-      indexNNeutrals_FW_L_ = index_type (&bits_, "nNeutrals_FW_L");
-      indexNNeutrals_FW_U_ = index_type (&bits_, "nNeutrals_FW_U");
-      if ( quality_ == TIGHTLEPVETO ) {indexMUF_ = index_type (&bits_, "MUF");}
-    }
-
-
-
-    retInternal_ = getBitTemplate();
+   initCuts();
+   initIndex();
  }
 
 
@@ -706,6 +371,179 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
   }
 
  private: // member variables
+
+  void initCuts()
+  {
+    push_back("CHF" );
+    push_back("NHF" );
+    if( (version_ != WINTER17 && version_!=WINTER17PUPPI) || quality_ != TIGHT ) push_back("CEF" );
+    push_back("NEF" );
+    push_back("NCH" );
+    push_back("nConstituents");
+    if(version_ == RUNIISTARTUP ){
+      push_back("NEF_FW");
+      push_back("nNeutrals_FW");
+    }
+    if(version_ == WINTER16 ){
+      push_back("NHF_EC");
+      push_back("NEF_EC");
+      push_back("nNeutrals_EC");
+      push_back("NEF_FW");
+      push_back("nNeutrals_FW");
+    }
+    if(version_ == WINTER17 ){
+      push_back("NEF_EC_L");
+      push_back("NEF_EC_U");
+      push_back("nNeutrals_EC");
+      push_back("NEF_FW");
+      push_back("NHF_FW");
+      push_back("nNeutrals_FW");
+      if (quality_ == TIGHTLEPVETO) push_back("MUF");
+    }
+    if(version_ == WINTER17PUPPI ){
+      push_back("NHF_EC");
+      push_back("NEF_FW");
+      push_back("NHF_FW");
+      push_back("nNeutrals_FW_L");
+      push_back("nNeutrals_FW_U");
+      if (quality_ == TIGHTLEPVETO) push_back("MUF");
+    }
+ 
+
+    if( (version_ == WINTER17 || version_ == WINTER17PUPPI) && quality_ == LOOSE ){
+      edm::LogWarning("BadJetIDVersion") << "Winter17 JetID version does not support the LOOSE operating point -- defaulting to TIGHT";
+      quality_ = TIGHT;
+      }
+
+   if( (version_ != WINTER17 && version_ != WINTER17PUPPI) && quality_ ==  TIGHTLEPVETO){
+      edm::LogWarning("BadJetIDVersion") << "JetID version does not support the TIGHTLEPVETO operating point -- defaulting to TIGHT";
+      quality_ = TIGHT;
+      }
+ 
+
+    // Set some default cuts for LOOSE, TIGHT
+    if ( quality_ == LOOSE ) {
+      set("CHF", 0.0);
+      set("NHF", 0.99);
+      set("CEF", 0.99);
+      set("NEF", 0.99);
+      set("NCH", 0);
+      set("nConstituents", 1);
+      if(version_ == RUNIISTARTUP){
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW",10);
+      }
+      if(version_ == WINTER16){
+	set("NHF_EC",0.98);
+	set("NEF_EC",0.01);
+	set("nNeutrals_EC",2);
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW",10);
+      }
+
+
+    } else if ( quality_ == TIGHT ) {
+      set("CHF", 0.0);
+      set("NHF", 0.9);
+      if(version_ != WINTER17 && version_ != WINTER17PUPPI ) set("CEF", 0.99);
+      set("NEF", 0.9);
+      set("NCH", 0);
+      set("nConstituents", 1);
+      if(version_ == RUNIISTARTUP){
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW",10);
+      }
+      if(version_ == WINTER16){
+	set("NHF_EC",0.98);
+	set("NEF_EC",0.01);
+	set("nNeutrals_EC",2);
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW",10);
+      }
+      if(version_ == WINTER17){
+	set("NEF_EC_L",0.02);
+	set("NEF_EC_U",0.99);
+	set("nNeutrals_EC",2);
+	set("NHF_FW",0.02);
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW",10);
+      }
+      if(version_ == WINTER17PUPPI){
+	set("NHF_EC",0.99);
+	set("NHF_FW",0.02);
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW_L",2);
+	set("nNeutrals_FW_U",15);
+      }
+
+    }else if ( quality_ == TIGHTLEPVETO ) {
+      set("CHF", 0.0);
+      set("NHF", 0.9);
+      set("CEF", 0.8);
+      set("NEF", 0.9);
+      set("NCH", 0);
+      set("nConstituents", 1);
+      if(version_ == WINTER17){
+	set("NEF_EC_L",0.02);
+	set("NEF_EC_U",0.99);
+	set("nNeutrals_EC",2);
+	set("NHF_FW",0.02);
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW",10);
+        set("MUF", 0.8);
+      }
+      if(version_ == WINTER17PUPPI){
+	set("NHF_EC",0.99);
+	set("NHF_FW",0.02);
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW_L",2);
+	set("nNeutrals_FW_U",15);
+        set("MUF", 0.8);
+      }
+
+    }
+  }
+
+  void initIndex()
+  {
+    indexNConstituents_ = index_type (&bits_, "nConstituents");
+    indexNEF_ = index_type (&bits_, "NEF");
+    indexNHF_ = index_type (&bits_, "NHF");
+    if((version_ != WINTER17 && version_ != WINTER17PUPPI) || quality_ != TIGHT ) indexCEF_ = index_type (&bits_, "CEF");
+
+    indexCHF_ = index_type (&bits_, "CHF");
+    indexNCH_ = index_type (&bits_, "NCH");
+    if(version_ == RUNIISTARTUP){
+      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
+      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
+    }
+    if(version_ == WINTER16){
+      indexNHF_EC_ = index_type (&bits_, "NHF_EC");
+      indexNEF_EC_ = index_type (&bits_, "NEF_EC");
+      indexNNeutrals_EC_ = index_type (&bits_, "nNeutrals_EC");
+      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
+      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
+    }
+    if(version_ == WINTER17){
+      indexNEF_EC_L_ = index_type (&bits_, "NEF_EC_L");
+      indexNEF_EC_U_ = index_type (&bits_, "NEF_EC_U");
+      indexNNeutrals_EC_ = index_type (&bits_, "nNeutrals_EC");
+      indexNHF_FW_ = index_type (&bits_, "NHF_FW");
+      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
+      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
+      if ( quality_ == TIGHTLEPVETO ) {indexMUF_ = index_type (&bits_, "MUF");}
+    }
+    if(version_ == WINTER17PUPPI){
+      indexNHF_EC_ = index_type (&bits_, "NHF_EC");
+      indexNHF_FW_ = index_type (&bits_, "NHF_FW");
+      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
+      indexNNeutrals_FW_L_ = index_type (&bits_, "nNeutrals_FW_L");
+      indexNNeutrals_FW_U_ = index_type (&bits_, "nNeutrals_FW_U");
+      if ( quality_ == TIGHTLEPVETO ) {indexMUF_ = index_type (&bits_, "MUF");}
+    }
+
+    retInternal_ = getBitTemplate();
+  }
 
   Version_t version_;
   Quality_t quality_;

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -522,6 +522,11 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 	nch = patJet->chargedMultiplicity();
 	nconstituents = patJet->numberOfDaughters();
 	nneutrals = patJet->neutralMultiplicity();
+        // Handle the special case of PUPPI jets with weighted multiplicities
+        if (patJet->hasUserFloat("patPuppiJetSpecificProducer:puppiMultiplicity"))
+           nconstituents = patJet->userFloat("patPuppiJetSpecificProducer:puppiMultiplicity");
+        if (patJet->hasUserFloat("patPuppiJetSpecificProducer:neutralPuppiMultiplicity"))
+           nneutrals = patJet->userFloat("patPuppiJetSpecificProducer:neutralPuppiMultiplicity");
       }
       // Handle the special case where this is a composed jet for
       // subjet analyses

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -25,7 +25,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 
  public: // interface
 
-  enum Version_t { FIRSTDATA, RUNIISTARTUP, WINTER16, WINTER17, N_VERSIONS };
+  enum Version_t { FIRSTDATA, RUNIISTARTUP, WINTER16, WINTER17, WINTER17PUPPI, N_VERSIONS };
   enum Quality_t { LOOSE, TIGHT, TIGHTLEPVETO, N_QUALITY};
 
   PFJetIDSelectionFunctor() {}
@@ -51,6 +51,8 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
      version_ = WINTER16; 
    else if( versionStr == "WINTER17") 
      version_ = WINTER17;   
+   else if( versionStr == "WINTER17PUPPI")
+     version_ = WINTER17PUPPI;
    else version_ = WINTER17;//set WINTER17 as default
    
 
@@ -61,7 +63,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 
     push_back("CHF" );
     push_back("NHF" );
-    if( version_ != WINTER17 || quality_ != TIGHT ) push_back("CEF" );
+    if( (version_ != WINTER17 && version_!=WINTER17PUPPI) || quality_ != TIGHT ) push_back("CEF" );
     push_back("NEF" );
     push_back("NCH" );
     push_back("nConstituents");
@@ -83,16 +85,24 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
       push_back("NEF_FW");
       push_back("NHF_FW");
       push_back("nNeutrals_FW");
-      if (quality_ == TIGHTLEPVETO) push_back("MUF");;
+      if (quality_ == TIGHTLEPVETO) push_back("MUF");
+    }
+    if(version_ == WINTER17PUPPI ){
+      push_back("NHF_EC");
+      push_back("NEF_FW");
+      push_back("NHF_FW");
+      push_back("nNeutrals_FW_L");
+      push_back("nNeutrals_FW_U");
+      if (quality_ == TIGHTLEPVETO) push_back("MUF");
     }
  
 
-    if(version_ == WINTER17 && quality_ == LOOSE ){
+    if( (version_ == WINTER17 || version_ == WINTER17PUPPI) && quality_ == LOOSE ){
       edm::LogWarning("BadJetIDVersion") << "Winter17 JetID version does not support the LOOSE operating point -- defaulting to TIGHT";
       quality_ = TIGHT;
       }
 
-   if(version_ != WINTER17 && quality_ ==  TIGHTLEPVETO){
+   if( (version_ != WINTER17 && version_ != WINTER17PUPPI) && quality_ ==  TIGHTLEPVETO){
       edm::LogWarning("BadJetIDVersion") << "JetID version does not support the TIGHTLEPVETO operating point -- defaulting to TIGHT";
       quality_ = TIGHT;
       }
@@ -122,7 +132,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
     } else if ( quality_ == TIGHT ) {
       set("CHF", 0.0);
       set("NHF", 0.9);
-      if(version_ != WINTER17 ) set("CEF", 0.99);
+      if(version_ != WINTER17 && version_ != WINTER17PUPPI ) set("CEF", 0.99);
       set("NEF", 0.9);
       set("NCH", 0);
       set("nConstituents", 1);
@@ -145,6 +155,13 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 	set("NEF_FW",0.90);
 	set("nNeutrals_FW",10);
       }
+      if(version_ == WINTER17PUPPI){
+	set("NHF_EC",0.99);
+	set("NHF_FW",0.02);
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW_L",2);
+	set("nNeutrals_FW_U",15);
+      }
 
     }else if ( quality_ == TIGHTLEPVETO ) {
       set("CHF", 0.0);
@@ -162,6 +179,14 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 	set("nNeutrals_FW",10);
         set("MUF", 0.8);
       }
+      if(version_ == WINTER17PUPPI){
+	set("NHF_EC",0.99);
+	set("NHF_FW",0.02);
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW_L",2);
+	set("nNeutrals_FW_H",15);
+        set("MUF", 0.8);
+      }
 
     }
 
@@ -169,7 +194,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
     // Now check the configuration to see if the user changed anything
     if ( params.exists("CHF") ) set("CHF", params.getParameter<double>("CHF") );
     if ( params.exists("NHF") ) set("NHF", params.getParameter<double>("NHF") );
-    if(version_ != WINTER17  || quality_ != TIGHT ) {if ( params.exists("CEF") ) set("CEF", params.getParameter<double>("CEF") );}
+    if ((version_ != WINTER17 && version_ != WINTER17PUPPI) || quality_ != TIGHT ) {if ( params.exists("CEF") ) set("CEF", params.getParameter<double>("CEF") );}
     if ( params.exists("NEF") ) set("NEF", params.getParameter<double>("NEF") );
     if ( params.exists("NCH") ) set("NCH", params.getParameter<int>   ("NCH") );
     if ( params.exists("nConstituents") ) set("nConstituents", params.getParameter<int> ("nConstituents") );
@@ -193,6 +218,14 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
       if ( params.exists("nNeutrals_FW") ) set("nNeutrals_FW", params.getParameter<int> ("nNeutrals_FW") );
       if ( quality_ == TIGHTLEPVETO ) {if ( params.exists("MUF") ) set("MUF", params.getParameter<int> ("MUF") );}
     }
+    if(version_ == WINTER17PUPPI){
+      if ( params.exists("NHF_EC") ) set("NHF_EC", params.getParameter<int> ("NHF_EC") );
+      if ( params.exists("NHF_FW") ) set("NHF_FW", params.getParameter<double> ("NHF_FW") );
+      if ( params.exists("NEF_FW") ) set("NEF_FW", params.getParameter<double> ("NEF_FW") );
+      if ( params.exists("nNeutrals_FW_L") ) set("nNeutrals_FW_L", params.getParameter<int> ("nNeutrals_FW_L") );
+      if ( params.exists("nNeutrals_FW_U") ) set("nNeutrals_FW_U", params.getParameter<int> ("nNeutrals_FW_U") );
+      if ( quality_ == TIGHTLEPVETO ) {if ( params.exists("MUF") ) set("MUF", params.getParameter<int> ("MUF") );}
+    }
 
 
     if ( params.exists("cutsToIgnore") )
@@ -202,7 +235,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
     indexNConstituents_ = index_type (&bits_, "nConstituents");
     indexNEF_ = index_type (&bits_, "NEF");
     indexNHF_ = index_type (&bits_, "NHF");
-    if(version_ != WINTER17 || quality_ != TIGHT ) indexCEF_ = index_type (&bits_, "CEF");
+    if((version_ != WINTER17 && version_ != WINTER17PUPPI) || quality_ != TIGHT ) indexCEF_ = index_type (&bits_, "CEF");
 
     indexCHF_ = index_type (&bits_, "CHF");
     indexNCH_ = index_type (&bits_, "NCH");
@@ -225,8 +258,14 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
       indexNEF_FW_ = index_type (&bits_, "NEF_FW");
       indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
       if ( quality_ == TIGHTLEPVETO ) {indexMUF_ = index_type (&bits_, "MUF");}
-
-
+    }
+    if(version_ == WINTER17PUPPI){
+      indexNHF_EC_ = index_type (&bits_, "NHF_EC");
+      indexNHF_FW_ = index_type (&bits_, "NHF_FW");
+      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
+      indexNNeutrals_FW_L_ = index_type (&bits_, "nNeutrals_FW_L");
+      indexNNeutrals_FW_U_ = index_type (&bits_, "nNeutrals_FW_U");
+      if ( quality_ == TIGHTLEPVETO ) {indexMUF_ = index_type (&bits_, "MUF");}
     }
 
 
@@ -243,40 +282,51 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 
     push_back("CHF" );
     push_back("NHF" );
-    if(version_ != WINTER17 || quality_ != TIGHT ) push_back("CEF" );
+    if( (version_ != WINTER17 && version_!=WINTER17PUPPI) || quality_ != TIGHT ) push_back("CEF" );
     push_back("NEF" );
     push_back("NCH" );
     push_back("nConstituents");
-    if(version_ == RUNIISTARTUP){
+    if(version_ == RUNIISTARTUP ){
       push_back("NEF_FW");
       push_back("nNeutrals_FW");
     }
-    if(version_ == WINTER16){
+    if(version_ == WINTER16 ){
       push_back("NHF_EC");
       push_back("NEF_EC");
       push_back("nNeutrals_EC");
       push_back("NEF_FW");
       push_back("nNeutrals_FW");
     }
-    if(version_ == WINTER17){
+    if(version_ == WINTER17 ){
       push_back("NEF_EC_L");
       push_back("NEF_EC_U");
       push_back("nNeutrals_EC");
-      push_back("NHF_FW");
       push_back("NEF_FW");
+      push_back("NHF_FW");
       push_back("nNeutrals_FW");
-      if ( quality_ == TIGHTLEPVETO ) { push_back("MUF");}
+      if (quality_ == TIGHTLEPVETO) push_back("MUF");
     }
+    if(version_ == WINTER17PUPPI ){
+      push_back("NHF_EC");
+      push_back("NEF_FW");
+      push_back("NHF_FW");
+      push_back("nNeutrals_FW_L");
+      push_back("nNeutrals_FW_U");
+      if (quality_ == TIGHTLEPVETO) push_back("MUF");
+    }
+ 
 
-
-    if(version_ == WINTER17 && quality_ == LOOSE ){
+    if( (version_ == WINTER17 || version_ == WINTER17PUPPI) && quality_ == LOOSE ){
       edm::LogWarning("BadJetIDVersion") << "Winter17 JetID version does not support the LOOSE operating point -- defaulting to TIGHT";
       quality_ = TIGHT;
       }
-   if(version_ != WINTER17 && quality_ ==  TIGHTLEPVETO){
+
+   if( (version_ != WINTER17 && version_ != WINTER17PUPPI) && quality_ ==  TIGHTLEPVETO){
       edm::LogWarning("BadJetIDVersion") << "JetID version does not support the TIGHTLEPVETO operating point -- defaulting to TIGHT";
       quality_ = TIGHT;
       }
+ 
+
     // Set some default cuts for LOOSE, TIGHT
     if ( quality_ == LOOSE ) {
       set("CHF", 0.0);
@@ -298,13 +348,10 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
       }
 
 
-
-
-
     } else if ( quality_ == TIGHT ) {
       set("CHF", 0.0);
       set("NHF", 0.9);
-      if(version_ != WINTER17) set("CEF", 0.99);
+      if(version_ != WINTER17 && version_ != WINTER17PUPPI ) set("CEF", 0.99);
       set("NEF", 0.9);
       set("NCH", 0);
       set("nConstituents", 1);
@@ -327,8 +374,15 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 	set("NEF_FW",0.90);
 	set("nNeutrals_FW",10);
       }
+      if(version_ == WINTER17PUPPI){
+	set("NHF_EC",0.99);
+	set("NHF_FW",0.02);
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW_L",2);
+	set("nNeutrals_FW_U",15);
+      }
 
-    } else if ( quality_ == TIGHTLEPVETO ) {
+    }else if ( quality_ == TIGHTLEPVETO ) {
       set("CHF", 0.0);
       set("NHF", 0.9);
       set("CEF", 0.8);
@@ -344,16 +398,23 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 	set("nNeutrals_FW",10);
         set("MUF", 0.8);
       }
+      if(version_ == WINTER17PUPPI){
+	set("NHF_EC",0.99);
+	set("NHF_FW",0.02);
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW_L",2);
+	set("nNeutrals_FW_H",15);
+        set("MUF", 0.8);
+      }
 
     }
-
-
 
 
     indexNConstituents_ = index_type (&bits_, "nConstituents");
     indexNEF_ = index_type (&bits_, "NEF");
     indexNHF_ = index_type (&bits_, "NHF");
-    if(version_ != WINTER17 || quality_ != TIGHT ) indexCEF_ = index_type (&bits_, "CEF");
+    if((version_ != WINTER17 && version_ != WINTER17PUPPI) || quality_ != TIGHT ) indexCEF_ = index_type (&bits_, "CEF");
+
     indexCHF_ = index_type (&bits_, "CHF");
     indexNCH_ = index_type (&bits_, "NCH");
     if(version_ == RUNIISTARTUP){
@@ -368,15 +429,23 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
       indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
     }
     if(version_ == WINTER17){
-
       indexNEF_EC_L_ = index_type (&bits_, "NEF_EC_L");
       indexNEF_EC_U_ = index_type (&bits_, "NEF_EC_U");
       indexNNeutrals_EC_ = index_type (&bits_, "nNeutrals_EC");
       indexNHF_FW_ = index_type (&bits_, "NHF_FW");
       indexNEF_FW_ = index_type (&bits_, "NEF_FW");
       indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
-      if ( quality_ == TIGHTLEPVETO ) { indexMUF_ = index_type (&bits_, "MUF"); }
+      if ( quality_ == TIGHTLEPVETO ) {indexMUF_ = index_type (&bits_, "MUF");}
     }
+    if(version_ == WINTER17PUPPI){
+      indexNHF_EC_ = index_type (&bits_, "NHF_EC");
+      indexNHF_FW_ = index_type (&bits_, "NHF_FW");
+      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
+      indexNNeutrals_FW_L_ = index_type (&bits_, "nNeutrals_FW_L");
+      indexNNeutrals_FW_U_ = index_type (&bits_, "nNeutrals_FW_U");
+      if ( quality_ == TIGHTLEPVETO ) {indexMUF_ = index_type (&bits_, "MUF");}
+    }
+
 
 
     retInternal_ = getBitTemplate();
@@ -388,7 +457,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
   //
   bool operator()( const pat::Jet & jet, pat::strbitset & ret ) override
   {
-    if ( version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17) {
+    if ( version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 || version_ == WINTER17PUPPI) {
       if ( jet.currentJECLevel() == "Uncorrected" || !jet.jecSetsAvailable() )
 	return firstDataCuts( jet, ret, version_);
       else
@@ -406,7 +475,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
   //
   bool operator()( const reco::PFJet & jet, pat::strbitset & ret )
   {
-    if ( version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17  ){ return firstDataCuts( jet, ret, version_);
+    if ( version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 || version_ == WINTER17PUPPI  ){ return firstDataCuts( jet, ret, version_);
     }
     else {
       return false;
@@ -552,7 +621,12 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 
 
    // Cuts for |eta| < 2.4 for FIRSTDATA, RUNIISTARTUP, WINTER16 and WINTER17
+<<<<<<< HEAD
     if(version_ != WINTER17 ||  quality_ != TIGHT ) {if ( ignoreCut(indexCEF_)           || ( cef < cut(indexCEF_, double()) || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexCEF_);}
+=======
+    if((version_ != WINTER17 && version_ != WINTER17PUPPI) ||  quality_ != TIGHT ) {if ( ignoreCut(indexCEF_)           || ( cef < cut(indexCEF_, double()) || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexCEF_);}
+
+>>>>>>> ed8ce8b98f8... implement PUPPI jet iD
     if ( ignoreCut(indexCHF_)           || ( chf > cut(indexCHF_, double()) || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexCHF_);
     if ( ignoreCut(indexNCH_)           || ( nch > cut(indexNCH_, int())    || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexNCH_);
 
@@ -603,6 +677,24 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
       if ( ignoreCut(indexNNeutrals_FW_) || ( nneutrals > cut(indexNNeutrals_FW_, int())    || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNNeutrals_FW_);
 
     }
+    else if(version_ == WINTER17PUPPI){
+      // Cuts for |eta| <= 2.7 for WINTER17 scenario
+      if ( ignoreCut(indexNConstituents_) || ( nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNConstituents_);
+      if ( ignoreCut(indexNEF_)           || ( nef < cut(indexNEF_, double())  || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNEF_);
+      if ( ignoreCut(indexNHF_)           || ( nhf < cut(indexNHF_, double())  || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNHF_);
+      if ( quality_ == TIGHTLEPVETO ) {if ( ignoreCut(indexMUF_)           || ( muf < cut(indexMUF_, double()) || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexMUF_);}
+
+      // Cuts for 2.7 < |eta| <= 3.0 for WINTER17 scenario
+
+      if ( ignoreCut(indexNHF_EC_)        || ( nhf < cut(indexNHF_EC_, double())  || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0)  ) passCut( ret, indexNHF_EC_);
+
+      // Cuts for |eta| > 3.0 for WINTER17 scenario
+      if ( ignoreCut(indexNHF_FW_)           || ( nhf > cut(indexNHF_FW_, double()) || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNHF_FW_);
+      if ( ignoreCut(indexNEF_FW_)           || ( nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNEF_FW_);
+      if ( ignoreCut(indexNNeutrals_FW_L_) || ( nneutrals > cut(indexNNeutrals_FW_L_, int())    || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNNeutrals_FW_L_);
+      if ( ignoreCut(indexNNeutrals_FW_U_) || ( nneutrals < cut(indexNNeutrals_FW_U_, int())    || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNNeutrals_FW_U_);
+
+    }
 
     //std::cout << "<PFJetIDSelectionFunctor::firstDataCuts>:" << std::endl;
     //std::cout << " jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << std::endl;
@@ -628,6 +720,8 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
   index_type indexNHF_FW_;
   index_type indexNEF_FW_;
   index_type indexNNeutrals_FW_;
+  index_type indexNNeutrals_FW_L_;
+  index_type indexNNeutrals_FW_U_;
 
   index_type indexNHF_EC_;
   index_type indexNEF_EC_;

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -621,12 +621,8 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 
 
    // Cuts for |eta| < 2.4 for FIRSTDATA, RUNIISTARTUP, WINTER16 and WINTER17
-<<<<<<< HEAD
-    if(version_ != WINTER17 ||  quality_ != TIGHT ) {if ( ignoreCut(indexCEF_)           || ( cef < cut(indexCEF_, double()) || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexCEF_);}
-=======
     if((version_ != WINTER17 && version_ != WINTER17PUPPI) ||  quality_ != TIGHT ) {if ( ignoreCut(indexCEF_)           || ( cef < cut(indexCEF_, double()) || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexCEF_);}
 
->>>>>>> ed8ce8b98f8... implement PUPPI jet iD
     if ( ignoreCut(indexCHF_)           || ( chf > cut(indexCHF_, double()) || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexCHF_);
     if ( ignoreCut(indexNCH_)           || ( nch > cut(indexNCH_, int())    || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexNCH_);
 


### PR DESCRIPTION
Without #23120 in 94X, DQM validation shows large inefficiencies for PUPPI jets in the forward region in JetMET/Jet/CleanedslimmedJetsPuppi/JetIDPassFractionVSeta which have shown up in the  9_4_9_cand1 validation.
Is this right branch for this fix?