### PR TITLE
[L1T][DQMOffline] Normalizing L1 vs offline histograms to bin area  (Jets & Energy Sums)

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
@@ -96,6 +96,7 @@ protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
   void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
+  void endJob() override;
 
 private:
   //histos booking function
@@ -108,6 +109,8 @@ private:
   void fillJetEfficiencies(const double & recoEt, const double & l1Et, const double & recoEta);
 
   bool doesNotOverlapWithHLTObjects(const l1t::Jet & jet) const;
+
+  void normalise2DHistogramsToBinArea();
 
   //private variables
   math::XYZPoint PVPoint_;

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -20,49 +20,106 @@ const std::map<std::string, unsigned int> L1TStage2CaloLayer2Offline::PlotConfig
 //
 // -------------------------------------- Constructor --------------------------------------------
 //
-L1TStage2CaloLayer2Offline::L1TStage2CaloLayer2Offline(const edm::ParameterSet& ps) :
-        thePFJetCollection_(
-            consumes < reco::PFJetCollection > (ps.getParameter < edm::InputTag > ("pfJetCollection"))),
-        thecaloMETCollection_(
-            consumes < reco::CaloMETCollection > (ps.getParameter < edm::InputTag > ("caloMETCollection"))),
-        thecaloETMHFCollection_(
-            consumes < reco::CaloMETCollection > (ps.getParameter < edm::InputTag > ("caloETMHFCollection"))),
-        thePFMETNoMuCollection_(consumes < reco::PFMETCollection > (ps.getParameter < edm::InputTag > ("pfMETNoMuCollection"))),
-        thePVCollection_(consumes < reco::VertexCollection > (ps.getParameter < edm::InputTag > ("PVCollection"))),
-        theBSCollection_(consumes < reco::BeamSpot > (ps.getParameter < edm::InputTag > ("beamSpotCollection"))),
-        triggerInputTag_(consumes < trigger::TriggerEvent > (ps.getParameter < edm::InputTag > ("triggerInputTag"))),
-        triggerResultsInputTag_(consumes<edm::TriggerResults>(ps.getParameter<edm::InputTag>("triggerResults"))),
-        triggerProcess_(ps.getParameter < std::string > ("triggerProcess")),
-        triggerNames_(ps.getParameter < std::vector<std::string> > ("triggerNames")),
-        histFolderEtSum_(ps.getParameter < std::string > ("histFolderEtSum")),
-        histFolderJet_(ps.getParameter < std::string > ("histFolderJet")),
-        efficiencyFolderEtSum_(histFolderEtSum_ + "/efficiency_raw"),
-        efficiencyFolderJet_(histFolderJet_ + "/efficiency_raw"),
-        stage2CaloLayer2JetToken_(
-            consumes < l1t::JetBxCollection > (ps.getParameter < edm::InputTag > ("stage2CaloLayer2JetSource"))),
-        stage2CaloLayer2EtSumToken_(
-            consumes < l1t::EtSumBxCollection > (ps.getParameter < edm::InputTag > ("stage2CaloLayer2EtSumSource"))),
-        jetEfficiencyThresholds_(ps.getParameter < std::vector<double> > ("jetEfficiencyThresholds")),
-        metEfficiencyThresholds_(ps.getParameter < std::vector<double> > ("metEfficiencyThresholds")),
-        mhtEfficiencyThresholds_(ps.getParameter < std::vector<double> > ("mhtEfficiencyThresholds")),
-        ettEfficiencyThresholds_(ps.getParameter < std::vector<double> > ("ettEfficiencyThresholds")),
-        httEfficiencyThresholds_(ps.getParameter < std::vector<double> > ("httEfficiencyThresholds")),
-        jetEfficiencyBins_(ps.getParameter < std::vector<double> > ("jetEfficiencyBins")),
-        metEfficiencyBins_(ps.getParameter < std::vector<double> > ("metEfficiencyBins")),
-        mhtEfficiencyBins_(ps.getParameter < std::vector<double> > ("mhtEfficiencyBins")),
-        ettEfficiencyBins_(ps.getParameter < std::vector<double> > ("ettEfficiencyBins")),
-        httEfficiencyBins_(ps.getParameter < std::vector<double> > ("httEfficiencyBins")),
-        recoHTTMaxEta_(ps.getParameter <double>("recoHTTMaxEta")),
-        recoMHTMaxEta_(ps.getParameter <double>("recoMHTMaxEta")),
-        hltConfig_(),
-        triggerIndices_(),
-        triggerResults_(),
-        triggerEvent_(),
-        histDefinitions_(dqmoffline::l1t::readHistDefinitions(ps.getParameterSet("histDefinitions"), PlotConfigNames)),
-        h_controlPlots_()
+L1TStage2CaloLayer2Offline::L1TStage2CaloLayer2Offline(const edm::ParameterSet& ps)
+    : thePFJetCollection_(consumes<reco::PFJetCollection>(ps.getParameter<edm::InputTag>("pfJetCollection"))),
+      thecaloMETCollection_(consumes<reco::CaloMETCollection>(ps.getParameter<edm::InputTag>("caloMETCollection"))),
+      thecaloETMHFCollection_(consumes<reco::CaloMETCollection>(ps.getParameter<edm::InputTag>("caloETMHFCollection"))),
+      thePFMETNoMuCollection_(consumes<reco::PFMETCollection>(ps.getParameter<edm::InputTag>("pfMETNoMuCollection"))),
+      thePVCollection_(consumes<reco::VertexCollection>(ps.getParameter<edm::InputTag>("PVCollection"))),
+      theBSCollection_(consumes<reco::BeamSpot>(ps.getParameter<edm::InputTag>("beamSpotCollection"))),
+      triggerInputTag_(consumes<trigger::TriggerEvent>(ps.getParameter<edm::InputTag>("triggerInputTag"))),
+      triggerResultsInputTag_(consumes<edm::TriggerResults>(ps.getParameter<edm::InputTag>("triggerResults"))),
+      triggerProcess_(ps.getParameter<std::string>("triggerProcess")),
+      triggerNames_(ps.getParameter<std::vector<std::string>>("triggerNames")),
+      histFolderEtSum_(ps.getParameter<std::string>("histFolderEtSum")),
+      histFolderJet_(ps.getParameter<std::string>("histFolderJet")),
+      efficiencyFolderEtSum_(histFolderEtSum_ + "/efficiency_raw"),
+      efficiencyFolderJet_(histFolderJet_ + "/efficiency_raw"),
+      stage2CaloLayer2JetToken_(
+          consumes<l1t::JetBxCollection>(ps.getParameter<edm::InputTag>("stage2CaloLayer2JetSource"))),
+      stage2CaloLayer2EtSumToken_(
+          consumes<l1t::EtSumBxCollection>(ps.getParameter<edm::InputTag>("stage2CaloLayer2EtSumSource"))),
+      jetEfficiencyThresholds_(ps.getParameter<std::vector<double>>("jetEfficiencyThresholds")),
+      metEfficiencyThresholds_(ps.getParameter<std::vector<double>>("metEfficiencyThresholds")),
+      mhtEfficiencyThresholds_(ps.getParameter<std::vector<double>>("mhtEfficiencyThresholds")),
+      ettEfficiencyThresholds_(ps.getParameter<std::vector<double>>("ettEfficiencyThresholds")),
+      httEfficiencyThresholds_(ps.getParameter<std::vector<double>>("httEfficiencyThresholds")),
+      jetEfficiencyBins_(ps.getParameter<std::vector<double>>("jetEfficiencyBins")),
+      metEfficiencyBins_(ps.getParameter<std::vector<double>>("metEfficiencyBins")),
+      mhtEfficiencyBins_(ps.getParameter<std::vector<double>>("mhtEfficiencyBins")),
+      ettEfficiencyBins_(ps.getParameter<std::vector<double>>("ettEfficiencyBins")),
+      httEfficiencyBins_(ps.getParameter<std::vector<double>>("httEfficiencyBins")),
+      recoHTTMaxEta_(ps.getParameter<double>("recoHTTMaxEta")),
+      recoMHTMaxEta_(ps.getParameter<double>("recoMHTMaxEta")),
+      hltConfig_(),
+      triggerIndices_(),
+      triggerResults_(),
+      triggerEvent_(),
+      histDefinitions_(dqmoffline::l1t::readHistDefinitions(ps.getParameterSet("histDefinitions"), PlotConfigNames)),
+      h_nVertex_(),
+      h_controlPlots_(),
+      h_L1METvsCaloMET_(),
+      h_L1ETMHFvsCaloETMHF_(),
+      h_L1METvsPFMetNoMu_(),
+      h_L1MHTvsRecoMHT_(),
+      h_L1METTvsCaloETT_(),
+      h_L1HTTvsRecoHTT_(),
+      h_L1METPhivsCaloMETPhi_(),
+      h_L1ETMHFPhivsCaloETMHFPhi_(),
+      h_L1METPhivsPFMetNoMuPhi_(),
+      h_L1MHTPhivsRecoMHTPhi_(),
+      h_resolutionMET_(),
+      h_resolutionETMHF_(),
+      h_resolutionPFMetNoMu_(),
+      h_resolutionMHT_(),
+      h_resolutionETT_(),
+      h_resolutionHTT_(),
+      h_resolutionMETPhi_(),
+      h_resolutionETMHFPhi_(),
+      h_resolutionPFMetNoMuPhi_(),
+      h_resolutionMHTPhi_(),
+      h_efficiencyMET_pass_(),
+      h_efficiencyETMHF_pass_(),
+      h_efficiencyPFMetNoMu_pass_(),
+      h_efficiencyMHT_pass_(),
+      h_efficiencyETT_pass_(),
+      h_efficiencyHTT_pass_(),
+      h_efficiencyMET_total_(),
+      h_efficiencyETMHF_total_(),
+      h_efficiencyPFMetNoMu_total_(),
+      h_efficiencyMHT_total_(),
+      h_efficiencyETT_total_(),
+      h_efficiencyHTT_total_(),
+      h_L1JetETvsPFJetET_HB_(),
+      h_L1JetETvsPFJetET_HE_(),
+      h_L1JetETvsPFJetET_HF_(),
+      h_L1JetETvsPFJetET_HB_HE_(),
+      h_L1JetPhivsPFJetPhi_HB_(),
+      h_L1JetPhivsPFJetPhi_HE_(),
+      h_L1JetPhivsPFJetPhi_HF_(),
+      h_L1JetPhivsPFJetPhi_HB_HE_(),
+      h_L1JetEtavsPFJetEta_(),
+      h_resolutionJetET_HB_(),
+      h_resolutionJetET_HE_(),
+      h_resolutionJetET_HF_(),
+      h_resolutionJetET_HB_HE_(),
+      h_resolutionJetPhi_HB_(),
+      h_resolutionJetPhi_HE_(),
+      h_resolutionJetPhi_HF_(),
+      h_resolutionJetPhi_HB_HE_(),
+      h_resolutionJetEta_(),
+      h_efficiencyJetEt_HB_pass_(),
+      h_efficiencyJetEt_HE_pass_(),
+      h_efficiencyJetEt_HF_pass_(),
+      h_efficiencyJetEt_HB_HE_pass_(),
+      h_efficiencyJetEt_HB_total_(),
+      h_efficiencyJetEt_HE_total_(),
+      h_efficiencyJetEt_HF_total_(),
+      h_efficiencyJetEt_HB_HE_total_()
 {
-  edm::LogInfo("L1TStage2CaloLayer2Offline") << "Constructor "
-      << "L1TStage2CaloLayer2Offline::L1TStage2CaloLayer2Offline " << std::endl;
+    edm::LogInfo("L1TStage2CaloLayer2Offline") << "Constructor "
+                                               << "L1TStage2CaloLayer2Offline::L1TStage2CaloLayer2Offline "
+                                               << std::endl;
 }
 
 //
