### PR TITLE
Fix DDLVector problem with boost 1.67

### DIFF
--- a/DetectorDescription/Core/interface/DDConstant.h
+++ b/DetectorDescription/Core/interface/DDConstant.h
@@ -8,6 +8,7 @@
 #include "DetectorDescription/Core/interface/DDName.h"
 
 class DDConstant;
+class ClhepEvaluator;
 
 //! output operator for printing ...
 std::ostream & operator<<(std::ostream & o, const DDConstant & cons);
@@ -26,7 +27,7 @@ public:
    DDConstant(const DDName & name, double* value);
    
    //! creates all DDConstants from the variables of the ClhepEvaluator
-   static void createConstantsFromEvaluator();
+   static void createConstantsFromEvaluator(ClhepEvaluator&);
       
    //! return the first stored value; does not check boundaries!
    double value() const { return rep(); }

--- a/DetectorDescription/Core/src/DDConstant.cc
+++ b/DetectorDescription/Core/src/DDConstant.cc
@@ -37,9 +37,8 @@ std::ostream & operator<<(std::ostream & os, const DDConstant & cons)
 }
 
 void
-DDConstant::createConstantsFromEvaluator( void )
+DDConstant::createConstantsFromEvaluator( ClhepEvaluator& eval )
 {
-  auto& eval = DDI::Singleton<ClhepEvaluator>::instance();
   const auto& vars = eval.variables();
   const auto& vals = eval.values();
   if( vars.size() != vals.size()) {

--- a/DetectorDescription/Core/src/StoresInstantiation.cc
+++ b/DetectorDescription/Core/src/StoresInstantiation.cc
@@ -11,7 +11,6 @@
 #include "DetectorDescription/Core/src/Material.h"
 #include "DetectorDescription/Core/src/Solid.h"
 #include "DetectorDescription/Core/src/Specific.h"
-#include "DetectorDescription/Core/interface/ClhepEvaluator.h"
 
 #include <map>
 #include <string>
@@ -19,7 +18,6 @@
 #include <vector>
 
 template class DDI::Singleton<AxesNames>;
-template class DDI::Singleton<ClhepEvaluator>;
 template class DDI::Singleton<DDRoot>;
 template class DDI::Singleton<DDI::Store<DDName, std::vector<std::string>* > >;
 template class DDI::Singleton<DDI::Store<DDName, std::string* > >;

--- a/DetectorDescription/Parser/interface/DDLElementRegistry.h
+++ b/DetectorDescription/Parser/interface/DDLElementRegistry.h
@@ -49,7 +49,4 @@ class DDLElementRegistry
   RegistryMap registry_;
 };
 
-///This is only here because of the boost::spirit::parser stuff of DDLMap needing to be re-designed.
-typedef DDI::Singleton<DDLElementRegistry> DDLGlobalRegistry;
-
 #endif

--- a/DetectorDescription/Parser/interface/DDLElementRegistry.h
+++ b/DetectorDescription/Parser/interface/DDLElementRegistry.h
@@ -1,8 +1,6 @@
 #ifndef DETECTOR_DESCRIPTION_PARSER_DDL_ELEMENT_REGISTRY_H
 #define DETECTOR_DESCRIPTION_PARSER_DDL_ELEMENT_REGISTRY_H
 
-#include "DetectorDescription/Core/interface/Singleton.h"
-#include "DetectorDescription/Core/interface/Singleton.icc"
 #include "DetectorDescription/Core/interface/ClhepEvaluator.h"
 
 #include <CLHEP/Evaluator/Evaluator.h>
@@ -43,10 +41,11 @@ class DDLElementRegistry
    */
   std::shared_ptr<DDXMLElement> getElement(const std::string& name); 
 
-  ClhepEvaluator &evaluator() { return DDI::Singleton<ClhepEvaluator>::instance(); }
+  ClhepEvaluator &evaluator() { return evaluator_; }
 
  private:
   RegistryMap registry_;
+  ClhepEvaluator evaluator_;
 };
 
 #endif

