### PR TITLE
Sensitive detectors update 7 

### DIFF
--- a/SimG4CMS/Forward/interface/BHMNumberingScheme.h
+++ b/SimG4CMS/Forward/interface/BHMNumberingScheme.h
@@ -2,27 +2,19 @@
 #define SimG4CMSForwardBHMNumberingScheme_h
 
 #include "G4Step.hh"
-#include <boost/cstdint.hpp>
-#include "G4ThreeVector.hh"
-#include <map>
-
-
-
+#include <cstdint>
 
 class BHMNumberingScheme {
   
 public:
   BHMNumberingScheme();
-  virtual ~BHMNumberingScheme();
+  ~BHMNumberingScheme() = default;
   
-  virtual unsigned int getUnitID(const G4Step* aStep) const;
+  unsigned int getUnitID(const G4Step* aStep) const;
   
   // Utilities to get detector levels during a step
-  virtual int  detectorLevel(const G4Step*) const;
-  virtual void detectorLevel(const G4Step*, int&, int*, G4String*) const;
-  
-  
-  //protected:
+  int  detectorLevel(const G4Step*) const;
+  void detectorLevel(const G4Step*, int&, int*, G4String*) const;
   
   static unsigned int packIndex(int subdet, int zside, int station);
   static void unpackIndex(const unsigned int& idx, int& subdet, int& zside,

--- a/SimG4CMS/Forward/interface/BHMSD.h
+++ b/SimG4CMS/Forward/interface/BHMSD.h
@@ -1,127 +1,32 @@
 #ifndef SimG4CMSForward_BHMSD_h
 #define SimG4CMSForward_BHMSD_h
 
-#include "SimG4Core/Notification/interface/Observer.h"
-#include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
-
-#include "SimG4Core/Notification/interface/BeginOfRun.h"
-#include "SimG4Core/Notification/interface/BeginOfEvent.h"
-#include "SimG4Core/Notification/interface/EndOfEvent.h"
-
-#include "SimG4CMS/Forward/interface/BscG4Hit.h"
-#include "SimG4CMS/Forward/interface/BscG4HitCollection.h"
-#include "SimG4CMS/Forward/interface/BHMNumberingScheme.h"
-
-  
-#include "G4Step.hh"
-#include "G4StepPoint.hh"
-#include "G4Track.hh"
-#include "G4VPhysicalVolume.hh"
+#include "SimG4CMS/Forward/interface/TimingSD.h"
 
 #include <string>
 
-class TrackingSlaveSD;
-
-class TrackInformation;
 class SimTrackManager;
-class TrackingSlaveSD;
-class UpdatablePSimHit;
-class G4ProcessTypeEnumerator;
-class G4TrackToParticleID;
-
+class G4Step;
+class BHMNumberingScheme;
 
 //-------------------------------------------------------------------
 
-class BHMSD : public SensitiveTkDetector,
-              public Observer<const BeginOfRun *>,
-              public Observer<const BeginOfEvent*>,
-              public Observer<const EndOfEvent*> {
+class BHMSD : public TimingSD {
 
 public:
   
-  BHMSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &, 
+  BHMSD(const std::string&, const DDCompactView &, 
+        const SensitiveDetectorCatalog &, 
 	edm::ParameterSet const &, const SimTrackManager* );
-
 
   ~BHMSD() override;
   
-  bool ProcessHits(G4Step *,G4TouchableHistory *) override;
   uint32_t  setDetUnitId(const G4Step*) override;
-
-  void Initialize(G4HCofThisEvent * HCE) override;
-  void EndOfEvent(G4HCofThisEvent * eventHC) override;
-  void clear() override;
-  void DrawAll() override;
-  void PrintAll() override;
-
-  double getEnergyDeposit(const G4Step* step);
-  void   fillHits(edm::PSimHitContainer&, const std::string&) override;
-  void   clearHits() override;
-    
-private:
-
-  void           update(const BeginOfRun *) override;
-  void           update(const BeginOfEvent *) override;
-  void           update(const ::EndOfEvent *) override;
-
-  G4ThreeVector SetToLocal(const G4ThreeVector& global);
-  G4ThreeVector SetToLocalExit(const G4ThreeVector& globalPoint);
-  void          GetStepInfo(G4Step* aStep);
-  G4bool        HitExists();
-  void          CreateNewHit();
-  void          UpdateHit();
-  void          StoreHit(BscG4Hit*);
-  void          ResetForNewPrimary();
-  void          Summarize();
     
 private:
   
-  TrackingSlaveSD       *slave;
   BHMNumberingScheme    *numberingScheme;
   
-  G4ThreeVector          entrancePoint, exitPoint;
-  G4ThreeVector          theEntryPoint, theExitPoint;
-  
-  float                  incidentEnergy;
-  G4int                  primID  ; 
-  
-  G4int                  hcID;
-  BscG4HitCollection*    theHC; 
-  const SimTrackManager* theManager;
- 
-  G4int                  tsID; 
-  BscG4Hit*              currentHit;
-  G4Track*               theTrack;
-  G4VPhysicalVolume*     currentPV;
-  uint32_t               unitID, previousUnitID;
-  G4int                  primaryID, tSliceID;  
-  G4double               tSlice;
-  
-  G4StepPoint*           preStepPoint; 
-  G4StepPoint*           postStepPoint; 
-  float                  edeposit;
-  
-  G4ThreeVector          hitPoint;
-  G4ThreeVector          hitPointExit;
-  G4ThreeVector          hitPointLocal;
-  G4ThreeVector          hitPointLocalExit;
-
-  float                  Pabs, Tof, Eloss;	
-  short                  ParticleType; 
-  float                  ThetaAtEntry, PhiAtEntry;
-  
-  int                    ParentId;
-  float                  Vx,Vy,Vz;
-  float                  X,Y,Z;
-  
-  int                    eventno;
-  
-protected:
-  
-  float                  edepositEM, edepositHAD;
-  G4int                  emPDG;
-  G4int                  epPDG;
-  G4int                  gammaPDG;
 };
 
 #endif

--- a/SimG4CMS/Forward/interface/Bcm1fSD.h
+++ b/SimG4CMS/Forward/interface/Bcm1fSD.h
@@ -1,36 +1,14 @@
 #ifndef Forward_Bcm1fSD_h
 #define Forward_Bcm1fSD_h
  
-// system include files
+#include "SimG4CMS/Forward/interface/TimingSD.h"
 
-// user include files
-
-#include "SimG4Core/Notification/interface/Observer.h"
-#include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
-#include "SimG4Core/Notification/interface/BeginOfJob.h"
-#include "SimG4Core/Notification/interface/BeginOfEvent.h"
-#include "SimG4Core/Notification/interface/BeginOfTrack.h"
-
-#include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
-#include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
-
-#include "G4Step.hh"
-#include "G4StepPoint.hh"
-#include "G4Track.hh"
- 
 #include <string>
 
-class TrackInformation;
 class SimTrackManager;
-class TrackingSlaveSD;
-class UpdatablePSimHit;
-class G4ProcessTypeEnumerator;
-class G4TrackToParticleID;
+class G4Step;
 
-class Bcm1fSD : public SensitiveTkDetector,
-                             public Observer<const BeginOfEvent*>,
-                             public Observer<const BeginOfTrack*>,
-                             public Observer<const BeginOfJob*> {
+class Bcm1fSD : public TimingSD {
 
 public:
 
@@ -39,42 +17,16 @@ public:
 	  edm::ParameterSet const &, const SimTrackManager*);
   ~Bcm1fSD() override;
 
-  bool     ProcessHits(G4Step *,G4TouchableHistory *) override;
   uint32_t setDetUnitId(const G4Step*) override;
-  void EndOfEvent(G4HCofThisEvent*) override;
 
-  void fillHits(edm::PSimHitContainer&, const std::string&) override;
-  void clearHits() override;
+protected:
 
-private:
-
-  virtual void   sendHit();
-  virtual void   updateHit(G4Step *);
-  virtual bool   newHit(G4Step *);
-  virtual bool   closeHit(G4Step *);
-  virtual void   createHit(G4Step *);
-  void           update(const BeginOfEvent *) override;
-  void           update(const BeginOfTrack *) override;
-  void           update(const BeginOfJob *) override;
-  TrackInformation* getOrCreateTrackInformation(const G4Track *);
+  bool checkHit(const G4Step*, BscG4Hit*) override;
 
 private:
 
-  TrackingSlaveSD*            slave;
-  G4ProcessTypeEnumerator * theG4ProcessTypeEnumerator;
-  G4TrackToParticleID * myG4TrackToParticleID;
-  UpdatablePSimHit * mySimHit;
   float energyCut;
   float energyHistoryCut;
-
-  Local3DPoint globalEntryPoint;
-  Local3DPoint globalExitPoint;
-  G4VPhysicalVolume * oldVolume;
-  uint32_t lastId;
-  unsigned int lastTrack;
-  int eventno;
-  std::string pname;
-
 };
 
 #endif

--- a/SimG4CMS/Forward/interface/BscG4Hit.h
+++ b/SimG4CMS/Forward/interface/BscG4Hit.h
@@ -24,109 +24,110 @@ public:
   const BscG4Hit& operator=(const BscG4Hit &right);
   int operator==(const BscG4Hit &){return 0;}
   
-  void         Draw() override{}
-  void         Print() override;
+  void          Draw() override{}
+  void          Print() override;
   
 public:
   
-  G4ThreeVector   getEntry() const;
-  void         setEntry(const G4ThreeVector& xyz);
+  const G4ThreeVector& getEntry() const            { return entry; };
+  void          setEntry(const G4ThreeVector& xyz);
   
-  G4ThreeVector    getEntryLocalP() const;
-  void         setEntryLocalP(const G4ThreeVector& xyz1);
+  const G4ThreeVector& getEntryLocalP() const      { return entrylp; };
+  void          setEntryLocalP(const G4ThreeVector& xyz) { entrylp = xyz; };
 
-  G4ThreeVector    getExitLocalP() const;
-  void         setExitLocalP(const G4ThreeVector& xyz1);
+  const G4ThreeVector& getExitLocalP() const       { return exitlp; };
+  void          setExitLocalP(const G4ThreeVector& xyz)  { exitlp = xyz; };
 
-  float        getEM() const;
-  void         setEM (float e);
+  float         getEM() const                      { return elem; };       
+  void          setEM (float e)                    { elem = e; theEnergyLoss = elem + hadr; };
   
-  float        getHadr() const;
-  void         setHadr (float e);
+  float         getHadr() const                    { return hadr; };
+  void          setHadr (float e)                  { hadr = e; theEnergyLoss = elem + hadr; };
   
-  float        getIncidentEnergy() const;
-  void         setIncidentEnergy (float e);
+  float         getIncidentEnergy() const          { return theIncidentEnergy; };
+  void          setIncidentEnergy (float e)        { theIncidentEnergy = e; };
   
-  int          getTrackID() const;
-  void         setTrackID (int i);
+  int           getTrackID() const                 { return theTrackID; };
+  void          setTrackID (int id)                { theTrackID = id; };
   
-  uint32_t     getUnitID() const;
-  void         setUnitID (uint32_t i);
+  uint32_t      getUnitID() const                  { return theUnitID; };      
+  void          setUnitID (uint32_t id)            { theUnitID = id; };
   
-  double       getTimeSlice() const;     
-  void         setTimeSlice(double d);
-  int          getTimeSliceID() const;     
+  double        getTimeSlice() const               { return theTimeSlice; };
+  void          setTimeSlice(double d)             { theTimeSlice = d; };
+  int           getTimeSliceID() const             { return (int)theTimeSlice; };  
+  void          addEnergyDeposit(float em, float hd);
+  void          addEnergyDeposit(const BscG4Hit& aHit);
   
-  void         addEnergyDeposit(float em, float hd);
-  void         addEnergyDeposit(const BscG4Hit& aHit);
+  float         getEnergyDeposit() const           { return theEnergyLoss; };
   
-  float        getEnergyDeposit() const;
-  
-  float getPabs() const;
-  float getTof() const;
-  float getEnergyLoss() const;
-  int getParticleType() const;
+  float getPabs() const                            { return thePabs; };
+  float getTof() const                             { return theTof; };
+  float getEnergyLoss() const                      { return theEnergyLoss; };
+  int getParticleType() const                      { return theParticleType; };
 
-  void setPabs(float e);
-  void setTof(float e);
-  void setEnergyLoss(float e);
-  void setParticleType(int i);
+  void setPabs(float e)                            { thePabs = e; };
+  void setTof(float e)                             { theTof = e; };
+  void setEnergyLoss(float e)                      { theEnergyLoss = e; };
+  void setParticleType(int i)                      { theParticleType = i; };
 
-  float getThetaAtEntry() const;   
-  float getPhiAtEntry() const;
+  float getThetaAtEntry() const                    { return theThetaAtEntry; };
+  float getPhiAtEntry() const                      { return thePhiAtEntry; };
 
-  void setThetaAtEntry(float t);
-  void setPhiAtEntry(float f) ;
+  void setThetaAtEntry(float t)                    { theThetaAtEntry = t; };
+  void setPhiAtEntry(float f)                      { thePhiAtEntry = f; };
 
-    float getX() const;
-    void setX(float t);
-    float getY() const;
-    float getZ() const;
-    void setY(float t);
-    void setZ(float t);
+  float getX() const                               { return theX; };
+  void  setX(float t)                              { theX = t; };
+  float getY() const                               { return theY; };
+  float getZ() const                               { return theZ; };
+  void  setY(float t)                              { theY = t; };
+  void  setZ(float t)                              { theZ = t; };
 
+  void  setHitPosition(const G4ThreeVector&);
+  void  setVertexPosition(const G4ThreeVector&);
 
-    int getParentId() const;
-    float getVx() const;
-    float getVy() const;
-    float getVz() const;
+  int getParentId() const                          { return theParentId; };
+  int getProcessId() const                         { return theProcessId; };
+  float getVx() const                              { return theVx; };
+  float getVy() const                              { return theVy; };
+  float getVz() const                              { return theVz; };
 
-    void setParentId(int p);
-    void setVx(float p);
-    void setVy(float p);
-    void setVz(float p);
-
+  void setParentId(int p)                          { theParentId = p; };
+  void setProcessId(int p)                         { theProcessId = p; };
+  void setVx(float p)                              { theVx = p; };
+  void setVy(float p)                              { theVy = p; };
+  void setVz(float p)                              { theVz = p; };
 
 private:
   
-    G4ThreeVector entry;             //Entry point
-    G4ThreeVector entrylp;    //Entry  local point
-    G4ThreeVector exitlp;    //Exit  local point
+  G4ThreeVector entry;           //Entry point
+  G4ThreeVector entrylp;         //Entry  local point
+  G4ThreeVector exitlp;          //Exit  local point
   float       elem;              //EnergyDeposit of EM particles
   float       hadr;              //EnergyDeposit of HD particles
   float       theIncidentEnergy; //Energy of the primary particle
-  int          theTrackID;        //Identification number of the primary
-                                  //particle
-  double       theTimeSlice;      //Time Slice Identification
+  int         theTrackID;        //Geant4 track ID
+  double      theTimeSlice;      //Time Slice Identification
 
-  int theUnitID;         //Bsc Unit Number
+  int theUnitID;                 // Unit Number
 
   float theX;
   float theY;
   float theZ;
-  float thePabs  ;
-    float theTof ;
-    float theEnergyLoss   ;
-    int theParticleType ;
+  float thePabs;
+  float theTof;
+  float theEnergyLoss;
+  int theParticleType;
 
+  float theThetaAtEntry;
+  float thePhiAtEntry;
 
-  float theThetaAtEntry ;
-    float thePhiAtEntry    ;
-
-    int theParentId;
-    float theVx;
-    float theVy;
-    float theVz;
+  int theParentId;
+  int theProcessId;
+  float theVx;
+  float theVy;
+  float theVz;
 };
 
 std::ostream& operator<<(std::ostream&, const BscG4Hit&);

--- a/SimG4CMS/Forward/interface/BscG4HitCollection.h
+++ b/SimG4CMS/Forward/interface/BscG4HitCollection.h
@@ -9,8 +9,6 @@
 
 #include "G4THitsCollection.hh"
 #include "SimG4CMS/Forward/interface/BscG4Hit.h"
-#include "G4Step.hh"
-#include <boost/cstdint.hpp>
 
 typedef G4THitsCollection<BscG4Hit> BscG4HitCollection;
 

--- a/SimG4CMS/Forward/interface/BscNumberingScheme.h
+++ b/SimG4CMS/Forward/interface/BscNumberingScheme.h
@@ -8,33 +8,22 @@
 #define BscNumberingScheme_h
 
 #include "G4Step.hh"
-#include <boost/cstdint.hpp>
-#include "G4ThreeVector.hh"
-#include <map>
-
-
-
+#include <cstdint>
 
 class BscNumberingScheme {
   
- public:
+public:
   BscNumberingScheme();
-  virtual ~BscNumberingScheme();
+  ~BscNumberingScheme() = default;
   
-  virtual unsigned int getUnitID(const G4Step* aStep) const;
+  unsigned int getUnitID(const G4Step* aStep) const;
   
   // Utilities to get detector levels during a step
-  virtual int  detectorLevel(const G4Step*) const;
-  virtual void detectorLevel(const G4Step*, int&, int*, G4String*) const;
-  
-  
-  //protected:
-  
-  static unsigned int packBscIndex(int det, int zside, int station);
-  
+  int  detectorLevel(const G4Step*) const;
+  void detectorLevel(const G4Step*, int&, int*, G4String*) const;
+
+  static unsigned int packBscIndex(int det, int zside, int station);  
   static void unpackBscIndex(const unsigned int& idx);
-  
-  
   
 };
 

--- a/SimG4CMS/Forward/interface/BscSD.h
+++ b/SimG4CMS/Forward/interface/BscSD.h
@@ -1,111 +1,31 @@
-//
-#ifndef Bsc_BscSD_h
-#define Bsc_BscSD_h
-//
+#ifndef SimG4CMSForward_BscSD_h
+#define SimG4CMSForward_BscSD_h
 
-#include "SimG4Core/Notification/interface/Observer.h"
-#include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
-
-#include "SimG4Core/Notification/interface/BeginOfEvent.h"
-
-#include "SimG4CMS/Forward/interface/BscG4Hit.h"
-#include "SimG4CMS/Forward/interface/BscG4HitCollection.h"
-#include "SimG4CMS/Forward/interface/BscNumberingScheme.h"
+#include "SimG4CMS/Forward/interface/TimingSD.h"
   
-#include "G4Step.hh"
-#include "G4StepPoint.hh"
-#include "G4Track.hh"
-#include "G4VPhysicalVolume.hh"
-
 #include <string>
 
-class TrackingSlaveSD;
-class TrackInformation;
 class SimTrackManager;
-class TrackingSlaveSD;
-class UpdatablePSimHit;
-class G4ProcessTypeEnumerator;
-class G4TrackToParticleID;
-
+class BscNumberingScheme;
 
 //-------------------------------------------------------------------
 
-class BscSD : public SensitiveTkDetector,
-              public Observer<const BeginOfEvent *>{
+class BscSD : public TimingSD {
 
 public:
   
-  BscSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
+  BscSD(const std::string&, const DDCompactView &, 
+        const SensitiveDetectorCatalog &,
 	edm::ParameterSet const &, const SimTrackManager* );
 
   ~BscSD() override;
   
-  bool ProcessHits(G4Step *,G4TouchableHistory *) override;
   uint32_t  setDetUnitId(const G4Step*) override;
-
-  void Initialize(G4HCofThisEvent * HCE) override;
-  void EndOfEvent(G4HCofThisEvent * eventHC) override;
-  void PrintAll() override;
-
-  double getEnergyDeposit(const G4Step* step);
-  void fillHits(edm::PSimHitContainer&, const std::string&) override;
-  void clearHits() override;
-  
-protected:
-
-  void          update(const BeginOfEvent *) override;
   
 private:
-  G4ThreeVector setToLocal(const G4ThreeVector& global);
-  G4ThreeVector setToLocalExit(const G4ThreeVector& globalPoint);
-  void          getStepInfo(const G4Step* aStep);
-  bool          hitExists();
-  void          createNewHit();
-  void          updateHit();
-  void          storeHit(BscG4Hit*);
-  void          resetForNewPrimary();
-  
-  TrackingSlaveSD* slave;
+
   BscNumberingScheme * numberingScheme;
   
-  G4ThreeVector entrancePoint, exitPoint;
-  G4ThreeVector theEntryPoint ;
-  G4ThreeVector theExitPoint  ;
-  
-  float                incidentEnergy;
-  G4int                primID  ; 
-
-  G4int                    hcID;
-  BscG4HitCollection*       theHC; 
-  const SimTrackManager*      theManager;
- 
-  G4int                    tsID; 
-  BscG4Hit*               currentHit;
-  const G4Track*           theTrack;
-  const G4VPhysicalVolume* currentPV;
-  uint32_t             unitID, previousUnitID;
-  G4int                primaryID, tSliceID;  
-  G4double             tSlice;
-  
-  const G4StepPoint*   preStepPoint; 
-  const G4StepPoint*   postStepPoint; 
-  float                edeposit;
-  
-  G4ThreeVector        hitPoint;
-  G4ThreeVector        hitPointExit;
-  G4ThreeVector        hitPointLocal;
-  G4ThreeVector        hitPointLocalExit;
-  float Pabs;
-  float Tof;
-  int particleCode; 
-  
-  float ThetaAtEntry;
-  float PhiAtEntry;
-  
-  int ParentId;
-  float Vx,Vy,Vz;
-  float X,Y,Z;
-  float edepositEM, edepositHAD;
 };
 
 #endif // BscSD_h

--- a/SimG4CMS/Forward/interface/FastTimerSD.h
+++ b/SimG4CMS/Forward/interface/FastTimerSD.h
@@ -1,112 +1,46 @@
 #ifndef SimG4CMSForward_FastTimerSD_h
 #define SimG4CMSForward_FastTimerSD_h
 
+#include "SimG4CMS/Forward/interface/TimingSD.h"
+
 #include "DetectorDescription/Core/interface/DDsvalues.h"
 #include "SimG4Core/Notification/interface/Observer.h"
-#include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
-
 #include "SimG4Core/Notification/interface/BeginOfJob.h"
-#include "SimG4Core/Notification/interface/BeginOfEvent.h"
-
-#include "SimG4CMS/Forward/interface/BscG4Hit.h"
-#include "SimG4CMS/Forward/interface/BscG4HitCollection.h"
-#include "Geometry/HGCalCommonData/interface/FastTimeDDDConstants.h"
   
-#include "G4Step.hh"
-#include "G4StepPoint.hh"
-#include "G4Track.hh"
-#include "G4VPhysicalVolume.hh"
-
 #include <string>
+#include <vector>
 
-class TrackingSlaveSD;
-class TrackInformation;
+class G4Step;
 class SimTrackManager;
-class TrackingSlaveSD;
-class UpdatablePSimHit;
-class G4ProcessTypeEnumerator;
+class FastTimeDDDConstants;
 
 //-------------------------------------------------------------------
 
-class FastTimerSD : public SensitiveTkDetector,
-                    public Observer<const BeginOfJob *>,
-                    public Observer<const BeginOfEvent*>{
+class FastTimerSD : public TimingSD,
+                    public Observer<const BeginOfJob *>{
 
 public:
   
-  FastTimerSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &, 
+  FastTimerSD(const std::string&, const DDCompactView &, 
+              const SensitiveDetectorCatalog &, 
 	      edm::ParameterSet const &, const SimTrackManager* );
 
   ~FastTimerSD() override;
   
-  bool     ProcessHits(G4Step *,G4TouchableHistory *) override;
   uint32_t setDetUnitId(const G4Step*) override;
-
-  void     Initialize(G4HCofThisEvent * HCE) override;
-  void     EndOfEvent(G4HCofThisEvent * eventHC) override;
-  void     PrintAll() override;
-
-  double   getEnergyDeposit(const G4Step* step);
-  void     fillHits(edm::PSimHitContainer&, const std::string&) override;
-  void     clearHits() override;
   
 protected:
+
   void     update(const BeginOfJob *) override;
-  void     update(const BeginOfEvent *) override;
 
 private:
-  G4ThreeVector    SetToLocal(const G4ThreeVector& global);
-  G4ThreeVector    SetToLocalExit(const G4ThreeVector& globalPoint);
-  void             GetStepInfo(G4Step* aStep);
-  G4bool           HitExists();
-  void             CreateNewHit();
-  void             UpdateHit();
-  void             StoreHit(BscG4Hit*);
-  void             ResetForNewPrimary();
+
   std::vector<double> getDDDArray(const std::string &, const DDsvalues_type &);
   
 private:
   
-  TrackingSlaveSD             *slave;
   const FastTimeDDDConstants  *ftcons;
-  int                          type_;
-
-  G4ThreeVector                entrancePoint, exitPoint;
-  G4ThreeVector                theEntryPoint, theExitPoint;
-  
-  float                        incidentEnergy;
-  G4int                        primID  ; 
-  
-  G4int                        hcID;
-  BscG4HitCollection*          theHC; 
-  const SimTrackManager*       theManager;
- 
-  G4int                        tsID; 
-  BscG4Hit*                    currentHit;
-  const G4Track*               theTrack;
-  const G4VPhysicalVolume*     currentPV;
-  uint32_t                     unitID, previousUnitID;
-  G4int                        primaryID, tSliceID;  
-  G4double                     tSlice;
-  
-  const G4StepPoint*           preStepPoint; 
-  const G4StepPoint*           postStepPoint; 
-  float                        edeposit;
-  
-  G4ThreeVector                hitPoint;
-  G4ThreeVector                hitPointExit;
-  G4ThreeVector                hitPointLocal;
-  G4ThreeVector                hitPointLocalExit;
-
-  float                        Pabs, Tof, Eloss;	
-  float                        ThetaAtEntry, PhiAtEntry;
-  
-  int                          particleType; 
-  int                          ParentId;
-  float                        Vx,Vy,Vz;
-  float                        X,Y,Z;
-  
-  float                        edepositEM, edepositHAD;
+  int type_;
 };
 
 #endif

--- a/SimG4CMS/Forward/interface/MtdSD.h
+++ b/SimG4CMS/Forward/interface/MtdSD.h
@@ -1,119 +1,43 @@
 #ifndef SimG4CMSForward_MtdSD_h
 #define SimG4CMSForward_MtdSD_h
 
+#include "SimG4CMS/Forward/interface/TimingSD.h"
+
 #include "DetectorDescription/Core/interface/DDsvalues.h"
-#include "SimG4Core/Notification/interface/Observer.h"
-#include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
-
-#include "SimG4Core/Notification/interface/BeginOfJob.h"
-#include "SimG4Core/Notification/interface/BeginOfRun.h"
-#include "SimG4Core/Notification/interface/BeginOfEvent.h"
-#include "SimG4Core/Notification/interface/EndOfEvent.h"
-
-#include "SimG4CMS/Forward/interface/BscG4Hit.h"
-#include "SimG4CMS/Forward/interface/BscG4HitCollection.h"
 #include "Geometry/MTDCommonData/interface/MTDNumberingScheme.h"
+#include "Geometry/MTDCommonData/interface/MTDBaseNumber.h"
   
-#include "G4Step.hh"
-#include "G4StepPoint.hh"
-#include "G4Track.hh"
-#include "G4VPhysicalVolume.hh"
-
 #include <string>
+#include <vector>
 
-class TrackingSlaveSD;
-class TrackInformation;
+class G4Step;
 class SimTrackManager;
-class TrackingSlaveSD;
-class UpdatablePSimHit;
-class G4ProcessTypeEnumerator;
-class G4TrackToParticleID;
-class MTDBaseNumber;
 
 //-------------------------------------------------------------------
 
-class MtdSD : public SensitiveTkDetector,
-                    public Observer<const BeginOfEvent*>{
+class MtdSD : public TimingSD
+{
 
 public:
   
-  MtdSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &, 
-	      edm::ParameterSet const &, const SimTrackManager* );
+  MtdSD(const std::string&, const DDCompactView &, 
+        const SensitiveDetectorCatalog &, 
+	edm::ParameterSet const &, const SimTrackManager* );
 
   ~MtdSD() override;
   
-  bool     ProcessHits(G4Step *,G4TouchableHistory *) override;
   uint32_t setDetUnitId(const G4Step*) override;
 
-  void     Initialize(G4HCofThisEvent * HCE) override;
-  void     EndOfEvent(G4HCofThisEvent * eventHC) override;
-  void     PrintAll() override;
-
-  void     fillHits(edm::PSimHitContainer&, const std::string&) override;
-  void     clearHits() override;
-  
-protected:
-  void     update(const BeginOfEvent *) override;
-
 private:
-  G4ThreeVector    SetToLocal(const G4ThreeVector& global);
-  G4ThreeVector    SetToLocalExit(const G4ThreeVector& globalPoint);
-  void             GetStepInfo(const G4Step* aStep);
-  G4bool           HitExists();
-  void             CreateNewHit();
-  void             UpdateHit();
-  void             StoreHit(BscG4Hit*);
-  void             ResetForNewPrimary();
+
   std::vector<double> getDDDArray(const std::string &, const DDsvalues_type &);
   void             setNumberingScheme(MTDNumberingScheme*);
   void             getBaseNumber(const G4Step*);
-  
-private:
-  
-  TrackingSlaveSD             *slave;
-  int                          type_;
-
-  G4ThreeVector                entrancePoint, exitPoint;
-  G4ThreeVector                theEntryPoint, theExitPoint;
-  
-  float                        incidentEnergy;
-  G4int                        primID  ; 
-  
-  G4int                        hcID;
-  BscG4HitCollection*          theHC; 
-  const SimTrackManager*       theManager;
- 
-  G4int                        tsID; 
-  BscG4Hit*                    currentHit;
-  const G4Track*               theTrack;
-  const G4VPhysicalVolume*     currentPV;
-  uint32_t                     unitID, previousUnitID;
-  G4int                        primaryID, tSliceID;  
-  G4double                     tSlice;
-  
-  const G4StepPoint*           preStepPoint; 
-  const G4StepPoint*           postStepPoint; 
-  float                        edeposit;
-  
-  G4ThreeVector                hitPoint;
-  G4ThreeVector                hitPointExit;
-  G4ThreeVector                hitPointLocal;
-  G4ThreeVector                hitPointLocalExit;
-
-  float                        Pabs, Tof;	
-  int                          ParticleType; 
-  float                        ThetaAtEntry, PhiAtEntry;
-  
-  int                          ParentId;
-  float                        Vx,Vy,Vz;
-  float                        X,Y,Z;
   
   MTDNumberingScheme *         numberingScheme;
   MTDBaseNumber                theBaseNumber;
   bool                         isBTL;
   bool                         isETL;
-  
-  float                        edepositEM, edepositHAD;
 };
 
 #endif

--- a/SimG4CMS/Forward/interface/PltSD.h
+++ b/SimG4CMS/Forward/interface/PltSD.h
@@ -1,31 +1,14 @@
 #ifndef Forward_PltSD_h
 #define Forward_PltSD_h
  
-// system include files
-
-// user include files
-
-#include "SimG4Core/Notification/interface/Observer.h"
-#include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
-#include "SimG4Core/Notification/interface/BeginOfEvent.h"
-
-#include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
-
-#include "G4Step.hh"
-#include "G4StepPoint.hh"
-#include "G4Track.hh"
+#include "SimG4CMS/Forward/interface/TimingSD.h"
  
 #include <string>
 
-class TrackInformation;
+class G4Step;
 class SimTrackManager;
-class TrackingSlaveSD;
-class UpdatablePSimHit;
-class G4ProcessTypeEnumerator;
-class G4ParticleDefinition;
 
-class PltSD : public SensitiveTkDetector,
-  public Observer<const BeginOfEvent*>{
+class PltSD : public TimingSD {
 
 public:
 
@@ -34,39 +17,16 @@ public:
 	edm::ParameterSet const &, const SimTrackManager*);
   ~PltSD() override;
 
-  bool     ProcessHits(G4Step *,G4TouchableHistory *) override;
   uint32_t setDetUnitId(const G4Step*) override;
-  void EndOfEvent(G4HCofThisEvent*) override;
-
-  void fillHits (edm::PSimHitContainer&, const std::string&) override;
-  void clearHits() override;
-
-private:
-
-  virtual void   sendHit();
-  virtual void   updateHit(const G4Step *);
-  virtual bool   newHit(const G4Step *);
-  virtual bool   closeHit(const G4Step *);
-  virtual void   createHit(const G4Step *);
 
 protected:
 
-  void           update(const BeginOfEvent *) override;
+  bool checkHit(const G4Step*, BscG4Hit*) override;
 
 private:
 
-  TrackingSlaveSD* slave;
-  G4ProcessTypeEnumerator * theG4ProcessTypeEnumerator;
-  UpdatablePSimHit * mySimHit;
   double energyCut;
   double energyHistoryCut;
-
-  Local3DPoint globalEntryPoint;
-  Local3DPoint globalExitPoint;
-  const G4VPhysicalVolume * oldVolume;
-  uint32_t lastId;
-  int lastTrack;
-  const G4ParticleDefinition* particle;
 };
 
 #endif

--- a/SimG4CMS/Forward/interface/TimingSD.h
+++ b/SimG4CMS/Forward/interface/TimingSD.h
@@ -1,0 +1,119 @@
+#ifndef Forward_TimingSD_h
+#define Forward_TimingSD_h
+//
+// Base sensitive class for timing detectors and sensors
+//
+// Created 17 June 2018 V.Ivantchenko
+//
+
+#include "SimG4Core/Notification/interface/Observer.h"
+#include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
+
+#include "SimG4Core/Notification/interface/BeginOfEvent.h"
+
+#include "SimG4CMS/Forward/interface/BscG4Hit.h"
+#include "SimG4CMS/Forward/interface/BscG4HitCollection.h"
+
+#include <string>
+
+class G4Step;
+class G4StepPoint;
+class G4Track;
+class G4VPhysicalVolume;
+class TrackingSlaveSD;
+class SimTrackManager;
+class G4ProcessTypeEnumerator;
+
+//-------------------------------------------------------------------
+
+class TimingSD : public SensitiveTkDetector,
+                 public Observer<const BeginOfEvent *>{
+
+public:
+  
+  TimingSD(const std::string&, const DDCompactView&, 
+           const SensitiveDetectorCatalog&,
+	   const edm::ParameterSet&, const SimTrackManager*);
+
+  ~TimingSD() override;
+  
+  bool ProcessHits(G4Step *,G4TouchableHistory *) override;
+
+  void Initialize(G4HCofThisEvent * HCE) override;
+  void EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void PrintAll() override;
+
+  void fillHits(edm::PSimHitContainer&, const std::string&) override;
+  void clearHits() override;
+  
+protected:
+
+  void update(const BeginOfEvent *) override;
+
+  // define time slices
+  void setTimeFactor(double);
+
+  // define MC truth thresholds
+  void setCuts(double eCut, double historyCut);
+
+  // by default accumulate hit for the same detector
+  // and time slice, use primary information for fastest 
+  // Geant4 particle, check if for this detector new
+  // hit can be merged with the existing one
+  virtual bool checkHit(const G4Step*, BscG4Hit*);
+
+  void setToLocal(const G4StepPoint* stepPoint,
+                  const G4ThreeVector& globalPoint, G4ThreeVector& localPoint);
+
+  // accessors
+  const G4ThreeVector& getLocalEntryPoint() const { return hitPointLocal; };
+  const G4ThreeVector& getGlobalEntryPoint() const { return hitPoint; };
+
+private:
+  void          getStepInfo(const G4Step*);
+  bool          hitExists(const G4Step*);
+  void          createNewHit(const G4Step*);
+  void          updateHit();
+  void          storeHit(BscG4Hit*);
+  
+  TrackingSlaveSD* slave;
+  G4ProcessTypeEnumerator* theEnumerator;
+    
+  const SimTrackManager*   theManager;
+  BscG4HitCollection*      theHC; 
+
+  BscG4Hit*                currentHit;
+  const G4Track*           theTrack;
+  const G4StepPoint*       preStepPoint; 
+  const G4StepPoint*       postStepPoint; 
+
+  uint32_t unitID, previousUnitID;
+
+  int primID; 
+  int hcID; 
+  int tsID; 
+  int primaryID;
+  int tSliceID;  
+
+  G4ThreeVector  hitPoint;
+  G4ThreeVector  hitPointExit;
+  G4ThreeVector  hitPointLocal;
+  G4ThreeVector  hitPointLocalExit;
+
+  double tSlice;
+  double timeFactor;
+
+  double energyCut;        // MeV
+  double energyHistoryCut; // MeV
+  
+  double incidentEnergy;   // MeV
+  float  tof;              // ns
+  float  edeposit;
+  float  edepositEM, edepositHAD;
+};
+
+#endif
+
+
+
+

--- a/SimG4CMS/Forward/interface/TotemRPOrganization.h
+++ b/SimG4CMS/Forward/interface/TotemRPOrganization.h
@@ -34,7 +34,7 @@ public:
   ~TotemRPOrganization() override;
 
   // ---------- member functions ---------------------------
-  uint32_t         GetUnitID(const G4Step* aStep) const override;
+  uint32_t getUnitID(const G4Step* aStep) const override;
 
 };
 #endif

--- a/SimG4CMS/Forward/interface/TotemSD.h
+++ b/SimG4CMS/Forward/interface/TotemSD.h
@@ -65,15 +65,15 @@ protected:
 
 private:
 
-  G4ThreeVector  SetToLocal(const G4ThreeVector& globalPoint);
-  void           GetStepInfo(const G4Step* aStep);
-  bool           HitExists();
-  void           CreateNewHit();
-  void           CreateNewHitEvo();
-  G4ThreeVector  PosizioEvo(const G4ThreeVector&,double ,double ,double, double,int&);
-  void           UpdateHit();
-  void           StoreHit(TotemG4Hit*);
-  void           ResetForNewPrimary();
+  G4ThreeVector  setToLocal(const G4ThreeVector& globalPoint);
+  void           getStepInfo(const G4Step* aStep);
+  bool           hitExists();
+  void           createNewHit();
+  void           createNewHitEvo();
+  G4ThreeVector  posizioEvo(const G4ThreeVector&,double ,double ,double, double,int&);
+  void           updateHit();
+  void           storeHit(TotemG4Hit*);
+  void           resetForNewPrimary();
 
 private:
 

--- a/SimG4CMS/Forward/interface/TotemT1Organization.h
+++ b/SimG4CMS/Forward/interface/TotemT1Organization.h
@@ -57,40 +57,40 @@ public:
   ~TotemT1Organization() override;
 
   // ---------- member functions ---------------------------
-  uint32_t         GetUnitID(const G4Step* aStep) const override;
+  uint32_t         getUnitID(const G4Step* aStep) const override;
   
-  int              GetCurrentUnitID(void) const;
-  void             SetCurrentUnitID(int currentUnitID);
+  int              getCurrentUnitID(void) const;
+  void             setCurrentUnitID(int currentUnitID);
 
   // ---------- Detector position --------------------------
 
-  int              GetCurrentDetectorPosition(void) const;
-  void             SetCurrentDetectorPosition(int currentDetectorPosition);
+  int              getCurrentDetectorPosition(void) const;
+  void             setCurrentDetectorPosition(int currentDetectorPosition);
 
   // ---------- Plane: between 0 and (nPlanes-1) (or -1 for Undefined)
-  int              GetCurrentPlane(void) const;
-  void             SetCurrentPlane(int currentPlane);
+  int              getCurrentPlane(void) const;
+  void             setCurrentPlane(int currentPlane);
 
   // ---------- CSC: between 0 and 5 (or -1 for Undefined)
-  int              GetCurrentCSC(void) const;
-  void             SetCurrentCSC(int currentCSC);
+  int              getCurrentCSC(void) const;
+  void             setCurrentCSC(int currentCSC);
 
   // ---------- Layer: between 0 and (nLayers-1) (or -1 for Undefined)
-  int              GetCurrentLayer(void) const;
-  void             SetCurrentLayer(int currentLayer);
+  int              getCurrentLayer(void) const;
+  void             setCurrentLayer(int currentLayer);
 
   // ---------- Object Type --------------------------------
 
-  ObjectType       GetCurrentObjectType(void) const;
-  void             SetCurrentObjectType(ObjectType currentObjectType);
+  ObjectType       getCurrentObjectType(void) const;
+  void             setCurrentObjectType(ObjectType currentObjectType);
 
-  int              FromObjectTypeToInt(ObjectType objectType);
-  int              FromObjectTypeToInt(ObjectType objectType, int layer);
+  int              fromObjectTypeToInt(ObjectType objectType);
+  int              fromObjectTypeToInt(ObjectType objectType, int layer);
 
   // ---------- Private methods ----------------------------
 
 private:
-  uint32_t         GetUnitID(const G4Step* aStep);
+  uint32_t         getUnitID(const G4Step* aStep);
 
   void             _checkUnitIDUpdate(void) const;
   void             _checkDataUpdate(void) const;

--- a/SimG4CMS/Forward/interface/TotemT2OrganizationGem.h
+++ b/SimG4CMS/Forward/interface/TotemT2OrganizationGem.h
@@ -33,7 +33,7 @@ public:
   ~TotemT2OrganizationGem() override;
 
   // ---------- member functions ---------------------------
-  uint32_t         GetUnitID(const G4Step* aStep) const override;
+  uint32_t getUnitID(const G4Step* aStep) const override;
 
 };
 

--- a/SimG4CMS/Forward/interface/TotemVDetectorOrganization.h
+++ b/SimG4CMS/Forward/interface/TotemVDetectorOrganization.h
@@ -13,7 +13,7 @@ class TotemVDetectorOrganization {
 public:
   TotemVDetectorOrganization(){};
   virtual ~TotemVDetectorOrganization(){};   
-  virtual uint32_t GetUnitID(const  G4Step* aStep) const =0;
+  virtual uint32_t getUnitID(const  G4Step* aStep) const =0;
 };      
 
 

--- a/SimG4CMS/Forward/src/BHMNumberingScheme.cc
+++ b/SimG4CMS/Forward/src/BHMNumberingScheme.cc
@@ -7,17 +7,11 @@ BHMNumberingScheme::BHMNumberingScheme() {
   LogDebug("BHMSim") << " Creating BHMNumberingScheme" ;
 }
 
-BHMNumberingScheme::~BHMNumberingScheme() {
-  LogDebug("BHMSim") << " Deleting BHMNumberingScheme" ;
-}
-
 int BHMNumberingScheme::detectorLevel(const G4Step* aStep) const {
 
   //Find number of levels
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
-  int level = 0;
-  if (touch) level = ((touch->GetHistoryDepth())+1);
-  return level;
+  return (touch) ? ((touch->GetHistoryDepth())+1) : 0;
 }
 
 void BHMNumberingScheme::detectorLevel(const G4Step* aStep, int& level,
@@ -26,7 +20,7 @@ void BHMNumberingScheme::detectorLevel(const G4Step* aStep, int& level,
   //Get name and copy numbers
   if (level > 0) {
     const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
-    for (int ii = 0; ii < level; ii++) {
+    for (int ii = 0; ii < level; ++ii) {
       int i      = level - ii - 1;
       name[ii]   = touch->GetVolume(i)->GetName();
       copyno[ii] = touch->GetReplicaNumber(i);
@@ -63,7 +57,7 @@ unsigned int BHMNumberingScheme::getUnitID(const G4Step* aStep) const {
   
 }
 
-unsigned BHMNumberingScheme::packIndex(int subdet, int zside, int station) {
+unsigned int BHMNumberingScheme::packIndex(int subdet, int zside, int station) {
 
   unsigned int idx = ((6<<28)|(subdet&0x7)<<25); // Use 6 as the detector name
   idx |= ((zside&0x3)<<5) | (station&0x1F);   // bits 0-4:station 5-6:side

--- a/SimG4CMS/Forward/src/BHMSD.cc
+++ b/SimG4CMS/Forward/src/BHMSD.cc
@@ -1,48 +1,26 @@
-#include "SimG4Core/Notification/interface/TrackInformation.h"
-#include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
-#include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
-
-#include "SimDataFormats/SimHitMaker/interface/TrackingSlaveSD.h"
-#include "SimDataFormats/TrackingHit/interface/UpdatablePSimHit.h"
 #include "SimG4CMS/Forward/interface/BHMSD.h"
+#include "SimG4CMS/Forward/interface/BHMNumberingScheme.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "SimG4Core/Notification/interface/TrackInformation.h"
-
-#include "G4Track.hh"
-#include "G4SDManager.hh"
-#include "G4VProcess.hh"
-#include "G4EventManager.hh"
 #include "G4Step.hh"
-#include "G4ParticleTable.hh"
 
-#include <string>
-#include <vector>
 #include <iostream>
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //#define debug
 //-------------------------------------------------------------------
 BHMSD::BHMSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg, 
 	     edm::ParameterSet const & p, const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr), 
-  hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
-  currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
-  postStepPoint(nullptr), eventno(0){
+  TimingSD(name, cpv, clg, p, manager), numberingScheme(nullptr) { 
     
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("BHMSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");
-  //int verbn = 1;
     
   SetVerboseLevel(verbn);
-    
-  slave  = new TrackingSlaveSD(name);
     
   if (verbn > 0) {
     edm::LogInfo("BHMSim") << "name = " <<name <<" and new BHMNumberingScheme";
@@ -51,310 +29,9 @@ BHMSD::BHMSD(const std::string& name, const DDCompactView & cpv,
 }
 
 BHMSD::~BHMSD() { 
-
-  if (slave)           delete slave; 
-  if (numberingScheme) delete numberingScheme;
-}
-
-double BHMSD::getEnergyDeposit(const G4Step* aStep) {
-  return aStep->GetTotalEnergyDeposit();
-}
-
-void BHMSD::Initialize(G4HCofThisEvent * HCE) { 
-#ifdef debug
-  LogDebug("BHMSim") << "BHMSD : Initialize called for " << GetName();
-#endif
-
-  theHC = new BscG4HitCollection(GetName(), collectionName[0]);
-  if (hcID<0) 
-    hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
-  HCE->AddHitsCollection(hcID, theHC);
-
-  tsID   = -2;
-  primID = -2;
-}
-
-
-bool BHMSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
-
-  if (aStep == nullptr) {
-    return true;
-  } else {
-    GetStepInfo(aStep);
-#ifdef debug
-    LogDebug("BHMSim") << "BHMSD :  number of hits = " << theHC->entries() << std::endl;
-#endif
-    if (HitExists() == false && edeposit>0. ){ 
-      CreateNewHit();
-      return true;
-    }
-  }
-  return true;
-} 
-
-void BHMSD::GetStepInfo(G4Step* aStep) {
-  
-  preStepPoint = aStep->GetPreStepPoint(); 
-  postStepPoint= aStep->GetPostStepPoint(); 
-  theTrack     = aStep->GetTrack();   
-  hitPoint     = preStepPoint->GetPosition();	
-  currentPV    = preStepPoint->GetPhysicalVolume();
-  hitPointExit = postStepPoint->GetPosition();	
-
-  hitPointLocal = preStepPoint->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPoint);
-  hitPointLocalExit = preStepPoint->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPointExit);
-
-
-  G4int particleCode = theTrack->GetDefinition()->GetPDGEncoding();
-  LogDebug("BHMSim") <<  "  BHMSD :particleType =  " << theTrack->GetDefinition()->GetParticleName() <<std::endl;
-  if (particleCode == emPDG ||
-      particleCode == epPDG ||
-      particleCode == gammaPDG ) {
-    edepositEM  = getEnergyDeposit(aStep); edepositHAD = 0.;
-  } else {
-    edepositEM  = 0.; edepositHAD = getEnergyDeposit(aStep);
-  }
-  edeposit = aStep->GetTotalEnergyDeposit();
-  tSlice    = (postStepPoint->GetGlobalTime() )/CLHEP::nanosecond;
-  tSliceID  = (int) tSlice;
-  unitID    = setDetUnitId(aStep);
-#ifdef debug
-  LogDebug("BHMSim") << "unitID=" << unitID <<std::endl;
-#endif
-  primaryID    = theTrack->GetTrackID();
-  //  Position     = hitPoint;
-  Pabs         = aStep->GetPreStepPoint()->GetMomentum().mag()/CLHEP::GeV;
-  Tof          = aStep->GetPostStepPoint()->GetGlobalTime()/CLHEP::nanosecond;
-  Eloss        = aStep->GetTotalEnergyDeposit()/CLHEP::GeV;
-  ParticleType = theTrack->GetDefinition()->GetPDGEncoding();      
-  ThetaAtEntry = aStep->GetPreStepPoint()->GetPosition().theta()/CLHEP::deg;
-  PhiAtEntry   = aStep->GetPreStepPoint()->GetPosition().phi()/CLHEP::deg;
-
-  ParentId = theTrack->GetParentID();
-  Vx = theTrack->GetVertexPosition().x();
-  Vy = theTrack->GetVertexPosition().y();
-  Vz = theTrack->GetVertexPosition().z();
-  X  = hitPoint.x();
-  Y  = hitPoint.y();
-  Z  = hitPoint.z();
+  delete numberingScheme;
 }
 
 uint32_t BHMSD::setDetUnitId(const G4Step * aStep) { 
   return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
-}
-
-G4bool BHMSD::HitExists() {
-  if (primaryID<1) {
-    edm::LogWarning("BHMSim") << "***** BHMSD error: primaryID = " 
-				  << primaryID
-				  << " maybe detector name changed";
-  }
-
-  // Update if in the same detector, time-slice and for same track   
-  if (tSliceID == tsID && unitID==previousUnitID) {
-    UpdateHit();
-    return true;
-  }
-  // Reset entry point for new primary
-  if (primaryID != primID)
-    ResetForNewPrimary();
-   
-  //look in the HitContainer whether a hit with the same primID, unitID,
-  //tSliceID already exists:
-   
-  G4bool found = false;
-
-  for (int j=0; j<theHC->entries()&&!found; j++) {
-    BscG4Hit* aPreviousHit = (*theHC)[j];
-    if (aPreviousHit->getTrackID()     == primaryID &&
-	aPreviousHit->getTimeSliceID() == tSliceID  &&
-	aPreviousHit->getUnitID()      == unitID       ) {
-      currentHit = aPreviousHit;
-      found      = true;
-    }
-  }          
-
-  if (found) {
-    UpdateHit();
-    return true;
-  } else {
-    return false;
-  }    
-}
-
-void BHMSD::ResetForNewPrimary() {
-  
-  entrancePoint  = SetToLocal(hitPoint);
-  exitPoint      = SetToLocalExit(hitPointExit);
-  incidentEnergy = preStepPoint->GetKineticEnergy();
-}
-
-void BHMSD::StoreHit(BscG4Hit* hit){
-
-  if (primID<0) return;
-  if (hit == nullptr ) {
-    edm::LogWarning("BHMSim") << "BHMSD: hit to be stored is NULL !!";
-    return;
-  }
-
-  theHC->insert( hit );
-}
-
-void BHMSD::CreateNewHit() {
-
-#ifdef debug
-  LogDebug("BHMSim") << "BHMSD CreateNewHit for"
-		     << " PV "     << currentPV->GetName()
-		     << " PVid = " << currentPV->GetCopyNo()
-		     << " Unit "   << unitID <<std::endl;
-  LogDebug("BHMSim") << " primary "    << primaryID
-		     << " time slice " << tSliceID 
-		     << " For Track  " << theTrack->GetTrackID()
-		     << " which is a " << theTrack->GetDefinition()->GetParticleName();
-	   
-  if (theTrack->GetTrackID()==1) {
-    LogDebug("BHMSim") << " of energy "     << theTrack->GetTotalEnergy();
-  } else {
-    LogDebug("BHMSim") << " daughter of part. " << theTrack->GetParentID();
-  }
-
-  LogDebug("BHMSim")  << " and created by " ;
-  if (theTrack->GetCreatorProcess()!=nullptr)
-    LogDebug("BHMSim") << theTrack->GetCreatorProcess()->GetProcessName() ;
-  else 
-    LogDebug("BHMSim") << "NO process";
-  LogDebug("BHMSim") << std::endl;
-#endif          
-    
-  currentHit = new BscG4Hit;
-  currentHit->setTrackID(primaryID);
-  currentHit->setTimeSlice(tSlice);
-  currentHit->setUnitID(unitID);
-  currentHit->setIncidentEnergy(incidentEnergy);
-
-  currentHit->setPabs(Pabs);
-  currentHit->setTof(Tof);
-  currentHit->setEnergyLoss(Eloss);
-  currentHit->setParticleType(ParticleType);
-  currentHit->setThetaAtEntry(ThetaAtEntry);
-  currentHit->setPhiAtEntry(PhiAtEntry);
-
-  currentHit->setEntry(hitPoint);
-
-  currentHit->setEntryLocalP(hitPointLocal);
-  currentHit->setExitLocalP(hitPointLocalExit);
-
-  currentHit->setParentId(ParentId);
-  currentHit->setVx(Vx);
-  currentHit->setVy(Vy);
-  currentHit->setVz(Vz);
-
-  currentHit->setX(X);
-  currentHit->setY(Y);
-  currentHit->setZ(Z);
-
-  UpdateHit();
-  
-  StoreHit(currentHit);
-}	 
- 
-void BHMSD::UpdateHit() {
-
-  if (Eloss > 0.) {
-    currentHit->addEnergyDeposit(edepositEM,edepositHAD);
-
-#ifdef debug
-    LogDebug("BHMSim") << "updateHit: add eloss " << Eloss <<std::endl;
-    LogDebug("BHMSim") << "CurrentHit=" << currentHit
-		       << ", PostStepPoint=" << postStepPoint->GetPosition();
-#endif
-    currentHit->setEnergyLoss(Eloss);
-  }  
-
-  // buffer for next steps:
-  tsID           = tSliceID;
-  primID         = primaryID;
-  previousUnitID = unitID;
-}
-
-G4ThreeVector BHMSD::SetToLocal(const G4ThreeVector& global) {
-
-  const G4VTouchable* touch= preStepPoint->GetTouchable();
-  theEntryPoint = touch->GetHistory()->GetTopTransform().TransformPoint(global);
-  return theEntryPoint;  
-}
-     
-G4ThreeVector BHMSD::SetToLocalExit(const G4ThreeVector& globalPoint) {
-
-  const G4VTouchable* touch= postStepPoint->GetTouchable();
-  theExitPoint = touch->GetHistory()->GetTopTransform().TransformPoint(globalPoint);
-  return theExitPoint;  
-}
-     
-void BHMSD::EndOfEvent(G4HCofThisEvent* ) {
-
-  // here we loop over transient hits and make them persistent
-  for (int j=0; j<theHC->entries(); j++) {
-    BscG4Hit* aHit = (*theHC)[j];
-    LogDebug("BHMSim") << "hit number" << j << "unit ID = "<<aHit->getUnitID()<< "\n";
-    LogDebug("BHMSim") << "entry z " << aHit->getEntry().z()<< "\n";
-    LogDebug("BHMSim") << "entr theta " << aHit->getThetaAtEntry()<< "\n";
-
-    Local3DPoint locExitPoint(0,0,0);
-    Local3DPoint locEntryPoint(aHit->getEntry().x(),
-			       aHit->getEntry().y(),
-			       aHit->getEntry().z());
-    slave->processHits(PSimHit(locEntryPoint,locExitPoint,
-			       aHit->getPabs(),
-			       aHit->getTof(),
-			       aHit->getEnergyLoss(),
-			       aHit->getParticleType(),
-			       aHit->getUnitID(),
-			       aHit->getTrackID(),
-			       aHit->getThetaAtEntry(),
-			       aHit->getPhiAtEntry()));
-  }
-  Summarize();
-}
-     
-void BHMSD::Summarize() {
-}
-
-void BHMSD::clear() {
-} 
-
-void BHMSD::DrawAll() {
-} 
-
-void BHMSD::PrintAll() {
-  LogDebug("BHMSim") << "BHMSD: Collection " << theHC->GetName() << "\n";
-  theHC->PrintAllHits();
-} 
-
-void BHMSD::fillHits(edm::PSimHitContainer& cc, const std::string& hname) {
-  if (slave->name() == hname) { cc=slave->hits(); }
-}
-
-void BHMSD::update (const BeginOfEvent * i) {
-  LogDebug("BHMSim") << " Dispatched BeginOfEvent for " << GetName()
-                       << " !" ;
-   clearHits();
-   eventno = (*i)()->GetEventID();
-}
-
-void BHMSD::update(const BeginOfRun *) {
-
-  G4ParticleTable * theParticleTable = G4ParticleTable::GetParticleTable();
-  G4String particleName;
-  emPDG = theParticleTable->FindParticle(particleName="e-")->GetPDGEncoding();
-  epPDG = theParticleTable->FindParticle(particleName="e+")->GetPDGEncoding();
-  gammaPDG = theParticleTable->FindParticle(particleName="gamma")->GetPDGEncoding();
-
-} 
-
-void BHMSD::update (const ::EndOfEvent*) {
-}
-
-void BHMSD::clearHits(){
-  slave->Initialize();
 }

--- a/SimG4CMS/Forward/src/BSCG4Hit.cc
+++ b/SimG4CMS/Forward/src/BSCG4Hit.cc
@@ -6,37 +6,33 @@
 #include "SimG4CMS/Forward/interface/BscG4Hit.h"
 #include <iostream>
 
-BscG4Hit::BscG4Hit():entry(0) {
-
-  entrylp(0);
-  exitlp(0);
-  elem     = 0.;
-  hadr     = 0.;
-  theIncidentEnergy = 0.;
+BscG4Hit::BscG4Hit(): entry(0.,0.,0.),entrylp(0.,0.,0.),exitlp(0.,0.,0.) {
+  elem     = 0.f;
+  hadr     = 0.f;
+  theIncidentEnergy = 0.f;
   theTimeSlice = 0.;
   theTrackID = -1;
   theUnitID  =  0;
-  thePabs =0.;
-  theTof=0. ;
-  theEnergyLoss=0.   ;
-  theParticleType=0 ;
+  thePabs =0.f;
+  theTof=0.f;
+  theEnergyLoss=0.f;
+  theParticleType=0;
   theUnitID=0;
   theTrackID=-1;
-  theThetaAtEntry=-10000. ;
-  thePhiAtEntry=-10000. ;
+  theThetaAtEntry=-10000.f;
+  thePhiAtEntry=-10000.f;
   theParentId=0;
+  theProcessId=0;
   
-  theX = 0.;
-  theY = 0.;
-  theZ = 0.;
-  theVx = 0.;
-  theVy = 0.;
-  theVz = 0.;
+  theX = 0.f;
+  theY = 0.f;
+  theZ = 0.f;
+  theVx = 0.f;
+  theVy = 0.f;
+  theVz = 0.f;
 }
 
-
 BscG4Hit::~BscG4Hit(){}
-
 
 BscG4Hit::BscG4Hit(const BscG4Hit &right) {
   theUnitID         = right.theUnitID;
@@ -56,6 +52,7 @@ BscG4Hit::BscG4Hit(const BscG4Hit &right) {
   theThetaAtEntry    = right.theThetaAtEntry;
   thePhiAtEntry      = right.thePhiAtEntry;
   theParentId        = right.theParentId;
+  theProcessId       = right.theProcessId;
   
   theX = right.theX;
   theY = right.theY;
@@ -63,11 +60,8 @@ BscG4Hit::BscG4Hit(const BscG4Hit &right) {
   
   theVx = right.theVx;
   theVy = right.theVy;
-  theVz = right.theVz;
-  
-  
+  theVz = right.theVz;  
 }
-
 
 const BscG4Hit& BscG4Hit::operator=(const BscG4Hit &right) {
   theUnitID         = right.theUnitID;
@@ -87,6 +81,7 @@ const BscG4Hit& BscG4Hit::operator=(const BscG4Hit &right) {
   theThetaAtEntry    = right.theThetaAtEntry;
   thePhiAtEntry      = right.thePhiAtEntry;
   theParentId        = right.theParentId;
+  theProcessId       = right.theProcessId;
   
   theX = right.theX;
   theY = right.theY;
@@ -95,92 +90,38 @@ const BscG4Hit& BscG4Hit::operator=(const BscG4Hit &right) {
   theVx = right.theVx;
   theVy = right.theVy;
   theVz = right.theVz;
-  
-  
+    
   return *this;
 }
 
-
-void BscG4Hit::addEnergyDeposit(const BscG4Hit& aHit) {
-
-  elem += aHit.getEM();
-  hadr += aHit.getHadr();
+void BscG4Hit::setEntry(const G4ThreeVector& v) {
+  entry = v;
+  theX = v.x(); theY = v.y(); theZ = v.z();
 }
 
+void BscG4Hit::addEnergyDeposit(const BscG4Hit& aHit) {
+  elem += aHit.getEM();
+  hadr += aHit.getHadr();
+  theEnergyLoss = elem + hadr;
+}
 
 void BscG4Hit::Print() {
   std::cout << (*this);
 }
 
-G4ThreeVector   BscG4Hit::getEntry() const           {return entry;}
-void         BscG4Hit::setEntry(const G4ThreeVector& xyz)   { entry    = xyz; }
+void BscG4Hit::addEnergyDeposit(float em, float hd) {
+  elem  += em; 
+  hadr += hd; 
+  theEnergyLoss = elem + hadr;
+}
 
-G4ThreeVector    BscG4Hit::getEntryLocalP() const           {return entrylp;}
-void         BscG4Hit::setEntryLocalP(const G4ThreeVector& xyz1)   { entrylp    = xyz1; }
+void BscG4Hit::setHitPosition(const G4ThreeVector& v) {
+  theX = v.x(); theY = v.y(); theZ = v.z();
+}
 
-G4ThreeVector     BscG4Hit::getExitLocalP() const           {return exitlp;}
-void         BscG4Hit::setExitLocalP(const G4ThreeVector& xyz1)   { exitlp    = xyz1; }
-
-float        BscG4Hit::getEM() const              {return elem; }
-void         BscG4Hit::setEM (float e)            { elem     = e; }
-      
-float        BscG4Hit::getHadr() const            {return hadr; }
-void         BscG4Hit::setHadr (float e)          { hadr     = e; }
-      
-float        BscG4Hit::getIncidentEnergy() const  {return theIncidentEnergy; }
-void         BscG4Hit::setIncidentEnergy (float e){theIncidentEnergy  = e; }
-
-int          BscG4Hit::getTrackID() const         {return theTrackID; }
-void         BscG4Hit::setTrackID (int i)         { theTrackID = i; }
-
-uint32_t     BscG4Hit::getUnitID() const          {return theUnitID; }
-void         BscG4Hit::setUnitID (uint32_t i)     { theUnitID = i; }
-
-double       BscG4Hit::getTimeSlice() const       {return theTimeSlice; }
-void         BscG4Hit::setTimeSlice (double d)    { theTimeSlice = d; }
-int          BscG4Hit::getTimeSliceID() const     {return (int)theTimeSlice;}
-
-void         BscG4Hit::addEnergyDeposit(float em, float hd)
-{elem  += em; hadr += hd; theEnergyLoss += em + hd;}
-
-float        BscG4Hit::getEnergyDeposit() const   {return elem+hadr;}
-
-float BscG4Hit::getPabs() const {return thePabs;}
-float BscG4Hit::getTof() const {return theTof;}
-float BscG4Hit::getEnergyLoss() const {return theEnergyLoss;}
-int BscG4Hit::getParticleType() const {return theParticleType;}
-
-void BscG4Hit::setPabs(float e) {thePabs = e;}
-void BscG4Hit::setTof(float e) {theTof = e;}
-void BscG4Hit::setEnergyLoss(float e) {theEnergyLoss = e;}
-void BscG4Hit::setParticleType(int i) {theParticleType = i;}
-
-float BscG4Hit::getThetaAtEntry() const {return theThetaAtEntry;}   
-float BscG4Hit::getPhiAtEntry() const{ return thePhiAtEntry;}
-
-void BscG4Hit::setThetaAtEntry(float t){theThetaAtEntry = t;}
-void BscG4Hit::setPhiAtEntry(float f) {thePhiAtEntry = f ;}
-
-float BscG4Hit::getX() const{ return theX;}
-void BscG4Hit::setX(float t){theX = t;}
-
-float BscG4Hit::getY() const{ return theY;}
-void BscG4Hit::setY(float t){theY = t;}
-
-float BscG4Hit::getZ() const{ return theZ;}
-void BscG4Hit::setZ(float t){theZ = t;}
-
-int BscG4Hit::getParentId() const {return theParentId;}
-void BscG4Hit::setParentId(int p){theParentId = p;}
-
-float BscG4Hit::getVx() const{ return theVx;}
-void BscG4Hit::setVx(float t){theVx = t;}
-
-float BscG4Hit::getVy() const{ return theVy;}
-void BscG4Hit::setVy(float t){theVy = t;}
-
-float BscG4Hit::getVz() const{ return theVz;}
-void BscG4Hit::setVz(float t){theVz = t;}
+void BscG4Hit::setVertexPosition(const G4ThreeVector& v) {
+  theVx = v.x(); theVy = v.y(); theVz = v.z();
+}
 
 std::ostream& operator<<(std::ostream& os, const BscG4Hit& hit) {
   os << " Data of this BscG4Hit are:" << std::endl

--- a/SimG4CMS/Forward/src/Bcm1fSD.cc
+++ b/SimG4CMS/Forward/src/Bcm1fSD.cc
@@ -34,257 +34,61 @@ Bcm1fSD::Bcm1fSD(const std::string& name, const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg,
 		 edm::ParameterSet const & p,
 		 const SimTrackManager* manager) : 
-  SensitiveTkDetector(name, cpv, clg, p), mySimHit(nullptr),
-  oldVolume(nullptr), lastId(0), lastTrack(0), eventno(0) {
+  TimingSD(name, cpv, clg, p, manager) {
   
   edm::ParameterSet m_TrackerSD = p.getParameter<edm::ParameterSet>("Bcm1fSD");
-  energyCut           = m_TrackerSD.getParameter<double>("EnergyThresholdForPersistencyInGeV")*GeV; //default must be 0.5 (?)
-  energyHistoryCut    = m_TrackerSD.getParameter<double>("EnergyThresholdForHistoryInGeV")*GeV;//default must be 0.05 (?)
+  energyCut = m_TrackerSD.getParameter<double>("EnergyThresholdForPersistencyInGeV")*GeV; //default must be 0.5 (?)
+  energyHistoryCut = m_TrackerSD.getParameter<double>("EnergyThresholdForHistoryInGeV")*GeV;//default must be 0.05 (?)
 
-  edm::LogInfo("Bcm1fSD") <<" Criteria for Saving Tracker SimTracks: \n "
-			  <<" History: "<<energyHistoryCut<< " MeV ; Persistency: "
-			  << energyCut<<" MeV\n" <<" Constructing a Bcm1fSD";
-
-  slave  = new TrackingSlaveSD(name);
-  
-  theG4ProcessTypeEnumerator = new G4ProcessTypeEnumerator;
-  myG4TrackToParticleID = new G4TrackToParticleID;
+  setCuts(energyCut, energyHistoryCut);  
 }
 
 Bcm1fSD::~Bcm1fSD() { 
-  delete slave;
-  delete theG4ProcessTypeEnumerator;
-  delete myG4TrackToParticleID;
-}
-
-bool Bcm1fSD::ProcessHits(G4Step * aStep,  G4TouchableHistory *) {
-
-  LogDebug("Bcm1fSD") << " Entering a new Step " 
-		    << aStep->GetTotalEnergyDeposit() << " " 
-		    << aStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetName();
-
-  G4Track * gTrack  = aStep->GetTrack(); 
-  if ((unsigned int)(gTrack->GetTrackID()) != lastTrack) {
-    
-    if (gTrack->GetKineticEnergy() > energyCut){
-      TrackInformation* info = getOrCreateTrackInformation(gTrack);
-      info->storeTrack(true);
-    }
-    if (gTrack->GetKineticEnergy() > energyHistoryCut){
-      TrackInformation* info = getOrCreateTrackInformation(gTrack);
-      info->putInHistory();
-    }
-  }
-
-  if (aStep->GetTotalEnergyDeposit()>0.) {
-    if (newHit(aStep) == true) {
-      sendHit();
-      createHit(aStep);
-    } else {
-      updateHit(aStep);
-    }
-    return true;
-  }
-  return false;
 }
 
 uint32_t Bcm1fSD::setDetUnitId(const G4Step * aStep ) {
  
-  unsigned int detId = 0;
-
-  LogDebug("Bcm1fSD")<< " DetID = "<<detId; 
+  uint32_t detId = 0;
   
   //Find number of levels
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
-  int level = 0;
-  if (touch) level = ((touch->GetHistoryDepth())+1);
+  int level = (touch) ? ((touch->GetHistoryDepth())+1) : 0;
   
   //Get name and copy numbers
   if ( level > 1 ) {
      
-     G4String sensorName   = touch->GetVolume(0)->GetName();
-     G4String diamondName  = touch->GetVolume(1)->GetName();
-     G4String detectorName = touch->GetVolume(2)->GetName();
-     G4String volumeName   = touch->GetVolume(3)->GetName();
+    G4String sensorName   = touch->GetVolume(0)->GetName();
+    G4String diamondName  = touch->GetVolume(1)->GetName();
+    G4String detectorName = touch->GetVolume(2)->GetName();
+    G4String volumeName   = touch->GetVolume(3)->GetName();
      
-     if ( sensorName != "BCM1FSensor" )
-        std::cout << " Bcm1fSD::setDetUnitId -w- Sensor name not BCM1FSensor " << std::endl;
-     if ( detectorName != "BCM1F" )
-        std::cout << " Bcm1fSD::setDetUnitId -w- Detector name not BCM1F " << std::endl;
+    if ( sensorName != "BCM1FSensor" ) {
+      edm::LogWarning("ForwardSim") 
+	<< "Bcm1fSD::setDetUnitId -w- Sensor name not BCM1FSensor ";
+    }
+    if ( detectorName != "BCM1F" ) {
+      edm::LogWarning("ForwardSim") 
+        << " Bcm1fSD::setDetUnitId -w- Detector name not BCM1F ";
+    }
+    int sensorNo    = touch->GetReplicaNumber(0);
+    int diamondNo   = touch->GetReplicaNumber(1);
+    int volumeNo    = touch->GetReplicaNumber(3);
      
-     int sensorNo    = touch->GetReplicaNumber(0);
-     int diamondNo   = touch->GetReplicaNumber(1);
-//     int detectorNo  = touch->GetReplicaNumber(2);
-     int volumeNo    = touch->GetReplicaNumber(3);
+    // Detector ID definition
+    // detId = XYYZ
+    // X  = volume,  1: +Z, 2: -Z
+    // YY = diamond, 01-12, 12: phi = 90 deg, numbering clockwise when looking from the IP
+    // Z  = sensor,  1 or 2, clockwise when looking from the IP
      
-     // Detector ID definition
-     // detId = XYYZ
-     // X  = volume,  1: +Z, 2: -Z
-     // YY = diamond, 01-12, 12: phi = 90 deg, numbering clockwise when looking from the IP
-     // Z  = sensor,  1 or 2, clockwise when looking from the IP
-     
-//     detId = 10*volumeNo + diamondNo;
-     detId = 1000*volumeNo + 10*diamondNo + sensorNo;
-     
-//     for ( int ii = 0; ii < level; ii++ ) {
-//       int i      = level - ii - 1;
-//       G4String name   = touch->GetVolume(i)->GetName();
-//       int copyno = touch->GetReplicaNumber(i);
-//       const G4ThreeVector trans = touch->GetVolume(i)->GetTranslation();
-//       std::cout << " detId = " << detId << " name = " << name << " " << copyno
-//             << ",     translation x, y, z = " << trans.x() << ", " <<trans.y() << ", " <<trans.z()
-//             << ", eta = " << trans.eta() << std::endl;
-//     }
+    detId = 1000*volumeNo + 10*diamondNo + sensorNo;     
   }
-
   return detId;
 }
 
-void Bcm1fSD::EndOfEvent(G4HCofThisEvent *) {
-  
-  LogDebug("Bcm1fSD")<< " Saving the last hit in a ROU " << GetName();
-
-  if (mySimHit == nullptr) return;
-  sendHit();
-}
-
-void Bcm1fSD::fillHits(edm::PSimHitContainer& cc, const std::string& hname){
-  if (slave->name() == hname) { cc=slave->hits(); }
-}
-
-void Bcm1fSD::sendHit() {  
-  if (mySimHit == nullptr) return;
-  LogDebug("Bcm1fSD") << " Storing PSimHit: " << pname << " " << mySimHit->detUnitId() 
-				   << " " << mySimHit->trackId() << " " << mySimHit->energyLoss() 
-				   << " " << mySimHit->entryPoint() << " " << mySimHit->exitPoint();
+bool Bcm1fSD::checkHit(const G4Step*, BscG4Hit* hit) {
     
-  slave->processHits(*mySimHit); 
-
-  // clean up
-  delete mySimHit;
-  mySimHit = nullptr;
-  lastTrack = 0;
-  lastId = 0;
-}
-
-void Bcm1fSD::updateHit(G4Step * aStep) {
-
-  Local3DPoint theExitPoint = SensitiveDetector::FinalStepPosition(aStep,LocalCoordinates); 
-  float theEnergyLoss = aStep->GetTotalEnergyDeposit()/GeV;
-  mySimHit->setExitPoint(theExitPoint);
-  LogDebug("Bcm1fSD")<< " Before : " << mySimHit->energyLoss();
-  mySimHit->addEnergyLoss(theEnergyLoss);
-  globalExitPoint = SensitiveDetector::FinalStepPosition(aStep,WorldCoordinates);
-
-  LogDebug("Bcm1fSD") << " Updating: new exitpoint " << pname << " " 
-				   << theExitPoint << " new energy loss " << theEnergyLoss 
-				   << "\n Updated PSimHit: " << mySimHit->detUnitId() 
-				   << " " << mySimHit->trackId()
-				   << " " << mySimHit->energyLoss() << " " 
-				   << mySimHit->entryPoint() << " " << mySimHit->exitPoint();
-}
-
-bool Bcm1fSD::newHit(G4Step * aStep) {
-
-  G4Track * theTrack = aStep->GetTrack(); 
-  uint32_t theDetUnitId = setDetUnitId(aStep);
-  unsigned int theTrackID = theTrack->GetTrackID();
-
-  LogDebug("Bcm1fSD") << " OLD (d,t) = (" << lastId << "," << lastTrack 
-				   << "), new = (" << theDetUnitId << "," << theTrackID << ") return "
-				   << ((theTrackID == lastTrack) && (lastId == theDetUnitId));
-  if ((mySimHit != nullptr) && (theTrackID == lastTrack) && (lastId == theDetUnitId) && closeHit(aStep))
-    return false;
-  return true;
-}
-
-bool Bcm1fSD::closeHit(G4Step * aStep) {
-
-  if (mySimHit == nullptr) return false; 
-  const float tolerance = 0.05 * mm; // 50 micron are allowed between the exit 
+  // 50 micron are allowed between the exit
   // point of the current hit and the entry point of the new hit
-  Local3DPoint theEntryPoint = SensitiveDetector::InitialStepPosition(aStep,LocalCoordinates);  
-  LogDebug("Bcm1fSD")<< " closeHit: distance = " << (mySimHit->exitPoint()-theEntryPoint).mag();
-
-  if ((mySimHit->exitPoint()-theEntryPoint).mag()<tolerance) return true;
-  return false;
-}
-
-void Bcm1fSD::createHit(G4Step * aStep) {
-
-  if (mySimHit != nullptr) {
-    delete mySimHit;
-    mySimHit=nullptr;
-  }
-    
-  G4Track * theTrack  = aStep->GetTrack(); 
-  G4VPhysicalVolume * v = aStep->GetPreStepPoint()->GetPhysicalVolume();
-
-  Local3DPoint theEntryPoint = SensitiveDetector::InitialStepPosition(aStep,LocalCoordinates);  
-  Local3DPoint theExitPoint  = SensitiveDetector::FinalStepPosition(aStep,LocalCoordinates); 
-  
-  float thePabs             = aStep->GetPreStepPoint()->GetMomentum().mag()/GeV;
-  float theTof              = aStep->GetPreStepPoint()->GetGlobalTime()/nanosecond;
-  float theEnergyLoss       = aStep->GetTotalEnergyDeposit()/GeV;
-  int theParticleType       = myG4TrackToParticleID->particleID(theTrack);
-  uint32_t theDetUnitId     = setDetUnitId(aStep);
-  
-  globalEntryPoint = SensitiveDetector::InitialStepPosition(aStep,WorldCoordinates);
-  globalExitPoint = SensitiveDetector::FinalStepPosition(aStep,WorldCoordinates);
-  pname = theTrack->GetDynamicParticle()->GetDefinition()->GetParticleName();
-  
-  unsigned int theTrackID = theTrack->GetTrackID();
-  
-  G4ThreeVector gmd  = aStep->GetPreStepPoint()->GetMomentumDirection();
-  // convert it to local frame
-  G4ThreeVector lmd = ((G4TouchableHistory *)(aStep->GetPreStepPoint()->GetTouchable()))->GetHistory()->GetTopTransform().TransformAxis(gmd);
-  Local3DPoint lnmd = ConvertToLocal3DPoint(lmd);
-  float theThetaAtEntry = lnmd.theta();
-  float thePhiAtEntry = lnmd.phi();
-    
-  mySimHit = new UpdatablePSimHit(theEntryPoint,theExitPoint,thePabs,theTof,
-				  theEnergyLoss,theParticleType,theDetUnitId,
-				  theTrackID,theThetaAtEntry,thePhiAtEntry,
-				  theG4ProcessTypeEnumerator->processId(theTrack->GetCreatorProcess()));  
-
-  LogDebug("Bcm1fSD") << " Created PSimHit: " << pname << " " 
-				   << mySimHit->detUnitId() << " " << mySimHit->trackId()
-				   << " " << mySimHit->energyLoss() << " " 
-				   << mySimHit->entryPoint() << " " << mySimHit->exitPoint();
-  lastId = theDetUnitId;
-  lastTrack = theTrackID;
-  oldVolume = v;
-}
-
-void Bcm1fSD::update(const BeginOfJob * ) { }
-
-void Bcm1fSD::update(const BeginOfEvent * i) {
-
-  clearHits();
-  eventno = (*i)()->GetEventID();
-  mySimHit = nullptr;
-}
-
-void Bcm1fSD::update(const BeginOfTrack *bot) {
-
-  const G4Track* gTrack = (*bot)();
-  pname = gTrack->GetDynamicParticle()->GetDefinition()->GetParticleName();
-}
-
-void Bcm1fSD::clearHits() {
-    slave->Initialize();
-}
-
-TrackInformation* Bcm1fSD::getOrCreateTrackInformation( const G4Track* gTrack) {
-  G4VUserTrackInformation* temp = gTrack->GetUserInformation();
-  if (temp == nullptr){
-    edm::LogError("Bcm1fSD") <<" ERROR: no G4VUserTrackInformation available";
-    abort();
-  }else{
-    TrackInformation* info = dynamic_cast<TrackInformation*>(temp);
-    if (info == nullptr){
-      edm::LogError("Bcm1fSD") <<" ERROR: TkSimTrackSelection: the UserInformation does not appear to be a TrackInformation";
-    }
-    return info;
-  }
+  static const float tolerance2 = (float)(0.0025 * CLHEP::mm * CLHEP::mm); 
+  return ((hit->getExitLocalP()-getLocalEntryPoint()).mag2()<tolerance2);
 }

--- a/SimG4CMS/Forward/src/BscNumberingScheme.cc
+++ b/SimG4CMS/Forward/src/BscNumberingScheme.cc
@@ -14,26 +14,20 @@ BscNumberingScheme::BscNumberingScheme() {
   LogDebug("BscSim") << " Creating BscNumberingScheme" ;
 }
 
-BscNumberingScheme::~BscNumberingScheme() {
-  LogDebug("BscSim") << " Deleting BscNumberingScheme" ;
-}
-
 int BscNumberingScheme::detectorLevel(const G4Step* aStep) const {
 
   //Find number of levels
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
-  int level = 0;
-  if (touch) level = ((touch->GetHistoryDepth())+1);
-  return level;
+  return (touch) ? ((touch->GetHistoryDepth())+1) : 0;
 }
 
 void BscNumberingScheme::detectorLevel(const G4Step* aStep, int& level,
-                                        int* copyno, G4String* name) const {
+                                       int* copyno, G4String* name) const {
 
   //Get name and copy numbers
   if (level > 0) {
     const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
-    for (int ii = 0; ii < level; ii++) {
+    for (int ii = 0; ii < level; ++ii) {
       int i      = level - ii - 1;
       name[ii]   = touch->GetVolume(i)->GetName();
       copyno[ii] = touch->GetReplicaNumber(i);
@@ -43,12 +37,11 @@ void BscNumberingScheme::detectorLevel(const G4Step* aStep, int& level,
 
 unsigned int BscNumberingScheme::getUnitID(const G4Step* aStep) const {
 
-  unsigned intindex=0;
+  unsigned int intindex=0;
   int level = detectorLevel(aStep);
 
   LogDebug("BscSim") << "BscNumberingScheme number of levels= " << level;
 
- //  unsigned int intIndex = 0;
   if (level > 0) {
     int*      copyno = new int[level];
     G4String* name   = new G4String[level];
@@ -78,13 +71,14 @@ unsigned int BscNumberingScheme::getUnitID(const G4Step* aStep) const {
 			 << copyno[ich] << "name="  << name[ich];
 
     }
-    intindex = packBscIndex (zside,det,  station);
+    intindex = packBscIndex (zside, det, station);
     LogDebug("BscSim") << "BscNumberingScheme : det " << det << " zside " 
 		       << zside << " station " << station 
 		       << " UnitID 0x" << std::hex << intindex << std::dec;
 
     for (int ich = 0; ich < level; ich++)
       LogDebug("BscSim") <<" name = " << name[ich] <<" copy = " << copyno[ich];
+
     LogDebug("BscSim") << " packed index = 0x" << std::hex << intindex 
 		       << std::dec;
 
@@ -92,11 +86,10 @@ unsigned int BscNumberingScheme::getUnitID(const G4Step* aStep) const {
     delete[] name;
   }
 
-  return intindex;
-  
+  return intindex;  
 }
 
-unsigned BscNumberingScheme::packBscIndex(int zside,int det,  int station){
+unsigned int BscNumberingScheme::packBscIndex(int zside,int det,  int station){
   unsigned int idx = 6 << 28; // autre numero que les detecteurs existants 
   idx += (zside<<5)&32;       // vaut 0 ou 1 bit 5    
   idx += (det<<3)&24;         //bit 3-4    det:0-1-2    2 bits:0-1

--- a/SimG4CMS/Forward/src/BscSD.cc
+++ b/SimG4CMS/Forward/src/BscSD.cc
@@ -5,14 +5,6 @@
 // Modifications: 
 ///////////////////////////////////////////////////////////////////////////////
  
-#include "SimG4Core/Notification/interface/TrackInformation.h"
-#include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
-#include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
-
-#include "SimDataFormats/SimHitMaker/interface/TrackingSlaveSD.h"
-#include "SimDataFormats/TrackingHit/interface/UpdatablePSimHit.h"
-
-
 #include "SimG4CMS/Forward/interface/BscSD.h"
 #include "SimG4CMS/Forward/interface/BscG4Hit.h"
 #include "SimG4CMS/Forward/interface/BscG4HitCollection.h"
@@ -22,33 +14,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "SimG4Core/Notification/interface/TrackInformation.h"
-
-#include "G4Track.hh"
-#include "G4SDManager.hh"
-#include "G4VProcess.hh"
-#include "G4EventManager.hh"
 #include "G4Step.hh"
-#include "G4ParticleTable.hh"
 
-#include "G4PhysicalConstants.hh"
-#include "G4SystemOfUnits.hh"
-
-#include <string>
-#include <vector>
 #include <iostream>
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #define debug
 //-------------------------------------------------------------------
 BscSD::BscSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg,
 	     edm::ParameterSet const & p, const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr),
-  hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
-  currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
-  postStepPoint(nullptr){
+  TimingSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
     
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("BscSD");
@@ -56,8 +31,6 @@ BscSD::BscSD(const std::string& name, const DDCompactView & cpv,
     
   SetVerboseLevel(verbn);
     
-  slave  = new TrackingSlaveSD(name);
-        
   if(name == "BSCHits") {
     if (verbn > 0) {
       edm::LogInfo("BscSim") << "name = BSCHits and  new BscNumberingSchem";
@@ -69,271 +42,9 @@ BscSD::BscSD(const std::string& name, const DDCompactView & cpv,
 }
 
 BscSD::~BscSD() { 
-  delete slave; 
   delete numberingScheme;
-}
-
-void BscSD::Initialize(G4HCofThisEvent * HCE) { 
-#ifdef debug
-  LogDebug("BscSim") << "BscSD : Initialize called for " << GetName();
-#endif
-
-  theHC = new BscG4HitCollection(GetName(), collectionName[0]);
-  if (hcID<0) 
-    hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
-  HCE->AddHitsCollection(hcID, theHC);
-
-  tsID   = -2;
-  primID = -2;
-}
-
-bool BscSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
-
-  edeposit = aStep->GetTotalEnergyDeposit();
-  if (edeposit>0.f){ 
-    getStepInfo(aStep);
-    LogDebug("BscSim") << "BscSD :  number of hits = " << theHC->entries();
-    if (!hitExists()){ 
-      createNewHit();
-    }
-  }
-  return true;
-} 
-
-void BscSD::getStepInfo(const G4Step* aStep) {
-  
-  preStepPoint = aStep->GetPreStepPoint(); 
-  postStepPoint= aStep->GetPostStepPoint(); 
-  theTrack     = aStep->GetTrack();   
-  hitPoint     = preStepPoint->GetPosition();	
-  currentPV    = preStepPoint->GetPhysicalVolume();
-  hitPointExit = postStepPoint->GetPosition();	
-
-  hitPointLocal = preStepPoint->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPoint);
-  hitPointLocalExit = preStepPoint->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPointExit);
-
-  particleCode = theTrack->GetDefinition()->GetPDGEncoding();
-  LogDebug("BscSim") << "BscSD:particleType =  " << theTrack->GetDefinition()->GetParticleName();
-  edeposit /= GeV;
-  if ( G4TrackToParticleID::isGammaElectronPositron(theTrack) ) {
-    edepositEM  = edeposit; edepositHAD = 0.f;
-  } else {
-    edepositEM  = 0.f; edepositHAD = edeposit;
-  }
-  tSlice    = (postStepPoint->GetGlobalTime() )/nanosecond;
-  tSliceID  = (int) tSlice;
-  unitID    = setDetUnitId(aStep);
-#ifdef debug
-  LogDebug("BscSim") << "unitID=" << unitID;
-#endif
-  primaryID    = theTrack->GetTrackID();
-  //  Position     = hitPoint;
-  Pabs         = aStep->GetPreStepPoint()->GetMomentum().mag()/GeV;
-  Tof          = aStep->GetPostStepPoint()->GetGlobalTime()/nanosecond;
-  ThetaAtEntry = aStep->GetPreStepPoint()->GetPosition().theta()/deg;
-  PhiAtEntry   = aStep->GetPreStepPoint()->GetPosition().phi()/deg;
-
-  ParentId = theTrack->GetParentID();
-  Vx = theTrack->GetVertexPosition().x();
-  Vy = theTrack->GetVertexPosition().y();
-  Vz = theTrack->GetVertexPosition().z();
-  X  = hitPoint.x();
-  Y  = hitPoint.y();
-  Z  = hitPoint.z();
 }
 
 uint32_t BscSD::setDetUnitId(const G4Step * aStep) { 
   return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
-}
-
-bool BscSD::hitExists() {
-  if (primaryID<1) {
-    edm::LogWarning("BscSim") << "***** BscSD error: primaryID = " 
-				  << primaryID
-				  << " maybe detector name changed";
-  }
-
-  // Update if in the same detector, time-slice and for same track   
-  //  if (primaryID == primID && tSliceID == tsID && unitID==previousUnitID) {
-  if (tSliceID == tsID && unitID==previousUnitID) {
-    //AZ:
-    updateHit();
-    return true;
-  }
-  // Reset entry point for new primary
-  if (primaryID != primID)
-    resetForNewPrimary();
-   
-  //look in the HitContainer whether a hit with the same primID, unitID,
-  //tSliceID already exists:
-   
-  bool found = false;
-
-  //LogDebug("BscSim") << "BscSD: HCollection=  " << theHC->entries();
-  
-  for (int j=0; j<theHC->entries()&&!found; j++) {
-    BscG4Hit* aPreviousHit = (*theHC)[j];
-    if (aPreviousHit->getTrackID()     == primaryID &&
-	aPreviousHit->getTimeSliceID() == tSliceID  &&
-	aPreviousHit->getUnitID()      == unitID       ) {
-      currentHit = aPreviousHit;
-      found      = true;
-      break;
-    }
-  }          
-
-  if (found) { updateHit(); }
-  return found;
-}
-
-void BscSD::resetForNewPrimary() {
-  
-  entrancePoint  = setToLocal(hitPoint);
-  exitPoint      = setToLocalExit(hitPointExit);
-  incidentEnergy = preStepPoint->GetKineticEnergy();
-
-}
-
-void BscSD::storeHit(BscG4Hit* hit){
-
-  if (primID<0) return;
-  if (hit == nullptr ) {
-    edm::LogWarning("BscSim") << "BscSD: hit to be stored is NULL !!";
-    return;
-  }
-
-  theHC->insert( hit );
-}
-
-void BscSD::createNewHit() {
-
-#ifdef debug
-  LogDebug("BscSim") << "BscSD CreateNewHit for"
-		     << " PV "     << currentPV->GetName()
-		     << " PVid = " << currentPV->GetCopyNo()
-		     << " Unit "   << unitID <<std::endl;
-  LogDebug("BscSim") << " primary "    << primaryID
-		     << " time slice " << tSliceID 
-		     << " For Track  " << theTrack->GetTrackID()
-		     << " which is a " << theTrack->GetDefinition()->GetParticleName();
-	   
-  if (theTrack->GetTrackID()==1) {
-    LogDebug("BscSim") << " of energy "     << theTrack->GetTotalEnergy();
-  } else {
-    LogDebug("BscSim") << " daughter of part. " << theTrack->GetParentID();
-  }
-
-  LogDebug("BscSim")  << " and created by " ;
-  if (theTrack->GetCreatorProcess()!=nullptr)
-    LogDebug("BscSim") << theTrack->GetCreatorProcess()->GetProcessName() ;
-  else 
-    LogDebug("BscSim") << "NO process";
-  LogDebug("BscSim") << std::endl;
-#endif          
-    
-  currentHit = new BscG4Hit;
-  currentHit->setTrackID(primaryID);
-  currentHit->setTimeSlice(tSlice);
-  currentHit->setUnitID(unitID);
-  currentHit->setIncidentEnergy(incidentEnergy);
-
-  currentHit->setPabs(Pabs);
-  currentHit->setTof(Tof);
-  currentHit->setEnergyLoss(edeposit);
-  currentHit->setParticleType(particleCode);
-  currentHit->setThetaAtEntry(ThetaAtEntry);
-  currentHit->setPhiAtEntry(PhiAtEntry);
-
-  currentHit->setEntry(hitPoint);
-
-  currentHit->setEntryLocalP(hitPointLocal);
-  currentHit->setExitLocalP(hitPointLocalExit);
-
-  currentHit->setParentId(ParentId);
-  currentHit->setVx(Vx);
-  currentHit->setVy(Vy);
-  currentHit->setVz(Vz);
-
-  currentHit->setX(X);
-  currentHit->setY(Y);
-  currentHit->setZ(Z);
-
-  updateHit();
-  
-  storeHit(currentHit);
-}	 
- 
-void BscSD::updateHit() {
-
-  currentHit->addEnergyDeposit(edepositEM,edepositHAD);
-
-#ifdef debug
-  LogDebug("BscSim") << "updateHit: add eloss " << edeposit 
-		     << "CurrentHit=" << currentHit
-		     << ", PostStepPoint=" << postStepPoint->GetPosition();
-#endif
-
-  // buffer for next steps:
-  tsID           = tSliceID;
-  primID         = primaryID;
-  previousUnitID = unitID;
-}
-
-G4ThreeVector BscSD::setToLocal(const G4ThreeVector& global){
-
-  const G4VTouchable* touch= preStepPoint->GetTouchable();
-  theEntryPoint = touch->GetHistory()->GetTopTransform().TransformPoint(global);
-  return theEntryPoint;  
-}
-     
-G4ThreeVector BscSD::setToLocalExit(const G4ThreeVector& globalPoint){
-
-  const G4VTouchable* touch= postStepPoint->GetTouchable();
-  theExitPoint = touch->GetHistory()->GetTopTransform().TransformPoint(globalPoint);
-  return theExitPoint;  
-}
-     
-
-void BscSD::EndOfEvent(G4HCofThisEvent* ) {
-
-  // here we loop over transient hits and make them persistent
-  for (int j=0; j<theHC->entries(); j++) {
-    //AZ:
-    BscG4Hit* aHit = (*theHC)[j];
-    LogDebug("BscSim") << "hit number" << j << "unit ID = "<<aHit->getUnitID()<< "\n";
-    LogDebug("BscSim") << "entry z " << aHit->getEntry().z()<< "\n";
-    LogDebug("BscSim") << "entr theta " << aHit->getThetaAtEntry()<< "\n";
-
-    Local3DPoint locExitPoint(0,0,0);
-    Local3DPoint locEntryPoint(aHit->getEntry().x(),
-			       aHit->getEntry().y(),
-			       aHit->getEntry().z());
-    slave->processHits(PSimHit(locEntryPoint,locExitPoint,
-			       aHit->getPabs(),
-			       aHit->getTof(),
-			       aHit->getEnergyLoss(),
-			       aHit->getParticleType(),
-			       aHit->getUnitID(),
-			       aHit->getTrackID(),
-			       aHit->getThetaAtEntry(),
-			       aHit->getPhiAtEntry()));
-  }
-}
-     
-void BscSD::PrintAll() {
-  LogDebug("BscSim") << "BscSD: Collection " << theHC->GetName() << "\n";
-  theHC->PrintAllHits();
-} 
-
-void BscSD::fillHits(edm::PSimHitContainer& cc, const std::string& hname) {
-  if (slave->name() == hname) { cc=slave->hits(); }
-}
-
-void BscSD::update (const BeginOfEvent * i) {
-  LogDebug("BscSim") << " Dispatched BeginOfEvent for " << GetName();
-  clearHits();
-}
-
-void BscSD::clearHits(){
-  slave->Initialize();
 }

--- a/SimG4CMS/Forward/src/FastTimerSD.cc
+++ b/SimG4CMS/Forward/src/FastTimerSD.cc
@@ -14,24 +14,16 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/HGCalCommonData/interface/FastTimeDDDConstants.h"
 
-#include "SimDataFormats/SimHitMaker/interface/TrackingSlaveSD.h"
-#include "SimDataFormats/TrackingHit/interface/UpdatablePSimHit.h"
-
-#include "SimG4Core/Notification/interface/TrackInformation.h"
-#include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
-#include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
+#include <vector>
 
 #include "G4Track.hh"
-#include "G4SDManager.hh"
-#include "G4VProcess.hh"
 #include "G4Step.hh"
+#include "G4StepPoint.hh"
+#include "G4VPhysicalVolume.hh"
 
-#include <string>
-#include <vector>
 #include <iostream>
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //#define EDM_ML_DEBUG
 //-------------------------------------------------------------------
@@ -39,18 +31,13 @@ FastTimerSD::FastTimerSD(const std::string& name, const DDCompactView & cpv,
 			 const SensitiveDetectorCatalog & clg, 
 			 edm::ParameterSet const & p, 
 			 const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), ftcons(nullptr),
-  hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
-  currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
-  postStepPoint(nullptr) {
+  TimingSD(name, cpv, clg, p, manager), ftcons(nullptr) {
     
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("FastTimerSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");
     
   SetVerboseLevel(verbn);
-    
-  slave  = new TrackingSlaveSD(name);
         
   std::string attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute,name,0)};
@@ -58,100 +45,22 @@ FastTimerSD::FastTimerSD(const std::string& name, const DDCompactView & cpv,
   fv.firstChild();
   DDsvalues_type sv(fv.mergedSpecifics());
   std::vector<int> temp = dbl_to_int(getDDDArray("Type",sv));
-  type_  = temp[0];
+  type_ = temp[0];
+
+  setTimeFactor(100.);
 
   edm::LogInfo("FastTimerSim") << "FastTimerSD: Instantiation completed for "
 			       << name << " of type " << type_;
 }
 
 FastTimerSD::~FastTimerSD() { 
-  delete slave; 
-}
-
-void FastTimerSD::Initialize(G4HCofThisEvent * HCE) { 
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("FastTimerSD") 
-    << "FastTimerSD : Initialize called for " << GetName();
-#endif
-
-  theHC = new BscG4HitCollection(GetName(), collectionName[0]);
-  if (hcID<0) 
-    hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
-  HCE->AddHitsCollection(hcID, theHC);
-
-  tsID   = -2;
-  primID = -2;
-}
-
-bool FastTimerSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
-
-  edeposit = aStep->GetTotalEnergyDeposit();
-  if (edeposit>0.f){ 
-    GetStepInfo(aStep);
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("FastTimerSD") 
-    << "FastTimerSD :  number of hits = " << theHC->entries() <<"\n";
-#endif
-    if (!HitExists()){ 
-      CreateNewHit();
-    }
-  }
-  return true;
-} 
-
-void FastTimerSD::GetStepInfo(G4Step* aStep) {
-  
-  preStepPoint = aStep->GetPreStepPoint(); 
-  postStepPoint= aStep->GetPostStepPoint(); 
-  theTrack     = aStep->GetTrack();   
-  hitPoint     = preStepPoint->GetPosition();	
-  currentPV    = preStepPoint->GetPhysicalVolume();
-  hitPointExit = postStepPoint->GetPosition();	
-
-  hitPointLocal = preStepPoint->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPoint);
-  hitPointLocalExit = preStepPoint->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPointExit);
-
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("FastTimerSD") 
-    << "FastTimerSD: particle " << theTrack->GetDefinition()->GetParticleName();
-#endif
-  edeposit /= CLHEP::GeV;
-  if ( G4TrackToParticleID::isGammaElectronPositron(theTrack) ) {
-    edepositEM  = edeposit; edepositHAD = 0.f;
-  } else {
-    edepositEM  = 0.f; edepositHAD = edeposit;
-  }
-  tSlice    = (100*postStepPoint->GetGlobalTime() )/CLHEP::nanosecond;
-  tSliceID  = (int) tSlice;
-  unitID    = setDetUnitId(aStep);
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("FastTimerSD") 
-    << "FastTimerSD:unitID = " << std::hex << unitID << std::dec;
-#endif
-  primaryID    = theTrack->GetTrackID();
-  //  Position     = hitPoint;
-  Pabs         = aStep->GetPreStepPoint()->GetMomentum().mag()/CLHEP::GeV;
-  Tof          = aStep->GetPostStepPoint()->GetGlobalTime()/CLHEP::nanosecond;
-  Eloss        = aStep->GetTotalEnergyDeposit()/CLHEP::GeV;
-  particleType = theTrack->GetDefinition()->GetPDGEncoding();      
-  ThetaAtEntry = aStep->GetPreStepPoint()->GetPosition().theta()/CLHEP::deg;
-  PhiAtEntry   = aStep->GetPreStepPoint()->GetPosition().phi()/CLHEP::deg;
-
-  ParentId = theTrack->GetParentID();
-  Vx = theTrack->GetVertexPosition().x();
-  Vy = theTrack->GetVertexPosition().y();
-  Vz = theTrack->GetVertexPosition().z();
-  X  = hitPoint.x();
-  Y  = hitPoint.y();
-  Z  = hitPoint.z();
 }
 
 uint32_t FastTimerSD::setDetUnitId(const G4Step * aStep) { 
 
   //Find the depth segment
-  const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
-  G4ThreeVector global = aStep->GetPreStepPoint()->GetPosition();
-  G4ThreeVector local  = touch->GetHistory()->GetTopTransform().TransformPoint(global);
+  const G4ThreeVector& global = getGlobalEntryPoint();
+  const G4ThreeVector& local  = getLocalEntryPoint();
   int        iz = (global.z() > 0) ? 1 : -1;
   std::pair<int,int> izphi = ((ftcons) ? ((type_ == 1) ? 
 					  (ftcons->getZPhi(std::abs(local.z()),local.phi())) : 
@@ -160,188 +69,12 @@ uint32_t FastTimerSD::setDetUnitId(const G4Step * aStep) {
   uint32_t id = FastTimeDetId(type_,izphi.first,izphi.second,iz).rawId();
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("FastTimerSD") 
-    << "Volume " << touch->GetVolume(0)->GetName() << ":" << global.z()
+    << "Volume " << aStep->GetPreStepPoint()->GetPhysicalVolume()->GetName() 
+    << ": " << global.z()
     << " Iz(eta)phi " << izphi.first << ":"  << izphi.second << ":" 
-    << iz  << " id " << std::hex << id << std::dec << std::endl;
+    << iz  << " id " << std::hex << id << std::dec;
 #endif
   return id;
-}
-
-
-G4bool FastTimerSD::HitExists() {
-  if (primaryID<1) {
-    edm::LogWarning("FastTimerSim") << "***** FastTimerSD error: primaryID = " 
-				    << primaryID
-				    << " maybe detector name changed";
-  }
-
-  // Update if in the same detector, time-slice and for same track   
-  if (tSliceID == tsID && unitID==previousUnitID) {
-    UpdateHit();
-    return true;
-  }
-  // Reset entry point for new primary
-  if (primaryID != primID)
-    ResetForNewPrimary();
-   
-  //look in the HitContainer whether a hit with the same primID, unitID,
-  //tSliceID already exists:
-   
-  G4bool found = false;
-
-  for (int j=0; j<theHC->entries(); ++j) {
-    BscG4Hit* aPreviousHit = (*theHC)[j];
-    if (aPreviousHit->getTrackID()     == primaryID &&
-	aPreviousHit->getTimeSliceID() == tSliceID  &&
-	aPreviousHit->getUnitID()      == unitID       ) {
-      currentHit = aPreviousHit;
-      found      = true;
-      break;
-    }
-  }          
-
-  if (found) { UpdateHit(); }
-  return found;
-}
-
-void FastTimerSD::ResetForNewPrimary() {
-  entrancePoint  = SetToLocal(hitPoint);
-  exitPoint      = SetToLocalExit(hitPointExit);
-  incidentEnergy = preStepPoint->GetKineticEnergy();
-}
-
-void FastTimerSD::StoreHit(BscG4Hit* hit){
-
-  if (primID<0) return;
-  if (hit == nullptr) {
-    edm::LogWarning("FastTimerSim") << "FastTimerSD: hit to be stored is NULL !!";
-  } else {
-    theHC->insert( hit );
-  }
-}
-
-
-void FastTimerSD::CreateNewHit() {
-
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("FastTimerSD") 
-    << "CreateNewHit for" << " PV "
-    << currentPV->GetName() << " PVid = " << currentPV->GetCopyNo()
-    << " Unit " << unitID
-    << "\n primary " << primaryID << " time slice " << tSliceID 
-    << " For Track  " << theTrack->GetTrackID() << " which is a "
-    << theTrack->GetDefinition()->GetParticleName()
-    << " E(MeV)= "     << theTrack->GetTotalEnergy()
-    << " parentID= " << theTrack->GetParentID();
-  }
-
-  edm::LogVerbatim("FastTimerSD") << " and created by ";
-  if (theTrack->GetCreatorProcess())
-      edm::LogVerbatim("FastTimerSD") 
-	<< theTrack->GetCreatorProcess()->GetProcessName() ;
-  else 
-      edm::LogVerbatim("FastTimerSD") << "NO process";
-#endif          
-    
-  currentHit = new BscG4Hit;
-  currentHit->setTrackID(primaryID);
-  currentHit->setTimeSlice(tSlice);
-  currentHit->setUnitID(unitID);
-  currentHit->setIncidentEnergy(incidentEnergy);
-
-  currentHit->setPabs(Pabs);
-  currentHit->setTof(Tof);
-  currentHit->setEnergyLoss(edeposit);
-  currentHit->setParticleType(particleType);
-  currentHit->setThetaAtEntry(ThetaAtEntry);
-  currentHit->setPhiAtEntry(PhiAtEntry);
-
-  currentHit->setEntry(hitPoint);
-
-  currentHit->setEntryLocalP(hitPointLocal);
-  currentHit->setExitLocalP(hitPointLocalExit);
-
-  currentHit->setParentId(ParentId);
-  currentHit->setVx(Vx);
-  currentHit->setVy(Vy);
-  currentHit->setVz(Vz);
-
-  currentHit->setX(X);
-  currentHit->setY(Y);
-  currentHit->setZ(Z);
-
-  UpdateHit();
-  
-  StoreHit(currentHit);
-}	 
- 
-void FastTimerSD::UpdateHit() {
-
-  currentHit->addEnergyDeposit(edepositEM,edepositHAD);
-
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("FastTimerSD") 
-    << "updateHit: add eloss " << edeposit
-    << "\n CurrentHit="<< currentHit<< ", PostStepPoint = "
-    << postStepPoint->GetPosition();
-#endif
-
-  // buffer for next steps:
-  tsID           = tSliceID;
-  primID         = primaryID;
-  previousUnitID = unitID;
-}
-
-G4ThreeVector FastTimerSD::SetToLocal(const G4ThreeVector& global){
-
-  const G4VTouchable* touch= preStepPoint->GetTouchable();
-  theEntryPoint = touch->GetHistory()->GetTopTransform().TransformPoint(global);
-  return theEntryPoint;  
-}
-     
-G4ThreeVector FastTimerSD::SetToLocalExit(const G4ThreeVector& globalPoint){
-
-  const G4VTouchable* touch= postStepPoint->GetTouchable();
-  theExitPoint = touch->GetHistory()->GetTopTransform().TransformPoint(globalPoint);
-  return theExitPoint;  
-}
-     
-void FastTimerSD::EndOfEvent(G4HCofThisEvent* ) {
-
-  // here we loop over transient hits and make them persistent
-  for (int j=0; j<theHC->entries(); j++) {
-    BscG4Hit* aHit = (*theHC)[j];
-#ifdef EDM_ML_DEBUG
-    std::cout << "hit number " << j << " unit ID = " << std::hex 
-	      << aHit->getUnitID() << std::dec << " entry z "
-	      << aHit->getEntry().z() << " entry theta "
-	      << aHit->getThetaAtEntry() << std::endl;
-#endif
-    Local3DPoint locExitPoint(0,0,0);
-    Local3DPoint locEntryPoint(aHit->getEntry().x(),
-			       aHit->getEntry().y(),
-			       aHit->getEntry().z());
-    slave->processHits(PSimHit(locEntryPoint,locExitPoint,
-			       aHit->getPabs(),
-			       aHit->getTof(),
-			       aHit->getEnergyLoss(),
-			       aHit->getParticleType(),
-			       aHit->getUnitID(),
-			       aHit->getTrackID(),
-			       aHit->getThetaAtEntry(),
-			       aHit->getPhiAtEntry()));
-  }
-}
-     
-void FastTimerSD::PrintAll() {
-#ifdef EDM_ML_DEBUG
-  std::cout << "FastTimerSD: Collection " << theHC->GetName() << std::endl;
-#endif
-  theHC->PrintAllHits();
-} 
-
-void FastTimerSD::fillHits(edm::PSimHitContainer& cc, const std::string& hname) {
-  if (slave->name() == hname) { cc=slave->hits(); }
 }
 
 void FastTimerSD::update(const BeginOfJob * job) {
@@ -359,18 +92,6 @@ void FastTimerSD::update(const BeginOfJob * job) {
   edm::LogVerbatim("FastTimerSD") 
     << "FastTimerSD::Initialized with FastTimeDDDConstants\n";
 #endif
-}
-
-void FastTimerSD::update (const BeginOfEvent * i) {
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("FastTimerSD") 
-    << "Dispatched BeginOfEvent for " << GetName() << " !\n" ;
-#endif
-   clearHits();
-}
-
-void FastTimerSD::clearHits(){
-  slave->Initialize();
 }
 
 std::vector<double> FastTimerSD::getDDDArray(const std::string & str, 

--- a/SimG4CMS/Forward/src/MtdSD.cc
+++ b/SimG4CMS/Forward/src/MtdSD.cc
@@ -13,28 +13,15 @@
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
-#include "Geometry/MTDCommonData/interface/MTDBaseNumber.h"
 #include "Geometry/MTDCommonData/interface/BTLNumberingScheme.h"
 #include "Geometry/MTDCommonData/interface/ETLNumberingScheme.h"
 #include "DataFormats/ForwardDetId/interface/MTDDetId.h"
 
-#include "SimDataFormats/SimHitMaker/interface/TrackingSlaveSD.h"
-#include "SimDataFormats/TrackingHit/interface/UpdatablePSimHit.h"
-
-#include "SimG4Core/Notification/interface/TrackInformation.h"
-#include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
-#include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
-
 #include "G4Track.hh"
-#include "G4SDManager.hh"
-#include "G4VProcess.hh"
 #include "G4Step.hh"
+#include "G4StepPoint.hh"
 
-#include <string>
-#include <vector>
 #include <iostream>
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //#define EDM_ML_DEBUG
 //-------------------------------------------------------------------
@@ -42,18 +29,13 @@ MtdSD::MtdSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg, 
 	     edm::ParameterSet const & p, 
 	     const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), 
-  hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
-  currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
-  postStepPoint(nullptr), numberingScheme(nullptr) {
+  TimingSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
     
   //Parameters
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("MtdSD");
   int verbn = m_p.getUntrackedParameter<int>("Verbosity");
     
   SetVerboseLevel(verbn);
-    
-  slave  = new TrackingSlaveSD(name);
         
   std::string attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute,name,0)};
@@ -61,7 +43,7 @@ MtdSD::MtdSD(const std::string& name, const DDCompactView & cpv,
   fv.firstChild();
   DDsvalues_type sv(fv.mergedSpecifics());
   std::vector<int> temp = dbl_to_int(getDDDArray("Type",sv));
-  type_  = temp[0];
+  int type = temp[0];
 
   MTDNumberingScheme* scheme=nullptr;
   if (name == "FastTimerHitsBarrel") {
@@ -76,87 +58,13 @@ MtdSD::MtdSD(const std::string& name, const DDCompactView & cpv,
   }
   if (scheme)  setNumberingScheme(scheme);
 
-  edm::LogInfo("MtdSim") << "MtdSD: Instantiation completed for "
-			       << name << " of type " << type_;
+  setTimeFactor(100.);
+
+  edm::LogVerbatim("MtdSim") << "MtdSD: Instantiation completed for "
+			     << name << " of type " << type;
 }
 
 MtdSD::~MtdSD() { 
-  delete numberingScheme;
-  delete slave; 
-}
-
-void MtdSD::Initialize(G4HCofThisEvent * HCE) { 
-#ifdef EDM_ML_DEBUG
-  edm::LogInfo("MtdSim") << "MtdSD : Initialize called for " << GetName();
-#endif
-
-  theHC = new BscG4HitCollection(GetName(), collectionName[0]);
-  if (hcID<0) 
-    hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
-  HCE->AddHitsCollection(hcID, theHC);
-
-  tsID   = -2;
-  primID = -2;
-}
-
-bool MtdSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
-
-  edeposit = aStep->GetTotalEnergyDeposit();
-  if (edeposit>0.f){ 
-    GetStepInfo(aStep);
-#ifdef EDM_ML_DEBUG
-    edm::LogInfo("MtdSim") << "MtdSD :  number of hits = " << theHC->entries() <<"\n";
-#endif
-    if (!HitExists()){ 
-      CreateNewHit();
-    }
-  }
-  return true;
-} 
-
-void MtdSD::GetStepInfo(const G4Step* aStep) {
-  
-  preStepPoint = aStep->GetPreStepPoint(); 
-  postStepPoint= aStep->GetPostStepPoint(); 
-  theTrack     = aStep->GetTrack();   
-  hitPoint     = preStepPoint->GetPosition();	
-  currentPV    = preStepPoint->GetPhysicalVolume();
-  hitPointExit = postStepPoint->GetPosition();	
-
-  hitPointLocal = preStepPoint->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPoint);
-  hitPointLocalExit = preStepPoint->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPointExit);
-
-#ifdef EDM_ML_DEBUG
-  edm::LogInfo("MtdSim") << "MtdSD :particleType =  " 
-	    << theTrack->GetDefinition()->GetParticleName();
-#endif
-  edeposit /= CLHEP::GeV;
-  if ( G4TrackToParticleID::isGammaElectronPositron(theTrack) ) {
-    edepositEM  = edeposit; edepositHAD = 0.f;
-  } else {
-    edepositEM  = 0.f; edepositHAD = edeposit;
-  }
-  tSlice    = (100*postStepPoint->GetGlobalTime() )/CLHEP::nanosecond;
-  tSliceID  = (int) tSlice;
-  unitID    = setDetUnitId(aStep);
-#ifdef EDM_ML_DEBUG
-  edm::LogInfo("MtdSim") << "MtdSD:unitID = " << std::hex << unitID << std::dec<<"\n";
-#endif
-  primaryID    = theTrack->GetTrackID();
-  //  Position     = hitPoint;
-  Pabs         = aStep->GetPreStepPoint()->GetMomentum().mag()/CLHEP::GeV;
-  Tof          = aStep->GetPostStepPoint()->GetGlobalTime()/CLHEP::nanosecond;
-  ParticleType = theTrack->GetDefinition()->GetPDGEncoding();      
-  ThetaAtEntry = aStep->GetPreStepPoint()->GetPosition().theta()/CLHEP::deg;
-  PhiAtEntry   = aStep->GetPreStepPoint()->GetPosition().phi()/CLHEP::deg;
-
-  ParentId = theTrack->GetParentID();
-  Vx = theTrack->GetVertexPosition().x();
-  Vy = theTrack->GetVertexPosition().y();
-  Vz = theTrack->GetVertexPosition().z();
-  X  = hitPoint.x();
-  Y  = hitPoint.y();
-  Z  = hitPoint.z();
 }
 
 uint32_t MtdSD::setDetUnitId(const G4Step * aStep) { 
@@ -168,195 +76,8 @@ uint32_t MtdSD::setDetUnitId(const G4Step * aStep) {
   }
 }
 
-G4bool MtdSD::HitExists() {
-  if (primaryID<1) {
-    edm::LogWarning("MtdSim") << "***** MtdSD error: primaryID = " 
-				    << primaryID
-				    << " maybe detector name changed";
-  }
-
-  // Update if in the same detector, time-slice and for same track   
-  if (tSliceID == tsID && unitID==previousUnitID) {
-    UpdateHit();
-    return true;
-  }
-  // Reset entry point for new primary
-  if (primaryID != primID)
-    ResetForNewPrimary();
-   
-  //look in the HitContainer whether a hit with the same primID, unitID,
-  //tSliceID already exists:
-   
-  G4bool found = false;
-
-  for (int j=0; j<theHC->entries(); ++j) {
-    BscG4Hit* aPreviousHit = (*theHC)[j];
-    if (aPreviousHit->getTrackID()     == primaryID &&
-	aPreviousHit->getTimeSliceID() == tSliceID  &&
-	aPreviousHit->getUnitID()      == unitID       ) {
-      currentHit = aPreviousHit;
-      found      = true;
-      break;
-    }
-  }          
-
-  if (found) { UpdateHit(); }
-  return found;
-}
-
-void MtdSD::ResetForNewPrimary() {
-  entrancePoint  = SetToLocal(hitPoint);
-  exitPoint      = SetToLocalExit(hitPointExit);
-  incidentEnergy = preStepPoint->GetKineticEnergy();
-}
-
-void MtdSD::StoreHit(BscG4Hit* hit){
-
-  if (primID<0) return;
-  if (hit == nullptr) {
-    edm::LogWarning("MtdSim") << "MtdSD: hit to be stored is NULL !!";
-  } else {
-    theHC->insert( hit );
-  }
-}
-
-void MtdSD::CreateNewHit() {
-
-#ifdef EDM_ML_DEBUG
-  edm::LogInfo("MtdSim") << "MtdSD CreateNewHit for" << " PV "
-	    << currentPV->GetName() << " PVid = " << currentPV->GetCopyNo()
-	    << " Unit " << unitID ;
-  edm::LogInfo("MtdSim") << " primary " << primaryID << " time slice " << tSliceID 
-	    << " For Track  " << theTrack->GetTrackID() << " which is a "
-	    << theTrack->GetDefinition()->GetParticleName();
-	   
-  if (theTrack->GetTrackID()==1) {
-    edm::LogInfo("MtdSim") << " of energy "     << theTrack->GetTotalEnergy();
-  } else {
-    edm::LogInfo("MtdSim") << " daughter of part. " << theTrack->GetParentID();
-  }
-
-  edm::LogInfo("MtdSim") << " and created by " ;
-  if (theTrack->GetCreatorProcess()!=NULL)
-    edm::LogInfo("MtdSim") << theTrack->GetCreatorProcess()->GetProcessName() ;
-  else 
-    edm::LogInfo("MtdSim") << "NO process";
-  edm::LogInfo("MtdSim") ;
-#endif          
-    
-  currentHit = new BscG4Hit;
-  currentHit->setTrackID(primaryID);
-  currentHit->setTimeSlice(tSlice);
-  currentHit->setUnitID(unitID);
-  currentHit->setIncidentEnergy(incidentEnergy);
-
-  currentHit->setPabs(Pabs);
-  currentHit->setTof(Tof);
-  currentHit->setEnergyLoss(edeposit);
-  currentHit->setParticleType(ParticleType);
-  currentHit->setThetaAtEntry(ThetaAtEntry);
-  currentHit->setPhiAtEntry(PhiAtEntry);
-
-  currentHit->setEntry(hitPoint);
-
-  currentHit->setEntryLocalP(hitPointLocal);
-  currentHit->setExitLocalP(hitPointLocalExit);
-
-  currentHit->setParentId(ParentId);
-  currentHit->setVx(Vx);
-  currentHit->setVy(Vy);
-  currentHit->setVz(Vz);
-
-  currentHit->setX(X);
-  currentHit->setY(Y);
-  currentHit->setZ(Z);
-
-  UpdateHit();
-  
-  StoreHit(currentHit);
-}	 
- 
-void MtdSD::UpdateHit() {
-
-  currentHit->addEnergyDeposit(edepositEM,edepositHAD);
-
-#ifdef EDM_ML_DEBUG
-  edm::LogInfo("MtdSim") << "updateHit: add eloss " << edeposit;
-  edm::LogInfo("MtdSim") << "CurrentHit="<< currentHit<< ", PostStepPoint = "
-			 << postStepPoint->GetPosition() ;
-#endif
-
-  // buffer for next steps:
-  tsID           = tSliceID;
-  primID         = primaryID;
-  previousUnitID = unitID;
-}
-
-G4ThreeVector MtdSD::SetToLocal(const G4ThreeVector& global){
-
-  const G4VTouchable* touch= preStepPoint->GetTouchable();
-  theEntryPoint = touch->GetHistory()->GetTopTransform().TransformPoint(global);
-  return theEntryPoint;  
-}
-     
-G4ThreeVector MtdSD::SetToLocalExit(const G4ThreeVector& globalPoint){
-
-  const G4VTouchable* touch= postStepPoint->GetTouchable();
-  theExitPoint = touch->GetHistory()->GetTopTransform().TransformPoint(globalPoint);
-  return theExitPoint;  
-}
-     
-void MtdSD::EndOfEvent(G4HCofThisEvent* ) {
-
-  // here we loop over transient hits and make them persistent
-  for (int j=0; j<theHC->entries(); j++) {
-    BscG4Hit* aHit = (*theHC)[j];
-#ifdef EDM_ML_DEBUG
-    edm::LogInfo("MtdSim") << "hit number " << j << " unit ID = " << std::hex 
-	      << aHit->getUnitID() << std::dec << " entry z "
-	      << aHit->getEntry().z() << " entry theta "
-	      << aHit->getThetaAtEntry() ;
-#endif
-    Local3DPoint locExitPoint(0,0,0);
-    Local3DPoint locEntryPoint(aHit->getEntry().x(),
-			       aHit->getEntry().y(),
-			       aHit->getEntry().z());
-    slave->processHits(PSimHit(locEntryPoint,locExitPoint,
-			       aHit->getPabs(),
-			       aHit->getTof(),
-			       aHit->getEnergyLoss(),
-			       aHit->getParticleType(),
-			       aHit->getUnitID(),
-			       aHit->getTrackID(),
-			       aHit->getThetaAtEntry(),
-			       aHit->getPhiAtEntry()));
-  }
-}
-     
-void MtdSD::PrintAll() {
-#ifdef EDM_ML_DEBUG
-  edm::LogInfo("MtdSim") << "MtdSD: Collection " << theHC->GetName() ;
-#endif
-  theHC->PrintAllHits();
-} 
-
-void MtdSD::fillHits(edm::PSimHitContainer& cc, const std::string& hname) {
-  if (slave->name() == hname) { cc=slave->hits(); }
-}
-
-void MtdSD::update (const BeginOfEvent * i) {
-#ifdef EDM_ML_DEBUG
-  edm::LogInfo("MtdSim") << "Dispatched BeginOfEvent for " << GetName() << " !\n" ;
-#endif
-   clearHits();
-}
-
-void MtdSD::clearHits(){
-  slave->Initialize();
-}
-
 std::vector<double> MtdSD::getDDDArray(const std::string & str, 
-					     const DDsvalues_type & sv) {
+				       const DDsvalues_type & sv) {
 
   DDValue value(str);
   if (DDfetch(&sv,value)) {
@@ -386,7 +107,7 @@ void MtdSD::setNumberingScheme(MTDNumberingScheme* scheme) {
 void MtdSD::getBaseNumber(const G4Step* aStep) {
 
   theBaseNumber.reset();
-  const G4VTouchable* touch = preStepPoint->GetTouchable();
+  const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   int theSize = touch->GetHistoryDepth()+1;
   if ( theBaseNumber.getCapacity() < theSize ) theBaseNumber.setSize(theSize);
   //Get name and copy numbers

--- a/SimG4CMS/Forward/src/TimingSD.cc
+++ b/SimG4CMS/Forward/src/TimingSD.cc
@@ -1,0 +1,348 @@
+///////////////////////////////////////////////////////////////////////////////
+// File: TimingSD.cc
+// Date: 02.2006
+// Description: Sensitive Detector class for Timing
+// Modifications: 
+///////////////////////////////////////////////////////////////////////////////
+
+#include "SimG4CMS/Forward/interface/TimingSD.h"
+ 
+#include "SimG4Core/Notification/interface/TrackInformation.h"
+#include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
+#include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
+
+#include "SimDataFormats/SimHitMaker/interface/TrackingSlaveSD.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "G4Step.hh"
+#include "G4StepPoint.hh"
+#include "G4Track.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4SDManager.hh"
+#include "G4VProcess.hh"
+
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+
+#include <vector>
+#include <iostream>
+
+//#define debug
+
+static const float invgev = 1.0/CLHEP::GeV;
+static const double invns = 1.0/CLHEP::nanosecond;
+static const double invdeg= 1.0/CLHEP::deg;
+
+//-------------------------------------------------------------------
+TimingSD::TimingSD(const std::string& name, const DDCompactView& cpv,
+	     const SensitiveDetectorCatalog& clg,
+	     edm::ParameterSet const & p, const SimTrackManager* manager) :
+  SensitiveTkDetector(name, cpv, clg, p), 
+  theManager(manager), theHC(nullptr), currentHit(nullptr), theTrack(nullptr), 
+  preStepPoint(nullptr),postStepPoint(nullptr),
+  unitID(0), previousUnitID(0), primID(-2), hcID(-1), tsID(-2),
+  primaryID(0), tSliceID(-1),
+  timeFactor(1.0), energyCut(1.e+9), energyHistoryCut(1.e+9) {
+        
+  slave = new TrackingSlaveSD(name);
+  theEnumerator = new G4ProcessTypeEnumerator();
+}
+
+TimingSD::~TimingSD() { 
+  delete slave; 
+  delete theEnumerator;
+}
+
+void TimingSD::Initialize(G4HCofThisEvent * HCE) { 
+
+  edm::LogVerbatim("TimingSim") 
+    << "TimingSD : Initialize called for " << GetName()
+    << " time slice factor " << timeFactor
+    << "\n MC truth cuts in are " << energyCut/CLHEP::GeV 
+    << " GeV and " << energyHistoryCut/CLHEP::GeV << " GeV";
+
+  theHC = new BscG4HitCollection(GetName(), collectionName[0]);
+  if (hcID<0) {
+    hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
+  }
+  HCE->AddHitsCollection(hcID, theHC);
+
+  tsID   = -2;
+  primID = -2;
+}
+
+void TimingSD::setTimeFactor(double val)
+{
+  if(val <= 0.0) { return; }
+#ifdef debug
+  edm::LogVerbatim("TimingSim") 
+    << "TimingSD : for " << GetName()
+    << " time slice factor is set to " << timeFactor;
+#endif
+}
+
+void TimingSD::setCuts(double eCut, double historyCut)
+{
+  if(eCut > 0.) { energyCut = eCut; }
+  if(historyCut > 0.) { energyHistoryCut = historyCut; }
+#ifdef debug
+  edm::LogVerbatim("TimingSim") 
+    << "TimingSD : for " << GetName()
+    << " MC truth cuts in are " << energyCut/CLHEP::GeV 
+    << " GeV and " << energyHistoryCut/CLHEP::GeV << " GeV";
+#endif
+}
+
+bool TimingSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
+
+  edeposit = aStep->GetTotalEnergyDeposit();
+  if (edeposit>0.f){ 
+    getStepInfo(aStep);
+    if (!hitExists(aStep)){ 
+      createNewHit(aStep);
+    }
+  }
+  return true;
+} 
+
+void TimingSD::getStepInfo(const G4Step* aStep) {
+  
+  preStepPoint = aStep->GetPreStepPoint(); 
+  postStepPoint= aStep->GetPostStepPoint(); 
+  hitPointExit = postStepPoint->GetPosition();	
+  setToLocal(postStepPoint, hitPointExit, hitPointLocalExit);  
+  const G4Track* newTrack = aStep->GetTrack();   
+
+  // neutral particles deliver energy post step 
+  // charged particle start deliver energy pre step
+  if(newTrack->GetDefinition()->GetPDGCharge() == 0.0) {
+    hitPoint = hitPointExit;
+    hitPointLocal = hitPointLocalExit;
+    tof = (float)(postStepPoint->GetGlobalTime()*invns);
+  } else {
+    hitPoint = preStepPoint->GetPosition();
+    setToLocal(preStepPoint, hitPoint, hitPointLocal);  
+    tof = (float)(preStepPoint->GetGlobalTime()*invns);
+  }
+
+  incidentEnergy = preStepPoint->GetKineticEnergy();
+
+  // should MC truth be saved
+  if (newTrack != theTrack) {
+    theTrack = newTrack;
+    TrackInformation* info = nullptr;
+    if (incidentEnergy > energyCut) {
+      info = cmsTrackInformation(theTrack);
+      info->storeTrack(true);
+    }
+    if (incidentEnergy > energyHistoryCut){
+      if(!info) { info = cmsTrackInformation(theTrack); }
+      info->putInHistory();
+    }
+  }
+
+  edeposit *= invgev;
+  if ( G4TrackToParticleID::isGammaElectronPositron(theTrack) ) {
+    edepositEM  = edeposit; edepositHAD = 0.f;
+  } else {
+    edepositEM  = 0.f; edepositHAD = edeposit;
+  }
+  // time slice is defined for the entry point
+  tSlice    = timeFactor*preStepPoint->GetGlobalTime()*invns;
+  tSliceID  = (int) tSlice;
+
+  unitID    = setDetUnitId(aStep);
+  primaryID = theTrack->GetTrackID();
+}
+
+bool TimingSD::hitExists(const G4Step* aStep) {
+
+  if(!currentHit) { return false; }
+
+  // Update if in the same detector and time-slice   
+  if (tSliceID == tsID && unitID == previousUnitID) {
+    updateHit();
+    return true;
+  }
+   
+  //look in the HitContainer whether a hit with the same primID, unitID,
+  //tSliceID already exists:
+   
+  bool found = false;
+  for (int j=0; j<theHC->entries(); ++j) {
+    BscG4Hit* aHit = (*theHC)[j];
+    if (aHit->getTimeSliceID() == tSliceID && aHit->getUnitID() == unitID) {
+      if(checkHit(aStep, aHit)) {
+	currentHit = aHit;
+	found      = true;
+	break;
+      } 
+    }
+  }          
+  if (found) { updateHit(); }
+  return found;
+}
+
+bool TimingSD::checkHit(const G4Step*, BscG4Hit* hit) {
+
+  // change hit info to fastest primary particle
+  if(tof < hit->getTof()) { 
+    hit->setTrackID(primaryID);
+    hit->setIncidentEnergy((float)incidentEnergy);
+    hit->setPabs(float(preStepPoint->GetMomentum().mag())*invgev);
+    hit->setTof(tof);
+    hit->setParticleType(theTrack->GetDefinition()->GetPDGEncoding());
+
+    float ThetaAtEntry = (float)(hitPointLocal.theta()*invdeg);
+    float PhiAtEntry   = (float)(hitPointLocal.phi()*invdeg);
+
+    hit->setThetaAtEntry(ThetaAtEntry);
+    hit->setPhiAtEntry(PhiAtEntry);
+
+    hit->setEntry(hitPoint);
+    hit->setEntryLocalP(hitPointLocal);
+    hit->setExitLocalP(hitPointLocalExit);
+
+    hit->setParentId(theTrack->GetParentID());
+    hit->setProcessId(theEnumerator->processId(theTrack->GetCreatorProcess()));
+
+    hit->setVertexPosition(theTrack->GetVertexPosition());
+  }
+  return true;
+}
+
+void TimingSD::storeHit(BscG4Hit* hit){
+
+  if (primID<0) return;
+  if (hit == nullptr ) {
+    edm::LogWarning("BscSim") << "BscSD: hit to be stored is NULL !!";
+    return;
+  }
+
+  theHC->insert( hit );
+}
+
+void TimingSD::createNewHit(const G4Step* aStep) {
+
+#ifdef debug
+  const G4VPhysicsVolume* currentPV = preStepPoint->GetPhysicalVolume();
+  edm::LogVerbatim("TimingSim") 
+    << "TimingSD CreateNewHit for " << GetName()
+    << " PV "     << currentPV->GetName()
+    << " PVid = " << currentPV->GetCopyNo()
+    << " Unit "   << unitID <<
+    << "\n primary " << primaryID
+    << " Tof(ns)= " << tof
+    << " time slice " << tSliceID
+    << " E(GeV)= " << incidentEnergy 
+    << " trackID " << theTrack->GetTrackID()
+    << " " << theTrack->GetDefinition()->GetParticleName()
+    << " parentID " << theTrack->GetParentID();
+	   
+  if (theTrack->GetCreatorProcess()!=nullptr) {
+    edm::LogVerbatim("TimingSim") 
+      << theTrack->GetCreatorProcess()->GetProcessName();
+  } else { 
+    edm::LogVerbatim("TimingSim") << " is primary particle";
+  }
+#endif          
+    
+  currentHit = new BscG4Hit;
+  currentHit->setTrackID(primaryID);
+  currentHit->setTimeSlice(tSlice);
+  currentHit->setUnitID(unitID);
+  currentHit->setIncidentEnergy((float)incidentEnergy);
+
+  currentHit->setPabs(float(preStepPoint->GetMomentum().mag()*invgev));
+  currentHit->setTof(tof);
+  currentHit->setParticleType(theTrack->GetDefinition()->GetPDGEncoding());
+
+  float ThetaAtEntry = hitPointLocal.theta()*invdeg;
+  float PhiAtEntry   = hitPointLocal.phi()*invdeg;
+
+  currentHit->setThetaAtEntry(ThetaAtEntry);
+  currentHit->setPhiAtEntry(PhiAtEntry);
+
+  currentHit->setEntry(hitPoint);
+  currentHit->setEntryLocalP(hitPointLocal);
+  currentHit->setExitLocalP(hitPointLocalExit);
+
+  currentHit->setParentId(theTrack->GetParentID());
+  currentHit->setProcessId(theEnumerator->processId(theTrack->GetCreatorProcess()));
+
+  currentHit->setVertexPosition(theTrack->GetVertexPosition());
+
+  updateHit();  
+  storeHit(currentHit);
+}	 
+ 
+void TimingSD::updateHit() {
+
+  currentHit->addEnergyDeposit(edepositEM,edepositHAD);
+
+#ifdef debug
+  edm::LogVerbatim("TimingSim") 
+    << "updateHit: " << GetName() << " add eloss(GeV) " << edeposit 
+    << "CurrentHit=" << currentHit
+    << ", PostStepPoint= " << postStepPoint->GetPosition();
+#endif
+
+  // buffer for next steps:
+  tsID           = tSliceID;
+  primID         = primaryID;
+  previousUnitID = unitID;
+}
+
+void TimingSD::setToLocal(const G4StepPoint* stepPoint,
+			  const G4ThreeVector& globalPoint,
+			  G4ThreeVector& localPoint) {
+
+  const G4VTouchable* touch= stepPoint->GetTouchable();
+  localPoint = 
+    touch->GetHistory()->GetTopTransform().TransformPoint(globalPoint);  
+}
+     
+void TimingSD::EndOfEvent(G4HCofThisEvent* ) {
+
+  int nhits = theHC->entries();
+  if(0 == nhits) { return; }
+  // here we loop over transient hits and make them persistent
+  for (int j=0; j<nhits; ++j) {
+
+    BscG4Hit* aHit = (*theHC)[j];
+    Local3DPoint locEntryPoint= ConvertToLocal3DPoint(aHit->getEntryLocalP());
+    Local3DPoint locExitPoint = ConvertToLocal3DPoint(aHit->getExitLocalP());
+
+    slave->processHits(PSimHit(locEntryPoint,locExitPoint,
+			       aHit->getPabs(),
+			       aHit->getTof(),
+			       aHit->getEnergyLoss(),
+			       aHit->getParticleType(),
+			       aHit->getUnitID(),
+			       aHit->getTrackID(),
+			       aHit->getThetaAtEntry(),
+			       aHit->getPhiAtEntry(),
+                               aHit->getProcessId()));
+  }
+}
+     
+void TimingSD::PrintAll() {
+  LogDebug("TimingSim") << "TimingSD: Collection " << theHC->GetName() << "\n";
+  theHC->PrintAllHits();
+} 
+
+void TimingSD::fillHits(edm::PSimHitContainer& cc, const std::string& hname) {
+  if (slave->name() == hname) { cc=slave->hits(); }
+}
+
+void TimingSD::update (const BeginOfEvent * i) {
+  LogDebug("TimingSim") << " Dispatched BeginOfEvent for " << GetName();
+  clearHits();
+}
+
+void TimingSD::clearHits(){
+  slave->Initialize();
+}

--- a/SimG4CMS/Forward/src/TotemRPOrganization.cc
+++ b/SimG4CMS/Forward/src/TotemRPOrganization.cc
@@ -35,7 +35,7 @@ TotemRPOrganization :: ~TotemRPOrganization() {
 // member functions
 //
 
-uint32_t TotemRPOrganization :: GetUnitID(const G4Step* aStep) const {
+uint32_t TotemRPOrganization :: getUnitID(const G4Step* aStep) const {
 
   G4VPhysicalVolume* physVol;
   int32_t UNITA=0;

--- a/SimG4CMS/Forward/src/TotemSD.cc
+++ b/SimG4CMS/Forward/src/TotemSD.cc
@@ -81,21 +81,21 @@ TotemSD::~TotemSD() {
 
 bool TotemSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
-  GetStepInfo(aStep);
-  if (!HitExists() && edeposit>0.) { 
-    CreateNewHit();
+  getStepInfo(aStep);
+  if (!hitExists() && edeposit>0.) { 
+    createNewHit();
     return true;
   }
-  if (!HitExists() && (((unitID==1111 || unitID==2222) && 
+  if (!hitExists() && (((unitID==1111 || unitID==2222) && 
 			ParentId==0 && ParticleType==2212))) { 
-    CreateNewHitEvo();
+    createNewHitEvo();
   }
   return true;
 }
 
 uint32_t TotemSD::setDetUnitId(const G4Step * aStep) { 
 
-  return (numberingScheme == nullptr ? 0 : numberingScheme->GetUnitID(aStep));
+  return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
 }
 
 void TotemSD::Initialize(G4HCofThisEvent * HCE) { 
@@ -156,7 +156,7 @@ void TotemSD::clearHits(){
   slave->Initialize();
 }
 
-G4ThreeVector TotemSD::SetToLocal(const G4ThreeVector& global) {
+G4ThreeVector TotemSD::setToLocal(const G4ThreeVector& global) {
 
   G4ThreeVector       localPoint;
   const G4VTouchable* touch= preStepPoint->GetTouchable();
@@ -164,13 +164,11 @@ G4ThreeVector TotemSD::SetToLocal(const G4ThreeVector& global) {
   return localPoint;  
 }
 
-void TotemSD::GetStepInfo(const G4Step* aStep) {
+void TotemSD::getStepInfo(const G4Step* aStep) {
   
   preStepPoint = aStep->GetPreStepPoint(); 
   postStepPoint= aStep->GetPostStepPoint(); 
   theTrack     = aStep->GetTrack();   
-  //Local3DPoint theEntryPoint = SensitiveDetector::InitialStepPosition(aStep,LocalCoordinates);  
-  //Local3DPoint theExitPoint  = SensitiveDetector::FinalStepPosition(aStep,LocalCoordinates);
   hitPoint     = preStepPoint->GetPosition();	
   currentPV    = preStepPoint->GetPhysicalVolume();
 
@@ -204,7 +202,7 @@ void TotemSD::GetStepInfo(const G4Step* aStep) {
   Vz = theTrack->GetVertexPosition().z();
 }
 
-bool TotemSD::HitExists() {
+bool TotemSD::hitExists() {
    
   if (primaryID<1) {
     edm::LogWarning("ForwardSim") << "***** TotemSD error: primaryID = " 
@@ -215,13 +213,13 @@ bool TotemSD::HitExists() {
   // Update if in the same detector, time-slice and for same track   
   //  if (primaryID == primID && tSliceID == tsID && unitID==previousUnitID) {
   if (tSliceID == tsID && unitID==previousUnitID) {
-    UpdateHit();
+    updateHit();
     return true;
   }
    
   // Reset entry point for new primary
   if (primaryID != primID)
-    ResetForNewPrimary();
+    resetForNewPrimary();
    
   //look in the HitContainer whether a hit with the same primID, unitID,
   //tSliceID already exists:
@@ -240,14 +238,14 @@ bool TotemSD::HitExists() {
   }          
 
   if (found) {
-    UpdateHit();
+    updateHit();
     return true;
   } else {
     return false;
   }    
 }
 
-void TotemSD::CreateNewHit() {
+void TotemSD::createNewHit() {
 
 #ifdef debug
   LogDebug("ForwardSim") << "TotemSD CreateNewHit for"
@@ -294,12 +292,12 @@ void TotemSD::CreateNewHit() {
   currentHit->setVy(Vy);
   currentHit->setVz(Vz);
 
-  UpdateHit();
+  updateHit();
   
-  StoreHit(currentHit);
+  storeHit(currentHit);
 }	 
 
-void TotemSD::CreateNewHitEvo() {
+void TotemSD::createNewHitEvo() {
 
 // LogDebug("ForwardSim") << "INSIDE CREATE NEW HIT EVO ";
 
@@ -325,35 +323,35 @@ void TotemSD::CreateNewHitEvo() {
 
   G4ThreeVector _PosizioEvo;
   int flagAcc=0;
-  _PosizioEvo=PosizioEvo(Posizio,Vx,Vy,Vz,Pabs,flagAcc);
+  _PosizioEvo=posizioEvo(Posizio,Vx,Vy,Vz,Pabs,flagAcc);
 
   if(flagAcc==1){
     currentHit->setEntry(_PosizioEvo.x(),_PosizioEvo.y(),_PosizioEvo.z());
 
-    UpdateHit();
+    updateHit();
   
-    StoreHit(currentHit);
+    storeHit(currentHit);
   }
   // LogDebug("ForwardSim") << "STORED HIT IN: " << unitID;
 }	 
  
-G4ThreeVector TotemSD::PosizioEvo(const G4ThreeVector& Pos, double vx, double vy,
+G4ThreeVector TotemSD::posizioEvo(const G4ThreeVector& Pos, double vx, double vy,
 				  double vz, double pabs, int& accettanza) {
   accettanza=0;
   //Pos.xyz() in mm
   G4ThreeVector PosEvo; 
-  double ThetaX=atan((Pos.x()-vx)/(Pos.z()-vz));                 
-  double ThetaY=atan((Pos.y()-vy)/(Pos.z()-vz));                
+  double ThetaX=std::atan((Pos.x()-vx)/(Pos.z()-vz));                 
+  double ThetaY=std::atan((Pos.y()-vy)/(Pos.z()-vz));                
   double X_at_0 =(vx-((Pos.x()-vx)/(Pos.z()-vz))*vz)/1000.;   
   double Y_at_0 =(vy-((Pos.y()-vy)/(Pos.z()-vz))*vz)/1000.;  
   
   //  double temp_evo_X;
   //  double temp_evo_Y;
   //  double temp_evo_Z;
-  //  temp_evo_Z = fabs(Pos.z())/Pos.z()*220000.; 
+  //  temp_evo_Z = std::abs(Pos.z())/Pos.z()*220000.; 
  
   //csi=-dp/d
-  double csi = fabs((7000.-pabs)/7000.);
+  double csi = std::abs((7000.-pabs)/7000.);
 
   // all in m 
   const int no_rp=4;
@@ -388,22 +386,22 @@ G4ThreeVector TotemSD::PosizioEvo(const G4ThreeVector& Pos, double vx, double vy
    
    
   //pass TAN@141
-  if (fabs(y_par[0])<pipelim[0][1] && sqrt((y_par[0]*y_par[0])+(x_par[0]*x_par[0]))<pipelim[0][0])  {
+  if (std::abs(y_par[0])<pipelim[0][1] && sqrt((y_par[0]*y_par[0])+(x_par[0]*x_par[0]))<pipelim[0][0])  {
     //pass 149
     if ((sqrt((y_par[1]*y_par[1])+(x_par[1]*x_par[1]))<pipelim[1][0]) &&
-	(fabs(y_par[1])>detlim[1][1] || x_par[1]>detlim[1][0]))  {
+	(std::abs(y_par[1])>detlim[1][1] || x_par[1]>detlim[1][0]))  {
       accettanza = 1;
     }
   }
 
       
   //pass TAN@141
-  if (fabs(y_par[0])<pipelim[0][1] && sqrt((y_par[0])*(y_par[0])+(x_par[0])*(x_par[0]))<pipelim[0][0]) {
+  if (std::abs(y_par[0])<pipelim[0][1] && sqrt((y_par[0])*(y_par[0])+(x_par[0])*(x_par[0]))<pipelim[0][0]) {
     //pass Q5@198
-    if (fabs(y_par[2])<pipelim[2][1] && sqrt((y_par[2]*y_par[2])+(x_par[2]*x_par[2]))<pipelim[2][0]) {
+    if (std::abs(y_par[2])<pipelim[2][1] && sqrt((y_par[2]*y_par[2])+(x_par[2]*x_par[2]))<pipelim[2][0]) {
       //pass 220
       if ((sqrt((y_par[3]*y_par[3])+(x_par[3]*x_par[3]))<pipelim[3][0]) &&
-	  (fabs(y_par[3])>detlim[3][1] || x_par[3]>detlim[3][0])) {
+	  (std::abs(y_par[3])>detlim[3][1] || x_par[3]>detlim[3][0])) {
 	accettanza = 1;
 	
 	PosEvo.setX(1000*x_par[3]);
@@ -432,7 +430,7 @@ G4ThreeVector TotemSD::PosizioEvo(const G4ThreeVector& Pos, double vx, double vy
   return PosEvo;
 }
  
-void TotemSD::UpdateHit() {
+void TotemSD::updateHit() {
   //
   if (Eloss > 0.) {
 
@@ -452,7 +450,7 @@ void TotemSD::UpdateHit() {
   previousUnitID = unitID;
 }
 
-void TotemSD::StoreHit(TotemG4Hit* hit) {
+void TotemSD::storeHit(TotemG4Hit* hit) {
 
   if (primID<0) return;
   if (hit == nullptr ) {
@@ -463,9 +461,9 @@ void TotemSD::StoreHit(TotemG4Hit* hit) {
   theHC->insert( hit );
 }
 
-void TotemSD::ResetForNewPrimary() {
+void TotemSD::resetForNewPrimary() {
   
-  entrancePoint  = SetToLocal(hitPoint);
+  entrancePoint  = setToLocal(hitPoint);
   incidentEnergy = preStepPoint->GetKineticEnergy();
 }
 

--- a/SimG4CMS/Forward/src/TotemT1NumberingScheme.cc
+++ b/SimG4CMS/Forward/src/TotemT1NumberingScheme.cc
@@ -22,7 +22,7 @@
 TotemT1NumberingScheme::TotemT1NumberingScheme(int i) {
 
   edm::LogInfo("ForwardSim") << " Creating TotemT1NumberingScheme";
-  SetCurrentDetectorPosition(i);
+  setCurrentDetectorPosition(i);
 }
 
 TotemT1NumberingScheme::~TotemT1NumberingScheme() {

--- a/SimG4CMS/Forward/src/TotemT1Organization.cc
+++ b/SimG4CMS/Forward/src/TotemT1Organization.cc
@@ -42,11 +42,11 @@ TotemT1Organization :: ~TotemT1Organization() {
 // member functions
 //
 
-uint32_t TotemT1Organization :: GetUnitID(const G4Step* aStep) const {
-  return const_cast<TotemT1Organization *>(this)->GetUnitID(aStep);
+uint32_t TotemT1Organization :: getUnitID(const G4Step* aStep) const {
+  return const_cast<TotemT1Organization *>(this)->getUnitID(aStep);
 }
 
-uint32_t TotemT1Organization :: GetUnitID(const G4Step* aStep) {
+uint32_t TotemT1Organization :: getUnitID(const G4Step* aStep) {
 
   int currLAOT;
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
@@ -85,20 +85,20 @@ uint32_t TotemT1Organization :: GetUnitID(const G4Step* aStep) {
 			 << "CURRENT PLANE "<<_currentPlane;
 #endif
   _needUpdateUnitID=true;
-  return GetCurrentUnitID();
+  return getCurrentUnitID();
 }
 
-int TotemT1Organization :: GetCurrentUnitID(void) const {
+int TotemT1Organization :: getCurrentUnitID(void) const {
 
   _checkUnitIDUpdate();
 #ifdef SCRIVI
- LogDebug("ForwardSim") << "GetCurrentUnitID()=" << _currentUnitID;
+ LogDebug("ForwardSim") << "getCurrentUnitID()=" << _currentUnitID;
                                              << endl;
 #endif
  return _currentUnitID;
 }
 
-void TotemT1Organization :: SetCurrentUnitID(int currentUnitID) {
+void TotemT1Organization :: setCurrentUnitID(int currentUnitID) {
 
 #ifdef SCRIVI
   LogDebug("ForwardSim") << "_currentUnitID=" << currentUnitID;
@@ -107,17 +107,17 @@ void TotemT1Organization :: SetCurrentUnitID(int currentUnitID) {
   _needUpdateData=true;
 }
 
-int  TotemT1Organization :: GetCurrentDetectorPosition(void) const {
+int  TotemT1Organization :: getCurrentDetectorPosition(void) const {
 
   _checkDataUpdate();
 #ifdef SCRIVI
-  LogDebug("ForwardSim") << "GetCurrentDetectorPosition()=" 
+  LogDebug("ForwardSim") << "getCurrentDetectorPosition()=" 
 			 << _currentDetectorPosition;
 #endif
  return _currentDetectorPosition;
 }
 
-void TotemT1Organization :: SetCurrentDetectorPosition(int currentDetectorPosition) {
+void TotemT1Organization :: setCurrentDetectorPosition(int currentDetectorPosition) {
 
 #ifdef SCRIVI
   LogDebug("ForwardSim") << "_currentDetectorPosition=" << currentDetectorPosition;
@@ -126,17 +126,17 @@ void TotemT1Organization :: SetCurrentDetectorPosition(int currentDetectorPositi
   _needUpdateUnitID=true;
 }
 
-int TotemT1Organization :: GetCurrentPlane(void) const {
+int TotemT1Organization :: getCurrentPlane(void) const {
 
   _checkDataUpdate();
 
 #ifdef SCRIVI
-  LogDebug("ForwardSim") << "GetCurrentPlane()=" << _currentPlane;
+  LogDebug("ForwardSim") << "getCurrentPlane()=" << _currentPlane;
 #endif
  return _currentPlane;
 }
 
-void TotemT1Organization :: SetCurrentPlane(int currentPlane) {
+void TotemT1Organization :: setCurrentPlane(int currentPlane) {
 
 #ifdef SCRIVI
   LogDebug("ForwardSim") << "_currentPlane=" << currentPlane;
@@ -145,16 +145,16 @@ void TotemT1Organization :: SetCurrentPlane(int currentPlane) {
   _needUpdateUnitID=true;
 }
 
-int TotemT1Organization :: GetCurrentCSC(void) const {
+int TotemT1Organization :: getCurrentCSC(void) const {
 
   _checkDataUpdate();
 #ifdef SCRIVI
-  LogDebug("ForwardSim") << "GetCurrentCSC()=" << _currentCSC;
+  LogDebug("ForwardSim") << "getCurrentCSC()=" << _currentCSC;
 #endif 
  return _currentCSC;
 }
 
-void TotemT1Organization :: SetCurrentCSC(int currentCSC) {
+void TotemT1Organization :: setCurrentCSC(int currentCSC) {
 
 #ifdef SCRIVI
   LogDebug("ForwardSim") << "_currentCSC=" << currentCSC;
@@ -163,16 +163,16 @@ void TotemT1Organization :: SetCurrentCSC(int currentCSC) {
   _needUpdateUnitID=true; 
 }
 
-int TotemT1Organization :: GetCurrentLayer(void) const {
+int TotemT1Organization :: getCurrentLayer(void) const {
 
   _checkDataUpdate();
 #ifdef SCRIVI
-  LogDebug("ForwardSim") << "GetCurrentLayer()=" << _currentLayer;
+  LogDebug("ForwardSim") << "getCurrentLayer()=" << _currentLayer;
 #endif
   return _currentLayer;
 }
 
-void TotemT1Organization :: SetCurrentLayer(int currentLayer) {
+void TotemT1Organization :: setCurrentLayer(int currentLayer) {
 
 #ifdef SCRIVI
   LogDebug("ForwardSim") << "_currentLayer=" << currentLayer;
@@ -181,16 +181,16 @@ void TotemT1Organization :: SetCurrentLayer(int currentLayer) {
   _needUpdateUnitID=true;
 }
 
-TotemT1Organization::ObjectType  TotemT1Organization :: GetCurrentObjectType(void) const {
+TotemT1Organization::ObjectType  TotemT1Organization :: getCurrentObjectType(void) const {
   
  _checkDataUpdate();
 #ifdef SCRIVI
- LogDebug("ForwardSim") << "GetCurrentObjectType()=" << _currentObjectType;
+ LogDebug("ForwardSim") << "getCurrentObjectType()=" << _currentObjectType;
 #endif
  return _currentObjectType;
 }
 
-void TotemT1Organization :: SetCurrentObjectType(ObjectType currentObjectType){
+void TotemT1Organization :: setCurrentObjectType(ObjectType currentObjectType){
 
 #ifdef SCRIVI
   LogDebug("ForwardSim") << "_currentObjectType=" << currentObjectType;
@@ -199,7 +199,7 @@ void TotemT1Organization :: SetCurrentObjectType(ObjectType currentObjectType){
   _needUpdateUnitID=true;
 }
 
-int TotemT1Organization :: FromObjectTypeToInt(ObjectType objectType) {
+int TotemT1Organization :: fromObjectTypeToInt(ObjectType objectType) {
 
   int result(static_cast<int>(objectType));
   if (result<0 || result>=MaxObjectTypes) {
@@ -210,8 +210,8 @@ int TotemT1Organization :: FromObjectTypeToInt(ObjectType objectType) {
   return result;
 }
 
-int TotemT1Organization :: FromObjectTypeToInt(ObjectType objectType, int layer) {
-  return FromObjectTypeToInt(objectType)+layer*MaxObjectTypes;
+int TotemT1Organization :: fromObjectTypeToInt(ObjectType objectType, int layer) {
+  return fromObjectTypeToInt(objectType)+layer*MaxObjectTypes;
 }
 
 
@@ -347,7 +347,7 @@ void TotemT1Organization :: _FromDataToUnitID(void) {
   }
   currLA=_currentLayer+1;
  
-  currOT=FromObjectTypeToInt(_currentObjectType);
+  currOT=fromObjectTypeToInt(_currentObjectType);
  
   // currDP:  0..2 (3)
   // currPL:  0..infty

--- a/SimG4CMS/Forward/src/TotemT2OrganizationGem.cc
+++ b/SimG4CMS/Forward/src/TotemT2OrganizationGem.cc
@@ -31,7 +31,7 @@ TotemT2OrganizationGem :: TotemT2OrganizationGem() {
 TotemT2OrganizationGem :: ~TotemT2OrganizationGem() {
 }
 
-uint32_t TotemT2OrganizationGem :: GetUnitID(const G4Step* aStep) const {
+uint32_t TotemT2OrganizationGem :: getUnitID(const G4Step* aStep) const {
 
  G4VPhysicalVolume* physVol;
  uint32_t UNITA = 0;

--- a/SimG4CMS/Forward/src/ZdcSD.cc
+++ b/SimG4CMS/Forward/src/ZdcSD.cc
@@ -147,10 +147,10 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep) {
     float costheta = vert_mom.z()/sqrt(vert_mom.x()*vert_mom.x()+
                                        vert_mom.y()*vert_mom.y()+
                                        vert_mom.z()*vert_mom.z());
-    float theta = acos(std::min(std::max(costheta,float(-1.)),float(1.)));
-    float eta = -log(tan(theta/2));
+    float theta = std::acos(std::min(std::max(costheta,-1.f),1.f));
+    float eta = -std::log(std::tan(theta*0.5f));
     float phi = -100.;
-    if (vert_mom.x() != 0) phi = atan2(vert_mom.y(),vert_mom.x()); 
+    if (vert_mom.x() != 0) phi = std::atan2(vert_mom.y(),vert_mom.x()); 
     if (phi < 0.) phi += twopi;
 
     // Get the total energy deposit
@@ -204,10 +204,10 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep) {
       float DelFibPart = std::abs(th - thFibDirRad);
 
       // define real distances:
-      float d = std::abs(tan(th)-tan(thFibDirRad));   
+      float d = std::abs(std::tan(th)-std::tan(thFibDirRad));   
 
-      float a = tan(thFibDirRad)+tan(fabs(thFibDirRad-thFullReflRad));   
-      float r = tan(th)+tan(fabs(th-thcher));   
+      float a = std::tan(thFibDirRad)+std::tan(std::abs(thFibDirRad-thFullReflRad));   
+      float r = std::tan(th)+std::tan(std::abs(th-thcher));   
       
       // define losses d_qz in cone of full reflection inside quartz direction
       float d_qz = -1;
@@ -232,13 +232,13 @@ double ZdcSD::getEnergyDeposit(const G4Step * aStep) {
             float tan_arcos = 2.*a*d;
             if (tan_arcos != 0.) arg_arcos =(r*r-a*a-d*d)/tan_arcos; 
             // std::cout.testOut << "  d_qz: " << r << "," << a << "," << d << " " << tan_arcos << " " << arg_arcos;
-            arg_arcos = fabs(arg_arcos);
+            arg_arcos = std::abs(arg_arcos);
             // std::cout.testOut << "," << arg_arcos;
             float th_arcos = acos(std::min(std::max(arg_arcos,-1.f),1.f));
             // std::cout.testOut << " " << th_arcos;
-            d_qz = th_arcos/pi/2.;
+            d_qz = th_arcos/twopi;
             // std::cout.testOut << " " << d_qz;
-            d_qz = fabs(d_qz);
+            d_qz = std::abs(d_qz);
             // std::cout.testOut << "," << d_qz;
           }
         }


### PR DESCRIPTION
This is the last PR for clean up of Geant4 sensitive detector classes. Only forward detectors are updated:

1) A new class TimingSD surves for common computations. Duplicated codes in several classes are removed, instead inheritance is used.
2) Comments of @VinInn are implemented in a good part
3) Improved debug printouts
4) removed unused headers, commented and empty lines

Run-1 and run-2 workflows are expected to be unchanged.

