### PR TITLE
[10.2.X] 2018 MC updates : pixel 2D templates, dynamic ineff, channel quality and RECO Beamspot

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,9 +40,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '102X_mc2017_design_IdealBS_v2',
+    'phase1_2017_design'       :  '102X_mc2017_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '102X_mc2017_realistic_v2',
+    'phase1_2017_realistic'    : '102X_mc2017_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
     'phase1_2017_cosmics'      : '102X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
@@ -54,9 +54,9 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '102X_postLS2_design_v2', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '102X_postLS2_design_v3', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'       : '102X_postLS2_realistic_v2', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'       : '102X_postLS2_realistic_v3', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
     'phase2_realistic'         : '102X_upgrade2023_realistic_v3'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -44,21 +44,21 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
     'phase1_2017_realistic'    : '102X_mc2017_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '102X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'      : '102X_mc2017cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '102X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak' : '102X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '102X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v5',
+    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v4',
+    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '102X_postLS2_design_v3', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_realistic'       : '102X_postLS2_realistic_v3', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '102X_upgrade2023_realistic_v3'
+    'phase2_realistic'         : '102X_upgrade2023_realistic_v4'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -52,7 +52,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v3',
+    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '102X_postLS2_design_v3', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -48,17 +48,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' : '102X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '102X_upgrade2018_design_v2',
+    'phase1_2018_design'       : '102X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v6',
+    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v5',
+    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '102X_postLS2_design_v3', # GT containing design conditions for postLS2
+    'phase1_2019_design'       : '102X_postLS2_design_v4', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_realistic'       : '102X_postLS2_realistic_v3', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'       : '102X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '102X_upgrade2023_realistic_v4'
+    'phase2_realistic'         : '102X_upgrade2023_realistic_v5'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -50,7 +50,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '102X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v3',
+    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -50,15 +50,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '102X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v4',
+    'phase1_2018_realistic'    : '102X_upgrade2018_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v2',
+    'phase1_2018_cosmics'      :   '102X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : '102X_postLS2_design_v2', # GT containing design conditions for postLS2
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_realistic'       : '102X_postLS2_realistic_v2', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '102X_upgrade2023_realistic_v2'
+    'phase2_realistic'         : '102X_upgrade2023_realistic_v3'
 }
 
 aliases = {


### PR DESCRIPTION
### 2018 Realistic MC 

updated GT : https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/102X_upgrade2018_realistic_v7

diff : https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018_realistic_v7/102X_upgrade2018_realistic_v3

- update of pixel dynamic inefficiency : https://indico.cern.ch/event/688846/#24-dynamic-inefficiency-payloa & https://indico.cern.ch/event/688867/#33-bad-components-dcdc-issue
- update of pixel 2D templates needed for cluster repair and cluster merging : https://indico.cern.ch/event/737633/contributions/3043806
- update of pixel channel quality
- update of Reco Beamspot for 2018 scenario : https://indico.cern.ch/event/737633/contributions/3044911
- update of SiStrip bad channels
- update of L1T calibrations

### 2018 cosmic Realistic MC 

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018cosmics_realistic_deco_v6/102X_upgrade2018cosmics_realistic_deco_v2

- update of pixel channel quality
- update of SiStrip bad channels
- update of pixel 2D templates needed for cluster repair and cluster merging : https://indico.cern.ch/event/737633/contributions/3043806
- update of L1T calibrations

### 2018 Ideal MC 

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2018_design_v3/102X_upgrade2018_design_v2
- update of L1T calibrations


### Upgrade 2023 Realistic MC

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_upgrade2023_realistic_v5/102X_upgrade2023_realistic_v2 
- update of pixel channel quality
- update of SiStrip bad channels
- update of L1T calibrations


### MC 2017 Realistic, Design and Cosmics

#### diffs : 

- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mc2017_realistic_v3/102X_mc2017_realistic_v2
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mc2017_design_IdealBS_v3/102X_mc2017_design_IdealBS_v2
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mc2017cosmics_realistic_deco_v3/102X_mc2017cosmics_realistic_deco_v2
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/102X_mc2017cosmics_realistic_peak_v3/102X_mc2017cosmics_realistic_peak_v2

- including 2D pixel templates : technical update to make the tests run in #23596 