### PR TITLE
Tune selection of iso particles for tauID at Phase2

### DIFF
--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -130,7 +130,7 @@ hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminati
 )
 hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minTrackPt = 0.5
 phase2_common.toModify(hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr.qualityCuts,
-                       isolationQualityCuts = dict( minTrackPt = cms.double(0.8) )
+                       isolationQualityCuts = dict( minTrackPt = 0.8 )
                       )
 hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt = 1.0
 ## ByMediumCombinedIsolationDBSumPtCorr
@@ -145,7 +145,7 @@ hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminat
 )
 hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minTrackPt = 0.5
 phase2_common.toModify(hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr.qualityCuts,
-                       isolationQualityCuts = dict( minTrackPt = cms.double(0.8) )
+                       isolationQualityCuts = dict( minTrackPt = 0.8 )
                       )
 hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt = 1.0
 ## ByTightCombinedIsolationDBSumPtCorr
@@ -160,7 +160,7 @@ hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminati
 )
 hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minTrackPt = 0.5
 phase2_common.toModify(hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr.qualityCuts,
-                       isolationQualityCuts = dict( minTrackPt = cms.double(0.8) )
+                       isolationQualityCuts = dict( minTrackPt = 0.8 )
                       )
 hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt = 1.0
 ## ByLooseChargedIsolation

--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 import copy
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 
 '''
 
@@ -128,6 +129,9 @@ hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminati
     Prediscriminants = requireDecayMode.clone()
 )
 hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minTrackPt = 0.5
+phase2_common.toModify(hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr.qualityCuts,
+                       isolationQualityCuts = dict( minTrackPt = cms.double(0.8) )
+                      )
 hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt = 1.0
 ## ByMediumCombinedIsolationDBSumPtCorr
 hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminationByMediumIsolationDBSumPtCorr.clone(
@@ -140,6 +144,9 @@ hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminat
     Prediscriminants = requireDecayMode.clone()
 )
 hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minTrackPt = 0.5
+phase2_common.toModify(hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr.qualityCuts,
+                       isolationQualityCuts = dict( minTrackPt = cms.double(0.8) )
+                      )
 hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt = 1.0
 ## ByTightCombinedIsolationDBSumPtCorr
 hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminationByTightIsolationDBSumPtCorr.clone(
@@ -152,6 +159,9 @@ hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminati
     Prediscriminants = requireDecayMode.clone()
 )
 hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minTrackPt = 0.5
+phase2_common.toModify(hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr.qualityCuts,
+                       isolationQualityCuts = dict( minTrackPt = cms.double(0.8) )
+                      )
 hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt = 1.0
 ## ByLooseChargedIsolation
 hpsPFTauDiscriminationByLooseChargedIsolation = hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr.clone(

--- a/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
@@ -54,7 +54,7 @@ PFTauQualityCuts = cms.PSet(
 )
 phase2_common.toModify(PFTauQualityCuts,
                        isolationQualityCuts = dict(
-                          maxDeltaZ = cms.double(0.15),
-                          maxTransverseImpactParameter = cms.double(0.05)
+                          maxDeltaZ = 0.15,
+                          maxTransverseImpactParameter = 0.05
                        ) )
                        

--- a/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
@@ -53,5 +53,8 @@ PFTauQualityCuts = cms.PSet(
     ##leadingTrkOrPFCandOption = cms.string("firstTrack") #default behaviour until 710 (first track in the collection)
 )
 phase2_common.toModify(PFTauQualityCuts,
-                       isolationQualityCuts = dict( maxDeltaZ = cms.double(0.1) ) )
+                       isolationQualityCuts = dict(
+                          maxDeltaZ = cms.double(0.15),
+                          maxTransverseImpactParameter = cms.double(0.05)
+                       ) )
                        


### PR DESCRIPTION
As title of the PR says, it is a tuning of parameters to select particles for tau isolation for Phase2 studies. The tuning consists of the following modifications
* increase Pt threshold for charged particles
* relaxed (wrt current settings) requirements on dz and dxy [1]

The tuning is a result of study shown here [2] and is agreed with Tau POG conveners.

The PR is expected to modify output of all tau isolation discriminants in Phase2 workflows and has not effect in Run2 workflows.

FYI, @isobelojalvo @steggema @rmanzoni 

---
[1] Note: dz requirement is still tighter than for Run2
[2] https://indico.cern.ch/event/737180/contributions/3044559/attachments/1669844/2678320/NotWeightedResults_18_6.pdf