### PR TITLE
Monitoring of SiPixelQuality PCL using tracker offline DQM and bugfix for the SiPixelQuality tag for PromptReco

### DIFF
--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
@@ -180,8 +180,7 @@ void SiPixelStatusHarvester::endRunProduce(edm::Run& iRun, const edm::EventSetup
     std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t> fedError25IOV;
     std::map<edm::LuminosityBlockNumber_t, edm::LuminosityBlockNumber_t> pclIOV;
 
-    int nLumiBlock_ = countLumi_-FEDerror25Map.begin()->first+1;
-
+    //int nLumiBlock_ = countLumi_-FEDerror25Map.begin()->first+1;
 
     // container for SiPixelQuality for the whole run
     std::map<int, SiPixelQuality*> siPixelQualityStuckTBM_Tag;

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
@@ -60,20 +60,30 @@ class SiPixelStatusHarvester : public SiPixelPhase1Base {
   const SiPixelQuality* badPixelInfo_;
 
   // totoal number of lumi blocks with non-zero pixel DIGIs
-  int countLumi_;
+  int countLumi_ = 0;
   // last lumi section of the SiPixeDetectorStatus data
   edm::LuminosityBlockNumber_t endLumiBlock_;
+
+  const TrackerGeometry* trackerGeometry_ = nullptr;
+  const SiPixelFedCabling* cablingMap_ = nullptr;
+  std::map<int, unsigned int> sensorSize_;
+
+  // pixel online to offline pixel row/column
+  std::map<int, std::map<int, std::pair<int,int> > > pixelO2O_;
+
+  //Helper functions
 
   // "step function" for IOV
   edm::LuminosityBlockNumber_t stepIOV(edm::LuminosityBlockNumber_t pin, std::map<edm::LuminosityBlockNumber_t,edm::LuminosityBlockNumber_t> IOV);
 
-  const TrackerGeometry* trackerGeometry_ = nullptr;
-  const SiPixelFedCabling* cablingMap_ = nullptr;
-  std::map<int, int> sensorSize_;
+  // boolean function to check whether two SiPixelQualitys (pyloads) are identical
+  bool equal(SiPixelQuality* a, SiPixelQuality* b);
 
-  // pixel online to offline pixel row/column 
-  std::map<int, std::map<int, std::pair<int,int> > > pixelO2O_;
+  // Tag constructor
+  void constructTag(std::map<int,SiPixelQuality*>siPixelQualityTag, edm::Service<cond::service::PoolDBOutputService> &poolDbService, std::string tagName, edm::Run& iRun);
+
 
 };
+
 
 #endif

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
@@ -11,7 +11,19 @@
 #include "CalibTracker/SiPixelQuality/interface/SiPixelStatusManager.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
 
-class SiPixelStatusHarvester : public edm::EDAnalyzer {
+// PixelDQM Framework
+#include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
+
+class SiPixelStatusHarvester : public SiPixelPhase1Base {
+    enum {
+      BADROC,
+      PERMANENTBADROC,
+      FEDERRORROC,
+      STUCKTBMROC,
+      OTHERBADROC,
+      PROMPTBADROC
+    };
+
  public:
 
   // Constructor
@@ -23,15 +35,14 @@ class SiPixelStatusHarvester : public edm::EDAnalyzer {
   // Operations
   void beginJob            () override;
   void endJob              () override;  
-  void analyze             (const edm::Event&          , const edm::EventSetup&) override;
-  void beginRun            (const edm::Run&            , const edm::EventSetup&) override;
-  void endRun              (const edm::Run&            , const edm::EventSetup&) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
-  void endLuminosityBlock  (const edm::LuminosityBlock&, const edm::EventSetup&) override;
+  virtual void endRunProduce       (edm::Run&, const edm::EventSetup&) final;
+  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) final;
 
- protected:
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final;
+  virtual void endLuminosityBlock  (const edm::LuminosityBlock&, const edm::EventSetup&) final;
 
  private:
+
   // Parameters
   std::string outputBase_;
   int aveDigiOcc_;
@@ -48,11 +59,20 @@ class SiPixelStatusHarvester : public edm::EDAnalyzer {
   // permanent known bad components
   const SiPixelQuality* badPixelInfo_;
 
+  // totoal number of lumi blocks with non-zero pixel DIGIs
+  int countLumi_;
   // last lumi section of the SiPixeDetectorStatus data
   edm::LuminosityBlockNumber_t endLumiBlock_;
 
   // "step function" for IOV
   edm::LuminosityBlockNumber_t stepIOV(edm::LuminosityBlockNumber_t pin, std::map<edm::LuminosityBlockNumber_t,edm::LuminosityBlockNumber_t> IOV);
+
+  const TrackerGeometry* trackerGeometry_ = nullptr;
+  const SiPixelFedCabling* cablingMap_ = nullptr;
+  std::map<int, int> sensorSize_;
+
+  // pixel online to offline pixel row/column 
+  std::map<int, std::map<int, std::pair<int,int> > > pixelO2O_;
 
 };
 

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
@@ -35,11 +35,11 @@ class SiPixelStatusHarvester : public SiPixelPhase1Base {
   // Operations
   void beginJob            () override;
   void endJob              () override;  
-  virtual void endRunProduce       (edm::Run&, const edm::EventSetup&) final;
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) final;
+  void endRunProduce       (edm::Run&, const edm::EventSetup&) final;
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) final;
 
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final;
-  virtual void endLuminosityBlock  (const edm::LuminosityBlock&, const edm::EventSetup&) final;
+  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final;
+  void endLuminosityBlock  (const edm::LuminosityBlock&, const edm::EventSetup&) final;
 
  private:
 

--- a/CalibTracker/SiPixelQuality/python/SiPixelStatusHarvester_cfi.py
+++ b/CalibTracker/SiPixelQuality/python/SiPixelStatusHarvester_cfi.py
@@ -112,7 +112,7 @@ topFolderName = DefaultHisto.topFolderName.value() +"/SiPixelQualityPCL/BadROC_O
 )
 
 SiPixelPhase1PromptBadROC = DefaultHisto.clone(
-topFolderName = DefaultHisto.topFolderName.value() +"/SiPixelQualityPCL/BadRoc_Prompt",
+topFolderName = DefaultHisto.topFolderName.value() +"/SiPixelQualityPCL/BadROC_Prompt",
   name = "Dead Channels per ROC",
   title = "Dead Channels per ROC",
   xlabel = "dead channels per ROC",

--- a/CalibTracker/SiPixelQuality/python/SiPixelStatusHarvester_cfi.py
+++ b/CalibTracker/SiPixelQuality/python/SiPixelStatusHarvester_cfi.py
@@ -1,7 +1,152 @@
 import FWCore.ParameterSet.Config as cms
 
-siPixelStatusHarvester = cms.EDAnalyzer("SiPixelStatusHarvester",
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+import DQM.SiPixelPhase1Common.TriggerEventFlag_cfi as trigger
 
+# this might also go into te Common config,as we do not reference it
+from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
+
+SiPixelPhase1BadROC = DefaultHisto.clone(
+topFolderName = DefaultHisto.topFolderName.value() +"/SiPixelQualityPCL/BadROC_PCL",
+  name = "Dead Channels per ROC",
+  title = "Dead Channels per ROC",
+  xlabel = "dead channels per ROC",
+  range_min = 0, range_max = 1, range_nbins = 100,
+  dimensions = 0,
+  specs = VPSet(
+    Specification(PerLayer2D)
+       .groupBy("PXLayer/SignedLadderCoord/SignedModuleCoord")
+       .groupBy("PXLayer/SignedLadderCoord", "EXTEND_X")
+       .groupBy("PXLayer", "EXTEND_Y")
+       .save(),
+    Specification(PerLayer2D)
+       .groupBy("PXRing/SignedBladePanelCoord/SignedDiskCoord")
+       .groupBy("PXRing/SignedBladePanelCoord", "EXTEND_X")
+       .groupBy("PXRing", "EXTEND_Y")
+       .save()
+    )
+)
+
+SiPixelPhase1PermanentBadROC = DefaultHisto.clone(
+topFolderName = DefaultHisto.topFolderName.value() +"/SiPixelQualityPCL/BadROC_Permanent",
+  name = "Dead Channels per ROC",
+  title = "Dead Channels per ROC",
+  xlabel = "dead channels per ROC",
+  range_min = 0, range_max = 1, range_nbins = 100,
+  dimensions = 0,
+  specs = VPSet(
+    Specification(PerLayer2D)
+       .groupBy("PXLayer/SignedLadderCoord/SignedModuleCoord")
+       .groupBy("PXLayer/SignedLadderCoord", "EXTEND_X")
+       .groupBy("PXLayer", "EXTEND_Y")
+       .save(),
+    Specification(PerLayer2D)
+       .groupBy("PXRing/SignedBladePanelCoord/SignedDiskCoord")
+       .groupBy("PXRing/SignedBladePanelCoord", "EXTEND_X")
+       .groupBy("PXRing", "EXTEND_Y")
+       .save()
+    )
+)
+
+SiPixelPhase1FEDerrorROC = DefaultHisto.clone(
+topFolderName = DefaultHisto.topFolderName.value() +"/SiPixelQualityPCL/BadROC_FEDerror",
+  name = "Dead Channels per ROC",
+  title = "Dead Channels per ROC",
+  xlabel = "dead channels per ROC",
+  range_min = 0, range_max = 1, range_nbins = 100,
+  dimensions = 0,
+  specs = VPSet(
+    Specification(PerLayer2D)
+       .groupBy("PXLayer/SignedLadderCoord/SignedModuleCoord")
+       .groupBy("PXLayer/SignedLadderCoord", "EXTEND_X")
+       .groupBy("PXLayer", "EXTEND_Y")
+       .save(),
+    Specification(PerLayer2D)
+       .groupBy("PXRing/SignedBladePanelCoord/SignedDiskCoord")
+       .groupBy("PXRing/SignedBladePanelCoord", "EXTEND_X")
+       .groupBy("PXRing", "EXTEND_Y")
+       .save()
+    )
+)
+
+SiPixelPhase1StuckTBMROC = DefaultHisto.clone(
+topFolderName = DefaultHisto.topFolderName.value() +"/SiPixelQualityPCL/BadROC_StuckTBM",
+  name = "Dead Channels per ROC",
+  title = "Dead Channels per ROC",
+  xlabel = "dead channels per ROC",
+  range_min = 0, range_max = 1, range_nbins = 100,
+  dimensions = 0,
+  specs = VPSet(
+    Specification(PerLayer2D)
+       .groupBy("PXLayer/SignedLadderCoord/SignedModuleCoord")
+       .groupBy("PXLayer/SignedLadderCoord", "EXTEND_X")
+       .groupBy("PXLayer", "EXTEND_Y")
+       .save(),
+    Specification(PerLayer2D)
+       .groupBy("PXRing/SignedBladePanelCoord/SignedDiskCoord")
+       .groupBy("PXRing/SignedBladePanelCoord", "EXTEND_X")
+       .groupBy("PXRing", "EXTEND_Y")
+       .save()
+    )
+)
+
+SiPixelPhase1OtherBadROC = DefaultHisto.clone(
+topFolderName = DefaultHisto.topFolderName.value() +"/SiPixelQualityPCL/BadROC_Other",
+  name = "Dead Channels per ROC",
+  title = "Dead Channels per ROC",
+  xlabel = "dead channels per ROC",
+  range_min = 0, range_max = 1, range_nbins = 100,
+  dimensions = 0,
+  specs = VPSet(
+    Specification(PerLayer2D)
+       .groupBy("PXLayer/SignedLadderCoord/SignedModuleCoord")
+       .groupBy("PXLayer/SignedLadderCoord", "EXTEND_X")
+       .groupBy("PXLayer", "EXTEND_Y")
+       .save(),
+    Specification(PerLayer2D)
+       .groupBy("PXRing/SignedBladePanelCoord/SignedDiskCoord")
+       .groupBy("PXRing/SignedBladePanelCoord", "EXTEND_X")
+       .groupBy("PXRing", "EXTEND_Y")
+       .save()
+    )
+)
+
+SiPixelPhase1PromptBadROC = DefaultHisto.clone(
+topFolderName = DefaultHisto.topFolderName.value() +"/SiPixelQualityPCL/BadRoc_Prompt",
+  name = "Dead Channels per ROC",
+  title = "Dead Channels per ROC",
+  xlabel = "dead channels per ROC",
+  range_min = 0, range_max = 1, range_nbins = 100,
+  dimensions = 0,
+  specs = VPSet(
+    Specification(PerLayer2D)
+       .groupBy("PXLayer/SignedLadderCoord/SignedModuleCoord")
+       .groupBy("PXLayer/SignedLadderCoord", "EXTEND_X")
+       .groupBy("PXLayer", "EXTEND_Y")
+       .save(),
+    Specification(PerLayer2D)
+       .groupBy("PXRing/SignedBladePanelCoord/SignedDiskCoord")
+       .groupBy("PXRing/SignedBladePanelCoord", "EXTEND_X")
+       .groupBy("PXRing", "EXTEND_Y")
+       .save()
+    )
+)
+
+# This has to match the order of the names in the C++ enum.
+SiPixelPhase1BadROCConf = cms.VPSet(
+SiPixelPhase1BadROC,
+SiPixelPhase1PermanentBadROC,
+SiPixelPhase1FEDerrorROC,
+SiPixelPhase1StuckTBMROC, 
+SiPixelPhase1OtherBadROC,
+SiPixelPhase1PromptBadROC
+)
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+siPixelStatusHarvester = DQMEDAnalyzer("SiPixelStatusHarvester",
+    histograms = SiPixelPhase1BadROCConf,
+    geometry = SiPixelPhase1Geometry,
+    #triggerflags = trigger.SiPixelPhase1Triggers SiPixelQuality ALCARECO doesn't contain any trigger infor
     SiPixelStatusManagerParameters = cms.PSet(
         outputBase = cms.untracked.string("runbased"), #nLumibased #runbased #dynamicLumibased
         aveDigiOcc = cms.untracked.int32(20000),
@@ -12,5 +157,10 @@ siPixelStatusHarvester = cms.EDAnalyzer("SiPixelStatusHarvester",
     debug = cms.untracked.bool(False),
     recordName   = cms.untracked.string("SiPixelQualityFromDbRcd")
 
+)
+
+siPixelPhase1DQMHarvester = DQMEDHarvester("SiPixelPhase1Harvester",
+        histograms = SiPixelPhase1BadROCConf,
+        geometry = SiPixelPhase1Geometry
 )
 

--- a/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
@@ -120,7 +120,7 @@ void SiPixelStatusManager::createBadComponents(){
         }
 
         siPixelStatusVtr_iterator currentIt = it;
-        siPixelStatusVtr_iterator nextIt = (++currentIt);
+        siPixelStatusVtr_iterator nextIt = std::next(currentIt);
         // wirte out if current lumi is the last lumi-section in the IOV
         if(iterationLumi%nLumi_==nLumi_-1 || nextIt==lastStatus) 
         {
@@ -178,7 +178,7 @@ void SiPixelStatusManager::createBadComponents(){
 
          // if reaching the end of data, write the last IOV to the map whatsoevec
          siPixelStatusVtr_iterator currentIt = it;
-         siPixelStatusVtr_iterator nextIt = (++currentIt);
+         siPixelStatusVtr_iterator nextIt = std::next(currentIt);
          if(tmpSiPixelStatus.perRocDigiOcc()<aveDigiOcc && nextIt!=lastStatus){
             isNewIOV = false; // if digi occ is not enough, next data will not belong to new IOV
          }
@@ -252,7 +252,7 @@ void SiPixelStatusManager::createFEDerror25(){
     bool sameAsLastIOV = true;
     edm::LuminosityBlockNumber_t previousLumi = firstLumi;
 
-    siPixelStatusVtr_iterator secondStatus = ++siPixelStatusVtr_.begin();
+    siPixelStatusVtr_iterator secondStatus = std::next(siPixelStatusVtr_.begin());
     for (siPixelStatusVtr_iterator it = secondStatus; it != lastStatus; it++) {
         // init for each lumi section (iterator)
         edm::LuminosityBlockNumber_t tmpLumi = edm::LuminosityBlockNumber_t(it->getLSRange().first);

--- a/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
+++ b/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
@@ -88,34 +88,6 @@ ALCAHARVESTBeamSpotHPByLumi_dbOutput = cms.PSet(record = cms.string('BeamSpotObj
                                               timetype   = cms.untracked.string('lumiid')
                                               )
 
-
-# --------------------------------------------------------------------------------------
-# BeamSpot HP - Low PU - by Run
-ALCAHARVESTBeamSpotHPLowPUByRun = ALCAHARVESTBeamSpotHPByRun.clone()
-ALCAHARVESTBeamSpotHPLowPUByRun.AlcaBeamSpotHarvesterParameters.BeamSpotModuleName = cms.untracked.string('alcaBeamSpotProducerHPLowPU')
-
-# configuration of DropBox metadata and DB output
-ALCAHARVESTBeamSpotHPLowPUByRun_metadata = cms.PSet(record = cms.untracked.string('BeamSpotObjectsRcdHPByRun'))
-
-ALCAHARVESTBeamSpotHPLowPUByRun_dbOutput = cms.PSet(record = cms.string('BeamSpotObjectsRcdHPByRun'),
-                                                    tag = cms.string('BeamSpotObjectHP_ByRun'),
-                                                    timetype   = cms.untracked.string('runnumber')
-                                                    )
-
-# --------------------------------------------------------------------------------------
-# BeamSpot HP - Low PU - by Lumi
-ALCAHARVESTBeamSpotHPLowPUByLumi = ALCAHARVESTBeamSpotHPByLumi.clone()
-ALCAHARVESTBeamSpotHPLowPUByLumi.AlcaBeamSpotHarvesterParameters.BeamSpotModuleName = cms.untracked.string('alcaBeamSpotProducerHPLowPU')
-
-
-# configuration of DropBox metadata and DB output
-ALCAHARVESTBeamSpotHPLowPUByLumi_metadata = cms.PSet(record = cms.untracked.string('BeamSpotObjectsRcdHPByLumi'))
-
-ALCAHARVESTBeamSpotHPLowPUByLumi_dbOutput = cms.PSet(record = cms.string('BeamSpotObjectsRcdHPByLumi'),
-                                                     tag = cms.string('BeamSpotObjectHP_ByLumi'),
-                                                     timetype   = cms.untracked.string('lumiid')
-                                                     )
-
 # --------------------------------------------------------------------------------------
 # SiStrip Quality
 ALCAHARVESTSiStripQuality_metadata = cms.PSet(record = cms.untracked.string('SiStripBadStripRcd'))
@@ -217,15 +189,13 @@ BeamSpotByRun  = cms.Path(ALCAHARVESTBeamSpotByRun)
 BeamSpotByLumi = cms.Path(ALCAHARVESTBeamSpotByLumi)
 BeamSpotHPByRun  = cms.Path(ALCAHARVESTBeamSpotHPByRun)
 BeamSpotHPByLumi = cms.Path(ALCAHARVESTBeamSpotHPByLumi)
-BeamSpotHPLowPUByRun  = cms.Path(ALCAHARVESTBeamSpotHPLowPUByRun)
-BeamSpotHPLowPUByLumi = cms.Path(ALCAHARVESTBeamSpotHPLowPUByLumi)
 SiStripQuality = cms.Path(ALCAHARVESTSiStripQuality)
 SiStripGains   = cms.Path(ALCAHARVESTSiStripGains)
 SiPixelAli     = cms.Path(ALCAHARVESTSiPixelAli)
 EcalPedestals  = cms.Path(ALCAHARVESTEcalPedestals)
 SiStripGainsAAG = cms.Path(ALCAHARVESTSiStripGainsAAG)
 LumiPCC = cms.Path(ALCAHARVESTLumiPCC)
-SiPixelQuality = cms.Path(ALCAHARVESTSiPixelQuality)
+SiPixelQuality = cms.Path(ALCAHARVESTSiPixelQuality+siPixelPhase1DQMHarvester)
 
 ALCAHARVESTDQMSaveAndMetadataWriter = cms.Path(dqmSaver+pclMetadataWriter)
 

--- a/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
+++ b/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
@@ -88,6 +88,34 @@ ALCAHARVESTBeamSpotHPByLumi_dbOutput = cms.PSet(record = cms.string('BeamSpotObj
                                               timetype   = cms.untracked.string('lumiid')
                                               )
 
+
+# --------------------------------------------------------------------------------------
+# BeamSpot HP - Low PU - by Run
+ALCAHARVESTBeamSpotHPLowPUByRun = ALCAHARVESTBeamSpotHPByRun.clone()
+ALCAHARVESTBeamSpotHPLowPUByRun.AlcaBeamSpotHarvesterParameters.BeamSpotModuleName = cms.untracked.string('alcaBeamSpotProducerHPLowPU')
+
+# configuration of DropBox metadata and DB output
+ALCAHARVESTBeamSpotHPLowPUByRun_metadata = cms.PSet(record = cms.untracked.string('BeamSpotObjectsRcdHPByRun'))
+
+ALCAHARVESTBeamSpotHPLowPUByRun_dbOutput = cms.PSet(record = cms.string('BeamSpotObjectsRcdHPByRun'),
+                                                    tag = cms.string('BeamSpotObjectHP_ByRun'),
+                                                    timetype   = cms.untracked.string('runnumber')
+                                                    )
+
+# --------------------------------------------------------------------------------------
+# BeamSpot HP - Low PU - by Lumi
+ALCAHARVESTBeamSpotHPLowPUByLumi = ALCAHARVESTBeamSpotHPByLumi.clone()
+ALCAHARVESTBeamSpotHPLowPUByLumi.AlcaBeamSpotHarvesterParameters.BeamSpotModuleName = cms.untracked.string('alcaBeamSpotProducerHPLowPU')
+
+
+# configuration of DropBox metadata and DB output
+ALCAHARVESTBeamSpotHPLowPUByLumi_metadata = cms.PSet(record = cms.untracked.string('BeamSpotObjectsRcdHPByLumi'))
+
+ALCAHARVESTBeamSpotHPLowPUByLumi_dbOutput = cms.PSet(record = cms.string('BeamSpotObjectsRcdHPByLumi'),
+                                                     tag = cms.string('BeamSpotObjectHP_ByLumi'),
+                                                     timetype   = cms.untracked.string('lumiid')
+                                                     )
+
 # --------------------------------------------------------------------------------------
 # SiStrip Quality
 ALCAHARVESTSiStripQuality_metadata = cms.PSet(record = cms.untracked.string('SiStripBadStripRcd'))
@@ -189,6 +217,8 @@ BeamSpotByRun  = cms.Path(ALCAHARVESTBeamSpotByRun)
 BeamSpotByLumi = cms.Path(ALCAHARVESTBeamSpotByLumi)
 BeamSpotHPByRun  = cms.Path(ALCAHARVESTBeamSpotHPByRun)
 BeamSpotHPByLumi = cms.Path(ALCAHARVESTBeamSpotHPByLumi)
+BeamSpotHPLowPUByRun  = cms.Path(ALCAHARVESTBeamSpotHPLowPUByRun)
+BeamSpotHPLowPUByLumi = cms.Path(ALCAHARVESTBeamSpotHPLowPUByLumi)
 SiStripQuality = cms.Path(ALCAHARVESTSiStripQuality)
 SiStripGains   = cms.Path(ALCAHARVESTSiStripGains)
 SiPixelAli     = cms.Path(ALCAHARVESTSiPixelAli)

--- a/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
+++ b/Configuration/StandardSequences/python/AlCaHarvesting_cff.py
@@ -225,7 +225,7 @@ SiPixelAli     = cms.Path(ALCAHARVESTSiPixelAli)
 EcalPedestals  = cms.Path(ALCAHARVESTEcalPedestals)
 SiStripGainsAAG = cms.Path(ALCAHARVESTSiStripGainsAAG)
 LumiPCC = cms.Path(ALCAHARVESTLumiPCC)
-SiPixelQuality = cms.Path(ALCAHARVESTSiPixelQuality+siPixelPhase1DQMHarvester)
+SiPixelQuality = cms.Path(ALCAHARVESTSiPixelQuality)#+siPixelPhase1DQMHarvester)
 
 ALCAHARVESTDQMSaveAndMetadataWriter = cms.Path(dqmSaver+pclMetadataWriter)
 


### PR DESCRIPTION
Hello, the PR is meant to monitor the PCL payloads of SiPixelQuality using tracker offline DQM.
The harvester is changed to a DQMEDAnalyzer to produce the payloads and DQM IO in one CMSSW module. 

The continuous payloads are replace by one payload if they are identical. This will clean the redundant payloads in the tags.

And with the help of the DQM plots, I found a bug in the tag for prompt-reco from the SiPixelQuality production; only the low DIGI ROCs in the permanent bad components were added to the tag for prompt-reco, while all the components that were low efficient (due to 2017 DCDC damage) were not included. So this bug was fixed in the later commit of the PR.

More details can be seen in the pixel offline meeting this week.
https://indico.cern.ch/event/688868/contributions/3062848/attachments/1680102/2698910/PixelQualityPCL_July3rd_2018_pixeloffline.pdf

Sorry for pending the PR for quite some time. I was trying to find way to normalize the DQM plots in the way that they can be easily compared between different runs regardless the length of the run. But the simple way led to the crash of all TProfile plots for tracker DQM. There are other solutions, but from my point of view, too complicated to be done in a reasonable time. 
So I keep the plots as what they are and they are still good enough to use without the normalization.

