### PR TITLE
[muon] fixed compilation warning in DataFormats/MuonReco (ArbitrationType to unsigned int)

### DIFF
--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -179,6 +179,10 @@ namespace reco {
 
 
     /// define arbitration schemes
+    // WARNING: There can be not more than 7 arbritration types. If 
+    //          have more it will break the matching logic for types
+    //          defined in MuonSegmentMatch
+
     enum ArbitrationType { NoArbitration, SegmentArbitration, SegmentAndTrackArbitration, SegmentAndTrackArbitrationCleaned,
 			   RPCHitAndTrackArbitration, GEMSegmentAndTrackArbitration, ME0SegmentAndTrackArbitration };
     
@@ -234,7 +238,7 @@ namespace reco {
     /// number of chambers CSC or DT matches only (MuonChamberMatches include RPC rolls)
     int numberOfChambersCSCorDT() const;
     /// get number of chambers with matched segments
-    int numberOfMatches( ArbitrationType type = SegmentAndTrackArbitration ) const;
+    int numberOfMatches( unsigned int type = SegmentAndTrackArbitration ) const;
     /// get number of stations with matched segments
     /// just adds the bits returned by stationMask
     int numberOfMatchedStations( ArbitrationType type = SegmentAndTrackArbitration ) const;
@@ -244,7 +248,7 @@ namespace reco {
     /// get bit map of stations with matched segments
     /// bits 0-1-2-3 = DT stations 1-2-3-4
     /// bits 4-5-6-7 = CSC stations 1-2-3-4
-    unsigned int stationMask( ArbitrationType type = SegmentAndTrackArbitration ) const;
+    unsigned int stationMask( unsigned int type = SegmentAndTrackArbitration ) const;
     /// get bit map of stations with tracks within
     /// given distance (in cm) of chamber edges 
     /// bit assignments are same as above
@@ -334,12 +338,12 @@ namespace reco {
     const std::vector<const MuonChamberMatch*> chambers( int station, int muonSubdetId ) const;
     /// get pointers to best segment and corresponding chamber in vector of chambers
     std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> pair( const std::vector<const MuonChamberMatch*> &,
-									ArbitrationType type = SegmentAndTrackArbitration ) const;
+								     unsigned int type = SegmentAndTrackArbitration ) const;
     /// selector bitmap
     unsigned int selectors_;
    public:
      /// get number of segments
-     int numberOfSegments( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
+     int numberOfSegments( int station, int muonSubdetId, unsigned int type = SegmentAndTrackArbitration ) const;
      /// get deltas between (best) segment and track
      /// If no chamber or no segment returns 999999
      float dX       ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -60,7 +60,7 @@ int Muon::numberOfChambersCSCorDT() const
   return total;
 }
 
-int Muon::numberOfMatches( ArbitrationType type ) const
+int Muon::numberOfMatches( unsigned int type ) const
 {
    int matches(0);
    for( std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
@@ -152,7 +152,7 @@ unsigned int Muon::expectedNnumberOfMatchedStations( float minDistanceFromEdge )
   return n;
 }
 
-unsigned int Muon::stationMask( ArbitrationType type ) const
+unsigned int Muon::stationMask( unsigned int type ) const
 {
    unsigned int totMask(0);
    unsigned int curMask(0);
@@ -347,7 +347,7 @@ unsigned int Muon::stationGapMaskPull( float sigmaCut ) const
    return totMask;
 }
 
-int Muon::numberOfSegments( int station, int muonSubdetId, ArbitrationType type ) const
+int Muon::numberOfSegments( int station, int muonSubdetId, unsigned int type ) const
 {
    int segments(0);
    for( std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
@@ -404,7 +404,7 @@ const std::vector<const MuonChamberMatch*> Muon::chambers( int station, int muon
 }
 
 std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> Muon::pair( const std::vector<const MuonChamberMatch*> &chambers,
-     ArbitrationType type ) const
+     unsigned int type ) const
 {
    MuonChamberMatch* m = nullptr;
    MuonSegmentMatch* s = nullptr;


### PR DESCRIPTION
Addressed the issue https://github.com/cms-sw/cmssw/issues/23057. The warning raised the old design issue where a mix of basic arbitration types defined in MuonSegmentMatch and arbitration flags designed for end-users (Muon::ArbitrationType) were allowed to be used with the same interface. At the moment the only safe way to address the warning is to change the input type, which effectively doesn't change anything beside removing the warning. Long term we may want to address the issue more directly and forbid mixing arbitration types. This however requires a detailed validation, which is not wise to do so late in the release development cycle.