### PR TITLE
[muon] reco to trigger object matching

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1649,6 +1649,7 @@ class ConfigBuilder(object):
 		     self._options.customise_commands = self._options.customise_commands + " \n"
 	     self._options.customise_commands = self._options.customise_commands + "process.patTrigger.processName = \""+self._options.hltProcess+"\"\n"
              self._options.customise_commands = self._options.customise_commands + "process.slimmedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
+             self._options.customise_commands = self._options.customise_commands + "process.patMuons.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
 
 #            self.renameHLTprocessInSequence(sequence)
 

--- a/Configuration/Skimming/python/PDWG_BPHSkim_cff.py
+++ b/Configuration/Skimming/python/PDWG_BPHSkim_cff.py
@@ -18,6 +18,7 @@ oniaPATMuonsWithoutTrigger = PhysicsTools.PatAlgos.producersLayer1.muonProducer_
     userIsolation = cms.PSet(),   # no extra isolation beyond what's in reco::Muon itself
     isoDeposits = cms.PSet(),     # no heavy isodeposits
     addGenMatch = False,          # no mc
+    addTriggerMatching = cms.bool(False)
 )
 
 oniaSelectedMuons = cms.EDFilter('PATMuonSelector',

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -313,10 +313,15 @@ namespace pat {
       void setSimPhi(float phi){ simPhi_ = phi;}
       
       /// Trigger information
-      const pat::TriggerObjectStandAloneRef& getL1Object()  const { return l1Muon_; }
-      const pat::TriggerObjectStandAloneRef& getHltObject() const { return hltMuon_; }
-      void setL1Object(  const pat::TriggerObjectStandAloneRef& obj){ l1Muon_ = obj; }
-      void setHltObject( const pat::TriggerObjectStandAloneRef& obj){ hltMuon_ = obj; }
+      const pat::TriggerObjectStandAlone* l1Object(const size_t idx=0)  const { 
+	return triggerObjectMatchByType(trigger::TriggerL1Mu,idx);
+      }
+      const pat::TriggerObjectStandAlone* hltObject(const size_t idx=0)  const { 
+	return triggerObjectMatchByType(trigger::TriggerMuon,idx);
+      }
+      bool triggered( const char * pathName ){
+	return triggerObjectMatchByPath(pathName,true,true)!=nullptr;
+      }
 
     protected:
 
@@ -407,10 +412,6 @@ namespace pat {
       float simPt_;
       float simEta_;
       float simPhi_;
-      
-      // trigger info
-      pat::TriggerObjectStandAloneRef l1Muon_;
-      pat::TriggerObjectStandAloneRef hltMuon_;
   };
 
 

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -312,8 +312,12 @@ namespace pat {
       void setSimEta(float eta){ simEta_ = eta;}
       void setSimPhi(float phi){ simPhi_ = phi;}
       
-      void setL1Object(const pat::TriggerObjectStandAloneRef& obj){ l1Muon_ = obj; }
-      const pat::TriggerObjectStandAloneRef& getL1Object() const { return l1Muon_; }
+      /// Trigger information
+      const pat::TriggerObjectStandAloneRef& getL1Object()  const { return l1Muon_; }
+      const pat::TriggerObjectStandAloneRef& getHltObject() const { return hltMuon_; }
+      void setL1Object(  const pat::TriggerObjectStandAloneRef& obj){ l1Muon_ = obj; }
+      void setHltObject( const pat::TriggerObjectStandAloneRef& obj){ hltMuon_ = obj; }
+
     protected:
 
       // ---- for content embedding ----
@@ -406,7 +410,7 @@ namespace pat {
       
       // trigger info
       pat::TriggerObjectStandAloneRef l1Muon_;
-      
+      pat::TriggerObjectStandAloneRef hltMuon_;
   };
 
 

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -311,6 +311,9 @@ namespace pat {
       void setSimPt(float pt){ simPt_ = pt;}
       void setSimEta(float eta){ simEta_ = eta;}
       void setSimPhi(float phi){ simPhi_ = phi;}
+      
+      void setL1Object(const pat::TriggerObjectStandAloneRef& obj){ l1Muon_ = obj; }
+      const pat::TriggerObjectStandAloneRef& getL1Object() const { return l1Muon_; }
     protected:
 
       // ---- for content embedding ----
@@ -400,6 +403,9 @@ namespace pat {
       float simPt_;
       float simEta_;
       float simPhi_;
+      
+      // trigger info
+      pat::TriggerObjectStandAloneRef l1Muon_;
       
   };
 

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -61,7 +61,8 @@
   </ioread>
 
 
-  <class name="pat::Muon"  ClassVersion="25">
+  <class name="pat::Muon"  ClassVersion="26">
+   <version ClassVersion="26" checksum="67498443"/>
    <version ClassVersion="25" checksum="574733987"/>
    <version ClassVersion="24" checksum="2298704767"/>
    <version ClassVersion="23" checksum="3471390119"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -62,7 +62,7 @@
 
 
   <class name="pat::Muon"  ClassVersion="26">
-   <version ClassVersion="26" checksum="67498443"/>
+   <version ClassVersion="26" checksum="3835081798"/>
    <version ClassVersion="25" checksum="574733987"/>
    <version ClassVersion="24" checksum="2298704767"/>
    <version ClassVersion="23" checksum="3471390119"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -61,8 +61,7 @@
   </ioread>
 
 
-  <class name="pat::Muon"  ClassVersion="26">
-   <version ClassVersion="26" checksum="3835081798"/>
+  <class name="pat::Muon"  ClassVersion="25">
    <version ClassVersion="25" checksum="574733987"/>
    <version ClassVersion="24" checksum="2298704767"/>
    <version ClassVersion="23" checksum="3471390119"/>

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -618,11 +618,13 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
   if (primaryVertexIsValid) pv = &primaryVertex;
 
   edm::Handle<std::vector<pat::TriggerObjectStandAlone> > triggerObjects;
-  if (addTriggerMatching_) iEvent.getByToken(triggerObjects_, triggerObjects);
-
+  bool triggerInfoAvailable = false;
+  if (addTriggerMatching_) 
+    triggerInfoAvailable = iEvent.getByToken(triggerObjects_, triggerObjects);
+  
   for(auto& muon: *patMuons){
     // trigger info
-    if (addTriggerMatching_){
+    if (addTriggerMatching_ and triggerInfoAvailable){
       fillL1TriggerInfo(muon,triggerObjects,geometry);
       fillHltTriggerInfo(muon,triggerObjects,hltCollectionNames_);
     }

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -83,8 +83,7 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavy
   computeSoftMuonMVA_(false),
   recomputeBasicSelectors_(false),
   mvaUseJec_(false),
-  isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation") : edm::ParameterSet(), consumesCollector(), false),
-  era_(iConfig.exists("era") ? iConfig.getParameter<std::string>("era") : "")
+  isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation") : edm::ParameterSet(), consumesCollector(), false)
 {
   // input source
   muonToken_ = consumes<edm::View<reco::Muon> >(iConfig.getParameter<edm::InputTag>( "muonSource" ));

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -244,6 +244,7 @@ void PATMuonProducer::fillL1TriggerInfo(pat::Muon& aMuon,
     if (triggerObjects->at(i).hasTriggerObjectType(trigger::TriggerL1Mu)){
       if (deltaR(triggerObjects->at(i).p4(),*muonPosition)>0.1) continue;
       aMuon.setL1Object(pat::TriggerObjectStandAloneRef(triggerObjects,i));
+      aMuon.addTriggerObjectMatch(triggerObjects->at(i));
       break;
     }
   }
@@ -260,8 +261,10 @@ void PATMuonProducer::fillHltTriggerInfo(pat::Muon& muon,
   for (auto collection: collection_names){
     for (unsigned int i=0; i<triggerObjects->size(); ++i){
       if (triggerObjects->at(i).hasTriggerObjectType(trigger::TriggerMuon)){
-	if (collection != triggerObjects->at(i).collection()) continue;
 	float dr = deltaR(triggerObjects->at(i).p4(),muon);
+	if (dr<0.1)
+	  muon.addTriggerObjectMatch(triggerObjects->at(i));
+	if (collection != triggerObjects->at(i).collection()) continue;
 	if (dr>0.1 or dr>best_match_dr) continue;
 	best_match_dr = dr;
 	best_match_index = i;

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -189,8 +189,7 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig, PATMuonHeavy
   if ( addTriggerMatching_ ){
     triggerObjects_ = consumes<std::vector<pat::TriggerObjectStandAlone>>(edm::InputTag("slimmedPatTrigger"));
   }
-  if (iConfig.exists("hltCollectionNames"))
-    hltCollectionNames_ = iConfig.getParameter<std::vector<std::string>>("hltCollectionNames");
+  hltCollectionNames_ = iConfig.getParameter<std::vector<std::string>>("hltCollectionNames");
 
   // produces vector of muons
   produces<std::vector<Muon> >();
@@ -244,9 +243,6 @@ void PATMuonProducer::fillL1TriggerInfo(pat::Muon& aMuon,
   for (unsigned int i=0; i<triggerObjects->size(); ++i){
     if (triggerObjects->at(i).hasTriggerObjectType(trigger::TriggerL1Mu)){
       if (deltaR(triggerObjects->at(i).p4(),*muonPosition)>0.1) continue;
-      // printf("muon pt: %4.1f eta: %+5.3f phi: %+5.3f\n", aMuon.pt(), aMuon.eta(), aMuon.phi());
-      // if (muonPosition) printf("global direction MB2/ME2: eta: %+5.3f phi: %+5.3f\n",double(muonPosition->eta()), double(muonPosition->phi()));
-      // printf("L1 pt: %4.1f eta: %+5.3f phi: %+5.3f\n",triggerObjects->at(i).pt(), triggerObjects->at(i).eta(), triggerObjects->at(i).phi());
       aMuon.setL1Object(pat::TriggerObjectStandAloneRef(triggerObjects,i));
       break;
     }

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -112,9 +112,9 @@ namespace pat {
 			 bool beamspotIsValid );
     double relMiniIsoPUCorrected( const pat::Muon& aMuon,
 				  double rho);
-    GlobalPoint* getMuonDirection(const reco::MuonChamberMatch& chamberMatch,
-				   const edm::ESHandle<GlobalTrackingGeometry>& geometry,
-				   const DetId& chamberId);
+    std::unique_ptr<GlobalPoint> getMuonDirection(const reco::MuonChamberMatch& chamberMatch,
+						  const edm::ESHandle<GlobalTrackingGeometry>& geometry,
+						  const DetId& chamberId);
     void fillL1TriggerInfo(pat::Muon& muon,
 			   edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
 			   const edm::TriggerNames & names,

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -36,8 +36,6 @@
 #include "PhysicsTools/PatAlgos/interface/SoftMuonMvaEstimator.h"
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
-// #include "DataFormats/GeometryVector/interface/GlobalVector.h"
-// #include "DataFormats/GeometryVector/interface/LocalVector.h"
 
 namespace pat {
 

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -226,8 +226,6 @@ namespace pat {
 
     /// MC info
     edm::EDGetTokenT<edm::ValueMap<reco::MuonSimInfo> > simInfo_;
-    /// Era
-    std::string era_;
 
     /// Trigger
     edm::EDGetTokenT<std::vector<pat::TriggerObjectStandAlone>> triggerObjects_;

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -228,6 +228,7 @@ namespace pat {
     edm::EDGetTokenT<edm::ValueMap<reco::MuonSimInfo> > simInfo_;
 
     /// Trigger
+    bool addTriggerMatching_;
     edm::EDGetTokenT<std::vector<pat::TriggerObjectStandAlone>> triggerObjects_;
     std::vector<std::string> hltCollectionNames_;
   };

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -34,6 +34,7 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "PhysicsTools/PatAlgos/interface/MuonMvaEstimator.h"
 #include "PhysicsTools/PatAlgos/interface/SoftMuonMvaEstimator.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 
 namespace pat {
 
@@ -214,6 +215,11 @@ namespace pat {
 
     /// MC info
     edm::EDGetTokenT<edm::ValueMap<reco::MuonSimInfo> > simInfo_;
+    /// Era
+    std::string era_;
+
+    /// Trigger
+    edm::EDGetTokenT<std::vector<pat::TriggerObjectStandAlone>> triggerObjects_;
   };
 
 }

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -36,6 +36,7 @@
 #include "PhysicsTools/PatAlgos/interface/SoftMuonMvaEstimator.h"
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
 
 namespace pat {
 
@@ -116,9 +117,11 @@ namespace pat {
 				   const DetId& chamberId);
     void fillL1TriggerInfo(pat::Muon& muon,
 			   edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
+			   const edm::TriggerNames & names,
 			   const edm::ESHandle<GlobalTrackingGeometry>& geometry);
     void fillHltTriggerInfo(pat::Muon& muon,
 			    edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
+			    const edm::TriggerNames & names,
 			    const std::vector<std::string>& collection_names);
   private:
     /// input source
@@ -228,6 +231,7 @@ namespace pat {
     /// Trigger
     bool addTriggerMatching_;
     edm::EDGetTokenT<std::vector<pat::TriggerObjectStandAlone>> triggerObjects_;
+    edm::EDGetTokenT<edm::TriggerResults> triggerResults_;
     std::vector<std::string> hltCollectionNames_;
   };
 

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -232,7 +232,7 @@ namespace pat {
     bool addTriggerMatching_;
     edm::EDGetTokenT<std::vector<pat::TriggerObjectStandAlone>> triggerObjects_;
     edm::EDGetTokenT<edm::TriggerResults> triggerResults_;
-    std::vector<std::string> hltCollectionNames_;
+    std::vector<std::string> hltCollectionFilters_;
   };
 
 }

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -35,6 +35,9 @@
 #include "PhysicsTools/PatAlgos/interface/MuonMvaEstimator.h"
 #include "PhysicsTools/PatAlgos/interface/SoftMuonMvaEstimator.h"
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
+// #include "DataFormats/GeometryVector/interface/GlobalVector.h"
+// #include "DataFormats/GeometryVector/interface/LocalVector.h"
 
 namespace pat {
 
@@ -110,6 +113,12 @@ namespace pat {
 			 bool beamspotIsValid );
     double relMiniIsoPUCorrected( const pat::Muon& aMuon,
 				  double rho);
+    GlobalPoint* getMuonDirection(const reco::MuonChamberMatch& chamberMatch,
+				   const edm::ESHandle<GlobalTrackingGeometry>& geometry,
+				   const DetId& chamberId);
+    void fillL1TriggerInfo(pat::Muon& muon,
+			   edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
+			   const edm::ESHandle<GlobalTrackingGeometry>& geometry);
 
   private:
     /// input source

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -119,7 +119,9 @@ namespace pat {
     void fillL1TriggerInfo(pat::Muon& muon,
 			   edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
 			   const edm::ESHandle<GlobalTrackingGeometry>& geometry);
-
+    void fillHltTriggerInfo(pat::Muon& muon,
+			    edm::Handle<std::vector<pat::TriggerObjectStandAlone> >& triggerObjects,
+			    const std::vector<std::string>& collection_names);
   private:
     /// input source
     edm::EDGetTokenT<edm::View<reco::Muon> > muonToken_;
@@ -229,6 +231,7 @@ namespace pat {
 
     /// Trigger
     edm::EDGetTokenT<std::vector<pat::TriggerObjectStandAlone>> triggerObjects_;
+    std::vector<std::string> hltCollectionNames_;
   };
 
 }

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -125,7 +125,7 @@ patMuons = cms.EDProducer("PATMuonProducer",
     addTriggerMatching = cms.bool(True),                      
     triggerObjects = cms.InputTag("slimmedPatTrigger"),
     triggerResults = cms.InputTag("TriggerResults","","HLT"),
-    hltCollectionNames = cms.vstring('hltIterL3MuonCandidates::HLT','hltIterL3FromL2MuonCandidates::HLT','hltGlbTrkMuonCands::HLT','hltTrk50Filter::HLT')
+    hltCollectionFilters = cms.vstring('hltIterL3MuonCandidates::HLT','hltIterL3FromL2MuonCandidates::HLT','hltGlbTrkMuonCands::HLT','hltTrk50Filter::HLT')
 )
 
 

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -123,6 +123,8 @@ patMuons = cms.EDProducer("PATMuonProducer",
 
     # Trigger Info 
     addTriggerMatching = cms.bool(True),                      
+    triggerObjects = cms.InputTag("slimmedPatTrigger"),
+    triggerResults = cms.InputTag("TriggerResults","","HLT"),
     hltCollectionNames = cms.vstring('hltIterL3MuonCandidates::HLT','hltIterL3FromL2MuonCandidates::HLT','hltGlbTrkMuonCands::HLT','hltTrk50Filter::HLT')
 )
 

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -121,9 +121,10 @@ patMuons = cms.EDProducer("PATMuonProducer",
     # MC Info
     muonSimInfo = cms.InputTag("muonSimClassifier"),                 
 
+    # Trigger Info 
+    addTriggerMatching = cms.bool(True),                      
     hltCollectionNames = cms.vstring('hltIterL3MuonCandidates::HLT','hltIterL3FromL2MuonCandidates::HLT','hltGlbTrkMuonCands::HLT','hltTrk50Filter::HLT')
 )
-
 
 
 

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -119,8 +119,9 @@ patMuons = cms.EDProducer("PATMuonProducer",
     softMvaTrainingFile = cms.string("RecoMuon/MuonIdentification/data/TMVA-muonid-bmm4-B-25.weights.xml"),
 
     # MC Info
-    muonSimInfo = cms.InputTag("muonSimClassifier")                 
-                          
+    muonSimInfo = cms.InputTag("muonSimClassifier"),                 
+
+    hltCollectionNames = cms.vstring('hltIterL3MuonCandidates::HLT','hltIterL3FromL2MuonCandidates::HLT','hltGlbTrkMuonCands::HLT','hltTrk50Filter::HLT')
 )
 
 

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -125,7 +125,7 @@ patMuons = cms.EDProducer("PATMuonProducer",
     addTriggerMatching = cms.bool(True),                      
     triggerObjects = cms.InputTag("slimmedPatTrigger"),
     triggerResults = cms.InputTag("TriggerResults","","HLT"),
-    hltCollectionFilters = cms.vstring('hltIterL3MuonCandidates::HLT','hltIterL3FromL2MuonCandidates::HLT','hltGlbTrkMuonCands::HLT','hltTrk50Filter::HLT')
+    hltCollectionFilters = cms.vstring('*')
 )
 
 

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -529,6 +529,6 @@ def miniAOD_customizeAllMCFastSim(process):
     process = miniAOD_customizeMETFiltersFastSim(process)
     from PhysicsTools.PatAlgos.slimming.isolatedTracks_cfi import miniAOD_customizeIsolatedTracksFastSim
     process = miniAOD_customizeIsolatedTracksFastSim(process)
-    process.patMuons.addTriggerMatching = cms.bool(False)
+    process.patMuons.addTriggerMatching = False
 
     return process

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -451,6 +451,7 @@ def miniAOD_customizeCommon(process):
     phase2_hgcal.toModify(task, func=lambda t: t.add(process.slimmedEgammaFromMultiClTask))
 
 
+
 def miniAOD_customizeMC(process):
     task = getPatAlgosToolsTask(process)
     #GenJetFlavourInfos
@@ -528,4 +529,6 @@ def miniAOD_customizeAllMCFastSim(process):
     process = miniAOD_customizeMETFiltersFastSim(process)
     from PhysicsTools.PatAlgos.slimming.isolatedTracks_cfi import miniAOD_customizeIsolatedTracksFastSim
     process = miniAOD_customizeIsolatedTracksFastSim(process)
+    process.patMuons.addTriggerMatching = cms.bool(False)
+
     return process

--- a/PhysicsTools/PatAlgos/test/IntegrationTest_cfg.py
+++ b/PhysicsTools/PatAlgos/test/IntegrationTest_cfg.py
@@ -12,6 +12,7 @@ process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 patAlgosToolsTask.add(process.patCandidatesTask)
 # Temporary customize to the unit tests that fail due to old input samples
 process.patTaus.skipMissingTauID = True
+process.patMuons.addTriggerMatching = False
 
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)


### PR DESCRIPTION
This PR implements a proper matching of offline reco muons to L1 and HLT muon objects for trigger studies. L1 matching requires propagation to MB2/ME2, which is avoided by using the muon matching information. HLT matching is complicated by lack of a single muon hlt object producer and name changes of the primary producers during Run2. Fortunately in practice we almost always had just one primary muon producer used in all the main triggers, so the matching is solid and covers majority of use cases (it is not meant to replace results of advanced archaeology that one may want to do in a case of some special triggers). 