### PR TITLE
Update HCAL aging parameters and thresholds

### DIFF
--- a/CalibCalorimetry/HcalPlugins/python/HBHEDarkening_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/HBHEDarkening_cff.py
@@ -32,9 +32,9 @@ _years_HLLHC_ultimate = cms.VPSet(
 HEDarkeningEP = cms.ESSource("HBHEDarkeningEP",
     appendToDataLabel = cms.string("HE"),
     ieta_shift = cms.int32(16),
-    # parameters taken from https://indico.cern.ch/event/641946/contributions/2604357/attachments/1466160/2266650/PlanB_TDR.pdf, slide 4 (brown line)
-    drdA = cms.double(5.0),
-    drdB = cms.double(0.675),
+    # parameters taken from https://indico.cern.ch/event/721565/contributions/2966213/attachments/1632432/2603148/2018.04.12_Updated_DvsR_fits_and_predictions.pdf, slide 3
+    drdA = cms.double(2.7383),
+    drdB = cms.double(0.37471),
     dosemaps = cms.VPSet(
         cms.PSet(energy = cms.int32(8), file = cms.FileInPath("CalibCalorimetry/HcalPlugins/data/dosemapHE_4TeV.txt")),
         cms.PSet(energy = cms.int32(14), file = cms.FileInPath("CalibCalorimetry/HcalPlugins/data/dosemapHE_7TeV.txt")),

--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -115,8 +115,9 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
             depVsTemp = cms.double(0.0631),
             intlumiToNeutrons = cms.double(3.67e8),
             # slopes taken from https://twiki.cern.ch/twiki/pub/CMSPublic/HcalDPGResultsCMSDPS2017042/dark_current_vs_lumi.png
+            # crosstalk divided out
             # heUpgrade intlumiToNeutrons factor (below) used to convert from /fb-1 to /neutrons 
-            depVsNeutrons = cms.vdouble(6.678e-10,9.966e-10),
+            depVsNeutrons = cms.vdouble(5.543e-10,8.012e-10),
         ),
     ),
     heUpgrade = cms.PSet(
@@ -140,8 +141,9 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
             depVsTemp = cms.double(0.0631),
             intlumiToNeutrons = cms.double(2.92e7),
             # slopes taken from https://twiki.cern.ch/twiki/pub/CMSPublic/HcalDPGResultsCMSDPS2017042/dark_current_vs_lumi.png
+            # crosstalk divided out
             # above factor used to convert from /fb-1 to /neutrons 
-            depVsNeutrons = cms.vdouble(6.678e-10,9.966e-10),
+            depVsNeutrons = cms.vdouble(5.543e-10,8.012e-10),
         ),
     ),
     hfUpgrade = cms.PSet(

--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -114,7 +114,9 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
             intlumiOffset = cms.double(150),
             depVsTemp = cms.double(0.0631),
             intlumiToNeutrons = cms.double(3.67e8),
-            depVsNeutrons = cms.vdouble(5.69e-11,7.90e-11),
+            # slopes taken from https://twiki.cern.ch/twiki/pub/CMSPublic/HcalDPGResultsCMSDPS2017042/dark_current_vs_lumi.png
+            # heUpgrade intlumiToNeutrons factor (below) used to convert from /fb-1 to /neutrons 
+            depVsNeutrons = cms.vdouble(6.678e-10,9.966e-10),
         ),
     ),
     heUpgrade = cms.PSet(
@@ -137,7 +139,9 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
             intlumiOffset = cms.double(75),
             depVsTemp = cms.double(0.0631),
             intlumiToNeutrons = cms.double(2.92e7),
-            depVsNeutrons = cms.vdouble(5.69e-11,7.90e-11),
+            # slopes taken from https://twiki.cern.ch/twiki/pub/CMSPublic/HcalDPGResultsCMSDPS2017042/dark_current_vs_lumi.png
+            # above factor used to convert from /fb-1 to /neutrons 
+            depVsNeutrons = cms.vdouble(6.678e-10,9.966e-10),
         ),
     ),
     hfUpgrade = cms.PSet(

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -18,25 +18,25 @@ from HLTrigger.Configuration.common import *
 #     return process
 
 
-from RecoParticleFlow.PFClusterProducer.particleFlowClusterHBHE_cfi import recHitEnergyNorms2018,seedFinderThresholdsByDetector2018,initialClusteringStepThresholdsByDetector2018,logWeightDenominatorByDetector2018
-from RecoParticleFlow.PFClusterProducer.particleFlowClusterHCAL_cfi import logWeightDenominatorByDetector2018 as logWeightDenominatorByDetector2018_HCAL
-from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHBHE_cfi import cuts2018
+from RecoParticleFlow.PFClusterProducer.particleFlowClusterHBHE_cfi import _seedingThresholdsHEphase1, _thresholdsHEphase1
+from RecoParticleFlow.PFClusterProducer.particleFlowClusterHCAL_cfi import _thresholdsHEphase1 as _thresholdsHEphase1HCAL
+from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHBHE_cfi import _thresholdsHEphase1 as _thresholdsHEphase1Rec
 
 def customiseForUncollapsed(process):
     for producer in producers_by_type(process, "PFClusterProducer"):
         if producer.seedFinder.thresholdsByDetector[1].detector.value() == 'HCAL_ENDCAP':
-            producer.pfClusterBuilder.recHitEnergyNorms                  = recHitEnergyNorms2018
-            producer.seedFinder.thresholdsByDetector                     = seedFinderThresholdsByDetector2018
-            producer.initialClusteringStep.thresholdsByDetector          = initialClusteringStepThresholdsByDetector2018
-            producer.pfClusterBuilder.positionCalc.logWeightDenominatorByDetector         = logWeightDenominatorByDetector2018
-            producer.pfClusterBuilder.allCellsPositionCalc.logWeightDenominatorByDetector = logWeightDenominatorByDetector2018
+            producer.seedFinder.thresholdsByDetector[1].seedingThreshold              = _seedingThresholdsHEphase1
+            producer.initialClusteringStep.thresholdsByDetector[1].gatheringThreshold = _thresholdsHEphase1
+            producer.pfClusterBuilder.recHitEnergyNorms[1].recHitEnergyNorm           = _thresholdsHEphase1
+            producer.pfClusterBuilder.positionCalc.logWeightDenominatorByDetector[1].logWeightDenominator = _thresholdsHEphase1
+            producer.pfClusterBuilder.allCellsPositionCalc.logWeightDenominatorByDetector[1].logWeightDenominator = _thresholdsHEphase1
 
     for producer in producers_by_type(process, "PFMultiDepthClusterProducer"):
-        producer.pfClusterBuilder.allCellsPositionCalc.logWeightDenominatorByDetector = logWeightDenominatorByDetector2018_HCAL
+        producer.pfClusterBuilder.allCellsPositionCalc.logWeightDenominatorByDetector[1].logWeightDenominator = _thresholdsHEphase1HCAL
     
     for producer in producers_by_type(process, "PFRecHitProducer"):
         if producer.producers[0].name.value() == 'PFHBHERecHitCreator':
-            producer.producers[0].qualityTests[0].cuts = cuts2018
+            producer.producers[0].qualityTests[0].cuts[1].threshold = _thresholdsHEphase1Rec
     
     for producer in producers_by_type(process, "CaloTowersCreator"):
         producer.HcalPhase     = cms.int32(1)

--- a/RecoJets/Configuration/python/RecoCaloTowersGR_cff.py
+++ b/RecoJets/Configuration/python/RecoCaloTowersGR_cff.py
@@ -9,6 +9,8 @@ from RecoJets.JetProducers.CaloTowerSchemeBWithHO_cfi import *
 
 from RecoJets.JetProducers.CaloTowerSchemeB_cfi import *
 towerMaker.HBThreshold = cms.double(0.6)
+towerMaker.HBThreshold1 = cms.double(0.6)
+towerMaker.HBThreshold2 = cms.double(0.6)
 
 recoCaloTowersGR = cms.Sequence(towerMaker+towerMakerWithHO)
 

--- a/RecoLocalCalo/CaloTowersCreator/interface/CaloTowersCreationAlgo.h
+++ b/RecoLocalCalo/CaloTowersCreator/interface/CaloTowersCreationAlgo.h
@@ -59,7 +59,7 @@ public:
     bool useSymEBTreshold, bool useSymEETreshold,				    
 
     double HcalThreshold,
-    double HBthreshold, 
+    double HBthreshold, double HBthreshold1,
     double HESthreshold, double HESthreshold1,
     double HEDthreshold, double HEDthreshold1, 
     double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
@@ -84,7 +84,7 @@ public:
     bool useSymEBTreshold, bool useSymEETreshold,
 
     double HcalThreshold,
-    double HBthreshold, 
+    double HBthreshold, double HBthreshold1,
     double HESthreshold, double HESthreshold1,
     double HEDthreshold, double HEDthreshold1,
     double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
@@ -254,7 +254,7 @@ private:
   
   double  theHcalThreshold;
 
-  double theHBthreshold;
+  double theHBthreshold, theHBthreshold1;
   double theHESthreshold, theHESthreshold1; 
   double theHEDthreshold, theHEDthreshold1; 
   double theHOthreshold0, theHOthresholdPlus1, theHOthresholdMinus1;

--- a/RecoLocalCalo/CaloTowersCreator/interface/CaloTowersCreationAlgo.h
+++ b/RecoLocalCalo/CaloTowersCreator/interface/CaloTowersCreationAlgo.h
@@ -59,7 +59,7 @@ public:
     bool useSymEBTreshold, bool useSymEETreshold,				    
 
     double HcalThreshold,
-    double HBthreshold, double HBthreshold1,
+    double HBthreshold, double HBthreshold1, double HBthreshold2,
     double HESthreshold, double HESthreshold1,
     double HEDthreshold, double HEDthreshold1, 
     double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
@@ -84,7 +84,7 @@ public:
     bool useSymEBTreshold, bool useSymEETreshold,
 
     double HcalThreshold,
-    double HBthreshold, double HBthreshold1,
+    double HBthreshold, double HBthreshold1, double HBthreshold2,
     double HESthreshold, double HESthreshold1,
     double HEDthreshold, double HEDthreshold1,
     double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
@@ -254,7 +254,7 @@ private:
   
   double  theHcalThreshold;
 
-  double theHBthreshold, theHBthreshold1;
+  double theHBthreshold, theHBthreshold1, theHBthreshold2;
   double theHESthreshold, theHESthreshold1; 
   double theHEDthreshold, theHEDthreshold1; 
   double theHOthreshold0, theHOthresholdPlus1, theHOthresholdMinus1;

--- a/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
+++ b/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
@@ -20,7 +20,8 @@ calotowermaker = cms.EDProducer("CaloTowersCreator",
     HBGrid = cms.vdouble(-1.0, 1.0, 10.0, 100.0, 1000.0),
     # Energy threshold for HB cell inclusion [GeV]
     HBThreshold1 = cms.double(0.7), # depth 1
-    HBThreshold = cms.double(0.7), # depths 2-4
+    HBThreshold2 = cms.double(0.7), # depth 2
+    HBThreshold = cms.double(0.7), # depths 3-4
     EEWeights = cms.vdouble(1.0, 1.0, 1.0, 1.0, 1.0),
     # Energy threshold for long-fiber HF readout inclusion [GeV]
     HF1Threshold = cms.double(0.5),
@@ -168,5 +169,6 @@ run2_HECollapse_2018.toModify(calotowermaker,
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 run3_HB.toModify(calotowermaker,
     HBThreshold1 = cms.double(0.1),
+    HBThreshold2 = cms.double(0.2),
     HBThreshold = cms.double(0.3),
 )

--- a/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
+++ b/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
@@ -19,7 +19,8 @@ calotowermaker = cms.EDProducer("CaloTowersCreator",
     HOThresholdMinus2 = cms.double(3.5),
     HBGrid = cms.vdouble(-1.0, 1.0, 10.0, 100.0, 1000.0),
     # Energy threshold for HB cell inclusion [GeV]
-    HBThreshold = cms.double(0.7),
+    HBThreshold1 = cms.double(0.7), # depth 1
+    HBThreshold = cms.double(0.7), # depths 2-4
     EEWeights = cms.vdouble(1.0, 1.0, 1.0, 1.0, 1.0),
     # Energy threshold for long-fiber HF readout inclusion [GeV]
     HF1Threshold = cms.double(0.5),
@@ -162,4 +163,10 @@ run2_HECollapse_2018.toModify(calotowermaker,
     HESThreshold  = cms.double(0.8),
     HEDThreshold1 = cms.double(0.8),
     HEDThreshold  = cms.double(0.8)
+)
+
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toModify(calotowermaker,
+    HBThreshold1 = cms.double(0.1),
+    HBThreshold = cms.double(0.3),
 )

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -23,6 +23,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo()
 
    theHcalThreshold(-1000.),
    theHBthreshold(-1000.),
+   theHBthreshold1(-1000.),
    theHESthreshold(-1000.),
    theHESthreshold1(-1000.),
    theHEDthreshold(-1000.),
@@ -98,7 +99,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
 					       bool useSymEETreshold,				    
 
 					       double HcalThreshold,
-					       double HBthreshold, 
+					       double HBthreshold, double HBthreshold1,
                                                double HESthreshold, double HESthreshold1, 
                                                double HEDthreshold, double HEDthreshold1,
 					       double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
@@ -127,6 +128,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
 
     theHcalThreshold(HcalThreshold),
     theHBthreshold(HBthreshold),
+    theHBthreshold1(HBthreshold1),
     theHESthreshold(HESthreshold),
     theHESthreshold1(HESthreshold1),
     theHEDthreshold(HEDthreshold),
@@ -201,7 +203,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
        bool useSymEETreshold,
 
        double HcalThreshold,
-       double HBthreshold, 
+       double HBthreshold, double HBthreshold1,
        double HESthreshold, double HESthreshold1, 
        double HEDthreshold, double HEDthreshold1,
        double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
@@ -238,6 +240,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
 
     theHcalThreshold(HcalThreshold),
     theHBthreshold(HBthreshold),
+    theHBthreshold1(HBthreshold1),
     theHESthreshold(HESthreshold),
     theHESthreshold1(HESthreshold1),
     theHEDthreshold(HEDthreshold),
@@ -1231,7 +1234,7 @@ void CaloTowersCreationAlgo::getThresholdAndWeight(const DetId & detId, double &
     int depth =  hcalDetId.depth();   
 
     if(subdet == HcalBarrel) {
-      threshold = theHBthreshold;
+      threshold = (depth == 1) ? theHBthreshold1 : theHBthreshold;
       weight = theHBweight;
       if (weight <= 0.) {
         ROOT::Math::Interpolator my(theHBGrid,theHBWeights,ROOT::Math::Interpolation::kAKIMA);

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -24,6 +24,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo()
    theHcalThreshold(-1000.),
    theHBthreshold(-1000.),
    theHBthreshold1(-1000.),
+   theHBthreshold2(-1000.),
    theHESthreshold(-1000.),
    theHESthreshold1(-1000.),
    theHEDthreshold(-1000.),
@@ -99,7 +100,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
 					       bool useSymEETreshold,				    
 
 					       double HcalThreshold,
-					       double HBthreshold, double HBthreshold1,
+					       double HBthreshold, double HBthreshold1, double HBthreshold2,
                                                double HESthreshold, double HESthreshold1, 
                                                double HEDthreshold, double HEDthreshold1,
 					       double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
@@ -129,6 +130,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
     theHcalThreshold(HcalThreshold),
     theHBthreshold(HBthreshold),
     theHBthreshold1(HBthreshold1),
+    theHBthreshold2(HBthreshold2),
     theHESthreshold(HESthreshold),
     theHESthreshold1(HESthreshold1),
     theHEDthreshold(HEDthreshold),
@@ -203,7 +205,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
        bool useSymEETreshold,
 
        double HcalThreshold,
-       double HBthreshold, double HBthreshold1,
+       double HBthreshold, double HBthreshold1, double HBthreshold2,
        double HESthreshold, double HESthreshold1, 
        double HEDthreshold, double HEDthreshold1,
        double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
@@ -241,6 +243,7 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthre
     theHcalThreshold(HcalThreshold),
     theHBthreshold(HBthreshold),
     theHBthreshold1(HBthreshold1),
+    theHBthreshold2(HBthreshold2),
     theHESthreshold(HESthreshold),
     theHESthreshold1(HESthreshold1),
     theHEDthreshold(HEDthreshold),
@@ -1234,7 +1237,7 @@ void CaloTowersCreationAlgo::getThresholdAndWeight(const DetId & detId, double &
     int depth =  hcalDetId.depth();   
 
     if(subdet == HcalBarrel) {
-      threshold = (depth == 1) ? theHBthreshold1 : theHBthreshold;
+      threshold = (depth == 1) ? theHBthreshold1 : (depth == 2) ? theHBthreshold2 : theHBthreshold;
       weight = theHBweight;
       if (weight <= 0.) {
         ROOT::Math::Interpolator my(theHBGrid,theHBWeights,ROOT::Math::Interpolation::kAKIMA);

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
@@ -122,7 +122,7 @@ CaloTowersCreator::CaloTowersCreator(const edm::ParameterSet& conf) :
    theEcalSeveritiesToBeUsedInBadTowers_ =  
      StringToEnumValue<EcalSeverityLevel::SeverityLevel>(conf.getParameter<std::vector<std::string> >("EcalSeveritiesToBeUsedInBadTowers") );
 
-  if (eScales_.instanceLabel=="") produces<CaloTowerCollection>();
+  if (eScales_.instanceLabel.empty()) produces<CaloTowerCollection>();
   else produces<CaloTowerCollection>(eScales_.instanceLabel);
 
   /*
@@ -291,7 +291,7 @@ void CaloTowersCreator::produce(edm::Event& e, const edm::EventSetup& c) {
   */
 
   // Step D: Put into the event
-  if (eScales_.instanceLabel=="") e.put(std::move(prod));
+  if (eScales_.instanceLabel.empty()) e.put(std::move(prod));
   else e.put(std::move(prod),eScales_.instanceLabel);
 
 

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
@@ -22,6 +22,7 @@ CaloTowersCreator::CaloTowersCreator(const edm::ParameterSet& conf) :
 	conf.getParameter<double>("HcalThreshold"),
 	conf.getParameter<double>("HBThreshold"),
 	conf.getParameter<double>("HBThreshold1"),
+	conf.getParameter<double>("HBThreshold2"),
 	conf.getParameter<double>("HESThreshold"),
 	conf.getParameter<double>("HESThreshold1"),
 	conf.getParameter<double>("HEDThreshold"),
@@ -309,6 +310,7 @@ void CaloTowersCreator::fillDescriptions(edm::ConfigurationDescriptions& descrip
 	desc.add<double>("HOThresholdMinus2", 3.5);
 	desc.add<double>("HBThreshold", 0.7);
 	desc.add<double>("HBThreshold1", 0.7);
+	desc.add<double>("HBThreshold2", 0.7);
 	desc.add<double>("HF1Threshold", 0.5);
 	desc.add<double>("HEDWeight", 1.0);
 	desc.add<double>("EEWeight", 1.0);

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
@@ -21,6 +21,7 @@ CaloTowersCreator::CaloTowersCreator(const edm::ParameterSet& conf) :
 
 	conf.getParameter<double>("HcalThreshold"),
 	conf.getParameter<double>("HBThreshold"),
+	conf.getParameter<double>("HBThreshold1"),
 	conf.getParameter<double>("HESThreshold"),
 	conf.getParameter<double>("HESThreshold1"),
 	conf.getParameter<double>("HEDThreshold"),
@@ -307,6 +308,7 @@ void CaloTowersCreator::fillDescriptions(edm::ConfigurationDescriptions& descrip
 	desc.add<double>("HOThresholdPlus2", 3.5);
 	desc.add<double>("HOThresholdMinus2", 3.5);
 	desc.add<double>("HBThreshold", 0.7);
+	desc.add<double>("HBThreshold1", 0.7);
 	desc.add<double>("HF1Threshold", 0.5);
 	desc.add<double>("HEDWeight", 1.0);
 	desc.add<double>("EEWeight", 1.0);

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.cc
@@ -4,7 +4,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 CaloTowersReCreator::CaloTowersReCreator(const edm::ParameterSet& conf) : 
-  algo_(0.,0., false, false, false, false, 0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,// thresholds cannot be reapplied
+  algo_(0.,0., false, false, false, false, 0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,// thresholds cannot be reapplied
         conf.getParameter<std::vector<double> >("EBGrid"),
         conf.getParameter<std::vector<double> >("EBWeights"),
         conf.getParameter<std::vector<double> >("EEGrid"),

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.cc
@@ -4,7 +4,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 CaloTowersReCreator::CaloTowersReCreator(const edm::ParameterSet& conf) : 
-  algo_(0.,0., false, false, false, false, 0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,// thresholds cannot be reapplied
+  algo_(0.,0., false, false, false, false, 0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,// thresholds cannot be reapplied
         conf.getParameter<std::vector<double> >("EBGrid"),
         conf.getParameter<std::vector<double> >("EBWeights"),
         conf.getParameter<std::vector<double> >("EEGrid"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -5,6 +5,11 @@ _thresholdsHB = cms.vdouble(0.8, 0.8, 0.8, 0.8)
 _thresholdsHE = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
 _thresholdsHBphase1 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
 _thresholdsHEphase1 = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2)
+_seedingThresholdsHB = cms.vdouble(1.0, 1.0, 1.0, 1.0)
+_seedingThresholdsHE = cms.vdouble(1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1)
+_seedingThresholdsHBphase1 = cms.vdouble(0.125, 0.25, 0.25, 0.25)
+_seedingThresholdsHEphase1 = cms.vdouble(0.1375, 0.275, 0.275, 0.275, 0.275, 0.275, 0.275)
+
 
 #### PF CLUSTER HCAL ####
 particleFlowClusterHBHE = cms.EDProducer(
@@ -16,12 +21,12 @@ particleFlowClusterHBHE = cms.EDProducer(
         thresholdsByDetector = cms.VPSet(
               cms.PSet( detector = cms.string("HCAL_BARREL1"),
                         depths = cms.vint32(1, 2, 3, 4),
-                        seedingThreshold = cms.vdouble(1.0, 1.0, 1.0, 1.0),
+                        seedingThreshold = _seedingThresholdsHB,
                         seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
                         ),
               cms.PSet( detector = cms.string("HCAL_ENDCAP"),
                         depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-                        seedingThreshold = cms.vdouble(1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1),
+                        seedingThreshold = _seedingThresholdsHE,
                         seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
                         )
               ),
@@ -52,7 +57,6 @@ particleFlowClusterHBHE = cms.EDProducer(
                  algoName = cms.string("Basic2DGenericPFlowPositionCalc"),
                  minFractionInCalc = cms.double(1e-9),    
                  posCalcNCrystals = cms.int32(5),
-#                 logWeightDenominator = cms.double(0.8),#same as gathering threshold
                  logWeightDenominatorByDetector = cms.VPSet(
                        cms.PSet( detector = cms.string("HCAL_BARREL1"),
                                  depths = cms.vint32(1, 2, 3, 4),
@@ -69,7 +73,6 @@ particleFlowClusterHBHE = cms.EDProducer(
                  algoName = cms.string("Basic2DGenericPFlowPositionCalc"),
                  minFractionInCalc = cms.double(1e-9),    
                  posCalcNCrystals = cms.int32(-1),
-##                 logWeightDenominator = cms.double(0.8),#same as gathering threshold
                  logWeightDenominatorByDetector = cms.VPSet(
                        cms.PSet( detector = cms.string("HCAL_BARREL1"),
                                  depths = cms.vint32(1, 2, 3, 4),
@@ -113,221 +116,30 @@ particleFlowClusterHBHE = cms.EDProducer(
 
 #####
 
-seedFinderThresholdsByDetector2017 = particleFlowClusterHBHE.seedFinder.thresholdsByDetector
-
-seedFinderThresholdsByDetector2018 = cms.VPSet(
-    cms.PSet(
-        detector = cms.string("HCAL_BARREL1"),
-        depths = cms.vint32(1, 2, 3, 4),
-        seedingThreshold = cms.vdouble(1.0, 1.0, 1.0, 1.0),
-        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
-        ),
-    cms.PSet(
-        detector = cms.string("HCAL_ENDCAP"),
-        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        seedingThreshold = cms.vdouble(0.1375, 0.275, 0.275, 0.275, 0.275, 0.275, 0.275),
-        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-        )
-)
-
-seedFinderThresholdsByDetector2019 = cms.VPSet(
-    cms.PSet(
-        detector = cms.string("HCAL_BARREL1"),
-        depths = cms.vint32(1, 2, 3, 4),
-        seedingThreshold = cms.vdouble(0.125, 0.25, 0.25, 0.25),
-        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
-        ),
-    cms.PSet(
-        detector = cms.string("HCAL_ENDCAP"),
-        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        seedingThreshold = cms.vdouble(0.1375, 0.275, 0.275, 0.275, 0.275, 0.275, 0.275),
-        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-        )
-)
-
-seedFinderThresholdsByDetectorPhase2 = cms.VPSet(
-    cms.PSet(
-        detector = cms.string("HCAL_BARREL1"),
-        depths = cms.vint32(1, 2, 3, 4),
-        seedingThreshold = cms.vdouble(1.0, 1.0, 1.0, 1.0),
-        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
-        ),
-    cms.PSet(
-        detector = cms.string("HCAL_ENDCAP"),
-        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        seedingThreshold = cms.vdouble(1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1),
-        seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-        )
-    )
-
-#######################
-
-initialClusteringStepThresholdsByDetector2017 = particleFlowClusterHBHE.initialClusteringStep.thresholdsByDetector
-
-initialClusteringStepThresholdsByDetector2018 = cms.VPSet(
-    cms.PSet(
-        detector = cms.string("HCAL_BARREL1"),
-        depths = cms.vint32(1, 2, 3, 4),
-        gatheringThreshold = _thresholdsHB,
-        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
-        ),
-    cms.PSet(
-        detector = cms.string("HCAL_ENDCAP"),
-        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        gatheringThreshold = _thresholdsHEphase1,
-        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-        )
-)
-
-initialClusteringStepThresholdsByDetector2019 = cms.VPSet(
-    cms.PSet(
-        detector = cms.string("HCAL_BARREL1"),
-        depths = cms.vint32(1, 2, 3, 4),
-        gatheringThreshold = _thresholdsHBphase1,
-        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
-        ),
-    cms.PSet(
-        detector = cms.string("HCAL_ENDCAP"),
-        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        gatheringThreshold = _thresholdsHEphase1,
-        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-        )
-)
-
-initialClusteringStepThresholdsByDetectorPhase2 = cms.VPSet(
-    cms.PSet(
-        detector = cms.string("HCAL_BARREL1"),
-        depths = cms.vint32(1, 2, 3, 4),
-        gatheringThreshold = _thresholdsHB,
-        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
-        ),
-    cms.PSet(
-        detector = cms.string("HCAL_ENDCAP"),
-        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        gatheringThreshold = _thresholdsHE,
-        gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-        )
-    )
-
-#######################
-
-recHitEnergyNorms2017 = particleFlowClusterHBHE.pfClusterBuilder.recHitEnergyNorms
-
-recHitEnergyNorms2018 = cms.VPSet(
-    cms.PSet(
-        detector = cms.string("HCAL_BARREL1"),
-        depths = cms.vint32(1, 2, 3, 4),
-        recHitEnergyNorm = _thresholdsHB,
-        ),
-    cms.PSet(
-        detector = cms.string("HCAL_ENDCAP"),
-        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        recHitEnergyNorm = _thresholdsHEphase1,
-        )
-)
-
-recHitEnergyNorms2019 = cms.VPSet(
-    cms.PSet(
-        detector = cms.string("HCAL_BARREL1"),
-        depths = cms.vint32(1, 2, 3, 4),
-        recHitEnergyNorm = _thresholdsHBphase1,
-        ),
-    cms.PSet(
-        detector = cms.string("HCAL_ENDCAP"),
-        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        recHitEnergyNorm = _thresholdsHEphase1,
-        )
-    )
-
-recHitEnergyNormsPhase2 = cms.VPSet(
-    cms.PSet(
-        detector = cms.string("HCAL_BARREL1"),
-        depths = cms.vint32(1, 2, 3, 4),
-        recHitEnergyNorm = _thresholdsHB,
-        ),
-    cms.PSet(
-        detector = cms.string("HCAL_ENDCAP"),
-        depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        recHitEnergyNorm = _thresholdsHE,
-        )
-    )
-
-#######################
-
-logWeightDenominatorByDetector2017= particleFlowClusterHBHE.pfClusterBuilder.positionCalc.logWeightDenominatorByDetector
-
-logWeightDenominatorByDetector2018 = cms.VPSet(
-    cms.PSet( detector = cms.string("HCAL_BARREL1"),
-              depths = cms.vint32(1, 2, 3, 4),
-              logWeightDenominator = _thresholdsHB
-              ),
-    cms.PSet( detector = cms.string("HCAL_ENDCAP"),
-              depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-              logWeightDenominator = _thresholdsHEphase1,
-              )
-    )
-
-logWeightDenominatorByDetector2019 = cms.VPSet(
-    cms.PSet( detector = cms.string("HCAL_BARREL1"),
-              depths = cms.vint32(1, 2, 3, 4),
-              logWeightDenominator = _thresholdsHBphase1,
-              ),
-    cms.PSet( detector = cms.string("HCAL_ENDCAP"),
-              depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-              logWeightDenominator = _thresholdsHEphase1,
-              )
-    )
-
-logWeightDenominatorByDetectorPhase2 = cms.VPSet(
-    cms.PSet( detector = cms.string("HCAL_BARREL1"),
-              depths = cms.vint32(1, 2, 3, 4),
-              logWeightDenominator = _thresholdsHB,
-              ),
-    cms.PSet( detector = cms.string("HCAL_ENDCAP"),
-              depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-              logWeightDenominator = _thresholdsHE,
-              )
-    )
-
-#######################
+# offline phase2 restore what has been studied in the TDR
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 
 # offline 2018 -- uncollapsed
-from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
-run2_HCAL_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNorms2018)
-run2_HCAL_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2018)
-run2_HCAL_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2018)
-run2_HCAL_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder.positionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2018)
-run2_HCAL_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2018)
-
-
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
-run2_HE_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNorms2018)
-run2_HE_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2018)
-run2_HE_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2018)
-run2_HE_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder.positionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2018)
-run2_HE_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2018)
-
-# offline 2018 -- collapsed
-run2_HECollapse_2018 =  cms.Modifier()
-run2_HECollapse_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNorms2017)
-run2_HECollapse_2018.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2017)
-run2_HECollapse_2018.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2017)
-run2_HECollapse_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder.positionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2017)
-run2_HECollapse_2018.toModify(particleFlowClusterHBHE.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2017)
-
+from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
+(run2_HE_2018 & ~run2_HECollapse_2018 & ~phase2_hcal).toModify(particleFlowClusterHBHE,
+    seedFinder = dict(thresholdsByDetector = {1 : dict(seedingThreshold = _seedingThresholdsHEphase1) } ),
+    initialClusteringStep = dict(thresholdsByDetector = {1 : dict(gatheringThreshold = _thresholdsHEphase1) } ),
+    pfClusterBuilder = dict(
+        recHitEnergyNorms = {1 : dict(recHitEnergyNorm = _thresholdsHEphase1) },
+        positionCalc = dict(logWeightDenominatorByDetector = {1 : dict(logWeightDenominator = _thresholdsHEphase1) } ),
+        allCellsPositionCalc = dict(logWeightDenominatorByDetector = {1 : dict(logWeightDenominator = _thresholdsHEphase1) } ),
+    ),
+)
 
 # offline 2019
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
-run3_HB.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNorms2019)
-run3_HB.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetector2019)
-run3_HB.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetector2019)
-run3_HB.toModify(particleFlowClusterHBHE.pfClusterBuilder.positionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2019)
-run3_HB.toModify(particleFlowClusterHBHE.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2019)
-
-# offline phase2 restore what has been studied in the TDR
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toModify(particleFlowClusterHBHE.pfClusterBuilder, recHitEnergyNorms = recHitEnergyNormsPhase2)
-phase2_hcal.toModify(particleFlowClusterHBHE.seedFinder, thresholdsByDetector = seedFinderThresholdsByDetectorPhase2)
-phase2_hcal.toModify(particleFlowClusterHBHE.initialClusteringStep, thresholdsByDetector = initialClusteringStepThresholdsByDetectorPhase2)
-phase2_hcal.toModify(particleFlowClusterHBHE.pfClusterBuilder.positionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetectorPhase2)
-phase2_hcal.toModify(particleFlowClusterHBHE.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetectorPhase2)
+(run3_HB & ~phase2_hcal).toModify(particleFlowClusterHBHE,
+    seedFinder = dict(thresholdsByDetector = {0 : dict(seedingThreshold = _seedingThresholdsHBphase1) } ),
+    initialClusteringStep = dict(thresholdsByDetector = {0 : dict(gatheringThreshold = _thresholdsHBphase1) } ),
+    pfClusterBuilder = dict(
+        recHitEnergyNorms = {0 : dict(recHitEnergyNorm = _thresholdsHBphase1) },
+        positionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1) } ),
+        allCellsPositionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1) } ),
+    ),
+)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -7,7 +7,7 @@ _thresholdsHBphase1 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
 _thresholdsHEphase1 = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2)
 _seedingThresholdsHB = cms.vdouble(1.0, 1.0, 1.0, 1.0)
 _seedingThresholdsHE = cms.vdouble(1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1)
-_seedingThresholdsHBphase1 = cms.vdouble(0.125, 0.25, 0.25, 0.25)
+_seedingThresholdsHBphase1 = cms.vdouble(0.125, 0.25, 0.35, 0.35)
 _seedingThresholdsHEphase1 = cms.vdouble(0.1375, 0.275, 0.275, 0.275, 0.275, 0.275, 0.275)
 
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -116,13 +116,10 @@ particleFlowClusterHBHE = cms.EDProducer(
 
 #####
 
-# offline phase2 restore what has been studied in the TDR
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-
 # offline 2018 -- uncollapsed
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
 from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
-(run2_HE_2018 & ~run2_HECollapse_2018 & ~phase2_hcal).toModify(particleFlowClusterHBHE,
+(run2_HE_2018 & ~run2_HECollapse_2018).toModify(particleFlowClusterHBHE,
     seedFinder = dict(thresholdsByDetector = {1 : dict(seedingThreshold = _seedingThresholdsHEphase1) } ),
     initialClusteringStep = dict(thresholdsByDetector = {1 : dict(gatheringThreshold = _thresholdsHEphase1) } ),
     pfClusterBuilder = dict(
@@ -134,7 +131,7 @@ from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HEColla
 
 # offline 2019
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
-(run3_HB & ~phase2_hcal).toModify(particleFlowClusterHBHE,
+run3_HB.toModify(particleFlowClusterHBHE,
     seedFinder = dict(thresholdsByDetector = {0 : dict(seedingThreshold = _seedingThresholdsHBphase1) } ),
     initialClusteringStep = dict(thresholdsByDetector = {0 : dict(gatheringThreshold = _thresholdsHBphase1) } ),
     pfClusterBuilder = dict(

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -34,57 +34,22 @@ particleFlowClusterHCAL = cms.EDProducer('PFMultiDepthClusterProducer',
        energyCorrector = cms.PSet()
 )
 
-
-logWeightDenominatorByDetector2017= particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc.logWeightDenominatorByDetector
-
-logWeightDenominatorByDetector2018 = cms.VPSet(
-    cms.PSet( detector = cms.string("HCAL_BARREL1"),
-              depths = cms.vint32(1, 2, 3, 4),
-              logWeightDenominator = _thresholdsHB
-              ),
-    cms.PSet( detector = cms.string("HCAL_ENDCAP"),
-              depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-              logWeightDenominator = _thresholdsHEphase1,
-              )
-    )
-
-logWeightDenominatorByDetector2019 = cms.VPSet(
-    cms.PSet( detector = cms.string("HCAL_BARREL1"),
-              depths = cms.vint32(1, 2, 3, 4),
-              logWeightDenominator = _thresholdsHBphase1,
-              ),
-    cms.PSet( detector = cms.string("HCAL_ENDCAP"),
-              depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-              logWeightDenominator = _thresholdsHEphase1,
-              )
-    )
-
-logWeightDenominatorByDetectorPhase2 = cms.VPSet(
-    cms.PSet( detector = cms.string("HCAL_BARREL1"),
-              depths = cms.vint32(1, 2, 3, 4),
-              logWeightDenominator = _thresholdsHB,
-              ),
-    cms.PSet( detector = cms.string("HCAL_ENDCAP"),
-              depths = cms.vint32(1, 2, 3, 4, 5, 6, 7),
-              logWeightDenominator = _thresholdsHE,
-              )
-    )
+# offline phase2 restore what has been studied in the TDR
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 
 # offline 2018 -- uncollapsed
-from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
-run2_HCAL_2018.toModify(particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2018)
-
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
-run2_HE_2018.toModify(particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2018)
-
-# offline 2018 -- collapsed
-run2_HECollapse_2018 =  cms.Modifier()
-run2_HECollapse_2018.toModify(particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2017)
+from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
+(run2_HE_2018 & ~run2_HECollapse_2018 & ~phase2_hcal).toModify(particleFlowClusterHCAL,
+    pfClusterBuilder = dict(
+        allCellsPositionCalc = dict(logWeightDenominatorByDetector = {1 : dict(logWeightDenominator = _thresholdsHEphase1) } ),
+    ),
+)
 
 # offline 2019
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
-run3_HB.toModify(particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetector2019)
-
-# offline phase2 restore what has been studied in the TDR
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toModify(particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc, logWeightDenominatorByDetector= logWeightDenominatorByDetectorPhase2)
+(run3_HB & ~phase2_hcal).toModify(particleFlowClusterHCAL,
+    pfClusterBuilder = dict(
+        allCellsPositionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1) } ),
+    ),
+)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -34,13 +34,10 @@ particleFlowClusterHCAL = cms.EDProducer('PFMultiDepthClusterProducer',
        energyCorrector = cms.PSet()
 )
 
-# offline phase2 restore what has been studied in the TDR
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-
 # offline 2018 -- uncollapsed
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
 from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
-(run2_HE_2018 & ~run2_HECollapse_2018 & ~phase2_hcal).toModify(particleFlowClusterHCAL,
+(run2_HE_2018 & ~run2_HECollapse_2018).toModify(particleFlowClusterHCAL,
     pfClusterBuilder = dict(
         allCellsPositionCalc = dict(logWeightDenominatorByDetector = {1 : dict(logWeightDenominator = _thresholdsHEphase1) } ),
     ),
@@ -48,7 +45,7 @@ from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HEColla
 
 # offline 2019
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
-(run3_HB & ~phase2_hcal).toModify(particleFlowClusterHCAL,
+run3_HB.toModify(particleFlowClusterHCAL,
     pfClusterBuilder = dict(
         allCellsPositionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1) } ),
     ),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -44,18 +44,15 @@ particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
     )
 )
 
-# offline phase2 restore what has been studied in the TDR
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-
 # offline 2018 -- uncollapsed
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
 from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
-(run2_HE_2018 & ~run2_HECollapse_2018 & ~phase2_hcal).toModify(particleFlowRecHitHBHE,
+(run2_HE_2018 & ~run2_HECollapse_2018).toModify(particleFlowRecHitHBHE,
     producers = {0 : dict(qualityTests = {0 : dict(cuts = {1 : dict(threshold = _thresholdsHEphase1) } ) } ) },
 )
 
 # offline 2019
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
-(run3_HB & ~phase2_hcal).toModify(particleFlowRecHitHBHE,
+run3_HB.toModify(particleFlowRecHitHBHE,
     producers = {0 : dict(qualityTests = {0 : dict(cuts = {0 : dict(threshold = _thresholdsHBphase1) } ) } ) },
 )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -39,71 +39,23 @@ particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
                       cleaningThresholds = cms.vdouble(0.0),
                       flags              = cms.vstring('Standard')
                   )
-                  
-
              )
            ),
-           
     )
-
 )
-
-cuts2017 = particleFlowRecHitHBHE.producers[0].qualityTests[0].cuts
-
-cuts2018 = cms.VPSet(
-    cms.PSet(
-        depth=cms.vint32(1, 2, 3, 4),
-        threshold = _thresholdsHB,
-        detectorEnum = cms.int32(1)
-        ),
-    cms.PSet(
-        depth=cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        threshold = _thresholdsHEphase1,
-        detectorEnum = cms.int32(2)
-        )
-    )
-
-cuts2019 = cms.VPSet(
-    cms.PSet(
-        depth=cms.vint32(1, 2, 3, 4),
-        threshold = _thresholdsHBphase1,
-        detectorEnum = cms.int32(1)
-        ),
-    cms.PSet(
-        depth=cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        threshold = _thresholdsHEphase1,
-        detectorEnum = cms.int32(2)
-        )
-    )
-
-cutsPhase2 = cms.VPSet(
-    cms.PSet(
-        depth=cms.vint32(1, 2, 3, 4),
-        threshold = _thresholdsHB,
-        detectorEnum = cms.int32(1)
-        ),
-    cms.PSet(
-        depth=cms.vint32(1, 2, 3, 4, 5, 6, 7),
-        threshold = _thresholdsHE,
-        detectorEnum = cms.int32(2)
-        )
-    )
-
-# offline 2018 -- uncollapsed
-from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
-run2_HCAL_2018.toModify(particleFlowRecHitHBHE.producers[0].qualityTests[0], cuts = cuts2018)
-
-from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
-run2_HE_2018.toModify(particleFlowRecHitHBHE.producers[0].qualityTests[0], cuts = cuts2018)
-
-# offline 2018 -- collapsed
-run2_HECollapse_2018 =  cms.Modifier()
-run2_HECollapse_2018.toModify(particleFlowRecHitHBHE.producers[0].qualityTests[0], cuts = cuts2017)
-
-# offline 2019
-from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
-run3_HB.toModify(particleFlowRecHitHBHE.producers[0].qualityTests[0], cuts = cuts2019)
 
 # offline phase2 restore what has been studied in the TDR
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toModify(particleFlowRecHitHBHE.producers[0].qualityTests[0], cuts = cutsPhase2)
+
+# offline 2018 -- uncollapsed
+from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
+from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
+(run2_HE_2018 & ~run2_HECollapse_2018 & ~phase2_hcal).toModify(particleFlowRecHitHBHE,
+    producers = {0 : dict(qualityTests = {0 : dict(cuts = {1 : dict(threshold = _thresholdsHEphase1) } ) } ) },
+)
+
+# offline 2019
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+(run3_HB & ~phase2_hcal).toModify(particleFlowRecHitHBHE,
+    producers = {0 : dict(qualityTests = {0 : dict(cuts = {0 : dict(threshold = _thresholdsHBphase1) } ) } ) },
+)

--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -109,6 +109,7 @@ def ageSiPM(process,turnon,lumi):
             for ctmod in ctmodules:
                 if hasattr(process,ctmod):
                     getattr(process,ctmod).HBThreshold1 = hcal_thresholds[hcal_lumi]["rec"][0]
+                    getattr(process,ctmod).HBThreshold2 = hcal_thresholds[hcal_lumi]["rec"][1]
                     getattr(process,ctmod).HBThreshold = hcal_thresholds[hcal_lumi]["rec"][-1]
             break
 

--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -73,6 +73,40 @@ def ageSiPM(process,turnon,lumi):
 
     # todo: determine ZS threshold adjustments
 
+    # adjust PF thresholds for increased noise
+    hcal_lumis = [300, 1000, 3000, 4500, 1e10]
+    hcal_thresholds = {
+        300: {
+            "seed": [0.5, 0.625, 0.75, 0.75],
+            "rec": [0.4, 0.5, 0.6, 0.6],
+        },
+        1000: {
+            "seed": [1.0, 1.5, 1.5, 1.5],
+            "rec": [0.8, 1.2, 1.2, 1.2],
+        },
+        3000: {
+            "seed": [1.25, 2.5, 2.5, 2.5],
+            "rec": [1.0, 2.0, 2.0, 2.0],
+        },
+        4500: {
+            "seed": [1.5, 3.0, 3.0, 3.0],
+            "rec": [1.25, 2.5, 2.5, 2.5],
+        },
+    }
+    for ilumi, hcal_lumi in enumerate(hcal_lumis[:-1]):
+        if lumi >= hcal_lumi and lumi < hcal_lumis[ilumi+1]:
+            if hasattr(process,'particleFlowClusterHBHE'):
+                process.particleFlowClusterHBHE.seedFinder.thresholdsByDetector[0].seedingThreshold              = hcal_thresholds[hcal_lumi]["seed"]
+                process.particleFlowClusterHBHE.initialClusteringStep.thresholdsByDetector[0].gatheringThreshold = hcal_thresholds[hcal_lumi]["rec"]
+                process.particleFlowClusterHBHE.pfClusterBuilder.recHitEnergyNorms[0].recHitEnergyNorm           = hcal_thresholds[hcal_lumi]["rec"]
+                process.particleFlowClusterHBHE.pfClusterBuilder.positionCalc.logWeightDenominatorByDetector[0].logWeightDenominator = hcal_thresholds[hcal_lumi]["rec"]
+                process.particleFlowClusterHBHE.pfClusterBuilder.allCellsPositionCalc.logWeightDenominatorByDetector[0].logWeightDenominator = hcal_thresholds[hcal_lumi]["rec"]
+            if hasattr(process,'particleFlowClusterHCAL'):
+                process.particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc.logWeightDenominatorByDetector[0].logWeightDenominator = hcal_thresholds[hcal_lumi]["rec"]
+            if hasattr(process,'particleFlowRecHitHBHE'):
+                process.particleFlowRecHitHBHE.producers[0].qualityTests[0].cuts[0].threshold = hcal_thresholds[hcal_lumi]["rec"]
+            break
+
     return process
 
 def ageHcal(process,lumi,instLumi,scenarioHLLHC):

--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -93,6 +93,7 @@ def ageSiPM(process,turnon,lumi):
             "rec": [1.25, 2.5, 2.5, 2.5],
         },
     }
