### PR TITLE
Change of SiStrip cross-talk parameters: improvement of the simulated hits

### DIFF
--- a/SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py
@@ -121,3 +121,9 @@ premix_stage1.toModify(SiStripSimBlock,
     PreMixingMode = True,
     FedAlgorithm = 5, # special ZS mode: accept adc>0
 )
+
+from Configuration.Eras.Modifier_run2_common_cff import run2_common
+run2_common.toModify(SiStripSimBlock,
+                     CouplingConstantsRunIIDecB = True, #for TIB and TOB
+                     CouplingConstantsRunIIDecW = True  #for TID and TEC
+                     )

--- a/SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py
@@ -16,6 +16,9 @@ SiStripSimBlock = cms.PSet(
     ChargeDistributionRMS   = cms.double(6.5e-10),
     noDiffusion             = cms.bool(False),
     #---SiTrivialInduceChargeOnStrips
+    #switch to use different coupling constants set 
+    CouplingConstantsRunIIDecB   = cms.bool(True),
+    CouplingConstantsRunIIDecW   = cms.bool(True),
     #TIB
     CouplingConstantDecIB1  = cms.vdouble(0.7748, 0.0962,0.0165),                    
     CouplingConstantDecIB2  = cms.vdouble(0.8300, 0.0756,0.0094),                    
@@ -48,6 +51,27 @@ SiStripSimBlock = cms.PSet(
     CouplingConstantPeakW5  = cms.vdouble(0.968, 0.016),
     CouplingConstantPeakW6  = cms.vdouble(0.972, 0.014),
     CouplingConstantPeakW7  = cms.vdouble(0.964, 0.018),
+
+    #RunII (2018) deconvolution parameters 
+    #TIB
+    CouplingConstantRunIIDecIB1 = cms.vdouble(0.836, 0.0703, 0.0116),
+    CouplingConstantRunIIDecIB2 = cms.vdouble(0.862, 0.0589, 0.0104),
+    #TOB
+    CouplingConstantRunIIDecOB2 = cms.vdouble(0.792, 0.0834, 0.0204),
+    CouplingConstantRunIIDecOB1 = cms.vdouble(0.746, 0.0996, 0.0273), 
+    #TID
+    CouplingConstantRunIIDecW1a = cms.vdouble(0.857, 0.0608, 0.0107),
+    CouplingConstantRunIIDecW2a = cms.vdouble(0.886, 0.049, 0.00792),
+    CouplingConstantRunIIDecW3a = cms.vdouble(0.898, 0.0494, 0.00137),
+    #TEC
+    CouplingConstantRunIIDecW1b = cms.vdouble(0.883, 0.0518, 0.00685),
+    CouplingConstantRunIIDecW2b = cms.vdouble(0.894, 0.0483, 0.00457),
+    CouplingConstantRunIIDecW3b = cms.vdouble(0.861, 0.0573, 0.0122),
+    CouplingConstantRunIIDecW4  = cms.vdouble(0.888, 0.0544, 0.00152),
+    CouplingConstantRunIIDecW5  = cms.vdouble(0.8, 0.077, 0.0231),
+    CouplingConstantRunIIDecW6  = cms.vdouble(0.807, 0.0769, 0.0198),
+    CouplingConstantRunIIDecW7  = cms.vdouble(0.788, 0.0888, 0.017),
+
     #-----SiStripDigitizer
     DigiModeList = cms.PSet(SCDigi = cms.string('ScopeMode'),
                             ZSDigi = cms.string('ZeroSuppressed'),

--- a/SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py
@@ -19,8 +19,8 @@ SiStripSimBlock = cms.PSet(
     #switch to use different coupling constants set
     #if True RunII cross talk will be used
     #if False RunI cross talk will be used
-    CouplingConstantsRunIIDecB   = cms.bool(True), #for TIB and TOB
-    CouplingConstantsRunIIDecW   = cms.bool(True), #for TID and TEC
+    CouplingConstantsRunIIDecB   = cms.bool(False), #for TIB and TOB
+    CouplingConstantsRunIIDecW   = cms.bool(False), #for TID and TEC
     #TIB
     CouplingConstantDecIB1  = cms.vdouble(0.7748, 0.0962,0.0165),                    
     CouplingConstantDecIB2  = cms.vdouble(0.8300, 0.0756,0.0094),                    

--- a/SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py
@@ -16,9 +16,11 @@ SiStripSimBlock = cms.PSet(
     ChargeDistributionRMS   = cms.double(6.5e-10),
     noDiffusion             = cms.bool(False),
     #---SiTrivialInduceChargeOnStrips
-    #switch to use different coupling constants set 
-    CouplingConstantsRunIIDecB   = cms.bool(True),
-    CouplingConstantsRunIIDecW   = cms.bool(True),
+    #switch to use different coupling constants set
+    #if True RunII cross talk will be used
+    #if False RunI cross talk will be used
+    CouplingConstantsRunIIDecB   = cms.bool(True), #for TIB and TOB
+    CouplingConstantsRunIIDecW   = cms.bool(True), #for TID and TEC
     #TIB
     CouplingConstantDecIB1  = cms.vdouble(0.7748, 0.0962,0.0165),                    
     CouplingConstantDecIB2  = cms.vdouble(0.8300, 0.0756,0.0094),                    
@@ -54,23 +56,23 @@ SiStripSimBlock = cms.PSet(
 
     #RunII (2018) deconvolution parameters 
     #TIB
-    CouplingConstantRunIIDecIB1 = cms.vdouble(0.836, 0.0703, 0.0116),
-    CouplingConstantRunIIDecIB2 = cms.vdouble(0.862, 0.0589, 0.0104),
+    CouplingConstantRunIIDecIB1 = cms.vdouble(0.8361, 0.0703, 0.0117),
+    CouplingConstantRunIIDecIB2 = cms.vdouble(0.8616, 0.0588, 0.0104),
     #TOB
-    CouplingConstantRunIIDecOB2 = cms.vdouble(0.792, 0.0834, 0.0204),
-    CouplingConstantRunIIDecOB1 = cms.vdouble(0.746, 0.0996, 0.0273), 
+    CouplingConstantRunIIDecOB2 = cms.vdouble(0.7925, 0.0834, 0.0203),
+    CouplingConstantRunIIDecOB1 = cms.vdouble(0.7461, 0.0996, 0.0273),
     #TID
-    CouplingConstantRunIIDecW1a = cms.vdouble(0.857, 0.0608, 0.0107),
-    CouplingConstantRunIIDecW2a = cms.vdouble(0.886, 0.049, 0.00792),
-    CouplingConstantRunIIDecW3a = cms.vdouble(0.898, 0.0494, 0.00137),
+    CouplingConstantRunIIDecW1a = cms.vdouble(0.8571, 0.0608, 0.0106),
+    CouplingConstantRunIIDecW2a = cms.vdouble(0.8861, 0.049, 0.008),
+    CouplingConstantRunIIDecW3a = cms.vdouble(0.8984, 0.0494, 0.0014),
     #TEC
-    CouplingConstantRunIIDecW1b = cms.vdouble(0.883, 0.0518, 0.00685),
-    CouplingConstantRunIIDecW2b = cms.vdouble(0.894, 0.0483, 0.00457),
-    CouplingConstantRunIIDecW3b = cms.vdouble(0.861, 0.0573, 0.0122),
-    CouplingConstantRunIIDecW4  = cms.vdouble(0.888, 0.0544, 0.00152),
-    CouplingConstantRunIIDecW5  = cms.vdouble(0.8, 0.077, 0.0231),
-    CouplingConstantRunIIDecW6  = cms.vdouble(0.807, 0.0769, 0.0198),
-    CouplingConstantRunIIDecW7  = cms.vdouble(0.788, 0.0888, 0.017),
+    CouplingConstantRunIIDecW1b = cms.vdouble(0.8827, 0.0518, 0.0068),
+    CouplingConstantRunIIDecW2b = cms.vdouble(0.8943, 0.0483, 0.0046),
+    CouplingConstantRunIIDecW3b = cms.vdouble(0.8611, 0.0573, 0.0121),
+    CouplingConstantRunIIDecW4  = cms.vdouble(0.8881, 0.0544, 0.0015),
+    CouplingConstantRunIIDecW5  = cms.vdouble(0.7997, 0.077, 0.0231),
+    CouplingConstantRunIIDecW6  = cms.vdouble(0.8067, 0.0769, 0.0198),
+    CouplingConstantRunIIDecW7  = cms.vdouble(0.7883, 0.0888, 0.0171),
 
     #-----SiStripDigitizer
     DigiModeList = cms.PSet(SCDigi = cms.string('ScopeMode'),

--- a/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
@@ -58,7 +58,14 @@ namespace {
     signalCoupling.reserve(nTypes);
     std::string mode = conf.getParameter<bool>("APVpeakmode") ? "Peak" : "Dec";
     for(int i=0; i<nTypes; ++i) {
-      auto dc = conf.getParameter<std::vector<double> >("CouplingConstant"+mode+typeArray[i]);
+
+      std::string version = "";
+      if( typeArray[i].find("W") != std::string::npos && mode == "Dec" )
+        version =  conf.getParameter<bool>("CouplingConstantsRunIIDecW") ? "RunII" : "";
+      else if( typeArray[i].find("B") != std::string::npos  && mode == "Dec")
+        version =  conf.getParameter<bool>("CouplingConstantsRunIIDecB") ? "RunII" : "";
+
+      auto dc = conf.getParameter<std::vector<double> >("CouplingConstant"+version+mode+typeArray[i]);
       signalCoupling.emplace_back(dc.begin(),dc.end());
     }
     return signalCoupling;

--- a/SimTracker/SiStripDigitizer/python/SiStripDigiSimLink_cfi.py
+++ b/SimTracker/SiStripDigitizer/python/SiStripDigiSimLink_cfi.py
@@ -113,3 +113,9 @@ simSiStripDigiSimLink = cms.EDProducer("DigiSimLinkProducer",
                                TOFCutForPeak              = cms.double(100.0),
                                Inefficiency               = cms.double(0.0)
                               )
+
+from Configuration.Eras.Modifier_run2_common_cff import run2_common
+run2_common.toModify(simSiStripDigiSimLink,
+                     CouplingConstantsRunIIDecB   = cms.bool(True), #for TIB and TOB
+                     CouplingConstantsRunIIDecW   = cms.bool(True)  #for TID and TEC
+                     )

--- a/SimTracker/SiStripDigitizer/python/SiStripDigiSimLink_cfi.py
+++ b/SimTracker/SiStripDigitizer/python/SiStripDigiSimLink_cfi.py
@@ -18,6 +18,9 @@ simSiStripDigiSimLink = cms.EDProducer("DigiSimLinkProducer",
                                ChargeDistributionRMS   = cms.double(6.5e-10),
                                noDiffusion             = cms.bool(False),
                                #---SiTrivialInduceChargeOnStrips
+                               #switch to use different coupling constants set 
+                               CouplingConstantsRunIIDecB   = cms.bool(True),
+                               CouplingConstantsRunIIDecW   = cms.bool(True),
                                #TIB
                                CouplingConstantDecIB1  = cms.vdouble(0.7748, 0.0962,0.0165),                    
                                CouplingConstantDecIB2  = cms.vdouble(0.8300, 0.0756,0.0094),                    
@@ -50,6 +53,25 @@ simSiStripDigiSimLink = cms.EDProducer("DigiSimLinkProducer",
                                CouplingConstantPeakW5  = cms.vdouble(0.968, 0.016),
                                CouplingConstantPeakW6  = cms.vdouble(0.972, 0.014),
                                CouplingConstantPeakW7  = cms.vdouble(0.964, 0.018),
+			       #RunII (2018) deconvolution parameters 
+			       #TIB
+			       CouplingConstantRunIIDecIB1 = cms.vdouble(0.836, 0.0703, 0.0116),
+			       CouplingConstantRunIIDecIB2 = cms.vdouble(0.862, 0.0589, 0.0104),
+			       #TOB
+			       CouplingConstantRunIIDecOB2 = cms.vdouble(0.792, 0.0834, 0.0204),
+			       CouplingConstantRunIIDecOB1 = cms.vdouble(0.746, 0.0996, 0.0273), 
+			       #TID
+			       CouplingConstantRunIIDecW1a = cms.vdouble(0.857, 0.0608, 0.0107),
+			       CouplingConstantRunIIDecW2a = cms.vdouble(0.886, 0.049, 0.00792),
+			       CouplingConstantRunIIDecW3a = cms.vdouble(0.898, 0.0494, 0.00137),
+			       #TEC
+			       CouplingConstantRunIIDecW1b = cms.vdouble(0.883, 0.0518, 0.00685),
+			       CouplingConstantRunIIDecW2b = cms.vdouble(0.894, 0.0483, 0.00457),
+			       CouplingConstantRunIIDecW3b = cms.vdouble(0.861, 0.0573, 0.0122),
+			       CouplingConstantRunIIDecW4  = cms.vdouble(0.888, 0.0544, 0.00152),
+			       CouplingConstantRunIIDecW5  = cms.vdouble(0.8, 0.077, 0.0231),
+			       CouplingConstantRunIIDecW6  = cms.vdouble(0.807, 0.0769, 0.0198),
+			       CouplingConstantRunIIDecW7  = cms.vdouble(0.788, 0.0888, 0.017),
                                #-----SiStripDigitizer
                                DigiModeList = cms.PSet(SCDigi = cms.string('ScopeMode'),
                                                        ZSDigi = cms.string('ZeroSuppressed'),

--- a/SimTracker/SiStripDigitizer/python/SiStripDigiSimLink_cfi.py
+++ b/SimTracker/SiStripDigitizer/python/SiStripDigiSimLink_cfi.py
@@ -21,8 +21,8 @@ simSiStripDigiSimLink = cms.EDProducer("DigiSimLinkProducer",
                                #switch to use different coupling constants set
                                #if True RunII cross talk will be used
                                #if False RunI cross talk will be used
-                               CouplingConstantsRunIIDecB   = cms.bool(True), #for TIB and TOB
-                               CouplingConstantsRunIIDecW   = cms.bool(True), #for TID and TEC
+                               CouplingConstantsRunIIDecB   = cms.bool(False), #for TIB and TOB
+                               CouplingConstantsRunIIDecW   = cms.bool(False), #for TID and TEC
                                #TIB
                                CouplingConstantDecIB1  = cms.vdouble(0.7748, 0.0962,0.0165),                    
                                CouplingConstantDecIB2  = cms.vdouble(0.8300, 0.0756,0.0094),                    

--- a/SimTracker/SiStripDigitizer/python/SiStripDigiSimLink_cfi.py
+++ b/SimTracker/SiStripDigitizer/python/SiStripDigiSimLink_cfi.py
@@ -18,9 +18,11 @@ simSiStripDigiSimLink = cms.EDProducer("DigiSimLinkProducer",
                                ChargeDistributionRMS   = cms.double(6.5e-10),
                                noDiffusion             = cms.bool(False),
                                #---SiTrivialInduceChargeOnStrips
-                               #switch to use different coupling constants set 
-                               CouplingConstantsRunIIDecB   = cms.bool(True),
-                               CouplingConstantsRunIIDecW   = cms.bool(True),
+                               #switch to use different coupling constants set
+                               #if True RunII cross talk will be used
+                               #if False RunI cross talk will be used
+                               CouplingConstantsRunIIDecB   = cms.bool(True), #for TIB and TOB
+                               CouplingConstantsRunIIDecW   = cms.bool(True), #for TID and TEC
                                #TIB
                                CouplingConstantDecIB1  = cms.vdouble(0.7748, 0.0962,0.0165),                    
                                CouplingConstantDecIB2  = cms.vdouble(0.8300, 0.0756,0.0094),                    
@@ -53,25 +55,27 @@ simSiStripDigiSimLink = cms.EDProducer("DigiSimLinkProducer",
                                CouplingConstantPeakW5  = cms.vdouble(0.968, 0.016),
                                CouplingConstantPeakW6  = cms.vdouble(0.972, 0.014),
                                CouplingConstantPeakW7  = cms.vdouble(0.964, 0.018),
-			       #RunII (2018) deconvolution parameters 
-			       #TIB
-			       CouplingConstantRunIIDecIB1 = cms.vdouble(0.836, 0.0703, 0.0116),
-			       CouplingConstantRunIIDecIB2 = cms.vdouble(0.862, 0.0589, 0.0104),
-			       #TOB
-			       CouplingConstantRunIIDecOB2 = cms.vdouble(0.792, 0.0834, 0.0204),
-			       CouplingConstantRunIIDecOB1 = cms.vdouble(0.746, 0.0996, 0.0273), 
-			       #TID
-			       CouplingConstantRunIIDecW1a = cms.vdouble(0.857, 0.0608, 0.0107),
-			       CouplingConstantRunIIDecW2a = cms.vdouble(0.886, 0.049, 0.00792),
-			       CouplingConstantRunIIDecW3a = cms.vdouble(0.898, 0.0494, 0.00137),
-			       #TEC
-			       CouplingConstantRunIIDecW1b = cms.vdouble(0.883, 0.0518, 0.00685),
-			       CouplingConstantRunIIDecW2b = cms.vdouble(0.894, 0.0483, 0.00457),
-			       CouplingConstantRunIIDecW3b = cms.vdouble(0.861, 0.0573, 0.0122),
-			       CouplingConstantRunIIDecW4  = cms.vdouble(0.888, 0.0544, 0.00152),
-			       CouplingConstantRunIIDecW5  = cms.vdouble(0.8, 0.077, 0.0231),
-			       CouplingConstantRunIIDecW6  = cms.vdouble(0.807, 0.0769, 0.0198),
-			       CouplingConstantRunIIDecW7  = cms.vdouble(0.788, 0.0888, 0.017),
+
+                               #RunII (2018) deconvolution parameters 
+                               #TIB
+                               CouplingConstantRunIIDecIB1 = cms.vdouble(0.8361, 0.0703, 0.0117),
+                               CouplingConstantRunIIDecIB2 = cms.vdouble(0.8616, 0.0588, 0.0104),
+                               #TOB
+                               CouplingConstantRunIIDecOB2 = cms.vdouble(0.7925, 0.0834, 0.0203),
+                               CouplingConstantRunIIDecOB1 = cms.vdouble(0.7461, 0.0996, 0.0273),
+                               #TID
+                               CouplingConstantRunIIDecW1a = cms.vdouble(0.8571, 0.0608, 0.0106),
+                               CouplingConstantRunIIDecW2a = cms.vdouble(0.8861, 0.049, 0.008),
+                               CouplingConstantRunIIDecW3a = cms.vdouble(0.8984, 0.0494, 0.0014),
+                               #TEC
+                               CouplingConstantRunIIDecW1b = cms.vdouble(0.8827, 0.0518, 0.0068),
+                               CouplingConstantRunIIDecW2b = cms.vdouble(0.8943, 0.0483, 0.0046),
+                               CouplingConstantRunIIDecW3b = cms.vdouble(0.8611, 0.0573, 0.0121),
+                               CouplingConstantRunIIDecW4  = cms.vdouble(0.8881, 0.0544, 0.0015),
+                               CouplingConstantRunIIDecW5  = cms.vdouble(0.7997, 0.077, 0.0231),
+                               CouplingConstantRunIIDecW6  = cms.vdouble(0.8067, 0.0769, 0.0198),
+                               CouplingConstantRunIIDecW7  = cms.vdouble(0.7883, 0.0888, 0.0171),
+
                                #-----SiStripDigitizer
                                DigiModeList = cms.PSet(SCDigi = cms.string('ScopeMode'),
                                                        ZSDigi = cms.string('ZeroSuppressed'),


### PR DESCRIPTION
This PR follows a request of the strip local reco conveners (@mmusich, @echabert).

It aims to be integrated in 10_2_0_pre6.

This PR contains mainly changes in the configuration files SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py and SimTracker/SiStripDigitizer/python/SiStripDigiSimLink_cfi.py. It will affect the simulation of SiStrip tracker hits leading to a better description of their properties.

The cross-talk parameters (called here "CouplingConstants") describe the charge sharing between neighbor channels in the SiStrip tracker. Those parameters are used by the file SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc .

Thus only the shape of the simulated and then reconstructed clusters will be affected: change of the seed charge, change of the cluster width. The total cluster charge will almost be unchanged as the parameters only change the charge sharing but not the normalization.

The previous parameters were determined at run I but with ageing, these parameters had to be re-evaluated.

A measurement have been done (VR run with cosmics data) and the results are propagated into the config files.

Data/MC validation have been made to ensure that the new parameters improve the agreement of the cluster seed charge and the cluster width.

The validation plots can be found here: https://indico.cern.ch/event/688867/contributions/3040427/attachments/1670393/2679458/cross_talk2018_validation.pdf

On top of the configuration file, a modification of  SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc has been done to allow the activation of the new parameters through flags.

They are split into two categories: barrel modules (activated via  CouplingConstantsRunIIDecB ) and disk/wheels (via CouplingConstantsRunIIDecW ). If the two booleans are set to False, the default simulation will be executed.

By default the flags are turned to False, thus the simulation will not be modified.

We plan to request special reval with the flag turned to True so that we can validate the changes and turn it to True in the next pre-realease.