### PR TITLE
Fixing ECAL-Trk energy combination such that it gets the uncorrected ecal energy err

### DIFF
--- a/RecoEgamma/EgammaTools/interface/EpCombinationTool.h
+++ b/RecoEgamma/EgammaTools/interface/EpCombinationTool.h
@@ -26,6 +26,7 @@ public:
 
   void setEventContent(const edm::EventSetup& iSetup);
   std::pair<float, float> combine(const reco::GsfElectron& electron) const;
+  std::pair<float, float> combine(const reco::GsfElectron& electron,float corrEcalEnergyErr) const;
 
 private:
   EgammaRegressionContainer ecalTrkEnergyRegress_;

--- a/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
+++ b/RecoEgamma/EgammaTools/src/ElectronEnergyCalibrator.cc
@@ -148,8 +148,8 @@ setEnergyAndSystVarations(const float scale,const float smearNrSigma,const float
   energyData[EGEnergySysIndex::kSmearUp]   = calCombinedMom(ele,corrUp,smearUp).first;
   energyData[EGEnergySysIndex::kSmearDown] = calCombinedMom(ele,corrDn,smearDn).first;
   
+  const std::pair<float, float> combinedMomentum = calCombinedMom(ele,corr,smear);
   setEcalEnergy(ele,corr,smear);
-  const std::pair<float, float> combinedMomentum = epCombinationTool_->combine(ele);
   const float energyCorr =  combinedMomentum.first / oldP4.t();
 
   const math::XYZTLorentzVector newP4(oldP4.x() * energyCorr,
@@ -189,7 +189,7 @@ std::pair<float,float> ElectronEnergyCalibrator::calCombinedMom(reco::GsfElectro
   const float oldTrkMomErr = ele.trackMomentumError();
  
   setEcalEnergy(ele,scale,smear);
-  const auto& combinedMomentum = epCombinationTool_->combine(ele);
+  const auto& combinedMomentum = epCombinationTool_->combine(ele,oldEcalEnergyErr*scale);
   
   ele.setCorrectedEcalEnergy(oldEcalEnergy);
   ele.setCorrectedEcalEnergyError(oldEcalEnergyErr);

--- a/RecoEgamma/EgammaTools/src/EpCombinationTool.cc
+++ b/RecoEgamma/EgammaTools/src/EpCombinationTool.cc
@@ -44,12 +44,19 @@ void EpCombinationTool::setEventContent(const edm::EventSetup& iSetup)
 
 std::pair<float, float> EpCombinationTool::combine(const reco::GsfElectron& ele)const
 {
+  return combine(ele,ele.correctedEcalEnergyError());
+}
+
+//when doing the E/p combination, its very important to ensure the ecalEnergyErr
+//that the regression is trained on is used, not the actual ecalEnergyErr of the electron
+//these differ when you correct the ecalEnergyErr by smearing value needed to get data/MC to agree 
+std::pair<float, float> EpCombinationTool::combine(const reco::GsfElectron& ele,const float corrEcalEnergyErr)const
+{
   const float scRawEnergy = ele.superCluster()->rawEnergy(); 
   const float esEnergy = ele.superCluster()->preshowerEnergy();
   
 
   const float corrEcalEnergy = ele.correctedEcalEnergy();
-  const float corrEcalEnergyErr = ele.correctedEcalEnergyError();
   const float ecalMean = ele.correctedEcalEnergy() / (scRawEnergy+esEnergy);
   const float ecalSigma =  corrEcalEnergyErr / corrEcalEnergy;
 


### PR DESCRIPTION
Dear All,

A flaw in how the ECAL-Trk combination is done has been reported to E/gamma which introduces a discontinuity in the Et spectrum when scaled & smeared. This is due to using the corrected relative ecalEnergyErr for the ECAL-Trk combination.  This bug fix now means that the uncorrected relative ecalEnergyErr is used. 

In scale and smearing, the smearing is applied in quadrature to correct ecalEnergyErr which represents the per electron estimate of the resolution.  However due to how the combination uses this value, this results in incorrect responses. Details can be seen in https://indico.cern.ch/event/716848/contributions/3042888/attachments/1669765/2678161/scaleSmearingAndEP.pdf and a follow up https://sharper.web.cern.ch/sharper/cms/talks/scaleAndSmearingReprise.pdf

This bug effects the values stored in the 2017 miniAODv2 and the 2016 legacy miniAODv2. Obviously it is too late for the 2017 miniAODv2 but if it could fix the legacy, that would be good. These fixes can be applied at the user level, which will have to be done for 2017 data. 

When backporting to 94X, will I need a flag in the module config to reproduce the original bugged version?
 
 