+    ctmodules = ['calotowermaker','caloTowerForTrk','caloTowerForTrkPreSplitting','towerMaker','towerMakerWithHO']
     for ilumi, hcal_lumi in enumerate(hcal_lumis[:-1]):
         if lumi >= hcal_lumi and lumi < hcal_lumis[ilumi+1]:
             if hasattr(process,'particleFlowClusterHBHE'):
@@ -105,6 +106,10 @@ def ageSiPM(process,turnon,lumi):
                 process.particleFlowClusterHCAL.pfClusterBuilder.allCellsPositionCalc.logWeightDenominatorByDetector[0].logWeightDenominator = hcal_thresholds[hcal_lumi]["rec"]
             if hasattr(process,'particleFlowRecHitHBHE'):
                 process.particleFlowRecHitHBHE.producers[0].qualityTests[0].cuts[0].threshold = hcal_thresholds[hcal_lumi]["rec"]
+            for ctmod in ctmodules:
+                if hasattr(process,ctmod):
+                    getattr(process,ctmod).HBThreshold1 = hcal_thresholds[hcal_lumi]["rec"][0]
+                    getattr(process,ctmod).HBThreshold = hcal_thresholds[hcal_lumi]["rec"][-1]
             break
 
     return process

--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -74,6 +74,7 @@ def ageSiPM(process,turnon,lumi):
     # todo: determine ZS threshold adjustments
 
     # adjust PF thresholds for increased noise
