### PR TITLE
Changed BranchMap from std::map to SoATuple

### DIFF
--- a/IOPool/Input/src/RootDelayedReader.cc
+++ b/IOPool/Input/src/RootDelayedReader.cc
@@ -50,16 +50,15 @@ namespace edm {
     if (lastException_) {
       std::rethrow_exception(lastException_);
     }
-    iterator iter = branchIter(k);
-    if (!found(iter)) {
+    auto branchInfo = getBranchInfo(k);
+    if (not branchInfo) {
       if (nextReader_) {
         return nextReader_->getProduct(k, ep);
       } else {
         return std::unique_ptr<WrapperBase>();
       }
     }
-    roottree::BranchInfo const& branchInfo = getBranchInfo(iter);
-    TBranch* br = branchInfo.productBranch_;
+    TBranch* br = branchInfo->productBranch_;
     if (br == nullptr) {
       if (nextReader_) {
         return nextReader_->getProduct(k, ep);
@@ -72,14 +71,14 @@ namespace edm {
     //make code exception safe
     std::shared_ptr<void> refCoreStreamerGuard(nullptr,[](void*){    setRefCoreStreamer(false);
       ;});
-    TClass* cp = branchInfo.classCache_;
+    TClass* cp = branchInfo->classCache_;
     if(nullptr == cp) {
-      branchInfo.classCache_ = TClass::GetClass(branchInfo.branchDescription_.wrappedName().c_str());
-      cp = branchInfo.classCache_;
-      branchInfo.offsetToWrapperBase_ = cp->GetBaseClassOffset(wrapperBaseTClass_);
+      branchInfo->classCache_ = TClass::GetClass(branchInfo->branchDescription_.wrappedName().c_str());
+      cp = branchInfo->classCache_;
+      branchInfo->offsetToWrapperBase_ = cp->GetBaseClassOffset(wrapperBaseTClass_);
     }
     void* p = cp->New();
-    std::unique_ptr<WrapperBase> edp = getWrapperBasePtr(p, branchInfo.offsetToWrapperBase_); 
+    std::unique_ptr<WrapperBase> edp = getWrapperBasePtr(p, branchInfo->offsetToWrapperBase_);
     br->SetAddress(&p);
     try{
       //Run and Lumi only have 1 entry number, which is index 0

--- a/IOPool/Input/src/RootDelayedReader.h
+++ b/IOPool/Input/src/RootDelayedReader.h
@@ -33,7 +33,6 @@ namespace edm {
   public:
     typedef roottree::BranchInfo BranchInfo;
     typedef roottree::BranchMap BranchMap;
-    typedef roottree::BranchMap::const_iterator iterator;
     typedef roottree::EntryNumber EntryNumber;
     RootDelayedReader(
       RootTree const& tree,
@@ -65,9 +64,7 @@ namespace edm {
     std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> sharedResources_() const override;
 
     BranchMap const& branches() const {return tree_.branches();}
-    iterator branchIter(BranchKey const& k) const {return branches().find(k);}
-    bool found(iterator const& iter) const {return iter != branches().end();}
-    BranchInfo const& getBranchInfo(iterator const& iter) const {return iter->second; }
+    BranchInfo const* getBranchInfo(BranchKey const& k) const {return branches().find(k);}
     // NOTE: filePtr_ appears to be unused, but is needed to prevent
     // the file containing the branch from being reclaimed.
     RootTree const& tree_;

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -492,6 +492,20 @@ namespace edm {
 
     // Set up information from the product registry.
     ProductRegistry::ProductList const& prodList = productRegistry()->productList();
+
+    {
+      std::array<size_t,NumBranchTypes> nBranches;
+      nBranches.fill(0);
+      for(auto const& product : prodList) {
+        ++nBranches[product.second.branchType()];
+      }
+
+      int i = 0;
+      for(auto t: treePointers_) {
+        t->numberOfBranchesToAdd(nBranches[i]);
+        ++i;
+      }
+    }
     for(auto const& product : prodList) {
       BranchDescription const& prod = product.second;
       treePointers_[prod.branchType()]->addBranch(product.first, prod,

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -48,7 +48,7 @@ namespace edm {
     entryNumber_(-1),
     entryNumberForIndex_(new std::vector<EntryNumber>(nIndexes, IndexIntoFile::invalidEntry)),
     branchNames_(),
-    branches_(new BranchMap),
+    branches_{},
     trainNow_(false),
     switchOverEntry_(-1),
     rawTriggerSwitchOverEntry_(-1),
@@ -149,7 +149,7 @@ namespace edm {
       }
       TTree* provTree = (metaTree_ != nullptr ? metaTree_ : tree_);
       info.provenanceBranch_ = provTree->GetBranch(oldBranchName.c_str());
-      branches_->insert(std::make_pair(key, info));
+      branches_.insert(key, info);
   }
 
   void
@@ -176,7 +176,7 @@ namespace edm {
   }
 
   roottree::BranchMap const&
-  RootTree::branches() const {return *branches_;}
+  RootTree::branches() const {return branches_;}
 
   void
   RootTree::setCacheSize(unsigned int cacheSize) {


### PR DESCRIPTION
The number of items in the BranchMap is reasonably small so a linear container searched sequentially should be faster and require less memory.