### PR TITLE
pu jets in jet-core tracking for pp_on_AA_2018

### DIFF
--- a/RecoJets/JetProducers/python/caloJetsForTrk_cff.py
+++ b/RecoJets/JetProducers/python/caloJetsForTrk_cff.py
@@ -1,9 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoJets.JetProducers.ak4CaloJets_cfi import ak4CaloJets as _ak4CaloJets
+from RecoHI.HiJetAlgos.HiRecoJets_cff import akPu4CaloJets as _akPu4CaloJets
 from RecoLocalCalo.CaloTowersCreator.calotowermaker_cfi import calotowermaker
 caloTowerForTrk = calotowermaker.clone(hbheInput=cms.InputTag('hbheprereco'))
 ak4CaloJetsForTrk = _ak4CaloJets.clone(srcPVs = cms.InputTag('firstStepPrimaryVerticesUnsorted'), src= cms.InputTag('caloTowerForTrk'))
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toReplaceWith(ak4CaloJetsForTrk, _akPu4CaloJets.clone(srcPVs = cms.InputTag('firstStepPrimaryVerticesUnsorted'), src= cms.InputTag('caloTowerForTrk')))
 from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
 trackingLowPU.toModify(ak4CaloJetsForTrk,
     srcPVs = "pixelVertices"


### PR DESCRIPTION
This PR makes one change to the tracking in the pp_on_AA_2018 era to be used for PbPb data this year. The default jet-core collection (ak4CaloJetsForTrk) is replaced by a similar one that applies PU subtraction. This allows proper tracking behaviour in PbPb, and is especially crucial for central events.

@abaty @cfmcginn @FHead @mandrenguyen 
