### PR TITLE
Added HLT_*ZeroBias* to the list of paths

### DIFF
--- a/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
@@ -27,7 +27,7 @@ process.dqmSaver.tag = "DT"
 
 #Enable HLT*Mu* filtering to monitor on Muon events
 #OR HLT_Physics* to monitor FEDs in commissioning runs
-process.source.SelectEvents = cms.untracked.vstring("HLT*Mu*","HLT_*Physics*")
+process.source.SelectEvents = cms.untracked.vstring("HLT*Mu*","HLT_*Physics*","HLT_*ZeroBias*")
 
 # DT reco and DQM sequences
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")


### PR DESCRIPTION
Temporal switch for Online DQM only during current commissioning runs. 
No need to integrate this in Master, hence no forwardport