### PR TITLE
bug fix for case with SimClusters but no RecHits

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -58,6 +58,7 @@ namespace hgcal {
     unsigned int lastLayerEE() const {return fhOffset_;}
     unsigned int lastLayerFH() const {return bhOffset_;}
     unsigned int maxNumberOfWafersPerLayer() const {return maxNumberOfWafersPerLayer_;}
+    inline int getGeometryType() const {return geometryType_;}
   private:
     const CaloGeometry* geom_;
     unsigned int        fhOffset_, bhOffset_, maxNumberOfWafersPerLayer_;

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -66,14 +66,8 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
 {
     const SimClusterCollection& simClusters = *simClusterH_;
     auto const& hits = *input;
-    if(hits.empty()) return;
     RealisticHitToClusterAssociator realisticAssociator;
-    int geometryType = 0;
-    if(DetId(hits[0].detId()).det()==DetId::HGCalEE or 
-       DetId(hits[0].detId()).det()==DetId::HGCalHSi or 
-       DetId(hits[0].detId()).det()==DetId::HGCalHSc)
-    { geometryType = 1; }
-    const int numberOfLayers = geometryType==0 ? rhtools_.getLayer(ForwardSubdetector::ForwardEmpty) : rhtools_.getLayer(DetId::Forward);
+    const int numberOfLayers = rhtools_.getGeometryType()==0 ? rhtools_.getLayer(ForwardSubdetector::ForwardEmpty) : rhtools_.getLayer(DetId::Forward);
     realisticAssociator.init(hits.size(), simClusters.size(), numberOfLayers + 1);
     // for quick indexing back to hit energy
     std::unordered_map < uint32_t, size_t > detIdToIndex(hits.size());


### PR DESCRIPTION
type bugfix

Followup to #23545. An occasional crash (less than 1% frequency) was observed in private tests. I determined the reason as follows: there can be cases where there are SimClusters but no RecHits. If the SimMapper does not create the corresponding PF clusters in those cases, there is a mismatch in the SimPFProducer. This PR simplifies the determination of the geometry type (using RecHitTools) in order to avoid relying on a RecHit collection that may be empty.