### PR TITLE
SiPixelDigitizer: Switch on Cluster Charge Re-weighting

### DIFF
--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -38,6 +38,7 @@ def _modifyPixelDigitizerForPhase1Pixel( digitizer ) :
 
 
 SiPixelSimBlock = cms.PSet(
+    UseReweighting = cms.bool(True),
     DoPixelAging = cms.bool(False),
     ReadoutNoiseInElec = cms.double(350.0),
     deltaProductionCut = cms.double(0.03),

--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -35,10 +35,11 @@ def _modifyPixelDigitizerForPhase1Pixel( digitizer ) :
     digitizer.ElectronsPerVcal_L1        = cms.double(50)   # L1:   49.6 +- 2.6
     digitizer.ElectronsPerVcal_Offset    = cms.double(-60)  # L2-4: -60 +- 130
     digitizer.ElectronsPerVcal_L1_Offset = cms.double(-670) # L1:   -670 +- 220
+    digitizer.UseReweighting = cms.bool(True)
 
 
 SiPixelSimBlock = cms.PSet(
-    UseReweighting = cms.bool(True),
+    UseReweighting = cms.bool(False),
     PrintClusters = cms.bool(False),
     PrintTemplates = cms.bool(False),
     DoPixelAging = cms.bool(False),

--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -39,6 +39,8 @@ def _modifyPixelDigitizerForPhase1Pixel( digitizer ) :
 
 SiPixelSimBlock = cms.PSet(
     UseReweighting = cms.bool(True),
+    PrintClusters = cms.bool(False),
+    PrintTemplates = cms.bool(False),
     DoPixelAging = cms.bool(False),
     ReadoutNoiseInElec = cms.double(350.0),
     deltaProductionCut = cms.double(0.03),

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -265,7 +265,7 @@ SiPixelDigitizerAlgorithm::SiPixelDigitizerAlgorithm(const edm::ParameterSet& co
 
   // Add pixel radiation damage for upgrade studies
   AddPixelAging(conf.getParameter<bool>("DoPixelAging")),
-  UseReweighting(conf.exists("UseReweighting")?conf.getParameter<bool>("UseReweighting"):false),
+  UseReweighting(conf.exists("UseReweighting")?conf.getParameter<bool>("UseReweighting"):true),
   PrintClusters(conf.exists("PrintClusters")?conf.getParameter<bool>("PrintClusters"):false),
   PrintTemplates(conf.exists("PrintTemplates")?conf.getParameter<bool>("PrintTemplates"):false),
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -265,9 +265,9 @@ SiPixelDigitizerAlgorithm::SiPixelDigitizerAlgorithm(const edm::ParameterSet& co
 
   // Add pixel radiation damage for upgrade studies
   AddPixelAging(conf.getParameter<bool>("DoPixelAging")),
-  UseReweighting(conf.exists("UseReweighting")?conf.getParameter<bool>("UseReweighting"):true),
-  PrintClusters(conf.exists("PrintClusters")?conf.getParameter<bool>("PrintClusters"):false),
-  PrintTemplates(conf.exists("PrintTemplates")?conf.getParameter<bool>("PrintTemplates"):false),
+  UseReweighting(conf.getParameter<bool>("UseReweighting")),
+  PrintClusters(conf.getParameter<bool>("PrintClusters")),
+  PrintTemplates(conf.getParameter<bool>("PrintTemplates")),
 
   // delta cutoff in MeV, has to be same as in OSCAR(0.030/cmsim=1.0 MeV
   //tMax(0.030), // In MeV.

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -2273,7 +2273,10 @@ bool SiPixelDigitizerAlgorithm::hitSignalReweight(const PSimHit& hit,
   if (UseReweighting == true){
     int ID1 = dbobject_num->getTemplateID(detID);
     int ID0 = dbobject_den->getTemplateID(detID);
-    //ierr = PixelTempRewgt2D(IDden, IDnum, pixrewgt);
+
+    if(ID0==ID1){
+      return false;
+    }
     ierr = PixelTempRewgt2D(ID0, ID1, pixrewgt);
   }
   else{

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -2295,10 +2295,15 @@ bool SiPixelDigitizerAlgorithm::hitSignalReweight(const PSimHit& hit,
     for(int col = 0; col < TYSIZE; ++col) {
       float charge = 0;
       charge = pixrewgt[row][col];
-      chargeAfter += charge;
-      if( (hitPixel.first + row - THX) >= 0 && (hitPixel.first + row - THX) < topol->nrows() && (hitPixel.second + col - THY) >= 0 && (hitPixel.second + col - THY) < topol->ncolumns() && charge > 0)
+      if( (hitPixel.first + row - THX) >= 0 && (hitPixel.first + row - THX) < topol->nrows() && (hitPixel.second + col - THY) >= 0 && (hitPixel.second + col - THY) < topol->ncolumns() && charge > 0){
+	chargeAfter += charge;
 	theSignal[PixelDigi::pixelToChannel(hitPixel.first + row - THX, hitPixel.second + col - THY)] += (makeDigiSimLinks_ ? Amplitude(charge , &hit, hitIndex, tofBin, charge) : Amplitude( charge, charge) )  ;
+      }
     }
+  }
+
+  if(chargeBefore!=0. && chargeAfter==0.){
+    return false;
   }
   
   if(PrintClusters){

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -2346,7 +2346,7 @@ int SiPixelDigitizerAlgorithm::PixelTempRewgt2D(int id_in, int id_rewgt, array_2
     cotalpha = track[3]/track[5]; //if track[5] (direction in z) is 0 the hit is not processed by re-weighting
     cotbeta = track[4]/track[5];
   } else {
-    LogWarning ("Pixel Digitizer") << "Reweighting angle is not good!" << std::endl;
+    LogDebug ("Pixel Digitizer") << "Reweighting angle is not good!" << std::endl;
     return 9; //returned value here indicates that no reweighting was done in this case
   }
 


### PR DESCRIPTION
The Cluster Charge Re-weighting, implemented in #22911 and #23583 and currently switched off per default, was tested internally. Hence we propose to switch the feature on by default.

Additionally, a printout was moved from _warning_ to _debug_ at a position we're dealing with unphysical SimHits.

Interested users/conveners: @tsusa @tvami @veszpv 