### PR TITLE
Ratio plot no longer fails in specific cases

### DIFF
--- a/Validation/RecoMuon/test/macro/PlotHelpers.C
+++ b/Validation/RecoMuon/test/macro/PlotHelpers.C
@@ -828,11 +828,15 @@ TH1* PlotRatiosHistograms(TH1* h1, TH1* h2){
   ++ratioCounter;
 
   Int_t nbinsx = h1->GetNbinsX();
+  Double_t xbins[nbinsx+1];
 
-  Double_t xmin = h1->GetBinLowEdge(0);
-  Double_t xmax = h1->GetBinLowEdge(nbinsx+1);
+  //Loop necessary since some histograms are TH1 while some are TProfile and do not allow us to use the clone function (SetBinContent do not exists for TProfiles)                                             
+  for (Int_t ibin=1; ibin<=nbinsx+1; ibin++) {
+    Float_t xmin = h1->GetBinLowEdge(ibin);
+    xbins[ibin-1] = xmin;
+  }
 
-  TH1F* h_ratio = new TH1F(Form("h_ratio_%d", ratioCounter), "", nbinsx, xmin, xmax);
+  TH1F* h_ratio = new TH1F(Form("h_ratio_%d", ratioCounter), "", nbinsx, xbins);
 
   for (Int_t ibin=1; ibin<=nbinsx; ibin++) {
 
@@ -845,7 +849,7 @@ TH1* PlotRatiosHistograms(TH1* h1, TH1* h2){
     Float_t ratioVal = 999;
     Float_t ratioErr = 999;
 
-    if (h2Value > 0) {
+    if (h2Value > 0 || h2Value < 0) {
       ratioVal = h1Value / h2Value;
       ratioErr = h1Error / h2Value;
     }

--- a/Validation/RecoMuon/test/macro/new_PlotHelpers.C
+++ b/Validation/RecoMuon/test/macro/new_PlotHelpers.C
@@ -701,12 +701,18 @@ TH1* PlotRatiosHistograms(TH1* h1, TH1* h2){
 
   ++ratioCounter;
 
-  Int_t nbinsx = h1->GetNbinsX();
+  const Int_t nbinsx = h1->GetNbinsX();
 
-  Double_t xmin = h1->GetBinLowEdge(0);
-  Double_t xmax = h1->GetBinLowEdge(nbinsx+1);
+  Double_t xbins[nbinsx+1];
 
-  TH1F* h_ratio = new TH1F(Form("h_ratio_%d", ratioCounter), "", nbinsx, xmin, xmax);
+  //Loop necessary since some histograms are TH1 while some are TProfile and do not allow us to use the clone function (SetBinContent do not exists for TProfiles)
+  for (Int_t ibin=1; ibin<=nbinsx+1; ibin++) {
+    Float_t xmin = h1->GetBinLowEdge(ibin);
+    xbins[ibin-1] = xmin;
+  }
+
+
+  TH1F* h_ratio = new TH1F(Form("h_ratio_%d", ratioCounter), "", nbinsx, xbins);
 
   for (Int_t ibin=1; ibin<=nbinsx; ibin++) {
 
@@ -719,7 +725,7 @@ TH1* PlotRatiosHistograms(TH1* h1, TH1* h2){
     Float_t ratioVal = 999;
     Float_t ratioErr = 999;
 
-    if (h2Value > 0) {
+    if (h2Value > 0 || h2Value < 0) {
       ratioVal = h1Value / h2Value;
       ratioErr = h1Error / h2Value;
     }

--- a/Validation/RecoMuon/test/macro/new_TrackValHistoPublisher.C
+++ b/Validation/RecoMuon/test/macro/new_TrackValHistoPublisher.C
@@ -39,7 +39,7 @@ void plotOptReset(bool logx[6], bool logy[6], bool doKolmo[6], Double_t norm[6],
   for(int i=0; i<6; ++i) {
     logx[i] = false;
     logy[i] = false;
-    doKolmo[i] = false;
+    doKolmo[i] = true;
     norm[i] = -1;
     minx[i] = 0;
     maxx[i] = 0;
@@ -112,7 +112,7 @@ void new_TrackValHistoPublisher(const char* newFile="NEW_FILE",const char* refFi
 
   bool logy[6]     = {false,  false,  false,  false,   false,  false  };
   bool logx[6]     = {false,  false,  false,  false,   false,  false  };
-  bool doKolmo[6]  = {false,  false,  false,  false,   false,  false  };
+  bool doKolmo[6]  = {true,   true,   true,   true,    true,   true };
   Double_t norm[6] =  {-1.,-1.,-1.,-1.,-1.,-1.};  // initial default: do not normalize
   Double_t minx[6] = {0, 0, 0, 0, 0, 0};
   Double_t maxx[6] = {0, 0, 0, 0, 0, 0};
@@ -271,8 +271,8 @@ void new_TrackValHistoPublisher(const char* newFile="NEW_FILE",const char* refFi
     plots[0]="effic_vs_pu"      ; titles[0]="Efficiency vs n.PU interactions";
     plots[1]="fakerate_vs_pu"   ; titles[1]="Fake rate vs n.PU interactions" ;
 
-    maxx[0]= 100.;
-    maxx[1]= 100.;
+    //maxx[0]= 100.;
+    //maxx[1]= 100.;
 
     miny[0]= -0.0001;
     miny[1]=  0.;
@@ -463,10 +463,10 @@ void new_TrackValHistoPublisher(const char* newFile="NEW_FILE",const char* refFi
     logx[2]=false;
     logx[3]=false;
 
-    maxx[0]= 0.;
-    maxx[1]= 0.;
-    maxx[2]= 0.;
-    maxx[3]= 100.;
+    //maxx[0]= 0.;
+    //maxx[1]= 0.;
+    //maxx[2]= 0.;
+    //maxx[3]= 100.;
 
     miny[0]= -0.0001;
     miny[1]=  0.;
@@ -627,8 +627,8 @@ void new_TrackValHistoPublisher(const char* newFile="NEW_FILE",const char* refFi
   plots[0]="effic_vs_pu"    ; titles[0]="Efficiency vs n.PU interactions";
   plots[1]="fakerate_vs_pu" ; titles[1]="Fake rate vs  n.PU interactions" ;
   
-  maxx[0]= 100.;
-  maxx[1]= 100.;
+  //maxx[0]= 100.;
+  //maxx[1]= 100.;
   
   miny[0]= -0.0001;
   miny[1]=  0.;


### PR DESCRIPTION
Plot showing the ratio between the two MC being compared used to fail with asymmetric bins or when applying a logarithmic scale to the x-axis. This is no longer the case.