### PR TITLE
fix header L1Trigger/L1TMuonOverlap

### DIFF
--- a/L1Trigger/L1TMuonOverlap/interface/IGhostBuster.h
+++ b/L1Trigger/L1TMuonOverlap/interface/IGhostBuster.h
@@ -9,6 +9,7 @@
 #define OMTF_IGHOSTBUSTER_H_
 
 #include "L1Trigger/L1TMuonOverlap/interface/AlgoMuon.h"
+#include <vector>
 
 class IGhostBuster {
 public:


### PR DESCRIPTION
Fix headers related to #15248
We start enforcing the rule today to fail the PR if it doesn't comply with the header check.
The remaining headers to be fixed are currently - 1, for which we are adding an exception until the issue opened about that header is addressed