@@ -772,6 +829,34 @@ bool L1TStage2CaloLayer2Offline::doesNotOverlapWithHLTObjects(const l1t::Jet & j
   const trigger::TriggerObjectCollection matchedObjects = getMatchedTriggerObjects(l1Eta, l1Phi, 0.3, hltObjects);
 
   return matchedObjects.empty();
+}
+
+void L1TStage2CaloLayer2Offline::endJob(){
+  normalise2DHistogramsToBinArea();
+}
+
+void L1TStage2CaloLayer2Offline::normalise2DHistogramsToBinArea() {
+  std::vector<MonitorElement *> monElementstoNormalize = {
+    h_L1METvsCaloMET_,         h_L1ETMHFvsCaloETMHF_,
+    h_L1METvsPFMetNoMu_,       h_L1MHTvsRecoMHT_,
+    h_L1METTvsCaloETT_,        h_L1HTTvsRecoHTT_,
+    h_L1METPhivsCaloMETPhi_,   h_L1ETMHFPhivsCaloETMHFPhi_,
+    h_L1METPhivsPFMetNoMuPhi_, h_L1MHTPhivsRecoMHTPhi_,
+    h_L1JetETvsPFJetET_HB_,    h_L1JetETvsPFJetET_HE_,
+    h_L1JetETvsPFJetET_HF_,    h_L1JetETvsPFJetET_HB_HE_,
+    h_L1JetPhivsPFJetPhi_HB_,  h_L1JetPhivsPFJetPhi_HE_,
+    h_L1JetPhivsPFJetPhi_HF_,  h_L1JetPhivsPFJetPhi_HB_HE_,
+    h_L1JetEtavsPFJetEta_,
+};
+
+  for (auto mon : monElementstoNormalize) {
+    if (mon != nullptr) {
+      auto h = mon->getTH2F();
+      if (h != nullptr) {
+        h->Scale(1, "width");
+      }
+    }
+  }
 }
 
 //define this as a plug-in


### PR DESCRIPTION
Final part of https://its.cern.ch/jira/browse/CMSLITDPG-588:
 - implements normalisation of L1 vs offline histograms to bin area (for Jets & Energy Sums)
 - adds all member variables to initializer list