### PR TITLE
[muon] updated mva weights and tuned the default values

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -106,7 +106,7 @@ patMuons = cms.EDProducer("PATMuonProducer",
     # Depends on MiniIsolation, so only works in miniaod
     # Don't forget to set flags properly in miniAOD_tools.py                      
     computeMuonMVA = cms.bool(False),
-    mvaTrainingFile = cms.string("RecoMuon/MuonIdentification/data/mu_BDTG.weights.xml"),
+    mvaTrainingFile = cms.string("RecoMuon/MuonIdentification/data/mu_BDTG_Run2017.weights.xml"),
     recomputeBasicSelectors = cms.bool(True),
     mvaUseJec = cms.bool(True),
     mvaDrMax = cms.double(0.4),

--- a/PhysicsTools/PatAlgos/src/MuonMvaEstimator.cc
+++ b/PhysicsTools/PatAlgos/src/MuonMvaEstimator.cc
@@ -101,10 +101,19 @@ float MuonMvaEstimator::computeMva(const pat::Muon& muon,
   double jecL1L2L3Res = 1.;
   double jecL1 = 1.;
 
-  var[kJetPtRatio] = -99;
-  var[kJetPtRel]   = -99;
+  // Compute corrected isolation variables
+  double chIso  = muon.pfIsolationR04().sumChargedHadronPt;
+  double nIso   = muon.pfIsolationR04().sumNeutralHadronEt;
+  double phoIso = muon.pfIsolationR04().sumPhotonEt;
+  double puIso  = muon.pfIsolationR04().sumPUPt;
+  double dbCorrectedIsolation = chIso + std::max( nIso + phoIso - .5*puIso, 0. ) ;
+  double dbCorrectedRelIso = dbCorrectedIsolation/muon.pt();
+
+  var[kJetPtRatio] = 1./(1+dbCorrectedRelIso);
+  var[kJetPtRel]   = 0;
   var[kJetBTagCSV] = -999;
   var[kJetNDauCharged] = -1;
+
 
   for (const auto& tagI: bTags){
     // for each muon with the lepton 

--- a/PhysicsTools/PatAlgos/src/MuonMvaEstimator.cc
+++ b/PhysicsTools/PatAlgos/src/MuonMvaEstimator.cc
@@ -29,8 +29,8 @@ MuonMvaEstimator::MuonMvaEstimator(const std::string& weightsfile, float dRmax):
   tmvaReader.AddVariable("LepGood_miniRelIsoCharged",     &miniRelIsoCharged_);
   tmvaReader.AddVariable("LepGood_miniRelIsoNeutral",     &miniRelIsoNeutral_);
   tmvaReader.AddVariable("LepGood_jetPtRelv2",            &jetPtRel_         );
-  tmvaReader.AddVariable("min(LepGood_jetPtRatiov2,1.5)", &jetPtRatio_       );
   tmvaReader.AddVariable("max(LepGood_jetBTagCSV,0)",     &jetBTagCSV_       );
+  tmvaReader.AddVariable("(LepGood_jetBTagCSV>-5)*min(LepGood_jetPtRatiov2,1.5)+(LepGood_jetBTagCSV<-5)/(1+LepGood_relIso04)", &jetPtRatio_       );
   tmvaReader.AddVariable("LepGood_sip3d",                 &sip_              );
   tmvaReader.AddVariable("log(abs(LepGood_dxy))",         &log_abs_dxyBS_    );
   tmvaReader.AddVariable("log(abs(LepGood_dz))",          &log_abs_dzPV_     );


### PR DESCRIPTION
Updated MVA weights and tuned the default values in accordance with the recent practice in SUSY and HIG PAGs. It fits current reco better than the old MVA training. In future we may need to introduce an era dependent code.