--- a/DetectorDescription/Parser/interface/DDLParser.h
+++ b/DetectorDescription/Parser/interface/DDLParser.h
@@ -19,6 +19,7 @@
 
 class DDCompactView;
 class DDLDocumentProvider;
+class DDLElementRegistry;
 
 /// DDLParser is the main class of Detector Description Language Parser.
 /** @class DDLParser
@@ -149,7 +150,8 @@ class DDLParser
 
   /// SAX2XMLReader is one way of parsing.
   SAX2XMLReader* SAX2Parser_;
-  
+
+  DDLElementRegistry* elementRegistry_;
   DDLSAX2FileHandler* fileHandler_;
   DDLSAX2ExpressionHandler* expHandler_;
   DDLSAX2Handler* errHandler_;

--- a/DetectorDescription/Parser/interface/DDLSAX2ExpressionHandler.h
+++ b/DetectorDescription/Parser/interface/DDLSAX2ExpressionHandler.h
@@ -8,6 +8,7 @@
 #include "DetectorDescription/Parser/interface/DDLSAX2Handler.h"
 
 class DDCompactView;
+class DDLElementRegistry;
 
 /// DDLSAX2ExpressionHandler is the first pass SAX2 Handler for XML files found in the configuration file.
 /** @class DDLSAX2ExpressionHandler
@@ -25,7 +26,7 @@ class DDLSAX2ExpressionHandler : public DDLSAX2FileHandler
 {
  public:
 
-  DDLSAX2ExpressionHandler(DDCompactView& cpv);
+  DDLSAX2ExpressionHandler(DDCompactView& cpv, DDLElementRegistry&);
   ~DDLSAX2ExpressionHandler() override;
 
   void startElement( const XMLCh* uri, const XMLCh* localname,

--- a/DetectorDescription/Parser/interface/DDLSAX2FileHandler.h
+++ b/DetectorDescription/Parser/interface/DDLSAX2FileHandler.h
@@ -52,6 +52,9 @@ class DDLSAX2FileHandler : public DDLSAX2Handler
   void characters( const XMLCh* chars, XMLSize_t length) override;
   void comment( const XMLCh* chars, XMLSize_t length ) override;
 
+  //! creates all DDConstant from the evaluator which has been already 'filled' in the first scan of the documents
+  void createDDConstants() const; 
+
  protected:
   DDLElementRegistry& registry() { return registry_; }
  private:
@@ -59,8 +62,6 @@ class DDLSAX2FileHandler : public DDLSAX2Handler
   virtual const std::string& self() const;
   
  private:
-  //! creates all DDConstant from the evaluator which has been already 'filled' in the first scan of the documents
-  void createDDConstants() const; 
 
   std::vector< std::string > namesMap_;
   std::vector< size_t > names_;

--- a/DetectorDescription/Parser/interface/DDLSAX2FileHandler.h
+++ b/DetectorDescription/Parser/interface/DDLSAX2FileHandler.h
@@ -13,6 +13,7 @@
 #include "DetectorDescription/Parser/interface/DDLSAX2Handler.h"
 
 class DDCompactView;
+class DDLElementRegistry;
 
 /// DDLSAX2FileHandler is the SAX2 Handler for XML files found in the configuration file.
 /** @class DDLSAX2FileHandler
@@ -35,7 +36,7 @@ class DDLSAX2FileHandler : public DDLSAX2Handler
 {
  public:
   
-  DDLSAX2FileHandler( DDCompactView& cpv );
+  DDLSAX2FileHandler( DDCompactView& cpv, DDLElementRegistry& );
   ~DDLSAX2FileHandler() override;
 
   void init() ;
@@ -50,7 +51,9 @@ class DDLSAX2FileHandler : public DDLSAX2Handler
 		   const XMLCh* qname) override;
   void characters( const XMLCh* chars, XMLSize_t length) override;
   void comment( const XMLCh* chars, XMLSize_t length ) override;
-  
+
+ protected:
+  DDLElementRegistry& registry() { return registry_; }
  private:
   virtual const std::string& parent() const;
   virtual const std::string& self() const;
@@ -62,6 +65,7 @@ class DDLSAX2FileHandler : public DDLSAX2Handler
   std::vector< std::string > namesMap_;
   std::vector< size_t > names_;
   DDCompactView& cpv_;
+  DDLElementRegistry& registry_;
 };
 
 #endif

--- a/DetectorDescription/Parser/src/DDLElementRegistry.cc
+++ b/DetectorDescription/Parser/src/DDLElementRegistry.cc
@@ -1,4 +1,3 @@
-#include "DetectorDescription/Core/interface/Singleton.h"
 #include "DetectorDescription/Parser/interface/DDLElementRegistry.h"
 #include "DetectorDescription/Parser/src/DDLAlgorithm.h"
 #include "DetectorDescription/Parser/src/DDLBooleanSolid.h"
@@ -191,4 +190,3 @@ DDLElementRegistry::getElement( const std::string& name )
   return myret;
 }
 
-template class DDI::Singleton<DDLElementRegistry>;

--- a/DetectorDescription/Parser/src/DDLMap.cc
+++ b/DetectorDescription/Parser/src/DDLMap.cc
@@ -2,10 +2,54 @@
 #include "DetectorDescription/Core/interface/ClhepEvaluator.h"
 #include "DetectorDescription/Parser/interface/DDLElementRegistry.h"
 
+// Boost parser, spirit, for parsing the std::vector elements.
+#include "boost/spirit/home/classic/core/non_terminal/grammar.hpp"
+#include "boost/spirit/include/classic.hpp"
+
 #include <cstddef>
 #include <utility>
 
 class DDCompactView;
+
+class MapPair {
+public:
+  MapPair(DDLMap* iMap):map_{iMap} { };
+  void operator()(char const* str, char const* end) const;
+private:
+  DDLMap* map_;
+};
+
+class MapMakeName {
+public:
+  MapMakeName(DDLMap* iMap):map_{iMap} { };
+  void operator()(char const* str, char const* end) const;
+private:
+  DDLMap* map_;
+};
+
+class MapMakeDouble {
+public:
+  MapMakeDouble(DDLMap* iMap): map_{iMap} { };
+  void operator()(char const* str, char const* end) const;
+private:
+  DDLMap* map_;
+};
+
+class Mapper : public boost::spirit::classic::grammar<Mapper> {
+public:
+  Mapper(DDLMap* iMap):map_{iMap} { };
+  template <typename ScannerT> struct definition;
+
+  MapPair mapPair() const { return MapPair(map_); }
+  MapMakeName mapMakeName() const { return MapMakeName(map_); }
+  MapMakeDouble mapMakeDouble() const { return MapMakeDouble(map_); }
+
+private:
+  DDLMap* map_;
+};
+
+
+namespace boost { namespace spirit { namespace classic {} } }
 
 using namespace boost::spirit::classic;
 
@@ -18,8 +62,8 @@ template <typename ScannerT> struct Mapper::definition
   definition(Mapper const& self)
     {
       mapSet
-	=   ppair[MapPair()]
-	>> *((',' >> ppair)[MapPair()])
+	=   ppair[self.mapPair()]
+	>> *((',' >> ppair)[self.mapPair()])
 	;
       
       ppair
@@ -28,11 +72,11 @@ template <typename ScannerT> struct Mapper::definition
 	;
       
       name
-	=   (alpha_p >> *alnum_p)[MapMakeName()]
+	=   (alpha_p >> *alnum_p)[self.mapMakeName()]
 	;
       
       value
-	=   (+(anychar_p - ','))[MapMakeDouble()]
+	=   (+(anychar_p - ','))[self.mapMakeDouble()]
 	;     
     }
 
@@ -45,22 +89,19 @@ template <typename ScannerT> struct Mapper::definition
 void
 MapPair::operator() (char const* str, char const* end) const
 { 
-  std::shared_ptr<DDLMap> myDDLMap = std::static_pointer_cast<DDLMap>(DDLGlobalRegistry::instance().getElement("Map"));
-  myDDLMap->do_pair(str, end);
+  map_->do_pair(str, end);
 }
 
 void
 MapMakeName::operator() (char const* str, char const* end) const
 {
-  std::shared_ptr<DDLMap> myDDLMap = std::static_pointer_cast<DDLMap>(DDLGlobalRegistry::instance().getElement("Map"));
-  myDDLMap->do_makeName(str, end);
+  map_->do_makeName(str, end);
 }
 
 void
 MapMakeDouble::operator() (char const* str, char const* end)const
 {
-  std::shared_ptr<DDLMap> myDDLMap = std::static_pointer_cast<DDLMap>(DDLGlobalRegistry::instance().getElement("Map"));
-  myDDLMap->do_makeDouble(str, end);
+  map_->do_makeDouble(str, end);
 }
 
 void
@@ -91,7 +132,7 @@ DDLMap::processElement( const std::string& name, const std::string& nmspace, DDC
     errorOut("Map of type std::string is not supported yet.");
   }
 
-  Mapper mapGrammar;
+  Mapper mapGrammar{this};
   
   pMap.clear();
 

--- a/DetectorDescription/Parser/src/DDLMap.h
+++ b/DetectorDescription/Parser/src/DDLMap.h
@@ -8,43 +8,13 @@
 #include "DetectorDescription/Core/interface/DDReadMapType.h"
 #include "DetectorDescription/Core/interface/DDMap.h"
 #include "DetectorDescription/Parser/src/DDXMLElement.h"
-#include "boost/spirit/home/classic/core/non_terminal/grammar.hpp"
-// Boost parser, spirit, for parsing the std::vector elements.
-#include "boost/spirit/include/classic.hpp"
-#include "boost/thread/pthread/once_atomic.hpp"
 
 class DDCompactView;
 class DDLElementRegistry;
 
-namespace boost { namespace spirit { namespace classic { } } }
-
-class Mapper : public boost::spirit::classic::grammar<Mapper> {
-public:
-  Mapper() { };
-  ~Mapper() { };
-  template <typename ScannerT> struct definition;
-};
-
-class MapPair {
-public:
-  MapPair() { };
-  ~MapPair() { };
-  void operator()(char const* str, char const* end) const;
-};
-
-class MapMakeName {
-public:
-  MapMakeName() { };
-  ~MapMakeName() { };
-  void operator()(char const* str, char const* end) const;
-};
-
-class MapMakeDouble {
-public:
-  MapMakeDouble() { };
-  ~MapMakeDouble() { };
-  void operator()(char const* str, char const* end) const;
-};
+class MapPair;
+class MapMakeName;
+class MapMakeDouble;
 
 ///  DDLMap handles Map container.
 /** @class DDLMap

--- a/DetectorDescription/Parser/src/DDLParser.cc
+++ b/DetectorDescription/Parser/src/DDLParser.cc
@@ -28,9 +28,10 @@ DDLParser::DDLParser( DDCompactView& cpv )
   
   SAX2Parser_->setFeature(XMLUni::fgSAX2CoreValidation, false);   // optional
   SAX2Parser_->setFeature(XMLUni::fgSAX2CoreNameSpaces, false);   // optional
-  
-  expHandler_  = new DDLSAX2ExpressionHandler(cpv);
-  fileHandler_ = new DDLSAX2FileHandler(cpv);
+
+  elementRegistry_ = new DDLElementRegistry();
+  expHandler_  = new DDLSAX2ExpressionHandler(cpv, *elementRegistry_);
+  fileHandler_ = new DDLSAX2FileHandler(cpv, *elementRegistry_);
   errHandler_  = new DDLSAX2Handler();
   SAX2Parser_->setErrorHandler(errHandler_); 
   SAX2Parser_->setContentHandler(fileHandler_); 
@@ -43,6 +44,7 @@ DDLParser::~DDLParser( void )
   delete expHandler_;
   delete fileHandler_;
   delete errHandler_;
+  delete elementRegistry_;
   cms::concurrency::xercesTerminate();
 }
 

--- a/DetectorDescription/Parser/src/DDLParser.cc
+++ b/DetectorDescription/Parser/src/DDLParser.cc
@@ -119,7 +119,7 @@ DDLParser::parseOneFile( const std::string& fullname )
 
     LogDebug ("DDLParser") << "ParseOneFile() Parsing: " << fileNames_[fIndex].second << std::endl;
     parseFile( fIndex );
-
+    expHandler_->createDDConstants();
     // PASS 2:
 
     SAX2Parser_->setContentHandler(fileHandler_);
@@ -141,6 +141,8 @@ DDLParser::parse( const std::vector<unsigned char>& ablob, unsigned int bsize )
   char* dummy(nullptr);
   MemBufInputSource  mbis( &*ablob.begin(), bsize, dummy );
   SAX2Parser_->parse(mbis);
+  expHandler_->createDDConstants();
+  
 }
 
 int
@@ -202,6 +204,7 @@ DDLParser::parse( const DDLDocumentProvider& dp )
       parseFile(i);
     }
   }
+  expHandler_->createDDConstants();
 
   // PASS 2:
 

--- a/DetectorDescription/Parser/src/DDLSAX2ExpressionHandler.cc
+++ b/DetectorDescription/Parser/src/DDLSAX2ExpressionHandler.cc
@@ -10,8 +10,8 @@ using namespace cms::xerces;
 
 class DDCompactView;
 
-DDLSAX2ExpressionHandler::DDLSAX2ExpressionHandler( DDCompactView& cpv )
-  : DDLSAX2FileHandler::DDLSAX2FileHandler( cpv )
+DDLSAX2ExpressionHandler::DDLSAX2ExpressionHandler( DDCompactView& cpv, DDLElementRegistry& reg )
+  : DDLSAX2FileHandler::DDLSAX2FileHandler( cpv,reg )
 {}
 
 DDLSAX2ExpressionHandler::~DDLSAX2ExpressionHandler( void )
@@ -30,7 +30,7 @@ DDLSAX2ExpressionHandler::startElement( const XMLCh* const uri,
   {
     std::string varName = toString( attrs.getValue( uStr( "name" ).ptr()));
     std::string varValue = toString( attrs.getValue( uStr( "value" ).ptr()));
-    ClhepEvaluator & ev = DDLGlobalRegistry::instance().evaluator();
+    ClhepEvaluator & ev = registry().evaluator();
     ev.set(nmspace_, varName, varValue);
   }
 }

--- a/DetectorDescription/Parser/src/DDLSAX2FileHandler.cc
+++ b/DetectorDescription/Parser/src/DDLSAX2FileHandler.cc
@@ -10,8 +10,8 @@ class DDCompactView;
 
 // XERCES_CPP_NAMESPACE_USE 
 
-DDLSAX2FileHandler::DDLSAX2FileHandler( DDCompactView & cpv )
-  : cpv_(cpv)
+DDLSAX2FileHandler::DDLSAX2FileHandler( DDCompactView & cpv, DDLElementRegistry& reg )
+  : cpv_(cpv), registry_{reg}
 {
   init();
 }
@@ -46,7 +46,7 @@ DDLSAX2FileHandler::startElement( const XMLCh* const uri,
     names_.emplace_back(namesMap_.size() - 1);
   }
 
-  auto myElement = DDLGlobalRegistry::instance().getElement(myElementName);
+  auto myElement = registry_.getElement(myElementName);
 
   unsigned int numAtts = attrs.getLength();
   std::vector<std::string> attrNames, attrValues;
@@ -70,7 +70,7 @@ DDLSAX2FileHandler::endElement( const XMLCh* const uri,
   std::string ts(cStr(qname).ptr());
   const std::string&  myElementName = self();
 
-  auto myElement = DDLGlobalRegistry::instance().getElement(myElementName);
+  auto myElement = registry_.getElement(myElementName);
 
   std::string nmspace = nmspace_;
   // The need for processElement to have the nmspace so that it can 
@@ -98,7 +98,7 @@ void
 DDLSAX2FileHandler::characters( const XMLCh* const chars,
 				const XMLSize_t length )
 {
-  auto myElement = DDLGlobalRegistry::instance().getElement(self());
+  auto myElement = registry_.getElement(self());
   std::string inString = "";
   for (XMLSize_t i = 0; i < length; ++i)
   {

--- a/DetectorDescription/Parser/src/DDLSAX2FileHandler.cc
+++ b/DetectorDescription/Parser/src/DDLSAX2FileHandler.cc
@@ -19,7 +19,6 @@ DDLSAX2FileHandler::DDLSAX2FileHandler( DDCompactView & cpv, DDLElementRegistry&
 void
 DDLSAX2FileHandler::init()
 {
-  createDDConstants();
   namesMap_.emplace_back("*** root ***");
   names_.emplace_back(namesMap_.size() - 1);
 }

--- a/DetectorDescription/Parser/src/DDLSAX2FileHandler.cc
+++ b/DetectorDescription/Parser/src/DDLSAX2FileHandler.cc
@@ -119,7 +119,7 @@ DDLSAX2FileHandler::comment( const XMLCh* const chars,
 void
 DDLSAX2FileHandler::createDDConstants( void ) const
 {
-  DDConstant::createConstantsFromEvaluator();
+  DDConstant::createConstantsFromEvaluator(registry_.evaluator());
 }
 
 const std::string&

--- a/DetectorDescription/Parser/src/DDLVector.cc
+++ b/DetectorDescription/Parser/src/DDLVector.cc
@@ -13,39 +13,9 @@
 
 class DDCompactView;
 
-class VectorMakeDouble
-{
-public:
-  void operator() (char const* str, char const* end) const
-    {
-      ddlVector_->do_makeDouble(str, end);
-    }
-  
-  VectorMakeDouble() {
-    ddlVector_ = std::static_pointer_cast<DDLVector>(DDLGlobalRegistry::instance().getElement("Vector"));
-  }
-private: 
-  std::shared_ptr<DDLVector> ddlVector_;
-};
-
-class VectorMakeString
-{
-public:
-  void operator() (char const* str, char const* end) const
-    {
-      ddlVector_->do_makeString(str, end);
-    }
-  
-  VectorMakeString() {
-    ddlVector_ = std::static_pointer_cast<DDLVector>(DDLGlobalRegistry::instance().getElement("Vector"));
-  }
-private:
-  std::shared_ptr<DDLVector> ddlVector_;
-};
-
 namespace {
 template<typename F>
-void parse(char const* str, F& f) {
+void parse(char const* str, F&& f) {
 
   auto ptr = str;
 
@@ -80,18 +50,20 @@ void parse(char const* str, F& f) {
 
 
 bool
-DDLVector::parse_numbers(char const* str) const
+DDLVector::parse_numbers(char const* str)
 {
-  static VectorMakeDouble makeDouble;
-  parse(str, makeDouble);
+  parse(str, [this](char const* st, char const* end) {
+      do_makeDouble(st, end);
+    });
   return true;
 }
 
 bool
-DDLVector::parse_strings(char const* str) const
+DDLVector::parse_strings(char const* str)
 {
-  static VectorMakeString makeString;
-  parse(str,makeString);
+  parse(str,[this](char const* st, char const* end) {
+      do_makeString(st,end);
+    });
   return true;
 }
 

--- a/DetectorDescription/Parser/src/DDLVector.h
+++ b/DetectorDescription/Parser/src/DDLVector.h
@@ -12,8 +12,6 @@
 
 class DDCompactView;
 class DDLElementRegistry;
-class VectorMakeDouble;
-class VectorMakeString;
 
 ///  DDLVector handles Rotation and ReflectionRotation elements.
 /** @class DDLVector
@@ -30,9 +28,6 @@ class VectorMakeString;
  */
 class DDLVector final : public DDXMLElement
 {
-
-  friend class VectorMakeDouble;
-  friend class VectorMakeString;
 
  public:
 
@@ -54,8 +49,8 @@ class DDLVector final : public DDXMLElement
   void errorOut(const char* str) const;
   void do_makeDouble(char const* str, char const* end);
   void do_makeString(char const* str, char const* end);
-  bool parse_numbers(char const* str) const;
-  bool parse_strings(char const* str) const;
+  bool parse_numbers(char const* str);
+  bool parse_strings(char const* str);
 };
 
 #endif

