### PR TITLE
Disable hcalLaserEventFilter occupancy filter 

### DIFF
--- a/RecoMET/METFilters/python/hcalLaserEventFilter_cfi.py
+++ b/RecoMET/METFilters/python/hcalLaserEventFilter_cfi.py
@@ -10,7 +10,7 @@ hcalLaserEventFilter = hcallaserevent.clone(BadRunEventNumbers=cms.vuint32(badEv
 
 from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
 run2_HCAL_2018.toModify( hcalLaserEventFilter,
-                           vetoByHBHEOccupancy = cms.bool( False),
-                           minOccupiedHBHE = cms.uint32(8000)
+                           vetoByHBHEOccupancy=False,
+                           minOccupiedHBHE=8000,
                        )
 

--- a/RecoMET/METFilters/python/hcalLaserEventFilter_cfi.py
+++ b/RecoMET/METFilters/python/hcalLaserEventFilter_cfi.py
@@ -7,3 +7,10 @@ except:
     badEvents=[]
 
 hcalLaserEventFilter = hcallaserevent.clone(BadRunEventNumbers=cms.vuint32(badEvents) )
+
+from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+run2_HCAL_2018.toModify( hcalLaserEventFilter,
+                           vetoByHBHEOccupancy = cms.bool( False),
+                           minOccupiedHBHE = cms.uint32(8000)
+                       )
+


### PR DESCRIPTION
We found that the occupancy filter in the hcalLaserEventFilter is erroneously removing good events.  We think that increasing the threshold to 8000 would be sufficient, but we also simply disable it in favor of the LaserMon filter.  We use the eras to ensure that the settings are only updated for 2018 data.

@deguio @mariadalfonso