### PR TITLE
Phase2-hgx119 HGCDigi can work with generic DetId

### DIFF
--- a/DataFormats/HGCDigi/interface/HGCDigiCollections.h
+++ b/DataFormats/HGCDigi/interface/HGCDigiCollections.h
@@ -3,19 +3,16 @@
 
 #include "DataFormats/Common/interface/SortedCollection.h"
 #include "DataFormats/HGCDigi/interface/HGCDataFrame.h"
-#include "DataFormats/ForwardDetId/interface/HGCEEDetId.h"
-#include "DataFormats/ForwardDetId/interface/HGCHEDetId.h"
-#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
-#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HGCDigi/interface/HGCSample.h"
 
-typedef HGCDataFrame<HGCalDetId,HGCSample>      HGCEEDataFrame;
+typedef HGCDataFrame<DetId,HGCSample>           HGCEEDataFrame;
 typedef edm::SortedCollection< HGCEEDataFrame > HGCEEDigiCollection;
 
-typedef HGCDataFrame<HGCalDetId,HGCSample>           HGCHEDataFrame;
+typedef HGCDataFrame<DetId,HGCSample>           HGCHEDataFrame;
 typedef edm::SortedCollection< HGCHEDataFrame > HGCHEDigiCollection;
 
-typedef HGCDataFrame<HcalDetId,HGCSample>           HGCBHDataFrame;
+typedef HGCDataFrame<DetId,HGCSample>           HGCBHDataFrame;
 typedef edm::SortedCollection< HGCBHDataFrame > HGCBHDigiCollection;
 
 #endif

--- a/DataFormats/HGCDigi/interface/HGCDigiCollections.h
+++ b/DataFormats/HGCDigi/interface/HGCDigiCollections.h
@@ -2,17 +2,22 @@
 #define DIGIHGCAL_HGCALDIGICOLLECTION_H
 
 #include "DataFormats/Common/interface/SortedCollection.h"
-#include "DataFormats/HGCDigi/interface/HGCDataFrame.h"
 #include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/HGCDigi/interface/HGCDataFrame.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HGCDigi/interface/HGCSample.h"
 
-typedef HGCDataFrame<DetId,HGCSample>           HGCEEDataFrame;
+typedef HGCDataFrame<HGCalDetId,HGCSample>      HGCEEDataFrame;
 typedef edm::SortedCollection< HGCEEDataFrame > HGCEEDigiCollection;
 
-typedef HGCDataFrame<DetId,HGCSample>           HGCHEDataFrame;
+typedef HGCDataFrame<HGCalDetId,HGCSample>      HGCHEDataFrame;
 typedef edm::SortedCollection< HGCHEDataFrame > HGCHEDigiCollection;
 
-typedef HGCDataFrame<DetId,HGCSample>           HGCBHDataFrame;
+typedef HGCDataFrame<HcalDetId,HGCSample>       HGCBHDataFrame;
 typedef edm::SortedCollection< HGCBHDataFrame > HGCBHDigiCollection;
+
+typedef HGCDataFrame<DetId,HGCSample>           HGCalDataFrame;
+typedef edm::SortedCollection< HGCalDataFrame > HGCalDigiCollection;
 
 #endif

--- a/DataFormats/HGCDigi/src/classes.h
+++ b/DataFormats/HGCDigi/src/classes.h
@@ -1,5 +1,4 @@
 #include <vector>
-#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 #include "DataFormats/HGCDigi/interface/PHGCSimAccumulator.h"
 