--- a/DetectorDescription/RegressionTest/src/build.cc
+++ b/DetectorDescription/RegressionTest/src/build.cc
@@ -15,7 +15,6 @@
 #include "DetectorDescription/Core/interface/DDRoot.h"
 #include "DetectorDescription/Core/interface/DDSolid.h"
 #include "DetectorDescription/Core/interface/DDTransform.h"
-#include "DetectorDescription/Core/interface/ClhepEvaluator.h"
 #include "DetectorDescription/Parser/interface/DDLParser.h"
 #include "DetectorDescription/Parser/interface/FIPConfiguration.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -38,8 +37,7 @@ File elements.xml:
   Material(elem) Nitrogen
   Material(elem) Oxygen  
 */
-void regressionTest_setup() {
-   ClhepEvaluator & eval = DDI::Singleton<ClhepEvaluator>::instance();
+void regressionTest_setup(ClhepEvaluator& eval) {
    
    string ns = "setup"; // current namespace faking the filename 'setup.xml'
    
@@ -112,7 +110,7 @@ void regressionTest_setup() {
   File: first.xml
   
 */ 
-void regressionTest_first( ) {
+void regressionTest_first(ClhepEvaluator& eval ) {
   ///load the new cpv
   DDCompactView cpv;
   cout << "main::initialize DDL parser" << endl;
@@ -120,7 +118,6 @@ void regressionTest_first( ) {
   
   cout << "main::about to set configuration" << endl;
   
-  ClhepEvaluator & eval = DDI::Singleton<ClhepEvaluator>::instance();
   string ns("first");
   DDSolid support = DDSolidFactory::box(DDName("support",ns),
 					eval.eval(ns,"[setup:corner]/4."),

--- a/DetectorDescription/RegressionTest/src/build.h
+++ b/DetectorDescription/RegressionTest/src/build.h
@@ -6,14 +6,16 @@
 // will define a small setup using not XML
 // but only DDCore-calls
 
+class ClhepEvaluator;
+
 // constants and world-volume
 /* world-volume is a box. It will be subdevided (conceptually) into
    8 corners. In each corner a test can be done. */   
 /* adding a global file name */
-void regressionTest_setup();
+void regressionTest_setup(ClhepEvaluator&);
 
 // s
-void regressionTest_first();
+void regressionTest_first(ClhepEvaluator&);
 void regressionTest_second();
 void regressionTest_third();
 void regressionTest_forth();

--- a/DetectorDescription/RegressionTest/test/const_dump.cpp
+++ b/DetectorDescription/RegressionTest/test/const_dump.cpp
@@ -61,7 +61,6 @@ int main(int argc, char *argv[])
     DDErrorDetection ed(cpv);
     ed.report( cpv, std::cout);
 
-    DDConstant::createConstantsFromEvaluator();  // DDConstants are not being created by anyone... it confuses me!
     DDConstant::iterator<DDConstant> cit(DDConstant::begin()), ced(DDConstant::end());
     for(; cit != ced; ++cit) {
       cout << *cit << endl;

--- a/DetectorDescription/RegressionTest/test/reg_ddcore.cpp
+++ b/DetectorDescription/RegressionTest/test/reg_ddcore.cpp
@@ -1,8 +1,10 @@
 #include "DetectorDescription/RegressionTest/src/build.h"
+#include "DetectorDescription/Core/interface/ClhepEvaluator.h"
 
 int main() {
- regressionTest_setup();
- regressionTest_first();
+ ClhepEvaluator eval;
+ regressionTest_setup(eval);
+ regressionTest_first(eval);
  output("nix");
  return 0;
 }

--- a/DetectorDescription/RegressionTest/test/tutorial.cc
+++ b/DetectorDescription/RegressionTest/test/tutorial.cc
@@ -368,7 +368,7 @@ void tutorial()
       
 	double dv = 0.;
 	try {
-	  dv = DDI::Singleton<ClhepEvaluator>::instance().eval("",v);
+	  dv = ClhepEvaluator().eval("",v);
 	}
 	catch (const cms::Exception & e) {
 	  dv = 0;


### PR DESCRIPTION
Boost 1.67 had a chance to boost::spirit::classic which broke the parser in DDLVector.