### PR TITLE
Handle any trailing white space

### DIFF
--- a/CommonTools/Utils/src/MethodArgumentSetter.h
+++ b/CommonTools/Utils/src/MethodArgumentSetter.h
@@ -22,6 +22,11 @@ namespace reco {
       }
       void operator()(const char *begin, const char *end) const {
         assert(begin+1 <= end-1); // the quotes are included in [begin,end[ range.        
+        //in boost 1.67, the parser appends any extra white space to the
+        // end
+        if(*(end-1) != *begin) {
+          --end;
+        }
         stack_.push_back( AnyMethodArgument(std::string(begin+1,end-1)) );
       }
     private:

--- a/CommonTools/Utils/test/testCutParser.cc
+++ b/CommonTools/Utils/test/testCutParser.cc
@@ -187,6 +187,9 @@ void testCutParser::checkAll() {
   check("quality('goodIterative')", true);
   check("quality('looseSetWithPV')", false);
   check("quality('highPuritySetWithPV')", false);
+  check("quality('highPuritySetWithPV' )", false);
+  check("quality( 'highPuritySetWithPV')", false);
+  check("quality( 'highPuritySetWithPV' )", false);
 
   // check handling of errors 
   //   first those who are the same in lazy and non lazy parsing


### PR DESCRIPTION
In boost 1.67, the part of the parser which finds enum values
is being passed any trailing white spaces that follow the enum.
We now explicitly remove any extra characters.