### PR TITLE
Using early 2018 BS for 2018 MC relvals

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -217,6 +217,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2018_realistic',
         'HLTmenu': '@relval2018',
         'Era' : 'Run2_2018',
+        'BeamSpot': 'Realistic25ns13TeVEarly2018Collision',
         'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull','ALCAFull'],
     },
     '2018Design' : {


### PR DESCRIPTION
This PR is related to the deployment of the new RECO BS in the release for 2018 MC, that has happened with the merged PR #23619 

Therefore we need to update the generated BS in 2018 MC relvals, to use the one from which the RECO BS was derived: Realistic25ns13TeVEarly2018Collision.