### PR TITLE
L1 PR 10_2 Omtf unpacker and ghost-buster & CaloLayer2 HoEext and Qual bit in ntuple

### DIFF
--- a/DataFormats/L1Trigger/interface/BXVector.impl
+++ b/DataFormats/L1Trigger/interface/BXVector.impl
@@ -171,7 +171,7 @@ void BXVector<T>::clear()
 template < class T >
 void BXVector<T>::insert(int bx, unsigned i,T object)
 {
-  if(i >= size(bx)){	
+  if(i > size(bx)){	
      //cout<<"ERROR: bx "<<bx<<" is only "<<size(bx)<<" long"<<endl;
   }
   else{

--- a/DataFormats/L1Trigger/interface/BXVector.impl
+++ b/DataFormats/L1Trigger/interface/BXVector.impl
@@ -104,7 +104,7 @@ template < class T >
 typename BXVector<T>::const_iterator
 BXVector<T>::begin( int bx ) const
 {
-  assert(itrs_.size() > 0);
+  assert(!itrs_.empty());
   return data_.begin()+itrs_[indexFromBX(bx)];
 }
 

--- a/EventFilter/L1TRawToDigi/plugins/OmtfUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/OmtfUnpacker.cc
@@ -142,7 +142,7 @@ void OmtfUnpacker::produce(edm::Event& event, const edm::EventSetup& setup)
   auto producedRPCDigis = std::make_unique<RPCDigiCollection>();
   auto producedCscLctDigis = std::make_unique<CSCCorrelatedLCTDigiCollection>();
   auto producedMuonDigis = std::make_unique<l1t::RegionalMuonCandBxCollection>(); 
-  producedMuonDigis->setBXRange(-3,3);
+  producedMuonDigis->setBXRange(-3,4);
   auto producedDTPhDigis = std::make_unique<L1MuDTChambPhContainer>();
   auto producedDTThDigis = std::make_unique<L1MuDTChambThContainer>();
   std::vector<L1MuDTChambPhDigi> phi_Container;

--- a/EventFilter/L1TRawToDigi/src/OmtfMuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/src/OmtfMuonUnpacker.cc
@@ -27,8 +27,20 @@ void MuonUnpacker::unpack(unsigned int fed, unsigned int amc, const MuonDataWord
   digi.setTrackAddress(trackAddr);
   digi.setTFIdentifiers(iProcessor, overlap);
   int bx = data.bxNum()-3;
-  LogTrace("")  <<"OMTF Muon, BX="<<bx<<", hwPt="<<digi.hwPt()<< std::endl;
-  if(std::abs(bx) <= 3) producedMuonDigis->push_back(bx,digi);
+  LogTrace("")  <<"OMTF Muon, BX="<<bx<<", hwPt="<<digi.hwPt()<<", link: "<<digi.link() << std::endl;
+
+  // add digi to collection, keep fixed ascending link orderi (insert in proper place)
+  if(std::abs(bx) <= 3) {
+    l1t::RegionalMuonCandBxCollection::const_iterator itb=producedMuonDigis->begin(bx);
+    l1t::RegionalMuonCandBxCollection::const_iterator ite=producedMuonDigis->end(bx);
+    unsigned int indeks = 0;
+    while (indeks < ite-itb) {
+      if (digi.link()<(itb+indeks)->link()) break;
+      indeks++;
+    }
+    producedMuonDigis->insert(bx,indeks,digi);
+  }
+  
 }
  
 }

--- a/EventFilter/L1TRawToDigi/src/OmtfMuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/src/OmtfMuonUnpacker.cc
@@ -30,16 +30,14 @@ void MuonUnpacker::unpack(unsigned int fed, unsigned int amc, const MuonDataWord
   LogTrace("")  <<"OMTF Muon, BX="<<bx<<", hwPt="<<digi.hwPt()<<", link: "<<digi.link() << std::endl;
 
   // add digi to collection, keep fixed ascending link orderi (insert in proper place)
-  if(std::abs(bx) <= 3) {
-    l1t::RegionalMuonCandBxCollection::const_iterator itb=producedMuonDigis->begin(bx);
-    l1t::RegionalMuonCandBxCollection::const_iterator ite=producedMuonDigis->end(bx);
-    unsigned int indeks = 0;
-    while (indeks < ite-itb) {
-      if (digi.link()<(itb+indeks)->link()) break;
-      indeks++;
-    }
-    producedMuonDigis->insert(bx,indeks,digi);
+  l1t::RegionalMuonCandBxCollection::const_iterator itb=producedMuonDigis->begin(bx);
+  l1t::RegionalMuonCandBxCollection::const_iterator ite=producedMuonDigis->end(bx);
+  unsigned int indeks = 0;
+  while (indeks < ite-itb) {
+    if (digi.link()<(itb+indeks)->link()) break;
+    indeks++;
   }
+  producedMuonDigis->insert(bx,indeks,digi);
   
 }
  

--- a/L1Trigger/L1TCalorimeter/src/CaloTools.cc
+++ b/L1Trigger/L1TCalorimeter/src/CaloTools.cc
@@ -394,6 +394,7 @@ l1t::EGamma l1t::CaloTools::egP4MP(l1t::EGamma& eg) {
   tmpEG.setFootprintEt(eg.footprintEt());
   tmpEG.setNTT(eg.nTT());
   tmpEG.setShape(eg.shape());
+  tmpEG.setTowerHoE(eg.towerHoE());
   
   return tmpEG;
 

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EGammaAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EGammaAlgorithmFirmwareImp1.cc
@@ -127,14 +127,16 @@ void l1t::Stage2Layer2EGammaAlgorithmFirmwareImp1::processEvent(const std::vecto
       // Identification of the egamma
       // Based on the seed tower FG bit, the H/E ratio of the seed tower, and the shape of the cluster
       bool hOverEBit = cluster.hOverE()>0;
+      bool hOverEExtBit = true;
       if(!params_->egBypassExtHOverE())
-	hOverEBit &= HoE_ext;
+	hOverEExtBit = HoE_ext;
       bool shapeBit  = idShape(cluster, egamma.hwPt());
       bool fgBit     = !(cluster.fgECAL()); 
       int qual = 0;
       if(fgBit)     qual |= (0x1); // first bit = FG
       if(hOverEBit) qual |= (0x1<<1); // second bit = H/E
       if(shapeBit)  qual |= (0x1<<2); // third bit = shape
+      if(hOverEExtBit) qual |= (0x1<<3); // fourth bit = shape
       egamma.setHwQual( qual ); 
 
       // Isolation 
@@ -231,8 +233,9 @@ void l1t::Stage2Layer2EGammaAlgorithmFirmwareImp1::processEvent(const std::vecto
       int fgBit     = egammas_raw.at(iEG).hwQual()    & (0x1);
       int hOverEBit = egammas_raw.at(iEG).hwQual()>>1 & (0x1);
       int shapeBit  = egammas_raw.at(iEG).hwQual()>>2 & (0x1);
+      int hOverEExtBit = egammas_raw.at(iEG).hwQual()>>3 & (0x1);
 
-      bool IDcuts = (fgBit && hOverEBit && shapeBit) || (egammas_raw.at(iEG).pt()>=params_->egMaxPtHOverE()) || (params_->egBypassEGVetos());
+      bool IDcuts = (fgBit && hOverEBit && shapeBit && hOverEExtBit) || (egammas_raw.at(iEG).pt()>=params_->egMaxPtHOverE()) || (params_->egBypassEGVetos());
 
       if(!IDcuts) continue;
 

--- a/L1Trigger/L1TMuonOverlap/interface/GhostBuster.h
+++ b/L1Trigger/L1TMuonOverlap/interface/GhostBuster.h
@@ -9,19 +9,13 @@
 
 #include <memory>
 
+#include "L1Trigger/L1TMuonOverlap/interface/IGhostBuster.h"
 #include "L1Trigger/L1TMuonOverlap/interface/AlgoMuon.h"
 
-class OMTFGhostBuster {
-
-  public:
-  
-    void select(std::vector<AlgoMuon> & refHitCands, int charge=0);
-
-    void setNphiBins(unsigned int phiBins) {nPhiBins = phiBins;};
-
- private:
-
-    unsigned int nPhiBins;
+class GhostBuster: public IGhostBuster {
+public:
+  virtual ~GhostBuster() {};
+  virtual std::vector<AlgoMuon> select(std::vector<AlgoMuon> refHitCands, int charge=0);
 
 };
 #endif

--- a/L1Trigger/L1TMuonOverlap/interface/GhostBuster.h
+++ b/L1Trigger/L1TMuonOverlap/interface/GhostBuster.h
@@ -14,8 +14,8 @@
 
 class GhostBuster: public IGhostBuster {
 public:
-  virtual ~GhostBuster() {};
-  virtual std::vector<AlgoMuon> select(std::vector<AlgoMuon> refHitCands, int charge=0);
+  ~GhostBuster() override {};
+  std::vector<AlgoMuon> select(std::vector<AlgoMuon> refHitCands, int charge=0) override;
 
 };
 #endif

--- a/L1Trigger/L1TMuonOverlap/interface/GhostBusterPreferRefDt.h
+++ b/L1Trigger/L1TMuonOverlap/interface/GhostBusterPreferRefDt.h
@@ -1,0 +1,27 @@
+#ifndef OMTF_GhostBusterPreferRefDt_H
+#define OMTF_GhostBusterPreferRefDt_H
+
+#include <vector>
+#include <ostream>
+
+#include <map>
+#include <set>
+
+#include <memory>
+
+#include "L1Trigger/L1TMuonOverlap/interface/IGhostBuster.h"
+#include "L1Trigger/L1TMuonOverlap/interface/AlgoMuon.h"
+#include "L1Trigger/L1TMuonOverlap/interface/OMTFConfiguration.h"
+
+class GhostBusterPreferRefDt: public IGhostBuster {
+private:
+  const OMTFConfiguration* omtfConfig;
+public:
+  GhostBusterPreferRefDt(OMTFConfiguration* omtfConfig):omtfConfig(omtfConfig) {};
+
+  virtual ~GhostBusterPreferRefDt() {};
+
+  virtual std::vector<AlgoMuon> select(std::vector<AlgoMuon> refHitCands, int charge=0);
+
+};
+#endif

--- a/L1Trigger/L1TMuonOverlap/interface/GhostBusterPreferRefDt.h
+++ b/L1Trigger/L1TMuonOverlap/interface/GhostBusterPreferRefDt.h
@@ -19,9 +19,9 @@ private:
 public:
   GhostBusterPreferRefDt(OMTFConfiguration* omtfConfig):omtfConfig(omtfConfig) {};
 
-  virtual ~GhostBusterPreferRefDt() {};
+  ~GhostBusterPreferRefDt() override {};
 
-  virtual std::vector<AlgoMuon> select(std::vector<AlgoMuon> refHitCands, int charge=0);
+  std::vector<AlgoMuon> select(std::vector<AlgoMuon> refHitCands, int charge=0) override;
 
 };
 #endif

--- a/L1Trigger/L1TMuonOverlap/interface/IGhostBuster.h
+++ b/L1Trigger/L1TMuonOverlap/interface/IGhostBuster.h
@@ -1,0 +1,21 @@
+/*
+ * IGhostBuster.h
+ *
+ *  Created on: Jun 28, 2017
+ *      Author: kbunkow
+ */
+
+#ifndef OMTF_IGHOSTBUSTER_H_
+#define OMTF_IGHOSTBUSTER_H_
+
+#include "L1Trigger/L1TMuonOverlap/interface/AlgoMuon.h"
+
+class IGhostBuster {
+public:
+  virtual ~IGhostBuster() {}
+
+  virtual std::vector<AlgoMuon> select(std::vector<AlgoMuon> refHitCands, int charge=0) = 0;
+
+};
+
+#endif /* OMTF_IGHOSTBUSTER_H_ */

--- a/L1Trigger/L1TMuonOverlap/interface/OMTFReconstruction.h
+++ b/L1Trigger/L1TMuonOverlap/interface/OMTFReconstruction.h
@@ -74,7 +74,7 @@ class OMTFReconstruction {
     OMTFConfiguration   *m_OMTFConfig;
     OMTFinputMaker       m_InputMaker;
     OMTFSorter           m_Sorter;
-    OMTFGhostBuster      m_GhostBuster;
+    std::unique_ptr<IGhostBuster> m_GhostBuster;
     OMTFProcessor       *m_OMTF;    
   ///
     xercesc::DOMElement *aTopElement;

--- a/L1Trigger/L1TMuonOverlap/python/simOmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonOverlap/python/simOmtfDigis_cfi.py
@@ -14,7 +14,8 @@ simOmtfDigis = cms.EDProducer("L1TMuonOverlapTrackProducer",
                               eventsXMLFiles = cms.vstring("TestEvents.xml"),
                               dropRPCPrimitives = cms.bool(False),                                    
                               dropDTPrimitives = cms.bool(False),                                    
-                              dropCSCPrimitives = cms.bool(False)   
+                              dropCSCPrimitives = cms.bool(False),
+                              #ghostBusterType = cms.string("GhostBusterPreferRefDt")
 )
 
 

--- a/L1Trigger/L1TMuonOverlap/test/runMuonOverlap.py
+++ b/L1Trigger/L1TMuonOverlap/test/runMuonOverlap.py
@@ -11,10 +11,10 @@ process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(50)
 process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(False))
 
 process.source = cms.Source('PoolSource',
- fileNames = cms.untracked.vstring('file:/afs/cern.ch/work/g/gflouris/public/SingleMuPt6180_noanti_10k_eta1.root')
-                           )
+ #fileNames = cms.untracked.vstring('file:/afs/cern.ch/work/g/gflouris/public/SingleMuPt6180_noanti_10k_eta1.root')
+ fileNames = cms.untracked.vstring('file:///afs/cern.ch/work/k/kbunkow/private/omtf_data/SingleMu_15_p_1_1_qtl.root')                           )
 	                    
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10))
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000))
 
 # PostLS1 geometry used
 process.load('Configuration.Geometry.GeometryExtended2015Reco_cff')

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
@@ -65,6 +65,7 @@ namespace L1Analysis
       egNTT.clear();
       egShape.clear();
       egTowerHoE.clear();
+      egHwQual.clear();
 
       nTaus = 0;
       tauEt.clear();
@@ -148,6 +149,7 @@ namespace L1Analysis
     std::vector<short int> egNTT;
     std::vector<short int> egShape;
     std::vector<short int> egTowerHoE;
+    std::vector<short int> egHwQual;
  
     unsigned short int nTaus;
     std::vector<float> tauEt;

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
@@ -30,6 +30,7 @@ void L1Analysis::L1AnalysisL1Upgrade::SetEm(const edm::Handle<l1t::EGammaBxColle
 	l1upgrade_.egNTT.push_back(it->nTT());
 	l1upgrade_.egShape.push_back(it->shape());
 	l1upgrade_.egTowerHoE.push_back(it->towerHoE());
+	l1upgrade_.egHwQual.push_back(it->hwQual());
 	l1upgrade_.nEGs++;
       }
     }


### PR DESCRIPTION
PR 10_2  Fixes in L1T

Contains: 
 * OMTF unpacker in order assumed by GMT  (v97.23)
 * OMTF emulator ghost-buster second implementation (v97.28)
 * CaloLayer2 HoEext and Qual bit in ntuple (v97.26)