### PR TITLE
removing HLTMonitoring sequence by DQMOffline

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -75,7 +75,7 @@ HLTMonitoring = cms.Sequence( OfflineHLTMonitoring )
 HLTMonitoringPA = cms.Sequence( OfflineHLTMonitoringPA )
 DQMOffline = cms.Sequence( DQMOfflinePreDPG *
                            DQMOfflinePrePOG *
-                           HLTMonitoring *
+#                           HLTMonitoring *
                            # dqmFastTimerServiceLuminosity *
                            DQMMessageLogger )
 


### PR DESCRIPTION
The HLTMonitoring sequence is calling modules which need hlt Objects as input, in Express data there are not such objects with the result of polluting T0 logs with an unreasonable number of warning messages.

This PR disable such offending modules in Express. Nothing will change with Pixel/Strip HLT monitoring Online. Also the StreamHLTMon should be unaffected since there is a dedicated sequence for this:

'HLTMon':     ['HLTMonitoring', 'HLTMonitoringClient']