### PR TITLE
updated express GT for Event Display to v8

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -6,7 +6,7 @@ from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 # It should be kept in synch with Express processing at Tier0: what the url
 # https://cmsweb.cern.ch/t0wmadatasvc/prod/express_config
 # would tell you.
-GlobalTag.globaltag = "101X_dataRun2_Express_v7"
+GlobalTag.globaltag = "101X_dataRun2_Express_v8"
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.
 #       This needs a valid proxy to access the cern.ch network from the .cms one.


### PR DESCRIPTION
backport of #23607 
Express GT is updated to v8 for Event Display, as announced by AlCa/DB