### PR TITLE
Run2-hcx178 Usage of the correct Hcal geometry in FastSim

### DIFF
--- a/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc
+++ b/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc
@@ -99,10 +99,10 @@ DetId CaloGeometryHelper::getClosestCell(const XYZPoint& point, bool ecal, bool 
     }
   else
     {
-      result=HcalGeometry_->getClosestCell(GlobalPoint(point.X(),point.Y(),point.Z()));
+      result=static_cast<const HcalGeometry*>(HcalGeometry_)->getClosestCell(GlobalPoint(point.X(),point.Y(),point.Z()),true);
       HcalDetId myDetId(result);
 
-      // special patch for HF
+      // special patch for HF (this is already a part of HcalGeometry)
       if ( myDetId.subdetId() == HcalForward ) {
 	int mylayer;
 	if ( fabs(point.Z()) > 1132. ) {
@@ -112,12 +112,12 @@ DetId CaloGeometryHelper::getClosestCell(const XYZPoint& point, bool ecal, bool 
 	}
 	HcalDetId myDetId2((HcalSubdetector)myDetId.subdetId(),myDetId.ieta(),myDetId.iphi(),mylayer);
 	result = myDetId2;
-	return result;
+//      return result;
       }
 
-
+      // Special patch to correct the HCAL geometry (does not work)
+      /*
       if(result.subdetId()!=HcalEndcap) return result;
-      // Special patch to correct the HCAL geometry
       if(myDetId.depth()==3) return result;
 
       int ieta=myDetId.ietaAbs();
@@ -141,6 +141,7 @@ DetId CaloGeometryHelper::getClosestCell(const XYZPoint& point, bool ecal, bool 
           HcalDetId second(HcalEndcap,myDetId.ieta(),myDetId.iphi(),2);
 	  if(second!=HcalDetId()) result=second;
 	}
+      */
 #ifdef DEBUGGCC
       if(result.null()) 
 	{

--- a/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
@@ -56,6 +56,7 @@ public:
   std::shared_ptr<const CaloCellGeometry> getGeometry( const DetId& id ) const override ;
   
   DetId getClosestCell(const GlobalPoint& r) const override ;
+  DetId getClosestCell(const GlobalPoint& r, bool ignoreCorrect) const;
   
   CaloSubdetectorGeometry::DetIdSet getCells(const GlobalPoint& r, double dR) const override ;
 

--- a/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
@@ -104,6 +104,11 @@ std::shared_ptr<const CaloCellGeometry> HcalGeometry::getGeometry(const DetId& i
 }
 
 DetId HcalGeometry::getClosestCell(const GlobalPoint& r) const {
+  return getClosestCell(r,false);
+}
+
+DetId HcalGeometry::getClosestCell(const GlobalPoint& r,
+				   bool ignoreCorrect) const {
 
   // Now find the closest eta_bin, eta value of a bin i is average
   // of eta[i] and eta[i-1]
@@ -163,8 +168,12 @@ DetId HcalGeometry::getClosestCell(const GlobalPoint& r) const {
         }
       }
     }
-    
-    return correctId(bestId);
+#ifdef EDM_ML_DEBUG
+    std::cout << bestId << " Corrected to " << HcalDetId(correctId(bestId)) 
+	      << std::endl;
+#endif
+
+    return (ignoreCorrect ? bestId : correctId(bestId));
   }
 }
 


### PR DESCRIPTION
Output of SIM step should have uncollapsed depth for HCAL and collapsing is done only at RECO level