### PR TITLE
[L1T][DQMOffline] L1TEGammaOffline fixes (CMSLITDPG-585)

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
@@ -103,6 +103,7 @@ private:
 
   double maxDeltaRForL1Matching_;
   double maxDeltaRForHLTMatching_;
+  double recoToL1TThresholdFactor_;
 
   reco::GsfElectron tagElectron_;
   reco::GsfElectron probeElectron_;

--- a/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
@@ -53,6 +53,7 @@ l1tEGammaOfflineDQM = DQMEDAnalyzer(
     photonEfficiencyBins=cms.vdouble(photonEfficiencyBins),
     maxDeltaRForL1Matching=cms.double(0.3),
     maxDeltaRForHLTMatching=cms.double(0.3),
+    recoToL1TThresholdFactor=cms.double(1.25),
 
     histDefinitions=cms.PSet(
         nVertex=histDefinitions.nVertex.clone(),

--- a/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
@@ -52,6 +52,7 @@ L1TEGammaOffline::L1TEGammaOffline(const edm::ParameterSet& ps) :
         photonEfficiencyBins_(ps.getParameter < std::vector<double> > ("photonEfficiencyBins")),
         maxDeltaRForL1Matching_(ps.getParameter <double> ("maxDeltaRForL1Matching")),
         maxDeltaRForHLTMatching_(ps.getParameter <double> ("maxDeltaRForHLTMatching")),
+        recoToL1TThresholdFactor_(ps.getParameter <double> ("recoToL1TThresholdFactor")),
         tagElectron_(),
         probeElectron_(),
         tagAndProbleInvariantMass_(-1.),
@@ -257,24 +258,26 @@ void L1TEGammaOffline::fillElectrons(edm::Event const& e, const unsigned int nVe
 
   // plots for deeper inspection
   for (auto threshold : deepInspectionElectronThresholds_) {
-    fillWithinLimits(h_efficiencyElectronEta_total_[threshold], recoEta);
-    fillWithinLimits(h_efficiencyElectronPhi_total_[threshold], recoPhi);
-    fillWithinLimits(h_efficiencyElectronNVertex_total_[threshold], nVertex);
-    if(recoEt > threshold){
-      fillWithinLimits(h_efficiencyElectronEta_pass_[threshold], recoEta);
-      fillWithinLimits(h_efficiencyElectronPhi_pass_[threshold], recoPhi);
-      fillWithinLimits(h_efficiencyElectronNVertex_pass_[threshold], nVertex);
+    if (recoEt > threshold * recoToL1TThresholdFactor_) {
+        fillWithinLimits(h_efficiencyElectronEta_total_[threshold], recoEta);
+        fillWithinLimits(h_efficiencyElectronPhi_total_[threshold], recoPhi);
+        fillWithinLimits(h_efficiencyElectronNVertex_total_[threshold], nVertex);
+        if (l1Et > threshold + probeToL1Offset_) {
+            fillWithinLimits(h_efficiencyElectronEta_pass_[threshold], recoEta);
+            fillWithinLimits(h_efficiencyElectronPhi_pass_[threshold], recoPhi);
+            fillWithinLimits(h_efficiencyElectronNVertex_pass_[threshold], nVertex);
+        }
     }
-  }
+}
 
   for (auto threshold : electronEfficiencyThresholds_) {
-    fill2DWithinLimits(h_efficiencyElectronPhi_vs_Eta_total_[threshold],
-      recoEta, recoPhi);
-    if(l1Et > threshold + probeToL1Offset_){
-      fill2DWithinLimits(h_efficiencyElectronPhi_vs_Eta_pass_[threshold],
-        recoEta, recoPhi);
+    if (recoEt > threshold * recoToL1TThresholdFactor_) {
+        fill2DWithinLimits(h_efficiencyElectronPhi_vs_Eta_total_[threshold], recoEta, recoPhi);
+        if (l1Et > threshold + probeToL1Offset_) {
+            fill2DWithinLimits(h_efficiencyElectronPhi_vs_Eta_pass_[threshold], recoEta, recoPhi);
+        }
     }
-  }
+}
 
   if (std::abs(recoEta) <= 1.479) { // barrel
     // et

--- a/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
@@ -227,7 +227,6 @@ void L1TEGammaOffline::fillElectrons(edm::Event const& e, const unsigned int nVe
       minDeltaR = currentDeltaR;
       closestL1EGamma = *egamma;
       foundMatch = true;
-      break;
     }
 
   }


### PR DESCRIPTION
Jira issue: https://its.cern.ch/jira/browse/CMSLITDPG-585

Fixes:
 - early stopping in probe matching
 - adjusted cuts for efficiency vs &eta;/&phi;

@thomreis I am not quite sure if the cuts are as requested, could you please check?