+    # based on: https://baylor.box.com/s/w32ja75krcbxcycyifexu28dwlgrj7wg
     hcal_lumis = [300, 1000, 3000, 4500, 1e10]
     hcal_thresholds = {
         300: {


### PR DESCRIPTION
1. Updated HCAL scintillator radiation damage parameters based on latest measurements and fits (https://indico.cern.ch/event/721565/contributions/2966213/attachments/1632432/2603148/2018.04.12_Updated_DvsR_fits_and_predictions.pdf)
2. Updated HCAL SiPM radiation damage parameters based on latest measurements and fits (https://twiki.cern.ch/twiki/pub/CMSPublic/HcalDPGResultsCMSDPS2017042/dark_current_vs_lumi.png)
3. Simplified HCAL PF threshold adjustments for different eras.
4. Use Run 3 PF thresholds for Phase 2 by default (account for increased depth segmentation in HB).
5. Add separate CaloTower thresholds for Run 3 HB depths 1,2 (similar to Phase 1 HE, updated a while back).
6. Update PF and CaloTower thresholds for different HCAL aging scenarios, now that SiPM noise can increase beyond the previous default threshold of ~0.8 GeV.

The new thresholds were proposed, tested, and validated by @hatakeyamak (thanks!): https://baylor.app.box.com/s/w32ja75krcbxcycyifexu28dwlgrj7wg

We observed that PF gammas get a lot of extra energy introduced by ECAL aging; this will be followed up with the appropriate people.