### PR TITLE
adding displacedStandAlone muon collection to miniaod

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -80,7 +80,7 @@ MicroEventContent = cms.PSet(
         # CTPPS
         'keep CTPPSLocalTrackLites_ctppsLocalTrackLiteProducer_*_*',
 	# displacedStandAlone muon collection for EXO
-	'keep recoTracks_displacedStandAloneMuons_*_*',
+	'keep recoTracks_displacedStandAloneMuons__*',
     )
 )
 

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -78,7 +78,9 @@ MicroEventContent = cms.PSet(
         # Lumi
         'keep LumiScalerss_scalersRawToDigi_*_*',
         # CTPPS
-        'keep CTPPSLocalTrackLites_ctppsLocalTrackLiteProducer_*_*'
+        'keep CTPPSLocalTrackLites_ctppsLocalTrackLiteProducer_*_*',
+	# displacedStandAlone muon collection for EXO
+	'keep recoTracks_displacedStandAloneMuons_*_*',
     )
 )
 


### PR DESCRIPTION
following our request of the xpog meeting of May 28 by @dehuazhu and the approval by the conveners @arizzi and @gpetruc of June 8 (https://hypernews.cern.ch/HyperNews/CMS/get/exotica-longlived/532/2.html)  we submit our pull request to include the 'displacedStandAlone' muon collection
in the miniaod

a heads-up: we’re not entirely sure, that this is the only file that needs to be changed

riccardo manzoni, vinzenz stampf, dehua zhu