@@ -13,6 +12,18 @@ namespace DataFormats_HGCDigi {
     std::vector<HGCDataFrame<DetId,HGCSample> > vDataFrames;
     edm::SortedCollection< HGCDataFrame<DetId,HGCSample> > scDataFrames;
     edm::Wrapper< edm::SortedCollection< HGCDataFrame<DetId,HGCSample> > > prodDataFrames;
+
+    //HEX specific
+    HGCDataFrame<HGCalDetId,HGCSample> anHGCalDataFrame;
+    std::vector<HGCDataFrame<HGCalDetId,HGCSample> > vHGCalDataFrames;
+    edm::SortedCollection< HGCDataFrame<HGCalDetId,HGCSample> > scHGCalDataFrames;
+    edm::Wrapper< edm::SortedCollection< HGCDataFrame<HGCalDetId,HGCSample> > > prodHGCalDataFrames;
+
+    //BH (hcal) specific
+    HGCDataFrame<HcalDetId,HGCSample> anHGCalBHDataFrame;
+    std::vector<HGCDataFrame<HcalDetId,HGCSample> > vHGCalBHDataFrames;
+    edm::SortedCollection< HGCDataFrame<HcalDetId,HGCSample> > scHGCalBHDataFrames;
+    edm::Wrapper< edm::SortedCollection< HGCDataFrame<HcalDetId,HGCSample> > > prodHGCalBHDataFrames;
 
     // Sim cell accumulator (for premixing)
     PHGCSimAccumulator saHGC;

--- a/DataFormats/HGCDigi/src/classes.h
+++ b/DataFormats/HGCDigi/src/classes.h
@@ -1,4 +1,5 @@
 #include <vector>
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 #include "DataFormats/HGCDigi/interface/PHGCSimAccumulator.h"
 
@@ -7,33 +8,11 @@ namespace DataFormats_HGCDigi {
     HGCSample anHGCsample;
     std::vector<HGCSample> vHGCsample;
 
-    //HEX specific
-    HGCDataFrame<HGCalDetId,HGCSample> anHGCalDataFrame;
-    std::vector<HGCDataFrame<HGCalDetId,HGCSample> > vHGCalDataFrames;
-    edm::SortedCollection< HGCDataFrame<HGCalDetId,HGCSample> > scHGCalDataFrames;
-    edm::Wrapper< edm::SortedCollection< HGCDataFrame<HGCalDetId,HGCSample> > > prodHGCalDataFrames;
-
-    //BH (hcal) specific
-    HGCDataFrame<HcalDetId,HGCSample> anHGCalBHDataFrame;
-    std::vector<HGCDataFrame<HcalDetId,HGCSample> > vHGCalBHDataFrames;
-    edm::SortedCollection< HGCDataFrame<HcalDetId,HGCSample> > scHGCalBHDataFrames;
-    edm::Wrapper< edm::SortedCollection< HGCDataFrame<HcalDetId,HGCSample> > > prodHGCalBHDataFrames;
-    
-    //EE specific
-    HGCDataFrame<HGCEEDetId,HGCSample> anHGCEEDataFrame;
-    std::vector<HGCDataFrame<HGCEEDetId,HGCSample> > vHGCEEDataFrames;
-    edm::SortedCollection< HGCDataFrame<HGCEEDetId,HGCSample> > scHGCEEDataFrames;
-    edm::Wrapper< edm::SortedCollection< HGCDataFrame<HGCEEDetId,HGCSample> > > prodHGCEEDataFrames;
-    HGCEEDigiCollection dcHGCEE;
-    edm::Wrapper<HGCEEDigiCollection> wdcHGCEE;
-
-    //HE specific
-    HGCDataFrame<HGCHEDetId,HGCSample> anHGCHEDataFrame;
-    std::vector<HGCDataFrame<HGCHEDetId,HGCSample> > vHGCHEDataFrames;
-    edm::SortedCollection< HGCDataFrame<HGCHEDetId,HGCSample> > scHGCHEDataFrames;
-    edm::Wrapper< edm::SortedCollection< HGCDataFrame<HGCHEDetId,HGCSample> > > prodHGCHEDataFrames;
-    HGCHEDigiCollection dcHGCHE;
-    edm::Wrapper<HGCHEDigiCollection> wdcHGCHE;
+    //Not specific
+    HGCDataFrame<DetId,HGCSample> anDataFrame;
+    std::vector<HGCDataFrame<DetId,HGCSample> > vDataFrames;
+    edm::SortedCollection< HGCDataFrame<DetId,HGCSample> > scDataFrames;
+    edm::Wrapper< edm::SortedCollection< HGCDataFrame<DetId,HGCSample> > > prodDataFrames;
 
     // Sim cell accumulator (for premixing)
     PHGCSimAccumulator saHGC;

--- a/DataFormats/HGCDigi/src/classes_def.xml
+++ b/DataFormats/HGCDigi/src/classes_def.xml
@@ -2,31 +2,11 @@
    <class name="HGCSample"/>
    <class name="std::vector<HGCSample>"/>
 
-   <!-- HEX specific -->
-   <class name="HGCDataFrame<HGCalDetId,HGCSample>"/>
-   <class name="std::vector<HGCDataFrame<HGCalDetId,HGCSample> >"/>
-   <class name="edm::SortedCollection<HGCDataFrame<HGCalDetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<HGCalDetId,HGCSample> > >"/>
-   <class name="edm::Wrapper<edm::SortedCollection<HGCDataFrame<HGCalDetId,HGCSample>,edm::StrictWeakOrdering<HGCDataFrame<HGCalDetId,HGCSample> > > >" />
-
-   <!-- BH specific -->
-   <class name="HGCDataFrame<HcalDetId,HGCSample>"/>
-   <class name="std::vector<HGCDataFrame<HcalDetId,HGCSample> >"/>
-   <class name="edm::SortedCollection<HGCDataFrame<HcalDetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<HcalDetId,HGCSample> > >"/>
-   <class name="edm::Wrapper<edm::SortedCollection<HGCDataFrame<HcalDetId,HGCSample>,edm::StrictWeakOrdering<HGCDataFrame<HcalDetId,HGCSample> > > >" />
-
-   <!-- EE specific -->
-   <class name="HGCDataFrame<HGCEEDetId,HGCSample>"/>
-   <class name="std::vector<HGCDataFrame<HGCEEDetId,HGCSample> >"/>
-   <class name="edm::SortedCollection<HGCDataFrame<HGCEEDetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<HGCEEDetId,HGCSample> > >"/>
-   <class name="edm::Wrapper<edm::SortedCollection<HGCDataFrame<HGCEEDetId,HGCSample>,edm::StrictWeakOrdering<HGCDataFrame<HGCEEDetId,HGCSample> > > >" />
-   <class name="edm::Wrapper<HGCEEDigiCollection>"/>
-
-   <!-- HE specific -->
-   <class name="HGCDataFrame<HGCHEDetId,HGCSample>"/>
-   <class name="std::vector<HGCDataFrame<HGCHEDetId,HGCSample> >"/>
-   <class name="edm::SortedCollection<HGCDataFrame<HGCHEDetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<HGCHEDetId,HGCSample> > >"/>
-   <class name="edm::Wrapper<edm::SortedCollection<HGCDataFrame<HGCHEDetId,HGCSample>,edm::StrictWeakOrdering<HGCDataFrame<HGCHEDetId,HGCSample> > > >" />
-   <class name="edm::Wrapper<HGCHEDigiCollection>"/>
+   <!-- Not specific -->
+   <class name="HGCDataFrame<DetId,HGCSample>"/>
+   <class name="std::vector<HGCDataFrame<DetId,HGCSample> >"/>
+   <class name="edm::SortedCollection<HGCDataFrame<DetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<DetId,HGCSample> > >"/>
+   <class name="edm::Wrapper<edm::SortedCollection<HGCDataFrame<DetId,HGCSample>,edm::StrictWeakOrdering<HGCDataFrame<DetId,HGCSample> > > >" />
 
    <class name="PHGCSimAccumulator"/>
    <class name="PHGCSimAccumulator::Data"/>

--- a/DataFormats/HGCDigi/src/classes_def.xml
+++ b/DataFormats/HGCDigi/src/classes_def.xml
@@ -8,6 +8,18 @@
    <class name="edm::SortedCollection<HGCDataFrame<DetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<DetId,HGCSample> > >"/>
    <class name="edm::Wrapper<edm::SortedCollection<HGCDataFrame<DetId,HGCSample>,edm::StrictWeakOrdering<HGCDataFrame<DetId,HGCSample> > > >" />
 
+   <!-- HEX specific -->
+   <class name="HGCDataFrame<HGCalDetId,HGCSample>"/>
+   <class name="std::vector<HGCDataFrame<HGCalDetId,HGCSample> >"/>
+   <class name="edm::SortedCollection<HGCDataFrame<HGCalDetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<HGCalDetId,HGCSample> > >"/>
+   <class name="edm::Wrapper<edm::SortedCollection<HGCDataFrame<HGCalDetId,HGCSample>,edm::StrictWeakOrdering<HGCDataFrame<HGCalDetId,HGCSample> > > >" />
+   
+   <!-- BH specific -->
+   <class name="HGCDataFrame<HcalDetId,HGCSample>"/>
+   <class name="std::vector<HGCDataFrame<HcalDetId,HGCSample> >"/>
+   <class name="edm::SortedCollection<HGCDataFrame<HcalDetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<HcalDetId,HGCSample> > >"/>
+   <class name="edm::Wrapper<edm::SortedCollection<HGCDataFrame<HcalDetId,HGCSample>,edm::StrictWeakOrdering<HGCDataFrame<HcalDetId,HGCSample> > > >" />
+
    <class name="PHGCSimAccumulator"/>
    <class name="PHGCSimAccumulator::Data"/>
    <class name="PHGCSimAccumulator::DetIdSize"/>

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -127,4 +127,3 @@ void HGCDigitizerBase<DFr>::updateOutput(std::unique_ptr<HGCDigitizerBase::DColl
 // cause the compiler to generate the appropriate code
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 template class HGCDigitizerBase<HGCEEDataFrame>;
-template class HGCDigitizerBase<HGCBHDataFrame>;

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -127,3 +127,5 @@ void HGCDigitizerBase<DFr>::updateOutput(std::unique_ptr<HGCDigitizerBase::DColl
 // cause the compiler to generate the appropriate code
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 template class HGCDigitizerBase<HGCEEDataFrame>;
+template class HGCDigitizerBase<HGCBHDataFrame>;
+template class HGCDigitizerBase<HGCalDataFrame>;

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -420,5 +420,5 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
 // cause the compiler to generate the appropriate code
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 template class HGCFEElectronics<HGCEEDataFrame>;
-template class HGCFEElectronics<HGCBHDataFrame>;
+
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -420,5 +420,5 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
 // cause the compiler to generate the appropriate code
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 template class HGCFEElectronics<HGCEEDataFrame>;
-
-
+template class HGCFEElectronics<HGCBHDataFrame>;
+template class HGCFEElectronics<HGCalDataFrame>;

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
@@ -105,4 +105,3 @@ HGCHEbackDigitizer<DFr>::~HGCHEbackDigitizer()
 
 //explicit instantiations
 template class HGCHEbackDigitizer<HGCBHDataFrame>;
-template class HGCHEbackDigitizer<HGCHEDataFrame>;

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
@@ -105,3 +105,5 @@ HGCHEbackDigitizer<DFr>::~HGCHEbackDigitizer()
 
 //explicit instantiations
 template class HGCHEbackDigitizer<HGCBHDataFrame>;
+template class HGCHEbackDigitizer<HGCHEDataFrame>;
+template class HGCHEbackDigitizer<HGCalDataFrame>;


### PR DESCRIPTION
DetId class changed for HGC from HGCal to HGCSilicon and from Hcal to HGCScintillator. Accordingly Digi collection now depends on generic DetId 